### PR TITLE
feat(mapgen-studio): add preflight script to ensure recipe artifacts

### DIFF
--- a/apps/mapgen-studio/package.json
+++ b/apps/mapgen-studio/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "packageManager": "bun@1.3.7",
   "scripts": {
-    "dev": "vite",
+    "dev": "node ../../scripts/preflight/ensure-viz-runtime-deps.mjs && node ../../scripts/preflight/ensure-studio-recipe-artifacts.mjs && vite",
     "gen:civ7-tables": "bun ../../scripts/mapgen-studio/generate-civ7-browser-tables.ts",
     "check:worker-bundle": "node scripts/check-worker-bundle.mjs",
-    "build": "node ../../scripts/preflight/ensure-viz-runtime-deps.mjs && tsc && vite build && bun run check:worker-bundle",
+    "build": "node ../../scripts/preflight/ensure-viz-runtime-deps.mjs && node ../../scripts/preflight/ensure-studio-recipe-artifacts.mjs && tsc && vite build && bun run check:worker-bundle",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/docs/projects/mapgen-studio/RUNBOOK.md
+++ b/docs/projects/mapgen-studio/RUNBOOK.md
@@ -1,0 +1,34 @@
+# RUNBOOK: Mapgen Studio (Local Dev + Build Smoke)
+
+## Local Dev
+Recommended (root):
+```bash
+bun run dev:mapgen-studio
+```
+
+Notes:
+- The dev server is persistent. If port `5173` is busy, Vite will pick another port (e.g. `5174`) and print the Local URL.
+- Studio relies on `mod-swooper-maps` studio recipe artifacts. Preflight now ensures they exist when running Studio directly.
+
+Direct (from app):
+```bash
+bun run --cwd apps/mapgen-studio dev
+```
+
+## Build Smoke
+Standalone:
+```bash
+bun run --cwd apps/mapgen-studio build
+```
+
+Via Turbo (also ensures recipe artifacts build dependencies):
+```bash
+bun run build
+```
+
+## Common Failure Modes
+- `Rollup failed to resolve import "mod-swooper-maps/recipes/standard-artifacts"`:
+  - The `mod-swooper-maps` studio recipe artifacts were not built.
+  - Fix: rerun `bun run --cwd apps/mapgen-studio build` (preflight should self-heal), or run:
+    - `bun run --cwd mods/mod-swooper-maps build:studio-recipes`
+

--- a/docs/projects/pipeline-realism/scratch/agent-GOBI-PRR-per-era-boundaries/s00.md
+++ b/docs/projects/pipeline-realism/scratch/agent-GOBI-PRR-per-era-boundaries/s00.md
@@ -15,3 +15,4 @@ This file is the running scratch pad for the implementation stack described in:
 ### 2026-02-07
 - Created issue doc + scratch pad as the working checklist.
 - Slice s117: updated `map-morphology/build-elevation` to restore plotted terrain snapshot after engine `buildElevation()` and to resync water caches via `stampContinents()` + `storeWaterData()`. Added a mock drift regression test.
+- Slice s118: Mapgen Studio now self-heals missing `mod-swooper-maps` studio recipe artifacts in `apps/mapgen-studio` dev/build via a preflight script. Added a short Studio runbook.

--- a/scripts/preflight/ensure-studio-recipe-artifacts.mjs
+++ b/scripts/preflight/ensure-studio-recipe-artifacts.mjs
@@ -1,0 +1,47 @@
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const requiredArtifacts = [
+  "mods/mod-swooper-maps/dist/recipes/standard-artifacts.js",
+  "mods/mod-swooper-maps/dist/recipes/browser-test-artifacts.js",
+];
+
+const missingArtifacts = requiredArtifacts.filter((rel) => !existsSync(join(repoRoot, rel)));
+
+if (missingArtifacts.length === 0) {
+  process.exit(0);
+}
+
+const tsupCandidates = [
+  join(repoRoot, "node_modules", ".bin", "tsup"),
+  join(repoRoot, "mods", "mod-swooper-maps", "node_modules", ".bin", "tsup"),
+];
+const hasTsup = tsupCandidates.some((p) => existsSync(p));
+if (!hasTsup) {
+  console.error(
+    "[preflight] missing dev deps (tsup) for studio recipe artifacts. Run `bun install` at repo root (and/or in mods/mod-swooper-maps if using isolated linking), then retry."
+  );
+  process.exit(1);
+}
+
+const result = spawnSync("bun", ["run", "build:studio-recipes"], {
+  cwd: join(repoRoot, "mods", "mod-swooper-maps"),
+  stdio: "inherit",
+  env: process.env,
+});
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+
+const stillMissing = requiredArtifacts.filter((rel) => !existsSync(join(repoRoot, rel)));
+if (stillMissing.length > 0) {
+  console.error(
+    `[preflight] studio recipe artifacts still missing after build:\n${stillMissing.map((p) => `- ${p}`).join("\n")}`
+  );
+  process.exit(1);
+}
+


### PR DESCRIPTION
# Add preflight script to ensure studio recipe artifacts for Mapgen Studio

This PR adds a preflight script that ensures the required `mod-swooper-maps` studio recipe artifacts exist before running or building Mapgen Studio. The script automatically builds the artifacts if they're missing, preventing common "failed to resolve import" errors.

Changes include:
- Added `ensure-studio-recipe-artifacts.mjs` preflight script that checks for required artifacts and builds them if missing
- Updated `dev` and `build` scripts in `apps/mapgen-studio/package.json` to run the preflight check
- Added a Mapgen Studio runbook with instructions for local development, build processes, and troubleshooting common issues
- Updated the pipeline realism scratch pad to document this improvement

This change improves the developer experience by automatically handling dependencies that were previously manual steps.