### PR TITLE
feat(foundation): wire beltInfluenceDistance and beltDecay config parameters

### DIFF
--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s11.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s11.md
@@ -1,0 +1,142 @@
+# s11 — Phase A review thread closures (1077/1078/1083)
+
+This slice exists to close Phase A semantics threads with concrete, reproducible evidence (tests + probes + run IDs).
+
+## Change (1083 config consumption)
+Wired `beltInfluenceDistance` + `beltDecay` from runtime config into `compute-tectonic-history` belt-field diffusion footprint (radius/decay), preserving prior default behavior shape via per-channel multipliers.
+
+- Code: `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts`
+
+## Gates / Tests
+
+### Typecheck
+```bash
+bun run --cwd mods/mod-swooper-maps check
+```
+
+### Phase 0 guard (still green)
+```bash
+bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts
+```
+
+### Determinism suite (M1)
+```bash
+bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts
+```
+Output excerpt:
+```text
+[diagnostic:baseline-balanced] foundation-plate-motion-diagnostics: Plate motion diagnostics below preferred quality/residual thresholds.
+[diagnostic:wrap-active] foundation-plate-motion-diagnostics: Plate motion diagnostics below preferred quality/residual thresholds.
+[diagnostic:compact-low-plates] foundation-plate-motion-diagnostics: Plate motion diagnostics below preferred quality/residual thresholds.
+(pass) pipeline determinism suite (M1) > produces identical fingerprints across canonical cases
+```
+
+### Foundation gates (still green)
+```bash
+bun run --cwd mods/mod-swooper-maps test test/pipeline/foundation-gates.test.ts
+```
+
+### Thread-scoped tests
+```bash
+bun run --cwd mods/mod-swooper-maps test test/m11-config-knobs-and-presets.test.ts
+bun run --cwd mods/mod-swooper-maps test test/foundation/m11-plate-graph-resistance.test.ts
+bun run --cwd mods/mod-swooper-maps test test/foundation/m11-tectonic-events.test.ts
+bun run --cwd mods/mod-swooper-maps test test/morphology/belt-synthesis-history-provenance.test.ts
+```
+
+## Thread Evidence
+
+### #1077 — `PRRT_kwDOOOKvrc5swnXi` (plateCount knob semantics)
+Expectation: when `foundation.knobs.plateCount` is omitted, compile-time plate count inherits selected profile baseline; when explicitly provided, the knob value wins.
+
+Test:
+```bash
+bun run --cwd mods/mod-swooper-maps test test/m11-config-knobs-and-presets.test.ts
+```
+
+Probe dumps:
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label phase-a-1077-profile-default --override '{"foundation":{"profiles":{"resolutionProfile":"coarse"},"knobs":{}}}'
+# => {"runId":"76877bde651358fe862e6854b7133574ff4028e280111b7ea0f17359e620ee07","outputDir":".../dist/visualization/phase-a-1077-profile-default/76877bde651358fe862e6854b7133574ff4028e280111b7ea0f17359e620ee07"}
+
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label phase-a-1077-explicit-override --override '{"foundation":{"profiles":{"resolutionProfile":"coarse"},"knobs":{"plateCount":31}}}'
+# => {"runId":"69892d825a6290e4f8da3bfc015b44ca81b8aaa79560186f63eb6c1607340da9","outputDir":".../dist/visualization/phase-a-1077-explicit-override/69892d825a6290e4f8da3bfc015b44ca81b8aaa79560186f63eb6c1607340da9"}
+```
+
+Full JSON outputs:
+- `phase-a-1077-profile-default`
+```json
+{"runId":"76877bde651358fe862e6854b7133574ff4028e280111b7ea0f17359e620ee07","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/phase-a-1077-profile-default/76877bde651358fe862e6854b7133574ff4028e280111b7ea0f17359e620ee07"}
+```
+- `phase-a-1077-explicit-override`
+```json
+{"runId":"69892d825a6290e4f8da3bfc015b44ca81b8aaa79560186f63eb6c1607340da9","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/phase-a-1077-explicit-override/69892d825a6290e4f8da3bfc015b44ca81b8aaa79560186f63eb6c1607340da9"}
+```
+
+### #1078 — `PRRT_kwDOOOKvrc5swoFn` (lithosphere scalars are true 0..1 levers)
+Expectation: `yieldStrength01` / `mantleCoupling01` are consumed as direct 0..1 levers (no narrow remap preventing true weakening at 0).
+
+Tests:
+```bash
+bun run --cwd mods/mod-swooper-maps test test/m11-config-knobs-and-presets.test.ts
+bun run --cwd mods/mod-swooper-maps test test/foundation/m11-plate-graph-resistance.test.ts
+```
+
+Code probe:
+```bash
+rg -n "yieldStrength01|mantleCoupling01|\\*\\s*0\\.3|\\*\\s*0\\.2" mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust/index.ts
+```
+Output:
+```text
+68:        const yieldStrength = clamp01(config.yieldStrength01 ?? 0.55);
+69:        const mantleCoupling = clamp01(config.mantleCoupling01 ?? 0.6);
+```
+
+### #1083 — `PRRT_kwDOOOKvrc5swl4c` (beltInfluenceDistance + beltDecay honored)
+Expectation: `beltInfluenceDistance` / `beltDecay` are consumed by runtime belt-field generation; authored values are not ignored/replaced by fixed constants.
+
+Tests:
+```bash
+bun run --cwd mods/mod-swooper-maps test test/foundation/m11-tectonic-events.test.ts
+bun run --cwd mods/mod-swooper-maps test test/morphology/belt-synthesis-history-provenance.test.ts
+```
+
+Code probe:
+```bash
+rg -n "beltInfluenceDistance|beltDecay|EMISSION_RADIUS|EMISSION_DECAY" mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts
+```
+Output excerpt:
+```text
+140:function deriveEmissionParams(config: { beltInfluenceDistance: number; beltDecay: number }): EmissionParams {
+141:  const baseRadius = ... config.beltInfluenceDistance ...
+142:  const baseDecay = ... config.beltDecay ...
+746:          beltInfluenceDistance: config.beltInfluenceDistance,
+747:          beltDecay: config.beltDecay,
+```
+
+## Slice Evidence Bundle (canonical probe)
+
+### Dump
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label s11-phase-a-thread-closures
+```
+```json
+{"runId":"f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s11-phase-a-thread-closures/f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966"}
+```
+
+### Analyze
+```bash
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <outputDir>
+```
+(See JSON output in terminal; key landmask summary is embedded in the analyze payload.)
+
+### Spot-check layers
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey foundation.crustTiles.type
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey morphology.topography.landMask
+```
+Selected excerpts:
+- `foundation.crustTiles.type` stats: `min=0`, `max=1`
+- `morphology.topography.landMask` present at:
+  - `...morphology-coasts.landmass-plates...`
+  - `...morphology-erosion.geomorphology...`

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -17,7 +17,7 @@ $MOD = mods/mod-swooper-maps
 
 - [x] **s00** Phase 0 preflight + plan readiness (blocking): `agent-GOBI-PRR-s00-phase-0-preflight-no-shadow-and-plan-readiness`
 - [x] **s10** Phase A Foundation truth normalization + degeneracy elimination: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
-- [ ] **s11** Phase A review thread closures (1077/1078/1083): `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
+- [x] **s11** Phase A review thread closures (1077/1078/1083): `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
 - [ ] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
 - [ ] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
 - [ ] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
@@ -80,6 +80,9 @@ This section is intentionally short and pointer-only. Evidence payloads live und
 - s10: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1151
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s10.md`
+- s11: `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1152
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s11.md`
 
 ## Canonical Sources (Normative)
 


### PR DESCRIPTION
# Wire belt influence parameters from runtime config

This PR implements the consumption of `beltInfluenceDistance` and `beltDecay` parameters from runtime configuration into the `compute-tectonic-history` operation. These parameters control the belt-field diffusion footprint (radius and decay) in tectonic belt generation.

The implementation:
- Preserves the prior default behavior shape via per-channel multipliers
- Creates a new `deriveEmissionParams` function to handle the parameter processing
- Replaces hardcoded constants with dynamically calculated values based on config

This change closes thread #1083 by ensuring that authored values for belt influence parameters are properly honored by the runtime belt-field generation system rather than being ignored or replaced by fixed constants.

All tests remain green, including typecheck, Phase 0 guard, determinism suite, foundation gates, and thread-specific tests.