### PR TITLE
refactor(ecology): replace biome modifiers with mechanistic vegetation model

### DIFF
--- a/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/rules/vegetation.schema.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/rules/vegetation.schema.ts
@@ -1,62 +1,5 @@
 import { Type } from "@swooper/mapgen-core/authoring";
 
-const VegetationBiomeModifierSchema = Type.Object(
-  {
-    /**
-     * Multiplier applied after vegetation density is computed for the biome.
-     * Values < 1 thin vegetation; values > 1 densify the biome.
-     */
-    multiplier: Type.Optional(
-      Type.Number({
-        description:
-          "Biome-specific multiplier applied after vegetation density is computed (scalar).",
-        default: 1,
-        minimum: 0,
-      })
-    ),
-    /**
-     * Additive bonus applied after the multiplier (0..1 typical).
-     * Use small values (0.05-0.25) to make a biome feel lush without changing global weights.
-     */
-    bonus: Type.Optional(
-      Type.Number({
-        description:
-          "Biome-specific additive bonus applied after multiplier (0..1 typical).",
-        default: 0,
-      })
-    ),
-  },
-  {
-    additionalProperties: false,
-    description: "Per-biome vegetation multiplier/bonus applied after base density.",
-  }
-);
-
-const VegetationBiomeModifiersSchema = Type.Object(
-  {
-    /** Modifiers for snow/ice biomes. */
-    snow: VegetationBiomeModifierSchema,
-    /** Modifiers for tundra biomes. */
-    tundra: VegetationBiomeModifierSchema,
-    /** Modifiers for boreal forests. */
-    boreal: VegetationBiomeModifierSchema,
-    /** Modifiers for dry temperate grasslands/steppes. */
-    temperateDry: VegetationBiomeModifierSchema,
-    /** Modifiers for humid temperate plains/forests. */
-    temperateHumid: VegetationBiomeModifierSchema,
-    /** Modifiers for seasonal tropical savannas. */
-    tropicalSeasonal: VegetationBiomeModifierSchema,
-    /** Modifiers for tropical rainforest zones. */
-    tropicalRainforest: VegetationBiomeModifierSchema,
-    /** Modifiers for desert basins. */
-    desert: VegetationBiomeModifierSchema,
-  },
-  {
-    additionalProperties: false,
-    description: "Per-biome vegetation adjustments applied after base density.",
-  }
-);
-
 export const VegetationSchema = Type.Object(
   {
     /**
@@ -100,14 +43,9 @@ export const VegetationSchema = Type.Object(
       default: 40,
       minimum: 0,
     }),
-    /**
-     * Per-biome vegetation modifiers applied after the base density calculation.
-     * Use this to thin deserts/snow or boost tropical rainforest lushness.
-     */
-    biomeModifiers: VegetationBiomeModifiersSchema,
   },
   {
     additionalProperties: false,
-    description: "Vegetation density model knobs (base, moisture/humidity weights, biome tweaks).",
+    description: "Vegetation density model knobs (base, moisture/humidity weights, normalization).",
   }
 );

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/strategies/default.ts
@@ -61,6 +61,7 @@ export const defaultStrategy = createStrategy(BiomeClassificationContract, "defa
       humidity,
       effectiveMoistureF64,
       surfaceTemperatureF64,
+      freezeIndex,
       aridityIndexF64,
       config: resolvedConfig,
     });

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
@@ -354,16 +354,6 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
             moistureWeight: 0.6,
             humidityWeight: 0.3,
             moistureNormalizationPadding: 55,
