### PR TITLE
feat(placement): replace official generators with typed adapter intent materialization

### DIFF
--- a/docs/system/libs/mapgen/reference/domains/PLACEMENT.md
+++ b/docs/system/libs/mapgen/reference/domains/PLACEMENT.md
@@ -14,6 +14,7 @@
 ## Purpose
 
 Placement is legacy naming for the **Gameplay** domain’s “placement phase”: the pipeline boundary where “map content” becomes “gameplay outcomes”:
+
 - assign starts,
 - place wonders/resources/discoveries,
 - and publish placement outputs for verification and debugging.
@@ -21,11 +22,13 @@ Placement is legacy naming for the **Gameplay** domain’s “placement phase”
 Placement is intentionally **projection/engine-facing**: it depends on prior projection steps (engine rivers/features) and uses engine adapters to apply gameplay outcomes.
 
 Target posture: Gameplay absorbs Placement. See:
+
 - [`docs/system/libs/mapgen/reference/domains/GAMEPLAY.md`](/system/libs/mapgen/reference/domains/GAMEPLAY.md)
 
 ## Stages (standard recipe)
 
 Standard recipe stage(s):
+
 - `placement`
 
 See: [`docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`](/system/libs/mapgen/reference/STANDARD-RECIPE.md).
@@ -33,16 +36,19 @@ See: [`docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`](/system/libs/mapge
 ## Contract (requires/provides)
 
 Placement requires (dependency tags):
+
 - `effect:engine.riversModeled` (from `map-hydrology`)
 - `effect:engine.featuresApplied` (from `map-ecology`)
 - `effect:map.landmassRegionsPlotted` (from `plot-landmass-regions`)
 - `effect:placement.naturalWondersPlaced` (from `place-natural-wonders`, required by final placement)
 
 Placement provides:
+
 - `effect:placement.naturalWondersPlaced` (natural-wonder product boundary)
 - `effect:engine.placementApplied` (verified effect tag)
 
 Placement artifacts:
+
 - Provides `artifact:placementInputs` (derived from config + placement ops)
 - Provides deterministic plan artifacts: `artifact:placement.resourcePlan`, `artifact:placement.naturalWonderPlan`, `artifact:placement.discoveryPlan`
 - Provides `artifact:placement.naturalWonderPlacement` after all planned natural wonders stamp successfully
@@ -50,23 +56,27 @@ Placement artifacts:
 - Provides `artifact:placementOutputs` (verification/debug surface)
 
 Runtime semantics:
+
 - Placement apply is fail-hard.
 - Natural wonders use deterministic full-stamp-or-fail semantics in their own product/effect step.
-- Discoveries/resources run through official Civ generators; generator invocation failures and invalid placement metrics abort the placement step with explicit context.
-- Owned deterministic resource planning artifacts are retained for diagnostics/parity work but are non-primary at runtime and currently parity-incomplete for age/eligibility behavior.
+- Resources and discoveries are deterministic plan artifacts materialized through typed adapter intent APIs.
+- Resource/discovery placement publishes typed outcome artifacts; typed rejections are auditable, resource readback mismatches are fail-hard, and aggregate official-generator count equality is not a contract gate.
 - Terrain validation, area recalculation, water cache storage, landmass-region restamping, and fertility recalculation remain transactional inside final placement because no independent consumer currently exists.
 
 ## Key artifacts
 
 Placement artifacts are authored by the standard recipe:
+
 - `mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts`
 
 Placement also depends on gameplay-owned projection artifacts:
+
 - `mods/mod-swooper-maps/src/recipes/standard/map-artifacts.ts`
 
 ## Ops surface
 
 Placement domain ops used by the standard recipe:
+
 - `planWonders`
 - `planFloodplains`
 - `planNaturalWonders`
@@ -79,14 +89,16 @@ These ops produce placement plans/inputs which are then applied in the placement
 Natural-wonder placement is the first promoted product boundary: the plan
 artifact is materialized by `place-natural-wonders`, and final placement
 requires its effect/artifact before continuing. Resource and discovery
-reconciliation remains intentionally deferred to the D4 typed-outcome slice.
+reconciliation remains in final placement but publishes typed outcomes instead
+of treating official generator output as accepted truth.
 
 ## Config posture
 
 Placement stage config is currently minimal:
+
 - placement inputs are derived from runtime config and placement ops,
 - resource/discovery planning consumes adapter-owned manual catalogs (`packages/civ7-adapter/src/manual-catalogs`) that are verified against the official tables via `scripts/placement/verify-manual-catalogs.ts`, so there are no runtime GameInfo/Database lookups for these catalogs,
-- runtime apply uses official Civ generators for discovery/resources and deterministic stamping for natural wonders.
+- runtime apply uses typed adapter intent materialization for discovery/resources and deterministic stamping for natural wonders.
 
 ## Ground truth anchors
 

--- a/docs/system/mods/swooper-maps/adrs/adr-002-plot-tagging-adapter.md
+++ b/docs/system/mods/swooper-maps/adrs/adr-002-plot-tagging-adapter.md
@@ -19,7 +19,7 @@ Relying on fragile upstream utilities risks recurrent breakage as the SDK evolve
 
 1. **Maintain our own stable `addPlotTags` implementation** (`mods/mod-swooper-maps/mod/maps/core/plot_tags.js`) and stop depending on the missing Civ7 helper.
 
-2. **Continue to consume official resources where they are stable**, but prefer an adapter layer for Civ7 utilities/files so updates require changing only one surface.
+2. **Keep Civ7 resource/discovery materialization behind the adapter**, so updates require changing only one surface and map recipes reconcile typed outcomes instead of consuming aggregate generator output as truth.
 
 3. **Fully own high-churn or critical helpers** (plot tagging, deterministic RNG access) while keeping adapters thin for stable SDK surfaces.
 
@@ -28,7 +28,7 @@ Relying on fragile upstream utilities risks recurrent breakage as the SDK evolve
 ### Benefits
 
 - Map orchestrator now uses our `addPlotTags`, removing a runtime failure point when Civ7 moves/removes helpers
-- Future Civ7 resource changes are isolated behind a small adapter surface instead of spread across layers
+- Future Civ7 resource/discovery changes are isolated behind a small adapter surface instead of spread across layers
 - Improved resilience and diagnosability
 
 ### Trade-offs

--- a/docs/system/mods/swooper-maps/architecture.md
+++ b/docs/system/mods/swooper-maps/architecture.md
@@ -4,6 +4,7 @@ This page documents the Swooper Maps mod’s own architecture.
 It is **not** canonical MapGen SDK documentation.
 
 Canonical MapGen docs:
+
 - `docs/system/libs/mapgen/MAPGEN.md`
 - `docs/system/libs/mapgen/reference/REFERENCE.md`
 - `docs/system/libs/mapgen/explanation/ARCHITECTURE.md`
@@ -25,11 +26,16 @@ Current architecture for ecology, lakes, and placement is intentionally physics-
   - biome/placement land-water drift is always emitted and remains a strict-candidate gate until a post-hydrology authoritative land mask artifact is finalized.
 
 Placement runtime now uses:
-- deterministic stamping for natural wonders,
-- official Civ discovery generation (`generateOfficialDiscoveries`),
-- official Civ resource generation (`generateOfficialResources`) as the primary resource path for age-valid eligibility behavior.
 
-Owned deterministic resource planning artifacts remain in-repo for diagnostics/parity work, but are non-primary at runtime and currently parity-incomplete for age/eligibility semantics.
+- deterministic stamping for natural wonders,
+- deterministic resource/discovery plans materialized through typed adapter intent APIs,
+- typed per-placement outcome artifacts for resource/discovery reconciliation.
+
+The adapter, not a downstream mod-specific generator path, owns Civ7 feasibility
+checks and effect materialization. Resource rejections are accepted only when
+typed by the adapter; resource readback mismatches are fail-hard drift evidence.
+Discovery materialization records typed acceptance/rejection because Civ7 does
+not expose resource-like discovery readback.
 
 ## Current mod code pointers
 
@@ -46,6 +52,7 @@ Owned deterministic resource planning artifacts remain in-repo for diagnostics/p
 This section is retained as historical context and is not used by the current mod code pointers above.
 
 Example (minimal runnable pipeline):
+
 ```ts
 import standardRecipe from "./recipes/standard/recipe.js";
 import { applyMapInitData } from "./maps/_runtime/map-init.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
@@ -54,6 +54,83 @@ const NaturalWonderPlacementArtifactSchema = Type.Object(
   }
 );
 
+const ResourcePlacementOutcomeSchema = Type.Object(
+  {
+    status: Type.Union([
+      Type.Literal("placed"),
+      Type.Literal("rejected"),
+      Type.Literal("mismatch"),
+    ]),
+    plotIndex: Type.Integer(),
+    x: Type.Integer(),
+    y: Type.Integer(),
+    resourceType: Type.Integer(),
+    observedResourceType: Type.Optional(Type.Integer()),
+    reason: Type.Optional(
+      Type.Union([
+        Type.Literal("out-of-bounds"),
+        Type.Literal("invalid-resource-type"),
+        Type.Literal("cannot-have-resource"),
+        Type.Literal("wrong-resource-type"),
+      ])
+    ),
+  },
+  { additionalProperties: false }
+);
+
+const DiscoveryPlacementOutcomeSchema = Type.Object(
+  {
+    status: Type.Union([Type.Literal("placed"), Type.Literal("rejected")]),
+    plotIndex: Type.Integer(),
+    x: Type.Integer(),
+    y: Type.Integer(),
+    discoveryVisualType: Type.Integer(),
+    discoveryActivationType: Type.Integer(),
+    reason: Type.Optional(
+      Type.Union([
+        Type.Literal("out-of-bounds"),
+        Type.Literal("invalid-discovery-type"),
+        Type.Literal("adapter-rejected"),
+      ])
+    ),
+  },
+  { additionalProperties: false }
+);
+
+const PlacementOutcomeSummarySchema = Type.Object(
+  {
+    plannedCount: Type.Integer({ minimum: 0 }),
+    placedCount: Type.Integer({ minimum: 0 }),
+    rejectedCount: Type.Integer({ minimum: 0 }),
+    mismatchCount: Type.Integer({ minimum: 0 }),
+  },
+  { additionalProperties: false }
+);
+
+const ResourcePlacementOutcomesArtifactSchema = Type.Object(
+  {
+    summary: PlacementOutcomeSummarySchema,
+    outcomes: Type.Array(ResourcePlacementOutcomeSchema),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Typed resource intent reconciliation. Rejections are allowed only with named reasons; mismatches are fail-hard.",
+  }
+);
+
+const DiscoveryPlacementOutcomesArtifactSchema = Type.Object(
+  {
+    summary: PlacementOutcomeSummarySchema,
+    outcomes: Type.Array(DiscoveryPlacementOutcomeSchema),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Typed discovery intent reconciliation. Rejections are allowed only with named reasons.",
+  }
+);
+
 export const placementArtifacts = {
   placementInputs: defineArtifact({
     name: "placementInputs",
@@ -74,6 +151,16 @@ export const placementArtifacts = {
     name: "naturalWonderPlacement",
     id: "artifact:placement.naturalWonderPlacement",
     schema: NaturalWonderPlacementArtifactSchema,
+  }),
+  resourcePlacementOutcomes: defineArtifact({
+    name: "resourcePlacementOutcomes",
+    id: "artifact:placement.resourcePlacementOutcomes",
+    schema: ResourcePlacementOutcomesArtifactSchema,
+  }),
+  discoveryPlacementOutcomes: defineArtifact({
+    name: "discoveryPlacementOutcomes",
+    id: "artifact:placement.discoveryPlacementOutcomes",
+    schema: DiscoveryPlacementOutcomesArtifactSchema,
   }),
   discoveryPlan: defineArtifact({
     name: "discoveryPlan",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/apply.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/apply.ts
@@ -1,4 +1,10 @@
 import type { ExtendedMapContext, TraceScope } from "@swooper/mapgen-core";
+import type {
+  DiscoveryPlacementIntent,
+  DiscoveryPlacementOutcome,
+  ResourcePlacementIntent,
+  ResourcePlacementOutcome,
+} from "@civ7/adapter";
 import {
   HILL_TERRAIN,
   MOUNTAIN_TERRAIN,
@@ -28,6 +34,12 @@ type EngineTerrainSnapshot = Static<
 type PlacementEngineState = Static<
   (typeof import("../../artifacts.js").placementArtifacts)["engineState"]["schema"]
 >;
+type ResourcePlacementOutcomes = Static<
+  (typeof import("../../artifacts.js").placementArtifacts)["resourcePlacementOutcomes"]["schema"]
+>;
+type DiscoveryPlacementOutcomes = Static<
+  (typeof import("../../artifacts.js").placementArtifacts)["discoveryPlacementOutcomes"]["schema"]
+>;
 
 type ApplyPlacementArgs = {
   context: ExtendedMapContext;
@@ -41,6 +53,12 @@ type ApplyPlacementArgs = {
   landmassRegionSlotByTile: DeepReadonly<LandmassRegionSlotByTile>;
   publishOutputs: (outputs: PlacementOutputsV1) => DeepReadonly<PlacementOutputsV1>;
   publishEngineState?: (engineState: PlacementEngineState) => DeepReadonly<PlacementEngineState>;
+  publishResourcePlacementOutcomes?: (
+    outcomes: ResourcePlacementOutcomes
+  ) => DeepReadonly<ResourcePlacementOutcomes>;
+  publishDiscoveryPlacementOutcomes?: (
+    outcomes: DiscoveryPlacementOutcomes
+  ) => DeepReadonly<DiscoveryPlacementOutcomes>;
   publishEngineTerrainSnapshot?: (
     snapshot: EngineTerrainSnapshot
   ) => DeepReadonly<EngineTerrainSnapshot>;
@@ -93,6 +111,8 @@ export function applyPlacementPlan({
   landmassRegionSlotByTile,
   publishOutputs,
   publishEngineState = (engineState) => engineState,
+  publishResourcePlacementOutcomes = (outcomes) => outcomes,
+  publishDiscoveryPlacementOutcomes = (outcomes) => outcomes,
   publishEngineTerrainSnapshot = (snapshot) => snapshot,
 }: ApplyPlacementArgs): DeepReadonly<PlacementOutputsV1> {
   const { adapter, trace } = context;
@@ -184,28 +204,22 @@ export function applyPlacementPlan({
   });
 
   const resourcesAttempted = true;
-  // Runtime posture: resources are generated via official Civ path for age-valid
-  // eligibility behavior. Deterministic resource planning remains a non-primary
-  // artifact surface and is currently parity-incomplete by design.
-  const resourceGeneration = runPlacementStep("placement.resources", emit, () =>
-    generateResourcesWithOfficialPrimary({
+  const resourcePlacement = runPlacementStep("placement.resources", emit, () =>
+    placeResourcesWithTypedOutcomes({
       adapter,
       width,
       height,
       resources: resolvedResourcePlan,
     })
   );
-  const resourcesPlaced = resourceGeneration.placedCount;
-  emit({
-    type: "placement.resources.mode",
-    mode: resourceGeneration.mode,
-    minMarineResourceTypesOverride: resourceGeneration.minMarineResourceTypesOverride ?? null,
-  });
+  publishResourcePlacementOutcomes(resourcePlacement);
+  const resourcesPlaced = resourcePlacement.summary.placedCount;
   emit({
     type: "placement.resources.stamped",
-    mode: resourceGeneration.mode,
-    plannedCount: resourceGeneration.plannedCount,
-    placedCount: resourceGeneration.placedCount,
+    mode: "typed-intent",
+    plannedCount: resourcePlacement.summary.plannedCount,
+    placedCount: resourcePlacement.summary.placedCount,
+    rejectedCount: resourcePlacement.summary.rejectedCount,
   });
 
   const startPositions: number[] = [];
@@ -229,30 +243,23 @@ export function applyPlacementPlan({
   emitStartSectorViz(context, slotByTile as Uint8Array, starts);
   emitStartPositionsViz(context, startPositions);
 
-  const discoveryPolarMargin = resolveDiscoveryPolarMargin(context);
   const discoveryGeneration = runPlacementStep("placement.discoveries", emit, () =>
-    generateDiscoveriesWithOfficialFallback({
+    placeDiscoveriesWithTypedOutcomes({
       adapter,
       width,
       height,
       discoveries: resolvedDiscoveryPlan,
-      startPositions,
-      polarMargin: discoveryPolarMargin,
     })
   );
-  const discoveriesPlanned = discoveryGeneration.plannedCount;
-  const discoveriesPlaced = discoveryGeneration.placedCount;
-  emit({
-    type: "placement.discoveries.mode",
-    mode: discoveryGeneration.mode,
-    startPositionsCount: discoveryGeneration.startPositionsCount,
-    polarMargin: discoveryGeneration.polarMargin,
-  });
+  publishDiscoveryPlacementOutcomes(discoveryGeneration);
+  const discoveriesPlanned = discoveryGeneration.summary.plannedCount;
+  const discoveriesPlaced = discoveryGeneration.summary.placedCount;
   emit({
     type: "placement.discoveries.stamped",
-    mode: discoveryGeneration.mode,
-    plannedCount: discoveryGeneration.plannedCount,
-    placedCount: discoveryGeneration.placedCount,
+    mode: "typed-intent",
+    plannedCount: discoveryGeneration.summary.plannedCount,
+    placedCount: discoveryGeneration.summary.placedCount,
+    rejectedCount: discoveryGeneration.summary.rejectedCount,
   });
 
   runPlacementStep("placement.fertility.recalculate", emit, () => {
@@ -482,106 +489,114 @@ function normalizeNaturalWonderStampingStats(
   };
 }
 
-type GenerateDiscoveriesWithOfficialFallbackArgs = {
-  adapter: ExtendedMapContext["adapter"];
-  width: number;
-  height: number;
-  discoveries: DeepReadonly<PlanDiscoveriesOutput>;
-  startPositions: ReadonlyArray<number>;
-  polarMargin: number;
-};
-
-type OfficialDiscoveryGenerationStats = {
-  mode: "official-fallback";
-  plannedCount: number;
-  placedCount: number;
-  startPositionsCount: number;
-  polarMargin: number;
-};
-
-function resolveDiscoveryPolarMargin(context: ExtendedMapContext): number {
-  const globalPolarRows = (
-    globalThis as typeof globalThis & {
-      g_PolarWaterRows?: unknown;
-    }
-  ).g_PolarWaterRows;
-  if (Number.isFinite(globalPolarRows)) return Math.max(0, Math.trunc(globalPolarRows as number));
-  return 0;
-}
-
-function sanitizeStartPositions(values: ReadonlyArray<number>): number[] {
-  return (Array.isArray(values) ? values : [])
-    .filter((value) => Number.isFinite(value) && value >= 0)
-    .map((value) => Math.trunc(value));
-}
-
-function generateDiscoveriesWithOfficialFallback({
-  adapter,
-  width,
-  height,
-  discoveries,
-  startPositions,
-  polarMargin,
-}: GenerateDiscoveriesWithOfficialFallbackArgs): OfficialDiscoveryGenerationStats {
-  if ((discoveries.width | 0) !== (width | 0) || (discoveries.height | 0) !== (height | 0)) {
-    throw new Error(
-      `[Placement] Discovery plan dimensions ${discoveries.width}x${discoveries.height} do not match map ${width}x${height}.`
-    );
-  }
-
-  const plannedCount = Number.isFinite(discoveries.plannedCount)
-    ? Math.max(0, Math.trunc(discoveries.plannedCount))
-    : Math.max(0, discoveries.placements.length | 0);
-  const resolvedPolarMargin = Number.isFinite(polarMargin)
-    ? Math.max(0, Math.trunc(polarMargin))
-    : 0;
-  const resolvedStartPositions = sanitizeStartPositions(startPositions);
-  const placedCount = adapter.generateOfficialDiscoveries(
-    width,
-    height,
-    resolvedStartPositions,
-    resolvedPolarMargin
-  );
-  if (!Number.isFinite(placedCount) || placedCount < 0) {
-    throw new Error(
-      `[Placement] Official discovery generator returned invalid placed count (${String(placedCount)}).`
-    );
-  }
-  const resolvedPlacedCount = Math.trunc(placedCount);
-  // Official discovery generation owns final placement feasibility; planned count
-  // remains a deterministic diagnostic target rather than a fail-hard contract.
-
-  return {
-    mode: "official-fallback",
-    plannedCount,
-    placedCount: resolvedPlacedCount,
-    startPositionsCount: resolvedStartPositions.length,
-    polarMargin: resolvedPolarMargin,
-  };
-}
-
-type GenerateResourcesWithOfficialPrimaryArgs = {
+type PlaceResourcesWithTypedOutcomesArgs = {
   adapter: ExtendedMapContext["adapter"];
   width: number;
   height: number;
   resources: DeepReadonly<PlanResourcesOutput>;
-  minMarineResourceTypesOverride?: number;
 };
 
-type OfficialResourceGenerationStats = {
-  mode: "official-primary";
-  plannedCount: number;
-  placedCount: number;
-  minMarineResourceTypesOverride?: number;
-};
+const RESOURCE_REJECTION_REASONS = new Set<string>([
+  "out-of-bounds",
+  "invalid-resource-type",
+  "cannot-have-resource",
+]);
+const RESOURCE_MISMATCH_REASONS = new Set<string>(["wrong-resource-type"]);
+const DISCOVERY_REJECTION_REASONS = new Set<string>([
+  "out-of-bounds",
+  "invalid-discovery-type",
+  "adapter-rejected",
+]);
 
-function generateResourcesWithOfficialPrimary({
+function expectedTileForIntent(
+  width: number,
+  plotIndex: number
+): { plotIndex: number; x: number; y: number } {
+  const resolvedPlotIndex = Number.isFinite(plotIndex) ? Math.trunc(plotIndex) : -1;
+  const y = width > 0 ? Math.trunc(resolvedPlotIndex / width) : -1;
+  const x = width > 0 ? resolvedPlotIndex - y * width : -1;
+  return { plotIndex: resolvedPlotIndex, x, y };
+}
+
+function summarizeResourceOutcomes(
+  outcomes: readonly ResourcePlacementOutcome[]
+): ResourcePlacementOutcomes["summary"] {
+  let placedCount = 0;
+  let rejectedCount = 0;
+  let mismatchCount = 0;
+  for (const outcome of outcomes) {
+    if (outcome.status === "placed") placedCount += 1;
+    else if (outcome.status === "rejected") rejectedCount += 1;
+    else mismatchCount += 1;
+  }
+  return {
+    plannedCount: outcomes.length,
+    placedCount,
+    rejectedCount,
+    mismatchCount,
+  };
+}
+
+function assertResourceOutcomeMatchesIntent(
+  outcome: ResourcePlacementOutcome,
+  intent: ResourcePlacementIntent,
+  width: number
+): void {
+  const expected = expectedTileForIntent(width, intent.plotIndex);
+  const expectedResourceType = Number.isFinite(intent.resourceType)
+    ? Math.trunc(intent.resourceType)
+    : -1;
+  const status = (outcome as { status?: unknown }).status;
+
+  if (status !== "placed" && status !== "rejected" && status !== "mismatch") {
+    throw new Error(
+      `[Placement] Resource placement returned untyped outcome status (${String(status)}).`
+    );
+  }
+  if (
+    outcome.plotIndex !== expected.plotIndex ||
+    outcome.x !== expected.x ||
+    outcome.y !== expected.y ||
+    outcome.resourceType !== expectedResourceType
+  ) {
+    throw new Error(
+      `[Placement] Resource placement outcome location/type drifted from intent (intent=${expected.plotIndex}:${expectedResourceType}, outcome=${outcome.plotIndex}:${outcome.resourceType}).`
+    );
+  }
+  if (outcome.status === "rejected" && !RESOURCE_REJECTION_REASONS.has(outcome.reason)) {
+    throw new Error(
+      `[Placement] Resource placement returned an untyped rejection reason (${String(outcome.reason)}).`
+    );
+  }
+  if (outcome.status === "mismatch" && !RESOURCE_MISMATCH_REASONS.has(outcome.reason)) {
+    throw new Error(
+      `[Placement] Resource placement returned an untyped mismatch reason (${String(outcome.reason)}).`
+    );
+  }
+  if (
+    outcome.status === "placed" &&
+    (outcome.observedResourceType | 0) !== (expectedResourceType | 0)
+  ) {
+    throw new Error(
+      `[Placement] Resource placement reported placed but readback differed (${expectedResourceType}->${outcome.observedResourceType}).`
+    );
+  }
+}
+
+/**
+ * Materializes deterministic resource intent through the adapter and records
+ * typed per-tile outcomes. Typed engine rejection is acceptable; wrong-type
+ * readback is not, because that means projection no longer matches intent. The
+ * runtime checks here intentionally guard the whole outcome category: every
+ * returned outcome must match the planned location/type and carry a known
+ * rejection/mismatch reason when it is not placed.
+ */
+function placeResourcesWithTypedOutcomes({
   adapter,
   width,
   height,
   resources,
-  minMarineResourceTypesOverride,
-}: GenerateResourcesWithOfficialPrimaryArgs): OfficialResourceGenerationStats {
+}: PlaceResourcesWithTypedOutcomesArgs): ResourcePlacementOutcomes {
   if ((resources.width | 0) !== (width | 0) || (resources.height | 0) !== (height | 0)) {
     throw new Error(
       `[Placement] Resource plan dimensions ${resources.width}x${resources.height} do not match map ${width}x${height}.`
@@ -616,25 +631,146 @@ function generateResourcesWithOfficialPrimary({
     );
   }
 
-  const resolvedMinMarineResourceTypesOverride = Number.isFinite(minMarineResourceTypesOverride)
-    ? Math.max(0, Math.trunc(minMarineResourceTypesOverride as number))
-    : undefined;
-  const placedCount = adapter.generateOfficialResources(
-    width,
-    height,
-    resolvedMinMarineResourceTypesOverride
-  );
-  if (!Number.isFinite(placedCount) || placedCount < 0) {
+  const outcomes: ResourcePlacementOutcome[] = [];
+  for (const placement of resources.placements) {
+    const intent = {
+      plotIndex: placement.plotIndex,
+      resourceType: placement.preferredResourceType,
+    };
+    const outcome = adapter.placeResourceIntent(width, height, intent);
+    assertResourceOutcomeMatchesIntent(outcome, intent, width);
+    outcomes.push(outcome);
+  }
+
+  const mismatches = outcomes.filter((outcome) => outcome.status === "mismatch");
+  if (mismatches.length > 0) {
+    const sample = mismatches
+      .slice(0, 3)
+      .map(
+        (outcome) =>
+          `${outcome.plotIndex}:${outcome.resourceType}->${outcome.observedResourceType} (${outcome.reason})`
+      )
+      .join(", ");
     throw new Error(
-      `[Placement] Official resource generator returned invalid placed count (placedCount=${String(placedCount)}, planned=${plannedCount}, target=${targetCount}, minMarineResourceTypesOverride=${String(resolvedMinMarineResourceTypesOverride)}).`
+      `[Placement] Resource placement produced wrong-type readback for ${mismatches.length}/${outcomes.length} planned intents; sample: ${sample}.`
     );
   }
 
   return {
-    mode: "official-primary",
-    plannedCount,
-    placedCount: Math.trunc(placedCount),
-    minMarineResourceTypesOverride: resolvedMinMarineResourceTypesOverride,
+    summary: summarizeResourceOutcomes(outcomes),
+    outcomes,
+  };
+}
+
+type PlaceDiscoveriesWithTypedOutcomesArgs = {
+  adapter: ExtendedMapContext["adapter"];
+  width: number;
+  height: number;
+  discoveries: DeepReadonly<PlanDiscoveriesOutput>;
+};
+
+function summarizeDiscoveryOutcomes(
+  outcomes: readonly DiscoveryPlacementOutcome[]
+): DiscoveryPlacementOutcomes["summary"] {
+  let placedCount = 0;
+  let rejectedCount = 0;
+  for (const outcome of outcomes) {
+    if (outcome.status === "placed") placedCount += 1;
+    else rejectedCount += 1;
+  }
+  return {
+    plannedCount: outcomes.length,
+    placedCount,
+    rejectedCount,
+    mismatchCount: 0,
+  };
+}
+
+function assertDiscoveryOutcomeMatchesIntent(
+  outcome: DiscoveryPlacementOutcome,
+  intent: DiscoveryPlacementIntent,
+  width: number
+): void {
+  const expected = expectedTileForIntent(width, intent.plotIndex);
+  const expectedVisualType = Number.isFinite(intent.discoveryVisualType)
+    ? Math.trunc(intent.discoveryVisualType)
+    : -1;
+  const expectedActivationType = Number.isFinite(intent.discoveryActivationType)
+    ? Math.trunc(intent.discoveryActivationType)
+    : -1;
+  const status = (outcome as { status?: unknown }).status;
+
+  if (status !== "placed" && status !== "rejected") {
+    throw new Error(
+      `[Placement] Discovery placement returned untyped outcome status (${String(status)}).`
+    );
+  }
+  if (
+    outcome.plotIndex !== expected.plotIndex ||
+    outcome.x !== expected.x ||
+    outcome.y !== expected.y ||
+    outcome.discoveryVisualType !== expectedVisualType ||
+    outcome.discoveryActivationType !== expectedActivationType
+  ) {
+    throw new Error(
+      `[Placement] Discovery placement outcome location/type drifted from intent (intent=${expected.plotIndex}:${expectedVisualType}/${expectedActivationType}, outcome=${outcome.plotIndex}:${outcome.discoveryVisualType}/${outcome.discoveryActivationType}).`
+    );
+  }
+  if (outcome.status === "rejected" && !DISCOVERY_REJECTION_REASONS.has(outcome.reason)) {
+    throw new Error(
+      `[Placement] Discovery placement returned an untyped rejection reason (${String(outcome.reason)}).`
+    );
+  }
+}
+
+/**
+ * Materializes deterministic discovery intent through the adapter and records
+ * typed per-tile outcomes. The adapter cannot expose a richer Civ7 readback for
+ * discoveries yet, so the only accepted non-placement state is a named adapter
+ * rejection reason. As with resources, the recipe validates the whole outcome
+ * category rather than trusting any adapter object that happens to be returned.
+ */
+function placeDiscoveriesWithTypedOutcomes({
+  adapter,
+  width,
+  height,
+  discoveries,
+}: PlaceDiscoveriesWithTypedOutcomesArgs): DiscoveryPlacementOutcomes {
+  if ((discoveries.width | 0) !== (width | 0) || (discoveries.height | 0) !== (height | 0)) {
+    throw new Error(
+      `[Placement] Discovery plan dimensions ${discoveries.width}x${discoveries.height} do not match map ${width}x${height}.`
+    );
+  }
+
+  const plannedCount = discoveries.placements.length;
+  const declaredPlannedCount = Math.max(0, discoveries.plannedCount | 0);
+  const targetCount = Math.max(0, discoveries.targetCount | 0);
+  if (declaredPlannedCount !== plannedCount) {
+    throw new Error(
+      `[Placement] Discovery plan metadata mismatch (plannedCount=${declaredPlannedCount}, placements=${plannedCount}).`
+    );
+  }
+  if (plannedCount < targetCount) {
+    throw new Error(
+      `[Placement] Discovery plan cannot satisfy target count (target=${targetCount}, planned=${plannedCount}).`
+    );
+  }
+
+  const outcomes: DiscoveryPlacementOutcome[] = [];
+  for (const placement of discoveries.placements) {
+    const intent = {
+      plotIndex: placement.plotIndex,
+      discoveryVisualType: placement.preferredDiscoveryVisualType,
+      discoveryActivationType: placement.preferredDiscoveryActivationType,
+    };
+    const outcome = adapter.placeDiscoveryIntent(width, height, intent);
+    assertDiscoveryOutcomeMatchesIntent(outcome, intent, width);
+    outcomes.push(outcome);
+  }
+
+  return {
+    summary: summarizeDiscoveryOutcomes(outcomes),
+    outcomes,
   };
 }
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/contract.ts
@@ -31,6 +31,8 @@ const PlacementStepContract = defineStep({
     provides: [
       placementArtifacts.placementOutputs,
       placementArtifacts.engineState,
+      placementArtifacts.resourcePlacementOutcomes,
+      placementArtifacts.discoveryPlacementOutcomes,
       mapArtifacts.placementEngineTerrainSnapshot,
     ],
   },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/index.ts
@@ -10,11 +10,15 @@ export default createStep(PlacementStepContract, {
     [
       placementArtifacts.placementOutputs,
       placementArtifacts.engineState,
+      placementArtifacts.resourcePlacementOutcomes,
+      placementArtifacts.discoveryPlacementOutcomes,
       mapArtifacts.placementEngineTerrainSnapshot,
     ],
     {
       placementOutputs: {},
       engineState: {},
+      resourcePlacementOutcomes: {},
+      discoveryPlacementOutcomes: {},
       placementEngineTerrainSnapshot: {},
     }
   ),
@@ -39,6 +43,10 @@ export default createStep(PlacementStepContract, {
       landmassRegionSlotByTile,
       publishOutputs: (outputs) => deps.artifacts.placementOutputs.publish(context, outputs),
       publishEngineState: (engineState) => deps.artifacts.engineState.publish(context, engineState),
+      publishResourcePlacementOutcomes: (outcomes) =>
+        deps.artifacts.resourcePlacementOutcomes.publish(context, outcomes),
+      publishDiscoveryPlacementOutcomes: (outcomes) =>
+        deps.artifacts.discoveryPlacementOutcomes.publish(context, outcomes),
       publishEngineTerrainSnapshot: (snapshot) =>
         deps.artifacts.placementEngineTerrainSnapshot.publish(context, snapshot),
     });

--- a/mods/mod-swooper-maps/test/map-hydrology/lakes-area-recalc-resources.test.ts
+++ b/mods/mod-swooper-maps/test/map-hydrology/lakes-area-recalc-resources.test.ts
@@ -4,23 +4,22 @@ import { MockAdapter, type LakeProjectionResult } from "@civ7/adapter";
 import { FLAT_TERRAIN, createExtendedMapContext } from "@swooper/mapgen-core";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 
-import placement from "../../src/domain/placement/ops.js";
-import { getStandardRuntime } from "../../src/recipes/standard/runtime.js";
-import lakes from "../../src/recipes/standard/stages/map-hydrology/steps/lakes.js";
-import plotRivers from "../../src/recipes/standard/stages/map-hydrology/steps/plotRivers.js";
-import { applyPlacementPlan } from "../../src/recipes/standard/stages/placement/steps/placement/apply.js";
-import { buildTestDeps } from "../support/step-deps.js";
+import standardRecipe from "../../src/recipes/standard/recipe.js";
+import { initializeStandardRuntime } from "../../src/recipes/standard/runtime.js";
+import { placementArtifacts } from "../../src/recipes/standard/stages/placement/artifacts.js";
+import { standardConfig } from "../support/standard-config.js";
 
 /**
  * Area-sensitive adapter double.
  *
- * Lake stamping must refresh engine area and water caches before later map
- * stages and placement ask Civ7 resource logic about marine placement. This
- * double dries the stamped tile during validation if the adapter forgot the
- * area refresh.
+ * Civ7 resource feasibility depends on refreshed area/water caches after lake
+ * and river terrain edits. This double makes that ordering observable through
+ * the public recipe run instead of seeding step artifacts or invoking placement
+ * internals directly.
  */
 class AreaSensitiveLakeAdapter extends MockAdapter {
   private cachedWater: Uint8Array;
+  private cacheBackedWaterReads = false;
   private lakeNeedsAreaRefresh = false;
   readonly callOrder: string[] = [];
 
@@ -38,19 +37,22 @@ class AreaSensitiveLakeAdapter extends MockAdapter {
     const ocean = this.getTerrainTypeIndex("TERRAIN_OCEAN");
     for (let y = 0; y < this.height; y++) {
       for (let x = 0; x < this.width; x++) {
-        const t = this.getTerrainType(x, y) | 0;
-        this.cachedWater[this.idx2(x, y)] = t === coast || t === ocean ? 1 : 0;
+        const terrain = this.getTerrainType(x, y) | 0;
+        this.cachedWater[this.idx2(x, y)] = terrain === coast || terrain === ocean ? 1 : 0;
       }
     }
   }
 
   override isWater(x: number, y: number): boolean {
-    // Simulate engine cache-backed water reads.
+    // Simulate engine cache-backed water reads; cache freshness is the contract
+    // this regression protects.
+    if (!this.cacheBackedWaterReads) return super.isWater(x, y);
     return this.cachedWater[this.idx2(x, y)] === 1;
   }
 
   override stampLakes(width: number, height: number, lakeMask: Uint8Array): LakeProjectionResult {
     this.callOrder.push("stampLakes");
+    this.cacheBackedWaterReads = true;
     this.lakeNeedsAreaRefresh = true;
     return super.stampLakes(width, height, lakeMask);
   }
@@ -62,7 +64,8 @@ class AreaSensitiveLakeAdapter extends MockAdapter {
 
   override validateAndFixTerrain(): void {
     this.callOrder.push("validateAndFixTerrain");
-    // Simulate the engine normalizing stale post-lake terrain if areas were not rebuilt.
+    // If lake stamping did not refresh areas before later validation, model the
+    // kind of stale-cache normalization that previously dried projected lakes.
     if (this.lakeNeedsAreaRefresh) {
       this.setTerrainType(1, 1, FLAT_TERRAIN);
     }
@@ -81,15 +84,20 @@ class AreaSensitiveLakeAdapter extends MockAdapter {
     this.callOrder.push("defineNamedRivers");
   }
 
-  override canHaveResource(x: number, y: number, resourceType: number): boolean {
-    return this.isWater(x, y) && super.canHaveResource(x, y, resourceType);
+  override placeResourceIntent(
+    width: number,
+    height: number,
+    intent: Parameters<MockAdapter["placeResourceIntent"]>[2]
+  ): ReturnType<MockAdapter["placeResourceIntent"]> {
+    this.callOrder.push("placeResourceIntent");
+    return super.placeResourceIntent(width, height, intent);
   }
 }
 
 describe("map-hydrology lakes area/water ordering", () => {
-  it("keeps lake tiles water-filled across rivers + placement and uses official resource generation", () => {
-    const width = 4;
-    const height = 4;
+  it("refreshes water caches before recipe-level typed resource materialization", () => {
+    const width = 20;
+    const height = 12;
     const seed = 1234;
     const mapInfo = {
       GridWidth: width,
@@ -116,115 +124,33 @@ describe("map-hydrology lakes area/water ordering", () => {
       mapSizeId: 1,
       rng: createLabelRng(seed),
       defaultTerrainType: FLAT_TERRAIN,
-      officialResourcesPlacedCount: 1,
     });
     const context = createExtendedMapContext({ width, height }, adapter, env);
 
-    const size = width * height;
-    context.artifacts.set("artifact:morphology.topography", {
-      elevation: new Int16Array(size),
-      seaLevel: 0,
-      landMask: new Uint8Array(size).fill(1),
-      bathymetry: new Int16Array(size),
+    initializeStandardRuntime(context, {
+      mapInfo,
+      logPrefix: "[test]",
+      storyEnabled: true,
     });
-    context.artifacts.set("artifact:hydrology.hydrography", {
-      runoff: new Float32Array(size),
-      discharge: new Float32Array(size),
-      riverClass: new Uint8Array(size),
-      flowDir: new Int32Array(size).fill(-1),
-      sinkMask: new Uint8Array(size),
-      outletMask: new Uint8Array(size),
-    });
-    const lakeMask = new Uint8Array(size);
-    lakeMask[1 + width] = 1;
-    context.artifacts.set("artifact:hydrology.lakePlan", {
-      width,
-      height,
-      lakeMask,
-      plannedLakeTileCount: 1,
-      sinkLakeCount: 1,
-    });
+    standardRecipe.run(context, env, standardConfig, { log: () => {} });
 
-    lakes.run(context as any, { projectionReadback: true }, {} as any, buildTestDeps(lakes));
-    plotRivers.run(
-      context as any,
-      { minLength: 5, maxLength: 15 },
-      {} as any,
-      buildTestDeps(plotRivers)
+    const firstLakeStamp = adapter.callOrder.indexOf("stampLakes");
+    const firstAreaRefreshAfterLakes = adapter.callOrder.findIndex(
+      (call, index) => index > firstLakeStamp && call === "recalculateAreas"
     );
-
-    expect(adapter.callOrder.slice(0, 3)).toEqual([
-      "stampLakes",
-      "recalculateAreas",
-      "storeWaterData",
-    ]);
-    expect(adapter.isWater(1, 1)).toBe(true);
-
-    const runtime = getStandardRuntime(context);
-    const starts = placement.ops.planStarts.run(
-      {
-        baseStarts: {
-          playersLandmass1: runtime.playersLandmass1,
-          playersLandmass2: runtime.playersLandmass2,
-          startSectorRows: runtime.startSectorRows,
-          startSectorCols: runtime.startSectorCols,
-          startSectors: runtime.startSectors,
-        },
-      },
-      placement.ops.planStarts.defaultConfig
+    const firstWaterRefreshAfterLakes = adapter.callOrder.findIndex(
+      (call, index) => index > firstAreaRefreshAfterLakes && call === "storeWaterData"
     );
-    const wonders = placement.ops.planWonders.run(
-      { mapInfo: runtime.mapInfo },
-      placement.ops.planWonders.defaultConfig
-    );
-    const floodplains = placement.ops.planFloodplains.run({}, placement.ops.planFloodplains.defaultConfig);
-    const resources = {
-      width,
-      height,
-      candidateResourceTypes: [3],
-      targetCount: 1,
-      plannedCount: 1,
-      placements: [
-        {
-          plotIndex: 1 + width,
-          preferredResourceType: 3,
-          preferredTypeOffset: 0,
-          priority: 1,
-        },
-      ],
-    };
+    const firstResourceIntent = adapter.callOrder.indexOf("placeResourceIntent");
+    const resourceOutcomes = context.artifacts.get(
+      placementArtifacts.resourcePlacementOutcomes.id
+    ) as { summary?: { plannedCount?: number } } | undefined;
 
-    const outputs = applyPlacementPlan({
-      context,
-      starts,
-      wonders,
-      naturalWonderPlan: {
-        width,
-        height,
-        wondersCount: 0,
-        targetCount: 0,
-        plannedCount: 0,
-        placements: [],
-      },
-      discoveryPlan: {
-        width,
-        height,
-        candidateDiscoveries: [],
-        targetCount: 0,
-        plannedCount: 0,
-        placements: [],
-      },
-      floodplains,
-      resources,
-      landmassRegionSlotByTile: { slotByTile: new Uint8Array(size).fill(1) },
-      publishOutputs: (outputs) => outputs,
-    });
-
-    expect(adapter.calls.generateOfficialResources).toEqual([
-      { width, height, minMarineResourceTypesOverride: undefined },
-    ]);
-    expect(adapter.calls.setResourceType.length).toBe(0);
-    expect(outputs.resourcesCount).toBe(1);
-    expect(adapter.isWater(1, 1)).toBe(true);
+    expect(firstLakeStamp).toBeGreaterThanOrEqual(0);
+    expect(firstAreaRefreshAfterLakes).toBeGreaterThan(firstLakeStamp);
+    expect(firstWaterRefreshAfterLakes).toBeGreaterThan(firstAreaRefreshAfterLakes);
+    expect(firstResourceIntent).toBeGreaterThan(firstWaterRefreshAfterLakes);
+    expect(resourceOutcomes?.summary?.plannedCount ?? 0).toBeGreaterThan(0);
+    expect(adapter.calls.generateOfficialResources.length).toBe(0);
   });
 });

--- a/mods/mod-swooper-maps/test/placement/landmass-region-id-projection.test.ts
+++ b/mods/mod-swooper-maps/test/placement/landmass-region-id-projection.test.ts
@@ -9,7 +9,7 @@ import { initializeStandardRuntime } from "../../src/recipes/standard/runtime.js
 import { realismEarthlikeConfig } from "../../src/maps/presets/realism/earthlike.config.js";
 
 describe("placement landmass region projection", () => {
-  it("projects LandmassRegionId before official resource generation and starts using adapter constants", () => {
+  it("projects LandmassRegionId before typed resource materialization and starts using adapter constants", () => {
     const width = 20;
     const height = 12;
     const seed = 1337;
@@ -33,7 +33,13 @@ describe("placement landmass region projection", () => {
       },
     };
 
-    const adapter = createMockAdapter({ width, height, mapInfo, mapSizeId: 1, rng: createLabelRng(seed) });
+    const adapter = createMockAdapter({
+      width,
+      height,
+      mapInfo,
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
+    });
     const callOrder: string[] = [];
     const regionIds: number[] = [];
 
@@ -43,14 +49,10 @@ describe("placement landmass region projection", () => {
       regionIds.push(regionId);
       originalSetLandmassRegionId(x, y, regionId);
     };
-    const originalGenerateOfficialResources = adapter.generateOfficialResources.bind(adapter);
-    adapter.generateOfficialResources = (mapWidth, mapHeight, minMarineResourceTypesOverride) => {
-      callOrder.push("generateOfficialResources");
-      return originalGenerateOfficialResources(
-        mapWidth,
-        mapHeight,
-        minMarineResourceTypesOverride
-      );
+    const originalPlaceResourceIntent = adapter.placeResourceIntent.bind(adapter);
+    adapter.placeResourceIntent = (mapWidth, mapHeight, intent) => {
+      callOrder.push("placeResourceIntent");
+      return originalPlaceResourceIntent(mapWidth, mapHeight, intent);
     };
     const originalSetStartPosition = adapter.setStartPosition.bind(adapter);
     adapter.setStartPosition = (plotIndex, playerId) => {
@@ -63,14 +65,15 @@ describe("placement landmass region projection", () => {
     standardRecipe.run(context, env, realismEarthlikeConfig, { log: () => {} });
 
     const firstProjection = callOrder.indexOf("setLandmassRegionId");
-    const firstResourceGeneration = callOrder.indexOf("generateOfficialResources");
+    const firstResourceIntent = callOrder.indexOf("placeResourceIntent");
     const firstStart = callOrder.indexOf("setStartPosition");
 
     expect(firstProjection).toBeGreaterThanOrEqual(0);
-    expect(firstResourceGeneration).toBeGreaterThan(firstProjection);
+    expect(firstResourceIntent).toBeGreaterThan(firstProjection);
     expect(firstStart).toBeGreaterThan(firstProjection);
-    expect(firstStart).toBeGreaterThan(firstResourceGeneration);
-    expect(adapter.calls.generateOfficialResources.length).toBeGreaterThan(0);
+    expect(firstStart).toBeGreaterThan(firstResourceIntent);
+    expect(adapter.calls.generateOfficialResources.length).toBe(0);
+    expect(adapter.calls.setResourceType.length).toBeGreaterThan(0);
 
     const allowed = new Set([
       adapter.getLandmassId("WEST"),

--- a/mods/mod-swooper-maps/test/placement/placement-does-not-call-generate-snow.test.ts
+++ b/mods/mod-swooper-maps/test/placement/placement-does-not-call-generate-snow.test.ts
@@ -1,495 +1,295 @@
-import { describe, it, expect, vi } from "vitest";
-import { createMockAdapter } from "@civ7/adapter";
+import { describe, expect, it } from "bun:test";
+
+import {
+  MockAdapter,
+  createMockAdapter,
+  type DiscoveryPlacementIntent,
+  type DiscoveryPlacementOutcome,
+  type MapInfo,
+  type ResourcePlacementIntent,
+  type ResourcePlacementOutcome,
+} from "@civ7/adapter";
 import { createExtendedMapContext } from "@swooper/mapgen-core";
-import { implementArtifacts } from "@swooper/mapgen-core/authoring";
-import placement from "../../src/domain/placement/ops.js";
-import { getStandardRuntime } from "../../src/recipes/standard/runtime.js";
+import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
+
+import standardRecipe, { type StandardRecipeConfig } from "../../src/recipes/standard/recipe.js";
+import { initializeStandardRuntime } from "../../src/recipes/standard/runtime.js";
 import { placementArtifacts } from "../../src/recipes/standard/stages/placement/artifacts.js";
-import { applyPlacementPlan } from "../../src/recipes/standard/stages/placement/steps/placement/apply.js";
+import { standardConfig } from "../support/standard-config.js";
 
-describe("placement", () => {
-  it("does not call adapter.generateSnow", () => {
-    const adapter = createMockAdapter({
-      width: 4,
-      height: 4,
-      mapInfo: {
-        GridWidth: 4,
-        GridHeight: 4,
-        PlayersLandmass1: 1,
-        PlayersLandmass2: 1,
-        StartSectorRows: 1,
-        StartSectorCols: 1,
-        NumNaturalWonders: 1,
-      },
-      officialDiscoveriesPlacedCount: 1,
+type PlacementRecipeHarnessOptions = {
+  adapter?: MockAdapter;
+  config?: StandardRecipeConfig;
+  mapInfo?: MapInfo;
+  seed?: number;
+  width?: number;
+  height?: number;
+};
+
+/**
+ * Runs D4 placement reconciliation through the standard recipe instead of
+ * calling placement internals directly. The contract under review is the
+ * recipe-published intent/outcome artifact plus adapter materialization effect,
+ * so the guard must observe the same boundary that shipped maps exercise.
+ */
+function runStandardPlacementRecipe({
+  adapter,
+  config = standardConfig,
+  mapInfo,
+  seed = 1337,
+  width = 20,
+  height = 12,
+}: PlacementRecipeHarnessOptions = {}) {
+  const resolvedMapInfo = {
+    GridWidth: width,
+    GridHeight: height,
+    MinLatitude: -60,
+    MaxLatitude: 60,
+    PlayersLandmass1: 1,
+    PlayersLandmass2: 1,
+    StartSectorRows: 1,
+    StartSectorCols: 1,
+    NumNaturalWonders: 0,
+    ...mapInfo,
+  };
+  const env = {
+    seed,
+    dimensions: { width, height },
+    latitudeBounds: {
+      topLatitude: resolvedMapInfo.MaxLatitude ?? 60,
+      bottomLatitude: resolvedMapInfo.MinLatitude ?? -60,
+    },
+  };
+  const resolvedAdapter =
+    adapter ??
+    createMockAdapter({
+      width,
+      height,
+      mapInfo: resolvedMapInfo,
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
     });
-    const context = createExtendedMapContext({ width: 4, height: 4 }, adapter, { seed: 0 });
-    const runtime = getStandardRuntime(context);
-    const baseStarts = {
-      playersLandmass1: runtime.playersLandmass1,
-      playersLandmass2: runtime.playersLandmass2,
-      startSectorRows: runtime.startSectorRows,
-      startSectorCols: runtime.startSectorCols,
-      startSectors: runtime.startSectors,
+  const context = createExtendedMapContext({ width, height }, resolvedAdapter, env);
+
+  initializeStandardRuntime(context, {
+    mapInfo: resolvedMapInfo,
+    logPrefix: "[test]",
+    storyEnabled: true,
+  });
+  standardRecipe.run(context, env, config, { log: () => {} });
+
+  return { adapter: resolvedAdapter, context };
+}
+
+function readResourceOutcomes(context: ReturnType<typeof runStandardPlacementRecipe>["context"]) {
+  return context.artifacts.get(placementArtifacts.resourcePlacementOutcomes.id) as
+    | {
+        summary: {
+          plannedCount: number;
+          placedCount: number;
+          rejectedCount: number;
+          mismatchCount: number;
+        };
+      }
+    | undefined;
+}
+
+function readDiscoveryOutcomes(context: ReturnType<typeof runStandardPlacementRecipe>["context"]) {
+  return context.artifacts.get(placementArtifacts.discoveryPlacementOutcomes.id) as
+    | {
+        summary: {
+          plannedCount: number;
+          placedCount: number;
+          rejectedCount: number;
+          mismatchCount: number;
+        };
+      }
+    | undefined;
+}
+
+class RejectingDiscoveryAdapter extends MockAdapter {
+  override stampDiscovery(
+    x: number,
+    y: number,
+    discoveryVisualType: number,
+    discoveryActivationType: number
+  ): boolean {
+    this.calls.stampDiscovery.push({ x, y, discoveryVisualType, discoveryActivationType });
+    return false;
+  }
+}
+
+class MismatchingResourceAdapter extends MockAdapter {
+  override placeResourceIntent(
+    width: number,
+    height: number,
+    intent: ResourcePlacementIntent
+  ): ResourcePlacementOutcome {
+    const outcome = super.placeResourceIntent(width, height, intent);
+    if (outcome.status !== "placed") return outcome;
+    return {
+      ...outcome,
+      status: "mismatch",
+      reason: "wrong-resource-type",
+      observedResourceType: outcome.resourceType + 1,
     };
+  }
+}
 
-    const starts = placement.ops.planStarts.run(
-      { baseStarts },
-      placement.ops.planStarts.defaultConfig
-    );
-    const wonders = placement.ops.planWonders.run(
-      { mapInfo: runtime.mapInfo },
-      placement.ops.planWonders.defaultConfig
-    );
-    const floodplains = placement.ops.planFloodplains.run(
-      {},
-      placement.ops.planFloodplains.defaultConfig
-    );
-    const resources = {
-      width: 4,
-      height: 4,
-      candidateResourceTypes: [1],
-      targetCount: 1,
-      plannedCount: 1,
-      placements: [
-        {
-          plotIndex: 0,
-          preferredResourceType: 1,
-          preferredTypeOffset: 0,
-          priority: 1,
-        },
-      ],
+class UntypedResourceRejectionAdapter extends MockAdapter {
+  override placeResourceIntent(
+    width: number,
+    height: number,
+    intent: ResourcePlacementIntent
+  ): ResourcePlacementOutcome {
+    const outcome = super.placeResourceIntent(width, height, intent);
+    if (outcome.status !== "placed") return outcome;
+    return {
+      status: "rejected",
+      plotIndex: outcome.plotIndex,
+      x: outcome.x,
+      y: outcome.y,
+      resourceType: outcome.resourceType,
+      observedResourceType: outcome.observedResourceType,
+    } as ResourcePlacementOutcome;
+  }
+}
+
+class MislocatedDiscoveryAdapter extends MockAdapter {
+  override placeDiscoveryIntent(
+    width: number,
+    height: number,
+    intent: DiscoveryPlacementIntent
+  ): DiscoveryPlacementOutcome {
+    const outcome = super.placeDiscoveryIntent(width, height, intent);
+    if (outcome.status !== "placed") return outcome;
+    return {
+      ...outcome,
+      plotIndex: outcome.plotIndex + 1,
+      x: outcome.x + 1,
     };
+  }
+}
 
-    const placementRuntime = implementArtifacts([placementArtifacts.placementOutputs], {
-      placementOutputs: {},
-    });
-    const outputs = applyPlacementPlan({
-      context,
-      starts,
-      wonders,
-      naturalWonderPlan: {
-        width: 4,
-        height: 4,
-        wondersCount: 1,
-        targetCount: 1,
-        plannedCount: 1,
-        placements: [{ plotIndex: 1, featureType: 39, direction: 0, elevation: 100, priority: 1 }],
-      },
-      discoveryPlan: {
-        width: 4,
-        height: 4,
-        candidateDiscoveries: [{ discoveryVisualType: 0, discoveryActivationType: 0 }],
-        targetCount: 1,
-        plannedCount: 1,
-        placements: [
-          {
-            plotIndex: 2,
-            preferredDiscoveryVisualType: 0,
-            preferredDiscoveryActivationType: 0,
-            preferredDiscoveryOffset: 0,
-            priority: 1,
-          },
-        ],
-      },
-      floodplains,
-      resources,
-      landmassRegionSlotByTile: {
-        slotByTile: new Uint8Array(16).fill(1),
-      },
-      publishOutputs: (outputs) => placementRuntime.placementOutputs.publish(context, outputs),
-    });
+describe("placement reconciliation", () => {
+  it("materializes resources and discoveries through typed adapter intents", () => {
+    const { adapter, context } = runStandardPlacementRecipe();
+
+    const resourceOutcomes = readResourceOutcomes(context);
+    const discoveryOutcomes = readDiscoveryOutcomes(context);
 
     expect(adapter.calls.generateSnow.length).toBe(0);
-    expect(adapter.calls.stampNaturalWonder.length).toBe(1);
-    expect(adapter.calls.stampDiscovery.length).toBe(0);
-    expect(adapter.calls.generateOfficialResources.length).toBe(1);
-    expect(adapter.calls.generateOfficialResources[0]).toMatchObject({
-      width: 4,
-      height: 4,
+    expect(adapter.calls.generateOfficialResources.length).toBe(0);
+    expect(adapter.calls.generateOfficialDiscoveries.length).toBe(0);
+    expect(resourceOutcomes?.summary.plannedCount).toBeGreaterThan(0);
+    expect(discoveryOutcomes?.summary.plannedCount).toBeGreaterThan(0);
+    expect(adapter.calls.setResourceType.length).toBe(resourceOutcomes?.summary.placedCount);
+    expect(adapter.calls.stampDiscovery.length).toBe(discoveryOutcomes?.summary.placedCount);
+  });
+
+  it("records typed resource rejections without falling back to official generation", () => {
+    const width = 20;
+    const height = 12;
+    const seed = 1441;
+    const adapter = createMockAdapter({
+      width,
+      height,
+      mapInfo: { GridWidth: width, GridHeight: height },
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
+      canHaveResource: () => false,
     });
+
+    const { context } = runStandardPlacementRecipe({ adapter, seed, width, height });
+    const resourceOutcomes = readResourceOutcomes(context);
+
+    expect(adapter.calls.generateOfficialResources.length).toBe(0);
     expect(adapter.calls.setResourceType.length).toBe(0);
-    expect(adapter.calls.generateOfficialDiscoveries.length).toBe(1);
-    expect(adapter.calls.generateOfficialDiscoveries[0]).toMatchObject({
-      width: 4,
-      height: 4,
-      polarMargin: 0,
-    });
-    expect(outputs.naturalWondersCount).toBe(1);
-    expect(outputs.discoveriesCount).toBe(1);
+    expect(resourceOutcomes?.summary.plannedCount).toBeGreaterThan(0);
+    expect(resourceOutcomes?.summary.placedCount).toBe(0);
+    expect(resourceOutcomes?.summary.rejectedCount).toBe(resourceOutcomes?.summary.plannedCount);
+    expect(resourceOutcomes?.summary.mismatchCount).toBe(0);
   });
 
-  it("uses official discovery generation without relying on runtime discovery candidate lookups", () => {
-    const adapter = createMockAdapter({
-      width: 4,
-      height: 4,
-      mapInfo: {
-        GridWidth: 4,
-        GridHeight: 4,
-        PlayersLandmass1: 1,
-        PlayersLandmass2: 1,
-        StartSectorRows: 1,
-        StartSectorCols: 1,
-        NumNaturalWonders: 0,
-      },
-      officialDiscoveriesPlacedCount: 1,
-    });
-    const context = createExtendedMapContext({ width: 4, height: 4 }, adapter, { seed: 0 });
-    const runtime = getStandardRuntime(context);
-    const baseStarts = {
-      playersLandmass1: runtime.playersLandmass1,
-      playersLandmass2: runtime.playersLandmass2,
-      startSectorRows: runtime.startSectorRows,
-      startSectorCols: runtime.startSectorCols,
-      startSectors: runtime.startSectors,
-    };
-
-    const starts = placement.ops.planStarts.run(
-      { baseStarts },
-      placement.ops.planStarts.defaultConfig
-    );
-    const wonders = placement.ops.planWonders.run(
-      { mapInfo: runtime.mapInfo },
-      placement.ops.planWonders.defaultConfig
-    );
-    const floodplains = placement.ops.planFloodplains.run(
-      {},
-      placement.ops.planFloodplains.defaultConfig
-    );
-    const placementRuntime = implementArtifacts([placementArtifacts.placementOutputs], {
-      placementOutputs: {},
-    });
-    const discoveryVisualType = 2687284451;
-    const discoveryActivationType = 2398750021;
-
-    const outputs = applyPlacementPlan({
-      context,
-      starts,
-      wonders,
-      naturalWonderPlan: {
-        width: 4,
-        height: 4,
-        wondersCount: 0,
-        targetCount: 0,
-        plannedCount: 0,
-        placements: [],
-      },
-      discoveryPlan: {
-        width: 4,
-        height: 4,
-        candidateDiscoveries: [],
-        targetCount: 1,
-        plannedCount: 1,
-        placements: [
-          {
-            plotIndex: 2,
-            preferredDiscoveryVisualType: discoveryVisualType,
-            preferredDiscoveryActivationType: discoveryActivationType,
-            preferredDiscoveryOffset: 0,
-            priority: 1,
-          },
-        ],
-      },
-      floodplains,
-      resources: {
-        width: 4,
-        height: 4,
-        candidateResourceTypes: [1],
-        targetCount: 0,
-        plannedCount: 0,
-        placements: [],
-      },
-      landmassRegionSlotByTile: {
-        slotByTile: new Uint8Array(16).fill(1),
-      },
-      publishOutputs: (published) => placementRuntime.placementOutputs.publish(context, published),
+  it("records typed discovery rejections without falling back to official generation", () => {
+    const width = 20;
+    const height = 12;
+    const seed = 1551;
+    const adapter = new RejectingDiscoveryAdapter({
+      width,
+      height,
+      mapInfo: { GridWidth: width, GridHeight: height },
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
     });
 
-    expect(adapter.calls.stampDiscovery.length).toBe(0);
-    expect(adapter.calls.generateOfficialDiscoveries.length).toBe(1);
-    expect(adapter.calls.generateOfficialDiscoveries[0]?.startPositions.length ?? 0).toBeGreaterThan(0);
-    expect(adapter.calls.generateOfficialDiscoveries[0]).toMatchObject({
-      width: 4,
-      height: 4,
-      polarMargin: 0,
-    });
-    expect(outputs.discoveriesCount).toBe(1);
+    const { context } = runStandardPlacementRecipe({ adapter, seed, width, height });
+    const discoveryOutcomes = readDiscoveryOutcomes(context);
+
+    expect(adapter.calls.generateOfficialDiscoveries.length).toBe(0);
+    expect(discoveryOutcomes?.summary.plannedCount).toBeGreaterThan(0);
+    expect(discoveryOutcomes?.summary.placedCount).toBe(0);
+    expect(discoveryOutcomes?.summary.rejectedCount).toBe(discoveryOutcomes?.summary.plannedCount);
+    expect(discoveryOutcomes?.summary.mismatchCount).toBe(0);
   });
 
-  it("fails hard when official discovery generation throws", () => {
-    const adapter = createMockAdapter({
-      width: 4,
-      height: 4,
-      mapInfo: {
-        GridWidth: 4,
-        GridHeight: 4,
-        PlayersLandmass1: 1,
-        PlayersLandmass2: 1,
-        StartSectorRows: 1,
-        StartSectorCols: 1,
-        NumNaturalWonders: 0,
-      },
+  it("fails hard when resource readback contradicts typed intent", () => {
+    const width = 20;
+    const height = 12;
+    const seed = 1661;
+    const adapter = new MismatchingResourceAdapter({
+      width,
+      height,
+      mapInfo: { GridWidth: width, GridHeight: height },
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
     });
-    const discoverySpy = vi
-      .spyOn(adapter, "generateOfficialDiscoveries")
-      .mockImplementation(() => {
-        throw new Error("forced official discovery failure");
-      });
-    const context = createExtendedMapContext({ width: 4, height: 4 }, adapter, { seed: 0 });
-    const runtime = getStandardRuntime(context);
-    const baseStarts = {
-      playersLandmass1: runtime.playersLandmass1,
-      playersLandmass2: runtime.playersLandmass2,
-      startSectorRows: runtime.startSectorRows,
-      startSectorCols: runtime.startSectorCols,
-      startSectors: runtime.startSectors,
-    };
-    const starts = placement.ops.planStarts.run(
-      { baseStarts },
-      placement.ops.planStarts.defaultConfig
-    );
-    const wonders = placement.ops.planWonders.run(
-      { mapInfo: runtime.mapInfo },
-      placement.ops.planWonders.defaultConfig
-    );
-    const floodplains = placement.ops.planFloodplains.run(
-      {},
-      placement.ops.planFloodplains.defaultConfig
-    );
 
-    expect(() =>
-      applyPlacementPlan({
-        context,
-        starts,
-        wonders,
-        naturalWonderPlan: {
-          width: 4,
-          height: 4,
-          wondersCount: 0,
-          targetCount: 0,
-          plannedCount: 0,
-          placements: [],
-        },
-        discoveryPlan: {
-          width: 4,
-          height: 4,
-          candidateDiscoveries: [],
-          targetCount: 1,
-          plannedCount: 1,
-          placements: [
-            {
-              plotIndex: 2,
-              preferredDiscoveryVisualType: 0,
-              preferredDiscoveryActivationType: 0,
-              preferredDiscoveryOffset: 0,
-              priority: 1,
-            },
-          ],
-        },
-        floodplains,
-        resources: {
-          width: 4,
-          height: 4,
-          candidateResourceTypes: [1],
-          targetCount: 0,
-          plannedCount: 0,
-          placements: [],
-        },
-        landmassRegionSlotByTile: {
-          slotByTile: new Uint8Array(16).fill(1),
-        },
-        publishOutputs: (outputs) => outputs,
-      })
-    ).toThrow(/placement\.discoveries failed/i);
-
-    expect(discoverySpy).toHaveBeenCalledTimes(1);
+    expect(() => runStandardPlacementRecipe({ adapter, seed, width, height })).toThrow(
+      /placement\.resources failed/i
+    );
+    expect(adapter.calls.generateOfficialResources.length).toBe(0);
     expect(adapter.calls.recalculateFertility).toBe(0);
     expect(adapter.calls.assignAdvancedStartRegions).toBe(0);
   });
 
-  it("aborts placement when natural wonder stamping cannot fully satisfy the plan", () => {
-    const adapter = createMockAdapter({
-      width: 4,
-      height: 4,
-      mapInfo: {
-        GridWidth: 4,
-        GridHeight: 4,
-        PlayersLandmass1: 1,
-        PlayersLandmass2: 1,
-        StartSectorRows: 1,
-        StartSectorCols: 1,
-        NumNaturalWonders: 2,
-      },
-      canHaveFeature: () => false,
+  it("fails hard when resource outcomes omit typed rejection reasons", () => {
+    const width = 20;
+    const height = 12;
+    const seed = 1771;
+    const adapter = new UntypedResourceRejectionAdapter({
+      width,
+      height,
+      mapInfo: { GridWidth: width, GridHeight: height },
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
     });
-    const context = createExtendedMapContext({ width: 4, height: 4 }, adapter, { seed: 0 });
-    const runtime = getStandardRuntime(context);
-    const baseStarts = {
-      playersLandmass1: runtime.playersLandmass1,
-      playersLandmass2: runtime.playersLandmass2,
-      startSectorRows: runtime.startSectorRows,
-      startSectorCols: runtime.startSectorCols,
-      startSectors: runtime.startSectors,
-    };
 
-    const starts = placement.ops.planStarts.run(
-      { baseStarts },
-      placement.ops.planStarts.defaultConfig
+    expect(() => runStandardPlacementRecipe({ adapter, seed, width, height })).toThrow(
+      /untyped rejection reason/i
     );
-    const wonders = placement.ops.planWonders.run(
-      { mapInfo: runtime.mapInfo },
-      placement.ops.planWonders.defaultConfig
-    );
-    const floodplains = placement.ops.planFloodplains.run(
-      {},
-      placement.ops.planFloodplains.defaultConfig
-    );
-
-    expect(() =>
-      applyPlacementPlan({
-        context,
-        starts,
-        wonders,
-        naturalWonderPlan: {
-          width: 4,
-          height: 4,
-          wondersCount: 2,
-          targetCount: 2,
-          plannedCount: 2,
-          placements: [
-            { plotIndex: 99, featureType: 39, direction: 0, elevation: 100, priority: 1 },
-            { plotIndex: 1, featureType: 40, direction: 0, elevation: 100, priority: 1 },
-          ],
-        },
-        discoveryPlan: {
-          width: 4,
-          height: 4,
-          candidateDiscoveries: [{ discoveryVisualType: 0, discoveryActivationType: 0 }],
-          targetCount: 2,
-          plannedCount: 2,
-          placements: [
-            {
-              plotIndex: 98,
-              preferredDiscoveryVisualType: 0,
-              preferredDiscoveryActivationType: 0,
-              preferredDiscoveryOffset: 0,
-              priority: 1,
-            },
-            {
-              plotIndex: 2,
-              preferredDiscoveryVisualType: 0,
-              preferredDiscoveryActivationType: 0,
-              preferredDiscoveryOffset: 0,
-              priority: 1,
-            },
-          ],
-        },
-        floodplains,
-        resources: {
-          width: 4,
-          height: 4,
-          candidateResourceTypes: [1],
-          targetCount: 0,
-          plannedCount: 0,
-          placements: [],
-        },
-        landmassRegionSlotByTile: {
-          slotByTile: new Uint8Array(16).fill(1),
-        },
-        publishOutputs: (outputs) => outputs,
-      })
-    ).toThrow(/placement\.wonders failed/i);
-
-    expect(adapter.calls.stampNaturalWonder.length).toBe(0);
-    expect(adapter.calls.stampDiscovery.length).toBe(0);
     expect(adapter.calls.generateOfficialResources.length).toBe(0);
-    expect(adapter.calls.generateOfficialDiscoveries.length).toBe(0);
-    expect(adapter.calls.setStartPosition.length).toBe(0);
-    expect(adapter.calls.setResourceType.length).toBe(0);
+    expect(adapter.calls.recalculateFertility).toBe(0);
+    expect(adapter.calls.assignAdvancedStartRegions).toBe(0);
   });
 
-  it("fails explicitly when natural wonder metadata is invalid", () => {
-    const adapter = createMockAdapter({
-      width: 4,
-      height: 4,
-      mapInfo: {
-        GridWidth: 4,
-        GridHeight: 4,
-        PlayersLandmass1: 1,
-        PlayersLandmass2: 1,
-        StartSectorRows: 1,
-        StartSectorCols: 1,
-        NumNaturalWonders: 1,
-      },
+  it("fails hard when discovery outcomes drift from typed intent location", () => {
+    const width = 20;
+    const height = 12;
+    const seed = 1881;
+    const adapter = new MislocatedDiscoveryAdapter({
+      width,
+      height,
+      mapInfo: { GridWidth: width, GridHeight: height },
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
     });
-    const context = createExtendedMapContext({ width: 4, height: 4 }, adapter, { seed: 0 });
-    const runtime = getStandardRuntime(context);
-    const starts = placement.ops.planStarts.run(
-      {
-        baseStarts: {
-          playersLandmass1: runtime.playersLandmass1,
-          playersLandmass2: runtime.playersLandmass2,
-          startSectorRows: runtime.startSectorRows,
-          startSectorCols: runtime.startSectorCols,
-          startSectors: runtime.startSectors,
-        },
-      },
-      placement.ops.planStarts.defaultConfig
-    );
-    const wonders = placement.ops.planWonders.run(
-      { mapInfo: runtime.mapInfo },
-      placement.ops.planWonders.defaultConfig
-    );
-    const floodplains = placement.ops.planFloodplains.run(
-      {},
-      placement.ops.planFloodplains.defaultConfig
-    );
 
-    expect(() =>
-      applyPlacementPlan({
-        context,
-        starts,
-        wonders,
-        naturalWonderPlan: {
-          width: 4,
-          height: 4,
-          wondersCount: 1,
-          targetCount: 1,
-          plannedCount: 1,
-          placements: [
-            {
-              plotIndex: 3,
-              featureType: Number.NaN,
-              direction: 0,
-              elevation: 100,
-              priority: 1,
-            },
-          ],
-        },
-        discoveryPlan: {
-          width: 4,
-          height: 4,
-          candidateDiscoveries: [],
-          targetCount: 0,
-          plannedCount: 0,
-          placements: [],
-        },
-        floodplains,
-        resources: {
-          width: 4,
-          height: 4,
-          candidateResourceTypes: [1],
-          targetCount: 0,
-          plannedCount: 0,
-          placements: [],
-        },
-        landmassRegionSlotByTile: {
-          slotByTile: new Uint8Array(16).fill(1),
-        },
-        publishOutputs: (outputs) => outputs,
-      })
-    ).toThrow(/invalid feature metadata/i);
-
+    expect(() => runStandardPlacementRecipe({ adapter, seed, width, height })).toThrow(
+      /outcome location\/type drifted/i
+    );
     expect(adapter.calls.generateOfficialDiscoveries.length).toBe(0);
+    expect(adapter.calls.recalculateFertility).toBe(0);
+    expect(adapter.calls.assignAdvancedStartRegions).toBe(0);
   });
 });

--- a/mods/mod-swooper-maps/test/placement/resources-landmass-region-restamp.test.ts
+++ b/mods/mod-swooper-maps/test/placement/resources-landmass-region-restamp.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "bun:test";
 
-import { MockAdapter } from "@civ7/adapter";
+import { MockAdapter, type MapInfo } from "@civ7/adapter";
 import { FLAT_TERRAIN, createExtendedMapContext } from "@swooper/mapgen-core";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
 
-import placement from "../../src/domain/placement/ops.js";
-import { getStandardRuntime } from "../../src/recipes/standard/runtime.js";
-import { applyPlacementPlan } from "../../src/recipes/standard/stages/placement/steps/placement/apply.js";
+import { realismEarthlikeConfig } from "../../src/maps/presets/realism/earthlike.config.js";
+import standardRecipe from "../../src/recipes/standard/recipe.js";
+import { initializeStandardRuntime } from "../../src/recipes/standard/runtime.js";
+import { placementArtifacts } from "../../src/recipes/standard/stages/placement/artifacts.js";
 
 class RegionSensitiveResourceAdapter extends MockAdapter {
   readonly callOrder: string[] = [];
@@ -17,7 +18,8 @@ class RegionSensitiveResourceAdapter extends MockAdapter {
   }
 
   override validateAndFixTerrain(): void {
-    // Simulate engine normalization that can clear custom projection ids.
+    // Placement restamps region ids after terrain validation because Civ7
+    // normalization can clear projection-only region metadata.
     for (let y = 0; y < this.height; y++) {
       for (let x = 0; x < this.width; x++) {
         super.setLandmassRegionId(x, y, this.getLandmassId("NONE"));
@@ -25,13 +27,13 @@ class RegionSensitiveResourceAdapter extends MockAdapter {
     }
   }
 
-  override generateOfficialResources(
+  override placeResourceIntent(
     width: number,
     height: number,
-    minMarineResourceTypesOverride?: number
-  ): number {
-    this.callOrder.push("generateOfficialResources");
-    return super.generateOfficialResources(width, height, minMarineResourceTypesOverride);
+    intent: Parameters<MockAdapter["placeResourceIntent"]>[2]
+  ): ReturnType<MockAdapter["placeResourceIntent"]> {
+    this.callOrder.push("placeResourceIntent");
+    return super.placeResourceIntent(width, height, intent);
   }
 }
 
@@ -44,46 +46,42 @@ class RestampFailingAdapter extends RegionSensitiveResourceAdapter {
   }
 }
 
-function buildPlacementInputs(
-  adapter: MockAdapter,
-  width: number,
-  height: number,
-  seed: number
-) {
-  const context = createExtendedMapContext(
-    { width, height },
-    adapter,
-    {
-      seed,
-      dimensions: { width, height },
-      latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
-    }
-  );
-  const runtime = getStandardRuntime(context);
-  const starts = placement.ops.planStarts.run(
-    {
-      baseStarts: {
-        playersLandmass1: runtime.playersLandmass1,
-        playersLandmass2: runtime.playersLandmass2,
-        startSectorRows: runtime.startSectorRows,
-        startSectorCols: runtime.startSectorCols,
-        startSectors: runtime.startSectors,
-      },
+function runRecipeWithAdapter(adapter: MockAdapter, width: number, height: number, seed: number) {
+  const mapInfo: MapInfo = {
+    GridWidth: width,
+    GridHeight: height,
+    MinLatitude: -60,
+    MaxLatitude: 60,
+    PlayersLandmass1: 1,
+    PlayersLandmass2: 1,
+    StartSectorRows: 1,
+    StartSectorCols: 1,
+    NumNaturalWonders: 0,
+  };
+  const env = {
+    seed,
+    dimensions: { width, height },
+    latitudeBounds: {
+      topLatitude: mapInfo.MaxLatitude ?? 60,
+      bottomLatitude: mapInfo.MinLatitude ?? -60,
     },
-    placement.ops.planStarts.defaultConfig
-  );
-  const wonders = placement.ops.planWonders.run(
-    { mapInfo: runtime.mapInfo },
-    placement.ops.planWonders.defaultConfig
-  );
-  const floodplains = placement.ops.planFloodplains.run({}, placement.ops.planFloodplains.defaultConfig);
-  return { context, starts, wonders, floodplains };
+  };
+  const context = createExtendedMapContext({ width, height }, adapter, env);
+
+  initializeStandardRuntime(context, {
+    mapInfo,
+    logPrefix: "[test]",
+    storyEnabled: true,
+  });
+  standardRecipe.run(context, env, realismEarthlikeConfig, { log: () => {} });
+
+  return context;
 }
 
 describe("placement resources landmass-region restamp", () => {
-  it("re-stamps landmass regions before official resource generation", () => {
-    const width = 10;
-    const height = 6;
+  it("re-stamps landmass regions before typed resource materialization", () => {
+    const width = 20;
+    const height = 12;
     const seed = 4242;
     const mapInfo = {
       GridWidth: width,
@@ -104,177 +102,47 @@ describe("placement resources landmass-region restamp", () => {
       mapSizeId: 1,
       rng: createLabelRng(seed),
       defaultTerrainType: FLAT_TERRAIN,
-      officialResourcesPlacedCount: 1,
     });
 
-    const { context, starts, wonders, floodplains } = buildPlacementInputs(adapter, width, height, seed);
-
-    const outputs = applyPlacementPlan({
-      context,
-      starts,
-      wonders,
-      naturalWonderPlan: {
-        width,
-        height,
-        wondersCount: 0,
-        targetCount: 0,
-        plannedCount: 0,
-        placements: [],
-      },
-      discoveryPlan: {
-        width,
-        height,
-        candidateDiscoveries: [],
-        targetCount: 0,
-        plannedCount: 0,
-        placements: [],
-      },
-      floodplains,
-      resources: {
-        width,
-        height,
-        candidateResourceTypes: [7],
-        targetCount: 1,
-        plannedCount: 1,
-        placements: [
-          {
-            plotIndex: 0,
-            preferredResourceType: 7,
-            preferredTypeOffset: 0,
-            priority: 1,
-          },
-        ],
-      },
-      landmassRegionSlotByTile: { slotByTile: new Uint8Array(width * height).fill(1) },
-      publishOutputs: (placementOutputs) => placementOutputs,
-    });
+    const context = runRecipeWithAdapter(adapter, width, height, seed);
 
     const firstRestamp = adapter.callOrder.indexOf("setLandmassRegionId");
-    const firstOfficialResourceGeneration = adapter.callOrder.indexOf("generateOfficialResources");
+    const firstResourceIntent = adapter.callOrder.indexOf("placeResourceIntent");
+    const resourceOutcomes = context.artifacts.get(
+      placementArtifacts.resourcePlacementOutcomes.id
+    ) as { summary?: { plannedCount?: number; placedCount?: number } } | undefined;
+
     expect(firstRestamp).toBeGreaterThanOrEqual(0);
-    expect(firstOfficialResourceGeneration).toBeGreaterThan(firstRestamp);
-    expect(adapter.calls.generateOfficialResources).toEqual([
-      { width, height, minMarineResourceTypesOverride: undefined },
-    ]);
-    expect(adapter.calls.setResourceType.length).toBe(0);
-    expect(outputs.resourcesCount).toBe(1);
+    expect(firstResourceIntent).toBeGreaterThan(firstRestamp);
+    expect(adapter.calls.generateOfficialResources.length).toBe(0);
+    expect(resourceOutcomes?.summary?.plannedCount ?? 0).toBeGreaterThan(0);
+    expect(adapter.calls.setResourceType.length).toBe(resourceOutcomes?.summary?.placedCount);
   });
 
-  it("aborts placement before resource generation when region restamp fails", () => {
-    const width = 4;
-    const height = 4;
+  it("aborts placement before resource materialization when region restamp fails", () => {
+    const width = 20;
+    const height = 12;
     const seed = 99;
-    const mapInfo = {
-      GridWidth: width,
-      GridHeight: height,
-      MinLatitude: -60,
-      MaxLatitude: 60,
-      PlayersLandmass1: 1,
-      PlayersLandmass2: 1,
-      StartSectorRows: 1,
-      StartSectorCols: 1,
-      NumNaturalWonders: 0,
-    };
-
     const adapter = new RestampFailingAdapter({
       width,
       height,
-      mapInfo,
+      mapInfo: {
+        GridWidth: width,
+        GridHeight: height,
+        MinLatitude: -60,
+        MaxLatitude: 60,
+      },
       mapSizeId: 1,
       rng: createLabelRng(seed),
       defaultTerrainType: FLAT_TERRAIN,
     });
 
-    const { context, starts, wonders, floodplains } = buildPlacementInputs(adapter, width, height, seed);
-
-    expect(() =>
-      applyPlacementPlan({
-        context,
-        starts,
-        wonders,
-        floodplains,
-        landmassRegionSlotByTile: { slotByTile: new Uint8Array(width * height).fill(1) },
-        publishOutputs: (placementOutputs) => placementOutputs,
-      })
-    ).toThrow(/restamp failed/i);
+    expect(() => runRecipeWithAdapter(adapter, width, height, seed)).toThrow(
+      /forced restamp failure/i
+    );
 
     expect(adapter.calls.generateOfficialResources.length).toBe(0);
-    expect(adapter.calls.recalculateFertility).toBe(0);
-    expect(adapter.calls.assignAdvancedStartRegions).toBe(0);
-  });
-
-  it("fails hard when official resource generation throws", () => {
-    const width = 4;
-    const height = 4;
-    const seed = 31415;
-    const mapInfo = {
-      GridWidth: width,
-      GridHeight: height,
-      MinLatitude: -60,
-      MaxLatitude: 60,
-      PlayersLandmass1: 1,
-      PlayersLandmass2: 1,
-      StartSectorRows: 1,
-      StartSectorCols: 1,
-      NumNaturalWonders: 0,
-    };
-
-    const adapter = new MockAdapter({
-      width,
-      height,
-      mapInfo,
-      mapSizeId: 1,
-      rng: createLabelRng(seed),
-      defaultTerrainType: FLAT_TERRAIN,
-    });
-    adapter.generateOfficialResources = () => {
-      throw new Error("forced official resource failure");
-    };
-
-    const { context, starts, wonders, floodplains } = buildPlacementInputs(adapter, width, height, seed);
-
-    expect(() =>
-      applyPlacementPlan({
-        context,
-        starts,
-        wonders,
-        naturalWonderPlan: {
-          width,
-          height,
-          wondersCount: 0,
-          targetCount: 0,
-          plannedCount: 0,
-          placements: [],
-        },
-        discoveryPlan: {
-          width,
-          height,
-          candidateDiscoveries: [],
-          targetCount: 0,
-          plannedCount: 0,
-          placements: [],
-        },
-        floodplains,
-        resources: {
-          width,
-          height,
-          candidateResourceTypes: [7],
-          targetCount: 1,
-          plannedCount: 1,
-          placements: [
-            {
-              plotIndex: 0,
-              preferredResourceType: 7,
-              preferredTypeOffset: 0,
-              priority: 1,
-            },
-          ],
-        },
-        landmassRegionSlotByTile: { slotByTile: new Uint8Array(width * height).fill(1) },
-        publishOutputs: (placementOutputs) => placementOutputs,
-      })
-    ).toThrow(/placement\.resources failed/i);
-
+    expect(adapter.callOrder.includes("placeResourceIntent")).toBe(false);
     expect(adapter.calls.recalculateFertility).toBe(0);
     expect(adapter.calls.assignAdvancedStartRegions).toBe(0);
   });

--- a/openspec/changes/normalize-placement-contracts/implementation.md
+++ b/openspec/changes/normalize-placement-contracts/implementation.md
@@ -15,10 +15,10 @@ Resource, discovery, start, and advanced-start work was intentionally not
 promoted in this slice. Resource and discovery planning already has plan
 artifacts, but projection still delegates feasibility to official Civ
 generators; typed outcomes and rejection reasons belong to
-`normalize-placement-reconciliation`. Start assignment feeds discovery
-generation in the same runtime sequence and has no independent downstream
-consumer yet. Advanced-start assignment remains an engine-side terminal effect
-without an artifact consumer.
+`normalize-placement-reconciliation` and are superseded there. Start assignment
+feeds discovery materialization in the same runtime sequence and has no
+independent downstream consumer yet. Advanced-start assignment remains an
+engine-side terminal effect without an artifact consumer.
 
 Maintenance operations remain transactional inside final placement:
 
@@ -26,7 +26,7 @@ Maintenance operations remain transactional inside final placement:
 - terrain validation
 - area recalculation
 - water cache storage
-- landmass-region restamping before official resource generation
+- landmass-region restamping before typed resource materialization
 - fertility recalculation
 
 Those operations are ordered engine maintenance required for the placement

--- a/openspec/changes/normalize-placement-reconciliation/implementation.md
+++ b/openspec/changes/normalize-placement-reconciliation/implementation.md
@@ -1,0 +1,61 @@
+## Implementation Record
+
+This slice replaces resource/discovery official-generator authority with typed
+adapter intent materialization.
+
+Implemented surfaces:
+
+- `@civ7/adapter` now exports resource/discovery placement intent, outcome,
+  rejection, and mismatch types from its public entrypoint.
+- `EngineAdapter`, `Civ7Adapter`, and `MockAdapter` expose
+  `placeResourceIntent` and `placeDiscoveryIntent`.
+- Final placement publishes:
+  - `artifact:placement.resourcePlacementOutcomes`
+  - `artifact:placement.discoveryPlacementOutcomes`
+- Resource reconciliation accepts typed engine feasibility rejections, but
+  fails hard on wrong-type resource readback.
+- Discovery reconciliation accepts only typed adapter acceptance/rejection
+  because Civ7 does not expose resource-like discovery readback.
+- Final placement no longer calls `generateOfficialResources` or
+  `generateOfficialDiscoveries` as accepted truth for resource/discovery
+  outcomes.
+
+The implementation deliberately does not port all Civ7 legality rules into
+MapGen. Civ7 feasibility remains adapter-owned; MapGen owns deterministic
+intent and typed reconciliation evidence.
+
+## Test Posture
+
+D4 closure evidence uses recipe-level placement execution for MapGen behavior.
+Tests do not call `applyPlacementPlan` directly or seed placement step artifacts
+as the D4 harness. Direct adapter unit tests are limited to the adapter package,
+where the adapter boundary itself is the unit under review.
+
+## Authority Updates
+
+Updated authority surfaces:
+
+- `docs/system/libs/mapgen/reference/domains/PLACEMENT.md`
+- `docs/system/mods/swooper-maps/architecture.md`
+- `docs/system/mods/swooper-maps/adrs/adr-002-plot-tagging-adapter.md`
+- `openspec/changes/normalize-placement-contracts/implementation.md`
+
+No new deferral was recorded. The retained complexity is intentional: resources
+and discoveries stay in final placement for now because their independent
+product boundaries are not yet split, while typed outcome artifacts make the
+authority boundary auditable.
+
+## Validation
+
+- `bun run --cwd packages/civ7-adapter check`
+- `bun run --cwd packages/civ7-adapter build`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun test packages/civ7-adapter/test/placement-outcomes.test.ts packages/civ7-adapter/test/discovery-constants.test.ts`
+- `bun run --cwd mods/mod-swooper-maps test -- test/map-hydrology/lakes-area-recalc-resources.test.ts test/placement/placement-does-not-call-generate-snow.test.ts test/placement/resources-landmass-region-restamp.test.ts test/placement/landmass-region-id-projection.test.ts test/placement/plan-ops.test.ts test/placement/placement-contracts.test.ts test/standard-run.test.ts` (27 tests)
+- `bun run lint:mapgen-recipe-imports`
+- `bun run lint:domain-refactor-guardrails`
+- `bun run lint:mapgen-docs` (passes with the existing three `@mapgen/*`
+  documentation warnings)
+- `bun run openspec -- validate normalize-placement-reconciliation --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/normalize-placement-reconciliation/tasks.md
+++ b/openspec/changes/normalize-placement-reconciliation/tasks.md
@@ -1,27 +1,27 @@
 ## 1. Outcome Contract
 
-- [ ] 1.1 Define per-tile placement outcome schemas for resources and
+- [x] 1.1 Define per-tile placement outcome schemas for resources and
   discoveries.
-- [ ] 1.2 Define typed rejection reasons and mismatch categories.
-- [ ] 1.3 Update adapter/test doubles to report outcomes.
+- [x] 1.2 Define typed rejection reasons and mismatch categories.
+- [x] 1.3 Update adapter/test doubles to report outcomes.
 
 ## 2. Reconciliation
 
-- [ ] 2.1 Update resource placement to reconcile plan intent against outcomes.
-- [ ] 2.2 Update discovery placement to reconcile plan intent against outcomes.
-- [ ] 2.3 Fail on unexplained drift, wrong type/location, or untyped rejection.
-- [ ] 2.4 Avoid count-equality gates.
+- [x] 2.1 Update resource placement to reconcile plan intent against outcomes.
+- [x] 2.2 Update discovery placement to reconcile plan intent against outcomes.
+- [x] 2.3 Fail on unexplained drift, wrong type/location, or untyped rejection.
+- [x] 2.4 Avoid count-equality gates.
 
 ## 3. Authority Realignment
 
-- [ ] 3.1 Update docs that describe resource/discovery official generator
+- [x] 3.1 Update docs that describe resource/discovery official generator
   output as accepted truth.
-- [ ] 3.2 Update affected ADR/deferral records.
+- [x] 3.2 Update affected ADR/deferral records.
 
 ## 4. Verification
 
-- [ ] 4.1 Run resource/discovery reconciliation tests.
-- [ ] 4.2 Run adapter outcome tests.
-- [ ] 4.3 Run `bun run openspec -- validate normalize-placement-reconciliation --strict`.
-- [ ] 4.4 Run `bun run openspec:validate`.
-- [ ] 4.5 Run `git diff --check`.
+- [x] 4.1 Run resource/discovery reconciliation tests.
+- [x] 4.2 Run adapter outcome tests.
+- [x] 4.3 Run `bun run openspec -- validate normalize-placement-reconciliation --strict`.
+- [x] 4.4 Run `bun run openspec:validate`.
+- [x] 4.5 Run `git diff --check`.

--- a/packages/civ7-adapter/src/civ7-adapter.ts
+++ b/packages/civ7-adapter/src/civ7-adapter.ts
@@ -9,6 +9,8 @@
 
 import type {
   DiscoveryCatalogEntry,
+  DiscoveryPlacementIntent,
+  DiscoveryPlacementOutcome,
   EngineAdapter,
   FeatureData,
   LakeProjectionResult,
@@ -18,6 +20,8 @@ import type {
   MapSizeId,
   NaturalWonderCatalogEntry,
   PlotTagName,
+  ResourcePlacementIntent,
+  ResourcePlacementOutcome,
   VoronoiUtils,
 } from "./types.js";
 import { ENGINE_EFFECT_TAGS } from "./effects.js";
@@ -324,6 +328,58 @@ export class Civ7Adapter implements EngineAdapter {
     return [...PLACEABLE_RESOURCE_TYPE_IDS];
   }
 
+  placeResourceIntent(
+    width: number,
+    height: number,
+    intent: ResourcePlacementIntent
+  ): ResourcePlacementOutcome {
+    // D4 placement reconciliation treats Civ7 feasibility as adapter-owned.
+    // The recipe supplies deterministic intent; this boundary translates it
+    // into an engine write plus readback evidence without falling back to the
+    // aggregate official resource generator.
+    const resolvedWidth = Math.max(0, Math.trunc(width));
+    const resolvedHeight = Math.max(0, Math.trunc(height));
+    const plotIndex = Number.isFinite(intent.plotIndex) ? Math.trunc(intent.plotIndex) : -1;
+    const resourceType = Number.isFinite(intent.resourceType)
+      ? Math.trunc(intent.resourceType)
+      : this.NO_RESOURCE;
+    const y = resolvedWidth > 0 ? Math.trunc(plotIndex / resolvedWidth) : -1;
+    const x = resolvedWidth > 0 ? plotIndex - y * resolvedWidth : -1;
+
+    if (plotIndex < 0 || x < 0 || y < 0 || x >= resolvedWidth || y >= resolvedHeight) {
+      return { status: "rejected", plotIndex, x, y, resourceType, reason: "out-of-bounds" };
+    }
+    if (resourceType < 0 || resourceType === (this.NO_RESOURCE | 0)) {
+      return { status: "rejected", plotIndex, x, y, resourceType, reason: "invalid-resource-type" };
+    }
+    if (!this.canHaveResource(x, y, resourceType)) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        resourceType,
+        reason: "cannot-have-resource",
+        observedResourceType: this.getResourceType(x, y),
+      };
+    }
+
+    this.setResourceType(x, y, resourceType);
+    const observedResourceType = this.getResourceType(x, y);
+    if ((observedResourceType | 0) !== (resourceType | 0)) {
+      return {
+        status: "mismatch",
+        plotIndex,
+        x,
+        y,
+        resourceType,
+        reason: "wrong-resource-type",
+        observedResourceType,
+      };
+    }
+    return { status: "placed", plotIndex, x, y, resourceType, observedResourceType };
+  }
+
   // === PLOT EFFECTS ===
 
   getPlotEffectTypesContainingTags(tags: string[]): number[] {
@@ -624,6 +680,64 @@ export class Civ7Adapter implements EngineAdapter {
     );
     if (placed) this.recordPlacementEffect();
     return Boolean(placed);
+  }
+
+  placeDiscoveryIntent(
+    width: number,
+    height: number,
+    intent: DiscoveryPlacementIntent
+  ): DiscoveryPlacementOutcome {
+    // Discovery placement has no stable post-write readback, so the adapter
+    // exposes Civ7 acceptance/rejection as explicit reconciliation evidence
+    // instead of making the recipe infer success from generator counts.
+    const resolvedWidth = Math.max(0, Math.trunc(width));
+    const resolvedHeight = Math.max(0, Math.trunc(height));
+    const plotIndex = Number.isFinite(intent.plotIndex) ? Math.trunc(intent.plotIndex) : -1;
+    const discoveryVisualType = Number.isFinite(intent.discoveryVisualType)
+      ? Math.trunc(intent.discoveryVisualType)
+      : -1;
+    const discoveryActivationType = Number.isFinite(intent.discoveryActivationType)
+      ? Math.trunc(intent.discoveryActivationType)
+      : -1;
+    const y = resolvedWidth > 0 ? Math.trunc(plotIndex / resolvedWidth) : -1;
+    const x = resolvedWidth > 0 ? plotIndex - y * resolvedWidth : -1;
+
+    if (plotIndex < 0 || x < 0 || y < 0 || x >= resolvedWidth || y >= resolvedHeight) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        discoveryVisualType,
+        discoveryActivationType,
+        reason: "out-of-bounds",
+      };
+    }
+    if (discoveryVisualType < 0 || discoveryActivationType < 0) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        discoveryVisualType,
+        discoveryActivationType,
+        reason: "invalid-discovery-type",
+      };
+    }
+
+    const placed = this.stampDiscovery(x, y, discoveryVisualType, discoveryActivationType);
+    if (!placed) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        discoveryVisualType,
+        discoveryActivationType,
+        reason: "adapter-rejected",
+      };
+    }
+    return { status: "placed", plotIndex, x, y, discoveryVisualType, discoveryActivationType };
   }
 
   generateOfficialResources(

--- a/packages/civ7-adapter/src/index.ts
+++ b/packages/civ7-adapter/src/index.ts
@@ -29,6 +29,13 @@ export type {
   LandmassIdName,
   VoronoiUtils,
   DiscoveryCatalogEntry,
+  ResourcePlacementIntent,
+  ResourcePlacementOutcome,
+  ResourcePlacementRejectionReason,
+  ResourcePlacementMismatchReason,
+  DiscoveryPlacementIntent,
+  DiscoveryPlacementOutcome,
+  DiscoveryPlacementRejectionReason,
 } from "./types.js";
 export { ENGINE_EFFECT_TAGS } from "./effects.js";
 export type { EngineEffectTagId } from "./effects.js";

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -7,6 +7,8 @@
 
 import type {
   DiscoveryCatalogEntry,
+  DiscoveryPlacementIntent,
+  DiscoveryPlacementOutcome,
   EngineAdapter,
   FeatureData,
   LakeProjectionResult,
@@ -16,6 +18,8 @@ import type {
   MapSizeId,
   NaturalWonderCatalogEntry,
   PlotTagName,
+  ResourcePlacementIntent,
+  ResourcePlacementOutcome,
   VoronoiBoundingBox,
   VoronoiCell,
   VoronoiDiagram,
@@ -664,6 +668,56 @@ export class MockAdapter implements EngineAdapter {
     return [...this.resourceTypeCatalog];
   }
 
+  placeResourceIntent(
+    width: number,
+    height: number,
+    intent: ResourcePlacementIntent
+  ): ResourcePlacementOutcome {
+    // Mirror the production adapter contract so recipe tests exercise typed
+    // reconciliation outcomes instead of a mock-only placement shortcut.
+    const resolvedWidth = Math.max(0, Math.trunc(width));
+    const resolvedHeight = Math.max(0, Math.trunc(height));
+    const plotIndex = Number.isFinite(intent.plotIndex) ? Math.trunc(intent.plotIndex) : -1;
+    const resourceType = Number.isFinite(intent.resourceType)
+      ? Math.trunc(intent.resourceType)
+      : this.NO_RESOURCE;
+    const y = resolvedWidth > 0 ? Math.trunc(plotIndex / resolvedWidth) : -1;
+    const x = resolvedWidth > 0 ? plotIndex - y * resolvedWidth : -1;
+
+    if (plotIndex < 0 || x < 0 || y < 0 || x >= resolvedWidth || y >= resolvedHeight) {
+      return { status: "rejected", plotIndex, x, y, resourceType, reason: "out-of-bounds" };
+    }
+    if (resourceType < 0 || resourceType === (this.NO_RESOURCE | 0)) {
+      return { status: "rejected", plotIndex, x, y, resourceType, reason: "invalid-resource-type" };
+    }
+    if (!this.canHaveResource(x, y, resourceType)) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        resourceType,
+        reason: "cannot-have-resource",
+        observedResourceType: this.getResourceType(x, y),
+      };
+    }
+
+    this.setResourceType(x, y, resourceType);
+    const observedResourceType = this.getResourceType(x, y);
+    if ((observedResourceType | 0) !== (resourceType | 0)) {
+      return {
+        status: "mismatch",
+        plotIndex,
+        x,
+        y,
+        resourceType,
+        reason: "wrong-resource-type",
+        observedResourceType,
+      };
+    }
+    return { status: "placed", plotIndex, x, y, resourceType, observedResourceType };
+  }
+
   // === PLOT EFFECTS ===
 
   getPlotEffectTypesContainingTags(tags: string[]): number[] {
@@ -965,6 +1019,64 @@ export class MockAdapter implements EngineAdapter {
     });
     this.recordPlacementEffect();
     return true;
+  }
+
+  placeDiscoveryIntent(
+    width: number,
+    height: number,
+    intent: DiscoveryPlacementIntent
+  ): DiscoveryPlacementOutcome {
+    // Keep mock discovery behavior aligned with Civ7Adapter: placement success
+    // is explicit evidence, and rejection is a typed result the recipe can
+    // publish for review/debugging.
+    const resolvedWidth = Math.max(0, Math.trunc(width));
+    const resolvedHeight = Math.max(0, Math.trunc(height));
+    const plotIndex = Number.isFinite(intent.plotIndex) ? Math.trunc(intent.plotIndex) : -1;
+    const discoveryVisualType = Number.isFinite(intent.discoveryVisualType)
+      ? Math.trunc(intent.discoveryVisualType)
+      : -1;
+    const discoveryActivationType = Number.isFinite(intent.discoveryActivationType)
+      ? Math.trunc(intent.discoveryActivationType)
+      : -1;
+    const y = resolvedWidth > 0 ? Math.trunc(plotIndex / resolvedWidth) : -1;
+    const x = resolvedWidth > 0 ? plotIndex - y * resolvedWidth : -1;
+
+    if (plotIndex < 0 || x < 0 || y < 0 || x >= resolvedWidth || y >= resolvedHeight) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        discoveryVisualType,
+        discoveryActivationType,
+        reason: "out-of-bounds",
+      };
+    }
+    if (discoveryVisualType < 0 || discoveryActivationType < 0) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        discoveryVisualType,
+        discoveryActivationType,
+        reason: "invalid-discovery-type",
+      };
+    }
+
+    const placed = this.stampDiscovery(x, y, discoveryVisualType, discoveryActivationType);
+    if (!placed) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        discoveryVisualType,
+        discoveryActivationType,
+        reason: "adapter-rejected",
+      };
+    }
+    return { status: "placed", plotIndex, x, y, discoveryVisualType, discoveryActivationType };
   }
 
   generateOfficialDiscoveries(

--- a/packages/civ7-adapter/src/types.ts
+++ b/packages/civ7-adapter/src/types.ts
@@ -27,6 +27,105 @@ export interface DiscoveryCatalogEntry {
 }
 
 /**
+ * Named resource rejection reasons keep placement reconciliation auditable.
+ * MapGen owns the deterministic intent; the adapter owns Civ7 feasibility and
+ * readback evidence instead of hiding drift behind aggregate generator counts.
+ */
+export type ResourcePlacementRejectionReason =
+  | "out-of-bounds"
+  | "invalid-resource-type"
+  | "cannot-have-resource";
+
+export type ResourcePlacementMismatchReason = "wrong-resource-type";
+
+/**
+ * A single deterministic resource request from the map recipe to the engine
+ * adapter. It is intentionally plot-index based because recipe artifacts use
+ * tile-linear plans before adapter materialization converts to x/y.
+ */
+export interface ResourcePlacementIntent {
+  plotIndex: number;
+  resourceType: number;
+}
+
+/**
+ * Resource reconciliation result for one planned intent. Rejections are normal
+ * engine feasibility outcomes; mismatches mean the adapter accepted the intent
+ * but the engine readback disagreed, which callers should treat as fail-hard.
+ */
+export type ResourcePlacementOutcome =
+  | {
+      status: "placed";
+      plotIndex: number;
+      x: number;
+      y: number;
+      resourceType: number;
+      observedResourceType: number;
+    }
+  | {
+      status: "rejected";
+      plotIndex: number;
+      x: number;
+      y: number;
+      resourceType: number;
+      reason: ResourcePlacementRejectionReason;
+      observedResourceType?: number;
+    }
+  | {
+      status: "mismatch";
+      plotIndex: number;
+      x: number;
+      y: number;
+      resourceType: number;
+      reason: ResourcePlacementMismatchReason;
+      observedResourceType: number;
+    };
+
+/**
+ * Named discovery rejection reasons mirror resource reconciliation without
+ * pretending Civ7 exposes resource-like discovery readback.
+ */
+export type DiscoveryPlacementRejectionReason =
+  | "out-of-bounds"
+  | "invalid-discovery-type"
+  | "adapter-rejected";
+
+/**
+ * A single deterministic discovery request from placement planning. Visual and
+ * activation ids stay paired so the adapter can materialize the exact catalog
+ * entry selected by the planner.
+ */
+export interface DiscoveryPlacementIntent {
+  plotIndex: number;
+  discoveryVisualType: number;
+  discoveryActivationType: number;
+}
+
+/**
+ * Discovery reconciliation result for one planned intent. The adapter can only
+ * confirm placement or expose a named rejection, so there is no discovery
+ * mismatch state until Civ7 offers richer readback.
+ */
+export type DiscoveryPlacementOutcome =
+  | {
+      status: "placed";
+      plotIndex: number;
+      x: number;
+      y: number;
+      discoveryVisualType: number;
+      discoveryActivationType: number;
+    }
+  | {
+      status: "rejected";
+      plotIndex: number;
+      x: number;
+      y: number;
+      discoveryVisualType: number;
+      discoveryActivationType: number;
+      reason: DiscoveryPlacementRejectionReason;
+    };
+
+/**
  * Map dimensions
  */
 export interface MapDimensions {
@@ -292,6 +391,17 @@ export interface EngineAdapter {
   /** Adapter-owned placeable resource type catalog used by deterministic placement. */
   getPlaceableResourceTypes(): number[];
 
+  /**
+   * Materialize one planned resource intent and report a typed per-tile outcome.
+   * This keeps Civ7 feasibility/readback at the adapter boundary while letting
+   * MapGen reconcile deterministic intent without count-equality gates.
+   */
+  placeResourceIntent(
+    width: number,
+    height: number,
+    intent: ResourcePlacementIntent
+  ): ResourcePlacementOutcome;
+
   // === PLOT EFFECTS ===
 
   /**
@@ -454,6 +564,18 @@ export interface EngineAdapter {
     discoveryVisualType: number,
     discoveryActivationType: number
   ): boolean;
+
+  /**
+   * Materialize one planned discovery intent and report a typed per-tile outcome.
+   * Discovery placement has no stable engine readback equivalent to resources,
+   * so the adapter is the boundary that converts Civ7 acceptance into named
+   * reconciliation evidence.
+   */
+  placeDiscoveryIntent(
+    width: number,
+    height: number,
+    intent: DiscoveryPlacementIntent
+  ): DiscoveryPlacementOutcome;
 
   /**
    * Run Civ7's official resource generator.

--- a/packages/civ7-adapter/test/placement-outcomes.test.ts
+++ b/packages/civ7-adapter/test/placement-outcomes.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+
+import { createMockAdapter } from "../src/mock-adapter.js";
+
+/**
+ * Adapter outcome tests live at the adapter boundary by design.
+ *
+ * Recipes should exercise placement through recipe execution, but the adapter
+ * package still needs direct unit coverage for the typed reconciliation contract
+ * it exposes to every map type.
+ */
+describe("typed placement outcomes", () => {
+  it("returns placed resource outcomes with readback evidence", () => {
+    const adapter = createMockAdapter({ width: 4, height: 3 });
+
+    const outcome = adapter.placeResourceIntent(4, 3, {
+      plotIndex: 5,
+      resourceType: 7,
+    });
+
+    expect(outcome).toEqual({
+      status: "placed",
+      plotIndex: 5,
+      x: 1,
+      y: 1,
+      resourceType: 7,
+      observedResourceType: 7,
+    });
+    expect(adapter.getResourceType(1, 1)).toBe(7);
+  });
+
+  it("returns typed resource rejections without mutating the tile", () => {
+    const adapter = createMockAdapter({
+      width: 4,
+      height: 3,
+      canHaveResource: () => false,
+    });
+
+    const outcome = adapter.placeResourceIntent(4, 3, {
+      plotIndex: 5,
+      resourceType: 7,
+    });
+
+    expect(outcome).toEqual({
+      status: "rejected",
+      plotIndex: 5,
+      x: 1,
+      y: 1,
+      resourceType: 7,
+      reason: "cannot-have-resource",
+      observedResourceType: adapter.NO_RESOURCE,
+    });
+    expect(adapter.calls.setResourceType.length).toBe(0);
+  });
+
+  it("returns typed discovery outcomes and structural rejections", () => {
+    const adapter = createMockAdapter({ width: 4, height: 3 });
+
+    const placed = adapter.placeDiscoveryIntent(4, 3, {
+      plotIndex: 6,
+      discoveryVisualType: 2687284451,
+      discoveryActivationType: 2398750021,
+    });
+    const rejected = adapter.placeDiscoveryIntent(4, 3, {
+      plotIndex: -1,
+      discoveryVisualType: 2687284451,
+      discoveryActivationType: 2398750021,
+    });
+
+    expect(placed).toEqual({
+      status: "placed",
+      plotIndex: 6,
+      x: 2,
+      y: 1,
+      discoveryVisualType: 2687284451,
+      discoveryActivationType: 2398750021,
+    });
+    expect(rejected).toMatchObject({
+      status: "rejected",
+      reason: "out-of-bounds",
+    });
+  });
+});


### PR DESCRIPTION
Resource and discovery placement now routes through typed adapter intent APIs (`placeResourceIntent` / `placeDiscoveryIntent`) instead of delegating to the aggregate official Civ7 generators (`generateOfficialResources` / `generateOfficialDiscoveries`).

Each planned tile produces a per-tile outcome artifact (`artifact:placement.resourcePlacementOutcomes`, `artifact:placement.discoveryPlacementOutcomes`) with a typed status (`placed`, `rejected`, `mismatch`) and a named reason for any non-placement result. Typed engine feasibility rejections are accepted; wrong-type resource readback is fail-hard; discovery placement records named adapter acceptance/rejection because Civ7 does not expose resource-like discovery readback. Aggregate count equality is no longer a contract gate.

`EngineAdapter`, `Civ7Adapter`, and `MockAdapter` all expose the new intent/outcome methods. Typed intent, outcome, rejection, and mismatch types are exported from the `@civ7/adapter` public entrypoint.

Tests are rewritten to run through the standard recipe rather than calling `applyPlacementPlan` directly or seeding step artifacts. New test cases cover typed resource rejections, typed discovery rejections, fail-hard mismatch on wrong-type readback, and fail-hard on untyped rejection reasons. The lake area/water ordering regression and the landmass-region restamp ordering test are updated to assert against the published outcome artifacts and `placeResourceIntent` call order instead of `generateOfficialResources`.