### PR TITLE
docs (mapgen): replace AGENTS.md with domain router architecture and add package-level routers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,77 +1,65 @@
 # AGENTS
 
-> Quick reference for AI agents. For comprehensive documentation, see the [docs/](docs/) directory.
+This repo uses nested `AGENTS.md` files as lightweight domain routers: short, enduring rules plus links to canonical docs. Do not put implementation detail, task status, or temporal/refactor‑specific commentary in `AGENTS.md`.
 
-## Documentation Quick Links
+## How To Use AGENTS
 
-- [Product Overview](docs/PRODUCT.md) — What this is and why
-- [System Architecture](docs/SYSTEM.md) — Technical overview
-- [How We Work](docs/PROCESS.md) — Collaboration and workflows
-- [Roadmap](docs/ROADMAP.md) — Direction and milestones
+- Read this root router first, then the closest subtree `AGENTS.md` for any files you touch; deeper routers refine or override higher‑level guidance.
+- Open linked docs on demand instead of restating volatile detail in routers.
 
----
+## Hygiene & Maintenance
 
-## Civ7 Resources Quick Access
-- Run `pnpm run unzip-civ` to extract the official Civ7 data into `civ7-official-resources/`, placing the game files directly under that folder.
-- Age-specific XML definitions live under `civ7-official-resources/Base/modules/age-*/data/`.
-  - `resources.xml` – resource modifiers by age
-  - `units.xml` – unit definitions
-  - `constructibles.xml` – buildings and other constructibles
-- Replace `*` with the desired age (`age-antiquity`, `age-exploration`, `age-modern`, ...).
-- Use `rg` to search across ages, e.g. `rg Cotton civ7-official-resources/Base/modules`.
-- The default `pnpm run unzip-civ` profile excludes large media (movies/, data/icons/, fonts/, common media extensions) but keeps `Assets/schema` for reference. Use `pnpm run unzip-civ -- full` for a full extraction or `pnpm run unzip-civ -- assets` for only assets.
+- Before editing, skim `git status` for existing work and avoid undoing unrelated changes.
+- When changing behavior or public contracts, update adjacent docs and tests in the same change; use templates in `docs/_templates/` when adding new docs.
+- Record significant architectural decisions in `docs/system/ADR.md` and intentional deferrals with triggers in `docs/system/DEFERRALS.md`.
+- Treat generated artifacts (e.g., `dist/`, `mod/`) and lockfiles as read‑only; regenerate them via scripts instead of hand‑editing.
+- Follow established directory conventions; consult the relevant `docs/system/**` overviews before introducing new domains or layouts.
 
-## Plugins architecture
-- Reusable logic lives under `packages/plugins/*` (e.g., `plugin-files`, `plugin-graph`).
-- The old `plugin-mapgen` package has been removed; legacy reference docs now live under `docs/system/mods/swooper-maps/reference/`.
-- CLI commands should remain thin wrappers around these plugins.
-- Status-style CLI commands now accept `--json` for machine-readable output.
- - Subtree-based CLI commands expose only relevant flags; missing `slug` or `repoUrl` values are prompted interactively during setup, import, or update. Repo URL, remote name, and default branch are stored during setup and reused by downstream commands.
+## Docs Architecture (Where Things Go)
 
-## Mod: Swooper Maps
+- Canonical, evergreen entrypoints live at `docs/` root (`PRODUCT.md`, `SYSTEM.md`, `PROCESS.md`, `ROADMAP.md`, `DOCS.md`).
+- Use **ALL‑CAPS** filenames anywhere under `docs/` for canonical single‑source‑of‑truth docs at that directory’s scope.
+- Use **lowercase** filenames for supporting, scoped, or implementation‑detail docs.
+- Time‑bound specs, milestones, logs, and refactor notes belong under `docs/projects/<project‑slug>/...`.
+- Evergreen domain docs belong under `docs/product/`, `docs/system/`, and `docs/process/`.
+- Start new docs from `docs/_templates/` and copy into place; don’t edit templates in place.
+- Move superseded docs to `docs/_archive/` and preserve names.
 
