### PR TITLE
feat(mapgen-core): migrate landmass and terrain layers (CIV-11)

### DIFF
--- a/packages/mapgen-core/src/bootstrap/types.ts
+++ b/packages/mapgen-core/src/bootstrap/types.ts
@@ -46,13 +46,59 @@ export interface Toggles {
 // Landmass Types
 // ============================================================================
 
-export interface LandmassConfig {
-  baseWaterPercent?: number;
-  geometry?: LandmassGeometry;
+/** Tectonic noise configuration for landmass generation */
+export interface LandmassTectonicsConfig {
+  /** Weight for plate interior noise (0-1) */
+  interiorNoiseWeight?: number;
+  /** Weight for boundary arc influence (0-2) */
+  boundaryArcWeight?: number;
+  /** Noise weight for boundary arc (0-1) */
+  boundaryArcNoiseWeight?: number;
+  /** Fractal grain size (1-32) */
+  fractalGrain?: number;
+}
+
+/** Geometry post-processing configuration */
+export interface LandmassGeometryPost {
+  /** Tiles to expand all sides */
+  expandTiles?: number;
+  /** Tiles to expand west side */
+  expandWestTiles?: number;
+  /** Tiles to expand east side */
+  expandEastTiles?: number;
+  /** Minimum west boundary clamp */
+  clampWestMin?: number;
+  /** Maximum east boundary clamp */
+  clampEastMax?: number;
+  /** Override south boundary */
+  overrideSouth?: number;
+  /** Override north boundary */
+  overrideNorth?: number;
+  /** Minimum width in tiles */
+  minWidthTiles?: number;
+}
+
+/** Landmass geometry configuration */
+export interface LandmassGeometry {
+  /** Post-processing adjustments */
+  post?: LandmassGeometryPost;
   [key: string]: unknown;
 }
 
-export interface LandmassGeometry {
+/** Landmass generation configuration */
+export interface LandmassConfig {
+  /** Base water percentage (0-100) */
+  baseWaterPercent?: number;
+  /** Water scalar multiplier (0.25-1.75) */
+  waterScalar?: number;
+  /** Boundary bias for land placement (0-0.4) */
+  boundaryBias?: number;
+  /** Target share of land on boundaries (0-1) */
+  boundaryShareTarget?: number;
+  /** Tectonic noise configuration */
+  tectonics?: LandmassTectonicsConfig;
+  /** Geometry configuration */
+  geometry?: LandmassGeometry;
   [key: string]: unknown;
 }
 
@@ -67,6 +113,20 @@ export interface FoundationConfig {
   surface?: FoundationSurfaceConfig;
   policy?: FoundationPolicyConfig;
   diagnostics?: FoundationDiagnosticsConfig;
+  /** Ocean separation policy */
+  oceanSeparation?: OceanSeparationConfig;
+  /** Coastlines layer configuration */
+  coastlines?: CoastlinesConfig;
+  /** Islands layer configuration */
+  islands?: IslandsConfig;
+  /** Mountains layer configuration */
+  mountains?: MountainsConfig;
+  /** Volcanoes layer configuration */
+  volcanoes?: VolcanoesConfig;
+  /** Story system configuration */
+  story?: StoryConfig;
+  /** Corridor policy configuration */
+  corridors?: CorridorsConfig;
   [key: string]: unknown;
 }
 
@@ -140,6 +200,162 @@ export interface FoundationOceanSeparationConfig {
 }
 
 export interface FoundationDiagnosticsConfig {
+  [key: string]: unknown;
+}
+
+// ============================================================================
+// Ocean Separation Types
+// ============================================================================
+
+/** Ocean separation edge policy */
+export interface OceanSeparationEdgePolicy {
+  enabled?: boolean;
+  baseTiles?: number;
+  boundaryClosenessMultiplier?: number;
+  maxPerRowDelta?: number;
+}
+
+/** Ocean separation policy configuration */
+export interface OceanSeparationConfig {
+  enabled?: boolean;
+  bandPairs?: Array<[number, number]>;
+  baseSeparationTiles?: number;
+  boundaryClosenessMultiplier?: number;
+  maxPerRowDelta?: number;
+  edgeWest?: OceanSeparationEdgePolicy;
+  edgeEast?: OceanSeparationEdgePolicy;
+}
+
+// ============================================================================
+// Coastlines Types
+// ============================================================================
+
+/** Coastline plate bias configuration */
+export interface CoastlinePlateBiasConfig {
+  threshold?: number;
+  power?: number;
+  convergent?: number;
+  transform?: number;
+  divergent?: number;
+  interior?: number;
+  bayWeight?: number;
+  bayNoiseBonus?: number;
+  fjordWeight?: number;
+}
+
+/** Bay carving configuration */
+export interface CoastlineBayConfig {
+  noiseGateAdd?: number;
+  rollDenActive?: number;
+  rollDenDefault?: number;
+}
+
+/** Fjord generation configuration */
+export interface CoastlineFjordConfig {
+  baseDenom?: number;
+  activeBonus?: number;
+  passiveBonus?: number;
+}
+
+/** Coastlines layer configuration */
+export interface CoastlinesConfig {
+  bay?: CoastlineBayConfig;
+  fjord?: CoastlineFjordConfig;
+  plateBias?: CoastlinePlateBiasConfig;
+  minSeaLaneWidth?: number;
+}
+
+// ============================================================================
+// Islands Types
+// ============================================================================
+
+/** Islands layer configuration */
+export interface IslandsConfig {
+  fractalThresholdPercent?: number;
+  minDistFromLandRadius?: number;
+  baseIslandDenNearActive?: number;
+  baseIslandDenElse?: number;
+  hotspotSeedDenom?: number;
+  clusterMax?: number;
+}
+
+// ============================================================================
+// Mountains Types
+// ============================================================================
+
+/** Mountains layer configuration */
+export interface MountainsConfig {
+  tectonicIntensity?: number;
+  mountainThreshold?: number;
+  hillThreshold?: number;
+  upliftWeight?: number;
+  fractalWeight?: number;
+  riftDepth?: number;
+  boundaryWeight?: number;
+  boundaryExponent?: number;
+  interiorPenaltyWeight?: number;
+  convergenceBonus?: number;
+  transformPenalty?: number;
+  riftPenalty?: number;
+  hillBoundaryWeight?: number;
+  hillRiftBonus?: number;
+  hillConvergentFoothill?: number;
+  hillInteriorFalloff?: number;
+  hillUpliftWeight?: number;
+}
+
+// ============================================================================
+// Volcanoes Types
+// ============================================================================
+
+/** Volcanoes layer configuration */
+export interface VolcanoesConfig {
+  enabled?: boolean;
+  baseDensity?: number;
+  minSpacing?: number;
+  boundaryThreshold?: number;
+  boundaryWeight?: number;
+  convergentMultiplier?: number;
+  transformMultiplier?: number;
+  divergentMultiplier?: number;
+  hotspotWeight?: number;
+  shieldPenalty?: number;
+  randomJitter?: number;
+  minVolcanoes?: number;
+  maxVolcanoes?: number;
+}
+
+// ============================================================================
+// Story Types
+// ============================================================================
+
+/** Hotspot story tunables */
+export interface HotspotTunables {
+  paradiseBias?: number;
+  volcanicBias?: number;
+  volcanicPeakChance?: number;
+}
+
+/** Story system configuration */
+export interface StoryConfig {
+  hotspot?: HotspotTunables;
+  [key: string]: unknown;
+}
+
+// ============================================================================
+// Corridors Types
+// ============================================================================
+
+/** Sea corridor policy */
+export interface SeaCorridorPolicy {
+  protection?: "hard" | "soft";
+  softChanceMultiplier?: number;
+  avoidRadius?: number;
+}
+
+/** Corridors configuration */
+export interface CorridorsConfig {
+  sea?: SeaCorridorPolicy;
   [key: string]: unknown;
 }
 

--- a/packages/mapgen-core/src/layers/coastlines.ts
+++ b/packages/mapgen-core/src/layers/coastlines.ts
@@ -1,0 +1,365 @@
+/**
+ * Coastlines Layer — addRuggedCoasts
+ *
+ * Light-touch coastal reshaping that carves occasional bays and creates sparse
+ * fjord-like peninsulas while preserving open sea lanes. Uses a low-frequency
+ * fractal mask and conservative randomness to avoid chokepoint proliferation.
+ */
+
+import type { ExtendedMapContext } from "../core/types.js";
+import type { EngineAdapter } from "@civ7/adapter";
+import type {
+  CoastlinesConfig as BootstrapCoastlinesConfig,
+  CoastlinePlateBiasConfig as BootstrapCoastlinePlateBiasConfig,
+  CoastlineBayConfig as BootstrapCoastlineBayConfig,
+  CoastlineFjordConfig as BootstrapCoastlineFjordConfig,
+  SeaCorridorPolicy as BootstrapSeaCorridorPolicy,
+  CorridorsConfig,
+} from "../bootstrap/types.js";
+import { ctxRandom, writeHeightfield } from "../core/types.js";
+import { WorldModel, BOUNDARY_TYPE } from "../world/model.js";
+import { getStoryTags } from "../story/tags.js";
+import { getTunables } from "../bootstrap/tunables.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+// Re-export canonical types
+export type CoastlinePlateBiasConfig = BootstrapCoastlinePlateBiasConfig;
+export type CoastlineBayConfig = BootstrapCoastlineBayConfig;
+export type CoastlineFjordConfig = BootstrapCoastlineFjordConfig;
+export type SeaCorridorPolicy = BootstrapSeaCorridorPolicy;
+export type CoastlinesConfig = BootstrapCoastlinesConfig;
+
+/** Corridor policy configuration (uses canonical CorridorsConfig) */
+export type CorridorPolicy = CorridorsConfig;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const HILL_FRACTAL = 1;
+const COAST_TERRAIN = 1;
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function clamp(v: number, lo: number, hi: number): number {
+  if (v < lo) return lo;
+  if (v > hi) return hi;
+  return v;
+}
+
+function computePlateBias(
+  closenessNorm: number | null | undefined,
+  boundaryType: number,
+  cfg: Required<CoastlinePlateBiasConfig>
+): number {
+  let cn = closenessNorm;
+  if (cn == null || Number.isNaN(cn)) cn = 0;
+
+  const threshold = cfg.threshold;
+  const power = cfg.power;
+  let weight = 0;
+
+  if (cn >= threshold) {
+    const span = Math.max(1e-3, 1 - threshold);
+    const normalized = clamp((cn - threshold) / span, 0, 1);
+    const ramp = Math.pow(normalized, power);
+
+    let typeMul = 0;
+    if (boundaryType === BOUNDARY_TYPE.convergent) typeMul = cfg.convergent;
+    else if (boundaryType === BOUNDARY_TYPE.transform) typeMul = cfg.transform;
+    else if (boundaryType === BOUNDARY_TYPE.divergent) typeMul = cfg.divergent;
+
+    weight = ramp * typeMul;
+  } else if (cfg.interior !== 0 && threshold > 0) {
+    const normalized = clamp(1 - cn / threshold, 0, 1);
+    weight = Math.pow(normalized, power) * cfg.interior;
+  }
+
+  return weight;
+}
+
+// ============================================================================
+// Main Function
+// ============================================================================
+
+/**
+ * Ruggedize coasts in a sparse, performance-friendly pass.
+ * - Occasionally converts coastal land to shallow water (bays).
+ * - Occasionally converts adjacent ocean to coast (peninsulas/fjords).
+ * - Only operates near current coastlines; does not perform heavy flood fills.
+ *
+ * @param iWidth - Map width
+ * @param iHeight - Map height
+ * @param ctx - Optional MapContext for adapter-based operations
+ */
+export function addRuggedCoasts(
+  iWidth: number,
+  iHeight: number,
+  ctx?: ExtendedMapContext | null
+): void {
+  const adapter = ctx?.adapter;
+
+  // Size-aware modifiers
+  const area = Math.max(1, iWidth * iHeight);
+  const sqrtScale = Math.min(2.0, Math.max(0.6, Math.sqrt(area / 10000)));
+
+  // Create fractal for noise mask
+  if (adapter?.createFractal) {
+    adapter.createFractal(HILL_FRACTAL, iWidth, iHeight, 4, 0);
+  }
+
+  // WorldModel integration
+  const worldModelEnabled = WorldModel.isEnabled();
+  const boundaryCloseness = worldModelEnabled ? WorldModel.boundaryCloseness : null;
+  const boundaryType = worldModelEnabled ? WorldModel.boundaryType : null;
+
+  // Configuration
+  const tunables = getTunables();
+  const cfg = (tunables.FOUNDATION_CFG?.coastlines as CoastlinesConfig) || {};
+  const cfgBay = cfg.bay || {};
+  const cfgFjord = cfg.fjord || {};
+
+  const bayNoiseExtra =
+    (sqrtScale > 1 ? 1 : 0) + (Number.isFinite(cfgBay.noiseGateAdd) ? cfgBay.noiseGateAdd! : 0);
+  const fjordBaseDenom = Math.max(
+    6,
+    (Number.isFinite(cfgFjord.baseDenom) ? cfgFjord.baseDenom! : 12) - (sqrtScale > 1.3 ? 1 : 0)
+  );
+  const fjordActiveBonus = Number.isFinite(cfgFjord.activeBonus) ? cfgFjord.activeBonus! : 1;
+  const fjordPassiveBonus = Number.isFinite(cfgFjord.passiveBonus) ? cfgFjord.passiveBonus! : 2;
+  const bayRollDenActive = Number.isFinite(cfgBay.rollDenActive) ? cfgBay.rollDenActive! : 4;
+  const bayRollDenDefault = Number.isFinite(cfgBay.rollDenDefault) ? cfgBay.rollDenDefault! : 5;
+
+  const plateBiasRaw = cfg.plateBias || {};
+  const plateBiasCfg: Required<CoastlinePlateBiasConfig> = {
+    threshold: clamp(Number.isFinite(plateBiasRaw.threshold) ? plateBiasRaw.threshold! : 0.45, 0, 1),
+    power: Math.max(0.1, Number.isFinite(plateBiasRaw.power) ? plateBiasRaw.power! : 1.25),
+    convergent: Number.isFinite(plateBiasRaw.convergent) ? plateBiasRaw.convergent! : 1.0,
+    transform: Number.isFinite(plateBiasRaw.transform) ? plateBiasRaw.transform! : 0.4,
+    divergent: Number.isFinite(plateBiasRaw.divergent) ? plateBiasRaw.divergent! : -0.6,
+    interior: Number.isFinite(plateBiasRaw.interior) ? plateBiasRaw.interior! : 0,
+    bayWeight: Math.max(0, Number.isFinite(plateBiasRaw.bayWeight) ? plateBiasRaw.bayWeight! : 0.35),
+    bayNoiseBonus: Math.max(
+      0,
+      Number.isFinite(plateBiasRaw.bayNoiseBonus) ? plateBiasRaw.bayNoiseBonus! : 1.0
+    ),
+    fjordWeight: Math.max(
+      0,
+      Number.isFinite(plateBiasRaw.fjordWeight) ? plateBiasRaw.fjordWeight! : 0.8
+    ),
+  };
+
+  // Corridor policy
+  const corridorPolicy = (tunables.FOUNDATION_CFG?.corridors as CorridorPolicy) || {};
+  const seaPolicy = corridorPolicy.sea || {};
+  const SEA_PROTECTION = seaPolicy.protection || "hard";
+  const SOFT_MULT = Math.max(0, Math.min(1, seaPolicy.softChanceMultiplier ?? 0.5));
+
+  // Story tags
+  const StoryTags = getStoryTags();
+
+  const applyTerrain = (x: number, y: number, terrain: number, isLand: boolean): void => {
+    if (ctx) {
+      writeHeightfield(ctx, x, y, { terrain, isLand });
+    } else if (adapter) {
+      adapter.setTerrainType(x, y, terrain);
+    }
+  };
+
+  const isCoastalLand = (x: number, y: number): boolean => {
+    if (!adapter) return false;
+    if (adapter.isWater(x, y)) return false;
+    // Check adjacent tiles for water
+    for (let dy = -1; dy <= 1; dy++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        if (dx === 0 && dy === 0) continue;
+        const nx = x + dx;
+        const ny = y + dy;
+        if (nx >= 0 && nx < iWidth && ny >= 0 && ny < iHeight) {
+          if (adapter.isWater(nx, ny)) return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  const isAdjacentToLand = (x: number, y: number, radius: number): boolean => {
+    if (!adapter) return false;
+    for (let dy = -radius; dy <= radius; dy++) {
+      for (let dx = -radius; dx <= radius; dx++) {
+        if (dx === 0 && dy === 0) continue;
+        const nx = x + dx;
+        const ny = y + dy;
+        if (nx >= 0 && nx < iWidth && ny >= 0 && ny < iHeight) {
+          if (!adapter.isWater(nx, ny)) return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  const getRandom = (label: string, max: number): number => {
+    if (ctx) {
+      return ctxRandom(ctx, label, max);
+    }
+    if (adapter) {
+      return adapter.getRandomNumber(max, label);
+    }
+    return Math.floor(Math.random() * max);
+  };
+
+  const getFractalHeight = (x: number, y: number): number => {
+    if (adapter?.getFractalHeight) {
+      return adapter.getFractalHeight(HILL_FRACTAL, x, y);
+    }
+    return 0;
+  };
+
+  for (let y = 1; y < iHeight - 1; y++) {
+    for (let x = 1; x < iWidth - 1; x++) {
+      // Sea-lane policy check
+      const tileKey = `${x},${y}`;
+      const onSeaLane = StoryTags.corridorSeaLane?.has(tileKey) ?? false;
+      const softMult = onSeaLane && SEA_PROTECTION === "soft" ? SOFT_MULT : 1;
+
+      if (onSeaLane && SEA_PROTECTION === "hard") {
+        continue;
+      }
+
+      // Carve bays: coastal land -> coast water
+      if (isCoastalLand(x, y)) {
+        const h = getFractalHeight(x, y);
+
+        // Plate boundary integration
+        const i = y * iWidth + x;
+        const closenessByte = boundaryCloseness ? boundaryCloseness[i] | 0 : 0;
+        const closenessNorm = closenessByte / 255;
+        const bType = boundaryType ? boundaryType[i] | 0 : BOUNDARY_TYPE.none;
+        const nearBoundary = closenessNorm >= plateBiasCfg.threshold;
+        const plateBiasValue = boundaryCloseness
+          ? computePlateBias(closenessNorm, bType, plateBiasCfg)
+          : 0;
+
+        // Margin-aware bay carving
+        const isActive = StoryTags.activeMargin?.has(tileKey) || nearBoundary;
+        const noiseGateBonus =
+          plateBiasValue > 0 ? Math.round(plateBiasValue * plateBiasCfg.bayNoiseBonus) : 0;
+        const noiseGate = 2 + bayNoiseExtra + (isActive ? 1 : 0) + noiseGateBonus;
+        const bayRollDen = isActive ? bayRollDenActive : bayRollDenDefault;
+        let bayRollDenUsed =
+          softMult !== 1 ? Math.max(1, Math.round(bayRollDen / softMult)) : bayRollDen;
+
+        if (plateBiasCfg.bayWeight > 0 && plateBiasValue !== 0) {
+          const scale = clamp(1 + plateBiasValue * plateBiasCfg.bayWeight, 0.25, 4);
+          bayRollDenUsed = Math.max(1, Math.round(bayRollDenUsed / scale));
+        }
+
+        // Corridor edge effect
+        let laneAttr: Record<string, unknown> | null = null;
+        for (let ddy = -1; ddy <= 1 && !laneAttr; ddy++) {
+          for (let ddx = -1; ddx <= 1; ddx++) {
+            if (ddx === 0 && ddy === 0) continue;
+            const k = `${x + ddx},${y + ddy}`;
+            if (StoryTags.corridorSeaLane?.has(k)) {
+              laneAttr = (StoryTags.corridorAttributes?.get(k) as Record<string, unknown>) || null;
+              if (laneAttr) break;
+            }
+          }
+        }
+
+        if (laneAttr?.edge) {
+          const edgeCfg = laneAttr.edge as Record<string, unknown>;
+          const bayMult = Number.isFinite(edgeCfg.bayCarveMultiplier)
+            ? (edgeCfg.bayCarveMultiplier as number)
+            : 1;
+          if (bayMult && bayMult !== 1) {
+            bayRollDenUsed = Math.max(1, Math.round(bayRollDenUsed / bayMult));
+          }
+        }
+
+        if (h % 97 < noiseGate && getRandom("Carve Bay", bayRollDenUsed) === 0) {
+          applyTerrain(x, y, COAST_TERRAIN, false);
+          continue;
+        }
+      }
+
+      // Fjord-like peninsulas: turn some adjacent ocean into coast
+      if (adapter?.isWater(x, y)) {
+        if (isAdjacentToLand(x, y, 1)) {
+          // Plate boundary integration
+          const i = y * iWidth + x;
+          const closenessByte = boundaryCloseness ? boundaryCloseness[i] | 0 : 0;
+          const closenessNorm = closenessByte / 255;
+          const bType = boundaryType ? boundaryType[i] | 0 : BOUNDARY_TYPE.none;
+          const nearBoundary = closenessNorm >= plateBiasCfg.threshold;
+          const plateBiasValue = boundaryCloseness
+            ? computePlateBias(closenessNorm, bType, plateBiasCfg)
+            : 0;
+
+          // Margin-aware fjord generation
+          let nearActive = nearBoundary;
+          let nearPassive = false;
+
+          for (let ddy = -1; ddy <= 1 && (!nearActive || !nearPassive); ddy++) {
+            for (let ddx = -1; ddx <= 1; ddx++) {
+              if (ddx === 0 && ddy === 0) continue;
+              const nx = x + ddx;
+              const ny = y + ddy;
+              if (nx <= 0 || nx >= iWidth - 1 || ny <= 0 || ny >= iHeight - 1) continue;
+              const k = `${nx},${ny}`;
+              if (!nearActive && StoryTags.activeMargin?.has(k)) nearActive = true;
+              if (!nearPassive && StoryTags.passiveShelf?.has(k)) nearPassive = true;
+            }
+          }
+
+          const denom = Math.max(
+            4,
+            fjordBaseDenom - (nearPassive ? fjordPassiveBonus : 0) - (nearActive ? fjordActiveBonus : 0)
+          );
+          let denomUsed = softMult !== 1 ? Math.max(1, Math.round(denom / softMult)) : denom;
+
+          if (plateBiasCfg.fjordWeight > 0 && plateBiasValue !== 0) {
+            const fjScale = clamp(1 + plateBiasValue * plateBiasCfg.fjordWeight, 0.2, 5);
+            denomUsed = Math.max(1, Math.round(denomUsed / fjScale));
+          }
+
+          // Corridor edge effect
+          let edgeCfg: Record<string, unknown> | null = null;
+          for (let my = -1; my <= 1 && !edgeCfg; my++) {
+            for (let mx = -1; mx <= 1; mx++) {
+              if (mx === 0 && my === 0) continue;
+              const kk = `${x + mx},${y + my}`;
+              if (StoryTags.corridorSeaLane?.has(kk)) {
+                const attr = StoryTags.corridorAttributes?.get(kk) as Record<string, unknown> | undefined;
+                edgeCfg = attr?.edge ? (attr.edge as Record<string, unknown>) : null;
+                if (edgeCfg) break;
+              }
+            }
+          }
+
+          if (edgeCfg) {
+            const fj = Number.isFinite(edgeCfg.fjordChance) ? (edgeCfg.fjordChance as number) : 0;
+            const cliffs = Number.isFinite(edgeCfg.cliffsChance)
+              ? (edgeCfg.cliffsChance as number)
+              : 0;
+            const effect = Math.max(0, Math.min(0.5, fj + cliffs * 0.5));
+            if (effect > 0) {
+              denomUsed = Math.max(1, Math.round(denomUsed * (1 - effect)));
+            }
+          }
+
+          if (getRandom("Fjord Coast", denomUsed) === 0) {
+            applyTerrain(x, y, COAST_TERRAIN, false);
+          }
+        }
+      }
+    }
+  }
+}
+
+export default addRuggedCoasts;

--- a/packages/mapgen-core/src/layers/index.ts
+++ b/packages/mapgen-core/src/layers/index.ts
@@ -1,23 +1,90 @@
 /**
  * Layers module - Terrain generation stages
  *
- * This module will contain all layer implementations:
- * - Mountains
- * - Coastlines
- * - Climate
- * - Biomes
- * - Features
- * - Resources
- *
- * Placeholder for Gate A.
+ * This module contains all layer implementations for map generation:
+ * - Landmass: Plate-driven landmass generation and utilities
+ * - Coastlines: Rugged coast carving
+ * - Islands: Island chain placement
+ * - Mountains: Physics-based mountain placement
+ * - Volcanoes: Plate-aware volcano placement
  */
 
-// Placeholder exports - will be populated in CIV-7
-export const LAYERS_MODULE_VERSION = "0.1.0";
+export const LAYERS_MODULE_VERSION = "0.2.0";
+
+// ============================================================================
+// Landmass Layers
+// ============================================================================
+
+export {
+  applyLandmassPostAdjustments,
+  applyPlateAwareOceanSeparation,
+  type LandmassWindow,
+  type GeometryPostConfig,
+  type GeometryConfig,
+  type OceanSeparationPolicy,
+  type OceanSeparationEdgePolicy,
+  type PlateAwareOceanSeparationParams,
+  type PlateAwareOceanSeparationResult,
+} from "./landmass-utils.js";
+
+export {
+  createPlateDrivenLandmasses,
+  type LandmassConfig,
+  type TectonicsConfig,
+  type CreateLandmassesOptions,
+  type LandmassGenerationResult,
+} from "./landmass-plate.js";
+
+// ============================================================================
+// Coastlines Layer
+// ============================================================================
+
+export {
+  addRuggedCoasts,
+  type CoastlinesConfig,
+  type CoastlinePlateBiasConfig,
+  type CoastlineBayConfig,
+  type CoastlineFjordConfig,
+  type CorridorPolicy,
+  type SeaCorridorPolicy,
+} from "./coastlines.js";
+
+// ============================================================================
+// Islands Layer
+// ============================================================================
+
+export {
+  addIslandChains,
+  type IslandsConfig,
+  type HotspotTunables,
+  type CorridorsConfig,
+} from "./islands.js";
+
+// ============================================================================
+// Mountains Layer
+// ============================================================================
+
+export {
+  layerAddMountainsPhysics,
+  addMountainsCompat,
+  type MountainsConfig,
+} from "./mountains.js";
+
+// ============================================================================
+// Volcanoes Layer
+// ============================================================================
+
+export {
+  layerAddVolcanoesPlateAware,
+  type VolcanoesConfig,
+} from "./volcanoes.js";
+
+// ============================================================================
+// Layer Stage Types
+// ============================================================================
 
 /**
  * Layer stage manifest type
- * Will be fully implemented in CIV-7
  */
 export interface LayerStage {
   name: string;

--- a/packages/mapgen-core/src/layers/islands.ts
+++ b/packages/mapgen-core/src/layers/islands.ts
@@ -1,0 +1,260 @@
+/**
+ * Islands Layer — addIslandChains
+ *
+ * Seeds tiny offshore island clusters using a sparse fractal mask, with
+ * additional alignment/bias along previously tagged hotspot trails to create
+ * legible chains. Some hotspot centers are classified as "paradise" (reef-friendly,
+ * lusher), others as "volcanic" (occasional cone peeking above the sea; tougher
+ * vegetation nearby). Feature/biome micro-tweaks occur in other layers; this
+ * module only handles terrain placement and StoryTag classification.
+ *
+ * Guardrails:
+ * - Preserves open sea lanes by avoiding tiles within a small radius of land.
+ * - Keeps clusters tiny (1–3 tiles; 1–2 when hotspot-biased).
+ * - Leaves heavy validation to feature layers.
+ * - O(width × height) with constant-time local checks.
+ */
+
+import type { ExtendedMapContext } from "../core/types.js";
+import type { EngineAdapter } from "@civ7/adapter";
+import type {
+  IslandsConfig as BootstrapIslandsConfig,
+  HotspotTunables as BootstrapHotspotTunables,
+  CorridorsConfig as BootstrapCorridorsConfig,
+} from "../bootstrap/types.js";
+import { ctxRandom, writeHeightfield } from "../core/types.js";
+import { getStoryTags } from "../story/tags.js";
+import { getTunables } from "../bootstrap/tunables.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+// Re-export canonical types
+export type IslandsConfig = BootstrapIslandsConfig;
+export type HotspotTunables = BootstrapHotspotTunables;
+export type CorridorsConfig = BootstrapCorridorsConfig;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const HILL_FRACTAL = 1;
+const COAST_TERRAIN = 1;
+const FLAT_TERRAIN = 3;
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function storyKey(x: number, y: number): string {
+  return `${x},${y}`;
+}
+
+// ============================================================================
+// Main Function
+// ============================================================================
+
+/**
+ * Place small island clusters in deep water, with hotspot bias.
+ *
+ * @param iWidth - Map width
+ * @param iHeight - Map height
+ * @param ctx - Optional MapContext for adapter-based operations
+ */
+export function addIslandChains(
+  iWidth: number,
+  iHeight: number,
+  ctx?: ExtendedMapContext | null
+): void {
+  const adapter = ctx?.adapter;
+
+  // Create sparse mask fractal
+  if (adapter?.createFractal) {
+    adapter.createFractal(HILL_FRACTAL, iWidth, iHeight, 5, 0);
+  }
+
+  const tunables = getTunables();
+  const islandsCfg = (tunables.FOUNDATION_CFG?.islands as IslandsConfig) || {};
+  const storyTunables = (tunables.FOUNDATION_CFG?.story as { hotspot?: HotspotTunables }) || {};
+  const corridorsCfg = (tunables.FOUNDATION_CFG?.corridors as CorridorsConfig) || {};
+
+  const fracPct = (islandsCfg.fractalThresholdPercent ?? 90) | 0;
+  const threshold = getFractalThreshold(adapter, fracPct);
+
+  // Hotspot classification tunables
+  const paradiseWeight = (storyTunables.hotspot?.paradiseBias ?? 2) | 0;
+  const volcanicWeight = (storyTunables.hotspot?.volcanicBias ?? 1) | 0;
+  const peakPercent = Math.max(
+    0,
+    Math.min(100, Math.round((storyTunables.hotspot?.volcanicPeakChance ?? 0.33) * 100) + 10)
+  );
+
+  const StoryTags = getStoryTags();
+
+  const applyTerrain = (tileX: number, tileY: number, terrain: number, isLand: boolean): void => {
+    if (ctx) {
+      writeHeightfield(ctx, tileX, tileY, { terrain, isLand });
+    } else if (adapter) {
+      adapter.setTerrainType(tileX, tileY, terrain);
+    }
+  };
+
+  const getRandom = (label: string, max: number): number => {
+    if (ctx) {
+      return ctxRandom(ctx, label, max);
+    }
+    if (adapter) {
+      return adapter.getRandomNumber(max, label);
+    }
+    return Math.floor(Math.random() * max);
+  };
+
+  const getFractalHeight = (x: number, y: number): number => {
+    if (adapter?.getFractalHeight) {
+      return adapter.getFractalHeight(HILL_FRACTAL, x, y);
+    }
+    return 0;
+  };
+
+  const isWater = (x: number, y: number): boolean => {
+    if (adapter) {
+      return adapter.isWater(x, y);
+    }
+    return true;
+  };
+
+  const isAdjacentToLand = (x: number, y: number, radius: number): boolean => {
+    if (!adapter) return false;
+    for (let dy = -radius; dy <= radius; dy++) {
+      for (let dx = -radius; dx <= radius; dx++) {
+        if (dx === 0 && dy === 0) continue;
+        const nx = x + dx;
+        const ny = y + dy;
+        if (nx >= 0 && nx < iWidth && ny >= 0 && ny < iHeight) {
+          if (!adapter.isWater(nx, ny)) return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  for (let y = 2; y < iHeight - 2; y++) {
+    for (let x = 2; x < iWidth - 2; x++) {
+      if (!isWater(x, y)) continue;
+
+      // Keep islands away from existing land
+      const minDist = (islandsCfg.minDistFromLandRadius ?? 2) | 0;
+      if (isAdjacentToLand(x, y, Math.max(0, minDist))) continue;
+
+      // Respect strategic sea-lane corridors
+      const laneRadius = (corridorsCfg.sea?.avoidRadius ?? 2) | 0;
+      if (laneRadius > 0 && StoryTags.corridorSeaLane && StoryTags.corridorSeaLane.size > 0) {
+        let nearSeaLane = false;
+        for (let my = -laneRadius; my <= laneRadius && !nearSeaLane; my++) {
+          for (let mx = -laneRadius; mx <= laneRadius; mx++) {
+            const kk = storyKey(x + mx, y + my);
+            if (StoryTags.corridorSeaLane.has(kk)) {
+              nearSeaLane = true;
+              break;
+            }
+          }
+        }
+        if (nearSeaLane) continue;
+      }
+
+      const v = getFractalHeight(x, y);
+      const isHotspot = StoryTags.hotspot.has(storyKey(x, y));
+
+      // Margin context
+      let nearActive = false;
+      let nearPassive = false;
+      for (let my = -1; my <= 1 && (!nearActive || !nearPassive); my++) {
+        for (let mx = -1; mx <= 1; mx++) {
+          if (mx === 0 && my === 0) continue;
+          const k = storyKey(x + mx, y + my);
+          if (!nearActive && StoryTags.activeMargin?.has(k)) nearActive = true;
+          if (!nearPassive && StoryTags.passiveShelf?.has(k)) nearPassive = true;
+        }
+      }
+
+      // Base sparse placement vs. hotspot- and margin-biased placement
+      const denActive = (islandsCfg.baseIslandDenNearActive ?? 5) | 0;
+      const denElse = (islandsCfg.baseIslandDenElse ?? 7) | 0;
+      const baseIslandDen = nearActive ? denActive : denElse;
+
+      const baseAllowed =
+        v > threshold && getRandom("Island Seed", baseIslandDen) === 0;
+      const hotspotAllowed =
+        isHotspot &&
+        getRandom("Hotspot Island Seed", Math.max(1, (islandsCfg.hotspotSeedDenom ?? 2) | 0)) === 0;
+
+      if (!(baseAllowed || hotspotAllowed)) continue;
+
+      // Default to coast water; occasionally let a volcanic center "peek" as land
+      let centerTerrain = COAST_TERRAIN;
+      let classifyParadise = false;
+
+      if (isHotspot) {
+        const pWeight = paradiseWeight + (nearPassive ? 1 : 0);
+        const vWeight = volcanicWeight;
+        const bucket = pWeight + vWeight;
+        const roll = getRandom("HotspotKind", bucket || 1);
+        classifyParadise = roll < pWeight;
+
+        if (!classifyParadise) {
+          // Volcanic: rare cone peeking above sea level
+          if (getRandom("HotspotPeak", 100) < peakPercent) {
+            centerTerrain = FLAT_TERRAIN;
+          }
+        }
+      }
+
+      // Place center tile
+      const centerIsLand =
+        centerTerrain !== COAST_TERRAIN && centerTerrain !== 0; // 0 = OCEAN_TERRAIN
+      applyTerrain(x, y, centerTerrain, centerIsLand);
+
+      // Classify center for downstream microclimates/features
+      if (isHotspot) {
+        if (classifyParadise) {
+          StoryTags.hotspotParadise.add(storyKey(x, y));
+        } else {
+          StoryTags.hotspotVolcanic.add(storyKey(x, y));
+        }
+      }
+
+      // Create a tiny cluster around the center
+      const maxCluster = Math.max(1, (islandsCfg.clusterMax ?? 3) | 0);
+      const count = 1 + getRandom("Island Size", maxCluster);
+
+      for (let n = 0; n < count; n++) {
+        const dx = getRandom("dx", 3) - 1;
+        const dy = getRandom("dy", 3) - 1;
+        const nx = x + dx;
+        const ny = y + dy;
+
+        if (nx <= 0 || nx >= iWidth - 1 || ny <= 0 || ny >= iHeight - 1) continue;
+        if (!isWater(nx, ny)) continue;
+
+        applyTerrain(nx, ny, COAST_TERRAIN, false);
+      }
+    }
+  }
+}
+
+/**
+ * Get fractal height threshold from percentage.
+ */
+function getFractalThreshold(
+  adapter: EngineAdapter | undefined,
+  percent: number
+): number {
+  // Without adapter, use a simple approximation
+  // The engine's FractalBuilder.getHeightFromPercent returns a value based on the fractal distribution
+  // We approximate this as a linear scale for the fallback
+  const clampedPercent = Math.max(0, Math.min(100, percent));
+  return Math.floor((clampedPercent / 100) * 65535);
+}
+
+export default addIslandChains;

--- a/packages/mapgen-core/src/layers/landmass-plate.ts
+++ b/packages/mapgen-core/src/layers/landmass-plate.ts
@@ -1,0 +1,553 @@
+/**
+ * Plate-Driven Landmass Generator
+ *
+ * Uses Civ VII WorldModel plate fields to carve land and ocean before the
+ * remainder of the Swooper pipeline runs. The algorithm ranks tiles by plate
+ * interior "stability" (WorldModel.shieldStability) and selects the highest
+ * scoring tiles until the configured land/sea ratio is satisfied, while also
+ * respecting boundary closeness to preserve coastlines.
+ */
+
+import type { ExtendedMapContext } from "../core/types.js";
+import type { EngineAdapter } from "@civ7/adapter";
+import type {
+  LandmassConfig as BootstrapLandmassConfig,
+  LandmassTectonicsConfig,
+  LandmassGeometry,
+  LandmassGeometryPost,
+} from "../bootstrap/types.js";
+import { writeHeightfield } from "../core/types.js";
+import { WorldModel, BOUNDARY_TYPE } from "../world/model.js";
+import { getTunables } from "../bootstrap/tunables.js";
+import type { LandmassWindow } from "./landmass-utils.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+// Re-export canonical types
+export type { LandmassTectonicsConfig, LandmassGeometry, LandmassGeometryPost };
+
+/** Landmass generation configuration (re-export canonical type) */
+export type LandmassConfig = BootstrapLandmassConfig;
+
+/** Tectonic noise configuration (alias for LandmassTectonicsConfig) */
+export type TectonicsConfig = LandmassTectonicsConfig;
+
+/** Geometry configuration (alias for LandmassGeometry) */
+export type GeometryConfig = LandmassGeometry;
+
+/** Geometry post-processing configuration (alias for LandmassGeometryPost) */
+export type GeometryPostConfig = LandmassGeometryPost;
+
+/** Options for createPlateDrivenLandmasses */
+export interface CreateLandmassesOptions {
+  landmassCfg?: Partial<LandmassConfig>;
+  geometry?: GeometryConfig;
+}
+
+/** Result of landmass generation */
+export interface LandmassGenerationResult {
+  windows: LandmassWindow[];
+  startRegions?: {
+    westContinent?: LandmassWindow;
+    eastContinent?: LandmassWindow;
+  };
+  landMask: Uint8Array;
+  landTiles?: number;
+  threshold?: number;
+}
+
+/** Internal plate statistics */
+interface PlateStats {
+  plateId: number;
+  count: number;
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_CLOSENESS_LIMIT = 255;
+const CLOSENESS_STEP_PER_TILE = 8;
+const MIN_CLOSENESS_LIMIT = 150;
+const MAX_CLOSENESS_LIMIT = 255;
+const FRACTAL_TECTONIC_ID = 3;
+
+// Terrain type constants
+const OCEAN_TERRAIN = 0;
+const FLAT_TERRAIN = 3;
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function clampInt(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function clampPct(value: number, min: number, max: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, value));
+}
+
+function clamp01(value: number | undefined, fallback: number = 0): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function clampRange(value: number | undefined, fallback: number, min: number, max: number): number {
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function computeClosenessLimit(postCfg: GeometryPostConfig | undefined): number {
+  const expand = postCfg?.expandTiles ? Math.trunc(postCfg.expandTiles) : 0;
+  const limit = DEFAULT_CLOSENESS_LIMIT + expand * CLOSENESS_STEP_PER_TILE;
+  return clampInt(limit, MIN_CLOSENESS_LIMIT, MAX_CLOSENESS_LIMIT);
+}
+
+// ============================================================================
+// Main Function
+// ============================================================================
+
+/**
+ * Create landmasses using plate stability metrics.
+ *
+ * @param width - Map width
+ * @param height - Map height
+ * @param ctx - Optional ExtendedMapContext for adapter-based operations
+ * @param options - Optional configuration overrides
+ * @returns Landmass generation result or null if WorldModel unavailable
+ */
+export function createPlateDrivenLandmasses(
+  width: number,
+  height: number,
+  ctx?: ExtendedMapContext | null,
+  options: CreateLandmassesOptions = {}
+): LandmassGenerationResult | null {
+  if (!WorldModel.isEnabled()) {
+    return null;
+  }
+
+  const shield = WorldModel.shieldStability;
+  const closeness = WorldModel.boundaryCloseness;
+  const boundaryType = WorldModel.boundaryType;
+  const plateIds = WorldModel.plateId;
+
+  if (!shield || !closeness || !boundaryType || !plateIds) {
+    return null;
+  }
+
+  const size = width * height;
+  if (
+    shield.length !== size ||
+    closeness.length !== size ||
+    boundaryType.length !== size ||
+    plateIds.length !== size
+  ) {
+    return null;
+  }
+
+  const tunables = getTunables();
+  // Cast to our local LandmassConfig which includes extended properties
+  const landmassCfg: LandmassConfig = (options.landmassCfg ||
+    (tunables.LANDMASS_CFG as unknown as LandmassConfig) ||
+    {}) as LandmassConfig;
+
+  // Configuration extraction
+  const boundaryBias = clampInt(
+    Number.isFinite(landmassCfg.boundaryBias) ? landmassCfg.boundaryBias! : 0.25,
+    0,
+    0.4
+  );
+  const boundaryShareTarget = Number.isFinite(landmassCfg.boundaryShareTarget)
+    ? Math.max(0, Math.min(1, landmassCfg.boundaryShareTarget!))
+    : 0.15;
+
+  const tectonicsCfg: TectonicsConfig = landmassCfg.tectonics || {};
+  const interiorNoiseWeight = clamp01(tectonicsCfg.interiorNoiseWeight, 0.3);
+  const arcWeight = clampRange(tectonicsCfg.boundaryArcWeight, 0.8, 0, 2);
+  const arcNoiseWeight = clamp01(tectonicsCfg.boundaryArcNoiseWeight, 0.5);
+  const fractalGrain = clampInt(
+    Number.isFinite(tectonicsCfg.fractalGrain) ? tectonicsCfg.fractalGrain! : 4,
+    1,
+    32
+  );
+
+  const geomCfg: GeometryConfig = options.geometry || {};
+  const postCfg: GeometryPostConfig = geomCfg.post || {};
+
+  // Water coverage calculation
+  const baseWaterPct = clampPct(landmassCfg.baseWaterPercent ?? 64, 0, 100, 64);
+  const waterScalar =
+    clampPct(
+      Number.isFinite(landmassCfg.waterScalar) ? landmassCfg.waterScalar! * 100 : 100,
+      25,
+      175,
+      100
+    ) / 100;
+  const waterPct = clampPct(baseWaterPct * waterScalar, 0, 100, baseWaterPct);
+  const totalTiles = size || 1;
+  const targetLandTiles = Math.max(
+    1,
+    Math.min(totalTiles - 1, Math.round(totalTiles * (1 - waterPct / 100)))
+  );
+
+  const closenessLimit = computeClosenessLimit(postCfg);
+  const adapter = ctx?.adapter;
+
+  // Fractal setup for noise
+  const useFractal = !!(
+    adapter &&
+    typeof adapter.createFractal === "function" &&
+    typeof adapter.getFractalHeight === "function" &&
+    (interiorNoiseWeight > 0 || arcNoiseWeight > 0)
+  );
+
+  if (useFractal) {
+    adapter!.createFractal(FRACTAL_TECTONIC_ID, width, height, fractalGrain, 0);
+  }
+
+  // Score computation
+  const baseInteriorWeight = 1 - interiorNoiseWeight;
+  const interiorScore = new Uint16Array(size);
+  const arcScore = new Uint16Array(size);
+  const landScore = new Uint16Array(size);
+
+  let interiorMin = 255, interiorMax = 0, interiorSum = 0;
+  let arcMin = 255, arcMax = 0, arcSum = 0;
+  let interiorStretch = 1;
+
+  for (let y = 0; y < height; y++) {
+    const rowOffset = y * width;
+    for (let x = 0; x < width; x++) {
+      const idx = rowOffset + x;
+      const closenessVal = closeness[idx] | 0;
+      const interiorBase = 255 - closenessVal;
+
+      // Interior score: plate core + tectonic noise
+      let noise255 = 128;
+      if (useFractal && interiorNoiseWeight > 0) {
+        const raw = adapter!.getFractalHeight(FRACTAL_TECTONIC_ID, x, y) | 0;
+        noise255 = raw >>> 8;
+      }
+      const centeredNoise = noise255 - 128;
+      const noisyInterior = interiorBase * baseInteriorWeight + centeredNoise * interiorNoiseWeight;
+      const clampedInterior = noisyInterior < 0 ? 0 : noisyInterior > 255 ? 255 : noisyInterior;
+      const interiorVal = clampedInterior & 0xff;
+      interiorScore[idx] = interiorVal;
+      interiorMin = Math.min(interiorMin, interiorVal);
+      interiorMax = Math.max(interiorMax, interiorVal);
+      interiorSum += interiorVal;
+
+      // Arc score: convergent uplift / island arcs
+      const bType = boundaryType[idx] | 0;
+      const rawArc = closenessVal;
+      let arc = rawArc;
+      if (bType === BOUNDARY_TYPE.convergent) {
+        arc = rawArc * arcWeight;
+      } else if (bType === BOUNDARY_TYPE.divergent) {
+        arc = rawArc * 0.25;
+      } else {
+        arc = rawArc * 0.5;
+      }
+
+      if (useFractal && arcNoiseWeight > 0) {
+        const raw = adapter!.getFractalHeight(FRACTAL_TECTONIC_ID, x, y) | 0;
+        const noiseNorm = (raw >>> 8) / 255;
+        const noiseMix = 1.0 + (noiseNorm - 0.5) * arcNoiseWeight;
+        arc *= noiseMix;
+      }
+
+      if (boundaryBias > 0) {
+        arc += closenessVal * boundaryBias;
+      }
+
+      const clampedArc = arc < 0 ? 0 : arc > 255 ? 255 : arc;
+      arcScore[idx] = clampedArc & 0xff;
+      arcMin = Math.min(arcMin, arcScore[idx]);
+      arcMax = Math.max(arcMax, arcScore[idx]);
+      arcSum += arcScore[idx];
+    }
+  }
+
+  // Stretch interior scores if needed
+  if (interiorMax > 0) {
+    const desiredTop = arcMax > 0 ? arcMax + 32 : 255;
+    interiorStretch = desiredTop / interiorMax;
+    if (interiorStretch < 1.05 || !Number.isFinite(interiorStretch)) {
+      interiorStretch = 1;
+    } else {
+      interiorStretch = Math.min(1.6, interiorStretch);
+      interiorMin = 255;
+      interiorMax = 0;
+      interiorSum = 0;
+      for (let i = 0; i < size; i++) {
+        const stretched = Math.min(255, Math.round(interiorScore[i] * interiorStretch));
+        interiorScore[i] = stretched;
+        interiorMin = Math.min(interiorMin, stretched);
+        interiorMax = Math.max(interiorMax, stretched);
+        interiorSum += stretched;
+      }
+    }
+  }
+
+  // Final land score
+  for (let i = 0; i < size; i++) {
+    landScore[i] = interiorScore[i] >= arcScore[i] ? interiorScore[i] : arcScore[i];
+  }
+
+  const computeLandScore = (idx: number): number => landScore[idx] | 0;
+
+  const countTilesAboveTyped = (threshold: number): number => {
+    let count = 0;
+    for (let i = 0; i < size; i++) {
+      const score = computeLandScore(i);
+      if (score >= threshold && closeness[i] <= closenessLimit) {
+        count++;
+      }
+    }
+    return count;
+  };
+
+  // Binary search threshold to hit target land count
+  let low = 0;
+  let high = 255;
+  let bestThreshold = 128;
+  let bestDiff = Number.POSITIVE_INFINITY;
+  let bestCount = 0;
+
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    const count = countTilesAboveTyped(mid);
+    const diff = Math.abs(count - targetLandTiles);
+    if (diff < bestDiff || (diff === bestDiff && count > bestCount)) {
+      bestDiff = diff;
+      bestThreshold = mid;
+      bestCount = count;
+    }
+    if (count > targetLandTiles) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  // Boundary share adjustment
+  const boundaryBand = (closenessArr: Uint8Array, idx: number): boolean =>
+    (closenessArr[idx] | 0) >= 90;
+
+  const computeShares = (
+    threshold: number
+  ): { land: number; boundaryLand: number; convergentLand: number } => {
+    let land = 0,
+      boundaryLand = 0,
+      convergentLand = 0;
+    for (let i = 0; i < size; i++) {
+      const score = computeLandScore(i);
+      const isLand = score >= threshold && closeness[i] <= closenessLimit;
+      if (isLand) {
+        land++;
+        if (boundaryBand(closeness, i)) boundaryLand++;
+        if (boundaryType[i] === BOUNDARY_TYPE.convergent) convergentLand++;
+      }
+    }
+    return { land, boundaryLand, convergentLand };
+  };
+
+  let { land: landCount, boundaryLand } = computeShares(bestThreshold);
+  const minBoundary = Math.round(targetLandTiles * boundaryShareTarget);
+
+  if (boundaryLand < minBoundary) {
+    const maxAllowedLand = Math.round(targetLandTiles * 1.5);
+    let t = bestThreshold - 5;
+    while (t >= 0) {
+      const shares = computeShares(t);
+      landCount = shares.land;
+      boundaryLand = shares.boundaryLand;
+      if (boundaryLand >= minBoundary) {
+        bestThreshold = t;
+        break;
+      }
+      if (landCount > maxAllowedLand) {
+        break;
+      }
+      t -= 5;
+    }
+  }
+
+  // Apply terrain
+  const landMask = new Uint8Array(size);
+  let finalLandTiles = 0;
+
+  const setTerrain = (
+    x: number,
+    y: number,
+    terrain: number,
+    isLand: boolean
+  ): void => {
+    if (ctx) {
+      writeHeightfield(ctx, x, y, {
+        terrain,
+        elevation: isLand ? 0 : -1,
+        isLand,
+      });
+    } else if (adapter) {
+      adapter.setTerrainType(x, y, terrain);
+    }
+  };
+
+  for (let y = 0; y < height; y++) {
+    const rowOffset = y * width;
+    for (let x = 0; x < width; x++) {
+      const idx = rowOffset + x;
+      const score = computeLandScore(idx);
+      const isLand = score >= bestThreshold && closeness[idx] <= closenessLimit;
+
+      if (isLand) {
+        landMask[idx] = 1;
+        finalLandTiles++;
+        setTerrain(x, y, FLAT_TERRAIN, true);
+      } else {
+        landMask[idx] = 0;
+        setTerrain(x, y, OCEAN_TERRAIN, false);
+      }
+    }
+  }
+
+  // Derive bounding boxes per plate
+  const plateStats = new Map<number, PlateStats>();
+
+  for (let idx = 0; idx < size; idx++) {
+    if (!landMask[idx]) continue;
+    const plateId = plateIds[idx];
+    if (plateId == null || plateId < 0) continue;
+
+    const y = Math.floor(idx / width);
+    const x = idx - y * width;
+
+    let stat = plateStats.get(plateId);
+    if (!stat) {
+      stat = {
+        plateId,
+        count: 0,
+        minX: width,
+        maxX: -1,
+        minY: height,
+        maxY: -1,
+      };
+      plateStats.set(plateId, stat);
+    }
+
+    stat.count++;
+    if (x < stat.minX) stat.minX = x;
+    if (x > stat.maxX) stat.maxX = x;
+    if (y < stat.minY) stat.minY = y;
+    if (y > stat.maxY) stat.maxY = y;
+  }
+
+  const minWidth = postCfg.minWidthTiles ? Math.max(1, Math.trunc(postCfg.minWidthTiles)) : 0;
+  const polarRows = 0; // Default, would come from globals if available
+
+  interface WindowWithMeta extends LandmassWindow {
+    plateId: number;
+    centerX: number;
+    count: number;
+  }
+
+  const windows: WindowWithMeta[] = Array.from(plateStats.values())
+    .filter((s) => s.count > 0 && s.maxX >= s.minX && s.maxY >= s.minY)
+    .map((s) => {
+      const expand = postCfg.expandTiles ? Math.trunc(postCfg.expandTiles) : 0;
+      const expandWest = postCfg.expandWestTiles ? Math.trunc(postCfg.expandWestTiles) : 0;
+      const expandEast = postCfg.expandEastTiles ? Math.trunc(postCfg.expandEastTiles) : 0;
+
+      let west = Math.max(0, s.minX - Math.max(0, expand + expandWest));
+      let east = Math.min(width - 1, s.maxX + Math.max(0, expand + expandEast));
+
+      if (minWidth > 0) {
+        const span = east - west + 1;
+        if (span < minWidth) {
+          const deficit = minWidth - span;
+          const extraWest = Math.floor(deficit / 2);
+          const extraEast = deficit - extraWest;
+          west = Math.max(0, west - extraWest);
+          east = Math.min(width - 1, east + extraEast);
+        }
+      }
+
+      if (postCfg.clampWestMin != null) {
+        west = Math.max(west, Math.max(0, Math.trunc(postCfg.clampWestMin)));
+      }
+      if (postCfg.clampEastMax != null) {
+        east = Math.min(east, Math.min(width - 1, Math.trunc(postCfg.clampEastMax)));
+      }
+
+      const verticalPad = Math.max(0, expand);
+      const baseSouth = Math.max(polarRows, s.minY - verticalPad);
+      const baseNorth = Math.min(height - polarRows, s.maxY + verticalPad);
+
+      const south =
+        postCfg.overrideSouth != null
+          ? clampInt(Math.trunc(postCfg.overrideSouth), 0, height - 1)
+          : clampInt(baseSouth, 0, height - 1);
+      const north =
+        postCfg.overrideNorth != null
+          ? clampInt(Math.trunc(postCfg.overrideNorth), 0, height - 1)
+          : clampInt(baseNorth, 0, height - 1);
+
+      return {
+        plateId: s.plateId,
+        west,
+        east,
+        south,
+        north,
+        centerX: (west + east) * 0.5,
+        count: s.count,
+        continent: 0, // Will be assigned below
+      };
+    })
+    .sort((a, b) => a.centerX - b.centerX);
+
+  const windowsOut: LandmassWindow[] = windows.map((win, index) => ({
+    west: win.west,
+    east: win.east,
+    south: win.south,
+    north: win.north,
+    continent: index,
+  }));
+
+  let startRegions: LandmassGenerationResult["startRegions"] = undefined;
+  if (windowsOut.length >= 2) {
+    startRegions = {
+      westContinent: { ...windowsOut[0] },
+      eastContinent: { ...windowsOut[windowsOut.length - 1] },
+    };
+  }
+
+  if (ctx?.buffers?.heightfield?.landMask) {
+    ctx.buffers.heightfield.landMask.set(landMask);
+  }
+
+  return {
+    windows: windowsOut,
+    startRegions,
+    landMask,
+    landTiles: finalLandTiles,
+    threshold: bestThreshold,
+  };
+}
+
+export default createPlateDrivenLandmasses;

--- a/packages/mapgen-core/src/layers/landmass-utils.ts
+++ b/packages/mapgen-core/src/layers/landmass-utils.ts
@@ -1,0 +1,526 @@
+/**
+ * Landmass Utils — Shared helpers for landmass generation
+ *
+ * Provides post-processing utilities for landmass windows and
+ * plate-aware ocean separation logic.
+ */
+
+import type { ExtendedMapContext } from "../core/types.js";
+import type { EngineAdapter } from "@civ7/adapter";
+import type {
+  LandmassGeometryPost,
+  LandmassGeometry,
+  OceanSeparationConfig,
+  OceanSeparationEdgePolicy,
+} from "../bootstrap/types.js";
+import { writeHeightfield } from "../core/types.js";
+import { WorldModel } from "../world/model.js";
+import { getTunables } from "../bootstrap/tunables.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Landmass bounding window */
+export interface LandmassWindow {
+  west: number;
+  east: number;
+  south: number;
+  north: number;
+  continent: number;
+}
+
+// Re-export canonical types for convenience
+export type { LandmassGeometryPost, LandmassGeometry, OceanSeparationConfig, OceanSeparationEdgePolicy };
+
+/** Geometry post-processing configuration (alias for LandmassGeometryPost) */
+export type GeometryPostConfig = LandmassGeometryPost;
+
+/** Geometry configuration with post block (alias for LandmassGeometry) */
+export type GeometryConfig = LandmassGeometry;
+
+/** Ocean separation policy (alias for OceanSeparationConfig) */
+export type OceanSeparationPolicy = OceanSeparationConfig;
+
+/** Parameters for plate-aware ocean separation */
+export interface PlateAwareOceanSeparationParams {
+  width: number;
+  height: number;
+  windows: ReadonlyArray<Partial<LandmassWindow>>;
+  landMask?: Uint8Array | null;
+  context?: ExtendedMapContext | null;
+  adapter?: Pick<EngineAdapter, "setTerrainType"> | null;
+  policy?: OceanSeparationPolicy | null;
+}
+
+/** Result of plate-aware ocean separation */
+export interface PlateAwareOceanSeparationResult {
+  windows: LandmassWindow[];
+  landMask?: Uint8Array;
+}
+
+/** Internal row state for ocean separation */
+interface RowState {
+  index: number;
+  west: Int16Array;
+  east: Int16Array;
+  south: number;
+  north: number;
+  continent: number;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Default ocean separation policy */
+const DEFAULT_OCEAN_SEPARATION: OceanSeparationPolicy = {
+  enabled: true,
+  bandPairs: [
+    [0, 1],
+    [1, 2],
+  ],
+  baseSeparationTiles: 0,
+  boundaryClosenessMultiplier: 1.0,
+  maxPerRowDelta: 3,
+};
+
+// Terrain type constants (from base-standard/maps/map-globals.js)
+const OCEAN_TERRAIN = 0;
+const FLAT_TERRAIN = 3;
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function clampInt(value: number, min: number, max: number): number {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function normalizeWindow(
+  win: Partial<LandmassWindow> | null | undefined,
+  index: number,
+  width: number,
+  height: number
+): LandmassWindow {
+  if (!win) {
+    return {
+      west: 0,
+      east: Math.max(0, width - 1),
+      south: 0,
+      north: Math.max(0, height - 1),
+      continent: index,
+    };
+  }
+  const west = clampInt(win.west ?? 0, 0, width - 1);
+  const east = clampInt(win.east ?? width - 1, 0, width - 1);
+  const south = clampInt(win.south ?? 0, 0, height - 1);
+  const north = clampInt(win.north ?? height - 1, 0, height - 1);
+  return {
+    west: Math.min(west, east),
+    east: Math.max(west, east),
+    south: Math.min(south, north),
+    north: Math.max(south, north),
+    continent: win.continent ?? index,
+  };
+}
+
+function createRowState(
+  win: Partial<LandmassWindow> | null | undefined,
+  index: number,
+  width: number,
+  height: number
+): RowState {
+  const normalized = normalizeWindow(win, index, width, height);
+  const west = new Int16Array(height);
+  const east = new Int16Array(height);
+  for (let y = 0; y < height; y++) {
+    west[y] = normalized.west;
+    east[y] = normalized.east;
+  }
+  return {
+    index,
+    west,
+    east,
+    south: normalized.south,
+    north: normalized.north,
+    continent: normalized.continent,
+  };
+}
+
+function aggregateRowState(
+  state: RowState,
+  width: number,
+  height: number
+): LandmassWindow {
+  let minWest = width - 1;
+  let maxEast = 0;
+  const south = clampInt(state.south, 0, height - 1);
+  const north = clampInt(state.north, 0, height - 1);
+  for (let y = south; y <= north; y++) {
+    if (state.west[y] < minWest) minWest = state.west[y];
+    if (state.east[y] > maxEast) maxEast = state.east[y];
+  }
+  return {
+    west: clampInt(minWest, 0, width - 1),
+    east: clampInt(maxEast, 0, width - 1),
+    south,
+    north,
+    continent: state.continent,
+  };
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Apply geometry post-processing adjustments defined in config.
+ *
+ * @param windows - Array of landmass windows to adjust
+ * @param geometry - Geometry configuration with post block
+ * @param width - Map width
+ * @param height - Map height
+ * @returns Adjusted windows (or original if no changes)
+ */
+export function applyLandmassPostAdjustments(
+  windows: LandmassWindow[],
+  geometry: GeometryConfig | null | undefined,
+  width: number,
+  height: number
+): LandmassWindow[] {
+  if (!Array.isArray(windows) || windows.length === 0) return windows;
+
+  const post = geometry?.post;
+  if (!post || typeof post !== "object") return windows;
+
+  const expandAll = Number.isFinite(post.expandTiles)
+    ? Math.trunc(post.expandTiles!)
+    : 0;
+  const expandWest = Number.isFinite(post.expandWestTiles)
+    ? Math.trunc(post.expandWestTiles!)
+    : 0;
+  const expandEast = Number.isFinite(post.expandEastTiles)
+    ? Math.trunc(post.expandEastTiles!)
+    : 0;
+  const clampWest =
+    Number.isFinite(post.clampWestMin)
+      ? Math.max(0, Math.trunc(post.clampWestMin!))
+      : null;
+  const clampEast =
+    Number.isFinite(post.clampEastMax)
+      ? Math.min(width - 1, Math.trunc(post.clampEastMax!))
+      : null;
+  const overrideSouth =
+    Number.isFinite(post.overrideSouth)
+      ? clampInt(Math.trunc(post.overrideSouth!), 0, height - 1)
+      : null;
+  const overrideNorth =
+    Number.isFinite(post.overrideNorth)
+      ? clampInt(Math.trunc(post.overrideNorth!), 0, height - 1)
+      : null;
+  const minWidth =
+    Number.isFinite(post.minWidthTiles)
+      ? Math.max(0, Math.trunc(post.minWidthTiles!))
+      : null;
+
+  let changed = false;
+  const adjusted = windows.map((win) => {
+    if (!win) return win;
+
+    let west = clampInt(win.west | 0, 0, width - 1);
+    let east = clampInt(win.east | 0, 0, width - 1);
+    let south = clampInt(win.south | 0, 0, height - 1);
+    let north = clampInt(win.north | 0, 0, height - 1);
+
+    const expansionWest = expandAll + expandWest;
+    const expansionEast = expandAll + expandEast;
+
+    if (expansionWest > 0) west = clampInt(west - expansionWest, 0, width - 1);
+    if (expansionEast > 0) east = clampInt(east + expansionEast, 0, width - 1);
+    if (clampWest != null) west = Math.max(west, clampWest);
+    if (clampEast != null) east = Math.min(east, clampEast);
+
+    if (minWidth != null && minWidth > 0) {
+      const span = east - west + 1;
+      if (span < minWidth) {
+        const deficit = minWidth - span;
+        const extraWest = Math.floor(deficit / 2);
+        const extraEast = deficit - extraWest;
+        west = clampInt(west - extraWest, 0, width - 1);
+        east = clampInt(east + extraEast, 0, width - 1);
+      }
+    }
+
+    if (overrideSouth != null) south = overrideSouth;
+    if (overrideNorth != null) north = overrideNorth;
+
+    const mutated =
+      west !== win.west ||
+      east !== win.east ||
+      south !== win.south ||
+      north !== win.north;
+
+    if (mutated) changed = true;
+    if (!mutated) return win;
+
+    return {
+      west,
+      east,
+      south,
+      north,
+      continent: win.continent,
+    };
+  });
+
+  return changed ? adjusted : windows;
+}
+
+/**
+ * Apply plate-aware ocean separation to landmasses after generation.
+ *
+ * Widens or narrows ocean channels based on WorldModel boundary closeness,
+ * mutating both the supplied land mask (when available) and returning updated
+ * landmass windows for downstream consumers.
+ *
+ * @param params - Ocean separation parameters
+ * @returns Updated windows and optionally the modified land mask
+ */
+export function applyPlateAwareOceanSeparation(
+  params: PlateAwareOceanSeparationParams
+): PlateAwareOceanSeparationResult {
+  const width = params?.width | 0;
+  const height = params?.height | 0;
+  const windows = Array.isArray(params?.windows) ? params.windows : [];
+
+  if (!width || !height || windows.length === 0) {
+    return {
+      windows: windows.map((win, idx) => normalizeWindow(win, idx, width, height)),
+    };
+  }
+
+  const ctx = params?.context ?? null;
+  const adapter =
+    params?.adapter && typeof params.adapter.setTerrainType === "function"
+      ? params.adapter
+      : null;
+
+  const tunables = getTunables();
+  const foundationPolicy = tunables.FOUNDATION_CFG?.oceanSeparation as OceanSeparationPolicy | undefined;
+  const policy = params?.policy || foundationPolicy || DEFAULT_OCEAN_SEPARATION;
+
+  if (
+    !policy ||
+    !policy.enabled ||
+    !WorldModel.isEnabled()
+  ) {
+    return {
+      windows: windows.map((win, idx) => normalizeWindow(win, idx, width, height)),
+      landMask: params?.landMask ?? undefined,
+    };
+  }
+
+  const closeness = WorldModel.boundaryCloseness;
+  if (!closeness || closeness.length !== width * height) {
+    return {
+      windows: windows.map((win, idx) => normalizeWindow(win, idx, width, height)),
+      landMask: params?.landMask ?? undefined,
+    };
+  }
+
+  const landMask =
+    params?.landMask instanceof Uint8Array && params.landMask.length === width * height
+      ? params.landMask
+      : null;
+
+  const heightfield = ctx?.buffers?.heightfield;
+  const bandPairs =
+    Array.isArray(policy.bandPairs) && policy.bandPairs.length
+      ? policy.bandPairs
+      : [
+          [0, 1],
+          [1, 2],
+        ];
+
+  const baseSeparation = Math.max(0, (policy.baseSeparationTiles ?? 0) | 0);
+  const closenessMultiplier = Number.isFinite(policy.boundaryClosenessMultiplier)
+    ? policy.boundaryClosenessMultiplier!
+    : 1.0;
+  const maxPerRow = Math.max(0, (policy.maxPerRowDelta ?? 3) | 0);
+
+  const rowStates = windows.map((win, idx) => createRowState(win, idx, width, height));
+
+  const setTerrain = (x: number, y: number, terrain: number, isLand: boolean): void => {
+    if (x < 0 || x >= width || y < 0 || y >= height) return;
+    const idx = y * width + x;
+
+    if (landMask) {
+      landMask[idx] = isLand ? 1 : 0;
+    }
+
+    if (ctx) {
+      writeHeightfield(ctx, x, y, { terrain, isLand });
+    } else if (adapter) {
+      adapter.setTerrainType(x, y, terrain);
+    }
+
+    if (heightfield && !landMask) {
+      heightfield.landMask[idx] = isLand ? 1 : 0;
+    }
+  };
+
+  const carveOceanFromEast = (state: RowState, y: number, tiles: number): number => {
+    if (!tiles) return 0;
+    let removed = 0;
+    let x = state.east[y];
+    const limit = state.west[y];
+    const rowOffset = y * width;
+    while (removed < tiles && x >= limit) {
+      const idx = rowOffset + x;
+      if (!landMask || landMask[idx]) {
+        setTerrain(x, y, OCEAN_TERRAIN, false);
+        removed++;
+      }
+      x--;
+    }
+    state.east[y] = clampInt(state.east[y] - removed, limit, width - 1);
+    return removed;
+  };
+
+  const carveOceanFromWest = (state: RowState, y: number, tiles: number): number => {
+    if (!tiles) return 0;
+    let removed = 0;
+    let x = state.west[y];
+    const limit = state.east[y];
+    const rowOffset = y * width;
+    while (removed < tiles && x <= limit) {
+      const idx = rowOffset + x;
+      if (!landMask || landMask[idx]) {
+        setTerrain(x, y, OCEAN_TERRAIN, false);
+        removed++;
+      }
+      x++;
+    }
+    state.west[y] = clampInt(state.west[y] + removed, 0, limit);
+    return removed;
+  };
+
+  const fillLandFromWest = (state: RowState, y: number, tiles: number): number => {
+    if (!tiles) return 0;
+    let added = 0;
+    let x = state.west[y] - 1;
+    while (added < tiles && x >= 0) {
+      setTerrain(x, y, FLAT_TERRAIN, true);
+      added++;
+      x--;
+    }
+    state.west[y] = clampInt(state.west[y] - added, 0, width - 1);
+    return added;
+  };
+
+  const fillLandFromEast = (state: RowState, y: number, tiles: number): number => {
+    if (!tiles) return 0;
+    let added = 0;
+    let x = state.east[y] + 1;
+    while (added < tiles && x < width) {
+      setTerrain(x, y, FLAT_TERRAIN, true);
+      added++;
+      x++;
+    }
+    state.east[y] = clampInt(state.east[y] + added, 0, width - 1);
+    return added;
+  };
+
+  // Process band pairs
+  for (const pair of bandPairs) {
+    const li = Array.isArray(pair) ? (pair[0] | 0) : -1;
+    const ri = Array.isArray(pair) ? (pair[1] | 0) : -1;
+    const left = rowStates[li];
+    const right = rowStates[ri];
+    if (!left || !right) continue;
+
+    const rowStart = Math.max(0, Math.max(left.south, right.south));
+    const rowEnd = Math.min(height - 1, Math.min(left.north, right.north));
+
+    for (let y = rowStart; y <= rowEnd; y++) {
+      const mid = clampInt(Math.floor((left.east[y] + right.west[y]) / 2), 0, width - 1);
+      const clos = closeness[y * width + mid] | 0;
+      let sep = baseSeparation;
+      if (sep > 0) {
+        const weight = clos / 255;
+        sep += Math.round(weight * closenessMultiplier * baseSeparation);
+      }
+      if (sep > maxPerRow) sep = maxPerRow;
+      if (sep <= 0) continue;
+
+      carveOceanFromEast(left, y, sep);
+      carveOceanFromWest(right, y, sep);
+    }
+  }
+
+  // Edge west processing
+  const edgeWest = policy.edgeWest || {};
+  if (rowStates.length && edgeWest.enabled) {
+    const state = rowStates[0];
+    const base = (edgeWest.baseTiles ?? 0) | 0;
+    const mult = Number.isFinite(edgeWest.boundaryClosenessMultiplier)
+      ? edgeWest.boundaryClosenessMultiplier!
+      : 1.0;
+    const cap = Math.max(0, (edgeWest.maxPerRowDelta ?? 2) | 0);
+
+    for (let y = state.south; y <= state.north; y++) {
+      const clos = closeness[y * width + 0] | 0;
+      let mag = Math.abs(base) + Math.round((clos / 255) * Math.abs(base) * mult);
+      if (mag > cap) mag = cap;
+      if (mag <= 0) continue;
+
+      if (base >= 0) {
+        carveOceanFromWest(state, y, mag);
+      } else {
+        fillLandFromWest(state, y, mag);
+      }
+    }
+  }
+
+  // Edge east processing
+  const edgeEast = policy.edgeEast || {};
+  if (rowStates.length && edgeEast.enabled) {
+    const state = rowStates[rowStates.length - 1];
+    const base = (edgeEast.baseTiles ?? 0) | 0;
+    const mult = Number.isFinite(edgeEast.boundaryClosenessMultiplier)
+      ? edgeEast.boundaryClosenessMultiplier!
+      : 1.0;
+    const cap = Math.max(0, (edgeEast.maxPerRowDelta ?? 2) | 0);
+
+    for (let y = state.south; y <= state.north; y++) {
+      const clos = closeness[y * width + (width - 1)] | 0;
+      let mag = Math.abs(base) + Math.round((clos / 255) * Math.abs(base) * mult);
+      if (mag > cap) mag = cap;
+      if (mag <= 0) continue;
+
+      if (base >= 0) {
+        carveOceanFromEast(state, y, mag);
+      } else {
+        fillLandFromEast(state, y, mag);
+      }
+    }
+  }
+
+  const normalized = rowStates.map((state) => aggregateRowState(state, width, height));
+
+  if (ctx && landMask && ctx.buffers?.heightfield?.landMask) {
+    ctx.buffers.heightfield.landMask.set(landMask);
+  }
+
+  return {
+    windows: normalized,
+    landMask: landMask ?? undefined,
+  };
+}
+
+export default {
+  applyLandmassPostAdjustments,
+  applyPlateAwareOceanSeparation,
+};

--- a/packages/mapgen-core/src/layers/volcanoes.ts
+++ b/packages/mapgen-core/src/layers/volcanoes.ts
@@ -1,0 +1,240 @@
+/**
+ * Volcano Placement — Plate-Aware Wrapper
+ *
+ * Purpose:
+ * - Replace the base game's continent-edge heuristic with a WorldModel-driven
+ *   placement strategy that favors convergent arcs while still allowing inland
+ *   hotspot-style volcanoes when configured.
+ * - Exposes tunables through the `volcanoes` config block so presets can adjust
+ *   density, spacing, and boundary weighting without touching this layer.
+ *
+ * Fallback:
+ * - If the WorldModel is disabled or required fields are unavailable, the layer
+ *   gracefully degrades (no placement rather than crash).
+ */
+
+import type { ExtendedMapContext } from "../core/types.js";
+import type { EngineAdapter, FeatureData } from "@civ7/adapter";
+import type { VolcanoesConfig as BootstrapVolcanoesConfig } from "../bootstrap/types.js";
+import { writeHeightfield } from "../core/types.js";
+import { WorldModel, BOUNDARY_TYPE } from "../world/model.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+// Re-export canonical type
+export type VolcanoesConfig = BootstrapVolcanoesConfig;
+
+/** Volcano candidate */
+interface VolcanoCandidate {
+  x: number;
+  y: number;
+  weight: number;
+  closeness: number;
+  boundaryType: number;
+}
+
+/** Placed volcano position */
+interface PlacedVolcano {
+  x: number;
+  y: number;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const MOUNTAIN_TERRAIN = 5;
+const VOLCANO_FEATURE = 1; // Standard volcano feature type
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function idx(x: number, y: number, width: number): number {
+  return y * width + x;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (typeof max === "number" && max >= min) {
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
+  }
+  return Math.max(value, min);
+}
+
+function isTooCloseToExisting(
+  x: number,
+  y: number,
+  placed: PlacedVolcano[],
+  minSpacing: number
+): boolean {
+  for (const p of placed) {
+    const dx = Math.abs(x - p.x);
+    const dy = Math.abs(y - p.y);
+    const dist = Math.max(dx, dy); // Chebyshev distance
+    if (dist < minSpacing) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ============================================================================
+// Main Function
+// ============================================================================
+
+/**
+ * Plate-aware volcano placement.
+ *
+ * @param ctx - Map context
+ * @param options - Volcano placement options
+ */
+export function layerAddVolcanoesPlateAware(
+  ctx: ExtendedMapContext,
+  options: Partial<VolcanoesConfig> = {}
+): void {
+  const {
+    enabled = true,
+    baseDensity = 1 / 170,
+    minSpacing = 3,
+    boundaryThreshold = 0.35,
+    boundaryWeight = 1.2,
+    convergentMultiplier = 2.4,
+    transformMultiplier = 1.1,
+    divergentMultiplier = 0.35,
+    hotspotWeight = 0.12,
+    shieldPenalty = 0.6,
+    randomJitter = 0.08,
+    minVolcanoes = 5,
+    maxVolcanoes = 40,
+  } = options;
+
+  const dimensions = ctx?.dimensions;
+  const width = dimensions?.width ?? 0;
+  const height = dimensions?.height ?? 0;
+  const adapter = ctx?.adapter;
+
+  if (!width || !height || !adapter) {
+    return;
+  }
+
+  if (!enabled) {
+    return;
+  }
+
+  const worldEnabled = WorldModel.isEnabled();
+  const boundaryCloseness = WorldModel.boundaryCloseness;
+  const boundaryType = WorldModel.boundaryType;
+  const shieldStability = WorldModel.shieldStability;
+
+  if (!worldEnabled || !boundaryCloseness || !boundaryType) {
+    // WorldModel unavailable - skip placement
+    return;
+  }
+
+  // Count land tiles for density target
+  let landTiles = 0;
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      if (!adapter.isWater(x, y)) landTiles++;
+    }
+  }
+
+  const rawDesired = Math.round(landTiles * Math.max(0, baseDensity));
+  const targetVolcanoes = clamp(
+    Math.max(minVolcanoes | 0, rawDesired),
+    minVolcanoes | 0,
+    maxVolcanoes > 0 ? maxVolcanoes | 0 : rawDesired
+  );
+
+  if (targetVolcanoes <= 0) {
+    return;
+  }
+
+  const candidates: VolcanoCandidate[] = [];
+  const hotspotBase = Math.max(0, hotspotWeight);
+  const threshold = Math.max(0, Math.min(1, boundaryThreshold));
+  const shieldWeight = Math.max(0, Math.min(1, shieldPenalty));
+  const jitter = Math.max(0, randomJitter);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      if (adapter.isWater(x, y)) continue;
+      if (adapter.getFeatureType(x, y) === VOLCANO_FEATURE) continue;
+
+      const i = idx(x, y, width);
+      const closeness = boundaryCloseness[i] / 255;
+      const shield = shieldStability ? shieldStability[i] / 255 : 0;
+      const bType = boundaryType[i] | 0;
+
+      let weight = 0;
+      let boundaryBand = 0;
+
+      if (closeness >= threshold) {
+        boundaryBand = (closeness - threshold) / Math.max(1e-3, 1 - threshold);
+        const base = boundaryBand * Math.max(0, boundaryWeight);
+        let multiplier = 1;
+        if (bType === BOUNDARY_TYPE.convergent) multiplier = Math.max(0, convergentMultiplier);
+        else if (bType === BOUNDARY_TYPE.transform) multiplier = Math.max(0, transformMultiplier);
+        else if (bType === BOUNDARY_TYPE.divergent) multiplier = Math.max(0, divergentMultiplier);
+        weight += base * multiplier;
+      } else {
+        // Interior hotspot chance
+        const interiorBand = 1 - closeness;
+        weight += hotspotBase * interiorBand;
+      }
+
+      if (weight <= 0) continue;
+
+      if (shieldWeight > 0) {
+        const penalty = shield * shieldWeight;
+        weight *= Math.max(0, 1 - penalty);
+      }
+
+      if (jitter > 0) {
+        const randomScale = adapter.getRandomNumber(1000, "VolcanoJitter") / 1000;
+        weight += randomScale * jitter;
+      }
+
+      if (weight > 0) {
+        candidates.push({ x, y, weight, closeness, boundaryType: bType });
+      }
+    }
+  }
+
+  if (candidates.length === 0) {
+    return;
+  }
+
+  candidates.sort((a, b) => b.weight - a.weight);
+
+  const placed: PlacedVolcano[] = [];
+  const minSpacingClamped = Math.max(1, minSpacing | 0);
+
+  for (const candidate of candidates) {
+    if (placed.length >= targetVolcanoes) break;
+    if (adapter.getFeatureType(candidate.x, candidate.y) === VOLCANO_FEATURE) continue;
+    if (isTooCloseToExisting(candidate.x, candidate.y, placed, minSpacingClamped)) continue;
+
+    // Set terrain to mountain
+    writeHeightfield(ctx, candidate.x, candidate.y, {
+      terrain: MOUNTAIN_TERRAIN,
+      isLand: true,
+    });
+
+    // Set volcano feature
+    const featureData: FeatureData = {
+      Feature: VOLCANO_FEATURE,
+      Direction: -1,
+      Elevation: 0,
+    };
+    adapter.setFeatureType(candidate.x, candidate.y, featureData);
+
+    placed.push({ x: candidate.x, y: candidate.y });
+  }
+}
+
+export default layerAddVolcanoesPlateAware;


### PR DESCRIPTION
Migrates 6 layer files from JavaScript to TypeScript with adapter pattern:
- landmass-utils.ts: Window adjustments and ocean separation utilities
- landmass-plate.ts: Plate-driven landmass generation
- coastlines.ts: Rugged coast carving with plate boundary awareness
- islands.ts: Island chain placement with hotspot classification
- mountains.ts: Physics-based mountain and hill placement
- volcanoes.ts: Plate-aware volcano placement

All layers use ExtendedMapContext and EngineAdapter interface instead of
direct GameplayMap calls. Layer configs are properly typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>