### PR TITLE
docs(engine-refactor-v1): restructure story-drift spike into PRD format

### DIFF
--- a/docs/projects/engine-refactor-v1/issues/LOCAL-TBD-story-drift-legacy-removal.md
+++ b/docs/projects/engine-refactor-v1/issues/LOCAL-TBD-story-drift-legacy-removal.md
@@ -1,0 +1,250 @@
+---
+id: LOCAL-TBD
+title: "[M4] Remove Legacy Orchestration & Story Toggle Surfaces"
+state: planned
+priority: 2
+estimate: 8
+project: engine-refactor-v1
+milestone: null
+assignees: []
+labels: [Improvement, Architecture, Technical Debt]
+parent: null
+children: []
+blocked_by: []
+blocked: []
+related_to: [CIV-43]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+
+Remove the legacy orchestrator path and legacy `STORY_ENABLE_*` toggle surface from `@swooper/mapgen-core`, making TaskGraph the sole execution path and `stageManifest` the single source of truth for stage enablement.
+
+## Deliverables
+
+- [ ] **Group 1**: Migrate all in-repo consumers (mods, tests) to `useTaskGraph: true`
+- [ ] **Group 2**: Remove legacy orchestration fork—`generateMap()` becomes TaskGraph-only
+- [ ] **Group 3**: Remove `config.toggles.STORY_ENABLE_*` surface; migrate downstream to canonical signals
+- [ ] **Group 4**: Remove legacy shims (`createLegacy*Step`, `LegacyPlacementStep`, legacy bootstrap shapes) and update docs
+- [ ] **Group 5**: Move story state (tags, caches, overlays) to context-owned artifacts (requires design decision)
+
+## Acceptance Criteria
+
+- [ ] `generateMap()` has no branching logic—TaskGraph is the only path
+- [ ] `OrchestratorConfig.useTaskGraph` option does not exist
+- [ ] No `STORY_ENABLE_*` fields in config schema or presets
+- [ ] All downstream toggle consumers use canonical signals (tags, config presence, stage flags)
+- [ ] No `createLegacy*Step` exports or `LegacyPlacementStep.ts`
+- [ ] No legacy bootstrap input shapes
+- [ ] (Group 5) No module-level story singletons required for correctness
+- [ ] `pnpm -C packages/mapgen-core check` passes
+- [ ] `pnpm test:mapgen` passes
+- [ ] Mods load without error
+
+## Testing / Verification
+
+- `pnpm -C packages/mapgen-core check` (type check)
+- `pnpm test:mapgen` (unit tests)
+- Load mods in-game and verify no regressions (smoke test)
+- Spot-check story stage enable/disable combinations
+
+## Dependencies / Notes
+
+- **System area:** MapOrchestrator, bootstrap, config schema, pipeline steps, story system
+- **Change:** Eliminate dual orchestration paths and legacy compatibility surfaces; consolidate on TaskGraph + stageManifest
+- **Outcome:** Single execution path, single enablement surface, reduced drift risk
+- **Rationale:** Modularization work (CIV-M4-ADHOC) reduced "two story implementations" drift, but keeping two orchestrators alive still creates structural drift risk. This removes the primary source.
+
+**Architectural decisions (locked):**
+- TaskGraph is the only supported orchestration path
+- Stage enablement is driven only by `stageManifest` (resolved via `bootstrap()`)
+- Paleo runs whenever `climate.story.paleo` config is present (no independent toggle)
+- Story globals remain temporarily until Group 5 completes
+
+**Open questions (affect Group 5):**
+1. Context-owned representation for story tags/caches: artifact or `ctx.story.*` object?
+2. Overlay registry semantics: check size > 0 or use stable "exists but empty" representation?
+
+**Related docs:**
+- Spike/PRD: `docs/projects/engine-refactor-v1/resources/SPIKE-story-drift-legacy-path-removal.md`
+- Related issue: `CIV-M4-ADHOC-modularize.md`
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Quick Navigation
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)
+
+### Sub-Issue Breakdown
+
+This issue is structured as 5 sequential implementation groups. Each group is self-contained and can be completed in 1-2 sessions.
+
+#### Group 1: Migrate Consumers to TaskGraph
+
+**TL;DR:** Prepare all in-repo consumers before removing the legacy path.
+
+**Files to migrate:**
+- `mods/mod-swooper-maps/src/swooper-desert-mountains.ts` — add `useTaskGraph: true`
+- `packages/mapgen-core/test/orchestrator/story-parity.smoke.test.ts` — update to TaskGraph
+- Audit other orchestrator tests calling `generateMap()` without `useTaskGraph`
+
+**Done when:**
+- All mods explicitly use `useTaskGraph: true`
+- All orchestrator tests use TaskGraph path
+- `pnpm test:mapgen` passes
+- Mods load without error
+
+---
+
+#### Group 2: Remove Legacy Orchestration Fork
+
+**TL;DR:** Make TaskGraph the only execution path.
+
+**Deletions:**
+- `OrchestratorConfig.useTaskGraph` option
+- `generateMap()` branch selecting between orchestrators
+- Legacy inline stage runner blocks (including inline story stages)
+
+**Migrations:**
+- Remove now-unnecessary `useTaskGraph: true` from mods
+- Regenerate built artifacts under `mods/mod-swooper-maps/mod/maps/*.js`
+
+**Done when:**
+- `generateMap()` always uses TaskGraph
+- No inline stage runner code remains in `MapOrchestrator.ts`
+- Tests and mods pass
+
+---
+
+#### Group 3: Remove Legacy Toggle Surface
+
+**TL;DR:** Single source of truth for stage enablement.
+
+**Deletions:**
+- `config.toggles.STORY_ENABLE_*` fields from `TogglesSchema`
+- `config.toggles.STORY_ENABLE_*` assignments from presets
+- Toggle-derivation bridge in `MapOrchestrator.buildContextConfig()`
+- `StageDescriptorSchema.legacyToggles` dead metadata
+
+**Migrations (per-consumer):**
+
+| File | Current Toggle | Migration Strategy |
+|------|----------------|-------------------|
+| `domain/ecology/features/index.ts` | `STORY_ENABLE_HOTSPOTS` | Check story tag sets |
+| `domain/ecology/biomes/index.ts` | `STORY_ENABLE_RIFTS` | Check story tag sets |
+| `domain/hydrology/climate/refine/orogeny-belts.ts` | `STORY_ENABLE_OROGENY` | Check story tag sets or stage flag |
+| `pipeline/hydrology/index.ts` | Paleo toggle | Check `climate.story.paleo` config presence |
+
+**Done when:**
+- No `STORY_ENABLE_*` fields anywhere
+- All consumers use canonical signals
+- Type check and tests pass
+
+---
+
+#### Group 4: Remove Legacy Shims & Cleanup
+
+**TL;DR:** Remove compatibility surfaces for historical callers.
+
+**Deletions:**
+- `packages/mapgen-core/src/steps/*` legacy step aliases
+- `packages/mapgen-core/src/pipeline/placement/LegacyPlacementStep.ts`
+- `BootstrapConfig.stages` legacy interface
+
+**Migrations:**
+- `test/orchestrator/placement-config-wiring.test.ts` — use `createPlacementStep`
+- `docs/system/mods/swooper-maps/architecture.md` — remove legacy references
+
+**Done when:**
+- No legacy exports or files
+- Docs updated
+- Tests pass
+
+---
+
+#### Group 5: Story State to Context-Owned
+
+**TL;DR:** Explicit data flow with no hidden global state.
+
+**Prerequisite:** Resolve open questions (artifact vs ctx.story.* representation; overlay registry semantics)
+
+**Deletions:**
+- Global overlay registry fallback
+- Module-level StoryTags singleton
+- Module-level story caches
+
+**Migrations:**
+- Story steps publish tags/state as context artifact
+- All story tag consumers read from context
+- All overlay consumers read from context
+
+**Done when:**
+- No module-level story singletons required for correctness
+- All cross-stage story data carried via context
+- Disabling story stages cannot cause stale global state leakage
+- Smoke tests pass with story stages enabled and disabled
+
+---
+
+### Key File References
+
+**Orchestrator:**
+- `packages/mapgen-core/src/MapOrchestrator.ts` — main orchestrator with legacy fork
+
+**Config/Schema:**
+- `packages/mapgen-core/src/config/schema.ts` — `TogglesSchema`, `StageDescriptorSchema.legacyToggles`
+- `packages/mapgen-core/src/config/presets.ts` — story toggle assignments
+
+**Bootstrap:**
+- `packages/mapgen-core/src/bootstrap/entry.ts` — legacy `BootstrapConfig.stages` interface
+- `packages/mapgen-core/src/bootstrap/resolved.ts` — `STAGE_ORDER`
+
+**Pipeline:**
+- `packages/mapgen-core/src/pipeline/StepRegistry.ts`
+- `packages/mapgen-core/src/pipeline/PipelineExecutor.ts`
+- `packages/mapgen-core/src/pipeline/placement/LegacyPlacementStep.ts`
+
+**Steps:**
+- `packages/mapgen-core/src/steps/index.ts` — legacy step exports
+
+**Domain (toggle consumers):**
+- `packages/mapgen-core/src/domain/ecology/features/index.ts`
+- `packages/mapgen-core/src/domain/ecology/biomes/index.ts`
+- `packages/mapgen-core/src/domain/hydrology/climate/refine/orogeny-belts.ts`
+- `packages/mapgen-core/src/pipeline/hydrology/index.ts`
+
+**Mods:**
+- `mods/mod-swooper-maps/src/swooper-earthlike.ts`
+- `mods/mod-swooper-maps/src/swooper-desert-mountains.ts`
+
+**Tests:**
+- `packages/mapgen-core/test/orchestrator/story-parity.smoke.test.ts`
+- `packages/mapgen-core/test/orchestrator/placement-config-wiring.test.ts`
+
+### Scope Boundaries
+
+**In scope:**
+- Remove legacy orchestration path
+- Remove legacy story toggle surface
+- Remove legacy shims
+- Migrate downstream gating to canonical signals
+- Move story state to context-owned
+
+**Non-goals (explicit deferrals):**
+- Algorithm mode selectors like `"legacy" | "area"` (behavior modes, not compatibility surfaces)
+- Deprecated diagnostics toggles (not directly tied to story drift)
+
+### Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Internal breakage | Migrate all in-repo consumers in lockstep (Group 1) |
+| Config semantic ambiguity | Clean up presets and toggle derivation in same pass (Group 3) |
+| Global story state drift | Address in Group 5 after orchestration fork is gone |
+| Hidden external consumers | Low risk if repo not yet published; internal-only concern |

