### PR TITLE
feat(placement): implement deterministic resource planning and stamping

### DIFF
--- a/docs/projects/pipeline-realism/scratch/ecology-placement-physics-cutover/SCRATCH-orchestrator.md
+++ b/docs/projects/pipeline-realism/scratch/ecology-placement-physics-cutover/SCRATCH-orchestrator.md
@@ -2,7 +2,7 @@
 
 ## Program Metadata
 - Program branch root: `codex/prr-ecology-placement-physics-cutover`
-- Current branch: `codex/prr-epp-s2-ecology-physics-cutover`
+- Current branch: `codex/prr-epp-s4-resources-deterministic`
 - Scope lock: `Ecology+Placement first`
 - Drift policy lock: `Observe first`
 - Local safety lock: do not touch `mods/mod-swooper-maps/src/domain/morphology/ops/compute-sea-level/rules/index.ts`
@@ -12,9 +12,9 @@
 |---|---|---|---|---|---|
 | S0 | codex/prr-epp-s0-plan-bootstrap | Orchestrator | completed |  | Plan + scratchpads scaffold committed |
 | S1 | codex/prr-epp-s1-drift-observability | Worker D | completed |  | Observe-first parity artifacts/effects + trace/viz drift layers committed (`c03c163b7`) |
-| S2 | codex/prr-epp-s2-ecology-physics-cutover | Worker A | in_progress |  | Physics-surface cutover and no-fudge/RNG purge in progress |
-| S3 | codex/prr-epp-s3-lakes-deterministic | Worker B | pending |  | |
-| S4 | codex/prr-epp-s4-resources-deterministic | Worker C | pending |  | |
+| S2 | codex/prr-epp-s2-ecology-physics-cutover | Worker A | completed |  | Physics-surface cutover and no-fudge/RNG purge committed (`581aea351`) |
+| S3 | codex/prr-epp-s3-lakes-deterministic | Worker B | completed |  | Deterministic hydrology lake plan + map-hydrology stamping committed (`e42ac109d`) |
+| S4 | codex/prr-epp-s4-resources-deterministic | Worker C | in_progress |  | Deterministic resource planner + adapter/stamping cutover; tests/docs being aligned |
 | S5 | codex/prr-epp-s5-placement-randomness-zero | Worker C | pending |  | |
 | S6 | codex/prr-epp-s6-hardening-docs-tests | Worker E + Orchestrator | pending |  | |
 
@@ -37,3 +37,14 @@
 - S1 had a write-once artifact collision risk when a single parity artifact was published by multiple steps.
 - Mitigation landed in S1: split into per-step parity artifacts (`engineProjectionLakes`, `engineProjectionRivers`, and per-step engine terrain snapshots).
 - Validation completed for S1: `bun run --cwd mods/mod-swooper-maps check` plus targeted hydrology/morphology/placement/ecology tests.
+- S2 completed with map-ecology stage-surface correction (removed explicit `public`/`compile` shim; config moved to step-id keys only).
+- S3 has removed `lakeiness` and `tilesPerLakeMultiplier` from active config/knob paths and switched `map-hydrology/lakes` to deterministic terrain stamping from `artifact:hydrology.lakePlan`.
+- S4 execution is running through worker agents with strict architecture guardrails:
+  - no schema-import indirection in step contracts;
+  - no local duplicated shared grid/math helpers in domain ops (promote to `mapgen-core` first);
+  - no legacy compatibility fallback paths in placement apply.
+
+## Authoring Guardrails (enforced for active workers)
+- For new domain ops, inline `input`/`output`/`strategies` schemas directly inside `defineOp(...)` (no detached `*Schema` wrapper constants for this program’s new ops).
+- Do not add `additionalProperties` options to these op schemas; rely on mapgen authoring defaults and canonical contract style.
+- Do not leave default strategy configs empty unless the op is truly non-configurable; prefer explicit physical controls (e.g., `maxUpstreamSteps`) when behavior has meaningful tuning semantics.

