### PR TITLE
feat(engine-refactor): split CIV-21 into M2/M3 children

### DIFF
--- a/docs/projects/engine-refactor-v1/PROJECT-engine-refactor-v1.md
+++ b/docs/projects/engine-refactor-v1/PROJECT-engine-refactor-v1.md
@@ -108,10 +108,15 @@ See `milestones/M2-stable-engine-slice.md` for detailed scope, dependency mappin
   - Ensure `[Foundation]` diagnostics are wired to the orchestrated foundation slice (seed/plate/dynamics/surface logs, ASCII maps, histograms).
   - Add basic stage-level logging around the foundation slice (start/finish, duration, errors).
 
+- **Minimal story parity**
+  - Restore margins/hotspots/rifts (± orogeny) via orchestrator story stages to re‑enable narrative‑aware consumers.
+  - See `issues/LOCAL-M2-story-parity.md` under parent `issues/CIV-21-story-tagging.md`.
+
 **Out of Scope (Milestone 2)**
 
 - Full config shape evolution or tunables retirement.
 - Refactoring non-foundation phases (climate, overlays, biomes, placement) into first-class pipeline steps.
+- Full story system modernization (corridors, swatches, paleo, canonical overlays, step wrapping).
 - Comprehensive test suite or manifest validator (those land in Milestone 4, with some groundwork here).
 
 **Exit Criteria**

--- a/docs/projects/engine-refactor-v1/issues/CIV-21-story-tagging.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-21-story-tagging.md
@@ -1,6 +1,6 @@
 ---
 id: CIV-21
-title: "[M-TS-P0] Reactivate Minimal Story Tagging"
+title: "Port Full Story Tagging, Corridors, and Overlays"
 state: planned
 priority: 2
 estimate: 0
@@ -9,7 +9,7 @@ milestone: M3-core-engine-refactor-config-evolution
 assignees: []
 labels: [bug]
 parent: CIV-14
-children: []
+children: [LOCAL-M2-STORY-PARITY, LOCAL-M3-STORY-SYSTEM]
 blocked_by: [CIV-18]
 blocked: [CIV-23]
 related_to: [CIV-10]
@@ -18,9 +18,11 @@ related_to: [CIV-10]
 <!-- SECTION SCOPE [SYNC] -->
 ## TL;DR
 
-Port a minimal subset of story tagging from JS to populate `StoryTags` with continental margins, hotspots, and rifts — the foundational tags that climate, biomes, and features depend on.
+Port the complete legacy story system from JS into TypeScript: minimal tagging parity, remaining narrative overlays (orogeny, swatches, paleo), and strategic corridors, with clear orchestration and overlay publication so downstream climate/biomes/features regain narrative signals.
 
-> **Note:** This issue was originally scoped as P0 remediation under the M1 TypeScript migration (CIV-14). It is now part of Milestone M3, where story tagging will be implemented against the stabilized pipeline and config shapes.
+> **Note:** This issue was originally scoped as P0 remediation under the M1 TypeScript migration (CIV-14). It now represents the full story porting program, split into two canonical child issues:
+> - `LOCAL-M2-story-parity.md` (minimal parity in M2)
+> - `LOCAL-M3-story-system.md` (remaining system in M3)
 
 ## Problem
 
