### PR TITLE
feat(mapgen-core): stable diagnostics and stage logging

### DIFF
--- a/docs/projects/engine-refactor-v1/issues/CIV-38-dev-diagnostics.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-38-dev-diagnostics.md
@@ -22,33 +22,33 @@ Finish wiring and validating the developer diagnostics surface and stage‑level
 
 ## Deliverables
 
-- [ ] **Dev flag wiring**
+- [x] **Dev flag wiring**
   - Confirm `MapOrchestrator.generateMap()` initializes `DEV` from `foundation.diagnostics` (camelCase keys) and enables diagnostics for the generation pass.
   - Ensure the stable‑slice diagnostics keys used today are documented and consistent with code.
-- [ ] **Validated stable‑slice diagnostics surface**
+- [x] **Validated stable‑slice diagnostics surface**
   - Promote the currently‑used `foundation.diagnostics` dev flags into `MapGenConfigSchema` as explicit, validated keys (matching `DevLogConfig` in `dev/flags.ts`).
   - Keep `foundation.diagnostics` as the canonical stable‑slice diagnostics block; document it as M2‑supported config.
-- [ ] **Diagnostics surface cleanup**
+- [x] **Diagnostics surface cleanup**
   - Deprecate/remove the unused top‑level `diagnostics.*` schema/docs (`logAscii`, `logHistograms`) so the documented surface matches runtime behavior.
   - If a deprecated surface must remain in schema text for back‑compat, mark it clearly as legacy/non‑functional in M2.
-- [ ] **Stage‑level executor logging**
+- [x] **Stage‑level executor logging**
   - Emit a clear start/finish log for each stage in the orchestrator slice, including duration.
   - Surface stage errors with a consistent prefix and include them in `stageResults`.
-- [ ] **Foundation diagnostics parity**
+- [x] **Foundation diagnostics parity**
   - Ensure existing `[Foundation]` summaries, ASCII maps, histograms, and boundary metrics are reachable via `DEV` flags for the foundation/plate stages.
-- [ ] **Minimal smoke warnings**
+- [x] **Minimal smoke warnings**
   - When a stage is enabled but yields obviously empty results (e.g., zero plates, empty story tags), emit a warning to aid debugging.
 
 ## Acceptance Criteria
 
-- [ ] Running a map generation with diagnostics enabled produces:
+- [x] Running a map generation with diagnostics enabled produces:
   - Per‑stage start/finish logs with durations.
   - Foundation summaries/ASCII/histograms when the corresponding `DEV.LOG_FOUNDATION_*` flags are true.
-- [ ] `foundation.diagnostics` is explicitly modeled in `MapGenConfigSchema` with the same camelCase keys accepted by `initDevFlags`, and those keys are documented as stable‑slice config.
-- [ ] Top‑level `diagnostics.*` is either removed or clearly marked deprecated/non‑functional in schema/docs.
-- [ ] When diagnostics flags are absent/disabled, diagnostics output is no‑op except for critical errors.
-- [ ] Stage failures are logged once with a consistent prefix and recorded in `stageResults`.
-- [ ] Build and tests pass.
+- [x] `foundation.diagnostics` is explicitly modeled in `MapGenConfigSchema` with the same camelCase keys accepted by `initDevFlags`, and those keys are documented as stable‑slice config.
+- [x] Top‑level `diagnostics.*` is either removed or clearly marked deprecated/non‑functional in schema/docs.
+- [x] When diagnostics flags are absent/disabled, diagnostics output is no‑op except for critical errors.
+- [x] Stage failures are logged once with a consistent prefix and recorded in `stageResults`.
+- [x] Build and tests pass.
 
 ## Out of Scope
 

--- a/docs/projects/engine-refactor-v1/resources/config-wiring-status.md
+++ b/docs/projects/engine-refactor-v1/resources/config-wiring-status.md
@@ -173,10 +173,10 @@ are equivalent.
 |---|---|---|---|
 | `foundation.policy.oceanSeparation` | **Internal alias** | `layers/landmass-utils.ts` | Used as fallback policy when no explicit/top-level policy passed. |
 
-### foundation.diagnostics (internal)
+### foundation.diagnostics (stable M2)
 
-Schema lists no explicit keys; TS reads **untyped** camelCase DevLogConfig keys from this block.
-See “Untyped but consumed keys” below.
+Schema models this block explicitly with camelCase DevLogConfig keys.
+`MapOrchestrator.generateMap()` consumes it to initialize DEV flags; see “foundation.diagnostics (dev flags)”.
 
 ### foundation nested layer blocks
 