--- a/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T25.md
+++ b/docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/outcomes/M4-T25.md
@@ -1,0 +1,15 @@
+# Outcome M4-T25
+
+- task: M4-T25
+- workBranch: codex/prr-epp-s4-resources-deterministic
+- fixBranch: agent-TOMMY-M4-T25-fix-prr-epp-s4-resources-deterministic-21a5eb
+- classification: No actionable fix-now
+- workPR: #1265 (https://github.com/mateicanavra/civ7-modding-tools/pull/1265)
+- PR comment summary: unresolved review threads = 0 (see continuation ledger: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-pr-comments.md)
+- runtime-vs-viz: No new runtime-vs-viz mismatch observed in this continuation pass; runtime truth remains authoritative.
+- evidence:
+  - continuation manifest: docs/projects/pipeline-realism/scratch/m4-ecology-placement-physics-continuum-fix-review/continuation-manifest.tsv
+  - review entry: docs/projects/pipeline-realism/reviews/REVIEW-M4-ecology-placement-physics-continuum.md
+  - revalidation: n/a
+- supersedence: 
+- final recommendation: No branch-local change required now; keep covered by existing CI/regression checks and revisit only on new evidence.

--- a/mods/mod-swooper-maps/src/domain/placement/config.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/config.ts
@@ -10,6 +10,7 @@ export const PlacementConfigSchema = Type.Object(
   {
     wonders: placement.ops.planWonders.config,
     floodplains: placement.ops.planFloodplains.config,
+    resources: placement.ops.planResources.config,
     starts: placement.ops.planStarts.config,
   },
   { additionalProperties: false }

--- a/mods/mod-swooper-maps/src/domain/placement/ops/contracts.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/ops/contracts.ts
@@ -1,13 +1,15 @@
 import PlanFloodplainsContract from "./plan-floodplains/contract.js";
+import PlanResourcesContract from "./plan-resources/contract.js";
 import PlanStartsContract from "./plan-starts/contract.js";
 import PlanWondersContract from "./plan-wonders/contract.js";
 
 export const contracts = {
   planFloodplains: PlanFloodplainsContract,
+  planResources: PlanResourcesContract,
   planStarts: PlanStartsContract,
   planWonders: PlanWondersContract,
 } as const;
 
 export default contracts;
 
-export { PlanFloodplainsContract, PlanStartsContract, PlanWondersContract };
+export { PlanFloodplainsContract, PlanResourcesContract, PlanStartsContract, PlanWondersContract };

--- a/mods/mod-swooper-maps/src/domain/placement/ops/index.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/ops/index.ts
@@ -2,15 +2,17 @@ import type { DomainOpImplementationsForContracts } from "@swooper/mapgen-core/a
 import type { contracts } from "./contracts.js";
 
 import planFloodplains from "./plan-floodplains/index.js";
+import planResources from "./plan-resources/index.js";
 import planStarts from "./plan-starts/index.js";
 import planWonders from "./plan-wonders/index.js";
 
 const implementations = {
   planFloodplains,
+  planResources,
   planStarts,
   planWonders,
 } as const satisfies DomainOpImplementationsForContracts<typeof contracts>;
 
 export default implementations;
 
-export { planFloodplains, planStarts, planWonders };
+export { planFloodplains, planResources, planStarts, planWonders };

--- a/mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/contract.ts
@@ -1,0 +1,73 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+const PlanResourcesContract = defineOp({
+  kind: "plan",
+  id: "placement/plan-resources",
+  input: Type.Object({
+    width: Type.Integer({ minimum: 1 }),
+    height: Type.Integer({ minimum: 1 }),
+    landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
+    fertility: TypedArraySchemas.f32({ description: "Pedology fertility field (0..1)." }),
+    effectiveMoisture: TypedArraySchemas.f32({
+      description: "Ecology effective moisture field (normalized in strategy).",
+    }),
+    surfaceTemperature: TypedArraySchemas.f32({
+      description: "Surface temperature per tile (C).",
+    }),
+    aridityIndex: TypedArraySchemas.f32({
+      description: "Aridity index per tile (0..1).",
+    }),
+    riverClass: TypedArraySchemas.u8({
+      description: "Hydrology river class per tile (0=none,1=minor,2=major).",
+    }),
+    lakeMask: TypedArraySchemas.u8({
+      description: "Hydrology deterministic lake plan mask (1=lake, 0=non-lake).",
+    }),
+  }),
+  output: Type.Object({
+    width: Type.Integer({ minimum: 1 }),
+    height: Type.Integer({ minimum: 1 }),
+    candidateResourceTypes: Type.Array(Type.Integer({ minimum: 0 })),
+    targetCount: Type.Integer({ minimum: 0 }),
+    plannedCount: Type.Integer({ minimum: 0 }),
+    placements: Type.Array(
+      Type.Object({
+        plotIndex: Type.Integer({ minimum: 0 }),
+        preferredResourceType: Type.Integer({ minimum: 0 }),
+        preferredTypeOffset: Type.Integer({ minimum: 0 }),
+        priority: Type.Number({ minimum: 0, maximum: 1 }),
+      })
+    ),
+  }),
+  strategies: {
+    default: Type.Object({
+      candidateResourceTypes: Type.Array(Type.Integer({ minimum: 0 }), {
+        default: [
+          0, 1, 2, 3, 4, 5, 6, 7,
+          8, 9, 10, 11, 12, 13, 14, 15,
+          16, 17, 18, 19, 20, 21, 22, 23,
+        ],
+      }),
+      densityPer100Tiles: Type.Number({
+        minimum: 0,
+        maximum: 50,
+        default: 9,
+        description: "Target resource density over land tiles.",
+      }),
+      minSpacingTiles: Type.Integer({
+        minimum: 0,
+        maximum: 8,
+        default: 2,
+        description: "Minimum odd-q hex spacing between planned resources.",
+      }),
+      maxPlacementsPerResourceShare: Type.Number({
+        minimum: 0.05,
+        maximum: 1,
+        default: 0.3,
+        description: "Upper share cap for each resource type to avoid single-type collapse.",
+      }),
+    }),
+  },
+});
+
+export default PlanResourcesContract;

--- a/mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/index.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/index.ts
@@ -1,0 +1,15 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import PlanResourcesContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const planResources = createOp(PlanResourcesContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+export type * from "./types.js";
+
+export default planResources;

--- a/mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/strategies/default.ts
@@ -1,0 +1,170 @@
+import { clamp01 } from "@swooper/mapgen-core";
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+import { hexDistanceOddQPeriodicX } from "@swooper/mapgen-core/lib/grid";
+import PlanResourcesContract from "../contract.js";
+
+type Candidate = {
+  plotIndex: number;
+  priority: number;
+  stress: number;
+  preferredTypeOffset: number;
+};
+
+export const defaultStrategy = createStrategy(PlanResourcesContract, "default", {
+  run: (input, config) => {
+    const width = input.width | 0;
+    const height = input.height | 0;
+    const size = Math.max(0, width * height);
+    if (!(input.landMask instanceof Uint8Array) || input.landMask.length !== size) {
+      throw new Error("[Placement] Invalid landMask for placement/plan-resources.");
+    }
+    if (!(input.fertility instanceof Float32Array) || input.fertility.length !== size) {
+      throw new Error("[Placement] Invalid fertility for placement/plan-resources.");
+    }
+    if (!(input.effectiveMoisture instanceof Float32Array) || input.effectiveMoisture.length !== size) {
+      throw new Error("[Placement] Invalid effectiveMoisture for placement/plan-resources.");
+    }
+    if (!(input.surfaceTemperature instanceof Float32Array) || input.surfaceTemperature.length !== size) {
+      throw new Error("[Placement] Invalid surfaceTemperature for placement/plan-resources.");
+    }
+    if (!(input.aridityIndex instanceof Float32Array) || input.aridityIndex.length !== size) {
+      throw new Error("[Placement] Invalid aridityIndex for placement/plan-resources.");
+    }
+    if (!(input.riverClass instanceof Uint8Array) || input.riverClass.length !== size) {
+      throw new Error("[Placement] Invalid riverClass for placement/plan-resources.");
+    }
+    if (!(input.lakeMask instanceof Uint8Array) || input.lakeMask.length !== size) {
+      throw new Error("[Placement] Invalid lakeMask for placement/plan-resources.");
+    }
+
+    const candidateResourceTypes = Array.from(
+      new Set((config.candidateResourceTypes ?? []).map((value) => value | 0).filter((value) => value >= 0))
+    );
+    if (candidateResourceTypes.length === 0) {
+      return {
+        width,
+        height,
+        candidateResourceTypes: [],
+        targetCount: 0,
+        plannedCount: 0,
+        placements: [],
+      };
+    }
+
+    let landTiles = 0;
+    let moistureMin = Number.POSITIVE_INFINITY;
+    let moistureMax = Number.NEGATIVE_INFINITY;
+    for (let i = 0; i < size; i++) {
+      if (input.landMask[i] !== 1) continue;
+      landTiles += 1;
+      const moisture = input.effectiveMoisture[i] ?? 0;
+      if (moisture < moistureMin) moistureMin = moisture;
+      if (moisture > moistureMax) moistureMax = moisture;
+    }
+
+    const moistureRange = Number.isFinite(moistureMin) && Number.isFinite(moistureMax)
+      ? Math.max(1e-6, moistureMax - moistureMin)
+      : 1;
+
+    const candidates: Candidate[] = [];
+    for (let i = 0; i < size; i++) {
+      if (input.landMask[i] !== 1) continue;
+      if ((input.lakeMask[i] ?? 0) === 1) continue;
+
+      const fertility = clamp01(input.fertility[i] ?? 0);
+      const aridity = clamp01(input.aridityIndex[i] ?? 0);
+      const stress = 1 - aridity;
+      const moisture = clamp01(((input.effectiveMoisture[i] ?? moistureMin) - moistureMin) / moistureRange);
+      const temperature = input.surfaceTemperature[i] ?? 0;
+      const temperateSuitability = clamp01(1 - Math.abs(temperature - 16) / 36);
+      const riverHydration = clamp01((input.riverClass[i] ?? 0) / 2);
+      const hydro = clamp01((moisture + riverHydration) / 2);
+      const priority = clamp01((fertility + hydro + stress + temperateSuitability) / 4);
+
+      const signature = clamp01((fertility + hydro + temperateSuitability) / 3);
+      const preferredTypeOffset = Math.min(
+        candidateResourceTypes.length - 1,
+        Math.floor(signature * candidateResourceTypes.length)
+      );
+
+      candidates.push({
+        plotIndex: i,
+        priority,
+        stress,
+        preferredTypeOffset,
+      });
+    }
+
+    candidates.sort((a, b) => {
+      if (b.priority !== a.priority) return b.priority - a.priority;
+      if (b.stress !== a.stress) return b.stress - a.stress;
+      return a.plotIndex - b.plotIndex;
+    });
+
+    const targetCount = Math.min(
+      candidates.length,
+      Math.max(0, Math.round((landTiles * config.densityPer100Tiles) / 100))
+    );
+    const minSpacingTiles = Math.max(0, config.minSpacingTiles | 0);
+    const maxPerType = Math.max(
+      1,
+      Math.ceil(targetCount * clamp01(config.maxPlacementsPerResourceShare))
+    );
+
+    const selected: Array<{
+      plotIndex: number;
+      preferredResourceType: number;
+      preferredTypeOffset: number;
+      priority: number;
+    }> = [];
+    const perTypeCounts = new Map<number, number>();
+
+    for (const candidate of candidates) {
+      if (selected.length >= targetCount) break;
+      let tooClose = false;
+      if (minSpacingTiles > 0) {
+        for (const placed of selected) {
+          if (hexDistanceOddQPeriodicX(candidate.plotIndex, placed.plotIndex, width) < minSpacingTiles) {
+            tooClose = true;
+            break;
+          }
+        }
+      }
+      if (tooClose) continue;
+
+      let chosenOffset = candidate.preferredTypeOffset;
+      let foundCappedType = false;
+      for (let shift = 0; shift < candidateResourceTypes.length; shift++) {
+        const offset = (candidate.preferredTypeOffset + shift) % candidateResourceTypes.length;
+        const type = candidateResourceTypes[offset]!;
+        const current = perTypeCounts.get(type) ?? 0;
+        if (current < maxPerType) {
+          chosenOffset = offset;
+          foundCappedType = true;
+          break;
+        }
+      }
+      if (!foundCappedType) {
+        chosenOffset = candidate.preferredTypeOffset;
+      }
+
+      const preferredResourceType = candidateResourceTypes[chosenOffset]!;
+      selected.push({
+        plotIndex: candidate.plotIndex,
+        preferredResourceType,
+        preferredTypeOffset: chosenOffset,
+        priority: candidate.priority,
+      });
+      perTypeCounts.set(preferredResourceType, (perTypeCounts.get(preferredResourceType) ?? 0) + 1);
+    }
+
+    return {
+      width,
+      height,
+      candidateResourceTypes,
+      targetCount,
+      plannedCount: selected.length,
+      placements: selected,
+    };
+  },
+});

--- a/mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/types.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/types.ts
@@ -1,0 +1,5 @@
+import type { OpTypeBagOf } from "@swooper/mapgen-core/authoring";
+
+type Contract = typeof import("./contract.js").default;
+
+export type PlanResourcesTypes = OpTypeBagOf<Contract>;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
@@ -1,4 +1,5 @@
 import { Type, TypedArraySchemas, defineArtifact } from "@swooper/mapgen-core/authoring";
+import placement from "@mapgen/domain/placement";
 import { PlacementInputsV1Schema } from "./placement-inputs.js";
 import { PlacementOutputsV1Schema } from "./placement-outputs.js";
 
@@ -22,6 +23,7 @@ const PlacementEngineStateV1Schema = Type.Object(
     ),
     startsAssigned: Type.Integer({ minimum: 0 }),
     resourcesAttempted: Type.Boolean(),
+    resourcesPlaced: Type.Integer({ minimum: 0 }),
     resourcesError: Type.Optional(Type.String()),
     waterDriftCount: Type.Integer({
       minimum: 0,
@@ -36,6 +38,11 @@ export const placementArtifacts = {
     name: "placementInputs",
     id: "artifact:placementInputs",
     schema: PlacementInputsV1Schema,
+  }),
+  resourcePlan: defineArtifact({
+    name: "resourcePlan",
+    id: "artifact:placement.resourcePlan",
+    schema: placement.ops.planResources.output,
   }),
   placementOutputs: defineArtifact({
     name: "placementOutputs",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/placement-inputs.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/placement-inputs.ts
@@ -5,6 +5,7 @@ export const PlacementInputsConfigSchema = Type.Object(
   {
     wonders: placement.ops.planWonders.config,
     floodplains: placement.ops.planFloodplains.config,
+    resources: placement.ops.planResources.config,
     starts: placement.ops.planStarts.config,
   },
   { additionalProperties: false }
@@ -16,6 +17,7 @@ export const PlacementInputsV1Schema = Type.Object(
     starts: placement.ops.planStarts["output"],
     wonders: placement.ops.planWonders["output"],
     floodplains: placement.ops.planFloodplains["output"],
+    resources: placement.ops.planResources["output"],
     placementConfig: PlacementInputsConfigSchema,
   },
   { additionalProperties: false }

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/contract.ts
@@ -3,6 +3,9 @@ import placement from "@mapgen/domain/placement";
 
 import { M4_EFFECT_TAGS } from "../../../../tags.js";
 import { placementArtifacts } from "../../artifacts.js";
+import { hydrologyHydrographyArtifacts } from "../../../hydrology-hydrography/artifacts.js";
+import { ecologyArtifacts } from "../../../ecology/artifacts.js";
+import { morphologyArtifacts } from "../../../morphology/artifacts.js";
 
 /**
  * Builds the placement input artifact from runtime config and placement ops.
@@ -16,11 +19,19 @@ const DerivePlacementInputsContract = defineStep({
   ],
   provides: [],
   artifacts: {
-    provides: [placementArtifacts.placementInputs],
+    requires: [
+      morphologyArtifacts.topography,
+      hydrologyHydrographyArtifacts.hydrography,
+      hydrologyHydrographyArtifacts.lakePlan,
+      ecologyArtifacts.biomeClassification,
+      ecologyArtifacts.pedology,
+    ],
+    provides: [placementArtifacts.placementInputs, placementArtifacts.resourcePlan],
   },
   ops: {
     wonders: placement.ops.planWonders,
     floodplains: placement.ops.planFloodplains,
+    resources: placement.ops.planResources,
     starts: placement.ops.planStarts,
   },
   schema: Type.Object({}),

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/index.ts
@@ -5,11 +5,25 @@ import { buildPlacementInputs } from "./inputs.js";
 import { placementArtifacts } from "../../artifacts.js";
 
 export default createStep(DerivePlacementInputsContract, {
-  artifacts: implementArtifacts([placementArtifacts.placementInputs], {
+  artifacts: implementArtifacts([placementArtifacts.placementInputs, placementArtifacts.resourcePlan], {
     placementInputs: {},
+    resourcePlan: {},
   }),
   run: (context, config, ops, deps) => {
-    const inputs = buildPlacementInputs(context, config, ops);
+    const topography = deps.artifacts.topography.read(context);
+    const hydrography = deps.artifacts.hydrography.read(context);
+    const lakePlan = deps.artifacts.lakePlan.read(context);
+    const biomeClassification = deps.artifacts.biomeClassification.read(context);
+    const pedology = deps.artifacts.pedology.read(context);
+
+    const inputs = buildPlacementInputs(context, config, ops, {
+      topography,
+      hydrography,
+      lakePlan,
+      biomeClassification,
+      pedology,
+    });
     deps.artifacts.placementInputs.publish(context, inputs);
+    deps.artifacts.resourcePlan.publish(context, inputs.resources);
   },
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/inputs.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/inputs.ts
@@ -14,9 +14,29 @@ type DerivePlacementInputsOps = StepRuntimeOps<NonNullable<typeof DerivePlacemen
 export function buildPlacementInputs(
   context: ExtendedMapContext,
   config: DerivePlacementInputsConfig,
-  ops: DerivePlacementInputsOps
+  ops: DerivePlacementInputsOps,
+  physical: {
+    topography: {
+      landMask: Uint8Array;
+    };
+    hydrography: {
+      riverClass: Uint8Array;
+    };
+    lakePlan: {
+      lakeMask: Uint8Array;
+    };
+    biomeClassification: {
+      effectiveMoisture: Float32Array;
+      surfaceTemperature: Float32Array;
+      aridityIndex: Float32Array;
+    };
+    pedology: {
+      fertility: Float32Array;
+    };
+  }
 ): PlacementInputsV1 {
   const runtime = getStandardRuntime(context);
+  const { width, height } = context.dimensions;
   const baseStarts = {
     playersLandmass1: runtime.playersLandmass1,
     playersLandmass2: runtime.playersLandmass2,
@@ -27,12 +47,27 @@ export function buildPlacementInputs(
   const startsPlan = ops.starts({ baseStarts }, config.starts);
   const wondersPlan = ops.wonders({ mapInfo: runtime.mapInfo }, config.wonders);
   const floodplainsPlan = ops.floodplains({}, config.floodplains);
+  const resourcesPlan = ops.resources(
+    {
+      width,
+      height,
+      landMask: physical.topography.landMask,
+      fertility: physical.pedology.fertility,
+      effectiveMoisture: physical.biomeClassification.effectiveMoisture,
+      surfaceTemperature: physical.biomeClassification.surfaceTemperature,
+      aridityIndex: physical.biomeClassification.aridityIndex,
+      riverClass: physical.hydrography.riverClass,
+      lakeMask: physical.lakePlan.lakeMask,
+    },
+    config.resources
+  );
 
   return {
     mapInfo: runtime.mapInfo,
     starts: startsPlan,
     wonders: wondersPlan,
     floodplains: floodplainsPlan,
+    resources: resourcesPlan,
     placementConfig: config,
   };
 }

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/contract.ts
@@ -10,7 +10,11 @@ const PlacementStepContract = defineStep({
   requires: [M10_EFFECT_TAGS.map.landmassRegionsPlotted],
   provides: [M4_EFFECT_TAGS.engine.placementApplied, M10_EFFECT_TAGS.map.placementParityCaptured],
   artifacts: {
-    requires: [placementArtifacts.placementInputs, mapArtifacts.landmassRegionSlotByTile],
+    requires: [
+      placementArtifacts.placementInputs,
+      placementArtifacts.resourcePlan,
+      mapArtifacts.landmassRegionSlotByTile,
+    ],
     provides: [
       placementArtifacts.placementOutputs,
       placementArtifacts.engineState,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/index.ts
@@ -20,6 +20,7 @@ export default createStep(PlacementStepContract, {
   ),
   run: (context, _config, _ops, deps) => {
     const placementInputs = deps.artifacts.placementInputs.read(context);
+    const resourcePlan = deps.artifacts.resourcePlan.read(context);
     const landmassRegionSlotByTile = deps.artifacts.landmassRegionSlotByTile.read(context);
     const { starts, wonders, floodplains } = buildPlacementPlanInput(placementInputs);
 
@@ -28,6 +29,7 @@ export default createStep(PlacementStepContract, {
       starts,
       wonders,
       floodplains,
+      resources: resourcePlan,
       landmassRegionSlotByTile,
       publishOutputs: (outputs) =>
         deps.artifacts.placementOutputs.publish(context, outputs),

--- a/mods/mod-swooper-maps/test/placement/placement-does-not-call-generate-snow.test.ts
+++ b/mods/mod-swooper-maps/test/placement/placement-does-not-call-generate-snow.test.ts
@@ -44,6 +44,21 @@ describe("placement", () => {
       {},
       placement.ops.planFloodplains.defaultConfig
     );
+    const resources = {
+      width: 4,
+      height: 4,
+      candidateResourceTypes: [1],
+      targetCount: 1,
+      plannedCount: 1,
+      placements: [
+        {
+          plotIndex: 0,
+          preferredResourceType: 1,
+          preferredTypeOffset: 0,
+          priority: 1,
+        },
+      ],
+    };
 
     const placementRuntime = implementArtifacts([placementArtifacts.placementOutputs], {
       placementOutputs: {},
@@ -53,6 +68,7 @@ describe("placement", () => {
       starts,
       wonders,
       floodplains,
+      resources,
       landmassRegionSlotByTile: {
         slotByTile: new Uint8Array(16).fill(1),
       },
@@ -60,5 +76,6 @@ describe("placement", () => {
     });
 
     expect(adapter.calls.generateSnow.length).toBe(0);
+    expect(adapter.calls.generateResources.length).toBe(0);
   });
 });

--- a/mods/mod-swooper-maps/test/placement/resources-landmass-region-restamp.test.ts
+++ b/mods/mod-swooper-maps/test/placement/resources-landmass-region-restamp.test.ts
@@ -10,7 +10,6 @@ import { applyPlacementPlan } from "../../src/recipes/standard/stages/placement/
 
 class RegionSensitiveResourceAdapter extends MockAdapter {
   private regionByTile: Uint8Array;
-  resourcesPlaced = 0;
 
   constructor(config: ConstructorParameters<typeof MockAdapter>[0]) {
     super(config);
@@ -32,15 +31,9 @@ class RegionSensitiveResourceAdapter extends MockAdapter {
     this.regionByTile.fill(this.getLandmassId("NONE"));
   }
 
-  override generateResources(width: number, height: number): void {
+  override canHaveResource(x: number, y: number, resourceType: number): boolean {
     const none = this.getLandmassId("NONE");
-    let eligibleTiles = 0;
-    for (let y = 0; y < height; y++) {
-      for (let x = 0; x < width; x++) {
-        if (this.regionByTile[this.idx2(x, y)] !== none) eligibleTiles += 1;
-      }
-    }
-    this.resourcesPlaced = eligibleTiles;
+    return this.regionByTile[this.idx2(x, y)] !== none && super.canHaveResource(x, y, resourceType);
   }
 }
 
@@ -112,17 +105,35 @@ describe("placement resources landmass-region restamp", () => {
       placement.ops.planWonders.defaultConfig
     );
     const floodplains = placement.ops.planFloodplains.run({}, placement.ops.planFloodplains.defaultConfig);
+    const resources = {
+      width,
+      height,
+      candidateResourceTypes: [7],
+      targetCount: 1,
+      plannedCount: 1,
+      placements: [
+        {
+          plotIndex: 0,
+          preferredResourceType: 7,
+          preferredTypeOffset: 0,
+          priority: 1,
+        },
+      ],
+    };
 
-    applyPlacementPlan({
+    const outputs = applyPlacementPlan({
       context,
       starts,
       wonders,
       floodplains,
+      resources,
       landmassRegionSlotByTile: { slotByTile: new Uint8Array(width * height).fill(1) },
       publishOutputs: (outputs) => outputs,
     });
 
-    expect(adapter.resourcesPlaced).toBeGreaterThan(0);
+    expect(adapter.calls.setResourceType).toEqual([{ x: 0, y: 0, resourceType: 7 }]);
+    expect(adapter.resourcesPlaced).toBe(1);
+    expect(outputs.resourcesCount).toBe(1);
   });
 
   it("aborts placement before resource generation when region restamp fails", () => {

--- a/packages/civ7-adapter/src/civ7-adapter.ts
+++ b/packages/civ7-adapter/src/civ7-adapter.ts
@@ -244,6 +244,42 @@ export class Civ7Adapter implements EngineAdapter {
     return TerrainBuilder.canHaveFeature(x, y, featureType);
   }
 
+  getResourceType(x: number, y: number): number {
+    return GameplayMap.getResourceType(x, y);
+  }
+
+  setResourceType(x: number, y: number, resourceType: number): void {
+    const rb = (
+      globalThis as typeof globalThis & {
+        ResourceBuilder?: { setResourceType?: (x: number, y: number, resourceType: number) => void };
+      }
+    ).ResourceBuilder;
+    if (!rb?.setResourceType) {
+      throw new Error("[Adapter] ResourceBuilder.setResourceType is unavailable.");
+    }
+    rb.setResourceType(x, y, resourceType);
+    this.recordPlacementEffect();
+  }
+
+  canHaveResource(x: number, y: number, resourceType: number): boolean {
+    const rb = (
+      globalThis as typeof globalThis & {
+        ResourceBuilder?: {
+          canHaveResource?: (
+            x: number,
+            y: number,
+            resourceType: number,
+            ignoreWeight?: boolean
+          ) => boolean;
+        };
+      }
+    ).ResourceBuilder;
+    if (!rb?.canHaveResource) {
+      throw new Error("[Adapter] ResourceBuilder.canHaveResource is unavailable.");
+    }
+    return rb.canHaveResource(x, y, resourceType, false);
+  }
+
   // === PLOT EFFECTS ===
 
   getPlotEffectTypesContainingTags(tags: string[]): number[] {

--- a/packages/civ7-adapter/src/types.ts
+++ b/packages/civ7-adapter/src/types.ts
@@ -245,6 +245,17 @@ export interface EngineAdapter {
   /** Validate feature placement */
   canHaveFeature(x: number, y: number, featureType: number): boolean;
 
+  // === RESOURCE READS/WRITES ===
+
+  /** Get resource type ID (-1 when no resource is present). */
+  getResourceType(x: number, y: number): number;
+
+  /** Set resource type for a tile. */
+  setResourceType(x: number, y: number, resourceType: number): void;
+
+  /** Validate resource placement for a tile/resource combination. */
+  canHaveResource(x: number, y: number, resourceType: number): boolean;
+
   // === PLOT EFFECTS ===
 
   /**

--- a/packages/mapgen-core/src/lib/grid/hex-space.ts
+++ b/packages/mapgen-core/src/lib/grid/hex-space.ts
@@ -1,3 +1,5 @@
+import { wrapDeltaPeriodic } from "@mapgen/lib/math/wrap.js";
+
 export const HEX_WIDTH = Math.sqrt(3);
 export const HEX_HEIGHT = 1.5;
 export const HALF_HEX_HEIGHT = HEX_HEIGHT / 2;
@@ -15,3 +17,30 @@ export function projectOddqToHexSpace(x: number, y: number): { x: number; y: num
   return { x: hx, y: hy };
 }
 
+export type CubeCoord = Readonly<{ x: number; y: number; z: number }>;
+
+export function oddqToCube(x: number, y: number): CubeCoord {
+  const z = y - (x - (x & 1)) / 2;
+  const xCube = x;
+  const zCube = z;
+  const yCube = -xCube - zCube;
+  return { x: xCube, y: yCube, z: zCube };
+}
+
+/**
+ * Hex distance for odd-q row-major indices on a map with periodic X wrapping.
+ */
+export function hexDistanceOddQPeriodicX(aIndex: number, bIndex: number, width: number): number {
+  const ay = (aIndex / width) | 0;
+  const ax = aIndex - ay * width;
+  const by = (bIndex / width) | 0;
+  const bx = bIndex - by * width;
+  const wrappedBx = ax + wrapDeltaPeriodic(bx - ax, width);
+  const aCube = oddqToCube(ax, ay);
+  const bCube = oddqToCube(wrappedBx, by);
+  return Math.max(
+    Math.abs(aCube.x - bCube.x),
+    Math.abs(aCube.y - bCube.y),
+    Math.abs(aCube.z - bCube.z)
+  );
+}


### PR DESCRIPTION
# Deterministic Resource Placement Implementation

This PR implements deterministic resource placement in the map generation pipeline, replacing the previous random resource generation approach. Key changes include:

- Added a new `plan-resources` domain operation with a deterministic strategy that selects resource locations based on physical properties (fertility, hydrology, temperature)
- Created resource placement contract with configurable parameters for density, spacing, and type distribution
- Implemented resource stamping from plan to engine via new adapter methods (`getResourceType`, `setResourceType`, `canHaveResource`)
- Updated placement step to use deterministic resource plan instead of calling `generateResources()`
- Modified tests to validate deterministic resource stamping behavior
- Ensured proper ordering of operations (landmass region projection before resource stamping)
- Added resource placement telemetry and statistics to track placement success

The implementation preserves the existing resource suitability ranking algorithm but removes non-physical thresholds, using only valid land/non-lake candidates with deterministic tie-breaking. Resource type selection uses a rotation strategy with configurable type shares to prevent single-type dominance.

This change is part of the ecology-placement-physics-cutover program, completing the S4 deterministic resources milestone.