### PR TITLE
docs(pipeline-realism): add PRR evidence bundle with execution logs

### DIFF
--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/README.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/README.md
@@ -5,6 +5,7 @@ This directory is the durable, repo-tracked evidence bundle for the Pipeline Rea
 Evidence files (in stack order):
 - `s00.md`: Phase 0 no-shadow + execution runbook readiness
 - `s10.md`: Phase A (Foundation truth non-degenerate)
+- `s11.md`: Phase A review thread closures (1077/1078/1083)
 - `s20.md`: Phase B (landmask grounded in crust truth) + numeric gate
 - `s21.md`: Phase B erosion connectivity (no hidden reclassification)
 - `s30.md`: Phase C belts as modifiers (positive-intensity diffusion seeding)

--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/README.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/README.md
@@ -11,3 +11,4 @@ Evidence files (in stack order):
 - `s30.md`: Phase C belts as modifiers (positive-intensity diffusion seeding)
 - `s40.md`: Phase D observability enforcement
 - `s90.md`: Final legacy + docs cleanup sweep
+- `s91.md`: Follow-up: rift-driven craton growth landmask + foundation mesh resolution controls

--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/README.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/README.md
@@ -1,0 +1,12 @@
+# PRR Evidence Index (agent-GOBI)
+
+This directory is the durable, repo-tracked evidence bundle for the Pipeline Realism remediation stack.
+
+Evidence files (in stack order):
+- `s00.md`: Phase 0 no-shadow + execution runbook readiness
+- `s10.md`: Phase A (Foundation truth non-degenerate)
+- `s20.md`: Phase B (landmask grounded in crust truth) + numeric gate
+- `s21.md`: Phase B erosion connectivity (no hidden reclassification)
+- `s30.md`: Phase C belts as modifiers (positive-intensity diffusion seeding)
+- `s40.md`: Phase D observability enforcement
+- `s90.md`: Final legacy + docs cleanup sweep

--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s00.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s00.md
@@ -1,0 +1,31 @@
+# Evidence: PRR s00 (Phase 0 no-shadow + plan readiness)
+
+Branch: `agent-GOBI-PRR-s00-phase-0-preflight-no-shadow-and-plan-readiness`
+
+## Phase 0 gate
+
+- `bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts`: PASS
+
+## Determinism suite
+
+- `bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts`: PASS
+  - Diagnostics emitted (non-fatal): plate motion diagnostics below preferred residual thresholds for cases
+
+## Dump-first evidence bundle (probe `106 66 1337`)
+
+### diag:dump
+
+```json
+{"runId":"f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s00-phase-0/f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966"}
+```
+
+### diag:analyze (runA)
+
+Key landmask metrics (from the JSON output):
+- `landmass-plates`: `pctLand=0.3616`, `landComponents=434`, `largestLandFrac=0.2565`
+- `geomorphology`: `pctLand=0.2326`, `landComponents=183`, `largestLandFrac=0.3516`
+
+### diag:list spot-checks
+
+- `foundation.crustTiles.type`: `stats.min=1`, `stats.max=1` (degenerate; Phase A target)
+- `morphology.topography.landMask`: non-degenerate for both steps (`stats.min=0`, `stats.max=1`)

--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s10.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s10.md
@@ -1,0 +1,36 @@
+# Evidence: PRR s10 (Phase A core: non-degenerate crust truth + provenance resets)
+
+Branch: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
+
+## Gates
+
+- Phase 0 no-shadow: `bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts` (PASS)
+- Determinism suite: `bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts` (PASS)
+- Foundation gates: `bun run --cwd mods/mod-swooper-maps test test/pipeline/foundation-gates.test.ts` (PASS)
+
+## What Changed (Load-Bearing)
+
+- Calibrated provenance reset thresholds per-era to emitted driver magnitudes in:
+  - `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts`
+- Outcome: provenance `originEra` is no longer uniform, crust `age` is no longer saturated, and derived `crustTiles.type` is no longer uniform.
+
+## Dump-first evidence bundle (probe `106 66 1337`)
+
+### diag:dump
+
+```json
+{"runId":"f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s10-phase-a-core-2/f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966"}
+```
+
+### diag:analyze
+
+Landmask metrics (unchanged intent in Phase A; recorded for continuity):
+- `landmass-plates`: `pctLand=0.3609`, `landComponents=432`, `largestLandFrac=0.2570`
+- `geomorphology`: `pctLand=0.2321`, `landComponents=184`, `largestLandFrac=0.3522`
+
+### diag:list spot-checks (degeneracy eliminated)
+
+- `foundation.provenance.originEra`: `stats.min=0`, `stats.max=2`
+- `foundation.crustTiles.age`: `stats.min=123`, `stats.max=254`
+- `foundation.crustTiles.type`: `stats.min=0`, `stats.max=1`
+

