### PR TITLE
refactor(config): replace `advanced` wrapper with flat step-id surface

### DIFF
--- a/apps/mapgen-studio/src/ui/data/defaultConfig.ts
+++ b/apps/mapgen-studio/src/ui/data/defaultConfig.ts
@@ -4,10 +4,10 @@
 // This is the default configuration for the map generation pipeline.
 //
 // Backend Engineers: This structure should match your pipeline schema.
-// Each stage contains knobs (high-level presets) and advanced step configs.
+// Each stage contains knobs plus flat step-id config overrides.
 // ============================================================================
 
-import type { PipelineConfig } from '../types';
+import type { PipelineConfig } from "../types";
 
 export const defaultConfig: PipelineConfig = {
   // ============================================================================
@@ -17,115 +17,109 @@ export const defaultConfig: PipelineConfig = {
   foundation: {
     version: 1,
     profiles: {
-      resolutionProfile: 'balanced',
-      lithosphereProfile: 'maximal-basaltic-lid-v1',
-      mantleProfile: 'maximal-potential-v1'
+      resolutionProfile: "balanced",
+      lithosphereProfile: "maximal-basaltic-lid-v1",
+      mantleProfile: "maximal-potential-v1",
     },
     knobs: {
       plateCount: 28,
-      plateActivity: 0.5
-    }
+      plateActivity: 0.5,
+    },
   },
 
   // ============================================================================
   // Morphology Coasts Stage
   // Landmass formation + coastline shaping
   // ============================================================================
-  'morphology-coasts': {
+  "morphology-coasts": {
     knobs: {
-      seaLevel: 'earthlike',
-      coastRuggedness: 'normal'
+      seaLevel: "earthlike",
+      coastRuggedness: "normal",
     },
-    advanced: {
-      'landmass-plates': {
-        substrate: {
-          strategy: 'default',
-          config: {
-            continentalBaseErodibility: 0.63,
-            oceanicBaseErodibility: 0.53,
-            continentalBaseSediment: 0.19,
-            oceanicBaseSediment: 0.29
-          }
+    "landmass-plates": {
+      substrate: {
+        strategy: "default",
+        config: {
+          continentalBaseErodibility: 0.63,
+          oceanicBaseErodibility: 0.53,
+          continentalBaseSediment: 0.19,
+          oceanicBaseSediment: 0.29,
         },
-        seaLevel: {
-          strategy: 'default',
-          config: {
-            targetWaterPercent: 63,
-            targetScalar: 1,
-            variance: 1.5
-          }
-        }
-      }
-    }
+      },
+      seaLevel: {
+        strategy: "default",
+        config: {
+          targetWaterPercent: 63,
+          targetScalar: 1,
+          variance: 1.5,
+        },
+      },
+    },
   },
 
   // ============================================================================
   // Morphology Routing Stage
   // Drainage routing truth
   // ============================================================================
-  'morphology-routing': {
-    advanced: {
+  "morphology-routing": {
+    routing: {
       routing: {
-        routing: {
-          strategy: 'default',
-          config: {}
-        }
-      }
-    }
+        strategy: "default",
+        config: {},
+      },
+    },
   },
 
   // Morphology Erosion Stage
   // Erosion and geomorphology
   // ============================================================================
-  'morphology-erosion': {
+  "morphology-erosion": {
     knobs: {
-      erosion: 'normal'
+      erosion: "normal",
     },
-    advanced: {
+    geomorphology: {
       geomorphology: {
-        geomorphology: {
-          strategy: 'default',
-          config: {
-            geomorphology: {
-              fluvial: { rate: 0.26, m: 0.5, n: 1 },
-              diffusion: { rate: 0.23, talus: 0.5 },
-              deposition: { rate: 0.11 },
-              eras: 3
-            },
-            worldAge: 'mature'
-          }
-        }
-      }
-    }
+        strategy: "default",
+        config: {
+          geomorphology: {
+            fluvial: { rate: 0.26, m: 0.5, n: 1 },
+            diffusion: { rate: 0.23, talus: 0.5 },
+            deposition: { rate: 0.11 },
+            eras: 3,
+          },
+          worldAge: "mature",
+        },
+      },
+    },
   },
 
   // ============================================================================
   // Morphology Features Stage
   // Islands, volcanism, landmass decomposition
   // ============================================================================
-  'morphology-features': {
+  "morphology-features": {
     knobs: {
-      volcanism: 'normal'
-    }
+      volcanism: "normal",
+    },
   },
 
   // Hydrology & Climate Baseline Stage
   // Climate simulation and water systems
   // ============================================================================
-  'hydrology-climate-baseline': {
+  "hydrology-climate-baseline": {
     knobs: {
-      dryness: 'mix',
-      temperature: 'hot',
-      seasonality: 'high',
-      oceanCoupling: 'earthlike'
+      dryness: "mix",
+      temperature: "hot",
+      seasonality: "high",
+      oceanCoupling: "earthlike",
     },
-    'climate-baseline': {
+    "climate-baseline": {
       seasonality: {
         axialTiltDeg: 29.44,
-        modeCount: 4
+        modeCount: 4,
       },
       computeAtmosphericCirculation: {
-        strategy: 'earthlike',
+        strategy: "earthlike",
         config: {
           maxSpeed: 110,
           zonalStrength: 90,
@@ -136,18 +130,18 @@ export const defaultConfig: PipelineConfig = {
           waveStrength: 45,
           landHeatStrength: 20,
           mountainDeflectStrength: 18,
-          smoothIters: 4
-        }
+          smoothIters: 4,
+        },
       },
       computeOceanGeometry: {
-        strategy: 'default',
+        strategy: "default",
         config: {
           maxCoastDistance: 64,
-          maxCoastVectorDistance: 10
-        }
+          maxCoastVectorDistance: 10,
+        },
       },
       computeOceanSurfaceCurrents: {
-        strategy: 'earthlike',
+        strategy: "earthlike",
         config: {
           maxSpeed: 80,
           windStrength: 0.55,
@@ -155,31 +149,31 @@ export const defaultConfig: PipelineConfig = {
           gyreStrength: 26,
           coastStrength: 32,
           smoothIters: 3,
-          projectionIters: 8
-        }
+          projectionIters: 8,
+        },
       },
       computeOceanThermalState: {
-        strategy: 'default',
+        strategy: "default",
         config: {
           equatorTempC: 28,
           poleTempC: -2,
           advectIters: 28,
           diffusion: 0.18,
           secondaryWeightMin: 0.25,
-          seaIceThresholdC: -1
-        }
+          seaIceThresholdC: -1,
+        },
       },
       transportMoisture: {
-        strategy: 'vector',
+        strategy: "vector",
         config: {
           iterations: 42,
           advection: 0.7,
           retention: 0.93,
-          secondaryWeightMin: 0.2
-        }
+          secondaryWeightMin: 0.2,
+        },
       },
       computePrecipitation: {
-        strategy: 'vector',
+        strategy: "vector",
         config: {
           rainfallScale: 180,
           humidityExponent: 1,
@@ -189,13 +183,13 @@ export const defaultConfig: PipelineConfig = {
             radius: 5,
             perRingBonus: 4,
             lowlandBonus: 2,
-            lowlandElevationMax: 150
+            lowlandElevationMax: 150,
           },
           upliftStrength: 22,
-          convergenceStrength: 16
-        }
-      }
-    }
+          convergenceStrength: 16,
+        },
+      },
+    },
   },
 
   // ============================================================================
@@ -206,17 +200,17 @@ export const defaultConfig: PipelineConfig = {
     knobs: {},
     biomes: {
       classify: {
-        strategy: 'default',
+        strategy: "default",
         config: {
           temperature: {
             equator: 34,
             pole: -22,
-            lapseRate: 7.5
-          }
-        }
-      }
-    }
-  }
+            lapseRate: 7.5,
+          },
+        },
+      },
+    },
+  },
 };
 
 /**

--- a/apps/mapgen-studio/src/ui/types/index.ts
+++ b/apps/mapgen-studio/src/ui/types/index.ts
@@ -11,7 +11,7 @@
 // ============================================================================
 
 /** User's theme preference - 'system' follows OS setting */
-export type ThemePreference = 'system' | 'light' | 'dark';
+export type ThemePreference = "system" | "light" | "dark";
 
 /** Theme tokens for consistent styling across components */
 export interface Theme {
@@ -118,14 +118,14 @@ export interface WorldSettings {
   resources: ResourceMode;
 }
 
-export type WorldMode = 'browser' | 'dump';
+export type WorldMode = "browser" | "dump";
 export type MapSize =
-'MAPSIZE_TINY' |
-'MAPSIZE_SMALL' |
-'MAPSIZE_STANDARD' |
-'MAPSIZE_LARGE' |
-'MAPSIZE_HUGE';
-export type ResourceMode = 'balanced' | 'strategic';
+  | "MAPSIZE_TINY"
+  | "MAPSIZE_SMALL"
+  | "MAPSIZE_STANDARD"
+  | "MAPSIZE_LARGE"
+  | "MAPSIZE_HUGE";
+export type ResourceMode = "balanced" | "strategic";
 
 // ============================================================================
 // Recipe & Preset Types
@@ -158,10 +158,7 @@ export type ConfigPrimitive = string | number | boolean | null;
 /**
  * Recursive config value type - can be primitive, array, or nested object.
  */
-export type ConfigValue =
-ConfigPrimitive |
-ConfigValue[] |
-{[key: string]: ConfigValue;};
+export type ConfigValue = ConfigPrimitive | ConfigValue[] | { [key: string]: ConfigValue };
 
 /**
  * Configuration for a single pipeline step.
@@ -182,14 +179,12 @@ export interface StepConfig {
  *
  * Backend: Stages are executed in order. Each stage can have:
  * - knobs: High-level presets that map to multiple config values
- * - advanced: Detailed step-by-step configuration
+ * - top-level step-id keys: Detailed step-by-step configuration
  */
 export interface StageConfig {
   /** High-level knobs (semantic scalars or enums). */
   knobs?: Record<string, ConfigPrimitive>;
-  /** Advanced step configurations grouped by category */
-  advanced?: Record<string, StepConfig> | Record<string, Record<string, StepConfig>>;
-  /** Additional stage-specific groups */
+  /** Additional stage-specific step-id keys. */
   [key: string]: unknown;
 }
 
@@ -221,7 +216,7 @@ export interface ConfigPatch {
 // ============================================================================
 
 /** Current status of the generation process */
-export type GenerationStatus = 'ready' | 'running' | 'error';
+export type GenerationStatus = "ready" | "running" | "error";
 
 /**
  * Complete state for a generation run.

--- a/apps/mapgen-studio/src/ui/utils/config.ts
+++ b/apps/mapgen-studio/src/ui/utils/config.ts
@@ -13,9 +13,9 @@ import type {
   StageOption,
   StepOption,
   DataTypeOption,
-  StepConfig } from
-'../types';
-import { formatStageName } from './formatting';
+  StepConfig,
+} from "../types";
+import { formatStageName } from "./formatting";
 
 /**
  * Deep clone a configuration object.
@@ -29,10 +29,7 @@ export function cloneConfig<T>(config: T): T {
  * Apply a config patch using shallow copies (efficient immutable update).
  * Only clones objects along the path, not the entire tree.
  */
-export function applyConfigPatch(
-config: PipelineConfig,
-patch: ConfigPatch)
-: PipelineConfig {
+export function applyConfigPatch(config: PipelineConfig, patch: ConfigPatch): PipelineConfig {
   const { path, value } = patch;
 
   if (path.length === 0) {
@@ -65,10 +62,10 @@ patch: ConfigPatch)
  * updateConfigValue(config, ['foundation', 'knobs', 'plateCount'], 28)
  */
 export function updateConfigValue(
-config: PipelineConfig,
-path: string[],
-value: ConfigValue)
-: PipelineConfig {
+  config: PipelineConfig,
+  path: string[],
+  value: ConfigValue
+): PipelineConfig {
   const newConfig = cloneConfig(config);
   let current: Record<string, unknown> = newConfig;
 
@@ -87,10 +84,7 @@ value: ConfigValue)
  * Get a nested value from a config object by path.
  * Returns undefined if path doesn't exist.
  */
-export function getConfigValue(
-config: PipelineConfig,
-path: string[])
-: ConfigValue | undefined {
+export function getConfigValue(config: PipelineConfig, path: string[]): ConfigValue | undefined {
   let current: unknown = config;
 
   for (const key of path) {
@@ -118,25 +112,19 @@ export function configsEqual(a: PipelineConfig, b: PipelineConfig): boolean {
 /**
  * Check if world settings are equal.
  */
-export function worldSettingsEqual(
-a: WorldSettings,
-b: WorldSettings)
-: boolean {
+export function worldSettingsEqual(a: WorldSettings, b: WorldSettings): boolean {
   return (
     a.mode === b.mode &&
     a.mapSize === b.mapSize &&
     a.playerCount === b.playerCount &&
-    a.resources === b.resources);
-
+    a.resources === b.resources
+  );
 }
 
 /**
  * Check if recipe settings are equal.
  */
-export function recipeSettingsEqual(
-a: RecipeSettings,
-b: RecipeSettings)
-: boolean {
+export function recipeSettingsEqual(a: RecipeSettings, b: RecipeSettings): boolean {
   return a.recipe === b.recipe && a.preset === b.preset && a.seed === b.seed;
 }
 
@@ -145,16 +133,16 @@ b: RecipeSettings)
  * Useful for applying presets.
  */
 export function mergeConfigs(
-base: PipelineConfig,
-override: Partial<PipelineConfig>)
-: PipelineConfig {
+  base: PipelineConfig,
+  override: Partial<PipelineConfig>
+): PipelineConfig {
   const result = cloneConfig(base);
 
   for (const [stageName, stageConfig] of Object.entries(override)) {
     if (stageConfig) {
       result[stageName] = {
         ...result[stageName],
-        ...stageConfig
+        ...stageConfig,
       };
     }
   }
@@ -174,7 +162,7 @@ export function deriveStagesFromConfig(config: PipelineConfig): StageOption[] {
   return Object.keys(config).map((stage, index) => ({
     value: stage,
     label: formatStageName(stage),
-    index
+    index,
   }));
 }
 
@@ -182,28 +170,18 @@ export function deriveStagesFromConfig(config: PipelineConfig): StageOption[] {
  * Derive step options from a specific stage in the config.
  * Use this to populate step selectors in controlled components.
  */
-export function deriveStepsFromStage(
-config: PipelineConfig,
-stageName: string)
-: StepOption[] {
-  const stageConfig = config[stageName] as
-  {advanced?: Record<string, Record<string, StepConfig>>;} |
-  undefined;
+export function deriveStepsFromStage(config: PipelineConfig, stageName: string): StepOption[] {
+  const stageConfig = config[stageName] as Record<string, StepConfig | unknown> | undefined;
 
-  if (!stageConfig?.advanced) return [];
+  if (!stageConfig) return [];
 
-  const steps: StepOption[] = [];
-  Object.entries(stageConfig.advanced).forEach(([category, stepsMap]) => {
-    Object.keys(stepsMap).forEach((stepName) => {
-      steps.push({
-        value: stepName,
-        label: stepName,
-        category
-      });
-    });
-  });
-
-  return steps;
+  return Object.keys(stageConfig)
+    .filter((key) => key !== "knobs")
+    .map((stepName) => ({
+      value: stepName,
+      label: stepName,
+      category: stageName,
+    }));
 }
 
 /**
@@ -211,10 +189,10 @@ stageName: string)
  * Returns only data types that match the step's category.
  */
 export function filterDataTypesForStep(
-allDataTypes: readonly DataTypeOption[],
-steps: StepOption[],
-selectedStep: string)
-: DataTypeOption[] {
+  allDataTypes: readonly DataTypeOption[],
+  steps: StepOption[],
+  selectedStep: string
+): DataTypeOption[] {
   const currentStepObj = steps.find((s) => s.value === selectedStep);
   const category = currentStepObj?.category;
 

--- a/docs/system/libs/mapgen/explanation/PIPELINE-MODEL.md
+++ b/docs/system/libs/mapgen/explanation/PIPELINE-MODEL.md
@@ -14,6 +14,7 @@
 Provide a high-signal mental model for how a MapGen pipeline run works end-to-end.
 
 For contractual details, route to:
+
 - [`docs/system/libs/mapgen/reference/REFERENCE.md`](/system/libs/mapgen/reference/REFERENCE.md)
 
 ## Mental model
@@ -28,13 +29,13 @@ A pipeline run is:
 
 ## Lifecycle (compile → plan → run)
 
-1) **Author config** (knobs + advanced overrides)
-2) **Compile config**:
+1. **Author config** (knobs + flat step-id overrides)
+2. **Compile config**:
    - strict validation against stage and step schemas
    - deterministic normalization (shape-preserving)
-3) **Compile plan**:
+3. **Compile plan**:
    - recipe ordering becomes a list of execution nodes (step id + config)
-4) **Run**:
+4. **Run**:
    - executor iterates nodes in order
    - requires/provides validated via tag registry
    - step executes and publishes artifacts / mutates buffers
@@ -51,6 +52,7 @@ The system uses tags to prevent “accidental ordering”: if a step’s prerequ
 ## Observability (trace + viz)
 
 Trace provides:
+
 - run-level start/finish,
 - step-level start/finish,
 - optional verbose step events (structured debug).

--- a/docs/system/libs/mapgen/how-to/tune-realism-knobs.md
+++ b/docs/system/libs/mapgen/how-to/tune-realism-knobs.md
@@ -1,7 +1,7 @@
 <toc>
   <item id="purpose" title="Purpose"/>
   <item id="audience" title="Audience"/>
-  <item id="mental-model" title="Mental model (knobs vs advanced)"/>
+  <item id="mental-model" title="Mental model (knobs vs step config)"/>
   <item id="checklist" title="Checklist"/>
   <item id="verification" title="Verification"/>
   <item id="anchors" title="Ground truth anchors"/>
@@ -16,6 +16,7 @@ Tune the “realism” posture of the standard recipe by changing **stage knobs*
 This is the intended **author surface** for “make the world more X” tuning.
 
 Routes to:
+
 - Recipe schema: [`docs/system/libs/mapgen/reference/RECIPE-SCHEMA.md`](/system/libs/mapgen/reference/RECIPE-SCHEMA.md)
 - Config compilation: [`docs/system/libs/mapgen/reference/CONFIG-COMPILATION.md`](/system/libs/mapgen/reference/CONFIG-COMPILATION.md)
 - Standard recipe reference: [`docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`](/system/libs/mapgen/reference/STANDARD-RECIPE.md)
@@ -25,32 +26,35 @@ Routes to:
 - Authors who want to tune outcomes without extending SDK internals.
 - Developers who need to keep knobs stable while changing implementations.
 
-## Mental model (knobs vs advanced)
+## Mental model (knobs vs step config)
 
 Each stage has a surface schema shaped like:
 
 - `knobs`: small semantic enums (author-friendly)
-- `advanced`: deep per-step config overrides (expert-only)
+- top-level step IDs: deep per-step config overrides (expert-only)
 
 Contract (stage-level posture):
-- `advanced` is the baseline (schema-defaulted + authored overrides).
+
+- Step config is the baseline (schema-defaulted + authored overrides).
 - `knobs` apply **last**, as deterministic transforms over that baseline.
-Foundation additionally exposes `profiles` in its public schema; profiles select the baseline defaults that `knobs` then refine.
+  Foundation additionally exposes `profiles` in its public schema; profiles select the baseline defaults that `knobs` then refine.
 
 ## Checklist
 
 ### 1) Start from an existing realism preset (recommended)
 
 Pick a preset config file and use it as your starting point:
+
 - `mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts`
 - `mods/mod-swooper-maps/src/maps/presets/realism/young-tectonics.config.ts`
 - `mods/mod-swooper-maps/src/maps/presets/realism/old-erosion.config.ts`
 
-### 2) Edit stage knob values (not advanced step config)
+### 2) Edit stage knob values (not step config)
 
 In your config object, change only stage `knobs` values (unless you have a specific reason to go deeper).
 
 Examples of common “realism” knob sets (see anchors for exact ranges and mapping):
+
 - `foundation.knobs.plateCount`: integer baseline (e.g., `20`–`36`)
 - `foundation.knobs.plateActivity`: scalar `0..1` (e.g., `0.25` calmer, `0.5` baseline, `0.75` more active)
 - `morphology-coasts.knobs.seaLevel`: `low | earthlike | high`
@@ -63,9 +67,11 @@ Examples of common “realism” knob sets (see anchors for exact ranges and map
 ### 3) Run in Studio to validate quickly
 
 Use Studio as the canonical “author feedback loop”:
+
 - `bun run dev:mapgen-studio`
 
 Then:
+
 - select `mod-swooper-maps/standard`,
 - apply your knob changes through the config UI (or by routing your preset into Studio in a future feature slice),
 - run with a fixed seed,
@@ -80,7 +86,7 @@ Then:
 ## Ground truth anchors
 
 - Preset configs (author surface): `mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts`
-- Foundation stage surface schema (knobs vs advanced, “knobs apply last” statement): `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts`
+- Foundation stage surface schema (knobs plus step-id overrides, “knobs apply last” statement): `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts`
 - Morphology erosion knob application (normalize-time multiplier): `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/steps/geomorphology.ts`
 - Morphology erosion knob multipliers: `mods/mod-swooper-maps/src/domain/morphology/shared/knob-multipliers.ts`
 - Studio knob option enums (UI): `apps/mapgen-studio/src/ui/constants/options.ts`

--- a/docs/system/libs/mapgen/reference/STANDARD-RECIPE.md
+++ b/docs/system/libs/mapgen/reference/STANDARD-RECIPE.md
@@ -13,6 +13,7 @@
 ## Purpose
 
 Define the canonical “standard recipe” contract as a reference point for:
+
 - pipeline composition,
 - domain boundaries,
 - and Studio’s default end-to-end run.
@@ -24,9 +25,9 @@ Active MapGen / Swooper Maps normalization work is governed by
 This reference records the current standard recipe surface, but parts of it are
 known to be transitional during the OpenSpec change train:
 
-- Config posture is being normalized to the packet's flat default stage surface
+- Config posture uses the packet's flat default stage surface
   `{ knobs?, [stepId]?: stepConfig }`; persisted SDK-native `advanced` wrappers
-  are not the target shape.
+  are rejected.
 - Ecology, placement, lake projection, import boundaries, and guardrails are
   updated by their respective `openspec/changes/normalize-*` slices.
 
@@ -52,23 +53,24 @@ The standard recipe is **content-owned** (not SDK-owned):
 
 The current stage order is:
 
-1) `foundation`
-2) `morphology-coasts`
-3) `morphology-routing`
-4) `morphology-erosion`
-5) `morphology-features`
-6) `hydrology-climate-baseline`
-7) `hydrology-hydrography`
-8) `hydrology-climate-refine`
-9) `ecology`
-10) `map-morphology`
-11) `map-hydrology`
-12) `map-ecology`
-13) `placement`
+1. `foundation`
+2. `morphology-coasts`
+3. `morphology-routing`
+4. `morphology-erosion`
+5. `morphology-features`
+6. `hydrology-climate-baseline`
+7. `hydrology-hydrography`
+8. `hydrology-climate-refine`
+9. `ecology`
+10. `map-morphology`
+11. `map-hydrology`
+12. `map-ecology`
+13. `placement`
 
 Note:
