### PR TITLE
docs(mapgen): add ground truth anchors sections

### DIFF
--- a/docs/system/libs/mapgen/reference/domains/FOUNDATION.md
+++ b/docs/system/libs/mapgen/reference/domains/FOUNDATION.md
@@ -322,11 +322,25 @@ Marking these explicitly avoids “silent drift” in canonical docs.
 3. Is the effective invariant “tectonic history uses exactly 3 eras” a deliberate contract, or should validation be relaxed to match `FoundationTectonicHistorySchema` (`eraCount <= 8`)?
 4. Which downstream domain(s) should consume `artifact:foundation.tectonicHistory` (if any), and what is the minimal cross-domain contract for “age of orogeny” vs “recent activity”?
 
-**Ground truth anchors**
-- `mods/mod-swooper-maps/src/domain/foundation/ops/compute-mesh/contract.ts` (`FoundationMeshSchema`, `ComputeMeshContract`)
-- `mods/mod-swooper-maps/src/domain/foundation/ops/compute-mesh/index.ts` (`computeMesh`, call to `buildDelaunayMesh`)
-- `packages/mapgen-core/src/lib/mesh/delaunay.ts` (`buildDelaunayMesh`, `DelaunayMesh`)
+## Ground truth anchors
 
-- Domain id + ops bundle: `mods/mod-swooper-maps/src/domain/foundation/index.ts`
-- Standard recipe Foundation stage: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts`
-- Core artifact tag constants: `packages/mapgen-core/src/core/types.ts`
+This page contains many inline “Ground truth anchors” callouts. This section collects the canonical entrypoints:
+
+- Domain entrypoint + op ids: `mods/mod-swooper-maps/src/domain/foundation/index.ts`
+- Standard recipe stage definition (step ordering + wiring): `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts`
+- Stage artifact wiring (recipe-level tags, schemas, and helpers): `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts`
+- Core artifact tag constants (shared ids/types): `packages/mapgen-core/src/core/types.ts`
+
+- Mesh construction (truth root):
+  - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-mesh/contract.ts` (`ComputeMeshContract`, `FoundationMeshSchema`)
+  - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-mesh/index.ts` (`computeMesh`)
+  - `packages/mapgen-core/src/lib/mesh/delaunay.ts` (`buildDelaunayMesh`, `DelaunayMesh`)
+
+- Plates + tectonics (truth + projection):
+  - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts` (`ComputePlateGraphContract`, `FoundationPlateGraphSchema`)
+  - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-segments/contract.ts` (`ComputeTectonicSegmentsContract`, `FoundationTectonicSegmentsSchema`)
+  - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/contract.ts` (`ComputeTectonicHistoryContract`, `FoundationTectonicHistorySchema`, `FoundationTectonicsSchema`)
+  - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/contract.ts` (`ComputePlatesTensorsContract`, `tileToCellIndex`)
+  - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/lib/project-plates.ts` (`projectPlatesFromModel`, `tileToCellIndex`)
+
+- Policy (truth vs projection posture): `docs/system/libs/mapgen/policies/TRUTH-VS-PROJECTION.md`

--- a/docs/system/libs/mapgen/reference/domains/MORPHOLOGY.md
+++ b/docs/system/libs/mapgen/reference/domains/MORPHOLOGY.md
@@ -452,16 +452,33 @@ Applies Morphology truth into the engine adapter (terrain/features), and emits e
 3. Do we want Morphology truth artifacts to remain mutable across `map-morphology` projections, or should `map-morphology` read snapshots and treat the engine elevation/terrain as purely downstream projections?
 4. Is `artifact:morphology.volcanoes` intended to be the only canonical volcanic intent surface, or should it also include a stable “volcanism driver” snapshot for downstream consumers?
 
-**Ground truth anchors**
-- `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-pre/steps/landmassPlates.contract.ts` (`LandmassPlatesStepContract.requires/provides` are empty)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-mid/steps/routing.contract.ts` (`RoutingStepContract.requires/provides` are empty)
-- `mods/mod-swooper-maps/src/recipes/standard/tags.ts` (`M10_EFFECT_TAGS.map.*`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.contract.ts` (`PlotCoastsStepContract.provides`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotContinents.contract.ts` (`PlotContinentsStepContract.requires/provides`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotMountains.contract.ts` (`PlotMountainsStepContract.requires/provides`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotVolcanoes.contract.ts` (`PlotVolcanoesStepContract.requires/provides`)
-- `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/buildElevation.contract.ts` (`BuildElevationStepContract.requires/provides`)
+## Ground truth anchors
 
-- Domain id + ops bundle: `mods/mod-swooper-maps/src/domain/morphology/index.ts`
-- Standard recipe Morphology stages: `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-pre/index.ts`, `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-mid/index.ts`, `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-post/index.ts`
-- Engine-facing projections: `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/index.ts`
+This page contains many inline “Ground truth anchors” callouts. This section collects the canonical entrypoints:
+
+- Domain entrypoint + op ids: `mods/mod-swooper-maps/src/domain/morphology/index.ts`
+- Standard recipe stages:
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-pre/index.ts`
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-mid/index.ts`
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-post/index.ts`
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/index.ts`
+- Morphology artifact schemas: `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-pre/artifacts.ts`
+- Buffer mutability posture (core types): `packages/mapgen-core/src/core/types.ts`
+
+- Wiring + effect tags (current): `mods/mod-swooper-maps/src/recipes/standard/tags.ts` (`M10_EFFECT_TAGS.map.*`)
+
+- Example step contracts (truth stages):
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-pre/steps/landmassPlates.contract.ts` (`LandmassPlatesStepContract`)
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-mid/steps/routing.contract.ts` (`RoutingStepContract`)
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-mid/steps/ruggedCoasts.contract.ts` (`RuggedCoastsStepContract`)
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-post/steps/volcanoes.contract.ts` (`VolcanoesStepContract`)
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-post/steps/landmasses.contract.ts` (`LandmassesStepContract`)
+
+- Example step contracts (projection stage):
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.contract.ts` (`PlotCoastsStepContract`)
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotContinents.contract.ts` (`PlotContinentsStepContract`)
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotMountains.contract.ts` (`PlotMountainsStepContract`)
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotVolcanoes.contract.ts` (`PlotVolcanoesStepContract`)
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/buildElevation.contract.ts` (`BuildElevationStepContract`)
+
+- Policy (truth vs projection posture): `docs/system/libs/mapgen/policies/TRUTH-VS-PROJECTION.md`


### PR DESCRIPTION
## Summary
Adds required “Ground truth anchors” sections to canonical MapGen domain docs to satisfy the docs lint gate and preserve the evidence-driven posture.

## What’s in this PR
- Ensures canonical pages include `## Ground truth anchors` headings where required.

## Testing
- `bun run lint:mapgen-docs` (warnings OK)
