### PR TITLE
feat(hydrology): replace engine lake generation with deterministic plan-lakes stamping

### DIFF
--- a/docs/projects/engine-refactor-v1/deferrals.md
+++ b/docs/projects/engine-refactor-v1/deferrals.md
@@ -52,17 +52,17 @@ Each deferral follows this structure:
 
 ---
 
-## DEF-020: Discharge-Driven Hydrography Stamping (Engine Projection vs. Hydrology Truth)
+## DEF-020: Discharge-Driven River Stamping (Engine Projection vs. Hydrology Truth)
 
 **Deferred:** 2026-01-17  
-**Trigger:** When the adapter/engine surface can accept explicit river/lake geometry (or when we add an `EngineAdapter` capability that can stamp hydrography derived from Hydrology artifacts).  
-**Context:** M9 makes Hydrology the canonical owner of hydrography via discharge + routing-derived artifacts. Civ7 adapter surfaces currently support only engine-driven river/lake generation (`modelRivers(...)`, `generateLakes(...)`) and do not expose explicit “set river network / set lake mask” stamping. To keep the pipeline green without lying about ownership, engine hydrography is treated as projection-only while downstream consumes Hydrology’s typed hydrography artifacts as truth.  
+**Trigger:** When the adapter/engine surface can accept explicit river geometry (or when we add an `EngineAdapter` capability that can stamp river hydrography derived from Hydrology artifacts).
+**Context:** M9 makes Hydrology the canonical owner of hydrography via discharge + routing-derived artifacts. Lake stamping/readback now exists via `EngineAdapter.stampLakes(...)`, and placement consumes `artifact:hydrology.lakePlan` as truth. River projection still relies on `modelRivers(...)`; explicit river-network stamping remains deferred.
 **Scope:**
-- Introduce an explicit `EngineAdapter` capability for stamping hydrography from Hydrology artifacts (rivers + lakes).
+- Introduce an explicit `EngineAdapter` capability for stamping river hydrography from Hydrology artifacts.
 - Implement the capability in Civ adapter and `MockAdapter` (so determinism + monotonicity can be tested engine-free).
-- Migrate Hydrology engine projection calls to the stamping capability and deprecate any reliance on `modelRivers(...)` / `generateLakes(...)` as truth-bearing mechanisms.  
+- Migrate Hydrology river projection calls to the stamping capability and deprecate any reliance on `modelRivers(...)` as a truth-bearing mechanism.
 **Impact:**
-- Engine rivers/lakes may not exactly reflect discharge-derived hydrography; this is an acknowledged projection limitation.
+- Engine rivers may not exactly reflect discharge-derived hydrography; this is an acknowledged projection limitation.
 - Downstream logic must treat Hydrology artifacts as canonical truth; engine surfaces remain compatibility/visualization.  
 
 ---

