### PR TITLE
docs(pipeline-realism): start M3 ecology packet

### DIFF
--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-001-packet-harden-m3-ecology-physics-first-topology-contracts-gates.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-001-packet-harden-m3-ecology-physics-first-topology-contracts-gates.md
@@ -1,0 +1,68 @@
+id: LOCAL-TBD-PR-M3-001
+title: Packet hardening: M3 ecology physics-first topology + contracts + gates (decision-complete)
+state: planned
+priority: 1
+estimate: 8
+project: pipeline-realism
+milestone: M3-ecology-physics-first-feature-planning
+assignees: [codex]
+labels: [pipeline-realism]
+parent: null
+children: []
+blocked_by: []
+blocked: [LOCAL-TBD-PR-M3-002, LOCAL-TBD-PR-M3-003, LOCAL-TBD-PR-M3-004, LOCAL-TBD-PR-M3-005, LOCAL-TBD-PR-M3-006, LOCAL-TBD-PR-M3-007, LOCAL-TBD-PR-M3-008, LOCAL-TBD-PR-M3-009]
+related_to: [LOCAL-TBD-PR-M2-016]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+- Produce a decision-complete M3 packet (authority) that can be converted into a milestone and issue set with zero remaining "black ice".
+
+## Deliverables
+- Packet exists and is internally consistent:
+  - `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/README.md`
+  - `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/VISION.md`
+  - `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/ARCHITECTURE.md`
+  - `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/TOPOLOGY.md`
+  - `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/CONTRACTS.md`
+  - `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/EXECUTION-PLAN.md`
+  - `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/DECISIONS.md`
+  - `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/M2-REMEDIATION-MAP.md`
+- Milestone derived from packet:
+  - `docs/projects/pipeline-realism/milestones/M3-ecology-physics-first-feature-planning.md`
+- Local M3 issue docs exist and have no prework prompts:
+  - `docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-*.md`
+
+## Acceptance Criteria
+- [ ] Packet locks (no TBD):
+  - stage order + step topology
+  - `artifact:ecology.scoreLayers` schema + layer inventory
+  - occupancy/conflict model + ordering (ice -> reefs -> wetlands -> vegetation)
+  - explicit bans: chance/multipliers, disabled strategies, silent skips, ops-calling-ops
+- [ ] Packet explicitly addresses the "steps orchestrate; ops plan; steps may emit viz; no viz-only steps" posture.
+- [ ] Packet is consistent with MapGen contract vocabulary (stage/step/op/artifact/tags/config compilation vs plan compilation).
+
+## Testing / Verification
+- Docs sanity:
+  - `rg -n \"TBD\" docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first`
+  - `rg -n \"^## Prework Prompt \\(Agent Brief\\)$\" docs/projects/pipeline-realism/issues | rg \"PR-M3\" || true`
+
+## Dependencies / Notes
+- Blocks: all M3 implementation issues.
+- Related: M2 doc alignment pointers in `LOCAL-TBD-PR-M2-016`.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Quick Navigation
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)
+
+### Tooling posture (for later issues)
+- Prefer `$narsil-mcp` for semantic discovery when needed; do not use `hybrid_search`.
+- Keep the primary checkout (`/Users/mateicanavra/Documents/.nosync/DEV/civ7-modding-tools`) on the latest commit to keep the index fresh (detached HEAD is OK).

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-002-stage-split-ecology-into-earth-system-first-truth-stages-and-wire-recipe.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-002-stage-split-ecology-into-earth-system-first-truth-stages-and-wire-recipe.md
@@ -1,0 +1,83 @@
+id: LOCAL-TBD-PR-M3-002
+title: Stage split: earth-system-first truth stages for ecology + recipe wiring cutover (M3)
+state: planned
+priority: 1
+estimate: 16
+project: pipeline-realism
+milestone: M3-ecology-physics-first-feature-planning
+assignees: [codex]
+labels: [pipeline-realism]
+parent: null
+children: []
+blocked_by: [LOCAL-TBD-PR-M3-001]
+blocked: [LOCAL-TBD-PR-M3-003, LOCAL-TBD-PR-M3-004, LOCAL-TBD-PR-M3-005, LOCAL-TBD-PR-M3-006, LOCAL-TBD-PR-M3-007, LOCAL-TBD-PR-M3-008, LOCAL-TBD-PR-M3-009]
+related_to: [LOCAL-TBD-PR-M2-011]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+- Replace the single `ecology` truth stage with an ordered set of earth-system-first truth stages plus a dedicated score stage, preserving one projection stage (`map-ecology`).
+
+## Deliverables
+- New truth stage modules exist and are wired into the standard recipe in the order locked by the packet:
+  - `ecology-pedology`
+  - `ecology-biomes` (biome edge refinement integrated; no separate step)
+  - `ecology-features-score`
+  - `ecology-ice`
+  - `ecology-reefs`
+  - `ecology-wetlands`
+  - `ecology-vegetation`
+- Recipe wiring cutover:
+  - `mods/mod-swooper-maps/src/recipes/standard/recipe.ts` uses the explicit ordered list above before `mapEcology`.
+- Legacy topology removed:
+  - the old single truth `ecology` stage is deleted (no shims, no dual wiring).
+
+## Acceptance Criteria
+- [ ] `TOPOLOGY.md` stage list exactly matches code stage ids and recipe ordering.
+- [ ] Compile-time config boundaries remain correct:
+  - each new stage compiles to its own step configs
+  - no stage introduces runtime orchestration
+  - no stage re-exports authoring SDK extensions
+- [ ] Biomes step topology matches packet:
+  - no `biome-edge-refine` step exists
+  - refinement is integrated inside the single biomes op envelope
+- [ ] `map-ecology` remains the only projection stage.
+
+## Testing / Verification
+- Baseline build+tests:
+  - `bun run --cwd packages/civ7-adapter build`
+  - `bun run --cwd packages/mapgen-viz build`
+  - `bun run --cwd packages/mapgen-core build`
+  - `bun --cwd mods/mod-swooper-maps test test/ecology`
+- Determinism smoke (pre-M3 behavior change acceptance comes later; this just proves "it runs"):
+  - `bun --cwd mods/mod-swooper-maps run diag:dump -- 106 66 1337 --label m3-stage-split-smoke`
+
+## Dependencies / Notes
+- Blocked by: `LOCAL-TBD-PR-M3-001`
+- Blocks: `LOCAL-TBD-PR-M3-003` and all planner issues.
+- Related: M2 kept topology stable; M3 intentionally changes topology (do not preserve old ids).
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Quick Navigation
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)
+
+### Breadcrumbs (likely touch points)
+
+```yaml
+files:
+  - path: mods/mod-swooper-maps/src/recipes/standard/recipe.ts
+    notes: Replace single truth ecology stage with the ordered stage list from the packet.
+  - path: mods/mod-swooper-maps/src/recipes/standard/stages/ecology/index.ts
+    notes: Legacy multiplexer stage; must be deleted (no compatibility wrapper).
+  - path: mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/index.ts
+    notes: Projection stage remains; it should consume the new truth artifacts without probabilistic gating.
+```
+

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-003-scorelayers-artifact-schema-and-independent-per-feature-score-ops.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-003-scorelayers-artifact-schema-and-independent-per-feature-score-ops.md
@@ -1,0 +1,77 @@
+id: LOCAL-TBD-PR-M3-003
+title: ScoreLayers: artifact schema + independent per-feature score ops (all ecology features)
+state: planned
+priority: 1
+estimate: 16
+project: pipeline-realism
+milestone: M3-ecology-physics-first-feature-planning
+assignees: [codex]
+labels: [pipeline-realism]
+parent: null
+children: []
+blocked_by: [LOCAL-TBD-PR-M3-002]
+blocked: [LOCAL-TBD-PR-M3-004, LOCAL-TBD-PR-M3-005, LOCAL-TBD-PR-M3-006, LOCAL-TBD-PR-M3-007, LOCAL-TBD-PR-M3-008, LOCAL-TBD-PR-M3-009]
+related_to: [LOCAL-TBD-PR-M2-005, LOCAL-TBD-PR-M2-006]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+- Implement the dedicated truth score stage that publishes `artifact:ecology.scoreLayers` (all feature keys) and `artifact:ecology.occupancy.base`, with strict score-independence posture.
+
+## Deliverables
+- `ecology-features-score` stage exists with one step `score-layers` that publishes:
+  - `artifact:ecology.scoreLayers` (single shared score store)
+  - `artifact:ecology.occupancy.base` (reserved/available tile mask)
+- Score ops exist for every feature key in the packet inventory:
+  - vegetation: `FEATURE_FOREST`, `FEATURE_RAINFOREST`, `FEATURE_TAIGA`, `FEATURE_SAVANNA_WOODLAND`, `FEATURE_SAGEBRUSH_STEPPE`
+  - wet: `FEATURE_MARSH`, `FEATURE_TUNDRA_BOG`, `FEATURE_MANGROVE`, `FEATURE_OASIS`, `FEATURE_WATERING_HOLE`
+  - reef: `FEATURE_REEF`, `FEATURE_COLD_REEF`, `FEATURE_ATOLL`, `FEATURE_LOTUS`
+  - ice: `FEATURE_ICE`
+
+## Acceptance Criteria
+- [ ] `artifact:ecology.scoreLayers` schema-validated and contains *every* feature layer (typed arrays sized `width*height`).
+- [ ] Score independence enforced:
+  - no score op reads another feature's score layer
+  - cross-feature preferences are encoded in planners only
+- [ ] Scores are normalized suitability 0..1 (no chance knobs, no multipliers that gate existence).
+- [ ] `artifact:ecology.occupancy.base` correctly marks permanently reserved tiles deterministically (ocean/deep water/cliff/etc as defined by the packet).
+
+## Testing / Verification
+- Build+tests:
+  - `bun run --cwd packages/mapgen-core build`
+  - `bun --cwd mods/mod-swooper-maps test test/ecology`
+- Determinism:
+  - `bun --cwd mods/mod-swooper-maps run diag:dump -- 106 66 1337 --label m3-scores`
+  - rerun same command and `diag:diff` shows identical score layers
+- Static rails (exact patterns may evolve, but posture is required):
+  - `rg -n \"rollPercent|coverageChance|chance\\b|multiplier\\b\" mods/mod-swooper-maps/src/domain/ecology/ops | cat`
+
+## Dependencies / Notes
+- Blocked by: `LOCAL-TBD-PR-M3-002`
+- Blocks: all planner issues.
+- Related: M2 compute substrate provides shared fields; reuse where possible, but do not reintroduce mega-ops.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Quick Navigation
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)
+
+### Breadcrumbs (likely touch points)
+
+```yaml
+files:
+  - path: mods/mod-swooper-maps/src/domain/ecology/types.ts
+    notes: FeatureKey inventory (must match scoreLayers keys).
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops
+    notes: Add/replace score ops per feature.
+  - path: packages/mapgen-core/src
+    notes: Artifact schema plumbing / TypeBox helpers / validation surfaces.
+```
+

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-003-scorelayers-artifact-schema-and-independent-per-feature-score-ops.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-003-scorelayers-artifact-schema-and-independent-per-feature-score-ops.md
@@ -71,7 +71,8 @@ files:
     notes: FeatureKey inventory (must match scoreLayers keys).
   - path: mods/mod-swooper-maps/src/domain/ecology/ops
     notes: Add/replace score ops per feature.
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-*
+    notes: Existing vegetation scoring ops already match the "independent score layer" posture; reuse them as the canonical vegetation layers in `artifact:ecology.scoreLayers`.
   - path: packages/mapgen-core/src
     notes: Artifact schema plumbing / TypeBox helpers / validation surfaces.
 ```
-

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-004-deterministic-planning-ice-consume-scorelayers-and-occupancy.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-004-deterministic-planning-ice-consume-scorelayers-and-occupancy.md
@@ -63,9 +63,10 @@ related_to: []
 
 ```yaml
 files:
