### PR TITLE
docs(spike): ecology truth stage split

### DIFF
--- a/docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/SPIKE-ecology-stage-split.md
+++ b/docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/SPIKE-ecology-stage-split.md
@@ -1,0 +1,223 @@
+# SPIKE: Ecology Stage Split (Map Ecology Gameplay) + Maximal Drift Plan
+
+Status: in progress (research-only; no production refactors in this branch)
+
+This spike extends the existing ecology architecture-alignment packet by focusing on **stage boundaries** for the gameplay/projection portion of ecology, and on how we should structure **score -> plan -> plot/apply** sequences without violating the target MapGen architecture (engine-refactor-v1 posture).
+
+Companion scratchpad (breadcrumbs + raw notes):
+- `docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/_scratch/SCRATCH-ecology-stage-split-2026-02-09.md`
+
+## 1) Objective
+
+1. Re-anchor in ecology as it exists today (code reality) and in the MapGen target architecture (docs authority).
+2. Produce a **maximal** drift analysis for ecology (especially around stage/step/op/rule boundaries and compilation seams).
+3. Propose a clean **stage split** for the current ecology gameplay stage(s) that matches boundary meaning and supports future growth.
+4. Produce an execution plan (sliceable into worktrees/Graphite branches) to address every identified issue.
+
+## 2) Assumptions and Unknowns
+
+Assumptions (explicit):
+- We are operating target-architecture-first; MapGen explanation/reference/policies docs are the vocabulary authority.
+- Ops are atomic; steps orchestrate ops together (including grouped “score -> plan -> plot/apply” sequences).
+- “Wet feature placement” stays as a concept; we are fixing its architecture, not removing it.
+- Rules are a good fit for codified decisions and scoring inputs, and can be proxied via “scoring ops” as front doors.
+
+Unknowns (to resolve during investigation):
+- The precise current step ordering + contracts inside `mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/`.
+- Where “wetFeaturePlacements” exists today (data model, artifacts, config surface) and what depends on it.
+- Which ecology ops currently mix scoring+planning+plotting responsibilities, if any.
+
+## 3) What We Learned (target model recap)
+
+We will only make contract claims anchored to doc/code paths and named symbols.
+
+Key target boundaries (anchors):
+- Stages are author-facing config compilation boundaries: `docs/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md`.
+- Steps orchestrate: they bind ops via contracts, declare tags/artifacts, and implement `run()` (+ optional shape-preserving `normalize()`): `docs/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md`.
+- Domains own algorithmic ops; steps are not where heavy compute should live; rules are for shared contracts/types and codified decisions: `docs/system/libs/mapgen/policies/MODULE-SHAPE.md`, `docs/system/libs/mapgen/explanation/ARCHITECTURE.md`.
+
+## 4) Maximal Drift Inventory (stage split lens)
+
+This section will be populated with concrete breadcrumbs to code paths/symbols and mapped back to the target-doc constraints.
+
+### 4.1 Stage topology overload (current truth `ecology` stage is doing too much)
+
+Evidence:
+- `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/index.ts` contains *both* environmental truth modeling (pedology/resource basins/biomes) and all feature-intent planning.
+- The `featuresPlan` public config is compiled into a wide internal surface (vegetation substrate + multiple vegetation scoring ops + wetlands/reefs/ice + multiple wet placement ops), including a Studio sentinel forwarding hack.
+
+This overload leads to:
+- unclear config surface (knobs vs derived values vs deep overrides),
+- hard-to-read step ordering (implicit coupling),
+- architectural pressure to put orchestration inside ops (anti-pattern).
+
+### 4.2 Feature planning mega-step (mixed responsibilities)
+
+Evidence:
+- `features-plan` step contract binds many ops and also introduces disabled-by-default wet placement ops:
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/contract.ts`
+- `features-plan` implementation performs:
+  - vegetation scoring (multiple score ops),
+  - vegetation plan/picking,
+  - wetlands plan,
+  - multiple wet placement planners with collision field updates,
+  - and then merges/publishes multiple intents:
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/index.ts`
+
+Why this is drift:
+- Steps should orchestrate, but “mega-steps” make it hard to keep “compute substrate vs plan” seams explicit and make rule reuse a first-class unit.
+
+### 4.2 Score vs plan coupling (circular dependency pressure)
+
+Working claim: if planning needs global visibility across multiple per-tile score layers (to avoid circular dependencies and avoid baking cross-score heuristics into score computations), we should formalize:
+- “score layers” as an explicit artifact (or structured output) produced by a scoring step/op, and
+- a planning op that consumes that single aggregated view to make placement decisions.
+
+### 4.3 Underutilized rules for scoring/policy
+
+Working claim: “rules” are a natural unit for codified decisions and score inputs. A scoring op can proxy multiple rules and emit a layered score object, instead of scattering scoring logic across multiple ops/steps or mixing it into planners.
+
+### 4.4 Disabled strategy toggle for wet placements (anti-pattern)
+
+Evidence:
+- Stage public config models `wetFeaturePlacements` as `strategy: "disabled" | "default"`:
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/index.ts`
+- Step contract injects per-feature wet placement planners with `defaultStrategy: "disabled"`:
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/contract.ts`
+
+This is a legacy/optional toggle concept. With atomic ops and step-owned orchestration, we should remove “disabled strategy” as a first-class concept and instead:
+- express recipe composition explicitly (what runs), and
+- rely on honest algorithmic inputs (thresholds, masks, and constraints) to yield zero placements when appropriate.
+
+### 4.5 Underused compute substrate op (duplicate logic in steps)
+
+Evidence:
+- `ecology.ops.computeFeatureSubstrate` exists as a reusable compute substrate op returning navigable/adjacency masks:
+  - `mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/contract.ts`
+- `features-plan` step reimplements navigable river masks and adjacency masks ad hoc:
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/index.ts`
+
+## 5) Potential Stage Split Shapes (conceptual; no implementation yet)
+
+We are choosing boundaries based on meaning and compilation seams. Two main shapes seem plausible:
+
+### Shape A (recommended): Split truth `ecology` into multiple truth stages (hydrology/morphology pattern)
+
+Key point: keep the truth-vs-projection posture, but stop treating “truth ecology” as one monolithic stage. Instead, mirror Hydrology/Morphology by using multiple smaller truth stages with crisp config surfaces.
+
+Proposed truth-stage decomposition (names illustrative; align to conventions like `hydrology-climate-refine`, `morphology-erosion`):
+- `ecology-pedology`:
+  - steps: `pedology`, `resource-basins`
+  - artifacts: `artifact:ecology.soils`, `artifact:ecology.resourceBasins`
+- `ecology-biomes`:
+  - steps: `biomes` (and integrate edge refinement into classification; remove separate refine op/step)
+  - artifacts: `artifact:ecology.biomeClassification`
+- `ecology-features`:
+  - steps: explicitly segmented “score -> plan -> publish” per group (vegetation, wetlands, reefs, ice), with step-owned orchestration of atomic ops
+  - artifacts: `artifact:ecology.featureIntents.*`
+
+Pros:
+- Config surfaces map cleanly to conceptual levers.
+- Execution ordering is readable and tag seams are explicit.
+- Easy to extend with new feature families without turning one stage into a “kitchen sink”.
+ - Lets us collapse the current `featuresPlan` compile multiplexor and use per-step schemas directly (hydrology pattern).
+
+Cons:
+- More stage modules and compilation surfaces (more files).
+- Requires careful artifact seams if planners want cross-feature visibility (see score-layer artifact note below).
+
+Score-layer posture inside `ecology-features`:
+- If we want planners to see multiple score layers without circular dependencies, introduce a scoring step that outputs a single structured “score layers” artifact, and have each planner consume it (read-only) while still producing only its own intent list (keeps “atomic per-feature planning ops” intact).
+
+Concrete “sensible boundary” inside `ecology-features` (recommended):
+- `compute-feature-substrate` (step): calls `ecology.ops.computeFeatureSubstrate` and publishes a small, reusable mask artifact (or keeps it step-local if we’re not ready to surface a new artifact yet).
+- Vegetation:
+  - `score-vegetation` (step/op): one scoring op that proxies multiple vegetation scoring rules and emits layered `Float32Array`s (forest/rainforest/taiga/etc).
+  - `plan-vegetation` (step/op): consumes the aggregated vegetation score layers (and optionally other feature-family layers) and produces `artifact:ecology.featureIntents.vegetation`.
+- Wetlands:
+  - `plan-wetlands` (step): consumes substrate masks + inputs, calls `ecology.ops.planWetlands` plus atomic wet-placement ops (marsh/bog/mangrove/oasis/watering hole) in a step-owned sequence so ops never call each other.
+  - Remove “disabled strategy” by making these planners honest and always runnable (placements can naturally be empty).
+- Marine/cryosphere:
+  - `plan-reefs` (step/op) -> `artifact:ecology.featureIntents.reefs`
+  - `plan-ice` (step/op) -> `artifact:ecology.featureIntents.ice`
+
+Rule posture (as per session guidance):
+- Use rules for codified decisions and scoring inputs (especially where “a scoring op runs many rules and returns layered results”).
+- If a component is likely to host many future algorithms/strategies, keep it as a standalone op rather than overloading rules.
+
+### Shape B: Keep one truth `ecology` stage but split `features-plan` into many steps
+
+Example: a single stage whose steps are grouped by feature family, and each family has an internal step trio:
+- `score-<family>` (possibly via rules)
+- `plan-<family>` (consumes score layers)
+- `apply-<family>` (plots to engine/projection)
+
+Pros:
+- Fewer stage compilation surfaces.
+- Still respects the “steps orchestrate; ops are atomic” rule.
+
+Cons:
+- Stage config surface may become too broad and encourage derived/overlapping knobs.
+- Harder to justify the stage boundary meaningfully (it becomes “everything in ecology gameplay” again).
+
+## 6) Minimal Experiment (optional)
+
+If we need a fast validation step before planning the full refactor:
+- Produce a trace/viz run that emits score-layer artifacts for one feature family (vegetation), then feed the aggregated layers to a planning op.
+- Validate that this breaks circular dependencies cleanly and keeps responsibilities legible.
+
+## 7) Risks and Open Questions
+
+- Stage split may ripple through recipe ordering and tag gating; we need to make sure tags remain the source of truth (no implicit coupling).
+- “Wet feature placement” may currently be modeled as an output-fudging or derived-config concept; if so, we need to rebuild it as a clean score/plan/apply pipeline with honest inputs.
+- Rules vs ops: if a future space likely needs many different strategy algorithms, it should be a standalone op rather than overloading rules.
+
+## 8) Next Steps (within this spike)
+
+- Enumerate the exact current ecology stage/step layout and contracts (breadcrumbs to code).
+- Do a hydrology comparison pass: “hydrology pattern” vs “ecology violation” vs “required change”.
+- Finalize the recommended stage split shape and produce the sliceable remediation plan.
+
+## Appendix: Hydrology Comparison (pattern vs violation vs required change)
+
+Hydrology is our “clean reference” pattern for stages/steps/ops/config boundaries.
+
+### Pattern: multiple small stages with crisp meaning + knobs
+
+Evidence:
+- `mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/index.ts`
+- `mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/index.ts`
+- `mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/index.ts`
+
+Hydrology stages:
+- are small and semantically scoped (baseline climate vs hydrography vs refinement),
+- put stage-meaning in `knobsSchema` documentation,
+- and avoid “public config multiplexors” that translate one key into many internal keys.
+
+### Pattern: step owns orchestration; ops stay atomic; normalize is step-local
+
+Evidence:
+- `mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/rivers.contract.ts`
+- `mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/rivers.ts`
+
+Hydrology `rivers` step:
+- binds multiple atomic ops via `contract.ops`,
+- uses `normalize(config, ctx)` for knob-based deterministic transforms,
+- publishes a single artifact (`hydrography`) and emits viz from that truth.
+
+### Ecology violation: overloaded truth stage + mega-step + compile-time multiplexing
+
+Evidence:
+- `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/index.ts`
+- `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/index.ts`
+
+Ecology today:
+- has one truth stage that includes multiple distinct subsystems,
+- uses a wide `featuresPlan` config surface compiled into many internal keys (including Studio sentinel forwarding),
+- and has a `features-plan` mega-step that mixes scoring, planning, and cross-feature merging.
+
+### Required change (to match Hydrology pattern)
+
+- Split truth `ecology` into multiple truth stages with crisp meaning (`ecology-pedology`, `ecology-biomes`, `ecology-features`).
+- Replace `features-plan` with per-family steps and (where needed) explicit “score layers” artifacts so planners can see other layers without creating circular dependencies.
+- Move shared masks into explicit compute substrate (use `ecology.ops.computeFeatureSubstrate`), rather than reimplementing substrate logic inside feature planners.

--- a/docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/_scratch/SCRATCH-ecology-stage-split-2026-02-09.md
+++ b/docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/_scratch/SCRATCH-ecology-stage-split-2026-02-09.md
@@ -1,0 +1,211 @@
+# Scratch: Ecology Stage Split + Drift (2026-02-09)
+
+Owner: `agent-codex` (spike worktree: `wt-agent-codex-spike-ecology-stage-split`)
+
+Purpose: ongoing scratchpad for maximal drift analysis + remediation planning, with a focus on splitting the current ecology gameplay stage into multiple sensible stages that align with MapGen target architecture (engine-refactor-v1 posture).
+
+## Working Agreements (from session)
+
+- Ops are atomic; steps orchestrate ops together. If we want “grouped sequences” (score -> plan -> plot/apply), steps are the right boundary for grouping.
+- “Wet feature placement” remains a real concept; the goal is to redesign it so it does not break target architecture.
+- Rules are underutilized. Rules fit well for codified decisions / score inputs, and can be proxied via a single scoring op as the front door.
+- Separation of scoring vs planning is justified when we want a planning op to see multiple score layers at once (to avoid circular dependencies and avoid baking cross-score heuristics into individual score computations).
+
+## Breadcrumbs (where we looked)
+
+### Repo state
+
+- Base branch (stack tip): `codex/ecology-wet-placement-standalone` @ `db0c7ae97`
+- Spike branch: `agent-codex-spike-ecology-stage-split`
+- Worktree root: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-spike-ecology-stage-split`
+
+### Canonical MapGen doc spine (target-architecture-first)
+
+- Gateway: `docs/system/libs/mapgen/MAPGEN.md`
+- LLM rules/index: `docs/system/libs/mapgen/llms/LLMS.md`
+- Architecture (explanation): `docs/system/libs/mapgen/explanation/ARCHITECTURE.md`
+- Stage/step authoring contracts (reference): `docs/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md`
+- Module shape policy: `docs/system/libs/mapgen/policies/MODULE-SHAPE.md`
+
+### Ecology alignment baseline (existing spike directory)
+
+- Entry: `docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/README.md`
+- Current state snapshot: `docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/CURRENT.md`
+- Drift inventory: `docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/DRIFT.md`
+- Refactor target shape: `docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/REFRACTOR-TARGET-SHAPE.md`
+
+### Current ecology stage (code reality)
+
+- Stage: `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/index.ts`
+  - Steps (current order): `pedology`, `resource-basins`, `biomes`, `biome-edge-refine`, `features-plan`
+- Stage: `mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/index.ts`
+  - Steps: `plot-biomes`, `features-apply`, `plot-effects`
+- Feature planning mega-step:
+  - Contract: `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/contract.ts`
+  - Implementation: `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/index.ts`
+- Shared compute substrate op we are not using today (but should):
+  - `mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/contract.ts`
+  - `mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/strategies/default.ts`
+
+## Target-Architecture Definitions (anchor quotes and paraphrases)
+
+These definitions are *target authority* for vocabulary and boundaries; code is current reality.
+
+### Stage
+
+- Author-facing grouping + config surface; compiles stage config into per-step configs via `toInternal(...)`.
+  - Anchor: `docs/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md`
+
+### Step
+
+- Orchestration unit: declares `requires/provides` tags + artifacts; binds op contracts; implements `run()` and optional shape-preserving `normalize()`.
+  - Anchor: `docs/system/libs/mapgen/reference/STAGE-AND-STEP-AUTHORING.md`
+
+### Domain + ops + rules
+
+- Domains own algorithmic ops and shared semantics; steps orchestrate, not algorithms.
+- Module shape policy explicitly calls out: “steps orchestrate; domain ops do computation; strategies encode variants; rules define contracts/shared types.”
+  - Anchors:
+    - `docs/system/libs/mapgen/explanation/ARCHITECTURE.md`
+    - `docs/system/libs/mapgen/policies/MODULE-SHAPE.md`
+
+## Drift Findings (to be expanded; grouped)
+
+### Stage boundary drift (truth ecology stage is overloaded)
+
+Evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/index.ts` compiles a single public `featuresPlan` object into a large internal config surface (vegetation substrate + multiple vegetation score ops + wetlands/reefs/ice + multiple wet placement ops).
+
+Symptoms:
+- Stage compile function is doing UI/typegen sentinel forwarding across many keys (smells like “stage as UI adapter” rather than “stage as config compilation boundary”).
+- The mega-step `features-plan` mixes scoring, planning, and cross-feature merging in one `run()` method.
+
+Why this is target-architecture drift:
+- A stage’s primary job is a coherent author surface + compilation boundary, not an internal multiplexor for unrelated subpipelines.
+- A single step can orchestrate multiple ops, but a mega-step becomes an architectural sink that prevents clean “compute substrate vs plan” seams and rule reuse.
+
+### Disabled strategy (anti-pattern) for wet placements
+
+Evidence:
+- Public stage config models `wetFeaturePlacements` as `strategy: "disabled" | "default"`: `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/index.ts`.
+- Step contract injects atomic wet placement ops with `defaultStrategy: "disabled"`: `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/contract.ts`.
+
+Why this is drift:
+- “Disabled strategy” is a legacy toggle/hack; recipe composition should express what runs, and honest algorithmic inputs should decide what places.
+- Also, it creates odd configuration coupling: one public key fans out to multiple per-feature planners.
+
+### Bug: wet placements variable typo (current code does not typecheck)
+
+Evidence:
+- `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/index.ts` defines `const wetPlacements = ...` but later spreads `...wetPlacements` into wetlands placements.
+
+Impact:
+- This will fail typecheck/build; regardless of the longer refactor, it’s a correctness issue that must be fixed in the eventual execution plan.
+
+### Op/step boundary drift (grouping ops inside ops)
+
+Hypothesis: any ops that call other ops (or behave like orchestrators) violate atomic-op posture and should be split into atomic ops with orchestration in steps.
+
+### Rule underuse
+
+Hypothesis: scoring logic scattered across steps/ops could become a scoring op that runs multiple rules to produce score layers, improving modularity and enabling “plan with global visibility” without circular dependencies.
+
+### Underused compute substrate op (duplicate logic in steps)
+
+Evidence:
+- `ecology.ops.computeFeatureSubstrate` exists and is explicitly shaped as reusable compute substrate masks (navigableRiverMask / nearRiverMask / isolatedRiverMask / coastalLandMask).
+  - `mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/contract.ts`
+- `features-plan` step reimplements navigable river masks and adjacency masks ad hoc.
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/index.ts`
+
+Why this matters:
+- Compute substrate is the endorsed pattern (see morphology), and it’s a clean way to avoid cross-feature circularities while keeping plan ops atomic.
+
+## Proposed Stage Split (recommended)
+
+Goal: replace the single truth stage `ecology` with multiple smaller truth stages, mirroring Hydrology/Morphology patterns (multiple domain stages with crisp config meaning), while keeping projection stage `map-ecology` intact.
+
+### Proposed truth stages (in recipe order)
+
+1. `ecology-pedology`
+- Steps: `pedology`, `resource-basins`
+- Outputs: `artifact:ecology.soils`, `artifact:ecology.resourceBasins`
+- Meaning: “soil + basin substrate” (ecology truth products that are upstream inputs to later ecology steps and placement).
+
+2. `ecology-biomes`
+- Steps: `biomes` (integrate edge refinement here; remove `biome-edge-refine` step/op)
+- Outputs: `artifact:ecology.biomeClassification` (refined)
+- Meaning: “biosphere classification truth surface” (the canonical ecology truth lookup used by all planners).
+
+3. `ecology-features`
+- Steps (target posture, not current):
+  - shared compute substrate step: `compute-feature-substrate` (calls `ecology.ops.computeFeatureSubstrate`)
+  - vegetation pipeline: `score-vegetation` -> `plan-vegetation`
+  - wetlands pipeline: `score-wetlands` (optional) -> `plan-wetlands` (includes atomic wet placement planners orchestrated here)
+  - marine/cryosphere: `plan-reefs`, `plan-ice`
+- Outputs: `artifact:ecology.featureIntents.*`
+- Meaning: “feature intent truth” (all discrete placement intents; no engine writes).
+
+### Why these boundaries are “sensible”
+
+- They match the meaning of “stage = config compilation boundary + mental grouping”, not “stage = grab bag of unrelated subpipelines.”
+- They align with existing recipe posture: Hydrology and Morphology already use multiple stages for the same domain.
+- They eliminate the current `featuresPlan` compile multiplexor (including Studio sentinel forwarding across many internal keys) by giving each stage/step a smaller, direct schema surface.
+
+### Alternative (if we want even crisper author surfaces)
+
+- Split `ecology-features` into separate feature-family stages (`ecology-vegetation`, `ecology-wetlands`, `ecology-reefs`, `ecology-ice`).
+- Tradeoff: more stages, but the per-stage config surfaces become very clean and may map better to presets.
+- Risk: cross-feature planning needs an explicit shared score-layers artifact if planners should see each other’s scores.
+
+## Remediation Slices (dev-loop-parallel inputs)
+
+Placeholder: we will enumerate one slice per “fixable unit” (stage split, op extraction, rule refactor, config compilation boundary, artifact boundaries, tag/id/registry alignment).
+
+Each slice will include:
+- Branch/worktree: `agent-?-...`
+- Scope: what changes
+- Acceptance criteria: observable, testable
+- Verification: build/typecheck/tests/viz trace expectations
+
+### Slice 1: Stage topology split (truth ecology -> multiple stages)
+
+- Scope:
+  - Replace `mods/mod-swooper-maps/src/recipes/standard/stages/ecology/index.ts` with multiple stage modules.
+  - Update `mods/mod-swooper-maps/src/recipes/standard/recipe.ts` stage list order.
+  - Keep step ids stable where possible (to preserve viz/test baselines).
+- Acceptance:
+  - Recipe compiles; stage config schemas remain strict and do not introduce derived-value knobs.
+  - No behavior changes intended; parity fixtures continue to pass after mechanical moves.
+- Verification:
+  - `bun --cwd packages/mapgen-core run build`
+  - `bun --cwd mods/mod-swooper-maps run typecheck`
+  - `bun run test:ci` (or package-local ecology tests)
+
+### Slice 2: De-mega-step `features-plan` (split into per-family steps; keep ops atomic)
+
+- Scope:
+  - Replace the single `features-plan` step with multiple steps (vegetation/wetlands/reefs/ice).
+  - Introduce an optional shared compute-substrate step using `ecology.ops.computeFeatureSubstrate`.
+- Acceptance:
+  - All intent artifacts are still published with identical semantics.
+  - No direct domain imports from steps to reach ops outside `contract.ops` injection.
+- Verification:
+  - Existing import guardrails tests (ecology) still pass.
+  - Viz keys remain stable (`ecology.featureIntents.featureType` etc).
+
+### Slice 3: Remove “disabled strategy” posture for wet placements (keep wet placement concept)
+
+- Scope:
+  - Delete `strategy: "disabled"` from wet placement planners and from stage public schema.
+  - Model wet placement planners as always-on with honest constraints, or move enable/disable to recipe composition (not config).
+- Acceptance:
+  - No “optional ops” concept; steps decide orchestration, ops remain atomic.
+  - Wet placement still works; it does not require a fan-out config key (`wetFeaturePlacements`) that controls multiple planners.
+
+### Slice 4: Integrate biome edge refinement into biome classification
+
+- Scope:
+  - Remove `biome-edge-refine` as a standalone step/op; integrate into `classifyBiomes` pipeline.
+- Acceptance:
+  - The refined `biomeIndex` is available immediately from biome classification.
+  - No output fudging or post-hoc projection tricks.

