### PR TITLE
feat(bootstrap): refactor to lazy providers with test isolation (CIV-6)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,18 +20,7 @@
       "Bash(time pnpm -C packages/mapgen-core test:*)",
       "Bash(git add:*)",
       "Bash(git commit:*)",
-      "Bash(bun test:*)",
-      "Bash(gt ss:*)",
-      "Bash(git log:*)",
-      "Bash(gh pr list:*)",
-      "Bash(gh pr view:*)",
-      "mcp__linear-personal__get_issue",
-      "mcp__linear-personal__list_comments",
-      "Bash(git ls-tree:*)",
-      "Bash(gh pr diff:*)",
-      "mcp__linear-personal__list_issues",
-      "mcp__linear-personal__list_teams",
-      "mcp__linear-personal__create_issue"
+      "Bash(bun test:*)"
     ],
     "deny": [],
     "ask": []

--- a/packages/mapgen-core/src/bootstrap/entry.ts
+++ b/packages/mapgen-core/src/bootstrap/entry.ts
@@ -1,14 +1,40 @@
 /**
- * Bootstrap entry point
+ * Bootstrap Entry Point
  *
  * Provides the main `bootstrap()` function that initializes map generation.
- * This module uses lazy loading to avoid crashes when globals are unavailable.
+ * Uses lazy loading to avoid crashes when globals are unavailable.
+ *
+ * Usage (in a map entry file):
+ *   import { bootstrap } from "@swooper/mapgen-core/bootstrap";
+ *   bootstrap({
+ *     presets: ["classic", "temperate"],
+ *     overrides: {
+ *       foundation: { plates: { count: 12 } },
+ *     },
+ *   });
  */
 
 /// <reference types="@civ7/types" />
 
