### PR TITLE
test(sdk): add coverage for builders and mod generation

### DIFF
--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -142,3 +142,6 @@ See `apps/playground/src/examples/` for working examples
 - [TECHNICAL_GUIDE.md](./TECHNICAL_GUIDE.md) - Deep technical details
 - [CHANGELOG.md](./CHANGELOG.md) - Version history
 - Game schema: Extract with `pnpm refresh:data` at workspace root
+
+### Testing Notes
+- `XmlFile.write` uses an asynchronous `fs.mkdir` callback; wait briefly after `Mod.build` in tests before reading generated files.

--- a/packages/sdk/TESTING.md
+++ b/packages/sdk/TESTING.md
@@ -11,8 +11,13 @@ pnpm --filter @civ7/sdk test
 ## Current smoke tests
 
 - `Mod` initializes with default values.
+- `BaseBuilder.fill` updates known properties and triggers migration.
+- `BaseFile.modInfoPath` resolves modinfo-relative paths.
+- `Mod` adds builders and files and invokes their `build`/`write` methods.
+- `Mod.build` outputs a modinfo referencing generated files.
+- `CivilizationBuilder` migrates trait types and produces core XML files.
 
 ## Suggested future tests
 
-- Builders generate correct XML and file structures.
+- Additional builder coverage and XML validation.
 - Constant exports match game data.

--- a/packages/sdk/test/base-builder.test.ts
+++ b/packages/sdk/test/base-builder.test.ts
@@ -1,0 +1,21 @@
+import { BaseBuilder } from '../src/builders';
+import { expect, test } from 'vitest';
+
+class DummyBuilder extends BaseBuilder<{ foo: string; bar: string }> {
+  foo = 'initial';
+  bar = 'initial';
+  migrateCount = 0;
+  migrate() {
+    this.bar = 'migrated';
+    this.migrateCount++;
+    return this;
+  }
+}
+
+test('BaseBuilder.fill updates known properties and triggers migrate', () => {
+  const builder = new DummyBuilder().fill({ foo: 'updated', unknown: 'ignored' } as any);
+  expect(builder.foo).toBe('updated');
+  expect((builder as any).unknown).toBeUndefined();
+  expect(builder.bar).toBe('migrated');
+  expect(builder.migrateCount).toBe(1);
+});

--- a/packages/sdk/test/base-file.test.ts
+++ b/packages/sdk/test/base-file.test.ts
@@ -1,0 +1,12 @@
+import { BaseFile } from '../src/files';
+import { expect, test } from 'vitest';
+
+test('BaseFile.modInfoPath strips leading slash', () => {
+  const file = new BaseFile({ path: '/foo/', name: 'bar.xml', content: 'data' });
+  expect(file.modInfoPath).toBe('foo/bar.xml');
+});
+
+test('BaseFile.modInfoPath keeps relative path', () => {
+  const file = new BaseFile({ path: 'foo/', name: 'bar.xml', content: 'data' });
+  expect(file.modInfoPath).toBe('foo/bar.xml');
+});

--- a/packages/sdk/test/civilization-builder.test.ts
+++ b/packages/sdk/test/civilization-builder.test.ts
@@ -1,0 +1,23 @@
+import { CivilizationBuilder } from '../src';
+import { expect, test } from 'vitest';
+
+const civPayload = {
+  civilization: {
+    civilizationType: 'CIVILIZATION_FOO',
+    domain: 'AntiquityAgeCivilizations'
+  }
+};
+
+test('CivilizationBuilder migrates trait types from civilization', () => {
+  const builder = new CivilizationBuilder(civPayload);
+  expect(builder.trait.traitType).toBe('TRAIT_FOO');
+  expect(builder.traitAbility.traitType).toBe('TRAIT_FOO_ABILITY');
+});
+
+test('CivilizationBuilder.build produces core files', () => {
+  const builder = new CivilizationBuilder(civPayload);
+  const files = builder.build();
+  const names = files.map(f => f.name);
+  expect(names).toContain('current.xml');
+  expect(names).toContain('localization.xml');
+});

