### PR TITLE
docs(pipeline-realism): add GOBI agent PRR evidence index

### DIFF
--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/README.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/README.md
@@ -1,0 +1,12 @@
+# PRR Evidence Index (agent-GOBI)
+
+This directory is the durable, repo-tracked evidence bundle for the Pipeline Realism remediation stack.
+
+Evidence files (in stack order):
+- `s00.md`: Phase 0 no-shadow + execution runbook readiness
+- `s10.md`: Phase A (Foundation truth non-degenerate)
+- `s20.md`: Phase B (landmask grounded in crust truth) + numeric gate
+- `s21.md`: Phase B erosion connectivity (no hidden reclassification)
+- `s30.md`: Phase C belts as modifiers (positive-intensity diffusion seeding)
+- `s40.md`: Phase D observability enforcement
+- `s90.md`: Final legacy + docs cleanup sweep


### PR DESCRIPTION
Added documentation for the Pipeline Realism remediation stack evidence bundle. The new README.md file serves as an index for evidence files organized by phase, including foundation truth verification, landmask grounding, erosion connectivity, belt modifiers, observability enforcement, and final cleanup steps for the agent-GOBI project.