### PR TITLE
feat(mapgen-core): implement Task Graph MVP with dependency tracking (CIV-41)

### DIFF
--- a/docs/projects/DOCS.md
+++ b/docs/projects/DOCS.md
@@ -1,0 +1,34 @@
+# Projects — Docs Hygiene
+
+This directory holds time-bound, project-scoped docs (milestones, issue specs, reviews, status, etc.).
+
+## Always record deferrals + follow-ups
+
+When you discover work that is **real** but **intentionally not done now**, record it immediately in the project’s:
+
+- `deferrals.md` for **intentional deferrals / temporary compatibility tradeoffs**
+  - Use this for “we’re living with X until Y happens” items.
+  - Include a **trigger** for when to revisit.
+- `triage.md` for **unsequenced follow-ups**
+  - Use **Triage** when a decision/research is needed.
+  - Use **Backlog** when the work is definite but not yet scheduled.
+
+Avoid leaving these only in:
+- PR review threads
+- milestone review docs
+- issue docs
+- chat logs
+
+Those are useful context, but `deferrals.md` + `triage.md` are the durable “don’t lose it” sinks.
+
+## Where to put things (quick rule)
+
+- If it’s a **temporary compromise** with an explicit revisit condition → `deferrals.md`
+- If it’s **work we should do later** but not scheduled → `triage.md`
+
+## Cross-linking
+
+When adding an entry:
+- Link back to the source issue/review/milestone doc that surfaced it.
+- If a triage item is derived from a deferral, reference the deferral ID.
+

--- a/docs/projects/engine-refactor-v1/deferrals.md
+++ b/docs/projects/engine-refactor-v1/deferrals.md
@@ -109,6 +109,21 @@ Each deferral follows this structure:
 
 ---
 
+## DEF-008: `state:engine.*` Dependency Tags Are Trusted (Not Runtime-Verified)
+
+**Deferred:** 2025-12-14  
+**Trigger:** When the engine adapter can reliably expose/verifiably report the relevant engine-side invariants (or when we stop depending on engine-surface state tags for gating).  
+**Context:** In M3, `PipelineExecutor` enforces `artifact:*` and `field:*` dependencies at runtime, but `state:engine.*` tags represent engine-surface guarantees that are not currently introspectable from the TS runtime. We intentionally treat these tags as trusted declarations to enable wrap-first steps without blocking on new adapter APIs.  
+**Scope:**
+- Define a verification strategy for `state:engine.*` dependencies (adapter queries, explicit step-owned checks, or replacing `state:*` tags with canonical artifacts where feasible).
+- Add a small set of runtime checks for the highest-risk `state:engine.*` tags once a strategy exists.
+- Document which `state:engine.*` tags are considered stable contracts vs transitional wiring.  
+**Impact:**
+- A misdeclared or stale `state:engine.*` dependency can bypass executor gating and fail later (or silently degrade output).
+- Contract correctness relies on discipline + review rather than runtime enforcement for this namespace in M3.
+
+---
+
 ## Resolved Deferrals
 
 *Move resolved deferrals here with resolution notes.*

