### PR TITLE
feat(types): scaffold @civ7/types package

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,15 @@
       "WebFetch(domain:civilization.2k.com)",
       "Read(//Users/mateicanavra/Library/Application Support/Civilization VII/Logs/**)",
       "Bash(ls:*)",
-      "Bash(tree:*)"
+      "Bash(tree:*)",
+      "Bash(mkdir:*)",
+      "Bash(linear team:*)",
+      "Bash(linear project:*)",
+      "Bash(gt ls:*)",
+      "Bash(gt create:*)",
+      "Bash(rg:*)",
+      "Bash(pnpm:*)",
+      "Bash(grep:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,22 @@
       "Bash(gt create:*)",
       "Bash(rg:*)",
       "Bash(pnpm:*)",
-      "Bash(grep:*)"
+      "Bash(grep:*)",
+      "Bash(time pnpm -C packages/mapgen-core test:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(bun test:*)",
+      "Bash(gt ss:*)",
+      "Bash(git log:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr view:*)",
+      "mcp__linear-personal__get_issue",
+      "mcp__linear-personal__list_comments",
+      "Bash(git ls-tree:*)",
+      "Bash(gh pr diff:*)",
+      "mcp__linear-personal__list_issues",
+      "mcp__linear-personal__list_teams",
+      "mcp__linear-personal__create_issue"
     ],
     "deny": [],
     "ask": []

