### PR TITLE
feat(adapter): create @civ7/adapter package

### DIFF
--- a/packages/civ7-adapter/package.json
+++ b/packages/civ7-adapter/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@civ7/adapter",
+  "version": "0.1.0",
+  "description": "Centralized adapter for Civ7 engine APIs - the only package allowed to import /base-standard/...",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./civ7": {
+      "types": "./dist/civ7-adapter.d.ts",
+      "import": "./dist/civ7-adapter.js"
+    },
+    "./mock": {
+      "types": "./dist/mock-adapter.d.ts",
+      "import": "./dist/mock-adapter.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@civ7/types": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.0",
+    "typescript": "^5.9.2"
+  },
+  "keywords": [
+    "civ7",
+    "civilization",
+    "modding",
+    "adapter"
+  ],
+  "license": "MIT"
+}

--- a/packages/civ7-adapter/src/civ7-adapter.ts
+++ b/packages/civ7-adapter/src/civ7-adapter.ts
@@ -1,0 +1,151 @@
+/**
+ * Civ7Adapter - Production implementation using Civ7 engine APIs
+ *
+ * This is the ONLY module allowed to import /base-standard/... paths.
+ * All other code must consume the EngineAdapter interface.
+ */
+
+/// <reference types="@civ7/types" />
+
+import type { EngineAdapter, FeatureData } from "./types.js";
+
+// Import from /base-standard/... — these are external and resolved at runtime
+import "/base-standard/maps/map-globals.js";
+
+/**
+ * Production adapter wrapping GameplayMap, TerrainBuilder, AreaBuilder, FractalBuilder
+ */
+export class Civ7Adapter implements EngineAdapter {
+  readonly width: number;
+  readonly height: number;
+
+  constructor(width: number, height: number) {
+    this.width = width;
+    this.height = height;
+  }
+
+  // === TERRAIN READS ===
+
+  isWater(x: number, y: number): boolean {
+    return GameplayMap.isWater(x, y);
+  }
+
+  isMountain(x: number, y: number): boolean {
+    if (typeof GameplayMap.isMountain === "function") {
+      return GameplayMap.isMountain(x, y);
+    }
+    // Fallback: check elevation >= 500
+    return GameplayMap.getElevation(x, y) >= 500;
+  }
+
+  isAdjacentToRivers(x: number, y: number, radius = 1): boolean {
+    return GameplayMap.isAdjacentToRivers(x, y, radius);
+  }
+
+  getElevation(x: number, y: number): number {
+    return GameplayMap.getElevation(x, y);
+  }
+
+  getTerrainType(x: number, y: number): number {
+    return GameplayMap.getTerrainType(x, y);
+  }
+
+  getRainfall(x: number, y: number): number {
+    return GameplayMap.getRainfall(x, y);
+  }
+
+  getTemperature(x: number, y: number): number {
+    return GameplayMap.getTemperature(x, y);
+  }
+
+  getLatitude(x: number, y: number): number {
+    return GameplayMap.getPlotLatitude(x, y);
+  }
+
+  // === TERRAIN WRITES ===
+
+  setTerrainType(x: number, y: number, terrainType: number): void {
+    TerrainBuilder.setTerrainType(x, y, terrainType);
+  }
+
+  setRainfall(x: number, y: number, rainfall: number): void {
+    TerrainBuilder.setRainfall(x, y, rainfall);
+  }
+
+  setElevation(x: number, y: number, elevation: number): void {
+    TerrainBuilder.setElevation(x, y, elevation);
+  }
+
+  // === FEATURE READS/WRITES ===
+
+  getFeatureType(x: number, y: number): number {
+    return GameplayMap.getFeatureType(x, y);
+  }
+
+  setFeatureType(x: number, y: number, featureData: FeatureData): void {
+    TerrainBuilder.setFeatureType(x, y, featureData);
+  }
+
+  canHaveFeature(x: number, y: number, featureType: number): boolean {
+    return TerrainBuilder.canHaveFeature(x, y, featureType);
+  }
+
+  // === RANDOM NUMBER GENERATION ===
+
+  getRandomNumber(max: number, label: string): number {
+    return TerrainBuilder.getRandomNumber(max, label);
+  }
+
+  // === UTILITIES ===
+
+  validateAndFixTerrain(): void {
+    TerrainBuilder.validateAndFixTerrain();
+  }
+
+  recalculateAreas(): void {
+    AreaBuilder.recalculateAreas();
+  }
+
+  createFractal(
+    fractalId: number,
+    width: number,
+    height: number,
+    grain: number,
+    flags: number
+  ): void {
+    FractalBuilder.create(fractalId, width, height, grain, flags);
+  }
+
+  getFractalHeight(fractalId: number, x: number, y: number): number {
+    return FractalBuilder.getHeight(fractalId, x, y);
+  }
+
+  stampContinents(): void {
+    TerrainBuilder.stampContinents();
+  }
+
+  buildElevation(): void {
+    TerrainBuilder.buildElevation();
+  }
+
+  modelRivers(minLength: number, maxLength: number, navigableTerrain: number): void {
+    TerrainBuilder.modelRivers(minLength, maxLength, navigableTerrain);
+  }
+
+  defineNamedRivers(): void {
+    TerrainBuilder.defineNamedRivers();
+  }
+
+  storeWaterData(): void {
+    TerrainBuilder.storeWaterData();
+  }
+}
+
+/**
+ * Create a Civ7 adapter from current map dimensions
+ */
+export function createCiv7Adapter(): Civ7Adapter {
+  const width = GameplayMap.getGridWidth();
+  const height = GameplayMap.getGridHeight();
+  return new Civ7Adapter(width, height);
+}

