### PR TITLE
refactor(ecology): add compiler-owned binding seam for advanced planners

### DIFF
--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-vegetated-feature-placements/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-vegetated-feature-placements/contract.ts
@@ -100,6 +100,13 @@ const PlanVegetatedFeaturePlacementsContract = defineOp({
     placements: Type.Array(VegetatedPlacementSchema),
   }),
   strategies: {
+    disabled: Type.Object(
+      {},
+      {
+        additionalProperties: false,
+        description: "Disabled planner (returns no placements).",
+      }
+    ),
     default: Type.Object({
       multiplier: Type.Number({
         description: "Scalar multiplier applied to all per-feature chances (0..2 typical).",

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-vegetated-feature-placements/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-vegetated-feature-placements/index.ts
@@ -1,10 +1,11 @@
 import { createOp } from "@swooper/mapgen-core/authoring";
 
 import PlanVegetatedFeaturePlacementsContract from "./contract.js";
-import { defaultStrategy } from "./strategies/index.js";
+import { defaultStrategy, disabledStrategy } from "./strategies/index.js";
 
 const planVegetatedFeaturePlacements = createOp(PlanVegetatedFeaturePlacementsContract, {
   strategies: {
+    disabled: disabledStrategy,
     default: defaultStrategy,
   },
 });

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-vegetated-feature-placements/strategies/disabled.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-vegetated-feature-placements/strategies/disabled.ts
@@ -1,0 +1,8 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import PlanVegetatedFeaturePlacementsContract from "../contract.js";
+
+export const disabledStrategy = createStrategy(PlanVegetatedFeaturePlacementsContract, "disabled", {
+  run: () => ({ placements: [] }),
+});
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-vegetated-feature-placements/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-vegetated-feature-placements/strategies/index.ts
@@ -1,2 +1,2 @@
+export { disabledStrategy } from "./disabled.js";
 export { defaultStrategy } from "./default.js";
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-feature-placements/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-feature-placements/contract.ts
@@ -88,6 +88,13 @@ const PlanWetFeaturePlacementsContract = defineOp({
     placements: Type.Array(WetPlacementSchema),
   }),
   strategies: {
+    disabled: Type.Object(
+      {},
+      {
+        additionalProperties: false,
+        description: "Disabled planner (returns no placements).",
+      }
+    ),
     default: Type.Object({
       multiplier: Type.Number({
         description: "Scalar multiplier applied to all per-feature chances (0..2 typical).",

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-feature-placements/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-feature-placements/index.ts
@@ -1,10 +1,11 @@
 import { createOp } from "@swooper/mapgen-core/authoring";
 
 import PlanWetFeaturePlacementsContract from "./contract.js";
-import { defaultStrategy } from "./strategies/index.js";
+import { defaultStrategy, disabledStrategy } from "./strategies/index.js";
 
 const planWetFeaturePlacements = createOp(PlanWetFeaturePlacementsContract, {
   strategies: {
+    disabled: disabledStrategy,
     default: defaultStrategy,
   },
 });

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-feature-placements/strategies/disabled.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-feature-placements/strategies/disabled.ts
@@ -1,0 +1,8 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import PlanWetFeaturePlacementsContract from "../contract.js";
+
+export const disabledStrategy = createStrategy(PlanWetFeaturePlacementsContract, "disabled", {
+  run: () => ({ placements: [] }),
+});
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-feature-placements/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-feature-placements/strategies/index.ts
@@ -1,2 +1,2 @@
+export { disabledStrategy } from "./disabled.js";
 export { defaultStrategy } from "./default.js";
-

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifact-validation.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifact-validation.ts
@@ -1,7 +1,7 @@
 import type { MapDimensions } from "@civ7/adapter";
 import type {
   BiomeClassificationArtifact,
-  FeatureIntentsArtifact,
+  FeatureIntentsListArtifact,
   PedologyArtifact,
   ResourceBasinsArtifact,
 } from "./artifacts.js";
@@ -79,15 +79,8 @@ function isResourceBasinsArtifact(value: unknown): value is ResourceBasinsArtifa
   );
 }
 
-function isFeatureIntentsArtifact(value: unknown): value is FeatureIntentsArtifact {
-  if (!value || typeof value !== "object") return false;
-  const candidate = value as FeatureIntentsArtifact;
-  return (
-    Array.isArray(candidate.vegetation) &&
-    Array.isArray(candidate.wetlands) &&
-    Array.isArray(candidate.reefs) &&
-    Array.isArray(candidate.ice)
-  );
+function isFeatureIntentsListArtifact(value: unknown): value is FeatureIntentsListArtifact {
+  return Array.isArray(value);
 }
 
 export function validateBiomeClassificationArtifact(
@@ -146,12 +139,12 @@ export function validateResourceBasinsArtifact(
   return errors;
 }
 
-export function validateFeatureIntentsArtifact(
+export function validateFeatureIntentsListArtifact(
   value: unknown,
   _dimensions: MapDimensions
 ): ArtifactValidationIssue[] {
   const errors: ArtifactValidationIssue[] = [];
-  if (!isFeatureIntentsArtifact(value)) {
+  if (!isFeatureIntentsListArtifact(value)) {
     errors.push({ message: "Invalid feature intents artifact payload." });
     return errors;
   }

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/artifacts.ts
@@ -52,57 +52,23 @@ export const ResourceBasinsArtifactSchema = Type.Object(
 
 export type ResourceBasinsArtifact = Static<typeof ResourceBasinsArtifactSchema>;
 
-export const FeatureIntentsArtifactSchema = Type.Object(
+export const FeaturePlacementIntentSchema = Type.Object(
   {
-    vegetation: Type.Array(
-      Type.Object(
-        {
-          x: Type.Integer({ minimum: 0 }),
-          y: Type.Integer({ minimum: 0 }),
-          feature: Type.String(),
-          weight: Type.Optional(Type.Number()),
-        },
-        { additionalProperties: false }
-      )
-    ),
-    wetlands: Type.Array(
-      Type.Object(
-        {
-          x: Type.Integer({ minimum: 0 }),
-          y: Type.Integer({ minimum: 0 }),
-          feature: Type.String(),
-          weight: Type.Optional(Type.Number()),
-        },
-        { additionalProperties: false }
-      )
-    ),
-    reefs: Type.Array(
-      Type.Object(
-        {
-          x: Type.Integer({ minimum: 0 }),
-          y: Type.Integer({ minimum: 0 }),
-          feature: Type.String(),
-          weight: Type.Optional(Type.Number()),
-        },
-        { additionalProperties: false }
-      )
-    ),
-    ice: Type.Array(
-      Type.Object(
-        {
-          x: Type.Integer({ minimum: 0 }),
-          y: Type.Integer({ minimum: 0 }),
-          feature: Type.String(),
-          weight: Type.Optional(Type.Number()),
-        },
-        { additionalProperties: false }
-      )
-    ),
+    x: Type.Integer({ minimum: 0 }),
+    y: Type.Integer({ minimum: 0 }),
+    feature: Type.String(),
+    weight: Type.Optional(Type.Number()),
   },
   { additionalProperties: false }
 );
 
-export type FeatureIntentsArtifact = Static<typeof FeatureIntentsArtifactSchema>;
+export type FeaturePlacementIntent = Static<typeof FeaturePlacementIntentSchema>;
+
+export const FeatureIntentsListArtifactSchema = Type.Array(FeaturePlacementIntentSchema, {
+  additionalProperties: false,
+});
+
+export type FeatureIntentsListArtifact = Static<typeof FeatureIntentsListArtifactSchema>;
 
 export const ecologyArtifacts = {
   biomeClassification: defineArtifact({
@@ -120,9 +86,24 @@ export const ecologyArtifacts = {
     id: "artifact:ecology.resourceBasins",
     schema: ResourceBasinsArtifactSchema,
   }),
-  featureIntents: defineArtifact({
-    name: "featureIntents",
-    id: "artifact:ecology.featureIntents",
-    schema: FeatureIntentsArtifactSchema,
+  featureIntentsVegetation: defineArtifact({
+    name: "featureIntentsVegetation",
+    id: "artifact:ecology.featureIntents.vegetation",
+    schema: FeatureIntentsListArtifactSchema,
+  }),
+  featureIntentsWetlands: defineArtifact({
+    name: "featureIntentsWetlands",
+    id: "artifact:ecology.featureIntents.wetlands",
+    schema: FeatureIntentsListArtifactSchema,
+  }),
+  featureIntentsReefs: defineArtifact({
+    name: "featureIntentsReefs",
+    id: "artifact:ecology.featureIntents.reefs",
+    schema: FeatureIntentsListArtifactSchema,
+  }),
+  featureIntentsIce: defineArtifact({
+    name: "featureIntentsIce",
+    id: "artifact:ecology.featureIntents.ice",
+    schema: FeatureIntentsListArtifactSchema,
   }),
 } as const;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/index.ts
@@ -1,4 +1,4 @@
-import { Type, createStage, type Static } from "@swooper/mapgen-core/authoring";
+import { Type, createStage } from "@swooper/mapgen-core/authoring";
 import { steps } from "./steps/index.js";
 
 const publicSchema = Type.Object(
@@ -7,41 +7,10 @@ const publicSchema = Type.Object(
     resourceBasins: Type.Optional(steps.resourceBasins.contract.schema),
     biomes: Type.Optional(steps.biomes.contract.schema),
     biomeEdgeRefine: Type.Optional(steps.biomeEdgeRefine.contract.schema),
-    featuresPlan: Type.Optional(
-      Type.Omit(steps.featuresPlan.contract.schema, [
-        "advancedVegetatedFeaturePlacements",
-        "advancedWetFeaturePlacements",
-      ])
-    ),
+    featuresPlan: Type.Optional(steps.featuresPlan.contract.schema),
   },
   { additionalProperties: false }
 );
-
-type EcologyStagePublicConfig = Static<typeof publicSchema>;
-type FeaturesPlanPublicConfig = NonNullable<EcologyStagePublicConfig["featuresPlan"]>;
-type FeaturesPlanInternalConfig = Static<typeof steps.featuresPlan.contract.schema>;
-
-type FeaturesPlanTranslatedConfig = Omit<
-  FeaturesPlanPublicConfig,
-  "vegetatedFeaturePlacements" | "wetFeaturePlacements"
-> &
-  Partial<
-    Pick<
-      FeaturesPlanInternalConfig,
-      "advancedVegetatedFeaturePlacements" | "advancedWetFeaturePlacements"
-    >
-  >;
-
-function translateFeaturesPlanConfig(input: FeaturesPlanPublicConfig): FeaturesPlanTranslatedConfig {
-  const { vegetatedFeaturePlacements, wetFeaturePlacements, ...rest } = input;
-  return {
-    ...rest,
-    ...(vegetatedFeaturePlacements
-      ? { advancedVegetatedFeaturePlacements: vegetatedFeaturePlacements }
-      : null),
-    ...(wetFeaturePlacements ? { advancedWetFeaturePlacements: wetFeaturePlacements } : null),
-  };
-}
 
 export default createStage({
   id: "ecology",
@@ -50,16 +19,12 @@ export default createStage({
   compile: ({ env, knobs, config }) => {
     void env;
     void knobs;
-    const featuresPlan = config.featuresPlan
-      ? translateFeaturesPlanConfig(config.featuresPlan)
-      : config.featuresPlan;
-
     return {
       pedology: config.pedology,
       "resource-basins": config.resourceBasins,
       biomes: config.biomes,
       "biome-edge-refine": config.biomeEdgeRefine,
-      "features-plan": featuresPlan,
+      "features-plan": config.featuresPlan,
     };
   },
   steps: [

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/index.ts
@@ -1,4 +1,4 @@
-import { Type, createStage } from "@swooper/mapgen-core/authoring";
+import { Type, createStage, type Static } from "@swooper/mapgen-core/authoring";
 import { steps } from "./steps/index.js";
 
 const publicSchema = Type.Object(
@@ -7,10 +7,41 @@ const publicSchema = Type.Object(
     resourceBasins: Type.Optional(steps.resourceBasins.contract.schema),
     biomes: Type.Optional(steps.biomes.contract.schema),
     biomeEdgeRefine: Type.Optional(steps.biomeEdgeRefine.contract.schema),
-    featuresPlan: Type.Optional(steps.featuresPlan.contract.schema),
+    featuresPlan: Type.Optional(
+      Type.Omit(steps.featuresPlan.contract.schema, [
+        "advancedVegetatedFeaturePlacements",
+        "advancedWetFeaturePlacements",
+      ])
+    ),
   },
   { additionalProperties: false }
 );
+
+type EcologyStagePublicConfig = Static<typeof publicSchema>;
+type FeaturesPlanPublicConfig = NonNullable<EcologyStagePublicConfig["featuresPlan"]>;
+type FeaturesPlanInternalConfig = Static<typeof steps.featuresPlan.contract.schema>;
+
+type FeaturesPlanTranslatedConfig = Omit<
+  FeaturesPlanPublicConfig,
+  "vegetatedFeaturePlacements" | "wetFeaturePlacements"
+> &
+  Partial<
+    Pick<
+      FeaturesPlanInternalConfig,
+      "advancedVegetatedFeaturePlacements" | "advancedWetFeaturePlacements"
+    >
+  >;
+
+function translateFeaturesPlanConfig(input: FeaturesPlanPublicConfig): FeaturesPlanTranslatedConfig {
+  const { vegetatedFeaturePlacements, wetFeaturePlacements, ...rest } = input;
+  return {
+    ...rest,
+    ...(vegetatedFeaturePlacements
+      ? { advancedVegetatedFeaturePlacements: vegetatedFeaturePlacements }
+      : null),
+    ...(wetFeaturePlacements ? { advancedWetFeaturePlacements: wetFeaturePlacements } : null),
+  };
+}
 
 export default createStage({
   id: "ecology",
@@ -19,12 +50,16 @@ export default createStage({
   compile: ({ env, knobs, config }) => {
     void env;
     void knobs;
+    const featuresPlan = config.featuresPlan
+      ? translateFeaturesPlanConfig(config.featuresPlan)
+      : config.featuresPlan;
+
     return {
       pedology: config.pedology,
       "resource-basins": config.resourceBasins,
       biomes: config.biomes,
       "biome-edge-refine": config.biomeEdgeRefine,
-      "features-plan": config.featuresPlan,
+      "features-plan": featuresPlan,
     };
   },
   steps: [

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/contract.ts
@@ -4,25 +4,24 @@ import { ecologyArtifacts } from "../../artifacts.js";
 import { hydrologyHydrographyArtifacts } from "../../../hydrology-hydrography/artifacts.js";
 import { morphologyArtifacts } from "../../../morphology/artifacts.js";
 
-function createOpSelectionSchema<Selection>(op: { id: string; strategies: Record<string, TSchema> }) {
+function createOpSelectionSchema<TSelection>(op: { id: string; strategies: Record<string, TSchema> }) {
   const strategyIds = Object.keys(op.strategies);
   if (strategyIds.length === 0) {
     throw new Error(`op(${op.id}) missing strategies`);
   }
 
-  return Type.Unsafe<Selection>(
-    Type.Union(
-      strategyIds.map((id) =>
-        Type.Object(
-          {
-            strategy: Type.Literal(id),
-            config: op.strategies[id]!,
-          },
-          { additionalProperties: false }
-        )
-      ) as any
+  // IMPORTANT: do not set a default on this schema. These keys must stay absent unless the author provides them.
+  const cases = strategyIds.map((id) =>
+    Type.Object(
+      {
+        strategy: Type.Literal(id),
+        config: op.strategies[id]!,
+      },
+      { additionalProperties: false }
     )
   );
+
+  return Type.Unsafe<TSelection>(Type.Union(cases as [TSchema, ...TSchema[]]));
 }
 
 type VegetatedFeaturePlacementsSelection = Static<
@@ -30,10 +29,9 @@ type VegetatedFeaturePlacementsSelection = Static<
 >;
 type WetFeaturePlacementsSelection = Static<(typeof ecology.ops.planWetFeaturePlacements)["config"]>;
 
-const VegetatedFeaturePlacementsSelectionSchema =
-  createOpSelectionSchema<VegetatedFeaturePlacementsSelection>(
-    ecology.ops.planVegetatedFeaturePlacements
-  );
+const VegetatedFeaturePlacementsSelectionSchema = createOpSelectionSchema<VegetatedFeaturePlacementsSelection>(
+  ecology.ops.planVegetatedFeaturePlacements
+);
 
 const WetFeaturePlacementsSelectionSchema = createOpSelectionSchema<WetFeaturePlacementsSelection>(
   ecology.ops.planWetFeaturePlacements
@@ -58,6 +56,14 @@ const FeaturesPlanStepContract = defineStep({
     wetlands: ecology.ops.planWetlands,
     reefs: ecology.ops.planReefs,
     ice: ecology.ops.planIce,
+    advancedVegetatedFeaturePlacements: {
+      contract: ecology.ops.planVegetatedFeaturePlacements,
+      defaultStrategy: "disabled",
+    },
+    advancedWetFeaturePlacements: {
+      contract: ecology.ops.planWetFeaturePlacements,
+      defaultStrategy: "disabled",
+    },
   },
   schema: Type.Object(
     {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/contract.ts
@@ -9,7 +9,12 @@ const FeaturesApplyStepContract = defineStep({
   requires: [],
   provides: [M3_DEPENDENCY_TAGS.field.featureType, M4_EFFECT_TAGS.engine.featuresApplied],
   artifacts: {
-    requires: [ecologyArtifacts.featureIntents],
+    requires: [
+      ecologyArtifacts.featureIntentsVegetation,
+      ecologyArtifacts.featureIntentsWetlands,
+      ecologyArtifacts.featureIntentsReefs,
+      ecologyArtifacts.featureIntentsIce,
+    ],
   },
   ops: {
     apply: ecology.ops.applyFeatures,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/index.ts
@@ -10,12 +10,11 @@ const TILE_SPACE_ID = "tile.hexOddR" as const;
 
 export default createStep(FeaturesApplyStepContract, {
   run: (context, config, ops, deps) => {
-    const intents = deps.artifacts.featureIntents.read(context);
     const placements = {
-      vegetation: Array.from(intents.vegetation),
-      wetlands: Array.from(intents.wetlands),
-      reefs: Array.from(intents.reefs),
-      ice: Array.from(intents.ice),
+      vegetation: Array.from(deps.artifacts.featureIntentsVegetation.read(context)),
+      wetlands: Array.from(deps.artifacts.featureIntentsWetlands.read(context)),
+      reefs: Array.from(deps.artifacts.featureIntentsReefs.read(context)),
+      ice: Array.from(deps.artifacts.featureIntentsIce.read(context)),
     };
 
     const merged = ops.apply(

--- a/mods/mod-swooper-maps/test/ecology/ecology-compat-ledger.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/ecology-compat-ledger.test.ts
@@ -50,7 +50,10 @@ describe("M2 contract freeze: ecology compatibility ledger (v1)", () => {
       ecologyArtifacts.pedology.id,
       ecologyArtifacts.resourceBasins.id,
       ecologyArtifacts.biomeClassification.id,
-      ecologyArtifacts.featureIntents.id,
+      ecologyArtifacts.featureIntentsVegetation.id,
+      ecologyArtifacts.featureIntentsWetlands.id,
+      ecologyArtifacts.featureIntentsReefs.id,
+      ecologyArtifacts.featureIntentsIce.id,
     ];
     expect(actualArtifactIds).toEqual([...ledger.artifactIds.ecology]);
 

--- a/mods/mod-swooper-maps/test/ecology/features-owned.helpers.ts
+++ b/mods/mod-swooper-maps/test/ecology/features-owned.helpers.ts
@@ -262,15 +262,24 @@ export function runOwnedFeaturePlacements(options: {
     placements.ice
   );
 
-  const intentsRuntime = implementArtifacts([ecologyArtifacts.featureIntents], {
-    featureIntents: {},
-  });
-  intentsRuntime.featureIntents.publish(ctx, {
-    vegetation: vegetation.placements,
-    wetlands: wetlands.placements,
-    reefs: reefs.placements,
-    ice: ice.placements,
-  });
+  const intentsRuntime = implementArtifacts(
+    [
+      ecologyArtifacts.featureIntentsVegetation,
+      ecologyArtifacts.featureIntentsWetlands,
+      ecologyArtifacts.featureIntentsReefs,
+      ecologyArtifacts.featureIntentsIce,
+    ],
+    {
+      featureIntentsVegetation: {},
+      featureIntentsWetlands: {},
+      featureIntentsReefs: {},
+      featureIntentsIce: {},
+    }
+  );
+  intentsRuntime.featureIntentsVegetation.publish(ctx, vegetation.placements);
+  intentsRuntime.featureIntentsWetlands.publish(ctx, wetlands.placements);
+  intentsRuntime.featureIntentsReefs.publish(ctx, reefs.placements);
+  intentsRuntime.featureIntentsIce.publish(ctx, ice.placements);
 
   const applyConfig = {
     apply: normalizeOpSelectionOrThrow(ecology.ops.applyFeatures, {

--- a/mods/mod-swooper-maps/test/ecology/features-plan-advanced-defaults.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/features-plan-advanced-defaults.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+
+import standardRecipe from "../../src/recipes/standard/recipe.js";
+
+import { standardConfig } from "../support/standard-config.js";
+
+function getStrategy(config: unknown, key: string): string | undefined {
+  if (!config || typeof config !== "object") return undefined;
+  const entry = (config as Record<string, unknown>)[key];
+  if (!entry || typeof entry !== "object") return undefined;
+  const strategy = (entry as Record<string, unknown>).strategy;
+  return typeof strategy === "string" ? strategy : undefined;
+}
+
+describe("features-plan advanced planner defaults", () => {
+  it("keeps internal advanced planners disabled when public keys are omitted", () => {
+    const env = {
+      seed: 1337,
+      dimensions: { width: 32, height: 20 },
+      latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
+    } as const;
+
+    const plan = standardRecipe.compile(env, standardConfig);
+    const node = plan.nodes.find(
+      (entry) =>
+        Boolean(entry) &&
+        typeof entry === "object" &&
+        (entry as Record<string, unknown>).stepId === "mod-swooper-maps.standard.ecology.features-plan"
+    );
+    if (!node) throw new Error("Missing features-plan node.");
+
+    const config = (node as Record<string, unknown>).config;
+    expect(getStrategy(config, "advancedVegetatedFeaturePlacements")).toBe("disabled");
+    expect(getStrategy(config, "advancedWetFeaturePlacements")).toBe("disabled");
+  });
+});

--- a/mods/mod-swooper-maps/test/ecology/features-plan-advanced-defaults.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/features-plan-advanced-defaults.test.ts
@@ -13,7 +13,7 @@ function getStrategy(config: unknown, key: string): string | undefined {
 }
 
 describe("features-plan advanced planner defaults", () => {
-  it("keeps internal advanced planners disabled when public keys are omitted", () => {
+  it("keeps advanced planners disabled when keys are omitted", () => {
     const env = {
       seed: 1337,
       dimensions: { width: 32, height: 20 },
@@ -30,7 +30,7 @@ describe("features-plan advanced planner defaults", () => {
     if (!node) throw new Error("Missing features-plan node.");
 
     const config = (node as Record<string, unknown>).config;
-    expect(getStrategy(config, "advancedVegetatedFeaturePlacements")).toBe("disabled");
-    expect(getStrategy(config, "advancedWetFeaturePlacements")).toBe("disabled");
+    expect(getStrategy(config, "vegetatedFeaturePlacements")).toBe("disabled");
+    expect(getStrategy(config, "wetFeaturePlacements")).toBe("disabled");
   });
 });

--- a/mods/mod-swooper-maps/test/ecology/features-plan-apply.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/features-plan-apply.test.ts
@@ -42,6 +42,14 @@ describe("features plan/apply pipeline", () => {
       }),
       reefs: normalizeOpSelectionOrThrow(ecology.ops.planReefs, { strategy: "default", config: {} }),
       ice: normalizeOpSelectionOrThrow(ecology.ops.planIce, { strategy: "default", config: {} }),
+      advancedVegetatedFeaturePlacements: normalizeOpSelectionOrThrow(ecology.ops.planVegetatedFeaturePlacements, {
+        strategy: "disabled",
+        config: {},
+      }),
+      advancedWetFeaturePlacements: normalizeOpSelectionOrThrow(ecology.ops.planWetFeaturePlacements, {
+        strategy: "disabled",
+        config: {},
+      }),
     };
     const planOps = ecology.ops.bind(featuresPlanStep.contract.ops!).runtime;
     featuresPlanStep.run(ctx, planConfig, planOps, buildTestDeps(featuresPlanStep));

--- a/mods/mod-swooper-maps/test/ecology/features-plan-apply.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/features-plan-apply.test.ts
@@ -42,11 +42,11 @@ describe("features plan/apply pipeline", () => {
       }),
       reefs: normalizeOpSelectionOrThrow(ecology.ops.planReefs, { strategy: "default", config: {} }),
       ice: normalizeOpSelectionOrThrow(ecology.ops.planIce, { strategy: "default", config: {} }),
-      advancedVegetatedFeaturePlacements: normalizeOpSelectionOrThrow(ecology.ops.planVegetatedFeaturePlacements, {
+      vegetatedFeaturePlacements: normalizeOpSelectionOrThrow(ecology.ops.planVegetatedFeaturePlacements, {
         strategy: "disabled",
         config: {},
       }),
-      advancedWetFeaturePlacements: normalizeOpSelectionOrThrow(ecology.ops.planWetFeaturePlacements, {
+      wetFeaturePlacements: normalizeOpSelectionOrThrow(ecology.ops.planWetFeaturePlacements, {
         strategy: "disabled",
         config: {},
       }),
@@ -54,9 +54,9 @@ describe("features plan/apply pipeline", () => {
     const planOps = ecology.ops.bind(featuresPlanStep.contract.ops!).runtime;
     featuresPlanStep.run(ctx, planConfig, planOps, buildTestDeps(featuresPlanStep));
 
-    const intents = ctx.artifacts.get(ecologyArtifacts.featureIntents.id);
-    expect(intents).toBeTruthy();
-    expect(intents?.vegetation.length).toBeGreaterThanOrEqual(0);
+    const vegetationIntents = ctx.artifacts.get(ecologyArtifacts.featureIntentsVegetation.id);
+    expect(vegetationIntents).toBeTruthy();
+    expect(Array.isArray(vegetationIntents)).toBe(true);
 
     const applyConfig = {
       apply: normalizeOpSelectionOrThrow(ecology.ops.applyFeatures, { strategy: "default", config: {} }),

--- a/mods/mod-swooper-maps/test/fixtures/ecology-compat/ecology-compat-ledger.v1.json
+++ b/mods/mod-swooper-maps/test/fixtures/ecology-compat/ecology-compat-ledger.v1.json
@@ -23,7 +23,10 @@
       "artifact:ecology.soils",
       "artifact:ecology.resourceBasins",
       "artifact:ecology.biomeClassification",
-      "artifact:ecology.featureIntents"
+      "artifact:ecology.featureIntents.vegetation",
+      "artifact:ecology.featureIntents.wetlands",
+      "artifact:ecology.featureIntents.reefs",
+      "artifact:ecology.featureIntents.ice"
     ]
   },
   "vizKeysFixture": {
@@ -32,4 +35,3 @@
   },
   "determinismLabels": ["ecology:planFeatureIntents", "ecology:planPlotEffects"]
 }
-

--- a/mods/mod-swooper-maps/test/fixtures/ecology-parity/ecology-artifacts-fingerprints.v1.json
+++ b/mods/mod-swooper-maps/test/fixtures/ecology-parity/ecology-artifacts-fingerprints.v1.json
@@ -9,6 +9,9 @@
     "artifact:ecology.soils": "109728a5197411f0285108d4a55b68a603b14bcc48efe08b60f8909c26499594",
     "artifact:ecology.resourceBasins": "f0955ebb31fb793be429702cbef7346c9ef395c901aed38dfc196ed473c3e709",
     "artifact:ecology.biomeClassification": "058b9d4216c457fa4b085b090c555b2e55cf31351c1b690c0e2afb700c203dd1",
-    "artifact:ecology.featureIntents": "c8a4cc9c5f919c79c52c5b608f17d92f7b22a71fe65d3636d99b53231db953cf"
+    "artifact:ecology.featureIntents.vegetation": "83fd22ae911440ce45953232436b8c0bbb9f79b426fa2c711603623f989f782d",
+    "artifact:ecology.featureIntents.wetlands": "85f032656e4e0d08309f49971057c174b5c8745013061c18886f501f8fffae20",
+    "artifact:ecology.featureIntents.reefs": "b79e55f8955a717d1083ed37dd3d199093dd8ea31450703112806b5c2ffaa1cc",
+    "artifact:ecology.featureIntents.ice": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   }
 }

--- a/mods/mod-swooper-maps/test/support/ecology-fixtures.ts
+++ b/mods/mod-swooper-maps/test/support/ecology-fixtures.ts
@@ -15,7 +15,10 @@ export const ECOLOGY_TIER1_ARTIFACT_IDS = [
   ecologyArtifacts.pedology.id,
   ecologyArtifacts.resourceBasins.id,
   ecologyArtifacts.biomeClassification.id,
-  ecologyArtifacts.featureIntents.id,
+  ecologyArtifacts.featureIntentsVegetation.id,
+  ecologyArtifacts.featureIntentsWetlands.id,
+  ecologyArtifacts.featureIntentsReefs.id,
+  ecologyArtifacts.featureIntentsIce.id,
 ] as const;
 
 const VIZ_KEY_PREFIXES = ["ecology.", "map.ecology.", "debug.heightfield."] as const;
@@ -130,4 +133,3 @@ export function computeEcologyBaselineV1(input?: {
     vizKeys: listVizKeys(entries),
   };
 }
-


### PR DESCRIPTION
refactor(ecology): add compiler-owned binding seam for advanced planners

refactor(ecology): split feature intents artifacts; simplify features-plan binding