### PR TITLE
refactor(ecology): enforce strict feature stamping with no probabilistic gating

### DIFF
--- a/docs/projects/pipeline-realism/scratch/ORCH-PLAN-M3-ecology-execution.md
+++ b/docs/projects/pipeline-realism/scratch/ORCH-PLAN-M3-ecology-execution.md
@@ -2,13 +2,13 @@
 
 ## Breadcrumbs
 - Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-MAMBO-M3-ecology-physics-first`
-- Stack tip branch: `codex/MAMBO-m3-012-fix-biomes-stripes` (parent: `codex/MAMBO-m3-011-canonical-docs-sweep`; base: `main`)
-- Draft PRs: M3-002 `#1223`, M3-003 `#1224`, M3-004 `#1225`, M3-005 `#1226`, M3-006 `#1227`, M3-007 `#1228`, M3-008 `#1229`, M3-009 `#1230`, M3-010 `#1231`, M3-011 `#1232`, M3-012 `#1233`
+- Branch: `codex/MAMBO-m3-008-stamping-strict-features-apply` (parent: `codex/MAMBO-m3-007-plan-vegetation-deterministic`; base: `main`)
+- Draft PRs: M3-002 `#1223`, M3-003 `#1224`, M3-004 `#1225`, M3-005 `#1226`, M3-006 `#1227`, M3-007 `#1228`
 - Packet: `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/`
   - Authority order: `VISION.md` -> `TOPOLOGY.md` -> `CONTRACTS.md` -> `DECISIONS.md`
-- Current issue: `docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-012-fix-biomes-horizontal-stripes.md`
+- Current issue: `docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-008-projection-stamping-strictness-features-apply-must-not-drop-or-randomly-gate.md`
 
-## Slice Checklist (M3-001..012)
+## Slice Checklist (M3-001..009)
 - [x] M3-001 Packet harden: topology/contracts/gates (verification-only unless drift)
 - [x] M3-002 Stage split: earth-system-first truth stages + recipe wiring cutover
 - [x] M3-003 ScoreLayers: schema + independent per-feature score ops + base occupancy
@@ -16,13 +16,14 @@
 - [x] M3-005 Deterministic planning: reefs (consume scoreLayers + occupancy; add missing reef-family features)
 - [x] M3-006 Deterministic planning: wetlands (joint resolver; no disabled strategies)
 - [x] M3-007 Deterministic planning: vegetation (joint resolver over score layers)
-- [x] M3-008 Projection strictness: stamping must not drop placements or randomly gate (add gates)
-- [x] M3-009 Cleanup: delete chance/multiplier paths; update tests + viz inventories (and enforce explicit viz palettes)
-- [x] M3-010 Post-cutover cleanup: plot-effects score ops split + stable viz categories + preset sync
-- [x] M3-011 Canonical docs sweep: ecology config reference + directional intent
-- [x] M3-012 Bugfix: biomes horizontal stripe banding (and ensure biomes inputs are correctly wired)
+- [ ] M3-008 Projection strictness: stamping must not drop placements or randomly gate (add gates)
+- [ ] M3-009 Cleanup: delete chance/multiplier paths; update tests + viz inventories (and enforce explicit viz palettes)
 
-Current pointer: **M3 COMPLETE**
+Future slices (post M3-009):
+- [ ] M3-010 Post-cutover cleanup (dedicated cleanup slice; after M3-009)
+- [ ] M3-011 Canonical docs sweep (dedicated docs sweep; after M3-010)
+
+Current pointer: **M3-008**
 
 ## Gates Checklist (Hard, Forward-Only)
 - [ ] No legacy shims/dual paths/wrappers
@@ -54,7 +55,6 @@ Current pointer: **M3 COMPLETE**
   - `bun run build`
   - `timeout 20s bun run dev:mapgen-studio` (exit code 124 OK if it started; fail only on early crash)
   - (Stamping slice only) `rg -n "createLabelRng" mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply -S | cat`