@@ -406,8 +406,8 @@ All fields wired in `layers/placement.ts` and/or MapOrchestrator-derived contine
 
 | Field | Status | Notes |
 |---|---|---|
-| `diagnostics.logAscii` | **Unused / planned** | No TS stage reads this. ASCII output is controlled by `foundation.diagnostics` dev flags (untyped). |
-| `diagnostics.logHistograms` | **Unused / planned** | Histograms currently controlled by dev flags (untyped). |
+| `diagnostics.logAscii` | **Deprecated / no-op** | Unused in M2 stable slice. Use `foundation.diagnostics.*` (e.g., `logFoundationAscii`, `logLandmassAscii`). |
+| `diagnostics.logHistograms` | **Deprecated / no-op** | Unused in M2 stable slice. Use `foundation.diagnostics.foundationHistograms` or other stage-specific flags. |
 
 ## Untyped but consumed keys (not in schema)
 

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
@@ -325,3 +325,38 @@ The following items are **not in scope for this lane** but represent the next lo
   - Extend `EngineAdapter`/`Civ7Adapter` to cover map-size and map-init semantics.
   - Remove `OrchestratorAdapter` entirely so `MapOrchestrator` depends solely on `EngineAdapter` + `MapGenConfig`/`MapGenContext`.
 - This lane intentionally did **not** attempt to collapse the adapter boundary; it only removed the accidental conflation where `OrchestratorConfig.adapter` (typed as `EngineAdapter`) was being assigned to the `OrchestratorAdapter` field.
+
+---
+
+## CIV-38 – Dev Diagnostics & Stage Executor Logging for Stable Slice
+
+**Quick Take**  
+Mostly satisfied for M2, with minor clarity gaps. The stable-slice diagnostics surface is now canonicalized under `foundation.diagnostics`, DEV flags are initialized from that block during `generateMap()`, per-stage executor timing/logging is in place, and the legacy top-level `diagnostics.*` surface is explicitly deprecated/no-op. Remaining concerns are drift/confusion risks rather than functional blockers.
+
+**Intent & Assumptions**  
+- Make the M2 “stable slice” observable: promote and validate the existing dev diagnostics flags into schema, wire them into `MapOrchestrator.generateMap()`, and provide stage-level timing logs and consistent stage failure reporting.  
+- Treat `foundation.diagnostics` as the canonical M2 diagnostics block; retire or clearly deprecate the old top-level `diagnostics.*` surface.  
+- Assume “per-stage logs when diagnostics enabled” is satisfied via `foundation.diagnostics.logTiming` gating stage start/finish logs, per the issue’s implementation notes.
+
+**What’s Strong**  
+- `FoundationDiagnosticsConfigSchema` is explicit, camelCase, and documented as the stable M2 diagnostics surface, matching `DevLogConfig` and `initDevFlags()` mapping.  
+- `MapOrchestrator.generateMap()` resets DEV state, reads `FOUNDATION_CFG.diagnostics`, auto-enables diagnostics when any other flag is true, and initializes DEV flags for the pass.  
+- Stage executor logging is centralized in `runStage()`, emitting start/finish timings (when `logTiming` is enabled), capturing durations, and recording structured `stageResults` with consistent failure prefixes.  
+- Foundation diagnostics parity is preserved: summaries/ASCII/histograms/boundary metrics are reachable via DEV flags and no-op cleanly when disabled.  
+- Smoke warnings are lightweight and correctly scoped to obviously empty/degenerate outputs (plates, landmass windows, story tags).
+
+**High-Leverage Issues**  
+- **Legacy top-level `diagnostics` is still exposed as a normal config knob.**  
+  `DiagnosticsConfigSchema` is deprecated/no-op, but `MapGenConfigSchema` still exposes `diagnostics`. This is intentional for back-compat, but the property-level description doesn’t strongly discourage use. Consider marking the `diagnostics` property itself as legacy/no-op (or hiding it from the public schema) to reduce user confusion.  
+- **Manual schema↔DEV-flag sync is a drift risk.**  
+  `FoundationDiagnosticsConfigSchema` and `DevLogConfig` must be kept in lockstep by hand. A small parity guard (test or build-time assertion) would prevent silent divergence as new flags are added.  
+- **Stage failure logging can produce two lines when timing is enabled.**  
+  Failures log a `console.error` plus a timing “Failed …” line under `LOG_TIMING`. Not a blocker, but if log noise becomes an issue, consider collapsing to a single failure line.
+
+**Fit Within the Milestone**  
+This task lands cleanly inside M2’s scope: it makes the current stable slice debuggable without attempting step-level logging or deeper data-product validation. The remaining legacy exposure feels like an M2 sequencing compromise rather than a local miss.
+
+**Recommended Next Moves (Future Work, Not M2)**  
+1. Tighten public schema/docs around legacy top-level `diagnostics` to avoid suggesting it still works.  
+2. Add a parity check between `FoundationDiagnosticsConfigSchema` keys and the `DevLogConfig` mapping.  
+3. Reuse the `runStage()` prefix/timing pattern when M3 introduces step-level or executor-level logging.

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
@@ -360,3 +360,8 @@ This task lands cleanly inside M2’s scope: it makes the current stable slice d
 1. Tighten public schema/docs around legacy top-level `diagnostics` to avoid suggesting it still works.  
 2. Add a parity check between `FoundationDiagnosticsConfigSchema` keys and the `DevLogConfig` mapping.  
 3. Reuse the `runStage()` prefix/timing pattern when M3 introduces step-level or executor-level logging.