@@ -35,218 +37,62 @@ The TypeScript migration created `story/tags.ts` with type definitions, but `sto
 
 **Result:** All story-aware code paths are no-ops, producing bland, uniform maps.
 
-### What We Need (Minimal Set)
+### What We Need (Complete Set)
 
-Not the full story system, just the foundation:
-1. **Continental margins** — active vs passive edges, subduction zones
-2. **Hotspots** — volcanic activity centers
-3. **Rifts** — divergent boundaries, potential lakes/seas
+The JS archive implements a layered “history in terrain” system. Full parity requires porting:
+1. **Continental margins** — active vs passive shelves, subduction indicators
+2. **Hotspot trails** — volcanic chains and paradise/volcanic sub-tags
+3. **Rift valleys** — rift lines and rift shoulders
+4. **Orogeny belts** — belt tagging + windward/lee caches used by climate
+5. **Climate swatches** — macro swatch overlays with soft edges
+6. **Paleo hydrology motifs** — elevation-aware paleo wetness overlays
+7. **Strategic corridors** — pre‑islands and post‑rivers corridor tagging with kind/style metadata
 
-These feed into climate moisture patterns, biome special cases, and feature placement.
+These feed rainfall refinement, biome biasing, feature placement, and strategic “lanes” in later layers.
 
 ## Deliverables
 
-- [ ] **Port minimal `story/tagging.ts`:**
-  - `imaprintMargins(ctx)` — classify plate boundaries as active/passive
-  - `seedHotspots(ctx)` — place volcanic hotspot tags based on plate stress
-  - `seedRifts(ctx)` — place rift tags at divergent boundaries
-- [ ] **Wire into orchestrator:**
-  - Call tagging functions in `storySeed` or `story*` stages
-  - Ensure `StoryTags` is populated before climate/biomes/features run
-- [ ] **Verify downstream consumption:**
-  - Climate reads margin tags for moisture adjustments
-  - Biomes reads hotspot tags for volcanic rules
-  - Features reads rift tags for geological placement
-- [ ] **Add smoke tests:**
-  - After story stages, assert `StoryTags` contains non-empty margin/hotspot/rift data
+This parent issue tracks the *complete* story port. Delivery is split across child issues:
+
+- [ ] **M2 minimal parity (child: `LOCAL-M2-STORY-PARITY`)**
+  - Port and wire continental margins, hotspot trails, rift valleys (optional orogeny belts).
+  - Publish corresponding overlays and re-enable story‑aware consumers.
+- [ ] **M3 remaining system (child: `LOCAL-M3-STORY-SYSTEM`)**
+  - Port corridors, climate swatches, paleo hydrology, and any deferred orogeny work.
+  - Canonicalize `StoryOverlays` as a data product and wrap story logic into steps once the pipeline executor exists.
+
+Legacy references:
+- `docs/system/libs/mapgen/_archive/original-mod-swooper-maps-js/story/tagging.js`
+- `docs/system/libs/mapgen/_archive/original-mod-swooper-maps-js/story/corridors.js`
 
 ## Acceptance Criteria
 
-- [ ] `story/tagging.ts` exists with minimal porting
-- [ ] `StoryTags` populated after story stages execute
-- [ ] Margin tags present (active/passive classification)
-- [ ] Hotspot tags present (based on tectonic stress)
-- [ ] Rift tags present (at divergent boundaries)
-- [ ] Climate/biomes/features can read these tags
-- [ ] Build passes, tests pass
+Parent completion requires both children to be complete:
+
+- [ ] Minimal story parity landed in M2 (`LOCAL-M2-STORY-PARITY` complete).
+- [ ] Remaining story system landed in M3 (`LOCAL-M3-STORY-SYSTEM` complete).
+- [ ] Story stages/steps populate `StoryTags` and publish overlays before consumers run.
+- [ ] Climate/biomes/features/corridor consumers regain narrative behavior.
+- [ ] Build passes, tests pass.
 
 ## Testing / Verification
 
-```typescript
-// Test: story tagging populates StoryTags
-test("story stages populate margin tags", () => {
-  const ctx = createMockContext();
-  setupFoundationWithPlates(ctx);
-
-  runStoryStages(ctx);
-
-  expect(ctx.overlays.has("margins")).toBe(true);
-  const margins = ctx.overlays.get("margins");
-  expect(margins.active.length).toBeGreaterThan(0);
-});
-
-// Test: climate uses margin tags
-test("climate reads margin tags for moisture", () => {
-  const ctx = createMockContext();
-  populateStoryTags(ctx);  // Mock story data
-
-  applyClimate(ctx);
-
-  // Active margins should have moisture bonus
-  const activeMarginIdx = findActiveMarginCell(ctx);
-  expect(ctx.fields.rainfall[activeMarginIdx]).toBeGreaterThan(baseRainfall);
-});
-```
-
-```bash
-# Build verification
-pnpm -C packages/mapgen-core build
-
-# Run story tests
-pnpm -C packages/mapgen-core test --grep "story|margin|hotspot|rift"
-```
+See the child issues for concrete test cases. At a high level:
+- M2 child adds smoke checks for non‑empty margins/hotspots/rifts when enabled.
+- M3 child adds corridor/swatches/paleo behavior checks and step‑level tests after pipeline refactor.
 
 ## Dependencies / Notes
 
 - **Blocked by**: Config resolver + call-site fixes (Stack 2)
 - **Blocks**: Integration tests (story enables meaningful downstream behavior)
 - **Related to**: CIV-10 (original story migration, incomplete)
-- **Scope**: Minimal port, not full story system (full system is P1)
-
-### What's NOT In Scope
-
-- Full corridor algorithms (sea lanes, mountain passes)
-- Paleo-geological history
-- Named story overlays for specific terrain features
-- Story-driven placement (cities, resources)
-
-These are deferred to P1 once the pipeline is stable.
+- **Scope**: Full story system, split across M2/M3 children.
 
 ---
 
 <!-- SECTION IMPLEMENTATION [NOSYNC] -->
 ## Implementation Details (Local Only)
 
-### Minimal Story Functions
-
-```typescript
-// story/tagging.ts
-
-import type { ExtendedMapContext, FoundationContext } from "../core/types.js";
-import { BOUNDARY_TYPE } from "../world/constants.js";
-
-export function imprintMargins(ctx: ExtendedMapContext): void {
-  const { foundation, dimensions } = ctx;
-  const { plates } = foundation;
-  const { width, height } = dimensions;
-
-  const activeMargins: number[] = [];
-  const passiveMargins: number[] = [];
-
-  for (let i = 0; i < width * height; i++) {
-    const boundaryType = plates.boundaryType[i];
-    const closeness = plates.boundaryCloseness[i];
-
-    // Only tag cells near plate boundaries
-    if (closeness < 10) continue;
-
-    if (boundaryType === BOUNDARY_TYPE.CONVERGENT ||
-        boundaryType === BOUNDARY_TYPE.SUBDUCTION) {
-      activeMargins.push(i);
-    } else if (boundaryType === BOUNDARY_TYPE.DIVERGENT ||
-               boundaryType === BOUNDARY_TYPE.TRANSFORM) {
-      passiveMargins.push(i);
-    }
-  }
-
-  ctx.overlays.set("margins", {
-    key: "margins",
-    kind: "continental-margins",
-    version: 1,
-    width,
-    height,
-    active: activeMargins,
-    passive: passiveMargins,
-    summary: {
-      activeCount: activeMargins.length,
-      passiveCount: passiveMargins.length,
-    },
-  });
-}
-
-export function seedHotspots(ctx: ExtendedMapContext): void {
-  const { foundation, dimensions, rng } = ctx;
-  const { plates } = foundation;
-  const { width, height } = dimensions;
-
-  const hotspots: number[] = [];
-  const threshold = 200;  // High tectonic stress threshold
-
-  for (let i = 0; i < width * height; i++) {
-    const stress = plates.tectonicStress[i];
-    if (stress > threshold) {
-      // Probability based on stress intensity
-      if (Math.random() < stress / 255) {
-        hotspots.push(i);
-      }
-    }
-  }
-
-  ctx.overlays.set("hotspots", {
-    key: "hotspots",
-    kind: "volcanic-hotspots",
-    version: 1,
-    width,
-    height,
-    active: hotspots,
-    summary: { count: hotspots.length },
-  });
-}
-
-export function seedRifts(ctx: ExtendedMapContext): void {
-  const { foundation, dimensions } = ctx;
-  const { plates } = foundation;
-  const { width, height } = dimensions;
-
-  const rifts: number[] = [];
-
-  for (let i = 0; i < width * height; i++) {
-    const riftPotential = plates.riftPotential[i];
-    if (riftPotential > 100) {
-      rifts.push(i);
-    }
-  }
-
-  ctx.overlays.set("rifts", {
-    key: "rifts",
-    kind: "tectonic-rifts",
-    version: 1,
-    width,
-    height,
-    active: rifts,
-    summary: { count: rifts.length },
-  });
-}
-```
-
-### Orchestrator Integration
-
-```typescript
-// MapOrchestrator.ts - in story stage
-if (stageEnabled("storySeed")) {
-  console.log("Starting: storySeed");
-  imprintMargins(ctx);
-  seedHotspots(ctx);
-  seedRifts(ctx);
-  console.log("Finished: storySeed");
-}
-```
-
-### Quick Navigation
-
-- [TL;DR](#tldr)
-- [Problem](#problem)
-- [Deliverables](#deliverables)
-- [Acceptance Criteria](#acceptance-criteria)
-- [Testing / Verification](#testing--verification)
-- [Dependencies / Notes](#dependencies--notes)
+Implementation is tracked in the children:
+- M2 minimal parity is implemented in orchestrator story stages.
+- M3 remaining system is implemented as steps after pipeline refactor.

--- a/docs/projects/engine-refactor-v1/issues/LOCAL-M2-story-parity.md
+++ b/docs/projects/engine-refactor-v1/issues/LOCAL-M2-story-parity.md
@@ -1,0 +1,68 @@
+---
+id: LOCAL-M2-STORY-PARITY
+title: "[M2] Minimal Story Parity (Margins, Hotspots, Rifts)"
+state: planned
+priority: 2
+estimate: 2
+project: engine-refactor-v1
+milestone: M2-stable-engine-slice
+assignees: []
+labels: [Improvement, Story, Architecture]
+parent: CIV-21
+children: []
+blocked_by: [CIV-18]
+blocked: []
+related_to: [CIV-21]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Restore the minimum narrative signals needed for downstream parity by porting and wiring **continental margins**, **hotspot trails**, and **rift valleys** (optionally **orogeny belts**) into the current orchestrator flow. This lands in M2 to stabilize config/consumer behavior without waiting for pipeline refactoring.
+
+Parent issue: `CIV-21-story-tagging.md`.
+
+## Deliverables
+
+- [ ] **Port minimal `story/tagging.ts` subset**
+  - Continental margins tagging (active/passive shelves) and publish a margins overlay.
+  - Hotspot trail tagging with core sub-tags (`hotspot`, `hotspotParadise`, `hotspotVolcanic`).
+  - Rift line + shoulder tagging.
+  - Optional: basic orogeny belts if it is low‑risk in the orchestrator slice.
+- [ ] **Wire into `MapOrchestrator`**
+  - Call minimal tagging in `storySeed` / `storyHotspots` / `storyRifts` stages without changing ordering.
+  - Ensure story tags/overlays exist before climate/biomes/features run.
+- [ ] **Minimal validation**
+  - When story stages are enabled, emit a warning or assert if the corresponding tag sets remain empty.
+- [ ] **Smoke checks**
+  - Add one orchestrator/story smoke test that asserts non‑empty margins/hotspots/rifts on a typical map when enabled.
+
+## Acceptance Criteria
+
+- [ ] TS `story/tagging.ts` exists and implements margins/hotspots/rifts (± orogeny).
+- [ ] `StoryTags` are populated after story stages execute.
+- [ ] Margins overlay is published and `hydrateMarginsStoryTags` is exercised.
+- [ ] Downstream climate/biomes/features regain story‑aware branches.
+- [ ] Build passes; smoke checks pass.
+
+## Out of Scope
+
+- Strategic corridors (pre/post passes).
+- Climate swatches and paleo hydrology overlays.
+- Canonical `StoryOverlays` product migration and `MapGenStep` wrapping.
+- Any pipeline executor / task‑graph changes.
+
+These land under `LOCAL-M3-story-system.md`.
+
+## Dependencies / Notes
+
+- Depends on config/call‑site stability (CIV‑18).
+- This is an orchestrator‑centric port intended to be wrapped as steps in M3.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Notes (Local Only)
+
+- Port directly from `docs/system/libs/mapgen/_archive/original-mod-swooper-maps-js/story/tagging.js`, keeping behavior close to JS.
+- Prefer context‑oriented helpers (pure functions on `ExtendedMapContext`) to minimize later refactors into steps.

--- a/docs/projects/engine-refactor-v1/issues/LOCAL-M3-story-system.md
+++ b/docs/projects/engine-refactor-v1/issues/LOCAL-M3-story-system.md
@@ -1,0 +1,69 @@
+---
+id: LOCAL-M3-STORY-SYSTEM
+title: "[M3] Full Story System Modernization (Corridors, Swatches, Paleo, Steps)"
+state: planned
+priority: 2
+estimate: 4
+project: engine-refactor-v1
+milestone: M3-core-engine-refactor-config-evolution
+assignees: []
+labels: [Improvement, Story, Architecture]
+parent: CIV-21
+children: []
+blocked_by: [LOCAL-M2-STORY-PARITY]
+blocked: []
+related_to: [CIV-21]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Complete the story port by implementing the remaining legacy narrative layers and corridors, then migrating story logic to the Task Graph as `MapGenStep`s with canonical `StoryOverlays` products. This lands in M3 alongside pipeline refactoring and config evolution.
+
+Parent issue: `CIV-21-story-tagging.md`.
+
+## Deliverables
+
+- [ ] **Port remaining `story/tagging` passes**
+  - Orogeny belts + windward/lee caches (if not done in M2).
+  - Climate swatches (macro swatch overlay + soft edges).
+  - Paleo hydrology overlays (deltas/oxbows/fossil channels).
+- [ ] **Port `story/corridors.ts`**
+  - Pre‑islands corridor tagging.
+  - Post‑rivers corridor tagging.
+  - Corridor kind/style/attribute metadata.
+- [ ] **Canonicalize overlays**
+  - Publish all narrative outputs through `StoryOverlays` as authoritative products.
+  - Reduce direct `StoryTags` mutation to a compatibility layer or retire it where possible.
+- [ ] **Wrap story system as steps**
+  - Implement `MapGenStep` wrappers for story stages once `PipelineExecutor` exists.
+  - Declare `requires`/`provides` and phase alignment per architecture.
+- [ ] **Behavior checks**
+  - Add step‑level or integration tests for corridors/swatches/paleo once the pipeline is in place.
+
+## Acceptance Criteria
+
+- [ ] TS equivalents exist for all legacy story passes and corridors.
+- [ ] Corridors/swatches/paleo overlays are populated when stages enabled.
+- [ ] Story logic runs as steps under the Task Graph with explicit contracts.
+- [ ] Downstream consumers use `StoryOverlays`/`ClimateField` rather than ad‑hoc reads.
+
+## Out of Scope
+
+- Re‑tuning narrative parameters beyond parity checks.
+- New story motifs not present in the JS archive.
+
+## Dependencies / Notes
+
+- Depends on minimal parity landing in M2 (`LOCAL-M2-STORY-PARITY`).
+- Must coordinate with pipeline primitives and config shape evolution in M3.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Notes (Local Only)
+
+- Port from:
+  - `docs/system/libs/mapgen/_archive/original-mod-swooper-maps-js/story/tagging.js`
+  - `docs/system/libs/mapgen/_archive/original-mod-swooper-maps-js/story/corridors.js`
+- Decide whether to introduce a dedicated `storyPaleo` stage or fold paleo into swatches/climate refinement steps.

--- a/docs/projects/engine-refactor-v1/milestones/M1-TS-typescript-migration.md
+++ b/docs/projects/engine-refactor-v1/milestones/M1-TS-typescript-migration.md
@@ -14,7 +14,7 @@ M1 is considered complete for the TypeScript migration and initial remediation:
 - Core packages (`@civ7/types`, `@civ7/adapter`, `@swooper/mapgen-core`) and the Swooper mod entry are migrated to TypeScript and building successfully.
 - P0 remediation for the "Null Map Script" (adapter boundary, FoundationContext consumption, config-to-manifest resolver, call-site fixes, map-size awareness, and dev diagnostics) has landed via CIV-15-CIV-20, CIV-22, and CIV-24.
 - M1 issues are closed; remaining work is intentionally deferred:
-  - Story tagging (CIV-21) now lives in M3.
+  - Story porting (CIV-21) is split: minimal parity lands in M2, remaining system lands in M3.
   - Integration & behavior tests (CIV-23) now live in M4.
   - Further JS-to-TS parity clean-up will be driven from the parity docs and later milestones (see below).
 

--- a/docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md
+++ b/docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md
@@ -8,7 +8,7 @@
 
 ## Summary
 
-Establish a minimal but production-ready slice of the new engine architecture: validated configuration and a modern foundation/plate stack wired into Swooper Maps with strong diagnostics, using the current `MapOrchestrator`-centric flow. Downstream phases (climate, overlays, biomes, placement) remain mostly legacy in this milestone.
+Establish a minimal but production-ready slice of the new engine architecture: validated configuration and a modern foundation/plate stack wired into Swooper Maps with strong diagnostics, using the current `MapOrchestrator`-centric flow. Downstream phases (climate, overlays, biomes, placement) remain mostly legacy in this milestone, **except for minimal story parity** needed to stabilize narrative‑aware consumers.
 
 This milestone corresponds to **Milestone 2** in `PROJECT-engine-refactor-v1.md`.
 
@@ -17,6 +17,7 @@ This milestone corresponds to **Milestone 2** in `PROJECT-engine-refactor-v1.md`
 - Introduce a single, validated `MapGenConfig` schema and fail-fast configuration loading.
 - Wire the existing `MapOrchestrator` and context/tunables flow to consume validated config instead of globals.
 - Run the **foundation / plate generation** stack through this orchestrated slice and bridge its outputs into legacy downstream stages.
+- Restore **minimal story parity** (margins + hotspots + rifts, optional orogeny) via orchestrator story stages so climate/biomes/features regain narrative signals.
 - Preserve existing map behavior as much as possible while enabling new diagnostics and determinism.
 
 ## Scope
@@ -61,10 +62,19 @@ Related PRD: `resources/PRD-plate-generation.md`
 - Add basic stage-level logging (start/finish of stages, durations, error reporting).
 - Optionally, add minimal smoke checks for foundation outputs (e.g., non-empty plate graphs, sane uplift distributions).
 
+### 4. Minimal Story Parity (Narrative Seed)
+
+- Port and wire the minimal story tagging subset from the JS archive:
+  - Continental margins (active/passive shelves) + margins overlay publication.
+  - Hotspot trails and rift valleys (optional early orogeny belts if low‑risk).
+- Run these through the existing story stages in `MapOrchestrator` without introducing pipeline primitives yet.
+- Add a small smoke check or warning when story stages are enabled but produce empty tag sets.
+
 ## Acceptance Criteria
 
 - Engine can execute the `foundation` slice via the `MapOrchestrator` using validated config.
 - Foundation data products (mesh, crust, plate graph, tectonics / `FoundationContext`) are populated and consumed by existing morphology stages via the legacy bridge.
+- When story stages are enabled, minimal story tags/overlays (margins/hotspots/rifts) are populated and visible to downstream consumers.
 - Existing Swooper Maps entries still generate valid maps (no “null script” regressions) after this milestone.
 - Diagnostics clearly reflect the foundation data and stage flow.
 
@@ -78,6 +88,8 @@ Related PRD: `resources/PRD-plate-generation.md`
 - Foundation pipeline & diagnostics:
   - [ ] LOCAL-TBD: foundation stage parent and step issues (`../issues/LOCAL-TBD-foundation-stage-parent.md`, step 1–5 issues)
   - [ ] CIV-24: Dev diagnostics and executor logging (`../issues/CIV-24-dev-diagnostics.md`)
+- Narrative parity:
+  - [ ] LOCAL-M2-STORY-PARITY: Minimal story parity (`../issues/LOCAL-M2-story-parity.md`)
 
 These may be split or reassigned across milestones as we refine the execution plan.
 

--- a/docs/projects/engine-refactor-v1/milestones/M3-core-engine-refactor-config-evolution.md
+++ b/docs/projects/engine-refactor-v1/milestones/M3-core-engine-refactor-config-evolution.md
@@ -69,6 +69,8 @@ Related PRD: `resources/PRD-pipeline-refactor.md`
 - Make `FoundationContext`, `Heightfield`, `ClimateField`, and `StoryOverlays` the authoritative sources for downstream logic.
 - Reduce or eliminate ad-hoc reads from `GameplayMap` and `StoryTags` in modernized stages.
 
+**Story system note:** Minimal story parity (margins/hotspots/rifts ± orogeny) is restored in M2 via orchestrator stages. M3 owns the **remaining** story system (corridors, swatches, paleo, canonical overlay products) and the migration of story logic into Task Graph steps.
+
 Related system docs:
 
 - `../../system/libs/mapgen/architecture.md`
@@ -98,7 +100,8 @@ As part of M3 (and, where appropriate, M4), we may break specific `Missing` and 
 - Migration of remaining legacy story/climate/biome/placement code into steps:
   - CIV-19: Biomes & features adapter (`../issues/CIV-19-biomes-features-adapter.md`)
   - CIV-20: Placement adapter (`../issues/CIV-20-placement-adapter.md`)
-  - CIV-21: Story tagging & overlays (`../issues/CIV-21-story-tagging.md`)
+  - CIV-21: Full story port parent (`../issues/CIV-21-story-tagging.md`)
+    - Remaining M3 portion: `LOCAL-M3-STORY-SYSTEM` (`../issues/LOCAL-M3-story-system.md`)
   - CIV-22: Map size awareness (`../issues/CIV-22-map-size-awareness.md`)
 - Any new issues spawned from the parity matrix or config refactor PRD that touch multiple phases.
 

--- a/docs/projects/engine-refactor-v1/resources/PRD-config-refactor.md
+++ b/docs/projects/engine-refactor-v1/resources/PRD-config-refactor.md
@@ -305,9 +305,10 @@ brief (`PROJECT-engine-refactor-v1.md`) and the milestone docs (for example,
 
 3. **Story/corridors config timing**
    - `SPIKE-config-refactor-design.md` and the parity matrix call out story/corridor config surfaces that currently have no TS implementation.
-   - We likely want to:
+   - We want to:
      - Include the necessary fields in the schema in Phase 1 (for compatibility).
-     - Treat them as “config for not-yet-implemented steps” until story/corridor steps are implemented in the Task Graph.
+     - Implement **minimal story parity** (margins/hotspots/rifts ± orogeny) under the existing orchestrator in M2 so these knobs become real and consumers stabilize.
+     - Treat the remaining story/corridors surfaces (corridors, swatches, paleo, canonical overlays) as “config for not‑yet‑implemented steps” until they are migrated into the Task Graph in M3.
 
 4. **Backward compatibility window**
    - How long do we support old config shapes via adapters once the new shape is in place?

--- a/docs/projects/engine-refactor-v1/resources/STATUS-M-TS-parity-matrix.md
+++ b/docs/projects/engine-refactor-v1/resources/STATUS-M-TS-parity-matrix.md
@@ -39,6 +39,7 @@ Detractions / Open Questions:
 
 Detractions / Open Questions:
 - `hydrateMarginsStoryTags` has no TS caller today; no TS stage publishes a margins overlay. In JS, `storyTagContinentalMargins` used this to back-fill margin tags. TS currently has a **dead overlay pipe**.
+- Planned to be revived by minimal story parity in M2 (`LOCAL-M2-STORY-PARITY`), with full overlay canonicalization in M3 (`LOCAL-M3-STORY-SYSTEM`).
 
 ---
 
@@ -46,7 +47,7 @@ Detractions / Open Questions:
 
 | JS Module | TS Equivalent | Status | Notes |
 |----------|---------------|--------|-------|
-| `story/tagging.js` | **None** (expected: `packages/mapgen-core/src/story/tagging.ts`) | Missing (major behavior gap) | JS implements the core climate story: `storyTagHotspotTrails`, `storyTagRiftValleys`, `storyTagOrogenyBelts`, `storyTagContinentalMargins`, `storyTagClimateSwatches`, `storyTagPaleoHydrology` plus an `OrogenyCache`. These functions populate `StoryTags`, publish overlays, and drive rainfall via `writeClimateField`/`syncClimateField` and `applyClimateSwatches`. There is no TS implementation; only data structures and downstream consumers exist. |
+| `story/tagging.js` | **None** (expected: `packages/mapgen-core/src/story/tagging.ts`) | Missing (planned split across M2/M3) | JS implements the core climate story: `storyTagHotspotTrails`, `storyTagRiftValleys`, `storyTagOrogenyBelts`, `storyTagContinentalMargins`, `storyTagClimateSwatches`, `storyTagPaleoHydrology` plus an `OrogenyCache`. These functions populate `StoryTags`, publish overlays, and drive rainfall via `writeClimateField`/`syncClimateField` and `applyClimateSwatches`. TS implementation is tracked under parent `CIV-21` with children `LOCAL-M2-STORY-PARITY` and `LOCAL-M3-STORY-SYSTEM`. |
 
 Detractions / Open Questions:
 - **Missing parity:** None of the following exist in TS:
@@ -55,7 +56,7 @@ Detractions / Open Questions:
   - Orogeny belts and caches used by climate refinement.
   - Continental margins tagging + margins overlay publication.
   - Climate swatches and paleo passes that adjust rainfall around story structures.
-- **Orchestration gap:** `MapOrchestrator` only has a stub `storySeed` stage that calls `resetStoryTags()`; there is nowhere to plug a `storyTag*` implementation yet.
+- **Orchestration gap (today):** `MapOrchestrator` only has a stub `storySeed` stage that calls `resetStoryTags()`. Minimal tagging will be wired into existing story stages in M2 (`LOCAL-M2-STORY-PARITY`), with remaining stages migrated into Task Graph steps in M3 (`LOCAL-M3-STORY-SYSTEM`).
 
 ---
 
@@ -82,6 +83,7 @@ Detractions / Open Questions:
 - The TS stage manifest advertises a rich story pipeline that is **not implemented**, which is misleading for config and callers. We should either:
   - Implement the missing stages and wire them to TS `story/tagging` / `story/corridors`, or
   - Hide/disable these stages until the implementations exist.
+- Minimal story stages are explicitly scoped for M2 (orchestrator‑centric parity), while corridors/swatches/paleo and step wrapping are scoped for M3 under `CIV-21` children.
 
 ---
 

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
@@ -37,7 +37,7 @@ Looking forward, M3 and M4 are realigned at a high level as follows:
   - Canonicalize core engine data products, including:
     - `ClimateField` and basic hydrology/river products.
     - `StoryOverlays` and their relationship to `StoryTags`.
-  - Start migrating key clusters (foundation extensions, climate, early story overlays) into `MapGenStep`s with clear `requires` / `provides` contracts.
+  - Start migrating key clusters (foundation extensions, climate, remaining story overlays after M2 minimal parity) into `MapGenStep`s with clear `requires` / `provides` contracts.
 - **M4**
   - Focus on validation, contracts, and robustness:
     - Data-product and `StageManifest` validation (requires/provides checks, manifest consistency).

--- a/docs/projects/engine-refactor-v1/status.md
+++ b/docs/projects/engine-refactor-v1/status.md
@@ -9,15 +9,16 @@
 
 ## Gaps / In Progress
 - Climate consumers still read `GameplayMap` instead of `ClimateField`; river flow data not exposed as a product.
-- Narrative overlays (hotspots/rifts/orogeny/corridors/swatches) still mutate `StoryTags`; overlays registry only holds margins.
+- Narrative overlays are still largely unported: minimal parity (margins/hotspots/rifts ± orogeny) is now scoped for M2 (`LOCAL-M2-STORY-PARITY`), while corridors/swatches/paleo and canonical overlay products remain M3 work (`LOCAL-M3-STORY-SYSTEM`).
 - Biomes/features/placement read legacy fields and do not require overlays or `ClimateField` inputs.
 - No manifest/data-product validator; stages can still run without declared inputs beyond manual assertions.
 - No automated smoke tests for orchestrator/context; verification is manual via diagnostics.
 
 ## Ready Next
-1. Make `ClimateField` the canonical rainfall source and surface river flow/summary data for downstream overlays (Phase C / early M3).
-2. Begin refitting story tagging to consume `FoundationContext`/`Heightfield`/`ClimateField` and publish `StoryOverlays`; retire direct `StoryTags` mutation (Phase D / M3).
-3. Introduce `PipelineExecutor` / `MapGenStep` / `StepRegistry` on top of the stabilized data products, and add manifest/data-product validation to gate stages on declared `requires`/`provides` (late M3–M4).
+1. Restore minimal story parity (margins/hotspots/rifts ± orogeny) via orchestrator stages so narrative‑aware consumers react again (M2).
+2. Make `ClimateField` the canonical rainfall source and surface river flow/summary data for downstream overlays (Phase C / early M3).
+3. Complete remaining story system modernization (corridors, swatches, paleo, canonical overlays) and migrate story logic into steps after pipeline refactor (M3).
+4. Introduce `PipelineExecutor` / `MapGenStep` / `StepRegistry` on top of the stabilized data products, and add manifest/data-product validation to gate stages on declared `requires`/`provides` (late M3–M4).
 
 ## Spikes / Research
 - Overlay payload schema for corridors/hotspots/rifts/swatches (fields + summary for consumers).


### PR DESCRIPTION
feat(engine-refactor): split CIV-21 into M2/M3 children

- Reframe CIV-21 as full story port parent issue
- Add canonical M2 minimal-parity and M3 remaining-system child issue docs

docs(engine-refactor): align milestones for story split

- Add minimal story parity to M2 scope and docs
- Move remaining story system to M3 via CIV-21 children
- Update project brief, status, PRD config, parity matrix, and M1 carry-over notes