### PR TITLE
feat(cli): add Codex SDK runner and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,5 +89,9 @@
       "puppeteer",
       "sharp"
     ]
+  },
+  "dependencies": {
+    "@openai/codex-sdk": "^0.77.0",
+    "yaml": "^2.8.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,13 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      '@openai/codex-sdk':
+        specifier: ^0.77.0
+        version: 0.77.0
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -186,7 +193,7 @@ importers:
         version: 24.10.1
       bun-types:
         specifier: ^1.2.19
-        version: 1.3.4
+        version: 1.3.5
       oclif:
         specifier: ^4.22.6
         version: 4.22.54(@types/node@24.10.1)
@@ -230,7 +237,7 @@ importers:
     devDependencies:
       bun-types:
         specifier: latest
-        version: 1.3.4
+        version: 1.3.5
       esbuild:
         specifier: ^0.27.0
         version: 0.27.1
@@ -1354,6 +1361,10 @@ packages:
   '@oclif/plugin-warn-if-update-available@3.1.53':
     resolution: {integrity: sha512-ALxKMNFFJQJV1Z2OMVTV+q7EbKHhnTAPcTgkgHeXCNdW5nFExoXuwusZLS4Zv2o83j9UoDx1R/CSX7QZVgEHTA==}
     engines: {node: '>=18.0.0'}
+
+  '@openai/codex-sdk@0.77.0':
+    resolution: {integrity: sha512-bvJQ4dASnZ7jgfxmseViQwdRupHxs0TwHSZFeYB0gpdOAXnWwDWdGJRCMyphLSHwExRp27JNOk7EBFVmZRBanQ==}
+    engines: {node: '>=18'}
 
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':
     resolution: {integrity: sha512-Gj6C0JwCr8arj0sYuslWXUBSP/KnUlEGnPW4qxlXvAl543oaNQgMgIgkQUA6vs5BCCvwTEiL8m/wdWzfl4UvSw==}
@@ -2649,8 +2660,8 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
-  bun-types@1.3.4:
-    resolution: {integrity: sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ==}
+  bun-types@1.3.5:
+    resolution: {integrity: sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -5117,7 +5128,7 @@ packages:
   puppeteer@22.14.0:
     resolution: {integrity: sha512-MGTR6/pM8zmWbTdazb6FKnwIihzsSEXBPH49mFFU96DNZpQOevCAZMnjBZGlZRGRzRK6aADCavR6SQtrbv5dQw==}
     engines: {node: '>=18'}
-    deprecated: < 24.15.0 is no longer supported
+    deprecated: < 24.9.0 is no longer supported
     hasBin: true
 
   qs@6.11.0:
@@ -7917,6 +7928,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@openai/codex-sdk@0.77.0': {}
+
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':
     dependencies:
       fast-deep-equal: 3.1.3
@@ -9343,7 +9356,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bun-types@1.3.4:
+  bun-types@1.3.5:
     dependencies:
       '@types/node': 24.10.1
 

--- a/scripts/cli-orchestration/codex-sdk-runner.ts
+++ b/scripts/cli-orchestration/codex-sdk-runner.ts
@@ -1,0 +1,64 @@
+import { createWriteStream, promises as fs } from "node:fs";
+import { dirname } from "node:path";
+import { Codex } from "@openai/codex-sdk";
+import type { Runner, RunnerInput, RunnerOutput } from "./runner.js";
+
+async function loadSchema(schemaPath?: string): Promise<unknown | undefined> {
+  if (!schemaPath) {
+    return undefined;
+  }
+  const raw = await fs.readFile(schemaPath, "utf8");
+  return JSON.parse(raw) as unknown;
+}
+
+async function ensureParentDir(path: string) {
+  await fs.mkdir(dirname(path), { recursive: true });
+}
+
+export class CodexSdkRunner implements Runner {
+  private codex: Codex;
+
+  constructor() {
+    this.codex = new Codex();
+  }
+
+  async run<T>(input: RunnerInput): Promise<RunnerOutput<T>> {
+    await ensureParentDir(input.logPath);
+    await ensureParentDir(input.stderrPath);
+
+    const logStream = createWriteStream(input.logPath, { flags: "w" });
+    let exitCode = 0;
+
+    try {
+      const thread = this.codex.startThread({
+        workingDirectory: input.cwd,
+      });
+
+      const outputSchema = await loadSchema(input.schemaPath);
+      const { events } = await thread.runStreamed(input.prompt, { outputSchema });
+
+      let finalMessage: string | undefined;
+      for await (const event of events) {
+        logStream.write(`${JSON.stringify(event)}\n`);
+        if (event.type === "item.completed" && event.item.type === "agent_message") {
+          finalMessage = event.item.text;
+        }
+      }
+
+      logStream.end();
+
+      if (!finalMessage) {
+        throw new Error("Codex SDK did not return a final agent message.");
+      }
+
+      const result = JSON.parse(finalMessage) as T;
+      return { result, exitCode, rawEventsPath: input.logPath };
+    } catch (error) {
+      exitCode = 1;
+      logStream.end();
+      const message = error instanceof Error ? error.message : String(error);
+      await fs.writeFile(input.stderrPath, `${message}\n`, "utf8");
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
### TL;DR

Added OpenAI Codex SDK integration for CLI orchestration.

### What changed?

- Added `@openai/codex-sdk` and `yaml` dependencies to package.json
- Created a new `CodexSdkRunner` class in `scripts/cli-orchestration/codex-sdk-runner.ts` that implements the `Runner` interface
- The new runner uses the Codex SDK to process prompts and return structured results
- Updated pnpm-lock.yaml with the new dependencies and version updates

### How to test?

1. Install the new dependencies with `pnpm install`
2. Use the `CodexSdkRunner` in CLI orchestration by importing it from `./scripts/cli-orchestration/codex-sdk-runner.js`
3. Create a runner instance and call its `run` method with appropriate `RunnerInput`
4. Verify that the runner correctly processes prompts and returns structured results

### Why make this change?

This change adds support for the OpenAI Codex SDK, allowing the application to leverage Codex's capabilities for processing prompts and generating structured outputs. The implementation follows the existing runner interface pattern, making it easy to integrate with the current CLI orchestration system.