-  - (Worker init check) first action each slice: write a "CHECK-IN" line to `docs/projects/pipeline-realism/issues/MAMBO.scratch.md`
 
 ## Closure Notes
 
@@ -81,48 +81,3 @@ Current pointer: **M3 COMPLETE**
   - static scan: remaining `rollPercent|chance|multiplier` hits only in `plan-plot-effects` + a `noise.schema.ts` docstring
   - `bun run build` PASS
   - `timeout 20s bun run dev:mapgen-studio` reached Vite READY (exit `124` OK)
-
-### M3-008 (Stamping Strictness) DONE
-- Draft PR: `#1229`
-- Key behavior: `map-ecology/features-apply` is strict stamping (no RNG, no chance/weight gating, no silent drops). Unknown features and any rejected placements fail loudly with a rejection report.
-- Gates (local):
-  - `bun --cwd mods/mod-swooper-maps test test/ecology` PASS
-  - `diag:dump` rerun + `diag:diff` mismatches `0` (runId `b391a4d0...`, label `m3-stamp`)
-  - static scan: no `rollPercent|chance|createLabelRng(` in `ops/features-apply`
-  - `bun run build` PASS
-  - `timeout 20s bun run dev:mapgen-studio` reached Vite READY (exit `124` OK)
-
-### M3-009 (No-Fudging Cleanup) DONE
-- Draft PR: `#1230`
-- Key behavior:
-  - `plot-effects` is deterministic top-coverage selection (seeded tie-break only).
-  - Ecology baseline fixtures track viz keys and M3 truth artifacts.
-- Gates (local):
-  - `bun --cwd mods/mod-swooper-maps test test/ecology` PASS
-  - `diag:dump` rerun + `diag:diff` mismatches `0` (runId `cc5296195...`, labels `m3-stamp-a`/`m3-stamp-b`)
-  - static scan: `0` hits in `mods/mod-swooper-maps/src/domain/ecology` for `rollPercent|coverageChance|chance|multiplier` (also gated by `no-fudging-static-scan` test)
-  - `bun run --cwd packages/civ7-adapter build` PASS
-  - `bun run --cwd packages/mapgen-viz build` PASS
-  - `bun run --cwd packages/mapgen-core build` PASS
-  - `bun run build` PASS
-  - `timeout 20s bun run dev:mapgen-studio` reached Vite READY (exit `124` OK)
-
-### M3-010 (Post-Cutover Cleanup) DONE
-- Draft PR: `#1231`
-- Notes:
-  - Split plot-effects scoring into separate ops (snow/sand/burned) and planner consumes score arrays + eligibility masks.
-  - Added stable categories/colors for plot-effects viz and meaningful tests around viz metadata.
-  - Fixed default preset JSON validity so `bun run build` + Studio startup stay green.
-
-### M3-011 (Canonical Docs Sweep) DONE
-- Notes:
-  - Updated canonical mapgen docs for stage order, ecology stage split, and schema posture (no `additionalProperties: false`; avoid manual stage `public`/`compile` unless truly needed).
-  - Added per-property descriptions + JSDoc for new/changed ecology config surfaces.
-
-### M3-012 (Biomes Stripe Banding Fix) DONE
-- Draft PR: `#1233`
-- Notes:
-  - Biomes consumes Hydrology `climateIndices` (surfaceTemperatureC/aridityIndex/freezeIndex) instead of re-deriving from latitude/elevation.
-  - Added truth viz layer `ecology.biome.biomeIndex` with stable explicit categories/colors.
-  - Added regression test ensuring within-row biome variety for fixed seed (prevents horizontal banding domination).
-  - Removed remaining `additionalProperties: false` annotations in the classify-biomes schema surface per compiler-closed-object posture.

