### PR TITLE
docs(mapgen): slice 14B add hub see also

### DIFF
--- a/docs/system/libs/mapgen/explanation/EXPLANATION.md
+++ b/docs/system/libs/mapgen/explanation/EXPLANATION.md
@@ -34,6 +34,12 @@ Potential future explanation pages (only if they add clarity beyond policy/refer
 - Narrative status (target contract + current wiring status) — if this warrants its own page
 - Studio as a reference consumer (not architecture authority) — may be folded into Studio docs
 
+## See also
+
+- [`docs/system/libs/mapgen/MAPGEN.md`](/system/libs/mapgen/MAPGEN.md)
+- [`docs/system/libs/mapgen/reference/REFERENCE.md`](/system/libs/mapgen/reference/REFERENCE.md)
+- [`docs/system/libs/mapgen/policies/POLICIES.md`](/system/libs/mapgen/policies/POLICIES.md)
+
 ## Ground truth anchors
 
 - Gateway: `docs/system/libs/mapgen/MAPGEN.md`

--- a/docs/system/libs/mapgen/how-to/HOW-TO.md
+++ b/docs/system/libs/mapgen/how-to/HOW-TO.md
@@ -33,6 +33,13 @@ Canonical how-tos:
 Potential future how-tos:
 - Run a recipe headless
 
+## See also
+
+- [`docs/system/libs/mapgen/MAPGEN.md`](/system/libs/mapgen/MAPGEN.md)
+- [`docs/system/libs/mapgen/reference/REFERENCE.md`](/system/libs/mapgen/reference/REFERENCE.md)
+- [`docs/system/libs/mapgen/policies/POLICIES.md`](/system/libs/mapgen/policies/POLICIES.md)
+- [`docs/system/libs/mapgen/tutorials/TUTORIALS.md`](/system/libs/mapgen/tutorials/TUTORIALS.md)
+
 ## Ground truth anchors
 
 - Gateway: `docs/system/libs/mapgen/MAPGEN.md`

--- a/docs/system/libs/mapgen/llms/LLMS.md
+++ b/docs/system/libs/mapgen/llms/LLMS.md
@@ -28,6 +28,12 @@ It’s meant for AI agents and tooling that need stable pointers to “the one r
 - Prefer published package entrypoints; do not use unstable workspace-only aliases in canonical examples.
 - Visualization (deck.gl pipeline viz) is current canon; do not create competing viz docs.
 
+## See also
+
+- [`docs/system/libs/mapgen/MAPGEN.md`](/system/libs/mapgen/MAPGEN.md)
+- [`docs/system/libs/mapgen/policies/POLICIES.md`](/system/libs/mapgen/policies/POLICIES.md)
+- [`docs/system/libs/mapgen/reference/REFERENCE.md`](/system/libs/mapgen/reference/REFERENCE.md)
+
 ## Ground truth anchors
 
 - Gateway: `docs/system/libs/mapgen/MAPGEN.md`

--- a/docs/system/libs/mapgen/policies/POLICIES.md
+++ b/docs/system/libs/mapgen/policies/POLICIES.md
@@ -31,6 +31,12 @@ Canonical policies:
 - Truth vs projection: [`docs/system/libs/mapgen/policies/TRUTH-VS-PROJECTION.md`](/system/libs/mapgen/policies/TRUTH-VS-PROJECTION.md)
 - Module shape: [`docs/system/libs/mapgen/policies/MODULE-SHAPE.md`](/system/libs/mapgen/policies/MODULE-SHAPE.md)
 
+## See also
+
+- [`docs/system/libs/mapgen/MAPGEN.md`](/system/libs/mapgen/MAPGEN.md)
+- [`docs/system/libs/mapgen/reference/REFERENCE.md`](/system/libs/mapgen/reference/REFERENCE.md)
+- [`docs/system/libs/mapgen/how-to/HOW-TO.md`](/system/libs/mapgen/how-to/HOW-TO.md)
+
 ## Ground truth anchors
 
 - Gateway: `docs/system/libs/mapgen/MAPGEN.md`

--- a/docs/system/libs/mapgen/reference/REFERENCE.md
+++ b/docs/system/libs/mapgen/reference/REFERENCE.md
@@ -38,6 +38,12 @@ Additional reference pages:
 - Domains: [`docs/system/libs/mapgen/reference/domains/DOMAINS.md`](/system/libs/mapgen/reference/domains/DOMAINS.md)
 - Studio integration seam: [`docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`](/system/libs/mapgen/reference/STUDIO-INTEGRATION.md)
 
+## See also
+
+- [`docs/system/libs/mapgen/MAPGEN.md`](/system/libs/mapgen/MAPGEN.md)
+- [`docs/system/libs/mapgen/policies/POLICIES.md`](/system/libs/mapgen/policies/POLICIES.md)
+- [`docs/system/libs/mapgen/explanation/EXPLANATION.md`](/system/libs/mapgen/explanation/EXPLANATION.md)
+
 ## Ground truth anchors
 
 - Gateway: `docs/system/libs/mapgen/MAPGEN.md`

--- a/docs/system/libs/mapgen/tutorials/TUTORIALS.md
+++ b/docs/system/libs/mapgen/tutorials/TUTORIALS.md
@@ -27,6 +27,12 @@ Canonical tutorials:
 Potential future tutorials:
 - Implement a new step end-to-end
 
+## See also
+
+- [`docs/system/libs/mapgen/MAPGEN.md`](/system/libs/mapgen/MAPGEN.md)
+- [`docs/system/libs/mapgen/how-to/HOW-TO.md`](/system/libs/mapgen/how-to/HOW-TO.md)
+- [`docs/system/libs/mapgen/reference/REFERENCE.md`](/system/libs/mapgen/reference/REFERENCE.md)
+
 ## Ground truth anchors
 
 - Gateway: `docs/system/libs/mapgen/MAPGEN.md`


### PR DESCRIPTION
## Summary
Slice 14B adds lightweight `## See also` navigation to MapGen hub pages only, without introducing a backlink graph.

## What’s in this PR
Adds `## See also` blocks (inserted immediately before `## Ground truth anchors`) to:
- `docs/system/libs/mapgen/reference/REFERENCE.md`
- `docs/system/libs/mapgen/how-to/HOW-TO.md`
- `docs/system/libs/mapgen/tutorials/TUTORIALS.md`
- `docs/system/libs/mapgen/explanation/EXPLANATION.md`
- `docs/system/libs/mapgen/policies/POLICIES.md`
- `docs/system/libs/mapgen/llms/LLMS.md`

Notes:
- Intentionally does not add `## See also` to `docs/system/libs/mapgen/MAPGEN.md` since it already has “Start here” + “Fast links”.

## Testing
- `bun run lint:mapgen-docs` (warnings OK)
