### PR TITLE
chore(mapgen): migrate tests/mods to TaskGraph flag

### DIFF
--- a/mods/mod-swooper-maps/src/swooper-desert-mountains.ts
+++ b/mods/mod-swooper-maps/src/swooper-desert-mountains.ts
@@ -274,7 +274,7 @@ function buildConfig(): BootstrapConfig {
 }
 
 // Orchestrator options (shared between requestMapData and generateMap)
-const orchestratorOptions = { logPrefix: "[SWOOPER_MOD]" };
+const orchestratorOptions = { logPrefix: "[SWOOPER_MOD]", useTaskGraph: true };
 
 // Wire engine events to orchestrator methods
 // RequestMapInitData: Bootstrap with defaults to set up map dimensions

--- a/packages/mapgen-core/test/orchestrator/foundation.smoke.test.ts
+++ b/packages/mapgen-core/test/orchestrator/foundation.smoke.test.ts
@@ -69,7 +69,11 @@ describe("smoke: MapOrchestrator.generateMap foundation slice", () => {
     });
 
     const config = bootstrap({ stageConfig: { foundation: true } });
-    const orchestrator = new MapOrchestrator(config, { adapter, logPrefix: "[TEST]" });
+    const orchestrator = new MapOrchestrator(config, {
+      adapter,
+      logPrefix: "[TEST]",
+      useTaskGraph: true,
+    });
     const result = orchestrator.generateMap();
 
     expect(result.success).toBe(true);

--- a/packages/mapgen-core/test/orchestrator/generateMap.integration.test.ts
+++ b/packages/mapgen-core/test/orchestrator/generateMap.integration.test.ts
@@ -40,6 +40,7 @@ describe("integration: bootstrap → orchestrator (stages disabled)", () => {
     const orchestrator = new MapOrchestrator(config, {
       adapter,
       logPrefix: "[TEST]",
+      useTaskGraph: true,
     });
 
     const result = orchestrator.generateMap();

--- a/packages/mapgen-core/test/orchestrator/paleo-ordering.test.ts
+++ b/packages/mapgen-core/test/orchestrator/paleo-ordering.test.ts
@@ -109,7 +109,7 @@ describe("orchestrator: paleo hydrology runs post-rivers", () => {
       },
     });
 
-    const orchestrator = new MapOrchestrator(config, { adapter, logPrefix: "[TEST]" });
+    const orchestrator = new MapOrchestrator(config, { adapter, logPrefix: "[TEST]", useTaskGraph: true });
     const result = orchestrator.generateMap();
     expect(result.success).toBe(true);
     expect(readPaleoDeltas()).toBe(1);

--- a/packages/mapgen-core/test/orchestrator/placement-config-wiring.test.ts
+++ b/packages/mapgen-core/test/orchestrator/placement-config-wiring.test.ts
@@ -55,7 +55,7 @@ describe("placement config wiring", () => {
       },
     });
 
-    const orchestrator = new MapOrchestrator(config, { adapter, logPrefix: "[TEST]" });
+    const orchestrator = new MapOrchestrator(config, { adapter, logPrefix: "[TEST]", useTaskGraph: true });
     const result = orchestrator.generateMap();
 
     expect(result.success).toBe(true);
@@ -65,4 +65,3 @@ describe("placement config wiring", () => {
     expect(calls.addFloodplains[0]).toEqual({ minLength: 1, maxLength: 2 });
   });
 });
-

--- a/packages/mapgen-core/test/orchestrator/story-parity.smoke.test.ts
+++ b/packages/mapgen-core/test/orchestrator/story-parity.smoke.test.ts
@@ -76,6 +76,7 @@ describe("smoke: minimal story parity (margins, hotspots, rifts)", () => {
     const orchestrator = new MapOrchestrator(config, {
       adapter,
       logPrefix: "[TEST]",
+      useTaskGraph: true,
     });
 
     orchestrator.generateMap();

--- a/packages/mapgen-core/test/orchestrator/worldmodel-config-wiring.test.ts
+++ b/packages/mapgen-core/test/orchestrator/worldmodel-config-wiring.test.ts
@@ -87,7 +87,7 @@ describe("MapOrchestrator WorldModel config wiring", () => {
       rng: () => 0,
     });
 
-    const orchestrator = new MapOrchestrator(config, { adapter, logPrefix: "[TEST]" });
+    const orchestrator = new MapOrchestrator(config, { adapter, logPrefix: "[TEST]", useTaskGraph: true });
     const result = orchestrator.generateMap();
     expect(result.success).toBe(true);
 
@@ -131,7 +131,7 @@ describe("MapOrchestrator WorldModel config wiring", () => {
       rng: () => 0,
     });
 
-    const orchestrator = new MapOrchestrator(config, { adapter, logPrefix: "[TEST]" });
+    const orchestrator = new MapOrchestrator(config, { adapter, logPrefix: "[TEST]", useTaskGraph: true });
     const result = orchestrator.generateMap();
     expect(result.success).toBe(true);
 


### PR DESCRIPTION
### TL;DR

Enable task graph execution in map generation orchestrator across all test cases and the Swooper desert mountains map.

### What changed?

Added the `useTaskGraph: true` option to the `MapOrchestrator` constructor in:
- The Swooper desert mountains map configuration
- All test files that use the `MapOrchestrator` class, including:
  - Foundation smoke tests
  - Generate map integration tests
  - Paleo ordering tests
  - Placement config wiring tests
  - Story parity smoke tests
  - WorldModel config wiring tests

### How to test?

1. Run the test suite to ensure all tests pass with task graph enabled
2. Load the Swooper desert mountains map in-game to verify it generates correctly
3. Check for any performance improvements or differences in map generation

### Why make this change?

Enabling the task graph execution model allows for better orchestration of map generation tasks, potentially improving performance and providing a more structured approach to task dependencies. This change ensures consistent use of the task graph feature across both production code and tests.