### PR TITLE
docs(spike): integrate foundation domain axe research Create the full foundation-domain-axe spike artifact set in the orchestrator branch: plan, master scratch integration, six agent scratchpads, and the integrated spike report. Includes YAML parseability

### DIFF
--- a/docs/projects/pipeline-realism/resources/research/SPIKE-foundation-domain-axe-2026-02-14.md
+++ b/docs/projects/pipeline-realism/resources/research/SPIKE-foundation-domain-axe-2026-02-14.md
@@ -1,0 +1,388 @@
+# SPIKE: Foundation Domain Axe Investigation (Ops + Stages + Boundaries)
+
+Date: 2026-02-14
+Scope type: research-only (`/dev-spike`), no production refactor in this document
+
+## 1) Objective and Non-Goals
+
+### Objective
+Define a decision-ready target architecture for Foundation so stage/step/op/strategy/rule boundaries align with domain modeling guidelines, while preserving pragmatic delivery sequencing and supporting visualization/tracing.
+
+### Non-goals
+- No production implementation changes in this spike.
+- No compatibility shims or dual-path runtime recommendations.
+- No "soft" migration plan that leaves legacy structures in place indefinitely.
+
+```yaml
+source_of_truth:
+  primary_spec:
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md
+  agent_research_inputs:
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-D-integration-wiring-contracts.md
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-E-viz-tracing-boundaries.md
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-F-testing-docs-guardrails.md
+```
+
+## 2) Current-State Structural Inventory (Stages/Steps/Ops/Strategies/Rules)
+
+Foundation is currently one monolithic stage (`id: foundation`) with 10 sequential steps. Ops are present, but major compute concerns are concentrated in large files and there is limited explicit `rules/` and `strategies/` factoring in Foundation.
+
+```yaml
+current_foundation_shape:
+  stage_id: foundation
+  ordered_steps:
+    - mesh
+    - mantle-potential
+    - mantle-forcing
+    - crust
+    - plate-graph
+    - plate-motion
+    - tectonics
+    - crust-evolution
+    - projection
+    - plate-topology
+  key_inventory_evidence:
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:539
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:771
+
+heavy_surfaces:
+  mega_op:
+    path: mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts
+    notes:
+      - large mixed-responsibility op
+      - contains op-calls-op behavior
+  heavy_steps:
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts
+
+downstream_contract_pressure:
+  morphology_reads_foundation_projection_artifacts:
+    - mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.contract.ts:16
+    - mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/islands.contract.ts:16
+    - mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/volcanoes.contract.ts:15
+```
+
+## 3) Boundary Violations and Anti-Patterns
+
+The current model violates guideline intent across stage compile boundaries, step orchestration boundaries, op composition boundaries, and strategy config truthfulness.
+
+```yaml
+violations:
+  - id: BV-1
+    title: dual compile path in stage boundary
+    summary: foundation compile has canonical lowering plus sentinel bypass branches
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:552
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:570
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:170
+  - id: BV-2
+    title: step contains direct compute logic (op boundary leak)
+    summary: plate-topology compute is implemented step-local instead of as a domain op contract
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts:12
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts:52
+  - id: BV-3
+    title: op-calls-op composition inside mega-op
+    summary: compute-tectonic-history calls compute-tectonic-segments internally
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:7
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1183
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:25
+  - id: BV-4
+    title: contract drift (input passed but ignored)
+    summary: history input.segments is passed by step but ignored by op runtime
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/contract.ts:206
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:74
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1184
+  - id: BV-5
+    title: dead strategy/config knobs
+    summary: multiple declared knobs are inert at runtime
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts:14
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:63
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:59
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:40
+  - id: BV-6
+    title: truth/projection lane bleed
+    summary: foundation currently owns tile/map-facing projection artifacts
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:21
+      - mods/mod-swooper-maps/src/recipes/standard/map-artifacts.ts:34
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:185
+```
+
+## 4) Target Stage Model Options and Chosen Recommendation
+
+### Option A: 2-stage split
+- `foundation-physics`
+- `foundation-projection`
+
+### Option B: 3-stage split (recommended)
+- `foundation-substrate-kinematics`
+- `foundation-tectonics-history`
+- `foundation-projection`
+
+Chosen recommendation: Option B.
+
+Rationale: it creates tighter semantic gates around the highest-volatility boundaries (`tectonics` and `projection`) and maps directly to the artifact handoff clusters discovered in the current dependency DAG.
+
+```yaml
+stage_options:
+  option_A:
+    stages:
+      - foundation-physics
+      - foundation-projection
+    tradeoff: lower migration churn, weaker long-term boundary clarity
+  option_B:
+    stages:
+      - foundation-substrate-kinematics
+      - foundation-tectonics-history
+      - foundation-projection
+    tradeoff: higher migration churn, stronger long-term boundary clarity
+
+chosen_recommendation:
+  option: option_B
+  evidence_paths:
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:1
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:1
+```
+
+## 5) Target Op Catalog and Decomposition Map
+
+Primary decomposition target is `compute-tectonic-history`: split into focused ops and move sequencing into the step layer.
+
+```yaml
+tectonics_decomposition:
+  current_op:
+    - foundation/compute-tectonic-history
+  target_ops:
+    - foundation/compute-era-plate-membership
+    - foundation/compute-segment-events
+    - foundation/compute-hotspot-events
+    - foundation/compute-era-tectonic-fields
+    - foundation/compute-tectonic-history-rollups
+    - foundation/compute-tectonics-current
+    - foundation/compute-tracer-advection
+    - foundation/compute-tectonic-provenance
+  orchestration_owner: foundation step layer (tectonics)
+  evidence_paths:
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:25
+
+secondary_decomposition_candidates:
+  - from: foundation/compute-plate-graph
+    to:
+      - foundation/plan-plate-seeds
+      - foundation/compute-plate-membership
+  - from: foundation/compute-plate-motion
+    to:
+      - foundation/compute-plate-motion-fit
+      - foundation/score-plate-motion-fit
+  - from: foundation/compute-plates-tensors
+    to:
+      - foundation/compute-tile-to-cell-index
+      - foundation/project-crust-tiles
+      - foundation/project-tectonic-history-tiles
+      - foundation/project-tectonic-provenance-tiles
+      - foundation/project-plates-tiles
+```
+
+## 6) Strategy and Rules Factoring Model
+
+Adopt strict layering:
+- Step orchestrates ops.
+- Op implements stable I/O boundary.
+- Strategy varies algorithm without changing I/O.
+- Rules hold small policy decisions internal to op.
+
+```yaml
+factoring_contract:
+  strategies:
+    requirement: every declared strategy field must affect runtime
+    action_on_dead_knob: remove field or implement semantics (no inert knobs)
+  rules:
+    location: op-local rules/**
+    scope: non-exported policy units (thresholds, scoring, selection)
+  op_contracts:
+    requirement: no op-internal peer op run(...) calls
+  evidence_paths:
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:75
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:77
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:243
+```
+
+## 7) Visualization/Tracing Boundary Model
+
+Observability remains step-owned at public boundaries, but emission assembly should be moved into lane-owned helper modules to avoid monolithic step files. During op decomposition, keep existing step-level compose points so external viz contracts do not explode.
+
+```yaml
+viz_tracing_model:
+  retain:
+    - step-level public emit boundaries
+    - trace transport in mapgen-core
+  change:
+    - move emission formatting into lane-owned emitter modules
+    - centralize duplicated legend/category metadata
+  stage_alignment:
+    - foundation-substrate-kinematics
+    - foundation-tectonics-history
+    - foundation-projection
+  identity_note:
+    - layerKey is step-id bound today; stage-id changes will churn layer keys
+  evidence_paths:
+    - packages/mapgen-viz/src/index.ts:213
+    - mods/mod-swooper-maps/src/dev/viz/dump.ts:105
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-E-viz-tracing-boundaries.md
+```
+
+## 8) Breaking-Change Contract Matrix (Ops/Artifacts/Steps/Stage Config)
+
+```yaml
+breaking_change_matrix:
+  - id: D-BC1
+    surface: ops
+    change: remove compute-tectonic-history input.segments + internal recomputation
+    impact: tectonics step contract and tests
+  - id: D-BC2
+    surface: ops
+    change: split mega-op history into focused ops and step orchestration
+    impact: op registry, contracts.ts, step wiring
+  - id: D-BC3
+    surface: ops_and_stage_config
+    change: remove dead config fields (crust-evolution knobs, plate-graph tangential knobs, inert stage fields)
+    impact: authored configs, presets, docs, type tests
+  - id: D-BC4
+    surface: stage_compile
+    change: remove sentinel compile branches; keep one canonical lowering path
+    impact: producer payload shape and Studio compatibility payloads
+  - id: D-BC5
+    surface: stages_and_steps
+    change: split foundation stage ids (3-stage model)
+    impact: full step IDs, recipe config keys, snapshot tooling
+  - id: D-BC6
+    surface: artifacts
+    variants:
+      strict_now: move projection artifacts to artifact:map.* in same stack
+      phased_recommended: keep IDs stable through phases 1-2, then hard lane split in phase 3
+    impact: morphology contracts and downstream artifact consumers
+
+matrix_evidence_paths:
+  - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-D-integration-wiring-contracts.md
+  - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md
+  - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md
+```
+
+## 9) Legacy Deletion Plan (100% No Shims)
+
+No dual publish, no compatibility aliases, no temporary mirror surfaces in the target implementation stack.
+
+```yaml
+legacy_deletion_plan:
+  remove:
+    - stage compile sentinel paths
+    - dead strategy/stage knobs
+    - op-internal op chaining in foundation mega-op
+  prohibit:
+    - dual contract requirements in step contracts
+    - shadow/compare/dual runtime paths
+    - compatibility aliases for deprecated stage IDs and artifact IDs
+  enforcement:
+    - hard CI gate for no-shim/no-dual-path checks
+    - explicit denylist manifest tests
+  evidence_paths:
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:192
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-F-testing-docs-guardrails.md
+```
+
+## 10) Test and Guardrail Plan
+
+Add a required CI job (`architecture-cutover-guardrails`) that blocks merge on boundary regressions.
+
+```yaml
+required_ci_job:
+  name: architecture-cutover-guardrails
+  commands:
+    - bun run lint
+    - bun run lint:adapter-boundary
+    - REFRACTOR_DOMAINS=foundation,morphology,hydrology,ecology,placement,narrative DOMAIN_REFACTOR_GUARDRAILS_PROFILE=full bun run lint:domain-refactor-guardrails
+    - run no-shim/no-dual-path structural tests (existing + new)
+    - bun run check
+
+new_structural_tests:
+  - foundation-topology.contract-guard.test.ts
+  - no-dual-contract-paths.test.ts
+  - no-shim-surfaces.test.ts (expanded scope)
+  - foundation-step-boundary-guard.test.ts
+  - validation-artifacts.contract.test.ts
+  - foundation-legacy-absence.test.ts
+  - foundation-tag-freeze.test.ts
+  - no-op-calls-op-tectonics.test.ts
+
+docs_updates:
+  - docs/system/TESTING.md
+  - docs/projects/pipeline-realism/resources/spec/no-shim-cutover-guardrails.md
+```
+
+## 11) Migration Risks and Mitigation
+
+```yaml
+migration_risks:
+  - id: R-1
+    risk: hidden step-id consumers break after stage split
+    mitigation: pre-cut inventory + explicit updates in traces/snapshots/scripts
+  - id: R-2
+    risk: determinism drift during op decomposition
+    mitigation: gate with determinism suite and fixed compose-point contracts
+  - id: R-3
+    risk: observability churn due to step-bound layerKey identity
+    mitigation: treat as expected break, rely on semantic dataTypeKey for diffing where possible
+  - id: R-4
+    risk: CI/runtime time increase from strict guardrails
+    mitigation: split fast static checks from heavier suites and make strict set required
+  - id: R-5
+    risk: policy conflict (strict no-shim vs temporary bridge language)
+    mitigation: explicit precedence decision before implementation starts
+
+risk_evidence_paths:
+  - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md
+  - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-E-viz-tracing-boundaries.md
+  - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-F-testing-docs-guardrails.md
+```
+
+## 12) Execution-Plan Handoff Inputs
+
+Recommended execution sequencing is intentionally no-shim and hard-cut per phase.
+
+```yaml
+execution_handoff:
+  recommended_sequence:
+    - phase_1_contract_cleanup_and_op_decomposition
+    - phase_2_foundation_three_stage_split
+    - phase_3_lane_namespace_hard_split_to_artifact_map
+    - phase_4_ci_guardrail_lock_and_docs_normativity
+
+required_pre_implementation_decisions:
+  - lane_policy: strict_now vs phased_hard_split
+  - dead_knob_policy: remove_now vs implement_then_keep
+  - stage_split_timing: same_stack_as_decomposition vs followup_stack
+  - policy_precedence: strict_no_shim_vs_temporary_bridge_language
+
+acceptance_criteria_for_next_phase:
+  - all foundation boundaries mapped to stage/step/op/strategy/rule model
+  - breaking-change matrix approved
+  - no-shim guardrail suite defined and accepted
+  - no unresolved ownership ambiguity for viz/tracing boundaries
+```
+
+## Recommended Decisions (Integrator Call)
+
+1. Approve 3-stage topology (`foundation-substrate-kinematics`, `foundation-tectonics-history`, `foundation-projection`).
+2. Approve immediate decomposition of `compute-tectonic-history` and step-owned orchestration.
+3. Approve sequencing: contract cleanup/decomposition first, stage split second, lane namespace hard split third.
+4. Approve strict no-shim policy as governing posture for implementation stacks.
+

--- a/docs/projects/pipeline-realism/reviews/REVIEW-M4-full-stack-chain.md
+++ b/docs/projects/pipeline-realism/reviews/REVIEW-M4-full-stack-chain.md
@@ -448,3 +448,29 @@ Full-chain review ledger for the active Graphite stack (`#1201`..`#1348`) using 
 
 ### Cross-cutting Risks
 - Repeated restacks across the chain can hide branch-local regressions without focused probes.
+
+## REVIEW codex/agent-ORCH-foundation-domain-axe-spike
+
+### Quick Take
+- Reviewed PR #1262 (https://github.com/mateicanavra/civ7-modding-tools/pull/1262).
+- Churn profile: +2085 / -0 across 9 files.
+- Verification signal: docs-only; no runtime check run.
+
+### High-Leverage Issues
+- No branch-local high-severity defect identified in this pass.
+
+### PR Comment Context
+- Review threads: unresolved=0, resolved=0.
+- No unresolved review threads; automation chatter (if present) treated as non-actionable.
+
+### Fix Now (Recommended)
+- None.
+
+### Defer / Follow-up
+- None beyond normal post-merge monitoring.
+
+### Needs Discussion
+- None.
+
+### Cross-cutting Risks
+- Documentation-led review records can drift from implementation unless periodically reconciled.

--- a/docs/projects/pipeline-realism/scratch/dev-loop-review/M4-full-stack-review-loop-plan.md
+++ b/docs/projects/pipeline-realism/scratch/dev-loop-review/M4-full-stack-review-loop-plan.md
@@ -31,3 +31,4 @@
 - 2026-02-17: Reviewed #1255 (agent-SWANKO-PRR-s119-c01-fix-pass-plateMotion); unresolved=0, resolved=0; verification: bun run --cwd mods/mod-swooper-maps check: FAIL.
 - 2026-02-17: Reviewed #1256 (agent-SWANKO-PRR-s120-c01-fix-era-plateMotion-recompute); unresolved=0, resolved=0; verification: bun run --cwd mods/mod-swooper-maps check: FAIL.
 - 2026-02-17: Reviewed #1257 (agent-SWANKO-PRR-s124-c01-fix-diag-analyze-mountains-guard); unresolved=0, resolved=0; verification: bun run --cwd mods/mod-swooper-maps check: FAIL.
+- 2026-02-17: Reviewed #1262 (codex/agent-ORCH-foundation-domain-axe-spike); unresolved=0, resolved=0; verification: docs-only; no runtime check run.