-**Documentation:** See [docs/system/mods/swooper-maps/](docs/system/mods/swooper-maps/) for architecture and design docs, and [docs/projects/swooper-maps/](docs/projects/swooper-maps/) for active plans.
+See `docs/DOCS.md` for the full docs layout and naming heuristics.
 
-- The huge-plate baseline entry now lives at `mods/mod-swooper-maps/mod/maps/swooper-desert-mountains.js`, with config and localization rows using the same `desert-mountains` slug.
-- `mods/mod-swooper-maps/mod/maps/bootstrap/dev.js` now emits ASCII diagnostics for landmass windows, relief (mountains/hills/volcanoes), rainfall buckets, and biome distribution in addition to plate boundaries/corridors. Toggle them with `DEV.LOG_LANDMASS_ASCII`, `DEV.LOG_RELIEF_ASCII`, `DEV.LOG_RAINFALL_ASCII`, and `DEV.LOG_BIOME_ASCII`.
-- Stage execution is coordinated through `stageManifest` (defaults in `mods/mod-swooper-maps/mod/maps/bootstrap/defaults/base.js`). The resolver normalizes dependencies, mirrors legacy `STORY_ENABLE_*` toggles, and logs `[StageManifest]` warnings when prerequisites are missing. Use `tunables.stageEnabled()` instead of raw toggles when gating layers.
-- The manifest now exposes `foundation` and `landmassPlates` as the default early stages. The legacy landmass stub has been removed, so presets and orchestration must target the Voronoi physics pipeline exclusively.
-- Landmass generation now flows Voronoi → plate mask; ocean separation lives in `layers/landmass_utils.js::applyPlateAwareOceanSeparation` and the legacy three-band generator has been removed.
-- Deterministic Voronoi seeds are captured through `mod/maps/world/plate_seed.js::PlateSeedManager`; `WorldModel` publishes the frozen snapshot via `plateSeed` for diagnostics and context consumers.
-- Entries and named presets can declare a `stageConfig` map to indicate which stages they supply overrides for; the resolver warns when those stages are disabled or missing so presets can prune dead config.
-- `bootstrap/tunables.js` exposes a `CLIMATE` helper (`CLIMATE.drivers`, `CLIMATE.moistureAdjustments`) that climate layers and story overlays consume instead of reading raw config blocks.
-- Climate layers stage rainfall via `MapContext.buffers.climate`; prefer `writeClimateField` / `syncClimateField` when mutating or syncing rainfall rather than writing to `GameplayMap` directly.
-- Baseline, swatch, and refinement rainfall logic live in `layers/climate-engine.js`; stage wrappers delegate to this module so edits stay centralized.
-- `core/types.js` exports `createFoundationContext`/`assertFoundationContext`; `MapContext.foundation` is now an immutable snapshot that must exist before any stage requiring physics runs.
-- Narrative metadata now publishes through `MapContext.overlays` (see `story/overlays.js`). Continental margins are seeded once during morphology and rehydrated from the `StoryOverlays` registry instead of rerunning the tagging helper.
-- Runtime overrides must target the consolidated `foundation.*` block directly—`bootstrap/resolved.js` no longer backfills from `worldModel`, and the resolver emits `[Foundation]` warnings if legacy groups are present.
-- Dev diagnostics toggles have been renamed to `LOG_FOUNDATION_*`; the ASCII, summary, and histogram helpers now log under a `[Foundation]` prefix.
+## Workflow (Graphite + Linear)
 
-## MapGen configuration
+- Git work uses Graphite stacked PRs, not ad‑hoc branches/PRs. Stage changes as small, reviewable layers (one logical change per branch) and merge bottom → top of the stack using `gt`.
+- Linear is the canonical task tracker. Keep issue descriptions durable (scope/objectives/acceptance), and keep status/progress in Linear fields or comments—not in docs or issue bodies.
+- When a task needs durable context, add or update the appropriate doc under `docs/` and link it from Linear instead of duplicating.
 