--- a/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T07.md
+++ b/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T07.md
@@ -1,0 +1,15 @@
+# Outcome M4-T07
+
+- task: M4-T07
+- workBranch: codex/MAMBO-m3-008-stamping-strict-features-apply
+- fixBranch: agent-TOMMY-M4-T07-fix-mambo-m3-008-stamping-strict-features-ap-5cbbf9
+- classification: No actionable fix-now
+- workPR: #1229 (https://github.com/mateicanavra/civ7-modding-tools/pull/1229)
+- PR comment summary: unresolved review threads = 1 (see continuation ledger: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-pr-comments.md)
+- runtime-vs-viz: No new runtime-vs-viz mismatch observed in this continuation pass; runtime truth remains authoritative.
+- evidence:
+  - continuation manifest: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-manifest.tsv
+  - review entry: docs/projects/pipeline-realism/reviews/REVIEW-M4-ecology-placement-physics-continuum.md
+  - revalidation: n/a
+- supersedence: 
+- final recommendation: No branch-local change required now; keep covered by existing CI/regression checks and revisit only on new evidence.

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-apply/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-apply/strategies/default.ts
@@ -1,39 +1,55 @@
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 import FeaturesApplyContract from "../contract.js";
+
 type Placement = { x: number; y: number; feature: string; weight?: number };
