### PR TITLE
docs(engine-refactor): update deferrals with resolved items and status notes

### DIFF
--- a/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
+++ b/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
@@ -400,7 +400,6 @@ import { compileExecutionPlan } from "@mapgen/core/compiler";
 import { noise2d } from "@mapgen/core/lib/noise";
 import { buildTerrainMask } from "@mod/lib/terrain";
 ```
-
 ### 7.2 `RegistryEntry` and `Registry` (single catalog, no clever names)
 
 Key DX goal: step files export a **single registry entry** that contains

--- a/docs/projects/engine-refactor-v1/resources/SPIKE-target-architecture-draft.md
+++ b/docs/projects/engine-refactor-v1/resources/SPIKE-target-architecture-draft.md
@@ -595,6 +595,9 @@ Status: `open`
 Context:
 - `DEF-008` treats `state:engine.*` dependency tags as trusted declarations
   because the adapter cannot yet verify them at runtime.
+- We have since accepted **effects as first-class tags** (`effect:*`) in the
+  canonical tag registry (see §2.8), which creates a plausible replacement
+  surface for “engine-side happened” signals.
 
 Why this is ambiguous:
 - Target docs imply artifacts/fields are canonical, but `state:*` tags act like
@@ -607,6 +610,16 @@ Why this is a problem:
 Simplest option:
 - Replace `state:engine.*` tags with explicit artifacts/fields or verify them
   via adapter queries.
+
+What’s *actually* still undecided (given accepted tag/effect decisions):
+- Whether “engine-side happened” signals should be modeled as:
+  - **(A)** explicit artifacts/fields (preferred when the data can be reified),
+  - **(B)** **effects** (`effect:engine.*`) as asserted step outputs used for
+    ordering/observability (and optionally verified), or
+  - **(C)** a retained `state:engine.*` namespace that is either transitional
+    only or fully verifiable via adapter APIs.
+- Whether any such signals are allowed to participate in **scheduling** (as
+  `requires/provides`) without an adapter-backed verification strategy.
 
 Why we might not simplify yet:
 - Adapter APIs do not yet expose all required invariants.


### PR DESCRIPTION
# docs(engine-refactor): update deferrals and align draft target docs

This PR updates the engine refactor documentation by:

- Moving three resolved deferrals to the "Resolved Deferrals" section:
  - DEF-003: Global StoryOverlays Registry Fallback
  - DEF-007: WorldModel Legacy Bridge
  - DEF-009: Legacy Orchestrator Execution Path

- Adding status updates to several active deferrals:
  - DEF-002: Added status note that StoryTags are context-owned but still directly consumed
  - DEF-004: Added status note about recipe-driven ordering/config decisions
  - DEF-013: Added status note about enablement decisions and implementation work
  - DEF-012: Expanded status details about story state migration progress

- Expanded the engine boundary discussion in the target architecture draft with detailed context, options, and a recommended path forward