### PR TITLE
docs(mapgen): close authority-routing slice and update normalization entrypoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ See `docs/process/GRAPHITE.md` and `docs/process/LINEAR.md` for full conventions
 ## Domain Routers
 
 - MapGen / Swooper Maps mod: `mods/mod-swooper-maps/AGENTS.md`, `docs/system/mods/swooper-maps/`, `docs/system/libs/mapgen/`.
+- MapGen / Swooper Maps architecture normalization: `docs/projects/engine-refactor-v1/architecture-normalization-packet.md` is the active project baseline; `openspec/changes/README.md` owns the downstream change train.
 - CLI & plugins: `packages/cli/AGENTS.md`, `packages/plugins/*/AGENTS.md`, `docs/system/cli/`.
 - SDK: `packages/sdk/AGENTS.md`, `docs/system/sdk/`.
 

--- a/docs/system/libs/mapgen/MAPGEN.md
+++ b/docs/system/libs/mapgen/MAPGEN.md
@@ -48,6 +48,13 @@ Each section routes to implemented pages and is the authoritative entrypoint for
 
 This doc spine is target-architecture-first (engine-refactor-v1), while remaining correct by making current drift explicit when needed.
 
+Active normalization work enters through
+`docs/projects/engine-refactor-v1/architecture-normalization-packet.md`.
+The packet supersedes older review, comparison, and debate artifacts for the
+MapGen / Swooper Maps normalization workstream. OpenSpec changes under
+`openspec/changes/` are downstream implementation slices, not competing
+architecture authority.
+
 Hard rules:
 - Do not guess contracts. If a claim can’t be anchored to code/spec, treat it as an open question.
 - Prefer published package entrypoints in docs/examples; avoid workspace-only aliases like `@mapgen/*`.

--- a/docs/system/libs/mapgen/explanation/ARCHITECTURE.md
+++ b/docs/system/libs/mapgen/explanation/ARCHITECTURE.md
@@ -17,6 +17,13 @@ This is an explanation page; it does not redefine contracts. When you need “wh
 - [`docs/system/libs/mapgen/policies/POLICIES.md`](/system/libs/mapgen/policies/POLICIES.md)
 - [`docs/system/libs/mapgen/reference/REFERENCE.md`](/system/libs/mapgen/reference/REFERENCE.md)
 
+Normalization note: for active MapGen / Swooper Maps architecture
+normalization, `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`
+owns the current D1-D5 and 0e decisions. Any older text on this page that
+mentions a persisted `advanced` stage-config surface, stale stage ids, or
+projection/truth ownership is implementation-drift context until the relevant
+OpenSpec slice updates the evergreen docs.
+
 ## System model (what MapGen is)
 
 MapGen is a deterministic pipeline system that produces:
@@ -41,7 +48,7 @@ Think of MapGen as these layers:
      - and implement `run()` (plus optional `normalize()`).
 3) **Stages**
    - author-facing grouping and config surface:
-     - knobs (semantic tuning) + advanced (deep overrides),
+     - knobs and stage/step config surfaces,
      - compile “surface config” → per-step config inputs.
 4) **Recipe**
    - composes stages/steps into a canonical pipeline for a given output posture (e.g. “standard”).

--- a/docs/system/libs/mapgen/reference/STANDARD-RECIPE.md
+++ b/docs/system/libs/mapgen/reference/STANDARD-RECIPE.md
@@ -17,6 +17,23 @@ Define the canonical “standard recipe” contract as a reference point for:
 - domain boundaries,
 - and Studio’s default end-to-end run.
 
+## Normalization status
+
+Active MapGen / Swooper Maps normalization work is governed by
+`docs/projects/engine-refactor-v1/architecture-normalization-packet.md`.
+This reference records the current standard recipe surface, but parts of it are
+known to be transitional during the OpenSpec change train:
+
+- Config posture is being normalized to the packet's flat default stage surface
+  `{ knobs?, [stepId]?: stepConfig }`; persisted SDK-native `advanced` wrappers
+  are not the target shape.
+- Ecology, placement, lake projection, import boundaries, and guardrails are
+  updated by their respective `openspec/changes/normalize-*` slices.
+
+When this page conflicts with the normalization packet during that workstream,
+follow the packet and the controlling OpenSpec slice, then update this page in
+the topic slice that changes the underlying source.
+
 ## Scope + ownership
 
 The standard recipe is **content-owned** (not SDK-owned):
