### PR TITLE
spike(mapgen): slice 13 kickoff (deprecation manifest + linking + handoff)

### DIFF
--- a/docs/projects/engine-refactor-v1/mapgen-docs-alignment/DEPRECATION-MANIFEST.md
+++ b/docs/projects/engine-refactor-v1/mapgen-docs-alignment/DEPRECATION-MANIFEST.md
@@ -1,0 +1,103 @@
+<toc>
+  <item id="tldr" title="TL;DR"/>
+  <item id="scope" title="Scope"/>
+  <item id="rules" title="Rules (how we decide)"/>
+  <item id="rubric" title="Classification rubric"/>
+  <item id="manifest" title="Deprecation manifest (candidates)"/>
+  <item id="scan" title="Scan output (untriaged)"/>
+  <item id="next" title="Next actions (follow-on slices)"/>
+  <item id="anchors" title="Ground truth anchors"/>
+</toc>
+
+# Deprecation manifest: MapGen-related docs outside the canonical spine
+
+## TL;DR
+
+We now have a canonical MapGen doc spine under `docs/system/libs/mapgen/**`.
+
+To make that spine safe to treat as “primary source of truth” (for humans and agents), we still need an explicit sweep
+of **other** MapGen-related docs/specs elsewhere in the repo and a manifest of:
+- what should be **archived** (not deleted),
+- what should be **kept but explicitly framed** (project history / planning docs),
+- what should be **routed** to canonical docs (legacy entrypoints),
+- and what should be **updated** to avoid conflicting guidance.
+
+This file is the authoritative working manifest for that sweep.
+
+## Scope
+
+Included:
+- Any non-archived docs under `docs/**` that contain **MapGen guidance** (how to run, how to extend, architecture/contracts),
+  but do **not** live under `docs/system/libs/mapgen/**`.
+- Project docs/specs that are likely to be found by agents (by search) and accidentally treated as canonical.
+
+Excluded:
+- `docs/_archive/**` (already archived; we may still add routers, but we don’t “re-archive” these).
+- `docs/_sidebar.md` (auto-generated; do not edit).
+
+## Rules (how we decide)
+
+We keep a hard separation between:
+- **WHAT IS**: current implementation posture (anchored to code paths/symbols), and
+- **WHAT SHOULD BE**: target authority posture (anchored to workflow/spec docs).
+
+We do **not** “decide architecture by doc-writing” during this sweep.
+
+## Classification rubric
+
+For each candidate doc:
+
+- `archive`: obsolete/superseded; should move under `docs/_archive/**` (preserve history).
+- `route`: keep file but convert it to a short router (“This is legacy; go here instead”), then point to canonical docs.
+- `keep`: still useful and non-conflicting; may add a small “Status” header clarifying its scope.
+- `update`: still needed but has conflicting guidance; must be corrected to align with canonical docs and/or target authority.
+
+## Deprecation manifest (candidates)
+
+> This table is intentionally conservative: being in the list does **not** automatically mean “archive it”.
+> It means “it’s MapGen-adjacent and likely to cause confusion unless explicitly handled.”
+
+| path | status | why obsolete / risky | replaced by (canonical) | notes |
+|---|---|---|---|---|
+| `docs/projects/mapgen-studio/V0-IMPLEMENTATION-PLAN.md` | archive | V0 plan docs read as actionable instructions, but Studio + viz posture has now moved to the canonical MapGen spine and current Studio code. | `docs/system/libs/mapgen/MAPGEN.md`, `docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`, `docs/system/libs/mapgen/pipeline-visualization-deckgl.md` | Archive as “implementation history”; keep as provenance only. |
+| `docs/projects/mapgen-studio/V0.1-SLICE-FOUNDATION-WORKER-DECKGL.md` | archive | Slice planning doc; likely conflicts with current deck.gl viewer implementation + naming (`layer` → `dataType`, `projection` → `renderMode`). | `docs/system/libs/mapgen/pipeline-visualization-deckgl.md` | Replace with a router or archive; prefer archive if fully superseded. |
+| `docs/projects/mapgen-studio/V0.1-SLICE-TILESPACE-HEIGHT-LANDMASK-DECKGL.md` | archive | Early viz slice planning; may describe deprecated layer taxonomy. | `docs/system/libs/mapgen/pipeline-visualization-deckgl.md` | Same. |
+| `docs/projects/mapgen-studio/V0.1-SLICE-CONFIG-OVERRIDES-UI-WORKER.md` | archive | Early config-overrides planning; Studio UI + schema-defaulting posture has evolved. | `docs/system/libs/mapgen/tutorials/run-standard-recipe-in-studio.md`, `docs/system/libs/mapgen/tutorials/tune-a-preset-and-knobs.md` | Archive as history; optionally add a short pointer to current tutorial docs. |
+| `docs/projects/mapgen-studio/BROWSER-RUNNER-V0.1.md` | update/keep | Could still be useful as deep design notes, but it must not contradict the canonical Studio seam docs and must clearly label itself as project doc. | `docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md` | Candidate for “keep with explicit Status header + ‘See canonical’ links”. |
+| `docs/projects/mapgen-studio/BROWSER-ADAPTER.md` | update/keep | Potentially still relevant, but must not be treated as canonical SDK docs. | `docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md` | Likely “keep” with framing. |
+| `docs/projects/mapgen-studio/VIZ-SDK-V1.md` | update | If it defines viz contracts that differ from current `@swooper/mapgen-viz` and Studio dump viewer reality, it’s a conflict risk. | `docs/system/libs/mapgen/reference/VISUALIZATION.md`, `docs/system/libs/mapgen/pipeline-visualization-deckgl.md` | Needs parity check once viz implementation stack stabilizes. |
+| `docs/projects/mapgen-studio/VIZ-LAYER-CATALOG.md` | update/keep | Useful, but if it uses old terminology (layer/projection) it should be updated or labeled as historical. | `docs/system/libs/mapgen/pipeline-visualization-deckgl.md` | Might become an appendix linked from canonical viz doc (if still accurate). |
+| `docs/projects/mapgen-studio/VIZ-DECLUTTER-SEMANTICS-GREENFIELD-PLAN.md` | keep/archive | Plan doc; may still guide future viz work. Risk is being mistaken as current contract. | `docs/system/libs/mapgen/pipeline-visualization-deckgl.md` | Prefer keep but add top “Status: project plan; canonical contract is …”. |
+| `docs/projects/mapgen-studio/ROADMAP.md` | keep | Roadmap is legitimate, but should route readers to canonical contracts so it’s not used as “how to”. | `docs/system/libs/mapgen/MAPGEN.md` | Add explicit “canon lives here” link. |
+| `docs/projects/mapgen-studio/architecture-assessment.md` | keep/archive | Assessment docs are useful but can confuse “current” vs “target”. | `docs/system/libs/mapgen/architecture/ARCHITECTURE.md` | Consider “keep with framing”. |
+| `docs/system/mods/swooper-maps/architecture.md` | update | If it gives usage guidance that duplicates/collides with canonical MapGen docs, add explicit routing and remove prescriptive instructions. | `docs/system/libs/mapgen/MAPGEN.md` | This is mod-level doc; should focus on mod structure, not MapGen SDK contracts. |
+| `docs/system/mods/swooper-maps/vision.md` | keep | Vision-level doc is OK; ensure it doesn’t prescribe old architecture. | `docs/system/libs/mapgen/MAPGEN.md` | Add a “See canonical MapGen docs” link if missing. |
+| `docs/system/ADR.md` (MapGen/viz sections) | keep | ADRs are canonical decisions; they should remain but may need explicit links to the canonical doc spine. | `docs/system/libs/mapgen/pipeline-visualization-deckgl.md` | Keep; add cross-links only if they help. |
+
+## Scan output (untriaged)
+
+The curated table above is not exhaustive. For a machine-assisted, search-based candidate list (not triaged),
+see:
+- `docs/projects/engine-refactor-v1/mapgen-docs-alignment/scratch/deprecation-scan.md`
+
+## Next actions (follow-on slices)
+
+This manifest enables two follow-on slices (not done in this slice):
+
+1) **Slice 13B — Execute archiving + routing**  
+   - Move `archive` docs under `docs/_archive/**` (preserve structure), using a Python script (bulk move).
+   - Convert `route` docs into minimal routers that point to canonical pages.
+   - Add a short “Status” header to `keep/update` docs clarifying scope.
+
+2) **Slice 13C — Viz parity pass (post-merge)**  
+   - Once the `dev-viz-v1-*` implementation stack stabilizes/merges, update canonical viz docs to match:
+     - UI terminology (`layer` vs `dataType`, `projection` vs `renderMode`),
+     - any contract shape changes (if any),
+     - and viewer workflow details.
+
+## Ground truth anchors
+
+- Canonical MapGen gateway: `docs/system/libs/mapgen/MAPGEN.md`
+- Canonical Studio seam reference: `docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`
+- Canonical viz doc: `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
+- Claim/audit posture (no architecture invention): `docs/projects/engine-refactor-v1/mapgen-docs-alignment/SLICE-12A-CLAIMS-AUDIT-DIRECTIVE.md`

--- a/docs/projects/engine-refactor-v1/mapgen-docs-alignment/HANDOFF-CONTEXT-PACKET.md
+++ b/docs/projects/engine-refactor-v1/mapgen-docs-alignment/HANDOFF-CONTEXT-PACKET.md
@@ -1,0 +1,131 @@
+<toc>
+  <item id="purpose" title="Purpose"/>
+  <item id="tldr" title="TL;DR (what to do next)"/>
+  <item id="where" title="Where the canonical docs live"/>
+  <item id="invariants" title="Critical invariants (do not regress)"/>
+  <item id="workflow" title="Workflow + tooling"/>
+  <item id="current-state" title="Current stack state (high level)"/>
+  <item id="next-work" title="Next work (cleanups + parity)"/>
+  <item id="gotchas" title="Gotchas"/>
+  <item id="anchors" title="Ground truth anchors"/>
+</toc>
+
+# Handoff context packet: MapGen docs alignment + follow-up cleanup
+
+## Purpose
+
+This packet is meant to onboard a fresh agent so they can continue MapGen docs work without rediscovering context or
+reintroducing architecture regressions.
+
+## TL;DR (what to do next)
+
+Immediate follow-ups:
+
+1) **Viz parity patch (post-merge)**  
+   - The viz implementation stack (`dev-viz-v1-*`) is still moving; once it stabilizes, reconcile canonical viz docs:
+     - match UI terminology (`layer` → `dataType`, `projection` → `renderMode`),
+     - confirm paths/symbols in `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`,
+     - and update `docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md` if workflows changed.
+
+2) **Docs sweep + deprecation manifest execution**  
+   - Use `docs/projects/engine-refactor-v1/mapgen-docs-alignment/DEPRECATION-MANIFEST.md` as the working manifest.
+   - Decide which candidate docs are `archive` vs `keep/update/route`, then execute moves/routers as a slice using Python scripts for bulk moves.
+
+3) **Link normalization / lightweight backlinks (optional)**  
+   - If desired, implement `docs/projects/engine-refactor-v1/mapgen-docs-alignment/LINKING-BACKLINKS-PROPOSAL.md` as Slice 14A/14B.
+
+## Where the canonical docs live
+
+Canonical MapGen docs:
+
+- Gateway (start here): `docs/system/libs/mapgen/MAPGEN.md`
+- Tutorials: `docs/system/libs/mapgen/tutorials/TUTORIALS.md`
+- How-to: `docs/system/libs/mapgen/how-to/HOW-TO.md`
+- Reference: `docs/system/libs/mapgen/reference/REFERENCE.md`
+- Explanation: `docs/system/libs/mapgen/explanation/EXPLANATION.md`
+- Policies: `docs/system/libs/mapgen/policies/POLICIES.md`
+- AI-agent entrypoint: `docs/system/libs/mapgen/llms/LLMS.md`
+- Canonical viz doc: `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
+
+Project alignment artifacts (planning/audit; not the “product docs”):
+
+- Prompt: `docs/projects/engine-refactor-v1/mapgen-docs-alignment/PROMPT.md`
+- Spike synthesis: `docs/projects/engine-refactor-v1/mapgen-docs-alignment/SPIKE.md`
+- Claims audit directive: `docs/projects/engine-refactor-v1/mapgen-docs-alignment/SLICE-12A-CLAIMS-AUDIT-DIRECTIVE.md`
+- Claims ledger: `docs/projects/engine-refactor-v1/mapgen-docs-alignment/scratch/claims-ledger/CLAIMS-LEDGER.md`
+- Examples plan (Slice 12B): `docs/projects/engine-refactor-v1/mapgen-docs-alignment/SLICE-12B-CONCRETE-EXAMPLES-PROPOSAL.md`
+
+## Critical invariants (do not regress)
+
+Architecture posture:
+- Do not “invent” architecture via docs. Maintain separation of:
+  - **WHAT IS** (anchored to current code), vs
+  - **WHAT SHOULD BE** (anchored to authoritative workflow/spec docs).
+
+Known canonical decisions encoded in docs:
+- `Env` is the canonical run boundary. `RunSettings` is legacy naming only (router acceptable).
+- Gameplay absorbs Narrative + Placement; do not present Narrative/Placement as target-canonical MapGen domains.
+- Deck.gl visualization pipeline is **current canon** (implemented). Do not fork competing viz docs.
+
+Docs conventions:
+- Do not edit `docs/_sidebar.md` (auto-generated).
+- Canonical pages start with a mini XML `<toc>`.
+- Canonical pages include “Ground truth anchors” (except explicit “legacy router” stubs).
+
+## Workflow + tooling
+
+Repo uses Graphite stacks (small, reviewable slices):
+- Each slice should be its own stacked branch/PR (avoid mega PRs).
+- During `gt sync`/`gt submit`, accept restacks and branch deletions (normal cleanup as merges happen below).
+
+Useful commands:
+- View stack: `gt log --stack`
+- Sync + restack: `gt sync`
+- Submit current branch (non-interactive): `gt submit`
+- Docs linter: `bun run lint:mapgen-docs`
+
+Code-intel:
+- `narsil-code-intel` MCP may be unavailable (“Transport closed”). Fallback to `rg` + direct file reads.
+
+## Current stack state (high level)
+
+As of the end of Slice 12B:
+- Slice 12A resolved P0/P1 drift via claims ledger + corrective patches.
+- Slice 12B upgraded how-tos/tutorials with runnable commands and minimal anchored code excerpts, including:
+  - trace + viz dump replay workflow,
+  - Studio worker seam snippets,
+  - runnable tutorials.
+
+If you need exact branch/PR numbers, run `gt log --stack` in the active worktree.
+
+## Next work (cleanups + parity)
+
+1) **Viz parity patch**  
+   - Wait for the viz implementation stack (`dev-viz-v1-*`) to stabilize/merge.
+   - Reconcile canonical docs to match the merged UI naming and any contract changes:
+     - `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
+     - `docs/system/libs/mapgen/reference/VISUALIZATION.md`
+     - `docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md`
+
+2) **Repo-wide docs sweep / archive execution**  
+   - Populate and execute `docs/projects/engine-refactor-v1/mapgen-docs-alignment/DEPRECATION-MANIFEST.md`.
+   - Goal: prevent agents from discovering old project docs and treating them as canonical usage instructions.
+
+3) **Ecology refactor readiness**  
+   - For the ecology domain rework, prefer:
+     - canonical MapGen docs for “how to work in the system”, plus
+     - the engine-refactor workflow plan docs for “target modeling workflow”.
+   - Do not let “current ecology implementation docs” silently define the target architecture.
+
+## Gotchas
+
+- Studio “presets” vs “schema defaults”: Studio currently defaults pipeline config using schema defaults, not a curated preset catalog. Docs should reflect reality.
+- Viz “layer” terminology is in flux: current Studio UI code is trending toward “dataType/renderMode/variant”; avoid hardcoding UI labels until the viz stack merges.
+- Don’t mass-edit links or archive content without a manifest and a Python-scripted move (bulk operations policy).
+
+## Ground truth anchors
+
+- Canonical MapGen gateway: `docs/system/libs/mapgen/MAPGEN.md`
+- Canonical viz: `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
+- Authority posture: `docs/projects/engine-refactor-v1/mapgen-docs-alignment/SLICE-12A-CLAIMS-AUDIT-DIRECTIVE.md`
+- Deprecation sweep manifest: `docs/projects/engine-refactor-v1/mapgen-docs-alignment/DEPRECATION-MANIFEST.md`