--- a/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/00-plan.md
+++ b/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/00-plan.md
@@ -1,0 +1,77 @@
+# 00 Plan — Foundation Domain Axe Spike
+
+## Charter
+Perform a research-only, no-shim, no-legacy investigation of Foundation domain architecture to define a decision-ready target model for:
+- stage boundaries,
+- step boundaries,
+- op/strategy/rule boundaries,
+- wiring/contracts,
+- viz/tracing boundaries,
+- testing/docs guardrails.
+
+This spike explicitly allows breaking current contracts when required for architectural correctness.
+
+## Scope
+In scope:
+- `mods/mod-swooper-maps/src/domain/foundation/**`
+- `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/**`
+- Downstream consumers of foundation artifacts where boundary pressure exists.
+- Trace/viz surfaces that couple to foundation boundaries.
+
+Out of scope:
+- Implementing production refactors.
+- Preserving legacy shims/dual paths.
+
+## Acceptance Rubric
+A valid spike output must provide:
+1. Current-state inventory (stages/steps/ops/strategies/rules).
+2. Explicit boundary violations and anti-patterns with evidence.
+3. Target stage model options and a chosen recommendation.
+4. Target op catalog with decomposition map.
+5. Strategy/rules factoring model for major ops (esp. tectonic history).
+6. Breaking-change matrix (ops/artifacts/steps/stage compile/public).
+7. No-legacy cutover posture (0 shims, 0 dual paths).
+8. Test/guardrail and docs plan to enforce architecture.
+9. Migration risks + mitigations.
+10. Execution-plan handoff inputs.
+
+## Team Axes
+- Agent A: boundaries/structure.
+- Agent B: op decomposition and strategy/rules factoring.
+- Agent C: stage topology and ordering options.
+- Agent D: integration/wiring/contracts and break matrix.
+- Agent E: visualization/tracing boundary model.
+- Agent F: test/docs/guardrails and no-shim enforcement.
+
+## Operating Constraints
+- Append-only notes in agent files.
+- Every non-obvious claim must include evidence paths.
+- No recommendations that preserve compatibility shims.
+- Keep proposals pragmatic and implementable.
+
+## Parseability Addendum (YAML)
+
+```yaml
+scope_paths:
+  foundation_domain:
+    - mods/mod-swooper-maps/src/domain/foundation/**
+  foundation_stage:
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/**
+  downstream_pressure:
+    - mods/mod-swooper-maps/src/recipes/standard/stages/morphology-*/**
+  spec_source:
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md
+
+deliverable_paths:
+  plan: docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/00-plan.md
+  master: docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/master-scratch.md
+  final_spike_doc: docs/projects/pipeline-realism/resources/research/SPIKE-foundation-domain-axe-2026-02-14.md
+
+agent_axes:
+  A: boundaries-structure
+  B: ops-strategies-rules
+  C: stage-topology
+  D: integration-wiring-contracts
+  E: viz-tracing-boundaries
+  F: testing-docs-guardrails
+```