@@ -63,7 +80,9 @@ The standard recipe publishes:
 Config is stage-scoped and must be strict (`additionalProperties: false`).
 
 Stage-level posture:
-- “advanced” baseline configs exist for some stages, with knobs applied last as deterministic transforms.
+- Some current stages still expose transitional config wrappers. The
+  normalization target is the flat default stage surface named above; topic
+  slices are responsible for updating this reference when source contracts move.
 
 ## Domains + ops registry
 

--- a/mods/mod-swooper-maps/AGENTS.md
+++ b/mods/mod-swooper-maps/AGENTS.md
@@ -24,6 +24,7 @@ Scope: `mods/mod-swooper-maps/**`
 
 ## Canonical Docs
 
-- Mod architecture & presets: `docs/system/mods/swooper-maps/architecture.md`
-- MapGen engine architecture/config: `docs/system/libs/mapgen/architecture.md`
+- MapGen / Swooper Maps normalization baseline: `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`; downstream implementation slices: `openspec/changes/README.md`.
+- Mod architecture & presets: `docs/system/mods/swooper-maps/`
+- MapGen engine architecture/config: `docs/system/libs/mapgen/MAPGEN.md`
 - Testing overview: `docs/system/TESTING.md`

--- a/openspec/changes/normalize-authority-routing/implementation.md
+++ b/openspec/changes/normalize-authority-routing/implementation.md
@@ -1,0 +1,131 @@
+# Authority Routing Implementation Record
+
+Date: 2026-05-30
+Branch: `codex/normalize-authority-routing-impl`
+Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-DRA-normalize-authority-routing`
+
+## Scope
+
+This record closes the Domino 0 routing slice for the MapGen / Swooper Maps
+normalization train. It records authority inventory, router updates, downstream
+disposition, and review lanes without changing source behavior.
+
+Controlling authority:
+
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`
+- `openspec/changes/normalize-authority-routing/{proposal.md,design.md,tasks.md}`
+- `openspec/specs/mapgen-normalization-workstreams/spec.md`
+
+## Authority Inventory
+
+Root-level architecture-normalization decision artifacts under
+`docs/projects/engine-refactor-v1/`:
+
+- Active packet: `architecture-normalization-packet.md`
+- Source material only:
+  - `architecture-normalization-sources/architecture-normalization-review.md`
+  - `architecture-normalization-sources/architecture-normalization-review-independent.md`
+  - `architecture-normalization-sources/architecture-normalization-decisions-codex.md`
+  - `architecture-normalization-sources/architecture-normalization-decisions-independent.md`
+  - `architecture-normalization-sources/architecture-normalization-decisions-comparison.md`
+  - `architecture-normalization-sources/architecture-normalization-decision-debate.md`
+
+`architecture-normalization-sources/README.md` already labels the source files
+as provenance and states that they are not active decision authority.
+
+## Router Updates
+
+Patched entrypoints:
+
+- `AGENTS.md`: added the active normalization packet and OpenSpec train under
+  the MapGen / Swooper Maps domain router.
+- `mods/mod-swooper-maps/AGENTS.md`: added the packet and train as the
+  normalization route and corrected stale lowercase MapGen doc paths.
+- `packages/mapgen-core/AGENTS.md`: added the packet and train as the
+  normalization route and corrected stale lowercase MapGen doc paths.
+- `packages/civ7-adapter/AGENTS.md`: routed truth/projection normalization to
+  the packet and stable MapGen policy docs.
+- `docs/system/libs/mapgen/MAPGEN.md`: added the packet as the normalization
+  entrypoint and clarified that OpenSpec is downstream implementation
+  management.
+- `docs/system/libs/mapgen/explanation/ARCHITECTURE.md`: added a normalization
+  note so stale `advanced`/stage/projection language does not compete with the
+  packet.
+- `docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`: added a
+  normalization-status section and moved stale config posture into transitional
+  status language.
+
+## Downstream Disposition
+
+Patch now:
+
+- Authority entrypoints and status labels that could send implementers to stale
+  source material or stale `advanced` posture.
+
+Patch in later topic slices:
+
+- Full standard recipe stage-list reconciliation: `normalize-ecology-topology`,
+  `normalize-morphology-catalog-owners`, `normalize-projection-lakes`,
+  `normalize-placement-contracts`, and `normalize-placement-reconciliation`.
+- Config schema/defaults/Studio/presets migration:
+  `normalize-config-surface`.
+- Import-policy enforcement: `normalize-import-boundaries`.
+- Evergreen promotion and guardrails: `normalize-guardrails-promotion`.
+
+No patch:
+
+- Archived project resources and source-material documents that are explicitly
+  retained as provenance.
+- Generated outputs and lockfiles.
+- Source code, recipe configs, Studio, presets, stage topology, placement,
+  lake projection, or guardrails; those are outside this slice.
+
+## Review Disposition
+
+Architecture lane:
+
+- The packet remains the only active root-level normalization decision
+  artifact. Source materials stay retained but non-normative.
+
+Product/DX lane:
+
+- Implementer entrypoints now route future contributors to the packet and
+  OpenSpec train before package-local docs that still carry transitional
+  language.
+
+Adversarial lane:
+
+- No alternate active decision artifact was found outside the source-material
+  directory.
+- The standard recipe and architecture explanation still contain topic-specific
+  drift. This slice labels the drift and assigns substantive repair to the
+  corresponding implementation slices instead of rewriting behavior claims
+  without source changes.
+
+## Verification
+
+Required gates for closure:
+
+- `find docs/projects/engine-refactor-v1 -maxdepth 2 -type f | rg 'architecture-normalization'`
+- `rg -n "architecture-normalization-(review|decisions|comparison|debate)" docs .agents AGENTS.md openspec -g '!docs/projects/engine-refactor-v1/architecture-normalization-sources/**'`
+- `bun run openspec -- validate normalize-authority-routing --strict`
+- `bun run openspec:validate`
+- `git diff --check`
+
+OpenSpec validation in the dedicated worktree used the primary checkout's
+installed project executables on `PATH` because the fresh worktree does not
+have its own `node_modules/` directory. No dependency install or lockfile edit
+was required.
+
+Results from this worktree:
+
+- Authority inventory found one active packet plus the six source-material
+  files listed above.
+- The source-material reference search outside
+  `architecture-normalization-sources/` returned only the packet's source
+  material list and this implementation record.
+- `PATH="/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/node_modules/.bin:$PATH" bun run openspec -- validate normalize-authority-routing --strict`
+  passed.
+- `PATH="/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/node_modules/.bin:$PATH" bun run openspec:validate`
+  passed with 12 items validated and 0 failures.
+- `git diff --check` passed.

