### PR TITLE
docs(pipeline-realism): add post-cutover cleanup and bugfix issues

### DIFF
--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-010-post-cutover-cleanup.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-010-post-cutover-cleanup.md
@@ -1,0 +1,71 @@
+id: LOCAL-TBD-PR-M3-010
+title: Post-cutover cleanup: split plot-effects score ops + stabilize viz categories/colors + keep presets in sync
+state: planned
+priority: 2
+estimate: 8
+project: pipeline-realism
+milestone: M3-ecology-physics-first-feature-planning
+assignees: [codex]
+labels: [pipeline-realism]
+parent: null
+children: []
+blocked_by: [LOCAL-TBD-PR-M3-009]
+blocked: []
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+- Split plot-effects scoring into dedicated compute ops (snow/sand/burned), refactor placement to consume score arrays, and make plot-effects viz categorical mapping stable with explicit colors.
+
+## Deliverables
+- Add dedicated plot-effects score ops:
+  - `ecology/plot-effects/score/snow`
+  - `ecology/plot-effects/score/sand`
+  - `ecology/plot-effects/score/burned`
+- Refactor `ecology/plot-effects/placement` to:
+  - consume the score arrays (plus minimal masks/inputs)
+  - perform deterministic top-coverage selection
+  - use seeded RNG only as a tie-break for exact-equal scores
+- Refactor map-ecology plot-effects step to orchestrate: score ops -> placement op -> apply.
+- Stabilize plot-effects viz categories:
+  - replace dynamic `valueByKey` mapping with a stable key -> integer mapping
+  - provide explicit `meta.categories` entries with `value`, `label`, and `[r,g,b,a]` color tuples
+- Keep default preset/config in sync (earthlike):
+  - `$MOD/src/maps/configs/swooper-earthlike.config.json`
+  - `$MOD/src/presets/standard/earthlike.json`
+- Update tests meaningfully for the new ops and viz categories.
+
+## Acceptance Criteria
+- [ ] No chance/multiplier logic in plot-effects planning:
+  - no probabilistic gating
+  - seeded randomness only for tie-break ordering on exact equal scores
+- [ ] New score ops validate and are wired into the map-ecology plot-effects step.
+- [ ] Plot-effects viz uses stable category mapping with explicit colors (no dynamic category assignment).
+- [ ] Earthlike preset/config remain aligned for plot-effects configuration.
+
+## Testing / Verification
+- Slice gates:
+  - `bun --cwd mods/mod-swooper-maps test test/ecology`
+  - `bun run build`
+  - `timeout 20s bun run dev:mapgen-studio` (exit `124` OK if it started; fail only on early crash)
+- Determinism:
+  - `bun --cwd mods/mod-swooper-maps run diag:dump -- 106 66 1337 --label m3-010`
+  - rerun with same args yields identical outputs per `diag:diff` (empty)
+
+## Dependencies / Notes
+- Blocked by: `LOCAL-TBD-PR-M3-009`
+- This is a cleanup slice: deletions are a feature (no dual paths/wrappers/shims).
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Quick Navigation
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)
+

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-011-canonical-docs-sweep-ecology.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-011-canonical-docs-sweep-ecology.md
@@ -1,0 +1,54 @@
+id: LOCAL-TBD-PR-M3-011
+title: Canonical docs sweep: ecology architecture + config reference completeness post M3 cutover
+state: planned
+priority: 3
+estimate: 8
+project: pipeline-realism
+milestone: M3-ecology-physics-first-feature-planning
+assignees: [codex]
+labels: [pipeline-realism]
+parent: null
+children: []
+blocked_by: [LOCAL-TBD-PR-M3-010]
+blocked: []
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+- Sweep and harden canonical ecology docs so the post-cutover architecture and config surfaces are accurate, complete, and directional.
+
+## Deliverables
+- Update canonical (non-archived) ecology docs to reflect current M3 architecture and invariants:
+  - ops atomic; steps orchestrate; no ops calling ops
+  - score-then-plan determinism posture (seeded tie-break only)
+  - artifact contracts and stage boundaries after stage split
+- Ensure config properties are documented:
+  - every config property has description (schema) and JSDoc where appropriate
+- Ensure default preset/config and documented defaults match (no drift).
+
+## Acceptance Criteria
+- [ ] Canonical docs updated (no new archives) and aligned with current code + presets.
+- [ ] All ecology config surfaces that are exposed in recipe schemas have descriptions.
+- [ ] Build is green (docs changes must not break schema builds).
+
+## Testing / Verification
+- `bun run build`
+- (If docs changes touch schemas/contracts) `bun --cwd mods/mod-swooper-maps test test/ecology`
+
+## Dependencies / Notes
+- Blocked by: `LOCAL-TBD-PR-M3-010`
+- Do not move durable spec detail into issues; keep canonical truth in `docs/system/**` and link from Linear.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Quick Navigation
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)
+

