### PR TITLE
docs(engine-refactor): update deferrals and M4 milestone with accepted architecture decisions

### DIFF
--- a/docs/projects/engine-refactor-v1/deferrals.md
+++ b/docs/projects/engine-refactor-v1/deferrals.md
@@ -25,12 +25,12 @@ Each deferral follows this structure:
 ## DEF-002: StoryTags Compatibility Layer (Derived From StoryOverlays)
 
 **Deferred:** 2025-12-14  
-**Trigger:** After M3 story steps land and all in-repo consumers read `artifact:storyOverlays` (or an explicitly versioned overlay artifact) directly.  
-**Context:** During Milestone 3 story modernization we publish canonical overlays, but some legacy consumers still expect `StoryTags`. To avoid forcing an all-at-once consumer migration, `StoryTags` remains as a derived compatibility layer populated from overlays.  
+**Trigger:** After narrative/playability artifacts are published/consumed as explicit `artifact:narrative.*` products and no in-repo consumers require `StoryTags` for correctness.  
+**Context:** During Milestone 3 story modernization we introduced “overlays” + `StoryTags` to bridge legacy consumers. Target architecture decision 3.4 locks the end-state: **typed narrative artifacts are canonical and `StoryTags` is not a target contract surface**. This deferral exists only to sequence the cleanup safely.  
 **Scope:**
-- Keep `StoryTags` available as a derived view computed from overlays (not a parallel source of truth).
-- Migrate remaining in-repo consumers to read overlays directly.
-- Remove or demote `StoryTags` once no longer needed (ideally delete, otherwise dev-only).  
+- Keep `StoryTags` available only as a temporary compatibility surface.
+- Migrate consumers to `artifact:narrative.*` (or derived, context-scoped query helpers).
+- Remove `StoryTags` entirely once consumers are migrated.  
 **Impact:**
 - Temporary duplication of narrative representation (overlays + tags) with risk of semantic drift if not kept strictly derived.
 - Continued support surface for legacy semantics during M3.
@@ -130,11 +130,11 @@ Each deferral follows this structure:
 ## DEF-012: Story State to Context-Owned Artifacts (Remove Globals)
 
 **Deferred:** 2025-12-18  
-**Trigger:** After legacy orchestration + toggle removal is complete and story-state representation is fully migrated away from StoryTags/caches.  
-**Context:** The intended end-state is context-owned story data. While StoryTags are now stored on context artifacts, many domain layers still consume StoryTags directly and several story subsystems still rely on module-level caches.  
+**Trigger:** After narrative/playability state is fully represented as explicit `artifact:narrative.*` products and any remaining story caches are context-owned artifacts.  
+**Context:** Target architecture decision 3.4 locks the end-state: narrative/playability state is explicit artifacts and there are no module-level story globals/caches. This deferral tracks the remaining implementation cleanup (migrating consumers and removing caches) safely.  
 **Scope:**
-- Choose a canonical context-owned representation (`artifact:storyState`/`artifact:storyTags` or `ctx.story.*`) and migrate consumers to it.
-- Remove StoryTags as a compatibility surface once no longer needed.
+- Publish/consume narrative/playability state as `artifact:narrative.*` products (typed, versioned).
+- Remove StoryTags as a compatibility surface once no longer needed (see `DEF-002`).
 - Remove module-level story caches (or make them explicitly keyed/scoped and safely reset by context) so story execution is purely context-driven.  
 **Impact:**
 - Story behavior can still be influenced by hidden module-level state and caches.
@@ -202,7 +202,7 @@ Each deferral follows this structure:
 **Context:** `StoryOverlays` currently has a global registry fallback to support legacy reads and transitional wiring. This is intentionally kept through M3 to avoid brittle cutovers while the Task Graph and story steps are stabilized.  
 **Scope:**
 - Keep the global fallback through M3 for compatibility.
-- Migrate callers to context-scoped overlays (`artifact:storyOverlays`).
+- Migrate callers to context-scoped narrative state (target: explicit `artifact:narrative.*` products; legacy: `ctx.overlays` during transition).
 - Remove the global registry fallback (or make it dev-only) once consumers are migrated.  
 **Impact:**
 - Global state makes tests less isolated and can hide ordering/coupling problems.

--- a/docs/projects/engine-refactor-v1/deferrals.md
+++ b/docs/projects/engine-refactor-v1/deferrals.md
@@ -80,7 +80,7 @@ Each deferral follows this structure:
 **Impact:**
 - Placement contracts are less data-centric and more “engine state” centric in M3.
 - Harder to test placement purely in-memory without adapter/engine involvement.
- - **Status (2025-12-21):** The target contract (3.7) is accepted; remaining work is implementation cutover from the current engine-effect wiring to the explicit `artifact:placementInputs@v1` + verified `effect:*` model.
+- **Status (2025-12-21):** The target contract (3.7) is accepted; remaining work is implementation cutover from the current engine-effect wiring to the explicit `artifact:placementInputs@v1` + verified `effect:*` model.
 
 ---
 

