### PR TITLE
feat(foundation): remove dead knobs and enforce no-op-calls-op in tectonics

### DIFF
--- a/docs/projects/pipeline-realism/milestones/M4-foundation-domain-axe-cutover.md
+++ b/docs/projects/pipeline-realism/milestones/M4-foundation-domain-axe-cutover.md
@@ -222,3 +222,7 @@ prework_status:
 
 - This milestone is the canonical source for M4 sequencing and dependencies.
 - Issue docs are canonical for implementation detail and acceptance checks.
+
+## Full-stack review traceability
+- Full-stack review ledger: `docs/projects/pipeline-realism/reviews/REVIEW-M4-full-stack-chain.md`
+- Carried loop plan: `docs/projects/pipeline-realism/scratch/dev-loop-review/M4-full-stack-review-loop-plan.md`

--- a/docs/projects/pipeline-realism/reviews/REVIEW-M4-full-stack-chain.md
+++ b/docs/projects/pipeline-realism/reviews/REVIEW-M4-full-stack-chain.md
@@ -500,3 +500,30 @@ Full-chain review ledger for the active Graphite stack (`#1201`..`#1348`) using 
 
 ### Cross-cutting Risks
 - Documentation-led review records can drift from implementation unless periodically reconciled.
+
+## REVIEW codex/prr-m4-s02-contract-freeze-dead-knobs
+
+### Quick Take
+- Reviewed PR #1325 (https://github.com/mateicanavra/civ7-modding-tools/pull/1325).
+- Churn profile: +794 / -207 across 35 files files.
+- Verification signal: bun run --cwd mods/mod-swooper-maps check: FAIL.
+
+### High-Leverage Issues
+- Verification gate failed for this branch (bun run --cwd mods/mod-swooper-maps check: FAIL).
+
+### PR Comment Context
+- Comment volume: comments=2, reviews=0.
+- Review threads: unresolved=0, resolved=0.
+- Automation/non-substantive chatter excluded from issue ranking.
+
+### Fix Now (Recommended)
+- Re-run and stabilize the failing verification gate for this branch before merge.
+
+### Defer / Follow-up
+- Add a focused post-merge regression sweep for high-churn slices that failed local verification in this pass.
+
+### Needs Discussion
+- None.
+
+### Cross-cutting Risks
+- Stack-wide risk: repeated restacks can mask branch-local regressions without targeted validation.

--- a/docs/projects/pipeline-realism/scratch/dev-loop-review/M4-full-stack-review-loop-plan.md
+++ b/docs/projects/pipeline-realism/scratch/dev-loop-review/M4-full-stack-review-loop-plan.md
@@ -33,3 +33,13 @@
 - 2026-02-17: Reviewed #1257 (agent-SWANKO-PRR-s124-c01-fix-diag-analyze-mountains-guard); unresolved=0, resolved=0; verification: bun run --cwd mods/mod-swooper-maps check: FAIL.
 - 2026-02-17: Reviewed #1262 (codex/agent-ORCH-foundation-domain-axe-spike); unresolved=0, resolved=0; verification: docs-only; no runtime check run.
 - 2026-02-17: Reviewed #1263 (codex/agent-ORCH-foundation-domain-axe-execution); unresolved=0, resolved=2; verification: docs-only; no runtime check run.
+
+## Reusable Review Axes (apply to every PR)
+1. Contract integrity: truth vs projection boundaries and artifact-id ownership are not blurred.
+2. Topology discipline: steps orchestrate; ops do not orchestrate peer ops.
+3. Shim/dual-path posture: no legacy+new dual publish or hidden compatibility shims in final state.
+4. Verification posture: changed behavior has direct test/lint/guardrail evidence.
+5. Docs-contract parity: docs/spec/tutorials reflect real runtime/config surfaces.
+6. PR feedback closure: unresolved comment threads are either fixed or explicitly deferred.
+7. Stack safety: restacks preserve behavior and do not silently regress parent invariants.
+- PR #1325 codex/prr-m4-s02-contract-freeze-dead-knobs: review appended; verification=FAIL; unresolvedThreads=0

--- a/mods/mod-swooper-maps/src/dev/viz/foundation-run.ts
+++ b/mods/mod-swooper-maps/src/dev/viz/foundation-run.ts
@@ -11,8 +11,6 @@ const BROWSER_TEST_RECIPE_CONFIG = {
     version: 1,
     profiles: {
       resolutionProfile: "balanced",
-      lithosphereProfile: "maximal-basaltic-lid-v1",
-      mantleProfile: "maximal-potential-v1",
     },
     knobs: {
       plateCount: 28,

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/contract.ts
@@ -3,38 +3,10 @@ import type { Static } from "@swooper/mapgen-core/authoring";
 
 import { FoundationCrustSchema } from "../compute-crust/contract.js";
 import { FoundationMeshSchema } from "../compute-mesh/contract.js";
-import {
-  FoundationTectonicHistorySchema,
-  FoundationTectonicProvenanceSchema,
-  FoundationTectonicsSchema,
-} from "../compute-tectonic-history/contract.js";
+import { FoundationTectonicHistorySchema, FoundationTectonicsSchema } from "../compute-tectonic-history/contract.js";
 
 const StrategySchema = Type.Object(
-  {
-    /** How strongly accumulated uplift contributes to crust maturity (0..2). */
-    upliftToMaturity: Type.Number({
-      minimum: 0,
-      maximum: 2,
-      default: 1.0,
-      description: "How strongly accumulated uplift contributes to crust maturity (0..2).",
-    }),
-    /** How strongly provenance “material age” contributes to maturity (0..2). */
-    ageToMaturity: Type.Number({
-      minimum: 0,
-      maximum: 2,
-      // Provenance "material age" is an important stability/strength signal, but it should not
-      // dominate continental emergence (oceanic crust does not become continental simply by aging).
-      default: 0.25,
-      description: "How strongly provenance “material age” contributes to maturity (0..2).",
-    }),
-    /** How strongly rift/fracture signals suppress maturity (0..2). */
-    disruptionToMaturity: Type.Number({
-      minimum: 0,
-      maximum: 2,
-      default: 0.9,
-      description: "How strongly rift/fracture signals suppress maturity (0..2).",
-    }),
-  },
+  {},
   { additionalProperties: false, description: "Default strategy parameters for crust evolution from tectonic history." }
 );
 
@@ -47,7 +19,6 @@ const ComputeCrustEvolutionContract = defineOp({
       crustInit: FoundationCrustSchema,
       tectonics: FoundationTectonicsSchema,
       tectonicHistory: FoundationTectonicHistorySchema,
-      tectonicProvenance: FoundationTectonicProvenanceSchema,
     },
     { additionalProperties: false, description: "Input payload for foundation/compute-crust-evolution." }
   ),

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-crust-evolution/index.ts
@@ -1,7 +1,7 @@
 import { createOp } from "@swooper/mapgen-core/authoring";
 import { clamp01, clampU8 } from "@swooper/mapgen-core/lib/math";
 
-import { requireCrust, requireMesh, requireTectonicHistory, requireTectonicProvenance, requireTectonics } from "../../lib/require.js";
+import { requireCrust, requireMesh, requireTectonicHistory, requireTectonics } from "../../lib/require.js";
 import ComputeCrustEvolutionContract from "./contract.js";
 
 const MATURITY_CONTINENT_THRESHOLD = 0.55;
@@ -71,8 +71,6 @@ const computeCrustEvolution = createOp(ComputeCrustEvolutionContract, {
           cellCount,
           "foundation/compute-crust-evolution"
         );
-        // Keep provenance as a hard input even if this strategy doesn't currently consume its fields.
-        requireTectonicProvenance(input.tectonicProvenance, cellCount, "foundation/compute-crust-evolution");
 
         const maturity = new Float32Array(cellCount);
         const thickness = new Float32Array(cellCount);

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-plate-graph/contract.ts
@@ -56,18 +56,6 @@ const StrategySchema = Type.Object(
             maximum: 10_000,
             description: "Minimum cell area for a polar microplate (sliver guardrail).",
           }),
-          tangentialSpeed: Type.Number({
-            default: 0.9,
-            minimum: 0,
-            maximum: 10,
-            description: "Baseline tangential speed magnitude used for polar caps and polar microplates.",
-          }),
-          tangentialJitterDeg: Type.Number({
-            default: 12,
-            minimum: 0,
-            maximum: 90,
-            description: "Angle jitter (degrees) applied around tangential direction for polar microplates.",
-          }),
         },
         { additionalProperties: false }
       )

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/contract.ts
@@ -5,7 +5,6 @@ import { FoundationMantleForcingSchema } from "../compute-mantle-forcing/contrac
 import { FoundationMeshSchema } from "../compute-mesh/contract.js";
 import { FoundationPlateGraphSchema } from "../compute-plate-graph/contract.js";
 import { FoundationPlateMotionSchema } from "../compute-plate-motion/contract.js";
