### PR TITLE
feat(cli): add orchestration script framework

### DIFF
--- a/scripts/cli-orchestration/orchestrate.ts
+++ b/scripts/cli-orchestration/orchestrate.ts
@@ -1,0 +1,53 @@
+import { parseArgs } from "node:util";
+import { join } from "node:path";
+import { runOrchestrator } from "./orchestrator.js";
+import type { OrchestratorConfig } from "./types.js";
+
+function usage(): string {
+  return [
+    "Usage:",
+    "  bun run scripts/cli-orchestration/orchestrate.ts --milestone <ID>",
+    "",
+    "Options:",
+    "  -m, --milestone   Milestone ID to run (required)",
+    "  --logs-root       Override logs root (default: logs/orch)",
+  ].join("\n");
+}
+
+function parseCliArgs() {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      milestone: { type: "string", short: "m" },
+      "logs-root": { type: "string" },
+    },
+  });
+
+  if (!values.milestone) {
+    console.error(usage());
+    process.exit(1);
+  }
+
+  return {
+    milestoneId: values.milestone,
+    logsRoot: values["logs-root"],
+  };
+}
+
+async function main() {
+  const { milestoneId, logsRoot } = parseCliArgs();
+  const repoRoot = process.cwd();
+
+  const config: OrchestratorConfig = {
+    repoRoot,
+    logsRoot: logsRoot ?? join(repoRoot, "logs", "orch"),
+    maxReviewCycles: 2,
+  };
+
+  await runOrchestrator(config, { milestoneId });
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/cli-orchestration/orchestrator.ts
+++ b/scripts/cli-orchestration/orchestrator.ts
@@ -1,0 +1,9 @@
+import type { OrchestratorConfig } from "./types.js";
+
+export interface OrchestratorArgs {
+  milestoneId: string;
+}
+
+export async function runOrchestrator(_config: OrchestratorConfig, _args: OrchestratorArgs) {
+  throw new Error("Orchestrator not implemented yet.");
+}

--- a/scripts/cli-orchestration/runner.ts
+++ b/scripts/cli-orchestration/runner.ts
@@ -1,0 +1,17 @@
+export interface RunnerInput {
+  prompt: string;
+  cwd: string;
+  schemaPath?: string;
+  logPath: string;
+  stderrPath: string;
+}
+
+export interface RunnerOutput<T> {
+  result: T;
+  exitCode: number;
+  rawEventsPath?: string;
+}
+
+export interface Runner {
+  run<T>(input: RunnerInput): Promise<RunnerOutput<T>>;
+}

--- a/scripts/cli-orchestration/types.ts
+++ b/scripts/cli-orchestration/types.ts
@@ -1,0 +1,75 @@
+export type Phase = "dev" | "review" | "fix";
+
+export type DevStatus = "pass" | "failed" | "deferred";
+export type ReviewStatus = "pass" | "changes_required" | "blocked";
+
+export interface PhaseBase {
+  phase: Phase;
+  status: string;
+  issueId: string;
+  milestoneId: string;
+  branch: string;
+  worktreePath: string;
+  summary: string;
+}
+
+export interface TestRun {
+  command: string;
+  status: "pass" | "fail" | "skipped";
+  notes?: string;
+}
+
+export interface ReviewIssue {
+  severity: "low" | "medium" | "high";
+  title: string;
+  details: string;
+  evidence?: string;
+}
+
+export interface DevResult extends PhaseBase {
+  phase: "dev" | "fix";
+  status: DevStatus;
+  testsRun?: TestRun[];
+  docsUpdated?: string[];
+  draftPrs?: string[];
+  stackBranches?: string[];
+  deferred?: string[];
+  openQuestions?: string[];
+}
+
+export interface ReviewResult extends PhaseBase {
+  phase: "review";
+  status: ReviewStatus;
+  issues?: ReviewIssue[];
+  requiredActions?: string[];
+  followups?: string[];
+  reviewDocPath?: string;
+  confidence?: "low" | "medium" | "high";
+}
+
+export interface IssueDoc {
+  id: string;
+  title: string;
+  project: string;
+  milestone?: string;
+  blocked_by?: string[];
+  blocked?: string[];
+  path: string;
+}
+
+export interface MilestoneDoc {
+  id: string;
+  path: string;
+}
+
+export interface IssuePlan {
+  issue: IssueDoc;
+  branchName: string;
+  worktreePath: string;
+}
+
+export interface OrchestratorConfig {
+  repoRoot: string;
+  logsRoot: string;
+  maxReviewCycles: number;
+}


### PR DESCRIPTION
### TL;DR

Added initial CLI orchestration framework for milestone-based development workflow.

### What changed?

Created a new CLI orchestration system with the following components:
- `orchestrate.ts`: Entry point script that parses command line arguments and runs the orchestrator
- `orchestrator.ts`: Core orchestrator function (currently a placeholder)
- `runner.ts`: Interface definitions for running commands
- `types.ts`: Type definitions for the orchestration system, including:
  - Phase types (dev, review, fix)
  - Status types for different phases
  - Interfaces for test runs, review issues, and results
  - Document structures for issues and milestones

The system is designed to manage development workflows through milestones, with support for multiple review cycles and structured logging.

### How to test?

Run the orchestration script with a milestone ID:
```
bun run scripts/cli-orchestration/orchestrate.ts --milestone <ID>
```

You can also override the logs directory:
```
bun run scripts/cli-orchestration/orchestrate.ts --milestone <ID> --logs-root <PATH>
```

Note: The orchestrator itself is not yet implemented and will throw an error.

### Why make this change?

This framework provides the foundation for automating development workflows through milestones. It will enable structured development phases (dev, review, fix), track issues through these phases, and maintain consistent logging of the process. The system is designed to improve development efficiency and ensure consistent quality through automated review cycles.