### PR TITLE
feat(viz): foundation plate formation dumps + MapGen Studio viewer (v0)

### DIFF
--- a/apps/mapgen-studio/package.json
+++ b/apps/mapgen-studio/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@deck.gl/core": "^9.0.43",
+    "@deck.gl/layers": "^9.0.43",
+    "@deck.gl/react": "^9.0.43",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/apps/mapgen-studio/src/App.tsx
+++ b/apps/mapgen-studio/src/App.tsx
@@ -1,25 +1,1004 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { DeckGL } from "@deck.gl/react";
+import { OrthographicView } from "@deck.gl/core";
+import { PathLayer, ScatterplotLayer, PolygonLayer } from "@deck.gl/layers";
+
+type Bounds = [minX: number, minY: number, maxX: number, maxY: number];
+
+type VizScalarFormat = "u8" | "i8" | "u16" | "i16" | "i32" | "f32";
+
+type VizLayerEntryV0 =
+  | {
+      kind: "grid";
+      layerId: string;
+      stepId: string;
+      phase?: string;
+      stepIndex: number;
+      format: VizScalarFormat;
+      dims: { width: number; height: number };
+      path: string;
+      bounds: Bounds;
+    }
+  | {
+      kind: "points";
+      layerId: string;
+      stepId: string;
+      phase?: string;
+      stepIndex: number;
+      count: number;
+      positionsPath: string;
+      valuesPath?: string;
+      valueFormat?: VizScalarFormat;
+      bounds: Bounds;
+    }
+  | {
+      kind: "segments";
+      layerId: string;
+      stepId: string;
+      phase?: string;
+      stepIndex: number;
+      count: number;
+      segmentsPath: string;
+      valuesPath?: string;
+      valueFormat?: VizScalarFormat;
+      bounds: Bounds;
+    };
+
+type VizManifestV0 = {
+  version: 0;
+  runId: string;
+  planFingerprint: string;
+  steps: Array<{ stepId: string; phase?: string; stepIndex: number }>;
+  layers: VizLayerEntryV0[];
+};
+
+type FileMap = Map<string, File>;
+
+type EraLayerInfo = { eraIndex: number; baseLayerId: string };
+
+function stripRootDirPrefix(path: string): string {
+  const parts = path.split("/").filter(Boolean);
+  if (parts.length <= 1) return path;
+  return parts.slice(1).join("/");
+}
+
+function formatLabel(stepId: string): string {
+  return stepId.split(".").slice(-1)[0] ?? stepId;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function niceStep(target: number): number {
+  const t = Math.max(1e-9, target);
+  const pow = Math.pow(10, Math.floor(Math.log10(t)));
+  const scaled = t / pow;
+  if (scaled <= 1) return 1 * pow;
+  if (scaled <= 2) return 2 * pow;
+  if (scaled <= 5) return 5 * pow;
+  return 10 * pow;
+}
+
+function axialToPixelPointy(q: number, r: number, size: number): [number, number] {
+  const x = size * Math.sqrt(3) * (q + r / 2);
+  const y = size * 1.5 * r;
+  return [x, y];
+}
+
+type TileLayout = "row-offset" | "col-offset";
+
+function oddQToAxialR(row: number, colParityBase: number): number {
+  const q = colParityBase | 0;
+  return row - (q - (q & 1)) / 2;
+}
+
+function oddQTileCenter(col: number, row: number, size: number): [number, number] {
+  const r = oddQToAxialR(row, col);
+  return axialToPixelPointy(col, r, size);
+}
+
+function oddQPointFromTileXY(x: number, y: number, size: number): [number, number] {
+  const qParityBase = Math.round(x);
+  const r = oddQToAxialR(y, qParityBase);
+  return axialToPixelPointy(x, r, size);
+}
+
+function oddRTileCenter(col: number, row: number, size: number): [number, number] {
+  // Pointy-top, rows offset horizontally.
+  // Equivalent to: axial(q = col - (row - (row&1))/2, r = row) → pointy pixel.
+  const x = size * Math.sqrt(3) * (col + ((row & 1) ? 0.5 : 0));
+  const y = size * 1.5 * row;
+  return [x, y];
+}
+
+function oddRPointFromTileXY(x: number, y: number, size: number): [number, number] {
+  // Use the integer row parity for horizontal shift; y may be fractional for centroids.
+  const row = Math.floor(y);
+  const px = size * Math.sqrt(3) * (x + ((row & 1) ? 0.5 : 0));
+  const py = size * 1.5 * y;
+  return [px, py];
+}
+
+function hexPolygonPointy(center: [number, number], size: number): Array<[number, number]> {
+  const [cx, cy] = center;
+  const out: Array<[number, number]> = [];
+  for (let i = 0; i < 6; i++) {
+    const angle = ((30 + 60 * i) * Math.PI) / 180;
+    out.push([cx + size * Math.cos(angle), cy + size * Math.sin(angle)]);
+  }
+  return out;
+}
+
+function boundsForTileGrid(layout: TileLayout, dims: { width: number; height: number }, size: number): Bounds {
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  for (let y = 0; y < dims.height; y++) {
+    for (let x = 0; x < dims.width; x++) {
+      const [cx, cy] = layout === "col-offset" ? oddQTileCenter(x, y, size) : oddRTileCenter(x, y, size);
+      minX = Math.min(minX, cx - size);
+      maxX = Math.max(maxX, cx + size);
+      minY = Math.min(minY, cy - size);
+      maxY = Math.max(maxY, cy + size);
+    }
+  }
+
+  if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
+    return [0, 0, 1, 1];
+  }
+
+  return [minX, minY, maxX, maxY];
+}
+
+function fitToBounds(bounds: Bounds, viewport: { width: number; height: number }): { target: [number, number, number]; zoom: number } {
+  const [minX, minY, maxX, maxY] = bounds;
+  const bw = Math.max(1e-6, maxX - minX);
+  const bh = Math.max(1e-6, maxY - minY);
+  const padding = 0.92;
+  const scale = Math.min((viewport.width * padding) / bw, (viewport.height * padding) / bh);
+  const zoom = Math.log2(Math.max(1e-6, scale));
+  return { target: [(minX + maxX) / 2, (minY + maxY) / 2, 0], zoom };
+}
+
+function colorForValue(layerId: string, value: number): [number, number, number, number] {
+  if (!Number.isFinite(value)) return [120, 120, 120, 220];
+
+  if (layerId.includes("crust") && layerId.toLowerCase().includes("type")) {
+    return value === 1 ? [34, 197, 94, 230] : [37, 99, 235, 230];
+  }
+
+  if (layerId.includes("boundaryType")) {
+    if (value === 1) return [239, 68, 68, 240];
+    if (value === 2) return [59, 130, 246, 240];
+    if (value === 3) return [245, 158, 11, 240];
+    return [107, 114, 128, 180];
+  }
+
+  if (layerId.includes("plate")) {
+    // stable hash color for categorical IDs
+    const v = (value | 0) >>> 0;
+    const r = (v * 97) % 255;
+    const g = (v * 57) % 255;
+    const b = (v * 23) % 255;
+    return [r, g, b, 230];
+  }
+
+  // generic 0..1 mapping
+  const t = clamp(value, 0, 1);
+  const r = Math.round(255 * t);
+  const b = Math.round(255 * (1 - t));
+  return [r, 80, b, 230];
+}
+
+type LegendItem = { label: string; color: [number, number, number, number] };
+
+function legendForLayer(layer: VizLayerEntryV0 | null, stats: { min?: number; max?: number } | null): { title: string; items: LegendItem[]; note?: string } | null {
+  if (!layer) return null;
+  const id = layer.layerId;
+
+  if (id.endsWith("tileBoundaryType") || id.endsWith("boundaryType") || id.includes("boundaryType")) {
+    return {
+      title: "Boundary Type",
+      items: [
+        { label: "0 = none/unknown", color: [107, 114, 128, 180] },
+        { label: "1 = convergent", color: [239, 68, 68, 240] },
+        { label: "2 = divergent", color: [59, 130, 246, 240] },
+        { label: "3 = transform", color: [245, 158, 11, 240] },
+      ],
+    };
+  }
+
+  if (id.includes("crusttiles") || id.includes("crust") && id.toLowerCase().includes("type")) {
+    return {
+      title: "Crust Type",
+      items: [
+        { label: "0 = oceanic", color: [37, 99, 235, 230] },
+        { label: "1 = continental", color: [34, 197, 94, 230] },
+      ],
+    };
+  }
+
+  if (id.includes("plate") && (id.toLowerCase().includes("id") || id.toLowerCase().includes("plate"))) {
+    return {
+      title: "Plate IDs",
+      items: [
+        { label: "categorical (stable hashed color by ID)", color: [148, 163, 184, 220] },
+      ],
+    };
+  }
+
+  if (stats && Number.isFinite(stats.min) && Number.isFinite(stats.max)) {
+    const min = stats.min ?? 0;
+    const max = stats.max ?? 1;
+    return {
+      title: "Scalar",
+      items: [
+        { label: `min = ${min.toFixed(3)}`, color: colorForValue(id, 0) },
+        { label: `max = ${max.toFixed(3)}`, color: colorForValue(id, 1) },
+      ],
+      note: "Values are mapped with a simple palette in V0.",
+    };
+  }
+
+  return {
+    title: "Legend",
+    items: [{ label: "no legend available for this layer yet", color: [148, 163, 184, 220] }],
+  };
+}
+
+function parseTectonicHistoryEraLayerId(layerId: string): EraLayerInfo | null {
+  // e.g. foundation.tectonicHistory.era3.upliftPotential
+  const m = /^foundation\.tectonicHistory\.era(\d+)\.(.+)$/.exec(layerId);
+  if (!m) return null;
+  const eraIndex = Number.parseInt(m[1] ?? "", 10);
+  const baseLayerId = String(m[2] ?? "");
+  if (!Number.isFinite(eraIndex) || eraIndex < 0 || !baseLayerId) return null;
+  return { eraIndex, baseLayerId };
+}
+
+function decodeScalarArray(buffer: ArrayBuffer, format: VizScalarFormat): ArrayBufferView {
+  switch (format) {
+    case "u8":
+      return new Uint8Array(buffer);
+    case "i8":
+      return new Int8Array(buffer);
+    case "u16":
+      return new Uint16Array(buffer);
+    case "i16":
+      return new Int16Array(buffer);
+    case "i32":
+      return new Int32Array(buffer);
+    case "f32":
+      return new Float32Array(buffer);
+  }
+}
+
+async function readFileAsArrayBuffer(file: File): Promise<ArrayBuffer> {
+  return await file.arrayBuffer();
+}
+
+async function readFileAsText(file: File): Promise<string> {
+  return await file.text();
+}
+
+async function loadManifestFromFileMap(fileMap: FileMap): Promise<VizManifestV0> {
+  const manifestFile = fileMap.get("manifest.json");
+  if (!manifestFile) {
+    throw new Error("manifest.json not found. Select the run folder that contains manifest.json.");
+  }
+  const text = await readFileAsText(manifestFile);
+  return JSON.parse(text) as VizManifestV0;
+}
+
 export function App() {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [viewportSize, setViewportSize] = useState({ width: 800, height: 600 });
+  const isNarrow = viewportSize.width < 760;
+
+  const [fileMap, setFileMap] = useState<FileMap | null>(null);
+  const [manifest, setManifest] = useState<VizManifestV0 | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
+  const [selectedLayerKey, setSelectedLayerKey] = useState<string | null>(null);
+
+  const [viewState, setViewState] = useState<any>({ target: [0, 0, 0], zoom: 0 });
+  const [layerStats, setLayerStats] = useState<{ min?: number; max?: number } | null>(null);
+  const [tileLayout, setTileLayout] = useState<TileLayout>("row-offset");
+  const [showMeshEdges, setShowMeshEdges] = useState(true);
+  const [showBackgroundGrid, setShowBackgroundGrid] = useState(true);
+  const [eraIndex, setEraIndex] = useState<number>(0);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => {
+      const rect = el.getBoundingClientRect();
+      setViewportSize({ width: Math.max(1, rect.width), height: Math.max(1, rect.height) });
+    };
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  const steps = useMemo(() => {
+    if (!manifest) return [];
+    return [...manifest.steps].sort((a, b) => a.stepIndex - b.stepIndex);
+  }, [manifest]);
+
+  const layersForStep = useMemo(() => {
+    if (!manifest || !selectedStepId) return [];
+    return manifest.layers
+      .filter((l) => l.stepId === selectedStepId)
+      .map((l) => ({ key: `${l.stepId}::${l.layerId}::${l.kind}`, layer: l }));
+  }, [manifest, selectedStepId]);
+
+  const selectedLayer = useMemo(() => {
+    if (!layersForStep.length || !selectedLayerKey) return null;
+    return layersForStep.find((l) => l.key === selectedLayerKey)?.layer ?? null;
+  }, [layersForStep, selectedLayerKey]);
+
+  const eraInfo = useMemo(() => {
+    if (!selectedLayer) return null;
+    return parseTectonicHistoryEraLayerId(selectedLayer.layerId);
+  }, [selectedLayer]);
+
+  const eraMax = useMemo(() => {
+    if (!manifest || !selectedStepId || !eraInfo) return null;
+    let max = -1;
+    const prefix = `foundation.tectonicHistory.era`;
+    const suffix = `.${eraInfo.baseLayerId}`;
+    for (const layer of manifest.layers) {
+      if (layer.stepId !== selectedStepId) continue;
+      if (!layer.layerId.startsWith(prefix)) continue;
+      if (!layer.layerId.endsWith(suffix)) continue;
+      const info = parseTectonicHistoryEraLayerId(layer.layerId);
+      if (!info) continue;
+      if (info.baseLayerId !== eraInfo.baseLayerId) continue;
+      if (info.eraIndex > max) max = info.eraIndex;
+    }
+    return max >= 0 ? max : null;
+  }, [manifest, selectedStepId, eraInfo]);
+
+  const effectiveLayer = useMemo(() => {
+    if (!manifest || !selectedStepId || !selectedLayer) return selectedLayer;
+    if (!eraInfo) return selectedLayer;
+    const idx = eraMax != null ? clamp(eraIndex, 0, eraMax) : eraIndex;
+    const desiredId = `foundation.tectonicHistory.era${idx}.${eraInfo.baseLayerId}`;
+    return (
+      manifest.layers.find((l) => l.stepId === selectedStepId && l.layerId === desiredId) ?? selectedLayer
+    );
+  }, [manifest, selectedStepId, selectedLayer, eraInfo, eraIndex, eraMax]);
+
+  const setFittedView = useCallback(
+    (bounds: Bounds) => {
+      const fit = fitToBounds(bounds, viewportSize);
+      setViewState((prev: any) => ({ ...prev, ...fit }));
+    },
+    [viewportSize]
+  );
+
+  const openDumpFolder = useCallback(async () => {
+    setError(null);
+    try {
+      const anyWindow = window as any;
+      if (typeof anyWindow.showDirectoryPicker === "function") {
+        const dirHandle: any = await anyWindow.showDirectoryPicker();
+        const files: FileMap = new Map();
+
+        const walk = async (handle: any, prefix: string) => {
+          for await (const [name, entry] of handle.entries()) {
+            const path = prefix ? `${prefix}/${name}` : name;
+            if (entry.kind === "directory") {
+              await walk(entry, path);
+            } else if (entry.kind === "file") {
+              const file = await entry.getFile();
+              files.set(path, file);
+            }
+          }
+        };
+
+        await walk(dirHandle, "");
+        // If the selected folder is the run folder, manifest.json should be at root.
+        // If it was selected with an extra parent dir, allow stripping one leading component.
+        const normalized: FileMap = new Map();
+        for (const [path, file] of files.entries()) {
+          normalized.set(path, file);
+          normalized.set(stripRootDirPrefix(path), file);
+        }
+        setFileMap(normalized);
+        const m = await loadManifestFromFileMap(normalized);
+        setManifest(m);
+        const firstStep = [...m.steps].sort((a, b) => a.stepIndex - b.stepIndex)[0]?.stepId ?? null;
+        setSelectedStepId(firstStep);
+        setSelectedLayerKey(null);
+        setFittedView([0, 0, 1, 1]);
+        return;
+      }
+
+      // Fallback: directory upload (Chromium via webkitdirectory).
+      setError("Your browser does not support folder picking. Use a Chromium-based browser, or enable directory picking.");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [setFittedView]);
+
+  const directoryInputRef = useRef<HTMLInputElement | null>(null);
+  const onDirectoryFiles = useCallback(async () => {
+    setError(null);
+    try {
+      const input = directoryInputRef.current;
+      if (!input?.files) return;
+      const files: FileMap = new Map();
+      for (const file of Array.from(input.files)) {
+        const rel = (file as any).webkitRelativePath ? String((file as any).webkitRelativePath) : file.name;
+        files.set(stripRootDirPrefix(rel), file);
+      }
+      setFileMap(files);
+      const m = await loadManifestFromFileMap(files);
+      setManifest(m);
+      const firstStep = [...m.steps].sort((a, b) => a.stepIndex - b.stepIndex)[0]?.stepId ?? null;
+      setSelectedStepId(firstStep);
+      setSelectedLayerKey(null);
+      setFittedView([0, 0, 1, 1]);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [setFittedView]);
+
+  useEffect(() => {
+    if (!manifest || !selectedStepId) return;
+    const first = manifest.layers
+      .filter((l) => l.stepId === selectedStepId)
+      .sort((a, b) => a.stepIndex - b.stepIndex)[0];
+    if (!first) return;
+    const key = `${first.stepId}::${first.layerId}::${first.kind}`;
+    setSelectedLayerKey(key);
+    if (first.kind === "grid") {
+      setFittedView(boundsForTileGrid(tileLayout, first.dims, 1));
+    } else {
+      setFittedView(first.bounds);
+    }
+  }, [manifest, selectedStepId, setFittedView, tileLayout]);
+
+  useEffect(() => {
+    if (!eraInfo) return;
+    setEraIndex(eraInfo.eraIndex);
+  }, [eraInfo]);
+
+  const deckLayers = useMemo(() => {
+    if (!manifest || !fileMap || !effectiveLayer) return [];
+
+    const layerId = effectiveLayer.layerId;
+    const isTileOddQLayer = effectiveLayer.kind === "grid" || layerId.startsWith("foundation.plateTopology.");
+    const tileSize = 1;
+
+    const meshEdges = manifest.layers.find(
+      (l) => l.kind === "segments" && l.layerId === "foundation.mesh.edges"
+    ) as Extract<VizLayerEntryV0, { kind: "segments" }> | undefined;
+
+    const loadScalar = async (path: string, format: VizScalarFormat): Promise<ArrayBufferView> => {
+      const file = fileMap.get(path);
+      if (!file) throw new Error(`Missing file: ${path}`);
+      const buf = await readFileAsArrayBuffer(file);
+      return decodeScalarArray(buf, format);
+    };
+
+    // We keep data in component state via a simple async cache.
+    // For V0 (MAPSIZE_HUGE), sizes are small enough to materialize on selection.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    return (async () => {
+      setLayerStats(null);
+
+      const baseLayers: any[] = [];
+      const shouldShowMeshEdges =
+        Boolean(showMeshEdges) &&
+        Boolean(meshEdges) &&
+        (effectiveLayer.kind === "points" || effectiveLayer.kind === "segments") &&
+        effectiveLayer.layerId.startsWith("foundation.") &&
+        !effectiveLayer.layerId.startsWith("foundation.plateTopology.");
+
+      if (shouldShowMeshEdges && meshEdges) {
+        const segFile = fileMap.get(meshEdges.segmentsPath);
+        if (!segFile) throw new Error(`Missing file: ${meshEdges.segmentsPath}`);
+        const segBuf = await readFileAsArrayBuffer(segFile);
+        const seg = new Float32Array(segBuf);
+
+        const edges: Array<{ path: [[number, number], [number, number]] }> = [];
+        const count = (seg.length / 4) | 0;
+        for (let i = 0; i < count; i++) {
+          const x0 = seg[i * 4] ?? 0;
+          const y0 = seg[i * 4 + 1] ?? 0;
+          const x1 = seg[i * 4 + 2] ?? 0;
+          const y1 = seg[i * 4 + 3] ?? 0;
+          edges.push({ path: [[x0, y0], [x1, y1]] });
+        }
+
+        baseLayers.push(
+          new PathLayer({
+            id: "foundation.mesh.edges::base",
+            data: edges,
+            getPath: (d) => d.path,
+            getColor: [148, 163, 184, 140],
+            getWidth: 1,
+            widthUnits: "pixels",
+            pickable: false,
+          })
+        );
+      }
+
+      if (effectiveLayer.kind === "grid") {
+        const values = await loadScalar(effectiveLayer.path, effectiveLayer.format);
+        const { width, height } = effectiveLayer.dims;
+
+        let min = Number.POSITIVE_INFINITY;
+        let max = Number.NEGATIVE_INFINITY;
+
+        const tiles: Array<{ polygon: Array<[number, number]>; v: number }> = [];
+        const len = width * height;
+        for (let i = 0; i < len; i++) {
+          const x = i % width;
+          const y = (i / width) | 0;
+          const v = (values as any)[i] ?? 0;
+          const vv = Number(v);
+          if (Number.isFinite(vv)) {
+            if (vv < min) min = vv;
+            if (vv > max) max = vv;
+          }
+
+          const center = tileLayout === "col-offset" ? oddQTileCenter(x, y, tileSize) : oddRTileCenter(x, y, tileSize);
+          tiles.push({ polygon: hexPolygonPointy(center, tileSize), v: vv });
+        }
+
+        if (Number.isFinite(min) && Number.isFinite(max)) setLayerStats({ min, max });
+
+        return [
+          ...baseLayers,
+          new PolygonLayer({
+            id: `${layerId}::hex`,
+            data: tiles,
+            getFillColor: (d) => colorForValue(layerId, d.v),
+            getPolygon: (d) => d.polygon,
+            stroked: true,
+            getLineColor: [17, 24, 39, 220],
+            getLineWidth: 1,
+            lineWidthUnits: "pixels",
+            pickable: true,
+          }),
+        ];
+      }
+
+      if (effectiveLayer.kind === "points") {
+        const posFile = fileMap.get(effectiveLayer.positionsPath);
+        if (!posFile) throw new Error(`Missing file: ${effectiveLayer.positionsPath}`);
+        const posBuf = await readFileAsArrayBuffer(posFile);
+        const positions = new Float32Array(posBuf);
+
+        const values =
+          effectiveLayer.valuesPath && effectiveLayer.valueFormat
+            ? await loadScalar(effectiveLayer.valuesPath, effectiveLayer.valueFormat)
+            : null;
+
+        let min = Number.POSITIVE_INFINITY;
+        let max = Number.NEGATIVE_INFINITY;
+
+        const points: Array<{ x: number; y: number; v: number }> = [];
+        const count = (positions.length / 2) | 0;
+        for (let i = 0; i < count; i++) {
+          const rawX = positions[i * 2] ?? 0;
+          const rawY = positions[i * 2 + 1] ?? 0;
+          const v = values ? Number((values as any)[i] ?? 0) : 0;
+          if (Number.isFinite(v)) {
+            if (v < min) min = v;
+            if (v > max) max = v;
+          }
+
+          const [x, y] = isTileOddQLayer
+            ? tileLayout === "col-offset"
+              ? oddQPointFromTileXY(rawX, rawY, tileSize)
+              : oddRPointFromTileXY(rawX, rawY, tileSize)
+            : [rawX, rawY];
+          points.push({ x, y, v });
+        }
+
+        if (Number.isFinite(min) && Number.isFinite(max)) setLayerStats({ min, max });
+
+        return [
+          ...baseLayers,
+          new ScatterplotLayer({
+            id: `${layerId}::points`,
+            data: points,
+            getPosition: (d) => [d.x, d.y],
+            getFillColor: (d) => colorForValue(layerId, d.v),
+            radiusUnits: "common",
+            getRadius: 0.95,
+            pickable: true,
+          }),
+        ];
+      }
+
+      if (effectiveLayer.kind === "segments") {
+        const segFile = fileMap.get(effectiveLayer.segmentsPath);
+        if (!segFile) throw new Error(`Missing file: ${effectiveLayer.segmentsPath}`);
+        const segBuf = await readFileAsArrayBuffer(segFile);
+        const seg = new Float32Array(segBuf);
+
+        const values =
+          effectiveLayer.valuesPath && effectiveLayer.valueFormat
+            ? await loadScalar(effectiveLayer.valuesPath, effectiveLayer.valueFormat)
+            : null;
+
+        let min = Number.POSITIVE_INFINITY;
+        let max = Number.NEGATIVE_INFINITY;
+
+        const segments: Array<{ path: [[number, number], [number, number]]; v: number }> = [];
+        const count = (seg.length / 4) | 0;
+        for (let i = 0; i < count; i++) {
+          const rx0 = seg[i * 4] ?? 0;
+          const ry0 = seg[i * 4 + 1] ?? 0;
+          const rx1 = seg[i * 4 + 2] ?? 0;
+          const ry1 = seg[i * 4 + 3] ?? 0;
+          const v = values ? Number((values as any)[i] ?? 0) : 0;
+          if (Number.isFinite(v)) {
+            if (v < min) min = v;
+            if (v > max) max = v;
+          }
+
+          const [x0, y0] = isTileOddQLayer
+            ? tileLayout === "col-offset"
+              ? oddQPointFromTileXY(rx0, ry0, tileSize)
+              : oddRPointFromTileXY(rx0, ry0, tileSize)
+            : [rx0, ry0];
+          const [x1, y1] = isTileOddQLayer
+            ? tileLayout === "col-offset"
+              ? oddQPointFromTileXY(rx1, ry1, tileSize)
+              : oddRPointFromTileXY(rx1, ry1, tileSize)
+            : [rx1, ry1];
+          segments.push({ path: [[x0, y0], [x1, y1]], v });
+        }
+
+        if (Number.isFinite(min) && Number.isFinite(max)) setLayerStats({ min, max });
+
+        return [
+          ...baseLayers,
+          new PathLayer({
+            id: `${layerId}::segments`,
+            data: segments,
+            getPath: (d) => d.path,
+            getColor: (d) => colorForValue(layerId, d.v),
+            getWidth: 1.5,
+            widthUnits: "pixels",
+            pickable: true,
+          }),
+        ];
+      }
+
+      return [];
+    })() as any;
+  }, [manifest, fileMap, effectiveLayer, tileLayout, showMeshEdges]);
+
+  // Resolve async layers into a stable state
+  const [resolvedLayers, setResolvedLayers] = useState<any[]>([]);
+  useEffect(() => {
+    const v = deckLayers as any;
+    if (typeof v?.then === "function") {
+      v.then(setResolvedLayers).catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+    } else {
+      setResolvedLayers(v);
+    }
+  }, [deckLayers]);
+
+  useEffect(() => {
+    if (!effectiveLayer) return;
+    if (effectiveLayer.kind === "grid") {
+      setFittedView(boundsForTileGrid(tileLayout, effectiveLayer.dims, 1));
+      return;
+    }
+    setFittedView(effectiveLayer.bounds);
+  }, [effectiveLayer, setFittedView, tileLayout]);
+
+  const legend = useMemo(() => legendForLayer(effectiveLayer, layerStats), [effectiveLayer, layerStats]);
+
+  const triggerDirectoryPicker = useCallback(() => {
+    directoryInputRef.current?.click();
+  }, []);
+
+  const controlBaseStyle: React.CSSProperties = useMemo(
+    () => ({
+      background: "#111827",
+      color: "#e5e7eb",
+      border: "1px solid #374151",
+      borderRadius: 8,
+      padding: isNarrow ? "10px 10px" : "6px 8px",
+      minWidth: 0,
+      fontSize: isNarrow ? 14 : 13,
+    }),
+    [isNarrow]
+  );
+
+  const buttonStyle: React.CSSProperties = useMemo(
+    () => ({
+      ...controlBaseStyle,
+      padding: isNarrow ? "10px 12px" : "6px 10px",
+      cursor: "pointer",
+      fontWeight: 600,
+      width: isNarrow ? "100%" : undefined,
+      textAlign: "center",
+    }),
+    [controlBaseStyle, isNarrow]
+  );
+
+  const backgroundGridLayer = useMemo(() => {
+    if (!showBackgroundGrid) return null;
+    if (!effectiveLayer) return null;
+    if (!(effectiveLayer.kind === "points" || effectiveLayer.kind === "segments")) return null;
+    if (effectiveLayer.layerId.startsWith("foundation.plateTopology.")) return null;
+
+    const zoom = typeof viewState?.zoom === "number" ? viewState.zoom : 0;
+    const scale = Math.pow(2, zoom);
+    const worldWidth = viewportSize.width / Math.max(1e-6, scale);
+    const worldHeight = viewportSize.height / Math.max(1e-6, scale);
+
+    const tx = Array.isArray(viewState?.target) ? Number(viewState.target[0]) : 0;
+    const ty = Array.isArray(viewState?.target) ? Number(viewState.target[1]) : 0;
+    const minX = tx - worldWidth / 2;
+    const maxX = tx + worldWidth / 2;
+    const minY = ty - worldHeight / 2;
+    const maxY = ty + worldHeight / 2;
+
+    const step = niceStep(worldWidth / 26);
+    const x0 = Math.floor(minX / step) * step;
+    const y0 = Math.floor(minY / step) * step;
+    const x1 = Math.ceil(maxX / step) * step;
+    const y1 = Math.ceil(maxY / step) * step;
+
+    const points: Array<{ x: number; y: number }> = [];
+    const maxPoints = 1800;
+    for (let y = y0; y <= y1; y += step) {
+      for (let x = x0; x <= x1; x += step) {
+        points.push({ x, y });
+        if (points.length >= maxPoints) break;
+      }
+      if (points.length >= maxPoints) break;
+    }
+
+    return new ScatterplotLayer({
+      id: "bg.mesh.grid",
+      data: points,
+      getPosition: (d) => [d.x, d.y],
+      getFillColor: [148, 163, 184, 55],
+      radiusUnits: "pixels",
+      getRadius: 1.2,
+      pickable: false,
+    });
+  }, [showBackgroundGrid, effectiveLayer, viewState, viewportSize]);
+
   return (
-    <div style={{ padding: '2rem', textAlign: 'center' }}>
-      <h1 style={{ marginBottom: '1rem' }}>MapGen Studio</h1>
-      <p style={{ color: '#888', marginBottom: '2rem' }}>
-        Civ7 Map Generation Pipeline Visualizer
-      </p>
+    <div style={{ height: "100vh", display: "flex", flexDirection: "column", background: "#0b1020", color: "#e5e7eb" }}>
       <div
         style={{
-          background: '#16213e',
-          borderRadius: '8px',
-          padding: '2rem',
-          maxWidth: '600px',
-          margin: '0 auto',
+          padding: isNarrow ? "10px 12px" : "12px 14px",
+          borderBottom: "1px solid #1f2937",
+          display: "flex",
+          flexDirection: "column",
+          gap: isNarrow ? 10 : 12,
         }}
       >
-        <p style={{ color: '#4ecca3', fontFamily: 'monospace' }}>
-          Deployment successful.
-        </p>
-        <p style={{ color: '#666', marginTop: '1rem', fontSize: '0.9rem' }}>
-          Next: Web Worker + deck.gl integration
-        </p>
+        <div style={{ display: "flex", gap: 12, alignItems: isNarrow ? "flex-start" : "center", flexWrap: "wrap" }}>
+          <div style={{ fontWeight: 800, fontSize: isNarrow ? 16 : 14 }}>MapGen Studio</div>
+          <div style={{ color: "#9ca3af", fontSize: isNarrow ? 13 : 12 }}>Foundation Viz (V0)</div>
+          <div style={{ flex: 1 }} />
+          {!isNarrow ? (
+            <div style={{ fontSize: 12, color: "#9ca3af" }}>
+              Open a run folder under <span style={{ color: "#e5e7eb" }}>mods/mod-swooper-maps/dist/visualization</span>
+            </div>
+          ) : null}
+        </div>
+
+        <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
+          <button onClick={openDumpFolder} style={buttonStyle}>
+            Open dump folder
+          </button>
+
+          <input
+            ref={directoryInputRef}
+            type="file"
+            multiple
+            onChange={onDirectoryFiles}
+            style={{ display: "none" }}
+            {...({ webkitdirectory: "", directory: "" } as any)}
+          />
+          <button onClick={triggerDirectoryPicker} style={buttonStyle}>
+            Upload dump folder
+          </button>
+
+          <button
+            onClick={() => selectedLayer && setFittedView(selectedLayer.bounds)}
+            style={{ ...buttonStyle, opacity: selectedLayer ? 1 : 0.55 }}
+            disabled={!selectedLayer}
+          >
+            Fit
+          </button>
+
+          <label
+            style={{
+              display: "flex",
+              gap: 10,
+              alignItems: "center",
+              flex: isNarrow ? "1 1 100%" : "0 0 auto",
+              width: isNarrow ? "100%" : undefined,
+              justifyContent: isNarrow ? "space-between" : "flex-start",
+              padding: isNarrow ? "2px 2px" : 0,
+            }}
+          >
+            <span style={{ fontSize: 12, color: "#9ca3af" }}>Show mesh edges</span>
+            <input type="checkbox" checked={showMeshEdges} onChange={(e) => setShowMeshEdges(e.target.checked)} />
+          </label>
+
+          <label
+            style={{
+              display: "flex",
+              gap: 10,
+              alignItems: "center",
+              flex: isNarrow ? "1 1 100%" : "0 0 auto",
+              width: isNarrow ? "100%" : undefined,
+              justifyContent: isNarrow ? "space-between" : "flex-start",
+              padding: isNarrow ? "2px 2px" : 0,
+            }}
+          >
+            <span style={{ fontSize: 12, color: "#9ca3af" }}>Background grid</span>
+            <input
+              type="checkbox"
+              checked={showBackgroundGrid}
+              onChange={(e) => setShowBackgroundGrid(e.target.checked)}
+            />
+          </label>
+        </div>
+
+        <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
+          <label style={{ display: "flex", gap: 8, alignItems: "center", flex: isNarrow ? "1 1 100%" : "0 0 auto", width: isNarrow ? "100%" : undefined }}>
+            <span style={{ fontSize: 12, color: "#9ca3af", minWidth: isNarrow ? 56 : undefined }}>Step</span>
+            <select
+              value={selectedStepId ?? ""}
+              onChange={(e) => setSelectedStepId(e.target.value || null)}
+              style={{ ...controlBaseStyle, flex: 1, width: "100%" }}
+              disabled={!steps.length}
+            >
+              {steps.map((s) => (
+                <option key={s.stepId} value={s.stepId}>
+                  {s.stepIndex} · {formatLabel(s.stepId)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label style={{ display: "flex", gap: 8, alignItems: "center", flex: isNarrow ? "1 1 100%" : "1 1 420px", width: isNarrow ? "100%" : undefined }}>
+            <span style={{ fontSize: 12, color: "#9ca3af", minWidth: isNarrow ? 56 : undefined }}>Layer</span>
+            <select
+              value={selectedLayerKey ?? ""}
+              onChange={(e) => setSelectedLayerKey(e.target.value || null)}
+              style={{ ...controlBaseStyle, flex: 1, width: "100%" }}
+              disabled={!layersForStep.length}
+            >
+              {layersForStep.map((l) => (
+                <option key={l.key} value={l.key}>
+                  {l.layer.layerId} ({l.layer.kind})
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label style={{ display: "flex", gap: 8, alignItems: "center", flex: isNarrow ? "1 1 100%" : "0 0 auto", width: isNarrow ? "100%" : undefined }}>
+            <span style={{ fontSize: 12, color: "#9ca3af", minWidth: isNarrow ? 76 : undefined }}>Hex layout</span>
+            <select
+              value={tileLayout}
+              onChange={(e) => setTileLayout(e.target.value as TileLayout)}
+              style={{ ...controlBaseStyle, flex: 1, width: isNarrow ? "100%" : 220 }}
+            >
+              <option value="row-offset">row-offset (Civ-like)</option>
+              <option value="col-offset">col-offset</option>
+            </select>
+          </label>
+
+          {eraInfo && eraMax != null ? (
+            <label style={{ display: "flex", gap: 8, alignItems: "center", flex: isNarrow ? "1 1 100%" : "1 1 420px", width: isNarrow ? "100%" : undefined }}>
+              <span style={{ fontSize: 12, color: "#9ca3af", minWidth: isNarrow ? 76 : undefined }}>Era</span>
+              <input
+                type="range"
+                min={0}
+                max={eraMax}
+                step={1}
+                value={clamp(eraIndex, 0, eraMax)}
+                onChange={(e) => setEraIndex(Number.parseInt(e.target.value, 10))}
+                style={{ flex: 1, width: "100%" }}
+              />
+              <span style={{ fontSize: 12, color: "#e5e7eb", minWidth: 26, textAlign: "right" }}>
+                {clamp(eraIndex, 0, eraMax)}
+              </span>
+            </label>
+          ) : null}
+        </div>
+      </div>
+
+      {error ? (
+        <div style={{ padding: 12, background: "#2a0b0b", borderBottom: "1px solid #7f1d1d", color: "#fecaca" }}>
+          {error}
+        </div>
+      ) : null}
+
+      <div ref={containerRef} style={{ flex: 1, position: "relative" }}>
+        {manifest ? (
+          <DeckGL
+            views={new OrthographicView({ id: "ortho" })}
+            controller={true}
+            viewState={viewState}
+            onViewStateChange={({ viewState: vs }: any) => setViewState(vs)}
+            layers={[...(backgroundGridLayer ? [backgroundGridLayer] : []), ...resolvedLayers]}
+          />
+        ) : (
+          <div style={{ padding: 18, color: "#9ca3af" }}>
+            Select a dump folder containing `manifest.json` (e.g. `mods/mod-swooper-maps/dist/visualization/&lt;runId&gt;`).
+          </div>
+        )}
+        <div style={{ position: "absolute", bottom: 10, left: 10, fontSize: 12, color: "#9ca3af", background: "rgba(0,0,0,0.35)", padding: "6px 8px", borderRadius: 8 }}>
+          {manifest ? (
+            <>
+              runId: <span style={{ color: "#e5e7eb" }}>{manifest.runId.slice(0, 12)}…</span>
+              {" · "}
+              viewport: {Math.round(viewportSize.width)}×{Math.round(viewportSize.height)}
+            </>
+          ) : (
+            <>No dump loaded</>
+          )}
+        </div>
+
+        {manifest && effectiveLayer && legend ? (
+          <div
+            style={{
+              position: "absolute",
+              top: 10,
+              left: 10,
+              fontSize: 12,
+              color: "#e5e7eb",
+              background: "rgba(0,0,0,0.55)",
+              border: "1px solid rgba(255,255,255,0.10)",
+              padding: "10px 10px",
+              borderRadius: 10,
+              maxWidth: isNarrow ? "calc(100% - 20px)" : 360,
+              maxHeight: isNarrow ? "40vh" : "70vh",
+              overflowY: "auto",
+            }}
+          >
+            <div style={{ fontWeight: 700, marginBottom: 6 }}>{legend.title}</div>
+            <div style={{ color: "#9ca3af", marginBottom: 8 }}>
+              <div>step: {formatLabel(effectiveLayer.stepId)}</div>
+              <div>layer: {effectiveLayer.layerId} ({effectiveLayer.kind})</div>
+              {eraInfo && eraMax != null ? <div>era: {clamp(eraIndex, 0, eraMax)}</div> : null}
+              {effectiveLayer.kind === "grid" ? <div>tile layout: {tileLayout}</div> : null}
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              {legend.items.map((item) => (
+                <div key={item.label} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <span
+                    style={{
+                      width: 14,
+                      height: 14,
+                      borderRadius: 4,
+                      background: `rgba(${item.color[0]},${item.color[1]},${item.color[2]},${item.color[3] / 255})`,
+                      border: "1px solid rgba(255,255,255,0.15)",
+                      display: "inline-block",
+                    }}
+                  />
+                  <span style={{ color: "#e5e7eb" }}>{item.label}</span>
+                </div>
+              ))}
+            </div>
+            {legend.note ? <div style={{ marginTop: 8, color: "#9ca3af" }}>{legend.note}</div> : null}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,9 @@
       "name": "mapgen-studio",
       "version": "0.1.0",
       "dependencies": {
+        "@deck.gl/core": "^9.0.43",
+        "@deck.gl/layers": "^9.0.43",
+        "@deck.gl/react": "^9.0.43",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
@@ -391,6 +394,14 @@
 
     "@civ7/types": ["@civ7/types@workspace:packages/civ7-types"],
 
+    "@deck.gl/core": ["@deck.gl/core@9.2.6", "", { "dependencies": { "@loaders.gl/core": "^4.2.0", "@loaders.gl/images": "^4.2.0", "@luma.gl/constants": "^9.2.6", "@luma.gl/core": "^9.2.6", "@luma.gl/engine": "^9.2.6", "@luma.gl/shadertools": "^9.2.6", "@luma.gl/webgl": "^9.2.6", "@math.gl/core": "^4.1.0", "@math.gl/sun": "^4.1.0", "@math.gl/types": "^4.1.0", "@math.gl/web-mercator": "^4.1.0", "@probe.gl/env": "^4.1.0", "@probe.gl/log": "^4.1.0", "@probe.gl/stats": "^4.1.0", "@types/offscreencanvas": "^2019.6.4", "gl-matrix": "^3.0.0", "mjolnir.js": "^3.0.0" } }, "sha512-bBFfwfythPPpXS/OKUMvziQ8td84mRGMnYZfqdUvfUVltzjFtQCBQUJTzgo3LubvOzSnzo8GTWskxHaZzkqdKQ=="],
+
+    "@deck.gl/layers": ["@deck.gl/layers@9.2.6", "", { "dependencies": { "@loaders.gl/images": "^4.2.0", "@loaders.gl/schema": "^4.2.0", "@luma.gl/shadertools": "^9.2.6", "@mapbox/tiny-sdf": "^2.0.5", "@math.gl/core": "^4.1.0", "@math.gl/polygon": "^4.1.0", "@math.gl/web-mercator": "^4.1.0", "earcut": "^2.2.4" }, "peerDependencies": { "@deck.gl/core": "~9.2.0", "@loaders.gl/core": "^4.2.0", "@luma.gl/core": "~9.2.6", "@luma.gl/engine": "~9.2.6" } }, "sha512-ASwL5CHm/QX+fVW+MejmtA/84RKO0BaL2/Fv9N+l+WcSII2M5s730rrTw3JgyQ66AUGFPe1SL3JDkqsUlVJ0yg=="],
+
+    "@deck.gl/react": ["@deck.gl/react@9.2.6", "", { "peerDependencies": { "@deck.gl/core": "~9.2.0", "@deck.gl/widgets": "~9.2.0", "react": ">=16.3.0", "react-dom": ">=16.3.0" } }, "sha512-wYjfX52EAeThZposplTT/vkP0dk2qOv5AryLOq/Y/DIrtA1FGe91GlL28DvDJ2YZrl6K7cFAvoXpuFZe2zYULA=="],
+
+    "@deck.gl/widgets": ["@deck.gl/widgets@9.2.6", "", { "dependencies": { "preact": "^10.17.0" }, "peerDependencies": { "@deck.gl/core": "~9.2.0", "@luma.gl/core": "~9.2.6" } }, "sha512-WkKP+HB90x1qwOxs5l6Dg0d1iAvf999jJGDdGUbDVsRF7+hJDv03GZY6XKpoiEW7VfcZ1y1iU2vRwV/GHuQ57g=="],
+
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
@@ -573,9 +584,41 @@
 
     "@leichtgewicht/ip-codec": ["@leichtgewicht/ip-codec@2.0.5", "", {}, "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="],
 
+    "@loaders.gl/core": ["@loaders.gl/core@4.3.4", "", { "dependencies": { "@loaders.gl/loader-utils": "4.3.4", "@loaders.gl/schema": "4.3.4", "@loaders.gl/worker-utils": "4.3.4", "@probe.gl/log": "^4.0.2" } }, "sha512-cG0C5fMZ1jyW6WCsf4LoHGvaIAJCEVA/ioqKoYRwoSfXkOf+17KupK1OUQyUCw5XoRn+oWA1FulJQOYlXnb9Gw=="],
+
+    "@loaders.gl/images": ["@loaders.gl/images@4.3.4", "", { "dependencies": { "@loaders.gl/loader-utils": "4.3.4" }, "peerDependencies": { "@loaders.gl/core": "^4.3.0" } }, "sha512-qgc33BaNsqN9cWa/xvcGvQ50wGDONgQQdzHCKDDKhV2w/uptZoR5iofJfuG8UUV2vUMMd82Uk9zbopRx2rS4Ag=="],
+
+    "@loaders.gl/loader-utils": ["@loaders.gl/loader-utils@4.3.4", "", { "dependencies": { "@loaders.gl/schema": "4.3.4", "@loaders.gl/worker-utils": "4.3.4", "@probe.gl/log": "^4.0.2", "@probe.gl/stats": "^4.0.2" }, "peerDependencies": { "@loaders.gl/core": "^4.3.0" } }, "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q=="],
+
+    "@loaders.gl/schema": ["@loaders.gl/schema@4.3.4", "", { "dependencies": { "@types/geojson": "^7946.0.7" }, "peerDependencies": { "@loaders.gl/core": "^4.3.0" } }, "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw=="],
+
+    "@loaders.gl/worker-utils": ["@loaders.gl/worker-utils@4.3.4", "", { "peerDependencies": { "@loaders.gl/core": "^4.3.0" } }, "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA=="],
+
+    "@luma.gl/constants": ["@luma.gl/constants@9.2.6", "", {}, "sha512-rvFFrJuSm5JIWbDHFuR4Q2s4eudO3Ggsv0TsGKn9eqvO7bBiPm/ANugHredvh3KviEyYuMZZxtfJvBdr3kzldg=="],
+
+    "@luma.gl/core": ["@luma.gl/core@9.2.6", "", { "dependencies": { "@math.gl/types": "^4.1.0", "@probe.gl/env": "^4.0.8", "@probe.gl/log": "^4.0.8", "@probe.gl/stats": "^4.0.8", "@types/offscreencanvas": "^2019.6.4" } }, "sha512-d8KcH8ZZcjDAodSN/G2nueA9YE2X8kMz7Q0OxDGpCww6to1MZXM3Ydate/Jqsb5DDKVgUF6yD6RL8P5jOki9Yw=="],
+
+    "@luma.gl/engine": ["@luma.gl/engine@9.2.6", "", { "dependencies": { "@math.gl/core": "^4.1.0", "@math.gl/types": "^4.1.0", "@probe.gl/log": "^4.0.8", "@probe.gl/stats": "^4.0.8" }, "peerDependencies": { "@luma.gl/core": "~9.2.0", "@luma.gl/shadertools": "~9.2.0" } }, "sha512-1AEDs2AUqOWh7Wl4onOhXmQF+Rz1zNdPXF+Kxm4aWl92RQ42Sh2CmTvRt2BJku83VQ91KFIEm/v3qd3Urzf+Uw=="],
+
+    "@luma.gl/shadertools": ["@luma.gl/shadertools@9.2.6", "", { "dependencies": { "@math.gl/core": "^4.1.0", "@math.gl/types": "^4.1.0", "wgsl_reflect": "^1.2.0" }, "peerDependencies": { "@luma.gl/core": "~9.2.0" } }, "sha512-4+uUbynqPUra9d/z1nQChyHmhLgmKfSMjS7kOwLB6exSnhKnpHL3+Hu9fv55qyaX50nGH3oHawhGtJ6RRvu65w=="],
+
+    "@luma.gl/webgl": ["@luma.gl/webgl@9.2.6", "", { "dependencies": { "@luma.gl/constants": "9.2.6", "@math.gl/types": "^4.1.0", "@probe.gl/env": "^4.0.8" }, "peerDependencies": { "@luma.gl/core": "~9.2.0" } }, "sha512-NGBTdxJMk7j8Ygr1zuTyAvr1Tw+EpupMIQo7RelFjEsZXg6pujFqiDMM+rgxex8voCeuhWBJc7Rs+MoSqd46UQ=="],
+
+    "@mapbox/tiny-sdf": ["@mapbox/tiny-sdf@2.0.7", "", {}, "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug=="],
+
     "@mateicanavra/civ7-cli": ["@mateicanavra/civ7-cli@workspace:packages/cli"],
 
     "@mateicanavra/civ7-sdk": ["@mateicanavra/civ7-sdk@workspace:packages/sdk"],
+
+    "@math.gl/core": ["@math.gl/core@4.1.0", "", { "dependencies": { "@math.gl/types": "4.1.0" } }, "sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA=="],
+
+    "@math.gl/polygon": ["@math.gl/polygon@4.1.0", "", { "dependencies": { "@math.gl/core": "4.1.0" } }, "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA=="],
+
+    "@math.gl/sun": ["@math.gl/sun@4.1.0", "", {}, "sha512-i3q6OCBLSZ5wgZVhXg+X7gsjY/TUtuFW/2KBiq/U1ypLso3S4sEykoU/MGjxUv1xiiGtr+v8TeMbO1OBIh/HmA=="],
+
+    "@math.gl/types": ["@math.gl/types@4.1.0", "", {}, "sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA=="],
+
+    "@math.gl/web-mercator": ["@math.gl/web-mercator@4.1.0", "", { "dependencies": { "@math.gl/core": "4.1.0" } }, "sha512-HZo3vO5GCMkXJThxRJ5/QYUYRr3XumfT8CzNNCwoJfinxy5NtKUd7dusNTXn7yJ40UoB8FMIwkVwNlqaiRZZAw=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
@@ -624,6 +667,12 @@
     "@pnpm/npm-conf": ["@pnpm/npm-conf@3.0.2", "", { "dependencies": { "@pnpm/config.env-replace": "^1.1.0", "@pnpm/network.ca-file": "^1.0.1", "config-chain": "^1.1.11" } }, "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "@probe.gl/env": ["@probe.gl/env@4.1.0", "", {}, "sha512-5ac2Jm2K72VCs4eSMsM7ykVRrV47w32xOGMvcgqn8vQdEMF9PRXyBGYEV9YbqRKWNKpNKmQJVi4AHM/fkCxs9w=="],
+
+    "@probe.gl/log": ["@probe.gl/log@4.1.0", "", { "dependencies": { "@probe.gl/env": "4.1.0" } }, "sha512-r4gRReNY6f+OZEMgfWEXrAE2qJEt8rX0HsDJQXUBMoc+5H47bdB7f/5HBHAmapK8UydwPKL9wCDoS22rJ0yq7Q=="],
+
+    "@probe.gl/stats": ["@probe.gl/stats@4.1.0", "", {}, "sha512-EI413MkWKBDVNIfLdqbeNSJTs7ToBz/KVGkwi3D+dQrSIkRI2IYbWGAU3xX+D6+CI4ls8ehxMhNpUVMaZggDvQ=="],
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.3.0", "", { "dependencies": { "debug": "^4.3.5", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.4.0", "semver": "^7.6.3", "tar-fs": "^3.0.6", "unbzip2-stream": "^1.4.3", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA=="],
 
@@ -917,6 +966,8 @@
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
 
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/http-cache-semantics": ["@types/http-cache-semantics@4.0.4", "", {}, "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="],
@@ -940,6 +991,8 @@
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
     "@types/node": ["@types/node@22.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw=="],
+
+    "@types/offscreencanvas": ["@types/offscreencanvas@2019.7.3", "", {}, "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="],
 
     "@types/react": ["@types/react@19.2.10", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw=="],
 
@@ -1343,6 +1396,8 @@
 
     "duplexer3": ["duplexer3@0.1.5", "", {}, "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA=="],
 
+    "earcut": ["earcut@2.2.4", "", {}, "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="],
+
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
@@ -1562,6 +1617,8 @@
     "git-hooks-list": ["git-hooks-list@3.2.0", "", {}, "sha512-ZHG9a1gEhUMX1TvGrLdyWb9kDopCBbTnI8z4JgRMYxsijWipgjSEYoPWqBuIB0DnRnvqlQSEeVmzpeuPm7NdFQ=="],
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
+
+    "gl-matrix": ["gl-matrix@3.4.4", "", {}, "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ=="],
 
     "glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
 
@@ -2027,6 +2084,8 @@
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
+    "mjolnir.js": ["mjolnir.js@3.0.0", "", {}, "sha512-siX3YCG7N2HnmN1xMH3cK4JkUZJhbkhRFJL+G5N1vH0mh1t5088rJknIoqDFWDIU6NPGvRRgLnYW3ZHjSMEBLA=="],
+
     "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
     "mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
@@ -2196,6 +2255,8 @@
     "postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "preact": ["preact@10.28.2", "", {}, "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -2690,6 +2751,8 @@
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "wgsl_reflect": ["wgsl_reflect@1.2.3", "", {}, "sha512-BQWBIsOn411M+ffBxmA6QRLvAOVbuz3Uk4NusxnqC1H7aeQcVLhdA3k2k/EFFFtqVjhz3z7JOOZF1a9hj2tv4Q=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 

--- a/docs/projects/mapgen-studio/RAILWAY-DEPLOYMENT-HANDOFF.md
+++ b/docs/projects/mapgen-studio/RAILWAY-DEPLOYMENT-HANDOFF.md
@@ -9,6 +9,10 @@
 
 MapGen Studio is a browser-based visualization tool for the Civ7 map generation pipeline. The near-term goal is a **public, static deployment** (zero auth) to prove the Railway deployment pipeline before we build the real product: an **in-browser pipeline runner** (Web Worker) plus **rich visualization** (e.g., deck.gl) for debugging/iteration.
 
+Roadmap for the visualization product (including V0 “dump + deck.gl viewer”): `docs/projects/mapgen-studio/ROADMAP.md`.
+
+This document is intentionally **deployment-only** (Railway + static hosting). Product/architecture details live in the roadmap and V0 plan.
+
 **Current state:**
 - Railway service exists, connected to the monorepo
 - But it's configured for the whole repo, not the `apps/mapgen-studio` subdirectory

--- a/docs/projects/mapgen-studio/ROADMAP.md
+++ b/docs/projects/mapgen-studio/ROADMAP.md
@@ -1,0 +1,90 @@
+# MapGen Studio Roadmap
+
+This roadmap describes the incremental path to a practical, external visualization workflow for Civ7 mapgen.
+
+## Definitions (shared terminology)
+
+- **Dump**: a replayable folder containing at minimum `manifest.json` and referenced payload files under `data/`.
+- **Layer**: a single visualizable artifact (grid/mesh/vector/points/polygons) described in the manifest.
+- **`layerId`**: stable identifier for a layer (recommended form: `<domain>.<name>`), used for UI selection and comparisons.
+- **`runId` / `planFingerprint`**: identifiers for a particular execution; exact semantics must match the mapgen trace/plan implementation.
+- **`outputsRoot`**: where dump folders are written. For V0 we keep dumps local to the map mod’s `dist/` output (see V0 plan).
+
+## North Star
+
+MapGen Studio becomes the place to **inspect mapgen runs** via:
+- **Replayable dumps** emitted during a run (no “debug mode” required).
+- A **fast, rich viewer** (deck.gl) that can scrub steps, toggle layers, and compare runs.
+
+## V0 — Dump + deck.gl Viewer (Vertical Slice)
+
+Goal: prove the end-to-end loop: **run once → dump artifacts → view later**.
+
+Implementation plan: `docs/projects/mapgen-studio/V0-IMPLEMENTATION-PLAN.md`.
+
+### Deliverables
+
+**1) Dump format + writer (pipeline-side)**
+- A deterministic output folder per run:
+  - `trace.jsonl` (events/spine; optional but recommended)
+  - `manifest.json` (index of layers)
+  - `data/*` (binary payloads + optional sidecars)
+- Foundation-first: dump and visualize the plate-formation process “bottom-up”, capturing as many intermediate steps as practical.
+- Minimum set (separate layers):
+  - mesh (sites / adjacency where feasible)
+  - plates (assignments + boundaries)
+  - crust (cell-space + tile-space)
+
+**2) MapGen Studio viewer MVP (browser-side)**
+- Load a local/hosted dump folder (at minimum: `manifest.json`).
+- Render multiple layer kinds as needed for Foundation (grid + points + segments).
+- Minimal UI:
+  - Layer picker
+  - Step picker (plate formation process is step-by-step)
+  - Legend/palette mapping for the layer
+  - Fit-to-viewport / pan / zoom
+
+**3) Operator workflow**
+- A single command/workflow to produce a dump for a seed and open the viewer pointing at it.
+
+### Acceptance Criteria
+- A run dump can be produced deterministically for a given seed/plan.
+- MapGen Studio can open that dump and render the grid layer reliably.
+- The dump+viewer loop works without importing pipeline runtime code into the browser.
+
+### Verification (V0)
+- Producer: `manifest.json` is present and references at least one grid layer payload under `data/`.
+- Viewer: MapGen Studio can load the dump and render the layer at correct dimensions with stable pan/zoom.
+- Defaults: we typically validate on Civ7 **MAPSIZE_HUGE** (grid **106×66**).
+
+### Non-goals (V0)
+- Running the pipeline in-browser (Web Worker runner).
+- Full step scrubbing, diffing runs, or deep layer taxonomy coverage.
+- Complex geometry layers (rivers/paths/polygons/meshes) beyond the one proven slice.
+
+## V0.1 — More Layers + Step Playback
+
+Goal: make the viewer meaningfully useful for debugging.
+
+- Add a small set of “core” layers across domains (Foundation → Placement).
+- Add step/era controls:
+  - Render “latest at step” for each layer, or allow step snapshots.
+- Add basic diagnostics:
+  - min/max histogram, value probe on hover, and palette controls.
+
+## V0.2 — Geometry Support
+
+Goal: make non-grid artifacts first-class.
+
+- Add vector/path and point layers (rivers, faults, hotspots).
+- Add polygon/mesh layers (plates, landmasses) where feasible.
+- Add consistent coordinate mapping between dumps and viewer bounds.
+
+## V1 — Comparison + Sharing
+
+Goal: move from “viewer” to “debugging platform”.
+
+- Compare two runs (seed/config diffs) with layer selection.
+- Save/share view state (deep links, presets).
+- Integrate with CLI/CI:
+  - attach dumps to artifacts for regression inspection.

--- a/docs/projects/mapgen-studio/V0-IMPLEMENTATION-PLAN.md
+++ b/docs/projects/mapgen-studio/V0-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,185 @@
+# V0 Implementation Plan — Dump + Deck.gl Viewer
+
+This plan turns the V0 roadmap into an executable slice: **dump a single layer from one run and render it in MapGen Studio**.
+
+## Definitions (must stay consistent with runtime)
+
+- **Dump folder**: contains `manifest.json` and binary payloads under `data/`.
+- **`outputsRoot` (V0)**: the map mod’s built output directory: `mods/mod-swooper-maps/dist`. Dumps are written under it so they travel with the mod artifact.
+  - **Shortcut (explicit):** this is runtime/debug output inside a generated directory; it may be overwritten by rebuilds and should not be committed.
+- **`layerId`**: stable identifier for a layer; filenames are implementation detail.
+- **Trace events**: emitted via the mapgen trace system; note that `step.event` emission may be gated (e.g. verbose-only).
+
+## Coordinate Spaces (what to expect in the viewer)
+
+Foundation data is emitted in two main spaces:
+
+- **Tile space** (game grid): arrays sized `width×height` (e.g. `foundation.plates.tilePlateId`, `foundation.crustTiles.*`). In the viewer these render as **pointy-top, row-offset hexes** (Civ-like).
+- **Mesh space** (plate mesh): arrays sized `cellCount` and coordinates in mesh units (e.g. `foundation.crust.cellType`, `foundation.tectonics.*`). These must be rendered against the **mesh edges/sites**, not the tile grid. Otherwise they will look “rotated/skewed” relative to tiles.
+
+The Foundation `projection` step exists to bridge these: it emits `tileToCellIndex` so mesh-space fields can be sampled into tile-space fields.
+
+## Goal
+
+Prove the loop:
+
+1) Run mapgen once
+2) Emit a replayable dump folder (`manifest.json` + `data/*`, optionally `trace.jsonl`)
+3) Open MapGen Studio and render a dumped grid layer via deck.gl
+
+Dump outputs (V0) are written under: `mods/mod-swooper-maps/dist/visualization/<runId>/…`.
+
+## Scope (V0)
+
+- Foundation-first: visualize the plate formation process step-by-step.
+- Dump and render multiple layer kinds as needed:
+  - tile-space grids (e.g. plateId, boundaryType, crust tiles)
+  - mesh-space points (mesh sites, cell-to-plate assignment, crust/tectonics tensors)
+  - mesh-space segments where feasible (tectonic segments, neighbor graphs / mesh edges)
+- External replay only: viewer **does not execute** pipeline code.
+- Default validation target is Civ7 **MAPSIZE_HUGE** (grid **106×66**), as defined in `.civ7/outputs/resources/Base/modules/base-standard/data/maps.xml`.
+
+## Decisions to Lock (Before Coding)
+
+1) **Viewer input mode**
+   - **Option A (recommended for static deploy):** user selects a dump folder via file picker (`manifest.json` + binaries).
+   - Option B: viewer loads dumps by URL (requires serving dumps over HTTP).
+2) **Binary encoding for the first grid layer**
+   - Raw typed array bytes + sidecar JSON (recommended).
+   - Arrow/Parquet (defer).
+3) **Coordinate model**
+   - Tile grid coordinates with bounds `[0..width] x [0..height]` (recommended for V0).
+   - World lat/lon (defer until there’s a stable mapping contract).
+
+## Open Questions (explicit; do not silently decide)
+
+1) **Which single layer is the V0 slice?**
+   - Options: elevation, land/water mask, temperature, rainfall.
+   - Recommendation: pick the easiest layer that is available “in one place” without pulling large new dependencies.
+2) **How do we guarantee `layer.dump` events are emitted?**
+   - Constraint: the trace system may only emit `step.event` in verbose mode.
+     - Reference: `packages/mapgen-core/src/trace/index.ts` (`TraceScope.event`).
+   - Prework: confirm whether V0 should require verbose trace for the instrumented step(s), or whether the dump sink should also support non-verbose paths.
+3) **How should we derive dims for a dump?**
+   - Constraint: the dump must include `dims: [width, height]` and match the underlying arrays.
+   - Default: for most V0 testing, use Civ7 **MAPSIZE_HUGE** (**106×66**) from `.civ7/outputs/resources/Base/modules/base-standard/data/maps.xml`.
+   - Future: allow selecting other map sizes by `MapSizeType` (not needed for V0).
+
+## Pipeline-Side Work (Dump Producer)
+
+### 1) Define the V0 dump contract (types + schema)
+
+Deliver:
+- A TypeScript type for the manifest + layer entries.
+- A minimal JSON schema section in docs (format/dims/path fields).
+
+Minimum layer entry fields:
+- `layerId` (stable `domain.field` identifier)
+- `stepId`
+- `kind` (`grid`)
+- `format` (`uint8`/`uint16`/`float32`)
+- `dims` (`[width, height]`)
+- `path` (relative path under dump root)
+- optional: `palette`, `tags`, `domain`
+
+### 2) Implement a trace dump sink (events spine + manifest builder)
+
+Target: `packages/mapgen-core/src/trace/…` using the existing `TraceSink` interface.
+
+Responsibilities:
+- Append all trace events to `trace.jsonl` (1 JSON object per line).
+- Detect `step.event` payloads of the form `{ type: "layer.dump", ... }`.
+- Maintain an in-memory manifest and write/refresh `manifest.json`.
+
+Notes:
+- The current trace system only emits `step.event` when the step is configured as `verbose`.
+- The sink must never throw (trace is non-functional / best-effort).
+
+### 3) Implement a grid layer dump helper (writes binary + emits event)
+
+Provide a helper that:
+- Writes a single typed array to `data/<file>.bin` (filename is an implementation detail; `layerId` stays stable in the manifest).
+- Writes a small sidecar JSON if needed (format/dims/palette) or embeds that in the event.
+- Emits the `layer.dump` step event referencing the relative path.
+
+### 4) Instrument one step to dump one layer
+
+Pick a layer that is:
+- stable and easy to extract in a single step, and
+- useful for verifying the viewer’s correctness.
+
+Deliver:
+- One step emits one `layer.dump` event in verbose mode.
+
+### 5) Producer validation
+
+Add/extend a `packages/mapgen-core` test:
+- Run a minimal plan with the dump sink enabled.
+- Assert `manifest.json` exists and includes the dumped layer entry.
+- Assert the referenced `data/*` file exists and has the expected byte length.
+
+## Viewer-Side Work (MapGen Studio)
+
+### 6) Add deck.gl-based grid rendering
+
+Target: `apps/mapgen-studio`.
+
+Deliver:
+- Add deck.gl (and required peer deps) to the app.
+- Render one grid layer from a selected dump:
+  - decode binary (based on `format`)
+  - colorize via a simple palette mapping (start with grayscale if needed)
+  - render with a deck.gl layer suitable for textures (e.g., `BitmapLayer`)
+
+### 7) Implement dump loading UX (V0 input mode)
+
+If choosing **folder upload**:
+- UI: “Open dump folder”
+- Require at minimum: `manifest.json` + referenced binaries.
+- Keep all paths relative to the selected folder; no network required.
+
+If choosing **URL load**:
+- UI: URL input + query param (`?dumpUrl=...`) support.
+
+### 8) Viewer validation
+
+Deliver:
+- A fixture dump folder (small, committed under an appropriate test/fixture location) or a scripted generator.
+- A basic integration check (manual is acceptable for V0; automated if a test harness exists).
+
+## Operator Workflow (Glue)
+
+### 9) One command to produce + open
+
+Deliver one of:
+- A `bun` script that runs a known seed/plan and writes `mods/mod-swooper-maps/dist/visualization/<runId>/…`.
+- A small CLI wrapper command (if an existing CLI entrypoint is the right home).
+
+Acceptance:
+- Running the command produces a dump folder and opens MapGen Studio pointed at it (or prints exact “how to open” instructions).
+
+V0 local entrypoint (current intent):
+- Produce foundation dump: `bun run --cwd mods/mod-swooper-maps viz:foundation`
+- Open MapGen Studio: `bun run --cwd apps/mapgen-studio dev` then “Open dump folder” and select `mods/mod-swooper-maps/dist/visualization/<runId>`
+
+## Acceptance Criteria (V0)
+
+- Dump producer: produces `manifest.json` + one grid layer binary for a seed/plan.
+- Viewer: loads the dump and renders the grid layer with correct dimensions and a stable palette.
+- No pipeline runtime code is bundled into the browser app.
+
+## Verification Methods (V0)
+
+Producer:
+- Run mapgen-core tests: `bun run test:mapgen`
+- If adding a dedicated dump test, keep it small and deterministic (tiny grid dims, fixed seed).
+
+Viewer:
+- Dev run: `bun run --cwd apps/mapgen-studio dev`
+- Build check: `bun run --cwd apps/mapgen-studio build`
+
+## Out of Scope / Defer
+
+- In-browser pipeline runner (Web Worker).
+- Multi-layer playback, diffs, and advanced legend tooling.
+- Geometry layers (paths/polygons/meshes) beyond the first proven slice.

--- a/docs/system/libs/mapgen/pipeline-visualization-deckgl.md
+++ b/docs/system/libs/mapgen/pipeline-visualization-deckgl.md
@@ -1,0 +1,280 @@
+# Pipeline Visualization (Deck.gl) Proposal
+
+> **System:** Mapgen diagnostics and external visualization.
+> **Scope:** Capture per-step artifacts/buffers as post-run dumps and render them in a deck.gl viewer.
+> **Status:** Proposed (design outline).
+
+## Definitions
+
+- **Dump folder**: replayable output containing `manifest.json` and payloads under `data/`.
+- **`outputsRoot`**: where dump folders are written. For V0 we keep dumps local to the map mod’s `dist/` output (see `docs/projects/mapgen-studio/V0-IMPLEMENTATION-PLAN.md`).
+  - **Shortcut (explicit):** writing debug dumps under `dist/` is convenient for local iteration but may be overwritten by rebuilds.
+- **`layerId`**: stable identifier for a layer (recommended form: `<domain>.<name>`).
+- **`runId` / `planFingerprint`**: run identifiers; must match the trace/plan implementation.
+
+## Coordinate Spaces (critical for “why does it look rotated?”)
+
+Mapgen produces data in multiple coordinate systems. The viewer must not “guess” a single space.
+
+### Tile space (game map grid)
+
+- Discrete tiles: `(x, y)` where `0 ≤ x < width`, `0 ≤ y < height`.
+- For Civ7, tiles are hexes; in V0 MapGen Studio renders tile grids as **pointy-top, row-offset** hexes (“Civ-like wide map”).
+- Typical tile-space tensors: `foundation.plates.tile*`, `foundation.crustTiles.*`.
+
+### Mesh space (foundation “plates mesh”)
+
+- A set of irregular sites (points) plus adjacency relationships; this is built via a **Delaunay/Voronoi-style construction**:
+  - Delaunay edges define neighbor connectivity.
+  - Voronoi cells are the dual partition of space around sites.
+- In this codebase, the “mesh” artifact currently dumps:
+  - site coordinates (`siteX/siteY`)
+  - neighbor connectivity (`neighborsOffsets` + `neighbors` CSR)
+  - derived per-cell fields (crust/tectonics/etc)
+- **Important:** mesh-space coordinates are not the same as tile `(x, y)` coordinates. If you plot mesh points in tile space, the result will look skewed/rotated.
+
+### Projection (mesh → tile)
+
+- A dedicated step (Foundation `projection`) produces `tileToCellIndex` (nearest cell per tile).
+- Tile-space arrays derived from mesh-space arrays must use this mapping to “sample” mesh fields into tile fields.
+
+## Purpose
+
+We want a **post-generation visualization system** that can replay any run and show how each layer (buffers, artifacts, and indices) evolves through the pipeline. The viewer must operate **externally** from the pipeline runtime, consuming **logs/trace/dumps** emitted during a run.
+
+Key goals:
+
+- **External replay:** run once, inspect later.
+- **Layered inspection:** show buffers (e.g., temperature), indices (e.g., biome IDs), and derived fields (e.g., mountain masks).
+- **Deterministic provenance:** every layer is tagged with run/step/plan fingerprints.
+- **Zero coupling to runtime:** pipeline must not depend on deck.gl.
+
+---
+
+## Can We Use Trace as-is?
+
+We can keep the existing trace system as the **primary event spine** and add **lightweight dump primitives** on top:
+
+- **Trace already supports** run/step events and allows custom payloads via `trace.event(...)` in step scopes.
+- **Trace sinks are pluggable**, so we can implement a sink that writes **JSONL events + a binary data directory**.
+- **Missing piece:** a standardized, structured **layer dump format** that references large buffers without bloating the trace stream.
+
+### Conclusion
+
+- **No new runtime primitive is required** to emit diagnostics: the trace system is enough.
+- **One new convention is needed:** a **layer dump manifest** + optional helpers to write binary payloads.
+
+### Constraint to make explicit (avoid drift)
+
+If the runtime’s trace implementation gates `step.event` behind “verbose”, then layer dumps emitted via `trace.event(...)` will also be gated. The dump sink design must either:
+- reference the runtime behavior explicitly (e.g. `packages/mapgen-core/src/trace/index.ts`), and
+- document that V0 requires verbose tracing for the instrumented steps, or
+- provide an additional non-verbose dump path (still without impacting pipeline correctness).
+
+---
+
+## System Architecture (Data Flow)
+
+```
+Pipeline run
+  → trace session (runId + planFingerprint)
+  → step.event payloads (metadata only)
+  → dump sink writes:
+       - trace.jsonl   (events)
+       - manifest.json (layer index)
+       - data/         (binary arrays)
+  → deck.gl viewer loads manifest + data
+```
+
+**Key property:** the viewer never runs pipeline code; it replays serialized outputs.
+
+---
+
+## Proposed Dump Primitives
+
+### 1) Trace Sink: `TraceSinkDump`
+
+A drop-in sink that writes events and data to disk:
+
+```
+<outputsRoot>/visualization/<runId>/
+  trace.jsonl
+  manifest.json
+  data/
+    layer-<slug>.bin
+    layer-<slug>.json
+```
+
+- `trace.jsonl`: every `TraceEvent` as JSON per line.
+- `manifest.json`: index of layers (for fast viewer loading).
+- `data/`: raw typed arrays, encoded as binary + sidecar metadata.
+
+### Manifest contract (minimum)
+
+At minimum, the viewer should be able to rely on:
+- `runId`, `planFingerprint`
+- `layers[]` entries with `layerId`, `kind`, `format`, `dims`, `path`, and `stepId`
+
+### 2) Layer Manifest Schema
+
+```json
+{
+  "runId": "<hash>",
+  "planFingerprint": "<hash>",
+  "layers": [
+    {
+      "layerId": "foundation.crust.type",
+      "stepId": "foundation/compute-crust",
+      "era": 0,
+      "kind": "grid",
+      "format": "uint8",
+      "dims": [width, height],
+      "path": "data/layer-foundation-crust-type.bin",
+      "palette": "crustType",
+      "domain": "foundation",
+      "tags": ["artifact", "crust"]
+    }
+  ]
+}
+```
+
+### 3) Layer Dump Event Convention
+
+Layer dumps can be emitted via `trace.event` with a stable payload shape:
+
+```ts
+trace.event(() => ({
+  type: "layer.dump",
+  layerId: "foundation.crust.type",
+  path: "data/layer-foundation-crust-type.bin",
+  dims: [width, height],
+  format: "uint8",
+  palette: "crustType",
+  tags: ["artifact", "crust"],
+}));
+```
+
+The sink can normalize these into `manifest.json` while keeping the raw event stream intact.
+
+---
+
+## Layer Taxonomy (What We Visualize)
+
+**Layer kinds:**
+
+- **Grid layers** (tile fields): elevation, temperature, biome IDs, masks.
+- **Mesh layers** (graph/fields): plate mesh sites, mesh neighbor edges, and per-cell tensors.
+- **Vector layers** (paths): rivers, fault lines, corridors.
+- **Point layers** (samples): craton seeds, hotspots, volcanoes.
+- **Polygon layers** (regions): landmasses, plates.
+
+**Sources:**
+
+- **Buffers:** mutable but snapshot-able (elevation, climate fields).
+- **Artifacts:** immutable products (crust, plate graph, tectonic history).
+- **Fields:** engine-facing outputs (biome IDs, terrain IDs).
+
+---
+
+## Deck.gl Viewer Design
+
+### Viewer App Shape
+
+A standalone web app (or an extension of MapGen Studio) that can load a dump folder:
+
+- **Input:** `manifest.json` + `trace.jsonl` + binary data.
+- **UI:** layer list, time/era controls, palette controls, min/max/legend.
+- **Playback:** step-by-step overlay of layer changes.
+
+### Deck.gl Layer Mapping
+
+| Layer kind | deck.gl layer | Notes |
+|---|---|---|
+| Grid | `PolygonLayer` (hexes) or `BitmapLayer` | V0 uses hex polygons to match Civ; a texture-based approach can come later for speed. |
+| Mesh | `ScatterplotLayer` + `PathLayer` | Sites as points, neighbors as segments (Delaunay adjacency). Voronoi polygons require additional geometry dumps. |
+| Vector | `PathLayer` | Rivers, rifts, corridors. |
+| Point | `ScatterplotLayer` | Seeds, hotspots, volcanoes. |
+| Polygon | `PolygonLayer` | Plate/continent extents. |
+
+### Layer Loading Path (Pseudo)
+
+```ts
+const manifest = await fetch("manifest.json").then((r) => r.json());
+const layer = manifest.layers.find((l) => l.layerId === activeLayerId);
+const data = await fetch(layer.path).then((r) => r.arrayBuffer());
+const texture = toTexture(data, layer.format, layer.dims, palette);
+return new BitmapLayer({ id: layer.layerId, image: texture, bounds });
+```
+
+---
+
+## What Needs to Change in the Pipeline?
+
+### Minimal changes (preferred)
+
+- **Add a dump sink** implementation (no changes to core trace primitives).
+- **Introduce optional helpers** to format layer payloads consistently.
+- **Emit layer dump events** for core artifacts/buffers (guarded by trace verbosity).
+
+### Optional enhancements
+
+- **Step-level opt-in registry** (e.g., `diagnostics.layers` for a step).
+- **Palette registry** in docs (shared legend definitions for IDs/fields).
+- **Layer diff events** (for deltas vs full snapshots).
+
+---
+
+## Visualization of the Pipeline (Conceptual)
+
+```
+Foundation
+  ├─ crust type / age / strength (grid)
+  ├─ plates + boundaries (mesh + vector)
+  └─ tectonic history (grid per era)
+
+Morphology
+  ├─ elevation / slope / erosion (grid)
+  └─ landmass masks (grid + polygons)
+
+Hydrology
+  ├─ rainfall / temp / rivers (grid + vector)
+
+Ecology
+  ├─ biome IDs / soil signals (grid)
+
+Placement
+  └─ starts / wonders (points)
+```
+
+---
+
+## What This Enables
+
+- **Postmortem debugging:** compare two runs by diffing manifests.
+- **Model transparency:** show why a biome landed where it did.
+- **Authoring confidence:** validate knobs and presets visually.
+
+---
+
+## Implementation Sequence (Suggested)
+
+1. Add a **trace dump sink** that writes `trace.jsonl` + `manifest.json` + `data/`.
+2. Add **layer dump helpers** in mapgen-core (format + validation).
+3. Emit layer dumps for the core pipeline (Foundation → Placement).
+4. Build a **deck.gl viewer** (standalone or MapGen Studio).
+5. Add palette definitions + legend mapping docs.
+
+## Verification (proposal → implementation)
+
+- Add a small deterministic test that runs a tiny plan with a dump sink and asserts:
+  - `manifest.json` exists,
+  - at least one `layers[]` entry exists,
+  - the referenced `path` exists and byte length matches `dims × sizeof(format)`.
+
+---
+
+## Open Questions
+
+- **Binary format:** raw typed arrays + sidecar JSON vs Arrow/Parquet.
+- **File size controls:** snapshot every step vs key steps only.
+- **Layer privacy:** remove any user identifiers from dumps.

--- a/mods/mod-swooper-maps/package.json
+++ b/mods/mod-swooper-maps/package.json
@@ -11,6 +11,7 @@
     "check": "tsc --noEmit",
     "pretest": "bun run --cwd ../../packages/mapgen-core build",
     "test": "bun test",
+    "viz:foundation": "bun ./src/dev/viz/foundation-run.ts",
     "deploy": "bun run build && bun run --filter @mateicanavra/civ7-cli dev -- mod manage deploy --input \"$PWD/mod\" --id mod-swooper-maps"
   },
   "dependencies": {

--- a/mods/mod-swooper-maps/src/dev/viz/dump.ts
+++ b/mods/mod-swooper-maps/src/dev/viz/dump.ts
@@ -1,0 +1,343 @@
+import type { TraceEvent, TraceSink, TraceScope } from "@swooper/mapgen-core";
+import type { VizDumper, VizLayerKind, VizScalarFormat } from "@swooper/mapgen-core";
+import { mkdirSync, writeFileSync, appendFileSync } from "node:fs";
+import { join } from "node:path";
+
+type Bounds = [minX: number, minY: number, maxX: number, maxY: number];
+
+export type VizManifestV0 = {
+  version: 0;
+  runId: string;
+  planFingerprint: string;
+  steps: Array<{ stepId: string; phase?: string; stepIndex: number }>;
+  layers: VizLayerEntryV0[];
+};
+
+export type VizLayerEntryV0 =
+  | {
+      kind: "grid";
+      layerId: string;
+      stepId: string;
+      phase?: string;
+      stepIndex: number;
+      format: VizScalarFormat;
+      dims: { width: number; height: number };
+      path: string;
+      bounds: Bounds;
+    }
+  | {
+      kind: "points";
+      layerId: string;
+      stepId: string;
+      phase?: string;
+      stepIndex: number;
+      count: number;
+      positionsPath: string;
+      valuesPath?: string;
+      valueFormat?: VizScalarFormat;
+      bounds: Bounds;
+    }
+  | {
+      kind: "segments";
+      layerId: string;
+      stepId: string;
+      phase?: string;
+      stepIndex: number;
+      count: number;
+      segmentsPath: string;
+      valuesPath?: string;
+      valueFormat?: VizScalarFormat;
+      bounds: Bounds;
+    };
+
+type LayerDumpPayloadV0 =
+  | ({
+      type: "layer.dump";
+      kind: VizLayerKind;
+      layerId: string;
+      bounds: Bounds;
+    } & (
+      | { kind: "grid"; format: VizScalarFormat; dims: { width: number; height: number }; path: string }
+      | {
+          kind: "points";
+          count: number;
+          positionsPath: string;
+          valuesPath?: string;
+          valueFormat?: VizScalarFormat;
+        }
+      | {
+          kind: "segments";
+          count: number;
+          segmentsPath: string;
+          valuesPath?: string;
+          valueFormat?: VizScalarFormat;
+        }
+    ));
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-+)|(-+$)/g, "");
+}
+
+function ensureDir(path: string): void {
+  mkdirSync(path, { recursive: true });
+}
+
+function boundsFromPositions(positions: Float32Array): Bounds {
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  for (let i = 0; i + 1 < positions.length; i += 2) {
+    const x = positions[i]!;
+    const y = positions[i + 1]!;
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+  }
+
+  if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) {
+    return [0, 0, 1, 1];
+  }
+
+  return [minX, minY, maxX, maxY];
+}
+
+function boundsFromSegments(segments: Float32Array): Bounds {
+  // segments is [x0,y0,x1,y1,...] pairs; treat as positions list
+  const positions = new Float32Array((segments.length / 2) | 0);
+  for (let i = 0; i < positions.length; i++) {
+    positions[i] = segments[i]!;
+  }
+  return boundsFromPositions(positions);
+}
+
+function writeBinary(path: string, view: ArrayBufferView): void {
+  const buffer = Buffer.from(view.buffer, view.byteOffset, view.byteLength);
+  writeFileSync(path, buffer);
+}
+
+function resolveRunDir(outputRoot: string, runId: string): string {
+  return join(outputRoot, runId);
+}
+
+function resolveDataDir(outputRoot: string, runId: string): string {
+  return join(resolveRunDir(outputRoot, runId), "data");
+}
+
+export function createTraceDumpSink(options: { outputRoot: string }): TraceSink {
+  const { outputRoot } = options;
+
+  const stepIndexById = new Map<string, number>();
+  let nextStepIndex = 0;
+
+  const manifestByRun = new Map<string, VizManifestV0>();
+
+  const emit = (event: TraceEvent): void => {
+    try {
+      const runDir = resolveRunDir(outputRoot, event.runId);
+      const dataDir = resolveDataDir(outputRoot, event.runId);
+      ensureDir(dataDir);
+
+      appendFileSync(join(runDir, "trace.jsonl"), `${JSON.stringify(event)}\n`);
+
+      let manifest = manifestByRun.get(event.runId);
+      if (!manifest) {
+        manifest = {
+          version: 0,
+          runId: event.runId,
+          planFingerprint: event.planFingerprint,
+          steps: [],
+          layers: [],
+        };
+        manifestByRun.set(event.runId, manifest);
+      }
+
+      if (event.kind === "step.start" && event.stepId) {
+        if (!stepIndexById.has(event.stepId)) {
+          const stepIndex = nextStepIndex++;
+          stepIndexById.set(event.stepId, stepIndex);
+          manifest.steps.push({ stepId: event.stepId, phase: event.phase, stepIndex });
+          writeFileSync(join(runDir, "manifest.json"), JSON.stringify(manifest, null, 2));
+        }
+        return;
+      }
+
+      if (event.kind !== "step.event" || !event.stepId) return;
+      const data = event.data;
+      if (!isPlainObject(data)) return;
+      if (data.type !== "layer.dump") return;
+
+      const payload = data as unknown as LayerDumpPayloadV0;
+      const stepIndex = stepIndexById.get(event.stepId) ?? -1;
+
+      const base = {
+        kind: payload.kind,
+        layerId: payload.layerId,
+        stepId: event.stepId,
+        phase: event.phase,
+        stepIndex,
+        bounds: payload.bounds,
+      } as const;
+
+      let entry: VizLayerEntryV0 | null = null;
+
+      if (payload.kind === "grid") {
+        entry = {
+          ...base,
+          kind: "grid",
+          format: payload.format,
+          dims: payload.dims,
+          path: payload.path,
+        };
+      } else if (payload.kind === "points") {
+        entry = {
+          ...base,
+          kind: "points",
+          count: payload.count,
+          positionsPath: payload.positionsPath,
+          valuesPath: payload.valuesPath,
+          valueFormat: payload.valueFormat,
+        };
+      } else if (payload.kind === "segments") {
+        entry = {
+          ...base,
+          kind: "segments",
+          count: payload.count,
+          segmentsPath: payload.segmentsPath,
+          valuesPath: payload.valuesPath,
+          valueFormat: payload.valueFormat,
+        };
+      }
+
+      if (!entry) return;
+      manifest.layers.push(entry);
+      writeFileSync(join(runDir, "manifest.json"), JSON.stringify(manifest, null, 2));
+    } catch {
+      // tracing/diagnostics must never alter execution flow
+    }
+  };
+
+  return { emit };
+}
+
+export function createVizDumper(options: { outputRoot: string }): VizDumper {
+  const { outputRoot } = options;
+
+  const dumpGrid: VizDumper["dumpGrid"] = (trace, layer) => {
+    if (!trace.isVerbose) return;
+    if (!trace.runId) return;
+
+    try {
+      const runDir = resolveRunDir(outputRoot, trace.runId);
+      const dataDir = resolveDataDir(outputRoot, trace.runId);
+      ensureDir(dataDir);
+
+      const key = layer.fileKey ? `__${slugify(layer.fileKey)}` : "";
+      const fileBase = `${slugify(layer.layerId)}${key}`;
+      const relPath = `data/${fileBase}.bin`;
+      const absPath = join(runDir, relPath);
+
+      writeBinary(absPath, layer.values);
+
+      const { width, height } = layer.dims;
+      const bounds: Bounds = [0, 0, width, height];
+
+      trace.event(() => ({
+        type: "layer.dump",
+        kind: "grid",
+        layerId: layer.layerId,
+        format: layer.format,
+        dims: layer.dims,
+        path: relPath,
+        bounds,
+      }));
+    } catch {
+      // diagnostics must not break generation
+    }
+  };
+
+  const dumpPoints: VizDumper["dumpPoints"] = (trace, layer) => {
+    if (!trace.isVerbose) return;
+    if (!trace.runId) return;
+
+    try {
+      const runDir = resolveRunDir(outputRoot, trace.runId);
+      const dataDir = resolveDataDir(outputRoot, trace.runId);
+      ensureDir(dataDir);
+
+      const key = layer.fileKey ? `__${slugify(layer.fileKey)}` : "";
+      const fileBase = `${slugify(layer.layerId)}${key}`;
+      const posRel = `data/${fileBase}__pos.bin`;
+      const valRel = layer.values ? `data/${fileBase}__val.bin` : undefined;
+
+      writeBinary(join(runDir, posRel), layer.positions);
+      if (layer.values && valRel) {
+        writeBinary(join(runDir, valRel), layer.values);
+      }
+
+      const bounds = boundsFromPositions(layer.positions);
+      trace.event(() => ({
+        type: "layer.dump",
+        kind: "points",
+        layerId: layer.layerId,
+        count: (layer.positions.length / 2) | 0,
+        positionsPath: posRel,
+        valuesPath: valRel,
+        valueFormat: layer.valueFormat,
+        bounds,
+      }));
+    } catch {
+      // diagnostics must not break generation
+    }
+  };
+
+  const dumpSegments: VizDumper["dumpSegments"] = (trace, layer) => {
+    if (!trace.isVerbose) return;
+    if (!trace.runId) return;
+
+    try {
+      const runDir = resolveRunDir(outputRoot, trace.runId);
+      const dataDir = resolveDataDir(outputRoot, trace.runId);
+      ensureDir(dataDir);
+
+      const key = layer.fileKey ? `__${slugify(layer.fileKey)}` : "";
+      const fileBase = `${slugify(layer.layerId)}${key}`;
+      const segRel = `data/${fileBase}__seg.bin`;
+      const valRel = layer.values ? `data/${fileBase}__val.bin` : undefined;
+
+      writeBinary(join(runDir, segRel), layer.segments);
+      if (layer.values && valRel) {
+        writeBinary(join(runDir, valRel), layer.values);
+      }
+
+      const bounds = boundsFromSegments(layer.segments);
+      trace.event(() => ({
+        type: "layer.dump",
+        kind: "segments",
+        layerId: layer.layerId,
+        count: (layer.segments.length / 4) | 0,
+        segmentsPath: segRel,
+        valuesPath: valRel,
+        valueFormat: layer.valueFormat,
+        bounds,
+      }));
+    } catch {
+      // diagnostics must not break generation
+    }
+  };
+
+  return { outputRoot, dumpGrid, dumpPoints, dumpSegments };
+}
+

--- a/mods/mod-swooper-maps/src/dev/viz/foundation-run.ts
+++ b/mods/mod-swooper-maps/src/dev/viz/foundation-run.ts
@@ -1,0 +1,58 @@
+import { createMockAdapter } from "@civ7/adapter";
+import { createExtendedMapContext } from "@swooper/mapgen-core";
+import { deriveRunId } from "@swooper/mapgen-core/engine";
+
+import foundationRecipe from "../../recipes/foundation/recipe.js";
+import { createTraceDumpSink, createVizDumper } from "./dump.js";
+import { join } from "node:path";
+
+function parseIntArg(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const n = Number.parseInt(value, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+// V0 default: Civ7 MAPSIZE_HUGE.
+const width = parseIntArg(process.argv[2], 106);
+const height = parseIntArg(process.argv[3], 66);
+const seed = parseIntArg(process.argv[4], 123);
+
+const outputRoot = join(process.cwd(), "dist", "visualization");
+
+const traceSink = createTraceDumpSink({ outputRoot });
+const viz = createVizDumper({ outputRoot });
+
+const envBase = {
+  seed,
+  dimensions: { width, height },
+  latitudeBounds: { topLatitude: 80, bottomLatitude: -80 },
+} as const;
+
+const plan = foundationRecipe.compile(envBase, { foundation: {} });
+const verboseSteps = Object.fromEntries(plan.nodes.map((node) => [node.stepId, "verbose"] as const));
+
+const env = {
+  ...envBase,
+  trace: {
+    enabled: true,
+    steps: verboseSteps,
+  },
+} as const;
+
+const adapter = createMockAdapter({
+  width,
+  height,
+  mapSizeId: "MAPSIZE_HUGE",
+  mapInfo: {
+    GridWidth: width,
+    GridHeight: height,
+  },
+});
+
+const context = createExtendedMapContext({ width, height }, adapter, env);
+context.viz = viz;
+
+foundationRecipe.run(context, env, { foundation: {} }, { traceSink });
+
+const runId = deriveRunId(plan);
+console.log(`[viz] wrote dump under: ${join(outputRoot, runId)}`);

--- a/mods/mod-swooper-maps/src/maps/swooper-earthlike.ts
+++ b/mods/mod-swooper-maps/src/maps/swooper-earthlike.ts
@@ -30,7 +30,7 @@ export default createMap({
               "strategy": "default",
               "config": {
                 "plateCount": 28,
-                "cellsPerPlate": 7,
+                "cellsPerPlate": 14,
                 "relaxationSteps": 4,
                 "referenceArea": 6996,
                 "plateScalePower": 0.65

--- a/mods/mod-swooper-maps/src/recipes/foundation/recipe.ts
+++ b/mods/mod-swooper-maps/src/recipes/foundation/recipe.ts
@@ -1,0 +1,22 @@
+import { collectCompileOps, createRecipe, type CompiledRecipeConfigOf, type RecipeConfigInputOf } from "@swooper/mapgen-core/authoring";
+import foundationDomain from "@mapgen/domain/foundation/ops";
+
+import foundation from "../standard/stages/foundation/index.js";
+import { STANDARD_TAG_DEFINITIONS } from "../standard/tags.js";
+
+const NAMESPACE = "mod-swooper-maps";
+const stages = [foundation] as const;
+
+export type FoundationRecipeConfig = RecipeConfigInputOf<typeof stages>;
+export type FoundationRecipeCompiledConfig = CompiledRecipeConfigOf<typeof stages>;
+
+export const compileOpsById = collectCompileOps(foundationDomain);
+
+export default createRecipe({
+  id: "foundation",
+  namespace: NAMESPACE,
+  tagDefinitions: STANDARD_TAG_DEFINITIONS,
+  stages,
+  compileOpsById,
+} as const);
+

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crust.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crust.ts
@@ -3,6 +3,7 @@ import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { foundationArtifacts } from "../artifacts.js";
 import CrustStepContract from "./crust.contract.js";
 import { validateCrustArtifact, wrapFoundationValidateNoDims } from "./validation.js";
+import { interleaveXY } from "./viz.js";
 
 export default createStep(CrustStepContract, {
   artifacts: implementArtifacts([foundationArtifacts.crust], {
@@ -24,5 +25,25 @@ export default createStep(CrustStepContract, {
     );
 
     deps.artifacts.foundationCrust.publish(context, crustResult.crust);
+
+    const positions = interleaveXY(mesh.siteX, mesh.siteY);
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.crust.cellType",
+      positions,
+      values: crustResult.crust.type,
+      valueFormat: "u8",
+    });
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.crust.cellAge",
+      positions,
+      values: crustResult.crust.age,
+      valueFormat: "u8",
+    });
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.crust.cellBaseElevation",
+      positions,
+      values: crustResult.crust.baseElevation,
+      valueFormat: "f32",
+    });
   },
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts
@@ -5,6 +5,7 @@ import MeshStepContract from "./mesh.contract.js";
 import { validateMeshArtifact, wrapFoundationValidateNoDims } from "./validation.js";
 import { FOUNDATION_PLATE_COUNT_MULTIPLIER } from "@mapgen/domain/foundation/shared/knob-multipliers.js";
 import type { FoundationPlateCountKnob } from "@mapgen/domain/foundation/shared/knobs.js";
+import { interleaveXY, segmentsFromMeshNeighbors } from "./viz.js";
 
 function clampInt(value: number, bounds: { min: number; max?: number }): number {
   const rounded = Math.round(value);
@@ -53,5 +54,23 @@ export default createStep(MeshStepContract, {
     );
 
     deps.artifacts.foundationMesh.publish(context, meshResult.mesh);
+
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.mesh.sites",
+      positions: interleaveXY(meshResult.mesh.siteX, meshResult.mesh.siteY),
+      values: meshResult.mesh.areas,
+      valueFormat: "f32",
+      fileKey: "areas",
+    });
+
+    context.viz?.dumpSegments(context.trace, {
+      layerId: "foundation.mesh.edges",
+      segments: segmentsFromMeshNeighbors(
+        meshResult.mesh.neighborsOffsets,
+        meshResult.mesh.neighbors,
+        meshResult.mesh.siteX,
+        meshResult.mesh.siteY
+      ),
+    });
   },
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.ts
@@ -5,6 +5,7 @@ import PlateGraphStepContract from "./plateGraph.contract.js";
 import { validatePlateGraphArtifact, wrapFoundationValidateNoDims } from "./validation.js";
 import { FOUNDATION_PLATE_COUNT_MULTIPLIER } from "@mapgen/domain/foundation/shared/knob-multipliers.js";
 import type { FoundationPlateCountKnob } from "@mapgen/domain/foundation/shared/knobs.js";
+import { interleaveXY, pointsFromPlateSeeds } from "./viz.js";
 
 function clampInt(value: number, bounds: { min: number; max?: number }): number {
   const rounded = Math.round(value);
@@ -54,5 +55,21 @@ export default createStep(PlateGraphStepContract, {
     );
 
     deps.artifacts.foundationPlateGraph.publish(context, plateGraphResult.plateGraph);
+
+    const positions = interleaveXY(mesh.siteX, mesh.siteY);
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.plateGraph.cellToPlate",
+      positions,
+      values: plateGraphResult.plateGraph.cellToPlate,
+      valueFormat: "i16",
+    });
+
+    const seeds = pointsFromPlateSeeds(plateGraphResult.plateGraph.plates);
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.plateGraph.plateSeeds",
+      positions: seeds.positions,
+      values: seeds.ids,
+      valueFormat: "i16",
+    });
   },
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts
@@ -4,6 +4,7 @@ import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { foundationArtifacts } from "../artifacts.js";
 import PlateTopologyStepContract from "./plateTopology.contract.js";
 import { validatePlateTopologyArtifact, wrapFoundationValidateNoDims } from "./validation.js";
+import { pointsFromTileCentroids, segmentsFromTileTopologyNeighbors } from "./viz.js";
 
 function validateTopologySymmetry(plates: ReadonlyArray<{ id: number; neighbors: number[] }>): void {
   const neighborSets = new Map<number, Set<number>>();
@@ -49,5 +50,19 @@ export default createStep(PlateTopologyStepContract, {
     validateTopologySymmetry(topologyPlates);
 
     deps.artifacts.foundationPlateTopology.publish(context, { plateCount, plates: topologyPlates });
+
+    const centroidPoints = pointsFromTileCentroids(topologyPlates);
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.plateTopology.centroids",
+      positions: centroidPoints.positions,
+      values: centroidPoints.areas,
+      valueFormat: "i32",
+      fileKey: "areas",
+    });
+
+    context.viz?.dumpSegments(context.trace, {
+      layerId: "foundation.plateTopology.neighbors",
+      segments: segmentsFromTileTopologyNeighbors(topologyPlates),
+    });
   },
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts
@@ -91,6 +91,109 @@ export default createStep(ProjectionStepContract, {
     deps.artifacts.foundationTileToCellIndex.publish(context, platesResult.tileToCellIndex);
     deps.artifacts.foundationCrustTiles.publish(context, platesResult.crustTiles);
 
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.plates.tilePlateId",
+      dims: { width, height },
+      format: "i16",
+      values: platesResult.plates.id,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.plates.tileBoundaryType",
+      dims: { width, height },
+      format: "u8",
+      values: platesResult.plates.boundaryType,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.plates.tileBoundaryCloseness",
+      dims: { width, height },
+      format: "u8",
+      values: platesResult.plates.boundaryCloseness,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.plates.tileTectonicStress",
+      dims: { width, height },
+      format: "u8",
+      values: platesResult.plates.tectonicStress,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.plates.tileUpliftPotential",
+      dims: { width, height },
+      format: "u8",
+      values: platesResult.plates.upliftPotential,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.plates.tileRiftPotential",
+      dims: { width, height },
+      format: "u8",
+      values: platesResult.plates.riftPotential,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.plates.tileShieldStability",
+      dims: { width, height },
+      format: "u8",
+      values: platesResult.plates.shieldStability,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.plates.tileVolcanism",
+      dims: { width, height },
+      format: "u8",
+      values: platesResult.plates.volcanism,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.plates.tileMovementU",
+      dims: { width, height },
+      format: "i8",
+      values: platesResult.plates.movementU,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.plates.tileMovementV",
+      dims: { width, height },
+      format: "i8",
+      values: platesResult.plates.movementV,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.plates.tileRotation",
+      dims: { width, height },
+      format: "i8",
+      values: platesResult.plates.rotation,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.crustTiles.type",
+      dims: { width, height },
+      format: "u8",
+      values: platesResult.crustTiles.type,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.crustTiles.age",
+      dims: { width, height },
+      format: "u8",
+      values: platesResult.crustTiles.age,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.crustTiles.buoyancy",
+      dims: { width, height },
+      format: "f32",
+      values: platesResult.crustTiles.buoyancy,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.crustTiles.baseElevation",
+      dims: { width, height },
+      format: "f32",
+      values: platesResult.crustTiles.baseElevation,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.crustTiles.strength",
+      dims: { width, height },
+      format: "f32",
+      values: platesResult.crustTiles.strength,
+    });
+    context.viz?.dumpGrid(context.trace, {
+      layerId: "foundation.tileToCellIndex",
+      dims: { width, height },
+      format: "i32",
+      values: platesResult.tileToCellIndex,
+    });
+
     context.trace.event(() => {
       const sampleStep = computeSampleStep(width, height);
       const boundaryType = platesResult.plates.boundaryType;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts
@@ -7,6 +7,7 @@ import {
   validateTectonicsArtifact,
   wrapFoundationValidateNoDims,
 } from "./validation.js";
+import { interleaveXY, segmentsFromCellPairs } from "./viz.js";
 
 export default createStep(TectonicsStepContract, {
   artifacts: implementArtifacts(
@@ -49,5 +50,183 @@ export default createStep(TectonicsStepContract, {
 
     deps.artifacts.foundationTectonicHistory.publish(context, historyResult.tectonicHistory);
     deps.artifacts.foundationTectonics.publish(context, historyResult.tectonics);
+
+    const positions = interleaveXY(mesh.siteX, mesh.siteY);
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.tectonics.boundaryType",
+      positions,
+      values: historyResult.tectonics.boundaryType,
+      valueFormat: "u8",
+    });
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.tectonics.upliftPotential",
+      positions,
+      values: historyResult.tectonics.upliftPotential,
+      valueFormat: "u8",
+    });
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.tectonics.riftPotential",
+      positions,
+      values: historyResult.tectonics.riftPotential,
+      valueFormat: "u8",
+    });
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.tectonics.shearStress",
+      positions,
+      values: historyResult.tectonics.shearStress,
+      valueFormat: "u8",
+    });
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.tectonics.volcanism",
+      positions,
+      values: historyResult.tectonics.volcanism,
+      valueFormat: "u8",
+    });
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.tectonics.fracture",
+      positions,
+      values: historyResult.tectonics.fracture,
+      valueFormat: "u8",
+    });
+
+    context.viz?.dumpSegments(context.trace, {
+      layerId: "foundation.tectonics.segments",
+      segments: segmentsFromCellPairs(
+        segmentsResult.segments.aCell,
+        segmentsResult.segments.bCell,
+        mesh.siteX,
+        mesh.siteY
+      ),
+      values: segmentsResult.segments.regime,
+      valueFormat: "u8",
+      fileKey: "regime",
+    });
+
+    context.viz?.dumpSegments(context.trace, {
+      layerId: "foundation.tectonics.segments",
+      segments: segmentsFromCellPairs(
+        segmentsResult.segments.aCell,
+        segmentsResult.segments.bCell,
+        mesh.siteX,
+        mesh.siteY
+      ),
+      values: segmentsResult.segments.compression,
+      valueFormat: "u8",
+      fileKey: "compression",
+    });
+
+    context.viz?.dumpSegments(context.trace, {
+      layerId: "foundation.tectonics.segments",
+      segments: segmentsFromCellPairs(
+        segmentsResult.segments.aCell,
+        segmentsResult.segments.bCell,
+        mesh.siteX,
+        mesh.siteY
+      ),
+      values: segmentsResult.segments.extension,
+      valueFormat: "u8",
+      fileKey: "extension",
+    });
+
+    context.viz?.dumpSegments(context.trace, {
+      layerId: "foundation.tectonics.segments",
+      segments: segmentsFromCellPairs(
+        segmentsResult.segments.aCell,
+        segmentsResult.segments.bCell,
+        mesh.siteX,
+        mesh.siteY
+      ),
+      values: segmentsResult.segments.shear,
+      valueFormat: "u8",
+      fileKey: "shear",
+    });
+
+    context.viz?.dumpSegments(context.trace, {
+      layerId: "foundation.tectonics.segments",
+      segments: segmentsFromCellPairs(
+        segmentsResult.segments.aCell,
+        segmentsResult.segments.bCell,
+        mesh.siteX,
+        mesh.siteY
+      ),
+      values: segmentsResult.segments.volcanism,
+      valueFormat: "u8",
+      fileKey: "volcanism",
+    });
+
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.tectonicHistory.upliftTotal",
+      positions,
+      values: historyResult.tectonicHistory.upliftTotal,
+      valueFormat: "u8",
+    });
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.tectonicHistory.fractureTotal",
+      positions,
+      values: historyResult.tectonicHistory.fractureTotal,
+      valueFormat: "u8",
+    });
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.tectonicHistory.volcanismTotal",
+      positions,
+      values: historyResult.tectonicHistory.volcanismTotal,
+      valueFormat: "u8",
+    });
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.tectonicHistory.upliftRecentFraction",
+      positions,
+      values: historyResult.tectonicHistory.upliftRecentFraction,
+      valueFormat: "u8",
+    });
+    context.viz?.dumpPoints(context.trace, {
+      layerId: "foundation.tectonicHistory.lastActiveEra",
+      positions,
+      values: historyResult.tectonicHistory.lastActiveEra,
+      valueFormat: "u8",
+    });
+
+    const eras = historyResult.tectonicHistory.eras ?? [];
+    for (let eraIndex = 0; eraIndex < eras.length; eraIndex++) {
+      const era = eras[eraIndex];
+      if (!era) continue;
+      const prefix = `foundation.tectonicHistory.era${eraIndex}`;
+
+      context.viz?.dumpPoints(context.trace, {
+        layerId: `${prefix}.boundaryType`,
+        positions,
+        values: era.boundaryType,
+        valueFormat: "u8",
+      });
+      context.viz?.dumpPoints(context.trace, {
+        layerId: `${prefix}.upliftPotential`,
+        positions,
+        values: era.upliftPotential,
+        valueFormat: "u8",
+      });
+      context.viz?.dumpPoints(context.trace, {
+        layerId: `${prefix}.riftPotential`,
+        positions,
+        values: era.riftPotential,
+        valueFormat: "u8",
+      });
+      context.viz?.dumpPoints(context.trace, {
+        layerId: `${prefix}.shearStress`,
+        positions,
+        values: era.shearStress,
+        valueFormat: "u8",
+      });
+      context.viz?.dumpPoints(context.trace, {
+        layerId: `${prefix}.volcanism`,
+        positions,
+        values: era.volcanism,
+        valueFormat: "u8",
+      });
+      context.viz?.dumpPoints(context.trace, {
+        layerId: `${prefix}.fracture`,
+        positions,
+        values: era.fracture,
+        valueFormat: "u8",
+      });
+    }
   },
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/viz.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/viz.ts
@@ -1,0 +1,115 @@
+export function interleaveXY(x: Float32Array, y: Float32Array): Float32Array {
+  const n = Math.min(x.length, y.length);
+  const out = new Float32Array(n * 2);
+  for (let i = 0; i < n; i++) {
+    out[i * 2] = x[i];
+    out[i * 2 + 1] = y[i];
+  }
+  return out;
+}
+
+export function pointsFromPlateSeeds(
+  plates: ReadonlyArray<{ id: number; seedX: number; seedY: number }>
+): { positions: Float32Array; ids: Int16Array } {
+  const positions = new Float32Array(plates.length * 2);
+  const ids = new Int16Array(plates.length);
+  for (let i = 0; i < plates.length; i++) {
+    const plate = plates[i]!;
+    positions[i * 2] = plate.seedX;
+    positions[i * 2 + 1] = plate.seedY;
+    ids[i] = plate.id;
+  }
+  return { positions, ids };
+}
+
+export function segmentsFromCellPairs(
+  aCell: Int32Array,
+  bCell: Int32Array,
+  siteX: Float32Array,
+  siteY: Float32Array
+): Float32Array {
+  const n = Math.min(aCell.length, bCell.length);
+  const out = new Float32Array(n * 4);
+  for (let i = 0; i < n; i++) {
+    const a = aCell[i]!;
+    const b = bCell[i]!;
+    out[i * 4] = siteX[a] ?? 0;
+    out[i * 4 + 1] = siteY[a] ?? 0;
+    out[i * 4 + 2] = siteX[b] ?? 0;
+    out[i * 4 + 3] = siteY[b] ?? 0;
+  }
+  return out;
+}
+
+export function segmentsFromMeshNeighbors(
+  neighborsOffsets: Int32Array,
+  neighbors: Int32Array,
+  siteX: Float32Array,
+  siteY: Float32Array
+): Float32Array {
+  const cellCount = Math.max(0, Math.min(siteX.length, siteY.length));
+  if (cellCount <= 0) return new Float32Array();
+  if (neighborsOffsets.length < cellCount + 1) return new Float32Array();
+
+  const segments: number[] = [];
+
+  for (let cell = 0; cell < cellCount; cell++) {
+    const start = neighborsOffsets[cell] ?? 0;
+    const end = neighborsOffsets[cell + 1] ?? start;
+    const x0 = siteX[cell] ?? 0;
+    const y0 = siteY[cell] ?? 0;
+
+    for (let j = start; j < end; j++) {
+      const other = neighbors[j] ?? -1;
+      // Deduplicate undirected edges.
+      if (other <= cell) continue;
+      if (other < 0 || other >= cellCount) continue;
+      const x1 = siteX[other] ?? 0;
+      const y1 = siteY[other] ?? 0;
+      segments.push(x0, y0, x1, y1);
+    }
+  }
+
+  return new Float32Array(segments);
+}
+
+export function pointsFromTileCentroids(
+  plates: ReadonlyArray<{ id: number; centroid: { x: number; y: number }; area: number }>
+): { positions: Float32Array; ids: Int16Array; areas: Int32Array } {
+  const positions = new Float32Array(plates.length * 2);
+  const ids = new Int16Array(plates.length);
+  const areas = new Int32Array(plates.length);
+  for (let i = 0; i < plates.length; i++) {
+    const plate = plates[i]!;
+    positions[i * 2] = plate.centroid.x;
+    positions[i * 2 + 1] = plate.centroid.y;
+    ids[i] = plate.id;
+    areas[i] = plate.area;
+  }
+  return { positions, ids, areas };
+}
+
+export function segmentsFromTileTopologyNeighbors(
+  plates: ReadonlyArray<{ id: number; centroid: { x: number; y: number }; neighbors: number[] }>
+): Float32Array {
+  const centroidById = new Map<number, { x: number; y: number }>();
+  for (const plate of plates) centroidById.set(plate.id, plate.centroid);
+
+  const segments: number[] = [];
+  const seen = new Set<string>();
+
+  for (const plate of plates) {
+    const a = centroidById.get(plate.id);
+    if (!a) continue;
+    for (const neighborId of plate.neighbors) {
+      const b = centroidById.get(neighborId);
+      if (!b) continue;
+      const k = plate.id < neighborId ? `${plate.id}-${neighborId}` : `${neighborId}-${plate.id}`;
+      if (seen.has(k)) continue;
+      seen.add(k);
+      segments.push(a.x, a.y, b.x, b.y);
+    }
+  }
+
+  return new Float32Array(segments);
+}

