### PR TITLE
fix(mapgen-core): fail fast when mapInfo missing

### DIFF
--- a/docs/projects/engine-refactor-v1/resources/SPIKE-story-drift-legacy-path-removal.md
+++ b/docs/projects/engine-refactor-v1/resources/SPIKE-story-drift-legacy-path-removal.md
@@ -2,12 +2,16 @@
 
 ## Objective
 
-Investigate the current “story drift” risk in `@swooper/mapgen-core`, and determine whether it’s feasible (and safe) to fully remove the legacy orchestration path in favor of the newer hybrid/pipeline (“TaskGraph”) path, given that we currently control all consumers.
+Investigate the current “story drift” risk in `@swooper/mapgen-core`, and determine whether it’s feasible (and safe) to fully remove legacy orchestration **and** legacy compatibility surfaces (config toggles, shims/re-exports) in favor of the newer hybrid/pipeline (“TaskGraph”) architecture, given that we currently control all consumers.
 
 ## Context (what “legacy” means here)
 
-- **Legacy path**: `MapOrchestrator.generateMap()`’s inline stage runner (including inline story stages), selected when `OrchestratorConfig.useTaskGraph !== true` (`packages/mapgen-core/src/MapOrchestrator.ts:329-332`).
-- **TaskGraph path**: `PipelineExecutor + StepRegistry` execution from `MapOrchestrator.generateMapTaskGraph()` (`packages/mapgen-core/src/MapOrchestrator.ts:939`), used when `useTaskGraph: true`.
+- **Legacy orchestrator path**: `MapOrchestrator.generateMap()`’s inline stage runner (including inline story stages), selected when `OrchestratorConfig.useTaskGraph !== true` (`packages/mapgen-core/src/MapOrchestrator.ts`, `generateMap()`).
+- **TaskGraph path**: `PipelineExecutor + StepRegistry` execution from `MapOrchestrator.generateMapTaskGraph()` (`packages/mapgen-core/src/MapOrchestrator.ts`, `generateMapTaskGraph()`), used when `useTaskGraph: true`.
+- **Legacy compatibility surfaces** (separate from orchestration):
+  - Legacy story enablement toggles (`config.toggles.STORY_ENABLE_*`) that mirror old JS-era switches (`packages/mapgen-core/src/config/schema.ts`, `TogglesSchema`).
+  - Legacy step/shim exports (`packages/mapgen-core/src/steps/*`, `createLegacy*Step`) and a legacy placement step type (`packages/mapgen-core/src/pipeline/placement/LegacyPlacementStep.ts`).
+  - Legacy bootstrap input shapes (e.g., `bootstrap()`’s `BootstrapConfig.stages` “legacy interface” in `packages/mapgen-core/src/bootstrap/entry.ts`).
 
 ## Assumptions and unknowns
 
@@ -18,18 +22,18 @@ Investigate the current “story drift” risk in `@swooper/mapgen-core`, and de
 
 ### Unknowns (that affect feasibility and rollout risk)
 
-- Whether any out-of-repo consumers already rely on `OrchestratorConfig.useTaskGraph` or legacy `generateMap()` semantics.
-- Whether `config.stageConfig/stageManifest` should be the sole “enable story” surface, or whether `config.toggles.STORY_ENABLE_*` should remain an authored input.
+- Whether any out-of-repo consumers already rely on `OrchestratorConfig.useTaskGraph`, legacy `generateMap()` semantics, or the `config.toggles.STORY_ENABLE_*` surface (none found in-repo beyond tests/mods/docs, but this can’t be proven from a workspace scan).
+- Whether we still need an independent, non-legacy equivalent of “paleo enabled” separate from stage gating (see “Open decisions”).
 
 ## Summary verdict
 
-**Feasible with caveats.** The TaskGraph pipeline already includes story steps that mirror the legacy inline story stages, and at least one internal mod already runs via TaskGraph. The main remaining risk is semantic drift from maintaining two orchestration paths and two story enablement representations (stages vs toggles).
+**Feasible, and high-leverage to do now.** With story logic now modularized and shared across the pipeline steps + domain modules, the dominant drift vector is keeping multiple orchestration paths and legacy compatibility surfaces alive. Given that we control consumers, it’s practical to remove the legacy orchestrator path and the legacy story toggle surface in the same stack, while explicitly deferring only true behavior-mode selectors (e.g. `"legacy" | "area"` algorithm modes).
 
 ## Evidence (current state)
 
 ### 1) Two orchestration paths exist today (drift is structurally inevitable)
 
