### PR TITLE
feat(placement): promote natural wonder stamping to dedicated product/effect step

### DIFF
--- a/docs/system/libs/mapgen/reference/domains/PLACEMENT.md
+++ b/docs/system/libs/mapgen/reference/domains/PLACEMENT.md
@@ -36,21 +36,25 @@ Placement requires (dependency tags):
 - `effect:engine.riversModeled` (from `map-hydrology`)
 - `effect:engine.featuresApplied` (from `map-ecology`)
 - `effect:map.landmassRegionsPlotted` (from `plot-landmass-regions`)
+- `effect:placement.naturalWondersPlaced` (from `place-natural-wonders`, required by final placement)
 
 Placement provides:
+- `effect:placement.naturalWondersPlaced` (natural-wonder product boundary)
 - `effect:engine.placementApplied` (verified effect tag)
 
 Placement artifacts:
 - Provides `artifact:placementInputs` (derived from config + placement ops)
 - Provides deterministic plan artifacts: `artifact:placement.resourcePlan`, `artifact:placement.naturalWonderPlan`, `artifact:placement.discoveryPlan`
-- Requires `artifact:placementInputs` and `artifact:map.landmassRegionSlotByTile` for final placement
+- Provides `artifact:placement.naturalWonderPlacement` after all planned natural wonders stamp successfully
+- Requires `artifact:placementInputs`, `artifact:placement.naturalWonderPlacement`, and `artifact:map.landmassRegionSlotByTile` for final placement
 - Provides `artifact:placementOutputs` (verification/debug surface)
 
 Runtime semantics:
 - Placement apply is fail-hard.
-- Natural wonders still use deterministic full-stamp-or-fail semantics.
+- Natural wonders use deterministic full-stamp-or-fail semantics in their own product/effect step.
 - Discoveries/resources run through official Civ generators; generator invocation failures and invalid placement metrics abort the placement step with explicit context.
 - Owned deterministic resource planning artifacts are retained for diagnostics/parity work but are non-primary at runtime and currently parity-incomplete for age/eligibility behavior.
+- Terrain validation, area recalculation, water cache storage, landmass-region restamping, and fertility recalculation remain transactional inside final placement because no independent consumer currently exists.
 
 ## Key artifacts
 
@@ -72,6 +76,11 @@ Placement domain ops used by the standard recipe:
 
 These ops produce placement plans/inputs which are then applied in the placement step.
 
+Natural-wonder placement is the first promoted product boundary: the plan
+artifact is materialized by `place-natural-wonders`, and final placement
+requires its effect/artifact before continuing. Resource and discovery
+reconciliation remains intentionally deferred to the D4 typed-outcome slice.
+
 ## Config posture
 
 Placement stage config is currently minimal:
@@ -86,6 +95,7 @@ Placement stage config is currently minimal:
 - Step contracts:
   - `mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/contract.ts`
   - `mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plot-landmass-regions/contract.ts`
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/contract.ts`
   - `mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/contract.ts`
 - Placement artifacts: `mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts`
 - Projection artifacts (inputs): `mods/mod-swooper-maps/src/recipes/standard/map-artifacts.ts`

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
@@ -33,10 +33,25 @@ const PlacementEngineStateV1Schema = Type.Object(
     discoveriesError: Type.Optional(Type.String()),
     waterDriftCount: Type.Integer({
       minimum: 0,
-      description: "Mismatch count between physics landMask and engine landMask at placement completion.",
+      description:
+        "Mismatch count between physics landMask and engine landMask at placement completion.",
     }),
   },
   { additionalProperties: false }
+);
+
+const NaturalWonderPlacementArtifactSchema = Type.Object(
+  {
+    plannedCount: Type.Integer({ minimum: 0 }),
+    placedCount: Type.Integer({ minimum: 0 }),
+    skippedOutOfBoundsCount: Type.Integer({ minimum: 0 }),
+    rejectedCount: Type.Integer({ minimum: 0 }),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Verified natural-wonder stamping result. This is a product contract because failed or partial stamping aborts the placement pipeline.",
+  }
 );
 
 export const placementArtifacts = {
@@ -54,6 +69,11 @@ export const placementArtifacts = {
     name: "naturalWonderPlan",
     id: "artifact:placement.naturalWonderPlan",
     schema: placement.ops.planNaturalWonders.output,
+  }),
+  naturalWonderPlacement: defineArtifact({
+    name: "naturalWonderPlacement",
+    id: "artifact:placement.naturalWonderPlacement",
+    schema: NaturalWonderPlacementArtifactSchema,
   }),
   discoveryPlan: defineArtifact({
     name: "discoveryPlan",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/index.ts
@@ -1,8 +1,17 @@
 import { Type, createStage } from "@swooper/mapgen-core/authoring";
-import { derivePlacementInputs, placement, plotLandmassRegions } from "./steps/index.js";
+import {
+  derivePlacementInputs,
+  placeNaturalWonders,
+  placement,
+  plotLandmassRegions,
+} from "./steps/index.js";
 
+/**
+ * Placement exposes true gameplay products as step boundaries while keeping
+ * maintenance sequencing inside the transactional placement step.
+ */
 export default createStage({
   id: "placement",
   knobsSchema: Type.Object({}, { additionalProperties: false }),
-  steps: [derivePlacementInputs, plotLandmassRegions, placement],
+  steps: [derivePlacementInputs, plotLandmassRegions, placeNaturalWonders, placement],
 } as const);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/index.ts
@@ -1,3 +1,4 @@
 export { default as derivePlacementInputs } from "./derive-placement-inputs/index.js";
 export { default as plotLandmassRegions } from "./plot-landmass-regions/index.js";
+export { default as placeNaturalWonders } from "./place-natural-wonders/index.js";
 export { default as placement } from "./placement/index.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/contract.ts
@@ -1,0 +1,24 @@
+import { Type, defineStep } from "@swooper/mapgen-core/authoring";
+
+import { PLACEMENT_PRODUCT_EFFECT_TAGS } from "../../../../tags.js";
+import { placementArtifacts } from "../../artifacts.js";
+
+/**
+ * Natural wonders are a placement product boundary, not a maintenance helper.
+ *
+ * The upstream planner owns intent and this step owns the materialized Civ7
+ * effect: every planned wonder must stamp successfully or placement aborts.
+ */
+const PlaceNaturalWondersStepContract = defineStep({
+  id: "place-natural-wonders",
+  phase: "placement",
+  requires: [],
+  provides: [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.naturalWondersPlaced],
+  artifacts: {
+    requires: [placementArtifacts.placementInputs, placementArtifacts.naturalWonderPlan],
+    provides: [placementArtifacts.naturalWonderPlacement],
+  },
+  schema: Type.Object({}, { additionalProperties: false }),
+});
+
+export default PlaceNaturalWondersStepContract;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/index.ts
@@ -1,0 +1,31 @@
+import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
+
+import { buildPlacementPlanInput } from "../placement/inputs.js";
+import {
+  stampNaturalWondersFromPlan,
+  type NaturalWonderStampingStats,
+} from "../placement/apply.js";
+import { placementArtifacts } from "../../artifacts.js";
+import PlaceNaturalWondersStepContract from "./contract.js";
+
+export default createStep(PlaceNaturalWondersStepContract, {
+  artifacts: implementArtifacts([placementArtifacts.naturalWonderPlacement], {
+    naturalWonderPlacement: {},
+  }),
+  run: (context, _config, _ops, deps) => {
+    const placementInputs = deps.artifacts.placementInputs.read(context);
+    const naturalWonderPlan = deps.artifacts.naturalWonderPlan.read(context);
+    const { wonders } = buildPlacementPlanInput(placementInputs);
+    const { width, height } = context.dimensions;
+
+    const stamping: NaturalWonderStampingStats = stampNaturalWondersFromPlan({
+      adapter: context.adapter,
+      width,
+      height,
+      wonders: naturalWonderPlan,
+      requestedCount: wonders.wondersCount,
+    });
+
+    deps.artifacts.naturalWonderPlacement.publish(context, stamping);
+  },
+});

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/apply.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/apply.ts
@@ -12,12 +12,12 @@ import placement from "@mapgen/domain/placement";
 import type { DeepReadonly, Static } from "@swooper/mapgen-core/authoring";
 import type { PlacementOutputsV1 } from "../../placement-outputs.js";
 
-type PlanFloodplainsOutput = Static<typeof placement.ops.planFloodplains["output"]>;
-type PlanDiscoveriesOutput = Static<typeof placement.ops.planDiscoveries["output"]>;
-type PlanNaturalWondersOutput = Static<typeof placement.ops.planNaturalWonders["output"]>;
-type PlanResourcesOutput = Static<typeof placement.ops.planResources["output"]>;
-type PlanStartsOutput = Static<typeof placement.ops.planStarts["output"]>;
-type PlanWondersOutput = Static<typeof placement.ops.planWonders["output"]>;
+type PlanFloodplainsOutput = Static<(typeof placement.ops.planFloodplains)["output"]>;
+type PlanDiscoveriesOutput = Static<(typeof placement.ops.planDiscoveries)["output"]>;
+type PlanNaturalWondersOutput = Static<(typeof placement.ops.planNaturalWonders)["output"]>;
+type PlanResourcesOutput = Static<(typeof placement.ops.planResources)["output"]>;
+type PlanStartsOutput = Static<(typeof placement.ops.planStarts)["output"]>;
+type PlanWondersOutput = Static<(typeof placement.ops.planWonders)["output"]>;
 
 type LandmassRegionSlotByTile = Static<
   (typeof import("../../../../map-artifacts.js").mapArtifacts)["landmassRegionSlotByTile"]["schema"]
@@ -33,6 +33,7 @@ type ApplyPlacementArgs = {
   context: ExtendedMapContext;
   starts: DeepReadonly<PlanStartsOutput>;
   wonders: DeepReadonly<PlanWondersOutput>;
+  naturalWonderPlacement?: DeepReadonly<NaturalWonderStampingStats>;
   naturalWonderPlan: DeepReadonly<PlanNaturalWondersOutput>;
   discoveryPlan: DeepReadonly<PlanDiscoveriesOutput>;
   floodplains: DeepReadonly<PlanFloodplainsOutput>;
@@ -84,6 +85,7 @@ export function applyPlacementPlan({
   context,
   starts,
   wonders,
+  naturalWonderPlacement,
   naturalWonderPlan,
   discoveryPlan,
   floodplains,
@@ -133,21 +135,18 @@ export function applyPlacementPlan({
 
   logTerrainStats(trace, adapter, width, height, "Initial");
 
-  const wonderStamping = runPlacementStep("placement.wonders", emit, () => {
-    const stamping = stampNaturalWondersFromPlan({
-      adapter,
-      width,
-      height,
-      wonders: resolvedNaturalWonderPlan,
-    });
-    const requestedCount = Math.max(0, wonders.wondersCount | 0);
-    if (requestedCount !== (stamping.plannedCount | 0)) {
-      throw new Error(
-        `[Placement] Natural wonder planner could not meet requested count (requested ${requestedCount}, planned ${stamping.plannedCount}).`
-      );
-    }
-    return stamping;
-  });
+  const wonderStamping = naturalWonderPlacement
+    ? normalizeNaturalWonderStampingStats(naturalWonderPlacement)
+    : runPlacementStep("placement.wonders", emit, () => {
+        const stamping = stampNaturalWondersFromPlan({
+          adapter,
+          width,
+          height,
+          wonders: resolvedNaturalWonderPlan,
+          requestedCount: wonders.wondersCount,
+        });
+        return stamping;
+      });
   const wondersPlanned = wonderStamping.plannedCount;
   const wondersPlaced = wonderStamping.placedCount;
   emit({
@@ -278,7 +277,9 @@ export function applyPlacementPlan({
 
   const physics = context.buffers.heightfield;
   const engineSnapshot = snapshotEngineHeightfield(context);
-  const engineLandMask = engineSnapshot ? engineSnapshot.landMask : new Uint8Array(physics.landMask);
+  const engineLandMask = engineSnapshot
+    ? engineSnapshot.landMask
+    : new Uint8Array(physics.landMask);
   let waterDriftCount = 0;
   for (let i = 0; i < engineLandMask.length; i++) {
     if ((engineLandMask[i] ?? 0) !== (physics.landMask[i] ?? 0)) waterDriftCount += 1;
@@ -355,20 +356,29 @@ type StampNaturalWondersFromPlanArgs = {
   width: number;
   height: number;
   wonders: DeepReadonly<PlanNaturalWondersOutput>;
+  requestedCount?: number;
 };
 
-type NaturalWonderStampingStats = {
+export type NaturalWonderStampingStats = {
   plannedCount: number;
   placedCount: number;
   skippedOutOfBoundsCount: number;
   rejectedCount: number;
 };
 
-function stampNaturalWondersFromPlan({
+/**
+ * Stamps deterministic natural-wonder intent as its own placement product.
+ *
+ * Natural wonders have a concrete plan artifact and all-or-nothing materialized
+ * effect. Keeping that verification here lets the recipe expose a standalone
+ * step without duplicating Civ7 adapter policy in the domain planner.
+ */
+export function stampNaturalWondersFromPlan({
   adapter,
   width,
   height,
   wonders,
+  requestedCount,
 }: StampNaturalWondersFromPlanArgs): NaturalWonderStampingStats {
   if ((wonders.width | 0) !== (width | 0) || (wonders.height | 0) !== (height | 0)) {
     throw new Error(
@@ -386,6 +396,15 @@ function stampNaturalWondersFromPlan({
   if (plannedCount < targetCount) {
     throw new Error(
       `[Placement] Natural wonder plan cannot satisfy target count (target=${targetCount}, planned=${plannedCount}).`
+    );
+  }
+  const requested = Math.max(
+    0,
+    Number.isFinite(requestedCount) ? (requestedCount as number) | 0 : targetCount
+  );
+  if (requested !== plannedCount) {
+    throw new Error(
+      `[Placement] Natural wonder planner could not meet requested count (requested ${requested}, planned ${plannedCount}).`
     );
   }
 
@@ -435,6 +454,26 @@ function stampNaturalWondersFromPlan({
     );
   }
 
+  return {
+    plannedCount,
+    placedCount,
+    skippedOutOfBoundsCount,
+    rejectedCount,
+  };
+}
+
+function normalizeNaturalWonderStampingStats(
+  stats: DeepReadonly<NaturalWonderStampingStats>
+): NaturalWonderStampingStats {
+  const plannedCount = Math.max(0, stats.plannedCount | 0);
+  const placedCount = Math.max(0, stats.placedCount | 0);
+  const skippedOutOfBoundsCount = Math.max(0, stats.skippedOutOfBoundsCount | 0);
+  const rejectedCount = Math.max(0, stats.rejectedCount | 0);
+  if (placedCount !== plannedCount || skippedOutOfBoundsCount > 0 || rejectedCount > 0) {
+    throw new Error(
+      `[Placement] Natural wonder placement artifact is not fully satisfied (placed ${placedCount}/${plannedCount}, outOfBounds=${skippedOutOfBoundsCount}, rejected=${rejectedCount}).`
+    );
+  }
   return {
     plannedCount,
     placedCount,
@@ -493,7 +532,9 @@ function generateDiscoveriesWithOfficialFallback({
   const plannedCount = Number.isFinite(discoveries.plannedCount)
     ? Math.max(0, Math.trunc(discoveries.plannedCount))
     : Math.max(0, discoveries.placements.length | 0);
-  const resolvedPolarMargin = Number.isFinite(polarMargin) ? Math.max(0, Math.trunc(polarMargin)) : 0;
+  const resolvedPolarMargin = Number.isFinite(polarMargin)
+    ? Math.max(0, Math.trunc(polarMargin))
+    : 0;
   const resolvedStartPositions = sanitizeStartPositions(startPositions);
   const placedCount = adapter.generateOfficialDiscoveries(
     width,
@@ -627,11 +668,7 @@ type AssignStartPositionsArgs = {
   slotByTile: Uint8Array;
 };
 
-function assignStartPositions({
-  context,
-  starts,
-  slotByTile,
-}: AssignStartPositionsArgs): {
+function assignStartPositions({ context, starts, slotByTile }: AssignStartPositionsArgs): {
   positions: number[];
   assigned: number;
   primaryAssigned: number;
@@ -823,10 +860,7 @@ function buildStartSectorGrid(input: {
   return out;
 }
 
-function emitStartPositionsViz(
-  context: ExtendedMapContext,
-  startPositions: number[]
-): void {
+function emitStartPositionsViz(context: ExtendedMapContext, startPositions: number[]): void {
   if (!startPositions.length) return;
   const { width, height } = context.dimensions;
   const valid = startPositions
@@ -893,10 +927,7 @@ function emitStartPositionsViz(
   });
 }
 
-function collectCandidates(
-  slotByTile: Uint8Array,
-  slot: number | null
-): number[] {
+function collectCandidates(slotByTile: Uint8Array, slot: number | null): number[] {
   const candidates: number[] = [];
   for (let i = 0; i < slotByTile.length; i++) {
     const value = slotByTile[i] ?? 0;
@@ -924,7 +955,8 @@ function filterCandidatesBySectors(
     return candidates;
   }
 
-  const offset = sectors.length === sectorsPerRegion * 2 && region === "east" ? sectorsPerRegion : 0;
+  const offset =
+    sectors.length === sectorsPerRegion * 2 && region === "east" ? sectorsPerRegion : 0;
   const cellWidth = width / cols;
   const cellHeight = height / rows;
   const maxCol = Math.max(1, cols);
@@ -1021,12 +1053,7 @@ function minDistanceToSelection(
   return best;
 }
 
-function hexDistanceOddQ(
-  aIndex: number,
-  bIndex: number,
-  width: number,
-  _height: number
-): number {
+function hexDistanceOddQ(aIndex: number, bIndex: number, width: number, _height: number): number {
   const ay = (aIndex / width) | 0;
   const ax = aIndex - ay * width;
   const by = (bIndex / width) | 0;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/contract.ts
@@ -1,13 +1,20 @@
 import { Type, defineStep } from "@swooper/mapgen-core/authoring";
 
-import { STANDARD_ENGINE_EFFECT_TAGS, MAP_PROJECTION_EFFECT_TAGS } from "../../../../tags.js";
+import {
+  STANDARD_ENGINE_EFFECT_TAGS,
+  MAP_PROJECTION_EFFECT_TAGS,
+  PLACEMENT_PRODUCT_EFFECT_TAGS,
+} from "../../../../tags.js";
 import { placementArtifacts } from "../../artifacts.js";
 import { mapArtifacts } from "../../../../map-artifacts.js";
 
 const PlacementStepContract = defineStep({
   id: "placement",
   phase: "placement",
-  requires: [MAP_PROJECTION_EFFECT_TAGS.map.landmassRegionsPlotted],
+  requires: [
+    MAP_PROJECTION_EFFECT_TAGS.map.landmassRegionsPlotted,
+    PLACEMENT_PRODUCT_EFFECT_TAGS.placement.naturalWondersPlaced,
+  ],
   provides: [
     STANDARD_ENGINE_EFFECT_TAGS.engine.placementApplied,
     MAP_PROJECTION_EFFECT_TAGS.map.placementParityCaptured,
@@ -16,6 +23,7 @@ const PlacementStepContract = defineStep({
     requires: [
       placementArtifacts.placementInputs,
       placementArtifacts.resourcePlan,
+      placementArtifacts.naturalWonderPlacement,
       placementArtifacts.naturalWonderPlan,
       placementArtifacts.discoveryPlan,
       mapArtifacts.landmassRegionSlotByTile,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/index.ts
@@ -16,11 +16,12 @@ export default createStep(PlacementStepContract, {
       placementOutputs: {},
       engineState: {},
       placementEngineTerrainSnapshot: {},
-    },
+    }
   ),
   run: (context, _config, _ops, deps) => {
     const placementInputs = deps.artifacts.placementInputs.read(context);
     const resourcePlan = deps.artifacts.resourcePlan.read(context);
+    const naturalWonderPlacement = deps.artifacts.naturalWonderPlacement.read(context);
     const naturalWonderPlan = deps.artifacts.naturalWonderPlan.read(context);
     const discoveryPlan = deps.artifacts.discoveryPlan.read(context);
     const landmassRegionSlotByTile = deps.artifacts.landmassRegionSlotByTile.read(context);
@@ -30,15 +31,14 @@ export default createStep(PlacementStepContract, {
       context,
       starts,
       wonders,
+      naturalWonderPlacement,
       naturalWonderPlan,
       discoveryPlan,
       floodplains,
       resources: resourcePlan,
       landmassRegionSlotByTile,
-      publishOutputs: (outputs) =>
-        deps.artifacts.placementOutputs.publish(context, outputs),
-      publishEngineState: (engineState) =>
-        deps.artifacts.engineState.publish(context, engineState),
+      publishOutputs: (outputs) => deps.artifacts.placementOutputs.publish(context, outputs),
+      publishEngineState: (engineState) => deps.artifacts.engineState.publish(context, engineState),
       publishEngineTerrainSnapshot: (snapshot) =>
         deps.artifacts.placementEngineTerrainSnapshot.publish(context, snapshot),
     });

--- a/mods/mod-swooper-maps/src/recipes/standard/tags.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/tags.ts
@@ -42,6 +42,12 @@ export const MAP_PROJECTION_EFFECT_TAGS = {
   },
 } as const;
 
+export const PLACEMENT_PRODUCT_EFFECT_TAGS = {
+  placement: {
+    naturalWondersPlaced: "effect:placement.naturalWondersPlaced",
+  },
+} as const;
+
 export const CANONICAL_FIELD_AND_ENGINE_TAGS: ReadonlySet<string> = new Set([
   ...Object.values(FIELD_DEPENDENCY_TAGS.field),
   ...Object.values(STANDARD_ENGINE_EFFECT_TAGS.engine),
@@ -113,6 +119,11 @@ const EFFECT_OWNERS: Record<string, TagOwner> = {
     phase: "placement",
     stepId: "placement",
   },
+  [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.naturalWondersPlaced]: {
+    pkg: "mod-swooper-maps",
+    phase: "placement",
+    stepId: "place-natural-wonders",
+  },
   [STANDARD_ENGINE_EFFECT_TAGS.engine.riversModeled]: {
     pkg: "mod-swooper-maps",
     phase: "gameplay",
@@ -181,6 +192,17 @@ export const STANDARD_TAG_DEFINITIONS: readonly DependencyTagDefinition<Extended
     validateDemo: (demo) => isInt16Array(demo),
   },
   ...Object.values(MAP_PROJECTION_EFFECT_TAGS.map).map((id) => {
+    const definition: DependencyTagDefinition<ExtendedMapContext> = {
+      id,
+      kind: "effect",
+    };
+    const owner = EFFECT_OWNERS[id];
+    if (owner) {
+      definition.owner = owner;
+    }
+    return definition;
+  }),
+  ...Object.values(PLACEMENT_PRODUCT_EFFECT_TAGS.placement).map((id) => {
     const definition: DependencyTagDefinition<ExtendedMapContext> = {
       id,
       kind: "effect",

--- a/mods/mod-swooper-maps/test/placement/placement-contracts.test.ts
+++ b/mods/mod-swooper-maps/test/placement/placement-contracts.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+
+import standardRecipe from "../../src/recipes/standard/recipe.js";
+import {
+  PLACEMENT_PRODUCT_EFFECT_TAGS,
+  STANDARD_ENGINE_EFFECT_TAGS,
+} from "../../src/recipes/standard/tags.js";
+import { placementArtifacts } from "../../src/recipes/standard/stages/placement/artifacts.js";
+import placeNaturalWondersStep from "../../src/recipes/standard/stages/placement/steps/place-natural-wonders/index.js";
+import placementStep from "../../src/recipes/standard/stages/placement/steps/placement/index.js";
+
+describe("placement product/effect contracts", () => {
+  it("promotes natural wonder stamping as a product/effect boundary before final placement", () => {
+    const placementStepIds = standardRecipe.recipe.steps
+      .map((step) => step.id)
+      .filter((id) => id.includes(".placement."));
+
+    expect(placementStepIds).toContain("mod-swooper-maps.standard.placement.place-natural-wonders");
+    expect(
+      placementStepIds.indexOf("mod-swooper-maps.standard.placement.place-natural-wonders")
+    ).toBeLessThan(placementStepIds.indexOf("mod-swooper-maps.standard.placement.placement"));
+
+    expect(placeNaturalWondersStep.contract.provides).toContain(
+      PLACEMENT_PRODUCT_EFFECT_TAGS.placement.naturalWondersPlaced
+    );
+    expect(placeNaturalWondersStep.contract.artifacts.provides).toContain(
+      placementArtifacts.naturalWonderPlacement
+    );
+    expect(placementStep.contract.requires).toContain(
+      PLACEMENT_PRODUCT_EFFECT_TAGS.placement.naturalWondersPlaced
+    );
+    expect(placementStep.contract.artifacts.requires).toContain(
+      placementArtifacts.naturalWonderPlacement
+    );
+  });
+
+  it("keeps maintenance operations transactional until they own an independent product contract", () => {
+    const placementStepIds = standardRecipe.recipe.steps.map((step) => step.id);
+
+    expect(placementStep.contract.provides).toContain(
+      STANDARD_ENGINE_EFFECT_TAGS.engine.placementApplied
+    );
+    expect(placementStepIds.some((id) => id.includes(".terrain.validate"))).toBe(false);
+    expect(placementStepIds.some((id) => id.includes(".areas.recalculate"))).toBe(false);
+    expect(placementStepIds.some((id) => id.includes(".water.store"))).toBe(false);
+    expect(placementStepIds.some((id) => id.includes(".fertility.recalculate"))).toBe(false);
+  });
+});

--- a/openspec/changes/normalize-placement-contracts/implementation.md
+++ b/openspec/changes/normalize-placement-contracts/implementation.md
@@ -1,0 +1,46 @@
+## Implementation Record
+
+This slice promotes the first real placement product boundary:
+`place-natural-wonders`.
+
+Natural wonders were promoted because they already have:
+
+- an upstream deterministic plan artifact: `artifact:placement.naturalWonderPlan`
+- a materialized product artifact: `artifact:placement.naturalWonderPlacement`
+- an effect surface: `effect:placement.naturalWondersPlaced`
+- full-stamp-or-fail verification
+- a downstream consumer: final placement requires the effect and artifact
+
+Resource, discovery, start, and advanced-start work was intentionally not
+promoted in this slice. Resource and discovery planning already has plan
+artifacts, but projection still delegates feasibility to official Civ
+generators; typed outcomes and rejection reasons belong to
+`normalize-placement-reconciliation`. Start assignment feeds discovery
+generation in the same runtime sequence and has no independent downstream
+consumer yet. Advanced-start assignment remains an engine-side terminal effect
+without an artifact consumer.
+
+Maintenance operations remain transactional inside final placement:
+
+- floodplain application
+- terrain validation
+- area recalculation
+- water cache storage
+- landmass-region restamping before official resource generation
+- fertility recalculation
+
+Those operations are ordered engine maintenance required for the placement
+transaction; no independent artifact/effect/consumer contract currently
+justifies splitting them into separate recipe steps.
+
+## Validation
+
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run --cwd mods/mod-swooper-maps build`
+- `bun run --cwd mods/mod-swooper-maps test -- test/placement/placement-contracts.test.ts test/placement/placement-does-not-call-generate-snow.test.ts test/placement/resources-landmass-region-restamp.test.ts test/placement/plan-ops.test.ts test/placement/landmass-region-id-projection.test.ts test/standard-run.test.ts test/standard-recipe.test.ts test/pipeline/artifacts.test.ts`
+- `bun run lint:mapgen-recipe-imports`
+- `bun run lint:domain-refactor-guardrails`
+- `bun run lint:mapgen-docs` (passes with the existing three `@mapgen/*` documentation warnings)
+- `bun run openspec -- validate normalize-placement-contracts --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/normalize-placement-contracts/tasks.md
+++ b/openspec/changes/normalize-placement-contracts/tasks.md
@@ -1,31 +1,31 @@
 ## 1. Product Boundary Inventory
 
-- [ ] 1.1 Inventory placement apply sub-concerns and classify each as product,
+- [x] 1.1 Inventory placement apply sub-concerns and classify each as product,
   effect, maintenance, or helper.
-- [ ] 1.2 Name artifact/effect/consumer/verification surfaces for promoted
+- [x] 1.2 Name artifact/effect/consumer/verification surfaces for promoted
   products.
 
 ## 2. Decomposition
 
-- [ ] 2.1 Split natural wonder placement if it has a real product/effect
+- [x] 2.1 Split natural wonder placement if it has a real product/effect
   contract.
-- [ ] 2.2 Split resource, start, discovery, and advanced-start boundaries only
+- [x] 2.2 Split resource, start, discovery, and advanced-start boundaries only
   where contracts are explicit.
-- [ ] 2.3 Keep maintenance operations transactional unless promoted by a named
+- [x] 2.3 Keep maintenance operations transactional unless promoted by a named
   contract.
-- [ ] 2.4 Preserve current projection semantics for resources/discoveries until
+- [x] 2.4 Preserve current projection semantics for resources/discoveries until
   the D4 slice.
 
 ## 3. Docs And Tests
 
-- [ ] 3.1 Add placement contract tests.
-- [ ] 3.2 Update placement docs to describe product/effect boundaries.
-- [ ] 3.3 Record any maintenance operations intentionally left transactional.
+- [x] 3.1 Add placement contract tests.
+- [x] 3.2 Update placement docs to describe product/effect boundaries.
+- [x] 3.3 Record any maintenance operations intentionally left transactional.
 
 ## 4. Verification
 
-- [ ] 4.1 Run placement focused tests.
-- [ ] 4.2 Run recipe/stage contract checks affected by the split.
-- [ ] 4.3 Run `bun run openspec -- validate normalize-placement-contracts --strict`.
-- [ ] 4.4 Run `bun run openspec:validate`.
-- [ ] 4.5 Run `git diff --check`.
+- [x] 4.1 Run placement focused tests.
+- [x] 4.2 Run recipe/stage contract checks affected by the split.
+- [x] 4.3 Run `bun run openspec -- validate normalize-placement-contracts --strict`.
+- [x] 4.4 Run `bun run openspec:validate`.
+- [x] 4.5 Run `git diff --check`.


### PR DESCRIPTION
Natural wonder stamping is promoted to its own recipe step (`place-natural-wonders`) with an explicit product artifact (`artifact:placement.naturalWonderPlacement`) and effect tag (`effect:placement.naturalWondersPlaced`). Final placement now requires both before continuing, enforcing a hard product boundary between wonder materialization and the rest of placement apply.

The `stampNaturalWondersFromPlan` function is exported from `apply.ts` and called directly by the new step. When final placement receives the pre-stamped artifact, it validates the counts through `normalizeNaturalWonderStampingStats` rather than re-running the stamping logic. The `requestedCount` parameter is threaded through so the planner-vs-requested count check happens at stamp time regardless of which path invokes it.

`NaturalWonderPlacementArtifactSchema` is added to `artifacts.ts` with `plannedCount`, `placedCount`, `skippedOutOfBoundsCount`, and `rejectedCount` fields. The placement step contract is updated to require the new effect tag and artifact.

Maintenance operations (terrain validation, area recalculation, water cache storage, landmass-region restamping, fertility recalculation) remain transactional inside final placement because no independent artifact consumer currently exists for any of them. Resource, discovery, and start assignment are also intentionally deferred — resource and discovery reconciliation belongs to the typed-outcome slice, and start assignment has no independent downstream consumer yet.

Contract tests are added in `placement-contracts.test.ts` to assert step ordering, that `place-natural-wonders` provides the expected effect and artifact, that final placement requires both, and that none of the maintenance operations have been incorrectly split into standalone steps.