--- a/packages/civ7-adapter/src/index.ts
+++ b/packages/civ7-adapter/src/index.ts
@@ -1,0 +1,27 @@
+/**
+ * @civ7/adapter - Centralized adapter for Civ7 engine APIs
+ *
+ * This package is the ONLY place allowed to import /base-standard/... paths.
+ * All other packages must consume the EngineAdapter interface.
+ *
+ * Usage:
+ *   // In production (mod code):
+ *   import { createCiv7Adapter } from "@civ7/adapter/civ7";
+ *
+ *   // In tests:
+ *   import { createMockAdapter } from "@civ7/adapter/mock";
+ *
+ *   // For types only:
+ *   import type { EngineAdapter } from "@civ7/adapter";
+ */
+
+// Re-export types
+export type { EngineAdapter, FeatureData, MapDimensions, MapContext } from "./types.js";
+
+// Re-export mock adapter (safe to import anywhere)
+export { MockAdapter, createMockAdapter } from "./mock-adapter.js";
+export type { MockAdapterConfig } from "./mock-adapter.js";
+
+// Note: Civ7Adapter is NOT re-exported from index to prevent accidental
+// bundling of /base-standard/... imports. Import it explicitly from:
+//   import { Civ7Adapter, createCiv7Adapter } from "@civ7/adapter/civ7";

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -1,0 +1,211 @@
+/**
+ * MockAdapter - Test implementation with configurable behavior
+ *
+ * This module has NO /base-standard/... imports and can be used
+ * in unit tests without the Civ7 game engine.
+ */
+
+import type { EngineAdapter, FeatureData } from "./types.js";
+
+/**
+ * Configuration options for MockAdapter
+ */
+export interface MockAdapterConfig {
+  width?: number;
+  height?: number;
+  /** Default terrain type for all tiles */
+  defaultTerrainType?: number;
+  /** Default elevation for all tiles */
+  defaultElevation?: number;
+  /** Default rainfall for all tiles */
+  defaultRainfall?: number;
+  /** Default temperature for all tiles */
+  defaultTemperature?: number;
+  /** Custom RNG function (default: Math.random) */
+  rng?: (max: number, label: string) => number;
+}
+
+/**
+ * Mock adapter for testing map generation logic without Civ7 engine
+ */
+export class MockAdapter implements EngineAdapter {
+  readonly width: number;
+  readonly height: number;
+
+  private terrainTypes: Uint8Array;
+  private elevations: Int16Array;
+  private rainfall: Uint8Array;
+  private temperature: Uint8Array;
+  private features: Int16Array;
+  private waterMask: Uint8Array;
+  private mountainMask: Uint8Array;
+  private rngFn: (max: number, label: string) => number;
+
+  constructor(config: MockAdapterConfig = {}) {
+    this.width = config.width ?? 128;
+    this.height = config.height ?? 80;
+    const size = this.width * this.height;
+
+    this.terrainTypes = new Uint8Array(size).fill(config.defaultTerrainType ?? 0);
+    this.elevations = new Int16Array(size).fill(config.defaultElevation ?? 100);
+    this.rainfall = new Uint8Array(size).fill(config.defaultRainfall ?? 50);
+    this.temperature = new Uint8Array(size).fill(config.defaultTemperature ?? 15);
+    this.features = new Int16Array(size).fill(-1);
+    this.waterMask = new Uint8Array(size);
+    this.mountainMask = new Uint8Array(size);
+    this.rngFn = config.rng ?? ((max) => Math.floor(Math.random() * max));
+  }
+
+  private idx(x: number, y: number): number {
+    return y * this.width + x;
+  }
+
+  // === TERRAIN READS ===
+
+  isWater(x: number, y: number): boolean {
+    return this.waterMask[this.idx(x, y)] === 1;
+  }
+
+  isMountain(x: number, y: number): boolean {
+    return this.mountainMask[this.idx(x, y)] === 1;
+  }
+
+  isAdjacentToRivers(_x: number, _y: number, _radius = 1): boolean {
+    return false; // Mock: no rivers by default
+  }
+
+  getElevation(x: number, y: number): number {
+    return this.elevations[this.idx(x, y)];
+  }
+
+  getTerrainType(x: number, y: number): number {
+    return this.terrainTypes[this.idx(x, y)];
+  }
+
+  getRainfall(x: number, y: number): number {
+    return this.rainfall[this.idx(x, y)];
+  }
+
+  getTemperature(x: number, y: number): number {
+    return this.temperature[this.idx(x, y)];
+  }
+
+  getLatitude(x: number, y: number): number {
+    // Simple latitude calculation: -90 to 90 based on y position
+    const normalizedY = y / this.height;
+    return 90 - normalizedY * 180;
+  }
+
+  // === TERRAIN WRITES ===
+
+  setTerrainType(x: number, y: number, terrainType: number): void {
+    this.terrainTypes[this.idx(x, y)] = terrainType;
+  }
+
+  setRainfall(x: number, y: number, value: number): void {
+    this.rainfall[this.idx(x, y)] = Math.max(0, Math.min(200, value));
+  }
+
+  setElevation(x: number, y: number, elevation: number): void {
+    this.elevations[this.idx(x, y)] = elevation;
+  }
+
+  // === FEATURE READS/WRITES ===
+
+  getFeatureType(x: number, y: number): number {
+    return this.features[this.idx(x, y)];
+  }
+
+  setFeatureType(x: number, y: number, featureData: FeatureData): void {
+    this.features[this.idx(x, y)] = featureData.Feature;
+  }
+
+  canHaveFeature(_x: number, _y: number, _featureType: number): boolean {
+    return true; // Mock: always allow features
+  }
+
+  // === RANDOM NUMBER GENERATION ===
+
+  getRandomNumber(max: number, label: string): number {
+    return this.rngFn(max, label);
+  }
+
+  // === UTILITIES ===
+
+  validateAndFixTerrain(): void {
+    // No-op in mock
+  }
+
+  recalculateAreas(): void {
+    // No-op in mock
+  }
+
+  createFractal(
+    _fractalId: number,
+    _width: number,
+    _height: number,
+    _grain: number,
+    _flags: number
+  ): void {
+    // No-op in mock
+  }
+
+  getFractalHeight(_fractalId: number, _x: number, _y: number): number {
+    return 0; // Mock: flat fractal
+  }
+
+  stampContinents(): void {
+    // No-op in mock
+  }
+
+  buildElevation(): void {
+    // No-op in mock
+  }
+
+  modelRivers(_minLength: number, _maxLength: number, _navigableTerrain: number): void {
+    // No-op in mock
+  }
+
+  defineNamedRivers(): void {
+    // No-op in mock
+  }
+
+  storeWaterData(): void {
+    // No-op in mock
+  }
+
+  // === MOCK-SPECIFIC HELPERS ===
+
+  /** Set water mask for testing */
+  setWater(x: number, y: number, isWater: boolean): void {
+    this.waterMask[this.idx(x, y)] = isWater ? 1 : 0;
+  }
+
+  /** Set mountain mask for testing */
+  setMountain(x: number, y: number, isMountain: boolean): void {
+    this.mountainMask[this.idx(x, y)] = isMountain ? 1 : 0;
+  }
+
+  /** Fill all tiles with water/land */
+  fillWater(isWater: boolean): void {
+    this.waterMask.fill(isWater ? 1 : 0);
+  }
+
+  /** Reset all data to defaults */
+  reset(config: MockAdapterConfig = {}): void {
+    this.terrainTypes.fill(config.defaultTerrainType ?? 0);
+    this.elevations.fill(config.defaultElevation ?? 100);
+    this.rainfall.fill(config.defaultRainfall ?? 50);
+    this.temperature.fill(config.defaultTemperature ?? 15);
+    this.features.fill(-1);
+    this.waterMask.fill(0);
+    this.mountainMask.fill(0);
+  }
+}
+
+/**
+ * Create a mock adapter with default configuration
+ */
+export function createMockAdapter(config?: MockAdapterConfig): MockAdapter {
+  return new MockAdapter(config);
+}

