### PR TITLE
fix(hydrology): call storeWaterData after generateLakes to update water tables

### DIFF
--- a/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T12.md
+++ b/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T12.md
@@ -1,0 +1,15 @@
+# Outcome M4-T12
+
+- task: M4-T12
+- workBranch: codex/MAMBO-m3-014-lakes-not-filled
+- fixBranch: agent-TOMMY-M4-T12-fix-mambo-m3-014-lakes-not-filled-993ca5
+- classification: Already tracked/superseded
+- workPR: #1234 (https://github.com/mateicanavra/civ7-modding-tools/pull/1234)
+- PR comment summary: unresolved review threads = 0 (see continuation ledger: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-pr-comments.md)
+- runtime-vs-viz: No new runtime-vs-viz mismatch observed in this continuation pass; runtime truth remains authoritative.
+- evidence:
+  - continuation manifest: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-manifest.tsv
+  - review entry: docs/projects/pipeline-realism/reviews/REVIEW-M4-ecology-placement-physics-continuum.md
+  - revalidation: n/a
+- supersedence: Superseded by codex/MAMBO-lakes-resources-waterfill-rootcause (PR #1238).
+- final recommendation: Accept supersedence and avoid duplicate changes on this branch.

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.ts
@@ -54,6 +54,12 @@ export default createStep(LakesStepContract, {
     });
 
     context.adapter.generateLakes(width, height, tilesPerLake);
+
+    // Civ's base-standard scripts run `generateLakes()` before `buildElevation()`, which implicitly
+    // refreshes engine water caches. Our pipeline runs `generateLakes()` after `buildElevation()`,
+    // so we must explicitly resync water tables here; otherwise `isWater()` (and downstream rendering)
+    // can treat lake tiles as land even if terrain was set to COAST.
+    context.adapter.storeWaterData();
     const physics = context.buffers.heightfield;
     const engine = snapshotEngineHeightfield(context);
     if (engine) {

--- a/mods/mod-swooper-maps/test/map-hydrology/lakes-store-water-data.test.ts
+++ b/mods/mod-swooper-maps/test/map-hydrology/lakes-store-water-data.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "bun:test";
+
+import { MockAdapter } from "@civ7/adapter";
+import { COAST_TERRAIN, FLAT_TERRAIN, createExtendedMapContext } from "@swooper/mapgen-core";
+import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
+
+import lakes from "../../src/recipes/standard/stages/map-hydrology/steps/lakes.js";
+import { buildTestDeps } from "../support/step-deps.js";
+
+class CachedWaterAdapter extends MockAdapter {
+  private cachedWater: Uint8Array;
+  readonly callOrder: string[] = [];
+
+  constructor(config: ConstructorParameters<typeof MockAdapter>[0]) {
+    super(config);
+    this.cachedWater = new Uint8Array(Math.max(0, this.width * this.height));
+  }
+
+  private idx2(x: number, y: number): number {
+    return y * this.width + x;
+  }
+
+  override isWater(x: number, y: number): boolean {
+    // Simulate Civ engine behavior: water can be backed by cached water tables,
+    // not recomputed automatically from terrain edits.
+    return this.cachedWater[this.idx2(x, y)] === 1;
+  }
+
+  override generateLakes(width: number, height: number, tilesPerLake: number): void {
+    this.callOrder.push("generateLakes");
+    super.generateLakes(width, height, tilesPerLake);
+
+    // Simulate engine lake generation: set terrain to COAST for a lake tile, but
+    // do NOT update the cached water tables.
+    this.setTerrainType(1, 1, COAST_TERRAIN);
+  }
+
+  override storeWaterData(): void {
+    this.callOrder.push("storeWaterData");
+
+    // Recompute cached water tables from plotted terrain.
+    const coast = this.getTerrainTypeIndex("TERRAIN_COAST");
+    const ocean = this.getTerrainTypeIndex("TERRAIN_OCEAN");
+    for (let y = 0; y < this.height; y++) {
+      for (let x = 0; x < this.width; x++) {
+        const t = this.getTerrainType(x, y) | 0;
+        this.cachedWater[this.idx2(x, y)] = t === coast || t === ocean ? 1 : 0;
+      }
+    }
+  }
+}
+
+describe("map-hydrology/lakes", () => {
+  it("calls storeWaterData after generateLakes so cached water tables reflect new lakes", () => {
+    const width = 4;
+    const height = 3;
+    const seed = 1234;
+    const mapInfo = {
+      GridWidth: width,
+      GridHeight: height,
+      MinLatitude: -60,
+      MaxLatitude: 60,
+      LakeGenerationFrequency: 5,
+    };
+    const env = {
+      seed,
+      dimensions: { width, height },
+      latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
+    };
+
+    const adapter = new CachedWaterAdapter({
+      width,
+      height,
+      mapInfo,
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
+      defaultTerrainType: FLAT_TERRAIN,
+    });
+    const context = createExtendedMapContext({ width, height }, adapter, env);
+
+    const size = width * height;
+    context.artifacts.set("artifact:morphology.topography", {
+      elevation: new Int16Array(size),
+      seaLevel: 0,
+      landMask: new Uint8Array(size).fill(1),
+      bathymetry: new Int16Array(size),
+    });
+    context.artifacts.set("artifact:hydrology.hydrography", {
+      runoff: new Float32Array(size),
+      discharge: new Float32Array(size),
+      riverClass: new Uint8Array(size),
+      sinkMask: new Uint8Array(size),
+      outletMask: new Uint8Array(size),
+    });
+
+    // Before running the step: cached water tables say "land".
+    expect(adapter.isWater(1, 1)).toBe(false);
+
+    lakes.run(context as any, { tilesPerLakeMultiplier: 1 }, {} as any, buildTestDeps(lakes));
+
+    expect(adapter.callOrder.slice(-2)).toEqual(["generateLakes", "storeWaterData"]);
+    // After storeWaterData: cached water tables reflect the new lake tile.
+    expect(adapter.isWater(1, 1)).toBe(true);
+  });
+});
+


### PR DESCRIPTION
# Fix lake rendering by explicitly refreshing water caches

This PR addresses an issue where lake tiles could be incorrectly treated as land in downstream rendering, despite having their terrain set to COAST.

The root cause is a pipeline ordering difference between our code and Civ's base scripts:
- Civ's scripts run `generateLakes()` before `buildElevation()`, which implicitly refreshes water caches
- Our pipeline runs `generateLakes()` after `buildElevation()`, requiring an explicit cache refresh

The fix adds a call to `storeWaterData()` after lake generation to ensure the engine's water tables are properly synchronized with the terrain changes.

Added a test that verifies:
1. Lake generation sets terrain to COAST but doesn't update water caches
2. The `storeWaterData()` call properly updates the cached water tables
3. The correct call sequence is maintained