### PR TITLE
fix(morphology): improve belt seed selection for better boundary proximity fields

### DIFF
--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-belt-drivers/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-belt-drivers/contract.ts
@@ -63,7 +63,7 @@ const ComputeBeltDriversContract = defineOp({
   output: Type.Object(
     {
       boundaryCloseness: TypedArraySchemas.u8({
-        description: "Boundary proximity field per tile (0..255), weighted by tectonic intensity and belt decay.",
+        description: "Boundary proximity field per tile (0..255), derived from distance to active belt seed spines.",
       }),
       boundaryType: TypedArraySchemas.u8({
         description: "Boundary regime per tile (BOUNDARY_TYPE values), resolved from active eras/provenance.",
@@ -97,4 +97,3 @@ const ComputeBeltDriversContract = defineOp({
 });
 
 export default ComputeBeltDriversContract;
-


### PR DESCRIPTION
# Improved Belt Driver Extraction for Tectonic Boundaries

This PR refines how we extract active tectonic belt "spines" from influence fields, addressing issues with boundary detection and proximity calculations.

Key improvements:

- Changed how belt seeds are selected, using local maxima detection and quantile-based thresholding to create more stable, deterministic spine extraction
- Modified the boundary closeness field to derive from distance to active belt seed spines rather than using weighted tectonic intensity
- Added minimum cutoff distances that scale with map size to ensure belts maintain sufficient width for foothills even with young/small belts
- Fixed an issue where using integrated uplift history could make intensity nonzero almost everywhere, which collapsed distance calculations
- Ensured each boundary type with any intensity produces at least one seed
- Updated tests to verify the new behavior produces expected results

These changes produce more reliable belt extraction, especially in complex tectonic scenarios, and prevent issues where boundary closeness would saturate across large areas.