### PR TITLE
feat(morphology): add mountain driver thresholds and physics weights

### DIFF
--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges-and-foothills/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges-and-foothills/rules/index.ts
@@ -7,33 +7,27 @@ import type { PlanRidgesAndFoothillsTypes } from "../types.js";
 
 const BOUNDARY_STRENGTH_EPS = 1e-6;
 
-const OROGENY_CONVERGENT_STRESS_WEIGHT = 0.6;
-const OROGENY_CONVERGENT_UPLIFT_WEIGHT = 0.4;
-const OROGENY_TRANSFORM_STRESS_WEIGHT = 0.4;
-const OROGENY_DIVERGENT_RIFT_WEIGHT = 0.55;
-const OROGENY_DIVERGENT_STRESS_WEIGHT = 0.15;
-
-const FRACTURE_BOUNDARY_WEIGHT = 0.7;
-const FRACTURE_STRESS_WEIGHT = 0.2;
-const FRACTURE_RIFT_WEIGHT = 0.1;
-
-const MOUNTAIN_BOUNDARY_STRESS_WEIGHT = 0.5;
-const MOUNTAIN_BOUNDARY_UPLIFT_WEIGHT = 0.5;
-const MOUNTAIN_UPLIFT_WEIGHT_SCALE = 0.5;
-const MOUNTAIN_FRACTAL_WEIGHT_SCALE = 0.3;
-const MOUNTAIN_CONVERGENCE_BASE = 0.6;
-const MOUNTAIN_CONVERGENCE_FRACTAL_GAIN = 0.4;
-
-const HILL_FOOTHILL_BASE = 0.5;
-const HILL_FOOTHILL_FRACTAL_GAIN = 0.5;
-const HILL_FRACTAL_WEIGHT_SCALE = 0.8;
-const HILL_UPLIFT_WEIGHT_SCALE = 0.3;
-const HILL_RIFT_BONUS_SCALE = 0.5;
-const HILL_RIFT_DEPTH_SCALE = 0.5;
-
 function clampByte(value: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.max(0, Math.min(255, Math.round(value))) | 0;
+}
+
+function clamp01(value: number): number {
+  return clamp(value, 0, 1);
+}
+
+export function resolveDriverStrength01(params: {
+  driverByte: number;
+  driverSignalByteMin: number;
+  driverExponent: number;
+}): number {
+  const driverByte = params.driverByte | 0;
+  const driverMin = Math.max(0, Math.min(255, Math.round(params.driverSignalByteMin))) | 0;
+  if (driverByte <= driverMin) return 0;
+  const denom = Math.max(1, 255 - driverMin);
+  const normalized = (driverByte - driverMin) / denom;
+  const exponent = Math.max(0.01, params.driverExponent);
+  return Math.pow(clamp01(normalized), exponent);
 }
 
 function resolveBoundaryRegime(params: { boundaryType: number; uplift: number; stress: number; rift: number }): number {
@@ -130,27 +124,33 @@ export function computeOrogenyPotential01(params: {
   uplift: number;
   stress: number;
   rift: number;
+  config: PlanRidgesAndFoothillsTypes["config"]["default"];
 }): number {
-  const { boundaryStrength, boundaryType, uplift, stress, rift } = params;
+  const { boundaryStrength, boundaryType, uplift, stress, rift, config } = params;
   const regime = resolveBoundaryRegime({ boundaryType, uplift, stress, rift });
 
   const collision = regime === BOUNDARY_TYPE.convergent ? boundaryStrength : 0;
   const transform = regime === BOUNDARY_TYPE.transform ? boundaryStrength : 0;
   const divergence = regime === BOUNDARY_TYPE.divergent ? boundaryStrength : 0;
 
-  const collisionSignal = collision * (OROGENY_CONVERGENT_STRESS_WEIGHT * stress + OROGENY_CONVERGENT_UPLIFT_WEIGHT * uplift);
-  const transformSignal = transform * (OROGENY_TRANSFORM_STRESS_WEIGHT * stress);
-  const divergenceSignal = divergence * (OROGENY_DIVERGENT_RIFT_WEIGHT * rift + OROGENY_DIVERGENT_STRESS_WEIGHT * stress);
+  const collisionSignal =
+    collision * (config.orogenyCollisionStressWeight * stress + config.orogenyCollisionUpliftWeight * uplift);
+  const transformSignal = transform * (config.orogenyTransformStressWeight * stress);
+  const divergenceSignal =
+    divergence * (config.orogenyDivergentRiftWeight * rift + config.orogenyDivergentStressWeight * stress);
 
-  return clamp(collisionSignal + transformSignal + divergenceSignal, 0, 1);
+  return clamp01(collisionSignal + transformSignal + divergenceSignal);
 }
 
-export function computeFracture01(params: { boundaryStrength: number; stress: number; rift: number }): number {
-  const { boundaryStrength, stress, rift } = params;
-  return clamp(
-    FRACTURE_BOUNDARY_WEIGHT * boundaryStrength + FRACTURE_STRESS_WEIGHT * stress + FRACTURE_RIFT_WEIGHT * rift,
-    0,
-    1
+export function computeFracture01(params: {
+  boundaryStrength: number;
+  stress: number;
+  rift: number;
+  config: PlanRidgesAndFoothillsTypes["config"]["default"];
+}): number {
+  const { boundaryStrength, stress, rift, config } = params;
+  return clamp01(
+    config.fractureBoundaryWeight * boundaryStrength + config.fractureStressWeight * stress + config.fractureRiftWeight * rift
   );
 }
 
@@ -164,9 +164,10 @@ export function computeMountainScore(params: {
   stress: number;
   rift: number;
   fractal: number;
+  driverStrength: number;
   config: PlanRidgesAndFoothillsTypes["config"]["default"];
 }): number {
-  const { boundaryStrength, boundaryType, uplift, stress, rift, fractal, config } = params;
+  const { boundaryStrength, boundaryType, uplift, stress, rift, fractal, driverStrength, config } = params;
   const regime = resolveBoundaryRegime({ boundaryType, uplift, stress, rift });
 
   const scaledConvergenceBonus = config.convergenceBonus * config.tectonicIntensity;
@@ -183,18 +184,21 @@ export function computeMountainScore(params: {
     uplift,
     stress,
     rift,
+    config,
   });
 
   let mountainScore =
-    collision * scaledBoundaryWeight * (MOUNTAIN_BOUNDARY_STRESS_WEIGHT * stress + MOUNTAIN_BOUNDARY_UPLIFT_WEIGHT * uplift) +
-    uplift * scaledUpliftWeight * MOUNTAIN_UPLIFT_WEIGHT_SCALE +
-    fractal * config.fractalWeight * MOUNTAIN_FRACTAL_WEIGHT_SCALE * orogenyPotential01;
+    collision *
+      scaledBoundaryWeight *
+      (config.mountainCollisionStressWeight * stress + config.mountainCollisionUpliftWeight * uplift) +
+    uplift * scaledUpliftWeight * config.mountainInteriorUpliftScale * driverStrength +
+    fractal * config.fractalWeight * config.mountainFractalScale * orogenyPotential01;
 
   if (collision > 0) {
     mountainScore +=
       collision *
       scaledConvergenceBonus *
-      (MOUNTAIN_CONVERGENCE_BASE + fractal * MOUNTAIN_CONVERGENCE_FRACTAL_GAIN) *
+      (config.mountainConvergenceFractalBase + fractal * config.mountainConvergenceFractalSpan) *
       orogenyPotential01;
   }
 
@@ -214,7 +218,8 @@ export function computeMountainScore(params: {
     mountainScore = Math.max(0, mountainScore - rift * config.riftDepth);
   }
 
-  return Math.max(0, mountainScore);
+  // Ensure mountains cannot appear without a meaningful tectonic driver signal.
+  return Math.max(0, mountainScore) * clamp01(driverStrength);
 }
 
 /**
@@ -227,9 +232,10 @@ export function computeHillScore(params: {
   stress: number;
   rift: number;
   fractal: number;
+  driverStrength: number;
   config: PlanRidgesAndFoothillsTypes["config"]["default"];
 }): number {
-  const { boundaryStrength, boundaryType, uplift, stress, rift, fractal, config } = params;
+  const { boundaryStrength, boundaryType, uplift, stress, rift, fractal, driverStrength, config } = params;
   const regime = resolveBoundaryRegime({ boundaryType, uplift, stress, rift });
 
   const scaledHillBoundaryWeight = config.hillBoundaryWeight * config.tectonicIntensity;
@@ -244,13 +250,14 @@ export function computeHillScore(params: {
     uplift,
     stress,
     rift,
+    config,
   });
 
   const hillIntensity = Math.sqrt(boundaryStrength);
-  const foothillExtent = HILL_FOOTHILL_BASE + fractal * HILL_FOOTHILL_FRACTAL_GAIN;
+  const foothillExtent = config.hillFoothillBase + fractal * config.hillFoothillFractalGain;
   let hillScore =
-    fractal * config.fractalWeight * HILL_FRACTAL_WEIGHT_SCALE * orogenyPotential01 +
-    uplift * config.hillUpliftWeight * HILL_UPLIFT_WEIGHT_SCALE;
+    fractal * config.fractalWeight * config.hillFractalScale * orogenyPotential01 +
+    uplift * config.hillUpliftWeight * config.hillUpliftScale * driverStrength;
 
   if (collision > 0 && config.hillBoundaryWeight > 0) {
     hillScore += hillIntensity * scaledHillBoundaryWeight * foothillExtent;
@@ -258,7 +265,7 @@ export function computeHillScore(params: {
   }
 
   if (divergence > 0) {
-    hillScore += hillIntensity * rift * config.hillRiftBonus * foothillExtent * HILL_RIFT_BONUS_SCALE;
+    hillScore += hillIntensity * rift * config.hillRiftBonus * foothillExtent * config.hillRiftBonusScale;
   }
 
   if (config.hillInteriorFalloff > 0) {
@@ -267,10 +274,10 @@ export function computeHillScore(params: {
   }
 
   if (config.riftDepth > 0 && regime === BOUNDARY_TYPE.divergent) {
-    hillScore = Math.max(0, hillScore - rift * config.riftDepth * HILL_RIFT_DEPTH_SCALE);
+    hillScore = Math.max(0, hillScore - rift * config.riftDepth * config.hillRiftDepthScale);
   }
 
-  return Math.max(0, hillScore);
+  return Math.max(0, hillScore) * clamp01(driverStrength);
 }
 
 /**


### PR DESCRIPTION
# Enhanced Mountain and Hill Generation with Tectonic Driver Controls

This PR adds several improvements to the mountain and hill generation system:

1. **Driver Signal Threshold**: Added a minimum driver byte threshold (`driverSignalByteMin`) to ensure mountains only form in areas with significant tectonic activity, mirroring the determinism gate's driver-signal threshold.

2. **Driver Exponent Control**: Added a nonlinear shaping parameter (`driverExponent`) that allows concentrating mountains into stronger corridors (values >1) or spreading them wider (values <1).

3. **Physics Decomposition Parameters**: Added configurable weights for:
   - Orogeny potential calculations (collision, transform, and divergent regimes)
   - Fracture surface diagnostics
   - Mountain scoring in collision regimes
   - Hill generation parameters

4. **Improved Mountain Scoring**: Enhanced the mountain scoring algorithm to:
   - Keep mountains tied to tectonic driver corridors
   - Better blend convergence bonuses with fractal modulation
   - Prevent mountains from appearing without meaningful tectonic drivers

5. **Hill Generation Refinements**: Added parameters for foothill extent, fractal modulation, uplift contribution, and rift interactions.

These changes provide more precise control over mountain and hill formation while maintaining the physics-driven deterministic approach.