### PR TITLE
feat(config): type story rainfall knobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This repo uses nested `AGENTS.md` files as lightweight domain routers: short, en
 - Record significant architectural decisions in `docs/system/ADR.md` and intentional deferrals with triggers in `docs/system/DEFERRALS.md`.
 - Treat generated artifacts (e.g., `dist/`, `mod/`) and lockfiles as read‑only; regenerate them via scripts instead of hand‑editing.
 - Follow established directory conventions; consult the relevant `docs/system/**` overviews before introducing new domains or layouts.
+- When you find important, surprising, interesting, or particularly novel or useful, please add it to the respective project or canonical doc (depending on the timescale of its quality).
 
 ## Docs Architecture (Where Things Go)
 

--- a/docs/projects/engine-refactor-v1/issues/CIV-39-config-surface-alignment.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-39-config-surface-alignment.md
@@ -1,6 +1,6 @@
 ---
 id: CIV-39
-title: "[M2] Stable-Slice Story Rainfall/Orogeny Config Surface Alignment"
+title: "[M2] Stable-Slice Story Rainfall Config Surface Alignment (Orogeny Deferred)"
 state: planned
 priority: 2
 estimate: 1
@@ -18,7 +18,8 @@ related_to: [CIV-27, CIV-30, CIV-38]
 <!-- SECTION SCOPE [SYNC] -->
 ## TL;DR
 
-Promote and document the **story-driven rainfall and orogeny knobs** that are already meaningful in the M2 stable slice, so validated config matches the runtime tunables consumed by `climate-engine.ts`.
+Promote and document the **story-driven rainfall knobs** that are already meaningful in the M2 stable slice, so validated config matches the runtime tunables consumed by `climate-engine.ts`.  
+Story orogeny (windward/lee amplification along belts) is explicitly deferred to the M3+ task‑graph architecture and should not be promoted via legacy cache shims in M2.
 
 ## Deliverables
 
@@ -29,11 +30,6 @@ Promote and document the **story-driven rainfall and orogeny knobs** that are al
     - `paradiseDelta` (rainfall units)
     - `volcanicDelta` (rainfall units)
   - Document defaults/ranges consistent with current behavior in `layers/climate-engine.ts`.
-- [ ] **Typed `foundation.story.orogeny` tunables**
-  - Extend `StoryConfigSchema` (as used under `foundation.story`) to include an optional `orogeny` tunables object with:
-    - `windwardBoost` (rainfall units)
-    - `leeDrynessAmplifier` (multiplier)
-  - Ensure schema/docs reflect that these values are consumed during `refineClimateEarthlike` when `STORY_ENABLE_OROGENY` is active.
 - [ ] **Stable‑slice docs alignment**
   - Update any M2 stable‑slice config docs/snippets to advertise these blocks as supported in the orchestrator‑centric slice.
   - Keep scope limited to keys already used in TS; no new story climate behavior is introduced here.
@@ -42,14 +38,14 @@ Promote and document the **story-driven rainfall and orogeny knobs** that are al
 
 - [ ] `MapGenConfigSchema` validates and defaults:
   - `climate.story.rainfall.{riftRadius,riftBoost,paradiseDelta,volcanicDelta}`.
-  - `foundation.story.orogeny.{windwardBoost,leeDrynessAmplifier}`.
-- [ ] `getTunables().CLIMATE_CFG.story.rainfall` and `getTunables().FOUNDATION_CFG.story.orogeny` resolve to the validated values without extra shims.
+- [ ] `getTunables().CLIMATE_CFG.story.rainfall` resolves to the validated values without extra shims.
 - [ ] Climate refinement uses these knobs when minimal story tags exist (from CIV‑36) and is unchanged when blocks are absent.
 - [ ] Build and tests pass.
 
 ## Out of Scope
 
 - Any new story overlays or additional climate/story passes beyond what is already in the stable slice.
+- Story orogeny belts / windward‑lee amplification and any config surface for them (handled in M3+ as a dedicated orogeny step/layer).
 - Canonical data‑product reshaping of story/climate config (owned by M3).
 - Diagnostics config promotion or alias cleanup (owned by CIV-38).
 
@@ -57,9 +53,8 @@ Promote and document the **story-driven rainfall and orogeny knobs** that are al
 
 - Depends on minimal story tagging being present so these knobs have effect (CIV‑36).
 - Runtime sources:
-  - `packages/mapgen-core/src/layers/climate-engine.ts` (Pass D rift humidity; Pass E orogeny belts).
+  - `packages/mapgen-core/src/layers/climate-engine.ts` (Pass D rift humidity; Pass E orogeny belts is deferred in M2).
   - `packages/mapgen-core/src/bootstrap/tunables.ts` (`CLIMATE_CFG`, `FOUNDATION_CFG.story` views).
 - Historical reference:
   - `docs/system/libs/mapgen/_archive/original-mod-swooper-maps-js/layers/climate-engine.js`
   - `docs/system/libs/mapgen/_archive/original-mod-swooper-maps-js/bootstrap/tunables.js`
-

--- a/docs/projects/engine-refactor-v1/issues/CIV-39-config-surface-alignment.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-39-config-surface-alignment.md
@@ -23,24 +23,24 @@ Story orogeny (windward/lee amplification along belts) is explicitly deferred to
 
 ## Deliverables
 
-- [ ] **Typed `climate.story.rainfall` block**
+- [x] **Typed `climate.story.rainfall` block**
   - Add an optional `story` sub‑block to `ClimateConfigSchema` with a `rainfall` object that explicitly models the stable‑slice knobs used today:
     - `riftRadius` (tiles)
     - `riftBoost` (rainfall units)
     - `paradiseDelta` (rainfall units)
     - `volcanicDelta` (rainfall units)
   - Document defaults/ranges consistent with current behavior in `layers/climate-engine.ts`.
-- [ ] **Stable‑slice docs alignment**
+- [x] **Stable‑slice docs alignment**
   - Update any M2 stable‑slice config docs/snippets to advertise these blocks as supported in the orchestrator‑centric slice.
   - Keep scope limited to keys already used in TS; no new story climate behavior is introduced here.
 
 ## Acceptance Criteria
 
-- [ ] `MapGenConfigSchema` validates and defaults:
+- [x] `MapGenConfigSchema` validates and defaults:
   - `climate.story.rainfall.{riftRadius,riftBoost,paradiseDelta,volcanicDelta}`.
-- [ ] `getTunables().CLIMATE_CFG.story.rainfall` resolves to the validated values without extra shims.
-- [ ] Climate refinement uses these knobs when minimal story tags exist (from CIV‑36) and is unchanged when blocks are absent.
-- [ ] Build and tests pass.
+- [x] `getTunables().CLIMATE_CFG.story.rainfall` resolves to the validated values without extra shims.
+- [x] Climate refinement uses these knobs when minimal story tags exist (from CIV‑36) and is unchanged when blocks are absent.
+- [x] Build and tests pass.
 
 ## Out of Scope
 

--- a/docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md
+++ b/docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md
@@ -77,7 +77,8 @@ Related PRD: `resources/PRD-plate-generation.md`
 
 - Ensure the validated schema and docs reflect the config keys actually consumed in the M2 stable slice:
   - `foundation.diagnostics` dev flags (currently untyped but wired via `initDevFlags`).
-  - Story‑driven rainfall/orogeny knobs (`climate.story.rainfall.*`, `foundation.story.orogeny.*`) that influence `climateRefine` once minimal story tags exist.
+  - Story‑driven rainfall knobs (`climate.story.rainfall.*`) that influence `climateRefine` once minimal story tags exist.
+  - **Note:** story orogeny windward‑lee amplification (and any legacy `foundation.story.orogeny.*` knobs) is deferred to M3+ as a modern orogeny step/layer.
   - Resolve the mismatch between top‑level `diagnostics.*` aliases and the stable `foundation.diagnostics` block by treating `foundation.diagnostics` as canonical and deprecating/removing the unused top‑level surface.
 - This work is limited to promoting and documenting keys already meaningful in the stable slice; no diagnostics redesign is intended in M2.
 - Sources: `resources/config-wiring-status.md` (diagnostics + untyped stable‑slice keys), `resources/STATUS-M-TS-parity-matrix.md` (dev diagnostics + story/climate notes), `../issues/CIV-36-story-parity.md`, `../issues/CIV-38-dev-diagnostics.md`, `../issues/CIV-39-config-surface-alignment.md`.

--- a/docs/projects/engine-refactor-v1/resources/STATUS-M-TS-parity-matrix.md
+++ b/docs/projects/engine-refactor-v1/resources/STATUS-M-TS-parity-matrix.md
@@ -47,13 +47,13 @@ Detractions / Open Questions:
 
 | JS Module | TS Equivalent | Status | Notes |
 |----------|---------------|--------|-------|
