### PR TITLE
feat(morphology): increase uplift effects for more pronounced mountain ranges

### DIFF
--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts
@@ -17,7 +17,7 @@ const EVENT_TYPE = {
 // Belt-field influence is a runtime contract ("authored values must be honored"),
 // but we preserve the old channel shape by scaling around the previous defaults.
 const EMISSION_RADIUS_MUL = {
-  uplift: 1.5,
+  uplift: 2.0,
   rift: 1.25,
   shear: 1.0,
   volcanism: 0.875,
@@ -25,7 +25,7 @@ const EMISSION_RADIUS_MUL = {
 } as const;
 
 const EMISSION_DECAY_MUL = {
-  uplift: 0.45 / 0.55,
+  uplift: 0.30 / 0.55,
   rift: 1.0,
   shear: 0.7 / 0.55,
   volcanism: 0.85 / 0.55,

--- a/mods/mod-swooper-maps/src/domain/morphology/config.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/config.ts
@@ -501,7 +501,7 @@ export const ReliefConfigSchema = Type.Object(
         }),
         boundaryArcWeight: Type.Number({
           description: "Multiplier for convergent boundary uplift arcs.",
-          default: 0.35,
+          default: 0.55,
           minimum: 0,
         }),
         boundaryArcNoiseWeight: Type.Number({

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-base-topography/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-base-topography/rules/index.ts
@@ -65,7 +65,7 @@ export function computeElevationRaw(params: {
   const crust01 = clamp(crustBaseElevation01, 0, 1);
   const base = config.oceanicHeight + reliefSpan * crust01;
   const boundaryBoost = config.boundaryBias * closenessNorm;
-  const upliftEffect = upliftBlend * reliefSpan * 0.25;
+  const upliftEffect = upliftBlend * reliefSpan * 0.45;
   const riftPenalty = riftNorm * reliefSpan * 0.15;
   return base + upliftEffect + boundaryBoost - riftPenalty + noise + arcNoise * closenessNorm;
 }

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -48,7 +48,7 @@
             "continentalHeight": 0.62,
             "oceanicHeight": -0.75,
             "tectonics": {
-              "boundaryArcWeight": 0.32,
+              "boundaryArcWeight": 0.55,
               "boundaryArcNoiseWeight": 0.26,
               "interiorNoiseWeight": 0.5,
               "fractalGrain": 3


### PR DESCRIPTION
# Enhance Mountain Ranges in Tectonic Simulations

This PR adjusts several parameters to create more pronounced mountain ranges along tectonic boundaries:

- Increased uplift emission radius multiplier from 1.5 to 2.0
- Reduced uplift emission decay multiplier from 0.45/0.55 to 0.30/0.55
- Increased boundary arc weight from 0.35 to 0.55 in the relief configuration
- Boosted uplift effect on elevation from 0.25 to 0.45
- Updated the earthlike map configuration to match the new boundary arc weight (0.55)

These changes will result in more dramatic mountain ranges at convergent plate boundaries, creating more realistic topographical features in generated maps.