-- Branching entrypoint: `packages/mapgen-core/src/MapOrchestrator.ts:329-332`.
+- Branching entrypoint: `packages/mapgen-core/src/MapOrchestrator.ts` (`generateMap()` checks `options.useTaskGraph`).
 - Legacy inline story stages live in the legacy runner:
   - `storySeed`, `storyHotspots`, `storyRifts`, `storyOrogeny`, `storyCorridorsPre` (`packages/mapgen-core/src/MapOrchestrator.ts:553-636`)
   - `storySwatches` + paleo-in-rivers + `storyCorridorsPost` (`packages/mapgen-core/src/MapOrchestrator.ts:741-823`)
@@ -37,66 +41,135 @@ Investigate the current “story drift” risk in `@swooper/mapgen-core`, and de
   - `packages/mapgen-core/src/pipeline/narrative/*`
   - Example parity: `StorySeedStep` resets story state and runs `storyTagContinentalMargins`, matching the legacy stage body (`packages/mapgen-core/src/pipeline/narrative/StorySeedStep.ts:20-46`).
 
-### 2) Internal consumers exercise both paths
+### 2) Story modularization increases the cost of keeping legacy orchestration
 
-- TaskGraph enabled: `mods/mod-swooper-maps/src/swooper-earthlike.ts:352` (`useTaskGraph: true`).
-- Legacy path still used: `mods/mod-swooper-maps/src/swooper-desert-mountains.ts:298-330` (no `useTaskGraph`).
+The modularization work reduced “two story implementations” drift, but it increased the architectural drift cost of keeping two orchestrators alive:
 
-### 3) Pipeline ordering is already canonicalized (a good foundation for removing legacy)
+- The M4 design locks the invariant: **reset story globals once per generation at the orchestrator boundary**, not inside story stages that can be disabled (`docs/projects/engine-refactor-v1/issues/CIV-M4-ADHOC-modularize.md`, “Story/Playability Steps”).
+- TaskGraph implements that invariant: `generateMapTaskGraph()` resets story globals once per run before executing the recipe (`packages/mapgen-core/src/MapOrchestrator.ts`, `generateMapTaskGraph()`).
+- Legacy path still resets primarily inside the `storySeed` stage (and other story stages), so disabling `storySeed` can re-introduce cross-run leakage and violate the intended “story is optional” contract (`packages/mapgen-core/src/MapOrchestrator.ts`, legacy inline runner).
 
-- Canonical stage order is centralized in `STAGE_ORDER` (`packages/mapgen-core/src/bootstrap/resolved.ts:28-50`).
-- TaskGraph executes `StageManifest.order` filtered by enablement (`packages/mapgen-core/src/pipeline/StepRegistry.ts:32-37`).
-- TaskGraph also adds guardrails via requires/provides validation (`packages/mapgen-core/src/pipeline/PipelineExecutor.ts:83-99`).
+### 3) Internal consumers (in-repo) and what actually needs migration
 
-### 4) Story enablement is currently represented twice (stages + toggles)
+Workspace scan suggests there are only three meaningful categories of “internal consumers” to migrate off legacy:
 
