### PR TITLE
docs(engine-refactor): accept engine boundary policy (3.5)

### DIFF
--- a/docs/projects/engine-refactor-v1/issues/LOCAL-TBD-foundation-stage-parent.md
+++ b/docs/projects/engine-refactor-v1/issues/LOCAL-TBD-foundation-stage-parent.md
@@ -64,7 +64,7 @@ This refactor is broken down into 6 sequential steps (Sub-Issues). Each step mus
 
 ### Step 1: Core Pipeline Infrastructure
 **Goal:** Establish the "Skeleton" (Types & Registry).
-- Define `MapGenStep` interface with `phase`, `requires`, `provides`, `shouldRun`.
+- Define `MapGenStep` interface with `phase`, `requires`, `provides`.
 - Implement `StepRegistry` (simple Map-based plugin system).
 - Update `MapGenContext` to split `fields` (Canvas) vs `artifacts` (Intermediate).
 - Define `CrustData` interface with `type` and `age` arrays.

--- a/docs/projects/engine-refactor-v1/issues/LOCAL-TBD-foundation-step-1-pipeline.md
+++ b/docs/projects/engine-refactor-v1/issues/LOCAL-TBD-foundation-step-1-pipeline.md
@@ -19,15 +19,18 @@ related_to: []
 ## TL;DR
 Establish the "Skeleton" for the new Foundation Pipeline: define the `MapGenStep` interface, implement the `StepRegistry`, and update `MapGenContext` to split `fields` (Canvas) vs `artifacts` (Intermediate data).
 
+Update (2025-12-20):
+- `MapGenStep` no longer includes `shouldRun` (enablement is recipe-only; CIV-53 / decision 3.2).
+
 ## Deliverables
-- `MapGenStep` interface in `packages/mapgen-core/src/core/pipeline.ts` with `phase`, `requires`, `provides`, `shouldRun`.
+- `MapGenStep` interface in `packages/mapgen-core/src/core/pipeline.ts` with `phase`, `requires`, `provides`.
 - `StepRegistry` implementation (simple Map-based plugin system) in the same file.
 - Updated `MapGenContext` in `packages/mapgen-core/src/core/types.ts` with the new `artifacts` container.
 - Type definitions for `RegionMesh`, `CrustData`, `PlateGraph`, and `TectonicData` (can be empty interfaces initially).
 - Unit tests for the Registry (registration, lookup, error handling).
 
 ## Acceptance Criteria
-- [ ] `MapGenStep` interface is defined with `phase`, `requires`, `provides`, and `shouldRun` properties.
+- [ ] `MapGenStep` interface is defined with `phase`, `requires`, and `provides` properties.
 - [ ] `StepRegistry` allows registering and retrieving steps by string ID.
 - [ ] `MapGenContext` includes `artifacts` object with optional `mesh`, `crust`, `plateGraph`, and `tectonics` properties.
 - [ ] `RegionMesh`, `CrustData`, `PlateGraph`, and `TectonicData` interfaces match the Foundation Stage Architecture spec.