--- a/docs/projects/engine-refactor-v1/deferrals.md
+++ b/docs/projects/engine-refactor-v1/deferrals.md
@@ -101,14 +101,14 @@ Each deferral follows this structure:
 
 **Deferred:** 2025-12-18  
 **Trigger:** When the climate pipeline artifacts are stable and we need engine-less rainfall testing or broader engine decoupling.  
-**Context:** Phase A fixes the adapter boundary for rainfall writes, but rainfall generation still relies on engine-side state. We want to reclaim rainfall generation into TS-owned artifacts once the foundation/climate contracts are settled.  
+**Context:** Climate is moving toward TS-owned canonical products. `syncClimateField()` has been removed and climate steps already publish `artifact:climateField`; however, some climate inputs still rely on engine adapter reads (e.g., `getLatitude`, `isWater`, `getElevation`) and thus full engine-less climate runs remain deferred.  
 **Scope:**
-- Define a canonical rainfall artifact (or field) in the pipeline and publish it from climate steps.
-- Route engine writes through a dedicated adapter publish step instead of direct reads/writes during generation.
-- Remove reliance on `GameplayMap` / `TerrainBuilder` as the source of truth for rainfall values.  
+- Keep `artifact:climateField` as the canonical TS product and treat adapter writes as publish-only effects (not a source of truth).
+- Define and adopt explicit TS-owned prerequisites where feasible (e.g., `artifact:heightfield`, `field:latitude`, TS water/landmask) so climate generation no longer depends on engine-only reads.
+- When engine reads are unavoidable, ensure any cross-step dependency is reified into `field:*`/`artifact:*` with explicit `requires/provides` (no implicit “read engine later” edges).  
 **Impact:**
-- Until this lands, rainfall is effectively engine-owned, limiting offline testing and keeping a hidden coupling to engine state.
-- Boundary correctness improves now, but full decoupling is intentionally deferred.
+- Until this lands, climate remains partially engine-coupled via adapter reads, limiting offline testing and keeping hidden coupling to engine-derived signals.
+- Canonical ownership is still TS-first; this deferral tracks completing the reification of climate prerequisites and eliminating accidental engine-dependency surfaces.
 
 ---
 

--- a/docs/projects/engine-refactor-v1/deferrals.md
+++ b/docs/projects/engine-refactor-v1/deferrals.md
@@ -149,6 +149,7 @@ Each deferral follows this structure:
 **Deferred:** 2025-12-18  
 **Trigger:** When Phase B / foundation PRD work begins and consumers are ready to migrate off `ctx.foundation`.  
 **Context:** The orchestrator bloat assessment explicitly defers the target multi-artifact foundation model; Phase A keeps the `FoundationContext` snapshot as the compatibility boundary.  
+**Decision status (locked):** The target foundation surface is **discrete** `artifact:*` products; any `FoundationContext`-like object is migration-only compatibility wiring. The remaining work is implementation + consumer migration (this deferral tracks that work).
 **Scope:**
 - Define the canonical foundation artifact set (mesh, crust, plateGraph, tectonics, and any required raster artifacts).
 - Migrate consumers from `ctx.foundation` to explicit artifacts/fields with named contracts.

--- a/docs/projects/engine-refactor-v1/deferrals.md
+++ b/docs/projects/engine-refactor-v1/deferrals.md
@@ -67,17 +67,20 @@ Each deferral follows this structure:
 
 ---
 
-## DEF-006: Placement Inputs Artifact Deferred (Placement Remains Engine-Effect Driven)
+## DEF-006: Placement Inputs Artifact Implementation Deferred (M3 Placement Remains Engine-Effect Driven)
 
 **Deferred:** 2025-12-14  
-**Trigger:** When we need engine-less placement testing or want placement composition that depends on a stable, reusable “placement inputs” artifact.  
-**Context:** Placement currently consumes a mix of map-init inputs and engine-surface state, not a single in-memory “inputs” artifact. In M3 we keep placement as an engine-effect step with `state:*` dependency tags, and we do not force immediate publication of a canonical `artifact:placementInputs`.  
+**Trigger:** When we need engine-less placement testing, want placement composition that depends on a stable “placement inputs” artifact, or are ready to cut over M3 placement wiring to the accepted target contract.  
+**Context:** Placement currently consumes a mix of map-init inputs and engine-surface state, not a single TS-owned “inputs” artifact. In M3 we keep placement as an engine-effect step and avoid blocking on a full placement-input contract design. Target decision 3.7 is now accepted: placement consumes an explicit `artifact:placementInputs@v1` and does not rely on implicit engine reads as a cross-step dependency surface. This deferral remains only to sequence the implementation safely.  
 **Scope:**