--- a/packages/civ7-adapter/src/types.ts
+++ b/packages/civ7-adapter/src/types.ts
@@ -1,0 +1,137 @@
+/**
+ * @civ7/adapter - Type definitions for the engine adapter interface
+ *
+ * The EngineAdapter interface abstracts all engine/surface interactions.
+ * Core logic consumes this interface; tests can mock it.
+ */
+
+/// <reference types="@civ7/types" />
+
+/**
+ * Feature placement data
+ */
+export interface FeatureData {
+  Feature: number;
+  Direction: number;
+  Elevation: number;
+}
+
+/**
+ * Map dimensions
+ */
+export interface MapDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * EngineAdapter - abstraction for all engine/surface interactions
+ *
+ * All terrain/feature reads and writes MUST go through this interface.
+ * Implementations:
+ * - Civ7Adapter: uses GameplayMap, TerrainBuilder, etc. (production)
+ * - MockAdapter: configurable mock for testing (no engine dependencies)
+ */
+export interface EngineAdapter {
+  /** Map width */
+  readonly width: number;
+  /** Map height */
+  readonly height: number;
+
+  // === TERRAIN READS ===
+
+  /** Check if tile is water */
+  isWater(x: number, y: number): boolean;
+
+  /** Check if tile is mountain */
+  isMountain(x: number, y: number): boolean;
+
+  /** Check if tile is near rivers */
+  isAdjacentToRivers(x: number, y: number, radius?: number): boolean;
+
+  /** Get tile elevation */
+  getElevation(x: number, y: number): number;
+
+  /** Get terrain type ID */
+  getTerrainType(x: number, y: number): number;
+
+  /** Get rainfall (0..200) */
+  getRainfall(x: number, y: number): number;
+
+  /** Get temperature */
+  getTemperature(x: number, y: number): number;
+
+  /** Get latitude in degrees */
+  getLatitude(x: number, y: number): number;
+
+  // === TERRAIN WRITES ===
+
+  /** Set terrain type */
+  setTerrainType(x: number, y: number, terrainType: number): void;
+
+  /** Set rainfall (0..200) */
+  setRainfall(x: number, y: number, rainfall: number): void;
+
+  /** Set elevation */
+  setElevation(x: number, y: number, elevation: number): void;
+
+  // === FEATURE READS/WRITES ===
+
+  /** Get feature type ID */
+  getFeatureType(x: number, y: number): number;
+
+  /** Set feature */
+  setFeatureType(x: number, y: number, featureData: FeatureData): void;
+
+  /** Validate feature placement */
+  canHaveFeature(x: number, y: number, featureType: number): boolean;
+
+  // === RANDOM NUMBER GENERATION ===
+
+  /** Seeded RNG (0..max-1) */
+  getRandomNumber(max: number, label: string): number;
+
+  // === UTILITIES ===
+
+  /** Run engine validation pass */
+  validateAndFixTerrain(): void;
+
+  /** Rebuild continent/area data */
+  recalculateAreas(): void;
+
+  /** Initialize fractal */
+  createFractal(
+    fractalId: number,
+    width: number,
+    height: number,
+    grain: number,
+    flags: number
+  ): void;
+
+  /** Sample fractal value */
+  getFractalHeight(fractalId: number, x: number, y: number): number;
+
+  /** Stamp continent assignments */
+  stampContinents(): void;
+
+  /** Build elevation layer */
+  buildElevation(): void;
+
+  /** Model river paths */
+  modelRivers(minLength: number, maxLength: number, navigableTerrain: number): void;
+
+  /** Define named rivers */
+  defineNamedRivers(): void;
+
+  /** Store water data */
+  storeWaterData(): void;
+}
+
+/**
+ * Map context for passing state between generation stages
+ */
+export interface MapContext {
+  dimensions: MapDimensions;
+  adapter: EngineAdapter;
+  config: Record<string, unknown>;
+}

