### PR TITLE
docs(engine-refactor-v1): align M2 docs with implemented slice

### DIFF
--- a/docs/projects/engine-refactor-v1/PROJECT-engine-refactor-v1.md
+++ b/docs/projects/engine-refactor-v1/PROJECT-engine-refactor-v1.md
@@ -46,7 +46,7 @@ This document is the **directional project brief** for **MAPS Engine Refactor v1
 - **Narrative overlays:** ⏳ Not modernized. Margin overlays exist, but other story passes still mutate `StoryTags` directly and do not publish immutable overlays.
 - **Biomes/features/placement:** ⏳ Legacy read paths (`GameplayMap` + `StoryTags`). No overlay/`ClimateField` consumption yet.
 - **Manifest enforcement:** ⏳ Manifest describes `requires`/`provides`, but no runtime validator for data products; legacy shims still allow silent drift.
-- **Tests/verification:** ⏳ No automated smoke for the orchestrator/context; verification is manual via diagnostics.
+- **Tests/verification:** ⚠️ Partial. There is basic automated coverage for the stable slice (orchestrator integration + foundation smoke); broader validation remains manual and will be expanded in Milestone 4.
 - **TypeScript migration:** ⚠️ Largely complete for core engine and Swooper Maps entrypoints, but some shims/edge modules remain and need cleanup and tests (see `milestones/M1-TS-typescript-migration.md`).
 
 ## 4. Milestone Plan

--- a/docs/projects/engine-refactor-v1/issues/CIV-33-docs-alignment.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-33-docs-alignment.md
@@ -31,10 +31,10 @@ Update M2 project docs and related issue files so they accurately describe the r
 
 ## Acceptance Criteria
 
-- [ ] `docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md` summary/scope/objectives describe the orchestrator-centric M2 slice and do not promise a fully generic `PipelineExecutor` in this milestone.
-- [ ] `docs/projects/engine-refactor-v1/PROJECT-engine-refactor-v1.md` describes M2 as “config + foundation slice, documented, test-backed” and defers the task-graph primitives to M3.
-- [ ] `docs/projects/engine-refactor-v1/status.md` marks the config + foundation slice as done and lists pipeline primitives + ClimateField/StoryOverlays evolution under “Ready Next” / M3.
-- [ ] Any remaining references to `globalThis.__EPIC_MAP_CONFIG__` in project docs or engine-refactor issues are removed or clearly marked as historical/future.
+- [x] `docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md` summary/scope/objectives describe the orchestrator-centric M2 slice and do not promise a fully generic `PipelineExecutor` in this milestone.
+- [x] `docs/projects/engine-refactor-v1/PROJECT-engine-refactor-v1.md` describes M2 as “config + foundation slice, documented, test-backed” and defers the task-graph primitives to M3.
+- [x] `docs/projects/engine-refactor-v1/status.md` marks the config + foundation slice as done and lists pipeline primitives + ClimateField/StoryOverlays evolution under “Ready Next” / M3.
+- [x] Any remaining references to `globalThis.__EPIC_MAP_CONFIG__` in project docs or engine-refactor issues are removed or clearly marked as historical/future.
 
 ## Testing / Verification
 
@@ -55,4 +55,3 @@ Update M2 project docs and related issue files so they accurately describe the r
 
 - Focus on project-level docs under `docs/projects/engine-refactor-v1/` plus the engine-refactor status snapshot.
 - Avoid over-describing current limitations in the system architecture docs; keep them focused on target shape with a light heads-up where needed.
-

--- a/docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md
+++ b/docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md
@@ -121,7 +121,7 @@ These may be split or reassigned across milestones as we refine the execution pl
   - **Final M2 cleanup/stabilization batch (to land before calling the milestone fully done):**
   - **Docs alignment**
     - Update M2 docs and issue files so they accurately describe the current flow: `bootstrap() → validated MapGenConfig → tunables → MapOrchestrator → FoundationContext`, and remove or soften wording that assumes an already-implemented `PipelineExecutor` / `MapGenStep` / `StepRegistry`.
-    - Remove or clearly mark as “future” any remaining references to `globalThis.__EPIC_MAP_CONFIG__` and the old global config pattern.
+    - Treat `globalThis.__EPIC_MAP_CONFIG__` as historical (removed); avoid reintroducing it in docs and clearly label any mentions as “pre-M2”.
   - **Contract stabilization**
     - Make the `FoundationContext` contract explicit: what it guarantees to downstream consumers, and which data products exist at the end of the M2 slice (see `resources/CONTRACT-foundation-context.md` as the working contract doc).
     - Clarify the role of tunables as a view over validated `MapGenConfig` (derived/read-only perspective) rather than a primary config store.

--- a/docs/projects/engine-refactor-v1/resources/PRD-config-refactor.md
+++ b/docs/projects/engine-refactor-v1/resources/PRD-config-refactor.md
@@ -13,6 +13,8 @@ The goal is to move from the current multi-layer, global, tunables-driven config
 2. Then align config usage with the new **Task Graph / Foundation pipeline**.
 3. Finally reshape the external config surface and mod entrypoints to match the long-term architecture (flat, recipe-friendly, per-step config).
 
