### PR TITLE
refactor(morphology): rename 01-suffixed fields to standard unit naming

### DIFF
--- a/docs/projects/engine-refactor-v1/issues/_archive/M11-U06-orogeny-mountains-physics-anchored.md
+++ b/docs/projects/engine-refactor-v1/issues/_archive/M11-U06-orogeny-mountains-physics-anchored.md
@@ -36,7 +36,7 @@ related_to: [M11-U00]
   - correlation between convergence regime and mountain density above a threshold,
   - noise-only runs cannot create mountain belts without orogeny signal.
 - Add a simple “diagnostic dump” (trace or artifact) to render:
-  - `orogenyPotential01`, `fracture01`, and final mountain mask for a fixture.
+  - `orogenyPotential`, `fracturePotential`, and final mountain mask for a fixture.
 
 ## Dependencies / Notes
 - Primary driver source is Foundation; the work is blocked on adding coherent regime blends / fracture / cumulative deformation signals if they do not already exist.

--- a/docs/projects/mapgen-studio/VIZ-LAYER-CATALOG.md
+++ b/docs/projects/mapgen-studio/VIZ-LAYER-CATALOG.md
@@ -42,8 +42,8 @@ This catalog documents the visualization layers that MapGen Studio surfaces from
 **Map‑morphology projections (pipeline‑owned mocks)**
 - `map.morphology.mountains.mountainMask`
 - `map.morphology.mountains.hillMask`
-- `map.morphology.mountains.orogenyPotential01`
-- `map.morphology.mountains.fracture01`
+- `map.morphology.mountains.orogenyPotential`
+- `map.morphology.mountains.fracturePotential`
 - `map.morphology.coasts.coastalLand`
 - `map.morphology.coasts.coastalWater`
 - `map.morphology.volcanoes.points`

--- a/docs/projects/mapgen-studio/issues/LOCAL-TBD-pipeline-viz-surface.md
+++ b/docs/projects/mapgen-studio/issues/LOCAL-TBD-pipeline-viz-surface.md
@@ -198,8 +198,8 @@ related_to: []
 **Map‑morphology (projection overlays for viz/mock)**
 - `map.morphology.mountains.mountainMask` (grid, u8)
 - `map.morphology.mountains.hillMask` (grid, u8)
-- `map.morphology.mountains.orogenyPotential01` (grid, u8/ f32)
-- `map.morphology.mountains.fracture01` (grid, u8/ f32)
+- `map.morphology.mountains.orogenyPotential` (grid, u8/ f32)
+- `map.morphology.mountains.fracturePotential` (grid, u8/ f32)
 - `map.morphology.coasts.coastalLand` (grid, u8) + `map.morphology.coasts.coastalWater` (grid, u8)
 - `map.morphology.volcanoes.points` (points; value=strength01) [if not reusing morphology layer]
 

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M1-022-visualization-refinement-debug-vs-refined-layer-sets-era-scr.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M1-022-visualization-refinement-debug-vs-refined-layer-sets-era-scr.md
@@ -37,7 +37,7 @@ related_to: []
     - with controllable alpha.
   - Provide curated overlay presets for M1 tuning (depends on `LOCAL-TBD-PR-M1-003` stable `dataTypeKey`s):
     - overlay `foundation.events.boundary` on top of `foundation.history.regime`
-    - overlay `morphology.drivers.uplift` on top of `map.morphology.mountains.orogenyPotential01`
+    - overlay `morphology.drivers.uplift` on top of `map.morphology.mountains.orogenyPotential`
   - Keep overlays clearly labeled as “viewer assistance”; all gates live in D09r (`LOCAL-TBD-PR-M1-020`).
 
 ## Acceptance Criteria

