### PR TITLE
Add CLI tests for run.js

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,54 +1,55 @@
 {
-    "name": "@civ7-modding/cli",
-    "version": "0.1.0",
-    "description": "CLI for managing Civilization VII modding resources.",
-    "author": "Your Name",
-    "license": "MIT",
-    "main": "dist/index.js",
-    "bin": {
-        "civ7": "./bin/run.js"
-    },
-    "files": [
-        "bin",
-        "dist",
-        "oclif.manifest.json"
+  "name": "@civ7-modding/cli",
+  "version": "0.1.0",
+  "description": "CLI for managing Civilization VII modding resources.",
+  "author": "Your Name",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "bin": {
+    "civ7": "./bin/run.js"
+  },
+  "files": [
+    "bin",
+    "dist",
+    "oclif.manifest.json"
+  ],
+  "scripts": {
+    "build": "rimraf dist && tsc -b --force && oclif manifest && chmod +x bin/run.js",
+    "start": "pnpm run build && node .",
+    "dev": "bun run src/index.ts",
+    "publish:local": "pnpm run build && pnpm link --global",
+    "zip": "node ./bin/run.js zip",
+    "unzip": "node ./bin/run.js unzip",
+    "pack": "pnpm pack",
+    "publish": "pnpm publish",
+    "prepack": "pnpm run build && oclif readme",
+    "postpack": "rimraf oclif.manifest.json",
+    "version": "oclif readme && git add README.md",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@oclif/core": "^4.5.2",
+    "@oclif/plugin-help": "^6.2.32",
+    "jsonc-parser": "^3.3.1",
+    "tslib": "^2.6.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.2.0",
+    "bun-types": "latest",
+    "oclif": "^4.22.6",
+    "rimraf": "^6.0.1",
+    "typescript": "^5.9.2"
+  },
+  "oclif": {
+    "bin": "civ7",
+    "dirname": "cli",
+    "commands": "./dist/commands",
+    "plugins": [
+      "@oclif/plugin-help"
     ],
-    "scripts": {
-        "build": "rimraf dist && tsc -b --force && oclif manifest && chmod +x bin/run.js",
-        "start": "pnpm run build && node .",
-        "dev": "bun run src/index.ts",
-        "publish:local": "pnpm run build && pnpm link --global",
-        "zip": "node ./bin/run.js zip",
-        "unzip": "node ./bin/run.js unzip",
-        "pack": "pnpm pack",
-        "publish": "pnpm publish",
-        "prepack": "pnpm run build && oclif readme",
-        "postpack": "rimraf oclif.manifest.json",
-        "version": "oclif readme && git add README.md"
-    },
-    "dependencies": {
-        "@oclif/core": "^4.5.2",
-        "@oclif/plugin-help": "^6.2.32",
-        "jsonc-parser": "^3.3.1",
-        "tslib": "^2.6.3"
-    },
-    "devDependencies": {
-        "@types/node": "^24.2.0",
-        "bun-types": "latest",
-        "oclif": "^4.22.6",
-        "rimraf": "^6.0.1",
-        "typescript": "^5.9.2"
-    },
-    "oclif": {
-        "bin": "civ7",
-        "dirname": "cli",
-        "commands": "./dist/commands",
-        "plugins": [
-            "@oclif/plugin-help"
-        ],
-        "topicSeparator": " "
-    },
-    "engines": {
-        "node": ">=18.0.0"
-    }
+    "topicSeparator": " "
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
 }

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "bun:test";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+const binPath = path.join(__dirname, "..", "bin", "run.js");
+const repoRoot = path.resolve(__dirname, "..", "..", "..",);
+
+describe("cli bin", () => {
+  it("shows help", () => {
+    const output = execFileSync("node", [binPath, "--help"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+    expect(output).toContain("COMMANDS");
+  });
+
+  it("zips and unzips with provided config", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cli-test-"));
+    try {
+      const srcDir = path.join(tmpDir, "src");
+      fs.mkdirSync(srcDir);
+      fs.writeFileSync(path.join(srcDir, "hello.txt"), "hi");
+
+      const configPath = path.join(tmpDir, "civ-zip-config.jsonc");
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({ src_path: srcDir, default: {} })
+      );
+
+      const zipPath = path.join(tmpDir, "test.zip");
+
+      execFileSync(
+        "node",
+        [binPath, "zip", "--config", configPath, "default", zipPath],
+        { cwd: repoRoot, stdio: "pipe" }
+      );
+
+      expect(fs.existsSync(zipPath)).toBe(true);
+
+      const extractDir = path.join(tmpDir, "extract");
+      execFileSync(
+        "node",
+        [
+          binPath,
+          "unzip",
+          "--config",
+          configPath,
+          "default",
+          zipPath,
+          extractDir,
+        ],
+        { cwd: repoRoot, stdio: "pipe" }
+      );
+
+      const extractedFile = path.join(extractDir, "hello.txt");
+      expect(fs.readFileSync(extractedFile, "utf8")).toBe("hi");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add Bun-based tests for CLI's help, zip, and unzip commands
- wire up `bun test` script for CLI package

## Testing
- `pnpm run build`
- `pnpm --filter @civ7-modding/cli test`


------
https://chatgpt.com/codex/tasks/task_e_689435febbf0832285e1248e44029146