### PR TITLE
refactor(sdk): move `createMap` from mapgen-core to civ7-sdk mapgen entrypoint

### DIFF
--- a/apps/mapgen-studio/src/recipes/catalog.ts
+++ b/apps/mapgen-studio/src/recipes/catalog.ts
@@ -62,8 +62,10 @@ function makeRecipeId(namespace: string, recipeId: string): StudioRecipeId {
   return `${namespace}/${recipeId}`;
 }
 
-// This is a bundled catalog for the current Studio build. Studio's engine code
-// only depends on the generic `RecipeArtifacts` interface, not on any one recipe.
+// This is a bundled catalog for the current Studio build. Recipe schema/default
+// contracts are generated from recipe package source by `build:studio-recipes`
+// and exported as first-class package artifacts; Studio does not treat `dist/`
+// or generated output as editable policy.
 import {
   STANDARD_RECIPE_CONFIG as swooperStandardDefaultConfig,
   STANDARD_RECIPE_CONFIG_SCHEMA as swooperStandardConfigSchema,

--- a/bun.lock
+++ b/bun.lock
@@ -96,6 +96,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@civ7/adapter": "workspace:*",
+        "@mateicanavra/civ7-sdk": "workspace:*",
         "@swooper/mapgen-core": "workspace:*",
         "@swooper/mapgen-viz": "workspace:*",
         "typebox": "^1.0.80",
@@ -248,10 +249,13 @@
       "name": "@mateicanavra/civ7-sdk",
       "version": "0.0.0",
       "dependencies": {
+        "@civ7/adapter": "workspace:*",
+        "@swooper/mapgen-core": "workspace:*",
         "jstoxml": "^7.0.1",
         "lodash-es": "^4.17.23",
       },
       "devDependencies": {
+        "@civ7/types": "workspace:*",
         "@types/jstoxml": "^5.0.0",
         "@types/lodash": "^4.17.23",
         "@types/node": "^22.14.0",

--- a/docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md
+++ b/docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md
@@ -161,6 +161,11 @@ Worker seam + protocol:
 Recipe selection + artifacts boundary:
 - Runtime recipes (worker-side): `apps/mapgen-studio/src/browser-runner/recipeRuntime.ts`
 - Bundled recipe artifacts (UI schema + defaults + ui meta): `apps/mapgen-studio/src/recipes/catalog.ts`
+- Recipe artifacts source: `mod-swooper-maps` recipe source is compiled by
+  `bun run --cwd mods/mod-swooper-maps build:studio-recipes` into package
+  artifact entrypoints (`mod-swooper-maps/recipes/*-artifacts`). Studio imports
+  those first-class package artifacts; generated `dist/` files are build proof,
+  not editable product policy.
 - Worker creation boundary: `apps/mapgen-studio/src/features/browserRunner/workerClient.ts`
 
 Core SDK contracts this seam depends on:

--- a/mods/mod-swooper-maps/package.json
+++ b/mods/mod-swooper-maps/package.json
@@ -42,6 +42,7 @@
     "@swooper/mapgen-core": "workspace:*",
     "@swooper/mapgen-viz": "workspace:*",
     "@civ7/adapter": "workspace:*",
+    "@mateicanavra/civ7-sdk": "workspace:*",
     "typebox": "^1.0.80"
   },
   "devDependencies": {

--- a/mods/mod-swooper-maps/src/maps/__type_tests__/createMap-config.inference.ts
+++ b/mods/mod-swooper-maps/src/maps/__type_tests__/createMap-config.inference.ts
@@ -1,6 +1,6 @@
 /// <reference types="@civ7/types" />
 
-import { createMap } from "@swooper/mapgen-core/authoring/maps";
+import { createMap } from "@mateicanavra/civ7-sdk/mapgen";
 import type { Static } from "@swooper/mapgen-core/authoring";
 import foundationDomain from "@mapgen/domain/foundation";
 import standardRecipe, { type StandardRecipeConfig } from "../../recipes/standard/recipe.js";
@@ -42,8 +42,11 @@ const _computeMeshConfigFromOpIsObject: _ComputeMeshConfigFromOpIsObject = true;
 type _MeshStep = Extract<(typeof foundationStage.steps)[number], { contract: { id: "mesh" } }>;
 type _MeshStepRuntimeConfig = Static<_MeshStep["contract"]["schema"]>;
 type _ComputeMeshEnvelopeFromStepSchema = _MeshStepRuntimeConfig["computeMesh"];
-type _ComputeMeshEnvelopeFromStepSchemaConfig =
-  _ComputeMeshEnvelopeFromStepSchema extends { config: infer C } ? C : never;
+type _ComputeMeshEnvelopeFromStepSchemaConfig = _ComputeMeshEnvelopeFromStepSchema extends {
+  config: infer C;
+}
+  ? C
+  : never;
 type _ComputeMeshEnvelopeFromStepSchemaConfigIsObject =
   _ComputeMeshEnvelopeFromStepSchemaConfig extends object ? true : false;
 const _computeMeshEnvelopeFromStepSchemaConfigIsObject: _ComputeMeshEnvelopeFromStepSchemaConfigIsObject = true;
@@ -54,7 +57,8 @@ type _PlateCountKnobIsNumber = Exclude<_PlateCountKnob, undefined> extends numbe
 const _plateCountKnobIsNumber: _PlateCountKnobIsNumber = true;
 
 type _PlateActivityKnob = _FoundationKnobs["plateActivity"];
-type _PlateActivityKnobIsNumber = Exclude<_PlateActivityKnob, undefined> extends number ? true : false;
+type _PlateActivityKnobIsNumber =
+  Exclude<_PlateActivityKnob, undefined> extends number ? true : false;
 const _plateActivityKnobIsNumber: _PlateActivityKnobIsNumber = true;
 
 createMap({

--- a/mods/mod-swooper-maps/src/maps/shattered-ring.ts
+++ b/mods/mod-swooper-maps/src/maps/shattered-ring.ts
@@ -12,7 +12,7 @@
 
 /// <reference types="@civ7/types" />
 
-import { createMap } from "@swooper/mapgen-core/authoring/maps";
+import { createMap } from "@mateicanavra/civ7-sdk/mapgen";
 import standardRecipe from "../recipes/standard/recipe.js";
 import { SHATTERED_RING_CONFIG } from "./configs/shattered-ring.config.js";
 

--- a/mods/mod-swooper-maps/src/maps/sundered-archipelago.ts
+++ b/mods/mod-swooper-maps/src/maps/sundered-archipelago.ts
@@ -12,7 +12,7 @@
 
 /// <reference types="@civ7/types" />
 
-import { createMap } from "@swooper/mapgen-core/authoring/maps";
+import { createMap } from "@mateicanavra/civ7-sdk/mapgen";
 import standardRecipe from "../recipes/standard/recipe.js";
 import { SUNDERED_ARCHIPELAGO_CONFIG } from "./configs/sundered-archipelago.config.js";
 

--- a/mods/mod-swooper-maps/src/maps/swooper-desert-mountains.ts
+++ b/mods/mod-swooper-maps/src/maps/swooper-desert-mountains.ts
@@ -10,7 +10,7 @@
 
 /// <reference types="@civ7/types" />
 
-import { createMap } from "@swooper/mapgen-core/authoring/maps";
+import { createMap } from "@mateicanavra/civ7-sdk/mapgen";
 import standardRecipe from "../recipes/standard/recipe.js";
 import { SWOOPER_DESERT_MOUNTAINS_CONFIG } from "./configs/swooper-desert-mountains.config.js";
 

--- a/mods/mod-swooper-maps/src/maps/swooper-earthlike.ts
+++ b/mods/mod-swooper-maps/src/maps/swooper-earthlike.ts
@@ -10,8 +10,8 @@
 
 /// <reference types="@civ7/types" />
 
-import { createMap } from "@swooper/mapgen-core/authoring/maps";
 import { stripSchemaMetadataRoot } from "@swooper/mapgen-core/authoring";
+import { createMap } from "@mateicanavra/civ7-sdk/mapgen";
 import type { StandardRecipeConfig } from "../recipes/standard/recipe.js";
 import standardRecipe from "../recipes/standard/recipe.js";
 import swooperEarthlikeConfigRaw from "./configs/swooper-earthlike.config.json";

--- a/openspec/changes/normalize-core-studio-dx-boundaries/implementation.md
+++ b/openspec/changes/normalize-core-studio-dx-boundaries/implementation.md
@@ -1,0 +1,61 @@
+# normalize-core-studio-dx-boundaries Implementation Record
+
+Date: 2026-05-30
+Branch: `codex/normalize-core-studio-dx-boundaries-impl`
+Worktree: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-DRA-normalize-authority-routing`
+
+## Scope
+
+This slice separates pure MapGen core from Civ7 runtime-bound map entrypoint
+glue and records Studio's recipe artifact contract source.
+
+## Core Runtime Boundary
+
+- Removed the Civ7-bound `@swooper/mapgen-core/authoring/maps` entrypoint from
+  `mapgen-core`.
+- Moved `createMap` into the shared Civ7 SDK at
+  `@mateicanavra/civ7-sdk/mapgen`.
+- Updated Swooper map entrypoints and their type-inference guard to import the
+  SDK map surface.
+- Did not add a compatibility alias in `mapgen-core`; the old owner was the
+  purity violation this slice removes.
+
+The SDK owner is intentional: `createMap` is a reusable Civ7 map-entrypoint
+helper for any map package, not a `mod-swooper-maps` special case.
+
+## Studio Contract Source
+
+- Studio continues to consume recipe schema/default/ui metadata through
+  first-class `mod-swooper-maps/recipes/*-artifacts` package entrypoints.
+- `apps/mapgen-studio/src/recipes/catalog.ts` and
+  `docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md` now state that
+  those artifacts are generated from recipe package source by
+  `bun run --cwd mods/mod-swooper-maps build:studio-recipes`.
+- Generated `dist/` files remain build proof, not editable product policy.
+
+## Consumer Impact
+
+- Affected in-repo consumers:
+  - `mods/mod-swooper-maps/src/maps/*.ts`
+  - `mods/mod-swooper-maps/src/maps/__type_tests__/createMap-config.inference.ts`
+- Public API change:
+  - Removed `@swooper/mapgen-core/authoring/maps`.
+  - Added `@mateicanavra/civ7-sdk/mapgen`.
+
+## Verification
+
+Commands run from the worktree:
+
+- `bun install`
+- `bun run --cwd packages/sdk check`
+- `bun run --cwd packages/sdk build`
+- `bun run --cwd packages/mapgen-core check`
+- `bun run --cwd packages/mapgen-core build`
+- `bun run --cwd packages/mapgen-core test -- test/architecture/core-purity.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run --cwd mods/mod-swooper-maps build`
+- `bun run --cwd apps/mapgen-studio build`
+- `rg -n "^import(?!\\s+type).*@civ7/adapter|@civ7/adapter/civ7|\\bcreateCiv7Adapter\\b|\\bGameplayMap\\b|\\bengine\\s+as\\s+unknown\\b" packages/mapgen-core/src -g '*.ts' -g '!packages/mapgen-core/src/dev/**' -P || true`
+- `bun run openspec -- validate normalize-core-studio-dx-boundaries --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/normalize-core-studio-dx-boundaries/tasks.md
+++ b/openspec/changes/normalize-core-studio-dx-boundaries/tasks.md
@@ -1,29 +1,29 @@
 ## 1. Boundary Inventory
 
-- [ ] 1.1 Inventory pure-core imports of Civ7 adapter values, runtime globals,
+- [x] 1.1 Inventory pure-core imports of Civ7 adapter values, runtime globals,
   or map runtime helpers.
-- [ ] 1.2 Inventory Studio recipe schema/default imports and generation
+- [x] 1.2 Inventory Studio recipe schema/default imports and generation
   assumptions.
-- [ ] 1.3 Identify public SDK or Studio consumers affected by moved exports.
+- [x] 1.3 Identify public SDK or Studio consumers affected by moved exports.
 
 ## 2. Core Runtime Boundary
 
-- [ ] 2.1 Move Civ7-bound map helper implementation to an explicit runtime
+- [x] 2.1 Move Civ7-bound map helper implementation to an explicit runtime
   owner.
-- [ ] 2.2 Update imports and package exports without adding compatibility
+- [x] 2.2 Update imports and package exports without adding compatibility
   aliases unless an accepted consumer gate requires them.
-- [ ] 2.3 Add or update tests proving pure core does not import runtime values.
+- [x] 2.3 Add or update tests proving pure core does not import runtime values.
 
 ## 3. Studio Contract Source
 
-- [ ] 3.1 Choose and document the Studio recipe contract source.
-- [ ] 3.2 Update Studio imports and generation flow to use that source.
-- [ ] 3.3 Update Studio tests or typechecks for the new contract path.
+- [x] 3.1 Choose and document the Studio recipe contract source.
+- [x] 3.2 Update Studio imports and generation flow to use that source.
+- [x] 3.3 Update Studio tests or typechecks for the new contract path.
 
 ## 4. Verification
 
-- [ ] 4.1 Run core, adapter/mod, and Studio checks affected by the move.
-- [ ] 4.2 Run a pure-core runtime-import search.
-- [ ] 4.3 Run `bun run openspec -- validate normalize-core-studio-dx-boundaries --strict`.
-- [ ] 4.4 Run `bun run openspec:validate`.
-- [ ] 4.5 Run `git diff --check`.
+- [x] 4.1 Run core, adapter/mod, and Studio checks affected by the move.
+- [x] 4.2 Run a pure-core runtime-import search.
+- [x] 4.3 Run `bun run openspec -- validate normalize-core-studio-dx-boundaries --strict`.
+- [x] 4.4 Run `bun run openspec:validate`.
+- [x] 4.5 Run `git diff --check`.

--- a/packages/mapgen-core/package.json
+++ b/packages/mapgen-core/package.json
@@ -22,10 +22,6 @@
       "types": "./dist/authoring/index.d.ts",
       "import": "./dist/authoring/index.js"
     },
-    "./authoring/maps": {
-      "types": "./dist/authoring/maps/index.d.ts",
-      "import": "./dist/authoring/maps/index.js"
-    },
     "./compiler/normalize": {
       "types": "./dist/compiler/normalize.d.ts",
       "import": "./dist/compiler/normalize.js"

--- a/packages/mapgen-core/test/architecture/core-purity.test.ts
+++ b/packages/mapgen-core/test/architecture/core-purity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC_ROOT = fileURLToPath(new URL("../../src", import.meta.url));
+
+const RUNTIME_BOUNDARY_PATTERNS: readonly RegExp[] = [
+  /^import(?!\s+type).*["@']@civ7\/adapter/m,
+  /["@']@civ7\/adapter\/civ7["@']/,
+  /\bcreateCiv7Adapter\b/,
+  /\bGameplayMap\b/,
+  /\bengine\s+as\s+unknown\b/,
+];
+
+function collectProductionSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    const rel = relative(SRC_ROOT, path);
+    if (rel === "dev" || rel.startsWith(`dev/`)) continue;
+    if (entry.isDirectory()) {
+      out.push(...collectProductionSourceFiles(path));
+    } else if (entry.isFile() && path.endsWith(".ts")) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+describe("core runtime boundary", () => {
+  it("keeps production mapgen-core free of Civ7 runtime values", () => {
+    const violations = collectProductionSourceFiles(SRC_ROOT).flatMap((file) => {
+      const text = readFileSync(file, "utf8");
+      return RUNTIME_BOUNDARY_PATTERNS.filter((pattern) => pattern.test(text)).map((pattern) => ({
+        file: relative(SRC_ROOT, file),
+        pattern: String(pattern),
+      }));
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/mapgen-core/tsup.config.ts
+++ b/packages/mapgen-core/tsup.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
     "src/index.ts",
     "src/engine/index.ts",
     "src/authoring/index.ts",
-    "src/authoring/maps/index.ts",
     "src/compiler/normalize.ts",
     "src/compiler/recipe-compile.ts",
     "src/lib/math/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -12,11 +12,16 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./mapgen": {
+      "types": "./dist/mapgen/index.d.ts",
+      "import": "./dist/mapgen/index.js",
+      "require": "./dist/mapgen/index.cjs"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts",
-    "dev": "tsup src/index.ts --format esm,cjs --dts --watch",
+    "build": "tsup src/index.ts src/mapgen/index.ts --format esm,cjs --dts",
+    "dev": "tsup src/index.ts src/mapgen/index.ts --format esm,cjs --dts --watch",
     "test": "vitest run --project sdk",
     "lint": "eslint .",
     "check": "tsc -p tsconfig.json --noEmit",
@@ -24,6 +29,8 @@
     "prepublishOnly": "bun run build"
   },
   "dependencies": {
+    "@civ7/adapter": "workspace:*",
+    "@swooper/mapgen-core": "workspace:*",
     "jstoxml": "^7.0.1",
     "lodash-es": "^4.17.23"
   },
@@ -34,7 +41,8 @@
     "@types/node": "^22.14.0",
     "eslint": "^9.39.2",
     "@types/lodash": "^4.17.23",
-    "@types/jstoxml": "^5.0.0"
+    "@types/jstoxml": "^5.0.0",
+    "@civ7/types": "workspace:*"
   },
   "engines": {
     "node": ">=22.14.0"

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,3 +7,4 @@ export * from './utils';
 export * from './localizations';
 export * from './nodes';
 export * from './presets';
+export * from './mapgen';

--- a/packages/sdk/src/mapgen/createMap.ts
+++ b/packages/sdk/src/mapgen/createMap.ts
@@ -1,13 +1,9 @@
 /// <reference types="@civ7/types" />
 
-import "../../polyfills/text-encoder.js";
-
 import type { MapInfo, MapInitParams, MapSizeId } from "@civ7/adapter";
 import { createCiv7Adapter } from "@civ7/adapter/civ7";
-
-import { createExtendedMapContext, type ExtendedMapContext } from "../../core/types.js";
-import type { Env } from "../../engine/index.js";
-import type { RecipeModule } from "../types.js";
+import { createExtendedMapContext, type Env, type ExtendedMapContext } from "@swooper/mapgen-core";
+import type { RecipeModule } from "@swooper/mapgen-core/authoring";
 
 type RecipeConfigInputOfRecipe<TRecipe extends RecipeModule<any, any, any>> =
   TRecipe extends RecipeModule<any, infer TConfigInput, any> ? TConfigInput : never;
@@ -54,7 +50,10 @@ function resolveSeed(def: MapDefinition<any>): number {
   return seed;
 }
 
-function resolveLatitudeBounds(def: MapDefinition<any>, base: { topLatitude: number; bottomLatitude: number }): {
+function resolveLatitudeBounds(
+  def: MapDefinition<any>,
+  base: { topLatitude: number; bottomLatitude: number }
+): {
   topLatitude: number;
   bottomLatitude: number;
 } {
@@ -84,7 +83,10 @@ function resolveMapInfo(mapSizeId: MapSizeId): MapInfo {
   return mapInfo;
 }
 
-function resolveInitCapture(def: MapDefinition<any>, initParams: Partial<MapInitParams> | null | undefined): InitCapture {
+function resolveInitCapture(
+  def: MapDefinition<any>,
+  initParams: Partial<MapInitParams> | null | undefined
+): InitCapture {
   const mapSizeId: MapSizeId = initParams?.mapSize ?? GameplayMap.getMapSize();
   const mapInfo = resolveMapInfo(mapSizeId);
 
@@ -93,7 +95,12 @@ function resolveInitCapture(def: MapDefinition<any>, initParams: Partial<MapInit
   const baseTopLatitude = initParams?.topLatitude ?? mapInfo.MaxLatitude;
   const baseBottomLatitude = initParams?.bottomLatitude ?? mapInfo.MinLatitude;
 
-  if (typeof width !== "number" || !Number.isFinite(width) || typeof height !== "number" || !Number.isFinite(height)) {
+  if (
+    typeof width !== "number" ||
+    !Number.isFinite(width) ||
+    typeof height !== "number" ||
+    !Number.isFinite(height)
+  ) {
     throw new Error(
       `${def.logPrefix ?? "[SWOOPER_MOD]"} Missing map dimensions (width/height not provided by init params and not present in mapInfo).`
     );

--- a/packages/sdk/src/mapgen/index.ts
+++ b/packages/sdk/src/mapgen/index.ts
@@ -1,0 +1,2 @@
+export { createMap } from "./createMap.js";
+export type { MapDefinition, MapLatitudeBounds } from "./createMap.js";


### PR DESCRIPTION
`createMap` has been moved out of `@swooper/mapgen-core/authoring/maps` and into a new `@mateicanavra/civ7-sdk/mapgen` entrypoint. This removes a Civ7 runtime dependency from the pure mapgen-core package, which should remain runtime-agnostic.

The `@swooper/mapgen-core/authoring/maps` export has been removed entirely — no compatibility alias was added. All in-repo map entrypoints (`shattered-ring`, `sundered-archipelago`, `swooper-desert-mountains`, `swooper-earthlike`) and the `createMap` type-inference test now import from `@mateicanavra/civ7-sdk/mapgen`. The SDK gains `@civ7/adapter` and `@swooper/mapgen-core` as runtime dependencies to support this.

A new architecture test (`packages/mapgen-core/test/architecture/core-purity.test.ts`) enforces that production `mapgen-core` source files contain no imports of Civ7 adapter values, runtime globals, or map runtime helpers.

Studio's recipe artifact contract source is also clarified: `catalog.ts` and `STUDIO-INTEGRATION.md` now explicitly state that recipe schema/defaults are generated from `mod-swooper-maps` recipe source via `build:studio-recipes` and exported as first-class package artifacts. Generated `dist/` output is build proof, not editable policy.