+
+**Update (2025-12)**  
+- `MapGenConfigSchema.diagnostics` is now explicitly documented as legacy/no-op to discourage use in M2.  
+- Added a compile-time parity guard between `FoundationDiagnosticsConfigSchema` and `DevLogConfig` in `packages/mapgen-core/src/dev/diagnostics-parity.ts`.  
+- Stage failure logging now emits a single failure line (with optional timing suffix) even when `LOG_TIMING` is enabled.

--- a/packages/mapgen-core/src/MapOrchestrator.ts
+++ b/packages/mapgen-core/src/MapOrchestrator.ts
@@ -1054,10 +1054,12 @@ export class MapOrchestrator {
     } catch (err) {
       const durationMs = nowMs() - t0;
       const errorMessage = err instanceof Error ? err.message : String(err);
-      console.error(`[MapOrchestrator][Stage:${name}] ${errorMessage}`, err);
-      devLogIf(
-        "LOG_TIMING",
-        `${basePrefix} [Stage] Failed ${name} (${durationMs.toFixed(2)}ms)`
+      const timingSuffix = DEV.ENABLED && DEV.LOG_TIMING
+        ? ` (${durationMs.toFixed(2)}ms)`
+        : "";
+      console.error(
+        `[MapOrchestrator][Stage:${name}] Failed${timingSuffix}: ${errorMessage}`,
+        err
       );
       return { stage: name, success: false, durationMs, error: errorMessage };
     }

--- a/packages/mapgen-core/src/MapOrchestrator.ts
+++ b/packages/mapgen-core/src/MapOrchestrator.ts
@@ -69,7 +69,7 @@ import {
   stageEnabled,
 } from "./bootstrap/tunables.js";
 import { validateStageDrift } from "./bootstrap/resolved.js";
-import { resetStoryTags } from "./story/tags.js";
+import { getStoryTags, resetStoryTags } from "./story/tags.js";
 import { WorldModel, setConfigProvider, type WorldModelConfig } from "./world/index.js";
 
 // Layer imports
@@ -92,7 +92,9 @@ import { runPlacement } from "./layers/placement.js";
 import {
   DEV,
   initDevFlags,
-  timeSection,
+  resetDevFlags,
+  devLogIf,
+  devWarn,
   logFoundationSummary,
   logFoundationAscii,
   logLandmassAscii,
@@ -104,6 +106,7 @@ import {
   logFoundationHistograms,
   logBoundaryMetrics,
   logEngineSurfaceApisOnce,
+  type DevLogConfig,
   type FoundationPlates,
 } from "./dev/index.js";
 
@@ -212,23 +215,6 @@ function assertFoundationContext(
         `Ensure the "foundation" stage is enabled and runs before "${stageName}".`
     );
   }
-}
-
-// ============================================================================
-// Timing Utilities
-// ============================================================================
-
-/** Simple timing helper for stage execution (always logs, unlike DEV timing) */
-function stageTimeStart(label: string): { label: string; start: number } {
-  console.log(`[SWOOPER_MOD] Starting: ${label}`);
-  return { label, start: Date.now() };
-}
-
-/** End stage timing and return elapsed ms */
-function stageTimeEnd(timer: { label: string; start: number }): number {
-  const elapsed = Date.now() - timer.start;
-  console.log(`[SWOOPER_MOD] Completed: ${timer.label} (${elapsed}ms)`);
-  return elapsed;
 }
 
 // ============================================================================
