### PR TITLE
fix(foundation): adjust crust evolution parameters for better continental emergence

### DIFF
--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts
@@ -22,7 +22,9 @@ const StrategySchema = Type.Object(
     ageToMaturity: Type.Number({
       minimum: 0,
       maximum: 2,
-      default: 0.8,
+      // Provenance "material age" is an important stability/strength signal, but it should not
+      // dominate continental emergence (oceanic crust does not become continental simply by aging).
+      default: 0.25,
       description: "How strongly provenance “material age” contributes to maturity (0..2).",
     }),
     /** How strongly rift/fracture signals suppress maturity (0..2). */
@@ -62,4 +64,3 @@ const ComputeCrustEvolutionContract = defineOp({
 
 export default ComputeCrustEvolutionContract;
 export type ComputeCrustEvolutionConfig = Static<typeof StrategySchema>;
-

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts
@@ -77,9 +77,12 @@ const computeCrustEvolution = createOp(ComputeCrustEvolutionContract, {
 
         const provenance = tectonicProvenance.provenance;
         // Contract allows these scalars in 0..2 (not normalized 0..1).
-        const ageToMaturity = clampFinite(config.ageToMaturity ?? 0.8, 0, 2, 0);
+        // Provenance "material age" is a stabilizing term, not the primary continent generator.
+        // If this is too large, most of the map matures into "continental" purely via age.
+        const ageToMaturity = clampFinite(config.ageToMaturity ?? 0.25, 0, 2, 0);
         const upliftToMaturity = clampFinite(config.upliftToMaturity ?? 1.0, 0, 2, 0);
-        const disruptionToMaturity = clampFinite(config.disruptionToMaturity ?? 0.9, 0, 2, 0);
+        // Disruption should strongly suppress maturity so boundary recycling prevents global saturation.
+        const disruptionToMaturity = clampFinite(config.disruptionToMaturity ?? 1.1, 0, 2, 0);
 
         for (let i = 0; i < cellCount; i++) {
           const initThickness = crustInit.thickness[i] ?? 0.25;

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts
@@ -35,11 +35,13 @@ const EMISSION_DECAY_MUL = {
 // Reset thresholds must be calibrated to the actually-emitted driver magnitudes.
 // If these are too high relative to emitted fields, provenance never resets and the
 // downstream crust truth degenerates (uniformly ancient, uniformly "continental").
-const RIFT_RESET_THRESHOLD_MIN = 35;
-const ARC_RESET_THRESHOLD_MIN = 45;
-const HOTSPOT_RESET_THRESHOLD_MIN = 55;
+// Note: these minimums must remain low. Emitted potentials are often in the ~0-30 range
+// after per-era weighting + diffusion, so high floors can fully disable resets.
+const RIFT_RESET_THRESHOLD_MIN = 1;
+const ARC_RESET_THRESHOLD_MIN = 1;
+const HOTSPOT_RESET_THRESHOLD_MIN = 1;
 
-const RIFT_RESET_THRESHOLD_FRAC_OF_MAX = 0.7;
+const RIFT_RESET_THRESHOLD_FRAC_OF_MAX = 0.6;
 const ARC_RESET_THRESHOLD_FRAC_OF_MAX = 0.75;
 const HOTSPOT_RESET_THRESHOLD_FRAC_OF_MAX = 0.8;
 const ERA_COUNT_MIN = 5;


### PR DESCRIPTION
# Improve Continental Crust Evolution and Sea Level Calculation

This PR makes several key adjustments to improve the realism and stability of continental formation and sea level calculation:

1. Reduced the default `ageToMaturity` parameter from 0.8 to 0.25 to prevent oceanic crust from unrealistically transforming into continental crust simply by aging.

2. Increased the `disruptionToMaturity` parameter from 0.9 to 1.1 to ensure boundary recycling prevents global continental saturation.

3. Lowered tectonic reset thresholds to ensure proper provenance resets:
   - Reduced minimum thresholds for rift, arc, and hotspot resets from 35-55 to 1
   - Adjusted rift reset threshold fraction from 0.7 to 0.6

4. Improved sea level calculation algorithm:
   - Added guardrails to prevent extreme all-water or all-land outcomes
   - Implemented a bounded window search around the initial hypsometry target
   - Added a maximum target adjustment percentage (20%) and penalty weighting
   - Changed from a greedy local search to a more robust scanning approach

These changes ensure more realistic continental formation patterns and better sea level stability when constraints are difficult to satisfy.