-- The canonical TypeBox schema and derived types live at `packages/mapgen-core/src/config/schema.ts` and are exported via `@swooper/mapgen-core/config` (built by the `tsup` entry `src/config/index.ts`).
-- The schema now includes inline JSDoc for every field. When clarifying semantics or tuning ranges, refer to `docs/system/libs/mapgen/_archive/original-mod-swooper-maps-js/bootstrap/map_config.types.js` for the historical descriptions that informed the current comments.
+See `docs/process/GRAPHITE.md` and `docs/process/LINEAR.md` for full conventions.
 
-### Testing imports
-- Prefer importing from a package's public entry point (e.g., `@civ7/plugin-graph`) in tests rather than deep paths like `../src/*`. This keeps tests resilient to internal refactors (such as folder renames like `pipelines/` → `workflows/`) and validates the surface that external consumers use.
+## Start Here (Evergreen Docs)
 
-## Contributing
+- [Product Overview](docs/PRODUCT.md)
+- [System Architecture](docs/system/ARCHITECTURE.md)
+- [How We Work](docs/PROCESS.md)
+- [Contributing](docs/process/CONTRIBUTING.md)
+- [Testing](docs/system/TESTING.md)
 
-See [docs/process/CONTRIBUTING.md](docs/process/CONTRIBUTING.md) for full guidelines.
+## Tooling Defaults
 
-- When modifying scripts or TypeScript sources, run `pnpm run build` before committing.
-- Run `pnpm lint` to ensure code style and `pnpm test` for unit tests across workspaces.
-- Verify XML examples in docs against `civ7-official-resources` so that `<ActionGroups>` and `<Item>` tags match the SDK output.
-- Configuration utilities and schema are documented in `packages/config/README.md` and `packages/config/TESTING.md`. Unit tests live under `packages/config/test/` and are included in the root Vitest projects.
-- Use `pnpm test` to execute the Vitest suites across all workspaces and ensure basic smoke tests pass.
-- Use `pnpm test:ui` to open the interactive Vitest UI when visualizing test runs.
-- When adding CLI command tests, mock filesystem and configuration interactions to avoid touching real resources.
-- If tests or builds fail with missing workspace packages (e.g. `@civ7/plugin-git` or `lodash-es`), run `pnpm install` to link all workspace dependencies before retrying.
+- Use `pnpm` workspace scripts for build, type‑checks, lint, and tests unless a closer `AGENTS.md` says otherwise.
+- Prefer package scripts (`pnpm -C <path> <script>`) over ad‑hoc commands.
 
-### Repository and PR policy
-- We now push branches and open pull requests exclusively against the `fork` remote (`mateicanavra/civ7-modding-tools-fork`). Do not target the original `origin` upstream, as it has diverged and no longer receives updates.
+## Civ7 Resources
 
-## Task tracking
+- Populate `civ7-official-resources/` with `pnpm run unzip-civ`; see `docs/system/sdk/` for details.
+- Search extracted game data with `rg` under `civ7-official-resources/Base/modules/...`.
 
-- See [docs/projects/](docs/projects/) for active project work
-- Past planning documents are archived under `.ai/archive/plans/` and `docs/_archive/`
+## Domain Routers
+
+- MapGen / Swooper Maps mod: `mods/mod-swooper-maps/AGENTS.md`, `docs/system/mods/swooper-maps/`, `docs/system/libs/mapgen/`.
+- CLI & plugins: `packages/cli/AGENTS.md`, `packages/plugins/*/AGENTS.md`, `docs/system/cli/`.
+- SDK: `packages/sdk/AGENTS.md`, `docs/system/sdk/`.
+
+## Repo Policy
+
+- Open PRs against the `fork` remote (not `origin`); details in `docs/process/CONTRIBUTING.md`.
+- Active work lives under `docs/projects/`.