@@ -109,7 +112,6 @@ interface MapGenStep {
   phase: string;        // e.g., 'foundation'
   requires: string[];   // Artifact keys this step needs
   provides: string[];   // Artifact keys this step produces
-  shouldRun(ctx: MapGenContext): boolean;
   run(ctx: MapGenContext): void | Promise<void>;
 }
 ```

--- a/docs/projects/engine-refactor-v1/issues/LOCAL-TBD-foundation-step-5-integration.md
+++ b/docs/projects/engine-refactor-v1/issues/LOCAL-TBD-foundation-step-5-integration.md
@@ -68,9 +68,7 @@ class PipelineExecutor {
     const sorted = this.topologicalSort(stepIds);
     for (const id of sorted) {
       const step = this.registry.get(id);
-      if (step.shouldRun(ctx)) {
-        step.run(ctx);
-      }
+      step.run(ctx);
     }
   }
 }

--- a/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
+++ b/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
@@ -34,7 +34,7 @@ This section describes the greenfield target with no legacy constraints.
 - No globals; all state is in `MapGenContext`.
 - Recipe is the single source of truth for step ordering (3.1 accepted) and enablement (3.2 accepted).
 - Artifacts, fields, and effects are explicit, typed, and versioned (3.8 accepted).
-- Engine boundary is adapter-only; engine state is not canonical (pending 3.5).
+- Engine boundary is adapter-only; engine is an I/O surface. Cross-step dependencies prefer reified `field:*` / `artifact:*` products, and engine-surface guarantees are modeled as verified, schedulable `effect:*` tags (`state:engine.*` is transitional only; 3.5 accepted).
 - Offline determinism is required; engine is optional.
 - The core engine is content-agnostic; pipeline content ships as **mods** that provide
   their own registry + recipes (the standard pipeline is just one mod).
@@ -84,7 +84,7 @@ via the recipe and carried in the compiled `ExecutionPlan` nodes.
 - `field:*` tags reference concrete buffers in `context.fields`.
 - `effect:*` tags reference externally meaningful changes/events emitted by steps.
 - Intended end-state: `state:*` tags are transitional only and not part of the
-  target contract (pending decision 3.5).
+  target contract (3.5 accepted).
 
 ### 1.5 Phase ownership (target surfaces)
 
@@ -276,7 +276,7 @@ flowchart LR
   class enablement spine,accepted
   class registry spine,accepted
 
-  class engineBoundary boundary,open
+  class engineBoundary boundary,accepted
   class observability boundary,open
 
   class foundation domain,open
@@ -291,7 +291,7 @@ flowchart LR
 | 3.2 | Enablement model (recipe-only; remove `shouldRun`) | accepted | §2.2 |
 | 3.3 | Foundation surface (discrete artifacts vs `FoundationContext`) | open | §2.3 |
 | 3.4 | Story model (overlays vs tags canonical) | open | §2.4 |
-| 3.5 | Engine boundary (`state:engine.*` transitional vs canonical) | open | §2.5 |
+| 3.5 | Engine boundary (adapter-only; reification-first; verified `effect:*`; `state:engine.*` transitional-only) | accepted | §2.5 |
 | 3.6 | Climate ownership (`ClimateField` vs engine rainfall) | open | §2.6 |
 | 3.7 | Placement inputs (explicit artifact vs engine reads) | open | §2.7 |
 | 3.8 | Artifact registry (names + schema ownership + versioning) | accepted | §2.8 |

--- a/docs/projects/engine-refactor-v1/resources/SPIKE-orchestrator-bloat-assessment.md
+++ b/docs/projects/engine-refactor-v1/resources/SPIKE-orchestrator-bloat-assessment.md
@@ -53,7 +53,7 @@ This is a structural mismatch with target architecture:
 
 - It obscures step contracts (data provenance is not `ctx.artifacts` / `ctx.fields`).
 - It encourages cross-step mutation (e.g., “mutable landmass bounds” for placement).
-- It duplicates enablement logic (stage gating is partially in the recipe and partially in `shouldRun()`).
+- It historically duplicated enablement logic (stage gating split between the derived recipe list and `shouldRun()`); this is now resolved in-repo (CIV-53 / DEF-013).
 
 Key example wiring:
 - `packages/mapgen-core/src/MapOrchestrator.ts:439` (`registerStandardLibrary(registry, config, { ... })`)

--- a/docs/projects/engine-refactor-v1/resources/SPIKE-story-drift-legacy-path-removal.md
+++ b/docs/projects/engine-refactor-v1/resources/SPIKE-story-drift-legacy-path-removal.md
@@ -144,7 +144,7 @@ Note: built artifacts under `mods/mod-swooper-maps/mod/maps/*.js` also contain l
 
 We have a canonical "what stages are enabled" representation (the resolved `stageManifest`), but legacy toggles still exist as an authored config surface and are consumed in domain logic.
 
-- Stage gating is derived from `stageManifest` (`packages/mapgen-core/src/MapOrchestrator.ts`, `resolveStageFlags()`).
+- Stage gating is derived from `stageManifest` and applied when deriving the recipe list (`packages/mapgen-core/src/pipeline/StepRegistry.ts#getStandardRecipe`).
 - `MapOrchestrator` derives and overwrites story-related toggles when constructing `context.config` (`packages/mapgen-core/src/MapOrchestrator.ts`, `buildContextConfig()`).
 - Downstream logic still reads `config.toggles.STORY_ENABLE_*` directly:
   - Features: `packages/mapgen-core/src/domain/ecology/features/index.ts` gates some effects via `STORY_ENABLE_HOTSPOTS` even though it also checks story tag sets.

--- a/docs/projects/engine-refactor-v1/resources/SPIKE-target-architecture-draft.md
+++ b/docs/projects/engine-refactor-v1/resources/SPIKE-target-architecture-draft.md
@@ -110,7 +110,7 @@ flowchart LR
   class enablement spine,accepted
   class registry spine,accepted
 
-  class engineBoundary boundary,open
+  class engineBoundary boundary,accepted
   class observability boundary,open
 
   class foundation domain,open
@@ -588,144 +588,51 @@ Why we might not simplify yet:
 - Legacy consumers still rely on `StoryTags` and global registry access.
 - The final schema for overlays/tags is not locked.
 
-### 2.5 Engine boundary (`state:engine.*` canonical vs transitional)
+### 2.5 Engine boundary (adapter-only; reification-first; verified `effect:*`)
 
-**Status:** `open`
+**Status:** `accepted`
 
-**Decision (one sentence):** What is the canonical engine boundary contract in
-the target system: which engine state signals (if any) may participate in
-dependency scheduling (`requires/provides`), how they are verified (if at all),
-and what replaces today’s trusted `state:engine.*` tags?
+**Decision (one sentence):** The Civ engine is an I/O surface behind
+`EngineAdapter`; cross-step dependencies must flow through reified `field:*` /
+`artifact:*` products and verified, schedulable `effect:*` tags (with
+`state:engine.*` treated as transitional-only wiring).
 
-**What is already settled (do not re-open in this packet):**
-- **Adapter-only boundary:** core pipeline code talks to the engine only through
-  `EngineAdapter` (no direct `GameplayMap`/`TerrainBuilder` calls in mapgen-core).
-  - Evidence: `docs/projects/engine-refactor-v1/issues/CIV-47-adapter-collapse.md`
-- **Canonical dependency language includes effects:** `effect:*` is a first-class
-  dependency tag namespace (registry-visible, collision-checked) alongside
-  `field:*` and `artifact:*` (decision `2.8` accepted).
-- **Fail-fast execution:** enablement is recipe-only and there are no silent
-  skips/guards (decision `2.2` accepted). Any engine precondition failures must
-  be loud runtime errors (never “skip”).
-
-**Why this exists (how ambiguity was created):**
-- M3 adopted dependency tags but kept a transitional engine state namespace:
-  - `packages/mapgen-core/src/pipeline/tags.ts` defines `state:engine.*` tags and
-    treats them as “satisfied” via an internal set (not verified).
-  - `packages/mapgen-core/src/config/schema.ts` documents `state:engine.*` as
-    trusted assertions (aligns with `DEF-008`).
-- Several steps use `state:engine.*` as scheduling dependencies for “engine-side
-  happened” signals (coastlines/biomes/features/placement), but those signals
-  are not reified as artifacts and are not adapter-verifiable today.
-  - Evidence: `packages/mapgen-core/src/pipeline/standard.ts` (`M3_STAGE_DEPENDENCY_SPINE`)
-
-**Why it matters (what stays hard until resolved):**
-- **Contract correctness:** if engine-side invariants are represented only as
-  “trusted” state tags, plan validation can succeed while the engine surface is
-  inconsistent (then downstream steps fail unpredictably).
-- **Engine-less determinism + testing:** we cannot define which steps are truly
-  engine-coupled vs engine-optional unless we have a clear policy for engine
-  reads/writes and for what “engine-side happened” means in the dependency language.
-- **Registry semantics:** `effect:*` exists as a namespace, but the policy for
-  whether effects can participate in scheduling (and under what constraints) is
-  not fully articulated; without this, `requires/provides` semantics remain muddy.
+**Accepted policy (enforceable rules):**
+- **Adapter-only:** steps must not touch engine globals directly; all reads/writes
+  go through `context.adapter` (CIV-47).
+- **Effects schedule:** `effect:*` is a first-class dependency namespace and is
+  valid in `requires`/`provides` as true scheduling edges (3.8).
+- **No unverified schedulable effects:** any `effect:*` used for scheduling must
+  be runtime-verifiable (typically adapter postcondition checks). There is no
+  “asserted but unverified” category for schedulable engine signals.
+- **Reification-first:** pipeline state is canonical in TS-owned `field:*` /
+  `artifact:*`. If a step reads engine state that later steps depend on, it must
+  publish (reify) the corresponding `field:*` / `artifact:*` onto the context.
+- **Engine mutations must be reflected back:** if a step mutates the engine and
+  later steps depend on the results, the step must either:
+  - compute/carry authoritative data in TS first and publish to engine (“publish step”), or
+  - mutate engine then reify the relevant results back into `field:*` / `artifact:*`
+    (often as a separate “reify step”).
+- **`state:engine.*` is transitional-only:** migrate to `effect:engine.*` +
+  reified products; do not enshrine `state:engine.*` as a permanent namespace
+  (aligns with `docs/projects/engine-refactor-v1/deferrals.md` DEF-008).
+- **Escape hatch (rare, transitional):** engine-first steps may remain during
+  migration for parity/correctness (e.g., Civ scripts), but must not introduce
+  implicit cross-step dependencies on opaque engine state. If any downstream
+  step depends on a value, that value must be reified.
 
 **Evidence (current code + docs):**
 - Transitional state tags and lack of verification:
-  - `packages/mapgen-core/src/pipeline/tags.ts` (`M3_DEPENDENCY_TAGS.state`,
-    `isDependencyTagSatisfied()` defaults to “trusted set” for `state:*`).
+  - `packages/mapgen-core/src/pipeline/tags.ts` (`state:engine.*` tags are trusted).
   - `docs/projects/engine-refactor-v1/deferrals.md` `DEF-008`.
-- Steps depend on engine-state tags for ordering:
-  - `packages/mapgen-core/src/pipeline/standard.ts` uses `state:engine.*` for
-    `requires/provides` across many steps.
-- M3 explicitly preserved some engine-state contracts:
-  - `docs/projects/engine-refactor-v1/issues/CIV-42-hydrology-products.md`
-    locks `state:engine.riversModeled` for “engine rivers exist on the surface”
-    in M3 (for adjacency mask derivation).
-- Target docs already imply a direction but stop short of locking policy:
-  - `docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md`
-    includes `effect:engine.*` examples and says “engine state is not canonical
-    (pending 3.5)”.
-
-**Greenfield simplest (pure target):**
-- Engine state is **never** a canonical dependency surface:
-  - if a downstream step needs data, that data is a `field:*`/`artifact:*`.
-  - if a downstream step needs to know an engine-side publish happened, that is
-    represented as an `effect:*` emitted by an explicit publish step.
-- Engine reads happen only through adapter APIs and are minimized:
-  - the canonical pipeline is artifact/field-driven,
-  - publish steps are the only place engine writes happen,
-  - any required engine reads are either reified into artifacts (preferred) or
-    become explicit hard runtime preconditions.
-
-**What is *actually* still open (the choices we need to make):**
-1) **Scheduling semantics for engine-side signals:**
-   - Are `effect:*` tags allowed in `requires/provides` as true scheduling edges,
-     or are they tooling/observability-only?
-2) **Verification posture for engine-side signals:**
-   - Do we require adapter-backed verification for any engine-side signal that
-     participates in scheduling, or do we allow “asserted effects” (unverified)
-     as long as failures are loud downstream?
-3) **Fate of `state:engine.*`:**
-   - Is `state:engine.*`:
-     - banned in the target (transitional-only, with a sunset plan), or
-     - kept as a permanent namespace with an adapter-verification requirement?
-
-**Options (target policy):**
-- **A) No `state:*` in target; engine publishes are `effect:*`; scheduling allowed; verification best-effort**
-  - Replace `state:engine.*` with `effect:engine.*` for “publish happened”.
-  - Effects may participate in scheduling when they represent an explicit publish step.
-  - Verification is adapter-backed only when it is cheap and reliable; otherwise
-    the effect is an asserted contract and downstream steps must fail loudly if
-    engine state is incompatible.
-  - Pros: aligns with “effects are first-class”; keeps engine coupling explicit;
-    avoids blocking on adapter API expansion.
-  - Cons: some scheduling edges are still not formally verified.
-- **B) No engine-state signals participate in scheduling; only artifacts/fields do**
-  - Eliminate `state:*` and treat `effect:*` as observability-only.
-  - Any step that currently relies on engine-side ordering must instead depend
-    on an artifact/field that reifies the needed state (or fail fast).
-  - Pros: strongest dataflow purity; maximizes engine-less determinism.
-  - Cons: forces large reification work (placement/climate/rivers) before we can
-    express current pipeline structure cleanly.
-- **C) Keep `state:engine.*` as a permanent namespace but require verification**
-  - Retain `state:engine.*` but make it adapter-verifiable and fail-fast.
-  - Pros: preserves the existing mental model; makes dependencies “real”.
-  - Cons: pushes complexity into adapter APIs; risks widening adapter surface or
-    encoding fragile invariants.
-
-**What blocks simplification (what is truly necessary vs legacy-only):**
-- Necessary (real constraints):
-  - Some steps are currently engine-effect driven (e.g., placement) and cannot
-    be fully reified to artifacts without additional design work (`DEF-006`).
-  - Some engine invariants are not introspectable today (verification gap).
-- Legacy/transitional:
-  - `state:engine.*` exists primarily to preserve stage-era ordering without
-    forcing immediate adapter expansion (`DEF-008`).
-
-**Tentative default (recommended for closure direction, not yet accepted):**
-- **Option A**: treat `state:engine.*` as transitional only; migrate to explicit
-  `effect:engine.*` emitted by publish steps; allow effects to participate in
-  scheduling; add adapter verification only where cheap/reliable.
-
-**SPEC impact (if/when accepted):**
-- `docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md`:
-  - tighten “engine boundary is adapter-only” into explicit rules:
-    - no `state:engine.*` in target (or explicitly fenced transitional namespace),
-    - effect scheduling semantics (`effect:*` may/May not participate in `requires/provides`),
-    - verification posture (what must be verifiable vs asserted).
-- `docs/projects/engine-refactor-v1/deferrals.md`:
-  - update/close `DEF-008` once `state:engine.*` is replaced or verified.
-
-**ADR stub:**
-- ADR-TBD: Engine boundary policy (`state:engine.*` transitional vs canonical)
+- Current scheduling depends on engine-surface signals:
+  - `packages/mapgen-core/src/pipeline/standard.ts` uses `state:engine.*`.
 
 **Migration note (current hybrid -> target):**
-- Replace `state:engine.*` dependencies with `effect:engine.*` emitted by
-  explicit publish steps (one per engine publish boundary) and remove “trusted
-  assertions” from core tag satisfaction logic.
-- Add adapter verification only for selected high-risk publish effects (when
-  possible) and keep the rest as asserted contracts with loud downstream failures.
+- Replace `state:engine.*` scheduling edges with `effect:engine.*`.
+- Add executor support for verifying provided `effect:*` tags (postcondition checks).
+- Split “engine-first” clusters into explicit publish/reify steps wherever a
+  downstream dependency exists, so cross-step contracts remain dataflow-shaped.
 
 ### 2.6 Climate ownership (`ClimateField` vs engine rainfall)
 
@@ -1215,14 +1122,14 @@ Assumptions to confirm:
 - Whether narrative is a separate phase or cross-cutting overlays.
 - Placement inputs as explicit artifact vs direct field reads.
 
-**Engine boundary policy (draft):**
-- `state:engine.*` tags are transitional only, not canonical contracts.
-- Engine writes are adapter-driven from fields/artifacts, not read-back gates.
-- Validation hooks verify that required engine state matches artifacts if used.
+**Engine boundary policy (accepted):**
+- `state:engine.*` tags are transitional only; target uses verified `effect:*`.
+- `effect:*` participates in scheduling via `requires`/`provides` and is runtime-verifiable.
+- Reification-first: any engine-derived value that flows across steps is reified into `field:*` / `artifact:*`.
+- Engine reads/writes happen only through `EngineAdapter`; no direct engine globals.
 
 Assumptions to confirm:
-- Long-term policy for engine state verification (required vs optional).
-- Whether any engine-only surfaces remain canonical.
+- The minimal “effect verifier” surface (adapter queries + executor hook) and the first set of high-risk effects to verify (placement/biomes/features).
 
 **Story model (draft):**
 - Story overlays are the canonical surface; story tags are derived views.
@@ -1252,7 +1159,7 @@ These will be promoted to `docs/system/ADR.md` as decisions are accepted.
 - ADR-TBD: Step enablement model (recipe-only; remove `shouldRun`).
 - ADR-TBD: Foundation contract (snapshot vs discrete artifacts).
 - ADR-TBD: Story data model (overlays vs tags).
-- ADR-TBD: Engine boundary policy (`state:engine.*` transitional vs canonical).
+- ADR-TBD: Engine boundary policy (adapter-only; reification-first; verified `effect:*`).
 - ADR-TBD: Climate ownership (`ClimateField` vs engine rainfall).
 - ADR-TBD: Placement inputs (artifact vs engine reads).
 - ADR-TBD: Artifact registry ownership and versioning.

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M-TS-typescript-migration-remediation.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M-TS-typescript-migration-remediation.md
@@ -13,6 +13,8 @@ focused on fixing the TypeScript migration's "null script" behavior and restorin
 runtime correctness: CIV-15 (Adapter Boundary & Orchestrator), CIV-16 (FoundationContext
 consumption), and related follow-ups.
 
+> Update (2025-12-20): This review predates CIV-53/DEF-013. Any references to `stageFlags` / `resolveStageFlags()` / per-step `shouldRun()` are historical only; enablement is now single-sourced from the derived recipe list and `MapGenStep` no longer includes `shouldRun`.
+
 ## Testing Strategy Note
 
 During this remediation phase, we prioritize **shipping working fixes quickly** over

--- a/docs/projects/engine-refactor-v1/reviews/REVIEW-M3-core-engine-refactor-config-evolution.md
+++ b/docs/projects/engine-refactor-v1/reviews/REVIEW-M3-core-engine-refactor-config-evolution.md
@@ -8,6 +8,8 @@ reviewer: AI agent (Codex CLI)
 
 # M3: Core Engine Refactor & Config Evolution — Aggregate Review (Running Log)
 
+> Update (2025-12-20): This review predates CIV-53/DEF-013. Any references to per-step `shouldRun()` or `stageFlags`-driven enablement are historical only; enablement is now single-sourced from the derived recipe list and `MapGenStep` no longer includes `shouldRun`.
+
 This running log captures task-level reviews for milestone M3. Entries focus on
 correctness, completeness, sequencing fit, and forward-looking risks.
 

--- a/docs/system/libs/mapgen/architecture.md
+++ b/docs/system/libs/mapgen/architecture.md
@@ -9,6 +9,10 @@ This page intentionally mixes:
 - **Target architecture (canonical):** the Task Graph / `MapGenStep` / `StepRegistry` direction we are steering toward.
 - **Current implementation (post‑M2, transient):** the orchestrator‑centric stable slice used today while M3/M4 land.
 
+Config note (important):
+- Some older sections still refer to a monolithic `MapGenConfig` object in `context.config`.
+- The current target drafts supersede that: boundary input is `RunRequest = { recipe, settings }`, and step-local knobs are validated per step (no global config mega-object). See `docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md`.
+
 When you need “what’s actually wired right now,” prefer the project snapshot docs:
 
 - `docs/projects/engine-refactor-v1/status.md`
@@ -105,9 +109,9 @@ The map script is defined by a JSON recipe. This allows the UI to manipulate the
 }
 ```
 
-### 2.5. Configuration Schema (MapGenConfig)
+### 2.5. Configuration Schema (Current: `MapGenConfig`; Target: step-owned config)
 
-In addition to the pipeline recipe, the engine is driven by a strongly-typed, runtime‑validated **configuration object**:
+Current (M3): in addition to the pipeline ordering inputs, the engine is driven by a strongly-typed, runtime‑validated **configuration object** (`MapGenConfig`) that is injected into the context:
 
 ```typescript
 export interface MapGenContext {
@@ -135,9 +139,11 @@ Key points:
 
 Relationship to the recipe:
 
-- `MapGenConfig` covers **parameters** (plate counts, landmass water %, mountains/volcano/climate tuning, diagnostics, etc.).
-- The recipe covers **which steps run and in what order** (and may provide per‑step overrides via the `config` field).
-- Steps read configuration either directly from `context.config` or from a combination of `context.config` and their recipe‑level `config`, depending on their design.
+- Current (M3): `MapGenConfig` covers **parameters** (plate counts, landmass water %, tuning, diagnostics, etc.) while ordering/enablement are still transitional (`STAGE_ORDER` + `stageManifest`; DEF-004).
+- Target: there is **no** `context.config` mega-object. Boundary input is:
+  - `RunRequest = { recipe, settings }`
+  - `settings` are narrow, per-run globals (seed + dimensions at minimum) at `context.settings`
+  - step-local knobs are validated per-step and supplied via per-occurrence recipe config
 
 ---
 

--- a/docs/system/libs/mapgen/ecology.md
+++ b/docs/system/libs/mapgen/ecology.md
@@ -2,6 +2,8 @@
 
 > **Status:** Target (post‑M3). M3 is wrap‑first: legacy/engine behavior is wrapped to preserve map quality; the algorithms described here are not required for M3.
 
+> **Config note:** Some sections still reference legacy `MapGenConfig` slices. The current target drafts supersede that: boundary input is `RunRequest = { recipe, settings }`, and step-local knobs are validated per step (no global config mega-object). See `docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md`.
+
 ## 1. Overview
 
 The **Ecology Stage** follows Hydrology. Its responsibility is to interpret the physical world (Geology + Climate) into gameplay concepts: **Soils**, **Biomes**, **Resources**, and **Features**.

--- a/docs/system/libs/mapgen/foundation.md
+++ b/docs/system/libs/mapgen/foundation.md
@@ -2,6 +2,8 @@
 
 > **Target vs Current (post‑M2):** This doc describes the target Foundation design. The current M2 stable slice is an orchestrator‑centric bridge and is intentionally transient while M3 introduces step/task‑graph execution.
 
+> **Config note:** Some sections still reference legacy `MapGenConfig` slices. The current target drafts supersede that: boundary input is `RunRequest = { recipe, settings }`, and step-local knobs are validated per step (no global config mega-object). See `docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md`.
+
 ## 1. Overview
 
 The **Foundation Stage** is the first major phase of the map generation pipeline. Its responsibility is to construct the physical "board" (Mesh), the geological material (Crust), and the tectonic "pieces" (Plates) that drive all downstream morphology.

--- a/docs/system/libs/mapgen/hydrology.md
+++ b/docs/system/libs/mapgen/hydrology.md
@@ -2,6 +2,8 @@
 
 > **Status:** Target (post‑M3). M3 is wrap‑first: hydrology/climate runs as wrapper steps to preserve map quality; the sub-step breakdown and optional extensions below are not required for M3.
 
+> **Config note:** Some sections still reference legacy `MapGenConfig` slices. The current target drafts supersede that: boundary input is `RunRequest = { recipe, settings }`, and step-local knobs are validated per step (no global config mega-object). See `docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md`.
+
 ## 1. Overview
 
 The **Hydrology & Climate** phase turns landform + latitude into gameplay‑relevant fields and signals:

--- a/docs/system/libs/mapgen/morphology.md
+++ b/docs/system/libs/mapgen/morphology.md
@@ -2,6 +2,8 @@
 
 > **Status:** Target (post‑M3). M3 is wrap‑first: legacy/engine behavior is wrapped to preserve map quality; the algorithms described here are not required for M3.
 
+> **Config note:** Some sections still reference legacy `MapGenConfig` slices. The current target drafts supersede that: boundary input is `RunRequest = { recipe, settings }`, and step-local knobs are validated per step (no global config mega-object). See `docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md`.
+
 ## 1. Overview
 
 The **Morphology Stage** follows the Foundation phase. Its responsibility is to transform the raw tectonic potential (Uplift, Volcanism) into a realistic, playable landscape.

--- a/docs/system/libs/mapgen/narrative.md
+++ b/docs/system/libs/mapgen/narrative.md
@@ -2,6 +2,8 @@
 
 > **Status:** Target (post‑M3). M3 is wrap‑first: legacy/engine behavior is wrapped to preserve map quality; the algorithms described here are not required for M3.
 
+> **Config note:** Some sections still reference legacy `MapGenConfig` slices. The current target drafts supersede that: boundary input is `RunRequest = { recipe, settings }`, and step-local knobs are validated per step (no global config mega-object). See `docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md`.
+
 ## 1. Overview
 
 The **Narrative System** is the "Soul" of the map generation engine. While the physical layers (Foundation, Morphology, Hydrology) determine *what* the world looks like, the Narrative system determines *why* it matters and *how* it feels.


### PR DESCRIPTION
docs(engine-refactor): accept engine boundary policy (3.5)

docs(engine-refactor): sync legacy spikes with accepted decisions