--- a/docs/projects/engine-refactor-v1/resources/SPIKE-story-drift-legacy-path-removal.md
+++ b/docs/projects/engine-refactor-v1/resources/SPIKE-story-drift-legacy-path-removal.md
@@ -1,55 +1,35 @@
-# SPIKE: Story Drift + Legacy Path Removal (MapGen Core)
+# Story Drift + Legacy Path Removal (MapGen Core)
 
-## Objective
+> **Status**: SPIKE complete → PRD for implementation
+> **Verdict**: Feasible, high-leverage to do now
+> **Related**: `docs/projects/engine-refactor-v1/issues/CIV-M4-ADHOC-modularize.md`
 
-Investigate the current “story drift” risk in `@swooper/mapgen-core`, and determine whether it’s feasible (and safe) to fully remove legacy orchestration **and** legacy compatibility surfaces (config toggles, shims/re-exports) in favor of the newer hybrid/pipeline (“TaskGraph”) architecture, given that we currently control all consumers.
+---
 
-## Context (what “legacy” means here)
+# Part A: Context & Design
 
-- **Legacy orchestrator path**: `MapOrchestrator.generateMap()`’s inline stage runner (including inline story stages), selected when `OrchestratorConfig.useTaskGraph !== true` (`packages/mapgen-core/src/MapOrchestrator.ts`, `generateMap()`).
+## 1. Summary
+
+Remove the legacy orchestration path and legacy compatibility surfaces from `@swooper/mapgen-core`, making TaskGraph the sole execution path. With story logic now modularized and shared across pipeline steps + domain modules, the dominant drift vector is keeping multiple orchestration paths and legacy compatibility surfaces alive. Given that we control all consumers, it's practical to remove the legacy orchestrator path and the legacy story toggle surface in the same stack, while explicitly deferring only true behavior-mode selectors (e.g. `"legacy" | "area"` algorithm modes).
+
+**Core insight**: Eliminating the orchestration fork + legacy config surfaces removes the primary structural source of drift and sharply reduces ongoing migration overhead.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 What "Legacy" Means Here
+
+- **Legacy orchestrator path**: `MapOrchestrator.generateMap()`'s inline stage runner (including inline story stages), selected when `OrchestratorConfig.useTaskGraph !== true` (`packages/mapgen-core/src/MapOrchestrator.ts`, `generateMap()`).
 - **TaskGraph path**: `PipelineExecutor + StepRegistry` execution from `MapOrchestrator.generateMapTaskGraph()` (`packages/mapgen-core/src/MapOrchestrator.ts`, `generateMapTaskGraph()`), used when `useTaskGraph: true`.
 - **Legacy compatibility surfaces** (separate from orchestration):
   - Legacy story enablement toggles (`config.toggles.STORY_ENABLE_*`) that mirror old JS-era switches (`packages/mapgen-core/src/config/schema.ts`, `TogglesSchema`).
   - Legacy step/shim exports (`packages/mapgen-core/src/steps/*`, `createLegacy*Step`) and a legacy placement step type (`packages/mapgen-core/src/pipeline/placement/LegacyPlacementStep.ts`).