@@ -518,17 +504,24 @@ export class MapOrchestrator {
     this.stageResults = [];
     const startPositions: number[] = [];
 
-    // Enable dev diagnostics so engine surface introspection and other DEV
-    // helpers can run during this generation pass.
-    // Load diagnostics flags from config (e.g. LOG_LANDMASS_ASCII)
-    const devTunables = getTunables();
-    const devFoundationCfg = devTunables.FOUNDATION_CFG || {};
-    const diagnostics = (devFoundationCfg.diagnostics || {}) as Record<string, unknown>;
-    initDevFlags({ ...diagnostics, enabled: true });
-
-    // Refresh configuration and world state
+    // Refresh configuration and tunables snapshot for this generation pass.
     resetTunables();
     const tunables = getTunables();
+
+    // Initialize DEV flags from stable-slice diagnostics config.
+    // Keys are camelCase and match DevLogConfig.
+    resetDevFlags();
+    const foundationCfg = tunables.FOUNDATION_CFG || {};
+    const rawDiagnostics = (foundationCfg.diagnostics || {}) as Record<string, unknown>;
+    const diagnosticsConfig = { ...rawDiagnostics } as DevLogConfig;
+    const hasTruthyFlag = Object.entries(diagnosticsConfig).some(
+      ([key, value]) => key !== "enabled" && value === true
+    );
+    if (diagnosticsConfig.enabled === undefined && hasTruthyFlag) {
+      diagnosticsConfig.enabled = true;
+    }
+    initDevFlags(diagnosticsConfig);
+
     console.log(`${prefix} Tunables rebound successfully`);
 
     // Reset WorldModel to ensure fresh state for this generation run
@@ -565,7 +558,6 @@ export class MapOrchestrator {
     console.log(`${prefix} Enabled stages: ${enabledStages || "(none)"}`);
 
     // Get layer configurations from tunables
-    const foundationCfg = tunables.FOUNDATION_CFG || {};
     const landmassCfg = tunables.LANDMASS_CFG || {};
     const mountainsCfg = (foundationCfg.mountains || {}) as MountainsConfig;
     const volcanosCfg = (foundationCfg.volcanoes || {}) as VolcanoesConfig;
@@ -601,7 +593,10 @@ export class MapOrchestrator {
     // Initialize WorldModel and FoundationContext
     // Note: foundationContext stored for potential future use in story stages
     if (stageFlags.foundation && ctx) {
-      this.initializeFoundation(ctx, tunables);
+      const stageResult = this.runStage("foundation", () => {
+        this.initializeFoundation(ctx!, tunables);
+      });
+      this.stageResults.push(stageResult);
     }
 
     // Set up start sectors
@@ -656,6 +651,13 @@ export class MapOrchestrator {
 
         // Apply post-adjustments
         windows = applyLandmassPostAdjustments(windows, landmassCfg.geometry, iWidth, iHeight);
+
+        // Minimal smoke warning: plate-driven landmass should yield at least two windows.
+        if (DEV.ENABLED && windows.length < 2) {
+          devWarn(
+            `[smoke] landmassPlates produced ${windows.length} window(s); expected >= 2 for west/east continents.`
+          );
+        }
 
         // Update continent bounds from windows
         if (windows.length >= 2) {
@@ -754,7 +756,8 @@ export class MapOrchestrator {
         // Assert foundation is available - fail fast if not
         assertFoundationContext(ctx, "mountains");
 
-        console.log(
+        devLogIf(
+          "LOG_MOUNTAINS",
           `${prefix} [Mountains] thresholds ` +
             `mountain=${mountainOptions.mountainThreshold}, ` +
             `hill=${mountainOptions.hillThreshold}, ` +
@@ -956,6 +959,34 @@ export class MapOrchestrator {
       this.stageResults.push(stageResult);
     }
 
+    // Minimal smoke warning: enabled story stages should emit some tags.
+    const storyStagesEnabled =
+      stageFlags.storySeed ||
+      stageFlags.storyHotspots ||
+      stageFlags.storyRifts ||
+      stageFlags.storyOrogeny ||
+      stageFlags.storyCorridorsPre ||
+      stageFlags.storySwatches ||
+      stageFlags.storyCorridorsPost;
+    if (DEV.ENABLED && storyStagesEnabled) {
+      const tags = getStoryTags();
+      const tagTotal =
+        tags.hotspot.size +
+        tags.hotspotParadise.size +
+        tags.hotspotVolcanic.size +
+        tags.riftLine.size +
+        tags.riftShoulder.size +
+        tags.activeMargin.size +
+        tags.passiveShelf.size +
+        tags.corridorSeaLane.size +
+        tags.corridorIslandHop.size +
+        tags.corridorLandOpen.size +
+        tags.corridorRiverChain.size;
+      if (tagTotal === 0) {
+        devWarn("[smoke] story stages enabled but no story tags were emitted");
+      }
+    }
+
     console.log(`${prefix} === GenerateMap COMPLETE ===`);
 
     const success = this.stageResults.every((r) => r.success);
@@ -997,15 +1028,37 @@ export class MapOrchestrator {
   }
 
   private runStage(name: string, fn: () => void): StageResult {
-    const timer = stageTimeStart(name);
+    const basePrefix = this.options.logPrefix || "[SWOOPER_MOD]";
+    const nowMs = (): number => {
+      try {
+        if (typeof performance !== "undefined" && typeof performance.now === "function") {
+          return performance.now();
+        }
+      } catch {
+        // Fallback to Date.now()
+      }
+      return Date.now();
+    };
+
+    devLogIf("LOG_TIMING", `${basePrefix} [Stage] Starting ${name}`);
+    const t0 = nowMs();
+
     try {
       fn();
-      const durationMs = stageTimeEnd(timer);
+      const durationMs = nowMs() - t0;
+      devLogIf(
+        "LOG_TIMING",
+        `${basePrefix} [Stage] Completed ${name} (${durationMs.toFixed(2)}ms)`
+      );
       return { stage: name, success: true, durationMs };
     } catch (err) {
-      const durationMs = stageTimeEnd(timer);
+      const durationMs = nowMs() - t0;
       const errorMessage = err instanceof Error ? err.message : String(err);
-      console.error(`[MapOrchestrator] Stage "${name}" failed:`, err);
+      console.error(`[MapOrchestrator][Stage:${name}] ${errorMessage}`, err);
+      devLogIf(
+        "LOG_TIMING",
+        `${basePrefix} [Stage] Failed ${name} (${durationMs.toFixed(2)}ms)`
+      );
       return { stage: name, success: false, durationMs, error: errorMessage };
     }
   }
@@ -1028,57 +1081,67 @@ export class MapOrchestrator {
   private initializeFoundation(
     ctx: ExtendedMapContext,
     tunables: ReturnType<typeof getTunables>
-  ): FoundationContext | null {
+  ): FoundationContext {
     const prefix = this.options.logPrefix || "[SWOOPER_MOD]";
     console.log(`${prefix} Initializing foundation...`);
 
     // Ensure WorldModel pulls configuration from foundation tunables
     this.bindWorldModelConfigProvider();
-    try {
-      console.log(`${prefix} WorldModel.init() starting`);
-      if (!WorldModel.init()) {
-        throw new Error("WorldModel initialization failed");
-      }
-      console.log(`${prefix} WorldModel.init() succeeded`);
-      ctx.worldModel = WorldModel as unknown as WorldModelState;
-
-      const foundationCfg = tunables.FOUNDATION_CFG || {};
-      console.log(`${prefix} createFoundationContext() starting`);
-      const foundationContext = createFoundationContext(WorldModel as unknown as WorldModelState, {
-        dimensions: ctx.dimensions,
-        config: {
-          seed: (foundationCfg.seed || {}) as Record<string, unknown>,
-          plates: tunables.FOUNDATION_PLATES as Record<string, unknown>,
-          dynamics: tunables.FOUNDATION_DYNAMICS as Record<string, unknown>,
-          surface: (foundationCfg.surface || {}) as Record<string, unknown>,
-          policy: (foundationCfg.policy || {}) as Record<string, unknown>,
-          diagnostics: (foundationCfg.diagnostics || {}) as Record<string, unknown>,
-        },
-      });
-      console.log(`${prefix} createFoundationContext() succeeded`);
-      ctx.foundation = foundationContext;
-
-      console.log(`${prefix} Foundation context initialized`);
-
-      // Dev diagnostics for foundation
-      if (DEV.ENABLED && ctx.adapter) {
-        const plates: FoundationPlates = {
-          plateId: foundationContext.plates.id,
-          boundaryType: foundationContext.plates.boundaryType,
-          boundaryCloseness: foundationContext.plates.boundaryCloseness,
-          upliftPotential: foundationContext.plates.upliftPotential,
-          riftPotential: foundationContext.plates.riftPotential,
-        };
-        logFoundationSummary(ctx.adapter, ctx.dimensions.width, ctx.dimensions.height, plates);
-        logFoundationAscii(ctx.adapter, ctx.dimensions.width, ctx.dimensions.height, plates);
-        logFoundationHistograms(ctx.dimensions.width, ctx.dimensions.height, plates);
-      }
-
-      return foundationContext;
-    } catch (err) {
-      console.error(`${prefix} Failed to initialize foundation:`, err);
-      return null;
+    console.log(`${prefix} WorldModel.init() starting`);
+    if (!WorldModel.init()) {
+      throw new Error("WorldModel initialization failed");
     }
+    console.log(`${prefix} WorldModel.init() succeeded`);
+    ctx.worldModel = WorldModel as unknown as WorldModelState;
+
+    const foundationCfg = tunables.FOUNDATION_CFG || {};
+    console.log(`${prefix} createFoundationContext() starting`);
+    const foundationContext = createFoundationContext(WorldModel as unknown as WorldModelState, {
+      dimensions: ctx.dimensions,
+      config: {
+        seed: (foundationCfg.seed || {}) as Record<string, unknown>,
+        plates: tunables.FOUNDATION_PLATES as Record<string, unknown>,
+        dynamics: tunables.FOUNDATION_DYNAMICS as Record<string, unknown>,
+        surface: (foundationCfg.surface || {}) as Record<string, unknown>,
+        policy: (foundationCfg.policy || {}) as Record<string, unknown>,
+        diagnostics: (foundationCfg.diagnostics || {}) as Record<string, unknown>,
+      },
+    });
+    console.log(`${prefix} createFoundationContext() succeeded`);
+    ctx.foundation = foundationContext;
+
+    console.log(`${prefix} Foundation context initialized`);
+
+    // Dev diagnostics for foundation (gated by DEV flags internally)
+    if (DEV.ENABLED && ctx.adapter) {
+      const plates: FoundationPlates = {
+        plateId: foundationContext.plates.id,
+        boundaryType: foundationContext.plates.boundaryType,
+        boundaryCloseness: foundationContext.plates.boundaryCloseness,
+        upliftPotential: foundationContext.plates.upliftPotential,
+        riftPotential: foundationContext.plates.riftPotential,
+      };
+      logFoundationSummary(ctx.adapter, ctx.dimensions.width, ctx.dimensions.height, plates);
+      logFoundationAscii(ctx.adapter, ctx.dimensions.width, ctx.dimensions.height, plates);
+      logFoundationHistograms(ctx.dimensions.width, ctx.dimensions.height, plates);
+      logBoundaryMetrics(ctx.adapter, ctx.dimensions.width, ctx.dimensions.height, plates);
+
+      // Minimal smoke warning: foundation should produce at least one plate.
+      const plateId = foundationContext.plates.id;
+      if (!plateId || plateId.length === 0) {
+        devWarn("[smoke] foundation enabled but produced empty plate data");
+      } else {
+        const uniquePlates = new Set<number>();
+        for (let i = 0; i < plateId.length; i++) {
+          uniquePlates.add(plateId[i]);
+        }
+        if (uniquePlates.size === 0) {
+          devWarn("[smoke] foundation enabled but produced zero plates");
+        }
+      }
+    }
+
+    return foundationContext;
   }
 
   private createLayerAdapter(width: number, height: number): EngineAdapter {

--- a/packages/mapgen-core/src/config/schema.ts
+++ b/packages/mapgen-core/src/config/schema.ts
@@ -2228,7 +2228,7 @@ export const FoundationConfigSchema = Type.Object(
     surface: Type.Optional(FoundationSurfaceConfigSchema),
     /** @internal Policy flags for foundation stage (engine plumbing). */
     policy: Type.Optional(FoundationPolicyConfigSchema),
-    /** @internal Diagnostics toggles for foundation stage (engine plumbing). */
+    /** Diagnostics toggles for stable-slice debugging (M2-supported). */
     diagnostics: Type.Optional(FoundationDiagnosticsConfigSchema),
     /** Ocean separation policy ensuring water channels between continents. */
     oceanSeparation: Type.Optional(OceanSeparationConfigSchema),
@@ -2340,7 +2340,10 @@ export const MapGenConfigSchema = Type.Object(
     oceanSeparation: Type.Optional(OceanSeparationConfigSchema),
     /** Late-stage placement: wonders, floodplains, starts. */
     placement: Type.Optional(PlacementConfigSchema),
-    /** Diagnostics toggles for debugging output. */
+    /**
+     * @deprecated Legacy top-level diagnostics toggles.
+     * These are no-op in the M2 stable slice; use foundation.diagnostics instead.
+     */
     diagnostics: Type.Optional(DiagnosticsConfigSchema),
   },
   { additionalProperties: true, default: {} }

--- a/packages/mapgen-core/src/config/schema.ts
+++ b/packages/mapgen-core/src/config/schema.ts
@@ -889,17 +889,123 @@ export const FoundationPolicyConfigSchema = Type.Object(
 );
 
 /**
- * Diagnostics and logging toggles for the foundation pipeline.
+ * Diagnostics and logging toggles for the stable-slice (M2) pipeline.
  *
- * @internal Engine debugging; prefer top-level diagnostics for general logging.
+ * This block is the canonical supported diagnostics surface for M2 and is
+ * consumed by MapOrchestrator via initDevFlags().
+ *
+ * Keys are camelCase and match DevLogConfig in dev/flags.ts.
  */
 export const FoundationDiagnosticsConfigSchema = Type.Object(
-  {},
+  {
+    /**
+     * Master diagnostics switch.
+     *
+     * If omitted, MapOrchestrator will auto-enable diagnostics when any other
+     * diagnostics flag is explicitly set to true.
+     */
+    enabled: Type.Optional(
+      Type.Boolean({
+        description:
+          "Master diagnostics switch. If omitted, diagnostics auto-enable when any other diagnostics flag is true.",
+      })
+    ),
+    /** Log per-stage timings and section durations. */
+    logTiming: Type.Optional(
+      Type.Boolean({ default: false, description: "Log per-stage timings and section durations." })
+    ),
+    /** Log foundation seed configuration. */
+    logFoundationSeed: Type.Optional(
+      Type.Boolean({ default: false, description: "Log foundation seed configuration." })
+    ),
+    /** Log foundation plates configuration. */
+    logFoundationPlates: Type.Optional(
+      Type.Boolean({ default: false, description: "Log foundation plates configuration." })
+    ),
+    /** Log foundation dynamics configuration. */
+    logFoundationDynamics: Type.Optional(
+      Type.Boolean({ default: false, description: "Log foundation dynamics configuration." })
+    ),
+    /** Log foundation surface configuration. */
+    logFoundationSurface: Type.Optional(
+      Type.Boolean({ default: false, description: "Log foundation surface configuration." })
+    ),
+    /** Print compact foundation summary. */
+    logFoundationSummary: Type.Optional(
+      Type.Boolean({ default: false, description: "Print compact foundation summary." })
+    ),
+    /** ASCII visualization of plate boundaries and masks. */
+    logFoundationAscii: Type.Optional(
+      Type.Boolean({
+        default: false,
+        description: "Emit ASCII visualizations for foundation plates and boundaries.",
+      })
+    ),
+    /** ASCII snapshot of land vs. ocean. */
+    logLandmassAscii: Type.Optional(
+      Type.Boolean({ default: false, description: "Emit ASCII snapshot of land vs. ocean." })
+    ),
+    /** Log landmass window bounding boxes. */
+    logLandmassWindows: Type.Optional(
+      Type.Boolean({ default: false, description: "Log landmass window bounding boxes." })
+    ),
+    /** ASCII visualization of terrain relief. */
+    logReliefAscii: Type.Optional(
+      Type.Boolean({ default: false, description: "Emit ASCII visualization of terrain relief." })
+    ),
+    /** ASCII heatmap for rainfall. */
+    logRainfallAscii: Type.Optional(
+      Type.Boolean({ default: false, description: "Emit ASCII heatmap for rainfall buckets." })
+    ),
+    /** Log rainfall min/max/avg statistics. */
+    logRainfallSummary: Type.Optional(
+      Type.Boolean({ default: false, description: "Log rainfall min/max/avg statistics." })
+    ),
+    /** ASCII biome classification overlay. */
+    logBiomeAscii: Type.Optional(
+      Type.Boolean({ default: false, description: "Emit ASCII biome classification overlay." })
+    ),
+    /** Log biome tile counts. */
+    logBiomeSummary: Type.Optional(
+      Type.Boolean({ default: false, description: "Log biome tile counts and distribution." })
+    ),
+    /** Log StoryTags summary counts. */
+    logStoryTags: Type.Optional(
+      Type.Boolean({ default: false, description: "Log StoryTags summary counts." })
+    ),
+    /** ASCII corridor overlay. */
+    logCorridorAscii: Type.Optional(
+      Type.Boolean({ default: false, description: "Emit ASCII corridor overlay." })
+    ),
+    /** Quantitative boundary coverage metrics. */
+    logBoundaryMetrics: Type.Optional(
+      Type.Boolean({ default: false, description: "Log boundary coverage metrics." })
+    ),
+    /** Detailed mountain placement summaries. */
+    logMountains: Type.Optional(
+      Type.Boolean({ default: false, description: "Log detailed mountain placement summaries." })
+    ),
+    /** Detailed volcano placement summaries. */
+    logVolcanoes: Type.Optional(
+      Type.Boolean({ default: false, description: "Log detailed volcano placement summaries." })
+    ),
+    /** Print histograms for uplift/rift distributions. */
+    foundationHistograms: Type.Optional(
+      Type.Boolean({
+        default: false,
+        description: "Print histograms for uplift/rift distributions.",
+      })
+    ),
+    /** Layer-specific counters and tile counts. */
+    layerCounts: Type.Optional(
+      Type.Boolean({ default: false, description: "Log layer-specific counters and tile counts." })
+    ),
+  },
   {
     additionalProperties: true,
     default: {},
-    description: "[internal] Foundation-specific diagnostics toggles.",
-    [INTERNAL_METADATA_KEY]: true,
+    description:
+      "Stable-slice diagnostics toggles consumed by MapOrchestrator. Keys match DevLogConfig and are camelCase.",
   }
 );
 
@@ -2149,32 +2255,41 @@ export const FoundationConfigSchema = Type.Object(
 );
 
 /**
- * Diagnostics toggles shared by top-level map generation stages.
+ * Legacy top-level diagnostics toggles.
+ *
+ * These fields are currently unused by the stable-slice runtime and are kept
+ * only for backward compatibility. Use foundation.diagnostics instead.
  */
 export const DiagnosticsConfigSchema = Type.Object(
   {
     /**
-     * Emit ASCII map visualizations during generation.
-     * Useful for debugging terrain distribution in console logs.
-     * @default false
+     * @deprecated Unused in M2 stable slice. Use foundation.diagnostics.*.
      */
     logAscii: Type.Optional(
       Type.Boolean({
-        description: "Emit ASCII diagnostics for core stages such as foundation and landmass windows.",
+        description:
+          "[legacy/no-op] Unused in M2 stable slice. Use foundation.diagnostics.* for ASCII output.",
+        deprecated: true,
       })
     ),
     /**
-     * Log histogram summaries for terrain and climate distributions.
-     * Helps validate that thresholds produce expected ratios.
-     * @default false
+     * @deprecated Unused in M2 stable slice. Use foundation.diagnostics.*.
      */
     logHistograms: Type.Optional(
       Type.Boolean({
-        description: "Log histogram summaries for quick visual validation of distributions.",
+        description:
+          "[legacy/no-op] Unused in M2 stable slice. Use foundation.diagnostics.* for histogram output.",
+        deprecated: true,
       })
     ),
   },
-  { additionalProperties: true, default: {} }
+  {
+    additionalProperties: true,
+    default: {},
+    description:
+      "[legacy/no-op] Top-level diagnostics are deprecated in M2. Use foundation.diagnostics instead.",
+    deprecated: true,
+  }
 );
 
 /**

--- a/packages/mapgen-core/src/dev/diagnostics-parity.ts
+++ b/packages/mapgen-core/src/dev/diagnostics-parity.ts
@@ -1,0 +1,24 @@
+import type { DevLogConfig } from "./flags.js";
+import type { FoundationDiagnosticsConfig } from "../config/index.js";
+
+type KnownKeys<T> = {
+  [K in keyof T]: string extends K
+    ? never
+    : number extends K
+      ? never
+      : symbol extends K
+        ? never
+        : K;
+}[keyof T];
+
+type DevKeys = KnownKeys<DevLogConfig>;
+type SchemaKeys = KnownKeys<FoundationDiagnosticsConfig>;
+
+type MissingInDev = Exclude<SchemaKeys, DevKeys>;
+type MissingInSchema = Exclude<DevKeys, SchemaKeys>;
+
+type Assert<T extends true> = T;
+
+type _AssertNoMissingInDev = Assert<MissingInDev extends never ? true : false>;
+type _AssertNoMissingInSchema = Assert<MissingInSchema extends never ? true : false>;
+


### PR DESCRIPTION
feat(mapgen-core): stable diagnostics and stage logging

- model foundation.diagnostics dev flags in schema\n- gate DEV init and stage logs by config\n- add per-stage results, durations, and smoke warnings\n- deprecate top-level diagnostics block

docs(engine-refactor): mark CIV-38 complete