-- Keep placement’s precomputed inputs assembled internally to the placement step in M3.
-- Consider publishing a canonical `artifact:placementInputs` later if it materially improves testability/composability.  
+- Add `artifact:placementInputs@v1` to the tag registry with a safe demo payload.
+- Introduce a `derivePlacementInputs` step (or small cluster) that produces `artifact:placementInputs@v1` from explicit prerequisites and reifies any engine-only reads that become cross-step dependencies.
+- Update placement to `requires: ["artifact:placementInputs@v1"]` and publish a verified `effect:engine.placementApplied` when it mutates the engine.
+- Remove `state:*` placement scheduling once `effect:*` + artifact prerequisites are in place (align with DEF-008).  
 **Impact:**
 - Placement contracts are less data-centric and more “engine state” centric in M3.
 - Harder to test placement purely in-memory without adapter/engine involvement.
+ - **Status (2025-12-21):** The target contract (3.7) is accepted; remaining work is implementation cutover from the current engine-effect wiring to the explicit `artifact:placementInputs@v1` + verified `effect:*` model.
 
 ---
 

--- a/docs/projects/engine-refactor-v1/milestones/M4-tests-validation-cleanup.md
+++ b/docs/projects/engine-refactor-v1/milestones/M4-tests-validation-cleanup.md
@@ -84,7 +84,7 @@ This milestone corresponds to **Milestone 4** in `PROJECT-engine-refactor-v1.md`
 
 > This milestone should be executed as a small set of parent issues that each leave the mod runnable. Each parent may internally land as a few stacked PR layers, but should preserve a working end-to-end pipeline after each parent completes.
 
-### 1) M4-PIPELINE-CUTOVER: Recipe + ExecutionPlan as the only ordering surface (DEF-004)
+### 1) M4-PIPELINE-CUTOVER: Recipe + ExecutionPlan as the only ordering surface (DEF-004) — **Estimate: 8**
 
 - Outcome: Runtime input is `RunRequest = { recipe, settings }`, compiled into an `ExecutionPlan` that the executor runs (no `stageManifest`/`STAGE_ORDER` ordering input).
 - Acceptance:
@@ -92,14 +92,14 @@ This milestone corresponds to **Milestone 4** in `PROJECT-engine-refactor-v1.md`
   - `stageManifest` and `STAGE_ORDER` are not required to run the pipeline.
   - Any remaining enablement artifacts (`stageFlags`, `shouldRun`) are deleted (or quarantined behind dev-only tooling) and not part of the runtime contract.
 
-### 2) M4-EFFECTS-VERIFICATION: Replace `state:engine.*` with verifiable `effect:*` + reification (DEF-008)
+### 2) M4-EFFECTS-VERIFICATION: Replace `state:engine.*` with verifiable `effect:*` + reification (DEF-008) — **Estimate: 8**
 
 - Outcome: Engine-surface prerequisites are explicit `effect:*` tags that participate in scheduling and are verified via adapter-backed postconditions; cross-step data is reified into `field:*` / `artifact:*`.
 - Acceptance:
   - `state:engine.*` is removed from the target registry/contract surface (migration-only compatibility, if any, is isolated and explicit).
   - Highest-risk engine effects (biomes/features/placement) have verifiable `effect:*` tags and minimal postcondition checks.
 
-### 3) M4-PLACEMENT-INPUTS: Cut placement over to `artifact:placementInputs@v1` (DEF-006)
+### 3) M4-PLACEMENT-INPUTS: Cut placement over to `artifact:placementInputs@v1` (DEF-006) — **Estimate: 4**
 
 - Outcome: Placement consumes explicit, TS-canonical inputs and publishes a verified `effect:engine.placementApplied`; no implicit engine reads act as the cross-step dependency surface.
 - Acceptance:
@@ -107,14 +107,14 @@ This milestone corresponds to **Milestone 4** in `PROJECT-engine-refactor-v1.md`
   - A derive step produces it from explicit prerequisites.
   - Placement requires it and no longer relies on `state:*` scheduling tags.
 
-### 4) M4-NARRATIVE-CLEANUP: Narrative/playability artifacts become canonical; StoryTags/caches removed (DEF-002/DEF-012)
+### 4) M4-NARRATIVE-CLEANUP: Narrative/playability artifacts become canonical; StoryTags/caches removed (DEF-002/DEF-012) — **Estimate: 4**
 
 - Outcome: Typed `artifact:narrative.*` products are the canonical playability surface; StoryTags are removed as a dependency surface and caches are context-owned or eliminated.
 - Acceptance:
   - All in-repo consumers read (directly or via derived query helpers) from `artifact:narrative.*`.
   - StoryTags is either deleted or fenced to explicit compatibility tooling with no consumer correctness dependency.
 
