### PR TITLE
docs(cli-orchestration): mark autonomous development variants as complete

### DIFF
--- a/docs/projects/cli-orchestration-v0/issues/LOCAL-TBD-dev-auto-variants.md
+++ b/docs/projects/cli-orchestration-v0/issues/LOCAL-TBD-dev-auto-variants.md
@@ -20,10 +20,10 @@ related_to: []
 - Create autonomous `dev-auto-*` prompt variants and the shared `autonomous-development` skill so the orchestrator can run without interactive worktree logic.
 
 ## Deliverables
-- `dev-auto-parallel` prompt variant aligned to the contract (structured JSON, no worktree lifecycle).
-- `dev-auto-review-linear` prompt variant aligned to the contract (structured JSON, no worktree lifecycle).
-- `dev-auto-fix-review` prompt variant aligned to the contract (structured JSON, no worktree lifecycle).
-- `autonomous-development` skill that codifies auto-safe constraints (worktree rules, Graphite allowlist, structured output).
+- [x] `dev-auto-parallel` prompt variant aligned to the contract (structured JSON, no worktree lifecycle).
+- [x] `dev-auto-review-linear` prompt variant aligned to the contract (structured JSON, no worktree lifecycle).
+- [x] `dev-auto-fix-review` prompt variant aligned to the contract (structured JSON, no worktree lifecycle).
+- [x] `autonomous-development` skill that codifies auto-safe constraints (worktree rules, Graphite allowlist, structured output).
 
 ## Acceptance Criteria
 - All three `dev-auto-*` variants reference the contract and emit required structured JSON.


### PR DESCRIPTION
### TL;DR

Marked all deliverables as completed in the autonomous development variants issue document.

### What changed?

Updated the status of all four deliverables in the `LOCAL-TBD-dev-auto-variants.md` issue document by adding `[x]` checkmarks to indicate completion:
- `dev-auto-parallel` prompt variant
- `dev-auto-review-linear` prompt variant
- `dev-auto-fix-review` prompt variant
- `autonomous-development` skill

### How to test?

Verify that all deliverables in the issue document are properly marked as completed and that the implementations meet the specified requirements for structured JSON output and autonomous operation without worktree lifecycle dependencies.

### Why make this change?

To track progress on the autonomous development variants implementation and indicate that all required deliverables have been successfully completed according to the acceptance criteria.