--- a/docs/projects/engine-refactor-v1/mapgen-docs-alignment/LINKING-BACKLINKS-PROPOSAL.md
+++ b/docs/projects/engine-refactor-v1/mapgen-docs-alignment/LINKING-BACKLINKS-PROPOSAL.md
@@ -1,0 +1,119 @@
+<toc>
+  <item id="tldr" title="TL;DR"/>
+  <item id="current" title="Current posture (why it looks like plain text)"/>
+  <item id="recommendation" title="Recommendation"/>
+  <item id="conventions" title="Proposed conventions"/>
+  <item id="backlinks" title="Backlinks: do we want them?"/>
+  <item id="slices" title="Implementation slices"/>
+  <item id="anchors" title="Ground truth anchors"/>
+</toc>
+
+# Proposal: links + backlinks for the MapGen canonical docs spine
+
+## TL;DR
+
+The current MapGen docs intentionally use **literal path references** (e.g. `docs/system/libs/mapgen/...`) because:
+- they are extremely searchable (humans + AI agents),
+- they survive refactors (the text still matches the repo path),
+- and they avoid link-rot when pages are moved or the site routing changes.
+
+However, navigation is genuinely worse without clickable links.
+
+Recommendation:
+- keep the literal paths as **link text**, but make them **real markdown links** using stable docs-site absolute paths (e.g. `/system/libs/mapgen/...`), and
+- adopt a minimal, low-rot “Related / Up / See also” pattern instead of a full backlink graph.
+
+## Current posture (why it looks like plain text)
+
+In the spike, the priority was:
+1) correct target-authority posture (“WHAT IS” vs “WHAT SHOULD BE”), and
+2) eliminate ambiguity/drift without inventing architecture.
+
+Using literal path references was a deliberate tactic:
+- Agents can reliably “jump” to a file by exact string match.
+- It’s resilient even if the docs renderer changes.
+
+The cost: navigation in the rendered docs is weaker, and context is easier to lose.
+
+## Recommendation
+
+Implement link normalization as a follow-on slice:
+
+- Convert canonical doc spine references like:
+  - ``docs/system/libs/mapgen/reference/STANDARD-RECIPE.md``
+  into:
+  - [`docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`](/system/libs/mapgen/reference/STANDARD-RECIPE.md)
+
+This keeps:
+- searchability (the literal path remains visible),
+- and adds clickability (docs-site absolute link).
+
+## Proposed conventions
+
+### 1) Link style for internal docs
+
+Use markdown links whose **visible text is the literal repo path**:
+
+```
+[`docs/system/libs/mapgen/MAPGEN.md`](/system/libs/mapgen/MAPGEN.md)
+```
+
+Rationale:
+- visible string still helps grep/search,
+- the href is stable within the docs site.
+
+### 2) “Related” sections (lightweight backlinks)
+
+Instead of global backlinks, add a small section to “hub” pages:
+
+- `MAPGEN.md`: “Start here” + “Fast links”
+- each index page (`REFERENCE.md`, `HOW-TO.md`, `TUTORIALS.md`, `EXPLANATION.md`): short “See also”
+
+Avoid backlinking every leaf page to every parent; it creates high maintenance cost.
+
+### 3) One canonical “routing” map per doc type
+
+Prefer index pages as the navigational backbone, not ad-hoc backlinks:
+- `docs/system/libs/mapgen/tutorials/TUTORIALS.md`
+- `docs/system/libs/mapgen/how-to/HOW-TO.md`
+- `docs/system/libs/mapgen/reference/REFERENCE.md`
+- `docs/system/libs/mapgen/explanation/EXPLANATION.md`
+
+### 4) Keep “Ground truth anchors” as plain paths
+
+Anchors remain plain paths (not links) because they are “evidence strings” more than navigation aids.
+
+## Backlinks: do we want them?
+
+Recommendation: **no full backlink graph**, yes to **lightweight local backlinks**.
+
+Why avoid full backlinks:
+- They are hard to keep correct as the spine evolves.
+- They can accidentally encode “this is canon” through association.
+- They often become noise in agent contexts.
+
+What we do want:
+- a predictable “Up / See also” pattern on hub pages,
+- and an optional `RELATED.md` per directory if navigation genuinely suffers.
+
+## Implementation slices
+
+If we do this, implement it as two small slices:
+
+1) **Slice 14A — Link normalization**  
+   - Update `docs/system/libs/mapgen/**` to make “Fast links” and other cross-doc pointers clickable.
+   - Keep literal path strings as visible text.
+   - Do not touch `docs/_sidebar.md`.
+
+2) **Slice 14B — Lightweight “Related” sections**  
+   - Add `## See also` to the hub pages only.
+   - Keep leaf pages focused; no giant link farms.
+
+Optional tooling:
+- A small Python script that finds inline-code doc paths and offers a patch (non-destructive) to turn them into markdown links when safe.
+
+## Ground truth anchors
+
+- Canonical MapGen gateway: `docs/system/libs/mapgen/MAPGEN.md`
+- Canonical doc spine policies: `docs/system/libs/mapgen/policies/POLICIES.md`
+- Diátaxis routing: `docs/system/libs/mapgen/MAPGEN.md` (“Routing map (Diátaxis)”)

