### PR TITLE
feat(mod): wire mod-swooper-maps TypeScript build pipeline

### DIFF
--- a/mods/mod-swooper-maps/mod/config/config.xml
+++ b/mods/mod-swooper-maps/mod/config/config.xml
@@ -8,5 +8,12 @@
 			Description="LOC_MAP_SWOOPER_DESERT_MOUNTAINS_DESCRIPTION"
 			SortIndex="500"
 		/>
+		<!-- Gate A - TypeScript pipeline validation -->
+		<Row
+			File="{swooper-maps}/maps/gate-a-continents.js"
+			Name="LOC_MAP_GATE_A_CONTINENTS_NAME"
+			Description="LOC_MAP_GATE_A_CONTINENTS_DESCRIPTION"
+			SortIndex="501"
+		/>
 	</Maps>
 </Database>

--- a/mods/mod-swooper-maps/mod/maps/gate-a-continents.js
+++ b/mods/mod-swooper-maps/mod/maps/gate-a-continents.js
@@ -1,0 +1,9 @@
+// src/gate-a-continents.ts
+import "/base-standard/maps/continents.js";
+
+// ../../packages/mapgen-core/dist/index.js
+var VERSION = "0.1.0";
+
+// src/gate-a-continents.ts
+console.log(`[Swooper] Gate A Wrapper Loaded - TypeScript Build Pipeline Working`);
+console.log(`[Swooper] mapgen-core version: ${VERSION}`);

--- a/mods/mod-swooper-maps/mod/text/en_us/MapText.xml
+++ b/mods/mod-swooper-maps/mod/text/en_us/MapText.xml
@@ -7,6 +7,11 @@
 		<Row Tag="LOC_MAP_SWOOPER_DESERT_MOUNTAINS_DESCRIPTION">
 			<Text>Plate-forged mega ranges carve a hyper-arid world into stark basins and windward oases. Expect towering boundary cordilleras, savage lee-side deserts, and a handful of monsoon belts clinging to the mountains that feed them.</Text>
 		</Row>
-
+		<Row Tag="LOC_MAP_GATE_A_CONTINENTS_NAME">
+			<Text>[Gate A] TS Pipeline Test</Text>
+		</Row>
+		<Row Tag="LOC_MAP_GATE_A_CONTINENTS_DESCRIPTION">
+			<Text>TypeScript build pipeline validation. Generates a standard Continents map via base-standard delegation. If this loads without errors, Gate A passes.</Text>
+		</Row>
 	</EnglishText>
 </Database>

--- a/mods/mod-swooper-maps/package.json
+++ b/mods/mod-swooper-maps/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mod-swooper-maps",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Swooper Maps mod for Civilization VII",
+  "type": "module",
+  "scripts": {
+    "build": "tsup",
+    "check": "tsc --noEmit",
+    "deploy": "pnpm run build && pnpm exec civ7 mod manage deploy"
+  },
+  "dependencies": {
+    "@swooper/mapgen-core": "workspace:*",
+    "@civ7/adapter": "workspace:*"
+  },
+  "devDependencies": {
+    "@civ7/types": "workspace:*",
+    "tsup": "^8.3.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/mods/mod-swooper-maps/src/gate-a-continents.ts
+++ b/mods/mod-swooper-maps/src/gate-a-continents.ts
@@ -1,0 +1,26 @@
+/**
+ * Gate A Continents - TypeScript Pipeline Validation
+ *
+ * This minimal map entry proves the TypeScript build pipeline works by
+ * delegating to the base-standard Continents generator.
+ *
+ * Once Gate A passes (game loads without errors), the real swooper maps
+ * will be migrated to TypeScript in Gate B/C.
+ */
+
+/// <reference types="@civ7/types" />
+
+// Import base-standard Continents to handle actual map generation
+// This is kept external by tsup and resolved at runtime by Civ7
+import "/base-standard/maps/continents.js";
+
+// Import from our packages to verify bundling works
+import { VERSION } from "@swooper/mapgen-core";
+import type { EngineAdapter } from "@civ7/adapter";
+
+// Gate A marker - proves TypeScript pipeline is working
+console.log(`[Swooper] Gate A Wrapper Loaded - TypeScript Build Pipeline Working`);
+console.log(`[Swooper] mapgen-core version: ${VERSION}`);
+
+// Verify type system is working (compile-time only, no runtime effect)
+const _typeCheck: EngineAdapter | null = null;

--- a/mods/mod-swooper-maps/tsconfig.json
+++ b/mods/mod-swooper-maps/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./mod/maps",
+    "rootDir": "./src",
+    "declaration": false,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["@civ7/types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/mods/mod-swooper-maps/tsup.config.ts
+++ b/mods/mod-swooper-maps/tsup.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  // Entry point for the Gate A validation map
+  entry: ["src/gate-a-continents.ts"],
+
+  // Output directly to the structure the .modinfo expects
+  outDir: "mod/maps",
+
+  format: ["esm"],
+  target: "esnext",
+
+  // Bundle all dependencies into the output file
+  bundle: true,
+
+  // Do NOT clear the directory - preserve existing JS files and XML
+  clean: false,
+
+  // CRITICAL: Keep /base-standard/... imports external
+  // These are resolved at runtime by the Civ7 game engine
+  external: [/^\/base-standard\/.*/],
+
+  // Force bundling of our workspace packages
+  noExternal: ["@swooper/mapgen-core", "@civ7/adapter"],
+
+  // Civ7 doesn't use source maps
+  sourcemap: false,
+  minify: false,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,25 @@ importers:
         specifier: ^5.9.2
         version: 5.9.2
 
+  mods/mod-swooper-maps:
+    dependencies:
+      '@civ7/adapter':
+        specifier: workspace:*
+        version: link:../../packages/civ7-adapter
+      '@swooper/mapgen-core':
+        specifier: workspace:*
+        version: link:../../packages/mapgen-core
+    devDependencies:
+      '@civ7/types':
+        specifier: workspace:*
+        version: link:../../packages/civ7-types
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+
   packages/civ7-adapter:
     dependencies:
       '@civ7/types':


### PR DESCRIPTION
- Add package.json with tsup build script and workspace dependencies
- Add tsconfig.json with proper module resolution
- Add tsup.config.ts with /base-standard/... external, workspace deps bundled
- Create Gate A entry point (src/gate-a-continents.ts)
- Register new map in config.xml and MapText.xml

Gate A validation map:
- Delegates to /base-standard/maps/continents.js
- Logs 'Gate A Wrapper Loaded' to verify pipeline works
- Original swooper-desert-mountains.js preserved (11942 bytes)
- New gate-a-continents.js created (311 bytes)

Verified:
- typecheck passes
- /base-standard/ import preserved as external
- @civ7/adapter and @swooper/mapgen-core inlined
- Both maps registered in config.xml

Ready for in-game verification.

Ref: CIV-4