--- a/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-012-fix-biomes-horizontal-stripes.md
+++ b/docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-012-fix-biomes-horizontal-stripes.md
@@ -1,0 +1,58 @@
+id: LOCAL-TBD-PR-M3-012
+title: Bugfix: biomes horizontal stripe banding (grassland/tundra/rainforest dominate) + downstream fallout
+state: planned
+priority: 2
+estimate: 8
+project: pipeline-realism
+milestone: M3-ecology-physics-first-feature-planning
+assignees: [codex]
+labels: [pipeline-realism, bug]
+parent: null
+children: []
+blocked_by: [LOCAL-TBD-PR-M3-011]
+blocked: []
+related_to: []
+---
+
+<!-- SECTION SCOPE [SYNC] -->
+## TL;DR
+- Investigate and fix a biomes banding bug where only a few biomes dominate in large horizontal stripes; ensure downstream ecology calcs consume correct, non-banded climate layers.
+
+## Deliverables
+- Root cause identified (wiring/indexing/artifact consumption) with a minimal fix.
+- Add a regression test that would fail under the banding bug and pass with the fix.
+- Confirm downstream ecology (vegetation/wetlands/reefs/ice/plot-effects) consumes the correct artifacts post stage split (no silent fallbacks).
+
+## Acceptance Criteria
+- [ ] Biomes output no longer exhibits map-wide horizontal stripe domination for fixed seeds.
+- [ ] Climate truth layers (temp/moisture/aridity/freeze) are verified non-banded, and biomes correctly reflect them.
+- [ ] Determinism preserved (repeat run for fixed seed is identical via `diag:diff`).
+
+## Testing / Verification
+- Repro + determinism:
+  - `bun --cwd mods/mod-swooper-maps run diag:dump -- 106 66 1337 --label m3-012`
+  - rerun and `diag:diff` is empty
+- Targeted tests (to be defined once the fix is localized):
+  - `bun --cwd mods/mod-swooper-maps test test/ecology`
+
+## Dependencies / Notes
+- Blocked by: `LOCAL-TBD-PR-M3-011` (do not start implementation until the docs sweep is closed).
+
+### Investigation Checklist
+- Verify upstream climate layers (temperature/moisture/aridity/freeze) are not already banded.
+- Check typed-array indexing (`idx = y * width + x`) everywhere; banding often indicates swapped/incorrect indexing.
+- Confirm biomes stage is consuming the right artifacts post stage split (no silent fallback to latitude bands).
+- Confirm noise/humidity sources are wired and not constant.
+
+---
+
+<!-- SECTION IMPLEMENTATION [NOSYNC] -->
+## Implementation Details (Local Only)
+
+### Quick Navigation
+- [TL;DR](#tldr)
+- [Deliverables](#deliverables)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Testing / Verification](#testing--verification)
+- [Dependencies / Notes](#dependencies--notes)
+

--- a/docs/projects/pipeline-realism/milestones/M3-ecology-physics-first-feature-planning.md
+++ b/docs/projects/pipeline-realism/milestones/M3-ecology-physics-first-feature-planning.md
@@ -76,13 +76,17 @@ This milestone is an index. Full detail lives in `$PACKET/EXECUTION-PLAN.md` and
 - [ ] `LOCAL-TBD-PR-M3-007`: Deterministic planning: vegetation
 - [ ] `LOCAL-TBD-PR-M3-008`: Projection stamping strictness + gates
 - [ ] `LOCAL-TBD-PR-M3-009`: Delete legacy chance/multiplier paths + update tests/viz inventories
+- [ ] `LOCAL-TBD-PR-M3-010`: Post-cutover cleanup: plot-effects score ops split + stable viz categories + preset sync
+- [ ] `LOCAL-TBD-PR-M3-011`: Canonical docs sweep: ecology config reference + directional intent
+- [ ] `LOCAL-TBD-PR-M3-012`: Bugfix: biomes horizontal stripe banding
 
 ## Sequencing & Parallelization Plan
 
 **Stacks Overview**
 - Stack A (sequential unblockers): `M3-001` -> `M3-002` -> `M3-003`
 - Stack B (parallel planners after substrate+scoreLayers): `M3-004..007`
-- Stack C (sequential integration): `M3-008` -> `M3-009`
+- Stack C (sequential integration): `M3-008` -> `M3-009` -> `M3-010`
+- Stack D (post-cutover): `M3-011` -> `M3-012`
 
 ## Notes
 

--- a/docs/projects/pipeline-realism/scratch/ORCH-PLAN-M3-ecology-execution.md
+++ b/docs/projects/pipeline-realism/scratch/ORCH-PLAN-M3-ecology-execution.md
@@ -2,13 +2,13 @@
 
 ## Breadcrumbs
 - Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-MAMBO-M3-ecology-physics-first`
-- Branch: `codex/MAMBO-m3-008-stamping-strict-features-apply` (parent: `codex/MAMBO-m3-007-plan-vegetation-deterministic`; base: `main`)
-- Draft PRs: M3-002 `#1223`, M3-003 `#1224`, M3-004 `#1225`, M3-005 `#1226`, M3-006 `#1227`, M3-007 `#1228`
+- Branch: `codex/MAMBO-m3-010-post-cutover-cleanup` (parent: `codex/MAMBO-m3-009-cleanup-delete-legacy-chance`; base: `main`)
+- Draft PRs: M3-002 `#1223`, M3-003 `#1224`, M3-004 `#1225`, M3-005 `#1226`, M3-006 `#1227`, M3-007 `#1228`, M3-008 `#1229`, M3-009 `#1230`, M3-010 `#1231`
 - Packet: `docs/projects/pipeline-realism/resources/packets/PACKET-M3-ecology-physics-first/`
   - Authority order: `VISION.md` -> `TOPOLOGY.md` -> `CONTRACTS.md` -> `DECISIONS.md`
-- Current issue: `docs/projects/pipeline-realism/issues/LOCAL-TBD-PR-M3-008-projection-stamping-strictness-features-apply-must-not-drop-or-randomly-gate.md`
+- Current issue: M3-010 post-cutover cleanup (draft PR `#1231`; issue doc TBD)
 
-## Slice Checklist (M3-001..009)
+## Slice Checklist (M3-001..012)
 - [x] M3-001 Packet harden: topology/contracts/gates (verification-only unless drift)
 - [x] M3-002 Stage split: earth-system-first truth stages + recipe wiring cutover
 - [x] M3-003 ScoreLayers: schema + independent per-feature score ops + base occupancy
@@ -16,14 +16,17 @@
 - [x] M3-005 Deterministic planning: reefs (consume scoreLayers + occupancy; add missing reef-family features)
 - [x] M3-006 Deterministic planning: wetlands (joint resolver; no disabled strategies)
 - [x] M3-007 Deterministic planning: vegetation (joint resolver over score layers)
-- [ ] M3-008 Projection strictness: stamping must not drop placements or randomly gate (add gates)
-- [ ] M3-009 Cleanup: delete chance/multiplier paths; update tests + viz inventories (and enforce explicit viz palettes)
+- [x] M3-008 Projection strictness: stamping must not drop placements or randomly gate (add gates)
+- [x] M3-009 Cleanup: delete chance/multiplier paths; update tests + viz inventories (and enforce explicit viz palettes)
+- [ ] M3-010 Post-cutover cleanup: plot-effects score ops split + stable viz categories + preset sync
+- [ ] M3-011 Canonical docs sweep: ecology config reference + directional intent
+- [ ] M3-012 Bugfix: biomes horizontal stripe banding (and ensure biomes inputs are correctly wired)
 
 Future slices (post M3-009):
-- [ ] M3-010 Post-cutover cleanup (dedicated cleanup slice; after M3-009)
 - [ ] M3-011 Canonical docs sweep (dedicated docs sweep; after M3-010)
+- [ ] M3-012 Biomes banding fix (after M3-011)
 
-Current pointer: **M3-008**
+Current pointer: **M3-010**
 
 ## Gates Checklist (Hard, Forward-Only)
 - [ ] No legacy shims/dual paths/wrappers
@@ -81,3 +84,35 @@ Current pointer: **M3-008**
   - static scan: remaining `rollPercent|chance|multiplier` hits only in `plan-plot-effects` + a `noise.schema.ts` docstring
   - `bun run build` PASS
   - `timeout 20s bun run dev:mapgen-studio` reached Vite READY (exit `124` OK)
+
+### M3-008 (Stamping Strictness) DONE
+- Draft PR: `#1229`
+- Key behavior: `map-ecology/features-apply` is strict stamping (no RNG, no chance/weight gating, no silent drops). Unknown features and any rejected placements fail loudly with a rejection report.
+- Gates (local):
+  - `bun --cwd mods/mod-swooper-maps test test/ecology` PASS
+  - `diag:dump` rerun + `diag:diff` mismatches `0` (runId `b391a4d0...`, label `m3-stamp`)
+  - static scan: no `rollPercent|chance|createLabelRng(` in `ops/features-apply`
+  - `bun run build` PASS
+  - `timeout 20s bun run dev:mapgen-studio` reached Vite READY (exit `124` OK)
+
+### M3-009 (No-Fudging Cleanup) DONE
+- Draft PR: `#1230`
+- Key behavior:
+  - `plot-effects` is deterministic top-coverage selection (seeded tie-break only).
+  - Ecology baseline fixtures track viz keys and M3 truth artifacts.
+- Gates (local):
+  - `bun --cwd mods/mod-swooper-maps test test/ecology` PASS
+  - `diag:dump` rerun + `diag:diff` mismatches `0` (runId `cc5296195...`, labels `m3-stamp-a`/`m3-stamp-b`)
+  - static scan: `0` hits in `mods/mod-swooper-maps/src/domain/ecology` for `rollPercent|coverageChance|chance|multiplier` (also gated by `no-fudging-static-scan` test)
+  - `bun run --cwd packages/civ7-adapter build` PASS
+  - `bun run --cwd packages/mapgen-viz build` PASS
+  - `bun run --cwd packages/mapgen-core build` PASS
+  - `bun run build` PASS
+  - `timeout 20s bun run dev:mapgen-studio` reached Vite READY (exit `124` OK)
+
+### M3-010 (Post-Cutover Cleanup) IN PROGRESS
+- Draft PR: `#1231`
+- Key behavior (target):
+  - Plot effects follow the M3 posture: separate compute score ops (`ecology/plot-effects/score/snow|sand|burned`) and a planner op consuming those scores.
+  - `map.ecology.plotEffects.plotEffect` categorical viz declares explicit, stable categories/colors (no Studio auto palette).
+  - Default preset/config stays in sync with the new step op surface (`scoreSnow|scoreSand|scoreBurned|plotEffects`).

--- a/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T09.md
+++ b/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T09.md
@@ -1,0 +1,15 @@
+# Outcome M4-T09
+
+- task: M4-T09
+- workBranch: codex/MAMBO-m3-010-post-cutover-cleanup
+- fixBranch: agent-TOMMY-M4-T09-fix-mambo-m3-010-post-cutover-cleanup-5fefd4
+- classification: No actionable fix-now
+- workPR: #1231 (https://github.com/mateicanavra/civ7-modding-tools/pull/1231)
+- PR comment summary: unresolved review threads = 0 (see continuation ledger: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-pr-comments.md)
+- runtime-vs-viz: No new runtime-vs-viz mismatch observed in this continuation pass; runtime truth remains authoritative.
+- evidence:
+  - continuation manifest: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-manifest.tsv
+  - review entry: docs/projects/pipeline-realism/reviews/REVIEW-M4-ecology-placement-physics-continuum.md
+  - revalidation: n/a
+- supersedence: 
+- final recommendation: No branch-local change required now; keep covered by existing CI/regression checks and revisit only on new evidence.


### PR DESCRIPTION
# Add post-cutover ecology cleanup and bugfix issues

This PR adds three new issues to the pipeline-realism project for post-cutover cleanup and bugfixes:

1. **LOCAL-TBD-PR-M3-010**: Post-cutover cleanup for plot-effects, which:
   - Splits plot-effects scoring into dedicated compute ops (snow/sand/burned)
   - Refactors placement to consume score arrays with deterministic selection
   - Stabilizes visualization categories with explicit color mappings
   - Ensures presets and configs stay in sync

2. **LOCAL-TBD-PR-M3-011**: Documentation sweep for ecology architecture that:
   - Updates canonical docs to reflect the M3 architecture and invariants
   - Ensures all config properties are properly documented
   - Verifies alignment between docs, code, and presets

3. **LOCAL-TBD-PR-M3-012**: Bugfix for biomes horizontal stripe banding that:
   - Investigates and fixes the issue where few biomes dominate in horizontal stripes
   - Adds regression tests to prevent recurrence
   - Verifies downstream ecology calculations consume correct artifacts

The milestone sequencing plan is updated to include these new issues, with M3-010 added to Stack C (sequential integration) and a new Stack D for post-cutover work (M3-011 → M3-012).