### PR TITLE
docs(pipeline-realism): add no-legacy Foundation-Morphology refactor plan

### DIFF
--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -1,5 +1,19 @@
 # PLAN — No-legacy Foundation ↔ Morphology refactor (2026-02-05)
 
+## Canonical Status
+
+This file is the sole canonical runbook going forward.
+
+The extracted "Execution Runbook — Remediation Spike v2" from session `019c2c49-864f-7cd2-904f-14c5cc310a9f` is historical execution context that has already been carried out.
+
+## Completed Prerequisites (as of 2026-02-06)
+
+- [x] Stack repair/restack completed during remediation spike execution (`2b940a030`, `a081c3ce4`, `b869cb526` context stack).
+- [x] Diagnostics toolkit promoted into repo tooling (`2b940a030`).
+- [x] Dump-first diagnosis docs added and cross-linked (`2b940a030`).
+- [x] Consolidated realism diagnosis spike doc added (`a081c3ce4`).
+- [x] Planning artifacts generated, including this canonical plan (`b869cb526`).
+
 ## Summary
 
 This plan converts the current “looks wired but behaves unchanged” posture into a **single causal spine**:
@@ -10,13 +24,33 @@ This plan converts the current “looks wired but behaves unchanged” posture i
 
 This plan is intentionally **no-legacy**: any legacy-independent “truth” (ocean basin separation, noise-first landmask) is deleted or redefined as a derived view of Foundation truth.
 
+## Forward Runbook (Start Here)
+
+Only future-facing implementation work remains:
+
+### Phase A — Foundation truth normalization + degeneracy elimination
+- Make crust truth continuous and non-degenerate for canonical probes.
+- Ensure provenance resets are materially present and calibrated to observed forcing ranges.
+
+### Phase B — Morphology landmask re-grounding on Foundation truth
+- Replace threshold/noise-dominant landmask behavior with crust-truth-driven continent potential.
+- Ensure coherence gates (components and largestLandFrac) become pass conditions.
+
+### Phase C — Belt-driver modulation cleanup
+- Keep belts as modifiers for mountains/coasts/islands, not the primary landmass generator.
+- Remove or constrain any hidden re-thresholding that shreds land connectivity.
+
+### Phase D — Observability hardening as enforcement
+- Use existing diagnostics tooling as regression gates (not bootstrap/setup work).
+- Promote required acceptance checks into routine verification for each refactor slice.
+
 ## Why this plan exists (current ground truth)
 
 Deterministic probe (`106×66 seed=1337`) demonstrates:
 - `morphology-coasts.landmass-plates` landmask components: **434** (high speckle)
 - `foundation.crustTiles.type` stats: `min=max=1` (continent signal saturated / degenerate)
 
-Repro:
+Diagnostics bootstrap is already complete; use these existing commands for verification/regression checks:
 - `bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label probe-baseline`
 - `bun run --cwd mods/mod-swooper-maps diag:analyze -- <runDir>`
 - `bun run --cwd mods/mod-swooper-maps diag:list -- <runDir> --dataTypeKey foundation.crustTiles.type`
@@ -262,3 +296,8 @@ These are mandatory for verifying the refactor:
   - landmass-plates components drop materially
   - largestLandFrac rises materially
 - meaningful knob/physics changes produce non-trivial A/B hamming where expected (dead levers eliminated)