--- a/packages/sdk/test/mod-build.test.ts
+++ b/packages/sdk/test/mod-build.test.ts
@@ -1,0 +1,33 @@
+import { Mod, BaseBuilder, XmlFile, ActionGroupNode, ACTION_GROUP_ACTION } from '../src';
+import { expect, test } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { join } from 'node:path';
+
+class FileBuilder extends BaseBuilder {
+  build() {
+    return [
+      new XmlFile({
+        path: '/foo/',
+        name: 'bar.xml',
+        content: { _name: 'Test' },
+        actionGroups: [new ActionGroupNode({ id: 'ag1' })],
+        actionGroupActions: [ACTION_GROUP_ACTION.UPDATE_DATABASE]
+      })
+    ];
+  }
+}
+
+test('Mod.build writes modinfo referencing builder files', async () => {
+  const mod = new Mod({ id: 'my-mod' });
+  mod.add(new FileBuilder());
+  const tmp = fs.mkdtempSync(join(os.tmpdir(), 'mod-build-'));
+  mod.build(tmp);
+  await new Promise(r => setTimeout(r, 50));
+  const modinfoPath = join(tmp, 'my-mod.modinfo');
+  const xml = fs.readFileSync(modinfoPath, 'utf-8');
+  expect(xml).toContain('<UpdateDatabase>');
+  expect(xml).toContain('<Item>foo/bar.xml</Item>');
+  const builderFile = fs.readFileSync(join(tmp, 'foo', 'bar.xml'), 'utf-8');
+  expect(builderFile).toContain('<Test');
+});

--- a/packages/sdk/test/mod.test.ts
+++ b/packages/sdk/test/mod.test.ts
@@ -1,7 +1,52 @@
-import { Mod } from '../src';
+import { Mod, BaseBuilder, BaseFile } from '../src';
 import { expect, test } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { join } from 'node:path';
 
 test('Mod has default id', () => {
   const mod = new Mod();
   expect(mod.id).toBe('test');
+});
+
+test('Mod.add invokes build for each builder', () => {
+  const mod = new Mod();
+  let single = 0;
+  let array = 0;
+  class SingleBuilder extends BaseBuilder {
+    build() {
+      single++;
+      return [];
+    }
+  }
+  class ArrayBuilder extends BaseBuilder {
+    build() {
+      array++;
+      return [];
+    }
+  }
+  mod.add(new SingleBuilder());
+  mod.add([new ArrayBuilder(), new ArrayBuilder()]);
+  const tmp = fs.mkdtempSync(join(os.tmpdir(), 'mod-test-'));
+  mod.build(tmp);
+  expect(single).toBe(1);
+  expect(array).toBe(2);
+});
+
+test('Mod.addFiles invokes write for each file', () => {
+  const mod = new Mod();
+  let count = 0;
+  class FileStub extends BaseFile {
+    constructor() {
+      super({ content: 'data' });
+    }
+    write() {
+      count++;
+    }
+  }
+  mod.addFiles(new FileStub());
+  mod.addFiles([new FileStub(), new FileStub()]);
+  const tmp = fs.mkdtempSync(join(os.tmpdir(), 'mod-test-'));
+  mod.build(tmp);
+  expect(count).toBe(3);
 });


### PR DESCRIPTION
## Summary
- expand Mod tests to cover builder and file registration
- add BaseBuilder, BaseFile, Mod.build and CivilizationBuilder unit tests
- document new smoke tests and async XmlFile write caveat

## Testing
- `pnpm lint`
- `pnpm --filter @civ7/sdk run check`
- `pnpm build`
- `pnpm test`
- `pnpm --filter @civ7/sdk test`


------
https://chatgpt.com/codex/tasks/task_e_6899b1016d608322adab63d525427d53