-- Stage gating is derived from `stageManifest` (`packages/mapgen-core/src/MapOrchestrator.ts:1190-1218`).
-- `MapOrchestrator` derives and overwrites story-related toggles when constructing `context.config` (`packages/mapgen-core/src/MapOrchestrator.ts:1163-1179`).
-- Some downstream logic reads `config.toggles.STORY_ENABLE_*` directly (e.g., features/biomes) rather than deriving intent from stage enablement and/or overlay presence:
-  - `packages/mapgen-core/src/domain/ecology/features/index.ts:92-107`
-  - `packages/mapgen-core/src/domain/ecology/biomes/index.ts:179-186`
-- Presets set story toggles but do not enable story stages by default, which is a confusing contract if stages are meant to be authoritative (`packages/mapgen-core/src/config/presets.ts:52-88`).
+- **Mods (TypeScript sources):**
+  - TaskGraph enabled: `mods/mod-swooper-maps/src/swooper-earthlike.ts` (`useTaskGraph: true`).
+  - Legacy path: `mods/mod-swooper-maps/src/swooper-desert-mountains.ts` (no `useTaskGraph`).
+- **Tests:** multiple orchestrator tests call `generateMap()` without `useTaskGraph`, so they currently exercise legacy by default (e.g. `packages/mapgen-core/test/orchestrator/story-parity.smoke.test.ts`).
+- **Docs/examples:** a few docs still imply legacy control surfaces / patterns (e.g. `docs/system/mods/swooper-maps/architecture.md`).
+
+Note: built artifacts under `mods/mod-swooper-maps/mod/maps/*.js` also contain legacy strings, but these are generated outputs and are not treated as meaningful “consumers” (they can be regenerated after source updates).
+
+### 4) Pipeline ordering + stage enablement is already canonicalized (strong foundation)
+
+- Canonical stage order is centralized in `STAGE_ORDER` (`packages/mapgen-core/src/bootstrap/resolved.ts`).
+- `bootstrap()` resolves `stageConfig -> stageManifest`, so stage enablement has a canonical representation by default (`packages/mapgen-core/src/bootstrap/entry.ts`).
+- TaskGraph executes `StageManifest.order` filtered by enablement (`packages/mapgen-core/src/pipeline/StepRegistry.ts`).
+- TaskGraph adds guardrails via requires/provides validation (`packages/mapgen-core/src/pipeline/PipelineExecutor.ts`).
+
+### 5) Story enablement is still represented twice (stages + legacy toggles)
+
+We have a canonical “what stages are enabled” representation (the resolved `stageManifest`), but legacy toggles still exist as an authored config surface and are consumed in domain logic.
+
+- Stage gating is derived from `stageManifest` (`packages/mapgen-core/src/MapOrchestrator.ts`, `resolveStageFlags()`).
+- `MapOrchestrator` derives and overwrites story-related toggles when constructing `context.config` (`packages/mapgen-core/src/MapOrchestrator.ts`, `buildContextConfig()`).
+- Downstream logic still reads `config.toggles.STORY_ENABLE_*` directly:
+  - Features: `packages/mapgen-core/src/domain/ecology/features/index.ts` gates some effects via `STORY_ENABLE_HOTSPOTS` even though it also checks story tag sets.
+  - Biomes: `packages/mapgen-core/src/domain/ecology/biomes/index.ts` gates rift shoulder bias via `STORY_ENABLE_RIFTS`.
+  - Climate refine: `packages/mapgen-core/src/domain/hydrology/climate/refine/orogeny-belts.ts` gates refinement via `STORY_ENABLE_OROGENY`.
+  - Paleo is gated in the rivers step via a toggle (`packages/mapgen-core/src/pipeline/hydrology/index.ts`).
+- Presets set story toggles but do not enable story stages by default, which is a confusing contract if `stageManifest` is intended to be authoritative (`packages/mapgen-core/src/config/presets.ts`).
+
+Also: `StageDescriptorSchema` includes `legacyToggles` metadata (`packages/mapgen-core/src/config/schema.ts`) but there are no in-repo reads of that field today. That “half-bridge” is drift bait: it suggests canonical mapping exists, but it currently doesn’t.
+
+### 6) Other legacy compatibility surfaces that are removable now
+
+- `packages/mapgen-core/src/steps/index.ts` re-exports `createLegacyBiomesStep`, `createLegacyFeaturesStep`, `createLegacyPlacementStep` (thin aliases over pipeline steps).
+- `packages/mapgen-core/src/pipeline/placement/LegacyPlacementStep.ts` exists and is exercised by tests (`packages/mapgen-core/test/orchestrator/placement-config-wiring.test.ts`), even though the standard pipeline uses `createPlacementStep` (`packages/mapgen-core/src/pipeline/placement/index.ts`).
+- `bootstrap()` still types a legacy `BootstrapConfig.stages` object (commented as “legacy interface”) in `packages/mapgen-core/src/bootstrap/entry.ts`; no in-repo callsites were found using this surface.
 
 ## Primary recommendation
 
-### Make TaskGraph the only orchestrator path; remove legacy inline stage runner entirely
+### Remove legacy orchestration and legacy compat surfaces now (keep only behavior modes)
 
 Why:
 
-- Keeping both paths guarantees drift: any change to story order, caches/resets, artifacts, or “story optionality” must be duplicated.
-- TaskGraph has stronger correctness guardrails (dependency checks and provides validation) that will catch story-step regressions earlier.
+- Keeping multiple orchestrators guarantees drift: any change to stage order, resets, artifacts, or “story optionality” must be implemented twice.
+- With story now modularized and shared across pipeline wiring + domain components, the dominant remaining drift is configuration and orchestration, not the story algorithms themselves.
+- TaskGraph has stronger guardrails (requires/provides validation) and matches the M4 invariant “reset story globals outside story steps”.
 
 Scope note:
 
