### PR TITLE
feat(morphology): split mountain planning into separate ridge and foothill ops

### DIFF
--- a/mods/mod-swooper-maps/src/domain/morphology/ops/contracts.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/contracts.ts
@@ -9,6 +9,8 @@ import ComputeShelfMaskContract from "./compute-shelf-mask/contract.js";
 import ComputeSeaLevelContract from "./compute-sea-level/contract.js";
 import ComputeSubstrateContract from "./compute-substrate/contract.js";
 import PlanIslandChainsContract from "./plan-island-chains/contract.js";
+import PlanFoothillsContract from "./plan-foothills/contract.js";
+import PlanRidgesContract from "./plan-ridges/contract.js";
 import PlanRidgesAndFoothillsContract from "./plan-ridges-and-foothills/contract.js";
 import PlanVolcanoesContract from "./plan-volcanoes/contract.js";
 
@@ -24,6 +26,8 @@ export const contracts = {
   computeSeaLevel: ComputeSeaLevelContract,
   computeSubstrate: ComputeSubstrateContract,
   planIslandChains: PlanIslandChainsContract,
+  planFoothills: PlanFoothillsContract,
+  planRidges: PlanRidgesContract,
   planRidgesAndFoothills: PlanRidgesAndFoothillsContract,
   planVolcanoes: PlanVolcanoesContract,
 } as const;

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/index.ts
@@ -12,6 +12,8 @@ import computeShelfMask from "./compute-shelf-mask/index.js";
 import computeSeaLevel from "./compute-sea-level/index.js";
 import computeSubstrate from "./compute-substrate/index.js";
 import planIslandChains from "./plan-island-chains/index.js";
+import planFoothills from "./plan-foothills/index.js";
+import planRidges from "./plan-ridges/index.js";
 import planRidgesAndFoothills from "./plan-ridges-and-foothills/index.js";
 import planVolcanoes from "./plan-volcanoes/index.js";
 
@@ -27,6 +29,8 @@ const implementations = {
   computeSeaLevel,
   computeSubstrate,
   planIslandChains,
+  planFoothills,
+  planRidges,
   planRidgesAndFoothills,
   planVolcanoes,
 } as const satisfies DomainOpImplementationsForContracts<typeof contracts>;