+
+## Non-Goals for this runbook
+
+- Do not repeat stack-unscrew/restack work unless a new divergence event is observed.
+- Do not re-run diagnostics bootstrap/setup phases already captured by completed commits.

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -1,0 +1,264 @@
+# PLAN — No-legacy Foundation ↔ Morphology refactor (2026-02-05)
+
+## Summary
+
+This plan converts the current “looks wired but behaves unchanged” posture into a **single causal spine**:
+
+- **Foundation** produces a non-degenerate continent/basin truth signal and era/provenance fields that materially affect downstream outcomes.
+- **Morphology** consumes Foundation truth as the primary driver for continents and landmask coherence; tectonic belts/drivers modulate and refine, and noise is strictly secondary flavor.
+- **Observability** becomes a correctness harness: dumps + metrics gate degeneracy and dead-lever regressions.
+
+This plan is intentionally **no-legacy**: any legacy-independent “truth” (ocean basin separation, noise-first landmask) is deleted or redefined as a derived view of Foundation truth.
+
+## Why this plan exists (current ground truth)
+
+Deterministic probe (`106×66 seed=1337`) demonstrates:
+- `morphology-coasts.landmass-plates` landmask components: **434** (high speckle)
+- `foundation.crustTiles.type` stats: `min=max=1` (continent signal saturated / degenerate)
+
+Repro:
+- `bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label probe-baseline`
+- `bun run --cwd mods/mod-swooper-maps diag:analyze -- <runDir>`
+- `bun run --cwd mods/mod-swooper-maps diag:list -- <runDir> --dataTypeKey foundation.crustTiles.type`
+
+## Non-negotiables (physics-first, maximal realism)
+
+- Foundation is the only source of tectonic “truth”.
+- Morphology must be grounded in Foundation (no parallel legacy truth).
+- Noise is allowed only as *secondary* diversity; it must not create continents.
+- Every authored input must be either:
+  - physics input (initial conditions / constitutive parameters / simulation horizon), or
+  - a semantic “knob” scaling physics inputs (never output sculpting).
+- Every Foundation output is either:
+  - consumed correctly downstream, or
+  - deleted, or
+  - explicitly deferred with trigger + rationale.
+
+## Contract vNext (decision-complete)
+
+### Foundation “crust truth” contract
+
+Foundation must expose **continuous** crust truth fields, and all categorical labels must be derived:
+
+- Canonical continuous truth (examples; exact names may map to existing arrays):
+  - `maturity01` (0..1)
+  - `thickness01` (0..1)
+  - `thermalAge01` (0..1) or age proxy
+  - `damage01` (0..1)
+  - `buoyancy01` (0..1)
+  - `strength01` (0..1)
+
+- Derived labels (views, not truth):
+  - `isContinental` derived from `maturity01` + `buoyancy01` + `strength01`
+  - `cratonCoreMask` derived from high maturity + low disruption + long provenance age
+
+**Invariant:** derived labels must be non-degenerate for earthlike presets (no `min=max` for tile projections).
+
+### Foundation provenance contract
+
+Provenance is a first-class physics constraint, not just metadata:
+- `originEra`, `originPlateId`, `lastBoundaryEra`, `lastBoundaryType`, `driftDistance`
+- Resets must trigger at realistic rates (rift/subduction/collision thresholds calibrated to observed driver ranges).
+
+**Invariant:** provenance resets must occur in every canonical probe run (non-zero count; non-trivial spatial structure).
+
+### Morphology consumption contract
+
+Morphology must treat:
+- crust truth + provenance as the **primary** landmass/continent/basin structure
+- belt/tectonic drivers as modifiers (mountains, rugged coasts, island chains)
+
+Morphology may not:
+- use pure elevation thresholding on noise-dominated fields as the primary land/water classifier
+- invent independent “basin separation truth” not grounded in Foundation
+
+## What must be removed (explicit, no hand-waving)
+
+### Legacy / noise-first landmask posture
+
+Remove or redefine (as derived post-process) any logic where:
+- the landmask is primarily a local threshold on a noisy elevation field, and/or
+- continent-scale structure is not anchored to crust truth.
+
+Primary targets (anchors for the refactor):
+- `mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/strategies/default.ts`
+- `mods/mod-swooper-maps/src/domain/morphology/ops/compute-base-topography/strategies/default.ts` (noise terms must be demoted to secondary flavor)
+
+### Hidden reclassification of land/water during erosion
+
+Constrain or remove geomorphology behavior that shreds connectivity by re-thresholding land/water as a side effect.
+
+Anchor:
+- `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/steps/geomorphology.ts`
+
+### Dead-lever class (normalization traps)
+
+Remove or redesign parameter surfaces where amplitude knobs are canceled out by normalization.
+
+Anchor example:
+- `mods/mod-swooper-maps/src/domain/foundation/ops/compute-mantle-potential/index.ts` (`normalizeSigned`)
+
+## What must be replaced (explicit replacements)
+
+### Replace discrete `crust.type` as truth
+
+Current issue: `foundation.crustTiles.type` is saturated (uniform).
+
+Replacement:
+- Treat discrete `type` as a **derived view** over continuous fields.
+- Recalibrate crust evolution so that:
+  - maturity is not dominated globally by “materialAge” without disruptive suppression,
+  - disruption signals meaningfully suppress maturity and increase damage,
+  - provenance resets (rift/subduction/collision) occur at observed driver magnitudes.
+
+Primary anchor:
+- `mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts` (maturity formula + threshold)
+
+### Replace landmask algorithm with a continent-scale classifier grounded in crust truth
+
+Replacement algorithm posture (decision-complete, implementation-independent):
+1) Define a **continent potential field** as a low-frequency function of crust truth:
+   - dominated by `buoyancy01`, `maturity01`, `thickness01`, and provenance stability
+   - explicitly *not* dominated by local noise
+2) Choose sea level against that potential (physics-first targets are allowed only as derived from crust truth).
+3) Produce landmask from the low-frequency potential first; then apply high-frequency flavor (noise) only to coast shaping.
+4) Ensure belts and uplift drivers modulate topography after land is coherently established (no “belts on noise continents”).
+
+## What must be rethought from first principles
+
+### “Continent emergence” mechanism
+
+The current behavior implies a mismatch between intended emergent continents and the implemented maturity/provenance dynamics.
+
+First-principles posture:
+- continents emerge from long-lived, stable, thickened crust (craton cores) + buoyancy
+- disruption (rift, shear, subduction recycling) prevents uniform maturation
+
+This requires:
+- a provenance reset model calibrated to actual driver signals
+- a maturity evolution model that yields multi-modal distributions (oceanic vs continental vs craton cores), not saturation
+
+## Phased refactor proposal (no dual pipelines)
+
+This is the intended sequencing for the *next* implementation stack. Each phase deletes legacy paths as it lands; no “run both”.
+
+### Phase 1 — Foundation truth normalization + degeneracy gates
+- Make `crust.type` derived (or delete it as a primary state); ensure tile projections are non-degenerate.
+- Add invariants:
+  - `foundation.crustTiles.type` not uniform
+  - maturity/age distributions non-trivial
+  - provenance reset frequency non-zero
+
+### Phase 2 — Morphology landmask grounded in crust truth
+- Replace the primary landmask classifier with the continent potential posture above.
+- Ensure geomorphology cannot silently destroy connectivity unless explicitly intended.
+- Gate: connected-components and largestLandFrac must improve for earthlike baselines.
+
+### Phase 3 — Belt drivers as modifiers (unified spine)
+- Ensure beltDrivers modulate mountain building and ruggedness without becoming the primary land/water generator.
+- Confirm consumers (coasts/features/mountains) all consume the same beltDrivers artifact.
+
+### Phase 4 — Observability hardening
+- Make dump-first metrics a required harness for regression prevention:
+  - store canonical probe run commands in docs
+  - add CI-adjacent checks later (post-spike) for degeneracy gates
+
+## Matrix — Foundation outputs → consumers → disposition
+
+Legend:
+- **Class**: `truth` | `derived` | `projection` | `legacy`
+- **Disposition**: `keep` | `delete` | `defer`
+
+| Output (artifact) | Class | Primary consumers | Disposition | Notes |
+|---|---|---|---|---|
+| `foundationArtifacts.mesh` | truth | Foundation ops/steps | keep | canonical mesh space |
+| `foundationArtifacts.mantlePotential` | truth | mantleForcing | keep | watch for normalization traps |
+| `foundationArtifacts.mantleForcing` | truth | crust, plateMotion, tectonics | keep | must be causal |
+| `foundationArtifacts.crustInit` | truth | plateGraph, tectonics, crustEvolution | keep | t=0 basaltic lid |
+| `foundationArtifacts.crust` | truth | projection (crustTiles), downstream via projection | keep | continuous truth is canonical |
+| `foundationArtifacts.plateGraph` | derived | plateMotion, tectonics, projection | keep | segmentation should be conditioned by crust truth |
+| `foundationArtifacts.plateMotion` | derived | tectonics, projection | keep | ensure morphology consumes only derived projections, not raw tensors |
+| `foundationArtifacts.tectonicSegments` | derived | tectonics | keep | intermediate for event mechanics |
+| `foundationArtifacts.tectonicHistory` | truth/derived | crustEvolution, projection | keep | must materially affect crust truth |
+| `foundationArtifacts.tectonicProvenance` | truth/derived | crustEvolution, projection | keep | resets must be non-trivial |
+| `foundationArtifacts.tectonics` | derived | crustEvolution, projection | keep | mesh-space drivers |
+| `foundationArtifacts.plates` | projection | projection, morphology-features (islands/volcanoes), foundation plateTopology | keep | ensure semantics align with beltDrivers posture |
+| `foundationArtifacts.tileToCellIndex` | projection | projection | keep | keep as a canonical projection/debug seam (tile↔cell mapping) |
+| `foundationArtifacts.crustTiles` | projection | morphology-coasts landmass | keep | must be non-degenerate; `type` becomes derived view |
+| `foundationArtifacts.tectonicHistoryTiles` | projection | morphology-coasts landmass | keep | era-indexed drivers |
+| `foundationArtifacts.tectonicProvenanceTiles` | projection | morphology-coasts landmass | keep | provenance stability inputs |
+| `foundationArtifacts.plateTopology` | derived | (currently foundation-only) | defer | defer unless a downstream consumer requires explicit topology; trigger: morphology or other domains need stable plate adjacency not already encoded in `plates.*` projections |
+
+## Consumer map (current, code-anchored)
+
+This is the current (as of this plan) “who reads what” map in `mods/mod-swooper-maps`:
+
+- `foundationArtifacts.mesh`
+  - required by: `foundation/steps/{mantlePotential,mantleForcing,crust,plateGraph,plateMotion,tectonics,crustEvolution,projection}.*`
+  - provided by: `foundation/steps/mesh.*`
+- `foundationArtifacts.mantlePotential`
+  - provided by: `foundation/steps/mantlePotential.*`
+  - consumed by: `foundation/steps/mantleForcing.*`
+- `foundationArtifacts.mantleForcing`
+  - provided by: `foundation/steps/mantleForcing.*`
+  - consumed by: `foundation/steps/{crust,plateMotion,tectonics}.*`
+- `foundationArtifacts.crustInit`
+  - provided by: `foundation/steps/crust.*`
+  - consumed by: `foundation/steps/{plateGraph,tectonics,crustEvolution}.*`
+- `foundationArtifacts.crust`
+  - provided by: `foundation/steps/crustEvolution.*`
+  - consumed by: `foundation/steps/projection.*` (via `compute-plates-tensors`)
+- `foundationArtifacts.plateGraph`
+  - provided by: `foundation/steps/plateGraph.*`
+  - consumed by: `foundation/steps/{plateMotion,tectonics,projection}.*`
+- `foundationArtifacts.plateMotion`
+  - provided by: `foundation/steps/plateMotion.*`
+  - consumed by: `foundation/steps/{tectonics,projection}.*`
+- `foundationArtifacts.tectonicSegments`
+  - provided/consumed within: `foundation/steps/tectonics.*` (intermediate artifact required by the step)
+- `foundationArtifacts.tectonicHistory`
+  - produced by: `foundation/steps/tectonics.*`
+  - consumed by: `foundation/steps/{crustEvolution,projection}.*`
+- `foundationArtifacts.tectonicProvenance`
+  - produced by: `foundation/steps/tectonics.*`
+  - consumed by: `foundation/steps/{crustEvolution,projection}.*`
+- `foundationArtifacts.tectonics`
+  - produced by: `foundation/steps/tectonics.*`
+  - consumed by: `foundation/steps/{crustEvolution,projection}.*`
+- `foundationArtifacts.plates`
+  - produced by: `foundation/steps/projection.*` (tile-space driver tensors)
+  - consumed by:
+    - `foundation/steps/plateTopology.*`
+    - `morphology-features/steps/{islands,volcanoes}.*`
+- `foundationArtifacts.crustTiles`, `foundationArtifacts.tectonicHistoryTiles`, `foundationArtifacts.tectonicProvenanceTiles`
+  - produced by: `foundation/steps/projection.*`
+  - consumed by: `morphology-coasts/steps/landmassPlates.*`
+- `foundationArtifacts.tileToCellIndex`
+  - produced by: `foundation/steps/projection.*`
+  - currently only used as a projection/debug seam (no downstream consumers found)
+- `foundationArtifacts.plateTopology`
+  - produced by: `foundation/steps/plateTopology.*`
+  - currently no downstream consumers found
+
+## Matrix — Morphology inputs → source classification → action
+
+| Step / op seam | Inputs | Source | Classification | Required action |
+|---|---|---|---|---|
+| `morphology-coasts.landmass-plates` | `crustTiles`, `tectonicHistoryTiles`, `tectonicProvenanceTiles`, `beltDrivers` | Foundation projections + Morphology artifact | physics-backed (+ derived) | Make continent potential/crust truth the **primary** driver for land/water; treat beltDrivers as modifiers; ensure outputs are coherence-gated. |
+| `morphology-coasts.rugged-coasts` | `beltDrivers`, `topography` | Morphology artifact + Morphology truth | derived | Keep; ensure ruggedness follows beltDrivers and cannot dominate land/water classification. |
+| `map-morphology.plot-mountains` | `beltDrivers`, `topography` | Morphology artifact + Morphology truth | derived | Keep; mountains are a modifier layered on coherent continents (no “belts on noise land”). |
+| `morphology-features.islands` | `foundation.plates`, `topography` | Foundation projection + Morphology truth | physics-backed (+ derived) | Keep; ensure island generation is constrained by tectonic drivers and coast context (not random-only). |
+| `morphology-features.volcanoes` | `foundation.plates`, `topography` | Foundation projection + Morphology truth | physics-backed (+ derived) | Keep; ensure volcanism follows rift/subduction driver fields. |
+| `compute-base-topography` | `crustTiles.{baseElevation,buoyancy,strength,type}` (+ modifiers) | Foundation projection | physics-backed | Demote noise to secondary; base topography must reflect continent potential as low-frequency structure. |
+| `compute-landmask` | elevation + sea level | Morphology derived | derived | Replace threshold-first posture: landmask must be grounded in crust truth potential; avoid noise-dominated thresholding. |
+| `geomorphology` (erosion) | topography | Morphology derived | derived | Constrain reclassification: erosion should sculpt; land/water should not silently fragment as a side effect. |
+
+## Required dump-first acceptance checks (for the next implementation)
+
+These are mandatory for verifying the refactor:
+
+- `foundation.crustTiles.type` not uniform (`min != max`)
+- landmask coherence improves vs current baseline:
+  - landmass-plates components drop materially
+  - largestLandFrac rises materially
+- meaningful knob/physics changes produce non-trivial A/B hamming where expected (dead levers eliminated)

