### PR TITLE
feat(recipes): enforce named domain surface import boundaries

### DIFF
--- a/docs/system/libs/mapgen/policies/IMPORTS.md
+++ b/docs/system/libs/mapgen/policies/IMPORTS.md
@@ -36,11 +36,26 @@ import { normalizeStrict } from "@swooper/mapgen-core/compiler/normalize";
 
 Inside `packages/mapgen-core/**`, use relative imports as needed.
 
+### 3) Standard recipe imports use named domain surfaces
+
+Inside `mods/mod-swooper-maps/src/recipes/**`, imports from `@mapgen/domain/*`
+must stay on a named domain surface.
+
+| Importing code                          | Allowed domain surface                                                         | Enforcement                  |
+| --------------------------------------- | ------------------------------------------------------------------------------ | ---------------------------- |
+| Standard recipe assembly                | `@mapgen/domain/<domain>`                                                      | Policy only                  |
+| Standard recipe op registry             | `@mapgen/domain/<domain>/ops`                                                  | `lint:mapgen-recipe-imports` |
+| Standard recipe config/knob compilation | `@mapgen/domain/<domain>/config.js`                                            | `lint:mapgen-recipe-imports` |
+| Cross-domain source code                | Domain-root contracts first; domain-internal imports only with a named owner   | Policy only                  |
+| Domain internals                        | Relative imports within the same domain owner                                  | Policy only                  |
+| Tests                                   | Public surfaces by default; deep imports only for focused internals under test | Policy only                  |
+
 ## Disallowed
 
 ### 1) Workspace-only aliases in canonical docs/examples
 
 Do not use `@mapgen/*` in canonical docs or examples. This alias:
+
 - is not a public contract,
 - collides across packages,
 - and breaks copy/paste outside the monorepo.
@@ -48,13 +63,27 @@ Do not use `@mapgen/*` in canonical docs or examples. This alias:
 ### 2) Deep imports into `src/` or `dist/`
 
 Do not import:
+
 - `@swooper/mapgen-core/src/...`
 - `@swooper/mapgen-core/dist/...`
 - relative paths that traverse package boundaries (e.g., `../../packages/mapgen-core/src/...`)
 
+### 3) Recipe deep imports into domain internals
+
+Do not import domain internals from recipe files, such as:
+
+- `@mapgen/domain/<domain>/shared/...`
+- `@mapgen/domain/<domain>/ops/<op>/...`
+- `@mapgen/domain/<domain>/rules/...`
+- `@mapgen/domain/<domain>/types.js`
+
+If recipe assembly needs those symbols, expose them through the domain root,
+`/ops`, or `/config.js` surface with a named owner.
+
 ## Why
 
 We’ve historically had “multiple architectures” emerge via imports:
+
 - docs using workspace-only TS path aliases,
 - examples relying on internal module layouts,
 - and downstream consumers copying these patterns.
@@ -66,4 +95,4 @@ This policy is the simplest guardrail that keeps the ecosystem coherent: use the
 - Exported entrypoints (source of truth for allowed imports): `packages/mapgen-core/package.json`
 - `@mapgen/*` is an internal/workspace alias, used inside the package: `packages/mapgen-core/src/engine/index.ts`
 - Target posture for packaging and boundaries: `docs/projects/engine-refactor-v1/resources/spec/SPEC-packaging-and-file-structure.md`
-
+- Recipe import guard: `scripts/lint/lint-mapgen-recipe-imports.sh`

--- a/mods/mod-swooper-maps/src/domain/foundation/config.ts
+++ b/mods/mod-swooper-maps/src/domain/foundation/config.ts
@@ -1,0 +1,2 @@
+export * from "./shared/knobs.js";
+export * from "./shared/knob-multipliers.js";

--- a/mods/mod-swooper-maps/src/domain/hydrology/config.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/config.ts
@@ -1,0 +1,2 @@
+export * from "./shared/knobs.js";
+export * from "./shared/knob-multipliers.js";

--- a/mods/mod-swooper-maps/src/domain/morphology/config.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/config.ts
@@ -1,5 +1,8 @@
 import { Type, type Static } from "@swooper/mapgen-core/authoring";
 
+export * from "./shared/knobs.js";
+export * from "./shared/knob-multipliers.js";
+
 /**
  * Plate-aware weighting for bay/fjord odds based on boundary closeness.
  */

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/biomes/viz.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology/steps/biomes/viz.ts
@@ -1,4 +1,4 @@
-import { BIOME_SYMBOL_ORDER } from "@mapgen/domain/ecology/types.js";
+import { BIOME_SYMBOL_ORDER } from "@mapgen/domain/ecology";
 
 // Stable, explicit categories/colors (no auto palette) for truth biomeIndex visualization.
 // Note: biomeIndex uses 255 as the water/unknown sentinel.
@@ -23,11 +23,12 @@ export function assertBiomeIndexVizCategoriesCoverSymbols(): void {
   const values = new Set(BIOME_INDEX_VIZ_CATEGORIES.map((c) => c.value));
   for (let i = 0; i <= maxSymbolValue; i++) {
     if (!values.has(i)) {
-      throw new Error(`BiomeIndex viz categories missing value=${i} (${BIOME_SYMBOL_ORDER[i] ?? "?"}).`);
+      throw new Error(
+        `BiomeIndex viz categories missing value=${i} (${BIOME_SYMBOL_ORDER[i] ?? "?"}).`
+      );
     }
   }
   if (!values.has(255)) {
     throw new Error("BiomeIndex viz categories missing sentinel value=255 (Water/Unknown).");
   }
 }