--- a/docs/projects/mapgen-studio/BROWSER-ADAPTER.md
+++ b/docs/projects/mapgen-studio/BROWSER-ADAPTER.md
@@ -70,14 +70,14 @@ The standard recipe uses these adapter members (directly or via `createExtendedM
 - `setStartPosition(plotIndex, playerId)`
 - `validateAndFixTerrain()`, `recalculateAreas()`, `stampContinents()`, `buildElevation()`
 - `modelRivers(minLen,maxLen,navigableTerrain)`, `defineNamedRivers()`, `storeWaterData()`
-- `generateLakes(width,height,tilesPerLake)`, `expandCoasts(width,height)`
+- `generateLakes(width,height,tilesPerLake)`, `stampLakes(width,height,lakeMask)`, `expandCoasts(width,height)`
 - `addNaturalWonders(width,height,numWonders)`, `generateResources(width,height)`, `generateDiscoveries(width,height,startPositions)`
 - `addFloodplains(minLen,maxLen)`, `recalculateFertility()`, `assignAdvancedStartRegions()`
 - `verifyEffect(effectId)`
 
 **Direct callsites by stage (standard recipe):**
 - `map-morphology`: `buildElevation`, `expandCoasts`, `getFeatureTypeIndex`, `isWater`, `recalculateAreas`, `setFeatureType`, `setTerrainType`, `stampContinents`, `validateAndFixTerrain`
-- `map-hydrology`: `defineNamedRivers`, `generateLakes`, `getTerrainType`, `isWater`, `modelRivers`, `validateAndFixTerrain`
+- `map-hydrology`: `defineNamedRivers`, `getTerrainType`, `isWater`, `modelRivers`, `stampLakes`, `validateAndFixTerrain`
 - `map-ecology`: `addPlotEffect`, `canHaveFeature`, `getBiomeGlobal`, `getFeatureType`, `getFeatureTypeIndex`, `getPlotEffectTypeIndex`, `recalculateAreas`, `setBiomeType`, `setFeatureType`, `validateAndFixTerrain`
 - `placement`: `addFloodplains`, `addNaturalWonders`, `assignAdvancedStartRegions`, `generateDiscoveries`, `generateResources`, `getLandmassId`, `getTerrainType`, `isWater`, `recalculateAreas`, `recalculateFertility`, `setLandmassRegionId`, `setStartPosition`, `storeWaterData`, `validateAndFixTerrain`
 
@@ -149,8 +149,8 @@ These currently wrap Civ7 engine algorithms (TerrainBuilder/AreaBuilder/base-sta
   - `buildElevation()`
 - Rivers / water bookkeeping:
   - `modelRivers(...)`, `defineNamedRivers()`, `storeWaterData()`
-- Coast/lake generators:
-  - `generateLakes(...)`, `expandCoasts(...)`
+- Coast/lake projection:
+  - `stampLakes(...)`, `expandCoasts(...)`
 - Placement & content generators:
   - `addNaturalWonders(...)`, `generateResources(...)`, `generateDiscoveries(...)`
   - `addFloodplains(...)`, `recalculateFertility()`, `assignAdvancedStartRegions()`

--- a/docs/projects/mapgen-studio/issues/LOCAL-TBD-pipeline-viz-surface.md
+++ b/docs/projects/mapgen-studio/issues/LOCAL-TBD-pipeline-viz-surface.md
@@ -149,7 +149,7 @@ related_to: []
   - Ecology: biome classification fields, pedology (soilType/fertility), resource basins (plots/intensity), feature intents (vegetation/wetlands/reefs/ice).
   - Map/Gameplay: landmass region slots, engine terrain/feature/biome fields after map-morphology/map-ecology/map-hydrology/placement.
 - Engine-dependent / mock-sensitive inputs:
-  - `buildElevation`, `generateLakes`, `addNaturalWonders`, `generateResources`, `addFloodplains`, `generateSnow`, `storeWaterData`, and placement apply calls in the mock adapter are no-ops.
+  - `buildElevation`, `addNaturalWonders`, `generateResources`, `addFloodplains`, `generateSnow`, `storeWaterData`, and placement apply calls in the mock adapter are no-ops; `stampLakes` mutates terrain and reports readback.
   - `syncHeightfield` pulls from adapter; mock currently returns flat elevations unless we inject a fallback.
   - Plan: add explicit mock fallbacks where no-op yields empty/flat fields (with code comments noting non-1:1).
 - Doc gap: `docs/projects/mapgen-studio/VIZ-LAYER-CATALOG.md` not present in repo; need to decide whether to create/update a catalog file or document in issue+stage docs.
@@ -163,9 +163,9 @@ related_to: []
   - `mods/mod-swooper-maps/src/recipes/standard/stages/map-morphology/steps/plotCoasts.ts` and `plotMountains.ts`/`plotVolcanoes.ts` write terrain/feature via adapter only (projection).
   - `packages/civ7-adapter/src/mock-adapter.ts` implements `buildElevation()` as **no‑op** and `expandCoasts()` as simple adjacency; therefore adapter‑only outputs are not trustworthy for viz in mock mode.
 - Map‑hydrology rivers/lakes are adapter calls in map‑hydrology:
-  - `mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/plotRivers.ts` calls `adapter.modelRivers(...)` then `syncHeightfield(context)`.
-  - `mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.ts` calls `adapter.generateLakes(...)`.
-  - `packages/civ7-adapter/src/mock-adapter.ts` `generateLakes()` is **no‑op**; `modelRivers()` is a best‑effort stub. This reinforces pipeline‑owned hydrography as the viz truth.
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/plotRivers.ts` calls `adapter.modelRivers(...)`.
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.ts` calls `adapter.stampLakes(...)` with `artifact:hydrology.lakePlan`.
+  - `packages/civ7-adapter/src/mock-adapter.ts` `stampLakes()` is a terrain-stamping/readback double; `modelRivers()` is a best-effort stub. This reinforces pipeline-owned hydrography as the viz truth.
 - Map‑ecology (biomes/features/effects) writes engine types only:
   - `mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/plotBiomes.ts` and `features/apply.ts` set engine biomes/features.
   - Mock adapter’s `designateBiomes()`/`addFeatures()` are no‑ops (only effect tags), so engine biomes/features aren’t a reliable source for viz in mock runs.
@@ -285,7 +285,7 @@ related_to: []
 
 **Should be pipeline‑owned (override OK)**
 - **Map‑morphology projection** (viz/mock): derive coasts/continents/mountains/volcano masks from `topography`, `coastlineMetrics`, `volcanoes`, and `plotMountains` plan output; avoid adapter‑only effects (engine is projection, not truth).
-- **Map‑hydrology projection** (viz/mock): derive rivers/lakes from hydrography + topography (e.g., riverClass, discharge) instead of `adapter.modelRivers`/`generateLakes`.
+- **Map‑hydrology projection** (viz/mock): derive rivers/lakes from hydrography + topography (e.g., riverClass, discharge, lakePlan) instead of `adapter.modelRivers` or engine lake generation.
 - **Map‑ecology projection** (viz/mock): drive biomes/features/plot‑effects from ecology artifacts + feature intents; do not depend on adapter in mock path.
   - **Plot coasts / terrain stamping**: OK to pipeline‑own for viz/mock (explicit user requirement); treat adapter as gameplay-only projection.
 
@@ -310,10 +310,10 @@ related_to: []
 - `map-morphology/steps/plotVolcanoes.ts` → adapter terrain + feature writes; uses `artifact:morphology.volcanoes`
 - `map-morphology/steps/buildElevation.ts` → adapter `buildElevation()` + `syncHeightfield` (adapter readback)
 - `map-hydrology/steps/plotRivers.ts` → adapter `modelRivers`; references `artifact:hydrology.hydrography` but doesn’t project from it
-- `map-hydrology/steps/lakes.ts` → adapter `generateLakes`
+- `map-hydrology/steps/lakes.ts` → adapter `stampLakes`
 - `map-ecology/steps/plotBiomes.ts` → adapter biome writes from `artifact:ecology.biomeClassification`
 - `placement/steps/placement/apply.ts` → adapter placement calls (wonders/resources/floodplains/starts/discoveries)
-- `packages/civ7-adapter/src/mock-adapter.ts` → no-ops for `buildElevation`, `generateLakes`, `storeWaterData`, `addNaturalWonders`, `generateResources`, `addFloodplains`, `generateDiscoveries`, `assignAdvancedStartRegions` (terrain/biome/feature writes *do* mutate mock arrays)
+- `packages/civ7-adapter/src/mock-adapter.ts` → no-ops for `buildElevation`, `storeWaterData`, `addNaturalWonders`, `generateResources`, `addFloodplains`, `generateDiscoveries`, `assignAdvancedStartRegions`; `stampLakes` mutates terrain and reports readback (terrain/biome/feature writes *do* mutate mock arrays)
 
 **Updated should/should-not**
 - **Override OK (viz/mock, pipeline-owned):**

--- a/docs/system/TESTING.md
+++ b/docs/system/TESTING.md
@@ -55,7 +55,7 @@ Each app and package includes a minimal smoke test and a local `TESTING.md` desc
 For `mods/mod-swooper-maps`, CI/local validation should include:
 
 - Deterministic placement suite (`test/placement/**`) validating stamp-based resources/wonders/discoveries.
-- Hydrology regression suite (`test/map-hydrology/**`, `test/hydrology-plan-lakes.test.ts`) validating sink-driven lake planning and runtime fill parity.
+- Hydrology regression suite (`test/map-hydrology/**`, `test/hydrology/plan-lakes.test.ts`) validating sink-driven lake planning and runtime fill parity.
 - Static policy scans (`test/ecology/no-fudging-static-scan.test.ts`) enforcing no RNG/fudge constructs and no legacy generator call/module usage in scoped ecology/hydrology/placement surfaces.
 
 When these fail, treat them as architecture regressions rather than tuning noise.

--- a/docs/system/libs/mapgen/reference/domains/HYDROLOGY.md
+++ b/docs/system/libs/mapgen/reference/domains/HYDROLOGY.md
@@ -74,6 +74,7 @@ Hydrology domain ops are bound by step contracts. In the standard recipe, Hydrol
 - `computePrecipitation` (baseline + refine strategies)
 - `accumulateDischarge`
 - `projectRiverNetwork`
+- `planLakes`
 - `computeLandWaterBudget`
 - `computeClimateDiagnostics`
 - `computeCryosphereState`, `applyAlbedoFeedback`
@@ -83,9 +84,9 @@ Hydrology domain ops are bound by step contracts. In the standard recipe, Hydrol
 Author-facing control is primarily via stage knobs (compiled at stage compile time). In the standard recipe:
 
 - `hydrology-climate-baseline` knobs: `dryness`, `temperature`, `seasonality`, `oceanCoupling`
-- `hydrology-hydrography` knobs: `riverDensity` (projection thresholds for hydrography)
+- `hydrology-hydrography` knobs: `riverDensity` (projection thresholds for hydrography), `lakeiness` (sink-derived lake intent expansion)
 - `hydrology-climate-refine` knobs: `dryness`, `temperature`, `cryosphere`
-- `map-hydrology` knobs: `lakeiness`, `riverDensity` (engine projection only)
+- `map-hydrology` knobs: `riverDensity` (engine river projection only)
 
 Some steps also expose flat step config surfaces for explicit overrides (e.g., seasonality posture).
 
@@ -94,7 +95,7 @@ Some steps also expose flat step config surfaces for explicit overrides (e.g., s
 The `map-hydrology` stage:
 
 - is `phase: "gameplay"` (projection-only),
-- consumes Hydrology truth artifacts (hydrography) plus Morphology truth (topography),
+- consumes Hydrology truth artifacts (hydrography and lakePlan) plus Morphology truth (topography),
 - publishes effect tags like `effect:engine.riversModeled`,
 - and must not be treated as Hydrology truth.
 

--- a/docs/system/mods/swooper-maps/architecture.md
+++ b/docs/system/mods/swooper-maps/architecture.md
@@ -21,7 +21,7 @@ Current architecture for ecology, lakes, and placement is intentionally physics-
 - Pipeline artifacts are canonical truth (`hydrography`, `lakePlan`, biome/feature intents, resource/wonder/discovery plans).
 - Map and placement stages project those artifacts to engine state; they do not delegate generation authority to engine random generators.
 - Runtime parity is now treated as a contract boundary:
-  - lake plan vs engine water mask mismatch is fail-hard,
+  - lake plan vs engine water mask mismatch is emitted as projection evidence,
   - biome/placement land-water drift is always emitted and remains a strict-candidate gate until a post-hydrology authoritative land mask artifact is finalized.
 
 Placement runtime now uses:

--- a/docs/system/mods/swooper-maps/vision.md
+++ b/docs/system/mods/swooper-maps/vision.md
@@ -56,7 +56,7 @@ flowchart LR
 - No random generator authority remains in active placement paths (resources, natural wonders, discoveries).
 - Hydrology lake planning is sink-driven by default (no upstream expansion by default).
 - Engine projection is downstream evidence only; pipeline artifacts remain the source of truth.
-- Drift between pipeline truth and engine truth at contract boundaries is instrumented everywhere and fail-hard where authoritative comparisons are finalized (currently lake-plan projection).
+- Drift between pipeline truth and engine truth at contract boundaries is instrumented everywhere and fail-hard only where authoritative comparisons are finalized.
 
 ---
 

--- a/mods/mod-swooper-maps/src/domain/hydrology/ops/contracts.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/ops/contracts.ts
@@ -13,6 +13,7 @@ import ComputeLandWaterBudgetContract from "./compute-land-water-budget/contract
 import ComputeClimateDiagnosticsContract from "./compute-climate-diagnostics/contract.js";
 import AccumulateDischargeContract from "./accumulate-discharge/contract.js";
 import ProjectRiverNetworkContract from "./project-river-network/contract.js";
+import PlanLakesContract from "./plan-lakes/contract.js";
 
 export const contracts = {
   computeRadiativeForcing: ComputeRadiativeForcingContract,
@@ -30,6 +31,7 @@ export const contracts = {
   computeClimateDiagnostics: ComputeClimateDiagnosticsContract,
   accumulateDischarge: AccumulateDischargeContract,
   projectRiverNetwork: ProjectRiverNetworkContract,
+  planLakes: PlanLakesContract,
 } as const;
 
 export default contracts;

--- a/mods/mod-swooper-maps/src/domain/hydrology/ops/index.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/ops/index.ts
@@ -16,6 +16,7 @@ import computeLandWaterBudget from "./compute-land-water-budget/index.js";
 import computeClimateDiagnostics from "./compute-climate-diagnostics/index.js";
 import accumulateDischarge from "./accumulate-discharge/index.js";
 import projectRiverNetwork from "./project-river-network/index.js";
+import planLakes from "./plan-lakes/index.js";
 
 const implementations = {
   computeRadiativeForcing,
@@ -33,6 +34,7 @@ const implementations = {
   computeClimateDiagnostics,
   accumulateDischarge,
   projectRiverNetwork,
+  planLakes,
 } as const satisfies DomainOpImplementationsForContracts<typeof contracts>;
 
 export default implementations;
@@ -53,4 +55,5 @@ export {
   computeClimateDiagnostics,
   accumulateDischarge,
   projectRiverNetwork,
+  planLakes,
 };

--- a/mods/mod-swooper-maps/src/domain/hydrology/ops/plan-lakes/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/ops/plan-lakes/contract.ts
@@ -1,5 +1,11 @@
 import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
 
+/**
+ * Hydrology lake planning is the truth-side counterpart to engine lake stamping.
+ * The contract owns the typed inputs and strategy config so implementations can
+ * focus on deterministic intent instead of repeating validation already handled
+ * by the authoring/runtime boundary.
+ */
 const PlanLakesContract = defineOp({
   kind: "compute",
   id: "hydrology/plan-lakes",

--- a/mods/mod-swooper-maps/src/domain/hydrology/ops/plan-lakes/index.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/ops/plan-lakes/index.ts
@@ -1,0 +1,17 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import PlanLakesContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+/**
+ * Op-local registration keeps the lake strategy contract beside the code that
+ * owns it. Domain-level config remains a thin facade for recipe-facing knobs.
+ */
+const planLakes = createOp(PlanLakesContract, {
+  strategies: { default: defaultStrategy },
+});
+
+export type * from "./types.js";
+export type * from "./contract.js";
+
+export default planLakes;

--- a/mods/mod-swooper-maps/src/domain/hydrology/ops/plan-lakes/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/ops/plan-lakes/strategies/default.ts
@@ -1,0 +1,49 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import PlanLakesContract from "../contract.js";
+
+/**
+ * Default lake planning strategy.
+ *
+ * Sinks are the minimum lake intent because they are where Hydrology routing
+ * terminates on land. Optional upstream expansion is deliberately bounded and
+ * follows `flowDir` receivers so "many lakes" grows from drainage structure
+ * rather than reintroducing engine frequency heuristics.
+ */
+export const defaultStrategy = createStrategy(PlanLakesContract, "default", {
+  run: (input, config) => {
+    const width = input.width | 0;
+    const height = input.height | 0;
+    const size = Math.max(0, width * height);
+
+    const lakeMask = new Uint8Array(size);
+    let sinkLakeCount = 0;
+    for (let i = 0; i < size; i++) {
+      if (input.landMask[i] !== 1 || input.sinkMask[i] !== 1) continue;
+      lakeMask[i] = 1;
+      sinkLakeCount += 1;
+    }
+
+    let frontier = lakeMask;
+    const maxUpstreamSteps = Math.max(0, config.maxUpstreamSteps | 0);
+    for (let step = 0; step < maxUpstreamSteps; step++) {
+      const nextFrontier = new Uint8Array(size);
+      for (let i = 0; i < size; i++) {
+        if (input.landMask[i] !== 1 || lakeMask[i] === 1) continue;
+        const receiver = input.flowDir[i] ?? -1;
+        if (receiver < 0 || receiver >= size) continue;
+        if (frontier[receiver] !== 1) continue;
+        lakeMask[i] = 1;
+        nextFrontier[i] = 1;
+      }
+      frontier = nextFrontier;
+    }
+
+    let plannedLakeTileCount = 0;
+    for (let i = 0; i < size; i++) {
+      if (lakeMask[i] === 1) plannedLakeTileCount += 1;
+    }
+
+    return { lakeMask, plannedLakeTileCount, sinkLakeCount } as const;
+  },
+});

--- a/mods/mod-swooper-maps/src/domain/hydrology/ops/plan-lakes/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/ops/plan-lakes/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/domain/hydrology/ops/plan-lakes/types.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/ops/plan-lakes/types.ts
@@ -1,0 +1,9 @@
+import type { OpTypeBagOf } from "@swooper/mapgen-core/authoring";
+
+type Contract = typeof import("./contract.js").default;
+
+/**
+ * Generated op type bag for plan-lakes consumers.
+ * Keeping the alias op-local avoids a shared hydrology config/type dumping ground.
+ */
+export type PlanLakesTypes = OpTypeBagOf<Contract>;

--- a/mods/mod-swooper-maps/src/domain/hydrology/shared/knob-multipliers.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/shared/knob-multipliers.ts
@@ -83,10 +83,15 @@ export const HYDROLOGY_OROGRAPHIC_REDUCTION_BASE = 8 as const;
 export const HYDROLOGY_OROGRAPHIC_REDUCTION_PER_STEP = 6 as const;
 export const HYDROLOGY_WATER_GRADIENT_LOWLAND_BONUS_BASE = 2 as const;
 
-export const HYDROLOGY_LAKEINESS_TILES_PER_LAKE_MULTIPLIER = {
-  few: 1.5,
-  normal: 1.0,
-  many: 0.7,
+/**
+ * Lakeiness now tunes Hydrology-owned intent, not Civ7's lake frequency.
+ * Keeping the transform in sink/upstream terms preserves the invariant that
+ * `map-hydrology` only projects a plan it did not author.
+ */
+export const HYDROLOGY_LAKEINESS_UPSTREAM_EXPANSION_STEPS = {
+  few: 0,
+  normal: 0,
+  many: 1,
 } as const satisfies Record<HydrologyLakeinessKnob, number>;
 
 export const HYDROLOGY_RIVER_DENSITY_LENGTH_BOUNDS = {

--- a/mods/mod-swooper-maps/src/domain/hydrology/shared/knobs.ts
+++ b/mods/mod-swooper-maps/src/domain/hydrology/shared/knobs.ts
@@ -121,19 +121,18 @@ export type HydrologyRiverDensityKnob = Static<typeof HydrologyRiverDensityKnobS
  * Hydrology lakeiness knob (semantic intent).
  *
  * Meaning:
- * - Lake projection frequency bias (does not change discharge routing truth).
+ * - Lake intent expansion bias over already-derived hydrology sinks.
  *
  * Stage scope:
- * - Used by `hydrology-climate-baseline` only.
+ * - Used by `hydrology-hydrography` only.
  */
 export const HydrologyLakeinessKnobSchema = Type.Union(
   [Type.Literal("few"), Type.Literal("normal"), Type.Literal("many")],
   {
     default: "normal",
     description:
-      "Lake projection frequency preset (few/normal/many). Applies as a deterministic multiplier over lake projection frequency; routing/discharge truth is unchanged.",
+      "Lake intent preset (few/normal/many). Applies as a deterministic transform over sink-derived lake planning; engine projection remains downstream.",
   }
 );
 
 export type HydrologyLakeinessKnob = Static<typeof HydrologyLakeinessKnobSchema>;
-

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
@@ -237,6 +237,7 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
   "hydrology-hydrography": {
     knobs: {
       riverDensity: "dense",
+      lakeiness: "normal",
     },
   },
   "hydrology-climate-refine": {
@@ -248,7 +249,6 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
   },
   "map-hydrology": {
     knobs: {
-      lakeiness: "normal",
       riverDensity: "dense",
     },
   },

--- a/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
@@ -239,6 +239,7 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
   "hydrology-hydrography": {
     knobs: {
       riverDensity: "dense",
+      lakeiness: "normal",
     },
   },
   "hydrology-climate-refine": {
@@ -250,7 +251,6 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
   },
   "map-hydrology": {
     knobs: {
-      lakeiness: "normal",
       riverDensity: "dense",
     },
   },

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
@@ -227,6 +227,7 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
   "hydrology-hydrography": {
     knobs: {
       riverDensity: "sparse",
+      lakeiness: "few",
     },
   },
   "hydrology-climate-refine": {
@@ -238,7 +239,6 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
   },
   "map-hydrology": {
     knobs: {
-      lakeiness: "few",
       riverDensity: "sparse",
     },
   },

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -479,7 +479,8 @@
   },
   "hydrology-hydrography": {
     "knobs": {
-      "riverDensity": "dense"
+      "riverDensity": "dense",
+      "lakeiness": "normal"
     },
     "rivers": {
       "accumulateDischarge": {
@@ -971,12 +972,9 @@
   },
   "map-hydrology": {
     "knobs": {
-      "lakeiness": "normal",
       "riverDensity": "dense"
     },
-    "lakes": {
-      "tilesPerLakeMultiplier": 1
-    },
+    "lakes": {},
     "plot-rivers": {
       "minLength": 5,
       "maxLength": 15

--- a/mods/mod-swooper-maps/src/presets/standard/earthlike.json
+++ b/mods/mod-swooper-maps/src/presets/standard/earthlike.json
@@ -483,7 +483,8 @@
     },
     "hydrology-hydrography": {
       "knobs": {
-        "riverDensity": "dense"
+        "riverDensity": "dense",
+        "lakeiness": "normal"
       },
       "rivers": {
         "accumulateDischarge": {
@@ -975,12 +976,9 @@
     },
     "map-hydrology": {
       "knobs": {
-        "lakeiness": "normal",
         "riverDensity": "dense"
       },
-      "lakes": {
-        "tilesPerLakeMultiplier": 1
-      },
+      "lakes": {},
       "plot-rivers": {
         "minLength": 5,
         "maxLength": 15

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/artifacts.ts
@@ -20,17 +20,24 @@ export const HydrologyHydrographyArtifactSchema = Type.Object(
     riverClass: TypedArraySchemas.u8({
       description: "River class per tile (0=none, 1=minor, 2=major).",
     }),
+    /** Steepest-descent receiver index per tile, used by downstream Hydrology lake planning. */
+    flowDir: TypedArraySchemas.i32({
+      description: "Steepest-descent receiver index per tile (or -1 for sinks/edges).",
+    }),
     /** Routing sinks: candidate endorheic basins / internal drainage endpoints. */
     sinkMask: TypedArraySchemas.u8({
       description: "Mask (1/0): land tiles that are routing sinks (candidate endorheic basins).",
     }),
     /** Routing outlets: land tiles that drain to ocean/edges (land→water/out-of-bounds). */
     outletMask: TypedArraySchemas.u8({
-      description: "Mask (1/0): land tiles that drain directly to ocean/edges (land→water/out-of-bounds).",
+      description:
+        "Mask (1/0): land tiles that drain directly to ocean/edges (land→water/out-of-bounds).",
     }),
     /** Optional basin identifier per tile (or -1 when unassigned). */
     basinId: Type.Optional(
-      TypedArraySchemas.i32({ description: "Optional basin identifier per tile (or -1 when unassigned)." })
+      TypedArraySchemas.i32({
+        description: "Optional basin identifier per tile (or -1 when unassigned).",
+      })
     ),
   },
   {
@@ -45,7 +52,8 @@ export const HydrologyEngineProjectionArtifactSchema = Type.Object(
     width: Type.Integer({ minimum: 1 }),
     height: Type.Integer({ minimum: 1 }),
     lakeMask: TypedArraySchemas.u8({
-      description: "Engine water mask attributable to map-hydrology projection (1=water, 0=land).",
+      description:
+        "Engine-accepted lake mask attributable to map-hydrology projection (1=accepted lake, 0=not accepted).",
     }),
     riverMask: TypedArraySchemas.u8({
       description:
@@ -69,11 +77,39 @@ export const HydrologyEngineProjectionArtifactSchema = Type.Object(
   }
 );
 
+export const HydrologyLakePlanArtifactSchema = Type.Object(
+  {
+    width: Type.Integer({ minimum: 1 }),
+    height: Type.Integer({ minimum: 1 }),
+    lakeMask: TypedArraySchemas.u8({
+      description: "Deterministic Hydrology lake intent mask (1=planned lake, 0=not planned).",
+    }),
+    plannedLakeTileCount: Type.Integer({
+      minimum: 0,
+      description: "Count of tiles marked as planned lakes.",
+    }),
+    sinkLakeCount: Type.Integer({
+      minimum: 0,
+      description: "Count of hydrography sink tiles mapped to lake tiles.",
+    }),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Hydrology-owned deterministic lake intent plan consumed by map-hydrology projection and placement.",
+  }
+);
+
 export const hydrologyHydrographyArtifacts = {
   hydrography: defineArtifact({
     name: "hydrography",
     id: "artifact:hydrology.hydrography",
     schema: HydrologyHydrographyArtifactSchema,
+  }),
+  lakePlan: defineArtifact({
+    name: "lakePlan",
+    id: "artifact:hydrology.lakePlan",
+    schema: HydrologyLakePlanArtifactSchema,
   }),
   engineProjectionLakes: defineArtifact({
     name: "engineProjectionLakes",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/index.ts
@@ -1,6 +1,9 @@
 import { Type, createStage } from "@swooper/mapgen-core/authoring";
-import { rivers } from "./steps/index.js";
-import { HydrologyRiverDensityKnobSchema } from "@mapgen/domain/hydrology/config.js";
+import { lakes, rivers } from "./steps/index.js";
+import {
+  HydrologyLakeinessKnobSchema,
+  HydrologyRiverDensityKnobSchema,
+} from "@mapgen/domain/hydrology/config.js";
 
 const knobsSchema = Type.Object(
   {
@@ -12,15 +15,23 @@ const knobsSchema = Type.Object(
      * - Does not change discharge routing truth (only projection/classification).
      */
     riverDensity: Type.Optional(HydrologyRiverDensityKnobSchema),
+    /**
+     * Hydrology lake intent density.
+     *
+     * Stage scope:
+     * - Transforms `plan-lakes` over the defaulted op config.
+     * - Does not call Civ7 lake generation or tune projection frequency.
+     */
+    lakeiness: Type.Optional(HydrologyLakeinessKnobSchema),
   },
   {
     description:
-      "Hydrology hydrography knobs (riverDensity). Knobs apply after defaulted step config as deterministic transforms.",
+      "Hydrology hydrography knobs (riverDensity/lakeiness). Knobs apply after defaulted step config as deterministic transforms.",
   }
 );
 
 export default createStage({
   id: "hydrology-hydrography",
   knobsSchema,
-  steps: [rivers],
+  steps: [rivers, lakes],
 } as const);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/index.ts
@@ -1,1 +1,2 @@
+export { default as lakes } from "./lakes.js";
 export { default as rivers } from "./rivers.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/lakes.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/lakes.contract.ts
@@ -1,0 +1,38 @@
+import { Type, defineStep } from "@swooper/mapgen-core/authoring";
+import hydrology from "@mapgen/domain/hydrology";
+
+import { hydrologyHydrographyArtifacts } from "../artifacts.js";
+import { morphologyArtifacts } from "../../morphology/artifacts.js";
+
+/**
+ * Lake intent step contract.
+ *
+ * `planLakes` is declared through `contract.ops`, so the authoring layer owns
+ * the op envelope and default strategy injection. The step schema stays empty
+ * to avoid a second, divergent config surface for the same operation.
+ */
+const LakesStepConfigSchema = Type.Object(
+  {},
+  {
+    additionalProperties: false,
+    description:
+      "Hydrology lake planning config. Produces deterministic lake intent; map-hydrology projects it.",
+  }
+);
+
+const LakesStepContract = defineStep({
+  id: "lakes",
+  phase: "hydrology",
+  requires: [],
+  provides: [],
+  artifacts: {
+    requires: [morphologyArtifacts.topography, hydrologyHydrographyArtifacts.hydrography],
+    provides: [hydrologyHydrographyArtifacts.lakePlan],
+  },
+  ops: {
+    planLakes: hydrology.ops.planLakes,
+  },
+  schema: LakesStepConfigSchema,
+});
+
+export default LakesStepContract;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/lakes.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/lakes.ts
@@ -1,0 +1,73 @@
+import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
+import { defineVizMeta } from "@swooper/mapgen-core";
+import { HYDROLOGY_LAKEINESS_UPSTREAM_EXPANSION_STEPS } from "@mapgen/domain/hydrology/config.js";
+import type { HydrologyLakeinessKnob } from "@mapgen/domain/hydrology/config.js";
+
+import { hydrologyHydrographyArtifacts } from "../artifacts.js";
+import LakesStepContract from "./lakes.contract.js";
+
+const GROUP_HYDROGRAPHY = "Hydrology / Hydrography";
+const TILE_SPACE_ID = "tile.hexOddR" as const;
+
+export default createStep(LakesStepContract, {
+  artifacts: implementArtifacts([hydrologyHydrographyArtifacts.lakePlan], {
+    lakePlan: {},
+  }),
+  normalize: (config, ctx) => {
+    const { lakeiness = "normal" as HydrologyLakeinessKnob } = ctx.knobs as {
+      lakeiness?: HydrologyLakeinessKnob;
+    };
+    if (config.planLakes.strategy !== "default") return config;
+
+    const maxUpstreamSteps = Math.max(
+      config.planLakes.config.maxUpstreamSteps,
+      HYDROLOGY_LAKEINESS_UPSTREAM_EXPANSION_STEPS[lakeiness]
+    );
+
+    return {
+      ...config,
+      planLakes: {
+        ...config.planLakes,
+        config: { ...config.planLakes.config, maxUpstreamSteps },
+      },
+    };
+  },
+  run: (context, config, ops, deps) => {
+    const { width, height } = context.dimensions;
+    const topography = deps.artifacts.topography.read(context);
+    const hydrography = deps.artifacts.hydrography.read(context);
+    // Hydrology publishes lake intent before the map stage touches engine terrain.
+    // Placement and diagnostics read this truth artifact instead of engine readback.
+    const lakePlan = ops.planLakes(
+      {
+        width,
+        height,
+        landMask: topography.landMask,
+        flowDir: hydrography.flowDir,
+        sinkMask: hydrography.sinkMask,
+      },
+      config.planLakes
+    );
+
+    deps.artifacts.lakePlan.publish(context, {
+      width,
+      height,
+      lakeMask: lakePlan.lakeMask,
+      plannedLakeTileCount: lakePlan.plannedLakeTileCount,
+      sinkLakeCount: lakePlan.sinkLakeCount,
+    });
+
+    context.viz?.dumpGrid(context.trace, {
+      dataTypeKey: "hydrology.lakes.lakePlan",
+      spaceId: TILE_SPACE_ID,
+      dims: { width, height },
+      format: "u8",
+      values: lakePlan.lakeMask,
+      meta: defineVizMeta("hydrology.lakes.lakePlan", {
+        label: "Lake Plan",
+        group: GROUP_HYDROGRAPHY,
+        palette: "categorical",
+      }),
+    });
+  },
+});

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/rivers.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/hydrology-hydrography/steps/rivers.ts
@@ -53,6 +53,7 @@ function validateHydrography(value: unknown, dimensions: MapDimensions): Artifac
     runoff?: unknown;
     discharge?: unknown;
     riverClass?: unknown;
+    flowDir?: unknown;
     sinkMask?: unknown;
     outletMask?: unknown;
     basinId?: unknown;
@@ -60,6 +61,7 @@ function validateHydrography(value: unknown, dimensions: MapDimensions): Artifac
   validateTypedArray(errors, "hydrography.runoff", candidate.runoff, Float32Array, size);
   validateTypedArray(errors, "hydrography.discharge", candidate.discharge, Float32Array, size);
   validateTypedArray(errors, "hydrography.riverClass", candidate.riverClass, Uint8Array, size);
+  validateTypedArray(errors, "hydrography.flowDir", candidate.flowDir, Int32Array, size);
   validateTypedArray(errors, "hydrography.sinkMask", candidate.sinkMask, Uint8Array, size);
   validateTypedArray(errors, "hydrography.outletMask", candidate.outletMask, Uint8Array, size);
   if (candidate.basinId != null)
@@ -164,6 +166,7 @@ export default createStep(RiversStepContract, {
       runoff: discharge.runoff,
       discharge: discharge.discharge,
       riverClass: projected.riverClass,
+      flowDir,
       sinkMask: discharge.sinkMask,
       outletMask: discharge.outletMask,
     });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/index.ts
@@ -1,18 +1,14 @@
 import { Type, createStage } from "@swooper/mapgen-core/authoring";
-import {
-  HydrologyLakeinessKnobSchema,
-  HydrologyRiverDensityKnobSchema,
-} from "@mapgen/domain/hydrology/config.js";
+import { HydrologyRiverDensityKnobSchema } from "@mapgen/domain/hydrology/config.js";
 import { lakes, plotRivers } from "./steps/index.js";
 
 const knobsSchema = Type.Object(
   {
-    lakeiness: Type.Optional(HydrologyLakeinessKnobSchema),
     riverDensity: Type.Optional(HydrologyRiverDensityKnobSchema),
   },
   {
     description:
-      "Map-hydrology knobs (lakeiness/riverDensity). Knobs apply to engine projection only.",
+      "Map-hydrology knobs (riverDensity). Knobs apply to engine projection only.",
   }
 );
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.contract.ts
@@ -8,29 +8,20 @@ import { hydrologyHydrographyArtifacts } from "../../hydrology-hydrography/artif
 /**
  * Lake projection step (engine-facing).
  *
- * Lakes are projected via engine mechanisms as a Gameplay projection only.
- * This step must remain deterministic and must not embed regional “paint” behavior inside Hydrology truth.
+ * Hydrology owns lake intent. This map stage only materializes that intent and
+ * records readback evidence from the adapter.
  */
 const LakesStepConfigSchema = Type.Object(
   {
-    /**
-     * Multiplier applied to engine lake frequency.
-     *
-     * Practical guidance:
-     * - If you want more lakes: decrease this value (e.g. 0.75).
-     * - If you want fewer lakes: increase this value (e.g. 1.5).
-     */
-    tilesPerLakeMultiplier: Type.Number({
-      description: "Multiplier applied to the engine lake frequency (higher = fewer lakes; lower = more lakes).",
-      default: 1,
-      minimum: 0.25,
-      maximum: 4,
+    projectionReadback: Type.Boolean({
+      description: "Whether to emit projection readback diagnostics for the planned lake mask.",
+      default: true,
     }),
   },
   {
     additionalProperties: false,
     description:
-      "Lakes step config. Controls lake frequency projection only; does not change Hydrology discharge routing truth.",
+      "Lakes projection config. Hydrology lake intent is produced upstream; this step only stamps and records readback.",
   }
 );
 
@@ -40,7 +31,7 @@ const LakesStepContract = defineStep({
   requires: [],
   provides: [MAP_PROJECTION_EFFECT_TAGS.map.hydrologyLakesParityCaptured],
   artifacts: {
-    requires: [morphologyArtifacts.topography, hydrologyHydrographyArtifacts.hydrography],
+    requires: [morphologyArtifacts.topography, hydrologyHydrographyArtifacts.lakePlan],
     provides: [
       hydrologyHydrographyArtifacts.engineProjectionLakes,
       mapArtifacts.hydrologyLakesEngineTerrainSnapshot,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.ts
@@ -1,9 +1,6 @@
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import { defineVizMeta, snapshotEngineHeightfield } from "@swooper/mapgen-core";
-import { getStandardRuntime } from "../../../runtime.js";
 import LakesStepContract from "./lakes.contract.js";
-import { HYDROLOGY_LAKEINESS_TILES_PER_LAKE_MULTIPLIER } from "@mapgen/domain/hydrology/config.js";
-import type { HydrologyLakeinessKnob } from "@mapgen/domain/hydrology/config.js";
 import { hydrologyHydrographyArtifacts } from "../../hydrology-hydrography/artifacts.js";
 import { mapArtifacts } from "../../../map-artifacts.js";
 
@@ -21,87 +18,37 @@ export default createStep(LakesStepContract, {
       hydrologyLakesEngineTerrainSnapshot: {},
     }
   ),
-  normalize: (config, ctx) => {
-    const { lakeiness = "normal" as HydrologyLakeinessKnob } = ctx.knobs as {
-      lakeiness?: HydrologyLakeinessKnob;
-    };
-    const tilesPerLakeMultiplier =
-      config.tilesPerLakeMultiplier * HYDROLOGY_LAKEINESS_TILES_PER_LAKE_MULTIPLIER[lakeiness];
-    return tilesPerLakeMultiplier === config.tilesPerLakeMultiplier
-      ? config
-      : { ...config, tilesPerLakeMultiplier };
-  },
   run: (context, config, _ops, deps) => {
-    const hydrography = deps.artifacts.hydrography.read(context);
-    const runtime = getStandardRuntime(context);
+    const lakePlan = deps.artifacts.lakePlan.read(context);
     const { width, height } = context.dimensions;
-    const baseTilesPerLake = Math.max(10, runtime.mapInfo.LakeGenerationFrequency ?? 5);
-    const tilesPerLake = Math.max(10, Math.round(baseTilesPerLake * config.tilesPerLakeMultiplier));
 
-    // Map-stage visualization: hydrology sink/outlet masks are inputs to engine lake generation (not 1:1 with engine results).
+    // Map-stage visualization: planned lakes are Hydrology truth. This step only materializes and reads back.
     context.viz?.dumpGrid(context.trace, {
-      dataTypeKey: "map.hydrology.lakes.sinkMask",
+      dataTypeKey: "map.hydrology.lakes.plannedLakeMask",
       spaceId: TILE_SPACE_ID,
       dims: { width, height },
       format: "u8",
-      values: hydrography.sinkMask,
-      meta: defineVizMeta("map.hydrology.lakes.sinkMask", {
-        label: "Lake Sinks (Hydrology)",
+      values: lakePlan.lakeMask,
+      meta: defineVizMeta("map.hydrology.lakes.plannedLakeMask", {
+        label: "Lake Mask (Planned)",
         group: GROUP_MAP_HYDROLOGY,
         palette: "categorical",
-      }),
-    });
-    context.viz?.dumpGrid(context.trace, {
-      dataTypeKey: "map.hydrology.lakes.outletMask",
-      spaceId: TILE_SPACE_ID,
-      dims: { width, height },
-      format: "u8",
-      values: hydrography.outletMask,
-      meta: defineVizMeta("map.hydrology.lakes.outletMask", {
-        label: "Lake Outlets (Hydrology)",
-        group: GROUP_MAP_HYDROLOGY,
-        palette: "categorical",
-        visibility: "debug",
+        role: "physics",
       }),
     });
 
-    // Capture a pre-projection snapshot so we can isolate "new water on prior land" (lakes)
-    // instead of treating all existing water (ocean) as lake coverage.
-    context.adapter.storeWaterData();
-    const engineBefore = snapshotEngineHeightfield(context);
-
-    context.adapter.generateLakes(width, height, tilesPerLake);
-
-    // Keep area topology in sync with post-lake terrain edits before any downstream validation.
-    // Base-standard scripts always rebuild areas immediately after generateLakes().
-    context.adapter.recalculateAreas();
-
-    // Our pipeline projects lakes after buildElevation(), so refresh water caches explicitly.
-    // This ensures GameplayMap.isWater and downstream eligibility reads include new lakes.
-    context.adapter.storeWaterData();
+    // The adapter is the only engine boundary. Stamping plus readback stays there
+    // so this stage records projection evidence without owning Civ7 terrain APIs.
+    const projection = context.adapter.stampLakes(width, height, lakePlan.lakeMask);
     const physics = context.buffers.heightfield;
     const engineAfter = snapshotEngineHeightfield(context);
-    if (engineBefore && engineAfter) {
-      const lakeMask = new Uint8Array(width * height);
-      const sinkMismatchMask = new Uint8Array(width * height);
-      let sinkMismatchCount = 0;
-      for (let i = 0; i < lakeMask.length; i++) {
-        const wasLand = (engineBefore.landMask[i] ?? 1) === 1;
-        const isWater = (engineAfter.landMask[i] ?? 1) === 0;
-        const becameWater = wasLand && isWater;
-        lakeMask[i] = becameWater ? 1 : 0;
-        if ((hydrography.sinkMask[i] ?? 0) === 1 && lakeMask[i] === 0) {
-          sinkMismatchMask[i] = 1;
-          sinkMismatchCount += 1;
-        }
-      }
-
+    if (engineAfter) {
       deps.artifacts.engineProjectionLakes.publish(context, {
         width,
         height,
-        lakeMask,
+        lakeMask: projection.stampedLakeMask,
         riverMask: new Uint8Array(width * height),
-        sinkMismatchCount,
+        sinkMismatchCount: projection.rejectedLakeTileCount,
         riverMismatchCount: 0,
       });
 
@@ -116,39 +63,44 @@ export default createStep(LakesStepContract, {
 
       context.trace.event(() => ({
         type: "map.hydrology.lakes.parity",
-        sinkMismatchCount,
-        sinkMismatchShare: Number((sinkMismatchCount / Math.max(1, width * height)).toFixed(4)),
+        plannedLakeTileCount: projection.plannedLakeTileCount,
+        stampedLakeTileCount: projection.stampedLakeTileCount,
+        rejectedLakeTileCount: projection.rejectedLakeTileCount,
+        rejectedLakeShare: Number(
+          (projection.rejectedLakeTileCount / Math.max(1, projection.plannedLakeTileCount)).toFixed(
+            4
+          )
+        ),
       }));
-      // NOTE: hydrography.sinkMask is a drainage diagnostic (candidate sinks), not
-      // a deterministic lake-intent contract for engine projection.
-      // Keep this as parity telemetry rather than a runtime gate.
 
-      context.viz?.dumpGrid(context.trace, {
-        dataTypeKey: "map.hydrology.lakes.engineLakeMask",
-        spaceId: TILE_SPACE_ID,
-        dims: { width, height },
-        format: "u8",
-        values: lakeMask,
-        meta: defineVizMeta("map.hydrology.lakes.engineLakeMask", {
-          label: "Lake Mask (Engine)",
-          group: GROUP_MAP_HYDROLOGY,
-          palette: "categorical",
-          role: "engine",
-        }),
-      });
-      context.viz?.dumpGrid(context.trace, {
-        dataTypeKey: "map.hydrology.lakes.sinkMismatchMask",
-        spaceId: TILE_SPACE_ID,
-        dims: { width, height },
-        format: "u8",
-        values: sinkMismatchMask,
-        meta: defineVizMeta("map.hydrology.lakes.sinkMismatchMask", {
-          label: "Sink Mismatch Mask",
-          group: GROUP_MAP_HYDROLOGY,
-          palette: "categorical",
-          visibility: "debug",
-        }),
-      });
+      if (config.projectionReadback) {
+        context.viz?.dumpGrid(context.trace, {
+          dataTypeKey: "map.hydrology.lakes.engineLakeMask",
+          spaceId: TILE_SPACE_ID,
+          dims: { width, height },
+          format: "u8",
+          values: projection.stampedLakeMask,
+          meta: defineVizMeta("map.hydrology.lakes.engineLakeMask", {
+            label: "Lake Mask (Engine)",
+            group: GROUP_MAP_HYDROLOGY,
+            palette: "categorical",
+            role: "engine",
+          }),
+        });
+        context.viz?.dumpGrid(context.trace, {
+          dataTypeKey: "map.hydrology.lakes.rejectedLakeMask",
+          spaceId: TILE_SPACE_ID,
+          dims: { width, height },
+          format: "u8",
+          values: projection.rejectedLakeMask,
+          meta: defineVizMeta("map.hydrology.lakes.rejectedLakeMask", {
+            label: "Rejected Lake Mask",
+            group: GROUP_MAP_HYDROLOGY,
+            palette: "categorical",
+            visibility: "debug",
+          }),
+        });
+      }
 
       context.viz?.dumpGrid(context.trace, {
         dataTypeKey: "debug.heightfield.landMask",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/contract.ts
@@ -9,6 +9,10 @@ import { morphologyArtifacts } from "../../../morphology/artifacts.js";
 
 /**
  * Builds the placement input artifact from runtime config and placement ops.
+ *
+ * Placement consumes Hydrology lake truth (`lakePlan`) rather than projection
+ * diagnostics so downstream planning does not inherit engine readback drift as
+ * source authority.
  */
 const DerivePlacementInputsContract = defineStep({
   id: "derive-placement-inputs",
@@ -22,7 +26,7 @@ const DerivePlacementInputsContract = defineStep({
     requires: [
       morphologyArtifacts.topography,
       hydrologyHydrographyArtifacts.hydrography,
-      hydrologyHydrographyArtifacts.engineProjectionLakes,
+      hydrologyHydrographyArtifacts.lakePlan,
       ecologyArtifacts.biomeClassification,
       ecologyArtifacts.pedology,
     ],

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/index.ts
@@ -5,21 +5,26 @@ import { buildPlacementInputs } from "./inputs.js";
 import { placementArtifacts } from "../../artifacts.js";
 
 export default createStep(DerivePlacementInputsContract, {
-  artifacts: implementArtifacts([
-    placementArtifacts.placementInputs,
-    placementArtifacts.resourcePlan,
-    placementArtifacts.naturalWonderPlan,
-    placementArtifacts.discoveryPlan,
-  ], {
-    placementInputs: {},
-    resourcePlan: {},
-    naturalWonderPlan: {},
-    discoveryPlan: {},
-  }),
+  artifacts: implementArtifacts(
+    [
+      placementArtifacts.placementInputs,
+      placementArtifacts.resourcePlan,
+      placementArtifacts.naturalWonderPlan,
+      placementArtifacts.discoveryPlan,
+    ],
+    {
+      placementInputs: {},
+      resourcePlan: {},
+      naturalWonderPlan: {},
+      discoveryPlan: {},
+    }
+  ),
   run: (context, config, ops, deps) => {
     const topography = deps.artifacts.topography.read(context);
     const hydrography = deps.artifacts.hydrography.read(context);
-    const lakePlan = deps.artifacts.engineProjectionLakes.read(context);
+    // Lake placement constraints use the deterministic Hydrology plan. Engine
+    // projection artifacts remain diagnostics for materialization drift.
+    const lakePlan = deps.artifacts.lakePlan.read(context);
     const biomeClassification = deps.artifacts.biomeClassification.read(context);
     const pedology = deps.artifacts.pedology.read(context);
 

--- a/mods/mod-swooper-maps/test/hydrology-knobs.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology-knobs.test.ts
@@ -47,6 +47,7 @@ describe("hydrology knobs compilation", () => {
       "hydrology-climate-baseline": {
         knobs: { dryness: "wet", seasonality: "high", oceanCoupling: "earthlike" },
       },
+      "hydrology-hydrography": { knobs: { riverDensity: "dense", lakeiness: "many" } },
       "map-hydrology": { knobs: { riverDensity: "dense" } },
       "hydrology-climate-refine": { knobs: { dryness: "wet" } },
     } as const;
@@ -117,10 +118,12 @@ describe("hydrology knobs compilation", () => {
     const compiled = standardRecipe.compileConfig(
       env,
       withFoundation({
+        "hydrology-hydrography": { lakes: {} },
         "map-hydrology": { lakes: {} },
       })
     );
-    expect(compiled["map-hydrology"].lakes.tilesPerLakeMultiplier).toBe(1);
+    expect(compiled["hydrology-hydrography"].lakes.planLakes.config.maxUpstreamSteps).toBe(0);
+    expect(compiled["map-hydrology"].lakes.projectionReadback).toBe(true);
   });
 
   it("applies knobs as deterministic transforms over flat step config baselines", () => {
@@ -143,9 +146,27 @@ describe("hydrology knobs compilation", () => {
             },
           },
         },
-        "map-hydrology": {
+        "hydrology-hydrography": {
           knobs: { riverDensity: "dense", lakeiness: "many" },
-          lakes: { tilesPerLakeMultiplier: 2 },
+          lakes: {
+            planLakes: {
+              strategy: "default",
+              config: { maxUpstreamSteps: 0 },
+            },
+          },
+          rivers: {
+            projectRiverNetwork: {
+              strategy: "default",
+              config: {
+                minorPercentile: 0.85,
+                majorPercentile: 0.95,
+              },
+            },
+          },
+        },
+        "map-hydrology": {
+          knobs: { riverDensity: "dense" },
+          lakes: { projectionReadback: true },
           "plot-rivers": { minLength: 11, maxLength: 11 },
         },
         "hydrology-climate-refine": {
@@ -174,13 +195,20 @@ describe("hydrology knobs compilation", () => {
     );
 
     // Baseline values apply first (schema defaults + flat step config), then knobs transform them.
-    // - lakeiness=many multiplies tilesPerLakeMultiplier by 0.7 (more lakes).
-    expect(compiled["map-hydrology"].lakes.tilesPerLakeMultiplier).toBeCloseTo(1.4, 6);
+    // - lakeiness=many expands Hydrology lake intent one upstream hop from sink tiles.
+    expect(compiled["hydrology-hydrography"].lakes.planLakes.config.maxUpstreamSteps).toBe(1);
     // - dryness=wet scales rainfallScale by 1.15 (wetter climate).
     expect(
       compiled["hydrology-climate-baseline"]["climate-baseline"].computePrecipitation.config
         .rainfallScale
     ).toBeCloseTo(141.45, 6);
+    // - riverDensity=dense shifts Hydrology river projection percentiles down relative to normal.
+    expect(
+      compiled["hydrology-hydrography"].rivers.projectRiverNetwork.config.minorPercentile
+    ).toBeCloseTo(0.78, 6);
+    expect(
+      compiled["hydrology-hydrography"].rivers.projectRiverNetwork.config.majorPercentile
+    ).toBeCloseTo(0.91, 6);
     // - riverDensity=dense shifts length bounds down relative to normal.
     expect(compiled["map-hydrology"]["plot-rivers"].minLength).toBe(9);
     // Note: clamp enforces schema bounds and keeps maxLength >= minLength.

--- a/mods/mod-swooper-maps/test/hydrology/plan-lakes.test.ts
+++ b/mods/mod-swooper-maps/test/hydrology/plan-lakes.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+
+import { defaultStrategy as planLakes } from "../../src/domain/hydrology/ops/plan-lakes/strategies/default.js";
+
+/**
+ * Plan-lakes strategy tests.
+ *
+ * These cover the category-level contract for Hydrology lake truth: sinks
+ * create deterministic lake intent, and optional density expansion follows
+ * drainage receivers instead of engine lake-generation frequency.
+ */
+describe("hydrology/plan-lakes", () => {
+  it("plans land sinks as lake intent and ignores water sinks", () => {
+    const width = 4;
+    const height = 3;
+    const size = width * height;
+    const landMask = new Uint8Array(size).fill(1);
+    const sinkMask = new Uint8Array(size);
+    sinkMask[5] = 1;
+    sinkMask[6] = 1;
+    landMask[6] = 0;
+
+    const result = planLakes.run(
+      {
+        width,
+        height,
+        landMask,
+        flowDir: new Int32Array(size).fill(-1),
+        sinkMask,
+      },
+      { maxUpstreamSteps: 0 }
+    );
+
+    expect(result.sinkLakeCount).toBe(1);
+    expect(result.plannedLakeTileCount).toBe(1);
+    expect(result.lakeMask[5]).toBe(1);
+    expect(result.lakeMask[6]).toBe(0);
+  });
+
+  it("expands lake intent upstream through flow receivers when configured", () => {
+    const width = 5;
+    const height = 1;
+    const size = width * height;
+    const sinkMask = new Uint8Array(size);
+    sinkMask[4] = 1;
+    const flowDir = new Int32Array([-1, 2, 3, 4, -1]);
+
+    const result = planLakes.run(
+      {
+        width,
+        height,
+        landMask: new Uint8Array(size).fill(1),
+        flowDir,
+        sinkMask,
+      },
+      { maxUpstreamSteps: 2 }
+    );
+
+    expect(Array.from(result.lakeMask)).toEqual([0, 0, 1, 1, 1]);
+    expect(result.sinkLakeCount).toBe(1);
+    expect(result.plannedLakeTileCount).toBe(3);
+  });
+});

--- a/mods/mod-swooper-maps/test/map-hydrology/lakes-area-recalc-resources.test.ts
+++ b/mods/mod-swooper-maps/test/map-hydrology/lakes-area-recalc-resources.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
-import { MockAdapter } from "@civ7/adapter";
-import { COAST_TERRAIN, FLAT_TERRAIN, createExtendedMapContext } from "@swooper/mapgen-core";
+import { MockAdapter, type LakeProjectionResult } from "@civ7/adapter";
+import { FLAT_TERRAIN, createExtendedMapContext } from "@swooper/mapgen-core";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 
 import placement from "../../src/domain/placement/ops.js";
@@ -11,6 +11,14 @@ import plotRivers from "../../src/recipes/standard/stages/map-hydrology/steps/pl
 import { applyPlacementPlan } from "../../src/recipes/standard/stages/placement/steps/placement/apply.js";
 import { buildTestDeps } from "../support/step-deps.js";
 
+/**
+ * Area-sensitive adapter double.
+ *
+ * Lake stamping must refresh engine area and water caches before later map
+ * stages and placement ask Civ7 resource logic about marine placement. This
+ * double dries the stamped tile during validation if the adapter forgot the
+ * area refresh.
+ */
 class AreaSensitiveLakeAdapter extends MockAdapter {
   private cachedWater: Uint8Array;
   private lakeNeedsAreaRefresh = false;
@@ -41,11 +49,10 @@ class AreaSensitiveLakeAdapter extends MockAdapter {
     return this.cachedWater[this.idx2(x, y)] === 1;
   }
 
-  override generateLakes(width: number, height: number, tilesPerLake: number): void {
-    this.callOrder.push("generateLakes");
-    super.generateLakes(width, height, tilesPerLake);
-    this.setTerrainType(1, 1, COAST_TERRAIN);
+  override stampLakes(width: number, height: number, lakeMask: Uint8Array): LakeProjectionResult {
+    this.callOrder.push("stampLakes");
     this.lakeNeedsAreaRefresh = true;
+    return super.stampLakes(width, height, lakeMask);
   }
 
   override recalculateAreas(): void {
@@ -124,14 +131,33 @@ describe("map-hydrology lakes area/water ordering", () => {
       runoff: new Float32Array(size),
       discharge: new Float32Array(size),
       riverClass: new Uint8Array(size),
+      flowDir: new Int32Array(size).fill(-1),
       sinkMask: new Uint8Array(size),
       outletMask: new Uint8Array(size),
     });
+    const lakeMask = new Uint8Array(size);
+    lakeMask[1 + width] = 1;
+    context.artifacts.set("artifact:hydrology.lakePlan", {
+      width,
+      height,
+      lakeMask,
+      plannedLakeTileCount: 1,
+      sinkLakeCount: 1,
+    });
 
-    lakes.run(context as any, { tilesPerLakeMultiplier: 1 }, {} as any, buildTestDeps(lakes));
-    plotRivers.run(context as any, { minLength: 5, maxLength: 15 }, {} as any, buildTestDeps(plotRivers));
+    lakes.run(context as any, { projectionReadback: true }, {} as any, buildTestDeps(lakes));
+    plotRivers.run(
+      context as any,
+      { minLength: 5, maxLength: 15 },
+      {} as any,
+      buildTestDeps(plotRivers)
+    );
 
-    expect(adapter.callOrder.slice(0, 3)).toEqual(["storeWaterData", "generateLakes", "recalculateAreas"]);
+    expect(adapter.callOrder.slice(0, 3)).toEqual([
+      "stampLakes",
+      "recalculateAreas",
+      "storeWaterData",
+    ]);
     expect(adapter.isWater(1, 1)).toBe(true);
 
     const runtime = getStandardRuntime(context);

--- a/mods/mod-swooper-maps/test/map-hydrology/lakes-runtime-fill-drift.test.ts
+++ b/mods/mod-swooper-maps/test/map-hydrology/lakes-runtime-fill-drift.test.ts
@@ -4,18 +4,23 @@ import { MockAdapter } from "@civ7/adapter";
 import { COAST_TERRAIN, FLAT_TERRAIN, createExtendedMapContext } from "@swooper/mapgen-core";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 
-import { defaultStrategy as accumulateDischarge } from "../../src/domain/hydrology/ops/accumulate-discharge/strategies/default.js";
 import lakes from "../../src/recipes/standard/stages/map-hydrology/steps/lakes.js";
 import plotRivers from "../../src/recipes/standard/stages/map-hydrology/steps/plotRivers.js";
 import { buildTestDeps } from "../support/step-deps.js";
 
+/**
+ * Runtime validation double.
+ *
+ * Civ7 terrain validation can disagree with a projected lake after the map
+ * stage stamps it. This double dries one planned sink during river validation
+ * so the test proves mismatch accounting remains diagnostic and downstream.
+ */
 class RuntimeLakeValidationAdapter extends MockAdapter {
   override modelRivers(): void {
     // Keep this scenario focused on lake projection/validation behavior.
   }
 
   override validateAndFixTerrain(): void {
-    // Simulate runtime validation removing an over-placed non-sink lake tile.
     if (this.getTerrainType(1, 1) === COAST_TERRAIN) {
       this.setTerrainType(1, 1, FLAT_TERRAIN);
     }
@@ -28,8 +33,7 @@ describe("map-hydrology/lakes runtime fill drift", () => {
     const height = 4;
     const size = width * height;
     const seed = 2468;
-    const sinkIdx = 6;
-    const upstreamIdx = 5;
+    const sinkIdx = 1 + width;
     const mapInfo = {
       GridWidth: width,
       GridHeight: height,
@@ -52,56 +56,44 @@ describe("map-hydrology/lakes runtime fill drift", () => {
       defaultTerrainType: FLAT_TERRAIN,
     });
     const context = createExtendedMapContext({ width, height }, adapter, env);
-
-    const landMask = new Uint8Array(size).fill(1);
-    const flowDir = new Int32Array(size).fill(sinkIdx);
-    flowDir[sinkIdx] = -1;
-
-    const discharge = accumulateDischarge.run(
-      {
-        width,
-        height,
-        landMask,
-        flowDir,
-        rainfall: new Uint8Array(size).fill(100),
-        humidity: new Uint8Array(size).fill(100),
-      },
-      {
-        runoffScale: 1,
-        infiltrationFraction: 0.15,
-        humidityDampening: 0.25,
-        minRunoff: 0,
-      }
-    );
-
     const sinkLakeMask = new Uint8Array(size);
     sinkLakeMask[sinkIdx] = 1;
-
-    expect(sinkLakeMask[sinkIdx]).toBe(1);
-    expect(sinkLakeMask[upstreamIdx]).toBe(0);
 
     context.artifacts.set("artifact:morphology.topography", {
       elevation: new Int16Array(size),
       seaLevel: 0,
-      landMask,
+      landMask: new Uint8Array(size).fill(1),
       bathymetry: new Int16Array(size),
     });
     context.artifacts.set("artifact:hydrology.hydrography", {
-      runoff: discharge.runoff,
-      discharge: discharge.discharge,
+      runoff: new Float32Array(size),
+      discharge: new Float32Array(size),
       riverClass: new Uint8Array(size),
-      sinkMask: discharge.sinkMask,
-      outletMask: discharge.outletMask,
+      flowDir: new Int32Array(size).fill(-1),
+      sinkMask: sinkLakeMask,
+      outletMask: new Uint8Array(size),
+    });
+    context.artifacts.set("artifact:hydrology.lakePlan", {
+      width,
+      height,
+      lakeMask: sinkLakeMask,
+      plannedLakeTileCount: 1,
+      sinkLakeCount: 1,
     });
 
-    lakes.run(context as any, {}, {} as any, buildTestDeps(lakes));
-    plotRivers.run(context as any, { minLength: 5, maxLength: 15 }, {} as any, buildTestDeps(plotRivers));
+    lakes.run(context as any, { projectionReadback: true }, {} as any, buildTestDeps(lakes));
+    plotRivers.run(
+      context as any,
+      { minLength: 5, maxLength: 15 },
+      {} as any,
+      buildTestDeps(plotRivers)
+    );
 
     const projection = context.artifacts.get("artifact:hydrology.engineProjectionRivers") as
       | { sinkMismatchCount?: number }
       | undefined;
     expect(typeof projection?.sinkMismatchCount).toBe("number");
-    expect((projection?.sinkMismatchCount ?? 0)).toBeGreaterThanOrEqual(1);
+    expect(projection?.sinkMismatchCount ?? 0).toBeGreaterThanOrEqual(1);
     expect(adapter.isWater(1, 1)).toBe(false);
   });
 });

--- a/mods/mod-swooper-maps/test/map-hydrology/lakes-store-water-data.test.ts
+++ b/mods/mod-swooper-maps/test/map-hydrology/lakes-store-water-data.test.ts
@@ -1,12 +1,21 @@
 import { describe, expect, it } from "bun:test";
 
-import { MockAdapter } from "@civ7/adapter";
-import { COAST_TERRAIN, FLAT_TERRAIN, createExtendedMapContext } from "@swooper/mapgen-core";
+import { MockAdapter, type LakeProjectionResult } from "@civ7/adapter";
+import { FLAT_TERRAIN, createExtendedMapContext } from "@swooper/mapgen-core";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 
 import lakes from "../../src/recipes/standard/stages/map-hydrology/steps/lakes.js";
 import { buildTestDeps } from "../support/step-deps.js";
 
+type TestContext = ReturnType<typeof createExtendedMapContext>;
+
+/**
+ * Cache-backed adapter double.
+ *
+ * The real engine can answer water queries from cached topology, so this double
+ * makes lake stamping fail unless the adapter boundary refreshes water data
+ * after terrain mutation.
+ */
 class CachedWaterAdapter extends MockAdapter {
   private cachedWater: Uint8Array;
   readonly callOrder: string[] = [];
@@ -21,183 +30,178 @@ class CachedWaterAdapter extends MockAdapter {
   }
 
   override isWater(x: number, y: number): boolean {
-    // Simulate Civ engine behavior: water can be backed by cached water tables,
-    // not recomputed automatically from terrain edits.
     return this.cachedWater[this.idx2(x, y)] === 1;
   }
 
-  override generateLakes(width: number, height: number, tilesPerLake: number): void {
-    this.callOrder.push("generateLakes");
-    super.generateLakes(width, height, tilesPerLake);
+  override stampLakes(width: number, height: number, lakeMask: Uint8Array): LakeProjectionResult {
+    this.callOrder.push("stampLakes");
+    return super.stampLakes(width, height, lakeMask);
+  }
 
-    // Simulate engine lake generation: set terrain to COAST for a lake tile, but
-    // do NOT update the cached water tables.
-    this.setTerrainType(1, 1, COAST_TERRAIN);
+  override recalculateAreas(): void {
+    this.callOrder.push("recalculateAreas");
   }
 
   override storeWaterData(): void {
     this.callOrder.push("storeWaterData");
 
-    // Recompute cached water tables from plotted terrain.
     const coast = this.getTerrainTypeIndex("TERRAIN_COAST");
     const ocean = this.getTerrainTypeIndex("TERRAIN_OCEAN");
     for (let y = 0; y < this.height; y++) {
       for (let x = 0; x < this.width; x++) {
-        const t = this.getTerrainType(x, y) | 0;
-        this.cachedWater[this.idx2(x, y)] = t === coast || t === ocean ? 1 : 0;
+        const terrain = this.getTerrainType(x, y) | 0;
+        this.cachedWater[this.idx2(x, y)] = terrain === coast || terrain === ocean ? 1 : 0;
       }
     }
   }
 }
 
+/**
+ * Readback-rejecting adapter double.
+ *
+ * This keeps the test focused on the projection contract: `map-hydrology/lakes`
+ * records rejections as diagnostics and does not turn engine disagreement into
+ * Hydrology truth or a runtime throw.
+ */
+class RejectingLakeAdapter extends MockAdapter {
+  override stampLakes(width: number, height: number, lakeMask: Uint8Array): LakeProjectionResult {
+    this.calls.stampLakes.push({ width, height, lakeMask });
+    const size = width * height;
+    const rejectedLakeMask = new Uint8Array(size);
+    let plannedLakeTileCount = 0;
+    for (let i = 0; i < size; i++) {
+      if (lakeMask[i] !== 1) continue;
+      rejectedLakeMask[i] = 1;
+      plannedLakeTileCount += 1;
+    }
+    return {
+      width,
+      height,
+      plannedLakeMask: lakeMask,
+      stampedLakeMask: new Uint8Array(size),
+      rejectedLakeMask,
+      plannedLakeTileCount,
+      stampedLakeTileCount: 0,
+      rejectedLakeTileCount: plannedLakeTileCount,
+    };
+  }
+}
+
+function createContext(adapter: MockAdapter, width: number, height: number, seed: number): TestContext {
+  return createExtendedMapContext(
+    { width, height },
+    adapter,
+    {
+      seed,
+      dimensions: { width, height },
+      latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
+    }
+  );
+}
+
+function seedLakePlan(context: TestContext, lakeMask: Uint8Array): void {
+  const { width, height } = context.dimensions;
+  const size = width * height;
+  context.artifacts.set("artifact:morphology.topography", {
+    elevation: new Int16Array(size),
+    seaLevel: 0,
+    landMask: new Uint8Array(size).fill(1),
+    bathymetry: new Int16Array(size),
+  });
+  context.artifacts.set("artifact:hydrology.lakePlan", {
+    width,
+    height,
+    lakeMask,
+    plannedLakeTileCount: lakeMask.reduce((count, value) => count + (value === 1 ? 1 : 0), 0),
+    sinkLakeCount: lakeMask.reduce((count, value) => count + (value === 1 ? 1 : 0), 0),
+  });
+}
+
 describe("map-hydrology/lakes", () => {
-  it("calls storeWaterData after generateLakes so cached water tables reflect new lakes", () => {
+  it("refreshes engine water caches after stamping planned lakes", () => {
     const width = 4;
     const height = 3;
     const seed = 1234;
-    const mapInfo = {
-      GridWidth: width,
-      GridHeight: height,
-      MinLatitude: -60,
-      MaxLatitude: 60,
-      LakeGenerationFrequency: 5,
-    };
-    const env = {
-      seed,
-      dimensions: { width, height },
-      latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
-    };
-
     const adapter = new CachedWaterAdapter({
       width,
       height,
-      mapInfo,
+      mapInfo: { GridWidth: width, GridHeight: height, MinLatitude: -60, MaxLatitude: 60 },
       mapSizeId: 1,
       rng: createLabelRng(seed),
       defaultTerrainType: FLAT_TERRAIN,
     });
-    const context = createExtendedMapContext({ width, height }, adapter, env);
+    const context = createContext(adapter, width, height, seed);
+    const lakeMask = new Uint8Array(width * height);
+    lakeMask[1 + width] = 1;
+    seedLakePlan(context, lakeMask);
 
-    const size = width * height;
-    context.artifacts.set("artifact:morphology.topography", {
-      elevation: new Int16Array(size),
-      seaLevel: 0,
-      landMask: new Uint8Array(size).fill(1),
-      bathymetry: new Int16Array(size),
-    });
-    context.artifacts.set("artifact:hydrology.hydrography", {
-      runoff: new Float32Array(size),
-      discharge: new Float32Array(size),
-      riverClass: new Uint8Array(size),
-      sinkMask: new Uint8Array(size),
-      outletMask: new Uint8Array(size),
-    });
-
-    // Before running the step: cached water tables say "land".
     expect(adapter.isWater(1, 1)).toBe(false);
 
-    lakes.run(context as any, { tilesPerLakeMultiplier: 1 }, {} as any, buildTestDeps(lakes));
+    lakes.run(context as any, { projectionReadback: true }, {} as any, buildTestDeps(lakes));
 
-    expect(adapter.callOrder.slice(-2)).toEqual(["generateLakes", "storeWaterData"]);
-    // After storeWaterData: cached water tables reflect the new lake tile.
+    expect(adapter.callOrder.slice(-3)).toEqual([
+      "stampLakes",
+      "recalculateAreas",
+      "storeWaterData",
+    ]);
     expect(adapter.isWater(1, 1)).toBe(true);
   });
 
-  it("keeps sink mismatch as diagnostics (no runtime throw)", () => {
+  it("records projection rejection as diagnostics without throwing", () => {
     const width = 4;
     const height = 3;
     const seed = 4321;
-    const mapInfo = {
-      GridWidth: width,
-      GridHeight: height,
-      MinLatitude: -60,
-      MaxLatitude: 60,
-      LakeGenerationFrequency: 5,
-    };
-    const env = {
-      seed,
-      dimensions: { width, height },
-      latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
-    };
-
-    const adapter = new CachedWaterAdapter({
+    const adapter = new RejectingLakeAdapter({
       width,
       height,
-      mapInfo,
+      mapInfo: { GridWidth: width, GridHeight: height, MinLatitude: -60, MaxLatitude: 60 },
       mapSizeId: 1,
       rng: createLabelRng(seed),
       defaultTerrainType: FLAT_TERRAIN,
     });
-    const context = createExtendedMapContext({ width, height }, adapter, env);
+    const context = createContext(adapter, width, height, seed);
+    const lakeMask = new Uint8Array(width * height);
+    lakeMask[1 + width] = 1;
+    seedLakePlan(context, lakeMask);
 
-    const size = width * height;
-    context.artifacts.set("artifact:morphology.topography", {
-      elevation: new Int16Array(size),
-      seaLevel: 0,
-      landMask: new Uint8Array(size).fill(1),
-      bathymetry: new Int16Array(size),
-    });
-    context.artifacts.set("artifact:hydrology.hydrography", {
-      runoff: new Float32Array(size),
-      discharge: new Float32Array(size),
-      riverClass: new Uint8Array(size),
-      sinkMask: new Uint8Array(size).fill(1),
-      outletMask: new Uint8Array(size),
-    });
-
-    expect(() => lakes.run(context as any, { tilesPerLakeMultiplier: 1 }, {} as any, buildTestDeps(lakes))).not.toThrow();
+    expect(() =>
+      lakes.run(context as any, { projectionReadback: true }, {} as any, buildTestDeps(lakes))
+    ).not.toThrow();
 
     const projection = context.artifacts.get("artifact:hydrology.engineProjectionLakes") as
       | { sinkMismatchCount: number }
       | undefined;
     expect(projection).toBeDefined();
-    expect(projection?.sinkMismatchCount ?? 0).toBeGreaterThan(0);
+    expect(projection?.sinkMismatchCount ?? 0).toBe(1);
   });
 
-  it("uses map info lake frequency directly so default projection does not over-seed lakes", () => {
-    const width = 84;
-    const height = 54;
+  it("stamps the Hydrology lake plan directly instead of calling engine lake generation", () => {
+    const width = 6;
+    const height = 5;
     const seed = 9876;
-    const mapInfo = {
-      GridWidth: width,
-      GridHeight: height,
-      MinLatitude: -60,
-      MaxLatitude: 60,
-      LakeGenerationFrequency: 25,
-    };
-    const env = {
-      seed,
-      dimensions: { width, height },
-      latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
-    };
-
     const adapter = new CachedWaterAdapter({
       width,
       height,
-      mapInfo,
+      mapInfo: {
+        GridWidth: width,
+        GridHeight: height,
+        MinLatitude: -60,
+        MaxLatitude: 60,
+        LakeGenerationFrequency: 25,
+      },
       mapSizeId: 1,
       rng: createLabelRng(seed),
       defaultTerrainType: FLAT_TERRAIN,
     });
-    const context = createExtendedMapContext({ width, height }, adapter, env);
+    const context = createContext(adapter, width, height, seed);
+    const lakeMask = new Uint8Array(width * height);
+    lakeMask[2 + width] = 1;
+    lakeMask[3 + width] = 1;
+    seedLakePlan(context, lakeMask);
 
-    const size = width * height;
-    context.artifacts.set("artifact:morphology.topography", {
-      elevation: new Int16Array(size),
-      seaLevel: 0,
-      landMask: new Uint8Array(size).fill(1),
-      bathymetry: new Int16Array(size),
-    });
-    context.artifacts.set("artifact:hydrology.hydrography", {
-      runoff: new Float32Array(size),
-      discharge: new Float32Array(size),
-      riverClass: new Uint8Array(size),
-      sinkMask: new Uint8Array(size),
-      outletMask: new Uint8Array(size),
-    });
+    lakes.run(context as any, { projectionReadback: false }, {} as any, buildTestDeps(lakes));
 
-    lakes.run(context as any, { tilesPerLakeMultiplier: 1 }, {} as any, buildTestDeps(lakes));
-
-    expect(adapter.calls.generateLakes.at(-1)?.tilesPerLake).toBe(25);
+    expect(adapter.calls.generateLakes).toEqual([]);
+    expect(adapter.calls.stampLakes.at(-1)?.lakeMask).toBe(lakeMask);
   });
 });

--- a/mods/mod-swooper-maps/test/pipeline/map-stamping.contract-guard.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/map-stamping.contract-guard.test.ts
@@ -83,6 +83,26 @@ describe("map stamping contract guardrails", () => {
     expect(contractText).toContain("MAP_PROJECTION_EFFECT_TAGS.map.elevationBuilt");
   });
 
+  it("keeps deterministic lake projection on the stampLakes adapter capability", () => {
+    const repoRoot = path.resolve(import.meta.dir, "../..");
+    const stagesRoot = path.join(repoRoot, "src/recipes/standard/stages");
+    const files = listFilesRecursive(stagesRoot).filter((file) => file.endsWith(".ts"));
+
+    const engineLakeGenerators = files.filter((file) => {
+      const text = readFileSync(file, "utf8");
+      return /adapter\.generateLakes\s*\(/.test(text);
+    });
+    const lakeStampers = files.filter((file) => {
+      const text = readFileSync(file, "utf8");
+      return /adapter\.stampLakes\s*\(/.test(text);
+    });
+
+    engineLakeGenerators.sort();
+    lakeStampers.sort();
+    expect(engineLakeGenerators).toEqual([]);
+    expect(lakeStampers).toEqual([path.join(stagesRoot, "map-hydrology/steps/lakes.ts")]);
+  });
+
   it("does not allow physics stage code to call engine elevation/cliff reads", () => {
     const repoRoot = path.resolve(import.meta.dir, "../..");
     const physicsRoots = [

--- a/openspec/changes/normalize-projection-lakes/implementation.md
+++ b/openspec/changes/normalize-projection-lakes/implementation.md
@@ -1,0 +1,46 @@
+## Implementation Record
+
+`normalize-projection-lakes` moves lake authority from Civ7 engine generation to
+Hydrology-owned intent plus adapter projection evidence.
+
+## What Changed
+
+- Added `EngineAdapter.stampLakes(width, height, lakeMask)` with readback masks
+  and counts in both `Civ7Adapter` and `MockAdapter`.
+- Added Hydrology `plan-lakes` as an op-local contract/strategy. The strategy
+  trusts the contract boundary for typed-array shape validation and only owns
+  lake intent rules.
+- Added `artifact:hydrology.lakePlan` and a `hydrology-hydrography/lakes` step.
+- Moved `lakeiness` to `hydrology-hydrography`; it now maps to
+  `planLakes.config.maxUpstreamSteps` instead of `map-hydrology` projection
+  frequency.
+- Updated `map-hydrology/lakes` to stamp `lakePlan` through the adapter and
+  publish accepted/rejected projection evidence.
+- Updated placement input derivation to consume `lakePlan` instead of
+  `engineProjectionLakes`.
+- Added a categorical map-stage guard: standard recipe stages may not call
+  `adapter.generateLakes(...)`; only `map-hydrology/steps/lakes.ts` may call
+  `adapter.stampLakes(...)`.
+- Updated active hydrology, browser-adapter, testing, and deferral docs.
+
+## Ownership Notes
+
+- `plan-lakes` strategy config remains op-local. Domain-root Hydrology config
+  remains a thin recipe-facing knob facade, not a strategy schema dumping
+  ground.
+- `map-hydrology` remains projection-only. It records engine readback but does
+  not author lake truth.
+- `generateLakes(...)` stays on the adapter interface as an existing Civ7 wrapper
+  but is no longer used by the standard recipe lake path.
+
+## Verification Evidence
+
+- `bun run --cwd packages/civ7-adapter build`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run --cwd mods/mod-swooper-maps build`
+- `bun run --cwd mods/mod-swooper-maps test -- test/hydrology/plan-lakes.test.ts test/hydrology-knobs.test.ts test/map-hydrology/lakes-store-water-data.test.ts test/map-hydrology/lakes-runtime-fill-drift.test.ts test/map-hydrology/lakes-area-recalc-resources.test.ts test/config/maps-schema-valid.test.ts test/config/presets-schema-valid.test.ts test/config/studio-presets-schema-valid.test.ts test/pipeline/map-stamping.contract-guard.test.ts test/pipeline/artifacts.test.ts test/pipeline/foundation-topology-lock.test.ts`
+- `bun run lint:mapgen-recipe-imports`
+- `bun run lint:domain-refactor-guardrails`
+- `bun run openspec -- validate normalize-projection-lakes --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/normalize-projection-lakes/proposal.md
+++ b/openspec/changes/normalize-projection-lakes/proposal.md
@@ -26,8 +26,8 @@ or resource/discovery reconciliation.
   truth can be materialized and read back.
 - Audit `map-*` stages touched by this change against the projection-only
   rule.
-- Keep fail-hard parity gates after materialization/readback can prove the
-  planned mask.
+- Keep parity evidence scoped to materialization/readback; do not promote
+  projection diagnostics into Hydrology truth.
 
 ## Capabilities
 
@@ -78,6 +78,7 @@ None.
   - map-hydrology projection/readback tests;
   - placement no longer consumes lake projection diagnostics as truth;
   - no fail-hard parity before readback evidence exists;
+  - no `map-hydrology` calls to engine lake generation;
   - `bun run openspec -- validate normalize-projection-lakes --strict`;
   - `bun run openspec:validate`;
   - `git diff --check`.

--- a/openspec/changes/normalize-projection-lakes/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/normalize-projection-lakes/specs/mapgen-normalization-workstreams/spec.md
@@ -11,17 +11,17 @@ before enabling fail-hard parity for Hydrology lake intent.
   already implemented and tested
 - **AND** the gate compares planned truth to observed projection evidence
 
-### Requirement: Engine Lake Generation Is Labeled Projection Until Replaced
+### Requirement: Engine Lake Generation Is Replaced By Stamping
 
-The lake projection change SHALL label engine-generated lake behavior as
-projection or diagnostic behavior until Hydrology intent is stamped and read
-back.
+The lake projection change SHALL stamp Hydrology lake intent through an
+adapter capability instead of calling Civ7 engine lake generation from the
+standard recipe.
 
-#### Scenario: map-hydrology still calls engine lake generation
-- **WHEN** engine lake generation remains in use during the migration
-- **THEN** docs and artifacts do not call that output deterministic Hydrology
-  truth
-- **AND** placement does not consume it as final lake intent
+#### Scenario: map-hydrology projects lake intent
+- **WHEN** `map-hydrology/lakes` materializes lakes
+- **THEN** it calls `stampLakes(...)` with `artifact:hydrology.lakePlan`
+- **AND** it does not call `generateLakes(...)`
+- **AND** rejected/stamped lake masks are recorded as projection evidence
 
 ### Requirement: Placement Lake Inputs Move After Lake Readback
 

--- a/openspec/changes/normalize-projection-lakes/tasks.md
+++ b/openspec/changes/normalize-projection-lakes/tasks.md
@@ -1,29 +1,29 @@
 ## 1. Adapter Capability
 
-- [ ] 1.1 Inventory current adapter lake generation/stamping/readback support.
-- [ ] 1.2 Add or expose lake stamping/readback capability.
-- [ ] 1.3 Update browser/test adapter doubles.
+- [x] 1.1 Inventory current adapter lake generation/stamping/readback support.
+- [x] 1.2 Add or expose lake stamping/readback capability.
+- [x] 1.3 Update browser/test adapter doubles.
 
 ## 2. Hydrology Truth
 
-- [ ] 2.1 Define `plan-lakes` contract, artifacts, and config inputs.
-- [ ] 2.2 Implement lake intent planning as Hydrology truth.
-- [ ] 2.3 Add focused tests for lake intent.
+- [x] 2.1 Define `plan-lakes` contract, artifacts, and config inputs.
+- [x] 2.2 Implement lake intent planning as Hydrology truth.
+- [x] 2.3 Add focused tests for lake intent.
 
 ## 3. Projection
 
-- [ ] 3.1 Update `map-hydrology` to project/stamp the lake plan.
-- [ ] 3.2 Add readback diagnostics and parity checks only after capability is
+- [x] 3.1 Update `map-hydrology` to project/stamp the lake plan.
+- [x] 3.2 Add readback diagnostics and parity checks only after capability is
   available.
-- [ ] 3.3 Migrate placement lake-input contracts away from projection
+- [x] 3.3 Migrate placement lake-input contracts away from projection
   diagnostics.
-- [ ] 3.4 Audit touched `map-*` stages against the projection-only rule.
-- [ ] 3.5 Update hydrology docs and deferrals affected by the capability.
+- [x] 3.4 Audit touched `map-*` stages against the projection-only rule.
+- [x] 3.5 Update hydrology docs and deferrals affected by the capability.
 
 ## 4. Verification
 
-- [ ] 4.1 Run adapter and hydrology focused tests.
-- [ ] 4.2 Run projection/readback tests.
-- [ ] 4.3 Run `bun run openspec -- validate normalize-projection-lakes --strict`.
-- [ ] 4.4 Run `bun run openspec:validate`.
-- [ ] 4.5 Run `git diff --check`.
+- [x] 4.1 Run adapter and hydrology focused tests.
+- [x] 4.2 Run projection/readback tests.
+- [x] 4.3 Run `bun run openspec -- validate normalize-projection-lakes --strict`.
+- [x] 4.4 Run `bun run openspec:validate`.
+- [x] 4.5 Run `git diff --check`.

--- a/packages/civ7-adapter/src/civ7-adapter.ts
+++ b/packages/civ7-adapter/src/civ7-adapter.ts
@@ -11,6 +11,7 @@ import type {
   DiscoveryCatalogEntry,
   EngineAdapter,
   FeatureData,
+  LakeProjectionResult,
   LandmassIdName,
   MapInfo,
   MapInitParams,
@@ -32,6 +33,7 @@ import "/base-standard/maps/map-globals.js";
 import { VoronoiUtils as CivVoronoiUtils } from "/base-standard/scripts/voronoi-utils.js";
 // Vanilla Civ7 biomes/features live in feature-biome-generator.js
 // @ts-ignore - resolved only at Civ7 runtime
+// prettier-ignore
 import { designateBiomes as civ7DesignateBiomes, addFeatures as civ7AddFeatures } from "/base-standard/maps/feature-biome-generator.js";
 // @ts-ignore - resolved only at Civ7 runtime
 import { generateSnow as civ7GenerateSnow } from "/base-standard/maps/snow-generator.js";
@@ -40,6 +42,7 @@ import { generateDiscoveries as civ7GenerateDiscoveries } from "/base-standard/m
 // @ts-ignore - resolved only at Civ7 runtime
 import * as civ7ResourceGeneratorModule from "/base-standard/maps/resource-generator.js";
 // @ts-ignore - resolved only at Civ7 runtime
+// prettier-ignore
 import { assignStartPositions as civ7AssignStartPositions, chooseStartSectors as civ7ChooseStartSectors } from "/base-standard/maps/assign-starting-plots.js";
 // @ts-ignore - resolved only at Civ7 runtime
 import { needHumanNearEquator as civ7NeedHumanNearEquator } from "/base-standard/maps/map-utilities.js";
@@ -47,6 +50,7 @@ import { needHumanNearEquator as civ7NeedHumanNearEquator } from "/base-standard
 import { assignAdvancedStartRegions as civ7AssignAdvancedStartRegions } from "/base-standard/maps/assign-advanced-start-region.js";
 // Elevation terrain generator (lakes/coasts)
 // @ts-ignore - resolved only at Civ7 runtime
+// prettier-ignore
 import { generateLakes as civ7GenerateLakes, expandCoasts as civ7ExpandCoasts } from "/base-standard/maps/elevation-terrain-generator.js";
 
 /**
@@ -284,7 +288,9 @@ export class Civ7Adapter implements EngineAdapter {
   setResourceType(x: number, y: number, resourceType: number): void {
     const rb = (
       globalThis as typeof globalThis & {
-        ResourceBuilder?: { setResourceType?: (x: number, y: number, resourceType: number) => void };
+        ResourceBuilder?: {
+          setResourceType?: (x: number, y: number, resourceType: number) => void;
+        };
       }
     ).ResourceBuilder;
     if (!rb?.setResourceType) {
@@ -336,9 +342,10 @@ export class Civ7Adapter implements EngineAdapter {
       ? name.toUpperCase()
       : `PLOTEFFECT_${name.toUpperCase()}`;
 
-    const effect = plotEffects.find((entry) => entry.PlotEffectType === effectType) as
-      | { Index?: number; $index?: number }
-      | null;
+    const effect = plotEffects.find((entry) => entry.PlotEffectType === effectType) as {
+      Index?: number;
+      $index?: number;
+    } | null;
 
     if (typeof effect?.Index === "number") return effect.Index;
     if (typeof effect?.$index === "number") return effect.$index;
@@ -419,6 +426,83 @@ export class Civ7Adapter implements EngineAdapter {
     civ7GenerateLakes(width, height, tilesPerLake);
   }
 
+  /**
+   * Materialize MapGen's lake intent through Civ7 terrain APIs.
+   *
+   * The engine boundary refreshes area and water caches immediately after
+   * stamping because downstream Civ7 checks often read cached topology rather
+   * than raw terrain edits.
+   */
+  stampLakes(width: number, height: number, lakeMask: Uint8Array): LakeProjectionResult {
+    const expectedSize = Math.max(0, (width | 0) * (height | 0));
+    if (lakeMask.length !== expectedSize) {
+      throw new Error(
+        `[Civ7Adapter] Invalid lake mask length for stampLakes (expected ${expectedSize}, got ${lakeMask.length}).`
+      );
+    }
+
+    const lakeTerrain = this.getTerrainTypeIndex("TERRAIN_COAST");
+    if (lakeTerrain < 0) {
+      throw new Error("[Civ7Adapter] Cannot stamp lakes: TERRAIN_COAST terrain id is unavailable.");
+    }
+
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const idx = y * width + x;
+        if (lakeMask[idx] !== 1) continue;
+        this.setTerrainType(x, y, lakeTerrain);
+      }
+    }
+
+    this.recalculateAreas();
+    this.storeWaterData();
+
+    return this.readLakeProjection(width, height, lakeMask);
+  }
+
+  /**
+   * Read back what the engine accepted so projection diagnostics remain evidence,
+   * not the source of lake truth.
+   */
+  private readLakeProjection(
+    width: number,
+    height: number,
+    plannedLakeMask: Uint8Array
+  ): LakeProjectionResult {
+    const size = Math.max(0, (width | 0) * (height | 0));
+    const stampedLakeMask = new Uint8Array(size);
+    const rejectedLakeMask = new Uint8Array(size);
+    let plannedLakeTileCount = 0;
+    let stampedLakeTileCount = 0;
+    let rejectedLakeTileCount = 0;
+
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const idx = y * width + x;
+        if (plannedLakeMask[idx] !== 1) continue;
+        plannedLakeTileCount += 1;
+        if (this.isWater(x, y)) {
+          stampedLakeMask[idx] = 1;
+          stampedLakeTileCount += 1;
+        } else {
+          rejectedLakeMask[idx] = 1;
+          rejectedLakeTileCount += 1;
+        }
+      }
+    }
+
+    return {
+      width,
+      height,
+      plannedLakeMask,
+      stampedLakeMask,
+      rejectedLakeMask,
+      plannedLakeTileCount,
+      stampedLakeTileCount,
+      rejectedLakeTileCount,
+    };
+  }
+
   expandCoasts(width: number, height: number): void {
     civ7ExpandCoasts(width, height);
   }
@@ -470,9 +554,10 @@ export class Civ7Adapter implements EngineAdapter {
     if (!features) return -1;
 
     // Use the find method from GameInfoTable interface
-    const feature = features.find((f) => f.FeatureType === name) as
-      | { Index?: number; $index?: number }
-      | null;
+    const feature = features.find((f) => f.FeatureType === name) as {
+      Index?: number;
+      $index?: number;
+    } | null;
 
     if (typeof feature?.Index === "number") return feature.Index;
     if (typeof feature?.$index === "number") return feature.$index;
@@ -628,7 +713,9 @@ export class Civ7Adapter implements EngineAdapter {
     const resolvedStartPositions = (Array.isArray(startPositions) ? startPositions : [])
       .filter((value) => Number.isFinite(value) && value >= 0)
       .map((value) => Math.trunc(value));
-    const resolvedPolarMargin = Number.isFinite(polarMargin) ? Math.max(0, Math.trunc(polarMargin)) : 0;
+    const resolvedPolarMargin = Number.isFinite(polarMargin)
+      ? Math.max(0, Math.trunc(polarMargin))
+      : 0;
 
     const mapConstructibles = (
       globalThis as typeof globalThis & {
@@ -767,11 +854,14 @@ export class Civ7Adapter implements EngineAdapter {
 
   recalculateFertility(): void {
     // FertilityBuilder may not exist in all engine versions
-    const fb = (globalThis as unknown as { FertilityBuilder?: { recalculate?: () => void } }).FertilityBuilder;
+    const fb = (globalThis as unknown as { FertilityBuilder?: { recalculate?: () => void } })
+      .FertilityBuilder;
     if (fb && typeof fb.recalculate === "function") {
       fb.recalculate();
     } else {
-      console.log("[Civ7Adapter] FertilityBuilder not available - fertility will be calculated by engine defaults");
+      console.log(
+        "[Civ7Adapter] FertilityBuilder not available - fertility will be calculated by engine defaults"
+      );
     }
     this.recordPlacementEffect();
   }

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -9,6 +9,7 @@ import type {
   DiscoveryCatalogEntry,
   EngineAdapter,
   FeatureData,
+  LakeProjectionResult,
   LandmassIdName,
   MapInfo,
   MapInitParams,
@@ -34,8 +35,8 @@ const DEFAULT_VORONOI_UTILS: VoronoiUtils = {
     for (let id = 0; id < count; id++) {
       const seed1 = (id * 1664525 + 1013904223) >>> 0;
       const seed2 = (seed1 * 1664525 + 1013904223) >>> 0;
-      const x = (seed1 % 10000) / 10000 * width;
-      const y = (seed2 % 10000) / 10000 * height;
+      const x = ((seed1 % 10000) / 10000) * width;
+      const y = ((seed2 % 10000) / 10000) * height;
       sites.push({ x, y, voronoiId: id });
     }
     return sites;
@@ -210,14 +211,17 @@ function sanitizeResourceTypeCatalog(input: number[] | undefined, noResource: nu
   return Array.from(unique).sort((a, b) => a - b);
 }
 
-function sanitizeDiscoveryCatalog(input: DiscoveryCatalogEntry[] | undefined): DiscoveryCatalogEntry[] {
+function sanitizeDiscoveryCatalog(
+  input: DiscoveryCatalogEntry[] | undefined
+): DiscoveryCatalogEntry[] {
   const source = Array.isArray(input) ? input : DEFAULT_DISCOVERY_CATALOG;
   const unique = new Set<string>();
   const catalog: DiscoveryCatalogEntry[] = [];
   for (const entry of source) {
     const discoveryVisualType = entry?.discoveryVisualType;
     const discoveryActivationType = entry?.discoveryActivationType;
-    if (!Number.isFinite(discoveryVisualType) || !Number.isFinite(discoveryActivationType)) continue;
+    if (!Number.isFinite(discoveryVisualType) || !Number.isFinite(discoveryActivationType))
+      continue;
     const visual = Math.trunc(discoveryVisualType as number) >>> 0;
     const activation = Math.trunc(discoveryActivationType as number) >>> 0;
     const key = `${visual}:${activation}`;
@@ -360,6 +364,7 @@ export class MockAdapter implements EngineAdapter {
     generateSnow: Array<{ width: number; height: number }>;
     setResourceType: Array<{ x: number; y: number; resourceType: number }>;
     generateLakes: Array<{ width: number; height: number; tilesPerLake: number }>;
+    stampLakes: Array<{ width: number; height: number; lakeMask: Uint8Array }>;
     expandCoasts: Array<{ width: number; height: number }>;
     assignStartPositions: Array<{
       playersLandmass1: number;
@@ -408,10 +413,12 @@ export class MockAdapter implements EngineAdapter {
     this.landmassIds = { ...DEFAULT_LANDMASS_IDS, ...(config.landmassIds ?? {}) };
     this.canHaveFeatureFn = config.canHaveFeature;
     this.canHaveResourceFn = config.canHaveResource;
-    this.naturalWonderCatalog = (config.naturalWonderCatalog ?? DEFAULT_NATURAL_WONDER_CATALOG).map((entry) => ({
-      featureType: entry.featureType,
-      direction: entry.direction,
-    }));
+    this.naturalWonderCatalog = (config.naturalWonderCatalog ?? DEFAULT_NATURAL_WONDER_CATALOG).map(
+      (entry) => ({
+        featureType: entry.featureType,
+        direction: entry.direction,
+      })
+    );
     this.discoveryCatalog = sanitizeDiscoveryCatalog(config.discoveryCatalog);
     this.plotEffectTypes = (config.plotEffectTypes ?? DEFAULT_PLOT_EFFECT_TYPES).map((entry) => ({
       id: entry.id,
@@ -440,6 +447,7 @@ export class MockAdapter implements EngineAdapter {
       generateSnow: [],
       setResourceType: [],
       generateLakes: [],
+      stampLakes: [],
       expandCoasts: [],
       assignStartPositions: [],
       setStartPosition: [],
@@ -754,8 +762,8 @@ export class MockAdapter implements EngineAdapter {
 
     if (startX < 0) return;
 
-    const maxLen = Math.max(1, Math.min(this.height - startY, (_maxLength | 0) || this.height));
-    const minLen = Math.max(1, (_minLength | 0) || 1);
+    const maxLen = Math.max(1, Math.min(this.height - startY, _maxLength | 0 || this.height));
+    const minLen = Math.max(1, _minLength | 0 || 1);
     const length = Math.min(maxLen, minLen);
 
     for (let dy = 0; dy < length; dy++) {
@@ -778,6 +786,65 @@ export class MockAdapter implements EngineAdapter {
   generateLakes(width: number, height: number, tilesPerLake: number): void {
     this.calls.generateLakes.push({ width, height, tilesPerLake });
     // Mock: no-op
+  }
+
+  /**
+   * Test-double counterpart to the engine adapter lake projection boundary.
+   * It stamps requested lake terrain and reports readback masks so map-stage
+   * tests exercise the same plan/project/diagnose shape as runtime.
+   */
+  stampLakes(width: number, height: number, lakeMask: Uint8Array): LakeProjectionResult {
+    this.calls.stampLakes.push({ width, height, lakeMask });
+    const expectedSize = Math.max(0, (width | 0) * (height | 0));
+    if (lakeMask.length !== expectedSize) {
+      throw new Error(
+        `[MockAdapter] Invalid lake mask length for stampLakes (expected ${expectedSize}, got ${lakeMask.length}).`
+      );
+    }
+
+    let plannedLakeTileCount = 0;
+
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const idx = y * width + x;
+        if (lakeMask[idx] !== 1) continue;
+        plannedLakeTileCount += 1;
+        this.terrainTypes[idx] = this.coastTerrainId & 0xff;
+      }
+    }
+
+    this.recalculateAreas();
+    this.storeWaterData();
+
+    const stampedLakeMask = new Uint8Array(expectedSize);
+    const rejectedLakeMask = new Uint8Array(expectedSize);
+    let stampedLakeTileCount = 0;
+    let rejectedLakeTileCount = 0;
+
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const idx = y * width + x;
+        if (lakeMask[idx] !== 1) continue;
+        if (this.isWater(x, y)) {
+          stampedLakeMask[idx] = 1;
+          stampedLakeTileCount += 1;
+        } else {
+          rejectedLakeMask[idx] = 1;
+          rejectedLakeTileCount += 1;
+        }
+      }
+    }
+
+    return {
+      width,
+      height,
+      plannedLakeMask: lakeMask,
+      stampedLakeMask,
+      rejectedLakeMask,
+      plannedLakeTileCount,
+      stampedLakeTileCount,
+      rejectedLakeTileCount,
+    };
   }
 
   expandCoasts(width: number, height: number): void {
@@ -909,7 +976,9 @@ export class MockAdapter implements EngineAdapter {
     const resolvedStartPositions = (Array.isArray(startPositions) ? startPositions : [])
       .filter((value) => Number.isFinite(value) && value >= 0)
       .map((value) => Math.trunc(value));
-    const resolvedPolarMargin = Number.isFinite(polarMargin) ? Math.max(0, Math.trunc(polarMargin)) : 0;
+    const resolvedPolarMargin = Number.isFinite(polarMargin)
+      ? Math.max(0, Math.trunc(polarMargin))
+      : 0;
 
     this.calls.generateOfficialDiscoveries.push({
       width,
@@ -1069,6 +1138,7 @@ export class MockAdapter implements EngineAdapter {
     this.calls.generateSnow.length = 0;
     this.calls.setResourceType.length = 0;
     this.calls.generateLakes.length = 0;
+    this.calls.stampLakes.length = 0;
     this.calls.expandCoasts.length = 0;
     this.calls.assignStartPositions.length = 0;
     this.calls.setStartPosition.length = 0;
@@ -1084,7 +1154,9 @@ export class MockAdapter implements EngineAdapter {
     this.canHaveFeatureFn = config.canHaveFeature ?? this.canHaveFeatureFn;
     this.canHaveResourceFn = config.canHaveResource ?? this.canHaveResourceFn;
     this.naturalWonderCatalog = (
-      config.naturalWonderCatalog ?? this.naturalWonderCatalog ?? DEFAULT_NATURAL_WONDER_CATALOG
+      config.naturalWonderCatalog ??
+      this.naturalWonderCatalog ??
+      DEFAULT_NATURAL_WONDER_CATALOG
     ).map((entry) => ({
       featureType: entry.featureType,
       direction: entry.direction,

--- a/packages/civ7-adapter/src/types.ts
+++ b/packages/civ7-adapter/src/types.ts
@@ -78,6 +78,23 @@ export interface MapInfo {
   [key: string]: unknown;
 }
 
+/**
+ * Adapter readback for deterministic lake projection.
+ *
+ * The planned mask is MapGen truth; stamped/rejected masks are engine evidence
+ * used by projection diagnostics and should not replace the upstream plan.
+ */
+export interface LakeProjectionResult {
+  width: number;
+  height: number;
+  plannedLakeMask: Uint8Array;
+  stampedLakeMask: Uint8Array;
+  rejectedLakeMask: Uint8Array;
+  plannedLakeTileCount: number;
+  stampedLakeTileCount: number;
+  rejectedLakeTileCount: number;
+}
+
 // ============================================================================
 // Voronoi Utilities (foundation dependency)
 // ============================================================================
@@ -357,6 +374,13 @@ export interface EngineAdapter {
 
   /** Generate lakes (wraps Civ7 base-standard elevation terrain generator) */
   generateLakes(width: number, height: number, tilesPerLake: number): void;
+
+  /**
+   * Stamp a deterministic lake plan and read back engine water acceptance.
+   *
+   * MapGen owns the plan; the adapter owns engine terrain mutation and cache refresh.
+   */
+  stampLakes(width: number, height: number, lakeMask: Uint8Array): LakeProjectionResult;
 
   /** Expand coasts (wraps Civ7 base-standard elevation terrain generator) */
   expandCoasts(width: number, height: number): void;


### PR DESCRIPTION
Lake authority has been moved from Civ7 engine generation to Hydrology-owned intent with adapter projection evidence.

**Hydrology truth side:**
- Added a `plan-lakes` op with a default strategy that seeds lake intent from drainage sinks and optionally expands upstream through `flowDir` receivers. The strategy config is op-local to avoid a shared config dumping ground.
- Added `artifact:hydrology.lakePlan` (deterministic lake intent mask, planned tile count, sink count) and a `hydrology-hydrography/lakes` step that publishes it.
- Added `flowDir` (steepest-descent receiver index per tile) to the `hydrography` artifact so the lake planning step can follow drainage structure.
- Moved the `lakeiness` knob from `map-hydrology` to `hydrology-hydrography`, where it now maps to `planLakes.config.maxUpstreamSteps` instead of tuning engine lake frequency.

**Projection side:**
- Added `EngineAdapter.stampLakes(width, height, lakeMask): LakeProjectionResult` to both `Civ7Adapter` and `MockAdapter`. The adapter stamps terrain, refreshes area and water caches, then reads back stamped/rejected masks as projection evidence.
- `map-hydrology/lakes` now calls `stampLakes` with `artifact:hydrology.lakePlan` instead of `generateLakes`. It records accepted/rejected lake tile counts as diagnostics and no longer authors lake truth.
- Placement input derivation now consumes `artifact:hydrology.lakePlan` instead of `engineProjectionLakes` so downstream planning does not inherit engine readback drift as source authority.
- Lake plan vs. engine water mask mismatch is emitted as projection evidence rather than a fail-hard gate.

**Guardrails and tests:**
- Added a categorical map-stage contract guard asserting that no standard recipe stage calls `adapter.generateLakes(...)` and that only `map-hydrology/steps/lakes.ts` calls `adapter.stampLakes(...)`.
- Added `test/hydrology/plan-lakes.test.ts` covering sink-only intent and upstream expansion through flow receivers.
- Updated `lakes-store-water-data`, `lakes-runtime-fill-drift`, and `lakes-area-recalc-resources` tests to use `stampLakes`-based adapter doubles and the new artifact shape.
- Updated the `normalize-projection-lakes` openspec tasks, spec, and implementation record to reflect completion.