--- a/docs/projects/pipeline-realism/resources/research/SPIKE-m1-realism-miss-dump-driven-diagnosis-2026-02-05.md
+++ b/docs/projects/pipeline-realism/resources/research/SPIKE-m1-realism-miss-dump-driven-diagnosis-2026-02-05.md
@@ -1,0 +1,188 @@
+# SPIKE — M1 realism miss (dump-driven diagnosis) — 2026-02-05
+
+## Objective + scope
+
+M1 (“Pipeline Realism”) landed substantial Foundation + observability work, but the **primary user-facing goal** remains missed:
+
+- Morphology produces **speckled / fragmented** landmasses (weak continent-scale coherence).
+- Many Foundation-level changes feel **non-causal** downstream (either dead levers, normalized away, or not consumed).
+
+This spike is a **data-first, deterministic** diagnosis that treats VizDumper dumps (manifest + trace + binaries) as the canonical truth and produces:
+
+- a reproduction protocol,
+- metric snapshots (no screenshots required),
+- grouped root causes with concrete code anchors,
+- an exhaustive issue ledger used as the input to the next “no-legacy” refactor plan.
+
+No remediation code is performed here.
+
+## Reproduction protocol (dump-first)
+
+### Tooling
+- Dump runner: `bun run --cwd mods/mod-swooper-maps diag:dump -- ...`
+- Metrics: `bun run --cwd mods/mod-swooper-maps diag:analyze -- <runDirA> [runDirB]`
+- Layer stats/diffs: `diag:list`, `diag:diff`, `diag:trace`
+
+See `docs/system/libs/mapgen/how-to/diagnose-with-viz-dumps.md`.
+
+### Deterministic probe (canonical)
+
+Use fixed dims + seed:
+- width `106`, height `66`, seed `1337`
+
+Commands:
+
+```bash
+# baseline
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label probe-baseline
+
+# variant (example: plateCount)
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label probe-platecount6 --override '{"foundation":{"knobs":{"plateCount":6}}}'
+
+# A/B metrics
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <runDirA> <runDirB>
+```
+
+## Observed symptoms (metrics, deterministic)
+
+### Symptom A — landmass speckle exists early (landmass-plates)
+
+Baseline (`106×66 seed=1337`) shows extreme fragmentation at the landmask stage:
+- `morphology-coasts.landmass-plates` landmask:
+  - `landComponents`: **434**
+  - `largestLandFrac`: **0.2565**
+- After `geomorphology` (erosion + re-thresholding), land is reduced and still fragmented:
+  - `landTiles`: **1627** (down from 2530)
+  - `landComponents`: **183**
+
+These values come directly from `diag:analyze` connected-components over the dumped `morphology.topography.landMask` grid (Odd-Q hex adjacency).
+
+### Symptom B — some knobs move landmask (non-zero hamming), but do not improve coherence
+
+Example A/B (baseline vs `foundation.knobs.plateCount=6`):
+- landmask hamming:
+  - landmass-plates: **~19.3%**
+  - geomorphology: **~26.6%**
+- coherence does not materially improve:
+  - components drop somewhat (434 → 361) but remain extremely high
+  - largestLandFrac stays low (0.2565 → 0.2503)
+
+Interpretation: even when the pipeline is sensitive, it remains structurally capable of producing speckle.
+
+## Root causes (grouped, with evidence anchors)
+
+### Root cause 1 — “continent emergence” signal is degenerate: `crustTiles.type` saturates
+
+In the baseline dump, `foundation.crustTiles.type` is **uniform**:
+- `manifest.json` stats: `min == max == 1`
+
+Repro (for any dump run dir):
+
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <runDir> --dataTypeKey foundation.crustTiles.type
+```
+
+Evidence anchors:
+- Projection emits `foundation.crustTiles.type` from `platesResult.crustTiles.type`:
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts`
+- `crustTiles.type` is a direct projection of the Foundation crust model’s `crust.type[cellId]`:
+  - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/lib/project-plates.ts` (`crustType[i] = crust.type[cellId] ?? 0;`)
+
+Consequence:
+- Any downstream logic that depends on “continental vs oceanic” classification (including sea-level “continental fraction” posture) becomes ineffective or misleading if the classifier saturates.
+
+### Root cause 2 — landmask coherence is poor by construction without strong low-frequency structure
+
+Morphology currently forms land primarily by **thresholding elevation**:
+- base topography contains high-frequency components (noise + arc noise + boundary biases)
+- landmask is formed by `elevation > seaLevel`
+- geomorphology can re-threshold after erosion, shredding narrow connectors
+
+Evidence anchors:
+- Base topography composition (noise + arc-noise terms):
+  - `mods/mod-swooper-maps/src/domain/morphology/ops/compute-base-topography/strategies/default.ts`
+- Landmask threshold:
+  - `mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/strategies/default.ts`
+- Geomorphology re-thresholding / land reclassification:
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/steps/geomorphology.ts`
+
+Consequence:
+- Without a strong continent/basin signal (low-frequency “continent-scale” structure), the threshold boundary cuts through noise, yielding many disconnected land components.
+
+### Root cause 3 — some Foundation levers are dead / normalized away / not consumed
+
+Patterns observed in the broader diagnosis (to be validated per-lever via A/B dump diffs):
+- Upstream changes can propagate into fields that Morphology does not consume (apparent “no downstream change”).
+- Normalization can cancel out intended amplitude knobs (a “dead lever” trap).
+
+Evidence anchors (example class of issue):
+- Signed normalization eliminating global amplitude scaling:
+  - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-mantle-potential/index.ts` (`normalizeSigned` usage)
+- Projection scaling knobs not feeding Morphology contracts:
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts`
+
+Operational check (for any suspected knob):
+- Run A/B dumps changing a single knob
+- `diag:diff --prefix foundation.` and `diag:diff --dataTypeKey morphology.topography.{elevation,landMask}`
+- If foundation layers change but landmask doesn’t, the contract/wiring is the likely break.
+
+## Full issue ledger (exhaustive list for the next plan)
+
+This section is the actionable “no skipped steps” ledger. Each item must be:
+- independently reproducible with the diagnostics toolkit,
+- traceable to a concrete code location,
+- tied to an explicit “physics-first” violation mode (legacy, noise-primary, dead lever, normalization trap, shadowed output).
+
+### Problem: `foundation.crustTiles.type` saturates (min=max)
+- Evidence:
+  - dump stats show `min=max=1` for `foundation.crustTiles.type`
+  - projection uses `crust.type` directly (`project-plates.ts`)
+- Repro:
+  - `diag:list --dataTypeKey foundation.crustTiles.type`
+- Why it violates physics-first:
+  - the continent/basin classifier is supposed to carry tectonic “continent emergence” truth; saturation removes that signal.
+
+### Problem: landmask speckle (high component count) exists already at landmass-plates
+- Evidence:
+  - baseline `landComponents=434` at `morphology-coasts.landmass-plates`
+- Repro:
+  - `diag:analyze -- <runDir>`
+- Why it violates physics-first:
+  - coherent continents should arise from low-frequency crust + tectonic drivers, not “peaks-only” noise thresholding.
+
+### Problem: geomorphology re-thresholding can shred connectivity
+- Evidence:
+  - landTiles drop significantly (2530 → 1627) and components change post-geomorphology
+- Repro:
+  - `diag:analyze -- <runDir>` (compare landmask layers by stepId)
+- Why it violates physics-first:
+  - erosion should sculpt terrain; it should not primarily reclassify land/water unless explicitly intended by the physics model.
+
+### Problem: dead-lever class (normalization / non-consumption / shadowed outputs)
+- Evidence:
+  - per-lever A/B diff shows changes upstream but 0% landmask hamming (or unchanged elevation)
+- Repro:
+  - `diag:dump` A/B + `diag:diff` + `diag:analyze`
+- Why it violates physics-first:
+  - authoring surface becomes misleading; tuning degenerates into “cargo cult knobs”.
+
+## Open questions (must be answered by the next planning spike)
+
+1) What is the intended semantic of `crust.type` (oceanic/continental) once crust evolution exists?
+   - Should it be a derived label from continuous state (maturity/thickness/buoyancy), or a primary state variable?
+2) Which Morphology steps are allowed to reclassify land/water, and under what invariants?
+3) Which Foundation outputs are:
+   - canonical physics truth,
+   - derived projections,
+   - legacy or redundant,
+   - currently unused or shadowed?
+
+## Constraints for the next plan (non-negotiable)
+
+- Physics-first: Foundation is truth; Morphology is grounded in Foundation.
+- Noise is secondary flavor only (never primary continent/basin structure).
+- No legacy dual-path pipelines: explicit delete/replace list; no “keep both”.
+- Every Foundation output is either:
+  - consumed correctly downstream, or
+  - deleted, or
+  - explicitly deferred with trigger + rationale.

