### PR TITLE
docs(pipeline-realism): harden M1 milestone

### DIFF
--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M1-001-publish-new-foundation-truth-artifacts-mesh-tiles-docs-align.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M1-001-publish-new-foundation-truth-artifacts-mesh-tiles-docs-align.md
@@ -97,6 +97,11 @@ Implementation is expected to touch (non-exhaustive, but the “main highways”
 - `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/*.contract.ts` (requires/provides lists; if step ownership changes)
 - `docs/projects/pipeline-realism/resources/spec/artifact-catalog.md` (normative artifact entries)
 
+## Implementation Decisions
+
+- **Plate motion artifact naming:** `artifact:foundation.plateMotion` is the canonical ID (per milestone + artifact catalog). The schema mirrors the `plateKinematics` contract defined in `docs/projects/pipeline-realism/resources/spec/sections/plate-motion.md`; `plateKinematics` remains a schema concept, not a separate artifact id.
+- **Versioned payloads for new artifacts:** new maximal artifacts introduced here carry `version: 1` at top level; legacy artifacts without explicit `version` remain unchanged until their owning issues upgrade producers.
+
 ### Pitfalls / Rakes
 
 - “We implemented the algorithm but forgot the contract surface”: new arrays exist but are not published as artifacts, so consumers can’t rely on them.

--- a/docs/projects/pipeline-realism/milestones/M1-foundation-maximal-cutover.md
+++ b/docs/projects/pipeline-realism/milestones/M1-foundation-maximal-cutover.md
@@ -78,7 +78,7 @@ Note: issue doc links are populated in Slice 3 of the plan (local issue docs und
 These 25 issue docs are the **canonical milestone checklist**. Do not duplicate them as additional checkbox sections; use the narrative sections below for workstream framing and sequencing.
 
 ### Prepare (Slice-01)
-- [ ] [`LOCAL-TBD-PR-M1-001`](../issues/LOCAL-TBD-PR-M1-001-publish-new-foundation-truth-artifacts-mesh-tiles-docs-align.md) Publish new Foundation truth artifacts (mesh + tiles) + docs alignment
+- [x] [`LOCAL-TBD-PR-M1-001`](../issues/LOCAL-TBD-PR-M1-001-publish-new-foundation-truth-artifacts-mesh-tiles-docs-align.md) Publish new Foundation truth artifacts (mesh + tiles) + docs alignment — branch: `agent-URSULA-M1-LOCAL-TBD-PR-M1-001-publish-foundation-truth-artifacts`; PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1073
 - [ ] [`LOCAL-TBD-PR-M1-002`](../issues/LOCAL-TBD-PR-M1-002-add-tile-projections-for-tectonic-history-provenance-mandato.md) Add tile projections for tectonic history + provenance (mandatory drivers)
 - [ ] [`LOCAL-TBD-PR-M1-003`](../issues/LOCAL-TBD-PR-M1-003-wire-visualization-datatypekeys-minimal-layer-taxonomy-for-c.md) Wire visualization `dataTypeKey`s + minimal layer taxonomy for the causal spine
 - [ ] [`LOCAL-TBD-PR-M1-004`](../issues/LOCAL-TBD-PR-M1-004-add-validation-harness-scaffolding-determinism-fingerprints-.md) Add validation harness scaffolding (determinism fingerprints + invariant runners)

--- a/docs/projects/pipeline-realism/resources/spec/artifact-catalog.md
+++ b/docs/projects/pipeline-realism/resources/spec/artifact-catalog.md
@@ -25,17 +25,17 @@ Legend:
 | artifactId | kind | space | payload (shape) | key fields / meaning | derivedFrom | consumers | viz `dataTypeKey` |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `artifact:foundation.mesh` | truth | mesh | `{ cellCount, siteX[], siteY[], neighborsCSR... }` | mesh geometry + adjacency | — | Foundation | `foundation.mesh.sites`, `foundation.mesh.neighbors` |
-| `artifact:foundation.mantlePotential` | truth | mesh | `{ potential[cell] (f32), sources... }` | mantle potential field; signed | — | Foundation | `foundation.mantle.potential` |
-| `artifact:foundation.mantleForcing` | truth | mesh | `{ forcingU/V[cell], stress01[cell], div/curl... }` | derived mantle stress + forcing vector field | `mantlePotential` | Foundation | `foundation.mantle.forcing` |
+| `artifact:foundation.mantlePotential` | truth | mesh | `{ version, cellCount, potential[cell], sourceType[], sourceCell[], sourceAmplitude[], sourceRadius[] }` | mantle potential field; signed | — | Foundation | `foundation.mantle.potential` |
+| `artifact:foundation.mantleForcing` | truth | mesh | `{ version, cellCount, forcingU/V[cell], stress[cell], forcingMag[cell], upwellingClass[cell], divergence[cell] }` | derived mantle stress + forcing vector field | `mantlePotential` | Foundation | `foundation.mantle.forcing` |
 | `artifact:foundation.crust` | truth | mesh | `{ maturity[cell], thickness[cell], strength[cell], ... }` | canonical lithosphere/crust state | — | Foundation | `foundation.crust.*` |
-| `artifact:foundation.plateMotion` | truth | mesh | `{ motionU/V[cell], plateKinematics[plate], fitResiduals... }` | plate-like kinematics derived from mantle forcing | `mantleForcing` | Foundation | `foundation.plates.motion` |
+| `artifact:foundation.plateMotion` | truth | mesh | `{ version, cellCount, plateCount, plateCenterX/Y[plate], plateVelocityX/Y[plate], plateOmega[plate], plateFitRms/P90[plate], plateQuality[plate], cellFitError[cell] }` | plate-like kinematics derived from mantle forcing | `mantleForcing` | Foundation | `foundation.plates.motion` |
 | `artifact:foundation.plateGraph` | truth | mesh | `{ cellToPlate[cell], plates[plate]... }` | plate partition + per-plate metadata | `(crust, plateMotion)` | Foundation | `foundation.plates.partition` |
 | `artifact:foundation.tectonicSegments` | truth | mesh | `{ segmentCount, aCell[], bCell[], plateA/B[], regime[], ... }` | boundary segments + regimes | `(plateGraph, plateMotion)` | Foundation | `foundation.plates.boundary.*` |
 | `artifact:foundation.tectonicHistory` | truth | mesh | `{ eraCount, eras[era]{...}, rollups{...} }` | Eulerian era fields + rollups | `(segments, events)` | Foundation → Morphology | `foundation.history.*` |
-| `artifact:foundation.tectonicProvenance` | truth | mesh | `{ eraCount, tracerIndex[era][cell], lineageScalars... }` | Lagrangian provenance: tracer history + scalars | `(history, events)` | Foundation → Morphology | `foundation.provenance.*` |
+| `artifact:foundation.tectonicProvenance` | truth | mesh | `{ version, eraCount, cellCount, tracerIndex[era][cell], provenance{originEra, originPlateId, lastBoundaryEra/Type/Polarity/Intensity, crustAge} }` | Lagrangian provenance: tracer history + scalars | `(history, events)` | Foundation → Morphology | `foundation.provenance.*` |
 | `artifact:foundation.tileToCellIndex` | projection | tile | `i32[tile]` | nearest mesh cell per tile | `mesh` | Foundation + downstream | `foundation.projection.tileToCellIndex` |
-| `artifact:foundation.tectonicHistoryTiles` | projection | tile | `{ eraCount, perEra[tile], rollups[tile] }` | projected history fields for tile-first consumers | `(tectonicHistory, tileToCellIndex)` | Morphology | `foundation.history.*` |
-| `artifact:foundation.tectonicProvenanceTiles` | projection | tile | `{ perEra[tile], rollups[tile] }` | projected provenance fields | `(tectonicProvenance, tileToCellIndex)` | Morphology | `foundation.provenance.*` |
+| `artifact:foundation.tectonicHistoryTiles` | projection | tile | `{ version, eraCount, perEra[tile]{boundaryType, uplift/rift/shear/volcanism/fracture, masks}, rollups{upliftTotal, fractureTotal, volcanismTotal, upliftRecentFraction, lastActiveEra} }` | projected history fields for tile-first consumers | `(tectonicHistory, tileToCellIndex)` | Morphology | `foundation.history.*` |
+| `artifact:foundation.tectonicProvenanceTiles` | projection | tile | `{ version, originEra[tile], originPlateId[tile], driftDistance[tile], lastBoundaryEra[tile], lastBoundaryType[tile] }` | projected provenance fields | `(tectonicProvenance, tileToCellIndex)` | Morphology | `foundation.provenance.*` |
 | `artifact:foundation.mantleForcingTiles` | projection | tile | `{ forcingU/V[tile], stress01[tile], div/curl... }` | projected mantle forcing (author visual + debug) | `(mantleForcing, tileToCellIndex)` | Studio / debug | `foundation.mantle.forcing` |
 | `artifact:foundation.crustTiles` | projection | tile | `{ maturity[tile], thickness[tile], strength[tile], ... }` | projected crust state | `(crust, tileToCellIndex)` | Morphology + debug | `foundation.crust.*` |
 | `artifact:morphology.topography` | truth | tile | `{ elevation[i16], seaLevel[f64], landMask[u8] }` | topography output | — | downstream | `morphology.topography.elevation` |
@@ -49,4 +49,3 @@ Notes:
 - Any artifact marked `diagnostics` must include an “allowed uses / disallowed uses” note at definition time.
 - Projections must never feed back into mesh truth computation (no tile→mesh inference).
 - If a breaking meaning change occurs without a shape change, treat it as a breaking change (see versioning doc).
-

--- a/docs/projects/pipeline-realism/resources/spec/schema-and-versioning.md
+++ b/docs/projects/pipeline-realism/resources/spec/schema-and-versioning.md
@@ -22,6 +22,19 @@ Where “public” means:
 - consumed by visualization as part of the authoring loop, or
 - listed in `docs/projects/pipeline-realism/resources/spec/artifact-catalog.md`.
 
+#### M1 Foundation artifacts (versioned now)
+
+The following new Foundation artifacts introduced in M1 MUST carry `version: 1` at top level:
+
+- `artifact:foundation.mantlePotential`
+- `artifact:foundation.mantleForcing`
+- `artifact:foundation.plateMotion`
+- `artifact:foundation.tectonicProvenance`
+- `artifact:foundation.tectonicHistoryTiles`
+- `artifact:foundation.tectonicProvenanceTiles`
+
+Legacy artifacts without explicit `version` fields remain unchanged until their owning issues upgrade the schema and producers in lockstep.
+
 ### Change taxonomy
 
 1. **Breaking change** (shape OR meaning)
@@ -72,4 +85,3 @@ Normative sources:
 - Validation gates: `docs/projects/pipeline-realism/resources/spec/sections/validation-and-observability.md`
 
 Any artifact schema change MUST update all three where relevant.
-

--- a/docs/projects/pipeline-realism/triage.md
+++ b/docs/projects/pipeline-realism/triage.md
@@ -4,9 +4,8 @@ Unsequenced follow-ups and “we should do this later” work discovered while r
 
 ## Triage
 
-- (empty)
+- Decision (M1-001): Use `artifact:foundation.plateMotion` as the canonical ID; `plateKinematics` remains a schema concept. New M1 artifacts carry `version: 1` while legacy artifacts stay unversioned until their owning issues update producers.
 
 ## Backlog
 
 - (empty)
-

--- a/mods/mod-swooper-maps/test/foundation/contract-guard.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/contract-guard.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it } from "bun:test";
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
+import {
+  FOUNDATION_MANTLE_FORCING_ARTIFACT_TAG,
+  FOUNDATION_MANTLE_POTENTIAL_ARTIFACT_TAG,
+  FOUNDATION_PLATE_MOTION_ARTIFACT_TAG,
+  FOUNDATION_TECTONIC_HISTORY_TILES_ARTIFACT_TAG,
+  FOUNDATION_TECTONIC_PROVENANCE_ARTIFACT_TAG,
+  FOUNDATION_TECTONIC_PROVENANCE_TILES_ARTIFACT_TAG,
+} from "@swooper/mapgen-core";
+import { foundationArtifacts } from "../../src/recipes/standard/stages/foundation/artifacts.js";
 
 function listFilesRecursive(rootDir: string): string[] {
   const out: string[] = [];
@@ -86,5 +95,16 @@ describe("foundation contract guardrails", () => {
       expect(text).not.toContain("polarBandFraction");
       expect(text).not.toContain("polarBoundary");
     }
+  });
+
+  it("publishes maximal foundation artifact ids via contracts", () => {
+    expect(foundationArtifacts.mantlePotential.id).toBe(FOUNDATION_MANTLE_POTENTIAL_ARTIFACT_TAG);
+    expect(foundationArtifacts.mantleForcing.id).toBe(FOUNDATION_MANTLE_FORCING_ARTIFACT_TAG);
+    expect(foundationArtifacts.plateMotion.id).toBe(FOUNDATION_PLATE_MOTION_ARTIFACT_TAG);
+    expect(foundationArtifacts.tectonicProvenance.id).toBe(FOUNDATION_TECTONIC_PROVENANCE_ARTIFACT_TAG);
+    expect(foundationArtifacts.tectonicHistoryTiles.id).toBe(FOUNDATION_TECTONIC_HISTORY_TILES_ARTIFACT_TAG);
+    expect(foundationArtifacts.tectonicProvenanceTiles.id).toBe(
+      FOUNDATION_TECTONIC_PROVENANCE_TILES_ARTIFACT_TAG
+    );
   });
 });

