### PR TITLE
fix(morphology): prevent erosion from reclassifying land/water

### DIFF
--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s21.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s21.md
@@ -1,0 +1,54 @@
+# s21 — Phase B erosion: no hidden land/water reclassification
+
+This slice constrains geomorphology so erosion sculpts elevation without silently fragmenting continents by re-thresholding land/water.
+
+## Change
+- Geomorphology no longer recomputes `landMask` from `elevation > seaLevel`.
+- Instead, it preserves the pre-erosion landmask (from `landmass-plates`) and clamps elevation/bathymetry to remain consistent with that classification.
+
+Anchor:
+- `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/steps/geomorphology.ts`
+
+## Gates / Tests
+```bash
+bun run --cwd mods/mod-swooper-maps check
+bun run --cwd mods/mod-swooper-maps test
+bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts
+```
+
+## Phase B Evidence (baseline vs s21 after)
+
+### Baseline dump (pre-s20 code)
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label phase-b-baseline-pre-s20
+```
+```json
+{"runId":"f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/phase-b-baseline-pre-s20/f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966"}
+```
+
+### After dump (s21)
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label phase-b-s21-after
+```
+```json
+{"runId":"65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/phase-b-s21-after/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac"}
+```
+
+### Compare analyze
+```bash
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <baselineOutputDir> <afterOutputDir>
+```
+Key metrics from compare:
+
+**Landmask (landmass-plates step)**
+- Baseline: `pctLand=0.3571`, `landComponents=433`, `largestLandFrac=0.2598`
+- After: `pctLand=0.3571`, `landComponents=4`, `largestLandFrac=0.5797`
+
+**Landmask (geomorphology step)**
+- Baseline: `pctLand=0.2296`, `landComponents=186`, `largestLandFrac=0.3562`
+- After: `pctLand=0.3571`, `landComponents=4`, `largestLandFrac=0.5797`
+
+Interpretation:
+- Erosion no longer reclassifies land/water (geomorphology landmask matches landmass-plates landmask).
+- Connectivity is preserved (no post-erosion re-shattering).

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -19,7 +19,7 @@ $MOD = mods/mod-swooper-maps
 - [x] **s10** Phase A Foundation truth normalization + degeneracy elimination: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
 - [x] **s11** Phase A review thread closures (1077/1078/1083): `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
 - [x] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
-- [ ] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
+- [x] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
 - [ ] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
 - [ ] **s40** Phase D observability enforcement (tiers + gate correctness): `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
 - [ ] **s90** Final legacy cleanup sweep + docs sweep: `agent-GOBI-PRR-s90-final-legacy-sweep-and-docs`
@@ -86,6 +86,9 @@ This section is intentionally short and pointer-only. Evidence payloads live und
 - s20: `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1153
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s20.md`
+- s21: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1154
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s21.md`
 
 ## Canonical Sources (Normative)
 


### PR DESCRIPTION
# Prevent erosion from reclassifying land/water boundaries

This PR modifies the geomorphology step to preserve the original land/water classification from the landmass-plates stage during erosion. Instead of recalculating the landmask based on elevation thresholds after erosion, we now:

1. Store the pre-erosion landmask
2. Clamp elevation values to ensure they remain consistent with the original land/water classification
3. Ensure land tiles stay above sea level and water tiles stay below sea level

This change prevents erosion from fragmenting continents by silently reclassifying land as water (or vice versa). Testing shows the approach successfully maintains the same landmask metrics between the landmass-plates and geomorphology steps, preserving continent connectivity.