--- a/docs/projects/pipeline-realism/scratch/diag-toolkit-and-spike/agent-config.md
+++ b/docs/projects/pipeline-realism/scratch/diag-toolkit-and-spike/agent-config.md
@@ -1,0 +1,22 @@
+# Scratch — Config / presets / propagation audit
+
+## Principle
+
+Treat “no downstream change” as a dataflow problem until proven otherwise:
+- config may not reach `standardRecipe.compile(...)`,
+- compile may normalize/overwrite,
+- step may ignore config,
+- op may normalize away amplitude,
+- downstream may not consume the changed field.
+
+## Diagnostics harness
+
+Use:
+- `diag:dump --override '{...}'` (deep merge at root config)
+- `diag:diff --prefix foundation.` to confirm upstream fields move
+- `diag:diff --dataTypeKey morphology.topography.{elevation,landMask}` to confirm downstream sensitivity
+
+## Known footgun class (to explicitly test)
+
+- “Knob changes are visible in some Foundation layers but do not move `crust.type` (and therefore do not move continent-scale behavior).”
+

--- a/docs/projects/pipeline-realism/scratch/diag-toolkit-and-spike/agent-coupling.md
+++ b/docs/projects/pipeline-realism/scratch/diag-toolkit-and-spike/agent-coupling.md
@@ -1,0 +1,18 @@
+# Scratch — Pipeline coupling plan
+
+## Single causal spine posture
+
+Foundation must publish:
+- canonical crust truth (continuous fields + derived labels),
+- history/provenance projections (era-indexed + rollups),
+- plate/tectonic drivers (for belts + secondary shaping).
+
+Morphology must consume:
+- crust truth + provenance as the **primary** continent/basin structure,
+- tectonic/belt drivers as modifiers (mountains, rugged coasts, island chains),
+- noise as secondary flavor only.
+
+## No-legacy rule
+
+Any legacy independent “ocean basin separation” or other non-Foundation “truth” must be deleted or redefined as a derived post-process of Foundation truth.
+

--- a/docs/projects/pipeline-realism/scratch/diag-toolkit-and-spike/agent-foundation.md
+++ b/docs/projects/pipeline-realism/scratch/diag-toolkit-and-spike/agent-foundation.md
@@ -1,0 +1,41 @@
+# Scratch — Foundation audit
+
+## Outputs (current artifact surface)
+
+From `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts`:
+- `foundationArtifacts.mesh`
+- `foundationArtifacts.mantlePotential`
+- `foundationArtifacts.mantleForcing`
+- `foundationArtifacts.crustInit`
+- `foundationArtifacts.crust`
+- `foundationArtifacts.plateGraph`
+- `foundationArtifacts.plateMotion`
+- `foundationArtifacts.tectonicSegments`
+- `foundationArtifacts.tectonicHistory`
+- `foundationArtifacts.tectonicProvenance`
+- `foundationArtifacts.plates`
+- `foundationArtifacts.tileToCellIndex`
+- `foundationArtifacts.crustTiles`
+- `foundationArtifacts.tectonicHistoryTiles`
+- `foundationArtifacts.tectonicProvenanceTiles`
+- `foundationArtifacts.plateTopology`
+- `foundationArtifacts.tectonics`
+
+## Key degeneracy (must fix)
+
+`foundation.crustTiles.type` is uniform (`min=max=1`) in the canonical probe.
+
+Anchor:
+- `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/lib/project-plates.ts` projects `crust.type[cellId]` → tile type.
+
+Likely cause (mechanical):
+- `mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts` computes:
+  - `maturity01 = clamp01(upliftToMaturity*uplift + ageToMaturity*materialAge + (1 - disruptionToMaturity*disruption))`
+  - `type = maturity01 >= 0.55 ? 1 : 0`
+If `materialAge01` is high everywhere and disruption is weak, maturity saturates → type=1 everywhere.
+
+## Normalization traps class
+
+Mantle potential amplitude scaling is prone to cancellation via normalization:
+- `mods/mod-swooper-maps/src/domain/foundation/ops/compute-mantle-potential/index.ts` (`normalizeSigned`)
+

