### PR TITLE
chore(graphite): add import helpers

### DIFF
--- a/docs/process/GRAPHITE.md
+++ b/docs/process/GRAPHITE.md
@@ -318,12 +318,28 @@ If a coworker created a branch with standard Git:
 # Pull their changes
 git pull
 
-# Bring into Graphite workflow
-gt track
-# or alias: gt tr
+# Bring into Graphite workflow (manual)
+gt track          # or alias: gt tr
 
 # Now you can use gt commands on this branch
 # Note: Graphite will rebase during gt sync
+```
+
+For branches created via external tools (e.g., Claude/Codex worktrees or cloud tasks), prefer the helper commands:
+
+```bash
+# Workflow 1: Import current worktree/standalone branch into Graphite
+# - Tracks the branch with Graphite
+# - Renames it to the desired name
+# - Optionally restacks it onto a parent branch
+# - Submits the stack as draft PRs
+pnpm gt:import-worktree <new-branch-name> [parent-branch]
+
+# Workflow 2: Import a remote PR branch into Graphite
+# - Fetches the remote branch
+# - Creates/checks out a local branch with the desired name
+# - Delegates to the worktree importer (Workflow 1)
+pnpm gt:import-pr <remote> <remote-branch> <new-branch-name> [parent-branch]
 ```
 
 ### Avoiding Conflicts

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
@@ -1,0 +1,53 @@
+---
+id: M2-stable-engine-slice-review
+milestone: M2-stable-engine-slice
+title: "M2: Stable Engine Slice – Aggregate Review"
+status: draft
+reviewer: AI agent (Codex CLI)
+---
+
+# M2: Stable Engine Slice – Aggregate Review (Running Log)
+
+This running log captures task-level reviews for milestone M2. Entries focus on
+correctness, completeness, and forward-looking risks for the engine refactor.
+
+---
+
+## CIV-27 – MapGenConfig TypeBox Schema
+
+**Quick Take**  
+Mostly satisfied: schema + loader + defaults are in place and type-safe, but public/internal surface separation and a few metadata/validation edges need a follow-up sweep.
+
+**Intent & Assumptions**  
+- Establish `MapGenConfigSchema` as the canonical TypeBox schema with inferred `MapGenConfig`.  
+- Apply defaults/normalization via loader helpers; keep legacy nesting/back-compat.  
+- Mark internal-only controls for later hiding/removal without blocking this milestone.
+
+**What’s Strong**  
+- Broad coverage of landmass, foundation, climate, story, corridors, ocean separation, etc., with sensible defaults and ranges.  
+- Loader (`parseConfig`/`safeParseConfig`) clones→defaults→converts→cleans and surfaces structured errors; `getDefaultConfig`/`getJsonSchema` exported.  
+- Public exports wired in `config/index.ts`; type checks green across the repo.  
+- Tests cover defaults, type/range failures, and safe parse paths.
+
+**High-Leverage Issues**  
+- Public vs. internal knobs remain co-mingled. `[tag]` markers flag fields that likely belong behind an internal-only contract (stageConfig/manifest, foundation internals, ocean separation alias), but nothing enforces the boundary yet.  
+- Optional-wrapper metadata was stripped to satisfy TypeBox v1 signatures; reattach descriptions/defaults at the property schema level to avoid losing docs/JSON Schema detail.  
+- `UnknownRecord` escape hatches keep validation loose (notably climate knobs); narrowing these is important to maintain config hygiene.
+
+**Fit Within the Milestone**  
+Delivers the schema/loader backbone needed for M2’s config hygiene goals; defers public/internal split and tightening of escape hatches to later tasks.
+
+**Recommended Next Moves**  
+1. Reattach descriptions/defaults where `Type.Optional` options were dropped in the v1 migration.  
+2. Enforce/partition public vs. internal fields identified by `[tag]` (e.g., internal-only manifest/toggle plumbing).  
+3. Gradually replace `UnknownRecord` sections with typed shapes (start with climate bands/blend/orographic blocks).  
+4. Add a small guard to keep public JSON Schema aligned with the intended surface (exclude or flag internal fields).
+
+**Follow-ups / Checklist**  
+- [x] TypeBox v1 compatibility and typechecks fixed (dependency bumped; loader/schema updated).  
+- [ ] Public/internal boundary enforced or documented beyond `[tag]` markers.  
+- [ ] Reattach property-level descriptions/defaults removed from `Type.Optional` wrappers.  
+- [ ] Narrow `UnknownRecord` escape hatches to typed schemas where semantics are known.  
+- [ ] Add public-schema guard (exclude/internal-flag) to prevent leaking internal knobs.
+
+---

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "test:mapgen": "pnpm -C packages/mapgen-core test",
     "build:mapgen": "pnpm -C packages/mapgen-core build",
     "lint:adapter-boundary": "./scripts/lint-adapter-boundary.sh",
-    "deploy:mods": "turbo run deploy --filter='./mods/*'"
+    "deploy:mods": "turbo run deploy --filter='./mods/*'",
+    "gt:import-worktree": "bash ./scripts/graphite-import-worktree.sh",
+    "gt:import-pr": "bash ./scripts/graphite-import-pr.sh"
   },
   "workspaces": [
     "apps/*",

--- a/scripts/graphite-import-pr.sh
+++ b/scripts/graphite-import-pr.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v gt >/dev/null 2>&1; then
+  echo "Error: gt (Graphite CLI) is not installed or not on PATH." >&2
+  exit 1
+fi
+
+if [ $# -lt 3 ] || [ $# -gt 4 ]; then
+  echo "Usage: pnpm gt:import-pr <remote> <remote-branch> <new-branch-name> [parent-branch]" >&2
+  echo "Example: pnpm gt:import-pr fork codex-civ-27-config-schema civ-27-config-schema main" >&2
+  exit 1
+fi
+
+REMOTE="$1"
+REMOTE_BRANCH="$2"
+NEW_BRANCH="$3"
+PARENT_BRANCH="${4-}"
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: Working tree has uncommitted changes. Commit or stash before importing into Graphite." >&2
+  exit 1
+fi
+
+echo "=== Graphite Import (remote PR branch) ==="
+echo "Remote: $REMOTE"
+echo "Remote branch: $REMOTE_BRANCH"
+echo "Local Graphite branch name: $NEW_BRANCH"
+if [ -n "$PARENT_BRANCH" ]; then
+  echo "Desired parent branch: $PARENT_BRANCH"
+fi
+echo ""
+
+echo "Fetching remote branch $REMOTE/$REMOTE_BRANCH…"
+git fetch "$REMOTE" "$REMOTE_BRANCH"
+
+echo "Checking out local branch $NEW_BRANCH tracking $REMOTE/$REMOTE_BRANCH…"
+git checkout -B "$NEW_BRANCH" --track "$REMOTE/$REMOTE_BRANCH"
+
+if [ -n "$PARENT_BRANCH" ]; then
+  "$REPO_ROOT/scripts/graphite-import-worktree.sh" "$NEW_BRANCH" "$PARENT_BRANCH"
+else
+  "$REPO_ROOT/scripts/graphite-import-worktree.sh" "$NEW_BRANCH"
+fi

--- a/scripts/graphite-import-worktree.sh
+++ b/scripts/graphite-import-worktree.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v gt >/dev/null 2>&1; then
+  echo "Error: gt (Graphite CLI) is not installed or not on PATH." >&2
+  exit 1
+fi
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: pnpm gt:import-worktree <new-branch-name> [parent-branch]" >&2
+  echo "  - Operates on the CURRENT branch (\"this branch\") by default." >&2
+  exit 1
+fi
+
+NEW_BRANCH="$1"
+PARENT_BRANCH="${2-}"
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: Working tree has uncommitted changes. Commit or stash before importing into Graphite." >&2
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$CURRENT_BRANCH" = "HEAD" ]; then
+  echo "Error: Detached HEAD state. Checkout the worktree branch before running this script." >&2
+  exit 1
+fi
+
+echo "=== Graphite Import (worktree/standalone branch) ==="
+echo "Current branch: $CURRENT_BRANCH"
+echo "Target Graphite branch name: $NEW_BRANCH"
+if [ -n "$PARENT_BRANCH" ]; then
+  echo "Desired parent branch: $PARENT_BRANCH"
+fi
+echo ""
+
+echo "Tracking current branch with Graphite (gt track)…"
+if ! gt track; then
+  echo "Warning: 'gt track' failed. The branch may already be tracked; continuing." >&2
+fi
+
+if [ "$CURRENT_BRANCH" != "$NEW_BRANCH" ]; then
+  echo "Renaming branch via Graphite: $CURRENT_BRANCH -> $NEW_BRANCH"
+  gt rename "$NEW_BRANCH"
+else
+  echo "Branch is already named $NEW_BRANCH; skipping rename."
+fi
+
+if [ -n "$PARENT_BRANCH" ]; then
+  echo ""
+  echo "Restacking $NEW_BRANCH onto parent $PARENT_BRANCH…"
+  gt checkout "$PARENT_BRANCH"
+  gt checkout "$NEW_BRANCH"
+  gt restack
+fi
+
+echo ""
+echo "Submitting stack as draft PRs via Graphite…"
+gt ss --draft
+
+echo ""
+echo "Done. Branch '$NEW_BRANCH' is now part of the Graphite stack and submitted as draft."


### PR DESCRIPTION
### TL;DR

Added Graphite workflow helpers for importing external branches and documented a new milestone review.

### What changed?

- Added two new helper scripts for Graphite workflow:
  - `scripts/graphite-import-worktree.sh`: Imports a current worktree/standalone branch into Graphite
  - `scripts/graphite-import-pr.sh`: Imports a remote PR branch into Graphite
- Added npm scripts in package.json to easily run these helpers:
  - `pnpm gt:import-worktree <new-branch-name> [parent-branch]`
  - `pnpm gt:import-pr <remote> <remote-branch> <new-branch-name> [parent-branch]`
- Updated Graphite documentation to include these new workflows
- Added a new milestone review document for "M2: Stable Engine Slice" with detailed review of the MapGenConfig TypeBox Schema task

### How to test?

1. Try importing an external branch:
   ```bash
   pnpm gt:import-worktree my-branch main
   ```

2. Try importing a remote PR branch:
   ```bash
   pnpm gt:import-pr fork feature-branch my-local-branch main
   ```

3. Verify the branches are properly tracked in Graphite and stacked as expected

### Why make this change?

- Streamlines the process of bringing externally created branches (from Claude/Codex worktrees or cloud tasks) into the Graphite workflow
- Provides consistent, documented helpers for common Graphite operations
- Reduces friction when collaborating between different branch creation methods
- Documents progress on the engine refactor milestone for better tracking and visibility