+**Status (M2):** Phase 1 (“config hygiene”) is now implemented: configs are validated via `parseConfig()` and injected into the orchestrator (no `globalThis.__EPIC_MAP_CONFIG__`). Remaining phases in this PRD describe the *future* shape evolution and pipeline integration work (M3+).
+
 ---
 
 ## 2. Problem Statement
@@ -28,7 +30,7 @@ The current configuration system (as described in `SPIKE-config-refactor-design.
    - Defaults repeated in types, tunables, and layer functions (e.g., `buildMountainOptions()` plus inline defaults inside `layerAddMountainsPhysics()`).
 
 3. **Global state & bootstrap coupling**
-   - Config stored and merged via globals (`globalThis.__EPIC_MAP_CONFIG__`) and bootstrap helpers.
+   - Pre-M2: Config stored and merged via globals (`globalThis.__EPIC_MAP_CONFIG__`) and bootstrap helpers.
    - This conflicts with the pipeline architecture, which expects explicit `MapGenContext.config` injected at the boundary.
 
 4. **Weak runtime validation**

--- a/docs/projects/engine-refactor-v1/resources/PRD-plate-generation.md
+++ b/docs/projects/engine-refactor-v1/resources/PRD-plate-generation.md
@@ -68,7 +68,8 @@ Implementers should refer to `foundation.md` for the specific math behind Lloyd 
 *   Implement `TectonicEngine` (Vector Physics with Material-Aware Interactions).
 
 ### Phase 3: Integration
-*   Wire the strategies into the `MapOrchestrator` via the new `StepRegistry`.
+*   Wire the strategies into the current `MapOrchestrator`-centric stable slice (M2).
+*   (Later, M3+) Wrap these strategies as `MapGenStep`s and register them via `StepRegistry` / `PipelineExecutor` once pipeline primitives exist.
 *   Implement the "Legacy Bridge" to sync the new `context.artifacts` to the old `WorldModel` singleton (to keep downstream morphology scripts working).
 
 ---

--- a/docs/projects/engine-refactor-v1/resources/STATUS-M-TS-parity-matrix.md
+++ b/docs/projects/engine-refactor-v1/resources/STATUS-M-TS-parity-matrix.md
@@ -131,7 +131,7 @@ Detractions / Open Questions:
 
 | JS Module | TS Equivalent | Status | Notes |
 |----------|---------------|--------|-------|
-| `bootstrap/runtime.js` | `packages/mapgen-core/src/bootstrap/runtime.ts` | Parity (TS+ evolution) | TS keeps the same global-key runtime store (`__EPIC_MAP_CONFIG__`) with shallow-frozen per-map config, but adds `resetConfig()` and strong `MapConfig` typing. Behavior is equivalent for `setConfig`/`getConfig`, with better testability. |
+| `bootstrap/runtime.js` | `packages/mapgen-core/src/bootstrap/runtime.ts` | Removed (M2) | TS no longer keeps a global runtime store (`__EPIC_MAP_CONFIG__`). `runtime.ts` is now a type re-export only; config is injected via `bootstrap()`/`parseConfig()` and bound to tunables via `bindTunables()`. |
 
 ---
 
@@ -139,7 +139,7 @@ Detractions / Open Questions:
 
 | JS Module | TS Equivalent | Status | Notes |
 |----------|---------------|--------|-------|
-| `bootstrap/entry.js` | `packages/mapgen-core/src/bootstrap/entry.ts` | Parity (TS+ evolution) | TS `bootstrap()` composes `presets` + `overrides` + `stageConfig` and stores them via `setConfig`, like JS. It additionally resolves `stageConfig` into a concrete `stageManifest` and validates overrides against it, then rebinds tunables. This is a superset of the JS helper. |
+| `bootstrap/entry.js` | `packages/mapgen-core/src/bootstrap/entry.ts` | Evolved (M2) | TS `bootstrap()` composes `presets` + `overrides` + `stageConfig`, resolves a `stageManifest`, validates overrides, then returns a validated `MapGenConfig` (`parseConfig`) and binds tunables (`bindTunables`). Callers pass the validated config explicitly to `MapOrchestrator`. |
 
 Detractions / Open Questions:
 - None obvious; the main decision is how mod-level entries discover TS presets (see 5.7).

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M2-stable-engine-slice.md
@@ -507,6 +507,36 @@ This task is a good M2 compromise: it restores story‑driven consumer behavior 
 
 ---
 
+## CIV-33 – Align M2 Project Docs with Implemented Config + Foundation Slice
+
+**Quick Take**  
+Yes for M2. The project-level milestone, brief, and status snapshot now consistently describe the actual post‑M2 flow (`bootstrap() → validated MapGenConfig → tunables → MapOrchestrator → FoundationContext`) and explicitly defer generic pipeline primitives (`PipelineExecutor` / `MapGenStep` / `StepRegistry`) to M3+.
+
+**Intent & Assumptions**  
+- Align `docs/projects/engine-refactor-v1/` docs to describe the orchestrator-centric M2 slice, not the target Task Graph architecture.  
+- Ensure legacy global-config patterns are not described as current behavior.  
+- Treat system docs (`docs/system/libs/mapgen/*`) as canonical *target* architecture and avoid turning them into temporal status logs.
+
+**What’s Strong**  
+- `docs/projects/engine-refactor-v1/milestones/M2-stable-engine-slice.md` cleanly frames the milestone boundary around the current `MapOrchestrator` slice and calls out pipeline primitives as deferred work.  
+- `docs/projects/engine-refactor-v1/PROJECT-engine-refactor-v1.md` and `docs/projects/engine-refactor-v1/status.md` match that framing, placing `PipelineExecutor`/steps/registry under M3+ “Ready Next” work.  
+- Remaining mentions of `globalThis.__EPIC_MAP_CONFIG__` in project docs/issues are framed as historical or “removed,” rather than implying it is still used today.
+
+**High-Leverage Issues**  
+- **Milestone doc still reads “Status: Planned”.**  
+  The content reads like an executed milestone definition and post‑mortem boundary note; leaving the status as Planned is confusing for readers using these docs as the system of record. Direction: either update the milestone status to reflect reality, or add a clear “this doc is a living plan; M2 is now complete” callout. (Follow-up)  
+- **Some historical `__EPIC_MAP_CONFIG__` mentions remain outside project docs.**  
+  Example: `docs/system/mods/swooper-maps/architecture.md` still mentions the global config store. This is not a CIV‑33 blocker (scope is project docs/issues), but it’s a predictable source of confusion until CIV‑40’s “Target vs Current” framing is consistently applied. (Follow-up)
+
+**Fit Within the Milestone**  
+This is high‑leverage “close the loop” work for M2: it prevents the docs from promising M3 architecture early and keeps the stable slice definition aligned with what is actually shipped today.
+
+**Recommended Next Moves (Future Work, Not M2)**  
+1. As part of CIV‑40, add explicit “Current (post‑M2)” pointers/banners in system docs where they currently read like an implementation guide.  
+2. Add a lightweight docs checklist (or `rg`-based guard) to prevent reintroducing “pipeline primitives already wired” language into M2 status/brief docs.
+
+---
+
 ## CIV-34 – FoundationContext Contract + Config → Tunables → World-Model Flow Doc
 
 **Quick Take**  

--- a/docs/projects/engine-refactor-v1/status.md
+++ b/docs/projects/engine-refactor-v1/status.md
@@ -6,13 +6,14 @@
 - Deterministic `PlateSeedManager` + `FoundationContext` exported and asserted; `foundation.*` config unified and legacy `worldModel` overrides warned away.
 - Heightfield buffers in `MapContext`; landmass, coasts, mountains, volcanoes, lakes, and climate baseline/refine write through staging helpers.
 - `[Foundation]` diagnostics cover seed/plate/dynamics/surface plus ASCII/histograms.
+- Basic automated coverage for the stable slice: orchestrator integration + foundation smoke tests in `packages/mapgen-core/test/orchestrator/*`.
 
 ## Gaps / In Progress
 - Climate consumers still read `GameplayMap` instead of `ClimateField`; river flow data not exposed as a product.
 - Narrative overlays are still largely unported: minimal parity (margins/hotspots/rifts ± orogeny) is now scoped for M2 (`CIV-36`), while corridors/swatches/paleo and canonical overlay products remain M3 work (`LOCAL-M3-STORY-SYSTEM`).
 - Biomes/features/placement read legacy fields and do not require overlays or `ClimateField` inputs.
 - No manifest/data-product validator; stages can still run without declared inputs beyond manual assertions.
-- No automated smoke tests for orchestrator/context; verification is manual via diagnostics.
+- Test coverage is still thin outside the stable slice; most verification remains manual via diagnostics.
 
 ## Ready Next
 1. Restore minimal story parity (margins/hotspots/rifts ± orogeny) via orchestrator stages so narrative‑aware consumers react again (M2).
@@ -27,4 +28,4 @@
 
 ## Testing & Observability
 - Existing: `[Foundation]` logs, stage gating warnings, ASCII diagnostics (landmass, relief, rainfall, biomes), histograms.
-- Needed: Vitest smoke for orchestrator using stub adapter and presets; assertions that `FoundationContext`/`Heightfield`/`ClimateField`/`StoryOverlays` are present before stages execute.
+- Needed: Expand Vitest coverage beyond the stable slice; add invariant checks for `FoundationContext`/`Heightfield`/`ClimateField`/`StoryOverlays` at stage boundaries.


### PR DESCRIPTION
docs(engine-refactor-v1): align M2 docs with implemented slice

- clarify M2 stable slice as orchestrator-centric and test-backed
- mark global config pattern as historical/removed
- update PRD notes to reflect M3+ pipeline primitives

docs(engine-refactor-v1): mark CIV-33 complete