### PR TITLE
refactor(mapgen-core): consolidate defaults into schema and update docs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -42,7 +42,9 @@
       "Bash(linear --help:*)",
       "Bash(pnpm -C packages/mapgen-core run check-types:*)",
       "Bash(pnpm deploy:mods)",
-      "Bash(pnpm test:*)"
+      "Bash(pnpm test:*)",
+      "mcp__linear-personal__list_projects",
+      "Bash(pnpm -C packages/mapgen-core test)"
     ],
     "deny": [],
     "ask": []

--- a/docs/projects/engine-refactor-v1/issues/LOCAL-M2-docs-alignment.md
+++ b/docs/projects/engine-refactor-v1/issues/LOCAL-M2-docs-alignment.md
@@ -1,0 +1,58 @@
+---
+id: LOCAL-M2-DOCS-ALIGNMENT
+title: "[M2] Align docs and status with config + foundation slice implementation"
+state: planned
+priority: 2
+estimate: 2
+project: engine-refactor-v1
+milestone: M2-stable-engine-slice
+assignees: []
+labels: [Documentation, Architecture]
+parent: null
+children: []
+blocked_by: []
+blocked: []
+related_to: [CIV-26, CIV-27, CIV-28, CIV-29, CIV-30, CIV-31]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Update M2 project docs and related issue files so they accurately describe the real engine flow (`bootstrap() → MapGenConfig → tunables → MapOrchestrator → FoundationContext`) and reflect that generic pipeline primitives (`PipelineExecutor` / `MapGenStep` / `StepRegistry`) are planned for M3+, not already implemented in M2.
+
+## Deliverables
+
+- M2 milestone doc and project brief describe M2 as:
+  - “Config + foundation slice is stable, documented, and test-backed” on the current `MapOrchestrator`-centric architecture.
+  - Explicitly not delivering a generic `PipelineExecutor` / `MapGenStep` / `StepRegistry` yet.
+- References to `globalThis.__EPIC_MAP_CONFIG__` and the legacy global-config pattern are removed or clearly marked as historical/future, not current behavior.
+- Language that assumes an already-implemented generic pipeline executor in M2 is softened or moved under M3+ scope.
+- The engine-refactor status snapshot reflects config + foundation slice as complete and positions pipeline primitives + data-product evolution as upcoming M3 work.
+
+## Acceptance Criteria
+
+- [ ] `docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md` summary/scope/objectives describe the orchestrator-centric M2 slice and do not promise a fully generic `PipelineExecutor` in this milestone.
+- [ ] `docs/projects/engine-refactor-v1/PROJECT-engine-refactor-v1.md` describes M2 as “config + foundation slice, documented, test-backed” and defers the task-graph primitives to M3.
+- [ ] `docs/projects/engine-refactor-v1/status.md` marks the config + foundation slice as done and lists pipeline primitives + ClimateField/StoryOverlays evolution under “Ready Next” / M3.
+- [ ] Any remaining references to `globalThis.__EPIC_MAP_CONFIG__` in project docs or engine-refactor issues are removed or clearly marked as historical/future.
+
+## Testing / Verification
+
+- Read through the updated M2 milestone, project brief, and status snapshot to ensure:
+  - They all agree on the M2 definition and on where pipeline primitives land.
+  - There is no lingering implication that `PipelineExecutor` / `MapGenStep` / `StepRegistry` are already wired in M2.
+- Optionally, cross-check against the M2 review doc to confirm wording is consistent.
+
+## Dependencies / Notes
+
+- This is a documentation-only follow-up to CIV-26–CIV-31; it should not change runtime behavior.
+- System docs (`docs/system/libs/mapgen/*.md`) remain canonical and describe the **target** architecture; they may include a brief heads-up that some pieces are not wired yet, but should not carry temporal status.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Notes (Local Only)
+
+- Focus on project-level docs under `docs/projects/engine-refactor-v1/` plus the engine-refactor status snapshot.
+- Avoid over-describing current limitations in the system architecture docs; keep them focused on target shape with a light heads-up where needed.
+

--- a/docs/projects/engine-refactor-v1/issues/LOCAL-M2-foundation-context-contract.md
+++ b/docs/projects/engine-refactor-v1/issues/LOCAL-M2-foundation-context-contract.md
@@ -1,0 +1,59 @@
+---
+id: LOCAL-M2-FOUNDATION-CONTEXT-CONTRACT
+title: "[M2] Document FoundationContext contract and config → tunables → world-model flow"
+state: planned
+priority: 2
+estimate: 3
+project: engine-refactor-v1
+milestone: M2-stable-engine-slice
+assignees: []
+labels: [Documentation, Architecture]
+parent: null
+children: []
+blocked_by: []
+blocked: []
+related_to: [CIV-26, CIV-30, CIV-31]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Make the `FoundationContext` contract explicit and document the end-to-end flow from config through tunables to the world model, so downstream work in M3+ can rely on a clear, stable definition of what the M2 slice guarantees.
+
+## Deliverables
+
+- A concise contract doc at `docs/projects/engine-refactor-v1/resources/CONTRACT-foundation-context.md` that:
+  - Defines the `FoundationContext` structure and semantics at the end of the M2 slice.
+  - Lists the key data products available after foundation runs (e.g., plate IDs/tensors, uplift/rift fields, heightfield linkage).
+  - Describes the `config → tunables → MapOrchestrator → FoundationContext → world model` flow in one place.
+- Clarified language in the M2 milestone / review docs that:
+  - Treats tunables as a derived, read-only view over `MapGenConfig`.
+  - Makes clear that tunables are not the primary config store for future work.
+
+## Acceptance Criteria
+
+- [ ] `FoundationContext` fields and guarantees are documented in `resources/CONTRACT-foundation-context.md` and linked from the engine-refactor project docs.
+- [ ] The config → tunables → world-model flow is described as the canonical M2 slice and matches the actual implementation.
+- [ ] M2 docs and review explicitly describe tunables as a view over validated `MapGenConfig`, not as a separate config store.
+- [ ] Future M3+ issues can reference this contract instead of re-deriving the behavior from code/reviews.
+
+## Testing / Verification
+
+- Cross-check the documented `FoundationContext` contract against:
+  - `packages/mapgen-core/src/core/types.ts`
+  - `packages/mapgen-core/src/MapOrchestrator.ts`
+  - `packages/mapgen-core/src/world/*` consumers
+- Confirm that the described flow matches the current `bootstrap()` / tunables / orchestrator wiring.
+
+## Dependencies / Notes
+
+- Builds directly on CIV-26–CIV-31; no new engine behavior is introduced here.
+- This is intended as a reference for upcoming data-product and pipeline work in M3+, so it should be kept evergreen (updated if the contract changes).
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Notes (Local Only)
+
+- Use `resources/CONTRACT-foundation-context.md` as the focused “FoundationContext & config flow” contract doc for this milestone; keep it small and tightly scoped to the M2 slice.
+- Keep this at the “what is guaranteed” level; detailed stage-by-stage behavior belongs in system docs and PRDs.

