### PR TITLE
fix(ecology): smooth tropical-temperate biome transitions to prevent latitude cutoffs

### DIFF
--- a/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/layers/classify.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/layers/classify.ts
@@ -50,11 +50,30 @@ export function classifyBiomesFromFields(args: {
     const freezeIndex = args.freezeIndex[i] ?? 0;
     const energy01 = clamp01((temperature - energyMin) / energyRange);
 
-    const tempZone = temperatureZoneOf(temperature, args.config.temperature);
+    const aridityShift = aridityShiftForIndex(aridity, args.config.aridity.moistureShiftThresholds);
     const moistureZone = shiftMoistureZone(
       moistureZoneOf(moisture, [dry, semiArid, subhumid, humidThreshold]),
-      aridityShiftForIndex(aridity, args.config.aridity.moistureShiftThresholds)
+      aridityShift
     );
+
+    const tropicalThreshold = args.config.temperature.tropicalThreshold;
+    const transitionBandC = 1.25;
+
+    let tempZone = temperatureZoneOf(temperature, args.config.temperature);
+    if (
+      (tempZone === "temperate" || tempZone === "tropical") &&
+      Math.abs(temperature - tropicalThreshold) <= transitionBandC
+    ) {
+      // Soft transition: use a stronger x-varying wetness signal (derived from rainfall + humidity)
+      // to prevent row-perfect biome cutoffs near the tropical threshold.
+      const transitionDenom = Math.max(1e-6, humidThreshold - subhumid);
+      const wetness01 = clamp01((moisture - subhumid) / transitionDenom);
+      const wetnessShiftC = (wetness01 - 0.5) * 2.0; // [-1C..+1C]
+      const wetnessShiftScaleC = 0.85;
+      const effectiveThreshold = tropicalThreshold - wetnessShiftC * wetnessShiftScaleC;
+      tempZone = temperature >= effectiveThreshold ? "tropical" : "temperate";
+    }
+
     const symbol = biomeSymbolForZones(tempZone, moistureZone);
     biomeIndex[i] = BIOME_SYMBOL_TO_INDEX[symbol]!;
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/layers/classify.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/layers/classify.ts
@@ -68,8 +68,9 @@ export function classifyBiomesFromFields(args: {
       // to prevent row-perfect biome cutoffs near the tropical threshold.
       const transitionDenom = Math.max(1e-6, humidThreshold - subhumid);
       const wetness01 = clamp01((moisture - subhumid) / transitionDenom);
-      const wetnessShiftC = (wetness01 - 0.5) * 2.0; // [-1C..+1C]
-      const wetnessShiftScaleC = 0.85;
+      const wetnessShiftRaw = (wetness01 - 0.55) * 2.0;
+      const wetnessShiftC = Math.max(-1, Math.min(1, wetnessShiftRaw)); // [-1C..+1C]
+      const wetnessShiftScaleC = 1.4;
       const effectiveThreshold = tropicalThreshold - wetnessShiftC * wetnessShiftScaleC;
       tempZone = temperature >= effectiveThreshold ? "tropical" : "temperate";
     }

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/rules/lookup.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/classify-biomes/rules/lookup.ts
@@ -23,7 +23,7 @@ const BIOME_LOOKUP: Record<
     semiArid: "temperateDry",
     subhumid: "temperateHumid",
     humid: "temperateHumid",
-    perhumid: "temperateHumid",
+    perhumid: "tropicalRainforest",
   },
   tropical: {
     arid: "desert",

--- a/mods/mod-swooper-maps/src/domain/hydrology/ops/compute-thermal-state/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/ops/compute-thermal-state/contract.ts
@@ -57,14 +57,14 @@ const ComputeThermalStateDefaultStrategySchema = Type.Object(
   {
     /** Global baseline temperature at sea level and mid-insolation. */
     baseTemperatureC: Type.Number({
-      default: 14,
+      default: 9,
       minimum: -40,
       maximum: 60,
       description: "Global baseline temperature at sea level and mid-insolation.",
     }),
     /** Temperature delta contributed by insolation forcing. */
     insolationScaleC: Type.Number({
-      default: 28,
+      default: 47,
       minimum: 0,
       maximum: 80,
       description: "Temperature delta contributed by insolation forcing.",

--- a/mods/mod-swooper-maps/src/domain/hydrology/shared/knob-multipliers.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/shared/knob-multipliers.ts
@@ -14,9 +14,9 @@ export const HYDROLOGY_DRYNESS_WETNESS_SCALE = {
 } as const satisfies Record<HydrologyDrynessKnob, number>;
 
 export const HYDROLOGY_TEMPERATURE_BASE_TEMPERATURE_C = {
-  cold: 6,
-  temperate: 14,
-  hot: 22,
+  cold: 4,
+  temperate: 9,
+  hot: 14,
 } as const satisfies Record<HydrologyTemperatureKnob, number>;
 
 export const HYDROLOGY_SEASONALITY_WIND_JET_STREAKS = {

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -327,8 +327,8 @@
       "computeThermalState": {
         "strategy": "default",
         "config": {
-          "baseTemperatureC": 14,
-          "insolationScaleC": 28,
+          "baseTemperatureC": 9,
+          "insolationScaleC": 47,
           "lapseRateCPerM": -0.0065,
           "landCoolingC": 2,
           "minC": -40,
@@ -399,15 +399,15 @@
         "strategy": "default",
         "config": {
           "equatorInsolation": 1,
-          "poleInsolation": 0.35,
+          "poleInsolation": 0.25,
           "latitudeExponent": 1.2
         }
       },
       "computeThermalState": {
         "strategy": "default",
         "config": {
-          "baseTemperatureC": 14,
-          "insolationScaleC": 28,
+          "baseTemperatureC": 9,
+          "insolationScaleC": 47,
           "lapseRateCPerM": -0.0065,
           "landCoolingC": 2,
           "minC": -40,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.ts
@@ -218,7 +218,14 @@ export default createStep(ClimateBaselineStepContract, {
             ...config.computeThermalState,
             config: {
               ...config.computeThermalState.config,
-              baseTemperatureC: config.computeThermalState.config.baseTemperatureC + temperatureDeltaC,
+              // Temperature knobs should not simply warm/cool the whole world uniformly (that erases tundra/snow).
+              // Instead, bias the baseline modestly and put most of the adjustment into the equator-to-pole contrast.
+              baseTemperatureC: config.computeThermalState.config.baseTemperatureC + temperatureDeltaC * 0.5,
+              insolationScaleC: clampNumber(
+                config.computeThermalState.config.insolationScaleC + temperatureDeltaC * 2,
+                0,
+                80
+              ),
             },
           }
         : config.computeThermalState;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/steps/climateRefine.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/steps/climateRefine.ts
@@ -120,7 +120,10 @@ export default createStep(ClimateRefineStepContract, {
           ...next.computeThermalState,
           config: {
             ...next.computeThermalState.config,
-            baseTemperatureC: next.computeThermalState.config.baseTemperatureC + deltaC,
+            // Temperature knobs should not simply warm/cool the whole world uniformly (that erases tundra/snow).
+            // Instead, bias the baseline modestly and put most of the adjustment into the equator-to-pole contrast.
+            baseTemperatureC: next.computeThermalState.config.baseTemperatureC + deltaC * 0.5,
+            insolationScaleC: Math.max(0, Math.min(80, next.computeThermalState.config.insolationScaleC + deltaC * 2)),
           },
         };
       }

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/index.ts
@@ -4,6 +4,7 @@ import { defineVizMeta, snapshotEngineHeightfield } from "@swooper/mapgen-core";
 import FeaturesApplyStepContract from "./contract.js";
 import { applyFeaturePlacements, reifyFeatureField } from "../features/apply.js";
 import { resolveFeatureKeyLookups } from "../features/feature-keys.js";
+import { buildFeatureTypeVizCategories } from "./viz.js";
 
 const GROUP_MAP_ECOLOGY = "Map / Ecology (Engine)";
 const TILE_SPACE_ID = "tile.hexOddR" as const;
@@ -34,16 +35,18 @@ export default createStep(FeaturesApplyStepContract, {
     const applied = applyFeaturePlacements(context, filteredPlacements, lookups);
     if (applied > 0) {
       reifyFeatureField(context);
+      const featureTypeCategories = buildFeatureTypeVizCategories(context.adapter);
       context.viz?.dumpGrid(context.trace, {
         dataTypeKey: "map.ecology.featureType",
         spaceId: TILE_SPACE_ID,
         dims: { width: context.dimensions.width, height: context.dimensions.height },
         format: "i16",
         values: context.fields.featureType,
-      meta: defineVizMeta("map.ecology.featureType", {
+        meta: defineVizMeta("map.ecology.featureType", {
           label: "Feature Type (Engine)",
           group: GROUP_MAP_ECOLOGY,
           palette: "categorical",
+          categories: featureTypeCategories,
         }),
       });
       context.adapter.validateAndFixTerrain();

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/index.ts
@@ -35,7 +35,10 @@ export default createStep(FeaturesApplyStepContract, {
     const applied = applyFeaturePlacements(context, filteredPlacements, lookups);
     if (applied > 0) {
       reifyFeatureField(context);
-      const featureTypeCategories = buildFeatureTypeVizCategories(context.adapter);
+      const featureTypeCategories = buildFeatureTypeVizCategories(
+        context.adapter,
+        context.fields.featureType
+      );
       context.viz?.dumpGrid(context.trace, {
         dataTypeKey: "map.ecology.featureType",
         spaceId: TILE_SPACE_ID,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/viz.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/viz.ts
@@ -1,0 +1,79 @@
+import type { EngineAdapter } from "@civ7/adapter";
+import { FEATURE_PLACEMENT_KEYS, type FeatureKey } from "@mapgen/domain/ecology";
+
+export type VizCategory = Readonly<{
+  value: number;
+  label: string;
+  color: readonly [number, number, number, number];
+}>;
+
+export const FEATURE_TYPE_NONE_VALUE = -1;
+
+export const FEATURE_TYPE_VIZ_COLORS_BY_KEY: Readonly<Record<FeatureKey, VizCategory["color"]>> = {
+  FEATURE_FOREST: [34, 197, 94, 235],
+  FEATURE_RAINFOREST: [21, 128, 61, 235],
+  FEATURE_TAIGA: [16, 185, 129, 235],
+  FEATURE_SAVANNA_WOODLAND: [234, 179, 8, 235],
+  FEATURE_SAGEBRUSH_STEPPE: [180, 83, 9, 235],
+  FEATURE_MARSH: [74, 222, 128, 235],
+  FEATURE_TUNDRA_BOG: [148, 163, 184, 235],
+  FEATURE_MANGROVE: [101, 163, 13, 235],
+  FEATURE_OASIS: [6, 182, 212, 235],
+  FEATURE_WATERING_HOLE: [59, 130, 246, 235],
+  FEATURE_REEF: [14, 165, 233, 235],
+  FEATURE_COLD_REEF: [37, 99, 235, 235],
+  FEATURE_ATOLL: [125, 211, 252, 235],
+  FEATURE_LOTUS: [244, 114, 182, 235],
+  FEATURE_ICE: [255, 255, 255, 240],
+} as const;
+
+const NONE_CATEGORY: VizCategory = Object.freeze({
+  value: FEATURE_TYPE_NONE_VALUE,
+  label: "None",
+  color: [148, 163, 184, 0],
+});
+
+function colorForKey(key: FeatureKey): VizCategory["color"] {
+  const color = FEATURE_TYPE_VIZ_COLORS_BY_KEY[key];
+  if (!color) throw new Error(`Missing FEATURE_TYPE_VIZ_COLORS_BY_KEY entry for "${key}".`);
+  return color;
+}
+
+/**
+ * Builds stable categories/colors for engine featureType indices.
+ *
+ * Notes:
+ * - Engine ids are resolved at runtime; categories are computed dynamically.
+ * - If multiple keys map to the same engine id, labels are combined deterministically.
+ * - Colors are explicit per feature key (no auto palette).
+ */
+export function buildFeatureTypeVizCategories(adapter: EngineAdapter): ReadonlyArray<VizCategory> {
+  const byEngineId = new Map<number, FeatureKey[]>();
+
+  for (const key of FEATURE_PLACEMENT_KEYS) {
+    const engineId = adapter.getFeatureTypeIndex(key);
+    if (typeof engineId !== "number" || Number.isNaN(engineId) || engineId < 0) {
+      throw new Error(`buildFeatureTypeVizCategories: missing engine feature for key "${key}".`);
+    }
+    const bucket = byEngineId.get(engineId) ?? [];
+    bucket.push(key);
+    byEngineId.set(engineId, bucket);
+  }
+
+  const out: VizCategory[] = [NONE_CATEGORY];
+
+  for (const [engineId, keys] of byEngineId.entries()) {
+    const orderedKeys = keys
+      .slice()
+      .sort((a, b) => FEATURE_PLACEMENT_KEYS.indexOf(a) - FEATURE_PLACEMENT_KEYS.indexOf(b));
+    out.push({
+      value: engineId,
+      label: orderedKeys.join("|"),
+      color: colorForKey(orderedKeys[0]!),
+    });
+  }
+
+  out.sort((a, b) => a.value - b.value);
+  return out;
+}
+

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-biomes/viz.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-biomes/viz.ts
@@ -1,0 +1,68 @@
+import type { BiomeSymbol } from "@mapgen/domain/ecology";
+import { BIOME_SYMBOL_ORDER } from "@mapgen/domain/ecology/types.js";
+
+import { BIOME_INDEX_VIZ_CATEGORIES } from "../../../ecology/steps/biomes/viz.js";
+
+export type VizCategory = Readonly<{
+  value: number;
+  label: string;
+  color: readonly [number, number, number, number];
+}>;
+
+const MARINE_LABEL = "marine";
+const MARINE_COLOR: VizCategory["color"] = [59, 130, 246, 210];
+
+function colorForBiomeSymbol(symbol: BiomeSymbol): VizCategory["color"] {
+  const category = BIOME_INDEX_VIZ_CATEGORIES.find((c) => c.label === symbol);
+  if (!category) {
+    throw new Error(`Missing BIOME_INDEX_VIZ_CATEGORIES color for symbol "${symbol}".`);
+  }
+  return category.color;
+}
+
+/**
+ * Builds stable categories/colors for engine biome ids.
+ *
+ * Notes:
+ * - Engine ids are resolved from globals at runtime; categories are computed dynamically.
+ * - If multiple biome symbols map to the same engine id, labels are combined deterministically.
+ * - Colors reuse the truth biome palette where possible.
+ */
+export function buildEngineBiomeIdVizCategories(args: {
+  land: Record<BiomeSymbol, number>;
+  marine: number;
+}): ReadonlyArray<VizCategory> {
+  const byEngineId = new Map<number, { symbols: BiomeSymbol[]; marine: boolean }>();
+
+  for (const symbol of BIOME_SYMBOL_ORDER) {
+    const engineId = args.land[symbol];
+    const bucket = byEngineId.get(engineId) ?? { symbols: [], marine: false };
+    bucket.symbols.push(symbol);
+    byEngineId.set(engineId, bucket);
+  }
+
+  const marineBucket = byEngineId.get(args.marine) ?? { symbols: [], marine: false };
+  marineBucket.marine = true;
+  byEngineId.set(args.marine, marineBucket);
+
+  const out: VizCategory[] = [];
+  for (const [engineId, bucket] of byEngineId.entries()) {
+    const symbols = bucket.symbols.slice().sort((a, b) => BIOME_SYMBOL_ORDER.indexOf(a) - BIOME_SYMBOL_ORDER.indexOf(b));
+    const labelParts = symbols.slice();
+    if (bucket.marine) labelParts.push(MARINE_LABEL);
+
+    let color: VizCategory["color"] = MARINE_COLOR;
+    if (symbols.length > 0) color = colorForBiomeSymbol(symbols[0]!);
+
+    out.push({
+      value: engineId,
+      label: labelParts.join("|"),
+      color,
+    });
+  }
+
+  // Deterministic ordering (engine ids are the values being visualized).
+  out.sort((a, b) => a.value - b.value);
+  return out;
+}
+

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plotBiomes.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plotBiomes.ts
@@ -4,6 +4,7 @@ import * as ecology from "@mapgen/domain/ecology";
 import PlotBiomesStepContract from "./plotBiomes.contract.js";
 import { clampToByte } from "./plot-biomes/helpers/apply.js";
 import { resolveEngineBiomeIds } from "./plot-biomes/helpers/engine-bindings.js";
+import { buildEngineBiomeIdVizCategories } from "./plot-biomes/viz.js";
 
 const GROUP_MAP_ECOLOGY = "Map / Ecology (Engine)";
 const TILE_SPACE_ID = "tile.hexOddR" as const;
@@ -17,6 +18,10 @@ export default createStep(PlotBiomesStepContract, {
       context.adapter,
       config.bindings
     );
+    const biomeIdCategories = buildEngineBiomeIdVizCategories({
+      land: engineBindings,
+      marine: marineBiome,
+    });
 
     const biomeField = context.fields.biomeId;
     const temperatureField = context.fields.temperature;
@@ -55,6 +60,7 @@ export default createStep(PlotBiomesStepContract, {
         label: "Biome Id (Engine)",
         group: GROUP_MAP_ECOLOGY,
         palette: "categorical",
+        categories: biomeIdCategories,
       }),
     });
     context.viz?.dumpGrid(context.trace, {

--- a/mods/mod-swooper-maps/test/ecology/biomes-latcutoff-regression.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/biomes-latcutoff-regression.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "bun:test";
+
+import { createMockAdapter } from "@civ7/adapter";
+import { createExtendedMapContext } from "@swooper/mapgen-core";
+import { stripSchemaMetadataRoot } from "@swooper/mapgen-core/authoring";
+import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
+
+import standardRecipe from "../../src/recipes/standard/recipe.js";
+import { initializeStandardRuntime } from "../../src/recipes/standard/runtime.js";
+import { ecologyArtifacts } from "../../src/recipes/standard/stages/ecology/artifacts.js";
+import swooperEarthlikeConfigRaw from "../../src/maps/configs/swooper-earthlike.config.json";
+
+describe("biomes latitude-cutoff regression (M3-013)", () => {
+  it("does not hard-cut rainforest into latitude stripes (and still produces cold biomes)", { timeout: 20_000 }, () => {
+    const width = 106;
+    const height = 66;
+    const seed = 1337;
+
+    const mapInfo = {
+      GridWidth: width,
+      GridHeight: height,
+      MinLatitude: -80,
+      MaxLatitude: 80,
+      PlayersLandmass1: 4,
+      PlayersLandmass2: 4,
+      StartSectorRows: 4,
+      StartSectorCols: 4,
+    };
+
+    const env = {
+      seed,
+      dimensions: { width, height },
+      latitudeBounds: { topLatitude: mapInfo.MaxLatitude, bottomLatitude: mapInfo.MinLatitude },
+    } as const;
+
+    const adapter = createMockAdapter({
+      width,
+      height,
+      mapInfo,
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
+    });
+
+    const ctx = createExtendedMapContext({ width, height }, adapter, env);
+    initializeStandardRuntime(ctx, { mapInfo, logPrefix: "[test]", storyEnabled: true });
+
+    const config = stripSchemaMetadataRoot(swooperEarthlikeConfigRaw);
+    standardRecipe.run(ctx, env, config, { log: () => {} });
+
+    const classification = ctx.artifacts.get(ecologyArtifacts.biomeClassification.id) as
+      | { biomeIndex?: Uint8Array }
+      | undefined;
+    const biomeIndex = classification?.biomeIndex;
+    if (!(biomeIndex instanceof Uint8Array)) throw new Error("Missing biomeIndex.");
+
+    const rainforestIndex = 6; // tropicalRainforest
+    const rowRainforestFrac: Array<number | null> = [];
+
+    for (let y = 0; y < height; y++) {
+      let land = 0;
+      let rainforest = 0;
+      for (let x = 0; x < width; x++) {
+        if (adapter.isWater(x, y)) continue;
+        land += 1;
+        const idx = y * width + x;
+        const b = biomeIndex[idx] ?? 255;
+        if (b === rainforestIndex) rainforest += 1;
+      }
+      // Ignore extremely sparse rows; they can legitimately swing if only a tiny island is present.
+      rowRainforestFrac.push(land >= 20 ? rainforest / land : null);
+    }
+
+    let maxDelta = 0;
+    for (let y = 1; y < height; y++) {
+      const a = rowRainforestFrac[y - 1];
+      const b = rowRainforestFrac[y];
+      if (a == null || b == null) continue;
+      maxDelta = Math.max(maxDelta, Math.abs(b - a));
+    }
+
+    // Symptom: a hard cutoff where rainforest flips abruptly between adjacent latitudes.
+    // Expectation: transitions across latitude should be gradual or patchy, not row-perfect.
+    expect(maxDelta).toBeLessThanOrEqual(0.6);
+
+    // Regression: we should still be able to generate cold biomes under high-latitude spans.
+    const coldSet = new Set([1, 2]); // tundra, boreal
+    let coldCount = 0;
+    for (let i = 0; i < biomeIndex.length; i++) {
+      if (coldSet.has(biomeIndex[i] ?? 255)) coldCount += 1;
+    }
+    expect(coldCount).toBeGreaterThan(0);
+  });
+});

--- a/mods/mod-swooper-maps/test/ecology/features-apply-viz-meta.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/features-apply-viz-meta.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+
+import { createMockAdapter } from "@civ7/adapter";
+import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
+import { FEATURE_PLACEMENT_KEYS } from "@mapgen/domain/ecology";
+
+import {
+  FEATURE_TYPE_NONE_VALUE,
+  buildFeatureTypeVizCategories,
+} from "../../src/recipes/standard/stages/map-ecology/steps/features-apply/viz.js";
+
+describe("features apply viz meta (engine featureType)", () => {
+  it("declares explicit stable categories/colors for engine featureType", () => {
+    const width = 1;
+    const height = 1;
+    const seed = 1337;
+
+    const adapter = createMockAdapter({
+      width,
+      height,
+      mapInfo: {
+        GridWidth: width,
+        GridHeight: height,
+        MinLatitude: -60,
+        MaxLatitude: 60,
+        PlayersLandmass1: 1,
+        PlayersLandmass2: 1,
+        StartSectorRows: 1,
+        StartSectorCols: 1,
+      },
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
+    });
+
+    const categoriesA = buildFeatureTypeVizCategories(adapter);
+    const categoriesB = buildFeatureTypeVizCategories(adapter);
+
+    // Deterministic ordering/labels for a fixed adapter mapping.
+    expect(JSON.stringify(categoriesA)).toBe(JSON.stringify(categoriesB));
+
+    const values = categoriesA.map((c) => c.value);
+    const uniqueValues = new Set(values);
+    expect(uniqueValues.size).toBe(values.length);
+
+    // Must include the sentinel "no feature" category.
+    expect(values.includes(FEATURE_TYPE_NONE_VALUE)).toBe(true);
+
+    // Ensure all possible emitted ids are covered (sentinel + known placement keys).
+    const expectedIds = new Set<number>([FEATURE_TYPE_NONE_VALUE]);
+    for (const key of FEATURE_PLACEMENT_KEYS) {
+      expectedIds.add(adapter.getFeatureTypeIndex(key));
+    }
+    const categoryValues = new Set<number>(values);
+    for (const id of expectedIds) {
+      expect(categoryValues.has(id)).toBe(true);
+    }
+
+    // Explicit RGBA colors for each category.
+    for (const category of categoriesA) {
+      expect(category.color.length).toBe(4);
+      for (const component of category.color) {
+        expect(Number.isFinite(component)).toBe(true);
+      }
+    }
+  });
+});
+

--- a/mods/mod-swooper-maps/test/ecology/plot-biomes-viz-meta.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/plot-biomes-viz-meta.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+
+import { createMockAdapter } from "@civ7/adapter";
+import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
+
+import { resolveEngineBiomeIds } from "../../src/recipes/standard/stages/map-ecology/steps/plot-biomes/helpers/engine-bindings.js";
+import { buildEngineBiomeIdVizCategories } from "../../src/recipes/standard/stages/map-ecology/steps/plot-biomes/viz.js";
+
+describe("plot biomes viz meta (engine biomeId)", () => {
+  it("declares explicit stable categories/colors for engine biomeId", () => {
+    const width = 1;
+    const height = 1;
+    const seed = 1337;
+
+    const adapter = createMockAdapter({
+      width,
+      height,
+      mapInfo: {
+        GridWidth: width,
+        GridHeight: height,
+        MinLatitude: -60,
+        MaxLatitude: 60,
+        PlayersLandmass1: 1,
+        PlayersLandmass2: 1,
+        StartSectorRows: 1,
+        StartSectorCols: 1,
+      },
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
+    });
+
+    const resolved = resolveEngineBiomeIds(adapter, {});
+    const categoriesA = buildEngineBiomeIdVizCategories(resolved);
+    const categoriesB = buildEngineBiomeIdVizCategories(resolved);
+
+    // Deterministic ordering/labels for a fixed mapping.
+    expect(JSON.stringify(categoriesA)).toBe(JSON.stringify(categoriesB));
+
+    const values = categoriesA.map((c) => c.value);
+    const uniqueValues = new Set(values);
+    expect(uniqueValues.size).toBe(values.length);
+
+    // Ensure all possible emitted ids are covered (bindings + marine).
+    const expectedIds = new Set<number>([resolved.marine, ...Object.values(resolved.land)]);
+    const categoryValues = new Set<number>(values);
+    for (const id of expectedIds) {
+      expect(categoryValues.has(id)).toBe(true);
+    }
+
+    // Basic schema sanity (explicit RGBA colors).
+    for (const category of categoriesA) {
+      expect(category.color.length).toBe(4);
+      for (const component of category.color) {
+        expect(Number.isFinite(component)).toBe(true);
+      }
+    }
+
+    // Default bindings intentionally collapse multiple symbols into single engine ids.
+    expect(categoriesA.some((c) => c.label.includes("snow|tundra|boreal"))).toBe(true);
+    expect(categoriesA.some((c) => c.label.includes("temperateHumid|tropicalSeasonal"))).toBe(true);
+    expect(categoriesA.some((c) => c.label.includes("marine"))).toBe(true);
+  });
+});
+

--- a/mods/mod-swooper-maps/test/fixtures/ecology-parity/ecology-artifacts-fingerprints.v1.json
+++ b/mods/mod-swooper-maps/test/fixtures/ecology-parity/ecology-artifacts-fingerprints.v1.json
@@ -6,18 +6,18 @@
     "height": 20
   },
   "artifacts": {
-    "artifact:ecology.soils": "109728a5197411f0285108d4a55b68a603b14bcc48efe08b60f8909c26499594",
+    "artifact:ecology.soils": "d3deae01994aa65b0b858546cb9e62ebaea0e5c4860de9079f5e97096d6b88a2",
     "artifact:ecology.resourceBasins": "f0955ebb31fb793be429702cbef7346c9ef395c901aed38dfc196ed473c3e709",
-    "artifact:ecology.biomeClassification": "a27de0967b7a183dc823e9f59ee0dbdce0b8a0c6c0adafc60f1a811735a25b41",
-    "artifact:ecology.scoreLayers": "67d12a70995a3fc5c6483d67f76a0ad2b218ad25ddefb7c95ffc0fd081067cbd",
+    "artifact:ecology.biomeClassification": "7de26dbaf078283d150a0987835da29dfb68256132c71ff402a52dcf8a826f3a",
+    "artifact:ecology.scoreLayers": "a8c9df44fa16bd6ade3523f590ef5a7a3b96d1898764cf0eba324791d79b380a",
     "artifact:ecology.occupancy.base": "eb946feb43185f3340691ed53943667d4e3abcb01265f1ae25f63d3289d578b4",
     "artifact:ecology.occupancy.ice": "eb946feb43185f3340691ed53943667d4e3abcb01265f1ae25f63d3289d578b4",
-    "artifact:ecology.occupancy.reefs": "077becf76e36e0a8301e8967042045e6a56588c241e204e2bccfcadf37f9b896",
-    "artifact:ecology.occupancy.wetlands": "077becf76e36e0a8301e8967042045e6a56588c241e204e2bccfcadf37f9b896",
-    "artifact:ecology.occupancy.vegetation": "4a133f697d12bf7e4b7b538ef7a18a001c8a6f329f6ddc176bcc0178b30212a9",
-    "artifact:ecology.featureIntents.vegetation": "281687bb6089088946f3af536360666677fb8c8e58d5c7043045191808d7c8d7",
+    "artifact:ecology.occupancy.reefs": "1455d0d8cc12026a1ba98c372e2cee02d2bc5cc7213f66e5adebf358f7b97f6f",
+    "artifact:ecology.occupancy.wetlands": "1455d0d8cc12026a1ba98c372e2cee02d2bc5cc7213f66e5adebf358f7b97f6f",
+    "artifact:ecology.occupancy.vegetation": "4c8181f19d87787c09f23617e2ef72a1348ffc35d2f9d615f44eb6f70e6ee50a",
+    "artifact:ecology.featureIntents.vegetation": "d3cf941594d45c2941fb516dcd834d5fd437ee281a7f1afb57e4e0d42d62201c",
     "artifact:ecology.featureIntents.wetlands": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
-    "artifact:ecology.featureIntents.reefs": "563cd377bf2c3c0967a7fb12c87c57a4ff860e2aa13966797870d3814790a644",
+    "artifact:ecology.featureIntents.reefs": "bf6bdde73e8eed860c42b1fd015d96ee767f38ceaf34d6a87cfd2587a7c1b983",
     "artifact:ecology.featureIntents.ice": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
   }
 }


### PR DESCRIPTION
# Improve Biome Classification and Temperature Modeling

This PR addresses a biome classification issue where rainforests were appearing in perfect latitude stripes rather than following natural moisture patterns. The changes include:

1. Added a soft transition between tropical and temperate zones based on wetness to prevent row-perfect biome cutoffs
2. Adjusted temperature parameters to create more realistic climate patterns:
   - Lowered base temperature values (14°C → 9°C)
   - Increased insolation scale (28°C → 47°C) for better equator-to-pole contrast
   - Modified how temperature knobs affect the world (applying changes proportionally to baseline and contrast)

3. Updated biome classification rules to make perhumid temperate zones appear as tropical rainforest

4. Added visualization metadata for feature types and biome IDs to improve debugging and analysis

The PR includes regression tests to verify that:
- Rainforest transitions are now gradual rather than abrupt latitude cutoffs
- Cold biomes (tundra, boreal) are still properly generated in high latitudes

These changes result in more natural-looking biome distributions that better follow moisture patterns rather than strict latitude boundaries.