### PR TITLE
feat(mapgen-core): wire MapOrchestrator to validated config

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -41,7 +41,8 @@
       "Bash(claude mcp list:*)",
       "Bash(linear --help:*)",
       "Bash(pnpm -C packages/mapgen-core run check-types:*)",
-      "Bash(pnpm deploy:mods)"
+      "Bash(pnpm deploy:mods)",
+      "Bash(pnpm test:*)"
     ],
     "deny": [],
     "ask": []

--- a/docs/projects/engine-refactor-v1/issues/CIV-30-config-orchestrator.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-30-config-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 id: CIV-30
 title: "[M2] Wire MapOrchestrator to validated config"
-state: planned
+state: in-progress
 priority: 2
 estimate: 0
 project: engine-refactor-v1
@@ -22,22 +22,22 @@ Update `MapOrchestrator` to receive validated `MapGenConfig` via constructor inj
 
 ## Deliverables
 
-- [ ] Update `MapOrchestrator` constructor to accept `MapGenConfig` as parameter
-- [ ] Remove internal calls to `getConfig()` or global config lookups
-- [ ] Store validated config as instance property (`this.config`)
-- [ ] Add fail-fast check: throw if config is not provided or invalid
-- [ ] Update callers (mod entry points) to pass config from `bootstrap()`
-- [ ] Ensure config is accessible to downstream stages via orchestrator
+- [x] Update `MapOrchestrator` constructor to accept `MapGenConfig` as parameter
+- [x] Remove internal calls to `getConfig()` or global config lookups
+- [x] Store validated config as instance property (`this.mapGenConfig`)
+- [x] Add fail-fast check: throw if config is not provided or invalid
+- [x] Update callers (mod entry points) to pass config from `bootstrap()`
+- [x] Ensure config is accessible to downstream stages via orchestrator (`getMapGenConfig()`)
 
 ## Acceptance Criteria
 
-- [ ] `MapOrchestrator` constructor signature: `constructor(config: MapGenConfig, adapter: EngineAdapter)`
-- [ ] Constructing without config throws: `new MapOrchestrator(undefined as any, adapter)` → Error
-- [ ] `this.config` is available throughout orchestration lifecycle
-- [ ] No `getConfig()` calls remain in `MapOrchestrator.ts`
-- [ ] Mod entry points updated to: `const config = bootstrap(opts); new MapOrchestrator(config, adapter)`
-- [ ] TypeScript compiles without errors
-- [ ] Existing map generation continues to work
+- [x] `MapOrchestrator` constructor signature: `constructor(config: MapGenConfig, options?: OrchestratorConfig)`
+- [x] Constructing without config throws: `new MapOrchestrator(undefined as any, {})` → Error
+- [x] `this.mapGenConfig` is available throughout orchestration lifecycle
+- [x] No `getConfig()` calls remain in `MapOrchestrator.ts`
+- [x] Mod entry points updated to: `const config = bootstrap(opts); new MapOrchestrator(config, options)`
+- [x] TypeScript compiles without errors
+- [x] Existing map generation continues to work (deploy succeeds)
 
 ## Testing / Verification
 

--- a/packages/mapgen-core/src/MapOrchestrator.ts
+++ b/packages/mapgen-core/src/MapOrchestrator.ts
@@ -19,12 +19,19 @@
  * - Stages are enabled/disabled via configuration
  *
  * Usage (in mod entry point):
- *   import { MapOrchestrator } from '@swooper/mapgen-core';
- *   import { CivEngineAdapter } from '@civ7/adapter';
+ *   import { bootstrap, MapOrchestrator } from '@swooper/mapgen-core';
  *
- *   const orchestrator = new MapOrchestrator();
- *   engine.on('RequestMapInitData', () => orchestrator.requestMapData());
- *   engine.on('GenerateMap', () => orchestrator.generateMap());
+ *   engine.on('RequestMapInitData', () => {
+ *     const config = bootstrap({});
+ *     const orchestrator = new MapOrchestrator(config, { logPrefix: '[MOD]' });
+ *     orchestrator.requestMapData();
+ *   });
+ *
+ *   engine.on('GenerateMap', () => {
+ *     const config = bootstrap({ overrides: { ... } });
+ *     const orchestrator = new MapOrchestrator(config, { logPrefix: '[MOD]' });
+ *     orchestrator.generateMap();
+ *   });
  */
 
 import type { EngineAdapter } from "@civ7/adapter";

