### PR TITLE
feat(cli-orchestration): add JSON logging and ignore logs/orch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ Thumbs.db
 !.ai/archive/
 !.ai/archive/**
 .claude/settings.local.json
+logs/orch/

--- a/scripts/cli-orchestration/logging.ts
+++ b/scripts/cli-orchestration/logging.ts
@@ -1,0 +1,7 @@
+import { promises as fs } from "node:fs";
+import { dirname } from "node:path";
+
+export async function writeJson(path: string, data: unknown) {
+  await fs.mkdir(dirname(path), { recursive: true });
+  await fs.writeFile(path, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}

--- a/scripts/cli-orchestration/orchestrator.ts
+++ b/scripts/cli-orchestration/orchestrator.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { CodexSdkRunner } from "./codex-sdk-runner.js";
 import { loadIssuesByMilestone, orderIssuesLinear } from "./issue-discovery.js";
+import { writeJson } from "./logging.js";
 import { renderPrompt } from "./prompt-renderer.js";
 import type { DevResult, IssueDoc, OrchestratorConfig } from "./types.js";
 import { deriveBranchName, ensureWorktree, removeWorktree } from "./worktree.js";
@@ -53,6 +54,8 @@ export async function runOrchestrator(config: OrchestratorConfig, args: Orchestr
       logPath: join(logRoot, "dev.jsonl"),
       stderrPath: join(logRoot, "dev.stderr.log"),
     });
+
+    await writeJson(join(logRoot, "dev-result.json"), result.result);
 
     return result;
   } finally {


### PR DESCRIPTION
### TL;DR

Added JSON logging capability to the CLI orchestration system.

### What changed?

- Created a new `logging.ts` module with a `writeJson` utility function
- Added logging of development results to JSON files in a logs directory
- Updated `.gitignore` to exclude the `logs/orch/` directory from version control
- Integrated the logging functionality into the orchestrator workflow

### How to test?

1. Run the orchestrator with any configuration
2. Verify that a `dev-result.json` file is created in the logs directory
3. Check that the JSON file contains the expected development result data

### Why make this change?

This change improves debugging and analysis capabilities by persisting development results to disk in a structured JSON format. This allows for better tracking of orchestration runs and makes it easier to inspect the outputs without having to rely solely on console logs.