-### 5) M4-SAFETY-NET: Observability baseline + CI tests (CIV-23 + CIV-55)
+### 5) M4-SAFETY-NET: Observability baseline + CI tests (CIV-23 + CIV-55) — **Estimate: 4**
 
 - Outcome: We can compile, execute, and debug the pipeline confidently.
 - Acceptance:

--- a/docs/projects/engine-refactor-v1/milestones/M4-tests-validation-cleanup.md
+++ b/docs/projects/engine-refactor-v1/milestones/M4-tests-validation-cleanup.md
@@ -14,10 +14,10 @@ This milestone corresponds to **Milestone 4** in `PROJECT-engine-refactor-v1.md`
 
 ## Objectives
 
-- Add a basic but meaningful automated test suite around the Task Graph pipeline and critical steps.
-- Extend runtime validation to cover `state:engine.*` dependencies (or replace them with verifiable artifacts/fields).
-- Remove remaining legacy globals, fallbacks, and compatibility shims that keep old data flows alive.
-- Close remaining TS migration and orchestrator hygiene cleanup that blocks the target architecture.
+- Finish the M3→Target cutover: mod-authored recipe + compiled `ExecutionPlan` as the single source of truth (remove `stageManifest`/`STAGE_ORDER` as ordering inputs).
+- Replace `state:engine.*` scheduling with verifiable `effect:*` tags + reified `field:*` / `artifact:*` products as cross-step dependency surfaces.
+- Remove remaining legacy globals, fallbacks, and compatibility shims that keep old data flows alive (WorldModel bridge, GameplayMap reads, StoryTags compatibility).
+- Add a basic but meaningful automated test suite and observability baseline around pipeline compile + execution.
 
 ## Scope
 
@@ -27,9 +27,9 @@ This milestone corresponds to **Milestone 4** in `PROJECT-engine-refactor-v1.md`
   - **M2** has established the validated-config + foundation slice driven by `MapOrchestrator` (see `M2-stable-engine-slice.md` and related PRDs).
   - **M3** has generalized the pipeline and evolved `MapGenConfig` into its step/phase-aligned shape (see `M3-core-engine-refactor-config-evolution.md`).
 - Within that baseline, M4 focuses on:
-  - Hardening the engine with tests and validation (leveraging the Task Graph and data products defined in `resources/PRD-pipeline-refactor.md` and `PROJECT-engine-refactor-v1.md`).
+  - Finalizing the **target boundary** (`RunRequest = { recipe, settings }` → compile to `ExecutionPlan` → execute) and removing transitional ordering/config sources (`stageManifest`, `STAGE_ORDER`, `stageFlags`, `shouldRun`).
+  - Hardening the engine with tests/validation and expanding explicit products across high-risk boundaries (leveraging the Task Graph + the target architecture SPIKE/SPEC).
   - Removing remaining globals/fallbacks that prevent a fully context-owned, fail-fast pipeline.
-  - Cleaning up remaining JS shims and orchestrator hygiene, informed by the remediation/review docs.
 - Lower-level expectations for config behavior, pipeline contracts, and foundation outputs remain in:
   - `resources/PRD-config-refactor.md`
   - `resources/PRD-pipeline-refactor.md`
@@ -42,49 +42,91 @@ This milestone corresponds to **Milestone 4** in `PROJECT-engine-refactor-v1.md`
 - RNG and adapter boundaries in `mapgen-core` are standardized (no `Math.random()` or direct `TerrainBuilder.*` usage).
 - Foundation production is step-owned; legacy globals still exist for compatibility (see deferrals).
 
-### 1. Testing & Verification
+### 1. Pipeline Cutover (Ordering + Enablement + Inputs)
+
+- Remove `stageManifest`/`STAGE_ORDER` as pipeline ordering inputs; treat a mod-authored recipe as canonical.
+- Remove all residual enablement mechanisms (`stageFlags`, `shouldRun`) and ensure only recipe-driven enablement exists.
+- Ensure the executor consumes only a compiled `ExecutionPlan` (no runtime filtering / silent skips).
+
+### 2. Testing & Verification
 
 - Add Vitest smoke tests for:
   - Task Graph pipeline execution against a stub adapter + minimal presets.
   - Foundation, climate, and overlay steps with deterministic invariants.
 - Add regression tests for one or more key Swooper presets to catch breaking changes.
 
-### 2. Validation & Contract Hardening
+### 3. Validation & Contract Hardening
 
-- Define and implement a verification strategy for `state:engine.*` dependencies (see `deferrals.md` DEF-008).
-- Add targeted runtime checks for the highest-risk `state:engine.*` tags or replace them with verifiable artifacts/fields.
+- Replace `state:engine.*` dependencies with verifiable `effect:*` tags + targeted adapter-backed verification (see `deferrals.md` DEF-008).
+- Expand explicit, TS-canonical products at high-risk boundaries (e.g., `artifact:placementInputs@v1` in DEF-006) and reify engine-derived values when they become cross-step dependencies.
 