-- “foundation/morphology-*/hydrology/ecology” stages are primarily **truth** producers.
-- “map-*” and “placement” stages are primarily **projection** / engine-facing surfaces.
+
+- “foundation/morphology-\*/hydrology/ecology” stages are primarily **truth** producers.
+- “map-\*” and “placement” stages are primarily **projection** / engine-facing surfaces.
 
 ## Config surface (schema + posture)
 
@@ -80,9 +82,13 @@ The standard recipe publishes:
 Config is stage-scoped and must be strict (`additionalProperties: false`).
 
 Stage-level posture:
-- Some current stages still expose transitional config wrappers. The
-  normalization target is the flat default stage surface named above; topic
-  slices are responsible for updating this reference when source contracts move.
+
+- Wrapper-only `advanced` stage surfaces have been removed. Step overrides live
+  at `<stageId>.<stepId>`.
+- `map-morphology` still uses `public + compile` as a genuine public transform
+  from public keys (`plotCoasts`, `plotContinents`, `mountains`,
+  `plotVolcanoes`, `buildElevation`) to kebab-case step ids. It is not a
+  wrapper-only compatibility surface.
 
 ## Domains + ops registry
 
@@ -97,6 +103,7 @@ The standard recipe collects compile-time domain ops into a single registry:
 This registry is used during config compilation to bind op contracts to implementations by op id.
 
 Domain contract references:
+
 - [`docs/system/libs/mapgen/reference/domains/DOMAINS.md`](/system/libs/mapgen/reference/domains/DOMAINS.md)
 
 ## Ground truth anchors

--- a/docs/system/libs/mapgen/reference/domains/HYDROLOGY.md
+++ b/docs/system/libs/mapgen/reference/domains/HYDROLOGY.md
@@ -15,22 +15,25 @@
 ## Purpose
 
 Hydrology produces climate + water-cycle truth products for downstream consumption:
+
 - baseline climate field (rainfall/humidity),
 - winds + moisture transport state,
 - discharge/hydrography truth snapshots,
 - refined indices (aridity/freeze/etc) and optional cryosphere products,
-and related diagnostics.
+  and related diagnostics.
 
 Hydrology also owns engine-facing projection steps (rivers/lakes) via `map-hydrology`, which are explicitly **projection-only**.
 
 ## Stages (standard recipe)
 
 Truth stages:
+
 - `hydrology-climate-baseline`
 - `hydrology-hydrography`
 - `hydrology-climate-refine`
 
 Projection stage:
+
 - `map-hydrology`
 
 See: [`docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`](/system/libs/mapgen/reference/STANDARD-RECIPE.md).
@@ -38,9 +41,11 @@ See: [`docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`](/system/libs/mapge
 ## Contract (requires/provides)
 
 Hydrology requires:
+
 - Morphology topography truth.
 
 Hydrology provides (truth artifacts):
+
 - `artifact:climateField` (baseline rainfall/humidity)
 - `artifact:hydrology.climateSeasonality` (amplitude surface)
 - `artifact:hydrology.hydrography` (discharge + river class snapshot)
@@ -51,6 +56,7 @@ Hydrology provides (truth artifacts):
 ## Key artifacts
 
 Hydrology artifacts are authored by the standard recipe (content-owned):
+
 - `mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/artifacts.ts`
 - `mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/artifacts.ts`
 - `mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/artifacts.ts`
@@ -58,6 +64,7 @@ Hydrology artifacts are authored by the standard recipe (content-owned):
 ## Ops surface
 
 Hydrology domain ops are bound by step contracts. In the standard recipe, Hydrology uses op contracts such as:
+
 - `computeRadiativeForcing`
 - `computeThermalState`
 - `computeAtmosphericCirculation`
@@ -80,11 +87,12 @@ Author-facing control is primarily via stage knobs (compiled at stage compile ti
 - `hydrology-climate-refine` knobs: `dryness`, `temperature`, `cryosphere`
 - `map-hydrology` knobs: `lakeiness`, `riverDensity` (engine projection only)
 
-Some steps also expose “advanced” config surfaces for explicit overrides (e.g., seasonality posture).
+Some steps also expose flat step config surfaces for explicit overrides (e.g., seasonality posture).
 
 ## Engine projection notes (map-hydrology)
 
 The `map-hydrology` stage:
+
 - is `phase: "gameplay"` (projection-only),
 - consumes Hydrology truth artifacts (hydrography) plus Morphology truth (topography),
 - publishes effect tags like `effect:engine.riversModeled`,
@@ -110,4 +118,3 @@ The `map-hydrology` stage:
 ## Open questions
 
 - `artifact:hydrology._internal.windField` is currently tagged as internal; do we want a stable public wind artifact tag (or should downstream consumers continue to rely on derived outputs only)?
-

--- a/docs/system/libs/mapgen/tutorials/tune-a-preset-and-knobs.md
+++ b/docs/system/libs/mapgen/tutorials/tune-a-preset-and-knobs.md
@@ -13,10 +13,10 @@
 
 Learn the “author workflow” for changing map realism posture safely:
 
-1) start from a known preset config,
-2) adjust only **knobs** first (semantic, stable),
-3) validate quickly in Studio with deterministic runs,
-4) only then reach for advanced step config overrides.
+1. start from a known preset config,
+2. adjust only **knobs** first (semantic, stable),
+3. validate quickly in Studio with deterministic runs,
+4. only then reach for explicit step config overrides.
 
 ## What you’ll learn
 
@@ -38,6 +38,7 @@ Learn the “author workflow” for changing map realism posture safely:
 In Studio today, the pipeline config UI starts from **schema defaults** (not from a curated preset dropdown).
 
 This means “baseline preset” is effectively:
+
 - “whatever defaults the recipe config schema defines” (plus any schema defaulted enums)
 
 If you want a curated baseline that can be shared as code, authors can still write and maintain a “preset config object”
@@ -50,14 +51,23 @@ export const realismEarthlikeConfig = {
   foundation: {
     knobs: { plateCount: 28, plateActivity: 0.5 },
   },
-  "morphology-coasts": { knobs: { seaLevel: "water-heavy", coastRuggedness: "normal", shelfWidth: "narrow" } },
+  "morphology-coasts": {
+    knobs: { seaLevel: "water-heavy", coastRuggedness: "normal", shelfWidth: "narrow" },
+  },
   "morphology-erosion": { knobs: { erosion: "normal" } },
   "morphology-features": { knobs: { volcanism: "normal" } },
   "hydrology-climate-baseline": {
-    knobs: { dryness: "dry", temperature: "temperate", seasonality: "normal", oceanCoupling: "earthlike" },
+    knobs: {
+      dryness: "dry",
+      temperature: "temperate",
+      seasonality: "normal",
+      oceanCoupling: "earthlike",
+    },
   },
   "hydrology-hydrography": { knobs: { riverDensity: "normal" } },
-  "hydrology-climate-refine": { knobs: { dryness: "dry", temperature: "temperate", cryosphere: "on" } },
+  "hydrology-climate-refine": {
+    knobs: { dryness: "dry", temperature: "temperate", cryosphere: "on" },
+  },
   "map-morphology": { knobs: { orogeny: "normal" } },
 };
 ```
@@ -69,11 +79,13 @@ Source: `mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts`
 Pick one knob and change it by one step (avoid multiple simultaneous changes initially).
 
 Example targets:
+
 - more plates → increase `foundation.knobs.plateCount`
 - rougher coasts → increase `morphology-coasts.knobs.coastRuggedness`
 - wetter world → change `hydrology-*.knobs.dryness`
 
 In Studio:
+
 - ensure Mode is `Browser` (live run)
 - in the left panel, open **Config** and keep it switched **On** (overrides enabled)
 - use Form view for enums, or switch to JSON view to paste an entire “preset object”
@@ -81,6 +93,7 @@ In Studio:
 ### 3) Run and compare in Studio (fixed seed)
 
 In Studio:
+
 - select recipe: `mod-swooper-maps/standard`
 - set a fixed seed
 - apply your knob changes (via the config UI)
@@ -88,9 +101,10 @@ In Studio:
 
 Repeat until you’re satisfied with the semantic tuning.
 
-### 4) Escalate to advanced overrides only when necessary
+### 4) Escalate to step overrides only when necessary
 
 If knob tuning can’t express what you need:
+
 - identify the specific step you need to override (in the standard recipe stage you care about),
 - override only that step config subtree (stage-dependent; see below),
 - re-run with the same seed to validate the change.
@@ -104,14 +118,18 @@ export default createStage({
     plateCount: Type.Optional(FoundationPlateCountKnobSchema),
     plateActivity: Type.Optional(FoundationPlateActivityKnobSchema),
   }),
-  steps: [/* per-step contracts */],
+  steps: [
+    /* per-step contracts */
+  ],
 });
 ```
 
 Interpretation:
