### PR TITLE
docs(engine-refactor-v1): align FoundationContext contract with code

### DIFF
--- a/docs/process/CONTRIBUTING.md
+++ b/docs/process/CONTRIBUTING.md
@@ -117,5 +117,30 @@ pnpm publish:all   # SDK then CLI
 git checkout -b feat/your-change
 # make changes
 pnpm test
-git commit -m "feat: concise description"
+git commit
 ```
+
+### Commit message conventions
+
+Use Conventional Commits with an optional ticket prefix when a trackable ID exists (Linear or other):
+
+```text
+[LIN-123] feat(cli): add unzip progress output
+
+Add a per-archive progress indicator and per-file counts so long extractions
+are easier to monitor.
+
+Notes:
+- Default output stays stable for scripts; progress is opt-in via `--progress`.
+
+References:
+- Project: @civ7/cli
+- Linear: LIN-123
+- Docs: docs/system/sdk/overview.md
+```
+
+Rules:
+- **Title:** `[TICKET] type(scope): summary` (ticket prefix optional if no ID).
+- **Scope:** internal area of concern (package/app/subsystem), not the repo/project name.
+- **Body:** explain intent + user-visible behavior and any operational/testing notes.
+- **Footer references:** include the project/package being worked on and the ticket ID from the title (plus any other durable references).

--- a/docs/projects/engine-refactor-v1/issues/CIV-34-foundation-context-contract.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-34-foundation-context-contract.md
@@ -32,10 +32,10 @@ Make the `FoundationContext` contract explicit and document the end-to-end flow 
 
 ## Acceptance Criteria
 
-- [ ] `FoundationContext` fields and guarantees are documented in `resources/CONTRACT-foundation-context.md` and linked from the engine-refactor project docs.
-- [ ] The config → tunables → world-model flow is described as the canonical M2 slice and matches the actual implementation.
-- [ ] M2 docs and review explicitly describe tunables as a view over validated `MapGenConfig`, not as a separate config store.
-- [ ] Future M3+ issues can reference this contract instead of re-deriving the behavior from code/reviews.
+- [x] `FoundationContext` fields and guarantees are documented in `resources/CONTRACT-foundation-context.md` and linked from the engine-refactor project docs.
+- [x] The config → tunables → world-model flow is described as the canonical M2 slice and matches the actual implementation.
+- [x] M2 docs and review explicitly describe tunables as a view over validated `MapGenConfig`, not as a separate config store.
+- [x] Future M3+ issues can reference this contract instead of re-deriving the behavior from code/reviews.
 
 ## Testing / Verification
 

--- a/docs/projects/engine-refactor-v1/issues/LOCAL-M3-system-docs-target-vs-current.md
+++ b/docs/projects/engine-refactor-v1/issues/LOCAL-M3-system-docs-target-vs-current.md
@@ -1,0 +1,77 @@
+---
+id: LOCAL-M3-SYSTEM-DOCS-TARGET-VS-CURRENT
+title: "[M3] Clarify MapGen system docs: Target vs Current (post-M2)"
+state: planned
+priority: 4
+estimate: 2
+project: engine-refactor-v1
+milestone: M3-core-engine-refactor-config-evolution
+assignees: []
+labels: [Documentation, Architecture]
+parent: null
+children: []
+blocked_by: []
+blocked: []
+related_to: [CIV-33, CIV-34]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Add an explicit “Target vs Current implementation” framing to the canonical system docs so agents and humans can quickly understand (1) the stable target architecture we’re steering toward, and (2) the pragmatic post‑M2 reality, without rewriting the target design or doing a full current-vs-target reconciliation.
+
+## Deliverables
+
+- Update the system docs:
+  - `docs/system/libs/mapgen/architecture.md`
+  - `docs/system/libs/mapgen/foundation.md`
+  - `docs/system/libs/mapgen/climate.md`
+- Each doc has a prominent preamble/banner that:
+  - States the doc contains both **Target** and **Current** guidance.
+  - Makes clear **Target** is canonical long-term architecture.
+  - Makes clear **Current (post‑M2)** is intentionally transient while M3/M4 land.
+- Add a short **Current implementation (M2)** subsection (or equivalent) to `foundation.md` and `climate.md` that:
+  - Points to the current source-of-truth for the M2 slice:
+    - `docs/projects/engine-refactor-v1/resources/CONTRACT-foundation-context.md`
+    - `docs/projects/engine-refactor-v1/PROJECT-engine-refactor-v1.md`
+    - `docs/projects/engine-refactor-v1/status.md`
+  - Avoids over-describing details likely to churn in M3 (e.g., step registry/task graph wiring).
+- Confirm the docs do **not** imply that `PipelineExecutor` / `MapGenStep` / `StepRegistry` are already wired today (unless/when they become true).
+
+## Acceptance Criteria
+
+- [ ] `docs/system/libs/mapgen/architecture.md` clearly labels “Target” vs “Current” guidance and points readers to project docs for post‑M2 reality where appropriate.
+- [ ] `docs/system/libs/mapgen/foundation.md` includes a clear “Current implementation (post‑M2)” subsection and links to the M2 contract + project snapshot docs.
+- [ ] `docs/system/libs/mapgen/climate.md` includes a clear “Current implementation (post‑M2)” subsection and links to the M2 contract + project snapshot docs.
+- [ ] The added “Current” sections are short, scoped, and explicitly described as transient.
+- [ ] The target architecture sections remain canonical and are not rewritten to mirror current code line-by-line.
+
+## Out of Scope
+
+- Full architecture doc sweep / full reconciliation of system docs vs implementation details.
+- Changing the target architecture/design described in `docs/system/libs/mapgen/*`.
+- Re-specifying every data product, step boundary, or pipeline recipe.
+
+## Dependencies / Notes
+
+- Current M2 slice truth:
+  - `docs/projects/engine-refactor-v1/resources/CONTRACT-foundation-context.md`
+  - `docs/projects/engine-refactor-v1/PROJECT-engine-refactor-v1.md`
+  - `docs/projects/engine-refactor-v1/status.md`
+  - `docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md`
+  - `docs/projects/engine-refactor-v1/milestones/M3-core-engine-refactor-config-evolution.md`
+- Related doc alignment work:
+  - `docs/projects/engine-refactor-v1/issues/CIV-33-docs-alignment.md`
+  - `docs/projects/engine-refactor-v1/issues/CIV-34-foundation-context-contract.md`
+- A larger “full system docs sweep” should be tracked separately (see `docs/projects/engine-refactor-v1/triage.md`) once Task Graph / steps / canonical products stabilize.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Notes (Local Only)
+
+- Keep the “Current” sections extremely short and link-heavy; avoid embedding volatile details that will churn during M3.
+- Suggested structure for `foundation.md` / `climate.md`:
+  - `## Target Architecture` (existing content; canonical)
+  - `## Current Implementation (post‑M2)` (new; transient; links to M2 contract/status)
+  - `## Migration Notes` (optional; 2–4 bullets max; what will change in M3)

--- a/docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md
+++ b/docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md
@@ -118,13 +118,13 @@ These may be split or reassigned across milestones as we refine the execution pl
   - For planning and reconciliation after CIV-26–CIV-31, M2 is now defined as: “Config + foundation slice is stable, documented, and test-backed,” using the current `MapOrchestrator`-centric architecture.
   - M2 explicitly does *not* deliver the full generic `PipelineExecutor` / `MapGenStep` / `StepRegistry` abstraction; that work is deferred to early M3+.
 
-- **Final M2 cleanup/stabilization batch (to land before calling the milestone fully done):**
+  - **Final M2 cleanup/stabilization batch (to land before calling the milestone fully done):**
   - **Docs alignment**
-    - Update M2 docs and issue files so they accurately describe the current flow: `bootstrap() → MapGenConfig → tunables → MapOrchestrator → FoundationContext`, and remove or soften wording that assumes an already-implemented `PipelineExecutor` / `MapGenStep` / `StepRegistry`.
+    - Update M2 docs and issue files so they accurately describe the current flow: `bootstrap() → validated MapGenConfig → tunables → MapOrchestrator → FoundationContext`, and remove or soften wording that assumes an already-implemented `PipelineExecutor` / `MapGenStep` / `StepRegistry`.
     - Remove or clearly mark as “future” any remaining references to `globalThis.__EPIC_MAP_CONFIG__` and the old global config pattern.
   - **Contract stabilization**
     - Make the `FoundationContext` contract explicit: what it guarantees to downstream consumers, and which data products exist at the end of the M2 slice (see `resources/CONTRACT-foundation-context.md` as the working contract doc).
-    - Clarify the role of tunables as a view over `MapGenConfig` (derived/read-only perspective) rather than a primary config store.
+    - Clarify the role of tunables as a view over validated `MapGenConfig` (derived/read-only perspective) rather than a primary config store.
   - **Tests**
     - Add at least one end-to-end `MapOrchestrator.generateMap` smoke test using a minimal/default `MapGenConfig` and a stub adapter, asserting that the foundation data products are populated and no stages regress.
 

--- a/docs/projects/engine-refactor-v1/resources/CONTRACT-foundation-context.md
+++ b/docs/projects/engine-refactor-v1/resources/CONTRACT-foundation-context.md
@@ -135,13 +135,11 @@ contracts, not internal implementation details.
 - When running the `foundation` stage, the orchestrator:
   - Creates an `ExtendedMapContext` with:
     - Dimensions from the Civ7 adapter or test defaults.
-    - The same `MapGenConfig` instance passed into the constructor.
-  - Configures and runs `WorldModel` using tunables derived from that config.
+    - A lightweight runtime `ctx.config` object (currently: toggle flags) for legacy call sites.
+  - Configures and runs `WorldModel` using tunables derived from the **validated `MapGenConfig`** (bound via `bootstrap()` / `bindTunables()`).
   - After `WorldModel` finishes foundation physics, calls:
     - `createFoundationContext(WorldModel, { dimensions, config: foundationConfigSlice })`.
-  - Stores the resulting `FoundationContext` on:
-    - `ctx.foundation` (for downstream TS stages).
-    - `WorldModel` (for any remaining legacy consumers and diagnostics).
+  - Stores the resulting `FoundationContext` on `ctx.foundation` (for downstream TS stages and diagnostics).
 
 **M2 Contract for World Model & FoundationContext**
 
@@ -184,7 +182,7 @@ assuming `FoundationContext` remains the canonical physics snapshot.
     - `config.foundation` and related tunables (plates, dynamics, surface, diagnostics).
   - `provides`:
     - `FoundationContext` (as defined above).
-    - Populated `HeightfieldBuffer` (via `syncHeightfield`) and initial land mask.
+    - `HeightfieldBuffer` exists on `ctx.buffers.heightfield`, but it is populated later (via `syncHeightfield()` after terrain-modifying stages), not during foundation initialization.
 
 - **Proposed: Climate baseline step (M3)**
   - `requires`:

--- a/docs/projects/engine-refactor-v1/resources/CONTRACT-foundation-context.md
+++ b/docs/projects/engine-refactor-v1/resources/CONTRACT-foundation-context.md
@@ -1,44 +1,50 @@
 # CONTRACT: FoundationContext (M2 Slice)
 
-> Working draft — project-level contract only.  
-> This document tracks the **current and intended** `FoundationContext` contract for the M2 engine slice.  
-> Keep it in sync with the implementation as we evolve the engine. Once the contract is stable, we should
-> promote it into `docs/system/libs/mapgen` (and potentially clone the pattern for other data products).
+> Working draft — project-level contract.  
+> Sections 1–5 are **binding** for the M2 “stable slice”. Sections 6–7 are **non-binding** notes.
 
 ## 1. Purpose
 
-- Capture what the **M2 engine slice** guarantees about `FoundationContext` and the config→tunables→orchestrator flow.
-- Give M3+ work (pipeline, climate, story) a **single reference** instead of reverse-engineering behavior from code.
-- Provide a bridge between the **target architecture docs** and the **current MapOrchestrator-centric implementation**.
+- Define the consumer-facing contract for the `FoundationContext` data product emitted by the M2 `foundation` slice.
+- Make “M2 stable slice” dependencies explicit for M3+ work (climate, story overlays, hydrology, placement).
+- Provide a stable reference while the implementation refactors.
 
 Authoritative implementation references:
 
 - Types & factories: `packages/mapgen-core/src/core/types.ts`
   - `FoundationContext`, `FoundationConfigSnapshot`, `createFoundationContext`, `assertFoundationContext`, `hasFoundationContext`
 - Orchestration & world model: `packages/mapgen-core/src/MapOrchestrator.ts`
+- World semantics: `packages/mapgen-core/src/world/types.ts`, `packages/mapgen-core/src/world/model.ts`
 - Config & tunables flow: `packages/mapgen-core/src/bootstrap/entry.ts`, `packages/mapgen-core/src/bootstrap/tunables.ts`
 - Target architecture: `docs/system/libs/mapgen/architecture.md`, `docs/system/libs/mapgen/foundation.md`
 
 ## 2. Scope & Status
 
-- **Scope (M2):**
-  - Describe the **shape and semantics** of `FoundationContext` as emitted by the current `foundation` slice.
-  - Describe the **config → tunables → MapOrchestrator → FoundationContext → world model** flow at a high level.
-  - Define what downstream stages may **assume** once the foundation slice has completed successfully.
+- **Binding scope (M2):**
+  - What exists on `ctx.foundation` after a successful `foundation` stage.
+  - How to interpret the tensors (indexing, encodings, value ranges, stability expectations).
+  - The config → tunables → orchestrator wiring that feeds foundation.
+- **Explicitly out of scope:**
+  - Exact physics algorithms, numeric distributions, or parity targets.
+  - “Interesting map” guarantees (e.g., plate count > 1); this contract is about shape + semantics, not quality.
 - **Status:**
-  - This contract is **binding** for M2 and for any M3+ work that claims to build on the “M2 stable slice”.
-  - It may be **refined** as we discover gaps; when we make changes, we should update this doc alongside the code.
+  - Sections 1–5 are binding for the M2 “stable slice”.
+  - Sections 6–7 are non-binding design notes (planning + future enforcement ideas).
+  - Any change to binding guarantees should update this doc alongside the code.
 
 ## 3. Data Product: FoundationContext
 
-At the end of the `foundation` slice, the orchestrator must have:
+`FoundationContext` is the canonical foundation-physics snapshot exposed to downstream stages as `ctx.foundation`.
 
-- An `ExtendedMapContext` (`ctx`) whose:
-  - `ctx.dimensions` is a valid `MapDimensions` (width, height, size).
-  - `ctx.worldModel` is initialized and contains all plate/dynamics tensors used by `createFoundationContext`.
-  - `ctx.foundation` is a **non-null**, immutable `FoundationContext` snapshot created via `createFoundationContext`.
+At the end of the `foundation` stage (when enabled and successful):
+
+- `ctx.foundation` is non-null and produced via `createFoundationContext(...)`.
+- `ctx.foundation` only exists if required tensors are present and length-consistent (validation fails fast).
+- `ctx.dimensions` matches `ctx.foundation.dimensions` (same width/height/size).
 
 ### 3.1 Shape
+
+The authoritative type is `FoundationContext` in `packages/mapgen-core/src/core/types.ts`:
 
 ```ts
 interface FoundationContext {
@@ -51,57 +57,56 @@ interface FoundationContext {
 }
 ```
 
-- `dimensions`
-  - Width/height/size for the **foundation tensors**, derived from the map dimensions used by `WorldModel`.
-  - **Invariant:** `size === width * height` and matches the length of all plate/dynamics tensors.
-- `plateSeed`
-  - Snapshot from `PlateSeedManager`, if available.
-  - Used for diagnostics and deterministic reproduction of plate layouts.
-  - May be `null` in test harnesses or non-standard entrypoints; consumers *must* tolerate `null`.
-- `plates` (`FoundationPlateFields`)
-  - Each field is a 1D tensor of length `size`, representing per-tile plate state:
-    - `id`: plate ID per tile.
-    - `boundaryCloseness`: proximity to the nearest plate boundary.
-    - `boundaryType`: encoded interaction type at boundaries (convergent/divergent/transform).
-    - `tectonicStress`: aggregate boundary stress metric.
-    - `upliftPotential`: collision-driven uplift intensity.
-    - `riftPotential`: divergence-driven rift intensity.
-    - `shieldStability`: craton/plate interior stability measure.
-    - `movementU` / `movementV`: plate motion vectors.
-    - `rotation`: plate angular velocity.
-  - **Invariant:** All tensors are present, and `createFoundationContext` enforces exact length matches.
-- `dynamics` (`FoundationDynamicsFields`)
-  - Per-tile atmospheric/oceanic state:
-    - `windU` / `windV`: coarse wind vectors.
-    - `currentU` / `currentV`: ocean current vectors.
-    - `pressure`: scalar pressure field.
-  - **Invariant:** All tensors are present and sized to `dimensions.size`.
-- `diagnostics` (`FoundationDiagnosticsFields`)
-  - Currently:
-    - `boundaryTree`: optional structure used by diagnostics (ASCII, histograms, debug views).
-  - This is explicitly **non-stable** and may evolve; consumers outside diagnostics should not depend on its shape.
-- `config` (`FoundationConfigSnapshot`)
-  - Immutable snapshot of the configuration that informed the foundation run:
-    - `seed`, `plates`, `dynamics`, `surface`, `policy`, `diagnostics`.
-  - Each sub-object is frozen via `freezeConfigSnapshot` and intended for:
-    - Diagnostics and reproducibility.
-    - Future pipeline steps that want to introspect the config that produced the tensors, without mutating it.
+This contract focuses on semantics and invariants (next section) rather than duplicating the field list.
 
-### 3.2 Invariants & Usage Guarantees
+### 3.2 Binding Semantics & Invariants
 
-For the **M2 slice**, downstream stages may assume:
+- **Availability**
+  - `ctx.foundation` is `null` until the `foundation` stage runs.
+  - If the `foundation` stage is disabled, `ctx.foundation` remains `null`.
+  - After a successful run, `ctx.foundation` remains available for the rest of the generation pass.
 
-- `ctx.foundation` is **either**:
-  - `null` (before foundation runs or if the foundation stage is disabled), **or**
-  - A fully-populated `FoundationContext` that passed `createFoundationContext`’s validation.
-- Any stage that **requires** physics data must:
-  - Call `assertFoundationContext(ctx, stageName)` or an equivalent guard before reading plate/dynamics tensors.
-  - Treat a missing `FoundationContext` as a hard error (this is how we surface manifest/wiring issues).
-- New work in M3+ that depends on foundation physics (climate, story overlays, rivers, etc.) should:
-  - Read from `ctx.foundation` and derived buffers (`Heightfield`, `ClimateField`) rather than re-reading raw `WorldModel` tensors.
-  - Treat `FoundationContext` as the **canonical bridge** between the physics engine and downstream data products.
+- **Tile indexing**
+  - All tensors in `plates` and `dynamics` are per-tile 1D typed arrays in row-major order:
+    - `i = y * width + x` where `0 ≤ x < width`, `0 ≤ y < height`
+  - `dimensions.size === width * height`, and every tensor has `length === dimensions.size`.
 
-## 4. Config → Tunables → Orchestrator → FoundationContext → World Model
+- **Read-only snapshot**
+  - `FoundationContext` is treated as immutable after creation.
+  - The object graph is frozen, but the typed arrays are not deep-copied; **do not** mutate tensor contents.
+
+- **Plates (`ctx.foundation.plates`)**
+  - `id` (`Int16Array`): plate identifier per tile (opaque; stable within the run).
+  - `boundaryType` (`Uint8Array`): boundary interaction type using `BOUNDARY_TYPE` from `packages/mapgen-core/src/world/types.ts`:
+    - `none=0`, `convergent=1`, `divergent=2`, `transform=3`
+  - `boundaryCloseness`, `tectonicStress`, `upliftPotential`, `riftPotential`, `shieldStability` (`Uint8Array`, `0..255`):
+    - closeness/stress are higher near boundaries
+    - uplift is higher at convergent boundaries
+    - rift is higher at divergent boundaries
+    - shield stability is higher in plate interiors (inverse of stress)
+  - `movementU`, `movementV`, `rotation` (`Int8Array`, `-127..127`): relative motion/rotation proxies (units may evolve).
+
+- **Dynamics (`ctx.foundation.dynamics`)**
+  - `windU`, `windV`, `currentU`, `currentV` (`Int8Array`, `-127..127`): coarse vector components.
+    - In the current implementation, negative `U` indicates westward flow and positive `U` indicates eastward flow.
+  - `pressure` (`Uint8Array`, `0..255`): normalized mantle-pressure proxy (relative, unitless).
+
+- **Plate seed (`ctx.foundation.plateSeed`)**
+  - Optional (`null` allowed). When present, contains a `SeedSnapshot` suitable for reproducing plate layouts and diagnostic logging.
+
+- **Config snapshot (`ctx.foundation.config`)**
+  - Shallow-frozen snapshot of config inputs that informed the run (`seed`, `plates`, `dynamics`, `surface`, `policy`, `diagnostics`).
+  - Intended for reproducibility and diagnostics; treat as read-only.
+
+- **Diagnostics (`ctx.foundation.diagnostics`)**
+  - Debug-only surface; explicitly non-stable (shape may change).
+  - Currently includes `boundaryTree` (often `null`).
+
+- **Guard rails**
+  - Stages that require foundation physics must call `assertFoundationContext(ctx, stageName)` (or equivalent) before reading tensors.
+  - Treat missing `FoundationContext` as a wiring/manifest error, not a recoverable “no-op”.
+
+## 4. Config → Tunables → MapOrchestrator → WorldModel → FoundationContext
 
 This section summarizes the **M2-era flow** that leads to `FoundationContext`. It intentionally focuses on
 contracts, not internal implementation details.
@@ -125,14 +130,12 @@ contracts, not internal implementation details.
 - Tunables are a **derived, read-only view**:
   - They must not be mutated by callers.
   - Their backing `MapGenConfig` comes from the last successful `bootstrap()` / `bindTunables()` call.
-- Future work (M3+) should treat tunables as:
-  - A **compatibility layer** for legacy code.
-  - Not the primary long-term config surface for new pipeline steps.
 
 ### 4.2 Orchestrator & World Model Flow
 
 - `MapOrchestrator` is constructed with a **validated `MapGenConfig`** and optional adapter options.
 - When running the `foundation` stage, the orchestrator:
+  - Refreshes the tunables snapshot for the generation pass (`resetTunables()` → `getTunables()`).
   - Creates an `ExtendedMapContext` with:
     - Dimensions from the Civ7 adapter or test defaults.
     - A lightweight runtime `ctx.config` object (currently: toggle flags) for legacy call sites.
@@ -148,7 +151,7 @@ contracts, not internal implementation details.
   - Map dimensions are missing or invalid.
   - Any required tensor is missing or has the wrong length.
 - On success:
-  - `ctx.foundation` is immutable and remains valid for the rest of the generation run.
+  - `ctx.foundation` is treated as immutable and remains valid for the rest of the generation run.
   - Downstream stages must treat it as read-only and may rely on its tensors to be internally consistent.
 
 ## 5. How to Use This Contract (M3+ Work)
@@ -158,19 +161,26 @@ When implementing M3+ issues (pipeline generalization, climate, story overlays):
 - **Do reference this doc** when:
   - Deciding which `requires`/`provides` contracts to declare for steps that depend on foundation physics.
   - Designing new data products (e.g., `ClimateField`, `StoryOverlays`) that build on plate/dynamics tensors.
-- **Do not treat it as immutable**:
-  - If you need additional guarantees or fields from foundation, add them to the code **and** update this contract.
+- **Do treat it as a consumer boundary**:
+  - If you need additional guarantees or fields, update the code **and** update this contract in the same change.
   - If you discover mismatches between this doc and the implementation, treat that as a bug in the doc and fix it.
-- **Promotion path**:
-  - Once `FoundationContext` usage stabilizes across M3/M4, we should:
-    - Move this contract (possibly refined) into `docs/system/libs/mapgen` as canonical architecture.
-    - Optionally introduce similar contract docs for other data products (`Heightfield`, `ClimateField`, `StoryOverlays`).
+- **Do not depend on non-contract surfaces**:
+  - Avoid reading raw `WorldModel` state (or a singleton `WorldModel`) in new work; treat `ctx.foundation` as the stable interface.
+  - Do not depend on `ctx.foundation.diagnostics` shape outside diagnostics tooling.
+  - Do not treat tunables as the long-term config surface for new steps.
 
-## 6. Proposed Extensions (Non-Canonical, To Review)
+See Sections 6–7 for non-binding planning notes and future enforcement ideas.
 
-> The ideas in this section are **proposals**, not decided architecture.  
-> They exist to seed discussion and planning for M3/M4. It is explicitly okay to
-> revise or discard them as we learn more.
+## 6. Appendix: Future Extensions (Non-Binding)
+
+> Everything in this section is **non-binding**.  
+> It exists to seed discussion and planning for M3/M4 and may change or be deleted freely.
+
+### 6.0 Promotion Path (Non-Binding)
+
+- Once `FoundationContext` usage stabilizes across M3/M4, consider:
+  - Moving a refined version of this contract into `docs/system/libs/mapgen`.
+  - Splitting “contract” from “design sandbox” material if it becomes noisy for consumers.
 
 ### 6.1 Proposed Step Contracts on Top of FoundationContext
 
@@ -253,3 +263,13 @@ be confident that:
 
 Until then, treat this section as a **design sandbox**: useful for planning and coordination,
 but not authoritative.
+
+## 7. How This Could Be Enforced (Non-Binding)
+
+We do **not** enforce this contract yet. If/when we choose to enforce it, candidates include:
+
+- **Unit invariants:** tests for `createFoundationContext` failure modes (missing tensors, size mismatch) and success invariants (lengths, boundaryType enum range).
+- **Integration invariants:** run a minimal `MapOrchestrator` pass and assert `ctx.foundation` availability + invariants for typical map sizes.
+- **Determinism checks:** for fixed seeds/configs, compare `FoundationContext` tensors across runs to detect accidental drift.
+- **Mutation guards:** copy tensors into new typed arrays (true snapshot) and/or introduce readonly tensor wrappers to prevent accidental writes.
+- **CI + review gates:** require updating this doc when `FoundationContext` / `createFoundationContext` changes; consider linting against new code reading a global `WorldModel` instead of `ctx.foundation`.

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
@@ -15,14 +15,14 @@ M2 is effectively concluded as a **“config + foundation slice is stable, docum
 Before calling M2 fully done, we will land a small, concrete cleanup/stabilization batch:
 
 - **Docs alignment**
-  - Update M2 docs and relevant issue files so they accurately describe the real flow: `bootstrap() → MapGenConfig → tunables → MapOrchestrator → FoundationContext`.
+  - Update M2 docs and relevant issue files so they accurately describe the real flow: `bootstrap() → validated MapGenConfig → tunables → MapOrchestrator → FoundationContext`.
   - Remove or clearly mark as “future” any remaining references to `globalThis.__EPIC_MAP_CONFIG__` and the old global-config pattern.
   - Soften or relocate language that assumes a currently implemented generic `PipelineExecutor` / `MapGenStep` / `StepRegistry`, making clear that these land in M3+.
 - **Stable‑slice config surface**
   - Align schema/docs with stable‑slice keys already meaningful in M2 (foundation diagnostics flags, story‑driven rainfall knobs) and decide parity vs. deprecate for any diagnostics aliases.
 - **Contract stabilization**
   - Make the `FoundationContext` contract explicit: what it guarantees to downstream consumers and which data products exist at the end of the M2 slice (captured in `resources/CONTRACT-foundation-context.md` as a working contract doc).
-  - Clarify the role of tunables as a derived, read-only view over `MapGenConfig`, not a primary config store.
+  - Clarify the role of tunables as a derived, read-only view over validated `MapGenConfig`, not a primary config store.
 - **Tests**
   - Add at least one end-to-end `MapOrchestrator.generateMap` smoke test using a minimal/default `MapGenConfig` and a stub adapter, asserting that:
     - Foundation data products are populated as expected.

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
@@ -504,3 +504,33 @@ This task is a good M2 compromise: it restores story‑driven consumer behavior 
 - **Globals coupling:** acknowledged; tracked under `docs/projects/engine-refactor-v1/issues/LOCAL-M3-story-system.md` as part of step/task‑graph migration (no M2 change required).  
 - **Regression harness:** added to project backlog in `docs/projects/engine-refactor-v1/triage.md` (“Add minimal story parity regression harness”).  
 - **Orogeny belts:** explicitly deferred out of M2 in `docs/projects/engine-refactor-v1/issues/CIV-36-story-parity.md` and `docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md`; backlog entry exists in `docs/projects/engine-refactor-v1/triage.md`.
+
+---
+
+## CIV-34 – FoundationContext Contract + Config → Tunables → World-Model Flow Doc
+
+**Quick Take**  
+Yes for M2. The `FoundationContext` contract is explicit, grounded in the actual M2 implementation, and centrally documents the config→tunables→orchestrator→world-model flow in a way that M3 work can safely reference without re-deriving intent from code.
+
+**Intent & Assumptions**  
+- Deliver an M2 “binding” contract for what `ctx.foundation` guarantees after the foundation stage.  
+- Document the canonical “stable slice” wiring (`bootstrap → MapGenConfig → tunables → MapOrchestrator → WorldModel → FoundationContext`).  
+- Clarify tunables as a derived, read-only view over validated `MapGenConfig` (not a primary config store).
+
+**What’s Strong**  
+- `docs/projects/engine-refactor-v1/resources/CONTRACT-foundation-context.md` cleanly separates binding guarantees (shape/semantics/invariants) from non-binding planning notes, which reduces future ambiguity.  
+- The contract matches the code surfaces that matter for M2 consumers (`createFoundationContext` fail-fast validation; `MapOrchestrator.initializeFoundation` building the snapshot from WorldModel and tunables).  
+- Project-level docs already point to the contract (`PROJECT-engine-refactor-v1.md`, `milestones/M2-stable-engine-slice.md`, `triage.md`), which makes it discoverable for M3+.
+
+**High-Leverage Issues**  
+- **The contract doc mixes “binding” and “planning” in one file.**  
+  This is currently well-labeled, but it is a drift risk as M3 evolves: non-binding content tends to accrete and can blur what is actually guaranteed. Direction: keep Sections 1–5 strict and minimal; consider moving Sections 6–7 into a separate “design notes” doc once M3 starts landing step contracts. (Follow-up)  
+- **Typed-array immutability is a convention, not enforced.**  
+  The doc correctly warns consumers not to mutate tensor contents; the code freezes the object graph but cannot deep-freeze typed arrays. Direction: add a small “consumer contract” test or lint-style guideline that catches accidental mutation in new steps, once step migration begins. (Nice-to-have)
+
+**Fit Within the Milestone**  
+This is the right kind of “stabilize the consumer boundary” work for M2: it codifies the minimum reliable interface (`FoundationContext`) without forcing premature pipeline abstractions. It also cleanly reinforces M2’s sequencing decision that tunables are transitional/view-layer plumbing.
+
+**Recommended Next Moves (Future Work, Not M2)**  
+1. Promote the binding portion of the contract into `docs/system/libs/mapgen/` once the `FoundationContext` shape stabilizes across early M3 steps.  
+2. Add one small integration check that asserts the contract’s invariants (tensor lengths, nullability rules) across a couple of canonical seeds.

--- a/docs/projects/engine-refactor-v1/triage.md
+++ b/docs/projects/engine-refactor-v1/triage.md
@@ -16,6 +16,12 @@ Milestone and issue docs remain canonical for scheduled/active scope; entries he
 
 ## Triage (needs decision / research)
 
+- **Revisit `FoundationContext` contract doc structure & enforcement** [Review by: end of M3]
+  - **Context:** M2 stable-slice contract at `resources/CONTRACT-foundation-context.md` (CIV-34 follow-up).
+  - **Type:** triage
+  - **Notes:** Re-evaluate whether to split into (1) a crisp, binding contract doc and (2) a separate aspirations/planning doc; tighten semantics as more M3 consumers land; implement enforcement ideas outlined in the contract doc (tests/CI/mutation guards) when the interface stabilizes.
+  - **Next check:** after the first real M3 consumer steps ship (e.g., climate baseline) or at the end of M3.
+
 ## Backlog (definite, unsequenced)
 
 - **Modern story orogeny layer (windward/lee amplification)** [Review by: early M3+]

--- a/docs/projects/engine-refactor-v1/triage.md
+++ b/docs/projects/engine-refactor-v1/triage.md
@@ -24,6 +24,12 @@ Milestone and issue docs remain canonical for scheduled/active scope; entries he
 
 ## Backlog (definite, unsequenced)
 
+- **Full MapGen architecture documentation sweep (post Task Graph / canonical products)** [Review by: late M3 / early M4]
+  - **Context:** System docs at `docs/system/libs/mapgen/*.md` vs implementation once `PipelineExecutor` / `MapGenStep` / `StepRegistry` and canonical products stabilize.
+  - **Type:** backlog
+  - **Notes:** Larger pass to fully reconcile “current vs target” details across canonical system docs (e.g., `architecture.md`, `foundation.md`, `climate.md`, plus adjacent system pages as needed), removing remaining mismatches once the M3 architecture lands. This is explicitly **not** part of `LOCAL-M3-SYSTEM-DOCS-TARGET-VS-CURRENT` (which only adds framing + minimal current-state pointers).
+  - **Next check:** after Task Graph + step execution is implemented and key products (`FoundationContext`, `ClimateField`, `StoryOverlays`) are stabilized.
+
 - **Modern story orogeny layer (windward/lee amplification)** [Review by: early M3+]
   - **Context:** M2 / `CIV-36` minimal story parity deferred orogeny; `CIV-39` orogeny tunables promotion explicitly deferred in 2025‑12‑12 discussion.
   - **Type:** backlog


### PR DESCRIPTION
docs(engine-refactor-v1): align FoundationContext contract with code

- clarify that ctx.config is a lightweight toggle-only view, not the validated MapGenConfig\n- remove implication that FoundationContext is stored on WorldModel\n- fix heightfield buffer timing (sync occurs after terrain stages)

docs(engine-refactor-v1): clarify tunables as validated view

docs(engine-refactor-v1): mark CIV-34 complete