-

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/index.ts
@@ -14,7 +14,7 @@ import {
 import {
   FoundationPlateActivityKnobSchema,
   FoundationPlateCountKnobSchema,
-} from "@mapgen/domain/foundation/shared/knobs.js";
+} from "@mapgen/domain/foundation/config.js";
 
 export default createStage({
   id: "foundation",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/mesh.ts
@@ -3,7 +3,7 @@ import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { foundationArtifacts } from "../artifacts.js";
 import MeshStepContract from "./mesh.contract.js";
 import { validateMeshArtifact, wrapFoundationValidateNoDims } from "./validation.js";
-import type { FoundationPlateCountKnob } from "@mapgen/domain/foundation/shared/knobs.js";
+import type { FoundationPlateCountKnob } from "@mapgen/domain/foundation/config.js";
 import { interleaveXY, segmentsFromMeshNeighbors } from "./viz.js";
 
 const GROUP_MESH = "Foundation / Mesh";
@@ -23,19 +23,23 @@ export default createStep(MeshStepContract, {
       config.computeMesh.strategy === "default" && override !== undefined
         ? {
             ...config.computeMesh,
-	            config: {
-	              ...config.computeMesh.config,
-	              plateCount: clampInt(override, 2, 256),
-	            },
-	          }
-	        : config.computeMesh;
+            config: {
+              ...config.computeMesh.config,
+              plateCount: clampInt(override, 2, 256),
+            },
+          }
+        : config.computeMesh;
 
     return { ...config, computeMesh };
   },
   run: (context, config, ops, deps) => {
     const { width, height } = context.dimensions;
     const stepId = `${MeshStepContract.phase}/${MeshStepContract.id}`;
-    const rngSeed = ctxRandom(context, ctxRandomLabel(stepId, "foundation/compute-mesh"), 2_147_483_647);
+    const rngSeed = ctxRandom(
+      context,
+      ctxRandomLabel(stepId, "foundation/compute-mesh"),
+      2_147_483_647
+    );
 
     const meshResult = ops.computeMesh(
       {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateGraph.ts
@@ -3,7 +3,7 @@ import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { foundationArtifacts } from "../artifacts.js";
 import PlateGraphStepContract from "./plateGraph.contract.js";
 import { validatePlateGraphArtifact, wrapFoundationValidateNoDims } from "./validation.js";
-import type { FoundationPlateCountKnob } from "@mapgen/domain/foundation/shared/knobs.js";
+import type { FoundationPlateCountKnob } from "@mapgen/domain/foundation/config.js";
 import { interleaveXY, pointsFromPlateSeeds } from "./viz.js";
 
 const GROUP_PLATE_GRAPH = "Foundation / Plate Graph";
@@ -23,12 +23,12 @@ export default createStep(PlateGraphStepContract, {
       config.computePlateGraph.strategy === "default" && override !== undefined
         ? {
             ...config.computePlateGraph,
-	            config: {
-	              ...config.computePlateGraph.config,
-	              plateCount: clampInt(override, 2, 256),
-	            },
-	          }
-	        : config.computePlateGraph;
+            config: {
+              ...config.computePlateGraph.config,
+              plateCount: clampInt(override, 2, 256),
+            },
+          }
+        : config.computePlateGraph;
 
     return { ...config, computePlateGraph };
   },
@@ -36,7 +36,11 @@ export default createStep(PlateGraphStepContract, {
     const mesh = deps.artifacts.foundationMesh.read(context);
     const crust = deps.artifacts.foundationCrustInit.read(context);
     const stepId = `${PlateGraphStepContract.phase}/${PlateGraphStepContract.id}`;
-    const rngSeed = ctxRandom(context, ctxRandomLabel(stepId, "foundation/compute-plate-graph"), 2_147_483_647);
+    const rngSeed = ctxRandom(
+      context,
+      ctxRandomLabel(stepId, "foundation/compute-plate-graph"),
+      2_147_483_647
+    );
 
     const plateGraphResult = ops.computePlateGraph(
       {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts
@@ -1,4 +1,9 @@
-import { computeSampleStep, defineVizMeta, dumpVectorFieldVariants, renderAsciiGrid } from "@swooper/mapgen-core";
+import {
+  computeSampleStep,
+  defineVizMeta,
+  dumpVectorFieldVariants,
+  renderAsciiGrid,
+} from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { mapArtifacts } from "../../../map-artifacts.js";
 import ProjectionStepContract from "./projection.contract.js";
@@ -13,8 +18,8 @@ import {
 import {
   resolvePlateActivityBoundaryDelta,
   resolvePlateActivityKinematicsMultiplier,
-} from "@mapgen/domain/foundation/shared/knob-multipliers.js";
-import type { FoundationPlateActivityKnob } from "@mapgen/domain/foundation/shared/knobs.js";
+} from "@mapgen/domain/foundation/config.js";
+import type { FoundationPlateActivityKnob } from "@mapgen/domain/foundation/config.js";
 import { clampFinite, clampInt } from "@swooper/mapgen-core/lib/math";
 
 const GROUP_PLATES = "Foundation / Plates";
@@ -35,13 +40,16 @@ export default createStep(ProjectionStepContract, {
     ],
     {
       foundationPlates: {
-        validate: (value, context) => wrapFoundationValidate(value, context.dimensions, validatePlatesArtifact),
+        validate: (value, context) =>
+          wrapFoundationValidate(value, context.dimensions, validatePlatesArtifact),
       },
       foundationTileToCellIndex: {
-        validate: (value, context) => wrapFoundationValidate(value, context.dimensions, validateTileToCellIndexArtifact),
+        validate: (value, context) =>
+          wrapFoundationValidate(value, context.dimensions, validateTileToCellIndexArtifact),
       },
       foundationCrustTiles: {
-        validate: (value, context) => wrapFoundationValidate(value, context.dimensions, validateCrustTilesArtifact),
+        validate: (value, context) =>
+          wrapFoundationValidate(value, context.dimensions, validateCrustTilesArtifact),
       },
       foundationTectonicHistoryTiles: {
         validate: (value, context) =>
@@ -49,12 +57,18 @@ export default createStep(ProjectionStepContract, {
       },
       foundationTectonicProvenanceTiles: {
         validate: (value, context) =>
-          wrapFoundationValidate(value, context.dimensions, validateTectonicProvenanceTilesArtifact),
+          wrapFoundationValidate(
+            value,
+            context.dimensions,
+            validateTectonicProvenanceTilesArtifact
+          ),
       },
     }
   ),
   normalize: (config, ctx) => {
-    const { plateActivity } = ctx.knobs as Readonly<{ plateActivity?: FoundationPlateActivityKnob }>;
+    const { plateActivity } = ctx.knobs as Readonly<{
+      plateActivity?: FoundationPlateActivityKnob;
+    }>;
     const kinematicsMultiplier = resolvePlateActivityKinematicsMultiplier(plateActivity);
     const boundaryDelta = resolvePlateActivityBoundaryDelta(plateActivity);
 
@@ -62,17 +76,25 @@ export default createStep(ProjectionStepContract, {
       config.computePlates.strategy === "default"
         ? {
             ...config.computePlates,
-	            config: {
-	              ...config.computePlates.config,
-	              boundaryInfluenceDistance: clampInt(
-	                (config.computePlates.config.boundaryInfluenceDistance ?? 0) + boundaryDelta,
-	                1,
-	                32
-	              ),
-	              movementScale: clampFinite((config.computePlates.config.movementScale ?? 0) * kinematicsMultiplier, 1, 200),
-	              rotationScale: clampFinite((config.computePlates.config.rotationScale ?? 0) * kinematicsMultiplier, 1, 200),
-	            },
-	          }
+            config: {
+              ...config.computePlates.config,
+              boundaryInfluenceDistance: clampInt(
+                (config.computePlates.config.boundaryInfluenceDistance ?? 0) + boundaryDelta,
+                1,
+                32
+              ),
+              movementScale: clampFinite(
+                (config.computePlates.config.movementScale ?? 0) * kinematicsMultiplier,
+                1,
+                200
+              ),
+              rotationScale: clampFinite(
+                (config.computePlates.config.rotationScale ?? 0) * kinematicsMultiplier,
+                1,
+                200
+              ),
+            },
+          }
         : config.computePlates;
 
     return { ...config, computePlates };
@@ -105,8 +127,14 @@ export default createStep(ProjectionStepContract, {
     deps.artifacts.foundationPlates.publish(context, platesResult.plates);
     deps.artifacts.foundationTileToCellIndex.publish(context, platesResult.tileToCellIndex);
     deps.artifacts.foundationCrustTiles.publish(context, platesResult.crustTiles);
-    deps.artifacts.foundationTectonicHistoryTiles.publish(context, platesResult.tectonicHistoryTiles);
-    deps.artifacts.foundationTectonicProvenanceTiles.publish(context, platesResult.tectonicProvenanceTiles);
+    deps.artifacts.foundationTectonicHistoryTiles.publish(
+      context,
+      platesResult.tectonicHistoryTiles
+    );
+    deps.artifacts.foundationTectonicProvenanceTiles.publish(
+      context,
+      platesResult.tectonicProvenanceTiles
+    );
 
     context.viz?.dumpGrid(context.trace, {
       dataTypeKey: "foundation.plates.tilePlateId",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/index.ts
@@ -5,7 +5,7 @@ import {
   HydrologyOceanCouplingKnobSchema,
   HydrologySeasonalityKnobSchema,
   HydrologyTemperatureKnobSchema,
-} from "@mapgen/domain/hydrology/shared/knobs.js";
+} from "@mapgen/domain/hydrology/config.js";
 
 const knobsSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-baseline/steps/climateBaseline.ts
@@ -28,13 +28,13 @@ import {
   HYDROLOGY_TEMPERATURE_BASE_TEMPERATURE_C,
   HYDROLOGY_WATER_GRADIENT_LOWLAND_BONUS_BASE,
   HYDROLOGY_WATER_GRADIENT_PER_RING_BONUS_BASE,
-} from "@mapgen/domain/hydrology/shared/knob-multipliers.js";
+} from "@mapgen/domain/hydrology/config.js";
 import type {
   HydrologyDrynessKnob,
   HydrologyOceanCouplingKnob,
   HydrologySeasonalityKnob,
   HydrologyTemperatureKnob,
-} from "@mapgen/domain/hydrology/shared/knobs.js";
+} from "@mapgen/domain/hydrology/config.js";
 
 type ArtifactValidationIssue = Readonly<{ message: string }>;
 type TypedArrayConstructor = { new (...args: unknown[]): { length: number } };
@@ -120,8 +120,20 @@ function validateClimateSeasonalityPayload(
     errors.push({ message: "Expected climateSeasonality.axialTiltDeg to be a finite number." });
   }
 
-  validateTypedArray(errors, "climateSeasonality.rainfallAmplitude", candidate.rainfallAmplitude, Uint8Array, size);
-  validateTypedArray(errors, "climateSeasonality.humidityAmplitude", candidate.humidityAmplitude, Uint8Array, size);
+  validateTypedArray(
+    errors,
+    "climateSeasonality.rainfallAmplitude",
+    candidate.rainfallAmplitude,
+    Uint8Array,
+    size
+  );
+  validateTypedArray(
+    errors,
+    "climateSeasonality.humidityAmplitude",
+    candidate.humidityAmplitude,
+    Uint8Array,
+    size
+  );
   return errors;
 }
 
@@ -193,8 +205,7 @@ export default createStep(ClimateBaselineStepContract, {
       HYDROLOGY_SEASONALITY_WIND_JET_STREAKS[seasonality] -
       HYDROLOGY_SEASONALITY_WIND_JET_STREAKS.normal;
     const varianceFactor =
-      HYDROLOGY_SEASONALITY_WIND_VARIANCE[seasonality] /
-      HYDROLOGY_SEASONALITY_WIND_VARIANCE.normal;
+      HYDROLOGY_SEASONALITY_WIND_VARIANCE[seasonality] / HYDROLOGY_SEASONALITY_WIND_VARIANCE.normal;
     const noiseAmplitudeFactor =
       HYDROLOGY_SEASONALITY_PRECIP_NOISE_AMPLITUDE[seasonality] /
       HYDROLOGY_SEASONALITY_PRECIP_NOISE_AMPLITUDE.normal;
@@ -210,7 +221,8 @@ export default createStep(ClimateBaselineStepContract, {
       HYDROLOGY_OCEAN_COUPLING_MOISTURE_TRANSPORT_ITERATIONS[oceanCoupling] -
       HYDROLOGY_OCEAN_COUPLING_MOISTURE_TRANSPORT_ITERATIONS.earthlike;
 
-    const clampNumber = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
+    const clampNumber = (value: number, min: number, max: number): number =>
+      Math.max(min, Math.min(max, value));
 
     const computeThermalState =
       config.computeThermalState.strategy === "default"
@@ -220,7 +232,8 @@ export default createStep(ClimateBaselineStepContract, {
               ...config.computeThermalState.config,
               // Temperature knobs should not simply warm/cool the whole world uniformly (that erases tundra/snow).
               // Instead, bias the baseline modestly and put most of the adjustment into the equator-to-pole contrast.
-              baseTemperatureC: config.computeThermalState.config.baseTemperatureC + temperatureDeltaC * 0.5,
+              baseTemperatureC:
+                config.computeThermalState.config.baseTemperatureC + temperatureDeltaC * 0.5,
               insolationScaleC: clampNumber(
                 config.computeThermalState.config.insolationScaleC + temperatureDeltaC * 2,
                 0,
@@ -238,10 +251,13 @@ export default createStep(ClimateBaselineStepContract, {
             ...config.computeAtmosphericCirculation.config,
             windJetStreaks: Math.max(
               0,
-              Math.round(config.computeAtmosphericCirculation.config.windJetStreaks + jetStreakDelta)
+              Math.round(
+                config.computeAtmosphericCirculation.config.windJetStreaks + jetStreakDelta
+              )
             ),
             windVariance: config.computeAtmosphericCirculation.config.windVariance * varianceFactor,
-            windJetStrength: config.computeAtmosphericCirculation.config.windJetStrength * jetStrengthFactor,
+            windJetStrength:
+              config.computeAtmosphericCirculation.config.windJetStrength * jetStrengthFactor,
           },
         };
       }
@@ -267,7 +283,11 @@ export default createStep(ClimateBaselineStepContract, {
               0,
               400
             ),
-            waveStrength: clampNumber(config.computeAtmosphericCirculation.config.waveStrength * varianceFactor, 0, 300),
+            waveStrength: clampNumber(
+              config.computeAtmosphericCirculation.config.waveStrength * varianceFactor,
+              0,
+              300
+            ),
           },
         };
       }
@@ -336,7 +356,10 @@ export default createStep(ClimateBaselineStepContract, {
           ...config.transportMoisture,
           config: {
             ...config.transportMoisture.config,
-            iterations: Math.max(0, Math.round(config.transportMoisture.config.iterations + transportIterationsDelta)),
+            iterations: Math.max(
+              0,
+              Math.round(config.transportMoisture.config.iterations + transportIterationsDelta)
+            ),
           },
         };
       }
@@ -346,7 +369,10 @@ export default createStep(ClimateBaselineStepContract, {
           ...config.transportMoisture,
           config: {
             ...config.transportMoisture.config,
-            iterations: Math.max(0, Math.round(config.transportMoisture.config.iterations + transportIterationsDelta)),
+            iterations: Math.max(
+              0,
+              Math.round(config.transportMoisture.config.iterations + transportIterationsDelta)
+            ),
           },
         };
       }
@@ -369,22 +395,42 @@ export default createStep(ClimateBaselineStepContract, {
           config: {
             ...config.computePrecipitation.config,
             rainfallScale: config.computePrecipitation.config.rainfallScale * wetnessScale,
-            noiseAmplitude: config.computePrecipitation.config.noiseAmplitude * noiseAmplitudeFactor,
+            noiseAmplitude:
+              config.computePrecipitation.config.noiseAmplitude * noiseAmplitudeFactor,
             waterGradient: {
               ...config.computePrecipitation.config.waterGradient,
-              radius: Math.max(1, Math.round(config.computePrecipitation.config.waterGradient.radius + waterGradientRadiusDelta)),
+              radius: Math.max(
+                1,
+                Math.round(
+                  config.computePrecipitation.config.waterGradient.radius + waterGradientRadiusDelta
+                )
+              ),
               perRingBonus: Math.max(
                 0,
-                Math.round((config.computePrecipitation.config.waterGradient.perRingBonus + perRingBonusDelta) * wetnessScale)
+                Math.round(
+                  (config.computePrecipitation.config.waterGradient.perRingBonus +
+                    perRingBonusDelta) *
+                    wetnessScale
+                )
               ),
-              lowlandBonus: Math.max(0, Math.round(config.computePrecipitation.config.waterGradient.lowlandBonus * wetnessScale)),
+              lowlandBonus: Math.max(
+                0,
+                Math.round(
+                  config.computePrecipitation.config.waterGradient.lowlandBonus * wetnessScale
+                )
+              ),
             },
             orographic: {
               ...config.computePrecipitation.config.orographic,
-              reductionBase: Math.max(0, Math.round(config.computePrecipitation.config.orographic.reductionBase / scaleDenom)),
+              reductionBase: Math.max(
+                0,
+                Math.round(config.computePrecipitation.config.orographic.reductionBase / scaleDenom)
+              ),
               reductionPerStep: Math.max(
                 0,
-                Math.round(config.computePrecipitation.config.orographic.reductionPerStep / scaleDenom)
+                Math.round(
+                  config.computePrecipitation.config.orographic.reductionPerStep / scaleDenom
+                )
               ),
             },
           },
@@ -397,15 +443,30 @@ export default createStep(ClimateBaselineStepContract, {
           config: {
             ...config.computePrecipitation.config,
             rainfallScale: config.computePrecipitation.config.rainfallScale * wetnessScale,
-            noiseAmplitude: config.computePrecipitation.config.noiseAmplitude * noiseAmplitudeFactor,
+            noiseAmplitude:
+              config.computePrecipitation.config.noiseAmplitude * noiseAmplitudeFactor,
             waterGradient: {
               ...config.computePrecipitation.config.waterGradient,
-              radius: Math.max(1, Math.round(config.computePrecipitation.config.waterGradient.radius + waterGradientRadiusDelta)),
+              radius: Math.max(
+                1,
+                Math.round(
+                  config.computePrecipitation.config.waterGradient.radius + waterGradientRadiusDelta
+                )
+              ),
               perRingBonus: Math.max(
                 0,
-                Math.round((config.computePrecipitation.config.waterGradient.perRingBonus + perRingBonusDelta) * wetnessScale)
+                Math.round(
+                  (config.computePrecipitation.config.waterGradient.perRingBonus +
+                    perRingBonusDelta) *
+                    wetnessScale
+                )
               ),
-              lowlandBonus: Math.max(0, Math.round(config.computePrecipitation.config.waterGradient.lowlandBonus * wetnessScale)),
+              lowlandBonus: Math.max(
+                0,
+                Math.round(
+                  config.computePrecipitation.config.waterGradient.lowlandBonus * wetnessScale
+                )
+              ),
             },
           },
         };
@@ -480,16 +541,14 @@ export default createStep(ClimateBaselineStepContract, {
       config.transportMoisture.strategy === "default" ||
       config.computePrecipitation.strategy === "default";
 
-    let oceanGeometry:
-      | {
-          basinId: Int32Array;
-          coastDistance: Uint16Array;
-          coastNormalU: Int8Array;
-          coastNormalV: Int8Array;
-          coastTangentU: Int8Array;
-          coastTangentV: Int8Array;
-        }
-      | null = null;
+    let oceanGeometry: {
+      basinId: Int32Array;
+      coastDistance: Uint16Array;
+      coastNormalU: Int8Array;
+      coastNormalV: Int8Array;
+      coastTangentU: Int8Array;
+      coastTangentV: Int8Array;
+    } | null = null;
 
     if (useCirculationV2) {
       oceanGeometry = ops.computeOceanGeometry(
@@ -699,7 +758,10 @@ export default createStep(ClimateBaselineStepContract, {
         dataTypeKey: "hydrology.current.divergence",
         spaceId: TILE_SPACE_ID,
         dims: { width, height },
-        field: { format: "f32", values: estimateDivergenceOddQ(width, height, currentFx, currentFy) },
+        field: {
+          format: "f32",
+          values: estimateDivergenceOddQ(width, height, currentFx, currentFy),
+        },
         label: "Current Divergence (Proxy)",
         group: GROUP_CURRENT,
         palette: "continuous",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/index.ts
@@ -4,7 +4,7 @@ import {
   HydrologyCryosphereKnobSchema,
   HydrologyDrynessKnobSchema,
   HydrologyTemperatureKnobSchema,
-} from "@mapgen/domain/hydrology/shared/knobs.js";
+} from "@mapgen/domain/hydrology/config.js";
 
 const knobsSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/steps/climateRefine.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-climate-refine/steps/climateRefine.ts
@@ -1,4 +1,10 @@
-import { ctxRandom, ctxRandomLabel, defineVizMeta, dumpScalarFieldVariants, writeClimateField } from "@swooper/mapgen-core";
+import {
+  ctxRandom,
+  ctxRandomLabel,
+  defineVizMeta,
+  dumpScalarFieldVariants,
+  writeClimateField,
+} from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import ClimateRefineStepContract from "./climateRefine.contract.js";
 import { hydrologyClimateRefineArtifacts } from "../artifacts.js";
@@ -6,12 +12,12 @@ import { computeRiverAdjacencyMaskFromRiverClass } from "../../hydrology-hydrogr
 import {
   HYDROLOGY_DRYNESS_WETNESS_SCALE,
   HYDROLOGY_TEMPERATURE_BASE_TEMPERATURE_C,
-} from "@mapgen/domain/hydrology/shared/knob-multipliers.js";
+} from "@mapgen/domain/hydrology/config.js";
 import type {
   HydrologyCryosphereKnob,
   HydrologyDrynessKnob,
   HydrologyTemperatureKnob,
-} from "@mapgen/domain/hydrology/shared/knobs.js";
+} from "@mapgen/domain/hydrology/config.js";
 
 type ArtifactValidationIssue = Readonly<{ message: string }>;
 
@@ -46,7 +52,9 @@ function validateTypedArray(
     return;
   }
   if (expectedLength != null && value.length !== expectedLength) {
-    errors.push({ message: `Expected ${label} length ${expectedLength} (received ${value.length}).` });
+    errors.push({
+      message: `Expected ${label} length ${expectedLength} (received ${value.length}).`,
+    });
   }
 }
 
@@ -62,7 +70,8 @@ export default createStep(ClimateRefineStepContract, {
         validate: (value, context) => {
           const errors: ArtifactValidationIssue[] = [];
           const size = expectedSize(context.dimensions.width, context.dimensions.height);
-          if (!isRecord(value)) return [{ message: "Missing hydrology climate indices artifact payload." }];
+          if (!isRecord(value))
+            return [{ message: "Missing hydrology climate indices artifact payload." }];
           const candidate = value as {
             surfaceTemperatureC?: unknown;
             effectiveMoisture?: unknown;
@@ -70,11 +79,35 @@ export default createStep(ClimateRefineStepContract, {
             aridityIndex?: unknown;
             freezeIndex?: unknown;
           };
-          validateTypedArray(errors, "climateIndices.surfaceTemperatureC", candidate.surfaceTemperatureC, Float32Array, size);
-          validateTypedArray(errors, "climateIndices.effectiveMoisture", candidate.effectiveMoisture, Float32Array, size);
+          validateTypedArray(
+            errors,
+            "climateIndices.surfaceTemperatureC",
+            candidate.surfaceTemperatureC,
+            Float32Array,
+            size
+          );
+          validateTypedArray(
+            errors,
+            "climateIndices.effectiveMoisture",
+            candidate.effectiveMoisture,
+            Float32Array,
+            size
+          );
           validateTypedArray(errors, "climateIndices.pet", candidate.pet, Float32Array, size);
-          validateTypedArray(errors, "climateIndices.aridityIndex", candidate.aridityIndex, Float32Array, size);
-          validateTypedArray(errors, "climateIndices.freezeIndex", candidate.freezeIndex, Float32Array, size);
+          validateTypedArray(
+            errors,
+            "climateIndices.aridityIndex",
+            candidate.aridityIndex,
+            Float32Array,
+            size
+          );
+          validateTypedArray(
+            errors,
+            "climateIndices.freezeIndex",
+            candidate.freezeIndex,
+            Float32Array,
+            size
+          );
           return errors;
         },
       },
@@ -82,10 +115,21 @@ export default createStep(ClimateRefineStepContract, {
         validate: (value, context) => {
           const errors: ArtifactValidationIssue[] = [];
           const size = expectedSize(context.dimensions.width, context.dimensions.height);
-          if (!isRecord(value)) return [{ message: "Missing hydrology cryosphere artifact payload." }];
-          const candidate = value as { snowCover?: unknown; seaIceCover?: unknown; albedo?: unknown };
+          if (!isRecord(value))
+            return [{ message: "Missing hydrology cryosphere artifact payload." }];
+          const candidate = value as {
+            snowCover?: unknown;
+            seaIceCover?: unknown;
+            albedo?: unknown;
+          };
           validateTypedArray(errors, "cryosphere.snowCover", candidate.snowCover, Uint8Array, size);
-          validateTypedArray(errors, "cryosphere.seaIceCover", candidate.seaIceCover, Uint8Array, size);
+          validateTypedArray(
+            errors,
+            "cryosphere.seaIceCover",
+            candidate.seaIceCover,
+            Uint8Array,
+            size
+          );
           validateTypedArray(errors, "cryosphere.albedo", candidate.albedo, Uint8Array, size);
           return errors;
         },
@@ -94,15 +138,34 @@ export default createStep(ClimateRefineStepContract, {
         validate: (value, context) => {
           const errors: ArtifactValidationIssue[] = [];
           const size = expectedSize(context.dimensions.width, context.dimensions.height);
-          if (!isRecord(value)) return [{ message: "Missing hydrology climate diagnostics artifact payload." }];
+          if (!isRecord(value))
+            return [{ message: "Missing hydrology climate diagnostics artifact payload." }];
           const candidate = value as {
             rainShadowIndex?: unknown;
             continentalityIndex?: unknown;
             convergenceIndex?: unknown;
           };
-          validateTypedArray(errors, "climateDiagnostics.rainShadowIndex", candidate.rainShadowIndex, Float32Array, size);
-          validateTypedArray(errors, "climateDiagnostics.continentalityIndex", candidate.continentalityIndex, Float32Array, size);
-          validateTypedArray(errors, "climateDiagnostics.convergenceIndex", candidate.convergenceIndex, Float32Array, size);
+          validateTypedArray(
+            errors,
+            "climateDiagnostics.rainShadowIndex",
+            candidate.rainShadowIndex,
+            Float32Array,
+            size
+          );
+          validateTypedArray(
+            errors,
+            "climateDiagnostics.continentalityIndex",
+            candidate.continentalityIndex,
+            Float32Array,
+            size
+          );
+          validateTypedArray(
+            errors,
+            "climateDiagnostics.convergenceIndex",
+            candidate.convergenceIndex,
+            Float32Array,
+            size
+          );
           return errors;
         },
       },
@@ -130,7 +193,10 @@ export default createStep(ClimateRefineStepContract, {
             // Temperature knobs should not simply warm/cool the whole world uniformly (that erases tundra/snow).
             // Instead, bias the baseline modestly and put most of the adjustment into the equator-to-pole contrast.
             baseTemperatureC: next.computeThermalState.config.baseTemperatureC + deltaC * 0.5,
-            insolationScaleC: Math.max(0, Math.min(80, next.computeThermalState.config.insolationScaleC + deltaC * 2)),
+            insolationScaleC: Math.max(
+              0,
+              Math.min(80, next.computeThermalState.config.insolationScaleC + deltaC * 2)
+            ),
           },
         };
       }
@@ -144,8 +210,12 @@ export default createStep(ClimateRefineStepContract, {
           ...cur,
           riverCorridor: {
             ...cur.riverCorridor,
-            lowlandAdjacencyBonus: Math.round(cur.riverCorridor.lowlandAdjacencyBonus * wetnessScale),
-            highlandAdjacencyBonus: Math.round(cur.riverCorridor.highlandAdjacencyBonus * wetnessScale),
+            lowlandAdjacencyBonus: Math.round(
+              cur.riverCorridor.lowlandAdjacencyBonus * wetnessScale
+            ),
+            highlandAdjacencyBonus: Math.round(
+              cur.riverCorridor.highlandAdjacencyBonus * wetnessScale
+            ),
           },
           lowBasin: {
             ...cur.lowBasin,
@@ -281,10 +351,14 @@ export default createStep(ClimateRefineStepContract, {
       const rainfall = refined.rainfall[i] ?? 0;
       const humidity = refined.humidity[i] ?? 0;
       const riparianBonus = riparianBonusByTile[i] ?? 0;
-      effectiveMoisture[i] = rainfall + EFFECTIVE_MOISTURE_HUMIDITY_WEIGHT * humidity + riparianBonus;
+      effectiveMoisture[i] =
+        rainfall + EFFECTIVE_MOISTURE_HUMIDITY_WEIGHT * humidity + riparianBonus;
     }
 
-    const forcing = ops.computeRadiativeForcing({ width, height, latitudeByRow }, config.computeRadiativeForcing);
+    const forcing = ops.computeRadiativeForcing(
+      { width, height, latitudeByRow },
+      config.computeRadiativeForcing
+    );
     const thermal = ops.computeThermalState(
       {
         width,
@@ -563,6 +637,5 @@ export default createStep(ClimateRefineStepContract, {
       continentalityIndex: diagnostics.continentalityIndex,
       convergenceIndex: diagnostics.convergenceIndex,
     });
-
   },
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/index.ts
@@ -1,8 +1,6 @@
 import { Type, createStage } from "@swooper/mapgen-core/authoring";
 import { rivers } from "./steps/index.js";
-import {
-  HydrologyRiverDensityKnobSchema,
-} from "@mapgen/domain/hydrology/shared/knobs.js";
+import { HydrologyRiverDensityKnobSchema } from "@mapgen/domain/hydrology/config.js";
 
 const knobsSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/rivers.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/rivers.ts
@@ -7,8 +7,8 @@ import RiversStepContract from "./rivers.contract.js";
 import {
   HYDROLOGY_RIVER_DENSITY_MAJOR_PERCENTILE,
   HYDROLOGY_RIVER_DENSITY_MINOR_PERCENTILE,
-} from "@mapgen/domain/hydrology/shared/knob-multipliers.js";
-import type { HydrologyRiverDensityKnob } from "@mapgen/domain/hydrology/shared/knobs.js";
+} from "@mapgen/domain/hydrology/config.js";
+import type { HydrologyRiverDensityKnob } from "@mapgen/domain/hydrology/config.js";
 
 type ArtifactValidationIssue = Readonly<{ message: string }>;
 
@@ -62,7 +62,8 @@ function validateHydrography(value: unknown, dimensions: MapDimensions): Artifac
   validateTypedArray(errors, "hydrography.riverClass", candidate.riverClass, Uint8Array, size);
   validateTypedArray(errors, "hydrography.sinkMask", candidate.sinkMask, Uint8Array, size);
   validateTypedArray(errors, "hydrography.outletMask", candidate.outletMask, Uint8Array, size);
-  if (candidate.basinId != null) validateTypedArray(errors, "hydrography.basinId", candidate.basinId, Int32Array, size);
+  if (candidate.basinId != null)
+    validateTypedArray(errors, "hydrography.basinId", candidate.basinId, Int32Array, size);
   return errors;
 }
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-biomes/viz.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plot-biomes/viz.ts
@@ -1,5 +1,4 @@
-import type { BiomeSymbol } from "@mapgen/domain/ecology";
-import { BIOME_SYMBOL_ORDER } from "@mapgen/domain/ecology/types.js";
+import { BIOME_SYMBOL_ORDER, type BiomeSymbol } from "@mapgen/domain/ecology";
 
 import { BIOME_INDEX_VIZ_CATEGORIES } from "../../../ecology/steps/biomes/viz.js";
 
@@ -47,7 +46,9 @@ export function buildEngineBiomeIdVizCategories(args: {
 
   const out: VizCategory[] = [];
   for (const [engineId, bucket] of byEngineId.entries()) {
-    const symbols = bucket.symbols.slice().sort((a, b) => BIOME_SYMBOL_ORDER.indexOf(a) - BIOME_SYMBOL_ORDER.indexOf(b));
+    const symbols = bucket.symbols
+      .slice()
+      .sort((a, b) => BIOME_SYMBOL_ORDER.indexOf(a) - BIOME_SYMBOL_ORDER.indexOf(b));
     const labelParts: string[] = [...symbols];
     if (bucket.marine) labelParts.push(MARINE_LABEL);
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/index.ts
@@ -2,7 +2,7 @@ import { Type, createStage } from "@swooper/mapgen-core/authoring";
 import {
   HydrologyLakeinessKnobSchema,
   HydrologyRiverDensityKnobSchema,
-} from "@mapgen/domain/hydrology/shared/knobs.js";
+} from "@mapgen/domain/hydrology/config.js";
 import { lakes, plotRivers } from "./steps/index.js";
 
 const knobsSchema = Type.Object(

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.ts
@@ -2,8 +2,8 @@ import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { defineVizMeta, snapshotEngineHeightfield } from "@swooper/mapgen-core";
 import { getStandardRuntime } from "../../../runtime.js";
 import LakesStepContract from "./lakes.contract.js";
-import { HYDROLOGY_LAKEINESS_TILES_PER_LAKE_MULTIPLIER } from "@mapgen/domain/hydrology/shared/knob-multipliers.js";
-import type { HydrologyLakeinessKnob } from "@mapgen/domain/hydrology/shared/knobs.js";
+import { HYDROLOGY_LAKEINESS_TILES_PER_LAKE_MULTIPLIER } from "@mapgen/domain/hydrology/config.js";
+import type { HydrologyLakeinessKnob } from "@mapgen/domain/hydrology/config.js";
 import { hydrologyHydrographyArtifacts } from "../../hydrology-hydrography/artifacts.js";
 import { mapArtifacts } from "../../../map-artifacts.js";
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/plotRivers.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/plotRivers.ts
@@ -8,10 +8,8 @@ import {
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { clampInt } from "@swooper/mapgen-core/lib/math";
 import PlotRiversStepContract from "./plotRivers.contract.js";
-import {
-  HYDROLOGY_RIVER_DENSITY_LENGTH_BOUNDS,
-} from "@mapgen/domain/hydrology/shared/knob-multipliers.js";
-import type { HydrologyRiverDensityKnob } from "@mapgen/domain/hydrology/shared/knobs.js";
+import { HYDROLOGY_RIVER_DENSITY_LENGTH_BOUNDS } from "@mapgen/domain/hydrology/config.js";
+import type { HydrologyRiverDensityKnob } from "@mapgen/domain/hydrology/config.js";
 import { hydrologyHydrographyArtifacts } from "../../hydrology-hydrography/artifacts.js";
 import { mapArtifacts } from "../../../map-artifacts.js";
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/index.ts
@@ -1,6 +1,12 @@
 import { Type, createStage, type Static } from "@swooper/mapgen-core/authoring";
-import { buildElevation, plotCoasts, plotContinents, plotMountains, plotVolcanoes } from "./steps/index.js";
-import { MorphologyOrogenyKnobSchema } from "@mapgen/domain/morphology/shared/knobs.js";
+import {
+  buildElevation,
+  plotCoasts,
+  plotContinents,
+  plotMountains,
+  plotVolcanoes,
+} from "./steps/index.js";
+import { MorphologyOrogenyKnobSchema } from "@mapgen/domain/morphology/config.js";
 
 const publicSchema = Type.Object(
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotMountains.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotMountains.ts
@@ -19,19 +19,14 @@ import {
   MORPHOLOGY_OROGENY_HILL_THRESHOLD_DELTA,
   MORPHOLOGY_OROGENY_MOUNTAIN_THRESHOLD_DELTA,
   MORPHOLOGY_OROGENY_TECTONIC_INTENSITY_MULTIPLIER,
-} from "@mapgen/domain/morphology/shared/knob-multipliers.js";
-import type { MorphologyOrogenyKnob } from "@mapgen/domain/morphology/shared/knobs.js";
+} from "@mapgen/domain/morphology/config.js";
+import type { MorphologyOrogenyKnob } from "@mapgen/domain/morphology/config.js";
 
 const GROUP_MAP_MORPHOLOGY = "Map / Morphology (Engine)";
 const GROUP_BELT_DRIVERS = "Morphology / Belt Drivers";
 const TILE_SPACE_ID = "tile.hexOddR" as const;
 
-function buildFractalArray(
-  width: number,
-  height: number,
-  seed: number,
-  grain: number
-): Int16Array {
+function buildFractalArray(width: number, height: number, seed: number, grain: number): Int16Array {
   const fractal = new Int16Array(width * height);
   const perlin = new PerlinNoise(seed | 0);
   const scale = 1 / Math.max(1, Math.round(grain));
@@ -50,7 +45,8 @@ export default createStep(PlotMountainsStepContract, {
   normalize: (config, ctx) => {
     const { orogeny } = ctx.knobs as Readonly<{ orogeny?: MorphologyOrogenyKnob }>;
     const multiplier = MORPHOLOGY_OROGENY_TECTONIC_INTENSITY_MULTIPLIER[orogeny ?? "normal"] ?? 1.0;
-    const mountainThresholdDelta = MORPHOLOGY_OROGENY_MOUNTAIN_THRESHOLD_DELTA[orogeny ?? "normal"] ?? 0;
+    const mountainThresholdDelta =
+      MORPHOLOGY_OROGENY_MOUNTAIN_THRESHOLD_DELTA[orogeny ?? "normal"] ?? 0;
     const hillThresholdDelta = MORPHOLOGY_OROGENY_HILL_THRESHOLD_DELTA[orogeny ?? "normal"] ?? 0;
 
     const ridgesSelection =
@@ -59,9 +55,18 @@ export default createStep(PlotMountainsStepContract, {
             ...config.ridges,
             config: {
               ...config.ridges.config,
-              tectonicIntensity: clampFinite(config.ridges.config.tectonicIntensity * multiplier, 0),
-              mountainThreshold: clampFinite(config.ridges.config.mountainThreshold + mountainThresholdDelta, 0),
-              hillThreshold: clampFinite(config.ridges.config.hillThreshold + hillThresholdDelta, 0),
+              tectonicIntensity: clampFinite(
+                config.ridges.config.tectonicIntensity * multiplier,
+                0
+              ),
+              mountainThreshold: clampFinite(
+                config.ridges.config.mountainThreshold + mountainThresholdDelta,
+                0
+              ),
+              hillThreshold: clampFinite(
+                config.ridges.config.hillThreshold + hillThresholdDelta,
+                0
+              ),
             },
           }
         : config.ridges;
@@ -72,12 +77,18 @@ export default createStep(PlotMountainsStepContract, {
             ...config.foothills,
             config: {
               ...config.foothills.config,
-              tectonicIntensity: clampFinite(config.foothills.config.tectonicIntensity * multiplier, 0),
+              tectonicIntensity: clampFinite(
+                config.foothills.config.tectonicIntensity * multiplier,
+                0
+              ),
               mountainThreshold: clampFinite(
                 config.foothills.config.mountainThreshold + mountainThresholdDelta,
                 0
               ),
-              hillThreshold: clampFinite(config.foothills.config.hillThreshold + hillThresholdDelta, 0),
+              hillThreshold: clampFinite(
+                config.foothills.config.hillThreshold + hillThresholdDelta,
+                0
+              ),
             },
           }
         : config.foothills;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/index.ts
@@ -4,7 +4,7 @@ import {
   MorphologyCoastRuggednessKnobSchema,
   MorphologySeaLevelKnobSchema,
   MorphologyShelfWidthKnobSchema,
-} from "@mapgen/domain/morphology/shared/knobs.js";
+} from "@mapgen/domain/morphology/config.js";
 
 /**
  * Morphology-coasts knobs (seaLevel/coastRuggedness/shelfWidth).

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/landmassPlates.ts
@@ -1,10 +1,16 @@
-import { computeSampleStep, ctxRandom, ctxRandomLabel, defineVizMeta, renderAsciiGrid } from "@swooper/mapgen-core";
+import {
+  computeSampleStep,
+  ctxRandom,
+  ctxRandomLabel,
+  defineVizMeta,
+  renderAsciiGrid,
+} from "@swooper/mapgen-core";
 import type { MapDimensions } from "@civ7/adapter";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { clampFinite, clampInt16, roundHalfAwayFromZero } from "@swooper/mapgen-core/lib/math";
 import LandmassPlatesStepContract from "./landmassPlates.contract.js";
-import { MORPHOLOGY_SEA_LEVEL_TARGET_WATER_PERCENT_DELTA } from "@mapgen/domain/morphology/shared/knob-multipliers.js";
-import type { MorphologySeaLevelKnob } from "@mapgen/domain/morphology/shared/knobs.js";
+import { MORPHOLOGY_SEA_LEVEL_TARGET_WATER_PERCENT_DELTA } from "@mapgen/domain/morphology/config.js";
+import type { MorphologySeaLevelKnob } from "@mapgen/domain/morphology/config.js";
 
 type ArtifactValidationIssue = Readonly<{ message: string }>;
 
@@ -40,7 +46,10 @@ function validateTypedArray(
   return true;
 }
 
-function validateHeightfieldBuffer(value: unknown, dimensions: MapDimensions): ArtifactValidationIssue[] {
+function validateHeightfieldBuffer(
+  value: unknown,
+  dimensions: MapDimensions
+): ArtifactValidationIssue[] {
   const errors: ArtifactValidationIssue[] = [];
   if (!isRecord(value)) {
     errors.push({ message: "Missing heightfield buffer." });
@@ -62,7 +71,10 @@ function validateHeightfieldBuffer(value: unknown, dimensions: MapDimensions): A
   return errors;
 }
 
-function validateSubstrateBuffer(value: unknown, dimensions: MapDimensions): ArtifactValidationIssue[] {
+function validateSubstrateBuffer(
+  value: unknown,
+  dimensions: MapDimensions
+): ArtifactValidationIssue[] {
   const errors: ArtifactValidationIssue[] = [];
   if (!isRecord(value)) {
     errors.push({ message: "Missing substrate buffer." });
@@ -71,11 +83,20 @@ function validateSubstrateBuffer(value: unknown, dimensions: MapDimensions): Art
   const size = expectedSize(dimensions);
   const candidate = value as { erodibilityK?: unknown; sedimentDepth?: unknown };
   validateTypedArray(errors, "substrate.erodibilityK", candidate.erodibilityK, Float32Array, size);
-  validateTypedArray(errors, "substrate.sedimentDepth", candidate.sedimentDepth, Float32Array, size);
+  validateTypedArray(
+    errors,
+    "substrate.sedimentDepth",
+    candidate.sedimentDepth,
+    Float32Array,
+    size
+  );
   return errors;
 }
 
-function validateBeltDriversBuffer(value: unknown, dimensions: MapDimensions): ArtifactValidationIssue[] {
+function validateBeltDriversBuffer(
+  value: unknown,
+  dimensions: MapDimensions
+): ArtifactValidationIssue[] {
   const errors: ArtifactValidationIssue[] = [];
   if (!isRecord(value)) {
     errors.push({ message: "Missing beltDrivers buffer." });
@@ -97,18 +118,60 @@ function validateBeltDriversBuffer(value: unknown, dimensions: MapDimensions): A
     beltNearestSeed?: unknown;
     beltComponents?: unknown;
   };
-  validateTypedArray(errors, "beltDrivers.boundaryCloseness", candidate.boundaryCloseness, Uint8Array, size);
+  validateTypedArray(
+    errors,
+    "beltDrivers.boundaryCloseness",
+    candidate.boundaryCloseness,
+    Uint8Array,
+    size
+  );
   validateTypedArray(errors, "beltDrivers.boundaryType", candidate.boundaryType, Uint8Array, size);
-  validateTypedArray(errors, "beltDrivers.upliftPotential", candidate.upliftPotential, Uint8Array, size);
-  validateTypedArray(errors, "beltDrivers.collisionPotential", candidate.collisionPotential, Uint8Array, size);
-  validateTypedArray(errors, "beltDrivers.subductionPotential", candidate.subductionPotential, Uint8Array, size);
-  validateTypedArray(errors, "beltDrivers.riftPotential", candidate.riftPotential, Uint8Array, size);
-  validateTypedArray(errors, "beltDrivers.tectonicStress", candidate.tectonicStress, Uint8Array, size);
+  validateTypedArray(
+    errors,
+    "beltDrivers.upliftPotential",
+    candidate.upliftPotential,
+    Uint8Array,
+    size
+  );
+  validateTypedArray(
+    errors,
+    "beltDrivers.collisionPotential",
+    candidate.collisionPotential,
+    Uint8Array,
+    size
+  );
+  validateTypedArray(
+    errors,
+    "beltDrivers.subductionPotential",
+    candidate.subductionPotential,
+    Uint8Array,
+    size
+  );
+  validateTypedArray(
+    errors,
+    "beltDrivers.riftPotential",
+    candidate.riftPotential,
+    Uint8Array,
+    size
+  );
+  validateTypedArray(
+    errors,
+    "beltDrivers.tectonicStress",
+    candidate.tectonicStress,
+    Uint8Array,
+    size
+  );
   validateTypedArray(errors, "beltDrivers.beltAge", candidate.beltAge, Uint8Array, size);
   validateTypedArray(errors, "beltDrivers.dominantEra", candidate.dominantEra, Uint8Array, size);
   validateTypedArray(errors, "beltDrivers.beltMask", candidate.beltMask, Uint8Array, size);
   validateTypedArray(errors, "beltDrivers.beltDistance", candidate.beltDistance, Uint8Array, size);
-  validateTypedArray(errors, "beltDrivers.beltNearestSeed", candidate.beltNearestSeed, Int32Array, size);
+  validateTypedArray(
+    errors,
+    "beltDrivers.beltNearestSeed",
+    candidate.beltNearestSeed,
+    Int32Array,
+    size
+  );
   if (!Array.isArray(candidate.beltComponents)) {
     errors.push({ message: "Expected beltDrivers.beltComponents to be an array." });
   }
@@ -167,7 +230,11 @@ export default createStep(LandmassPlatesStepContract, {
             ...config.seaLevel,
             config: {
               ...config.seaLevel.config,
-              targetWaterPercent: clampFinite((config.seaLevel.config.targetWaterPercent ?? 0) + delta, 0, 100),
+              targetWaterPercent: clampFinite(
+                (config.seaLevel.config.targetWaterPercent ?? 0) + delta,
+                0,
+                100
+              ),
             },
           }
         : config.seaLevel;
@@ -213,7 +280,11 @@ export default createStep(LandmassPlatesStepContract, {
         boundaryCloseness: beltDrivers.boundaryCloseness,
         upliftPotential: beltDrivers.upliftPotential,
         riftPotential: beltDrivers.riftPotential,
-        rngSeed: ctxRandom(context, ctxRandomLabel(stepId, "morphology/compute-base-topography"), 2_147_483_647),
+        rngSeed: ctxRandom(
+          context,
+          ctxRandomLabel(stepId, "morphology/compute-base-topography"),
+          2_147_483_647
+        ),
       },
       config.baseTopography
     );
@@ -226,7 +297,11 @@ export default createStep(LandmassPlatesStepContract, {
         crustType: crustTiles.type,
         boundaryCloseness: beltDrivers.boundaryCloseness,
         upliftPotential: beltDrivers.upliftPotential,
-        rngSeed: ctxRandom(context, ctxRandomLabel(stepId, "morphology/compute-sea-level"), 2_147_483_647),
+        rngSeed: ctxRandom(
+          context,
+          ctxRandomLabel(stepId, "morphology/compute-sea-level"),
+          2_147_483_647
+        ),
       },
       config.seaLevel
     );

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/steps/ruggedCoasts.ts
@@ -8,11 +8,11 @@ import { clampFinite, clampInt16, roundHalfAwayFromZero } from "@swooper/mapgen-
 import {
   MORPHOLOGY_COAST_RUGGEDNESS_MULTIPLIER,
   MORPHOLOGY_SHELF_WIDTH_MULTIPLIER,
-} from "@mapgen/domain/morphology/shared/knob-multipliers.js";
+} from "@mapgen/domain/morphology/config.js";
 import type {
   MorphologyCoastRuggednessKnob,
   MorphologyShelfWidthKnob,
-} from "@mapgen/domain/morphology/shared/knobs.js";
+} from "@mapgen/domain/morphology/config.js";
 
 type ArtifactValidationIssue = Readonly<{ message: string }>;
 
@@ -47,7 +47,10 @@ function validateTypedArray(
   return true;
 }
 
-function validateCoastlineMetrics(value: unknown, dimensions: MapDimensions): ArtifactValidationIssue[] {
+function validateCoastlineMetrics(
+  value: unknown,
+  dimensions: MapDimensions
+): ArtifactValidationIssue[] {
   const errors: ArtifactValidationIssue[] = [];
   if (!isRecord(value)) {
     errors.push({ message: "Missing coastline metrics." });
@@ -60,10 +63,28 @@ function validateCoastlineMetrics(value: unknown, dimensions: MapDimensions): Ar
     shelfMask?: unknown;
     distanceToCoast?: unknown;
   };
-  validateTypedArray(errors, "coastlineMetrics.coastalLand", candidate.coastalLand, Uint8Array, size);
-  validateTypedArray(errors, "coastlineMetrics.coastalWater", candidate.coastalWater, Uint8Array, size);
+  validateTypedArray(
+    errors,
+    "coastlineMetrics.coastalLand",
+    candidate.coastalLand,
+    Uint8Array,
+    size
+  );
+  validateTypedArray(
+    errors,
+    "coastlineMetrics.coastalWater",
+    candidate.coastalWater,
+    Uint8Array,
+    size
+  );
   validateTypedArray(errors, "coastlineMetrics.shelfMask", candidate.shelfMask, Uint8Array, size);
-  validateTypedArray(errors, "coastlineMetrics.distanceToCoast", candidate.distanceToCoast, Uint16Array, size);
+  validateTypedArray(
+    errors,
+    "coastlineMetrics.distanceToCoast",
+    candidate.distanceToCoast,
+    Uint16Array,
+    size
+  );
   return errors;
 }
 
@@ -124,9 +145,18 @@ export default createStep(RuggedCoastsStepContract, {
                 ...config.coastlines.config.coast,
                 plateBias: {
                   ...config.coastlines.config.coast.plateBias,
-                  bayWeight: clampFinite(config.coastlines.config.coast.plateBias.bayWeight * multiplier, 0),
-                  bayNoiseBonus: clampFinite(config.coastlines.config.coast.plateBias.bayNoiseBonus * multiplier, 0),
-                  fjordWeight: clampFinite(config.coastlines.config.coast.plateBias.fjordWeight * multiplier, 0),
+                  bayWeight: clampFinite(
+                    config.coastlines.config.coast.plateBias.bayWeight * multiplier,
+                    0
+                  ),
+                  bayNoiseBonus: clampFinite(
+                    config.coastlines.config.coast.plateBias.bayNoiseBonus * multiplier,
+                    0
+                  ),
+                  fjordWeight: clampFinite(
+                    config.coastlines.config.coast.plateBias.fjordWeight * multiplier,
+                    0
+                  ),
                 },
               },
             },
@@ -162,7 +192,10 @@ export default createStep(RuggedCoastsStepContract, {
   run: (context, config, ops, deps) => {
     const { width, height } = context.dimensions;
     const beltDrivers = deps.artifacts.beltDrivers.read(context);
-    const topography = deps.artifacts.topography.read(context) as { seaLevel?: number; bathymetry?: Int16Array };
+    const topography = deps.artifacts.topography.read(context) as {
+      seaLevel?: number;
+      bathymetry?: Int16Array;
+    };
     const heightfield = context.buffers.heightfield;
     const rngSeed = deriveStepSeed(context.env.seed, "morphology:computeCoastlineMetrics");
 
@@ -290,7 +323,10 @@ export default createStep(RuggedCoastsStepContract, {
     if (!(capTilesByTile instanceof Uint8Array) || capTilesByTile.length !== coastal.length) {
       throw new Error("Computed capTilesByTile missing or shape-mismatched.");
     }
-    if (!(nearshoreCandidateMask instanceof Uint8Array) || nearshoreCandidateMask.length !== coastal.length) {
+    if (
+      !(nearshoreCandidateMask instanceof Uint8Array) ||
+      nearshoreCandidateMask.length !== coastal.length
+    ) {
       throw new Error("Computed nearshoreCandidateMask missing or shape-mismatched.");
     }
     if (!(depthGateMask instanceof Uint8Array) || depthGateMask.length !== coastal.length) {
@@ -418,7 +454,8 @@ export default createStep(RuggedCoastsStepContract, {
       meta: defineVizMeta("morphology.shelf.activeMarginMask", {
         label: "Active Margin Mask",
         group: GROUP_SHELF,
-        description: "Tiles treated as active margins (convergent/transform with high boundary closeness).",
+        description:
+          "Tiles treated as active margins (convergent/transform with high boundary closeness).",
         role: "membership",
         palette: "categorical",
         categories: [
@@ -437,7 +474,8 @@ export default createStep(RuggedCoastsStepContract, {
       meta: defineVizMeta("morphology.shelf.capTiles", {
         label: "Shelf Distance Cap (Tiles)",
         group: GROUP_SHELF,
-        description: "Per-tile max distance to coast used by the shelf classifier (active margins narrower).",
+        description:
+          "Per-tile max distance to coast used by the shelf classifier (active margins narrower).",
         role: "membership",
         palette: "continuous",
       }),
@@ -453,7 +491,8 @@ export default createStep(RuggedCoastsStepContract, {
         label: "Nearshore Candidates",
         group: GROUP_SHELF,
         visibility: "debug",
-        description: "Water tiles within nearshoreDistance, used to sample bathymetry for shallowCutoff.",
+        description:
+          "Water tiles within nearshoreDistance, used to sample bathymetry for shallowCutoff.",
         role: "membership",
         palette: "categorical",
         categories: [
@@ -473,7 +512,8 @@ export default createStep(RuggedCoastsStepContract, {
         label: "Depth Gate (Shallow Enough)",
         group: GROUP_SHELF,
         visibility: "debug",
-        description: "Water tiles where bathymetry >= shallowCutoff (shallower than the selected cutoff).",
+        description:
+          "Water tiles where bathymetry >= shallowCutoff (shallower than the selected cutoff).",
         role: "membership",
         palette: "categorical",
         categories: [

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/index.ts
@@ -1,6 +1,6 @@
 import { Type, createStage } from "@swooper/mapgen-core/authoring";
 import { geomorphology } from "./steps/index.js";
-import { MorphologyErosionKnobSchema } from "@mapgen/domain/morphology/shared/knobs.js";
+import { MorphologyErosionKnobSchema } from "@mapgen/domain/morphology/config.js";
 
 /**
  * Morphology-erosion knobs (erosion). Knobs apply after defaulted step config as deterministic transforms.

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/steps/geomorphology.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/steps/geomorphology.ts
@@ -1,10 +1,17 @@
-import { BYTE_SHADE_RAMP, computeSampleStep, defineVizMeta, dumpScalarFieldVariants, renderAsciiGrid, shadeByte } from "@swooper/mapgen-core";
+import {
+  BYTE_SHADE_RAMP,
+  computeSampleStep,
+  defineVizMeta,
+  dumpScalarFieldVariants,
+  renderAsciiGrid,
+  shadeByte,
+} from "@swooper/mapgen-core";
 import { createStep } from "@swooper/mapgen-core/authoring";
 import { clampFinite, clampInt16, roundHalfAwayFromZero } from "@swooper/mapgen-core/lib/math";
 
 import GeomorphologyStepContract from "./geomorphology.contract.js";
-import { MORPHOLOGY_EROSION_RATE_MULTIPLIER } from "@mapgen/domain/morphology/shared/knob-multipliers.js";
-import type { MorphologyErosionKnob } from "@mapgen/domain/morphology/shared/knobs.js";
+import { MORPHOLOGY_EROSION_RATE_MULTIPLIER } from "@mapgen/domain/morphology/config.js";
+import type { MorphologyErosionKnob } from "@mapgen/domain/morphology/config.js";
 
 const GROUP_GEOMORPHOLOGY = "Morphology / Geomorphology";
 const TILE_SPACE_ID = "tile.hexOddR" as const;
@@ -24,15 +31,24 @@ export default createStep(GeomorphologyStepContract, {
                 ...config.geomorphology.config.geomorphology,
                 fluvial: {
                   ...config.geomorphology.config.geomorphology.fluvial,
-                  rate: clampFinite(config.geomorphology.config.geomorphology.fluvial.rate * multiplier, 0),
+                  rate: clampFinite(
+                    config.geomorphology.config.geomorphology.fluvial.rate * multiplier,
+                    0
+                  ),
                 },
                 diffusion: {
                   ...config.geomorphology.config.geomorphology.diffusion,
-                  rate: clampFinite(config.geomorphology.config.geomorphology.diffusion.rate * multiplier, 0),
+                  rate: clampFinite(
+                    config.geomorphology.config.geomorphology.diffusion.rate * multiplier,
+                    0
+                  ),
                 },
                 deposition: {
                   ...config.geomorphology.config.geomorphology.deposition,
-                  rate: clampFinite(config.geomorphology.config.geomorphology.deposition.rate * multiplier, 0),
+                  rate: clampFinite(
+                    config.geomorphology.config.geomorphology.deposition.rate * multiplier,
+                    0
+                  ),
                 },
               },
             },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/index.ts
@@ -1,6 +1,6 @@
 import { Type, createStage } from "@swooper/mapgen-core/authoring";
 import { islands, landmasses, volcanoes } from "./steps/index.js";
-import { MorphologyVolcanismKnobSchema } from "@mapgen/domain/morphology/shared/knobs.js";
+import { MorphologyVolcanismKnobSchema } from "@mapgen/domain/morphology/config.js";
 
 /**
  * Morphology-features knobs (volcanism). Knobs apply after defaulted step config as deterministic transforms.

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/volcanoes.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/volcanoes.ts
@@ -1,4 +1,9 @@
-import { computeSampleStep, defineVizMeta, renderAsciiGrid, xyFromIndex } from "@swooper/mapgen-core";
+import {
+  computeSampleStep,
+  defineVizMeta,
+  renderAsciiGrid,
+  xyFromIndex,
+} from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { clamp01, clampFinite } from "@swooper/mapgen-core/lib/math";
 import VolcanoesStepContract from "./volcanoes.contract.js";
@@ -7,8 +12,8 @@ import {
   MORPHOLOGY_VOLCANISM_BASE_DENSITY_MULTIPLIER,
   MORPHOLOGY_VOLCANISM_CONVERGENT_MULTIPLIER_MULTIPLIER,
   MORPHOLOGY_VOLCANISM_HOTSPOT_WEIGHT_MULTIPLIER,
-} from "@mapgen/domain/morphology/shared/knob-multipliers.js";
-import type { MorphologyVolcanismKnob } from "@mapgen/domain/morphology/shared/knobs.js";
+} from "@mapgen/domain/morphology/config.js";
+import type { MorphologyVolcanismKnob } from "@mapgen/domain/morphology/config.js";
 
 type ArtifactValidationIssue = Readonly<{ message: string }>;
 type VolcanoKind = "subductionArc" | "rift" | "hotspot";
@@ -33,13 +38,17 @@ function validateVolcanoes(value: unknown): ArtifactValidationIssue[] {
   }
   for (const entry of candidate.volcanoes) {
     if (!isRecord(entry) || typeof entry.tileIndex !== "number" || entry.tileIndex < 0) {
-      return [{ message: "Expected volcanoes.volcanoes entries to include a non-negative tileIndex." }];
+      return [
+        { message: "Expected volcanoes.volcanoes entries to include a non-negative tileIndex." },
+      ];
     }
     if (entry.kind !== "subductionArc" && entry.kind !== "rift" && entry.kind !== "hotspot") {
       return [{ message: "Expected volcanoes.volcanoes entries to include a Phase 2 kind." }];
     }
     if (typeof entry.strength01 !== "number" || entry.strength01 < 0 || entry.strength01 > 1) {
-      return [{ message: "Expected volcanoes.volcanoes entries to include strength01 within [0,1]." }];
+      return [
+        { message: "Expected volcanoes.volcanoes entries to include strength01 within [0,1]." },
+      ];
     }
   }
   return [];
@@ -53,8 +62,10 @@ export default createStep(VolcanoesStepContract, {
   }),
   normalize: (config, ctx) => {
     const { volcanism } = ctx.knobs as Readonly<{ volcanism?: MorphologyVolcanismKnob }>;
-    const densityMultiplier = MORPHOLOGY_VOLCANISM_BASE_DENSITY_MULTIPLIER[volcanism ?? "normal"] ?? 1.0;
-    const hotspotMultiplier = MORPHOLOGY_VOLCANISM_HOTSPOT_WEIGHT_MULTIPLIER[volcanism ?? "normal"] ?? 1.0;
+    const densityMultiplier =
+      MORPHOLOGY_VOLCANISM_BASE_DENSITY_MULTIPLIER[volcanism ?? "normal"] ?? 1.0;
+    const hotspotMultiplier =
+      MORPHOLOGY_VOLCANISM_HOTSPOT_WEIGHT_MULTIPLIER[volcanism ?? "normal"] ?? 1.0;
     const convergentMultiplier =
       MORPHOLOGY_VOLCANISM_CONVERGENT_MULTIPLIER_MULTIPLIER[volcanism ?? "normal"] ?? 1.0;
 
@@ -65,8 +76,14 @@ export default createStep(VolcanoesStepContract, {
             config: {
               ...config.volcanoes.config,
               baseDensity: clampFinite(config.volcanoes.config.baseDensity * densityMultiplier, 0),
-              hotspotWeight: clampFinite(config.volcanoes.config.hotspotWeight * hotspotMultiplier, 0),
-              convergentMultiplier: clampFinite(config.volcanoes.config.convergentMultiplier * convergentMultiplier, 0),
+              hotspotWeight: clampFinite(
+                config.volcanoes.config.hotspotWeight * hotspotMultiplier,
+                0
+              ),
+              convergentMultiplier: clampFinite(
+                config.volcanoes.config.convergentMultiplier * convergentMultiplier,
+                0
+              ),
             },
           }
         : config.volcanoes;
@@ -97,7 +114,10 @@ export default createStep(VolcanoesStepContract, {
     const volcanoMask = new Uint8Array(size);
     const volcanoes = plan.volcanoes
       .map((entry) => entry.index | 0)
-      .filter((tileIndex) => tileIndex >= 0 && tileIndex < size && (topography.landMask[tileIndex] | 0) === 1)
+      .filter(
+        (tileIndex) =>
+          tileIndex >= 0 && tileIndex < size && (topography.landMask[tileIndex] | 0) === 1
+      )
       .sort((a, b) => a - b)
       .map((tileIndex) => {
         volcanoMask[tileIndex] = 1;

--- a/mods/mod-swooper-maps/test/pipeline/recipe-import-boundary.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/recipe-import-boundary.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const RECIPE_ROOT = fileURLToPath(new URL("../../src/recipes", import.meta.url));
+
+const RECIPE_DEEP_DOMAIN_IMPORT =
+  /@mapgen\/domain\/[^"']+\/(?!(?:ops(?:\.js)?|config(?:\.js)?)["'])[^"']+/;
+
+function collectTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectTsFiles(path));
+    } else if (entry.isFile() && path.endsWith(".ts")) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+describe("recipe import boundary", () => {
+  it("catches deep domain imports while allowing public recipe surfaces", () => {
+    expect(
+      RECIPE_DEEP_DOMAIN_IMPORT.test(`import x from "@mapgen/domain/hydrology/shared/knobs.js";`)
+    ).toBe(true);
+    expect(RECIPE_DEEP_DOMAIN_IMPORT.test(`import x from "@mapgen/domain/hydrology/ops";`)).toBe(
+      false
+    );
+    expect(
+      RECIPE_DEEP_DOMAIN_IMPORT.test(`import x from "@mapgen/domain/hydrology/config.js";`)
+    ).toBe(false);
+    expect(RECIPE_DEEP_DOMAIN_IMPORT.test(`import x from "@mapgen/domain/hydrology";`)).toBe(false);
+  });
+
+  it("keeps recipes on named domain public surfaces", () => {
+    const violations = collectTsFiles(RECIPE_ROOT).flatMap((file) => {
+      const text = readFileSync(file, "utf8");
+      return text
+        .split("\n")
+        .map((line, index) => ({ file, line: index + 1, text: line }))
+        .filter((entry) => RECIPE_DEEP_DOMAIN_IMPORT.test(entry.text));
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/openspec/changes/normalize-import-boundaries/implementation.md
+++ b/openspec/changes/normalize-import-boundaries/implementation.md
@@ -1,0 +1,59 @@
+# normalize-import-boundaries Implementation Record
+
+Date: 2026-05-30
+Branch: `codex/normalize-import-boundaries-impl`
+Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-DRA-normalize-authority-routing`
+
+## Scope
+
+This slice implements the first narrow import guard from the normalization
+packet: standard recipe source may assemble named domain public surfaces, but
+must not deep-import domain internals.
+
+## Policy
+
+The scoped import matrix is documented in
+`docs/system/libs/mapgen/policies/IMPORTS.md`.
+
+The first enforced rule covers only:
+
+- Importing code: `mods/mod-swooper-maps/src/recipes/**`
+- Blocked shape: `@mapgen/domain/<domain>/<internal-subpath>`
+- Allowed domain surfaces:
+  - `@mapgen/domain/<domain>`
+  - `@mapgen/domain/<domain>/ops`
+  - `@mapgen/domain/<domain>/config.js`
+
+Broader cross-domain, test, and domain-internal restrictions remain policy-only
+until their owner surfaces are normalized by later slices.
+
+## Remediation
+
+- Added public config surfaces for foundation and hydrology:
+  - `mods/mod-swooper-maps/src/domain/foundation/config.ts`
+  - `mods/mod-swooper-maps/src/domain/hydrology/config.ts`
+- Extended the morphology config surface to export morphology knobs and knob
+  multipliers.
+- Updated standard recipe imports that reached into `shared/knobs`,
+  `shared/knob-multipliers`, or ecology `types.js` to use root or `/config.js`
+  public surfaces.
+- Did not move catalogs, stages, ops, or topology files.
+
+## Guard
+
+- Added `scripts/lint/lint-mapgen-recipe-imports.sh`.
+- Wired it into the root `check` script as `lint:mapgen-recipe-imports`.
+- Added `mods/mod-swooper-maps/test/pipeline/recipe-import-boundary.test.ts`
+  with a seeded deep-import violation string plus a current-tree scan.
+
+## Verification
+
+Commands run from the worktree:
+
+- `bun run lint:mapgen-recipe-imports`
+- `bun run --cwd mods/mod-swooper-maps test -- test/pipeline/recipe-import-boundary.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `rg -n "@mapgen/domain/[^'\\\"]+/(?!ops(?:\\.js)?['\\\"]|config(?:\\.js)?['\\\"])[^'\\\"]+" mods/mod-swooper-maps/src/recipes -g '*.ts' -P || true`
+- `bun run openspec -- validate normalize-import-boundaries --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/normalize-import-boundaries/tasks.md
+++ b/openspec/changes/normalize-import-boundaries/tasks.md
@@ -1,26 +1,26 @@
 ## 1. Policy
 
-- [ ] 1.1 Document the scoped import matrix.
-- [ ] 1.2 Identify the first recipe deep-import rule and its exact allowed
+- [x] 1.1 Document the scoped import matrix.
+- [x] 1.2 Identify the first recipe deep-import rule and its exact allowed
   surfaces.
 
 ## 2. Remediation
 
-- [ ] 2.1 Add or repair domain/stage public surfaces required by recipe
+- [x] 2.1 Add or repair domain/stage public surfaces required by recipe
   assembly.
-- [ ] 2.2 Update recipe imports covered by the first guard.
-- [ ] 2.3 Avoid unrelated file moves and catalog rewrites.
+- [x] 2.2 Update recipe imports covered by the first guard.
+- [x] 2.3 Avoid unrelated file moves and catalog rewrites.
 
 ## 3. Guard
 
-- [ ] 3.1 Add the narrow recipe deep-import guard.
-- [ ] 3.2 Add a seeded violation or focused test if the guard framework
+- [x] 3.1 Add the narrow recipe deep-import guard.
+- [x] 3.2 Add a seeded violation or focused test if the guard framework
   supports it.
 
 ## 4. Verification
 
-- [ ] 4.1 Run the import guard or focused lint.
-- [ ] 4.2 Run package checks affected by import rewrites.
-- [ ] 4.3 Run `bun run openspec -- validate normalize-import-boundaries --strict`.
-- [ ] 4.4 Run `bun run openspec:validate`.
-- [ ] 4.5 Run `git diff --check`.
+- [x] 4.1 Run the import guard or focused lint.
+- [x] 4.2 Run package checks affected by import rewrites.
+- [x] 4.3 Run `bun run openspec -- validate normalize-import-boundaries --strict`.
+- [x] 4.4 Run `bun run openspec:validate`.
+- [x] 4.5 Run `git diff --check`.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "packageManager": "bun@1.3.7",
   "scripts": {
     "build": "turbo run build",
-    "check": "turbo run check && bun run lint:domain-refactor-guardrails && bun run lint:mapgen-docs",
+    "check": "turbo run check && bun run lint:domain-refactor-guardrails && bun run lint:mapgen-recipe-imports && bun run lint:mapgen-docs",
     "check-types": "turbo run check",
     "dev:cli": "bun run --filter @mateicanavra/civ7-cli dev",
     "dev:sdk": "bun run --filter @mateicanavra/civ7-sdk dev",
@@ -38,6 +38,7 @@
     "build:mapgen": "bun run --cwd packages/mapgen-core build",
     "lint:adapter-boundary": "./scripts/lint/lint-adapter-boundary.sh",
     "lint:domain-refactor-guardrails": "./scripts/lint/lint-domain-refactor-guardrails.sh",
+    "lint:mapgen-recipe-imports": "./scripts/lint/lint-mapgen-recipe-imports.sh",
     "lint:domain-refactor-guardrails:strict-core": "REFRACTOR_DOMAINS=\"foundation,morphology,hydrology,ecology,placement,narrative\" DOMAIN_REFACTOR_GUARDRAILS_PROFILE=full DOMAIN_REFACTOR_GUARDRAILS_REQUIRE_FULL=1 ./scripts/lint/lint-domain-refactor-guardrails.sh",
     "ci:architecture-strict-core": "bun run lint && bun run lint:adapter-boundary && bun run test:architecture-cutover && bun run lint:domain-refactor-guardrails && bun run check",
     "lint:adrs": "node scripts/lint/lint-doc-adrs.mjs",

--- a/scripts/lint/lint-mapgen-recipe-imports.sh
+++ b/scripts/lint/lint-mapgen-recipe-imports.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# MapGen recipe import boundary guard.
+# Keeps recipe assembly on named domain public surfaces.
+#
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+RECIPE_ROOT="mods/mod-swooper-maps/src/recipes"
+
+echo "=== MapGen Recipe Import Boundary ==="
+echo ""
+
+if [ ! -d "$RECIPE_ROOT" ]; then
+  echo -e "${RED}ERROR: Missing recipe root: ${RECIPE_ROOT}${NC}"
+  exit 2
+fi
+
+# First narrow rule: recipes may import a domain root plus the domain's public
+# ops/config surfaces. Deep shared/ops/rules/strategy/type files need a named
+# public owner before recipes can depend on them.
+violations="$(
+  rg -n \
+    "@mapgen/domain/[^\"']+/(?!ops(?:\\.js)?[\"']|config(?:\\.js)?[\"'])[^\"']+" \
+    "$RECIPE_ROOT" \
+    -g "*.ts" \
+    -P 2>/dev/null || true
+)"
+
+if [ -n "$violations" ]; then
+  echo -e "${RED}ERROR: Recipe deep domain imports found.${NC}"
+  echo "$violations" | sed 's/^/  /'
+  echo ""
+  echo "Allowed domain imports from recipes:"
+  echo "  - @mapgen/domain/<domain>"
+  echo "  - @mapgen/domain/<domain>/ops"
+  echo "  - @mapgen/domain/<domain>/config.js"
+  exit 1
+fi
+
+echo -e "${GREEN}MapGen recipe import boundary passed.${NC}"


### PR DESCRIPTION
Enforces a named domain surface boundary for standard recipe imports, preventing recipes from reaching into domain internals like `shared/knobs`, `shared/knob-multipliers`, `rules`, or `types.js`.

**What changed:**

- Added `config.ts` public surfaces for the `foundation` and `hydrology` domains, re-exporting knobs and knob-multipliers from their internal `shared/` paths. Extended the existing `morphology/config.ts` to do the same.
- Migrated all recipe imports that previously pointed at `@mapgen/domain/<domain>/shared/knobs.js`, `@mapgen/domain/<domain>/shared/knob-multipliers.js`, or `@mapgen/domain/ecology/types.js` to use the domain root or the new `/config.js` surface.
- Added `scripts/lint/lint-mapgen-recipe-imports.sh`, a shell guard using `rg` that fails if any recipe file imports a deep domain path not matching the allowed surfaces (`@mapgen/domain/<domain>`, `/ops`, or `/config.js`).
- Wired `lint:mapgen-recipe-imports` into the root `check` script.
- Added `mods/mod-swooper-maps/test/pipeline/recipe-import-boundary.test.ts`, which validates the regex logic against known allowed and disallowed patterns and performs a live scan of the recipe tree.
- Documented the scoped import matrix in `docs/system/libs/mapgen/policies/IMPORTS.md`, including the allowed surfaces per import context and the disallowed deep-import patterns.
- Marked all tasks in `openspec/changes/normalize-import-boundaries/tasks.md` as complete and added an implementation record at `openspec/changes/normalize-import-boundaries/implementation.md`.