### PR TITLE
feat(foundation): re-evaluate boundary segmentation per era

### DIFF
--- a/docs/projects/pipeline-realism/scratch/agent-GOBI-PRR-per-era-boundaries/s00.md
+++ b/docs/projects/pipeline-realism/scratch/agent-GOBI-PRR-per-era-boundaries/s00.md
@@ -17,3 +17,4 @@ This file is the running scratch pad for the implementation stack described in:
 - Slice s117: updated `map-morphology/build-elevation` to restore plotted terrain snapshot after engine `buildElevation()` and to resync water caches via `stampContinents()` + `storeWaterData()`. Added a mock drift regression test.
 - Slice s118: Mapgen Studio now self-heals missing `mod-swooper-maps` studio recipe artifacts in `apps/mapgen-studio` dev/build via a preflight script. Added a short Studio runbook.
 - Slice s119: added an era plate membership payload (`plateIdByEra`) to `foundation.tectonicHistory` by advecting plate seeds using plate velocities and assigning cells via deterministic multi-source Dijkstra.
+- Slice s120: re-evaluated boundary segmentation per era by re-running `foundation/compute-tectonic-segments` against `plateIdByEra[era]` and building era fields from era-specific segments (disables seed drift to avoid double-displacement).


### PR DESCRIPTION
# Re-evaluate Boundary Segmentation Per Era Using Era-Specific Plate Membership

This PR enhances tectonic history computation by re-evaluating boundary segmentation for each geological era. Instead of using a single segmentation for all eras, we now:

1. Run `compute-tectonic-segments` against each era's plate configuration (`plateIdByEra[era]`)
2. Build era-specific tectonic events from era-specific segments
3. Disable seed drift to prevent double-displacement (since plate membership already drifts per era)

This approach provides more accurate representation of tectonic boundaries as they evolve through time, better reflecting how plate interactions change across geological eras.