### PR TITLE
fix(foundation): anchor newest-era plate membership to current plate graph

### DIFF
--- a/docs/projects/pipeline-realism/scratch/agent-GOBI-PRR-per-era-boundaries/s00.md
+++ b/docs/projects/pipeline-realism/scratch/agent-GOBI-PRR-per-era-boundaries/s00.md
@@ -19,3 +19,4 @@ This file is the running scratch pad for the implementation stack described in:
 - Slice s119: added an era plate membership payload (`plateIdByEra`) to `foundation.tectonicHistory` by advecting plate seeds using plate velocities and assigning cells via deterministic multi-source Dijkstra.
 - Slice s120: re-evaluated boundary segmentation per era by re-running `foundation/compute-tectonic-segments` against `plateIdByEra[era]` and building era fields from era-specific segments (disables seed drift to avoid double-displacement).
 - Slice s121: classified convergent events as collision vs. subduction based on crust type on each side of the boundary, rather than using "polarity is set" as a proxy.
+- Slice s122: anchored newest-era plate membership to the current plate graph (`plateGraph.cellToPlate`) so present-day boundaries match exactly; older eras still drift via advection.


### PR DESCRIPTION
Anchored newest-era plate membership to current plate graph for exact present-day boundary matching

This PR anchors the newest era's plate membership to the current plate graph (`plateGraph.cellToPlate`), ensuring that present-day tectonic boundaries match exactly with the current plate configuration. Older eras continue to use the existing advection-based approach for historical plate drift.

The implementation adds a `currentCellToPlate` parameter to the plate membership computation function and uses it to directly set the plate membership for the most recent era, bypassing the advection calculations for that specific era.