@@ -45,6 +49,8 @@ export {
   computeSeaLevel,
   computeSubstrate,
   planIslandChains,
+  planFoothills,
+  planRidges,
   planRidgesAndFoothills,
   planVolcanoes,
 };

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules.ts
@@ -1,0 +1,1 @@
+export * from "./rules/index.js";

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeFracture01.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeFracture01.ts
@@ -1,0 +1,17 @@
+import type { MountainsConfig } from "./types.js";
+import { clamp01 } from "./util.js";
+
+export function computeFracture01(params: {
+  boundaryStrength: number;
+  stress: number;
+  rift: number;
+  config: MountainsConfig;
+}): number {
+  const { boundaryStrength, stress, rift, config } = params;
+  return clamp01(
+    config.fractureBoundaryWeight * boundaryStrength +
+      config.fractureStressWeight * stress +
+      config.fractureRiftWeight * rift
+  );
+}
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeHillScore.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeHillScore.ts
@@ -1,0 +1,68 @@
+import { BOUNDARY_TYPE } from "@mapgen/domain/foundation/constants.js";
+
+import { clamp } from "@swooper/mapgen-core/lib/math";
+
+import type { MountainsConfig } from "./types.js";
+import { clamp01 } from "./util.js";
+import { resolveBoundaryRegime } from "./resolveBoundaryRegime.js";
+import { computeOrogenyPotential01 } from "./computeOrogenyPotential01.js";
+
+/**
+ * Computes hill score from tectonic signals and fractal noise.
+ */
+export function computeHillScore(params: {
+  boundaryStrength: number;
+  boundaryType: number;
+  uplift: number;
+  stress: number;
+  rift: number;
+  fractal: number;
+  driverStrength: number;
+  config: MountainsConfig;
+}): number {
+  const { boundaryStrength, boundaryType, uplift, stress, rift, fractal, driverStrength, config } = params;
+  const regime = resolveBoundaryRegime({ boundaryType, uplift, stress, rift });
+
+  const scaledHillBoundaryWeight = config.hillBoundaryWeight * config.tectonicIntensity;
+  const scaledHillConvergentFoothill = config.hillConvergentFoothill * config.tectonicIntensity;
+
+  const collision = regime === BOUNDARY_TYPE.convergent ? boundaryStrength : 0;
+  const divergence = regime === BOUNDARY_TYPE.divergent ? boundaryStrength : 0;
+
+  const orogenyPotential01 = computeOrogenyPotential01({
+    boundaryStrength,
+    boundaryType: regime,
+    uplift,
+    stress,
+    rift,
+    config,
+  });
+
+  const hillIntensity = Math.sqrt(boundaryStrength);
+  const foothillExtent = config.hillFoothillBase + fractal * config.hillFoothillFractalGain;
+  let hillScore =
+    fractal * config.fractalWeight * config.hillFractalScale * orogenyPotential01 +
+    uplift * config.hillUpliftWeight * config.hillUpliftScale * driverStrength;
+
+  if (collision > 0 && config.hillBoundaryWeight > 0) {
+    hillScore += hillIntensity * scaledHillBoundaryWeight * foothillExtent;
+    hillScore += hillIntensity * scaledHillConvergentFoothill * foothillExtent;
+  }
+
+  if (divergence > 0) {
+    hillScore += hillIntensity * rift * config.hillRiftBonus * foothillExtent * config.hillRiftBonusScale;
+  }
+
+  if (config.hillInteriorFalloff > 0) {
+    const penalty = clamp((1 - hillIntensity) * config.hillInteriorFalloff, 0, 1);
+    hillScore *= Math.max(0, 1 - penalty);
+  }
+
+  if (config.riftDepth > 0 && regime === BOUNDARY_TYPE.divergent) {
+    hillScore = Math.max(0, hillScore - rift * config.riftDepth * config.hillRiftDepthScale);
+  }
+
+  // As with mountains, treat driverStrength as a gate (not a multiplier) to preserve score range.
+  const driverGate = driverStrength > 0 ? 1 : 0;
+  return Math.max(0, hillScore) * driverGate;
+}

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeMountainScore.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeMountainScore.ts
@@ -1,0 +1,81 @@
+import { BOUNDARY_TYPE } from "@mapgen/domain/foundation/constants.js";
+
+import { clamp } from "@swooper/mapgen-core/lib/math";
+
+import type { MountainsConfig } from "./types.js";
+import { clamp01 } from "./util.js";
+import { resolveBoundaryRegime } from "./resolveBoundaryRegime.js";
+import { computeOrogenyPotential01 } from "./computeOrogenyPotential01.js";
+
+/**
+ * Computes mountain score from tectonic signals and fractal noise.
+ */
+export function computeMountainScore(params: {
+  boundaryStrength: number;
+  boundaryType: number;
+  uplift: number;
+  stress: number;
+  rift: number;
+  fractal: number;
+  driverStrength: number;
+  config: MountainsConfig;
+}): number {
+  const { boundaryStrength, boundaryType, uplift, stress, rift, fractal, driverStrength, config } = params;
+  const regime = resolveBoundaryRegime({ boundaryType, uplift, stress, rift });
+
+  const scaledConvergenceBonus = config.convergenceBonus * config.tectonicIntensity;
+  const scaledBoundaryWeight = config.boundaryWeight * config.tectonicIntensity;
+  const scaledUpliftWeight = config.upliftWeight * config.tectonicIntensity;
+
+  const collision = regime === BOUNDARY_TYPE.convergent ? boundaryStrength : 0;
+  const transform = regime === BOUNDARY_TYPE.transform ? boundaryStrength : 0;
+  const divergence = regime === BOUNDARY_TYPE.divergent ? boundaryStrength : 0;
+
+  const orogenyPotential01 = computeOrogenyPotential01({
+    boundaryStrength,
+    boundaryType: regime,
+    uplift,
+    stress,
+    rift,
+    config,
+  });
+
+  let mountainScore =
+    collision *
+      scaledBoundaryWeight *
+      (config.mountainCollisionStressWeight * stress + config.mountainCollisionUpliftWeight * uplift) +
+    uplift * scaledUpliftWeight * config.mountainInteriorUpliftScale * driverStrength +
+    fractal * config.fractalWeight * config.mountainFractalScale * orogenyPotential01;
+
+  if (collision > 0) {
+    mountainScore +=
+      collision *
+      scaledConvergenceBonus *
+      (config.mountainConvergenceFractalBase + fractal * config.mountainConvergenceFractalSpan) *
+      orogenyPotential01;
+  }
+
+  if (config.interiorPenaltyWeight > 0) {
+    const penalty = clamp((1 - boundaryStrength) * config.interiorPenaltyWeight, 0, 1);
+    mountainScore *= Math.max(0, 1 - penalty);
+  }
+
+  if (divergence > 0) {
+    mountainScore *= Math.max(0, 1 - divergence * config.riftPenalty);
+  }
+  if (transform > 0) {
+    mountainScore *= Math.max(0, 1 - transform * config.transformPenalty);
+  }
+
+  if (config.riftDepth > 0 && regime === BOUNDARY_TYPE.divergent) {
+    mountainScore = Math.max(0, mountainScore - rift * config.riftDepth);
+  }
+
+  // Ensure mountains cannot appear without a meaningful tectonic driver signal.
+  // driverStrength is already derived from the driver byte magnitude; using it as a *multiplier*
+  // collapses the score dynamic range and suppresses mountains in moderate-but-real corridors.
+  // We treat it as a gate: below the configured minimum, no mountains; above it, the score is
+  // controlled by the physical terms (stress/uplift/regime/proximity).
+  const driverGate = driverStrength > 0 ? 1 : 0;
+  return Math.max(0, mountainScore) * driverGate;
+}

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeOrogenyPotential01.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeOrogenyPotential01.ts
@@ -1,0 +1,30 @@
+import { BOUNDARY_TYPE } from "@mapgen/domain/foundation/constants.js";
+
+import type { MountainsConfig } from "./types.js";
+import { clamp01 } from "./util.js";
+import { resolveBoundaryRegime } from "./resolveBoundaryRegime.js";
+
+export function computeOrogenyPotential01(params: {
+  boundaryStrength: number;
+  boundaryType: number;
+  uplift: number;
+  stress: number;
+  rift: number;
+  config: MountainsConfig;
+}): number {
+  const { boundaryStrength, boundaryType, uplift, stress, rift, config } = params;
+  const regime = resolveBoundaryRegime({ boundaryType, uplift, stress, rift });
+
+  const collision = regime === BOUNDARY_TYPE.convergent ? boundaryStrength : 0;
+  const transform = regime === BOUNDARY_TYPE.transform ? boundaryStrength : 0;
+  const divergence = regime === BOUNDARY_TYPE.divergent ? boundaryStrength : 0;
+
+  const collisionSignal =
+    collision * (config.orogenyCollisionStressWeight * stress + config.orogenyCollisionUpliftWeight * uplift);
+  const transformSignal = transform * (config.orogenyTransformStressWeight * stress);
+  const divergenceSignal =
+    divergence * (config.orogenyDivergentRiftWeight * rift + config.orogenyDivergentStressWeight * stress);
+
+  return clamp01(collisionSignal + transformSignal + divergenceSignal);
+}
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/encode01Byte.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/encode01Byte.ts
@@ -1,0 +1,6 @@
+import { clamp01, clampByte } from "./util.js";
+
+export function encode01Byte(value01: number): number {
+  return clampByte(clamp01(value01) * 255);
+}
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/index.ts
@@ -1,0 +1,9 @@
+export { resolveDriverStrength01 } from "./resolveDriverStrength01.js";
+export { resolveBoundaryStrength } from "./resolveBoundaryStrength.js";
+export { computeOrogenyPotential01 } from "./computeOrogenyPotential01.js";
+export { computeFracture01 } from "./computeFracture01.js";
+export { computeMountainScore } from "./computeMountainScore.js";
+export { computeHillScore } from "./computeHillScore.js";
+export { normalizeMountainFractal } from "./normalizeMountainFractal.js";
+export { encode01Byte } from "./encode01Byte.js";
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/normalizeMountainFractal.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/normalizeMountainFractal.ts
@@ -1,0 +1,9 @@
+import { normalizeFractal } from "@swooper/mapgen-core/lib/noise";
+
+/**
+ * Normalizes fractal values to a 0..1 range.
+ */
+export function normalizeMountainFractal(value: number): number {
+  return normalizeFractal(value);
+}
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/resolveBoundaryRegime.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/resolveBoundaryRegime.ts
@@ -1,0 +1,27 @@
+import { BOUNDARY_TYPE } from "@mapgen/domain/foundation/constants.js";
+
+export function resolveBoundaryRegime(params: {
+  boundaryType: number;
+  uplift: number;
+  stress: number;
+  rift: number;
+}): number {
+  const boundaryType = params.boundaryType | 0;
+  if (
+    boundaryType === BOUNDARY_TYPE.convergent ||
+    boundaryType === BOUNDARY_TYPE.divergent ||
+    boundaryType === BOUNDARY_TYPE.transform
+  ) {
+    return boundaryType;
+  }
+
+  const uplift = params.uplift;
+  const rift = params.rift;
+  const stress = params.stress;
+
+  if (uplift > 0 && uplift >= rift) return BOUNDARY_TYPE.convergent;
+  if (rift > 0 && rift > uplift) return BOUNDARY_TYPE.divergent;
+  if (stress > 0) return BOUNDARY_TYPE.transform;
+  return 0;
+}
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/resolveBoundaryStrength.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/resolveBoundaryStrength.ts
@@ -1,0 +1,13 @@
+const BOUNDARY_STRENGTH_EPS = 1e-6;
+
+/**
+ * Converts boundary proximity into a normalized boundary strength.
+ */
+export function resolveBoundaryStrength(closenessNorm: number, boundaryGate: number, exponent: number): number {
+  const normalized =
+    closenessNorm <= boundaryGate
+      ? 0
+      : (closenessNorm - boundaryGate) / Math.max(BOUNDARY_STRENGTH_EPS, 1 - boundaryGate);
+  return Math.pow(normalized, exponent);
+}
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/resolveDriverStrength01.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/resolveDriverStrength01.ts
@@ -1,0 +1,16 @@
+import { clamp01 } from "./util.js";
+
+export function resolveDriverStrength01(params: {
+  driverByte: number;
+  driverSignalByteMin: number;
+  driverExponent: number;
+}): number {
+  const driverByte = params.driverByte | 0;
+  const driverMin = Math.max(0, Math.min(255, Math.round(params.driverSignalByteMin))) | 0;
+  if (driverByte <= driverMin) return 0;
+  const denom = Math.max(1, 255 - driverMin);
+  const normalized = (driverByte - driverMin) / denom;
+  const exponent = Math.max(0.01, params.driverExponent);
+  return Math.pow(clamp01(normalized), exponent);
+}
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/types.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/types.ts
@@ -1,0 +1,6 @@
+import type { Static } from "@swooper/mapgen-core/authoring";
+
+import { MountainsConfigSchema } from "../../../config.js";
+
+export type MountainsConfig = Static<typeof MountainsConfigSchema>;
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/util.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/util.ts
@@ -1,0 +1,11 @@
+import { clamp } from "@swooper/mapgen-core/lib/math";
+
+export function clamp01(value: number): number {
+  return clamp(value, 0, 1);
+}
+
+export function clampByte(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(255, Math.round(value))) | 0;
+}
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/contract.ts
@@ -1,0 +1,35 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+import { MountainsConfigSchema } from "../../config.js";
+
+/**
+ * Plans foothill (hill) masks adjacent to ridges/mountain corridors.
+ *
+ * This op intentionally consumes the ridge (mountain) mask so hills remain a distinct,
+ * non-overlapping class.
+ */
+const PlanFoothillsContract = defineOp({
+  kind: "plan",
+  id: "morphology/plan-foothills",
+  input: Type.Object({
+    width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+    height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+    landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
+    mountainMask: TypedArraySchemas.u8({ description: "Mask (1/0): mountain tiles to exclude from hills." }),
+    boundaryCloseness: TypedArraySchemas.u8({ description: "Boundary proximity per tile (0..255)." }),
+    boundaryType: TypedArraySchemas.u8({ description: "Boundary type per tile (BOUNDARY_TYPE values)." }),
+    upliftPotential: TypedArraySchemas.u8({ description: "Uplift potential per tile (0..255)." }),
+    riftPotential: TypedArraySchemas.u8({ description: "Rift potential per tile (0..255)." }),
+    tectonicStress: TypedArraySchemas.u8({ description: "Tectonic stress per tile (0..255)." }),
+    fractalHill: TypedArraySchemas.i16({ description: "Fractal noise for hill scores." }),
+  }),
+  output: Type.Object({
+    hillMask: TypedArraySchemas.u8({ description: "Mask (1/0): hill tiles (excluding mountains)." }),
+  }),
+  strategies: {
+    default: MountainsConfigSchema,
+  },
+});
+
+export default PlanFoothillsContract;
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/index.ts
@@ -1,0 +1,16 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import PlanFoothillsContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const planFoothills = createOp(PlanFoothillsContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+export type * from "./types.js";
+
+export default planFoothills;
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/strategies/default.ts
@@ -1,0 +1,120 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import PlanFoothillsContract from "../contract.js";
+import type { PlanFoothillsTypes } from "../types.js";
+
+import {
+  computeHillScore,
+  normalizeMountainFractal,
+  resolveBoundaryStrength,
+  resolveDriverStrength01,
+} from "../../mountains-shared/rules.js";
+
+function validateFoothillsInputs(input: PlanFoothillsTypes["input"]): {
+  size: number;
+  landMask: Uint8Array;
+  mountainMask: Uint8Array;
+  boundaryCloseness: Uint8Array;
+  boundaryType: Uint8Array;
+  upliftPotential: Uint8Array;
+  riftPotential: Uint8Array;
+  tectonicStress: Uint8Array;
+  fractalHill: Int16Array;
+} {
+  const { width, height } = input;
+  const size = Math.max(0, (width | 0) * (height | 0));
+
+  const landMask = input.landMask as Uint8Array;
+  const mountainMask = input.mountainMask as Uint8Array;
+  const boundaryCloseness = input.boundaryCloseness as Uint8Array;
+  const boundaryType = input.boundaryType as Uint8Array;
+  const upliftPotential = input.upliftPotential as Uint8Array;
+  const riftPotential = input.riftPotential as Uint8Array;
+  const tectonicStress = input.tectonicStress as Uint8Array;
+  const fractalHill = input.fractalHill as Int16Array;
+
+  if (
+    landMask.length !== size ||
+    mountainMask.length !== size ||
+    boundaryCloseness.length !== size ||
+    boundaryType.length !== size ||
+    upliftPotential.length !== size ||
+    riftPotential.length !== size ||
+    tectonicStress.length !== size ||
+    fractalHill.length !== size
+  ) {
+    throw new Error("[PlanFoothills] Input tensors must match width*height.");
+  }
+
+  return {
+    size,
+    landMask,
+    mountainMask,
+    boundaryCloseness,
+    boundaryType,
+    upliftPotential,
+    riftPotential,
+    tectonicStress,
+    fractalHill,
+  };
+}
+
+export const defaultStrategy = createStrategy(PlanFoothillsContract, "default", {
+  run: (input, config) => {
+    const {
+      size,
+      landMask,
+      mountainMask,
+      boundaryCloseness,
+      boundaryType,
+      upliftPotential,
+      riftPotential,
+      tectonicStress,
+      fractalHill,
+    } = validateFoothillsInputs(input);
+
+    const hillMask = new Uint8Array(size);
+
+    const boundaryGate = Math.min(0.99, Math.max(0, config.boundaryGate));
+    const falloffExponent = config.boundaryExponent;
+
+    for (let i = 0; i < size; i++) {
+      if (landMask[i] === 0) continue;
+      if (mountainMask[i] === 1) continue;
+
+      const closenessNorm = boundaryCloseness[i] / 255;
+      const boundaryStrength = resolveBoundaryStrength(closenessNorm, boundaryGate, falloffExponent);
+
+      const uplift = upliftPotential[i] / 255;
+      const stress = tectonicStress[i] / 255;
+      const rift = riftPotential[i] / 255;
+      const bType = boundaryType[i];
+
+      const driverByte = Math.max(upliftPotential[i] ?? 0, tectonicStress[i] ?? 0, riftPotential[i] ?? 0);
+      const driverStrength = resolveDriverStrength01({
+        driverByte,
+        driverSignalByteMin: config.driverSignalByteMin,
+        driverExponent: config.driverExponent,
+      });
+
+      const fractal = normalizeMountainFractal(fractalHill[i]);
+      const hillScore = computeHillScore({
+        boundaryStrength,
+        boundaryType: bType,
+        uplift,
+        stress,
+        rift,
+        fractal,
+        driverStrength,
+        config,
+      });
+
+      if (hillScore > config.hillThreshold) {
+        hillMask[i] = 1;
+      }
+    }
+
+    return { hillMask };
+  },
+});
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/strategies/index.ts
@@ -1,0 +1,2 @@
+export { defaultStrategy } from "./default.js";
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/types.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/types.ts
@@ -1,0 +1,6 @@
+import type { OpTypeBagOf } from "@swooper/mapgen-core/authoring";
+
+type Contract = typeof import("./contract.js").default;
+
+export type PlanFoothillsTypes = OpTypeBagOf<Contract>;
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/contract.ts
@@ -1,0 +1,40 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+import { MountainsConfigSchema } from "../../config.js";
+
+/**
+ * Plans ridge (mountain) masks and diagnostic driver surfaces from tectonic belt drivers.
+ *
+ * This op is intentionally limited to ridges/mountains. Foothills (hills) are planned by a separate op
+ * to keep concerns and downstream composition explicit.
+ */
+const PlanRidgesContract = defineOp({
+  kind: "plan",
+  id: "morphology/plan-ridges",
+  input: Type.Object({
+    width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+    height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+    landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
+    boundaryCloseness: TypedArraySchemas.u8({ description: "Boundary proximity per tile (0..255)." }),
+    boundaryType: TypedArraySchemas.u8({ description: "Boundary type per tile (BOUNDARY_TYPE values)." }),
+    upliftPotential: TypedArraySchemas.u8({ description: "Uplift potential per tile (0..255)." }),
+    riftPotential: TypedArraySchemas.u8({ description: "Rift potential per tile (0..255)." }),
+    tectonicStress: TypedArraySchemas.u8({ description: "Tectonic stress per tile (0..255)." }),
+    fractalMountain: TypedArraySchemas.i16({ description: "Fractal noise for mountain scores." }),
+  }),
+  output: Type.Object({
+    mountainMask: TypedArraySchemas.u8({ description: "Mask (1/0): mountain tiles." }),
+    orogenyPotential01: TypedArraySchemas.u8({
+      description: "Orogeny potential per tile (0..255). Diagnostic driver surface (physics-gated).",
+    }),
+    fracture01: TypedArraySchemas.u8({
+      description: "Fracture proxy per tile (0..255). Diagnostic driver surface (physics-gated).",
+    }),
+  }),
+  strategies: {
+    default: MountainsConfigSchema,
+  },
+});
+
+export default PlanRidgesContract;
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/index.ts
@@ -1,0 +1,16 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import PlanRidgesContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const planRidges = createOp(PlanRidgesContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+export type * from "./types.js";
+
+export default planRidges;
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/strategies/default.ts
@@ -1,0 +1,127 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import PlanRidgesContract from "../contract.js";
+import type { PlanRidgesTypes } from "../types.js";
+import {
+  computeFracture01,
+  computeMountainScore,
+  computeOrogenyPotential01,
+  encode01Byte,
+  normalizeMountainFractal,
+  resolveBoundaryStrength,
+  resolveDriverStrength01,
+} from "../../mountains-shared/rules.js";
+
+function validateRidgesInputs(input: PlanRidgesTypes["input"]): {
+  size: number;
+  landMask: Uint8Array;
+  boundaryCloseness: Uint8Array;
+  boundaryType: Uint8Array;
+  upliftPotential: Uint8Array;
+  riftPotential: Uint8Array;
+  tectonicStress: Uint8Array;
+  fractalMountain: Int16Array;
+} {
+  const { width, height } = input;
+  const size = Math.max(0, (width | 0) * (height | 0));
+
+  const landMask = input.landMask as Uint8Array;
+  const boundaryCloseness = input.boundaryCloseness as Uint8Array;
+  const boundaryType = input.boundaryType as Uint8Array;
+  const upliftPotential = input.upliftPotential as Uint8Array;
+  const riftPotential = input.riftPotential as Uint8Array;
+  const tectonicStress = input.tectonicStress as Uint8Array;
+  const fractalMountain = input.fractalMountain as Int16Array;
+
+  if (
+    landMask.length !== size ||
+    boundaryCloseness.length !== size ||
+    boundaryType.length !== size ||
+    upliftPotential.length !== size ||
+    riftPotential.length !== size ||
+    tectonicStress.length !== size ||
+    fractalMountain.length !== size
+  ) {
+    throw new Error("[PlanRidges] Input tensors must match width*height.");
+  }
+
+  return {
+    size,
+    landMask,
+    boundaryCloseness,
+    boundaryType,
+    upliftPotential,
+    riftPotential,
+    tectonicStress,
+    fractalMountain,
+  };
+}
+
+export const defaultStrategy = createStrategy(PlanRidgesContract, "default", {
+  run: (input, config) => {
+    const { size, landMask, boundaryCloseness, boundaryType, upliftPotential, riftPotential, tectonicStress, fractalMountain } =
+      validateRidgesInputs(input);
+
+    const mountainMask = new Uint8Array(size);
+    const orogenyPotential01 = new Uint8Array(size);
+    const fracture01 = new Uint8Array(size);
+
+    const boundaryGate = Math.min(0.99, Math.max(0, config.boundaryGate));
+    const falloffExponent = config.boundaryExponent;
+
+    for (let i = 0; i < size; i++) {
+      if (landMask[i] === 0) continue;
+
+      const closenessNorm = boundaryCloseness[i] / 255;
+      const boundaryStrength = resolveBoundaryStrength(closenessNorm, boundaryGate, falloffExponent);
+      // Diagnostics should remain continuous even when placement is gated.
+      // The gate exists to prevent low-signal residual fields from producing mountains everywhere,
+      // but the underlying physical proximity signal does not have a discontinuity.
+      const boundaryInfluence = Math.pow(closenessNorm, falloffExponent);
+
+      const uplift = upliftPotential[i] / 255;
+      const stress = tectonicStress[i] / 255;
+      const rift = riftPotential[i] / 255;
+      const bType = boundaryType[i];
+
+      const driverByte = Math.max(upliftPotential[i] ?? 0, tectonicStress[i] ?? 0, riftPotential[i] ?? 0);
+      const driverStrength = resolveDriverStrength01({
+        driverByte,
+        driverSignalByteMin: config.driverSignalByteMin,
+        driverExponent: config.driverExponent,
+      });
+
+      const fractal = normalizeMountainFractal(fractalMountain[i]);
+
+      const orogeny = computeOrogenyPotential01({
+        boundaryStrength: boundaryInfluence,
+        boundaryType: bType,
+        uplift,
+        stress,
+        rift,
+        config,
+      });
+      orogenyPotential01[i] = encode01Byte(orogeny);
+
+      const fracture = computeFracture01({ boundaryStrength: boundaryInfluence, stress, rift, config });
+      fracture01[i] = encode01Byte(fracture);
+
+      const score = computeMountainScore({
+        boundaryStrength,
+        boundaryType: bType,
+        uplift,
+        stress,
+        rift,
+        fractal,
+        driverStrength,
+        config,
+      });
+
+      if (score > config.mountainThreshold) {
+        mountainMask[i] = 1;
+      }
+    }
+
+    return { mountainMask, orogenyPotential01, fracture01 };
+  },
+});

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/strategies/index.ts
@@ -1,0 +1,2 @@
+export { defaultStrategy } from "./default.js";
+

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/types.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/types.ts
@@ -1,0 +1,6 @@
+import type { OpTypeBagOf } from "@swooper/mapgen-core/authoring";
+
+type Contract = typeof import("./contract.js").default;
+
+export type PlanRidgesTypes = OpTypeBagOf<Contract>;
+

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
@@ -188,7 +188,32 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
   },
   "map-morphology": {
     mountains: {
-      mountains: {
+      ridges: {
+        strategy: "default",
+        config: {
+          // High intensity for ring mountain formation
+          tectonicIntensity: 0.85,
+          mountainThreshold: 0.5,
+          hillThreshold: 0.3,
+          upliftWeight: 0.45,
+          fractalWeight: 0.3,
+          riftDepth: 0.3,
+          // Strong emphasis on plate boundaries for the ring
+          boundaryWeight: 1.35,
+          boundaryGate: 0.1,
+          boundaryExponent: 2.0,
+          interiorPenaltyWeight: 0.1,
+          convergenceBonus: 0.95,
+          transformPenalty: 0.5,
+          riftPenalty: 0.7,
+          hillBoundaryWeight: 0.45,
+          hillRiftBonus: 0.35,
+          hillConvergentFoothill: 0.5,
+          hillInteriorFalloff: 0.2,
+          hillUpliftWeight: 0.3,
+        },
+      },
+      foothills: {
         strategy: "default",
         config: {
           // High intensity for ring mountain formation

--- a/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
@@ -190,7 +190,32 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
   },
   "map-morphology": {
     mountains: {
-      mountains: {
+      ridges: {
+        strategy: "default",
+        config: {
+          // Focused volcanic peaks rather than ranges
+          tectonicIntensity: 0.65,
+          mountainThreshold: 0.6,
+          hillThreshold: 0.32,
+          upliftWeight: 0.25,
+          fractalWeight: 0.3,
+          riftDepth: 0.35,
+          // Strong boundary influence for arc volcanism
+          boundaryWeight: 1.1,
+          boundaryGate: 0.1,
+          boundaryExponent: 1.6,
+          interiorPenaltyWeight: 0.2,
+          convergenceBonus: 1.0,
+          transformPenalty: 0.5,
+          riftPenalty: 0.7,
+          hillBoundaryWeight: 0.55,
+          hillRiftBonus: 0.4,
+          hillConvergentFoothill: 0.45,
+          hillInteriorFalloff: 0.25,
+          hillUpliftWeight: 0.28,
+        },
+      },
+      foothills: {
         strategy: "default",
         config: {
           // Focused volcanic peaks rather than ranges

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
@@ -180,7 +180,31 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
   },
   "map-morphology": {
     mountains: {
-      mountains: {
+      ridges: {
+        strategy: "default",
+        config: {
+          // Desert mountains: frequent peaks, strong rift relief, reduced erosion
+          tectonicIntensity: 0.63,
+          mountainThreshold: 0.64,
+          hillThreshold: 0.36,
+          upliftWeight: 0.20,
+          fractalWeight: 0.90,
+          riftDepth: 0.45,
+          boundaryWeight: 0.38,
+          boundaryGate: 0.14,
+          boundaryExponent: 1.1,
+          interiorPenaltyWeight: 0.16,
+          convergenceBonus: 0.6,
+          transformPenalty: 0.55,
+          riftPenalty: 0.65,
+          hillBoundaryWeight: 0.22,
+          hillRiftBonus: 0.5,
+          hillConvergentFoothill: 0.36,
+          hillInteriorFalloff: 0.2,
+          hillUpliftWeight: 0.2,
+        },
+      },
+      foothills: {
         strategy: "default",
         config: {
           // Desert mountains: frequent peaks, strong rift relief, reduced erosion

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -683,31 +683,54 @@
     },
     "plotCoasts": {},
     "plotContinents": {},
-    "mountains": {
-      "mountains": {
-        "strategy": "default",
-        "config": {
-          "tectonicIntensity": 0.61,
-          "mountainThreshold": 0.605,
-          "hillThreshold": 0.42,
-          "upliftWeight": 0.3,
-          "fractalWeight": 0.75,
-          "riftDepth": 0.25,
-          "boundaryWeight": 0.22,
-          "boundaryGate": 0.1,
-          "boundaryExponent": 1.12,
-          "interiorPenaltyWeight": 0.09,
-          "convergenceBonus": 0.65,
-          "transformPenalty": 0.65,
-          "riftPenalty": 0.78,
-          "hillBoundaryWeight": 0.36,
-          "hillRiftBonus": 0.36,
-          "hillConvergentFoothill": 0.42,
-          "hillInteriorFalloff": 0.14,
-          "hillUpliftWeight": 0.18
-        }
+  "mountains": {
+    "ridges": {
+      "strategy": "default",
+      "config": {
+        "tectonicIntensity": 2,
+        "mountainThreshold": 0.55,
+        "hillThreshold": 0.42,
+        "upliftWeight": 0.3,
+        "fractalWeight": 0.75,
+        "riftDepth": 0.25,
+        "boundaryWeight": 0.8,
+        "boundaryGate": 0.1,
+        "boundaryExponent": 1.12,
+        "interiorPenaltyWeight": 0.09,
+        "convergenceBonus": 0.9,
+        "transformPenalty": 0.65,
+        "riftPenalty": 0.78,
+        "hillBoundaryWeight": 0.36,
+        "hillRiftBonus": 0.36,
+        "hillConvergentFoothill": 0.42,
+        "hillInteriorFalloff": 0.14,
+        "hillUpliftWeight": 0.18
       }
     },
+    "foothills": {
+      "strategy": "default",
+      "config": {
+        "tectonicIntensity": 2,
+        "mountainThreshold": 0.55,
+        "hillThreshold": 0.42,
+        "upliftWeight": 0.3,
+        "fractalWeight": 0.75,
+        "riftDepth": 0.25,
+        "boundaryWeight": 0.8,
+        "boundaryGate": 0.1,
+        "boundaryExponent": 1.12,
+        "interiorPenaltyWeight": 0.09,
+        "convergenceBonus": 0.9,
+        "transformPenalty": 0.65,
+        "riftPenalty": 0.78,
+        "hillBoundaryWeight": 0.36,
+        "hillRiftBonus": 0.36,
+        "hillConvergentFoothill": 0.42,
+        "hillInteriorFalloff": 0.14,
+        "hillUpliftWeight": 0.18
+      }
+    }
+  },
     "plotVolcanoes": {},
     "buildElevation": {}
   },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotMountains.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotMountains.contract.ts
@@ -14,13 +14,15 @@ const PlotMountainsStepContract = defineStep({
     provides: [],
   },
   ops: {
-    mountains: morphology.ops.planRidgesAndFoothills,
+    ridges: morphology.ops.planRidges,
+    foothills: morphology.ops.planFoothills,
   },
   schema: Type.Object(
     {},
     {
       additionalProperties: false,
-      description: "Gameplay mountain projection config (op envelope for morphology/plan-ridges-and-foothills).",
+      description:
+        "Gameplay mountain projection config (op envelopes for morphology/plan-ridges + morphology/plan-foothills).",
     }
   ),
 });

--- a/mods/mod-swooper-maps/test/m11-config-knobs-and-presets.test.ts
+++ b/mods/mod-swooper-maps/test/m11-config-knobs-and-presets.test.ts
@@ -122,7 +122,16 @@ describe("M11 config layering: knobs-last (foundation + morphology)", () => {
       },
       "map-morphology": {
         knobs: { orogeny: "high" },
-        mountains: { mountains: { strategy: "default", config: { tectonicIntensity: 1.0, mountainThreshold: 0.6, hillThreshold: 0.35 } } },
+        mountains: {
+          ridges: {
+            strategy: "default",
+            config: { tectonicIntensity: 1.0, mountainThreshold: 0.6, hillThreshold: 0.35 },
+          },
+          foothills: {
+            strategy: "default",
+            config: { tectonicIntensity: 1.0, mountainThreshold: 0.6, hillThreshold: 0.35 },
+          },
+        },
       },
     });
 
@@ -169,9 +178,14 @@ describe("M11 config layering: knobs-last (foundation + morphology)", () => {
     expect(compiled["morphology-features"].volcanoes.volcanoes.config.convergentMultiplier).toBeCloseTo(3.0, 6);
 
     // - orogeny=high scales intensity and lowers thresholds.
-    expect(compiled["map-morphology"]["plot-mountains"].mountains.config.tectonicIntensity).toBeCloseTo(1.25, 6);
-    expect(compiled["map-morphology"]["plot-mountains"].mountains.config.mountainThreshold).toBeCloseTo(0.55, 6);
-    expect(compiled["map-morphology"]["plot-mountains"].mountains.config.hillThreshold).toBeCloseTo(0.32, 6);
+    expect(compiled["map-morphology"]["plot-mountains"].ridges.config.tectonicIntensity).toBeCloseTo(1.25, 6);
+    expect(compiled["map-morphology"]["plot-mountains"].ridges.config.mountainThreshold).toBeCloseTo(0.55, 6);
+    expect(compiled["map-morphology"]["plot-mountains"].ridges.config.hillThreshold).toBeCloseTo(0.32, 6);
+
+    // Both ops should receive the same knob transform (they share the knob envelope).
+    expect(compiled["map-morphology"]["plot-mountains"].foothills.config.tectonicIntensity).toBeCloseTo(1.25, 6);
+    expect(compiled["map-morphology"]["plot-mountains"].foothills.config.mountainThreshold).toBeCloseTo(0.55, 6);
+    expect(compiled["map-morphology"]["plot-mountains"].foothills.config.hillThreshold).toBeCloseTo(0.32, 6);
   });
 
   it("compiles deterministically for identical inputs", () => {

--- a/mods/mod-swooper-maps/test/pipeline/mountains-nonzero-probe.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/mountains-nonzero-probe.test.ts
@@ -8,8 +8,10 @@ import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 import type { StandardRecipeConfig } from "../../src/recipes/standard/recipe.js";
 import standardRecipe from "../../src/recipes/standard/recipe.js";
 import { initializeStandardRuntime } from "../../src/recipes/standard/runtime.js";
+import { foundationArtifacts } from "../../src/recipes/standard/stages/foundation/artifacts.js";
 import { morphologyArtifacts } from "../../src/recipes/standard/stages/morphology/artifacts.js";
-import planRidgesAndFoothills from "../../src/domain/morphology/ops/plan-ridges-and-foothills/index.js";
+import planRidges from "../../src/domain/morphology/ops/plan-ridges/index.js";
+import planFoothills from "../../src/domain/morphology/ops/plan-foothills/index.js";
 
 const PROBE_WIDTH = 106;
 const PROBE_HEIGHT = 66;
@@ -48,11 +50,13 @@ function runStandardContext(args: { width: number; height: number; seed: number;
     },
   };
 
+  // compileConfig may normalize/mutate inputs; keep the runtime config object pristine for standardRecipe.run.
+  const compiled = standardRecipe.compileConfig(env, JSON.parse(JSON.stringify(config)));
   const adapter = createMockAdapter({ width, height, mapInfo, mapSizeId: 1, rng: createLabelRng(seed) });
   const context = createExtendedMapContext({ width, height }, adapter, env);
   initializeStandardRuntime(context, { mapInfo, logPrefix: "[mountains-probe]", storyEnabled: true });
   standardRecipe.run(context, env, config, { log: () => {} });
-  return context;
+  return { context, env, compiled } as const;
 }
 
 function countMask(mask: Uint8Array): number {
@@ -70,10 +74,51 @@ function maxU8(values: Uint8Array): number {
   return m;
 }
 
+function maxU8Where(values: Uint8Array, mask: Uint8Array): number {
+  let m = 0;
+  for (let i = 0; i < values.length; i++) {
+    if (mask[i] !== 1) continue;
+    const v = values[i] ?? 0;
+    if (v > m) m = v;
+  }
+  return m;
+}
+
+function countNonzeroWhere(values: Uint8Array, mask: Uint8Array): number {
+  let n = 0;
+  for (let i = 0; i < values.length; i++) {
+    if (mask[i] !== 1) continue;
+    if ((values[i] ?? 0) > 0) n += 1;
+  }
+  return n;
+}
+
+function countEqWhere(values: Uint8Array, mask: Uint8Array, expected: number): number {
+  const expectedByte = expected | 0;
+  let n = 0;
+  for (let i = 0; i < values.length; i++) {
+    if (mask[i] !== 1) continue;
+    if (((values[i] ?? 0) | 0) === expectedByte) n += 1;
+  }
+  return n;
+}
+
+function maxU8WhereEq(values: Uint8Array, mask: Uint8Array, types: Uint8Array, expectedType: number): number {
+  const t = expectedType | 0;
+  let m = 0;
+  for (let i = 0; i < values.length; i++) {
+    if (mask[i] !== 1) continue;
+    if (((types[i] ?? 0) | 0) !== t) continue;
+    const v = values[i] ?? 0;
+    if (v > m) m = v;
+  }
+  return m;
+}
+
 describe("pipeline: mountains nonzero canonical probe (earthlike)", () => {
   it("produces nonzero orogeny + mountains, and keeps volcano points nonzero", () => {
     const config = loadEarthlikeConfig();
-    const context = runStandardContext({
+    const { context, compiled } = runStandardContext({
       width: PROBE_WIDTH,
       height: PROBE_HEIGHT,
       seed: PROBE_SEED,
@@ -83,6 +128,7 @@ describe("pipeline: mountains nonzero canonical probe (earthlike)", () => {
     const topography = context.artifacts.get(morphologyArtifacts.topography.id) as any;
     const belts = context.artifacts.get(morphologyArtifacts.beltDrivers.id) as any;
     const volcanoes = context.artifacts.get(morphologyArtifacts.volcanoes.id) as any;
+    const historyTiles = context.artifacts.get(foundationArtifacts.tectonicHistoryTiles.id) as any;
 
     const size = PROBE_WIDTH * PROBE_HEIGHT;
     expect(topography?.landMask).toBeInstanceOf(Uint8Array);
@@ -92,7 +138,7 @@ describe("pipeline: mountains nonzero canonical probe (earthlike)", () => {
 
     // Physics-first guard: use zero fractal noise so mountains can't "appear" from fractal randomness alone.
     const zeros = new Int16Array(size);
-    const plan = planRidgesAndFoothills.run(
+    const ridges = planRidges.run(
       {
         width: PROBE_WIDTH,
         height: PROBE_HEIGHT,
@@ -103,18 +149,108 @@ describe("pipeline: mountains nonzero canonical probe (earthlike)", () => {
         riftPotential: belts.riftPotential,
         tectonicStress: belts.tectonicStress,
         fractalMountain: zeros,
-        fractalHill: zeros,
       },
       // Map-morphology step config shape: { strategy, config }.
-      (config as any)?.["map-morphology"]?.mountains?.mountains ?? { strategy: "default", config: {} }
+      (compiled as any)?.["map-morphology"]?.["plot-mountains"]?.ridges ?? { strategy: "default", config: {} }
     ) as any;
 
-    expect(plan?.orogenyPotential01).toBeInstanceOf(Uint8Array);
-    expect(maxU8(plan.orogenyPotential01)).toBeGreaterThan(0);
+    const foothills = planFoothills.run(
+      {
+        width: PROBE_WIDTH,
+        height: PROBE_HEIGHT,
+        landMask: topography.landMask,
+        mountainMask: ridges.mountainMask,
+        boundaryCloseness: belts.boundaryCloseness,
+        boundaryType: belts.boundaryType,
+        upliftPotential: belts.upliftPotential,
+        riftPotential: belts.riftPotential,
+        tectonicStress: belts.tectonicStress,
+        fractalHill: zeros,
+      },
+      (compiled as any)?.["map-morphology"]?.["plot-mountains"]?.foothills ?? { strategy: "default", config: {} }
+    ) as any;
 
-    expect(plan?.mountainMask).toBeInstanceOf(Uint8Array);
-    expect(maxU8(plan.mountainMask)).toBe(1);
-    expect(countMask(plan.mountainMask)).toBeGreaterThanOrEqual(MIN_MOUNTAIN_TILES);
+    const beltStats = {
+      all: {
+        boundaryClosenessMax: maxU8(belts.boundaryCloseness),
+        boundaryTypeMax: maxU8(belts.boundaryType),
+        upliftPotentialMax: maxU8(belts.upliftPotential),
+        riftPotentialMax: maxU8(belts.riftPotential),
+        tectonicStressMax: maxU8(belts.tectonicStress),
+      },
+      land: {
+        boundaryClosenessMax: maxU8Where(belts.boundaryCloseness, topography.landMask),
+        boundaryTypeMax: maxU8Where(belts.boundaryType, topography.landMask),
+        upliftPotentialMax: maxU8Where(belts.upliftPotential, topography.landMask),
+        riftPotentialMax: maxU8Where(belts.riftPotential, topography.landMask),
+        tectonicStressMax: maxU8Where(belts.tectonicStress, topography.landMask),
+        upliftPotentialNonzero: countNonzeroWhere(belts.upliftPotential, topography.landMask),
+        tectonicStressNonzero: countNonzeroWhere(belts.tectonicStress, topography.landMask),
+        boundaryTypeCounts: {
+          convergent: countEqWhere(belts.boundaryType, topography.landMask, 1),
+          divergent: countEqWhere(belts.boundaryType, topography.landMask, 2),
+          transform: countEqWhere(belts.boundaryType, topography.landMask, 3),
+        },
+        convergentMax: {
+          boundaryClosenessMax: maxU8WhereEq(
+            belts.boundaryCloseness,
+            topography.landMask,
+            belts.boundaryType,
+            1
+          ),
+          upliftPotentialMax: maxU8WhereEq(
+            belts.upliftPotential,
+            topography.landMask,
+            belts.boundaryType,
+            1
+          ),
+          tectonicStressMax: maxU8WhereEq(
+            belts.tectonicStress,
+            topography.landMask,
+            belts.boundaryType,
+            1
+          ),
+        },
+      },
+      foundation: {
+        upliftTotalMax: maxU8Where(historyTiles?.rollups?.upliftTotal ?? new Uint8Array(size), topography.landMask),
+        upliftRecentFractionMax: maxU8Where(
+          historyTiles?.rollups?.upliftRecentFraction ?? new Uint8Array(size),
+          topography.landMask
+        ),
+        volcanismTotalMax: maxU8Where(
+          historyTiles?.rollups?.volcanismTotal ?? new Uint8Array(size),
+          topography.landMask
+        ),
+        fractureTotalMax: maxU8Where(
+          historyTiles?.rollups?.fractureTotal ?? new Uint8Array(size),
+          topography.landMask
+        ),
+      },
+    };
+
+    expect(ridges?.orogenyPotential01).toBeInstanceOf(Uint8Array);
+    const maxOrogeny = maxU8(ridges.orogenyPotential01);
+    if (maxOrogeny <= 0) {
+      throw new Error(
+        `Expected nonzero orogenyPotential01 on canonical probe; got max=${maxOrogeny}. beltStats=${JSON.stringify(
+          beltStats
+        )}`
+      );
+    }
+
+    expect(ridges?.mountainMask).toBeInstanceOf(Uint8Array);
+    const maxMountain = maxU8(ridges.mountainMask);
+    if (maxMountain !== 1) {
+      throw new Error(
+        `Expected nonzero mountainMask on canonical probe; got max=${maxMountain}. beltStats=${JSON.stringify(
+          beltStats
+        )}`
+      );
+    }
+    expect(countMask(ridges.mountainMask)).toBeGreaterThanOrEqual(MIN_MOUNTAIN_TILES);
+
+    expect(foothills?.hillMask).toBeInstanceOf(Uint8Array);
 
     // Volcanoes are planned via a separate step, but the artifact should remain non-degenerate.
     const volcanoList = Array.isArray(volcanoes?.volcanoes) ? volcanoes.volcanoes : [];

--- a/mods/mod-swooper-maps/test/support/standard-config.ts
+++ b/mods/mod-swooper-maps/test/support/standard-config.ts
@@ -419,7 +419,10 @@ export const standardConfig = {
     },
   },
   "map-morphology": {
-    mountains: { mountains: { strategy: "default", config: mountainsConfig } },
+    mountains: {
+      ridges: { strategy: "default", config: mountainsConfig },
+      foothills: { strategy: "default", config: mountainsConfig },
+    },
   },
   "hydrology-climate-baseline": {
     knobs: {


### PR DESCRIPTION
# Enhance Mountain Generation with Separate Ridge and Foothill Planning

This PR refactors the mountain generation system to split ridge (mountain) and foothill (hill) planning into separate operations. This architectural change provides several benefits:

1. Improves the physics-based mountain generation by enhancing the uplift signal calculation
2. Allows for more precise control over mountain and foothill placement
3. Creates cleaner separation of concerns between ridge and foothill generation

## Key Changes

- Created new dedicated operations: `planRidges` and `planFoothills` with their respective contracts
- Added shared rule modules in `mountains-shared/rules` to maintain consistent physics calculations
- Enhanced uplift signal calculation to better handle late-era uplift, preserving dynamic range while maintaining stable interiors
- Modified the mountain driver strength calculation to use a "gate" approach rather than a multiplier to preserve score dynamic range
- Updated map configs to use the new split operations
- Adjusted test cases to work with the new architecture

The uplift signal enhancement is particularly important - it now mixes in a "recent-weighted cumulative uplift" term that preserves the key invariant that old/stable interiors don't light up everywhere, while ensuring late-era uplift signals are strong enough for believable mountains and foothills.