--- a/docs/projects/engine-refactor-v1/issues/CIV-41-task-graph-mvp.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-41-task-graph-mvp.md
@@ -22,22 +22,22 @@ Implement Task Graph primitives (`MapGenStep`, `StepRegistry`, `PipelineExecutor
 
 ## Deliverables
 
-- [ ] Define `MapGenStep` contract (id/phase/requires/provides + run hooks) aligned with `docs/system/libs/mapgen/architecture.md`.
-- [ ] Implement `StepRegistry` (register/lookup steps by id; supports a “standard recipe”).
-- [ ] Implement `PipelineExecutor` (execute recipe; runtime gate `requires/provides`; deterministic logs/trace).
-- [ ] Define canonical dependency tags (the “spine”) used by `requires/provides` in M3, with explicit namespaces:
+- [x] Define `MapGenStep` contract (id/phase/requires/provides + run hooks) aligned with `docs/system/libs/mapgen/architecture.md`.
+- [x] Implement `StepRegistry` (register/lookup steps by id; supports a “standard recipe”).
+- [x] Implement `PipelineExecutor` (execute recipe; runtime gate `requires/provides`; deterministic logs/trace).
+- [x] Define canonical dependency tags (the “spine”) used by `requires/provides` in M3, with explicit namespaces:
   - `artifact:*` for canonical in-memory artifacts (e.g., `artifact:foundation`, `artifact:heightfield`, `artifact:climateField`, `artifact:storyOverlays`, `artifact:riverAdjacency`)
   - `field:*` for mutable canvas buffers when needed (e.g., `field:terrainType`, `field:elevation`)
   - `state:*` for engine-surface guarantees (e.g., `state:engine.riversModeled`, `state:engine.biomesApplied`, `state:engine.placementApplied`)
-- [ ] Register wrap-first steps for the current stage order (foundation → placement) using existing stage implementations so the executor can run an end-to-end mapgen without algorithm changes.
-- [ ] Add a standard pipeline entry that runs mapgen via the executor (keep the current orchestrator entry available during migration).
+- [x] Register wrap-first steps for the current stage order (foundation → placement) using existing stage implementations so the executor can run an end-to-end mapgen without algorithm changes.
+- [x] Add a standard pipeline entry that runs mapgen via the executor (keep the current orchestrator entry available during migration).
 
 ## Acceptance Criteria
 
-- [ ] The executor can run a “standard recipe” and produce a coherent map end-to-end (wrap-first; no algorithm changes).
-- [ ] Missing `requires` fails fast at runtime with a clear error (e.g., `MissingDependencyError`).
-- [ ] `requires/provides` keys are standardized and used consistently across subsequent M3 issues.
-- [ ] The legacy orchestrator entry path remains runnable until the M3 stack lands.
+- [x] The executor can run a “standard recipe” and produce a coherent map end-to-end (wrap-first; no algorithm changes).
+- [x] Missing `requires` fails fast at runtime with a clear error (e.g., `MissingDependencyError`).
+- [x] `requires/provides` keys are standardized and used consistently across subsequent M3 issues.
+- [x] The legacy orchestrator entry path remains runnable until the M3 stack lands.
 
 ## Testing / Verification
 

--- a/docs/projects/engine-refactor-v1/issues/CIV-41-task-graph-mvp.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-41-task-graph-mvp.md
@@ -74,6 +74,13 @@ Implement Task Graph primitives (`MapGenStep`, `StepRegistry`, `PipelineExecutor
 - `packages/mapgen-core/src/pipeline/` (new: executor + registry + step types; location TBD but keep cohesive)
 - `packages/mapgen-core/src/MapOrchestrator.ts` (modify: add executor entry path during transition)
 
+### Review Loop Notes (M3 Aggregate Review)
+
+- `generateMapTaskGraph()` surfaces executor throws as a structured `stageResults` entry (uses `stepId` when available).
+- Added a regression test for missing `requires` (enable `landmassPlates` while `foundation` is disabled).
+- Aligned `StageDescriptorSchema` wording with the canonical tag-only contract; documented the current trust model for `state:engine.*` tags.
+- Deferred (post-merge): deduplicate `PipelineExecutor.execute()` / `executeAsync()` logic; add runtime verification for `state:engine.*` tags (tracked as M4 follow-up in the M3 review).
+
 ### Design Notes
 
 - Prefer aligning with existing concepts:

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M3-core-engine-refactor-config-evolution.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M3-core-engine-refactor-config-evolution.md
@@ -1,0 +1,99 @@
+---
+id: M3-core-engine-refactor-config-evolution-review
+milestone: M3-core-engine-refactor-config-evolution
+title: "M3: Core Engine Refactor & Config Evolution — Aggregate Review"
+status: draft
+reviewer: AI agent (Codex CLI)
+---
+
+# M3: Core Engine Refactor & Config Evolution — Aggregate Review (Running Log)
+
+This running log captures task-level reviews for milestone M3. Entries focus on
+correctness, completeness, sequencing fit, and forward-looking risks.
+
+---
+
+## CIV-41 – Task Graph MVP: Pipeline Primitives + Standard Entry
+
+**Reviewed:** 2024-12-14 | **PR:** [#87](https://github.com/mateicanavra/civ7-modding-tools-fork/pull/87)
+
+### Effort Estimate
+
+**Complexity:** Low-Medium (2/4) — clear contract, minimal coordination, one new module tree with well-scoped integration into existing orchestrator.
+**Parallelism:** High (4/4) — no blockers; downstream M3 issues can proceed once this merges.
+**Score:** 3/16 — fast, low-risk foundational work.
+
+---
+
+### Quick Take
+
+**Yes:** CIV-41 meaningfully satisfies its acceptance criteria. The Task Graph primitives (`MapGenStep`, `StepRegistry`, `PipelineExecutor`) are implemented, runtime `requires`/`provides` gating with fail-fast errors is in place, the canonical dependency tag spine is defined, and a standard executor entry path is wired into `MapOrchestrator` via `useTaskGraph: true`. The legacy orchestrator path remains fully runnable.
+
+---
+
+### Intent & Assumptions
+
+- Land `MapGenStep`/`StepRegistry`/`PipelineExecutor` as the M3 execution spine (wrap-first, no algorithm changes).
+- Derive a "standard recipe" from `STAGE_ORDER` + resolved `stageManifest` enablement.
+- Keep orchestrator legacy entry runnable during transition.
+- Enforce runtime gating: missing `requires` → `MissingDependencyError`; unsatisfied `provides` → `UnsatisfiedProvidesError`.
+
+---
+
+### What's Strong
+
+- **Clean primitive design:** `MapGenStep<TContext>` is minimal and composable (`id`, `phase`, `requires`, `provides`, `shouldRun`, `run`). The type is generic over context, future-proofing for potential context extensions.
+- **Comprehensive error surface:** Six distinct error classes (`DuplicateStepError`, `UnknownStepError`, `InvalidDependencyTagError`, `UnknownDependencyTagError`, `MissingDependencyError`, `UnsatisfiedProvidesError`) provide precise failure messages.
+- **Tag namespace enforcement:** `validateDependencyTag()` enforces `artifact:*`, `field:*`, `state:engine.*` namespaces with regex validation + allowlist gating. This catches typos at registration time.
+- **Dual execution paths:** `PipelineExecutor.execute()` (sync) and `executeAsync()` exist; sync path errors on Promise return for safety.
+- **Provides verification:** After each step, concrete `provides` tags (foundation, storyOverlays, field:*) are checked against context state — not just trusted.
+- **Standard recipe integration:** `StepRegistry.getStandardRecipe(stageManifest)` filters by enabled stages; `generateMapTaskGraph()` registers all 21 stages as wrap-first steps.
+- **Smoke test:** `task-graph.smoke.test.ts` validates the executor entry path with a mock adapter.
+
+---
+
+### High-Leverage Issues
+
+1. **Code duplication between `execute()` and `executeAsync()`**
+   The two methods share ~95% logic. Consider extracting a shared `_runStep()` helper or using an async-first design with a sync wrapper.
+   *Impact:* Maintenance burden; easy to drift.
+   *Severity:* Low (cosmetic).
+
+2. **Placeholder steps with `shouldRun: () => false`**
+   `storyOrogeny`, `storyCorridorsPre`, `storySwatches`, `storyCorridorsPost` are registered but always skipped. They satisfy the issue's "register wrap-first steps" requirement, but downstream issues must remember to flip them on.
+   *Impact:* Acceptable for M3 scope; just needs tracking.
+
+3. **`provides` verification is partial**
+   Only `artifact:foundation`, `artifact:storyOverlays`, and `field:*` tags are verified post-run (lines 83–96 in `PipelineExecutor.ts`). `state:engine.*` tags are trusted because no context property exists to check them against. This is documented implicitly but not explicitly.
+   *Impact:* A step could declare `provides: ["state:engine.riversModeled"]` and not actually call the engine method. The executor won't catch it.
+   *Mitigation:* Acceptable for M3 (wrap-first); M4 should add engine-surface verification or explicit "trust markers."
+
+4. **`M3_STAGE_DEPENDENCY_SPINE` vs runtime registration mismatch risk**
+   The spine in `standard.ts` is the source of truth for `requires`/`provides`, but `generateMapTaskGraph()` pulls from `stageManifest.stages[stageName]` via `getStageDescriptor()`. If `resolveStageManifest()` doesn't correctly propagate spine data, contracts could diverge.
+   *Current state:* `resolveStageManifest()` does pull from `M3_STAGE_DEPENDENCY_SPINE` (lines 78–87 in `resolved.ts`), so this is correctly wired.
+
+5. **No integration test for `MissingDependencyError` path**
+   The smoke test only runs the happy path. A test that disables `foundation` but enables `landmassPlates` would validate the fail-fast gating.
+   *Impact:* Low risk (code is straightforward), but would increase confidence.
+
+---
+
+### Fit Within the Milestone
+
+CIV-41 is the correct Phase A foundational work. It unblocks Stacks 2–7:
+
+- **CIV-42–45:** Can now register steps that consume/produce canonical artifacts.
+- **CIV-46:** Config evolution can align with the executor's recipe model.
+- **CIV-47:** Adapter collapse can proceed once the executor is the primary path.
+
+No scope creep or backward push detected. The issue's "locked decisions" (recipe source of truth, runtime enforcement scope, mod-facing recipe surface, tag naming conventions) are all honored.
+
+---
+
+### Recommended Next Moves
+
+- **Nice-to-have (post-merge):** Add a unit test for `MissingDependencyError` gating.
+- **Nice-to-have (post-merge):** Deduplicate `execute()`/`executeAsync()` logic.
+- **Follow-up (M4):** Add verification for `state:engine.*` tags or document the trust model explicitly.
+- **Follow-up (CIV-42+):** Flip placeholder steps to real implementations as their issues land.
+

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M3-core-engine-refactor-config-evolution.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M3-core-engine-refactor-config-evolution.md
@@ -102,3 +102,9 @@ No scope creep or backward push detected. The issue's "locked decisions" (recipe
 - **Nice-to-have (post-merge):** Deduplicate `execute()`/`executeAsync()` logic.
 - **Follow-up (M4):** Add verification for `state:engine.*` tags or document the trust model explicitly.
 - **Follow-up (CIV-42+):** Flip placeholder steps to real implementations as their issues land.
+
+### Update
+
+- `generateMapTaskGraph()` now records a structured failure entry in `stageResults` when the executor throws (uses `stepId` when available).
+- Added a regression test for the missing-`requires` path (`landmassPlates` enabled while `foundation` is disabled).
+- Aligned `StageDescriptorSchema` wording to reflect tag-only `requires`/`provides` in M3 and note the current trust model for `state:engine.*`.

--- a/docs/projects/engine-refactor-v1/triage.md
+++ b/docs/projects/engine-refactor-v1/triage.md
@@ -32,6 +32,18 @@ Time-bound temporary compatibility tradeoffs live in `docs/projects/engine-refac
   - **Notes:** Larger pass to fully reconcile “current vs target” details across canonical system docs (e.g., `architecture.md`, `foundation.md`, `hydrology.md`, plus adjacent system pages as needed), removing remaining mismatches once the M3 architecture lands. This is explicitly **not** part of `CIV-40` (which only adds framing + minimal current-state pointers).
   - **Next check:** after Task Graph + step execution is implemented and key products (`FoundationContext`, `ClimateField`, `StoryOverlays`) are stabilized.
 
+- **Runtime verification strategy for `state:engine.*` dependency tags** [Review by: early M4]
+  - **Context:** `CIV-41` Task Graph MVP; deferral at `docs/projects/engine-refactor-v1/deferrals.md` (DEF-008).
+  - **Type:** backlog
+  - **Notes:** Decide how to validate `state:engine.*` tags (adapter queries, step-owned invariants, or eliminating `state:*` in favor of canonical artifacts where feasible). Add runtime checks for the highest-risk tags once a strategy exists.
+  - **Next check:** when engine adapter invariants are available or when the first M3 consumer step depends critically on `state:engine.*` correctness.
+
+- **Deduplicate `PipelineExecutor.execute()` / `executeAsync()` execution loops** [Review by: early M4]
+  - **Context:** `CIV-41` Task Graph MVP review follow-up.
+  - **Type:** backlog
+  - **Notes:** Reduce duplicated control flow while preserving deterministic trace/log ordering and the existing error semantics (fail-fast for missing dependencies).
+  - **Next check:** once M3 executor behavior stabilizes and before adding more step phases that would multiply duplicated logic.
+
 - **Modern story orogeny layer (windward/lee amplification)** [Review by: early M3+]
   - **Context:** M2 / `CIV-36` minimal story parity deferred orogeny; `CIV-39` orogeny tunables promotion explicitly deferred in 2025‑12‑12 discussion.
   - **Type:** backlog

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -530,90 +530,6 @@
         "serve.js"
       ]
     },
-    "mod:manage:deploy": {
-      "aliases": [],
-      "args": {},
-      "description": "Copies files from an input directory into Mods/[mod-id].",
-      "examples": [
-        "<%= config.bin %> mod manage deploy --input ./dist --id my_mod",
-        "<%= config.bin %> mod manage deploy -i mods/mod-swooper-maps/mod -m swooper-maps"
-      ],
-      "flags": {
-        "input": {
-          "char": "i",
-          "description": "Input directory of the mod files",
-          "name": "input",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "id": {
-          "char": "m",
-          "description": "Target mod id (directory name under Mods/)",
-          "name": "id",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "dir": {
-          "description": "Override Mods directory path",
-          "name": "dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "mod:manage:deploy",
-      "pluginAlias": "@mateicanavra/civ7-cli",
-      "pluginName": "@mateicanavra/civ7-cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Deploy a mod folder into the Civ7 Mods directory",
-      "enableJsonFlag": false,
-      "isESM": false,
-      "relativePath": [
-        "dist",
-        "commands",
-        "mod",
-        "manage",
-        "deploy.js"
-      ]
-    },
-    "mod:manage:list": {
-      "aliases": [],
-      "args": {},
-      "description": "Finds the Mods directory on this machine and lists subdirectories.",
-      "flags": {
-        "dir": {
-          "description": "Override Mods directory path",
-          "name": "dir",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "mod:manage:list",
-      "pluginAlias": "@mateicanavra/civ7-cli",
-      "pluginName": "@mateicanavra/civ7-cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "List locally installed Civ7 mods in the Mods directory",
-      "enableJsonFlag": false,
-      "isESM": false,
-      "relativePath": [
-        "dist",
-        "commands",
-        "mod",
-        "manage",
-        "list.js"
-      ]
-    },
     "git:subtree:clear": {
       "aliases": [],
       "args": {},
@@ -1110,6 +1026,90 @@
         "git",
         "subtree",
         "update.js"
+      ]
+    },
+    "mod:manage:deploy": {
+      "aliases": [],
+      "args": {},
+      "description": "Copies files from an input directory into Mods/[mod-id].",
+      "examples": [
+        "<%= config.bin %> mod manage deploy --input ./dist --id my_mod",
+        "<%= config.bin %> mod manage deploy -i mods/mod-swooper-maps/mod -m swooper-maps"
+      ],
+      "flags": {
+        "input": {
+          "char": "i",
+          "description": "Input directory of the mod files",
+          "name": "input",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "id": {
+          "char": "m",
+          "description": "Target mod id (directory name under Mods/)",
+          "name": "id",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dir": {
+          "description": "Override Mods directory path",
+          "name": "dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "mod:manage:deploy",
+      "pluginAlias": "@mateicanavra/civ7-cli",
+      "pluginName": "@mateicanavra/civ7-cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Deploy a mod folder into the Civ7 Mods directory",
+      "enableJsonFlag": false,
+      "isESM": false,
+      "relativePath": [
+        "dist",
+        "commands",
+        "mod",
+        "manage",
+        "deploy.js"
+      ]
+    },
+    "mod:manage:list": {
+      "aliases": [],
+      "args": {},
+      "description": "Finds the Mods directory on this machine and lists subdirectories.",
+      "flags": {
+        "dir": {
+          "description": "Override Mods directory path",
+          "name": "dir",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "mod:manage:list",
+      "pluginAlias": "@mateicanavra/civ7-cli",
+      "pluginName": "@mateicanavra/civ7-cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "List locally installed Civ7 mods in the Mods directory",
+      "enableJsonFlag": false,
+      "isESM": false,
+      "relativePath": [
+        "dist",
+        "commands",
+        "mod",
+        "manage",
+        "list.js"
       ]
     },
     "mod:git:clear": {

--- a/packages/mapgen-core/src/bootstrap/resolved.ts
+++ b/packages/mapgen-core/src/bootstrap/resolved.ts
@@ -15,6 +15,7 @@
  */
 
 import type { StageManifest, StageDescriptor } from "./types.js";
+import { M3_STAGE_DEPENDENCY_SPINE } from "../pipeline/standard.js";
 
 // ============================================================================
 // Canonical Stage Order
@@ -31,6 +32,7 @@ export const STAGE_ORDER: readonly string[] = Object.freeze([
   "storySeed",
   "storyHotspots",
   "storyRifts",
+  "ruggedCoasts",
   "storyOrogeny",
   "storyCorridorsPre",
   "islands",
@@ -73,8 +75,15 @@ export function resolveStageManifest(
 
   for (let i = 0; i < STAGE_ORDER.length; i++) {
     const stageName = STAGE_ORDER[i];
+    const spine = M3_STAGE_DEPENDENCY_SPINE[stageName];
+    const enabled =
+      stageName === "ruggedCoasts"
+        ? config.ruggedCoasts === true || config.coastlines === true
+        : config[stageName] === true;
     stages[stageName] = {
-      enabled: config[stageName] === true,
+      enabled,
+      requires: spine?.requires ? [...spine.requires] : [],
+      provides: spine?.provides ? [...spine.provides] : [],
     };
   }
 

--- a/packages/mapgen-core/src/config/schema.ts
+++ b/packages/mapgen-core/src/config/schema.ts
@@ -82,14 +82,14 @@ export const StageDescriptorSchema = Type.Object(
       Type.Array(Type.String(), {
         default: [],
         description:
-          "Dependency tags that must be satisfied before this stage executes (e.g., stage ids, artifact tags, or engine-state tags).",
+          "Canonical dependency tags that must be satisfied before this stage executes (artifact:*, field:*, state:engine.*). Stage-id dependencies are not supported in M3; use tags only.",
       })
     ),
     provides: Type.Optional(
       Type.Array(Type.String(), {
         default: [],
         description:
-          "Dependency tags this stage makes available to dependents (data artifacts, fields, and/or engine-state guarantees).",
+          "Dependency tags this stage makes available to dependents (data artifacts, fields, and/or engine-state guarantees). Note: state:engine.* tags are treated as trusted assertions in M3 and are not runtime-verified.",
       })
     ),
     legacyToggles: Type.Optional(

--- a/packages/mapgen-core/src/index.ts
+++ b/packages/mapgen-core/src/index.ts
@@ -43,5 +43,8 @@ export {
   type GenerationResult,
 } from "./MapOrchestrator.js";
 
+// Re-export pipeline primitives (M3 Task Graph MVP)
+export * from "./pipeline/index.js";
+
 // Package version
 export const VERSION = "0.1.0";

--- a/packages/mapgen-core/src/pipeline/PipelineExecutor.ts
+++ b/packages/mapgen-core/src/pipeline/PipelineExecutor.ts
@@ -1,0 +1,199 @@
+import type { ExtendedMapContext } from "../core/types.js";
+import {
+  MissingDependencyError,
+  UnsatisfiedProvidesError,
+} from "./errors.js";
+import {
+  computeInitialSatisfiedTags,
+  isDependencyTagSatisfied,
+  validateDependencyTags,
+} from "./tags.js";
+import type { MapGenStep } from "./types.js";
+import type { StepRegistry } from "./StepRegistry.js";
+import type { PipelineStepResult } from "./types.js";
+
+export interface PipelineExecutorOptions {
+  logPrefix?: string;
+  log?: (message: string) => void;
+}
+
+function nowMs(): number {
+  try {
+    if (typeof performance !== "undefined" && typeof performance.now === "function") {
+      return performance.now();
+    }
+  } catch {
+    // ignore
+  }
+  return Date.now();
+}
+
+export class PipelineExecutor<TContext extends ExtendedMapContext> {
+  private readonly registry: StepRegistry<TContext>;
+  private readonly log: (message: string) => void;
+  private readonly logPrefix: string;
+
+  constructor(registry: StepRegistry<TContext>, options: PipelineExecutorOptions = {}) {
+    this.registry = registry;
+    this.log = options.log ?? console.log;
+    this.logPrefix = options.logPrefix ?? "[PipelineExecutor]";
+  }
+
+  execute(
+    context: TContext,
+    recipe: readonly string[]
+  ): { stepResults: PipelineStepResult[]; satisfied: ReadonlySet<string> } {
+    const stepResults: PipelineStepResult[] = [];
+    const satisfied = computeInitialSatisfiedTags(context);
+    const satisfactionState = { satisfied };
+
+    const steps: MapGenStep<TContext>[] = recipe
+      .map((id) => this.registry.get(id))
+      .filter((step) => (step.shouldRun ? step.shouldRun(context) : true));
+
+    const total = steps.length;
+
+    for (let index = 0; index < total; index++) {
+      const step = steps[index];
+      validateDependencyTags(step.requires);
+      validateDependencyTags(step.provides);
+
+      const missing = step.requires.filter(
+        (tag) => !isDependencyTagSatisfied(tag, context, satisfactionState)
+      );
+      if (missing.length > 0) {
+        throw new MissingDependencyError({
+          stepId: step.id,
+          missing,
+          satisfied: Array.from(satisfied).sort(),
+        });
+      }
+
+      this.log(`${this.logPrefix} [${index + 1}/${total}] start ${step.id}`);
+      const t0 = nowMs();
+      try {
+        const res = step.run(context);
+        if (res && typeof (res as Promise<void>).then === "function") {
+          throw new Error(
+            `Step "${step.id}" returned a Promise in a sync executor call. Use executeAsync().`
+          );
+        }
+        for (const tag of step.provides) satisfied.add(tag);
+
+        const missingProvides = step.provides.filter((tag) => {
+          // Only verify tags that have concrete satisfaction checks.
+          if (
+            tag === "artifact:foundation" ||
+            tag === "artifact:storyOverlays" ||
+            tag.startsWith("field:")
+          ) {
+            return !isDependencyTagSatisfied(tag, context, satisfactionState);
+          }
+          return false;
+        });
+        if (missingProvides.length > 0) {
+          throw new UnsatisfiedProvidesError(step.id, missingProvides);
+        }
+
+        const durationMs = nowMs() - t0;
+        this.log(
+          `${this.logPrefix} [${index + 1}/${total}] ok ${step.id} (${durationMs.toFixed(2)}ms)`
+        );
+        stepResults.push({ stepId: step.id, success: true, durationMs });
+      } catch (err) {
+        const durationMs = nowMs() - t0;
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        this.log(
+          `${this.logPrefix} [${index + 1}/${total}] fail ${step.id} (${durationMs.toFixed(
+            2
+          )}ms): ${errorMessage}`
+        );
+        stepResults.push({
+          stepId: step.id,
+          success: false,
+          durationMs,
+          error: errorMessage,
+        });
+        break;
+      }
+    }
+
+    return { stepResults, satisfied };
+  }
+
+  async executeAsync(
+    context: TContext,
+    recipe: readonly string[]
+  ): Promise<{ stepResults: PipelineStepResult[]; satisfied: ReadonlySet<string> }> {
+    const stepResults: PipelineStepResult[] = [];
+    const satisfied = computeInitialSatisfiedTags(context);
+    const satisfactionState = { satisfied };
+
+    const steps: MapGenStep<TContext>[] = recipe
+      .map((id) => this.registry.get(id))
+      .filter((step) => (step.shouldRun ? step.shouldRun(context) : true));
+
+    const total = steps.length;
+
+    for (let index = 0; index < total; index++) {
+      const step = steps[index];
+      validateDependencyTags(step.requires);
+      validateDependencyTags(step.provides);
+
+      const missing = step.requires.filter(
+        (tag) => !isDependencyTagSatisfied(tag, context, satisfactionState)
+      );
+      if (missing.length > 0) {
+        throw new MissingDependencyError({
+          stepId: step.id,
+          missing,
+          satisfied: Array.from(satisfied).sort(),
+        });
+      }
+
+      this.log(`${this.logPrefix} [${index + 1}/${total}] start ${step.id}`);
+      const t0 = nowMs();
+      try {
+        await step.run(context);
+        for (const tag of step.provides) satisfied.add(tag);
+
+        const missingProvides = step.provides.filter((tag) => {
+          if (
+            tag === "artifact:foundation" ||
+            tag === "artifact:storyOverlays" ||
+            tag.startsWith("field:")
+          ) {
+            return !isDependencyTagSatisfied(tag, context, satisfactionState);
+          }
+          return false;
+        });
+        if (missingProvides.length > 0) {
+          throw new UnsatisfiedProvidesError(step.id, missingProvides);
+        }
+
+        const durationMs = nowMs() - t0;
+        this.log(
+          `${this.logPrefix} [${index + 1}/${total}] ok ${step.id} (${durationMs.toFixed(2)}ms)`
+        );
+        stepResults.push({ stepId: step.id, success: true, durationMs });
+      } catch (err) {
+        const durationMs = nowMs() - t0;
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        this.log(
+          `${this.logPrefix} [${index + 1}/${total}] fail ${step.id} (${durationMs.toFixed(
+            2
+          )}ms): ${errorMessage}`
+        );
+        stepResults.push({
+          stepId: step.id,
+          success: false,
+          durationMs,
+          error: errorMessage,
+        });
+        break;
+      }
+    }
+
+    return { stepResults, satisfied };
+  }
+}

--- a/packages/mapgen-core/src/pipeline/StepRegistry.ts
+++ b/packages/mapgen-core/src/pipeline/StepRegistry.ts
@@ -1,0 +1,39 @@
+import type { StageManifest } from "../config/index.js";
+import { DuplicateStepError, UnknownStepError } from "./errors.js";
+import { validateDependencyTags } from "./tags.js";
+import type { MapGenStep } from "./types.js";
+
+export class StepRegistry<TContext> {
+  private readonly steps = new Map<string, MapGenStep<TContext>>();
+
+  register(step: MapGenStep<TContext>): void {
+    if (this.steps.has(step.id)) {
+      throw new DuplicateStepError(step.id);
+    }
+    validateDependencyTags(step.requires);
+    validateDependencyTags(step.provides);
+    this.steps.set(step.id, step);
+  }
+
+  get(stepId: string): MapGenStep<TContext> {
+    const step = this.steps.get(stepId);
+    if (!step) throw new UnknownStepError(stepId);
+    return step;
+  }
+
+  has(stepId: string): boolean {
+    return this.steps.has(stepId);
+  }
+
+  /**
+   * Standard recipe for M3: execute STAGE_ORDER filtered by the resolved stage manifest.
+   * The recipe IDs must match stage ids (1:1 mapping).
+   */
+  getStandardRecipe(stageManifest: Readonly<StageManifest>): string[] {
+    const order = Array.isArray(stageManifest.order) ? stageManifest.order : [];
+    const stages = stageManifest.stages ?? {};
+    const enabled = (id: string): boolean => stages[id]?.enabled !== false;
+    return order.filter(enabled);
+  }
+}
+

--- a/packages/mapgen-core/src/pipeline/errors.ts
+++ b/packages/mapgen-core/src/pipeline/errors.ts
@@ -1,0 +1,75 @@
+export class StepRegistryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StepRegistryError";
+  }
+}
+
+export class DuplicateStepError extends StepRegistryError {
+  constructor(stepId: string) {
+    super(`Step "${stepId}" is already registered.`);
+    this.name = "DuplicateStepError";
+  }
+}
+
+export class UnknownStepError extends StepRegistryError {
+  constructor(stepId: string) {
+    super(`Unknown step "${stepId}".`);
+    this.name = "UnknownStepError";
+  }
+}
+
+export class DependencyTagError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DependencyTagError";
+  }
+}
+
+export class InvalidDependencyTagError extends DependencyTagError {
+  constructor(tag: string) {
+    super(`Invalid dependency tag "${tag}".`);
+    this.name = "InvalidDependencyTagError";
+  }
+}
+
+export class UnknownDependencyTagError extends DependencyTagError {
+  constructor(tag: string) {
+    super(`Unknown dependency tag "${tag}".`);
+    this.name = "UnknownDependencyTagError";
+  }
+}
+
+export class MissingDependencyError extends Error {
+  readonly stepId: string;
+  readonly missing: readonly string[];
+  readonly satisfied: readonly string[];
+
+  constructor(options: {
+    stepId: string;
+    missing: readonly string[];
+    satisfied: readonly string[];
+  }) {
+    const missingList = options.missing.join(", ");
+    super(`Missing dependency for "${options.stepId}": ${missingList}`);
+    this.name = "MissingDependencyError";
+    this.stepId = options.stepId;
+    this.missing = options.missing;
+    this.satisfied = options.satisfied;
+  }
+}
+
+export class UnsatisfiedProvidesError extends Error {
+  readonly stepId: string;
+  readonly missingProvides: readonly string[];
+
+  constructor(stepId: string, missingProvides: readonly string[]) {
+    super(
+      `Step "${stepId}" did not satisfy declared provides: ${missingProvides.join(", ")}`
+    );
+    this.name = "UnsatisfiedProvidesError";
+    this.stepId = stepId;
+    this.missingProvides = missingProvides;
+  }
+}
+

--- a/packages/mapgen-core/src/pipeline/index.ts
+++ b/packages/mapgen-core/src/pipeline/index.ts
@@ -1,0 +1,18 @@
+export type {
+  DependencyTag,
+  GenerationPhase,
+  MapGenStep,
+  PipelineStepResult,
+} from "./types.js";
+export {
+  DuplicateStepError,
+  UnknownStepError,
+  MissingDependencyError,
+  InvalidDependencyTagError,
+  UnknownDependencyTagError,
+  UnsatisfiedProvidesError,
+} from "./errors.js";
+export { M3_DEPENDENCY_TAGS, M3_CANONICAL_DEPENDENCY_TAGS } from "./tags.js";
+export { StepRegistry } from "./StepRegistry.js";
+export { PipelineExecutor } from "./PipelineExecutor.js";
+export { M3_STANDARD_STAGE_PHASE, M3_STAGE_DEPENDENCY_SPINE } from "./standard.js";

--- a/packages/mapgen-core/src/pipeline/standard.ts
+++ b/packages/mapgen-core/src/pipeline/standard.ts
@@ -1,0 +1,116 @@
+import type { GenerationPhase } from "./types.js";
+import { M3_DEPENDENCY_TAGS } from "./tags.js";
+
+export const M3_STANDARD_STAGE_PHASE: Readonly<Record<string, GenerationPhase>> =
+  Object.freeze({
+    foundation: "foundation",
+    landmassPlates: "morphology",
+    coastlines: "morphology",
+    storySeed: "morphology",
+    storyHotspots: "morphology",
+    storyRifts: "morphology",
+    ruggedCoasts: "morphology",
+    storyOrogeny: "morphology",
+    storyCorridorsPre: "morphology",
+    islands: "morphology",
+    mountains: "morphology",
+    volcanoes: "morphology",
+    lakes: "hydrology",
+    climateBaseline: "hydrology",
+    storySwatches: "hydrology",
+    rivers: "hydrology",
+    storyCorridorsPost: "hydrology",
+    climateRefine: "hydrology",
+    biomes: "ecology",
+    features: "ecology",
+    placement: "placement",
+  });
+
+export const M3_STAGE_DEPENDENCY_SPINE: Readonly<
+  Record<string, { requires: readonly string[]; provides: readonly string[] }>
+> = Object.freeze({
+  foundation: {
+    requires: [],
+    provides: [M3_DEPENDENCY_TAGS.artifact.foundation],
+  },
+  landmassPlates: {
+    requires: [M3_DEPENDENCY_TAGS.artifact.foundation],
+    provides: [M3_DEPENDENCY_TAGS.state.landmassApplied],
+  },
+  coastlines: {
+    requires: [M3_DEPENDENCY_TAGS.state.landmassApplied],
+    provides: [M3_DEPENDENCY_TAGS.state.coastlinesApplied],
+  },
+  storySeed: {
+    requires: [M3_DEPENDENCY_TAGS.state.coastlinesApplied],
+    provides: [M3_DEPENDENCY_TAGS.artifact.storyOverlays],
+  },
+  storyHotspots: {
+    requires: [M3_DEPENDENCY_TAGS.state.coastlinesApplied],
+    provides: [M3_DEPENDENCY_TAGS.artifact.storyOverlays],
+  },
+  storyRifts: {
+    requires: [M3_DEPENDENCY_TAGS.state.coastlinesApplied],
+    provides: [M3_DEPENDENCY_TAGS.artifact.storyOverlays],
+  },
+  ruggedCoasts: {
+    requires: [M3_DEPENDENCY_TAGS.state.coastlinesApplied],
+    provides: [M3_DEPENDENCY_TAGS.state.coastlinesApplied],
+  },
+  storyOrogeny: {
+    requires: [M3_DEPENDENCY_TAGS.state.coastlinesApplied],
+    provides: [M3_DEPENDENCY_TAGS.artifact.storyOverlays],
+  },
+  storyCorridorsPre: {
+    requires: [M3_DEPENDENCY_TAGS.state.coastlinesApplied],
+    provides: [M3_DEPENDENCY_TAGS.artifact.storyOverlays],
+  },
+  islands: {
+    requires: [M3_DEPENDENCY_TAGS.state.coastlinesApplied],
+    provides: [M3_DEPENDENCY_TAGS.state.landmassApplied],
+  },
+  mountains: {
+    requires: [M3_DEPENDENCY_TAGS.artifact.foundation],
+    provides: [M3_DEPENDENCY_TAGS.state.landmassApplied],
+  },
+  volcanoes: {
+    requires: [M3_DEPENDENCY_TAGS.artifact.foundation],
+    provides: [M3_DEPENDENCY_TAGS.state.landmassApplied],
+  },
+  lakes: {
+    requires: [M3_DEPENDENCY_TAGS.state.landmassApplied],
+    provides: [M3_DEPENDENCY_TAGS.artifact.heightfield],
+  },
+  climateBaseline: {
+    requires: [M3_DEPENDENCY_TAGS.artifact.foundation],
+    provides: [M3_DEPENDENCY_TAGS.artifact.climateField],
+  },
+  storySwatches: {
+    requires: [M3_DEPENDENCY_TAGS.artifact.storyOverlays, M3_DEPENDENCY_TAGS.artifact.climateField],
+    provides: [M3_DEPENDENCY_TAGS.artifact.climateField],
+  },
+  rivers: {
+    requires: [M3_DEPENDENCY_TAGS.artifact.foundation],
+    provides: [M3_DEPENDENCY_TAGS.state.riversModeled],
+  },
+  storyCorridorsPost: {
+    requires: [M3_DEPENDENCY_TAGS.state.coastlinesApplied],
+    provides: [M3_DEPENDENCY_TAGS.artifact.storyOverlays],
+  },
+  climateRefine: {
+    requires: [M3_DEPENDENCY_TAGS.artifact.foundation, M3_DEPENDENCY_TAGS.artifact.climateField],
+    provides: [M3_DEPENDENCY_TAGS.artifact.climateField],
+  },
+  biomes: {
+    requires: [M3_DEPENDENCY_TAGS.artifact.climateField],
+    provides: [M3_DEPENDENCY_TAGS.state.biomesApplied],
+  },
+  features: {
+    requires: [M3_DEPENDENCY_TAGS.state.biomesApplied],
+    provides: [M3_DEPENDENCY_TAGS.state.featuresApplied],
+  },
+  placement: {
+    requires: [M3_DEPENDENCY_TAGS.state.featuresApplied],
+    provides: [M3_DEPENDENCY_TAGS.state.placementApplied],
+  },
+});

--- a/packages/mapgen-core/src/pipeline/tags.ts
+++ b/packages/mapgen-core/src/pipeline/tags.ts
@@ -1,0 +1,99 @@
+import type { ExtendedMapContext } from "../core/types.js";
+import { getStoryOverlayRegistry } from "../story/overlays.js";
+import {
+  InvalidDependencyTagError,
+  UnknownDependencyTagError,
+} from "./errors.js";
+
+export const M3_DEPENDENCY_TAGS = {
+  artifact: {
+    foundation: "artifact:foundation",
+    heightfield: "artifact:heightfield",
+    climateField: "artifact:climateField",
+    storyOverlays: "artifact:storyOverlays",
+    riverAdjacency: "artifact:riverAdjacency",
+  },
+  field: {
+    terrainType: "field:terrainType",
+    elevation: "field:elevation",
+    rainfall: "field:rainfall",
+    biomeId: "field:biomeId",
+    featureType: "field:featureType",
+  },
+  state: {
+    landmassApplied: "state:engine.landmassApplied",
+    coastlinesApplied: "state:engine.coastlinesApplied",
+    riversModeled: "state:engine.riversModeled",
+    biomesApplied: "state:engine.biomesApplied",
+    featuresApplied: "state:engine.featuresApplied",
+    placementApplied: "state:engine.placementApplied",
+  },
+} as const;
+
+export const M3_CANONICAL_DEPENDENCY_TAGS: ReadonlySet<string> = new Set([
+  ...Object.values(M3_DEPENDENCY_TAGS.artifact),
+  ...Object.values(M3_DEPENDENCY_TAGS.field),
+  ...Object.values(M3_DEPENDENCY_TAGS.state),
+]);
+
+const ARTIFACT_RE = /^artifact:[a-z][A-Za-z0-9]*$/;
+const FIELD_RE = /^field:[a-z][A-Za-z0-9]*$/;
+const STATE_RE = /^state:engine\.[a-z][A-Za-z0-9]*$/;
+
+export function validateDependencyTag(tag: string): void {
+  if (typeof tag !== "string" || tag.length === 0) {
+    throw new InvalidDependencyTagError(String(tag));
+  }
+  if (!ARTIFACT_RE.test(tag) && !FIELD_RE.test(tag) && !STATE_RE.test(tag)) {
+    throw new InvalidDependencyTagError(tag);
+  }
+  if (!M3_CANONICAL_DEPENDENCY_TAGS.has(tag)) {
+    throw new UnknownDependencyTagError(tag);
+  }
+}
+
+export function validateDependencyTags(tags: readonly string[]): void {
+  for (const tag of tags) validateDependencyTag(tag);
+}
+
+type SatisfactionState = {
+  satisfied: ReadonlySet<string>;
+};
+
+export function isDependencyTagSatisfied(
+  tag: string,
+  context: ExtendedMapContext,
+  state: SatisfactionState
+): boolean {
+  switch (tag) {
+    case M3_DEPENDENCY_TAGS.artifact.foundation:
+      return !!context.foundation;
+    case M3_DEPENDENCY_TAGS.artifact.storyOverlays:
+      return (
+        (context.overlays?.size ?? 0) > 0 || getStoryOverlayRegistry().size > 0
+      );
+    case M3_DEPENDENCY_TAGS.field.terrainType:
+      return !!context.fields?.terrainType;
+    case M3_DEPENDENCY_TAGS.field.elevation:
+      return !!context.fields?.elevation;
+    case M3_DEPENDENCY_TAGS.field.rainfall:
+      return !!context.fields?.rainfall;
+    case M3_DEPENDENCY_TAGS.field.biomeId:
+      return !!context.fields?.biomeId;
+    case M3_DEPENDENCY_TAGS.field.featureType:
+      return !!context.fields?.featureType;
+    default:
+      return state.satisfied.has(tag);
+  }
+}
+
+export function computeInitialSatisfiedTags(context: ExtendedMapContext): Set<string> {
+  const satisfied = new Set<string>();
+  // Fields are preallocated when the context is created.
+  if (context.fields?.terrainType) satisfied.add(M3_DEPENDENCY_TAGS.field.terrainType);
+  if (context.fields?.elevation) satisfied.add(M3_DEPENDENCY_TAGS.field.elevation);
+  if (context.fields?.rainfall) satisfied.add(M3_DEPENDENCY_TAGS.field.rainfall);
+  if (context.fields?.biomeId) satisfied.add(M3_DEPENDENCY_TAGS.field.biomeId);
+  if (context.fields?.featureType) satisfied.add(M3_DEPENDENCY_TAGS.field.featureType);
+  return satisfied;
+}

--- a/packages/mapgen-core/src/pipeline/types.ts
+++ b/packages/mapgen-core/src/pipeline/types.ts
@@ -1,0 +1,27 @@
+import type { ExtendedMapContext } from "../core/types.js";
+
+export type GenerationPhase =
+  | "setup"
+  | "foundation"
+  | "morphology"
+  | "hydrology"
+  | "ecology"
+  | "placement";
+
+export type DependencyTag = string;
+
+export interface MapGenStep<TContext = ExtendedMapContext> {
+  id: string;
+  phase: GenerationPhase;
+  requires: readonly DependencyTag[];
+  provides: readonly DependencyTag[];
+  shouldRun?: (context: TContext) => boolean;
+  run: (context: TContext) => void | Promise<void>;
+}
+
+export interface PipelineStepResult {
+  stepId: string;
+  success: boolean;
+  durationMs?: number;
+  error?: string;
+}

--- a/packages/mapgen-core/test/orchestrator/task-graph.smoke.test.ts
+++ b/packages/mapgen-core/test/orchestrator/task-graph.smoke.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { createMockAdapter } from "@civ7/adapter";
+import { bootstrap, MapOrchestrator } from "../../src/index.js";
+import { resetTunablesForTest } from "../../src/bootstrap/tunables.js";
+import { resetConfigProviderForTest, WorldModel } from "../../src/world/model.js";
+
+describe("smoke: MapOrchestrator.generateMap TaskGraph entry", () => {
+  const width = 24;
+  const height = 16;
+
+  let originalGameplayMap: unknown;
+  let originalGameInfo: unknown;
+
+  beforeEach(() => {
+    resetTunablesForTest();
+    resetConfigProviderForTest();
+    WorldModel.reset();
+
+    originalGameplayMap = (globalThis as Record<string, unknown>).GameplayMap;
+    originalGameInfo = (globalThis as Record<string, unknown>).GameInfo;
+
+    (globalThis as Record<string, unknown>).GameplayMap = {
+      getGridWidth: () => width,
+      getGridHeight: () => height,
+      getMapSize: () => 1,
+      getIndexFromXY: (x: number, y: number) => y * width + x,
+      getLocationFromIndex: (index: number) => ({
+        x: index % width,
+        y: Math.floor(index / width),
+      }),
+      getPlotLatitude: () => 0,
+      getRandomSeed: () => 12345,
+      isWater: () => false,
+    };
+
+    (globalThis as Record<string, unknown>).GameInfo = {
+      Maps: {
+        lookup: () => ({
+          GridWidth: width,
+          GridHeight: height,
+          MinLatitude: -80,
+          MaxLatitude: 80,
+          NumNaturalWonders: 0,
+          LakeGenerationFrequency: 0,
+          PlayersLandmass1: 4,
+          PlayersLandmass2: 4,
+          StartSectorRows: 4,
+          StartSectorCols: 4,
+        }),
+      },
+    };
+  });
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).GameplayMap = originalGameplayMap;
+    (globalThis as Record<string, unknown>).GameInfo = originalGameInfo;
+
+    resetTunablesForTest();
+    resetConfigProviderForTest();
+    WorldModel.reset();
+  });
+
+  it("runs the foundation stage via PipelineExecutor", () => {
+    const adapter = createMockAdapter({
+      width,
+      height,
+      rng: () => 0,
+    });
+
+    const config = bootstrap({ stageConfig: { foundation: true } });
+    const orchestrator = new MapOrchestrator(config, {
+      adapter,
+      logPrefix: "[TEST]",
+      useTaskGraph: true,
+    });
+    const result = orchestrator.generateMap();
+
+    expect(result.success).toBe(true);
+    expect(
+      result.stageResults.some((stage) => stage.stage === "foundation" && stage.success)
+    ).toBe(true);
+  });
+});
+

--- a/packages/mapgen-core/test/orchestrator/task-graph.smoke.test.ts
+++ b/packages/mapgen-core/test/orchestrator/task-graph.smoke.test.ts
@@ -80,5 +80,31 @@ describe("smoke: MapOrchestrator.generateMap TaskGraph entry", () => {
       result.stageResults.some((stage) => stage.stage === "foundation" && stage.success)
     ).toBe(true);
   });
-});
 
+  it("surfaces a MissingDependencyError as a structured stageResult entry", () => {
+    const adapter = createMockAdapter({
+      width,
+      height,
+      rng: () => 0,
+    });
+
+    const config = bootstrap({ stageConfig: { foundation: false, landmassPlates: true } });
+    const orchestrator = new MapOrchestrator(config, {
+      adapter,
+      logPrefix: "[TEST]",
+      useTaskGraph: true,
+    });
+    const result = orchestrator.generateMap();
+
+    expect(result.success).toBe(false);
+    expect(
+      result.stageResults.some(
+        (stage) =>
+          stage.stage === "landmassPlates" &&
+          stage.success === false &&
+          typeof stage.error === "string" &&
+          stage.error.includes("Missing dependency")
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
### TL;DR

Implemented the Task Graph MVP for the map generation pipeline, providing a structured execution framework with dependency management and runtime validation.

### What changed?

- Added a new pipeline module with core components:
  - `MapGenStep` interface defining the contract for generation steps
  - `StepRegistry` for registering and retrieving steps
  - `PipelineExecutor` for running steps with dependency validation
  - Standardized dependency tag system with namespaces (`artifact:*`, `field:*`, `state:engine.*`)
  
- Integrated the Task Graph execution path into `MapOrchestrator` via a new `useTaskGraph` option
- Implemented wrap-first steps for all current stages using existing implementations
- Added runtime validation for dependency requirements with fail-fast error handling
- Created a new deferral (DEF-008) documenting the trust model for `state:engine.*` tags
- Added documentation for project docs hygiene practices

### How to test?

1. Run the new task graph execution path:
   ```typescript
   const orchestrator = new MapOrchestrator(config, { useTaskGraph: true });
   const result = orchestrator.generateMap();
   ```

2. Verify dependency validation by intentionally disabling a required stage:
   ```typescript
   // This will fail with MissingDependencyError since landmassPlates requires foundation
   const config = bootstrap({ stageConfig: { foundation: false, landmassPlates: true } });
   ```

3. Run the smoke test that validates both the happy path and error handling:
   ```
   bun test packages/mapgen-core/test/orchestrator/task-graph.smoke.test.ts
   ```

### Why make this change?

This implementation establishes the foundation for the M3 engine refactor by:

1. Creating a structured execution model with explicit dependencies between steps
2. Providing runtime validation to catch missing dependencies early
3. Standardizing the contract for map generation steps
4. Enabling a gradual migration path from the legacy orchestrator to the new task graph

The Task Graph MVP unblocks subsequent M3 work by providing the execution spine that future steps will plug into, while maintaining backward compatibility through the wrap-first approach.