### PR TITLE
feat(mod-swooper-maps): tune earthlike map generation parameters

### DIFF
--- a/mods/mod-swooper-maps/src/swooper-earthlike.ts
+++ b/mods/mod-swooper-maps/src/swooper-earthlike.ts
@@ -11,7 +11,7 @@
 /// <reference types="@civ7/types" />
 
 import "@swooper/mapgen-core/polyfills/text-encoder";
-import { bootstrap, MapOrchestrator } from "@swooper/mapgen-core";
+import { bootstrap, MapOrchestrator, OrchestratorConfig } from "@swooper/mapgen-core";
 import type { BootstrapConfig } from "@swooper/mapgen-core/bootstrap";
 
 // ============================================================================
@@ -349,7 +349,7 @@ function buildConfig(plateCount: number): BootstrapConfig {
   };
 }
 
-const orchestratorOptions = { logPrefix: "[SWOOPER_MOD]" };
+const orchestratorOptions: OrchestratorConfig = { logPrefix: "[SWOOPER_MOD]", useTaskGraph: true };
 
 engine.on("RequestMapInitData", () => {
   const defaultConfig = bootstrap({});

--- a/mods/mod-swooper-maps/src/swooper-earthlike.ts
+++ b/mods/mod-swooper-maps/src/swooper-earthlike.ts
@@ -74,9 +74,9 @@ function buildConfig(plateCount: number): BootstrapConfig {
         boundaryShareTarget: 0.2,
         tectonics: {
           // Favor coastal arcs (Andes/Ring of Fire) but keep thick interiors.
-          boundaryArcWeight: 0.6,
+          boundaryArcWeight: 0.37,
           boundaryArcNoiseWeight: 0.35,
-          interiorNoiseWeight: 0.7,
+          interiorNoiseWeight: 0.75,
           fractalGrain: 5,
         },
       },
@@ -94,23 +94,23 @@ function buildConfig(plateCount: number): BootstrapConfig {
           transform: 0.4,
           divergent: -0.4,
           interior: 0.7,
-          bayWeight: 0.4,
-          bayNoiseBonus: 1.0,
+          bayWeight: 0.8,
+          bayNoiseBonus: 0.5,
           fjordWeight: 0.8,
         },
       },
       mountains: {
         // Earth-like prevalence: a few major ranges, not wall-to-wall mountains.
-        tectonicIntensity: 0.85,
+        tectonicIntensity: 0.65,
         mountainThreshold: 0.6,
         hillThreshold: 0.32,
         upliftWeight: 0.35,
-        fractalWeight: 0.18,
+        fractalWeight: 0.37,
         riftDepth: 0.25,
-        boundaryWeight: 1.0,
+        boundaryWeight: 0.7,
         boundaryExponent: 1.6,
         interiorPenaltyWeight: 0.0,
-        convergenceBonus: 0.9,
+        convergenceBonus: 0.77,
         transformPenalty: 0.6,
         riftPenalty: 1.0,
         hillBoundaryWeight: 0.35,
@@ -136,7 +136,7 @@ function buildConfig(plateCount: number): BootstrapConfig {
       },
       foundation: {
         plates: {
-          count: 28,
+          count: 32,
           convergenceMix: 0.55,
           relaxationSteps: 5,
           plateRotationMultiple: 1.3,
@@ -155,9 +155,9 @@ function buildConfig(plateCount: number): BootstrapConfig {
           directionality: {
             cohesion: 0.15,
             primaryAxes: {
-              plateAxisDeg: 0,
-              windBiasDeg: 0,
-              currentBiasDeg: 0,
+              plateAxisDeg: 12,
+              windBiasDeg: 12,
+              currentBiasDeg: 12,
             },
             interplay: {
               windsFollowPlates: 0.3,
@@ -202,7 +202,7 @@ function buildConfig(plateCount: number): BootstrapConfig {
         baseline: {
           blend: {
             baseWeight: 0.55,
-            bandWeight: 0.45,
+            bandWeight: 0.25,
           },
           bands: {
             deg0to10: 125,


### PR DESCRIPTION
### TL;DR

Adjusted Earth-like map generation parameters to create more realistic terrain features and improved performance with task graph.

### What changed?

- Reduced tectonic boundary arc weight from 0.6 to 0.37 and increased interior noise weight from 0.7 to 0.75
- Doubled bay weight from 0.4 to 0.8 and halved bay noise bonus from 1.0 to 0.5
- Decreased mountain tectonic intensity from 0.85 to 0.65
- Increased fractal weight for mountains from 0.18 to 0.37
- Reduced boundary weight from 1.0 to 0.7 and convergence bonus from 0.9 to 0.77
- Increased plate count from 28 to 32
- Added 12-degree directionality to plate axis, wind bias, and current bias
- Reduced band weight in baseline blend from 0.45 to 0.25
- Enabled task graph in orchestrator configuration for improved performance

### How to test?

1. Generate Earth-like maps with the updated parameters
2. Compare coastlines, mountain ranges, and overall terrain distribution to previous versions
3. Verify that the maps have more natural-looking features with better defined coastal areas and mountain ranges
4. Check that map generation performance is improved with the task graph enabled

### Why make this change?

These parameter adjustments create more realistic Earth-like terrain by:
- Creating more natural coastlines with better defined bays
- Producing more varied and less overwhelming mountain ranges
- Improving the distribution and flow of terrain features with directional bias
- Enhancing performance through task graph parallelization

The changes aim to make generated maps more closely resemble actual Earth geography while maintaining good gameplay balance.