--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s11.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s11.md
@@ -1,0 +1,142 @@
+# s11 — Phase A review thread closures (1077/1078/1083)
+
+This slice exists to close Phase A semantics threads with concrete, reproducible evidence (tests + probes + run IDs).
+
+## Change (1083 config consumption)
+Wired `beltInfluenceDistance` + `beltDecay` from runtime config into `compute-tectonic-history` belt-field diffusion footprint (radius/decay), preserving prior default behavior shape via per-channel multipliers.
+
+- Code: `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts`
+
+## Gates / Tests
+
+### Typecheck
+```bash
+bun run --cwd mods/mod-swooper-maps check
+```
+
+### Phase 0 guard (still green)
+```bash
+bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts
+```
+
+### Determinism suite (M1)
+```bash
+bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts
+```
+Output excerpt:
+```text
+[diagnostic:baseline-balanced] foundation-plate-motion-diagnostics: Plate motion diagnostics below preferred quality/residual thresholds.
+[diagnostic:wrap-active] foundation-plate-motion-diagnostics: Plate motion diagnostics below preferred quality/residual thresholds.
+[diagnostic:compact-low-plates] foundation-plate-motion-diagnostics: Plate motion diagnostics below preferred quality/residual thresholds.
+(pass) pipeline determinism suite (M1) > produces identical fingerprints across canonical cases
+```
+
+### Foundation gates (still green)
+```bash
+bun run --cwd mods/mod-swooper-maps test test/pipeline/foundation-gates.test.ts
+```
+
+### Thread-scoped tests
+```bash
+bun run --cwd mods/mod-swooper-maps test test/m11-config-knobs-and-presets.test.ts
+bun run --cwd mods/mod-swooper-maps test test/foundation/m11-plate-graph-resistance.test.ts
+bun run --cwd mods/mod-swooper-maps test test/foundation/m11-tectonic-events.test.ts
+bun run --cwd mods/mod-swooper-maps test test/morphology/belt-synthesis-history-provenance.test.ts
+```
+
+## Thread Evidence
+
+### #1077 — `PRRT_kwDOOOKvrc5swnXi` (plateCount knob semantics)
+Expectation: when `foundation.knobs.plateCount` is omitted, compile-time plate count inherits selected profile baseline; when explicitly provided, the knob value wins.
+
+Test:
+```bash
+bun run --cwd mods/mod-swooper-maps test test/m11-config-knobs-and-presets.test.ts
+```
+
+Probe dumps:
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label phase-a-1077-profile-default --override '{"foundation":{"profiles":{"resolutionProfile":"coarse"},"knobs":{}}}'
+# => {"runId":"76877bde651358fe862e6854b7133574ff4028e280111b7ea0f17359e620ee07","outputDir":".../dist/visualization/phase-a-1077-profile-default/76877bde651358fe862e6854b7133574ff4028e280111b7ea0f17359e620ee07"}
+
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label phase-a-1077-explicit-override --override '{"foundation":{"profiles":{"resolutionProfile":"coarse"},"knobs":{"plateCount":31}}}'
+# => {"runId":"69892d825a6290e4f8da3bfc015b44ca81b8aaa79560186f63eb6c1607340da9","outputDir":".../dist/visualization/phase-a-1077-explicit-override/69892d825a6290e4f8da3bfc015b44ca81b8aaa79560186f63eb6c1607340da9"}
+```
+
+Full JSON outputs:
+- `phase-a-1077-profile-default`
+```json
+{"runId":"76877bde651358fe862e6854b7133574ff4028e280111b7ea0f17359e620ee07","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/phase-a-1077-profile-default/76877bde651358fe862e6854b7133574ff4028e280111b7ea0f17359e620ee07"}
+```
+- `phase-a-1077-explicit-override`
+```json
+{"runId":"69892d825a6290e4f8da3bfc015b44ca81b8aaa79560186f63eb6c1607340da9","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/phase-a-1077-explicit-override/69892d825a6290e4f8da3bfc015b44ca81b8aaa79560186f63eb6c1607340da9"}
+```
+
+### #1078 — `PRRT_kwDOOOKvrc5swoFn` (lithosphere scalars are true 0..1 levers)
+Expectation: `yieldStrength01` / `mantleCoupling01` are consumed as direct 0..1 levers (no narrow remap preventing true weakening at 0).
+
+Tests:
+```bash
+bun run --cwd mods/mod-swooper-maps test test/m11-config-knobs-and-presets.test.ts
+bun run --cwd mods/mod-swooper-maps test test/foundation/m11-plate-graph-resistance.test.ts
+```
+
+Code probe:
+```bash
+rg -n "yieldStrength01|mantleCoupling01|\\*\\s*0\\.3|\\*\\s*0\\.2" mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust/index.ts
+```
+Output:
+```text
+68:        const yieldStrength = clamp01(config.yieldStrength01 ?? 0.55);
+69:        const mantleCoupling = clamp01(config.mantleCoupling01 ?? 0.6);
+```
+
+### #1083 — `PRRT_kwDOOOKvrc5swl4c` (beltInfluenceDistance + beltDecay honored)
+Expectation: `beltInfluenceDistance` / `beltDecay` are consumed by runtime belt-field generation; authored values are not ignored/replaced by fixed constants.
+
+Tests:
+```bash
+bun run --cwd mods/mod-swooper-maps test test/foundation/m11-tectonic-events.test.ts
+bun run --cwd mods/mod-swooper-maps test test/morphology/belt-synthesis-history-provenance.test.ts
+```
+
+Code probe:
+```bash
+rg -n "beltInfluenceDistance|beltDecay|EMISSION_RADIUS|EMISSION_DECAY" mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts
+```
+Output excerpt:
+```text
+140:function deriveEmissionParams(config: { beltInfluenceDistance: number; beltDecay: number }): EmissionParams {
+141:  const baseRadius = ... config.beltInfluenceDistance ...
+142:  const baseDecay = ... config.beltDecay ...
+746:          beltInfluenceDistance: config.beltInfluenceDistance,
+747:          beltDecay: config.beltDecay,
+```
+
+## Slice Evidence Bundle (canonical probe)
+
+### Dump
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label s11-phase-a-thread-closures
+```
+```json
+{"runId":"f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s11-phase-a-thread-closures/f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966"}
+```
+
+### Analyze
+```bash
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <outputDir>
+```
+(See JSON output in terminal; key landmask summary is embedded in the analyze payload.)
+
+### Spot-check layers
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey foundation.crustTiles.type
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey morphology.topography.landMask
+```
+Selected excerpts:
+- `foundation.crustTiles.type` stats: `min=0`, `max=1`
+- `morphology.topography.landMask` present at:
+  - `...morphology-coasts.landmass-plates...`
+  - `...morphology-erosion.geomorphology...`

--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s20.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s20.md
@@ -1,0 +1,76 @@
+# s20 — Phase B: Landmask grounded in Foundation truth (numeric gate)
+
+This slice hard-cuts the Morphology landmask to be derived from Foundation truth, eliminating noise/threshold-first landmasks.
+
+## Behavior Change (the point)
+- Landmask is now derived from a **low-frequency continent potential** computed from:
+  - Foundation crust truth (`crustType`, `crustBaseElevation`, `crustAge`)
+  - Foundation provenance stability (`originEra`, `driftDistance`)
+- Hypsometry still sets *how much* land (via sea level), but **continent shape/connectivity** comes from Foundation truth.
+- Removed `basinSeparation` (a plate-band carving surface) to avoid hidden non-physics reclassification.
+
+## Code
+- `mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts`
+- `mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/strategies/default.ts`
+- `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.ts`
+- Config/schema updates:
+  - `mods/mod-swooper-maps/src/presets/standard/earthlike.json`
+  - `mods/mod-swooper-maps/src/maps/configs/*.config.*`
+
+## Gates / Tests
+```bash
+bun run --cwd mods/mod-swooper-maps check
+bun run --cwd mods/mod-swooper-maps test
+bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/foundation-gates.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts
+```
+
+## Phase B Evidence (baseline vs after)
+
+### Baseline dump
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label phase-b-baseline
+```
+```json
+{"runId":"f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/phase-b-baseline/f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966"}
+```
+
+### After dump
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label phase-b-after
+```
+```json
+{"runId":"65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/phase-b-after/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac"}
+```
+
+### Compare analyze
+```bash
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <baselineOutputDir> <afterOutputDir>
+```
+Key metrics from compare:
+
+**Landmask (landmass-plates step)**
+- Baseline: `pctLand=0.3571`, `landComponents=433`, `largestLandFrac=0.2598`
+- After: `pctLand=0.3571`, `landComponents=4`, `largestLandFrac=0.5797`
+
+**Landmask (geomorphology step)**
+- Baseline: `pctLand=0.2296`, `landComponents=186`, `largestLandFrac=0.3562`
+- After: `pctLand=0.3425`, `landComponents=4`, `largestLandFrac=0.5826`
+
+Interpretation:
+- Connectivity is now continent-scale (components collapse from hundreds to single digits).
+- Largest land component share increases materially.
+- Land fraction remains within sane bounds and still respects sea-level target.
+
+### Spot-check layers
+After run:
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <afterOutputDir> --dataTypeKey foundation.crustTiles.type
+bun run --cwd mods/mod-swooper-maps diag:list -- <afterOutputDir> --dataTypeKey morphology.topography.landMask
+```
+Selected excerpts:
+- `foundation.crustTiles.type` stats: `min=0`, `max=1`
+- `morphology.topography.landMask` present at:
+  - `...morphology-coasts.landmass-plates...`
+  - `...morphology-erosion.geomorphology...`

--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s21.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s21.md
@@ -1,0 +1,54 @@
+# s21 — Phase B erosion: no hidden land/water reclassification
+
+This slice constrains geomorphology so erosion sculpts elevation without silently fragmenting continents by re-thresholding land/water.
+
+## Change
+- Geomorphology no longer recomputes `landMask` from `elevation > seaLevel`.
+- Instead, it preserves the pre-erosion landmask (from `landmass-plates`) and clamps elevation/bathymetry to remain consistent with that classification.
+
+Anchor:
+- `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/steps/geomorphology.ts`
+
+## Gates / Tests
+```bash
+bun run --cwd mods/mod-swooper-maps check
+bun run --cwd mods/mod-swooper-maps test
+bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts
+```
+
+## Phase B Evidence (baseline vs s21 after)
+
+### Baseline dump (pre-s20 code)
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label phase-b-baseline-pre-s20
+```
+```json
+{"runId":"f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/phase-b-baseline-pre-s20/f38bd16daa5fd570b1bde65c8fb71aff831aa5f5f6472050daa32225807fe966"}
+```
+
+### After dump (s21)
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label phase-b-s21-after
+```
+```json
+{"runId":"65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/phase-b-s21-after/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac"}
+```
+
+### Compare analyze
+```bash
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <baselineOutputDir> <afterOutputDir>
+```
+Key metrics from compare:
+
+**Landmask (landmass-plates step)**
+- Baseline: `pctLand=0.3571`, `landComponents=433`, `largestLandFrac=0.2598`
+- After: `pctLand=0.3571`, `landComponents=4`, `largestLandFrac=0.5797`
+
+**Landmask (geomorphology step)**
+- Baseline: `pctLand=0.2296`, `landComponents=186`, `largestLandFrac=0.3562`
+- After: `pctLand=0.3571`, `landComponents=4`, `largestLandFrac=0.5797`
+
+Interpretation:
+- Erosion no longer reclassifies land/water (geomorphology landmask matches landmass-plates landmask).
+- Connectivity is preserved (no post-erosion re-shattering).

--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s30.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s30.md
@@ -1,0 +1,109 @@
+# s30 — Phase C belts as modifiers (positive-intensity diffusion seeding)
+
+This slice enforces that belt diffusion is seeded only from **positive-intensity** boundary sources, so zero-intensity belt corridor tiles cannot become the nearest diffusion seed and silently suppress influence.
+
+## Change
+- `beltDistance` / `beltNearestSeed` distance field now seeds from `beltSeedMask = beltMask && intensityBlend>0`, not from `beltMask` directly.
+- Adds a regression test that constructs a belt corridor with zero-intensity corridor tiles and asserts diffusion influence is still present.
+
+Anchor:
+- `mods/mod-swooper-maps/src/domain/morphology/ops/compute-belt-drivers/deriveFromHistory.ts`
+
+Test:
+- `mods/mod-swooper-maps/test/morphology/belt-synthesis-history-provenance.test.ts`
+
+PR:
+- https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1155
+
+## Gates / Tests
+```bash
+bun run --cwd mods/mod-swooper-maps check
+bun run --cwd mods/mod-swooper-maps test
+bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts
+```
+
+Determinism excerpt:
+```text
+[diagnostic:baseline-balanced] foundation-plate-motion-diagnostics: Plate motion diagnostics below preferred quality/residual thresholds.
+[diagnostic:wrap-active] foundation-plate-motion-diagnostics: Plate motion diagnostics below preferred quality/residual thresholds.
+[diagnostic:compact-low-plates] foundation-plate-motion-diagnostics: Plate motion diagnostics below preferred quality/residual thresholds.
+(pass) pipeline determinism suite (M1) > produces identical fingerprints across canonical cases
+```
+
+## Evidence
+
+### Dump
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label s30-phase-c-belts-seeds
+```
+```json
+{"runId":"65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s30-phase-c-belts-seeds/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac"}
+```
+
+### Analyze
+```bash
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <outputDir>
+```
+```json
+{
+  "runA": {
+    "runId": "65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac",
+    "dir": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s30-phase-c-belts-seeds/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac",
+    "landmasks": [
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+        "stepIndex": 10,
+        "dataTypeKey": "morphology.topography.landMask",
+        "pctLand": 0.3570611778158948,
+        "landComponents": 4,
+        "largestLandFrac": 0.5796637309847879
+      },
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+        "stepIndex": 13,
+        "dataTypeKey": "morphology.topography.landMask",
+        "pctLand": 0.3570611778158948,
+        "landComponents": 4,
+        "largestLandFrac": 0.5796637309847879
+      }
+    ]
+  }
+}
+```
+
+### Spot-check layers
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey foundation.crustTiles.type
+```
+```json
+{
+  "layers": [
+    {
+      "dataTypeKey": "foundation.crustTiles.type",
+      "stats": { "min": 0, "max": 1 }
+    }
+  ]
+}
+```
+
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey morphology.topography.landMask
+```
+```json
+{
+  "layers": [
+    {
+      "dataTypeKey": "morphology.topography.landMask",
+      "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+      "stats": { "min": 0, "max": 1 }
+    },
+    {
+      "dataTypeKey": "morphology.topography.landMask",
+      "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+      "stats": { "min": 0, "max": 1 }
+    }
+  ]
+}
+```
+

--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s40.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s40.md
@@ -1,0 +1,100 @@
+# s40 — Phase D observability enforcement (1080/1092)
+
+This slice hardens observability surfaces as enforcement by making gates reflect runtime truth (no capped-metric artifacts; config evaluated from compiled recipe inputs).
+
+## Targets
+- #1080 (`PRRT_kwDOOOKvrc5swnAd`): `plateFitP90` reflects an uncapped residual distribution (normalization scale is not a cap).
+- #1092 (`PRRT_kwDOOOKvrc5swmzA`): morphology driver correlation invariant uses recipe-compiled (runtime) mountain config instead of static op defaults.
+
+PR:
+- https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1156
+
+## Gates / Tests
+```bash
+bun run --cwd mods/mod-swooper-maps check
+bun run --cwd mods/mod-swooper-maps test
+
+# Plan thread table commands
+bun run --cwd mods/mod-swooper-maps test test/foundation/m11-plate-motion.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/foundation-gates.test.ts
+bun run --cwd mods/mod-swooper-maps test test/morphology/m11-mountains-physics-anchored.test.ts
+
+# Cross-slice posture gates
+bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts
+```
+
+## Evidence
+
+### Dump
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label s40-phase-d-observability
+```
+```json
+{"runId":"65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s40-phase-d-observability/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac"}
+```
+
+### Analyze
+```bash
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <outputDir>
+```
+```json
+{
+  "runA": {
+    "runId": "65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac",
+    "dir": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s40-phase-d-observability/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac",
+    "landmasks": [
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+        "dataTypeKey": "morphology.topography.landMask",
+        "pctLand": 0.3570611778158948,
+        "landComponents": 4,
+        "largestLandFrac": 0.5796637309847879
+      },
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+        "dataTypeKey": "morphology.topography.landMask",
+        "pctLand": 0.3570611778158948,
+        "landComponents": 4,
+        "largestLandFrac": 0.5796637309847879
+      }
+    ]
+  }
+}
+```
+
+### Spot-check layers
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey foundation.crustTiles.type
+```
+```json
+{
+  "layers": [
+    {
+      "dataTypeKey": "foundation.crustTiles.type",
+      "stats": { "min": 0, "max": 1 }
+    }
+  ]
+}
+```
+
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey morphology.topography.landMask
+```
+```json
+{
+  "layers": [
+    {
+      "dataTypeKey": "morphology.topography.landMask",
+      "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+      "stats": { "min": 0, "max": 1 }
+    },
+    {
+      "dataTypeKey": "morphology.topography.landMask",
+      "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+      "stats": { "min": 0, "max": 1 }
+    }
+  ]
+}
+```
+

--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s90.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s90.md
@@ -1,0 +1,89 @@
+# s90 — Final legacy + docs cleanup sweep
+
+This slice is the forward-only lock-in: re-run the enforcement gates, ensure no shadow/dual/compare drift, and ensure repo-tracked execution docs are complete and truthy.
+
+PR:
+- (pending)
+
+## Gates / Checks (final posture)
+```bash
+bun run --cwd mods/mod-swooper-maps check
+bun run --cwd mods/mod-swooper-maps test
+bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts
+```
+
+## Evidence
+
+### Dump
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label s90-final-sweep
+```
+```json
+{"runId":"65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s90-final-sweep/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac"}
+```
+
+### Analyze
+```bash
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <outputDir>
+```
+```json
+{
+  "runA": {
+    "runId": "65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac",
+    "dir": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s90-final-sweep/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac",
+    "landmasks": [
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+        "dataTypeKey": "morphology.topography.landMask",
+        "pctLand": 0.3570611778158948,
+        "landComponents": 4,
+        "largestLandFrac": 0.5796637309847879
+      },
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+        "dataTypeKey": "morphology.topography.landMask",
+        "pctLand": 0.3570611778158948,
+        "landComponents": 4,
+        "largestLandFrac": 0.5796637309847879
+      }
+    ]
+  }
+}
+```
+
+### Spot-check layers
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey foundation.crustTiles.type
+```
+```json
+{
+  "layers": [
+    {
+      "dataTypeKey": "foundation.crustTiles.type",
+      "stats": { "min": 0, "max": 1 }
+    }
+  ]
+}
+```
+
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey morphology.topography.landMask
+```
+```json
+{
+  "layers": [
+    {
+      "dataTypeKey": "morphology.topography.landMask",
+      "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+      "stats": { "min": 0, "max": 1 }
+    },
+    {
+      "dataTypeKey": "morphology.topography.landMask",
+      "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+      "stats": { "min": 0, "max": 1 }
+    }
+  ]
+}
+```
+

--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s90.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s90.md
@@ -3,7 +3,7 @@
 This slice is the forward-only lock-in: re-run the enforcement gates, ensure no shadow/dual/compare drift, and ensure repo-tracked execution docs are complete and truthy.
 
 PR:
-- (pending)
+- https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1157
 
 ## Gates / Checks (final posture)
 ```bash
@@ -86,4 +86,3 @@ bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey morph
   ]
 }
 ```
-

--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s91.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s91.md
@@ -5,7 +5,7 @@ This follow-up slice strengthens the “physically grounded” posture for landm
 - Ensuring Foundation `resolutionProfile` ordering is monotonic (fine/ultra are not coarser than balanced), and exposing mesh knobs in advanced config (`cellsPerPlate`, `relaxationSteps`).
 
 PR:
-- (pending submit)
+- https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1158
 
 ## Gates / Checks
 ```bash
@@ -122,4 +122,3 @@ bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey morph
   ]
 }
 ```
-

--- a/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s91.md
+++ b/docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s91.md
@@ -1,0 +1,125 @@
+# s91 — Rift-driven craton growth landmask + foundation mesh resolution controls
+
+This follow-up slice strengthens the “physically grounded” posture for landmass generation by:
+- Adding a deterministic, time-stepped (eras × steps) rift/fracture + plate-motion driven craton growth term into landmask continent potential.
+- Ensuring Foundation `resolutionProfile` ordering is monotonic (fine/ultra are not coarser than balanced), and exposing mesh knobs in advanced config (`cellsPerPlate`, `relaxationSteps`).
+
+PR:
+- (pending submit)
+
+## Gates / Checks
+```bash
+bun run --cwd mods/mod-swooper-maps check
+bun run --cwd mods/mod-swooper-maps test
+bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts
+bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts
+```
+
+## Evidence (canonical probe 106 66 1337)
+
+### Baseline dump (s90)
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label s91-baseline
+```
+```json
+{"runId":"65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s91-baseline/65efcd0dd9265a2c0b07561720946a8e9d1fa49e493512a9f7b82b36229036ac"}
+```
+
+### After dump (s91)
+```bash
+bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label s91-after
+```
+```json
+{"runId":"d2cbd4077c5a8ff73c7fd9a3120a09636463725ef1e6451ed3cd992895de49b9","outputDir":"/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology/mods/mod-swooper-maps/dist/visualization/s91-after/d2cbd4077c5a8ff73c7fd9a3120a09636463725ef1e6451ed3cd992895de49b9"}
+```
+
+### Compare analyze (baseline vs after)
+```bash
+bun run --cwd mods/mod-swooper-maps diag:analyze -- <baselineOutputDir> <afterOutputDir>
+```
+```json
+{
+  "runA": {
+    "landmasks": [
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+        "pctLand": 0.3570611778158948,
+        "landComponents": 4,
+        "largestLandFrac": 0.5796637309847879
+      },
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+        "pctLand": 0.3570611778158948,
+        "landComponents": 4,
+        "largestLandFrac": 0.5796637309847879
+      }
+    ]
+  },
+  "runB": {
+    "landmasks": [
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+        "pctLand": 0.37507146941109204,
+        "landComponents": 3,
+        "largestLandFrac": 0.5316310975609756
+      },
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+        "pctLand": 0.37507146941109204,
+        "landComponents": 3,
+        "largestLandFrac": 0.5316310975609756
+      }
+    ]
+  },
+  "diff": {
+    "landmaskLayerDiffs": [
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+        "hamming": 372,
+        "hammingPct": 0.05317324185248713
+      },
+      {
+        "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+        "hamming": 372,
+        "hammingPct": 0.05317324185248713
+      }
+    ]
+  }
+}
+```
+
+### Spot-check layers
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey foundation.crustTiles.type
+```
+```json
+{
+  "layers": [
+    {
+      "dataTypeKey": "foundation.crustTiles.type",
+      "stats": { "min": 0, "max": 1 }
+    }
+  ]
+}
+```
+
+```bash
+bun run --cwd mods/mod-swooper-maps diag:list -- <outputDir> --dataTypeKey morphology.topography.landMask
+```
+```json
+{
+  "layers": [
+    {
+      "dataTypeKey": "morphology.topography.landMask",
+      "stepId": "mod-swooper-maps.standard.morphology-coasts.landmass-plates",
+      "stats": { "min": 0, "max": 1 }
+    },
+    {
+      "dataTypeKey": "morphology.topography.landMask",
+      "stepId": "mod-swooper-maps.standard.morphology-erosion.geomorphology",
+      "stats": { "min": 0, "max": 1 }
+    }
+  ]
+}
+```
+

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -18,7 +18,7 @@ $MOD = mods/mod-swooper-maps
 - [x] **s00** Phase 0 preflight + plan readiness (blocking): `agent-GOBI-PRR-s00-phase-0-preflight-no-shadow-and-plan-readiness`
 - [x] **s10** Phase A Foundation truth normalization + degeneracy elimination: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
 - [x] **s11** Phase A review thread closures (1077/1078/1083): `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
-- [ ] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
+- [x] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
 - [ ] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
 - [ ] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
 - [ ] **s40** Phase D observability enforcement (tiers + gate correctness): `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
@@ -83,6 +83,9 @@ This section is intentionally short and pointer-only. Evidence payloads live und
 - s11: `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1152
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s11.md`
+- s20: `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1153
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s20.md`
 
 ## Canonical Sources (Normative)
 

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -95,6 +95,9 @@ This section is intentionally short and pointer-only. Evidence payloads live und
 - s40: `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1156
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s40.md`
+- s90: `agent-GOBI-PRR-s90-final-legacy-sweep-and-docs`
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1157
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s90.md`
 
 ## Canonical Sources (Normative)
 

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -22,7 +22,7 @@ $MOD = mods/mod-swooper-maps
 - [x] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
 - [x] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
 - [x] **s40** Phase D observability enforcement (tiers + gate correctness): `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
-- [ ] **s90** Final legacy cleanup sweep + docs sweep: `agent-GOBI-PRR-s90-final-legacy-sweep-and-docs`
+- [x] **s90** Final legacy cleanup sweep + docs sweep: `agent-GOBI-PRR-s90-final-legacy-sweep-and-docs`
 
 ### Slice s00 — Phase 0 (No-Shadow) + Plan Readiness (blocking)
 

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -39,9 +39,9 @@ $MOD = mods/mod-swooper-maps
     - [x] `bun run --cwd $MOD diag:list -- <outputDir> --dataTypeKey foundation.crustTiles.type`
     - [x] `bun run --cwd $MOD diag:list -- <outputDir> --dataTypeKey morphology.topography.landMask`
 - [x] Plan is execution-ready (this section exists + runbooks below are present).
-- [ ] Submit posture (per slice):
-  - [ ] `gt restack --upstack`
-  - [ ] `gt submit --stack --draft --ai`
+- [x] Submit posture (per slice):
+  - [x] `gt restack --upstack`
+  - [x] `gt submit --stack --draft --ai`
 - [x] This plan doc is updated to reflect completion of s00 (checkboxes in this section are checked).
 
 ### Orchestrator Loop (Milestone Owner)

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -19,7 +19,7 @@ $MOD = mods/mod-swooper-maps
 - [x] **s10** Phase A Foundation truth normalization + degeneracy elimination: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
 - [x] **s11** Phase A review thread closures (1077/1078/1083): `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
 - [x] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
-- [ ] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
+- [x] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
 - [ ] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
 - [ ] **s40** Phase D observability enforcement (tiers + gate correctness): `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
 - [ ] **s90** Final legacy cleanup sweep + docs sweep: `agent-GOBI-PRR-s90-final-legacy-sweep-and-docs`
@@ -86,6 +86,9 @@ This section is intentionally short and pointer-only. Evidence payloads live und
 - s20: `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1153
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s20.md`
+- s21: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1154
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s21.md`
 
 ## Canonical Sources (Normative)
 

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -17,7 +17,7 @@ $MOD = mods/mod-swooper-maps
 
 - [x] **s00** Phase 0 preflight + plan readiness (blocking): `agent-GOBI-PRR-s00-phase-0-preflight-no-shadow-and-plan-readiness`
 - [x] **s10** Phase A Foundation truth normalization + degeneracy elimination: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
-- [ ] **s11** Phase A review thread closures (1077/1078/1083): `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
+- [x] **s11** Phase A review thread closures (1077/1078/1083): `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
 - [ ] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
 - [ ] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
 - [ ] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
@@ -80,6 +80,9 @@ This section is intentionally short and pointer-only. Evidence payloads live und
 - s10: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1151
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s10.md`
+- s11: `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1152
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s11.md`
 
 ## Canonical Sources (Normative)
 

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -20,7 +20,7 @@ $MOD = mods/mod-swooper-maps
 - [x] **s11** Phase A review thread closures (1077/1078/1083): `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
 - [x] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
 - [x] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
-- [ ] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
+- [x] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
 - [ ] **s40** Phase D observability enforcement (tiers + gate correctness): `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
 - [ ] **s90** Final legacy cleanup sweep + docs sweep: `agent-GOBI-PRR-s90-final-legacy-sweep-and-docs`
 
@@ -89,6 +89,9 @@ This section is intentionally short and pointer-only. Evidence payloads live und
 - s21: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1154
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s21.md`
+- s30: `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1155
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s30.md`
 
 ## Canonical Sources (Normative)
 

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -100,7 +100,7 @@ This section is intentionally short and pointer-only. Evidence payloads live und
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1157
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s90.md`
 - s91: `agent-GOBI-PRR-s91-phase-b-rift-craton-growth-landmass`
-  - PR: (pending submit)
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1158
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s91.md`
 
 ## Canonical Sources (Normative)

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -13,26 +13,36 @@ $MOD = mods/mod-swooper-maps
 
 ## Execution (Read This First)
 
+### Master Slice Checklist (Mark As You Go)
+
+- [x] **s00** Phase 0 preflight + plan readiness (blocking): `agent-GOBI-PRR-s00-phase-0-preflight-no-shadow-and-plan-readiness`
+- [ ] **s10** Phase A Foundation truth normalization + degeneracy elimination: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
+- [ ] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
+- [ ] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
+- [ ] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
+- [ ] **s40** Phase D observability enforcement (tiers + gate correctness): `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
+- [ ] **s90** Final legacy cleanup sweep + docs sweep: `agent-GOBI-PRR-s90-final-legacy-sweep-and-docs`
+
 ### Slice s00 — Phase 0 (No-Shadow) + Plan Readiness (blocking)
 
-- [ ] Working checkout is the isolated milestone worktree (single worktree + single stack).
-- [ ] Branch posture is correct: on the current slice branch (not `main`).
-- [ ] Graphite sync posture:
-  - [ ] `gt sync --no-restack`
-- [ ] Phase 0 blocking gate is green:
-  - [ ] `bun run --cwd $MOD test test/pipeline/no-shadow-paths.test.ts`
-- [ ] Slice evidence bundle captured (required every slice):
-  - [ ] Determinism suite (authoritative “what actually ran”): `bun run --cwd $MOD test test/pipeline/determinism-suite.test.ts`
-  - [ ] Dump: `bun run --cwd $MOD diag:dump -- 106 66 1337 --label s00-phase-0`
-  - [ ] Analyze: `bun run --cwd $MOD diag:analyze -- <outputDir>`
-  - [ ] Spot-check layers:
-    - [ ] `bun run --cwd $MOD diag:list -- <outputDir> --dataTypeKey foundation.crustTiles.type`
-    - [ ] `bun run --cwd $MOD diag:list -- <outputDir> --dataTypeKey morphology.topography.landMask`
-- [ ] Plan is execution-ready (this section exists + runbooks below are present).
+- [x] Working checkout is the isolated milestone worktree (single worktree + single stack).
+- [x] Branch posture is correct: on the current slice branch (not `main`).
+- [x] Graphite sync posture:
+  - [x] `gt sync --no-restack`
+- [x] Phase 0 blocking gate is green:
+  - [x] `bun run --cwd $MOD test test/pipeline/no-shadow-paths.test.ts`
+- [x] Slice evidence bundle captured (required every slice):
+  - [x] Determinism suite (authoritative “what actually ran”): `bun run --cwd $MOD test test/pipeline/determinism-suite.test.ts`
+  - [x] Dump: `bun run --cwd $MOD diag:dump -- 106 66 1337 --label s00-phase-0`
+  - [x] Analyze: `bun run --cwd $MOD diag:analyze -- <outputDir>`
+  - [x] Spot-check layers:
+    - [x] `bun run --cwd $MOD diag:list -- <outputDir> --dataTypeKey foundation.crustTiles.type`
+    - [x] `bun run --cwd $MOD diag:list -- <outputDir> --dataTypeKey morphology.topography.landMask`
+- [x] Plan is execution-ready (this section exists + runbooks below are present).
 - [ ] Submit posture (per slice):
   - [ ] `gt restack --upstack`
   - [ ] `gt submit --stack --draft --ai`
-- [ ] This plan doc is updated to reflect completion of s00 (checkboxes in this section are checked).
+- [x] This plan doc is updated to reflect completion of s00 (checkboxes in this section are checked).
 
 ### Orchestrator Loop (Milestone Owner)
 

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -78,6 +78,7 @@ This section is intentionally short and pointer-only. Evidence payloads live und
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1150
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s00.md`
 - s10: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1151
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s10.md`
 
 ## Canonical Sources (Normative)

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -16,7 +16,8 @@ $MOD = mods/mod-swooper-maps
 ### Master Slice Checklist (Mark As You Go)
 
 - [x] **s00** Phase 0 preflight + plan readiness (blocking): `agent-GOBI-PRR-s00-phase-0-preflight-no-shadow-and-plan-readiness`
-- [ ] **s10** Phase A Foundation truth normalization + degeneracy elimination: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
+- [x] **s10** Phase A Foundation truth normalization + degeneracy elimination: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
+- [ ] **s11** Phase A review thread closures (1077/1078/1083): `agent-GOBI-PRR-s11-phase-a-thread-closures-1077-1078-1083`
 - [ ] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
 - [ ] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
 - [ ] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
@@ -68,6 +69,16 @@ $MOD = mods/mod-swooper-maps
    - `gt restack --upstack`
    - `gt submit --stack --draft --ai`
 7. Report the stack tip (branch + commit SHA) to the orchestrator so primary checkout + narsil indexing can be advanced.
+
+### Execution Log (Slice Completion + Evidence Pointers)
+
+This section is intentionally short and pointer-only. Evidence payloads live under `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/`.
+
+- s00: `agent-GOBI-PRR-s00-phase-0-preflight-no-shadow-and-plan-readiness`
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1150
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s00.md`
+- s10: `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s10.md`
 
 ## Canonical Sources (Normative)
 

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -23,6 +23,7 @@ $MOD = mods/mod-swooper-maps
 - [x] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
 - [x] **s40** Phase D observability enforcement (tiers + gate correctness): `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
 - [x] **s90** Final legacy cleanup sweep + docs sweep: `agent-GOBI-PRR-s90-final-legacy-sweep-and-docs`
+- [x] **s91** Follow-up: rift-driven craton growth landmask + foundation mesh resolution controls: `agent-GOBI-PRR-s91-phase-b-rift-craton-growth-landmass`
 
 ### Slice s00 — Phase 0 (No-Shadow) + Plan Readiness (blocking)
 
@@ -98,6 +99,9 @@ This section is intentionally short and pointer-only. Evidence payloads live und
 - s90: `agent-GOBI-PRR-s90-final-legacy-sweep-and-docs`
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1157
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s90.md`
+- s91: `agent-GOBI-PRR-s91-phase-b-rift-craton-growth-landmass`
+  - PR: (pending submit)
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s91.md`
 
 ## Canonical Sources (Normative)
 

--- a/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md
@@ -21,7 +21,7 @@ $MOD = mods/mod-swooper-maps
 - [x] **s20** Phase B landmask grounded in crust truth (numeric gate slice): `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
 - [x] **s21** Phase B erosion: no hidden land/water reclassification: `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
 - [x] **s30** Phase C belts as modifiers (positive-intensity seeding): `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
-- [ ] **s40** Phase D observability enforcement (tiers + gate correctness): `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
+- [x] **s40** Phase D observability enforcement (tiers + gate correctness): `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
 - [ ] **s90** Final legacy cleanup sweep + docs sweep: `agent-GOBI-PRR-s90-final-legacy-sweep-and-docs`
 
 ### Slice s00 — Phase 0 (No-Shadow) + Plan Readiness (blocking)
@@ -92,6 +92,9 @@ This section is intentionally short and pointer-only. Evidence payloads live und
 - s30: `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
   - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1155
   - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s30.md`
+- s40: `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
+  - PR: https://app.graphite.com/github/pr/mateicanavra/civ7-modding-tools/1156
+  - Evidence: `docs/projects/pipeline-realism/evidence/agent-GOBI-PRR/s40.md`
 
 ## Canonical Sources (Normative)
 

--- a/docs/projects/pipeline-realism/resources/runbooks/WORKING-ORCHESTRATOR-PLAN-PRR.md
+++ b/docs/projects/pipeline-realism/resources/runbooks/WORKING-ORCHESTRATOR-PLAN-PRR.md
@@ -1,0 +1,307 @@
+# Working Orchestrator Plan (PRR) — No-Legacy Foundation ↔ Morphology Cutover
+
+This is a working orchestration document for executing the canonical plan:
+
+- Canonical execution plan: `docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md`
+
+This document is a runbook and posture aid. It does not supersede the canonical plan; it exists to preserve the orchestrator+worker execution loop and the intended posture in one place.
+
+## Original Orchestrated Execution Plan (Verbatim)
+
+PLEASE IMPLEMENT THIS PLAN:
+# Orchestrated Execution Plan: No‑Legacy Foundation → Morphology Cutover (Pipeline Realism Remediation)
+
+## Summary (Objective + Non‑Negotiables)
+**Objective (behavioral outcome):** Morphology must derive **continents/landmask from Foundation’s physics/tectonics truth** (crust truth + provenance), eliminating the current “looks wired but behaves unchanged” hybrid seam (belts/mountains use new drivers while landmask remains noise/threshold driven).
+
+**Posture (non‑negotiable):**
+- **Forward‑only maximal physics.** No legacy compatibility, no shims, no dual paths, no shadow/compare surfaces.
+- **Determinism + invariants are gates**, not debug tools.
+- **Evidence bundle every slice** (fingerprints + stats + dumps), attached in PRs/threads as required by the plan doc.
+- Willing to **break contracts** to achieve the single causal spine, as long as the end state is correct and green.
+
+Canonical execution source: `/Users/mateicanavra/Documents/.nosync/DEV/civ7-modding-tools/docs/projects/pipeline-realism/plans/PLAN-no-legacy-foundation-morphology-refactor-2026-02-05.md`  
+Workflow contract to follow: `/Users/mateicanavra/.claude/plugins/local/plugins/dev/commands/dev-loop-parallel.md` (single worktree + Graphite stack)
+
+---
+
+## Roles (Orchestrator vs Worker)
+
+### Orchestrator (you asked me to be this)
+I run a calm loop that keeps the worker moving slice-by-slice with taste and sequencing, not micromanagement.
+
+Responsibilities:
+1. Choose the next slice (in plan order, respecting Phase gates).
+2. Kick off the worker on that slice using `dev-linear` (then interrupt to send a context packet).
+3. Monitor primarily via the worker’s scratchpad (read file directly).
+4. When the worker says “done”, do a high-level review for drift, gate compliance, and evidence attachments.
+5. At slice boundaries:
+   - request a concise continuity snippet from the worker
+   - `/compact` the worker
+   - move the **primary** checkout to the **stack tip** so code-intel can re-index the newest changes.
+
+### Worker (one long-running agent): `GOBI`
+Responsibilities:
+- Use **one milestone worktree** for the whole effort (kept alive until the end).
+- One Graphite branch per slice; commit often; keep each slice reviewable and green.
+- Maintain scratch + planning discipline (below).
+- Update the canonical plan doc by checking off slice items and preserving “truthy” resolved detail.
+- Delete/clear scratch artifacts at the end of each slice so the repo/worktree isn’t left dirty.
+
+---
+
+## Planning + Scratch Discipline (Mandatory)
+We will maintain three “planning surfaces” during execution:
+
+1. **Canonical plan doc (repo-tracked):**
+   - Add/maintain a **top-of-doc execution checklist** (checkbox tasks per slice).
+   - Check items off as slices complete.
+   - Any ambiguity resolved with evidence gets written back here.
+
+2. **Overall in-memory plan (operational):**
+   - As orchestrator, I keep the slice sequencing + dependency picture up to date (and re-state it to the worker only at slice boundaries).
+
+3. **Per-slice in-memory plan (worker-owned):**
+   - Worker keeps a short checklist and evolving notes while implementing the slice.
+
+**Scratchpad file (worker-owned, not committed):**
+- Location (in-repo so I can monitor):  
+  `/Users/mateicanavra/Documents/.nosync/DEV/civ7-modding-tools/docs/projects/pipeline-realism/issues/GOBI.scratch.md`
+- Rules:
+  - Write thinking/notes first; code second.
+  - Update continuously while working.
+  - At slice end: **wipe the file contents or delete it**, and confirm `git status` is clean.
+
+(If `docs/projects/pipeline-realism/issues/` doesn’t exist, create it in the first slice; it’s just an untracked workspace. Keep it empty/clean at slice boundaries.)
+
+---
+
+## Branching / Naming / Worktree (Decision-Complete)
+We follow `dev-loop-parallel` naming rules (agent prefix required) plus phase-readable suffixes.
+
+**Pseudo-milestone key for naming:** `PRR` (Pipeline Realism Remediation)
+
+**Single milestone worktree + stack base:**
+- Trunk: `main`
+- Milestone base branch: `agent-GOBI-PRR-milestone-no-legacy-foundation-morphology`
+- Worktree root: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees`
+- Milestone worktree path:  
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-GOBI-PRR-milestone-no-legacy-foundation-morphology`
+
+**Slice branches (one per slice, stacked):**
+1. `agent-GOBI-PRR-s00-phase-0-preflight-no-shadow-and-plan-readiness`
+2. `agent-GOBI-PRR-s10-phase-a-foundation-truth-nondegenerate`
+3. `agent-GOBI-PRR-s20-phase-b-landmask-grounded-in-crust-truth`
+4. `agent-GOBI-PRR-s21-phase-b-erosion-no-hidden-reclass`
+5. `agent-GOBI-PRR-s30-phase-c-belts-as-modifiers`
+6. `agent-GOBI-PRR-s40-phase-d-observability-enforcement`
+7. `agent-GOBI-PRR-s90-final-legacy-sweep-and-docs`
+
+**Graphite submission flag:** always include `--ai` when submitting/updating PRs for the stack (use draft posture until we’re confident).
+
+---
+
+## Slice Map (What Each Slice Must Accomplish)
+
+### Slice s00: Phase 0 + Plan Readiness (Blocking)
+Purpose: ensure we can’t “fake progress” with dual/shadow/compare surfaces, and make the canonical plan doc execution-ready.
+
+Required work in this slice:
+- Make any concrete adjustments to the plan doc required for confidence:
+  - add the top-of-doc slice checklist (checkboxes matching the slice list above)
+  - add a short “Orchestrator loop” + “Worker per-slice loop” section (runbook style, not prose)
+  - remove misleading/ambiguous notes if any remain (the plan doc should read as authoritative and current)
+- Enforce Phase 0 gate:
+  - `bun run --cwd mods/mod-swooper-maps test test/pipeline/no-shadow-paths.test.ts`
+  - If it fails: delete/rename surfaced patterns (no shims), and if needed extend the guardrail patterns (per plan).
+- Evidence bundle attached to the PR for this slice (see Evidence section below).
+
+Acceptance:
+- Phase 0 test green.
+- Plan doc has a clear, checkable execution checklist.
+- No shadow/dual/compare surfaces remain.
+
+---
+
+### Slice s10: Phase A — Foundation Truth Normalization + Degeneracy Elimination
+Purpose: make “material evolution” real so Morphology can consume a non-degenerate crust truth spine.
+
+Work must satisfy Phase A intent:
+- Re-establish baseline probe evidence bundle (plan’s canonical `106 66 1337`), and ensure the “degenerate `crustTiles.type`” problem is addressed by making `type` derived/non-degenerate and/or promoting the continuous truth contract.
+- Ensure provenance resets are non-trivial (frequency + spatial structure), and “events emit fields but don’t change state” dead-lever behavior is eliminated.
+- Ensure Phase A gate bundle is green (plan-defined).
+
+Also: start/complete Phase A review thread closures as the plan requires:
+- #1077 (`PRRT_kwDOOOKvrc5swnXi`)
+- #1078 (`PRRT_kwDOOOKvrc5swoFn`)
+- #1083 (`PRRT_kwDOOOKvrc5swl4c`)
+
+Acceptance:
+- Phase 0 gate still green.
+- Determinism suite green.
+- Foundation gates green.
+- Evidence bundle posted, and Phase A thread evidence posted per table in the plan.
+
+---
+
+### Slice s20: Phase B — Landmask Grounded in Foundation Truth (Numeric Gate Slice)
+Purpose: replace noise/threshold-first landmask with a continent-scale classifier grounded in crust truth + provenance stability.
+
+Work must do (plan B0–B1):
+- Define “continent potential” as low-frequency function of crust truth + provenance stability.
+- Replace threshold/noise-dominant landmask behavior with crust-truth-driven classifier.
+- Ensure belts remain modifiers (not continent generators).
+
+Numeric gate (blocking, per plan):
+- Capture **Phase B baseline** + **Phase B after** with:
+  - `diag:dump --label phase-b-baseline`
+  - `diag:dump --label phase-b-after`
+  - `diag:analyze -- <baselineOutputDir> <afterOutputDir>`
+- Pass the plan’s delta-based formulas for component reduction + largestLandFrac increase + pctLand sanity bands.
+
+Acceptance:
+- Phase A gate bundle satisfied.
+- Phase B compare evidence attached.
+- Numeric gate passes.
+
+---
+
+### Slice s21: Phase B Cleanup — No Hidden Reclassification During Erosion (B2/Basin + Geomorphology)
+Purpose: stop geomorphology from silently shredding connectivity via re-thresholding/reclassification, and delete any basin separation “truth” not derived from Foundation.
+
+Work must do:
+- Remove/redefine any land/water reclassification during erosion that is not explicitly derived from Foundation truth.
+- Ensure the post-erosion landmask stays coherent (and does not re-shatter what s20 fixed).
+
+Acceptance:
+- Re-run Phase B compare (baseline vs after for this slice) and ensure gates remain satisfied post-erosion (per plan’s “geomorphology does not re-shatter coherence” constraints).
+- Evidence bundle posted.
+
+---
+
+### Slice s30: Phase C — Belts as Modifiers (Unified Spine)
+Purpose: belt drivers modulate, not generate continents; enforce positive-intensity seeding semantics.
+
+Work must do (plan C0–C2):
+- Enforce “positive-intensity only seeds diffusion” (thread #1087 / `PRRT_kwDOOOKvrc5swmNO`).
+- Confirm belts modulate relief/coasts/mountains but do not create continents.
+- Resolve “segments seed belts” semantics as either a Phase C change or an explicit deferral with deletion trigger (per plan; default is implement, not defer).
+
+Acceptance:
+- Belt diffusion seeding semantics proved by tests + evidence bundle.
+- Thread closure evidence posted.
+
+---
+
+### Slice s40: Phase D — Observability as Enforcement
+Purpose: turn observability into correctness enforcement, with clear tiers and no false diffs.
+
+Work must do:
+- Define/enforce gate tiers as per plan (Tier 1 contracts + budgets; CI determinism equivalence; promoted subset enforcement).
+- Close Phase D threads with required evidence:
+  - #1080 (`PRRT_kwDOOOKvrc5swnAd`) plateFitP90 uncapped proof
+  - #1092 (`PRRT_kwDOOOKvrc5swmzA`) morphology correlation gate uses runtime-normalized config
+
+Acceptance:
+- Determinism suite green, foundation gates green.
+- Evidence bundle attached.
+- Phase D threads have in-thread evidence and closure triggers met.
+
+---
+
+### Slice s90: Final Sweep — No Legacy Remnants + Docs Cleanup (End-of-Project Requirement)
+Purpose: ensure the repo reflects the forward-only posture in reality, not just intent.
+
+Work must do:
+- Full “legacy cleanup sweep”:
+  - remove any remaining dual paths/shims/legacy remnants
+  - remove dead-lever normalization traps if still present (per plan targets)
+  - ensure Phase 0 guard patterns still hold (and expand if synonyms appeared)
+- Documentation sweep:
+  - canonical plan doc is fully checked off and “truthy”
+  - resolved nuance stays in the plan doc (no rediscovery)
+  - ensure no scratch files remain
+
+Acceptance:
+- Entire stack green.
+- Plan doc matches the final reality.
+- No leftover scratch artifacts; `git status` clean.
+- All phase threads closed with evidence.
+
+---
+
+## Per-Slice Execution Loop (Worker Must Follow Every Time)
+This is the **deterministic** slice loop (derived from the plan doc + workflow):
+
+1. `gt sync --no-restack`
+2. `gt create <slice-branch-name>`
+3. Preflight:
+   - `git status` clean (except the untracked scratchpad while in-flight)
+   - ensure deps are available in the worktree (`bun install` if needed)
+4. Implement (forward-only; include deletions; no shims).
+5. Validate (minimum, every slice):
+   - `bun run --cwd mods/mod-swooper-maps check`
+   - `bun run --cwd mods/mod-swooper-maps test`
+   - `bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts`
+   - `bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label <slice-label>`
+   - Plus any phase/thread-specific commands from the plan doc tables.
+6. Evidence bundle (paste into PR description; see below).
+7. `gt restack --upstack`
+8. Submit/update PRs: `gt submit --stack --draft --ai`
+9. Update the canonical plan doc checklist (check the slice item; add any resolved nuance).
+10. End-of-slice hygiene:
+   - wipe/delete `.../GOBI.scratch.md`
+   - confirm `git status` clean
+
+---
+
+## Evidence Bundle (Every Slice, No Exceptions)
+Attach to PR description (and to PRRT threads when a phase table requires it):
+
+- `diag:dump` JSON: `{"runId":"...","outputDir":"..."}`
+- `diag:analyze` JSON:
+  - single-run form: `diag:analyze -- <outputDir>`
+  - Phase B compare form: `diag:analyze -- <baselineOutputDir> <afterOutputDir>`
+- Spot-check layers (as in plan):
+  - `diag:list ... foundation.crustTiles.type` (or replacement derived view if `type` is demoted)
+  - `diag:list ... morphology.topography.landMask`
+- Determinism enforcement proof:
+  - `bun run --cwd mods/mod-swooper-maps test test/pipeline/determinism-suite.test.ts` output excerpt (or CI excerpt)
+
+---
+
+## Important Public Contract / Interface Changes (Expected)
+We should assume these changes will be real and potentially breaking (by design):
+- Foundation: `crustTiles.type` becomes **derived view**, not truth; continuous crust truth fields (maturity/thickness/age/damage/etc.) become primary.
+- Morphology: landmask algorithm becomes continent-scale classifier grounded in Foundation truth; noise demoted to secondary coast flavor.
+- Observability: gating tiers hardened; determinism/invariant expectations may tighten.
+
+---
+
+## Test Scenarios / Acceptance (End State)
+By the end of s90, we must be able to say (with evidence):
+- Phase 0 guard is green (no shadow/dual/compare).
+- Determinism suite is green (fingerprints stable).
+- Foundation gates are green.
+- Phase B numeric gate passes on the canonical probe (components materially reduced, largestLandFrac materially increased, pctLand sanity bands respected).
+- Review threads listed in the plan are closed with in-thread evidence.
+- No legacy remnants / dual semantics remain; docs are clean; worktree is clean.
+
+---
+
+## Assumptions / Defaults (Locked)
+- Base branch is `main` (repo currently clean and on `main`).
+- Graphite is available (`gt` present); we never run `gt sync` without `--no-restack`.
+- We run the whole effort in **one** milestone worktree and one Graphite stack.
+- We will treat `PRR` as the naming key for this remediation (since this is “milestone-style” without a single Linear milestone id).
+- We submit PRs with `--ai` and keep them `--draft` by default until the stack is clearly stable.
+
+## Synthesis Additions (Alternate Plan Nuance)
+
+The alternate plan strengthens the posture in a few ways; we incorporate them as additions (workflow unchanged):
+
+- Maintain an **Execution Log** section in the canonical plan doc tracking slice completion and evidence pointers (plus PR links).
+- Split Phase A into two slices:
+  - `s10`: Phase A core (crust truth non-degenerate + provenance resets non-trivial)
+  - `s11`: Phase A thread closures (1077/1078/1083) with required in-thread evidence
+- Treat any docs-only readiness as a first-class deliverable; if further runbook/doc adjustments are required later, land them as their own small commit at the start of the relevant slice.

--- a/mods/mod-swooper-maps/scripts/generate-studio-recipe-types.ts
+++ b/mods/mod-swooper-maps/scripts/generate-studio-recipe-types.ts
@@ -214,32 +214,10 @@ function deriveStageStepConfigFocusMap(args: {
   // In that case, we focus those steps directly under `advanced.<stepId>`, and fall back
   // to the stage-level mapping (usually `profiles`) for the rest.
   if (publicKeys.includes("advanced") && advancedStepIds.length > 0) {
-    const advanced: Record<string, unknown> = Object.fromEntries(
-      advancedStepIds.map((stepId) => [stepId, makeSentinel(["advanced", stepId])])
-    );
-    const { rawSteps: advancedRawSteps } = stage.toInternal({
-      env: {},
-      stageConfig: { knobs: {}, advanced },
-    });
-    for (const stepId of advancedStepIds) {
-      if (!(stepId in advancedRawSteps)) {
-        throw new Error(
-          `[recipe:${args.namespace}.${args.recipeId}] stage("${stage.id}") missing rawSteps["${stepId}"] when probing partial advanced mapping`
-        );
-      }
-      const path = assertSingleSentinelPath({
-        label: `[recipe:${args.namespace}.${args.recipeId}] stage("${stage.id}") step("${stepId}")`,
-        value: advancedRawSteps[stepId],
-      });
-      if (path.join(".") !== ["advanced", stepId].join(".")) {
-        throw new Error(
-          `[recipe:${args.namespace}.${args.recipeId}] stage("${stage.id}") partial advanced mapping produced unexpected focus path for step("${stepId}"): ${JSON.stringify(
-            path
-          )}`
-        );
-      }
-      mapping[stepId] = path;
-    }
+    // Intentionally schema-driven: `advanced.<stepId>` may be compiled into a derived step config
+    // (so a sentinel value won't necessarily survive through `toInternal`), but the Studio editor
+    // still needs to focus the relevant subtree for that step.
+    for (const stepId of advancedStepIds) mapping[stepId] = ["advanced", stepId];
   }
 
   return mapping;

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-mantle-potential/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-mantle-potential/index.ts
@@ -1,15 +1,9 @@
 import { createOp } from "@swooper/mapgen-core/authoring";
-import { clamp01, wrapDeltaPeriodic } from "@swooper/mapgen-core/lib/math";
+import { clamp01, clampInt, wrapDeltaPeriodic } from "@swooper/mapgen-core/lib/math";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 
 import { requireMesh } from "../../lib/require.js";
 import ComputeMantlePotentialContract from "./contract.js";
-
-function clampInt(value: number, bounds: { min: number; max?: number }): number {
-  const rounded = Math.round(value);
-  const max = bounds.max ?? Number.POSITIVE_INFINITY;
-  return Math.max(bounds.min, Math.min(max, rounded));
-}
 
 function distanceSqWrapped(ax: number, ay: number, bx: number, by: number, wrapWidth: number): number {
   const dx = wrapDeltaPeriodic(ax - bx, wrapWidth);
@@ -101,13 +95,13 @@ const computeMantlePotential = createOp(ComputeMantlePotentialContract, {
         const rng = createLabelRng(rngSeed);
         const cellCount = mesh.cellCount | 0;
 
-        const plumeCount = clampInt(config.plumeCount ?? 6, { min: 0, max: 32 });
-        const downwellingCount = clampInt(config.downwellingCount ?? 6, { min: 0, max: 32 });
+        const plumeCount = clampInt(config.plumeCount ?? 6, 0, 32);
+        const downwellingCount = clampInt(config.downwellingCount ?? 6, 0, 32);
         const plumeRadius = Math.max(1e-6, config.plumeRadius ?? 0.18);
         const downwellingRadius = Math.max(1e-6, config.downwellingRadius ?? 0.18);
         const plumeAmplitude = config.plumeAmplitude ?? 1.0;
         const downwellingAmplitude = config.downwellingAmplitude ?? -1.0;
-        const smoothingIterations = clampInt(config.smoothingIterations ?? 2, { min: 0, max: 4 });
+        const smoothingIterations = clampInt(config.smoothingIterations ?? 2, 0, 4);
         const smoothingAlpha = clamp01(config.smoothingAlpha ?? 0.35);
         const minSeparationScale = Math.max(0, config.minSeparationScale ?? 0.85);
 

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-motion/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-motion/index.ts
@@ -1,5 +1,5 @@
 import { createOp } from "@swooper/mapgen-core/authoring";
-import { clamp01, wrapDeltaPeriodic } from "@swooper/mapgen-core/lib/math";
+import { clamp01, clampInt, wrapDeltaPeriodic } from "@swooper/mapgen-core/lib/math";
 
 import { requireMantleForcing, requireMesh, requirePlateGraph } from "../../lib/require.js";
 import ComputePlateMotionContract from "./contract.js";
@@ -9,11 +9,6 @@ function clampByte(value: number): number {
   if (value <= 0) return 0;
   if (value >= 255) return 255;
   return Math.round(value) | 0;
-}
-
-function clampInt(value: number, bounds: { min: number; max: number }): number {
-  const rounded = Math.round(value);
-  return Math.max(bounds.min, Math.min(bounds.max, rounded));
 }
 
 const EPS = 1e-9;
@@ -42,8 +37,8 @@ const computePlateMotion = createOp(ComputePlateMotionContract, {
         const plateRadiusMin = Math.max(1e-6, config.plateRadiusMin ?? 1);
         const residualNormScale = Math.max(0.01, config.residualNormScale ?? 1);
         const p90NormScale = Math.max(0.01, config.p90NormScale ?? 1);
-        const histogramBins = clampInt(config.histogramBins ?? 32, { min: 8, max: 128 });
-        const smoothingSteps = clampInt(config.smoothingSteps ?? 0, { min: 0, max: 1 });
+        const histogramBins = clampInt(config.histogramBins ?? 32, 8, 128);
+        const smoothingSteps = clampInt(config.smoothingSteps ?? 0, 0, 1);
 
         let forcingU = mantleForcing.forcingU;
         let forcingV = mantleForcing.forcingV;

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/contract.ts
@@ -255,6 +255,10 @@ const TectonicHistoryTilesRollupSchema = Type.Object(
     }),
     /** Last active era index per tile (0..255; 255 = never). */
     lastActiveEra: TypedArraySchemas.u8({ description: "Last active era index per tile (0..255; 255 = never)." }),
+    /** Plate movement U component per tile (-127..127). */
+    movementU: TypedArraySchemas.i8({ description: "Plate movement U component per tile (-127..127)." }),
+    /** Plate movement V component per tile (-127..127). */
+    movementV: TypedArraySchemas.i8({ description: "Plate movement V component per tile (-127..127)." }),
   },
   { description: "Foundation tectonic history tiles rollup payload (tile-space rollups)." }
 );

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/lib/project-plates.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/lib/project-plates.ts
@@ -128,6 +128,8 @@ export function projectPlatesFromModel(input: {
       volcanismTotal: Uint8Array;
       upliftRecentFraction: Uint8Array;
       lastActiveEra: Uint8Array;
+      movementU: Int8Array;
+      movementV: Int8Array;
     };
   };
   tectonicProvenanceTiles: {
@@ -208,6 +210,8 @@ export function projectPlatesFromModel(input: {
     volcanismTotal: new Uint8Array(size),
     upliftRecentFraction: new Uint8Array(size),
     lastActiveEra: new Uint8Array(size),
+    movementU,
+    movementV,
   } as const;
 
   const provenanceTiles = {

--- a/mods/mod-swooper-maps/src/domain/foundation/shared/knob-multipliers.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/shared/knob-multipliers.ts
@@ -1,6 +1,7 @@
-function clamp01(value: number): number {
-  if (!Number.isFinite(value)) return 0.5;
-  return Math.max(0, Math.min(1, value));
+import { clampFinite } from "@swooper/mapgen-core/lib/math";
+
+function clampActivity01(value: number | undefined): number {
+  return clampFinite(value ?? 0.5, 0, 1, 0.5);
 }
 
 function lerp(a: number, b: number, t: number): number {
@@ -13,7 +14,7 @@ function lerp(a: number, b: number, t: number): number {
  * Mapping: 0.0 -> 0.8, 0.5 -> 1.0, 1.0 -> 1.2 (piecewise linear).
  */
 export function resolvePlateActivityKinematicsMultiplier(value: number | undefined): number {
-  const v = clamp01(value ?? 0.5);
+  const v = clampActivity01(value);
   if (v <= 0.5) return lerp(0.8, 1.0, v / 0.5);
   return lerp(1.0, 1.2, (v - 0.5) / 0.5);
 }
@@ -24,7 +25,7 @@ export function resolvePlateActivityKinematicsMultiplier(value: number | undefin
  * Mapping: 0.0 -> -1, 0.5 -> 0, 1.0 -> +2 (piecewise linear, rounded).
  */
 export function resolvePlateActivityBoundaryDelta(value: number | undefined): number {
-  const v = clamp01(value ?? 0.5);
+  const v = clampActivity01(value);
   const delta = v <= 0.5 ? lerp(-1, 0, v / 0.5) : lerp(0, 2, (v - 0.5) / 0.5);
   return Math.round(delta);
 }

--- a/mods/mod-swooper-maps/src/domain/foundation/shared/knobs.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/shared/knobs.ts
@@ -13,7 +13,6 @@ import { Type, type Static } from "@swooper/mapgen-core/authoring";
  * - Plate count target (integer >= 2). Used as the authored baseline for plate discretization.
  */
 export const FoundationPlateCountKnobSchema = Type.Integer({
-  default: 28,
   minimum: 2,
   maximum: 256,
   description:

--- a/mods/mod-swooper-maps/src/domain/morphology/config.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/config.ts
@@ -1,99 +1,6 @@
 import { Type, type Static } from "@swooper/mapgen-core/authoring";
 
 /**
- * Edge override policy for the ocean separation pass.
- */
-export const OceanSeparationEdgePolicySchema = Type.Object(
-  {
-    /** Enable edge-specific override for this map border (west or east). */
-    enabled: Type.Boolean({
-      description: "Enable edge-specific override for this map border (west or east).",
-      default: false,
-    }),
-    /** Baseline separation enforced at the map edge in tiles (before boundary multipliers). */
-    baseTiles: Type.Number({
-      description: "Baseline separation enforced at the map edge in tiles (before boundary multipliers).",
-      default: 0,
-      minimum: 0,
-    }),
-    /** Multiplier applied near active margins when widening oceans at the edge. */
-    boundaryClosenessMultiplier: Type.Number({
-      description: "Multiplier applied near active margins when widening oceans at the edge.",
-      default: 1,
-      minimum: 0,
-    }),
-    /** Maximum allowed per-latitude separation delta for this edge to avoid extreme zig-zags. */
-    maxPerRowDelta: Type.Number({
-      description: "Maximum allowed per-latitude separation delta for this edge to avoid extreme zig-zags.",
-      default: 3,
-      minimum: 0,
-    }),
-  }
-);
-
-/**
- * Plate-aware ocean separation policy controlling continental drift spacing.
- */
-export const OceanSeparationConfigSchema = Type.Object(
-  {
-    /** Master switch for plate-aware ocean widening between continent bands. */
-    enabled: Type.Boolean({
-      description: "Master switch for plate-aware ocean widening between continent bands.",
-      default: false,
-    }),
-    /**
-     * Pairs of continent indices to separate.
-     * @example [[0,1],[1,2]] separates band 0 from 1, and band 1 from 2.
-     */
-    bandPairs: Type.Optional(
-      Type.Array(Type.Tuple([Type.Number(), Type.Number()]), {
-        default: [],
-        description: "Pairs of continent indices to separate (e.g., [[0,1],[1,2]]).",
-      })
-    ),
-    /** Baseline widening between continents in tiles before modifiers are applied. */
-    baseSeparationTiles: Type.Number({
-      description: "Baseline widening between continents in tiles before modifiers are applied.",
-      default: 0,
-      minimum: 0,
-    }),
-    /** Extra separation applied when plates are close to active boundaries (multiplier 0..2). */
-    boundaryClosenessMultiplier: Type.Number({
-      description: "Extra separation applied when plates are close to active boundaries (multiplier 0..2).",
-      default: 1,
-      minimum: 0,
-    }),
-    /** Maximum per-latitude variation in separation (tiles) to keep oceans smooth north-south. */
-    maxPerRowDelta: Type.Number({
-      description: "Maximum per-latitude variation in separation (tiles) to keep oceans smooth north-south.",
-      default: 3,
-      minimum: 0,
-    }),
-    /** Minimum navigable channel width to preserve while widening seas (tiles). */
-    minChannelWidth: Type.Number({
-      description: "Minimum navigable channel width to preserve while widening seas (tiles).",
-      default: 3,
-      minimum: 0,
-    }),
-    /** Random jitter applied to channel widths to avoid uniform straight lines. */
-    channelJitter: Type.Number({
-      description: "Random jitter applied to channel widths to avoid uniform straight lines.",
-      default: 0,
-      minimum: 0,
-    }),
-    /** Whether strategic sea corridors should be preserved when enforcing separation. */
-    respectSeaLanes: Type.Boolean({
-      description: "Whether strategic sea corridors should be preserved when enforcing separation.",
-      default: true,
-    }),
-    /** West edge-specific override policy. */
-    edgeWest: OceanSeparationEdgePolicySchema,
-    /** East edge-specific override policy. */
-    edgeEast: OceanSeparationEdgePolicySchema,
-  }
-);
-
-/**
  * Plate-aware weighting for bay/fjord odds based on boundary closeness.
  */
 export const CoastlinePlateBiasConfigSchema = Type.Object(
@@ -698,7 +605,6 @@ export const MorphologyConfigSchema = Type.Object(
   {
     hypsometry: HypsometryConfigSchema,
     relief: ReliefConfigSchema,
-    basinSeparation: OceanSeparationConfigSchema,
     coast: CoastConfigSchema,
     landforms: LandformsConfigSchema,
     geomorphology: GeomorphologyConfigSchema,
@@ -710,10 +616,6 @@ export type MorphologyConfig = Static<typeof MorphologyConfigSchema>;
 export type HypsometryConfig = Static<typeof HypsometryConfigSchema>;
 export type ReliefConfig = Static<typeof ReliefConfigSchema>;
 export type GeomorphologyConfig = Static<typeof GeomorphologyConfigSchema>;
-export type BasinSeparationConfig =
-  Static<typeof MorphologyConfigSchema["properties"]["basinSeparation"]>;
-export type OceanSeparationEdgePolicy =
-  Static<typeof OceanSeparationConfigSchema["properties"]["edgeWest"]>;
 export type CoastConfig = Static<typeof CoastConfigSchema>;
 export type LandformsConfig = Static<typeof LandformsConfigSchema>;
 export type CoastlinePlateBiasConfig =

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-belt-drivers/deriveFromHistory.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-belt-drivers/deriveFromHistory.ts
@@ -286,8 +286,16 @@ export function deriveBeltDriversFromHistory(input: {
 
   const maxSigma = 1 + 3 * (maxAge / Math.max(1, maxAge));
   const maxDistance = Math.max(1, Math.round(5 * maxSigma * 1.2));
+  // Diffusion must be seeded only from positive-intensity sources; otherwise nearestSeed can land on a
+  // zero-intensity belt tile and silently suppress the entire region.
+  const beltSeedMask = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    if (beltMask[i] !== 1) continue;
+    if ((intensityBlend[i] ?? 0) <= 0) continue;
+    beltSeedMask[i] = 1;
+  }
   const { distance: beltDistance, nearestSeed: beltNearestSeed } = computeDistanceField(
-    beltMask,
+    beltSeedMask,
     width,
     height,
     maxDistance
@@ -340,4 +348,3 @@ export function deriveBeltDriversFromHistory(input: {
     beltComponents,
   } as const;
 }
-

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts
@@ -52,7 +52,7 @@ const LandmaskConfigSchema = Type.Object(
       description: "Half-saturation constant used to normalize craton mass into 0..1 without hard clamping.",
     }),
     cratonPotentialWeight: Type.Number({
-      default: 0.18,
+      default: 0.12,
       minimum: 0,
       maximum: 1,
       description: "Weight of rift/fracture-driven craton mass in the final continent potential.",

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts
@@ -1,18 +1,36 @@
 import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
 
-import { OceanSeparationConfigSchema } from "../../config.js";
-
 const LandmaskConfigSchema = Type.Object(
   {
-    basinSeparation: OceanSeparationConfigSchema,
+    continentPotentialGrain: Type.Integer({
+      default: 8,
+      minimum: 1,
+      maximum: 64,
+      description: "Coarse grain (tile block size) used to low-pass continent potential before thresholding.",
+    }),
+    continentPotentialBlurSteps: Type.Integer({
+      default: 3,
+      minimum: 0,
+      maximum: 16,
+      description: "Number of hex-neighborhood blur passes applied after coarse-grain averaging.",
+    }),
+    keepLandComponentFraction: Type.Number({
+      default: 0.985,
+      minimum: 0.5,
+      maximum: 1,
+      description:
+        "Fraction of land tiles to keep by retaining only the largest connected components (removes speckle islands).",
+    }),
   },
   {
-    description: "Landmask shaping controls, including ocean separation policy.",
+    additionalProperties: false,
+    description:
+      "Landmask shaping controls. Landmask is derived from Foundation crust truth + provenance stability (continent potential), not from noise-first thresholding.",
   }
 );
 
 /**
- * Derives the land mask and coastline distance field from elevation and sea level.
+ * Derives the land mask and coastline distance field from a low-frequency continent potential grounded in Foundation truth.
  */
 const ComputeLandmaskContract = defineOp({
   kind: "compute",
@@ -24,6 +42,21 @@ const ComputeLandmaskContract = defineOp({
     seaLevel: Type.Number({ description: "Sea level threshold." }),
     boundaryCloseness: TypedArraySchemas.u8({
       description: "Boundary proximity per tile (0..255).",
+    }),
+    crustType: TypedArraySchemas.u8({
+      description: "Foundation crust type per tile (0=oceanic, 1=continental).",
+    }),
+    crustBaseElevation: TypedArraySchemas.f32({
+      description: "Foundation crust base elevation proxy per tile (0..1).",
+    }),
+    crustAge: TypedArraySchemas.u8({
+      description: "Foundation crust age bucket per tile (0..255).",
+    }),
+    provenanceOriginEra: TypedArraySchemas.u8({
+      description: "Foundation provenance origin era per tile (0..eraCount-1).",
+    }),
+    provenanceDriftDistance: TypedArraySchemas.u8({
+      description: "Foundation provenance drift distance bucket per tile (0..255).",
     }),
   }),
   output: Type.Object({

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts
@@ -21,6 +21,42 @@ const LandmaskConfigSchema = Type.Object(
       description:
         "Fraction of land tiles to keep by retaining only the largest connected components (removes speckle islands).",
     }),
+    cratonStepsPerEra: Type.Integer({
+      default: 2,
+      minimum: 0,
+      maximum: 8,
+      description: "Craton-growth simulation steps per tectonic era (0 disables rift-driven growth).",
+    }),
+    cratonNucleationScale: Type.Number({
+      default: 0.9,
+      minimum: 0,
+      maximum: 3,
+      description: "Scalar applied to rift/fracture-driven craton nucleation rate.",
+    }),
+    cratonDiffusion: Type.Number({
+      default: 0.25,
+      minimum: 0,
+      maximum: 1,
+      description: "Per-step diffusion rate for craton mass (merges/advects seeds over time).",
+    }),
+    cratonAdvection: Type.Number({
+      default: 0.15,
+      minimum: 0,
+      maximum: 1,
+      description: "Per-step advection rate moving craton mass along plate movement vectors (approximates drift).",
+    }),
+    cratonHalfSaturation: Type.Number({
+      default: 0.35,
+      minimum: 0.01,
+      maximum: 10,
+      description: "Half-saturation constant used to normalize craton mass into 0..1 without hard clamping.",
+    }),
+    cratonPotentialWeight: Type.Number({
+      default: 0.18,
+      minimum: 0,
+      maximum: 1,
+      description: "Weight of rift/fracture-driven craton mass in the final continent potential.",
+    }),
   },
   {
     additionalProperties: false,
@@ -57,6 +93,19 @@ const ComputeLandmaskContract = defineOp({
     }),
     provenanceDriftDistance: TypedArraySchemas.u8({
       description: "Foundation provenance drift distance bucket per tile (0..255).",
+    }),
+    riftPotentialByEra: Type.Array(TypedArraySchemas.u8({ shape: null }), {
+      description:
+        "Rift potential per tile (0..255) for each tectonic era (oldest..newest). Used for time-stepped rift-driven craton growth.",
+    }),
+    fractureTotal: TypedArraySchemas.u8({
+      description: "Accumulated fracture total per tile (0..255) from Foundation history rollups.",
+    }),
+    movementU: TypedArraySchemas.i8({
+      description: "Plate movement U component per tile (-127..127) from Foundation plate tensors.",
+    }),
+    movementV: TypedArraySchemas.i8({
+      description: "Plate movement V component per tile (-127..127) from Foundation plate tensors.",
     }),
   }),
   output: Type.Object({

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/rules/index.ts
@@ -14,6 +14,10 @@ export function validateLandmaskInputs(
   crustAge: Uint8Array;
   provenanceOriginEra: Uint8Array;
   provenanceDriftDistance: Uint8Array;
+  riftPotentialByEra: Uint8Array[];
+  fractureTotal: Uint8Array;
+  movementU: Int8Array;
+  movementV: Int8Array;
 } {
   const { width, height } = input;
   const size = Math.max(0, (width | 0) * (height | 0));
@@ -24,6 +28,10 @@ export function validateLandmaskInputs(
   const crustAge = input.crustAge as Uint8Array;
   const provenanceOriginEra = input.provenanceOriginEra as Uint8Array;
   const provenanceDriftDistance = input.provenanceDriftDistance as Uint8Array;
+  const riftPotentialByEra = input.riftPotentialByEra as Uint8Array[];
+  const fractureTotal = input.fractureTotal as Uint8Array;
+  const movementU = input.movementU as Int8Array;
+  const movementV = input.movementV as Int8Array;
 
   if (
     elevation.length !== size ||
@@ -32,9 +40,25 @@ export function validateLandmaskInputs(
     crustBaseElevation.length !== size ||
     crustAge.length !== size ||
     provenanceOriginEra.length !== size ||
-    provenanceDriftDistance.length !== size
+    provenanceDriftDistance.length !== size ||
+    fractureTotal.length !== size ||
+    movementU.length !== size ||
+    movementV.length !== size
   ) {
     throw new Error("[Landmask] Input tensors must match width*height.");
+  }
+
+  if (!Array.isArray(riftPotentialByEra) || riftPotentialByEra.length <= 0) {
+    throw new Error("[Landmask] Expected riftPotentialByEra to be a non-empty array.");
+  }
+  for (let e = 0; e < riftPotentialByEra.length; e++) {
+    const era = riftPotentialByEra[e];
+    if (!(era instanceof Uint8Array)) {
+      throw new Error(`[Landmask] Expected riftPotentialByEra[${e}] to be Uint8Array.`);
+    }
+    if (era.length !== size) {
+      throw new Error(`[Landmask] Expected riftPotentialByEra[${e}] length ${size}.`);
+    }
   }
 
   return {
@@ -46,5 +70,9 @@ export function validateLandmaskInputs(
     crustAge,
     provenanceOriginEra,
     provenanceDriftDistance,
+    riftPotentialByEra,
+    fractureTotal,
+    movementU,
+    movementV,
   };
 }

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/rules/index.ts
@@ -5,79 +5,46 @@ import type { ComputeLandmaskTypes } from "../types.js";
  */
 export function validateLandmaskInputs(
   input: ComputeLandmaskTypes["input"]
-): { size: number; elevation: Int16Array } {
+): {
+  size: number;
+  elevation: Int16Array;
+  boundaryCloseness: Uint8Array;
+  crustType: Uint8Array;
+  crustBaseElevation: Float32Array;
+  crustAge: Uint8Array;
+  provenanceOriginEra: Uint8Array;
+  provenanceDriftDistance: Uint8Array;
+} {
   const { width, height } = input;
   const size = Math.max(0, (width | 0) * (height | 0));
   const elevation = input.elevation as Int16Array;
-  if (elevation.length !== size) {
-    throw new Error(`Expected elevation length ${size} (received ${elevation.length}).`);
-  }
-  return { size, elevation };
-}
+  const boundaryCloseness = input.boundaryCloseness as Uint8Array;
+  const crustType = input.crustType as Uint8Array;
+  const crustBaseElevation = input.crustBaseElevation as Float32Array;
+  const crustAge = input.crustAge as Uint8Array;
+  const provenanceOriginEra = input.provenanceOriginEra as Uint8Array;
+  const provenanceDriftDistance = input.provenanceDriftDistance as Uint8Array;
 
-/**
- * Applies plate-aware basin separation to carve ocean buffers.
- */
-export function applyBasinSeparation(
-  width: number,
-  height: number,
-  landMask: Uint8Array,
-  config: ComputeLandmaskTypes["config"]["default"]["basinSeparation"]
-): void {
-  if (!config.enabled) return;
-  const base = Math.max(0, Math.round(config.baseSeparationTiles));
-  if (base <= 0) return;
-
-  const bandPairs = config.bandPairs ?? [];
-  let maxBand = 1;
-  for (const [a, b] of bandPairs) {
-    maxBand = Math.max(maxBand, a, b);
-  }
-  const bands = Math.max(2, maxBand + 1);
-  const half = Math.max(1, Math.floor(base / 2));
-
-  const boundaries = new Set<number>();
-  for (const [a, b] of bandPairs) {
-    const boundary = Math.max(a | 0, b | 0);
-    if (boundary > 0 && boundary < bands) boundaries.add(boundary);
-  }
-  if (boundaries.size === 0) {
-    for (let boundary = 1; boundary < bands; boundary++) {
-      boundaries.add(boundary);
-    }
+  if (
+    elevation.length !== size ||
+    boundaryCloseness.length !== size ||
+    crustType.length !== size ||
+    crustBaseElevation.length !== size ||
+    crustAge.length !== size ||
+    provenanceOriginEra.length !== size ||
+    provenanceDriftDistance.length !== size
+  ) {
+    throw new Error("[Landmask] Input tensors must match width*height.");
   }
 
-  const sortedBoundaries = Array.from(boundaries).sort((a, b) => a - b);
-
-  for (const band of sortedBoundaries) {
-    const center = Math.round((band / bands) * width);
-    const start = Math.max(0, center - half);
-    const end = Math.min(width - 1, center + half);
-    for (let y = 0; y < height; y++) {
-      const row = y * width;
-      for (let x = start; x <= end; x++) {
-        landMask[row + x] = 0;
-      }
-    }
-  }
-
-  if (config.edgeWest.enabled) {
-    const edge = Math.max(0, Math.round(config.edgeWest.baseTiles));
-    for (let y = 0; y < height; y++) {
-      const row = y * width;
-      for (let x = 0; x < Math.min(width, edge); x++) {
-        landMask[row + x] = 0;
-      }
-    }
-  }
-
-  if (config.edgeEast.enabled) {
-    const edge = Math.max(0, Math.round(config.edgeEast.baseTiles));
-    for (let y = 0; y < height; y++) {
-      const row = y * width;
-      for (let x = Math.max(0, width - edge); x < width; x++) {
-        landMask[row + x] = 0;
-      }
-    }
-  }
+  return {
+    size,
+    elevation,
+    boundaryCloseness,
+    crustType,
+    crustBaseElevation,
+    crustAge,
+    provenanceOriginEra,
+    provenanceDriftDistance,
+  };
 }

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/strategies/default.ts
@@ -1,55 +1,309 @@
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
+import { clamp01 } from "@swooper/mapgen-core/lib/math";
 
 import ComputeLandmaskContract from "../contract.js";
-import { applyBasinSeparation, validateLandmaskInputs } from "../rules/index.js";
+import { validateLandmaskInputs } from "../rules/index.js";
+
+function buildCoarseAverage(width: number, height: number, values: Float32Array, grain: number): Float32Array {
+  const size = Math.max(0, (width | 0) * (height | 0));
+  const g = Math.max(1, Math.round(grain)) | 0;
+  const gx = Math.max(1, Math.ceil(width / g)) | 0;
+  const gy = Math.max(1, Math.ceil(height / g)) | 0;
+  const sums = new Float32Array(gx * gy);
+  const counts = new Int32Array(gx * gy);
+
+  for (let y = 0; y < height; y++) {
+    const gyIdx = ((y / g) | 0) * gx;
+    for (let x = 0; x < width; x++) {
+      const cell = gyIdx + ((x / g) | 0);
+      const i = y * width + x;
+      sums[cell] += values[i] ?? 0;
+      counts[cell] += 1;
+    }
+  }
+
+  const out = new Float32Array(size);
+  for (let y = 0; y < height; y++) {
+    const gyIdx = ((y / g) | 0) * gx;
+    for (let x = 0; x < width; x++) {
+      const cell = gyIdx + ((x / g) | 0);
+      const denom = counts[cell] || 1;
+      out[y * width + x] = sums[cell] / denom;
+    }
+  }
+
+  return out;
+}
+
+function blurHex(width: number, height: number, values: Float32Array, steps: number): Float32Array {
+  const size = Math.max(0, (width | 0) * (height | 0));
+  const n = Math.max(0, Math.round(steps)) | 0;
+  if (n <= 0) return values;
+
+  let current: Float32Array = values;
+  let next: Float32Array = new Float32Array(size);
+  for (let pass = 0; pass < n; pass++) {
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const i = y * width + x;
+        let sum = current[i] ?? 0;
+        let count = 1;
+        forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+          const ni = ny * width + nx;
+          sum += current[ni] ?? 0;
+          count++;
+        });
+        next[i] = sum / count;
+      }
+    }
+    const tmp: Float32Array = current;
+    current = next;
+    next = tmp;
+  }
+
+  return current;
+}
+
+function chooseThresholdForLandCount(potential: Float32Array, landCount: number): number {
+  const size = potential.length;
+  const desired = Math.max(0, Math.min(size, landCount | 0)) | 0;
+  if (desired <= 0) return Infinity;
+  if (desired >= size) return -Infinity;
+  const values = Array.from(potential);
+  values.sort((a, b) => a - b);
+  const idx = Math.max(0, Math.min(values.length - 1, values.length - desired));
+  return values[idx] ?? 0;
+}
+
+function countLand(landMask: Uint8Array): number {
+  let n = 0;
+  for (let i = 0; i < landMask.length; i++) n += landMask[i] === 1 ? 1 : 0;
+  return n;
+}
+
+function computeComponents(width: number, height: number, landMask: Uint8Array): { id: Int32Array; sizes: number[] } {
+  const size = Math.max(0, (width | 0) * (height | 0));
+  const id = new Int32Array(size);
+  id.fill(-1);
+
+  const sizes: number[] = [];
+  const queue = new Int32Array(size);
+
+  let nextId = 0;
+  for (let start = 0; start < size; start++) {
+    if (landMask[start] !== 1) continue;
+    if (id[start] !== -1) continue;
+
+    let head = 0;
+    let tail = 0;
+    queue[tail++] = start;
+    id[start] = nextId;
+    let componentSize = 0;
+
+    while (head < tail) {
+      const idx = queue[head++]!;
+      componentSize++;
+      const y = (idx / width) | 0;
+      const x = idx - y * width;
+      forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+        const ni = ny * width + nx;
+        if (landMask[ni] !== 1) return;
+        if (id[ni] !== -1) return;
+        id[ni] = nextId;
+        queue[tail++] = ni;
+      });
+    }
+
+    sizes.push(componentSize);
+    nextId++;
+  }
+
+  return { id, sizes };
+}
+
+function pruneSpeckle(params: {
+  width: number;
+  height: number;
+  landMask: Uint8Array;
+  keepFraction: number;
+}): void {
+  const { width, height, landMask } = params;
+  const keepFraction = clamp01(params.keepFraction);
+  const totalLand = countLand(landMask);
+  if (totalLand <= 0) return;
+
+  const { id, sizes } = computeComponents(width, height, landMask);
+  const order = sizes
+    .map((size, idx) => ({ size, idx }))
+    .sort((a, b) => b.size - a.size)
+    .map((entry) => entry.idx);
+
+  const keepUntil = Math.max(1, Math.ceil(totalLand * keepFraction));
+  const keep = new Uint8Array(sizes.length);
+  let kept = 0;
+  for (const compId of order) {
+    keep[compId] = 1;
+    kept += sizes[compId] ?? 0;
+    if (kept >= keepUntil) break;
+  }
+
+  for (let i = 0; i < landMask.length; i++) {
+    if (landMask[i] !== 1) continue;
+    const comp = id[i] ?? -1;
+    if (comp < 0 || keep[comp] !== 1) landMask[i] = 0;
+  }
+}
+
+function fillToTarget(params: {
+  width: number;
+  height: number;
+  landMask: Uint8Array;
+  potential: Float32Array;
+  desiredLandCount: number;
+}): void {
+  const { width, height, landMask, potential } = params;
+  const desired = Math.max(0, Math.min(landMask.length, params.desiredLandCount | 0)) | 0;
+  let current = countLand(landMask);
+  if (current >= desired) return;
+
+  // Grow continents by annexing high-potential water adjacent to existing land.
+  // Recompute frontier in rounds to allow growth to continue outward.
+  for (let round = 0; round < 8 && current < desired; round++) {
+    const candidates: { idx: number; score: number }[] = [];
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const i = y * width + x;
+        if (landMask[i] === 1) continue;
+        let adjacentLand = 0;
+        forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+          if (adjacentLand) return;
+          const ni = ny * width + nx;
+          if (landMask[ni] === 1) adjacentLand = 1;
+        });
+        if (!adjacentLand) continue;
+        const base = potential[i] ?? 0;
+        candidates.push({ idx: i, score: base });
+      }
+    }
+    if (candidates.length === 0) break;
+    candidates.sort((a, b) => b.score - a.score);
+
+    for (const c of candidates) {
+      if (current >= desired) break;
+      if (landMask[c.idx] === 1) continue;
+      // Still must be adjacent to land at time-of-flip.
+      const y = (c.idx / width) | 0;
+      const x = c.idx - y * width;
+      let adjacentLand = 0;
+      forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+        if (adjacentLand) return;
+        const ni = ny * width + nx;
+        if (landMask[ni] === 1) adjacentLand = 1;
+      });
+      if (!adjacentLand) continue;
+      landMask[c.idx] = 1;
+      current++;
+    }
+  }
+}
+
+function computeDistanceToCoast(width: number, height: number, landMask: Uint8Array): Uint16Array {
+  const size = Math.max(0, (width | 0) * (height | 0));
+  const distanceToCoast = new Uint16Array(size);
+  distanceToCoast.fill(65535);
+  const queue = new Int32Array(size);
+  let head = 0;
+  let tail = 0;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = y * width + x;
+      const isLand = landMask[i] === 1;
+      let isCoastal = false;
+      forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+        if (isCoastal) return;
+        const ni = ny * width + nx;
+        if ((landMask[ni] === 1) !== isLand) isCoastal = true;
+      });
+      if (isCoastal) {
+        distanceToCoast[i] = 0;
+        queue[tail++] = i;
+      }
+    }
+  }
+
+  while (head < tail) {
+    const idx = queue[head++]!;
+    const y = (idx / width) | 0;
+    const x = idx - y * width;
+    const dist = distanceToCoast[idx] ?? 0;
+    forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+      const ni = ny * width + nx;
+      const next = (dist + 1) as number;
+      if ((distanceToCoast[ni] ?? 65535) <= next) return;
+      distanceToCoast[ni] = next;
+      queue[tail++] = ni;
+    });
+  }
+
+  return distanceToCoast;
+}
 
 export const defaultStrategy = createStrategy(ComputeLandmaskContract, "default", {
   run: (input, config) => {
     const { width, height } = input;
-    const { size, elevation } = validateLandmaskInputs(input);
+    const {
+      size,
+      elevation,
+      crustType,
+      crustBaseElevation,
+      crustAge,
+      provenanceOriginEra,
+      provenanceDriftDistance,
+    } = validateLandmaskInputs(input);
 
+    // Preserve hypsometry intent by targeting the land fraction implied by (elevation > seaLevel),
+    // but derive the actual landmask from a low-frequency continent potential grounded in Foundation truth.
+    const seaLevel = input.seaLevel;
+    let desiredLandCount = 0;
+    for (let i = 0; i < size; i++) {
+      desiredLandCount += (elevation[i] ?? 0) > seaLevel ? 1 : 0;
+    }
+    desiredLandCount = Math.max(1, Math.min(size - 1, desiredLandCount));
+
+    const potentialRaw = new Float32Array(size);
+    for (let i = 0; i < size; i++) {
+      const type01 = (crustType[i] ?? 0) === 1 ? 1 : 0;
+      const baseElev01 = clamp01(crustBaseElevation[i] ?? 0);
+      const drift01 = clamp01((provenanceDriftDistance[i] ?? 0) / 255);
+      const originEra01 = clamp01(1 - (provenanceOriginEra[i] ?? 0) / 7);
+      const stability01 = clamp01(0.6 * (1 - drift01) + 0.4 * originEra01);
+      const age01 = clamp01((crustAge[i] ?? 0) / 255);
+
+      // Continent potential: crust truth primary; provenance stability secondary.
+      const p = 0.48 * type01 + 0.28 * baseElev01 + 0.14 * stability01 + 0.1 * age01;
+      potentialRaw[i] = clamp01(p);
+    }
+
+    const coarse = buildCoarseAverage(width, height, potentialRaw, config.continentPotentialGrain);
+    const potential = blurHex(width, height, coarse, config.continentPotentialBlurSteps);
+
+    const threshold = chooseThresholdForLandCount(potential, desiredLandCount);
     const landMask = new Uint8Array(size);
     for (let i = 0; i < size; i++) {
-      landMask[i] = elevation[i] > input.seaLevel ? 1 : 0;
+      landMask[i] = (potential[i] ?? 0) >= threshold ? 1 : 0;
     }
 
-    applyBasinSeparation(width, height, landMask, config.basinSeparation);
+    pruneSpeckle({
+      width,
+      height,
+      landMask,
+      keepFraction: config.keepLandComponentFraction,
+    });
+    fillToTarget({ width, height, landMask, potential, desiredLandCount });
 
-    const distanceToCoast = new Uint16Array(size);
-    distanceToCoast.fill(65535);
-    const queue: number[] = [];
-
-    for (let y = 0; y < height; y++) {
-      for (let x = 0; x < width; x++) {
-        const i = y * width + x;
-        const isLand = landMask[i] === 1;
-        let isCoastal = false;
-        forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
-          if (isCoastal) return;
-          const ni = ny * width + nx;
-          if ((landMask[ni] === 1) !== isLand) isCoastal = true;
-        });
-        if (isCoastal) {
-          distanceToCoast[i] = 0;
-          queue.push(i);
-        }
-      }
-    }
-
-    while (queue.length > 0) {
-      const idx = queue.shift()!;
-      const y = (idx / width) | 0;
-      const x = idx - y * width;
-      const dist = distanceToCoast[idx];
-      forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
-        const ni = ny * width + nx;
-        if (distanceToCoast[ni] <= dist + 1) return;
-        distanceToCoast[ni] = dist + 1;
-        queue.push(ni);
-      });
-    }
-
+    const distanceToCoast = computeDistanceToCoast(width, height, landMask);
     return { landMask, distanceToCoast };
   },
 });

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/strategies/default.ts
@@ -29,7 +29,9 @@ const CRATON_FRACTURE_BLEND_BASE = 0.65;
 const CRATON_FRACTURE_BLEND_GAIN = 0.35;
 const CRATON_SPEED_BLEND_BASE = 0.25;
 const CRATON_SPEED_BLEND_GAIN = 0.75;
