### PR TITLE
docs(mapgen): slice 13C viz parity

### DIFF
--- a/docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md
+++ b/docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md
@@ -16,7 +16,7 @@
 Enable trace + viz emissions for a run so you can debug:
 - step ordering and gating,
 - invariants and validation failures,
-- artifact/projection drift,
+- artifact/projection drift (map projection, not UI render mode),
 - scalar field correctness (via dumped layers + deck.gl viewer).
 
 Routes to:
@@ -104,7 +104,7 @@ Then click **Run** and pick the dump folder (the folder containing `manifest.jso
 Use the Explore panel to:
 - choose a stage + step (from the manifest),
 - choose a `spaceId` (coordinate space),
-- choose a layer and render variant.
+- choose a data type (`dataTypeKey`), render mode (`kind[:role]`), and variant (`variantKey`) as needed.
 
 For the full system explanation (streaming vs replay, schema, layer taxonomy), see:
 - [`docs/system/libs/mapgen/pipeline-visualization-deckgl.md`](/system/libs/mapgen/pipeline-visualization-deckgl.md)

--- a/docs/system/libs/mapgen/pipeline-visualization-deckgl.md
+++ b/docs/system/libs/mapgen/pipeline-visualization-deckgl.md
@@ -5,7 +5,7 @@
   <item id="trace" title="Trace posture (current)"/>
   <item id="architecture" title="System architecture"/>
   <item id="primitives" title="Viz primitives (implemented)"/>
-  <item id="taxonomy" title="Layer taxonomy"/>
+  <item id="taxonomy" title="Data type taxonomy"/>
   <item id="viewer" title="Viewer design (implemented)"/>
   <item id="changes" title="Future enhancements"/>
   <item id="verification" title="Verification"/>
@@ -27,7 +27,9 @@
 - `planFingerprint`: plan identity (hash of plan inputs); see [`docs/system/libs/mapgen/reference/GLOSSARY.md`](/system/libs/mapgen/reference/GLOSSARY.md) and `packages/mapgen-core/src/engine/observability.ts`.
 - `dataTypeKey`: stable semantic identity for a data product (e.g. `"hydrology.wind.wind"`).
 - `layerKey`: canonical, opaque identity for a layer within a run (used for streaming upserts and dump replay identity).
-- `spaceId`: explicit coordinate space (“projection” selector in the Studio UI).
+- `variantKey`: optional disambiguator for variants within the same semantic data product (UI label: “Variant”).
+- `spaceId`: explicit coordinate space (UI label: “Space”).
+- `renderModeId`: UI grouping key derived from `kind[:role]` (e.g. `"grid"`, `"segments:edgeOverlay"`).
 
 ## Coordinate Spaces (critical for “why does it look rotated?”)
 
@@ -143,7 +145,18 @@ MapGen Studio’s dump viewer expects `manifest.json` with `version: 1`.
 
 ---
 
-## Layer Taxonomy (What We Visualize)
+## Data Type Taxonomy (How Studio groups visualization)
+
+Studio presents visualization by grouping concrete layer emissions into “data types”:
+
+- **Data type**: `dataTypeKey` (stable semantic identity; what the thing *means*).
+- **Space**: `spaceId` (coordinate system; where the numbers live).
+- **Render mode**: derived `kind[:role]` (how the thing is rendered).
+- **Variant**: `variantKey` (optional; multiple complementary variants of the same data type).
+
+Each emitted entry in `manifest.layers[]` is still a **layer** (concrete emission), but Studio’s primary selector is the **data type**.
+
+## Layer Taxonomy (What we render)
 
 **Layer kinds:**
 

--- a/docs/system/libs/mapgen/reference/VISUALIZATION.md
+++ b/docs/system/libs/mapgen/reference/VISUALIZATION.md
@@ -18,6 +18,11 @@ Define the canonical visualization contract and route readers to the single cano
 - MapGen Studio renders visualization via deck.gl:
   - live runs consume streamed layer upserts (`viz.layer.upsert`),
   - dump viewer workflows consume dump folders (when produced).
+- Studio’s primary UI terminology is:
+  - **Data type**: `dataTypeKey` (semantic identity; what a visualization *means*),
+  - **Space**: `spaceId` (coordinate space),
+  - **Render mode**: derived from `kind[:role]` (grid / points / segments / gridFields + optional role),
+  - **Variant**: `variantKey` (optional; disambiguates multiple variants of the same data type).
 
 Hard rule:
 - There must be **exactly one** canonical deck.gl visualization doc. Do not fork competing viz architecture pages.


### PR DESCRIPTION
## Summary
Slice 13C updates the canonical viz docs to match the merged `dev-viz-v1-*` UI semantics and terminology (data type / space / render mode / variant).

## What’s in this PR
Updates only these canonical docs:
- `docs/system/libs/mapgen/pipeline-visualization-deckgl.md`
- `docs/system/libs/mapgen/reference/VISUALIZATION.md`
- `docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md`

## Terminology parity
- **Data type**: `dataTypeKey`
- **Space**: `spaceId`
- **Render mode**: derived from `kind[:role]`
- **Variant**: `variantKey`

## Testing
- `bun run lint:mapgen-docs` (warnings OK)