-| `story/tagging.js` | **None** (expected: `packages/mapgen-core/src/story/tagging.ts`) | Missing (planned split across M2/M3) | JS implements the core climate story: `storyTagHotspotTrails`, `storyTagRiftValleys`, `storyTagOrogenyBelts`, `storyTagContinentalMargins`, `storyTagClimateSwatches`, `storyTagPaleoHydrology` plus an `OrogenyCache`. These functions populate `StoryTags`, publish overlays, and drive rainfall via `writeClimateField`/`syncClimateField` and `applyClimateSwatches`. TS implementation is tracked under parent `CIV-21` with children `CIV-36` and `LOCAL-M3-STORY-SYSTEM`. |
+| `story/tagging.js` | **None** (expected: `packages/mapgen-core/src/story/tagging.ts`) | Missing (planned split across M2/M3) | JS implements the core climate story: `storyTagHotspotTrails`, `storyTagRiftValleys`, `storyTagOrogenyBelts`, `storyTagContinentalMargins`, `storyTagClimateSwatches`, `storyTagPaleoHydrology` plus an `OrogenyCache`. TS implementation is tracked under parent `CIV-21` with children `CIV-36` and `LOCAL-M3-STORY-SYSTEM`. **Decision:** TS will not recreate the legacy cache flow; orogeny windward/lee amplification will return as a modern M3+ orogeny step/layer. |
 
 Detractions / Open Questions:
 - **Missing parity:** None of the following exist in TS:
   - Hotspot trail tagging (`hotspot`, `hotspotParadise`, `hotspotVolcanic`) with size, land-distance, and directionality constraints.
   - Rift line + shoulder tagging using `WorldModel` fields and `FOUNDATION_DIRECTIONALITY`.
-  - Orogeny belts and caches used by climate refinement.
+  - Orogeny belts (windward/lee amplification) are deferred to M3+ modern pipeline; legacy cache plumbing will not be ported in M2.
   - Continental margins tagging + margins overlay publication.
   - Climate swatches and paleo passes that adjust rainfall around story structures.
 - **Orchestration gap (today):** `MapOrchestrator` only has a stub `storySeed` stage that calls `resetStoryTags()`. Minimal tagging will be wired into existing story stages in M2 (`CIV-36`), with remaining stages migrated into Task Graph steps in M3 (`LOCAL-M3-STORY-SYSTEM`).

--- a/docs/projects/engine-refactor-v1/resources/STATUS-M-TS-typescript-migration-parity-notes.md
+++ b/docs/projects/engine-refactor-v1/resources/STATUS-M-TS-typescript-migration-parity-notes.md
@@ -72,7 +72,7 @@ These are the major “behavior gaps” vs the JS archive.
     - Use `FOUNDATION_DIRECTIONALITY` for oriented rift lines.
   - TS:
     - `bootstrap/tunables.ts` includes story-related config (e.g., `foundation.story`, `foundation.corridors`, `CLIMATE_CFG.story`) but there is no TS code that implements the actual tagging passes for those tunables.
-    - `climate-engine.ts` reads `CLIMATE_CFG.story.rainfall` and `FOUNDATION_CFG.story.orogeny`, but more advanced passes like swatches and paleo hydrology are not implemented as explicit “story stages” that operate on the climate buffer the way JS does.
+    - `climate-engine.ts` reads `CLIMATE_CFG.story.rainfall`; its orogeny windward/lee tunables are currently inert in M2 because no orogeny belts/step are produced. Orogeny will be reintroduced as a dedicated M3+ step/layer in the task‑graph pipeline (no legacy `OrogenyCache` port planned).
   - Net: story-related tunables have been given a nice config home but the logic that consumes them at the story-tagging level is not migrated. The climate refinement pass uses some story tags (`riftLine`, `hotspotParadise`, `hotspotVolcanic`) if present, but never gets them.
 
 - **Corridors system (sea lanes, island-hop, land corridors, river chains)**