--- a/docs/projects/engine-refactor-v1/mapgen-docs-alignment/SPIKE.md
+++ b/docs/projects/engine-refactor-v1/mapgen-docs-alignment/SPIKE.md
@@ -21,7 +21,7 @@
 Reconcile our current MapGen docs + examples with the intended “DX-first” architecture:
 - MapGen core SDK
 - MapGen pipeline / recipe model
-- Domains + “standard recipe” (foundation/morphology/hydrology/ecology/placement/narrative)
+- Domains + “standard recipe” (foundation/morphology/hydrology/ecology), plus gameplay surfaces
 
 This spike treats all non-archived docs as **not meeting the bar** until proven otherwise.
 
@@ -39,7 +39,7 @@ This is the integrated “where we are” picture after auditing:
 - The **standard recipe** has a coherent stage order and a practical separation between:
   - **truth** artifact-producing stages (foundation/morphology/hydrology/ecology), and
   - gameplay **projection** stages that mostly produce `effect:*` / `field:*` and write engine-facing surfaces.
-- Domain conceptual docs under `docs/system/libs/mapgen/**` are generally strong and align with the target mental model (especially Hydrology + Placement + Narrative’s intended posture).
+- Domain conceptual docs under `docs/system/libs/mapgen/**` are generally strong and align with the target mental model (especially Foundation/Morphology/Hydrology), while gameplay-facing concerns are now documented under a separate “Gameplay” domain surface.
 
 ### What is confusing (high-impact doc drift)
 
