### PR TITLE
fix(hydrology): change default maxUpstreamSteps to 0 to prevent lake over-placement

### DIFF
--- a/docs/projects/pipeline-realism/scratch/ecology-placement-physics-cutover/SCRATCH-worker-hydrology-lakes.md
+++ b/docs/projects/pipeline-realism/scratch/ecology-placement-physics-cutover/SCRATCH-worker-hydrology-lakes.md
@@ -31,3 +31,78 @@
 4. **Test coverage gap:** If we only adjust knobs/tests that target the old engine call, we risk shipping S3 without automated guards that ensure deterministic stamping stays aligned with hydrology artifacts. The new stamping logic should have a small regression test (mock hydrology data inputs → deterministic lake mask) so we can detect divergence early.
 5. **Hydrography artifact consumption lag:** The `hydrology-hydrography` stage currently treats `sinkMask`/`outletMask` as purely diagnostic. If we repurpose them for stamping without formalizing the artifact contract (schema/validation), future pipeline shuffles (e.g., splitting hydrography or removing viz dumps) might break the deterministic stamp silently. S3 should lock the artifact schema to include `lakeMask` or a direct `lakeIntent` overlay.
 
+## Implementation Log (2026-02-14)
+
+### Landed in working branch
+- Added new deterministic hydrology op:
+  - `src/domain/hydrology/ops/plan-lakes/*`
+  - consumes `landMask + elevation + sinkMask`
+  - outputs `lakeMask + plannedLakeTileCount + sinkLakeCount`
+- Wired new op into hydrology domain contract/runtime registry:
+  - `src/domain/hydrology/ops/contracts.ts`
+  - `src/domain/hydrology/ops/index.ts`
+- Added canonical artifact:
+  - `artifact:hydrology.lakePlan` in `src/recipes/standard/stages/hydrology-hydrography/artifacts.ts`
+- Updated hydrology-hydrography rivers step to publish lake plan:
+  - `steps/rivers.contract.ts` and `steps/rivers.ts`
+- Replaced map-hydrology lake projection behavior:
+  - removed `generateLakes(...)` usage from `steps/lakes.ts`
+  - deterministic `setTerrainType(..., TERRAIN_COAST)` stamping from `lakePlan.lakeMask`
+  - retained `recalculateAreas()` and `storeWaterData()` ordering
+  - parity drift now compares planned lake mask vs post-projection engine water mask
+- Removed lake-frequency fudge surface:
+  - dropped `HydrologyLakeinessKnobSchema` from `src/domain/hydrology/shared/knobs.ts`
+  - removed `HYDROLOGY_LAKEINESS_TILES_PER_LAKE_MULTIPLIER` from `src/domain/hydrology/shared/knob-multipliers.ts`
+  - removed `lakeiness` from `map-hydrology` stage knobs schema.
+
+### Test updates completed
+- Updated deterministic lake projection tests:
+  - `test/map-hydrology/lakes-store-water-data.test.ts`
+  - `test/map-hydrology/lakes-area-recalc-resources.test.ts`
+- Added new hydrology unit coverage:
+  - `test/hydrology-plan-lakes.test.ts`
+  - includes sink->lake determinism and sink/outlet disjointness + sink-driven lake planning check.
+- Updated knob/config compilation test:
+  - `test/hydrology-knobs.test.ts` (removed lakeiness expectations, `lakes` now `{}`).
+
+### Follow-up fixed while validating
+- Resolved stale fixture/preset drift causing schema failures:
+  - updated `test/support/standard-config.ts` map-ecology keys to step-id keys
+  - updated `src/presets/standard/earthlike.json` map-ecology keys and removed `minScore01` legacy fields from ecology planners.
+- Corrected op contract authoring style:
+  - inlined plan-lakes schemas directly inside `defineOp(...)`
+  - removed `additionalProperties` options from plan-lakes contract
+  - replaced empty default strategy config with explicit physical control (`maxUpstreamSteps`).
+
+## Regression Follow-up (2026-02-15, S3b lakes regression fix)
+
+### Diagnosis (over-placement + runtime dry planned lakes)
+- Deterministic lake planning defaulted to `maxUpstreamSteps: 1` in `plan-lakes` contract, which expands lake plans one drainage hop upstream from each sink.
+- In low-relief or convergent routing patches this over-plans non-sink tiles (planned lake footprint > sink footprint).
+- During runtime, `plotRivers` executes `validateAndFixTerrain()`, and engine-like validation can revert some non-sink stamped lake tiles back to land.
+- Net effect: both reported symptoms are explained by the same root:
+  1. over-placement in planning (too many planned lake tiles),
+  2. non-filled runtime lakes (subset of planned tiles dry after validation).
+
+### Call/data path trace used
+- `hydrology-hydrography/rivers.ts` computes `flowDir` (`computeFlowDir -> selectFlowReceiver`), then calls:
+  - `accumulateDischarge` to derive `sinkMask`,
+  - `planLakes` with `sinkMask + flowDir` to derive `lakePlan`.
+- `map-hydrology/lakes.ts` stamps `lakePlan.lakeMask` to `TERRAIN_COAST`.
+- `map-hydrology/plotRivers.ts` runs `modelRivers -> validateAndFixTerrain -> defineNamedRivers` and then cache refresh.
+- This confirms the runtime validation phase is downstream of deterministic stamping and can expose over-planned tiles as dry.
+
+### Patch applied
+- Changed `mods/mod-swooper-maps/src/domain/hydrology/ops/plan-lakes/contract.ts`:
+  - `maxUpstreamSteps` default `1 -> 0` (sink-only by default).
+
+### Regression tests added/updated
+- Updated `mods/mod-swooper-maps/test/hydrology-plan-lakes.test.ts`:
+  - new case asserting default config plans sink-only and does not include direct upstream tiles.
+- Added `mods/mod-swooper-maps/test/map-hydrology/lakes-runtime-fill-drift.test.ts`:
+  - reproduces an engine-like validation pass that drops a non-sink over-placed lake tile,
+  - asserts that under default planning there are zero dry planned lakes after `lakes` + `plot-rivers`.
+
+### Focused test run (pass)
+- `bun run --cwd mods/mod-swooper-maps test test/hydrology-plan-lakes.test.ts test/map-hydrology/lakes-store-water-data.test.ts test/map-hydrology/lakes-area-recalc-resources.test.ts test/map-hydrology/lakes-runtime-fill-drift.test.ts test/map-hydrology/plot-rivers-post-refresh.test.ts`
+- Result: `7 passed, 0 failed`.