--- a/packages/mapgen-core/test/orchestrator/requestMapData.test.ts
+++ b/packages/mapgen-core/test/orchestrator/requestMapData.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { MapOrchestrator } from "../../src/MapOrchestrator.js";
+import { getDefaultConfig } from "../../src/config/index.js";
 
 describe("MapOrchestrator.requestMapData", () => {
   // Capture SetMapInitData calls via engine.call spy
@@ -44,7 +45,7 @@ describe("MapOrchestrator.requestMapData", () => {
 
   describe("with mapSizeDefaults config", () => {
     it("should use dimensions from mapSizeDefaults.mapInfo", () => {
-      const orchestrator = new MapOrchestrator({
+      const orchestrator = new MapOrchestrator(getDefaultConfig(), {
         mapSizeDefaults: {
           mapSizeId: 1,
           mapInfo: {
@@ -73,7 +74,7 @@ describe("MapOrchestrator.requestMapData", () => {
     });
 
     it("should use standard fallbacks when mapInfo is null", () => {
-      const orchestrator = new MapOrchestrator({
+      const orchestrator = new MapOrchestrator(getDefaultConfig(), {
         mapSizeDefaults: {
           mapSizeId: -1,
           mapInfo: undefined,
@@ -98,7 +99,7 @@ describe("MapOrchestrator.requestMapData", () => {
     });
 
     it("should use partial mapInfo with fallbacks for missing fields", () => {
-      const orchestrator = new MapOrchestrator({
+      const orchestrator = new MapOrchestrator(getDefaultConfig(), {
         mapSizeDefaults: {
           mapSizeId: 1,
           mapInfo: {
@@ -127,7 +128,7 @@ describe("MapOrchestrator.requestMapData", () => {
 
   describe("with initParams overrides", () => {
     it("should allow explicit dimension overrides via initParams", () => {
-      const orchestrator = new MapOrchestrator({
+      const orchestrator = new MapOrchestrator(getDefaultConfig(), {
         mapSizeDefaults: {
           mapSizeId: 1,
           mapInfo: {
@@ -160,7 +161,7 @@ describe("MapOrchestrator.requestMapData", () => {
     });
 
     it("should allow explicit latitude overrides via initParams", () => {
-      const orchestrator = new MapOrchestrator({
+      const orchestrator = new MapOrchestrator(getDefaultConfig(), {
         mapSizeDefaults: {
           mapSizeId: 1,
           mapInfo: {
@@ -192,7 +193,7 @@ describe("MapOrchestrator.requestMapData", () => {
     });
 
     it("should allow wrapX/wrapY overrides via initParams", () => {
-      const orchestrator = new MapOrchestrator({
+      const orchestrator = new MapOrchestrator(getDefaultConfig(), {
         mapSizeDefaults: {
           mapSizeId: 1,
           mapInfo: { GridWidth: 84, GridHeight: 54 },
@@ -217,7 +218,7 @@ describe("MapOrchestrator.requestMapData", () => {
 
   describe("default wrapX/wrapY behavior", () => {
     it("should default to wrapX=true, wrapY=false", () => {
-      const orchestrator = new MapOrchestrator({
+      const orchestrator = new MapOrchestrator(getDefaultConfig(), {
         mapSizeDefaults: {
           mapSizeId: 1,
           mapInfo: { GridWidth: 84, GridHeight: 54 },
@@ -239,7 +240,7 @@ describe("MapOrchestrator.requestMapData", () => {
 
   describe("different map sizes", () => {
     it("should respect large map dimensions from mapInfo", () => {
-      const orchestrator = new MapOrchestrator({
+      const orchestrator = new MapOrchestrator(getDefaultConfig(), {
         mapSizeDefaults: {
           mapSizeId: 2, // Simulating MAPSIZE_LARGE
           mapInfo: {
@@ -267,7 +268,7 @@ describe("MapOrchestrator.requestMapData", () => {
     });
 
     it("should respect small map dimensions from mapInfo", () => {
-      const orchestrator = new MapOrchestrator({
+      const orchestrator = new MapOrchestrator(getDefaultConfig(), {
         mapSizeDefaults: {
           mapSizeId: 0, // Simulating MAPSIZE_SMALL
           mapInfo: {


### PR DESCRIPTION
# Wire MapOrchestrator to validated config

- Update constructor signature: `constructor(config: MapGenConfig, options?: OrchestratorConfig)`
- Add fail-fast validation: throw if config not provided
- Store validated config as `this.mapGenConfig` instance property
- Add `getMapGenConfig()` method for downstream access
- Set module-scoped config in constructor for backwards compat with tunables
- Update mod entry point to pass config from bootstrap()

Closes CIV-30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>