@@ -51,9 +51,9 @@ This is the integrated “where we are” picture after auditing:
 
 ### What must be reconciled (non-negotiable for canonical docs)
 
-- **Run boundary naming:** target `RunRequest = { recipe, settings }` vs current code `RunRequest = { recipe, env }`.
+- **Run boundary naming:** `Env` is canonical in current code; `RunSettings` is legacy naming and must not be treated as “target posture”.
 - **Dependency kind naming:** specs mention `buffer:*` while runtime uses `field:*` as the “mutable engine-facing surface” kind.
-- **Narrative integration:** Narrative is target-canonical (story entries), but it is not currently wired into the standard recipe pipeline.
+- **Domain ownership:** Narrative + Placement were explicitly absorbed into **Gameplay** planning/ownership; docs must not present them as target-canonical MapGen domains.
 - **Import policy:** `@mapgen/*` is not a stable public import surface; it collides across packages and breaks copy/paste.
 
 ## Working artifacts

--- a/docs/projects/engine-refactor-v1/mapgen-docs-alignment/scratch/deprecation-scan.md
+++ b/docs/projects/engine-refactor-v1/mapgen-docs-alignment/scratch/deprecation-scan.md
@@ -1,0 +1,87 @@
+<toc>
+  <item id="purpose" title="Purpose"/>
+  <item id="method" title="Method (how the scan was produced)"/>
+  <item id="output" title="Raw scan output (untriaged)"/>
+  <item id="notes" title="Triage notes"/>
+</toc>
+
+# Deprecation scan: raw candidates outside the canonical MapGen spine
+
+## Purpose
+
+This is a machine-assisted (search-based) inventory of MapGen/Studio/viz-adjacent markdown/docs **outside**
+`docs/system/libs/mapgen/**`.
+
+It is intentionally **untriaged**. The goal is to make it harder for superseded docs to hide “in random places”
+and confuse humans/agents when the new canonical MapGen doc spine becomes the primary source of truth.
+
+Use this in conjunction with:
+- `docs/projects/engine-refactor-v1/mapgen-docs-alignment/DEPRECATION-MANIFEST.md` (curated manifest with decisions)
+
+## Method (how the scan was produced)
+
+Search terms (case-insensitive) included:
+- `MapGen`, `mapgen`
+- `hydrology`, `morphology`, `ecology`, `foundation`
+- `deck.gl`, `mapgen-studio`
+- `standard recipe`, `RunSettings`, `Env`
+
+Exclusions:
+- `docs/system/libs/mapgen/**` (canonical spine)
+- `docs/projects/engine-refactor-v1/mapgen-docs-alignment/**` (this spike work)
+- `docs/_archive/**`
+- most “already archived” issue/milestone/review material (but not all project-level archives)
+
+If this file feels too noisy, tighten the search terms and/or add additional exclusions, then regenerate.
+
+## Raw scan output (untriaged)
+
+- `docs/ROADMAP.md`
+- `docs/process/LINEAR.md`
+- `docs/projects/engine-refactor-v1/PROJECT-engine-refactor-v1.md`
+- `docs/projects/engine-refactor-v1/deferrals.md`
+- `docs/projects/engine-refactor-v1/resources/spec/SPEC-architecture-overview.md`
+- `docs/projects/engine-refactor-v1/resources/spec/SPEC-core-sdk.md`
+- `docs/projects/engine-refactor-v1/resources/spec/SPEC-packaging-and-file-structure.md`
+- `docs/projects/engine-refactor-v1/resources/spec/SPEC-step-domain-operation-modules.md`
+- `docs/projects/engine-refactor-v1/resources/spec/SPEC-standard-content-package.md`
+- `docs/projects/engine-refactor-v1/resources/spec/SPEC-tag-registry.md`
+- `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md`
+- `docs/projects/engine-refactor-v1/resources/workflow/domain-refactor/references/phase-2-modeling.md`
+- `docs/projects/engine-refactor-v1/resources/workflow/domain-refactor/references/verification-and-guardrails.md`
+- `docs/projects/engine-refactor-v1/resources/workflow/domain-refactor/references/structure-and-module-shape.md`
+- `docs/projects/engine-refactor-v1/resources/workflow/domain-refactor/references/op-and-config-design.md`
+- `docs/projects/engine-refactor-v1/resources/workflow/domain-refactor/references/domain-inventory-and-boundaries.md`
+- `docs/projects/engine-refactor-v1/resources/workflow/domain-refactor/prompts/ECOLOGY-CONTEXT.md`
+- `docs/projects/engine-refactor-v1/resources/workflow/domain-refactor/prompts/HYDROLOGY-IMPLEMENTATION.md`
+- `docs/projects/engine-refactor-v1/resources/workflow/domain-refactor/prompts/MORPHOLOGY-IMPLEMENTATION.md`
+- `docs/projects/engine-refactor-v1/resources/workflow/domain-refactor/prompts/GAMEPLAY-CONTEXT.md`
+- `docs/projects/engine-refactor-v1/resources/workflow/domain-refactor/plans/morphology/spec/PHASE-2-CONTRACTS.md`
+- `docs/projects/mapgen-orographic-precipitation/spike-feasibility.md`
+- `docs/projects/mapgen-studio/ROADMAP.md`
+- `docs/projects/mapgen-studio/V0-IMPLEMENTATION-PLAN.md`
+- `docs/projects/mapgen-studio/BROWSER-RUNNER-V0.1.md`
+- `docs/projects/mapgen-studio/BROWSER-ADAPTER.md`
+- `docs/projects/mapgen-studio/VIZ-SDK-V1.md`
+- `docs/projects/mapgen-studio/VIZ-LAYER-CATALOG.md`
+- `docs/projects/mapgen-studio/VIZ-DECLUTTER-SEMANTICS-GREENFIELD-PLAN.md`
+- `docs/projects/mapgen-studio/architecture-assessment.md`
+- `docs/projects/mapgen-studio/issues/LOCAL-TBD-pipeline-viz-surface.md`
+- `docs/projects/mapgen-studio/resources/seams/SEAM-VIZ-DECKGL.md`
+- `docs/projects/mapgen-studio/resources/seams/SEAM-DUMP-VIEWER.md`
+- `docs/projects/mapgen-studio/resources/seams/SEAM-BROWSER-RUNNER.md`
+- `docs/system/ADR.md`
+- `docs/system/DEFERRALS.md`
+- `docs/system/mods/swooper-maps/adrs/adr-002-plot-tagging-adapter.md`
+- `docs/system/mods/swooper-maps/adrs/index.md`
+- `docs/system/sdk/overview.md`
+
+## Triage notes
+
+- Many items above are **target authority** (engine-refactor-v1 specs + workflow docs). They should usually be `keep`,
+  but they must be clearly framed as “WHAT SHOULD BE / workflow authority”, not “SDK how-to”.
+- `docs/projects/mapgen-studio/**` is the highest confusion risk because it reads like actionable instructions but
+  often represents prior planning iterations. Most of it should become `archive` or `keep-with-framing` and should
+  link back to the canonical MapGen spine for contracts.
+- Mod-level docs (like `docs/system/mods/swooper-maps/**`) should not define MapGen SDK contracts; they should route
+  to `docs/system/libs/mapgen/**` for SDK posture.


### PR DESCRIPTION
## Summary
This is the Slice 13 kickoff for the MapGen docs alignment effort: it establishes the working manifest and handoff packet so future slices can safely execute archiving/routing/link normalization without inventing architecture.

## What’s in this PR
- Adds a deprecation/archiving manifest to enumerate MapGen-adjacent docs outside the canonical spine and classify them (`archive|route|keep|update`).
- Adds a handoff context packet describing invariants, canonical doc locations, and follow-on work (Slice 13B execution, Slice 14 optional, Slice 13C viz parity gating).
- Adds a proposal for link normalization/backlinks (later Slice 14A/14B).

## Key artifacts
- `docs/projects/engine-refactor-v1/mapgen-docs-alignment/DEPRECATION-MANIFEST.md`
- `docs/projects/engine-refactor-v1/mapgen-docs-alignment/HANDOFF-CONTEXT-PACKET.md`
- `docs/projects/engine-refactor-v1/mapgen-docs-alignment/LINKING-BACKLINKS-PROPOSAL.md`

## Out of scope
- Does **not** execute archiving/routing (that’s Slice 13B).
- Does **not** apply viz terminology parity (that’s Slice 13C).

## Testing
- `bun run lint:mapgen-docs` (warnings OK)