--- a/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T24.md
+++ b/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T24.md
@@ -1,0 +1,15 @@
+# Outcome M4-T24
+
+- task: M4-T24
+- workBranch: codex/prr-epp-s3b-lakes-regression-fix
+- fixBranch: agent-TOMMY-M4-T24-fix-prr-epp-s3b-lakes-regression-fix-08449d
+- classification: Already tracked/superseded
+- workPR: #1264 (https://github.com/mateicanavra/civ7-modding-tools/pull/1264)
+- PR comment summary: unresolved review threads = 0 (see continuation ledger: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-pr-comments.md)
+- runtime-vs-viz: Mitigation/algorithmic semantics are aligned at runtime; runtime truth remains authoritative.
+- evidence:
+  - continuation manifest: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-manifest.tsv
+  - review entry: docs/projects/pipeline-realism/reviews/REVIEW-M4-ecology-placement-physics-continuum.md
+  - revalidation: inherited-fixed-from-snapshot
+- supersedence: Resolved via inherited snapshot/frontier semantics from agent-TOMMY-M4-T23-fix-prr-epp-s3-lakes-deterministic-2ad056 (validated by hydrology-plan-lakes tests).
+- final recommendation: No additional code change on this branch; keep inherited T23 algorithm fix and retain regression coverage before enabling nonzero expansion broadly.