-const CRATON_SHOULDER_DEPOSIT_FRACTION = 0.35;
+const CRATON_EMERGENCE_BASE = 0.35;
+const CRATON_EMERGENCE_GAIN = 0.65;
+const CRATON_SHOULDER_DEPOSIT_FRACTION = 0.2;
 const CRATON_DIFFUSION_FANOUT = 7; // self + 6 neighbors
 
 function buildCoarseAverage(width: number, height: number, values: Float32Array, grain: number): Float32Array {
@@ -389,7 +391,10 @@ export const defaultStrategy = createStrategy(ComputeLandmaskContract, "default"
 
             const fractureBlend = CRATON_FRACTURE_BLEND_BASE + CRATON_FRACTURE_BLEND_GAIN * fracture01;
             const speedBlend = CRATON_SPEED_BLEND_BASE + CRATON_SPEED_BLEND_GAIN * speed01;
-            const nucleate = eraWeight * nucleationScale * rift01 * fractureBlend * speedBlend;
+            const baseElev01 = clamp01(crustBaseElevation[i] ?? 0);
+            const emergenceBias = CRATON_EMERGENCE_BASE + CRATON_EMERGENCE_GAIN * baseElev01;
+
+            const nucleate = eraWeight * nucleationScale * rift01 * fractureBlend * speedBlend * emergenceBias;
             if (nucleate <= 0) continue;
 
             // Deposit on the rift tile and immediate neighbors (rift shoulders).

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
@@ -1,14 +1,10 @@
 import { createStrategy } from "@swooper/mapgen-core/authoring";
+import { clampInt } from "@swooper/mapgen-core/lib/math";
 
 import ComputeShelfMaskContract from "../contract.js";
 
 const BOUNDARY_CONVERGENT = 1;
 const BOUNDARY_TRANSFORM = 3;
-
-function clampInt(value: number, min: number, max: number): number {
-  if (!Number.isFinite(value)) return min;
-  return Math.max(min, Math.min(max, value));
-}
 
 function computeQuantileCutoff(values: Int16Array, count: number, q01: number): number {
   if (count <= 0) return 0;

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
@@ -61,28 +61,9 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
       landmask: {
         strategy: "default",
         config: {
-          basinSeparation: {
-            enabled: false,
-            bandPairs: [],
-            baseSeparationTiles: 0,
-            boundaryClosenessMultiplier: 1.0,
-            maxPerRowDelta: 4,
-            minChannelWidth: 5,
-            channelJitter: 0,
-            respectSeaLanes: true,
-            edgeWest: {
-              enabled: false,
-              baseTiles: 0,
-              boundaryClosenessMultiplier: 1.0,
-              maxPerRowDelta: 2,
-            },
-            edgeEast: {
-              enabled: false,
-              baseTiles: 0,
-              boundaryClosenessMultiplier: 1.0,
-              maxPerRowDelta: 2,
-            },
-          },
+          continentPotentialGrain: 8,
+          continentPotentialBlurSteps: 3,
+          keepLandComponentFraction: 0.985,
         },
       },
     },

--- a/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
@@ -63,28 +63,9 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
       landmask: {
         strategy: "default",
         config: {
-          basinSeparation: {
-            enabled: false,
-            bandPairs: [],
-            baseSeparationTiles: 0,
-            boundaryClosenessMultiplier: 1.0,
-            maxPerRowDelta: 5,
-            minChannelWidth: 3,
-            channelJitter: 0,
-            respectSeaLanes: true,
-            edgeWest: {
-              enabled: false,
-              baseTiles: 0,
-              boundaryClosenessMultiplier: 1.0,
-              maxPerRowDelta: 2,
-            },
-            edgeEast: {
-              enabled: false,
-              baseTiles: 0,
-              boundaryClosenessMultiplier: 1.0,
-              maxPerRowDelta: 2,
-            },
-          },
+          continentPotentialGrain: 8,
+          continentPotentialBlurSteps: 3,
+          keepLandComponentFraction: 0.985,
         },
       },
     },

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
@@ -57,28 +57,9 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
       landmask: {
         strategy: "default",
         config: {
-          basinSeparation: {
-            enabled: false,
-            bandPairs: [],
-            baseSeparationTiles: 3,
-            boundaryClosenessMultiplier: 0.9,
-            maxPerRowDelta: 10,
-            minChannelWidth: 3,
-            channelJitter: 0,
-            respectSeaLanes: true,
-            edgeWest: {
-              enabled: false,
-              baseTiles: 3,
-              boundaryClosenessMultiplier: 0.5,
-              maxPerRowDelta: 1,
-            },
-            edgeEast: {
-              enabled: false,
-              baseTiles: 3,
-              boundaryClosenessMultiplier: 0.5,
-              maxPerRowDelta: 1,
-            },
-          },
+          continentPotentialGrain: 8,
+          continentPotentialBlurSteps: 3,
+          keepLandComponentFraction: 0.985,
         },
       },
     },

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -68,28 +68,9 @@
         "landmask": {
           "strategy": "default",
           "config": {
-            "basinSeparation": {
-              "enabled": false,
-              "bandPairs": [],
-              "baseSeparationTiles": 0,
-              "boundaryClosenessMultiplier": 1,
-              "maxPerRowDelta": 3,
-              "minChannelWidth": 4,
-              "channelJitter": 0,
-              "respectSeaLanes": true,
-              "edgeWest": {
-                "enabled": false,
-                "baseTiles": 0,
-                "boundaryClosenessMultiplier": 1,
-                "maxPerRowDelta": 2
-              },
-              "edgeEast": {
-                "enabled": false,
-                "baseTiles": 0,
-                "boundaryClosenessMultiplier": 1,
-                "maxPerRowDelta": 2
-              }
-            }
+            "continentPotentialGrain": 8,
+            "continentPotentialBlurSteps": 3,
+            "keepLandComponentFraction": 0.985
           }
         }
       },