--- a/docs/projects/engine-refactor-v1/issues/CIV-14-typescript-migration-remediation.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-14-typescript-migration-remediation.md
@@ -1,0 +1,165 @@
+---
+id: CIV-14
+title: "[M-TS-P0] TypeScript Migration Remediation"
+state: planned
+priority: 1
+estimate: 13
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [bug, technical-debt, architecture]
+parent: null
+children: [CIV-15, CIV-16, CIV-17, CIV-18, CIV-19, CIV-20, CIV-21, CIV-22, CIV-23]
+blocked_by: []
+blocked: [CIV-8]
+related_to: [CIV-7]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Emergency remediation for the TypeScript migration that compiles successfully but produces no runtime output ("Null Map Script"). Three foundational breaks must be fixed before CIV-8 E2E validation can complete.
+
+> **Context:** The TypeScript migration (CIV-1 through CIV-13) succeeded at the compilation gate but failed at runtime orchestration. The system builds, deploys, and loads—but generates nothing. This issue tracks the structured fix organized into four Graphite stacks.
+
+## Problem Statement
+
+### The "Null Map Script" Phenomenon
+
+The migrated TypeScript mod:
+- Compiles without errors
+- Bundles correctly with external `/base-standard/` imports
+- Deploys to the game folder
+- Loads in Civ7 without module errors
+- **Produces no terrain output** — all 14 stages are skipped
+
+### Root Cause Chain
+
+1. **Config Air Gap** (`bootstrap/entry.ts:118` vs `tunables.ts:161`)
+   - `bootstrap()` accepts `stageConfig` → stores in `config.stageConfig`
+   - `buildTunablesSnapshot()` reads from `config.stageManifest` (not stageConfig)
+   - `stageManifest` defaults to empty `{}`
+   - `stageEnabled()` always returns `false`
+
+2. **Adapter Anti-Pattern** (`MapOrchestrator.ts:734`)
+   - Dynamic `require("./core/adapters.js")` — file doesn't exist in build
+   - Falls back to `createFallbackAdapter()` using globals
+   - The `@civ7/adapter` package is never instantiated
+
+3. **Story Void** (`story/tagging.ts` never created)
+   - `StoryTags` exist as types but nothing populates them
+   - Climate/biomes/features depend on margin/hotspot/rift tags
+   - All story-aware code paths are no-ops
+
+4. **FoundationContext Bypass** (layers import `WorldModel` directly)
+   - `ctx.foundation` (immutable snapshot) already exists and is populated
+   - Layers import `WorldModel` singleton instead of reading from `ctx.foundation`
+   - This regressed from the original JS refactor that removed "legacy worldModel shims"
+
+## Remediation Strategy
+
+Organized into 4 Graphite stacks with clear dependencies:
+
+| Stack | Phase | Goal | Exit Condition |
+|-------|-------|------|----------------|
+| **1** | P0-A.1 | Fix shape | Adapter injected, layers read `ctx.foundation`, lifecycle documented |
+| **2** | P0-A.2 | Enable behavior | `stageEnabled()` returns true, stages execute |
+| **3** | P0-B | Wire to engine | Biomes/features/placement call real Civ7 APIs |
+| **4** | P0-C | Validate | Tests pass, CIV-8 in-game verification complete |
+
+## Sub-Issues
+
+### Stack 1: Shape Fixes (P0-A.1)
+- [ ] [CIV-15: Fix Adapter Boundary & Orchestration Wiring](CIV-15-fix-adapter-boundary.md)
+- [ ] [CIV-16: Migrate Layers to FoundationContext Consumption](CIV-16-foundationcontext-consumption.md)
+
+### Stack 2: Enable Behavior (P0-A.2)
+- [ ] [CIV-17: Implement Config→Manifest Resolver](CIV-17-config-manifest-resolver.md)
+- [ ] [CIV-18: Fix Biomes & Climate Call-Sites](CIV-18-callsite-fixes.md)
+
+### Stack 3: Wire to Engine (P0-B)
+- [ ] [CIV-19: Biomes & Features Adapter Integration](CIV-19-biomes-features-adapter.md)
+- [ ] [CIV-20: Placement Adapter Integration](CIV-20-placement-adapter.md)
+- [ ] [CIV-21: Reactivate Minimal Story Tagging](CIV-21-story-tagging.md)
+- [ ] [CIV-22: Restore Map-Size Awareness](CIV-22-map-size-awareness.md)
+
+### Stack 4: Validation (P0-C)
+- [ ] [CIV-23: Integration & Behavior Tests](CIV-23-integration-tests.md)
+- Completes: [CIV-8: Validate End-to-End](CIV-8-validate-end-to-end.md)
+
+## Acceptance Criteria
+
+- [ ] Pipeline no longer "null script" — stages actually execute
+- [ ] Adapter boundary lint passes (no `/base-standard/` in mapgen-core outside adapter)
+- [ ] Layers read from `ctx.foundation`, not `WorldModel` singleton
+- [ ] `stageEnabled("foundation")` returns `true` when configured
+- [ ] Biomes, features, and placement call real Civ7 APIs via adapter
+- [ ] Integration tests prove stages execute with MockAdapter
+- [ ] CIV-8 in-game validation passes (map generates with visible terrain)
+
+## Dependencies / Notes
+
+- **Blocked by**: Nothing (this is the critical path)
+- **Blocks**: CIV-8 (E2E validation cannot complete until pipeline works)
+- **Related to**: CIV-7 (migration work that introduced these issues)
+
+### Why This Happened
+
+The TypeScript migration (CIV-1 through CIV-13) was treated as a "blind port" — converting syntax while preserving structure. This worked for compilation but failed to account for:
+
+1. **The original JS architecture was already broken** in subtle ways (globals fallback, config indirection)
+2. **The TS migration ported the broken patterns** faithfully, including vestigial code paths
+3. **The gate criteria (CIV-8) focused on build artifacts**, not runtime behavior
+4. **The FoundationContext migration from the original refactor was incomplete** — TS ported the singleton pattern that was supposed to be removed
+
+### Lessons for Future Gates
+
+- Gate criteria must include **behavioral verification**, not just compilation
+- "Builds successfully" ≠ "Works correctly"
+- Migration gates should include minimal smoke tests with MockAdapter
+- Follow-up work: Add adapter boundary lint to CI so violations fail builds
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Graphite Stack Dependencies
+
+```
+Stack 1 (Shape) ─────────────┐
+  CIV-15 Adapter Boundary    │
+  CIV-16 FoundationContext   │
+                             ▼
+Stack 2 (Behavior) ──────────┐
+  CIV-17 Config Resolver     │
+  CIV-18 Call-Site Fixes     │
+                             ▼
+Stack 3 (Engine) ────────────┐
+  CIV-19 Biomes/Features     │
+  CIV-20 Placement           │
+  CIV-21 Story Tagging       │
+  CIV-22 Map-Size            │
+                             ▼
+Stack 4 (Validation) ────────┘
+  CIV-23 Tests
+  CIV-8 E2E (completes)
+```
+
+Each stack depends on the previous. Stack N+1 cannot merge until Stack N is complete.
+
+### Reference Documents
+
+- **Analysis**: `docs/projects/engine-refactor-v1/reviews/M-TS-typescript-migration-review.md`
+- **Canvas**: `docs/projects/engine-refactor-v1/reviews/M-TS-typescript-migration-canvas.md`
+- **Remediation**: `docs/projects/engine-refactor-v1/reviews/M-TS-typescript-migration-remediation.md`
+- **Prioritization**: `docs/projects/engine-refactor-v1/reviews/M-TS-typescript-migration-prioritization.md`
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Problem Statement](#problem-statement)
+- [Remediation Strategy](#remediation-strategy)
+- [Sub-Issues](#sub-issues)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-15-fix-adapter-boundary.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-15-fix-adapter-boundary.md
@@ -1,0 +1,203 @@
+---
+id: CIV-15
+title: "[M-TS-P0] Fix Adapter Boundary & Orchestration Wiring"
+state: planned
+priority: 1
+estimate: 0
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [bug, architecture]
+parent: CIV-14
+children: []
+blocked_by: []
+blocked: [CIV-16, CIV-17]
+related_to: [CIV-2]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Replace `MapOrchestrator`'s broken dynamic adapter loading with explicit constructor injection, and add a lint check to prevent future `/base-standard/` boundary violations.
+
+## Problem
+
+`MapOrchestrator.ts:734` attempts:
+```typescript
+require("./core/adapters.js")  // File doesn't exist in build
+```
+
+This fails silently and falls back to `createFallbackAdapter()`, which bypasses the entire `@civ7/adapter` architecture to access `GameplayMap`/`TerrainBuilder` globals directly.
+
+**Result:** The carefully designed adapter package (CIV-2) is never used in production.
+
+## Deliverables
+
+- [ ] Replace dynamic `require()` with explicit adapter strategy:
+  - Prefer **constructor injection**: `new MapOrchestrator({ adapter })`
+  - Accept adapter factory: `new MapOrchestrator({ createAdapter: (w, h) => new Civ7Adapter(w, h) })`
+- [ ] Import `Civ7Adapter` from `@civ7/adapter/civ7` as the default production adapter
+- [ ] Remove `createFallbackAdapter()` and globals fallback code
+- [ ] Remove direct `/base-standard/` imports from `MapOrchestrator.ts`
+  - Move any necessary imports behind `@civ7/adapter`
+- [ ] **Add adapter-boundary lint check:**
+  - Create `pnpm lint:adapter-boundary` script
+  - Fail if `/base-standard/` appears in `packages/**` outside `packages/civ7-adapter/**`
+  - Initially allowlist known violations (`placement.ts`) so each branch leaves repo passing
+- [ ] Update mod entry point (`swooper-desert-mountains.ts`) to instantiate adapter explicitly
+
+## Acceptance Criteria
+
+- [ ] `MapOrchestrator` accepts adapter via constructor (no dynamic require)
+- [ ] `Civ7Adapter` is the default adapter in production
+- [ ] No `/base-standard/` imports in `MapOrchestrator.ts`
+- [ ] Adapter-boundary lint exists and passes (violations allowlisted)
+- [ ] Build passes, existing tests still pass
+- [ ] MockAdapter can be injected for testing
+
+## Testing / Verification
+
+```bash
+# Adapter boundary check
+pnpm lint:adapter-boundary
+# Should pass (with allowlisted violations)
+
+# Build verification
+pnpm -C packages/mapgen-core build
+
+# Test that MockAdapter can be injected
+pnpm -C packages/mapgen-core test --grep "MapOrchestrator"
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: Nothing (first in Stack 1)
+- **Blocks**: CIV-16 (FoundationContext), CIV-17 (Config resolver)
+- **Related to**: CIV-2 (original adapter package creation)
+
+### Files to Modify
+
+- `packages/mapgen-core/src/MapOrchestrator.ts` — main orchestrator
+- `mods/mod-swooper-maps/src/swooper-desert-mountains.ts` — entry point
+- `package.json` — add lint script
+- New: `scripts/lint-adapter-boundary.sh` or similar
+
+### Allowlist Strategy
+
+The lint check should initially allowlist:
+- `packages/mapgen-core/src/layers/placement.ts` (deferred to CIV-20)
+- Any test files using `/base-standard/` for integration testing
+
+Each subsequent PR should remove items from the allowlist as violations are fixed.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Current Code Pattern (Broken)
+
+```typescript
+// MapOrchestrator.ts:734 (approximate)
+let adapters;
+try {
+  adapters = require("./core/adapters.js");
+} catch {
+  adapters = { createFallbackAdapter };
+}
+
+// createFallbackAdapter accesses globals directly:
+function createFallbackAdapter() {
+  return {
+    setTerrainType: (x, y, t) => TerrainBuilder.setTerrainType(x, y, t),
+    // ... direct global access
+  };
+}
+```
+
+### Target Pattern
+
+```typescript
+// MapOrchestrator.ts
+import type { EngineAdapter } from "@civ7/adapter";
+import { Civ7Adapter } from "@civ7/adapter/civ7";
+
+export interface MapOrchestratorOptions {
+  adapter?: EngineAdapter;
+  createAdapter?: (width: number, height: number) => EngineAdapter;
+}
+
+export class MapOrchestrator {
+  private adapter: EngineAdapter;
+
+  constructor(options: MapOrchestratorOptions = {}) {
+    if (options.adapter) {
+      this.adapter = options.adapter;
+    } else if (options.createAdapter) {
+      // Defer creation until dimensions known
+      this._createAdapter = options.createAdapter;
+    } else {
+      // Default to Civ7Adapter
+      this._createAdapter = (w, h) => new Civ7Adapter(w, h);
+    }
+  }
+}
+```
+
+### Entry Point Update
+
+```typescript
+// swooper-desert-mountains.ts
+import { MapOrchestrator, bootstrap } from "@swooper/mapgen-core";
+import { Civ7Adapter } from "@civ7/adapter/civ7";
+
+bootstrap({ preset: "desert-mountains" });
+
+const orchestrator = new MapOrchestrator({
+  createAdapter: (w, h) => new Civ7Adapter(w, h)
+});
+
+engine.on("GenerateMap", () => orchestrator.generateMap());
+```
+
+### Lint Script
+
+```bash
+#!/bin/bash
+# scripts/lint-adapter-boundary.sh
+
+ALLOWLIST=(
+  "packages/mapgen-core/src/layers/placement.ts"
+)
+
+violations=$(rg "/base-standard/" packages/ \
+  --glob "!**/civ7-adapter/**" \
+  --glob "!**/*.d.ts" \
+  --glob "!**/node_modules/**" \
+  -l)
+
+for file in $violations; do
+  allowed=false
+  for allowed_file in "${ALLOWLIST[@]}"; do
+    if [[ "$file" == *"$allowed_file" ]]; then
+      allowed=true
+      break
+    fi
+  done
+  if [ "$allowed" = false ]; then
+    echo "ERROR: Adapter boundary violation in $file"
+    exit 1
+  fi
+done
+
+echo "Adapter boundary check passed"
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Problem](#problem)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-16-foundationcontext-consumption.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-16-foundationcontext-consumption.md
@@ -1,0 +1,238 @@
+---
+id: CIV-16
+title: "[M-TS-P0] Migrate Layers to FoundationContext Consumption"
+state: planned
+priority: 1
+estimate: 0
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [bug, architecture, technical-debt]
+parent: CIV-14
+children: []
+blocked_by: [CIV-15]
+blocked: [CIV-17]
+related_to: [CIV-7]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Migrate layers from importing the `WorldModel` singleton directly to reading from `ctx.foundation` — the immutable snapshot that was *supposed* to replace WorldModel access in the original refactor.
+
+## Problem
+
+**Key insight:** `ctx.foundation` (immutable snapshot) and `ctx.worldModel` (mutable reference) are **already populated** by `MapOrchestrator.initializeFoundation()`. The problem is that layers import the `WorldModel` singleton directly instead of reading from context.
+
+The original engine refactor plan (Phase A) stated: "legacy `worldModel` shims removed, `FoundationContext` emitted and asserted." The TS migration ported `WorldModel` but did not complete the migration to `ctx.foundation` consumption.
+
+### Current Layer Pattern (Broken)
+
+```typescript
+// layers/mountains.ts
+import { WorldModel, BOUNDARY_TYPE } from "../world/model.js";
+
+export function applyMountains(ctx: ExtendedMapContext) {
+  const plateId = WorldModel.plateId;  // Direct singleton access
+  // ...
+}
+```
+
+### Target Pattern
+
+```typescript
+// layers/mountains.ts
+import { BOUNDARY_TYPE } from "../world/constants.js";  // Exported separately
+
+export function applyMountains(ctx: ExtendedMapContext) {
+  const { plates } = ctx.foundation;  // Read from immutable context
+  const plateId = plates.id;
+  // ...
+}
+```
+
+## Deliverables
+
+- [ ] **Update layers to read from `ctx.foundation`:**
+  - [ ] `layers/landmass-plate.ts` — read `ctx.foundation.plates.*`
+  - [ ] `layers/coastlines.ts` — read `ctx.foundation.plates.*`
+  - [ ] `layers/mountains.ts` — read `ctx.foundation.plates.*`
+  - [ ] `layers/volcanoes.ts` — read `ctx.foundation.plates.*`
+  - [ ] `layers/landmass-utils.ts` — read `ctx.foundation.plates.*`
+  - [ ] `layers/climate-engine.ts` — read `ctx.foundation.dynamics.*`
+- [ ] **Export `BOUNDARY_TYPE` from shared location:**
+  - Create `world/constants.ts` or add to `core/types.ts`
+  - Remove need to import from `WorldModel` for constants
+- [ ] **Keep `WorldModel` singleton only for orchestrator:**
+  - `WorldModel.init()` and `WorldModel.reset()` called only by orchestrator
+  - Layers never call these methods directly
+- [ ] **Add `WorldModel.reset()` if missing:**
+  - Call in orchestrator entry sequence before `init()`
+- [ ] **Document authoritative generation session sequence:**
+  ```
+  1. resetConfig() / resetTunables() / WorldModel.reset()
+  2. bootstrap(...) (presets, overrides, stageConfig)
+  3. rebind() / getTunables()
+  4. WorldModel.init(...)
+  5. new MapOrchestrator(...).generateMap() → creates ctx.foundation
+  ```
+
+## Acceptance Criteria
+
+- [ ] No layer file contains `import { WorldModel } from`
+- [ ] Layers read from `ctx.foundation.plates.*` and `ctx.foundation.dynamics.*`
+- [ ] `BOUNDARY_TYPE` exported from shared location (not requiring WorldModel import)
+- [ ] `WorldModel.reset()` exists and is called in orchestrator entry
+- [ ] Build passes, existing tests still pass
+- [ ] Pipeline still "null script" (expected — stages not yet enabled in Stack 2)
+
+## Testing / Verification
+
+```bash
+# Check no WorldModel imports in layers
+rg "import.*WorldModel" packages/mapgen-core/src/layers/
+# Should return empty
+
+# Build verification
+pnpm -C packages/mapgen-core build
+
+# Test suite passes
+pnpm -C packages/mapgen-core test
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: CIV-15 (Adapter boundary must be fixed first)
+- **Blocks**: CIV-17 (Config resolver depends on clean context flow)
+- **Related to**: CIV-7 (layer migration introduced these patterns)
+
+### Files to Modify
+
+- `packages/mapgen-core/src/layers/landmass-plate.ts`
+- `packages/mapgen-core/src/layers/coastlines.ts`
+- `packages/mapgen-core/src/layers/mountains.ts`
+- `packages/mapgen-core/src/layers/volcanoes.ts`
+- `packages/mapgen-core/src/layers/landmass-utils.ts`
+- `packages/mapgen-core/src/layers/climate-engine.ts`
+- `packages/mapgen-core/src/world/model.ts` — add `reset()` if missing
+- New: `packages/mapgen-core/src/world/constants.ts` — extract `BOUNDARY_TYPE`
+- `packages/mapgen-core/src/MapOrchestrator.ts` — update lifecycle sequence
+
+### Why This Matters
+
+The `FoundationContext` was explicitly designed as:
+
+> "Immutable data product emitted by the foundation stage. Downstream stages rely on this instead of touching WorldModel directly."
+
+By having layers import `WorldModel` directly:
+1. **Testing is impossible** — can't inject mock plate data
+2. **State leaks** — WorldModel singleton carries state between runs
+3. **Architecture violated** — the immutable context pattern is bypassed
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Migration Checklist by File
+
+**landmass-plate.ts:**
+```typescript
+// Before
+import { WorldModel, BOUNDARY_TYPE } from "../world/model.js";
+const plateId = WorldModel.plateId[idx];
+const boundaryType = WorldModel.boundaryType[idx];
+
+// After
+import { BOUNDARY_TYPE } from "../world/constants.js";
+const { plates } = ctx.foundation;
+const plateId = plates.id[idx];
+const boundaryType = plates.boundaryType[idx];
+```
+
+**mountains.ts:**
+```typescript
+// Before
+import { WorldModel, BOUNDARY_TYPE } from "../world/model.js";
+const uplift = WorldModel.upliftPotential[idx];
+const stress = WorldModel.tectonicStress[idx];
+
+// After
+import { BOUNDARY_TYPE } from "../world/constants.js";
+const { plates } = ctx.foundation;
+const uplift = plates.upliftPotential[idx];
+const stress = plates.tectonicStress[idx];
+```
+
+**climate-engine.ts:**
+```typescript
+// Before
+import { WorldModel } from "../world/model.js";
+const windU = WorldModel.windU[idx];
+const windV = WorldModel.windV[idx];
+
+// After
+const { dynamics } = ctx.foundation;
+const windU = dynamics.windU[idx];
+const windV = dynamics.windV[idx];
+```
+
+### WorldModel.reset() Implementation
+
+```typescript
+// world/model.ts
+export const WorldModel = {
+  initialized: false,
+  // ... existing fields ...
+
+  reset(): void {
+    this.initialized = false;
+    this.plateId = null;
+    this.boundaryCloseness = null;
+    this.boundaryType = null;
+    this.tectonicStress = null;
+    this.upliftPotential = null;
+    this.riftPotential = null;
+    this.shieldStability = null;
+    this.plateMovementU = null;
+    this.plateMovementV = null;
+    this.plateRotation = null;
+    this.windU = null;
+    this.windV = null;
+    this.currentU = null;
+    this.currentV = null;
+    this.pressure = null;
+    this.plateSeed = null;
+    this.boundaryTree = null;
+  },
+
+  init(width: number, height: number, rng: () => number): void {
+    // ... existing initialization ...
+    this.initialized = true;
+  }
+};
+```
+
+### Constants Extraction
+
+```typescript
+// world/constants.ts
+export const BOUNDARY_TYPE = {
+  NONE: 0,
+  CONVERGENT: 1,
+  DIVERGENT: 2,
+  TRANSFORM: 3,
+  SUBDUCTION: 4,
+} as const;
+
+export type BoundaryType = typeof BOUNDARY_TYPE[keyof typeof BOUNDARY_TYPE];
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Problem](#problem)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-17-config-manifest-resolver.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-17-config-manifest-resolver.md
@@ -1,0 +1,223 @@
+---
+id: CIV-17
+title: "[M-TS-P0] Implement Config to Manifest Resolver"
+state: planned
+priority: 1
+estimate: 0
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [bug, architecture]
+parent: CIV-14
+children: []
+blocked_by: [CIV-15, CIV-16]
+blocked: [CIV-18, CIV-19]
+related_to: [CIV-6]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Bridge the "Config Air Gap" by implementing a resolver that translates `bootstrap()` input into the `StageManifest` structure that `stageEnabled()` reads — this is the primary reason all stages are currently skipped.
+
+## Problem
+
+### The Config Air Gap
+
+```
+bootstrap({ stageConfig: { foundation: true, landmassPlates: true } })
+    │
+    ▼
+config.stageConfig = { foundation: true, landmassPlates: true }  ← STORED HERE
+    │
+    ▼
+buildTunablesSnapshot() reads config.stageManifest  ← BUT READS HERE
+    │
+    ▼
+config.stageManifest = {}  ← ALWAYS EMPTY
+    │
+    ▼
+stageEnabled("foundation") → false  ← ALWAYS FALSE
+    │
+    ▼
+All 14 stages skipped  ← "NULL SCRIPT"
+```
+
+**Root cause:** `bootstrap/entry.ts:118` stores `stageConfig` but `tunables.ts:161` reads `stageManifest`. There is no translation logic connecting them.
+
+## Deliverables
+
+- [ ] **Implement minimal resolver:**
+  - Create `bootstrap/resolved.ts` (or integrate into existing bootstrap)
+  - Map `stageConfig` booleans into `StageManifest.stages` structure
+  - Use canonical stage order from `bootstrap/defaults/base.js`
+- [ ] **Ensure `tunables.STAGE_MANIFEST` is populated:**
+  - After `bootstrap()` completes, `STAGE_MANIFEST.stages` should contain enabled flags
+  - `stageEnabled()` should return the intended boolean values
+- [ ] **Reintroduce minimal `[StageManifest]` warnings:**
+  - Warn when overrides target missing or disabled stages
+  - Helps catch configuration errors early
+- [ ] **Add resolver unit test:**
+  - Given `stageConfig: { foundation: true, landmassPlates: true }`
+  - Assert `stageEnabled("foundation") === true`
+  - Assert `stageEnabled("landmassPlates") === true`
+  - Assert `stageEnabled("someDisabledStage") === false`
+
+## Acceptance Criteria
+
+- [ ] `stageEnabled("foundation")` returns `true` when `stageConfig.foundation = true`
+- [ ] `stageEnabled("landmassPlates")` returns `true` when `stageConfig.landmassPlates = true`
+- [ ] Resolver test confirms stageConfig→manifest mapping works
+- [ ] Build passes, tests pass
+- [ ] Pipeline still won't generate full terrain (depends on later stacks), but stages should now *attempt* to execute
+
+## Testing / Verification
+
+```typescript
+// Test: resolver maps config correctly
+import { bootstrap, stageEnabled, resetBootstrap } from "@swooper/mapgen-core";
+
+beforeEach(() => resetBootstrap());
+
+test("stageConfig enables stages via manifest", () => {
+  bootstrap({
+    stageConfig: {
+      foundation: true,
+      landmassPlates: true,
+      coastlines: true,
+    }
+  });
+
+  expect(stageEnabled("foundation")).toBe(true);
+  expect(stageEnabled("landmassPlates")).toBe(true);
+  expect(stageEnabled("coastlines")).toBe(true);
+  expect(stageEnabled("biomes")).toBe(false);  // Not enabled
+});
+```
+
+```bash
+# Build verification
+pnpm -C packages/mapgen-core build
+
+# Run resolver tests
+pnpm -C packages/mapgen-core test --grep "stageConfig"
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: CIV-15 (adapter), CIV-16 (context) — shape must be fixed first
+- **Blocks**: CIV-18 (call-site fixes), CIV-19 (biomes adapter)
+- **Related to**: CIV-6 (bootstrap refactor)
+
+### Design Decision: Typed Config vs Runtime Resolution
+
+**Option A: Patch (The Bridge)** — Keep two formats, translate at runtime
+- Pros: Least code change
+- Cons: Maintains technical debt of dual formats
+
+**Option B: Simplify (Interface-Driven)** [RECOMMENDED]
+- Define strict `MapConfiguration` interface
+- Entry point constructs fully-typed config including manifest
+- Drop hidden runtime resolution logic
+- Compile-time guarantee: if config is valid TS, pipeline runs
+
+This issue implements the minimal bridge (Option A) to unblock progress. A follow-up P1 issue can migrate to Option B for cleaner architecture.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Current Flow (Broken)
+
+```typescript
+// bootstrap/entry.ts
+export function bootstrap(options: BootstrapOptions) {
+  config.stageConfig = options.stageConfig;  // Line 118
+  // ... no translation to stageManifest
+}
+
+// tunables.ts
+function buildTunablesSnapshot() {
+  return {
+    STAGE_MANIFEST: config.stageManifest || {},  // Line 161 — always empty!
+  };
+}
+
+// usage
+function stageEnabled(stage: string): boolean {
+  const manifest = getTunables().STAGE_MANIFEST;
+  return manifest.stages?.[stage]?.enabled ?? false;  // Always false
+}
+```
+
+### Target Flow
+
+```typescript
+// bootstrap/resolved.ts
+import { STAGE_ORDER } from "./defaults/base.js";
+
+export function resolveStageManifest(stageConfig: Record<string, boolean>): StageManifest {
+  const stages: Record<string, { enabled: boolean; order: number }> = {};
+
+  STAGE_ORDER.forEach((stageName, index) => {
+    stages[stageName] = {
+      enabled: stageConfig[stageName] ?? false,
+      order: index,
+    };
+  });
+
+  return { stages };
+}
+
+// bootstrap/entry.ts
+export function bootstrap(options: BootstrapOptions) {
+  config.stageConfig = options.stageConfig;
+  config.stageManifest = resolveStageManifest(options.stageConfig || {});  // NEW
+}
+```
+
+### Stage Order Reference
+
+From `bootstrap/defaults/base.js`, the canonical stage order is:
+1. `foundation`
+2. `landmassPlates`
+3. `continents`
+4. `coastlines`
+5. `islands`
+6. `mountains`
+7. `volcanoes`
+8. `climate`
+9. `biomes`
+10. `features`
+11. `rivers`
+12. `placement`
+13. `resources`
+14. `discoveries`
+
+### Warning Implementation
+
+```typescript
+export function validateOverrides(
+  overrides: Record<string, unknown>,
+  manifest: StageManifest
+): void {
+  for (const key of Object.keys(overrides)) {
+    const stage = manifest.stages[key];
+    if (!stage) {
+      console.warn(`[StageManifest] Override targets unknown stage: "${key}"`);
+    } else if (!stage.enabled) {
+      console.warn(`[StageManifest] Override targets disabled stage: "${key}"`);
+    }
+  }
+}
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Problem](#problem)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-18-callsite-fixes.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-18-callsite-fixes.md
@@ -1,0 +1,188 @@
+---
+id: CIV-18
+title: "[M-TS-P0] Fix Biomes & Climate Call-Sites"
+state: planned
+priority: 1
+estimate: 0
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [bug]
+parent: CIV-14
+children: []
+blocked_by: [CIV-17]
+blocked: [CIV-19, CIV-20, CIV-21, CIV-22]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Fix two trivial call-site bugs that block existing layer logic from executing: (1) biomes stage missing `ctx` parameter, and (2) climate adapter stubs blocking neighborhood fallbacks.
+
+## Problem
+
+### Issue 1: Biomes Missing Context
+
+`MapOrchestrator.ts:594` calls:
+```typescript
+designateEnhancedBiomes(iWidth, iHeight)  // Missing ctx!
+```
+
+Should be:
+```typescript
+designateEnhancedBiomes(iWidth, iHeight, ctx)
+```
+
+Without `ctx`, the biomes layer cannot access the adapter and falls into its dummy path.
+
+### Issue 2: Climate Stubs Block Fallbacks
+
+`climate-engine.ts`'s `resolveAdapter()` returns an adapter where `isCoastalLand` and `isAdjacentToShallowWater` are **present but stubbed to always return `false`**.
+
+The climate code checks:
+```typescript
+if (adapter.isCoastalLand) {
+  // Use adapter method
+  return adapter.isCoastalLand(x, y);  // Always returns false!
+} else {
+  // Use local neighborhood fallback
+  return checkNeighborhood(x, y);  // Never reached
+}
+```
+
+**Result:** Coastal and shallow water gradients are effectively disabled.
+
+**Fix:** Leave methods `undefined` (not stubbed to false) so the local fallback executes.
+
+## Deliverables
+
+- [ ] **Biomes ctx fix (1 line):**
+  - `MapOrchestrator.ts:594`: Add `ctx` parameter to `designateEnhancedBiomes` call
+- [ ] **Climate adapter fix (~10 lines):**
+  - `climate-engine.ts`: Modify `resolveAdapter()`
+  - Remove `isCoastalLand` and `isAdjacentToShallowWater` stub implementations
+  - Leave them undefined so fallback code path executes
+- [ ] **Verify biomes receives context:**
+  - Add assertion or log in `designateEnhancedBiomes` confirming ctx.adapter is present
+- [ ] **Smoke test:**
+  - With MockAdapter, run climate stage and verify coastal modifiers apply
+
+## Acceptance Criteria
+
+- [ ] Biomes stage receives `ctx` and can access adapter
+- [ ] Climate coastal/shallow fallbacks execute (not blocked by stubs)
+- [ ] Build passes, tests pass
+- [ ] A minimal MockAdapter smoke test shows biomes and climate stages execute (basic assertions)
+
+## Testing / Verification
+
+```typescript
+// Test: biomes receives context
+test("biomes stage receives ctx with adapter", () => {
+  const ctx = createMockContext();
+  const adapter = ctx.adapter;
+
+  // Should not throw "adapter undefined"
+  expect(() => designateEnhancedBiomes(84, 54, ctx)).not.toThrow();
+
+  // Verify adapter was called
+  expect(adapter.getBiomeType).toHaveBeenCalled();
+});
+
+// Test: climate uses fallback when adapter method undefined
+test("climate uses neighborhood fallback for coastal check", () => {
+  const ctx = createMockContext();
+  // Ensure adapter.isCoastalLand is undefined
+  delete ctx.adapter.isCoastalLand;
+
+  // Run climate pass
+  applyClimate(ctx);
+
+  // Verify coastal cells got moisture bonus
+  const coastalIdx = findCoastalCell(ctx);
+  expect(ctx.fields.rainfall[coastalIdx]).toBeGreaterThan(baseRainfall);
+});
+```
+
+```bash
+# Build verification
+pnpm -C packages/mapgen-core build
+
+# Run call-site tests
+pnpm -C packages/mapgen-core test --grep "biomes.*ctx|climate.*fallback"
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: Config resolver (stages must be enabled to test execution)
+- **Blocks**: Biomes/features adapter integration
+- **Low risk**: These are trivial fixes with clear scope
+
+### Files to Modify
+
+- `packages/mapgen-core/src/MapOrchestrator.ts` — add ctx to designateEnhancedBiomes call
+- `packages/mapgen-core/src/layers/climate-engine.ts` — fix resolveAdapter stubs
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Biomes Fix
+
+```typescript
+// MapOrchestrator.ts (around line 594)
+// Before:
+designateEnhancedBiomes(iWidth, iHeight);
+
+// After:
+designateEnhancedBiomes(iWidth, iHeight, ctx);
+```
+
+### Climate Adapter Fix
+
+```typescript
+// climate-engine.ts - resolveAdapter()
+// Before:
+function resolveAdapter(adapter: EngineAdapter): ClimateAdapter {
+  return {
+    ...adapter,
+    isCoastalLand: adapter.isCoastalLand ?? (() => false),  // Stub blocks fallback
+    isAdjacentToShallowWater: adapter.isAdjacentToShallowWater ?? (() => false),
+  };
+}
+
+// After:
+function resolveAdapter(adapter: EngineAdapter): ClimateAdapter {
+  return {
+    ...adapter,
+    // Don't provide stubs - let calling code use its own fallback
+    // isCoastalLand: inherited from adapter (may be undefined)
+    // isAdjacentToShallowWater: inherited from adapter (may be undefined)
+  };
+}
+```
+
+### Fallback Pattern in Climate Code
+
+The climate code should check for method existence before calling:
+
+```typescript
+function getCoastalModifier(x: number, y: number, adapter: ClimateAdapter): number {
+  if (typeof adapter.isCoastalLand === "function") {
+    return adapter.isCoastalLand(x, y) ? COASTAL_MOISTURE_BONUS : 0;
+  }
+  // Local fallback using neighborhood check
+  return isAdjacentToWater(x, y, adapter) ? COASTAL_MOISTURE_BONUS : 0;
+}
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Problem](#problem)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-19-biomes-features-adapter.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-19-biomes-features-adapter.md
@@ -1,0 +1,237 @@
+---
+id: CIV-19
+title: "[M-TS-P0] Wire Biomes & Features Adapter Integration"
+state: planned
+priority: 2
+estimate: 0
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [bug, architecture]
+parent: CIV-14
+children: []
+blocked_by: [CIV-18]
+blocked: [CIV-23]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Replace local stubs in `biomes.ts` and `features.ts` with real adapter calls to Civ7's biome/feature generators, so TS logic becomes a thin layer on top of engine behavior rather than a parallel synthetic system.
+
+## Problem
+
+### Phantom Types & Stubs
+
+`layers/biomes.ts` and `layers/features.ts` define local interfaces (`BiomeAdapter`, `FeaturesAdapter`) that do not exist on the main `EngineAdapter`. To make this compile, the code uses local stubs:
+
+```typescript
+// biomes.ts
+const BiomeAdapter = {
+  getBiomeGlobal: () => -1,  // Stub returns invalid ID
+  setBiomeType: () => {},    // No-op
+  designateBiomes: () => {}, // No-op
+};
+```
+
+**Result:** Biomes and features are "generated" but produce nothing meaningful against the real engine.
+
+### Missing Engine Integration
+
+The TS biomes/features code should:
+1. Call Civ7's base-standard biome generator
+2. Read biome globals from GameInfo
+3. Apply TS-specific nudges on top (tundra restraint, tropical coasts, etc.)
+
+Currently, none of this happens.
+
+## Deliverables
+
+- [ ] **Extend adapter surface** (either `EngineAdapter` or extension interface):
+  - **Biomes:**
+    - `designateBiomes(width: number, height: number): void`
+    - `getBiomeGlobal(name: string): number`
+    - `setBiomeType(x: number, y: number, biomeId: number): void`
+    - `getBiomeType(x: number, y: number): number`
+  - **Features:**
+    - `addFeatures(width: number, height: number): void`
+    - `getFeatureTypeIndex(name: string): number`
+    - `setFeatureType(x: number, y: number, featureId: number): void`
+    - `getFeatureType(x: number, y: number): number`
+    - `NO_FEATURE` sentinel constant
+- [ ] **Update `Civ7Adapter`** in `@civ7/adapter`:
+  - Wrap Civ7's base-standard biome module
+  - Wrap GameInfo/FeatureTypes appropriately
+  - Expose biome globals lookup
+- [ ] **Replace local stubs:**
+  - `layers/biomes.ts`: Call adapter.designateBiomes, adapter.getBiomeGlobal
+  - `layers/features.ts`: Call adapter.addFeatures, adapter.getFeatureTypeIndex
+- [ ] **Update MockAdapter** with test implementations
+
+## Acceptance Criteria
+
+- [ ] `EngineAdapter` interface includes biomes/features methods
+- [ ] `Civ7Adapter` implements biomes/features by wrapping base-standard
+- [ ] `layers/biomes.ts` calls adapter methods, not local stubs
+- [ ] `layers/features.ts` calls adapter methods, not local stubs
+- [ ] MockAdapter provides testable biomes/features mocks
+- [ ] Build passes, tests pass
+
+## Testing / Verification
+
+```typescript
+// Test: biomes uses adapter
+test("biomes calls adapter.designateBiomes", () => {
+  const adapter = createMockAdapter();
+  const ctx = createMockContext({ adapter });
+
+  applyBiomes(ctx);
+
+  expect(adapter.designateBiomes).toHaveBeenCalledWith(ctx.dimensions.width, ctx.dimensions.height);
+});
+
+// Test: features uses adapter
+test("features calls adapter.addFeatures", () => {
+  const adapter = createMockAdapter();
+  const ctx = createMockContext({ adapter });
+
+  applyFeatures(ctx);
+
+  expect(adapter.addFeatures).toHaveBeenCalled();
+});
+```
+
+```bash
+# Build verification
+pnpm -C packages/mapgen-core build
+pnpm -C packages/civ7-adapter build
+
+# Run adapter tests
+pnpm -C packages/civ7-adapter test --grep "biomes|features"
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: Call-site fixes (stages must execute first)
+- **Blocks**: Integration tests
+- **Related to**: Placement adapter (similar pattern)
+
+### Files to Modify
+
+- `packages/civ7-adapter/src/types.ts` — extend EngineAdapter interface
+- `packages/civ7-adapter/src/civ7-adapter.ts` — implement biomes/features methods
+- `packages/civ7-adapter/src/mock-adapter.ts` — add mock implementations
+- `packages/mapgen-core/src/layers/biomes.ts` — use adapter instead of stubs
+- `packages/mapgen-core/src/layers/features.ts` — use adapter instead of stubs
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Adapter Interface Extensions
+
+```typescript
+// @civ7/adapter/types.ts
+export interface BiomesMethods {
+  designateBiomes(width: number, height: number): void;
+  getBiomeGlobal(name: string): number;
+  setBiomeType(x: number, y: number, biomeId: number): void;
+  getBiomeType(x: number, y: number): number;
+}
+
+export interface FeaturesMethods {
+  addFeatures(width: number, height: number): void;
+  getFeatureTypeIndex(name: string): number;
+  setFeatureType(x: number, y: number, featureId: number): void;
+  getFeatureType(x: number, y: number): number;
+  readonly NO_FEATURE: number;
+}
+
+export interface EngineAdapter extends CoreMethods, BiomesMethods, FeaturesMethods {
+  // Combined interface
+}
+```
+
+### Civ7Adapter Implementation
+
+```typescript
+// @civ7/adapter/civ7-adapter.ts
+import { designateBiomes as civ7DesignateBiomes } from "/base-standard/maps/biomes.js";
+import { addFeatures as civ7AddFeatures } from "/base-standard/maps/features.js";
+
+export class Civ7Adapter implements EngineAdapter {
+  // ... existing methods ...
+
+  designateBiomes(width: number, height: number): void {
+    civ7DesignateBiomes(width, height);
+  }
+
+  getBiomeGlobal(name: string): number {
+    // Access GameInfo biome globals
+    return (globalThis as any)[name] ?? -1;
+  }
+
+  setBiomeType(x: number, y: number, biomeId: number): void {
+    TerrainBuilder.setBiomeType(x, y, biomeId);
+  }
+
+  getBiomeType(x: number, y: number): number {
+    return GameplayMap.getBiomeType(x, y);
+  }
+
+  addFeatures(width: number, height: number): void {
+    civ7AddFeatures(width, height);
+  }
+
+  getFeatureTypeIndex(name: string): number {
+    const feature = GameInfo.Features.find((f: any) => f.FeatureType === name);
+    return feature?.Index ?? -1;
+  }
+
+  setFeatureType(x: number, y: number, featureId: number): void {
+    TerrainBuilder.setFeatureType(x, y, featureId);
+  }
+
+  getFeatureType(x: number, y: number): number {
+    return GameplayMap.getFeatureType(x, y);
+  }
+
+  get NO_FEATURE(): number {
+    return -1;  // Or GameInfo constant if available
+  }
+}
+```
+
+### Updated Biomes Layer
+
+```typescript
+// layers/biomes.ts
+export function applyBiomes(ctx: ExtendedMapContext): void {
+  const { adapter, dimensions } = ctx;
+  const { width, height } = dimensions;
+
+  // 1. Run base Civ7 biome designation
+  adapter.designateBiomes(width, height);
+
+  // 2. Apply TS-specific nudges
+  applyTundraRestraint(ctx);
+  applyTropicalCoastRules(ctx);
+  applyRiverValleyGrassland(ctx);
+
+  // 3. Story-aware adjustments (if story tags present)
+  if (ctx.overlays.has("margins")) {
+    applyCorridorNudges(ctx);
+  }
+}
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Problem](#problem)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-20-placement-adapter.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-20-placement-adapter.md
@@ -1,0 +1,205 @@
+---
+id: CIV-20
+title: "[M-TS-P0] Wire Placement Adapter Integration"
+state: planned
+priority: 2
+estimate: 0
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [bug, architecture]
+parent: CIV-14
+children: []
+blocked_by: [CIV-18]
+blocked: [CIV-23]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Move all `/base-standard/` imports from `layers/placement.ts` behind the adapter surface, completing the adapter boundary cleanup and enabling the placement layer to be tested with MockAdapter.
+
+## Problem
+
+`layers/placement.ts` contains heavy direct imports from `/base-standard/`:
+
+```typescript
+import { generateLakes } from "/base-standard/maps/placement.js";
+import { expandCoasts } from "/base-standard/maps/placement.js";
+import { chooseStartSectors } from "/base-standard/maps/placement.js";
+// ... more direct imports
+```
+
+This violates the "Single Adapter Boundary" rule established in CIV-2 and prevents:
+1. Testing placement logic with MockAdapter
+2. Running placement code outside the game environment
+3. Adapter boundary lint from passing
+
+## Deliverables
+
+- [ ] **Extend adapter with placement methods:**
+  - `generateLakes(): void`
+  - `expandCoasts(): void`
+  - `chooseStartSectors(): void`
+  - `placeResources(): void`
+  - `placeDiscoveries(): void`
+  - Any other placement helpers currently imported directly
+- [ ] **Implement in `Civ7Adapter`:**
+  - Wrap corresponding `/base-standard/maps/placement.js` functions
+- [ ] **Update `layers/placement.ts`:**
+  - Remove all `/base-standard/` imports
+  - Call placement methods via `ctx.adapter`
+- [ ] **Update adapter-boundary lint allowlist:**
+  - Remove `placement.ts` from allowlist
+  - Lint should now pass with no violations in mapgen-core
+- [ ] **Update MockAdapter:**
+  - Add placement method stubs/mocks for testing
+
+## Acceptance Criteria
+
+- [ ] No `/base-standard/` imports in `layers/placement.ts`
+- [ ] Placement methods available on `EngineAdapter` interface
+- [ ] `Civ7Adapter` implements placement by wrapping base-standard
+- [ ] Adapter-boundary lint passes with no allowlisted violations in mapgen-core
+- [ ] Build passes, tests pass
+
+## Testing / Verification
+
+```bash
+# Adapter boundary check (no violations)
+pnpm lint:adapter-boundary
+# Should pass with no allowlist entries for mapgen-core
+
+# Check no /base-standard/ in placement.ts
+rg "/base-standard/" packages/mapgen-core/src/layers/placement.ts
+# Should return empty
+
+# Build verification
+pnpm -C packages/mapgen-core build
+pnpm -C packages/civ7-adapter build
+
+# Test suite
+pnpm -C packages/mapgen-core test
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: Config resolver + call-site fixes (Stack 2)
+- **Blocks**: Integration tests
+- **Note**: This is the last step to complete the adapter boundary cleanup
+
+### Files to Modify
+
+- `packages/civ7-adapter/src/types.ts` — extend EngineAdapter
+- `packages/civ7-adapter/src/civ7-adapter.ts` — implement placement methods
+- `packages/civ7-adapter/src/mock-adapter.ts` — add mock implementations
+- `packages/mapgen-core/src/layers/placement.ts` — use adapter
+- `scripts/lint-adapter-boundary.sh` — remove placement.ts from allowlist
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Adapter Interface Extensions
+
+```typescript
+// @civ7/adapter/types.ts
+export interface PlacementMethods {
+  generateLakes(): void;
+  expandCoasts(): void;
+  generateFloodplains(): void;
+  chooseStartSectors(): void;
+  placeResources(): void;
+  placeDiscoveries(): void;
+  addSnow(): void;
+}
+
+export interface EngineAdapter extends
+  CoreMethods,
+  BiomesMethods,
+  FeaturesMethods,
+  PlacementMethods {
+  // Combined interface
+}
+```
+
+### Civ7Adapter Implementation
+
+```typescript
+// @civ7/adapter/civ7-adapter.ts
+import * as PlacementModule from "/base-standard/maps/placement.js";
+
+export class Civ7Adapter implements EngineAdapter {
+  // ... existing methods ...
+
+  generateLakes(): void {
+    PlacementModule.generateLakes();
+  }
+
+  expandCoasts(): void {
+    PlacementModule.expandCoasts();
+  }
+
+  generateFloodplains(): void {
+    PlacementModule.generateFloodplains();
+  }
+
+  chooseStartSectors(): void {
+    PlacementModule.chooseStartSectors();
+  }
+
+  placeResources(): void {
+    PlacementModule.placeResources();
+  }
+
+  placeDiscoveries(): void {
+    PlacementModule.placeDiscoveries();
+  }
+
+  addSnow(): void {
+    PlacementModule.addSnow();
+  }
+}
+```
+
+### Updated Placement Layer
+
+```typescript
+// layers/placement.ts
+// BEFORE:
+import { generateLakes } from "/base-standard/maps/placement.js";
+
+export function runPlacement(ctx: ExtendedMapContext) {
+  generateLakes();
+}
+
+// AFTER:
+export function runPlacement(ctx: ExtendedMapContext) {
+  ctx.adapter.generateLakes();
+}
+```
+
+### Current /base-standard/ Imports in Placement
+
+From grep analysis, `placement.ts` likely imports:
+- `generateLakes`
+- `expandCoasts`
+- `generateFloodplains`
+- `chooseStartSectors`
+- `placeResources`
+- `placeDiscoveries`
+- `addSnow`
+- Possibly others
+
+Each needs to be moved behind the adapter.
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Problem](#problem)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-21-story-tagging.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-21-story-tagging.md
@@ -1,0 +1,250 @@
+---
+id: CIV-21
+title: "[M-TS-P0] Reactivate Minimal Story Tagging"
+state: planned
+priority: 2
+estimate: 0
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [bug]
+parent: CIV-14
+children: []
+blocked_by: [CIV-18]
+blocked: [CIV-23]
+related_to: [CIV-10]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Port a minimal subset of story tagging from JS to populate `StoryTags` with continental margins, hotspots, and rifts — the foundational tags that climate, biomes, and features depend on.
+
+## Problem
+
+### The Story Void
+
+The TypeScript migration created `story/tags.ts` with type definitions, but `story/tagging.ts` (the actual tagging logic) was never ported. This means:
+
+- `StoryTags` data structures exist but are always empty
+- Climate code checks for margin tags → finds nothing → skips moisture adjustments
+- Biomes code checks for hotspot tags → finds nothing → skips volcanic rules
+- Features code checks for rift tags → finds nothing → skips geological placement
+
+**Result:** All story-aware code paths are no-ops, producing bland, uniform maps.
+
+### What We Need (Minimal Set)
+
+Not the full story system, just the foundation:
+1. **Continental margins** — active vs passive edges, subduction zones
+2. **Hotspots** — volcanic activity centers
+3. **Rifts** — divergent boundaries, potential lakes/seas
+
+These feed into climate moisture patterns, biome special cases, and feature placement.
+
+## Deliverables
+
+- [ ] **Port minimal `story/tagging.ts`:**
+  - `imaprintMargins(ctx)` — classify plate boundaries as active/passive
+  - `seedHotspots(ctx)` — place volcanic hotspot tags based on plate stress
+  - `seedRifts(ctx)` — place rift tags at divergent boundaries
+- [ ] **Wire into orchestrator:**
+  - Call tagging functions in `storySeed` or `story*` stages
+  - Ensure `StoryTags` is populated before climate/biomes/features run
+- [ ] **Verify downstream consumption:**
+  - Climate reads margin tags for moisture adjustments
+  - Biomes reads hotspot tags for volcanic rules
+  - Features reads rift tags for geological placement
+- [ ] **Add smoke tests:**
+  - After story stages, assert `StoryTags` contains non-empty margin/hotspot/rift data
+
+## Acceptance Criteria
+
+- [ ] `story/tagging.ts` exists with minimal porting
+- [ ] `StoryTags` populated after story stages execute
+- [ ] Margin tags present (active/passive classification)
+- [ ] Hotspot tags present (based on tectonic stress)
+- [ ] Rift tags present (at divergent boundaries)
+- [ ] Climate/biomes/features can read these tags
+- [ ] Build passes, tests pass
+
+## Testing / Verification
+
+```typescript
+// Test: story tagging populates StoryTags
+test("story stages populate margin tags", () => {
+  const ctx = createMockContext();
+  setupFoundationWithPlates(ctx);
+
+  runStoryStages(ctx);
+
+  expect(ctx.overlays.has("margins")).toBe(true);
+  const margins = ctx.overlays.get("margins");
+  expect(margins.active.length).toBeGreaterThan(0);
+});
+
+// Test: climate uses margin tags
+test("climate reads margin tags for moisture", () => {
+  const ctx = createMockContext();
+  populateStoryTags(ctx);  // Mock story data
+
+  applyClimate(ctx);
+
+  // Active margins should have moisture bonus
+  const activeMarginIdx = findActiveMarginCell(ctx);
+  expect(ctx.fields.rainfall[activeMarginIdx]).toBeGreaterThan(baseRainfall);
+});
+```
+
+```bash
+# Build verification
+pnpm -C packages/mapgen-core build
+
+# Run story tests
+pnpm -C packages/mapgen-core test --grep "story|margin|hotspot|rift"
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: Config resolver + call-site fixes (Stack 2)
+- **Blocks**: Integration tests (story enables meaningful downstream behavior)
+- **Related to**: CIV-10 (original story migration, incomplete)
+- **Scope**: Minimal port, not full story system (full system is P1)
+
+### What's NOT In Scope
+
+- Full corridor algorithms (sea lanes, mountain passes)
+- Paleo-geological history
+- Named story overlays for specific terrain features
+- Story-driven placement (cities, resources)
+
+These are deferred to P1 once the pipeline is stable.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Minimal Story Functions
+
+```typescript
+// story/tagging.ts
+
+import type { ExtendedMapContext, FoundationContext } from "../core/types.js";
+import { BOUNDARY_TYPE } from "../world/constants.js";
+
+export function imprintMargins(ctx: ExtendedMapContext): void {
+  const { foundation, dimensions } = ctx;
+  const { plates } = foundation;
+  const { width, height } = dimensions;
+
+  const activeMargins: number[] = [];
+  const passiveMargins: number[] = [];
+
+  for (let i = 0; i < width * height; i++) {
+    const boundaryType = plates.boundaryType[i];
+    const closeness = plates.boundaryCloseness[i];
+
+    // Only tag cells near plate boundaries
+    if (closeness < 10) continue;
+
+    if (boundaryType === BOUNDARY_TYPE.CONVERGENT ||
+        boundaryType === BOUNDARY_TYPE.SUBDUCTION) {
+      activeMargins.push(i);
+    } else if (boundaryType === BOUNDARY_TYPE.DIVERGENT ||
+               boundaryType === BOUNDARY_TYPE.TRANSFORM) {
+      passiveMargins.push(i);
+    }
+  }
+
+  ctx.overlays.set("margins", {
+    key: "margins",
+    kind: "continental-margins",
+    version: 1,
+    width,
+    height,
+    active: activeMargins,
+    passive: passiveMargins,
+    summary: {
+      activeCount: activeMargins.length,
+      passiveCount: passiveMargins.length,
+    },
+  });
+}
+
+export function seedHotspots(ctx: ExtendedMapContext): void {
+  const { foundation, dimensions, rng } = ctx;
+  const { plates } = foundation;
+  const { width, height } = dimensions;
+
+  const hotspots: number[] = [];
+  const threshold = 200;  // High tectonic stress threshold
+
+  for (let i = 0; i < width * height; i++) {
+    const stress = plates.tectonicStress[i];
+    if (stress > threshold) {
+      // Probability based on stress intensity
+      if (Math.random() < stress / 255) {
+        hotspots.push(i);
+      }
+    }
+  }
+
+  ctx.overlays.set("hotspots", {
+    key: "hotspots",
+    kind: "volcanic-hotspots",
+    version: 1,
+    width,
+    height,
+    active: hotspots,
+    summary: { count: hotspots.length },
+  });
+}
+
+export function seedRifts(ctx: ExtendedMapContext): void {
+  const { foundation, dimensions } = ctx;
+  const { plates } = foundation;
+  const { width, height } = dimensions;
+
+  const rifts: number[] = [];
+
+  for (let i = 0; i < width * height; i++) {
+    const riftPotential = plates.riftPotential[i];
+    if (riftPotential > 100) {
+      rifts.push(i);
+    }
+  }
+
+  ctx.overlays.set("rifts", {
+    key: "rifts",
+    kind: "tectonic-rifts",
+    version: 1,
+    width,
+    height,
+    active: rifts,
+    summary: { count: rifts.length },
+  });
+}
+```
+
+### Orchestrator Integration
+
+```typescript
+// MapOrchestrator.ts - in story stage
+if (stageEnabled("storySeed")) {
+  console.log("Starting: storySeed");
+  imprintMargins(ctx);
+  seedHotspots(ctx);
+  seedRifts(ctx);
+  console.log("Finished: storySeed");
+}
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Problem](#problem)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-22-map-size-awareness.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-22-map-size-awareness.md
@@ -1,0 +1,244 @@
+---
+id: CIV-22
+title: "[M-TS-P0] Restore Map-Size Awareness"
+state: planned
+priority: 2
+estimate: 0
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [bug]
+parent: CIV-14
+children: []
+blocked_by: [CIV-18]
+blocked: [CIV-23]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Stop hard-coding `84×54` map dimensions and restore the flow from `GameplayMap.getMapSize()` to `GameInfo.Maps.lookup()` so the system respects actual map size selection.
+
+## Problem
+
+`MapOrchestrator.requestMapData()` currently hard-codes dimensions:
+
+```typescript
+const iWidth = 84;   // Hard-coded!
+const iHeight = 54;  // Hard-coded!
+const minLatitude = -80;
+const maxLatitude = 80;
+```
+
+This ignores:
+- The player's map size selection in game setup
+- Map size defaults from GameInfo
+- Latitude bounds associated with different map sizes
+
+**Result:** All maps generate at the same fixed size regardless of game settings.
+
+## Deliverables
+
+- [ ] **Restore map size lookup flow:**
+  - `GameplayMap.getMapSize()` → get selected map size ID
+  - `GameInfo.Maps.lookup(sizeId)` → get map defaults
+  - Extract width, height, min/max latitude from defaults
+- [ ] **Add adapter methods if needed:**
+  - `adapter.getMapSize(): MapSizeId`
+  - `adapter.getMapDefaults(sizeId): MapDefaults`
+- [ ] **Update `requestMapData()`:**
+  - Read dimensions from game, not constants
+  - Pass latitude bounds from map defaults
+- [ ] **Fallback for testing:**
+  - MockAdapter should provide sensible test defaults
+  - Allow explicit dimension override in bootstrap for tests
+
+## Acceptance Criteria
+
+- [ ] `requestMapData()` reads dimensions from game settings
+- [ ] Different map size selections produce different dimension maps
+- [ ] Latitude bounds come from map defaults, not constants
+- [ ] MockAdapter provides default dimensions for testing
+- [ ] Build passes, tests pass
+
+## Testing / Verification
+
+```typescript
+// Test: dimensions come from game settings
+test("requestMapData uses game map size", () => {
+  const adapter = createMockAdapter({
+    mapSize: "MAPSIZE_STANDARD",
+    mapDefaults: { width: 84, height: 54, minLat: -80, maxLat: 80 }
+  });
+  const orchestrator = new MapOrchestrator({ adapter });
+
+  const data = orchestrator.requestMapData();
+
+  expect(data.width).toBe(84);
+  expect(data.height).toBe(54);
+});
+
+// Test: different sizes work
+test("requestMapData respects large map size", () => {
+  const adapter = createMockAdapter({
+    mapSize: "MAPSIZE_LARGE",
+    mapDefaults: { width: 104, height: 64, minLat: -85, maxLat: 85 }
+  });
+  const orchestrator = new MapOrchestrator({ adapter });
+
+  const data = orchestrator.requestMapData();
+
+  expect(data.width).toBe(104);
+  expect(data.height).toBe(64);
+});
+```
+
+```bash
+# Build verification
+pnpm -C packages/mapgen-core build
+
+# Run size tests
+pnpm -C packages/mapgen-core test --grep "mapSize|dimensions"
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: Config resolver + call-site fixes (Stack 2)
+- **Blocks**: Integration tests
+- **Scope**: Basic flow restoration, not full preset system
+
+### What's NOT In Scope
+
+- Full preset resurrection (classic, temperate, etc.)
+- Named preset lookups
+- Complex map type configurations
+
+These are deferred to P1. This issue just restores "dimensions come from game, not constants."
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Current Code (Hard-coded)
+
+```typescript
+// MapOrchestrator.ts - requestMapData()
+requestMapData(): MapInitData {
+  const iWidth = 84;   // FIXME: Should come from game
+  const iHeight = 54;  // FIXME: Should come from game
+  const minLatitude = -80;
+  const maxLatitude = 80;
+
+  return {
+    width: iWidth,
+    height: iHeight,
+    // ...
+  };
+}
+```
+
+### Target Code
+
+```typescript
+// MapOrchestrator.ts - requestMapData()
+requestMapData(): MapInitData {
+  // Get map size from game settings
+  const mapSizeId = this.adapter.getMapSize();
+  const defaults = this.adapter.getMapDefaults(mapSizeId);
+
+  const iWidth = defaults.width;
+  const iHeight = defaults.height;
+  const minLatitude = defaults.minLatitude ?? -80;
+  const maxLatitude = defaults.maxLatitude ?? 80;
+
+  return {
+    width: iWidth,
+    height: iHeight,
+    wrapX: true,
+    wrapY: false,
+    // ...
+  };
+}
+```
+
+### Adapter Interface
+
+```typescript
+// @civ7/adapter/types.ts
+export interface MapSizeMethods {
+  getMapSize(): string;  // e.g., "MAPSIZE_STANDARD"
+  getMapDefaults(sizeId: string): MapDefaults;
+}
+
+export interface MapDefaults {
+  width: number;
+  height: number;
+  minLatitude?: number;
+  maxLatitude?: number;
+  worldAge?: string;
+  temperature?: string;
+  rainfall?: string;
+}
+```
+
+### Civ7Adapter Implementation
+
+```typescript
+// @civ7/adapter/civ7-adapter.ts
+export class Civ7Adapter implements EngineAdapter {
+  getMapSize(): string {
+    return GameplayMap.getMapSize();
+  }
+
+  getMapDefaults(sizeId: string): MapDefaults {
+    const mapInfo = GameInfo.Maps.find((m: any) => m.MapSizeType === sizeId);
+    if (!mapInfo) {
+      // Fallback to standard
+      return { width: 84, height: 54, minLatitude: -80, maxLatitude: 80 };
+    }
+    return {
+      width: mapInfo.GridWidth,
+      height: mapInfo.GridHeight,
+      minLatitude: mapInfo.MinLatitude ?? -80,
+      maxLatitude: mapInfo.MaxLatitude ?? 80,
+    };
+  }
+}
+```
+
+### MockAdapter Implementation
+
+```typescript
+// @civ7/adapter/mock-adapter.ts
+export class MockAdapter implements EngineAdapter {
+  private mockMapSize: string = "MAPSIZE_STANDARD";
+  private mockDefaults: MapDefaults = {
+    width: 84, height: 54, minLatitude: -80, maxLatitude: 80
+  };
+
+  getMapSize(): string {
+    return this.mockMapSize;
+  }
+
+  getMapDefaults(sizeId: string): MapDefaults {
+    return this.mockDefaults;
+  }
+
+  // Test helper
+  setMockMapSize(size: string, defaults: MapDefaults): void {
+    this.mockMapSize = size;
+    this.mockDefaults = defaults;
+  }
+}
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Problem](#problem)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/issues/CIV-23-integration-tests.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-23-integration-tests.md
@@ -1,0 +1,299 @@
+---
+id: CIV-23
+title: "[M-TS-P0] Add Integration & Behavior Tests"
+state: planned
+priority: 2
+estimate: 0
+project: engine-refactor-v1
+milestone: M-TS-typescript-migration
+assignees: []
+labels: [testing]
+parent: CIV-14
+children: []
+blocked_by: [CIV-19, CIV-20, CIV-21, CIV-22]
+blocked: []
+related_to: [CIV-8]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Lock in guardrails with integration tests proving the pipeline actually works: orchestrator executes stages, WorldModel lifecycle is deterministic, and climate/biomes/features produce expected behavior.
+
+## Context
+
+After Stacks 1-3 complete the structural fixes and engine wiring, we need tests that would have caught the "null script" regression. These tests ensure:
+
+1. **Orchestrator actually runs stages** (not just returns without error)
+2. **WorldModel lifecycle is clean** (reset/init sequence is deterministic)
+3. **Layers produce expected outputs** (not just compile without errors)
+
+## Deliverables
+
+### 1. Orchestrator Integration Test
+
+- [ ] Create long-lived `MapOrchestrator + MockAdapter` integration test
+- [ ] Call `bootstrap({ stageConfig: { foundation: true, landmassPlates: true, ... } })`
+- [ ] Create `MapOrchestrator` with `MockAdapter`
+- [ ] Run `generateMap()`
+- [ ] Assert:
+  - Expected stages are enabled (via `stageEnabled()`)
+  - Stages actually execute (via call counts or output checks)
+  - At minimum: foundation, landmassPlates, coastlines, mountains, placement
+
+### 2. WorldModel Lifecycle Tests
+
+- [ ] `init()` with explicit width/height/RNG:
+  - Arrays allocated with correct size
+  - Plate fields populated (plateId, boundaryType, etc.)
+  - Dynamics fields populated (windU/V, currentU/V, pressure)
+- [ ] `reset()` clears state:
+  - Back-to-back `init()` calls produce deterministic results
+  - No state leakage between runs
+- [ ] `setConfigProvider` / `getConfig()` integration
+
+### 3. Targeted Behavior Tests
+
+- [ ] **Climate tests:**
+  - Latitude bands produce expected temperature gradient
+  - Orographic bonuses apply near mountains
+  - Coastal/shallow modifiers work (via fallback or adapter)
+- [ ] **Biomes tests:**
+  - Tundra restraint fires in polar regions
+  - Tropical coast rules apply in equatorial zones
+  - River-valley grassland works near rivers
+  - Corridor nudge works when StoryTags present
+- [ ] **Features tests:**
+  - Reef placement in shallow coastal water
+  - Volcanic forest/taiga near hotspots
+  - Density tweaks apply based on biome
+
+## Acceptance Criteria
+
+- [ ] Orchestrator integration test exists and passes
+- [ ] WorldModel lifecycle tests exist and pass
+- [ ] Climate behavior tests exist and pass
+- [ ] Biomes behavior tests exist and pass
+- [ ] Features behavior tests exist and pass
+- [ ] All tests run in `pnpm -C packages/mapgen-core test`
+- [ ] Tests would fail if stage manifest wiring regresses
+
+## Testing / Verification
+
+```bash
+# Run all tests
+pnpm -C packages/mapgen-core test
+
+# Run integration tests specifically
+pnpm -C packages/mapgen-core test --grep "integration|orchestrator"
+
+# Run lifecycle tests
+pnpm -C packages/mapgen-core test --grep "WorldModel|lifecycle"
+
+# Run behavior tests
+pnpm -C packages/mapgen-core test --grep "climate|biomes|features"
+
+# Verify timing (should be fast)
+time pnpm -C packages/mapgen-core test
+# Should complete in <10 seconds
+```
+
+## Dependencies / Notes
+
+- **Blocked by**: All of Stack 3 (engine wiring must be complete)
+- **Blocks**: Nothing directly (enables CIV-8 completion)
+- **Related to**: CIV-8 (these tests validate what E2E will verify in-game)
+
+### Test Philosophy
+
+These are **guardrail tests**, not comprehensive coverage:
+
+1. **Smoke-level assertions** — "stages execute and produce output"
+2. **Regression prevention** — "null script" scenario would fail these tests
+3. **MockAdapter based** — run in milliseconds, no game dependency
+
+Full behavioral correctness is validated in CIV-8's in-game verification.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Orchestrator Integration Test
+
+```typescript
+// __tests__/integration/orchestrator.test.ts
+import { describe, test, expect, beforeEach } from "bun:test";
+import { bootstrap, resetBootstrap, stageEnabled } from "../../src/bootstrap/index.js";
+import { MapOrchestrator } from "../../src/MapOrchestrator.js";
+import { MockAdapter } from "@civ7/adapter/mock";
+
+describe("MapOrchestrator Integration", () => {
+  beforeEach(() => {
+    resetBootstrap();
+  });
+
+  test("stages are enabled after bootstrap", () => {
+    bootstrap({
+      stageConfig: {
+        foundation: true,
+        landmassPlates: true,
+        coastlines: true,
+        mountains: true,
+      }
+    });
+
+    expect(stageEnabled("foundation")).toBe(true);
+    expect(stageEnabled("landmassPlates")).toBe(true);
+    expect(stageEnabled("coastlines")).toBe(true);
+    expect(stageEnabled("mountains")).toBe(true);
+    expect(stageEnabled("biomes")).toBe(false);  // Not enabled
+  });
+
+  test("generateMap executes enabled stages", () => {
+    bootstrap({
+      stageConfig: {
+        foundation: true,
+        landmassPlates: true,
+        coastlines: true,
+      }
+    });
+
+    const adapter = new MockAdapter();
+    const orchestrator = new MapOrchestrator({ adapter });
+
+    // Should not throw
+    orchestrator.generateMap();
+
+    // Verify adapter was called (stages executed)
+    expect(adapter.setTerrainType).toHaveBeenCalled();
+  });
+
+  test("context has foundation after generateMap", () => {
+    bootstrap({ stageConfig: { foundation: true } });
+
+    const adapter = new MockAdapter();
+    const orchestrator = new MapOrchestrator({ adapter });
+    const ctx = orchestrator.generateMap();
+
+    expect(ctx.foundation).toBeDefined();
+    expect(ctx.foundation.plates.id).toBeDefined();
+    expect(ctx.foundation.dynamics.windU).toBeDefined();
+  });
+});
+```
+
+### WorldModel Lifecycle Tests
+
+```typescript
+// __tests__/world/lifecycle.test.ts
+import { describe, test, expect, beforeEach } from "bun:test";
+import { WorldModel } from "../../src/world/model.js";
+
+describe("WorldModel Lifecycle", () => {
+  beforeEach(() => {
+    WorldModel.reset();
+  });
+
+  test("init allocates arrays correctly", () => {
+    const rng = () => Math.random();
+    WorldModel.init(84, 54, rng);
+
+    expect(WorldModel.initialized).toBe(true);
+    expect(WorldModel.plateId?.length).toBe(84 * 54);
+    expect(WorldModel.windU?.length).toBe(84 * 54);
+  });
+
+  test("reset clears state", () => {
+    const rng = () => Math.random();
+    WorldModel.init(84, 54, rng);
+    WorldModel.reset();
+
+    expect(WorldModel.initialized).toBe(false);
+    expect(WorldModel.plateId).toBeNull();
+  });
+
+  test("back-to-back init is deterministic", () => {
+    let seed = 12345;
+    const deterministicRng = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+
+    WorldModel.init(20, 20, deterministicRng);
+    const firstPlateId = [...WorldModel.plateId!];
+
+    seed = 12345;  // Reset seed
+    WorldModel.reset();
+    WorldModel.init(20, 20, deterministicRng);
+    const secondPlateId = [...WorldModel.plateId!];
+
+    expect(firstPlateId).toEqual(secondPlateId);
+  });
+});
+```
+
+### Climate Behavior Tests
+
+```typescript
+// __tests__/layers/climate.test.ts
+import { describe, test, expect } from "bun:test";
+import { applyClimate } from "../../src/layers/climate-engine.js";
+import { createMockContext } from "../helpers/mock-context.js";
+
+describe("Climate Behavior", () => {
+  test("latitude bands produce temperature gradient", () => {
+    const ctx = createMockContext({ width: 20, height: 20 });
+
+    applyClimate(ctx);
+
+    // Equator (y=10) should be warmer than poles (y=0, y=19)
+    const equatorTemp = ctx.fields.temperature![10 * 20 + 10];
+    const poleTemp = ctx.fields.temperature![0 * 20 + 10];
+
+    expect(equatorTemp).toBeGreaterThan(poleTemp);
+  });
+
+  test("coastal cells get moisture bonus", () => {
+    const ctx = createMockContext({ width: 20, height: 20 });
+    // Set up coastal scenario
+    setupCoastalCell(ctx, 5, 5);
+
+    applyClimate(ctx);
+
+    const coastalRainfall = ctx.fields.rainfall![5 * 20 + 5];
+    const inlandRainfall = ctx.fields.rainfall![10 * 20 + 10];
+
+    expect(coastalRainfall).toBeGreaterThan(inlandRainfall);
+  });
+});
+```
+
+### Test Helpers
+
+```typescript
+// __tests__/helpers/mock-context.ts
+import { createExtendedMapContext } from "../../src/core/types.js";
+import { MockAdapter } from "@civ7/adapter/mock";
+
+export function createMockContext(options: {
+  width?: number;
+  height?: number;
+} = {}): ExtendedMapContext {
+  const width = options.width ?? 84;
+  const height = options.height ?? 54;
+  const adapter = new MockAdapter();
+  const config = { stageConfig: {} };
+
+  return createExtendedMapContext({ width, height }, adapter, config);
+}
+```
+
+### Quick Navigation
+
+- [TL;DR](#tldr)
+- [Context](#context)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)

--- a/docs/projects/engine-refactor-v1/reviews/M-TS-typescript-migration-canvas.md
+++ b/docs/projects/engine-refactor-v1/reviews/M-TS-typescript-migration-canvas.md
@@ -1,0 +1,236 @@
+# M-TS: TypeScript Migration – Concern Canvas
+
+Reorganization of the findings from `M-TS-typescript-migration-review.md`, cross-checked against the current TypeScript mapgen (`packages/mapgen-core/**`) and the original JS archive under `docs/projects/engine-refactor-v1/resources/_archive/original-mod-swooper-maps-js/`.
+
+Legend (per item, implicit from section but called out where useful):
+- **D** = Downstream side-effect (symptom of an upstream choice)
+- **M** = Missing / incomplete implementation
+- **A** = Core architectural problem / code smell
+Status legend:
+- `[DECIDED]` – Direction already chosen in existing plans/docs; execution may still be pending.
+- `[TODO]` – Concrete fix or implementation required; overall approach is mostly known.
+- `[OPEN]` – Design choice to discuss/confirm; not yet committed.
+
+---
+
+## Downstream side-effect issues (D)
+
+These are primarily symptoms: they show up because stage enablement, adapters, or lifecycle are not wired correctly.
+
+- **Entire stage pipeline effectively disabled (D, root cause in M/A) [TODO]**  
+  - `bootstrap()` only writes `stageConfig` into `MapConfig`; `tunables.buildTunablesSnapshot()` only reads `config.stageManifest`.  
+  - `tunables.STAGE_MANIFEST` therefore defaults to `{ order: [], stages: {} }`, and `stageEnabled(stage)` always returns `false`.  
+  - `MapOrchestrator.generateMap()` gates every stage on `stageEnabled`, so the TS pipeline is *logically* present but *never executes* with the shipped `swooper-desert-mountains` config.
+
+- **Story-driven behavior never triggers (D, rooted in missing story stages) [TODO]**  
+  - `storySeed` stage in `MapOrchestrator` only calls `resetStoryTags()` and logs; there is no call into a ported `story/tagging` or `story/corridors` implementation.  
+  - `StoryTags` collections for margins, hotspots, rifts, corridors, etc. remain empty during a run.  
+  - Downstream layers (`coastlines`, `islands`, `climate-engine`, `biomes`, `features`) that are written to consume these tags run with no narrative signals.
+
+- **Climate coastal/shallow modifiers neutralized (D, rooted in adapter design) [TODO]**  
+  - In `layers/climate-engine.ts`, `resolveAdapter(ctx)` always supplies `isCoastalLand` and `isAdjacentToShallowWater` functions that just return `false`.  
+  - Baseline/swatches then *check for the presence* of these methods and, seeing them defined, never fall back to local neighborhood scans.  
+  - Result: coastal and shallow-water bonuses are effectively disabled; rainfall patterns lose the coastal gradients described in the original JS.
+
+- **Biomes layer runs in “no-op” mode against the engine (D, rooted in adapter + call-site) [TODO]**  
+  - `MapOrchestrator` calls `designateEnhancedBiomes(iWidth, iHeight)` without passing `ctx`, so `biomes.resolveAdapter` falls back to its dummy adapter.  
+  - Even when `ctx` is provided, `BiomeAdapter` stubs `designateBiomes` and `setBiomeType` to no-ops and synthesizes biome globals instead of using engine state.  
+  - Net effect: baseline biomes are *never* written back to the engine, and all climate/story-aware nudges operate on an isolated, synthetic view at best.
+
+- **Feature placement logic largely inert (D, rooted in adapter surface and defaults) [TODO]**  
+  - `FeaturesAdapter` in `layers/features.ts` stubs `addFeatures`, `getFeatureTypeIndex`, `getBiomeGlobal`, and `getNoFeatureConstant`; all return `() => {}` or `-1`.  
+  - `runPlacement` correctly calls base-standard resource/snow/start-position generators, but `addDiverseFeatures` never actually invokes base-standard feature generation or resolves feature/biome IDs.  
+  - Consequence: paradise reefs, volcanic forests/taiga, and density tweaks for rainforest/forest/taiga almost never fire, because feature indices and biome IDs are all `-1`.
+
+- **State leakage across runs (D, rooted in lifecycle design) [OPEN][TODO]**  
+  - `MapOrchestrator.generateMap()` calls `resetTunables()` but *not* `resetBootstrap()` or `WorldModel.reset()`.  
+  - `bootstrap/runtime` and `WorldModel` both hold process-wide state; without coordinated resets, back-to-back runs can share configuration and world tensors.  
+  - This undermines deterministic tests and can cause subtle differences between “first map this session” and subsequent maps.
+
+- **Config toggle changes not reliably applied (D) [TODO]**  
+  - `generateMap()` refreshes tunables but does not re-run a resolver that would re-derive presets, stage manifests, or derived toggles from the active runtime config.  
+  - Changing presets or overrides between runs (e.g., via `bootstrap()`) may not take effect until a manual `resetConfig()` in user code.
+
+- **CIV‑8 validation cannot detect regressions (D, blocked by upstream issues) [TODO]**  
+  - With stages disabled and core adapters stubbed, CIV‑8’s intended E2E maps would either not generate at all or produce near-vanilla results.  
+  - Because in-game validation steps were never actually executed, there is currently no empirical confirmation that the TS pipeline can produce a working map once stage gating is fixed.
+
+---
+
+## Missing or incomplete implementations (M)
+
+These items represent functionality that existed or was planned in the JS design but is absent, stubbed, or only partially ported in TS.
+
+### Bootstrap, presets, and stage manifest
+
+- **Missing resolver for presets + map-size defaults + stage manifest (M, with downstream D and architectural A) [TODO][OPEN]**  
+  - The original JS `bootstrap/resolved.js` composed `BASE_CONFIG` defaults, named presets, and runtime overrides; it also did `GameInfo.Maps.lookup(GameplayMap.getMapSize())` and normalized the `stageManifest`.  
+  - TS `bootstrap` only stores a shallow `MapConfig` (`presets`, `stageConfig`, `overrides`) and leaves `stageManifest` and map-size lookup unimplemented.  
+  - As a result, map-size-aware tuning, manifest-based dependency checks, and `[StageManifest]` / `[Foundation]` warnings are all missing.
+
+- **StageConfig → StageManifest mapping not implemented (M, causes D) [TODO]**  
+  - `BootstrapOptions.stageConfig` is accepted and stored, but no code turns those flags into `StageDescriptor` entries.  
+  - The canonical manifest order and dependency graph that existed in `defaults/base.js` is not reconstructed in TS.
+
+- **Entry map init still hard-coded (M) [TODO][OPEN]**  
+  - `MapOrchestrator.requestMapData()` always uses `84×54` with ±80° latitudes and never consults `GameInfo.Maps` or presets for dimension/latitude defaults.  
+  - The original JS orchestrator threaded map-size information from `GameInfo.Maps` into both bootstrapping and world initialization.
+
+### Story system and narrative overlays
+
+- **Story tagging and corridor generation not ported (M, causes D) [TODO]**  
+  - `story/tagging.js` and `story/corridors.js` logic (margin imprinting, rift tagging, corridor graph construction) do not have TS equivalents.  
+  - TS `story/tags.ts` and `story/overlays.ts` provide a solid registry and overlay API, but no TS stage populates them.  
+  - Orchestrator stages for `storySeed`, `storyHotspots`, `storyRifts`, `storyOrogeny`, `storyPaleo`, and `storyCorridors*` are effectively placeholders.
+
+### Adapter integration (biomes, features, placement, orchestrator)
+
+- **Adapter-backed biome generator not wired (M) [TODO]**  
+  - `BiomeAdapter` is designed to wrap an `EngineAdapter` plus biome-specific methods (biome globals, `designateBiomes`, `setBiomeType`).  
+  - No production adapter bridges this to Civ7’s `/base-standard/maps/feature-biome-generator.js` or to `GameplayMap`/`TerrainBuilder` biome APIs.  
+  - Without this adapter, the biome layer cannot honor vanilla constraints or reuse Civ7’s core biome assignments.
+
+- **Adapter-backed feature generator not wired (M) [TODO]**  
+  - Similarly, `FeaturesAdapter` expects feature indices, biome globals, and a “no feature” constant, but no adapter implementation populates these from Civ7 (`GameInfo.Features`, `FeatureTypes`, etc.).  
+  - `@civ7/adapter` does not expose higher-level biome/feature surfaces yet; `EngineAdapter` stops at terrain/elevation/rainfall.
+
+- **Production Civ7 adapter unused in orchestrator (M/A) [DECIDED][TODO]**  
+  - `MapOrchestrator.createLayerAdapter()` tries to `require("./core/adapters.js")`, which does not exist, then falls back to a globals-based adapter.  
+  - `Civ7Adapter` from `@civ7/adapter/civ7` is never instantiated for real runs; `MockAdapter` is only used in tests.  
+  - All the effort in CIV‑2 to isolate `/base-standard/...` into `@civ7/adapter` is not leveraged by the orchestrator.
+
+- **Placement layer bypasses adapter completely (M/A) [DECIDED][TODO]**  
+  - `layers/placement.ts` imports six `/base-standard/...` modules directly and also reaches out to `TerrainBuilder` and `FertilityBuilder` globals, rather than going through a placement-aware adapter surface.  
+  - This duplicates engine coupling that was supposed to be centralized and makes the placement layer hard to test outside the game.
+
+### World / Voronoi and config mapping
+
+- **Voronoi fidelity and adapter not finalized (M/A) [OPEN]**  
+  - `world/plates.ts` uses `DefaultVoronoiUtils`, which returns trivial cells with empty half-edges and constant areas; it never calls Civ7’s Voronoi or kd-tree utilities.  
+  - The design leaves room for a `VoronoiUtilsInterface` but does not ship a Civ7-backed implementation or make an explicit “independent vs adapter” decision.
+
+- **Mapping between bootstrap foundation config and world config not explicit (M/A) [OPEN][TODO]**  
+  - TS defines `FoundationPlatesConfig` / `FoundationDynamicsConfig` / `FoundationDirectionalityConfig` and also `PlateConfig` / `DirectionalityConfig` in `world/types.ts`.  
+  - There is no dedicated translator (e.g., `foundationPlatesToPlateConfig`), and `WorldModel.setConfigProvider` is never clearly wired from bootstrap.  
+  - This makes it ambiguous which config shape is canonical and where world config should be derived from.
+
+### Tests, tooling, and type surface
+
+- **WorldModel lifecycle tests missing (M) [TODO]**  
+  - CIV‑5 adds rich tests for `computePlatesVoronoi`, `calculateVoronoiCells`, and `PlateSeedManager`, but no focused tests for `WorldModel.init/reset/config provider`.  
+  - Behavior such as dimension inference, plateSeed snapshot publishing, and idempotent `init()` is only exercised indirectly.
+
+- **No integration tests for orchestrator + stages (M) [TODO]**  
+  - There is no test that runs `bootstrap({ stageConfig })` followed by `new MapOrchestrator().generateMap()` with a mock adapter to assert which stages executed.  
+  - This allowed the “all stages disabled” regression and the missing adapter wiring to land unnoticed.
+
+- **No tests for climate/biomes/features behavior (M) [TODO]**  
+  - CIV‑12 adds substantial TS logic but no unit tests for climate bands, swatches, refinement, biome nudges, or feature placement.  
+  - As a result, subtle changes (e.g., adapter stubs) are not caught by automated tests.
+
+- **Adapter-boundary enforcement script not implemented (M/A) [DECIDED][TODO]**  
+  - CIV‑2 calls for a simple check that `/base-standard/...` imports only appear under `packages/civ7-adapter/**`.  
+  - No such script exists; current grep reveals violations in `MapOrchestrator.ts` and `layers/placement.ts`.
+
+- **Type coverage gaps in `@civ7/types` (M, future-facing) [TODO]**  
+  - `Players` is under-typed compared to actual JS usage; several helpers (`getAlive*`, `isHuman`, etc.) are missing.  
+  - `GameInfoTable.lookup` returns `T | null` (correct but stricter than JS usage), and some other globals have narrow surfaces.  
+  - This is not a current runtime bug but will cause friction as more of the JS mod is migrated.
+
+---
+
+## Core architectural problems / code smells (A)
+
+These shape how hard it is to finish the migration cleanly and how much debt we carry into future refactors.
+
+### Adapter and engine boundary
+
+- **Adapter boundary violations in core (A, causing M/D elsewhere) [DECIDED][TODO]**  
+  - `MapOrchestrator.resolveOrchestratorAdapter()` dynamically `require`s `/base-standard/maps/...` modules and reaches directly into `GameplayMap`, `TerrainBuilder`, `AreaBuilder`, and `engine`.  
+  - `layers/placement.ts` statically imports multiple `/base-standard/...` modules.  
+  - This breaks the “single adapter owns all Civ7 imports” decision and makes `@swooper/mapgen-core` harder to test or reuse outside Civ7.
+
+- **Adapter surface mismatch vs. layer needs (A, leads to stubs and workarounds) [OPEN][TODO]**  
+  - `EngineAdapter` focuses on terrain/elevation/rainfall and a few RNG helpers; layers now want:  
+    - Biome reads/writes and globals (`getBiomeType`, `setBiomeType`, `getBiomeGlobals`).  
+    - Feature indices, “no feature” sentinel, and `addFeatures`.  
+    - Placement helpers (floodplains, fertility, natural wonders, resources, discoveries).  
+  - Without a layered or extended adapter strategy, layers either reach for globals or stub these methods, leading directly to the missing implementations described above.
+
+### Config ownership and world model coupling
+
+- **WorldModel treated as a global singleton (A) [OPEN][TODO]**  
+  - Layers (`landmass-plate`, `coastlines`, `mountains`, `volcanoes`, `landmass-utils`, some climate code) import `WorldModel` directly instead of flowing through `ctx.worldModel`/`FoundationContext`.  
+  - This tightens coupling to a single concrete world implementation and complicates testing alternative world snapshots or future multi-world scenarios.
+
+- **Unclear ownership of world config provider (A) [OPEN]**  
+  - `WorldModel` exposes `setConfigProvider` / `getConfig()`, while bootstrap manages `MapConfig` and foundation config via `runtime` + `tunables`.  
+  - It is not explicit whether bootstrap should push a provider into `WorldModel`, or whether `WorldModel` should own its own config and treat bootstrap as an overlay.  
+  - This ambiguity makes it easy for world config and bootstrap config to drift when presets/overrides change.
+
+- **Config shape duplication between bootstrap and world (A) [OPEN][TODO]**  
+  - Separate but similar types for plates/directionality in `bootstrap/types.ts` and `world/types.ts` create parallel configuration paths.  
+  - Without a single mapping boundary, future changes to plate or directionality parameters risk divergence between bootstrap and world logic.
+
+### Lifecycle, reset semantics, and manifest
+
+- **Lifecycle/reset responsibilities scattered (A, leading to D) [OPEN][TODO]**  
+  - Per-map lifecycle spans `bootstrap/runtime`, `bootstrap/tunables`, `WorldModel`, and `MapOrchestrator`.  
+  - There is no single “generation session” abstraction that defines the correct sequence of `reset → bootstrap → rebind → init world → run stages`.  
+  - This makes it unclear who is responsible for ensuring clean state between runs (mod entry vs. orchestrator vs. tests).
+
+- **Stage manifest design present but hollow (A) [OPEN][TODO]**  
+  - Types for `StageManifest` / `StageDescriptor` exist, and the JS version had a robust `normalizeStageManifest`/`deriveStageOverrideWarnings` pipeline.  
+  - TS `tunables` simply trusts any `config.stageManifest` it finds and never evaluates dependencies, derives `legacyToggles`, or emits `[StageManifest]` warnings.  
+  - As a result, the manifest is not actually used to protect layers from invalid dependency graphs or disabled prerequisites.
+
+### Terrain, constants, and cross-layer contracts
+
+- **Magic terrain IDs duplicated across layers (A) [TODO]**  
+  - Terrain constants (`OCEAN_TERRAIN`, `COAST_TERRAIN`, `FLAT_TERRAIN`, `HILL_TERRAIN`, `MOUNTAIN_TERRAIN`, etc.) are re-declared in multiple files (`landmass-plate`, `coastlines`, `islands`, `mountains`, `volcanoes`, `landmass-utils`).  
+  - Centralizing these in a shared `core/constants` module (or in `@civ7/types` if appropriate) would reduce drift and make refactors safer.
+
+- **Defensive adapter fallbacks can hide configuration errors (A) [OPEN][TODO]**  
+  - Patterns like “if ctx exists use buffers, else fall back to adapter, else do nothing” appear in several layers.  
+  - While pragmatic, they can make it hard to notice when a stage is running with an incomplete `ExtendedMapContext` or missing buffers.
+
+### Voronoi strategy and long-term alignment with Civ7
+
+- **Unsettled Voronoi strategy (A) [OPEN]**  
+  - TS world logic is self-contained and testable (good), but diverges in fidelity from the Civ7 Voronoi/kd-tree stack referenced in earlier design docs.  
+  - Without a clear decision, there is a risk of “partial parity” where plates behave differently than in the base game but are still assumed to be equivalent in documentation and tuning.
+
+### Tooling, tests, and acceptance criteria
+
+- **Narrow acceptance criteria for CIV‑7 and CIV‑8 (A) [OPEN][TODO]**  
+  - Gate C primarily checks that TypeScript compiles, builds, and replaces JS sources; it does not require functional correctness or in-game validation.  
+  - Combined with the lack of integration tests, this allowed the disabled stage pipeline and unused adapter to slip through Gate C and block Gate B/D style validation.
+
+---
+
+## How this frames port vs. refactor decisions
+
+Using the classifications above, the near-term strategy can be framed as:
+
+- **“Implement as-is first” (port now, refactor later)**  
+  - Map the old JS behavior into TS for blocking correctness gaps, even if the architecture is not ideal:  
+    - Implement a minimal but faithful resolver (`bootstrap/resolved` equivalent) that composes defaults, presets, overrides, and produces a normalized `stageManifest`.  
+    - Wire `stageConfig` → `stageManifest.stages` so `stageEnabled()` reflects intended stage choices.  
+    - Bridge biomes and features through a concrete adapter (or thin wrappers) that actually call Civ7’s base-standard generators and lookups.  
+    - Use `@civ7/adapter/civ7` in `MapOrchestrator.createLayerAdapter()` and keep globals-only fallbacks for test/dev only.  
+    - Port story tagging/corridor passes closely from JS so `StoryTags` and overlays exist again.
+
+- **“Refactor during migration” (simplify now where risk is low)**  
+  - Areas where the TS design can be improved *while* porting behavior without adding too much risk:  
+    - Introduce a clear adapter layering strategy (core `EngineAdapter` + optional biome/feature/placement extensions) and align layers on it.  
+    - Centralize terrain IDs and other cross-layer constants.  
+    - Replace direct `WorldModel` singleton imports with consumption via `ctx.worldModel`/`FoundationContext` where practical, so tests can swap world snapshots.  
+    - Clarify the world config mapping boundary by adding explicit translation helpers and documenting which config shape is canonical.
+
+- **“Refactor later, once parity is proven”**  
+  - Larger architectural moves that should wait until the TS pipeline is producing correct maps and has basic E2E coverage:  
+    - Deciding whether Voronoi should remain self-contained TS or be backed by Civ7’s utilities via an adapter.  
+    - Introducing a “generation session” abstraction that owns all lifecycle/reset semantics.  
+    - Tightening acceptance criteria for future gates to require both compile-time and runtime validation.
+
+The immediate next step after this canvas should be to pick a *small* set of P0 items—primarily stage manifest wiring, adapter usage, and story tagging reactivation—and treat them as “port behavior faithfully,” while keeping an eye on the adapter/interface and lifecycle simplifications that can ride along without derailing migration velocity.

--- a/docs/projects/engine-refactor-v1/reviews/M-TS-typescript-migration-prioritization.md
+++ b/docs/projects/engine-refactor-v1/reviews/M-TS-typescript-migration-prioritization.md
@@ -1,0 +1,288 @@
+# M-TS: TypeScript Migration – Remediation Priorities
+
+Status: Working plan for stabilizing the migrated MapGen pipeline and reducing future rework.
+
+This document turns the canvas + remediation analysis into a concrete "what to do first" plan, focusing on:
+
+- Structural seams that must be **refactored now** (so we stop reinforcing the wrong shape)
+- Behavior that should be **ported faithfully** once plumbing is sane
+- Larger refactors that can wait until we have TS parity and tests
+
+---
+
+## P0-A – Fix the plumbing (structural seams, minimal behavior change)
+
+These are structural refactors, not later cleanups. They affect every stage, every test, and every future change. The goal is to fix the **shape** of the system while keeping behavior no worse than today.
+
+> **Graphite Stacks:**
+> - **Stack 1 (P0-A.1):** Adapter boundary + WorldModel context + lifecycle — pure shape fixes; pipeline remains "null script" by design.
+> - **Stack 2 (P0-A.2):** Config→manifest + call-site fixes — enables behavior in a controlled way.
+
+---
+
+### P0-A.1 – Shape fixes (adapter, context, lifecycle)
+
+These changes define how data flows through the system. They do not yet enable stages.
+
+#### 1. Adapter boundary & orchestration wiring
+
+- Replace `MapOrchestrator`'s dynamic `require("./core/adapters.js")` + globals fallback with an explicit adapter strategy:
+  - Prefer **constructor injection**: `new MapOrchestrator({ createAdapter: (w, h) => new Civ7Adapter(w, h) })`.
+  - At minimum, import `Civ7Adapter` from `@civ7/adapter/civ7` and use it as the default.
+- Remove direct `/base-standard/...` imports from `mapgen-core` (especially `MapOrchestrator.ts`), moving them behind `@civ7/adapter`.
+  - **Note:** `layers/placement.ts` has heavier `/base-standard/` usage requiring adapter extensions; defer to P0-B.
+- Add an **adapter-boundary check**:
+  - A small script (e.g. `pnpm lint:adapter-boundary`) that fails if `/base-standard/` appears in `packages/**` outside `packages/civ7-adapter/**` (excluding config/tests).
+  - Initially allow-list known violations (placement, any remaining orchestrator imports) so each Graphite branch leaves the repo in a passing state.
+
+#### 2. FoundationContext consumption & lifecycle sequence
+
+> **Key insight:** `ctx.foundation` (immutable snapshot) and `ctx.worldModel` (mutable reference) are **already populated** by `MapOrchestrator.initializeFoundation()`. The problem is that layers import the `WorldModel` singleton directly instead of reading from context.
+>
+> Per the original engine refactor plan (Phase A): "legacy `worldModel` shims removed, `FoundationContext` emitted and asserted." The TS migration ported `WorldModel` but did not complete the migration to `ctx.foundation` consumption.
+
+- **Prefer `ctx.foundation` over `ctx.worldModel`:**
+  - `FoundationContext` is explicitly documented as "Immutable data product... Downstream stages rely on this instead of touching WorldModel directly."
+  - Layers should read from `ctx.foundation.plates.*` (plateId, boundaryCloseness, upliftPotential, etc.) and `ctx.foundation.dynamics.*` (windU/V, currentU/V, pressure).
+  - Do NOT add new reads from `ctx.worldModel` — that would perpetuate the mutable singleton pattern.
+- **Update layers to read from `ctx.foundation`:**
+  - `landmass-plate.ts`, `coastlines.ts`, `mountains.ts`, `volcanoes.ts`, `landmass-utils.ts`, and climate code currently import `WorldModel` directly.
+  - Change these to receive `ctx` and read from `ctx.foundation.plates.*` and `ctx.foundation.dynamics.*`.
+  - Export `BOUNDARY_TYPE` constant from a shared location (it's currently re-exported from `WorldModel`).
+- **Keep `WorldModel` singleton only for orchestrator:**
+  - `WorldModel.init()` and `WorldModel.reset()` are called by the orchestrator to populate the singleton.
+  - Layers never call these methods — they just read from the immutable `ctx.foundation` snapshot.
+- **Add `WorldModel.reset()` if missing** and call it in the orchestrator's entry sequence.
+- **Document the authoritative "generation session" sequence:**
+  1. `resetConfig()` / `resetTunables()` / `WorldModel.reset()`
+  2. `bootstrap(...)` (presets, overrides, stageConfig)
+  3. `rebind()` / `getTunables()`
+  4. `WorldModel.init(...)`
+  5. `new MapOrchestrator(...).generateMap()` → creates `ctx.foundation` from `WorldModel`
+- Make sure tests and the mod entry use the same ordering, to avoid hard-to-reproduce state leakage between runs.
+
+**P0-A.1 Exit Criteria:**
+- [ ] Adapter boundary lint exists and passes (violations explicitly allowlisted)
+- [ ] Layers read from `ctx.foundation.plates.*` / `ctx.foundation.dynamics.*`, not `WorldModel` singleton import
+- [ ] `BOUNDARY_TYPE` exported from shared location (not requiring `WorldModel` import)
+- [ ] `WorldModel.reset()` exists and is called in orchestrator entry
+- [ ] Build passes, existing tests still pass
+- [ ] Pipeline still "null script" (expected — stages not yet enabled)
+
+---
+
+### P0-A.2 – Enable behavior (config→manifest, call-site fixes)
+
+These changes turn the pipeline back on in a controlled way.
+
+#### 3. Config → manifest → stage enabling
+
+- Implement a minimal resolver so that:
+  - `bootstrap()` input (presets, overrides, `stageConfig`) yields a normalized snapshot.
+  - `stageConfig` is mapped into `StageManifest.stages` using the canonical order from `bootstrap/defaults/base.js`.
+  - `tunables.STAGE_MANIFEST` is non-empty and `stageEnabled()` returns the intended flags.
+- Decide where this resolver lives:
+  - Either as a new `bootstrap/resolved.ts` (TS version of the JS resolver), or
+  - By introducing a typed `MapConfiguration` that the mod entry builds up explicitly, including the manifest.
+- Reintroduce minimal `[StageManifest]` warnings when overrides target missing/disabled stages.
+
+#### 4. Trivial call-site fixes
+
+These are low-risk, high-leverage fixes that unblock existing design once stages are enabled.
+
+- **Biomes (1-line fix):**
+  - Change `designateEnhancedBiomes(iWidth, iHeight)` → `designateEnhancedBiomes(iWidth, iHeight, ctx)` in `MapOrchestrator.ts:594`.
+- **Climate (~20 lines):**
+  - Fix `climate-engine.ts`'s `resolveAdapter()` so that `isCoastalLand` / `isAdjacentToShallowWater` are **not** stubbed to always `false` when they aren't on `EngineAdapter`.
+  - Instead, leave them undefined so the local neighborhood fallback runs.
+
+**P0-A.2 Exit Criteria:**
+- [ ] `stageEnabled("foundation")` returns `true` when `stageConfig.foundation = true`
+- [ ] Resolver test confirms stageConfig→manifest mapping works
+- [ ] Biomes stage receives `ctx` and can access adapter
+- [ ] Climate coastal/shallow fallbacks execute (not blocked by stubs)
+- [ ] A minimal `MockAdapter` smoke test shows stages actually execute (to be superseded by the fuller orchestrator integration test in P0-C)
+- [ ] Build passes, tests pass
+
+---
+
+## P0-B – Wire existing TS layers to the real engine
+
+Once the structural seams above are addressed (or at least staged), we should hook existing TS code to real Civ7 behavior instead of stubs.
+
+> **Graphite Stack 3:** Biomes/features adapter + placement adapter + story tagging + map-size awareness.
+
+### 5. Biomes & features adapter integration
+
+- Extend the adapter surface (either `EngineAdapter` or a small extension interface) to provide:
+  - Biomes:
+    - `designateBiomes(width, height)`
+    - Biome globals (e.g. `getBiomeGlobal("tropical")`)
+    - `setBiomeType(x, y, biomeId)`
+  - Features:
+    - `addFeatures(width, height)`
+    - Feature type indices (e.g. `getFeatureTypeIndex("FEATURE_REEF")`)
+    - "No feature" sentinel
+- Update `Civ7Adapter` in `@civ7/adapter` to wrap Civ7's base-standard modules and `GameInfo`/`FeatureTypes` appropriately.
+- Replace local stubs in:
+  - `layers/biomes.ts` (`BiomeAdapter`)
+  - `layers/features.ts` (`FeaturesAdapter`)
+  so they call the adapter instead of returning synthetic IDs and no-ops.
+
+### 6. Placement adapter integration
+
+- Move `/base-standard/...` imports from `layers/placement.ts` behind the adapter surface.
+- Extend `EngineAdapter` or create a `PlacementAdapter` extension with methods for:
+  - `generateLakes()`, `expandCoasts()`, `chooseStartSectors()`, etc.
+- Update the adapter-boundary lint allowlist to remove placement violations once complete.
+
+### 7. Minimal story tagging reactivation
+
+- Port a **minimal** subset of `story/tagging` / `story/corridors` sufficient to:
+  - Imprint continental margins ("active/passive" edges).
+  - Seed basic hotspot and rift tags needed by climate/biomes/features.
+- Wire this into the `storySeed` / `story*` stages so `StoryTags` is non-empty when climate, biomes, and features run.
+
+### 8. Presets & map-size awareness (first pass)
+
+- Restore the basic flow:
+  - `GameplayMap.getMapSize()` → `GameInfo.Maps.lookup()` → map size / defaults.
+- Stop hard-coding `84×54` and ±80° latitudes in `MapOrchestrator.requestMapData()`.
+- It's fine in this pass to **not** resurrect every named preset; we just need dimensions and key defaults coming from the same place as the JS baseline.
+
+**P0-B Exit Criteria:**
+- [ ] Biomes/features stages call real Civ7 generators via adapter
+- [ ] Placement layer has no direct `/base-standard/` imports
+- [ ] Adapter-boundary lint passes with no allowlisted violations in mapgen-core
+- [ ] StoryTags contain margin/hotspot/rift data after story stages
+- [ ] Map dimensions come from GameInfo, not hardcoded constants
+- [ ] Civ7-backed run shows visible terrain features
+
+---
+
+## P0-C – Testing & CIV‑8 validation
+
+> **Graphite Stack 4:** Lock in guardrails once behavior is reasonably correct.
+
+### 9. Integration & lifecycle tests
+
+- Add a **long-lived MapOrchestrator + MockAdapter integration test** in `mapgen-core` that:
+  - Calls `bootstrap({ stageConfig: { foundation: true, landmassPlates: true, ... } })`.
+  - Creates a `MapOrchestrator` using `MockAdapter` from `@civ7/adapter/mock`.
+  - Runs `generateMap()` and asserts:
+    - The expected stages are enabled.
+    - A minimal set of stages actually execute (e.g., landmassPlates, coastlines, mountains, placement).
+- Add **WorldModel lifecycle tests**:
+  - `init()` with explicit width/height and RNG: arrays allocated/populated as expected.
+  - `reset()` clears state so back-to-back `init()` is deterministic.
+  - `setConfigProvider` / `getConfig()` integration sanity checks.
+
+### 10. Targeted behavior tests (small but meaningful)
+
+- Climate:
+  - Use `ExtendedMapContext` + `MockAdapter` to assert that latitude bands, orographic bonuses, and **coastal/shallow** modifiers actually behave (smoke-level grids).
+- Biomes:
+  - With a fake adapter that exposes biome reads/writes, assert that:
+    - Tundra restraint, tropical coasts, river-valley grassland rules fire.
+    - Corridor/rift-shoulder nudge works when `StoryTags` are present.
+- Features:
+  - With a fake adapter that returns real feature indices/biome globals, assert that:
+    - Reefs, volcanic forests/taiga, and density tweaks actually place features under expected conditions.
+
+### 11. CIV‑8 in-game validation
+
+- After P0 plumbing and wiring changes:
+  - Build the mod and load it in Civ7.
+  - Generate Swooper maps and verify:
+    - Stages log as running (`Starting: landmassPlates`, etc.).
+    - Landmasses, coasts, mountains, rainfall belts, biomes, and key features appear.
+  - Capture logs/screenshots and update `CIV‑8-validate-end-to-end.md` with a first "TS parity achieved" checkpoint.
+
+**P0-C Exit Criteria:**
+- [ ] Orchestrator integration test exists and passes
+- [ ] WorldModel lifecycle tests exist and pass
+- [ ] Climate/biomes/features have at least smoke-level behavior tests
+- [ ] CIV-8 in-game validation documented with evidence (logs/screenshots)
+- [ ] "TS parity achieved" checkpoint recorded
+
+---
+
+## P1 – Domain logic porting & later refactors
+
+These are important but can follow once the P0 plumbing is stable and CIV‑8 can be run meaningfully.
+
+### 12. Full story algorithms
+
+- Port remaining story algorithms (full hotspots, rifts, corridors, paleo) more or less as-is from JS, leaning on the now-correct tagging overlays and adapter wiring.
+- Once tests and E2E behavior are good, consider refactoring for clarity/performance.
+
+### 13. Voronoi strategy (world vs Civ7 fidelity)
+
+- Decide between:
+  - **Independent TS Voronoi**: treat `DefaultVoronoiUtils` as canonical, document divergence from Civ7 voronoi/kd-tree, and tune locally.
+  - **Adapter-backed Voronoi**: define `VoronoiUtilsInterface` and provide:
+    - A Civ7-backed production implementation via `/base-standard/voronoi-utils.js` (through the adapter).
+    - A TS implementation for tests and offline runs.
+- Update docs and tests to reflect the decision.
+
+### 14. Config ownership & world mapping
+
+- Introduce explicit mapping helpers:
+  - `foundationPlatesToPlateConfig`, `foundationDynamicsToWorldConfig`, etc.
+- Clarify where configuration ownership ultimately lives:
+  - Bootstrap (runtime config + presets) vs. world module (physics config) vs. foundation context.
+  - With access already routed through context (P0), this P1 work focuses on mapping and ownership semantics rather than basic wiring.
+
+### 15. Session abstraction & acceptance criteria
+
+- If needed, wrap the generation lifecycle in a small "session" helper that:
+  - Owns resets, bootstrap, WorldModel init, and orchestrator execution.
+- Tighten future acceptance criteria (for any new Gate) to require:
+  - Both compile-time checks and at least minimal behavioral validation (tests + an updated CIV‑8-style checklist).
+
+---
+
+## Open questions – WorldModel & FoundationContext (P1+ exploration)
+
+These are intentional follow-ups, not blockers for P0. Capture them so we can make conscious decisions once the TS pipeline is stable.
+
+- **Do any layers truly need procedural WorldModel methods?**
+  - Today, most consumers only need the plate/dynamics tensors, which are already available via `ctx.foundation.plates` / `ctx.foundation.dynamics`.
+  - If a layer genuinely needs procedural helpers (beyond the tensors), treat that as an explicit exception:
+    - Document it clearly.
+    - Consider routing it through a thin façade on top of `FoundationContext` rather than reaching into `WorldModel` directly.
+
+- **Should FoundationContext become the only exposed physics surface long-term?**
+  - P0 standardizes on `ctx.foundation` as the primary read surface while keeping `WorldModel` as the internal engine that produces it.
+  - In P1, we should decide whether:
+    - `WorldModel` remains an internal implementation detail, or
+    - We refactor world computation into a more obviously pure/functional pipeline that only ever exposes `FoundationContext`.
+  - Whichever direction we choose, align the "Config ownership & world mapping" work (P1/Item 14) and future docs so there is one clear, canonical physics contract for downstream stages.
+
+---
+
+## Summary: Graphite Stack Structure
+
+| Stack | Phase | Goal | Key Deliverables |
+|-------|-------|------|------------------|
+| **1** | P0-A.1 | Fix shape | Adapter injection, FoundationContext consumption, lifecycle sequence |
+| **2** | P0-A.2 | Enable behavior | Config→manifest resolver, biomes ctx fix, climate stub fix |
+| **3** | P0-B | Wire to engine | Biomes/features/placement adapters, story tagging, map-size |
+| **4** | P0-C | Validate | Integration tests, behavior tests, CIV-8 in-game |
+
+Each stack leaves the codebase in a stable, non-broken state. Stack 1 keeps the "null script" behavior intentionally. Stack 2 turns stages on. Stack 3 connects to real Civ7. Stack 4 proves it works.
+
+---
+
+## Rule of Thumb: Refactor-Now vs Port-Now
+
+Use this when deciding how to treat a specific item:
+
+- If it is a **boundary** everything will depend on (adapter wiring, config/manifest shape, lifecycle entry),
+  → **Refactor now**, before more code grows around it.
+
+- If it is **internal math/behavior** that can be treated as a black box once correct (story algorithms, climate nuances),
+  → **Port as-is**, test it, then refactor for clarity later if there is a clear benefit.
+
+- If it is a **trivial call-site bug or obvious misuse** of the new architecture (missing `ctx`, stub adapter blocking behavior),
+  → **Fix immediately**; it's cheap and prevents subtle debugging later.

--- a/docs/projects/engine-refactor-v1/reviews/M-TS-typescript-migration-remediation.md
+++ b/docs/projects/engine-refactor-v1/reviews/M-TS-typescript-migration-remediation.md
@@ -1,0 +1,309 @@
+MapGen TypeScript Migration Canvas
+
+Status: Critical Architectural Pivot
+
+Context: The "blind port" from JavaScript to TypeScript has succeeded in compilation but failed in runtime orchestration. The system compiles but produces no output ("Null Map Script") due to broken wiring between configuration, the adapter layer, and the engine.
+
+1. The Canvas of Concerns
+
+🔴 Core Architectural Problems & Code Smells
+
+Structural issues where the current design actively prevents the system from working. These require redesign, not just patching.
+
+Broken Dependency Injection (The Adapter Anti-Pattern)
+
+The Issue: The MapOrchestrator attempts a dynamic require("./core/adapters.js") which does not exist in the build. It immediately falls back to createFallbackAdapter, which bypasses the architecture to access global GameplayMap/TerrainBuilder directly.
+
+The Smell: The dedicated @civ7/adapter package—designed to be the single source of truth for engine interaction—is fully implemented but never instantiated in production.
+
+Violation: MapOrchestrator.ts and placement.ts contain direct imports of /base-standard/..., violating the "Single Adapter Boundary" rule.
+
+The Configuration "Air Gap"
+
+The Issue: bootstrap() accepts simple stageConfig booleans (e.g., { foundation: true }), but the tunables module reads from a complex stageManifest object. There is no logic connecting the two.
+
+The Result: stageEnabled('foundation') always returns false. The pipeline runs, checks every flag, sees them all as false, and exits successfully having done nothing.
+
+Phantom Types & Stubs
+
+The Issue: Layers like biomes.ts and features.ts define local interfaces (BiomeAdapter, FeaturesAdapter) that do not exist on the main EngineAdapter.
+
+The Smell: To make this compile, the code uses local stubs that return -1 or no-op. The architecture allows layers to define requirements that the system does not actually satisfy.
+
+Global Singleton Coupling
+
+The Issue: Layers (mountains.ts, volcanoes.ts) import the WorldModel singleton directly rather than receiving data through the FoundationContext.
+
+The Smell: This prevents testing layers in isolation (requires resetting global state) and defeats the purpose of the immutable context data flow.
+
+Lifecycle State Leakage
+
+The Issue: MapOrchestrator.generateMap() calls resetTunables() but never calls resetBootstrap() or WorldModel.reset().
+
+The Risk: Multi-run sessions (or tests) can carry over stale config or world state, producing inconsistent or non-deterministic outputs.
+
+🟡 Missing or Incomplete Implementations
+
+Functionality that existed in JS but is currently absent.
+
+Story Tagging Implementation: story/tagging.ts (Margins, Rifts, Hotspots logic) and story/corridors.ts (Sea Lanes) are missing. The data structures exist (StoryTags), but nothing populates them.
+
+Base-Standard Integration: The logic to actually ask the engine simple questions (e.g., "What is the ID for Rainforest?" or "Can I place a reef here?") is stubbed out.
+
+Preset Resolution: The classic and temperate presets were not ported. The system currently hardcodes map dimensions (84x54 in requestMapData) because it lacks the logic to look up map sizes from GameInfo.
+
+Missing Utilities: Specific JS utilities isAdjacentToLand and getFeatureTypeIndex (engine-aware version) were not ported, forcing layers to use inferior local fallbacks or stubs.
+
+🟠 Downstream Side-Effect Issues
+
+Symptoms caused by the issues above.
+
+Pipeline Silent Failure: The orchestrator reports success but generates nothing.
+
+Climate Fidelity Loss: Two compounding issues:
+- Missing Story Tags (Margins) means narrative-driven moisture adjustments never run.
+- In climate-engine.ts, resolveAdapter() returns an adapter where isCoastalLand / isAdjacentToShallowWater are *present* but stubbed to always return false. Because the baseline/swatches passes check “if adapter.hasMethod, use it”, the local neighborhood fallbacks never execute. Even with a correct world model and no story, coastal/shallow gradients are effectively disabled.
+
+Biomes & Features No-Op: In addition to the phantom adapter types, the orchestrator calls designateEnhancedBiomes(iWidth, iHeight) without passing ctx, forcing the biomes layer into its dummy adapter path. Features use an adapter that never calls base-standard addFeatures, never resolves getFeatureTypeIndex / biome globals correctly, and treats “no feature” as -1. Together, biomes and feature embellishments are effectively disabled against the real engine.
+
+Unverified Feature Parity: We cannot verify parity with the JS version because we are effectively running a null script (stages disabled, story empty, biomes/features blocked by adapter stubs).
+
+2. Strategic Pivot: Refactor vs. Port
+
+To stabilize the build, we must stop "porting" complexity and start "redesigning" the flow for TypeScript strictness.
+
+A. Simplify & Redesign (Immediate Priority)
+
+Fix the plumbing so water flows.
+
+Strict Adapter Injection:
+
+Action: Remove all "fallback to global" logic inside layers. Layers must accept an ExtendedMapContext. The Adapter must be the Civ7Adapter.
+
+Benefit: Deletes defensive code; enforces the architecture; fixes the boundary violation.
+
+Configuration Interface:
+
+Action: Drop the complex runtime resolver logic from JS. Define a strict MapConfiguration interface. The mod entry point (swooper-desert-mountains.ts) constructs this object typed.
+
+Benefit: Closes the "Air Gap." If the config is valid TS, the pipeline runs.
+
+WorldModel Context:
+
+Action: Add worldModel to ExtendedMapContext. Layers read from ctx.worldModel. Remove import { WorldModel } from all layer files.
+
+B. Port As-Is (Secondary Priority)
+
+Fill in the missing logic once the plumbing works.
+
+Story Algorithms: Port the math for hotspots and rifts directly from tagging.js.
+
+Engine Wrappers: Implement the missing methods in Civ7Adapter by wrapping the engine scripts (do not rewrite designateBiomes from scratch). This includes:
+- Biomes: delegate to Civ7’s biome generator (designateBiomes, biome globals, setBiomeType) and then layer TS nudges on top.
+- Features: wire addFeatures, feature indices, biome globals, and the “no feature” sentinel via GameInfo / FeatureTypes.
+- Late placement helpers: expose floodplains, fertility, resources, discoveries, and snow through the adapter rather than calling globals in layers.
+
+Stage Manifest & Warnings: Reintroduce a minimal resolver (similar to the JS normalizeStageManifest) that:
+- Builds a normalized manifest from defaults + presets + overrides.
+- Evaluates requires/ordering and derives legacy toggles.
+- Emits [StageManifest] warnings when overrides target missing or disabled stages.
+
+Presets & Map Size: Restore the flow GameplayMap.getMapSize() → GameInfo.Maps.lookup() → map defaults. Even if we do not port every named preset, the orchestrator should not hard-code 84x54; dimensions and latitudes should come from the same place the JS version used.
+
+Adapter-Bound Biomes/Features: Replace local stubs in biomes.ts / features.ts with calls into the adapter surface described above, so TS logic becomes a thin, testable layer on top of real engine behavior rather than a parallel, synthetic system.
+
+3. Immediate Action Plan
+
+Fix the Adapter: Modify MapOrchestrator to import and instantiate @civ7/adapter directly. Remove the dynamic require.
+
+Fix the Config: Update bootstrap to either:
+- Map simple stageConfig inputs into the stageManifest that tunables expects, or
+- Accept a fully-typed MapConfiguration (including manifest) and drop hidden runtime “resolution” logic.
+
+Verify Execution: Run the mod. It should now actually attempt to generate terrain (even if that terrain is ugly because of missing Story Tags).
+
+4. Alternative Solutions Analysis
+
+For each core architectural problem, we have multiple paths forward. We must choose the one that reduces complexity while ensuring stability.
+
+Problem: The Configuration "Air Gap" (Stage Config vs. Manifest)
+
+Why does the pipeline run but do nothing? Because A doesn't talk to B.
+
+Option A: Patch (The Bridge)
+
+Approach: Update bootstrap() or buildTunablesSnapshot() to manually translate the simple stageConfig object (booleans) into the complex StageManifest structure expected by the system.
+
+Pros: Least code change; keeps existing structure.
+
+Cons: Keeps the complexity of two different config formats (input vs. internal); essentially maintaining technical debt.
+
+Option B: Simplify (Interface-Driven Config) [RECOMMENDED]
+
+Approach: Define a strict TypeScript interface MapConfiguration. The mod entry point constructs this object fully typed (including the manifest). Drop the runtime "resolution" logic entirely.
+
+Pros: Compiles = Works. Removes the "magic" resolution step. Leverages TS type checking. Directly supports the future "Pipeline Manifest" architecture (data-driven stages).
+
+Cons: Entry point file becomes slightly more verbose.
+
+Option C: Remove (Delete the Manifest)
+
+Approach: Delete the concept of a "Stage Manifest" entirely. In the orchestrator, just check if (config.stages.foundation).
+
+Pros: Drastically reduces complexity. We don't need a dependency graph for a linear script.
+
+Cons: Loses future flexibility if we ever want dynamic stage reordering (YAGNI?). Moves backward toward procedural scripts, conflicting with the "Modular Map Pipeline" vision.
+
+Problem: Broken Dependency Injection (Adapter Anti-Pattern)
+
+Why is the Adapter package unused? Because the Orchestrator tries to dynamic-load it.
+
+Option A: Patch (Dynamic Shim)
+
+Approach: Fix the build config to ensure the adapter file exists where the dynamic require looks for it.
+
+Pros: Preserves the dynamic loading pattern (if that was important).
+
+Cons: Fragile; fights against the bundler (tsup); obscures dependencies.
+
+Option B: Simplify (Constructor Injection)
+
+Approach: Instantiate Civ7Adapter in the mod entry point (swooper-desert-mountains.ts) and pass it into new MapOrchestrator(adapter).
+
+Pros: explicit ownership; bundler works automatically; zero magic. Tests can pass new MockAdapter().
+
+Cons: API change for MapOrchestrator.
+
+Option C: Remove (Static Import)
+
+Approach: Just import { Civ7Adapter } inside MapOrchestrator.ts. Remove the configuration option to inject it.
+
+Pros: Easiest to implement immediately.
+
+Cons: Makes testing MapOrchestrator harder (can't easily swap mock); tightly couples core to Civ7 implementation.
+
+Problem: Phantom Types & Stubs (Biomes/Features)
+
+Why do we have code that does nothing? Because the interface doesn't match reality.
+
+Option A: Patch (Direct Globals)
+
+Approach: Fill in the stub functions in biomes.ts / features.ts by directly calling GameplayMap and TerrainBuilder globals.
+
+Pros: Fastest "fix" to get behavior working.
+
+Cons: Violates the "Adapter Boundary" architecture; makes code untestable outside the game.
+
+Option B: Simplify (Extend Adapter)
+
+Approach: Add the missing methods (designateBiomes, getFeatureTypeIndex, etc.) to the main EngineAdapter interface. Implement them in Civ7Adapter.
+
+Pros: Keeps the architecture pure; keeps logic testable via mocks.
+
+Cons: EngineAdapter interface grows large (Monolithic Adapter).
+
+Option C: Redesign (Specialized Adapters)
+
+Approach: Create separate BiomeProvider and FeatureProvider interfaces. Inject them into the context alongside the main adapter.
+
+Pros: Clean separation of concerns.
+
+Cons: Over-engineering for a map script? Increases boilerplate.
+
+Problem: Global Singleton Coupling (WorldModel)
+
+Why can't we test layers in isolation? Because they reach for global state.
+
+Option A: Patch (Lifecycle Management)
+
+Approach: Add explicit WorldModel.reset() calls in the Orchestrator and Test Setup.
+
+Pros: Low effort.
+
+Cons: Mutable global state is the root of all evil; race conditions in tests; hidden side effects.
+
+Option B: Refactor (Pass Context)
+
+Approach: Ensure FoundationContext (the immutable data snapshot) is populated in the MapContext. Update layers to read ctx.foundation.plates instead of importing WorldModel.
+
+Pros: Functional purity; easy testing (just pass a mock object); decoupling.
+
+Cons: Requires updating signatures in all layer files.
+
+Option C: Remove (Pure Function)
+
+Approach: Delete the WorldModel singleton object. Make generateFoundation(config) a pure function that returns the data arrays. Store that result in the context.
+
+Pros: The "WorldModel" stops being a place that holds state and becomes just a calculation.
+
+Cons: Major refactor of the world/ directory structure.
+
+Problem: Voronoi Strategy (World vs Civ7 Fidelity)
+
+Why is plate behavior hard to reason about vs the base game? Because the TS world implementation uses its own simplified Voronoi utility.
+
+Option A: Accept Independent TS Voronoi (Documented Divergence)
+
+Approach: Treat DefaultVoronoiUtils as the canonical implementation, optimize/test it locally, and clearly document that plate tessellation is intentionally independent from Civ7’s voronoi/kd-tree pipeline.
+
+Pros: No hard runtime dependency on Civ7 internals; easier to test and evolve; fully controlled in this repo.
+
+Cons: Harder to claim “bit-level parity” with Civ7 world generation; tuning may need to diverge from Civ defaults.
+
+Option B: Adapter-Backed Voronoi (Delayed Integration)
+
+Approach: Define a VoronoiUtilsInterface in world code and provide two implementations:
+- A “production” implementation that calls Civ7’s /base-standard/voronoi-utils.js and kd-tree via the adapter.
+- A “test” implementation (DefaultVoronoiUtils) used in unit tests and offline experiments.
+
+Pros: Gives us true parity in production while maintaining testability; aligns with adapter boundary principles.
+
+Cons: Requires more adapter plumbing; test vs runtime differences must be carefully managed/documented.
+
+5. Testing & Diagnostics Remediation
+
+We should treat testing and diagnostics as first-class remediation steps, not afterthoughts. The goal is to make the next set of regressions impossible to land silently.
+
+Orchestrator + Stages Integration Test
+
+Add a targeted test in mapgen-core that:
+- Calls bootstrap({ stageConfig: { foundation: true, landmassPlates: true, ... } }).
+- Instantiates MapOrchestrator with a MockAdapter from @civ7/adapter/mock.
+- Runs generateMap() and asserts that:
+  - Stage flags are correctly enabled/disabled.
+  - At least a minimal subset of stages actually execute (e.g., landmassPlates, coastlines, mountains, placement).
+
+This test should fail if the stage manifest wiring regresses again.
+
+WorldModel Lifecycle Tests
+
+Add focused tests for WorldModel:
+- init() with explicit width/height and injected RNG should allocate and populate the core fields (plates, winds, currents, etc.).
+- reset() should clear state in a way that makes back-to-back init() calls deterministic.
+- setConfigProvider / getConfig() integration should be verified at least minimally.
+
+Climate / Biomes / Features Behavior Tests
+
+For climate:
+- Use ExtendedMapContext + MockAdapter to assert that baseline bands, orographic bonuses, and coastal/shallow modifiers behave as expected on small grids.
+
+For biomes:
+- Provide a fake adapter that exposes biome reads/writes, and assert that tundra restraint, tropical coasts, river-valley grassland, and corridor/rift-shoulder rules fire when their conditions are met.
+
+For features:
+- Provide a fake adapter with concrete feature indices and biome globals, and assert that reef placement, volcanic forests/taiga, and density tweaks actually place features.
+
+Adapter-Boundary Check
+
+Implement a grep-based “adapter boundary” check and wire it into CI so that /base-standard/ imports in packages/** outside civ7-adapter cause a failure (excluding config/tests). This protects the boundary we are about to repair.
+
+CIV‑8 In-Game Validation
+
+Once the above wiring and tests are in place, re-run CIV‑8 with explicit, documented steps:
+- Launch the game with the TypeScript build.
+- Generate maps with the Swooper preset and collect:
+  - Logs showing stage execution (Starting: landmassPlates, etc.).
+  - Quick visual checks for coasts, mountains, rainfall belts, biomes, and features.
+  - Comparisons vs a JS-baseline save or screenshots, at least at a qualitative level.
+
+Document these observations in the CIV‑8 review so we have a concrete “TS parity achieved” checkpoint.

--- a/packages/civ7-types/index.d.ts
+++ b/packages/civ7-types/index.d.ts
@@ -1,0 +1,463 @@
+/**
+ * @civ7/types - TypeScript definitions for Civilization VII modding runtime
+ *
+ * This package provides ambient type declarations for:
+ * - Global objects (GameplayMap, GameInfo, TerrainBuilder, etc.)
+ * - Virtual module imports (/base-standard/...)
+ *
+ * Usage:
+ *   /// <reference types="@civ7/types" />
+ *   or add to tsconfig.json "types": ["@civ7/types"]
+ */
+
+// =============================================================================
+// GLOBAL INTERFACES
+// =============================================================================
+
+/**
+ * Location coordinates on the game map
+ */
+interface PlotLocation {
+  x: number;
+  y: number;
+}
+
+/**
+ * Feature placement data
+ */
+interface FeatureData {
+  Feature: number;
+  Direction: number;
+  Elevation: number;
+}
+
+/**
+ * GameInfo table row with common accessors
+ */
+interface GameInfoTable<T = any> {
+  /** Find row by predicate */
+  find(predicate: (row: T) => boolean): T | null;
+  /** Lookup row by key */
+  lookup(key: string | number): T | null;
+  /** Number of rows in the table */
+  length: number;
+  /** Iterate over all rows */
+  [Symbol.iterator](): Iterator<T>;
+}
+
+/**
+ * Map configuration row from GameInfo.Maps
+ */
+interface MapConfigRow {
+  NumNaturalWonders: number;
+  LakeGenerationFrequency: number;
+  PlayersLandmass1: number;
+  PlayersLandmass2: number;
+  StartSectorRows: number;
+  StartSectorCols: number;
+  Width: number;
+  Height: number;
+  MinimumResources: number;
+  DesiredRivers: number;
+  MinIslandSize: number;
+  MaxIslandSize: number;
+  NumMinorIslands: number;
+  [key: string]: any;
+}
+
+/**
+ * Terrain row from GameInfo.Terrains
+ */
+interface TerrainRow {
+  TerrainType: string;
+  Index: number;
+  Name: string;
+  [key: string]: any;
+}
+
+/**
+ * Biome row from GameInfo.Biomes
+ */
+interface BiomeRow {
+  BiomeType: string;
+  Index: number;
+  Name: string;
+  [key: string]: any;
+}
+
+/**
+ * Feature row from GameInfo.Features
+ */
+interface FeatureRow {
+  FeatureType: string;
+  Index: number;
+  Name: string;
+  NaturalWonder: boolean;
+  [key: string]: any;
+}
+
+/**
+ * Resource row from GameInfo.Resources
+ */
+interface ResourceRow {
+  ResourceType: string;
+  Index: number;
+  Name: string;
+  ResourceClassType: string;
+  [key: string]: any;
+}
+
+// =============================================================================
+// GLOBAL DECLARATIONS
+// =============================================================================
+
+declare global {
+  // ---------------------------------------------------------------------------
+  // GameplayMap - Map query and state API (read-only)
+  // ---------------------------------------------------------------------------
+  const GameplayMap: {
+    // Grid dimensions
+    getGridWidth(): number;
+    getGridHeight(): number;
+    getMapSize(): string;
+
+    // Index/location conversion
+    getIndexFromXY(x: number, y: number): number;
+    getLocationFromIndex(index: number): PlotLocation;
+    getAdjacentPlotLocation(x: number, y: number, direction: number): PlotLocation;
+
+    // Terrain queries
+    getTerrainType(x: number, y: number): number;
+    getBiomeType(x: number, y: number): number;
+    getFeatureType(x: number, y: number): number;
+    getResourceType(x: number, y: number): number;
+    getElevation(x: number, y: number): number;
+    getRainfall(x: number, y: number): number;
+    getTemperature(x: number, y: number): number;
+    getPlotLatitude(x: number, y: number): number;
+    getRiverType(x: number, y: number): number;
+
+    // Area/continent queries
+    getAreaId(x: number, y: number): number;
+    getAreaIsWater(areaId: number): boolean;
+    getContinentType(x: number, y: number): number;
+    getHemisphere(x: number, y: number): number;
+    getPrimaryHemisphere(): number;
+    findSecondContinent(): number;
+
+    // Owner/plot queries
+    getOwner(x: number, y: number): number;
+    getPlotTag(x: number, y: number): number;
+    hasPlotTag(x: number, y: number, tag: number): boolean;
+    getPlotDistance(x1: number, y1: number, x2: number, y2: number): number;
+    getPlotIndicesInRadius(x: number, y: number, radius: number): number[];
+
+    // Predicate queries
+    isWater(x: number, y: number): boolean;
+    isMountain(x: number, y: number): boolean;
+    isLake(x: number, y: number): boolean;
+    isRiver(x: number, y: number): boolean;
+    isNavigableRiver(x: number, y: number): boolean;
+    isCoastalLand(x: number, y: number): boolean;
+    isNaturalWonder(x: number, y: number): boolean;
+    isImpassable(x: number, y: number): boolean;
+    isCliffCrossing(x: number, y: number, direction: number): boolean;
+
+    // Adjacency queries
+    isAdjacentToRivers(x: number, y: number, radius?: number): boolean;
+    isAdjacentToLand(x: number, y: number): boolean;
+    isAdjacentToShallowWater(x: number, y: number): boolean;
+    isAdjacentToFeature(x: number, y: number, featureType: number): boolean;
+
+    // RNG
+    getRandomSeed(): number;
+  };
+
+  // ---------------------------------------------------------------------------
+  // TerrainBuilder - Map modification API (write operations)
+  // ---------------------------------------------------------------------------
+  const TerrainBuilder: {
+    // Setters
+    setTerrainType(x: number, y: number, terrainType: number): void;
+    setBiomeType(x: number, y: number, biomeType: number): void;
+    setFeatureType(x: number, y: number, featureData: FeatureData): void;
+    setElevation(x: number, y: number, elevation: number): void;
+    setRainfall(x: number, y: number, rainfall: number): void;
+
+    // Plot tags
+    setPlotTag(x: number, y: number, tag: number): void;
+    addPlotTag(x: number, y: number, tag: number): void;
+    removePlotTag(x: number, y: number, tag: number): void;
+
+    // Validation
+    canHaveFeature(x: number, y: number, featureType: number): boolean;
+    canHaveFeatureParam(x: number, y: number, featureType: number, param: any): boolean;
+    validateAndFixTerrain(): void;
+
+    // Random number generation
+    getRandomNumber(max: number, label: string): number;
+
+    // Map building phases
+    stampContinents(): void;
+    buildElevation(): void;
+    modelRivers(minLength: number, maxLength: number, navigableTerrain: number): void;
+    defineNamedRivers(): void;
+    storeWaterData(): void;
+    addFloodplains(): void;
+
+    // Utilities
+    generatePoissonMap(
+      width: number,
+      height: number,
+      minDistance: number,
+      maxAttempts: number
+    ): PlotLocation[];
+    getHeightFromPercent(percent: number): number;
+  };
+
+  // ---------------------------------------------------------------------------
+  // AreaBuilder - Area/continent management
+  // ---------------------------------------------------------------------------
+  const AreaBuilder: {
+    recalculateAreas(): void;
+  };
+
+  // ---------------------------------------------------------------------------
+  // FractalBuilder - Fractal noise generation
+  // ---------------------------------------------------------------------------
+  const FractalBuilder: {
+    create(
+      fractalId: number,
+      width: number,
+      height: number,
+      grain: number,
+      flags: number
+    ): void;
+    getHeight(fractalId: number, x: number, y: number): number;
+  };
+
+  // ---------------------------------------------------------------------------
+  // GameInfo - Database tables
+  // ---------------------------------------------------------------------------
+  const GameInfo: {
+    // Core tables
+    Maps: GameInfoTable<MapConfigRow>;
+    Terrains: GameInfoTable<TerrainRow>;
+    Biomes: GameInfoTable<BiomeRow>;
+    Features: GameInfoTable<FeatureRow>;
+    Resources: GameInfoTable<ResourceRow>;
+    Ages: GameInfoTable;
+    Civilizations: GameInfoTable;
+    Leaders: GameInfoTable;
+
+    // Feature tables
+    FeatureClasses: GameInfoTable;
+    Feature_NaturalWonders: GameInfoTable;
+
+    // Start bias tables
+    StartBiasBiomes: GameInfoTable;
+    StartBiasTerrains: GameInfoTable;
+    StartBiasRivers: GameInfoTable;
+    StartBiasLakes: GameInfoTable;
+    StartBiasAdjacentToCoasts: GameInfoTable;
+    StartBiasFeatureClasses: GameInfoTable;
+    StartBiasNaturalWonders: GameInfoTable;
+    StartBiasResources: GameInfoTable;
+
+    // Resource tables
+    Resource_Distribution: GameInfoTable;
+    MapResourceMinimumAmountModifier: GameInfoTable;
+
+    // Map behavior tables
+    MapIslandBehavior: GameInfoTable;
+    DiscoverySiftingImprovements: GameInfoTable;
+
+    // Other tables
+    GlobalParameters: GameInfoTable;
+    AdvancedStartParameters: GameInfoTable;
+    NarrativeStories: GameInfoTable;
+    Unit_ShadowReplacements: GameInfoTable;
+
+    // Generic accessor for any table
+    [tableName: string]: GameInfoTable | undefined;
+  };
+
+  // ---------------------------------------------------------------------------
+  // engine - Event messaging API
+  // ---------------------------------------------------------------------------
+  const engine: {
+    on(event: string, callback: (...args: any[]) => void): void;
+    call(method: string, ...args: any[]): any;
+  };
+
+  // ---------------------------------------------------------------------------
+  // Configuration - Game settings
+  // ---------------------------------------------------------------------------
+  const Configuration: {
+    getGameValue(key: string): any;
+    getMapValue(key: string): any;
+  };
+
+  // ---------------------------------------------------------------------------
+  // Players - Player management
+  // ---------------------------------------------------------------------------
+  interface Player {
+    isAlive: boolean;
+    [key: string]: any;
+  }
+
+  interface AdvancedStartPlayer {
+    dynamicCardsAddedComplete(): void;
+    addDynamicAvailableCard(card: any): void;
+    [key: string]: any;
+  }
+
+  const Players: {
+    get(playerId: number): Player | null;
+    AdvancedStart: {
+      get(playerId: number): AdvancedStartPlayer | null;
+    };
+  };
+
+  // ---------------------------------------------------------------------------
+  // Game - Game state
+  // ---------------------------------------------------------------------------
+  const Game: {
+    age: number;
+    EconomicRules: {
+      adjustForGameSpeed(value: number): number;
+    };
+    PlacementRules: {
+      getValidOceanNavalLocation(playerId: number): number;
+    };
+  };
+
+  // ---------------------------------------------------------------------------
+  // Database - Hash utilities
+  // ---------------------------------------------------------------------------
+  const Database: {
+    makeHash(key: string): number;
+  };
+
+  // ---------------------------------------------------------------------------
+  // PlotTags - Plot tag constants
+  // ---------------------------------------------------------------------------
+  const PlotTags: {
+    [tagName: string]: number;
+  };
+
+  // ---------------------------------------------------------------------------
+  // FeatureTypes - Feature type constants
+  // ---------------------------------------------------------------------------
+  const FeatureTypes: {
+    [featureName: string]: number;
+  };
+
+  // Ensure console is available
+  var console: Console;
+}
+
+// =============================================================================
+// VIRTUAL MODULE DECLARATIONS (/base-standard/...)
+// =============================================================================
+
+declare module "/base-standard/maps/map-utilities.js" {
+  export function needHumanNearEquator(): boolean;
+  export function assignStartingPlots(): void;
+  // Add more exports as discovered
+}
+
+declare module "/base-standard/maps/assign-starting-plots.js" {
+  export function chooseStartSectors(
+    numPlayers1: number,
+    numPlayers2: number,
+    rows: number,
+    cols: number,
+    humanNearEquator: boolean
+  ): any;
+  export function assignStartingPlots(): void;
+}
+
+declare module "/base-standard/maps/elevation-terrain-generator.js" {
+  export function expandCoasts(width: number, height: number): void;
+  export function generateLakes(
+    width: number,
+    height: number,
+    tilesPerLake: number
+  ): void;
+}
+
+declare module "/base-standard/maps/map-globals.js" {
+  export const g_AvoidSeamOffset: number;
+  export const g_PolarWaterRows: number;
+  export const g_HillTerrain: number;
+  export const g_NavigableRiverTerrain: number;
+  export const g_CommanderUnitIndex: number;
+}
+
+declare module "/base-standard/maps/feature-biome-generator.js" {
+  export function addFeatures(): void;
+  export function addBiomes(): void;
+}
+
+declare module "/base-standard/maps/resource-generator.js" {
+  export function addResources(): void;
+}
+
+declare module "/base-standard/maps/continents.js" {
+  // This module has side effects and registers map generation
+  const _default: void;
+  export default _default;
+}
+
+declare module "/base-standard/scripts/voronoi-region.js" {
+  export class PlateRegion {
+    constructor(id: number, center: PlotLocation);
+    id: number;
+    center: PlotLocation;
+    cells: PlotLocation[];
+    neighbors: Set<number>;
+    addCell(cell: PlotLocation): void;
+  }
+}
+
+declare module "/base-standard/scripts/kd-tree.js" {
+  export interface RegionCell {
+    x: number;
+    y: number;
+    regionId: number;
+  }
+
+  export type RegionCellPosGetter = (cell: RegionCell) => [number, number];
+
+  export class kdTree<T> {
+    constructor(points: T[], distance: (a: T, b: T) => number, dimensions: string[]);
+    nearest(point: T, count: number): Array<[T, number]>;
+  }
+
+  export const VoronoiUtils: {
+    assignCellsToRegions(
+      cells: RegionCell[],
+      regions: any[],
+      posGetter: RegionCellPosGetter
+    ): void;
+  };
+}
+
+declare module "/base-standard/scripts/random-pcg-32.js" {
+  export class RandomPCG32 {
+    constructor(seed: number);
+    next(): number;
+    nextFloat(): number;
+    nextInRange(min: number, max: number): number;
+  }
+}
+
+// Catch-all for rapid migration - allows any /base-standard/ import
+declare module "/base-standard/*" {
+  const value: any;
+  export = value;
+  export default value;
+}
+
+export {};

--- a/packages/civ7-types/package.json
+++ b/packages/civ7-types/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@civ7/types",
+  "version": "0.1.0",
+  "description": "TypeScript type definitions for Civilization VII modding runtime environment",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts"
+    }
+  },
+  "scripts": {
+    "check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.2"
+  },
+  "keywords": [
+    "civ7",
+    "civilization",
+    "modding",
+    "types",
+    "typescript"
+  ],
+  "license": "MIT"
+}

