### PR TITLE
refactor(swooper-maps): move rainfall config from microclimate to story

### DIFF
--- a/mods/mod-swooper-maps/src/swooper-desert-mountains.ts
+++ b/mods/mod-swooper-maps/src/swooper-desert-mountains.ts
@@ -212,20 +212,20 @@ function buildConfig(): BootstrapConfig {
             delta: 10,
           },
         },
+        story: {
+          rainfall: {
+            riftBoost: 10,
+            riftRadius: 2,
+            paradiseDelta: 10,
+            volcanicDelta: 10,
+          },
+        },
       },
       story: {
         hotspot: {
           paradiseBias: 1,
           volcanicBias: 1,
           volcanicPeakChance: 0.3,
-        },
-      },
-      microclimate: {
-        rainfall: {
-          riftBoost: 10,
-          riftRadius: 2,
-          paradiseDelta: 10,
-          volcanicDelta: 10,
         },
         features: {
           paradiseReefChance: 25,


### PR DESCRIPTION
### TL;DR

Moved rainfall configuration from `microclimate` to `story` section in the desert mountains map configuration.

### What changed?

Relocated the rainfall configuration object (containing riftBoost, riftRadius, paradiseDelta, and volcanicDelta parameters) from the `microclimate` section to the `story` section in the swooper-desert-mountains.ts file. Also moved the `features` object to be nested under `story` instead of being a separate section.

### How to test?

1. Load the swooper desert mountains map
2. Verify that rainfall behavior works correctly with the new configuration structure
3. Check that paradise reefs and volcanic forests still generate as expected

### Why make this change?

This change aligns the configuration structure with the expected schema, ensuring that rainfall parameters are properly accessed by the story generation system rather than the microclimate system. This organizational change helps maintain consistency in how map features are generated.