### PR TITLE
docs(pipeline-realism): add canonical execution plan documentation

### DIFF
--- a/docs/projects/pipeline-realism/plans/README.md
+++ b/docs/projects/pipeline-realism/plans/README.md
@@ -1,0 +1,21 @@
+# pipeline-realism plans
+
+This directory contains the canonical execution plan for the Pipeline Realism remediation work.
+
+## Canonical (Execution Source)
+
+- `PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md`
+
+## Execution Posture
+
+- Forward-only: no legacy compatibility, no shims, no dual paths.
+- Evidence + numeric gates are blocking (determinism + diagnostics + Phase B formulas).
+
+## Execution Workflow (Orchestrated)
+
+This work is intended to be executed via one long-running worker agent (YARSI) on a Graphite stack:
+
+- Milestone base branch: `agent-YARSI-PRR-milestone-pipeline-realism-remediation`
+- Prep slice (docs/runbooks): `agent-YARSI-PRR-p00-prep-execution-ready-docs-runbooks`
+- Then proceed slice-by-slice per the checklist in the canonical plan doc.
+


### PR DESCRIPTION
# Pipeline Realism Remediation Plan

Added the canonical execution plan for the Pipeline Realism remediation work. The plan outlines:

- Forward-only execution posture with no legacy compatibility, shims, or dual paths
- Evidence and numeric gates as blocking requirements
- Execution workflow via a long-running worker agent (YARSI) on a Graphite stack
- Milestone branch and preparation slice information
- Reference to the canonical plan document for slice-by-slice execution

This establishes the foundation for the structured remediation approach to be followed.