+
+type TileBucket = {
+  x: number;
+  y: number;
+  placements: Placement[];
+};
 
 export const defaultStrategy = createStrategy(FeaturesApplyContract, "default", {
   run: (input, config) => {
     // Stamping is strict in M3: no probabilistic gating and no silent drops.
     // Any collision (multiple placements for a tile) is treated as a bug and fails loudly.
-    const seen = new Map<number, Placement[]>();
+    // Weight semantics are forbidden: allow only unset/1 so legacy fudging can't leak through.
+    const seen = new Map<string, TileBucket>();
+
     const merge = (placements: Placement[]) => {
       for (const placement of placements) {
         const x = placement.x | 0;
         const y = placement.y | 0;
-        const key = y * 65536 + x;
-        const list = seen.get(key) ?? [];
-        if (list.length >= config.maxPerTile) {
+
+        if (placement.weight != null && placement.weight !== 1) {
+          throw new Error(
+            `features-apply rejected non-unit weight: tile=(${x},${y}) feature=${placement.feature} weight=${placement.weight} (expected 1 or unset)`
+          );
+        }
+
+        const key = `${x},${y}`;
+        const tile = seen.get(key) ?? { x, y, placements: [] };
+        if (tile.placements.length >= config.maxPerTile) {
           throw new Error(
             `features-apply collision: tile=(${x},${y}) has >${config.maxPerTile} placements (example feature=${placement.feature})`
           );
         }
-        list.push({ ...placement, x, y });
-        seen.set(key, list);
+
+        // Normalize coords and weight so downstream consumers never see undefined/non-integer coords.
+        tile.placements.push({ ...placement, x, y, weight: placement.weight ?? 1 });
+        seen.set(key, tile);
       }
     };
+
     merge(input.ice);
     merge(input.reefs);
     merge(input.wetlands);
     merge(input.vegetation);
 
-    // Deterministic application order: sort by tile key (y-major, then x), preserving merge order within a tile.
-    const keys = [...seen.keys()].sort((a, b) => a - b);
+    // Deterministic application order: y-major, then x, preserving merge order within a tile.
     const merged: Placement[] = [];
-    for (const key of keys) {
-      const values = seen.get(key);
-      if (values) merged.push(...values);
-    }
+    const tiles = [...seen.values()].sort((a, b) => a.y - b.y || a.x - b.x);
+    for (const tile of tiles) merged.push(...tile.placements);
 
     return { placements: merged };
   },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/index.ts
@@ -2,7 +2,7 @@ import { createStep } from "@swooper/mapgen-core/authoring";
 import type { FeatureKey } from "@mapgen/domain/ecology";
 import { defineVizMeta, snapshotEngineHeightfield } from "@swooper/mapgen-core";
 import FeaturesApplyStepContract from "./contract.js";
-import { applyFeaturePlacements, reifyFeatureField } from "../features/apply.js";
+import { reifyFeatureField } from "../features/apply.js";
 import { resolveFeatureKeyLookups } from "../features/feature-keys.js";
 
 const GROUP_MAP_ECOLOGY = "Map / Ecology (Engine)";
@@ -23,21 +23,73 @@ export default createStep(FeaturesApplyStepContract, {
     );
 
     const lookups = resolveFeatureKeyLookups(context.adapter);
-    const filteredPlacements = merged.placements.filter(
-      (placement): placement is { x: number; y: number; feature: FeatureKey; weight?: number } =>
-        placement.feature in lookups.byKey
+    const unknown: string[] = [];
+    for (const placement of merged.placements) {
+      if (!(placement.feature in lookups.byKey)) unknown.push(placement.feature);
+    }
+    if (unknown.length > 0) {
+      const unique = [...new Set(unknown)].sort((a, b) => a.localeCompare(b));
+      throw new Error(
+        `features-apply rejected unknown feature keys: ${unique.slice(0, 12).join(", ")}${
+          unique.length > 12 ? ` (and ${unique.length - 12} more)` : ""
+        }`
+      );
+    }
+
+    const resolvedPlacements = merged.placements as Array<{
+      x: number;
+      y: number;
+      feature: FeatureKey;
+      weight?: number;
+    }>;
+
+    resolvedPlacements.sort(
+      (a, b) => a.y * context.dimensions.width + a.x - (b.y * context.dimensions.width + b.x)
     );
+
+    const { width, height } = context.dimensions;
+    const rejections: Array<{ x: number; y: number; feature: FeatureKey; reason: string }> = [];
+    let applied = 0;
+
+    for (const placement of resolvedPlacements) {
+      const x = placement.x | 0;
+      const y = placement.y | 0;
+      if (x < 0 || x >= width || y < 0 || y >= height) {
+        rejections.push({ x, y, feature: placement.feature, reason: "out-of-bounds" });
+        continue;
+      }
+      const featureIndex = lookups.byKey[placement.feature];
+      if (featureIndex == null || featureIndex < 0) {
+        rejections.push({ x, y, feature: placement.feature, reason: "unknown-feature-index" });
+        continue;
+      }
+      if (!context.adapter.canHaveFeature(x, y, featureIndex)) {
+        rejections.push({ x, y, feature: placement.feature, reason: "canHaveFeature=false" });
+        continue;
+      }
+      context.adapter.setFeatureType(x, y, { Feature: featureIndex, Direction: -1, Elevation: 0 });
+      applied += 1;
+    }
+
+    if (rejections.length > 0) {
+      const sample = rejections.slice(0, 12).map((r) => `(${r.x},${r.y}) ${r.feature} ${r.reason}`);
+      throw new Error(
+        `features-apply rejected ${rejections.length}/${resolvedPlacements.length} placements; sample: ${sample.join(
+          "; "
+        )}`
+      );
+    }
+
     const size = context.dimensions.width * context.dimensions.height;
     if (!context.fields.featureType || context.fields.featureType.length !== size) {
       context.fields.featureType = new Int16Array(size);
     }
-    const applied = applyFeaturePlacements(context, filteredPlacements, lookups);
     if (applied > 0) {
       reifyFeatureField(context);
       context.viz?.dumpGrid(context.trace, {
         dataTypeKey: "map.ecology.featureType",
         spaceId: TILE_SPACE_ID,
-        dims: { width: context.dimensions.width, height: context.dimensions.height },
+        dims: { width, height },
         format: "i16",
         values: context.fields.featureType,
       meta: defineVizMeta("map.ecology.featureType", {

--- a/mods/mod-swooper-maps/test/ecology/earthlike-balance-smoke.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/earthlike-balance-smoke.test.ts
@@ -10,7 +10,7 @@ import { BIOME_SYMBOL_TO_INDEX } from "@mapgen/domain/ecology/types.js";
 import { realismEarthlikeConfig } from "../../src/maps/presets/realism/earthlike.config.js";
 
 describe("Earthlike ecology balance (smoke)", () => {
-  it("has biome variety and non-zero vegetation without drowning coasts", () => {
+  it("has biome variety and non-zero vegetation without drowning coasts", { timeout: 15_000 }, () => {
     const width = 32;
     const height = 20;
     const seed = 1018;

--- a/mods/mod-swooper-maps/test/ecology/features-apply-strictness.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/features-apply-strictness.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+
+import ecology from "@mapgen/domain/ecology/ops";
+import { createMockAdapter } from "@civ7/adapter";
+import { createExtendedMapContext } from "@swooper/mapgen-core";
+import { implementArtifacts } from "@swooper/mapgen-core/authoring";
+import featuresApplyStep from "../../src/recipes/standard/stages/map-ecology/steps/features-apply/index.js";
+import { ecologyArtifacts } from "../../src/recipes/standard/stages/ecology/artifacts.js";
+import { normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
+import { buildTestDeps } from "../support/step-deps.js";
+
+describe("map-ecology features-apply strictness (M3-008)", () => {
+  it("fails loudly when intents contain unknown feature keys", () => {
+    const width = 2;
+    const height = 2;
+    const env = {
+      seed: 0,
+      dimensions: { width, height },
+      latitudeBounds: { topLatitude: 0, bottomLatitude: 0 },
+    };
+
+    const adapter = createMockAdapter({ width, height });
+    adapter.fillWater(false);
+    const ctx = createExtendedMapContext({ width, height }, adapter, env);
+
+    const stageArtifacts = implementArtifacts(
+      [
+        ecologyArtifacts.featureIntentsVegetation,
+        ecologyArtifacts.featureIntentsWetlands,
+        ecologyArtifacts.featureIntentsReefs,
+        ecologyArtifacts.featureIntentsIce,
+      ],
+      { featureIntentsVegetation: {}, featureIntentsWetlands: {}, featureIntentsReefs: {}, featureIntentsIce: {} }
+    );
+
+    stageArtifacts.featureIntentsVegetation.publish(ctx, [
+      { x: 0, y: 0, feature: "FEATURE_DOES_NOT_EXIST" },
+    ]);
+    stageArtifacts.featureIntentsWetlands.publish(ctx, []);
+    stageArtifacts.featureIntentsReefs.publish(ctx, []);
+    stageArtifacts.featureIntentsIce.publish(ctx, []);
+
+    const config = {
+      apply: normalizeOpSelectionOrThrow(ecology.ops.applyFeatures, { strategy: "default", config: {} }),
+    };
+    const ops = ecology.ops.bind(featuresApplyStep.contract.ops!).runtime;
+
+    expect(() => featuresApplyStep.run(ctx, config, ops, buildTestDeps(featuresApplyStep))).toThrow(
+      /unknown feature keys/i
+    );
+  });
+});
+


### PR DESCRIPTION
# Implement Strict Feature Stamping in Ecology Pipeline

This PR enforces strict feature stamping in the ecology pipeline, eliminating probabilistic behavior and silent failures:

- Replaced random feature placement with deterministic application
- Added strict validation that rejects:
  - Non-unit weights (must be 1 or unset)
  - Unknown feature keys
  - Out-of-bounds placements
  - Placements that exceed the maximum per tile
  - Placements that fail canHaveFeature checks
- Improved error reporting with detailed rejection reasons
- Ensured deterministic application order (y-major, then x)
- Added test coverage for feature application strictness
- Updated ecology test timeout to accommodate more thorough validation

This change ensures that feature placement is fully deterministic and that any issues are caught early with clear error messages rather than silently ignored.