### PR TITLE
feat(bootstrap): remove globalThis config stores

### DIFF
--- a/docs/projects/engine-refactor-v1/issues/CIV-29-config-globals.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-29-config-globals.md
@@ -1,7 +1,7 @@
 ---
 id: CIV-29
 title: "[M2] Remove global config stores"
-state: planned
+state: in-progress
 priority: 2
 estimate: 0
 project: engine-refactor-v1
@@ -22,20 +22,20 @@ Remove `globalThis.__EPIC_MAP_CONFIG__` and any other global config stores from 
 
 ## Deliverables
 
-- [ ] Remove `globalThis.__EPIC_MAP_CONFIG__` from `bootstrap/runtime.ts`
-- [ ] Remove or refactor `setConfig()` / `getConfig()` to use module-scoped state (not globalThis)
-- [ ] Update all call sites that read from global config to receive config via parameters
-- [ ] Ensure `bootstrap()` function returns validated config instead of storing globally
-- [ ] Document the new config flow in code comments
+- [x] Remove `globalThis.__EPIC_MAP_CONFIG__` from `bootstrap/runtime.ts`
+- [x] Remove or refactor `setConfig()` / `getConfig()` to use module-scoped state (not globalThis)
+- [x] Update all call sites that read from global config to receive config via parameters
+- [x] Ensure `bootstrap()` function returns validated config instead of storing globally
+- [x] Document the new config flow in code comments
 
 ## Acceptance Criteria
 
-- [ ] No `globalThis` config stores in `packages/mapgen-core/src/`
-- [ ] `grep -r "globalThis.*CONFIG" packages/mapgen-core/` returns no matches
-- [ ] `bootstrap()` returns `MapGenConfig` instead of storing it
-- [ ] All consumers receive config via explicit parameters or module imports
-- [ ] TypeScript compiles without errors
-- [ ] Existing mod scripts continue to work (bootstrap still accepts same options)
+- [x] No `globalThis` config stores in `packages/mapgen-core/src/`
+- [x] `grep -r "globalThis.*CONFIG" packages/mapgen-core/` returns no matches
+- [x] `bootstrap()` returns `MapGenConfig` instead of storing it
+- [x] All consumers receive config via explicit parameters or module imports
+- [x] TypeScript compiles without errors
+- [x] Existing mod scripts continue to work (bootstrap still accepts same options)
 
 ## Testing / Verification
 

--- a/packages/mapgen-core/src/bootstrap/entry.ts
+++ b/packages/mapgen-core/src/bootstrap/entry.ts
@@ -2,11 +2,14 @@
  * Bootstrap Entry Point
  *
  * Provides the main `bootstrap()` function that initializes map generation.
- * Uses lazy loading to avoid crashes when globals are unavailable.
+ * Config is validated via parseConfig() and stored module-scoped.
+ *
+ * Config Flow:
+ *   bootstrap(options) → parseConfig(rawConfig) → setValidatedConfig() → MapGenConfig
  *
  * Usage (in a map entry file):
  *   import { bootstrap } from "@swooper/mapgen-core/bootstrap";
