### PR TITLE
chore(mod-swooper-maps): clean maps outdir and rename chunks

### DIFF
--- a/mods/mod-swooper-maps/package.json
+++ b/mods/mod-swooper-maps/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@civ7/types": "workspace:*",
+    "esbuild": "^0.27.0",
     "tsup": "^8.3.0",
     "typescript": "^5.9.2"
   }

--- a/mods/mod-swooper-maps/tsconfig.tsup.json
+++ b/mods/mod-swooper-maps/tsconfig.tsup.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["tsup.config.ts"]
+}

--- a/mods/mod-swooper-maps/tsup.config.ts
+++ b/mods/mod-swooper-maps/tsup.config.ts
@@ -5,7 +5,7 @@ import type { Plugin } from "esbuild";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 // Reuse mapgen-core’s TypeBox format shim to avoid Unicode regexes in Civ7’s V8 (built-in format validation is disabled).
-const typeboxFormatShim = join(__dirname, "../packages/mapgen-core/src/shims/typebox-format.ts");
+const typeboxFormatShim = join(__dirname, "../../packages/mapgen-core/src/shims/typebox-format.ts");
 const typeboxFormatPlugin: Plugin = {
   name: "typebox-format-shim",
   setup(build) {

--- a/packages/mapgen-core/package.json
+++ b/packages/mapgen-core/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "bun-types": "latest",
+    "esbuild": "^0.27.0",
     "tsup": "^8.3.0",
     "typescript": "^5.9.2"
   },

--- a/packages/mapgen-core/tsconfig.tsup.json
+++ b/packages/mapgen-core/tsconfig.tsup.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["tsup.config.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@civ7/types':
         specifier: workspace:*
         version: link:../../packages/civ7-types
+      esbuild:
+        specifier: ^0.27.0
+        version: 0.27.1
       tsup:
         specifier: ^8.3.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -228,6 +231,9 @@ importers:
       bun-types:
         specifier: latest
         version: 1.3.4
+      esbuild:
+        specifier: ^0.27.0
+        version: 0.27.1
       tsup:
         specifier: ^8.3.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)


### PR DESCRIPTION
# Fix TypeBox Format Shim Path and Add Build Configuration

- Add `esbuild` as a dev dependency to both `mod-swooper-maps` and `mapgen-core` packages
- Fix the path to TypeBox format shim in `mod-swooper-maps/tsup.config.ts`
- Add TypeScript configuration files for tsup in both packages
- Configure proper Node.js types for build scripts