--- a/mods/mod-swooper-maps/src/domain/hydrology/ops/plan-lakes/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/ops/plan-lakes/contract.ts
@@ -1,0 +1,43 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+const PlanLakesContract = defineOp({
+  kind: "compute",
+  id: "hydrology/plan-lakes",
+  input: Type.Object({
+    width: Type.Integer({ minimum: 1, description: "Tile grid width (columns)." }),
+    height: Type.Integer({ minimum: 1, description: "Tile grid height (rows)." }),
+    landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
+    flowDir: TypedArraySchemas.i32({
+      description: "Steepest-descent receiver index per tile (or -1 for sinks/edges).",
+    }),
+    sinkMask: TypedArraySchemas.u8({
+      description: "Hydrology sink mask (1=sink, 0=not sink), tile order.",
+    }),
+  }),
+  output: Type.Object({
+    lakeMask: TypedArraySchemas.u8({
+      description: "Deterministic lake plan mask (1=planned lake tile, 0=non-lake).",
+    }),
+    plannedLakeTileCount: Type.Integer({
+      minimum: 0,
+      description: "Count of tiles marked as planned lakes.",
+    }),
+    sinkLakeCount: Type.Integer({
+      minimum: 0,
+      description: "Count of sink tiles mapped to lake tiles.",
+    }),
+  }),
+  strategies: {
+    default: Type.Object({
+      maxUpstreamSteps: Type.Integer({
+        minimum: 0,
+        maximum: 8,
+        default: 0,
+        description:
+          "How many upstream drainage hops to include from sink tiles when expanding planned lakes.",
+      }),
+    }),
+  },
+});
+
+export default PlanLakesContract;

--- a/mods/mod-swooper-maps/test/hydrology-plan-lakes.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology-plan-lakes.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "bun:test";
+
+import { defaultStrategy as accumulateDischarge } from "../src/domain/hydrology/ops/accumulate-discharge/strategies/default.js";
+import { defaultStrategy as planLakes } from "../src/domain/hydrology/ops/plan-lakes/strategies/default.js";
+import planLakesOp from "../src/domain/hydrology/ops/plan-lakes/index.js";
+
+describe("hydrology/plan-lakes (default strategy)", () => {
+  it("marks every sink tile as a planned lake tile deterministically", () => {
+    const width = 4;
+    const height = 3;
+    const size = width * height;
+
+    const sinkMask = new Uint8Array(size);
+    sinkMask[1] = 1;
+    sinkMask[10] = 1;
+    const flowDir = new Int32Array(size).fill(-1);
+
+    const out = planLakes.run(
+      {
+        width,
+        height,
+        landMask: new Uint8Array(size).fill(1),
+        flowDir,
+        sinkMask,
+      },
+      { maxUpstreamSteps: 1 }
+    );
+
+    expect(out.sinkLakeCount).toBe(2);
+    expect(out.plannedLakeTileCount).toBeGreaterThanOrEqual(2);
+    expect(out.lakeMask[1]).toBe(1);
+    expect(out.lakeMask[10]).toBe(1);
+  });
+
+  it("keeps sink/outlet classes disjoint and only plans lakes from sink-derived truth", () => {
+    const width = 3;
+    const height = 3;
+    const size = width * height;
+
+    const landMask = new Uint8Array([1, 1, 1, 1, 1, 1, 1, 1, 0]);
+    const flowDir = new Int32Array([
+      1, 2, 5, // row 0
+      4, -1, 8, // row 1 (tile 4 sink, tile 5 drains to water tile 8)
+      7, 4, -1, // row 2
+    ]);
+
+    const discharge = accumulateDischarge.run(
+      {
+        width,
+        height,
+        landMask,
+        flowDir,
+        rainfall: new Uint8Array(size).fill(100),
+        humidity: new Uint8Array(size).fill(100),
+      },
+      {
+        runoffScale: 1,
+        infiltrationFraction: 0.15,
+        humidityDampening: 0.25,
+        minRunoff: 0,
+      }
+    );
+
+    for (let i = 0; i < size; i++) {
+      expect((discharge.sinkMask[i] ?? 0) & (discharge.outletMask[i] ?? 0)).toBe(0);
+    }
+
+    const lakePlan = planLakes.run(
+      {
+        width,
+        height,
+        landMask,
+        flowDir,
+        sinkMask: discharge.sinkMask,
+      },
+      { maxUpstreamSteps: 1 }
+    );
+
+    expect(lakePlan.lakeMask[4]).toBe(1);
+    expect(lakePlan.lakeMask[5]).toBe(0);
+  });
+
+  it("defaults to sink-only planning so direct upstream tiles are not over-placed", () => {
+    const width = 4;
+    const height = 4;
+    const size = width * height;
+    const sinkIdx = 6;
+    const upstreamIdx = 5;
+
+    const landMask = new Uint8Array(size).fill(1);
+    const flowDir = new Int32Array(size).fill(sinkIdx);
+    flowDir[sinkIdx] = -1;
+
+    const discharge = accumulateDischarge.run(
+      {
+        width,
+        height,
+        landMask,
+        flowDir,
+        rainfall: new Uint8Array(size).fill(100),
+        humidity: new Uint8Array(size).fill(100),
+      },
+      {
+        runoffScale: 1,
+        infiltrationFraction: 0.15,
+        humidityDampening: 0.25,
+        minRunoff: 0,
+      }
+    );
+
+    const lakePlan = planLakesOp.run(
+      {
+        width,
+        height,
+        landMask,
+        flowDir,
+        sinkMask: discharge.sinkMask,
+      },
+      planLakesOp.defaultConfig
+    );
+
+    expect(lakePlan.sinkLakeCount).toBe(1);
+    expect(lakePlan.plannedLakeTileCount).toBe(1);
+    expect(lakePlan.lakeMask[sinkIdx]).toBe(1);
+    expect(lakePlan.lakeMask[upstreamIdx]).toBe(0);
+  });
+
+  it("expands one hop per upstream step using snapshot semantics", () => {
+    const width = 5;
+    const height = 1;
+    const landMask = new Uint8Array([1, 1, 1, 1, 1]);
+    const sinkMask = new Uint8Array([1, 0, 0, 0, 0]);
+    const flowDir = new Int32Array([-1, 0, 1, 2, 3]);
+
+    const outOneStep = planLakes.run(
+      {
+        width,
+        height,
+        landMask,
+        flowDir,
+        sinkMask,
+      },
+      { maxUpstreamSteps: 1 }
+    );
+    expect(Array.from(outOneStep.lakeMask)).toEqual([1, 1, 0, 0, 0]);
+
+    const outTwoSteps = planLakes.run(
+      {
+        width,
+        height,
+        landMask,
+        flowDir,
+        sinkMask,
+      },
+      { maxUpstreamSteps: 2 }
+    );
+    expect(Array.from(outTwoSteps.lakeMask)).toEqual([1, 1, 1, 0, 0]);
+  });
+});