--- a/packages/civ7-adapter/tsconfig.json
+++ b/packages/civ7-adapter/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["@civ7/types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/civ7-adapter/tsup.config.ts
+++ b/packages/civ7-adapter/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/civ7-adapter.ts", "src/mock-adapter.ts"],
+  format: ["esm"],
+  target: "esnext",
+  dts: true,
+  clean: true,
+  // CRITICAL: Keep /base-standard/... imports external
+  // These are resolved at runtime by the Civ7 game engine
+  external: [/^\/base-standard\/.*/],
+  // Bundle our workspace dependencies
+  noExternal: ["@civ7/types"],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,19 @@ importers:
         specifier: ^5.9.2
         version: 5.9.2
 
+  packages/civ7-adapter:
+    dependencies:
+      '@civ7/types':
+        specifier: workspace:*
+        version: link:../civ7-types
+    devDependencies:
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+
   packages/civ7-types:
     devDependencies:
       typescript:


### PR DESCRIPTION
- Create packages/civ7-adapter with centralized engine adapter pattern
- Add EngineAdapter interface (types.ts) for all engine interactions
- Add Civ7Adapter (civ7-adapter.ts) with /base-standard/... imports
- Add MockAdapter (mock-adapter.ts) for testing without engine deps
- Configure tsup to keep /base-standard/... as external imports
- Export mock from index.ts, require explicit import for Civ7Adapter

This is the ONLY package allowed to import /base-standard/... paths.
Verified: typecheck passes, build succeeds, boundary enforcement working.

Ref: CIV-2