### PR TITLE
feat(mapgen-core): implement config to manifest resolver (CIV-17)

### DIFF
--- a/docs/projects/engine-refactor-v1/issues/CIV-17-config-manifest-resolver.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-17-config-manifest-resolver.md
@@ -47,17 +47,17 @@ All 14 stages skipped  ← "NULL SCRIPT"
 
 ## Deliverables
 
-- [ ] **Implement minimal resolver:**
+- [x] **Implement minimal resolver:**
   - Create `bootstrap/resolved.ts` (or integrate into existing bootstrap)
   - Map `stageConfig` booleans into `StageManifest.stages` structure
-  - Use canonical stage order from `bootstrap/defaults/base.js`
-- [ ] **Ensure `tunables.STAGE_MANIFEST` is populated:**
+  - Use canonical stage order from `MapOrchestrator.resolveStageFlags()`
+- [x] **Ensure `tunables.STAGE_MANIFEST` is populated:**
   - After `bootstrap()` completes, `STAGE_MANIFEST.stages` should contain enabled flags
   - `stageEnabled()` should return the intended boolean values
-- [ ] **Reintroduce minimal `[StageManifest]` warnings:**
+- [x] **Reintroduce minimal `[StageManifest]` warnings:**
   - Warn when overrides target missing or disabled stages
   - Helps catch configuration errors early
-- [ ] **Add resolver unit test:**
+- [x] **Add resolver unit test:**
   - Given `stageConfig: { foundation: true, landmassPlates: true }`
   - Assert `stageEnabled("foundation") === true`
   - Assert `stageEnabled("landmassPlates") === true`
@@ -65,10 +65,10 @@ All 14 stages skipped  ← "NULL SCRIPT"
 
 ## Acceptance Criteria
 
-- [ ] `stageEnabled("foundation")` returns `true` when `stageConfig.foundation = true`
-- [ ] `stageEnabled("landmassPlates")` returns `true` when `stageConfig.landmassPlates = true`
-- [ ] Resolver test confirms stageConfig→manifest mapping works
-- [ ] Build passes, tests pass
+- [x] `stageEnabled("foundation")` returns `true` when `stageConfig.foundation = true`
+- [x] `stageEnabled("landmassPlates")` returns `true` when `stageConfig.landmassPlates = true`
+- [x] Resolver test confirms stageConfig→manifest mapping works
+- [x] Build passes, tests pass
 - [ ] Pipeline still won't generate full terrain (depends on later stacks), but stages should now *attempt* to execute
 
 ## Testing / Verification

--- a/packages/mapgen-core/src/MapOrchestrator.ts
+++ b/packages/mapgen-core/src/MapOrchestrator.ts
@@ -46,6 +46,7 @@ import {
 } from "./core/types.js";
 import { addPlotTagsSimple, type TerrainBuilderLike } from "./core/plot-tags.js";
 import { getTunables, resetTunables, stageEnabled } from "./bootstrap/tunables.js";
+import { validateStageDrift } from "./bootstrap/resolved.js";
 import { resetStoryTags } from "./story/tags.js";
 import { WorldModel } from "./world/model.js";
 