--- a/mods/mod-swooper-maps/tsconfig.json
+++ b/mods/mod-swooper-maps/tsconfig.json
@@ -15,5 +15,6 @@
     "moduleResolution": "Bundler",
     "types": ["@civ7/types"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/dev/**"]
 }

--- a/packages/mapgen-core/src/core/types.ts
+++ b/packages/mapgen-core/src/core/types.ts
@@ -158,6 +158,58 @@ export interface GenerationMetrics {
   warnings: string[];
 }
 
+export type VizLayerKind = "grid" | "points" | "segments";
+
+export type VizScalarFormat = "u8" | "i8" | "u16" | "i16" | "i32" | "f32";
+
+export interface VizDumper {
+  /**
+   * Base directory for run dumps. The concrete run directory is typically
+   * resolved as `${outputRoot}/${runId}`.
+   *
+   * NOTE: this is expected to be injected by local tooling; runtime/game code
+   * should not assume it exists.
+   */
+  outputRoot: string;
+
+  dumpGrid: (
+    trace: TraceScope,
+    layer: {
+      layerId: string;
+      dims: { width: number; height: number };
+      format: VizScalarFormat;
+      values: ArrayBufferView;
+      /**
+       * Optional stable suffix to keep filenames unique within a run.
+       * Does not affect `layerId` (which should remain stable).
+       */
+      fileKey?: string;
+    }
+  ) => void;
+
+  dumpPoints: (
+    trace: TraceScope,
+    layer: {
+      layerId: string;
+      positions: Float32Array; // [x0,y0,x1,y1,...]
+      values?: ArrayBufferView;
+      valueFormat?: VizScalarFormat;
+      fileKey?: string;
+    }
+  ) => void;
+
+  dumpSegments: (
+    trace: TraceScope,
+    layer: {
+      layerId: string;
+      segments: Float32Array; // [x0,y0,x1,y1,...] pairs per segment
+      values?: ArrayBufferView;
+      valueFormat?: VizScalarFormat;
+      fileKey?: string;
+    }
+  ) => void;
+}
+
 // ============================================================================
 // Extended MapContext
 // ============================================================================
