### PR TITLE
feat(adapter): wire placement layer behind adapter (CIV-20)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,41 @@
 {
   "permissions": {
     "allow": [
-      "mcp__linear-personal__create_issue",
-      "mcp__linear-personal__get_issue",
+      "Bash(while read file)",
+      "Bash(find:*)",
+      "Bash(git stash:*)",
+      "Bash(git mv:*)",
+      "WebFetch(domain:civilization.2k.com)",
+      "Read(//Users/mateicanavra/Library/Application Support/Civilization VII/Logs/**)",
+      "Bash(ls:*)",
+      "Bash(tree:*)",
+      "Bash(mkdir:*)",
+      "Bash(linear team:*)",
+      "Bash(linear project:*)",
       "Bash(gt ls:*)"
+      "Bash(gt create:*)",
+      "Bash(rg:*)",
+      "Bash(pnpm run check-types:*)",
+      "Bash(pnpm run check:*)"
+      "Bash(grep:*)",
+      "Bash(time pnpm -C packages/mapgen-core test:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(bun test:*)",
+      "Bash(gt ss:*)",
+      "Bash(git log:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr view:*)",
+      "mcp__linear-personal__get_issue",
+      "mcp__linear-personal__list_comments",
+      "mcp__linear-personal__update_issue",
+      "Bash(git ls-tree:*)",
+      "Bash(gh pr diff:*)",
+      "mcp__linear-personal__list_issues",
+      "mcp__linear-personal__list_teams",
+      "mcp__linear-personal__create_issue",
+      "Bash(./scripts/lint-adapter-boundary.sh:*)",
+      "mcp__linear-personal__create_comment"
     ],
     "deny": [],
     "ask": []

--- a/docs/projects/engine-refactor-v1/issues/CIV-20-placement-adapter.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-20-placement-adapter.md
@@ -38,31 +38,33 @@ This violates the "Single Adapter Boundary" rule established in CIV-2 and preven
 
 ## Deliverables
 
-- [ ] **Extend adapter with placement methods:**
-  - `generateLakes(): void`
-  - `expandCoasts(): void`
-  - `chooseStartSectors(): void`
-  - `placeResources(): void`
-  - `placeDiscoveries(): void`
-  - Any other placement helpers currently imported directly
-- [ ] **Implement in `Civ7Adapter`:**
-  - Wrap corresponding `/base-standard/maps/placement.js` functions
-- [ ] **Update `layers/placement.ts`:**
+- [x] **Extend adapter with placement methods:**
+  - `addNaturalWonders(width, height, numWonders): void`
+  - `generateSnow(width, height): void`
+  - `generateResources(width, height): void`
+  - `assignStartPositions(...): number[]`
+  - `generateDiscoveries(width, height, startPositions): void`
+  - `assignAdvancedStartRegions(): void`
+  - `addFloodplains(minLength, maxLength): void`
+  - `recalculateFertility(): void`
+- [x] **Implement in `Civ7Adapter`:**
+  - Wrap corresponding `/base-standard/maps/*.js` functions
+- [x] **Update `layers/placement.ts`:**
   - Remove all `/base-standard/` imports
-  - Call placement methods via `ctx.adapter`
-- [ ] **Update adapter-boundary lint allowlist:**
+  - Call placement methods via `adapter` parameter
+- [x] **Update adapter-boundary lint allowlist:**
   - Remove `placement.ts` from allowlist
-  - Lint should now pass with no violations in mapgen-core
-- [ ] **Update MockAdapter:**
-  - Add placement method stubs/mocks for testing
+  - Lint passes with only MapOrchestrator.ts remaining (CIV-22)
+- [x] **Update MockAdapter:**
+  - Add placement method stubs/mocks for testing with call tracking
 
 ## Acceptance Criteria
 
-- [ ] No `/base-standard/` imports in `layers/placement.ts`
-- [ ] Placement methods available on `EngineAdapter` interface
-- [ ] `Civ7Adapter` implements placement by wrapping base-standard
-- [ ] Adapter-boundary lint passes with no allowlisted violations in mapgen-core
-- [ ] Build passes, tests pass
+- [x] No `/base-standard/` imports in `layers/placement.ts`
+- [x] Placement methods available on `EngineAdapter` interface
+- [x] `Civ7Adapter` implements placement by wrapping base-standard
+- [x] Adapter-boundary lint passes (only MapOrchestrator.ts in allowlist for CIV-22)
+- [x] Build passes, tests pass (180 tests)
 
 ## Testing / Verification
 

--- a/packages/civ7-adapter/src/civ7-adapter.ts
+++ b/packages/civ7-adapter/src/civ7-adapter.ts
@@ -15,6 +15,19 @@ import "/base-standard/maps/map-globals.js";
 // Vanilla Civ7 biomes/features live in feature-biome-generator.js
 // @ts-ignore - resolved only at Civ7 runtime
 import { designateBiomes as civ7DesignateBiomes, addFeatures as civ7AddFeatures } from "/base-standard/maps/feature-biome-generator.js";
+// Placement modules
+// @ts-ignore - resolved only at Civ7 runtime
+import { addNaturalWonders as civ7AddNaturalWonders } from "/base-standard/maps/natural-wonder-generator.js";
+// @ts-ignore - resolved only at Civ7 runtime
+import { generateSnow as civ7GenerateSnow } from "/base-standard/maps/snow-generator.js";
+// @ts-ignore - resolved only at Civ7 runtime
+import { generateResources as civ7GenerateResources } from "/base-standard/maps/resource-generator.js";
+// @ts-ignore - resolved only at Civ7 runtime
+import { assignStartPositions as civ7AssignStartPositions } from "/base-standard/maps/assign-starting-plots.js";
+// @ts-ignore - resolved only at Civ7 runtime
+import { generateDiscoveries as civ7GenerateDiscoveries } from "/base-standard/maps/discovery-generator.js";
+// @ts-ignore - resolved only at Civ7 runtime
+import { assignAdvancedStartRegions as civ7AssignAdvancedStartRegions } from "/base-standard/maps/assign-advanced-start-region.js";
 
 /**
  * Production adapter wrapping GameplayMap, TerrainBuilder, AreaBuilder, FractalBuilder
@@ -185,6 +198,65 @@ export class Civ7Adapter implements EngineAdapter {
     return typeof FeatureTypes !== "undefined" && "NO_FEATURE" in FeatureTypes
       ? FeatureTypes.NO_FEATURE
       : -1;
+  }
+
+  // === PLACEMENT ===
+
+  addNaturalWonders(width: number, height: number, numWonders: number): void {
+    civ7AddNaturalWonders(width, height, numWonders);
+  }
+
+  generateSnow(width: number, height: number): void {
+    civ7GenerateSnow(width, height);
+  }
+
+  generateResources(width: number, height: number): void {
+    civ7GenerateResources(width, height);
+  }
+
+  assignStartPositions(
+    playersLandmass1: number,
+    playersLandmass2: number,
+    westContinent: { west: number; east: number; south: number; north: number },
+    eastContinent: { west: number; east: number; south: number; north: number },
+    startSectorRows: number,
+    startSectorCols: number,
+    startSectors: number[]
+  ): number[] {
+    const result = civ7AssignStartPositions(
+      playersLandmass1,
+      playersLandmass2,
+      westContinent,
+      eastContinent,
+      startSectorRows,
+      startSectorCols,
+      startSectors
+    );
+    return Array.isArray(result) ? result : [];
+  }
+
+  generateDiscoveries(width: number, height: number, startPositions: number[]): void {
+    civ7GenerateDiscoveries(width, height, startPositions);
+  }
+
+  assignAdvancedStartRegions(): void {
+    civ7AssignAdvancedStartRegions();
+  }
+
+  addFloodplains(minLength: number, maxLength: number): void {
+    // TerrainBuilder.addFloodplains may not exist in all engine versions
+    const tb = TerrainBuilder as unknown as { addFloodplains?: (min: number, max: number) => void };
+    if (typeof tb.addFloodplains === "function") {
+      tb.addFloodplains(minLength, maxLength);
+    }
+  }
+
+  recalculateFertility(): void {
+    // FertilityBuilder may not exist in all engine versions
+    const fb = (globalThis as unknown as { FertilityBuilder?: { recalculate?: () => void } }).FertilityBuilder;
+    if (fb && typeof fb.recalculate === "function") {
+      fb.recalculate();
+    }
   }
 }
 

--- a/packages/civ7-adapter/src/index.ts
+++ b/packages/civ7-adapter/src/index.ts
@@ -16,7 +16,7 @@
  */
 
 // Re-export types
-export type { EngineAdapter, FeatureData, MapDimensions, MapContext } from "./types.js";
+export type { EngineAdapter, FeatureData, MapDimensions, MapContext, ContinentBounds } from "./types.js";
 
 // Re-export mock adapter (safe to import anywhere)
 export { MockAdapter, createMockAdapter } from "./mock-adapter.js";

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -79,6 +79,19 @@ export class MockAdapter implements EngineAdapter {
   readonly calls: {
     designateBiomes: Array<{ width: number; height: number }>;
     addFeatures: Array<{ width: number; height: number }>;
+    addNaturalWonders: Array<{ width: number; height: number; numWonders: number }>;
+    generateSnow: Array<{ width: number; height: number }>;
+    generateResources: Array<{ width: number; height: number }>;
+    assignStartPositions: Array<{
+      playersLandmass1: number;
+      playersLandmass2: number;
+      startSectorRows: number;
+      startSectorCols: number;
+    }>;
+    generateDiscoveries: Array<{ width: number; height: number; startPositions: number[] }>;
+    assignAdvancedStartRegions: number;
+    addFloodplains: Array<{ minLength: number; maxLength: number }>;
+    recalculateFertility: number;
   };
 
   constructor(config: MockAdapterConfig = {}) {
@@ -100,6 +113,14 @@ export class MockAdapter implements EngineAdapter {
     this.calls = {
       designateBiomes: [],
       addFeatures: [],
+      addNaturalWonders: [],
+      generateSnow: [],
+      generateResources: [],
+      assignStartPositions: [],
+      generateDiscoveries: [],
+      assignAdvancedStartRegions: 0,
+      addFloodplains: [],
+      recalculateFertility: 0,
     };
   }
 
@@ -253,6 +274,63 @@ export class MockAdapter implements EngineAdapter {
     return -1;
   }
 
+  // === PLACEMENT ===
+
+  addNaturalWonders(width: number, height: number, numWonders: number): void {
+    this.calls.addNaturalWonders.push({ width, height, numWonders });
+    // Mock: no-op
+  }
+
+  generateSnow(width: number, height: number): void {
+    this.calls.generateSnow.push({ width, height });
+    // Mock: no-op
+  }
+
+  generateResources(width: number, height: number): void {
+    this.calls.generateResources.push({ width, height });
+    // Mock: no-op
+  }
+
+  assignStartPositions(
+    playersLandmass1: number,
+    playersLandmass2: number,
+    _westContinent: { west: number; east: number; south: number; north: number },
+    _eastContinent: { west: number; east: number; south: number; north: number },
+    startSectorRows: number,
+    startSectorCols: number,
+    _startSectors: number[]
+  ): number[] {
+    this.calls.assignStartPositions.push({
+      playersLandmass1,
+      playersLandmass2,
+      startSectorRows,
+      startSectorCols,
+    });
+    // Mock: return array of placeholder positions (one per player)
+    const totalPlayers = playersLandmass1 + playersLandmass2;
+    return Array.from({ length: totalPlayers }, (_, i) => i * 100);
+  }
+
+  generateDiscoveries(width: number, height: number, startPositions: number[]): void {
+    this.calls.generateDiscoveries.push({ width, height, startPositions: [...startPositions] });
+    // Mock: no-op
+  }
+
+  assignAdvancedStartRegions(): void {
+    this.calls.assignAdvancedStartRegions++;
+    // Mock: no-op
+  }
+
+  addFloodplains(minLength: number, maxLength: number): void {
+    this.calls.addFloodplains.push({ minLength, maxLength });
+    // Mock: no-op
+  }
+
+  recalculateFertility(): void {
+    this.calls.recalculateFertility++;
+    // Mock: no-op
+  }
+
   // === MOCK-SPECIFIC HELPERS ===
 
   /** Set water mask for testing */
@@ -282,6 +360,14 @@ export class MockAdapter implements EngineAdapter {
     this.mountainMask.fill(0);
     this.calls.designateBiomes.length = 0;
     this.calls.addFeatures.length = 0;
+    this.calls.addNaturalWonders.length = 0;
+    this.calls.generateSnow.length = 0;
+    this.calls.generateResources.length = 0;
+    this.calls.assignStartPositions.length = 0;
+    this.calls.generateDiscoveries.length = 0;
+    this.calls.assignAdvancedStartRegions = 0;
+    this.calls.addFloodplains.length = 0;
+    this.calls.recalculateFertility = 0;
   }
 
   /** Set biome type for testing */

--- a/packages/civ7-adapter/src/types.ts
+++ b/packages/civ7-adapter/src/types.ts
@@ -167,6 +167,76 @@ export interface EngineAdapter {
    * Sentinel value for "no feature"
    */
   readonly NO_FEATURE: number;
+
+  // === PLACEMENT ===
+
+  /**
+   * Add natural wonders to the map
+   * Wraps /base-standard/maps/natural-wonder-generator.js addNaturalWonders()
+   */
+  addNaturalWonders(width: number, height: number, numWonders: number): void;
+
+  /**
+   * Generate snow terrain
+   * Wraps /base-standard/maps/snow-generator.js generateSnow()
+   */
+  generateSnow(width: number, height: number): void;
+
+  /**
+   * Generate resources on the map
+   * Wraps /base-standard/maps/resource-generator.js generateResources()
+   */
+  generateResources(width: number, height: number): void;
+
+  /**
+   * Assign starting positions for players
+   * Wraps /base-standard/maps/assign-starting-plots.js assignStartPositions()
+   */
+  assignStartPositions(
+    playersLandmass1: number,
+    playersLandmass2: number,
+    westContinent: ContinentBounds,
+    eastContinent: ContinentBounds,
+    startSectorRows: number,
+    startSectorCols: number,
+    startSectors: number[]
+  ): number[];
+
+  /**
+   * Generate discoveries on the map (post-starts)
+   * Wraps /base-standard/maps/discovery-generator.js generateDiscoveries()
+   */
+  generateDiscoveries(width: number, height: number, startPositions: number[]): void;
+
+  /**
+   * Assign advanced start regions
+   * Wraps /base-standard/maps/assign-advanced-start-region.js assignAdvancedStartRegions()
+   */
+  assignAdvancedStartRegions(): void;
+
+  /**
+   * Add floodplains to rivers
+   * Wraps TerrainBuilder.addFloodplains()
+   */
+  addFloodplains(minLength: number, maxLength: number): void;
+
+  /**
+   * Recalculate fertility values
+   * Wraps FertilityBuilder.recalculate()
+   */
+  recalculateFertility(): void;
+}
+
+/**
+ * Continent bounds for start placement
+ * Compatible with mapgen-core ContinentBounds
+ */
+export interface ContinentBounds {
+  west: number;
+  east: number;
+  south: number;
+  north: number;
+  continent?: number;
 }
 
 /**

--- a/packages/mapgen-core/src/MapOrchestrator.ts
+++ b/packages/mapgen-core/src/MapOrchestrator.ts
@@ -731,9 +731,9 @@ export class MapOrchestrator {
     // ========================================================================
     // Stage: Placement
     // ========================================================================
-    if (stageFlags.placement) {
+    if (stageFlags.placement && ctx) {
       const stageResult = this.runStage("placement", () => {
-        const positions = runPlacement(iWidth, iHeight, {
+        const positions = runPlacement(ctx.adapter, iWidth, iHeight, {
           mapInfo: mapInfo as { NumNaturalWonders?: number },
           wondersPlusOne: true,
           floodplains: { minLength: 4, maxLength: 10 },

--- a/packages/mapgen-core/src/bootstrap/types.ts
+++ b/packages/mapgen-core/src/bootstrap/types.ts
@@ -4,6 +4,10 @@
  * Type definitions for configuration and bootstrap system.
  */
 
+// ContinentBounds canonical source is @civ7/adapter
+import type { ContinentBounds } from "@civ7/adapter";
+export type { ContinentBounds };
+
 // ============================================================================
 // Runtime Configuration Types
 // ============================================================================
@@ -446,15 +450,6 @@ export interface PlacementConfig {
   wondersPlusOne?: boolean;
   /** Floodplains generation settings */
   floodplains?: FloodplainsConfig;
-}
-
-/** Start placement continent boundary */
-export interface ContinentBounds {
-  west: number;
-  east: number;
-  south: number;
-  north: number;
-  continent: number;
 }
 
 /** Start placement configuration passed to the placement layer */

--- a/scripts/lint-adapter-boundary.sh
+++ b/scripts/lint-adapter-boundary.sh
@@ -24,10 +24,9 @@ echo ""
 # Files that are explicitly allowed to contain /base-standard/ imports
 # Each entry should be removed when its corresponding issue is completed.
 ALLOWLIST=(
-  # CIV-15: Orchestrator-level operations (deferred to CIV-20/CIV-22)
+  # CIV-15: Orchestrator-level operations (deferred to CIV-22)
   "packages/mapgen-core/src/MapOrchestrator.ts"
-  # CIV-20: Placement layer (heavy /base-standard/ usage)
-  "packages/mapgen-core/src/layers/placement.ts"
+  # CIV-20: DONE - placement.ts now uses adapter
 )
 
 # Config/build files that may reference /base-standard/ in comments or patterns


### PR DESCRIPTION
Moves all /base-standard/ imports from layers/placement.ts behind the
EngineAdapter interface, completing the adapter boundary cleanup for
the placement layer.

Changes:
- Extended EngineAdapter with placement methods:
  - addNaturalWonders, generateSnow, generateResources
  - assignStartPositions, generateDiscoveries, assignAdvancedStartRegions
  - addFloodplains, recalculateFertility
- Implemented methods in Civ7Adapter wrapping base-standard modules
- Updated MockAdapter with placement stubs and call tracking
- Refactored placement.ts to accept adapter parameter
- Updated MapOrchestrator to pass ctx.adapter to runPlacement
- Removed placement.ts from adapter-boundary allowlist

Fixes CIV-20. Remediates CIV-12 adapter boundary gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>