### PR TITLE
fix(map-morphology): remove redundant terrain validation in buildElevation

### DIFF
--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/buildElevation.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/buildElevation.ts
@@ -11,11 +11,12 @@ export default createStep(BuildElevationStepContract, {
     const topography = deps.artifacts.topography.read(context);
     const { width, height } = context.dimensions;
 
-    // Align with base-standard posture: validate + stamp before buildElevation so
-    // engine elevation/cliffs reflect the finalized terrain surface (incl. mountains/volcanoes).
-    context.adapter.validateAndFixTerrain();
-    context.adapter.recalculateAreas();
-    context.adapter.stampContinents();
+    // Base-standard ordering: do not call validateAndFixTerrain/stampContinents here.
+    // We have already stamped land/water + coasts from Morphology truth and verified
+    // no drift earlier (plot-coasts/plot-continents/plot-mountains/plot-volcanoes).
+    //
+    // Calling validateAndFixTerrain here can reclassify coastal tiles (engine coast/lake
+    // repair) and violate our "landMask is authoritative" invariant.
     context.adapter.recalculateAreas();
     context.adapter.buildElevation();
     context.adapter.recalculateAreas();


### PR DESCRIPTION
Removed redundant terrain validation and stamping in buildElevation step

This PR removes calls to `validateAndFixTerrain()` and `stampContinents()` in the buildElevation step, as these operations have already been performed earlier in the pipeline. The previous approach could cause coastal tiles to be reclassified, violating the "landMask is authoritative" invariant. 

The change maintains a single call to `recalculateAreas()` before building elevation to ensure proper area calculations, preserving the intended map generation flow while preventing potential terrain classification issues.