-- This recommendation is intentionally limited to removing the **legacy orchestrator path**, not re-architecting story state (globals) or extracting story into plugin packages. Those are follow-on improvements.
+- This recommendation intentionally **does not** remove true behavioral modes (e.g., algorithm mode selectors like `"legacy" | "area"`), because those are not compatibility shims—they’re behavior contracts. See “Explicit deferrals”.
 
 ## What “done” looks like (conceptual shape)
 
-- `MapOrchestrator.generateMap()` always executes via `PipelineExecutor + StepRegistry` and never runs inline stages.
-- `OrchestratorConfig.useTaskGraph` is removed (or becomes a no-op) so there is one supported execution path.
-- Story stages remain optional via `stageConfig/stageManifest` gating, but the semantics are clarified so there is a single source of truth:
-  - Either treat `stageConfig/stageManifest` as canonical and make story toggles derived-only (or remove presets’ story toggles to avoid misleading config),
-  - Or treat toggles as canonical and derive stage enablement from them (less aligned with the current StageManifest design).
+End-state vision:
+
+- **Single orchestrator path**: `MapOrchestrator.generateMap()` is TaskGraph-only; no inline legacy stage runner exists; `OrchestratorConfig.useTaskGraph` does not exist.
+- **Single enablement surface**: stage enablement is expressed only via `stageConfig/stageManifest` (resolved by `bootstrap()`), not via legacy story toggle mirrors.
+- **Story optionality is structural**:
+  - Disabling story stages never re-introduces state leakage (globals reset per run at the orchestrator boundary).
+  - Downstream steps that “benefit from story” use the presence/absence of story artifacts/tags as their primary signal, not an independent legacy toggle surface.
+- **No legacy shims in the public API**: remove `createLegacy*Step` aliases and legacy bootstrap config shapes that only exist for historical callers.
+
+## What we plan to delete (non-exhaustive)
+
+- **Orchestration switch + duplicate runner**
+  - `OrchestratorConfig.useTaskGraph` and the `generateMap()` branch that selects between two orchestrators (`packages/mapgen-core/src/MapOrchestrator.ts`).
+  - The legacy inline stage runner blocks inside `generateMap()` (including inline story stages).
+- **Legacy story toggle surface**
+  - `config.toggles.STORY_ENABLE_*` from config schema (`packages/mapgen-core/src/config/schema.ts`) and presets (`packages/mapgen-core/src/config/presets.ts`).
+  - The toggle-derivation bridge in `MapOrchestrator.buildContextConfig()` (`packages/mapgen-core/src/MapOrchestrator.ts`).
+  - Downstream toggle-based gating in non-story code paths (e.g. ecology/biomes/climate refine), migrating those decisions to stage enablement and/or artifact/tag presence.
+- **Dead / half-migrated metadata**
+  - `StageDescriptorSchema.legacyToggles` (present in schema; no in-repo reads found).
+- **Legacy shims / re-export surfaces**
+  - `packages/mapgen-core/src/steps/*` legacy step aliases and any remaining references to `createLegacy*Step`.
+  - `packages/mapgen-core/src/pipeline/placement/LegacyPlacementStep.ts` (after tests migrate off it).
+- **Legacy bootstrap input shapes**
+  - `BootstrapConfig.stages` legacy interface in `packages/mapgen-core/src/bootstrap/entry.ts` (no in-repo callsites found using it).
 
 ## High-level implementation outline (sequenced, thin-slice)
 
-1) Migrate all in-repo callsites to TaskGraph-only behavior (e.g., bring `swooper-desert-mountains` in line with `swooper-earthlike`).
-2) Make `generateMap()` TaskGraph-only (keep method name/signature stable).
-3) Delete the legacy inline stage runner blocks (including inline story stages).
-4) Resolve story enablement semantics:
-   - pick one canonical surface (stages vs toggles),
-   - remove contradictory defaults (notably presets).
-5) Validation strategy:
-   - Keep a small set of orchestrator smoke tests that ensure key story behaviors still work in the single remaining path (e.g. paleo ordering; story tags emitted when enabled).
+1) Migrate all in-repo callsites and tests to a single orchestration path (TaskGraph-only).
+2) Make `generateMap()` TaskGraph-only; remove `OrchestratorConfig.useTaskGraph`; delete the legacy inline stage runner blocks.
+3) Remove legacy story toggle surface (`config.toggles.STORY_ENABLE_*`) and migrate gating to canonical signals:
+   - stage enablement (`stageManifest`) and/or
+   - artifact/tag presence (story overlays/tags), depending on the subsystem.
+4) Remove other legacy shims:
+   - `createLegacy*Step` exports and `LegacyPlacementStep` (after migrating the tests that rely on them),
+   - unused schema metadata like `StageDescriptorSchema.legacyToggles` (or finish the mapping and then immediately remove it once all callers are migrated—prefer removal).
+5) Align presets and docs with the new contract (presets should not set legacy story toggles; docs should not describe legacy control surfaces).
+6) Validation strategy:
+   - Keep a small set of orchestrator smoke tests that assert intended optional-story behavior (story tags when enabled; no story effects when disabled; paleo ordering).
 
 ## Risks, trade-offs, regressions
 
 - **Internal breakage** is expected: any internal mod/config relying on legacy behavior must be migrated in lockstep.
 - **Config semantic ambiguity** is the biggest footgun: presets and runtime toggle-derivation currently send mixed signals.
