### PR TITLE
fix(observability): ensure gates reflect runtime truth without capped metrics

### DIFF
--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s40.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s40.md
@@ -1,0 +1,100 @@
+# s40 — Phase D observability enforcement (1080/1092)
+
+This slice hardens observability surfaces as enforcement by making gates reflect runtime truth (no capped-metric artifacts; config evaluated from compiled recipe inputs).
+
+## Targets
+- #1080 (`PRRT_kwDOOOKvrc5swnAd`): `plateFitP90` reflects an uncapped residual distribution (normalization scale is not a cap).
+- #1092 (`PRRT_kwDOOOKvrc5swmzA`): morphology driver correlation invariant uses recipe-compiled (runtime) mountain config instead of static op defaults.
+
+PR:
+- https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1156
+
+## Gates / Tests
+```bash
+bun run --cwd mods/mod-swooper-maps check
+bun run --cwd mods/mod-swooper-maps test
+
+# Plan thread table commands
+bun run --cwd mods/mod-swooper-maps test test/foundation/m11-plate-motion.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/foundation-gates.test.ts
+bun run --cwd mods/mod-swooper-maps test test/morphology/m11-mountains-physics-anchored.test.ts
+
+# Cross-slice posture gates
+bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts
+```
+
+## Evidence
+
+### Dump
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label s40-phase-d-observability
+```
+```json
+{"runId":"65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s40-phase-d-observability/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac"}
+```
+
+### Analyze
+```bash
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <outputDir>
+```
+```json
+{
+  "runA": {
+    "runId": "65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac",
+    "dir": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s40-phase-d-observability/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac",
+    "landmasks": [
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+        "dataTypeKey": "morphology.topography.landMask",
+        "pctLand": 0.3570611778158948,
+        "landComponents": 4,
+        "largestLandFrac": 0.5796637309847879
+      },
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+        "dataTypeKey": "morphology.topography.landMask",
+        "pctLand": 0.3570611778158948,
+        "landComponents": 4,
+        "largestLandFrac": 0.5796637309847879
+      }
+    ]
+  }
+}
+```
+
+### Spot-check layers
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey foundation.crustTiles.type
+```
+```json
+{
+  "layers": [
+    {
+      "dataTypeKey": "foundation.crustTiles.type",
+      "stats": { "min": 0, "max": 1 }
+    }
+  ]
+}
+```
+
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey morphology.topography.landMask
+```
+```json
+{
+  "layers": [
+    {
+      "dataTypeKey": "morphology.topography.landMask",
+      "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+      "stats": { "min": 0, "max": 1 }
+    },
+    {
+      "dataTypeKey": "morphology.topography.landMask",
+      "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+      "stats": { "min": 0, "max": 1 }
+    }
+  ]
+}
+```
+

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -21,7 +21,7 @@ $MOD = mods/mod-swooper-maps
 - [x] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
 - [x] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
 - [x] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
-- [ ] **s40** Phase D observability enforcement (tiers + gate correctness): `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
+- [x] **s40** Phase D observability enforcement (tiers + gate correctness): `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
 - [ ] **s90** Final legacy cleanup sweep + docs sweep: `agent-GOBI-PRR-s90-final-legacy-sweep-and-docs`
 
 ### Slice s00 — Phase 0 (No-Shadow) + Plan Readiness (blocking)
@@ -92,6 +92,9 @@ This section is intentionally short and pointer-only. Evidence payloads live und
 - s30: `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1155
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s30.md`
+- s40: `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1156
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s40.md`
 
 ## Canonical Sources (Normative)
 


### PR DESCRIPTION
# Phase D Observability Enforcement

This PR implements two key improvements to observability surfaces:

1. Fixed `plateFitP90` calculation to properly reflect uncapped residual distribution. The residual normalization scale is now correctly treated as a normalization factor rather than a cap, allowing P90 values to exceed the normalization scale when warranted. This provides more accurate plate quality measurements.

2. Updated the morphology driver correlation invariant to use the recipe-compiled (runtime) mountain configuration instead of static operation defaults. This ensures that validation tests accurately reflect the actual runtime behavior of the system.

Added comprehensive tests to verify that P90 values can exceed the normalization scale when appropriate, ensuring that quality metrics accurately represent the true distribution of residuals.