### PR TITLE
docs(pipeline-realism): add Phase 0 preflight to morphology refactor plan

### DIFF
--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -28,6 +28,10 @@ This plan is intentionally **no-legacy**: any legacy-independent “truth” (oc
 
 Only future-facing implementation work remains:
 
+### Phase 0 — No Dual-Engine Preflight
+- Add preflight-only guards and targeted UI correctness fixes that unblock Phase A.
+- Preflight slices complete here; do not execute Phase A/B/C/D in this pass.
+
 ### Phase A — Foundation truth normalization + degeneracy elimination
 - Make crust truth continuous and non-degenerate for canonical probes.
 - Ensure provenance resets are materially present and calibrated to observed forcing ranges.

--- a/docs/projects/pipeline-realism/reviews/REVIEW-M1-foundation-maximal-cutover.md
+++ b/docs/projects/pipeline-realism/reviews/REVIEW-M1-foundation-maximal-cutover.md
@@ -663,6 +663,18 @@ Assessment: Still relevant. This is a contract/authoring-surface drift problem (
 - Projection now requires tectonic provenance and a guard test enforces that dependency, which is a meaningful contract hardening step.
 - The bulk of the diff is a MapGen Studio config-override refactor; the ticket’s core deliverable (removing shadow/dual compute paths and comparison layers) is not clearly implemented.
 
+### Disposition (2026-02-06)
+
+| Item | Disposition | Rationale | Owning Slice | Phase |
+| --- | --- | --- | --- | --- |
+| no-dual-engine guard | must-fix-now | Core M1-025 acceptance requires explicit protection against shadow/dual compare surfaces in standard pipeline paths. | Slice 1 | Phase 0 |
+| provenance-required projection guard | fixed | Projection now hard-requires provenance and is covered by contract guard coverage. | — | Complete |
+| dual-read lingering concern | fixed | Prior dual-read concern from belt cutover is closed by existing no-dual-read guard coverage. | — | Complete |
+| M1-022 era snapping + overlay normalization | scheduled | Studio manual era selection must resolve to available variant keys with normalized matching to avoid drift. | Slice 2 | Phase 0 |
+| M1-021/022 overlay hardcoding | scheduled | Move overlay suggestions out of app shell and bind to recipe-driven lookup to reduce coupling. | Slice 3 | Phase 0 |
+| M1-023 motion-field risk | scheduled | Add guard that motion surfaces stay derived from canonical `plateMotion` path while preserving current contract shape. | Slice 4 | Phase 0 |
+| M1-024 plate-tensor concern | superseded by plan matrices/Phase B/C | Remaining morphology tensor-consumer decisions are tracked in canonical plan matrices and execute in later phases. | — | Phase B/C |
+
 ### High-Leverage Issues
 - Acceptance criteria are not met: there is no removal of shadow/dual compute paths or comparison-only layers, and no “no shadow paths” guard beyond the provenance requirement.
 - The large Studio config override refactor is out-of-scope for a pipeline shadow-path cleanup and increases review surface area and regression risk without explicit justification.


### PR DESCRIPTION
# Add Phase 0 for No Dual-Engine Preflight to Foundation Morphology Refactor Plan

This PR adds a new Phase 0 to the foundation morphology refactor plan, focusing on preflight-only guards and UI correctness fixes that will unblock subsequent phases. The phase is specifically designed to address no-dual-engine requirements without executing the more substantial changes in Phases A through D.

Additionally, the PR updates the M1 foundation maximal cutover review document with a detailed disposition table that:

1. Identifies specific items requiring immediate fixes (no-dual-engine guard)
2. Marks items that are already fixed (provenance-required projection guard, dual-read concerns)
3. Schedules work across four slices for Phase 0, including:
   - Studio manual era selection normalization (Slice 2)
   - Moving overlay suggestions to recipe-driven lookup (Slice 3)
   - Adding guards for motion surfaces (Slice 4)
4. Notes that plate-tensor concerns are superseded by plan matrices in later phases

This change provides a clearer roadmap for addressing preflight requirements before proceeding with the main refactoring work.