### PR TITLE
fix(mapgen-studio): improve era display value resolution

### DIFF
--- a/apps/mapgen-studio/src/App.tsx
+++ b/apps/mapgen-studio/src/App.tsx
@@ -40,6 +40,7 @@ import {
   findVariantKeyForEra,
   listEraVariants,
   parseEraVariantKey,
+  resolveFixedEraUiValue,
 } from "./features/viz/era";
 import { formatErrorForUi } from "./shared/errorFormat";
 import { shouldIgnoreGlobalShortcutsInEditableTarget } from "./shared/shortcuts/shortcutPolicy";
@@ -948,7 +949,16 @@ function AppContent(props: AppContentProps) {
   }, [eraVariants]);
   const autoEra = useMemo(() => parseEraVariantKey(selectedVariantKey), [selectedVariantKey]);
   const eraEnabled = Boolean(eraRange);
-  const eraDisplayValue = eraMode === "fixed" ? manualEra : autoEra ?? eraRange?.min ?? 1;
+  const fixedEraUiValue = useMemo(
+    () =>
+      resolveFixedEraUiValue({
+        variants: selectedVariants,
+        selectedVariantKey,
+        requestedEra: manualEra,
+      }),
+    [manualEra, selectedVariantKey, selectedVariants]
+  );
+  const eraDisplayValue = eraMode === "fixed" ? fixedEraUiValue : autoEra ?? eraRange?.min ?? 1;
 
   useEffect(() => {
     if (!eraRange) return;

--- a/apps/mapgen-studio/src/features/viz/era.ts
+++ b/apps/mapgen-studio/src/features/viz/era.ts
@@ -71,3 +71,13 @@ export function findVariantKeyForEra(variants: readonly LayerVariant[], era: num
   }
   return null;
 }
+
+export function resolveFixedEraUiValue(args: {
+  variants: readonly LayerVariant[];
+  selectedVariantKey: string | null | undefined;
+  requestedEra: number;
+}): number {
+  const selectedEra = parseEraVariantKey(args.selectedVariantKey);
+  if (selectedEra != null) return selectedEra;
+  return snapEraToAvailable(args.variants, args.requestedEra) ?? args.requestedEra;
+}

--- a/apps/mapgen-studio/test/viz/eraSelection.test.ts
+++ b/apps/mapgen-studio/test/viz/eraSelection.test.ts
@@ -5,6 +5,7 @@ import {
   findVariantKeyForEra,
   listEraVariants,
   parseEraVariantKey,
+  resolveFixedEraUiValue,
   snapEraToAvailable,
 } from "../../src/features/viz/era";
 
@@ -81,5 +82,25 @@ describe("findVariantKeyForEra", () => {
     const variants = [makeVariant("display-era-001", "era:001"), makeVariant("display-era-003", "era:003")];
     expect(findVariantKeyForEra(variants, 2)).toBe("era:001");
     expect(findVariantKeyForEra(variants, 3)).toBe("era:003");
+  });
+});
+
+describe("resolveFixedEraUiValue", () => {
+  it("uses the selected rendered era when fixed mode snaps to sparse variants", () => {
+    const variants = [
+      makeVariant("era:1", "era:1"),
+      makeVariant("era:3", "era:3"),
+      makeVariant("era:5", "era:5"),
+    ];
+    expect(resolveFixedEraUiValue({ variants, selectedVariantKey: "era:3", requestedEra: 4 })).toBe(3);
+  });
+
+  it("falls back to nearest snapped era with lower-era tiebreak", () => {
+    const variants = [
+      makeVariant("era:1", "era:1"),
+      makeVariant("era:3", "era:3"),
+      makeVariant("era:5", "era:5"),
+    ];
+    expect(resolveFixedEraUiValue({ variants, selectedVariantKey: null, requestedEra: 4 })).toBe(3);
   });
 });


### PR DESCRIPTION
# Fix era slider display value in fixed mode

This PR fixes an issue with the era slider display value in fixed mode. Previously, when a user selected a specific era variant, the slider would still show the manually entered era value, which could be confusing if they didn't match.

Now, the slider correctly displays:
1. The actual era of the selected variant when a specific era variant is selected
2. The nearest available era when no specific variant is selected but the requested era doesn't match any available variant

Added a new `resolveFixedEraUiValue` function with tests to handle this logic consistently.