### PR TITLE
fix(morphology): improve belt driver seeding and proximity calculation

### DIFF
--- a/mods/mod-swooper-maps/test/morphology/belt-drivers-boundary-closeness.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/belt-drivers-boundary-closeness.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+
+import { deriveBeltDriversFromHistory } from "../../src/domain/morphology/ops/compute-belt-drivers/deriveFromHistory.js";
+
+function buildHistoryTiles(width: number, height: number, eraCount: number) {
+  const size = width * height;
+  const perEra = Array.from({ length: eraCount }, () => ({
+    boundaryType: new Uint8Array(size),
+    upliftPotential: new Uint8Array(size),
+    riftPotential: new Uint8Array(size),
+    shearStress: new Uint8Array(size),
+    volcanism: new Uint8Array(size),
+    fracture: new Uint8Array(size),
+  }));
+  const rollups = {
+    upliftTotal: new Uint8Array(size),
+    fractureTotal: new Uint8Array(size),
+    volcanismTotal: new Uint8Array(size),
+    upliftRecentFraction: new Uint8Array(size),
+    lastActiveEra: new Uint8Array(size),
+  };
+  rollups.lastActiveEra.fill(255);
+  return { version: 1, eraCount, perEra, rollups };
+}
+
+function buildProvenanceTiles(width: number, height: number) {
+  const size = width * height;
+  const provenance = {
+    version: 1,
+    originEra: new Uint8Array(size),
+    originPlateId: new Int16Array(size),
+    driftDistance: new Uint8Array(size),
+    lastBoundaryEra: new Uint8Array(size),
+    lastBoundaryType: new Uint8Array(size),
+  };
+  provenance.lastBoundaryEra.fill(255);
+  provenance.lastBoundaryType.fill(255);
+  provenance.originPlateId.fill(-1);
+  return provenance;
+}
+
+describe("belt drivers: boundaryCloseness semantics", () => {
+  it("boundaryCloseness is pure proximity (seed tile is near-255 even when intensity is low)", () => {
+    const width = 12;
+    const height = 1;
+    const historyTiles = buildHistoryTiles(width, height, 3);
+    const provenanceTiles = buildProvenanceTiles(width, height);
+
+    const era = historyTiles.perEra[2]!;
+    // Make a small convergent corridor that survives MIN_BELT_LENGTH.
+    for (let i = 3; i <= 8; i++) {
+      era.boundaryType[i] = 1;
+      historyTiles.rollups.lastActiveEra[i] = 2;
+      // Ensure boundary type is recoverable even when intensity is localized and the "best era"
+      // chooser would otherwise pick an all-zero era for boundaryType.
+      provenanceTiles.lastBoundaryType[i] = 1;
+      provenanceTiles.lastBoundaryEra[i] = 2;
+    }
+
+    // Give intensity only at a single seed tile (not max).
+    const seedIdx = 5;
+    era.upliftPotential[seedIdx] = 64;
+    historyTiles.rollups.upliftTotal[seedIdx] = 64;
+
+    const drivers = deriveBeltDriversFromHistory({ width, height, historyTiles, provenanceTiles });
+
+    expect(drivers.beltMask[seedIdx]).toBe(1);
+    expect(drivers.boundaryCloseness[seedIdx]).toBeGreaterThanOrEqual(240);
+    // Ensure we're not accidentally scaling closeness by intensity.
+    expect(drivers.boundaryCloseness[seedIdx]).toBeGreaterThan(64);
+  });
+});

--- a/mods/mod-swooper-maps/test/support/standard-config.ts
+++ b/mods/mod-swooper-maps/test/support/standard-config.ts
@@ -37,17 +37,20 @@ const coastConfig = {
 };
 
 const mountainsConfig = {
-  tectonicIntensity: 0.65,
-  mountainThreshold: 0.62,
+  // Physics-first: mountain placement should be primarily driven by belts/uplift history, not
+  // fractal noise. Keep thresholds compatible with current driver magnitudes so invariants can
+  // catch "no mountains" regressions.
+  tectonicIntensity: 1.4,
+  mountainThreshold: 0.55,
   hillThreshold: 0.32,
-  upliftWeight: 0.4,
-  fractalWeight: 0.45,
+  upliftWeight: 0.45,
+  fractalWeight: 0.2,
   riftDepth: 0.25,
-  boundaryWeight: 0.55,
+  boundaryWeight: 1.0,
   boundaryGate: 0,
   boundaryExponent: 1.15,
   interiorPenaltyWeight: 0.15,
-  convergenceBonus: 0.6,
+  convergenceBonus: 1.0,
   transformPenalty: 0.6,
   riftPenalty: 0.76,
   hillBoundaryWeight: 0.32,


### PR DESCRIPTION
# Improved Belt Driver Calculation for Mountain Placement

This PR enhances the tectonic belt driver calculation to produce more realistic mountain ranges. Key improvements include:

- Added explicit constants for all tuning parameters with descriptive names
- Fixed mountain belt seeding to use a threshold relative to maximum intensity, creating proper "spine" formations
- Modified era weighting to better favor newer eras with a boost for last-active regions
- Improved width modulation based on uplift recency
- Used total uplift history for mountain belts instead of just newest-era influence
- Refined boundary closeness to be a pure distance signal, separating it from intensity
- Added test to verify boundary closeness semantics
- Updated mountain configuration parameters to prioritize physics-based placement over fractal noise

These changes result in more realistic mountain ranges that follow tectonic boundaries more naturally, with better differentiation between young, narrow mountain ranges and older, wider ones.