-### 3. Legacy Cleanup & Hygiene
+### 4. Legacy Cleanup & Hygiene
 
 - Remove remaining legacy globals and compatibility shims:
-  - StoryTags compatibility layer and overlay registry fallback.
+  - StoryTags compatibility layer (DEF-002) and remaining story caches (DEF-012).
   - WorldModel bridge paths and direct `GameplayMap` reads in mapgen-core.
 - Complete remaining JS/TS cleanup in engine paths.
-- Consolidate enablement gating in `MapOrchestrator` (see DEF-013).
 
 ### Out of Scope (Explicit)
 
 - New algorithm modernization (morphology/hydrology/ecology).
-- Recipe UI or externally composable pipeline definitions.
+- Recipe UI (in-game) and mod recipe patching/insertion tooling (beyond “pick a recipe and run it”).
 - Rainfall ownership transfer or behavior-mode consolidation unless explicitly pulled in.
 
 ## Acceptance Criteria
 
-- Core engine paths are covered by smoke tests that run quickly in CI.
-- Targeted regression tests exist for at least one Swooper preset.
-- `state:engine.*` dependencies have a defined verification strategy with runtime checks for high-risk tags.
-- Legacy globals/fallbacks are removed or demoted to dev-only, and failures manifest as explicit errors.
-- Orchestrator enablement and cleanup work is complete.
+- Pipeline ordering + enablement derive solely from the mod recipe; `stageManifest`/`STAGE_ORDER`/`stageFlags`/`shouldRun` are not part of the runtime contract.
+- Core engine paths are covered by smoke tests that run quickly in CI; at least one Swooper preset regression test exists.
+- `state:engine.*` is no longer a target contract surface; engine-side prerequisites are expressed as verifiable `effect:*` tags and/or reified `field:*` / `artifact:*` products.
+- Legacy globals/fallbacks are removed (or quarantined to dev-only with explicit errors) and failures manifest as explicit errors.
 
-## Candidate Issues / Deliverables
+## Recommended Parent Issues (keep the repo working after each)
 
-> These mappings reflect the re-baseline and will be refined into issue docs.
+> This milestone should be executed as a small set of parent issues that each leave the mod runnable. Each parent may internally land as a few stacked PR layers, but should preserve a working end-to-end pipeline after each parent completes.
 
-- [ ] CIV-23: Integration & behavior tests (re-scope for Task Graph + context artifacts) (`../issues/CIV-23-integration-tests.md`)
-- [ ] M4-VALIDATION: `state:engine.*` verification strategy + targeted checks (DEF-008) (issue doc TBD)
-- [ ] M4-LEGACY-CLEANUP: remove StoryTags/overlay registry fallback + WorldModel bridge + GameplayMap reads (DEF-002/003/007/012) (issue doc TBD)
-- [ ] CIV-53: Orchestrator hygiene + enablement consolidation (DEF-013) (`../issues/CIV-53-def-013-enablement-consolidation.md`)
-- [ ] CIV-9: Bun/pnpm bridge scripts (`../issues/CIV-9-bun-pnpm-bridge.md`) - optional tooling improvement
+### 1) M4-PIPELINE-CUTOVER: Recipe + ExecutionPlan as the only ordering surface (DEF-004)
+
+- Outcome: Runtime input is `RunRequest = { recipe, settings }`, compiled into an `ExecutionPlan` that the executor runs (no `stageManifest`/`STAGE_ORDER` ordering input).
+- Acceptance:
+  - The default “standard” mod exposes a recipe that fully defines step order + enablement.
+  - `stageManifest` and `STAGE_ORDER` are not required to run the pipeline.
+  - Any remaining enablement artifacts (`stageFlags`, `shouldRun`) are deleted (or quarantined behind dev-only tooling) and not part of the runtime contract.
+
+### 2) M4-EFFECTS-VERIFICATION: Replace `state:engine.*` with verifiable `effect:*` + reification (DEF-008)
+
+- Outcome: Engine-surface prerequisites are explicit `effect:*` tags that participate in scheduling and are verified via adapter-backed postconditions; cross-step data is reified into `field:*` / `artifact:*`.
+- Acceptance:
+  - `state:engine.*` is removed from the target registry/contract surface (migration-only compatibility, if any, is isolated and explicit).
+  - Highest-risk engine effects (biomes/features/placement) have verifiable `effect:*` tags and minimal postcondition checks.
+
+### 3) M4-PLACEMENT-INPUTS: Cut placement over to `artifact:placementInputs@v1` (DEF-006)
+
+- Outcome: Placement consumes explicit, TS-canonical inputs and publishes a verified `effect:engine.placementApplied`; no implicit engine reads act as the cross-step dependency surface.
+- Acceptance:
+  - `artifact:placementInputs@v1` exists in the registry with a safe demo payload.
+  - A derive step produces it from explicit prerequisites.
+  - Placement requires it and no longer relies on `state:*` scheduling tags.
+
+### 4) M4-NARRATIVE-CLEANUP: Narrative/playability artifacts become canonical; StoryTags/caches removed (DEF-002/DEF-012)
+
+- Outcome: Typed `artifact:narrative.*` products are the canonical playability surface; StoryTags are removed as a dependency surface and caches are context-owned or eliminated.
+- Acceptance:
+  - All in-repo consumers read (directly or via derived query helpers) from `artifact:narrative.*`.
+  - StoryTags is either deleted or fenced to explicit compatibility tooling with no consumer correctness dependency.
+
+### 5) M4-SAFETY-NET: Observability baseline + CI tests (CIV-23 + CIV-55)
+
+- Outcome: We can compile, execute, and debug the pipeline confidently.
+- Acceptance:
+  - Step tracing can be toggled per step on a shared foundation; run id + plan fingerprint are emitted.
+  - CI runs a small suite of smoke tests (stub adapter) plus at least one regression-style preset test.
+
+## Existing / Related Issue Docs
+
+- CIV-23: Integration & behavior tests (`../issues/CIV-23-integration-tests.md`) — will need re-scope to the recipe/ExecutionPlan boundary.
+- CIV-53: Enablement consolidation (`../issues/CIV-53-def-013-enablement-consolidation.md`) — overlaps with M4-PIPELINE-CUTOVER and may be merged into it.
+- Deferrals to close or advance in M4:
+  - DEF-004, DEF-006, DEF-008, DEF-002, DEF-012.
 
 Any remaining remediation items from:
 - `../reviews/M-TS-typescript-migration-remediation.md`

