### PR TITLE
docs(mapgen): clarify target vs current guidance

### DIFF
--- a/docs/projects/engine-refactor-v1/issues/CIV-40-system-docs-target-vs-current.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-40-system-docs-target-vs-current.md
@@ -1,5 +1,5 @@
 ---
-id: LOCAL-M3-SYSTEM-DOCS-TARGET-VS-CURRENT
+id: CIV-40
 title: "[M3] Clarify MapGen system docs: Target vs Current (post-M2)"
 state: planned
 priority: 4

--- a/docs/projects/engine-refactor-v1/issues/CIV-40-system-docs-target-vs-current.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-40-system-docs-target-vs-current.md
@@ -40,11 +40,11 @@ Add an explicit “Target vs Current implementation” framing to the canonical 
 
 ## Acceptance Criteria
 
-- [ ] `docs/system/libs/mapgen/architecture.md` clearly labels “Target” vs “Current” guidance and points readers to project docs for post‑M2 reality where appropriate.
-- [ ] `docs/system/libs/mapgen/foundation.md` includes a clear “Current implementation (post‑M2)” subsection and links to the M2 contract + project snapshot docs.
-- [ ] `docs/system/libs/mapgen/climate.md` includes a clear “Current implementation (post‑M2)” subsection and links to the M2 contract + project snapshot docs.
-- [ ] The added “Current” sections are short, scoped, and explicitly described as transient.
-- [ ] The target architecture sections remain canonical and are not rewritten to mirror current code line-by-line.
+- [x] `docs/system/libs/mapgen/architecture.md` clearly labels “Target” vs “Current” guidance and points readers to project docs for post‑M2 reality where appropriate.
+- [x] `docs/system/libs/mapgen/foundation.md` includes a clear “Current implementation (post‑M2)” subsection and links to the M2 contract + project snapshot docs.
+- [x] `docs/system/libs/mapgen/climate.md` includes a clear “Current implementation (post‑M2)” subsection and links to the M2 contract + project snapshot docs.
+- [x] The added “Current” sections are short, scoped, and explicitly described as transient.
+- [x] The target architecture sections remain canonical and are not rewritten to mirror current code line-by-line.
 
 ## Out of Scope
 

--- a/docs/projects/engine-refactor-v1/triage.md
+++ b/docs/projects/engine-refactor-v1/triage.md
@@ -27,7 +27,7 @@ Milestone and issue docs remain canonical for scheduled/active scope; entries he
 - **Full MapGen architecture documentation sweep (post Task Graph / canonical products)** [Review by: late M3 / early M4]
   - **Context:** System docs at `docs/system/libs/mapgen/*.md` vs implementation once `PipelineExecutor` / `MapGenStep` / `StepRegistry` and canonical products stabilize.
   - **Type:** backlog
-  - **Notes:** Larger pass to fully reconcile “current vs target” details across canonical system docs (e.g., `architecture.md`, `foundation.md`, `climate.md`, plus adjacent system pages as needed), removing remaining mismatches once the M3 architecture lands. This is explicitly **not** part of `LOCAL-M3-SYSTEM-DOCS-TARGET-VS-CURRENT` (which only adds framing + minimal current-state pointers).
+  - **Notes:** Larger pass to fully reconcile “current vs target” details across canonical system docs (e.g., `architecture.md`, `foundation.md`, `climate.md`, plus adjacent system pages as needed), removing remaining mismatches once the M3 architecture lands. This is explicitly **not** part of `CIV-40` (which only adds framing + minimal current-state pointers).
   - **Next check:** after Task Graph + step execution is implemented and key products (`FoundationContext`, `ClimateField`, `StoryOverlays`) are stabilized.
 
 - **Modern story orogeny layer (windward/lee amplification)** [Review by: early M3+]

--- a/docs/system/libs/mapgen/architecture.md
+++ b/docs/system/libs/mapgen/architecture.md
@@ -1,6 +1,22 @@
 # Map Generation Engine Architecture
 