--- a/docs/projects/engine-refactor-v1/issues/LOCAL-M2-orchestrator-smoke-test.md
+++ b/docs/projects/engine-refactor-v1/issues/LOCAL-M2-orchestrator-smoke-test.md
@@ -1,0 +1,57 @@
+---
+id: LOCAL-M2-ORCHESTRATOR-SMOKE-TEST
+title: "[M2] Add MapOrchestrator.generateMap smoke test for config + foundation slice"
+state: planned
+priority: 2
+estimate: 3
+project: engine-refactor-v1
+milestone: M2-stable-engine-slice
+assignees: []
+labels: [Testing, Architecture]
+parent: null
+children: []
+blocked_by: []
+blocked: []
+related_to: [CIV-23, CIV-26, CIV-31]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Add at least one end-to-end `MapOrchestrator.generateMap` smoke test over the current M2 slice, using a minimal/default `MapGenConfig` and a stub adapter, to ensure foundation data products are populated and the stage flow does not regress.
+
+## Deliverables
+
+- A new Vitest test file under `packages/mapgen-core/test/` (or an appropriate subfolder) that:
+  - Uses `getDefaultConfig()` or an equivalent helper to construct a minimal `MapGenConfig`.
+  - Wires a stub `EngineAdapter` sufficient to exercise the orchestrator without touching the real Civ7 runtime.
+  - Calls `MapOrchestrator.generateMap()` with the validated config and stub adapter.
+  - Asserts that:
+    - The foundation-related data products (e.g., `FoundationContext`, plate tensors) are present and well-formed.
+    - No unexpected errors are thrown and the stage flow completes.
+
+## Acceptance Criteria
+
+- [ ] Test suite includes at least one end-to-end `MapOrchestrator.generateMap` smoke test for the M2 slice.
+- [ ] The test uses validated `MapGenConfig` and does not rely on global config stores.
+- [ ] The test asserts presence of foundation data products and fails loudly if a regression breaks the foundation slice.
+- [ ] Tests run as part of `pnpm test` and pass reliably.
+
+## Testing / Verification
+
+- Run `pnpm test` (or the scoped test command for `packages/mapgen-core`) and confirm the new smoke test passes.
+- Temporarily break an obvious part of the foundation wiring (locally) to confirm the test fails in a useful way, then revert.
+
+## Dependencies / Notes
+
+- Complements CIV-23 (broader integration tests) by providing a focused, minimal safety net for the M2 config + foundation slice.
+- This test should remain valid even as pipeline primitives are introduced in M3, as long as `MapOrchestrator` continues to expose a compatible entrypoint.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Notes (Local Only)
+
+- Consider reusing any existing stub adapters or test helpers from other engine tests to avoid duplication.
+- Keep the test narrow and smoke-level; detailed assertions about climate, overlays, or placement belong in later milestones.
+

--- a/docs/projects/engine-refactor-v1/milestones/M3-core-engine-refactor-config-evolution.md
+++ b/docs/projects/engine-refactor-v1/milestones/M3-core-engine-refactor-config-evolution.md
@@ -26,9 +26,9 @@ This milestone corresponds to **Milestone 3** in `PROJECT-engine-refactor-v1.md`
   - **M1** has effectively completed the bulk of the TypeScript migration and package layout.
   - **M2** has delivered:
     - Phase 1 “Config Hygiene” from `resources/PRD-config-refactor.md`.
-    - The initial Task Graph plumbing and foundation slice from `resources/PRD-pipeline-refactor.md`.
-    - The first integrated foundation/plate stack from `resources/PRD-plate-generation.md`.
+    - A validated-config + foundation slice driven by `MapOrchestrator`, with the modern foundation/plate stack integrated behind it.
 - Within that baseline, M3 is responsible for:
+  - Introducing the generic pipeline primitives (`MapGenStep`, `StepRegistry`, `PipelineExecutor`) on top of the stabilized data products.
   - Driving **Phase 2 & 3** of the config refactor (config integration + shape evolution).
   - Generalizing the pipeline from the foundation slice to all major clusters (morphology, hydrology/climate, overlays, biomes, placement).
   - Promoting the shared data products (`FoundationContext`, `Heightfield`, `ClimateField`, `StoryOverlays`) to canonical status across the engine.

--- a/docs/projects/engine-refactor-v1/milestones/M4-tests-validation-cleanup.md
+++ b/docs/projects/engine-refactor-v1/milestones/M4-tests-validation-cleanup.md
@@ -23,7 +23,7 @@ This milestone corresponds to **Milestone 4** in `PROJECT-engine-refactor-v1.md`
 ### Dependencies & Sequencing
 
 - This milestone runs after:
-  - **M2** has established the validated-config + foundation slice of the Task Graph (see `M2-stable-engine-slice.md` and related PRDs).
+  - **M2** has established the validated-config + foundation slice driven by `MapOrchestrator` (see `M2-stable-engine-slice.md` and related PRDs).
   - **M3** has generalized the pipeline and evolved `MapGenConfig` into its step/phase-aligned shape (see `M3-core-engine-refactor-config-evolution.md`).
 - Within that baseline, M4 focuses on:
   - Hardening the engine with tests and validation (leveraging the Task Graph and data products defined in `resources/PRD-pipeline-refactor.md` and `PROJECT-engine-refactor-v1.md`).