@@ -173,6 +225,7 @@ export interface ExtendedMapContext {
   env: Env;
   metrics: GenerationMetrics;
   trace: TraceScope;
+  viz?: VizDumper;
   adapter: EngineAdapter;
   /**
    * Published data products keyed by dependency tag (e.g. "artifact:climateField").

--- a/packages/mapgen-core/src/trace/index.ts
+++ b/packages/mapgen-core/src/trace/index.ts
@@ -30,6 +30,8 @@ export interface TraceStepMeta {
 }
 
 export interface TraceScope {
+  runId: string;
+  planFingerprint: string;
   level: TraceLevel;
   isEnabled: boolean;
   isVerbose: boolean;
@@ -50,6 +52,8 @@ export interface TraceSession {
 }
 
 const NOOP_SCOPE: TraceScope = Object.freeze({
+  runId: "",
+  planFingerprint: "",
   level: "off",
   isEnabled: false,
   isVerbose: false,
@@ -172,7 +176,7 @@ export function createTraceSession(options: TraceSessionOptions): TraceSession {
       emit({ kind: "step.event", ...meta, data: payload });
     };
 
-    return { level, isEnabled, isVerbose, event };
+    return { runId, planFingerprint, level, isEnabled, isVerbose, event };
   };
 
   return {


### PR DESCRIPTION
Adds V0 foundation visualization: per-step dumps for mesh/crust/plates/tectonics/topology written under mods/mod-swooper-maps/dist/visualization/<runId>, plus a MapGen Studio viewer that loads manifest.json and renders grid/points/segments with step+layer pickers.

Run: bun run --cwd mods/mod-swooper-maps viz:foundation, then bun run --cwd apps/mapgen-studio dev and open the dump folder.