--- a/mods/mod-swooper-maps/AGENTS.md
+++ b/mods/mod-swooper-maps/AGENTS.md
@@ -1,0 +1,21 @@
+# MapGen Mod (Swooper Maps) — Agent Router
+
+Scope: `mods/mod-swooper-maps/**`
+
+## What This Directory Is
+
+- The Swooper Maps / MapGen mod package.
+- `src/` holds the TypeScript game‑facing entry files.
+- `mod/` is generated build output for Civ VII; treat it as read‑only.
+
+## Tooling Rules
+
+- Use `pnpm` scripts for build, type‑checks, and mod deployment in this package (see `mods/mod-swooper-maps/package.json`).
+- Prefer regenerating `mod/` via `pnpm build` over editing build artifacts.
+- Run broader tests from the repo root (`pnpm test`) or the MapGen core package when needed.
+
+## Canonical Docs
+
+- Mod architecture & presets: `docs/system/mods/swooper-maps/architecture.md`
+- MapGen engine architecture/config: `docs/system/libs/mapgen/architecture.md`
+- Testing overview: `docs/system/TESTING.md`

--- a/mods/mod-swooper-maps/src/AGENTS.md
+++ b/mods/mod-swooper-maps/src/AGENTS.md
@@ -1,0 +1,11 @@
+# MapGen Mod Entry Sources — Agent Router
+
+Scope: `mods/mod-swooper-maps/src/**`
+
+- These files are game‑facing entrypoints for map variants. Keep them small and declarative (bootstrap + imports).
+- Avoid adding generator logic here; put shared logic in MapGen core or the mod’s shared modules instead.
+- Validate changes with this package’s `pnpm` scripts (build/check).
+
+Docs:
+- `docs/system/mods/swooper-maps/architecture.md`
+- `docs/system/libs/mapgen/architecture.md`

--- a/packages/civ7-adapter/AGENTS.md
+++ b/packages/civ7-adapter/AGENTS.md
@@ -1,0 +1,13 @@
+# Civ7 Engine Adapter — Agent Router
+
+Scope: `packages/civ7-adapter/**`
+
+- Sole boundary for importing Civ7 engine globals / `base-standard` APIs.
+- Exposes stable `EngineAdapter` implementations consumed by MapGen and mods.
+- Keep this package thin: translate engine calls to adapter methods; no MapGen algorithms or mod logic.
+
+Tooling: use this package’s `pnpm` scripts for build/check.
+
+Docs:
+- `docs/system/libs/mapgen/architecture.md` (adapter boundary)
+

--- a/packages/civ7-types/AGENTS.md
+++ b/packages/civ7-types/AGENTS.md
@@ -1,0 +1,11 @@
+# Civ7 Runtime Types — Agent Router
+
+Scope: `packages/civ7-types/**`
+
+- Type definitions for the Civ7 scripting/runtime environment.
+- No runtime code here; keep exports type‑only.
+- Validate with this package’s `pnpm` type‑check script after changes.
+
+Docs:
+- `docs/system/sdk/overview.md`
+

--- a/packages/mapgen-core/AGENTS.md
+++ b/packages/mapgen-core/AGENTS.md
@@ -1,0 +1,27 @@
+# MapGen Engine Core — Agent Router
+
+Scope: `packages/mapgen-core/**`
+
+## What This Package Is
+
+- Shared MapGen engine/library used by map mods.
+- Pure TypeScript domain logic: algorithms, phases/layers, config schema, orchestration glue.
+- `dist/` is generated build output; treat it as read‑only.
+
+## Tooling Rules
+
+- Use package scripts via `pnpm` for build, type‑checks, and tests (`pnpm -F @swooper/mapgen-core <script>`).
+- Run workspace‑wide validation from repo root when changing cross‑package contracts.
+
+## Domain Rules
+
+- No direct Civ7 engine imports here; all engine interaction goes through `@civ7/adapter` and `MapGenContext.adapter`.
+- Avoid global mutable state; steps/layers communicate only via `MapGenContext`.
+
+## Canonical Docs
+
+- Engine architecture & phases: `docs/system/libs/mapgen/architecture.md`
+- Design notes & invariants: `docs/system/libs/mapgen/design.md`
+- Foundation & climate concepts: `docs/system/libs/mapgen/foundation.md`, `docs/system/libs/mapgen/climate.md`
+- Testing overview: `docs/system/TESTING.md`
+