- *   bootstrap({
+ *   const config = bootstrap({
  *     presets: ["classic", "temperate"],
  *     overrides: {
  *       foundation: { plates: { count: 12 } },
@@ -16,8 +19,15 @@
 
 /// <reference types="@civ7/types" />
 
-import type { MapConfig } from "./types.js";
-import { setConfig, resetConfig } from "./runtime.js";
+import type { MapGenConfig } from "../config/index.js";
+import { parseConfig } from "../config/index.js";
+import {
+  setValidatedConfig,
+  resetConfig,
+  // Deprecated exports for backwards compatibility
+  setConfig,
+  getConfig,
+} from "./runtime.js";
 import { resetTunables, rebind as rebindTunables } from "./tunables.js";
 import { resolveStageManifest, validateOverrides } from "./resolved.js";
 
@@ -29,7 +39,7 @@ export interface BootstrapOptions {
   /** Ordered list of preset names (applied by resolved.js) */
   presets?: string[];
   /** Inline overrides applied last (highest precedence) */
-  overrides?: Partial<MapConfig>;
+  overrides?: Partial<MapGenConfig>;
   /** Stage metadata indicating which stages provide config overrides */
   stageConfig?: Record<string, boolean>;
 }
@@ -93,10 +103,14 @@ function deepMerge<T extends object>(base: T, src: Partial<T> | undefined): T {
 /**
  * Bootstrap the map generation system.
  *
- * Composes configuration from presets and overrides, then sets the active
- * runtime config. This is called from mod entry points.
+ * Composes configuration from presets and overrides, validates via parseConfig(),
+ * then stores the validated config. Returns the validated MapGenConfig.
+ *
+ * @param options - Bootstrap options including presets and overrides
+ * @returns Validated MapGenConfig with defaults applied
+ * @throws Error if config validation fails
  */
-export function bootstrap(options: BootstrapConfig = {}): void {
+export function bootstrap(options: BootstrapConfig = {}): MapGenConfig {
   // Extract presets
   const presets =
     Array.isArray(options.presets) && options.presets.length > 0
@@ -113,15 +127,15 @@ export function bootstrap(options: BootstrapConfig = {}): void {
       ? clone(options.stageConfig)
       : undefined;
 
-  // Build config object
-  const cfg: MapConfig = {};
-  if (presets) cfg.presets = presets;
-  if (stageConfig) cfg.stageConfig = stageConfig;
+  // Build raw config object (before validation)
+  const rawConfig: Partial<MapGenConfig> = {};
+  if (presets) rawConfig.presets = presets;
+  if (stageConfig) rawConfig.stageConfig = stageConfig;
 
   // Resolve stageConfig → stageManifest (bridges the "Config Air Gap")
   // This ensures stageEnabled() returns the correct values
   const manifest = resolveStageManifest(stageConfig);
-  cfg.stageManifest = manifest;
+  rawConfig.stageManifest = manifest;
 
   // Validate overrides against manifest (warn about targeting disabled stages)
   if (overrides) {
@@ -130,14 +144,20 @@ export function bootstrap(options: BootstrapConfig = {}): void {
 
   // Merge overrides (highest precedence)
   if (overrides) {
-    Object.assign(cfg, deepMerge(cfg, overrides as Partial<MapConfig>));
+    Object.assign(rawConfig, deepMerge(rawConfig as object, overrides as object));
   }
 
-  // Store runtime config
-  setConfig(cfg);
+  // Validate and apply defaults via parseConfig
+  // This uses the TypeBox schema to ensure type correctness
+  const validatedConfig = parseConfig(rawConfig);
+
+  // Store validated config in module-scoped state
+  setValidatedConfig(validatedConfig);
 
   // Rebind tunables to pick up new config
   rebindTunables();
+
+  return validatedConfig;
 }
 
 /**
@@ -158,8 +178,17 @@ export function rebind(): void {
 }
 
 // Re-export types and functions for convenience
-export type { MapConfig } from "./types.js";
-export { setConfig, getConfig, resetConfig } from "./runtime.js";
+export type { MapConfig } from "./runtime.js";
+export type { MapGenConfig } from "../config/index.js";
+export {
+  setValidatedConfig,
+  getValidatedConfig,
+  hasConfig,
+  resetConfig,
+  // Deprecated exports
+  setConfig,
+  getConfig,
+} from "./runtime.js";
 export { getTunables, resetTunables, stageEnabled, TUNABLES } from "./tunables.js";
 export {
   STAGE_ORDER,


### PR DESCRIPTION
# Remove global config stores in favor of module-scoped validated config

- Remove globalThis.__EPIC_MAP_CONFIG__ from runtime.ts
- Use module-scoped state for config storage
- Add setValidatedConfig/getValidatedConfig with strict semantics
- Integrate parseConfig into bootstrap() flow
- bootstrap() now returns validated MapGenConfig
- Keep deprecated setConfig/getConfig for backwards compatibility
- Document new config flow in code comments

Part of M2 config hygiene epic (CIV-29).