### PR TITLE
fix(morphology): improve landmask generation with hex-aligned binning

### DIFF
--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts
@@ -3,13 +3,13 @@ import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authorin
 const LandmaskConfigSchema = Type.Object(
   {
     continentPotentialGrain: Type.Integer({
-      default: 8,
+      default: 5,
       minimum: 1,
       maximum: 64,
-      description: "Coarse grain (tile block size) used to low-pass continent potential before thresholding.",
+      description: "Coarse grain (hex bin size) used to low-pass continent potential before thresholding.",
     }),
     continentPotentialBlurSteps: Type.Integer({
-      default: 3,
+      default: 5,
       minimum: 0,
       maximum: 16,
       description: "Number of hex-neighborhood blur passes applied after coarse-grain averaging.",

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -68,8 +68,8 @@
         "landmask": {
           "strategy": "default",
           "config": {
-            "continentPotentialGrain": 8,
-            "continentPotentialBlurSteps": 3,
+            "continentPotentialGrain": 5,
+            "continentPotentialBlurSteps": 5,
             "keepLandComponentFraction": 0.985
           }
         }


### PR DESCRIPTION
# Improve landmask generation with hex-aligned binning

This PR enhances the landmask generation algorithm by replacing the rectangular grid-based coarse averaging with a hex-aligned binning approach. This change better aligns with the underlying hex grid topology and eliminates rectangular artifacts in the generated landmasses.

Key changes:
- Replaced `buildCoarseAverage` with `buildCoarseAverageHexOddQ` which bins values using axial coordinates derived from odd-q offset coordinates
- Updated default parameters for improved results:
  - Reduced `continentPotentialGrain` from 8 to 5
  - Increased `continentPotentialBlurSteps` from 3 to 5
- Updated parameter descriptions to reflect the hex-based approach

These changes result in more natural-looking landmasses with better alignment to the hex grid structure.