@@ -208,7 +208,7 @@ To get to “migration finished” in the sense you describe (parity or explicit
 
   - **Story-aware climate passes (CIV‑18/19/21)**
     - Ensure that:
-      - `applyClimateSwatches` is explicitly invoked by a story stage, passing any `OrogenyCache` and context.
+      - `applyClimateSwatches` is explicitly invoked by a story stage, with any future orogeny artifacts supplied via `MapGenContext` (no legacy `OrogenyCache` port).
       - Paleo hydrology modifications use `writeClimateField`/`syncClimateField` consistently (as in JS), but within TS story stages.
       - All rainfall adjustments are clamped `[0, 200]` and pulled from `CLIMATE_CFG.story`.
     - Add a small integration test around `refineClimateEarthlike` + story tags, using the mock adapter + synthetic tags to confirm behavior.

--- a/docs/projects/engine-refactor-v1/resources/config-wiring-status.md
+++ b/docs/projects/engine-refactor-v1/resources/config-wiring-status.md
@@ -340,6 +340,17 @@ All refine sub-fields except `pressure` are wired in `layers/climate-engine.ts::
 |---|---|---|
 | `climate.swatches` | **Unused / planned** | Schema placeholder. TS instead reads `climate.story.swatches` (untyped) for macro swatch logic. |
 
+### climate.story.rainfall
+
+Typed story rainfall knobs consumed in `layers/climate-engine.ts::refineClimateEarthlike`.
+
+| Field | Status | Notes |
+|---|---|---|
+| `climate.story.rainfall.riftRadius` | **Wired** | Pass D rift humidity radius (tiles). Default 2. |
+| `climate.story.rainfall.riftBoost` | **Wired** | Pass D rift humidity delta (rainfall units). Default 8. |
+| `climate.story.rainfall.paradiseDelta` | **Wired** | Pass F paradise hotspot humidity bonus. Default 6. |
+| `climate.story.rainfall.volcanicDelta` | **Wired** | Pass F volcanic hotspot humidity bonus. Default 8. |
+
 Untyped climate.story keys in use are listed later.
 
 ## biomes (stage: `biomes`)
@@ -438,15 +449,11 @@ Read in `layers/climate-engine.ts`:
 | `climate.story.swatches.types.<kind>.lowlandMaxElevation` | `storySwatches` | Used by `greatPlains`. |
 | `climate.story.swatches.types.<kind>.dryDelta` | `storySwatches` | Used by `greatPlains`. |
 | `climate.story.swatches.sizeScaling.widthMulSqrt` | `storySwatches` | Scales band widths with map area. |
-| `climate.story.rainfall.riftRadius` | `climateRefine` | Pass D rift humidity radius. |
-| `climate.story.rainfall.riftBoost` | `climateRefine` | Pass D rift humidity delta. |
-| `climate.story.rainfall.paradiseDelta` | `climateRefine` | Pass F paradise hotspot humidity. |
-| `climate.story.rainfall.volcanicDelta` | `climateRefine` | Pass F volcanic hotspot humidity. |
-| `climate.story.orogeny.windwardBoost` | `climateRefine` | Pass E windward rainfall bonus (gated by STORY_ENABLE_OROGENY). |
-| `climate.story.orogeny.leeDrynessAmplifier` | `climateRefine` | Pass E lee-side drying multiplier. |
 
 Swatch kinds currently recognized by code: `macroDesertBelt`, `equatorialRainbelt`, `rainforestArchipelago`,
 `mountainForests`, `greatPlains` (others ignored unless code adds handlers).
+
+Note: `refineClimateEarthlike` also contains an orogeny windward/lee pass, but M2 stable slice does not provide orogeny belts/cache plumbing. Orogeny is deferred to a modern M3+ step/layer (no legacy `OrogenyCache` port).
 
 ### foundation.diagnostics (dev flags)
 

--- a/docs/projects/engine-refactor-v1/triage.md
+++ b/docs/projects/engine-refactor-v1/triage.md
@@ -11,21 +11,21 @@ Milestone and issue docs remain canonical for scheduled/active scope; entries he
   - **Next check:** when/how to re‑evaluate.
 
 **Revisit index (best‑effort scan)**
-- [Early M3] Port story orogeny belts to TS
+- [Early M3+] Design/implement modern story orogeny layer
 - [During M3 story migration] Add minimal story parity regression harness
 
 ## Triage (needs decision / research)
 
 ## Backlog (definite, unsequenced)
 
-- **Port story orogeny belts to TS** [Review by: early M3]
-  - **Context:** M2 / `CIV-36` minimal story parity; decision to defer recorded 2025‑12‑12 discussion.
+- **Modern story orogeny layer (windward/lee amplification)** [Review by: early M3+]
+  - **Context:** M2 / `CIV-36` minimal story parity deferred orogeny; `CIV-39` orogeny tunables promotion explicitly deferred in 2025‑12‑12 discussion.
   - **Type:** backlog
-  - **Notes:** Legacy `storyTagOrogenyBelts` relies on convergent‑boundary physics (`upliftPotential`, `tectonicStress`, `boundaryType`, `boundaryCloseness`) and prevailing winds. To make it meaningful in TS we need:
-    - A TS port producing belt + windward/lee sets.
-    - A `storyOrogeny` orchestrator stage.
-    - Passing an `OrogenyCache` into `refineClimateEarthlike` (and `applyClimateSwatches` once that stage is wired), so rainfall/biomes regain the windward‑lee motifs.
-  - **Next check:** revisit in early M3 when story swatches/corridors plumbing is scheduled and we can validate parity without destabilizing M2 defaults.
+  - **Notes:** Legacy JS used `storyTagOrogenyBelts` + an `OrogenyCache` to amplify rainfall on windward/lee flanks along long convergent belts. We will **not** port that cache‑based flow in M2. In the task‑graph architecture (`docs/system/libs/mapgen/architecture.md`), reintroduce orogeny as a dedicated step/layer that:
+    - Derives belts/flanks from `MapGenContext.artifacts.tectonics` (uplift/convergence) and prevailing winds.
+    - Publishes modern story tags/overlays and/or applies rainfall/biome modifiers via context fields/buffers.
+    - Owns a modern config surface (may replace legacy `foundation.story.orogeny.*` knobs).
+  - **Next check:** schedule once Pipeline/Story steps land in M3 and we can validate parity without re‑adding legacy shims.
 
 - **Add minimal story parity regression harness** [Review by: during M3 story migration]
   - **Context:** M2 review `REVIEW-M2-stable-engine-slice.md` CIV‑36 section; noted 2025‑12‑12.

--- a/packages/mapgen-core/src/config/schema.ts
+++ b/packages/mapgen-core/src/config/schema.ts
@@ -1941,12 +1941,72 @@ export const ClimateRefineSchema = Type.Object(
 /**
  * Aggregated climate configuration grouping baseline, refinement, and swatch knobs.
  */
+export const ClimateStoryRainfallSchema = Type.Object(
+  {
+    /**
+     * Radius around rift line tiles that receives a humidity boost.
+     * @default 2
+     */
+    riftRadius: Type.Optional(
+      Type.Number({
+        default: 2,
+        description:
+          "Radius around rift line tiles that receives a humidity boost (tiles). Typically 2–5.",
+      })
+    ),
+    /**
+     * Base rainfall bonus applied near rift shoulders, reduced by elevation.
+     * @default 8
+     */
+    riftBoost: Type.Optional(
+      Type.Number({
+        default: 8,
+        description:
+          "Base rainfall bonus applied near rifts before elevation penalties (rainfall units). Typically 15–30.",
+      })
+    ),
+    /**
+     * Rainfall bonus applied within hotspot paradise neighborhoods.
+     * @default 6
+     */
+    paradiseDelta: Type.Optional(
+      Type.Number({
+        default: 6,
+        description:
+          "Rainfall bonus applied near paradise hotspots (rainfall units). Typically 10–20.",
+      })
+    ),
+    /**
+     * Rainfall bonus applied within hotspot volcanic neighborhoods.
+     * @default 8
+     */
+    volcanicDelta: Type.Optional(
+      Type.Number({
+        default: 8,
+        description:
+          "Rainfall bonus applied near volcanic hotspots (rainfall units). Typically 8–15.",
+      })
+    ),
+  },
+  { additionalProperties: true, default: {} }
+);
+
+export const ClimateStorySchema = Type.Object(
+  {
+    /** Story-driven rainfall modifiers keyed off narrative tags. */
+    rainfall: Type.Optional(ClimateStoryRainfallSchema),
+  },
+  { additionalProperties: true, default: {} }
+);
+
 export const ClimateConfigSchema = Type.Object(
   {
     /** Baseline rainfall and local bonuses. */
     baseline: Type.Optional(ClimateBaselineSchema),
     /** Earthlike refinement parameters (rain shadow, river corridors, etc.). */
     refine: Type.Optional(ClimateRefineSchema),
+    /** Story-driven climate modifiers reacting to narrative overlays. */
+    story: Type.Optional(ClimateStorySchema),
     /** Swatch overrides for macro climate regions (untyped placeholder). */
     swatches: Type.Optional(UnknownRecord),
   },


### PR DESCRIPTION
feat(config): type story rainfall knobs

- add climate.story.rainfall schema with defaults/ranges
- align M2 docs to defer orogeny and advertise rainfall knobs

docs(engine-refactor): mark CIV-39 complete