### PR TITLE
feat(story): implement full story system with corridors, swatches and paleo (CIV-43)

### DIFF
--- a/docs/projects/engine-refactor-v1/issues/CIV-43-story-system.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-43-story-system.md
@@ -33,7 +33,7 @@ Parent issue: `CIV-21-story-tagging.md`.
 - [x] TS equivalents exist for all legacy story passes and corridors
 - [x] Corridors/swatches/paleo overlays are populated when stages enabled
 - [x] Story logic runs as steps under the Task Graph with explicit contracts
-- [ ] Downstream consumers use `StoryOverlays`/`ClimateField` rather than ad‑hoc reads
+- [ ] Downstream consumers use `StoryOverlays`/`ClimateField` rather than ad‑hoc reads (deferred: DEF-002, tracked in CIV-44)
 - [x] Story steps declare `requires`/`provides` and run via `PipelineExecutor`
 - [x] Steps fail fast if required dependency tags are missing (runtime gating enforced)
 

--- a/docs/projects/engine-refactor-v1/issues/CIV-43-story-system.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-43-story-system.md
@@ -24,18 +24,18 @@ Parent issue: `CIV-21-story-tagging.md`.
 
 ## Deliverables
 
-- [ ] Port remaining legacy story passes: corridors, swatches, paleo (and any remaining in-slice orogeny work if still missing).
-- [ ] Publish narrative outputs via canonical `StoryOverlays` (downstream consumers read overlays, not ad-hoc globals).
-- [ ] Wrap story stages as `MapGenStep`s with explicit `requires/provides` and runtime-gated execution.
+- [x] Port remaining legacy story passes: corridors, swatches, paleo (and any remaining in-slice orogeny work if still missing).
+- [x] Publish narrative outputs via canonical `StoryOverlays` (downstream consumers read overlays, not ad-hoc globals).
+- [x] Wrap story stages as `MapGenStep`s with explicit `requires/provides` and runtime-gated execution.
 
 ## Acceptance Criteria
 
-- [ ] TS equivalents exist for all legacy story passes and corridors
-- [ ] Corridors/swatches/paleo overlays are populated when stages enabled
-- [ ] Story logic runs as steps under the Task Graph with explicit contracts
+- [x] TS equivalents exist for all legacy story passes and corridors
+- [x] Corridors/swatches/paleo overlays are populated when stages enabled
+- [x] Story logic runs as steps under the Task Graph with explicit contracts
 - [ ] Downstream consumers use `StoryOverlays`/`ClimateField` rather than ad‑hoc reads
-- [ ] Story steps declare `requires`/`provides` and run via `PipelineExecutor`
-- [ ] Steps fail fast if required dependency tags are missing (runtime gating enforced)
+- [x] Story steps declare `requires`/`provides` and run via `PipelineExecutor`
+- [x] Steps fail fast if required dependency tags are missing (runtime gating enforced)
 
 ## Testing / Verification
 

--- a/docs/projects/engine-refactor-v1/issues/CIV-43-story-system.md
+++ b/docs/projects/engine-refactor-v1/issues/CIV-43-story-system.md
@@ -79,3 +79,9 @@ Parent issue: `CIV-21-story-tagging.md`.
   - `docs/system/libs/mapgen/_archive/original-mod-swooper-maps-js/story/tagging.js`
   - `docs/system/libs/mapgen/_archive/original-mod-swooper-maps-js/story/corridors.js`
 - M3 decision: implement `paleo` as part of the `storySwatches` stage/step (no new `storyPaleo` stage in `STAGE_ORDER` for M3).
+
+### Review Follow-ups
+- Removed `syncClimateField()` usage from paleo; tests seed canonical climate buffers instead.
+- Ensured `storySwatches` republishes `artifact:climateField` after swatches/paleo mutations.
+- Tightened `storyCorridorsPost` dependency spine to require climate + river artifacts (fail-fast on misordered/disabled stages).
+- Reset story globals at generation start to prevent cross-run leakage when story stages are selectively enabled.

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M3-core-engine-refactor-config-evolution.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M3-core-engine-refactor-config-evolution.md
@@ -194,6 +194,10 @@ No scope creep or backward push detected. The issue's "locked decisions" (recipe
 - Updated stage dependencies so `biomes` requires `artifact:riverAdjacency` and `features` requires `artifact:climateField`, matching actual data reads.
 - Documented `ClimateField.humidity` as an M3 placeholder.
 - Ensured the legacy `generateMap()` entry path publishes `artifact:climateField` / `artifact:riverAdjacency` so artifact-only consumers behave consistently even when TaskGraph is disabled.
+- Fixed paleo MapContext path by removing the removed `syncClimateField()` call; paleo now requires canonical climate buffers (tests seed buffers explicitly).
+- Ensured `storySwatches` republishes `artifact:climateField` after swatches/paleo mutations (so `provides` matches runtime behavior).
+- Reset story globals at generation start to avoid cross-run overlay/tag leakage when story stages are selectively enabled.
+- Tightened `storyCorridorsPost` stage dependencies to require `artifact:climateField` + `artifact:riverAdjacency` (fail-fast is meaningful for misordered recipes).
 
 ---
 

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M3-core-engine-refactor-config-evolution.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M3-core-engine-refactor-config-evolution.md
@@ -108,6 +108,7 @@ No scope creep or backward push detected. The issue's "locked decisions" (recipe
 - `generateMapTaskGraph()` now records a structured failure entry in `stageResults` when the executor throws (uses `stepId` when available).
 - Added a regression test for the missing-`requires` path (`landmassPlates` enabled while `foundation` is disabled).
 - Aligned `StageDescriptorSchema` wording to reflect tag-only `requires`/`provides` in M3 and note the current trust model for `state:engine.*`.
+- CIV-43 implements the previously placeholder story steps (`storyOrogeny`, `storyCorridorsPre`, `storySwatches`, `storyCorridorsPost`) and gates them via `stageFlags` rather than `shouldRun: () => false`.
 
 ---
 

--- a/packages/mapgen-core/src/MapOrchestrator.ts
+++ b/packages/mapgen-core/src/MapOrchestrator.ts
@@ -620,6 +620,12 @@ export class MapOrchestrator {
       return { success: false, stageResults: this.stageResults, startPositions };
     }
 
+    // Reset story state once per generation to prevent cross-run leakage via globals.
+    resetStoryTags();
+    resetStoryOverlays();
+    resetOrogenyCache();
+    resetCorridorStyleCache();
+
     // Initialize WorldModel and FoundationContext
     // Note: foundationContext stored for potential future use in story stages
     if (stageFlags.foundation && ctx) {
@@ -943,6 +949,8 @@ export class MapOrchestrator {
           console.log(`${prefix} Applying paleo hydrology...`);
           storyTagClimatePaleo(ctx!);
         }
+
+        publishClimateFieldArtifact(ctx!);
       });
       this.stageResults.push(stageResult);
     }
@@ -1207,6 +1215,12 @@ export class MapOrchestrator {
       console.error(`${prefix} Failed to create context:`, err);
       return { success: false, stageResults: this.stageResults, startPositions };
     }
+
+    // Reset story state once per generation to prevent cross-run leakage via globals.
+    resetStoryTags();
+    resetStoryOverlays();
+    resetOrogenyCache();
+    resetCorridorStyleCache();
 
     // Set up start sectors (placement consumes these)
     const iNumPlayers1 = mapInfo.PlayersLandmass1 ?? 4;
@@ -1531,6 +1545,7 @@ export class MapOrchestrator {
         if (ctx?.config?.toggles?.STORY_ENABLE_PALEO) {
           storyTagClimatePaleo(ctx);
         }
+        publishClimateFieldArtifact(ctx);
       },
     });
 

