### PR TITLE
feat(ecology): add vegetation substrate computation op

### DIFF
--- a/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/contract.ts
@@ -1,0 +1,67 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+const VegetationSubstrateConfigSchema = Type.Object(
+  {
+    moistureNormalization: Type.Number({
+      description:
+        "Effective moisture value mapped to water01=1.0. Default aligns with humid threshold + padding in biome classification.",
+      default: 230,
+      minimum: 1,
+    }),
+    temperatureMinC: Type.Number({
+      description: "Surface temperature (C) mapped to energy01=0.0.",
+      default: -20,
+    }),
+    temperatureMaxC: Type.Number({
+      description: "Surface temperature (C) mapped to energy01=1.0.",
+      default: 40,
+    }),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Normalization constants for vegetation substrate fields. Keep these stable and minimal; upstream physics should drive realism.",
+  }
+);
+
+/**
+ * Computes normalized vegetation planning fields (0..1) used by per-feature score ops.
+ *
+ * Ops are compute-only: no picking, no routing, no ordering assumptions.
+ */
+const ComputeVegetationSubstrateContract = defineOp({
+  kind: "compute",
+  id: "ecology/vegetation/compute-substrate",
+  input: Type.Object(
+    {
+      width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+      height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+      landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
+      effectiveMoisture: TypedArraySchemas.f32({ description: "Effective moisture per tile." }),
+      surfaceTemperature: TypedArraySchemas.f32({ description: "Surface temperature per tile (C)." }),
+      aridityIndex: TypedArraySchemas.f32({ description: "Aridity index per tile (0..1)." }),
+      freezeIndex: TypedArraySchemas.f32({ description: "Freeze index per tile (0..1)." }),
+      vegetationDensity: TypedArraySchemas.f32({ description: "Vegetation density per tile (0..1)." }),
+      fertility: TypedArraySchemas.f32({ description: "Fertility overlay per tile (0..1)." }),
+    },
+    { additionalProperties: false }
+  ),
+  output: Type.Object({
+    energy01: TypedArraySchemas.f32({
+      description: "Normalized growth energy proxy from surfaceTemperature (0..1).",
+    }),
+    water01: TypedArraySchemas.f32({
+      description: "Normalized water availability proxy from effectiveMoisture (0..1).",
+    }),
+    waterStress01: TypedArraySchemas.f32({ description: "Water stress proxy from aridityIndex (0..1)." }),
+    coldStress01: TypedArraySchemas.f32({ description: "Cold stress proxy from freezeIndex (0..1)." }),
+    biomass01: TypedArraySchemas.f32({ description: "Biomass proxy from vegetationDensity (0..1)." }),
+    fertility01: TypedArraySchemas.f32({ description: "Normalized fertility proxy (0..1)." }),
+  }),
+  strategies: {
+    default: VegetationSubstrateConfigSchema,
+  },
+});
+
+export default ComputeVegetationSubstrateContract;
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/index.ts
@@ -1,0 +1,15 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import ComputeVegetationSubstrateContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const computeVegetationSubstrate = createOp(ComputeVegetationSubstrateContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+
+export default computeVegetationSubstrate;
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/rules/compute-substrate-fields.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/rules/compute-substrate-fields.ts
@@ -1,0 +1,62 @@
+import { clamp01 } from "@swooper/mapgen-core";
+
+export function computeVegetationSubstrateFields(args: {
+  size: number;
+  landMask: Uint8Array;
+  effectiveMoisture: Float32Array;
+  surfaceTemperature: Float32Array;
+  aridityIndex: Float32Array;
+  freezeIndex: Float32Array;
+  vegetationDensity: Float32Array;
+  fertility: Float32Array;
+  moistureNormalization: number;
+  temperatureMinC: number;
+  temperatureMaxC: number;
+}): Readonly<{
+  energy01: Float32Array;
+  water01: Float32Array;
+  waterStress01: Float32Array;
+  coldStress01: Float32Array;
+  biomass01: Float32Array;
+  fertility01: Float32Array;
+}> {
+  const moistureNormalization = Math.max(1e-6, args.moistureNormalization);
+  const tempMin = Math.min(args.temperatureMinC, args.temperatureMaxC);
+  const tempMax = Math.max(args.temperatureMinC, args.temperatureMaxC);
+  const tempRange = Math.max(1e-6, tempMax - tempMin);
+
+  const energy01 = new Float32Array(args.size);
+  const water01 = new Float32Array(args.size);
+  const waterStress01 = new Float32Array(args.size);
+  const coldStress01 = new Float32Array(args.size);
+  const biomass01 = new Float32Array(args.size);
+  const fertility01 = new Float32Array(args.size);
+
+  for (let i = 0; i < args.size; i++) {
+    if (args.landMask[i] === 0) {
+      energy01[i] = 0;
+      water01[i] = 0;
+      waterStress01[i] = 0;
+      coldStress01[i] = 0;
+      biomass01[i] = 0;
+      fertility01[i] = 0;
+      continue;
+    }
+
+    const temp = args.surfaceTemperature[i];
+    energy01[i] = clamp01((temp - tempMin) / tempRange);
+
+    const moisture = args.effectiveMoisture[i];
+    water01[i] = clamp01(moisture / moistureNormalization);
+
+    // Indices from biome classification are already normalized to 0..1.
+    waterStress01[i] = clamp01(args.aridityIndex[i]);
+    coldStress01[i] = clamp01(args.freezeIndex[i]);
+
+    biomass01[i] = clamp01(args.vegetationDensity[i]);
+    fertility01[i] = clamp01(args.fertility[i]);
+  }
+
+  return { energy01, water01, waterStress01, coldStress01, biomass01, fertility01 };
+}
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/rules/index.ts
@@ -1,0 +1,3 @@
+export { computeVegetationSubstrateFields } from "./compute-substrate-fields.js";
+export { validateVegetationSubstrateInputs } from "./validate.js";
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/rules/validate.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/rules/validate.ts
@@ -1,0 +1,32 @@
+export function validateVegetationSubstrateInputs(args: {
+  width: number;
+  height: number;
+  landMask: Uint8Array;
+  effectiveMoisture: Float32Array;
+  surfaceTemperature: Float32Array;
+  aridityIndex: Float32Array;
+  freezeIndex: Float32Array;
+  vegetationDensity: Float32Array;
+  fertility: Float32Array;
+}): number {
+  const width = args.width | 0;
+  const height = args.height | 0;
+  if (!Number.isFinite(width) || width <= 0) throw new Error("invalid width");
+  if (!Number.isFinite(height) || height <= 0) throw new Error("invalid height");
+  const size = width * height;
+
+  const check = (label: string, arr: { length: number }) => {
+    if (arr.length !== size) throw new Error(`${label} length ${arr.length} != ${size}`);
+  };
+
+  check("landMask", args.landMask);
+  check("effectiveMoisture", args.effectiveMoisture);
+  check("surfaceTemperature", args.surfaceTemperature);
+  check("aridityIndex", args.aridityIndex);
+  check("freezeIndex", args.freezeIndex);
+  check("vegetationDensity", args.vegetationDensity);
+  check("fertility", args.fertility);
+
+  return size;
+}
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/strategies/default.ts
@@ -1,0 +1,35 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import ComputeVegetationSubstrateContract from "../contract.js";
+import { computeVegetationSubstrateFields, validateVegetationSubstrateInputs } from "../rules/index.js";
+
+export const defaultStrategy = createStrategy(ComputeVegetationSubstrateContract, "default", {
+  run: (input, config) => {
+    const size = validateVegetationSubstrateInputs({
+      width: input.width,
+      height: input.height,
+      landMask: input.landMask as Uint8Array,
+      effectiveMoisture: input.effectiveMoisture as Float32Array,
+      surfaceTemperature: input.surfaceTemperature as Float32Array,
+      aridityIndex: input.aridityIndex as Float32Array,
+      freezeIndex: input.freezeIndex as Float32Array,
+      vegetationDensity: input.vegetationDensity as Float32Array,
+      fertility: input.fertility as Float32Array,
+    });
+
+    return computeVegetationSubstrateFields({
+      size,
+      landMask: input.landMask as Uint8Array,
+      effectiveMoisture: input.effectiveMoisture as Float32Array,
+      surfaceTemperature: input.surfaceTemperature as Float32Array,
+      aridityIndex: input.aridityIndex as Float32Array,
+      freezeIndex: input.freezeIndex as Float32Array,
+      vegetationDensity: input.vegetationDensity as Float32Array,
+      fertility: input.fertility as Float32Array,
+      moistureNormalization: config.moistureNormalization,
+      temperatureMinC: config.temperatureMinC,
+      temperatureMaxC: config.temperatureMaxC,
+    });
+  },
+});
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/compute-vegetation-substrate/strategies/index.ts
@@ -1,0 +1,2 @@
+export { defaultStrategy } from "./default.js";
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/contracts.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/contracts.ts
@@ -1,6 +1,7 @@
 import AggregatePedologyContract from "./pedology-aggregate/contract.js";
 import BiomeClassificationContract from "./classify-biomes/contract.js";
 import ComputeFeatureSubstrateContract from "./compute-feature-substrate/contract.js";
+import ComputeVegetationSubstrateContract from "./compute-vegetation-substrate/contract.js";
 import FeaturesApplyContract from "./features-apply/contract.js";
 import PedologyClassifyContract from "./pedology-classify/contract.js";
 
@@ -53,6 +54,7 @@ export const contracts = {
   refineBiomeEdges: RefineBiomeEdgesContract,
 
   computeFeatureSubstrate: ComputeFeatureSubstrateContract,
+  computeVegetationSubstrate: ComputeVegetationSubstrateContract,
 
   planAquaticReefPlacements: PlanAquaticReefPlacementsContract,
   planAquaticColdReefPlacements: PlanAquaticColdReefPlacementsContract,
@@ -99,6 +101,7 @@ export {
   AggregatePedologyContract,
   BiomeClassificationContract,
   ComputeFeatureSubstrateContract,
+  ComputeVegetationSubstrateContract,
   FeaturesApplyContract,
   PedologyClassifyContract,
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/index.ts
@@ -3,6 +3,7 @@ import type { contracts } from "./contracts.js";
 
 import applyFeatures from "./features-apply/index.js";
 import computeFeatureSubstrate from "./compute-feature-substrate/index.js";
+import computeVegetationSubstrate from "./compute-vegetation-substrate/index.js";
 
 import planVegetationForest from "./features-plan-vegetation-forest/index.js";
 import planVegetationRainforest from "./features-plan-vegetation-rainforest/index.js";
@@ -57,6 +58,7 @@ const implementations = {
   refineBiomeEdges,
 
   computeFeatureSubstrate,
+  computeVegetationSubstrate,
 
   planAquaticReefPlacements,
   planAquaticColdReefPlacements,
@@ -102,6 +104,7 @@ export default implementations;
 export {
   applyFeatures,
   computeFeatureSubstrate,
+  computeVegetationSubstrate,
 
   planVegetationForest,
   planVegetationRainforest,


### PR DESCRIPTION
# Add Vegetation Substrate Computation Operation

This PR introduces a new operation `computeVegetationSubstrate` that calculates normalized vegetation planning fields (0-1 range) used by per-feature score operations. The operation transforms raw environmental data into standardized substrate fields that can be used for vegetation placement decisions.

The operation takes inputs including:
- Land mask
- Effective moisture
- Surface temperature
- Aridity index
- Freeze index
- Vegetation density
- Fertility

And produces normalized outputs:
- energy01 (growth energy proxy)
- water01 (water availability)
- waterStress01 (water stress)
- coldStress01 (cold stress)
- biomass01 (biomass proxy)
- fertility01 (normalized fertility)

The implementation includes configurable normalization parameters for moisture and temperature ranges to ensure consistent interpretation of environmental data across different map conditions.