--- a/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md
+++ b/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md
@@ -1,0 +1,139 @@
+# Agent A — Boundaries and Structure
+
+## Axis Ownership
+Define and evaluate Foundation boundaries:
+- stage boundary semantics,
+- step boundary semantics,
+- op boundary semantics,
+- strategy boundary semantics,
+- rule boundary semantics,
+and identify concrete current violations.
+
+## Deliverables
+1. Boundary definitions grounded in current SPEC + code reality.
+2. Violation inventory with evidence paths.
+3. Recommended target boundary model (Foundation-specific).
+
+## Working Notes (append-only)
+- 
+
+## Proposed target model
+- 
+
+## Breaking-change inventory
+- 
+
+## Open risks
+- 
+
+## Decision asks for orchestrator
+- 
+
+### 2026-02-14 — Boundary semantics + violation pass
+
+#### Boundary semantics (Foundation, grounded)
+- `Stage boundary`: author-facing surface + compile-time config lowering only; runtime logic belongs to steps/ops (evidence: `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:155`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:160`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:101`).
+- `Step boundary`: orchestration + artifact/effect boundary; steps build inputs, call ops, publish outputs (evidence: `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:93`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:96`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:257`).
+- `Op boundary`: stable pure contract; no orchestration role creep; prefer focused ops over mega-ops (evidence: `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:82`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:83`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:29`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:39`).
+- `Strategy boundary`: same op I/O, algorithmic variation only; strategy config must map to runtime behavior (evidence: `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:75`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:77`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:205`).
+- `Rule boundary`: small pure policy units under op-local `rules/**`, not public contract surfaces (evidence: `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:70`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:73`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:243`).
+
+#### Current violation inventory (with evidence)
+- `V1 — Stage boundary breach (legacy dual-path shim)`: Foundation stage compile still branches on Studio sentinel-shaped payloads (`advanced.<stepId>` and `profiles.__studioUiMetaSentinelPath`) and bypasses the single canonical lowering path (evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:552`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:570`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:579`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:170`).
+- `V2 — Step boundary breach (compute logic inside step)`: `plate-topology` is implemented directly in the step with no op contract, including topology construction + symmetry validation (evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.contract.ts:14`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts:52`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:22`).
+- `V3 — Domain lane boundary breach (physics vs projection lane)`: Foundation stage currently owns tile/map-facing projection tensors via `projection` and publishes them as `artifact:foundation.*`, while SPEC posture says map-facing projection is Gameplay lane (`artifact:map.*`) and physics should stay truth-only (evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:21`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts:739`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/contract.ts:340`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:109`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:114`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:185`).
+- `V4 — Op boundary breach (op-to-op orchestration inside an op)`: `compute-tectonic-history` imports and executes `computeTectonicSegments.run(...)` per era; orchestration of multiple ops is step responsibility per decision framework (evidence: `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:7`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1183`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:22`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:136`).
+- `V5 — Op sizing breach (mega-op consolidation)`: `compute-tectonic-history` mixes plate-membership evolution, event synthesis, field diffusion, rollup derivation, and provenance/advection in one 1.5k LOC op (evidence: `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:225`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:458`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:972`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1025`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:29`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:39`).
+- `V6 — Strategy boundary breach (declared strategy knobs not wired)`: `compute-crust-evolution` declares configurable strategy knobs, but runtime ignores config (`_config`) and uses hardcoded coefficients/constants (evidence: `mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts:12`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:23`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:63`).
+- `V7 — Strategy boundary breach (dead contract knobs)`: `compute-plate-graph` strategy exposes `tangentialSpeed` and `tangentialJitterDeg`, but implementation never reads them (evidence: `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:59`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:65`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/index.ts:341`).
+- `V8 — Rule boundary breach (rules not materialized as units)`: Foundation ops currently keep heuristics inline in op files, with no op-local `rules/**` structure under the foundation ops tree (evidence: `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/index.ts:109`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:458`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-segments/index.ts:57`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:73`).
+
+## Proposed target model
+- `Stage model (single path)`: keep Foundation stage as authoring + compile lowering only; remove sentinel/legacy compile branches and keep one canonical lowering path from `public` + knobs -> step config envelopes (evidence driver: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:552`).
+- `Step model`: each step should orchestrate one coherent boundary and call ops only; migrate `plate-topology` compute into a dedicated op (`foundation/compute-plate-topology`) and keep the step as orchestrator/publisher (evidence driver: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts:52`).
+- `Domain lane split (no-shim posture)`:
+  - Foundation (physics truth lane): mesh-space and physics-owned truths only (`mesh`, `mantlePotential`, `mantleForcing`, `crust`, `plateGraph`, `plateMotion`, tectonic truths/provenance).
+  - Gameplay projection/materialization lane: tile/map-facing projections under `artifact:map.*` and later effects under `effect:map.*`.
+  - Cutover should be direct (no dual publish surfaces) per single-path/no-legacy posture (evidence: `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:170`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:192`).
+- `Op model (decomposition for tectonic stack)`:
+  - Split `compute-tectonic-history` into focused ops with stable contracts, e.g. `compute-plate-membership-history`, `derive-tectonic-events`, `emit-tectonic-era-fields`, `rollup-tectonic-history`, `compute-tectonic-provenance`.
+  - Move orchestration across those ops into the `tectonics` step (or a dedicated sub-step sequence) instead of op-internal orchestration.
+- `Strategy model`:
+  - Remove dead strategy config keys or wire them fully.
+  - Ensure each declared strategy field has runtime effect; otherwise move fixed coefficients to constants that are intentionally non-configurable.
+- `Rule model`:
+  - Introduce op-local `rules/**` for scoring/selection/threshold logic (seed picking, regime selection, emission decay, reset thresholds, provenance reset checks), keeping op `run` focused on orchestration over rule calls.
+
+## Breaking-change inventory
+- `BC1`: remove Studio sentinel compile branches in Foundation stage (`advanced.<stepId>` + sentinel profile path) and enforce one compile path.
+- `BC2`: add and require `foundation/compute-plate-topology` op; `plate-topology` step contract gains an op dependency instead of `ops: {}`.
+- `BC3`: relocate tile/map-facing tensors out of Foundation artifact namespace into Gameplay map projection surfaces (`artifact:map.*`), with downstream dependency rewiring.
+- `BC4`: split `foundation/compute-tectonic-history` contract into multiple ops; existing single-op consumers and tests must migrate to new contracts/order.
+- `BC5`: remove or implement currently dead strategy keys (`compute-crust-evolution` and `compute-plate-graph` knobs), which changes authored config compatibility.
+- `BC6`: introduce explicit rule modules and test targets; op file/module layout changes for `compute-plate-graph`, `compute-tectonic-segments`, and `compute-tectonic-history`.
+
+## Open risks
+- `R1`: projection-lane extraction can ripple into downstream stages expecting `artifact:foundation.plates`/tile tensors; cutover sequencing must avoid hidden dependency gaps (evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:21`).
+- `R2`: tectonic-history decomposition can change determinism if random order/tie-break behavior moves across module boundaries (evidence: heap/tie logic in `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:656` and `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/index.ts:77`).
+- `R3`: removing dead knobs is a behavior-preserving cleanup only if no external tooling depends on their presence in schemas; compatibility audit is needed before contract removal.
+- `R4`: extracting rules increases module count; without strict naming/ownership conventions, responsibilities could re-fragment.
+
+## Decision asks for orchestrator
+- `D1`: Approve hard lane split: Foundation ends at physics truth; map/tile projection moves to Gameplay (`artifact:map.*`) with no dual-publish shim.
+- `D2`: Approve tectonic-history decomposition now (multi-op target) versus deferred behind a temporary transitional wrapper. Recommendation: now, to honor no-shim/no-legacy posture.
+- `D3`: Approve contract cleanup policy for dead strategy knobs:
+  - Option A: remove immediately (breaking config surface, cleaner architecture).
+  - Option B: keep for one short cutover window with explicit deprecation gate and deletion trigger.
+- `D4`: Decide where to host shared projection helpers long-term (`packages/mapgen-core` vs `packages/sdk`) for cross-domain reuse consistency.
+
+### 2026-02-14 — Parseability Addendum (YAML)
+
+```yaml
+boundary_semantics_evidence:
+  stage_boundary:
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:155
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:160
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:101
+  step_boundary:
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:93
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:96
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:257
+  op_boundary:
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:82
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:83
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:29
+  strategy_boundary:
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:75
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:77
+  rule_boundary:
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:70
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:73
+
+violations:
+  V1_stage_dual_compile_path:
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:552
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:570
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:579
+  V2_step_contains_compute_logic:
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts:12
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts:52
+  V3_truth_vs_projection_lane_bleed:
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:21
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts:739
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:185
+  V4_op_calls_op:
+    - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:7
+    - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1183
+  V5_tectonic_history_mega_op:
+    - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:225
+    - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:972
+  V6_dead_crust_evolution_strategy_knobs:
+    - mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts:12
+    - mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:63
+  V7_dead_plate_graph_tangential_knobs:
+    - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:59
+    - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:65
+  V8_rules_not_materialized:
+    - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/index.ts:109
+    - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:458
+```

--- a/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md
+++ b/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md
@@ -1,0 +1,253 @@
+# Agent B — Operation Decomposition / Strategies / Rules
+
+## Axis Ownership
+Break mega-ops into coherent smaller ops and define strategy/rules factoring, with emphasis on:
+- `compute-tectonic-history`,
+- op orchestration within steps,
+- eliminating op-calls-op composition smells.
+
+## Deliverables
+1. Decomposition map for major Foundation ops.
+2. Proposed op catalog (ids/kinds, boundaries, sequencing assumptions).
+3. Strategy and rule module factoring model per decomposed op.
+
+## Working Notes (append-only)
+- 
+
+## Proposed target model
+- 
+
+## Breaking-change inventory
+- 
+
+## Open risks
+- 
+
+## Decision asks for orchestrator
+- 
+
+### 2026-02-14 — Agent B decomposition pass
+
+#### Evidence snapshot
+- The modeling rules are explicit that steps orchestrate and ops stay atomic/internal (steps call ops; strategies/rules stay internal; avoid mega-ops). [evidence: docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:25, docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:30, docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:136, docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:139]
+- The Foundation spike already locks "atomic ops" + "no op-calls-op" as an invariant. [evidence: docs/projects/engine-refactor-v1/resources/workflow/domain-refactor/plans/foundation/spike-foundation-modeling.md:267, docs/projects/engine-refactor-v1/resources/workflow/domain-refactor/plans/foundation/spike-foundation-modeling.md:466]
+- `compute-tectonic-history` is materially monolithic (1563 LOC) and currently calls another op (`computeTectonicSegments.run`) inside op runtime. [evidence: mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1, mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1184, mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1192]
+- Inference: `compute-tectonic-history` accepts `input.segments` by contract/step wiring but recomputes per-era segments internally with default config; this means provided segments are not driving history behavior. [evidence: mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/contract.ts:206, mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:74, mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1184]
+- Step wiring is currently mostly one-op-per-step except `tectonics`; we can keep step boundaries and still move composition into steps without stage explosion. [evidence: mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.contract.ts:15, mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateMotion.contract.ts:16, mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts:27, mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:771]
+- Other large ops with mixed concerns: `compute-plate-graph` (seed planning + partition assignment), `compute-plate-motion` (fit + diagnostics), `compute-plates-tensors` delegating to a large projection function. [evidence: mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/index.ts:341, mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/index.ts:544, mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-motion/index.ts:121, mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-motion/index.ts:192, mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/index.ts:45, mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/lib/project-plates.ts:75]
+- `compute-crust-evolution` exposes strategy knobs in contract but runtime currently ignores config (`_config`), so factoring should make config meaning explicit or remove it. [evidence: mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts:14, mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:63]
+
+#### Decomposition map (current -> target)
+- `foundation/compute-tectonic-history` -> split into:
+  - `foundation/compute-era-plate-membership` (derive `plateIdByEra`)
+  - `foundation/compute-segment-events` (convert segment tensors -> tectonic event stream)
+  - `foundation/compute-hotspot-events` (intraplate forcing events)
+  - `foundation/compute-era-tectonic-fields` (diffuse events to per-era fields)
+  - `foundation/compute-tectonic-history-rollups` (totals/fractions/last-era indices)
+  - `foundation/compute-tectonics-current` (newest-era snapshot + cumulative uplift)
+  - `foundation/compute-tracer-advection` (era tracer index transport)
+  - `foundation/compute-tectonic-provenance` (origin/last-boundary/crustAge updates)
+  - Rationale: separates kinematics history, event semantics, field synthesis, and provenance state transitions currently interleaved in one op. [evidence: mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:225, mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:458, mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:972, mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1231, mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1414]
+- `foundation/compute-plate-graph` -> split into:
+  - `foundation/plan-plate-seeds` (role/kind/seed selection + polar lock plan)
+  - `foundation/compute-plate-membership` (weighted region growth assignment)
+  - Rationale: seed policy and partition algorithm are distinct responsibilities with different config pressure. [evidence: mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/index.ts:341, mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/index.ts:517, mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/index.ts:549]
+- `foundation/compute-plate-motion` -> split into:
+  - `foundation/compute-plate-motion-fit` (center/velocity/omega)
+  - `foundation/score-plate-motion-fit` (RMS/P90/quality diagnostics)
+  - Rationale: fit and scoring are separable compute vs score concerns. [evidence: mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-motion/index.ts:116, mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-motion/index.ts:138, mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-motion/index.ts:192]
+- `foundation/compute-crust-evolution` -> split into:
+  - `foundation/compute-crust-state-evolution` (maturity/thickness/thermalAge/damage)
+  - `foundation/compute-crust-derived-fields` (type/age/buoyancy/baseElevation/strength)
+  - Rationale: separates time integration state from deterministic projection/derivation. [evidence: mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:77, mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:140, mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:148]
+- `foundation/compute-plates-tensors` -> split into:
+  - `foundation/compute-tile-to-cell-index`
+  - `foundation/project-crust-tiles`
+  - `foundation/project-tectonic-history-tiles`
+  - `foundation/project-tectonic-provenance-tiles`
+  - `foundation/project-plates-tiles`
+  - Rationale: projection sub-products already have independent schemas/artifacts and can be tested independently. [evidence: mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/contract.ts:340, mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts:770, mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts:775, mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts:780, mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts:785, mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts:820]
+
+#### Step weaving proposal (no op-calls-op)
+- Keep current stage step boundaries for initial migration stability: `mesh -> mantle-potential -> mantle-forcing -> crust -> plate-graph -> plate-motion -> tectonics -> crust-evolution -> projection -> plate-topology`. [evidence: mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:771]
+- `tectonics` step should become the explicit orchestrator for era loops:
+  - call `compute-era-plate-membership` once,
+  - for each era: call `compute-tectonic-segments` with era membership, then `compute-segment-events`, `compute-hotspot-events`, `compute-era-tectonic-fields`,
+  - after loop: call rollup/current/provenance ops,
+  - publish `tectonicSegments`, `tectonicHistory`, `tectonicProvenance`, `tectonics`.
+  - This removes op-internal op calls while preserving artifact contract boundaries. [evidence: mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts:20, mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:55, mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1184]
+- `plate-graph` step should orchestrate `plan-plate-seeds -> compute-plate-membership` and then publish existing `foundationPlateGraph` shape.
+- `plate-motion` step should orchestrate `compute-plate-motion-fit -> score-plate-motion-fit` and publish existing artifact shape.
+- `projection` step should orchestrate mapping first (`compute-tile-to-cell-index`) then parallel-safe projections (`project-*` ops) before publishing existing artifact set. [evidence: mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:21]
+
+#### Strategy/rules factoring model (per decomposed op family)
+- General rule:
+  - Default to a single `default` strategy per new op first.
+  - Add strategy variants only when algorithmic variants preserve exact I/O shape.
+  - Keep micro-heuristics in op-local `rules/**` (not exported to steps). [evidence: docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:75, docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:77, docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:243]
+- `compute-era-plate-membership`
+  - strategy: `advected-voronoi` (current behavior)
+  - rules: `computeMeanEdgeLen`, `findNearestCell`, `seedPlateCellsForEra`, `growPlateVoronoi`
+- `compute-segment-events`
+  - strategy: `regime-intensity` (current behavior)
+  - rules: `inferConvergenceMode`, `deriveEventIntensities`, `deriveEventOriginPlate`, `buildSeedCells`
+- `compute-era-tectonic-fields`
+  - strategy: `diffusive-belts`
+  - rules: `deriveEmissionParams`, `driftSeedCells`, `diffuseEventInfluence`, `pickBoundaryTypeByChannel`
+- `compute-tectonic-history-rollups`
+  - strategy: `u8-rollup`
+  - rules: `sumEraChannel`, `computeRecentFraction`, `computeLastActiveEra`
+- `compute-tracer-advection`
+  - strategy: `neighbor-greedy-backtrace`
+  - rules: `chooseDriftNeighbor`, `mixBoundaryAndMantleDrift`
+- `compute-tectonic-provenance`
+  - strategy: `threshold-reset`
+  - rules: `deriveResetThreshold`, `propagateProvenanceByTrace`, `applyRiftReset`, `applyArcReset`, `applyHotspotReset`, `deriveCrustAge`
+- `plan-plate-seeds`
+  - strategy: `polar-caps-v1`
+  - rules: `buildPolarEligibilityMasks`, `pickExtremeYCell`, `pickSeedCell`, `lockContiguousRegion`
+- `compute-plate-membership`
+  - strategy: `weighted-region-growth`
+  - rules: `computeCellResistance`, `growAssignments`
+- `compute-plate-motion-fit`
+  - strategy: `weighted-rigid-fit`
+  - rules: `smoothForcing`, `accumulatePlateMoments`, `fitOmegaWithClamp`
+- `score-plate-motion-fit`
+  - strategy: `histogram-p90`
+  - rules: `computeResiduals`, `buildLogHistogram`, `deriveQualityByte`
+- `compute-crust-state-evolution`
+  - strategy: `history-integrated-v1`
+  - rules: `integrateEraSignals`, `applyRiftRecycle`, `accumulateDamage`
+- `compute-crust-derived-fields`
+  - strategy: `isostatic-proxy-v1`
+  - rules: `deriveTypeFromMaturity`, `deriveBuoyancy`, `deriveStrength`
+- projection family
+  - strategies: `nearest-cell` mapping + `direct-sample` projection variants
+  - rules: `nearestMeshCellForTile`, `computeBoundaryDistanceField`, `sampleHistoryEra`, `sampleProvenance`
+
+#### Candidate target op catalog (ids/kinds + rough I/O boundaries)
+| id | kind | rough input boundary | rough output boundary |
+|---|---|---|---|
+| `foundation/compute-mesh` | `compute` | `{ width,height,rngSeed } + mesh config` | `{ mesh }` |
+| `foundation/compute-mantle-potential` | `compute` | `{ mesh,rngSeed } + source/potential config` | `{ mantlePotential }` |
+| `foundation/compute-mantle-forcing` | `compute` | `{ mesh,mantlePotential } + forcing config` | `{ mantleForcing }` |
+| `foundation/compute-crust` | `compute` | `{ mesh,mantleForcing,rngSeed } + lithosphere config` | `{ crustInit }` |
+| `foundation/plan-plate-seeds` | `plan` | `{ mesh,crust,rngSeed } + plate/polar config` | `{ platesMeta,seedCells,lockedPlateId,allowedMasks }` |
+| `foundation/compute-plate-membership` | `compute` | `{ mesh,crust,seedPlan }` | `{ cellToPlate }` |
+| `foundation/compute-plate-graph` | `compute` | `{ seedPlan,cellToPlate }` | `{ plateGraph }` |
+| `foundation/compute-plate-motion-fit` | `compute` | `{ mesh,plateGraph,mantleForcing } + fit config` | `{ centers,velocities,omega,cellResidual }` |
+| `foundation/score-plate-motion-fit` | `score` | `{ plateFit,cellResidual,plateGraph } + scoring config` | `{ plateFitRms,plateFitP90,plateQuality,cellFitError }` |
+| `foundation/compute-tectonic-segments` | `compute` | `{ mesh,crust,plateGraphLike,plateMotion } + segment config` | `{ segments }` |
+| `foundation/compute-era-plate-membership` | `compute` | `{ mesh,plateGraph,plateMotion } + era drift config` | `{ plateIdByEra }` |
+| `foundation/compute-segment-events` | `compute` | `{ mesh,crust,segments }` | `{ events }` |
+| `foundation/compute-hotspot-events` | `compute` | `{ mesh,mantleForcing,eraPlateId }` | `{ hotspotEvents }` |
+| `foundation/compute-era-tectonic-fields` | `compute` | `{ mesh,events } + emission/weight config` | `{ eraFields }` |
+| `foundation/compute-tectonic-history-rollups` | `compute` | `{ eras,activityThreshold }` | `{ upliftTotal,collisionTotal,subductionTotal,fractureTotal,volcanismTotal,recentFractions,last*Era }` |
+| `foundation/compute-tectonics-current` | `compute` | `{ newestEra,rollups }` | `{ tectonics }` |
+| `foundation/compute-tracer-advection` | `compute` | `{ mesh,eras,mantleForcing,stepsPerEra }` | `{ tracerIndex }` |
+| `foundation/compute-tectonic-provenance` | `compute` | `{ mesh,eras,tracerIndex,plateGraph } + threshold config` | `{ tectonicProvenance }` |
+| `foundation/compute-crust-state-evolution` | `compute` | `{ crustInit,tectonics,tectonicHistory,tectonicProvenance } + evolution config` | `{ maturity,thickness,thermalAge,damage }` |
+| `foundation/compute-crust-derived-fields` | `compute` | `{ crustState }` | `{ type,age,buoyancy,baseElevation,strength }` |
+| `foundation/compute-tile-to-cell-index` | `compute` | `{ width,height,mesh }` | `{ tileToCellIndex }` |
+| `foundation/project-crust-tiles` | `compute` | `{ crust,tileToCellIndex }` | `{ crustTiles }` |
+| `foundation/project-tectonic-history-tiles` | `compute` | `{ tectonicHistory,plateMotion,tileToCellIndex }` | `{ tectonicHistoryTiles }` |
+| `foundation/project-tectonic-provenance-tiles` | `compute` | `{ tectonicProvenance,plateGraph,tileToCellIndex }` | `{ tectonicProvenanceTiles }` |
+| `foundation/project-plates-tiles` | `compute` | `{ plateGraph,plateMotion,tectonics,tileToCellIndex } + boundary projection config` | `{ plates }` |
+| `foundation/compute-plate-topology` | `compute` | `{ plates.id,width,height }` | `{ plateTopology }` |
+
+## Proposed target model
+- Keep Foundation stage step boundaries stable in phase-1 decomposition, but convert heavy steps into explicit multi-op orchestrators (especially `tectonics`, `projection`, `plate-motion`, `plate-graph`). [evidence: mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:771]
+- Remove op-internal composition by extracting `compute-tectonic-history` into eight focused ops and moving all sequencing to `tectonics` step runtime.
+- Preserve external artifact contracts during decomposition (`foundation.tectonicSegments`, `foundation.tectonicHistory`, `foundation.tectonicProvenance`, `foundation.tectonics`, projection artifacts) while replacing the internal op graph.
+- Use strict strategy/rules layering for each decomposed op:
+  - strategy = algorithm variant with stable I/O,
+  - rules = small internal decision units,
+  - no step imports from rules/strategies directly. [evidence: docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:26, docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:27]
+
+## Breaking-change inventory
+- Op id and config surface breaks (internal): introducing new op ids around tectonic history, plate graph, plate motion, and projection decomposition; step contracts need remapping of `ops` bindings. [evidence: mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts:26]
+- Behavior break (likely intentional): tectonic history should stop recomputing segments with `computeTectonicSegments.defaultConfig`; it should consume step-orchestrated segment computation per era.
+- Potential behavior break: making `compute-crust-evolution` config meaningful (or deleting dead knobs) changes outputs because current runtime ignores these knobs. [evidence: mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:63]
+- Stage compile config break: `foundation.index.ts` currently emits monolithic `computeTectonicHistory` config; decomposition introduces nested op configs and likely new defaults. [evidence: mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:748]
+- Test/tooling break: validators and fixtures currently expect current artifact pathways; new intermediate ops imply additional unit targets and updated integration assertions. [evidence: mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts:499]
+
+## Open risks
+- Determinism drift risk if era loop sequencing or RNG label boundaries change during extraction (especially if any per-era randomized behavior is introduced later).
+- Performance risk from per-era segment recomputation now made explicit at step level; could increase runtime cost unless cached/memoized across adjacent eras.
+- Semantic risk in provenance resets if threshold calibration logic is split incorrectly across ops (resets currently depend on era-local maxima + event types). [evidence: mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1372]
+- Integration risk with visualization because `tectonics` step currently assumes one combined `historyResult`; decomposition needs a stable compose point before viz dumping. [evidence: mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:83]
+
+## Decision asks for orchestrator
+- Decide whether decomposition lands as:
+  - A) single-step internal refactor (keep step list unchanged), or
+  - B) additional intermediate steps for tectonic era simulation/provenance.
+- Decide policy for `segments` truth in history:
+  - A) step-owned per-era segment recomputation (recommended), or
+  - B) keep internal recomputation behavior (conflicts with no-op-calls-op posture).
+- Decide whether to preserve current artifact contracts exactly during first cut, or allow additive intermediate artifacts for debug/test leverage.
+- Decide fate of dead `compute-crust-evolution` strategy knobs:
+  - A) activate and honor them,
+  - B) remove from contract.
+- Decide whether `plate-topology` remains step-local (`buildPlateTopology`) or becomes a domain op to align with op-per-concern posture. [evidence: mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts:52]
+
+### 2026-02-14 — Parseability Addendum (YAML)
+
+```yaml
+decomposition_map:
+  compute_tectonic_history:
+    target_ops:
+      - foundation/compute-era-plate-membership
+      - foundation/compute-segment-events
+      - foundation/compute-hotspot-events
+      - foundation/compute-era-tectonic-fields
+      - foundation/compute-tectonic-history-rollups
+      - foundation/compute-tectonics-current
+      - foundation/compute-tracer-advection
+      - foundation/compute-tectonic-provenance
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:225
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:458
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:972
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1414
+  compute_plate_graph:
+    target_ops:
+      - foundation/plan-plate-seeds
+      - foundation/compute-plate-membership
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/index.ts:341
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/index.ts:549
+  compute_plate_motion:
+    target_ops:
+      - foundation/compute-plate-motion-fit
+      - foundation/score-plate-motion-fit
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-motion/index.ts:116
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-motion/index.ts:192
+  compute_plates_tensors:
+    target_ops:
+      - foundation/compute-tile-to-cell-index
+      - foundation/project-crust-tiles
+      - foundation/project-tectonic-history-tiles
+      - foundation/project-tectonic-provenance-tiles
+      - foundation/project-plates-tiles
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/contract.ts:340
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/index.ts:45
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/lib/project-plates.ts:75
+
+step_orchestration_shift:
+  tectonics_step_orchestrates_ops:
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:55
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts:20
+  no_op_calls_op_policy:
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:25
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:30
+    - docs/projects/engine-refactor-v1/resources/workflow/domain-refactor/plans/foundation/spike-foundation-modeling.md:466
+
+strategy_rules_factoring:
+  rule: strategies_keep_io_stable_rules_hold_micro_policies
+  evidence_paths:
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:75
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:77
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:243
+```

--- a/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md
+++ b/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md
@@ -1,0 +1,180 @@
+# Agent C — Foundation Stage Topology
+
+## Axis Ownership
+Investigate how Foundation should be split/reorganized into stages (and step sequences) to produce a maintainable architecture and better operation ergonomics.
+
+## Deliverables
+1. Current stage/step topology diagnosis.
+2. Candidate target stage topologies (at least 2 options).
+3. Chosen recommended topology with rationale and gating boundaries.
+
+## Working Notes (append-only)
+- 
+
+## Proposed target model
+- 
+
+## Breaking-change inventory
+- 
+
+## Open risks
+- 
+
+## Decision asks for orchestrator
+- 
+
+### 2026-02-14 - Agent C topology diagnosis
+
+#### Current topology (single stage, 10 ordered steps)
+- Foundation is authored as one stage (`id: "foundation"`) and declares 10 step ids: `mesh`, `mantle-potential`, `mantle-forcing`, `crust`, `plate-graph`, `plate-motion`, `tectonics`, `crust-evolution`, `projection`, `plate-topology`. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:539`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:557`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:771`]
+- Recipe order is stage order from `recipe.ts`, with `foundation` first, then morphology/hydrology/ecology/map/placement stages. [evidence: `mods/mod-swooper-maps/src/recipes/standard/recipe.ts:29`, `mods/mod-swooper-maps/src/recipes/standard/recipe.ts:30`, `mods/mod-swooper-maps/src/recipes/standard/recipe.ts:43`]
+- Runtime execution is linear in compiled recipe node order; there is no runtime topological reordering pass. [evidence: `packages/mapgen-core/src/engine/execution-plan.ts:96`, `packages/mapgen-core/src/engine/PipelineExecutor.ts:107`]
+
+#### Effective in-stage dependency DAG (from step contracts)
+- `mesh` -> `mantle-potential` -> `mantle-forcing` -> `crust` -> (`plate-graph`, `plate-motion`) -> `tectonics` -> `crust-evolution` -> `projection` -> `plate-topology`. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.contract.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mantlePotential.contract.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mantleForcing.contract.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crust.contract.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.contract.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateMotion.contract.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crustEvolution.contract.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.contract.ts:11`]
+- Handoff to Morphology currently happens through projection outputs (`foundation.plates`, `foundation.crustTiles`, `foundation.tectonicHistoryTiles`, `foundation.tectonicProvenanceTiles`). [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.contract.ts:16`, `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/islands.contract.ts:16`, `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/volcanoes.contract.ts:15`]
+
+#### Topology pain points in current single-stage model
+1. The stage authoring surface is overloaded (profiles + 5 advanced sub-surfaces + knobs + studio sentinel compatibility in one module), making the stage a broad coordination point instead of a narrow contract boundary. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:38`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:57`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:108`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:147`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:172`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:223`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:236`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:272`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:552`]
+2. Knob/config normalization for plate count is duplicated across stage compile and two step normalizers, increasing drift risk when one side changes. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:586`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:688`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:731`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts:17`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.ts:17`]
+3. Late-stage concentration is very high: `tectonics.ts` (395 lines) and `projection.ts` (497 lines) are heavy orchestrators with dense viz emission, while they are still inside one stage label (`foundation`). [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:1`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:395`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:1`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:497`]
+4. `plate-topology` is a derived, configless analytics step over already projected tile plates, but it currently shares the same stage-level lifecycle as deep physics generation. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.contract.ts:11`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.contract.ts:14`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts:35`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.ts:39`]
+5. Validation logic for Foundation artifacts is centralized in one large file (708 lines), which increases edit collision probability and slows local reasoning when touching any one artifact boundary. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts:6`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts:708`]
+6. Stage boundaries have proven ergonomics value elsewhere in this repo (Morphology split ADR): explicit stage boundaries improved legibility and knob scoping at the cost of step-id churn. Foundation is exhibiting similar symptoms today. [evidence: `docs/system/ADR.md:117`, `docs/system/ADR.md:131`, `docs/system/ADR.md:132`, `docs/system/ADR.md:129`]
+
+### Candidate target stage topologies
+
+#### Candidate A: 2-stage split (physics spine + projection/topology)
+- `foundation-physics`:
+  - steps: `mesh`, `mantle-potential`, `mantle-forcing`, `crust`, `plate-graph`, `plate-motion`, `tectonics`, `crust-evolution`.
+- `foundation-projection`:
+  - steps: `projection`, `plate-topology`.
+
+Assessment:
+- Pros: minimal graph change, clear mesh-space -> tile-space cut, preserves existing physics chain intact. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.contract.ts:11`]
+- Cons: first stage is still large (8 steps), so configuration and ergonomics pressure remains concentrated. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:771`]
+
+#### Candidate B: 3-stage split (substrate/kinematics -> tectonic history -> projection/topology)
+- `foundation-substrate-kinematics`:
+  - steps: `mesh`, `mantle-potential`, `mantle-forcing`, `crust`, `plate-graph`, `plate-motion`.
+- `foundation-tectonics-history`:
+  - steps: `tectonics`, `crust-evolution`.
+- `foundation-projection`:
+  - steps: `projection`, `plate-topology`.
+
+Assessment:
+- Pros: aligns stage boundaries with artifact handoff clusters (kinematics products, tectonic products, tile products) and keeps each stage semantically coherent. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateMotion.contract.ts:13`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts:19`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crustEvolution.contract.ts:19`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:21`]
+- Pros: naturally isolates the largest/most volatile orchestration files into separate stages (`tectonics.ts`, `projection.ts`). [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:1`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:1`]
+- Cons: more migration churn than Candidate A (more stage-id and config-key changes). [evidence: `packages/mapgen-core/src/authoring/recipe.ts:58`, `docs/system/ADR.md:129`]
+
+#### Candidate comparison summary
+- Candidate A optimizes for lower migration cost.
+- Candidate B optimizes for clearer architecture boundaries and future sliceability.
+- Given current pain concentration around tectonic/projection boundaries, Candidate B gives better long-term maintainability for only moderate extra migration cost.
+
+### Recommended topology and gating rationale
+
+Recommendation: adopt **Candidate B (3-stage split)**.
+
+Proposed sequencing and gates:
+1. Gate after `foundation-substrate-kinematics`: require `foundationMesh`, `foundationMantleForcing`, `foundationCrustInit`, `foundationPlateGraph`, `foundationPlateMotion`. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.contract.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mantleForcing.contract.ts:13`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crust.contract.ts:13`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.contract.ts:13`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateMotion.contract.ts:13`]
+2. Gate after `foundation-tectonics-history`: require `foundationTectonics`, `foundationTectonicSegments`, `foundationTectonicHistory`, `foundationTectonicProvenance`, `foundationCrust`. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts:19`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crustEvolution.contract.ts:19`]
+3. Gate after `foundation-projection`: require `foundationPlates`, `foundationTileToCellIndex`, `foundationCrustTiles`, `foundationTectonicHistoryTiles`, `foundationTectonicProvenanceTiles`, `foundationPlateTopology` before morphology start. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:21`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.contract.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.contract.ts:16`, `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/islands.contract.ts:16`]
+
+Operation ergonomics impact:
+- Better stage-level observability and Studio legibility because semantics move from one broad `foundation` bucket into three narrower stage addresses (same rationale already accepted for morphology split). [evidence: `docs/system/ADR.md:117`, `docs/system/ADR.md:131`, `docs/system/ADR.md:133`]
+- Reduced merge-collision surface in stage compile modules by shrinking the single giant stage file and concentrating each stage’s compile/default logic by concern. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:1`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:772`]
+- Clearer knob ownership:
+  - substrate/kinematics knobs (plateCount-related) stay in stage 1,
+  - projection activity multiplier knobs stay in stage 3 (`computePlates` normalize). [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts:17`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.ts:17`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:56`]
+
+Future maintainability impact:
+- Preserves op contracts/artifact ids while improving composition boundaries (domain contracts remain reusable, stage contracts become clearer). [evidence: `mods/mod-swooper-maps/src/domain/foundation/ops/contracts.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts:739`]
+- Matches the domain-modeling guideline that steps are orchestration boundaries and composition should avoid broad, conflated units. [evidence: `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:13`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:22`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:30`]
+
+## Proposed target model
+- Adopt a 3-stage Foundation topology:
+  1. `foundation-substrate-kinematics` -> `mesh`, `mantle-potential`, `mantle-forcing`, `crust`, `plate-graph`, `plate-motion`.
+  2. `foundation-tectonics-history` -> `tectonics`, `crust-evolution`.
+  3. `foundation-projection` -> `projection`, `plate-topology`.
+- Keep current op ids and artifact ids unchanged (`foundation.*`) to minimize downstream dependency churn. [evidence: `mods/mod-swooper-maps/src/domain/foundation/ops/contracts.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts:739`]
+- Keep recipe ordering explicit in `recipe.ts`, with the three Foundation stages still preceding morphology. [evidence: `mods/mod-swooper-maps/src/recipes/standard/recipe.ts:29`, `mods/mod-swooper-maps/src/recipes/standard/recipe.ts:31`]
+
+## Breaking-change inventory
+- Full step ids will change because step ids are namespaced by stage id in recipe assembly (`<namespace>.<recipe>.<stage>.<step>`). [evidence: `packages/mapgen-core/src/authoring/recipe.ts:58`, `packages/mapgen-core/src/authoring/recipe.ts:65`, `docs/system/ADR.md:129`]
+- Stage config keys will change from one `foundation` config block to multiple Foundation stage blocks (compile schema keyed by stage id). [evidence: `packages/mapgen-core/src/compiler/recipe-compile.ts:81`, `packages/mapgen-core/src/compiler/recipe-compile.ts:83`]
+- Any tooling/tests/docs that reference old `foundation` stage id or full step ids need updates (same class of break observed in morphology split). [evidence: `docs/system/ADR.md:134`]
+- If stage-level labels are surfaced in Studio, uiMeta stage names likely need updates to preserve author readability after split. [evidence: `docs/system/ADR.md:133`]
+
+## Open risks
+- Hidden consumers may rely on hard-coded Foundation full step ids in traces/snapshots/scripts; this is not fully inventoried in this pass. [evidence: `packages/mapgen-core/src/authoring/recipe.ts:58`]
+- If split execution order is miswired, runtime will fail fast with missing dependency errors; there is no runtime reorder fallback. [evidence: `packages/mapgen-core/src/engine/PipelineExecutor.ts:113`, `packages/mapgen-core/src/engine/PipelineExecutor.ts:117`]
+- `plate-topology` currently depends on projected tile plates only; moving it earlier would violate dependency reality. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.contract.ts:11`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:22`]
+- Validation logic remains centralized in one large module; stage split alone does not solve validator collision pressure. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts:6`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts:708`]
+
+## Decision asks for orchestrator
+- Confirm split granularity: approve Candidate B (3-stage) vs Candidate A (2-stage).
+- Confirm final stage ids (`foundation-substrate-kinematics`, `foundation-tectonics-history`, `foundation-projection`) or provide naming edits.
+- Confirm cutover posture for config/tests/docs: hard cutover in one stack (no compatibility aliases), consistent with prior stage-split posture.
+- Confirm whether `plate-topology` should remain bundled with projection or become a later optional analytics stage in a follow-up slice.
+- Confirm whether to keep all current per-step viz emissions in place during topology split, or pair split with a follow-up viz-thinning task.
+
+### 2026-02-14 — Parseability Addendum (YAML)
+
+```yaml
+current_topology:
+  stage_id: foundation
+  ordered_steps:
+    - mesh
+    - mantle-potential
+    - mantle-forcing
+    - crust
+    - plate-graph
+    - plate-motion
+    - tectonics
+    - crust-evolution
+    - projection
+    - plate-topology
+  evidence_paths:
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:539
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:771
+
+candidate_models:
+  A_two_stage_split:
+    stages:
+      - foundation-physics
+      - foundation-projection
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:12
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.contract.ts:11
+  B_three_stage_split:
+    stages:
+      - foundation-substrate-kinematics
+      - foundation-tectonics-history
+      - foundation-projection
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateMotion.contract.ts:13
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts:19
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:21
+
+recommended_model:
+  id: candidate_B_three_stage_split
+  reasons:
+    - isolates volatile tectonics/projection orchestration
+    - aligns stage gates to artifact handoff clusters
+    - improves stage-level legibility for tracing and Studio
+  evidence_paths:
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:1
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:1
+    - docs/system/ADR.md:117
+    - docs/system/ADR.md:131
+
+migration_impact:
+  changed_full_step_ids:
+    - packages/mapgen-core/src/authoring/recipe.ts:65
+  changed_stage_config_keys:
+    - packages/mapgen-core/src/compiler/recipe-compile.ts:81
+  known_break_surface_examples:
+    - mods/mod-swooper-maps/src/maps/__type_tests__/createMap-config.inference.ts:15
+    - docs/system/ADR.md:134
+```

--- a/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-D-integration-wiring-contracts.md
+++ b/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-D-integration-wiring-contracts.md
@@ -1,0 +1,389 @@
+# Agent D — Integration, Wiring, and Contracts
+
+## Axis Ownership
+Map required integration and contract changes across:
+- op contracts,
+- step contracts,
+- foundation artifacts,
+- stage compile/public config envelopes,
+- downstream consumers impacted by boundary correction.
+
+## Deliverables
+1. Contract consistency gap report (inputs/outputs vs usage reality).
+2. Proposed breaking-change matrix (no-compat posture).
+3. Integration/wiring migration outline for cutover.
+
+## Working Notes (append-only)
+- 
+
+## Proposed target model
+- 
+
+## Breaking-change inventory
+- 
+
+## Open risks
+- 
+
+## Decision asks for orchestrator
+- 
+
+### 2026-02-14 — Agent D integration/wiring/contracts pass
+
+#### Contract consistency gap report (ops/steps/artifacts/config compile)
+| Gap ID | Surface | Declared contract | Observed runtime/compile behavior | Integration consequence | Evidence |
+|---|---|---|---|---|---|
+| D-G1 | `foundation/compute-tectonic-history` input + tectonics step wiring | History op declares `input.segments`; `tectonics` step computes segments and passes them into history. | History op recomputes segments internally per era via `computeTectonicSegments.run(..., computeTectonicSegments.defaultConfig)` and never reads `input.segments`. | Step-provided segments are non-authoritative for history/provenance outputs; segment config can diverge from history generation path. | `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/contract.ts:206`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:55`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:67`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1184`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1191` |
+| D-G2 | `compute-crust-evolution` strategy config | Contract exposes strategy knobs (`upliftToMaturity`, `ageToMaturity`, `disruptionToMaturity`). | Strategy `run` uses `_config` and does not reference those knobs. | Public/typed config surface is dead; authored values do not affect outputs. | `mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts:14`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:63` |
+| D-G3 | `compute-crust-evolution` required input edge | Op input requires `tectonicProvenance`; step requires and passes that artifact. | Runtime only validates provenance shape and does not consume fields for computation. | Hard dependency edge with no behavioral effect; wiring cost without output influence. | `mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts:50`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crustEvolution.ts:22`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:74` |
+| D-G4 | `compute-plate-graph` strategy envelope | Contract includes `polarCaps.tangentialSpeed` + `polarCaps.tangentialJitterDeg`. | No runtime references in implementation; identifiers appear only in contract file. | Dead strategy knobs in op contract; any authored values are ignored. | `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:59`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:65` |
+| D-G5 | Foundation stage public/advanced compile surface | Public surface includes `profiles.lithosphereProfile`, `profiles.mantleProfile`; advanced includes `mantleForcing.potentialMode`. | Stage compile consumes only `profiles.resolutionProfile`; mantle override parser consumes only `plumeCount`, `downwellingCount`, `lengthScale01`, `potentialAmplitude01`. | User-facing fields exist but do not affect compiled step config. | `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:40`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:42`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:59`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:585`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:601` |
+| D-G6 | Projection op input optionality vs step contract | `compute-plates-tensors` input marks `tectonicProvenance` optional. | Projection step contract requires `foundationArtifacts.tectonicProvenance` and step always reads/passes it; op still carries null-fallback path. | Optional branch is unreachable in standard pipeline wiring. | `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/contract.ts:152`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:19`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:88`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/lib/project-plates.ts:163` |
+| D-G7 | Foundation stage compile path | Stage compile has canonical lowering plus Studio sentinel branches (`advanced.<stepId>` and profile sentinel). | Sentinel branch can bypass canonical lowering and return per-step raw config blobs. | Dual compile contracts in one stage; conflicts with single-path posture. | `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:552`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:570`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:579`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:170` |
+| D-G8 | Knob application ownership (compile vs step normalize) | Stage comment says knobs apply after defaulted step config. | `plateCount` is applied in stage compile and then applied again in `mesh`/`plate-graph` step normalizers. | Split ownership for same transform raises drift risk across compile surfaces. | `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:234`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:586`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts:17`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.ts:17` |
+| D-G9 | Foundation artifact publication vs downstream reads | Foundation publishes `tectonicSegments`, `plateTopology`, `tileToCellIndex`. | Standard runtime downstream reads only `plates`, `crustTiles`, `tectonicHistoryTiles`, `tectonicProvenanceTiles` from Foundation outputs. | Multiple published artifacts are currently diagnostics-only in runtime wiring. | `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts:20`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.contract.ts:12`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:23`, `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.contract.ts:17`, `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/islands.contract.ts:16`, `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/volcanoes.contract.ts:15` |
+
+#### Concrete mismatch inventory (requested categories)
+1. Input passed but unused:
+   - `computeTectonicHistory.input.segments` is passed by `tectonics` step but ignored in favor of internal recomputation. (evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:74`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1184`)
+   - `computeCrustEvolution.input.tectonicProvenance` is required and passed, but only validated, not used in output equations. (evidence: `mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:75`)
+2. Recomputed outputs:
+   - Tectonic era boundary events are rebuilt from internally recomputed per-era segments using default segment config; this can diverge from published `foundationTectonicSegments`. (evidence: `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1183`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1191`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:65`)
+3. Dead config surfaces:
+   - `compute-crust-evolution` strategy knobs are dead at runtime. (evidence: `mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts:14`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:63`)
+   - `compute-plate-graph.polarCaps.tangentialSpeed` and `tangentialJitterDeg` are declared but unconsumed. (evidence: `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:59`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:65`)
+   - Stage surface fields `profiles.lithosphereProfile`, `profiles.mantleProfile`, and `advanced.mantleForcing.potentialMode` are inert. (evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:40`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:42`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:59`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:601`)
+
+#### Breaking-change matrix (no shims)
+| Break ID | Hard break | Why it is required | Primary impacted wiring | Evidence |
+|---|---|---|---|---|
+| D-BC1 | Remove `segments` from `foundation/compute-tectonic-history` contract and stop op-internal segment recomputation. | Align contract with actual source-of-truth and eliminate op-calls-op composition breach. | `tectonics` step op binding + any tests relying on current contract shape. | `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/contract.ts:206`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1184`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:25` |
+| D-BC2 | Split `foundation/compute-tectonic-history` into focused ops and move orchestration to step layer. | Current op is mega-op and currently hides orchestration internally. | `tectonics` step schema/run, `contracts.ts`, compile-op map, op registry. | `mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1022`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:30`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:71` |
+| D-BC3 | Delete dead op/stage config fields (`crust-evolution` knobs, plate-graph tangential knobs, inert stage profile fields, inert `potentialMode`). | Prevent false configurability and contract drift. | Presets/type-tests/dev scripts that currently include inert keys. | `mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts:14`, `mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:59`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:40`, `mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts:13`, `mods/mod-swooper-maps/src/dev/viz/foundation-run.ts:10` |
+| D-BC4 | Remove Foundation compile sentinel branches (`advanced.<stepId>` and profile sentinel path). | Enforce single compile lowering contract; remove dual-path behavior. | Studio/config producers currently emitting sentinel payload shapes. | `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:552`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:570`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:170` |
+| D-BC5 | Split Foundation into multiple stage ids (recommended topology candidate B). | Reduce stage overloading and align integration boundaries; step ids will change because full ids include stage id. | Recipe config keys (`foundation` -> multiple keys), full step-id consumers, traces, snapshots, type tests. | `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:96`, `packages/mapgen-core/src/authoring/recipe.ts:65`, `packages/mapgen-core/src/compiler/recipe-compile.ts:81`, `mods/mod-swooper-maps/src/maps/__type_tests__/createMap-config.inference.ts:15` |
+| D-BC6A (strict lane split path) | Move tile/map-facing Foundation projection artifacts to Gameplay map artifacts (`artifact:map.*`) in one cut (no dual publish). | Align with strict lane posture from domain modeling spec and Agent A boundary recommendation. | Morphology contracts/steps consuming `foundation.plates`, `foundation.crustTiles`, `foundation.tectonicHistoryTiles`, `foundation.tectonicProvenanceTiles`. | `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:185`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md:54`, `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.contract.ts:17`, `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/islands.contract.ts:16` |
+| D-BC6B (incremental ID stability path) | Keep `artifact:foundation.*` projection IDs for the topology split, but still hard-break op/step contracts now. | Minimizes immediate downstream rewiring while still removing core contract inconsistencies. | Preserves morphology wiring in first cut; defers lane namespace break to a separate hard cut. | `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:100`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md:82` |
+
+#### Integration/wiring migration outline for downstream consumers
+1. Contract cutover first (ops/steps), artifact IDs stable in same commit:
+   - Land `D-BC1` + `D-BC2` + `D-BC3` + `D-BC4` together so no intermediate inconsistent op graph is exposed.
+   - Update `foundation` step contracts and stage compile output together; compile schema is strict and stage-keyed, so partial migration will fail compile. (evidence: `packages/mapgen-core/src/compiler/recipe-compile.ts:85`, `packages/mapgen-core/src/compiler/recipe-compile.ts:125`)
+2. Stage-topology cutover second (if approved):
+   - Replace single `foundation` stage entry with split stage entries in recipe ordering.
+   - Expect full step-id churn because IDs are `namespace.recipe.stage.step`; update any trace assertions/snapshots/tooling keyed by full step id.
+   - Migrate config keys in all concrete map configs/presets and browser test recipe types. (evidence: `mods/mod-swooper-maps/src/recipes/standard/recipe.ts:29`, `packages/mapgen-core/src/authoring/recipe.ts:65`, `mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts:4`, `mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts:11`, `mods/mod-swooper-maps/src/recipes/browser-test/recipe.ts:14`)
+3. Lane split cutover third (only if strict path chosen):
+   - Rewire morphology consumers from Foundation projection artifacts to Gameplay map artifacts in one hard cut.
+   - Update `morphology-coasts` and `morphology-features` step contracts + runtime reads in the same change so dependency tags remain satisfiable.
+   - Update docs/catalog references after wiring cutover to avoid stale contract docs. (evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.ts:178`, `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/volcanoes.ts:77`, `docs/projects/pipeline-realism/resources/spec/artifact-catalog.md:37`)
+4. Diagnostic/observability reconciliation:
+   - Decide explicitly whether diagnostics-only Foundation artifacts (`tectonicSegments`, `plateTopology`, `tileToCellIndex`) remain public truth/projection surfaces or are reduced/relocated.
+   - If retained, document them as diagnostics-only consumers to avoid future “unused artifact” ambiguity.
+
+## Proposed target model
+- Recommended sequencing posture: **contract cleanup first, topology split second, lane split third (decision-gated)**.
+- Keep one canonical compile path for Foundation stage surfaces (remove sentinel dual path) and keep step ownership of orchestration per spec. (evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:552`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:25`)
+- Make `tectonics` step the single orchestration boundary for tectonic-history sub-ops; no op-internal `computeTectonicSegments` calls.
+- Resolve the checkpoint conflict explicitly:
+  - If orchestrator selects strict lane split now, do `D-BC6A` in same stack and rewire morphology immediately.
+  - If orchestrator selects incremental artifact-ID stability first, do `D-BC6B` now and schedule lane split as the next hard-break stack.
+
+## Breaking-change inventory
+- Remove `computeTectonicHistory.input.segments` + internal recomputation path; replace with explicit step-owned sequencing.
+- Split `compute-tectonic-history` op surface into focused contracts (per Agent B decomposition pressure) and rebind tectonics step.
+- Remove dead config keys:
+  - `compute-crust-evolution` strategy knobs,
+  - `compute-plate-graph.polarCaps.tangentialSpeed/tangentialJitterDeg`,
+  - stage-level inert fields (`profiles.lithosphereProfile`, `profiles.mantleProfile`, `advanced.mantleForcing.potentialMode`).
+- Remove compile sentinel branches in foundation stage.
+- Topology split break: stage IDs and full step IDs change; recipe config keys and typed config tests must migrate.
+- Optional policy break (decision-gated): lane split from `artifact:foundation.*` projection artifacts to `artifact:map.*` gameplay artifacts.
+
+## Open risks
+- Hidden consumers of current full step IDs and stage key `foundation` in tooling/scripts may fail silently until compile/run time. (evidence: `mods/mod-swooper-maps/src/dev/viz/foundation-run.ts:10`, `mods/mod-swooper-maps/src/maps/__type_tests__/createMap-config.inference.ts:15`)
+- Removing inert config keys is semantically correct but may break authored configs/docs that currently include those keys even if they are no-op.
+- Lane split in same stack as topology split creates a high blast radius across morphology + docs + visual diagnostics.
+- If diagnostics-only artifacts are dropped without replacement, observability workflows that depend on them may regress.
+
+## Decision asks for orchestrator
+- Approve **lane policy now**:
+  - Option 1: strict lane split now (`D-BC6A`) and accept immediate morphology contract rewiring.
+  - Option 2: incremental artifact ID stability for this stack (`D-BC6B`), with a separate scheduled hard lane split next.
+- Approve dead-surface cleanup policy: remove inert config keys now vs implement them before contract cleanup.
+- Approve topology split timing: same stack as op decomposition vs follow-up stack after op contract cleanup lands.
+- Confirm diagnostics contract policy for `artifact:foundation.tectonicSegments`, `artifact:foundation.plateTopology`, and `artifact:foundation.tileToCellIndex` (retain as explicit diagnostics surfaces vs retire/relocate).
+
+### 2026-02-14 — Parseability formatting update (no content changes)
+
+#### Contract consistency gap report (YAML evidence map)
+```yaml
+contract_gaps:
+  - gap_id: D-G1
+    topic: compute-tectonic-history input segments ignored
+    consequence: step-provided segments are non-authoritative for history/provenance outputs
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/contract.ts:206
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:55
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:67
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1184
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1191
+  - gap_id: D-G2
+    topic: compute-crust-evolution dead strategy config
+    consequence: public knobs do not affect outputs
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts:14
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:63
+  - gap_id: D-G3
+    topic: required tectonicProvenance dependency with no behavioral usage
+    consequence: hard edge with wiring cost but no output influence
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts:50
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crustEvolution.ts:22
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:74
+  - gap_id: D-G4
+    topic: compute-plate-graph dead tangential polar cap knobs
+    consequence: authored values are ignored
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:59
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:65
+  - gap_id: D-G5
+    topic: inert stage public/advanced fields
+    consequence: user-facing stage fields do not influence compiled step config
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:40
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:42
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:59
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:585
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:601
+  - gap_id: D-G6
+    topic: compute-plates-tensors optional provenance vs required step contract
+    consequence: optional branch unreachable in standard wiring
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/contract.ts:152
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:19
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:88
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plates-tensors/lib/project-plates.ts:163
+  - gap_id: D-G7
+    topic: dual compile path via sentinel branches
+    consequence: conflicting compile contracts in one stage
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:552
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:570
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:579
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:170
+  - gap_id: D-G8
+    topic: plateCount knob applied at both compile and step normalize layers
+    consequence: ownership split increases drift risk
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:234
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:586
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts:17
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.ts:17
+  - gap_id: D-G9
+    topic: published Foundation artifacts not consumed by runtime downstream
+    consequence: diagnostics-only surfaces are mixed into public artifact contract
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts:20
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateTopology.contract.ts:12
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:23
+      - mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.contract.ts:17
+      - mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/islands.contract.ts:16
+      - mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/volcanoes.contract.ts:15
+```
+
+#### Concrete mismatch inventory (YAML evidence map)
+```yaml
+mismatches:
+  input_passed_but_unused:
+    - claim: computeTectonicHistory.input.segments passed by step but ignored by op runtime
+      evidence_paths:
+        - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:74
+        - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1184
+    - claim: computeCrustEvolution.input.tectonicProvenance required/passed but only validated
+      evidence_paths:
+        - mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:75
+  recomputed_outputs:
+    - claim: tectonic history era boundaries rebuilt from internal per-era segment recomputation
+      evidence_paths:
+        - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1183
+        - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1191
+        - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:65
+  dead_config_surfaces:
+    - claim: compute-crust-evolution strategy knobs are inert
+      evidence_paths:
+        - mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts:14
+        - mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts:63
+    - claim: compute-plate-graph tangential polar cap knobs are inert
+      evidence_paths:
+        - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:59
+        - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:65
+    - claim: stage profiles.lithosphereProfile, profiles.mantleProfile, advanced.mantleForcing.potentialMode are inert
+      evidence_paths:
+        - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:40
+        - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:42
+        - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:59
+        - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:601
+```
+
+#### Breaking-change matrix (YAML evidence map, no shims)
+```yaml
+breaking_changes:
+  - break_id: D-BC1
+    change: remove compute-tectonic-history input.segments and internal recomputation
+    impact_area: tectonics step op binding and contract shape
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/contract.ts:206
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1184
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:25
+  - break_id: D-BC2
+    change: split compute-tectonic-history into focused ops; move orchestration to step layer
+    impact_area: step contracts, op registry, compile-op bindings
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/index.ts:1022
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:30
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:71
+  - break_id: D-BC3
+    change: delete dead config fields across ops and stage compile surfaces
+    impact_area: presets, type tests, dev scripts that include inert keys
+    evidence_paths:
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts:14
+      - mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts:59
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:40
+      - mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts:13
+      - mods/mod-swooper-maps/src/dev/viz/foundation-run.ts:10
+  - break_id: D-BC4
+    change: remove compile sentinel branches and keep one canonical lowering path
+    impact_area: Studio/config producers emitting sentinel payloads
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:552
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:570
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:170
+  - break_id: D-BC5
+    change: split Foundation stage ids (topology candidate B)
+    impact_area: recipe config keys, full step-id consumers, snapshots, type tests
+    evidence_paths:
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:96
+      - packages/mapgen-core/src/authoring/recipe.ts:65
+      - packages/mapgen-core/src/compiler/recipe-compile.ts:81
+      - mods/mod-swooper-maps/src/maps/__type_tests__/createMap-config.inference.ts:15
+  - break_id: D-BC6A
+    change: strict lane split now to artifact:map.*
+    impact_area: morphology contracts/steps currently reading foundation projection artifacts
+    evidence_paths:
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:185
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md:54
+      - mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.contract.ts:17
+      - mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/islands.contract.ts:16
+  - break_id: D-BC6B
+    change: incremental artifact ID stability first; defer lane namespace break
+    impact_area: preserves immediate morphology wiring but defers namespace break
+    evidence_paths:
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:100
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md:82
+```
+
+#### Integration/wiring migration outline (YAML evidence map)
+```yaml
+migration_outline:
+  - phase: contract_cutover_first
+    actions:
+      - land D-BC1, D-BC2, D-BC3, D-BC4 together
+      - update foundation step contracts and stage compile output in same commit
+    evidence_paths:
+      - packages/mapgen-core/src/compiler/recipe-compile.ts:85
+      - packages/mapgen-core/src/compiler/recipe-compile.ts:125
+  - phase: stage_topology_cutover_second
+    actions:
+      - replace single foundation stage entry with split stage entries
+      - migrate full step-id keyed consumers and config keys
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/recipe.ts:29
+      - packages/mapgen-core/src/authoring/recipe.ts:65
+      - mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts:4
+      - mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts:11
+      - mods/mod-swooper-maps/src/recipes/browser-test/recipe.ts:14
+  - phase: lane_split_cutover_third_decision_gated
+    actions:
+      - rewire morphology from foundation projection artifacts to gameplay map artifacts in one hard cut
+      - update contracts/runtime reads and artifact catalog together
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.ts:178
+      - mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/volcanoes.ts:77
+      - docs/projects/pipeline-realism/resources/spec/artifact-catalog.md:37
+```
+
+## Proposed target model
+- Recommended sequencing remains: contract cleanup first, topology split second, lane split third (decision-gated).
+- Keep one canonical Foundation compile path and step-owned orchestration; no op-internal op chaining.
+- Resolve strict lane split vs incremental artifact ID stability as an explicit orchestrator decision.
+```yaml
+evidence_paths:
+  sequencing:
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:96
+  single_compile_path:
+    - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:552
+    - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:25
+  op_decomposition_pressure:
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:71
+  lane_policy_conflict:
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md:54
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:100
+```
+
+## Breaking-change inventory
+```yaml
+breaking_change_inventory:
+  - id: D-BC1
+    summary: remove history input.segments and internal segment recomputation
+  - id: D-BC2
+    summary: split mega-op history into focused ops with step-layer orchestration
+  - id: D-BC3
+    summary: delete dead config fields across ops and stage compile surfaces
+  - id: D-BC4
+    summary: remove compile sentinel branches and dual-path lowering
+  - id: D-BC5
+    summary: split foundation stage IDs and migrate full step-id/config consumers
+  - id: D-BC6A_or_D-BC6B
+    summary: choose strict lane split now or incremental artifact ID stability now
+```
+
+## Open risks
+```yaml
+open_risks:
+  - risk: hidden full-step-id and stage-key consumers outside recipe compile path
+    evidence_paths:
+      - mods/mod-swooper-maps/src/dev/viz/foundation-run.ts:10
+      - mods/mod-swooper-maps/src/maps/__type_tests__/createMap-config.inference.ts:15
+  - risk: authored configs/docs include inert keys that will hard-fail after cleanup
+    evidence_paths:
+      - mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts:13
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:40
+  - risk: combining topology split and strict lane split in one stack creates high blast radius
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.contract.ts:17
+      - mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/islands.contract.ts:16
+```
+
+## Decision asks for orchestrator
+```yaml
+decision_asks:
+  - ask: choose lane policy now
+    options:
+      - id: D-BC6A
+        label: strict lane split now (artifact:map.*)
+      - id: D-BC6B
+        label: incremental artifact ID stability now; lane split in follow-up hard break
+  - ask: approve dead-surface policy
+    options:
+      - remove inert keys now
+      - implement semantics before cleanup
+  - ask: approve topology split timing
+    options:
+      - same stack as op decomposition
+      - follow-up stack after op contract cleanup
+  - ask: diagnostics artifact policy for foundation.tectonicSegments/plateTopology/tileToCellIndex
+    options:
+      - retain as explicit diagnostics-only surfaces
+      - retire or relocate
+```

--- a/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-E-viz-tracing-boundaries.md
+++ b/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-E-viz-tracing-boundaries.md
@@ -1,0 +1,127 @@
+# Agent E — Visualization and Tracing Boundaries
+
+## Axis Ownership
+Define how visualization/tracing should align with target Foundation boundaries without leaking orchestration or contract concerns across layers.
+
+## Deliverables
+1. Current coupling/bleed inventory (stage/step/op -> viz/tracing).
+2. Target boundary model for debug/observability surfaces.
+3. Recommended organization of viz/tracing ownership in refactored structure.
+
+## Working Notes (append-only)
+- 
+
+## Proposed target model
+- 
+
+## Breaking-change inventory
+- 
+
+## Open risks
+- 
+
+## Decision asks for orchestrator
+- 
+
+### 2026-02-14 — Agent E viz/tracing boundary pass
+
+#### Working Notes (append-only)
+- Foundation still executes as a single stage (`id: "foundation"`) with all 10 step contracts under one stage envelope, and runtime full step ids are derived as `<namespace>.<recipe>.<stageId>.<stepId>`. This means observability identity currently inherits stage topology directly. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:557`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:771`, `packages/mapgen-core/src/authoring/recipe.ts:58`, `packages/mapgen-core/src/authoring/recipe.ts:65`]
+- Foundation viz emission is step-owned (not op-owned) and concentrated in two heavy steps: `projection.ts` (~28 emission/trace callsites) and `tectonics.ts` (~22), with lighter emissions spread across the other 8 steps. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:111`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:475`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:84`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:381`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts:51`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateMotion.ts:123`]
+- `tectonics.ts` interleaves orchestration + publication + dense viz emission for both current tensors and per-era history variants, including repeated boundary-type category definitions local to the step. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:55`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:79`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:84`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:18`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:320`]
+- `projection.ts` does the same for tile projection artifacts plus diagnostics; it emits many tile layers and also emits a custom ASCII trace event payload (`kind: foundation.plates.ascii.boundaryType`) outside the viz-layer envelope. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:90`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:105`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:111`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:355`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:475`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:490`]
+- Foundation uses one local viz helper module (`steps/viz.ts`) for geometry conversion across both mesh/world and tile-topology emissions; helper ownership is currently by step folder, not by domain lane. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/viz.ts:1`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/viz.ts:25`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/viz.ts:76`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/viz.ts:92`]
+- Core interfaces couple viz to tracing by design: `ExtendedMapContext` carries both `trace` and `viz`, `VizDumper.dump*` requires `TraceScope`, and `PipelineExecutor` replaces `context.trace` per step. [evidence: `packages/mapgen-core/src/core/types.ts:213`, `packages/mapgen-core/src/core/types.ts:275`, `packages/mapgen-core/src/engine/PipelineExecutor.ts:124`, `packages/mapgen-core/src/engine/PipelineExecutor.ts:126`]
+- Dump emission is currently tied to `trace.isVerbose`; each `dump*` call emits a `step.event` payload and layer identity is keyed with `trace.stepId`. [evidence: `mods/mod-swooper-maps/src/dev/viz/dump.ts:153`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:154`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:162`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:175`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:211`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:270`]
+- The sink indexes manifests by step identity and only materializes viz layers when `event.data.type === "viz.layer.dump.v1"`; custom step events remain trace-only. [evidence: `mods/mod-swooper-maps/src/dev/viz/dump.ts:101`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:105`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:111`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:114`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:117`]
+- Contract-level identity also bakes in step topology: `VizLayerIdentityV1` stores `stepId`, and `createVizLayerKey` includes `stepId` in the canonical key material. [evidence: `packages/mapgen-viz/src/index.ts:102`, `packages/mapgen-viz/src/index.ts:107`, `packages/mapgen-viz/src/index.ts:204`, `packages/mapgen-viz/src/index.ts:213`]
+- Foundation ops themselves appear instrumentation-free today (no `TraceScope`, `context.trace`, `VizDumper`, or `dump*` references in `mods/mod-swooper-maps/src/domain/foundation/ops`), so observability responsibility is currently step-only. [evidence: `mods/mod-swooper-maps/src/domain/foundation/ops` directory scan for `context.trace|TraceScope|VizDumper|dumpGrid|dumpPoints|dumpSegments` returned no matches]
+- Observable lane bleed already exists in naming/ownership: Foundation projection publishes tile/map-facing artifacts (`foundation.plates`, `foundation.crustTiles`, `foundation.tectonicHistoryTiles`, `foundation.tectonicProvenanceTiles`) while a separate gameplay-owned `artifact:map.*` namespace already exists for projection metadata/materialization. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:21`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/artifacts.ts:770`, `mods/mod-swooper-maps/src/recipes/standard/map-artifacts.ts:31`, `mods/mod-swooper-maps/src/recipes/standard/map-artifacts.ts:34`]
+- Checkpoint context to preserve in this axis: lane split is contested (keep Foundation projection vs move map-facing projection to `artifact:map.*`), and topology split is contested (2-stage vs 3-stage, with 3-stage preferred in stage analysis). [evidence: `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/master-scratch.md:40`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/master-scratch.md:41`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/master-scratch.md:46`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/master-scratch.md:47`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:47`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:57`]
+- Op decomposition pressure materially affects this axis: `compute-tectonic-history` decomposition proposals keep warning that `tectonics` viz currently expects one aggregated `historyResult` compose point. [evidence: `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:34`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:78`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:178`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:67`]
+
+#### Boundary-bleed hotspots
+- Bleed A: runtime observability enablement is coupled to trace verbosity, so there is no independent viz gate in the current contract surface. [evidence: `packages/mapgen-core/src/trace/index.ts:177`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:154`, `docs/system/libs/mapgen/pipeline-visualization-deckgl.md:81`, `docs/system/libs/mapgen/pipeline-visualization-deckgl.md:82`]
+- Bleed B: visualization identity is coupled to orchestration topology (`stepId` in `layerKey` + manifest step list), so stage-id changes become viz-contract changes even when data semantics (`dataTypeKey`) are unchanged. [evidence: `packages/mapgen-viz/src/index.ts:12`, `packages/mapgen-viz/src/index.ts:107`, `packages/mapgen-viz/src/index.ts:213`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:105`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:162`]
+- Bleed C: truth/projection concerns co-reside in Foundation naming and emission (`foundation.history.*` appears in world-space tectonics and tile-space projection), which blurs ownership boundaries for observability catalogs. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:320`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:355`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:21`]
+- Bleed D: legend/category metadata for similar concepts is duplicated across steps (example: boundary type category arrays in both `tectonics.ts` and `projection.ts`). [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:18`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:132`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:365`]
+- Bleed E: custom debug traces (ASCII summaries) are embedded in projection step orchestration and bypass the typed viz-layer path, fragmenting observability shapes. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:475`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:114`]
+
+## Proposed target model
+- Ownership split by boundary, not by file size:
+  1. **Trace transport ownership (`mapgen-core`)**: keep `TraceSession`/`TraceScope` and sink mechanics as the shared transport spine. [evidence: `packages/mapgen-core/src/trace/index.ts:43`, `packages/mapgen-core/src/engine/PipelineExecutor.ts:99`]
+  2. **Lane observability ownership (`mods/mod-swooper-maps`)**:
+     - Foundation truth-lane observability owns mesh/world emissions for physics truth artifacts (mesh, plate graph/motion, tectonics, crust truth).
+     - Projection/materialization observability owns tile/map emissions and map-facing projection artifacts (targeting `artifact:map.*` posture when lane split is approved). [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.contract.ts:19`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:21`, `mods/mod-swooper-maps/src/recipes/standard/map-artifacts.ts:34`]
+  3. **Step orchestration ownership**: steps remain the callsite owners, but emission assembly should move to lane-owned emitter modules so compute orchestration and observability formatting are not interleaved in monolithic step bodies. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:55`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:80`]
+- Stage topology recommendation for this axis: align with 3-stage split (`substrate-kinematics`, `tectonics-history`, `projection`) because it isolates the two highest-emission boundaries (`tectonics`, `projection`) into dedicated stage envelopes; this improves trace filtering and ownership clarity more than a 2-stage split. [evidence: `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:57`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:67`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:1`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:1`]
+- Op decomposition posture for observability: preserve **step-level public emit boundaries** while allowing internal op decomposition; add optional op-tagged sub-events under `step.event` only when needed for diagnosis, but keep manifest layer publication at step compose points to avoid layer-key explosion. [evidence: `packages/mapgen-core/src/trace/index.ts:14`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:160`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:178`]
+- Data identity policy: keep `dataTypeKey` as semantic owner identity and treat `layerKey` as transport identity; lane split should change semantic ownership prefixes intentionally (e.g. Foundation truth vs map projection) rather than implicitly via stage-id churn. [evidence: `packages/mapgen-viz/src/index.ts:17`, `packages/mapgen-viz/src/index.ts:204`, `docs/projects/mapgen-studio/VIZ-SDK-V1.md:38`, `docs/projects/mapgen-studio/VIZ-SDK-V1.md:203`]
+
+## Breaking-change inventory
+- Stage split (2-stage or 3-stage) changes full `stepId` strings because step id includes `stageId`; this cascades into trace step keys and viz `layerKey` values. [evidence: `packages/mapgen-core/src/authoring/recipe.ts:65`, `packages/mapgen-viz/src/index.ts:213`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:557`]
+- Dump manifest step inventory and layer `stepIndex` ordering will change with stage topology changes, even if `dataTypeKey` remains stable. [evidence: `mods/mod-swooper-maps/src/dev/viz/dump.ts:103`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:117`, `packages/mapgen-viz/src/index.ts:200`]
+- Any explicit `env.trace.steps` pinning by step id must be updated after stage split; current dev tooling derives this dynamically from plan nodes, but static configs/scripts would break. [evidence: `packages/mapgen-core/src/core/env.ts:18`, `mods/mod-swooper-maps/src/dev/viz/standard-run.ts:50`, `mods/mod-swooper-maps/src/dev/viz/foundation-run.ts:47`]
+- If lane split moves tile/map-facing projection out of Foundation namespace, downstream morphology and any consumers requiring `foundation.plates`/tile tensors need contract rewiring (or hard cutover). [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/islands.contract.ts:16`, `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.contract.ts:16`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:22`]
+- Op decomposition that introduces new steps (instead of step-internal composition) would further multiply step-id/layer-key churn; step-internal decomposition avoids this specific external observability break. [evidence: `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:159`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:160`]
+
+## Open risks
+- Highest risk: unintentional observability drift where the same semantic field appears under mixed lane ownership (`foundation.*` + `map.*`) during migration, confusing Studio grouping and historical diffing. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:111`, `mods/mod-swooper-maps/src/recipes/standard/map-artifacts.ts:34`, `docs/projects/mapgen-studio/VIZ-SDK-V1.md:200`]
+- Topology churn risk: because `layerKey` is step-bound, historical cross-run comparisons by layer key will fragment after stage renames unless comparison tooling pivots to `dataTypeKey/space/variant`. [evidence: `packages/mapgen-viz/src/index.ts:213`, `docs/projects/mapgen-studio/VIZ-SDK-V1.md:34`, `docs/projects/mapgen-studio/VIZ-SDK-V1.md:51`]
+- Decomposition risk: if tectonics decomposition removes the single aggregate compose point too early, viz emissions can become partial/inconsistent across eras and break expected manifests. [evidence: `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:178`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:314`]
+- Operability risk: viz is currently `verbose`-gated; large decomposition or extra sub-events can sharply increase trace volume and dump size if no boundary policy is enforced. [evidence: `packages/mapgen-core/src/trace/index.ts:177`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:154`, `mods/mod-swooper-maps/src/dev/viz/dump.ts:87`]
+
+## Decision asks for orchestrator
+- Confirm boundary posture: adopt the 3-stage split for observability ownership (`substrate-kinematics`, `tectonics-history`, `projection`) vs 2-stage. Recommendation: 3-stage for cleaner viz/tracing ownership boundaries. [evidence: `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:57`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:67`]
+- Confirm lane posture: approve hard truth/projection lane split for map-facing products (`artifact:map.*`) or keep Foundation owning tile projections for this migration slice. [evidence: `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/master-scratch.md:40`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/master-scratch.md:41`, `mods/mod-swooper-maps/src/recipes/standard/map-artifacts.ts:31`]
+- Confirm identity policy during split: accept `layerKey` churn as expected (step-bound contract) or queue a viz-contract evolution to decouple layer identity from step id in a later version. [evidence: `packages/mapgen-viz/src/index.ts:12`, `packages/mapgen-viz/src/index.ts:213`, `docs/projects/mapgen-studio/VIZ-SDK-V1.md:19`]
+- Confirm decomposition posture for observability: keep op decomposition step-internal at first (stable public step emits) vs introducing new intermediate steps with finer-grained trace/viz surfaces. [evidence: `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/master-scratch.md:54`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:159`]
+- Confirm trace/viz gating policy: keep current verbose-only viz gate, or define a separate viz gate to reduce coupling and control dump size during decomposition-heavy iterations. [evidence: `packages/mapgen-core/src/trace/index.ts:177`, `docs/system/libs/mapgen/pipeline-visualization-deckgl.md:82`]
+
+### 2026-02-14 — Parseability Addendum (YAML)
+
+```yaml
+observability_coupling:
+  step_id_shapes_viz_identity:
+    evidence_paths:
+      - packages/mapgen-core/src/authoring/recipe.ts:65
+      - packages/mapgen-viz/src/index.ts:213
+      - mods/mod-swooper-maps/src/dev/viz/dump.ts:105
+  viz_gate_is_trace_verbose:
+    evidence_paths:
+      - packages/mapgen-core/src/trace/index.ts:177
+      - mods/mod-swooper-maps/src/dev/viz/dump.ts:154
+      - docs/system/libs/mapgen/pipeline-visualization-deckgl.md:82
+
+hotspots:
+  tectonics_step_density:
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:84
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:381
+  projection_step_density:
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:111
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:475
+
+boundary_bleed:
+  truth_projection_lane_mix:
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.contract.ts:21
+      - mods/mod-swooper-maps/src/recipes/standard/map-artifacts.ts:34
+  duplicated_boundary_legends:
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:18
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:132
+
+recommendation:
+  stage_topology_for_viz:
+    value: foundation_substrate_kinematics__foundation_tectonics_history__foundation_projection
+    evidence_paths:
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:57
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:67
+  compose_point_policy:
+    value: keep_public_emit_boundaries_at_step_level_during_op_decomposition
+    evidence_paths:
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:159
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:178
+```

--- a/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-F-testing-docs-guardrails.md
+++ b/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-F-testing-docs-guardrails.md
@@ -1,0 +1,403 @@
+# Agent F — Testing, Docs, and Guardrails
+
+## Axis Ownership
+Define enforcement strategy for no-shim/no-legacy cutover using:
+- tests,
+- lint/guardrails,
+- docs updates and canonical references.
+
+## Deliverables
+1. Gap inventory in current tests/guardrails for boundary correctness.
+2. Proposed test matrix for structural and contract integrity.
+3. Proposed docs and lint/guardrail updates to lock architecture.
+
+## Working Notes (append-only)
+- 
+
+## Proposed target model
+- 
+
+## Breaking-change inventory
+- 
+
+## Open risks
+- 
+
+## Decision asks for orchestrator
+- 
+
+### 2026-02-14 — Agent F guardrail audit (research-only)
+
+#### 1) Audit of current test / validation / lint guardrails (boundary + contract integrity)
+- CI currently executes `build`, `lint`, and `test:ci`, but does **not** run `bun run check`, `lint:domain-refactor-guardrails`, or `lint:adapter-boundary` explicitly as required jobs. This means key architecture guardrails are not guaranteed by CI. [evidence: `.github/workflows/ci.yml:50`, `.github/workflows/ci.yml:53`, `.github/workflows/ci.yml:56`, `package.json:9`, `package.json:38`, `package.json:39`]
+- `check` includes `lint:domain-refactor-guardrails` + `lint:mapgen-docs`, but still omits `lint:adapter-boundary`; additionally CI never calls `check`. [evidence: `package.json:9`, `package.json:38`, `.github/workflows/ci.yml:53`]
+- Domain guardrails default to `boundary` profile, and boundary mode only checks two ops-level patterns (`adapter/context` crossing + `artifact|effect:map` in ops). Stage/contract strict checks are gated behind opt-in `full` profile. [evidence: `scripts/lint/lint-domain-refactor-guardrails.sh:24`, `scripts/lint/lint-domain-refactor-guardrails.sh:236`, `scripts/lint/lint-domain-refactor-guardrails.sh:238`, `scripts/lint/lint-domain-refactor-guardrails.sh:189`, `scripts/lint/lint-domain-refactor-guardrails.sh:336`]
+- The stricter anti-shim checks already exist in `full` mode (`domain deep-imports`, `domain tag/artifact shims`, `domain artifacts modules`), but are not mandatory today. [evidence: `scripts/lint/lint-domain-refactor-guardrails.sh:343`, `scripts/lint/lint-domain-refactor-guardrails.sh:348`, `scripts/lint/lint-domain-refactor-guardrails.sh:350`]
+- Adapter-boundary lint exists and has allowlist debt, but is not wired into CI and not part of `check`; therefore adapter boundary regressions can pass CI if ESLint does not catch them. [evidence: `scripts/lint/lint-adapter-boundary.sh:24`, `scripts/lint/lint-adapter-boundary.sh:29`, `package.json:9`, `package.json:38`, `.github/workflows/ci.yml:53`]
+- Pre-commit hook currently only publishes the resources submodule; it does not enforce architecture checks pre-commit. [evidence: `scripts/git-hooks/pre-commit:4`, `scripts/git-hooks/pre-commit:6`]
+- ESLint already enforces meaningful structural boundaries (restricted deep imports, step/runtime restrictions, contract import rules), and **this does run in CI** via `bun run lint`. [evidence: `eslint.config.js:68`, `eslint.config.js:92`, `eslint.config.js:176`, `.github/workflows/ci.yml:53`]
+- Existing test guardrails are strong but uneven:
+  - `no-shadow-paths` bans dual/shadow/compare surfaces in standard pipeline files. [evidence: `mods/mod-swooper-maps/test/pipeline/no-shadow-paths.test.ts:21`, `mods/mod-swooper-maps/test/pipeline/no-shadow-paths.test.ts:33`, `mods/mod-swooper-maps/test/pipeline/no-shadow-paths.test.ts:50`]
+  - foundation contract guard bans multiple legacy surfaces and legacy kinematics symbols. [evidence: `mods/mod-swooper-maps/test/foundation/contract-guard.test.ts:69`, `mods/mod-swooper-maps/test/foundation/contract-guard.test.ts:81`, `mods/mod-swooper-maps/test/foundation/contract-guard.test.ts:97`]
+  - map-stamping guard enforces hard physics-vs-map boundary on contracts and adapter calls. [evidence: `mods/mod-swooper-maps/test/pipeline/map-stamping.contract-guard.test.ts:24`, `mods/mod-swooper-maps/test/pipeline/map-stamping.contract-guard.test.ts:80`]
+  - determinism suite runs canonical foundation gates over repeated runs. [evidence: `mods/mod-swooper-maps/test/pipeline/determinism-suite.test.ts:61`, `mods/mod-swooper-maps/test/pipeline/determinism-suite.test.ts:69`, `mods/mod-swooper-maps/test/support/foundation-invariants.ts:868`]
+- Foundation artifact validators are robust and wired into step artifact publication (`validate:` hooks), but there is limited direct unit-level coverage of validator functions themselves (coverage is mostly integration-driven). [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mantlePotential.ts:11`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:38`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:34`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts:31`]
+- `docs/system/TESTING.md` is execution-oriented and does not document architecture-cutover guardrail commands or required no-shim checks. [evidence: `docs/system/TESTING.md:7`, `docs/system/TESTING.md:11`, `docs/system/TESTING.md:51`]
+
+#### 2) Charter alignment and policy anchors (no-shim / no-dual-path)
+- Target policy is explicit: single-path posture and zero-legacy cutover requirement (no shims / no dual paths). [evidence: `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:170`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:192`]
+- ADR policy also states pure-target architecture excludes compatibility shims/parity guarantees. [evidence: `docs/projects/engine-refactor-v1/resources/spec/adr/adr-er1-016-pure-target-non-goals-no-compatibility-guarantees-no-migration-shims-in-the-spec.md:25`, `docs/projects/engine-refactor-v1/resources/spec/adr/adr-er1-016-pure-target-non-goals-no-compatibility-guarantees-no-migration-shims-in-the-spec.md:26`]
+- Foundation SPEC contains a migration note that allows temporary bridges with explicit deletion targets; this is a policy tension vs the stricter no-shim posture and needs orchestrator resolution. [evidence: `docs/projects/pipeline-realism/resources/spec/foundation-evolutionary-physics-SPEC.md:241`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:193`]
+- A/B/C findings indicate likely large structural movement (sentinel dual-path compile branch, op-calls-op, stage split pressure), so enforcement must be topology-resilient and not tied to one file layout only. [evidence: `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md:42`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:34`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:77`]
+
+#### 3) Proposed structural audit test scenarios required by spike charter
+1. Foundation stage topology lock test (`test/pipeline/foundation-topology.contract-guard.test.ts`)
+- Assert canonical foundation step graph (or canonical staged variant after split) is exact: no extra legacy steps, no renamed dual aliases. [evidence basis: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:539`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:771`]
+- Failure signal: any step id added/removed/aliased without explicit target-model update.
+
+2. No-dual-requires contract scan (`test/pipeline/no-dual-contract-paths.test.ts`)
+- Parse all step contracts under standard recipe; fail when a step requires both legacy+target representations for the same semantic (denylist pair registry).
+- Failure signal: dual dependency shape exists in one step contract (compat path).
+
+3. No-shim symbol sweep expanded to domain + stage + map config (`test/pipeline/no-shim-surfaces.test.ts`)
+- Extend current no-shadow scan beyond `src/recipes/standard` to include `src/domain/foundation`, `src/maps`, and relevant shared runtime folders.
+- Include banned list union from existing guardrails (`dual/shadow/compare`, known removed surfaces).
+- Failure signal: any shim/dual marker reappears.
+- Baseline anchor: current scope is recipe-standard only. [evidence: `mods/mod-swooper-maps/test/pipeline/no-shadow-paths.test.ts:33`, `mods/mod-swooper-maps/test/pipeline/no-shadow-paths.test.ts:50`]
+
+4. Foundation step boundary scan for adapter/engine access (`test/pipeline/foundation-step-boundary-guard.test.ts`)
+- Static scan foundation steps to fail on `context.adapter` usage or direct engine-only readbacks in physics lane.
+- Rationale: current domain lint boundary checks target ops root, not step runtime in boundary mode. [evidence: `scripts/lint/lint-domain-refactor-guardrails.sh:237`, `scripts/lint/lint-domain-refactor-guardrails.sh:238`]
+
+5. Full validator unit matrix (`test/foundation/validation-artifacts.contract.test.ts`)
+- Unit-test each validator function with one valid payload and focused invalid payload per critical field/length invariant.
+- Failure signal: schema/shape regressions escape integration tests.
+- Baseline anchor: validator functions are extensive and mostly integration-covered today. [evidence: `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts:31`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts:338`, `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts:570`]
+
+6. Legacy surface absence manifest test (`test/pipeline/foundation-legacy-absence.test.ts`)
+- Maintain explicit denylist of removed file/module paths + removed symbol imports; fail if reintroduced.
+- Failure signal: deleted legacy path/surface returns.
+
+7. Artifact/effect namespace freeze + uniqueness (`test/pipeline/foundation-tag-freeze.test.ts`)
+- Snapshot canonical `foundation.*` truth artifacts and map effects, fail on reintroduction of deprecated aliases or duplicate-semantic tag pairs.
+- Failure signal: namespace drift or compatibility alias added.
+- Baseline anchors: existing tag/effect definitions and contract guards. [evidence: `mods/mod-swooper-maps/src/recipes/standard/tags.ts:28`, `mods/mod-swooper-maps/src/recipes/standard/tags.ts:111`, `mods/mod-swooper-maps/test/foundation/contract-guard.test.ts:113`]
+
+8. Structural no-op-calls-op guard for decomposed tectonics (`test/foundation/no-op-calls-op-tectonics.test.ts`)
+- Add focused static/AST check on target decomposed ops to ensure op modules do not execute peer op `run(...)`.
+- Failure signal: composition logic leaks back into ops.
+- Baseline anchor: current violation already observed in `compute-tectonic-history`. [evidence: `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:34`]
+
+#### 4) Proposed docs + lint/guardrail updates to lock target architecture
+- `docs/system/TESTING.md`: add an "Architecture Cutover Guardrails" section with mandatory commands and expected CI required checks (not just how to run tests). [evidence: `docs/system/TESTING.md:7`, `docs/system/TESTING.md:51`]
+- Add canonical cutover guardrail doc under project scope (recommended): `docs/projects/pipeline-realism/resources/spec/no-shim-cutover-guardrails.md` with:
+  - banned surface classes,
+  - denylist ownership,
+  - required CI job wiring,
+  - policy precedence (ADR vs migration notes).
+- `scripts/lint/lint-domain-refactor-guardrails.sh`: add a dedicated `cutover` profile (or promote `full` for CI) that includes no-shim and deep-import checks by default for all relevant domains.
+- Add new lint script (`scripts/lint/lint-no-shim-cutover.sh`) for direct, deterministic scanning of banned terms/symbols/paths across source roots used by A/B/C changes.
+- ESLint hardening: add restricted patterns for relative deep-imports into domain internals from step files (current restrictions are alias-centric and can be bypassed by relative paths). [evidence: `eslint.config.js:73`, `eslint.config.js:123`, `eslint.config.js:185`]
+
+#### 5) Explicit CI definition for enforcing no-shim / no-dual-path
+Proposed required CI job: `architecture-cutover-guardrails` (must pass before merge).
+- Step 1: `bun run lint` (retain existing ESLint contract/import boundaries). [evidence baseline: `.github/workflows/ci.yml:53`, `eslint.config.js:68`]
+- Step 2: `bun run lint:adapter-boundary` (make adapter boundary mandatory in CI). [evidence baseline: `package.json:38`, `scripts/lint/lint-adapter-boundary.sh:46`]
+- Step 3: `REFRACTOR_DOMAINS="foundation,morphology,hydrology,ecology,placement,narrative" DOMAIN_REFACTOR_GUARDRAILS_PROFILE=full bun run lint:domain-refactor-guardrails`.
+- Step 4: run no-shim/no-dual-path tests (existing + new):
+  - `no-shadow-paths`, `foundation contract guard`, `map-stamping guard`, topology lock, dual-contract scan, legacy-absence manifest.
+- Step 5: `bun run check` or equivalent architecture doc lint gate so docs and guardrails stay synchronized. [evidence baseline: `package.json:9`]
+- Enforcement semantics:
+  - Any hit in no-shim/dual-path scans is a hard fail.
+  - No allowlist bypass without explicit orchestrator-approved deletion ticket.
+  - Branch protection marks this CI job as required.
+
+## Proposed target model
+- Single-path cutover enforcement model:
+  - `policy`: no compatibility shim / no dual-path / no shadow surfaces in runtime contracts or source.
+  - `implementation`: combined static lint + structural tests + required CI gate.
+  - `governance`: denylist changes require explicit orchestrator decision + deletion date.
+- Make CI the source of truth for cutover compliance by requiring:
+  1. `lint:adapter-boundary`,
+  2. domain guardrails in strict mode (`full` or new `cutover`),
+  3. no-shim/no-dual-path test suite,
+  4. docs guardrail checks.
+- Keep guardrails topology-agnostic so A/B/C structural changes remain enforceable after stage/ops reorganization. [evidence: `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md:42`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:34`, `docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:77`]
+
+## Breaking-change inventory
+- CI behavior change: PRs that currently pass may fail once adapter-boundary + strict domain guardrails become required.
+- Lint behavior change: adding relative deep-import bans and no-shim scans will fail previously tolerated import/symbol patterns.
+- Test behavior change: topology lock and legacy-absence manifest will intentionally fail on unapproved structure/surface drift.
+- Process change: allowlist-based temporary compat paths become exceptional and tracked; silent compatibility shims become impossible.
+- Docs policy change: `docs/system/TESTING.md` and project spec docs become normative for cutover enforcement, not optional guidance.
+
+## Open risks
+- False-positive risk from token-based no-shim scans if scope is too broad (especially comments/docs); mitigated by source-root scoping + AST where possible.
+- CI duration risk from added structural checks; mitigated by separating fast static scans from heavier runtime tests.
+- Policy conflict risk between strict no-shim posture and Foundation SPEC migration note about temporary bridges. [evidence: `docs/projects/pipeline-realism/resources/spec/foundation-evolutionary-physics-SPEC.md:241`, `docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:193`]
+- Governance risk if denylist updates lack ownership/expiry metadata; mitigated by requiring orchestrator-approved change records.
+
+## Decision asks for orchestrator
+- Decide policy precedence for this spike: should strict no-shim posture override Foundation SPEC migration-note allowance for temporary bridges? [evidence: `docs/projects/pipeline-realism/resources/spec/foundation-evolutionary-physics-SPEC.md:241`, `docs/projects/engine-refactor-v1/resources/spec/adr/adr-er1-016-pure-target-non-goals-no-compatibility-guarantees-no-migration-shims-in-the-spec.md:25`]
+- Approve CI hardening scope now vs phased:
+  1. Immediate: wire `lint:adapter-boundary` + strict domain guardrails + existing no-shadow/contract tests.
+  2. Follow-up: add new topology/dual-path/legacy-absence tests.
+- Confirm whether to enforce `DOMAIN_REFACTOR_GUARDRAILS_PROFILE=full` or introduce a dedicated `cutover` profile with identical strictness plus no-shim denies.
+- Confirm denylist governance model (owner + deletion trigger + expiry) for any temporary exception, or decide zero exceptions.
+
+### 2026-02-14 — Parseability Addendum (YAML)
+
+```yaml
+guardrail_audit:
+  ci_wiring:
+    finding: "CI runs build/lint/test but does not explicitly run check/domain-guardrails/adapter-boundary gates."
+    evidence_paths:
+      - .github/workflows/ci.yml:50
+      - .github/workflows/ci.yml:53
+      - .github/workflows/ci.yml:56
+      - package.json:9
+      - package.json:38
+      - package.json:39
+  check_script_scope:
+    finding: "check includes domain-refactor-guardrails + mapgen-docs, excludes adapter-boundary; CI does not run check."
+    evidence_paths:
+      - package.json:9
+      - package.json:38
+      - .github/workflows/ci.yml:53
+  domain_guardrails_profile:
+    finding: "Default profile is boundary-only; strict anti-shim checks exist only in full profile."
+    evidence_paths:
+      - scripts/lint/lint-domain-refactor-guardrails.sh:24
+      - scripts/lint/lint-domain-refactor-guardrails.sh:236
+      - scripts/lint/lint-domain-refactor-guardrails.sh:238
+      - scripts/lint/lint-domain-refactor-guardrails.sh:336
+      - scripts/lint/lint-domain-refactor-guardrails.sh:343
+      - scripts/lint/lint-domain-refactor-guardrails.sh:348
+      - scripts/lint/lint-domain-refactor-guardrails.sh:350
+  adapter_boundary_gate:
+    finding: "Adapter boundary lint exists with allowlist debt and is not mandatory in CI."
+    evidence_paths:
+      - scripts/lint/lint-adapter-boundary.sh:24
+      - scripts/lint/lint-adapter-boundary.sh:29
+      - scripts/lint/lint-adapter-boundary.sh:46
+      - package.json:38
+      - .github/workflows/ci.yml:53
+  pre_commit_enforcement:
+    finding: "Pre-commit hook only syncs/publishes resources submodule, not architecture guardrails."
+    evidence_paths:
+      - scripts/git-hooks/pre-commit:4
+      - scripts/git-hooks/pre-commit:6
+  eslint_boundaries:
+    finding: "ESLint enforces substantial import/contract/runtime boundaries and does run in CI lint step."
+    evidence_paths:
+      - eslint.config.js:68
+      - eslint.config.js:92
+      - eslint.config.js:176
+      - .github/workflows/ci.yml:53
+  tests_existing:
+    finding: "No-shadow, foundation contract, map-stamping, determinism gates are present and active under mod tests."
+    evidence_paths:
+      - mods/mod-swooper-maps/test/pipeline/no-shadow-paths.test.ts:21
+      - mods/mod-swooper-maps/test/pipeline/no-shadow-paths.test.ts:33
+      - mods/mod-swooper-maps/test/foundation/contract-guard.test.ts:69
+      - mods/mod-swooper-maps/test/foundation/contract-guard.test.ts:81
+      - mods/mod-swooper-maps/test/pipeline/map-stamping.contract-guard.test.ts:24
+      - mods/mod-swooper-maps/test/pipeline/map-stamping.contract-guard.test.ts:80
+      - mods/mod-swooper-maps/test/pipeline/determinism-suite.test.ts:61
+      - mods/mod-swooper-maps/test/support/foundation-invariants.ts:868
+  validator_binding:
+    finding: "Foundation step artifact validators are wired through validate hooks in step artifact implementations."
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mantlePotential.ts:11
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts:38
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts:34
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts:31
+  testing_doc_gap:
+    finding: "Testing doc is execution-oriented and does not define architecture cutover guardrail policy."
+    evidence_paths:
+      - docs/system/TESTING.md:7
+      - docs/system/TESTING.md:11
+      - docs/system/TESTING.md:51
+
+policy_anchors:
+  no_shim_single_path:
+    finding: "Target posture requires single-path and zero-legacy cutover (no shims / no dual paths)."
+    evidence_paths:
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:170
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:192
+  adr_pure_target:
+    finding: "ADR disallows compatibility shims/parity constraints in pure-target architecture."
+    evidence_paths:
+      - docs/projects/engine-refactor-v1/resources/spec/adr/adr-er1-016-pure-target-non-goals-no-compatibility-guarantees-no-migration-shims-in-the-spec.md:25
+      - docs/projects/engine-refactor-v1/resources/spec/adr/adr-er1-016-pure-target-non-goals-no-compatibility-guarantees-no-migration-shims-in-the-spec.md:26
+  policy_tension:
+    finding: "Foundation SPEC migration note allows temporary bridges; conflicts with stricter no-shim policy."
+    evidence_paths:
+      - docs/projects/pipeline-realism/resources/spec/foundation-evolutionary-physics-SPEC.md:241
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:193
+  checkpoint_context_ABC:
+    finding: "A/B/C report boundary violations and likely major topology/op restructuring."
+    evidence_paths:
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md:42
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:34
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:77
+
+structural_audit_scenarios:
+  - id: foundation_topology_lock
+    scope: "mods/mod-swooper-maps/test/pipeline/foundation-topology.contract-guard.test.ts"
+    purpose: "Assert canonical foundation step graph (or approved split graph) with no legacy alias steps."
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:539
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts:771
+  - id: no_dual_requires_contract_scan
+    scope: "mods/mod-swooper-maps/test/pipeline/no-dual-contract-paths.test.ts"
+    purpose: "Fail if a step contract requires dual legacy+target representations for same semantic guarantee."
+    evidence_paths:
+      - mods/mod-swooper-maps/test/pipeline/map-stamping.contract-guard.test.ts:24
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:170
+  - id: no_shim_symbol_sweep_expanded
+    scope: "mods/mod-swooper-maps/test/pipeline/no-shim-surfaces.test.ts"
+    purpose: "Extend no-shadow/no-dual scanning to domain+stage+maps roots."
+    evidence_paths:
+      - mods/mod-swooper-maps/test/pipeline/no-shadow-paths.test.ts:33
+      - mods/mod-swooper-maps/test/pipeline/no-shadow-paths.test.ts:50
+  - id: foundation_step_boundary_scan
+    scope: "mods/mod-swooper-maps/test/pipeline/foundation-step-boundary-guard.test.ts"
+    purpose: "Fail on adapter/engine access in physics-lane foundation steps."
+    evidence_paths:
+      - scripts/lint/lint-domain-refactor-guardrails.sh:237
+      - scripts/lint/lint-domain-refactor-guardrails.sh:238
+  - id: validator_unit_matrix
+    scope: "mods/mod-swooper-maps/test/foundation/validation-artifacts.contract.test.ts"
+    purpose: "Direct unit coverage for validator functions (valid + focused invalid payloads)."
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts:31
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts:338
+      - mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/validation.ts:570
+  - id: legacy_surface_absence_manifest
+    scope: "mods/mod-swooper-maps/test/pipeline/foundation-legacy-absence.test.ts"
+    purpose: "Assert deleted legacy modules/symbols do not reappear."
+    evidence_paths:
+      - mods/mod-swooper-maps/test/foundation/contract-guard.test.ts:81
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:192
+  - id: namespace_freeze_uniqueness
+    scope: "mods/mod-swooper-maps/test/pipeline/foundation-tag-freeze.test.ts"
+    purpose: "Freeze canonical artifact/effect namespaces and fail on alias reintroduction."
+    evidence_paths:
+      - mods/mod-swooper-maps/src/recipes/standard/tags.ts:28
+      - mods/mod-swooper-maps/src/recipes/standard/tags.ts:111
+      - mods/mod-swooper-maps/test/foundation/contract-guard.test.ts:113
+  - id: no_op_calls_op_tectonics
+    scope: "mods/mod-swooper-maps/test/foundation/no-op-calls-op-tectonics.test.ts"
+    purpose: "Prevent op-internal orchestration reintroduction after decomposition."
+    evidence_paths:
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:34
+
+docs_and_lint_updates:
+  docs:
+    - target: docs/system/TESTING.md
+      update: "Add architecture cutover guardrails section with mandatory no-shim verification commands + required CI checks."
+      evidence_paths:
+        - docs/system/TESTING.md:7
+        - docs/system/TESTING.md:51
+    - target: docs/projects/pipeline-realism/resources/spec/no-shim-cutover-guardrails.md
+      update: "Canonical denylist ownership, CI contract, and policy precedence notes."
+      evidence_paths:
+        - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:170
+        - docs/projects/engine-refactor-v1/resources/spec/adr/adr-er1-016-pure-target-non-goals-no-compatibility-guarantees-no-migration-shims-in-the-spec.md:25
+  lint:
+    - target: scripts/lint/lint-domain-refactor-guardrails.sh
+      update: "Promote strict mode in CI (full/cutover profile) across all active domains."
+      evidence_paths:
+        - scripts/lint/lint-domain-refactor-guardrails.sh:24
+        - scripts/lint/lint-domain-refactor-guardrails.sh:336
+    - target: scripts/lint/lint-no-shim-cutover.sh
+      update: "Add deterministic no-shim/no-dual-path source scan."
+      evidence_paths:
+        - mods/mod-swooper-maps/test/pipeline/no-shadow-paths.test.ts:21
+    - target: eslint.config.js
+      update: "Add relative deep-import restrictions into domain internals from steps/contracts."
+      evidence_paths:
+        - eslint.config.js:73
+        - eslint.config.js:123
+        - eslint.config.js:185
+
+ci_enforcement_plan:
+  required_job: architecture-cutover-guardrails
+  required_steps:
+    - "bun run lint"
+    - "bun run lint:adapter-boundary"
+    - "REFRACTOR_DOMAINS=foundation,morphology,hydrology,ecology,placement,narrative DOMAIN_REFACTOR_GUARDRAILS_PROFILE=full bun run lint:domain-refactor-guardrails"
+    - "run no-shim/no-dual-path structural tests (existing + new)"
+    - "bun run check (or equivalent docs+guardrails gate)"
+  branch_protection:
+    required_status_check: true
+    allowlist_policy: "No silent allowlists; exceptions require orchestrator-owned deletion target."
+  baseline_evidence_paths:
+    - .github/workflows/ci.yml:53
+    - package.json:9
+    - package.json:38
+    - package.json:39
+```
+
+## Proposed target model
+```yaml
+summary:
+  posture: "single-path, no-shim, no-dual-path cutover"
+  enforcement_layers:
+    - static_lint
+    - structural_tests
+    - required_ci_gate
+  topology_resilience: "Guardrails must survive A/B/C stage+op restructuring without relaxing invariants."
+  evidence_paths:
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md:42
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md:34
+    - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md:77
+```
+
+## Breaking-change inventory
+```yaml
+breaking_changes:
+  - id: ci_gate_strictness
+    impact: "Previously passing PRs may fail when adapter-boundary + strict domain guardrails become required."
+  - id: lint_rule_hardening
+    impact: "Relative deep imports and shim surfaces that are currently tolerated will fail lint/test."
+  - id: topology_lock_tests
+    impact: "Unapproved stage/step id drift will fail structural tests immediately."
+  - id: allowlist_governance
+    impact: "Temporary compat exceptions become explicit, owned, and time-bounded."
+  - id: docs_normativity
+    impact: "Testing docs shift from runbook-only to normative architecture enforcement contract."
+```
+
+## Open risks
+```yaml
+open_risks:
+  - id: scan_false_positives
+    mitigation: "Scope scans to source roots and prefer AST checks for ambiguous patterns."
+  - id: ci_runtime_growth
+    mitigation: "Split fast static checks from heavier runtime suites; keep required set lean."
+  - id: policy_conflict_bridges_vs_no_shim
+    mitigation: "Orchestrator policy precedence decision before enforcement lands."
+    evidence_paths:
+      - docs/projects/pipeline-realism/resources/spec/foundation-evolutionary-physics-SPEC.md:241
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:193
+  - id: exception_governance_drift
+    mitigation: "Require owner+expiry+deletion-trigger metadata for any exception."
+```
+
+## Decision asks for orchestrator
+```yaml
+decision_asks:
+  - id: policy_precedence
+    ask: "Does strict no-shim policy override temporary-bridge migration note for this spike?"
+    evidence_paths:
+      - docs/projects/pipeline-realism/resources/spec/foundation-evolutionary-physics-SPEC.md:241
+      - docs/projects/engine-refactor-v1/resources/spec/adr/adr-er1-016-pure-target-non-goals-no-compatibility-guarantees-no-migration-shims-in-the-spec.md:25
+  - id: ci_rollout_mode
+    ask: "Immediate strict rollout vs phased rollout (existing gates first, then new structural tests)."
+  - id: strict_profile_choice
+    ask: "Use DOMAIN_REFACTOR_GUARDRAILS_PROFILE=full in CI or create dedicated cutover profile."
+  - id: exception_model
+    ask: "Allow any temporary exceptions, or enforce zero-exception posture."
+```

--- a/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/master-scratch.md
+++ b/docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/master-scratch.md
@@ -1,0 +1,129 @@
+# Master Scratch — Foundation Domain Axe Spike
+
+## Snapshot
+- Base branch: `agent-SWANKO-PRR-s112-c01-fix-driverStrength-proportional`
+- Orchestrator branch: `codex/agent-ORCH-foundation-domain-axe-spike`
+- Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-codex-agent-ORCH-foundation-domain-axe-spike`
+
+## Confirmed Facts (seed)
+1. Foundation stage is monolithic (`id: foundation`) with 10 sequential steps.
+2. Foundation ops currently have no `rules/` directories.
+3. Foundation ops currently have no dedicated `strategies/` directories.
+4. `compute-tectonic-history/index.ts` is 1489 lines and includes op-calls-op behavior.
+
+## Integration Ledger
+
+### Checkpoint 0 (seed)
+- Agents launched: pending
+- Consolidated decisions: pending
+- Cross-agent conflicts: pending
+
+## Decision Candidates (rolling)
+- pending
+
+## Conflicts to Resolve (rolling)
+- pending
+
+### Checkpoint 1 (A/B/C complete)
+- Agents launched: A, B, C
+- Status: complete
+
+#### Confirmed facts
+1. Foundation stage compile includes dual-path sentinel behavior (Studio sentinel + canonical lowering).
+2. `plate-topology` compute logic is step-local (no op contract), violating strict op-per-concern posture.
+3. `compute-tectonic-history` is a mega-op and directly calls `compute-tectonic-segments` internally.
+4. Multiple strategy-contract drifts exist (`compute-crust-evolution` config ignored; dead knobs in `compute-plate-graph`).
+5. Foundation currently mixes physics truth and tile projection concerns.
+
+#### Consolidated decision candidates
+1. Lane split posture:
+- Option A: keep Foundation owning projection tensors.
+- Option B (preferred by A): move map-facing projection ownership to Gameplay lane (`artifact:map.*`) with hard cutover.
+2. Tectonic history refactor posture:
+- Option A (preferred by B): decompose now into multiple focused ops and move orchestration to steps.
+- Option B: transitional wrapper/defer split.
+3. Stage topology posture:
+- Option A: 2-stage split (physics + projection).
+- Option B (preferred by C): 3-stage split (substrate/kinematics -> tectonics/history -> projection).
+4. Dead config surface cleanup:
+- Option A: immediate breaking removal/fix of dead knobs.
+- Option B: temporary compatibility window.
+
+#### Cross-agent conflict notes
+1. A recommends strict truth-vs-map lane split; C recommends keeping existing artifact IDs initially to reduce churn.
+2. B proposes large op decomposition while C proposes stage split that can be done with op IDs mostly stable first.
+3. Ordering question: should lane split and op decomposition happen together or staged.
+
+### Checkpoint 2 (D/E/F complete)
+- Agents launched: A, B, C, D, E, F
+- Status: complete
+
+#### Confirmed facts
+1. Foundation integration has multiple contract drifts: passed-but-unused inputs, dead config fields, and dual compile-path sentinel behavior.
+2. Observability identity is tightly coupled to step IDs (`layerKey`/manifest keyed by step identity), so stage-id changes propagate to tracing/viz artifacts.
+3. CI does not currently enforce strict no-shim/no-dual-path guardrails (`lint:adapter-boundary`, strict domain guardrails, and `check` are not mandatory today).
+4. Structural decomposition can be done without introducing shims, but sequence matters to control blast radius.
+
+#### Consolidated decision candidates
+1. Stage model:
+- Option A: 2-stage split.
+- Option B (recommended): 3-stage split (`foundation-substrate-kinematics` -> `foundation-tectonics-history` -> `foundation-projection`).
+2. Tectonics operation model:
+- Option A (recommended): decompose `compute-tectonic-history` into focused ops and move orchestration fully to step layer.
+- Option B: keep mega-op shape and defer decomposition.
+3. Lane policy:
+- Option A: strict lane split now (`artifact:map.*` hard cut).
+- Option B: keep artifact IDs stable through topology+op cleanup, then hard lane split in next stack.
+4. Guardrail policy:
+- Option A (recommended): strict no-shim policy takes precedence now with required CI job.
+- Option B: temporary bridge allowances from migration note.
+
+#### Cross-agent conflict notes
+1. A favors immediate strict lane split; C favors staged topology with artifact-id stability first.
+2. B favors immediate decomposition; E warns to preserve step-level emit compose points during decomposition to reduce viz breakage.
+3. F calls out policy conflict between strict no-shim posture and migration-note temporary bridges.
+
+#### Orchestrator synthesis (proposed sequence)
+1. Phase 1: Contract cleanup + mega-op decomposition + single compile path (`D-BC1/2/3/4`) while preserving current projection artifact IDs.
+2. Phase 2: 3-stage topology split with full step-id/config migration.
+3. Phase 3: hard lane namespace split to `artifact:map.*` in dedicated breaking stack.
+4. Throughout: enforce no-shim guardrails as required CI status checks.
+
+## Parseability Addendum (YAML)
+
+```yaml
+checkpoint_2:
+  completed_agents:
+    - agent-A-boundaries-structure.md
+    - agent-B-ops-strategies-rules.md
+    - agent-C-stage-topology.md
+    - agent-D-integration-wiring-contracts.md
+    - agent-E-viz-tracing-boundaries.md
+    - agent-F-testing-docs-guardrails.md
+
+core_conflicts:
+  lane_policy:
+    option_A: strict_lane_split_now
+    option_B: artifact_id_stability_then_lane_split
+    evidence_paths:
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-A-boundaries-structure.md
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-C-stage-topology.md
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-D-integration-wiring-contracts.md
+  decomposition_vs_observability:
+    requirement: keep_step_level_emit_compose_points_during_op_decomposition
+    evidence_paths:
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-B-ops-strategies-rules.md
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-E-viz-tracing-boundaries.md
+  no_shim_policy_precedence:
+    conflict: strict_spec_posture_vs_migration_note_temporary_bridges
+    evidence_paths:
+      - docs/projects/engine-refactor-v1/resources/spec/SPEC-DOMAIN-MODELING-GUIDELINES.md:192
+      - docs/projects/pipeline-realism/resources/spec/foundation-evolutionary-physics-SPEC.md:241
+      - docs/projects/pipeline-realism/scratch/foundation-domain-axe-spike/agent-F-testing-docs-guardrails.md
+
+recommended_sequence:
+  - phase_1_contract_cleanup_and_decomposition
+  - phase_2_three_stage_split
+  - phase_3_lane_namespace_split
+  - phase_4_guardrail_lock_in_ci
+```


### PR DESCRIPTION
Create the full foundation-domain-axe spike artifact set in the orchestrator branch: plan, master scratch integration, six agent scratchpads, and the integrated spike report.
Includes YAML parseability addenda for path-heavy evidence sections across scratch and final docs to improve human/agent scanning and structured search.
Context: pipeline-realism foundation modeling investigation and no-shim/no-legacy cutover planning.