### PR TITLE
feat(morphology): derive landmask from Foundation truth instead of noise thresholding

### DIFF
--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s20.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s20.md
@@ -1,0 +1,76 @@
+# s20 — Phase B: Landmask grounded in Foundation truth (numeric gate)
+
+This slice hard-cuts the Morphology landmask to be derived from Foundation truth, eliminating noise/threshold-first landmasks.
+
+## Behavior Change (the point)
+- Landmask is now derived from a **low-frequency continent potential** computed from:
+  - Foundation crust truth (`crustType`, `crustBaseElevation`, `crustAge`)
+  - Foundation provenance stability (`originEra`, `driftDistance`)
+- Hypsometry still sets *how much* land (via sea level), but **continent shape/connectivity** comes from Foundation truth.
+- Removed `basinSeparation` (a plate-band carving surface) to avoid hidden non-physics reclassification.
+
+## Code
+- `mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts`
+- `mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/strategies/default.ts`
+- `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.ts`
+- Config/schema updates:
+  - `mods/mod-swooper-maps/src/presets/standard/earthlike.json`
+  - `mods/mod-swooper-maps/src/maps/configs/*.config.*`
+
+## Gates / Tests
+```bash
+bun run --cwd mods/mod-swooper-maps check
+bun run --cwd mods/mod-swooper-maps test
+bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/foundation-gates.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts
+```
+
+## Phase B Evidence (baseline vs after)
+
+### Baseline dump
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label phase-b-baseline
+```
+```json
+{"runId":"f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/phase-b-baseline/f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966"}
+```
+
+### After dump
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label phase-b-after
+```
+```json
+{"runId":"65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/phase-b-after/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac"}
+```
+
+### Compare analyze
+```bash
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <baselineOutputDir> <afterOutputDir>
+```
+Key metrics from compare:
+
+**Landmask (landmass-plates step)**
+- Baseline: `pctLand=0.3571`, `landComponents=433`, `largestLandFrac=0.2598`
+- After: `pctLand=0.3571`, `landComponents=4`, `largestLandFrac=0.5797`
+
+**Landmask (geomorphology step)**
+- Baseline: `pctLand=0.2296`, `landComponents=186`, `largestLandFrac=0.3562`
+- After: `pctLand=0.3425`, `landComponents=4`, `largestLandFrac=0.5826`
+
+Interpretation:
+- Connectivity is now continent-scale (components collapse from hundreds to single digits).
+- Largest land component share increases materially.
+- Land fraction remains within sane bounds and still respects sea-level target.
+
+### Spot-check layers
+After run:
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <afterOutputDir> --dataTypeKey foundation.crustTiles.type
+bun run --cwd mods/mod-swooper-maps diag:list -- <afterOutputDir> --dataTypeKey morphology.topography.landMask
+```
+Selected excerpts:
+- `foundation.crustTiles.type` stats: `min=0`, `max=1`
+- `morphology.topography.landMask` present at:
+  - `...morphology-coasts.landmass-plates...`
+  - `...morphology-erosion.geomorphology...`

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -18,7 +18,7 @@ $MOD = mods/mod-swooper-maps
 - [x] **s00** Phase 0 preflight + plan readiness (blocking): `agent-GOBI-PRR-s00-phase-0-preflight-no-shadow-and-plan-readiness`
 - [x] **s10** Phase A Foundation truth normalization + degeneracy elimination: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
 - [x] **s11** Phase A review thread closures (1077/1078/1083): `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
