### PR TITLE
feat(cli-orchestration): add issue selection to orchestrator

### DIFF
--- a/scripts/cli-orchestration/orchestrate.ts
+++ b/scripts/cli-orchestration/orchestrate.ts
@@ -10,6 +10,7 @@ function usage(): string {
     "",
     "Options:",
     "  -m, --milestone   Milestone ID to run (required)",
+    "  -i, --issue       Issue ID to run (optional, defaults to first)",
     "  --logs-root       Override logs root (default: logs/orch)",
   ].join("\n");
 }
@@ -19,6 +20,7 @@ function parseCliArgs() {
     args: process.argv.slice(2),
     options: {
       milestone: { type: "string", short: "m" },
+      issue: { type: "string", short: "i" },
       "logs-root": { type: "string" },
     },
   });
@@ -30,12 +32,13 @@ function parseCliArgs() {
 
   return {
     milestoneId: values.milestone,
+    issueId: values.issue,
     logsRoot: values["logs-root"],
   };
 }
 
 async function main() {
-  const { milestoneId, logsRoot } = parseCliArgs();
+  const { milestoneId, issueId, logsRoot } = parseCliArgs();
   const repoRoot = process.cwd();
 
   const config: OrchestratorConfig = {
@@ -44,7 +47,7 @@ async function main() {
     maxReviewCycles: 2,
   };
 
-  await runOrchestrator(config, { milestoneId });
+  await runOrchestrator(config, { milestoneId, issueId });
 }
 
 main().catch((error) => {

--- a/scripts/cli-orchestration/orchestrator.ts
+++ b/scripts/cli-orchestration/orchestrator.ts
@@ -1,9 +1,61 @@
-import type { OrchestratorConfig } from "./types.js";
+import { join } from "node:path";
+import { CodexSdkRunner } from "./codex-sdk-runner.js";
+import { loadIssuesByMilestone, orderIssuesLinear } from "./issue-discovery.js";
+import { renderPrompt } from "./prompt-renderer.js";
+import type { DevResult, IssueDoc, OrchestratorConfig } from "./types.js";
+import { deriveBranchName, ensureWorktree, removeWorktree } from "./worktree.js";
 
 export interface OrchestratorArgs {
   milestoneId: string;
+  issueId?: string;
 }
 
-export async function runOrchestrator(_config: OrchestratorConfig, _args: OrchestratorArgs) {
-  throw new Error("Orchestrator not implemented yet.");
+function selectIssue(issues: IssueDoc[], issueId?: string): IssueDoc {
+  if (!issueId) {
+    return issues[0];
+  }
+  const match = issues.find((issue) => issue.id === issueId);
+  if (!match) {
+    throw new Error(`Issue ${issueId} not found in milestone list.`);
+  }
+  return match;
+}
+
+export async function runOrchestrator(config: OrchestratorConfig, args: OrchestratorArgs) {
+  const issues = orderIssuesLinear(await loadIssuesByMilestone(config.repoRoot, args.milestoneId));
+  if (issues.length === 0) {
+    throw new Error(`No issues found for milestone ${args.milestoneId}.`);
+  }
+
+  const issue = selectIssue(issues, args.issueId);
+  const branchName = deriveBranchName(issue.id, issue.title);
+  const worktreePath = await ensureWorktree(config.repoRoot, branchName, "main");
+
+  try {
+    const prompt = await renderPrompt("dev-auto-parallel", {
+      issueId: issue.id,
+      issueDocPath: issue.path,
+      milestoneId: args.milestoneId,
+      milestoneDocPath: "",
+      branchName,
+      worktreePath,
+      maxReviewCycles: config.maxReviewCycles,
+      reviewCycle: 1,
+    });
+
+    const logRoot = join(config.logsRoot, args.milestoneId, issue.id);
+    const runner = new CodexSdkRunner();
+
+    const result = await runner.run<DevResult>({
+      prompt,
+      cwd: worktreePath,
+      schemaPath: join(config.repoRoot, "scripts", "cli-orchestration", "schemas", "dev.schema.json"),
+      logPath: join(logRoot, "dev.jsonl"),
+      stderrPath: join(logRoot, "dev.stderr.log"),
+    });
+
+    return result;
+  } finally {
+    await removeWorktree(config.repoRoot, worktreePath);
+  }
 }

--- a/scripts/cli-orchestration/prompt-renderer.ts
+++ b/scripts/cli-orchestration/prompt-renderer.ts
@@ -1,0 +1,45 @@
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface OrchContext {
+  issueId: string;
+  issueDocPath: string;
+  milestoneId: string;
+  milestoneDocPath: string;
+  branchName: string;
+  worktreePath: string;
+  maxReviewCycles: number;
+  reviewCycle: number;
+  priorFixSummary?: string;
+  reviewResult?: unknown;
+}
+
+const FRONT_MATTER_BOUNDARY = "---";
+
+function stripFrontMatter(content: string): string {
+  if (!content.startsWith(FRONT_MATTER_BOUNDARY)) {
+    return content;
+  }
+  const endIndex = content.indexOf(`\n${FRONT_MATTER_BOUNDARY}`, FRONT_MATTER_BOUNDARY.length);
+  if (endIndex === -1) {
+    return content;
+  }
+  return content.slice(endIndex + FRONT_MATTER_BOUNDARY.length + 1);
+}
+
+function promptDir(): string {
+  return process.env.CODEX_PROMPTS_DIR ?? join(homedir(), ".codex", "prompts");
+}
+
+export async function loadPromptTemplate(name: string): Promise<string> {
+  const path = join(promptDir(), `${name}.md`);
+  return fs.readFile(path, "utf8");
+}
+
+export async function renderPrompt(name: string, context: OrchContext): Promise<string> {
+  const template = await loadPromptTemplate(name);
+  const body = stripFrontMatter(template).trim();
+  const contextBlock = `ORCH_CONTEXT:\n${JSON.stringify(context)}`;
+  return `${contextBlock}\n\n${body}`;
+}

--- a/scripts/cli-orchestration/schemas/dev.schema.json
+++ b/scripts/cli-orchestration/schemas/dev.schema.json
@@ -1,0 +1,40 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "phase",
+    "status",
+    "issueId",
+    "milestoneId",
+    "branch",
+    "worktreePath",
+    "summary"
+  ],
+  "properties": {
+    "phase": { "type": "string", "enum": ["dev", "fix"] },
+    "status": { "type": "string", "enum": ["pass", "failed", "deferred"] },
+    "issueId": { "type": "string" },
+    "milestoneId": { "type": "string" },
+    "branch": { "type": "string" },
+    "worktreePath": { "type": "string" },
+    "summary": { "type": "string" },
+    "testsRun": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["command", "status"],
+        "properties": {
+          "command": { "type": "string" },
+          "status": { "type": "string", "enum": ["pass", "fail", "skipped"] },
+          "notes": { "type": "string" }
+        }
+      }
+    },
+    "docsUpdated": { "type": "array", "items": { "type": "string" } },
+    "draftPrs": { "type": "array", "items": { "type": "string" } },
+    "stackBranches": { "type": "array", "items": { "type": "string" } },
+    "deferred": { "type": "array", "items": { "type": "string" } },
+    "openQuestions": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/scripts/cli-orchestration/shell.ts
+++ b/scripts/cli-orchestration/shell.ts
@@ -1,0 +1,23 @@
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export async function runCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string },
+): Promise<CommandResult> {
+  const proc = Bun.spawn([command, ...args], {
+    cwd: options.cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+
+  return { exitCode, stdout, stderr };
+}

--- a/scripts/cli-orchestration/worktree.ts
+++ b/scripts/cli-orchestration/worktree.ts
@@ -1,0 +1,64 @@
+import { promises as fs } from "node:fs";
+import { resolve } from "node:path";
+import { runCommand } from "./shell.js";
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await fs.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function branchExists(repoRoot: string, branchName: string): Promise<boolean> {
+  const result = await runCommand(
+    "git",
+    ["show-ref", "--verify", "--quiet", `refs/heads/${branchName}`],
+    { cwd: repoRoot },
+  );
+  return result.exitCode === 0;
+}
+
+export function deriveBranchName(issueId: string, title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+  return `${issueId}-${slug}`;
+}
+
+export function issueWorktreePath(repoRoot: string, branchName: string): string {
+  return resolve(repoRoot, "..", `wt-${branchName}`);
+}
+
+export async function ensureWorktree(
+  repoRoot: string,
+  branchName: string,
+  parentBranch: string,
+): Promise<string> {
+  const worktreePath = issueWorktreePath(repoRoot, branchName);
+
+  if (await pathExists(worktreePath)) {
+    return worktreePath;
+  }
+
+  const exists = await branchExists(repoRoot, branchName);
+  const args = exists
+    ? ["worktree", "add", worktreePath, branchName]
+    : ["worktree", "add", "-b", branchName, worktreePath, parentBranch];
+
+  const result = await runCommand("git", args, { cwd: repoRoot });
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to create worktree: ${result.stderr || result.stdout}`);
+  }
+
+  return worktreePath;
+}
+
+export async function removeWorktree(repoRoot: string, worktreePath: string): Promise<void> {
+  const result = await runCommand("git", ["worktree", "remove", worktreePath], { cwd: repoRoot });
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to remove worktree: ${result.stderr || result.stdout}`);
+  }
+}


### PR DESCRIPTION
### TL;DR

Added issue selection capability to the CLI orchestration tool and implemented the core orchestrator functionality.

### What changed?

- Added a new `-i, --issue` CLI option to allow selecting a specific issue to work on
- Implemented the `runOrchestrator` function that was previously a stub
- Created a prompt rendering system that loads templates and injects context
- Added Git worktree management utilities to create isolated development environments
- Implemented shell command execution utilities for Git operations
- Added a JSON schema for validating development results

### How to test?

Run the orchestration tool with a milestone and optionally an issue ID:

```bash
# Run with just a milestone (uses first issue)
bun run scripts/cli-orchestration/orchestrate.ts -m milestone-id

# Run with a specific issue
bun run scripts/cli-orchestration/orchestrate.ts -m milestone-id -i issue-id
```

### Why make this change?

This change enables the CLI orchestration tool to process issues from a milestone, create isolated Git worktrees for development, and execute the development workflow. The addition of issue selection allows for more targeted development when working on specific issues within a milestone.