-export interface BootstrapConfig {
-  /** Enable specific generation stages */
+import type { MapConfig } from "./types.js";
+import { setConfig, resetConfig } from "./runtime.js";
+import { resetTunables, rebind as rebindTunables } from "./tunables.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface BootstrapOptions {
+  /** Ordered list of preset names (applied by resolved.js) */
+  presets?: string[];
+  /** Inline overrides applied last (highest precedence) */
+  overrides?: Partial<MapConfig>;
+  /** Stage metadata indicating which stages provide config overrides */
+  stageConfig?: Record<string, boolean>;
+}
+
+export interface BootstrapConfig extends BootstrapOptions {
+  /** Enable specific generation stages (legacy interface) */
   stages?: {
     foundation?: boolean;
     mountains?: boolean;
@@ -17,26 +43,112 @@ export interface BootstrapConfig {
     features?: boolean;
     resources?: boolean;
   };
-  /** Override default configuration values */
-  overrides?: Record<string, unknown>;
 }
 
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return (
+    v != null &&
+    typeof v === "object" &&
+    (Object.getPrototypeOf(v) === Object.prototype || Object.getPrototypeOf(v) === null)
+  );
+}
+
+function clone<T>(v: T): T {
+  if (Array.isArray(v)) return v.slice() as unknown as T;
+  if (isObject(v)) {
+    const o: Record<string, unknown> = {};
+    for (const k of Object.keys(v)) o[k] = v[k];
+    return o as T;
+  }
+  return v;
+}
+
+function deepMerge<T extends object>(base: T, src: Partial<T> | undefined): T {
+  if (!src || !isObject(src)) return clone(base);
+  if (!isObject(base)) return clone(src) as T;
+
+  const out: Record<string, unknown> = {};
+  for (const k of Object.keys(base)) out[k] = clone((base as Record<string, unknown>)[k]);
+  for (const k of Object.keys(src)) {
+    const b = out[k];
+    const s = (src as Record<string, unknown>)[k];
+    if (isObject(b) && isObject(s)) {
+      out[k] = deepMerge(b as object, s as object);
+    } else {
+      out[k] = clone(s);
+    }
+  }
+  return out as T;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
 /**
- * Bootstrap the map generation system
+ * Bootstrap the map generation system.
  *
- * This is called from the mod entry point to initialize generation.
- * It sets up configuration and registers with the game engine.
+ * Composes configuration from presets and overrides, then sets the active
+ * runtime config. This is called from mod entry points.
  */
-export function bootstrap(config: BootstrapConfig = {}): void {
-  console.log("[mapgen-core] Bootstrap called with config:", config);
+export function bootstrap(options: BootstrapConfig = {}): void {
+  // Extract presets
+  const presets =
+    Array.isArray(options.presets) && options.presets.length > 0
+      ? options.presets.filter((n): n is string => typeof n === "string")
+      : undefined;
 
-  // Gate A: Minimal implementation - just log that we're loaded
-  // Full implementation comes in Gate B/C
+  // Extract overrides
+  const overrides =
+    options && typeof options === "object" && options.overrides ? clone(options.overrides) : undefined;
+
+  // Extract stage config
+  const stageConfig =
+    options && typeof options === "object" && options.stageConfig
+      ? clone(options.stageConfig)
+      : undefined;
+
+  // Build config object
+  const cfg: MapConfig = {};
+  if (presets) cfg.presets = presets;
+  if (stageConfig) cfg.stageConfig = stageConfig;
+
+  // Merge overrides (highest precedence)
+  if (overrides) {
+    Object.assign(cfg, deepMerge(cfg, overrides as Partial<MapConfig>));
+  }
+
+  // Store runtime config
+  setConfig(cfg);
+
+  // Rebind tunables to pick up new config
+  rebindTunables();
 }
 
 /**
- * Reset bootstrap state (for testing)
+ * Reset all bootstrap state.
+ * Call this at the start of each generateMap() or in test beforeEach().
  */
 export function resetBootstrap(): void {
-  // Will be implemented when we add lazy providers in CIV-6
+  resetConfig();
+  resetTunables();
 }
+
+/**
+ * Rebind all tunables from current config.
+ * Call this at the start of each generateMap() entry.
+ */
+export function rebind(): void {
+  rebindTunables();
+}
+
+// Re-export types and functions for convenience
+export type { MapConfig } from "./types.js";
+export { setConfig, getConfig, resetConfig } from "./runtime.js";
+export { getTunables, resetTunables, stageEnabled, TUNABLES } from "./tunables.js";
+
+export default { bootstrap, resetBootstrap, rebind };

--- a/packages/mapgen-core/src/bootstrap/runtime.ts
+++ b/packages/mapgen-core/src/bootstrap/runtime.ts
@@ -1,0 +1,99 @@
+/**
+ * Runtime Config Store
+ *
+ * Minimal runtime config store for per-map inline configuration.
+ * Uses lazy initialization to avoid crashes when globals unavailable.
+ *
+ * Usage (in a map entry file):
+ *   import { setConfig } from "./runtime.js";
+ *   setConfig({
+ *     landmass: { ... },
+ *     foundation: { ... },
+ *   });
+ *
+ * Usage (in the orchestrator/generator):
+ *   import { getConfig, resetConfig } from "./runtime.js";
+ *   function generateMap() {
+ *     resetConfig(); // Clear any stale config
+ *     const cfg = getConfig();
+ *     // read cfg.toggles, cfg.landmass, etc.
+ *   }
+ */
+
+import type { MapConfig } from "./types.js";
+
+// ============================================================================
+// Internal State
+// ============================================================================
+
+const GLOBAL_KEY = "__EPIC_MAP_CONFIG__";
+const EMPTY_FROZEN_OBJECT: Readonly<MapConfig> = Object.freeze({});
+
+/** Local fallback store in case globalThis access fails */
+let _localStore: Readonly<MapConfig> = EMPTY_FROZEN_OBJECT;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === "object";
+}
+
+function shallowFreeze<T extends object>(obj: T): Readonly<T> {
+  try {
+    return Object.freeze(obj);
+  } catch {
+    return obj;
+  }
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Store the per-map configuration for this run.
+ * Accepts any plain object. Non-objects are coerced to an empty object.
+ * The stored object is shallow-frozen to prevent accidental mutation.
+ */
+export function setConfig(config: Partial<MapConfig>): void {
+  const obj = isObject(config) ? config : {};
+  const frozen = shallowFreeze(obj) as Readonly<MapConfig>;
+
+  try {
+    // Use a single well-known global key so all modules can access the same config
+    (globalThis as Record<string, unknown>)[GLOBAL_KEY] = frozen;
+  } catch {
+    // In restricted environments, fall back to local static
+    _localStore = frozen;
+  }
+}
+
+/**
+ * Retrieve the current per-map configuration.
+ * Returns an empty frozen object if none was set.
+ */
+export function getConfig(): Readonly<MapConfig> {
+  try {
+    const v = (globalThis as Record<string, unknown>)[GLOBAL_KEY];
+    return isObject(v) ? (v as Readonly<MapConfig>) : EMPTY_FROZEN_OBJECT;
+  } catch {
+    return isObject(_localStore) ? _localStore : EMPTY_FROZEN_OBJECT;
+  }
+}
+
+/**
+ * Reset the runtime config to empty state.
+ * Call this at the start of each generateMap() or in test beforeEach().
+ */
+export function resetConfig(): void {
+  try {
+    (globalThis as Record<string, unknown>)[GLOBAL_KEY] = EMPTY_FROZEN_OBJECT;
+  } catch {
+    // Ignore
+  }
+  _localStore = EMPTY_FROZEN_OBJECT;
+}
+
+export default { setConfig, getConfig, resetConfig };

--- a/packages/mapgen-core/src/bootstrap/tunables.ts
+++ b/packages/mapgen-core/src/bootstrap/tunables.ts
@@ -1,0 +1,280 @@
+/**
+ * Unified Tunables — Lazy loading with memoized provider pattern
+ *
+ * Intent:
+ * - Provide a single import surface for all generator tunables
+ * - Use lazy loading to avoid crashes when globals unavailable
+ * - Provide reset functions for test isolation
+ *
+ * Usage:
+ *   import { getTunables, resetTunables, rebind } from "./tunables.js";
+ *
+ *   // In tests
+ *   beforeEach(() => {
+ *     resetTunables();
+ *   });
+ *
+ *   // In generator
+ *   function generateMap() {
+ *     rebind(); // Refresh config from game state
+ *     const tunables = getTunables();
+ *     // use tunables.LANDMASS_CFG, etc.
+ *   }
+ */
+
+import type {
+  MapConfig,
+  Toggles,
+  LandmassConfig,
+  FoundationConfig,
+  FoundationPlatesConfig,
+  FoundationDynamicsConfig,
+  FoundationDirectionalityConfig,
+  ClimateConfig,
+  StageManifest,
+  StageDescriptor,
+  TunablesSnapshot,
+} from "./types.js";
+import { getConfig } from "./runtime.js";
+
+// ============================================================================
+// Internal State (memoized cache)
+// ============================================================================
+
+let _cache: TunablesSnapshot | null = null;
+
+// ============================================================================
+// Default Values
+// ============================================================================
+
+const EMPTY_OBJECT = Object.freeze({}) as Readonly<Record<string, unknown>>;
+
+const EMPTY_STAGE_MANIFEST: Readonly<StageManifest> = Object.freeze({
+  order: [] as string[],
+  stages: {} as Record<string, StageDescriptor>,
+});
+
+const DEFAULT_TOGGLES: Readonly<Toggles> = Object.freeze({
+  STORY_ENABLE_HOTSPOTS: true,
+  STORY_ENABLE_RIFTS: true,
+  STORY_ENABLE_OROGENY: true,
+  STORY_ENABLE_SWATCHES: true,
+  STORY_ENABLE_PALEO: true,
+  STORY_ENABLE_CORRIDORS: true,
+});
+
+const DEFAULT_LANDMASS: Readonly<LandmassConfig> = Object.freeze({
+  baseWaterPercent: 60,
+});
+
+const DEFAULT_FOUNDATION: Readonly<FoundationConfig> = Object.freeze({});
+
+const DEFAULT_PLATES: Readonly<FoundationPlatesConfig> = Object.freeze({
+  count: 8,
+  relaxationSteps: 5,
+  convergenceMix: 0.5,
+  plateRotationMultiple: 1.0,
+  seedMode: "engine",
+});
+
+const DEFAULT_DYNAMICS: Readonly<FoundationDynamicsConfig> = Object.freeze({
+  mantle: Object.freeze({ bumps: 4, amplitude: 0.6, scale: 0.4 }),
+  wind: Object.freeze({ jetStreaks: 3, jetStrength: 1.0, variance: 0.6 }),
+});
+
+const DEFAULT_DIRECTIONALITY: Readonly<FoundationDirectionalityConfig> = Object.freeze({
+  cohesion: 0,
+});
+
+const DEFAULT_CLIMATE: Readonly<ClimateConfig> = Object.freeze({});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function safeFreeze<T extends object>(obj: T | null | undefined): Readonly<T> {
+  if (!obj || typeof obj !== "object") {
+    return EMPTY_OBJECT as Readonly<T>;
+  }
+  if (Object.isFrozen(obj)) {
+    return obj as Readonly<T>;
+  }
+  return Object.freeze({ ...obj }) as Readonly<T>;
+}
+
+function deepMerge<T extends object>(base: T, override: Partial<T> | undefined): Readonly<T> {
+  if (!override || typeof override !== "object") {
+    return safeFreeze(base);
+  }
+
+  const result = { ...base } as Record<string, unknown>;
+
+  for (const key of Object.keys(override)) {
+    const baseVal = (base as Record<string, unknown>)[key];
+    const overrideVal = (override as Record<string, unknown>)[key];
+
+    if (
+      baseVal &&
+      typeof baseVal === "object" &&
+      !Array.isArray(baseVal) &&
+      overrideVal &&
+      typeof overrideVal === "object" &&
+      !Array.isArray(overrideVal)
+    ) {
+      result[key] = deepMerge(baseVal as object, overrideVal as object);
+    } else if (overrideVal !== undefined) {
+      result[key] = overrideVal;
+    }
+  }
+
+  return Object.freeze(result) as Readonly<T>;
+}
+
+// ============================================================================
+// Core Functions
+// ============================================================================
+
+/**
+ * Build the tunables snapshot from current config.
+ * This is called lazily when getTunables() is first accessed after reset.
+ */
+function buildTunablesSnapshot(): TunablesSnapshot {
+  const config = getConfig();
+
+  // Resolve toggles
+  const togglesConfig = config.toggles || {};
+  const toggleValue = (key: keyof Toggles, fallback: boolean): boolean => {
+    const val = togglesConfig[key];
+    return typeof val === "boolean" ? val : fallback;
+  };
+
+  // Resolve foundation config
+  const foundationConfig = (config.foundation || {}) as FoundationConfig;
+  const platesConfig = deepMerge(DEFAULT_PLATES, foundationConfig.plates);
+  const dynamicsConfig = deepMerge(DEFAULT_DYNAMICS, foundationConfig.dynamics);
+  const directionalityConfig = deepMerge(
+    DEFAULT_DIRECTIONALITY,
+    dynamicsConfig.directionality || foundationConfig.dynamics?.directionality
+  );
+
+  // Resolve stage manifest
+  const manifestConfig = config.stageManifest || {};
+  const stageManifest: Readonly<StageManifest> = Object.freeze({
+    order: (manifestConfig.order || []) as string[],
+    stages: (manifestConfig.stages || {}) as Record<string, StageDescriptor>,
+  });
+
+  return {
+    STAGE_MANIFEST: stageManifest,
+    STORY_ENABLE_HOTSPOTS: toggleValue("STORY_ENABLE_HOTSPOTS", true),
+    STORY_ENABLE_RIFTS: toggleValue("STORY_ENABLE_RIFTS", true),
+    STORY_ENABLE_OROGENY: toggleValue("STORY_ENABLE_OROGENY", true),
+    STORY_ENABLE_SWATCHES: toggleValue("STORY_ENABLE_SWATCHES", true),
+    STORY_ENABLE_PALEO: toggleValue("STORY_ENABLE_PALEO", true),
+    STORY_ENABLE_CORRIDORS: toggleValue("STORY_ENABLE_CORRIDORS", true),
+    LANDMASS_CFG: deepMerge(DEFAULT_LANDMASS, config.landmass as LandmassConfig | undefined),
+    FOUNDATION_CFG: safeFreeze(foundationConfig),
+    FOUNDATION_PLATES: platesConfig,
+    FOUNDATION_DYNAMICS: dynamicsConfig,
+    FOUNDATION_DIRECTIONALITY: directionalityConfig,
+    CLIMATE_CFG: deepMerge(DEFAULT_CLIMATE, config.climate as ClimateConfig | undefined),
+  };
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Get the current tunables snapshot.
+ * Returns cached value if available, otherwise builds from current config.
+ */
+export function getTunables(): Readonly<TunablesSnapshot> {
+  if (_cache) return _cache;
+  _cache = buildTunablesSnapshot();
+  return _cache;
+}
+
+/**
+ * Reset the tunables cache.
+ * Call this at the start of each generateMap() or in test beforeEach().
+ */
+export function resetTunables(): void {
+  _cache = null;
+}
+
+/**
+ * Refresh the tunables from current config.
+ * Alias for resetTunables() + getTunables() for backwards compatibility.
+ */
+export function rebind(): void {
+  resetTunables();
+  getTunables();
+}
+
+/**
+ * Check whether a manifest stage is enabled.
+ */
+export function stageEnabled(stage: string): boolean {
+  const tunables = getTunables();
+  const stages = tunables.STAGE_MANIFEST.stages || {};
+  const entry = stages[stage];
+  return !!(entry && entry.enabled !== false);
+}
+
+// ============================================================================
+// Convenience Exports (for backwards compatibility)
+// ============================================================================
+
+// These are getters that return the current cached value
+// They're defined as functions to maintain live binding semantics
+
+export const TUNABLES = {
+  get STAGE_MANIFEST() {
+    return getTunables().STAGE_MANIFEST;
+  },
+  get STORY_ENABLE_HOTSPOTS() {
+    return getTunables().STORY_ENABLE_HOTSPOTS;
+  },
+  get STORY_ENABLE_RIFTS() {
+    return getTunables().STORY_ENABLE_RIFTS;
+  },
+  get STORY_ENABLE_OROGENY() {
+    return getTunables().STORY_ENABLE_OROGENY;
+  },
+  get STORY_ENABLE_SWATCHES() {
+    return getTunables().STORY_ENABLE_SWATCHES;
+  },
+  get STORY_ENABLE_PALEO() {
+    return getTunables().STORY_ENABLE_PALEO;
+  },
+  get STORY_ENABLE_CORRIDORS() {
+    return getTunables().STORY_ENABLE_CORRIDORS;
+  },
+  get LANDMASS_CFG() {
+    return getTunables().LANDMASS_CFG;
+  },
+  get FOUNDATION_CFG() {
+    return getTunables().FOUNDATION_CFG;
+  },
+  get FOUNDATION_PLATES() {
+    return getTunables().FOUNDATION_PLATES;
+  },
+  get FOUNDATION_DYNAMICS() {
+    return getTunables().FOUNDATION_DYNAMICS;
+  },
+  get FOUNDATION_DIRECTIONALITY() {
+    return getTunables().FOUNDATION_DIRECTIONALITY;
+  },
+  get CLIMATE_CFG() {
+    return getTunables().CLIMATE_CFG;
+  },
+};
+
+export default {
+  getTunables,
+  resetTunables,
+  rebind,
+  stageEnabled,
+  TUNABLES,
+};

--- a/packages/mapgen-core/src/bootstrap/types.ts
+++ b/packages/mapgen-core/src/bootstrap/types.ts
@@ -1,0 +1,213 @@
+/**
+ * Bootstrap Module Types
+ *
+ * Type definitions for configuration and bootstrap system.
+ */
+
+// ============================================================================
+// Runtime Configuration Types
+// ============================================================================
+
+/** Per-map configuration object */
+export interface MapConfig {
+  /** Optional preset names to apply (in order) */
+  presets?: string[];
+  /** Stage configuration providers */
+  stageConfig?: Record<string, boolean>;
+  /** Toggle overrides */
+  toggles?: Partial<Toggles>;
+  /** Landmass configuration */
+  landmass?: Partial<LandmassConfig>;
+  /** Foundation configuration */
+  foundation?: Partial<FoundationConfig>;
+  /** Climate configuration */
+  climate?: Partial<ClimateConfig>;
+  /** Stage manifest */
+  stageManifest?: Partial<StageManifest>;
+  /** Other arbitrary config groups */
+  [key: string]: unknown;
+}
+
+// ============================================================================
+// Toggle Types
+// ============================================================================
+
+export interface Toggles {
+  STORY_ENABLE_HOTSPOTS: boolean;
+  STORY_ENABLE_RIFTS: boolean;
+  STORY_ENABLE_OROGENY: boolean;
+  STORY_ENABLE_SWATCHES: boolean;
+  STORY_ENABLE_PALEO: boolean;
+  STORY_ENABLE_CORRIDORS: boolean;
+  [key: string]: boolean;
+}
+
+// ============================================================================
+// Landmass Types
+// ============================================================================
+
+export interface LandmassConfig {
+  baseWaterPercent?: number;
+  geometry?: LandmassGeometry;
+  [key: string]: unknown;
+}
+
+export interface LandmassGeometry {
+  [key: string]: unknown;
+}
+
+// ============================================================================
+// Foundation Types
+// ============================================================================
+
+export interface FoundationConfig {
+  seed?: FoundationSeedConfig;
+  plates?: FoundationPlatesConfig;
+  dynamics?: FoundationDynamicsConfig;
+  surface?: FoundationSurfaceConfig;
+  policy?: FoundationPolicyConfig;
+  diagnostics?: FoundationDiagnosticsConfig;
+  [key: string]: unknown;
+}
+
+export interface FoundationSeedConfig {
+  mode?: "engine" | "fixed";
+  fixedSeed?: number;
+  offset?: number;
+  [key: string]: unknown;
+}
+
+export interface FoundationPlatesConfig {
+  count?: number;
+  relaxationSteps?: number;
+  convergenceMix?: number;
+  plateRotationMultiple?: number;
+  seedMode?: "engine" | "fixed";
+  fixedSeed?: number;
+  seedOffset?: number;
+  [key: string]: unknown;
+}
+
+export interface FoundationDynamicsConfig {
+  mantle?: {
+    bumps?: number;
+    amplitude?: number;
+    scale?: number;
+  };
+  wind?: {
+    jetStreaks?: number;
+    jetStrength?: number;
+    variance?: number;
+  };
+  directionality?: FoundationDirectionalityConfig;
+  [key: string]: unknown;
+}
+
+export interface FoundationDirectionalityConfig {
+  cohesion?: number;
+  primaryAxes?: {
+    plateAxisDeg?: number;
+    windBiasDeg?: number;
+    currentBiasDeg?: number;
+  };
+  variability?: {
+    angleJitterDeg?: number;
+    magnitudeVariance?: number;
+  };
+  hemispheres?: {
+    southernFlip?: boolean;
+  };
+  interplay?: {
+    windsFollowPlates?: number;
+    currentsFollowWinds?: number;
+  };
+  [key: string]: unknown;
+}
+
+export interface FoundationSurfaceConfig {
+  landmass?: LandmassConfig;
+  oceanSeparation?: FoundationOceanSeparationConfig;
+  [key: string]: unknown;
+}
+
+export interface FoundationPolicyConfig {
+  oceanSeparation?: FoundationOceanSeparationConfig;
+  [key: string]: unknown;
+}
+
+export interface FoundationOceanSeparationConfig {
+  [key: string]: unknown;
+}
+
+export interface FoundationDiagnosticsConfig {
+  [key: string]: unknown;
+}
+
+// ============================================================================
+// Climate Types
+// ============================================================================
+
+export interface ClimateConfig {
+  baseline?: ClimateBaseline;
+  refine?: ClimateRefine;
+  swatches?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface ClimateBaseline {
+  bands?: Record<string, unknown>;
+  blend?: Record<string, unknown>;
+  orographic?: Record<string, unknown>;
+  coastal?: Record<string, unknown>;
+  noise?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface ClimateRefine {
+  waterGradient?: Record<string, unknown>;
+  orographic?: Record<string, unknown>;
+  riverCorridor?: Record<string, unknown>;
+  lowBasin?: Record<string, unknown>;
+  pressure?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+// ============================================================================
+// Stage Manifest Types
+// ============================================================================
+
+export interface StageManifest {
+  order: string[];
+  stages: Record<string, StageDescriptor>;
+}
+
+export interface StageDescriptor {
+  enabled?: boolean;
+  requires?: string[];
+  provides?: string[];
+  legacyToggles?: string[];
+  blockedBy?: string;
+}
+
+export type StageName = string;
+
+// ============================================================================
+// Tunables Snapshot Types
+// ============================================================================
+
+export interface TunablesSnapshot {
+  STAGE_MANIFEST: Readonly<StageManifest>;
+  STORY_ENABLE_HOTSPOTS: boolean;
+  STORY_ENABLE_RIFTS: boolean;
+  STORY_ENABLE_OROGENY: boolean;
+  STORY_ENABLE_SWATCHES: boolean;
+  STORY_ENABLE_PALEO: boolean;
+  STORY_ENABLE_CORRIDORS: boolean;
+  LANDMASS_CFG: Readonly<LandmassConfig>;
+  FOUNDATION_CFG: Readonly<FoundationConfig>;
+  FOUNDATION_PLATES: Readonly<FoundationPlatesConfig>;
+  FOUNDATION_DYNAMICS: Readonly<FoundationDynamicsConfig>;
+  FOUNDATION_DIRECTIONALITY: Readonly<FoundationDirectionalityConfig>;
+  CLIMATE_CFG: Readonly<ClimateConfig>;
+  [key: string]: unknown;
+}

--- a/packages/mapgen-core/test/bootstrap/entry.test.ts
+++ b/packages/mapgen-core/test/bootstrap/entry.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Bootstrap Entry Tests
+ *
+ * Tests for bootstrap/resetBootstrap/rebind functions.
+ * Key acceptance criteria: importing @swooper/mapgen-core/bootstrap does NOT crash without globals.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  bootstrap,
+  resetBootstrap,
+  rebind,
+  getConfig,
+  getTunables,
+  resetTunables,
+} from "../../src/bootstrap/entry.js";
+
+describe("bootstrap/entry", () => {
+  beforeEach(() => {
+    resetBootstrap();
+  });
+
+  describe("import safety", () => {
+    it("can be imported without globals available", () => {
+      // This test passes if the import at the top of this file succeeded
+      expect(bootstrap).toBeDefined();
+      expect(resetBootstrap).toBeDefined();
+      expect(rebind).toBeDefined();
+    });
+
+    it("functions are callable without game engine globals", () => {
+      // Should not throw even without RandomImpl, etc.
+      expect(() => bootstrap()).not.toThrow();
+      expect(() => resetBootstrap()).not.toThrow();
+      expect(() => rebind()).not.toThrow();
+    });
+  });
+
+  describe("bootstrap", () => {
+    it("accepts empty options", () => {
+      expect(() => bootstrap()).not.toThrow();
+      expect(() => bootstrap({})).not.toThrow();
+    });
+
+    it("stores presets in config", () => {
+      bootstrap({ presets: ["classic", "temperate"] });
+
+      const config = getConfig();
+      expect(config.presets).toEqual(["classic", "temperate"]);
+    });
+
+    it("stores overrides in config", () => {
+      bootstrap({
+        overrides: {
+          foundation: { plates: { count: 12 } },
+        },
+      });
+
+      const config = getConfig();
+      expect(config.foundation?.plates?.count).toBe(12);
+    });
+
+    it("stores stageConfig in config", () => {
+      bootstrap({
+        stageConfig: {
+          foundation: true,
+          climate: false,
+        },
+      });
+
+      const config = getConfig();
+      expect(config.stageConfig?.foundation).toBe(true);
+      expect(config.stageConfig?.climate).toBe(false);
+    });
+
+    it("triggers tunables rebind", () => {
+      // Get tunables with defaults
+      const before = getTunables();
+      expect(before.FOUNDATION_PLATES.count).toBe(8);
+
+      // Bootstrap with override
+      bootstrap({
+        overrides: {
+          foundation: { plates: { count: 16 } },
+        },
+      });
+
+      const after = getTunables();
+      expect(after.FOUNDATION_PLATES.count).toBe(16);
+    });
+
+    it("filters invalid preset values", () => {
+      bootstrap({
+        presets: ["valid", 123 as unknown as string, null as unknown as string, "another"],
+      });
+
+      const config = getConfig();
+      expect(config.presets).toEqual(["valid", "another"]);
+    });
+  });
+
+  describe("resetBootstrap", () => {
+    it("resets config and tunables", () => {
+      bootstrap({
+        presets: ["test"],
+        overrides: { toggles: { STORY_ENABLE_HOTSPOTS: false } },
+      });
+
+      resetBootstrap();
+
+      const config = getConfig();
+      const tunables = getTunables();
+
+      expect(config.presets).toBeUndefined();
+      expect(tunables.STORY_ENABLE_HOTSPOTS).toBe(true);
+    });
+
+    it("allows fresh bootstrap after reset", () => {
+      bootstrap({ presets: ["first"] });
+      resetBootstrap();
+      bootstrap({ presets: ["second"] });
+
+      const config = getConfig();
+      expect(config.presets).toEqual(["second"]);
+    });
+  });
+
+  describe("rebind", () => {
+    it("refreshes tunables from current config", () => {
+      bootstrap({ overrides: { landmass: { baseWaterPercent: 50 } } });
+
+      const tunables = getTunables();
+      expect(tunables.LANDMASS_CFG.baseWaterPercent).toBe(50);
+    });
+
+    it("can be called multiple times", () => {
+      expect(() => {
+        rebind();
+        rebind();
+        rebind();
+      }).not.toThrow();
+    });
+  });
+
+  describe("integration", () => {
+    it("full bootstrap -> rebind -> reset cycle", () => {
+      // Initial state
+      expect(getTunables().FOUNDATION_PLATES.count).toBe(8);
+
+      // Bootstrap with overrides
+      bootstrap({
+        presets: ["continent"],
+        overrides: {
+          foundation: { plates: { count: 10 } },
+          toggles: { STORY_ENABLE_OROGENY: false },
+        },
+      });
+
+      expect(getConfig().presets).toEqual(["continent"]);
+      expect(getTunables().FOUNDATION_PLATES.count).toBe(10);
+      expect(getTunables().STORY_ENABLE_OROGENY).toBe(false);
+
+      // Rebind (should maintain state)
+      rebind();
+      expect(getTunables().FOUNDATION_PLATES.count).toBe(10);
+
+      // Reset
+      resetBootstrap();
+      expect(getConfig().presets).toBeUndefined();
+      expect(getTunables().FOUNDATION_PLATES.count).toBe(8);
+      expect(getTunables().STORY_ENABLE_OROGENY).toBe(true);
+    });
+  });
+
+  describe("test isolation", () => {
+    it("starts clean in each test", () => {
+      const config = getConfig();
+      const tunables = getTunables();
+
+      expect(config.presets).toBeUndefined();
+      expect(tunables.FOUNDATION_PLATES.count).toBe(8);
+      expect(tunables.STORY_ENABLE_HOTSPOTS).toBe(true);
+    });
+  });
+});

--- a/packages/mapgen-core/test/bootstrap/runtime.test.ts
+++ b/packages/mapgen-core/test/bootstrap/runtime.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Bootstrap Runtime Tests
+ *
+ * Tests for setConfig/getConfig/resetConfig functions.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { setConfig, getConfig, resetConfig } from "../../src/bootstrap/runtime.js";
+import type { MapConfig } from "../../src/bootstrap/types.js";
+
+describe("bootstrap/runtime", () => {
+  beforeEach(() => {
+    resetConfig();
+  });
+
+  describe("getConfig", () => {
+    it("returns empty object by default", () => {
+      const config = getConfig();
+      expect(config).toBeDefined();
+      expect(typeof config).toBe("object");
+    });
+
+    it("returns the same object on repeated calls", () => {
+      const config1 = getConfig();
+      const config2 = getConfig();
+      expect(config1).toBe(config2);
+    });
+  });
+
+  describe("setConfig", () => {
+    it("sets config that can be retrieved", () => {
+      const testConfig: MapConfig = {
+        presets: ["classic"],
+        toggles: { STORY_ENABLE_HOTSPOTS: false },
+      };
+
+      setConfig(testConfig);
+      const config = getConfig();
+
+      expect(config.presets).toEqual(["classic"]);
+      expect(config.toggles?.STORY_ENABLE_HOTSPOTS).toBe(false);
+    });
+
+    it("replaces previous config entirely", () => {
+      setConfig({ presets: ["first"] });
+      setConfig({ presets: ["second"] });
+
+      const config = getConfig();
+      expect(config.presets).toEqual(["second"]);
+    });
+
+    it("accepts partial config", () => {
+      setConfig({ landmass: { baseWaterPercent: 70 } });
+      const config = getConfig();
+      expect(config.landmass?.baseWaterPercent).toBe(70);
+    });
+  });
+
+  describe("resetConfig", () => {
+    it("resets config to empty state", () => {
+      setConfig({ presets: ["test"] });
+      resetConfig();
+      const config = getConfig();
+      expect(config.presets).toBeUndefined();
+    });
+
+    it("allows new config after reset", () => {
+      setConfig({ presets: ["first"] });
+      resetConfig();
+      setConfig({ presets: ["second"] });
+      const config = getConfig();
+      expect(config.presets).toEqual(["second"]);
+    });
+  });
+
+  describe("isolation", () => {
+    it("does not share state between resets", () => {
+      setConfig({ toggles: { STORY_ENABLE_RIFTS: false } });
+      const config1 = getConfig();
+
+      resetConfig();
+      const config2 = getConfig();
+
+      expect(config1.toggles?.STORY_ENABLE_RIFTS).toBe(false);
+      expect(config2.toggles).toBeUndefined();
+    });
+  });
+});

--- a/packages/mapgen-core/test/bootstrap/tunables.test.ts
+++ b/packages/mapgen-core/test/bootstrap/tunables.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Bootstrap Tunables Tests
+ *
+ * Tests for getTunables/resetTunables/rebind/stageEnabled functions.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { setConfig, resetConfig } from "../../src/bootstrap/runtime.js";
+import {
+  getTunables,
+  resetTunables,
+  rebind,
+  stageEnabled,
+  TUNABLES,
+} from "../../src/bootstrap/tunables.js";
+
+describe("bootstrap/tunables", () => {
+  beforeEach(() => {
+    resetConfig();
+    resetTunables();
+  });
+
+  describe("getTunables", () => {
+    it("returns default tunables without config", () => {
+      const tunables = getTunables();
+
+      expect(tunables).toBeDefined();
+      expect(tunables.STORY_ENABLE_HOTSPOTS).toBe(true);
+      expect(tunables.STORY_ENABLE_RIFTS).toBe(true);
+      expect(tunables.STORY_ENABLE_OROGENY).toBe(true);
+      expect(tunables.STORY_ENABLE_SWATCHES).toBe(true);
+      expect(tunables.STORY_ENABLE_PALEO).toBe(true);
+      expect(tunables.STORY_ENABLE_CORRIDORS).toBe(true);
+    });
+
+    it("returns cached value on repeated calls", () => {
+      const tunables1 = getTunables();
+      const tunables2 = getTunables();
+      expect(tunables1).toBe(tunables2);
+    });
+
+    it("includes default foundation plates config", () => {
+      const tunables = getTunables();
+
+      expect(tunables.FOUNDATION_PLATES).toBeDefined();
+      expect(tunables.FOUNDATION_PLATES.count).toBe(8);
+      expect(tunables.FOUNDATION_PLATES.relaxationSteps).toBe(5);
+      expect(tunables.FOUNDATION_PLATES.convergenceMix).toBe(0.5);
+      expect(tunables.FOUNDATION_PLATES.plateRotationMultiple).toBe(1.0);
+      expect(tunables.FOUNDATION_PLATES.seedMode).toBe("engine");
+    });
+
+    it("includes default foundation dynamics config", () => {
+      const tunables = getTunables();
+
+      expect(tunables.FOUNDATION_DYNAMICS).toBeDefined();
+      expect(tunables.FOUNDATION_DYNAMICS.mantle?.bumps).toBe(4);
+      expect(tunables.FOUNDATION_DYNAMICS.wind?.jetStreaks).toBe(3);
+    });
+
+    it("includes default landmass config", () => {
+      const tunables = getTunables();
+
+      expect(tunables.LANDMASS_CFG).toBeDefined();
+      expect(tunables.LANDMASS_CFG.baseWaterPercent).toBe(60);
+    });
+  });
+
+  describe("config overrides", () => {
+    it("respects toggle overrides", () => {
+      setConfig({ toggles: { STORY_ENABLE_HOTSPOTS: false } });
+      rebind();
+
+      const tunables = getTunables();
+      expect(tunables.STORY_ENABLE_HOTSPOTS).toBe(false);
+      expect(tunables.STORY_ENABLE_RIFTS).toBe(true); // default
+    });
+
+    it("merges foundation plates config", () => {
+      setConfig({ foundation: { plates: { count: 12 } } });
+      rebind();
+
+      const tunables = getTunables();
+      expect(tunables.FOUNDATION_PLATES.count).toBe(12);
+      expect(tunables.FOUNDATION_PLATES.relaxationSteps).toBe(5); // default preserved
+    });
+
+    it("merges foundation dynamics config", () => {
+      setConfig({
+        foundation: {
+          dynamics: {
+            mantle: { bumps: 6 },
+          },
+        },
+      });
+      rebind();
+
+      const tunables = getTunables();
+      expect(tunables.FOUNDATION_DYNAMICS.mantle?.bumps).toBe(6);
+      expect(tunables.FOUNDATION_DYNAMICS.wind?.jetStreaks).toBe(3); // default
+    });
+
+    it("merges landmass config", () => {
+      setConfig({ landmass: { baseWaterPercent: 75 } });
+      rebind();
+
+      const tunables = getTunables();
+      expect(tunables.LANDMASS_CFG.baseWaterPercent).toBe(75);
+    });
+  });
+
+  describe("resetTunables", () => {
+    it("clears the cached tunables", () => {
+      const tunables1 = getTunables();
+      resetTunables();
+      const tunables2 = getTunables();
+
+      expect(tunables1).not.toBe(tunables2);
+    });
+
+    it("allows new config to take effect", () => {
+      getTunables(); // Cache with defaults
+
+      setConfig({ toggles: { STORY_ENABLE_PALEO: false } });
+      resetTunables();
+
+      const tunables = getTunables();
+      expect(tunables.STORY_ENABLE_PALEO).toBe(false);
+    });
+  });
+
+  describe("rebind", () => {
+    it("refreshes tunables from current config", () => {
+      getTunables(); // Cache with defaults
+
+      setConfig({ foundation: { plates: { count: 16 } } });
+      rebind();
+
+      const tunables = getTunables();
+      expect(tunables.FOUNDATION_PLATES.count).toBe(16);
+    });
+
+    it("returns fresh instance after rebind", () => {
+      const tunables1 = getTunables();
+      rebind();
+      const tunables2 = getTunables();
+
+      // After rebind, should be the same (rebind caches)
+      expect(tunables2).toBeDefined();
+    });
+  });
+
+  describe("stageEnabled", () => {
+    it("returns false for unknown stages", () => {
+      expect(stageEnabled("unknown_stage")).toBe(false);
+    });
+
+    it("returns true for enabled stages in manifest", () => {
+      setConfig({
+        stageManifest: {
+          order: ["foundation", "climate"],
+          stages: {
+            foundation: { enabled: true },
+            climate: { enabled: true },
+          },
+        },
+      });
+      rebind();
+
+      expect(stageEnabled("foundation")).toBe(true);
+      expect(stageEnabled("climate")).toBe(true);
+    });
+
+    it("returns false for disabled stages in manifest", () => {
+      setConfig({
+        stageManifest: {
+          order: ["foundation"],
+          stages: {
+            foundation: { enabled: false },
+          },
+        },
+      });
+      rebind();
+
+      expect(stageEnabled("foundation")).toBe(false);
+    });
+  });
+
+  describe("TUNABLES proxy object", () => {
+    it("provides live access to current tunables", () => {
+      expect(TUNABLES.STORY_ENABLE_HOTSPOTS).toBe(true);
+
+      setConfig({ toggles: { STORY_ENABLE_HOTSPOTS: false } });
+      rebind();
+
+      expect(TUNABLES.STORY_ENABLE_HOTSPOTS).toBe(false);
+    });
+
+    it("reflects reset state", () => {
+      setConfig({ toggles: { STORY_ENABLE_RIFTS: false } });
+      rebind();
+      expect(TUNABLES.STORY_ENABLE_RIFTS).toBe(false);
+
+      resetConfig();
+      resetTunables();
+      expect(TUNABLES.STORY_ENABLE_RIFTS).toBe(true);
+    });
+  });
+
+  describe("isolation", () => {
+    it("does not leak state between tests", () => {
+      const tunables = getTunables();
+      expect(tunables.STORY_ENABLE_HOTSPOTS).toBe(true);
+      expect(tunables.FOUNDATION_PLATES.count).toBe(8);
+    });
+  });
+});


### PR DESCRIPTION
Implements lazy provider pattern for bootstrap module to avoid import-time
crashes when game engine globals are unavailable.

Changes:
- Add types.ts with MapConfig, Toggles, Foundation, Climate types
- Add runtime.ts with setConfig/getConfig/resetConfig for config store
- Add tunables.ts with getTunables/resetTunables/rebind for lazy loading
- Update entry.ts with bootstrap/resetBootstrap/rebind API
- Add comprehensive tests for all modules (41 tests)

Key improvements:
- Import @swooper/mapgen-core/bootstrap does NOT crash without globals
- reset*() functions enable test isolation between beforeEach() calls
- Memoized provider pattern avoids repeated config resolution
- Deep merge preserves defaults while allowing selective overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>