--- a/packages/mapgen-core/src/authoring/typed-array-schemas.ts
+++ b/packages/mapgen-core/src/authoring/typed-array-schemas.ts
@@ -40,6 +40,8 @@ export const TypedArraySchemas = Object.freeze({
     unsafe<Int8Array>("Int8Array", options),
   u16: (options?: TypedArraySchemaOptions): TUnsafe<Uint16Array> =>
     unsafe<Uint16Array>("Uint16Array", options),
+  u32: (options?: TypedArraySchemaOptions): TUnsafe<Uint32Array> =>
+    unsafe<Uint32Array>("Uint32Array", options),
   i16: (options?: TypedArraySchemaOptions): TUnsafe<Int16Array> =>
     unsafe<Int16Array>("Int16Array", options),
   i32: (options?: TypedArraySchemaOptions): TUnsafe<Int32Array> =>

--- a/packages/mapgen-core/src/core/types.ts
+++ b/packages/mapgen-core/src/core/types.ts
@@ -157,11 +157,18 @@ export interface FoundationPlateFields {
 
 export const FOUNDATION_PLATES_ARTIFACT_TAG = "artifact:foundation.plates";
 export const FOUNDATION_MESH_ARTIFACT_TAG = "artifact:foundation.mesh";
+export const FOUNDATION_MANTLE_POTENTIAL_ARTIFACT_TAG = "artifact:foundation.mantlePotential";
+export const FOUNDATION_MANTLE_FORCING_ARTIFACT_TAG = "artifact:foundation.mantleForcing";
 export const FOUNDATION_CRUST_ARTIFACT_TAG = "artifact:foundation.crust";
+export const FOUNDATION_PLATE_MOTION_ARTIFACT_TAG = "artifact:foundation.plateMotion";
 export const FOUNDATION_PLATE_GRAPH_ARTIFACT_TAG = "artifact:foundation.plateGraph";
 export const FOUNDATION_TECTONICS_ARTIFACT_TAG = "artifact:foundation.tectonics";
+export const FOUNDATION_TECTONIC_PROVENANCE_ARTIFACT_TAG = "artifact:foundation.tectonicProvenance";
 export const FOUNDATION_TILE_TO_CELL_INDEX_ARTIFACT_TAG = "artifact:foundation.tileToCellIndex";
 export const FOUNDATION_CRUST_TILES_ARTIFACT_TAG = "artifact:foundation.crustTiles";
+export const FOUNDATION_TECTONIC_HISTORY_TILES_ARTIFACT_TAG = "artifact:foundation.tectonicHistoryTiles";
+export const FOUNDATION_TECTONIC_PROVENANCE_TILES_ARTIFACT_TAG =
+  "artifact:foundation.tectonicProvenanceTiles";
 
 /**
  * Store of published artifacts keyed by dependency tag id.


### PR DESCRIPTION
docs(pipeline-realism): harden M1 milestone

docs(pipeline-realism): expand M1 into local issue docs

docs(pipeline-realism): complete prework sweep for M1 issues

docs(pipeline-realism): M1 implementation readiness report

docs(pipeline-realism): update M1 plan checklist

docs(pipeline-realism): mark M1 planning stack submitted

docs(pipeline-realism): sanitize M1 issue docs

docs(pipeline-realism): rebuild M1 milestone index

docs(pipeline-realism): deepen PR-M1-001..002

docs(pipeline-realism): deepen PR-M1-003..005

docs(pipeline-realism): deepen PR-M1-006..008

docs(pipeline-realism): deepen PR-M1-009..011

docs(pipeline-realism): deepen PR-M1-012..013

docs(pipeline-realism): deepen PR-M1-014..016

docs(pipeline-realism): deepen PR-M1-017..020

docs(pipeline-realism): deepen PR-M1-021..022

docs(pipeline-realism): deepen PR-M1-023..025

docs(pipeline-realism): update readiness report + plan

docs(pipeline-realism): add sync implementation anchors PR-M1-001..013

feat(pipeline-realism): PR-M1-001 publish foundation artifact contracts

test(pipeline-realism): PR-M1-001 guard new foundation artifacts

docs(pipeline-realism): PR-M1-001 align artifact docs