-> This document describes the **target** architecture for the MAPS engine. The current implementation is converging toward this design; some details (such as the generic Pipeline Executor and full step registry) may be introduced incrementally across milestones.
+> This document describes the **target** architecture for the MAPS engine.
+
+## Status (Target vs Current)
+
+This page intentionally mixes:
+
+- **Target architecture (canonical):** the Task Graph / `MapGenStep` / `StepRegistry` direction we are steering toward.
+- **Current implementation (post‑M2, transient):** the orchestrator‑centric stable slice used today while M3/M4 land.
+
+When you need “what’s actually wired right now,” prefer the project snapshot docs:
+
+- `docs/projects/engine-refactor-v1/status.md`
+- `docs/projects/engine-refactor-v1/PROJECT-engine-refactor-v1.md`
+- `docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md`
+- `docs/projects/engine-refactor-v1/resources/CONTRACT-foundation-context.md`
+
+**Important:** `PipelineExecutor` / the generic step registry are **target**, not universally present in the current codebase yet.
 
 ## 1. Core Philosophy
 

--- a/docs/system/libs/mapgen/climate.md
+++ b/docs/system/libs/mapgen/climate.md
@@ -1,5 +1,7 @@
 # Climate & Hydrology Stage Architecture
 
+> **Target vs Current (post‑M2):** This doc describes the target Climate/Hydrology design. The current M2 stable slice is orchestrator‑centric and is intentionally transient while M3 introduces step/task‑graph execution and canonical products.
+
 ## 1. Overview
 
 The **Climate & Hydrology Stage** follows the Foundation and Morphology phases. Its responsibility is to simulate the atmospheric and hydrological processes that determine the habitability of the map.
@@ -11,6 +13,17 @@ This stage transforms the physical board (Elevation, Landmasses) into a living w
 2.  **Regional Weather:** Apply localized weather systems (Monsoons, Trade Winds) via configurable "Swatches".
 3.  **Orographic Physics:** Simulate the interaction between wind and terrain to create rain shadows and moisture gradients.
 4.  **Hydrology:** Route water downhill to form rivers, lakes, and erosion patterns.
+
+### Current implementation (post‑M2)
+
+In the current stable slice, climate/hydrology behavior is executed via orchestrator stages and TS layers, not a fully generic `MapGenStep` registry yet.
+
+Source of truth for what is wired today:
+
+- `docs/projects/engine-refactor-v1/status.md`
+- `docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md`
+- `docs/projects/engine-refactor-v1/PROJECT-engine-refactor-v1.md`
+- Relevant M2 story/climate config surfaces (e.g., `docs/projects/engine-refactor-v1/issues/CIV-39-config-surface-alignment.md`)
 
 ---
 

--- a/docs/system/libs/mapgen/foundation.md
+++ b/docs/system/libs/mapgen/foundation.md
@@ -1,5 +1,7 @@
 # Foundation Stage Architecture
 
+> **Target vs Current (post‑M2):** This doc describes the target Foundation design. The current M2 stable slice is an orchestrator‑centric bridge and is intentionally transient while M3 introduces step/task‑graph execution.
+
 ## 1. Overview
 
 The **Foundation Stage** is the first major phase of the map generation pipeline. Its responsibility is to construct the physical "board" (Mesh), the geological material (Crust), and the tectonic "pieces" (Plates) that drive all downstream morphology.
@@ -11,6 +13,17 @@ Unlike legacy approaches that rely on grid-based noise or nearest-neighbor heuri
 2.  **Crust Generation:** Define the material properties of the world (Continental vs. Oceanic) independent of plate boundaries.
 3.  **Partitioning:** Group mesh cells into tectonic plates with distinct kinematic properties (Velocity, Rotation).
 4.  **Tectonics:** Simulate physical interactions (Subduction, Orogeny, Rifting) by intersecting the Plate Graph with the Crust Mask.
+
+### Current implementation (post‑M2)
+
+For M2, the stable slice is wired through `MapOrchestrator` + staged layers and publishes a **read‑only `FoundationContext` snapshot** to downstream consumers.
+
+Source of truth for the current slice:
+
+- `docs/projects/engine-refactor-v1/resources/CONTRACT-foundation-context.md` (binding M2 contract)
+- `docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md`
+- `docs/projects/engine-refactor-v1/status.md`
+- Implementation entrypoints under `packages/mapgen-core/src` (orchestrator + foundation bootstrap)
 
 ---
 


### PR DESCRIPTION
docs(mapgen): clarify target vs current guidance

- Add explicit Target vs Current framing to mapgen system docs\n- Point current-state readers to engine-refactor-v1 contract/status docs\n- Rename local issue doc to CIV-40

docs(engine-refactor): mark CIV-40 complete