--- a/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
+++ b/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
@@ -61,6 +61,16 @@ This section describes the greenfield target with no legacy constraints.
   executor runs (validated, defaults resolved, bundles expanded, topo-sorted).
 - Canonical DAG scheduling (when DAG authoring is introduced): compile to a deterministic schedule via stable topological sort (tie-break rule is a separate decision tracked in the SPIKE).
 
+Observability baseline (accepted; 3.10):
+- Required outputs (always-on; stable contract):
+  - A deterministic `runId` and a stable “plan fingerprint” derived from `settings + recipe + step IDs + config`.
+  - Structured compile-time errors (recipe schema, unknown IDs, invalid tags/config) and structured runtime failures (missing deps, `effect:*` verification failures, step precondition failures).
+  - `ExecutionPlan` must carry enough normalized data to explain scheduling (resolved node IDs + per-node `requires/provides` + resolved per-node config).
+- Optional (dev/tracing):
+  - Rich tracing and diagnostics are implemented as optional sinks fed by a shared event model.
+  - Tracing must be toggleable globally and per step occurrence; toggles must not change execution semantics.
+  - Steps own domain-specific richness (events/summaries) but emit through the shared foundation.
+
 V1 recipe structure (sketch):
 - Recipe is versioned via `schemaVersion`.
 - Recipe references runnable atoms by registry step `id`.
@@ -277,7 +287,7 @@ flowchart LR
   class registry spine,accepted
 
   class engineBoundary boundary,accepted
-  class observability boundary,open
+  class observability boundary,accepted
 
   class foundation domain,open
   class story domain,open
@@ -296,7 +306,7 @@ flowchart LR
 | 3.7 | Placement inputs (explicit artifact vs engine reads) | open | §2.7 |
 | 3.8 | Artifact registry (names + schema ownership + versioning) | accepted | §2.8 |
 | 3.9 | Recipe schema (versioning + compatibility rules) | accepted | §2.9 |
-| 3.10 | Observability (required diagnostics + validation behavior) | open | §2.10 |
+| 3.10 | Observability (required diagnostics + validation behavior) | accepted | §2.10 |
 
 ---
 

--- a/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
+++ b/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
@@ -321,7 +321,7 @@ flowchart LR
 
   class foundation domain,accepted
   class story domain,accepted
