### PR TITLE
fix(swooper-maps): restore baseline rainfall bands

### DIFF
--- a/mods/mod-swooper-maps/src/swooper-desert-mountains.ts
+++ b/mods/mod-swooper-maps/src/swooper-desert-mountains.ts
@@ -164,8 +164,8 @@ function buildConfig(): BootstrapConfig {
       climate: {
         baseline: {
           blend: {
-            baseWeight: 0.8,
-            bandWeight: 0.2,
+            baseWeight: 0,
+            bandWeight: 1,
           },
           bands: {
             // Standard Earth-like distribution

--- a/mods/mod-swooper-maps/src/swooper-earthlike.ts
+++ b/mods/mod-swooper-maps/src/swooper-earthlike.ts
@@ -297,7 +297,7 @@ function buildConfig(): BootstrapConfig {
       },
       biomes: {
         tundra: {
-          latMin: 65,
+          latMin: 73,
           elevMin: 700,
           rainMax: 85,
         },

--- a/mods/mod-swooper-maps/src/swooper-earthlike.ts
+++ b/mods/mod-swooper-maps/src/swooper-earthlike.ts
@@ -39,7 +39,7 @@ function buildConfig(): BootstrapConfig {
       landmass: {
         crustMode: "area",
         // Earth-like ocean dominance (~70% water).
-        baseWaterPercent: 63,
+        baseWaterPercent: 68,
         waterScalar: 1,
         // Crust-first height tuning to preserve water even with broken boundary fields.
         crustEdgeBlend: 0.35,
@@ -70,7 +70,7 @@ function buildConfig(): BootstrapConfig {
           convergent: 1.4,
           transform: 0.4,
           divergent: -0.4,
-          interior: 0.7,
+          interior: 0.4,
           bayWeight: 0.8,
           bayNoiseBonus: 0.5,
           fjordWeight: 0.8,
@@ -297,7 +297,7 @@ function buildConfig(): BootstrapConfig {
       },
       biomes: {
         tundra: {
-          latMin: 73,
+          latMin: 80,
           elevMin: 700,
           rainMax: 85,
         },

--- a/mods/mod-swooper-maps/src/swooper-earthlike.ts
+++ b/mods/mod-swooper-maps/src/swooper-earthlike.ts
@@ -178,8 +178,8 @@ function buildConfig(): BootstrapConfig {
       climate: {
         baseline: {
           blend: {
-            baseWeight: 0.55,
-            bandWeight: 0.25,
+            baseWeight: 0,
+            bandWeight: 1,
           },
           bands: {
             deg0to10: 125,
@@ -297,7 +297,7 @@ function buildConfig(): BootstrapConfig {
       },
       biomes: {
         tundra: {
-          latMin: 85,
+          latMin: 65,
           elevMin: 700,
           rainMax: 85,
         },


### PR DESCRIPTION
# Adjust climate and terrain parameters for swooper maps

- Modify climate blend weights in desert-mountains and earthlike maps to prioritize band-based rainfall distribution
- Increase base water percentage from 63% to 68% in earthlike maps
- Reduce interior terrain weight from 0.7 to 0.4 in earthlike maps
- Expand tundra biome coverage by lowering minimum latitude from 85 to 80 degrees