### PR TITLE
feat(mapgen-studio): make overlay suggestions recipe-specific

### DIFF
--- a/apps/mapgen-studio/src/recipes/overlaySuggestions.ts
+++ b/apps/mapgen-studio/src/recipes/overlaySuggestions.ts
@@ -1,0 +1,43 @@
+import type { StudioRecipeId } from "./catalog";
+
+export type OverlaySuggestion = Readonly<{
+  id: string;
+  primaryDataTypeKey: string;
+  overlayDataTypeKey: string;
+  label: string;
+}>;
+
+const SUGGESTIONS_BY_RECIPE: Readonly<Record<string, readonly OverlaySuggestion[]>> = {
+  "mod-swooper-maps/standard": [
+    {
+      id: "foundation.history.boundaryType::foundation.tectonics.boundaryType",
+      primaryDataTypeKey: "foundation.history.boundaryType",
+      overlayDataTypeKey: "foundation.tectonics.boundaryType",
+      label: "Boundary events (snapshot)",
+    },
+    {
+      id: "map.morphology.mountains.orogenyPotential01::morphology.drivers.uplift",
+      primaryDataTypeKey: "map.morphology.mountains.orogenyPotential01",
+      overlayDataTypeKey: "morphology.drivers.uplift",
+      label: "Uplift driver",
+    },
+  ],
+  "mod-swooper-maps/browser-test": [
+    {
+      id: "foundation.history.boundaryType::foundation.tectonics.boundaryType",
+      primaryDataTypeKey: "foundation.history.boundaryType",
+      overlayDataTypeKey: "foundation.tectonics.boundaryType",
+      label: "Boundary events (snapshot)",
+    },
+    {
+      id: "map.morphology.mountains.orogenyPotential01::morphology.drivers.uplift",
+      primaryDataTypeKey: "map.morphology.mountains.orogenyPotential01",
+      overlayDataTypeKey: "morphology.drivers.uplift",
+      label: "Uplift driver",
+    },
+  ],
+};
+
+export function getOverlaySuggestions(recipeId: StudioRecipeId): readonly OverlaySuggestion[] {
+  return SUGGESTIONS_BY_RECIPE[recipeId] ?? [];
+}

--- a/apps/mapgen-studio/test/viz/overlaySuggestions.test.ts
+++ b/apps/mapgen-studio/test/viz/overlaySuggestions.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getOverlaySuggestions } from "../../src/recipes/overlaySuggestions";
+
+describe("getOverlaySuggestions", () => {
+  it("returns configured suggestions for known recipes", () => {
+    const suggestions = getOverlaySuggestions("mod-swooper-maps/standard");
+    expect(suggestions.length).toBeGreaterThan(0);
+    expect(suggestions.some((suggestion) => suggestion.primaryDataTypeKey === "foundation.history.boundaryType")).toBe(
+      true
+    );
+  });
+
+  it("returns an empty list for unknown recipes", () => {
+    expect(getOverlaySuggestions("unknown/recipe")).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Recipe-specific Overlay Suggestions in MapGen Studio

This PR refactors overlay suggestions in MapGen Studio to be recipe-specific rather than global. It:

- Extracts overlay suggestions from `App.tsx` into a new `overlaySuggestions.ts` module
- Implements `getOverlaySuggestions()` function that returns appropriate overlay options based on the current recipe
- Organizes suggestions by recipe ID in a structured format
- Updates the UI to dynamically fetch overlay suggestions based on the active recipe
- Adds unit tests to verify the overlay suggestion functionality

This change allows for more tailored visualization options depending on the specific map generation recipe being used.