--- a/packages/civ7-types/tsconfig.json
+++ b/packages/civ7-types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.d.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,12 @@ importers:
         specifier: ^5.9.2
         version: 5.9.2
 
+  packages/civ7-types:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+
   packages/cli:
     dependencies:
       '@civ7/config':
@@ -230,25 +236,6 @@ importers:
       tsup:
         specifier: ^8.5.0
         version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1)
-      typescript:
-        specifier: ^5.9.2
-        version: 5.9.2
-      vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(@vitest/ui@3.2.4)(jiti@1.21.7)(tsx@4.20.4)(yaml@2.8.1)
-
-  packages/plugins/plugin-mapgen:
-    dependencies:
-      '@civ7/plugin-files':
-        specifier: workspace:*
-        version: link:../plugin-files
-      '@civ7/plugin-mods':
-        specifier: workspace:*
-        version: link:../plugin-mods
-    devDependencies:
-      '@types/node':
-        specifier: ^24.2.1
-        version: 24.2.1
       typescript:
         specifier: ^5.9.2
         version: 5.9.2


### PR DESCRIPTION
- Create packages/civ7-types with TypeScript declarations for Civ7 runtime
- Add GameplayMap interface (40 methods: terrain, area, adjacency queries)
- Add GameInfo interface (26 tables: Maps, Terrains, Biomes, Features, etc.)
- Add TerrainBuilder interface (19 methods: setters, validation, phases)
- Add AreaBuilder, FractalBuilder, engine, Configuration, Players, Game globals
- Declare /base-standard/... virtual module imports
- Include catch-all module declaration for rapid migration

Ref: CIV-1