### PR TITLE
fix(morphology): reduce MIN_BELT_LENGTH from 6 to 3

### DIFF
--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-belt-drivers/deriveFromHistory.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-belt-drivers/deriveFromHistory.ts
@@ -9,7 +9,7 @@ import type {
 import type { BeltComponentSummary, BeltDriverOutputs } from "./types.js";
 
 const GAP_FILL_DISTANCE = 2;
-const MIN_BELT_LENGTH = 6;
+const MIN_BELT_LENGTH = 3;
 
 function clampByte(value: number): number {
   return Math.max(0, Math.min(255, Math.round(value))) | 0;


### PR DESCRIPTION
Reduced the minimum belt length from 6 to 3 in the belt driver computation logic. This change allows for shorter belt segments to be recognized and processed by the system.