### PR TITLE
docs(mapgen): slice 14A link normalization

### DIFF
--- a/docs/projects/engine-refactor-v1/mapgen-docs-alignment/scripts/normalize_mapgen_doc_links.py
+++ b/docs/projects/engine-refactor-v1/mapgen-docs-alignment/scripts/normalize_mapgen_doc_links.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+_MAPGEN_DOCS_PREFIX = "docs/system/libs/mapgen/"
+_CODE_SPAN_PATH_RE = re.compile(rf"`({_MAPGEN_DOCS_PREFIX}[^`\n]+?\.md)`")
+_FENCE_RE = re.compile(r"^\s*```")
+_H1_H2_RE = re.compile(r"^\s*#{1,2}\s+")
+_GT_ANCHORS_H2 = "## Ground truth anchors"
+_INLINE_GT_ANCHORS_RE = re.compile(r"\*\*Ground truth anchors\*\*", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class FileResult:
+    path: Path
+    changed: bool
+    replacements: int
+
+
+def _find_repo_root(start: Path) -> Path:
+    for parent in [start, *start.parents]:
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError(f"Could not find repo root from: {start}")
+
+
+def _to_docs_site_href(label_path: str) -> str:
+    # `docs/system/libs/mapgen/foo.md` -> `/system/libs/mapgen/foo.md`
+    if not label_path.startswith("docs/"):
+        raise ValueError(f"Expected docs-rooted path, got: {label_path}")
+    return "/" + label_path[len("docs/") :]
+
+
+def _is_already_link_wrapped(text: str, match_start: int, match_end: int) -> bool:
+    if match_start <= 0:
+        return False
+    if text[match_start - 1] != "[":
+        return False
+    return text[match_end :].startswith("](")
+
+
+def _normalize_text(*, text: str) -> tuple[str, int]:
+    lines = text.splitlines(keepends=True)
+
+    in_fence = False
+    in_gt_anchors_section = False
+    in_inline_gt_anchors_block = False
+
+    total_replacements = 0
+    out: list[str] = []
+
+    for line in lines:
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+
+        if not in_fence and line.rstrip("\n").strip() == _GT_ANCHORS_H2:
+            in_gt_anchors_section = True
+            in_inline_gt_anchors_block = False
+            out.append(line)
+            continue
+
+        # Exit the `## Ground truth anchors` section on the next H1/H2 heading.
+        if (
+            in_gt_anchors_section
+            and _H1_H2_RE.match(line)
+            and line.rstrip("\n").strip() != _GT_ANCHORS_H2
+        ):
+            in_gt_anchors_section = False
+
+        # Inline “Ground truth anchors” blocks (not H2 headings) are treated as evidence; skip until blank line.
+        if not in_fence and not in_gt_anchors_section and _INLINE_GT_ANCHORS_RE.search(line):
+            in_inline_gt_anchors_block = True
+            out.append(line)
+            continue
+
+        if in_inline_gt_anchors_block and (line.strip() == "" or _H1_H2_RE.match(line)):
+            in_inline_gt_anchors_block = False
+
+        if in_fence or in_gt_anchors_section or in_inline_gt_anchors_block:
+            out.append(line)
+            continue
+
+        def repl(m: re.Match[str]) -> str:
+            nonlocal total_replacements
+            if _is_already_link_wrapped(line, m.start(), m.end()):
+                return m.group(0)
+            label_path = m.group(1)
+            href = _to_docs_site_href(label_path)
+            total_replacements += 1
+            return f"[`{label_path}`]({href})"
+
+        out.append(_CODE_SPAN_PATH_RE.sub(repl, line))
+
+    return ("".join(out), total_replacements)
+
+
+def _diff(*, before: str, after: str, rel_path: str) -> str:
+    before_lines = before.splitlines()
+    after_lines = after.splitlines()
+    diff_lines = difflib.unified_diff(
+        before_lines,
+        after_lines,
+        fromfile=f"a/{rel_path}",
+        tofile=f"b/{rel_path}",
+        lineterm="",
+    )
+    return "\n".join(diff_lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Normalize MapGen canonical docs intra-links while keeping literal repo paths as visible text.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply changes in-place (default is dry-run).",
+    )
+    parser.add_argument(
+        "--diff",
+        action="store_true",
+        help="Print per-file unified diffs for changed files (default: on for dry-run; off for --apply).",
+    )
+    parser.add_argument(
+        "--root",
+        type=str,
+        default="",
+        help="Repo root override (default: auto-detect from this script location).",
+    )
+    args = parser.parse_args()
+
+    script_path = Path(__file__).resolve()
+    repo_root = Path(args.root).resolve() if args.root else _find_repo_root(script_path)
+
+    docs_root = repo_root / "docs" / "system" / "libs" / "mapgen"
+    if not docs_root.exists():
+        raise RuntimeError(f"Expected MapGen docs root at: {docs_root}")
+
+    show_diff = args.diff if args.diff else (not args.apply)
+
+    results: list[FileResult] = []
+    changed_files = 0
+    total_replacements = 0
+
+    for path in sorted(docs_root.rglob("*.md")):
+        # Do not churn archived / historical pages.
+        rel_from_docs_root = path.relative_to(docs_root)
+        if rel_from_docs_root.parts and rel_from_docs_root.parts[0] == "_archive":
+            continue
+
+        before = path.read_text(encoding="utf-8")
+        after, replacements = _normalize_text(text=before)
+        changed = after != before
+
+        results.append(FileResult(path=path, changed=changed, replacements=replacements))
+
+        if not changed:
+            continue
+
+        changed_files += 1
+        total_replacements += replacements
+
+        rel_path = str(path.relative_to(repo_root))
+        if show_diff:
+            print(_diff(before=before, after=after, rel_path=rel_path))
+
+        if args.apply:
+            path.write_text(after, encoding="utf-8")
+
+    print("\nSummary:")
+    print(f"- Files scanned: {len(results)}")
+    print(f"- Files changed: {changed_files}")
+    print(f"- Replacements:  {total_replacements}")
+    print(f"- Mode:          {'apply' if args.apply else 'dry-run'}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/system/libs/mapgen/MAPGEN.md
+++ b/docs/system/libs/mapgen/MAPGEN.md
@@ -17,21 +17,21 @@ This doc routes you into the correct doc type (tutorial / how-to / reference / e
 
 ## Start here (choose your path)
 
-- If you want to **run MapGen end-to-end**: start in `docs/system/libs/mapgen/tutorials/TUTORIALS.md`.
-- If you want to **change or extend MapGen** (add a step/op/artifact/tag): start in `docs/system/libs/mapgen/how-to/HOW-TO.md`.
-- If you want the **exact SDK and pipeline contracts**: start in `docs/system/libs/mapgen/reference/REFERENCE.md`.
-- If you want the **why / architecture / model**: start in `docs/system/libs/mapgen/explanation/EXPLANATION.md`.
-- If you are writing docs or code and want the “rules of the road”: start in `docs/system/libs/mapgen/policies/POLICIES.md`.
-- If you are an **AI agent** and want curated pointers: start in `docs/system/libs/mapgen/llms/LLMS.md`.
+- If you want to **run MapGen end-to-end**: start in [`docs/system/libs/mapgen/tutorials/TUTORIALS.md`](/system/libs/mapgen/tutorials/TUTORIALS.md).
+- If you want to **change or extend MapGen** (add a step/op/artifact/tag): start in [`docs/system/libs/mapgen/how-to/HOW-TO.md`](/system/libs/mapgen/how-to/HOW-TO.md).
+- If you want the **exact SDK and pipeline contracts**: start in [`docs/system/libs/mapgen/reference/REFERENCE.md`](/system/libs/mapgen/reference/REFERENCE.md).
+- If you want the **why / architecture / model**: start in [`docs/system/libs/mapgen/explanation/EXPLANATION.md`](/system/libs/mapgen/explanation/EXPLANATION.md).
+- If you are writing docs or code and want the “rules of the road”: start in [`docs/system/libs/mapgen/policies/POLICIES.md`](/system/libs/mapgen/policies/POLICIES.md).
+- If you are an **AI agent** and want curated pointers: start in [`docs/system/libs/mapgen/llms/LLMS.md`](/system/libs/mapgen/llms/LLMS.md).
 
 ## Fast links
 
 Common “one hop” destinations:
 
-- Standard recipe reference: `docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`
-- Domain contracts: `docs/system/libs/mapgen/reference/domains/DOMAINS.md`
-- Studio seam (reference): `docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`
-- Visualization (canonical; deck.gl): `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
+- Standard recipe reference: [`docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`](/system/libs/mapgen/reference/STANDARD-RECIPE.md)
+- Domain contracts: [`docs/system/libs/mapgen/reference/domains/DOMAINS.md`](/system/libs/mapgen/reference/domains/DOMAINS.md)
+- Studio seam (reference): [`docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`](/system/libs/mapgen/reference/STUDIO-INTEGRATION.md)
+- Visualization (canonical; deck.gl): [`docs/system/libs/mapgen/pipeline-visualization-deckgl.md`](/system/libs/mapgen/pipeline-visualization-deckgl.md)
 
 ## Routing map (Diátaxis)
 

--- a/docs/system/libs/mapgen/architecture.md
+++ b/docs/system/libs/mapgen/architecture.md
@@ -13,10 +13,10 @@ It is **not** canonical documentation.
 
 ## Canonical replacements
 
-- `docs/system/libs/mapgen/explanation/ARCHITECTURE.md`
-- `docs/system/libs/mapgen/explanation/DOMAIN-MODELING.md`
-- `docs/system/libs/mapgen/reference/domains/DOMAINS.md`
+- [`docs/system/libs/mapgen/explanation/ARCHITECTURE.md`](/system/libs/mapgen/explanation/ARCHITECTURE.md)
+- [`docs/system/libs/mapgen/explanation/DOMAIN-MODELING.md`](/system/libs/mapgen/explanation/DOMAIN-MODELING.md)
+- [`docs/system/libs/mapgen/reference/domains/DOMAINS.md`](/system/libs/mapgen/reference/domains/DOMAINS.md)
 
 ## Legacy archive
 
-The previous contents of this page were moved to `docs/system/libs/mapgen/_archive/architecture.md`.
+The previous contents of this page were moved to [`docs/system/libs/mapgen/_archive/architecture.md`](/system/libs/mapgen/_archive/architecture.md).

--- a/docs/system/libs/mapgen/ecology.md
+++ b/docs/system/libs/mapgen/ecology.md
@@ -13,8 +13,8 @@ It is **not** canonical documentation.
 
 ## Canonical replacements
 
-- `docs/system/libs/mapgen/reference/domains/ECOLOGY.md`
+- [`docs/system/libs/mapgen/reference/domains/ECOLOGY.md`](/system/libs/mapgen/reference/domains/ECOLOGY.md)
 
 ## Legacy archive
 
-The previous contents of this page were moved to `docs/system/libs/mapgen/_archive/ecology.md`.
+The previous contents of this page were moved to [`docs/system/libs/mapgen/_archive/ecology.md`](/system/libs/mapgen/_archive/ecology.md).

--- a/docs/system/libs/mapgen/explanation/ARCHITECTURE.md
+++ b/docs/system/libs/mapgen/explanation/ARCHITECTURE.md
@@ -14,8 +14,8 @@
 Explain the canonical MapGen architecture and why it’s shaped the way it is (engine-refactor-v1 posture).
 
 This is an explanation page; it does not redefine contracts. When you need “what is allowed”, route to:
-- `docs/system/libs/mapgen/policies/POLICIES.md`
-- `docs/system/libs/mapgen/reference/REFERENCE.md`
+- [`docs/system/libs/mapgen/policies/POLICIES.md`](/system/libs/mapgen/policies/POLICIES.md)
+- [`docs/system/libs/mapgen/reference/REFERENCE.md`](/system/libs/mapgen/reference/REFERENCE.md)
 
 ## System model (what MapGen is)
 

--- a/docs/system/libs/mapgen/explanation/DOMAIN-MODELING.md
+++ b/docs/system/libs/mapgen/explanation/DOMAIN-MODELING.md
@@ -14,8 +14,8 @@
 Explain how MapGen uses domains to keep algorithmic code modular, testable, and reusable across recipes.
 
 Contract references:
-- `docs/system/libs/mapgen/reference/domains/DOMAINS.md`
-- `docs/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md`
+- [`docs/system/libs/mapgen/reference/domains/DOMAINS.md`](/system/libs/mapgen/reference/domains/DOMAINS.md)
+- [`docs/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md`](/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md)
 
 ## What a domain owns
 

--- a/docs/system/libs/mapgen/explanation/EXPLANATION.md
+++ b/docs/system/libs/mapgen/explanation/EXPLANATION.md
@@ -22,12 +22,12 @@ Explanation pages should link down to reference/policies — not the other way a
 
 Canonical explanation pages:
 
-- System architecture + ownership boundaries: `docs/system/libs/mapgen/explanation/ARCHITECTURE.md`
-- Pipeline model (mental model): `docs/system/libs/mapgen/explanation/PIPELINE-MODEL.md`
-- Truth vs projection (rationale): `docs/system/libs/mapgen/explanation/TRUTH-VS-PROJECTION.md`
-- Pipeline compilation (why split compile phases): `docs/system/libs/mapgen/explanation/PIPELINE-COMPILATION.md`
-- Domain modeling + boundaries: `docs/system/libs/mapgen/explanation/DOMAIN-MODELING.md`
-- Determinism + reproducibility: `docs/system/libs/mapgen/explanation/DETERMINISM.md`
+- System architecture + ownership boundaries: [`docs/system/libs/mapgen/explanation/ARCHITECTURE.md`](/system/libs/mapgen/explanation/ARCHITECTURE.md)
+- Pipeline model (mental model): [`docs/system/libs/mapgen/explanation/PIPELINE-MODEL.md`](/system/libs/mapgen/explanation/PIPELINE-MODEL.md)
+- Truth vs projection (rationale): [`docs/system/libs/mapgen/explanation/TRUTH-VS-PROJECTION.md`](/system/libs/mapgen/explanation/TRUTH-VS-PROJECTION.md)
+- Pipeline compilation (why split compile phases): [`docs/system/libs/mapgen/explanation/PIPELINE-COMPILATION.md`](/system/libs/mapgen/explanation/PIPELINE-COMPILATION.md)
+- Domain modeling + boundaries: [`docs/system/libs/mapgen/explanation/DOMAIN-MODELING.md`](/system/libs/mapgen/explanation/DOMAIN-MODELING.md)
+- Determinism + reproducibility: [`docs/system/libs/mapgen/explanation/DETERMINISM.md`](/system/libs/mapgen/explanation/DETERMINISM.md)
 
 Potential future explanation pages (only if they add clarity beyond policy/reference):
 - Mutation model (artifacts vs fields/buffers) — if needed beyond policy/reference

--- a/docs/system/libs/mapgen/explanation/PIPELINE-COMPILATION.md
+++ b/docs/system/libs/mapgen/explanation/PIPELINE-COMPILATION.md
@@ -18,8 +18,8 @@ Explain why MapGen splits compilation into:
 before runtime execution.
 
 Contract reference:
-- `docs/system/libs/mapgen/reference/CONFIG-COMPILATION.md`
-- `docs/system/libs/mapgen/reference/PLAN-COMPILATION.md`
+- [`docs/system/libs/mapgen/reference/CONFIG-COMPILATION.md`](/system/libs/mapgen/reference/CONFIG-COMPILATION.md)
+- [`docs/system/libs/mapgen/reference/PLAN-COMPILATION.md`](/system/libs/mapgen/reference/PLAN-COMPILATION.md)
 
 ## Why compilation is split
 

--- a/docs/system/libs/mapgen/explanation/PIPELINE-MODEL.md
+++ b/docs/system/libs/mapgen/explanation/PIPELINE-MODEL.md
@@ -14,7 +14,7 @@
 Provide a high-signal mental model for how a MapGen pipeline run works end-to-end.
 
 For contractual details, route to:
-- `docs/system/libs/mapgen/reference/REFERENCE.md`
+- [`docs/system/libs/mapgen/reference/REFERENCE.md`](/system/libs/mapgen/reference/REFERENCE.md)
 
 ## Mental model
 

--- a/docs/system/libs/mapgen/explanation/TRUTH-VS-PROJECTION.md
+++ b/docs/system/libs/mapgen/explanation/TRUTH-VS-PROJECTION.md
@@ -14,7 +14,7 @@
 Explain the “truth vs projection” model as a mental tool for reasoning about MapGen correctness and drift.
 
 Contract/policy lives in:
-- `docs/system/libs/mapgen/policies/TRUTH-VS-PROJECTION.md`
+- [`docs/system/libs/mapgen/policies/TRUTH-VS-PROJECTION.md`](/system/libs/mapgen/policies/TRUTH-VS-PROJECTION.md)
 
 ## Why this exists
 

--- a/docs/system/libs/mapgen/foundation.md
+++ b/docs/system/libs/mapgen/foundation.md
@@ -13,8 +13,8 @@ It is **not** canonical documentation.
 
 ## Canonical replacements
 
-- `docs/system/libs/mapgen/reference/domains/FOUNDATION.md`
+- [`docs/system/libs/mapgen/reference/domains/FOUNDATION.md`](/system/libs/mapgen/reference/domains/FOUNDATION.md)
 
 ## Legacy archive
 
-The previous contents of this page were moved to `docs/system/libs/mapgen/_archive/foundation.md`.
+The previous contents of this page were moved to [`docs/system/libs/mapgen/_archive/foundation.md`](/system/libs/mapgen/_archive/foundation.md).

--- a/docs/system/libs/mapgen/how-to/HOW-TO.md
+++ b/docs/system/libs/mapgen/how-to/HOW-TO.md
@@ -21,14 +21,14 @@ They assume you already understand the basics and want to accomplish a specific 
 
 Canonical how-tos:
 
-- Add a step: `docs/system/libs/mapgen/how-to/add-a-step.md`
-- Add an op: `docs/system/libs/mapgen/how-to/add-an-op.md`
-- Add a new artifact: `docs/system/libs/mapgen/how-to/add-a-new-artifact.md`
-- Add a new tag: `docs/system/libs/mapgen/how-to/add-a-new-tag.md`
-- Debug with trace and visualization (deck.gl): `docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md`
-- Tune realism knobs: `docs/system/libs/mapgen/how-to/tune-realism-knobs.md`
-- Visualize pipeline (deck.gl): `docs/system/libs/mapgen/how-to/visualize-pipeline-deckgl.md`
-- Integrate the MapGen Studio worker: `docs/system/libs/mapgen/how-to/integrate-mapgen-studio-worker.md`
+- Add a step: [`docs/system/libs/mapgen/how-to/add-a-step.md`](/system/libs/mapgen/how-to/add-a-step.md)
+- Add an op: [`docs/system/libs/mapgen/how-to/add-an-op.md`](/system/libs/mapgen/how-to/add-an-op.md)
+- Add a new artifact: [`docs/system/libs/mapgen/how-to/add-a-new-artifact.md`](/system/libs/mapgen/how-to/add-a-new-artifact.md)
+- Add a new tag: [`docs/system/libs/mapgen/how-to/add-a-new-tag.md`](/system/libs/mapgen/how-to/add-a-new-tag.md)
+- Debug with trace and visualization (deck.gl): [`docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md`](/system/libs/mapgen/how-to/debug-with-trace-and-viz.md)
+- Tune realism knobs: [`docs/system/libs/mapgen/how-to/tune-realism-knobs.md`](/system/libs/mapgen/how-to/tune-realism-knobs.md)
+- Visualize pipeline (deck.gl): [`docs/system/libs/mapgen/how-to/visualize-pipeline-deckgl.md`](/system/libs/mapgen/how-to/visualize-pipeline-deckgl.md)
+- Integrate the MapGen Studio worker: [`docs/system/libs/mapgen/how-to/integrate-mapgen-studio-worker.md`](/system/libs/mapgen/how-to/integrate-mapgen-studio-worker.md)
 
 Potential future how-tos:
 - Run a recipe headless

--- a/docs/system/libs/mapgen/how-to/add-a-new-artifact.md
+++ b/docs/system/libs/mapgen/how-to/add-a-new-artifact.md
@@ -16,9 +16,9 @@ Add a new **artifact** (a published, dependency-gated data product) with a stabl
 This how-to is **recipe/stage-level**: artifacts are typically owned by a stage and used by steps.
 
 Routes to:
-- Artifact reference: `docs/system/libs/mapgen/reference/ARTIFACTS.md`
-- Artifact mutation policy: `docs/system/libs/mapgen/policies/ARTIFACT-MUTATION.md`
-- Dependency id policy: `docs/system/libs/mapgen/policies/DEPENDENCY-IDS-AND-REGISTRIES.md`
+- Artifact reference: [`docs/system/libs/mapgen/reference/ARTIFACTS.md`](/system/libs/mapgen/reference/ARTIFACTS.md)
+- Artifact mutation policy: [`docs/system/libs/mapgen/policies/ARTIFACT-MUTATION.md`](/system/libs/mapgen/policies/ARTIFACT-MUTATION.md)
+- Dependency id policy: [`docs/system/libs/mapgen/policies/DEPENDENCY-IDS-AND-REGISTRIES.md`](/system/libs/mapgen/policies/DEPENDENCY-IDS-AND-REGISTRIES.md)
 
 ## Prereqs
 

--- a/docs/system/libs/mapgen/how-to/add-a-new-tag.md
+++ b/docs/system/libs/mapgen/how-to/add-a-new-tag.md
@@ -14,8 +14,8 @@
 Add a new **dependency tag** for pipeline gating (target posture: all requires/provides go through a registry; no magic).
 
 Routes to:
-- Tag reference: `docs/system/libs/mapgen/reference/TAGS.md`
-- Dependency id policy: `docs/system/libs/mapgen/policies/DEPENDENCY-IDS-AND-REGISTRIES.md`
+- Tag reference: [`docs/system/libs/mapgen/reference/TAGS.md`](/system/libs/mapgen/reference/TAGS.md)
+- Dependency id policy: [`docs/system/libs/mapgen/policies/DEPENDENCY-IDS-AND-REGISTRIES.md`](/system/libs/mapgen/policies/DEPENDENCY-IDS-AND-REGISTRIES.md)
 
 ## Prereqs
 

--- a/docs/system/libs/mapgen/how-to/add-a-step.md
+++ b/docs/system/libs/mapgen/how-to/add-a-step.md
@@ -14,10 +14,10 @@
 Add a new **step** to a recipe stage (target posture: step contracts + dependency tags + artifacts; no hidden coupling).
 
 This how-to is **recipe-level** (steps are authored/registered in a recipe). It routes to:
-- Step authoring contract reference: `docs/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md`
-- Tag registry reference: `docs/system/libs/mapgen/reference/TAGS.md`
-- Artifact reference: `docs/system/libs/mapgen/reference/ARTIFACTS.md`
-- Import policy: `docs/system/libs/mapgen/policies/IMPORTS.md`
+- Step authoring contract reference: [`docs/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md`](/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md)
+- Tag registry reference: [`docs/system/libs/mapgen/reference/TAGS.md`](/system/libs/mapgen/reference/TAGS.md)
+- Artifact reference: [`docs/system/libs/mapgen/reference/ARTIFACTS.md`](/system/libs/mapgen/reference/ARTIFACTS.md)
+- Import policy: [`docs/system/libs/mapgen/policies/IMPORTS.md`](/system/libs/mapgen/policies/IMPORTS.md)
 
 ## Prereqs
 
@@ -157,7 +157,7 @@ export default createStage({
 ### 5) Update dependency tags if needed
 
 If your step introduces a new required/provided dependency tag:
-- Define it and register it in the tag registry (see: `docs/system/libs/mapgen/how-to/add-a-new-tag.md`).
+- Define it and register it in the tag registry (see: [`docs/system/libs/mapgen/how-to/add-a-new-tag.md`](/system/libs/mapgen/how-to/add-a-new-tag.md)).
 
 ## Verification
 

--- a/docs/system/libs/mapgen/how-to/add-an-op.md
+++ b/docs/system/libs/mapgen/how-to/add-an-op.md
@@ -14,8 +14,8 @@
 Add a new **op** to a domain module (target posture: `defineOp` contract + `createOp` implementation + domain registry wiring).
 
 This how-to is **domain-level** (ops live inside a domain). It routes to:
-- Ops module contract reference: `docs/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md`
-- Import policy: `docs/system/libs/mapgen/policies/IMPORTS.md`
+- Ops module contract reference: [`docs/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md`](/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md)
+- Import policy: [`docs/system/libs/mapgen/policies/IMPORTS.md`](/system/libs/mapgen/policies/IMPORTS.md)
 
 ## Prereqs
 

--- a/docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md
+++ b/docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md
@@ -20,9 +20,9 @@ Enable trace + viz emissions for a run so you can debug:
 - scalar field correctness (via dumped layers + deck.gl viewer).
 
 Routes to:
-- Observability reference: `docs/system/libs/mapgen/reference/OBSERVABILITY.md`
-- Visualization reference: `docs/system/libs/mapgen/reference/VISUALIZATION.md`
-- Canonical viz doc (deck.gl): `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
+- Observability reference: [`docs/system/libs/mapgen/reference/OBSERVABILITY.md`](/system/libs/mapgen/reference/OBSERVABILITY.md)
+- Visualization reference: [`docs/system/libs/mapgen/reference/VISUALIZATION.md`](/system/libs/mapgen/reference/VISUALIZATION.md)
+- Canonical viz doc (deck.gl): [`docs/system/libs/mapgen/pipeline-visualization-deckgl.md`](/system/libs/mapgen/pipeline-visualization-deckgl.md)
 
 ## When to use
 
@@ -107,14 +107,14 @@ Use the Explore panel to:
 - choose a layer and render variant.
 
 For the full system explanation (streaming vs replay, schema, layer taxonomy), see:
-- `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
+- [`docs/system/libs/mapgen/pipeline-visualization-deckgl.md`](/system/libs/mapgen/pipeline-visualization-deckgl.md)
 
 ## Workflow: live streaming in Studio (optional)
 
 If you’re iterating on worker-side visualization behavior (Transferables, upsert semantics), prefer the live Studio run and inspect `viz.layer.upsert` events.
 
 Routing:
-- Studio integration seam reference: `docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`
+- Studio integration seam reference: [`docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`](/system/libs/mapgen/reference/STUDIO-INTEGRATION.md)
 
 ## Footguns
 

--- a/docs/system/libs/mapgen/how-to/integrate-mapgen-studio-worker.md
+++ b/docs/system/libs/mapgen/how-to/integrate-mapgen-studio-worker.md
@@ -20,7 +20,7 @@ Use MapGen Studio’s **browser worker runner** as the canonical integration pos
 
 This is a how-to: it focuses on “what to do” and “what to copy”.
 For contracts and invariants, see:
-- `docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`
+- [`docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`](/system/libs/mapgen/reference/STUDIO-INTEGRATION.md)
 
 ## When to use this pattern
 
@@ -141,7 +141,7 @@ const dumpGrid: VizDumper["dumpGrid"] = (trace, layer) => {
 ```
 
 Routing:
-- Canonical deck.gl visualization doc: `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
+- Canonical deck.gl visualization doc: [`docs/system/libs/mapgen/pipeline-visualization-deckgl.md`](/system/libs/mapgen/pipeline-visualization-deckgl.md)
 
 ## Cancellation posture
 

--- a/docs/system/libs/mapgen/how-to/tune-realism-knobs.md
+++ b/docs/system/libs/mapgen/how-to/tune-realism-knobs.md
@@ -16,9 +16,9 @@ Tune the “realism” posture of the standard recipe by changing **stage knobs*
 This is the intended **author surface** for “make the world more X” tuning.
 
 Routes to:
-- Recipe schema: `docs/system/libs/mapgen/reference/RECIPE-SCHEMA.md`
-- Config compilation: `docs/system/libs/mapgen/reference/CONFIG-COMPILATION.md`
-- Standard recipe reference: `docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`
+- Recipe schema: [`docs/system/libs/mapgen/reference/RECIPE-SCHEMA.md`](/system/libs/mapgen/reference/RECIPE-SCHEMA.md)
+- Config compilation: [`docs/system/libs/mapgen/reference/CONFIG-COMPILATION.md`](/system/libs/mapgen/reference/CONFIG-COMPILATION.md)
+- Standard recipe reference: [`docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`](/system/libs/mapgen/reference/STANDARD-RECIPE.md)
 
 ## Audience
 

--- a/docs/system/libs/mapgen/how-to/visualize-pipeline-deckgl.md
+++ b/docs/system/libs/mapgen/how-to/visualize-pipeline-deckgl.md
@@ -12,7 +12,7 @@ Route to the single canonical deck.gl visualization doc (no duplication).
 
 ## Start here
 
-- `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
+- [`docs/system/libs/mapgen/pipeline-visualization-deckgl.md`](/system/libs/mapgen/pipeline-visualization-deckgl.md)
 
 ## Ground truth anchors
 

--- a/docs/system/libs/mapgen/hydrology-api.md
+++ b/docs/system/libs/mapgen/hydrology-api.md
@@ -13,9 +13,9 @@ It is **not** canonical documentation.
 
 ## Canonical replacements
 
-- `docs/system/libs/mapgen/reference/domains/HYDROLOGY.md`
-- `docs/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md`
+- [`docs/system/libs/mapgen/reference/domains/HYDROLOGY.md`](/system/libs/mapgen/reference/domains/HYDROLOGY.md)
+- [`docs/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md`](/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md)
 
 ## Legacy archive
 
-The previous contents of this page were moved to `docs/system/libs/mapgen/_archive/hydrology-api.md`.
+The previous contents of this page were moved to [`docs/system/libs/mapgen/_archive/hydrology-api.md`](/system/libs/mapgen/_archive/hydrology-api.md).

--- a/docs/system/libs/mapgen/hydrology.md
+++ b/docs/system/libs/mapgen/hydrology.md
@@ -13,8 +13,8 @@ It is **not** canonical documentation.
 
 ## Canonical replacements
 
-- `docs/system/libs/mapgen/reference/domains/HYDROLOGY.md`
+- [`docs/system/libs/mapgen/reference/domains/HYDROLOGY.md`](/system/libs/mapgen/reference/domains/HYDROLOGY.md)
 
 ## Legacy archive
 
-The previous contents of this page were moved to `docs/system/libs/mapgen/_archive/hydrology.md`.
+The previous contents of this page were moved to [`docs/system/libs/mapgen/_archive/hydrology.md`](/system/libs/mapgen/_archive/hydrology.md).

--- a/docs/system/libs/mapgen/llms/LLMS.md
+++ b/docs/system/libs/mapgen/llms/LLMS.md
@@ -14,12 +14,12 @@ It’s meant for AI agents and tooling that need stable pointers to “the one r
 
 ## Curated entrypoints
 
-- Gateway: `docs/system/libs/mapgen/MAPGEN.md`
-- Policies: `docs/system/libs/mapgen/policies/POLICIES.md`
-- Reference: `docs/system/libs/mapgen/reference/REFERENCE.md`
-- How-to: `docs/system/libs/mapgen/how-to/HOW-TO.md`
-- Tutorials: `docs/system/libs/mapgen/tutorials/TUTORIALS.md`
-- Explanation: `docs/system/libs/mapgen/explanation/EXPLANATION.md`
+- Gateway: [`docs/system/libs/mapgen/MAPGEN.md`](/system/libs/mapgen/MAPGEN.md)
+- Policies: [`docs/system/libs/mapgen/policies/POLICIES.md`](/system/libs/mapgen/policies/POLICIES.md)
+- Reference: [`docs/system/libs/mapgen/reference/REFERENCE.md`](/system/libs/mapgen/reference/REFERENCE.md)
+- How-to: [`docs/system/libs/mapgen/how-to/HOW-TO.md`](/system/libs/mapgen/how-to/HOW-TO.md)
+- Tutorials: [`docs/system/libs/mapgen/tutorials/TUTORIALS.md`](/system/libs/mapgen/tutorials/TUTORIALS.md)
+- Explanation: [`docs/system/libs/mapgen/explanation/EXPLANATION.md`](/system/libs/mapgen/explanation/EXPLANATION.md)
 
 ## Rules for agents
 

--- a/docs/system/libs/mapgen/morphology.md
+++ b/docs/system/libs/mapgen/morphology.md
@@ -13,8 +13,8 @@ It is **not** canonical documentation.
 
 ## Canonical replacements
 
-- `docs/system/libs/mapgen/reference/domains/MORPHOLOGY.md`
+- [`docs/system/libs/mapgen/reference/domains/MORPHOLOGY.md`](/system/libs/mapgen/reference/domains/MORPHOLOGY.md)
 
 ## Legacy archive
 
-The previous contents of this page were moved to `docs/system/libs/mapgen/_archive/morphology.md`.
+The previous contents of this page were moved to [`docs/system/libs/mapgen/_archive/morphology.md`](/system/libs/mapgen/_archive/morphology.md).

--- a/docs/system/libs/mapgen/narrative.md
+++ b/docs/system/libs/mapgen/narrative.md
@@ -13,8 +13,8 @@ It is **not** canonical documentation.
 
 ## Canonical replacements
 
-- `docs/system/libs/mapgen/reference/domains/NARRATIVE.md`
+- [`docs/system/libs/mapgen/reference/domains/NARRATIVE.md`](/system/libs/mapgen/reference/domains/NARRATIVE.md)
 
 ## Legacy archive
 
-The previous contents of this page were moved to `docs/system/libs/mapgen/_archive/narrative.md`.
+The previous contents of this page were moved to [`docs/system/libs/mapgen/_archive/narrative.md`](/system/libs/mapgen/_archive/narrative.md).

--- a/docs/system/libs/mapgen/pipeline-visualization-deckgl.md
+++ b/docs/system/libs/mapgen/pipeline-visualization-deckgl.md
@@ -23,8 +23,8 @@
 
 - **Dump folder**: replayable output containing `manifest.json` plus payloads under `data/`.
 - `outputsRoot`: where dump folders are written (implementation chooses the root; the contract only assumes a per-run folder containing `manifest.json`).
-- `runId`: run identity used by trace/dumps. Current implementation: `runId === planFingerprint` (see `docs/system/libs/mapgen/reference/GLOSSARY.md`).
-- `planFingerprint`: plan identity (hash of plan inputs); see `docs/system/libs/mapgen/reference/GLOSSARY.md` and `packages/mapgen-core/src/engine/observability.ts`.
+- `runId`: run identity used by trace/dumps. Current implementation: `runId === planFingerprint` (see [`docs/system/libs/mapgen/reference/GLOSSARY.md`](/system/libs/mapgen/reference/GLOSSARY.md)).
+- `planFingerprint`: plan identity (hash of plan inputs); see [`docs/system/libs/mapgen/reference/GLOSSARY.md`](/system/libs/mapgen/reference/GLOSSARY.md) and `packages/mapgen-core/src/engine/observability.ts`.
 - `dataTypeKey`: stable semantic identity for a data product (e.g. `"hydrology.wind.wind"`).
 - `layerKey`: canonical, opaque identity for a layer within a run (used for streaming upserts and dump replay identity).
 - `spaceId`: explicit coordinate space (“projection” selector in the Studio UI).

--- a/docs/system/libs/mapgen/placement.md
+++ b/docs/system/libs/mapgen/placement.md
@@ -13,8 +13,8 @@ It is **not** canonical documentation.
 
 ## Canonical replacements
 
-- `docs/system/libs/mapgen/reference/domains/PLACEMENT.md`
+- [`docs/system/libs/mapgen/reference/domains/PLACEMENT.md`](/system/libs/mapgen/reference/domains/PLACEMENT.md)
 
 ## Legacy archive
 
-The previous contents of this page were moved to `docs/system/libs/mapgen/_archive/placement.md`.
+The previous contents of this page were moved to [`docs/system/libs/mapgen/_archive/placement.md`](/system/libs/mapgen/_archive/placement.md).

--- a/docs/system/libs/mapgen/policies/POLICIES.md
+++ b/docs/system/libs/mapgen/policies/POLICIES.md
@@ -23,13 +23,13 @@ Policies are *normative* (“Allowed / Disallowed”) and must be anchored to co
 
 Canonical policies:
 
-- Imports: `docs/system/libs/mapgen/policies/IMPORTS.md`
-- Schemas and validation: `docs/system/libs/mapgen/policies/SCHEMAS-AND-VALIDATION.md`
-- Dependency IDs and registries: `docs/system/libs/mapgen/policies/DEPENDENCY-IDS-AND-REGISTRIES.md`
-- Artifact mutation: `docs/system/libs/mapgen/policies/ARTIFACT-MUTATION.md`
-- Config vs plan compilation: `docs/system/libs/mapgen/policies/CONFIG-VS-PLAN-COMPILATION.md`
-- Truth vs projection: `docs/system/libs/mapgen/policies/TRUTH-VS-PROJECTION.md`
-- Module shape: `docs/system/libs/mapgen/policies/MODULE-SHAPE.md`
+- Imports: [`docs/system/libs/mapgen/policies/IMPORTS.md`](/system/libs/mapgen/policies/IMPORTS.md)
+- Schemas and validation: [`docs/system/libs/mapgen/policies/SCHEMAS-AND-VALIDATION.md`](/system/libs/mapgen/policies/SCHEMAS-AND-VALIDATION.md)
+- Dependency IDs and registries: [`docs/system/libs/mapgen/policies/DEPENDENCY-IDS-AND-REGISTRIES.md`](/system/libs/mapgen/policies/DEPENDENCY-IDS-AND-REGISTRIES.md)
+- Artifact mutation: [`docs/system/libs/mapgen/policies/ARTIFACT-MUTATION.md`](/system/libs/mapgen/policies/ARTIFACT-MUTATION.md)
+- Config vs plan compilation: [`docs/system/libs/mapgen/policies/CONFIG-VS-PLAN-COMPILATION.md`](/system/libs/mapgen/policies/CONFIG-VS-PLAN-COMPILATION.md)
+- Truth vs projection: [`docs/system/libs/mapgen/policies/TRUTH-VS-PROJECTION.md`](/system/libs/mapgen/policies/TRUTH-VS-PROJECTION.md)
+- Module shape: [`docs/system/libs/mapgen/policies/MODULE-SHAPE.md`](/system/libs/mapgen/policies/MODULE-SHAPE.md)
 
 ## Ground truth anchors
 

--- a/docs/system/libs/mapgen/realism-knobs-and-presets.md
+++ b/docs/system/libs/mapgen/realism-knobs-and-presets.md
@@ -13,9 +13,9 @@ It is **not** canonical documentation.
 
 ## Canonical replacements
 
-- `docs/system/libs/mapgen/how-to/tune-realism-knobs.md`
-- `docs/system/libs/mapgen/tutorials/tune-a-preset-and-knobs.md`
+- [`docs/system/libs/mapgen/how-to/tune-realism-knobs.md`](/system/libs/mapgen/how-to/tune-realism-knobs.md)
+- [`docs/system/libs/mapgen/tutorials/tune-a-preset-and-knobs.md`](/system/libs/mapgen/tutorials/tune-a-preset-and-knobs.md)
 
 ## Legacy archive
 
-The previous contents of this page were moved to `docs/system/libs/mapgen/_archive/realism-knobs-and-presets.md`.
+The previous contents of this page were moved to [`docs/system/libs/mapgen/_archive/realism-knobs-and-presets.md`](/system/libs/mapgen/_archive/realism-knobs-and-presets.md).

--- a/docs/system/libs/mapgen/reference/OBSERVABILITY.md
+++ b/docs/system/libs/mapgen/reference/OBSERVABILITY.md
@@ -26,8 +26,8 @@ Define how MapGen runs can be inspected and debugged deterministically:
 Visualization is current canon and must reflect the deck.gl posture.
 
 See:
-- Contract routing: `docs/system/libs/mapgen/reference/VISUALIZATION.md`
-- Canonical implementation: `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
+- Contract routing: [`docs/system/libs/mapgen/reference/VISUALIZATION.md`](/system/libs/mapgen/reference/VISUALIZATION.md)
+- Canonical implementation: [`docs/system/libs/mapgen/pipeline-visualization-deckgl.md`](/system/libs/mapgen/pipeline-visualization-deckgl.md)
 
 ## Ground truth anchors
 

--- a/docs/system/libs/mapgen/reference/REFERENCE.md
+++ b/docs/system/libs/mapgen/reference/REFERENCE.md
@@ -21,22 +21,22 @@ Reference pages define contracts precisely (APIs, schemas, invariants, and key v
 
 Core contract references:
 
-- Glossary: `docs/system/libs/mapgen/reference/GLOSSARY.md`
-- Env (run boundary): `docs/system/libs/mapgen/reference/ENV.md` (legacy router: `docs/system/libs/mapgen/reference/RUN-SETTINGS.md`)
-- Recipe schema (RecipeV2): `docs/system/libs/mapgen/reference/RECIPE-SCHEMA.md`
-- Stage and step authoring: `docs/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md`
-- Config compilation: `docs/system/libs/mapgen/reference/CONFIG-COMPILATION.md`
-- Plan compilation: `docs/system/libs/mapgen/reference/PLAN-COMPILATION.md`
-- Tags and registries: `docs/system/libs/mapgen/reference/TAGS.md`
-- Artifacts: `docs/system/libs/mapgen/reference/ARTIFACTS.md`
-- Ops module contract: `docs/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md`
-- Observability: `docs/system/libs/mapgen/reference/OBSERVABILITY.md`
-- Visualization (contract + routing): `docs/system/libs/mapgen/reference/VISUALIZATION.md`
+- Glossary: [`docs/system/libs/mapgen/reference/GLOSSARY.md`](/system/libs/mapgen/reference/GLOSSARY.md)
+- Env (run boundary): [`docs/system/libs/mapgen/reference/ENV.md`](/system/libs/mapgen/reference/ENV.md) (legacy router: [`docs/system/libs/mapgen/reference/RUN-SETTINGS.md`](/system/libs/mapgen/reference/RUN-SETTINGS.md))
+- Recipe schema (RecipeV2): [`docs/system/libs/mapgen/reference/RECIPE-SCHEMA.md`](/system/libs/mapgen/reference/RECIPE-SCHEMA.md)
+- Stage and step authoring: [`docs/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md`](/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md)
+- Config compilation: [`docs/system/libs/mapgen/reference/CONFIG-COMPILATION.md`](/system/libs/mapgen/reference/CONFIG-COMPILATION.md)
+- Plan compilation: [`docs/system/libs/mapgen/reference/PLAN-COMPILATION.md`](/system/libs/mapgen/reference/PLAN-COMPILATION.md)
+- Tags and registries: [`docs/system/libs/mapgen/reference/TAGS.md`](/system/libs/mapgen/reference/TAGS.md)
+- Artifacts: [`docs/system/libs/mapgen/reference/ARTIFACTS.md`](/system/libs/mapgen/reference/ARTIFACTS.md)
+- Ops module contract: [`docs/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md`](/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md)
+- Observability: [`docs/system/libs/mapgen/reference/OBSERVABILITY.md`](/system/libs/mapgen/reference/OBSERVABILITY.md)
+- Visualization (contract + routing): [`docs/system/libs/mapgen/reference/VISUALIZATION.md`](/system/libs/mapgen/reference/VISUALIZATION.md)
 
 Additional reference pages:
-- Standard recipe: `docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`
-- Domains: `docs/system/libs/mapgen/reference/domains/DOMAINS.md`
-- Studio integration seam: `docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`
+- Standard recipe: [`docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`](/system/libs/mapgen/reference/STANDARD-RECIPE.md)
+- Domains: [`docs/system/libs/mapgen/reference/domains/DOMAINS.md`](/system/libs/mapgen/reference/domains/DOMAINS.md)
+- Studio integration seam: [`docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`](/system/libs/mapgen/reference/STUDIO-INTEGRATION.md)
 
 ## Ground truth anchors
 

--- a/docs/system/libs/mapgen/reference/RUN-SETTINGS.md
+++ b/docs/system/libs/mapgen/reference/RUN-SETTINGS.md
@@ -11,7 +11,7 @@
 
 Canonical doc:
 
-`docs/system/libs/mapgen/reference/ENV.md`
+[`docs/system/libs/mapgen/reference/ENV.md`](/system/libs/mapgen/reference/ENV.md)
 
 ## Legacy naming
 

--- a/docs/system/libs/mapgen/reference/STANDARD-RECIPE.md
+++ b/docs/system/libs/mapgen/reference/STANDARD-RECIPE.md
@@ -77,7 +77,7 @@ The standard recipe collects compile-time domain ops into a single registry:
 This registry is used during config compilation to bind op contracts to implementations by op id.
 
 Domain contract references:
-- `docs/system/libs/mapgen/reference/domains/DOMAINS.md`
+- [`docs/system/libs/mapgen/reference/domains/DOMAINS.md`](/system/libs/mapgen/reference/domains/DOMAINS.md)
 
 ## Ground truth anchors
 

--- a/docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md
+++ b/docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md
@@ -22,7 +22,7 @@ This page is:
 - and anchored to current code.
 
 For “how do I build this in my app?”, see:
-- `docs/system/libs/mapgen/how-to/integrate-mapgen-studio-worker.md`
+- [`docs/system/libs/mapgen/how-to/integrate-mapgen-studio-worker.md`](/system/libs/mapgen/how-to/integrate-mapgen-studio-worker.md)
 
 ## The Studio seam (what it is)
 
@@ -128,7 +128,7 @@ post({ type: "viz.layer.upsert", runToken, generation, layer }, transfer);
 ```
 
 Routing:
-- Visualization architecture and deck.gl rendering are canonical in `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`.
+- Visualization architecture and deck.gl rendering are canonical in [`docs/system/libs/mapgen/pipeline-visualization-deckgl.md`](/system/libs/mapgen/pipeline-visualization-deckgl.md).
 
 ## Cancellation + concurrency
 

--- a/docs/system/libs/mapgen/reference/VISUALIZATION.md
+++ b/docs/system/libs/mapgen/reference/VISUALIZATION.md
@@ -24,7 +24,7 @@ Hard rule:
 
 ## Canonical implementation doc
 
-- `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
+- [`docs/system/libs/mapgen/pipeline-visualization-deckgl.md`](/system/libs/mapgen/pipeline-visualization-deckgl.md)
 
 ## Ground truth anchors
 

--- a/docs/system/libs/mapgen/reference/domains/DOMAINS.md
+++ b/docs/system/libs/mapgen/reference/domains/DOMAINS.md
@@ -21,19 +21,19 @@ This section is the intended “source of truth” for domain boundaries and con
 
 Truth-first simulation domains:
 
-- Foundation: `docs/system/libs/mapgen/reference/domains/FOUNDATION.md`
-- Morphology: `docs/system/libs/mapgen/reference/domains/MORPHOLOGY.md`
-- Hydrology: `docs/system/libs/mapgen/reference/domains/HYDROLOGY.md`
-- Ecology: `docs/system/libs/mapgen/reference/domains/ECOLOGY.md`
+- Foundation: [`docs/system/libs/mapgen/reference/domains/FOUNDATION.md`](/system/libs/mapgen/reference/domains/FOUNDATION.md)
+- Morphology: [`docs/system/libs/mapgen/reference/domains/MORPHOLOGY.md`](/system/libs/mapgen/reference/domains/MORPHOLOGY.md)
+- Hydrology: [`docs/system/libs/mapgen/reference/domains/HYDROLOGY.md`](/system/libs/mapgen/reference/domains/HYDROLOGY.md)
+- Ecology: [`docs/system/libs/mapgen/reference/domains/ECOLOGY.md`](/system/libs/mapgen/reference/domains/ECOLOGY.md)
 
 Gameplay / engine-facing integration domain (target):
 
-- Gameplay: `docs/system/libs/mapgen/reference/domains/GAMEPLAY.md`
+- Gameplay: [`docs/system/libs/mapgen/reference/domains/GAMEPLAY.md`](/system/libs/mapgen/reference/domains/GAMEPLAY.md)
 
 Legacy domain naming (mapping only; not target-canonical domains):
 
-- Placement (legacy name for Gameplay’s placement phase): `docs/system/libs/mapgen/reference/domains/PLACEMENT.md`
-- Narrative (legacy name; absorbed into Gameplay): `docs/system/libs/mapgen/reference/domains/NARRATIVE.md`
+- Placement (legacy name for Gameplay’s placement phase): [`docs/system/libs/mapgen/reference/domains/PLACEMENT.md`](/system/libs/mapgen/reference/domains/PLACEMENT.md)
+- Narrative (legacy name; absorbed into Gameplay): [`docs/system/libs/mapgen/reference/domains/NARRATIVE.md`](/system/libs/mapgen/reference/domains/NARRATIVE.md)
 
 ## How to read these pages
 

--- a/docs/system/libs/mapgen/reference/domains/ECOLOGY.md
+++ b/docs/system/libs/mapgen/reference/domains/ECOLOGY.md
@@ -29,7 +29,7 @@ Truth stage:
 Projection stage:
 - `map-ecology`
 
-See: `docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`.
+See: [`docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`](/system/libs/mapgen/reference/STANDARD-RECIPE.md).
 
 ## Contract (requires/provides)
 

--- a/docs/system/libs/mapgen/reference/domains/GAMEPLAY.md
+++ b/docs/system/libs/mapgen/reference/domains/GAMEPLAY.md
@@ -31,7 +31,7 @@ Authoritative scope and absorption plan lives in:
 ## Contract (current + target posture)
 
 Current (standard recipe) provides an engine-facing “placement applied” effect tag and related debug artifacts (see legacy naming page):
-- `docs/system/libs/mapgen/reference/domains/PLACEMENT.md`
+- [`docs/system/libs/mapgen/reference/domains/PLACEMENT.md`](/system/libs/mapgen/reference/domains/PLACEMENT.md)
 
 Target posture:
 - Gameplay owns the API/schema for any narrative/playability surfaces.

--- a/docs/system/libs/mapgen/reference/domains/HYDROLOGY.md
+++ b/docs/system/libs/mapgen/reference/domains/HYDROLOGY.md
@@ -33,7 +33,7 @@ Truth stages:
 Projection stage:
 - `map-hydrology`
 
-See: `docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`.
+See: [`docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`](/system/libs/mapgen/reference/STANDARD-RECIPE.md).
 
 ## Contract (requires/provides)
 

--- a/docs/system/libs/mapgen/reference/domains/MORPHOLOGY.md
+++ b/docs/system/libs/mapgen/reference/domains/MORPHOLOGY.md
@@ -67,7 +67,7 @@ MORPHOLOGY is **tile-first**: its canonical “truth” products are tile-indexe
 ## Contract
 
 For the common “ops module” wiring pattern (op contracts, op envelope schemas, binding, and compile/runtime registries), see:
-- `docs/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md`
+- [`docs/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md`](/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md)
 
 ### Requires
 
@@ -446,7 +446,7 @@ Applies Morphology truth into the engine adapter (terrain/features), and emits e
 
 ## Open Questions
 
-0. `docs/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md` is referenced as the canonical ops-module contract, but is not currently present in this repo snapshot. Should it be added (and should domain docs link to it as the single source of truth for op envelope semantics)?
+0. [`docs/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md`](/system/libs/mapgen/reference/OPS-MODULE-CONTRACT.md) is referenced as the canonical ops-module contract, but is not currently present in this repo snapshot. Should it be added (and should domain docs link to it as the single source of truth for op envelope semantics)?
 1. What is the canonical unit/datum for `morphology.topography.elevation` before (and after) engine `buildElevation`? Should the artifact schema say “normalized units * 100” rather than “meters”, or should base-topography/hypsometry be reparameterized into meters?
 2. Should `distanceToCoast` be a single canonical product? Options:
    - publish the `compute-landmask` distance field as part of `morphology.topography` (or a dedicated artifact), and remove the bespoke BFS in `rugged-coasts`; or

--- a/docs/system/libs/mapgen/reference/domains/NARRATIVE.md
+++ b/docs/system/libs/mapgen/reference/domains/NARRATIVE.md
@@ -13,7 +13,7 @@ Target posture: narrative/playability work is **Gameplay-owned** (Narrative is a
 
 Canonical doc:
 
-`docs/system/libs/mapgen/reference/domains/GAMEPLAY.md`
+[`docs/system/libs/mapgen/reference/domains/GAMEPLAY.md`](/system/libs/mapgen/reference/domains/GAMEPLAY.md)
 
 ## Ground truth anchors
 

--- a/docs/system/libs/mapgen/reference/domains/PLACEMENT.md
+++ b/docs/system/libs/mapgen/reference/domains/PLACEMENT.md
@@ -21,14 +21,14 @@ Placement is legacy naming for the **Gameplay** domain’s “placement phase”
 Placement is intentionally **projection/engine-facing**: it depends on prior projection steps (engine rivers/features) and uses engine adapters to apply gameplay outcomes.
 
 Target posture: Gameplay absorbs Placement. See:
-- `docs/system/libs/mapgen/reference/domains/GAMEPLAY.md`
+- [`docs/system/libs/mapgen/reference/domains/GAMEPLAY.md`](/system/libs/mapgen/reference/domains/GAMEPLAY.md)
 
 ## Stages (standard recipe)
 
 Standard recipe stage(s):
 - `placement`
 
-See: `docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`.
+See: [`docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`](/system/libs/mapgen/reference/STANDARD-RECIPE.md).
 
 ## Contract (requires/provides)
 

--- a/docs/system/libs/mapgen/research/SPIKE-civ7-map-generation-features.md
+++ b/docs/system/libs/mapgen/research/SPIKE-civ7-map-generation-features.md
@@ -5,13 +5,13 @@
 > **Do not treat as contract truth.** This document is an exploratory synthesis of Civ7 mapgen behaviors and a physics-inspired framing. It may contain assumptions that are outdated relative to the current SDK architecture.
 >
 > **Canonical modeling references (preferred):**
-> - `docs/system/libs/mapgen/architecture.md`
-> - `docs/system/libs/mapgen/foundation.md`
-> - `docs/system/libs/mapgen/morphology.md`
-> - `docs/system/libs/mapgen/hydrology.md`
-> - `docs/system/libs/mapgen/ecology.md`
-> - `docs/system/libs/mapgen/narrative.md`
-> - `docs/system/libs/mapgen/placement.md`
+> - [`docs/system/libs/mapgen/architecture.md`](/system/libs/mapgen/architecture.md)
+> - [`docs/system/libs/mapgen/foundation.md`](/system/libs/mapgen/foundation.md)
+> - [`docs/system/libs/mapgen/morphology.md`](/system/libs/mapgen/morphology.md)
+> - [`docs/system/libs/mapgen/hydrology.md`](/system/libs/mapgen/hydrology.md)
+> - [`docs/system/libs/mapgen/ecology.md`](/system/libs/mapgen/ecology.md)
+> - [`docs/system/libs/mapgen/narrative.md`](/system/libs/mapgen/narrative.md)
+> - [`docs/system/libs/mapgen/placement.md`](/system/libs/mapgen/placement.md)
 >
 > **How to use this spike now:** treat it as a “feature inventory + hypothesis bank”; salvage durable insights into the canonical system docs above when doing domain modeling.
 

--- a/docs/system/libs/mapgen/research/SPIKE-earth-physics-systems-modeling-alt.md
+++ b/docs/system/libs/mapgen/research/SPIKE-earth-physics-systems-modeling-alt.md
@@ -5,13 +5,13 @@
 > **Do not treat as contract truth.** This document is a detailed first-principles write-up, but it mixes legacy architectural assumptions with modeling guidance.
 >
 > **Canonical modeling references (preferred):**
-> - `docs/system/libs/mapgen/architecture.md`
-> - `docs/system/libs/mapgen/foundation.md`
-> - `docs/system/libs/mapgen/morphology.md`
-> - `docs/system/libs/mapgen/hydrology.md`
-> - `docs/system/libs/mapgen/ecology.md`
-> - `docs/system/libs/mapgen/narrative.md`
-> - `docs/system/libs/mapgen/placement.md`
+> - [`docs/system/libs/mapgen/architecture.md`](/system/libs/mapgen/architecture.md)
+> - [`docs/system/libs/mapgen/foundation.md`](/system/libs/mapgen/foundation.md)
+> - [`docs/system/libs/mapgen/morphology.md`](/system/libs/mapgen/morphology.md)
+> - [`docs/system/libs/mapgen/hydrology.md`](/system/libs/mapgen/hydrology.md)
+> - [`docs/system/libs/mapgen/ecology.md`](/system/libs/mapgen/ecology.md)
+> - [`docs/system/libs/mapgen/narrative.md`](/system/libs/mapgen/narrative.md)
+> - [`docs/system/libs/mapgen/placement.md`](/system/libs/mapgen/placement.md)
 >
 > **How to use this spike now:** treat it as “research raw material”; extract stable causal models into the canonical domain docs and ignore any implied SDK mechanics that conflict with current specs/workflows.
 

--- a/docs/system/libs/mapgen/research/SPIKE-earth-physics-systems-modeling.md
+++ b/docs/system/libs/mapgen/research/SPIKE-earth-physics-systems-modeling.md
@@ -5,13 +5,13 @@
 > **Do not treat as contract truth.** This document contains deep first-principles physics framing and candidate staging ideas, but it is not guaranteed to match the current SDK’s canonical contracts.
 >
 > **Canonical modeling references (preferred):**
-> - `docs/system/libs/mapgen/architecture.md`
-> - `docs/system/libs/mapgen/foundation.md`
-> - `docs/system/libs/mapgen/morphology.md`
-> - `docs/system/libs/mapgen/hydrology.md`
-> - `docs/system/libs/mapgen/ecology.md`
-> - `docs/system/libs/mapgen/narrative.md`
-> - `docs/system/libs/mapgen/placement.md`
+> - [`docs/system/libs/mapgen/architecture.md`](/system/libs/mapgen/architecture.md)
+> - [`docs/system/libs/mapgen/foundation.md`](/system/libs/mapgen/foundation.md)
+> - [`docs/system/libs/mapgen/morphology.md`](/system/libs/mapgen/morphology.md)
+> - [`docs/system/libs/mapgen/hydrology.md`](/system/libs/mapgen/hydrology.md)
+> - [`docs/system/libs/mapgen/ecology.md`](/system/libs/mapgen/ecology.md)
+> - [`docs/system/libs/mapgen/narrative.md`](/system/libs/mapgen/narrative.md)
+> - [`docs/system/libs/mapgen/placement.md`](/system/libs/mapgen/placement.md)
 >
 > **How to use this spike now:** mine it for “from scratch” physics insights, then rewrite the resulting target model into the canonical domain docs rather than copying proposed APIs/surfaces verbatim.
 

--- a/docs/system/libs/mapgen/research/SPIKE-synthesis-earth-physics-systems-swooper-engine.md
+++ b/docs/system/libs/mapgen/research/SPIKE-synthesis-earth-physics-systems-swooper-engine.md
@@ -5,13 +5,13 @@
 > **Do not treat as contract truth.** This document proposes a synthesis pipeline and candidate product surfaces; it predates parts of the current SDK architecture and may contain outdated mechanics.
 >
 > **Canonical modeling references (preferred):**
-> - `docs/system/libs/mapgen/architecture.md`
-> - `docs/system/libs/mapgen/foundation.md`
-> - `docs/system/libs/mapgen/morphology.md`
-> - `docs/system/libs/mapgen/hydrology.md`
-> - `docs/system/libs/mapgen/ecology.md`
-> - `docs/system/libs/mapgen/narrative.md`
-> - `docs/system/libs/mapgen/placement.md`
+> - [`docs/system/libs/mapgen/architecture.md`](/system/libs/mapgen/architecture.md)
+> - [`docs/system/libs/mapgen/foundation.md`](/system/libs/mapgen/foundation.md)
+> - [`docs/system/libs/mapgen/morphology.md`](/system/libs/mapgen/morphology.md)
+> - [`docs/system/libs/mapgen/hydrology.md`](/system/libs/mapgen/hydrology.md)
+> - [`docs/system/libs/mapgen/ecology.md`](/system/libs/mapgen/ecology.md)
+> - [`docs/system/libs/mapgen/narrative.md`](/system/libs/mapgen/narrative.md)
+> - [`docs/system/libs/mapgen/placement.md`](/system/libs/mapgen/placement.md)
 >
 > **How to use this spike now:** use it as a “causal staging and product ideation” seed; salvage enduring causal claims into the canonical system docs rather than copying the proposed API/wiring patterns.
 

--- a/docs/system/libs/mapgen/tutorials/TUTORIALS.md
+++ b/docs/system/libs/mapgen/tutorials/TUTORIALS.md
@@ -20,9 +20,9 @@ Tutorials are learning-oriented, end-to-end walkthroughs.
 
 Canonical tutorials:
 
-- Run the standard recipe in Studio: `docs/system/libs/mapgen/tutorials/run-standard-recipe-in-studio.md`
-- Inspect artifacts and projections: `docs/system/libs/mapgen/tutorials/inspect-artifacts-and-projections.md`
-- Tune a preset and knobs: `docs/system/libs/mapgen/tutorials/tune-a-preset-and-knobs.md`
+- Run the standard recipe in Studio: [`docs/system/libs/mapgen/tutorials/run-standard-recipe-in-studio.md`](/system/libs/mapgen/tutorials/run-standard-recipe-in-studio.md)
+- Inspect artifacts and projections: [`docs/system/libs/mapgen/tutorials/inspect-artifacts-and-projections.md`](/system/libs/mapgen/tutorials/inspect-artifacts-and-projections.md)
+- Tune a preset and knobs: [`docs/system/libs/mapgen/tutorials/tune-a-preset-and-knobs.md`](/system/libs/mapgen/tutorials/tune-a-preset-and-knobs.md)
 
 Potential future tutorials:
 - Implement a new step end-to-end

--- a/docs/system/libs/mapgen/tutorials/inspect-artifacts-and-projections.md
+++ b/docs/system/libs/mapgen/tutorials/inspect-artifacts-and-projections.md
@@ -56,14 +56,14 @@ Inside the run directory:
 ### 3) Replay the dump in Studio (Dump mode)
 
 Follow the concrete replay workflow:
-- `docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md`
+- [`docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md`](/system/libs/mapgen/how-to/debug-with-trace-and-viz.md)
 
 This uses MapGen Studio’s dump viewer (deck.gl) to load `manifest.json` and the referenced `data/*` payloads.
 
 ### 4) Open the deck.gl visualization workflow (system reference)
 
 Follow the canonical viz doc (do not invent alternate viewers):
-- `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
+- [`docs/system/libs/mapgen/pipeline-visualization-deckgl.md`](/system/libs/mapgen/pipeline-visualization-deckgl.md)
 
 ### 5) Correlate projections back to their source step
 

--- a/docs/system/libs/mapgen/tutorials/run-standard-recipe-in-studio.md
+++ b/docs/system/libs/mapgen/tutorials/run-standard-recipe-in-studio.md
@@ -46,7 +46,7 @@ In the Studio header:
 
 Note: `Dump` mode is for **replaying** a saved trace/viz dump; “Run” will open a folder picker instead of running a recipe.
 Replay is covered in:
-- `docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md`
+- [`docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md`](/system/libs/mapgen/how-to/debug-with-trace-and-viz.md)
 
 ### 3) Select the Standard recipe runtime
 
@@ -82,10 +82,10 @@ Today’s posture (implementation detail, but important for expectations):
 - Studio’s worker currently enables trace for **all steps** at **verbose** level (so steps that emit viz layers can be viewed).
 
 When you need deeper grounding:
-- Standard recipe reference: `docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`
-- Visualization reference: `docs/system/libs/mapgen/reference/VISUALIZATION.md`
-- Studio seam reference: `docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`
-- Canonical deck.gl viz doc: `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
+- Standard recipe reference: [`docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`](/system/libs/mapgen/reference/STANDARD-RECIPE.md)
+- Visualization reference: [`docs/system/libs/mapgen/reference/VISUALIZATION.md`](/system/libs/mapgen/reference/VISUALIZATION.md)
+- Studio seam reference: [`docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`](/system/libs/mapgen/reference/STUDIO-INTEGRATION.md)
+- Canonical deck.gl viz doc: [`docs/system/libs/mapgen/pipeline-visualization-deckgl.md`](/system/libs/mapgen/pipeline-visualization-deckgl.md)
 
 ## Verification
 
@@ -97,9 +97,9 @@ When you need deeper grounding:
 
 ## Next steps
 
-- Learn how to debug with trace + viz outside Studio: `docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md`
-- Learn the reference contract model for stages/steps: `docs/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md`
-- Inspect the artifact/projection model: `docs/system/libs/mapgen/tutorials/inspect-artifacts-and-projections.md`
+- Learn how to debug with trace + viz outside Studio: [`docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md`](/system/libs/mapgen/how-to/debug-with-trace-and-viz.md)
+- Learn the reference contract model for stages/steps: [`docs/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md`](/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md)
+- Inspect the artifact/projection model: [`docs/system/libs/mapgen/tutorials/inspect-artifacts-and-projections.md`](/system/libs/mapgen/tutorials/inspect-artifacts-and-projections.md)
 
 ## Ground truth anchors
 

--- a/docs/system/libs/mapgen/tutorials/tune-a-preset-and-knobs.md
+++ b/docs/system/libs/mapgen/tutorials/tune-a-preset-and-knobs.md
@@ -28,8 +28,8 @@ Learn the “author workflow” for changing map realism posture safely:
 
 - You can run Studio locally: `bun run dev:mapgen-studio`
 - You understand the schema split:
-  - `docs/system/libs/mapgen/reference/RECIPE-SCHEMA.md`
-  - `docs/system/libs/mapgen/reference/CONFIG-COMPILATION.md`
+  - [`docs/system/libs/mapgen/reference/RECIPE-SCHEMA.md`](/system/libs/mapgen/reference/RECIPE-SCHEMA.md)
+  - [`docs/system/libs/mapgen/reference/CONFIG-COMPILATION.md`](/system/libs/mapgen/reference/CONFIG-COMPILATION.md)
 
 ## Walkthrough
 


### PR DESCRIPTION
## Summary
Slice 14A makes the canonical MapGen doc spine easier to navigate by converting MapGen→MapGen literal path references into clickable markdown links while keeping the literal repo path as visible/greppable link text.

## What’s in this PR
- Adds a small normalizer script to rewrite backticked MapGen doc paths into markdown links.
- Applies the normalization across `docs/system/libs/mapgen/**`.

## Link style
- Before: `` `docs/system/libs/mapgen/.../FOO.md` ``
- After:  [`docs/system/libs/mapgen/.../FOO.md`](/system/libs/mapgen/.../FOO.md)

## Safety rules
- Does not touch “Ground truth anchors” evidence strings.
- Does not churn `docs/system/libs/mapgen/_archive/**`.

## Key artifact
- `docs/projects/engine-refactor-v1/mapgen-docs-alignment/scripts/normalize_mapgen_doc_links.py`

## Testing
- `bun run lint:mapgen-docs` (warnings OK)