-  - path: mods/mod-swooper-maps/src/domain/ecology/ops/plan-ice/**
-    notes: Existing chance-based logic must be deleted and replaced with deterministic planning.
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/**
+    notes: Current ice planning op (chance/RNG posture) to delete and replace with deterministic planning.
+  - path: mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/index.ts
+    notes: Current monolithic orchestration site that will be replaced by the dedicated planner stages.
   - path: docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/CONTRACTS.md
     notes: Ice planner contract is locked here.
 ```
-

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-004-deterministic-planning-ice-consume-scorelayers-and-occupancy.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-004-deterministic-planning-ice-consume-scorelayers-and-occupancy.md
@@ -1,0 +1,71 @@
+id: LOCAL-TBD-PR-M3-004
+title: Deterministic planning: ice (consume scoreLayers + occupancy; publish intents + snapshot)
+state: planned
+priority: 2
+estimate: 16
+project: pipeline-realism
+milestone: M3-ecology-physics-first-feature-planning
+assignees: [codex]
+labels: [pipeline-realism]
+parent: null
+children: []
+blocked_by: [LOCAL-TBD-PR-M3-003]
+blocked: [LOCAL-TBD-PR-M3-008, LOCAL-TBD-PR-M3-009]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+- Replace ice planning with a deterministic planner op that consumes `artifact:ecology.scoreLayers` and the occupancy snapshot chain, then publishes `featureIntents.ice` and `occupancy.ice`.
+
+## Deliverables
+- `ecology-ice` stage:
+  - step `plan-ice`
+  - op `ops.planIce`
+  - publishes:
+    - `artifact:ecology.featureIntents.ice`
+    - `artifact:ecology.occupancy.ice`
+
+## Acceptance Criteria
+- [ ] No chance knobs or probabilistic gating remain in ice planning.
+- [ ] Planner only uses seeded randomness as a *tie-breaker* (equal-score tiles), never as a gate.
+- [ ] Planner respects occupancy:
+  - never claims reserved tiles
+  - never claims already-occupied tiles
+- [ ] Placements are sorted deterministically before publishing (stable viz/diag).
+
+## Testing / Verification
+- Build+tests:
+  - `bun --cwd mods/mod-swooper-maps test test/ecology`
+- Determinism:
+  - `bun --cwd mods/mod-swooper-maps run diag:dump -- 106 66 1337 --label m3-ice`
+  - rerun and `diag:diff` is empty
+- Static scan:
+  - `rg -n \"rollPercent|chance\\b|jitter|multiplier\\b\" mods/mod-swooper-maps/src/domain/ecology/ops | cat`
+
+## Dependencies / Notes
+- Blocked by: `LOCAL-TBD-PR-M3-003`
+- Blocks: integration and deletion issues.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Quick Navigation
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)
+
+### Breadcrumbs
+
+```yaml
+files:
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/plan-ice/**
+    notes: Existing chance-based logic must be deleted and replaced with deterministic planning.
+  - path: docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/CONTRACTS.md
+    notes: Ice planner contract is locked here.
+```
+

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-005-deterministic-planning-reefs-add-missing-reef-family-features.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-005-deterministic-planning-reefs-add-missing-reef-family-features.md
@@ -63,9 +63,10 @@ related_to: []
 
 ```yaml
 files:
-  - path: mods/mod-swooper-maps/src/domain/ecology/ops/plan-reef-feature-placements/**
-    notes: Current reef planning surfaces to replace; ensure cold reefs/atolls/lotus are actually produced.
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/**
+    notes: Current reef planning op surface to replace; ensure cold reefs/atolls/lotus are actually produced.
+  - path: mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/index.ts
+    notes: Current monolithic orchestration site that will be replaced by the dedicated planner stages.
   - path: mods/mod-swooper-maps/src/domain/ecology/types.ts
     notes: Reef feature keys inventory (must match scoreLayers).
 ```
-

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-005-deterministic-planning-reefs-add-missing-reef-family-features.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-005-deterministic-planning-reefs-add-missing-reef-family-features.md
@@ -1,0 +1,71 @@
+id: LOCAL-TBD-PR-M3-005
+title: Deterministic planning: reefs (consume scoreLayers + occupancy; add missing reef-family features)
+state: planned
+priority: 2
+estimate: 16
+project: pipeline-realism
+milestone: M3-ecology-physics-first-feature-planning
+assignees: [codex]
+labels: [pipeline-realism]
+parent: null
+children: []
+blocked_by: [LOCAL-TBD-PR-M3-003]
+blocked: [LOCAL-TBD-PR-M3-008, LOCAL-TBD-PR-M3-009]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+- Implement a deterministic reef-family planner that consumes the shared score store and occupancy and emits reef-family intents without chance-based gating.
+
+## Deliverables
+- `ecology-reefs` stage:
+  - step `plan-reefs`
+  - op `ops.planReefs`
+  - publishes:
+    - `artifact:ecology.featureIntents.reefs`
+    - `artifact:ecology.occupancy.reefs`
+- Reef-family features are all first-class in M3:
+  - `FEATURE_REEF`, `FEATURE_COLD_REEF`, `FEATURE_ATOLL`, `FEATURE_LOTUS`
+
+## Acceptance Criteria
+- [ ] No chance knobs/probabilistic gating remain in reef planning.
+- [ ] Planner respects occupancy chain and only claims allowed tiles.
+- [ ] Feature availability is determined by deterministic constraints (shoreline, temperature, depth masks), not randomness.
+- [ ] Placement ordering and tie-breaking are deterministic (seeded tie-breaks only for exact ties).
+
+## Testing / Verification
+- Build+tests:
+  - `bun --cwd mods/mod-swooper-maps test test/ecology`
+- Determinism:
+  - `bun --cwd mods/mod-swooper-maps run diag:dump -- 106 66 1337 --label m3-reefs`
+  - rerun and `diag:diff` is empty
+- Static scan:
+  - `rg -n \"rollPercent|chance\\b|multiplier\\b\" mods/mod-swooper-maps/src/domain/ecology/ops | cat`
+
+## Dependencies / Notes
+- Blocked by: `LOCAL-TBD-PR-M3-003`
+- Blocks: integration and deletion issues.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Quick Navigation
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)
+
+### Breadcrumbs
+
+```yaml
+files:
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/plan-reef-feature-placements/**
+    notes: Current reef planning surfaces to replace; ensure cold reefs/atolls/lotus are actually produced.
+  - path: mods/mod-swooper-maps/src/domain/ecology/types.ts
+    notes: Reef feature keys inventory (must match scoreLayers).
+```
+

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-006-deterministic-planning-wetlands-and-wet-features-no-disabled-strategies.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-006-deterministic-planning-wetlands-and-wet-features-no-disabled-strategies.md
@@ -64,9 +64,10 @@ related_to: []
 
 ```yaml
 files:
-  - path: mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-feature-placements/**
-    notes: Current chance/multiplier-based wet placement logic must be deleted and replaced.
-  - path: mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-feature-placements/strategies/default.ts
-    notes: Evidence of current "chances/multipliers" posture that is forbidden in M3.
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-wetlands/**
+    notes: Current wetlands-family planning op surface to replace.
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-placement-*
+    notes: Per-feature wet placement ops with `disabled` strategies and chance/multiplier gating; these must be deleted/replaced by deterministic wetlands planning.
+  - path: mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/index.ts
+    notes: Current monolithic orchestration site that will be replaced by the dedicated planner stages.
 ```
-

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-006-deterministic-planning-wetlands-and-wet-features-no-disabled-strategies.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-006-deterministic-planning-wetlands-and-wet-features-no-disabled-strategies.md
@@ -1,0 +1,72 @@
+id: LOCAL-TBD-PR-M3-006
+title: Deterministic planning: wetlands + wet features (joint resolver; no disabled strategies)
+state: planned
+priority: 2
+estimate: 16
+project: pipeline-realism
+milestone: M3-ecology-physics-first-feature-planning
+assignees: [codex]
+labels: [pipeline-realism]
+parent: null
+children: []
+blocked_by: [LOCAL-TBD-PR-M3-003]
+blocked: [LOCAL-TBD-PR-M3-008, LOCAL-TBD-PR-M3-009]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+- Implement a deterministic wetlands-family planner op that consumes wet-feature score layers, resolves intra-family conflicts explicitly, and publishes wetlands intents without probability gates or "disabled" toggles.
+
+## Deliverables
+- `ecology-wetlands` stage:
+  - step `plan-wetlands`
+  - op `ops.planWetlands`
+  - publishes:
+    - `artifact:ecology.featureIntents.wetlands`
+    - `artifact:ecology.occupancy.wetlands`
+- Wet-family features are first-class:
+  - `FEATURE_MARSH`, `FEATURE_TUNDRA_BOG`, `FEATURE_MANGROVE`, `FEATURE_OASIS`, `FEATURE_WATERING_HOLE`
+
+## Acceptance Criteria
+- [ ] No chance knobs/probabilistic gating remain in wet planning.
+- [ ] No multipliers/bonuses used to gate existence.
+- [ ] No "disabled strategy" or silent skip remains in the runtime path.
+- [ ] Planner respects occupancy chain and only claims allowed tiles.
+- [ ] Selection among wet-feature candidates is codified inside the planner op (joint resolver), not in the step.
+
+## Testing / Verification
+- Build+tests:
+  - `bun --cwd mods/mod-swooper-maps test test/ecology`
+- Determinism:
+  - `bun --cwd mods/mod-swooper-maps run diag:dump -- 106 66 1337 --label m3-wetlands`
+  - rerun and `diag:diff` is empty
+- Static scan:
+  - `rg -n \"rollPercent|chance\\b|multiplier\\b\" mods/mod-swooper-maps/src/domain/ecology/ops | cat`
+
+## Dependencies / Notes
+- Blocked by: `LOCAL-TBD-PR-M3-003`
+- Blocks: integration and deletion issues.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Quick Navigation
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)
+
+### Breadcrumbs
+
+```yaml
+files:
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-feature-placements/**
+    notes: Current chance/multiplier-based wet placement logic must be deleted and replaced.
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-feature-placements/strategies/default.ts
+    notes: Evidence of current "chances/multipliers" posture that is forbidden in M3.
+```
+

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-007-deterministic-planning-vegetation-joint-resolver-over-score-layers.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-007-deterministic-planning-vegetation-joint-resolver-over-score-layers.md
@@ -63,8 +63,7 @@ related_to: []
 ```yaml
 files:
   - path: mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/index.ts
-    notes: Legacy step planning entrypoint; in M3 it is replaced by dedicated planner stages.
-  - path: mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/**
-    notes: Legacy multi-feature planning logic (M2 split); M3 replaces with score->plan joint resolver.
+    notes: Current vegetation selection logic lives here today (step-level planning). M3 replaces it with a dedicated truth planner stage/op.
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-*
+    notes: Existing independent vegetation score ops to reuse as scoreLayers inputs.
 ```
-

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-007-deterministic-planning-vegetation-joint-resolver-over-score-layers.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-007-deterministic-planning-vegetation-joint-resolver-over-score-layers.md
@@ -1,0 +1,70 @@
+id: LOCAL-TBD-PR-M3-007
+title: Deterministic planning: vegetation (joint resolver over vegetation score layers)
+state: planned
+priority: 2
+estimate: 16
+project: pipeline-realism
+milestone: M3-ecology-physics-first-feature-planning
+assignees: [codex]
+labels: [pipeline-realism]
+parent: null
+children: []
+blocked_by: [LOCAL-TBD-PR-M3-003]
+blocked: [LOCAL-TBD-PR-M3-008, LOCAL-TBD-PR-M3-009]
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+- Replace vegetation feature planning with a deterministic joint-resolver planner op that consumes vegetation score layers and occupancy and emits vegetation intents without random gating.
+
+## Deliverables
+- `ecology-vegetation` stage:
+  - step `plan-vegetation`
+  - op `ops.planVegetation`
+  - publishes:
+    - `artifact:ecology.featureIntents.vegetation`
+    - `artifact:ecology.occupancy.vegetation`
+
+## Acceptance Criteria
+- [ ] No chance knobs/probabilistic gating remain in vegetation planning.
+- [ ] Planner consumes the shared score store (no recomputing "scores" inside planning).
+- [ ] Selection across vegetation features is codified in the planner op (joint resolver), not in the step.
+- [ ] Seeded randomness allowed only as a tie-breaker (equal scores).
+- [ ] Placements are deterministically ordered before publishing.
+
+## Testing / Verification
+- Build+tests:
+  - `bun --cwd mods/mod-swooper-maps test test/ecology`
+- Determinism:
+  - `bun --cwd mods/mod-swooper-maps run diag:dump -- 106 66 1337 --label m3-vegetation`
+  - rerun and `diag:diff` is empty
+- Static scan:
+  - `rg -n \"rollPercent|chance\\b|multiplier\\b\" mods/mod-swooper-maps/src/domain/ecology/ops | cat`
+
+## Dependencies / Notes
+- Blocked by: `LOCAL-TBD-PR-M3-003`
+- Blocks: integration and deletion issues.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Quick Navigation
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)
+
+### Breadcrumbs
+
+```yaml
+files:
+  - path: mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/features-plan/index.ts
+    notes: Legacy step planning entrypoint; in M3 it is replaced by dedicated planner stages.
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/**
+    notes: Legacy multi-feature planning logic (M2 split); M3 replaces with score->plan joint resolver.
+```
+

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-008-projection-stamping-strictness-features-apply-must-not-drop-or-randomly-gate.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-008-projection-stamping-strictness-features-apply-must-not-drop-or-randomly-gate.md
@@ -1,0 +1,69 @@
+id: LOCAL-TBD-PR-M3-008
+title: Projection strictness: features-apply stamping must not drop placements or randomly gate (add gates)
+state: planned
+priority: 2
+estimate: 8
+project: pipeline-realism
+milestone: M3-ecology-physics-first-feature-planning
+assignees: [codex]
+labels: [pipeline-realism]
+parent: null
+children: []
+blocked_by: [LOCAL-TBD-PR-M3-004, LOCAL-TBD-PR-M3-005, LOCAL-TBD-PR-M3-006, LOCAL-TBD-PR-M3-007]
+blocked: [LOCAL-TBD-PR-M3-009]
+related_to: [LOCAL-TBD-PR-M2-015]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+- Make projection stamping (`map-ecology/features-apply`) a strict deterministic materialization layer: it must not probabilistically gate or silently drop truth placements, and it must be guarded by explicit gates.
+
+## Deliverables
+- `map-ecology/features-apply`:
+  - no RNG usage
+  - deterministic application order
+  - explicit accounting of any rejected placements (fail gates)
+- Gates exist to prevent projection from masking planner bugs:
+  - if stamping rejects placements, the run fails in tests/diagnostics
+
+## Acceptance Criteria
+- [ ] `features-apply` does not contain chance/multiplier gating.
+- [ ] Projection stamping either:
+  - succeeds exactly, or
+  - fails loudly (test/diag), with actionable rejection report.
+- [ ] The gate is enforced in CI-style checks for the mod test suite.
+
+## Testing / Verification
+- `bun --cwd mods/mod-swooper-maps test test/ecology`
+- Determinism probe:
+  - `bun --cwd mods/mod-swooper-maps run diag:dump -- 106 66 1337 --label m3-stamp`
+  - rerun and `diag:diff` is empty
+- Static scan:
+  - `rg -n \"rollPercent|chance\\b|createLabelRng\\(\" mods/mod-swooper-maps/src/domain/ecology/ops/features-apply | cat`
+
+## Dependencies / Notes
+- Blocked by: all four family planners (needs truth plan artifacts).
+- Blocks: final deletion and cleanup issue.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Quick Navigation
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)
+
+### Breadcrumbs
+
+```yaml
+files:
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/features-apply/**
+    notes: Current application strategies may be RNG/weight based; M3 makes this pure stamping.
+  - path: docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/TOPOLOGY.md
+    notes: Projection semantics are locked here.
+```
+

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-009-delete-legacy-chance-and-multiplier-paths-update-tests-and-viz-inventories.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-009-delete-legacy-chance-and-multiplier-paths-update-tests-and-viz-inventories.md
@@ -1,0 +1,74 @@
+id: LOCAL-TBD-PR-M3-009
+title: Cleanup: delete legacy chance/multiplier paths; update tests + viz inventories (M3 no-fudging)
+state: planned
+priority: 2
+estimate: 16
+project: pipeline-realism
+milestone: M3-ecology-physics-first-feature-planning
+assignees: [codex]
+labels: [pipeline-realism]
+parent: null
+children: []
+blocked_by: [LOCAL-TBD-PR-M3-008]
+blocked: []
+related_to: [LOCAL-TBD-PR-M2-015]
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+- Delete all remaining chance/multiplier based ecology logic and harden the test/viz inventory so the no-fudging posture cannot regress.
+
+## Deliverables
+- Legacy chance/multiplier paths deleted (not wrapped, not shimmed).
+- `plot-effects` is deterministic (no `rollPercent`, no `coverageChance`), or its chance-based implementation is fully removed and replaced.
+- Static scan gates and runtime invariants are updated to enforce:
+  - no probabilistic gating
+  - seeded randomness only for tie-breaking
+- Viz inventories updated for the topology cutover and new truth artifacts.
+
+## Acceptance Criteria
+- [ ] `rg` scans for forbidden constructs in ecology truth planning are clean (allowlist only for tie-break helpers):
+  - `rollPercent`, `coverageChance`, `chance`, `multiplier`
+- [ ] Determinism suite: repeat run for fixed seeds is identical via `diag:diff`.
+- [ ] Viz key inventory is explicitly documented/updated for M3 (no silent drift).
+
+## Testing / Verification
+- Build+tests:
+  - `bun run --cwd packages/civ7-adapter build`
+  - `bun run --cwd packages/mapgen-viz build`
+  - `bun run --cwd packages/mapgen-core build`
+  - `bun --cwd mods/mod-swooper-maps test test/ecology`
+- Determinism:
+  - `bun --cwd mods/mod-swooper-maps run diag:dump -- 106 66 1337 --label m3-final`
+  - rerun and `diag:diff` is empty
+- Static scan (tighten patterns/allowlist during implementation):
+  - `rg -n \"rollPercent|coverageChance|chance\\b|multiplier\\b\" mods/mod-swooper-maps/src | cat`
+
+## Dependencies / Notes
+- Blocked by: `LOCAL-TBD-PR-M3-008`
+- This is where we enforce "no legacy left": deletion is a feature.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Quick Navigation
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)
+
+### Breadcrumbs (known violations to delete)
+
+```yaml
+known_violations:
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/features-apply/strategies/default.ts
+    notes: contains RNG-driven weight gating (`createLabelRng`, weights); forbidden in M3 stamping.
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/**
+    notes: contains chance-based effect placement (`coverageChance`, `rollPercent`); must be replaced with deterministic planning.
+  - path: mods/mod-swooper-maps/src/domain/ecology/ops/plan-wet-feature-placements/**
+    notes: contains multipliers/chances; replaced by deterministic wetlands planning.
+```
+

--- a/docs/projects/pipeline-realism/milestones/M3-ecology-physics-first-feature-planning.md
+++ b/docs/projects/pipeline-realism/milestones/M3-ecology-physics-first-feature-planning.md
@@ -1,0 +1,89 @@
+# M3-ecology-physics-first-feature-planning: Score Layers + Deterministic Planning (Remediates M2)
+
+**Goal:** Cut Ecology over to a physics-first, no-fudging, score-then-plan model with earth-system-first stage boundaries. This is explicitly **M3 that remediates M2**.
+**Status:** Planned
+**Owner:** pipeline-realism
+
+<!-- Path roots -->
+$MOD = mods/mod-swooper-maps
+$CORE = packages/mapgen-core
+$PACKET = docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first
+
+## Summary
+
+- **M2** (behavior-preserving) aligns architecture: atomic ops + compute substrate + compiler-owned binding.
+- **M3** (behavior-changing) upgrades realism:
+  - score every feature independently first (per-tile score layers)
+  - plan afterwards (deterministic; ordered; conflict-aware)
+  - stamp in projection as minimal deterministic materialization
+
+Canonical spec spine: `$PACKET/README.md` (this milestone is derived from the packet; the packet is the authority).
+
+## Locked Directives (Non-Negotiable)
+
+- No output fudging:
+  - no chance percentages
+  - no multipliers/bonuses used to gate output
+  - no probabilistic gating in merge/stamp
+  - seeded tie-breakers only
+- No legacy shims / dual paths.
+- Ops atomic; steps orchestrate; ops do not call ops.
+- Rules are op-local policy units; steps never import rules.
+- Ordering is recipe-only.
+
+## Scope
+
+### In Scope
+
+- Stage topology change: split truth ecology into earth-system-first stages.
+- Introduce `artifact:ecology.scoreLayers` as a first-class truth product.
+- Redesign feature planning to be deterministic and conflict-aware.
+- Redesign projection stamping to be minimal and deterministic; stamping drops are planner bugs.
+- Replace chance/multiplier gating in ecology planners and plot effects.
+
+### Out of Scope
+
+- Gameplay "modding layer" adjustments beyond minimal deterministic stamping.
+- Performance optimization beyond keeping runs reasonable.
+
+## Acceptance Criteria
+
+### Tier 1 (Must Pass)
+
+- [ ] Build + tests green:
+  - `bun run --cwd packages/civ7-adapter build`
+  - `bun run --cwd packages/mapgen-viz build`
+  - `bun run --cwd packages/mapgen-core build`
+  - `bun --cwd mods/mod-swooper-maps test test/ecology`
+- [ ] Deterministic run equivalence for fixed seed (M3 baseline vs rerun):
+  - `bun --cwd $MOD run diag:dump -- 106 66 1337 --label m3-probe`
+  - rerun with same args yields identical outputs per `diag:diff`.
+- [ ] No-fudging gates pass:
+  - static scan gates show no chance/multiplier gating in truth planning.
+- [ ] `artifact:ecology.scoreLayers` exists, is schema-validated, and contains all per-feature score layers.
+- [ ] Truth planning is ordered and conflict-aware; projection stamping does not probabilistically gate.
+
+## Issues / Deliverables
+
+This milestone is an index. Full detail lives in `$PACKET/EXECUTION-PLAN.md` and the local issue docs generated from it.
+
+- [ ] `LOCAL-TBD-PR-M3-001`: Packet hardening: finalize topology + contracts + decision log
+- [ ] `LOCAL-TBD-PR-M3-002`: Stage split: add truth ecology stages (earth-system-first) + recipe wiring
+- [ ] `LOCAL-TBD-PR-M3-003`: ScoreLayers: schema + compute ops + viz
+- [ ] `LOCAL-TBD-PR-M3-004`: Deterministic planning: ice
+- [ ] `LOCAL-TBD-PR-M3-005`: Deterministic planning: reefs
+- [ ] `LOCAL-TBD-PR-M3-006`: Deterministic planning: wetlands + wet features
+- [ ] `LOCAL-TBD-PR-M3-007`: Deterministic planning: vegetation
+- [ ] `LOCAL-TBD-PR-M3-008`: Projection stamping strictness + gates
+- [ ] `LOCAL-TBD-PR-M3-009`: Delete legacy chance/multiplier paths + update tests/viz inventories
+
+## Sequencing & Parallelization Plan
+
+**Stacks Overview**
+- Stack A (sequential unblockers): `M3-001` -> `M3-002` -> `M3-003`
+- Stack B (parallel planners after substrate+scoreLayers): `M3-004..007`
+- Stack C (sequential integration): `M3-008` -> `M3-009`
+
+## Notes
+
+- M2 must land first; M3 assumes atomic ops + compute substrate surfaces exist.

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/ARCHITECTURE.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/ARCHITECTURE.md
@@ -1,0 +1,72 @@
+# Architecture: How M3 Uses Stage/Step/Op/Strategy/Rule Semantics
+
+This document applies the MapGen architecture semantics to the Ecology M3 cutover.
+
+Read first: `VISION.md`.
+
+## Canonical Semantics (applied)
+
+- **Stage**: config compilation boundary; produces per-step raw configs. Stages do not run; steps run.
+- **Step**: orchestration node; reads artifacts/buffers; calls ops; publishes artifacts; emits viz.
+- **Op**: atomic algorithmic unit (compute/score/plan); explicit strategy envelope `{ strategy, config }`.
+- **Strategy**: variability within an op; selected by config; schema-valid.
+- **Rule**: op-local policy unit; used heavily for scoring; not imported by steps.
+
+## Truth vs Projection
+
+M3 preserves a one-way dependency:
+- Truth stages produce canonical physics products (artifacts).
+- Projection stages deterministically map truth into engine-facing fields/effects.
+
+In M3:
+- Truth ecology includes: pedology, biomes, score layers, and deterministic planning.
+- Projection `map-ecology` stamps/materializes the finalized plan (minimal, deterministic).
+
+## Score -> Plan -> Stamp (the causal spine)
+
+### Score
+
+- A dedicated truth stage produces `artifact:ecology.scoreLayers`.
+- Every feature has an independent per-tile score layer.
+- Score layers must not bake cross-feature heuristics.
+
+### Plan
+
+- Planning is codified inside planning ops (strategies + rules), not in steps.
+- Steps orchestrate:
+  1. read scoreLayers + any required truth artifacts
+  2. pass relevant layers into plan ops
+  3. publish deterministic feature intent artifacts
+
+### Stamp (projection)
+
+- `map-ecology/features-apply` stamps the plan into the engine.
+- Engine constraint failures (cannot stamp) are treated as planner bugs (gated).
+
+## Determinism + No-Fudging Contract
+
+Allowed:
+- deterministic ranking and selection
+- seeded tie-breaks (only for ties / stable sorting)
+
+Disallowed:
+- chance percentages
+- output multipliers/bonuses used to gate existence
+- probabilistic edges/jitter that changes outcomes
+- random gating in merge/stamp
+
+## Mutation Posture
+
+- Artifacts are treated as immutable snapshots.
+- If large mutable numeric state is required across steps, we explicitly model it as:
+  - either a published-once handle with codified mutation posture, or
+  - a recomputed derived snapshot per step.
+
+M3 will choose one posture for occupancy/conflict state and lock it in `CONTRACTS.md`.
+
+## Enforcement Rails (what we will gate)
+
+- Ordering source of truth is recipe-only.
+- No silent skips / no shouldRun.
+- Steps must not import op implementations or rules.
+- Strategy envelopes are explicit and compile-resolved.

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/CONTRACTS.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/CONTRACTS.md
@@ -1,129 +1,147 @@
-# Contracts: Artifacts, Schemas, Score Layers, and Planning IO
+# CONTRACTS: Score Layers, Planning, and Occupancy (M3 Ecology)
 
-Read first: `VISION.md`.
+This is the decision-complete source of truth for the M3 cut-over: it defines
+1. how *scoreLayers* are produced and shaped,
+2. how we track cross-family conflicts through explicit occupancy snapshots, and
+3. the per-stage/per-family planner contracts that consume those artifacts.
 
-This document is where M3 becomes **decision complete**.
+It also locks the must-have / must-not-have invariants that enforce the "no
+chance / no multipliers / deterministic" posture described in `VISION.md`.
 
-## Artifact Inventory (M3)
+## Score artifact: `artifact:ecology.scoreLayers`
+- **Purpose**: every planner consumes a single, shared score store so we never
+  bake another feature's heuristic into a scoring op and so conflict resolution
+  stays in the planning ops, not the score ops.
+- **Schema** (shape, refer to TypeBox in implementation):
+  ```ts
+  {
+    width: number,
+    height: number,
+    layers: {
+      "FEATURE_FOREST": Float32Array,
+      "FEATURE_RAINFOREST": Float32Array,
+      "FEATURE_TAIGA": Float32Array,
+      "FEATURE_SAVANNA_WOODLAND": Float32Array,
+      "FEATURE_SAGEBRUSH_STEPPE": Float32Array,
+      "FEATURE_MARSH": Float32Array,
+      "FEATURE_TUNDRA_BOG": Float32Array,
+      "FEATURE_MANGROVE": Float32Array,
+      "FEATURE_OASIS": Float32Array,
+      "FEATURE_WATERING_HOLE": Float32Array,
+      "FEATURE_REEF": Float32Array,
+      "FEATURE_COLD_REEF": Float32Array,
+      "FEATURE_ATOLL": Float32Array,
+      "FEATURE_LOTUS": Float32Array,
+      "FEATURE_ICE": Float32Array,
+    },
+  }
+  ```
+  Each typed array is `width * height` long and encodes a 0..1 suitability score
+  for that feature on every tile.
+- **Computation posture**:
+  - Score ops run independently and return typed arrays (see existing
+    `scoreVegetation*` ops for reference) so there is no cross-feature polling
+    inside a scoring op.
+  - Each layer is normalized per the op's rules (no probability knobs). Every
+    planner consumes these raw layers and makes deterministic decisions.
+  - The score stage is responsible for publishing `artifact:ecology.scoreLayers`
+    once per map, plus a base occupancy snapshot (see below).
 
-Existing ecology truth artifacts (must remain stable):
-- `artifact:ecology.soils`
-- `artifact:ecology.resourceBasins`
-- `artifact:ecology.biomeClassification`
-- `artifact:ecology.featureIntents.vegetation`
-- `artifact:ecology.featureIntents.wetlands`
-- `artifact:ecology.featureIntents.reefs`
-- `artifact:ecology.featureIntents.ice`
+## Occupancy / conflict artifact chain (Option A: immutable snapshots)
+- **Rationale**: staying immutably snapshot-based honors the pipeline's artifact
+  semantics and keeps per-stage gating explicit. Mutable handles would leak
+  ownership and make compile-time verification harder.
+- **Artifacts** (one new artifact per stage):
+  | artifact id | produced by | describes |
+  |-------------|-------------|-----------|
+  | `artifact:ecology.occupancy.base` | `ecology-features-score` | tile availability derived from topography + hydrology (initially 0 for free land tiles, special sentinel for water/reserved tiles) |
+  | `artifact:ecology.occupancy.ice` | `ecology-ice` | base mask + `FEATURE_ICE` assignments |
+  | `artifact:ecology.occupancy.reefs` | `ecology-reefs` | previous occupancy plus reef assignments |
+  | `artifact:ecology.occupancy.wetlands` | `ecology-wetlands` | previous occupancy plus wetland assignments |
+  | `artifact:ecology.occupancy.vegetation` | `ecology-vegetation` | final occupancy after all families |
+- **Schema (shared)**:
+  ```ts
+  {
+    width: number,
+    height: number,
+    featureIndex: TypedArraySchema.u16({ description: '0 = unoccupied, otherwise 1 + FEATURE_KEY_INDEX' }),
+    reserved: TypedArraySchema.u8({ description: '0 = tile can be claimed, 1 = permanently blocked (ocean, cliff, debug)'}),
+  }
+  ```
+  - `featureIndex` is a dense per-tile record of the current occupant, so each
+    planner can cheaply skip already claimed tiles.
+  - `reserved` lets the score stage encode tiles that must stay untouched (deep water, reserved artwork, etc.).
+  - Each stage reads the previous snapshot, copies the typed arrays, applies
+    its placements, and publishes the next snapshot; there is never any
+    in-place mutation _after_ the artifact is published.
 
-New M3 truth artifacts:
-- `artifact:ecology.scoreLayers`
-  - authoritative per-feature per-tile scores.
+## Stage + step + op contracts
+We insert a new truth stage (`ecology-features-score`) before the family
+planners. Each of the four planners runs in its own stage so we can gate
+execution order, consumption, and occupancy updates.
 
-Optional new artifacts (only if required by the conflict model):
-- `artifact:ecology.featureOccupancy` (or equivalent)
-  - explicit conflict/occupancy state consumed by planners.
+### `ecology-features-score` stage
+- **Step**: `score-layers`
+- **Requires**: `artifact:ecology.biomeClassification`, `artifact:ecology.soils`,
+  `artifact:hydrology.hydrography`, `artifact:morphology.topography`,
+  climate artifacts already published by upstream stages.
+- **Provides**: `artifact:ecology.scoreLayers`, `artifact:ecology.occupancy.base`.
+- **Ops**:
+  - All existing vegetation scoring ops (`scoreVegetationForest`, …) plus new
+    scoring ops for wetlands, reefs, and ice layers. Each op returns a
+    float32 array that is stored under its feature key.
+  - No planner ops run here; the stage solely emits scores and the base occupancy.
+- **Decision**:
+  - If in the future we need cross-layer visibility during scoring, we can
+    extend this step to also emit prepocessed `layersByFamily` sub-objects, but
+    the canonical artifact is the single `scoreLayers` map so that planners can
+    rely on a single input regardless of how scores are evolved.
 
-## Score Layers Contract (artifact:ecology.scoreLayers)
+### `ecology-ice` stage (step: `plan-ice`)
+- **Requires**: `artifact:ecology.scoreLayers`, `artifact:ecology.occupancy.base`,
+  `artifact:morphology.topography`, `artifact:ecology.biomeClassification`,
+  hydrology/cryosphere inputs as needed.
+- **Provides**: `artifact:ecology.featureIntents.ice`, `artifact:ecology.occupancy.ice`.
+- **Op**: `ecology.ops.planIce`
+  - Input: `scoreLayers.layers.FEATURE_ICE`, occupancy snapshot, land/water/elevation masks, deterministic tie-break context (seed derived from `context.env.seed`).
+  - Behavior: deterministic thresholding (no `jitterC`, no density multiplier, no feathered randomness). Tiles with elevation-based ice (alpine) vs sea ice are resolved via deterministic ranges and ordered evaluation. Ties resolve using deterministic ranking (e.g., prefer sea ice over alpine when both apply, then use seeded tie-breaker to pick between equally scored tiles).
+  - Writes placements that are appended to occupancy snapshot; stage publishes the updated snapshot.
 
-### Shape
+### `ecology-reefs` stage (step: `plan-reefs`)
+- **Requires**: previous occupancy (`artifact:ecology.occupancy.ice`), `scoreLayers.layers.FEATURE_REEF`/`_COLD_REEF`/`_ATOLL`/`_LOTUS`, `artifact:morphology.topography` (for shoreline), temperature layers.
+- **Provides**: `artifact:ecology.featureIntents.reefs`, `artifact:ecology.occupancy.reefs`.
+- **Op**: `ecology.ops.planReefs`
+  - Input: relevant score layers, occupancy snapshot, shoreline mask from topography, surface temperature.
+  - Behavior: deterministic spacing rules (e.g., fixed stripe/hop pattern instead of seeded randomness). The op writes placements only onto tiles flagged as available in the occupancy snapshot; once placements are determined, the stage sorts them by `tileIndex` before publishing so viz/diagnostics stay repeatable.
 
-A single object containing:
-- `width`, `height`
-- `layers`: a fixed set of per-feature score typed arrays
+### `ecology-wetlands` stage (step: `plan-wetlands`)
+- **Requires**: `artifact:ecology.occupancy.reefs`, `scoreLayers.layers` for wetlands features, `artifact:morphology.topography`, classifiers (moisture, fertility).
+- **Provides**: `artifact:ecology.featureIntents.wetlands`, `artifact:ecology.occupancy.wetlands`.
+- **Ops**:
+  - `ecology.ops.planWetlands` consumes the *five* wet-feature layers (`FEATURE_MARSH`, `FEATURE_TUNDRA_BOG`, `FEATURE_MANGROVE`, `FEATURE_OASIS`, `FEATURE_WATERING_HOLE`) and emits deterministic placements for the family.
+  - The op is allowed (and encouraged) to use **rules** heavily for scoring-derived policy inputs (thresholds, adjacency filters, hard constraints), because rules are the right place to codify "this is a decision input" without smuggling cross-feature heuristics into scoring.
+  - There is **no** "disabled strategy" or "optional wet features" concept at runtime. If we need knobs, they are threshold/constraint knobs, not on/off gates.
+  - The stage sorts the final placements by tile index before publishing to keep viz/diagnostics repeatable.
+  - After placements are locked in, the stage snapshots occupancy for the vegetation stage.
 
-Rules:
-- layers are computed independently.
-- values must be comparable within a layer; cross-layer comparison happens only in planning.
-- sentinel values are explicit.
+### `ecology-vegetation` stage (step: `plan-vegetation`)
+- **Requires**: `artifact:ecology.occupancy.wetlands`, `scoreLayers.layers` for the five vegetation features, `artifact:morphology.topography`, classification masks, `artifact:hydrology.hydrography` if adjacency is needed.
+- **Provides**: `artifact:ecology.featureIntents.vegetation`, `artifact:ecology.occupancy.vegetation` (final occupancy).
+- **Op**: `ecology.ops.planVegetation` (new op)
+  - Input: the five vegetation layers plus occupancy snapshot and land mask.
+  - Behavior: for each tile, compute the feature with the highest score; skip tiles where occupancy says `featureIndex > 0`. If there is a tie, fall back to a deterministic priority list (e.g., forest → rainforest → taiga → savanna → sagebrush) or a seeded tie-breaker derived from `context.env.seed`. No random gating is allowed; either a tile meets the minimum threshold or it remains empty.
+  - Updated occupancy is published as the final snapshot consumed by projection tests / diag dumps.
 
-### Typed array types
+## Must not exist (explicit bans)
+1. **Chance knobs** (`jitterC`, random probability gates, etc.): every planner must make determinate decisions; randomness is only acceptable when breaking ties via a seeded RNG whose only job is to break equal scores.
+2. **Multipliers that gate existence** (`densityScale` that can turn a feature on/off, or `featherC` leveraged to probabilistically feather edges): forbidden. The stage either places a feature or it does not; there are no weights that can be toggled to implicitly suppress a placement.
+3. **Cross-feature heuristics inside score ops**: scores must remain independent per feature; any cross-feature preference must be encoded inside the appropriate planner, not the scorer.
+4. **Silent skips / shouldRun flags / ops executed outside their owning step**: each planner step binds the exact op(s) it calls via the compile-time seam, and strategy selection is explicit in `{ strategy, config }`. There is no runtime "disable" switch that silently makes an op a no-op.
+5. **Any call path that relies on projection to resolve conflicts**: conflict resolution is finalized inside the ordered planners using the occupancy snapshots above; projection is purely stamping.
 
-Default:
-- use `Float32Array` for score layers in [0..1].
-
-We can move to quantized types later only with explicit migration + proof.
-
-## Feature Inventory (M3 scope)
-
-The current feature key universe is defined in:
-- `mods/mod-swooper-maps/src/domain/ecology/types.ts`
-
-As of this packet, the feature keys are:
-
-### Vegetation
-- `FEATURE_FOREST`
-- `FEATURE_RAINFOREST`
-- `FEATURE_TAIGA`
-- `FEATURE_SAVANNA_WOODLAND`
-- `FEATURE_SAGEBRUSH_STEPPE`
-
-### Wetlands / Wet features
-- `FEATURE_MARSH`
-- `FEATURE_TUNDRA_BOG`
-- `FEATURE_MANGROVE`
-- `FEATURE_OASIS`
-- `FEATURE_WATERING_HOLE`
-
-### Reefs / Aquatic
-- `FEATURE_REEF`
-- `FEATURE_COLD_REEF`
-- `FEATURE_ATOLL`
-- `FEATURE_LOTUS`
-
-### Ice
-- `FEATURE_ICE`
-
-## Layer IDs (decision-complete list)
-
-Each feature has a score layer id:
-
-- `ecology.score.FEATURE_FOREST`
-- `ecology.score.FEATURE_RAINFOREST`
-- `ecology.score.FEATURE_TAIGA`
-- `ecology.score.FEATURE_SAVANNA_WOODLAND`
-- `ecology.score.FEATURE_SAGEBRUSH_STEPPE`
-
-- `ecology.score.FEATURE_MARSH`
-- `ecology.score.FEATURE_TUNDRA_BOG`
-- `ecology.score.FEATURE_MANGROVE`
-- `ecology.score.FEATURE_OASIS`
-- `ecology.score.FEATURE_WATERING_HOLE`
-
-- `ecology.score.FEATURE_REEF`
-- `ecology.score.FEATURE_COLD_REEF`
-- `ecology.score.FEATURE_ATOLL`
-- `ecology.score.FEATURE_LOTUS`
-
-- `ecology.score.FEATURE_ICE`
-
-Notes:
-- These ids are for the scoreLayers internal schema and viz keys.
-- They are stable within M3. If we rename, we must provide an explicit migration table.
-
-## Planning IO Contract (per feature)
-
-Each per-feature plan op consumes:
-- relevant score layer (`Float32Array`, [0..1])
-- optional additional layers (read-only) for cross-feature constraints
-- required truth artifacts (biomes, soils, hydrography, climate, topography)
-- conflict state (occupancy) as defined for M3
-
-And outputs:
-- placements/intents for that feature (tile coordinates)
-- optional debug fields for viz (not required by core correctness)
-
-## Deterministic Tie-Break Policy
-
-- Planners must be deterministic.
-- Tie breaks (equal scores) must use:
-  - deterministic stable ordering first, then
-  - seeded tie-break only if needed.
-
-No random gating.
-
-## “Must Not Exist” List (enforced by gates)
-
-- chance percentages in planners
-- multipliers/bonuses that gate whether a feature exists
-- probabilistic edges/jitter that changes outcomes
-- disabled strategies / shouldRun / silent skips
+## Summary of decisions
+- `artifact:ecology.scoreLayers` is the single score store.
+- Occupancy is handled by immutable snapshots (`artifact:ecology.occupancy.*`).
+- Planning stages run in the explicit order: ice → reefs → wetlands → vegetation. Each planner consumes the previous occupancy snapshot and publishes the next.
+- Per-family planning ops remain the ownership surface: vegetation and wetlands are inherently joint decisions (select among multiple candidate features for the same tile while respecting shared constraints). Future algorithm diversity is handled via op strategies, not by reintroducing step-level logic or cross-op orchestration inside ops.
+- Determinism is enforced by banning chance/multipliers and by sorting placements before publishing.

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/CONTRACTS.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/CONTRACTS.md
@@ -1,0 +1,129 @@
+# Contracts: Artifacts, Schemas, Score Layers, and Planning IO
+
+Read first: `VISION.md`.
+
+This document is where M3 becomes **decision complete**.
+
+## Artifact Inventory (M3)
+
+Existing ecology truth artifacts (must remain stable):
+- `artifact:ecology.soils`
+- `artifact:ecology.resourceBasins`
+- `artifact:ecology.biomeClassification`
+- `artifact:ecology.featureIntents.vegetation`
+- `artifact:ecology.featureIntents.wetlands`
+- `artifact:ecology.featureIntents.reefs`
+- `artifact:ecology.featureIntents.ice`
+
+New M3 truth artifacts:
+- `artifact:ecology.scoreLayers`
+  - authoritative per-feature per-tile scores.
+
+Optional new artifacts (only if required by the conflict model):
+- `artifact:ecology.featureOccupancy` (or equivalent)
+  - explicit conflict/occupancy state consumed by planners.
+
+## Score Layers Contract (artifact:ecology.scoreLayers)
+
+### Shape
+
+A single object containing:
+- `width`, `height`
+- `layers`: a fixed set of per-feature score typed arrays
+
+Rules:
+- layers are computed independently.
+- values must be comparable within a layer; cross-layer comparison happens only in planning.
+- sentinel values are explicit.
+
+### Typed array types
+
+Default:
+- use `Float32Array` for score layers in [0..1].
+
+We can move to quantized types later only with explicit migration + proof.
+
+## Feature Inventory (M3 scope)
+
+The current feature key universe is defined in:
+- `mods/mod-swooper-maps/src/domain/ecology/types.ts`
+
+As of this packet, the feature keys are:
+
+### Vegetation
+- `FEATURE_FOREST`
+- `FEATURE_RAINFOREST`
+- `FEATURE_TAIGA`
+- `FEATURE_SAVANNA_WOODLAND`
+- `FEATURE_SAGEBRUSH_STEPPE`
+
+### Wetlands / Wet features
+- `FEATURE_MARSH`
+- `FEATURE_TUNDRA_BOG`
+- `FEATURE_MANGROVE`
+- `FEATURE_OASIS`
+- `FEATURE_WATERING_HOLE`
+
+### Reefs / Aquatic
+- `FEATURE_REEF`
+- `FEATURE_COLD_REEF`
+- `FEATURE_ATOLL`
+- `FEATURE_LOTUS`
+
+### Ice
+- `FEATURE_ICE`
+
+## Layer IDs (decision-complete list)
+
+Each feature has a score layer id:
+
+- `ecology.score.FEATURE_FOREST`
+- `ecology.score.FEATURE_RAINFOREST`
+- `ecology.score.FEATURE_TAIGA`
+- `ecology.score.FEATURE_SAVANNA_WOODLAND`
+- `ecology.score.FEATURE_SAGEBRUSH_STEPPE`
+
+- `ecology.score.FEATURE_MARSH`
+- `ecology.score.FEATURE_TUNDRA_BOG`
+- `ecology.score.FEATURE_MANGROVE`
+- `ecology.score.FEATURE_OASIS`
+- `ecology.score.FEATURE_WATERING_HOLE`
+
+- `ecology.score.FEATURE_REEF`
+- `ecology.score.FEATURE_COLD_REEF`
+- `ecology.score.FEATURE_ATOLL`
+- `ecology.score.FEATURE_LOTUS`
+
+- `ecology.score.FEATURE_ICE`
+
+Notes:
+- These ids are for the scoreLayers internal schema and viz keys.
+- They are stable within M3. If we rename, we must provide an explicit migration table.
+
+## Planning IO Contract (per feature)
+
+Each per-feature plan op consumes:
+- relevant score layer (`Float32Array`, [0..1])
+- optional additional layers (read-only) for cross-feature constraints
+- required truth artifacts (biomes, soils, hydrography, climate, topography)
+- conflict state (occupancy) as defined for M3
+
+And outputs:
+- placements/intents for that feature (tile coordinates)
+- optional debug fields for viz (not required by core correctness)
+
+## Deterministic Tie-Break Policy
+
+- Planners must be deterministic.
+- Tie breaks (equal scores) must use:
+  - deterministic stable ordering first, then
+  - seeded tie-break only if needed.
+
+No random gating.
+
+## “Must Not Exist” List (enforced by gates)
+
+- chance percentages in planners
+- multipliers/bonuses that gate whether a feature exists
+- probabilistic edges/jitter that changes outcomes
+- disabled strategies / shouldRun / silent skips

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/DECISIONS.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/DECISIONS.md
@@ -1,0 +1,35 @@
+# Decisions (M3 Packet)
+
+This file is intentionally small.
+
+Format:
+
+### <Decision title>
+- **Context:** why this decision exists
+- **Options:** A, B, C
+- **Choice:** A/B/C
+- **Rationale:** why
+- **Risk:** what could break or drift
+
+---
+
+### Cross-family conflict model is explicit occupancy state
+- **Context:** planning stages must avoid relying on projection stamping to resolve conflicts.
+- **Options:** (A) immutable occupancy snapshot artifact chain, (B) publish-once mutable handle.
+- **Choice:** TBD (must be locked during packet completion).
+- **Rationale:**
+- **Risk:** choice affects memory footprint and enforcement of artifact mutation policy.
+
+### Score layers representation
+- **Context:** planners must consume a single score store for all features; layer ids must be stable.
+- **Options:** (A) explicit keyed typed arrays per feature (Float32), (B) packed representation.
+- **Choice:** A (explicit keyed typed arrays).
+- **Rationale:** easiest to validate, easiest to evolve, and easiest to gate.
+- **Risk:** memory footprint; mitigated by later quantization/migration if needed.
+
+### Projection (map-ecology) remains one stage
+- **Context:** minimize projection surface; invest complexity in truth stages.
+- **Options:** (A) keep one stage, (B) split.
+- **Choice:** A.
+- **Rationale:** stable topology; easier gating.
+- **Risk:** none material.

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/DECISIONS.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/DECISIONS.md
@@ -16,9 +16,9 @@ Format:
 ### Cross-family conflict model is explicit occupancy state
 - **Context:** planning stages must avoid relying on projection stamping to resolve conflicts.
 - **Options:** (A) immutable occupancy snapshot artifact chain, (B) publish-once mutable handle.
-- **Choice:** TBD (must be locked during packet completion).
-- **Rationale:**
-- **Risk:** choice affects memory footprint and enforcement of artifact mutation policy.
+- **Choice:** A (immutable occupancy snapshot artifact chain).
+- **Rationale:** snapshot artifacts keep ownership explicit and verifiable at stage boundaries. They preserve the "publish once" artifact posture, avoid hidden mutation channels across steps, and make determinism/cutover gating straightforward (each stage has one explicit "before/after" occupancy surface).
+- **Risk:** memory footprint (multiple typed arrays). Mitigation: keep occupancy representation minimal (dense `u16` + `u8` reserved mask) and consider future compression/packing only after M3 is stable.
 
 ### Score layers representation
 - **Context:** planners must consume a single score store for all features; layer ids must be stable.
@@ -33,3 +33,17 @@ Format:
 - **Choice:** A.
 - **Rationale:** stable topology; easier gating.
 - **Risk:** none material.
+
+### No viz-only steps
+- **Context:** steps are orchestration nodes; viz is a byproduct of the work, not a separate phase.
+- **Options:** (A) "viz steps" that only publish deck.gl layers, (B) each step emits its own viz.
+- **Choice:** B.
+- **Rationale:** keeps causality obvious (viz comes from the same inputs/ops that produced the truth artifacts) and avoids redundant stage/step boundaries that would only exist to move data for visualization.
+- **Risk:** steps may get visually noisy; mitigate by keeping viz emission conventions consistent and gated by trace/debug flags (without changing algorithm behavior).
+
+### Biome edge refinement is integrated into biome classification
+- **Context:** biome edges are part of "what the biome is," not a later optional pass.
+- **Options:** (A) separate `biome-edge-refine` step/op, (B) integrated into `classifyBiomes` op.
+- **Choice:** B.
+- **Rationale:** reduces pipeline seams and prevents downstream scorers from consuming a pre-refine variant. If refinement needs toggles, they are compile-time knobs inside the one biomes op envelope, not a separate stage/step path.
+- **Risk:** larger biomes op; acceptable because it remains a single atomic classification operation with clear inputs/outputs.

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/EXECUTION-PLAN.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/EXECUTION-PLAN.md
@@ -1,0 +1,79 @@
+# Execution Plan: M3 Ecology Physics-First Feature Scoring + Planning
+
+Read first: `README.md` and `VISION.md`.
+
+This is the decision-complete execution plan that will be used to generate the milestone + issue docs.
+
+## High-level Workstreams
+
+1. Packet finalization (contracts + topology + gates)
+2. Milestone authoring (M3 framed as remediation of M2)
+3. Issue breakout (local issue docs)
+4. Prework sweep (zero remaining prompts)
+
+## Gating Philosophy
+
+- No-fudging is enforced by static scans + runtime invariants.
+- Determinism is enforced by fixed-seed diag dumps/diffs.
+- Projection stamping must not hide truth planner errors.
+
+## Tooling (already in repo)
+
+Diagnostics scripts in `mods/mod-swooper-maps`:
+- `bun --cwd mods/mod-swooper-maps run diag:dump -- <w> <h> <seed> --label <label>`
+- `bun --cwd mods/mod-swooper-maps run diag:diff -- <baselineRunDir> <candidateRunDir>`
+- `bun --cwd mods/mod-swooper-maps run diag:list`
+
+## Slice Map (for later implementation via dev-loop-parallel)
+
+M3 is a behavior-changing milestone. We will still keep slices reviewable and shippable.
+
+### Slice 0: Phase 0-3 docs only (this branch)
+
+- Packet is complete and decision complete.
+- Milestone doc exists.
+- Issue docs exist.
+- Prework prompts are executed/removed.
+
+### Slice 1: Stage split topology + recipe wiring (truth stages)
+
+- Introduce new truth ecology stages (pedology, biomes, score, ice, reefs, wetlands, vegetation).
+- Keep `map-ecology` as one projection stage.
+- Gates: recipe compile, determinism smoke.
+
+### Slice 2: ScoreLayers op + artifact contract
+
+- Implement `ecology-features-score` stage to publish `artifact:ecology.scoreLayers`.
+- Compute all per-feature score layers independently.
+
+### Slice 3-6: Per-family deterministic planning
+
+- `ecology-ice` planner (deterministic)
+- `ecology-reefs` planner
+- `ecology-wetlands` planner
+- `ecology-vegetation` planner
+
+Each consumes scoreLayers + occupancy state.
+
+### Slice 7: Projection stamping strictness
+
+- `map-ecology/features-apply` becomes pure stamping and must not probabilistically gate.
+- Add gate: stamping drops are failures.
+
+### Slice 8: Delete legacy chance/multiplier paths
+
+- Delete chance knobs, multipliers, rollPercent gating from ecology planning.
+- Update tests and viz inventories.
+
+## Commands (baseline checks)
+
+- `bun run --cwd packages/civ7-adapter build`
+- `bun run --cwd packages/mapgen-viz build`
+- `bun run --cwd packages/mapgen-core build`
+- `bun --cwd mods/mod-swooper-maps test test/ecology`
+
+## Agent Team Execution (later)
+
+Agents will work in isolated worktrees with Graphite stacks.
+- Each agent owns a slice or a clearly partitioned set of issues.
+- Each agent keeps a scratchpad under `docs/projects/pipeline-realism/scratch/` and clears it at slice boundaries.

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/EXECUTION-PLAN.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/EXECUTION-PLAN.md
@@ -24,6 +24,12 @@ Diagnostics scripts in `mods/mod-swooper-maps`:
 - `bun --cwd mods/mod-swooper-maps run diag:diff -- <baselineRunDir> <candidateRunDir>`
 - `bun --cwd mods/mod-swooper-maps run diag:list`
 
+Code discovery posture:
+- Prefer `$narsil-mcp` when semantic search helps. Do not use `hybrid_search` (server instability).
+- Prefer native tools (`rg`, `git`, direct file reads) for bulk scanning and high-signal verification.
+- Keep the primary checkout on latest commits to keep MCP index fresh:
+  - `/Users/mateicanavra/Documents/.nosync/DEV/civ7-modding-tools` can be detached HEAD.
+
 ## Slice Map (for later implementation via dev-loop-parallel)
 
 M3 is a behavior-changing milestone. We will still keep slices reviewable and shippable.

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/M2-REMEDIATION-MAP.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/M2-REMEDIATION-MAP.md
@@ -1,0 +1,38 @@
+# M2 Remediation Map (What M3 Assumes and Replaces)
+
+M3 is explicitly "M3 that remediates M2":
+
+- **M2** = behavior-preserving architecture alignment (compute substrate + atomic per-feature ops + compiler-owned binding seam).
+- **M3** = realism cutover (score layers first + deterministic planning + no-fudging).
+
+## M2 as Prerequisite (assumed true by end of M2)
+
+From `docs/projects/pipeline-realism/milestones/M2-ecology-architecture-alignment.md`:
+
+- Atomic per-feature ops exist (no mega-ops in runtime path).
+- Compute substrate model exists (shared compute layers consumed by plan ops).
+- Steps orchestrate; ops do not orchestrate.
+- Steps do not import op implementations or rules.
+- features-plan binding seam is compiler-owned (no hand-wired optional ops hacks).
+
+## What M3 Changes (behavioral, forward-only)
+
+M3 changes behavior by design:
+
+- Introduces an explicit `artifact:ecology.scoreLayers` as a first-class truth product.
+- Replaces chance/multiplier/probabilistic gating with deterministic selection.
+- Moves cross-family reasoning into truth planning (projection stamping does not "fix" truth).
+
+## M3 Does NOT Redo M2
+
+- M3 does not re-fight op modularization.
+- M3 treats M2 architecture alignment as infrastructure.
+
+## Where M3 must delete legacy remnants
+
+Anything that remains from pre-M2 or transitional M2 shims that violates M3 posture:
+- chance percentages / multipliers / probabilistic edges
+- disabled strategies / silent skips
+- projection merge logic that gates existence
+
+Deletion is explicit and gated.

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/README.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/README.md
@@ -1,0 +1,34 @@
+# PACKET: M3 Ecology Physics-First Feature Scoring + Planning
+
+This packet is the **execution authority** for Pipeline-Realism **M3**.
+
+M3 is explicitly framed as **"M3 that remediates M2"**:
+- **M2** (`docs/projects/pipeline-realism/milestones/M2-ecology-architecture-alignment.md`) is behavior-preserving architecture alignment (atomic ops + compute substrate + compiler-owned binding seam).
+- **M3** is a behavior-changing realism cutover:
+  - score *every* feature independently first (per-tile score layers)
+  - plan afterwards (deterministic; ordered; conflict-aware)
+  - project/stamp in `map-ecology` as a minimal deterministic materialization step
+
+## Reading Order (mandatory)
+
+1. `VISION.md` (human intent; non-negotiables; optimization targets)
+2. `ARCHITECTURE.md` (stage/step/op/rule semantics applied to ecology)
+3. `TOPOLOGY.md` (exact stage + step breakdown; truth vs projection)
+4. `CONTRACTS.md` (artifacts + schemas; scoreLayers; planner IO)
+5. `EXECUTION-PLAN.md` (slice map; gates; verification; agent team runbooks)
+6. `DECISIONS.md` (decision log; must stay small)
+7. `M2-REMEDIATION-MAP.md` (explicit relationship to M2; what is assumed/removed)
+
+## Output Docs Produced From This Packet
+
+- Milestone: `docs/projects/pipeline-realism/milestones/M3-ecology-physics-first-feature-planning.md`
+- Local issue docs: `docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-*.md`
+
+## Hard Constraints (non-negotiable)
+
+- No output fudging: no chance percentages, multipliers, probabilistic gating.
+  - Deterministic selection + seeded tie-breaks only.
+- No legacy shims, no dual paths, no wrappers around bad ideas.
+- Ops are atomic; steps orchestrate; ops do not call ops.
+- Rules are op-local policy units; steps never import rules.
+- Ordering is recipe-only (no stage manifest ordering).

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-0-context.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-0-context.md
@@ -1,0 +1,40 @@
+# Runbook: Phase 0 (Context + Anchors)
+
+## Goal
+
+Re-anchor the execution work in `pipeline-realism` and establish the M3 packet as the execution authority.
+
+## Inputs / Sources of Truth
+
+- Project home: `docs/projects/pipeline-realism/`
+- M2 milestone (architecture alignment, behavior-preserving):
+  - `docs/projects/pipeline-realism/milestones/M2-ecology-architecture-alignment.md`
+- M2 issue corpus:
+  - `docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M2-*.md`
+- Engine-refactor-v1 ecology spike directory is evidence-only:
+  - `docs/projects/engine-refactor-v1/resources/spike/ecology-arch-alignment/`
+
+## Outputs
+
+- Packet directory exists: `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/`
+- `README.md` and `VISION.md` exist.
+- Orchestrator scratch exists: `docs/projects/pipeline-realism/scratch/ORCH-M3-ecology.md`
+
+## Agent Assignments (Phase 0)
+
+- Orchestrator: ensure the packet exists and is the authority.
+- ARCH/SCORE/PLAN/VIZ/GATES agents should only start after `VISION.md` exists.
+
+## Gates
+
+- Everyone can answer:
+  - What is M2?
+  - What is M3?
+  - What is the no-fudging posture?
+  - Where is the packet?
+  - Where do decisions live?
+
+## Do Not Do
+
+- Do not treat engine-refactor-v1 milestones as the execution project.
+- Do not write new plan docs outside the packet except the milestone/issues that the packet generates.

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-1-vision.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-1-vision.md
@@ -1,0 +1,27 @@
+# Runbook: Phase 1 (Vision Capture)
+
+## Goal
+
+Capture the human intent as the top-level directive and ensure all downstream documents (architecture, topology, contracts, execution plan) are subordinate to it.
+
+## Inputs
+
+- Human vision as captured in `VISION.md`.
+
+## Outputs
+
+- `VISION.md` is complete and stable.
+- Every other packet doc explicitly links to `VISION.md` and respects its non-negotiables.
+
+## Agent Discipline
+
+- Every agent must read `VISION.md` first.
+- Agents must not propose shims, optional ops, disabled strategies, or chance/multiplier gating.
+
+## Gates
+
+`VISION.md` must explicitly include:
+- optimization priorities
+- earth-system-first stage boundaries
+- architecture semantics (stage/step/op/strategy/rule)
+- non-negotiables (no-fudging; determinism; no legacy; no silent skips)

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-2-architecture-topology-and-contracts.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-2-architecture-topology-and-contracts.md
@@ -1,0 +1,62 @@
+# Runbook: Phase 2 (Architecture, Topology, Contracts)
+
+## Goal
+
+Lock a decision-complete M3 design that implementers can execute without making decisions:
+- stage/step topology (truth vs projection)
+- artifact contracts (`scoreLayers`, `occupancy`, `featureIntents`)
+- ordering + conflict model (explicit occupancy snapshot chain)
+- deterministic + no-fudging posture (explicit bans + gates)
+
+## Inputs / Sources of Truth
+
+- Packet spine:
+  - `../VISION.md`
+  - `../ARCHITECTURE.md`
+- Canon MapGen semantics and policy vocabulary:
+  - `docs/system/libs/mapgen/MAPGEN.md`
+  - `docs/system/libs/mapgen/llms/LLMS.md`
+  - `docs/system/libs/mapgen/reference/REFERENCE.md`
+  - `docs/system/libs/mapgen/reference/RECIPE-SCHEMA.md`
+  - `docs/system/libs/mapgen/reference/ARTIFACTS.md`
+  - `docs/system/libs/mapgen/reference/TAGS.md`
+  - `docs/system/libs/mapgen/policies/ARTIFACT-MUTATION.md`
+  - `docs/system/libs/mapgen/policies/CONFIG-VS-PLAN-COMPILATION.md`
+
+## Outputs
+
+- `../TOPOLOGY.md` is internally consistent and recipe-owned.
+- `../CONTRACTS.md` declares exact artifact schemas and planner IO.
+- `../DECISIONS.md` has no TBD and stays small.
+
+## Agent Assignments (Phase 2)
+
+- ARCH: topology consistency (stage ids, recipe wiring, truth vs projection invariants).
+- SCORE: `scoreLayers` schema + per-feature layer inventory.
+- PLAN: occupancy/conflict model + planning order + deterministic tie-break policy.
+- VIZ: confirm no viz-only steps; ensure each step's viz output is attributable to the work.
+- GATES: define the minimal static scan + deterministic dump/diff gates.
+
+Scratch discipline:
+- each agent keeps an untracked scratchpad under `docs/projects/pipeline-realism/scratch/`
+- orchestrator migrates durable decisions into `../DECISIONS.md` and contracts into `../CONTRACTS.md`
+
+## Gates
+
+- `../TOPOLOGY.md` and `../CONTRACTS.md` agree on:
+  - stage order
+  - step names
+  - artifact ids
+  - planner ordering (ice -> reefs -> wetlands -> vegetation)
+- `../DECISIONS.md` contains:
+  - occupancy posture choice
+  - no viz-only steps decision
+  - biome-edge-refine integration decision
+- `rg -n "TBD" ../` is empty except references to `LOCAL-TBD` issue ids.
+
+## Do Not Do
+
+- Do not leave any "disabled strategy" or silent skip concept in the target.
+- Do not move planning logic into steps "because it's easier".
+- Do not preserve legacy stage/step ids if they violate the new topology (M3 is a cutover).
+

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-3-packet-hardening-and-consistency-sweep.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-3-packet-hardening-and-consistency-sweep.md
@@ -1,0 +1,41 @@
+# Runbook: Phase 3 (Packet Hardening + Consistency Sweep)
+
+## Goal
+
+Turn the packet into the single execution authority by removing inconsistencies and making the "no black ice" posture real.
+
+## Inputs / Sources of Truth
+
+- Packet:
+  - `../README.md`
+  - `../VISION.md`
+  - `../ARCHITECTURE.md`
+  - `../TOPOLOGY.md`
+  - `../CONTRACTS.md`
+  - `../EXECUTION-PLAN.md`
+  - `../DECISIONS.md`
+  - `../M2-REMEDIATION-MAP.md`
+
+## Outputs
+
+- Packet is self-consistent (no contradictions between topology and contracts).
+- Packet is decision-complete (no TBD decisions).
+- Packet includes the minimal "design space" section in `../ARCHITECTURE.md` to make the choice legible.
+
+## Agent Assignments (Phase 3)
+
+- Orchestrator only (preferred): avoid flooding context; do a single coherent pass.
+- Optionally:
+  - GATES agent to propose `rg` patterns and allowlists for no-fudging rails.
+
+## Gates
+
+- `rg -n "TBD" ../` is empty (except `LOCAL-TBD` id references).
+- `../DECISIONS.md` stays small (no long debate transcripts).
+- Packet uses consistent vocabulary (stage/step/op/strategy/rule, truth vs projection).
+
+## Do Not Do
+
+- Do not expand the authoring SDK.
+- Do not introduce optional operations as a new concept.
+

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-4-spec-to-milestone.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-4-spec-to-milestone.md
@@ -1,0 +1,40 @@
+# Runbook: Phase 4 (Spec Packet -> Milestone)
+
+## Goal
+
+Convert the packet into the canonical M3 milestone doc without diluting constraints.
+
+## Inputs / Sources of Truth
+
+- Packet authority:
+  - `../README.md`
+  - `../EXECUTION-PLAN.md`
+  - `../TOPOLOGY.md`
+  - `../CONTRACTS.md`
+
+## Outputs
+
+- Milestone exists:
+  - `docs/projects/pipeline-realism/milestones/M3-ecology-physics-first-feature-planning.md`
+- Milestone is explicitly framed as:
+  - "M3 that remediates M2"
+  - behavior-changing realism cutover
+
+## Agent Assignments (Phase 4)
+
+- Orchestrator only.
+
+## Gates
+
+- Milestone references the packet as authority (the milestone is derived, not peer).
+- Milestone scope includes:
+  - stage split
+  - `scoreLayers` artifact contract
+  - deterministic planners + ordering
+  - strict projection stamping
+  - deletion of legacy chance/multiplier paths
+
+## Do Not Do
+
+- Do not introduce new decisions in the milestone; decisions live in the packet.
+

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-5-harden-milestone.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-5-harden-milestone.md
@@ -1,0 +1,37 @@
+# Runbook: Phase 5 (Harden Milestone)
+
+## Goal
+
+Make every milestone item executable:
+- acceptance criteria are verifiable
+- commands/gates are explicit
+- there are no hidden "and then figure it out" steps
+
+## Inputs / Sources of Truth
+
+- Milestone:
+  - `docs/projects/pipeline-realism/milestones/M3-ecology-physics-first-feature-planning.md`
+- Packet (authority):
+  - `../EXECUTION-PLAN.md`
+
+## Outputs
+
+- Milestone reads like an index and points to:
+  - local issue docs for implementation detail
+  - packet docs for authority
+
+## Agent Assignments (Phase 5)
+
+- GATES agent: propose the minimal deterministic + no-fudging gate set.
+- Orchestrator: integrate; keep scope stable (harden, don't expand).
+
+## Gates
+
+- Every milestone acceptance criterion has:
+  - a command
+  - an expected result
+
+## Do Not Do
+
+- Do not change the milestone scope; only clarify and make it executable.
+

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-6-milestone-to-issues.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-6-milestone-to-issues.md
@@ -1,0 +1,40 @@
+# Runbook: Phase 6 (Milestone -> Local Issues)
+
+## Goal
+
+Produce a full local issue corpus where each leaf issue is implementation-ready and contains the acceptance/verification needed for later Graphite + worktree execution.
+
+## Inputs / Sources of Truth
+
+- Milestone:
+  - `docs/projects/pipeline-realism/milestones/M3-ecology-physics-first-feature-planning.md`
+- Packet authority:
+  - `../EXECUTION-PLAN.md`
+  - `../TOPOLOGY.md`
+  - `../CONTRACTS.md`
+
+## Outputs
+
+- Issues exist:
+  - `docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-*.md`
+- Each issue contains:
+  - deliverables
+  - acceptance criteria
+  - verification commands
+  - breadcrumbs (paths/symbols)
+
+## Agent Assignments (Phase 6)
+
+- Orchestrator only (preferred) to keep coherence.
+- Optionally:
+  - ARCH/SCORE/PLAN agents can propose breadcrumbs, but orchestrator writes the final issue docs.
+
+## Gates
+
+- No `## Prework Prompt (Agent Brief)` sections remain in M3 issues.
+- Each issue has explicit dependencies (blocked_by/blocked) that match the slice ordering.
+
+## Do Not Do
+
+- Do not leave placeholder issue docs in the repo (they create false confidence).
+

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-7-prework-sweep.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-7-prework-sweep.md
@@ -1,0 +1,39 @@
+# Runbook: Phase 7 (Prework Sweep)
+
+## Goal
+
+Eliminate "black ice" before implementation begins:
+- no ambiguous contracts
+- no unresolved decisions that would fork the implementation
+- no missing artifact ids/schemas
+
+## Inputs / Sources of Truth
+
+- Packet:
+  - `../TOPOLOGY.md`
+  - `../CONTRACTS.md`
+  - `../DECISIONS.md`
+- Issues:
+  - `docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-*.md`
+
+## Outputs
+
+- Zero remaining prework prompts (none in issue bodies).
+- Any remaining uncertainties are either:
+  - removed (decision made), or
+  - captured as an explicit decision entry in `../DECISIONS.md`.
+
+## Agent Assignments (Phase 7)
+
+- Orchestrator: run the sweep and fix any doc drift.
+- GATES: propose the static scan allowlist approach for "no-fudging" enforcement.
+
+## Gates
+
+- `rg -n "^## Prework Prompt \\(Agent Brief\\)$" docs/projects/pipeline-realism/issues | rg "PR-M3"` is empty.
+- `rg -n "TBD" ../` is empty except `LOCAL-TBD` id references.
+
+## Do Not Do
+
+- Do not "leave it for implementation" if it would change topology/contracts.
+

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-8-implementation-dev-loop-parallel.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-8-implementation-dev-loop-parallel.md
@@ -1,0 +1,53 @@
+# Runbook: Phase 8 (Implementation via Graphite + Worktrees)
+
+## Goal
+
+Execute M3 as a set of reviewable, parallelizable slices with no legacy shims left behind.
+
+This runbook is a guide for the later execution workflow (not performed on this docs-only branch).
+
+## Inputs / Sources of Truth
+
+- Packet authority:
+  - `../EXECUTION-PLAN.md`
+  - `../TOPOLOGY.md`
+  - `../CONTRACTS.md`
+- Milestone + issues:
+  - `docs/projects/pipeline-realism/milestones/M3-ecology-physics-first-feature-planning.md`
+  - `docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-*.md`
+
+## Execution Posture
+
+- Graphite stacks + worktrees only (no ad-hoc branches).
+- Ops are atomic and never call ops.
+- Steps orchestrate and may emit viz, but do not encode planning logic.
+- No legacy shims/dual paths: cut over, delete, and harden gates.
+
+Tooling:
+- Prefer `$narsil-mcp` for semantic discovery (no `hybrid_search`).
+- Keep primary checkout on latest commits to keep MCP index fresh.
+
+## Suggested Slice/Stack Layout
+
+- Stack A (sequential unblockers):
+  - M3-002 -> M3-003
+- Stack B/C/D (parallel planners after scoreLayers + base occupancy):
+  - M3-004, M3-005, M3-006, M3-007
+- Stack Final (sequential integration + deletion):
+  - M3-008 -> M3-009
+
+## Gates (non-negotiable)
+
+- Determinism:
+  - fixed-seed dump reruns are identical via `diag:diff`
+- No-fudging:
+  - static scans are clean (allowlist only for tie-break utilities)
+- Projection strictness:
+  - stamping does not drop placements; rejections fail tests/diagnostics
+
+## Do Not Do
+
+- Do not restack or reparent other active stacks.
+- Do not introduce "optional ops" or "disabled strategies" as new concepts.
+- Do not keep chance/multiplier paths behind a config flag; delete them.
+

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/TOPOLOGY.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/TOPOLOGY.md
@@ -1,0 +1,80 @@
+# Topology: M3 Ecology Truth Stages + Projection
+
+Read first: `VISION.md` and `ARCHITECTURE.md`.
+
+## Current (baseline)
+
+The standard recipe currently has one truth ecology stage:
+- `ecology` (steps: pedology, resource-basins, biomes, biome-edge-refine, features-plan)
+
+Projection ecology:
+- `map-ecology` (steps: plot-biomes, features-apply, plot-effects)
+
+Reference: `mods/mod-swooper-maps/src/recipes/standard/recipe.ts`.
+
+## Target (M3)
+
+### Truth stages (earth-system-first)
+
+We split truth ecology into separate stages so each boundary has meaning:
+
+1. `ecology-pedology`
+- Purpose: soil + ground substrate truth.
+- Produces: `artifact:ecology.soils` (and any pedology derivatives required downstream).
+
+2. `ecology-biomes`
+- Purpose: biome classification truth.
+- Important: biome edge refinement is integrated here (no separate refine stage/op).
+- Produces: `artifact:ecology.biomeClassification` (final).
+
+3. `ecology-features-score`
+- Purpose: compute independent per-feature per-tile score layers.
+- Produces: `artifact:ecology.scoreLayers` (authoritative score store).
+
+4. `ecology-ice`
+- Purpose: plan ice feature intents deterministically.
+- Consumes: scoreLayers + required truth artifacts.
+- Produces: `artifact:ecology.featureIntents.ice`.
+
+5. `ecology-reefs`
+- Purpose: plan reef-family feature intents deterministically.
+- Produces: `artifact:ecology.featureIntents.reefs`.
+
+6. `ecology-wetlands`
+- Purpose: plan wetlands + wet placements deterministically.
+- Produces: `artifact:ecology.featureIntents.wetlands`.
+
+7. `ecology-vegetation`
+- Purpose: plan vegetation feature intents deterministically.
+- Produces: `artifact:ecology.featureIntents.vegetation`.
+
+### Planning order
+
+Truth planning order is:
+
+`ecology-ice` -> `ecology-reefs` -> `ecology-wetlands` -> `ecology-vegetation`
+
+This order is a contract and exists to support conflict-aware deterministic planning.
+
+### Projection stage
+
+Keep `map-ecology` as one stage:
+- `plot-biomes`
+- `features-apply` (stamping/materialization; minimal deterministic adjustments)
+- `plot-effects` (note: plot-effects itself must be made deterministic and no-fudging in M3).
+
+## Required Artifacts (high-level)
+
+Truth artifacts required across these stages (non-exhaustive; finalized in `CONTRACTS.md`):
+- `artifact:morphology.topography`
+- `artifact:hydrology.climateField`
+- `artifact:hydrology.hydrography`
+- `artifact:hydrology.cryosphere`
+
+## Open Implementation Choice (locked by end of packet)
+
+Occupancy/conflict modeling:
+- (A) immutable occupancy snapshot artifact chain, or
+- (B) publish-once mutable handle posture.
+
+This is locked in `CONTRACTS.md` and enforced by M3 gates.

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/TOPOLOGY.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/TOPOLOGY.md
@@ -1,80 +1,104 @@
-# Topology: M3 Ecology Truth Stages + Projection
+# TOPOLOGY: M3 Earth-System-First Stage + Step Topology
 
-Read first: `VISION.md` and `ARCHITECTURE.md`.
+This document locks the canonical M3 stage/step layout.
 
-## Current (baseline)
+It must feel like an earth system while staying fully consistent with MapGen semantics:
+- stages are config compilation boundaries
+- steps orchestrate (read artifacts, call ops, publish artifacts, emit viz)
+- ops are atomic algorithms (compute/score/plan) and never call ops
+- rules are op-local policy inputs and are never imported by steps
 
-The standard recipe currently has one truth ecology stage:
-- `ecology` (steps: pedology, resource-basins, biomes, biome-edge-refine, features-plan)
+The causal spine is **Score -> Plan -> Stamp**:
+1. publish a single shared score store (`artifact:ecology.scoreLayers`)
+2. plan in ordered truth stages with explicit conflict/occupancy state
+3. stamp/materialize in the single projection stage (`map-ecology`)
 
-Projection ecology:
-- `map-ecology` (steps: plot-biomes, features-apply, plot-effects)
+## Stage order (recipe-owned)
 
-Reference: `mods/mod-swooper-maps/src/recipes/standard/recipe.ts`.
+1. `ecology-pedology` (truth)
+2. `ecology-biomes` (truth)
+3. `ecology-features-score` (truth; publishes `artifact:ecology.scoreLayers` + `artifact:ecology.occupancy.base`)
+4. `ecology-ice` (truth; plans `FEATURE_ICE`)
+5. `ecology-reefs` (truth; plans reef-family features)
+6. `ecology-wetlands` (truth; plans wet-family features)
+7. `ecology-vegetation` (truth; plans vegetation-family features)
+8. `map-ecology` (projection; stamps the final plan)
 
-## Target (M3)
+Notes:
+- Ordering is recipe-only (see `docs/system/libs/mapgen/reference/RECIPE-SCHEMA.md`).
+- Cross-family conflict resolution is enforced by the explicit occupancy snapshot chain in `CONTRACTS.md`.
+- There are **no viz-only steps** (viz is emitted by the steps doing the work).
 
-### Truth stages (earth-system-first)
+## Stage by stage breakdown
 
-We split truth ecology into separate stages so each boundary has meaning:
+### `ecology-pedology` (truth)
 
-1. `ecology-pedology`
-- Purpose: soil + ground substrate truth.
-- Produces: `artifact:ecology.soils` (and any pedology derivatives required downstream).
+| Step | Required artifacts | Provides | Notes |
+| --- | --- | --- | --- |
+| `pedology` | `artifact:morphology.topography`, `artifact:climateField` | `artifact:ecology.soils` | Calls `ops.classifyPedology`; emits soil/fertility viz. |
+| `resource-basins` | `artifact:ecology.soils`, `artifact:morphology.topography`, `artifact:climateField` | `artifact:ecology.resourceBasins` | Uses score/plan ops as needed; remains deterministic. |
 
-2. `ecology-biomes`
-- Purpose: biome classification truth.
-- Important: biome edge refinement is integrated here (no separate refine stage/op).
-- Produces: `artifact:ecology.biomeClassification` (final).
+### `ecology-biomes` (truth)
 
-3. `ecology-features-score`
-- Purpose: compute independent per-feature per-tile score layers.
-- Produces: `artifact:ecology.scoreLayers` (authoritative score store).
+| Step | Required artifacts | Provides | Notes |
+| --- | --- | --- | --- |
+| `biomes` | `artifact:climateField`, `artifact:hydrology.cryosphere`, `artifact:morphology.topography`, `artifact:hydrology.hydrography` | `artifact:ecology.biomeClassification` | Calls a single `ops.classifyBiomes` op. **Biome edge refinement is integrated into this op** (no separate `biome-edge-refine` step/op). |
 
-4. `ecology-ice`
-- Purpose: plan ice feature intents deterministically.
-- Consumes: scoreLayers + required truth artifacts.
-- Produces: `artifact:ecology.featureIntents.ice`.
+### `ecology-features-score` (truth)
 
-5. `ecology-reefs`
-- Purpose: plan reef-family feature intents deterministically.
-- Produces: `artifact:ecology.featureIntents.reefs`.
+| Step | Required artifacts | Provides | Notes |
+| --- | --- | --- | --- |
+| `score-layers` | `artifact:ecology.biomeClassification`, `artifact:ecology.soils`, `artifact:morphology.topography`, hydrology + climate artifacts as needed | `artifact:ecology.scoreLayers`, `artifact:ecology.occupancy.base` | Runs one score op per feature key. Scores are **independent** per feature (no cross-feature heuristics). This is also the right home for deterministic masks that define "reserved / unavailable" tiles for planners. |
 
-6. `ecology-wetlands`
-- Purpose: plan wetlands + wet placements deterministically.
-- Produces: `artifact:ecology.featureIntents.wetlands`.
+### `ecology-ice` (truth)
 
-7. `ecology-vegetation`
-- Purpose: plan vegetation feature intents deterministically.
-- Produces: `artifact:ecology.featureIntents.vegetation`.
+| Step | Required artifacts | Provides | Notes |
+| --- | --- | --- | --- |
+| `plan-ice` | `artifact:ecology.scoreLayers`, `artifact:ecology.occupancy.base`, `artifact:morphology.topography`, `artifact:ecology.biomeClassification` | `artifact:ecology.featureIntents.ice`, `artifact:ecology.occupancy.ice` | Calls `ops.planIce`. Deterministic thresholding + seeded tie-breaks only. Publishes the next occupancy snapshot. |
 
-### Planning order
+### `ecology-reefs` (truth)
 
-Truth planning order is:
+| Step | Required artifacts | Provides | Notes |
+| --- | --- | --- | --- |
+| `plan-reefs` | `artifact:ecology.scoreLayers`, `artifact:ecology.occupancy.ice`, `artifact:morphology.topography`, `artifact:ecology.biomeClassification` | `artifact:ecology.featureIntents.reefs`, `artifact:ecology.occupancy.reefs` | Calls `ops.planReefs`. Deterministic spacing/constraints; seeded tie-breaks only for exact ties. |
 
-`ecology-ice` -> `ecology-reefs` -> `ecology-wetlands` -> `ecology-vegetation`
+### `ecology-wetlands` (truth)
 
-This order is a contract and exists to support conflict-aware deterministic planning.
+| Step | Required artifacts | Provides | Notes |
+| --- | --- | --- | --- |
+| `plan-wetlands` | `artifact:ecology.scoreLayers`, `artifact:ecology.occupancy.reefs`, `artifact:morphology.topography`, hydrology artifacts as needed | `artifact:ecology.featureIntents.wetlands`, `artifact:ecology.occupancy.wetlands` | Calls `ops.planWetlands`. The planner is the joint resolver that consumes wet-family layers and codifies selection/constraints. **No disabled strategies; no probabilistic gating.** |
 
-### Projection stage
+### `ecology-vegetation` (truth)
 
-Keep `map-ecology` as one stage:
-- `plot-biomes`
-- `features-apply` (stamping/materialization; minimal deterministic adjustments)
-- `plot-effects` (note: plot-effects itself must be made deterministic and no-fudging in M3).
+| Step | Required artifacts | Provides | Notes |
+| --- | --- | --- | --- |
+| `plan-vegetation` | `artifact:ecology.scoreLayers`, `artifact:ecology.occupancy.wetlands`, `artifact:morphology.topography`, hydrology artifacts as needed | `artifact:ecology.featureIntents.vegetation`, `artifact:ecology.occupancy.vegetation` | Calls `ops.planVegetation`. The planner is the joint resolver that consumes vegetation layers and codifies selection/constraints. Deterministic selection + seeded tie-breaks only. |
 
-## Required Artifacts (high-level)
+### `map-ecology` (projection)
 
-Truth artifacts required across these stages (non-exhaustive; finalized in `CONTRACTS.md`):
-- `artifact:morphology.topography`
-- `artifact:hydrology.climateField`
-- `artifact:hydrology.hydrography`
-- `artifact:hydrology.cryosphere`
+| Step | Required artifacts | Provides | Tags | Notes |
+| --- | --- | --- | --- | --- |
+| `plot-biomes` | `artifact:ecology.biomeClassification`, `artifact:morphology.topography` | _none_ | `field:biomeId`, `effect:engine.biomesApplied` | Writes engine-facing biome fields deterministically from the truth classification. |
+| `features-apply` | `artifact:ecology.featureIntents.*` | _none_ | `field:featureType`, `effect:engine.featuresApplied` | Pure stamping/materialization. **Must not** probabilistically gate. If stamping would drop placements, that is a planner bug and fails gates. |
+| `plot-effects` | truth artifacts as needed (biomes, climate/topography/hydrology) | _none_ | `effect:engine.plotEffectsApplied` | Engine-facing effects are allowed here, but the implementation must be deterministic (no `rollPercent`, no chance knobs). If the current op is chance-based, M3 replaces it with deterministic thresholding driven by explicit score surfaces (still no output fudging). |
 
-## Open Implementation Choice (locked by end of packet)
+## Artifact + tag summary (M3 surfaces)
 
-Occupancy/conflict modeling:
-- (A) immutable occupancy snapshot artifact chain, or
-- (B) publish-once mutable handle posture.
+Truth artifacts:
+- `artifact:ecology.scoreLayers` (new): per-tile `Float32Array` scores for every feature key (see `CONTRACTS.md` for schema).
+- `artifact:ecology.occupancy.*` (new): immutable occupancy snapshots used to enforce cross-family conflict rules (see `CONTRACTS.md`).
+- `artifact:ecology.featureIntents.<family>` (existing ids): deterministic placements produced by planners.
 
-This is locked in `CONTRACTS.md` and enforced by M3 gates.
+Projection tags:
+- `field:biomeId`, `effect:engine.biomesApplied`
+- `field:featureType`, `effect:engine.featuresApplied`
+- `effect:engine.plotEffectsApplied`
+
+## Recipe wiring changes (M3 cutover)
+
+M3 replaces the single truth ecology stage entry in:
+- `mods/mod-swooper-maps/src/recipes/standard/recipe.ts`
+
+with the explicit ordered truth stages listed above, followed by the existing `mapEcology` projection stage.
+
+This is a topology change (behavior-changing milestone), so ids and ordering are treated as intentional cutover surfaces and are gated by the M3 issue suite.

--- a/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/VISION.md
+++ b/docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/VISION.md
@@ -1,0 +1,66 @@
+# Vision: M3 Ecology Physics-First Feature Scoring + Planning
+
+## TL;DR
+
+We are refactoring Ecology to be **physics-first**, **architecturally legible**, and **deterministic**, with a clean causal spine:
+
+1. **Truth produces independent per-tile score layers for every feature**.
+2. **Truth planning consumes those layers** to produce a deterministic, conflict-aware plan.
+3. **Projection stamps/materializes** that plan into engine fields/effects.
+
+This is a forward-only cutover. We will break legacy surfaces, replace them, and delete the old paths.
+
+## What We Are Optimizing For (in priority order)
+
+1. Developer DX (clear mental model; easy extension; minimal "where does this belong" confusion)
+2. Architectural clarity (stage/step/op/rule/strategy boundaries mean what they say)
+3. Maximal physical realism (scores encode physics signals; planners encode constraints)
+4. Determinism (repeatable outputs; seeded tie-breaks allowed)
+
+## Earth-System-First Stage Boundaries
+
+Stages exist because the domain reality exists:
+
+- Pedology (soil/ground substrate)
+- Biomes (classification + transitions as part of classification)
+- Vegetation (land plants)
+- Wetlands (marsh/bog/mangrove/oasis/watering-hole style features)
+- Reefs (marine ecology)
+- Ice (cryosphere feature layer)
+
+The pipeline should feel like an earth system, not a grab bag of "stuff we happened to compute." If splitting into more stages simplifies config and boundaries, we do it.
+
+## Architecture Semantics (non-negotiable)
+
+- **Stage**: config compilation boundary. Stages do not execute; steps execute.
+- **Step**: orchestration node. Reads artifacts/buffers; calls ops; publishes artifacts; emits viz.
+- **Op**: atomic algorithmic unit with explicit strategy envelope. Ops do not orchestrate other ops.
+- **Strategy**: variability inside an op, selected by `{ strategy, config }`.
+- **Rule**: op-local policy unit (scoring inputs, filters, thresholds); steps never import rules.
+
+## Non-Negotiables (behavioral posture)
+
+- **No legacy shims / dual paths**: no compatibility wrappers around bad ideas.
+- **No silent skips**: no `shouldRun`, no “disabled strategy,” no optional ops by omission.
+- **No output fudging**:
+  - no chance percentages
+  - no multipliers/bonuses that gate output
+  - no probabilistic edges/jitter that changes outcomes
+  - seeded tie-breakers are allowed only to break ties, not to decide whether something exists
+- **Score independence**: score layers are computed independently (no cross-feature heuristics baked into score ops).
+- **Planning is codified**: combining and selecting between layers is a planning-op concern.
+- **Projection is a modding layer later**: projection can apply deterministic adjustments for gameplay in later milestones, but M3 keeps projection minimal and deterministic.
+
+## Success Definition
+
+After M3:
+- there is an explicit `artifact:ecology.scoreLayers` (or equivalent) containing per-tile scores for every feature.
+- truth planning produces a single deterministic plan (ordered; conflict-aware; no random gating).
+- projection stamping does not "fix" planner bugs; it simply materializes.
+
+## Failure Modes We Refuse
+
+- “Works on my machine” randomness.
+- Plans that depend on chance knobs.
+- Cross-feature circular dependencies resolved by smuggling other scores into score functions.
+- A mega-step or mega-op that becomes an architectural sink.

--- a/docs/projects/pipeline-realism/scratch/ORCH-M3-ecology.md
+++ b/docs/projects/pipeline-realism/scratch/ORCH-M3-ecology.md
@@ -1,0 +1,67 @@
+# ORCH: M3 Ecology Physics-First Feature Scoring + Planning (Pipeline-Realism)
+
+Status: ACTIVE (orchestrator scratch plan; keep concise; update at phase boundaries)
+Owner: agent-codex
+Branch/worktree: `agent-codex-m3-ecology-physics-first-plan` / `wt-agent-codex-m3-ecology-physics-first-plan`
+
+## North Star (Human Vision)
+
+- Earth-system-first stage splits (pedology, biomes, vegetation, wetlands, reefs, ice).
+- Architecture semantics are sacred: stages compile configs; steps orchestrate; ops compute; strategies encode variants; rules encode policy inputs.
+- Physics truth first; later projection is the modding layer.
+- No legacy shims/dual paths. Break surfaces, build new ones, polish them.
+- No output fudging: no chance percentages, multipliers, probabilistic gating. Deterministic selection + seeded tie-breaks only.
+
+## Outputs We Must Produce (docs are the product for this branch)
+
+1. Packet: `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/`
+2. Milestone: `docs/projects/pipeline-realism/milestones/M3-ecology-physics-first-feature-planning.md`
+3. Local issue docs: `docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-*.md`
+4. Prework sweep complete: zero remaining `## Prework Prompt (Agent Brief)` in the M3 issue scope.
+
+## Phase Checklist (stop at gates)
+
+### Phase 0: Context + anchor
+- [ ] Confirm M2 is existing architecture-alignment plan: `docs/projects/pipeline-realism/milestones/M2-ecology-architecture-alignment.md`
+- [ ] Treat engine-refactor-v1 as evidence only.
+- [ ] Packet becomes execution authority.
+
+### Phase 1: Vision capture
+- [ ] Write `PACKET.../VISION.md` first.
+- [ ] Ensure every agent reads it first.
+
+### Phase 2/3: Decision-complete architecture + contracts
+- [ ] Stage list + step list is explicit.
+- [ ] `artifact:ecology.scoreLayers` schema is explicit.
+- [ ] Per-feature score layer inventory is explicit.
+- [ ] Planning order + conflict model is explicit.
+- [ ] “Must not exist” list is explicit.
+
+### Phase 4-7: Workflows
+- [ ] Spec -> milestone (`dev-spec-to-milestone` posture)
+- [ ] Harden milestone (`dev-harden-milestone` posture)
+- [ ] Milestone -> issues (`dev-milestone-to-issues` posture)
+- [ ] Prework sweep (`dev-prework-sweep` posture)
+
+## Non-Negotiable Gates
+
+- Determinism and no-fudging posture is encoded as:
+  - static scan gates (patterns + allowlists)
+  - runtime invariants (diagnostic dumps/diffs + tests)
+- No silent skips / no shouldRun.
+- Steps do not import op impls or rules.
+
+## Agent Team (peers; each keeps scratch)
+
+- ARCH: stage topology + truth/projection invariants + recipe wiring
+- SCORE: feature inventory + scoreLayers schema + scoring ops/rules catalog
+- PLAN: planners + occupancy/conflict model + deterministic tie-break policy
+- VIZ: viz keys + deck.gl identity + inventory gates
+- GATES: tests/guardrails + static scan gates
+
+Scratch files (untracked; clear per phase):
+- `docs/projects/pipeline-realism/scratch/agent-ARCH-M3.scratch.md`
+- `docs/projects/pipeline-realism/scratch/agent-SCORE-M3.scratch.md`
+- `docs/projects/pipeline-realism/scratch/agent-PLAN-M3.scratch.md`
+- `docs/projects/pipeline-realism/scratch/agent-VIZ-M3.scratch.md`
+- `docs/projects/pipeline-realism/scratch/agent-GATES-M3.scratch.md`

--- a/docs/projects/pipeline-realism/scratch/ORCH-M3-ecology.md
+++ b/docs/projects/pipeline-realism/scratch/ORCH-M3-ecology.md
@@ -51,6 +51,15 @@ Branch/worktree: `agent-codex-m3-ecology-physics-first-plan` / `wt-agent-codex-m
 - No silent skips / no shouldRun.
 - Steps do not import op impls or rules.
 
+## Tooling Notes (Do Not Forget)
+
+- Prefer `$narsil-mcp` for semantic code discovery and impact analysis.
+  - Do **not** use `hybrid_search` (currently crashes the server in this environment).
+  - Native tools (`rg`, `git`, file reads) are still preferred for bulk/fast scans.
+- MCP freshness depends on the primary checkout:
+  - Keep `/Users/mateicanavra/Documents/.nosync/DEV/civ7-modding-tools` checked out on the latest changes (can be detached HEAD).
+  - Work happens in worktrees; the primary checkout is for keeping the index current.
+
 ## Agent Team (peers; each keeps scratch)
 
 - ARCH: stage topology + truth/projection invariants + recipe wiring

--- a/docs/projects/pipeline-realism/scratch/ORCH-M3-ecology.md
+++ b/docs/projects/pipeline-realism/scratch/ORCH-M3-ecology.md
@@ -1,6 +1,7 @@
 # ORCH: M3 Ecology Physics-First Feature Scoring + Planning (Pipeline-Realism)
 
 Status: ACTIVE (orchestrator scratch plan; keep concise; update at phase boundaries)
+Last updated: 2026-02-09
 Owner: agent-codex
 Branch/worktree: `agent-codex-m3-ecology-physics-first-plan` / `wt-agent-codex-m3-ecology-physics-first-plan`
 
@@ -18,6 +19,12 @@ Branch/worktree: `agent-codex-m3-ecology-physics-first-plan` / `wt-agent-codex-m
 2. Milestone: `docs/projects/pipeline-realism/milestones/M3-ecology-physics-first-feature-planning.md`
 3. Local issue docs: `docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-*.md`
 4. Prework sweep complete: zero remaining `## Prework Prompt (Agent Brief)` in the M3 issue scope.
+
+Current status:
+- Packet: DONE (decision-complete; topology/contracts aligned)
+- Milestone: DONE (derived from packet; "M3 remediates M2" framing explicit)
+- Issues: DONE (M3-001..009; no prework prompts)
+- Phase runbooks: DONE (phase 0..8 runbooks under packet)
 
 ## Phase Checklist (stop at gates)
 
@@ -42,6 +49,12 @@ Branch/worktree: `agent-codex-m3-ecology-physics-first-plan` / `wt-agent-codex-m
 - [ ] Harden milestone (`dev-harden-milestone` posture)
 - [ ] Milestone -> issues (`dev-milestone-to-issues` posture)
 - [ ] Prework sweep (`dev-prework-sweep` posture)
+
+Note: for M3 docs, we executed the posture manually and captured it in packet runbooks:
+- `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-4-spec-to-milestone.md`
+- `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-5-harden-milestone.md`
+- `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-6-milestone-to-issues.md`
+- `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/RUNBOOKS/PHASE-7-prework-sweep.md`
 
 ## Non-Negotiable Gates
 


### PR DESCRIPTION
docs(pipeline-realism): start M3 ecology packet

docs(pipeline-realism): add M3 phase runbooks

docs(pipeline-realism): add M3 architecture+contracts

docs(pipeline-realism): finalize M3 packet topology/contracts

docs(pipeline-realism): add execution-ready M3 issue set

docs(pipeline-realism): add M3 phase runbooks and orch status

docs(pipeline-realism): fix M3 issue breadcrumbs to match repo