### PR TITLE
refactor(math): use shared clampInt implementation

### DIFF
--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-mantle-potential/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-mantle-potential/index.ts
@@ -1,15 +1,9 @@
 import { createOp } from "@swooper/mapgen-core/authoring";
-import { clamp01, wrapDeltaPeriodic } from "@swooper/mapgen-core/lib/math";
+import { clamp01, clampInt, wrapDeltaPeriodic } from "@swooper/mapgen-core/lib/math";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 
 import { requireMesh } from "../../lib/require.js";
 import ComputeMantlePotentialContract from "./contract.js";
-
-function clampInt(value: number, bounds: { min: number; max?: number }): number {
-  const rounded = Math.round(value);
-  const max = bounds.max ?? Number.POSITIVE_INFINITY;
-  return Math.max(bounds.min, Math.min(max, rounded));
-}
 
 function distanceSqWrapped(ax: number, ay: number, bx: number, by: number, wrapWidth: number): number {
   const dx = wrapDeltaPeriodic(ax - bx, wrapWidth);
@@ -101,13 +95,13 @@ const computeMantlePotential = createOp(ComputeMantlePotentialContract, {
         const rng = createLabelRng(rngSeed);
         const cellCount = mesh.cellCount | 0;
 
-        const plumeCount = clampInt(config.plumeCount ?? 6, { min: 0, max: 32 });
-        const downwellingCount = clampInt(config.downwellingCount ?? 6, { min: 0, max: 32 });
+        const plumeCount = clampInt(config.plumeCount ?? 6, 0, 32);
+        const downwellingCount = clampInt(config.downwellingCount ?? 6, 0, 32);
         const plumeRadius = Math.max(1e-6, config.plumeRadius ?? 0.18);
         const downwellingRadius = Math.max(1e-6, config.downwellingRadius ?? 0.18);
         const plumeAmplitude = config.plumeAmplitude ?? 1.0;
         const downwellingAmplitude = config.downwellingAmplitude ?? -1.0;
-        const smoothingIterations = clampInt(config.smoothingIterations ?? 2, { min: 0, max: 4 });
+        const smoothingIterations = clampInt(config.smoothingIterations ?? 2, 0, 4);
         const smoothingAlpha = clamp01(config.smoothingAlpha ?? 0.35);
         const minSeparationScale = Math.max(0, config.minSeparationScale ?? 0.85);
 

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-motion/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-motion/index.ts
@@ -1,5 +1,5 @@
 import { createOp } from "@swooper/mapgen-core/authoring";
-import { clamp01, wrapDeltaPeriodic } from "@swooper/mapgen-core/lib/math";
+import { clamp01, clampInt, wrapDeltaPeriodic } from "@swooper/mapgen-core/lib/math";
 
 import { requireMantleForcing, requireMesh, requirePlateGraph } from "../../lib/require.js";
 import ComputePlateMotionContract from "./contract.js";
@@ -9,11 +9,6 @@ function clampByte(value: number): number {
   if (value <= 0) return 0;
   if (value >= 255) return 255;
   return Math.round(value) | 0;
-}
-
-function clampInt(value: number, bounds: { min: number; max: number }): number {
-  const rounded = Math.round(value);
-  return Math.max(bounds.min, Math.min(bounds.max, rounded));
 }
 
 const EPS = 1e-9;
@@ -42,8 +37,8 @@ const computePlateMotion = createOp(ComputePlateMotionContract, {
         const plateRadiusMin = Math.max(1e-6, config.plateRadiusMin ?? 1);
         const residualNormScale = Math.max(0.01, config.residualNormScale ?? 1);
         const p90NormScale = Math.max(0.01, config.p90NormScale ?? 1);
-        const histogramBins = clampInt(config.histogramBins ?? 32, { min: 8, max: 128 });
-        const smoothingSteps = clampInt(config.smoothingSteps ?? 0, { min: 0, max: 1 });
+        const histogramBins = clampInt(config.histogramBins ?? 32, 8, 128);
+        const smoothingSteps = clampInt(config.smoothingSteps ?? 0, 0, 1);
 
         let forcingU = mantleForcing.forcingU;
         let forcingV = mantleForcing.forcingV;

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
@@ -1,14 +1,10 @@
 import { createStrategy } from "@swooper/mapgen-core/authoring";
+import { clampInt } from "@swooper/mapgen-core/lib/math";
 
 import ComputeShelfMaskContract from "../contract.js";
 
 const BOUNDARY_CONVERGENT = 1;
 const BOUNDARY_TRANSFORM = 3;
-
-function clampInt(value: number, min: number, max: number): number {
-  if (!Number.isFinite(value)) return min;
-  return Math.max(min, Math.min(max, value));
-}
 
 function computeQuantileCutoff(values: Int16Array, count: number, q01: number): number {
   if (count <= 0) return 0;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts
@@ -1,4 +1,4 @@
-import { clamp01, lerp } from "@swooper/mapgen-core";
+import { clamp01, clampInt, lerp } from "@swooper/mapgen-core";
 import { Type, createStage, type Static } from "@swooper/mapgen-core/authoring";
 import {
   crust,
@@ -507,12 +507,6 @@ const FOUNDATION_STEP_IDS = [
 // trigger for the physics-first `advanced` surface (which includes `advanced.mesh`).
 const FOUNDATION_STUDIO_STEP_CONFIG_IDS = FOUNDATION_STEP_IDS.filter((id) => id.includes("-"));
 
-function clampInt(value: number, bounds: { min: number; max?: number }): number {
-  const rounded = Math.round(value);
-  const max = bounds.max ?? Number.POSITIVE_INFINITY;
-  return Math.max(bounds.min, Math.min(max, rounded));
-}
-
 export default createStage({
   id: "foundation",
   knobsSchema,
@@ -545,7 +539,8 @@ export default createStage({
     const defaults = FOUNDATION_PROFILE_DEFAULTS[profiles.resolutionProfile];
     const plateCount = clampInt(
       typeof knobs.plateCount === "number" ? knobs.plateCount : defaults.plateCount,
-      { min: 2, max: 256 }
+      2,
+      256
     );
 
     const lithosphereOverrides =
@@ -580,14 +575,18 @@ export default createStage({
           )
         : defaults.mantle.amplitudeScale;
     const mantlePlumeCount = clampInt(
-      typeof mantleOverrideValues.plumeCount === "number" ? mantleOverrideValues.plumeCount : defaults.mantle.plumeCount,
-      { min: 2, max: 16 }
+      typeof mantleOverrideValues.plumeCount === "number"
+        ? mantleOverrideValues.plumeCount
+        : defaults.mantle.plumeCount,
+      2,
+      16
     );
     const mantleDownwellingCount = clampInt(
       typeof mantleOverrideValues.downwellingCount === "number"
         ? mantleOverrideValues.downwellingCount
         : defaults.mantle.downwellingCount,
-      { min: 2, max: 16 }
+      2,
+      16
     );
 
     const budgetsOverrides =
@@ -599,7 +598,8 @@ export default createStage({
       typeof budgetsOverrideValues.eraCount === "number"
         ? budgetsOverrideValues.eraCount
         : COMMON_TECTONIC_HISTORY.eraWeights.length,
-      { min: 5, max: 8 }
+      5,
+      8
     );
     const eraWeights = deriveEraWeights({ eraCount });
     const driftStepsByEra = deriveDriftStepsByEra({ eraCount });
@@ -608,12 +608,18 @@ export default createStage({
       advanced && typeof advanced === "object" && "mesh" in advanced ? (advanced as { mesh?: Record<string, unknown> }).mesh ?? {} : {};
     const meshOverrideValues = meshOverrides as { cellsPerPlate?: unknown; relaxationSteps?: unknown };
     const meshCellsPerPlate = clampInt(
-      typeof meshOverrideValues.cellsPerPlate === "number" ? meshOverrideValues.cellsPerPlate : defaults.mesh.cellsPerPlate,
-      { min: 1, max: 32 }
+      typeof meshOverrideValues.cellsPerPlate === "number"
+        ? meshOverrideValues.cellsPerPlate
+        : defaults.mesh.cellsPerPlate,
+      1,
+      32
     );
     const meshRelaxationSteps = clampInt(
-      typeof meshOverrideValues.relaxationSteps === "number" ? meshOverrideValues.relaxationSteps : defaults.mesh.relaxationSteps,
-      { min: 0, max: 50 }
+      typeof meshOverrideValues.relaxationSteps === "number"
+        ? meshOverrideValues.relaxationSteps
+        : defaults.mesh.relaxationSteps,
+      0,
+      50
     );
 
     return {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts
@@ -1,4 +1,4 @@
-import { ctxRandom, ctxRandomLabel, defineVizMeta } from "@swooper/mapgen-core";
+import { clampInt, ctxRandom, ctxRandomLabel, defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { foundationArtifacts } from "../artifacts.js";
 import MeshStepContract from "./mesh.contract.js";
@@ -7,12 +7,6 @@ import type { FoundationPlateCountKnob } from "@mapgen/domain/foundation/shared/
 import { interleaveXY, segmentsFromMeshNeighbors } from "./viz.js";
 
 const GROUP_MESH = "Foundation / Mesh";
-
-function clampInt(value: number, bounds: { min: number; max?: number }): number {
-  const rounded = Math.round(value);
-  const max = bounds.max ?? Number.POSITIVE_INFINITY;
-  return Math.max(bounds.min, Math.min(max, rounded));
-}
 
 export default createStep(MeshStepContract, {
   artifacts: implementArtifacts([foundationArtifacts.mesh], {
@@ -29,15 +23,12 @@ export default createStep(MeshStepContract, {
       config.computeMesh.strategy === "default" && override !== undefined
         ? {
             ...config.computeMesh,
-            config: {
-              ...config.computeMesh.config,
-              plateCount: clampInt(override, {
-                min: 2,
-                max: 256,
-              }),
-            },
-          }
-        : config.computeMesh;
+	            config: {
+	              ...config.computeMesh.config,
+	              plateCount: clampInt(override, 2, 256),
+	            },
+	          }
+	        : config.computeMesh;
 
     return { ...config, computeMesh };
   },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.ts
@@ -1,4 +1,4 @@
-import { ctxRandom, ctxRandomLabel, defineVizMeta } from "@swooper/mapgen-core";
+import { clampInt, ctxRandom, ctxRandomLabel, defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { foundationArtifacts } from "../artifacts.js";
 import PlateGraphStepContract from "./plateGraph.contract.js";
@@ -7,12 +7,6 @@ import type { FoundationPlateCountKnob } from "@mapgen/domain/foundation/shared/
 import { interleaveXY, pointsFromPlateSeeds } from "./viz.js";
 
 const GROUP_PLATE_GRAPH = "Foundation / Plate Graph";
-
-function clampInt(value: number, bounds: { min: number; max?: number }): number {
-  const rounded = Math.round(value);
-  const max = bounds.max ?? Number.POSITIVE_INFINITY;
-  return Math.max(bounds.min, Math.min(max, rounded));
-}
 
 export default createStep(PlateGraphStepContract, {
   artifacts: implementArtifacts([foundationArtifacts.plateGraph], {
@@ -29,15 +23,12 @@ export default createStep(PlateGraphStepContract, {
       config.computePlateGraph.strategy === "default" && override !== undefined
         ? {
             ...config.computePlateGraph,
-            config: {
-              ...config.computePlateGraph.config,
-              plateCount: clampInt(override, {
-                min: 2,
-                max: 256,
-              }),
-            },
-          }
-        : config.computePlateGraph;
+	            config: {
+	              ...config.computePlateGraph.config,
+	              plateCount: clampInt(override, 2, 256),
+	            },
+	          }
+	        : config.computePlateGraph;
 
     return { ...config, computePlateGraph };
   },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts
@@ -15,7 +15,7 @@ import {
   resolvePlateActivityKinematicsMultiplier,
 } from "@mapgen/domain/foundation/shared/knob-multipliers.js";
 import type { FoundationPlateActivityKnob } from "@mapgen/domain/foundation/shared/knobs.js";
-import { clampFinite } from "@swooper/mapgen-core/lib/math";
+import { clampFinite, clampInt } from "@swooper/mapgen-core/lib/math";
 
 const GROUP_PLATES = "Foundation / Plates";
 const GROUP_CRUST_TILES = "Foundation / Crust Tiles";
@@ -23,12 +23,6 @@ const GROUP_TILE_MAP = "Foundation / Tile Mapping";
 const GROUP_TECTONIC_HISTORY_TILES = "Foundation / Tectonic History Tiles";
 const GROUP_TECTONIC_PROVENANCE_TILES = "Foundation / Tectonic Provenance Tiles";
 const TILE_SPACE_ID = "tile.hexOddR" as const;
-
-function clampInt(value: number, bounds: { min: number; max?: number }): number {
-  const rounded = Math.round(value);
-  const max = bounds.max ?? Number.POSITIVE_INFINITY;
-  return Math.max(bounds.min, Math.min(max, rounded));
-}
 
 export default createStep(ProjectionStepContract, {
   artifacts: implementArtifacts(
@@ -68,16 +62,17 @@ export default createStep(ProjectionStepContract, {
       config.computePlates.strategy === "default"
         ? {
             ...config.computePlates,
-            config: {
-              ...config.computePlates.config,
-              boundaryInfluenceDistance: clampInt(
-                (config.computePlates.config.boundaryInfluenceDistance ?? 0) + boundaryDelta,
-                { min: 1, max: 32 }
-              ),
-              movementScale: clampFinite((config.computePlates.config.movementScale ?? 0) * kinematicsMultiplier, 1, 200),
-              rotationScale: clampFinite((config.computePlates.config.rotationScale ?? 0) * kinematicsMultiplier, 1, 200),
-            },
-          }
+	            config: {
+	              ...config.computePlates.config,
+	              boundaryInfluenceDistance: clampInt(
+	                (config.computePlates.config.boundaryInfluenceDistance ?? 0) + boundaryDelta,
+	                1,
+	                32
+	              ),
+	              movementScale: clampFinite((config.computePlates.config.movementScale ?? 0) * kinematicsMultiplier, 1, 200),
+	              rotationScale: clampFinite((config.computePlates.config.rotationScale ?? 0) * kinematicsMultiplier, 1, 200),
+	            },
+	          }
         : config.computePlates;
 
     return { ...config, computePlates };

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/plotRivers.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/plotRivers.ts
@@ -6,6 +6,7 @@ import {
   snapshotEngineHeightfield,
 } from "@swooper/mapgen-core";
 import { createStep } from "@swooper/mapgen-core/authoring";
+import { clampInt } from "@swooper/mapgen-core/lib/math";
 import PlotRiversStepContract from "./plotRivers.contract.js";
 import {
   HYDROLOGY_RIVER_DENSITY_LENGTH_BOUNDS,
@@ -14,13 +15,6 @@ import type { HydrologyRiverDensityKnob } from "@mapgen/domain/hydrology/shared/
 
 const GROUP_MAP_HYDROLOGY = "Map / Hydrology (Engine)";
 const TILE_SPACE_ID = "tile.hexOddR" as const;
-
-function clampInt(value: number, min: number, max: number): number {
-  const int = Math.trunc(value);
-  if (int < min) return min;
-  if (int > max) return max;
-  return int;
-}
 
 export default createStep(PlotRiversStepContract, {
   normalize: (config, ctx) => {


### PR DESCRIPTION
# Refactor clampInt function to use a consistent signature

This PR refactors the `clampInt` function to use a consistent signature across the codebase. Instead of accepting an object with `min` and `max` properties, the function now accepts three parameters: `value`, `min`, and `max`.

The changes include:
- Removing local implementations of `clampInt` in various files
- Using the imported `clampInt` from `@swooper/mapgen-core/lib/math`
- Updating all function calls to use the new parameter format

This standardization improves code consistency and maintainability by using a single implementation of the function throughout the codebase.