--- a/docs/projects/pipeline-realism/scratch/diag-toolkit-and-spike/agent-morphology.md
+++ b/docs/projects/pipeline-realism/scratch/diag-toolkit-and-spike/agent-morphology.md
@@ -1,0 +1,29 @@
+# Scratch — Morphology audit
+
+## Observed failure mode (canonical probe)
+
+At `morphology-coasts.landmass-plates`:
+- land components extremely high (speckle)
+- largestLandFrac low (no coherent continents)
+
+This exists *before* geomorphology; geomorphology can further shred land by re-thresholding.
+
+## Where speckle comes from (mechanical)
+
+- Base topography includes high-frequency variance:
+  - `mods/mod-swooper-maps/src/domain/morphology/ops/compute-base-topography/strategies/default.ts`
+- Landmask is a threshold:
+  - `mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/strategies/default.ts`
+- Geomorphology can reclassify land/water:
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/steps/geomorphology.ts`
+
+## Consumption surface (what Morphology expects from Foundation)
+
+`morphology-coasts.landmass-plates` requires:
+- `foundationArtifacts.crustTiles`
+- `foundationArtifacts.tectonicHistoryTiles`
+- `foundationArtifacts.tectonicProvenanceTiles`
+- `morphologyArtifacts.beltDrivers`
+
+Even with this wiring, coherence requires a **non-degenerate** crust signal and a landmask algorithm that is not dominated by local thresholding of noise.
+

--- a/docs/projects/pipeline-realism/scratch/diag-toolkit-and-spike/agent-viz.md
+++ b/docs/projects/pipeline-realism/scratch/diag-toolkit-and-spike/agent-viz.md
@@ -1,0 +1,20 @@
+# Scratch — Viz / observability alignment
+
+## Must-emit layers (baseline correctness harness)
+
+At minimum for tuning and correctness gating:
+- `foundation.crustTiles.type|age|baseElevation|strength`
+- `foundation.history.*` (per-era + rollups)
+- `foundation.provenance.*`
+- `morphology.topography.elevation|landMask`
+
+## Must-emit trace summaries
+
+- `morphology.landmassPlates.summary`
+- `morphology.geomorphology.summary`
+
+## Gating metrics (from dumps)
+
+- Connected components (landmask) + largest component fraction
+- A/B hamming on landmask and elevation for meaningful upstream deltas
+

--- a/docs/projects/pipeline-realism/scratch/diag-toolkit-and-spike/master-scratch.md
+++ b/docs/projects/pipeline-realism/scratch/diag-toolkit-and-spike/master-scratch.md
@@ -1,0 +1,26 @@
+# Scratch — diag-toolkit-and-spike (master)
+
+This folder holds append-only scratchpads used to produce:
+- `docs/projects/pipeline-realism/resources/research/SPIKE-m1-realism-miss-dump-driven-diagnosis-2026-02-05.md`
+- `docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md`
+
+## Snapshot (current ground truth)
+
+Deterministic probe (`106×66 seed=1337`) shows:
+- `morphology-coasts.landmass-plates` landmask components: **434**; largestLandFrac **~0.256**
+- `foundation.crustTiles.type` stats: `min=max=1` (uniform / saturated)
+
+Repro:
+- `bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label probe-baseline`
+- `bun run --cwd mods/mod-swooper-maps diag:analyze -- <runDir>`
+- `bun run --cwd mods/mod-swooper-maps diag:list -- <runDir> --dataTypeKey foundation.crustTiles.type`
+
+## Invariants the next plan must enforce
+
+- `foundation.crust.type` and `foundation.crustTiles.type` are **non-degenerate** (both 0 and 1 exist for earthlike; no `min=max`).
+- Provenance resets trigger at a non-trivial rate (avoid “age dominates everything forever”).
+- Morphology landmask coherence is measured and gated by:
+  - connected components count,
+  - largest component fraction,
+  - sensitivity/hamming between meaningful A/B config changes.
+

--- a/docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md
+++ b/docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md
@@ -23,6 +23,7 @@ Routes to:
 - Observability reference: [`docs/system/libs/mapgen/reference/OBSERVABILITY.md`](/system/libs/mapgen/reference/OBSERVABILITY.md)
 - Visualization reference: [`docs/system/libs/mapgen/reference/VISUALIZATION.md`](/system/libs/mapgen/reference/VISUALIZATION.md)
 - Canonical viz doc (deck.gl): [`docs/system/libs/mapgen/pipeline-visualization-deckgl.md`](/system/libs/mapgen/pipeline-visualization-deckgl.md)
+- Dump-first diagnosis: [`docs/system/libs/mapgen/how-to/diagnose-with-viz-dumps.md`](/system/libs/mapgen/how-to/diagnose-with-viz-dumps.md)
 
 ## When to use
 

--- a/docs/system/libs/mapgen/how-to/diagnose-with-viz-dumps.md
+++ b/docs/system/libs/mapgen/how-to/diagnose-with-viz-dumps.md
@@ -1,0 +1,109 @@
+<toc>
+  <item id="purpose" title="Purpose"/>
+  <item id="what-is-a-dump" title="What a dump contains"/>
+  <item id="quickstart" title="Quickstart (deterministic probes)"/>
+  <item id="metrics" title="Canonical metrics"/>
+  <item id="ab-diff" title="A/B diff workflow"/>
+  <item id="notes" title="Notes + footguns"/>
+</toc>
+
+# How-to: diagnose pipeline behavior with VizDumper dumps
+
+## Purpose
+
+Use **VizDumper dumps** (manifest + trace + binary layers) as the canonical, deterministic observability surface to answer questions like:
+
+- “Did my config change reach the compiled plan and step configs?”
+- “Did an upstream change move the landmask (or is this lever dead)?”
+- “Is land coherent (continents) or speckled (salt-and-pepper)?”
+
+This workflow is intentionally **data-first**:
+- trust dump outputs first,
+- treat Studio as a viewer for those outputs.
+
+See also:
+- `docs/system/libs/mapgen/how-to/debug-with-trace-and-viz.md`
+
+## What a dump contains
+
+A dump run directory contains:
+- `manifest.json` — the list of emitted layers (`dataTypeKey`, stepId, format, stats, file path)
+- `trace.jsonl` — step trace events (including summary events emitted by steps)
+- `data/*.bin` — raw grid binaries referenced from `manifest.json`
+
+In this repo, dumps are written under `mods/mod-swooper-maps/dist/visualization/...`.
+
+## Quickstart (deterministic probes)
+
+Use a fixed map size and seed so diffs are meaningful:
+- width `106`, height `66`, seed `1337`
+
+From repo root:
+
+```bash
+# baseline
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label probe-baseline
+
+# variant (example: change plateCount)
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label probe-platecount6 --override '{"foundation":{"knobs":{"plateCount":6}}}'
+```
+
+Each run prints:
+
+```json
+{"runId":"...","outputDir":"..."}
+```
+
+## Canonical metrics
+
+These are the first metrics to compute for landmass realism and responsiveness:
+
+- `landComponents` (lower is more coherent land)
+- `largestLandFrac` (higher is more coherent land)
+- `landmaskHammingPct` (A/B sensitivity signal; detects dead knobs / non-propagation)
+
+Compute them from the dump(s):
+
+```bash
+# analyze a single run
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <runDirA>
+
+# analyze + diff between two runs
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <runDirA> <runDirB>
+```
+
+## A/B diff workflow
+
+Use diffs to localize where the causal chain breaks:
+
+1) Confirm the upstream layers changed (Foundation)
+```bash
+bun run --cwd mods/mod-swooper-maps diag:diff -- <runDirA> <runDirB> --prefix foundation.
+```
+
+2) Confirm Morphology fields changed (elevation, landmask)
+```bash
+bun run --cwd mods/mod-swooper-maps diag:diff -- <runDirA> <runDirB> --dataTypeKey morphology.topography.elevation
+bun run --cwd mods/mod-swooper-maps diag:diff -- <runDirA> <runDirB> --dataTypeKey morphology.topography.landMask
+```
+
+3) Extract step summaries from trace (landmask, sea level, etc.)
+```bash
+bun run --cwd mods/mod-swooper-maps diag:trace -- <runDirA> --eventPrefix morphology.
+```
+
+If Foundation layers change but landmask doesn’t, the problem is usually one of:
+- “Foundation output isn’t consumed by Morphology” (contract/wiring gap),
+- “Morphology normalizes/thresholds away the difference” (algorithmic trap),
+- “the knob is dead / normalized away upstream.”
+
+## Notes + footguns
+
+- Dumps include per-layer `field.stats` in `manifest.json`. These are often enough to detect degeneracy (e.g. `min == max`) without parsing the binaries.
+- Use `diag:list` to enumerate layers for a run:
+
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <runDirA> --prefix foundation.
+```
+
+- Keep comparisons deterministic: fixed `{width,height,seed}` and one change at a time.

--- a/mods/mod-swooper-maps/package.json
+++ b/mods/mod-swooper-maps/package.json
@@ -31,6 +31,11 @@
     "test": "bun test",
     "viz:foundation": "node ../../scripts/preflight/ensure-viz-runtime-deps.mjs && bun ./src/dev/viz/foundation-run.ts",
     "viz:standard": "node ../../scripts/preflight/ensure-viz-runtime-deps.mjs && bun ./src/dev/viz/standard-run.ts",
+    "diag:dump": "node ../../scripts/preflight/ensure-viz-runtime-deps.mjs && bun ./src/dev/diagnostics/run-standard-dump.ts",
+    "diag:analyze": "bun ./src/dev/diagnostics/analyze-dump.ts",
+    "diag:list": "bun ./src/dev/diagnostics/list-layers.ts",
+    "diag:diff": "bun ./src/dev/diagnostics/diff-layers.ts",
+    "diag:trace": "bun ./src/dev/diagnostics/extract-trace.ts",
     "deploy": "bun run build && bunx turbo run build --filter=@mateicanavra/civ7-cli && bun run --filter @mateicanavra/civ7-cli dev -- mod manage deploy --input \"$PWD/mod\" --id mod-swooper-maps"
   },
   "dependencies": {

--- a/mods/mod-swooper-maps/src/dev/diagnostics/README.md
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/README.md
@@ -1,0 +1,42 @@
+# Diagnostics toolkit (dump‑first)
+
+This folder contains **data‑first** scripts for diagnosing pipeline behavior using **VizDumper** dumps (manifest + trace + binary layers).
+
+The goal is to make it easy to answer questions like:
+
+- “Does this config change actually propagate into the runtime plan?”
+- “Does this upstream change move the landmask?”
+- “Are we producing coherent continents or salt‑and‑pepper land?”
+
+## Key scripts
+
+- `run-standard-dump.ts` — run the full standard pipeline deterministically and write dumps under `dist/visualization/<label>/<runId>/...`.
+- `analyze-dump.ts` — compute land coherence metrics (components + largest component fraction) for all emitted `morphology.topography.landMask` layers, plus optional A/B diffs.
+- `list-layers.ts` — enumerate layers + paths from a run’s `manifest.json`.
+- `diff-layers.ts` — compute binary diffs for `u8`/`i16` grid layers between two runs.
+- `extract-trace.ts` — extract trace “summary” events from `trace.jsonl`.
+
+## Recommended deterministic probe
+
+Use a fixed map size + seed so diffs are meaningful:
+
+- width `106`, height `66`, seed `1337`
+
+Example:
+
+```bash
+# baseline
+bun run diag:dump -- 106 66 1337 --label probe-baseline
+
+# variant
+bun run diag:dump -- 106 66 1337 --label probe-platecount6 --override '{\"foundation\":{\"knobs\":{\"plateCount\":6}}}'
+
+# analyze / diff
+bun run diag:analyze -- dist/visualization/probe-baseline/<runId> dist/visualization/probe-platecount6/<runId>
+```
+
+## Notes
+
+- These scripts are intended to be **observability tooling**; they should not modify recipe behavior.
+- Dumps are written under `dist/`, which is ignored by git.
+

--- a/mods/mod-swooper-maps/src/dev/diagnostics/analyze-dump.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/analyze-dump.ts
@@ -1,0 +1,110 @@
+import { parseArgs, loadManifest, loadTraceLines, landmaskStats, connectedComponentsLandOddQ, hammingU8, readU8Grid } from "./shared.js";
+
+function lastSummary(trace: any[], kind: string): unknown {
+  const matches = trace
+    .filter((e) => e?.kind === "step.event" && e?.data?.kind === kind)
+    .map((e) => e.data);
+  return matches.at(-1) ?? null;
+}
+
+function landmaskLayers(manifest: ReturnType<typeof loadManifest>) {
+  return manifest.layers
+    .filter((l) => l.kind === "grid" && l.dataTypeKey === "morphology.topography.landMask" && l.field?.format === "u8")
+    .slice()
+    .sort((a, b) => (a.stepIndex ?? 0) - (b.stepIndex ?? 0));
+}
+
+function summarizeLandmasks(runDir: string, manifest: ReturnType<typeof loadManifest>) {
+  return landmaskLayers(manifest).map((layer) => {
+    const grid = readU8Grid(runDir, layer);
+    const basic = landmaskStats(grid.values);
+    const cc = connectedComponentsLandOddQ(grid.values, grid.width, grid.height);
+    return {
+      stepId: layer.stepId,
+      stepIndex: layer.stepIndex,
+      dataTypeKey: layer.dataTypeKey,
+      format: layer.field?.format ?? null,
+      path: layer.field?.data?.path ?? null,
+      ...basic,
+      ...cc,
+    };
+  });
+}
+
+function diffLandmasks(runDirA: string, runDirB: string, manifestA: ReturnType<typeof loadManifest>, manifestB: ReturnType<typeof loadManifest>) {
+  const layersA = landmaskLayers(manifestA);
+  const layersB = landmaskLayers(manifestB);
+  const byStepA = new Map(layersA.map((l) => [l.stepId, l] as const));
+  const byStepB = new Map(layersB.map((l) => [l.stepId, l] as const));
+
+  const diffs: any[] = [];
+  for (const [stepId, layerA] of byStepA.entries()) {
+    const layerB = byStepB.get(stepId);
+    if (!layerB) continue;
+    const gridA = readU8Grid(runDirA, layerA);
+    const gridB = readU8Grid(runDirB, layerB);
+    const diff = hammingU8(gridA.values, gridB.values);
+    diffs.push({
+      stepId,
+      stepIndexA: layerA.stepIndex,
+      stepIndexB: layerB.stepIndex,
+      hamming: diff,
+      hammingPct: gridA.values.length > 0 ? diff / gridA.values.length : 0,
+    });
+  }
+  return diffs;
+}
+
+/**
+ * Dump analyzer (metrics-first).
+ *
+ * Usage:
+ *   bun ./src/dev/diagnostics/analyze-dump.ts -- <runDirA> [runDirB]
+ *
+ * Output:
+ *   JSON summary with land coherence metrics + optional hamming diffs.
+ */
+function main(): void {
+  const { positionals } = parseArgs(process.argv.slice(2));
+  const runDirA = positionals[0];
+  const runDirB = positionals[1];
+  if (!runDirA) throw new Error('Usage: bun ./src/dev/diagnostics/analyze-dump.ts -- <runDirA> [runDirB]');
+
+  const manifestA = loadManifest(runDirA);
+  const traceA = loadTraceLines(runDirA);
+
+  const out: any = {
+    runA: {
+      runId: manifestA.runId,
+      dir: runDirA,
+      landmassSummary: lastSummary(traceA, "morphology.landmassPlates.summary"),
+      geomorphologySummary: lastSummary(traceA, "morphology.geomorphology.summary"),
+      landmasks: summarizeLandmasks(runDirA, manifestA),
+    },
+  };
+
+  if (runDirB) {
+    const manifestB = loadManifest(runDirB);
+    const traceB = loadTraceLines(runDirB);
+    out.runB = {
+      runId: manifestB.runId,
+      dir: runDirB,
+      landmassSummary: lastSummary(traceB, "morphology.landmassPlates.summary"),
+      geomorphologySummary: lastSummary(traceB, "morphology.geomorphology.summary"),
+      landmasks: summarizeLandmasks(runDirB, manifestB),
+    };
+    out.diff = {
+      landmaskLayerDiffs: diffLandmasks(runDirA, runDirB, manifestA, manifestB),
+    };
+  }
+
+  console.log(JSON.stringify(out, null, 2));
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err);
+  process.exitCode = 1;
+}
+