-  - Legacy bootstrap input shapes (e.g., `bootstrap()`’s `BootstrapConfig.stages` “legacy interface” in `packages/mapgen-core/src/bootstrap/entry.ts`).
+  - Legacy bootstrap input shapes (e.g., `bootstrap()`'s `BootstrapConfig.stages` "legacy interface" in `packages/mapgen-core/src/bootstrap/entry.ts`).
 
-## Assumptions and unknowns
+### 2.2 Why Drift Is Structurally Inevitable
 
-### Assumptions
-
-- There are no external, uncontrolled consumers relying on legacy stage order/behavior; the only risk is internal breakage.
-- “Target architecture” is the M3+ pipeline model: domain algorithms in `domain/**`, wiring in `pipeline/**`, and story/playability steps remaining optional and ultimately extractable (matches `docs/projects/engine-refactor-v1/issues/CIV-M4-ADHOC-modularize.md`).
-
-### Unknowns (that affect feasibility and rollout risk)
-
-- Whether any out-of-repo consumers already rely on `OrchestratorConfig.useTaskGraph`, legacy `generateMap()` semantics, or the `config.toggles.STORY_ENABLE_*` surface (none found in-repo beyond tests/mods/docs, but this can’t be proven from a workspace scan).
-- Whether we still need an independent, non-legacy equivalent of “paleo enabled” separate from stage gating (see “Open decisions”).
-
-## Summary verdict
-
-**Feasible, and high-leverage to do now.** With story logic now modularized and shared across the pipeline steps + domain modules, the dominant drift vector is keeping multiple orchestration paths and legacy compatibility surfaces alive. Given that we control consumers, it’s practical to remove the legacy orchestrator path and the legacy story toggle surface in the same stack, while explicitly deferring only true behavior-mode selectors (e.g. `"legacy" | "area"` algorithm modes).
-
-## Decisions captured from discussion (new baseline)
-
-We’re aligned on a pragmatic “canonical path now, refactor details later” approach:
-
-- **Canonical execution**: TaskGraph is the only supported orchestration path; legacy `generateMap()` inline runner is removed.
-- **Canonical enablement**:
-  - Stage enablement is driven only by `stageManifest` (resolved from `stageConfig` via `bootstrap()`).
-  - The legacy story toggle surface (`config.toggles.STORY_ENABLE_*`) is removed entirely; we are not optimizing for internal toggling right now.
-- **Paleo gating**: paleo runs whenever its config exists (no independent toggle). Concretely: if `climate.story.paleo` is present, we attempt to apply paleo effects (and it naturally no-ops when config is missing).
-- **Validation bar (for deleting legacy)**: prioritize “loads + no obviously missing major stage” over visual parity; existing step-level validation + smoke checks are sufficient for this removal pass.
-- **Story globals**:
-  - We accept keeping **StoryTags and related caches global temporarily** to keep scope bounded while we delete legacy orchestration + toggles.
-  - We explicitly intend to **gut globals by the end**, aligning all consumers on context-owned artifacts/overlays (and/or a context-owned story state object). This is the “last thing we do” in this initiative, after the legacy fork is gone.
-
-Rationale (short):
-
-- Eliminating the orchestration fork + legacy config surfaces removes the primary structural source of drift and sharply reduces ongoing migration overhead.
-
-## Evidence (current state)
-
-### 1) Two orchestration paths exist today (drift is structurally inevitable)
+Two orchestration paths exist today:
 
 - Branching entrypoint: `packages/mapgen-core/src/MapOrchestrator.ts` (`generateMap()` checks `options.useTaskGraph`).
 - Legacy inline story stages live in the legacy runner:
@@ -59,17 +39,91 @@ Rationale (short):
   - `packages/mapgen-core/src/pipeline/narrative/*`
   - Example parity: `StorySeedStep` resets story state and runs `storyTagContinentalMargins`, matching the legacy stage body (`packages/mapgen-core/src/pipeline/narrative/StorySeedStep.ts:20-46`).
 
-### 2) Story modularization increases the cost of keeping legacy orchestration
+### 2.3 Story Modularization Increases the Cost of Keeping Legacy
 
-The modularization work reduced “two story implementations” drift, but it increased the architectural drift cost of keeping two orchestrators alive:
+The modularization work reduced "two story implementations" drift, but it increased the architectural drift cost of keeping two orchestrators alive:
 
-- The M4 design locks the invariant: **reset story globals once per generation at the orchestrator boundary**, not inside story stages that can be disabled (`docs/projects/engine-refactor-v1/issues/CIV-M4-ADHOC-modularize.md`, “Story/Playability Steps”).
+- The M4 design locks the invariant: **reset story globals once per generation at the orchestrator boundary**, not inside story stages that can be disabled (`docs/projects/engine-refactor-v1/issues/CIV-M4-ADHOC-modularize.md`, "Story/Playability Steps").
 - TaskGraph implements that invariant: `generateMapTaskGraph()` resets story globals once per run before executing the recipe (`packages/mapgen-core/src/MapOrchestrator.ts`, `generateMapTaskGraph()`).
-- Legacy path still resets primarily inside the `storySeed` stage (and other story stages), so disabling `storySeed` can re-introduce cross-run leakage and violate the intended “story is optional” contract (`packages/mapgen-core/src/MapOrchestrator.ts`, legacy inline runner).
+- Legacy path still resets primarily inside the `storySeed` stage (and other story stages), so disabling `storySeed` can re-introduce cross-run leakage and violate the intended "story is optional" contract (`packages/mapgen-core/src/MapOrchestrator.ts`, legacy inline runner).
 
-### 3) Internal consumers (in-repo) and what actually needs migration
+---
 
-Workspace scan suggests there are only three meaningful categories of “internal consumers” to migrate off legacy:
+## 3. Assumptions & Unknowns
+
+### 3.1 Assumptions
+
+- There are no external, uncontrolled consumers relying on legacy stage order/behavior; the only risk is internal breakage.
+- "Target architecture" is the M3+ pipeline model: domain algorithms in `domain/**`, wiring in `pipeline/**`, and story/playability steps remaining optional and ultimately extractable (matches `docs/projects/engine-refactor-v1/issues/CIV-M4-ADHOC-modularize.md`).
+
+### 3.2 Unknowns (that affect feasibility and rollout risk)
+
+- Whether any out-of-repo consumers already rely on `OrchestratorConfig.useTaskGraph`, legacy `generateMap()` semantics, or the `config.toggles.STORY_ENABLE_*` surface (none found in-repo beyond tests/mods/docs, but this can't be proven from a workspace scan).
+- Whether we still need an independent, non-legacy equivalent of "paleo enabled" separate from stage gating (see "Open Questions").
+
+---
+
+## 4. Architectural Decisions (Locked)
+
+We're aligned on a pragmatic "canonical path now, refactor details later" approach:
+
+| Decision | Detail |
+|----------|--------|
+| **Canonical execution** | TaskGraph is the only supported orchestration path; legacy `generateMap()` inline runner is removed. |
+| **Canonical enablement** | Stage enablement is driven only by `stageManifest` (resolved from `stageConfig` via `bootstrap()`). The legacy story toggle surface (`config.toggles.STORY_ENABLE_*`) is removed entirely; we are not optimizing for internal toggling right now. |
+| **Paleo gating** | Paleo runs whenever its config exists (no independent toggle). Concretely: if `climate.story.paleo` is present, we attempt to apply paleo effects (and it naturally no-ops when config is missing). |
+| **Validation bar** | Prioritize "loads + no obviously missing major stage" over visual parity; existing step-level validation + smoke checks are sufficient for this removal pass. |
+| **Story globals (temporary)** | We accept keeping StoryTags and related caches global temporarily to keep scope bounded while we delete legacy orchestration + toggles. |
+| **Story globals (end-state)** | We explicitly intend to gut globals by the end, aligning all consumers on context-owned artifacts/overlays (and/or a context-owned story state object). This is the "last thing we do" in this initiative, after the legacy fork is gone. |
+
+**Rationale**: Eliminating the orchestration fork + legacy config surfaces removes the primary structural source of drift and sharply reduces ongoing migration overhead.
+
+---
+
+## 5. Target End-State
+
+- **Single orchestrator path**: `MapOrchestrator.generateMap()` is TaskGraph-only; no inline legacy stage runner exists; `OrchestratorConfig.useTaskGraph` does not exist.
+- **Single enablement surface**: stage enablement is expressed only via `stageConfig/stageManifest` (resolved by `bootstrap()`), not via legacy story toggle mirrors.
+- **Story optionality is structural**:
+  - Disabling story stages never re-introduces state leakage (globals reset per run at the orchestrator boundary).
+  - Downstream steps that "benefit from story" use the presence/absence of story artifacts/tags/config as their primary signal, not an independent legacy toggle surface.
+- **Paleo has no legacy switch**: paleo is driven by config presence (e.g. `climate.story.paleo`), not `STORY_ENABLE_PALEO`.
+- **No legacy shims in the public API**: remove `createLegacy*Step` aliases and legacy bootstrap config shapes that only exist for historical callers.
+- **End-state story state is context-owned** (after the final step in this initiative): no module-level narrative registries/caches are required for correctness; all cross-stage "story" data is carried via context artifacts/overlays (or a context-owned story state object) and referenced explicitly by consumers.
+
+---
+
+## 6. Scope Boundaries
+
+### 6.1 Goals (In Scope)
+
+- Remove legacy orchestration path and make `generateMap()` TaskGraph-only
+- Remove legacy story toggle surface (`config.toggles.STORY_ENABLE_*`)
+- Remove legacy shims (`createLegacy*Step`, `LegacyPlacementStep`, legacy bootstrap shapes)
+- Migrate downstream gating to canonical signals (stage enablement, config presence, artifact/tag presence)
+- Align presets and docs with the new contract
+
+### 6.2 Non-Goals (Explicit Deferrals)
+
+**Intent**: Remove legacy *compatibility* surfaces, but do not rename/remove "legacy" *behavior modes* that are part of algorithm semantics today.
+
+Examples to defer (non-exhaustive):
+
+- Algorithm mode selectors like `"legacy" | "area"` (e.g. landmask/crust behavior in `packages/mapgen-core/src/config/schema.ts` and `packages/mapgen-core/src/domain/morphology/landmass/crust-mode.ts`).
+
+**Trigger to revisit**: Once we have confidence that internal consumers no longer need to compare/validate "legacy vs area" behavior (e.g., parity matrices stabilized or the team decides one mode is canonical and deletes the other).
+
+**Other legacy surfaces noticed** (not behavior modes):
+
+- Deprecated top-level diagnostics toggles are still present in config schema as "[legacy/no-op]" (`packages/mapgen-core/src/config/schema.ts`, `DiagnosticsConfigSchema`). If the goal is "no legacy config surface at all", these can likely be removed in the same initiative, but they are not directly tied to story drift.
+
+---
+
+## 7. Current State Analysis
+
+### 7.1 Internal Consumers (What Actually Needs Migration)
+
+Workspace scan suggests there are only three meaningful categories of "internal consumers" to migrate off legacy:
 
 - **Mods (TypeScript sources):**
   - TaskGraph enabled: `mods/mod-swooper-maps/src/swooper-earthlike.ts` (`useTaskGraph: true`).
@@ -77,18 +131,18 @@ Workspace scan suggests there are only three meaningful categories of “interna
 - **Tests:** multiple orchestrator tests call `generateMap()` without `useTaskGraph`, so they currently exercise legacy by default (e.g. `packages/mapgen-core/test/orchestrator/story-parity.smoke.test.ts`).
 - **Docs/examples:** a few docs still imply legacy control surfaces / patterns (e.g. `docs/system/mods/swooper-maps/architecture.md`).
 
-Note: built artifacts under `mods/mod-swooper-maps/mod/maps/*.js` also contain legacy strings, but these are generated outputs and are not treated as meaningful “consumers” (they can be regenerated after source updates).
+Note: built artifacts under `mods/mod-swooper-maps/mod/maps/*.js` also contain legacy strings, but these are generated outputs and are not treated as meaningful "consumers" (they can be regenerated after source updates).
 
-### 4) Pipeline ordering + stage enablement is already canonicalized (strong foundation)
+### 7.2 Pipeline Ordering + Stage Enablement (Strong Foundation)
 
 - Canonical stage order is centralized in `STAGE_ORDER` (`packages/mapgen-core/src/bootstrap/resolved.ts`).
 - `bootstrap()` resolves `stageConfig -> stageManifest`, so stage enablement has a canonical representation by default (`packages/mapgen-core/src/bootstrap/entry.ts`).
 - TaskGraph executes `StageManifest.order` filtered by enablement (`packages/mapgen-core/src/pipeline/StepRegistry.ts`).
 - TaskGraph adds guardrails via requires/provides validation (`packages/mapgen-core/src/pipeline/PipelineExecutor.ts`).
 
-### 5) Story enablement is still represented twice (stages + legacy toggles)
+### 7.3 Story Enablement Is Still Represented Twice
 
-We have a canonical “what stages are enabled” representation (the resolved `stageManifest`), but legacy toggles still exist as an authored config surface and are consumed in domain logic.
+We have a canonical "what stages are enabled" representation (the resolved `stageManifest`), but legacy toggles still exist as an authored config surface and are consumed in domain logic.
 
 - Stage gating is derived from `stageManifest` (`packages/mapgen-core/src/MapOrchestrator.ts`, `resolveStageFlags()`).
 - `MapOrchestrator` derives and overwrites story-related toggles when constructing `context.config` (`packages/mapgen-core/src/MapOrchestrator.ts`, `buildContextConfig()`).
@@ -99,109 +153,154 @@ We have a canonical “what stages are enabled” representation (the resolved `
   - Paleo is gated in the rivers step via a toggle (`packages/mapgen-core/src/pipeline/hydrology/index.ts`).
 - Presets set story toggles but do not enable story stages by default, which is a confusing contract if `stageManifest` is intended to be authoritative (`packages/mapgen-core/src/config/presets.ts`).
 
-Also: `StageDescriptorSchema` includes `legacyToggles` metadata (`packages/mapgen-core/src/config/schema.ts`) but there are no in-repo reads of that field today. That “half-bridge” is drift bait: it suggests canonical mapping exists, but it currently doesn’t.
+Also: `StageDescriptorSchema` includes `legacyToggles` metadata (`packages/mapgen-core/src/config/schema.ts`) but there are no in-repo reads of that field today. That "half-bridge" is drift bait: it suggests canonical mapping exists, but it currently doesn't.
 
-### 6) Other legacy compatibility surfaces that are removable now
+### 7.4 Other Legacy Compatibility Surfaces (Removable Now)
 
 - `packages/mapgen-core/src/steps/index.ts` re-exports `createLegacyBiomesStep`, `createLegacyFeaturesStep`, `createLegacyPlacementStep` (thin aliases over pipeline steps).
 - `packages/mapgen-core/src/pipeline/placement/LegacyPlacementStep.ts` exists and is exercised by tests (`packages/mapgen-core/test/orchestrator/placement-config-wiring.test.ts`), even though the standard pipeline uses `createPlacementStep` (`packages/mapgen-core/src/pipeline/placement/index.ts`).
-- `bootstrap()` still types a legacy `BootstrapConfig.stages` object (commented as “legacy interface”) in `packages/mapgen-core/src/bootstrap/entry.ts`; no in-repo callsites were found using this surface.
+- `bootstrap()` still types a legacy `BootstrapConfig.stages` object (commented as "legacy interface") in `packages/mapgen-core/src/bootstrap/entry.ts`; no in-repo callsites were found using this surface.
 
-## Primary recommendation
+---
 
-### Remove legacy orchestration and legacy compat surfaces now (keep only behavior modes)
+## 8. Risks & Mitigations
 
-Why:
+| Risk | Mitigation |
+|------|------------|
+| **Internal breakage** is expected | Any internal mod/config relying on legacy behavior must be migrated in lockstep. |
+| **Config semantic ambiguity** is the biggest footgun | Presets and runtime toggle-derivation currently send mixed signals; clean up in same pass. |
+| **Global story state remains a drift risk until the last step** | As long as tags/overlays/caches can be read from module-level singletons, we can still accidentally couple stages or satisfy dependencies via stale global state. Addressed in final phase. |
+| **Hidden consumers** are the only meaningful external risk | If the repo is not yet published for modders, this is likely low. |
 
-- Keeping multiple orchestrators guarantees drift: any change to stage order, resets, artifacts, or “story optionality” must be implemented twice.
-- With story now modularized and shared across pipeline wiring + domain components, the dominant remaining drift is configuration and orchestration, not the story algorithms themselves.
-- TaskGraph has stronger guardrails (requires/provides validation) and matches the M4 invariant “reset story globals outside story steps”.
+---
 
-Scope note:
+## 9. Open Questions
 
-- This recommendation intentionally **does not** remove true behavioral modes (e.g., algorithm mode selectors like `"legacy" | "area"`), because those are not compatibility shims—they’re behavior contracts. See “Explicit deferrals”.
-
-## What “done” looks like (conceptual shape)
-
-End-state vision:
-
-- **Single orchestrator path**: `MapOrchestrator.generateMap()` is TaskGraph-only; no inline legacy stage runner exists; `OrchestratorConfig.useTaskGraph` does not exist.
-- **Single enablement surface**: stage enablement is expressed only via `stageConfig/stageManifest` (resolved by `bootstrap()`), not via legacy story toggle mirrors.
-- **Story optionality is structural**:
-  - Disabling story stages never re-introduces state leakage (globals reset per run at the orchestrator boundary).
-  - Downstream steps that “benefit from story” use the presence/absence of story artifacts/tags/config as their primary signal, not an independent legacy toggle surface.
-- **Paleo has no legacy switch**: paleo is driven by config presence (e.g. `climate.story.paleo`), not `STORY_ENABLE_PALEO`.
-- **No legacy shims in the public API**: remove `createLegacy*Step` aliases and legacy bootstrap config shapes that only exist for historical callers.
-- **End-state story state is context-owned** (after the final step in this initiative): no module-level narrative registries/caches are required for correctness; all cross-stage “story” data is carried via context artifacts/overlays (or a context-owned story state object) and referenced explicitly by consumers.
-
-## What we plan to delete (non-exhaustive)
-
-- **Orchestration switch + duplicate runner**
-  - `OrchestratorConfig.useTaskGraph` and the `generateMap()` branch that selects between two orchestrators (`packages/mapgen-core/src/MapOrchestrator.ts`).
-  - The legacy inline stage runner blocks inside `generateMap()` (including inline story stages).
-- **Legacy story toggle surface**
-  - `config.toggles.STORY_ENABLE_*` from config schema (`packages/mapgen-core/src/config/schema.ts`) and presets (`packages/mapgen-core/src/config/presets.ts`).
-  - The toggle-derivation bridge in `MapOrchestrator.buildContextConfig()` (`packages/mapgen-core/src/MapOrchestrator.ts`).
-  - Downstream toggle-based gating in non-story code paths (e.g. ecology/biomes/climate refine), migrating those decisions to stage enablement and/or artifact/tag presence.
-- **Dead / half-migrated metadata**
-  - `StageDescriptorSchema.legacyToggles` (present in schema; no in-repo reads found).
-- **Legacy shims / re-export surfaces**
-  - `packages/mapgen-core/src/steps/*` legacy step aliases and any remaining references to `createLegacy*Step`.
-  - `packages/mapgen-core/src/pipeline/placement/LegacyPlacementStep.ts` (after tests migrate off it).
-- **Legacy bootstrap input shapes**
-  - `BootstrapConfig.stages` legacy interface in `packages/mapgen-core/src/bootstrap/entry.ts` (no in-repo callsites found using it).
-
-## High-level implementation outline (sequenced, thin-slice)
-
-1) Migrate all in-repo callsites and tests to a single orchestration path (TaskGraph-only).
-2) Make `generateMap()` TaskGraph-only; remove `OrchestratorConfig.useTaskGraph`; delete the legacy inline stage runner blocks.
-3) Remove legacy story toggle surface (`config.toggles.STORY_ENABLE_*`) and migrate any remaining gating to canonical signals:
-   - stage enablement (`stageManifest`)
-   - config presence (notably: paleo runs iff its config exists; no independent toggle)
-   - artifact/tag presence where applicable (story overlays/tags), depending on the subsystem.
-4) Remove other legacy shims:
-   - `createLegacy*Step` exports and `LegacyPlacementStep` (after migrating the tests that rely on them),
-   - unused schema metadata like `StageDescriptorSchema.legacyToggles` (or finish the mapping and then immediately remove it once all callers are migrated—prefer removal).
-5) Align presets and docs with the new contract (presets should not set legacy story toggles; docs should not describe legacy control surfaces).
-6) Validation strategy (intentionally lightweight for this pass):
-   - Focus on “loads + no obviously missing major stage”; rely on existing step-level validation and a small number of orchestrator smokes.
-7) Last step (end-state alignment): remove story module-level globals and align consumers on context-owned data:
-   - remove global overlay registry fallback / dependency satisfaction based on global registry size
-   - migrate global StoryTags and related caches to a context-owned representation (artifact or explicit `ctx.story.*`)
-
-## Risks, trade-offs, regressions
-
-- **Internal breakage** is expected: any internal mod/config relying on legacy behavior must be migrated in lockstep.
-- **Config semantic ambiguity** is the biggest footgun: presets and runtime toggle-derivation currently send mixed signals.
-- **Global story state remains a drift risk until the last step**: as long as tags/overlays/caches can be read from module-level singletons, we can still accidentally couple stages or satisfy dependencies via stale global state.
-- **Hidden consumers** are the only meaningful external risk; if the repo is not yet published for modders, this is likely low.
-
-## Explicit deferrals (behavior modes we should not remove in this stack)
-
-Intent: remove legacy *compatibility* surfaces, but do not rename/remove “legacy” *behavior modes* that are part of algorithm semantics today.
-
-Examples to defer (non-exhaustive):
-
-- Algorithm mode selectors like `"legacy" | "area"` (e.g. landmask/crust behavior in `packages/mapgen-core/src/config/schema.ts` and `packages/mapgen-core/src/domain/morphology/landmass/crust-mode.ts`).
-
-Trigger to revisit:
-
-- Once we have confidence that internal consumers no longer need to compare/validate “legacy vs area” behavior (e.g., parity matrices stabilized or the team decides one mode is canonical and deletes the other).
-
-Other legacy surfaces noticed (not behavior modes):
-
-- Deprecated top-level diagnostics toggles are still present in config schema as “[legacy/no-op]” (`packages/mapgen-core/src/config/schema.ts`, `DiagnosticsConfigSchema`). If the goal is “no legacy config surface at all”, these can likely be removed in the same initiative, but they are not directly tied to story drift.
-
-## Open decisions (remaining)
-
-Resolved:
+### 9.1 Resolved
 
 - We will keep `generateMap()` as the stable entrypoint but make it TaskGraph-only.
 - Paleo runs whenever its config exists; no independent enablement switch is retained.
 
-Remaining (affects the “last step” scope):
+### 9.2 Remaining (affects "last step" scope)
 
-1) What is the canonical context-owned representation for story tags and caches?
+1. **What is the canonical context-owned representation for story tags and caches?**
    - Option A: an explicit `artifact:storyTags` / `artifact:storyState` value published by story steps and consumed by later steps.
    - Option B: a typed `ctx.story.*` object (parallel to `ctx.overlays` / `ctx.artifacts`) owned by the context factory.
-2) For overlays specifically: should the pipeline consider overlays an artifact only when `ctx.overlays.size > 0`, or do we want a stable “overlay registry exists but empty” representation that still satisfies dependency tags without relying on a global fallback?
+
+2. **For overlays specifically**: should the pipeline consider overlays an artifact only when `ctx.overlays.size > 0`, or do we want a stable "overlay registry exists but empty" representation that still satisfies dependency tags without relying on a global fallback?
+
+---
+
+# Part B: Implementation Manifest
+
+## 1. Deletion Manifest
+
+### 1.1 Orchestration Switch + Duplicate Runner
+
+- [ ] `OrchestratorConfig.useTaskGraph` option (`packages/mapgen-core/src/MapOrchestrator.ts`)
+- [ ] `generateMap()` branch that selects between two orchestrators (`packages/mapgen-core/src/MapOrchestrator.ts`)
+- [ ] Legacy inline stage runner blocks inside `generateMap()` (including inline story stages)
+
+### 1.2 Legacy Story Toggle Surface
+
+- [ ] `config.toggles.STORY_ENABLE_*` from config schema (`packages/mapgen-core/src/config/schema.ts`)
+- [ ] `config.toggles.STORY_ENABLE_*` from presets (`packages/mapgen-core/src/config/presets.ts`)
+- [ ] Toggle-derivation bridge in `MapOrchestrator.buildContextConfig()` (`packages/mapgen-core/src/MapOrchestrator.ts`)
+- [ ] Downstream toggle-based gating in non-story code paths:
+  - [ ] `packages/mapgen-core/src/domain/ecology/features/index.ts` (`STORY_ENABLE_HOTSPOTS`)
+  - [ ] `packages/mapgen-core/src/domain/ecology/biomes/index.ts` (`STORY_ENABLE_RIFTS`)
+  - [ ] `packages/mapgen-core/src/domain/hydrology/climate/refine/orogeny-belts.ts` (`STORY_ENABLE_OROGENY`)
+  - [ ] `packages/mapgen-core/src/pipeline/hydrology/index.ts` (paleo toggle)
+
+### 1.3 Dead / Half-Migrated Metadata
+
+- [ ] `StageDescriptorSchema.legacyToggles` (`packages/mapgen-core/src/config/schema.ts`)
+
+### 1.4 Legacy Shims / Re-export Surfaces
+
+- [ ] `packages/mapgen-core/src/steps/*` legacy step aliases (`createLegacyBiomesStep`, `createLegacyFeaturesStep`, `createLegacyPlacementStep`)
+- [ ] `packages/mapgen-core/src/pipeline/placement/LegacyPlacementStep.ts`
+- [ ] Tests using legacy placement step (`packages/mapgen-core/test/orchestrator/placement-config-wiring.test.ts`)
+
+### 1.5 Legacy Bootstrap Input Shapes
+
+- [ ] `BootstrapConfig.stages` legacy interface (`packages/mapgen-core/src/bootstrap/entry.ts`)
+
+---
+
+## 2. Phase Roadmap
+
+| Phase | Description | Dependencies |
+|-------|-------------|--------------|
+| **Phase 1** | Migrate all in-repo callsites and tests to TaskGraph-only | None |
+| **Phase 2** | Make `generateMap()` TaskGraph-only; remove `useTaskGraph`; delete legacy inline runner | Phase 1 |
+| **Phase 3** | Remove legacy story toggle surface; migrate gating to canonical signals | Phase 2 |
+| **Phase 4** | Remove legacy shims (`createLegacy*Step`, `LegacyPlacementStep`, dead metadata) | Phase 3 |
+| **Phase 5** | Align presets and docs with new contract | Phase 4 |
+| **Phase 6** | Validation pass (smoke tests, step-level validation) | Phase 5 |
+| **Phase 7** | Remove story module-level globals; migrate to context-owned data | Phase 6 |
+
+---
+
+## 3. Migration Checklists
+
+### 3.1 Mods Migration
+
+- [ ] `mods/mod-swooper-maps/src/swooper-desert-mountains.ts` — add `useTaskGraph: true` (or remove option once default)
+- [ ] `mods/mod-swooper-maps/src/swooper-earthlike.ts` — already enabled; remove explicit `useTaskGraph` once default
+- [ ] Regenerate built artifacts under `mods/mod-swooper-maps/mod/maps/*.js`
+
+### 3.2 Tests Migration
+
+- [ ] `packages/mapgen-core/test/orchestrator/story-parity.smoke.test.ts` — update to TaskGraph path
+- [ ] `packages/mapgen-core/test/orchestrator/placement-config-wiring.test.ts` — migrate off `LegacyPlacementStep`
+- [ ] Audit other orchestrator tests calling `generateMap()` without `useTaskGraph`
+
+### 3.3 Docs Migration
+
+- [ ] `docs/system/mods/swooper-maps/architecture.md` — remove legacy control surface references
+
+### 3.4 Downstream Gating Migration
+
+For each downstream toggle consumer, migrate to one of:
+- **Stage enablement**: check `stageManifest` or stage flags
+- **Config presence**: check if relevant config section exists (e.g. `climate.story.paleo`)
+- **Artifact/tag presence**: check story overlays/tags directly
+
+| File | Current Toggle | Migration Strategy |
+|------|----------------|-------------------|
+| `domain/ecology/features/index.ts` | `STORY_ENABLE_HOTSPOTS` | Check story tag sets (already partially done) |
+| `domain/ecology/biomes/index.ts` | `STORY_ENABLE_RIFTS` | Check story tag sets |
+| `domain/hydrology/climate/refine/orogeny-belts.ts` | `STORY_ENABLE_OROGENY` | Check story tag sets or stage flag |
+| `pipeline/hydrology/index.ts` | Paleo toggle | Check `climate.story.paleo` config presence |
+
+---
+
+## 4. Validation Checklist
+
+**Bar**: "loads + no obviously missing major stage" (not visual parity)
+
+- [ ] All mods load without error
+- [ ] All orchestrator tests pass
+- [ ] No major stage missing from output (spot-check map generation)
+- [ ] Existing step-level validation passes
+- [ ] Smoke tests pass
+
+---
+
+## 5. Implementation Notes
+
+### 5.1 Why TaskGraph Has Stronger Guardrails
+
+- Keeping multiple orchestrators guarantees drift: any change to stage order, resets, artifacts, or "story optionality" must be implemented twice.
+- With story now modularized and shared across pipeline wiring + domain components, the dominant remaining drift is configuration and orchestration, not the story algorithms themselves.
+- TaskGraph has stronger guardrails (requires/provides validation) and matches the M4 invariant "reset story globals outside story steps".
+
+### 5.2 End-State Story Globals Migration (Phase 7)
+
+This is the "last thing we do" in this initiative:
+
+- Remove global overlay registry fallback / dependency satisfaction based on global registry size
+- Migrate global StoryTags and related caches to a context-owned representation (artifact or explicit `ctx.story.*`)
+
+This depends on resolving the open questions in Section 9.2.


### PR DESCRIPTION
# Reorganize SPIKE document into actionable PRD with two parts:
- Part A: Context & Design (summary, problem statement, decisions, scope)
- Part B: Implementation Manifest (deletion manifest, phases, checklists)

This PR converts the existing SPIKE document on story drift and legacy path removal into a structured PRD with implementation groups. The document is now organized into:

1. A design section that clearly articulates the problem, architectural decisions, and scope boundaries
2. An implementation section with five sequential work groups, each with explicit deliverables and completion criteria

Key improvements:
- Added explicit issue metadata (priority, estimate, labels)
- Structured the document with clear navigation and section boundaries
- Converted analysis into actionable work groups with checklists
- Added explicit acceptance criteria and testing strategy
- Preserved all architectural decisions while making them more accessible

The reorganized document provides a clear roadmap for removing legacy orchestration paths and toggle surfaces, making TaskGraph the sole execution path and `stageManifest` the single source of truth for stage enablement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>