### PR TITLE
Simplify subtree remote resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 - `plugin-mapgen` sources are written in TypeScript with legacy JS copies under `js-archive/` for verification.
 - CLI commands should remain thin wrappers around these plugins.
 - Status-style CLI commands now accept `--json` for machine-readable output.
-- Subtree-based CLI commands expose only relevant flags; `remoteUrl` is required only for `config`, `import`, and `setup`. `remoteName` is resolved from config and hidden; use `--remoteName` only for advanced overrides.
+- Subtree-based CLI commands expose only relevant flags; `remoteUrl` is required only for `config`, `import`, and `setup`. Remote names are stored during setup and always resolved from config with no overrides.
 
 ### Testing imports
 - Prefer importing from a package's public entry point (e.g., `@civ7/plugin-graph`) in tests rather than deep paths like `../src/*`. This keeps tests resilient to internal refactors (such as folder renames like `pipelines/` → `workflows/`) and validates the surface that external consumers use.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -100,9 +100,9 @@ Status-style commands (e.g., `git status`, `mod status`) also accept `--json` fo
 
  - `src/base/` & `src/subtree/` — abstract oclif commands for git subtree flows (configure, import, push, pull, setup). Domain commands extend these to supply prefixes and defaults.
  - `src/commands/` — oclif commands grouped by topic: `data/` (crawl, explore, render, slice, zip, unzip), `docs/`, `git/`, and `mod/` (with `mod link` aliasing `mod setup` for backward compatibility)
-- `src/utils/` — config/path resolution helpers; generic git helpers (configureRemote, importSubtree, pushSubtree, pullSubtree, logRemotePushConfig, inferRemoteNameFromUrl, resolveRemoteName/requireRemoteName, resolveBranch/requireBranch, isNonEmptyDir) live in `utils/git.ts` and centralize logging, argument defaults, and remote/branch inference for git operations
+- `src/utils/` — config/path resolution helpers; generic git helpers (configureRemote, importSubtree, pushSubtree, pullSubtree, logRemotePushConfig, getRemoteNameForSlug/requireRemoteNameForSlug, resolveBranch/requireBranch, isNonEmptyDir) live in `utils/git.ts` and centralize logging, argument defaults, and remote/branch inference for git operations
 - Subtree command classes expose only the flags they consume; `remoteUrl` is required only for `config`, `import`, and `setup` flows, while `push`/`pull` rely on saved config.
-- `remoteName` is resolved from saved config and hidden from help; pass `--remoteName` only for advanced overrides.
+- `remoteName` is stored during setup and always resolved from saved config; no CLI override is supported.
 - Use `@civ7/plugin-graph` for graph workflows (`crawlGraph`, `exploreGraph`); archive helpers are in `@civ7/plugin-files`.
 
 ### Conceptual model and traversal

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -547,14 +547,6 @@
           "allowNo": false,
           "type": "boolean"
         },