--- a/packages/mapgen-core/src/pipeline/standard.ts
+++ b/packages/mapgen-core/src/pipeline/standard.ts
@@ -94,7 +94,12 @@ export const M3_STAGE_DEPENDENCY_SPINE: Readonly<
     provides: [M3_DEPENDENCY_TAGS.state.riversModeled, M3_DEPENDENCY_TAGS.artifact.riverAdjacency],
   },
   storyCorridorsPost: {
-    requires: [M3_DEPENDENCY_TAGS.state.coastlinesApplied],
+    requires: [
+      M3_DEPENDENCY_TAGS.state.coastlinesApplied,
+      M3_DEPENDENCY_TAGS.artifact.storyOverlays,
+      M3_DEPENDENCY_TAGS.artifact.climateField,
+      M3_DEPENDENCY_TAGS.artifact.riverAdjacency,
+    ],
     provides: [M3_DEPENDENCY_TAGS.artifact.storyOverlays],
   },
   climateRefine: {

--- a/packages/mapgen-core/src/story/corridors.ts
+++ b/packages/mapgen-core/src/story/corridors.ts
@@ -1,0 +1,837 @@
+/**
+ * Story Corridors — lightweight, gameplay-focused path tagging.
+ *
+ * Ports legacy JS story/corridors.js into MapContext-friendly logic:
+ * - Uses EngineAdapter reads (water/elevation/rainfall/latitude) when ctx provided
+ * - Publishes a canonical overlay snapshot for Task Graph contracts
+ *
+ * Corridors are stored in StoryTags for compatibility in M3:
+ *   - corridorSeaLane / corridorIslandHop / corridorLandOpen / corridorRiverChain
+ *   - corridorKind / corridorStyle / corridorAttributes metadata maps
+ */
+
+import type { ExtendedMapContext, StoryOverlaySnapshot } from "../core/types.js";
+import { inBounds, storyKey } from "../core/index.js";
+import { ctxRandom } from "../core/types.js";
+import { getTunables } from "../bootstrap/tunables.js";
+import { COAST_TERRAIN } from "../core/terrain-constants.js";
+import { getStoryTags } from "./tags.js";
+import { publishStoryOverlay, STORY_OVERLAY_KEYS } from "./overlays.js";
+
+export type CorridorStage = "preIslands" | "postRivers";
+
+type CorridorKind = "sea" | "islandHop" | "land" | "river";
+type CorridorStyle = string;
+type Orient = "col" | "row" | "diagNE" | "diagNW";
+
+const STYLE_PRIMITIVE_CACHE = new Map<string, Readonly<Record<string, unknown>>>();
+
+function freezeClone(obj: unknown): Readonly<Record<string, unknown>> | undefined {
+  if (!obj || typeof obj !== "object") return undefined;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(obj as Record<string, unknown>)) out[key] = (obj as Record<string, unknown>)[key];
+  return Object.freeze(out);
+}
+
+function fetchCorridorStylePrimitive(
+  corridorsCfg: Record<string, unknown>,
+  kind: CorridorKind,
+  style: CorridorStyle
+): Readonly<Record<string, unknown>> | null {
+  if (typeof kind !== "string" || typeof style !== "string") return null;
+  const cacheKey = `${kind}:${style}`;
+  if (STYLE_PRIMITIVE_CACHE.has(cacheKey)) return STYLE_PRIMITIVE_CACHE.get(cacheKey)!;
+
+  const kinds = corridorsCfg.kinds as Record<string, unknown> | undefined;
+  const kindCfg = (kinds?.[kind] || null) as Record<string, unknown> | null;
+  const styles = (kindCfg?.styles || null) as Record<string, unknown> | null;
+  const styleCfg = (styles?.[style] || null) as Record<string, unknown> | null;
+  if (!styleCfg) return null;
+
+  const primitive = Object.freeze({
+    kind,
+    style,
+    biomes: styleCfg.biomes ? freezeClone(styleCfg.biomes) : undefined,
+    features: styleCfg.features ? freezeClone(styleCfg.features) : undefined,
+    edge: styleCfg.edge ? freezeClone(styleCfg.edge) : undefined,
+  });
+
+  STYLE_PRIMITIVE_CACHE.set(cacheKey, primitive);
+  return primitive;
+}
+
+function assignCorridorMetadata(
+  corridorsCfg: Record<string, unknown>,
+  key: string,
+  kind: CorridorKind,
+  style: CorridorStyle
+): void {
+  if (typeof key !== "string" || typeof kind !== "string" || typeof style !== "string") return;
+  const tags = getStoryTags();
+  tags.corridorKind.set(key, kind);
+  tags.corridorStyle.set(key, style);
+  const primitive = fetchCorridorStylePrimitive(corridorsCfg, kind, style);
+  if (primitive) tags.corridorAttributes.set(key, primitive);
+  else tags.corridorAttributes.delete(key);
+}
+
+export function resetCorridorStyleCache(): void {
+  STYLE_PRIMITIVE_CACHE.clear();
+}
+
+function rand(ctx: ExtendedMapContext | null | undefined, max: number, label: string): number {
+  if (ctx) return ctxRandom(ctx, label, Math.max(1, max | 0));
+  if (typeof TerrainBuilder !== "undefined" && TerrainBuilder?.getRandomNumber) {
+    return TerrainBuilder.getRandomNumber(Math.max(1, max | 0), label || "Corr");
+  }
+  return Math.floor(Math.random() * Math.max(1, max | 0));
+}
+
+function getDims(ctx: ExtendedMapContext | null | undefined): { width: number; height: number } {
+  if (ctx?.dimensions) return { width: ctx.dimensions.width, height: ctx.dimensions.height };
+  const width = typeof GameplayMap !== "undefined" ? GameplayMap.getGridWidth() : 0;
+  const height = typeof GameplayMap !== "undefined" ? GameplayMap.getGridHeight() : 0;
+  return { width, height };
+}
+
+function isWaterAt(ctx: ExtendedMapContext | null | undefined, x: number, y: number): boolean {
+  if (ctx?.adapter) return ctx.adapter.isWater(x, y);
+  if (typeof GameplayMap !== "undefined" && GameplayMap?.isWater) return GameplayMap.isWater(x, y);
+  return true;
+}
+
+function isCoastalLand(ctx: ExtendedMapContext, x: number, y: number, width: number, height: number): boolean {
+  if (ctx.adapter.isWater(x, y)) return false;
+  for (let dy = -1; dy <= 1; dy++) {
+    for (let dx = -1; dx <= 1; dx++) {
+      if (dx === 0 && dy === 0) continue;
+      const nx = x + dx;
+      const ny = y + dy;
+      if (!inBounds(nx, ny, width, height)) continue;
+      if (ctx.adapter.isWater(nx, ny)) return true;
+    }
+  }
+  return false;
+}
+
+function isAdjacentToShallowWater(ctx: ExtendedMapContext, x: number, y: number, width: number, height: number): boolean {
+  for (let dy = -1; dy <= 1; dy++) {
+    for (let dx = -1; dx <= 1; dx++) {
+      if (dx === 0 && dy === 0) continue;
+      const nx = x + dx;
+      const ny = y + dy;
+      if (!inBounds(nx, ny, width, height)) continue;
+      if (!ctx.adapter.isWater(nx, ny)) continue;
+      if (ctx.adapter.getTerrainType(nx, ny) === COAST_TERRAIN) return true;
+    }
+  }
+  return false;
+}
+
+function isAdjacentToLand(
+  ctx: ExtendedMapContext,
+  x: number,
+  y: number,
+  radius: number,
+  width: number,
+  height: number
+): boolean {
+  for (let dy = -radius; dy <= radius; dy++) {
+    for (let dx = -radius; dx <= radius; dx++) {
+      if (dx === 0 && dy === 0) continue;
+      const nx = x + dx;
+      const ny = y + dy;
+      if (!inBounds(nx, ny, width, height)) continue;
+      if (!ctx.adapter.isWater(nx, ny)) return true;
+    }
+  }
+  return false;
+}
+
+// ----------------------------------------------------------------------------
+// Sea lanes
+// ----------------------------------------------------------------------------
+
+function hasPerpWidth(
+  ctx: ExtendedMapContext,
+  x: number,
+  y: number,
+  orient: Orient,
+  minWidth: number,
+  width: number,
+  height: number
+): boolean {
+  const r = Math.floor((minWidth - 1) / 2);
+  if (r <= 0) return ctx.adapter.isWater(x, y);
+  if (!ctx.adapter.isWater(x, y)) return false;
+
+  if (orient === "col") {
+    for (let dx = -r; dx <= r; dx++) {
+      const nx = x + dx;
+      if (nx < 0 || nx >= width) return false;
+      if (!ctx.adapter.isWater(nx, y)) return false;
+    }
+    return true;
+  }
+
+  if (orient === "row") {
+    for (let dy = -r; dy <= r; dy++) {
+      const ny = y + dy;
+      if (ny < 0 || ny >= height) return false;
+      if (!ctx.adapter.isWater(x, ny)) return false;
+    }
+    return true;
+  }
+
+  if (orient === "diagNE") {
+    for (let t = -r; t <= r; t++) {
+      const nx = x + t;
+      const ny = y + t;
+      if (nx < 0 || nx >= width || ny < 0 || ny >= height) return false;
+      if (!ctx.adapter.isWater(nx, ny)) return false;
+    }
+    return true;
+  }
+
+  if (orient === "diagNW") {
+    for (let t = -r; t <= r; t++) {
+      const nx = x + t;
+      const ny = y - t;
+      if (nx < 0 || nx >= width || ny < 0 || ny >= height) return false;
+      if (!ctx.adapter.isWater(nx, ny)) return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+function longestWaterRunColumn(ctx: ExtendedMapContext, x: number, height: number): { start: number; end: number; len: number } {
+  let bestStart = -1;
+  let bestEnd = -1;
+  let bestLen = 0;
+  let curStart = -1;
+  let curLen = 0;
+  for (let y = 0; y < height; y++) {
+    if (ctx.adapter.isWater(x, y)) {
+      if (curLen === 0) curStart = y;
+      curLen++;
+      if (curLen > bestLen) {
+        bestLen = curLen;
+        bestStart = curStart;
+        bestEnd = y;
+      }
+    } else {
+      curLen = 0;
+    }
+  }
+  return { start: bestStart, end: bestEnd, len: bestLen };
+}
+
+function longestWaterRunRow(ctx: ExtendedMapContext, y: number, width: number): { start: number; end: number; len: number } {
+  let bestStart = -1;
+  let bestEnd = -1;
+  let bestLen = 0;
+  let curStart = -1;
+  let curLen = 0;
+  for (let x = 0; x < width; x++) {
+    if (ctx.adapter.isWater(x, y)) {
+      if (curLen === 0) curStart = x;
+      curLen++;
+      if (curLen > bestLen) {
+        bestLen = curLen;
+        bestStart = curStart;
+        bestEnd = x;
+      }
+    } else {
+      curLen = 0;
+    }
+  }
+  return { start: bestStart, end: bestEnd, len: bestLen };
+}
+
+function longestWaterRunDiagSum(
+  ctx: ExtendedMapContext,
+  k: number,
+  width: number,
+  height: number
+): { startX: number; endX: number; len: number; axisLen: number } {
+  const xs = Math.max(0, k - (height - 1));
+  const xe = Math.min(width - 1, k);
+  let bestStartX = -1;
+  let bestEndX = -1;
+  let bestLen = 0;
+  let curStartX = -1;
+  let curLen = 0;
+  for (let x = xs; x <= xe; x++) {
+    const y = k - x;
+    if (ctx.adapter.isWater(x, y)) {
+      if (curLen === 0) curStartX = x;
+      curLen++;
+      if (curLen > bestLen) {
+        bestLen = curLen;
+        bestStartX = curStartX;
+        bestEndX = x;
+      }
+    } else {
+      curLen = 0;
+    }
+  }
+  return { startX: bestStartX, endX: bestEndX, len: bestLen, axisLen: xe - xs + 1 };
+}
+
+function longestWaterRunDiagDiff(
+  ctx: ExtendedMapContext,
+  d: number,
+  width: number,
+  height: number
+): { startY: number; endY: number; len: number; axisLen: number } {
+  const ys = Math.max(0, -d);
+  const ye = Math.min(height - 1, width - 1 - d);
+  let bestStartY = -1;
+  let bestEndY = -1;
+  let bestLen = 0;
+  let curStartY = -1;
+  let curLen = 0;
+  for (let y = ys; y <= ye; y++) {
+    const x = d + y;
+    if (ctx.adapter.isWater(x, y)) {
+      if (curLen === 0) curStartY = y;
+      curLen++;
+      if (curLen > bestLen) {
+        bestLen = curLen;
+        bestStartY = curStartY;
+        bestEndY = y;
+      }
+    } else {
+      curLen = 0;
+    }
+  }
+  return { startY: bestStartY, endY: bestEndY, len: bestLen, axisLen: ye - ys + 1 };
+}
+
+function tagSeaLanes(ctx: ExtendedMapContext, corridorsCfg: Record<string, unknown>): void {
+  const cfg = ((corridorsCfg.sea || {}) as Record<string, unknown>) || {};
+  const { width, height } = getDims(ctx);
+
+  const maxLanes = Math.max(0, Number((cfg.maxLanes as number) ?? 3) | 0);
+  const stride = Math.max(2, Number((cfg.scanStride as number) ?? 6) | 0);
+  const minLenFrac = Math.min(1, Math.max(0.4, Number((cfg.minLengthFrac as number) ?? 0.7)));
+  const preferDiagonals = !!cfg.preferDiagonals;
+  const laneSpacing = Math.max(0, Number((cfg.laneSpacing as number) ?? 6) | 0);
+  const requiredMinWidth = Math.max(1, Number((cfg.minChannelWidth as number) ?? 3) | 0);
+
+  const DIR = (getTunables().FOUNDATION_DIRECTIONALITY || {}) as Record<string, unknown>;
+  const COH = Math.max(0, Math.min(1, Number((DIR.cohesion as number) ?? 0)));
+  const primaryAxes = (DIR.primaryAxes || {}) as Record<string, number>;
+  const interplay = (DIR.interplay || {}) as Record<string, number>;
+  const plateAxisDeg = (primaryAxes.plateAxisDeg ?? 0) | 0;
+  let windAxisDeg = (primaryAxes.windBiasDeg ?? 0) | 0;
+  let currentAxisDeg = (primaryAxes.currentBiasDeg ?? 0) | 0;
+  const windsFollowPlates = Math.max(0, Math.min(1, interplay.windsFollowPlates ?? 0)) * COH;
+  const currentsFollowWinds = Math.max(0, Math.min(1, interplay.currentsFollowWinds ?? 0)) * COH;
+  windAxisDeg += Math.round(plateAxisDeg * windsFollowPlates);
+  currentAxisDeg += Math.round(plateAxisDeg * windsFollowPlates * 0.5);
+
+  const axisVec = (deg: number): { x: number; y: number } => {
+    const r = (deg * Math.PI) / 180;
+    return { x: Math.cos(r), y: Math.sin(r) };
+  };
+
+  const laneVec = (orient: Orient): { x: number; y: number } => {
+    if (orient === "col") return { x: 0, y: 1 };
+    if (orient === "row") return { x: 1, y: 0 };
+    if (orient === "diagNE") return { x: 1 / Math.SQRT2, y: -1 / Math.SQRT2 };
+    if (orient === "diagNW") return { x: 1 / Math.SQRT2, y: 1 / Math.SQRT2 };
+    return { x: 1, y: 0 };
+  };
+
+  const WV = axisVec(windAxisDeg);
+  const CV = axisVec(currentAxisDeg);
+
+  const directionalityBias = (orient: Orient): number => {
+    if (COH <= 0) return 0;
+    const L = laneVec(orient);
+    const dotWind = Math.abs(WV.x * L.x + WV.y * L.y);
+    const dotCurr = Math.abs(CV.x * L.x + CV.y * L.y);
+    const wW = 1.0;
+    const wC = 0.8 + 0.6 * currentsFollowWinds;
+    const align = (dotWind * wW + dotCurr * wC) / (wW + wC);
+    return Math.round(align * 25 * COH);
+  };
+
+  const candidates: Array<{ orient: Orient; index: number; start: number; end: number; len: number; minWidth: number; score: number }> = [];
+
+  const minCol = Math.floor(height * minLenFrac);
+  for (let x = 1; x < width - 1; x += stride) {
+    const run = longestWaterRunColumn(ctx, x, height);
+    if (run.len < minCol) continue;
+    const step = Math.max(1, Math.floor(run.len / 10));
+    let ok = true;
+    for (let y = run.start; y <= run.end; y += step) {
+      if (!hasPerpWidth(ctx, x, y, "col", requiredMinWidth, width, height)) {
+        ok = false;
+        break;
+      }
+    }
+    const minW = ok ? requiredMinWidth : 1;
+    const coverage = run.len / height;
+    let score = run.len + 3 * minW + Math.round(coverage * 10);
+    score += directionalityBias("col");
+    candidates.push({ orient: "col", index: x, start: run.start, end: run.end, len: run.len, minWidth: minW, score });
+  }
+
+  const minRow = Math.floor(width * minLenFrac);
+  for (let y = 1; y < height - 1; y += stride) {
+    const run = longestWaterRunRow(ctx, y, width);
+    if (run.len < minRow) continue;
+    const step = Math.max(1, Math.floor(run.len / 10));
+    let ok = true;
+    for (let x = run.start; x <= run.end; x += step) {
+      if (!hasPerpWidth(ctx, x, y, "row", requiredMinWidth, width, height)) {
+        ok = false;
+        break;
+      }
+    }
+    const minW = ok ? requiredMinWidth : 1;
+    const coverage = run.len / width;
+    let score = run.len + 3 * minW + Math.round(coverage * 10);
+    score += directionalityBias("row");
+    candidates.push({ orient: "row", index: y, start: run.start, end: run.end, len: run.len, minWidth: minW, score });
+  }
+
+  if (preferDiagonals) {
+    const kMax = (width - 1) + (height - 1);
+    for (let k = 0; k <= kMax; k += Math.max(2, stride)) {
+      const run = longestWaterRunDiagSum(ctx, k, width, height);
+      const minDiag = Math.floor(run.axisLen * minLenFrac);
+      if (run.len < minDiag || run.startX === -1) continue;
+      const step = Math.max(1, Math.floor(run.len / 10));
+      let ok = true;
+      for (let x = run.startX; x <= run.endX; x += step) {
+        const y = k - x;
+        if (!hasPerpWidth(ctx, x, y, "diagNE", requiredMinWidth, width, height)) {
+          ok = false;
+          break;
+        }
+      }
+      const minW = ok ? requiredMinWidth : 1;
+      const coverage = run.len / run.axisLen;
+      let score = run.len + 2 * minW + Math.round(coverage * 10);
+      score += directionalityBias("diagNE");
+      candidates.push({ orient: "diagNE", index: k, start: run.startX, end: run.endX, len: run.len, minWidth: minW, score });
+    }
+
+    const dMin = -(height - 1);
+    const dMax = width - 1;
+    for (let d = dMin; d <= dMax; d += Math.max(2, stride)) {
+      const run = longestWaterRunDiagDiff(ctx, d, width, height);
+      const minDiag = Math.floor(run.axisLen * minLenFrac);
+      if (run.len < minDiag || run.startY === -1) continue;
+      const step = Math.max(1, Math.floor(run.len / 10));
+      let ok = true;
+      for (let y = run.startY; y <= run.endY; y += step) {
+        const x = d + y;
+        if (!hasPerpWidth(ctx, x, y, "diagNW", requiredMinWidth, width, height)) {
+          ok = false;
+          break;
+        }
+      }
+      const minW = ok ? requiredMinWidth : 1;
+      const coverage = run.len / run.axisLen;
+      let score = run.len + 2 * minW + Math.round(coverage * 10);
+      score += directionalityBias("diagNW");
+      candidates.push({ orient: "diagNW", index: d, start: run.startY, end: run.endY, len: run.len, minWidth: minW, score });
+    }
+  }
+
+  candidates.sort((a, b) => b.score - a.score);
+
+  const chosenIdx: Record<Orient, number[]> = { col: [], row: [], diagNE: [], diagNW: [] };
+  const spaced = (orient: Orient, index: number): boolean => {
+    for (const existing of chosenIdx[orient]) {
+      if (Math.abs(existing - index) < laneSpacing) return false;
+    }
+    return true;
+  };
+
+  let lanes = 0;
+  const tags = getStoryTags();
+  for (const c of candidates) {
+    if (lanes >= maxLanes) break;
+    if (!spaced(c.orient, c.index)) continue;
+    chosenIdx[c.orient].push(c.index);
+
+    if (c.orient === "col") {
+      const x = c.index;
+      for (let y = c.start; y <= c.end; y++) {
+        if (!ctx.adapter.isWater(x, y)) continue;
+        const kk = storyKey(x, y);
+        tags.corridorSeaLane.add(kk);
+        const style = isAdjacentToLand(ctx, x, y, 2, width, height) ? "coastal" : "ocean";
+        assignCorridorMetadata(corridorsCfg, kk, "sea", style);
+      }
+    } else if (c.orient === "row") {
+      const y = c.index;
+      for (let x = c.start; x <= c.end; x++) {
+        if (!ctx.adapter.isWater(x, y)) continue;
+        const kk = storyKey(x, y);
+        tags.corridorSeaLane.add(kk);
+        const style = isAdjacentToLand(ctx, x, y, 2, width, height) ? "coastal" : "ocean";
+        assignCorridorMetadata(corridorsCfg, kk, "sea", style);
+      }
+    } else if (c.orient === "diagNE") {
+      const k = c.index;
+      for (let x = c.start; x <= c.end; x++) {
+        const y = k - x;
+        if (x < 0 || x >= width || y < 0 || y >= height) continue;
+        if (!ctx.adapter.isWater(x, y)) continue;
+        const kk = storyKey(x, y);
+        tags.corridorSeaLane.add(kk);
+        const style = isAdjacentToLand(ctx, x, y, 2, width, height) ? "coastal" : "ocean";
+        assignCorridorMetadata(corridorsCfg, kk, "sea", style);
+      }
+    } else if (c.orient === "diagNW") {
+      const d = c.index;
+      for (let y = c.start; y <= c.end; y++) {
+        const x = d + y;
+        if (x < 0 || x >= width || y < 0 || y >= height) continue;
+        if (!ctx.adapter.isWater(x, y)) continue;
+        const kk = storyKey(x, y);
+        tags.corridorSeaLane.add(kk);
+        const style = isAdjacentToLand(ctx, x, y, 2, width, height) ? "coastal" : "ocean";
+        assignCorridorMetadata(corridorsCfg, kk, "sea", style);
+      }
+    }
+
+    lanes++;
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Island-hop lanes (hotspots)
+// ----------------------------------------------------------------------------
+
+function tagIslandHopFromHotspots(ctx: ExtendedMapContext, corridorsCfg: Record<string, unknown>): void {
+  const cfg = ((corridorsCfg.islandHop || {}) as Record<string, unknown>) || {};
+  if (!cfg.useHotspots) return;
+
+  const maxArcs = Math.max(0, Number((cfg.maxArcs as number) ?? 2) | 0);
+  if (maxArcs === 0) return;
+
+  const { width, height } = getDims(ctx);
+  const tags = getStoryTags();
+  const keys = Array.from(tags.hotspot);
+  if (!keys.length) return;
+
+  const picked = new Set<string>();
+  let arcs = 0;
+  let attempts = 0;
+
+  while (arcs < maxArcs && attempts < 100 && attempts < keys.length * 2) {
+    attempts++;
+    const idx = rand(ctx, keys.length, "IslandHopPick");
+    const key = keys[idx % keys.length];
+    if (picked.has(key)) continue;
+    picked.add(key);
+    arcs++;
+
+    const [sx, sy] = key.split(",").map(Number);
+    for (let dy = -1; dy <= 1; dy++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        const nx = sx + dx;
+        const ny = sy + dy;
+        if (!inBounds(nx, ny, width, height)) continue;
+        if (!ctx.adapter.isWater(nx, ny)) continue;
+        const kk = storyKey(nx, ny);
+        tags.corridorIslandHop.add(kk);
+        assignCorridorMetadata(corridorsCfg, kk, "islandHop", "archipelago");
+      }
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Land corridors (rift shoulders)
+// ----------------------------------------------------------------------------
+
+function tagLandCorridorsFromRifts(ctx: ExtendedMapContext, corridorsCfg: Record<string, unknown>): void {
+  const cfg = ((corridorsCfg.land || {}) as Record<string, unknown>) || {};
+  if (!cfg.useRiftShoulders) return;
+
+  const { width, height } = getDims(ctx);
+  const tags = getStoryTags();
+
+  const maxCorridors = Math.max(0, Number((cfg.maxCorridors as number) ?? 2) | 0);
+  const minRun = Math.max(12, Number((cfg.minRunLength as number) ?? 24) | 0);
+  const spacing = Math.max(0, Number((cfg.spacing as number) ?? 0) | 0);
+
+  if (maxCorridors === 0 || tags.riftShoulder.size === 0) return;
+
+  let corridors = 0;
+  const usedRows: number[] = [];
+
+  for (let y = 1; y < height - 1 && corridors < maxCorridors; y++) {
+    let x = 1;
+    while (x < width - 1 && corridors < maxCorridors) {
+      while (x < width - 1 && !tags.riftShoulder.has(storyKey(x, y))) x++;
+      if (x >= width - 1) break;
+      const start = x;
+      while (x < width - 1 && tags.riftShoulder.has(storyKey(x, y))) x++;
+      const end = x - 1;
+      const len = end - start + 1;
+      if (len < minRun) continue;
+
+      let tooClose = false;
+      for (const row of usedRows) {
+        if (Math.abs(row - y) < spacing) {
+          tooClose = true;
+          break;
+        }
+      }
+      if (tooClose) continue;
+
+      let totalElev = 0;
+      let totalRain = 0;
+      let samples = 0;
+      let reliefHits = 0;
+
+      for (let cx = start; cx <= end; cx++) {
+        if (ctx.adapter.isWater(cx, y)) continue;
+        const e = ctx.adapter.getElevation(cx, y);
+        const r = ctx.adapter.getRainfall(cx, y);
+        totalElev += e;
+        totalRain += r;
+        samples++;
+
+        const eN = ctx.adapter.getElevation(cx, Math.max(0, y - 1));
+        const eS = ctx.adapter.getElevation(cx, Math.min(height - 1, y + 1));
+        const eW = ctx.adapter.getElevation(Math.max(0, cx - 1), y);
+        const eE = ctx.adapter.getElevation(Math.min(width - 1, cx + 1), y);
+        const dMax = Math.max(Math.abs(e - eN), Math.abs(e - eS), Math.abs(e - eW), Math.abs(e - eE));
+        if (dMax >= 60) reliefHits++;
+      }
+
+      const avgElev = samples > 0 ? Math.round(totalElev / samples) : 0;
+      const avgRain = samples > 0 ? Math.round(totalRain / samples) : 0;
+      const reliefFrac = samples > 0 ? reliefHits / samples : 0;
+      const latDeg = Math.abs(ctx.adapter.getLatitude(0, y));
+
+      let style = "plainsBelt";
+      if (reliefFrac > 0.35 && avgRain < 95) style = "canyon";
+      else if (avgElev > 650 && reliefFrac < 0.2) style = "plateau";
+      else if (avgElev > 550 && reliefFrac < 0.35) style = "flatMtn";
+      else if (avgRain < 85 && latDeg < 35) style = "desertBelt";
+      else if (avgRain > 115) style = "grasslandBelt";
+
+      try {
+        const DIR = (getTunables().FOUNDATION_DIRECTIONALITY || {}) as Record<string, unknown>;
+        const cohesion = Math.max(0, Math.min(1, Number((DIR.cohesion as number) ?? 0)));
+        if (cohesion > 0) {
+          const axes = (DIR.primaryAxes || {}) as Record<string, number>;
+          const plateDeg = (axes.plateAxisDeg ?? 0) | 0;
+          const windDeg = (axes.windBiasDeg ?? 0) | 0;
+          const radP = (plateDeg * Math.PI) / 180;
+          const radW = (windDeg * Math.PI) / 180;
+          const PV = { x: Math.cos(radP), y: Math.sin(radP) };
+          const WV = { x: Math.cos(radW), y: Math.sin(radW) };
+          const L = { x: 1, y: 0 };
+          const alignPlate = Math.abs(PV.x * L.x + PV.y * L.y);
+          const alignWind = Math.abs(WV.x * L.x + WV.y * L.y);
+          const hiAlign = 0.75 * cohesion + 0.1;
+          const midAlign = 0.5 * cohesion + 0.1;
+
+          if (alignPlate >= hiAlign) {
+            if (avgElev > 650 && reliefFrac < 0.28) style = "plateau";
+            else if (reliefFrac > 0.3 && avgRain < 100) style = "canyon";
+            else if (avgElev > 560 && reliefFrac < 0.35) style = "flatMtn";
+          } else if (alignPlate >= midAlign) {
+            if (avgElev > 600 && reliefFrac < 0.25) style = "plateau";
+          }
+
+          if (alignWind >= hiAlign) {
+            if (avgRain > 110 || (latDeg < 25 && avgRain > 100)) style = "grasslandBelt";
+            else if (avgRain < 90 && latDeg < 35) style = "desertBelt";
+          } else if (alignWind >= midAlign) {
+            if (avgRain > 120) style = "grasslandBelt";
+          }
+        }
+      } catch {
+        // keep baseline style
+      }
+
+      for (let cx = start; cx <= end; cx++) {
+        if (ctx.adapter.isWater(cx, y)) continue;
+        const kk = storyKey(cx, y);
+        tags.corridorLandOpen.add(kk);
+        assignCorridorMetadata(corridorsCfg, kk, "land", style);
+      }
+
+      usedRows.push(y);
+      corridors++;
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+// River chain corridors (post-rivers)
+// ----------------------------------------------------------------------------
+
+function tagRiverChainsPostRivers(ctx: ExtendedMapContext, corridorsCfg: Record<string, unknown>): void {
+  const cfg = ((corridorsCfg.river || {}) as Record<string, unknown>) || {};
+  const { width, height } = getDims(ctx);
+
+  const maxChains = Math.max(0, Number((cfg.maxChains as number) ?? 2) | 0);
+  const maxSteps = Math.max(20, Number((cfg.maxSteps as number) ?? 80) | 0);
+  const lowlandThresh = Math.max(0, Number((cfg.preferLowlandBelow as number) ?? 300) | 0);
+  const coastSeedR = Math.max(1, Number((cfg.coastSeedRadius as number) ?? 2) | 0);
+  const minTiles = Math.max(0, Number((cfg.minTiles as number) ?? 0) | 0);
+  const mustEndNearCoast = !!cfg.mustEndNearCoast;
+
+  if (maxChains === 0) return;
+
+  const tags = getStoryTags();
+  let chains = 0;
+  let tries = 0;
+
+  while (chains < maxChains && tries < 300) {
+    tries++;
+    const sx = rand(ctx, width, "RiverChainSX");
+    const sy = rand(ctx, height, "RiverChainSY");
+    if (!inBounds(sx, sy, width, height)) continue;
+    if (!isCoastalLand(ctx, sx, sy, width, height)) continue;
+    if (!ctx.adapter.isAdjacentToRivers(sx, sy, coastSeedR)) continue;
+
+    let x = sx;
+    let y = sy;
+    let steps = 0;
+    const pathKeys: string[] = [];
+
+    while (steps < maxSteps) {
+      if (!ctx.adapter.isWater(x, y) && ctx.adapter.isAdjacentToRivers(x, y, 1)) {
+        pathKeys.push(storyKey(x, y));
+      }
+
+      let bx = x;
+      let by = y;
+      let be = ctx.adapter.getElevation(x, y);
+      let improved = false;
+
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          if (dx === 0 && dy === 0) continue;
+          const nx = x + dx;
+          const ny = y + dy;
+          if (!inBounds(nx, ny, width, height) || ctx.adapter.isWater(nx, ny)) continue;
+          if (!ctx.adapter.isAdjacentToRivers(nx, ny, 1)) continue;
+          const e = ctx.adapter.getElevation(nx, ny);
+          const prefer = e <= be || (e < lowlandThresh && be >= lowlandThresh);
+          if (!prefer) continue;
+          if (!improved || rand(ctx, 3, "RiverChainTie") === 0) {
+            bx = nx;
+            by = ny;
+            be = e;
+            improved = true;
+          }
+        }
+      }
+
+      if (!improved) break;
+      x = bx;
+      y = by;
+      steps++;
+    }
+
+    let endOK = true;
+    if (mustEndNearCoast) {
+      endOK = isCoastalLand(ctx, x, y, width, height) || isAdjacentToShallowWater(ctx, x, y, width, height);
+    }
+
+    if (pathKeys.length >= minTiles && endOK) {
+      for (const kk of pathKeys) {
+        tags.corridorRiverChain.add(kk);
+        assignCorridorMetadata(corridorsCfg, kk, "river", "riverChain");
+      }
+      chains++;
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Backfill + overlay
+// ----------------------------------------------------------------------------
+
+function backfillCorridorKinds(ctx: ExtendedMapContext, corridorsCfg: Record<string, unknown>): void {
+  const { width, height } = getDims(ctx);
+  const tags = getStoryTags();
+
+  for (const key of tags.corridorSeaLane) {
+    const kind = (tags.corridorKind.get(key) as CorridorKind) || "sea";
+    let style = tags.corridorStyle.get(key);
+    if (!style) {
+      const [sx, sy] = key.split(",").map(Number);
+      style = isAdjacentToShallowWater(ctx, sx, sy, width, height) ? "coastal" : "ocean";
+    }
+    assignCorridorMetadata(corridorsCfg, key, kind, style);
+  }
+
+  for (const key of tags.corridorIslandHop) {
+    const kind = (tags.corridorKind.get(key) as CorridorKind) || "islandHop";
+    const style = tags.corridorStyle.get(key) || "archipelago";
+    assignCorridorMetadata(corridorsCfg, key, kind, style);
+  }
+
+  for (const key of tags.corridorLandOpen) {
+    const kind = (tags.corridorKind.get(key) as CorridorKind) || "land";
+    const style = tags.corridorStyle.get(key) || "plainsBelt";
+    assignCorridorMetadata(corridorsCfg, key, kind, style);
+  }
+
+  for (const key of tags.corridorRiverChain) {
+    const kind = (tags.corridorKind.get(key) as CorridorKind) || "river";
+    const style = tags.corridorStyle.get(key) || "riverChain";
+    assignCorridorMetadata(corridorsCfg, key, kind, style);
+  }
+}
+
+export function storyTagStrategicCorridors(ctx: ExtendedMapContext, stage: CorridorStage): StoryOverlaySnapshot {
+  const tunables = getTunables();
+  const corridorsCfg = (tunables.FOUNDATION_CFG?.corridors || {}) as Record<string, unknown>;
+
+  resetCorridorStyleCache();
+
+  if (stage === "preIslands") {
+    tagSeaLanes(ctx, corridorsCfg);
+    tagIslandHopFromHotspots(ctx, corridorsCfg);
+    tagLandCorridorsFromRifts(ctx, corridorsCfg);
+    backfillCorridorKinds(ctx, corridorsCfg);
+  } else if (stage === "postRivers") {
+    tagRiverChainsPostRivers(ctx, corridorsCfg);
+    backfillCorridorKinds(ctx, corridorsCfg);
+  }
+
+  const tags = getStoryTags();
+  const all = new Set<string>();
+  for (const k of tags.corridorSeaLane) all.add(k);
+  for (const k of tags.corridorIslandHop) all.add(k);
+  for (const k of tags.corridorLandOpen) all.add(k);
+  for (const k of tags.corridorRiverChain) all.add(k);
+
+  const { width, height } = ctx.dimensions;
+  return publishStoryOverlay(ctx, STORY_OVERLAY_KEYS.CORRIDORS, {
+    kind: STORY_OVERLAY_KEYS.CORRIDORS,
+    version: 1,
+    width,
+    height,
+    active: Array.from(all),
+    summary: {
+      stage,
+      seaLaneTiles: tags.corridorSeaLane.size,
+      islandHopTiles: tags.corridorIslandHop.size,
+      landOpenTiles: tags.corridorLandOpen.size,
+      riverChainTiles: tags.corridorRiverChain.size,
+      totalTiles: all.size,
+    },
+  });
+}
+

--- a/packages/mapgen-core/src/story/index.ts
+++ b/packages/mapgen-core/src/story/index.ts
@@ -46,3 +46,22 @@ export {
   type HotspotTrailsSummary,
   type RiftValleysSummary,
 } from "./tagging.js";
+
+export {
+  getOrogenyCache,
+  resetOrogenyCache,
+  clearOrogenyCache,
+  storyTagOrogenyBelts,
+  type OrogenyCacheInstance,
+  type OrogenySummary,
+} from "./orogeny.js";
+
+export {
+  resetCorridorStyleCache,
+  storyTagStrategicCorridors,
+  type CorridorStage,
+} from "./corridors.js";
+
+export { storyTagClimateSwatches, storyTagClimatePaleo } from "./swatches.js";
+
+export { storyTagPaleoHydrology, type PaleoSummary } from "./paleo.js";

--- a/packages/mapgen-core/src/story/orogeny.ts
+++ b/packages/mapgen-core/src/story/orogeny.ts
@@ -1,0 +1,237 @@
+/**
+ * Story Orogeny — Mountain belt tagging and windward/lee cache.
+ *
+ * Ports legacy story/orogeny logic into a MapContext-friendly implementation:
+ * - Uses FoundationContext tensors when available
+ * - Falls back to a conservative elevation-density heuristic otherwise
+ * - Publishes an immutable overlay snapshot for Task Graph contracts
+ *
+ * Uses lazy provider pattern for test isolation.
+ */
+
+import type { ExtendedMapContext, StoryOverlaySnapshot } from "../core/types.js";
+import { inBounds, storyKey } from "../core/index.js";
+import { getTunables } from "../bootstrap/tunables.js";
+import { publishStoryOverlay, STORY_OVERLAY_KEYS } from "./overlays.js";
+
+export interface OrogenyCacheInstance {
+  belts: Set<string>;
+  windward: Set<string>;
+  lee: Set<string>;
+}
+
+let _cache: OrogenyCacheInstance | null = null;
+
+function createCache(): OrogenyCacheInstance {
+  return { belts: new Set(), windward: new Set(), lee: new Set() };
+}
+
+export function getOrogenyCache(): OrogenyCacheInstance {
+  if (_cache) return _cache;
+  _cache = createCache();
+  return _cache;
+}
+
+export function resetOrogenyCache(): void {
+  _cache = null;
+}
+
+export function clearOrogenyCache(): void {
+  const cache = getOrogenyCache();
+  cache.belts.clear();
+  cache.windward.clear();
+  cache.lee.clear();
+}
+
+function getDims(ctx: ExtendedMapContext | null | undefined): { width: number; height: number } {
+  if (ctx?.dimensions) return { width: ctx.dimensions.width, height: ctx.dimensions.height };
+  const width = typeof GameplayMap !== "undefined" ? GameplayMap.getGridWidth() : 0;
+  const height = typeof GameplayMap !== "undefined" ? GameplayMap.getGridHeight() : 0;
+  return { width, height };
+}
+
+function isWaterAt(ctx: ExtendedMapContext | null | undefined, x: number, y: number): boolean {
+  if (ctx?.adapter) return ctx.adapter.isWater(x, y);
+  if (typeof GameplayMap !== "undefined" && GameplayMap?.isWater) return GameplayMap.isWater(x, y);
+  return true;
+}
+
+function zonalWindStep(
+  ctx: ExtendedMapContext | null | undefined,
+  x: number,
+  y: number
+): { dx: number; dy: number } {
+  try {
+    const lat = Math.abs(ctx?.adapter?.getLatitude?.(x, y) ?? GameplayMap?.getPlotLatitude?.(x, y) ?? 0);
+    return { dx: lat < 30 || lat >= 60 ? -1 : 1, dy: 0 };
+  } catch {
+    return { dx: 1, dy: 0 };
+  }
+}
+
+export interface OrogenySummary {
+  belts: number;
+  windward: number;
+  lee: number;
+  kind: "foundation" | "legacy";
+}
+
+/**
+ * Tag orogeny belts and populate an in-memory OrogenyCache for climate swatches.
+ * Always publishes a `storyOverlays` snapshot (even if empty) for Task Graph contracts.
+ */
+export function storyTagOrogenyBelts(ctx: ExtendedMapContext | null = null): StoryOverlaySnapshot {
+  const cache = getOrogenyCache();
+  cache.belts.clear();
+  cache.windward.clear();
+  cache.lee.clear();
+
+  const { width, height } = getDims(ctx);
+  const area = Math.max(1, width * height);
+  const sqrtScale = Math.min(2.0, Math.max(0.6, Math.sqrt(area / 10000)));
+
+  const tunables = getTunables();
+  const storyCfg = (tunables.FOUNDATION_CFG?.story || {}) as Record<string, unknown>;
+  const cfg = (storyCfg.orogeny || {}) as Record<string, number>;
+
+  const baseRadius = Number.isFinite(cfg.radius) ? (cfg.radius | 0) : 2;
+  const radius = baseRadius + (sqrtScale > 1.5 ? 1 : 0);
+  const beltMinLength = Number.isFinite(cfg.beltMinLength) ? (cfg.beltMinLength | 0) : 30;
+  const minLenSoft = Math.max(10, Math.round(beltMinLength * (0.9 + 0.4 * sqrtScale)));
+
+  let kind: OrogenySummary["kind"] = "legacy";
+
+  if (ctx?.foundation?.plates && ctx?.foundation?.dynamics) {
+    kind = "foundation";
+
+    const U = ctx.foundation.plates.upliftPotential;
+    const S = ctx.foundation.plates.tectonicStress;
+    const BT = ctx.foundation.plates.boundaryType;
+    const BC = ctx.foundation.plates.boundaryCloseness;
+
+    let thr = 180;
+    let attempts = 0;
+    while (attempts++ < 5) {
+      cache.belts.clear();
+      for (let y = 1; y < height - 1; y++) {
+        for (let x = 1; x < width - 1; x++) {
+          if (isWaterAt(ctx, x, y)) continue;
+          const i = y * width + x;
+          if (BT[i] !== 1 || BC[i] < 48) continue;
+          const metric = Math.round(0.7 * U[i] + 0.3 * S[i]);
+          if (metric < thr) continue;
+
+          let dense = 0;
+          for (let dy = -1; dy <= 1; dy++) {
+            for (let dx = -1; dx <= 1; dx++) {
+              if (dx === 0 && dy === 0) continue;
+              const j = (y + dy) * width + (x + dx);
+              if (j < 0 || j >= width * height) continue;
+              const m2 = Math.round(0.7 * U[j] + 0.3 * S[j]);
+              if (m2 >= thr) dense++;
+            }
+          }
+          if (dense >= 2) cache.belts.add(storyKey(x, y));
+        }
+      }
+      if (cache.belts.size >= minLenSoft || thr <= 128) break;
+      thr -= 12;
+    }
+
+    const windU = ctx.foundation.dynamics.windU;
+    const windV = ctx.foundation.dynamics.windV;
+    const windStepXY = (x: number, y: number): { dx: number; dy: number } => {
+      try {
+        const i = y * width + x;
+        const u = windU[i] | 0;
+        const v = windV[i] | 0;
+        if (Math.abs(u) >= Math.abs(v)) return { dx: u === 0 ? 0 : u > 0 ? 1 : -1, dy: 0 };
+        return { dx: 0, dy: v === 0 ? 0 : v > 0 ? 1 : -1 };
+      } catch {
+        return zonalWindStep(ctx, x, y);
+      }
+    };
+
+    if (cache.belts.size >= minLenSoft) {
+      for (const key of cache.belts) {
+        const [sx, sy] = key.split(",").map(Number);
+        const { dx, dy } = windStepXY(sx, sy);
+        const upwindX = -dx;
+        const upwindY = -dy;
+        const downX = dx;
+        const downY = dy;
+        for (let r = 1; r <= radius; r++) {
+          const wx = sx + upwindX * r;
+          const wy = sy + upwindY * r;
+          const lx = sx + downX * r;
+          const ly = sy + downY * r;
+          if (inBounds(wx, wy, width, height) && !isWaterAt(ctx, wx, wy)) cache.windward.add(storyKey(wx, wy));
+          if (inBounds(lx, ly, width, height) && !isWaterAt(ctx, lx, ly)) cache.lee.add(storyKey(lx, ly));
+        }
+      }
+    } else {
+      cache.belts.clear();
+    }
+  } else {
+    const isHighElev = (x: number, y: number): boolean => {
+      if (!inBounds(x, y, width, height)) return false;
+      try {
+        if (ctx?.adapter?.isMountain?.(x, y)) return true;
+      } catch {
+        // ignore
+      }
+      const elev = ctx?.adapter?.getElevation?.(x, y) ?? GameplayMap?.getElevation?.(x, y) ?? 0;
+      return elev >= 500;
+    };
+
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        if (!isHighElev(x, y)) continue;
+        let hi = 0;
+        for (let dy = -1; dy <= 1; dy++) {
+          for (let dx = -1; dx <= 1; dx++) {
+            if (dx === 0 && dy === 0) continue;
+            if (isHighElev(x + dx, y + dy)) hi++;
+          }
+        }
+        if (hi >= 2) cache.belts.add(storyKey(x, y));
+      }
+    }
+
+    if (cache.belts.size >= minLenSoft) {
+      for (const key of cache.belts) {
+        const [x, y] = key.split(",").map(Number);
+        const { dx, dy } = zonalWindStep(ctx, x, y);
+        const upwindX = -dx;
+        const upwindY = -dy;
+        const downX = dx;
+        const downY = dy;
+        for (let r = 1; r <= radius; r++) {
+          const wx = x + upwindX * r;
+          const wy = y + upwindY * r;
+          const lx = x + downX * r;
+          const ly = y + downY * r;
+          if (inBounds(wx, wy, width, height) && !isWaterAt(ctx, wx, wy)) cache.windward.add(storyKey(wx, wy));
+          if (inBounds(lx, ly, width, height) && !isWaterAt(ctx, lx, ly)) cache.lee.add(storyKey(lx, ly));
+        }
+      }
+    } else {
+      cache.belts.clear();
+    }
+  }
+
+  return publishStoryOverlay(ctx, STORY_OVERLAY_KEYS.OROGENY, {
+    kind: STORY_OVERLAY_KEYS.OROGENY,
+    version: 1,
+    width,
+    height,
+    active: Array.from(cache.belts),
+    passive: Array.from(cache.windward),
+    summary: {
+      belts: cache.belts.size,
+      windward: cache.windward.size,
+      lee: cache.lee.size,
+      kind,
+    },
+  });
+}

--- a/packages/mapgen-core/src/story/overlays.ts
+++ b/packages/mapgen-core/src/story/overlays.ts
@@ -20,7 +20,12 @@ import type { StoryTagsInstance } from "./tags.js";
  */
 export const STORY_OVERLAY_KEYS = {
   MARGINS: "margins",
+  HOTSPOTS: "hotspots",
+  RIFTS: "rifts",
+  OROGENY: "orogeny",
   CORRIDORS: "corridors",
+  SWATCHES: "swatches",
+  PALEO: "paleo",
 } as const;
 
 export type StoryOverlayKey = (typeof STORY_OVERLAY_KEYS)[keyof typeof STORY_OVERLAY_KEYS];

--- a/packages/mapgen-core/src/story/paleo.ts
+++ b/packages/mapgen-core/src/story/paleo.ts
@@ -1,0 +1,254 @@
+/**
+ * Story Paleo Hydrology — subtle rainfall artifacts (deltas, oxbows, fossils).
+ *
+ * Ported from legacy storyTagPaleoHydrology, adapted to prefer:
+ * - ctx.buffers.climate.rainfall via syncClimateField/writeClimateField
+ * - EngineAdapter reads/writes (no direct engine calls when ctx provided)
+ */
+
+import type { ExtendedMapContext } from "../core/types.js";
+import { inBounds } from "../core/index.js";
+import { ctxRandom, writeClimateField, syncClimateField } from "../core/types.js";
+import { getTunables } from "../bootstrap/tunables.js";
+
+export interface PaleoSummary {
+  deltas: number;
+  oxbows: number;
+  fossils: number;
+  kind: "applied" | "missing-config";
+}
+
+function getDims(ctx: ExtendedMapContext | null | undefined): { width: number; height: number } {
+  if (ctx?.dimensions) return { width: ctx.dimensions.width, height: ctx.dimensions.height };
+  const width = typeof GameplayMap !== "undefined" ? GameplayMap.getGridWidth() : 0;
+  const height = typeof GameplayMap !== "undefined" ? GameplayMap.getGridHeight() : 0;
+  return { width, height };
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v;
+}
+
+function isWaterAt(ctx: ExtendedMapContext | null | undefined, x: number, y: number): boolean {
+  if (ctx?.adapter) return ctx.adapter.isWater(x, y);
+  if (typeof GameplayMap !== "undefined" && GameplayMap?.isWater) return GameplayMap.isWater(x, y);
+  return true;
+}
+
+function isCoastalLand(
+  ctx: ExtendedMapContext | null | undefined,
+  x: number,
+  y: number,
+  width: number,
+  height: number
+): boolean {
+  if (isWaterAt(ctx, x, y)) return false;
+  for (let dy = -1; dy <= 1; dy++) {
+    for (let dx = -1; dx <= 1; dx++) {
+      if (dx === 0 && dy === 0) continue;
+      const nx = x + dx;
+      const ny = y + dy;
+      if (!inBounds(nx, ny, width, height)) continue;
+      if (isWaterAt(ctx, nx, ny)) return true;
+    }
+  }
+  return false;
+}
+
+function rand(ctx: ExtendedMapContext | null | undefined, max: number, label: string): number {
+  if (ctx) return ctxRandom(ctx, label, Math.max(1, max | 0));
+  if (typeof TerrainBuilder !== "undefined" && TerrainBuilder?.getRandomNumber) {
+    return TerrainBuilder.getRandomNumber(Math.max(1, max | 0), label);
+  }
+  return Math.floor(Math.random() * Math.max(1, max | 0));
+}
+
+/**
+ * Apply paleo-hydrology rainfall artifacts.
+ *
+ * Configuration is read from `CLIMATE_CFG.story.paleo` (untyped legacy shape).
+ */
+export function storyTagPaleoHydrology(ctx: ExtendedMapContext | null = null): PaleoSummary {
+  const tunables = getTunables();
+  const climateCfg = (tunables.CLIMATE_CFG || {}) as Record<string, unknown>;
+  const story = (climateCfg.story || {}) as Record<string, unknown>;
+  const cfg = story.paleo as Record<string, unknown> | undefined;
+
+  if (!cfg) {
+    return { deltas: 0, oxbows: 0, fossils: 0, kind: "missing-config" };
+  }
+
+  const { width, height } = getDims(ctx);
+  const area = Math.max(1, width * height);
+  const sqrtScale = Math.min(2.0, Math.max(0.6, Math.sqrt(area / 10000)));
+
+  if (ctx) syncClimateField(ctx);
+
+  const adapter = ctx?.adapter ?? null;
+  const rainfallBuf = ctx?.buffers?.climate?.rainfall || null;
+  const idx = (x: number, y: number): number => y * width + x;
+
+  const readRainfall = (x: number, y: number): number => {
+    if (ctx && rainfallBuf) return rainfallBuf[idx(x, y)] | 0;
+    return GameplayMap?.getRainfall?.(x, y) ?? 0;
+  };
+
+  const writeRainfall = (x: number, y: number, rainfall: number): void => {
+    const clamped = clamp(rainfall, 0, 200);
+    if (ctx) {
+      writeClimateField(ctx, x, y, { rainfall: clamped });
+    } else if (typeof TerrainBuilder !== "undefined" && TerrainBuilder?.setRainfall) {
+      TerrainBuilder.setRainfall(x, y, clamped);
+    }
+  };
+
+  const maxDeltas = Math.max(0, Number((cfg.maxDeltas as number) ?? 0) | 0);
+  const deltaFanRadius = Math.max(0, Number((cfg.deltaFanRadius as number) ?? 0) | 0);
+  const deltaMarshChance = Math.max(0, Math.min(1, Number((cfg.deltaMarshChance as number) ?? 0.35)));
+  const maxOxbows = Math.max(0, Number((cfg.maxOxbows as number) ?? 0) | 0);
+  const oxbowElevationMax = Number((cfg.oxbowElevationMax as number) ?? 280);
+  const maxFossilChannels = Math.max(0, Number((cfg.maxFossilChannels as number) ?? 0) | 0);
+
+  let deltas = 0;
+  let oxbows = 0;
+  let fossils = 0;
+
+  if (maxDeltas > 0) {
+    for (let y = 1; y < height - 1 && deltas < maxDeltas; y++) {
+      for (let x = 1; x < width - 1 && deltas < maxDeltas; x++) {
+        if (!isCoastalLand(ctx, x, y, width, height)) continue;
+        if (!(adapter?.isAdjacentToRivers ? adapter.isAdjacentToRivers(x, y, 1) : GameplayMap?.isAdjacentToRivers?.(x, y, 1))) {
+          continue;
+        }
+        const elev = adapter?.getElevation ? adapter.getElevation(x, y) : (GameplayMap?.getElevation?.(x, y) ?? 0);
+        if (elev > 300) continue;
+
+        for (let dy = -deltaFanRadius; dy <= deltaFanRadius; dy++) {
+          for (let dx = -deltaFanRadius; dx <= deltaFanRadius; dx++) {
+            const nx = x + dx;
+            const ny = y + dy;
+            if (!inBounds(nx, ny, width, height)) continue;
+            if (isWaterAt(ctx, nx, ny)) continue;
+            let rf = readRainfall(nx, ny);
+            rf += rand(ctx, 100, "DeltaMarsh") < Math.round(deltaMarshChance * 100) ? 6 : 3;
+            writeRainfall(nx, ny, rf);
+          }
+        }
+
+        deltas++;
+      }
+    }
+  }
+
+  if (maxOxbows > 0) {
+    let attempts = 0;
+    while (oxbows < maxOxbows && attempts < 300) {
+      attempts++;
+      const x = rand(ctx, width, "OxbowX");
+      const y = rand(ctx, height, "OxbowY");
+      if (!inBounds(x, y, width, height)) continue;
+      if (isWaterAt(ctx, x, y)) continue;
+
+      const elev = adapter?.getElevation ? adapter.getElevation(x, y) : (GameplayMap?.getElevation?.(x, y) ?? 0);
+      if (elev > oxbowElevationMax) continue;
+      if (!(adapter?.isAdjacentToRivers ? adapter.isAdjacentToRivers(x, y, 1) : GameplayMap?.isAdjacentToRivers?.(x, y, 1))) {
+        continue;
+      }
+
+      const rf = readRainfall(x, y);
+      writeRainfall(x, y, rf + 8);
+      oxbows++;
+    }
+  }
+
+  if (maxFossilChannels > 0) {
+    const baseLen = Math.max(6, Number((cfg.fossilChannelLengthTiles as number) ?? 6) | 0);
+    const step = Math.max(1, Number((cfg.fossilChannelStep as number) ?? 1) | 0);
+    const sizeScaling = (cfg.sizeScaling || {}) as Record<string, number>;
+    const len = Math.round(baseLen * (1 + (sizeScaling?.lengthMulSqrt || 0) * (sqrtScale - 1)));
+    const hum = Number((cfg.fossilChannelHumidity as number) ?? 0) | 0;
+    const minDistFromRivers = Math.max(
+      0,
+      Number((cfg.fossilChannelMinDistanceFromCurrentRivers as number) ?? 0) | 0
+    );
+    const canyonCfg = (cfg.elevationCarving || {}) as Record<string, unknown>;
+    const rimW = Math.max(0, Number((canyonCfg.rimWidth as number) ?? 0) | 0);
+    const canyonDryBonus = Math.max(0, Number((canyonCfg.canyonDryBonus as number) ?? 0) | 0);
+    const bluffWetReduction = Math.max(0, Number((cfg.bluffWetReduction as number) ?? 0) | 0);
+
+    let tries = 0;
+    while (fossils < maxFossilChannels && tries < 120) {
+      tries++;
+      const sx = rand(ctx, width, "FossilX");
+      const sy = rand(ctx, height, "FossilY");
+      if (!inBounds(sx, sy, width, height)) continue;
+      if (isWaterAt(ctx, sx, sy)) continue;
+      const startElev = adapter?.getElevation ? adapter.getElevation(sx, sy) : (GameplayMap?.getElevation?.(sx, sy) ?? 0);
+      if (startElev > 320) continue;
+      if (adapter?.isAdjacentToRivers?.(sx, sy, minDistFromRivers) ?? GameplayMap?.isAdjacentToRivers?.(sx, sy, minDistFromRivers)) {
+        continue;
+      }
+
+      let x = sx;
+      let y = sy;
+      let used = 0;
+
+      while (used < len) {
+        if (inBounds(x, y, width, height) && !isWaterAt(ctx, x, y)) {
+          let rf = readRainfall(x, y);
+          rf = clamp(rf + hum, 0, 200);
+          const enableCanyonRim = (canyonCfg.enableCanyonRim as boolean | undefined) ?? true;
+          if (enableCanyonRim && canyonDryBonus > 0) {
+            rf = clamp(rf - canyonDryBonus, 0, 200);
+          }
+          writeRainfall(x, y, rf);
+
+          if (enableCanyonRim && rimW > 0) {
+            for (let ry = -rimW; ry <= rimW; ry++) {
+              for (let rx = -rimW; rx <= rimW; rx++) {
+                if (rx === 0 && ry === 0) continue;
+                const nx = x + rx;
+                const ny = y + ry;
+                if (!inBounds(nx, ny, width, height) || isWaterAt(ctx, nx, ny)) continue;
+                const e0 = adapter?.getElevation ? adapter.getElevation(x, y) : (GameplayMap?.getElevation?.(x, y) ?? 0);
+                const e1 = adapter?.getElevation ? adapter.getElevation(nx, ny) : (GameplayMap?.getElevation?.(nx, ny) ?? 0);
+                if (e1 > e0 + 15) {
+                  const rfn = clamp(readRainfall(nx, ny) - bluffWetReduction, 0, 200);
+                  writeRainfall(nx, ny, rfn);
+                }
+              }
+            }
+          }
+        }
+
+        let bestNX = x;
+        let bestNY = y;
+        let bestElev = adapter?.getElevation ? adapter.getElevation(x, y) : (GameplayMap?.getElevation?.(x, y) ?? 0);
+        for (let dy = -1; dy <= 1; dy++) {
+          for (let dx = -1; dx <= 1; dx++) {
+            if (dx === 0 && dy === 0) continue;
+            if ((Math.abs(dx) + Math.abs(dy)) * step > 2) continue;
+            const nx = x + dx;
+            const ny = y + dy;
+            if (!inBounds(nx, ny, width, height)) continue;
+            const elev = adapter?.getElevation ? adapter.getElevation(nx, ny) : (GameplayMap?.getElevation?.(nx, ny) ?? 0);
+            if (elev < bestElev) {
+              bestElev = elev;
+              bestNX = nx;
+              bestNY = ny;
+            }
+          }
+        }
+
+        if (bestNX === x && bestNY === y) break;
+        x = bestNX;
+        y = bestNY;
+        used += step;
+      }
+
+      if (used >= len) fossils++;
+    }
+  }
+
+  return { deltas, oxbows, fossils, kind: "applied" };
+}

--- a/packages/mapgen-core/src/story/paleo.ts
+++ b/packages/mapgen-core/src/story/paleo.ts
@@ -2,13 +2,13 @@
  * Story Paleo Hydrology — subtle rainfall artifacts (deltas, oxbows, fossils).
  *
  * Ported from legacy storyTagPaleoHydrology, adapted to prefer:
- * - ctx.buffers.climate.rainfall via syncClimateField/writeClimateField
+ * - ctx.buffers.climate.rainfall via writeClimateField (climate buffers are canonical)
  * - EngineAdapter reads/writes (no direct engine calls when ctx provided)
  */
 
 import type { ExtendedMapContext } from "../core/types.js";
 import { inBounds } from "../core/index.js";
-import { ctxRandom, writeClimateField, syncClimateField } from "../core/types.js";
+import { ctxRandom, writeClimateField } from "../core/types.js";
 import { getTunables } from "../bootstrap/tunables.js";
 
 export interface PaleoSummary {
@@ -82,7 +82,11 @@ export function storyTagPaleoHydrology(ctx: ExtendedMapContext | null = null): P
   const area = Math.max(1, width * height);
   const sqrtScale = Math.min(2.0, Math.max(0.6, Math.sqrt(area / 10000)));
 
-  if (ctx) syncClimateField(ctx);
+  if (ctx && !ctx.buffers?.climate?.rainfall) {
+    throw new Error(
+      "[Story] Paleo hydrology requires canonical climate buffers. Ensure climate stages run before storySwatches (and avoid engine rainfall reads)."
+    );
+  }
 
   const adapter = ctx?.adapter ?? null;
   const rainfallBuf = ctx?.buffers?.climate?.rainfall || null;

--- a/packages/mapgen-core/src/story/swatches.ts
+++ b/packages/mapgen-core/src/story/swatches.ts
@@ -1,0 +1,61 @@
+/**
+ * Story Swatches — macro climate swatches + optional paleo hydrology.
+ *
+ * Operates on the canonical ClimateField buffer and publishes immutable overlay
+ * snapshots describing what was applied.
+ */
+
+import type { ExtendedMapContext } from "../core/types.js";
+import { applyClimateSwatches } from "../layers/climate-engine.js";
+import type { OrogenyCache } from "../layers/climate-engine.js";
+import { publishStoryOverlay, STORY_OVERLAY_KEYS } from "./overlays.js";
+import { storyTagPaleoHydrology } from "./paleo.js";
+
+export interface ClimateSwatchesSummary {
+  applied: boolean;
+  kind: string;
+  tiles?: number;
+}
+
+export function storyTagClimateSwatches(
+  ctx: ExtendedMapContext,
+  options: { orogenyCache?: OrogenyCache } = {}
+): ClimateSwatchesSummary {
+  const { width, height } = ctx.dimensions;
+
+  const result = applyClimateSwatches(width, height, ctx, {
+    orogenyCache: options.orogenyCache,
+  });
+
+  publishStoryOverlay(ctx, STORY_OVERLAY_KEYS.SWATCHES, {
+    kind: STORY_OVERLAY_KEYS.SWATCHES,
+    version: 1,
+    width,
+    height,
+    summary: {
+      applied: result.applied,
+      kind: result.kind,
+      tiles: result.tiles,
+    },
+  });
+
+  return result;
+}
+
+export function storyTagClimatePaleo(ctx: ExtendedMapContext): void {
+  const { width, height } = ctx.dimensions;
+  const summary = storyTagPaleoHydrology(ctx);
+
+  publishStoryOverlay(ctx, STORY_OVERLAY_KEYS.PALEO, {
+    kind: STORY_OVERLAY_KEYS.PALEO,
+    version: 1,
+    width,
+    height,
+    summary: {
+      deltas: summary.deltas,
+      oxbows: summary.oxbows,
+      fossils: summary.fossils,
+      kind: summary.kind,
+    },
+  });
+}

--- a/packages/mapgen-core/src/story/tagging.ts
+++ b/packages/mapgen-core/src/story/tagging.ts
@@ -356,7 +356,18 @@ export function storyTagHotspotTrails(
     if (taggedThisTrail > 0) trailsMade++;
   }
 
-  return { trails: trailsMade, points: totalPoints };
+  const summary = { trails: trailsMade, points: totalPoints };
+
+  publishStoryOverlay(ctx, STORY_OVERLAY_KEYS.HOTSPOTS, {
+    kind: STORY_OVERLAY_KEYS.HOTSPOTS,
+    version: 1,
+    width,
+    height,
+    active: Array.from(StoryTags.hotspot),
+    summary: { trails: summary.trails, points: summary.points },
+  });
+
+  return summary;
 }
 
 // ============================================================================
@@ -589,12 +600,29 @@ export function storyTagRiftValleys(
       if (riftsMade >= maxRiftsPerMap) break;
     }
 
-    return {
+    const summary: RiftValleysSummary = {
       rifts: riftsMade,
       lineTiles: lineCount,
       shoulderTiles: shoulderCount,
       kind: "foundation",
     };
+
+    publishStoryOverlay(ctx, STORY_OVERLAY_KEYS.RIFTS, {
+      kind: STORY_OVERLAY_KEYS.RIFTS,
+      version: 1,
+      width,
+      height,
+      active: Array.from(StoryTags.riftLine),
+      passive: Array.from(StoryTags.riftShoulder),
+      summary: {
+        rifts: summary.rifts,
+        lineTiles: summary.lineTiles,
+        shoulderTiles: summary.shoulderTiles,
+        kind: summary.kind,
+      },
+    });
+
+    return summary;
   }
 
   // Legacy random marching fallback.
@@ -685,12 +713,29 @@ export function storyTagRiftValleys(
     if (placedAny) riftsMade++;
   }
 
-  return {
+  const summary: RiftValleysSummary = {
     rifts: riftsMade,
     lineTiles: lineCount,
     shoulderTiles: shoulderCount,
     kind: "legacy",
   };
+
+  publishStoryOverlay(ctx, STORY_OVERLAY_KEYS.RIFTS, {
+    kind: STORY_OVERLAY_KEYS.RIFTS,
+    version: 1,
+    width,
+    height,
+    active: Array.from(StoryTags.riftLine),
+    passive: Array.from(StoryTags.riftShoulder),
+    summary: {
+      rifts: summary.rifts,
+      lineTiles: summary.lineTiles,
+      shoulderTiles: summary.shoulderTiles,
+      kind: summary.kind,
+    },
+  });
+
+  return summary;
 }
 
 // ============================================================================

--- a/packages/mapgen-core/test/pipeline/artifacts.test.ts
+++ b/packages/mapgen-core/test/pipeline/artifacts.test.ts
@@ -7,6 +7,7 @@ import {
   StepRegistry,
   M3_DEPENDENCY_TAGS,
 } from "../../src/pipeline/index.js";
+import { M3_STAGE_DEPENDENCY_SPINE } from "../../src/pipeline/standard.js";
 import { isDependencyTagSatisfied } from "../../src/pipeline/tags.js";
 import {
   computeRiverAdjacencyMask,
@@ -15,6 +16,16 @@ import {
 } from "../../src/pipeline/artifacts.js";
 
 describe("pipeline artifacts", () => {
+  it("includes climate/river prerequisites for storyCorridorsPost in the standard dependency spine", () => {
+    expect(M3_STAGE_DEPENDENCY_SPINE.storyCorridorsPost.requires).toEqual(
+      expect.arrayContaining([
+        M3_DEPENDENCY_TAGS.artifact.storyOverlays,
+        M3_DEPENDENCY_TAGS.artifact.climateField,
+        M3_DEPENDENCY_TAGS.artifact.riverAdjacency,
+      ])
+    );
+  });
+
   it("treats artifact:climateField as unsatisfied until published", () => {
     const adapter = createMockAdapter({ width: 4, height: 3, rng: () => 0 });
     const ctx = createExtendedMapContext(

--- a/packages/mapgen-core/test/story/corridors.test.ts
+++ b/packages/mapgen-core/test/story/corridors.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { createMockAdapter } from "@civ7/adapter";
+import { parseConfig } from "../../src/config/index.js";
+import { bindTunables, resetTunablesForTest } from "../../src/bootstrap/tunables.js";
+import { createExtendedMapContext } from "../../src/core/types.js";
+import { OCEAN_TERRAIN } from "../../src/core/terrain-constants.js";
+import { resetStoryTags, getStoryTags } from "../../src/story/tags.js";
+import { resetStoryOverlays, getStoryOverlay, STORY_OVERLAY_KEYS } from "../../src/story/overlays.js";
+import { storyTagStrategicCorridors } from "../../src/story/corridors.js";
+
+describe("story/corridors", () => {
+  beforeEach(() => {
+    resetTunablesForTest();
+    bindTunables(parseConfig({}));
+    resetStoryTags();
+    resetStoryOverlays();
+  });
+
+  it("tags sea lanes and publishes a corridors overlay", () => {
+    const width = 20;
+    const height = 12;
+    const adapter = createMockAdapter({ width, height, defaultTerrainType: OCEAN_TERRAIN });
+    (adapter as any).fillWater(true);
+
+    const ctx = createExtendedMapContext({ width, height }, adapter, parseConfig({}));
+
+    storyTagStrategicCorridors(ctx, "preIslands");
+
+    expect(getStoryTags().corridorSeaLane.size).toBeGreaterThan(0);
+
+    const overlay = getStoryOverlay(ctx, STORY_OVERLAY_KEYS.CORRIDORS);
+    expect(overlay).not.toBeNull();
+    expect(overlay?.summary).toMatchObject({ stage: "preIslands" });
+  });
+});

--- a/packages/mapgen-core/test/story/orogeny.test.ts
+++ b/packages/mapgen-core/test/story/orogeny.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { createMockAdapter } from "@civ7/adapter";
+import { parseConfig } from "../../src/config/index.js";
+import { bindTunables, resetTunablesForTest } from "../../src/bootstrap/tunables.js";
+import { createExtendedMapContext } from "../../src/core/types.js";
+import { resetStoryOverlays, getStoryOverlay, STORY_OVERLAY_KEYS } from "../../src/story/overlays.js";
+import { resetOrogenyCache, getOrogenyCache, storyTagOrogenyBelts } from "../../src/story/orogeny.js";
+
+describe("story/orogeny", () => {
+  beforeEach(() => {
+    resetTunablesForTest();
+    bindTunables(
+      parseConfig({
+        story: { orogeny: { beltMinLength: 12 } },
+      })
+    );
+    resetStoryOverlays();
+    resetOrogenyCache();
+  });
+
+  it("tags legacy orogeny belts from mountain density and publishes an overlay", () => {
+    const width = 30;
+    const height = 20;
+    const adapter = createMockAdapter({ width, height });
+
+    // Create a dense mountain patch to exceed the minLenSoft floor (>=10).
+    for (let y = 6; y <= 10; y++) {
+      for (let x = 10; x <= 14; x++) {
+        (adapter as any).setMountain(x, y, true);
+      }
+    }
+
+    const ctx = createExtendedMapContext({ width, height }, adapter, parseConfig({}));
+
+    storyTagOrogenyBelts(ctx);
+
+    const cache = getOrogenyCache();
+    expect(cache.belts.size).toBeGreaterThan(0);
+    expect(cache.windward.size).toBeGreaterThan(0);
+    expect(cache.lee.size).toBeGreaterThan(0);
+
+    const overlay = getStoryOverlay(ctx, STORY_OVERLAY_KEYS.OROGENY);
+    expect(overlay).not.toBeNull();
+    expect(overlay?.key).toBe(STORY_OVERLAY_KEYS.OROGENY);
+  });
+});

--- a/packages/mapgen-core/test/story/overlays.test.ts
+++ b/packages/mapgen-core/test/story/overlays.test.ts
@@ -24,7 +24,12 @@ describe("story/overlays", () => {
   describe("STORY_OVERLAY_KEYS", () => {
     it("has expected keys", () => {
       expect(STORY_OVERLAY_KEYS.MARGINS).toBe("margins");
+      expect(STORY_OVERLAY_KEYS.HOTSPOTS).toBe("hotspots");
+      expect(STORY_OVERLAY_KEYS.RIFTS).toBe("rifts");
+      expect(STORY_OVERLAY_KEYS.OROGENY).toBe("orogeny");
       expect(STORY_OVERLAY_KEYS.CORRIDORS).toBe("corridors");
+      expect(STORY_OVERLAY_KEYS.SWATCHES).toBe("swatches");
+      expect(STORY_OVERLAY_KEYS.PALEO).toBe("paleo");
     });
   });
 

--- a/packages/mapgen-core/test/story/paleo.test.ts
+++ b/packages/mapgen-core/test/story/paleo.test.ts
@@ -46,10 +46,11 @@ describe("story/paleo", () => {
     (adapter as any).isAdjacentToRivers = () => true;
 
     const ctx = createExtendedMapContext({ width, height }, adapter, parseConfig({}));
+    ctx.buffers?.climate?.rainfall?.fill(50);
+    ctx.fields?.rainfall?.fill(50);
 
     const summary = storyTagPaleoHydrology(ctx);
     expect(summary.deltas).toBe(1);
     expect(adapter.getRainfall(1, 1)).toBeGreaterThan(50);
   });
 });
-

--- a/packages/mapgen-core/test/story/paleo.test.ts
+++ b/packages/mapgen-core/test/story/paleo.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { createMockAdapter } from "@civ7/adapter";
+import { parseConfig } from "../../src/config/index.js";
+import { bindTunables, resetTunablesForTest } from "../../src/bootstrap/tunables.js";
+import { createExtendedMapContext } from "../../src/core/types.js";
+import { storyTagPaleoHydrology } from "../../src/story/paleo.js";
+import { COAST_TERRAIN, FLAT_TERRAIN } from "../../src/core/terrain-constants.js";
+
+describe("story/paleo", () => {
+  beforeEach(() => {
+    resetTunablesForTest();
+    bindTunables(
+      parseConfig({
+        climate: {
+          story: {
+            paleo: {
+              maxDeltas: 1,
+              deltaFanRadius: 1,
+              deltaMarshChance: 0,
+              maxOxbows: 0,
+              maxFossilChannels: 0,
+            },
+          },
+        },
+      })
+    );
+  });
+
+  it("applies a delta rainfall fan on coastal river-adjacent tiles", () => {
+    const width = 12;
+    const height = 8;
+    const adapter = createMockAdapter({
+      width,
+      height,
+      defaultTerrainType: FLAT_TERRAIN,
+      defaultRainfall: 50,
+    });
+
+    // Water row at y=0 (coast) so y=1 becomes coastal land.
+    for (let x = 0; x < width; x++) {
+      (adapter as any).setWater(x, 0, true);
+      adapter.setTerrainType(x, 0, COAST_TERRAIN);
+    }
+
+    // Treat everything as "adjacent to rivers" for this unit test.
+    (adapter as any).isAdjacentToRivers = () => true;
+
+    const ctx = createExtendedMapContext({ width, height }, adapter, parseConfig({}));
+
+    const summary = storyTagPaleoHydrology(ctx);
+    expect(summary.deltas).toBe(1);
+    expect(adapter.getRainfall(1, 1)).toBeGreaterThan(50);
+  });
+});
+


### PR DESCRIPTION
### TL;DR

Implemented the full story system modernization with corridors, swatches, paleo hydrology, and proper MapGenStep integration.

### What changed?

- Ported remaining legacy story passes (corridors, swatches, paleo) to TypeScript
- Implemented story stages as proper `MapGenStep`s with explicit `requires/provides` contracts
- Added `storyTagOrogenyBelts`, `storyTagStrategicCorridors`, `storyTagClimateSwatches`, and `storyTagClimatePaleo` functions
- Published narrative outputs via canonical `StoryOverlays` for downstream consumers
- Tightened `storyCorridorsPost` dependencies to require climate and river artifacts
- Reset story globals at generation start to prevent cross-run leakage
- Added unit tests for corridors, orogeny, and paleo functionality
- Marked CIV-43 deliverables and acceptance criteria as complete

### How to test?

1. Enable story stages in map generation recipes
2. Verify corridors appear in expected locations (sea lanes, island hops, land corridors)
3. Check that climate swatches and paleo hydrology modify rainfall patterns
4. Confirm that story stages fail fast when required dependencies are missing
5. Run the new unit tests: `bun test packages/mapgen-core/test/story/corridors.test.ts packages/mapgen-core/test/story/orogeny.test.ts packages/mapgen-core/test/story/paleo.test.ts`

### Why make this change?

This completes the story system modernization by converting all legacy story passes into proper MapGenStep implementations with explicit contracts. The changes ensure story stages run correctly within the Task Graph, publish canonical overlays for downstream consumers, and properly gate execution based on dependencies. This addresses the core requirements of CIV-43 while fixing issues identified in the review, such as paleo's MapContext path and potential cross-run leakage via global state.