--- a/packages/mapgen-core/src/AGENTS.md
+++ b/packages/mapgen-core/src/AGENTS.md
@@ -1,0 +1,14 @@
+# MapGen Core Sources — Agent Router
+
+Scope: `packages/mapgen-core/src/**`
+
+- Engine implementation. Keep logic organized by architectural phase and data products.
+- Steps/layers should be deterministic from `MapGenContext` + validated config, and write results only through the context.
+- Do not introduce mod‑specific entrypoints or Civ7 runtime imports here.
+
+Tooling: validate with this package’s `pnpm` scripts.
+
+Docs:
+- `docs/system/libs/mapgen/architecture.md`
+- `docs/system/libs/mapgen/design.md`
+

--- a/packages/mapgen-core/src/bootstrap/AGENTS.md
+++ b/packages/mapgen-core/src/bootstrap/AGENTS.md
@@ -1,0 +1,12 @@
+# MapGen Bootstrap — Agent Router
+
+Scope: `packages/mapgen-core/src/bootstrap/**`
+
+- Configuration bootstrap and tunables publishing.
+- This layer prepares validated config/context; it should not contain map‑generation algorithms.
+- Avoid direct Civ7 engine calls; use the adapter only when bootstrapping requires it.
+
+Docs:
+- `docs/system/libs/mapgen/architecture.md`
+- `docs/system/libs/mapgen/design.md`
+

--- a/packages/mapgen-core/src/config/AGENTS.md
+++ b/packages/mapgen-core/src/config/AGENTS.md
@@ -1,0 +1,12 @@
+# MapGen Config — Agent Router
+
+Scope: `packages/mapgen-core/src/config/**`
+
+- Owns the canonical `MapGenConfig` schema, defaults, and loader.
+- Keep config shapes centralized here; layers should not invent parallel schemas.
+- Changes here affect mods and tooling; run package + workspace checks after edits.
+
+Docs:
+- `docs/system/libs/mapgen/architecture.md` (configuration model)
+- `docs/system/libs/mapgen/design.md`
+

--- a/packages/mapgen-core/src/layers/AGENTS.md
+++ b/packages/mapgen-core/src/layers/AGENTS.md
@@ -1,0 +1,13 @@
+# MapGen Layers — Agent Router
+
+Scope: `packages/mapgen-core/src/layers/**`
+
+- Generation layers/steps for foundation → placement phases.
+- Read from `MapGenContext`/validated config and write back to context fields/artifacts.
+- No global state or I/O; keep behavior deterministic for a given seed/context.
+
+Docs:
+- `docs/system/libs/mapgen/architecture.md`
+- `docs/system/libs/mapgen/foundation.md`
+- `docs/system/libs/mapgen/climate.md`
+


### PR DESCRIPTION
# Rewrite AGENTS.md as a Durable Router System

- Restructured root AGENTS.md as a lightweight domain router with enduring rules and canonical doc links
- Added scoped AGENTS.md files to key directories:
  - `mods/mod-swooper-maps/` (and src subdirectory)
  - `packages/civ7-adapter/`
  - `packages/civ7-types/`
  - `packages/mapgen-core/` (including src, bootstrap, config, and layers subdirectories)
- Established clear docs architecture with conventions for ALL-CAPS canonical docs vs lowercase supporting docs
- Defined tooling defaults emphasizing package scripts over ad-hoc commands
- Documented Graphite + Linear workflow for stacked PRs and task tracking
- Clarified repo policy for PRs against fork remote
- Emphasized treating build artifacts (dist/, mod/) as read-only
- Reinforced adapter boundary pattern in core packages to isolate Civ7 engine dependencies

The new structure provides consistent guidance at each directory level while keeping volatile implementation details in dedicated docs rather than routers.