-        "remoteName": {
-          "description": "Git remote name (advanced override)",
-          "hidden": true,
-          "name": "remoteName",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
         "branch": {
           "char": "b",
           "description": "Branch to track",
@@ -666,14 +658,6 @@
           "allowNo": false,
           "type": "boolean"
         },
-        "remoteName": {
-          "description": "Git remote name (advanced override)",
-          "hidden": true,
-          "name": "remoteName",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
         "branch": {
           "char": "b",
           "description": "Branch to track",
@@ -753,14 +737,6 @@
           "name": "json",
           "allowNo": false,
           "type": "boolean"
-        },
-        "remoteName": {
-          "description": "Git remote name (advanced override)",
-          "hidden": true,
-          "name": "remoteName",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
         },
         "branch": {
           "char": "b",
@@ -878,14 +854,6 @@
           "allowNo": false,
           "type": "boolean"
         },
-        "remoteName": {
-          "description": "Git remote name (advanced override)",
-          "hidden": true,
-          "name": "remoteName",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
         "branch": {
           "char": "b",
           "description": "Branch to track",
@@ -956,14 +924,6 @@
           "name": "json",
           "allowNo": false,
           "type": "boolean"
-        },
-        "remoteName": {
-          "description": "Git remote name (advanced override)",
-          "hidden": true,
-          "name": "remoteName",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
         },
         "branch": {
           "char": "b",
@@ -1043,14 +1003,6 @@
           "name": "json",
           "allowNo": false,
           "type": "boolean"
-        },
-        "remoteName": {
-          "description": "Git remote name (advanced override)",
-          "hidden": true,
-          "name": "remoteName",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
         },
         "branch": {
           "char": "b",
@@ -1138,14 +1090,6 @@
           "allowNo": false,
           "type": "boolean"
         },
-        "remoteName": {
-          "description": "Git remote name (advanced override)",
-          "hidden": true,
-          "name": "remoteName",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
         "branch": {
           "char": "b",
           "description": "Branch to track",
@@ -1195,14 +1139,6 @@
           "name": "json",
           "allowNo": false,
           "type": "boolean"
-        },
-        "remoteName": {
-          "description": "Git remote name (advanced override)",
-          "hidden": true,
-          "name": "remoteName",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
         },
         "branch": {
           "char": "b",
@@ -1262,14 +1198,6 @@
           "name": "json",
           "allowNo": false,
           "type": "boolean"
-        },
-        "remoteName": {
-          "description": "Git remote name (advanced override)",
-          "hidden": true,
-          "name": "remoteName",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
         },
         "branch": {
           "char": "b",
@@ -1351,14 +1279,6 @@
           "allowNo": false,
           "type": "boolean"
         },
-        "remoteName": {
-          "description": "Git remote name (advanced override)",
-          "hidden": true,
-          "name": "remoteName",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
         "branch": {
           "char": "b",
           "description": "Branch to track",
@@ -1429,14 +1349,6 @@
           "name": "json",
           "allowNo": false,
           "type": "boolean"
-        },
-        "remoteName": {
-          "description": "Git remote name (advanced override)",
-          "hidden": true,
-          "name": "remoteName",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
         },
         "branch": {
           "char": "b",
@@ -1516,14 +1428,6 @@
           "name": "json",
           "allowNo": false,
           "type": "boolean"
-        },
-        "remoteName": {
-          "description": "Git remote name (advanced override)",
-          "hidden": true,
-          "name": "remoteName",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
         },
         "branch": {
           "char": "b",
@@ -1610,14 +1514,6 @@
           "name": "json",
           "allowNo": false,
           "type": "boolean"
-        },
-        "remoteName": {
-          "description": "Git remote name (advanced override)",
-          "hidden": true,
-          "name": "remoteName",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
         },
         "branch": {
           "char": "b",

--- a/packages/cli/src/base/SubtreeCommand.ts
+++ b/packages/cli/src/base/SubtreeCommand.ts
@@ -1,14 +1,10 @@
 import { Flags } from '@oclif/core';
 import BaseCommand from './BaseCommand.js';
-import { resolveBranch, resolveRemoteName } from '../utils/git.js';
+import { resolveBranch } from '../utils/git.js';
 
 export default abstract class SubtreeCommand extends BaseCommand {
   static baseFlags = {
     ...BaseCommand.baseFlags,
-    remoteName: Flags.string({
-      description: 'Git remote name (advanced override)',
-      hidden: true,
-    }),
     branch: Flags.string({
       description: 'Branch to track',
       char: 'b',
@@ -21,18 +17,6 @@ export default abstract class SubtreeCommand extends BaseCommand {
   } as const;
 
   protected abstract domain: string;
-
-  protected async resolveRemoteName(opts: { slug?: string; flags: any }) {
-    const { slug, flags } = opts;
-    return resolveRemoteName({
-      domain: this.domain,
-      slug,
-      remoteName: flags.remoteName,
-      remoteUrl: flags.remoteUrl,
-      verbose: flags.verbose,
-      logger: this,
-    });
-  }
 
   protected async resolveBranch(opts: { slug: string; flags: any }) {
     const { slug, flags } = opts;

--- a/packages/cli/src/commands/mod/status.ts
+++ b/packages/cli/src/commands/mod/status.ts
@@ -1,7 +1,7 @@
 import { Args } from '@oclif/core';
 import StatusBase from '../../subtree/StatusBase.js';
 import { getModStatus } from '@civ7/plugin-mods';
-import { getRemotePushConfig } from '../../utils/git.js';
+import { getRemoteNameForSlug, getRemotePushConfig } from '../../utils/git.js';
 
 export default class ModStatus extends StatusBase {
   static summary = 'Show git subtree status for a mod';
@@ -13,7 +13,7 @@ export default class ModStatus extends StatusBase {
   async run() {
     const { args, flags } = await this.parse(ModStatus);
     const slug = args.slug as string;
-    const remoteName = await this.resolveRemoteName({ slug, flags });
+    const remoteName = await getRemoteNameForSlug(this.domain, slug);
     const status = await getModStatus({ slug, remoteName, branch: flags.branch, verbose: flags.verbose });
 
     if (flags.json) {

--- a/packages/cli/src/subtree/ConfigRemoteBase.ts
+++ b/packages/cli/src/subtree/ConfigRemoteBase.ts
@@ -26,7 +26,6 @@ export default abstract class ConfigRemoteBase extends SubtreeCommand {
     await configureRemote({
       domain: this.domain,
       slug,
-      remoteName: flags.remoteName,
       remoteUrl: flags.remoteUrl,
       branch: flags.branch,
       verbose: flags.verbose,

--- a/packages/cli/src/subtree/ImportBase.ts
+++ b/packages/cli/src/subtree/ImportBase.ts
@@ -47,7 +47,6 @@ export default abstract class ImportBase extends SubtreeCommand {
       domain: this.domain,
       slug,
       prefix,
-      remoteName: flags.remoteName,
       remoteUrl: flags.remoteUrl,
       branch: flags.branch,
       squash: flags.squash,

--- a/packages/cli/src/subtree/PullBase.ts
+++ b/packages/cli/src/subtree/PullBase.ts
@@ -42,7 +42,6 @@ export default abstract class PullBase extends SubtreeCommand {
       domain: this.domain,
       slug,
       prefix,
-      remoteName: flags.remoteName,
       branch: flags.branch,
       squash: flags.squash,
       allowDirty: flags.yes,

--- a/packages/cli/src/subtree/PushBase.ts
+++ b/packages/cli/src/subtree/PushBase.ts
@@ -46,7 +46,6 @@ export default abstract class PushBase extends SubtreeCommand {
       domain: this.domain,
       slug,
       prefix,
-      remoteName: flags.remoteName,
       branch: flags.branch,
       allowDirty: flags.yes,
       autoUnshallow: flags.autoUnshallow,

--- a/packages/cli/src/subtree/SetupBase.ts
+++ b/packages/cli/src/subtree/SetupBase.ts
@@ -50,7 +50,6 @@ export default abstract class SetupBase extends SubtreeCommand {
     await configureRemote({
       domain: this.domain,
       slug,
-      remoteName: flags.remoteName,
       remoteUrl: flags.remoteUrl,
       branch: flags.branch,
       verbose: flags.verbose,
@@ -60,7 +59,6 @@ export default abstract class SetupBase extends SubtreeCommand {
       domain: this.domain,
       slug,
       prefix,
-      remoteName: flags.remoteName,
       remoteUrl: flags.remoteUrl,
       branch: flags.branch,
       squash: flags.squash,
@@ -68,7 +66,6 @@ export default abstract class SetupBase extends SubtreeCommand {
       autoUnshallow: flags.autoUnshallow,
       verbose: flags.verbose,
       logger: this,
-      remoteRequiredMessage: 'setup requires --remote-url <url>',
     });
   }
 }

--- a/packages/cli/src/subtree/StatusBase.ts
+++ b/packages/cli/src/subtree/StatusBase.ts
@@ -1,6 +1,6 @@
 import { Args } from '@oclif/core';
 import SubtreeCommand from '../base/SubtreeCommand.js';
-import { getRemotePushConfig, logRemotePushConfig } from '../utils/git.js';
+import { getRemoteNameForSlug, getRemotePushConfig, logRemotePushConfig } from '../utils/git.js';
 
 export default abstract class StatusBase extends SubtreeCommand {
   static flags = {
@@ -18,7 +18,9 @@ export default abstract class StatusBase extends SubtreeCommand {
       args: ctor.args ?? (this as any).args ?? StatusBase.args,
     });
     const slug = args.slug as string | undefined;
-    const remoteName = await this.resolveRemoteName({ slug, flags });
+    const remoteName = slug
+      ? await getRemoteNameForSlug(this.domain, slug)
+      : undefined;
     if (flags.json) {
       const config = remoteName
         ? await getRemotePushConfig(remoteName, { verbose: flags.verbose })

--- a/packages/cli/test/commands/mod.status.test.ts
+++ b/packages/cli/test/commands/mod.status.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../src/utils/git', () => ({
-  resolveRemoteName: vi.fn().mockResolvedValue('cfg-remote'),
+  getRemoteNameForSlug: vi.fn().mockResolvedValue('cfg-remote'),
   getRemotePushConfig: vi.fn(),
   logRemotePushConfig: vi.fn(),
 }));
@@ -11,7 +11,7 @@ vi.mock('@civ7/plugin-mods', () => ({
 }));
 
 import ModStatus from '../../src/commands/mod/status';
-import { resolveRemoteName } from '../../src/utils/git';
+import { getRemoteNameForSlug } from '../../src/utils/git';
 import { getModStatus } from '@civ7/plugin-mods';
 
 describe('mod status command', () => {
@@ -21,22 +21,12 @@ describe('mod status command', () => {
 
   test('resolves remote name from slug', async () => {
     await ModStatus.run(['foo']);
-    expect(resolveRemoteName).toHaveBeenCalledWith(
-      expect.objectContaining({ slug: 'foo', remoteName: undefined }),
-    );
+    expect(getRemoteNameForSlug).toHaveBeenCalledWith('mod', 'foo');
     expect(getModStatus).toHaveBeenCalledWith({
       slug: 'foo',
       remoteName: 'cfg-remote',
       branch: undefined,
       verbose: false,
     });
-  });
-
-  test('allows hidden remoteName override', async () => {
-    vi.mocked(resolveRemoteName).mockResolvedValueOnce('override');
-    await ModStatus.run(['foo', '--remoteName', 'override']);
-    expect(resolveRemoteName).toHaveBeenCalledWith(
-      expect.objectContaining({ remoteName: 'override' }),
-    );
   });
 });


### PR DESCRIPTION
## Summary
- remove hidden `--remoteName` flag and complex resolution
- store remote name during setup and always read from config
- update CLI tests and docs accordingly

## Testing
- `pnpm run build`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa6a32b7d88322850e35ae4574a67f