+
 - `foundation.knobs.*` expresses semantic, stable tuning.
-- Foundation does **not** wrap step overrides under `advanced`; per-step overrides (when required) live directly under `foundation.<stepId>`.
-- Many other stages expose a single `advanced` object specifically for step-level override baselines (e.g. `morphology-coasts.advanced.<stepId>`).
+- Standard recipe stages do **not** wrap step overrides under `advanced`; per-step overrides (when required) live directly under `<stageId>.<stepId>`.
+- Standard recipe stages expose step-level override baselines directly at the
+  stage root (for example, `morphology-coasts.<stepId>`).
 - Knobs apply as deterministic transforms (typically in `normalize`) over the defaulted baseline + any overrides.
 
 ## Verification
@@ -128,8 +146,8 @@ Interpretation:
 - Studio config overrides UI (On/Off + Form/JSON): `apps/mapgen-studio/src/ui/components/RecipePanel.tsx`
 - Stage schema examples:
   - knobs-only (Foundation): `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts`
-  - advanced step overrides (Morphology-coasts): `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/index.ts`
-  - advanced step overrides (Map-hydrology): `mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/index.ts`
+  - flat step overrides (Morphology-coasts): `mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/index.ts`
+  - flat step overrides (Map-hydrology): `mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/index.ts`
 - Example knob application at normalize-time (reads `ctx.knobs`): `mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts`
 - Example knob multiplier tables (Foundation): `mods/mod-swooper-maps/src/domain/foundation/shared/knob-multipliers.ts`
 - Standard recipe config types: `mods/mod-swooper-maps/src/recipes/standard/recipe.ts`

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
@@ -8,7 +8,6 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
     },
   },
   "morphology-coasts": {
-    "advanced": {
     "landmass-plates": {
       substrate: {
         strategy: "default",
@@ -93,20 +92,16 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
         },
       },
     },
-    }
   },
   "morphology-routing": {
-    "advanced": {
     routing: {
       routing: {
         strategy: "default",
         config: {},
       },
     },
-    }
   },
   "morphology-erosion": {
-    "advanced": {
     geomorphology: {
       geomorphology: {
         strategy: "default",
@@ -130,10 +125,8 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
         },
       },
     },
-    }
   },
   "morphology-features": {
-    "advanced": {
     islands: {
       islands: {
         strategy: "default",
@@ -178,7 +171,6 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
         config: {},
       },
     },
-    }
   },
   "map-morphology": {
     mountains: {
@@ -438,7 +430,7 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
             selector: {
               typeName: "PLOTEFFECT_BURNED",
             },
-            coveragePct: 20,       // More volcanic scorched earth
+            coveragePct: 20, // More volcanic scorched earth
           },
         },
       },
@@ -455,4 +447,4 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
     },
     placement: {},
   },
-  };
+};

--- a/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
@@ -8,7 +8,6 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
     },
   },
   "morphology-coasts": {
-    "advanced": {
     "landmass-plates": {
       substrate: {
         strategy: "default",
@@ -95,20 +94,16 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
         },
       },
     },
-    }
   },
   "morphology-routing": {
-    "advanced": {
     routing: {
       routing: {
         strategy: "default",
         config: {},
       },
     },
-    }
   },
   "morphology-erosion": {
-    "advanced": {
     geomorphology: {
       geomorphology: {
         strategy: "default",
@@ -132,10 +127,8 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
         },
       },
     },
-    }
   },
   "morphology-features": {
-    "advanced": {
     islands: {
       islands: {
         strategy: "default",
@@ -180,7 +173,6 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
         config: {},
       },
     },
-    }
   },
   "map-morphology": {
     mountains: {
@@ -422,20 +414,20 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
                 typeName: "PLOTEFFECT_SNOW_HEAVY_PERMANENT",
               },
             },
-            coveragePct: 28,              // Reduced for tropical world
-            lightThreshold: 0.45,         // Higher threshold
+            coveragePct: 28, // Reduced for tropical world
+            lightThreshold: 0.45, // Higher threshold
             mediumThreshold: 0.7,
             heavyThreshold: 0.85,
           },
           sand: {
-            enabled: false,               // Tropical islands don't have desert sand
+            enabled: false, // Tropical islands don't have desert sand
             selector: {
               typeName: "PLOTEFFECT_SAND",
             },
             coveragePct: 5,
           },
           burned: {
-            enabled: false,               // Lush tropical - no scorched earth
+            enabled: false, // Lush tropical - no scorched earth
             selector: {
               typeName: "PLOTEFFECT_BURNED",
             },
@@ -456,4 +448,4 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
     },
     placement: {},
   },
-  };
+};

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
@@ -8,7 +8,6 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
     },
   },
   "morphology-coasts": {
-    "advanced": {
     "landmass-plates": {
       substrate: {
         strategy: "default",
@@ -87,20 +86,16 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
         },
       },
     },
-    }
   },
   "morphology-routing": {
-    "advanced": {
     routing: {
       routing: {
         strategy: "default",
         config: {},
       },
     },
-    }
   },
   "morphology-erosion": {
-    "advanced": {
     geomorphology: {
       geomorphology: {
         strategy: "default",
@@ -124,10 +119,8 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
         },
       },
     },
-    }
   },
   "morphology-features": {
-    "advanced": {
     islands: {
       islands: {
         strategy: "default",
@@ -170,7 +163,6 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
         config: {},
       },
     },
-    }
   },
   "map-morphology": {
     mountains: {
@@ -181,8 +173,8 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
           tectonicIntensity: 0.63,
           mountainThreshold: 0.64,
           hillThreshold: 0.36,
-          upliftWeight: 0.20,
-          fractalWeight: 0.90,
+          upliftWeight: 0.2,
+          fractalWeight: 0.9,
           riftDepth: 0.45,
           boundaryWeight: 0.38,
           boundaryGate: 0.14,
@@ -205,8 +197,8 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
           tectonicIntensity: 0.63,
           mountainThreshold: 0.64,
           hillThreshold: 0.36,
-          upliftWeight: 0.20,
-          fractalWeight: 0.90,
+          upliftWeight: 0.2,
+          fractalWeight: 0.9,
           riftDepth: 0.45,
           boundaryWeight: 0.38,
           boundaryGate: 0.14,
@@ -421,14 +413,14 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
             selector: {
               typeName: "PLOTEFFECT_SAND",
             },
-            coveragePct: 42,       // Aggressive for desert world
+            coveragePct: 42, // Aggressive for desert world
           },
           burned: {
             enabled: true,
             selector: {
               typeName: "PLOTEFFECT_BURNED",
             },
-            coveragePct: 16,       // More scorched earth
+            coveragePct: 16, // More scorched earth
           },
         },
       },
@@ -445,4 +437,4 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
     },
     placement: {},
   },
