### PR TITLE
fix(maps): update orogenyPotential ID and add mountain mask categories

### DIFF
--- a/apps/mapgen-studio/src/recipes/overlaySuggestions.ts
+++ b/apps/mapgen-studio/src/recipes/overlaySuggestions.ts
@@ -16,8 +16,8 @@ const SUGGESTIONS_BY_RECIPE: Readonly<Record<string, readonly OverlaySuggestion[
       label: "Boundary events (snapshot)",
     },
     {
-      id: "map.morphology.mountains.orogenyPotential01::morphology.drivers.uplift",
-      primaryDataTypeKey: "map.morphology.mountains.orogenyPotential01",
+      id: "map.morphology.mountains.orogenyPotential::morphology.drivers.uplift",
+      primaryDataTypeKey: "map.morphology.mountains.orogenyPotential",
       overlayDataTypeKey: "morphology.drivers.uplift",
       label: "Uplift driver",
     },
@@ -30,8 +30,8 @@ const SUGGESTIONS_BY_RECIPE: Readonly<Record<string, readonly OverlaySuggestion[
       label: "Boundary events (snapshot)",
     },
     {
-      id: "map.morphology.mountains.orogenyPotential01::morphology.drivers.uplift",
-      primaryDataTypeKey: "map.morphology.mountains.orogenyPotential01",
+      id: "map.morphology.mountains.orogenyPotential::morphology.drivers.uplift",
+      primaryDataTypeKey: "map.morphology.mountains.orogenyPotential",
       overlayDataTypeKey: "morphology.drivers.uplift",
       label: "Uplift driver",
     },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotMountains.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotMountains.ts
@@ -295,6 +295,10 @@ export default createStep(PlotMountainsStepContract, {
         meta: defineVizMeta("map.morphology.mountains.mountainMask", {
           label: "Mountain Mask (Planned)",
           group: GROUP_MAP_MORPHOLOGY,
+          categories: [
+            { value: 0, label: "Not mountain", color: [148, 163, 184, 0] },
+            { value: 1, label: "Mountain", color: [250, 204, 21, 240] },
+          ],
         }),
       });
     }


### PR DESCRIPTION
This PR updates the orogeny potential data type key in overlay suggestions, removing the "01" suffix from both the ID and primary data type key. Additionally, it enhances the mountain mask visualization by adding category definitions that distinguish between mountain and non-mountain areas with appropriate colors and transparency settings.