### PR TITLE
refactor(mapgen-core): make story state context-owned

### DIFF
--- a/docs/projects/engine-refactor-v1/issues/LOCAL-TBD-story-drift-legacy-removal.md
+++ b/docs/projects/engine-refactor-v1/issues/LOCAL-TBD-story-drift-legacy-removal.md
@@ -22,23 +22,23 @@ Remove the legacy orchestrator path and legacy `STORY_ENABLE_*` toggle surface f
 
 ## Deliverables
 
-- [ ] **Group 1**: Migrate all in-repo consumers (mods, tests) to `useTaskGraph: true`
-- [ ] **Group 2**: Remove legacy orchestration fork—`generateMap()` becomes TaskGraph-only
-- [ ] **Group 3**: Remove `config.toggles.STORY_ENABLE_*` surface; migrate downstream to canonical signals
-- [ ] **Group 4**: Remove legacy shims (`createLegacy*Step`, `LegacyPlacementStep`, legacy bootstrap shapes) and update docs
-- [ ] **Group 5**: Move story state (tags, caches, overlays) to context-owned artifacts (requires design decision)
+- [x] **Group 1**: Migrate all in-repo consumers (mods, tests) to `useTaskGraph: true`
+- [x] **Group 2**: Remove legacy orchestration fork—`generateMap()` becomes TaskGraph-only
+- [x] **Group 3**: Remove `config.toggles.STORY_ENABLE_*` surface; migrate downstream to canonical signals
+- [x] **Group 4**: Remove legacy shims (`createLegacy*Step`, `LegacyPlacementStep`, legacy bootstrap shapes) and update docs
+- [x] **Group 5**: Move story state (tags, caches, overlays) to context-owned artifacts (requires design decision)
 
 ## Acceptance Criteria
 
-- [ ] `generateMap()` has no branching logic—TaskGraph is the only path
-- [ ] `OrchestratorConfig.useTaskGraph` option does not exist
-- [ ] No `STORY_ENABLE_*` fields in config schema or presets
-- [ ] All downstream toggle consumers use canonical signals (tags, config presence, stage flags)
-- [ ] No `createLegacy*Step` exports or `LegacyPlacementStep.ts`
-- [ ] No legacy bootstrap input shapes
-- [ ] (Group 5) No module-level story singletons required for correctness
-- [ ] `pnpm -C packages/mapgen-core check` passes
-- [ ] `pnpm test:mapgen` passes
+- [x] `generateMap()` has no branching logic—TaskGraph is the only path
+- [x] `OrchestratorConfig.useTaskGraph` option does not exist
+- [x] No `STORY_ENABLE_*` fields in config schema or presets
+- [x] All downstream toggle consumers use canonical signals (tags, config presence, stage flags)
+- [x] No `createLegacy*Step` exports or `LegacyPlacementStep.ts`
+- [x] No legacy bootstrap input shapes
+- [x] (Group 5) No module-level story singletons required for correctness
+- [x] `pnpm -C packages/mapgen-core check` passes
+- [x] `pnpm test:mapgen` passes
 - [ ] Mods load without error
 
 ## Testing / Verification

