### PR TITLE
docs(engine-refactor): add TypeScript migration milestone and issue specs

### DIFF
--- a/docs/projects/engine-refactor-v1/README.md
+++ b/docs/projects/engine-refactor-v1/README.md
@@ -17,6 +17,11 @@ Large-scale procedural map generation mod for Civilization VII featuring:
 - [ ] Climate engine integration
 - [ ] Narrative overlay system
 - [ ] Multiple map presets
+- [ ] TypeScript migration with testable package architecture
+
+## Milestones
+
+- [M-TS: TypeScript Migration & Package Architecture](milestones/M-TS-typescript-migration.md) — Transform monolithic JS into typed, testable packages
 
 ## Active Plans
 

--- a/docs/projects/engine-refactor-v1/issues/CIV-1-scaffold-type-foundation.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-1-scaffold-type-foundation.md
@@ -1,0 +1,125 @@
+---
+id: CIV-1
+title: "[M-TS-01] Scaffold Type Foundation (@civ7/types)"
+state: planned
+priority: 2
+estimate: 4
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [architecture, feature]
+parent: null
+children: []
+blocked_by: []
+blocked: [CIV-2, CIV-3]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Create `packages/civ7-types` to provide TypeScript definitions for Civ7's runtime environment (globals, engine APIs, and `/base-standard/...` virtual modules), enabling type-safe development across all map generation packages.
+
+## Deliverables
+
+- [ ] Create `packages/civ7-types/package.json` with proper workspace configuration
+- [ ] Create `packages/civ7-types/index.d.ts` with global declarations:
+  - [ ] `GameplayMap` interface (72+ methods: `getGridWidth`, `isWater`, `getRainfall`, `getBiomeType`, etc.)
+  - [ ] `GameInfo` interface with table accessors (`Maps`, `Terrains`, `Biomes`, `Features`, `Resources`, 7 `StartBias*` tables, `Ages`, etc.)
+  - [ ] `TerrainBuilder` interface (terrain modification, random numbers, map building phases)
+  - [ ] `AreaBuilder`, `FractalBuilder` interfaces
+  - [ ] `engine` messaging API (`on`, `call`)
+  - [ ] Other globals: `Game`, `Players`, `Configuration`, `Database`, `PlotTags`, `FeatureTypes`
+- [ ] Declare `/base-standard/...` virtual modules:
+  - [ ] `map-globals.js`, `map-utilities.js`, `elevation-terrain-generator.js`
+  - [ ] `assign-starting-plots.js`, `feature-biome-generator.js`, `resource-generator.js`
+  - [ ] `voronoi-*.js` utilities, `kd-tree.js`, `random-pcg-32.js`
+  - [ ] Catch-all for rapid migration: `declare module '/base-standard/*'`
+- [ ] Create `tsconfig.json` extending monorepo base
+- [ ] Add package to workspace (`pnpm-workspace.yaml` already includes `packages/*`)
+- [ ] Verify: importing `@civ7/types` in another package produces no TS errors
+
+## Acceptance Criteria
+
+- [ ] `pnpm install` succeeds with new package in workspace
+- [ ] `pnpm -C packages/civ7-types check` passes (TypeScript validation)
+- [ ] Consumer packages can `/// <reference types="@civ7/types" />` without errors
+- [ ] `import { something } from '/base-standard/maps/map-utilities.js'` compiles without error
+- [ ] **Full inventory coverage verified**:
+  - [ ] All 72+ GameplayMap methods from codebase exploration are typed
+  - [ ] All 15+ GameInfo tables (Maps, Terrains, Biomes, Features, Resources, 7 StartBias* tables, Ages, Civilizations, Leaders, etc.)
+  - [ ] All TerrainBuilder methods (setters, validation, RNG, phases)
+  - [ ] Grep check: `rg "GameplayMap\." mods/mod-swooper-maps` → all methods appear in types
+
+## Testing / Verification
+
+```bash
+# Workspace install
+pnpm install
+
+# Type check the package
+pnpm -C packages/civ7-types check
+
+# Verify no TS errors when referencing
+echo '/// <reference types="@civ7/types" />' > /tmp/test.ts
+echo 'const w = GameplayMap.getGridWidth();' >> /tmp/test.ts
+pnpm exec tsc --noEmit /tmp/test.ts
+```
+
+## Dependencies / Notes
+
+- **Blocks**: M-TS-02 (Adapter), M-TS-03 (MapGen Core)
+- **Reference**: Type inventory from codebase exploration (72+ GameplayMap methods, 15+ GameInfo tables)
+- **Reference Plan**: `docs/projects/engine-refactor-v1/resources/migrate-to-ts-plan.md` Section 3.1
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Type Inventory (from codebase exploration)
+
+**GameplayMap Methods:**
+- Grid: `getGridWidth()`, `getGridHeight()`, `getMapSize()`
+- Terrain reads: `getTerrainType`, `getBiomeType`, `getFeatureType`, `getResourceType`, `getElevation`, `getRainfall`, `getTemperature`, `getPlotLatitude`
+- Predicates: `isWater`, `isMountain`, `isCoastalLand`, `isAdjacentToRivers`, `isAdjacentToShallowWater`, `isRiver`, `isNavigableRiver`, `isNaturalWonder`
+- Location: `getLocationFromIndex`, `getPlotDistance`, `getPlotTag`, `getContinentType`
+- RNG: `getRandomSeed`
+
+**GameInfo Tables:**
+- `Terrains`, `Biomes`, `Features`, `Resources`, `Maps`, `Ages`
+- `StartBiasBiomes`, `StartBiasTerrains`, `StartBiasRivers`, `StartBiasAdjacentToCoasts`, `StartBiasFeatureClasses`, `StartBiasNaturalWonders`, `StartBiasResources`
+- `Civilizations`, `Leaders`, `GlobalParameters`, `AdvancedStartParameters`, `Resource_Distribution`, `MapIslandBehavior`, etc.
+
+**TerrainBuilder Methods:**
+- Setters: `setTerrainType`, `setBiomeType`, `setRainfall`, `setElevation`, `setFeatureType`, `setPlotTag`, `addPlotTag`
+- Validation: `canHaveFeature`
+- RNG: `getRandomNumber(max, label)`
+- Phases: `stampContinents`, `buildElevation`, `modelRivers`, `defineNamedRivers`, `validateAndFixTerrain`, `storeWaterData`, `addFloodplains`
+- Utils: `generatePoissonMap`, `getHeightFromPercent`
+
+### Package Structure
+
+```
+packages/civ7-types/
+├── package.json
+├── tsconfig.json
+├── index.d.ts          # Main ambient declarations
+├── globals/
+│   ├── engine.d.ts
+│   ├── gameplay-map.d.ts
+│   ├── game-info.d.ts
+│   ├── terrain-builder.d.ts
+│   └── ...
+└── modules/
+    ├── base-standard-maps.d.ts
+    └── base-standard-scripts.d.ts
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-10-core-utils-story.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-10-core-utils-story.md
@@ -1,0 +1,114 @@
+---
+id: CIV-10
+title: "[M-TS-07a] Migrate Core Utils & Story System"
+state: planned
+priority: 2
+estimate: 2
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [feature]
+parent: CIV-7
+children: []
+blocked_by: [CIV-5, CIV-6]
+blocked: [CIV-11, CIV-12, CIV-13]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Migrate core utility files and story system from JavaScript to TypeScript, establishing the foundation types that all other layers depend on.
+
+## Deliverables
+
+- [ ] Migrate core utilities to `src/core/`:
+  - [ ] `types.js` → `types.ts` (MapContext, FoundationContext, etc.)
+  - [ ] `utils.js` → `utils.ts` (clamp, inBounds, getFeatureTypeIndex)
+  - [ ] `plot_tags.js` → `plot-tags.ts` (addPlotTags)
+  - [ ] Remove `adapters.js` (use `@civ7/adapter` instead)
+- [ ] Migrate story system to `src/story/`:
+  - [ ] `tags.js` → `tags.ts` (StoryTags sparse registry)
+  - [ ] `overlays.js` → `overlays.ts` (StoryOverlaySnapshot)
+  - [ ] `tagging.js` → `tagging.ts` (hotspots, rifts, orogeny)
+  - [ ] `corridors.js` → `corridors.ts` (corridor tagging)
+- [ ] Export all types from `@swooper/mapgen-core`
+- [ ] Write unit tests for story tag operations
+
+## Acceptance Criteria
+
+- [ ] All core/story files compile without TypeScript errors
+- [ ] Types are properly exported and importable
+- [ ] StoryTags sparse registry operations tested
+- [ ] No remaining `.js` files in `src/core/` or `src/story/`
+
+## Testing / Verification
+
+```bash
+# Type check
+pnpm -C packages/mapgen-core check
+
+# Run tests
+pnpm -C packages/mapgen-core test --filter story
+pnpm -C packages/mapgen-core test --filter core
+
+# Verify exports
+node -e "import('@swooper/mapgen-core').then(m => console.log('MapContext' in m))"
+```
+
+## Dependencies / Notes
+
+- **Parent**: M-TS-07
+- **Blocked by**: M-TS-05 (World logic for FoundationContext), M-TS-06 (Bootstrap)
+- **Blocks**: M-TS-07b, M-TS-07c, M-TS-07d (all layers depend on these types)
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Files to Migrate
+
+| Source | Target | Lines |
+|--------|--------|-------|
+| `core/types.js` | `src/core/types.ts` | ~150 |
+| `core/utils.js` | `src/core/utils.ts` | ~100 |
+| `core/plot_tags.js` | `src/core/plot-tags.ts` | ~50 |
+| `story/tags.js` | `src/story/tags.ts` | ~200 |
+| `story/overlays.js` | `src/story/overlays.ts` | ~150 |
+| `story/tagging.js` | `src/story/tagging.ts` | ~300 |
+| `story/corridors.js` | `src/story/corridors.ts` | ~200 |
+
+### Key Types to Define
+
+```typescript
+// src/core/types.ts
+export interface MapContext {
+  dimensions: { width: number; height: number };
+  fields: MapFields;
+  worldModel: WorldModel | null;
+  rng: RngState;
+  config: MapConfig;
+  metrics: Metrics;
+  adapter: EngineAdapter;
+  foundation: FoundationContext | null;
+  buffers: MapBuffers;
+  overlays: Map<string, StoryOverlaySnapshot>;
+}
+
+// src/story/tags.ts
+export interface StoryTags {
+  get(key: string): Set<string>;
+  add(key: string, x: number, y: number): void;
+  has(key: string, x: number, y: number): boolean;
+  clear(key: string): void;
+}
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-11-landmass-terrain.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-11-landmass-terrain.md
@@ -1,0 +1,110 @@
+---
+id: CIV-11
+title: "[M-TS-07b] Migrate Landmass & Terrain Layers"
+state: planned
+priority: 2
+estimate: 2
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [feature]
+parent: CIV-7
+children: []
+blocked_by: [CIV-10]
+blocked: [CIV-13]
+related_to: [CIV-12]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Migrate landmass generation and terrain shaping layers (coastlines, islands, mountains, volcanoes) from JavaScript to TypeScript.
+
+## Deliverables
+
+- [ ] Migrate landmass layers to `src/layers/`:
+  - [ ] `landmass_plate.js` → `landmass-plate.ts` (plate-driven landmass generation)
+  - [ ] `landmass_utils.js` → `landmass-utils.ts` (landmass post-processing)
+  - [ ] `coastlines.js` → `coastlines.ts` (rugged coast generation)
+  - [ ] `islands.js` → `islands.ts` (island chain generation)
+- [ ] Migrate terrain shaping layers:
+  - [ ] `mountains.js` → `mountains.ts` (physics-based mountain placement)
+  - [ ] `volcanoes.js` → `volcanoes.ts` (plate-aware volcano generation)
+- [ ] Type all layer function signatures
+- [ ] Ensure layers consume adapter interface, not globals
+
+## Acceptance Criteria
+
+- [ ] All landmass/terrain layer files compile without TypeScript errors
+- [ ] Layers use `EngineAdapter` interface, not direct `GameplayMap` calls
+- [ ] Layer configs are properly typed
+- [ ] No remaining `.js` files for these layers
+
+## Testing / Verification
+
+```bash
+# Type check
+pnpm -C packages/mapgen-core check
+
+# Build
+pnpm -C packages/mapgen-core build
+
+# Verify layer exports
+node -e "import('@swooper/mapgen-core/layers').then(m => console.log(Object.keys(m)))"
+```
+
+## Dependencies / Notes
+
+- **Parent**: M-TS-07
+- **Blocked by**: M-TS-07a (Core types)
+- **Blocks**: M-TS-07d (Orchestrator)
+- **Related to**: M-TS-07c (Climate layers)
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Files to Migrate
+
+| Source | Target | Lines |
+|--------|--------|-------|
+| `layers/landmass_plate.js` | `src/layers/landmass-plate.ts` | ~300 |
+| `layers/landmass_utils.js` | `src/layers/landmass-utils.ts` | ~150 |
+| `layers/coastlines.js` | `src/layers/coastlines.ts` | ~200 |
+| `layers/islands.js` | `src/layers/islands.ts` | ~150 |
+| `layers/mountains.js` | `src/layers/mountains.ts` | ~250 |
+| `layers/volcanoes.js` | `src/layers/volcanoes.ts` | ~200 |
+
+### Layer Pattern
+
+```typescript
+// src/layers/mountains.ts
+import type { MapContext } from '../core/types';
+import type { EngineAdapter } from '@civ7/adapter';
+import { getTunables } from '../bootstrap/tunables';
+
+export interface MountainsConfig {
+  tectonicIntensity: number;
+  mountainThreshold: number;
+  hillThreshold: number;
+}
+
+export function applyMountains(
+  ctx: MapContext,
+  adapter: EngineAdapter,
+  config?: Partial<MountainsConfig>
+): void {
+  const { MOUNTAINS_CFG } = getTunables();
+  const cfg = { ...MOUNTAINS_CFG, ...config };
+  // Implementation...
+}
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-12-climate-biomes.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-12-climate-biomes.md
@@ -1,0 +1,114 @@
+---
+id: CIV-12
+title: "[M-TS-07c] Migrate Climate & Biomes Layers"
+state: planned
+priority: 2
+estimate: 2
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [feature]
+parent: CIV-7
+children: []
+blocked_by: [CIV-10]
+blocked: [CIV-13]
+related_to: [CIV-11]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Migrate climate simulation, biome designation, and feature placement layers from JavaScript to TypeScript.
+
+## Deliverables
+
+- [ ] Migrate climate layers to `src/layers/`:
+  - [ ] `climate-engine.js` → `climate-engine.ts` (rainfall & humidity modeling)
+- [ ] Migrate biome/feature layers:
+  - [ ] `biomes.js` → `biomes.ts` (enhanced biome designation)
+  - [ ] `features.js` → `features.ts` (feature placement with climate awareness)
+- [ ] Type ClimateField interfaces
+- [ ] Ensure layers consume adapter interface for base-standard calls
+
+## Acceptance Criteria
+
+- [ ] All climate/biome/feature layer files compile without TypeScript errors
+- [ ] ClimateField types properly defined and exported
+- [ ] Layers delegate `/base-standard/...` calls through adapter
+- [ ] No remaining `.js` files for these layers
+
+## Testing / Verification
+
+```bash
+# Type check
+pnpm -C packages/mapgen-core check
+
+# Build
+pnpm -C packages/mapgen-core build
+
+# Verify exports
+node -e "import('@swooper/mapgen-core/layers').then(m => console.log('applyClimate' in m))"
+```
+
+## Dependencies / Notes
+
+- **Parent**: M-TS-07
+- **Blocked by**: M-TS-07a (Core types)
+- **Blocks**: M-TS-07d (Orchestrator)
+- **Related to**: M-TS-07b (Terrain layers)
+- **Note**: These layers call base-standard `designateBiomes()` and `addFeatures()` — ensure adapter wraps these
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Files to Migrate
+
+| Source | Target | Lines |
+|--------|--------|-------|
+| `layers/climate-engine.js` | `src/layers/climate-engine.ts` | ~400 |
+| `layers/biomes.js` | `src/layers/biomes.ts` | ~200 |
+| `layers/features.js` | `src/layers/features.ts` | ~200 |
+
+### ClimateField Interface
+
+```typescript
+// src/core/types.ts (addition)
+export interface ClimateField {
+  rainfall: Float32Array;
+  humidity: Float32Array;
+  temperature: Float32Array;
+}
+
+export interface ClimateConfig {
+  baseline: BaselineConfig;
+  refine: RefineConfig;
+  swatches: SwatchConfig;
+}
+```
+
+### Base-Standard Wrapper Pattern
+
+```typescript
+// These layers call base-standard functions — wrap via adapter
+export function applyBiomes(
+  ctx: MapContext,
+  adapter: EngineAdapter
+): void {
+  // Prepare climate data...
+
+  // Call base-standard through adapter
+  adapter.designateBiomes();
+
+  // Apply narrative overlays...
+}
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-13-placement-orchestrator.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-13-placement-orchestrator.md
@@ -1,0 +1,156 @@
+---
+id: CIV-13
+title: "[M-TS-07d] Migrate Placement & Orchestrator"
+state: planned
+priority: 2
+estimate: 2
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [feature]
+parent: CIV-7
+children: []
+blocked_by: [CIV-10, CIV-11, CIV-12]
+blocked: [CIV-8]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Migrate the placement layer and MapOrchestrator from JavaScript to TypeScript, completing the Gate C migration and wiring up the mod entry point.
+
+## Deliverables
+
+- [ ] Migrate placement layer:
+  - [ ] `placement.js` → `placement.ts` (wonders, resources, starts, discoveries)
+- [ ] Migrate orchestrator:
+  - [ ] `map_orchestrator.js` → `src/MapOrchestrator.ts`
+  - [ ] Type stage manifest system
+  - [ ] Type `generateMap()` and `requestMapData()` functions
+  - [ ] Wire up lazy bootstrap integration
+  - [ ] Consume adapter interface for all engine calls
+- [ ] Update mod entry point:
+  - [ ] `src/swooper-desert-mountains.ts` imports from `@swooper/mapgen-core`
+  - [ ] Call `bootstrap()` with preset config
+  - [ ] Wire `engine.on()` handlers through adapter
+- [ ] Ensure all public APIs are exported
+
+## Acceptance Criteria
+
+- [ ] MapOrchestrator compiles without TypeScript errors
+- [ ] `pnpm -C packages/mapgen-core build` succeeds
+- [ ] `pnpm -C mods/mod-swooper-maps build` produces valid bundle
+- [ ] Bundle includes inlined core code with external `/base-standard/...` imports
+- [ ] Stage manifest properly typed with requires/provides
+- [ ] No remaining `.js` files in `packages/mapgen-core/src/`
+
+## Testing / Verification
+
+```bash
+# Build core library
+pnpm -C packages/mapgen-core build
+
+# Type check
+pnpm -C packages/mapgen-core check
+
+# Build mod bundle
+pnpm -C mods/mod-swooper-maps build
+
+# Verify bundle structure
+! grep "from '@swooper/mapgen-core'" mods/mod-swooper-maps/mod/maps/swooper-desert-mountains.js
+# ^^^ Should be empty (core inlined)
+
+grep "from '/base-standard/" mods/mod-swooper-maps/mod/maps/swooper-desert-mountains.js
+# ^^^ Should find imports (base-standard external)
+```
+
+## Dependencies / Notes
+
+- **Parent**: M-TS-07
+- **Blocked by**: M-TS-07a (Types), M-TS-07b (Terrain), M-TS-07c (Climate)
+- **Blocks**: M-TS-08 (E2E validation)
+- **Final sub-issue**: Completes Gate C migration
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Files to Migrate
+
+| Source | Target | Lines |
+|--------|--------|-------|
+| `layers/placement.js` | `src/layers/placement.ts` | ~400 |
+| `map_orchestrator.js` | `src/MapOrchestrator.ts` | ~600 |
+
+### MapOrchestrator Structure
+
+```typescript
+// src/MapOrchestrator.ts
+import type { EngineAdapter } from '@civ7/adapter';
+import type { MapContext, StageManifest } from './core/types';
+import { getTunables, resetTunables } from './bootstrap/tunables';
+
+export class MapOrchestrator {
+  private adapter: EngineAdapter;
+  private manifest: StageManifest;
+
+  constructor(adapter: EngineAdapter) {
+    this.adapter = adapter;
+    this.manifest = getTunables().STAGE_MANIFEST;
+  }
+
+  requestMapData(): void {
+    // Initialize map dimensions
+    resetTunables(); // Ensure fresh config for each run
+    const config = getTunables();
+    this.adapter.setMapInitData(config.dimensions);
+  }
+
+  generateMap(): void {
+    resetTunables(); // Runtime rebind at each generateMap entry
+    const ctx = this.createContext();
+
+    for (const stage of this.manifest.order) {
+      this.runStage(stage, ctx);
+    }
+  }
+
+  private createContext(): MapContext { /* ... */ }
+  private runStage(stage: string, ctx: MapContext): void { /* ... */ }
+}
+```
+
+### Entry Point Integration
+
+```typescript
+// mods/mod-swooper-maps/src/swooper-desert-mountains.ts
+/// <reference types="@civ7/types" />
+
+import { bootstrap, MapOrchestrator } from '@swooper/mapgen-core';
+import { CivEngineAdapter } from '@civ7/adapter/civ7-adapter';
+
+bootstrap({
+  preset: 'desert-mountains',
+  overrides: {
+    mountains: { tectonicIntensity: 0.77 }
+  }
+});
+
+const adapter = new CivEngineAdapter();
+const orchestrator = new MapOrchestrator(adapter);
+
+engine.on('RequestMapInitData', () => orchestrator.requestMapData());
+engine.on('GenerateMap', () => orchestrator.generateMap());
+
+console.log('Swooper Desert Mountains (TypeScript Build) Loaded');
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-2-create-adapter-package.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-2-create-adapter-package.md
@@ -1,0 +1,149 @@
+---
+id: CIV-2
+title: "[M-TS-02] Create Centralized Adapter (@civ7/adapter)"
+state: planned
+priority: 2
+estimate: 3
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [architecture, feature]
+parent: null
+children: []
+blocked_by: [CIV-1]
+blocked: [CIV-3]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Create `packages/civ7-adapter` as the single module allowed to import `/base-standard/...` paths, providing an interface that core logic consumes and tests can mock.
+
+## Deliverables
+
+- [ ] Create `packages/civ7-adapter/package.json` with workspace configuration
+- [ ] Create adapter interface (`src/types.ts`):
+  - [ ] `EngineAdapter` interface (reads, writes, RNG, utilities)
+  - [ ] `MapContext` type for passing state between stages
+- [ ] Create Civ7 adapter implementation (`src/civ7-adapter.ts`):
+  - [ ] Import from `/base-standard/maps/map-utilities.js`, `map-globals.js`, etc.
+  - [ ] Wrap `GameplayMap`, `TerrainBuilder`, `AreaBuilder`, `FractalBuilder`
+  - [ ] Proxy all engine/global calls
+- [ ] Create mock adapter for testing (`src/mock-adapter.ts`):
+  - [ ] Configurable mock for all interface methods
+  - [ ] No `/base-standard/...` imports
+- [ ] Export both adapters with clear entry points
+- [ ] Configure `tsup` to keep `/base-standard/...` imports external
+- [ ] Add lint rule / grep check: `/base-standard/...` imports only allowed in this package
+
+## Acceptance Criteria
+
+- [ ] `pnpm -C packages/civ7-adapter build` succeeds
+- [ ] Output bundle preserves `import ... from '/base-standard/...'` exactly
+- [ ] Mock adapter can be imported without any `/base-standard/...` resolution errors
+- [ ] Interface covers all methods used by existing `CivEngineAdapter` in mod
+- [ ] **Adapter boundary enforcement**: `rg '/base-standard/' packages/ --glob '!**/civ7-adapter/**' --glob '!**/*.d.ts'` returns empty (no /base-standard/ imports outside adapter)
+
+## Testing / Verification
+
+```bash
+# Build the adapter
+pnpm -C packages/civ7-adapter build
+
+# Verify external imports preserved
+grep "from '/base-standard/" packages/civ7-adapter/dist/civ7-adapter.js
+
+# Verify mock has no base-standard imports
+! grep "/base-standard/" packages/civ7-adapter/dist/mock-adapter.js
+
+# Lint check for import boundary
+rg "/base-standard/" packages/ --glob "!**/civ7-adapter/**" --glob "!**/*.d.ts"
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: M-TS-01 (Types package provides declarations)
+- **Blocks**: M-TS-03 (MapGen Core consumes this adapter)
+- **Reference**: Existing `CivEngineAdapter` at `mods/mod-swooper-maps/mod/maps/core/adapters.js`
+- **Key Decision**: This package is the **only** place `/base-standard/...` imports are allowed
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Existing CivEngineAdapter Analysis
+
+The current `core/adapters.js` already wraps GameplayMap methods. Key interface:
+
+```typescript
+interface EngineAdapter {
+  // Reads
+  isWater(x: number, y: number): boolean;
+  isMountain(x: number, y: number): boolean;
+  isAdjacentToRivers(x: number, y: number, radius?: number): boolean;
+  getElevation(x: number, y: number): number;
+  getTerrainType(x: number, y: number): number;
+  getRainfall(x: number, y: number): number;
+  getTemperature(x: number, y: number): number;
+  getLatitude(x: number, y: number): number;
+  getFeatureType(x: number, y: number): number;
+
+  // Writes
+  setTerrainType(x: number, y: number, type: number): void;
+  setRainfall(x: number, y: number, value: number): void;
+  setElevation(x: number, y: number, value: number): void;
+  setFeatureType(x: number, y: number, data: FeatureData): void;
+
+  // RNG
+  getRandomNumber(max: number, label: string): number;
+
+  // Utils
+  validateAndFixTerrain(): void;
+  recalculateAreas(): void;
+  createFractal(id: number, w: number, h: number, grain: number, flags: number): void;
+  getFractalHeight(id: number, x: number, y: number): number;
+  stampContinents(): void;
+  buildElevation(): void;
+  modelRivers(min: number, max: number, terrain: number): void;
+  defineNamedRivers(): void;
+  storeWaterData(): void;
+}
+```
+
+### Package Structure
+
+```
+packages/civ7-adapter/
+├── package.json
+├── tsconfig.json
+├── tsup.config.ts        # External: /base-standard/.*
+├── src/
+│   ├── index.ts          # Re-exports
+│   ├── types.ts          # EngineAdapter interface
+│   ├── civ7-adapter.ts   # Real implementation (imports base-standard)
+│   └── mock-adapter.ts   # Test mock (no base-standard)
+└── dist/
+```
+
+### tsup.config.ts
+
+```typescript
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/civ7-adapter.ts', 'src/mock-adapter.ts'],
+  format: ['esm'],
+  external: [/^\/base-standard\/.*/],
+  dts: true,
+});
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-3-initialize-mapgen-core.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-3-initialize-mapgen-core.md
@@ -1,0 +1,207 @@
+---
+id: CIV-3
+title: "[M-TS-03] Initialize MapGen Core Library (@swooper/mapgen-core)"
+state: planned
+priority: 2
+estimate: 3
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [architecture, feature]
+parent: null
+children: []
+blocked_by: [CIV-1, CIV-2]
+blocked: [CIV-4, CIV-5, CIV-6]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Create `packages/mapgen-core` as the pure TypeScript domain library containing all map generation algorithms, testable via `bun test` without game dependencies.
+
+## Deliverables
+
+- [ ] Create `packages/mapgen-core/package.json`:
+  - [ ] Name: `@swooper/mapgen-core`
+  - [ ] Dependencies: `@civ7/types`, `@civ7/adapter`
+  - [ ] Scripts: `test` → `bun test`, `build` → `tsup`
+- [ ] Create directory structure:
+  - [ ] `src/index.ts` — barrel exports
+  - [ ] `src/bootstrap/` — placeholder for lazy config providers
+  - [ ] `src/world/` — placeholder for Voronoi/plate logic
+  - [ ] `src/layers/` — placeholder for layer logic
+  - [ ] `src/core/` — placeholder for utils/types
+- [ ] Create `tsconfig.json` extending monorepo base
+- [ ] Create `tsup.config.ts` with ESM output
+- [ ] Create Bun test infrastructure:
+  - [ ] `bunfig.toml` with test preload
+  - [ ] `test/setup.ts` with Civ7 global mocks
+  - [ ] `test/smoke.test.ts` — minimal test proving setup works
+- [ ] Configure package exports for subpath imports
+- [ ] Add pnpm bridge script at root: `"test:mapgen": "pnpm -C packages/mapgen-core bun test"`
+
+## Acceptance Criteria
+
+- [ ] `pnpm install` succeeds with new package in workspace
+- [ ] `pnpm -C packages/mapgen-core build` produces valid ESM output
+- [ ] `pnpm -C packages/mapgen-core test` (or `bun test`) passes smoke test
+- [ ] Package exports work: `import { something } from '@swooper/mapgen-core'`
+- [ ] Subpath exports work: `import { something } from '@swooper/mapgen-core/world'`
+- [ ] Test setup correctly mocks `GameplayMap`, `GameInfo`, `TerrainBuilder`
+
+## Testing / Verification
+
+```bash
+# Install workspace
+pnpm install
+
+# Build the package
+pnpm -C packages/mapgen-core build
+
+# Run tests
+pnpm -C packages/mapgen-core test
+
+# Verify exports
+node -e "import('@swooper/mapgen-core').then(m => console.log(Object.keys(m)))"
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: M-TS-01 (Types), M-TS-02 (Adapter)
+- **Blocks**: M-TS-04 (Gate A validation), M-TS-05 (Voronoi migration), M-TS-06 (Bootstrap refactor)
+- **Tooling**: Prefer Bun for test/build; fall back to pnpm/vitest if instability occurs
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Package Structure
+
+```
+packages/mapgen-core/
+├── package.json
+├── tsconfig.json
+├── tsup.config.ts
+├── bunfig.toml
+├── src/
+│   ├── index.ts              # Barrel exports
+│   ├── bootstrap/
+│   │   └── entry.ts          # Placeholder
+│   ├── world/
+│   │   └── index.ts          # Placeholder
+│   ├── layers/
+│   │   └── index.ts          # Placeholder
+│   └── core/
+│       └── index.ts          # Placeholder
+└── test/
+    ├── setup.ts              # Global mocks
+    └── smoke.test.ts         # Minimal test
+```
+
+### package.json
+
+```json
+{
+  "name": "@swooper/mapgen-core",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./bootstrap": "./dist/bootstrap/entry.js",
+    "./world": "./dist/world/index.js",
+    "./layers": "./dist/layers/index.js"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "bun test",
+    "check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@civ7/types": "workspace:*",
+    "@civ7/adapter": "workspace:*"
+  },
+  "devDependencies": {
+    "bun-types": "latest",
+    "tsup": "^8.3.0",
+    "typescript": "^5.7.0"
+  }
+}
+```
+
+### bunfig.toml
+
+```toml
+[test]
+preload = ["./test/setup.ts"]
+```
+
+### test/setup.ts (Civ7 Global Mocks)
+
+```typescript
+// Mock Civ7 Engine API
+global.engine = {
+  on: () => {},
+  call: () => {}
+};
+
+// Mock Map Data API
+global.GameplayMap = {
+  getGridWidth: () => 128,
+  getGridHeight: () => 80,
+  getMapSize: () => "MAPSIZE_HUGE",
+  isWater: () => false,
+  isMountain: () => false,
+  getTerrainType: () => 0,
+  getRainfall: () => 0,
+  getTemperature: () => 0,
+  getPlotLatitude: () => 0,
+  // ... extend as needed
+};
+
+// Mock GameInfo Database
+global.GameInfo = {
+  Maps: {
+    lookup: () => ({
+      NumNaturalWonders: 4,
+      PlayersLandmass1: 2,
+      PlayersLandmass2: 2,
+    })
+  },
+  Terrains: { find: () => null, lookup: () => null, length: 0 },
+  Biomes: { find: () => null, lookup: () => null, length: 0 },
+  // ... extend as needed
+};
+
+global.TerrainBuilder = {
+  validateAndFixTerrain: () => {},
+  stampContinents: () => {},
+  buildElevation: () => {},
+  modelRivers: () => {},
+  defineNamedRivers: () => {},
+  storeWaterData: () => {},
+  getRandomNumber: (max: number) => Math.floor(Math.random() * max),
+};
+
+global.AreaBuilder = {
+  recalculateAreas: () => {}
+};
+
+global.FractalBuilder = {
+  create: () => {},
+  getHeight: () => 0,
+};
+
+global.console = console;
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-4-validate-build-pipeline.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-4-validate-build-pipeline.md
@@ -1,0 +1,152 @@
+---
+id: CIV-4
+title: "[M-TS-04] Validate Build Pipeline (Gate A)"
+state: planned
+priority: 2
+estimate: 2
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [architecture, testing]
+parent: null
+children: []
+blocked_by: [CIV-3]
+blocked: [CIV-5, CIV-6]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Prove the TypeScript build pipeline works end-to-end by creating a minimal mod entry point that imports a base-standard script, bundles via tsup, deploys to the game, and loads without errors (Gate A validation).
+
+## Deliverables
+
+- [ ] Configure `mods/mod-swooper-maps` for TypeScript:
+  - [ ] Add `package.json` with tsup build script
+  - [ ] Add `tsconfig.json` extending monorepo base
+  - [ ] Add `tsup.config.ts` with `/base-standard/.*` as external
+- [ ] Create minimal TypeScript entry point:
+  - [ ] `src/swooper-desert-mountains.ts`
+  - [ ] Import from `/base-standard/maps/continents.js` (or delegate script)
+  - [ ] Add `console.log("Gate A Wrapper Loaded")`
+- [ ] Run build: `bun run build` or `pnpm run build`
+- [ ] Verify output:
+  - [ ] `mod/maps/swooper-desert-mountains.js` exists
+  - [ ] Contains `import ... from '/base-standard/...'` preserved
+- [ ] Deploy to game: `bun run deploy`
+- [ ] Launch game and verify:
+  - [ ] Mod loads without "Module Not Found" errors
+  - [ ] Map generates successfully (Continents fallback)
+  - [ ] Console shows "Gate A Wrapper Loaded"
+
+## Acceptance Criteria
+
+- [ ] `tsup` produces single bundled JS file with externals preserved
+- [ ] `@civ7/adapter` and `@swooper/mapgen-core` are force-bundled (inlined, not external)
+- [ ] `/base-standard/...` imports appear ONLY as external imports at bundle top (not inlined code)
+- [ ] Adapter boundary verified: `/base-standard/` string only appears in import statements, not function bodies
+- [ ] No TypeScript compilation errors
+- [ ] Game loads mod without errors
+- [ ] Game console shows "Gate A Wrapper Loaded"
+- [ ] Map generation completes (uses base-standard Continents logic)
+
+## Testing / Verification
+
+```bash
+# Build the mod
+cd mods/mod-swooper-maps
+bun run build
+
+# Check output exists
+ls -la mod/maps/swooper-desert-mountains.js
+
+# Verify external imports preserved (should find import statements)
+grep "from '/base-standard/" mod/maps/swooper-desert-mountains.js
+
+# Verify adapter boundary: /base-standard/ ONLY in import lines, not in function bodies
+# This should return ONLY import/from lines, nothing else
+grep -n "/base-standard/" mod/maps/swooper-desert-mountains.js | grep -v "^[0-9]*:import\|^[0-9]*:.*from"
+# ^^^ Should return empty (no matches outside imports)
+
+# Verify @civ7/adapter is inlined (NOT an import)
+! grep "from '@civ7/adapter'" mod/maps/swooper-desert-mountains.js
+# ^^^ Should return empty (adapter is bundled, not imported)
+
+# Deploy to game
+bun run deploy
+
+# Then manually launch Civ 7 and:
+# 1. Enable the mod
+# 2. Start new game with Swooper map
+# 3. Check game console for "Gate A Wrapper Loaded"
+# 4. Verify map generates without crash
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: M-TS-03 (MapGen Core must exist for workspace dependencies)
+- **Blocks**: M-TS-05 (Voronoi migration), M-TS-06 (Bootstrap refactor) — we don't migrate heavy logic until pipeline proven
+- **Gate A Success Condition**: Game loads and generates a map (even if just Continents fallback)
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Mod tsup.config.ts
+
+```typescript
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/swooper-desert-mountains.ts'],
+  outDir: 'mod/maps',
+  format: ['esm'],
+  target: 'esnext',
+  bundle: true,
+  clean: false,  // Don't clear — preserve static XML files
+  external: [/^\/base-standard\/.*/],
+  noExternal: ['@swooper/mapgen-core', '@civ7/adapter'],  // Force-bundle these
+  sourcemap: false,
+  minify: false,
+});
+```
+
+### Minimal Entry Point
+
+```typescript
+// src/swooper-desert-mountains.ts
+/// <reference types="@civ7/types" />
+
+// Gate A: Prove pipeline works by delegating to base-standard
+import '/base-standard/maps/continents.js';
+
+console.log("Gate A Wrapper Loaded - TypeScript Build Pipeline Working");
+```
+
+### package.json scripts
+
+```json
+{
+  "scripts": {
+    "build": "tsup",
+    "deploy": "bun run build && bun ../../packages/cli/bin/run.js mod manage deploy"
+  }
+}
+```
+
+### Why Continents.js?
+
+Using `continents.js` as delegate ensures:
+1. Game generates a valid map (no crash from missing logic)
+2. We prove external imports work correctly
+3. We can iterate on build config before migrating real logic
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-5-migrate-voronoi-world-logic.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-5-migrate-voronoi-world-logic.md
@@ -1,0 +1,154 @@
+---
+id: CIV-5
+title: "[M-TS-05] Migrate World/Voronoi Logic (Gate B)"
+state: planned
+priority: 2
+estimate: 5
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [feature, testing]
+parent: null
+children: []
+blocked_by: [CIV-4]
+blocked: [CIV-7]
+related_to: [CIV-6]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Port the Voronoi plate tectonics logic from `mod/maps/world/*.js` to `packages/mapgen-core/src/world/*.ts` and prove testability by running algorithmic tests in Bun (Gate B validation).
+
+## Deliverables
+
+- [ ] Migrate `world/model.js` → `src/world/model.ts`:
+  - [ ] Convert WorldModel singleton to TypeScript class/module
+  - [ ] Type all tensor structures (plates, dynamics, diagnostics)
+  - [ ] Maintain API compatibility with existing consumers
+- [ ] Migrate `world/plates.js` → `src/world/plates.ts`:
+  - [ ] Type `calculateVoronoiCells` function
+  - [ ] Type plate boundary calculations
+  - [ ] Ensure pure functions where possible (no global state reads)
+- [ ] Migrate `world/plate_seed.js` → `src/world/plate-seed.ts`:
+  - [ ] Type `PlateSeedManager` class
+  - [ ] Convert seed generation to pure TypeScript
+- [ ] Write unit tests in `test/world/`:
+  - [ ] `voronoi.test.ts` — test plate generation produces expected count
+  - [ ] `plates.test.ts` — test boundary calculations
+  - [ ] `plate-seed.test.ts` — test deterministic seed generation
+- [ ] Verify tests run in <100ms without game dependencies
+- [ ] Export world modules from `@swooper/mapgen-core/world`
+
+## Acceptance Criteria
+
+- [ ] All `world/*.js` files migrated to TypeScript equivalents
+- [ ] `bun test` passes all world module tests
+- [ ] Tests complete in <100ms (no game dependency overhead)
+- [ ] `calculateVoronoiCells({ width: 80, height: 50, count: 12 })` returns 12 plates
+- [ ] No runtime errors from missing globals (mocks cover all dependencies)
+- [ ] TypeScript strict mode passes for migrated files
+
+## Testing / Verification
+
+```bash
+# Run world-specific tests
+pnpm -C packages/mapgen-core bun test --filter world
+
+# Run full test suite
+pnpm -C packages/mapgen-core bun test
+
+# Verify test timing
+time pnpm -C packages/mapgen-core bun test
+
+# Type check
+pnpm -C packages/mapgen-core check
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: M-TS-04 (Pipeline must be validated first)
+- **Related to**: M-TS-06 (Bootstrap refactor may be needed for some tests)
+- **Blocks**: M-TS-07 (Orchestrator migration depends on world logic)
+- **Gate B Goal**: Prove we can test complex algorithms outside the game
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Files to Migrate
+
+| Source | Target | Notes |
+|--------|--------|-------|
+| `mod/maps/world/model.js` | `src/world/model.ts` | Singleton → typed module |
+| `mod/maps/world/plates.js` | `src/world/plates.ts` | Voronoi calculations |
+| `mod/maps/world/plate_seed.js` | `src/world/plate-seed.ts` | Deterministic seed manager |
+
+### WorldModel Structure (from exploration)
+
+```typescript
+interface WorldModelState {
+  plates: {
+    id: Uint16Array;
+    boundaryCloseness: Float32Array;
+    boundaryType: Uint8Array;
+    tectonicStress: Float32Array;
+    upliftPotential: Float32Array;
+    riftPotential: Float32Array;
+    shieldStability: Float32Array;
+    movementU: Float32Array;
+    movementV: Float32Array;
+    rotation: Float32Array;
+  };
+  dynamics: {
+    windU: Float32Array;
+    windV: Float32Array;
+    currentU: Float32Array;
+    currentV: Float32Array;
+    pressure: Float32Array;
+  };
+  diagnostics: {
+    boundaryTree: kdTree | null;
+  };
+}
+```
+
+### Test Examples
+
+```typescript
+// test/world/voronoi.test.ts
+import { describe, it, expect } from "bun:test";
+import { calculateVoronoiCells } from "../src/world/plates";
+
+describe("Voronoi Tectonics", () => {
+  it("should generate the requested number of plates", () => {
+    const plates = calculateVoronoiCells({ width: 80, height: 50, count: 12 });
+    expect(plates.length).toBe(12);
+  });
+
+  it("should produce deterministic results with same seed", () => {
+    const opts = { width: 80, height: 50, count: 8, seed: 42 };
+    const plates1 = calculateVoronoiCells(opts);
+    const plates2 = calculateVoronoiCells(opts);
+    expect(plates1).toEqual(plates2);
+  });
+});
+```
+
+### Pure Function Extraction Strategy
+
+Where possible, extract pure functions from WorldModel:
+- Input: configuration + seed
+- Output: typed tensor arrays
+- No GameplayMap reads inside pure functions
+
+This enables testing without heavy mocking.
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-6-refactor-bootstrap-lazy-providers.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-6-refactor-bootstrap-lazy-providers.md
@@ -1,0 +1,191 @@
+---
+id: CIV-6
+title: "[M-TS-06] Refactor Bootstrap to Lazy Providers"
+state: planned
+priority: 2
+estimate: 4
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [architecture, technical-debt]
+parent: null
+children: []
+blocked_by: [CIV-4]
+blocked: [CIV-7]
+related_to: [CIV-5]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Refactor bootstrap files (`tunables.js`, `resolved.js`, `runtime.js`) to use a memoized provider pattern, eliminating import-time crashes when GameInfo/GameplayMap globals are unavailable (critical for test isolation).
+
+## Deliverables
+
+- [ ] Migrate `bootstrap/tunables.js` → `src/bootstrap/tunables.ts`:
+  - [ ] Replace top-level `GameInfo.Maps.lookup()` with `getTunables()` function
+  - [ ] Add module-level cache variable
+  - [ ] Export `resetTunables()` for test cleanup
+  - [ ] Maintain all existing config exports via lazy getters
+- [ ] Migrate `bootstrap/resolved.js` → `src/bootstrap/resolved.ts`:
+  - [ ] Defer config resolution to function call time
+  - [ ] Add `resetResolved()` for test isolation
+- [ ] Migrate `bootstrap/runtime.js` → `src/bootstrap/runtime.ts`:
+  - [ ] Already uses `setConfig()`/`getConfig()` pattern (minimal changes)
+  - [ ] Add TypeScript types for config object
+- [ ] Migrate `bootstrap/entry.js` → `src/bootstrap/entry.ts`:
+  - [ ] Type the `bootstrap()` function signature
+  - [ ] Ensure lazy initialization flows through correctly
+- [ ] Write tests for bootstrap modules:
+  - [ ] Test `getTunables()` returns expected structure with mocked globals
+  - [ ] Test `resetTunables()` clears cache (subsequent call re-reads)
+  - [ ] Test multiple `reset*()` calls in `beforeEach` for isolation
+- [ ] Update all consumers to call `getTunables()` instead of importing constants
+
+## Acceptance Criteria
+
+- [ ] Importing `@swooper/mapgen-core/bootstrap` does NOT crash without globals
+- [ ] `getTunables()` returns valid config when globals are mocked
+- [ ] `resetTunables()` clears cache, enabling test isolation
+- [ ] Each test file can mock different GameInfo values independently
+- [ ] **Runtime rebind**: `resetTunables()` / `rebind()` called at start of each `generateMap()` entry (not just tests)
+- [ ] **Test isolation**: `reset*()` functions called in test `beforeEach` hooks
+- [ ] TypeScript strict mode passes for all bootstrap files
+- [ ] Existing mod functionality unchanged (lazy init is transparent at runtime)
+
+## Testing / Verification
+
+```bash
+# Run bootstrap tests
+pnpm -C packages/mapgen-core bun test --filter bootstrap
+
+# Verify import doesn't crash
+node -e "import('@swooper/mapgen-core/bootstrap')" # Should not throw
+
+# Type check
+pnpm -C packages/mapgen-core check
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: M-TS-04 (Pipeline validation)
+- **Related to**: M-TS-05 (Voronoi migration may need bootstrap for config)
+- **Blocks**: M-TS-07 (Orchestrator migration depends on lazy bootstrap)
+- **Critical Problem**: Current `tunables.js` reads `GameplayMap.getMapSize()` at import time, crashing any test that imports it
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Current Pattern (Problematic)
+
+```javascript
+// Current tunables.js - crashes on import!
+const size = GameplayMap.getMapSize();
+export const config = GameInfo.Maps.lookup(size);
+export const LANDMASS_CFG = config.landmass;
+// ... all exports execute at import time
+```
+
+### New Pattern (Safe)
+
+```typescript
+// New tunables.ts - lazy evaluation
+let _cache: TunablesConfig | null = null;
+
+export function getTunables(): TunablesConfig {
+  if (_cache) return _cache;
+
+  // Only executes when called (inside game or mocked test)
+  const size = GameplayMap.getMapSize();
+  const rawConfig = GameInfo.Maps.lookup(size);
+
+  _cache = {
+    LANDMASS_CFG: rawConfig.landmass,
+    MOUNTAINS_CFG: rawConfig.mountains,
+    // ... all config groups
+  };
+
+  return _cache;
+}
+
+export function resetTunables(): void {
+  _cache = null;
+}
+
+// For backwards compatibility, export lazy getters
+export const LANDMASS_CFG = new Proxy({} as LandmassConfig, {
+  get(_, prop) {
+    return getTunables().LANDMASS_CFG[prop as keyof LandmassConfig];
+  }
+});
+```
+
+### Files to Migrate
+
+| Source | Target | Complexity |
+|--------|--------|------------|
+| `bootstrap/tunables.js` | `src/bootstrap/tunables.ts` | High — many exports |
+| `bootstrap/resolved.js` | `src/bootstrap/resolved.ts` | Medium — composition logic |
+| `bootstrap/runtime.js` | `src/bootstrap/runtime.ts` | Low — already deferred |
+| `bootstrap/entry.js` | `src/bootstrap/entry.ts` | Medium — entry point |
+
+### Test Pattern
+
+```typescript
+// test/bootstrap/tunables.test.ts
+import { describe, it, expect, beforeEach } from "bun:test";
+import { getTunables, resetTunables } from "../src/bootstrap/tunables";
+
+beforeEach(() => {
+  resetTunables();
+
+  // Set up mock
+  global.GameplayMap = { getMapSize: () => "MAPSIZE_STANDARD" };
+  global.GameInfo = {
+    Maps: { lookup: () => ({ landmass: { baseWaterPercent: 60 } }) }
+  };
+});
+
+describe("getTunables", () => {
+  it("should return landmass config from GameInfo", () => {
+    const tunables = getTunables();
+    expect(tunables.LANDMASS_CFG.baseWaterPercent).toBe(60);
+  });
+
+  it("should cache results", () => {
+    const t1 = getTunables();
+    const t2 = getTunables();
+    expect(t1).toBe(t2); // Same reference
+  });
+
+  it("should clear cache on reset", () => {
+    const t1 = getTunables();
+    resetTunables();
+
+    // Change mock
+    global.GameInfo.Maps.lookup = () => ({ landmass: { baseWaterPercent: 80 } });
+
+    const t2 = getTunables();
+    expect(t2.LANDMASS_CFG.baseWaterPercent).toBe(80);
+  });
+});
+```
+
+### Memoization Strategy from Plan
+
+> Keep an initial bind at module load for safety, but mandate `rebind()` (or cache reset) at each `generateMap` entry in runtime and in test `beforeEach` to avoid stale configs.
+
+This means:
+1. Lazy getters for safe import
+2. `reset*()` called at start of each `generateMap()` run
+3. `reset*()` called in test `beforeEach`
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-7-migrate-orchestrator-layers.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-7-migrate-orchestrator-layers.md
@@ -1,0 +1,198 @@
+---
+id: CIV-7
+title: "[M-TS-07] Migrate Orchestrator & Layers (Gate C)"
+state: planned
+priority: 2
+estimate: 8
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [feature]
+parent: null
+children: [CIV-10, CIV-11, CIV-12, CIV-13]
+blocked_by: [CIV-5, CIV-6]
+blocked: [CIV-8]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Port the MapOrchestrator and all layer modules from JavaScript to TypeScript, completing the core logic migration (Gate C). **This is a parent issue with 4 sub-issues for PR-sized work.**
+
+## Sub-Issues
+
+- [ ] [CIV-10: Core Utils & Story System](CIV-10-core-utils-story.md) — Foundation types and story system (~1200 lines)
+- [ ] [CIV-11: Landmass & Terrain Layers](CIV-11-landmass-terrain.md) — Landmass, coastlines, mountains, volcanoes (~1000 lines)
+- [ ] [CIV-12: Climate & Biomes](CIV-12-climate-biomes.md) — Climate engine, biomes, features (~800 lines)
+- [ ] [CIV-13: Placement & Orchestrator](CIV-13-placement-orchestrator.md) — Placement and orchestrator integration (~800 lines)
+
+## Deliverables
+
+- [ ] Migrate `map_orchestrator.js` → `src/MapOrchestrator.ts`:
+  - [ ] Type the stage manifest system
+  - [ ] Type `generateMap()` and `requestMapData()` functions
+  - [ ] Wire up lazy bootstrap integration
+  - [ ] Consume adapter interface for engine calls
+- [ ] Migrate layer modules to `src/layers/`:
+  - [ ] `mountains.js` → `mountains.ts`
+  - [ ] `volcanoes.js` → `volcanoes.ts`
+  - [ ] `coastlines.js` → `coastlines.ts`
+  - [ ] `islands.js` → `islands.ts`
+  - [ ] `biomes.js` → `biomes.ts`
+  - [ ] `features.js` → `features.ts`
+  - [ ] `climate-engine.js` → `climate-engine.ts`
+  - [ ] `landmass_plate.js` → `landmass-plate.ts`
+  - [ ] `landmass_utils.js` → `landmass-utils.ts`
+  - [ ] `placement.js` → `placement.ts`
+- [ ] Migrate core utilities to `src/core/`:
+  - [ ] `types.js` → `types.ts`
+  - [ ] `adapters.js` → (use @civ7/adapter instead)
+  - [ ] `utils.js` → `utils.ts`
+  - [ ] `plot_tags.js` → `plot-tags.ts`
+- [ ] Migrate story system to `src/story/`:
+  - [ ] `tags.js` → `tags.ts`
+  - [ ] `tagging.js` → `tagging.ts`
+  - [ ] `corridors.js` → `corridors.ts`
+  - [ ] `overlays.js` → `overlays.ts`
+- [ ] Update mod entry point to use TypeScript core:
+  - [ ] `src/swooper-desert-mountains.ts` imports from `@swooper/mapgen-core`
+  - [ ] Call `bootstrap()` with preset config
+  - [ ] Wire `engine.on()` handlers through adapter
+- [ ] Ensure all exports are properly typed and documented
+
+## Acceptance Criteria
+
+- [ ] All layer modules compile without TypeScript errors
+- [ ] `pnpm -C packages/mapgen-core build` succeeds
+- [ ] `pnpm -C mods/mod-swooper-maps build` produces valid bundle
+- [ ] Bundle includes inlined core code with external `/base-standard/...` imports
+- [ ] No remaining `.js` files in `packages/mapgen-core/src/`
+- [ ] Type coverage for all public APIs
+
+## Testing / Verification
+
+```bash
+# Build core library
+pnpm -C packages/mapgen-core build
+
+# Type check
+pnpm -C packages/mapgen-core check
+
+# Build mod bundle
+pnpm -C mods/mod-swooper-maps build
+
+# Verify bundle structure
+grep "from '@swooper/mapgen-core'" mods/mod-swooper-maps/mod/maps/swooper-desert-mountains.js
+# Should NOT find — core should be inlined
+
+grep "from '/base-standard/" mods/mod-swooper-maps/mod/maps/swooper-desert-mountains.js
+# Should find — base-standard remains external
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: M-TS-05 (World logic), M-TS-06 (Bootstrap refactor)
+- **Blocks**: M-TS-08 (E2E validation)
+- **Largest task**: 10+ layer files, 4+ story files, orchestrator
+- **Strategy**: Migrate in dependency order — utilities first, then layers, then orchestrator
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Migration Order (Dependency-Based)
+
+1. **Core utilities** (no internal dependencies):
+   - `utils.ts`, `plot-tags.ts`
+
+2. **Types and context** (depends on utilities):
+   - `types.ts` (MapContext, FoundationContext)
+
+3. **Story system** (depends on types):
+   - `tags.ts`, `overlays.ts`, `tagging.ts`, `corridors.ts`
+
+4. **Layers** (depends on types, story, bootstrap):
+   - Start with simpler layers: `coastlines.ts`, `islands.ts`
+   - Then complex: `mountains.ts`, `volcanoes.ts`, `climate-engine.ts`
+   - Then integrations: `biomes.ts`, `features.ts`, `placement.ts`
+   - Landmass: `landmass-plate.ts`, `landmass-utils.ts`
+
+5. **Orchestrator** (depends on all above):
+   - `MapOrchestrator.ts`
+
+### File Inventory
+
+| Category | Files | Lines (approx) |
+|----------|-------|----------------|
+| Orchestrator | 1 | ~600 |
+| Layers | 10 | ~2500 |
+| Story | 4 | ~800 |
+| Core | 4 | ~400 |
+| Bootstrap | 4 | (already in M-TS-06) |
+| World | 3 | (already in M-TS-05) |
+
+### Layer Interface Pattern
+
+Each layer should follow:
+
+```typescript
+// src/layers/mountains.ts
+import type { MapContext, FoundationContext } from '../core/types';
+import type { EngineAdapter } from '@civ7/adapter';
+import { getTunables } from '../bootstrap/tunables';
+
+export interface MountainsConfig {
+  tectonicIntensity: number;
+  mountainThreshold: number;
+  hillThreshold: number;
+  // ...
+}
+
+export function applyMountains(
+  ctx: MapContext,
+  adapter: EngineAdapter,
+  config?: Partial<MountainsConfig>
+): void {
+  const { MOUNTAINS_CFG } = getTunables();
+  const cfg = { ...MOUNTAINS_CFG, ...config };
+
+  // Implementation...
+}
+```
+
+### Entry Point Integration
+
+```typescript
+// mods/mod-swooper-maps/src/swooper-desert-mountains.ts
+/// <reference types="@civ7/types" />
+
+import { bootstrap, MapOrchestrator } from '@swooper/mapgen-core';
+import { CivEngineAdapter } from '@civ7/adapter/civ7-adapter';
+
+// Configure the generator
+bootstrap({
+  preset: 'desert-mountains',
+  overrides: {
+    mountains: { tectonicIntensity: 0.77 }
+  }
+});
+
+// Wire engine events
+const adapter = new CivEngineAdapter();
+const orchestrator = new MapOrchestrator(adapter);
+
+engine.on('RequestMapInitData', () => orchestrator.requestMapData());
+engine.on('GenerateMap', () => orchestrator.generateMap());
+
+console.log('Swooper Desert Mountains (TypeScript Build) Loaded');
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-8-validate-end-to-end.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-8-validate-end-to-end.md
@@ -1,0 +1,182 @@
+---
+id: CIV-8
+title: "[M-TS-08] Validate End-to-End (Gate C Complete)"
+state: planned
+priority: 2
+estimate: 2
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [testing]
+parent: null
+children: []
+blocked_by: [CIV-7]
+blocked: []
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Complete Gate C validation by deploying the fully migrated TypeScript mod to the game and verifying feature parity with the original JavaScript version.
+
+## Deliverables
+
+- [ ] Run full verification checklist from migration plan
+- [ ] Deploy TypeScript mod to game
+- [ ] Generate maps with multiple presets:
+  - [ ] Swooper Desert Mountains
+  - [ ] Classic preset
+  - [ ] Temperate preset
+- [ ] Compare generated maps to baseline JavaScript version:
+  - [ ] Mountain distribution
+  - [ ] Coastline shapes
+  - [ ] Climate patterns
+  - [ ] Feature placement
+- [ ] Verify game console logs match expected output
+- [ ] Document any differences or regressions
+- [ ] Run adapter boundary grep check
+- [ ] Run memoization verification
+
+## Acceptance Criteria
+
+From the migration plan verification checklist:
+
+- [ ] Type Check: `packages/civ7-types` allows `import ... from '/base-standard/...'` without error
+- [ ] Type Coverage: All known `GameplayMap` and `GameInfo` APIs declared (inventory complete)
+- [ ] Core Build: `packages/mapgen-core` compiles to valid ESM
+- [ ] Mod Bundle: `mod/maps/swooper-desert-mountains.js` generated with inlined Core code
+- [ ] External Imports: Generated JS contains `import ... from "/base-standard/..."` at top
+- [ ] Deployment: `bun run deploy` successfully copies files to Civ 7 Mods folder
+- [ ] Game Load: Civ 7 loads mod without "Module Not Found" errors
+- [ ] Adapter Boundary: Core uses adapter interface; `/base-standard/...` imports only in adapter
+- [ ] Adapter Enforcement: `/base-standard/...` imports appear only in adapter package (lint check)
+- [ ] Memoization: `reset*()` strategy verified to refresh configs per run and per test
+
+## Testing / Verification
+
+```bash
+# Full build
+pnpm run build
+
+# Deploy to game
+cd mods/mod-swooper-maps && bun run deploy
+
+# Adapter boundary check
+rg "/base-standard/" packages/ --glob "!**/civ7-adapter/**" --glob "!**/*.d.ts"
+# Should return empty
+
+# Type coverage check (all known APIs declared)
+# Manual review of packages/civ7-types/index.d.ts against inventory
+
+# Test suite passes
+pnpm -C packages/mapgen-core test
+```
+
+**In-Game Verification:**
+1. Launch Civilization VII
+2. Enable Swooper Maps mod
+3. Create new game → Select Swooper Desert Mountains
+4. Verify map generates without errors
+5. Inspect map: mountains, coasts, climate, features present
+6. Check console for `"Swooper Desert Mountains (TypeScript Build) Loaded"`
+7. Compare against baseline JS version (if available)
+
+## Dependencies / Notes
+
+- **Blocked by**: M-TS-07 (Orchestrator & Layers migration complete)
+- **Final gate**: Marks completion of TypeScript migration milestone
+- **If regressions found**: Create follow-up issues, don't block milestone completion
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Verification Checklist (Detailed)
+
+**Build Verification:**
+```bash
+# 1. Type check all packages
+pnpm run check
+
+# 2. Build all packages
+pnpm run build
+
+# 3. Verify mapgen-core output
+ls packages/mapgen-core/dist/
+# Should contain: index.js, index.d.ts, bootstrap/, world/, layers/, etc.
+
+# 4. Verify mod bundle
+ls mods/mod-swooper-maps/mod/maps/swooper-desert-mountains.js
+# Should exist
+
+# 5. Check bundle structure
+head -50 mods/mod-swooper-maps/mod/maps/swooper-desert-mountains.js
+# Should show imports from /base-standard/... at top
+```
+
+**Test Verification:**
+```bash
+# Run all tests
+pnpm -C packages/mapgen-core test
+
+# Verify timing
+time pnpm -C packages/mapgen-core test
+# Should complete in <5 seconds
+```
+
+**Adapter Boundary Verification:**
+```bash
+# Check no /base-standard/ imports outside adapter
+rg "/base-standard/" packages/ \
+  --glob "!**/civ7-adapter/**" \
+  --glob "!**/*.d.ts" \
+  --glob "!**/node_modules/**"
+
+# Result should be empty
+```
+
+**Memoization Verification:**
+```typescript
+// In test file or manual check
+import { getTunables, resetTunables } from '@swooper/mapgen-core/bootstrap';
+
+// Test 1: Import doesn't crash
+// (Just importing should not throw)
+
+// Test 2: Reset clears cache
+const t1 = getTunables();
+resetTunables();
+const t2 = getTunables();
+console.assert(t1 !== t2, 'Reset should clear cache');
+```
+
+### Baseline Comparison Strategy
+
+If original JS version is available:
+1. Run JS version, save map screenshot
+2. Run TS version with same seed, save map screenshot
+3. Visual comparison for major differences
+4. Check console logs match
+
+If baseline not available:
+1. Verify map generates without crash
+2. Verify major features present (mountains, water, continents)
+3. Verify config overrides work
+4. Trust test coverage from M-TS-05, M-TS-06, M-TS-07
+
+### Known Acceptable Differences
+
+Some differences may be acceptable:
+- Logging format changes
+- Internal timing differences (not affecting output)
+- Type narrowing that changes dead code paths
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-9-bun-pnpm-bridge.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-9-bun-pnpm-bridge.md
@@ -1,0 +1,115 @@
+---
+id: CIV-9
+title: "[M-TS-09] Configure Bun/pnpm Bridge Scripts (Gate D Contingency)"
+state: planned
+priority: 3
+estimate: 2
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [architecture, technical-debt]
+parent: null
+children: []
+blocked_by: [CIV-3]
+blocked: []
+related_to: [CIV-5, CIV-6]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Create bridge scripts for Bun ↔ pnpm interop and document the fallback path if Bun introduces instability, ensuring the migration can proceed regardless of toolchain friction.
+
+## Deliverables
+
+- [ ] Create bridge scripts at repo root:
+  - [ ] `scripts/bun-test.sh` — wrapper for running Bun tests from pnpm context
+  - [ ] `scripts/bun-build.sh` — wrapper for running Bun builds
+- [ ] Add pnpm scripts that delegate to Bun:
+  - [ ] `"test:mapgen": "pnpm -C packages/mapgen-core exec bun test"`
+  - [ ] `"build:mapgen": "pnpm -C packages/mapgen-core exec bun run build"`
+- [ ] Document fallback procedure in milestone notes:
+  - [ ] Criteria for triggering fallback (3+ blocking issues with Bun)
+  - [ ] Steps to migrate from Bun to pnpm/vitest/tsup
+  - [ ] Expected effort for fallback (~1 day)
+- [ ] Create fallback `vitest.config.ts` template (not wired, just ready)
+- [ ] Verify bridge scripts work in CI-like environment (no global Bun required)
+
+## Acceptance Criteria
+
+- [ ] `pnpm run test:mapgen` successfully runs Bun tests from repo root
+- [ ] `pnpm run build:mapgen` successfully builds mapgen-core via Bun
+- [ ] Bridge scripts work without global Bun install (use `pnpm exec bun`)
+- [ ] Fallback procedure documented with clear trigger criteria
+- [ ] vitest.config.ts template present and validated (dry run works)
+
+## Testing / Verification
+
+```bash
+# Test bridge from root
+pnpm run test:mapgen
+
+# Verify no global Bun dependency
+which bun && echo "Global Bun found" || echo "No global Bun"
+pnpm -C packages/mapgen-core exec bun --version
+
+# Dry-run fallback vitest config
+pnpm -C packages/mapgen-core exec vitest --config vitest.fallback.config.ts --dry-run
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: M-TS-03 (MapGen Core must exist)
+- **Related to**: M-TS-05 (Voronoi tests), M-TS-06 (Bootstrap tests)
+- **Gate D Trigger Criteria**: Switch to fallback if:
+  1. Bun causes 3+ blocking issues during Gate B/C
+  2. CI fails due to Bun version incompatibilities
+  3. pnpm workspace resolution conflicts with Bun imports
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Bridge Script Example
+
+```bash
+#!/bin/bash
+# scripts/bun-test.sh
+set -e
+cd "$(dirname "$0")/../packages/mapgen-core"
+pnpm exec bun test "$@"
+```
+
+### Fallback vitest.config.ts Template
+
+```typescript
+// packages/mapgen-core/vitest.fallback.config.ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    setupFiles: ['./test/setup.ts'],
+    include: ['test/**/*.test.ts'],
+  },
+});
+```
+
+### Fallback Migration Steps
+
+1. Rename `bunfig.toml` → `bunfig.toml.bak`
+2. Rename `vitest.fallback.config.ts` → `vitest.config.ts`
+3. Update `package.json` scripts: `"test": "vitest run"`
+4. Update test imports: `bun:test` → `vitest`
+5. Run `pnpm install` to ensure vitest deps
+6. Verify: `pnpm -C packages/mapgen-core test`
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/milestones/M-TS-typescript-migration.md
+++ b/docs/projects/engine-refactor-v1/milestones/M-TS-typescript-migration.md
@@ -1,0 +1,171 @@
+# M-TS: TypeScript Migration & Package Architecture
+
+**Goal:** Transform swooper-maps from a monolithic JavaScript mod into a typed, testable TypeScript library architecture with clean package boundaries.
+
+**Status:** Planned
+
+**Owner:** Engineering
+
+## Summary
+
+We are transitioning the swooper-maps mod from a monolithic collection of raw JavaScript files into a structured, type-safe TypeScript library within the existing monorepo. This enables:
+
+- **Testability**: Run complex algorithms (Voronoi, tectonics, climate) via `bun test` in milliseconds, outside the game
+- **Type Safety**: Catch errors at compile time, improve IDE support
+- **Modularity**: Separate domain logic (`@swooper/mapgen-core`) from mod delivery (`mods/mod-swooper-maps`)
+- **Reusability**: Shared `@civ7/types` package for typing the Civ7 runtime environment
+
+## Target Architecture
+
+| Package | Path | Role |
+|---------|------|------|
+| `@civ7/types` | `packages/civ7-types` | TypeScript definitions for game globals and `/base-standard/...` modules |
+| `@civ7/adapter` | `packages/civ7-adapter` | Single entry point for `/base-standard/...` imports; tests mock this |
+| `@swooper/mapgen-core` | `packages/mapgen-core` | Pure TS domain library: Orchestrator, Tectonics, Climate. No side effects on import. |
+| Swooper Mod | `mods/mod-swooper-maps` | Thin shell: configure core, bundle via tsup, deploy to game |
+
+## Acceptance Criteria
+
+- [ ] `packages/civ7-types` compiles and allows `import ... from '/base-standard/...'` without TS errors
+- [ ] `packages/mapgen-core` builds as valid ESM with `bun test` passing
+- [ ] `mods/mod-swooper-maps/mod/maps/swooper-desert-mountains.js` generated with `/base-standard/...` imports preserved as external
+- [ ] Game loads the mod without "Module Not Found" errors
+- [ ] Voronoi/plate algorithms run in Bun tests <100ms
+- [ ] `/base-standard/...` imports appear only in adapter package (grep check)
+
+## Issues / Deliverables
+
+### Foundation (Gate A Prerequisites)
+
+- [ ] [CIV-1: Scaffold Type Foundation](../issues/CIV-1-scaffold-type-foundation.md) — Create `@civ7/types` package
+- [ ] [CIV-2: Create Centralized Adapter](../issues/CIV-2-create-adapter-package.md) — Create `@civ7/adapter` package
+- [ ] [CIV-3: Initialize MapGen Core](../issues/CIV-3-initialize-mapgen-core.md) — Create `@swooper/mapgen-core` package
+
+### Pipeline Validation (Gate A)
+
+- [ ] [CIV-4: Validate Build Pipeline](../issues/CIV-4-validate-build-pipeline.md) — Prove tsup produces valid artifact that game loads
+
+### Testability (Gate B)
+
+- [ ] [CIV-5: Migrate World/Voronoi Logic](../issues/CIV-5-migrate-voronoi-world-logic.md) — Port `world/*.js` to TypeScript with tests
+- [ ] [CIV-6: Refactor Bootstrap to Lazy Providers](../issues/CIV-6-refactor-bootstrap-lazy-providers.md) — Fix import-time crashes for testing
+
+### Full Migration (Gate C)
+
+- [ ] [CIV-7: Migrate Orchestrator & Layers](../issues/CIV-7-migrate-orchestrator-layers.md) — Port remaining logic to TypeScript (parent issue)
+  - [ ] [CIV-10: Core Utils & Story](../issues/CIV-10-core-utils-story.md)
+  - [ ] [CIV-11: Landmass & Terrain](../issues/CIV-11-landmass-terrain.md)
+  - [ ] [CIV-12: Climate & Biomes](../issues/CIV-12-climate-biomes.md)
+  - [ ] [CIV-13: Placement & Orchestrator](../issues/CIV-13-placement-orchestrator.md)
+- [ ] [CIV-8: Validate End-to-End](../issues/CIV-8-validate-end-to-end.md) — Feature parity with JS version
+
+### Toolchain (Gate D Contingency)
+
+- [ ] [CIV-9: Bun/pnpm Bridge Scripts](../issues/CIV-9-bun-pnpm-bridge.md) — Bridge scripts and fallback procedure
+
+## Sequencing & Parallelization Plan
+
+**Stacks Overview**
+
+- **Stack A (Infrastructure)**: Types → Adapter → MapGen Core scaffold (sequential)
+- **Stack B (Gate A Validation)**: Depends on Stack A; minimal entry point proves pipeline works
+- **Stack C (Logic Migration)**: Voronoi + Bootstrap refactor (can parallelize after Stack A)
+- **Stack D (Full Migration)**: Orchestrator + Layers (depends on C)
+
+```mermaid
+flowchart TD
+    subgraph A["Stack A: Infrastructure"]
+        CIV1["CIV-1<br/>Types"]
+        CIV2["CIV-2<br/>Adapter"]
+        CIV3["CIV-3<br/>MapGen Core"]
+        CIV1 --> CIV2 --> CIV3
+    end
+
+    subgraph B["Stack B: Gate A + Toolchain"]
+        CIV4["CIV-4<br/>Pipeline Validation"]
+        CIV9["CIV-9<br/>Bun/pnpm Bridge"]
+    end
+
+    subgraph C["Stack C: Gate B"]
+        CIV5["CIV-5<br/>Voronoi Migration"]
+        CIV6["CIV-6<br/>Bootstrap Refactor"]
+        CIV5 <-.-> CIV6
+    end
+
+    subgraph D["Stack D: Gate C"]
+        subgraph D1["CIV-7 Sub-issues"]
+            CIV10["CIV-10<br/>Core & Story"]
+            CIV11["CIV-11<br/>Landmass"]
+            CIV12["CIV-12<br/>Climate"]
+            CIV13["CIV-13<br/>Orchestrator"]
+            CIV10 --> CIV11
+            CIV10 --> CIV12
+            CIV11 --> CIV13
+            CIV12 --> CIV13
+        end
+        CIV8["CIV-8<br/>E2E Validation"]
+        CIV13 --> CIV8
+    end
+
+    CIV3 --> CIV4
+    CIV3 --> CIV9
+    CIV4 --> CIV5
+    CIV4 --> CIV6
+    CIV5 --> CIV10
+    CIV6 --> CIV10
+
+    style CIV1 fill:#e1f5fe
+    style CIV2 fill:#e1f5fe
+    style CIV3 fill:#e1f5fe
+    style CIV4 fill:#fff3e0
+    style CIV9 fill:#fff3e0
+    style CIV5 fill:#e8f5e9
+    style CIV6 fill:#e8f5e9
+    style CIV10 fill:#fce4ec
+    style CIV11 fill:#fce4ec
+    style CIV12 fill:#fce4ec
+    style CIV13 fill:#fce4ec
+    style CIV8 fill:#fce4ec
+```
+
+**Notes**
+- Gate A proves the pipeline before heavy migration work begins
+- Gate B proves testability before committing to full migration
+- If Bun + pnpm friction occurs (Gate D contingency), fall back to pnpm/vitest/tsup
+
+## Key Technical Decisions
+
+### Decision A: Direct Game Path Imports
+
+Use exact file paths the game expects (`/base-standard/maps/map-utilities.js`) rather than creating wrapper abstractions. `tsup` marks these as external, passing them through untouched.
+
+### Decision A.1: Centralized Adapter Pattern
+
+Single adapter module (`@civ7/adapter`) is the only place allowed to import `/base-standard/...`. Core/tests consume the adapter interface. Enables mocking for tests.
+
+### Decision B: Lazy Bootstrapping with Reset
+
+Refactor `tunables.js`, `resolved.js`, `runtime.js` to use memoized provider pattern:
+- No logic execution at import time
+- Export `getX()` functions that cache results
+- Export `resetX()` functions for test isolation
+
+### Decision C: Adapter Boundary for Civ7 Engine
+
+Core stays "pure TS"; adapter owns all engine/Civ7 imports. Tests mock the adapter. Bundling keeps `/base-standard/...` external and stable.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Type coverage incomplete | Start with concrete inventory (72+ GameplayMap methods, 15+ GameInfo tables already cataloged) |
+| Import-time crashes in tests | Gate B specifically addresses this via lazy providers |
+| Bun + pnpm coexistence issues | Gate D contingency: fall back to pnpm/vitest/tsup |
+| Bundle output differs from expected | Gate A validates with minimal artifact before heavy migration |
+
+## Notes
+
+- Reference plan: `docs/projects/engine-refactor-v1/resources/migrate-to-ts-plan.md`
+- Existing adapter in `mod/maps/core/adapters.js` can be promoted to shared package
+- Story system (`story/*.js`) migration not explicitly scoped but follows same patterns
+- `mod/maps/base-standard/` contains 28 bundled game files — plan uses game runtime paths


### PR DESCRIPTION
Create comprehensive planning documentation for swooper-maps TypeScript migration:

Milestone: M-TS TypeScript Migration & Package Architecture
- Target architecture with 3 new packages (@civ7/types, @civ7/adapter, @swooper/mapgen-core)
- Gated rollout plan (Gate A-D)
- Mermaid dependency graph

Issues created in Linear (CIV-1 through CIV-13):
- CIV-1: Scaffold Type Foundation (@civ7/types)
- CIV-2: Create Centralized Adapter (@civ7/adapter)
- CIV-3: Initialize MapGen Core Library
- CIV-4: Validate Build Pipeline (Gate A)
- CIV-5: Migrate World/Voronoi Logic (Gate B)
- CIV-6: Refactor Bootstrap to Lazy Providers
- CIV-7: Migrate Orchestrator & Layers (Gate C) - parent issue
  - CIV-10: Core Utils & Story System
  - CIV-11: Landmass & Terrain Layers
  - CIV-12: Climate & Biomes Layers
  - CIV-13: Placement & Orchestrator
- CIV-8: Validate End-to-End
- CIV-9: Bun/pnpm Bridge Scripts (Gate D Contingency)