-  class climate domain,open
+  class climate domain,accepted
   class placement domain,open
 ```
 
@@ -332,7 +332,7 @@ flowchart LR
 | 3.3 | Foundation surface (discrete artifacts vs `FoundationContext`) | accepted | §2.3 |
 | 3.4 | Narrative/playability model (typed narrative artifacts; no `StoryTags`) | accepted | §2.4 |
 | 3.5 | Engine boundary (adapter-only; reification-first; verified `effect:*`; `state:engine.*` transitional-only) | accepted | §2.5 |
-| 3.6 | Climate ownership (`ClimateField` vs engine rainfall) | open | §2.6 |
+| 3.6 | Climate ownership (`ClimateField` vs engine rainfall) | accepted | §2.6 |
 | 3.7 | Placement inputs (explicit artifact vs engine reads) | open | §2.7 |
 | 3.8 | Artifact registry (names + schema ownership + versioning) | accepted | §2.8 |
 | 3.9 | Recipe schema (versioning + compatibility rules) | accepted | §2.9 |

--- a/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
+++ b/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
@@ -241,6 +241,7 @@ Type safety note:
 | `artifact:narrative.corridors@v1` | narrative | Strategic corridors / paths (typed) |
 | `artifact:narrative.regions@v1` | narrative | Named regions / partitions (typed) |
 | `artifact:narrative.motifs.*@v1` | narrative | Motif sets/heatmaps (typed, categorized) |
+| `artifact:placementInputs@v1` | placement | Resolved placement prerequisites (typed, TS-canonical) |
 | `artifact:placementOutputs` | placement | Final placement decisions |
 
 ### 3.2 Fields (engine-facing buffers)
@@ -322,7 +323,7 @@ flowchart LR
   class foundation domain,accepted
   class story domain,accepted
   class climate domain,accepted
-  class placement domain,open
+  class placement domain,accepted
 ```
 
 | ID | Decision | Status | SPIKE section |
@@ -333,7 +334,7 @@ flowchart LR
 | 3.4 | Narrative/playability model (typed narrative artifacts; no `StoryTags`) | accepted | §2.4 |
 | 3.5 | Engine boundary (adapter-only; reification-first; verified `effect:*`; `state:engine.*` transitional-only) | accepted | §2.5 |
 | 3.6 | Climate ownership (`ClimateField` vs engine rainfall) | accepted | §2.6 |
-| 3.7 | Placement inputs (explicit artifact vs engine reads) | open | §2.7 |
+| 3.7 | Placement inputs (explicit artifact vs engine reads) | accepted | §2.7 |
 | 3.8 | Artifact registry (names + schema ownership + versioning) | accepted | §2.8 |
 | 3.9 | Recipe schema (versioning + compatibility rules) | accepted | §2.9 |
 | 3.10 | Observability (required diagnostics + validation behavior) | accepted | §2.10 |

--- a/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
+++ b/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
@@ -99,10 +99,17 @@ via the recipe and carried in the compiled `ExecutionPlan` nodes.
 ### 1.5 Phase ownership (target surfaces)
 
 The concrete list of canonical artifacts/fields is a target sketch and is
-finalized via ADRs (pending decisions 3.3–3.7).
+finalized via ADRs (pending decisions 3.4, 3.6, 3.7).
 
-- Foundation: intended `artifact:mesh`, `artifact:crust`, `artifact:plateGraph`,
-  `artifact:tectonics` (pending 3.3).
+- Foundation (3.3 accepted): the foundation surface is **discrete artifacts**
+  (not a monolithic `FoundationContext`). The initial canonical tag set is
+  expected to look like:
+  - `artifact:foundation.mesh`
+  - `artifact:foundation.crust`
+  - `artifact:foundation.plateGraph`
+  - `artifact:foundation.tectonics`
+  Payload shapes may evolve during Phase B without blocking the rest of this
+  architecture.
 - Morphology: intended `field:heightfield` plus `artifact:terrainMask`,
   `artifact:erosion`, `artifact:sediment`.
 - Hydrology: intended `artifact:climateField` (rainfall + temperature) and
@@ -289,7 +296,7 @@ flowchart LR
   class engineBoundary boundary,accepted
   class observability boundary,accepted
 
-  class foundation domain,open
+  class foundation domain,accepted
   class story domain,open
   class climate domain,open
   class placement domain,open
@@ -299,7 +306,7 @@ flowchart LR
 | --- | --- | --- | --- |
 | 3.1 | Ordering source of truth (recipe vs manifest) | accepted | §2.1 |
 | 3.2 | Enablement model (recipe-only; remove `shouldRun`) | accepted | §2.2 |
-| 3.3 | Foundation surface (discrete artifacts vs `FoundationContext`) | open | §2.3 |
+| 3.3 | Foundation surface (discrete artifacts vs `FoundationContext`) | accepted | §2.3 |
 | 3.4 | Story model (overlays vs tags canonical) | open | §2.4 |
 | 3.5 | Engine boundary (adapter-only; reification-first; verified `effect:*`; `state:engine.*` transitional-only) | accepted | §2.5 |
 | 3.6 | Climate ownership (`ClimateField` vs engine rainfall) | open | §2.6 |

--- a/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
+++ b/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
@@ -110,6 +110,9 @@ finalized via ADRs (pending decisions 3.4, 3.6, 3.7).
   - `artifact:foundation.tectonics`
   Payload shapes may evolve during Phase B without blocking the rest of this
   architecture.
