### PR TITLE
fix(foundation): classify convergent events based on crust type instead of polarity

### DIFF
--- a/docs/projects/pipeline-realism/scratch/agent-GOBI-PRR-per-era-boundaries/s00.md
+++ b/docs/projects/pipeline-realism/scratch/agent-GOBI-PRR-per-era-boundaries/s00.md
@@ -18,3 +18,4 @@ This file is the running scratch pad for the implementation stack described in:
 - Slice s118: Mapgen Studio now self-heals missing `mod-swooper-maps` studio recipe artifacts in `apps/mapgen-studio` dev/build via a preflight script. Added a short Studio runbook.
 - Slice s119: added an era plate membership payload (`plateIdByEra`) to `foundation.tectonicHistory` by advecting plate seeds using plate velocities and assigning cells via deterministic multi-source Dijkstra.
 - Slice s120: re-evaluated boundary segmentation per era by re-running `foundation/compute-tectonic-segments` against `plateIdByEra[era]` and building era fields from era-specific segments (disables seed drift to avoid double-displacement).
+- Slice s121: classified convergent events as collision vs. subduction based on crust type on each side of the boundary, rather than using "polarity is set" as a proxy.


### PR DESCRIPTION
This PR improves the classification of convergent tectonic events by using crust types instead of polarity as the determining factor. Now, boundaries are classified as collision when both sides have continental crust, and as subduction otherwise. This provides a more geologically accurate model compared to the previous approach that used polarity as a proxy. The change maintains polarity as a directional signal for subduction arcs when available, but sets it to zero for collision events.