### PR TITLE
refactor(mapgen-core): remove legacy toggles system

### DIFF
--- a/mods/mod-swooper-maps/src/swooper-desert-mountains.ts
+++ b/mods/mod-swooper-maps/src/swooper-desert-mountains.ts
@@ -40,15 +40,6 @@ function buildConfig(): BootstrapConfig {
       placement: true,
     },
     overrides: {
-      toggles: {
-        // Enable standard story features for variety
-        STORY_ENABLE_HOTSPOTS: true,
-        STORY_ENABLE_RIFTS: true,
-        STORY_ENABLE_OROGENY: true,
-        STORY_ENABLE_SWATCHES: true,
-        STORY_ENABLE_PALEO: true,
-        STORY_ENABLE_CORRIDORS: true,
-      },
       landmass: {
         crustMode: "area",
         baseWaterPercent: 53, // More ocean for distinct continents

--- a/mods/mod-swooper-maps/src/swooper-earthlike.ts
+++ b/mods/mod-swooper-maps/src/swooper-earthlike.ts
@@ -36,14 +36,6 @@ function buildConfig(): BootstrapConfig {
       placement: true,
     },
     overrides: {
-      toggles: {
-        STORY_ENABLE_HOTSPOTS: true,
-        STORY_ENABLE_RIFTS: true,
-        STORY_ENABLE_OROGENY: true,
-        STORY_ENABLE_SWATCHES: true,
-        STORY_ENABLE_PALEO: true,
-        STORY_ENABLE_CORRIDORS: true,
-      },
       landmass: {
         crustMode: "area",
         // Earth-like ocean dominance (~70% water).

--- a/packages/mapgen-core/src/MapOrchestrator.ts
+++ b/packages/mapgen-core/src/MapOrchestrator.ts
@@ -394,7 +394,7 @@ export class MapOrchestrator {
       ctx = createExtendedMapContext(
         { width: iWidth, height: iHeight },
         layerAdapter,
-        this.buildContextConfig(stageFlags)
+        config
       );
       console.log(`${prefix} MapContext created successfully`);
     } catch (err) {
@@ -536,25 +536,6 @@ export class MapOrchestrator {
   // ==========================================================================
   // Private Helpers
   // ==========================================================================
-
-  private buildContextConfig(stageFlags: Record<string, boolean>): MapGenConfig {
-    const base = this.mapGenConfig;
-    const baseToggles = (base.toggles ?? {}) as Record<string, unknown>;
-    const paleo = (base.toggles as { STORY_ENABLE_PALEO?: boolean } | undefined)?.STORY_ENABLE_PALEO;
-
-    return {
-      ...base,
-      toggles: {
-        ...baseToggles,
-        STORY_ENABLE_HOTSPOTS: stageFlags.storyHotspots,
-        STORY_ENABLE_RIFTS: stageFlags.storyRifts,
-        STORY_ENABLE_OROGENY: stageFlags.storyOrogeny,
-        STORY_ENABLE_SWATCHES: stageFlags.storySwatches,
-        STORY_ENABLE_PALEO: paleo ?? true,
-        STORY_ENABLE_CORRIDORS: stageFlags.storyCorridorsPre || stageFlags.storyCorridorsPost,
-      },
-    };
-  }
 
   private buildPlacementStartsConfig(
     baseStarts: StartsConfig,

--- a/packages/mapgen-core/src/bootstrap/types.ts
+++ b/packages/mapgen-core/src/bootstrap/types.ts
@@ -45,7 +45,6 @@ import type {
   StageManifest,
   StartsConfig,
   StoryConfig,
-  Toggles,
   VolcanoesConfig,
 } from "../config/index.js";
 
@@ -90,7 +89,6 @@ export type {
   StageManifest,
   StartsConfig,
   StoryConfig,
-  Toggles,
   VolcanoesConfig,
 };
 

--- a/packages/mapgen-core/src/config/index.ts
+++ b/packages/mapgen-core/src/config/index.ts
@@ -52,7 +52,6 @@ export {
   StageManifestSchema,
   StartsConfigSchema,
   StoryConfigSchema,
-  TogglesSchema,
   VolcanoesConfigSchema,
 } from "./schema.js";
 
@@ -108,7 +107,6 @@ export type {
   StageManifest,
   StartsConfig,
   StoryConfig,
-  Toggles,
   VolcanoesConfig,
 } from "./schema.js";
 

--- a/packages/mapgen-core/src/config/presets.ts
+++ b/packages/mapgen-core/src/config/presets.ts
@@ -55,14 +55,6 @@ const PRESETS: Readonly<Record<MapGenPresetName, DeepPartial<MapGenConfig>>> = O
       foundation: true,
       landmassPlates: true,
     },
-    toggles: {
-      STORY_ENABLE_HOTSPOTS: true,
-      STORY_ENABLE_RIFTS: true,
-      STORY_ENABLE_OROGENY: true,
-      STORY_ENABLE_SWATCHES: true,
-      STORY_ENABLE_PALEO: true,
-      STORY_ENABLE_CORRIDORS: true,
-    },
     foundation: {
       diagnostics: {
         enabled: false,
@@ -76,14 +68,6 @@ const PRESETS: Readonly<Record<MapGenPresetName, DeepPartial<MapGenConfig>>> = O
     stageConfig: {
       foundation: true,
       landmassPlates: true,
-    },
-    toggles: {
-      STORY_ENABLE_HOTSPOTS: true,
-      STORY_ENABLE_RIFTS: true,
-      STORY_ENABLE_OROGENY: true,
-      STORY_ENABLE_SWATCHES: true,
-      STORY_ENABLE_PALEO: true,
-      STORY_ENABLE_CORRIDORS: true,
     },
     foundation: {
       dynamics: {

--- a/packages/mapgen-core/src/config/schema.ts
+++ b/packages/mapgen-core/src/config/schema.ts
@@ -67,7 +67,7 @@ export const StageConfigSchema = Type.Record(Type.String(), Type.Boolean(), {
 
 /**
  * Descriptor for a stage in the orchestrated manifest.
- * Captures dependencies, provided tags, and legacy toggle aliases.
+ * Captures dependencies and provided tags.
  *
  * @internal Engine plumbing for stage resolution; not part of the public mod API.
  */
@@ -90,12 +90,6 @@ export const StageDescriptorSchema = Type.Object(
         default: [],
         description:
           "Dependency tags this stage makes available to dependents (data artifacts, fields, and/or engine-state guarantees). Note: state:engine.* tags are treated as trusted assertions in M3 and are not runtime-verified.",
-      })
-    ),
-    legacyToggles: Type.Optional(
-      Type.Array(Type.String(), {
-        default: [],
-        description: "Legacy boolean toggles that map to this stage for backward compatibility.",
       })
     ),
     blockedBy: Type.Optional(
@@ -128,81 +122,6 @@ export const StageManifestSchema = Type.Object(
     description: "[internal] Stage manifest for orchestrated pipeline execution.",
     [INTERNAL_METADATA_KEY]: true,
   }
-);
-
-/**
- * High-level toggles that mirror the legacy STORY_ENABLE_* flags.
- */
-export const TogglesSchema = Type.Object(
-  {
-    /**
-     * Whether volcanic/paradise hotspots are allowed to generate story overlays.
-     * When enabled, creates Hawaii-style island chains and lush paradise archipelagos.
-     * @default true
-     */
-    STORY_ENABLE_HOTSPOTS: Type.Optional(
-      Type.Boolean({
-        default: true,
-        description: "Whether volcanic/paradise hotspots are allowed to generate story overlays.",
-      })
-    ),
-    /**
-     * Whether continental rift valleys and shoulders should be created.
-     * Produces East-African-style rift features with elevated shoulders and lowland troughs.
-     * @default true
-     */
-    STORY_ENABLE_RIFTS: Type.Optional(
-      Type.Boolean({
-        default: true,
-        description: "Whether continental rift valleys and shoulders should be created.",
-      })
-    ),
-    /**
-     * Controls whether orogenic mountain belts are simulated along convergent margins.
-     * Creates Andes/Himalayas-style ranges where plates collide.
-     * @default true
-     */
-    STORY_ENABLE_OROGENY: Type.Optional(
-      Type.Boolean({
-        default: true,
-        description: "Controls whether orogenic mountain belts are simulated along convergent margins.",
-      })
-    ),
-    /**
-     * Enables macro swatch overrides that recolor large climate regions.
-     * Creates coherent biome patches (e.g., Sahara-sized deserts or Amazon-style rainforests).
-     * @default true
-     */
-    STORY_ENABLE_SWATCHES: Type.Optional(
-      Type.Boolean({
-        default: true,
-        description: "Enables macro swatch overrides that recolor large climate regions.",
-      })
-    ),
-    /**
-     * Enables paleo-hydrology artifacts such as fossil channels and oxbows.
-     * Adds dry riverbeds and ancient lake basins for terrain variety.
-     * @default true
-     */
-    STORY_ENABLE_PALEO: Type.Optional(
-      Type.Boolean({
-        default: true,
-        description: "Enables paleo-hydrology artifacts such as fossil channels and oxbows.",
-      })
-    ),
-    /**
-     * Controls whether strategic corridor protection is applied.
-     * Preserves navigable sea lanes and land bridges for gameplay connectivity.
-     * @default true
-     */
-    STORY_ENABLE_CORRIDORS: Type.Optional(
-      Type.Boolean({
-        default: true,
-        description: "Controls whether strategic corridor protection is applied.",
-      })
-    ),
-  },
-  { additionalProperties: true, default: {} }
 );
 
 /**
@@ -2354,8 +2273,6 @@ export const MapGenConfigSchema = Type.Object(
     stageConfig: Type.Optional(StageConfigSchema),
     /** @internal Custom stage manifest for advanced pipelines (engine plumbing). */
     stageManifest: Type.Optional(StageManifestSchema),
-    /** Feature toggles controlling story events and generation features. */
-    toggles: Type.Optional(TogglesSchema),
     /** Landmass geometry: water percent, tectonic bias, and post-processing. */
     landmass: Type.Optional(LandmassConfigSchema),
     /** Foundation stage config: plates, dynamics, and internal policy/diagnostics. */
@@ -2394,7 +2311,6 @@ export const MapGenConfigSchema = Type.Object(
 export type StageConfig = Static<typeof StageConfigSchema>;
 export type StageDescriptor = Static<typeof StageDescriptorSchema>;
 export type StageManifest = Static<typeof StageManifestSchema>;
-export type Toggles = Static<typeof TogglesSchema>;
 export type LandmassTectonicsConfig = Static<typeof LandmassTectonicsConfigSchema>;
 export type LandmassGeometryPost = Static<typeof LandmassGeometryPostSchema>;
 export type LandmassGeometry = Static<typeof LandmassGeometrySchema>;

--- a/packages/mapgen-core/src/domain/ecology/biomes/index.ts
+++ b/packages/mapgen-core/src/domain/ecology/biomes/index.ts
@@ -176,7 +176,7 @@ export function designateEnhancedBiomes(
         riverBiasStrength: RIVER_BIAS_STRENGTH,
       });
 
-      if (config.toggles?.STORY_ENABLE_RIFTS && StoryTags.riftShoulder.size > 0) {
+      if (StoryTags.riftShoulder.size > 0) {
         applyRiftShoulderBias(adapter, globals, x, y, lat, rainfall, StoryTags, {
           grasslandLatMax: RS_GRASS_LAT_MAX,
           grasslandRainMin: RS_GRASS_RAIN_MIN,

--- a/packages/mapgen-core/src/domain/ecology/features/index.ts
+++ b/packages/mapgen-core/src/domain/ecology/features/index.ts
@@ -59,7 +59,6 @@ export function addDiverseFeatures(
   adapter.addFeatures(iWidth, iHeight);
 
   const config = ctx.config;
-  const toggles = config.toggles || {};
   const storyTunables = (config.story || {}) as { features?: FeaturesConfig };
   const featuresCfg = storyTunables.features || {};
   const densityCfg = (config.featuresDensity || {}) as FeaturesDensityConfig;
@@ -90,7 +89,6 @@ export function addDiverseFeatures(
 
   // 2) Paradise reefs near hotspot paradise centers
   if (
-    toggles.STORY_ENABLE_HOTSPOTS &&
     reefIndex !== -1 &&
     StoryTags.hotspotParadise.size > 0 &&
     paradiseReefChance > 0
@@ -155,7 +153,6 @@ export function addDiverseFeatures(
           inBounds,
           getRandom,
           hotspotVolcanic: StoryTags.hotspotVolcanic,
-          togglesEnabled: !!toggles.STORY_ENABLE_HOTSPOTS,
           forestIdx,
           taigaIdx,
           volcanicForestChance,

--- a/packages/mapgen-core/src/domain/ecology/features/volcanic-vegetation.ts
+++ b/packages/mapgen-core/src/domain/ecology/features/volcanic-vegetation.ts
@@ -8,7 +8,6 @@ export function applyVolcanicVegetationAtTile(params: {
   inBounds: (x: number, y: number) => boolean;
   getRandom: (label: string, max: number) => number;
   hotspotVolcanic: Set<string>;
-  togglesEnabled: boolean;
   forestIdx: number;
   taigaIdx: number;
   volcanicForestChance: number;
@@ -28,7 +27,6 @@ export function applyVolcanicVegetationAtTile(params: {
     inBounds,
     getRandom,
     hotspotVolcanic,
-    togglesEnabled,
     forestIdx,
     taigaIdx,
     volcanicForestChance,
@@ -42,7 +40,7 @@ export function applyVolcanicVegetationAtTile(params: {
     tundraBiome,
   } = params;
 
-  if (!togglesEnabled || hotspotVolcanic.size === 0) return false;
+  if (hotspotVolcanic.size === 0) return false;
 
   let nearVolcanic = false;
   for (let vdy = -1; vdy <= 1 && !nearVolcanic; vdy++) {
@@ -74,4 +72,3 @@ export function applyVolcanicVegetationAtTile(params: {
 
   return false;
 }
-

--- a/packages/mapgen-core/src/domain/hydrology/climate/refine/orogeny-belts.ts
+++ b/packages/mapgen-core/src/domain/hydrology/climate/refine/orogeny-belts.ts
@@ -14,7 +14,7 @@ export function applyOrogenyBeltsRefinement(
   const storyTunables = (ctx.config.story || {}) as Record<string, unknown>;
   const orogenyTunables = (storyTunables.orogeny || {}) as Record<string, number>;
 
-  if (ctx.config.toggles?.STORY_ENABLE_OROGENY && orogenyCache !== null) {
+  if (orogenyCache !== null) {
     const windwardSet = orogenyCache.windward;
     const leeSet = orogenyCache.lee;
     const hasWindward = (windwardSet?.size ?? 0) > 0;
@@ -44,4 +44,3 @@ export function applyOrogenyBeltsRefinement(
     }
   }
 }
-

--- a/packages/mapgen-core/src/pipeline/hydrology/index.ts
+++ b/packages/mapgen-core/src/pipeline/hydrology/index.ts
@@ -49,7 +49,7 @@ export function registerHydrologyLayer(
       ...runtime.getStageDescriptor("rivers"),
       shouldRun: () => stageFlags.rivers,
       logPrefix: runtime.logPrefix,
-      shouldRunPaleo: (context) => stageFlags.storySwatches && context.config.toggles?.STORY_ENABLE_PALEO === true,
+      shouldRunPaleo: (context) => stageFlags.storySwatches && context.config.climate?.story?.paleo != null,
     })
   );
 

--- a/packages/mapgen-core/test/bootstrap/resolved.test.ts
+++ b/packages/mapgen-core/test/bootstrap/resolved.test.ts
@@ -271,7 +271,7 @@ describe("bootstrap/resolved", () => {
       validateOverrides(
         {
           landmass: { baseWaterPercent: 40 },
-          toggles: { STORY_ENABLE_HOTSPOTS: false },
+          story: { hotspot: { maxTrails: 1 } },
         },
         manifest
       );

--- a/packages/mapgen-core/test/config/loader.test.ts
+++ b/packages/mapgen-core/test/config/loader.test.ts
@@ -43,7 +43,7 @@ describe("config/loader", () => {
   it("getDefaultConfig returns a validated defaulted config", () => {
     const cfg = getDefaultConfig();
     expect(cfg.foundation?.plates?.count).toBe(8);
-    expect(cfg.toggles?.STORY_ENABLE_HOTSPOTS).toBe(true);
+    expect(cfg.stageManifest).toBeDefined();
   });
 });
 
@@ -77,7 +77,7 @@ describe("config/loader public schema guard", () => {
     expect(properties.landmass).toBeDefined();
     expect(properties.climate).toBeDefined();
     expect(properties.mountains).toBeDefined();
-    expect(properties.toggles).toBeDefined();
+    expect(properties.toggles).toBeUndefined();
 
     // Verify landmass has nested properties intact
     const landmass = properties.landmass as Record<string, unknown>;

--- a/packages/mapgen-core/test/pipeline/artifacts.test.ts
+++ b/packages/mapgen-core/test/pipeline/artifacts.test.ts
@@ -34,7 +34,7 @@ describe("pipeline artifacts", () => {
     const ctx = createExtendedMapContext(
       { width: 4, height: 3 },
       adapter,
-      { toggles: {} } as unknown as MapConfig
+      {} as unknown as MapConfig
     );
 
     expect(
@@ -57,7 +57,7 @@ describe("pipeline artifacts", () => {
     const ctx = createExtendedMapContext(
       { width: 4, height: 3 },
       adapter,
-      { toggles: {} } as unknown as MapConfig
+      {} as unknown as MapConfig
     );
 
     const registry = new StepRegistry<typeof ctx>();
@@ -84,7 +84,7 @@ describe("pipeline artifacts", () => {
     const ctx = createExtendedMapContext(
       { width: 4, height: 3 },
       adapter,
-      { toggles: {} } as unknown as MapConfig
+      {} as unknown as MapConfig
     );
 
     const registry = new StepRegistry<typeof ctx>();


### PR DESCRIPTION
### TL;DR

Remove legacy feature toggles system in favor of direct stage configuration

### What changed?

- Removed the `toggles` configuration object and all `STORY_ENABLE_*` flags from the MapGen configuration
- Eliminated the `buildContextConfig` method in `MapOrchestrator` that was used to translate stage flags to toggles
- Updated code in various domain modules to check for feature presence directly rather than through toggle flags
- Removed toggle references from presets and map configurations
- Modified the paleo hydrology check to look for the presence of climate story configuration instead of a toggle

### How to test?

1. Generate maps with the swooper-desert-mountains and swooper-earthlike presets
2. Verify that all expected terrain features (hotspots, rifts, orogeny, swatches, paleo features, and corridors) still appear correctly
3. Check that map generation completes successfully without any toggle-related errors

### Why make this change?

This change simplifies the configuration system by removing an unnecessary layer of indirection. Instead of using boolean toggles to enable/disable features, the code now directly checks for the presence of relevant configuration or generated data. This makes the system more maintainable and reduces complexity by eliminating redundant configuration options that were essentially duplicating the stage configuration system.