+- **Paleo gating is the main nuance**: it’s currently controlled by both stage enablement and a legacy toggle; removing legacy toggles forces a decision about the replacement signal.
 - **Hidden consumers** are the only meaningful external risk; if the repo is not yet published for modders, this is likely low.
+
+## Explicit deferrals (behavior modes we should not remove in this stack)
+
+Intent: remove legacy *compatibility* surfaces, but do not rename/remove “legacy” *behavior modes* that are part of algorithm semantics today.
+
+Examples to defer (non-exhaustive):
+
+- Algorithm mode selectors like `"legacy" | "area"` (e.g. landmask/crust behavior in `packages/mapgen-core/src/config/schema.ts` and `packages/mapgen-core/src/domain/morphology/landmass/crust-mode.ts`).
+
+Trigger to revisit:
+
+- Once we have confidence that internal consumers no longer need to compare/validate “legacy vs area” behavior (e.g., parity matrices stabilized or the team decides one mode is canonical and deletes the other).
+
+Other legacy surfaces noticed (not behavior modes):
+
+- Deprecated top-level diagnostics toggles are still present in config schema as “[legacy/no-op]” (`packages/mapgen-core/src/config/schema.ts`, `DiagnosticsConfigSchema`). If the goal is “no legacy config surface at all”, these can likely be removed in the same initiative, but they are not directly tied to story drift.
 
 ## Open decisions
 
 1) Should `generateMap()` remain the stable entrypoint (TaskGraph-only), or should we require an explicit “pipeline” entrypoint to make the breaking change obvious?
-2) Should `config.toggles.STORY_ENABLE_*` remain an authored input, or become derived-only from `stageConfig/stageManifest`?
-
+2) For paleo specifically: do we still need an independent “paleo enabled” switch, or is “paleo config present + storySwatches enabled” the canonical gate?
+   - If an independent switch is still needed, prefer a non-legacy config surface (e.g. `climate.story.paleo.enabled`) rather than retaining `STORY_ENABLE_PALEO`.

--- a/packages/mapgen-core/test/orchestrator/story-parity.smoke.test.ts
+++ b/packages/mapgen-core/test/orchestrator/story-parity.smoke.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { createMockAdapter } from "@civ7/adapter";
-import { bootstrap, MapOrchestrator, getStoryTags } from "../../src/index.js";
+import { bootstrap, MapOrchestrator, narrative } from "../../src/index.js";
 import { resetStoryTags } from "../../src/domain/narrative/tags/index.js";
 import { resetStoryOverlays } from "../../src/domain/narrative/overlays/index.js";
 
@@ -80,7 +80,7 @@ describe("smoke: minimal story parity (margins, hotspots, rifts)", () => {
 
     orchestrator.generateMap();
 
-    const tags = getStoryTags();
+    const tags = narrative.getStoryTags();
     expect(tags.activeMargin.size + tags.passiveShelf.size).toBeGreaterThan(0);
     expect(tags.hotspot.size).toBeGreaterThan(0);
     expect(tags.riftLine.size).toBeGreaterThan(0);


### PR DESCRIPTION
# mapgen-core: fail fast when mapInfo missing

This PR improves error handling in the MapOrchestrator by:

1. Making `mapInfo` a required field in `MapSizeDefaults` interface
2. Adding explicit validation for map dimensions and latitude bounds
3. Replacing silent fallbacks with clear error messages when required data is missing
4. Updating tests to verify proper error handling instead of fallback behavior

# docs(spike): broaden legacy removal scope

Updates the story drift SPIKE document to expand the scope of legacy removal:
- Clarifies that we should remove both legacy orchestration paths and legacy compatibility surfaces
- Identifies additional legacy surfaces that can be removed (toggles, shims, re-exports)
- Provides more detailed implementation guidance and evidence for removal
- Distinguishes between legacy compatibility surfaces (to remove) and behavior modes (to keep)