### PR TITLE
docs(engine-refactor): update state:engine.* migration strategy to effect:* tags

### DIFF
--- a/docs/projects/engine-refactor-v1/deferrals.md
+++ b/docs/projects/engine-refactor-v1/deferrals.md
@@ -112,12 +112,13 @@ Each deferral follows this structure:
 ## DEF-008: `state:engine.*` Dependency Tags Are Trusted (Not Runtime-Verified)
 
 **Deferred:** 2025-12-14  
-**Trigger:** When the engine adapter can reliably expose/verifiably report the relevant engine-side invariants (or when we stop depending on engine-surface state tags for gating).  
-**Context:** In M3, `PipelineExecutor` enforces `artifact:*` and `field:*` dependencies at runtime, but `state:engine.*` tags represent engine-surface guarantees that are not currently introspectable from the TS runtime. We intentionally treat these tags as trusted declarations to enable wrap-first steps without blocking on new adapter APIs.  
+**Trigger:** When we migrate off `state:engine.*` to `effect:*` tags with runtime verification (or when the adapter exposes the necessary invariant queries to verify the current namespace).  
+**Context:** In M3, `PipelineExecutor` enforces `artifact:*` and `field:*` dependencies at runtime, but `state:engine.*` tags represent engine-surface guarantees that are not currently introspectable from the TS runtime. We intentionally treat these tags as trusted declarations to enable wrap-first steps without blocking on new adapter APIs. The accepted target policy is: `state:engine.*` is transitional-only; engine-surface guarantees should be modeled as `effect:*` tags that participate in scheduling and are runtime-verifiable, and cross-step data dependencies should prefer reified `field:*` / `artifact:*` products.  
 **Scope:**
-- Define a verification strategy for `state:engine.*` dependencies (adapter queries, explicit step-owned checks, or replacing `state:*` tags with canonical artifacts where feasible).
-- Add a small set of runtime checks for the highest-risk `state:engine.*` tags once a strategy exists.
-- Document which `state:engine.*` tags are considered stable contracts vs transitional wiring.  
+- Replace `state:engine.*` dependency tags with `effect:*` tags that are first-class schedulable tags.
+- Add runtime verification for provided `effect:*` tags (postcondition checks, typically via `EngineAdapter`).
+- Reify engine-derived data into `field:*` / `artifact:*` where downstream steps depend on it (avoid opaque engine-state coupling).
+- Delete/ban the `state:engine.*` namespace in the target contract; keep it only as a temporary compatibility surface during migration.  
 **Impact:**
 - A misdeclared or stale `state:engine.*` dependency can bypass executor gating and fail later (or silently degrade output).
 - Contract correctness relies on discipline + review rather than runtime enforcement for this namespace in M3.

--- a/docs/projects/engine-refactor-v1/triage.md
+++ b/docs/projects/engine-refactor-v1/triage.md
@@ -32,11 +32,11 @@ Time-bound temporary compatibility tradeoffs live in `docs/projects/engine-refac
   - **Notes:** Larger pass to fully reconcile “current vs target” details across canonical system docs (e.g., `architecture.md`, `foundation.md`, `hydrology.md`, plus adjacent system pages as needed), removing remaining mismatches once the M3 architecture lands. This is explicitly **not** part of `CIV-40` (which only adds framing + minimal current-state pointers).
   - **Next check:** after Task Graph + step execution is implemented and key products (`FoundationContext`, `ClimateField`, `StoryOverlays`) are stabilized.
 
-- **Runtime verification strategy for `state:engine.*` dependency tags** [Review by: early M4]
+- **Migrate `state:engine.*` → verified `effect:*` + reification** [Review by: early M4]
   - **Context:** `CIV-41` Task Graph MVP; deferral at `docs/projects/engine-refactor-v1/deferrals.md` (DEF-008).
   - **Type:** backlog
-  - **Notes:** Decide how to validate `state:engine.*` tags (adapter queries, step-owned invariants, or eliminating `state:*` in favor of canonical artifacts where feasible). Add runtime checks for the highest-risk tags once a strategy exists.
-  - **Next check:** when engine adapter invariants are available or when the first M3 consumer step depends critically on `state:engine.*` correctness.
+  - **Notes:** Target policy is now clear: `state:engine.*` is transitional-only; engine-surface guarantees are modeled as schedulable `effect:*` tags that are runtime-verifiable (adapter queries / postcondition checks), and cross-step data dependencies should prefer reified `field:*` / `artifact:*` products. Remaining work is implementation: introduce effect verification hooks and migrate the highest-risk `state:engine.*` usages first (e.g., placement prerequisites).
+  - **Next check:** when effect verification hooks exist in the executor/registry, or when we begin the `state:engine.*` namespace removal workstream.
 
 - **Deduplicate `PipelineExecutor.execute()` / `executeAsync()` execution loops** [Review by: early M4]
   - **Context:** `CIV-41` Task Graph MVP review follow-up.


### PR DESCRIPTION
# Update `state:engine.*` to `effect:*` tags with runtime verification policy

### TL;DR

Clarifies that `state:engine.*` tags are transitional only and will be replaced by runtime-verified `effect:*` tags, with a clear migration path and engine boundary policy.

### What changed?

- Updated DEF-008 deferral to specify that `state:engine.*` tags will be replaced with `effect:*` tags that are runtime-verifiable
- Clarified the scope of the deferral to include replacing tags, adding runtime verification, reifying engine data, and eventually removing the `state:engine.*` namespace
- Updated the triage document to reflect the new migration strategy from `state:engine.*` to `effect:*`
- Added a comprehensive "Engine Boundary Policy" section to the architecture document that establishes:
  - Hard rules for engine interaction (adapter-only, fail-fast, effect scheduling)
  - Reification-first best practices for pipeline state
  - Verification requirements for effects
  - Limited escape hatches for transitional code

### How to test?

Review the updated documentation for consistency and clarity. No code changes are included in this PR, so no functional testing is required.

### Why make this change?

This change establishes a clear policy for how the mapgen pipeline should interact with the engine, moving away from opaque engine state dependencies toward verifiable effects and explicit data reification. This improves reliability by ensuring dependencies are properly tracked and verified at runtime, while providing a clear migration path from the current transitional approach to the target architecture.