### PR TITLE
fix(mapgen-studio): adjust shortcuts and keep panels expanded

### DIFF
--- a/apps/mapgen-studio/src/App.tsx
+++ b/apps/mapgen-studio/src/App.tsx
@@ -807,26 +807,26 @@ function AppContent(props: AppContentProps) {
 
         if (!isMod) return;
 
-        // Cmd+Shift+Up/Down => stage
+        // Cmd+Shift+Up/Down => step
         if (event.shiftKey) {
-          if (!ctx.stages.length) return;
+          if (!ctx.steps.length) return;
           event.preventDefault();
-          const idx = ctx.stages.findIndex((s) => s.value === ctx.selectedStageId);
-          const nextIdx = clampIndex(idx + dir, ctx.stages.length - 1);
-          const nextStage = ctx.stages[nextIdx]?.value ?? null;
-          if (!nextStage || nextStage === ctx.selectedStageId) return;
-          ctx.handleStageChange(nextStage);
+          const idx = ctx.steps.findIndex((s) => s.value === ctx.selectedStepId);
+          const nextIdx = clampIndex(idx + dir, ctx.steps.length - 1);
+          const nextStep = ctx.steps[nextIdx]?.value ?? null;
+          if (!nextStep || nextStep === ctx.selectedStepId) return;
+          ctx.setSelectedStepId(nextStep);
           return;
         }
 
-        // Cmd+Up/Down => step
-        if (!ctx.steps.length) return;
+        // Cmd+Up/Down => stage
+        if (!ctx.stages.length) return;
         event.preventDefault();
-        const idx = ctx.steps.findIndex((s) => s.value === ctx.selectedStepId);
-        const nextIdx = clampIndex(idx + dir, ctx.steps.length - 1);
-        const nextStep = ctx.steps[nextIdx]?.value ?? null;
-        if (!nextStep || nextStep === ctx.selectedStepId) return;
-        ctx.setSelectedStepId(nextStep);
+        const idx = ctx.stages.findIndex((s) => s.value === ctx.selectedStageId);
+        const nextIdx = clampIndex(idx + dir, ctx.stages.length - 1);
+        const nextStage = ctx.stages[nextIdx]?.value ?? null;
+        if (!nextStage || nextStage === ctx.selectedStageId) return;
+        ctx.handleStageChange(nextStage);
       }
     };
 

--- a/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
+++ b/apps/mapgen-studio/src/ui/components/ExplorePanel.tsx
@@ -175,15 +175,12 @@ export const ExplorePanel: React.FC<ExplorePanelProps> = ({
   // ==========================================================================
   const handleSelectStage = (stageValue: string) => {
     onSelectedStageChange(stageValue);
-    setIsStageExpanded(false);
   };
   const handleSelectStep = (stepValue: string) => {
     onSelectedStepChange(stepValue);
-    setIsStepExpanded(false);
   };
   const handleSelectLayer = (layerValue: string) => {
     onSelectedDataTypeChange(layerValue);
-    setIsLayersExpanded(false);
   };
   // ==========================================================================
   // Styles


### PR DESCRIPTION
## Summary
Improves MapGen Studio keyboard shortcut handling to avoid collapsing panels unexpectedly and to keep shortcuts usable during normal interaction.

## What’s in this PR
- Adjusts shortcut behavior so panel state doesn’t auto-collapse in common flows.

## Testing
- Manual: run `bun run dev:mapgen-studio` and verify shortcut behavior in the UI.