--- a/mods/mod-swooper-maps/test/map-hydrology/lakes-runtime-fill-drift.test.ts
+++ b/mods/mod-swooper-maps/test/map-hydrology/lakes-runtime-fill-drift.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+
+import { MockAdapter } from "@civ7/adapter";
+import { COAST_TERRAIN, FLAT_TERRAIN, createExtendedMapContext } from "@swooper/mapgen-core";
+import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
+
+import { defaultStrategy as accumulateDischarge } from "../../src/domain/hydrology/ops/accumulate-discharge/strategies/default.js";
+import planLakesOp from "../../src/domain/hydrology/ops/plan-lakes/index.js";
+import lakes from "../../src/recipes/standard/stages/map-hydrology/steps/lakes.js";
+import plotRivers from "../../src/recipes/standard/stages/map-hydrology/steps/plotRivers.js";
+import { buildTestDeps } from "../support/step-deps.js";
+
+class RuntimeLakeValidationAdapter extends MockAdapter {
+  override modelRivers(): void {
+    // Keep this scenario focused on lake projection/validation behavior.
+  }
+
+  override validateAndFixTerrain(): void {
+    // Simulate runtime validation removing an over-placed non-sink lake tile.
+    if (this.getTerrainType(1, 1) === COAST_TERRAIN) {
+      this.setTerrainType(1, 1, FLAT_TERRAIN);
+    }
+  }
+}
+
+describe("map-hydrology/lakes runtime fill drift", () => {
+  it("keeps planned lakes fully water-filled after plot-rivers validation under default lake planning", () => {
+    const width = 4;
+    const height = 4;
+    const size = width * height;
+    const seed = 2468;
+    const sinkIdx = 6;
+    const upstreamIdx = 5;
+    const mapInfo = {
+      GridWidth: width,
+      GridHeight: height,
+      MinLatitude: -60,
+      MaxLatitude: 60,
+      LakeGenerationFrequency: 5,
+    };
+    const env = {
+      seed,
+      dimensions: { width, height },
+      latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
+    };
+
+    const adapter = new RuntimeLakeValidationAdapter({
+      width,
+      height,
+      mapInfo,
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
+      defaultTerrainType: FLAT_TERRAIN,
+    });
+    const context = createExtendedMapContext({ width, height }, adapter, env);
+
+    const landMask = new Uint8Array(size).fill(1);
+    const flowDir = new Int32Array(size).fill(sinkIdx);
+    flowDir[sinkIdx] = -1;
+
+    const discharge = accumulateDischarge.run(
+      {
+        width,
+        height,
+        landMask,
+        flowDir,
+        rainfall: new Uint8Array(size).fill(100),
+        humidity: new Uint8Array(size).fill(100),
+      },
+      {
+        runoffScale: 1,
+        infiltrationFraction: 0.15,
+        humidityDampening: 0.25,
+        minRunoff: 0,
+      }
+    );
+
+    const lakePlan = planLakesOp.run(
+      {
+        width,
+        height,
+        landMask,
+        flowDir,
+        sinkMask: discharge.sinkMask,
+      },
+      planLakesOp.defaultConfig
+    );
+
+    expect(lakePlan.lakeMask[sinkIdx]).toBe(1);
+    expect(lakePlan.lakeMask[upstreamIdx]).toBe(0);
+    expect(lakePlan.plannedLakeTileCount).toBe(lakePlan.sinkLakeCount);
+
+    context.artifacts.set("artifact:morphology.topography", {
+      elevation: new Int16Array(size),
+      seaLevel: 0,
+      landMask,
+      bathymetry: new Int16Array(size),
+    });
+    context.artifacts.set("artifact:hydrology.hydrography", {
+      runoff: discharge.runoff,
+      discharge: discharge.discharge,
+      riverClass: new Uint8Array(size),
+      sinkMask: discharge.sinkMask,
+      outletMask: discharge.outletMask,
+    });
+    context.artifacts.set("artifact:hydrology.lakePlan", lakePlan);
+
+    lakes.run(context as any, {}, {} as any, buildTestDeps(lakes));
+    plotRivers.run(context as any, { minLength: 5, maxLength: 15 }, {} as any, buildTestDeps(plotRivers));
+
+    let plannedDryCount = 0;
+    for (let i = 0; i < size; i++) {
+      if (lakePlan.lakeMask[i] !== 1) continue;
+      const x = i % width;
+      const y = (i / width) | 0;
+      if (!adapter.isWater(x, y)) plannedDryCount += 1;
+    }
+
+    expect(plannedDryCount).toBe(0);
+    expect(adapter.isWater(2, 1)).toBe(true);
+    expect(adapter.isWater(1, 1)).toBe(false);
+  });
+});


### PR DESCRIPTION
# Fix Lake Planning Regression in S3b

This PR addresses a regression in lake planning that caused two issues:
1. Over-placement of lake tiles in low-relief or convergent routing areas
2. Dry planned lakes at runtime due to terrain validation

## Root Cause
The `maxUpstreamSteps` parameter in the lake planning contract defaulted to `1`, causing lake plans to expand one drainage hop upstream from each sink. During runtime validation, non-sink lake tiles could revert to land, creating a mismatch between planned and actual lake coverage.

## Changes
- Changed the default `maxUpstreamSteps` from `1` to `0` in the plan-lakes contract to ensure sink-only planning by default
- Added a new test case verifying that default configuration plans sink-only lakes
- Created a new test file `lakes-runtime-fill-drift.test.ts` that:
  - Reproduces engine-like validation that drops non-sink over-placed lake tiles
  - Verifies zero dry planned lakes after the full lakes + plot-rivers workflow

All tests pass, confirming the regression is fixed while maintaining expected lake planning behavior.