--- a/docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/_scratch/SCRATCH-ecology-stage-split-2026-02-09.md
+++ b/docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/_scratch/SCRATCH-ecology-stage-split-2026-02-09.md
@@ -2,7 +2,7 @@
 
 Owner: `agent-codex` (spike worktree: `wt-agent-codex-spike-ecology-stage-split`)
 
-Purpose: ongoing scratchpad for maximal drift analysis + remediation planning, with a focus on splitting the current ecology gameplay stage into multiple sensible stages that align with MapGen target architecture (engine-refactor-v1 posture).
+Purpose: ongoing scratchpad for maximal drift analysis + remediation planning, with a focus on splitting the current truth `ecology` stage into multiple sensible stages that align with MapGen target architecture (engine-refactor-v1 posture).
 
 ## Working Agreements (from session)
 

--- a/docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/_scratch/SCRATCH-ecology-stage-split-2026-02-09.md
+++ b/docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/_scratch/SCRATCH-ecology-stage-split-2026-02-09.md
@@ -272,6 +272,35 @@ Anchor: `packages/mapgen-core/src/authoring/stage.ts`
   - ice (`plan-ice`)
   - plot effects (`plan-plot-effects`) if it still relies on `coverageChance`
 
+## Arrangement Options (matrix)
+
+This is the quick decision table for “where do scores live, where does planning live, where does viz live”.
+Full prose version is in the spike doc (`5.2 Layout Matrix`).
+
+Option A: per-family `plan-<family>` step orchestrates score ops + plan op
+- Pros: minimal pipeline nodes; symmetric; easy to evolve
+- Cons: no explicit cross-family score seam unless we add one later
+
+Option B: `score-features` step publishes unified `artifact:ecology.scoreLayers`, then per-family plan steps consume
+- Pros: explicit seam; prevents circular dependencies; best for “global visibility” planning
+- Cons: adds an artifact and a step; must define scoreLayers schema
+
+Option C: per-family score steps + per-family plan steps
+- Pros: maximal modularity and observability
+- Cons: many nodes/artifacts
+
+Option D: plan ops compute scores internally via rules (no score ops/steps)
+- Pros: smallest op surface
+- Cons: weak observability of scores unless op outputs debug payloads
+
+Option E: split into separate truth stages `ecology-features-score` + `ecology-features-plan`
+- Pros: stage-level config boundaries become crisp for presets/knobs
+- Cons: more stage modules; artifact seams mandatory
+
+Option F: global multi-family plan op (single decision maker)
+- Pros: explicit cross-family conflict resolution in truth
+- Cons: challenges “atomic per-feature ops” unless resolver is treated as its own atomic concern
+
 ## Remediation Slices (dev-loop-parallel inputs)
 
 Placeholder: we will enumerate one slice per “fixable unit” (stage split, op extraction, rule refactor, config compilation boundary, artifact boundaries, tag/id/registry alignment).


### PR DESCRIPTION
docs(spike): ecology truth stage split

docs(spike): tighten ecology stage split spec

docs(spike): clarify ecology truth posture

docs(spike): make feature pipelines symmetric

docs(spike): enumerate stage/step/op arrangement options

docs(spike): tighten ecology boundaries