### PR TITLE
docs(ecology): add descriptions to plot effects configuration schemas

### DIFF
--- a/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T10.md
+++ b/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T10.md
@@ -1,0 +1,15 @@
+# Outcome M4-T10
+
+- task: M4-T10
+- workBranch: codex/MAMBO-m3-011-canonical-docs-sweep
+- fixBranch: agent-TOMMY-M4-T10-fix-mambo-m3-011-canonical-docs-sweep-f6feb2
+- classification: No actionable fix-now
+- workPR: #1232 (https://github.com/mateicanavra/civ7-modding-tools/pull/1232)
+- PR comment summary: unresolved review threads = 0 (see continuation ledger: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-pr-comments.md)
+- runtime-vs-viz: No new runtime-vs-viz mismatch observed in this continuation pass; runtime truth remains authoritative.
+- evidence:
+  - continuation manifest: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-manifest.tsv
+  - review entry: docs/projects/pipeline-realism/reviews/REVIEW-M4-ecology-placement-physics-continuum.md
+  - revalidation: n/a
+- supersedence: 
+- final recommendation: No branch-local change required now; keep covered by existing CI/regression checks and revisit only on new evidence.

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plan-plot-effects/contract.ts
@@ -23,24 +23,54 @@ const PlotEffectsSnowSelectorsSchema = Type.Object({
 });
 
 const PlotEffectsSnowPlanSchema = Type.Object({
-  enabled: Type.Boolean({ default: true }),
+  enabled: Type.Boolean({ default: true, description: "Enable planning of snow plot effects." }),
   selectors: PlotEffectsSnowSelectorsSchema,
-  coveragePct: Type.Number({ default: 80, minimum: 0, maximum: 100 }),
-  lightThreshold: Type.Number({ default: 0.35, minimum: 0, maximum: 1 }),
-  mediumThreshold: Type.Number({ default: 0.6, minimum: 0, maximum: 1 }),
-  heavyThreshold: Type.Number({ default: 0.8, minimum: 0, maximum: 1 }),
+  coveragePct: Type.Number({
+    default: 80,
+    minimum: 0,
+    maximum: 100,
+    description: "Percent of eligible snow tiles to place (deterministic top-coverage selection).",
+  }),
+  lightThreshold: Type.Number({
+    default: 0.35,
+    minimum: 0,
+    maximum: 1,
+    description: "Minimum snowScore01 to place at least the light snow selector.",
+  }),
+  mediumThreshold: Type.Number({
+    default: 0.6,
+    minimum: 0,
+    maximum: 1,
+    description: "Minimum snowScore01 to place the medium snow selector.",
+  }),
+  heavyThreshold: Type.Number({
+    default: 0.8,
+    minimum: 0,
+    maximum: 1,
+    description: "Minimum snowScore01 to place the heavy snow selector.",
+  }),
 });
 
 const PlotEffectsSandPlanSchema = Type.Object({
-  enabled: Type.Boolean({ default: false }),
+  enabled: Type.Boolean({ default: false, description: "Enable planning of sand plot effects." }),
   selector: createPlotEffectSelectorSchema({ typeName: "PLOTEFFECT_SAND" }),
-  coveragePct: Type.Number({ default: 18, minimum: 0, maximum: 100 }),
+  coveragePct: Type.Number({
+    default: 18,
+    minimum: 0,
+    maximum: 100,
+    description: "Percent of eligible sand tiles to place (deterministic top-coverage selection).",
+  }),
 });
 
 const PlotEffectsBurnedPlanSchema = Type.Object({
-  enabled: Type.Boolean({ default: false }),
+  enabled: Type.Boolean({ default: false, description: "Enable planning of burned plot effects." }),
   selector: createPlotEffectSelectorSchema({ typeName: "PLOTEFFECT_BURNED" }),
-  coveragePct: Type.Number({ default: 8, minimum: 0, maximum: 100 }),
+  coveragePct: Type.Number({
+    default: 8,
+    minimum: 0,
+    maximum: 100,
+    description: "Percent of eligible burned tiles to place (deterministic top-coverage selection).",
+  }),
 });
 
 const PlotEffectKeySchema = Type.Unsafe<PlotEffectKey>(

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-burned/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-burned/contract.ts
@@ -18,12 +18,37 @@ const BiomeSymbolSchema = Type.Union(
 );
 
 const PlotEffectsScoreBurnedConfigSchema = Type.Object({
-  minAridity: Type.Number({ default: 0.45, minimum: 0, maximum: 1 }),
-  minTemperature: Type.Number({ default: 20 }),
-  maxFreeze: Type.Number({ default: 0.2, minimum: 0, maximum: 1 }),
-  maxVegetation: Type.Number({ default: 0.35, minimum: 0, maximum: 1 }),
-  maxMoisture: Type.Number({ default: 110, minimum: 0 }),
-  allowedBiomes: Type.Array(BiomeSymbolSchema, { default: ["temperateDry", "tropicalSeasonal"] }),
+  minAridity: Type.Number({
+    default: 0.45,
+    minimum: 0,
+    maximum: 1,
+    description: "Burned is eligible when aridityIndex >= minAridity (0..1).",
+  }),
+  minTemperature: Type.Number({
+    default: 20,
+    description: "Burned is eligible when surfaceTemperature >= minTemperature (C).",
+  }),
+  maxFreeze: Type.Number({
+    default: 0.2,
+    minimum: 0,
+    maximum: 1,
+    description: "Burned is eligible when freezeIndex <= maxFreeze (0..1).",
+  }),
+  maxVegetation: Type.Number({
+    default: 0.35,
+    minimum: 0,
+    maximum: 1,
+    description: "Burned is eligible when vegetationDensity <= maxVegetation (0..1).",
+  }),
+  maxMoisture: Type.Number({
+    default: 110,
+    minimum: 0,
+    description: "Burned is eligible when effectiveMoisture <= maxMoisture.",
+  }),
+  allowedBiomes: Type.Array(BiomeSymbolSchema, {
+    default: ["temperateDry", "tropicalSeasonal"],
+    description: "Biome symbols allowed to emit burned plot effects (allowlist).",
+  }),
 });
 
 const PlotEffectsScoreBurnedContract = defineOp({
@@ -56,4 +81,3 @@ const PlotEffectsScoreBurnedContract = defineOp({
 });
 
 export default PlotEffectsScoreBurnedContract;
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-sand/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-sand/contract.ts
@@ -18,12 +18,37 @@ const BiomeSymbolSchema = Type.Union(
 );
 
 const PlotEffectsScoreSandConfigSchema = Type.Object({
-  minAridity: Type.Number({ default: 0.55, minimum: 0, maximum: 1 }),
-  minTemperature: Type.Number({ default: 18 }),
-  maxFreeze: Type.Number({ default: 0.25, minimum: 0, maximum: 1 }),
-  maxVegetation: Type.Number({ default: 0.2, minimum: 0, maximum: 1 }),
-  maxMoisture: Type.Number({ default: 90, minimum: 0 }),
-  allowedBiomes: Type.Array(BiomeSymbolSchema, { default: ["desert", "temperateDry"] }),
+  minAridity: Type.Number({
+    default: 0.55,
+    minimum: 0,
+    maximum: 1,
+    description: "Sand is eligible when aridityIndex >= minAridity (0..1).",
+  }),
+  minTemperature: Type.Number({
+    default: 18,
+    description: "Sand is eligible when surfaceTemperature >= minTemperature (C).",
+  }),
+  maxFreeze: Type.Number({
+    default: 0.25,
+    minimum: 0,
+    maximum: 1,
+    description: "Sand is eligible when freezeIndex <= maxFreeze (0..1).",
+  }),
+  maxVegetation: Type.Number({
+    default: 0.2,
+    minimum: 0,
+    maximum: 1,
+    description: "Sand is eligible when vegetationDensity <= maxVegetation (0..1).",
+  }),
+  maxMoisture: Type.Number({
+    default: 90,
+    minimum: 0,
+    description: "Sand is eligible when effectiveMoisture <= maxMoisture.",
+  }),
+  allowedBiomes: Type.Array(BiomeSymbolSchema, {
+    default: ["desert", "temperateDry"],
+    description: "Biome symbols allowed to emit sand plot effects (allowlist).",
+  }),
 });
 
 const PlotEffectsScoreSandContract = defineOp({
@@ -56,4 +81,3 @@ const PlotEffectsScoreSandContract = defineOp({
 });
 
 export default PlotEffectsScoreSandContract;
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-snow/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/plot-effects-score-snow/contract.ts
@@ -10,20 +10,54 @@ const SnowElevationStrategySchema = Type.Union(
 );
 
 const PlotEffectsScoreSnowConfigSchema = Type.Object({
-  maxTemperature: Type.Number({ default: 4 }),
-  maxAridity: Type.Number({ default: 0.9, minimum: 0, maximum: 1 }),
-  freezeWeight: Type.Number({ default: 1, minimum: 0 }),
-  elevationWeight: Type.Number({ default: 1, minimum: 0 }),
-  moistureWeight: Type.Number({ default: 1, minimum: 0 }),
-  scoreNormalization: Type.Number({ default: 3, minimum: 0.0001 }),
-  scoreBias: Type.Number({ default: 0 }),
+  maxTemperature: Type.Number({
+    default: 4,
+    description: "Snow is eligible when surfaceTemperature <= maxTemperature (C).",
+  }),
+  maxAridity: Type.Number({
+    default: 0.9,
+    minimum: 0,
+    maximum: 1,
+    description: "Snow is eligible when aridityIndex <= maxAridity (0..1).",
+  }),
+  freezeWeight: Type.Number({
+    default: 1,
+    minimum: 0,
+    description: "Weight of freezeIndex contribution to the raw snow suitability score.",
+  }),
+  elevationWeight: Type.Number({
+    default: 1,
+    minimum: 0,
+    description: "Weight of elevation contribution to the raw snow suitability score.",
+  }),
+  moistureWeight: Type.Number({
+    default: 1,
+    minimum: 0,
+    description: "Weight of effectiveMoisture contribution to the raw snow suitability score.",
+  }),
+  scoreNormalization: Type.Number({
+    default: 3,
+    minimum: 0.0001,
+    description: "Divisor for raw score normalization before clamping to 0..1.",
+  }),
+  scoreBias: Type.Number({ default: 0, description: "Additive bias applied to the raw snow score." }),
   elevationStrategy: SnowElevationStrategySchema,
-  elevationMin: Type.Number({ default: 200 }),
-  elevationMax: Type.Number({ default: 2400 }),
-  elevationPercentileMin: Type.Number({ default: 0.7, minimum: 0, maximum: 1 }),
-  elevationPercentileMax: Type.Number({ default: 0.98, minimum: 0, maximum: 1 }),
-  moistureMin: Type.Number({ default: 40, minimum: 0 }),
-  moistureMax: Type.Number({ default: 160, minimum: 0 }),
+  elevationMin: Type.Number({ default: 200, description: "Minimum elevation used for elevation normalization (m)." }),
+  elevationMax: Type.Number({ default: 2400, description: "Maximum elevation used for elevation normalization (m)." }),
+  elevationPercentileMin: Type.Number({
+    default: 0.7,
+    minimum: 0,
+    maximum: 1,
+    description: "Minimum land elevation percentile used when elevationStrategy is percentile (0..1).",
+  }),
+  elevationPercentileMax: Type.Number({
+    default: 0.98,
+    minimum: 0,
+    maximum: 1,
+    description: "Maximum land elevation percentile used when elevationStrategy is percentile (0..1).",
+  }),
+  moistureMin: Type.Number({ default: 40, minimum: 0, description: "Minimum effectiveMoisture used for normalization." }),
+  moistureMax: Type.Number({ default: 160, minimum: 0, description: "Maximum effectiveMoisture used for normalization." }),
 });
 
 const PlotEffectsScoreSnowContract = defineOp({
@@ -51,4 +85,3 @@ const PlotEffectsScoreSnowContract = defineOp({
 });
 
 export default PlotEffectsScoreSnowContract;
-

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-effects/viz.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-effects/viz.ts
@@ -1,6 +1,6 @@
 import type { PlotEffectKey } from "@mapgen/domain/ecology";
 
-export const PLOT_EFFECT_VIZ_VALUE_BY_KEY: Readonly<Record<PlotEffectKey, number>> = {
+export const PLOT_EFFECT_VIZ_VALUE_BY_KEY: Readonly<Record<string, number>> = {
   PLOTEFFECT_SNOW_LIGHT_PERMANENT: 1,
   PLOTEFFECT_SNOW_MEDIUM_PERMANENT: 2,
   PLOTEFFECT_SNOW_HEAVY_PERMANENT: 3,


### PR DESCRIPTION
# Add descriptions to plot effects configuration parameters

This PR adds detailed descriptions to all configuration parameters in the plot effects system, making it clearer how each parameter affects snow, sand, and burned plot effects generation. The descriptions explain:

- Eligibility criteria for each effect type (temperature, aridity, moisture thresholds)
- How scoring and weighting works for snow effects
- Coverage percentages and selection mechanisms
- Biome allowlists and their purpose

The PR also fixes a type issue in the plot effects visualization by changing a strongly typed record to accept string keys.