--- a/mods/mod-swooper-maps/src/dev/diagnostics/diff-layers.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/diff-layers.ts
@@ -1,0 +1,133 @@
+import { parseArgs, loadManifest, listLayers, readU8Grid, readI16Grid, hammingU8 } from "./shared.js";
+
+type DiffRow = Readonly<{
+  dataTypeKey: string;
+  stepIdA: string;
+  stepIdB: string;
+  format: string | null;
+  hamming?: number;
+  hammingPct?: number;
+  note?: string;
+}>;
+
+function pickComparablePairs(args: {
+  manifestA: ReturnType<typeof loadManifest>;
+  manifestB: ReturnType<typeof loadManifest>;
+  prefix?: string;
+  dataTypeKey?: string;
+}): Array<[any, any]> {
+  const { manifestA, manifestB } = args;
+  const rowsA = listLayers(manifestA, { prefix: args.prefix, dataTypeKey: args.dataTypeKey });
+  const rowsB = listLayers(manifestB, { prefix: args.prefix, dataTypeKey: args.dataTypeKey });
+
+  // Use latest layer per (dataTypeKey, stepId) is already included; listLayers sorts by stepIndex.
+  const byKeyB = new Map(rowsB.map((r: any) => [`${r.dataTypeKey}::${r.stepId}`, r] as const));
+  const out: Array<[any, any]> = [];
+  for (const rA of rowsA) {
+    const key = `${rA.dataTypeKey}::${rA.stepId}`;
+    const rB = byKeyB.get(key);
+    if (rB) out.push([rA, rB]);
+  }
+  return out;
+}
+
+/**
+ * Diff layer binaries between two runs for u8/i16 grids.
+ *
+ * Usage:
+ *   bun ./src/dev/diagnostics/diff-layers.ts -- <runDirA> <runDirB> [--prefix morphology.topography] [--dataTypeKey morphology.topography.landMask]
+ */
+function main(): void {
+  const { positionals, flags } = parseArgs(process.argv.slice(2));
+  const runDirA = positionals[0];
+  const runDirB = positionals[1];
+  if (!runDirA || !runDirB) {
+    throw new Error("Usage: bun ./src/dev/diagnostics/diff-layers.ts -- <runDirA> <runDirB> [--prefix ...]");
+  }
+
+  const manifestA = loadManifest(runDirA);
+  const manifestB = loadManifest(runDirB);
+  const prefix = typeof flags.prefix === "string" ? flags.prefix : undefined;
+  const dataTypeKey = typeof flags.dataTypeKey === "string" ? flags.dataTypeKey : undefined;
+
+  const pairs = pickComparablePairs({ manifestA, manifestB, prefix, dataTypeKey });
+  const diffs: DiffRow[] = [];
+
+  for (const [a, b] of pairs) {
+    const format = a.format ?? null;
+    if (format === "u8") {
+      const layerA = manifestA.layers.find((l) => l.stepId === a.stepId && l.dataTypeKey === a.dataTypeKey && l.field?.data?.path === a.path);
+      const layerB = manifestB.layers.find((l) => l.stepId === b.stepId && l.dataTypeKey === b.dataTypeKey && l.field?.data?.path === b.path);
+      if (!layerA || !layerB) continue;
+      const gA = readU8Grid(runDirA, layerA);
+      const gB = readU8Grid(runDirB, layerB);
+      const ham = hammingU8(gA.values, gB.values);
+      diffs.push({
+        dataTypeKey: a.dataTypeKey,
+        stepIdA: a.stepId,
+        stepIdB: b.stepId,
+        format,
+        hamming: ham,
+        hammingPct: gA.values.length > 0 ? ham / gA.values.length : 0,
+      });
+      continue;
+    }
+    if (format === "i16") {
+      const layerA = manifestA.layers.find((l) => l.stepId === a.stepId && l.dataTypeKey === a.dataTypeKey && l.field?.data?.path === a.path);
+      const layerB = manifestB.layers.find((l) => l.stepId === b.stepId && l.dataTypeKey === b.dataTypeKey && l.field?.data?.path === b.path);
+      if (!layerA || !layerB) continue;
+      const gA = readI16Grid(runDirA, layerA);
+      const gB = readI16Grid(runDirB, layerB);
+      if (gA.values.length !== gB.values.length) {
+        diffs.push({
+          dataTypeKey: a.dataTypeKey,
+          stepIdA: a.stepId,
+          stepIdB: b.stepId,
+          format,
+          note: "length mismatch",
+        });
+        continue;
+      }
+      let diff = 0;
+      for (let i = 0; i < gA.values.length; i++) if (gA.values[i] !== gB.values[i]) diff++;
+      diffs.push({
+        dataTypeKey: a.dataTypeKey,
+        stepIdA: a.stepId,
+        stepIdB: b.stepId,
+        format,
+        hamming: diff,
+        hammingPct: gA.values.length > 0 ? diff / gA.values.length : 0,
+      });
+      continue;
+    }
+
+    diffs.push({
+      dataTypeKey: a.dataTypeKey,
+      stepIdA: a.stepId,
+      stepIdB: b.stepId,
+      format,
+      note: "format not diffed (supported: u8, i16)",
+    });
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        runA: { runId: manifestA.runId, runDir: runDirA },
+        runB: { runId: manifestB.runId, runDir: runDirB },
+        filter: { prefix: prefix ?? null, dataTypeKey: dataTypeKey ?? null },
+        diffs,
+      },
+      null,
+      2
+    )
+  );
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err);
+  process.exitCode = 1;
+}
+

