### PR TITLE
test(pipeline): add guardrails against shadow paths

### DIFF
--- a/mods/mod-swooper-maps/test/pipeline/no-shadow-paths.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/no-shadow-paths.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+function listFilesRecursive(rootDir: string): string[] {
+  const out: string[] = [];
+  const entries = readdirSync(rootDir);
+  for (const entry of entries) {
+    const full = path.join(rootDir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      out.push(...listFilesRecursive(full));
+      continue;
+    }
+    out.push(full);
+  }
+  return out;
+}
+
+const bannedShadowSurfacePatterns: RegExp[] = [
+  /\bdualRead\b/i,
+  /\bdual[-_ ]?engine\b/i,
+  /\bdual[-_ ]?path\b/i,
+  /\bshadow(?:Path|Compute|Layer|Mode|Toggle)\b/i,
+  /\bcompare(?:Layer|Layers|Mode|Toggle|Only)\b/i,
+  /\bcomparison(?:Layer|Layers|Mode|Toggle|Only)\b/i,
+];
+
+describe("pipeline no-shadow-path guardrails", () => {
+  it("does not keep shadow/dual/compare surfaces in standard contracts", () => {
+    const repoRoot = path.resolve(import.meta.dir, "../..");
+    const standardRoot = path.join(repoRoot, "src/recipes/standard");
+    const contractFiles = listFilesRecursive(standardRoot).filter(
+      (file) => file.endsWith("contract.ts") || file.endsWith("artifacts.ts")
+    );
+
+    expect(contractFiles.length).toBeGreaterThan(0);
+
+    for (const file of contractFiles) {
+      const text = readFileSync(file, "utf8");
+      for (const pattern of bannedShadowSurfacePatterns) {
+        expect(text).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it("does not reintroduce shadow/dual/compare toggles in standard pipeline sources", () => {
+    const repoRoot = path.resolve(import.meta.dir, "../..");
+    const standardRoot = path.join(repoRoot, "src/recipes/standard");
+    const sourceFiles = listFilesRecursive(standardRoot).filter((file) => file.endsWith(".ts"));
+
+    expect(sourceFiles.length).toBeGreaterThan(0);
+
+    for (const file of sourceFiles) {
+      const text = readFileSync(file, "utf8");
+      for (const pattern of bannedShadowSurfacePatterns) {
+        expect(text).not.toMatch(pattern);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Added test to prevent shadow path features in standard pipeline

This PR adds a new test file that ensures we don't accidentally reintroduce shadow path features in our standard pipeline. The test scans all contract files and source files in the standard recipes directory for banned patterns related to shadow/dual/compare surfaces.

The test checks for patterns like:
- `dualRead`, `dual-engine`, `dual_path`
- Shadow-related terms like `shadowPath`, `shadowCompute`, etc.
- Comparison-related terms like `compareLayer`, `comparisonMode`, etc.

This helps maintain our commitment to keeping the standard pipeline clean and focused on the primary rendering path.