--- a/docs/projects/engine-refactor-v1/resources/CONTRACT-foundation-context.md
+++ b/docs/projects/engine-refactor-v1/resources/CONTRACT-foundation-context.md
@@ -1,0 +1,170 @@
+# CONTRACT: FoundationContext (M2 Slice)
+
+> Working draft — project-level contract only.  
+> This document tracks the **current and intended** `FoundationContext` contract for the M2 engine slice.  
+> Keep it in sync with the implementation as we evolve the engine. Once the contract is stable, we should
+> promote it into `docs/system/libs/mapgen` (and potentially clone the pattern for other data products).
+
+## 1. Purpose
+
+- Capture what the **M2 engine slice** guarantees about `FoundationContext` and the config→tunables→orchestrator flow.
+- Give M3+ work (pipeline, climate, story) a **single reference** instead of reverse-engineering behavior from code.
+- Provide a bridge between the **target architecture docs** and the **current MapOrchestrator-centric implementation**.
+
+Authoritative implementation references:
+
+- Types & factories: `packages/mapgen-core/src/core/types.ts`
+  - `FoundationContext`, `FoundationConfigSnapshot`, `createFoundationContext`, `assertFoundationContext`, `hasFoundationContext`
+- Orchestration & world model: `packages/mapgen-core/src/MapOrchestrator.ts`
+- Config & tunables flow: `packages/mapgen-core/src/bootstrap/entry.ts`, `packages/mapgen-core/src/bootstrap/tunables.ts`
+- Target architecture: `docs/system/libs/mapgen/architecture.md`, `docs/system/libs/mapgen/foundation.md`
+
+## 2. Scope & Status
+
+- **Scope (M2):**
+  - Describe the **shape and semantics** of `FoundationContext` as emitted by the current `foundation` slice.
+  - Describe the **config → tunables → MapOrchestrator → FoundationContext → world model** flow at a high level.
+  - Define what downstream stages may **assume** once the foundation slice has completed successfully.
+- **Status:**
+  - This contract is **binding** for M2 and for any M3+ work that claims to build on the “M2 stable slice”.
+  - It may be **refined** as we discover gaps; when we make changes, we should update this doc alongside the code.
+
+## 3. Data Product: FoundationContext
+
+At the end of the `foundation` slice, the orchestrator must have:
+
+- An `ExtendedMapContext` (`ctx`) whose:
+  - `ctx.dimensions` is a valid `MapDimensions` (width, height, size).
+  - `ctx.worldModel` is initialized and contains all plate/dynamics tensors used by `createFoundationContext`.
+  - `ctx.foundation` is a **non-null**, immutable `FoundationContext` snapshot created via `createFoundationContext`.
+
+### 3.1 Shape
+
+```ts
+interface FoundationContext {
+  dimensions: Readonly<{ width: number; height: number; size: number }>;
+  plateSeed: Readonly<SeedSnapshot> | null;
+  plates: Readonly<FoundationPlateFields>;
+  dynamics: Readonly<FoundationDynamicsFields>;
+  diagnostics: Readonly<FoundationDiagnosticsFields>;
+  config: Readonly<FoundationConfigSnapshot>;
+}
+```
+
+- `dimensions`
+  - Width/height/size for the **foundation tensors**, derived from the map dimensions used by `WorldModel`.
+  - **Invariant:** `size === width * height` and matches the length of all plate/dynamics tensors.
+- `plateSeed`
+  - Snapshot from `PlateSeedManager`, if available.
+  - Used for diagnostics and deterministic reproduction of plate layouts.
+  - May be `null` in test harnesses or non-standard entrypoints; consumers *must* tolerate `null`.
+- `plates` (`FoundationPlateFields`)
+  - Each field is a 1D tensor of length `size`, representing per-tile plate state:
+    - `id`: plate ID per tile.
+    - `boundaryCloseness`: proximity to the nearest plate boundary.
+    - `boundaryType`: encoded interaction type at boundaries (convergent/divergent/transform).
+    - `tectonicStress`: aggregate boundary stress metric.
+    - `upliftPotential`: collision-driven uplift intensity.
+    - `riftPotential`: divergence-driven rift intensity.
+    - `shieldStability`: craton/plate interior stability measure.
+    - `movementU` / `movementV`: plate motion vectors.
+    - `rotation`: plate angular velocity.
+  - **Invariant:** All tensors are present, and `createFoundationContext` enforces exact length matches.
+- `dynamics` (`FoundationDynamicsFields`)
+  - Per-tile atmospheric/oceanic state:
+    - `windU` / `windV`: coarse wind vectors.
+    - `currentU` / `currentV`: ocean current vectors.
+    - `pressure`: scalar pressure field.
+  - **Invariant:** All tensors are present and sized to `dimensions.size`.
+- `diagnostics` (`FoundationDiagnosticsFields`)
+  - Currently:
+    - `boundaryTree`: optional structure used by diagnostics (ASCII, histograms, debug views).
+  - This is explicitly **non-stable** and may evolve; consumers outside diagnostics should not depend on its shape.
+- `config` (`FoundationConfigSnapshot`)
+  - Immutable snapshot of the configuration that informed the foundation run:
+    - `seed`, `plates`, `dynamics`, `surface`, `policy`, `diagnostics`.
+  - Each sub-object is frozen via `freezeConfigSnapshot` and intended for:
+    - Diagnostics and reproducibility.
+    - Future pipeline steps that want to introspect the config that produced the tensors, without mutating it.
+
+### 3.2 Invariants & Usage Guarantees
+
+For the **M2 slice**, downstream stages may assume:
+
+- `ctx.foundation` is **either**:
+  - `null` (before foundation runs or if the foundation stage is disabled), **or**
+  - A fully-populated `FoundationContext` that passed `createFoundationContext`’s validation.
+- Any stage that **requires** physics data must:
+  - Call `assertFoundationContext(ctx, stageName)` or an equivalent guard before reading plate/dynamics tensors.
+  - Treat a missing `FoundationContext` as a hard error (this is how we surface manifest/wiring issues).
+- New work in M3+ that depends on foundation physics (climate, story overlays, rivers, etc.) should:
+  - Read from `ctx.foundation` and derived buffers (`Heightfield`, `ClimateField`) rather than re-reading raw `WorldModel` tensors.
+  - Treat `FoundationContext` as the **canonical bridge** between the physics engine and downstream data products.
+
+## 4. Config → Tunables → Orchestrator → FoundationContext → World Model
+
+This section summarizes the **M2-era flow** that leads to `FoundationContext`. It intentionally focuses on
+contracts, not internal implementation details.
+
+### 4.1 Config & Tunables Flow
+
+- `bootstrap(options)` is the **single entrypoint** for building engine config:
+  - Composes presets and overrides into a raw config.
+  - Resolves `stageConfig` into a `stageManifest` (via `resolveStageManifest`).
+  - Validates the combined object via `parseConfig(rawConfig)` to produce a `MapGenConfig`.
+  - Calls `bindTunables(validatedConfig)`, which:
+    - Stores the validated config.
+    - Invalidates the tunables cache.
+- `getTunables()` (and the `TUNABLES` facade) produces a **read-only view** over `MapGenConfig`:
+  - Shapes configuration into `TunablesSnapshot` (including `FOUNDATION_CFG`, `FOUNDATION_PLATES`, `FOUNDATION_DYNAMICS`).
+  - Does **not** apply new defaults; it assumes `parseConfig` has already done so.
+  - Is the only supported way for legacy layers to read config in M2.
+
+**M2 Contract for Tunables**
+
+- Tunables are a **derived, read-only view**:
+  - They must not be mutated by callers.
+  - Their backing `MapGenConfig` comes from the last successful `bootstrap()` / `bindTunables()` call.
+- Future work (M3+) should treat tunables as:
+  - A **compatibility layer** for legacy code.
+  - Not the primary long-term config surface for new pipeline steps.
+
+### 4.2 Orchestrator & World Model Flow
+
+- `MapOrchestrator` is constructed with a **validated `MapGenConfig`** and optional adapter options.
+- When running the `foundation` stage, the orchestrator:
+  - Creates an `ExtendedMapContext` with:
+    - Dimensions from the Civ7 adapter or test defaults.
+    - The same `MapGenConfig` instance passed into the constructor.
+  - Configures and runs `WorldModel` using tunables derived from that config.
+  - After `WorldModel` finishes foundation physics, calls:
+    - `createFoundationContext(WorldModel, { dimensions, config: foundationConfigSlice })`.
+  - Stores the resulting `FoundationContext` on:
+    - `ctx.foundation` (for downstream TS stages).
+    - `WorldModel` (for any remaining legacy consumers and diagnostics).
+
+**M2 Contract for World Model & FoundationContext**
+
+- `createFoundationContext` **fails fast** if:
+  - `WorldModel` is not initialized.
+  - Map dimensions are missing or invalid.
+  - Any required tensor is missing or has the wrong length.
+- On success:
+  - `ctx.foundation` is immutable and remains valid for the rest of the generation run.
+  - Downstream stages must treat it as read-only and may rely on its tensors to be internally consistent.
+
+## 5. How to Use This Contract (M3+ Work)
+
+When implementing M3+ issues (pipeline generalization, climate, story overlays):
+
+- **Do reference this doc** when:
+  - Deciding which `requires`/`provides` contracts to declare for steps that depend on foundation physics.
+  - Designing new data products (e.g., `ClimateField`, `StoryOverlays`) that build on plate/dynamics tensors.
+- **Do not treat it as immutable**:
+  - If you need additional guarantees or fields from foundation, add them to the code **and** update this contract.
+  - If you discover mismatches between this doc and the implementation, treat that as a bug in the doc and fix it.
+- **Promotion path**:
+  - Once `FoundationContext` usage stabilizes across M3/M4, we should:
+    - Move this contract (possibly refined) into `docs/system/libs/mapgen` as canonical architecture.
+    - Optionally introduce similar contract docs for other data products (`Heightfield`, `ClimateField`, `StoryOverlays`).
+

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
@@ -6,6 +6,44 @@ status: draft
 reviewer: AI agent (Codex CLI)
 ---
 
+## Milestone M2 – Final Analysis & Path Forward
+
+M2 is effectively concluded as a **“config + foundation slice is stable, documented, and test-backed”** milestone, implemented on the current `MapOrchestrator`-centric architecture. It **does not** include a fully generic `PipelineExecutor` / `MapGenStep` / `StepRegistry`; those pipeline primitives are now explicitly planned for early M3+ on top of the stabilized data products.
+
+Before calling M2 fully done, we will land a small, concrete cleanup/stabilization batch:
+
+- **Docs alignment**
+  - Update M2 docs and relevant issue files so they accurately describe the real flow: `bootstrap() → MapGenConfig → tunables → MapOrchestrator → FoundationContext`.
+  - Remove or clearly mark as “future” any remaining references to `globalThis.__EPIC_MAP_CONFIG__` and the old global-config pattern.
+  - Soften or relocate language that assumes a currently implemented generic `PipelineExecutor` / `MapGenStep` / `StepRegistry`, making clear that these land in M3+.
+- **Contract stabilization**
+  - Make the `FoundationContext` contract explicit: what it guarantees to downstream consumers and which data products exist at the end of the M2 slice (captured in `resources/CONTRACT-foundation-context.md` as a working contract doc).
+  - Clarify the role of tunables as a derived, read-only view over `MapGenConfig`, not a primary config store.
+- **Tests**
+  - Add at least one end-to-end `MapOrchestrator.generateMap` smoke test using a minimal/default `MapGenConfig` and a stub adapter, asserting that:
+    - Foundation data products are populated as expected.
+    - The stage flow does not regress under the current M2 slice.
+
+These cleanup items will become a small set of discrete M2 follow-up issues (to be created in Linear later), for example:
+
+- “Align M2 docs and status with the actual config/orchestrator implementation.”
+- “Document the `FoundationContext` contract and the config → tunables → world-model flow.”
+- “Add `MapOrchestrator.generateMap` smoke tests over the current slice.”
+
+Looking forward, M3 and M4 are realigned at a high level as follows:
+
+- **M3**
+  - Introduce `PipelineExecutor` / `MapGenStep` / `StepRegistry` *on top of* the now-stable data products, rather than in parallel to them.
+  - Canonicalize core engine data products, including:
+    - `ClimateField` and basic hydrology/river products.
+    - `StoryOverlays` and their relationship to `StoryTags`.
+  - Start migrating key clusters (foundation extensions, climate, early story overlays) into `MapGenStep`s with clear `requires` / `provides` contracts.
+- **M4**
+  - Focus on validation, contracts, and robustness:
+    - Data-product and `StageManifest` validation (requires/provides checks, manifest consistency).
+    - Orchestrator/pipeline integration tests and diagnostics.
+    - Final cleanup of legacy paths and shims as the new architecture becomes the default.
+
 # M2: Stable Engine Slice – Aggregate Review (Running Log)
 
 This running log captures task-level reviews for milestone M2. Entries focus on

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
@@ -100,20 +100,36 @@ Satisfied for M2: `mapgen-core` no longer uses `globalThis`-backed config stores
 - Ensure `bootstrap()` returns a validated `MapGenConfig` instead of only mutating hidden state, while keeping the public `bootstrap(options)` signature stable for Swooper maps.  
 - Treat module-scoped, shallow-frozen config as a transitional step toward full injection (CIV‑30) and tunables-as-view (CIV‑31), not as a new long-term global pattern.
 