--- a/docs/projects/pipeline-realism/plans/PLAN-fix-blobular-continents-restore-mountains-post-s101-2026-02-07.md
+++ b/docs/projects/pipeline-realism/plans/PLAN-fix-blobular-continents-restore-mountains-post-s101-2026-02-07.md
@@ -12,7 +12,7 @@ Using `bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label code
 
 - `map.morphology.mountains.mountainMask`: `min=0 max=0`
 - `map.morphology.mountains.hillMask`: `min=0 max=0`
-- `map.morphology.mountains.orogenyPotential01`: `min=0 max=0`
+- `map.morphology.mountains.orogenyPotential`: `min=0 max=0`
 - Volcanoes are present: `map.morphology.volcanoes.points count = 17`
 - Belt drivers show the scaling issue:
   - `morphology.belts.boundaryCloseness`: `min=2 max=28` (too low to drive boundaryStrength meaningfully)
@@ -27,7 +27,7 @@ In `.../compute-belt-drivers/deriveFromHistory.ts`, `boundaryCloseness` is compu
 
 So even at the boundary (normalized≈1), if the seed intensity is ~30–60, you only get closeness≈30–60, and after diffusion it’s often <30.  
 Then in `plan-ridges-and-foothills`, `boundaryStrength` is computed via a gate+exponent (default `boundaryGate=0.1`, `boundaryExponent=1.6`) and becomes so tiny that:
-- `orogenyPotential01` rounds to 0 everywhere
+- `orogenyPotential` rounds to 0 everywhere
 - mountain/hill scores never exceed thresholds
 
 ### B) “Plopped up blob” continents because plates still don’t *visibly* migrate enough
@@ -65,7 +65,7 @@ We’ll add a new mini-stack (3 slices) on top of `agent-GOBI-PRR-s101-per-era-c
 
 **Acceptance (canonical probe)**
 - Re-run `diag:dump 106 66 1337`.
-- `map.morphology.mountains.orogenyPotential01 max > 0`
+- `map.morphology.mountains.orogenyPotential max > 0`
 - `map.morphology.mountains.mountainMask max == 1` and nonzero count
 - Volcano points still nonzero.
 
@@ -181,7 +181,7 @@ Compute 3 intermediate fields, then blend:
 - Capture `map.morphology.mountains.mountainMask` and assert:
   - `max == 1`
   - `sum(mountainMask) >= 10` (small but nonzero guard)
-  - `map.morphology.mountains.orogenyPotential01 max > 0`
+  - `map.morphology.mountains.orogenyPotential max > 0`
 - Also assert volcano points count within a sane band (e.g. `>= 1`), to catch “all volcanoes disappeared” regressions.
 
 **Acceptance (canonical probe + gates)**
@@ -210,4 +210,3 @@ For each slice:
 - Drift profile: **Realistic** `[12, 9, 6, 3, 1]`.
 - Belt fix: **boundaryCloseness becomes pure proximity** (not intensity-scaled).
 - Landmask: **include boundary type + stress + history rollups + crust truth**, blended multi-scale, while keeping land fraction fixed via thresholding to `desiredLandCount`.
-

--- a/docs/projects/pipeline-realism/resources/runbooks/FIX-BLOBULAR-CONTINENTS-RESTORE-MOUNTAINS-POST-S101.md
+++ b/docs/projects/pipeline-realism/resources/runbooks/FIX-BLOBULAR-CONTINENTS-RESTORE-MOUNTAINS-POST-S101.md
@@ -12,7 +12,7 @@ Using `bun run --cwd mods/mod-swooper-maps diag:dump -- 106 66 1337 --label code
 
 - `map.morphology.mountains.mountainMask`: `min=0 max=0`
 - `map.morphology.mountains.hillMask`: `min=0 max=0`
-- `map.morphology.mountains.orogenyPotential01`: `min=0 max=0`
+- `map.morphology.mountains.orogenyPotential`: `min=0 max=0`
 - Volcanoes are present: `map.morphology.volcanoes.points count = 17`
 - Belt drivers show the scaling issue:
   - `morphology.belts.boundaryCloseness`: `min=2 max=28` (too low to drive boundaryStrength meaningfully)
@@ -27,7 +27,7 @@ In `.../compute-belt-drivers/deriveFromHistory.ts`, `boundaryCloseness` is compu
 
 So even at the boundary (normalized≈1), if the seed intensity is ~30–60, you only get closeness≈30–60, and after diffusion it’s often <30.  
 Then in `plan-ridges-and-foothills`, `boundaryStrength` is computed via a gate+exponent (default `boundaryGate=0.1`, `boundaryExponent=1.6`) and becomes so tiny that:
-- `orogenyPotential01` rounds to 0 everywhere
+- `orogenyPotential` rounds to 0 everywhere
 - mountain/hill scores never exceed thresholds
 
 ### B) “Plopped up blob” continents because plates still don’t *visibly* migrate enough
@@ -65,7 +65,7 @@ We’ll add a new mini-stack (3 slices) on top of `agent-GOBI-PRR-s101-per-era-c
 
 **Acceptance (canonical probe)**
 - Re-run `diag:dump 106 66 1337`.
