### PR TITLE
feat(mod-swooper-maps): add budgets, shelf width, and craton configs

### DIFF
--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -12,9 +12,18 @@
       "plateActivity": 0.5
     },
     "advanced": {
+      "budgets": {
+        "eraCount": 5
+      },
       "tectonics": {
         "history": {
-          "driftStepsByEra": [12, 9, 6, 3, 1]
+          "driftStepsByEra": [
+            12,
+            9,
+            6,
+            3,
+            1
+          ]
         }
       }
     }
@@ -22,7 +31,8 @@
   "morphology-coasts": {
     "knobs": {
       "coastRuggedness": "normal",
-      "seaLevel": "earthlike"
+      "seaLevel": "earthlike",
+      "shelfWidth": "normal"
     },
     "advanced": {
       "landmass-plates": {
@@ -77,8 +87,18 @@
           "config": {
             "continentPotentialGrain": 4,
             "continentPotentialBlurSteps": 4,
-            "keepLandComponentFraction": 0.985
+            "keepLandComponentFraction": 0.985,
+            "cratonStepsPerEra": 2,
+            "cratonNucleationScale": 0.9,
+            "cratonDiffusion": 0.25,
+            "cratonAdvection": 0.15,
+            "cratonHalfSaturation": 0.35,
+            "cratonPotentialWeight": 0.12
           }
+        },
+        "beltDrivers": {
+          "strategy": "default",
+          "config": {}
         }
       },
       "rugged-coasts": {
@@ -108,6 +128,17 @@
                 "passiveBonus": 1
               }
             }
+          }
+        },
+        "shelfMask": {
+          "strategy": "default",
+          "config": {
+            "nearshoreDistance": 3,
+            "shallowQuantile": 0.7,
+            "activeClosenessThreshold": 0.45,
+            "capTilesActive": 2,
+            "capTilesPassive": 4,
+            "capTilesMax": 8
           }
         }
       }


### PR DESCRIPTION
# Add shelf width configuration and enhance continental shelf modeling

This PR enhances the swooper-earthlike map configuration with:

- Added `shelfWidth: "normal"` parameter to control continental shelf dimensions
- Configured detailed shelf mask parameters for better nearshore terrain
- Added cratonization parameters to improve continental formation
- Added belt drivers strategy for tectonic modeling
- Added budget configuration for era count
- Reformatted the `driftStepsByEra` array for better readability

These changes provide more realistic continental shelves and improved geological formation patterns in the earthlike map type.