@@ -695,7 +696,7 @@ export class MapOrchestrator {
   // ==========================================================================
 
   private resolveStageFlags(): Record<string, boolean> {
-    return {
+    const flags = {
       foundation: stageEnabled("foundation"),
       landmassPlates: stageEnabled("landmassPlates"),
       coastlines: stageEnabled("coastlines"),
@@ -717,6 +718,11 @@ export class MapOrchestrator {
       features: stageEnabled("features"),
       placement: stageEnabled("placement"),
     };
+
+    // Validate resolver/orchestrator stage alignment (runs once per session)
+    validateStageDrift(Object.keys(flags));
+
+    return flags;
   }
 
   private runStage(name: string, fn: () => void): StageResult {

--- a/packages/mapgen-core/src/bootstrap/entry.ts
+++ b/packages/mapgen-core/src/bootstrap/entry.ts
@@ -19,6 +19,7 @@
 import type { MapConfig } from "./types.js";
 import { setConfig, resetConfig } from "./runtime.js";
 import { resetTunables, rebind as rebindTunables } from "./tunables.js";
+import { resolveStageManifest, validateOverrides } from "./resolved.js";
 
 // ============================================================================
 // Types
@@ -117,6 +118,16 @@ export function bootstrap(options: BootstrapConfig = {}): void {
   if (presets) cfg.presets = presets;
   if (stageConfig) cfg.stageConfig = stageConfig;
 
+  // Resolve stageConfig → stageManifest (bridges the "Config Air Gap")
+  // This ensures stageEnabled() returns the correct values
+  const manifest = resolveStageManifest(stageConfig);
+  cfg.stageManifest = manifest;
+
+  // Validate overrides against manifest (warn about targeting disabled stages)
+  if (overrides) {
+    validateOverrides(overrides, manifest);
+  }
+
   // Merge overrides (highest precedence)
   if (overrides) {
     Object.assign(cfg, deepMerge(cfg, overrides as Partial<MapConfig>));
@@ -150,5 +161,12 @@ export function rebind(): void {
 export type { MapConfig } from "./types.js";
 export { setConfig, getConfig, resetConfig } from "./runtime.js";
 export { getTunables, resetTunables, stageEnabled, TUNABLES } from "./tunables.js";
+export {
+  STAGE_ORDER,
+  resolveStageManifest,
+  validateOverrides,
+  validateStageDrift,
+  resetDriftCheck,
+} from "./resolved.js";
 
 export default { bootstrap, resetBootstrap, rebind };

--- a/packages/mapgen-core/test/bootstrap/resolved.test.ts
+++ b/packages/mapgen-core/test/bootstrap/resolved.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Stage Manifest Resolver Tests
+ *
+ * Tests for the Config Air Gap fix: stageConfig -> stageManifest resolution.
+ *
+ * Key acceptance criteria:
+ * - stageEnabled("foundation") returns true when stageConfig.foundation = true
+ * - stageEnabled("landmassPlates") returns true when stageConfig.landmassPlates = true
+ * - Disabled stages return false
+ */
+
+import { describe, it, expect, beforeEach, spyOn } from "bun:test";
+import {
+  bootstrap,
+  resetBootstrap,
+  stageEnabled,
+  STAGE_ORDER,
+  resolveStageManifest,
+  validateOverrides,
+  validateStageDrift,
+  resetDriftCheck,
+  getConfig,
+} from "../../src/bootstrap/entry.js";
+
+describe("bootstrap/resolved", () => {
+  beforeEach(() => {
+    resetBootstrap();
+    resetDriftCheck();
+  });
+
+  describe("STAGE_ORDER", () => {
+    it("exports canonical stage order", () => {
+      expect(STAGE_ORDER).toBeDefined();
+      expect(Array.isArray(STAGE_ORDER)).toBe(true);
+      expect(STAGE_ORDER.length).toBeGreaterThan(0);
+    });
+
+    it("includes core stages in correct order", () => {
+      expect(STAGE_ORDER[0]).toBe("foundation");
+      expect(STAGE_ORDER[1]).toBe("landmassPlates");
+      expect(STAGE_ORDER).toContain("coastlines");
+      expect(STAGE_ORDER).toContain("mountains");
+      expect(STAGE_ORDER).toContain("biomes");
+      expect(STAGE_ORDER).toContain("placement");
+    });
+
+    it("is frozen (immutable)", () => {
+      expect(Object.isFrozen(STAGE_ORDER)).toBe(true);
+    });
+  });
+
+  describe("resolveStageManifest", () => {
+    it("creates manifest with all stages from STAGE_ORDER", () => {
+      const manifest = resolveStageManifest({});
+
+      expect(manifest.order).toEqual([...STAGE_ORDER]);
+      expect(Object.keys(manifest.stages).length).toBe(STAGE_ORDER.length);
+    });
+
+    it("enables stages that are true in stageConfig", () => {
+      const manifest = resolveStageManifest({
+        foundation: true,
+        landmassPlates: true,
+        coastlines: true,
+      });
+
+      expect(manifest.stages.foundation?.enabled).toBe(true);
+      expect(manifest.stages.landmassPlates?.enabled).toBe(true);
+      expect(manifest.stages.coastlines?.enabled).toBe(true);
+    });
+
+    it("disables stages that are false in stageConfig", () => {
+      const manifest = resolveStageManifest({
+        foundation: false,
+        biomes: false,
+      });
+
+      expect(manifest.stages.foundation?.enabled).toBe(false);
+      expect(manifest.stages.biomes?.enabled).toBe(false);
+    });
+
+    it("disables stages not present in stageConfig", () => {
+      const manifest = resolveStageManifest({
+        foundation: true,
+      });
+
+      // Only foundation enabled, all others disabled
+      expect(manifest.stages.foundation?.enabled).toBe(true);
+      expect(manifest.stages.landmassPlates?.enabled).toBe(false);
+      expect(manifest.stages.coastlines?.enabled).toBe(false);
+      expect(manifest.stages.biomes?.enabled).toBe(false);
+    });
+
+    it("handles undefined stageConfig", () => {
+      const manifest = resolveStageManifest(undefined);
+
+      // All stages disabled
+      expect(manifest.stages.foundation?.enabled).toBe(false);
+      expect(manifest.stages.landmassPlates?.enabled).toBe(false);
+    });
+
+    it("handles empty stageConfig", () => {
+      const manifest = resolveStageManifest({});
+
+      // All stages disabled
+      expect(manifest.stages.foundation?.enabled).toBe(false);
+      expect(manifest.stages.landmassPlates?.enabled).toBe(false);
+    });
+  });
+
+  describe("stageEnabled integration", () => {
+    it("returns true for enabled stages after bootstrap", () => {
+      bootstrap({
+        stageConfig: {
+          foundation: true,
+          landmassPlates: true,
+          coastlines: true,
+        },
+      });
+
+      expect(stageEnabled("foundation")).toBe(true);
+      expect(stageEnabled("landmassPlates")).toBe(true);
+      expect(stageEnabled("coastlines")).toBe(true);
+    });
+
+    it("returns false for disabled stages after bootstrap", () => {
+      bootstrap({
+        stageConfig: {
+          foundation: true,
+          landmassPlates: true,
+        },
+      });
+
+      // Not enabled in stageConfig
+      expect(stageEnabled("biomes")).toBe(false);
+      expect(stageEnabled("features")).toBe(false);
+      expect(stageEnabled("placement")).toBe(false);
+    });
+
+    it("returns false for unknown stages", () => {
+      bootstrap({
+        stageConfig: {
+          foundation: true,
+        },
+      });
+
+      expect(stageEnabled("nonexistent")).toBe(false);
+    });
+
+    it("populates stageManifest in config after bootstrap", () => {
+      bootstrap({
+        stageConfig: {
+          foundation: true,
+          mountains: true,
+        },
+      });
+
+      const config = getConfig();
+      expect(config.stageManifest).toBeDefined();
+      expect(config.stageManifest?.stages?.foundation?.enabled).toBe(true);
+      expect(config.stageManifest?.stages?.mountains?.enabled).toBe(true);
+      expect(config.stageManifest?.stages?.biomes?.enabled).toBe(false);
+    });
+  });
+
+  describe("validateOverrides", () => {
+    it("warns when override targets disabled stage", () => {
+      const warnSpy = spyOn(console, "warn");
+
+      const manifest = resolveStageManifest({
+        foundation: true,
+        // biomes NOT enabled
+      });
+
+      validateOverrides({ biomes: { tundra: { latMin: 80 } } }, manifest);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[StageManifest] Override targets disabled stage: "biomes"'
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("does not warn when override targets enabled stage", () => {
+      const warnSpy = spyOn(console, "warn");
+
+      const manifest = resolveStageManifest({
+        foundation: true,
+        biomes: true,
+      });
+
+      validateOverrides({ biomes: { tundra: { latMin: 80 } } }, manifest);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it("does not warn for non-stage override keys", () => {
+      const warnSpy = spyOn(console, "warn");
+
+      const manifest = resolveStageManifest({ foundation: true });
+
+      // These are config keys, not stage names
+      validateOverrides(
+        {
+          landmass: { baseWaterPercent: 40 },
+          toggles: { STORY_ENABLE_HOTSPOTS: false },
+        },
+        manifest
+      );
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it("handles undefined overrides", () => {
+      const manifest = resolveStageManifest({ foundation: true });
+
+      // Should not throw
+      expect(() => validateOverrides(undefined, manifest)).not.toThrow();
+    });
+  });
+
+  describe("full integration: Config Air Gap fix", () => {
+    it("stageConfig enables stages via manifest (acceptance test)", () => {
+      // This is the key acceptance test from the issue spec
+      bootstrap({
+        stageConfig: {
+          foundation: true,
+          landmassPlates: true,
+          coastlines: true,
+        },
+      });
+
+      expect(stageEnabled("foundation")).toBe(true);
+      expect(stageEnabled("landmassPlates")).toBe(true);
+      expect(stageEnabled("coastlines")).toBe(true);
+      expect(stageEnabled("biomes")).toBe(false); // Not enabled
+    });
+
+    it("all stages disabled when no stageConfig provided", () => {
+      bootstrap({});
+
+      // Without stageConfig, all stages should be disabled
+      expect(stageEnabled("foundation")).toBe(false);
+      expect(stageEnabled("landmassPlates")).toBe(false);
+    });
+
+    it("stages remain correct after resetBootstrap", () => {
+      bootstrap({
+        stageConfig: { foundation: true },
+      });
+      expect(stageEnabled("foundation")).toBe(true);
+
+      resetBootstrap();
+      expect(stageEnabled("foundation")).toBe(false);
+
+      bootstrap({
+        stageConfig: { biomes: true },
+      });
+      expect(stageEnabled("foundation")).toBe(false);
+      expect(stageEnabled("biomes")).toBe(true);
+    });
+  });
+
+  describe("validateStageDrift", () => {
+    it("does not warn when orchestrator stages match STAGE_ORDER", () => {
+      const warnSpy = spyOn(console, "warn");
+
+      // Pass the exact STAGE_ORDER - no drift
+      validateStageDrift([...STAGE_ORDER]);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it("warns when orchestrator has stage not in STAGE_ORDER", () => {
+      const warnSpy = spyOn(console, "warn");
+
+      // Orchestrator has extra stage not in resolver
+      validateStageDrift([...STAGE_ORDER, "newOrchestratorStage"]);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Orchestrator has stage "newOrchestratorStage" not in STAGE_ORDER')
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("warns when STAGE_ORDER has stage not in orchestrator", () => {
+      const warnSpy = spyOn(console, "warn");
+
+      // Orchestrator is missing a stage from STAGE_ORDER
+      const partialStages = STAGE_ORDER.slice(0, -1); // Remove last stage
+      validateStageDrift([...partialStages]);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("not in orchestrator")
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("only runs once per session", () => {
+      const warnSpy = spyOn(console, "warn");
+
+      // First call - should check
+      validateStageDrift(["missingStage"]);
+      expect(warnSpy).toHaveBeenCalled();
+
+      warnSpy.mockClear();
+
+      // Second call - should be no-op
+      validateStageDrift(["anotherMissingStage"]);
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it("can be reset with resetDriftCheck", () => {
+      const warnSpy = spyOn(console, "warn");
+
+      validateStageDrift(["missingStage"]);
+      expect(warnSpy).toHaveBeenCalled();
+
+      warnSpy.mockClear();
+      resetDriftCheck();
+
+      // After reset, should check again
+      validateStageDrift(["anotherMissingStage"]);
+      expect(warnSpy).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
Bridge the "Config Air Gap" by implementing a resolver that translates
stageConfig booleans into StageManifest structure that stageEnabled() reads.

- Add bootstrap/resolved.ts with resolveStageManifest() and STAGE_ORDER
- Integrate resolver into bootstrap() to populate stageManifest
- Add validateOverrides() warnings for disabled stage overrides
- Add comprehensive unit tests for resolver functionality

This fixes the root cause where all stages were being skipped because
stageManifest was never populated from stageConfig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>