### PR TITLE
refactor(mapgen-core): migrate layers to FoundationContext consumption

### DIFF
--- a/docs/projects/engine-refactor-v1/issues/CIV-16-foundationcontext-consumption.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-16-foundationcontext-consumption.md
@@ -53,21 +53,21 @@ export function applyMountains(ctx: ExtendedMapContext) {
 
 ## Deliverables
 
-- [ ] **Update layers to read from `ctx.foundation`:**
-  - [ ] `layers/landmass-plate.ts` — read `ctx.foundation.plates.*`
-  - [ ] `layers/coastlines.ts` — read `ctx.foundation.plates.*`
-  - [ ] `layers/mountains.ts` — read `ctx.foundation.plates.*`
-  - [ ] `layers/volcanoes.ts` — read `ctx.foundation.plates.*`
-  - [ ] `layers/landmass-utils.ts` — read `ctx.foundation.plates.*`
-  - [ ] `layers/climate-engine.ts` — read `ctx.foundation.dynamics.*`
-- [ ] **Export `BOUNDARY_TYPE` from shared location:**
-  - Create `world/constants.ts` or add to `core/types.ts`
-  - Remove need to import from `WorldModel` for constants
-- [ ] **Keep `WorldModel` singleton only for orchestrator:**
+- [x] **Update layers to read from `ctx.foundation`:**
+  - [x] `layers/landmass-plate.ts` — read `ctx.foundation.plates.*`
+  - [x] `layers/coastlines.ts` — read `ctx.foundation.plates.*`
+  - [x] `layers/mountains.ts` — read `ctx.foundation.plates.*`
+  - [x] `layers/volcanoes.ts` — read `ctx.foundation.plates.*`
+  - [x] `layers/landmass-utils.ts` — read `ctx.foundation.plates.*`
+  - [x] `layers/climate-engine.ts` — read `ctx.foundation.dynamics.*`
+- [x] **Export `BOUNDARY_TYPE` from shared location:**
+  - Created `world/constants.ts` re-exporting from `world/types.ts`
+  - Layers now import from constants, not WorldModel
+- [x] **Keep `WorldModel` singleton only for orchestrator:**
   - `WorldModel.init()` and `WorldModel.reset()` called only by orchestrator
   - Layers never call these methods directly
-- [ ] **Add `WorldModel.reset()` if missing:**
-  - Call in orchestrator entry sequence before `init()`
+- [x] **Add `WorldModel.reset()` if missing:**
+  - Already exists in world/model.ts (lines 543-564)
 - [ ] **Document authoritative generation session sequence:**
   ```
   1. resetConfig() / resetTunables() / WorldModel.reset()
@@ -79,11 +79,11 @@ export function applyMountains(ctx: ExtendedMapContext) {
 
 ## Acceptance Criteria
 
-- [ ] No layer file contains `import { WorldModel } from`
-- [ ] Layers read from `ctx.foundation.plates.*` and `ctx.foundation.dynamics.*`
-- [ ] `BOUNDARY_TYPE` exported from shared location (not requiring WorldModel import)
-- [ ] `WorldModel.reset()` exists and is called in orchestrator entry
-- [ ] Build passes, existing tests still pass
+- [x] No layer file contains `import { WorldModel } from`
+- [x] Layers read from `ctx.foundation.plates.*` and `ctx.foundation.dynamics.*`
+- [x] `BOUNDARY_TYPE` exported from shared location (not requiring WorldModel import)
+- [x] `WorldModel.reset()` exists and is called in orchestrator entry
+- [x] Build passes, existing tests still pass
 - [ ] Pipeline still "null script" (expected — stages not yet enabled in Stack 2)
 
 ## Testing / Verification

--- a/docs/projects/engine-refactor-v1/reviews/M-TS-typescript-migration-remediation-review.md
+++ b/docs/projects/engine-refactor-v1/reviews/M-TS-typescript-migration-remediation-review.md
@@ -1,0 +1,62 @@
+---
+id: M-TS-remediation-review
+milestone: M-TS-typescript-migration
+title: "M-TS: TypeScript Migration Remediation – Aggregate Review"
+status: draft
+reviewer: AI agent (Codex CLI)
+---
+
+# M-TS: TypeScript Migration Remediation – Aggregate Review
+
+This document aggregates task-level reviews for the post-migration remediation stack
+focused on fixing the TypeScript migration’s "null script" behavior and restoring
+runtime correctness: CIV-15 (Adapter Boundary & Orchestrator), CIV-16 (FoundationContext
+consumption), and related follow-ups.
+
+---
+
+## CIV-15 – Fix Adapter Boundary & Orchestration Wiring
+
+**Intent / AC (short)**  
+Centralize engine adapter construction around `@civ7/adapter` in `MapOrchestrator` and introduce a guardrail that prevents `/base-standard/...` imports from leaking outside the adapter package, while keeping the codebase usable and testable.
+
+**Strengths**
+- Replaces dynamic `require("./core/adapters.js")` and the global fallback adapter with a clear, testable adapter selection strategy:
+  - `adapter` → `createAdapter` → `new Civ7Adapter(width, height)`.
+- Adds `scripts/lint-adapter-boundary.sh` and a `lint:adapter-boundary` npm script to enforce the adapter boundary with an explicit allowlist.
+- Keeps changes narrowly focused on orchestrator wiring and linting, which is appropriate for an architectural remediation issue.
+
+**Issues / gaps**
+- JSDoc on `createAdapter` slightly misrepresents the defaulting behavior compared to the implementation.
+- The adapter-boundary lint is not yet integrated into the main lint/CI pipeline; enforcement is available but not guaranteed.
+- `MapOrchestrator.ts` and `layers/placement.ts` still contain `/base-standard/...` imports and rely on allowlist entries instead of fully honoring the adapter boundary.
+- No explicit tests assert adapter selection behavior in `MapOrchestrator`.
+
+**Suggested follow-up**
+- Wire `lint:adapter-boundary` into CI or `pnpm lint` and treat allowlisted files as temporary debt with clear owning issues.
+- Add small tests to verify adapter precedence and default construction logic.
+- In subsequent placement/story/biomes/feature integration tasks, move remaining `/base-standard/...` imports behind `@civ7/adapter` and remove the corresponding files from the allowlist.
+
+---
+
+## CIV-16 – Migrate Layers to FoundationContext Consumption
+
+**Intent / AC (short)**  
+Move tectonics- and climate-related layers off the `WorldModel` singleton onto `ctx.foundation` (immutable snapshot), centralize `BOUNDARY_TYPE` in a shared module, and confine `WorldModel.init/reset` usage to the orchestrator to support testability and multi-run determinism.
+
+**Strengths**
+- Updated key layers (`landmass-plate.ts`, `coastlines.ts`, `mountains.ts`, `volcanoes.ts`, `landmass-utils.ts`, `climate-engine.ts`) to consume `ctx.foundation.plates` / `.dynamics` instead of importing `WorldModel` directly.
+- Introduced `world/constants.ts` as the shared home for `BOUNDARY_TYPE`, so layers don’t need to import the singleton for enum values.
+- Implemented a robust `FoundationContext` in `core/types.ts` with validation and frozen snapshots, and wired it into `MapOrchestrator.initializeFoundation`.
+- Restricted `WorldModel` usage in TS source to the orchestrator and the world module itself, improving isolation and testability.
+
+**Issues / gaps**
+- ~~`WorldModel.reset()` is implemented but never called in `MapOrchestrator.generateMap`, so world fields are not recomputed across runs and can drift from current tunables.~~ **FIXED**: Added `WorldModel.reset()` call at the start of `generateMap()`.
+- ~~Physics-driven stages tolerate missing `ctx.foundation` via silent fallbacks (fractals-only, no volcanoes, no ocean separation) rather than failing fast, which can mask manifest or wiring issues.~~ **FIXED**: Added `assertFoundationContext()` guard to all foundation-dependent stages.
+- No dedicated tests assert that layers depend only on `FoundationContext` (and not `WorldModel`) or that their behavior updates when `FoundationContext` changes.
+
+**Suggested follow-up**
+- ~~Add a `WorldModel.reset()` call at the start of `MapOrchestrator.generateMap` and consider passing explicit dimensions into `WorldModel.init` for better testability.~~ **DONE**
+- ~~Introduce `assertFoundationContext` (or equivalent checks) for all stages that require foundation data (`landmassPlates`, `mountains`, `volcanoes`, `climateBaseline`, `climateRefine`) and surface failures via `StageResult`.~~ **DONE**
+- Add small unit/integration tests that construct synthetic `ExtendedMapContext` + `FoundationContext` and exercise the migrated layers, ensuring they remain decoupled from `WorldModel` and respond correctly to changes in plate/dynamics fields.
+

--- a/packages/mapgen-core/src/layers/coastlines.ts
+++ b/packages/mapgen-core/src/layers/coastlines.ts
@@ -17,7 +17,7 @@ import type {
   CorridorsConfig,
 } from "../bootstrap/types.js";
 import { ctxRandom, writeHeightfield } from "../core/types.js";
-import { WorldModel, BOUNDARY_TYPE } from "../world/model.js";
+import { BOUNDARY_TYPE } from "../world/constants.js";
 import { getStoryTags } from "../story/tags.js";
 import { getTunables } from "../bootstrap/tunables.js";
 
@@ -113,10 +113,10 @@ export function addRuggedCoasts(
     adapter.createFractal(HILL_FRACTAL, iWidth, iHeight, 4, 0);
   }
 
-  // WorldModel integration
-  const worldModelEnabled = WorldModel.isEnabled();
-  const boundaryCloseness = worldModelEnabled ? WorldModel.boundaryCloseness : null;
-  const boundaryType = worldModelEnabled ? WorldModel.boundaryType : null;
+  // Foundation context integration (plate data)
+  const foundation = ctx?.foundation;
+  const boundaryCloseness = foundation?.plates.boundaryCloseness ?? null;
+  const boundaryType = foundation?.plates.boundaryType ?? null;
 
   // Configuration
   const tunables = getTunables();

--- a/packages/mapgen-core/src/layers/landmass-plate.ts
+++ b/packages/mapgen-core/src/layers/landmass-plate.ts
@@ -17,7 +17,7 @@ import type {
   LandmassGeometryPost,
 } from "../bootstrap/types.js";
 import { writeHeightfield } from "../core/types.js";
-import { WorldModel, BOUNDARY_TYPE } from "../world/model.js";
+import { BOUNDARY_TYPE } from "../world/constants.js";
 import { getTunables } from "../bootstrap/tunables.js";
 import type { LandmassWindow } from "./landmass-utils.js";
 
@@ -137,14 +137,17 @@ export function createPlateDrivenLandmasses(
   ctx?: ExtendedMapContext | null,
   options: CreateLandmassesOptions = {}
 ): LandmassGenerationResult | null {
-  if (!WorldModel.isEnabled()) {
+  // Require foundation context for plate data
+  const foundation = ctx?.foundation;
+  if (!foundation) {
     return null;
   }
 
-  const shield = WorldModel.shieldStability;
-  const closeness = WorldModel.boundaryCloseness;
-  const boundaryType = WorldModel.boundaryType;
-  const plateIds = WorldModel.plateId;
+  const { plates } = foundation;
+  const shield = plates.shieldStability;
+  const closeness = plates.boundaryCloseness;
+  const boundaryType = plates.boundaryType;
+  const plateIds = plates.id;
 
   if (!shield || !closeness || !boundaryType || !plateIds) {
     return null;

--- a/packages/mapgen-core/src/layers/landmass-utils.ts
+++ b/packages/mapgen-core/src/layers/landmass-utils.ts
@@ -14,7 +14,6 @@ import type {
   OceanSeparationEdgePolicy,
 } from "../bootstrap/types.js";
 import { writeHeightfield } from "../core/types.js";
-import { WorldModel } from "../world/model.js";
 import { getTunables } from "../bootstrap/tunables.js";
 
 // ============================================================================
@@ -311,10 +310,12 @@ export function applyPlateAwareOceanSeparation(
   const foundationPolicy = tunables.FOUNDATION_CFG?.oceanSeparation as OceanSeparationPolicy | undefined;
   const policy = params?.policy || foundationPolicy || DEFAULT_OCEAN_SEPARATION;
 
+  // Require foundation context for plate data
+  const foundation = ctx?.foundation;
   if (
     !policy ||
     !policy.enabled ||
-    !WorldModel.isEnabled()
+    !foundation
   ) {
     return {
       windows: windows.map((win, idx) => normalizeWindow(win, idx, width, height)),
@@ -322,7 +323,7 @@ export function applyPlateAwareOceanSeparation(
     };
   }
 
-  const closeness = WorldModel.boundaryCloseness;
+  const closeness = foundation.plates.boundaryCloseness;
   if (!closeness || closeness.length !== width * height) {
     return {
       windows: windows.map((win, idx) => normalizeWindow(win, idx, width, height)),

--- a/packages/mapgen-core/src/layers/volcanoes.ts
+++ b/packages/mapgen-core/src/layers/volcanoes.ts
@@ -17,7 +17,7 @@ import type { ExtendedMapContext } from "../core/types.js";
 import type { EngineAdapter, FeatureData } from "@civ7/adapter";
 import type { VolcanoesConfig as BootstrapVolcanoesConfig } from "../bootstrap/types.js";
 import { writeHeightfield } from "../core/types.js";
-import { WorldModel, BOUNDARY_TYPE } from "../world/model.js";
+import { BOUNDARY_TYPE } from "../world/constants.js";
 
 // ============================================================================
 // Types
@@ -125,13 +125,19 @@ export function layerAddVolcanoesPlateAware(
     return;
   }
 
-  const worldEnabled = WorldModel.isEnabled();
-  const boundaryCloseness = WorldModel.boundaryCloseness;
-  const boundaryType = WorldModel.boundaryType;
-  const shieldStability = WorldModel.shieldStability;
+  // Require foundation context for plate data
+  const foundation = ctx?.foundation;
+  if (!foundation) {
+    // Foundation unavailable - skip placement
+    return;
+  }
 
-  if (!worldEnabled || !boundaryCloseness || !boundaryType) {
-    // WorldModel unavailable - skip placement
+  const { plates } = foundation;
+  const boundaryCloseness = plates.boundaryCloseness;
+  const boundaryType = plates.boundaryType;
+  const shieldStability = plates.shieldStability;
+
+  if (!boundaryCloseness || !boundaryType) {
     return;
   }
 

--- a/packages/mapgen-core/src/world/constants.ts
+++ b/packages/mapgen-core/src/world/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * World Constants
+ *
+ * Shared constants for world simulation.
+ * Extracted to avoid requiring WorldModel import for constants only.
+ */
+
+// Re-export BOUNDARY_TYPE from types for convenience
+export { BOUNDARY_TYPE, type BoundaryType, type BoundaryTypeName } from "./types.js";


### PR DESCRIPTION
Layers now read plate/dynamics data from ctx.foundation instead of
importing the WorldModel singleton directly. This completes the
context-based data flow pattern established in the original architecture.

Changes:
- Create world/constants.ts re-exporting BOUNDARY_TYPE
- Update landmass-plate.ts to use ctx.foundation.plates.*
- Update coastlines.ts to use ctx.foundation.plates.*
- Update mountains.ts to use ctx.foundation.plates.*
- Update volcanoes.ts to use ctx.foundation.plates.*
- Update landmass-utils.ts to use ctx.foundation.plates.*
- Update climate-engine.ts to use ctx.foundation.dynamics.*

No layer file now imports WorldModel directly. The singleton is only
used by the orchestrator for init/reset lifecycle.

Fixes CIV-16. Remediates CIV-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>