--- a/mods/mod-swooper-maps/src/dev/diagnostics/extract-trace.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/extract-trace.ts
@@ -1,0 +1,47 @@
+import { parseArgs, loadTraceLines } from "./shared.js";
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+/**
+ * Extract selected trace events from a dump run.
+ *
+ * Usage:
+ *   bun ./src/dev/diagnostics/extract-trace.ts -- <runDir> [--eventKind morphology.landmassPlates.summary]
+ */
+function main(): void {
+  const { positionals, flags } = parseArgs(process.argv.slice(2));
+  const runDir = positionals[0];
+  if (!runDir) throw new Error("Usage: bun ./src/dev/diagnostics/extract-trace.ts -- <runDir> [--eventKind ...]");
+
+  const trace = loadTraceLines(runDir);
+  const kindFlag = asString(flags.eventKind);
+  const prefixFlag = asString(flags.eventPrefix);
+
+  const events = trace
+    .filter((e) => e?.kind === "step.event" && e?.data)
+    .map((e) => ({
+      tsMs: e.tsMs ?? null,
+      stepId: e.stepId ?? null,
+      phase: e.phase ?? null,
+      kind: e.data.kind ?? null,
+      data: e.data,
+    }))
+    .filter((e) => {
+      if (kindFlag && e.kind !== kindFlag) return false;
+      if (prefixFlag && typeof e.kind === "string" && !e.kind.startsWith(prefixFlag)) return false;
+      if (prefixFlag && typeof e.kind !== "string") return false;
+      return true;
+    });
+
+  console.log(JSON.stringify({ runDir, count: events.length, events }, null, 2));
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err);
+  process.exitCode = 1;
+}
+

--- a/mods/mod-swooper-maps/src/dev/diagnostics/list-layers.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/list-layers.ts
@@ -1,0 +1,28 @@
+import { parseArgs, loadManifest, listLayers } from "./shared.js";
+
+/**
+ * List layers in a viz dump manifest.
+ *
+ * Usage:
+ *   bun ./src/dev/diagnostics/list-layers.ts -- <runDir> [--prefix foundation.] [--dataTypeKey morphology.topography.landMask]
+ */
+function main(): void {
+  const { positionals, flags } = parseArgs(process.argv.slice(2));
+  const runDir = positionals[0];
+  if (!runDir) throw new Error("Usage: bun ./src/dev/diagnostics/list-layers.ts -- <runDir> [--prefix ...]");
+
+  const manifest = loadManifest(runDir);
+  const prefix = typeof flags.prefix === "string" ? flags.prefix : undefined;
+  const dataTypeKey = typeof flags.dataTypeKey === "string" ? flags.dataTypeKey : undefined;
+
+  const rows = listLayers(manifest, { prefix, dataTypeKey });
+  console.log(JSON.stringify({ runId: manifest.runId, runDir, layers: rows }, null, 2));
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err);
+  process.exitCode = 1;
+}
+

--- a/mods/mod-swooper-maps/src/dev/diagnostics/run-standard-dump.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/run-standard-dump.ts
@@ -1,0 +1,121 @@
+/// <reference types="@civ7/types" />
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createMockAdapter } from "@civ7/adapter";
+import { createExtendedMapContext } from "@swooper/mapgen-core";
+import { stripSchemaMetadataRoot } from "@swooper/mapgen-core/authoring";
+import { deriveRunId } from "@swooper/mapgen-core/engine";
+import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
+
+import standardRecipe from "../../recipes/standard/recipe.js";
+import { initializeStandardRuntime } from "../../recipes/standard/runtime.js";
+import swooperEarthlikeConfigRaw from "../../maps/configs/swooper-earthlike.config.json";
+import { createTraceDumpSink, createVizDumper } from "../viz/dump.js";
+import { isPlainObject, mergeDeep, parseArgs } from "./shared.js";
+
+function parseIntOr(value: unknown, fallback: number): number {
+  const n = typeof value === "string" ? Number.parseInt(value, 10) : Number.NaN;
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function parseLabel(value: unknown): string {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (raw.length > 0) return raw;
+  const now = new Date();
+  const stamp = now.toISOString().replace(/[:.]/g, "-");
+  return `diag-${stamp}-${process.pid}`;
+}
+
+function loadOverride(flags: Record<string, string | true>): unknown {
+  const overrideRaw = flags.override;
+  const overrideFile = flags.overrideFile;
+  if (overrideRaw && overrideRaw !== true) return JSON.parse(String(overrideRaw)) as unknown;
+  if (overrideFile && overrideFile !== true) {
+    const text = readFileSync(String(overrideFile), "utf8");
+    return JSON.parse(text) as unknown;
+  }
+  return null;
+}
+
+function loadConfig(flags: Record<string, string | true>): unknown {
+  const configFile = flags.configFile;
+  if (configFile && configFile !== true) {
+    const text = readFileSync(String(configFile), "utf8");
+    return JSON.parse(text) as unknown;
+  }
+  return swooperEarthlikeConfigRaw as unknown;
+}
+
+/**
+ * Data-first dump runner for the full standard pipeline.
+ *
+ * Usage:
+ *   bun ./src/dev/diagnostics/run-standard-dump.ts -- 106 66 1337 --label probe --override '{...}'
+ *
+ * Output:
+ *   {"runId":"...","outputDir":"..."}
+ */
+async function main(): Promise<void> {
+  const { positionals, flags } = parseArgs(process.argv.slice(2));
+  const width = parseIntOr(positionals[0], 106);
+  const height = parseIntOr(positionals[1], 66);
+  const seed = parseIntOr(positionals[2], 1337);
+
+  const label = parseLabel(flags.label);
+  const outputRoot = join(process.cwd(), "dist", "visualization", label);
+  const traceSink = createTraceDumpSink({ outputRoot });
+  const viz = createVizDumper({ outputRoot });
+
+  const mapInfo = {
+    GridWidth: width,
+    GridHeight: height,
+    MinLatitude: -60,
+    MaxLatitude: 60,
+    PlayersLandmass1: 4,
+    PlayersLandmass2: 4,
+    StartSectorRows: 4,
+    StartSectorCols: 4,
+  } as const;
+
+  const envBase = {
+    seed,
+    dimensions: { width, height },
+    latitudeBounds: {
+      topLatitude: mapInfo.MaxLatitude,
+      bottomLatitude: mapInfo.MinLatitude,
+    },
+  } as const;
+
+  const baseConfig = stripSchemaMetadataRoot(loadConfig(flags));
+  const override = loadOverride(flags);
+  const merged =
+    override && isPlainObject(baseConfig) && isPlainObject(override) ? mergeDeep(baseConfig, override) : baseConfig;
+
+  const plan = standardRecipe.compile(envBase, merged);
+  const verboseSteps = Object.fromEntries(plan.nodes.map((node: any) => [node.stepId, "verbose"] as const));
+  const env = { ...envBase, trace: { enabled: true, steps: verboseSteps } } as const;
+
+  const adapter = createMockAdapter({
+    width,
+    height,
+    mapInfo,
+    mapSizeId: 1,
+    rng: createLabelRng(seed),
+  });
+
+  const context = createExtendedMapContext({ width, height }, adapter, env);
+  context.viz = viz;
+
+  initializeStandardRuntime(context, { mapInfo, logPrefix: "[diag]", storyEnabled: true });
+  standardRecipe.run(context, env, merged, { traceSink, log: () => {} });
+
+  const runId = deriveRunId(plan);
+  console.log(JSON.stringify({ runId, outputDir: join(outputRoot, runId) }));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});
+