--- a/packages/mapgen-core/src/MapOrchestrator.ts
+++ b/packages/mapgen-core/src/MapOrchestrator.ts
@@ -381,11 +381,8 @@ export class MapOrchestrator {
 
     // Layer configuration
     const landmassCfg = config.landmass ?? {};
-    const mountainsCfg = (config.mountains ?? {}) as MountainsConfig;
-    const volcanosCfg = (config.volcanoes ?? {}) as VolcanoesConfig;
-
-    const mountainOptions = this.buildMountainOptions(mountainsCfg);
-    const volcanoOptions = this.buildVolcanoOptions(volcanosCfg);
+    const mountainOptions = (config.mountains ?? {}) as MountainsConfig;
+    const volcanoOptions = (config.volcanoes ?? {}) as VolcanoesConfig;
 
     // Create context with adapter
     let ctx: ExtendedMapContext | null = null;
@@ -402,11 +399,11 @@ export class MapOrchestrator {
       return { success: false, stageResults: this.stageResults, startPositions };
     }
 
-    // Reset story state once per generation to prevent cross-run leakage via globals.
-    resetStoryTags();
-    resetStoryOverlays();
-    resetOrogenyCache();
-    resetCorridorStyleCache();
+    // Reset story state once per generation to prevent cross-run leakage.
+    resetStoryTags(ctx);
+    resetStoryOverlays(ctx);
+    resetOrogenyCache(ctx);
+    resetCorridorStyleCache(ctx);
 
     // Set up start sectors (placement consumes these)
     const iNumPlayers1 = mapInfo.PlayersLandmass1 ?? 4;
@@ -509,7 +506,7 @@ export class MapOrchestrator {
       stageFlags.storySwatches ||
       stageFlags.storyCorridorsPost;
     if (DEV.ENABLED && storyStagesEnabled) {
-      const tags = getStoryTags();
+      const tags = getStoryTags(ctx);
       const tagTotal =
         tags.hotspot.size +
         tags.hotspotParadise.size +
@@ -735,48 +732,6 @@ export class MapOrchestrator {
     };
   }
 
-  private buildMountainOptions(config: MountainsConfig): MountainsConfig {
-    return {
-      tectonicIntensity: config.tectonicIntensity ?? 1.0,
-      // Defaults are aligned with the crust-first collision-only formulation in
-      // layers/mountains.ts. If callers supply overrides, those values will be
-      // used instead.
-      mountainThreshold: config.mountainThreshold ?? 0.58,
-      hillThreshold: config.hillThreshold ?? 0.32,
-      upliftWeight: config.upliftWeight ?? 0.35,
-      fractalWeight: config.fractalWeight ?? 0.15,
-      riftDepth: config.riftDepth ?? 0.2,
-      boundaryWeight: config.boundaryWeight ?? 1.0,
-      boundaryExponent: config.boundaryExponent ?? 1.6,
-      interiorPenaltyWeight: config.interiorPenaltyWeight ?? 0.0,
-      convergenceBonus: config.convergenceBonus ?? 1.0,
-      transformPenalty: config.transformPenalty ?? 0.6,
-      riftPenalty: config.riftPenalty ?? 1.0,
-      hillBoundaryWeight: config.hillBoundaryWeight ?? 0.35,
-      hillRiftBonus: config.hillRiftBonus ?? 0.25,
-      hillConvergentFoothill: config.hillConvergentFoothill ?? 0.35,
-      hillInteriorFalloff: config.hillInteriorFalloff ?? 0.1,
-      hillUpliftWeight: config.hillUpliftWeight ?? 0.2,
-    };
-  }
-
-  private buildVolcanoOptions(config: VolcanoesConfig): VolcanoesConfig {
-    return {
-      enabled: config.enabled ?? true,
-      baseDensity: config.baseDensity ?? 1 / 170,
-      minSpacing: config.minSpacing ?? 3,
-      boundaryThreshold: config.boundaryThreshold ?? 0.35,
-      boundaryWeight: config.boundaryWeight ?? 1.2,
-      convergentMultiplier: config.convergentMultiplier ?? 2.4,
-      transformMultiplier: config.transformMultiplier ?? 1.1,
-      divergentMultiplier: config.divergentMultiplier ?? 0.35,
-      hotspotWeight: config.hotspotWeight ?? 0.12,
-      shieldPenalty: config.shieldPenalty ?? 0.6,
-      randomJitter: config.randomJitter ?? 0.08,
-      minVolcanoes: config.minVolcanoes ?? 5,
-      maxVolcanoes: config.maxVolcanoes ?? 40,
-    };
-  }
 }
 
 // ============================================================================

--- a/packages/mapgen-core/src/config/schema.ts
+++ b/packages/mapgen-core/src/config/schema.ts
@@ -1916,6 +1916,8 @@ export const ClimateStorySchema = Type.Object(
   {
     /** Story-driven rainfall modifiers keyed off narrative tags. */
     rainfall: Type.Optional(ClimateStoryRainfallSchema),
+    /** Optional paleo hydrology artifacts configuration (deltas, oxbows, fossil channels). */
+    paleo: Type.Optional(UnknownRecord),
   },
   { additionalProperties: true, default: {} }
 );

--- a/packages/mapgen-core/src/domain/ecology/biomes/index.ts
+++ b/packages/mapgen-core/src/domain/ecology/biomes/index.ts
@@ -64,7 +64,7 @@ export function designateEnhancedBiomes(
   const biomesCfg = (config.biomes || {}) as BiomeConfig;
   const corridorPolicy = (config.corridors || {}) as CorridorPolicy;
 
-  const StoryTags = getStoryTags();
+  const StoryTags = getStoryTags(ctx);
 
   // Apply small, climate-aware preferences
   const _tundra = biomesCfg.tundra || {};

--- a/packages/mapgen-core/src/domain/ecology/features/index.ts
+++ b/packages/mapgen-core/src/domain/ecology/features/index.ts
@@ -63,7 +63,7 @@ export function addDiverseFeatures(
   const featuresCfg = storyTunables.features || {};
   const densityCfg = (config.featuresDensity || {}) as FeaturesDensityConfig;
 
-  const StoryTags = getStoryTags();
+  const StoryTags = getStoryTags(ctx);
 
   const climateField = getPublishedClimateField(ctx);
   if (!climateField?.rainfall) {
@@ -109,7 +109,7 @@ export function addDiverseFeatures(
     const shelfMult = densityCfg?.shelfReefMultiplier ?? 0.6;
     const shelfReefChance = Math.max(
       1,
-      Math.min(100, Math.floor((paradiseReefChance || 18) * shelfMult))
+      Math.min(100, Math.floor(paradiseReefChance * shelfMult))
     );
     applyShelfReefs({
       adapter,

--- a/packages/mapgen-core/src/domain/hydrology/climate/refine/index.ts
+++ b/packages/mapgen-core/src/domain/hydrology/climate/refine/index.ts
@@ -36,7 +36,7 @@ export function refineClimateEarthlike(
   const storyRain = (storyMoisture?.rainfall || {}) as Record<string, number>;
   const orogenyCache = options?.orogenyCache || null;
 
-  const StoryTags: StoryTagsInstance = getStoryTags();
+  const StoryTags: StoryTagsInstance = getStoryTags(ctx);
 
   // Local bounds check with captured width/height
   const inBounds = (x: number, y: number): boolean => boundsCheck(x, y, width, height);

--- a/packages/mapgen-core/src/domain/morphology/coastlines/rugged-coasts.ts
+++ b/packages/mapgen-core/src/domain/morphology/coastlines/rugged-coasts.ts
@@ -59,7 +59,7 @@ export function addRuggedCoasts(iWidth: number, iHeight: number, ctx?: ExtendedM
 
   const { protection: SEA_PROTECTION, softChanceMultiplier: SOFT_MULT } = resolveSeaCorridorPolicy(ctx);
 
-  const StoryTags = getStoryTags();
+  const StoryTags = getStoryTags(ctx);
 
   const applyTerrain = (x: number, y: number, terrain: number, isLand: boolean): void => {
     if (ctx) {

--- a/packages/mapgen-core/src/domain/morphology/islands/placement.ts
+++ b/packages/mapgen-core/src/domain/morphology/islands/placement.ts
@@ -29,7 +29,7 @@ export function addIslandChains(iWidth: number, iHeight: number, ctx?: ExtendedM
     Math.min(100, Math.round((storyTunables.hotspot?.volcanicPeakChance ?? 0.33) * 100) + 10)
   );
 
-  const StoryTags = getStoryTags();
+  const StoryTags = getStoryTags(ctx);
 
   const applyTerrain = (tileX: number, tileY: number, terrain: number, isLand: boolean): void => {
     if (ctx) {

--- a/packages/mapgen-core/src/domain/narrative/corridors/backfill.ts
+++ b/packages/mapgen-core/src/domain/narrative/corridors/backfill.ts
@@ -7,7 +7,7 @@ import { getDims, isAdjacentToShallowWater } from "./runtime.js";
 
 export function backfillCorridorKinds(ctx: ExtendedMapContext, corridorsCfg: Record<string, unknown>): void {
   const { width, height } = getDims(ctx);
-  const tags = getStoryTags();
+  const tags = getStoryTags(ctx);
 
   for (const key of tags.corridorSeaLane) {
     const kind = (tags.corridorKind.get(key) as CorridorKind) || "sea";
@@ -16,24 +16,24 @@ export function backfillCorridorKinds(ctx: ExtendedMapContext, corridorsCfg: Rec
       const [sx, sy] = key.split(",").map(Number);
       style = isAdjacentToShallowWater(ctx, sx, sy, width, height) ? "coastal" : "ocean";
     }
-    assignCorridorMetadata(corridorsCfg, key, kind, style);
+    assignCorridorMetadata(ctx, corridorsCfg, key, kind, style);
   }
 
   for (const key of tags.corridorIslandHop) {
     const kind = (tags.corridorKind.get(key) as CorridorKind) || "islandHop";
     const style = tags.corridorStyle.get(key) || "archipelago";
-    assignCorridorMetadata(corridorsCfg, key, kind, style);
+    assignCorridorMetadata(ctx, corridorsCfg, key, kind, style);
   }
 
   for (const key of tags.corridorLandOpen) {
     const kind = (tags.corridorKind.get(key) as CorridorKind) || "land";
     const style = tags.corridorStyle.get(key) || "plainsBelt";
-    assignCorridorMetadata(corridorsCfg, key, kind, style);
+    assignCorridorMetadata(ctx, corridorsCfg, key, kind, style);
   }
 
   for (const key of tags.corridorRiverChain) {
     const kind = (tags.corridorKind.get(key) as CorridorKind) || "river";
     const style = tags.corridorStyle.get(key) || "riverChain";
-    assignCorridorMetadata(corridorsCfg, key, kind, style);
+    assignCorridorMetadata(ctx, corridorsCfg, key, kind, style);
   }
 }

--- a/packages/mapgen-core/src/domain/narrative/corridors/index.ts
+++ b/packages/mapgen-core/src/domain/narrative/corridors/index.ts
@@ -28,7 +28,7 @@ export { resetCorridorStyleCache } from "./style-cache.js";
 export function storyTagStrategicCorridors(ctx: ExtendedMapContext, stage: CorridorStage): StoryOverlaySnapshot {
   const corridorsCfg = (ctx.config.corridors || {}) as Record<string, unknown>;
 
-  resetCorridorStyleCache();
+  resetCorridorStyleCache(ctx);
 
   if (stage === "preIslands") {
     tagSeaLanes(ctx, corridorsCfg);
@@ -40,7 +40,7 @@ export function storyTagStrategicCorridors(ctx: ExtendedMapContext, stage: Corri
     backfillCorridorKinds(ctx, corridorsCfg);
   }
 
-  const tags = getStoryTags();
+  const tags = getStoryTags(ctx);
   const seaLane = Array.from(tags.corridorSeaLane);
   const islandHop = Array.from(tags.corridorIslandHop);
   const landOpen = Array.from(tags.corridorLandOpen);

--- a/packages/mapgen-core/src/domain/narrative/corridors/island-hop.ts
+++ b/packages/mapgen-core/src/domain/narrative/corridors/island-hop.ts
@@ -13,7 +13,7 @@ export function tagIslandHopFromHotspots(ctx: ExtendedMapContext, corridorsCfg: 
   if (maxArcs === 0) return;
 
   const { width, height } = getDims(ctx);
-  const tags = getStoryTags();
+  const tags = getStoryTags(ctx);
   const keys = Array.from(tags.hotspot);
   if (!keys.length) return;
 
@@ -38,7 +38,7 @@ export function tagIslandHopFromHotspots(ctx: ExtendedMapContext, corridorsCfg: 
         if (!ctx.adapter.isWater(nx, ny)) continue;
         const kk = storyKey(nx, ny);
         tags.corridorIslandHop.add(kk);
-        assignCorridorMetadata(corridorsCfg, kk, "islandHop", "archipelago");
+        assignCorridorMetadata(ctx, corridorsCfg, kk, "islandHop", "archipelago");
       }
     }
   }

--- a/packages/mapgen-core/src/domain/narrative/corridors/land-corridors.ts
+++ b/packages/mapgen-core/src/domain/narrative/corridors/land-corridors.ts
@@ -10,7 +10,7 @@ export function tagLandCorridorsFromRifts(ctx: ExtendedMapContext, corridorsCfg:
   if (!cfg.useRiftShoulders) return;
 
   const { width, height } = getDims(ctx);
-  const tags = getStoryTags();
+  const tags = getStoryTags(ctx);
 
   const maxCorridors = Math.max(0, Number((cfg.maxCorridors as number) ?? 2) | 0);
   const minRun = Math.max(12, Number((cfg.minRunLength as number) ?? 24) | 0);
@@ -114,7 +114,7 @@ export function tagLandCorridorsFromRifts(ctx: ExtendedMapContext, corridorsCfg:
         if (ctx.adapter.isWater(cx, y)) continue;
         const kk = storyKey(cx, y);
         tags.corridorLandOpen.add(kk);
-        assignCorridorMetadata(corridorsCfg, kk, "land", style);
+        assignCorridorMetadata(ctx, corridorsCfg, kk, "land", style);
       }
 
       usedRows.push(y);

--- a/packages/mapgen-core/src/domain/narrative/corridors/river-chains.ts
+++ b/packages/mapgen-core/src/domain/narrative/corridors/river-chains.ts
@@ -18,7 +18,7 @@ export function tagRiverChainsPostRivers(ctx: ExtendedMapContext, corridorsCfg: 
 
   if (maxChains === 0) return;
 
-  const tags = getStoryTags();
+  const tags = getStoryTags(ctx);
   let chains = 0;
   let tries = 0;
 
@@ -78,7 +78,7 @@ export function tagRiverChainsPostRivers(ctx: ExtendedMapContext, corridorsCfg: 
     if (pathKeys.length >= minTiles && endOK) {
       for (const kk of pathKeys) {
         tags.corridorRiverChain.add(kk);
-        assignCorridorMetadata(corridorsCfg, kk, "river", "riverChain");
+        assignCorridorMetadata(ctx, corridorsCfg, kk, "river", "riverChain");
       }
       chains++;
     }

--- a/packages/mapgen-core/src/domain/narrative/corridors/sea-lanes.ts
+++ b/packages/mapgen-core/src/domain/narrative/corridors/sea-lanes.ts
@@ -310,7 +310,7 @@ export function tagSeaLanes(ctx: ExtendedMapContext, corridorsCfg: Record<string
   };
 
   let lanes = 0;
-  const tags = getStoryTags();
+  const tags = getStoryTags(ctx);
   for (const c of candidates) {
     if (lanes >= maxLanes) break;
     if (!spaced(c.orient, c.index)) continue;
@@ -323,7 +323,7 @@ export function tagSeaLanes(ctx: ExtendedMapContext, corridorsCfg: Record<string
         const kk = storyKey(x, y);
         tags.corridorSeaLane.add(kk);
         const style = isAdjacentToLand(ctx, x, y, 2, width, height) ? "coastal" : "ocean";
-        assignCorridorMetadata(corridorsCfg, kk, "sea", style);
+        assignCorridorMetadata(ctx, corridorsCfg, kk, "sea", style);
       }
     } else if (c.orient === "row") {
       const y = c.index;
@@ -332,7 +332,7 @@ export function tagSeaLanes(ctx: ExtendedMapContext, corridorsCfg: Record<string
         const kk = storyKey(x, y);
         tags.corridorSeaLane.add(kk);
         const style = isAdjacentToLand(ctx, x, y, 2, width, height) ? "coastal" : "ocean";
-        assignCorridorMetadata(corridorsCfg, kk, "sea", style);
+        assignCorridorMetadata(ctx, corridorsCfg, kk, "sea", style);
       }
     } else if (c.orient === "diagNE") {
       const k = c.index;
@@ -343,7 +343,7 @@ export function tagSeaLanes(ctx: ExtendedMapContext, corridorsCfg: Record<string
         const kk = storyKey(x, y);
         tags.corridorSeaLane.add(kk);
         const style = isAdjacentToLand(ctx, x, y, 2, width, height) ? "coastal" : "ocean";
-        assignCorridorMetadata(corridorsCfg, kk, "sea", style);
+        assignCorridorMetadata(ctx, corridorsCfg, kk, "sea", style);
       }
     } else if (c.orient === "diagNW") {
       const d = c.index;
@@ -354,7 +354,7 @@ export function tagSeaLanes(ctx: ExtendedMapContext, corridorsCfg: Record<string
         const kk = storyKey(x, y);
         tags.corridorSeaLane.add(kk);
         const style = isAdjacentToLand(ctx, x, y, 2, width, height) ? "coastal" : "ocean";
-        assignCorridorMetadata(corridorsCfg, kk, "sea", style);
+        assignCorridorMetadata(ctx, corridorsCfg, kk, "sea", style);
       }
     }
 

--- a/packages/mapgen-core/src/domain/narrative/orogeny/belts.ts
+++ b/packages/mapgen-core/src/domain/narrative/orogeny/belts.ts
@@ -30,7 +30,7 @@ export interface OrogenySummary {
  * Always publishes a `storyOverlays` snapshot (even if empty) for Task Graph contracts.
  */
 export function storyTagOrogenyBelts(ctx: ExtendedMapContext | null = null): StoryOverlaySnapshot {
-  const cache = getOrogenyCache();
+  const cache = getOrogenyCache(ctx);
   cache.belts.clear();
   cache.windward.clear();
   cache.lee.clear();

--- a/packages/mapgen-core/src/domain/narrative/orogeny/cache.ts
+++ b/packages/mapgen-core/src/domain/narrative/orogeny/cache.ts
@@ -1,28 +1,33 @@
+import type { ExtendedMapContext } from "../../../core/types.js";
+
 export interface OrogenyCacheInstance {
   belts: Set<string>;
   windward: Set<string>;
   lee: Set<string>;
 }
 
-
-let _cache: OrogenyCacheInstance | null = null;
+const OROGENY_CACHE_ARTIFACT_KEY = "story:orogenyCache";
 
 function createCache(): OrogenyCacheInstance {
   return { belts: new Set(), windward: new Set(), lee: new Set() };
 }
 
-export function getOrogenyCache(): OrogenyCacheInstance {
-  if (_cache) return _cache;
-  _cache = createCache();
-  return _cache;
+export function getOrogenyCache(ctx: ExtendedMapContext | null | undefined): OrogenyCacheInstance {
+  if (!ctx) return createCache();
+  const existing = ctx.artifacts?.get(OROGENY_CACHE_ARTIFACT_KEY) as OrogenyCacheInstance | undefined;
+  if (existing) return existing;
+  const created = createCache();
+  ctx.artifacts?.set(OROGENY_CACHE_ARTIFACT_KEY, created);
+  return created;
 }
 
-export function resetOrogenyCache(): void {
-  _cache = null;
+export function resetOrogenyCache(ctx: ExtendedMapContext | null | undefined): void {
+  if (!ctx) return;
+  ctx.artifacts?.set(OROGENY_CACHE_ARTIFACT_KEY, createCache());
 }
 
-export function clearOrogenyCache(): void {
-  const cache = getOrogenyCache();
+export function clearOrogenyCache(ctx: ExtendedMapContext | null | undefined): void {
+  const cache = getOrogenyCache(ctx);
   cache.belts.clear();
   cache.windward.clear();
   cache.lee.clear();

--- a/packages/mapgen-core/src/domain/narrative/overlays/index.ts
+++ b/packages/mapgen-core/src/domain/narrative/overlays/index.ts
@@ -1,5 +1,5 @@
 export { STORY_OVERLAY_KEYS, type StoryOverlayKey } from "./keys.js";
-export { resetStoryOverlays, getStoryOverlayRegistry, publishStoryOverlay, finalizeStoryOverlay, getStoryOverlay } from "./registry.js";
+export { resetStoryOverlays, publishStoryOverlay, finalizeStoryOverlay, getStoryOverlay } from "./registry.js";
 
 export { hydrateMarginsStoryTags } from "./hydrate-margins.js";
 export type { MarginStoryTags, HydrateMarginsOptions } from "./hydrate-margins.js";
@@ -13,7 +13,6 @@ export type { CorridorStoryTags, HydrateCorridorsOptions } from "./hydrate-corri
 import { STORY_OVERLAY_KEYS } from "./keys.js";
 import {
   resetStoryOverlays,
-  getStoryOverlayRegistry,
   publishStoryOverlay,
   finalizeStoryOverlay,
   getStoryOverlay,
@@ -25,7 +24,6 @@ import { hydrateCorridorsStoryTags } from "./hydrate-corridors.js";
 export default {
   STORY_OVERLAY_KEYS,
   resetStoryOverlays,
-  getStoryOverlayRegistry,
   publishStoryOverlay,
   finalizeStoryOverlay,
   getStoryOverlay,
@@ -33,4 +31,3 @@ export default {
   hydrateRiftsStoryTags,
   hydrateCorridorsStoryTags,
 };
-

--- a/packages/mapgen-core/src/domain/narrative/overlays/registry.ts
+++ b/packages/mapgen-core/src/domain/narrative/overlays/registry.ts
@@ -1,24 +1,12 @@
 import type { StoryOverlaySnapshot, StoryOverlayRegistry } from "../../../core/types.js";
 import { normalizeOverlay } from "./normalize.js";
 
-let _registry: StoryOverlayRegistry | null = null;
-
-function getRegistry(): StoryOverlayRegistry {
-  if (_registry) return _registry;
-  _registry = new Map();
-  return _registry;
-}
-
-export function resetStoryOverlays(): void {
-  _registry = null;
-}
-
-export function getStoryOverlayRegistry(): ReadonlyMap<string, StoryOverlaySnapshot> {
-  return getRegistry();
-}
-
 interface OverlayContext {
   overlays?: StoryOverlayRegistry;
+}
+
+export function resetStoryOverlays(ctx: OverlayContext | null | undefined): void {
+  ctx?.overlays?.clear?.();
 }
 
 export function publishStoryOverlay(
@@ -27,7 +15,6 @@ export function publishStoryOverlay(
   overlay: Partial<StoryOverlaySnapshot>
 ): StoryOverlaySnapshot {
   const snapshot = normalizeOverlay(key, overlay);
-  getRegistry().set(key, snapshot);
 
   if (ctx && typeof ctx === "object") {
     if (!ctx.overlays || typeof ctx.overlays.set !== "function") {
@@ -51,6 +38,5 @@ export function getStoryOverlay(
     const local = ctx.overlays.get(key);
     if (local) return local;
   }
-  return getRegistry().get(key) || null;
+  return null;
 }
-

--- a/packages/mapgen-core/src/domain/narrative/tagging/hotspots.ts
+++ b/packages/mapgen-core/src/domain/narrative/tagging/hotspots.ts
@@ -34,7 +34,7 @@ export function storyTagHotspotTrails(
     Math.round(baseSteps * (0.9 + 0.4 * sqrtHot))
   );
 
-  const StoryTags = getStoryTags();
+  const StoryTags = getStoryTags(ctx);
 
   function farFromExisting(x: number, y: number): boolean {
     for (const key of StoryTags.hotspot) {

--- a/packages/mapgen-core/src/domain/narrative/tagging/margins.ts
+++ b/packages/mapgen-core/src/domain/narrative/tagging/margins.ts
@@ -125,7 +125,7 @@ export function storyTagContinentalMargins(
     : finalizeStoryOverlay(STORY_OVERLAY_KEYS.MARGINS, overlay);
 
   if (options.hydrateStoryTags !== false) {
-    hydrateMarginsStoryTags(snapshot, getStoryTags());
+    hydrateMarginsStoryTags(snapshot, getStoryTags(ctx));
   }
 
   return snapshot;

--- a/packages/mapgen-core/src/domain/narrative/tagging/rifts.ts
+++ b/packages/mapgen-core/src/domain/narrative/tagging/rifts.ts
@@ -36,7 +36,7 @@ export function storyTagRiftValleys(
   const stepLen = Math.max(1, baseStepLen | 0);
   const shoulderWidth = (baseShoulderWidth | 0) + (sqrtRift > 1.5 ? 1 : 0);
 
-  const StoryTags = getStoryTags();
+  const StoryTags = getStoryTags(ctx);
 
   const foundation = ctx?.foundation;
   const plates = foundation?.plates;

--- a/packages/mapgen-core/src/domain/narrative/tags/ops.ts
+++ b/packages/mapgen-core/src/domain/narrative/tags/ops.ts
@@ -1,20 +1,25 @@
+import type { ExtendedMapContext } from "../../../core/types.js";
 import type { StoryTagsInstance, TagSet } from "./instance.js";
 import { createStoryTags } from "./instance.js";
 
-let _cache: StoryTagsInstance | null = null;
+const STORY_TAGS_ARTIFACT_KEY = "story:tags";
 
-export function getStoryTags(): StoryTagsInstance {
-  if (_cache) return _cache;
-  _cache = createStoryTags();
-  return _cache;
+export function getStoryTags(ctx: ExtendedMapContext | null | undefined): StoryTagsInstance {
+  if (!ctx) return createStoryTags();
+  const existing = ctx.artifacts?.get(STORY_TAGS_ARTIFACT_KEY) as StoryTagsInstance | undefined;
+  if (existing) return existing;
+  const created = createStoryTags();
+  ctx.artifacts?.set(STORY_TAGS_ARTIFACT_KEY, created);
+  return created;
 }
 
-export function resetStoryTags(): void {
-  _cache = null;
+export function resetStoryTags(ctx: ExtendedMapContext | null | undefined): void {
+  if (!ctx) return;
+  ctx.artifacts?.set(STORY_TAGS_ARTIFACT_KEY, createStoryTags());
 }
 
-export function clearStoryTags(): void {
-  const tags = getStoryTags();
+export function clearStoryTags(ctx: ExtendedMapContext | null | undefined): void {
+  const tags = getStoryTags(ctx);
 
   tags.hotspot.clear();
   tags.hotspotParadise.clear();
@@ -63,4 +68,3 @@ export default {
   removeTag,
   getTagCoordinates,
 };
-

--- a/packages/mapgen-core/src/pipeline/ecology/BiomesStep.ts
+++ b/packages/mapgen-core/src/pipeline/ecology/BiomesStep.ts
@@ -24,7 +24,7 @@ export function createBiomesStep(options: BiomesStepOptions): MapGenStep<Extende
     provides: options.provides,
     shouldRun: options.shouldRun ? () => options.shouldRun?.() === true : undefined,
     run: (context) => {
-      const storyTags = getStoryTags();
+      const storyTags = getStoryTags(context);
       hydrateCorridorsStoryTags(getStoryOverlay(context, STORY_OVERLAY_KEYS.CORRIDORS), storyTags);
       hydrateRiftsStoryTags(getStoryOverlay(context, STORY_OVERLAY_KEYS.RIFTS), storyTags);
 

--- a/packages/mapgen-core/src/pipeline/ecology/FeaturesStep.ts
+++ b/packages/mapgen-core/src/pipeline/ecology/FeaturesStep.ts
@@ -19,7 +19,10 @@ export function createFeaturesStep(options: FeaturesStepOptions): MapGenStep<Ext
     provides: options.provides,
     shouldRun: options.shouldRun ? () => options.shouldRun?.() === true : undefined,
     run: (context) => {
-      hydrateMarginsStoryTags(getStoryOverlay(context, STORY_OVERLAY_KEYS.MARGINS), getStoryTags());
+      hydrateMarginsStoryTags(
+        getStoryOverlay(context, STORY_OVERLAY_KEYS.MARGINS),
+        getStoryTags(context)
+      );
 
       const { width, height } = context.dimensions;
       addDiverseFeatures(width, height, context);

--- a/packages/mapgen-core/src/pipeline/narrative/StorySeedStep.ts
+++ b/packages/mapgen-core/src/pipeline/narrative/StorySeedStep.ts
@@ -1,11 +1,7 @@
 import type { ExtendedMapContext } from "../../core/types.js";
 import { DEV, devWarn } from "../../dev/index.js";
 import { M3_STANDARD_STAGE_PHASE, type MapGenStep } from "../index.js";
-import { resetCorridorStyleCache } from "../../domain/narrative/corridors/index.js";
-import { resetOrogenyCache } from "../../domain/narrative/orogeny/index.js";
-import { resetStoryOverlays } from "../../domain/narrative/overlays/index.js";
 import { storyTagContinentalMargins } from "../../domain/narrative/tagging/index.js";
-import { resetStoryTags } from "../../domain/narrative/tags/index.js";
 
 export interface StorySeedStepRuntime {
   logPrefix: string;
@@ -28,10 +24,6 @@ export function createStorySeedStep(
     provides: options.provides,
     shouldRun: options.shouldRun ? () => options.shouldRun?.() === true : undefined,
     run: (context) => {
-      resetStoryTags();
-      resetStoryOverlays();
-      resetOrogenyCache();
-      resetCorridorStyleCache();
       console.log(`${runtime.logPrefix} Imprinting continental margins (active/passive)...`);
       const margins = storyTagContinentalMargins(context);
 

--- a/packages/mapgen-core/src/pipeline/narrative/StorySwatchesStep.ts
+++ b/packages/mapgen-core/src/pipeline/narrative/StorySwatchesStep.ts
@@ -20,7 +20,7 @@ export function createStorySwatchesStep(
     provides: options.provides,
     shouldRun: options.shouldRun ? () => options.shouldRun?.() === true : undefined,
     run: (context) => {
-      storyTagClimateSwatches(context, { orogenyCache: getOrogenyCache() });
+      storyTagClimateSwatches(context, { orogenyCache: getOrogenyCache(context) });
       publishClimateFieldArtifact(context);
     },
   };

--- a/packages/mapgen-core/src/pipeline/tags.ts
+++ b/packages/mapgen-core/src/pipeline/tags.ts
@@ -1,5 +1,4 @@
 import type { ExtendedMapContext } from "../core/types.js";
-import { getStoryOverlayRegistry } from "../domain/narrative/overlays/index.js";
 import {
   InvalidDependencyTagError,
   UnknownDependencyTagError,
@@ -98,9 +97,7 @@ export function isDependencyTagSatisfied(
       );
     }
     case M3_DEPENDENCY_TAGS.artifact.storyOverlays:
-      return (
-        (context.overlays?.size ?? 0) > 0 || getStoryOverlayRegistry().size > 0
-      );
+      return (context.overlays?.size ?? 0) > 0;
     case M3_DEPENDENCY_TAGS.artifact.riverAdjacency: {
       const value = context.artifacts?.get(tag);
       return value instanceof Uint8Array && value.length === expectedSize;

--- a/packages/mapgen-core/test/story/corridors.test.ts
+++ b/packages/mapgen-core/test/story/corridors.test.ts
@@ -1,22 +1,16 @@
-import { describe, it, expect, beforeEach } from "bun:test";
+import { describe, it, expect } from "bun:test";
 import { createMockAdapter } from "@civ7/adapter";
 import { parseConfig } from "../../src/config/index.js";
 import { createExtendedMapContext } from "../../src/core/types.js";
 import { OCEAN_TERRAIN } from "../../src/core/terrain-constants.js";
-import { resetStoryTags, getStoryTags } from "../../src/domain/narrative/tags/index.js";
+import { getStoryTags } from "../../src/domain/narrative/tags/index.js";
 import {
-  resetStoryOverlays,
   getStoryOverlay,
   STORY_OVERLAY_KEYS,
 } from "../../src/domain/narrative/overlays/index.js";
 import { storyTagStrategicCorridors } from "../../src/domain/narrative/corridors/index.js";
 
 describe("story/corridors", () => {
-  beforeEach(() => {
-    resetStoryTags();
-    resetStoryOverlays();
-  });
-
   it("tags sea lanes and publishes a corridors overlay", () => {
     const width = 20;
     const height = 12;
@@ -27,7 +21,7 @@ describe("story/corridors", () => {
 
     storyTagStrategicCorridors(ctx, "preIslands");
 
-    expect(getStoryTags().corridorSeaLane.size).toBeGreaterThan(0);
+    expect(getStoryTags(ctx).corridorSeaLane.size).toBeGreaterThan(0);
 
     const overlay = getStoryOverlay(ctx, STORY_OVERLAY_KEYS.CORRIDORS);
     expect(overlay).not.toBeNull();

--- a/packages/mapgen-core/test/story/orogeny.test.ts
+++ b/packages/mapgen-core/test/story/orogeny.test.ts
@@ -1,24 +1,17 @@
-import { describe, it, expect, beforeEach } from "bun:test";
+import { describe, it, expect } from "bun:test";
 import { createMockAdapter } from "@civ7/adapter";
 import { parseConfig } from "../../src/config/index.js";
 import { createExtendedMapContext } from "../../src/core/types.js";
 import {
-  resetStoryOverlays,
   getStoryOverlay,
   STORY_OVERLAY_KEYS,
 } from "../../src/domain/narrative/overlays/index.js";
 import {
-  resetOrogenyCache,
   getOrogenyCache,
   storyTagOrogenyBelts,
 } from "../../src/domain/narrative/orogeny/index.js";
 
 describe("story/orogeny", () => {
-  beforeEach(() => {
-    resetStoryOverlays();
-    resetOrogenyCache();
-  });
-
   it("tags legacy orogeny belts from mountain density and publishes an overlay", () => {
     const width = 30;
     const height = 20;
@@ -39,7 +32,7 @@ describe("story/orogeny", () => {
 
     storyTagOrogenyBelts(ctx);
 
-    const cache = getOrogenyCache();
+    const cache = getOrogenyCache(ctx);
     expect(cache.belts.size).toBeGreaterThan(0);
     expect(cache.windward.size).toBeGreaterThan(0);
     expect(cache.lee.size).toBeGreaterThan(0);


### PR DESCRIPTION
### TL;DR

Migrated story state from global singletons to context-owned artifacts, completing the engine refactor task graph migration.

### What changed?

- Moved all story state (tags, overlays, caches) from global singletons to context-owned artifacts
- Refactored story-related functions to accept and use context parameters
- Removed legacy mountain and volcano option building in favor of direct config usage
- Updated all story state reset functions to operate on context objects
- Added climate story paleo configuration to schema
- Marked all deliverables and acceptance criteria as complete in the issue doc

### How to test?

- Run `pnpm -C packages/mapgen-core check` to verify type safety
- Run `pnpm test:mapgen` to ensure all tests pass
- Verify that maps generate correctly with story elements (hotspots, rifts, corridors)
- Check that no story state leaks between map generations

### Why make this change?

This change completes the final deliverable (Group 5) of the engine refactor by eliminating module-level story singletons. Moving story state to context-owned artifacts improves isolation between map generations, prevents cross-run state leakage, and completes the transition to the task graph architecture. This change also simplifies the codebase by removing legacy code paths and standardizing on a single pattern for story state management.