--- a/mods/mod-swooper-maps/src/presets/standard/earthlike.json
+++ b/mods/mod-swooper-maps/src/presets/standard/earthlike.json
@@ -73,28 +73,9 @@
           "landmask": {
             "strategy": "default",
             "config": {
-              "basinSeparation": {
-                "enabled": false,
-                "bandPairs": [],
-                "baseSeparationTiles": 0,
-                "boundaryClosenessMultiplier": 1,
-                "maxPerRowDelta": 3,
-                "minChannelWidth": 4,
-                "channelJitter": 0,
-                "respectSeaLanes": true,
-                "edgeWest": {
-                  "enabled": false,
-                  "baseTiles": 0,
-                  "boundaryClosenessMultiplier": 1,
-                  "maxPerRowDelta": 2
-                },
-                "edgeEast": {
-                  "enabled": false,
-                  "baseTiles": 0,
-                  "boundaryClosenessMultiplier": 1,
-                  "maxPerRowDelta": 2
-                }
-              }
+              "continentPotentialGrain": 8,
+              "continentPotentialBlurSteps": 3,
+              "keepLandComponentFraction": 0.985
             }
           }
         },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts
@@ -552,6 +552,10 @@ const FoundationTectonicHistoryTilesRollupArtifactSchema = Type.Object(
     }),
     /** Last active era index per tile (0..255; 255 = never). */
     lastActiveEra: TypedArraySchemas.u8({ description: "Last active era index per tile (0..255; 255 = never)." }),
