### PR TITLE
feat(ecology): add vegetation scoring operations for biome classification

### DIFF
--- a/mods/mod-swooper-maps/src/domain/ecology/ops/contracts.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/contracts.ts
@@ -2,6 +2,11 @@ import AggregatePedologyContract from "./pedology-aggregate/contract.js";
 import BiomeClassificationContract from "./classify-biomes/contract.js";
 import ComputeFeatureSubstrateContract from "./compute-feature-substrate/contract.js";
 import ComputeVegetationSubstrateContract from "./compute-vegetation-substrate/contract.js";
+import ScoreVegetationForestContract from "./vegetation-score-forest/contract.js";
+import ScoreVegetationRainforestContract from "./vegetation-score-rainforest/contract.js";
+import ScoreVegetationTaigaContract from "./vegetation-score-taiga/contract.js";
+import ScoreVegetationSavannaWoodlandContract from "./vegetation-score-savanna-woodland/contract.js";
+import ScoreVegetationSagebrushSteppeContract from "./vegetation-score-sagebrush-steppe/contract.js";
 import FeaturesApplyContract from "./features-apply/contract.js";
 import PedologyClassifyContract from "./pedology-classify/contract.js";
 
@@ -55,6 +60,11 @@ export const contracts = {
 
   computeFeatureSubstrate: ComputeFeatureSubstrateContract,
   computeVegetationSubstrate: ComputeVegetationSubstrateContract,
+  scoreVegetationForest: ScoreVegetationForestContract,
+  scoreVegetationRainforest: ScoreVegetationRainforestContract,
+  scoreVegetationTaiga: ScoreVegetationTaigaContract,
+  scoreVegetationSavannaWoodland: ScoreVegetationSavannaWoodlandContract,
+  scoreVegetationSagebrushSteppe: ScoreVegetationSagebrushSteppeContract,
 
   planAquaticReefPlacements: PlanAquaticReefPlacementsContract,
   planAquaticColdReefPlacements: PlanAquaticColdReefPlacementsContract,
@@ -102,6 +112,11 @@ export {
   BiomeClassificationContract,
   ComputeFeatureSubstrateContract,
   ComputeVegetationSubstrateContract,
+  ScoreVegetationForestContract,
+  ScoreVegetationRainforestContract,
+  ScoreVegetationTaigaContract,
+  ScoreVegetationSavannaWoodlandContract,
+  ScoreVegetationSagebrushSteppeContract,
   FeaturesApplyContract,
   PedologyClassifyContract,
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/index.ts
@@ -4,6 +4,11 @@ import type { contracts } from "./contracts.js";
 import applyFeatures from "./features-apply/index.js";
 import computeFeatureSubstrate from "./compute-feature-substrate/index.js";
 import computeVegetationSubstrate from "./compute-vegetation-substrate/index.js";
+import scoreVegetationForest from "./vegetation-score-forest/index.js";
+import scoreVegetationRainforest from "./vegetation-score-rainforest/index.js";
+import scoreVegetationTaiga from "./vegetation-score-taiga/index.js";
+import scoreVegetationSavannaWoodland from "./vegetation-score-savanna-woodland/index.js";
+import scoreVegetationSagebrushSteppe from "./vegetation-score-sagebrush-steppe/index.js";
 
 import planVegetationForest from "./features-plan-vegetation-forest/index.js";
 import planVegetationRainforest from "./features-plan-vegetation-rainforest/index.js";
@@ -59,6 +64,11 @@ const implementations = {
 
   computeFeatureSubstrate,
   computeVegetationSubstrate,
+  scoreVegetationForest,
+  scoreVegetationRainforest,
+  scoreVegetationTaiga,
+  scoreVegetationSavannaWoodland,
+  scoreVegetationSagebrushSteppe,
 
   planAquaticReefPlacements,
   planAquaticColdReefPlacements,
@@ -105,6 +115,11 @@ export {
   applyFeatures,
   computeFeatureSubstrate,
   computeVegetationSubstrate,
+  scoreVegetationForest,
+  scoreVegetationRainforest,
+  scoreVegetationTaiga,
+  scoreVegetationSavannaWoodland,
+  scoreVegetationSagebrushSteppe,
 
   planVegetationForest,
   planVegetationRainforest,

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/contract.ts
@@ -1,0 +1,29 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+const ScoreVegetationForestContract = defineOp({
+  kind: "compute",
+  id: "ecology/vegetation/score/forest",
+  input: Type.Object(
+    {
+      width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+      height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+      landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
+      energy01: TypedArraySchemas.f32({ description: "Growth energy proxy (0..1)." }),
+      water01: TypedArraySchemas.f32({ description: "Water availability proxy (0..1)." }),
+      waterStress01: TypedArraySchemas.f32({ description: "Water stress proxy (0..1)." }),
+      coldStress01: TypedArraySchemas.f32({ description: "Cold stress proxy (0..1)." }),
+      biomass01: TypedArraySchemas.f32({ description: "Biomass proxy (0..1)." }),
+      fertility01: TypedArraySchemas.f32({ description: "Fertility proxy (0..1)." }),
+    },
+    { additionalProperties: false }
+  ),
+  output: Type.Object({
+    score01: TypedArraySchemas.f32({ description: "Forest suitability score per tile (0..1)." }),
+  }),
+  strategies: {
+    default: Type.Object({}, { additionalProperties: false }),
+  },
+});
+
+export default ScoreVegetationForestContract;
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/index.ts
@@ -1,0 +1,15 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import ScoreVegetationForestContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const scoreVegetationForest = createOp(ScoreVegetationForestContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+
+export default scoreVegetationForest;
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/rules/index.ts
@@ -1,0 +1,2 @@
+export { scoreForestSuitability } from "./score.js";
+export { validateVegetationScoreInputs } from "./validate.js";

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/rules/score.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/rules/score.ts
@@ -1,0 +1,52 @@
+import { clamp01 } from "@swooper/mapgen-core";
+
+function smoothstep(edge0: number, edge1: number, x: number): number {
+  const t = clamp01((x - edge0) / Math.max(1e-6, edge1 - edge0));
+  return t * t * (3 - 2 * t);
+}
+
+function bandpass(x: number, lo: number, hi: number, s: number): number {
+  const inLo = smoothstep(lo - s, lo + s, x);
+  const outHi = 1 - smoothstep(hi - s, hi + s, x);
+  return clamp01(inLo * outHi);
+}
+
+export function scoreForestSuitability(args: {
+  size: number;
+  landMask: Uint8Array;
+  energy01: Float32Array;
+  water01: Float32Array;
+  waterStress01: Float32Array;
+  coldStress01: Float32Array;
+  biomass01: Float32Array;
+  fertility01: Float32Array;
+}): Float32Array {
+  const score01 = new Float32Array(args.size);
+
+  for (let i = 0; i < args.size; i++) {
+    if (args.landMask[i] === 0) {
+      score01[i] = 0;
+      continue;
+    }
+
+    const biomass = args.biomass01[i];
+    const energy = args.energy01[i];
+    const water = args.water01[i];
+    const waterStress = args.waterStress01[i];
+    const coldStress = args.coldStress01[i];
+    const fertility = args.fertility01[i];
+
+    const score =
+      biomass *
+      bandpass(energy, 0.35, 0.8, 0.1) *
+      bandpass(water, 0.35, 0.8, 0.1) *
+      (1 - waterStress) *
+      (1 - coldStress) *
+      (0.6 + 0.4 * fertility);
+
+    score01[i] = clamp01(score);
+  }
+
+  return score01;
+}
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/rules/validate.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/rules/validate.ts
@@ -1,0 +1,32 @@
+export function validateVegetationScoreInputs(args: {
+  width: number;
+  height: number;
+  landMask: Uint8Array;
+  energy01: Float32Array;
+  water01: Float32Array;
+  waterStress01: Float32Array;
+  coldStress01: Float32Array;
+  biomass01: Float32Array;
+  fertility01: Float32Array;
+}): number {
+  const width = args.width | 0;
+  const height = args.height | 0;
+  if (!Number.isFinite(width) || width <= 0) throw new Error("invalid width");
+  if (!Number.isFinite(height) || height <= 0) throw new Error("invalid height");
+  const size = width * height;
+
+  const check = (label: string, arr: { length: number }) => {
+    if (arr.length !== size) throw new Error(`${label} length ${arr.length} != ${size}`);
+  };
+
+  check("landMask", args.landMask);
+  check("energy01", args.energy01);
+  check("water01", args.water01);
+  check("waterStress01", args.waterStress01);
+  check("coldStress01", args.coldStress01);
+  check("biomass01", args.biomass01);
+  check("fertility01", args.fertility01);
+
+  return size;
+}
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/strategies/default.ts
@@ -1,0 +1,34 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import ScoreVegetationForestContract from "../contract.js";
+import { scoreForestSuitability, validateVegetationScoreInputs } from "../rules/index.js";
+
+export const defaultStrategy = createStrategy(ScoreVegetationForestContract, "default", {
+  run: (input) => {
+    const size = validateVegetationScoreInputs({
+      width: input.width,
+      height: input.height,
+      landMask: input.landMask as Uint8Array,
+      energy01: input.energy01 as Float32Array,
+      water01: input.water01 as Float32Array,
+      waterStress01: input.waterStress01 as Float32Array,
+      coldStress01: input.coldStress01 as Float32Array,
+      biomass01: input.biomass01 as Float32Array,
+      fertility01: input.fertility01 as Float32Array,
+    });
+
+    const score01 = scoreForestSuitability({
+      size,
+      landMask: input.landMask as Uint8Array,
+      energy01: input.energy01 as Float32Array,
+      water01: input.water01 as Float32Array,
+      waterStress01: input.waterStress01 as Float32Array,
+      coldStress01: input.coldStress01 as Float32Array,
+      biomass01: input.biomass01 as Float32Array,
+      fertility01: input.fertility01 as Float32Array,
+    });
+
+    return { score01 };
+  },
+});
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-forest/strategies/index.ts
@@ -1,0 +1,2 @@
+export { defaultStrategy } from "./default.js";
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/contract.ts
@@ -1,0 +1,29 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+const ScoreVegetationRainforestContract = defineOp({
+  kind: "compute",
+  id: "ecology/vegetation/score/rainforest",
+  input: Type.Object(
+    {
+      width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+      height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+      landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
+      energy01: TypedArraySchemas.f32({ description: "Growth energy proxy (0..1)." }),
+      water01: TypedArraySchemas.f32({ description: "Water availability proxy (0..1)." }),
+      waterStress01: TypedArraySchemas.f32({ description: "Water stress proxy (0..1)." }),
+      coldStress01: TypedArraySchemas.f32({ description: "Cold stress proxy (0..1)." }),
+      biomass01: TypedArraySchemas.f32({ description: "Biomass proxy (0..1)." }),
+      fertility01: TypedArraySchemas.f32({ description: "Fertility proxy (0..1)." }),
+    },
+    { additionalProperties: false }
+  ),
+  output: Type.Object({
+    score01: TypedArraySchemas.f32({ description: "Rainforest suitability score per tile (0..1)." }),
+  }),
+  strategies: {
+    default: Type.Object({}, { additionalProperties: false }),
+  },
+});
+
+export default ScoreVegetationRainforestContract;
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/index.ts
@@ -1,0 +1,15 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import ScoreVegetationRainforestContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const scoreVegetationRainforest = createOp(ScoreVegetationRainforestContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+
+export default scoreVegetationRainforest;
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/rules/index.ts
@@ -1,0 +1,2 @@
+export { scoreRainforestSuitability } from "./score.js";
+export { validateVegetationScoreInputs } from "./validate.js";

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/rules/score.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/rules/score.ts
@@ -1,0 +1,49 @@
+import { clamp01 } from "@swooper/mapgen-core";
+
+function smoothstep(edge0: number, edge1: number, x: number): number {
+  const t = clamp01((x - edge0) / Math.max(1e-6, edge1 - edge0));
+  return t * t * (3 - 2 * t);
+}
+
+function bandpass(x: number, lo: number, hi: number, s: number): number {
+  const inLo = smoothstep(lo - s, lo + s, x);
+  const outHi = 1 - smoothstep(hi - s, hi + s, x);
+  return clamp01(inLo * outHi);
+}
+
+export function scoreRainforestSuitability(args: {
+  size: number;
+  landMask: Uint8Array;
+  energy01: Float32Array;
+  water01: Float32Array;
+  waterStress01: Float32Array;
+  coldStress01: Float32Array;
+  biomass01: Float32Array;
+}): Float32Array {
+  const score01 = new Float32Array(args.size);
+
+  for (let i = 0; i < args.size; i++) {
+    if (args.landMask[i] === 0) {
+      score01[i] = 0;
+      continue;
+    }
+
+    const biomass = args.biomass01[i];
+    const energy = args.energy01[i];
+    const water = args.water01[i];
+    const waterStress = args.waterStress01[i];
+    const coldStress = args.coldStress01[i];
+
+    const score =
+      biomass *
+      bandpass(energy, 0.65, 0.95, 0.08) *
+      bandpass(water, 0.7, 1.0, 0.08) *
+      (1 - waterStress) *
+      (1 - coldStress);
+
+    score01[i] = clamp01(score);
+  }
+
+  return score01;
+}
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/rules/validate.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/rules/validate.ts
@@ -1,0 +1,32 @@
+export function validateVegetationScoreInputs(args: {
+  width: number;
+  height: number;
+  landMask: Uint8Array;
+  energy01: Float32Array;
+  water01: Float32Array;
+  waterStress01: Float32Array;
+  coldStress01: Float32Array;
+  biomass01: Float32Array;
+  fertility01: Float32Array;
+}): number {
+  const width = args.width | 0;
+  const height = args.height | 0;
+  if (!Number.isFinite(width) || width <= 0) throw new Error("invalid width");
+  if (!Number.isFinite(height) || height <= 0) throw new Error("invalid height");
+  const size = width * height;
+
+  const check = (label: string, arr: { length: number }) => {
+    if (arr.length !== size) throw new Error(`${label} length ${arr.length} != ${size}`);
+  };
+
+  check("landMask", args.landMask);
+  check("energy01", args.energy01);
+  check("water01", args.water01);
+  check("waterStress01", args.waterStress01);
+  check("coldStress01", args.coldStress01);
+  check("biomass01", args.biomass01);
+  check("fertility01", args.fertility01);
+
+  return size;
+}
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/strategies/default.ts
@@ -1,0 +1,33 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import ScoreVegetationRainforestContract from "../contract.js";
+import { scoreRainforestSuitability, validateVegetationScoreInputs } from "../rules/index.js";
+
+export const defaultStrategy = createStrategy(ScoreVegetationRainforestContract, "default", {
+  run: (input) => {
+    validateVegetationScoreInputs({
+      width: input.width,
+      height: input.height,
+      landMask: input.landMask as Uint8Array,
+      energy01: input.energy01 as Float32Array,
+      water01: input.water01 as Float32Array,
+      waterStress01: input.waterStress01 as Float32Array,
+      coldStress01: input.coldStress01 as Float32Array,
+      biomass01: input.biomass01 as Float32Array,
+      fertility01: input.fertility01 as Float32Array,
+    });
+
+    const score01 = scoreRainforestSuitability({
+      size: (input.width | 0) * (input.height | 0),
+      landMask: input.landMask as Uint8Array,
+      energy01: input.energy01 as Float32Array,
+      water01: input.water01 as Float32Array,
+      waterStress01: input.waterStress01 as Float32Array,
+      coldStress01: input.coldStress01 as Float32Array,
+      biomass01: input.biomass01 as Float32Array,
+    });
+
+    return { score01 };
+  },
+});
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-rainforest/strategies/index.ts
@@ -1,0 +1,2 @@
+export { defaultStrategy } from "./default.js";
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/contract.ts
@@ -1,0 +1,31 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+const ScoreVegetationSagebrushSteppeContract = defineOp({
+  kind: "compute",
+  id: "ecology/vegetation/score/sagebrush-steppe",
+  input: Type.Object(
+    {
+      width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+      height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+      landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
+      energy01: TypedArraySchemas.f32({ description: "Growth energy proxy (0..1)." }),
+      water01: TypedArraySchemas.f32({ description: "Water availability proxy (0..1)." }),
+      waterStress01: TypedArraySchemas.f32({ description: "Water stress proxy (0..1)." }),
+      coldStress01: TypedArraySchemas.f32({ description: "Cold stress proxy (0..1)." }),
+      biomass01: TypedArraySchemas.f32({ description: "Biomass proxy (0..1)." }),
+      fertility01: TypedArraySchemas.f32({ description: "Fertility proxy (0..1)." }),
+    },
+    { additionalProperties: false }
+  ),
+  output: Type.Object({
+    score01: TypedArraySchemas.f32({
+      description: "Sagebrush steppe suitability score per tile (0..1).",
+    }),
+  }),
+  strategies: {
+    default: Type.Object({}, { additionalProperties: false }),
+  },
+});
+
+export default ScoreVegetationSagebrushSteppeContract;
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/index.ts
@@ -1,0 +1,15 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import ScoreVegetationSagebrushSteppeContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const scoreVegetationSagebrushSteppe = createOp(ScoreVegetationSagebrushSteppeContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+
+export default scoreVegetationSagebrushSteppe;
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/rules/index.ts
@@ -1,0 +1,2 @@
+export { scoreSagebrushSteppeSuitability } from "./score.js";
+export { validateVegetationScoreInputs } from "./validate.js";

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/rules/score.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/rules/score.ts
@@ -1,0 +1,46 @@
+import { clamp01 } from "@swooper/mapgen-core";
+
+function smoothstep(edge0: number, edge1: number, x: number): number {
+  const t = clamp01((x - edge0) / Math.max(1e-6, edge1 - edge0));
+  return t * t * (3 - 2 * t);
+}
+
+function bandpass(x: number, lo: number, hi: number, s: number): number {
+  const inLo = smoothstep(lo - s, lo + s, x);
+  const outHi = 1 - smoothstep(hi - s, hi + s, x);
+  return clamp01(inLo * outHi);
+}
+
+export function scoreSagebrushSteppeSuitability(args: {
+  size: number;
+  landMask: Uint8Array;
+  energy01: Float32Array;
+  water01: Float32Array;
+  waterStress01: Float32Array;
+  biomass01: Float32Array;
+}): Float32Array {
+  const score01 = new Float32Array(args.size);
+
+  for (let i = 0; i < args.size; i++) {
+    if (args.landMask[i] === 0) {
+      score01[i] = 0;
+      continue;
+    }
+
+    const biomass = args.biomass01[i];
+    const energy = args.energy01[i];
+    const water = args.water01[i];
+    const waterStress = args.waterStress01[i];
+
+    const score =
+      biomass *
+      bandpass(energy, 0.35, 0.8, 0.12) *
+      bandpass(water, 0.05, 0.35, 0.1) *
+      bandpass(waterStress, 0.45, 0.95, 0.1);
+
+    score01[i] = clamp01(score);
+  }
+
+  return score01;
+}
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/rules/validate.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/rules/validate.ts
@@ -1,0 +1,32 @@
+export function validateVegetationScoreInputs(args: {
+  width: number;
+  height: number;
+  landMask: Uint8Array;
+  energy01: Float32Array;
+  water01: Float32Array;
+  waterStress01: Float32Array;
+  coldStress01: Float32Array;
+  biomass01: Float32Array;
+  fertility01: Float32Array;
+}): number {
+  const width = args.width | 0;
+  const height = args.height | 0;
+  if (!Number.isFinite(width) || width <= 0) throw new Error("invalid width");
+  if (!Number.isFinite(height) || height <= 0) throw new Error("invalid height");
+  const size = width * height;
+
+  const check = (label: string, arr: { length: number }) => {
+    if (arr.length !== size) throw new Error(`${label} length ${arr.length} != ${size}`);
+  };
+
+  check("landMask", args.landMask);
+  check("energy01", args.energy01);
+  check("water01", args.water01);
+  check("waterStress01", args.waterStress01);
+  check("coldStress01", args.coldStress01);
+  check("biomass01", args.biomass01);
+  check("fertility01", args.fertility01);
+
+  return size;
+}
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/strategies/default.ts
@@ -1,0 +1,32 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import ScoreVegetationSagebrushSteppeContract from "../contract.js";
+import { scoreSagebrushSteppeSuitability, validateVegetationScoreInputs } from "../rules/index.js";
+
+export const defaultStrategy = createStrategy(ScoreVegetationSagebrushSteppeContract, "default", {
+  run: (input) => {
+    validateVegetationScoreInputs({
+      width: input.width,
+      height: input.height,
+      landMask: input.landMask as Uint8Array,
+      energy01: input.energy01 as Float32Array,
+      water01: input.water01 as Float32Array,
+      waterStress01: input.waterStress01 as Float32Array,
+      coldStress01: input.coldStress01 as Float32Array,
+      biomass01: input.biomass01 as Float32Array,
+      fertility01: input.fertility01 as Float32Array,
+    });
+
+    const score01 = scoreSagebrushSteppeSuitability({
+      size: (input.width | 0) * (input.height | 0),
+      landMask: input.landMask as Uint8Array,
+      energy01: input.energy01 as Float32Array,
+      water01: input.water01 as Float32Array,
+      waterStress01: input.waterStress01 as Float32Array,
+      biomass01: input.biomass01 as Float32Array,
+    });
+
+    return { score01 };
+  },
+});
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/strategies/index.ts
@@ -1,0 +1,2 @@
+export { defaultStrategy } from "./default.js";
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/contract.ts
@@ -1,0 +1,31 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+const ScoreVegetationSavannaWoodlandContract = defineOp({
+  kind: "compute",
+  id: "ecology/vegetation/score/savanna-woodland",
+  input: Type.Object(
+    {
+      width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+      height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+      landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
+      energy01: TypedArraySchemas.f32({ description: "Growth energy proxy (0..1)." }),
+      water01: TypedArraySchemas.f32({ description: "Water availability proxy (0..1)." }),
+      waterStress01: TypedArraySchemas.f32({ description: "Water stress proxy (0..1)." }),
+      coldStress01: TypedArraySchemas.f32({ description: "Cold stress proxy (0..1)." }),
+      biomass01: TypedArraySchemas.f32({ description: "Biomass proxy (0..1)." }),
+      fertility01: TypedArraySchemas.f32({ description: "Fertility proxy (0..1)." }),
+    },
+    { additionalProperties: false }
+  ),
+  output: Type.Object({
+    score01: TypedArraySchemas.f32({
+      description: "Savanna woodland suitability score per tile (0..1).",
+    }),
+  }),
+  strategies: {
+    default: Type.Object({}, { additionalProperties: false }),
+  },
+});
+
+export default ScoreVegetationSavannaWoodlandContract;
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/index.ts
@@ -1,0 +1,15 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import ScoreVegetationSavannaWoodlandContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const scoreVegetationSavannaWoodland = createOp(ScoreVegetationSavannaWoodlandContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+
+export default scoreVegetationSavannaWoodland;
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/rules/index.ts
@@ -1,0 +1,2 @@
+export { scoreSavannaWoodlandSuitability } from "./score.js";
+export { validateVegetationScoreInputs } from "./validate.js";

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/rules/score.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/rules/score.ts
@@ -1,0 +1,46 @@
+import { clamp01 } from "@swooper/mapgen-core";
+
+function smoothstep(edge0: number, edge1: number, x: number): number {
+  const t = clamp01((x - edge0) / Math.max(1e-6, edge1 - edge0));
+  return t * t * (3 - 2 * t);
+}
+
+function bandpass(x: number, lo: number, hi: number, s: number): number {
+  const inLo = smoothstep(lo - s, lo + s, x);
+  const outHi = 1 - smoothstep(hi - s, hi + s, x);
+  return clamp01(inLo * outHi);
+}
+
+export function scoreSavannaWoodlandSuitability(args: {
+  size: number;
+  landMask: Uint8Array;
+  energy01: Float32Array;
+  water01: Float32Array;
+  waterStress01: Float32Array;
+  biomass01: Float32Array;
+}): Float32Array {
+  const score01 = new Float32Array(args.size);
+
+  for (let i = 0; i < args.size; i++) {
+    if (args.landMask[i] === 0) {
+      score01[i] = 0;
+      continue;
+    }
+
+    const biomass = args.biomass01[i];
+    const energy = args.energy01[i];
+    const water = args.water01[i];
+    const waterStress = args.waterStress01[i];
+
+    const score =
+      biomass *
+      bandpass(energy, 0.65, 0.95, 0.08) *
+      bandpass(water, 0.2, 0.6, 0.1) *
+      bandpass(waterStress, 0.35, 0.75, 0.1);
+
+    score01[i] = clamp01(score);
+  }
+
+  return score01;
+}
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/rules/validate.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/rules/validate.ts
@@ -1,0 +1,32 @@
+export function validateVegetationScoreInputs(args: {
+  width: number;
+  height: number;
+  landMask: Uint8Array;
+  energy01: Float32Array;
+  water01: Float32Array;
+  waterStress01: Float32Array;
+  coldStress01: Float32Array;
+  biomass01: Float32Array;
+  fertility01: Float32Array;
+}): number {
+  const width = args.width | 0;
+  const height = args.height | 0;
+  if (!Number.isFinite(width) || width <= 0) throw new Error("invalid width");
+  if (!Number.isFinite(height) || height <= 0) throw new Error("invalid height");
+  const size = width * height;
+
+  const check = (label: string, arr: { length: number }) => {
+    if (arr.length !== size) throw new Error(`${label} length ${arr.length} != ${size}`);
+  };
+
+  check("landMask", args.landMask);
+  check("energy01", args.energy01);
+  check("water01", args.water01);
+  check("waterStress01", args.waterStress01);
+  check("coldStress01", args.coldStress01);
+  check("biomass01", args.biomass01);
+  check("fertility01", args.fertility01);
+
+  return size;
+}
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/strategies/default.ts
@@ -1,0 +1,32 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import ScoreVegetationSavannaWoodlandContract from "../contract.js";
+import { scoreSavannaWoodlandSuitability, validateVegetationScoreInputs } from "../rules/index.js";
+
+export const defaultStrategy = createStrategy(ScoreVegetationSavannaWoodlandContract, "default", {
+  run: (input) => {
+    validateVegetationScoreInputs({
+      width: input.width,
+      height: input.height,
+      landMask: input.landMask as Uint8Array,
+      energy01: input.energy01 as Float32Array,
+      water01: input.water01 as Float32Array,
+      waterStress01: input.waterStress01 as Float32Array,
+      coldStress01: input.coldStress01 as Float32Array,
+      biomass01: input.biomass01 as Float32Array,
+      fertility01: input.fertility01 as Float32Array,
+    });
+
+    const score01 = scoreSavannaWoodlandSuitability({
+      size: (input.width | 0) * (input.height | 0),
+      landMask: input.landMask as Uint8Array,
+      energy01: input.energy01 as Float32Array,
+      water01: input.water01 as Float32Array,
+      waterStress01: input.waterStress01 as Float32Array,
+      biomass01: input.biomass01 as Float32Array,
+    });
+
+    return { score01 };
+  },
+});
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-savanna-woodland/strategies/index.ts
@@ -1,0 +1,2 @@
+export { defaultStrategy } from "./default.js";
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/contract.ts
@@ -1,0 +1,29 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+const ScoreVegetationTaigaContract = defineOp({
+  kind: "compute",
+  id: "ecology/vegetation/score/taiga",
+  input: Type.Object(
+    {
+      width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+      height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+      landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
+      energy01: TypedArraySchemas.f32({ description: "Growth energy proxy (0..1)." }),
+      water01: TypedArraySchemas.f32({ description: "Water availability proxy (0..1)." }),
+      waterStress01: TypedArraySchemas.f32({ description: "Water stress proxy (0..1)." }),
+      coldStress01: TypedArraySchemas.f32({ description: "Cold stress proxy (0..1)." }),
+      biomass01: TypedArraySchemas.f32({ description: "Biomass proxy (0..1)." }),
+      fertility01: TypedArraySchemas.f32({ description: "Fertility proxy (0..1)." }),
+    },
+    { additionalProperties: false }
+  ),
+  output: Type.Object({
+    score01: TypedArraySchemas.f32({ description: "Taiga suitability score per tile (0..1)." }),
+  }),
+  strategies: {
+    default: Type.Object({}, { additionalProperties: false }),
+  },
+});
+
+export default ScoreVegetationTaigaContract;
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/index.ts
@@ -1,0 +1,15 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import ScoreVegetationTaigaContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const scoreVegetationTaiga = createOp(ScoreVegetationTaigaContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+
+export default scoreVegetationTaiga;
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/rules/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/rules/index.ts
@@ -1,0 +1,2 @@
+export { scoreTaigaSuitability } from "./score.js";
+export { validateVegetationScoreInputs } from "./validate.js";

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/rules/score.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/rules/score.ts
@@ -1,0 +1,49 @@
+import { clamp01 } from "@swooper/mapgen-core";
+
+function smoothstep(edge0: number, edge1: number, x: number): number {
+  const t = clamp01((x - edge0) / Math.max(1e-6, edge1 - edge0));
+  return t * t * (3 - 2 * t);
+}
+
+function bandpass(x: number, lo: number, hi: number, s: number): number {
+  const inLo = smoothstep(lo - s, lo + s, x);
+  const outHi = 1 - smoothstep(hi - s, hi + s, x);
+  return clamp01(inLo * outHi);
+}
+
+export function scoreTaigaSuitability(args: {
+  size: number;
+  landMask: Uint8Array;
+  energy01: Float32Array;
+  water01: Float32Array;
+  waterStress01: Float32Array;
+  coldStress01: Float32Array;
+  biomass01: Float32Array;
+}): Float32Array {
+  const score01 = new Float32Array(args.size);
+
+  for (let i = 0; i < args.size; i++) {
+    if (args.landMask[i] === 0) {
+      score01[i] = 0;
+      continue;
+    }
+
+    const biomass = args.biomass01[i];
+    const energy = args.energy01[i];
+    const water = args.water01[i];
+    const waterStress = args.waterStress01[i];
+    const coldStress = args.coldStress01[i];
+
+    const score =
+      biomass *
+      bandpass(energy, 0.1, 0.45, 0.1) *
+      bandpass(water, 0.25, 0.7, 0.1) *
+      (0.4 + 0.6 * coldStress) *
+      (1 - waterStress);
+
+    score01[i] = clamp01(score);
+  }
+
+  return score01;
+}
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/rules/validate.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/rules/validate.ts
@@ -1,0 +1,32 @@
+export function validateVegetationScoreInputs(args: {
+  width: number;
+  height: number;
+  landMask: Uint8Array;
+  energy01: Float32Array;
+  water01: Float32Array;
+  waterStress01: Float32Array;
+  coldStress01: Float32Array;
+  biomass01: Float32Array;
+  fertility01: Float32Array;
+}): number {
+  const width = args.width | 0;
+  const height = args.height | 0;
+  if (!Number.isFinite(width) || width <= 0) throw new Error("invalid width");
+  if (!Number.isFinite(height) || height <= 0) throw new Error("invalid height");
+  const size = width * height;
+
+  const check = (label: string, arr: { length: number }) => {
+    if (arr.length !== size) throw new Error(`${label} length ${arr.length} != ${size}`);
+  };
+
+  check("landMask", args.landMask);
+  check("energy01", args.energy01);
+  check("water01", args.water01);
+  check("waterStress01", args.waterStress01);
+  check("coldStress01", args.coldStress01);
+  check("biomass01", args.biomass01);
+  check("fertility01", args.fertility01);
+
+  return size;
+}
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/strategies/default.ts
@@ -1,0 +1,33 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import ScoreVegetationTaigaContract from "../contract.js";
+import { scoreTaigaSuitability, validateVegetationScoreInputs } from "../rules/index.js";
+
+export const defaultStrategy = createStrategy(ScoreVegetationTaigaContract, "default", {
+  run: (input) => {
+    validateVegetationScoreInputs({
+      width: input.width,
+      height: input.height,
+      landMask: input.landMask as Uint8Array,
+      energy01: input.energy01 as Float32Array,
+      water01: input.water01 as Float32Array,
+      waterStress01: input.waterStress01 as Float32Array,
+      coldStress01: input.coldStress01 as Float32Array,
+      biomass01: input.biomass01 as Float32Array,
+      fertility01: input.fertility01 as Float32Array,
+    });
+
+    const score01 = scoreTaigaSuitability({
+      size: (input.width | 0) * (input.height | 0),
+      landMask: input.landMask as Uint8Array,
+      energy01: input.energy01 as Float32Array,
+      water01: input.water01 as Float32Array,
+      waterStress01: input.waterStress01 as Float32Array,
+      coldStress01: input.coldStress01 as Float32Array,
+      biomass01: input.biomass01 as Float32Array,
+    });
+
+    return { score01 };
+  },
+});
+

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/strategies/index.ts
@@ -1,0 +1,2 @@
+export { defaultStrategy } from "./default.js";
+


### PR DESCRIPTION
# Add Vegetation Scoring Operations for Different Biomes

This PR adds five new vegetation scoring operations to evaluate the suitability of different biome types based on environmental factors:

1. `scoreVegetationForest` - Evaluates forest suitability based on biomass, energy, water availability, and stress factors
2. `scoreVegetationRainforest` - Scores areas for tropical rainforest suitability with higher energy and water requirements
3. `scoreVegetationTaiga` - Identifies suitable areas for taiga/boreal forests with cold stress tolerance
4. `scoreVegetationSavannaWoodland` - Evaluates savanna woodland suitability with moderate water requirements and stress tolerance
5. `scoreVegetationSagebrushSteppe` - Scores areas for sagebrush steppe vegetation with low water requirements and high stress tolerance

Each operation implements a specialized scoring algorithm using bandpass filters to identify optimal environmental ranges for each vegetation type. The operations share a common input structure but apply different ecological criteria to produce suitability scores ranging from 0 to 1.

These scoring operations will enable more accurate biome placement and improve ecological realism in generated maps.