-**What’s Strong**  
-- `packages/mapgen-core/src/bootstrap/runtime.ts` is rewritten as a module-scoped store (`_validatedConfig`) with `setValidatedConfig`/`getValidatedConfig`/`hasConfig`/`resetConfig`, completely removing `globalThis` from runtime config paths in the engine library.  
-- `packages/mapgen-core/src/bootstrap/entry.ts` (and its `dist` counterpart) now build a `rawConfig`, resolve `stageConfig` into a `stageManifest`, validate via `parseConfig(rawConfig)`, store via `setValidatedConfig`, and return the resulting `MapGenConfig`.  
-- The public surface remains compatible: `bootstrap(options)` still accepts the same options, `MapConfig` is aliased to `MapGenConfig`, and deprecated `setConfig`/`getConfig` shims exist only as a non-global, strongly-typed compatibility layer.
+**What's Strong**
+- ~~`packages/mapgen-core/src/bootstrap/runtime.ts` is rewritten as a module-scoped store (`_validatedConfig`) with `setValidatedConfig`/`getValidatedConfig`/`hasConfig`/`resetConfig`, completely removing `globalThis` from runtime config paths in the engine library.~~
 
-**High-Leverage Issues (Deferred / Covered Elsewhere)**  
-- **Consumption still goes through tunables and legacy getters (CIV‑30/31 scope).**  
-  `MapOrchestrator` and most layers still read configuration via `getTunables()` (which in turn calls `getConfig()`), rather than using `getValidatedConfig()` or constructor injection. This is by design for M2: CIV‑30 and CIV‑31 already cover wiring `MapOrchestrator` to `MapGenConfig` and refactoring tunables as a view over validated config. No new issue is needed; we should just verify those tasks close the loop.  
-- **Deprecated `setConfig`/`getConfig` remain exported (CIV‑26 / later cleanup).**  
-  The deprecated APIs are now safe (no globals) but still visible on the bootstrap entry. They’re clearly marked `@deprecated` and can be treated as transitional. Cleanup/removal is best handled once CIV‑30/31 are complete; this is already conceptually covered by the CIV‑26 parent (“no global config stores” + injected config) and does not require a separate ticket unless we want a dedicated “remove legacy runtime APIs” task.  
-- **Tests still reflect the pre-refactor runtime shape (low-risk hygiene).**  
-  Some bootstrap/runtime tests still assert the old `getConfig()` semantics (e.g., instance identity, always-present object) instead of focusing on `getValidatedConfig()`/`hasConfig` and the failure mode when called before `bootstrap()`. This doesn’t affect runtime behavior but slightly weakens the guardrails around the new model. It’s reasonable to either:  
-  - Update these tests as part of CIV‑30/31 when we touch orchestrator/tunables, or  
-  - Treat it as a small follow-up checklist item under CIV‑29/CIV‑26 without filing a dedicated issue.
+  **Update (2025‑12):** The module-scoped config store and `setConfig`/`getConfig`/`setValidatedConfig`/`getValidatedConfig`/`hasConfig`/`resetConfig` have been removed. `runtime.ts` now only exports a type alias. Configuration flows exclusively through `bootstrap(...) → MapGenConfig → bindTunables(config) → getTunables()`.
+
+- ~~`packages/mapgen-core/src/bootstrap/entry.ts` (and its `dist` counterpart) now build a `rawConfig`, resolve `stageConfig` into a `stageManifest`, validate via `parseConfig(rawConfig)`, store via `setValidatedConfig`, and return the resulting `MapGenConfig`.~~
+
+  **Update (2025‑12):** `entry.ts` no longer calls `setValidatedConfig`. It validates via `parseConfig(rawConfig)`, calls `bindTunables(validatedConfig)`, and returns the `MapGenConfig`. There is no longer a separate runtime config store.
+
+- ~~The public surface remains compatible: `bootstrap(options)` still accepts the same options, `MapConfig` is aliased to `MapGenConfig`, and deprecated `setConfig`/`getConfig` shims exist only as a non-global, strongly-typed compatibility layer.~~
+
+  **Update (2025‑12):** The deprecated `setConfig`/`getConfig` shims have been removed. The public surface is now `bootstrap(options) → MapGenConfig` plus the tunables API (`getTunables`, `bindTunables`, `resetTunables`, `stageEnabled`).
+
+**High-Leverage Issues (Deferred / Covered Elsewhere)**
+- ~~**Consumption still goes through tunables and legacy getters (CIV‑30/31 scope).**~~
+  ~~`MapOrchestrator` and most layers still read configuration via `getTunables()` (which in turn calls `getConfig()`), rather than using `getValidatedConfig()` or constructor injection. This is by design for M2: CIV‑30 and CIV‑31 already cover wiring `MapOrchestrator` to `MapGenConfig` and refactoring tunables as a view over validated config. No new issue is needed; we should just verify those tasks close the loop.~~
+
+  **Update (2025‑12):** `getTunables()` now reads from a bound validated `MapGenConfig` and throws when tunables have not been bound. There is no legacy fallback to `getConfig()` or module state; callers must go through `bootstrap()` or `bindTunables(config)`.
+
+- ~~**Deprecated `setConfig`/`getConfig` remain exported (CIV‑26 / later cleanup).**~~
+  ~~The deprecated APIs are now safe (no globals) but still visible on the bootstrap entry. They're clearly marked `@deprecated` and can be treated as transitional. Cleanup/removal is best handled once CIV‑30/31 are complete; this is already conceptually covered by the CIV‑26 parent ("no global config stores" + injected config) and does not require a separate ticket unless we want a dedicated "remove legacy runtime APIs" task.~~
+
+  **Update (2025‑12):** The deprecated `setConfig`/`getConfig` APIs have been removed from the codebase entirely.
+
+- ~~**Tests still reflect the pre-refactor runtime shape (low-risk hygiene).**~~
+  ~~Some bootstrap/runtime tests still assert the old `getConfig()` semantics (e.g., instance identity, always-present object) instead of focusing on `getValidatedConfig()`/`hasConfig` and the failure mode when called before `bootstrap()`. This doesn't affect runtime behavior but slightly weakens the guardrails around the new model. It's reasonable to either:~~
+  - ~~Update these tests as part of CIV‑30/31 when we touch orchestrator/tunables, or~~
+  - ~~Treat it as a small follow-up checklist item under CIV‑29/CIV‑26 without filing a dedicated issue.~~
+
+  **Update (2025‑12):** Tests have been updated to reflect the new model. `runtime.test.ts` was deleted (tested removed APIs). Bootstrap and tunables tests now use `bootstrap()` or `bindTunables()` and assert the fail-fast behavior when tunables are not initialized.
 
 **Fit Within the Milestone**  
 For M2’s “stable engine slice” goal, CIV‑29 delivers the key hygiene step: the engine library now uses a validated, module-scoped config store instead of `globalThis`, and `bootstrap()` is a proper entrypoint into the CIV‑27/28 schema & loader. The remaining responsibilities—making `MapOrchestrator` and tunables consume that validated config explicitly, and tightening tests around the new invariants—are intentionally scoped into CIV‑30/31 and the broader CIV‑26 epic rather than being missing work here.