-  };
+};

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -6,176 +6,164 @@
       "plateActivity": 0.7
     },
     "mesh": {
-        "computeMesh": {
-          "strategy": "default",
-          "config": {
-            "plateCount": 28,
-            "cellsPerPlate": 7,
-            "referenceArea": 6996,
-            "plateScalePower": 0.7,
-            "relaxationSteps": 2
+      "computeMesh": {
+        "strategy": "default",
+        "config": {
+          "plateCount": 28,
+          "cellsPerPlate": 7,
+          "referenceArea": 6996,
+          "plateScalePower": 0.7,
+          "relaxationSteps": 2
+        }
+      }
+    },
+    "mantle-potential": {
+      "computeMantlePotential": {
+        "strategy": "default",
+        "config": {
+          "plumeCount": 10,
+          "downwellingCount": 3,
+          "plumeRadius": 0.28,
+          "downwellingRadius": 0.18,
+          "plumeAmplitude": 1,
+          "downwellingAmplitude": -1,
+          "smoothingIterations": 1,
+          "smoothingAlpha": 0.35,
+          "minSeparationScale": 0.85
+        }
+      }
+    },
+    "mantle-forcing": {
+      "computeMantleForcing": {
+        "strategy": "default",
+        "config": {
+          "velocityScale": 1,
+          "rotationScale": 0.2,
+          "stressNorm": 1,
+          "curvatureWeight": 0.35,
+          "upwellingThreshold": 0.35,
+          "downwellingThreshold": 0.35
+        }
+      }
+    },
+    "crust": {
+      "computeCrust": {
+        "strategy": "default",
+        "config": {
+          "basalticThickness01": 0.25,
+          "yieldStrength01": 0.55,
+          "mantleCoupling01": 0.6,
+          "riftWeakening01": 0.35
+        }
+      }
+    },
+    "plate-graph": {
+      "computePlateGraph": {
+        "strategy": "default",
+        "config": {
+          "plateCount": 8,
+          "referenceArea": 4000,
+          "plateScalePower": 0.5,
+          "polarCaps": {
+            "capFraction": 0.1,
+            "microplateBandFraction": 0.2,
+            "microplatesPerPole": 0,
+            "microplatesMinPlateCount": 14,
+            "microplateMinAreaCells": 8
           }
         }
-      },
-      "mantle-potential": {
-        "computeMantlePotential": {
-          "strategy": "default",
-          "config": {
-            "plumeCount": 10,
-            "downwellingCount": 3,
-            "plumeRadius": 0.28,
-            "downwellingRadius": 0.18,
-            "plumeAmplitude": 1,
-            "downwellingAmplitude": -1,
-            "smoothingIterations": 1,
-            "smoothingAlpha": 0.35,
-            "minSeparationScale": 0.85
-          }
+      }
+    },
+    "plate-motion": {
+      "computePlateMotion": {
+        "strategy": "default",
+        "config": {
+          "omegaFactor": 1,
+          "plateRadiusMin": 1,
+          "residualNormScale": 1,
+          "p90NormScale": 1,
+          "histogramBins": 32,
+          "smoothingSteps": 0
+        }
+      }
+    },
+    "tectonics": {
+      "computePlateMotion": {
+        "strategy": "default",
+        "config": {
+          "omegaFactor": 1,
+          "plateRadiusMin": 1,
+          "residualNormScale": 1,
+          "p90NormScale": 1,
+          "histogramBins": 32,
+          "smoothingSteps": 0
         }
       },
-      "mantle-forcing": {
-        "computeMantleForcing": {
-          "strategy": "default",
-          "config": {
-            "velocityScale": 1,
-            "rotationScale": 0.2,
-            "stressNorm": 1,
-            "curvatureWeight": 0.35,
-            "upwellingThreshold": 0.35,
-            "downwellingThreshold": 0.35
-          }
+      "computeTectonicSegments": {
+        "strategy": "default",
+        "config": {
+          "intensityScale": 900,
+          "regimeMinIntensity": 4
         }
       },
-      "crust": {
-        "computeCrust": {
-          "strategy": "default",
-          "config": {
-            "basalticThickness01": 0.25,
-            "yieldStrength01": 0.55,
-            "mantleCoupling01": 0.6,
-            "riftWeakening01": 0.35
-          }
+      "computeEraPlateMembership": {
+        "strategy": "default",
+        "config": {
+          "eraWeights": [0.3, 0.25, 0.2, 0.15, 0.1],
+          "driftStepsByEra": [12, 9, 6, 3, 1]
         }
       },
-      "plate-graph": {
-        "computePlateGraph": {
-          "strategy": "default",
-          "config": {
-            "plateCount": 8,
-            "referenceArea": 4000,
-            "plateScalePower": 0.5,
-            "polarCaps": {
-              "capFraction": 0.1,
-              "microplateBandFraction": 0.2,
-              "microplatesPerPole": 0,
-              "microplatesMinPlateCount": 14,
-              "microplateMinAreaCells": 8
-            }
-          }
+      "computeSegmentEvents": {
+        "strategy": "default",
+        "config": {}
+      },
+      "computeHotspotEvents": {
+        "strategy": "default",
+        "config": {}
+      },
+      "computeEraTectonicFields": {
+        "strategy": "default",
+        "config": {
+          "beltInfluenceDistance": 8,
+          "beltDecay": 0.55
         }
       },
-      "plate-motion": {
-        "computePlateMotion": {
-          "strategy": "default",
-          "config": {
-            "omegaFactor": 1,
-            "plateRadiusMin": 1,
-            "residualNormScale": 1,
-            "p90NormScale": 1,
-            "histogramBins": 32,
-            "smoothingSteps": 0
-          }
+      "computeTectonicHistoryRollups": {
+        "strategy": "default",
+        "config": {
+          "activityThreshold": 1
         }
       },
-      "tectonics": {
-        "computePlateMotion": {
-          "strategy": "default",
-          "config": {
-            "omegaFactor": 1,
-            "plateRadiusMin": 1,
-            "residualNormScale": 1,
-            "p90NormScale": 1,
-            "histogramBins": 32,
-            "smoothingSteps": 0
-          }
-        },
-        "computeTectonicSegments": {
-          "strategy": "default",
-          "config": {
-            "intensityScale": 900,
-            "regimeMinIntensity": 4
-          }
-        },
-        "computeEraPlateMembership": {
-          "strategy": "default",
-          "config": {
-            "eraWeights": [
-              0.3,
-              0.25,
-              0.2,
-              0.15,
-              0.1
-            ],
-            "driftStepsByEra": [
-              12,
-              9,
-              6,
-              3,
-              1
-            ]
-          }
-        },
-        "computeSegmentEvents": {
-          "strategy": "default",
-          "config": {}
-        },
-        "computeHotspotEvents": {
-          "strategy": "default",
-          "config": {}
-        },
-        "computeEraTectonicFields": {
-          "strategy": "default",
-          "config": {
-            "beltInfluenceDistance": 8,
-            "beltDecay": 0.55
-          }
-        },
-        "computeTectonicHistoryRollups": {
-          "strategy": "default",
-          "config": {
-            "activityThreshold": 1
-          }
-        },
-        "computeTectonicsCurrent": {
-          "strategy": "default",
-          "config": {}
-        },
-        "computeTracerAdvection": {
-          "strategy": "default",
-          "config": {}
-        },
-        "computeTectonicProvenance": {
-          "strategy": "default",
-          "config": {}
-        }
+      "computeTectonicsCurrent": {
+        "strategy": "default",
+        "config": {}
       },
-      "crust-evolution": {
-        "computeCrustEvolution": {
-          "strategy": "default",
-          "config": {}
-        }
+      "computeTracerAdvection": {
+        "strategy": "default",
+        "config": {}
       },
-      "projection": {
-        "computePlates": {
-          "strategy": "default",
-          "config": {
-            "boundaryInfluenceDistance": 5,
-            "boundaryDecay": 0.55,
-            "movementScale": 100,
-            "rotationScale": 100
-          }
+      "computeTectonicProvenance": {
+        "strategy": "default",
+        "config": {}
+      }
+    },
+    "crust-evolution": {
+      "computeCrustEvolution": {
+        "strategy": "default",
+        "config": {}
+      }
+    },
+    "projection": {
+      "computePlates": {
+        "strategy": "default",
+        "config": {
+          "boundaryInfluenceDistance": 5,
+          "boundaryDecay": 0.55,
+          "movementScale": 100,
+          "rotationScale": 100
         }
-      },
+      }
+    },
     "plate-topology": {}
   },
   "morphology-coasts": {
@@ -184,123 +172,119 @@
       "coastRuggedness": "normal",
       "shelfWidth": "normal"
     },
-    "advanced": {
-      "landmass-plates": {
-        "beltDrivers": {
-          "strategy": "default",
-          "config": {}
-        },
-        "substrate": {
-          "strategy": "default",
-          "config": {
-            "continentalBaseErodibility": 0.63,
-            "oceanicBaseErodibility": 0.53,
-            "continentalBaseSediment": 0.19,
-            "oceanicBaseSediment": 0.29,
-            "ageErodibilityReduction": 0.25,
-            "ageSedimentBoost": 0.15,
-            "upliftErodibilityBoost": 0.35,
-            "riftSedimentBoost": 0.34,
-            "convergentBoundaryErodibilityBoost": 0.12,
-            "divergentBoundaryErodibilityBoost": 0.18,
-            "transformBoundaryErodibilityBoost": 0.08,
-            "convergentBoundarySedimentBoost": 0.05,
-            "divergentBoundarySedimentBoost": 0.1,
-            "transformBoundarySedimentBoost": 0.03
-          }
-        },
-        "baseTopography": {
-          "strategy": "default",
-          "config": {
-            "boundaryBias": 0.24,
-            "clusteringBias": 0.7,
-            "crustEdgeBlend": 0.6,
-            "crustNoiseAmplitude": 0.36,
-            "continentalHeight": 0.62,
-            "oceanicHeight": -0.75,
-            "tectonics": {
-              "interiorNoiseWeight": 0.5,
-              "boundaryArcWeight": 0.32,
-              "boundaryArcNoiseWeight": 0.26,
-              "fractalGrain": 3
-            }
-          }
-        },
-        "seaLevel": {
-          "strategy": "default",
-          "config": {
-            "targetWaterPercent": 63,
-            "targetScalar": 1,
-            "variance": 1.5,
-            "boundaryShareTarget": 0.005,
-            "continentalFraction": 0.39
-          }
-        },
-        "landmask": {
-          "strategy": "default",
-          "config": {
-            "continentPotentialGrain": 4,
-            "continentPotentialBlurSteps": 4,
-            "keepLandComponentFraction": 0.985,
-            "cratonStepsPerEra": 2,
-            "cratonNucleationScale": 0.9,
-            "cratonDiffusion": 0.25,
-            "cratonAdvection": 0.15,
-            "cratonHalfSaturation": 0.35,
-            "cratonPotentialWeight": 0.12
+    "landmass-plates": {
+      "beltDrivers": {
+        "strategy": "default",
+        "config": {}
+      },
+      "substrate": {
+        "strategy": "default",
+        "config": {
+          "continentalBaseErodibility": 0.63,
+          "oceanicBaseErodibility": 0.53,
+          "continentalBaseSediment": 0.19,
+          "oceanicBaseSediment": 0.29,
+          "ageErodibilityReduction": 0.25,
+          "ageSedimentBoost": 0.15,
+          "upliftErodibilityBoost": 0.35,
+          "riftSedimentBoost": 0.34,
+          "convergentBoundaryErodibilityBoost": 0.12,
+          "divergentBoundaryErodibilityBoost": 0.18,
+          "transformBoundaryErodibilityBoost": 0.08,
+          "convergentBoundarySedimentBoost": 0.05,
+          "divergentBoundarySedimentBoost": 0.1,
+          "transformBoundarySedimentBoost": 0.03
+        }
+      },
+      "baseTopography": {
+        "strategy": "default",
+        "config": {
+          "boundaryBias": 0.24,
+          "clusteringBias": 0.7,
+          "crustEdgeBlend": 0.6,
+          "crustNoiseAmplitude": 0.36,
+          "continentalHeight": 0.62,
+          "oceanicHeight": -0.75,
+          "tectonics": {
+            "interiorNoiseWeight": 0.5,
+            "boundaryArcWeight": 0.32,
+            "boundaryArcNoiseWeight": 0.26,
+            "fractalGrain": 3
           }
         }
       },
-      "rugged-coasts": {
-        "coastlines": {
-          "strategy": "default",
-          "config": {
-            "coast": {
-              "bay": {
-                "noiseGateAdd": 0.05,
-                "rollDenActive": 4,
-                "rollDenDefault": 7
-              },
-              "fjord": {
-                "baseDenom": 15,
-                "activeBonus": 2,
-                "passiveBonus": 1
-              },
-              "plateBias": {
-                "threshold": 0.42,
-                "power": 1.3,
-                "convergent": 1.5,
-                "transform": 0.35,
-                "divergent": -0.45,
-                "interior": 0.35,
-                "bayWeight": 0.9,
-                "bayNoiseBonus": 0.45,
-                "fjordWeight": 0.85
-              }
+      "seaLevel": {
+        "strategy": "default",
+        "config": {
+          "targetWaterPercent": 63,
+          "targetScalar": 1,
+          "variance": 1.5,
+          "boundaryShareTarget": 0.005,
+          "continentalFraction": 0.39
+        }
+      },
+      "landmask": {
+        "strategy": "default",
+        "config": {
+          "continentPotentialGrain": 4,
+          "continentPotentialBlurSteps": 4,
+          "keepLandComponentFraction": 0.985,
+          "cratonStepsPerEra": 2,
+          "cratonNucleationScale": 0.9,
+          "cratonDiffusion": 0.25,
+          "cratonAdvection": 0.15,
+          "cratonHalfSaturation": 0.35,
+          "cratonPotentialWeight": 0.12
+        }
+      }
+    },
+    "rugged-coasts": {
+      "coastlines": {
+        "strategy": "default",
+        "config": {
+          "coast": {
+            "bay": {
+              "noiseGateAdd": 0.05,
+              "rollDenActive": 4,
+              "rollDenDefault": 7
+            },
+            "fjord": {
+              "baseDenom": 15,
+              "activeBonus": 2,
+              "passiveBonus": 1
+            },
+            "plateBias": {
+              "threshold": 0.42,
+              "power": 1.3,
+              "convergent": 1.5,
+              "transform": 0.35,
+              "divergent": -0.45,
+              "interior": 0.35,
+              "bayWeight": 0.9,
+              "bayNoiseBonus": 0.45,
+              "fjordWeight": 0.85
             }
           }
-        },
-        "shelfMask": {
-          "strategy": "default",
-          "config": {
-            "nearshoreDistance": 3,
-            "shallowQuantile": 0.7,
-            "activeClosenessThreshold": 0.45,
-            "capTilesActive": 2,
-            "capTilesPassive": 4,
-            "capTilesMax": 8
-          }
+        }
+      },
+      "shelfMask": {
+        "strategy": "default",
+        "config": {
+          "nearshoreDistance": 3,
+          "shallowQuantile": 0.7,
+          "activeClosenessThreshold": 0.45,
+          "capTilesActive": 2,
+          "capTilesPassive": 4,
+          "capTilesMax": 8
         }
       }
     }
   },
   "morphology-routing": {
-    "advanced": {
+    "routing": {
       "routing": {
-        "routing": {
-          "strategy": "default",
-          "config": {}
-        }
+        "strategy": "default",
+        "config": {}
       }
     },
     "knobs": {}
@@ -309,28 +293,26 @@
     "knobs": {
       "erosion": "normal"
     },
-    "advanced": {
+    "geomorphology": {
       "geomorphology": {
-        "geomorphology": {
-          "strategy": "default",
-          "config": {
-            "geomorphology": {
-              "fluvial": {
-                "rate": 0.26,
-                "m": 0.5,
-                "n": 1
-              },
-              "diffusion": {
-                "rate": 0.23,
-                "talus": 0.5
-              },
-              "deposition": {
-                "rate": 0.11
-              },
-              "eras": 3
+        "strategy": "default",
+        "config": {
+          "geomorphology": {
+            "fluvial": {
+              "rate": 0.26,
+              "m": 0.5,
+              "n": 1
             },
-            "worldAge": "mature"
-          }
+            "diffusion": {
+              "rate": 0.23,
+              "talus": 0.5
+            },
+            "deposition": {
+              "rate": 0.11
+            },
+            "eras": 3
+          },
+          "worldAge": "mature"
         }
       }
     }
@@ -339,48 +321,46 @@
     "knobs": {
       "volcanism": "normal"
     },
-    "advanced": {
+    "islands": {
       "islands": {
-        "islands": {
-          "strategy": "default",
-          "config": {
-            "islands": {
-              "fractalThresholdPercent": 96,
-              "minDistFromLandRadius": 5,
-              "baseIslandDenNearActive": 2,
-              "baseIslandDenElse": 2,
-              "hotspotSeedDenom": 3,
-              "clusterMax": 12,
-              "microcontinentChance": 0.12
-            }
+        "strategy": "default",
+        "config": {
+          "islands": {
+            "fractalThresholdPercent": 96,
+            "minDistFromLandRadius": 5,
+            "baseIslandDenNearActive": 2,
+            "baseIslandDenElse": 2,
+            "hotspotSeedDenom": 3,
+            "clusterMax": 12,
+            "microcontinentChance": 0.12
           }
         }
-      },
+      }
+    },
+    "volcanoes": {
       "volcanoes": {
-        "volcanoes": {
-          "strategy": "default",
-          "config": {
-            "enabled": true,
-            "baseDensity": 0.00625,
-            "minSpacing": 6,
-            "boundaryThreshold": 0.32,
-            "boundaryWeight": 1.35,
-            "convergentMultiplier": 3.3,
-            "transformMultiplier": 0.8,
-            "divergentMultiplier": 0.32,
-            "hotspotWeight": 0.32,
-            "shieldPenalty": 0.55,
-            "randomJitter": 0.04,
-            "minVolcanoes": 12,
-            "maxVolcanoes": 42
-          }
+        "strategy": "default",
+        "config": {
+          "enabled": true,
+          "baseDensity": 0.00625,
+          "minSpacing": 6,
+          "boundaryThreshold": 0.32,
+          "boundaryWeight": 1.35,
+          "convergentMultiplier": 3.3,
+          "transformMultiplier": 0.8,
+          "divergentMultiplier": 0.32,
+          "hotspotWeight": 0.32,
+          "shieldPenalty": 0.55,
+          "randomJitter": 0.04,
+          "minVolcanoes": 12,
+          "maxVolcanoes": 42
         }
-      },
+      }
+    },
+    "landmasses": {
       "landmasses": {
-        "landmasses": {
-          "strategy": "default",
-          "config": {}
-        }
+        "strategy": "default",
+        "config": {}
       }
     }
   },
@@ -668,12 +648,7 @@
             "tropicalThreshold": 20
           },
           "moisture": {
-            "thresholds": [
-              95,
-              130,
-              170,
-              220
-            ]
+            "thresholds": [95, 130, 170, 220]
           },
           "aridity": {
             "temperatureMin": 0,
@@ -684,10 +659,7 @@
             "rainfallWeight": 1.15,
             "bias": 3,
             "normalization": 112,
-            "moistureShiftThresholds": [
-              0.37,
-              0.62
-            ],
+            "moistureShiftThresholds": [0.37, 0.62],
             "vegetationPenalty": 0.22
           },
           "vegetation": {
@@ -1002,14 +974,12 @@
       "lakeiness": "normal",
       "riverDensity": "dense"
     },
-    "advanced": {
-      "lakes": {
-        "tilesPerLakeMultiplier": 1
-      },
-      "plot-rivers": {
-        "minLength": 5,
-        "maxLength": 15
-      }
+    "lakes": {
+      "tilesPerLakeMultiplier": 1
+    },
+    "plot-rivers": {
+      "minLength": 5,
+      "maxLength": 15
     }
   },
   "map-ecology": {
@@ -1062,10 +1032,7 @@
           "maxFreeze": 0.3,
           "maxVegetation": 0.23,
           "maxMoisture": 90,
-          "allowedBiomes": [
-            "desert",
-            "temperateDry"
-          ]
+          "allowedBiomes": ["desert", "temperateDry"]
         }
       },
       "scoreBurned": {
@@ -1076,10 +1043,7 @@
           "maxFreeze": 0.22,
           "maxVegetation": 0.26,
           "maxMoisture": 98,
-          "allowedBiomes": [
-            "temperateDry",
-            "tropicalSeasonal"
-          ]
+          "allowedBiomes": ["temperateDry", "tropicalSeasonal"]
         }
       },
       "plotEffects": {
@@ -1152,61 +1116,9 @@
         "strategy": "default",
         "config": {
           "candidateResourceTypes": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-            21,
-            22,
-            23,
-            24,
-            25,
-            26,
-            27,
-            28,
-            29,
-            30,
-            31,
-            32,
-            33,
-            34,
-            35,
-            36,
-            37,
-            38,
-            39,
-            40,
-            41,
-            42,
-            43,
-            44,
-            45,
-            46,
-            47,
-            48,
-            49,
-            50,
-            51,
-            52,
-            53,
-            54
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+            46, 47, 48, 49, 50, 51, 52, 53, 54
           ],
           "densityPer100Tiles": 9,
           "minSpacingTiles": 2,

--- a/mods/mod-swooper-maps/src/presets/standard/earthlike.json
+++ b/mods/mod-swooper-maps/src/presets/standard/earthlike.json
@@ -10,176 +10,164 @@
         "plateActivity": 0.7
       },
       "mesh": {
-          "computeMesh": {
-            "strategy": "default",
-            "config": {
-              "plateCount": 28,
-              "cellsPerPlate": 7,
-              "referenceArea": 6996,
-              "plateScalePower": 0.7,
-              "relaxationSteps": 2
+        "computeMesh": {
+          "strategy": "default",
+          "config": {
+            "plateCount": 28,
+            "cellsPerPlate": 7,
+            "referenceArea": 6996,
+            "plateScalePower": 0.7,
+            "relaxationSteps": 2
+          }
+        }
+      },
+      "mantle-potential": {
+        "computeMantlePotential": {
+          "strategy": "default",
+          "config": {
+            "plumeCount": 10,
+            "downwellingCount": 3,
+            "plumeRadius": 0.28,
+            "downwellingRadius": 0.18,
+            "plumeAmplitude": 1,
+            "downwellingAmplitude": -1,
+            "smoothingIterations": 1,
+            "smoothingAlpha": 0.35,
+            "minSeparationScale": 0.85
+          }
+        }
+      },
+      "mantle-forcing": {
+        "computeMantleForcing": {
+          "strategy": "default",
+          "config": {
+            "velocityScale": 1,
+            "rotationScale": 0.2,
+            "stressNorm": 1,
+            "curvatureWeight": 0.35,
+            "upwellingThreshold": 0.35,
+            "downwellingThreshold": 0.35
+          }
+        }
+      },
+      "crust": {
+        "computeCrust": {
+          "strategy": "default",
+          "config": {
+            "basalticThickness01": 0.25,
+            "yieldStrength01": 0.55,
+            "mantleCoupling01": 0.6,
+            "riftWeakening01": 0.35
+          }
+        }
+      },
+      "plate-graph": {
+        "computePlateGraph": {
+          "strategy": "default",
+          "config": {
+            "plateCount": 8,
+            "referenceArea": 4000,
+            "plateScalePower": 0.5,
+            "polarCaps": {
+              "capFraction": 0.1,
+              "microplateBandFraction": 0.2,
+              "microplatesPerPole": 0,
+              "microplatesMinPlateCount": 14,
+              "microplateMinAreaCells": 8
             }
           }
-        },
-        "mantle-potential": {
-          "computeMantlePotential": {
-            "strategy": "default",
-            "config": {
-              "plumeCount": 10,
-              "downwellingCount": 3,
-              "plumeRadius": 0.28,
-              "downwellingRadius": 0.18,
-              "plumeAmplitude": 1,
-              "downwellingAmplitude": -1,
-              "smoothingIterations": 1,
-              "smoothingAlpha": 0.35,
-              "minSeparationScale": 0.85
-            }
+        }
+      },
+      "plate-motion": {
+        "computePlateMotion": {
+          "strategy": "default",
+          "config": {
+            "omegaFactor": 1,
+            "plateRadiusMin": 1,
+            "residualNormScale": 1,
+            "p90NormScale": 1,
+            "histogramBins": 32,
+            "smoothingSteps": 0
+          }
+        }
+      },
+      "tectonics": {
+        "computePlateMotion": {
+          "strategy": "default",
+          "config": {
+            "omegaFactor": 1,
+            "plateRadiusMin": 1,
+            "residualNormScale": 1,
+            "p90NormScale": 1,
+            "histogramBins": 32,
+            "smoothingSteps": 0
           }
         },
-        "mantle-forcing": {
-          "computeMantleForcing": {
-            "strategy": "default",
-            "config": {
-              "velocityScale": 1,
-              "rotationScale": 0.2,
-              "stressNorm": 1,
-              "curvatureWeight": 0.35,
-              "upwellingThreshold": 0.35,
-              "downwellingThreshold": 0.35
-            }
+        "computeTectonicSegments": {
+          "strategy": "default",
+          "config": {
+            "intensityScale": 900,
+            "regimeMinIntensity": 4
           }
         },
-        "crust": {
-          "computeCrust": {
-            "strategy": "default",
-            "config": {
-              "basalticThickness01": 0.25,
-              "yieldStrength01": 0.55,
-              "mantleCoupling01": 0.6,
-              "riftWeakening01": 0.35
-            }
+        "computeEraPlateMembership": {
+          "strategy": "default",
+          "config": {
+            "eraWeights": [0.3, 0.25, 0.2, 0.15, 0.1],
+            "driftStepsByEra": [12, 9, 6, 3, 1]
           }
         },
-        "plate-graph": {
-          "computePlateGraph": {
-            "strategy": "default",
-            "config": {
-              "plateCount": 8,
-              "referenceArea": 4000,
-              "plateScalePower": 0.5,
-              "polarCaps": {
-                "capFraction": 0.1,
-                "microplateBandFraction": 0.2,
-                "microplatesPerPole": 0,
-                "microplatesMinPlateCount": 14,
-                "microplateMinAreaCells": 8
-              }
-            }
+        "computeSegmentEvents": {
+          "strategy": "default",
+          "config": {}
+        },
+        "computeHotspotEvents": {
+          "strategy": "default",
+          "config": {}
+        },
+        "computeEraTectonicFields": {
+          "strategy": "default",
+          "config": {
+            "beltInfluenceDistance": 8,
+            "beltDecay": 0.55
           }
         },
-        "plate-motion": {
-          "computePlateMotion": {
-            "strategy": "default",
-            "config": {
-              "omegaFactor": 1,
-              "plateRadiusMin": 1,
-              "residualNormScale": 1,
-              "p90NormScale": 1,
-              "histogramBins": 32,
-              "smoothingSteps": 0
-            }
+        "computeTectonicHistoryRollups": {
+          "strategy": "default",
+          "config": {
+            "activityThreshold": 1
           }
         },
-        "tectonics": {
-          "computePlateMotion": {
-            "strategy": "default",
-            "config": {
-              "omegaFactor": 1,
-              "plateRadiusMin": 1,
-              "residualNormScale": 1,
-              "p90NormScale": 1,
-              "histogramBins": 32,
-              "smoothingSteps": 0
-            }
-          },
-          "computeTectonicSegments": {
-            "strategy": "default",
-            "config": {
-              "intensityScale": 900,
-              "regimeMinIntensity": 4
-            }
-          },
-          "computeEraPlateMembership": {
-            "strategy": "default",
-            "config": {
-              "eraWeights": [
-                0.3,
-                0.25,
-                0.2,
-                0.15,
-                0.1
-              ],
-              "driftStepsByEra": [
-                12,
-                9,
-                6,
-                3,
-                1
-              ]
-            }
-          },
-          "computeSegmentEvents": {
-            "strategy": "default",
-            "config": {}
-          },
-          "computeHotspotEvents": {
-            "strategy": "default",
-            "config": {}
-          },
-          "computeEraTectonicFields": {
-            "strategy": "default",
-            "config": {
-              "beltInfluenceDistance": 8,
-              "beltDecay": 0.55
-            }
-          },
-          "computeTectonicHistoryRollups": {
-            "strategy": "default",
-            "config": {
-              "activityThreshold": 1
-            }
-          },
-          "computeTectonicsCurrent": {
-            "strategy": "default",
-            "config": {}
-          },
-          "computeTracerAdvection": {
-            "strategy": "default",
-            "config": {}
-          },
-          "computeTectonicProvenance": {
-            "strategy": "default",
-            "config": {}
-          }
+        "computeTectonicsCurrent": {
+          "strategy": "default",
+          "config": {}
         },
-        "crust-evolution": {
-          "computeCrustEvolution": {
-            "strategy": "default",
-            "config": {}
-          }
+        "computeTracerAdvection": {
+          "strategy": "default",
+          "config": {}
         },
-        "projection": {
-          "computePlates": {
-            "strategy": "default",
-            "config": {
-              "boundaryInfluenceDistance": 7,
-              "boundaryDecay": 0.55,
-              "movementScale": 100,
-              "rotationScale": 100
-            }
+        "computeTectonicProvenance": {
+          "strategy": "default",
+          "config": {}
+        }
+      },
+      "crust-evolution": {
+        "computeCrustEvolution": {
+          "strategy": "default",
+          "config": {}
+        }
+      },
+      "projection": {
+        "computePlates": {
+          "strategy": "default",
+          "config": {
+            "boundaryInfluenceDistance": 7,
+            "boundaryDecay": 0.55,
+            "movementScale": 100,
+            "rotationScale": 100
           }
-        },
+        }
+      },
       "plate-topology": {}
     },
     "morphology-coasts": {
@@ -188,123 +176,119 @@
         "coastRuggedness": "normal",
         "shelfWidth": "normal"
       },
-      "advanced": {
-        "landmass-plates": {
-          "beltDrivers": {
-            "strategy": "default",
-            "config": {}
-          },
-          "substrate": {
-            "strategy": "default",
-            "config": {
-              "continentalBaseErodibility": 0.63,
-              "oceanicBaseErodibility": 0.53,
-              "continentalBaseSediment": 0.19,
-              "oceanicBaseSediment": 0.29,
-              "ageErodibilityReduction": 0.25,
-              "ageSedimentBoost": 0.15,
-              "upliftErodibilityBoost": 0.35,
-              "riftSedimentBoost": 0.34,
-              "convergentBoundaryErodibilityBoost": 0.12,
-              "divergentBoundaryErodibilityBoost": 0.18,
-              "transformBoundaryErodibilityBoost": 0.08,
-              "convergentBoundarySedimentBoost": 0.05,
-              "divergentBoundarySedimentBoost": 0.1,
-              "transformBoundarySedimentBoost": 0.03
-            }
-          },
-          "baseTopography": {
-            "strategy": "default",
-            "config": {
-              "boundaryBias": 0.24,
-              "clusteringBias": 0.7,
-              "crustEdgeBlend": 0.6,
-              "crustNoiseAmplitude": 0.36,
-              "continentalHeight": 0.62,
-              "oceanicHeight": -0.75,
-              "tectonics": {
-                "interiorNoiseWeight": 0.5,
-                "boundaryArcWeight": 0.32,
-                "boundaryArcNoiseWeight": 0.26,
-                "fractalGrain": 3
-              }
-            }
-          },
-          "seaLevel": {
-            "strategy": "default",
-            "config": {
-              "targetWaterPercent": 63,
-              "targetScalar": 1,
-              "variance": 1.5,
-              "boundaryShareTarget": 0.005,
-              "continentalFraction": 0.39
-            }
-          },
-          "landmask": {
-            "strategy": "default",
-            "config": {
-              "continentPotentialGrain": 4,
-              "continentPotentialBlurSteps": 4,
-              "keepLandComponentFraction": 0.985,
-              "cratonStepsPerEra": 2,
-              "cratonNucleationScale": 0.9,
-              "cratonDiffusion": 0.25,
-              "cratonAdvection": 0.15,
-              "cratonHalfSaturation": 0.35,
-              "cratonPotentialWeight": 0.12
+      "landmass-plates": {
+        "beltDrivers": {
+          "strategy": "default",
+          "config": {}
+        },
+        "substrate": {
+          "strategy": "default",
+          "config": {
+            "continentalBaseErodibility": 0.63,
+            "oceanicBaseErodibility": 0.53,
+            "continentalBaseSediment": 0.19,
+            "oceanicBaseSediment": 0.29,
+            "ageErodibilityReduction": 0.25,
+            "ageSedimentBoost": 0.15,
+            "upliftErodibilityBoost": 0.35,
+            "riftSedimentBoost": 0.34,
+            "convergentBoundaryErodibilityBoost": 0.12,
+            "divergentBoundaryErodibilityBoost": 0.18,
+            "transformBoundaryErodibilityBoost": 0.08,
+            "convergentBoundarySedimentBoost": 0.05,
+            "divergentBoundarySedimentBoost": 0.1,
+            "transformBoundarySedimentBoost": 0.03
+          }
+        },
+        "baseTopography": {
+          "strategy": "default",
+          "config": {
+            "boundaryBias": 0.24,
+            "clusteringBias": 0.7,
+            "crustEdgeBlend": 0.6,
+            "crustNoiseAmplitude": 0.36,
+            "continentalHeight": 0.62,
+            "oceanicHeight": -0.75,
+            "tectonics": {
+              "interiorNoiseWeight": 0.5,
+              "boundaryArcWeight": 0.32,
+              "boundaryArcNoiseWeight": 0.26,
+              "fractalGrain": 3
             }
           }
         },
-        "rugged-coasts": {
-          "coastlines": {
-            "strategy": "default",
-            "config": {
-              "coast": {
-                "bay": {
-                  "noiseGateAdd": 0.05,
-                  "rollDenActive": 4,
-                  "rollDenDefault": 7
-                },
-                "fjord": {
-                  "baseDenom": 15,
-                  "activeBonus": 2,
-                  "passiveBonus": 1
-                },
-                "plateBias": {
-                  "threshold": 0.42,
-                  "power": 1.3,
-                  "convergent": 1.5,
-                  "transform": 0.35,
-                  "divergent": -0.45,
-                  "interior": 0.35,
-                  "bayWeight": 0.9,
-                  "bayNoiseBonus": 0.45,
-                  "fjordWeight": 0.85
-                }
+        "seaLevel": {
+          "strategy": "default",
+          "config": {
+            "targetWaterPercent": 63,
+            "targetScalar": 1,
+            "variance": 1.5,
+            "boundaryShareTarget": 0.005,
+            "continentalFraction": 0.39
+          }
+        },
+        "landmask": {
+          "strategy": "default",
+          "config": {
+            "continentPotentialGrain": 4,
+            "continentPotentialBlurSteps": 4,
+            "keepLandComponentFraction": 0.985,
+            "cratonStepsPerEra": 2,
+            "cratonNucleationScale": 0.9,
+            "cratonDiffusion": 0.25,
+            "cratonAdvection": 0.15,
+            "cratonHalfSaturation": 0.35,
+            "cratonPotentialWeight": 0.12
+          }
+        }
+      },
+      "rugged-coasts": {
+        "coastlines": {
+          "strategy": "default",
+          "config": {
+            "coast": {
+              "bay": {
+                "noiseGateAdd": 0.05,
+                "rollDenActive": 4,
+                "rollDenDefault": 7
+              },
+              "fjord": {
+                "baseDenom": 15,
+                "activeBonus": 2,
+                "passiveBonus": 1
+              },
+              "plateBias": {
+                "threshold": 0.42,
+                "power": 1.3,
+                "convergent": 1.5,
+                "transform": 0.35,
+                "divergent": -0.45,
+                "interior": 0.35,
+                "bayWeight": 0.9,
+                "bayNoiseBonus": 0.45,
+                "fjordWeight": 0.85
               }
             }
-          },
-          "shelfMask": {
-            "strategy": "default",
-            "config": {
-              "nearshoreDistance": 3,
-              "shallowQuantile": 0.7,
-              "activeClosenessThreshold": 0.45,
-              "capTilesActive": 2,
-              "capTilesPassive": 4,
-              "capTilesMax": 8
-            }
+          }
+        },
+        "shelfMask": {
+          "strategy": "default",
+          "config": {
+            "nearshoreDistance": 3,
+            "shallowQuantile": 0.7,
+            "activeClosenessThreshold": 0.45,
+            "capTilesActive": 2,
+            "capTilesPassive": 4,
+            "capTilesMax": 8
           }
         }
       }
     },
     "morphology-routing": {
-      "advanced": {
+      "routing": {
         "routing": {
-          "routing": {
-            "strategy": "default",
-            "config": {}
-          }
+          "strategy": "default",
+          "config": {}
         }
       },
       "knobs": {}
@@ -313,28 +297,26 @@
       "knobs": {
         "erosion": "normal"
       },
-      "advanced": {
+      "geomorphology": {
         "geomorphology": {
-          "geomorphology": {
-            "strategy": "default",
-            "config": {
-              "geomorphology": {
-                "fluvial": {
-                  "rate": 0.26,
-                  "m": 0.5,
-                  "n": 1
-                },
-                "diffusion": {
-                  "rate": 0.23,
-                  "talus": 0.5
-                },
-                "deposition": {
-                  "rate": 0.11
-                },
-                "eras": 3
+          "strategy": "default",
+          "config": {
+            "geomorphology": {
+              "fluvial": {
+                "rate": 0.26,
+                "m": 0.5,
+                "n": 1
               },
-              "worldAge": "mature"
-            }
+              "diffusion": {
+                "rate": 0.23,
+                "talus": 0.5
+              },
+              "deposition": {
+                "rate": 0.11
+              },
+              "eras": 3
+            },
+            "worldAge": "mature"
           }
         }
       }
@@ -343,48 +325,46 @@
       "knobs": {
         "volcanism": "normal"
       },
-      "advanced": {
+      "islands": {
         "islands": {
-          "islands": {
-            "strategy": "default",
-            "config": {
-              "islands": {
-                "fractalThresholdPercent": 96,
-                "minDistFromLandRadius": 5,
-                "baseIslandDenNearActive": 2,
-                "baseIslandDenElse": 2,
-                "hotspotSeedDenom": 3,
-                "clusterMax": 12,
-                "microcontinentChance": 0.12
-              }
+          "strategy": "default",
+          "config": {
+            "islands": {
+              "fractalThresholdPercent": 96,
+              "minDistFromLandRadius": 5,
+              "baseIslandDenNearActive": 2,
+              "baseIslandDenElse": 2,
+              "hotspotSeedDenom": 3,
+              "clusterMax": 12,
+              "microcontinentChance": 0.12
             }
           }
-        },
+        }
+      },
+      "volcanoes": {
         "volcanoes": {
-          "volcanoes": {
-            "strategy": "default",
-            "config": {
-              "enabled": true,
-              "baseDensity": 0.00625,
-              "minSpacing": 6,
-              "boundaryThreshold": 0.32,
-              "boundaryWeight": 1.35,
-              "convergentMultiplier": 3.3,
-              "transformMultiplier": 0.8,
-              "divergentMultiplier": 0.32,
-              "hotspotWeight": 0.32,
-              "shieldPenalty": 0.55,
-              "randomJitter": 0.04,
-              "minVolcanoes": 12,
-              "maxVolcanoes": 42
-            }
+          "strategy": "default",
+          "config": {
+            "enabled": true,
+            "baseDensity": 0.00625,
+            "minSpacing": 6,
+            "boundaryThreshold": 0.32,
+            "boundaryWeight": 1.35,
+            "convergentMultiplier": 3.3,
+            "transformMultiplier": 0.8,
+            "divergentMultiplier": 0.32,
+            "hotspotWeight": 0.32,
+            "shieldPenalty": 0.55,
+            "randomJitter": 0.04,
+            "minVolcanoes": 12,
+            "maxVolcanoes": 42
           }
-        },
+        }
+      },
+      "landmasses": {
         "landmasses": {
-          "landmasses": {
-            "strategy": "default",
-            "config": {}
-          }
+          "strategy": "default",
+          "config": {}
         }
       }
     },
@@ -485,13 +465,13 @@
         "computePrecipitation": {
           "strategy": "default",
           "config": {
-              "rainfallScale": 174,
-              "humidityExponent": 1.05,
-              "noiseAmplitude": 14,
-              "noiseScale": 0.16,
-              "waterGradient": {
-                "radius": 6,
-                "perRingBonus": 5,
+            "rainfallScale": 174,
+            "humidityExponent": 1.05,
+            "noiseAmplitude": 14,
+            "noiseScale": 0.16,
+            "waterGradient": {
+              "radius": 6,
+              "perRingBonus": 5,
               "lowlandBonus": 3,
               "lowlandElevationMax": 200
             },
@@ -672,12 +652,7 @@
               "tropicalThreshold": 20
             },
             "moisture": {
-              "thresholds": [
-                95,
-                130,
-                170,
-                220
-              ]
+              "thresholds": [95, 130, 170, 220]
             },
             "aridity": {
               "temperatureMin": 0,
@@ -688,10 +663,7 @@
               "rainfallWeight": 1.15,
               "bias": 3,
               "normalization": 112,
-              "moistureShiftThresholds": [
-                0.37,
-                0.62
-              ],
+              "moistureShiftThresholds": [0.37, 0.62],
               "vegetationPenalty": 0.22
             },
             "vegetation": {
@@ -895,15 +867,15 @@
             "tectonicIntensity": 1,
             "driverSignalByteMin": 30,
             "driverExponent": 1,
-          "mountainMaxFraction": 0.1,
-          "hillMaxFraction": 0.18,
-          "mountainSpineFraction": 0.02,
-          "mountainSpineDilationSteps": 2,
+            "mountainMaxFraction": 0.1,
+            "hillMaxFraction": 0.18,
+            "mountainSpineFraction": 0.02,
+            "mountainSpineDilationSteps": 2,
             "oldBeltMountainScale": 0.4,
             "oldBeltHillScale": 1.1,
             "foothillMaxDistance": 2,
-          "mountainThreshold": 0.47,
-          "hillThreshold": 0.27,
+            "mountainThreshold": 0.47,
+            "hillThreshold": 0.27,
             "upliftWeight": 0.35,
             "fractalWeight": 0.15,
             "orogenyCollisionStressWeight": 0.6,
@@ -948,15 +920,15 @@
             "tectonicIntensity": 1,
             "driverSignalByteMin": 30,
             "driverExponent": 1,
-          "mountainMaxFraction": 0.1,
-          "hillMaxFraction": 0.18,
-          "mountainSpineFraction": 0.02,
-          "mountainSpineDilationSteps": 2,
+            "mountainMaxFraction": 0.1,
+            "hillMaxFraction": 0.18,
+            "mountainSpineFraction": 0.02,
+            "mountainSpineDilationSteps": 2,
             "oldBeltMountainScale": 0.4,
             "oldBeltHillScale": 1.1,
             "foothillMaxDistance": 2,
-          "mountainThreshold": 0.47,
-          "hillThreshold": 0.27,
+            "mountainThreshold": 0.47,
+            "hillThreshold": 0.27,
             "upliftWeight": 0.35,
             "fractalWeight": 0.15,
             "orogenyCollisionStressWeight": 0.6,
@@ -1006,14 +978,12 @@
         "lakeiness": "normal",
         "riverDensity": "dense"
       },
-      "advanced": {
-        "lakes": {
-          "tilesPerLakeMultiplier": 1
-        },
-        "plot-rivers": {
-          "minLength": 5,
-          "maxLength": 15
-        }
+      "lakes": {
+        "tilesPerLakeMultiplier": 1
+      },
+      "plot-rivers": {
+        "minLength": 5,
+        "maxLength": 15
       }
     },
     "map-ecology": {
@@ -1066,10 +1036,7 @@
             "maxFreeze": 0.3,
             "maxVegetation": 0.23,
             "maxMoisture": 90,
-            "allowedBiomes": [
-              "desert",
-              "temperateDry"
-            ]
+            "allowedBiomes": ["desert", "temperateDry"]
           }
         },
         "scoreBurned": {
@@ -1080,10 +1047,7 @@
             "maxFreeze": 0.22,
             "maxVegetation": 0.26,
             "maxMoisture": 98,
-            "allowedBiomes": [
-              "temperateDry",
-              "tropicalSeasonal"
-            ]
+            "allowedBiomes": ["temperateDry", "tropicalSeasonal"]
           }
         },
         "plotEffects": {
@@ -1156,61 +1120,9 @@
           "strategy": "default",
           "config": {
             "candidateResourceTypes": [
-              0,
-              1,
-              2,
-              3,
-              4,
-              5,
-              6,
-              7,
-              8,
-              9,
-              10,
-              11,
-              12,
-              13,
-              14,
-              15,
-              16,
-              17,
-              18,
-              19,
-              20,
-              21,
-              22,
-              23,
-              24,
-              25,
-              26,
-              27,
-              28,
-              29,
-              30,
-              31,
-              32,
-              33,
-              34,
-              35,
-              36,
-              37,
-              38,
-              39,
-              40,
-              41,
-              42,
-              43,
-              44,
-              45,
-              46,
-              47,
-              48,
-              49,
-              50,
-              51,
-              52,
-              53,
-              54
+              0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+              24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
+              45, 46, 47, 48, 49, 50, 51, 52, 53, 54
             ],
             "densityPer100Tiles": 9,
             "minSpacingTiles": 2,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/index.ts
@@ -22,7 +22,7 @@ const knobsSchema = Type.Object(
      *
      * Stage scope:
      * - Transforms baseline temperature regime and downstream evap/precip coupling inputs.
-     * - Must not implement “compat” behavior; use advanced config for exact numeric control.
+     * - Must not implement “compat” behavior; use flat step config for exact numeric control.
      */
     temperature: Type.Optional(HydrologyTemperatureKnobSchema),
     /**

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.contract.ts
@@ -11,12 +11,13 @@ import { morphologyArtifacts } from "../../morphology/artifacts.js";
  * canonical baseline climate + wind artifacts for downstream consumption.
  *
  * Configuration posture:
- * - No step-local config. All author-facing control flows through Hydrology knobs compiled at stage compile time.
+ * - Broad author-facing control flows through Hydrology knobs compiled at stage compile time.
+ * - Optional flat `climate-baseline.seasonality` step config is reserved for exact seasonality posture overrides.
  */
 const ClimateBaselineStepConfigSchema = Type.Object(
   {
     /**
-     * Advanced seasonality controls (optional).
+     * Seasonality controls (optional).
      *
      * Hydrology still exposes the broad `seasonality` knob, but these let authors override the exact internal
      * computation posture while keeping the public outputs stable (mean + amplitude only).
@@ -45,7 +46,7 @@ const ClimateBaselineStepConfigSchema = Type.Object(
         {
           additionalProperties: false,
           description:
-            "Advanced seasonality controls (optional). Explicit values override Hydrology knobs; missing values are derived from knobs.",
+            "Seasonality controls (optional). Explicit values override Hydrology knobs; missing values are derived from knobs.",
         }
       )
     ),
@@ -53,7 +54,7 @@ const ClimateBaselineStepConfigSchema = Type.Object(
   {
     additionalProperties: false,
     description:
-      "Climate baseline step config (advanced). Prefer Hydrology knobs for broad tuning; use this for explicit seasonality posture overrides.",
+      "Climate baseline step config. Prefer Hydrology knobs for broad tuning; use this for explicit seasonality posture overrides.",
   }
 );
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/index.ts
@@ -1,34 +1,9 @@
-import { Type, createStage, type Static } from "@swooper/mapgen-core/authoring";
+import { Type, createStage } from "@swooper/mapgen-core/authoring";
 import {
   HydrologyLakeinessKnobSchema,
   HydrologyRiverDensityKnobSchema,
 } from "@mapgen/domain/hydrology/shared/knobs.js";
 import { lakes, plotRivers } from "./steps/index.js";
-
-/**
- * Advanced Map-hydrology step config baseline (engine projection tuning).
- * Knobs apply last as deterministic transforms over this baseline.
- */
-const publicSchema = Type.Object(
-  {
-    advanced: Type.Optional(
-      Type.Object(
-        {
-          lakes: Type.Optional(lakes.contract.schema),
-          "plot-rivers": Type.Optional(plotRivers.contract.schema),
-        },
-        {
-          additionalProperties: false,
-          description:
-            "Advanced Map-hydrology step config baseline (engine projection tuning). Knobs apply last as deterministic transforms over this baseline.",
-        }
-      )
-    ),
-  },
-  { additionalProperties: false }
-);
-
-type MapHydrologyStageConfig = Static<typeof publicSchema>;
 
 const knobsSchema = Type.Object(
   {
@@ -44,7 +19,5 @@ const knobsSchema = Type.Object(
 export default createStage({
   id: "map-hydrology",
   knobsSchema,
-  public: publicSchema,
-  compile: ({ config }: { config: MapHydrologyStageConfig }) => (config.advanced ? config.advanced : {}),
   steps: [lakes, plotRivers],
 } as const);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/index.ts
@@ -1,34 +1,10 @@
-import { Type, createStage, type Static } from "@swooper/mapgen-core/authoring";
+import { Type, createStage } from "@swooper/mapgen-core/authoring";
 import { landmassPlates, ruggedCoasts } from "./steps/index.js";
 import {
   MorphologyCoastRuggednessKnobSchema,
   MorphologySeaLevelKnobSchema,
   MorphologyShelfWidthKnobSchema,
 } from "@mapgen/domain/morphology/shared/knobs.js";
-
-/**
- * Advanced Morphology-coasts step config baseline. Knobs apply last as deterministic transforms over this baseline.
- */
-const publicSchema = Type.Object(
-  {
-    advanced: Type.Optional(
-      Type.Object(
-        {
-          "landmass-plates": Type.Optional(landmassPlates.contract.schema),
-          "rugged-coasts": Type.Optional(ruggedCoasts.contract.schema),
-        },
-        {
-          additionalProperties: false,
-          description:
-            "Advanced Morphology-coasts step config baseline. Knobs apply last as deterministic transforms over this baseline.",
-        }
-      )
-    ),
-  },
-  { additionalProperties: false }
-);
-
-type MorphologyCoastsStageConfig = Static<typeof publicSchema>;
 
 /**
  * Morphology-coasts knobs (seaLevel/coastRuggedness/shelfWidth).
@@ -49,7 +25,5 @@ const knobsSchema = Type.Object(
 export default createStage({
   id: "morphology-coasts",
   knobsSchema,
-  public: publicSchema,
-  compile: ({ config }: { config: MorphologyCoastsStageConfig }) => (config.advanced ? config.advanced : {}),
   steps: [landmassPlates, ruggedCoasts],
 } as const);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/index.ts
@@ -1,28 +1,6 @@
-import { Type, createStage, type Static } from "@swooper/mapgen-core/authoring";
+import { Type, createStage } from "@swooper/mapgen-core/authoring";
 import { geomorphology } from "./steps/index.js";
 import { MorphologyErosionKnobSchema } from "@mapgen/domain/morphology/shared/knobs.js";
-
-/**
- * Advanced Morphology-erosion step config baseline.
- */
-const publicSchema = Type.Object(
-  {
-    advanced: Type.Optional(
-      Type.Object(
-        {
-          geomorphology: Type.Optional(geomorphology.contract.schema),
-        },
-        {
-          additionalProperties: false,
-          description: "Advanced Morphology-erosion step config baseline.",
-        }
-      )
-    ),
-  },
-  { additionalProperties: false }
-);
-
-type MorphologyErosionStageConfig = Static<typeof publicSchema>;
 
 /**
  * Morphology-erosion knobs (erosion). Knobs apply after defaulted step config as deterministic transforms.
@@ -40,7 +18,5 @@ const knobsSchema = Type.Object(
 export default createStage({
   id: "morphology-erosion",
   knobsSchema,
-  public: publicSchema,
-  compile: ({ config }: { config: MorphologyErosionStageConfig }) => (config.advanced ? config.advanced : {}),
   steps: [geomorphology],
 } as const);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/index.ts
@@ -1,30 +1,6 @@
-import { Type, createStage, type Static } from "@swooper/mapgen-core/authoring";
+import { Type, createStage } from "@swooper/mapgen-core/authoring";
 import { islands, landmasses, volcanoes } from "./steps/index.js";
 import { MorphologyVolcanismKnobSchema } from "@mapgen/domain/morphology/shared/knobs.js";
-
-/**
- * Advanced Morphology-features step config baseline.
- */
-const publicSchema = Type.Object(
-  {
-    advanced: Type.Optional(
-      Type.Object(
-        {
-          islands: Type.Optional(islands.contract.schema),
-          volcanoes: Type.Optional(volcanoes.contract.schema),
-          landmasses: Type.Optional(landmasses.contract.schema),
-        },
-        {
-          additionalProperties: false,
-          description: "Advanced Morphology-features step config baseline.",
-        }
-      )
-    ),
-  },
-  { additionalProperties: false }
-);
-
-type MorphologyFeaturesStageConfig = Static<typeof publicSchema>;
 
 /**
  * Morphology-features knobs (volcanism). Knobs apply after defaulted step config as deterministic transforms.
@@ -42,7 +18,5 @@ const knobsSchema = Type.Object(
 export default createStage({
   id: "morphology-features",
   knobsSchema,
-  public: publicSchema,
-  compile: ({ config }: { config: MorphologyFeaturesStageConfig }) => (config.advanced ? config.advanced : {}),
   steps: [islands, volcanoes, landmasses],
 } as const);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-routing/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-routing/index.ts
@@ -1,37 +1,16 @@
-import { Type, createStage, type Static } from "@swooper/mapgen-core/authoring";
+import { Type, createStage } from "@swooper/mapgen-core/authoring";
 import { routing } from "./steps/index.js";
-
-/**
- * Advanced Morphology-routing step config baseline.
- */
-const publicSchema = Type.Object(
-  {
-    advanced: Type.Optional(
-      Type.Object(
-        {
-          routing: Type.Optional(routing.contract.schema),
-        },
-        {
-          additionalProperties: false,
-          description: "Advanced Morphology-routing step config baseline.",
-        }
-      )
-    ),
-  },
-  { additionalProperties: false }
-);
-
-type MorphologyRoutingStageConfig = Static<typeof publicSchema>;
 
 /**
  * Morphology-routing has no knobs today (reserved for basin/outlet expansions).
  */
-const knobsSchema = Type.Object({}, { additionalProperties: false, description: "Morphology-routing knobs." });
+const knobsSchema = Type.Object(
+  {},
+  { additionalProperties: false, description: "Morphology-routing knobs." }
+);
 
 export default createStage({
   id: "morphology-routing",
   knobsSchema,
-  public: publicSchema,
-  compile: ({ config }: { config: MorphologyRoutingStageConfig }) => (config.advanced ? config.advanced : {}),
   steps: [routing],
 } as const);

--- a/mods/mod-swooper-maps/test/hydrology-knobs.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology-knobs.test.ts
@@ -30,15 +30,23 @@ describe("hydrology knobs compilation", () => {
       })
     );
 
-    expect(compiledMissing["hydrology-climate-baseline"]).toEqual(compiledExplicit["hydrology-climate-baseline"]);
-    expect(compiledMissing["hydrology-hydrography"]).toEqual(compiledExplicit["hydrology-hydrography"]);
-    expect(compiledMissing["hydrology-climate-refine"]).toEqual(compiledExplicit["hydrology-climate-refine"]);
+    expect(compiledMissing["hydrology-climate-baseline"]).toEqual(
+      compiledExplicit["hydrology-climate-baseline"]
+    );
+    expect(compiledMissing["hydrology-hydrography"]).toEqual(
+      compiledExplicit["hydrology-hydrography"]
+    );
+    expect(compiledMissing["hydrology-climate-refine"]).toEqual(
+      compiledExplicit["hydrology-climate-refine"]
+    );
     expect(compiledMissing["map-hydrology"]).toEqual(compiledExplicit["map-hydrology"]);
   });
 
   it("is deterministic for identical knob inputs", () => {
     const input = {
-      "hydrology-climate-baseline": { knobs: { dryness: "wet", seasonality: "high", oceanCoupling: "earthlike" } },
+      "hydrology-climate-baseline": {
+        knobs: { dryness: "wet", seasonality: "high", oceanCoupling: "earthlike" },
+      },
       "map-hydrology": { knobs: { riverDensity: "dense" } },
       "hydrology-climate-refine": { knobs: { dryness: "wet" } },
     } as const;
@@ -66,14 +74,20 @@ describe("hydrology knobs compilation", () => {
       })
     );
 
-    const wetScale = wet["hydrology-climate-baseline"]["climate-baseline"].computePrecipitation.config.rainfallScale;
-    const dryScale = dry["hydrology-climate-baseline"]["climate-baseline"].computePrecipitation.config.rainfallScale;
+    const wetScale =
+      wet["hydrology-climate-baseline"]["climate-baseline"].computePrecipitation.config
+        .rainfallScale;
+    const dryScale =
+      dry["hydrology-climate-baseline"]["climate-baseline"].computePrecipitation.config
+        .rainfallScale;
     expect(wetScale).toBeGreaterThan(dryScale);
 
     const wetRiverBonus =
-      wet["hydrology-climate-refine"]["climate-refine"].computePrecipitation.config.riverCorridor.lowlandAdjacencyBonus;
+      wet["hydrology-climate-refine"]["climate-refine"].computePrecipitation.config.riverCorridor
+        .lowlandAdjacencyBonus;
     const dryRiverBonus =
-      dry["hydrology-climate-refine"]["climate-refine"].computePrecipitation.config.riverCorridor.lowlandAdjacencyBonus;
+      dry["hydrology-climate-refine"]["climate-refine"].computePrecipitation.config.riverCorridor
+        .lowlandAdjacencyBonus;
     expect(wetRiverBonus).toBeGreaterThan(dryRiverBonus);
   });
 
@@ -91,21 +105,25 @@ describe("hydrology knobs compilation", () => {
       withFoundation({ "map-hydrology": { knobs: { riverDensity: "dense" } } })
     );
 
-    expect(sparse["map-hydrology"]["plot-rivers"].minLength).toBeGreaterThan(normal["map-hydrology"]["plot-rivers"].minLength);
-    expect(normal["map-hydrology"]["plot-rivers"].minLength).toBeGreaterThan(dense["map-hydrology"]["plot-rivers"].minLength);
+    expect(sparse["map-hydrology"]["plot-rivers"].minLength).toBeGreaterThan(
+      normal["map-hydrology"]["plot-rivers"].minLength
+    );
+    expect(normal["map-hydrology"]["plot-rivers"].minLength).toBeGreaterThan(
+      dense["map-hydrology"]["plot-rivers"].minLength
+    );
   });
 
-  it("allows optional advanced step config in hydrology stages", () => {
+  it("allows optional flat step config in hydrology stages", () => {
     const compiled = standardRecipe.compileConfig(
       env,
       withFoundation({
-        "map-hydrology": { advanced: { lakes: {} } },
+        "map-hydrology": { lakes: {} },
       })
     );
     expect(compiled["map-hydrology"].lakes.tilesPerLakeMultiplier).toBe(1);
   });
 
-  it("applies knobs as deterministic transforms over advanced config baselines", () => {
+  it("applies knobs as deterministic transforms over flat step config baselines", () => {
     const compiled = standardRecipe.compileConfig(
       env,
       withFoundation({
@@ -127,10 +145,8 @@ describe("hydrology knobs compilation", () => {
         },
         "map-hydrology": {
           knobs: { riverDensity: "dense", lakeiness: "many" },
-          advanced: {
-            lakes: { tilesPerLakeMultiplier: 2 },
-            "plot-rivers": { minLength: 11, maxLength: 11 },
-          },
+          lakes: { tilesPerLakeMultiplier: 2 },
+          "plot-rivers": { minLength: 11, maxLength: 11 },
         },
         "hydrology-climate-refine": {
           knobs: { dryness: "wet", temperature: "hot", cryosphere: "on" },
@@ -157,21 +173,21 @@ describe("hydrology knobs compilation", () => {
       })
     );
 
-    // Baseline values apply first (schema defaults + advanced config), then knobs transform them.
+    // Baseline values apply first (schema defaults + flat step config), then knobs transform them.
     // - lakeiness=many multiplies tilesPerLakeMultiplier by 0.7 (more lakes).
     expect(compiled["map-hydrology"].lakes.tilesPerLakeMultiplier).toBeCloseTo(1.4, 6);
     // - dryness=wet scales rainfallScale by 1.15 (wetter climate).
-    expect(compiled["hydrology-climate-baseline"]["climate-baseline"].computePrecipitation.config.rainfallScale).toBeCloseTo(
-      141.45,
-      6
-    );
+    expect(
+      compiled["hydrology-climate-baseline"]["climate-baseline"].computePrecipitation.config
+        .rainfallScale
+    ).toBeCloseTo(141.45, 6);
     // - riverDensity=dense shifts length bounds down relative to normal.
     expect(compiled["map-hydrology"]["plot-rivers"].minLength).toBe(9);
     // Note: clamp enforces schema bounds and keeps maxLength >= minLength.
     expect(compiled["map-hydrology"]["plot-rivers"].maxLength).toBe(9);
     expect(
-      compiled["hydrology-climate-refine"]["climate-refine"].computePrecipitation.config.riverCorridor
-        .lowlandAdjacencyBonus
+      compiled["hydrology-climate-refine"]["climate-refine"].computePrecipitation.config
+        .riverCorridor.lowlandAdjacencyBonus
     ).toBe(51);
   });
 });

--- a/mods/mod-swooper-maps/test/m11-config-knobs-and-presets.test.ts
+++ b/mods/mod-swooper-maps/test/m11-config-knobs-and-presets.test.ts
@@ -39,7 +39,9 @@ const foundationBaseConfig = {
 
 describe("M11 config layering: knobs-last (foundation + morphology)", () => {
   it("keeps foundation surface knobs-first (no stage-level public bridge keys)", () => {
-    const schema = deriveRecipeConfigSchema(STANDARD_STAGES) as { properties?: Record<string, unknown> };
+    const schema = deriveRecipeConfigSchema(STANDARD_STAGES) as {
+      properties?: Record<string, unknown>;
+    };
     const foundation = schema.properties?.foundation;
     expect(foundation).toBeTruthy();
     const keys = new Set<string>();
@@ -56,27 +58,27 @@ describe("M11 config layering: knobs-last (foundation + morphology)", () => {
       },
       "morphology-coasts": {
         knobs: { seaLevel: "water-heavy", coastRuggedness: "rugged" },
-        advanced: {
-          "landmass-plates": { seaLevel: { strategy: "default", config: { targetWaterPercent: 60 } } },
-          "rugged-coasts": {
-            coastlines: {
-              strategy: "default",
-              config: {
-                coast: {
-                  plateBias: {
-                    threshold: 0.4,
-                    power: 1.4,
-                    convergent: 2.2,
-                    transform: 0.3,
-                    divergent: -0.3,
-                    interior: 0.5,
-                    bayWeight: 1.0,
-                    bayNoiseBonus: 0.6,
-                    fjordWeight: 0.7,
-                  },
-                  bay: { noiseGateAdd: 0, rollDenActive: 4, rollDenDefault: 5 },
-                  fjord: { baseDenom: 12, activeBonus: 1, passiveBonus: 2 },
+        "landmass-plates": {
+          seaLevel: { strategy: "default", config: { targetWaterPercent: 60 } },
+        },
+        "rugged-coasts": {
+          coastlines: {
+            strategy: "default",
+            config: {
+              coast: {
+                plateBias: {
+                  threshold: 0.4,
+                  power: 1.4,
+                  convergent: 2.2,
+                  transform: 0.3,
+                  divergent: -0.3,
+                  interior: 0.5,
+                  bayWeight: 1.0,
+                  bayNoiseBonus: 0.6,
+                  fjordWeight: 0.7,
                 },
+                bay: { noiseGateAdd: 0, rollDenActive: 4, rollDenDefault: 5 },
+                fjord: { baseDenom: 12, activeBonus: 1, passiveBonus: 2 },
               },
             },
           },
@@ -84,31 +86,27 @@ describe("M11 config layering: knobs-last (foundation + morphology)", () => {
       },
       "morphology-erosion": {
         knobs: { erosion: "high" },
-        advanced: {
+        geomorphology: {
           geomorphology: {
-            geomorphology: {
-              strategy: "default",
-              config: {
-                geomorphology: {
-                  fluvial: { rate: 0.2, m: 0.5, n: 1.0 },
-                  diffusion: { rate: 0.2, talus: 0.5 },
-                  deposition: { rate: 0.1 },
-                  eras: 2,
-                },
-                worldAge: "mature",
+            strategy: "default",
+            config: {
+              geomorphology: {
+                fluvial: { rate: 0.2, m: 0.5, n: 1.0 },
+                diffusion: { rate: 0.2, talus: 0.5 },
+                deposition: { rate: 0.1 },
+                eras: 2,
               },
+              worldAge: "mature",
             },
           },
         },
       },
       "morphology-features": {
         knobs: { volcanism: "high" },
-        advanced: {
+        volcanoes: {
           volcanoes: {
-            volcanoes: {
-              strategy: "default",
-              config: { baseDensity: 0.01, hotspotWeight: 0.12, convergentMultiplier: 2.4 },
-            },
+            strategy: "default",
+            config: { baseDensity: 0.01, hotspotWeight: 0.12, convergentMultiplier: 2.4 },
           },
         },
       },
@@ -146,38 +144,77 @@ describe("M11 config layering: knobs-last (foundation + morphology)", () => {
       expectedPlateGraphPlateCount
     );
     // - plateActivity influences projection through knob transforms (no stage profile bridge).
-    expect(compiled.foundation.projection.computePlates.config.boundaryInfluenceDistance).toBeGreaterThan(0);
+    expect(
+      compiled.foundation.projection.computePlates.config.boundaryInfluenceDistance
+    ).toBeGreaterThan(0);
     expect(compiled.foundation.projection.computePlates.config.movementScale).toBeGreaterThan(0);
     expect(compiled.foundation.projection.computePlates.config.rotationScale).toBeGreaterThan(0);
 
     // Morphology:
     // - seaLevel=water-heavy adds +15 to targetWaterPercent.
-    expect(compiled["morphology-coasts"]["landmass-plates"].seaLevel.config.targetWaterPercent).toBe(75);
+    expect(
+      compiled["morphology-coasts"]["landmass-plates"].seaLevel.config.targetWaterPercent
+    ).toBe(75);
 
     // - erosion=high scales rates by 1.35.
-    expect(compiled["morphology-erosion"].geomorphology.geomorphology.config.geomorphology.fluvial.rate).toBeCloseTo(0.27, 6);
-    expect(compiled["morphology-erosion"].geomorphology.geomorphology.config.geomorphology.diffusion.rate).toBeCloseTo(0.27, 6);
-    expect(compiled["morphology-erosion"].geomorphology.geomorphology.config.geomorphology.deposition.rate).toBeCloseTo(0.135, 6);
+    expect(
+      compiled["morphology-erosion"].geomorphology.geomorphology.config.geomorphology.fluvial.rate
+    ).toBeCloseTo(0.27, 6);
+    expect(
+      compiled["morphology-erosion"].geomorphology.geomorphology.config.geomorphology.diffusion.rate
+    ).toBeCloseTo(0.27, 6);
+    expect(
+      compiled["morphology-erosion"].geomorphology.geomorphology.config.geomorphology.deposition
+        .rate
+    ).toBeCloseTo(0.135, 6);
 
     // - coastRuggedness=rugged scales bay/fjord weights by 1.4.
-    expect(compiled["morphology-coasts"]["rugged-coasts"].coastlines.config.coast.plateBias.bayWeight).toBeCloseTo(1.4, 6);
-    expect(compiled["morphology-coasts"]["rugged-coasts"].coastlines.config.coast.plateBias.bayNoiseBonus).toBeCloseTo(0.84, 6);
-    expect(compiled["morphology-coasts"]["rugged-coasts"].coastlines.config.coast.plateBias.fjordWeight).toBeCloseTo(0.98, 6);
+    expect(
+      compiled["morphology-coasts"]["rugged-coasts"].coastlines.config.coast.plateBias.bayWeight
+    ).toBeCloseTo(1.4, 6);
+    expect(
+      compiled["morphology-coasts"]["rugged-coasts"].coastlines.config.coast.plateBias.bayNoiseBonus
+    ).toBeCloseTo(0.84, 6);
+    expect(
+      compiled["morphology-coasts"]["rugged-coasts"].coastlines.config.coast.plateBias.fjordWeight
+    ).toBeCloseTo(0.98, 6);
 
     // - volcanism=high scales density/weights deterministically.
-    expect(compiled["morphology-features"].volcanoes.volcanoes.config.baseDensity).toBeCloseTo(0.015, 6);
-    expect(compiled["morphology-features"].volcanoes.volcanoes.config.hotspotWeight).toBeCloseTo(0.18, 6);
-    expect(compiled["morphology-features"].volcanoes.volcanoes.config.convergentMultiplier).toBeCloseTo(3.0, 6);
+    expect(compiled["morphology-features"].volcanoes.volcanoes.config.baseDensity).toBeCloseTo(
+      0.015,
+      6
+    );
+    expect(compiled["morphology-features"].volcanoes.volcanoes.config.hotspotWeight).toBeCloseTo(
+      0.18,
+      6
+    );
+    expect(
+      compiled["morphology-features"].volcanoes.volcanoes.config.convergentMultiplier
+    ).toBeCloseTo(3.0, 6);
 
     // - orogeny=high scales intensity and lowers thresholds.
-    expect(compiled["map-morphology"]["plot-mountains"].ridges.config.tectonicIntensity).toBeCloseTo(1.25, 6);
-    expect(compiled["map-morphology"]["plot-mountains"].ridges.config.mountainThreshold).toBeCloseTo(0.55, 6);
-    expect(compiled["map-morphology"]["plot-mountains"].ridges.config.hillThreshold).toBeCloseTo(0.32, 6);
+    expect(
+      compiled["map-morphology"]["plot-mountains"].ridges.config.tectonicIntensity
+    ).toBeCloseTo(1.25, 6);
+    expect(
+      compiled["map-morphology"]["plot-mountains"].ridges.config.mountainThreshold
+    ).toBeCloseTo(0.55, 6);
+    expect(compiled["map-morphology"]["plot-mountains"].ridges.config.hillThreshold).toBeCloseTo(
+      0.32,
+      6
+    );
 
     // Both ops should receive the same knob transform (they share the knob envelope).
-    expect(compiled["map-morphology"]["plot-mountains"].foothills.config.tectonicIntensity).toBeCloseTo(1.25, 6);
-    expect(compiled["map-morphology"]["plot-mountains"].foothills.config.mountainThreshold).toBeCloseTo(0.55, 6);
-    expect(compiled["map-morphology"]["plot-mountains"].foothills.config.hillThreshold).toBeCloseTo(0.32, 6);
+    expect(
+      compiled["map-morphology"]["plot-mountains"].foothills.config.tectonicIntensity
+    ).toBeCloseTo(1.25, 6);
+    expect(
+      compiled["map-morphology"]["plot-mountains"].foothills.config.mountainThreshold
+    ).toBeCloseTo(0.55, 6);
+    expect(compiled["map-morphology"]["plot-mountains"].foothills.config.hillThreshold).toBeCloseTo(
+      0.32,
+      6
+    );
   });
 
   it("compiles deterministically for identical inputs", () => {

--- a/mods/mod-swooper-maps/test/morphology/shelf-width-knob.test.ts
+++ b/mods/mod-swooper-maps/test/morphology/shelf-width-knob.test.ts
@@ -5,7 +5,7 @@ import { standardConfig } from "../support/standard-config.js";
 
 describe("morphology-coasts shelfWidth knob", () => {
   it("scales shelfMask distance caps deterministically in rugged-coasts normalize", () => {
-    const base = (standardConfig as any)["morphology-coasts"]?.advanced?.["rugged-coasts"];
+    const base = (standardConfig as any)["morphology-coasts"]?.["rugged-coasts"];
     expect(base).toBeTruthy();
 
     const shelfMask = {
@@ -20,13 +20,18 @@ describe("morphology-coasts shelfWidth knob", () => {
       },
     };
 
-    const wide = (ruggedCoasts as any).normalize({ ...base, shelfMask }, { knobs: { shelfWidth: "wide" } });
+    const wide = (ruggedCoasts as any).normalize(
+      { ...base, shelfMask },
+      { knobs: { shelfWidth: "wide" } }
+    );
     expect(wide.shelfMask.config.capTilesActive).toBe(3);
     expect(wide.shelfMask.config.capTilesPassive).toBe(5);
 
-    const narrow = (ruggedCoasts as any).normalize({ ...base, shelfMask }, { knobs: { shelfWidth: "narrow" } });
+    const narrow = (ruggedCoasts as any).normalize(
+      { ...base, shelfMask },
+      { knobs: { shelfWidth: "narrow" } }
+    );
     expect(narrow.shelfMask.config.capTilesActive).toBe(2);
     expect(narrow.shelfMask.config.capTilesPassive).toBe(3);
   });
 });
-

--- a/openspec/changes/normalize-config-surface/implementation.md
+++ b/openspec/changes/normalize-config-surface/implementation.md
@@ -1,0 +1,81 @@
+# normalize-config-surface Implementation Record
+
+Date: 2026-05-30
+Branch: `codex/normalize-config-surface-impl`
+Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-DRA-normalize-authority-routing`
+
+## Scope
+
+This slice normalizes persisted standard-recipe stage config to the flat D1
+shape:
+
+```ts
+{
+  knobs?: StageKnobs;
+  [stepId]?: StepConfig;
+}
+```
+
+The change removes wrapper-only `public.advanced` surfaces, migrates first-party
+configs and Studio defaults to top-level step ids, and tightens default stage
+surface schemas so declared step ids use their step contracts.
+
+## Disposition
+
+- Removed wrapper-only `public.advanced` schemas and compile functions from the
+  standard `morphology-coasts`, `morphology-routing`, `morphology-erosion`,
+  `morphology-features`, and `map-hydrology` stages.
+- Preserved `map-morphology` `public + compile` as a genuine public transform:
+  public keys (`plotCoasts`, `plotContinents`, `mountains`, `plotVolcanoes`,
+  `buildElevation`) compile to kebab-case step ids. This is the D1 exception
+  because it is semantic public API translation, not wrapper compatibility.
+- Updated `createStage` default surface derivation to expose `knobs` plus each
+  declared step id with the step contract schema. No flat declared step key is
+  intentionally left as `unknown`.
+- Migrated first-party map configs, presets, Studio defaults, Studio UI typing,
+  and Studio config parsing to read/write top-level step ids.
+- Updated docs and tests to describe `knobs` plus flat step config instead of a
+  persisted `advanced` wrapper.
+- Did not add dual-shape compatibility, generated output edits, or lockfile
+  edits.
+
+## Active `advanced` Search
+
+Remaining active-source hits were classified before closure:
+
+- Old-shape negative guards in tests remain intentional and prove `advanced` is
+  not accepted as a persisted config key.
+- `advancedStart` and `assign-advanced-start-region` are Civ/gameplay terms, not
+  MapGen config-surface vocabulary.
+- Archive or historical prose is outside the active public contract.
+
+No active standard stage now exposes a wrapper-only `public.advanced` surface.
+
+## Review Lanes
+
+- Architecture: flat stage config is enforced at the stage-authoring boundary,
+  with step ids sourced from declared step contracts.
+- Product/DX: author-facing examples, presets, and Studio defaults now use the
+  same shape authors are expected to persist.
+- Adversarial closure: watcher-reported stale `advanced` vocabulary and
+  transitional-wrapper prose were corrected before task closure.
+
+## Verification
+
+Commands run from the worktree:
+
+- `bun run --cwd packages/civ7-adapter build`
+- `bun run --cwd packages/mapgen-viz build`
+- `bun run --cwd packages/mapgen-core build`
+- `bun run --cwd mods/mod-swooper-maps build:studio-recipes`
+- `bun run --cwd mods/mod-swooper-maps build`
+- `bun run --cwd apps/mapgen-studio build`
+- `bun run --cwd packages/mapgen-core check`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run --cwd packages/mapgen-core test -- test/authoring/authoring.test.ts test/compiler/recipe-compile.test.ts`
+- `bun run --cwd mods/mod-swooper-maps test -- test/hydrology-knobs.test.ts test/m11-config-knobs-and-presets.test.ts test/morphology/shelf-width-knob.test.ts test/config/maps-schema-valid.test.ts test/config/presets-schema-valid.test.ts test/config/studio-presets-schema-valid.test.ts`
+- `(cd apps/mapgen-studio && bun test ./test/config/defaultConfigSchema.test.ts)`
+- `rg -n "advanced" packages/mapgen-core/src packages/mapgen-core/test mods/mod-swooper-maps/src mods/mod-swooper-maps/test apps/mapgen-studio/src apps/mapgen-studio/test docs/system/libs/mapgen docs/system/mods/swooper-maps -g '!**/_archive/**' -g '!**/*.gen.ts' -g '!**/dist/**' -g '!**/mod/**'`
+- `bun run openspec -- validate normalize-config-surface --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/normalize-config-surface/tasks.md
+++ b/openspec/changes/normalize-config-surface/tasks.md
@@ -1,33 +1,33 @@
 ## 1. Inventory
 
-- [ ] 1.1 Inventory active `advanced` config wrappers in stages, configs,
+- [x] 1.1 Inventory active `advanced` config wrappers in stages, configs,
   presets, tests, Studio code, and docs.
-- [ ] 1.2 Classify each occurrence as active persisted config, UI label,
+- [x] 1.2 Classify each occurrence as active persisted config, UI label,
   historical/archive prose, or genuine public transform.
 
 ## 2. SDK And Stage Surface
 
-- [ ] 2.1 Delete wrapper-only `public.advanced` schemas and compile functions
+- [x] 2.1 Delete wrapper-only `public.advanced` schemas and compile functions
   from standard stages.
-- [ ] 2.2 Preserve or document any genuine `public + compile` stage transform.
-- [ ] 2.3 Tighten derived flat stage schema validation where feasible.
-- [ ] 2.4 Record an exception ledger for any flat step key that remains
+- [x] 2.2 Preserve or document any genuine `public + compile` stage transform.
+- [x] 2.3 Tighten derived flat stage schema validation where feasible.
+- [x] 2.4 Record an exception ledger for any flat step key that remains
   late-validated rather than schema-derived.
-- [ ] 2.5 Update SDK authoring and compiler tests for the flat surface.
+- [x] 2.5 Update SDK authoring and compiler tests for the flat surface.
 
 ## 3. Consumers
 
-- [ ] 3.1 Migrate first-party map configs and presets to top-level step IDs.
-- [ ] 3.2 Update Swooper tests that author or assert config shape.
-- [ ] 3.3 Update Studio config defaults, UI types, parsing, and schema
+- [x] 3.1 Migrate first-party map configs and presets to top-level step IDs.
+- [x] 3.2 Update Swooper tests that author or assert config shape.
+- [x] 3.3 Update Studio config defaults, UI types, parsing, and schema
   consumers to emit and read the flat shape.
-- [ ] 3.4 Update config docs and examples that describe persisted `advanced`.
+- [x] 3.4 Update config docs and examples that describe persisted `advanced`.
 
 ## 4. Verification
 
-- [ ] 4.1 Run focused authoring/config tests.
-- [ ] 4.2 Run relevant Studio config/schema checks.
-- [ ] 4.3 Run the active-source `advanced` search and disposition exceptions.
-- [ ] 4.4 Run `bun run openspec -- validate normalize-config-surface --strict`.
-- [ ] 4.5 Run `bun run openspec:validate`.
-- [ ] 4.6 Run `git diff --check`.
+- [x] 4.1 Run focused authoring/config tests.
+- [x] 4.2 Run relevant Studio config/schema checks.
+- [x] 4.3 Run the active-source `advanced` search and disposition exceptions.
+- [x] 4.4 Run `bun run openspec -- validate normalize-config-surface --strict`.
+- [x] 4.5 Run `bun run openspec:validate`.
+- [x] 4.6 Run `git diff --check`.

--- a/packages/mapgen-core/src/authoring/stage.ts
+++ b/packages/mapgen-core/src/authoring/stage.ts
@@ -52,12 +52,21 @@ function objectProperties(schema: TObject): Record<string, TSchema> {
   return props ?? {};
 }
 
-function buildInternalAsPublicSurfaceSchema(stepIds: readonly string[], knobsSchema: TObject): TObject {
+function buildInternalAsPublicSurfaceSchema(
+  steps: readonly Readonly<{
+    contract: Readonly<{
+      id: string;
+      schema: TSchema;
+    }>;
+  }>[],
+  knobsSchema: TObject
+): TObject {
   const properties: Record<string, TSchema> = {
     knobs: Type.Optional(knobsSchema),
   };
-  for (const stepId of stepIds) {
-    properties[stepId] = Type.Optional(Type.Unknown());
+  for (const step of steps) {
+    if (step.contract.id === RESERVED_STAGE_KEY) continue;
+    properties[step.contract.id] = Type.Optional(step.contract.schema);
   }
   return Type.Object(properties, { additionalProperties: false });
 }
@@ -132,10 +141,7 @@ export function createStage(def: any): any {
 
   const surfaceSchema = def.public
     ? buildPublicSurfaceSchema(def.public, def.knobsSchema)
-    : buildInternalAsPublicSurfaceSchema(
-        stepIds.filter((id: string) => id !== RESERVED_STAGE_KEY),
-        def.knobsSchema
-      );
+    : buildInternalAsPublicSurfaceSchema(def.steps, def.knobsSchema);
 
   const toInternal = ({
     env,
@@ -147,7 +153,7 @@ export function createStage(def: any): any {
     const { knobs, ...configPart } = stageConfig as Record<string, unknown>;
     const resolvedKnobs = applySchemaDefaults(def.knobsSchema, knobs);
     const rawSteps = def.public
-      ? (def as any).compile({ env, knobs: resolvedKnobs, config: configPart }) ?? {}
+      ? ((def as any).compile({ env, knobs: resolvedKnobs, config: configPart }) ?? {})
       : configPart;
     if (Object.prototype.hasOwnProperty.call(rawSteps, RESERVED_STAGE_KEY)) {
       throw new Error(`stage("${def.id}") compile returned reserved key "${RESERVED_STAGE_KEY}"`);

--- a/packages/mapgen-core/src/authoring/step/ops.ts
+++ b/packages/mapgen-core/src/authoring/step/ops.ts
@@ -9,7 +9,7 @@ export type StepOpUse<C extends OpContractAny = OpContractAny> = Readonly<{
   contract: C;
   /**
    * Optional per-step default strategy. This only affects the default config used when the author
-   * omits this op envelope entirely; the author can still override `strategy` via advanced config.
+   * omits this op envelope entirely; the author can still override `strategy` via step config.
    */
   defaultStrategy?: keyof C["strategies"] & string;
 }>;

--- a/packages/mapgen-core/test/authoring/authoring.test.ts
+++ b/packages/mapgen-core/test/authoring/authoring.test.ts
@@ -56,9 +56,7 @@ describe("authoring SDK", () => {
   });
 
   it("createStep accepts explicit empty schema", () => {
-    expect(() =>
-      createStep(makeContract("alpha"), { run: () => {} })
-    ).not.toThrow();
+    expect(() => createStep(makeContract("alpha"), { run: () => {} })).not.toThrow();
   });
 
   it("defineStep rejects non-kebab step ids", () => {
@@ -177,11 +175,16 @@ describe("authoring SDK", () => {
   });
 
   it("createStage computes surfaceSchema for internal stages", () => {
-    const step = createStep(makeContract("alpha"), { run: () => {} });
+    const stepSchema = Type.Object(
+      { value: Type.Number({ minimum: 1 }) },
+      { additionalProperties: false }
+    );
+    const step = createStep(makeContract("alpha", stepSchema), { run: () => {} });
     const stage = createStage({ id: "foundation", knobsSchema: EmptyKnobsSchema, steps: [step] });
     const props = (stage.surfaceSchema as any).properties as Record<string, unknown>;
     expect(props).toHaveProperty("knobs");
     expect(props).toHaveProperty("alpha");
+    expect((props.alpha as any).properties).toHaveProperty("value");
   });
 
   it("createStage supports public schema with compile mapping", () => {
@@ -292,9 +295,9 @@ describe("authoring SDK", () => {
 
   it("bindCompileOps throws when registry is missing an op id", () => {
     const decl = { trees: { id: "missing" } } as const;
-    expect(() =>
-      bindCompileOps(decl, {} as Record<string, DomainOpCompileAny>)
-    ).toThrow(/missing/i);
+    expect(() => bindCompileOps(decl, {} as Record<string, DomainOpCompileAny>)).toThrow(
+      /missing/i
+    );
   });
 
   it("createRecipe produces Recipe schema v2 (no instance ids)", () => {
@@ -491,6 +494,8 @@ describe("authoring SDK", () => {
     expect(() => runtimes.artifactFoo.publish(ctx, { value: 0 })).toThrow(ArtifactValidationError);
 
     runtimes.artifactFoo.publish(ctx, { value: 1 });
-    expect(() => runtimes.artifactFoo.publish(ctx, { value: 2 })).toThrow(ArtifactDoublePublishError);
+    expect(() => runtimes.artifactFoo.publish(ctx, { value: 2 })).toThrow(
+      ArtifactDoublePublishError
+    );
   });
 });


### PR DESCRIPTION
Removes the wrapper-only `advanced` nesting layer from standard recipe stage configs, replacing it with a flat `{ knobs?, [stepId]?: StepConfig }` shape at the stage root.

**Stage surface changes:**
- Deleted `public.advanced` schemas and their `compile` pass-through functions from `morphology-coasts`, `morphology-routing`, `morphology-erosion`, `morphology-features`, and `map-hydrology`. These stages now expose step ids directly at the stage root with no intermediate wrapper.
- `map-morphology` retains its `public + compile` transform because it performs genuine semantic translation from public keys (`plotCoasts`, `mountains`, etc.) to kebab-case step ids — it is not a compatibility wrapper.
- Updated `createStage` default surface derivation to build `Optional(step.contract.schema)` entries for each declared step id rather than `Optional(Unknown())`, tightening schema validation at the authoring boundary.

**Config and preset migrations:**
- `swooper-earthlike.config.json`, `earthlike.json` preset, `shattered-ring`, `sundered-archipelago`, and `swooper-desert-mountains` configs all have their `advanced` wrapper keys removed; step ids are now top-level within each stage.
- Studio `defaultConfig.ts` and `StageConfig` type updated to match the flat shape. `deriveStepsFromStage` now reads top-level keys (excluding `knobs`) instead of iterating `advanced` categories.

**Tests and docs:**
- Test descriptions and assertions updated to reference "flat step config" instead of "advanced config."
- Test inputs that previously used `advanced: { stepId: ... }` now use `stepId: ...` directly.
- Documentation across `PIPELINE-MODEL.md`, `STANDARD-RECIPE.md`, `HYDROLOGY.md`, the tuning how-to, and the tutorial updated to remove `advanced` wrapper references and describe the flat step-id override surface.
- `openspec/changes/normalize-config-surface/tasks.md` marked complete; `implementation.md` added as a record of scope, disposition, and verification commands.