-- `map.morphology.mountains.orogenyPotential01 max > 0`
+- `map.morphology.mountains.orogenyPotential max > 0`
 - `map.morphology.mountains.mountainMask max == 1` and nonzero count
 - Volcano points still nonzero.
 
@@ -181,7 +181,7 @@ Compute 3 intermediate fields, then blend:
 - Capture `map.morphology.mountains.mountainMask` and assert:
   - `max == 1`
   - `sum(mountainMask) >= 10` (small but nonzero guard)
-  - `map.morphology.mountains.orogenyPotential01 max > 0`
+  - `map.morphology.mountains.orogenyPotential max > 0`
 - Also assert volcano points count within a sane band (e.g. `>= 1`), to catch “all volcanoes disappeared” regressions.
 
 **Acceptance (canonical probe + gates)**
@@ -210,4 +210,3 @@ For each slice:
 - Drift profile: **Realistic** `[12, 9, 6, 3, 1]`.
 - Belt fix: **boundaryCloseness becomes pure proximity** (not intensity-scaled).
 - Landmask: **include boundary type + stress + history rollups + crust truth**, blended multi-scale, while keeping land fraction fixed via thresholding to `desiredLandCount`.
-

--- a/mods/mod-swooper-maps/src/domain/morphology/config.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/config.ts
@@ -238,7 +238,7 @@ export const MountainsConfigSchema = Type.Object(
     /**
      * Orogeny diagnostic weights (physics decomposition).
      *
-     * These weights are used to build the `orogenyPotential01` visualization surface from
+     * These weights are used to build the `orogenyPotential` visualization surface from
      * boundary regime + stress/uplift/rift signals.
      */
     orogenyCollisionStressWeight: Type.Number({

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-base-topography/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-base-topography/rules/index.ts
@@ -45,7 +45,7 @@ export function computeUpliftBlend(params: {
  * Computes a raw elevation sample before edge blending and scaling.
  */
 export function computeElevationRaw(params: {
-  crustBaseElevation01: number;
+  crustBaseElevationUnit: number;
   upliftNorm: number;
   riftNorm: number;
   closenessNorm: number;
@@ -53,7 +53,7 @@ export function computeElevationRaw(params: {
   arcNoise: number;
   config: ComputeBaseTopographyTypes["config"]["default"];
 }): number {
-  const { crustBaseElevation01, upliftNorm, riftNorm, closenessNorm, noise, arcNoise, config } = params;
+  const { crustBaseElevationUnit, upliftNorm, riftNorm, closenessNorm, noise, arcNoise, config } = params;
   const upliftBlend = computeUpliftBlend({
     upliftNorm,
     closenessNorm,
@@ -62,8 +62,8 @@ export function computeElevationRaw(params: {
     clusteringBias: config.clusteringBias,
   });
   const reliefSpan = config.continentalHeight - config.oceanicHeight;
-  const crust01 = clamp(crustBaseElevation01, 0, 1);
-  const base = config.oceanicHeight + reliefSpan * crust01;
+  const crustUnit = clamp(crustBaseElevationUnit, 0, 1);
+  const base = config.oceanicHeight + reliefSpan * crustUnit;
   const boundaryBoost = config.boundaryBias * closenessNorm;
   const upliftEffect = upliftBlend * reliefSpan * 0.45;
   const riftPenalty = riftNorm * reliefSpan * 0.15;

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-base-topography/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-base-topography/strategies/default.ts
@@ -26,7 +26,7 @@ export const defaultStrategy = createStrategy(ComputeBaseTopographyContract, "de
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
         const i = y * width + x;
-        const crust01 = crustBaseElevation[i] ?? 0;
+        const crustUnit = crustBaseElevation[i] ?? 0;
         const upliftNorm = (uplift[i] ?? 0) / 255;
         const riftNorm = (rift[i] ?? 0) / 255;
         const closenessNorm = (closeness[i] ?? 0) / 255;
@@ -35,7 +35,7 @@ export const defaultStrategy = createStrategy(ComputeBaseTopographyContract, "de
         const noise = (rng(1000, `base-topography:${gx},${gy}`) / 1000 - 0.5) * noiseAmplitude;
         const arcNoise = (rng(1000, `boundary-arc:${gx},${gy}`) / 1000 - 0.5) * arcNoiseWeight;
         elevationRaw[i] = computeElevationRaw({
-          crustBaseElevation01: crust01,
+          crustBaseElevationUnit: crustUnit,
           upliftNorm,
           riftNorm,
           closenessNorm,

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/strategies/default.ts
@@ -6,7 +6,7 @@ import ComputeShelfMaskContract from "../contract.js";
 const BOUNDARY_CONVERGENT = 1;
 const BOUNDARY_TRANSFORM = 3;
 
-function computeQuantileCutoff(values: Int16Array, count: number, q01: number): number {
+function computeQuantileCutoff(values: Int16Array, count: number, qUnit: number): number {
   if (count <= 0) return 0;
 
   // Copy into a normal array for a simple deterministic quantile.
@@ -15,7 +15,7 @@ function computeQuantileCutoff(values: Int16Array, count: number, q01: number): 
   for (let i = 0; i < count; i++) copy[i] = values[i] as number;
   copy.sort((a, b) => a - b); // ascending: deepest (more negative) -> shallowest (towards 0)
 
-  const q = Math.max(0, Math.min(1, q01));
+  const q = Math.max(0, Math.min(1, qUnit));
   const idx = Math.floor(q * (count - 1));
   const cutoff = copy[idx] ?? 0;
   // Bathymetry contract says <= 0 in water; clamp just in case.

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-substrate/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-substrate/rules/index.ts
@@ -73,15 +73,15 @@ export function erodibilityForTile(
   crustTypeValue: number,
   crustAgeValue: number
 ): number {
-  const uplift01 = (upliftValue ?? 0) / 255;
-  const closeness01 = (boundaryClosenessValue ?? 0) / 255;
-  const age01 = (crustAgeValue ?? 0) / 255;
+  const upliftUnit = (upliftValue ?? 0) / 255;
+  const closenessUnit = (boundaryClosenessValue ?? 0) / 255;
+  const ageUnit = (crustAgeValue ?? 0) / 255;
   const isContinental = (crustTypeValue | 0) === 1;
 
   const base = isContinental ? config.continentalBaseErodibility : config.oceanicBaseErodibility;
-  const aged = base * (1 - age01 * config.ageErodibilityReduction);
-  const boundary = closeness01 * boundaryErodibilityBoost(config, boundaryTypeValue ?? 0);
-  const uplift = uplift01 * config.upliftErodibilityBoost;
+  const aged = base * (1 - ageUnit * config.ageErodibilityReduction);
+  const boundary = closenessUnit * boundaryErodibilityBoost(config, boundaryTypeValue ?? 0);
+  const uplift = upliftUnit * config.upliftErodibilityBoost;
 
   return clampNonNegative(aged + boundary + uplift);
 }
@@ -97,15 +97,15 @@ export function sedimentDepthForTile(
   crustTypeValue: number,
   crustAgeValue: number
 ): number {
-  const rift01 = (riftValue ?? 0) / 255;
-  const closeness01 = (boundaryClosenessValue ?? 0) / 255;
-  const age01 = (crustAgeValue ?? 0) / 255;
+  const riftUnit = (riftValue ?? 0) / 255;
+  const closenessUnit = (boundaryClosenessValue ?? 0) / 255;
+  const ageUnit = (crustAgeValue ?? 0) / 255;
   const isContinental = (crustTypeValue | 0) === 1;
 
   const base = isContinental ? config.continentalBaseSediment : config.oceanicBaseSediment;
-  const aged = base + age01 * config.ageSedimentBoost;
-  const boundary = closeness01 * boundarySedimentBoost(config, boundaryTypeValue ?? 0);
-  const rift = rift01 * config.riftSedimentBoost;
+  const aged = base + ageUnit * config.ageSedimentBoost;
+  const boundary = closenessUnit * boundarySedimentBoost(config, boundaryTypeValue ?? 0);
+  const rift = riftUnit * config.riftSedimentBoost;
 
   return clampNonNegative(aged + boundary + rift);
 }

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeFracturePotential.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeFracturePotential.ts
@@ -1,7 +1,7 @@
 import type { MountainsConfig } from "./types.js";
 import { clamp01 } from "./util.js";
 
-export function computeFracture01(params: {
+export function computeFracturePotential(params: {
   boundaryStrength: number;
   stress: number;
   rift: number;
@@ -14,4 +14,3 @@ export function computeFracture01(params: {
       config.fractureRiftWeight * rift
   );
 }
-

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeHillScore.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeHillScore.ts
@@ -5,7 +5,7 @@ import { clamp } from "@swooper/mapgen-core/lib/math";
 import type { MountainsConfig } from "./types.js";
 import { clamp01 } from "./util.js";
 import { resolveBoundaryRegime } from "./resolveBoundaryRegime.js";
-import { computeOrogenyPotential01 } from "./computeOrogenyPotential01.js";
+import { computeOrogenyPotential } from "./computeOrogenyPotential.js";
 
 /**
  * Computes hill score from tectonic signals and fractal noise.
@@ -29,7 +29,7 @@ export function computeHillScore(params: {
   const collision = regime === BOUNDARY_TYPE.convergent ? boundaryStrength : 0;
   const divergence = regime === BOUNDARY_TYPE.divergent ? boundaryStrength : 0;
 
-  const orogenyPotential01 = computeOrogenyPotential01({
+  const orogenyPotential = computeOrogenyPotential({
     boundaryStrength,
     boundaryType: regime,
     uplift,
@@ -41,7 +41,7 @@ export function computeHillScore(params: {
   const hillIntensity = Math.sqrt(boundaryStrength);
   const foothillExtent = config.hillFoothillBase + fractal * config.hillFoothillFractalGain;
   let hillScore =
-    fractal * config.fractalWeight * config.hillFractalScale * orogenyPotential01 +
+    fractal * config.fractalWeight * config.hillFractalScale * orogenyPotential +
     uplift * config.hillUpliftWeight * config.hillUpliftScale * driverStrength;
 
   if (collision > 0 && config.hillBoundaryWeight > 0) {

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeMountainScore.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeMountainScore.ts
@@ -5,7 +5,7 @@ import { clamp } from "@swooper/mapgen-core/lib/math";
 import type { MountainsConfig } from "./types.js";
 import { clamp01 } from "./util.js";
 import { resolveBoundaryRegime } from "./resolveBoundaryRegime.js";
-import { computeOrogenyPotential01 } from "./computeOrogenyPotential01.js";
+import { computeOrogenyPotential } from "./computeOrogenyPotential.js";
 
 /**
  * Computes mountain score from tectonic signals and fractal noise.
@@ -31,7 +31,7 @@ export function computeMountainScore(params: {
   const transform = regime === BOUNDARY_TYPE.transform ? boundaryStrength : 0;
   const divergence = regime === BOUNDARY_TYPE.divergent ? boundaryStrength : 0;
 
-  const orogenyPotential01 = computeOrogenyPotential01({
+  const orogenyPotential = computeOrogenyPotential({
     boundaryStrength,
     boundaryType: regime,
     uplift,
@@ -45,14 +45,14 @@ export function computeMountainScore(params: {
       scaledBoundaryWeight *
       (config.mountainCollisionStressWeight * stress + config.mountainCollisionUpliftWeight * uplift) +
     uplift * scaledUpliftWeight * config.mountainInteriorUpliftScale * driverStrength +
-    fractal * config.fractalWeight * config.mountainFractalScale * orogenyPotential01;
+    fractal * config.fractalWeight * config.mountainFractalScale * orogenyPotential;
 
   if (collision > 0) {
     mountainScore +=
       collision *
       scaledConvergenceBonus *
       (config.mountainConvergenceFractalBase + fractal * config.mountainConvergenceFractalSpan) *
-      orogenyPotential01;
+      orogenyPotential;
   }
 
   if (config.interiorPenaltyWeight > 0) {

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeOrogenyPotential.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/computeOrogenyPotential.ts
@@ -4,7 +4,7 @@ import type { MountainsConfig } from "./types.js";
 import { clamp01 } from "./util.js";
 import { resolveBoundaryRegime } from "./resolveBoundaryRegime.js";
 
-export function computeOrogenyPotential01(params: {
+export function computeOrogenyPotential(params: {
   boundaryStrength: number;
   boundaryType: number;
   uplift: number;
@@ -27,4 +27,3 @@ export function computeOrogenyPotential01(params: {
 
   return clamp01(collisionSignal + transformSignal + divergenceSignal);
 }
-

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/encode01Byte.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/encode01Byte.ts
@@ -1,6 +1,0 @@
-import { clamp01, clampByte } from "./util.js";
-
-export function encode01Byte(value01: number): number {
-  return clampByte(clamp01(value01) * 255);
-}
-

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/encodeNormalizedToU8.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/encodeNormalizedToU8.ts
@@ -1,0 +1,5 @@
+import { clamp01, clampByte } from "./util.js";
+
+export function encodeNormalizedToU8(valueUnit: number): number {
+  return clampByte(clamp01(valueUnit) * 255);
+}

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/index.ts
@@ -1,9 +1,8 @@
-export { resolveDriverStrength01 } from "./resolveDriverStrength01.js";
+export { resolveDriverStrength } from "./resolveDriverStrength.js";
 export { resolveBoundaryStrength } from "./resolveBoundaryStrength.js";
-export { computeOrogenyPotential01 } from "./computeOrogenyPotential01.js";
-export { computeFracture01 } from "./computeFracture01.js";
+export { computeOrogenyPotential } from "./computeOrogenyPotential.js";
+export { computeFracturePotential } from "./computeFracturePotential.js";
 export { computeMountainScore } from "./computeMountainScore.js";
 export { computeHillScore } from "./computeHillScore.js";
 export { normalizeMountainFractal } from "./normalizeMountainFractal.js";
-export { encode01Byte } from "./encode01Byte.js";
-
+export { encodeNormalizedToU8 } from "./encodeNormalizedToU8.js";

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/resolveDriverStrength.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/mountains-shared/rules/resolveDriverStrength.ts
@@ -1,6 +1,6 @@
 import { clamp01 } from "./util.js";
 
-export function resolveDriverStrength01(params: {
+export function resolveDriverStrength(params: {
   driverByte: number;
   driverSignalByteMin: number;
   driverExponent: number;
@@ -13,4 +13,3 @@ export function resolveDriverStrength01(params: {
   const exponent = Math.max(0.01, params.driverExponent);
   return Math.pow(clamp01(normalized), exponent);
 }
-

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-foothills/strategies/default.ts
@@ -7,7 +7,7 @@ import {
   computeHillScore,
   normalizeMountainFractal,
   resolveBoundaryStrength,
-  resolveDriverStrength01,
+  resolveDriverStrength,
 } from "../../mountains-shared/rules.js";
 
 function validateFoothillsInputs(input: PlanFoothillsTypes["input"]): {
@@ -91,7 +91,7 @@ export const defaultStrategy = createStrategy(PlanFoothillsContract, "default", 
       const bType = boundaryType[i];
 
       const driverByte = Math.max(upliftPotential[i] ?? 0, tectonicStress[i] ?? 0, riftPotential[i] ?? 0);
-      const driverStrength = resolveDriverStrength01({
+      const driverStrength = resolveDriverStrength({
         driverByte,
         driverSignalByteMin: config.driverSignalByteMin,
         driverExponent: config.driverExponent,
@@ -117,4 +117,3 @@ export const defaultStrategy = createStrategy(PlanFoothillsContract, "default", 
     return { hillMask };
   },
 });
-

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges-and-foothills/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges-and-foothills/contract.ts
@@ -23,10 +23,10 @@ const PlanRidgesAndFoothillsContract = defineOp({
   output: Type.Object({
     mountainMask: TypedArraySchemas.u8({ description: "Mask (1/0): mountain tiles." }),
     hillMask: TypedArraySchemas.u8({ description: "Mask (1/0): hill tiles (excluding mountains)." }),
-    orogenyPotential01: TypedArraySchemas.u8({
+    orogenyPotential: TypedArraySchemas.u8({
       description: "Orogeny potential per tile (0..255). Diagnostic driver surface (physics-gated).",
     }),
-    fracture01: TypedArraySchemas.u8({
+    fracturePotential: TypedArraySchemas.u8({
       description: "Fracture proxy per tile (0..255). Diagnostic driver surface (physics-gated).",
     }),
   }),

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-ridges/contract.ts
@@ -24,10 +24,10 @@ const PlanRidgesContract = defineOp({
   }),
   output: Type.Object({
     mountainMask: TypedArraySchemas.u8({ description: "Mask (1/0): mountain tiles." }),
-    orogenyPotential01: TypedArraySchemas.u8({
+    orogenyPotential: TypedArraySchemas.u8({
       description: "Orogeny potential per tile (0..255). Diagnostic driver surface (physics-gated).",
     }),
-    fracture01: TypedArraySchemas.u8({
+    fracturePotential: TypedArraySchemas.u8({
       description: "Fracture proxy per tile (0..255). Diagnostic driver surface (physics-gated).",
     }),
   }),
@@ -37,4 +37,3 @@ const PlanRidgesContract = defineOp({
 });
 
 export default PlanRidgesContract;
-

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotMountains.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotMountains.ts
@@ -126,8 +126,8 @@ export default createStep(PlotMountainsStepContract, {
     const plan = {
       mountainMask: ridges.mountainMask,
       hillMask: foothills.hillMask,
-      orogenyPotential01: ridges.orogenyPotential01,
-      fracture01: ridges.fracture01,
+      orogenyPotential: ridges.orogenyPotential,
+      fracturePotential: ridges.fracturePotential,
     } as const;
 
     context.viz?.dumpGrid(context.trace, {
@@ -258,28 +258,28 @@ export default createStep(PlotMountainsStepContract, {
         }),
       });
     }
-    if (plan.orogenyPotential01 instanceof Uint8Array) {
+    if (plan.orogenyPotential instanceof Uint8Array) {
       context.viz?.dumpGrid(context.trace, {
-        dataTypeKey: "map.morphology.mountains.orogenyPotential01",
+        dataTypeKey: "map.morphology.mountains.orogenyPotential",
         spaceId: TILE_SPACE_ID,
         dims: { width, height },
         format: "u8",
-        values: plan.orogenyPotential01,
-        meta: defineVizMeta("map.morphology.mountains.orogenyPotential01", {
+        values: plan.orogenyPotential,
+        meta: defineVizMeta("map.morphology.mountains.orogenyPotential", {
           label: "Orogeny Potential (Planned)",
           group: GROUP_MAP_MORPHOLOGY,
           visibility: "debug",
         }),
       });
     }
-    if (plan.fracture01 instanceof Uint8Array) {
+    if (plan.fracturePotential instanceof Uint8Array) {
       context.viz?.dumpGrid(context.trace, {
-        dataTypeKey: "map.morphology.mountains.fracture01",
+        dataTypeKey: "map.morphology.mountains.fracturePotential",
         spaceId: TILE_SPACE_ID,
         dims: { width, height },
         format: "u8",
-        values: plan.fracture01,
-        meta: defineVizMeta("map.morphology.mountains.fracture01", {
+        values: plan.fracturePotential,
+        meta: defineVizMeta("map.morphology.mountains.fracturePotential", {
           label: "Fracture (Planned)",
           group: GROUP_MAP_MORPHOLOGY,
           visibility: "debug",
@@ -334,11 +334,11 @@ export default createStep(PlotMountainsStepContract, {
         sampleStep,
         cellFn: (x, y) => {
           const idx = y * width + x;
-          return { base: shadeByte(plan.orogenyPotential01?.[idx] ?? 0) };
+          return { base: shadeByte(plan.orogenyPotential?.[idx] ?? 0) };
         },
       });
       return {
-        kind: "morphology.mountains.ascii.orogenyPotential01",
+        kind: "morphology.mountains.ascii.orogenyPotential",
         sampleStep,
         legend: `${BYTE_SHADE_RAMP} (low→high)`,
         rows,
@@ -352,11 +352,11 @@ export default createStep(PlotMountainsStepContract, {
         sampleStep,
         cellFn: (x, y) => {
           const idx = y * width + x;
-          return { base: shadeByte(plan.fracture01?.[idx] ?? 0) };
+          return { base: shadeByte(plan.fracturePotential?.[idx] ?? 0) };
         },
       });
       return {
-        kind: "morphology.mountains.ascii.fracture01",
+        kind: "morphology.mountains.ascii.fracturePotential",
         sampleStep,
         legend: `${BYTE_SHADE_RAMP} (low→high)`,
         rows,

--- a/mods/mod-swooper-maps/test/morphology/m11-mountains-physics-anchored.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m11-mountains-physics-anchored.test.ts
@@ -164,7 +164,7 @@ describe("m11 mountains (physics-anchored)", () => {
 
     expect(countMask(ridges.mountainMask, 0, size)).toBe(0);
     expect(countMask(foothills.hillMask, 0, size)).toBe(0);
-    expect(Array.from(ridges.orogenyPotential01)).toEqual(Array.from(new Uint8Array(size)));
-    expect(Array.from(ridges.fracture01)).toEqual(Array.from(new Uint8Array(size)));
+    expect(Array.from(ridges.orogenyPotential)).toEqual(Array.from(new Uint8Array(size)));
+    expect(Array.from(ridges.fracturePotential)).toEqual(Array.from(new Uint8Array(size)));
   });
 });

--- a/mods/mod-swooper-maps/test/pipeline/mountains-nonzero-probe.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/mountains-nonzero-probe.test.ts
@@ -229,11 +229,11 @@ describe("pipeline: mountains nonzero canonical probe (earthlike)", () => {
       },
     };
 
-    expect(ridges?.orogenyPotential01).toBeInstanceOf(Uint8Array);
-    const maxOrogeny = maxU8(ridges.orogenyPotential01);
+    expect(ridges?.orogenyPotential).toBeInstanceOf(Uint8Array);
+    const maxOrogeny = maxU8(ridges.orogenyPotential);
     if (maxOrogeny <= 0) {
       throw new Error(
-        `Expected nonzero orogenyPotential01 on canonical probe; got max=${maxOrogeny}. beltStats=${JSON.stringify(
+        `Expected nonzero orogenyPotential on canonical probe; got max=${maxOrogeny}. beltStats=${JSON.stringify(
           beltStats
         )}`
       );


### PR DESCRIPTION
# Rename Mountain Physics Visualization Fields for Clarity

This PR renames several fields in the mountain physics visualization system to improve clarity and consistency:

- `orogenyPotential01` → `orogenyPotential`
- `fracture01` → `fracturePotential`
- Various other `*01` suffixes → `*Unit` to better indicate normalized values

The changes maintain the same functionality while making the naming more descriptive and consistent throughout the codebase. This affects visualization layers, diagnostic outputs, and internal computation functions.

These naming improvements help clarify that these fields represent physical potentials rather than arbitrary 0-1 values, making the code more maintainable and easier to understand.