-            biomeModifiers: {
-              snow: { multiplier: 0.4, bonus: 0 },
-              tundra: { multiplier: 0.5, bonus: 0 },
-              boreal: { multiplier: 0.8, bonus: 0 },
-              temperateDry: { multiplier: 0.7, bonus: 0 },
-              temperateHumid: { multiplier: 0.95, bonus: 0 },
-              tropicalSeasonal: { multiplier: 0.95, bonus: 0 },
-              tropicalRainforest: { multiplier: 1, bonus: 0.2 },
-              desert: { multiplier: 0.1, bonus: 0 },
-            },
           },
           noise: {
             amplitude: 0.03,

--- a/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
@@ -356,16 +356,6 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
             moistureWeight: 0.7,
             humidityWeight: 0.4,
             moistureNormalizationPadding: 70,
-            biomeModifiers: {
-              snow: { multiplier: 0.5, bonus: 0 },
-              tundra: { multiplier: 0.55, bonus: 0 },
-              boreal: { multiplier: 0.9, bonus: 0 },
-              temperateDry: { multiplier: 0.8, bonus: 0 },
-              temperateHumid: { multiplier: 1, bonus: 0 },
-              tropicalSeasonal: { multiplier: 1, bonus: 0 },
-              tropicalRainforest: { multiplier: 1, bonus: 0.3 },
-              desert: { multiplier: 0.15, bonus: 0 },
-            },
           },
           noise: {
             amplitude: 0.03,

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
@@ -368,16 +368,6 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
             moistureWeight: 0.5,
             humidityWeight: 0.2,
             moistureNormalizationPadding: 45,
-            biomeModifiers: {
-              snow: { multiplier: 0.05, bonus: 0 },
-              tundra: { multiplier: 0.3, bonus: 0 },
-              boreal: { multiplier: 0.7, bonus: 0 },
-              temperateDry: { multiplier: 0.6, bonus: 0 },
-              temperateHumid: { multiplier: 0.9, bonus: 0 },
-              tropicalSeasonal: { multiplier: 0.9, bonus: 0 },
-              tropicalRainforest: { multiplier: 1, bonus: 0.2 },
-              desert: { multiplier: 0.18, bonus: 0.02 },
-            },
           },
           noise: {
             amplitude: 0.03,

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -547,41 +547,7 @@
             "base": 0.3,
             "moistureWeight": 0.6,
             "humidityWeight": 0.3,
-            "moistureNormalizationPadding": 60,
-            "biomeModifiers": {
-              "snow": {
-                "multiplier": 0.6,
-                "bonus": 0
-              },
-              "tundra": {
-                "multiplier": 0.5,
-                "bonus": 0
-              },
-              "boreal": {
-                "multiplier": 0.85,
-                "bonus": 0
-              },
-              "temperateDry": {
-                "multiplier": 0.75,
-                "bonus": 0
-              },
-              "temperateHumid": {
-                "multiplier": 1,
-                "bonus": 0
-              },
-              "tropicalSeasonal": {
-                "multiplier": 1,
-                "bonus": 0
-              },
-              "tropicalRainforest": {
-                "multiplier": 1,
-                "bonus": 0.25
-              },
-              "desert": {
-                "multiplier": 0.12,
-                "bonus": 0
-              }
-            }
+            "moistureNormalizationPadding": 60
           },
           "noise": {
             "amplitude": 0.04,

--- a/mods/mod-swooper-maps/src/presets/standard/earthlike.json
+++ b/mods/mod-swooper-maps/src/presets/standard/earthlike.json
@@ -514,41 +514,7 @@
               "base": 0.72,
               "moistureWeight": 0.88,
               "humidityWeight": 0.32,
-              "moistureNormalizationPadding": 45,
-              "biomeModifiers": {
-                "snow": {
-                  "multiplier": 3.2,
-                  "bonus": 0.3
-                },
-                "tundra": {
-                  "multiplier": 0.55,
-                  "bonus": 0
-                },
-                "boreal": {
-                  "multiplier": 0.9,
-                  "bonus": 0
-                },
-                "temperateDry": {
-                  "multiplier": 0.75,
-                  "bonus": 0
-                },
-                "temperateHumid": {
-                  "multiplier": 1,
-                  "bonus": 0
-                },
-                "tropicalSeasonal": {
-                  "multiplier": 1,
-                  "bonus": 0
-                },
-                "tropicalRainforest": {
-                  "multiplier": 5,
-                  "bonus": 1.2
-                },
-                "desert": {
-                  "multiplier": 5,
-                  "bonus": 0.25
-                }
-              }
+              "moistureNormalizationPadding": 45
             },
             "noise": {
               "amplitude": 0.028,


### PR DESCRIPTION
# Refactor Vegetation Density Calculation for Biomes

This PR replaces the biome-specific vegetation modifiers with a more mechanistic approach based on climate signals. Instead of using hardcoded multipliers and bonuses for each biome type, vegetation density is now calculated using:

1. Energy availability (normalized temperature)
2. Freeze index (penalizing perennially cold/frozen regions)
3. Aridity index (reducing density in water-stressed environments)

The changes:
- Remove the `biomeModifiers` configuration from all map presets
- Add `freezeIndex` as an input parameter to the vegetation calculation
- Implement a more climate-driven approach that suppresses growth in cold climates and penalizes frozen regimes
- Simplify the vegetation schema by removing the modifier configuration

This approach provides a more realistic and consistent vegetation model that responds directly to environmental conditions rather than using arbitrary biome-specific adjustments.