### PR TITLE
fix(map-morphology): restore terrain after buildElevation and resync water caches

### DIFF
--- a/docs/projects/pipeline-realism/scratch/agent-GOBI-PRR-per-era-boundaries/s00.md
+++ b/docs/projects/pipeline-realism/scratch/agent-GOBI-PRR-per-era-boundaries/s00.md
@@ -14,4 +14,4 @@ This file is the running scratch pad for the implementation stack described in:
 
 ### 2026-02-07
 - Created issue doc + scratch pad as the working checklist.
-
+- Slice s117: updated `map-morphology/build-elevation` to restore plotted terrain snapshot after engine `buildElevation()` and to resync water caches via `stampContinents()` + `storeWaterData()`. Added a mock drift regression test.

--- a/mods/mod-swooper-maps/test/map-morphology/build-elevation-no-water-drift.test.ts
+++ b/mods/mod-swooper-maps/test/map-morphology/build-elevation-no-water-drift.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+
+import { MockAdapter } from "@civ7/adapter";
+import { createExtendedMapContext } from "@swooper/mapgen-core";
+import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
+import { FLAT_TERRAIN, OCEAN_TERRAIN } from "@swooper/mapgen-core";
+
+import buildElevation from "../../src/recipes/standard/stages/map-morphology/steps/buildElevation.js";
+import { buildTestDeps } from "../support/step-deps.js";
+
+class DriftAfterBuildElevationAdapter extends MockAdapter {
+  buildElevationCalls = 0;
+  stampContinentsCalls = 0;
+  storeWaterDataCalls = 0;
+
+  private recomputeWaterMaskFromTerrain(): void {
+    const coast = this.getTerrainTypeIndex("TERRAIN_COAST");
+    const ocean = this.getTerrainTypeIndex("TERRAIN_OCEAN");
+    for (let y = 0; y < this.height; y++) {
+      for (let x = 0; x < this.width; x++) {
+        const t = this.getTerrainType(x, y) | 0;
+        this.setWater(x, y, t === coast || t === ocean);
+      }
+    }
+  }
+
+  override buildElevation(): void {
+    this.buildElevationCalls += 1;
+    // Simulate engine drift: cached water tables say "water" even though terrain remains land.
+    this.setWater(0, 0, true);
+  }
+
+  override stampContinents(): void {
+    this.stampContinentsCalls += 1;
+    this.recomputeWaterMaskFromTerrain();
+  }
+
+  override storeWaterData(): void {
+    this.storeWaterDataCalls += 1;
+    this.recomputeWaterMaskFromTerrain();
+  }
+}
+
+describe("map-morphology/build-elevation", () => {
+  it("restores plotted terrain snapshot and syncs water caches (no landMask drift)", () => {
+    const width = 4;
+    const height = 3;
+    const seed = 1234;
+    const mapInfo = { GridWidth: width, GridHeight: height, MinLatitude: -60, MaxLatitude: 60 };
+    const env = {
+      seed,
+      dimensions: { width, height },
+      latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
+    };
+
+    const adapter = new DriftAfterBuildElevationAdapter({
+      width,
+      height,
+      mapInfo,
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
+    });
+    const context = createExtendedMapContext({ width, height }, adapter, env);
+
+    const size = width * height;
+    const landMask = new Uint8Array(size).fill(0);
+    landMask[0] = 1;
+
+    // Seed the plotted terrain snapshot: flat land where landMask=1, ocean otherwise.
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const idx = y * width + x;
+        adapter.setTerrainType(x, y, landMask[idx] === 1 ? FLAT_TERRAIN : OCEAN_TERRAIN);
+      }
+    }
+
+    context.artifacts.set("artifact:morphology.topography", { landMask });
+
+    buildElevation.run(context as any, {}, {} as any, buildTestDeps(buildElevation));
+
+    expect(adapter.buildElevationCalls).toBe(1);
+    expect(adapter.stampContinentsCalls).toBeGreaterThanOrEqual(1);
+    expect(adapter.storeWaterDataCalls).toBeGreaterThanOrEqual(1);
+
+    // The drifted cached water bit must be corrected back to land.
+    expect(adapter.isWater(0, 0)).toBe(false);
+  });
+});
+


### PR DESCRIPTION
# Fix water drift in map-morphology/buildElevation

This PR addresses an issue where the engine's water caches could get out of sync with the plotted terrain after calling `buildElevation()`. 

Key changes:
- Modified `buildElevation` step to restore the full plotted terrain snapshot after the engine call
- Added engine synchronization calls (`stampContinents()` and `storeWaterData()`) to ensure water caches match the restored terrain
- Created a regression test that simulates water drift and verifies the fix works correctly
- Updated documentation in the scratch pad to track this implementation

The fix ensures that our invariant (Morphology landMask is authoritative) is maintained even when the engine's internal water tables drift from the terrain types.