-import { FoundationTectonicSegmentsSchema } from "../compute-tectonic-segments/contract.js";
 
 const StrategySchema = Type.Object(
   {
@@ -203,7 +202,6 @@ const ComputeTectonicHistoryContract = defineOp({
       mantleForcing: FoundationMantleForcingSchema,
       plateGraph: FoundationPlateGraphSchema,
       plateMotion: FoundationPlateMotionSchema,
-      segments: FoundationTectonicSegmentsSchema,
     },
     { additionalProperties: false }
   ),

--- a/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/lib/era-tectonics-kernels.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/ops/compute-tectonic-history/lib/era-tectonics-kernels.ts
@@ -1,0 +1,559 @@
+import { clamp01, clampInt, wrapDeltaPeriodic } from "@swooper/mapgen-core/lib/math";
+
+import { BOUNDARY_TYPE } from "../../../constants.js";
+import type { FoundationCrust } from "../../compute-crust/contract.js";
+import type { FoundationMantleForcing } from "../../compute-mantle-forcing/contract.js";
+import type { FoundationMesh } from "../../compute-mesh/contract.js";
+import type { FoundationPlateGraph } from "../../compute-plate-graph/contract.js";
+import type { ComputePlateMotionConfig, FoundationPlateMotion } from "../../compute-plate-motion/contract.js";
+import type { ComputeTectonicSegmentsConfig, FoundationTectonicSegments } from "../../compute-tectonic-segments/contract.js";
+
+const EPS = 1e-9;
+
+export const DEFAULT_PLATE_MOTION_CONFIG: ComputePlateMotionConfig = {
+  omegaFactor: 1,
+  plateRadiusMin: 1,
+  residualNormScale: 1,
+  p90NormScale: 1,
+  histogramBins: 32,
+  smoothingSteps: 0,
+};
+
+export const DEFAULT_TECTONIC_SEGMENTS_CONFIG: ComputeTectonicSegmentsConfig = {
+  intensityScale: 900,
+  regimeMinIntensity: 4,
+};
+
+type PlateGraphMembership = Readonly<Pick<FoundationPlateGraph, "cellToPlate" | "plates">>;
+
+type PlateMotionKernelInput = Readonly<{
+  mesh: FoundationMesh;
+  plateGraph: PlateGraphMembership;
+  mantleForcing: Pick<FoundationMantleForcing, "forcingU" | "forcingV">;
+}>;
+
+type TectonicSegmentsKernelInput = Readonly<{
+  mesh: FoundationMesh;
+  crust: Pick<FoundationCrust, "strength" | "type">;
+  plateGraph: PlateGraphMembership;
+  plateMotion: FoundationPlateMotion;
+}>;
+
+function clampByte(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value <= 0) return 0;
+  if (value >= 255) return 255;
+  return Math.round(value) | 0;
+}
+
+function clampInt8(value: number): number {
+  return Math.max(-127, Math.min(127, Math.round(value))) | 0;
+}
+
+function hypot2(x: number, y: number): number {
+  return Math.sqrt(x * x + y * y);
+}
+
+function normalizeToInt8(x: number, y: number): { u: number; v: number } {
+  const len = hypot2(x, y);
+  if (!Number.isFinite(len) || len <= 1e-9) return { u: 0, v: 0 };
+  return { u: clampInt8((x / len) * 127), v: clampInt8((y / len) * 127) };
+}
+
+function velocityAtPoint(params: {
+  plateId: number;
+  plateMotion: FoundationPlateMotion;
+  x: number;
+  y: number;
+  wrapWidth: number;
+}): { vx: number; vy: number } {
+  const plateId = params.plateId | 0;
+  const vx = params.plateMotion.plateVelocityX[plateId] ?? 0;
+  const vy = params.plateMotion.plateVelocityY[plateId] ?? 0;
+
+  const omega = params.plateMotion.plateOmega[plateId] ?? 0;
+  if (!omega) return { vx, vy };
+
+  const cx = params.plateMotion.plateCenterX[plateId] ?? 0;
+  const cy = params.plateMotion.plateCenterY[plateId] ?? 0;
+  const dx = wrapDeltaPeriodic(params.x - cx, params.wrapWidth);
+  const dy = params.y - cy;
+
+  return { vx: vx + -dy * omega, vy: vy + dx * omega };
+}
+
+function boundaryRegimeFromIntensities(intensities: {
+  compression: number;
+  extension: number;
+  shear: number;
+  minIntensity: number;
+}): number {
+  const c = intensities.compression | 0;
+  const e = intensities.extension | 0;
+  const s = intensities.shear | 0;
+  const max = Math.max(c, e, s);
+  if (max < (intensities.minIntensity | 0)) return BOUNDARY_TYPE.none;
+  if (c >= e && c >= s) return BOUNDARY_TYPE.convergent;
+  if (e >= c && e >= s) return BOUNDARY_TYPE.divergent;
+  return BOUNDARY_TYPE.transform;
+}
+
+export function computePlateMotionFromState(
+  input: PlateMotionKernelInput,
+  config: ComputePlateMotionConfig = DEFAULT_PLATE_MOTION_CONFIG
+): FoundationPlateMotion {
+  const mesh = input.mesh;
+  const plateGraph = input.plateGraph;
+  const mantleForcing = input.mantleForcing;
+
+  const cellCount = mesh.cellCount | 0;
+  const plateCount = plateGraph.plates.length | 0;
+  const wrapWidth = mesh.wrapWidth;
+
+  const omegaFactor = Math.max(0, config.omegaFactor ?? DEFAULT_PLATE_MOTION_CONFIG.omegaFactor);
+  const plateRadiusMin = Math.max(1e-6, config.plateRadiusMin ?? DEFAULT_PLATE_MOTION_CONFIG.plateRadiusMin);
+  const residualNormScale = Math.max(
+    0.01,
+    config.residualNormScale ?? DEFAULT_PLATE_MOTION_CONFIG.residualNormScale
+  );
+  const p90NormScale = Math.max(0.01, config.p90NormScale ?? DEFAULT_PLATE_MOTION_CONFIG.p90NormScale);
+  const histogramBins = clampInt(
+    Math.round(config.histogramBins ?? DEFAULT_PLATE_MOTION_CONFIG.histogramBins),
+    8,
+    128
+  );
+  const smoothingSteps = clampInt(
+    Math.round(config.smoothingSteps ?? DEFAULT_PLATE_MOTION_CONFIG.smoothingSteps),
+    0,
+    1
+  );
+
+  let forcingU = mantleForcing.forcingU;
+  let forcingV = mantleForcing.forcingV;
+
+  if (smoothingSteps > 0) {
+    const smoothedU = new Float32Array(cellCount);
+    const smoothedV = new Float32Array(cellCount);
+    for (let i = 0; i < cellCount; i++) {
+      const start = mesh.neighborsOffsets[i] ?? 0;
+      const end = mesh.neighborsOffsets[i + 1] ?? start;
+      let sumU = forcingU[i] ?? 0;
+      let sumV = forcingV[i] ?? 0;
+      let count = 1;
+      for (let j = start; j < end; j++) {
+        const n = mesh.neighbors[j] ?? -1;
+        if (n < 0 || n >= cellCount) continue;
+        sumU += forcingU[n] ?? 0;
+        sumV += forcingV[n] ?? 0;
+        count += 1;
+      }
+      const inv = 1 / count;
+      smoothedU[i] = sumU * inv;
+      smoothedV[i] = sumV * inv;
+    }
+    forcingU = smoothedU;
+    forcingV = smoothedV;
+  }
+
+  const sumW = new Float64Array(plateCount);
+  const sumX = new Float64Array(plateCount);
+  const sumY = new Float64Array(plateCount);
+  const sumU = new Float64Array(plateCount);
+  const sumV = new Float64Array(plateCount);
+
+  let totalWeight = 0;
+  let totalSpeed = 0;
+
+  for (let i = 0; i < cellCount; i++) {
+    const plateId = plateGraph.cellToPlate[i] | 0;
+    if (plateId < 0 || plateId >= plateCount) continue;
+
+    const start = mesh.neighborsOffsets[i] ?? 0;
+    const end = mesh.neighborsOffsets[i + 1] ?? start;
+    let boundaryDegree = 0;
+    for (let j = start; j < end; j++) {
+      const n = mesh.neighbors[j] ?? -1;
+      if (n < 0 || n >= cellCount) continue;
+      if ((plateGraph.cellToPlate[n] | 0) !== plateId) boundaryDegree += 1;
+    }
+
+    const area = mesh.areas[i] ?? 1;
+    const weight = area / (1 + boundaryDegree);
+    if (!Number.isFinite(weight) || weight <= 0) continue;
+
+    const plate = plateGraph.plates[plateId];
+    const xRef = plate?.seedX ?? 0;
+    const x = xRef + wrapDeltaPeriodic((mesh.siteX[i] ?? 0) - xRef, wrapWidth);
+    const y = mesh.siteY[i] ?? 0;
+
+    const u = forcingU[i] ?? 0;
+    const v = forcingV[i] ?? 0;
+
+    sumW[plateId] += weight;
+    sumX[plateId] += weight * x;
+    sumY[plateId] += weight * y;
+    sumU[plateId] += weight * u;
+    sumV[plateId] += weight * v;
+
+    totalWeight += weight;
+    totalSpeed += weight * Math.hypot(u, v);
+  }
+
+  const meanForcingSpeed = totalWeight > EPS ? totalSpeed / totalWeight : 0;
+
+  const plateCenterX = new Float32Array(plateCount);
+  const plateCenterY = new Float32Array(plateCount);
+  const plateVelocityX = new Float32Array(plateCount);
+  const plateVelocityY = new Float32Array(plateCount);
+
+  for (let p = 0; p < plateCount; p++) {
+    const weight = sumW[p] ?? 0;
+    if (weight > EPS) {
+      const inv = 1 / weight;
+      plateCenterX[p] = (sumX[p] ?? 0) * inv;
+      plateCenterY[p] = (sumY[p] ?? 0) * inv;
+      plateVelocityX[p] = (sumU[p] ?? 0) * inv;
+      plateVelocityY[p] = (sumV[p] ?? 0) * inv;
+    } else {
+      const plate = plateGraph.plates[p];
+      plateCenterX[p] = plate?.seedX ?? 0;
+      plateCenterY[p] = plate?.seedY ?? 0;
+      plateVelocityX[p] = 0;
+      plateVelocityY[p] = 0;
+    }
+  }
+
+  const numOmega = new Float64Array(plateCount);
+  const denOmega = new Float64Array(plateCount);
+
+  for (let i = 0; i < cellCount; i++) {
+    const plateId = plateGraph.cellToPlate[i] | 0;
+    if (plateId < 0 || plateId >= plateCount) continue;
+
+    const start = mesh.neighborsOffsets[i] ?? 0;
+    const end = mesh.neighborsOffsets[i + 1] ?? start;
+    let boundaryDegree = 0;
+    for (let j = start; j < end; j++) {
+      const n = mesh.neighbors[j] ?? -1;
+      if (n < 0 || n >= cellCount) continue;
+      if ((plateGraph.cellToPlate[n] | 0) !== plateId) boundaryDegree += 1;
+    }
+
+    const area = mesh.areas[i] ?? 1;
+    const weight = area / (1 + boundaryDegree);
+    if (!Number.isFinite(weight) || weight <= 0) continue;
+
+    const plate = plateGraph.plates[plateId];
+    const xRef = plate?.seedX ?? 0;
+    const x = xRef + wrapDeltaPeriodic((mesh.siteX[i] ?? 0) - xRef, wrapWidth);
+    const y = mesh.siteY[i] ?? 0;
+
+    const cx = plateCenterX[plateId] ?? 0;
+    const cy = plateCenterY[plateId] ?? 0;
+    const rx = x - cx;
+    const ry = y - cy;
+
+    const du = (forcingU[i] ?? 0) - (plateVelocityX[plateId] ?? 0);
+    const dv = (forcingV[i] ?? 0) - (plateVelocityY[plateId] ?? 0);
+
+    numOmega[plateId] += weight * (rx * dv - ry * du);
+    denOmega[plateId] += weight * (rx * rx + ry * ry);
+  }
+
+  const plateOmega = new Float32Array(plateCount);
+  for (let p = 0; p < plateCount; p++) {
+    const denom = Math.max(EPS, denOmega[p] ?? 0);
+    let omega = (numOmega[p] ?? 0) / denom;
+    const radiusRms = Math.sqrt((denOmega[p] ?? 0) / Math.max(sumW[p] ?? 0, EPS));
+    const omegaMax = omegaFactor > 0 ? (omegaFactor * meanForcingSpeed) / Math.max(plateRadiusMin, radiusRms) : 0;
+    if (omegaMax > 0) {
+      omega = Math.max(-omegaMax, Math.min(omegaMax, omega));
+    } else {
+      omega = 0;
+    }
+    plateOmega[p] = omega;
+  }
+
+  const plateFitRms = new Float32Array(plateCount);
+  const plateFitP90 = new Float32Array(plateCount);
+  const plateQuality = new Uint8Array(plateCount);
+  const cellFitError = new Uint8Array(cellCount);
+
+  const residualNorm = Math.max(EPS, meanForcingSpeed * residualNormScale);
+  const p90Norm = Math.max(EPS, meanForcingSpeed * p90NormScale);
+  const sumErrSq = new Float64Array(plateCount);
+  const cellWeight = new Float32Array(cellCount);
+  const cellErr = new Float32Array(cellCount);
+  const maxNormByPlate = new Float32Array(plateCount);
+
+  for (let i = 0; i < cellCount; i++) {
+    const plateId = plateGraph.cellToPlate[i] | 0;
+    if (plateId < 0 || plateId >= plateCount) continue;
+
+    const start = mesh.neighborsOffsets[i] ?? 0;
+    const end = mesh.neighborsOffsets[i + 1] ?? start;
+    let boundaryDegree = 0;
+    for (let j = start; j < end; j++) {
+      const n = mesh.neighbors[j] ?? -1;
+      if (n < 0 || n >= cellCount) continue;
+      if ((plateGraph.cellToPlate[n] | 0) !== plateId) boundaryDegree += 1;
+    }
+
+    const area = mesh.areas[i] ?? 1;
+    const weight = area / (1 + boundaryDegree);
+    if (!Number.isFinite(weight) || weight <= 0) continue;
+
+    const plate = plateGraph.plates[plateId];
+    const xRef = plate?.seedX ?? 0;
+    const x = xRef + wrapDeltaPeriodic((mesh.siteX[i] ?? 0) - xRef, wrapWidth);
+    const y = mesh.siteY[i] ?? 0;
+
+    const cx = plateCenterX[plateId] ?? 0;
+    const cy = plateCenterY[plateId] ?? 0;
+    const rx = x - cx;
+    const ry = y - cy;
+
+    const vx = (plateVelocityX[plateId] ?? 0) + -ry * (plateOmega[plateId] ?? 0);
+    const vy = (plateVelocityY[plateId] ?? 0) + rx * (plateOmega[plateId] ?? 0);
+
+    const du = (forcingU[i] ?? 0) - vx;
+    const dv = (forcingV[i] ?? 0) - vy;
+    const err = Math.hypot(du, dv);
+
+    cellWeight[i] = weight;
+    cellErr[i] = err;
+    sumErrSq[plateId] += weight * err * err;
+    cellFitError[i] = clampByte((255 * err) / residualNorm);
+
+    const normalized = err / residualNorm;
+    if (normalized > (maxNormByPlate[plateId] ?? 0)) {
+      maxNormByPlate[plateId] = normalized;
+    }
+  }
+
+  const logMaxByPlate = new Float32Array(plateCount);
+  for (let p = 0; p < plateCount; p++) {
+    const maxNorm = Math.max(0, maxNormByPlate[p] ?? 0);
+    logMaxByPlate[p] = Math.log1p(maxNorm);
+  }
+
+  const hist = new Float64Array(plateCount * histogramBins);
+  for (let i = 0; i < cellCount; i++) {
+    const plateId = plateGraph.cellToPlate[i] | 0;
+    if (plateId < 0 || plateId >= plateCount) continue;
+
+    const weight = cellWeight[i] ?? 0;
+    if (weight <= 0) continue;
+
+    const logMax = logMaxByPlate[plateId] ?? 0;
+    if (logMax <= EPS) continue;
+
+    const normalized = Math.max(0, (cellErr[i] ?? 0) / residualNorm);
+    const t = Math.log1p(normalized) / logMax;
+    const bin = Math.min(histogramBins - 1, Math.max(0, Math.floor(t * histogramBins)));
+    hist[plateId * histogramBins + bin] += weight;
+  }
+
+  for (let p = 0; p < plateCount; p++) {
+    const weight = sumW[p] ?? 0;
+    if (weight <= EPS) {
+      plateFitRms[p] = 0;
+      plateFitP90[p] = 0;
+      plateQuality[p] = 0;
+      continue;
+    }
+    plateFitRms[p] = Math.sqrt((sumErrSq[p] ?? 0) / weight);
+
+    const target = weight * 0.9;
+    let cumulative = 0;
+    let bin = histogramBins - 1;
+    for (let b = 0; b < histogramBins; b++) {
+      cumulative += hist[p * histogramBins + b] ?? 0;
+      if (cumulative >= target) {
+        bin = b;
+        break;
+      }
+    }
+    const logMax = Math.max(EPS, logMaxByPlate[p] ?? 0);
+    const t = ((bin + 0.5) / histogramBins) * logMax;
+    const normalizedP90 = Math.expm1(t);
+    plateFitP90[p] = normalizedP90 * residualNorm;
+
+    const q = clamp01(1 - (plateFitP90[p] ?? 0) / p90Norm);
+    plateQuality[p] = Math.round(q * 255);
+  }
+
+  return {
+    version: 1,
+    cellCount,
+    plateCount,
+    plateCenterX,
+    plateCenterY,
+    plateVelocityX,
+    plateVelocityY,
+    plateOmega,
+    plateFitRms,
+    plateFitP90,
+    plateQuality,
+    cellFitError,
+  } as const satisfies FoundationPlateMotion;
+}
+
+export function computeTectonicSegmentsFromState(
+  input: TectonicSegmentsKernelInput,
+  config: ComputeTectonicSegmentsConfig = DEFAULT_TECTONIC_SEGMENTS_CONFIG
+): FoundationTectonicSegments {
+  const mesh = input.mesh;
+  const crust = input.crust;
+  const plateGraph = input.plateGraph;
+  const plateMotion = input.plateMotion;
+
+  const cellCount = mesh.cellCount | 0;
+  const wrapWidth = mesh.wrapWidth;
+  const intensityScale = config.intensityScale ?? DEFAULT_TECTONIC_SEGMENTS_CONFIG.intensityScale;
+  const regimeMinIntensity = (config.regimeMinIntensity ?? DEFAULT_TECTONIC_SEGMENTS_CONFIG.regimeMinIntensity) | 0;
+
+  const aCell: number[] = [];
+  const bCell: number[] = [];
+  const plateA: number[] = [];
+  const plateB: number[] = [];
+  const regime: number[] = [];
+  const polarity: number[] = [];
+  const compression: number[] = [];
+  const extension: number[] = [];
+  const shear: number[] = [];
+  const volcanism: number[] = [];
+  const fracture: number[] = [];
+  const driftU: number[] = [];
+  const driftV: number[] = [];
+
+  for (let i = 0; i < cellCount; i++) {
+    const start = mesh.neighborsOffsets[i] | 0;
+    const end = mesh.neighborsOffsets[i + 1] | 0;
+    const plateAId = plateGraph.cellToPlate[i] | 0;
+    if (!plateGraph.plates[plateAId]) continue;
+
+    const ax = mesh.siteX[i] ?? 0;
+    const ay = mesh.siteY[i] ?? 0;
+
+    for (let cursor = start; cursor < end; cursor++) {
+      const j = mesh.neighbors[cursor] | 0;
+      if (j <= i) continue;
+      if (j < 0 || j >= cellCount) continue;
+
+      const plateBId = plateGraph.cellToPlate[j] | 0;
+      if (plateBId === plateAId) continue;
+
+      if (!plateGraph.plates[plateBId]) continue;
+
+      const bx = mesh.siteX[j] ?? 0;
+      const by = mesh.siteY[j] ?? 0;
+
+      const dx = wrapDeltaPeriodic(bx - ax, wrapWidth);
+      const dy = by - ay;
+      const len = hypot2(dx, dy);
+      if (!Number.isFinite(len) || len <= 1e-9) continue;
+
+      const nx = dx / len;
+      const ny = dy / len;
+      const tx = -ny;
+      const ty = nx;
+
+      const midX = ax + dx * 0.5;
+      const midY = ay + dy * 0.5;
+
+      const vA = velocityAtPoint({ plateId: plateAId, plateMotion, x: midX, y: midY, wrapWidth });
+      const vB = velocityAtPoint({ plateId: plateBId, plateMotion, x: midX, y: midY, wrapWidth });
+
+      const rvx = (vB.vx ?? 0) - (vA.vx ?? 0);
+      const rvy = (vB.vy ?? 0) - (vA.vy ?? 0);
+
+      const vn = rvx * nx + rvy * ny;
+      const vt = rvx * tx + rvy * ty;
+
+      const strengthA = clamp01(crust.strength[i] ?? 0);
+      const strengthB = clamp01(crust.strength[j] ?? 0);
+      const resistance = clamp01((strengthA + strengthB) * 0.5);
+      const weakness = clamp01(1 - resistance);
+
+      const compressionScale = 0.85 + 0.3 * resistance;
+      const extensionScale = 0.85 + 0.3 * weakness;
+      const shearScale = 0.9 + 0.2 * weakness;
+
+      const c = clampByte(Math.max(0, -vn) * intensityScale * compressionScale);
+      const e = clampByte(Math.max(0, vn) * intensityScale * extensionScale);
+      const s = clampByte(Math.abs(vt) * intensityScale * shearScale);
+      const kind = boundaryRegimeFromIntensities({
+        compression: c,
+        extension: e,
+        shear: s,
+        minIntensity: regimeMinIntensity,
+      });
+
+      let pol = 0;
+      if (kind === BOUNDARY_TYPE.convergent) {
+        const aType = crust.type[i] ?? 0;
+        const bType = crust.type[j] ?? 0;
+        if (aType !== bType) {
+          if (aType === 0 && bType === 1) pol = -1;
+          if (aType === 1 && bType === 0) pol = 1;
+        } else if (aType === 0) {
+          const diff = strengthA - strengthB;
+          if (Math.abs(diff) >= 0.03) pol = diff < 0 ? -1 : 1;
+        }
+      }
+
+      const v = (() => {
+        if (kind === BOUNDARY_TYPE.convergent) return clampByte(c * 0.6 + (pol !== 0 ? 40 : 0));
+        if (kind === BOUNDARY_TYPE.divergent) return clampByte(e * 0.25);
+        if (kind === BOUNDARY_TYPE.transform) return clampByte(s * 0.1);
+        return 0;
+      })();
+
+      const f = (() => {
+        if (kind === BOUNDARY_TYPE.transform) return clampByte(s * 0.7);
+        if (kind === BOUNDARY_TYPE.divergent) return clampByte(e * 0.3);
+        if (kind === BOUNDARY_TYPE.convergent) return clampByte(c * 0.2);
+        return 0;
+      })();
+
+      const drift = normalizeToInt8(
+        (plateMotion.plateVelocityX[plateAId] ?? 0) + (plateMotion.plateVelocityX[plateBId] ?? 0),
+        (plateMotion.plateVelocityY[plateAId] ?? 0) + (plateMotion.plateVelocityY[plateBId] ?? 0)
+      );
+
+      aCell.push(i);
+      bCell.push(j);
+      plateA.push(plateAId);
+      plateB.push(plateBId);
+      regime.push(kind);
+      polarity.push(pol);
+      compression.push(c);
+      extension.push(e);
+      shear.push(s);
+      volcanism.push(v);
+      fracture.push(f);
+      driftU.push(drift.u);
+      driftV.push(drift.v);
+    }
+  }
+
+  const segmentCount = aCell.length;
+
+  return {
+    segmentCount,
+    aCell: Int32Array.from(aCell),
+    bCell: Int32Array.from(bCell),
+    plateA: Int16Array.from(plateA),
+    plateB: Int16Array.from(plateB),
+    regime: Uint8Array.from(regime),
+    polarity: Int8Array.from(polarity),
+    compression: Uint8Array.from(compression),
+    extension: Uint8Array.from(extension),
+    shear: Uint8Array.from(shear),
+    volcanism: Uint8Array.from(volcanism),
+    fracture: Uint8Array.from(fracture),
+    driftU: Int8Array.from(driftU),
+    driftV: Int8Array.from(driftV),
+  } as const satisfies FoundationTectonicSegments;
+}

--- a/mods/mod-swooper-maps/src/maps/__type_tests__/createMap-config.inference.ts
+++ b/mods/mod-swooper-maps/src/maps/__type_tests__/createMap-config.inference.ts
@@ -81,8 +81,6 @@ createMap({
       version: 1,
       profiles: {
         resolutionProfile: "balanced",
-        lithosphereProfile: "maximal-basaltic-lid-v1",
-        mantleProfile: "maximal-potential-v1",
       },
       knobs: { plateCount: 28, plateActivity: 0.5 },
       advanced: {

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
@@ -5,8 +5,6 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
     version: 1,
     profiles: {
       resolutionProfile: "fine",
-      lithosphereProfile: "maximal-basaltic-lid-v1",
-      mantleProfile: "maximal-potential-v1",
     },
     knobs: {
       plateCount: 28,

--- a/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
@@ -5,8 +5,6 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
     version: 1,
     profiles: {
       resolutionProfile: "ultra",
-      lithosphereProfile: "maximal-basaltic-lid-v1",
-      mantleProfile: "maximal-potential-v1",
     },
     knobs: {
       plateCount: 32,

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
@@ -5,8 +5,6 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
     version: 1,
     profiles: {
       resolutionProfile: "coarse",
-      lithosphereProfile: "maximal-basaltic-lid-v1",
-      mantleProfile: "maximal-potential-v1",
     },
     knobs: {
       plateCount: 9,

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -3,9 +3,7 @@
   "foundation": {
     "version": 1,
     "profiles": {
-      "resolutionProfile": "balanced",
-      "lithosphereProfile": "maximal-basaltic-lid-v1",
-      "mantleProfile": "maximal-potential-v1"
+      "resolutionProfile": "balanced"
     },
     "knobs": {
       "plateCount": 28,

--- a/mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts
+++ b/mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts
@@ -12,8 +12,6 @@ export const realismEarthlikeConfig: StandardRecipeConfig = {
     version: 1,
     profiles: {
       resolutionProfile: "balanced",
-      lithosphereProfile: "maximal-basaltic-lid-v1",
-      mantleProfile: "maximal-potential-v1",
     },
     knobs: { plateCount: 28, plateActivity: 0.5 },
   },

--- a/mods/mod-swooper-maps/src/maps/presets/realism/old-erosion.config.ts
+++ b/mods/mod-swooper-maps/src/maps/presets/realism/old-erosion.config.ts
@@ -8,8 +8,6 @@ export const realismOldErosionConfig: StandardRecipeConfig = {
     version: 1,
     profiles: {
       resolutionProfile: "balanced",
-      lithosphereProfile: "maximal-basaltic-lid-v1",
-      mantleProfile: "maximal-potential-v1",
     },
     knobs: { plateCount: 28, plateActivity: 0.25 },
   },

--- a/mods/mod-swooper-maps/src/maps/presets/realism/young-tectonics.config.ts
+++ b/mods/mod-swooper-maps/src/maps/presets/realism/young-tectonics.config.ts
@@ -8,8 +8,6 @@ export const realismYoungTectonicsConfig: StandardRecipeConfig = {
     version: 1,
     profiles: {
       resolutionProfile: "balanced",
-      lithosphereProfile: "maximal-basaltic-lid-v1",
-      mantleProfile: "maximal-potential-v1",
     },
     knobs: { plateCount: 28, plateActivity: 0.75 },
   },

--- a/mods/mod-swooper-maps/src/presets/standard/earthlike.json
+++ b/mods/mod-swooper-maps/src/presets/standard/earthlike.json
@@ -8,9 +8,7 @@
     "foundation": {
       "version": 1,
       "profiles": {
-        "resolutionProfile": "balanced",
-        "lithosphereProfile": "maximal-basaltic-lid-v1",
-        "mantleProfile": "maximal-potential-v1"
+        "resolutionProfile": "balanced"
       },
       "knobs": {
         "plateCount": 28,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts
@@ -25,21 +25,9 @@ const FoundationResolutionProfileSchema = Type.Union(
   }
 );
 
-const FoundationLithosphereProfileSchema = Type.Literal("maximal-basaltic-lid-v1", {
-  description: "Lithosphere profile identifier.",
-  default: "maximal-basaltic-lid-v1",
-});
-
-const FoundationMantleProfileSchema = Type.Literal("maximal-potential-v1", {
-  description: "Mantle profile identifier.",
-  default: "maximal-potential-v1",
-});
-
 const profilesSchema = Type.Object(
   {
     resolutionProfile: FoundationResolutionProfileSchema,
-    lithosphereProfile: FoundationLithosphereProfileSchema,
-    mantleProfile: FoundationMantleProfileSchema,
   },
   {
     additionalProperties: false,
@@ -56,11 +44,6 @@ const profilesSchema = Type.Object(
 
 const advancedMantleForcingSchema = Type.Object(
   {
-    potentialMode: Type.Optional(
-      Type.Literal("default", {
-        description: "Mantle potential model selection (currently only \"default\").",
-      })
-    ),
     potentialAmplitude01: Type.Optional(
       Type.Number({
         minimum: 0,
@@ -532,8 +515,6 @@ const FOUNDATION_PROFILE_DEFAULTS: Readonly<
 
 const DEFAULT_PROFILES = {
   resolutionProfile: "balanced",
-  lithosphereProfile: "maximal-basaltic-lid-v1",
-  mantleProfile: "maximal-potential-v1",
 } as const;
 
 const FOUNDATION_STEP_IDS = [

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crustEvolution.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crustEvolution.contract.ts
@@ -14,7 +14,6 @@ const CrustEvolutionStepContract = defineStep({
       foundationArtifacts.crustInit,
       foundationArtifacts.tectonics,
       foundationArtifacts.tectonicHistory,
-      foundationArtifacts.tectonicProvenance,
     ],
     provides: [foundationArtifacts.crust],
   },
@@ -25,4 +24,3 @@ const CrustEvolutionStepContract = defineStep({
 });
 
 export default CrustEvolutionStepContract;
-

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crustEvolution.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crustEvolution.ts
@@ -19,7 +19,6 @@ export default createStep(CrustEvolutionStepContract, {
     const crustInit = deps.artifacts.foundationCrustInit.read(context);
     const tectonics = deps.artifacts.foundationTectonics.read(context);
     const tectonicHistory = deps.artifacts.foundationTectonicHistory.read(context);
-    const tectonicProvenance = deps.artifacts.foundationTectonicProvenance.read(context);
 
     const crustResult = ops.computeCrustEvolution(
       {
@@ -27,7 +26,6 @@ export default createStep(CrustEvolutionStepContract, {
         crustInit,
         tectonics,
         tectonicHistory,
-        tectonicProvenance,
       },
       config.computeCrustEvolution
     );
@@ -105,4 +103,3 @@ export default createStep(CrustEvolutionStepContract, {
     });
   },
 });
-

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/tectonics.ts
@@ -71,7 +71,6 @@ export default createStep(TectonicsStepContract, {
         mantleForcing,
         plateGraph,
         plateMotion,
-        segments: segmentsResult.segments,
       },
       config.computeTectonicHistory
     );

--- a/mods/mod-swooper-maps/test/foundation/contract-guard.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/contract-guard.test.ts
@@ -110,6 +110,37 @@ describe("foundation contract guardrails", () => {
     }
   });
 
+  it("does not reintroduce dead foundation knobs or required-unused inputs", () => {
+    const repoRoot = path.resolve(import.meta.dir, "../..");
+    const roots = [
+      path.join(repoRoot, "src/domain/foundation"),
+      path.join(repoRoot, "src/recipes/standard/stages/foundation"),
+      path.join(repoRoot, "src/maps"),
+    ];
+    const files = roots.flatMap((root) =>
+      listFilesRecursive(root).filter((file) => file.endsWith(".ts") || file.endsWith(".json"))
+    );
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const file of files) {
+      const text = readFileSync(file, "utf8");
+      expect(text).not.toContain("upliftToMaturity");
+      expect(text).not.toContain("ageToMaturity");
+      expect(text).not.toContain("disruptionToMaturity");
+      expect(text).not.toContain("lithosphereProfile");
+      expect(text).not.toContain("mantleProfile");
+      expect(text).not.toContain("potentialMode");
+      expect(text).not.toContain("tangentialSpeed");
+      expect(text).not.toContain("tangentialJitterDeg");
+    }
+
+    const tectonicHistoryContract = readFileSync(
+      path.join(repoRoot, "src/domain/foundation/ops/compute-tectonic-history/contract.ts"),
+      "utf8"
+    );
+    expect(tectonicHistoryContract).not.toContain("segments: FoundationTectonicSegmentsSchema");
+  });
+
   it("publishes maximal foundation artifact ids via contracts", () => {
     expect(foundationArtifacts.mantlePotential.id).toBe(FOUNDATION_MANTLE_POTENTIAL_ARTIFACT_TAG);
     expect(foundationArtifacts.mantleForcing.id).toBe(FOUNDATION_MANTLE_FORCING_ARTIFACT_TAG);

--- a/mods/mod-swooper-maps/test/foundation/m11-polar-plates-policy.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/m11-polar-plates-policy.test.ts
@@ -46,7 +46,7 @@ function isContiguous(mesh: { neighborsOffsets: Int32Array; neighbors: Int32Arra
 }
 
 describe("m11 polar plates policy (caps + optional microplates)", () => {
-  it("always emits north+south cap plates (contiguous, tangential motion baseline)", () => {
+  it("always emits north+south cap plates (contiguous)", () => {
     const width = 90;
     const height = 60;
 
@@ -79,7 +79,6 @@ describe("m11 polar plates policy (caps + optional microplates)", () => {
             ...computePlateGraph.defaultConfig.config.polarCaps,
             capFraction: 0.1,
             microplatesPerPole: 0,
-            tangentialSpeed: 1.0,
           },
         },
       }
@@ -134,8 +133,6 @@ describe("m11 polar plates policy (caps + optional microplates)", () => {
             microplatesPerPole: 2,
             microplatesMinPlateCount: 0,
             microplateMinAreaCells,
-            tangentialSpeed: 1.0,
-            tangentialJitterDeg: 18,
           },
         },
       }

--- a/mods/mod-swooper-maps/test/foundation/m11-projection-boundary-band.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/m11-projection-boundary-band.test.ts
@@ -6,7 +6,6 @@ import computeMantleForcing from "../../src/domain/foundation/ops/compute-mantle
 import computePlateGraph from "../../src/domain/foundation/ops/compute-plate-graph/index.js";
 import computePlateMotion from "../../src/domain/foundation/ops/compute-plate-motion/index.js";
 import computeTectonicHistory from "../../src/domain/foundation/ops/compute-tectonic-history/index.js";
-import computeTectonicSegments from "../../src/domain/foundation/ops/compute-tectonic-segments/index.js";
 import computePlatesTensors from "../../src/domain/foundation/ops/compute-plates-tensors/index.js";
 
 function computeBoundaryTiles(width: number, height: number, plateId: Int16Array): Uint8Array {
@@ -123,13 +122,9 @@ describe("m11 plates projection (boundary band)", () => {
 
     const plateMotion = derivePlateMotion(mesh, plateGraph, 12);
     const mantleForcing = deriveMantleForcing(mesh, 12);
-    const segments = computeTectonicSegments.run(
-      { mesh, crust: crust as any, plateGraph: plateGraph as any, plateMotion: plateMotion as any },
-      computeTectonicSegments.defaultConfig
-    ).segments;
 
     const historyResult = computeTectonicHistory.run(
-      { mesh, crust, mantleForcing, plateGraph, plateMotion, segments },
+      { mesh, crust, mantleForcing, plateGraph, plateMotion },
       {
         strategy: "default",
         config: {

--- a/mods/mod-swooper-maps/test/foundation/m11-tectonic-events.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/m11-tectonic-events.test.ts
@@ -76,35 +76,6 @@ function makeMantleForcing(
   } as const;
 }
 
-function makeSegments(params: {
-  regime: number;
-  polarity: number;
-  compression?: number;
-  extension?: number;
-  shear?: number;
-  volcanism?: number;
-  fracture?: number;
-  driftU?: number;
-  driftV?: number;
-}) {
-  return {
-    segmentCount: 1,
-    aCell: new Int32Array([0]),
-    bCell: new Int32Array([1]),
-    plateA: new Int16Array([0]),
-    plateB: new Int16Array([1]),
-    regime: new Uint8Array([params.regime]),
-    polarity: new Int8Array([params.polarity]),
-    compression: new Uint8Array([params.compression ?? 0]),
-    extension: new Uint8Array([params.extension ?? 0]),
-    shear: new Uint8Array([params.shear ?? 0]),
-    volcanism: new Uint8Array([params.volcanism ?? 0]),
-    fracture: new Uint8Array([params.fracture ?? 0]),
-    driftU: new Int8Array([params.driftU ?? 0]),
-    driftV: new Int8Array([params.driftV ?? 0]),
-  } as const;
-}
-
 describe("m11 tectonic events", () => {
   it("subduction events deterministically update boundary provenance", () => {
     const mesh = makeTwoCellMesh();
@@ -113,20 +84,13 @@ describe("m11 tectonic events", () => {
     const mantleForcing = makeMantleForcing(mesh.cellCount, [1, -1], [1, 1]);
     const plateGraph = makePlateGraph();
     const plateMotion = makePlateMotion(mesh.cellCount, plateGraph.plates.length);
-    const segments = makeSegments({
-      regime: BOUNDARY_TYPE.convergent,
-      polarity: -1,
-      compression: 210,
-      volcanism: 180,
-      fracture: 80,
-    });
 
     const a = computeTectonicHistory.run(
-      { mesh, crust, mantleForcing, plateGraph, plateMotion, segments },
+      { mesh, crust, mantleForcing, plateGraph, plateMotion },
       computeTectonicHistory.defaultConfig
     );
     const b = computeTectonicHistory.run(
-      { mesh, crust, mantleForcing, plateGraph, plateMotion, segments },
+      { mesh, crust, mantleForcing, plateGraph, plateMotion },
       computeTectonicHistory.defaultConfig
     );
 
@@ -145,16 +109,9 @@ describe("m11 tectonic events", () => {
     const mantleForcing = makeMantleForcing(mesh.cellCount, [-1, 1], [1, 1]);
     const plateGraph = makePlateGraph();
     const plateMotion = makePlateMotion(mesh.cellCount, plateGraph.plates.length);
-    const segments = makeSegments({
-      regime: BOUNDARY_TYPE.divergent,
-      polarity: 0,
-      extension: 255,
-      volcanism: 40,
-      fracture: 40,
-    });
 
     const history = computeTectonicHistory.run(
-      { mesh, crust, mantleForcing, plateGraph, plateMotion, segments },
+      { mesh, crust, mantleForcing, plateGraph, plateMotion },
       {
         ...computeTectonicHistory.defaultConfig,
         config: {
@@ -182,22 +139,13 @@ describe("m11 tectonic events", () => {
     const mantleForcing = makeMantleForcing(mesh.cellCount);
     const plateGraph = makePlateGraph();
     const plateMotion = makePlateMotion(mesh.cellCount, plateGraph.plates.length);
-    const segments = makeSegments({
-      regime: BOUNDARY_TYPE.convergent,
-      polarity: -1,
-      compression: 210,
-      volcanism: 180,
-      fracture: 80,
-      driftU: 127,
-      driftV: 0,
-    });
 
     const a = computeTectonicHistory.run(
-      { mesh, crust, mantleForcing, plateGraph, plateMotion, segments },
+      { mesh, crust, mantleForcing, plateGraph, plateMotion },
       computeTectonicHistory.defaultConfig
     );
     const b = computeTectonicHistory.run(
-      { mesh, crust, mantleForcing, plateGraph, plateMotion, segments },
+      { mesh, crust, mantleForcing, plateGraph, plateMotion },
       computeTectonicHistory.defaultConfig
     );
 

--- a/mods/mod-swooper-maps/test/foundation/m11-tectonic-segments-history.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/m11-tectonic-segments-history.test.ts
@@ -273,11 +273,11 @@ describe("m11 tectonics (segments + history)", () => {
 
     const mantleForcing = makeMantleForcing(mesh.cellCount);
     const a = computeTectonicHistory.run(
-      { mesh, crust, mantleForcing, plateGraph, plateMotion, segments },
+      { mesh, crust, mantleForcing, plateGraph, plateMotion },
       computeTectonicHistory.defaultConfig
     );
     const b = computeTectonicHistory.run(
-      { mesh, crust, mantleForcing, plateGraph, plateMotion, segments },
+      { mesh, crust, mantleForcing, plateGraph, plateMotion },
       computeTectonicHistory.defaultConfig
     );
 
@@ -327,7 +327,7 @@ describe("m11 tectonics (segments + history)", () => {
     };
 
     expect(() =>
-      computeTectonicHistory.run({ mesh, crust, mantleForcing, plateGraph, plateMotion, segments }, invalidConfig)
+      computeTectonicHistory.run({ mesh, crust, mantleForcing, plateGraph, plateMotion }, invalidConfig)
     ).toThrow("[Foundation] compute-tectonic-history expects eraCount within 5..8.");
   });
 });

--- a/mods/mod-swooper-maps/test/foundation/mesh-first-ops.test.ts
+++ b/mods/mod-swooper-maps/test/foundation/mesh-first-ops.test.ts
@@ -233,11 +233,11 @@ describe("foundation mesh-first ops (slice 2)", () => {
     expect(Array.from(segA.regime)).toEqual(Array.from(segB.regime));
 
     const histA = computeTectonicHistory.run(
-      { mesh, crust: crustA, mantleForcing, plateGraph: graphA, plateMotion, segments: segA },
+      { mesh, crust: crustA, mantleForcing, plateGraph: graphA, plateMotion },
       computeTectonicHistory.defaultConfig
     );
     const histB = computeTectonicHistory.run(
-      { mesh, crust: crustA, mantleForcing, plateGraph: graphA, plateMotion, segments: segA },
+      { mesh, crust: crustA, mantleForcing, plateGraph: graphA, plateMotion },
       computeTectonicHistory.defaultConfig
     );
 
@@ -283,7 +283,7 @@ describe("foundation mesh-first ops (slice 2)", () => {
         computeTectonicSegments.defaultConfig
       ).segments;
       const historyResult = computeTectonicHistory.run(
-        { mesh, crust, mantleForcing, plateGraph, plateMotion, segments },
+        { mesh, crust, mantleForcing, plateGraph, plateMotion },
         computeTectonicHistory.defaultConfig
       );
 
@@ -416,7 +416,7 @@ describe("foundation mesh-first ops (slice 2)", () => {
       computeTectonicSegments.defaultConfig
     ).segments;
     const historyResult = computeTectonicHistory.run(
-      { mesh, crust, mantleForcing, plateGraph, plateMotion, segments },
+      { mesh, crust, mantleForcing, plateGraph, plateMotion },
       computeTectonicHistory.defaultConfig
     );
     const projection = computePlatesTensors.run(

--- a/mods/mod-swooper-maps/test/hydrology-knobs.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology-knobs.test.ts
@@ -12,8 +12,6 @@ const foundationConfig = {
   version: 1,
   profiles: {
     resolutionProfile: "balanced",
-    lithosphereProfile: "maximal-basaltic-lid-v1",
-    mantleProfile: "maximal-potential-v1",
   },
   knobs: { plateCount: 28, plateActivity: 0.5 },
 };

--- a/mods/mod-swooper-maps/test/m11-config-knobs-and-presets.test.ts
+++ b/mods/mod-swooper-maps/test/m11-config-knobs-and-presets.test.ts
@@ -37,8 +37,6 @@ const foundationBaseConfig = {
   version: 1,
   profiles: {
     resolutionProfile: "balanced",
-    lithosphereProfile: "maximal-basaltic-lid-v1",
-    mantleProfile: "maximal-potential-v1",
   },
   knobs: { plateCount: 28, plateActivity: 0.5 },
 };

--- a/mods/mod-swooper-maps/test/morphology/m11-crust-baseline-consumption.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m11-crust-baseline-consumption.test.ts
@@ -8,7 +8,6 @@ import computePlateGraph from "../../src/domain/foundation/ops/compute-plate-gra
 import computePlateMotion from "../../src/domain/foundation/ops/compute-plate-motion/index.js";
 import computePlatesTensors from "../../src/domain/foundation/ops/compute-plates-tensors/index.js";
 import computeTectonicHistory from "../../src/domain/foundation/ops/compute-tectonic-history/index.js";
-import computeTectonicSegments from "../../src/domain/foundation/ops/compute-tectonic-segments/index.js";
 import computeBaseTopography from "../../src/domain/morphology/ops/compute-base-topography/index.js";
 
 function quantile(sorted: number[], q: number): number {
@@ -52,12 +51,8 @@ describe("m11 morphology baseline consumes crust isostasy prior", () => {
       { strategy: "default", config: { plateCount: 16, referenceArea: 2400, plateScalePower: 0 } }
     ).plateGraph;
     const plateMotion = derivePlateMotion(mesh, plateGraph, 13);
-    const segments = computeTectonicSegments.run(
-      { mesh, crust, plateGraph, plateMotion },
-      computeTectonicSegments.defaultConfig
-    ).segments;
     const historyResult = computeTectonicHistory.run(
-      { mesh, crust, mantleForcing, plateGraph, plateMotion, segments },
+      { mesh, crust, mantleForcing, plateGraph, plateMotion },
       computeTectonicHistory.defaultConfig
     );
     const tectonicHistory = historyResult.tectonicHistory;

--- a/mods/mod-swooper-maps/test/morphology/m11-hypsometry-continental-fraction.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m11-hypsometry-continental-fraction.test.ts
@@ -6,7 +6,6 @@ import computeMantlePotential from "../../src/domain/foundation/ops/compute-mant
 import computeMantleForcing from "../../src/domain/foundation/ops/compute-mantle-forcing/index.js";
 import computePlateGraph from "../../src/domain/foundation/ops/compute-plate-graph/index.js";
 import computePlateMotion from "../../src/domain/foundation/ops/compute-plate-motion/index.js";
-import computeTectonicSegments from "../../src/domain/foundation/ops/compute-tectonic-segments/index.js";
 import computeTectonicHistory from "../../src/domain/foundation/ops/compute-tectonic-history/index.js";
 import computePlatesTensors from "../../src/domain/foundation/ops/compute-plates-tensors/index.js";
 
@@ -56,13 +55,9 @@ describe("m11 hypsometry: continentalFraction does not collapse water coverage",
     const plateGraph = computePlateGraph.run({ mesh, crust, rngSeed: 3 }, plateGraphConfig).plateGraph;
 
     const plateMotion = derivePlateMotion(mesh, plateGraph, 4);
-    const segments = computeTectonicSegments.run(
-      { mesh, crust, plateGraph, plateMotion },
-      computeTectonicSegments.defaultConfig
-    ).segments;
 
     const history = computeTectonicHistory.run(
-      { mesh, crust, mantleForcing, plateGraph, plateMotion, segments },
+      { mesh, crust, mantleForcing, plateGraph, plateMotion },
       {
         ...computeTectonicHistory.defaultConfig,
         config: {

--- a/mods/mod-swooper-maps/test/morphology/m12-mountains-present.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/m12-mountains-present.test.ts
@@ -6,7 +6,6 @@ import computeMantlePotential from "../../src/domain/foundation/ops/compute-mant
 import computeMantleForcing from "../../src/domain/foundation/ops/compute-mantle-forcing/index.js";
 import computePlateGraph from "../../src/domain/foundation/ops/compute-plate-graph/index.js";
 import computePlateMotion from "../../src/domain/foundation/ops/compute-plate-motion/index.js";
-import computeTectonicSegments from "../../src/domain/foundation/ops/compute-tectonic-segments/index.js";
 import computeTectonicHistory from "../../src/domain/foundation/ops/compute-tectonic-history/index.js";
 import computePlatesTensors from "../../src/domain/foundation/ops/compute-plates-tensors/index.js";
 
@@ -52,13 +51,9 @@ describe("m12 mountains: ridge planning produces some non-volcano mountains", ()
     const plateGraph = computePlateGraph.run({ mesh, crust, rngSeed: 3 }, plateGraphConfig).plateGraph;
 
     const plateMotion = derivePlateMotion(mesh, plateGraph, 4);
-    const segments = computeTectonicSegments.run(
-      { mesh, crust, plateGraph, plateMotion },
-      computeTectonicSegments.defaultConfig
-    ).segments;
 
     const history = computeTectonicHistory.run(
-      { mesh, crust, mantleForcing, plateGraph, plateMotion, segments },
+      { mesh, crust, mantleForcing, plateGraph, plateMotion },
       {
         ...computeTectonicHistory.defaultConfig,
         config: {

--- a/mods/mod-swooper-maps/test/standard-compile-errors.test.ts
+++ b/mods/mod-swooper-maps/test/standard-compile-errors.test.ts
@@ -19,8 +19,6 @@ const foundationConfig = {
   version: 1,
   profiles: {
     resolutionProfile: "balanced",
-    lithosphereProfile: "maximal-basaltic-lid-v1",
-    mantleProfile: "maximal-potential-v1",
   },
   knobs: { plateCount: 28, plateActivity: 0.5 },
 };

--- a/mods/mod-swooper-maps/test/standard-recipe.test.ts
+++ b/mods/mod-swooper-maps/test/standard-recipe.test.ts
@@ -14,8 +14,6 @@ const baseConfig = {
     version: 1,
     profiles: {
       resolutionProfile: "balanced",
-      lithosphereProfile: "maximal-basaltic-lid-v1",
-      mantleProfile: "maximal-potential-v1",
     },
     knobs: { plateCount: 28, plateActivity: 0.5 },
   },

--- a/mods/mod-swooper-maps/test/support/standard-config.ts
+++ b/mods/mod-swooper-maps/test/support/standard-config.ts
@@ -79,8 +79,6 @@ const foundationConfig = {
   version: 1,
   profiles: {
     resolutionProfile: "balanced",
-    lithosphereProfile: "maximal-basaltic-lid-v1",
-    mantleProfile: "maximal-potential-v1",
   },
   knobs: { plateCount: 23, plateActivity: 0.5 },
 };


### PR DESCRIPTION
# Foundation Contract Cleanup: Remove Dead Knobs and Enforce Op Boundaries

Implements M4-001 contract-surface cleanup for foundation: removes inert/unused knobs and required-but-unused inputs, updates stage surfaces/config fixtures/tests, and enforces no peer-op runtime calls in compute-tectonic-history via local deterministic kernels.

Evidence and gate outputs are recorded in docs/projects/pipeline-realism/scratch/foundation-domain-axe-execution/agent-A-core-spine.md.