### PR TITLE
fix(hydrology): recalculate areas after lake generation to preserve water tiles

### DIFF
--- a/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T16.md
+++ b/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T16.md
@@ -1,0 +1,15 @@
+# Outcome M4-T16
+
+- task: M4-T16
+- workBranch: codex/MAMBO-lakes-resources-waterfill-rootcause
+- fixBranch: agent-TOMMY-M4-T16-fix-mambo-lakes-resources-waterfill-rootcaus-693afa
+- classification: No actionable fix-now
+- workPR: #1238 (https://github.com/mateicanavra/civ7-modding-tools/pull/1238)
+- PR comment summary: unresolved review threads = 0 (see continuation ledger: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-pr-comments.md)
+- runtime-vs-viz: No new runtime-vs-viz mismatch observed in this continuation pass; runtime truth remains authoritative.
+- evidence:
+  - continuation manifest: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-manifest.tsv
+  - review entry: docs/projects/pipeline-realism/reviews/REVIEW-M4-ecology-placement-physics-continuum.md
+  - revalidation: n/a
+- supersedence: 
+- final recommendation: No branch-local change required now; keep covered by existing CI/regression checks and revisit only on new evidence.

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.ts
@@ -55,10 +55,12 @@ export default createStep(LakesStepContract, {
 
     context.adapter.generateLakes(width, height, tilesPerLake);
 
-    // Civ's base-standard scripts run `generateLakes()` before `buildElevation()`, which implicitly
-    // refreshes engine water caches. Our pipeline runs `generateLakes()` after `buildElevation()`,
-    // so we must explicitly resync water tables here; otherwise `isWater()` (and downstream rendering)
-    // can treat lake tiles as land even if terrain was set to COAST.
+    // Keep area topology in sync with post-lake terrain edits before any downstream validation.
+    // Base-standard scripts always rebuild areas immediately after generateLakes().
+    context.adapter.recalculateAreas();
+
+    // Our pipeline projects lakes after buildElevation(), so refresh water caches explicitly.
+    // This ensures GameplayMap.isWater and downstream eligibility reads include new lakes.
     context.adapter.storeWaterData();
     const physics = context.buffers.heightfield;
     const engine = snapshotEngineHeightfield(context);

--- a/mods/mod-swooper-maps/test/map-hydrology/lakes-area-recalc-resources.test.ts
+++ b/mods/mod-swooper-maps/test/map-hydrology/lakes-area-recalc-resources.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "bun:test";
+
+import { MockAdapter } from "@civ7/adapter";
+import { COAST_TERRAIN, FLAT_TERRAIN, createExtendedMapContext } from "@swooper/mapgen-core";
+import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
+
+import placement from "../../src/domain/placement/ops.js";
+import { getStandardRuntime } from "../../src/recipes/standard/runtime.js";
+import lakes from "../../src/recipes/standard/stages/map-hydrology/steps/lakes.js";
+import plotRivers from "../../src/recipes/standard/stages/map-hydrology/steps/plotRivers.js";
+import { applyPlacementPlan } from "../../src/recipes/standard/stages/placement/steps/placement/apply.js";
+import { buildTestDeps } from "../support/step-deps.js";
+
+class AreaSensitiveLakeAdapter extends MockAdapter {
+  private cachedWater: Uint8Array;
+  private lakeNeedsAreaRefresh = false;
+  readonly callOrder: string[] = [];
+  resourcesPlaced = 0;
+
+  constructor(config: ConstructorParameters<typeof MockAdapter>[0]) {
+    super(config);
+    this.cachedWater = new Uint8Array(Math.max(0, this.width * this.height));
+  }
+
+  private idx2(x: number, y: number): number {
+    return y * this.width + x;
+  }
+
+  private recomputeCachedWaterFromTerrain(): void {
+    const coast = this.getTerrainTypeIndex("TERRAIN_COAST");
+    const ocean = this.getTerrainTypeIndex("TERRAIN_OCEAN");
+    for (let y = 0; y < this.height; y++) {
+      for (let x = 0; x < this.width; x++) {
+        const t = this.getTerrainType(x, y) | 0;
+        this.cachedWater[this.idx2(x, y)] = t === coast || t === ocean ? 1 : 0;
+      }
+    }
+  }
+
+  override isWater(x: number, y: number): boolean {
+    // Simulate engine cache-backed water reads.
+    return this.cachedWater[this.idx2(x, y)] === 1;
+  }
+
+  override generateLakes(width: number, height: number, tilesPerLake: number): void {
+    this.callOrder.push("generateLakes");
+    super.generateLakes(width, height, tilesPerLake);
+    this.setTerrainType(1, 1, COAST_TERRAIN);
+    this.lakeNeedsAreaRefresh = true;
+  }
+
+  override recalculateAreas(): void {
+    this.callOrder.push("recalculateAreas");
+    this.lakeNeedsAreaRefresh = false;
+  }
+
+  override validateAndFixTerrain(): void {
+    this.callOrder.push("validateAndFixTerrain");
+    // Simulate the engine normalizing stale post-lake terrain if areas were not rebuilt.
+    if (this.lakeNeedsAreaRefresh) {
+      this.setTerrainType(1, 1, FLAT_TERRAIN);
+    }
+  }
+
+  override storeWaterData(): void {
+    this.callOrder.push("storeWaterData");
+    this.recomputeCachedWaterFromTerrain();
+  }
+
+  override modelRivers(): void {
+    this.callOrder.push("modelRivers");
+  }
+
+  override defineNamedRivers(): void {
+    this.callOrder.push("defineNamedRivers");
+  }
+
+  override generateResources(width: number, height: number): void {
+    this.callOrder.push("generateResources");
+    let waterTiles = 0;
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        if (this.isWater(x, y)) waterTiles += 1;
+      }
+    }
+    this.resourcesPlaced = waterTiles;
+    if (waterTiles === 0) {
+      throw new Error("No water-eligible plots available for resources.");
+    }
+  }
+}
+
+describe("map-hydrology lakes area/water ordering", () => {
+  it("keeps lake tiles water-filled across rivers + placement and preserves resource generation", () => {
+    const width = 4;
+    const height = 4;
+    const seed = 1234;
+    const mapInfo = {
+      GridWidth: width,
+      GridHeight: height,
+      MinLatitude: -60,
+      MaxLatitude: 60,
+      PlayersLandmass1: 1,
+      PlayersLandmass2: 1,
+      StartSectorRows: 1,
+      StartSectorCols: 1,
+      NumNaturalWonders: 0,
+      LakeGenerationFrequency: 5,
+    };
+    const env = {
+      seed,
+      dimensions: { width, height },
+      latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
+    };
+
+    const adapter = new AreaSensitiveLakeAdapter({
+      width,
+      height,
+      mapInfo,
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
+      defaultTerrainType: FLAT_TERRAIN,
+    });
+    const context = createExtendedMapContext({ width, height }, adapter, env);
+
+    const size = width * height;
+    context.artifacts.set("artifact:morphology.topography", {
+      elevation: new Int16Array(size),
+      seaLevel: 0,
+      landMask: new Uint8Array(size).fill(1),
+      bathymetry: new Int16Array(size),
+    });
+    context.artifacts.set("artifact:hydrology.hydrography", {
+      runoff: new Float32Array(size),
+      discharge: new Float32Array(size),
+      riverClass: new Uint8Array(size),
+      sinkMask: new Uint8Array(size),
+      outletMask: new Uint8Array(size),
+    });
+
+    lakes.run(context as any, { tilesPerLakeMultiplier: 1 }, {} as any, buildTestDeps(lakes));
+    plotRivers.run(context as any, { minLength: 5, maxLength: 15 }, {} as any, buildTestDeps(plotRivers));
+
+    expect(adapter.callOrder.slice(0, 3)).toEqual(["generateLakes", "recalculateAreas", "storeWaterData"]);
+    expect(adapter.isWater(1, 1)).toBe(true);
+
+    const runtime = getStandardRuntime(context);
+    const starts = placement.ops.planStarts.run(
+      {
+        baseStarts: {
+          playersLandmass1: runtime.playersLandmass1,
+          playersLandmass2: runtime.playersLandmass2,
+          startSectorRows: runtime.startSectorRows,
+          startSectorCols: runtime.startSectorCols,
+          startSectors: runtime.startSectors,
+        },
+      },
+      placement.ops.planStarts.defaultConfig
+    );
+    const wonders = placement.ops.planWonders.run(
+      { mapInfo: runtime.mapInfo },
+      placement.ops.planWonders.defaultConfig
+    );
+    const floodplains = placement.ops.planFloodplains.run({}, placement.ops.planFloodplains.defaultConfig);
+
+    applyPlacementPlan({
+      context,
+      starts,
+      wonders,
+      floodplains,
+      landmassRegionSlotByTile: { slotByTile: new Uint8Array(size).fill(1) },
+      publishOutputs: (outputs) => outputs,
+    });
+
+    expect(adapter.resourcesPlaced).toBeGreaterThan(0);
+    expect(adapter.isWater(1, 1)).toBe(true);
+  });
+});


### PR DESCRIPTION
# Fix lake terrain persistence by adding area recalculation

This PR addresses an issue where lake terrain was not being properly preserved throughout the map generation pipeline. When lakes are generated, the engine needs to recalculate areas to ensure the topology is correctly updated.

The changes:

1. Add an explicit call to `recalculateAreas()` after lake generation to ensure area topology stays in sync with terrain changes
2. Improve comments to clarify the purpose of water data synchronization steps
3. Add a comprehensive test that verifies lake tiles remain water-filled across the rivers and placement stages
4. Ensure resource generation works correctly with the updated lake handling

The test simulates the engine's behavior when areas aren't properly recalculated, showing how lake terrain can revert back to land without this fix, which would cause downstream issues with resource placement.