+    /** Plate movement U component per tile (-127..127). */
+    movementU: TypedArraySchemas.i8({ description: "Plate movement U component per tile (-127..127)." }),
+    /** Plate movement V component per tile (-127..127). */
+    movementV: TypedArraySchemas.i8({ description: "Plate movement V component per tile (-127..127)." }),
   },
   { description: "Foundation tectonic history tiles rollup payload (tile-space rollups)." }
 );

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts
@@ -169,13 +169,45 @@ const advancedBudgetsSchema = Type.Object(
   }
 );
 
+const advancedMeshSchema = Type.Object(
+  {
+    cellsPerPlate: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        maximum: 32,
+        description:
+          "Mesh resolution control: number of Voronoi cells per plate. Higher values increase Foundation detail at increased compute cost.",
+      })
+    ),
+    relaxationSteps: Type.Optional(
+      Type.Integer({
+        minimum: 0,
+        maximum: 50,
+        description:
+          "Mesh relaxation passes applied during Voronoi site relaxation. Higher values produce more even cells but cost more.",
+      })
+    ),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Advanced mesh resolution inputs. These are simulation resolution knobs, not output sculpting.",
+    gs: {
+      comments: [
+        "This surface controls simulation resolution (mesh refinement), not output targets.",
+        "Validate changes via mesh/plates diagnostics and downstream determinism suite.",
+      ],
+    },
+  }
+);
+
 /**
  * Foundation knobs (plateCount/plateActivity). Knobs apply after defaulted step config as deterministic transforms.
  */
 const knobsSchema = Type.Object(
   {
-    plateCount: FoundationPlateCountKnobSchema,
-    plateActivity: FoundationPlateActivityKnobSchema,
+    plateCount: Type.Optional(FoundationPlateCountKnobSchema),
+    plateActivity: Type.Optional(FoundationPlateActivityKnobSchema),
   },
   {
     description:
@@ -188,6 +220,7 @@ const advancedSchema = Type.Object(
     mantleForcing: Type.Optional(advancedMantleForcingSchema),
     lithosphere: Type.Optional(advancedLithosphereSchema),
     budgets: Type.Optional(advancedBudgetsSchema),
+    mesh: Type.Optional(advancedMeshSchema),
   },
   {
     additionalProperties: false,
@@ -408,7 +441,8 @@ const FOUNDATION_PROFILE_DEFAULTS: Readonly<
   fine: {
     plateCount: 28,
     mesh: {
-      cellsPerPlate: 2,
+      // Fine = higher mesh resolution than balanced.
+      cellsPerPlate: 16,
       relaxationSteps: 6,
       referenceArea: 4000,
       plateScalePower: 0.5,
@@ -429,7 +463,8 @@ const FOUNDATION_PROFILE_DEFAULTS: Readonly<
   ultra: {
     plateCount: 32,
     mesh: {
-      cellsPerPlate: 2,
+      // Ultra = highest mesh resolution.
+      cellsPerPlate: 18,
       relaxationSteps: 4,
       referenceArea: 4000,
       plateScalePower: 0.5,
@@ -564,14 +599,26 @@ export default createStage({
     const eraWeights = deriveEraWeights({ eraCount });
     const driftStepsByEra = deriveDriftStepsByEra({ eraCount });
 
+    const meshOverrides =
+      advanced && typeof advanced === "object" && "mesh" in advanced ? (advanced as { mesh?: Record<string, unknown> }).mesh ?? {} : {};
+    const meshOverrideValues = meshOverrides as { cellsPerPlate?: unknown; relaxationSteps?: unknown };
+    const meshCellsPerPlate = clampInt(
+      typeof meshOverrideValues.cellsPerPlate === "number" ? meshOverrideValues.cellsPerPlate : defaults.mesh.cellsPerPlate,
+      { min: 1, max: 32 }
+    );
+    const meshRelaxationSteps = clampInt(
+      typeof meshOverrideValues.relaxationSteps === "number" ? meshOverrideValues.relaxationSteps : defaults.mesh.relaxationSteps,
+      { min: 0, max: 50 }
+    );
+
     return {
       mesh: {
         computeMesh: {
           strategy: "default",
           config: {
             plateCount,
-            cellsPerPlate: defaults.mesh.cellsPerPlate,
-            relaxationSteps: defaults.mesh.relaxationSteps,
+            cellsPerPlate: meshCellsPerPlate,
+            relaxationSteps: meshRelaxationSteps,
             referenceArea: defaults.mesh.referenceArea,
             plateScalePower: defaults.mesh.plateScalePower,
           },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts
@@ -1,4 +1,4 @@
-import { clamp01, lerp } from "@swooper/mapgen-core";
+import { clamp01, clampInt, lerp } from "@swooper/mapgen-core";
 import { Type, createStage, type Static } from "@swooper/mapgen-core/authoring";
 import {
   crust,
@@ -507,12 +507,6 @@ const FOUNDATION_STEP_IDS = [
 // trigger for the physics-first `advanced` surface (which includes `advanced.mesh`).
 const FOUNDATION_STUDIO_STEP_CONFIG_IDS = FOUNDATION_STEP_IDS.filter((id) => id.includes("-"));
 
-function clampInt(value: number, bounds: { min: number; max?: number }): number {
-  const rounded = Math.round(value);
-  const max = bounds.max ?? Number.POSITIVE_INFINITY;
-  return Math.max(bounds.min, Math.min(max, rounded));
-}
-
 export default createStage({
   id: "foundation",
   knobsSchema,
@@ -545,7 +539,8 @@ export default createStage({
     const defaults = FOUNDATION_PROFILE_DEFAULTS[profiles.resolutionProfile];
     const plateCount = clampInt(
       typeof knobs.plateCount === "number" ? knobs.plateCount : defaults.plateCount,
-      { min: 2, max: 256 }
+      2,
+      256
     );
 
     const lithosphereOverrides =
@@ -580,14 +575,18 @@ export default createStage({
           )
         : defaults.mantle.amplitudeScale;
     const mantlePlumeCount = clampInt(
-      typeof mantleOverrideValues.plumeCount === "number" ? mantleOverrideValues.plumeCount : defaults.mantle.plumeCount,
-      { min: 2, max: 16 }
+      typeof mantleOverrideValues.plumeCount === "number"
+        ? mantleOverrideValues.plumeCount
+        : defaults.mantle.plumeCount,
+      2,
+      16
     );
     const mantleDownwellingCount = clampInt(
       typeof mantleOverrideValues.downwellingCount === "number"
         ? mantleOverrideValues.downwellingCount
         : defaults.mantle.downwellingCount,
-      { min: 2, max: 16 }
+      2,
+      16
     );
 
     const budgetsOverrides =
@@ -599,7 +598,8 @@ export default createStage({
       typeof budgetsOverrideValues.eraCount === "number"
         ? budgetsOverrideValues.eraCount
         : COMMON_TECTONIC_HISTORY.eraWeights.length,
-      { min: 5, max: 8 }
+      5,
+      8
     );
     const eraWeights = deriveEraWeights({ eraCount });
     const driftStepsByEra = deriveDriftStepsByEra({ eraCount });
@@ -608,12 +608,18 @@ export default createStage({
       advanced && typeof advanced === "object" && "mesh" in advanced ? (advanced as { mesh?: Record<string, unknown> }).mesh ?? {} : {};
     const meshOverrideValues = meshOverrides as { cellsPerPlate?: unknown; relaxationSteps?: unknown };
     const meshCellsPerPlate = clampInt(
-      typeof meshOverrideValues.cellsPerPlate === "number" ? meshOverrideValues.cellsPerPlate : defaults.mesh.cellsPerPlate,
-      { min: 1, max: 32 }
+      typeof meshOverrideValues.cellsPerPlate === "number"
+        ? meshOverrideValues.cellsPerPlate
+        : defaults.mesh.cellsPerPlate,
+      1,
+      32
     );
     const meshRelaxationSteps = clampInt(
-      typeof meshOverrideValues.relaxationSteps === "number" ? meshOverrideValues.relaxationSteps : defaults.mesh.relaxationSteps,
-      { min: 0, max: 50 }
+      typeof meshOverrideValues.relaxationSteps === "number"
+        ? meshOverrideValues.relaxationSteps
+        : defaults.mesh.relaxationSteps,
+      0,
+      50
     );
 
     return {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts
@@ -503,6 +503,10 @@ const FOUNDATION_STEP_IDS = [
   "plate-topology",
 ] as const;
 
+// Studio-only sentinel mode uses per-step config objects under `advanced.<stepId>`. This should not
+// trigger for the physics-first `advanced` surface (which includes `advanced.mesh`).
+const FOUNDATION_STUDIO_STEP_CONFIG_IDS = FOUNDATION_STEP_IDS.filter((id) => id.includes("-"));
+
 function clampInt(value: number, bounds: { min: number; max?: number }): number {
   const rounded = Math.round(value);
   const max = bounds.max ?? Number.POSITIVE_INFINITY;
@@ -522,7 +526,8 @@ export default createStage({
   }) => {
     const advanced = config.advanced as Record<string, unknown> | undefined;
     if (advanced && typeof advanced === "object") {
-      const hasSentinel = FOUNDATION_STEP_IDS.some((stepId) =>
+      // Avoid colliding with `advanced.mesh` (physics), which is not a per-step config override.
+      const hasSentinel = FOUNDATION_STUDIO_STEP_CONFIG_IDS.some((stepId) =>
         Object.prototype.hasOwnProperty.call(advanced, stepId)
       );
       if (hasSentinel) {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts
@@ -1,4 +1,4 @@
-import { ctxRandom, ctxRandomLabel, defineVizMeta } from "@swooper/mapgen-core";
+import { clampInt, ctxRandom, ctxRandomLabel, defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { foundationArtifacts } from "../artifacts.js";
 import MeshStepContract from "./mesh.contract.js";
@@ -7,12 +7,6 @@ import type { FoundationPlateCountKnob } from "@mapgen/domain/foundation/shared/
 import { interleaveXY, segmentsFromMeshNeighbors } from "./viz.js";
 
 const GROUP_MESH = "Foundation / Mesh";
-
-function clampInt(value: number, bounds: { min: number; max?: number }): number {
-  const rounded = Math.round(value);
-  const max = bounds.max ?? Number.POSITIVE_INFINITY;
-  return Math.max(bounds.min, Math.min(max, rounded));
-}
 
 export default createStep(MeshStepContract, {
   artifacts: implementArtifacts([foundationArtifacts.mesh], {
@@ -29,15 +23,12 @@ export default createStep(MeshStepContract, {
       config.computeMesh.strategy === "default" && override !== undefined
         ? {
             ...config.computeMesh,
-            config: {
-              ...config.computeMesh.config,
-              plateCount: clampInt(override, {
-                min: 2,
-                max: 256,
-              }),
-            },
-          }
-        : config.computeMesh;
+	            config: {
+	              ...config.computeMesh.config,
+	              plateCount: clampInt(override, 2, 256),
+	            },
+	          }
+	        : config.computeMesh;
 
     return { ...config, computeMesh };
   },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.ts
@@ -1,4 +1,4 @@
-import { ctxRandom, ctxRandomLabel, defineVizMeta } from "@swooper/mapgen-core";
+import { clampInt, ctxRandom, ctxRandomLabel, defineVizMeta } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { foundationArtifacts } from "../artifacts.js";
 import PlateGraphStepContract from "./plateGraph.contract.js";
@@ -7,12 +7,6 @@ import type { FoundationPlateCountKnob } from "@mapgen/domain/foundation/shared/
 import { interleaveXY, pointsFromPlateSeeds } from "./viz.js";
 
 const GROUP_PLATE_GRAPH = "Foundation / Plate Graph";
-
-function clampInt(value: number, bounds: { min: number; max?: number }): number {
-  const rounded = Math.round(value);
-  const max = bounds.max ?? Number.POSITIVE_INFINITY;
-  return Math.max(bounds.min, Math.min(max, rounded));
-}
 
 export default createStep(PlateGraphStepContract, {
   artifacts: implementArtifacts([foundationArtifacts.plateGraph], {
@@ -29,15 +23,12 @@ export default createStep(PlateGraphStepContract, {
       config.computePlateGraph.strategy === "default" && override !== undefined
         ? {
             ...config.computePlateGraph,
-            config: {
-              ...config.computePlateGraph.config,
-              plateCount: clampInt(override, {
-                min: 2,
-                max: 256,
-              }),
-            },
-          }
-        : config.computePlateGraph;
+	            config: {
+	              ...config.computePlateGraph.config,
+	              plateCount: clampInt(override, 2, 256),
+	            },
+	          }
+	        : config.computePlateGraph;
 
     return { ...config, computePlateGraph };
   },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts
@@ -15,7 +15,7 @@ import {
   resolvePlateActivityKinematicsMultiplier,
 } from "@mapgen/domain/foundation/shared/knob-multipliers.js";
 import type { FoundationPlateActivityKnob } from "@mapgen/domain/foundation/shared/knobs.js";
-import { clampFinite } from "@swooper/mapgen-core/lib/math";
+import { clampFinite, clampInt } from "@swooper/mapgen-core/lib/math";
 
 const GROUP_PLATES = "Foundation / Plates";
 const GROUP_CRUST_TILES = "Foundation / Crust Tiles";
@@ -23,12 +23,6 @@ const GROUP_TILE_MAP = "Foundation / Tile Mapping";
 const GROUP_TECTONIC_HISTORY_TILES = "Foundation / Tectonic History Tiles";
 const GROUP_TECTONIC_PROVENANCE_TILES = "Foundation / Tectonic Provenance Tiles";
 const TILE_SPACE_ID = "tile.hexOddR" as const;
-
-function clampInt(value: number, bounds: { min: number; max?: number }): number {
-  const rounded = Math.round(value);
-  const max = bounds.max ?? Number.POSITIVE_INFINITY;
-  return Math.max(bounds.min, Math.min(max, rounded));
-}
 
 export default createStep(ProjectionStepContract, {
   artifacts: implementArtifacts(
@@ -68,16 +62,17 @@ export default createStep(ProjectionStepContract, {
       config.computePlates.strategy === "default"
         ? {
             ...config.computePlates,
-            config: {
-              ...config.computePlates.config,
-              boundaryInfluenceDistance: clampInt(
-                (config.computePlates.config.boundaryInfluenceDistance ?? 0) + boundaryDelta,
-                { min: 1, max: 32 }
-              ),
-              movementScale: clampFinite((config.computePlates.config.movementScale ?? 0) * kinematicsMultiplier, 1, 200),
-              rotationScale: clampFinite((config.computePlates.config.rotationScale ?? 0) * kinematicsMultiplier, 1, 200),
-            },
-          }
+	            config: {
+	              ...config.computePlates.config,
+	              boundaryInfluenceDistance: clampInt(
+	                (config.computePlates.config.boundaryInfluenceDistance ?? 0) + boundaryDelta,
+	                1,
+	                32
+	              ),
+	              movementScale: clampFinite((config.computePlates.config.movementScale ?? 0) * kinematicsMultiplier, 1, 200),
+	              rotationScale: clampFinite((config.computePlates.config.rotationScale ?? 0) * kinematicsMultiplier, 1, 200),
+	            },
+	          }
         : config.computePlates;
 
     return { ...config, computePlates };

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts
@@ -368,6 +368,15 @@ export function validateTectonicHistoryTilesArtifact(value: unknown, dims: MapDi
       throw new Error(`[FoundationArtifact] Invalid foundation tectonicHistoryTiles.rollups.${label}.`);
     }
   }
+
+  const movementU = (rollups as { movementU?: unknown }).movementU;
+  if (!(movementU instanceof Int8Array) || movementU.length !== expectedLen) {
+    throw new Error("[FoundationArtifact] Invalid foundation tectonicHistoryTiles.rollups.movementU.");
+  }
+  const movementV = (rollups as { movementV?: unknown }).movementV;
+  if (!(movementV instanceof Int8Array) || movementV.length !== expectedLen) {
+    throw new Error("[FoundationArtifact] Invalid foundation tectonicHistoryTiles.rollups.movementV.");
+  }
 }
 
 export function validateTectonicProvenanceTilesArtifact(value: unknown, dims: MapDimensions): void {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/plotRivers.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/plotRivers.ts
@@ -6,6 +6,7 @@ import {
   snapshotEngineHeightfield,
 } from "@swooper/mapgen-core";
 import { createStep } from "@swooper/mapgen-core/authoring";
+import { clampInt } from "@swooper/mapgen-core/lib/math";
 import PlotRiversStepContract from "./plotRivers.contract.js";
 import {
   HYDROLOGY_RIVER_DENSITY_LENGTH_BOUNDS,
@@ -14,13 +15,6 @@ import type { HydrologyRiverDensityKnob } from "@mapgen/domain/hydrology/shared/
 
 const GROUP_MAP_HYDROLOGY = "Map / Hydrology (Engine)";
 const TILE_SPACE_ID = "tile.hexOddR" as const;
-
-function clampInt(value: number, min: number, max: number): number {
-  const int = Math.trunc(value);
-  if (int < min) return min;
-  if (int > max) return max;
-  return int;
-}
 
 export default createStep(PlotRiversStepContract, {
   normalize: (config, ctx) => {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.ts
@@ -230,6 +230,11 @@ export default createStep(LandmassPlatesStepContract, {
         elevation: baseTopography.elevation,
         seaLevel: seaLevel.seaLevel,
         boundaryCloseness: beltDrivers.boundaryCloseness,
+        crustType: crustTiles.type,
+        crustBaseElevation: crustTiles.baseElevation,
+        crustAge: crustTiles.age,
+        provenanceOriginEra: provenanceTiles.originEra,
+        provenanceDriftDistance: provenanceTiles.driftDistance,
       },
       config.landmask
     );

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.ts
@@ -235,6 +235,10 @@ export default createStep(LandmassPlatesStepContract, {
         crustAge: crustTiles.age,
         provenanceOriginEra: provenanceTiles.originEra,
         provenanceDriftDistance: provenanceTiles.driftDistance,
+        riftPotentialByEra: historyTiles.perEra.map((era) => era.riftPotential),
+        fractureTotal: historyTiles.rollups.fractureTotal,
+        movementU: historyTiles.rollups.movementU,
+        movementV: historyTiles.rollups.movementV,
       },
       config.landmask
     );

--- a/mods/mod-swooper-maps/test/morphology/m11-hypsometry-continental-fraction.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m11-hypsometry-continental-fraction.test.ts
@@ -163,6 +163,10 @@ describe("m11 hypsometry: continentalFraction does not collapse water coverage",
         crustAge: crustTiles.age,
         provenanceOriginEra: projection.tectonicProvenanceTiles.originEra,
         provenanceDriftDistance: projection.tectonicProvenanceTiles.driftDistance,
+        riftPotentialByEra: projection.tectonicHistoryTiles.perEra.map((era) => era.riftPotential),
+        fractureTotal: projection.tectonicHistoryTiles.rollups.fractureTotal,
+        movementU: plates.movementU,
+        movementV: plates.movementV,
       },
       computeLandmask.defaultConfig
     );

--- a/mods/mod-swooper-maps/test/morphology/m11-hypsometry-continental-fraction.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m11-hypsometry-continental-fraction.test.ts
@@ -152,14 +152,19 @@ describe("m11 hypsometry: continentalFraction does not collapse water coverage",
     ).seaLevel;
 
     const landmask = computeLandmask.run(
-      { width, height, elevation: baseTopography.elevation, seaLevel, boundaryCloseness: plates.boundaryCloseness },
       {
-        ...computeLandmask.defaultConfig,
-        config: {
-          ...computeLandmask.defaultConfig.config,
-          basinSeparation: { ...computeLandmask.defaultConfig.config.basinSeparation, enabled: false },
-        },
-      }
+        width,
+        height,
+        elevation: baseTopography.elevation,
+        seaLevel,
+        boundaryCloseness: plates.boundaryCloseness,
+        crustType,
+        crustBaseElevation,
+        crustAge: crustTiles.age,
+        provenanceOriginEra: projection.tectonicProvenanceTiles.originEra,
+        provenanceDriftDistance: projection.tectonicProvenanceTiles.driftDistance,
+      },
+      computeLandmask.defaultConfig
     );
 
     let land = 0;

--- a/mods/mod-swooper-maps/test/morphology/m12-mountains-present.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m12-mountains-present.test.ts
@@ -148,7 +148,18 @@ describe("m12 mountains: ridge planning produces some non-volcano mountains", ()
     ).seaLevel;
 
     const landmask = computeLandmask.run(
-      { width, height, elevation: baseTopography.elevation, seaLevel, boundaryCloseness: plates.boundaryCloseness },
+      {
+        width,
+        height,
+        elevation: baseTopography.elevation,
+        seaLevel,
+        boundaryCloseness: plates.boundaryCloseness,
+        crustType,
+        crustBaseElevation,
+        crustAge: crustTiles.age,
+        provenanceOriginEra: projection.tectonicProvenanceTiles.originEra,
+        provenanceDriftDistance: projection.tectonicProvenanceTiles.driftDistance,
+      },
       computeLandmask.defaultConfig
     );
 

--- a/mods/mod-swooper-maps/test/morphology/m12-mountains-present.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m12-mountains-present.test.ts
@@ -159,6 +159,10 @@ describe("m12 mountains: ridge planning produces some non-volcano mountains", ()
         crustAge: crustTiles.age,
         provenanceOriginEra: projection.tectonicProvenanceTiles.originEra,
         provenanceDriftDistance: projection.tectonicProvenanceTiles.driftDistance,
+        riftPotentialByEra: projection.tectonicHistoryTiles.perEra.map((era) => era.riftPotential),
+        fractureTotal: projection.tectonicHistoryTiles.rollups.fractureTotal,
+        movementU: plates.movementU,
+        movementV: plates.movementV,
       },
       computeLandmask.defaultConfig
     );

--- a/mods/mod-swooper-maps/test/support/standard-config.ts
+++ b/mods/mod-swooper-maps/test/support/standard-config.ts
@@ -82,26 +82,10 @@ const foundationConfig = {
   knobs: { plateCount: 23, plateActivity: 0.5 },
 };
 
-const basinSeparationConfig = {
-  enabled: false,
-  baseSeparationTiles: 0,
-  boundaryClosenessMultiplier: 1.0,
-  maxPerRowDelta: 3,
-  minChannelWidth: 4,
-  channelJitter: 0,
-  respectSeaLanes: true,
-  edgeWest: {
-    enabled: false,
-    baseTiles: 0,
-    boundaryClosenessMultiplier: 1.0,
-    maxPerRowDelta: 2,
-  },
-  edgeEast: {
-    enabled: false,
-    baseTiles: 0,
-    boundaryClosenessMultiplier: 1.0,
-    maxPerRowDelta: 2,
-  },
+const landmaskConfig = {
+  continentPotentialGrain: 8,
+  continentPotentialBlurSteps: 3,
+  keepLandComponentFraction: 0.985,
 };
 
 const biomesConfig = {
@@ -389,7 +373,7 @@ export const standardConfig = {
         seaLevel: { strategy: "default", config: hypsometryConfig },
         landmask: {
           strategy: "default",
-          config: { basinSeparation: basinSeparationConfig },
+          config: landmaskConfig,
         },
       },
       "rugged-coasts": {

--- a/packages/mapgen-core/src/lib/math/clamp.ts
+++ b/packages/mapgen-core/src/lib/math/clamp.ts
@@ -12,6 +12,19 @@ export function clampInt(value: number, min: number, max: number): number {
   return clamp(v, min, max);
 }
 
+/**
+ * Clamp a value into an unsigned byte (0..255) and coerce to an integer.
+ *
+ * Notes:
+ * - This is intentionally used across the pipeline to avoid dozens of ad-hoc
+ *   `clampByte` helpers that silently differ in rounding and NaN handling.
+ */
+export function clampU8(value: number): number {
+  const v = Math.trunc(value);
+  if (!Number.isFinite(v)) return 0;
+  return clamp(v, 0, 255);
+}
+
 export function clampPct(value: number, min: number, max: number, fallback: number = min): number {
   if (!Number.isFinite(value)) return fallback;
   return clamp(value, min, max);


### PR DESCRIPTION
# Pipeline Realism Remediation: Foundation Truth to Morphology Cutover

This PR implements a comprehensive overhaul of the map generation pipeline to ensure Morphology derives continents and landmasses directly from Foundation's physics and tectonics truth. The changes establish a single causal spine from Foundation to Morphology, eliminating noise/threshold-driven landmask generation.

Key improvements:

- **Foundation Truth Non-Degenerate**: Calibrated provenance reset thresholds to emitted driver magnitudes, ensuring crust type and age are no longer uniform/saturated
- **Physics-Grounded Landmask**: Replaced noise/threshold landmask with a continent-scale classifier derived from crust truth and provenance stability
- **Rift-Driven Craton Growth**: Added deterministic, time-stepped simulation of continental craton growth driven by rifts/fractures and plate motion
- **Erosion Coherence**: Prevented geomorphology from silently fragmenting continents during erosion by preserving the pre-erosion landmask
- **Belt Diffusion Seeding**: Enforced positive-intensity seeding for belt diffusion to prevent zero-intensity corridor tiles from suppressing influence
- **Observability Enforcement**: Hardened gates to reflect runtime truth, including uncapped residual distribution for plateFitP90 and runtime-normalized mountain config

The PR includes extensive evidence bundles for each phase, with numeric gates confirming the improvements:
- Land components reduced from hundreds to single digits
- Largest land component fraction increased from ~0.26 to ~0.58
- Land percentage remains within sane bounds

All tests pass, including no-shadow paths, determinism suite, and foundation gates.