--- a/mods/mod-swooper-maps/src/dev/diagnostics/shared.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/shared.ts
@@ -1,0 +1,227 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
+
+export type VizManifestV1 = Readonly<{
+  version: number;
+  runId: string;
+  planFingerprint: string;
+  steps: ReadonlyArray<Readonly<{ stepId: string; phase: string; stepIndex: number }>>;
+  layers: ReadonlyArray<
+    Readonly<{
+      kind: string;
+      layerKey: string;
+      dataTypeKey: string;
+      variantKey?: string;
+      stepId: string;
+      phase: string;
+      stepIndex: number;
+      spaceId: string;
+      meta?: unknown;
+      dims?: Readonly<{ width: number; height: number }>;
+      field?: Readonly<{
+        format: string;
+        stats?: unknown;
+        data: Readonly<{ kind: "path"; path: string }>;
+      }>;
+    }>
+  >;
+}>;
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+export function mergeDeep(base: unknown, override: unknown): unknown {
+  if (override === undefined) return base;
+  if (!isPlainObject(base) || !isPlainObject(override)) return override;
+  const out: Record<string, unknown> = { ...base };
+  for (const [k, v] of Object.entries(override)) {
+    const prev = out[k];
+    out[k] = mergeDeep(prev, v);
+  }
+  return out;
+}
+
+export function parseArgs(argv: readonly string[]): {
+  positionals: string[];
+  flags: Record<string, string | true>;
+} {
+  const positionals: string[] = [];
+  const flags: Record<string, string | true> = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const raw = argv[i] ?? "";
+    if (!raw.startsWith("--")) {
+      positionals.push(raw);
+      continue;
+    }
+    const key = raw.slice(2);
+    const next = argv[i + 1];
+    if (next != null && !next.startsWith("--")) {
+      flags[key] = next;
+      i++;
+    } else {
+      flags[key] = true;
+    }
+  }
+
+  return { positionals, flags };
+}
+
+export function loadJsonFile(path: string): unknown {
+  const text = readFileSync(path, "utf8");
+  return JSON.parse(text) as unknown;
+}
+
+export function loadManifest(runDir: string): VizManifestV1 {
+  return loadJsonFile(join(runDir, "manifest.json")) as VizManifestV1;
+}
+
+export function loadTraceLines(runDir: string): any[] {
+  const text = readFileSync(join(runDir, "trace.jsonl"), "utf8");
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+export function pickLatestGridLayer(manifest: VizManifestV1, dataTypeKey: string): VizManifestV1["layers"][number] {
+  const matches = manifest.layers.filter((l) => l.kind === "grid" && l.dataTypeKey === dataTypeKey);
+  if (matches.length === 0) throw new Error(`Missing grid layer for dataTypeKey="${dataTypeKey}".`);
+  return matches.slice().sort((a, b) => (b.stepIndex ?? 0) - (a.stepIndex ?? 0))[0]!;
+}
+
+export function listLayers(manifest: VizManifestV1, filter?: { prefix?: string; dataTypeKey?: string }): any[] {
+  const prefix = filter?.prefix;
+  const exact = filter?.dataTypeKey;
+  return manifest.layers
+    .filter((l) => {
+      if (exact && l.dataTypeKey !== exact) return false;
+      if (prefix && !l.dataTypeKey.startsWith(prefix)) return false;
+      return true;
+    })
+    .map((l) => ({
+      dataTypeKey: l.dataTypeKey,
+      stepId: l.stepId,
+      stepIndex: l.stepIndex,
+      kind: l.kind,
+      format: l.field?.format ?? null,
+      stats: l.field?.stats ?? null,
+      path: l.field?.data?.path ?? null,
+      dims: l.dims ?? null,
+    }))
+    .sort((a, b) => (a.stepIndex ?? 0) - (b.stepIndex ?? 0));
+}
+
+export function readBinaryView(runDir: string, relPath: string): Buffer {
+  const abs = join(runDir, relPath);
+  return readFileSync(abs);
+}
+
+export function readU8Grid(runDir: string, layer: VizManifestV1["layers"][number]): {
+  values: Uint8Array;
+  width: number;
+  height: number;
+} {
+  if (!layer.dims) throw new Error(`Layer "${layer.dataTypeKey}" missing dims.`);
+  const relPath = layer.field?.data?.path;
+  if (!relPath) throw new Error(`Layer "${layer.dataTypeKey}" missing field.data.path.`);
+  const buf = readBinaryView(runDir, relPath);
+  return {
+    values: new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength),
+    width: layer.dims.width,
+    height: layer.dims.height,
+  };
+}
+
+export function readI16Grid(runDir: string, layer: VizManifestV1["layers"][number]): {
+  values: Int16Array;
+  width: number;
+  height: number;
+} {
+  if (!layer.dims) throw new Error(`Layer "${layer.dataTypeKey}" missing dims.`);
+  const relPath = layer.field?.data?.path;
+  if (!relPath) throw new Error(`Layer "${layer.dataTypeKey}" missing field.data.path.`);
+  const buf = readBinaryView(runDir, relPath);
+  const arr = new Int16Array(buf.buffer, buf.byteOffset, Math.floor(buf.byteLength / 2));
+  return { values: arr, width: layer.dims.width, height: layer.dims.height };
+}
+
+export function hammingU8(a: Uint8Array, b: Uint8Array): number {
+  if (a.length !== b.length) throw new Error(`Hamming length mismatch: ${a.length} vs ${b.length}`);
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) diff++;
+  return diff;
+}
+
+export function landmaskStats(values: Uint8Array): { land: number; water: number; pctLand: number } {
+  let land = 0;
+  for (let i = 0; i < values.length; i++) if (values[i] === 1) land++;
+  const water = values.length - land;
+  return { land, water, pctLand: values.length > 0 ? land / values.length : 0 };
+}
+
+export function connectedComponentsLandOddQ(values: Uint8Array, width: number, height: number): {
+  landComponents: number;
+  largestLandComponent: number;
+  largestLandFrac: number;
+  totalLand: number;
+} {
+  const size = width * height;
+  if (values.length !== size) throw new Error(`CC size mismatch: values=${values.length} dims=${size}`);
+
+  const visited = new Uint8Array(size);
+  const componentSizes: number[] = [];
+  const queue: number[] = [];
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = y * width + x;
+      if (visited[idx]) continue;
+      if (values[idx] !== 1) {
+        visited[idx] = 1;
+        continue;
+      }
+
+      visited[idx] = 1;
+      queue.length = 0;
+      queue.push(idx);
+
+      let count = 0;
+      while (queue.length) {
+        const cur = queue.pop()!;
+        count++;
+        const cy = (cur / width) | 0;
+        const cx = cur - cy * width;
+        forEachHexNeighborOddQ(cx, cy, width, height, (nx, ny) => {
+          const ni = ny * width + nx;
+          if (visited[ni]) return;
+          visited[ni] = 1;
+          if (values[ni] === 1) queue.push(ni);
+        });
+      }
+      componentSizes.push(count);
+    }
+  }
+
+  componentSizes.sort((a, b) => b - a);
+  const totalLand = componentSizes.reduce((a, b) => a + b, 0);
+  const largest = componentSizes[0] ?? 0;
+  return {
+    landComponents: componentSizes.length,
+    largestLandComponent: largest,
+    largestLandFrac: totalLand > 0 ? largest / totalLand : 0,
+    totalLand,
+  };
+}
+


### PR DESCRIPTION
# Foundation ↔ Morphology Refactor Plan

This PR adds comprehensive documentation and diagnostic tooling for the upcoming "no-legacy" refactor of the Foundation and Morphology pipeline. The work addresses critical realism issues where the current pipeline produces fragmented, speckled landmasses instead of coherent continents.

Key additions:

1. **Detailed refactor plan** outlining a physics-first approach where:
   - Foundation produces non-degenerate continent/basin signals that drive downstream outcomes
   - Morphology consumes Foundation truth as the primary driver for landmass coherence
   - Observability becomes a correctness harness with metrics to prevent regressions

2. **Diagnostic toolkit** with command-line tools for data-driven analysis:
   - `diag:dump` - Generate deterministic map dumps with configurable parameters
   - `diag:analyze` - Compute landmass coherence metrics (components, largest fraction)
   - `diag:diff` - Compare binary outputs between runs to detect dead levers
   - `diag:list` - Enumerate layers from dump manifests
   - `diag:trace` - Extract trace events for debugging

3. **Research spike documentation** capturing the root causes of current issues:
   - Saturated continent classification (`foundation.crustTiles.type` has `min=max=1`)
   - Noise-dominated landmask generation instead of continent-scale structure
   - Normalization traps that cancel out intended amplitude knobs

The plan establishes a phased implementation approach with explicit acceptance criteria and metrics for success, focusing on creating a single causal spine from Foundation through Morphology.