-- [ ] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
+- [x] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
 - [ ] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
 - [ ] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
 - [ ] **s40** Phase D observability enforcement (tiers + gate correctness): `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
@@ -83,6 +83,9 @@ This section is intentionally short and pointer-only. Evidence payloads live und
 - s11: `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1152
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s11.md`
+- s20: `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1153
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s20.md`
 
 ## Canonical Sources (Normative)
 

--- a/mods/mod-swooper-maps/src/domain/morphology/config.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/config.ts
@@ -1,99 +1,6 @@
 import { Type, type Static } from "@swooper/mapgen-core/authoring";
 
 /**
- * Edge override policy for the ocean separation pass.
- */
-export const OceanSeparationEdgePolicySchema = Type.Object(
-  {
-    /** Enable edge-specific override for this map border (west or east). */
-    enabled: Type.Boolean({
-      description: "Enable edge-specific override for this map border (west or east).",
-      default: false,
-    }),
-    /** Baseline separation enforced at the map edge in tiles (before boundary multipliers). */
-    baseTiles: Type.Number({
-      description: "Baseline separation enforced at the map edge in tiles (before boundary multipliers).",
-      default: 0,
-      minimum: 0,
-    }),
-    /** Multiplier applied near active margins when widening oceans at the edge. */
-    boundaryClosenessMultiplier: Type.Number({
-      description: "Multiplier applied near active margins when widening oceans at the edge.",
-      default: 1,
-      minimum: 0,
-    }),
-    /** Maximum allowed per-latitude separation delta for this edge to avoid extreme zig-zags. */
-    maxPerRowDelta: Type.Number({
-      description: "Maximum allowed per-latitude separation delta for this edge to avoid extreme zig-zags.",
-      default: 3,
-      minimum: 0,
-    }),
-  }
-);
-
-/**
- * Plate-aware ocean separation policy controlling continental drift spacing.
- */
-export const OceanSeparationConfigSchema = Type.Object(
-  {
-    /** Master switch for plate-aware ocean widening between continent bands. */
-    enabled: Type.Boolean({
-      description: "Master switch for plate-aware ocean widening between continent bands.",
-      default: false,
-    }),
-    /**
-     * Pairs of continent indices to separate.
-     * @example [[0,1],[1,2]] separates band 0 from 1, and band 1 from 2.
-     */
-    bandPairs: Type.Optional(
-      Type.Array(Type.Tuple([Type.Number(), Type.Number()]), {
-        default: [],
-        description: "Pairs of continent indices to separate (e.g., [[0,1],[1,2]]).",
-      })
-    ),
-    /** Baseline widening between continents in tiles before modifiers are applied. */
-    baseSeparationTiles: Type.Number({
-      description: "Baseline widening between continents in tiles before modifiers are applied.",
-      default: 0,
-      minimum: 0,
-    }),
-    /** Extra separation applied when plates are close to active boundaries (multiplier 0..2). */
-    boundaryClosenessMultiplier: Type.Number({
-      description: "Extra separation applied when plates are close to active boundaries (multiplier 0..2).",
-      default: 1,
-      minimum: 0,
-    }),
-    /** Maximum per-latitude variation in separation (tiles) to keep oceans smooth north-south. */
-    maxPerRowDelta: Type.Number({
-      description: "Maximum per-latitude variation in separation (tiles) to keep oceans smooth north-south.",
-      default: 3,
-      minimum: 0,
-    }),
-    /** Minimum navigable channel width to preserve while widening seas (tiles). */
-    minChannelWidth: Type.Number({
-      description: "Minimum navigable channel width to preserve while widening seas (tiles).",
-      default: 3,
-      minimum: 0,
-    }),
-    /** Random jitter applied to channel widths to avoid uniform straight lines. */
-    channelJitter: Type.Number({
-      description: "Random jitter applied to channel widths to avoid uniform straight lines.",
-      default: 0,
-      minimum: 0,
-    }),
-    /** Whether strategic sea corridors should be preserved when enforcing separation. */
-    respectSeaLanes: Type.Boolean({
-      description: "Whether strategic sea corridors should be preserved when enforcing separation.",
-      default: true,
-    }),
-    /** West edge-specific override policy. */
-    edgeWest: OceanSeparationEdgePolicySchema,
-    /** East edge-specific override policy. */
-    edgeEast: OceanSeparationEdgePolicySchema,
-  }
-);
-
-/**
  * Plate-aware weighting for bay/fjord odds based on boundary closeness.
  */
 export const CoastlinePlateBiasConfigSchema = Type.Object(
@@ -698,7 +605,6 @@ export const MorphologyConfigSchema = Type.Object(
   {
     hypsometry: HypsometryConfigSchema,
     relief: ReliefConfigSchema,
-    basinSeparation: OceanSeparationConfigSchema,
     coast: CoastConfigSchema,
     landforms: LandformsConfigSchema,
     geomorphology: GeomorphologyConfigSchema,
@@ -710,10 +616,6 @@ export type MorphologyConfig = Static<typeof MorphologyConfigSchema>;
 export type HypsometryConfig = Static<typeof HypsometryConfigSchema>;
 export type ReliefConfig = Static<typeof ReliefConfigSchema>;
 export type GeomorphologyConfig = Static<typeof GeomorphologyConfigSchema>;
-export type BasinSeparationConfig =
-  Static<typeof MorphologyConfigSchema["properties"]["basinSeparation"]>;
-export type OceanSeparationEdgePolicy =
-  Static<typeof OceanSeparationConfigSchema["properties"]["edgeWest"]>;
 export type CoastConfig = Static<typeof CoastConfigSchema>;
 export type LandformsConfig = Static<typeof LandformsConfigSchema>;
 export type CoastlinePlateBiasConfig =

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts
@@ -1,18 +1,36 @@
 import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
 
-import { OceanSeparationConfigSchema } from "../../config.js";
-
 const LandmaskConfigSchema = Type.Object(
   {
-    basinSeparation: OceanSeparationConfigSchema,
+    continentPotentialGrain: Type.Integer({
+      default: 8,
+      minimum: 1,
+      maximum: 64,
+      description: "Coarse grain (tile block size) used to low-pass continent potential before thresholding.",
+    }),
+    continentPotentialBlurSteps: Type.Integer({
+      default: 3,
+      minimum: 0,
+      maximum: 16,
+      description: "Number of hex-neighborhood blur passes applied after coarse-grain averaging.",
+    }),
+    keepLandComponentFraction: Type.Number({
+      default: 0.985,
+      minimum: 0.5,
+      maximum: 1,
+      description:
+        "Fraction of land tiles to keep by retaining only the largest connected components (removes speckle islands).",
+    }),
   },
   {
-    description: "Landmask shaping controls, including ocean separation policy.",
+    additionalProperties: false,
+    description:
+      "Landmask shaping controls. Landmask is derived from Foundation crust truth + provenance stability (continent potential), not from noise-first thresholding.",
   }
 );
 
 /**
- * Derives the land mask and coastline distance field from elevation and sea level.
+ * Derives the land mask and coastline distance field from a low-frequency continent potential grounded in Foundation truth.
  */
 const ComputeLandmaskContract = defineOp({
   kind: "compute",
@@ -24,6 +42,21 @@ const ComputeLandmaskContract = defineOp({
     seaLevel: Type.Number({ description: "Sea level threshold." }),
     boundaryCloseness: TypedArraySchemas.u8({
       description: "Boundary proximity per tile (0..255).",
+    }),
+    crustType: TypedArraySchemas.u8({
+      description: "Foundation crust type per tile (0=oceanic, 1=continental).",
+    }),
+    crustBaseElevation: TypedArraySchemas.f32({
+      description: "Foundation crust base elevation proxy per tile (0..1).",
+    }),
+    crustAge: TypedArraySchemas.u8({
+      description: "Foundation crust age bucket per tile (0..255).",
+    }),
+    provenanceOriginEra: TypedArraySchemas.u8({
+      description: "Foundation provenance origin era per tile (0..eraCount-1).",
+    }),
+    provenanceDriftDistance: TypedArraySchemas.u8({
+      description: "Foundation provenance drift distance bucket per tile (0..255).",
     }),
   }),
   output: Type.Object({

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/rules/index.ts
@@ -5,79 +5,46 @@ import type { ComputeLandmaskTypes } from "../types.js";
  */
 export function validateLandmaskInputs(
   input: ComputeLandmaskTypes["input"]
-): { size: number; elevation: Int16Array } {
+): {
+  size: number;
+  elevation: Int16Array;
+  boundaryCloseness: Uint8Array;
+  crustType: Uint8Array;
+  crustBaseElevation: Float32Array;
+  crustAge: Uint8Array;
+  provenanceOriginEra: Uint8Array;
+  provenanceDriftDistance: Uint8Array;
+} {
   const { width, height } = input;
   const size = Math.max(0, (width | 0) * (height | 0));
   const elevation = input.elevation as Int16Array;
-  if (elevation.length !== size) {
-    throw new Error(`Expected elevation length ${size} (received ${elevation.length}).`);
-  }
-  return { size, elevation };
-}
+  const boundaryCloseness = input.boundaryCloseness as Uint8Array;
+  const crustType = input.crustType as Uint8Array;
+  const crustBaseElevation = input.crustBaseElevation as Float32Array;
+  const crustAge = input.crustAge as Uint8Array;
+  const provenanceOriginEra = input.provenanceOriginEra as Uint8Array;
+  const provenanceDriftDistance = input.provenanceDriftDistance as Uint8Array;
 
-/**
- * Applies plate-aware basin separation to carve ocean buffers.
- */
-export function applyBasinSeparation(
-  width: number,
-  height: number,
-  landMask: Uint8Array,
-  config: ComputeLandmaskTypes["config"]["default"]["basinSeparation"]
-): void {
-  if (!config.enabled) return;
-  const base = Math.max(0, Math.round(config.baseSeparationTiles));
-  if (base <= 0) return;
-
-  const bandPairs = config.bandPairs ?? [];
-  let maxBand = 1;
-  for (const [a, b] of bandPairs) {
-    maxBand = Math.max(maxBand, a, b);
-  }
-  const bands = Math.max(2, maxBand + 1);
-  const half = Math.max(1, Math.floor(base / 2));
-
-  const boundaries = new Set<number>();
-  for (const [a, b] of bandPairs) {
-    const boundary = Math.max(a | 0, b | 0);
-    if (boundary > 0 && boundary < bands) boundaries.add(boundary);
-  }
-  if (boundaries.size === 0) {
-    for (let boundary = 1; boundary < bands; boundary++) {
-      boundaries.add(boundary);
-    }
+  if (
+    elevation.length !== size ||
+    boundaryCloseness.length !== size ||
+    crustType.length !== size ||
+    crustBaseElevation.length !== size ||
+    crustAge.length !== size ||
+    provenanceOriginEra.length !== size ||
+    provenanceDriftDistance.length !== size
+  ) {
+    throw new Error("[Landmask] Input tensors must match width*height.");
   }
 
-  const sortedBoundaries = Array.from(boundaries).sort((a, b) => a - b);
-
-  for (const band of sortedBoundaries) {
-    const center = Math.round((band / bands) * width);
-    const start = Math.max(0, center - half);
-    const end = Math.min(width - 1, center + half);
-    for (let y = 0; y < height; y++) {
-      const row = y * width;
-      for (let x = start; x <= end; x++) {
-        landMask[row + x] = 0;
-      }
-    }
-  }
-
-  if (config.edgeWest.enabled) {
-    const edge = Math.max(0, Math.round(config.edgeWest.baseTiles));
-    for (let y = 0; y < height; y++) {
-      const row = y * width;
-      for (let x = 0; x < Math.min(width, edge); x++) {
-        landMask[row + x] = 0;
-      }
-    }
-  }
-
-  if (config.edgeEast.enabled) {
-    const edge = Math.max(0, Math.round(config.edgeEast.baseTiles));
-    for (let y = 0; y < height; y++) {
-      const row = y * width;
-      for (let x = Math.max(0, width - edge); x < width; x++) {
-        landMask[row + x] = 0;
-      }
-    }
-  }
+  return {
+    size,
+    elevation,
+    boundaryCloseness,
+    crustType,
+    crustBaseElevation,
+    crustAge,
+    provenanceOriginEra,
+    provenanceDriftDistance,
+  };
 }

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/strategies/default.ts
@@ -1,55 +1,309 @@
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
+import { clamp01 } from "@swooper/mapgen-core/lib/math";
 
 import ComputeLandmaskContract from "../contract.js";
-import { applyBasinSeparation, validateLandmaskInputs } from "../rules/index.js";
+import { validateLandmaskInputs } from "../rules/index.js";
+
+function buildCoarseAverage(width: number, height: number, values: Float32Array, grain: number): Float32Array {
+  const size = Math.max(0, (width | 0) * (height | 0));
+  const g = Math.max(1, Math.round(grain)) | 0;
+  const gx = Math.max(1, Math.ceil(width / g)) | 0;
+  const gy = Math.max(1, Math.ceil(height / g)) | 0;
+  const sums = new Float32Array(gx * gy);
+  const counts = new Int32Array(gx * gy);
+
+  for (let y = 0; y < height; y++) {
+    const gyIdx = ((y / g) | 0) * gx;
+    for (let x = 0; x < width; x++) {
+      const cell = gyIdx + ((x / g) | 0);
+      const i = y * width + x;
+      sums[cell] += values[i] ?? 0;
+      counts[cell] += 1;
+    }
+  }
+
+  const out = new Float32Array(size);
+  for (let y = 0; y < height; y++) {
+    const gyIdx = ((y / g) | 0) * gx;
+    for (let x = 0; x < width; x++) {
+      const cell = gyIdx + ((x / g) | 0);
+      const denom = counts[cell] || 1;
+      out[y * width + x] = sums[cell] / denom;
+    }
+  }
+
+  return out;
+}
+
+function blurHex(width: number, height: number, values: Float32Array, steps: number): Float32Array {
+  const size = Math.max(0, (width | 0) * (height | 0));
+  const n = Math.max(0, Math.round(steps)) | 0;
+  if (n <= 0) return values;
+
+  let current: Float32Array = values;
+  let next: Float32Array = new Float32Array(size);
+  for (let pass = 0; pass < n; pass++) {
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const i = y * width + x;
+        let sum = current[i] ?? 0;
+        let count = 1;
+        forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+          const ni = ny * width + nx;
+          sum += current[ni] ?? 0;
+          count++;
+        });
+        next[i] = sum / count;
+      }
+    }
+    const tmp: Float32Array = current;
+    current = next;
+    next = tmp;
+  }
+
+  return current;
+}
+
+function chooseThresholdForLandCount(potential: Float32Array, landCount: number): number {
+  const size = potential.length;
+  const desired = Math.max(0, Math.min(size, landCount | 0)) | 0;
+  if (desired <= 0) return Infinity;
+  if (desired >= size) return -Infinity;
+  const values = Array.from(potential);
+  values.sort((a, b) => a - b);
+  const idx = Math.max(0, Math.min(values.length - 1, values.length - desired));
+  return values[idx] ?? 0;
+}
+
+function countLand(landMask: Uint8Array): number {
+  let n = 0;
+  for (let i = 0; i < landMask.length; i++) n += landMask[i] === 1 ? 1 : 0;
+  return n;
+}
+
+function computeComponents(width: number, height: number, landMask: Uint8Array): { id: Int32Array; sizes: number[] } {
+  const size = Math.max(0, (width | 0) * (height | 0));
+  const id = new Int32Array(size);
+  id.fill(-1);
+
+  const sizes: number[] = [];
+  const queue = new Int32Array(size);
+
+  let nextId = 0;
+  for (let start = 0; start < size; start++) {
+    if (landMask[start] !== 1) continue;
+    if (id[start] !== -1) continue;
+
+    let head = 0;
+    let tail = 0;
+    queue[tail++] = start;
+    id[start] = nextId;
+    let componentSize = 0;
+
+    while (head < tail) {
+      const idx = queue[head++]!;
+      componentSize++;
+      const y = (idx / width) | 0;
+      const x = idx - y * width;
+      forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+        const ni = ny * width + nx;
+        if (landMask[ni] !== 1) return;
+        if (id[ni] !== -1) return;
+        id[ni] = nextId;
+        queue[tail++] = ni;
+      });
+    }
+
+    sizes.push(componentSize);
+    nextId++;
+  }
+
+  return { id, sizes };
+}
+
+function pruneSpeckle(params: {
+  width: number;
+  height: number;
+  landMask: Uint8Array;
+  keepFraction: number;
+}): void {
+  const { width, height, landMask } = params;
+  const keepFraction = clamp01(params.keepFraction);
+  const totalLand = countLand(landMask);
+  if (totalLand <= 0) return;
+
+  const { id, sizes } = computeComponents(width, height, landMask);
+  const order = sizes
+    .map((size, idx) => ({ size, idx }))
+    .sort((a, b) => b.size - a.size)
+    .map((entry) => entry.idx);
+
+  const keepUntil = Math.max(1, Math.ceil(totalLand * keepFraction));
+  const keep = new Uint8Array(sizes.length);
+  let kept = 0;
+  for (const compId of order) {
+    keep[compId] = 1;
+    kept += sizes[compId] ?? 0;
+    if (kept >= keepUntil) break;
+  }
+
+  for (let i = 0; i < landMask.length; i++) {
+    if (landMask[i] !== 1) continue;
+    const comp = id[i] ?? -1;
+    if (comp < 0 || keep[comp] !== 1) landMask[i] = 0;
+  }
+}
+
+function fillToTarget(params: {
+  width: number;
+  height: number;
+  landMask: Uint8Array;
+  potential: Float32Array;
+  desiredLandCount: number;
+}): void {
+  const { width, height, landMask, potential } = params;
+  const desired = Math.max(0, Math.min(landMask.length, params.desiredLandCount | 0)) | 0;
+  let current = countLand(landMask);
+  if (current >= desired) return;
+
+  // Grow continents by annexing high-potential water adjacent to existing land.
+  // Recompute frontier in rounds to allow growth to continue outward.
+  for (let round = 0; round < 8 && current < desired; round++) {
+    const candidates: { idx: number; score: number }[] = [];
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const i = y * width + x;
+        if (landMask[i] === 1) continue;
+        let adjacentLand = 0;
+        forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+          if (adjacentLand) return;
+          const ni = ny * width + nx;
+          if (landMask[ni] === 1) adjacentLand = 1;
+        });
+        if (!adjacentLand) continue;
+        const base = potential[i] ?? 0;
+        candidates.push({ idx: i, score: base });
+      }
+    }
+    if (candidates.length === 0) break;
+    candidates.sort((a, b) => b.score - a.score);
+
+    for (const c of candidates) {
+      if (current >= desired) break;
+      if (landMask[c.idx] === 1) continue;
+      // Still must be adjacent to land at time-of-flip.
+      const y = (c.idx / width) | 0;
+      const x = c.idx - y * width;
+      let adjacentLand = 0;
+      forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+        if (adjacentLand) return;
+        const ni = ny * width + nx;
+        if (landMask[ni] === 1) adjacentLand = 1;
+      });
+      if (!adjacentLand) continue;
+      landMask[c.idx] = 1;
+      current++;
+    }
+  }
+}
+
+function computeDistanceToCoast(width: number, height: number, landMask: Uint8Array): Uint16Array {
+  const size = Math.max(0, (width | 0) * (height | 0));
+  const distanceToCoast = new Uint16Array(size);
+  distanceToCoast.fill(65535);
+  const queue = new Int32Array(size);
+  let head = 0;
+  let tail = 0;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = y * width + x;
+      const isLand = landMask[i] === 1;
+      let isCoastal = false;
+      forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+        if (isCoastal) return;
+        const ni = ny * width + nx;
+        if ((landMask[ni] === 1) !== isLand) isCoastal = true;
+      });
+      if (isCoastal) {
+        distanceToCoast[i] = 0;
+        queue[tail++] = i;
+      }
+    }
+  }
+
+  while (head < tail) {
+    const idx = queue[head++]!;
+    const y = (idx / width) | 0;
+    const x = idx - y * width;
+    const dist = distanceToCoast[idx] ?? 0;
+    forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+      const ni = ny * width + nx;
+      const next = (dist + 1) as number;
+      if ((distanceToCoast[ni] ?? 65535) <= next) return;
+      distanceToCoast[ni] = next;
+      queue[tail++] = ni;
+    });
+  }
+
+  return distanceToCoast;
+}
 
 export const defaultStrategy = createStrategy(ComputeLandmaskContract, "default", {
   run: (input, config) => {
     const { width, height } = input;
-    const { size, elevation } = validateLandmaskInputs(input);
+    const {
+      size,
+      elevation,
+      crustType,
+      crustBaseElevation,
+      crustAge,
+      provenanceOriginEra,
+      provenanceDriftDistance,
+    } = validateLandmaskInputs(input);
 
+    // Preserve hypsometry intent by targeting the land fraction implied by (elevation > seaLevel),
+    // but derive the actual landmask from a low-frequency continent potential grounded in Foundation truth.
+    const seaLevel = input.seaLevel;
+    let desiredLandCount = 0;
+    for (let i = 0; i < size; i++) {
+      desiredLandCount += (elevation[i] ?? 0) > seaLevel ? 1 : 0;
+    }
+    desiredLandCount = Math.max(1, Math.min(size - 1, desiredLandCount));
+
+    const potentialRaw = new Float32Array(size);
+    for (let i = 0; i < size; i++) {
+      const type01 = (crustType[i] ?? 0) === 1 ? 1 : 0;
+      const baseElev01 = clamp01(crustBaseElevation[i] ?? 0);
+      const drift01 = clamp01((provenanceDriftDistance[i] ?? 0) / 255);
+      const originEra01 = clamp01(1 - (provenanceOriginEra[i] ?? 0) / 7);
+      const stability01 = clamp01(0.6 * (1 - drift01) + 0.4 * originEra01);
+      const age01 = clamp01((crustAge[i] ?? 0) / 255);
+
+      // Continent potential: crust truth primary; provenance stability secondary.
+      const p = 0.48 * type01 + 0.28 * baseElev01 + 0.14 * stability01 + 0.1 * age01;
+      potentialRaw[i] = clamp01(p);
+    }
+
+    const coarse = buildCoarseAverage(width, height, potentialRaw, config.continentPotentialGrain);
+    const potential = blurHex(width, height, coarse, config.continentPotentialBlurSteps);
+
+    const threshold = chooseThresholdForLandCount(potential, desiredLandCount);
     const landMask = new Uint8Array(size);
     for (let i = 0; i < size; i++) {
-      landMask[i] = elevation[i] > input.seaLevel ? 1 : 0;
+      landMask[i] = (potential[i] ?? 0) >= threshold ? 1 : 0;
     }
 
-    applyBasinSeparation(width, height, landMask, config.basinSeparation);
+    pruneSpeckle({
+      width,
+      height,
+      landMask,
+      keepFraction: config.keepLandComponentFraction,
+    });
+    fillToTarget({ width, height, landMask, potential, desiredLandCount });
 
-    const distanceToCoast = new Uint16Array(size);
-    distanceToCoast.fill(65535);
-    const queue: number[] = [];
-
-    for (let y = 0; y < height; y++) {
-      for (let x = 0; x < width; x++) {
-        const i = y * width + x;
-        const isLand = landMask[i] === 1;
-        let isCoastal = false;
-        forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
-          if (isCoastal) return;
-          const ni = ny * width + nx;
-          if ((landMask[ni] === 1) !== isLand) isCoastal = true;
-        });
-        if (isCoastal) {
-          distanceToCoast[i] = 0;
-          queue.push(i);
-        }
-      }
-    }
-
-    while (queue.length > 0) {
-      const idx = queue.shift()!;
-      const y = (idx / width) | 0;
-      const x = idx - y * width;
-      const dist = distanceToCoast[idx];
-      forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
-        const ni = ny * width + nx;
-        if (distanceToCoast[ni] <= dist + 1) return;
-        distanceToCoast[ni] = dist + 1;
-        queue.push(ni);
-      });
-    }
-
+    const distanceToCoast = computeDistanceToCoast(width, height, landMask);
     return { landMask, distanceToCoast };
   },
 });

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
@@ -61,28 +61,9 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
       landmask: {
         strategy: "default",
         config: {
-          basinSeparation: {
-            enabled: false,
-            bandPairs: [],
-            baseSeparationTiles: 0,
-            boundaryClosenessMultiplier: 1.0,
-            maxPerRowDelta: 4,
-            minChannelWidth: 5,
-            channelJitter: 0,
-            respectSeaLanes: true,
-            edgeWest: {
-              enabled: false,
-              baseTiles: 0,
-              boundaryClosenessMultiplier: 1.0,
-              maxPerRowDelta: 2,
-            },
-            edgeEast: {
-              enabled: false,
-              baseTiles: 0,
-              boundaryClosenessMultiplier: 1.0,
-              maxPerRowDelta: 2,
-            },
-          },
+          continentPotentialGrain: 8,
+          continentPotentialBlurSteps: 3,
+          keepLandComponentFraction: 0.985,
         },
       },
     },

--- a/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
@@ -63,28 +63,9 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
       landmask: {
         strategy: "default",
         config: {
-          basinSeparation: {
-            enabled: false,
-            bandPairs: [],
-            baseSeparationTiles: 0,
-            boundaryClosenessMultiplier: 1.0,
-            maxPerRowDelta: 5,
-            minChannelWidth: 3,
-            channelJitter: 0,
-            respectSeaLanes: true,
-            edgeWest: {
-              enabled: false,
-              baseTiles: 0,
-              boundaryClosenessMultiplier: 1.0,
-              maxPerRowDelta: 2,
-            },
-            edgeEast: {
-              enabled: false,
-              baseTiles: 0,
-              boundaryClosenessMultiplier: 1.0,
-              maxPerRowDelta: 2,
-            },
-          },
+          continentPotentialGrain: 8,
+          continentPotentialBlurSteps: 3,
+          keepLandComponentFraction: 0.985,
         },
       },
     },

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
@@ -57,28 +57,9 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
       landmask: {
         strategy: "default",
         config: {
-          basinSeparation: {
-            enabled: false,
-            bandPairs: [],
-            baseSeparationTiles: 3,
-            boundaryClosenessMultiplier: 0.9,
-            maxPerRowDelta: 10,
-            minChannelWidth: 3,
-            channelJitter: 0,
-            respectSeaLanes: true,
-            edgeWest: {
-              enabled: false,
-              baseTiles: 3,
-              boundaryClosenessMultiplier: 0.5,
-              maxPerRowDelta: 1,
-            },
-            edgeEast: {
-              enabled: false,
-              baseTiles: 3,
-              boundaryClosenessMultiplier: 0.5,
-              maxPerRowDelta: 1,
-            },
-          },
+          continentPotentialGrain: 8,
+          continentPotentialBlurSteps: 3,
+          keepLandComponentFraction: 0.985,
         },
       },
     },

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -68,28 +68,9 @@
         "landmask": {
           "strategy": "default",
           "config": {
-            "basinSeparation": {
-              "enabled": false,
-              "bandPairs": [],
-              "baseSeparationTiles": 0,
-              "boundaryClosenessMultiplier": 1,
-              "maxPerRowDelta": 3,
-              "minChannelWidth": 4,
-              "channelJitter": 0,
-              "respectSeaLanes": true,
-              "edgeWest": {
-                "enabled": false,
-                "baseTiles": 0,
-                "boundaryClosenessMultiplier": 1,
-                "maxPerRowDelta": 2
-              },
-              "edgeEast": {
-                "enabled": false,
-                "baseTiles": 0,
-                "boundaryClosenessMultiplier": 1,
-                "maxPerRowDelta": 2
-              }
-            }
+            "continentPotentialGrain": 8,
+            "continentPotentialBlurSteps": 3,
+            "keepLandComponentFraction": 0.985
           }
         }
       },

--- a/mods/mod-swooper-maps/src/presets/standard/earthlike.json
+++ b/mods/mod-swooper-maps/src/presets/standard/earthlike.json
@@ -73,28 +73,9 @@
           "landmask": {
             "strategy": "default",
             "config": {
-              "basinSeparation": {
-                "enabled": false,
-                "bandPairs": [],
-                "baseSeparationTiles": 0,
-                "boundaryClosenessMultiplier": 1,
-                "maxPerRowDelta": 3,
-                "minChannelWidth": 4,
-                "channelJitter": 0,
-                "respectSeaLanes": true,
-                "edgeWest": {
-                  "enabled": false,
-                  "baseTiles": 0,
-                  "boundaryClosenessMultiplier": 1,
-                  "maxPerRowDelta": 2
-                },
-                "edgeEast": {
-                  "enabled": false,
-                  "baseTiles": 0,
-                  "boundaryClosenessMultiplier": 1,
-                  "maxPerRowDelta": 2
-                }
-              }
+              "continentPotentialGrain": 8,
+              "continentPotentialBlurSteps": 3,
+              "keepLandComponentFraction": 0.985
             }
           }
         },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.ts
@@ -230,6 +230,11 @@ export default createStep(LandmassPlatesStepContract, {
         elevation: baseTopography.elevation,
         seaLevel: seaLevel.seaLevel,
         boundaryCloseness: beltDrivers.boundaryCloseness,
+        crustType: crustTiles.type,
+        crustBaseElevation: crustTiles.baseElevation,
+        crustAge: crustTiles.age,
+        provenanceOriginEra: provenanceTiles.originEra,
+        provenanceDriftDistance: provenanceTiles.driftDistance,
       },
       config.landmask
     );

--- a/mods/mod-swooper-maps/test/morphology/m11-hypsometry-continental-fraction.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m11-hypsometry-continental-fraction.test.ts
@@ -152,14 +152,19 @@ describe("m11 hypsometry: continentalFraction does not collapse water coverage",
     ).seaLevel;
 
     const landmask = computeLandmask.run(
-      { width, height, elevation: baseTopography.elevation, seaLevel, boundaryCloseness: plates.boundaryCloseness },
       {
-        ...computeLandmask.defaultConfig,
-        config: {
-          ...computeLandmask.defaultConfig.config,
-          basinSeparation: { ...computeLandmask.defaultConfig.config.basinSeparation, enabled: false },
-        },
-      }
+        width,
+        height,
+        elevation: baseTopography.elevation,
+        seaLevel,
+        boundaryCloseness: plates.boundaryCloseness,
+        crustType,
+        crustBaseElevation,
+        crustAge: crustTiles.age,
+        provenanceOriginEra: projection.tectonicProvenanceTiles.originEra,
+        provenanceDriftDistance: projection.tectonicProvenanceTiles.driftDistance,
+      },
+      computeLandmask.defaultConfig
     );
 
     let land = 0;

--- a/mods/mod-swooper-maps/test/morphology/m12-mountains-present.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m12-mountains-present.test.ts
@@ -148,7 +148,18 @@ describe("m12 mountains: ridge planning produces some non-volcano mountains", ()
     ).seaLevel;
 
     const landmask = computeLandmask.run(
-      { width, height, elevation: baseTopography.elevation, seaLevel, boundaryCloseness: plates.boundaryCloseness },
+      {
+        width,
+        height,
+        elevation: baseTopography.elevation,
+        seaLevel,
+        boundaryCloseness: plates.boundaryCloseness,
+        crustType,
+        crustBaseElevation,
+        crustAge: crustTiles.age,
+        provenanceOriginEra: projection.tectonicProvenanceTiles.originEra,
+        provenanceDriftDistance: projection.tectonicProvenanceTiles.driftDistance,
+      },
       computeLandmask.defaultConfig
     );
 

--- a/mods/mod-swooper-maps/test/support/standard-config.ts
+++ b/mods/mod-swooper-maps/test/support/standard-config.ts
@@ -82,26 +82,10 @@ const foundationConfig = {
   knobs: { plateCount: 23, plateActivity: 0.5 },
 };
 
-const basinSeparationConfig = {
-  enabled: false,
-  baseSeparationTiles: 0,
-  boundaryClosenessMultiplier: 1.0,
-  maxPerRowDelta: 3,
-  minChannelWidth: 4,
-  channelJitter: 0,
-  respectSeaLanes: true,
-  edgeWest: {
-    enabled: false,
-    baseTiles: 0,
-    boundaryClosenessMultiplier: 1.0,
-    maxPerRowDelta: 2,
-  },
-  edgeEast: {
-    enabled: false,
-    baseTiles: 0,
-    boundaryClosenessMultiplier: 1.0,
-    maxPerRowDelta: 2,
-  },
+const landmaskConfig = {
+  continentPotentialGrain: 8,
+  continentPotentialBlurSteps: 3,
+  keepLandComponentFraction: 0.985,
 };
 
 const biomesConfig = {
@@ -389,7 +373,7 @@ export const standardConfig = {
         seaLevel: { strategy: "default", config: hypsometryConfig },
         landmask: {
           strategy: "default",
-          config: { basinSeparation: basinSeparationConfig },
+          config: landmaskConfig,
         },
       },
       "rugged-coasts": {


### PR DESCRIPTION
# Landmask Generation Grounded in Foundation Truth

This PR replaces the previous noise/threshold-based landmask generation with a physics-based approach derived from Foundation truth data. The new implementation:

- Derives landmask from a low-frequency continent potential computed from Foundation crust properties and provenance stability
- Maintains hypsometry's control over total land percentage while ensuring continent shapes and connectivity come from Foundation truth
- Removes `basinSeparation` which was causing hidden non-physics reclassification
- Introduces new configuration parameters for continent potential grain, blur steps, and component filtering

The changes significantly improve continent connectivity, reducing land components from hundreds to single digits while maintaining appropriate land percentages. This creates more realistic, continent-scale landmasses rather than fragmented islands.

Tests and configuration files have been updated to support the new approach, and all gates pass successfully.