### PR TITLE
docs: add gap analysis and zip config profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@
 !/docs
 !/docs/**
 !/fix_links.sh
+!/scripts
+!/scripts/**
 # 3. Re-ignore specific files and patterns that should never be tracked.
 # These rules override any un-ignoring above, ensuring that sensitive or
 # generated files are not accidentally committed.

--- a/docs/sessions/community-sdk-gap-analysis.md
+++ b/docs/sessions/community-sdk-gap-analysis.md
@@ -1,0 +1,37 @@
+# Civ7 Modding Documentation Gap Analysis
+
+## Purpose
+
+Comparison of the community modding references with the official Civ7 resources to identify discrepancies and areas needing updates.
+
+> The `civ7-official-resources` archive is generated with `scripts/zip-civ-resources.sh` using the `default` profile in `scripts/civ-zip-config.json`, which omits large media assets and binaries such as `Assets/`, `movies/`, `data/icons/`, `fonts/`, and common media extensions (`.mp4`, `.ogg`, `.dds`, `.png`, `.ttf`). Their absence in this repository is expected.
+
+## Findings
+
+### 1. ModInfo structure differs from official modules
+- Community reference describes `<FrontEndActions>` and `<InGameActions>` blocks with `<File>` elements for assets and data files.
+- Official modules use `<ActionGroups>` and `<Actions>` with `<Item>` entries for updates such as icons, art, colors, database, and text.
+- **Gap:** Documentation should be updated to reflect the `<ActionGroups>` pattern and use of `<Item>` instead of `<File>`.
+
+### 2. Referenced asset/schema paths are absent or pruned
+- The file-paths reference lists an `<GAME_RESOURCES>/Base/Assets/` tree with schema folders (gameplay, ui, loc, modding, icons).
+- The zip script excludes any `Assets` directories along with `data/icons`, `movies`, and `fonts`, so the pruned resources here contain only `Civ7.dep` and `modules` under `Base`.
+- Schema files cited in the community reference (`schema-modding-10.sql`, `IconManager.sql`) reside under `Assets` and are therefore missing from the archive.
+- **Gap:** Documentation should clarify that these large asset directories are intentionally excluded and direct modders to the full game installation if they need the schemas or media.
+
+### 3. Dependency files are undocumented
+- Official data includes `.dep` files (e.g., `Civ7.dep` in the base game and `<module>.dep` in DLC folders) that define package dependencies.
+- Community references omit these files entirely.
+- **Gap:** Add guidance on the purpose of `.dep` files and how mods should reference or include them.
+
+### 4. Module directory layout varies
+- Community guide recommends separating content into `civilizations/`, `leaders/`, `units/`, `constructibles/`, `text/`, and `assets/` directories.
+- Official modules group content under `data/`, `text/`, and related subdirectories within each module.
+- **Gap:** Clarify the recommended structure versus the official module layout so modders can align their projects with the SDK conventions.
+
+## Suggested Next Steps
+- Update community documentation to mirror the official modinfo format and module directory structure.
+- Note which asset directories are pruned from the shared archive and explain how to obtain them from a full game installation.
+- Document the role of `.dep` files in module loading and dependencies.
+- Provide examples from official modules to demonstrate the expected folder hierarchy and action configuration.
+

--- a/scripts/civ-zip-config.json
+++ b/scripts/civ-zip-config.json
@@ -1,0 +1,84 @@
+{
+  "default": {
+    "zip": {
+      "exclude": [
+        "*/Platforms/*",
+        "*/movies/*",
+        "*/data/icons/*",
+        "*/Assets/*",
+        "*/fonts/*",
+        "Assets.car",
+        "AppIcon.icns",
+        "default.metallib",
+        "ShaderAutoGen_*",
+        "*.mp4",
+        "*.webm",
+        "*.mov",
+        "*.ogg",
+        "*.mp3",
+        "*.wav",
+        "*.dds",
+        "*.png",
+        "*.ttf",
+        "*.otf"
+      ]
+    },
+    "unzip": {
+      "exclude": [
+        "*/Platforms/*",
+        "*/movies/*",
+        "*/data/icons/*",
+        "*/Assets/*",
+        "*/fonts/*",
+        "Assets.car",
+        "AppIcon.icns",
+        "default.metallib",
+        "ShaderAutoGen_*",
+        "*.mp4",
+        "*.webm",
+        "*.mov",
+        "*.ogg",
+        "*.mp3",
+        "*.wav",
+        "*.dds",
+        "*.png",
+        "*.ttf",
+        "*.otf"
+      ]
+    }
+  },
+  "full": {
+    "zip": {
+      "exclude": []
+    },
+    "unzip": {
+      "exclude": []
+    }
+  },
+  "assets": {
+    "zip": {
+      "include": [
+        "Assets/*",
+        "movies/*",
+        "data/icons/*",
+        "fonts/*",
+        "Assets.car",
+        "AppIcon.icns",
+        "default.metallib",
+        "ShaderAutoGen_*"
+      ]
+    },
+    "unzip": {
+      "include": [
+        "Assets/*",
+        "movies/*",
+        "data/icons/*",
+        "fonts/*",
+        "Assets.car",
+        "AppIcon.icns",
+        "default.metallib",
+        "ShaderAutoGen_*"
+      ]
+    }
+  }
+}

--- a/scripts/unzip-civ-resources.sh
+++ b/scripts/unzip-civ-resources.sh
@@ -1,26 +1,56 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# unzip-civ-resources.sh — Unpack a slimmed Civ7 Resources zip.
+# unzip-civ-resources.sh — Unpack Civ7 Resources using a profile from civ-zip-config.json.
 #
-# Usage: unzip-civ-resources.sh [ZIPFILE]
-# ZIPFILE:  path to civ7-official-resources.zip (defaults to civ7-official-resources.zip in cwd)
+# Usage: unzip-civ-resources.sh [PROFILE] [ZIPFILE]
+#   PROFILE: profile to apply for inclusion/exclusion (default)
+#   ZIPFILE: path to civ7-official-resources.zip (defaults to docs/civ7-official/civ7-official-resources.zip)
 
-ZIP_FILE=${1:-docs/civ7-official/civ7-official-resources.zip}
+CONFIG_FILE="$(dirname "$0")/civ-zip-config.json"
+PROFILE=${1:-default}
+ZIP_FILE=${2:-docs/civ7-official/civ7-official-resources.zip}
+if ! jq -e --arg p "$PROFILE" '.[$p]' "$CONFIG_FILE" >/dev/null; then
+  echo "❌ Unknown profile '$PROFILE'" >&2
+  exit 1
+fi
 if [[ ! -f "$ZIP_FILE" ]]; then
   echo "❌ Zip file not found: $ZIP_FILE" >&2
   exit 1
 fi
 
 DEST_DIR="civ7-official-resources"
-echo "🔍 Unpacking '$ZIP_FILE' to '$DEST_DIR'..."
+echo "🔍 Unpacking '$ZIP_FILE' to '$DEST_DIR' using profile '$PROFILE'..."
 rm -rf "$DEST_DIR"
 mkdir -p "$DEST_DIR"
 
+INCLUDE=($(jq -r --arg p "$PROFILE" '.[$p].unzip.include[]?' "$CONFIG_FILE"))
+EXCLUDE=($(jq -r --arg p "$PROFILE" '.[$p].unzip.exclude[]?' "$CONFIG_FILE"))
+
 if command -v unzip >/dev/null 2>&1; then
-  unzip -qq "$ZIP_FILE" -d "$DEST_DIR"
+  if (( ${#INCLUDE[@]} > 0 )); then
+    unzip -qq "$ZIP_FILE" "${INCLUDE[@]}" -d "$DEST_DIR"
+  else
+    EX_ARGS=()
+    for pat in "${EXCLUDE[@]}"; do
+      EX_ARGS+=(-x "$pat")
+    done
+    unzip -qq "$ZIP_FILE" -d "$DEST_DIR" "${EX_ARGS[@]}"
+  fi
 elif command -v bsdtar >/dev/null 2>&1; then
-  bsdtar -xf "$ZIP_FILE" -C "$DEST_DIR"
+  if (( ${#INCLUDE[@]} > 0 )); then
+    INC_ARGS=()
+    for pat in "${INCLUDE[@]}"; do
+      INC_ARGS+=(--include "$pat")
+    done
+    bsdtar -xf "$ZIP_FILE" -C "$DEST_DIR" "${INC_ARGS[@]}"
+  else
+    EX_ARGS=()
+    for pat in "${EXCLUDE[@]}"; do
+      EX_ARGS+=(--exclude "$pat")
+    done
+    bsdtar -xf "$ZIP_FILE" -C "$DEST_DIR" "${EX_ARGS[@]}"
+  fi
 else
   echo "❌ Neither 'unzip' nor 'bsdtar' is available to extract archives." >&2
   exit 1

--- a/scripts/zip-civ-resources.sh
+++ b/scripts/zip-civ-resources.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# zip-civ-resources.sh — Zip up a “media-pruned” Civ7 Resources tree (macOS Steam).
+# zip-civ-resources.sh — Zip up Civ7 Resources using a profile from civ-zip-config.json.
 #
 # Auto-locates the Resources folder under the standard Steam path:
 #   ~/Library/Application Support/Steam/steamapps/common/Sid Meier's Civilization VII/
 #   CivilizationVII.app/Contents/Resources
 #
-# Excludes platform binaries, in-game movies, icon packs, fonts, the top-level Assets folder,
-# and other large runtime assets.
-# Usage: zip-civ-resources.sh [OUTPUT_DIR]
-# OUTPUT_DIR: where to write civ7-official-resources.zip (defaults to cwd)
+# Profiles live in scripts/civ-zip-config.json and define include/exclude rules for zipping.
+# Usage: zip-civ-resources.sh [PROFILE] [OUTPUT_DIR]
+#   PROFILE:    config profile to apply (default)
+#   OUTPUT_DIR: where to write civ7-official-resources.zip (defaults to docs/civ7-official)
 
 SRC_DIR="$HOME/Library/Application Support/Steam/steamapps/common/Sid Meier's Civilization VII/CivilizationVII.app/Contents/Resources"
 if [[ ! -d "$SRC_DIR" ]]; then
@@ -19,7 +19,16 @@ if [[ ! -d "$SRC_DIR" ]]; then
   exit 1
 fi
 
-OUTPUT_DIR=${1:-docs/civ7-official}
+CONFIG_FILE="$(dirname "$0")/civ-zip-config.json"
+PROFILE=${1:-default}
+OUTPUT_DIR=${2:-docs/civ7-official}
+if ! jq -e --arg p "$PROFILE" '.[$p]' "$CONFIG_FILE" >/dev/null; then
+  echo "❌ Unknown profile '$PROFILE'" >&2
+  exit 1
+fi
+INCLUDE=($(jq -r --arg p "$PROFILE" '.[$p].zip.include[]?' "$CONFIG_FILE"))
+EXCLUDE=($(jq -r --arg p "$PROFILE" '.[$p].zip.exclude[]?' "$CONFIG_FILE"))
+
 mkdir -p "$OUTPUT_DIR"
 # Resolve output dir to an absolute path so zip can find it after `pushd`.
 OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
@@ -30,18 +39,18 @@ ZIP_PATH="$OUTPUT_DIR/$ZIP_NAME"
 # Ensure any old archive is deleted before creating a new one.
 rm -f "$ZIP_PATH"
 
-echo "🔍 Zipping slimmed Civ7 Resources to: $ZIP_PATH"
+echo "🔍 Zipping $PROFILE Civ7 Resources to: $ZIP_PATH"
 pushd "$SRC_DIR" >/dev/null
-zip -r -X "$ZIP_PATH" . \
-  -x "*/Platforms/*" \
-  -x "*/movies/*" \
-  -x "*/data/icons/*" \
-  -x "*/Assets/*" \
-  -x "*/fonts/*" \
-  -x "Assets.car" \
-  -x "AppIcon.icns" \
-  -x "default.metallib" \
-  -x "ShaderAutoGen_*"
+ZIP_CMD=(zip -r -X "$ZIP_PATH")
+if (( ${#INCLUDE[@]} > 0 )); then
+  ZIP_CMD+=("${INCLUDE[@]}")
+else
+  ZIP_CMD+=(.)
+  for pat in "${EXCLUDE[@]}"; do
+    ZIP_CMD+=(-x "$pat")
+  done
+fi
+"${ZIP_CMD[@]}"
 popd >/dev/null
 
 echo "✅ Done. Created $ZIP_PATH"


### PR DESCRIPTION
## Summary
- document inconsistencies between community modding docs and official Civ7 resources
- add `civ-zip-config.json` with default, full, and assets profiles for zipping/unzipping resources
- update zip/unzip scripts to read profiles and clarify doc session note on excluded assets

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893254374408322988f8e2c704b01b0