### PR TITLE
fix(mod-swooper-maps): adjust continent generation parameters

### DIFF
--- a/mods/mod-swooper-maps/src/presets/standard/earthlike.json
+++ b/mods/mod-swooper-maps/src/presets/standard/earthlike.json
@@ -73,8 +73,8 @@
           "landmask": {
             "strategy": "default",
             "config": {
-              "continentPotentialGrain": 8,
-              "continentPotentialBlurSteps": 3,
+              "continentPotentialGrain": 4,
+              "continentPotentialBlurSteps": 4,
               "keepLandComponentFraction": 0.985
             }
           }


### PR DESCRIPTION
Adjusted continent generation parameters in the earthlike map preset by reducing the continentPotentialGrain from 8 to 4 and increasing continentPotentialBlurSteps from 3 to 4. These changes will result in smoother, more natural-looking continent shapes.