+  - Storage layout is not part of the contract: it is acceptable to group the
+    discrete artifacts under `context.artifacts.foundation.*` (or similar) for
+    ergonomics, but new work must not depend on `ctx.foundation.*`.
 - Morphology: intended `field:heightfield` plus `artifact:terrainMask`,
   `artifact:erosion`, `artifact:sediment`.
 - Hydrology: intended `artifact:climateField` (rainfall + temperature) and

--- a/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
+++ b/docs/projects/engine-refactor-v1/resources/SPEC-target-architecture-draft.md
@@ -110,9 +110,10 @@ finalized via ADRs (pending decisions 3.4, 3.6, 3.7).
   - `artifact:foundation.tectonics`
   Payload shapes may evolve during Phase B without blocking the rest of this
   architecture.
-  - Storage layout is not part of the contract: it is acceptable to group the
-    discrete artifacts under `context.artifacts.foundation.*` (or similar) for
-    ergonomics, but new work must not depend on `ctx.foundation.*`.
+  - Storage layout is **decided**: canonical storage is nested under
+    `context.artifacts.foundation.*` (e.g., `context.artifacts.foundation.mesh`),
+    but dependencies are still expressed via `artifact:*` tags (no blob
+    dependency). New work must not depend on `ctx.foundation.*`.
 - Morphology: intended `field:heightfield` plus `artifact:terrainMask`,
   `artifact:erosion`, `artifact:sediment`.
 - Hydrology: intended `artifact:climateField` (rainfall + temperature) and

--- a/docs/projects/engine-refactor-v1/resources/SPIKE-target-architecture-draft.md
+++ b/docs/projects/engine-refactor-v1/resources/SPIKE-target-architecture-draft.md
@@ -562,11 +562,14 @@ skips—only fail-fast validation/precondition errors.
 - The exact *payload shapes* of foundation artifacts may evolve during Phase B;
   what is locked now is the **contract direction**: no monolithic “foundation
   blob” as the canonical dependency surface.
-- Storage layout is explicitly *not* the contract:
-  - In target, new work should not depend on `ctx.foundation.*` at all.
-  - It is acceptable to group the discrete artifacts under
-    `context.artifacts.foundation.*` (or similar) for authoring ergonomics, as
-    long as `requires`/`provides` remain explicit per `artifact:*` tag.
+- Storage layout is **decided** (not deferred):
+  - Target canonical storage is nested under `context.artifacts.foundation.*`
+    (e.g., `context.artifacts.foundation.plateGraph`).
+  - `requires`/`provides` remain explicit per `artifact:*` tag (e.g.,
+    `artifact:foundation.plateGraph`); storage grouping must not reintroduce a
+    “blob dependency”.
+  - New work must not depend on `ctx.foundation.*` at all; `ctx.foundation` is
+    compatibility-only wiring to be removed under `DEF-014`.
 
 **What remains (implementation, not a decision):**
 - Phase B migration plan (tracked by `DEF-014`):

--- a/docs/projects/engine-refactor-v1/resources/SPIKE-target-architecture-draft.md
+++ b/docs/projects/engine-refactor-v1/resources/SPIKE-target-architecture-draft.md
@@ -562,6 +562,11 @@ skips—only fail-fast validation/precondition errors.
 - The exact *payload shapes* of foundation artifacts may evolve during Phase B;
   what is locked now is the **contract direction**: no monolithic “foundation
   blob” as the canonical dependency surface.
+- Storage layout is explicitly *not* the contract:
+  - In target, new work should not depend on `ctx.foundation.*` at all.
+  - It is acceptable to group the discrete artifacts under
+    `context.artifacts.foundation.*` (or similar) for authoring ergonomics, as
+    long as `requires`/`provides` remain explicit per `artifact:*` tag.
 
 **What remains (implementation, not a decision):**
 - Phase B migration plan (tracked by `DEF-014`):


### PR DESCRIPTION
# Update target architecture decisions and deferrals

This PR updates the target architecture documentation to reflect accepted decisions and clarify implementation deferrals:

1. **Foundation surface (3.3)**: Accepts that foundation outputs are discrete artifacts, not a monolithic `FoundationContext`. Clarifies storage layout under `context.artifacts.foundation.*`.

2. **Narrative/playability model (3.4)**: Accepts that narrative state is expressed as typed `artifact:narrative.*` products with no `StoryTags` dependency surface.

3. **Climate ownership (3.6)**: Accepts that `artifact:climateField` is TS-owned and canonical, with engine as a publish surface only.

4. **Placement inputs (3.7)**: Accepts that placement consumes an explicit `artifact:placementInputs@v1` with no implicit engine reads.

5. **Observability baseline (3.10)**: Defines required outputs (runId, plan fingerprint, structured errors) and optional tracing capabilities.

Updates M4 milestone plan with parent issues and estimates to complete the target architecture implementation.