--- a/openspec/changes/normalize-authority-routing/tasks.md
+++ b/openspec/changes/normalize-authority-routing/tasks.md
@@ -1,24 +1,24 @@
 ## 1. Authority Inventory
 
-- [ ] 1.1 Search project docs for root-level architecture-normalization
+- [x] 1.1 Search project docs for root-level architecture-normalization
   decision artifacts and classify each as active packet or source material.
-- [ ] 1.2 Verify `architecture-normalization-sources/README.md` labels source
+- [x] 1.2 Verify `architecture-normalization-sources/README.md` labels source
   files as provenance, not current authority.
-- [ ] 1.3 Inspect root and relevant subtree `AGENTS.md` routers for stale
+- [x] 1.3 Inspect root and relevant subtree `AGENTS.md` routers for stale
   normalization entrypoints.
-- [ ] 1.4 Audit canonical docs, OpenSpec specs, standard recipe docs, old
+- [x] 1.4 Audit canonical docs, OpenSpec specs, standard recipe docs, old
   stage-name references, and source-doc links with patch/no-patch disposition.
 
 ## 2. Routing Updates
 
-- [ ] 2.1 Patch only routing or source-material labels needed to point future
+- [x] 2.1 Patch only routing or source-material labels needed to point future
   work to the packet and OpenSpec change train.
