### PR TITLE
fix(morphology): seed belt diffusion only from positive-intensity sources

### DIFF
--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s30.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s30.md
@@ -1,0 +1,109 @@
+# s30 — Phase C belts as modifiers (positive-intensity diffusion seeding)
+
+This slice enforces that belt diffusion is seeded only from **positive-intensity** boundary sources, so zero-intensity belt corridor tiles cannot become the nearest diffusion seed and silently suppress influence.
+
+## Change
+- `beltDistance` / `beltNearestSeed` distance field now seeds from `beltSeedMask = beltMask && intensityBlend>0`, not from `beltMask` directly.
+- Adds a regression test that constructs a belt corridor with zero-intensity corridor tiles and asserts diffusion influence is still present.
+
+Anchor:
+- `mods/mod-swooper-maps/src/domain/morphology/ops/compute-belt-drivers/deriveFromHistory.ts`
+
+Test:
+- `mods/mod-swooper-maps/test/morphology/belt-synthesis-history-provenance.test.ts`
+
+PR:
+- https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1155
+
+## Gates / Tests
+```bash
+bun run --cwd mods/mod-swooper-maps check
+bun run --cwd mods/mod-swooper-maps test
+bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts
+```
+
+Determinism excerpt:
+```text
+[diagnostic:baseline-balanced] foundation-plate-motion-diagnostics: Plate motion diagnostics below preferred quality/residual thresholds.
+[diagnostic:wrap-active] foundation-plate-motion-diagnostics: Plate motion diagnostics below preferred quality/residual thresholds.
+[diagnostic:compact-low-plates] foundation-plate-motion-diagnostics: Plate motion diagnostics below preferred quality/residual thresholds.
+(pass) pipeline determinism suite (M1) > produces identical fingerprints across canonical cases
+```
+
+## Evidence
+
+### Dump
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label s30-phase-c-belts-seeds
+```
+```json
+{"runId":"65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s30-phase-c-belts-seeds/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac"}
+```
+
+### Analyze
+```bash
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <outputDir>
+```
+```json
+{
+  "runA": {
+    "runId": "65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac",
+    "dir": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s30-phase-c-belts-seeds/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac",
+    "landmasks": [
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+        "stepIndex": 10,
+        "dataTypeKey": "morphology.topography.landMask",
+        "pctLand": 0.3570611778158948,
+        "landComponents": 4,
+        "largestLandFrac": 0.5796637309847879
+      },
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+        "stepIndex": 13,
+        "dataTypeKey": "morphology.topography.landMask",
+        "pctLand": 0.3570611778158948,
+        "landComponents": 4,
+        "largestLandFrac": 0.5796637309847879
+      }
+    ]
+  }
+}
+```
+
+### Spot-check layers
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey foundation.crustTiles.type
+```
+```json
+{
+  "layers": [
+    {
+      "dataTypeKey": "foundation.crustTiles.type",
+      "stats": { "min": 0, "max": 1 }
+    }
+  ]
+}
+```
+
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey morphology.topography.landMask
+```
+```json
+{
+  "layers": [
+    {
+      "dataTypeKey": "morphology.topography.landMask",
+      "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+      "stats": { "min": 0, "max": 1 }
+    },
+    {
+      "dataTypeKey": "morphology.topography.landMask",
+      "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+      "stats": { "min": 0, "max": 1 }
+    }
+  ]
+}
+```
+

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -20,7 +20,7 @@ $MOD = mods/mod-swooper-maps
 - [x] **s11** Phase A review thread closures (1077/1078/1083): `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
 - [x] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
 - [x] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
-- [ ] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
+- [x] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
 - [ ] **s40** Phase D observability enforcement (tiers + gate correctness): `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
 - [ ] **s90** Final legacy cleanup sweep + docs sweep: `agent-GOBI-PRR-s90-final-legacy-sweep-and-docs`
 
@@ -89,6 +89,9 @@ This section is intentionally short and pointer-only. Evidence payloads live und
 - s21: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1154
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s21.md`
+- s30: `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1155
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s30.md`
 
 ## Canonical Sources (Normative)
 

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-belt-drivers/deriveFromHistory.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-belt-drivers/deriveFromHistory.ts
@@ -286,8 +286,16 @@ export function deriveBeltDriversFromHistory(input: {
 
   const maxSigma = 1 + 3 * (maxAge / Math.max(1, maxAge));
   const maxDistance = Math.max(1, Math.round(5 * maxSigma * 1.2));
+  // Diffusion must be seeded only from positive-intensity sources; otherwise nearestSeed can land on a
+  // zero-intensity belt tile and silently suppress the entire region.
+  const beltSeedMask = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    if (beltMask[i] !== 1) continue;
+    if ((intensityBlend[i] ?? 0) <= 0) continue;
+    beltSeedMask[i] = 1;
+  }
   const { distance: beltDistance, nearestSeed: beltNearestSeed } = computeDistanceField(
-    beltMask,
+    beltSeedMask,
     width,
     height,
     maxDistance
@@ -340,4 +348,3 @@ export function deriveBeltDriversFromHistory(input: {
     beltComponents,
   } as const;
 }
-


### PR DESCRIPTION
Fix belt diffusion to only seed from positive-intensity sources

This PR addresses an issue where zero-intensity belt tiles could become diffusion seeds, potentially suppressing entire regions. The fix ensures that diffusion only occurs from belt tiles with positive intensity.

The change introduces a new `beltSeedMask` that filters out zero-intensity belt tiles before computing the distance field. This prevents the `nearestSeed` calculation from landing on zero-intensity tiles, which would silently suppress influence in the surrounding area.

A new test case verifies that zero-intensity belt tiles no longer suppress diffusion, ensuring that tiles near a belt corridor properly receive influence even when parts of the corridor have zero intensity.