@@ -140,9 +156,11 @@ Mostly, with notable gaps: `MapOrchestrator` now takes a validated `MapGenConfig
 - The constructor performs a clear fail-fast check for missing/undefined configs and is used consistently from the Swooper entry point (`mods/mod-swooper-maps/src/swooper-desert-mountains.ts`), which now calls `bootstrap(...)` and passes the returned config into `MapOrchestrator`.  
 - Direct calls to `getConfig()`/`getValidatedConfig()` were removed from the orchestrator; instead, it owns the config instance and relies on tunables/world-model hooks to derive per-stage views, which aligns with the CIV‑26/CIV‑29 direction.
 
-**High-Leverage Issues**  
-- **Constructor still has non-obvious side effects into the tunables runtime (CIV‑31 scope).**  
-  `MapOrchestrator`’s constructor calls `setValidatedConfig(config)` and `rebindTunables()` behind the scenes. This keeps M2 working but means the orchestrator is not yet “pure” from the config perspective, and callers can still accidentally rely on “constructor as global-mutator”. This bridging is appropriate for M2 but should be explicitly unwound in CIV‑31 when tunables are refactored to derive from injected config rather than hidden module state.  
+**High-Leverage Issues**
+- ~~**Constructor still has non-obvious side effects into the tunables runtime (CIV‑31 scope).**~~
+  ~~`MapOrchestrator`'s constructor calls `setValidatedConfig(config)` and `rebindTunables()` behind the scenes. This keeps M2 working but means the orchestrator is not yet "pure" from the config perspective, and callers can still accidentally rely on "constructor as global-mutator". This bridging is appropriate for M2 but should be explicitly unwound in CIV‑31 when tunables are refactored to derive from injected config rather than hidden module state.~~
+
+  **Update (2025‑12):** The `setValidatedConfig` and `rebindTunables` side effects have been removed from `MapOrchestrator`. The constructor no longer mutates module state. Configuration binding now happens explicitly via `bootstrap() → bindTunables(config)` before the orchestrator is constructed.  
 - **Tests still instantiate `MapOrchestrator` with options-shaped arguments, not `(config, options)`.**  
   `packages/mapgen-core/test/orchestrator/requestMapData.test.ts` still does `new MapOrchestrator({ mapSizeDefaults: { … } })`, which under the new signature is treated as a `MapGenConfig` rather than `OrchestratorConfig`. That means the `mapSizeDefaults` path is never exercised in these tests, and they instead fall back to engine globals and standard defaults. This doesn’t block runtime behavior but weakens our guardrails around the new constructor contract; updating these tests to pass a simple dummy `MapGenConfig` plus `{ mapSizeDefaults }` as `options` is a worthwhile follow-up, and can reasonably ride with CIV‑31 or a small CIV‑26 hygiene task.  
 - **Top-of-file usage docs still show the pre-injection constructor.**  
@@ -155,3 +173,87 @@ CIV‑30 delivers the key boundary shift for M2: the orchestrator is now constru
 1. As part of CIV‑31, move the `setValidatedConfig`/`rebindTunables` behavior out of the orchestrator constructor and into a clearer “bind config to tunables” layer, ideally driven directly from the injected `MapGenConfig`.  
 2. Update `requestMapData` tests to use a minimal `MapGenConfig` instance plus an explicit `{ mapSizeDefaults }` `OrchestratorConfig`, so the tests cover the intended override behavior instead of relying on global fallbacks.  
 3. Refresh the `MapOrchestrator` header documentation and any in-repo usage snippets to consistently show the “bootstrap → `MapOrchestrator(config, options)`” pattern and discourage resurrecting the old no-arg constructor in future work.
+
+---
+
+## CIV-31 – Refactor Tunables as View over MapGenConfig
+
+**Quick Take**
+~~No for M2 as currently implemented: tunables are correctly reoriented around `MapGenConfig` and no longer read `getConfig()`, but the new `resetTunables()` / `getTunables()` interaction introduces a runtime regression in `MapOrchestrator.generateMap` and breaks the stated "works from module state" compatibility story.~~
+
+**Update (2025‑12):** Yes for M2. All blocking issues have been resolved: `resetTunables()` now preserves the bound config (only clears cache), the fail-fast contract is explicit, tests are aligned, and defaults have been consolidated into the schema.
+
+**Intent & Assumptions**  
+- Make `buildTunablesFromConfig(config: MapGenConfig)` the canonical builder, operating solely on validated config instead of loosely typed globals.  
+- Keep the public tunables surface (`getTunables`, `TUNABLES`, `stageEnabled`) stable so layers and the orchestrator do not need to change in M2.  
+- Preserve backward compatibility for existing flows that relied on module-scoped config state, at least through this milestone, while moving defaults into the TypeBox schema where possible.
+
+**What’s Strong**  
+- `packages/mapgen-core/src/bootstrap/tunables.ts` now exposes `buildTunablesFromConfig(config: MapGenConfig)` and builds the snapshot from strongly typed config, including the “mod override” merge of top-level layer configs into `foundation` (e.g., `mountains`, `volcanoes`, `biomes`).  
+- Tunables no longer call `getConfig()` or rely on global config; `bootstrap()` binds tunables explicitly via `bindTunables(validatedConfig)`, aligning with the CIV‑26 config-hygiene direction.  
+- The TypeBox schema carries most primary defaults (toggles, plates, dynamics, landmass, climate) with detailed JSDoc, and the tunables snapshot reuses those structures rather than re-encoding shapes.  
+- The public API (`getTunables`, `TUNABLES`, `stageEnabled`) remains intact, so layers and `MapOrchestrator` continue to consume tunables through the same surface.
+
+**High-Leverage Issues**
+- ~~**`resetTunables()` clears the bound config, breaking `generateMap()`.**~~
+  ~~`resetTunables()` now sets both `_cache` and `_boundConfig` to `null`, while `getTunables()` throws when `_boundConfig` is `null`. `MapOrchestrator.generateMap()` calls `const devTunables = getTunables(); … resetTunables(); const tunables = getTunables();`, so the second call will throw and abort generation in the Swooper `GenerateMap` flow. For a "stable engine slice", this needs to be fixed in CIV‑31: either change `resetTunables()` to clear only `_cache`, or have `generateMap()` immediately re-bind via `bindTunables(this.mapGenConfig)` before subsequent tunables reads.~~
+
+  **Update (2025‑12):** Fixed. `resetTunables()` now clears only `_cache` while preserving `_boundConfig`. A separate `resetTunablesForTest()` function is provided for test isolation that clears both.
+
+- ~~**The "module-state compatibility" contract is now ambiguous and tests are misaligned.**~~
+  ~~The CIV‑31 issue text still describes `getTunables()` as working off module state for backward compat, but the implementation only ever consults `_boundConfig`, and test suites (`test/bootstrap/tunables.test.ts`, `test/bootstrap/entry.test.ts`) still rely on `setConfig()` + `rebind()` without `bindTunables()` or `bootstrap()`. We need an explicit decision for M2: either reintroduce a legacy fallback (e.g., when `_boundConfig` is missing, derive a config from `getConfig()` / `getDefaultConfig()`), or formally tighten the contract to "must call `bootstrap()` / `bindTunables()` first" and update tests and docs to match.~~
+
+  **Update (2025‑12):** Resolved. The contract is now explicit: `getTunables()` throws if no config has been bound via `bindTunables()` or `bootstrap()`. There is no legacy fallback to module state. Tests have been updated to use `bootstrap()` or `bindTunables()` and assert the fail-fast behavior.
+
+- ~~**Defaults remain duplicated between schema and tunables without a clearly documented boundary.**~~
+  ~~Many defaults (notably plates and dynamics) now live in both `schema.ts` and `tunables.ts` (`DEFAULT_PLATES`, `DEFAULT_DYNAMICS`, etc.). The intent in CIV‑31 is that schema owns primary defaults and tunables use fallbacks for merge behavior, but this split is not obvious from code comments and increases the risk of drift. This is not blocking M2, but a future pass should consolidate what lives in the schema vs. tunables and document that boundary near the `DEFAULT_*` declarations.~~
+
+  **Update (2025‑12):** Consolidated. All `DEFAULT_*` constants have been removed from `tunables.ts`. The schema (`src/config/schema.ts`) is now the single source of truth for all defaults (toggles, plates, dynamics, wind). Tunables reads directly from validated config without re-defaulting. `WorldModel` also no longer re-defaults values; it assumes config has been validated by `parseConfig`.
+
+- ~~**Tests don't cover the new binding path or StageConfig → StageManifest wiring.**~~
+  ~~The existing tunables/bootstrap tests primarily exercise legacy patterns rather than the canonical M2 path (`bootstrap()` → `bindTunables` → `MapOrchestrator(config, options)` → `stageEnabled()`). As a result, core behaviors (e.g., stage gating, manifest resolution driven by validated config) aren't pinned by tests, making regressions like the `resetTunables()` bug easy to introduce. This should be addressed under CIV‑23 / CIV‑26 with at least one focused test that proves the end-to-end tunables flow works as expected.~~
+
+  **Update (2025‑12):** Partially addressed. Tests now cover the `bootstrap()` → `bindTunables` → `getTunables()` path and the `stageConfig` → `stageManifest` resolution. Full end-to-end integration tests (bootstrap → orchestrator → generateMap) remain a follow-up for CIV-23.
+
+**Fit Within the Milestone**
+~~Structurally, CIV‑31 is an important step toward the desired end state: tunables are now a view over validated `MapGenConfig` with an explicit binding step, which is exactly what the config-hygiene PRD calls for. However, in its current form it does **not** yet meet the "stable engine slice" bar for M2 because `resetTunables()` breaks `MapOrchestrator.generateMap()` and the compatibility story for legacy module-state flows is unresolved. The structural refactor should stand, but we need at least one small code change (reset/binding fix) plus test/contract alignment before we can treat CIV‑31 as complete for this milestone.~~
+
+**Update (2025‑12):** CIV‑31 now meets the "stable engine slice" bar for M2. All blocking issues have been resolved, and the config/tunables flow is clean and well-documented. Tunables are a pure view over validated `MapGenConfig` with explicit fail-fast semantics.
+
+**Recommended Next Moves**
+~~1. Fix the `resetTunables()` / `getTunables()` regression as part of CIV‑31 (or an immediate follow-up) so `generateMap()` runs successfully in the Swooper entry path without additional workarounds.~~
+~~2. Decide and document the M2-era `getTunables()` contract (legacy module state vs. "must bootstrap"), then update tests and the CIV‑31 issue text accordingly; this is conceptually owned by CIV‑26 but should be resolved while CIV‑31 is still fresh.~~
+~~3. In a later config-focused pass (CIV‑26 / M3), consolidate defaults between schema and tunables where possible and add short comments clarifying when tunables-level defaults apply.~~
+4. Ensure CIV‑23 (integration tests) or a nearby test task adds at least one end-to-end test that exercises `bootstrap` → tunables binding → `MapOrchestrator` → `stageEnabled()` to guard the new configuration flow going forward.
+
+**Update (2025‑12):** Items 1-3 have been completed. Item 4 (full integration tests) remains a follow-up for CIV-23.
+
+---
+
+## Outcomes / Remaining Work
+
+The following items are **not in scope for this lane** but represent the next logical hygiene steps now that config and tunables are aligned with the schema-based model. These should be turned into new Linear issues for future work.
+
+### Dedicated "current config/tunables behavior" doc
+
+**Outcome:** We aligned the implementation and review docs for config/tunables, but details are still scattered across issues and reviews.
+
+**Follow‑up:** Create a small, dedicated document under `docs/system/` (or `docs/projects/engine-refactor-v1/`) that describes the current end-to-end config flow (`bootstrap → MapGenConfig → tunables → orchestrator → WorldModel`) as the single source of truth for future work.
+
+### Move layers off tunables toward direct config/context
+
+**Outcome:** Tunables now act as a thin view over `MapGenConfig`, and we centralized defaults in the schema, but layers and `WorldModel` still depend on tunables as the main configuration surface.
+
+**Follow‑up:** Introduce a gradual migration plan for layers and `WorldModel` to read directly from `MapGenConfig`/`MapContext` instead of tunables, with tunables remaining as a compatibility/view layer only.
+
+### Strengthen integration tests around config→tunables→orchestrator→WorldModel
+
+**Outcome:** Unit tests cover bootstrap, tunables, and some orchestrator behavior, but we still lack a robust integration test that runs the full `bootstrap → MapOrchestrator(config, options) → generateMap()` flow with a mock adapter and asserts that schema defaults + overrides drive real behavior end-to-end.
+
+**Follow‑up:** Add one or more integration tests under CIV‑23/CIV‑26 to pin the current configuration pipeline and protect against regressions.
+
+### Audit remaining engine-side defaults (currents, diagnostics, etc.)
+
+**Outcome:** We centralized key `WorldModel` defaults (plates, mantle, wind) into the schema, but some engine subsystems (currents, certain diagnostics, possibly other world fields) still embed internal magic numbers.
+
+**Follow‑up:** Audit these remaining defaults and decide which should be surfaced in `MapGenConfig` vs. remain internal constants, to avoid hidden behavior and make tuning more explicit.

--- a/docs/projects/engine-refactor-v1/status.md
+++ b/docs/projects/engine-refactor-v1/status.md
@@ -5,7 +5,7 @@
 - Voronoi-only landmass path with `foundation` + `landmassPlates` as default stages; legacy landmass stub removed.
 - Deterministic `PlateSeedManager` + `FoundationContext` exported and asserted; `foundation.*` config unified and legacy `worldModel` overrides warned away.
 - Heightfield buffers in `MapContext`; landmass, coasts, mountains, volcanoes, lakes, and climate baseline/refine write through staging helpers.
-- Margin overlays published via `StoryOverlays` and hydrated into `StoryTags`; `[Foundation]` diagnostics cover seed/plate/dynamics/surface plus ASCII/histograms.
+- `[Foundation]` diagnostics cover seed/plate/dynamics/surface plus ASCII/histograms.
 
 ## Gaps / In Progress
 - Climate consumers still read `GameplayMap` instead of `ClimateField`; river flow data not exposed as a product.
@@ -15,9 +15,9 @@
 - No automated smoke tests for orchestrator/context; verification is manual via diagnostics.
 
 ## Ready Next
-1. Finish Phase C: make `ClimateField` the canonical rainfall source; surface river flow/summary data for downstream overlays.
-2. Begin Phase D: refit story tagging to consume `FoundationContext`/`Heightfield`/`ClimateField` and publish overlays; retire direct `StoryTags` mutation.
-3. Add manifest/data-product validation to gate stages on declared `requires`/`provides`.
+1. Make `ClimateField` the canonical rainfall source and surface river flow/summary data for downstream overlays (Phase C / early M3).
+2. Begin refitting story tagging to consume `FoundationContext`/`Heightfield`/`ClimateField` and publish `StoryOverlays`; retire direct `StoryTags` mutation (Phase D / M3).
+3. Introduce `PipelineExecutor` / `MapGenStep` / `StepRegistry` on top of the stabilized data products, and add manifest/data-product validation to gate stages on declared `requires`/`provides` (late M3–M4).
 
 ## Spikes / Research
 - Overlay payload schema for corridors/hotspots/rifts/swatches (fields + summary for consumers).

--- a/docs/system/libs/mapgen/architecture.md
+++ b/docs/system/libs/mapgen/architecture.md
@@ -1,5 +1,7 @@
 # Map Generation Engine Architecture
 
+> This document describes the **target** architecture for the MAPS engine. The current implementation is converging toward this design; some details (such as the generic Pipeline Executor and full step registry) may be introduced incrementally across milestones.
+
 ## 1. Core Philosophy
 
 The Map Generation Engine is designed as a **Data-Driven Task Graph**. It moves away from monolithic "God Classes" (like the legacy `MapOrchestrator`) towards a composable pipeline of small, single-purpose **Strategies**.

--- a/docs/system/mods/swooper-maps/architecture.md
+++ b/docs/system/mods/swooper-maps/architecture.md
@@ -90,36 +90,25 @@ import "./map_orchestrator.js";    // Shared generator
 - Deep merges presets with overrides
 - Calls `setConfig()` to store result globally
 
-#### `bootstrap/runtime.js`
-**Purpose**: Global configuration storage
+#### `bootstrap/runtime.js` (legacy JS architecture)
+**Purpose (historical)**: Global configuration storage
 
-- Uses `globalThis[__EPIC_MAP_CONFIG__]` for cross-module access
-- No import-time coupling (avoids circular dependencies)
-- Freezes config to prevent mutation
+- Stored merged config under a global key (e.g., `globalThis[__EPIC_MAP_CONFIG__]`) for cross-module access.
+- Avoided import-time coupling (reduced circular dependency risk).
+- Froze config to prevent mutation.
 
 #### `bootstrap/resolved.js`
 **Purpose**: Configuration resolution and merging
 
-- Reads from runtime store
-- Merges: `BASE_CONFIG` + presets (ordered) + runtime overrides
+- Reads from the current config source.
+- Merges: `BASE_CONFIG` + presets (ordered) + runtime overrides.
 - Exports typed getters: `getToggles()`, `getLandmass()`, etc.
 
 #### `bootstrap/tunables.js`
 **Purpose**: Live module bindings
 
-- Exports ES module `let` variables (not constants!)
-- `rebind()` updates all bindings from resolved config
-- Called at start of `generateMap()` to refresh values
-
-**Example**:
-```javascript
-export let LANDMASS_CFG = {};  // Updated by rebind()
-
-export function rebind() {
-    LANDMASS_CFG = getLandmass();
-    // ... etc
-}
-```
+- Exports ES module `let` variables (not constants).
+- Produces a derived, read-only view over the resolved config for consumers such as the map orchestrator and world model.
 
 ---
 

--- a/packages/mapgen-core/src/MapOrchestrator.ts
+++ b/packages/mapgen-core/src/MapOrchestrator.ts
@@ -416,7 +416,8 @@ export class MapOrchestrator {
 
     this.mapGenConfig = config;
     this.options = options;
-    this.adapter = resolveOrchestratorAdapter();
+    // Prefer caller-supplied adapter to avoid pulling real Civ7 adapter in tests.
+    this.adapter = options.adapter ?? resolveOrchestratorAdapter();
 
     // Note: Tunables must already be bound before constructing MapOrchestrator.
     // The expected flow is: bootstrap(options) → config → new MapOrchestrator(config)

--- a/packages/mapgen-core/src/bootstrap/tunables.ts
+++ b/packages/mapgen-core/src/bootstrap/tunables.ts
@@ -156,13 +156,14 @@ export function buildTunablesFromConfig(config: MapGenConfig): TunablesSnapshot 
 
   return {
     STAGE_MANIFEST: stageManifest,
-    // Toggles: read directly; defaults are in schema (all true)
-    STORY_ENABLE_HOTSPOTS: togglesConfig.STORY_ENABLE_HOTSPOTS ?? true,
-    STORY_ENABLE_RIFTS: togglesConfig.STORY_ENABLE_RIFTS ?? true,
-    STORY_ENABLE_OROGENY: togglesConfig.STORY_ENABLE_OROGENY ?? true,
-    STORY_ENABLE_SWATCHES: togglesConfig.STORY_ENABLE_SWATCHES ?? true,
-    STORY_ENABLE_PALEO: togglesConfig.STORY_ENABLE_PALEO ?? true,
-    STORY_ENABLE_CORRIDORS: togglesConfig.STORY_ENABLE_CORRIDORS ?? true,
+    // Toggles: schema defaults apply via parseConfig; tunables reads directly.
+    // Non-null assertions (!) document the contract that parseConfig has applied defaults.
+    STORY_ENABLE_HOTSPOTS: togglesConfig.STORY_ENABLE_HOTSPOTS!,
+    STORY_ENABLE_RIFTS: togglesConfig.STORY_ENABLE_RIFTS!,
+    STORY_ENABLE_OROGENY: togglesConfig.STORY_ENABLE_OROGENY!,
+    STORY_ENABLE_SWATCHES: togglesConfig.STORY_ENABLE_SWATCHES!,
+    STORY_ENABLE_PALEO: togglesConfig.STORY_ENABLE_PALEO!,
+    STORY_ENABLE_CORRIDORS: togglesConfig.STORY_ENABLE_CORRIDORS!,
     // Layer configs: read directly; defaults are in schema
     LANDMASS_CFG: safeFreeze(config.landmass ?? {}),
     FOUNDATION_CFG: safeFreeze(foundationConfig),

--- a/packages/mapgen-core/src/config/schema.ts
+++ b/packages/mapgen-core/src/config/schema.ts
@@ -759,7 +759,7 @@ export const FoundationDynamicsConfigSchema = Type.Object(
             Type.Number({
               description: "Strength of mantle pressure contributions; higher values increase uplift everywhere.",
               default: 0.6,
-              minimum: 0,
+              minimum: 0.1,
               maximum: 5,
             })
           ),
@@ -772,7 +772,7 @@ export const FoundationDynamicsConfigSchema = Type.Object(
             Type.Number({
               description: "Spatial scale of mantle effects; larger scales spread hotspots wider before decay.",
               default: 0.4,
-              minimum: 0,
+              minimum: 0.1,
               maximum: 1,
             })
           ),

--- a/packages/mapgen-core/src/world/model.ts
+++ b/packages/mapgen-core/src/world/model.ts
@@ -120,6 +120,8 @@ function toByte(v: number): number {
 // Plate Computation
 // ============================================================================
 
+// Defaults for plates/dynamics/wind now live in the config schema (src/config/schema.ts).
+// WorldModel assumes it receives fully validated config via tunables/MapGenConfig.
 function computePlates(
   width: number,
   height: number,
@@ -128,14 +130,14 @@ function computePlates(
   const config = getConfig();
   const platesCfg = config.plates || {};
 
-  const count = Math.max(2, (platesCfg.count ?? 8) | 0);
-  const convergenceMix = Math.max(0, Math.min(1, platesCfg.convergenceMix ?? 0.5));
-  const relaxationSteps = Math.max(0, (platesCfg.relaxationSteps ?? 5) | 0);
-  const plateRotationMultiple = platesCfg.plateRotationMultiple ?? 1.0;
-  const seedMode = platesCfg.seedMode === "fixed" ? "fixed" : "engine";
-  const seedOffset = Number.isFinite(platesCfg.seedOffset)
-    ? Math.trunc(platesCfg.seedOffset!)
-    : 0;
+  // Schema defaults and min/max constraints are enforced by parseConfig.
+  // Integer conversion (| 0) retained for runtime safety; no re-defaulting.
+  const count = (platesCfg.count! | 0);
+  const convergenceMix = platesCfg.convergenceMix!;
+  const relaxationSteps = (platesCfg.relaxationSteps! | 0);
+  const plateRotationMultiple = platesCfg.plateRotationMultiple!;
+  const seedMode = platesCfg.seedMode!;
+  const seedOffset = Math.trunc(platesCfg.seedOffset!);
   const fixedSeed = Number.isFinite(platesCfg.fixedSeed)
     ? Math.trunc(platesCfg.fixedSeed!)
     : undefined;
@@ -234,9 +236,10 @@ function computePressure(width: number, height: number, rng?: RngFunction): void
 
   const config = getConfig();
   const mantleCfg = config.dynamics?.mantle || {};
-  const bumps = Math.max(1, (mantleCfg.bumps ?? 4) | 0);
-  const amp = Math.max(0.1, mantleCfg.amplitude ?? 0.6);
-  const scl = Math.max(0.1, mantleCfg.scale ?? 0.4);
+  // Schema defaults and min/max constraints are enforced by parseConfig.
+  const bumps = (mantleCfg.bumps! | 0);
+  const amp = mantleCfg.amplitude!;
+  const scl = mantleCfg.scale!;
   const sigma = Math.max(4, Math.floor(Math.min(width, height) * scl));
 
   const getRandom = rng || getDefaultRng();
@@ -297,9 +300,10 @@ function computeWinds(
 
   const config = getConfig();
   const windCfg = config.dynamics?.wind || {};
-  const streaks = Math.max(0, (windCfg.jetStreaks ?? 3) | 0);
-  const jetStrength = Math.max(0, windCfg.jetStrength ?? 1.0);
-  const variance = Math.max(0, windCfg.variance ?? 0.6);
+  // Schema defaults and min/max constraints are enforced by parseConfig.
+  const streaks = (windCfg.jetStreaks! | 0);
+  const jetStrength = windCfg.jetStrength!;
+  const variance = windCfg.variance!;
 
   const getRandom = rng || getDefaultRng();
   const getLat =

--- a/packages/mapgen-core/src/world/model.ts
+++ b/packages/mapgen-core/src/world/model.ts
@@ -91,7 +91,9 @@ function getConfig(): WorldModelConfig {
   if (_configProvider) {
     return _configProvider();
   }
-  return {};
+  throw new Error(
+    "WorldModel configuration provider not set. MapOrchestrator must bind a provider before WorldModel.init()."
+  );
 }
 
 // ============================================================================

--- a/packages/mapgen-core/test/orchestrator/generateMap.integration.test.ts
+++ b/packages/mapgen-core/test/orchestrator/generateMap.integration.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { bootstrap } from "../../src/bootstrap/entry.js";
+import { resetTunablesForTest } from "../../src/bootstrap/tunables.js";
+import { MapOrchestrator } from "../../src/MapOrchestrator.js";
+import type { EngineAdapter } from "@civ7/adapter";
+
+/**
+ * Minimal integration to pin the canonical config → tunables → orchestrator path.
+ *
+ * We disable all stage execution via stageManifest to avoid engine dependencies
+ * and supply a no-op adapter. The goal is to verify that generateMap() can run
+ * end-to-end with schema-defaulted config and bound tunables, not to exercise
+ * the full layer pipeline.
+ */
+describe("integration: bootstrap → tunables → orchestrator (stages disabled)", () => {
+  const calls: Array<{ method: string; args: unknown[] }> = [];
+
+  const adapter: EngineAdapter = {
+    getGridWidth: () => 84,
+    getGridHeight: () => 54,
+    getMapSize: () => 1,
+    lookupMapInfo: () => ({
+      GridWidth: 84,
+      GridHeight: 54,
+      MinLatitude: -80,
+      MaxLatitude: 80,
+      NumNaturalWonders: 0,
+      LakeGenerationFrequency: 0,
+      PlayersLandmass1: 4,
+      PlayersLandmass2: 4,
+      StartSectorRows: 4,
+      StartSectorCols: 4,
+    }),
+    setMapInitData: (params) => calls.push({ method: "setMapInitData", args: [params] }),
+    isWater: () => false,
+    validateAndFixTerrain: () => calls.push({ method: "validateAndFixTerrain", args: [] }),
+    recalculateAreas: () => calls.push({ method: "recalculateAreas", args: [] }),
+    stampContinents: () => calls.push({ method: "stampContinents", args: [] }),
+    buildElevation: () => calls.push({ method: "buildElevation", args: [] }),
+    modelRivers: () => calls.push({ method: "modelRivers", args: [] }),
+    defineNamedRivers: () => calls.push({ method: "defineNamedRivers", args: [] }),
+    storeWaterData: () => calls.push({ method: "storeWaterData", args: [] }),
+    generateLakes: () => calls.push({ method: "generateLakes", args: [] }),
+    expandCoasts: () => calls.push({ method: "expandCoasts", args: [] }),
+    chooseStartSectors: () => {
+      calls.push({ method: "chooseStartSectors", args: [] });
+      return [];
+    },
+    needHumanNearEquator: () => false,
+    getRandomNumber: () => 0,
+    setTerrainType: () => {},
+    setWater: () => {},
+    setHeight: () => {},
+    getTerrainType: () => 0,
+    setPlotTag: () => {},
+    getPlotTag: () => 0,
+    hasPlotTag: () => false,
+    removePlotTag: () => {},
+    addPlotTag: () => {},
+    setLandmassRegionId: () => {},
+  };
+
+  beforeEach(() => {
+    calls.length = 0;
+    resetTunablesForTest();
+  });
+
+  afterEach(() => {
+    resetTunablesForTest();
+  });
+
+  it("runs generateMap with schema defaults and no stage execution", () => {
+    const config = bootstrap({
+      // Disable all stages so we only exercise the config/tunables/orchestrator wiring.
+      stageManifest: { order: [], stages: {} },
+    });
+
+    const orchestrator = new MapOrchestrator(config, {
+      adapter,
+      mapSizeDefaults: {
+        mapSizeId: 1,
+        mapInfo: adapter.lookupMapInfo(1),
+      },
+      logPrefix: "[TEST]",
+    });
+
+    const result = orchestrator.generateMap();
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/mapgen-core/test/setup.ts
+++ b/packages/mapgen-core/test/setup.ts
@@ -37,6 +37,10 @@ mock.module("/base-standard/maps/discovery-generator.js", () => ({
 mock.module("/base-standard/maps/assign-advanced-start-region.js", () => ({
   assignAdvancedStartRegions: () => {},
 }));
+// Additional Civ7 adapter dependency
+mock.module("/base-standard/scripts/kd-tree.js", () => ({
+  VoronoiUtils: {},
+}));
 
 // Mock engine API
 (globalThis as any).engine = {

--- a/packages/mapgen-core/test/world/config-provider.test.ts
+++ b/packages/mapgen-core/test/world/config-provider.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { WorldModel, setConfigProvider } from "../../src/world/model.js";
+
+describe("WorldModel config provider", () => {
+  beforeEach(() => {
+    WorldModel.reset();
+  });
+
+  afterEach(() => {
+    WorldModel.reset();
+  });
+
+  it("fails fast when no provider is set", () => {
+    expect(() => WorldModel.init({ width: 4, height: 4 })).toThrow(
+      /configuration provider not set/i
+    );
+  });
+
+  it("initializes when provider is set", () => {
+    setConfigProvider(() => ({
+      plates: {
+        count: 4,
+        convergenceMix: 0.5,
+        relaxationSteps: 1,
+        plateRotationMultiple: 1,
+        seedMode: "engine",
+        seedOffset: 0,
+      },
+      dynamics: {
+        mantle: { bumps: 1, amplitude: 0.6, scale: 0.4 },
+        wind: { jetStreaks: 0, jetStrength: 1, variance: 0.6 },
+      },
+      directionality: { cohesion: 0 },
+    }));
+
+    const ok = WorldModel.init({ width: 4, height: 4 });
+    expect(ok).toBe(true);
+  });
+});


### PR DESCRIPTION
# Update M2 docs and align with config + foundation slice implementation

- Remove redundant toggle defaults from tunables.ts (schema already has defaults)
- Centralize WorldModel defaults into schema (plates, dynamics, wind)
- Update schema with minimum 0.1 for amplitude/scale (matching prior clamps)
- Update REVIEW-M2-stable-engine-slice.md with strikethrough updates for resolved issues
- Add Outcomes / Remaining Work section documenting follow-up items

This PR updates the engine refactor documentation to accurately reflect the current implementation, which uses a `bootstrap() → MapGenConfig → tunables → MapOrchestrator → FoundationContext` flow rather than a generic pipeline executor. It clarifies that pipeline primitives are planned for M3+, not already implemented in M2.

The PR also adds three new issues to track remaining M2 stabilization work:
1. Align docs with the actual config/orchestrator implementation
2. Document the `FoundationContext` contract and config flow
3. Add `MapOrchestrator.generateMap` smoke tests

Additionally, it includes code improvements to remove redundant defaults from tunables.ts (using schema defaults instead) and centralizes WorldModel defaults in the schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>