-- [ ] 2.2 Record any stale canonical docs discovered as downstream work owned
+- [x] 2.2 Record any stale canonical docs discovered as downstream work owned
   by later topic slices.
 
 ## 3. Verification
 
-- [ ] 3.1 Run the authority searches named in the proposal.
-- [ ] 3.2 Run `bun run openspec -- validate normalize-authority-routing --strict`.
-- [ ] 3.3 Run `bun run openspec:validate`.
-- [ ] 3.4 Run `git diff --check`.
+- [x] 3.1 Run the authority searches named in the proposal.
+- [x] 3.2 Run `bun run openspec -- validate normalize-authority-routing --strict`.
+- [x] 3.3 Run `bun run openspec:validate`.
+- [x] 3.4 Run `git diff --check`.

--- a/packages/civ7-adapter/AGENTS.md
+++ b/packages/civ7-adapter/AGENTS.md
@@ -9,4 +9,5 @@ Scope: `packages/civ7-adapter/**`
 Tooling: use this package’s `bun` scripts for build/check (`bun run --cwd packages/civ7-adapter build`, `bun run --cwd packages/civ7-adapter check`).
 
 Docs:
-- `docs/system/libs/mapgen/architecture.md` (adapter boundary)
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md` for MapGen / Swooper Maps truth/projection normalization.
+- `docs/system/libs/mapgen/MAPGEN.md` and `docs/system/libs/mapgen/policies/TRUTH-VS-PROJECTION.md` for adapter-boundary context.

--- a/packages/mapgen-core/AGENTS.md
+++ b/packages/mapgen-core/AGENTS.md
@@ -21,7 +21,7 @@ Scope: `packages/mapgen-core/**`
 
 ## Canonical Docs
 
-- Engine architecture & phases: `docs/system/libs/mapgen/architecture.md`
-- Design notes & invariants: `docs/system/libs/mapgen/design.md`
-- Foundation & climate concepts: `docs/system/libs/mapgen/foundation.md`, `docs/system/libs/mapgen/climate.md`
+- MapGen / Swooper Maps normalization baseline: `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`; downstream implementation slices: `openspec/changes/README.md`.
+- Engine architecture & contracts: `docs/system/libs/mapgen/MAPGEN.md`
+- Design notes & invariants: `docs/system/libs/mapgen/explanation/ARCHITECTURE.md`, `docs/system/libs/mapgen/policies/POLICIES.md`
 - Testing overview: `docs/system/TESTING.md`


### PR DESCRIPTION
Closes the Domino 0 (authority routing) slice of the MapGen / Swooper Maps normalization train.

## What this does

Establishes `docs/projects/engine-refactor-v1/architecture-normalization-packet.md` as the single active root-level decision authority for the MapGen / Swooper Maps normalization workstream, and routes all relevant agent and doc entrypoints to it. `openspec/changes/` is clarified as the downstream implementation change train, not a competing architecture authority.

## Routing changes

- Root `AGENTS.md` and `mods/mod-swooper-maps/AGENTS.md` now list the normalization packet and OpenSpec train as the first stop for normalization work.
- `packages/mapgen-core/AGENTS.md` and `packages/civ7-adapter/AGENTS.md` replace stale lowercase doc paths with correct evergreen paths and add the packet as the normalization baseline.
- `docs/system/libs/mapgen/MAPGEN.md` adds the packet as the normalization entrypoint and clarifies OpenSpec's downstream role.

## Drift labeling

- `docs/system/libs/mapgen/explanation/ARCHITECTURE.md` gains a normalization note so stale `advanced`/stage/projection language is understood as implementation drift, not current authority.
- `docs/system/libs/mapgen/reference/STANDARD-RECIPE.md` gains a normalization-status section marking transitional config posture (persisted `advanced` wrappers) and assigning substantive repair to the corresponding topic slices.

## Scope boundaries

This slice touches only routing and status labels. Source code, recipe configs, stage topology, config schemas, placement, lake projection, import boundaries, and guardrails are explicitly out of scope and assigned to their respective downstream `normalize-*` slices. All verification gates (`openspec validate`, `openspec:validate`, `git diff --check`) passed.