### PR TITLE
test(foundation): add plate motion non-finite value check

### DIFF
--- a/mods/mod-swooper-maps/test/pipeline/foundation-gates.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/foundation-gates.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+
+import { foundationArtifacts } from "../../src/recipes/standard/stages/foundation/artifacts.js";
+import { M1_FOUNDATION_GATES } from "../support/foundation-invariants.js";
+
+function findGate(name: string) {
+  const gate = M1_FOUNDATION_GATES.find((entry) => entry.name === name);
+  if (!gate) throw new Error(`Missing gate ${name}`);
+  return gate;
+}
+
+function makeInvariantContext(artifacts: Map<string, unknown>) {
+  return {
+    context: {
+      artifacts,
+      dimensions: { width: 2, height: 1 },
+    } as any,
+    fingerprints: { artifacts: {}, missing: [] },
+  };
+}
+
+describe("foundation invariant gates", () => {
+  it("fails the coupling gate when plateFitRms has non-finite values", () => {
+    const artifacts = new Map<string, unknown>([
+      [
+        foundationArtifacts.mantleForcing.id,
+        {
+          forcingU: new Float32Array([1, 1]),
+          forcingV: new Float32Array([0, 0]),
+        },
+      ],
+      [
+        foundationArtifacts.plateMotion.id,
+        {
+          plateFitRms: new Float32Array([Number.NaN, 0.2]),
+          plateQuality: new Uint8Array([120, 120]),
+          cellFitError: new Uint8Array([10, 10]),
+        },
+      ],
+    ]);
+
+    const gate = findGate("foundation-plate-motion-coupling");
+    const result = gate.check(makeInvariantContext(artifacts));
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("non-finite");
+    expect((result.details as { nonFinite?: number } | undefined)?.nonFinite).toBe(1);
+  });
+});

--- a/mods/mod-swooper-maps/test/support/foundation-invariants.ts
+++ b/mods/mod-swooper-maps/test/support/foundation-invariants.ts
@@ -354,6 +354,14 @@ const plateCouplingInvariant: ValidationInvariant = {
     }
 
     const rmsStats = scanFloat(motion.plateFitRms);
+    if (rmsStats.nonFinite > 0) {
+      return {
+        name: "foundation-plate-motion-coupling",
+        ok: false,
+        message: "Plate motion residuals contain non-finite values.",
+        details: { nonFinite: rmsStats.nonFinite },
+      };
+    }
     const meanRatio = rmsStats.mean / Math.max(meanForcing, EPS);
     const qualityStats = scanBytes(motion.plateQuality);
     const cellStats = scanBytes(motion.cellFitError);


### PR DESCRIPTION
# Add test for foundation plate motion coupling invariant

This PR adds a test for the foundation plate motion coupling invariant gate, specifically testing the case where `plateFitRms` contains non-finite values (like NaN). The test verifies that the gate correctly fails in this scenario and provides appropriate error details.

The implementation also adds a check in the `plateCouplingInvariant` to detect and report non-finite values in plate motion residuals, returning a descriptive error message and the count of non-finite values found.