### PR TITLE
feat(ecology): bound feature intent planners and partition wetland/reef habitats

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -15,6 +15,7 @@ discipline; they should not duplicate the packet as a parallel spec.
 | `civ7-architecture-authority` | Placing code, moving boundaries, changing MapGen stage/step/domain shape, separating core/mod/adapter/generated concerns, or reviewing architecture drift. |
 | `civ7-product-authority` | Deciding product/domain ownership, public SDK/CLI/mod behavior, official game-data authority, consumer contract claims, or proof boundaries. |
 | `civ7-open-spec-workstream` | Running a bounded spec/workstream phase from authority grounding through implementation, verification, downstream realignment, and handoff. |
+| `civ7-operational-debugging` | Debugging build/deploy/log/in-game evidence across generated mod output, deployed Civ7 Mods folders, official resources, and proof boundaries. |
 | `dra-structural-watcher` | Running or setting up a separate watcher DRA for OpenSpec workstreams: heartbeat/cron monitoring, NOTE-TO-DRA scans, correction logs, closure-drift checks, and branch/stack watcher passes without owning implementation. |
 
 ## Operating Rules

--- a/.agents/skills/civ7-operational-debugging/SKILL.md
+++ b/.agents/skills/civ7-operational-debugging/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: civ7-operational-debugging
+description: |
+  Use in the Civ7 Modding Tools repo when debugging operational behavior across official resources, generated mod output, deployed Mods folders, Civ7 logs, build/deploy scripts, or in-game verification. Trigger phrases include "check the deployed mod", "inspect Civ7 logs", "did deploy copy this", "is this in-game verified", "what did the game load", "verify build deploy logs", "debug mod runtime", "compare resources to deployed output", and "what proof do we have from logs".
+---
+
+# Civ7 Operational Debugging
+
+## Purpose
+
+Use this skill when the question is operational: what was built, what was
+deployed, what Civ7 loaded, what the logs say, and what can honestly be proven
+from those observations.
+
+This skill complements `civ7-architecture-authority` and
+`civ7-product-authority`. Architecture/product skills decide ownership and
+promises; this skill verifies runtime evidence without turning logs or generated
+files into source authority.
+
+## When To Use
+
+- Inspecting `mods/<mod-slug>/mod/` output or the OS-level Civ7 `Mods/`
+  directory.
+- Checking whether `bun run --cwd mods/<mod-slug> build`, a package `deploy`
+  script, or root `bun run deploy:mods` actually produced the expected files.
+- Reading Civ7 `Logs/` files after launching the game or loading a map/mod.
+- Comparing official resources in `.civ7/outputs/resources` to repo modeling or
+  generated mod behavior.
+- Closing a claim that depends on build, deploy, log, or in-game evidence.
+
+## Non-Goals
+
+- Do not use this as a task log, design record, project plan, or issue ledger.
+- Do not edit `dist/`, `mod/`, deployed Mods files, official resource outputs,
+  or logs by hand.
+- Do not use logs or deployed files to override source, architecture authority,
+  product authority, ADRs, accepted project baselines, or OpenSpec records.
+- Do not claim in-game correctness from build success, file presence, or a quiet
+  log alone.
+- Do not store task-specific debugging notes in this skill.
+
+## Default Workflow
+
+1. **Ground repo state.** Check branch, stack/worktree, dirty files, and the
+   closest `AGENTS.md` for the source files involved.
+2. **Name the operational question.** State whether you are proving build,
+   generated output, deployment, log behavior, resource evidence, or in-game
+   behavior.
+3. **Locate the surfaces.** Use `references/operational-paths.md` for source
+   mod paths, generated output, deployed mod locations, logs, and official
+   resources.
+4. **Run the narrow gate.** Use the smallest command or inspection that
+   exercises the named surface: package build, package deploy, root deploy,
+   deployed file inspection, log scan, or in-game run.
+5. **Compare source to output.** If inspecting generated or deployed files,
+   connect every claim back to source inputs and scripts. Generated output is
+   evidence, not the edit surface.
+6. **Read logs after the action.** Use timestamps, file mtimes, or a before/after
+   snapshot so stale log lines are not mistaken for the latest run.
+7. **Classify proof.** Use `references/proof-boundaries.md` to label the result
+   as build proof, deploy proof, log proof, in-game proof, resource evidence, or
+   unresolved.
+8. **Escalate to authority only when needed.** If the evidence implies a product
+   or architecture change, switch to the corresponding authority skill before
+   editing source or docs.
+
+## Reference Map
+
+| Reference | Path | Open When |
+|---|---|---|
+| Operational paths | `references/operational-paths.md` | Finding repo output, deployed Mods, logs, official resources, or scripts |
+| Proof boundaries | `references/proof-boundaries.md` | Closing claims from build, deploy, log, resource, or in-game evidence |
+| Debugging workflow | `references/debugging-workflow.md` | Running an end-to-end operational pass without overclaiming |
+
+## Core Invariants
+
+<invariants>
+<invariant name="operation-before-theory">Name the exact runtime surface being inspected before drawing conclusions from files or logs.</invariant>
+<invariant name="generated-output-is-evidence">`dist/`, `mod/`, deployed Mods folders, logs, and resource outputs are evidence surfaces. They are not hand-editable source authority.</invariant>
+<invariant name="deploy-proves-copy-not-load">A successful deploy proves files were copied into the game data Mods directory. It does not prove Civ7 loaded or executed them.</invariant>
+<invariant name="logs-prove-observation-not-absence">A log line proves an observed event. A quiet log only proves no matching line was found in the searched window.</invariant>
+<invariant name="in-game-proof-requires-game-action">In-game proof requires launching Civ7 and exercising the relevant mod/map behavior, then tying the observation to logs or visible behavior from that run.</invariant>
+<invariant name="resource-evidence-stays-separate">Official resources describe game data facts. Repo source decides how those facts become SDK, adapter, MapGen, CLI, or mod behavior.</invariant>
+<invariant name="proof-labels-are-mandatory">Close operational debugging by labeling each claim with the strongest evidence actually collected: built, generated, deployed, logged, in-game observed, or unresolved.</invariant>
+</invariants>
+
+## Anti-Patterns To Avoid
+
+- Editing generated or deployed files to test a source hypothesis.
+- Treating `bun run build` as proof that Civ7 can load the mod.
+- Treating a copied mod directory as proof that the game selected the mod.
+- Reading old log lines without bounding the run window.
+- Treating official resources as proof of this repo's intended product contract.
+- Turning a one-off incident into durable skill guidance.
+
+## Quick Start
+
+1. Open `references/operational-paths.md`.
+2. State the proof surface: build, generated output, deploy, logs, resources, or
+   in-game.
+3. Run the matching gate from `references/debugging-workflow.md`.
+4. Close with evidence-scoped claims from `references/proof-boundaries.md`.

--- a/.agents/skills/civ7-operational-debugging/references/debugging-workflow.md
+++ b/.agents/skills/civ7-operational-debugging/references/debugging-workflow.md
@@ -1,0 +1,56 @@
+# Debugging Workflow
+
+## Standard Pass
+
+1. Record repo branch, dirty state, and relevant `AGENTS.md` routers.
+2. Identify the mod slug, mod id, source entrypoints, generated output path, and
+   deployed target path.
+3. Capture current mtimes or a short baseline for the log files you will read.
+4. Run the narrow build or deploy command needed for the question.
+5. Inspect local generated output before inspecting deployed output.
+6. Inspect the deployed Mods directory only after the deploy command has run.
+7. Launch or use Civ7 only when the claim requires game load/runtime evidence.
+8. Read logs after the game action and bound findings to that run.
+9. Report claims with proof labels from `proof-boundaries.md`.
+
+## Build And Generated Output Gate
+
+Use when the question is "did source generate the expected mod files?"
+
+- Run `bun run --cwd mods/<mod-slug> build`.
+- Inspect `mods/<mod-slug>/mod/` for the expected `.modinfo`, XML, JS, text, or
+  config files.
+- If output is wrong, inspect source and build scripts; do not patch generated
+  output.
+
+## Deploy Gate
+
+Use when the question is "did the built mod reach Civ7's Mods directory?"
+
+- Run `bun run --cwd mods/<mod-slug> deploy` for a single mod or
+  `bun run deploy:mods` for all repo mods.
+- Inspect `<game-data>/Mods/<mod-id>/`.
+- Compare deployed files to `mods/<mod-slug>/mod/` when the copied content is in
+  question.
+
+## Log Gate
+
+Use when the question is "what did Civ7 report?"
+
+- Bound the log window before launching or exercising the game path.
+- Inspect `Modding.log` for discovery and load issues.
+- Inspect `Database.log` for XML import failures.
+- Inspect `Scripting.log` for map/runtime JavaScript errors and diagnostic
+  `console.log` output.
+- Inspect `Localization.log` when text keys or localization files are involved.
+- Record searched files, search terms, and whether findings were current.
+
+## In-Game Gate
+
+Use when the claim depends on Civ7 executing behavior.
+
+- Deploy the mod first and inspect the deployed target.
+- Launch Civ7, enable/select the mod or map path under test, and exercise the
+  relevant behavior.
+- Tie the observation to current logs or visible game behavior.
+- State the exact exercised path; do not generalize beyond it.

--- a/.agents/skills/civ7-operational-debugging/references/operational-paths.md
+++ b/.agents/skills/civ7-operational-debugging/references/operational-paths.md
@@ -1,0 +1,51 @@
+# Operational Paths
+
+## Repo Surfaces
+
+| Surface | Path |
+|---|---|
+| Official resource evidence | `.civ7/outputs/resources/` |
+| Mod sources | `mods/<mod-slug>/src/` |
+| Mod package scripts | `mods/<mod-slug>/package.json` |
+| Generated mod output | `mods/<mod-slug>/mod/` |
+| Root deploy command | `bun run deploy:mods` |
+| Package build command | `bun run --cwd mods/<mod-slug> build` |
+| Package deploy command | `bun run --cwd mods/<mod-slug> deploy` |
+
+`mods/<mod-slug>/mod/` is generated output. Inspect it to confirm generation,
+but change source files and regenerate instead of editing it directly.
+
+## Civ7 Game Data Locations
+
+The repo resolver for the local game data path lives in
+`packages/plugins/plugin-files/src/index.ts`.
+
+| Platform | Game Data Directory | Deployed Mods Directory |
+|---|---|---|
+| macOS | `~/Library/Application Support/Civilization VII` | `~/Library/Application Support/Civilization VII/Mods/<mod-id>/` |
+| Windows | `%USERPROFILE%/Documents/My Games/Sid Meier's Civilization VII` | `%USERPROFILE%/Documents/My Games/Sid Meier's Civilization VII/Mods/<mod-id>/` |
+| Linux/other | `~/.local/share/civ7` | `~/.local/share/civ7/Mods/<mod-id>/` |
+
+The deploy helper copies the contents of `--input` into
+`<game-data>/Mods/<mod-id>/`.
+
+## Civ7 Logs
+
+| Platform | Logs Directory |
+|---|---|
+| macOS | `~/Library/Application Support/Civilization VII/Logs/` |
+| Windows | `%USERPROFILE%/Documents/My Games/Sid Meier's Civilization VII/Logs/` |
+| Linux/other | `~/.local/share/civ7/Logs/` |
+
+Common files to inspect:
+
+- `Modding.log`: mod discovery, load, and package issues.
+- `Database.log`: XML database import and schema/data errors.
+- `Scripting.log`: map/runtime JavaScript errors and `console.log` output.
+- `Game.log` and `GameCore.log`: game-flow and simulation signals.
+- `Engine.log` and `General.log`: startup/runtime context.
+- `Localization.log`: missing or malformed localization records.
+- `output.log`: broad process output when present.
+
+Always bound log reads to the action under review. Use file mtimes, a pre-run
+snapshot, or a timestamp marker in the notes before treating a line as current.

--- a/.agents/skills/civ7-operational-debugging/references/proof-boundaries.md
+++ b/.agents/skills/civ7-operational-debugging/references/proof-boundaries.md
@@ -1,0 +1,35 @@
+# Proof Boundaries
+
+## Evidence Classes
+
+| Evidence | Proves | Does Not Prove |
+|---|---|---|
+| Typecheck/test | Source-level contracts exercised by that command | Generated output, deployment, or Civ7 runtime behavior |
+| Package build | The package build command completed and emitted expected local artifacts | The mod was deployed, selected, loaded, or executed by Civ7 |
+| Generated `mods/<mod-slug>/mod/` files | Source generation produced local mod files | The deployed copy matches or Civ7 loaded the files |
+| Deploy command | Files were copied into `<game-data>/Mods/<mod-id>/` | Civ7 discovered, enabled, or executed the mod |
+| Deployed file inspection | The OS-level Mods directory contains specific files | The game used those files in a run |
+| Log lines | Civ7 emitted the observed message in the bounded log window | A missing message means the behavior is impossible |
+| In-game observation | The exercised game path behaved as observed | Unexercised maps, settings, eras, or mod combinations behave the same |
+| Official resources | Current game data has the inspected shape | Repo SDK, adapter, MapGen, CLI, or mod policy |
+
+## Closure Labels
+
+Use these labels in final reports and handoffs:
+
+- `built`: the relevant build command completed.
+- `generated`: expected files exist in `mods/<mod-slug>/mod/`.
+- `deployed`: expected files exist in `<game-data>/Mods/<mod-id>/`.
+- `logged`: bounded Civ7 logs contain the named signal.
+- `in-game observed`: the relevant path was exercised inside Civ7.
+- `resource-backed`: official resources support the stated game-data fact.
+- `unresolved`: the available evidence does not prove the claim.
+
+## Claim Discipline
+
+- If only source checks ran, say source checks passed.
+- If a build ran, name the package and artifact inspected.
+- If deploy ran, name the target Mods directory and mod id.
+- If logs were read, name the files and how the log window was bounded.
+- If in-game behavior was checked, name the map/mod/settings path exercised.
+- If official resources were inspected, name the resource files or directories.

--- a/docs/system/libs/mapgen/reference/domains/ECOLOGY.md
+++ b/docs/system/libs/mapgen/reference/domains/ECOLOGY.md
@@ -73,6 +73,8 @@ Ecology domain ops used by the standard recipe are split along the target archit
 - Feature intent planners (truth stage `ecology-features`):
   - Vegetation signals (compute) used by step-owned picking: `computeVegetationSubstrate`, `scoreVegetation*`
   - Other intent planners: `planWetlands`, `planReefs`, `planIce`
+  - Planner-local `policies/` files own score-to-intent admission for each feature family. Do not route
+    feature admission through generic `shared` helpers or projection code.
 - Plot effect planners (truth stage `ecology-features`):
   - `planPlotEffects`
 - Atomic per-feature placement planners (truth stage, disabled-by-default; see config posture):
@@ -90,6 +92,12 @@ Current posture in the standard recipe:
 - knobs are present but currently empty at the stage level.
 
 Key contract point: strategy config schemas stay with their owning op contracts or named op-family modules. The shared Ecology artifact surface is allowed because multiple truth and projection stages consume the same artifact invariants; it is not a dumping ground for strategy-owned config.
+
+Feature scoring and planning stay separate:
+- Score ops produce continuous physical suitability fields. A positive score is not itself a placement command.
+- Planner-local policies decide whether a suitability candidate is strong enough to become an intent.
+- Reef-family habitat eligibility is reef-owned: warm reefs use warm shallow near-coast shelf water, cold reefs use colder deeper shelf/edge water, atolls use isolated warm shallow banks, and `FEATURE_LOTUS` uses warm shallow near-land water.
+- Wetland-family habitat eligibility is wet-feature-owned through named substrate masks: marsh and tundra bog require hydromorphic substrate, mangrove requires intertidal coast, and oasis/watering-hole features require isolated lowland water-source substrate plus arid scoring.
 
 ## Engine projection notes (map-ecology)
 

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/contract.ts
@@ -23,6 +23,21 @@ const FeatureSubstrateConfigSchema = Type.Object(
       default: 1,
       minimum: 0,
     }),
+    lowlandMaxElevationAboveSeaM: Type.Integer({
+      description: "Maximum land elevation above sea level treated as lowland wetland substrate.",
+      default: 160,
+      minimum: 0,
+    }),
+    intertidalMaxElevationAboveSeaM: Type.Integer({
+      description: "Maximum coastal land elevation above sea level treated as intertidal substrate.",
+      default: 40,
+      minimum: 0,
+    }),
+    floodplainDischargeMin: Type.Number({
+      description: "Minimum nearby discharge treated as meaningful floodplain water exchange.",
+      default: 0,
+      minimum: 0,
+    }),
   },
   {
     additionalProperties: false,
@@ -47,6 +62,18 @@ const ComputeFeatureSubstrateContract = defineOp({
       landMask: TypedArraySchemas.u8({
         description: "Land mask per tile (1=land, 0=water).",
       }),
+      elevation: TypedArraySchemas.i16({
+        description: "Elevation in meters, using the same datum as seaLevel.",
+      }),
+      seaLevel: Type.Number({
+        description: "Global sea-level datum in meters.",
+      }),
+      discharge: TypedArraySchemas.f32({
+        description: "Hydrology discharge proxy per tile.",
+      }),
+      sinkMask: TypedArraySchemas.u8({
+        description: "Mask (1/0): local drainage sink or depression.",
+      }),
     },
     { additionalProperties: false }
   ),
@@ -63,6 +90,27 @@ const ComputeFeatureSubstrateContract = defineOp({
     coastalLandMask: TypedArraySchemas.u8({
       description: "Mask (1/0): land tiles within coastalAdjacencyRadius of any water tile.",
     }),
+    lowlandMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): land tiles close enough to sea level for wetland substrate.",
+    }),
+    floodplainMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): lowland land with nearby meaningful river water exchange.",
+    }),
+    intertidalCoastMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): low coastal land adjacent to water.",
+    }),
+    sinkBasinMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): lowland drainage sinks/depressions.",
+    }),
+    hydromorphicMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): floodplain, intertidal, or sink-basin wetland substrate.",
+    }),
+    wellDrainedMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): land outside hydromorphic substrate.",
+    }),
+    isolatedWaterPointMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): isolated lowland water-point substrate for arid wet features.",
+    }),
   }),
   strategies: {
     default: FeatureSubstrateConfigSchema,
@@ -70,4 +118,3 @@ const ComputeFeatureSubstrateContract = defineOp({
 });
 
 export default ComputeFeatureSubstrateContract;
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/policies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/policies/index.ts
@@ -1,0 +1,1 @@
+export { computeWetlandSubstrateMasks } from "./wetland-substrate-masks.js";

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/policies/wetland-substrate-masks.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/policies/wetland-substrate-masks.ts
@@ -1,0 +1,130 @@
+export type WetlandSubstrateMasks = Readonly<{
+  lowlandMask: Uint8Array;
+  floodplainMask: Uint8Array;
+  intertidalCoastMask: Uint8Array;
+  sinkBasinMask: Uint8Array;
+  hydromorphicMask: Uint8Array;
+  wellDrainedMask: Uint8Array;
+  isolatedWaterPointMask: Uint8Array;
+}>;
+
+/**
+ * Wet features need waterlogged or water-source substrate before climate can
+ * choose a feature identity. These masks encode that policy once at the feature
+ * substrate owner so marsh, bog, mangrove, oasis, and watering-hole scoring do
+ * not each invent a different hydrology/topography proxy.
+ */
+export function computeWetlandSubstrateMasks(args: Readonly<{
+  width: number;
+  height: number;
+  landMask: Uint8Array;
+  elevation: Int16Array;
+  seaLevel: number;
+  riverClass: Uint8Array;
+  discharge: Float32Array;
+  sinkMask: Uint8Array;
+  nearRiverMask: Uint8Array;
+  isolatedRiverMask: Uint8Array;
+  coastalLandMask: Uint8Array;
+  nearRiverRadius: number;
+  lowlandMaxElevationAboveSeaM: number;
+  intertidalMaxElevationAboveSeaM: number;
+  floodplainDischargeMin: number;
+}>): WetlandSubstrateMasks {
+  const width = args.width | 0;
+  const height = args.height | 0;
+  const size = Math.max(0, width * height);
+  const riverRadius = Math.max(0, args.nearRiverRadius | 0);
+  const lowlandMax = Math.max(0, args.lowlandMaxElevationAboveSeaM | 0);
+  const intertidalMax = Math.max(0, args.intertidalMaxElevationAboveSeaM | 0);
+  const dischargeMin = Math.max(0, args.floodplainDischargeMin);
+
+  const lowlandMask = new Uint8Array(size);
+  const floodplainMask = new Uint8Array(size);
+  const intertidalCoastMask = new Uint8Array(size);
+  const sinkBasinMask = new Uint8Array(size);
+  const hydromorphicMask = new Uint8Array(size);
+  const wellDrainedMask = new Uint8Array(size);
+  const isolatedWaterPointMask = new Uint8Array(size);
+
+  for (let y = 0; y < height; y++) {
+    const y0 = Math.max(0, y - riverRadius);
+    const y1 = Math.min(height - 1, y + riverRadius);
+    for (let x = 0; x < width; x++) {
+      const i = y * width + x;
+      if (args.landMask[i] !== 1) continue;
+
+      const heightAboveSeaM = (args.elevation[i] ?? 0) - args.seaLevel;
+      const isLowland = heightAboveSeaM >= 0 && heightAboveSeaM <= lowlandMax;
+      lowlandMask[i] = isLowland ? 1 : 0;
+
+      const isIntertidal =
+        args.coastalLandMask[i] === 1 &&
+        heightAboveSeaM >= 0 &&
+        heightAboveSeaM <= intertidalMax;
+      intertidalCoastMask[i] = isIntertidal ? 1 : 0;
+
+      const hasNearbyFlow = hasRiverFlowNear({
+        x,
+        y,
+        width,
+        x0: Math.max(0, x - riverRadius),
+        x1: Math.min(width - 1, x + riverRadius),
+        y0,
+        y1,
+        riverClass: args.riverClass,
+        discharge: args.discharge,
+        dischargeMin,
+      });
+      const isFloodplain = isLowland && args.nearRiverMask[i] === 1 && hasNearbyFlow;
+      floodplainMask[i] = isFloodplain ? 1 : 0;
+
+      const isSinkBasin = isLowland && args.sinkMask[i] === 1;
+      sinkBasinMask[i] = isSinkBasin ? 1 : 0;
+
+      const hydromorphic = isFloodplain || isIntertidal || isSinkBasin;
+      hydromorphicMask[i] = hydromorphic ? 1 : 0;
+      wellDrainedMask[i] = hydromorphic ? 0 : 1;
+
+      // Oases and watering holes are point-scale arid water-source candidates:
+      // isolated river influence is allowed, but broad floodplains are not.
+      isolatedWaterPointMask[i] =
+        (isLowland && args.isolatedRiverMask[i] === 1 && !isFloodplain) || isSinkBasin ? 1 : 0;
+    }
+  }
+
+  return {
+    lowlandMask,
+    floodplainMask,
+    intertidalCoastMask,
+    sinkBasinMask,
+    hydromorphicMask,
+    wellDrainedMask,
+    isolatedWaterPointMask,
+  };
+}
+
+function hasRiverFlowNear(args: Readonly<{
+  x: number;
+  y: number;
+  width: number;
+  x0: number;
+  x1: number;
+  y0: number;
+  y1: number;
+  riverClass: Uint8Array;
+  discharge: Float32Array;
+  dischargeMin: number;
+}>): boolean {
+  for (let ny = args.y0; ny <= args.y1; ny++) {
+    const row = ny * args.width;
+    for (let nx = args.x0; nx <= args.x1; nx++) {
+      const idx = row + nx;
+      if ((args.riverClass[idx] ?? 0) === 0) continue;
+      if (args.dischargeMin <= 0 || (args.discharge[idx] ?? 0) >= args.dischargeMin) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/rules/validate.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/rules/validate.ts
@@ -3,6 +3,9 @@ type ComputeInputs = Readonly<{
   height: number;
   riverClass: Uint8Array;
   landMask: Uint8Array;
+  elevation: Int16Array;
+  discharge: Float32Array;
+  sinkMask: Uint8Array;
 }>;
 
 export function validateFeatureSubstrateInputs(input: ComputeInputs): number {
@@ -16,7 +19,15 @@ export function validateFeatureSubstrateInputs(input: ComputeInputs): number {
   if (!(input.landMask instanceof Uint8Array) || input.landMask.length !== size) {
     throw new Error("[Ecology] Invalid landMask for compute-feature-substrate.");
   }
+  if (!(input.elevation instanceof Int16Array) || input.elevation.length !== size) {
+    throw new Error("[Ecology] Invalid elevation for compute-feature-substrate.");
+  }
+  if (!(input.discharge instanceof Float32Array) || input.discharge.length !== size) {
+    throw new Error("[Ecology] Invalid discharge for compute-feature-substrate.");
+  }
+  if (!(input.sinkMask instanceof Uint8Array) || input.sinkMask.length !== size) {
+    throw new Error("[Ecology] Invalid sinkMask for compute-feature-substrate.");
+  }
 
   return size;
 }
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/compute-feature-substrate/strategies/default.ts
@@ -1,6 +1,7 @@
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 
 import ComputeFeatureSubstrateContract from "../contract.js";
+import { computeWetlandSubstrateMasks } from "../policies/index.js";
 import {
   computeCoastalLandMask,
   computeNavigableRiverMask,
@@ -15,12 +16,18 @@ export const defaultStrategy = createStrategy(ComputeFeatureSubstrateContract, "
       height: input.height,
       riverClass: input.riverClass as Uint8Array,
       landMask: input.landMask as Uint8Array,
+      elevation: input.elevation as Int16Array,
+      discharge: input.discharge as Float32Array,
+      sinkMask: input.sinkMask as Uint8Array,
     });
 
     const width = input.width | 0;
     const height = input.height | 0;
     const riverClass = input.riverClass as Uint8Array;
     const landMask = input.landMask as Uint8Array;
+    const elevation = input.elevation as Int16Array;
+    const discharge = input.discharge as Float32Array;
+    const sinkMask = input.sinkMask as Uint8Array;
 
     const navigableRiverMask = computeNavigableRiverMask({
       size,
@@ -49,7 +56,30 @@ export const defaultStrategy = createStrategy(ComputeFeatureSubstrateContract, "
       radius: config.coastalAdjacencyRadius,
     });
 
-    return { navigableRiverMask, nearRiverMask, isolatedRiverMask, coastalLandMask };
+    const wetlandSubstrate = computeWetlandSubstrateMasks({
+      width,
+      height,
+      landMask,
+      elevation,
+      seaLevel: input.seaLevel,
+      riverClass,
+      discharge,
+      sinkMask,
+      nearRiverMask,
+      isolatedRiverMask,
+      coastalLandMask,
+      nearRiverRadius: config.nearRiverRadius,
+      lowlandMaxElevationAboveSeaM: config.lowlandMaxElevationAboveSeaM,
+      intertidalMaxElevationAboveSeaM: config.intertidalMaxElevationAboveSeaM,
+      floodplainDischargeMin: config.floodplainDischargeMin,
+    });
+
+    return {
+      navigableRiverMask,
+      nearRiverMask,
+      isolatedRiverMask,
+      coastalLandMask,
+      ...wetlandSubstrate,
+    };
   },
 });
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/policies/admit-ice-intent.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/policies/admit-ice-intent.ts
@@ -1,0 +1,9 @@
+/**
+ * Ice planning should mark strong freeze evidence, not every tile with a
+ * non-zero coldness score. This local policy keeps ice admission attached to
+ * the ice feature family instead of making Ecology route through shared
+ * feature-planner machinery.
+ */
+export function admitIceIntent(candidate: Readonly<{ confidence01: number }>): boolean {
+  return candidate.confidence01 > 0.5;
+}

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/policies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/policies/index.ts
@@ -1,0 +1,1 @@
+export { admitIceIntent } from "./admit-ice-intent.js";

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/strategies/continentality.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/strategies/continentality.ts
@@ -5,6 +5,7 @@ import {
   validateGridSize,
 } from "../../score-shared/index.js";
 import PlanIceContract from "../contract.js";
+import { admitIceIntent } from "../policies/index.js";
 
 export const continentalityStrategy = createStrategy(PlanIceContract, "continentality", {
   run: (input, config) => {
@@ -29,7 +30,7 @@ export const continentalityStrategy = createStrategy(PlanIceContract, "continent
       if (input.featureIndex[i] !== 0) continue;
       const score = input.score01[i] ?? 0;
       const confidence01 = confidenceFromScore01(score);
-      if (confidence01 <= 0) continue;
+      if (!admitIceIntent({ confidence01 })) continue;
       const x = i % width;
       const y = (i / width) | 0;
       placements.push({ x, y, feature: "FEATURE_ICE" });

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/strategies/default.ts
@@ -5,6 +5,7 @@ import {
   validateGridSize,
 } from "../../score-shared/index.js";
 import PlanIceContract from "../contract.js";
+import { admitIceIntent } from "../policies/index.js";
 
 export const defaultStrategy = createStrategy(PlanIceContract, "default", {
   run: (input, config) => {
@@ -29,7 +30,7 @@ export const defaultStrategy = createStrategy(PlanIceContract, "default", {
       if (input.featureIndex[i] !== 0) continue;
       const score = input.score01[i] ?? 0;
       const confidence01 = confidenceFromScore01(score);
-      if (confidence01 <= 0) continue;
+      if (!admitIceIntent({ confidence01 })) continue;
       const x = i % width;
       const y = (i / width) | 0;
       placements.push({ x, y, feature: "FEATURE_ICE" });

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/policies/admit-reef-intent.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/policies/admit-reef-intent.ts
@@ -1,0 +1,9 @@
+/**
+ * Reef planning scores describe broad ocean suitability; they are not placement
+ * commands by themselves. This policy keeps the reef-family intent threshold
+ * with the reef planner so atoll, warm reef, cold reef, and lotus behavior can
+ * evolve with reef habitat physics instead of routing through a generic helper.
+ */
+export function admitReefIntent(candidate: Readonly<{ confidence01: number }>): boolean {
+  return candidate.confidence01 > 0.5;
+}

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/policies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/policies/index.ts
@@ -1,0 +1,1 @@
+export { admitReefIntent } from "./admit-reef-intent.js";

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/strategies/default.ts
@@ -7,6 +7,7 @@ import {
   validateGridSize,
 } from "../../score-shared/index.js";
 import PlanReefsContract from "../contract.js";
+import { admitReefIntent } from "../policies/index.js";
 
 export const defaultStrategy = createStrategy(PlanReefsContract, "default", {
   run: (input, config) => {
@@ -70,7 +71,7 @@ export const defaultStrategy = createStrategy(PlanReefsContract, "default", {
         },
       ]);
       if (best === null) continue;
-      if (best.confidence01 <= 0) continue;
+      if (!admitReefIntent(best)) continue;
 
       const x = i % width;
       const y = (i / width) | 0;

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/strategies/shipping-lanes.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/strategies/shipping-lanes.ts
@@ -7,6 +7,7 @@ import {
   validateGridSize,
 } from "../../score-shared/index.js";
 import PlanReefsContract from "../contract.js";
+import { admitReefIntent } from "../policies/index.js";
 
 export const shippingLanesStrategy = createStrategy(PlanReefsContract, "shipping-lanes", {
   run: (input, config) => {
@@ -70,7 +71,7 @@ export const shippingLanesStrategy = createStrategy(PlanReefsContract, "shipping
         },
       ]);
       if (best === null) continue;
-      if (best.confidence01 <= 0) continue;
+      if (!admitReefIntent(best)) continue;
 
       const x = i % width;
       const y = (i / width) | 0;

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/policies/admit-vegetation-intent.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/policies/admit-vegetation-intent.ts
@@ -1,0 +1,9 @@
+/**
+ * Vegetation layers are continuous biome suitability fields. Keeping the
+ * score-to-intent policy beside vegetation planning prevents every marginal
+ * land tile from becoming forest-like cover while leaving vegetation-specific
+ * habitat tradeoffs in this family.
+ */
+export function admitVegetationIntent(candidate: Readonly<{ confidence01: number }>): boolean {
+  return candidate.confidence01 > 0.12;
+}

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/policies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/policies/index.ts
@@ -1,0 +1,1 @@
+export { admitVegetationIntent } from "./admit-vegetation-intent.js";

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/strategies/default.ts
@@ -7,6 +7,7 @@ import {
   validateGridSize,
 } from "../../score-shared/index.js";
 import PlanVegetationContract from "../contract.js";
+import { admitVegetationIntent } from "../policies/index.js";
 
 export const defaultStrategy = createStrategy(PlanVegetationContract, "default", {
   run: (input, config) => {
@@ -81,7 +82,7 @@ export const defaultStrategy = createStrategy(PlanVegetationContract, "default",
         },
       ]);
       if (best === null) continue;
-      if (best.confidence01 <= 0) continue;
+      if (!admitVegetationIntent(best)) continue;
 
       const x = i % width;
       const y = (i / width) | 0;

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-wetlands/policies/admit-wetland-intent.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-wetlands/policies/admit-wetland-intent.ts
@@ -1,0 +1,9 @@
+/**
+ * Wetland scores combine hydrology, relief, and climate signals. A weak
+ * positive score can still describe a broadly moist tile, so the wetland
+ * planner owns the final admission policy before marsh, bog, mangrove, oasis,
+ * or watering-hole intents can claim occupancy.
+ */
+export function admitWetlandIntent(candidate: Readonly<{ confidence01: number }>): boolean {
+  return candidate.confidence01 > 0.12;
+}

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-wetlands/policies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-wetlands/policies/index.ts
@@ -1,0 +1,1 @@
+export { admitWetlandIntent } from "./admit-wetland-intent.js";

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-wetlands/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-wetlands/strategies/default.ts
@@ -7,6 +7,7 @@ import {
   validateGridSize,
 } from "../../score-shared/index.js";
 import PlanWetlandsContract from "../contract.js";
+import { admitWetlandIntent } from "../policies/index.js";
 
 export const defaultStrategy = createStrategy(PlanWetlandsContract, "default", {
   run: (input, config) => {
@@ -79,7 +80,7 @@ export const defaultStrategy = createStrategy(PlanWetlandsContract, "default", {
         },
       ]);
       if (best === null) continue;
-      if (best.confidence01 <= 0) continue;
+      if (!admitWetlandIntent(best)) continue;
 
       const x = i % width;
       const y = (i / width) | 0;

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-atoll/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-atoll/contract.ts
@@ -11,6 +11,9 @@ const ScoreAtollContract = defineOp({
     bathymetry: TypedArraySchemas.i16({
       description: "Bathymetry in meters (0 on land; <=0 in water; more negative is deeper).",
     }),
+    shelfMask: TypedArraySchemas.u8({ description: "Mask (1/0): water tile is on shallow shelf or bank." }),
+    coastalWater: TypedArraySchemas.u8({ description: "Mask (1/0): water tile is adjacent to existing land." }),
+    distanceToCoast: TypedArraySchemas.u16({ description: "Tile distance from nearest coast." }),
   }),
   output: Type.Object({
     score01: TypedArraySchemas.f32({ description: "Atoll suitability score per tile (0..1)." }),
@@ -19,11 +22,11 @@ const ScoreAtollContract = defineOp({
     default: Type.Object({
       tempWarmStartC: Type.Number({ default: 18 }),
       tempWarmEndC: Type.Number({ default: 30 }),
-      shallowDepthM: Type.Integer({ default: 80 }),
-      deepDepthM: Type.Integer({ default: 500 }),
+      shallowDepthM: Type.Integer({ default: 0 }),
+      deepDepthM: Type.Integer({ default: 100 }),
+      minDistanceToCoast: Type.Integer({ default: 4, minimum: 0 }),
     }),
   },
 });
 
 export default ScoreAtollContract;
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-atoll/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-atoll/strategies/default.ts
@@ -13,6 +13,9 @@ export const defaultStrategy = createStrategy(ScoreAtollContract, "default", {
         { label: "landMask", arr: input.landMask as Uint8Array },
         { label: "surfaceTemperature", arr: input.surfaceTemperature as Float32Array },
         { label: "bathymetry", arr: input.bathymetry as Int16Array },
+        { label: "shelfMask", arr: input.shelfMask as Uint8Array },
+        { label: "coastalWater", arr: input.coastalWater as Uint8Array },
+        { label: "distanceToCoast", arr: input.distanceToCoast as Uint16Array },
       ],
     });
 
@@ -20,10 +23,16 @@ export const defaultStrategy = createStrategy(ScoreAtollContract, "default", {
 
     const shallowDepthM = Math.max(0, config.shallowDepthM | 0);
     const deepDepthM = Math.max(shallowDepthM + 1, config.deepDepthM | 0);
+    const minDistanceToCoast = Math.max(0, config.minDistanceToCoast | 0);
 
     for (let i = 0; i < size; i++) {
       if (input.landMask[i] !== 0) continue;
+      if (input.shelfMask[i] !== 1) continue;
+      if (input.coastalWater[i] !== 0) continue;
+      if ((input.distanceToCoast[i] ?? 0) < minDistanceToCoast) continue;
 
+      // Atolls are isolated warm shallow banks, not every warm coastal reef
+      // tile. The coast-distance gate keeps them out of fringing reef habitat.
       const warmSuit = rampUp01(
         input.surfaceTemperature[i],
         config.tempWarmStartC,
@@ -39,4 +48,3 @@ export const defaultStrategy = createStrategy(ScoreAtollContract, "default", {
     return { score01 };
   },
 });
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-cold-reef/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-cold-reef/contract.ts
@@ -11,6 +11,9 @@ const ScoreColdReefContract = defineOp({
     bathymetry: TypedArraySchemas.i16({
       description: "Bathymetry in meters (0 on land; <=0 in water; more negative is deeper).",
     }),
+    shelfMask: TypedArraySchemas.u8({ description: "Mask (1/0): water tile is on continental shelf or edge." }),
+    coastalWater: TypedArraySchemas.u8({ description: "Mask (1/0): water tile is adjacent to land." }),
+    distanceToCoast: TypedArraySchemas.u16({ description: "Tile distance from nearest coast." }),
   }),
   output: Type.Object({
     score01: TypedArraySchemas.f32({ description: "Cold reef suitability score per tile (0..1)." }),
@@ -19,11 +22,12 @@ const ScoreColdReefContract = defineOp({
     default: Type.Object({
       tempColdMaxC: Type.Number({ default: 10 }),
       tempWarmMaxC: Type.Number({ default: 20 }),
-      shallowDepthM: Type.Integer({ default: 150 }),
-      deepDepthM: Type.Integer({ default: 1200 }),
+      minDepthM: Type.Integer({ default: 45 }),
+      peakDepthM: Type.Integer({ default: 300 }),
+      maxDepthM: Type.Integer({ default: 1200 }),
+      minDistanceToCoast: Type.Integer({ default: 1, minimum: 0 }),
     }),
   },
 });
 
 export default ScoreColdReefContract;
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-cold-reef/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-cold-reef/strategies/default.ts
@@ -1,7 +1,7 @@
 import { clamp01 } from "@swooper/mapgen-core";
 import { createStrategy } from "@swooper/mapgen-core/authoring";
 
-import { rampDown01, validateGridSize } from "../../score-shared/index.js";
+import { rampDown01, validateGridSize, window01 } from "../../score-shared/index.js";
 import ScoreColdReefContract from "../contract.js";
 
 export const defaultStrategy = createStrategy(ScoreColdReefContract, "default", {
@@ -13,17 +13,26 @@ export const defaultStrategy = createStrategy(ScoreColdReefContract, "default", 
         { label: "landMask", arr: input.landMask as Uint8Array },
         { label: "surfaceTemperature", arr: input.surfaceTemperature as Float32Array },
         { label: "bathymetry", arr: input.bathymetry as Int16Array },
+        { label: "shelfMask", arr: input.shelfMask as Uint8Array },
+        { label: "coastalWater", arr: input.coastalWater as Uint8Array },
+        { label: "distanceToCoast", arr: input.distanceToCoast as Uint16Array },
       ],
     });
 
     const score01 = new Float32Array(size);
 
-    const shallowDepthM = Math.max(0, config.shallowDepthM | 0);
-    const deepDepthM = Math.max(shallowDepthM + 1, config.deepDepthM | 0);
+    const minDepthM = Math.max(0, config.minDepthM | 0);
+    const peakDepthM = Math.max(minDepthM + 1, config.peakDepthM | 0);
+    const maxDepthM = Math.max(peakDepthM + 1, config.maxDepthM | 0);
+    const minDistanceToCoast = Math.max(0, config.minDistanceToCoast | 0);
 
     for (let i = 0; i < size; i++) {
       if (input.landMask[i] !== 0) continue;
+      if (input.shelfMask[i] !== 1) continue;
+      if ((input.distanceToCoast[i] ?? 0) < minDistanceToCoast) continue;
 
+      // Cold-water reefs are deeper shelf/edge habitats. They should not be a
+      // cold relabeling of shallow coastal warm-reef logic.
       const coldSuit = rampDown01(
         input.surfaceTemperature[i],
         config.tempColdMaxC,
@@ -31,12 +40,11 @@ export const defaultStrategy = createStrategy(ScoreColdReefContract, "default", 
       );
 
       const depth = Math.max(0, -(input.bathymetry[i] | 0));
-      const shallowSuit = rampDown01(depth, shallowDepthM, deepDepthM);
+      const depthSuit = window01(depth, minDepthM, peakDepthM, maxDepthM);
 
-      score01[i] = clamp01(coldSuit * shallowSuit);
+      score01[i] = clamp01(coldSuit * depthSuit);
     }
 
     return { score01 };
   },
 });
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-lotus/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-lotus/contract.ts
@@ -11,6 +11,9 @@ const ScoreLotusContract = defineOp({
     bathymetry: TypedArraySchemas.i16({
       description: "Bathymetry in meters (0 on land; <=0 in water; more negative is deeper).",
     }),
+    shelfMask: TypedArraySchemas.u8({ description: "Mask (1/0): water tile is on shallow shelf." }),
+    coastalWater: TypedArraySchemas.u8({ description: "Mask (1/0): water tile is adjacent to land." }),
+    distanceToCoast: TypedArraySchemas.u16({ description: "Tile distance from nearest coast." }),
   }),
   output: Type.Object({
     score01: TypedArraySchemas.f32({ description: "Lotus suitability score per tile (0..1)." }),
@@ -19,11 +22,11 @@ const ScoreLotusContract = defineOp({
     default: Type.Object({
       tempWarmStartC: Type.Number({ default: 16 }),
       tempWarmEndC: Type.Number({ default: 32 }),
-      shallowDepthM: Type.Integer({ default: 40 }),
-      deepDepthM: Type.Integer({ default: 350 }),
+      shallowDepthM: Type.Integer({ default: 0 }),
+      deepDepthM: Type.Integer({ default: 40 }),
+      maxDistanceToCoast: Type.Integer({ default: 2, minimum: 0 }),
     }),
   },
 });
 
 export default ScoreLotusContract;
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-lotus/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-lotus/strategies/default.ts
@@ -13,6 +13,9 @@ export const defaultStrategy = createStrategy(ScoreLotusContract, "default", {
         { label: "landMask", arr: input.landMask as Uint8Array },
         { label: "surfaceTemperature", arr: input.surfaceTemperature as Float32Array },
         { label: "bathymetry", arr: input.bathymetry as Int16Array },
+        { label: "shelfMask", arr: input.shelfMask as Uint8Array },
+        { label: "coastalWater", arr: input.coastalWater as Uint8Array },
+        { label: "distanceToCoast", arr: input.distanceToCoast as Uint16Array },
       ],
     });
 
@@ -20,10 +23,16 @@ export const defaultStrategy = createStrategy(ScoreLotusContract, "default", {
 
     const shallowDepthM = Math.max(0, config.shallowDepthM | 0);
     const deepDepthM = Math.max(shallowDepthM + 1, config.deepDepthM | 0);
+    const maxDistanceToCoast = Math.max(0, config.maxDistanceToCoast | 0);
 
     for (let i = 0; i < size; i++) {
       if (input.landMask[i] !== 0) continue;
+      if (input.shelfMask[i] !== 1) continue;
+      if (input.coastalWater[i] !== 1) continue;
+      if ((input.distanceToCoast[i] ?? 0) > maxDistanceToCoast) continue;
 
+      // Lotus is a shallow near-land water feature; it should not claim the
+      // isolated-bank habitat that atolls use.
       const warmSuit = rampUp01(
         input.surfaceTemperature[i],
         config.tempWarmStartC,
@@ -39,4 +48,3 @@ export const defaultStrategy = createStrategy(ScoreLotusContract, "default", {
     return { score01 };
   },
 });
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-reef/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-reef/contract.ts
@@ -11,6 +11,9 @@ const ScoreReefContract = defineOp({
     bathymetry: TypedArraySchemas.i16({
       description: "Bathymetry in meters (0 on land; <=0 in water; more negative is deeper).",
     }),
+    shelfMask: TypedArraySchemas.u8({ description: "Mask (1/0): water tile is on continental shelf." }),
+    coastalWater: TypedArraySchemas.u8({ description: "Mask (1/0): water tile is adjacent to land." }),
+    distanceToCoast: TypedArraySchemas.u16({ description: "Tile distance from nearest coast." }),
   }),
   output: Type.Object({
     score01: TypedArraySchemas.f32({ description: "Reef suitability score per tile (0..1)." }),
@@ -19,11 +22,11 @@ const ScoreReefContract = defineOp({
     default: Type.Object({
       tempWarmStartC: Type.Number({ default: 14 }),
       tempWarmEndC: Type.Number({ default: 28 }),
-      shallowDepthM: Type.Integer({ default: 150 }),
-      deepDepthM: Type.Integer({ default: 1200 }),
+      shallowDepthM: Type.Integer({ default: 0 }),
+      deepDepthM: Type.Integer({ default: 120 }),
+      maxDistanceToCoast: Type.Integer({ default: 3, minimum: 0 }),
     }),
   },
 });
 
 export default ScoreReefContract;
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-reef/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-reef/strategies/default.ts
@@ -13,6 +13,9 @@ export const defaultStrategy = createStrategy(ScoreReefContract, "default", {
         { label: "landMask", arr: input.landMask as Uint8Array },
         { label: "surfaceTemperature", arr: input.surfaceTemperature as Float32Array },
         { label: "bathymetry", arr: input.bathymetry as Int16Array },
+        { label: "shelfMask", arr: input.shelfMask as Uint8Array },
+        { label: "coastalWater", arr: input.coastalWater as Uint8Array },
+        { label: "distanceToCoast", arr: input.distanceToCoast as Uint16Array },
       ],
     });
 
@@ -20,10 +23,16 @@ export const defaultStrategy = createStrategy(ScoreReefContract, "default", {
 
     const shallowDepthM = Math.max(0, config.shallowDepthM | 0);
     const deepDepthM = Math.max(shallowDepthM + 1, config.deepDepthM | 0);
+    const maxDistanceToCoast = Math.max(0, config.maxDistanceToCoast | 0);
 
     for (let i = 0; i < size; i++) {
       if (input.landMask[i] !== 0) continue;
+      if (input.shelfMask[i] !== 1) continue;
+      if (input.coastalWater[i] !== 1) continue;
+      if ((input.distanceToCoast[i] ?? 0) > maxDistanceToCoast) continue;
 
+      // Reef-building corals need warm, shallow, near-coast shelf water; broad
+      // tropical ocean suitability must not become a blanket reef intent field.
       const warmSuit = rampUp01(
         input.surfaceTemperature[i],
         config.tempWarmStartC,
@@ -39,4 +48,3 @@ export const defaultStrategy = createStrategy(ScoreReefContract, "default", {
     return { score01 };
   },
 });
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/score-shared/index.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/score-shared/index.ts
@@ -73,7 +73,3 @@ export function choosePhysicalCandidate<T extends string>(
   }
   return best;
 }
-
-export function confidenceBeatsStress(candidate: Readonly<{ confidence01: number; stress01: number }>): boolean {
-  return candidate.confidence01 > candidate.stress01;
-}

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-mangrove/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-mangrove/contract.ts
@@ -7,7 +7,9 @@ const ScoreWetMangroveContract = defineOp({
     width: Type.Integer({ minimum: 1 }),
     height: Type.Integer({ minimum: 1 }),
     landMask: TypedArraySchemas.u8({ description: "Land mask (1 = land, 0 = water)." }),
-    coastalLandMask: TypedArraySchemas.u8({ description: "Mask (1/0): land tiles adjacent to water." }),
+    intertidalCoastMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): low coastal land adjacent to water.",
+    }),
     water01: TypedArraySchemas.f32({ description: "Water availability proxy (0..1)." }),
     fertility01: TypedArraySchemas.f32({ description: "Fertility proxy (0..1)." }),
     surfaceTemperature: TypedArraySchemas.f32({ description: "Surface temperature (C)." }),
@@ -28,4 +30,3 @@ const ScoreWetMangroveContract = defineOp({
 });
 
 export default ScoreWetMangroveContract;
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-mangrove/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-mangrove/strategies/default.ts
@@ -11,7 +11,7 @@ export const defaultStrategy = createStrategy(ScoreWetMangroveContract, "default
       height: input.height,
       fields: [
         { label: "landMask", arr: input.landMask as Uint8Array },
-        { label: "coastalLandMask", arr: input.coastalLandMask as Uint8Array },
+        { label: "intertidalCoastMask", arr: input.intertidalCoastMask as Uint8Array },
         { label: "water01", arr: input.water01 as Float32Array },
         { label: "fertility01", arr: input.fertility01 as Float32Array },
         { label: "surfaceTemperature", arr: input.surfaceTemperature as Float32Array },
@@ -23,8 +23,10 @@ export const defaultStrategy = createStrategy(ScoreWetMangroveContract, "default
 
     for (let i = 0; i < size; i++) {
       if (input.landMask[i] === 0) continue;
-      if (input.coastalLandMask[i] === 0) continue;
+      if (input.intertidalCoastMask[i] === 0) continue;
 
+      // Mangroves are warm intertidal coast features, not generic humid coastal
+      // vegetation. The substrate gate owns the tidal/low-coast proxy.
       const warmSuit = rampUp01(
         input.surfaceTemperature[i],
         config.tempWarmStartC,
@@ -40,4 +42,3 @@ export const defaultStrategy = createStrategy(ScoreWetMangroveContract, "default
     return { score01 };
   },
 });
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-marsh/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-marsh/contract.ts
@@ -7,7 +7,9 @@ const ScoreWetMarshContract = defineOp({
     width: Type.Integer({ minimum: 1 }),
     height: Type.Integer({ minimum: 1 }),
     landMask: TypedArraySchemas.u8({ description: "Land mask (1 = land, 0 = water)." }),
-    nearRiverMask: TypedArraySchemas.u8({ description: "Mask (1/0): tiles near any river." }),
+    hydromorphicMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): floodplain, sink-basin, or intertidal wetland substrate.",
+    }),
     water01: TypedArraySchemas.f32({ description: "Water availability proxy (0..1)." }),
     fertility01: TypedArraySchemas.f32({ description: "Fertility proxy (0..1)." }),
     surfaceTemperature: TypedArraySchemas.f32({ description: "Surface temperature (C)." }),
@@ -29,4 +31,3 @@ const ScoreWetMarshContract = defineOp({
 });
 
 export default ScoreWetMarshContract;
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-marsh/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-marsh/strategies/default.ts
@@ -11,7 +11,7 @@ export const defaultStrategy = createStrategy(ScoreWetMarshContract, "default", 
       height: input.height,
       fields: [
         { label: "landMask", arr: input.landMask as Uint8Array },
-        { label: "nearRiverMask", arr: input.nearRiverMask as Uint8Array },
+        { label: "hydromorphicMask", arr: input.hydromorphicMask as Uint8Array },
         { label: "water01", arr: input.water01 as Float32Array },
         { label: "fertility01", arr: input.fertility01 as Float32Array },
         { label: "surfaceTemperature", arr: input.surfaceTemperature as Float32Array },
@@ -23,8 +23,10 @@ export const defaultStrategy = createStrategy(ScoreWetMarshContract, "default", 
 
     for (let i = 0; i < size; i++) {
       if (input.landMask[i] === 0) continue;
-      if (input.nearRiverMask[i] === 0) continue;
+      if (input.hydromorphicMask[i] === 0) continue;
 
+      // Marshes are waterlogged landforms first and humid biomes second; this
+      // gate stops broad moisture from painting well-drained land as marsh.
       const waterSuit = rampUp01(input.water01[i], config.waterMin01, 1);
       const fertilitySuit = rampUp01(input.fertility01[i], config.fertilityMin01, 1);
       const tempSuit = window01(
@@ -41,4 +43,3 @@ export const defaultStrategy = createStrategy(ScoreWetMarshContract, "default", 
     return { score01 };
   },
 });
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-oasis/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-oasis/contract.ts
@@ -7,7 +7,9 @@ const ScoreWetOasisContract = defineOp({
     width: Type.Integer({ minimum: 1 }),
     height: Type.Integer({ minimum: 1 }),
     landMask: TypedArraySchemas.u8({ description: "Land mask (1 = land, 0 = water)." }),
-    isolatedRiverMask: TypedArraySchemas.u8({ description: "Mask (1/0): tiles near isolated rivers." }),
+    isolatedWaterPointMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): isolated lowland water-source substrate.",
+    }),
     water01: TypedArraySchemas.f32({ description: "Water availability proxy (0..1)." }),
     aridityIndex: TypedArraySchemas.f32({ description: "Aridity index (0..1)." }),
     surfaceTemperature: TypedArraySchemas.f32({ description: "Surface temperature (C)." }),
@@ -19,7 +21,7 @@ const ScoreWetOasisContract = defineOp({
     default: Type.Object({
       dryMin01: Type.Number({ default: 0.6, minimum: 0, maximum: 1 }),
       dryMax01: Type.Number({ default: 0.95, minimum: 0, maximum: 1 }),
-      lowWaterMin01: Type.Number({ default: 0.55, minimum: 0, maximum: 1 }),
+      waterMin01: Type.Number({ default: 0.35, minimum: 0, maximum: 1 }),
       tempWarmStartC: Type.Number({ default: 20 }),
       tempWarmEndC: Type.Number({ default: 38 }),
     }),
@@ -27,4 +29,3 @@ const ScoreWetOasisContract = defineOp({
 });
 
 export default ScoreWetOasisContract;
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-oasis/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-oasis/strategies/default.ts
@@ -11,7 +11,7 @@ export const defaultStrategy = createStrategy(ScoreWetOasisContract, "default", 
       height: input.height,
       fields: [
         { label: "landMask", arr: input.landMask as Uint8Array },
-        { label: "isolatedRiverMask", arr: input.isolatedRiverMask as Uint8Array },
+        { label: "isolatedWaterPointMask", arr: input.isolatedWaterPointMask as Uint8Array },
         { label: "water01", arr: input.water01 as Float32Array },
         { label: "aridityIndex", arr: input.aridityIndex as Float32Array },
         { label: "surfaceTemperature", arr: input.surfaceTemperature as Float32Array },
@@ -22,20 +22,21 @@ export const defaultStrategy = createStrategy(ScoreWetOasisContract, "default", 
 
     for (let i = 0; i < size; i++) {
       if (input.landMask[i] === 0) continue;
-      if (input.isolatedRiverMask[i] === 0) continue;
+      if (input.isolatedWaterPointMask[i] === 0) continue;
 
+      // Oases are arid local water-source features. This policy excludes broad
+      // floodplain wetlands and leaves lushness to climate/fertility scoring.
       const drySuit = rampUp01(input.aridityIndex[i], config.dryMin01, config.dryMax01);
-      const lowWaterSuit = rampUp01(1 - input.water01[i], config.lowWaterMin01, 1);
+      const waterSuit = rampUp01(input.water01[i], config.waterMin01, 1);
       const warmSuit = rampUp01(
         input.surfaceTemperature[i],
         config.tempWarmStartC,
         config.tempWarmEndC
       );
 
-      score01[i] = clamp01(drySuit * lowWaterSuit * warmSuit);
+      score01[i] = clamp01(drySuit * waterSuit * warmSuit);
     }
 
     return { score01 };
   },
 });
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-tundra-bog/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-tundra-bog/contract.ts
@@ -7,7 +7,9 @@ const ScoreWetTundraBogContract = defineOp({
     width: Type.Integer({ minimum: 1 }),
     height: Type.Integer({ minimum: 1 }),
     landMask: TypedArraySchemas.u8({ description: "Land mask (1 = land, 0 = water)." }),
-    nearRiverMask: TypedArraySchemas.u8({ description: "Mask (1/0): tiles near any river." }),
+    hydromorphicMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): floodplain, sink-basin, or intertidal wetland substrate.",
+    }),
     water01: TypedArraySchemas.f32({ description: "Water availability proxy (0..1)." }),
     fertility01: TypedArraySchemas.f32({ description: "Fertility proxy (0..1)." }),
     surfaceTemperature: TypedArraySchemas.f32({ description: "Surface temperature (C)." }),
@@ -28,4 +30,3 @@ const ScoreWetTundraBogContract = defineOp({
 });
 
 export default ScoreWetTundraBogContract;
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-tundra-bog/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-tundra-bog/strategies/default.ts
@@ -11,7 +11,7 @@ export const defaultStrategy = createStrategy(ScoreWetTundraBogContract, "defaul
       height: input.height,
       fields: [
         { label: "landMask", arr: input.landMask as Uint8Array },
-        { label: "nearRiverMask", arr: input.nearRiverMask as Uint8Array },
+        { label: "hydromorphicMask", arr: input.hydromorphicMask as Uint8Array },
         { label: "water01", arr: input.water01 as Float32Array },
         { label: "fertility01", arr: input.fertility01 as Float32Array },
         { label: "surfaceTemperature", arr: input.surfaceTemperature as Float32Array },
@@ -23,8 +23,10 @@ export const defaultStrategy = createStrategy(ScoreWetTundraBogContract, "defaul
 
     for (let i = 0; i < size; i++) {
       if (input.landMask[i] === 0) continue;
-      if (input.nearRiverMask[i] === 0) continue;
+      if (input.hydromorphicMask[i] === 0) continue;
 
+      // Tundra bogs require saturated cold ground; cold climate alone should
+      // not create bog intents on well-drained terrain.
       const waterSuit = rampUp01(input.water01[i], config.waterMin01, 1);
       const fertilitySuit = rampUp01(input.fertility01[i], config.fertilityMin01, 1);
       const coldSuit = rampDown01(
@@ -40,4 +42,3 @@ export const defaultStrategy = createStrategy(ScoreWetTundraBogContract, "defaul
     return { score01 };
   },
 });
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-watering-hole/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-watering-hole/contract.ts
@@ -7,7 +7,9 @@ const ScoreWetWateringHoleContract = defineOp({
     width: Type.Integer({ minimum: 1 }),
     height: Type.Integer({ minimum: 1 }),
     landMask: TypedArraySchemas.u8({ description: "Land mask (1 = land, 0 = water)." }),
-    isolatedRiverMask: TypedArraySchemas.u8({ description: "Mask (1/0): tiles near isolated rivers." }),
+    isolatedWaterPointMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): isolated lowland water-source substrate.",
+    }),
     water01: TypedArraySchemas.f32({ description: "Water availability proxy (0..1)." }),
     fertility01: TypedArraySchemas.f32({ description: "Fertility proxy (0..1)." }),
     aridityIndex: TypedArraySchemas.f32({ description: "Aridity index (0..1)." }),
@@ -20,7 +22,7 @@ const ScoreWetWateringHoleContract = defineOp({
     default: Type.Object({
       dryMin01: Type.Number({ default: 0.45, minimum: 0, maximum: 1 }),
       dryMax01: Type.Number({ default: 0.85, minimum: 0, maximum: 1 }),
-      lowWaterMin01: Type.Number({ default: 0.35, minimum: 0, maximum: 1 }),
+      waterMin01: Type.Number({ default: 0.25, minimum: 0, maximum: 1 }),
       fertilityMin01: Type.Number({ default: 0.1, minimum: 0, maximum: 1 }),
       tempWarmStartC: Type.Number({ default: 12 }),
       tempWarmEndC: Type.Number({ default: 32 }),
@@ -29,4 +31,3 @@ const ScoreWetWateringHoleContract = defineOp({
 });
 
 export default ScoreWetWateringHoleContract;
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-watering-hole/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/wet-score-watering-hole/strategies/default.ts
@@ -11,7 +11,7 @@ export const defaultStrategy = createStrategy(ScoreWetWateringHoleContract, "def
       height: input.height,
       fields: [
         { label: "landMask", arr: input.landMask as Uint8Array },
-        { label: "isolatedRiverMask", arr: input.isolatedRiverMask as Uint8Array },
+        { label: "isolatedWaterPointMask", arr: input.isolatedWaterPointMask as Uint8Array },
         { label: "water01", arr: input.water01 as Float32Array },
         { label: "fertility01", arr: input.fertility01 as Float32Array },
         { label: "aridityIndex", arr: input.aridityIndex as Float32Array },
@@ -23,10 +23,12 @@ export const defaultStrategy = createStrategy(ScoreWetWateringHoleContract, "def
 
     for (let i = 0; i < size; i++) {
       if (input.landMask[i] === 0) continue;
-      if (input.isolatedRiverMask[i] === 0) continue;
+      if (input.isolatedWaterPointMask[i] === 0) continue;
 
+      // Watering holes share the arid water-source substrate with oases but
+      // stay drier and less fertile through their own scoring policy.
       const drySuit = rampUp01(input.aridityIndex[i], config.dryMin01, config.dryMax01);
-      const lowWaterSuit = rampUp01(1 - input.water01[i], config.lowWaterMin01, 1);
+      const waterSuit = rampUp01(input.water01[i], config.waterMin01, 1);
       const fertilitySuit = rampUp01(input.fertility01[i], config.fertilityMin01, 1);
       const warmSuit = rampUp01(
         input.surfaceTemperature[i],
@@ -34,10 +36,9 @@ export const defaultStrategy = createStrategy(ScoreWetWateringHoleContract, "def
         config.tempWarmEndC
       );
 
-      score01[i] = clamp01(drySuit * lowWaterSuit * fertilitySuit * warmSuit);
+      score01[i] = clamp01(drySuit * waterSuit * fertilitySuit * warmSuit);
     }
 
     return { score01 };
   },
 });
-

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -822,7 +822,10 @@
           "navigableRiverClass": 2,
           "nearRiverRadius": 2,
           "isolatedRiverRadius": 1,
-          "coastalAdjacencyRadius": 1
+          "coastalAdjacencyRadius": 1,
+          "lowlandMaxElevationAboveSeaM": 160,
+          "intertidalMaxElevationAboveSeaM": 40,
+          "floodplainDischargeMin": 0
         }
       },
       "scoreForest": {
@@ -881,7 +884,7 @@
         "config": {
           "dryMin01": 0.6,
           "dryMax01": 0.95,
-          "lowWaterMin01": 0.55,
+          "waterMin01": 0.35,
           "tempWarmStartC": 20,
           "tempWarmEndC": 38
         }
@@ -891,7 +894,7 @@
         "config": {
           "dryMin01": 0.45,
           "dryMax01": 0.85,
-          "lowWaterMin01": 0.35,
+          "waterMin01": 0.25,
           "fertilityMin01": 0.1,
           "tempWarmStartC": 12,
           "tempWarmEndC": 32
@@ -900,10 +903,11 @@
       "scoreReef": {
         "strategy": "default",
         "config": {
-          "tempWarmStartC": 14,
+          "tempWarmStartC": 18,
           "tempWarmEndC": 28,
-          "shallowDepthM": 150,
-          "deepDepthM": 1200
+          "shallowDepthM": 0,
+          "deepDepthM": 120,
+          "maxDistanceToCoast": 3
         }
       },
       "scoreColdReef": {
@@ -911,8 +915,10 @@
         "config": {
           "tempColdMaxC": 10,
           "tempWarmMaxC": 20,
-          "shallowDepthM": 150,
-          "deepDepthM": 1200
+          "minDepthM": 45,
+          "peakDepthM": 300,
+          "maxDepthM": 1200,
+          "minDistanceToCoast": 1
         }
       },
       "scoreReefAtoll": {
@@ -920,8 +926,9 @@
         "config": {
           "tempWarmStartC": 18,
           "tempWarmEndC": 30,
-          "shallowDepthM": 80,
-          "deepDepthM": 500
+          "shallowDepthM": 0,
+          "deepDepthM": 100,
+          "minDistanceToCoast": 4
         }
       },
       "scoreReefLotus": {
@@ -929,8 +936,9 @@
         "config": {
           "tempWarmStartC": 16,
           "tempWarmEndC": 32,
-          "shallowDepthM": 40,
-          "deepDepthM": 350
+          "shallowDepthM": 0,
+          "deepDepthM": 40,
+          "maxDistanceToCoast": 2
         }
       },
       "scoreIce": {

--- a/mods/mod-swooper-maps/src/presets/standard/earthlike.json
+++ b/mods/mod-swooper-maps/src/presets/standard/earthlike.json
@@ -826,7 +826,10 @@
             "navigableRiverClass": 2,
             "nearRiverRadius": 2,
             "isolatedRiverRadius": 1,
-            "coastalAdjacencyRadius": 1
+            "coastalAdjacencyRadius": 1,
+            "lowlandMaxElevationAboveSeaM": 160,
+            "intertidalMaxElevationAboveSeaM": 40,
+            "floodplainDischargeMin": 0
           }
         },
         "scoreForest": {
@@ -885,7 +888,7 @@
           "config": {
             "dryMin01": 0.6,
             "dryMax01": 0.95,
-            "lowWaterMin01": 0.55,
+            "waterMin01": 0.35,
             "tempWarmStartC": 20,
             "tempWarmEndC": 38
           }
@@ -895,7 +898,7 @@
           "config": {
             "dryMin01": 0.45,
             "dryMax01": 0.85,
-            "lowWaterMin01": 0.35,
+            "waterMin01": 0.25,
             "fertilityMin01": 0.1,
             "tempWarmStartC": 12,
             "tempWarmEndC": 32
@@ -904,10 +907,11 @@
         "scoreReef": {
           "strategy": "default",
           "config": {
-            "tempWarmStartC": 14,
+            "tempWarmStartC": 18,
             "tempWarmEndC": 28,
-            "shallowDepthM": 150,
-            "deepDepthM": 1200
+            "shallowDepthM": 0,
+            "deepDepthM": 120,
+            "maxDistanceToCoast": 3
           }
         },
         "scoreColdReef": {
@@ -915,8 +919,10 @@
           "config": {
             "tempColdMaxC": 10,
             "tempWarmMaxC": 20,
-            "shallowDepthM": 150,
-            "deepDepthM": 1200
+            "minDepthM": 45,
+            "peakDepthM": 300,
+            "maxDepthM": 1200,
+            "minDistanceToCoast": 1
           }
         },
         "scoreReefAtoll": {
@@ -924,8 +930,9 @@
           "config": {
             "tempWarmStartC": 18,
             "tempWarmEndC": 30,
-            "shallowDepthM": 80,
-            "deepDepthM": 500
+            "shallowDepthM": 0,
+            "deepDepthM": 100,
+            "minDistanceToCoast": 4
           }
         },
         "scoreReefLotus": {
@@ -933,8 +940,9 @@
           "config": {
             "tempWarmStartC": 16,
             "tempWarmEndC": 32,
-            "shallowDepthM": 40,
-            "deepDepthM": 350
+            "shallowDepthM": 0,
+            "deepDepthM": 40,
+            "maxDistanceToCoast": 2
           }
         },
         "scoreIce": {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/index.ts
@@ -71,6 +71,10 @@ export default createStep(ScoreLayersStepContract, {
         height,
         riverClass: hydrography.riverClass,
         landMask: topography.landMask,
+        elevation: topography.elevation,
+        seaLevel: topography.seaLevel,
+        discharge: hydrography.discharge,
+        sinkMask: hydrography.sinkMask,
       },
       config.featureSubstrate
     );
@@ -80,7 +84,7 @@ export default createStep(ScoreLayersStepContract, {
         width,
         height,
         landMask: topography.landMask,
-        nearRiverMask: featureSubstrate.nearRiverMask,
+        hydromorphicMask: featureSubstrate.hydromorphicMask,
         water01: vegetationSubstrate.water01,
         fertility01: vegetationSubstrate.fertility01,
         surfaceTemperature: classification.surfaceTemperature,
@@ -94,7 +98,7 @@ export default createStep(ScoreLayersStepContract, {
         width,
         height,
         landMask: topography.landMask,
-        nearRiverMask: featureSubstrate.nearRiverMask,
+        hydromorphicMask: featureSubstrate.hydromorphicMask,
         water01: vegetationSubstrate.water01,
         fertility01: vegetationSubstrate.fertility01,
         surfaceTemperature: classification.surfaceTemperature,
@@ -108,7 +112,7 @@ export default createStep(ScoreLayersStepContract, {
         width,
         height,
         landMask: topography.landMask,
-        coastalLandMask: featureSubstrate.coastalLandMask,
+        intertidalCoastMask: featureSubstrate.intertidalCoastMask,
         water01: vegetationSubstrate.water01,
         fertility01: vegetationSubstrate.fertility01,
         surfaceTemperature: classification.surfaceTemperature,
@@ -122,7 +126,7 @@ export default createStep(ScoreLayersStepContract, {
         width,
         height,
         landMask: topography.landMask,
-        isolatedRiverMask: featureSubstrate.isolatedRiverMask,
+        isolatedWaterPointMask: featureSubstrate.isolatedWaterPointMask,
         water01: vegetationSubstrate.water01,
         aridityIndex: classification.aridityIndex,
         surfaceTemperature: classification.surfaceTemperature,
@@ -135,7 +139,7 @@ export default createStep(ScoreLayersStepContract, {
         width,
         height,
         landMask: topography.landMask,
-        isolatedRiverMask: featureSubstrate.isolatedRiverMask,
+        isolatedWaterPointMask: featureSubstrate.isolatedWaterPointMask,
         water01: vegetationSubstrate.water01,
         fertility01: vegetationSubstrate.fertility01,
         aridityIndex: classification.aridityIndex,
@@ -151,6 +155,9 @@ export default createStep(ScoreLayersStepContract, {
         landMask: topography.landMask,
         surfaceTemperature: classification.surfaceTemperature,
         bathymetry: topography.bathymetry,
+        shelfMask: coastline.shelfMask,
+        coastalWater: coastline.coastalWater,
+        distanceToCoast: coastline.distanceToCoast,
       },
       config.scoreReef
     ).score01;
@@ -162,6 +169,9 @@ export default createStep(ScoreLayersStepContract, {
         landMask: topography.landMask,
         surfaceTemperature: classification.surfaceTemperature,
         bathymetry: topography.bathymetry,
+        shelfMask: coastline.shelfMask,
+        coastalWater: coastline.coastalWater,
+        distanceToCoast: coastline.distanceToCoast,
       },
       config.scoreColdReef
     ).score01;
@@ -173,6 +183,9 @@ export default createStep(ScoreLayersStepContract, {
         landMask: topography.landMask,
         surfaceTemperature: classification.surfaceTemperature,
         bathymetry: topography.bathymetry,
+        shelfMask: coastline.shelfMask,
+        coastalWater: coastline.coastalWater,
+        distanceToCoast: coastline.distanceToCoast,
       },
       config.scoreReefAtoll
     ).score01;
@@ -184,6 +197,9 @@ export default createStep(ScoreLayersStepContract, {
         landMask: topography.landMask,
         surfaceTemperature: classification.surfaceTemperature,
         bathymetry: topography.bathymetry,
+        shelfMask: coastline.shelfMask,
+        coastalWater: coastline.coastalWater,
+        distanceToCoast: coastline.distanceToCoast,
       },
       config.scoreReefLotus
     ).score01;

--- a/mods/mod-swooper-maps/test/ecology/earthlike-balance-smoke.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/earthlike-balance-smoke.test.ts
@@ -75,16 +75,24 @@ describe("Earthlike ecology balance (smoke)", () => {
     const marshIdx = adapter.getFeatureTypeIndex("FEATURE_MARSH");
     const bogIdx = adapter.getFeatureTypeIndex("FEATURE_TUNDRA_BOG");
     const mangroveIdx = adapter.getFeatureTypeIndex("FEATURE_MANGROVE");
+    const reefIdx = adapter.getFeatureTypeIndex("FEATURE_REEF");
+    const coldReefIdx = adapter.getFeatureTypeIndex("FEATURE_COLD_REEF");
+    const atollIdx = adapter.getFeatureTypeIndex("FEATURE_ATOLL");
+    const lotusIdx = adapter.getFeatureTypeIndex("FEATURE_LOTUS");
 
+    let waterCount = 0;
     let forestCount = 0;
     let rainforestCount = 0;
     let taigaCount = 0;
     let savannaCount = 0;
     let steppeCount = 0;
     let wetlandCount = 0;
+    let reefFamilyCount = 0;
+    let atollCount = 0;
 
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
+        if (adapter.isWater(x, y)) waterCount++;
         const feature = adapter.getFeatureType(x, y);
         if (feature === forestIdx) forestCount++;
         if (feature === rainforestIdx) rainforestCount++;
@@ -92,6 +100,10 @@ describe("Earthlike ecology balance (smoke)", () => {
         if (feature === savannaIdx) savannaCount++;
         if (feature === steppeIdx) steppeCount++;
         if (feature === marshIdx || feature === bogIdx || feature === mangroveIdx) wetlandCount++;
+        if (feature === reefIdx || feature === coldReefIdx || feature === atollIdx || feature === lotusIdx) {
+          reefFamilyCount++;
+        }
+        if (feature === atollIdx) atollCount++;
       }
     }
 
@@ -102,6 +114,8 @@ describe("Earthlike ecology balance (smoke)", () => {
 
     expect(forestCount + rainforestCount + taigaCount + savannaCount + steppeCount + wetlandCount).toBeGreaterThan(0);
 
-    expect(wetlandCount).toBeLessThan(Math.max(1, Math.floor(landCount * 0.75)));
+    expect(wetlandCount).toBeLessThan(Math.max(1, Math.floor(landCount * 0.35)));
+    expect(reefFamilyCount).toBeLessThan(Math.max(1, Math.floor(waterCount * 0.35)));
+    expect(atollCount).toBeLessThan(Math.max(1, Math.floor(waterCount * 0.08)));
   });
 });

--- a/mods/mod-swooper-maps/test/ecology/feature-habitat-eligibility.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/feature-habitat-eligibility.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "bun:test";
+import ecology from "@mapgen/domain/ecology/ops";
+
+import { normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
+
+describe("ecology feature habitat eligibility", () => {
+  it("partitions reef-family habitats by shelf, coast distance, temperature, and depth", () => {
+    const width = 4;
+    const height = 1;
+    const size = width * height;
+    const landMask = new Uint8Array(size);
+    const warm = new Float32Array(size).fill(28);
+    const cold = new Float32Array(size).fill(8);
+    const shallow = new Int16Array(size).fill(-10);
+    const coldReefDepth = new Int16Array(size).fill(-300);
+    const shelfMask = new Uint8Array(size).fill(1);
+    const coastalWater = new Uint8Array([1, 0, 1, 1]);
+    const distanceToCoast = new Uint16Array([1, 5, 1, 1]);
+
+    const reef = ecology.ops.scoreReef.run(
+      { width, height, landMask, surfaceTemperature: warm, bathymetry: shallow, shelfMask, coastalWater, distanceToCoast },
+      normalizeOpSelectionOrThrow(ecology.ops.scoreReef, { strategy: "default", config: {} })
+    ).score01;
+    const atoll = ecology.ops.scoreReefAtoll.run(
+      { width, height, landMask, surfaceTemperature: warm, bathymetry: shallow, shelfMask, coastalWater, distanceToCoast },
+      normalizeOpSelectionOrThrow(ecology.ops.scoreReefAtoll, { strategy: "default", config: {} })
+    ).score01;
+    const lotus = ecology.ops.scoreReefLotus.run(
+      { width, height, landMask, surfaceTemperature: warm, bathymetry: shallow, shelfMask, coastalWater, distanceToCoast },
+      normalizeOpSelectionOrThrow(ecology.ops.scoreReefLotus, { strategy: "default", config: {} })
+    ).score01;
+    const coldReef = ecology.ops.scoreColdReef.run(
+      {
+        width,
+        height,
+        landMask,
+        surfaceTemperature: cold,
+        bathymetry: coldReefDepth,
+        shelfMask,
+        coastalWater,
+        distanceToCoast,
+      },
+      normalizeOpSelectionOrThrow(ecology.ops.scoreColdReef, { strategy: "default", config: {} })
+    ).score01;
+    const abyssalColdReef = ecology.ops.scoreColdReef.run(
+      {
+        width,
+        height,
+        landMask,
+        surfaceTemperature: cold,
+        bathymetry: new Int16Array(size).fill(-2000),
+        shelfMask,
+        coastalWater,
+        distanceToCoast,
+      },
+      normalizeOpSelectionOrThrow(ecology.ops.scoreColdReef, { strategy: "default", config: {} })
+    ).score01;
+
+    expect(reef[0]).toBeGreaterThan(0.5);
+    expect(reef[1]).toBe(0);
+    expect(atoll[0]).toBe(0);
+    expect(atoll[1]).toBeGreaterThan(0.5);
+    expect(lotus[0]).toBeGreaterThan(0.5);
+    expect(lotus[1]).toBe(0);
+    expect(coldReef[0]).toBeGreaterThan(0.5);
+    expect(abyssalColdReef[0]).toBe(0);
+  });
+
+  it("requires hydromorphic or isolated water-source substrate before wet feature scoring", () => {
+    const width = 2;
+    const height = 1;
+    const size = width * height;
+    const landMask = new Uint8Array(size).fill(1);
+    const hydromorphicMask = new Uint8Array([0, 1]);
+    const intertidalCoastMask = new Uint8Array([0, 1]);
+    const isolatedWaterPointMask = new Uint8Array([0, 1]);
+    const water01 = new Float32Array(size).fill(0.85);
+    const fertility01 = new Float32Array(size).fill(0.7);
+    const surfaceTemperature = new Float32Array(size).fill(14);
+    const mangroveTemperature = new Float32Array(size).fill(24);
+    const coldTemperature = new Float32Array(size).fill(0);
+    const aridityIndex = new Float32Array(size).fill(0.25);
+    const dryAridityIndex = new Float32Array(size).fill(0.8);
+    const aridWaterPointWater01 = new Float32Array(size).fill(0.7);
+    const freezeIndex = new Float32Array(size).fill(0.8);
+
+    const marsh = ecology.ops.scoreWetMarsh.run(
+      { width, height, landMask, hydromorphicMask, water01, fertility01, surfaceTemperature, aridityIndex },
+      normalizeOpSelectionOrThrow(ecology.ops.scoreWetMarsh, { strategy: "default", config: {} })
+    ).score01;
+    const bog = ecology.ops.scoreWetTundraBog.run(
+      { width, height, landMask, hydromorphicMask, water01, fertility01, surfaceTemperature: coldTemperature, freezeIndex },
+      normalizeOpSelectionOrThrow(ecology.ops.scoreWetTundraBog, { strategy: "default", config: {} })
+    ).score01;
+    const mangrove = ecology.ops.scoreWetMangrove.run(
+      { width, height, landMask, intertidalCoastMask, water01, fertility01, surfaceTemperature: mangroveTemperature, aridityIndex },
+      normalizeOpSelectionOrThrow(ecology.ops.scoreWetMangrove, { strategy: "default", config: {} })
+    ).score01;
+    const oasis = ecology.ops.scoreWetOasis.run(
+      {
+        width,
+        height,
+        landMask,
+        isolatedWaterPointMask,
+        water01: aridWaterPointWater01,
+        aridityIndex: dryAridityIndex,
+        surfaceTemperature: mangroveTemperature,
+      },
+      normalizeOpSelectionOrThrow(ecology.ops.scoreWetOasis, { strategy: "default", config: {} })
+    ).score01;
+
+    expect(marsh[0]).toBe(0);
+    expect(marsh[1]).toBeGreaterThan(0.2);
+    expect(bog[0]).toBe(0);
+    expect(bog[1]).toBeGreaterThan(0.2);
+    expect(mangrove[0]).toBe(0);
+    expect(mangrove[1]).toBeGreaterThan(0.2);
+    expect(oasis[0]).toBe(0);
+    expect(oasis[1]).toBeGreaterThan(0.05);
+  });
+});

--- a/mods/mod-swooper-maps/test/ecology/feature-planner-policies.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/feature-planner-policies.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ecology from "@mapgen/domain/ecology/ops";
+
+import { normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
+
+function f32(size: number, value: number): Float32Array {
+  return new Float32Array(size).fill(value);
+}
+
+describe("ecology feature planner policies", () => {
+  it("rejects weak positive scores across all feature-family planners", () => {
+    const width = 1;
+    const height = 1;
+    const size = width * height;
+    const weakPositive = 0.05;
+
+    const reefs = ecology.ops.planReefs.run(
+      {
+        width,
+        height,
+        seed: 1,
+        scoreReef01: f32(size, weakPositive),
+        scoreColdReef01: f32(size, weakPositive),
+        scoreAtoll01: f32(size, weakPositive),
+        scoreLotus01: f32(size, weakPositive),
+        featureIndex: new Uint16Array(size),
+        reserved: new Uint8Array(size),
+      },
+      normalizeOpSelectionOrThrow(ecology.ops.planReefs, { strategy: "default", config: {} })
+    );
+
+    const wetlands = ecology.ops.planWetlands.run(
+      {
+        width,
+        height,
+        seed: 1,
+        scoreMarsh01: f32(size, weakPositive),
+        scoreTundraBog01: f32(size, weakPositive),
+        scoreMangrove01: f32(size, weakPositive),
+        scoreOasis01: f32(size, weakPositive),
+        scoreWateringHole01: f32(size, weakPositive),
+        featureIndex: new Uint16Array(size),
+        reserved: new Uint8Array(size),
+      },
+      normalizeOpSelectionOrThrow(ecology.ops.planWetlands, { strategy: "default", config: {} })
+    );
+
+    const vegetation = ecology.ops.planVegetation.run(
+      {
+        width,
+        height,
+        seed: 1,
+        scoreForest01: f32(size, weakPositive),
+        scoreRainforest01: f32(size, weakPositive),
+        scoreTaiga01: f32(size, weakPositive),
+        scoreSavannaWoodland01: f32(size, weakPositive),
+        scoreSagebrushSteppe01: f32(size, weakPositive),
+        landMask: new Uint8Array(size).fill(1),
+        featureIndex: new Uint16Array(size),
+        reserved: new Uint8Array(size),
+      },
+      normalizeOpSelectionOrThrow(ecology.ops.planVegetation, { strategy: "default", config: {} })
+    );
+
+    const ice = ecology.ops.planIce.run(
+      {
+        width,
+        height,
+        seed: 1,
+        score01: f32(size, weakPositive),
+        featureIndex: new Uint16Array(size),
+        reserved: new Uint8Array(size),
+      },
+      normalizeOpSelectionOrThrow(ecology.ops.planIce, { strategy: "default", config: {} })
+    );
+
+    const continentalIce = ecology.ops.planIce.run(
+      {
+        width,
+        height,
+        seed: 1,
+        score01: f32(size, weakPositive),
+        featureIndex: new Uint16Array(size),
+        reserved: new Uint8Array(size),
+      },
+      normalizeOpSelectionOrThrow(ecology.ops.planIce, { strategy: "continentality", config: {} })
+    );
+
+    expect(reefs.placements).toEqual([]);
+    expect(wetlands.placements).toEqual([]);
+    expect(vegetation.placements).toEqual([]);
+    expect(ice.placements).toEqual([]);
+    expect(continentalIce.placements).toEqual([]);
+  });
+
+  it("keeps score-to-intent policies local to each feature planner family", () => {
+    const testDir = path.dirname(fileURLToPath(import.meta.url));
+    const opsRoot = path.resolve(testDir, "..", "..", "src", "domain", "ecology", "ops");
+    const families = [
+      "features-plan-reefs",
+      "features-plan-wetlands",
+      "features-plan-vegetation",
+      "features-plan-ice",
+    ] as const;
+
+    // This is a category guard: future ecology feature families should attach
+    // planner policy locally instead of restoring a generic routing owner.
+    expect(existsSync(path.join(opsRoot, "features-plan-shared"))).toBe(false);
+    const scoreShared = readFileSync(path.join(opsRoot, "score-shared", "index.ts"), "utf8");
+    expect(scoreShared).not.toContain("confidenceBeatsStress");
+    for (const family of families) {
+      const policyDir = path.join(opsRoot, family, "policies");
+      expect(existsSync(policyDir), `${family} should own local policies`).toBe(true);
+      const strategyDir = path.join(opsRoot, family, "strategies");
+      const strategyFiles = readdirSync(strategyDir).filter(
+        (file) => file.endsWith(".ts") && file !== "index.ts"
+      );
+      for (const strategyFile of strategyFiles) {
+        const strategy = readFileSync(path.join(strategyDir, strategyFile), "utf8");
+        expect(strategy).toContain("../policies/index.js");
+      }
+    }
+  });
+});

--- a/mods/mod-swooper-maps/test/ecology/op-contracts.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/op-contracts.test.ts
@@ -174,6 +174,10 @@ describe("ecology op contract surfaces", () => {
         height,
         riverClass: new Uint8Array(size),
         landMask: new Uint8Array(size).fill(1),
+        elevation: new Int16Array(size).fill(40),
+        seaLevel: 0,
+        discharge: new Float32Array(size),
+        sinkMask: new Uint8Array(size),
       },
       selection
     );
@@ -182,6 +186,13 @@ describe("ecology op contract surfaces", () => {
     expect(result.nearRiverMask.length).toBe(size);
     expect(result.isolatedRiverMask.length).toBe(size);
     expect(result.coastalLandMask.length).toBe(size);
+    expect(result.lowlandMask.length).toBe(size);
+    expect(result.floodplainMask.length).toBe(size);
+    expect(result.intertidalCoastMask.length).toBe(size);
+    expect(result.sinkBasinMask.length).toBe(size);
+    expect(result.hydromorphicMask.length).toBe(size);
+    expect(result.wellDrainedMask.length).toBe(size);
+    expect(result.isolatedWaterPointMask.length).toBe(size);
   });
 
   it("classifyBiomes validates output", () => {
@@ -304,9 +315,9 @@ describe("ecology op contract surfaces", () => {
 
     {
       const landMask = new Uint8Array(size).fill(1);
-      const nearRiverMask = new Uint8Array(size).fill(1);
-      const isolatedRiverMask = new Uint8Array(size).fill(1);
-      const coastalLandMask = new Uint8Array(size).fill(1);
+      const hydromorphicMask = new Uint8Array(size).fill(1);
+      const intertidalCoastMask = new Uint8Array(size).fill(1);
+      const isolatedWaterPointMask = new Uint8Array(size).fill(1);
       const water01 = new Float32Array(size).fill(0.7);
       const fertility01 = new Float32Array(size).fill(0.4);
       const surfaceTemperature = new Float32Array(size).fill(18);
@@ -320,7 +331,7 @@ describe("ecology op contract surfaces", () => {
             width,
             height,
             landMask,
-            nearRiverMask,
+            hydromorphicMask,
             water01,
             fertility01,
             surfaceTemperature,
@@ -333,7 +344,7 @@ describe("ecology op contract surfaces", () => {
             width,
             height,
             landMask,
-            nearRiverMask,
+            hydromorphicMask,
             water01,
             fertility01,
             surfaceTemperature,
@@ -346,7 +357,7 @@ describe("ecology op contract surfaces", () => {
             width,
             height,
             landMask,
-            coastalLandMask,
+            intertidalCoastMask,
             water01,
             fertility01,
             surfaceTemperature,
@@ -355,7 +366,7 @@ describe("ecology op contract surfaces", () => {
         },
         {
           op: ecology.ops.scoreWetOasis,
-          input: { width, height, landMask, isolatedRiverMask, water01, aridityIndex, surfaceTemperature },
+          input: { width, height, landMask, isolatedWaterPointMask, water01, aridityIndex, surfaceTemperature },
         },
         {
           op: ecology.ops.scoreWetWateringHole,
@@ -363,7 +374,7 @@ describe("ecology op contract surfaces", () => {
             width,
             height,
             landMask,
-            isolatedRiverMask,
+            isolatedWaterPointMask,
             water01,
             fertility01,
             aridityIndex,
@@ -384,23 +395,64 @@ describe("ecology op contract surfaces", () => {
       const surfaceTemperatureWarm = new Float32Array(size).fill(24);
       const surfaceTemperatureCold = new Float32Array(size).fill(12);
       const bathymetry = new Int16Array(size).fill(-120);
+      const shelfMask = new Uint8Array(size).fill(1);
+      const coastalWater = new Uint8Array(size).fill(1);
+      const distanceToCoast = new Uint16Array(size).fill(1);
+      const isolatedCoastalWater = new Uint8Array(size).fill(0);
+      const isolatedDistanceToCoast = new Uint16Array(size).fill(5);
 
       const reefScoreOps = [
         {
           op: ecology.ops.scoreReef,
-          input: { width, height, landMask, surfaceTemperature: surfaceTemperatureWarm, bathymetry },
+          input: {
+            width,
+            height,
+            landMask,
+            surfaceTemperature: surfaceTemperatureWarm,
+            bathymetry,
+            shelfMask,
+            coastalWater,
+            distanceToCoast,
+          },
         },
         {
           op: ecology.ops.scoreColdReef,
-          input: { width, height, landMask, surfaceTemperature: surfaceTemperatureCold, bathymetry },
+          input: {
+            width,
+            height,
+            landMask,
+            surfaceTemperature: surfaceTemperatureCold,
+            bathymetry,
+            shelfMask,
+            coastalWater,
+            distanceToCoast,
+          },
         },
         {
           op: ecology.ops.scoreReefAtoll,
-          input: { width, height, landMask, surfaceTemperature: surfaceTemperatureWarm, bathymetry },
+          input: {
+            width,
+            height,
+            landMask,
+            surfaceTemperature: surfaceTemperatureWarm,
+            bathymetry,
+            shelfMask,
+            coastalWater: isolatedCoastalWater,
+            distanceToCoast: isolatedDistanceToCoast,
+          },
         },
         {
           op: ecology.ops.scoreReefLotus,
-          input: { width, height, landMask, surfaceTemperature: surfaceTemperatureWarm, bathymetry },
+          input: {
+            width,
+            height,
+            landMask,
+            surfaceTemperature: surfaceTemperatureWarm,
+            bathymetry,
+            shelfMask,
+            coastalWater,
+            distanceToCoast,
+          },
         },
       ] as const;
 

--- a/mods/mod-swooper-maps/test/ecology/score-shared-physics-selection.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/score-shared-physics-selection.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "bun:test";
 import {
   choosePhysicalCandidate,
   comparePhysicalCandidates,
-  confidenceBeatsStress,
 } from "../../src/domain/ecology/ops/score-shared/index.js";
 
 describe("score-shared physics candidate ordering", () => {
@@ -42,9 +41,4 @@ describe("score-shared physics candidate ordering", () => {
     });
   });
 
-  it("admits a placement only when confidence beats stress", () => {
-    expect(confidenceBeatsStress({ confidence01: 0.7, stress01: 0.3 })).toBe(true);
-    expect(confidenceBeatsStress({ confidence01: 0.5, stress01: 0.5 })).toBe(false);
-    expect(confidenceBeatsStress({ confidence01: 0.2, stress01: 0.8 })).toBe(false);
-  });
 });

--- a/openspec/changes/add-civ7-operational-debugging-skill/.openspec.yaml
+++ b/openspec/changes/add-civ7-operational-debugging-skill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-30

--- a/openspec/changes/add-civ7-operational-debugging-skill/design.md
+++ b/openspec/changes/add-civ7-operational-debugging-skill/design.md
@@ -1,0 +1,24 @@
+## Context
+
+The skill is an operational router. It helps agents identify the runtime
+surface being inspected and classify what that evidence proves. It does not
+replace architecture, product, OpenSpec, Graphite, or watcher authority.
+
+## File Tree
+
+```text
+.agents/skills/civ7-operational-debugging/
+  SKILL.md
+  references/
+    debugging-workflow.md
+    operational-paths.md
+    proof-boundaries.md
+```
+
+## Review Lanes
+
+- Operational review: covers source build, generated output, deployed output,
+  logs, official resources, and in-game proof.
+- Architecture review: preserves generated-output read-only boundaries.
+- DX review: usable under incident pressure.
+- Adversarial review: does not become a dumping ground or task log.

--- a/openspec/changes/add-civ7-operational-debugging-skill/implementation.md
+++ b/openspec/changes/add-civ7-operational-debugging-skill/implementation.md
@@ -1,0 +1,19 @@
+## Implementation Evidence
+
+The repo-local operational skill was added at:
+
+```text
+.agents/skills/civ7-operational-debugging/
+```
+
+It documents Civ7 source/build/deploy/log/resource evidence loops generically,
+without reef/marsh task status or feature-specific diagnosis. It routes
+architecture, product, OpenSpec, and Graphite authority back to the existing
+Civ7 skills instead of becoming a dumping ground.
+
+## Verification
+
+- `bun run openspec -- validate add-civ7-operational-debugging-skill --strict`
+  passed.
+- `bun run openspec:validate` passed.
+- `git diff --check` passed.

--- a/openspec/changes/add-civ7-operational-debugging-skill/proposal.md
+++ b/openspec/changes/add-civ7-operational-debugging-skill/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Civ7 map failures are operationally diagnosed across source builds, generated
+mod output, deployed Mods folders, and game logs. That evidence loop is durable
+repo knowledge and should live in a generic repo-local skill, not in a chat or
+feature-specific task note.
+
+## Target Authority Refs
+
+- `AGENTS.md`: preserve important durable repo knowledge in canonical docs or
+  project-owned guidance.
+- `.agents/skills/civ7-product-authority/SKILL.md`: build, generated output,
+  deploy, logs, and in-game checks prove different claims.
+- `.agents/skills/civ7-architecture-authority/SKILL.md`: generated artifacts
+  and deployed output are evidence, not source authority.
+
+## What Changes
+
+- Add `.agents/skills/civ7-operational-debugging/`.
+- Document operational paths, debugging workflow, and proof boundaries for
+  Civ7 resources, build/deploy output, deployed mods, and logs.
+- Keep the skill generic; no reef/marsh task notes or incident-specific status.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `change-management`: recognizes repo-local operational skills as durable
+  process artifacts when they capture generic evidence loops.
+
+## Verification Gates
+
+- `bun run openspec -- validate add-civ7-operational-debugging-skill --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/add-civ7-operational-debugging-skill/specs/change-management/spec.md
+++ b/openspec/changes/add-civ7-operational-debugging-skill/specs/change-management/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Operational Skills Capture Durable Debugging Process
+
+Repo-local operational skills SHALL capture reusable process, evidence
+locations, proof boundaries, and anti-patterns without storing task status or
+feature-specific incident notes.
+
+#### Scenario: A Civ7 runtime failure is debugged through logs
+- **WHEN** a repeated debugging process depends on source builds, deployed mod
+  files, and Civ7 logs
+- **THEN** a repo-local operational skill may document that evidence loop
+- **AND** the skill routes architecture, product, OpenSpec, and Graphite
+  authority to their existing owners
+- **AND** task-specific findings remain in specs, implementation records,
+  watcher notes, commits, or issue artifacts instead of the skill

--- a/openspec/changes/add-civ7-operational-debugging-skill/tasks.md
+++ b/openspec/changes/add-civ7-operational-debugging-skill/tasks.md
@@ -1,0 +1,13 @@
+## 1. Skill Artifact
+
+- [x] 1.1 Create the repo-local Civ7 operational debugging skill.
+- [x] 1.2 Keep the skill generic and route authority to existing Civ7 product,
+      architecture, OpenSpec, and Graphite skills.
+- [x] 1.3 Review the skill for dumping-ground drift, generated-output edits,
+      task-specific reef/marsh content, and proof overclaims.
+
+## 2. Verification
+
+- [x] 2.1 Run `bun run openspec -- validate add-civ7-operational-debugging-skill --strict`.
+- [x] 2.2 Run `bun run openspec:validate`.
+- [x] 2.3 Run `git diff --check`.

--- a/openspec/changes/bound-ecology-feature-intent-planners/.openspec.yaml
+++ b/openspec/changes/bound-ecology-feature-intent-planners/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-30

--- a/openspec/changes/bound-ecology-feature-intent-planners/design.md
+++ b/openspec/changes/bound-ecology-feature-intent-planners/design.md
@@ -1,0 +1,59 @@
+## Context
+
+Ecology feature placement has two jobs. Score ops produce continuous physical
+suitability fields. Planner ops convert those fields into sparse feature
+intents that projection can materialize. The current planners collapse those
+jobs by treating any positive score as placement intent.
+
+## Owner
+
+Feature intent admission is a policy, and policies stay with the feature family
+strategy they modulate. Each ecology feature family MUST own its score-to-intent
+policy in a local `policies/` directory:
+
+```text
+mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-reefs/policies/
+mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-wetlands/policies/
+mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/policies/
+mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-ice/policies/
+```
+
+The implementation MUST NOT create `features-plan-shared`, `score-shared`
+admission, generic `shared`, projection admission, or step-contract routing. If
+score-to-intent admission later becomes product-free MapGen machinery, it must
+move to MapGen core through a separate change. Reef, wetland, vegetation, and
+ice habitat physics stay with their owning feature ops/contracts.
+
+## Policy
+
+Feature planners MUST NOT place a candidate only because its score is positive.
+Each family-local policy defines what counts as a confident intent for that
+family. Reef and ice features require high-confidence physical evidence;
+wetland and vegetation families may use lower family-local thresholds because
+their score ops multiply several independent ecology signals and would
+otherwise erase legitimate habitat. The invariant is not one universal
+threshold; it is that each in-kind planner has an explicit policy and weak
+positive scores cannot place features.
+
+Feature-family contracts may and should add stricter habitat rules. The local
+admission policies only close the weak-positive category and must not carry
+habitat physics that belong in feature-family score ops.
+
+Planner order is mandatory: feature-family habitat eligibility first,
+family-local weak-positive admission second, occupancy/reservation claim third,
+artifact publish last. Guard coverage should prevent generic feature-planner
+shared directories and should prove each in-kind planner has a local policy. If
+a policy grows beyond score-to-intent admission, the new logic must stay with
+the owning feature op/family or move to MapGen core if it is genuinely
+product-free machinery.
+
+## Review Lanes
+
+- Architecture: truth stays in `ecology-features`; projection stays in
+  `map-ecology`.
+- Physics/gameplay: family-local admission improves sparsity without flattening
+  feature-specific habitats.
+- DX/complexity: policy files are small behavior attachments used by strategies,
+  not routers or shared buckets.
+- Adversarial: no chance thinning, fallback behavior, or manual step wiring as
+  closure proof.

--- a/openspec/changes/bound-ecology-feature-intent-planners/implementation.md
+++ b/openspec/changes/bound-ecology-feature-intent-planners/implementation.md
@@ -1,0 +1,57 @@
+## Implementation Evidence
+
+Implemented in the active Graphite worktree on `codex/ecology-feature-density-spec`.
+
+The weak-positive category was repaired without creating generic shared
+machinery:
+
+- `features-plan-reefs/policies/admit-reef-intent.ts`
+- `features-plan-wetlands/policies/admit-wetland-intent.ts`
+- `features-plan-vegetation/policies/admit-vegetation-intent.ts`
+- `features-plan-ice/policies/admit-ice-intent.ts`
+
+Each planner strategy imports its family-local policy. The abandoned
+`features-plan-shared` owner was removed. Generic score math remains in
+`score-shared`, but score-to-intent policy does not live there; the former
+`confidenceBeatsStress` admission helper and direct admission test were removed.
+
+## Guard Evidence
+
+- `mods/mod-swooper-maps/test/ecology/feature-planner-policies.test.ts`
+  rejects weak positive scores across reef, wetland, vegetation, and ice
+  planners, including non-default planner strategies.
+- The same test proves each in-kind planner owns a local `policies/` directory
+  and every concrete planner strategy imports the local policy. It also proves
+  `features-plan-shared` plus `score-shared` admission are absent.
+- `mods/mod-swooper-maps/test/ecology/earthlike-balance-smoke.test.ts` runs the
+  standard recipe/runtime/config and bounds ecology feature density without
+  direct step wiring.
+
+## Review Disposition
+
+User correction superseded the earlier shared-admission design: policy logic
+must stay close to the feature family it modulates unless it is truly
+product-free MapGen core machinery. The implemented shape follows that
+disposition.
+
+Adversarial review P1/P2 findings were dispositioned by removing generic
+`score-shared` admission and simplifying local policy contracts to the family
+signal they actually use. A follow-up scan found the non-default ice planner
+strategy still admitted any positive score; it now imports the ice-local policy,
+and the guard scans all concrete strategy files in each planner family.
+
+## Verification
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/ecology/no-fudging-static-scan.test.ts test/ecology/ecology-step-import-guardrails.test.ts test/ecology/score-shared-physics-selection.test.ts test/ecology/feature-planner-policies.test.ts test/ecology/feature-habitat-eligibility.test.ts test/ecology/earthlike-balance-smoke.test.ts test/ecology/op-contracts.test.ts`
+  passed, 32/32 tests.
+- `bun run --cwd mods/mod-swooper-maps check` passed.
+- `bun run lint:normalization-guardrails` passed.
+- `bun run openspec -- validate bound-ecology-feature-intent-planners --strict`
+  passed.
+- `bun run openspec:validate` passed.
+- `bun run build` passed.
+- `bun run deploy:mods` passed and deployed `mod-swooper-maps`.
+- `git diff --check` passed.
+- Fresh `Scripting.log` evidence after deploy shows the standard recipe reached
+  `[50/50] ok mod-swooper-maps.standard.placement.placement` and destroyed the
+  `MapGeneration` context cleanly.

--- a/openspec/changes/bound-ecology-feature-intent-planners/proposal.md
+++ b/openspec/changes/bound-ecology-feature-intent-planners/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Fresh Civ7 logs show the map reaches Ecology and final placement successfully,
+so reef/marsh saturation is a behavior bug rather than a load failure. Source
+review and recipe diagnostics show the categorical planner issue: continuous
+feature score layers are converted into feature intents whenever the best score
+is merely positive. That makes broad physical plausibility paint nearly every
+eligible tile.
+
+This change fixes only the score-to-intent admission category. Reefs, wetlands,
+vegetation, and ice remain unique features with unique habitat logic; each
+family owns its admission policy locally and its specific physics are owned by
+separate feature-family changes where needed.
+
+## Target Authority Refs
+
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`:
+  Ecology truth belongs in `ecology-features`; `map-ecology` is projection.
+- `mods/mod-swooper-maps/AGENTS.md`: feature planning publishes split intents
+  before feature apply writes engine state.
+- `docs/system/libs/mapgen/reference/domains/ECOLOGY.md`: feature planning is
+  Ecology-owned truth.
+- Direct user guidance: categorical violations need categorical guards, but
+  shared logic must not erase feature-specific physics.
+
+## What Changes
+
+- Add local Ecology feature-family planner policies: weak positive suitability
+  is not enough to become a feature intent.
+- Apply the family-local policy to every feature-family planner that has the
+  same positive-score admission category.
+- Add tests that reject the category across feature planners, not just a reef
+  or marsh one-off.
+- Add recipe-level ecology balance checks that run through the standard recipe.
+
+## Dependencies
+
+- Builds on archived `normalize-ecology-topology` and
+  `normalize-architecture-dx-standardization`.
+
+## Forbidden Non-Goals
+
+- No probability/chance thinning.
+- No one-off `modswooper` or Earthlike special casing.
+- No projection-stage truth scoring or density filtering.
+- No replacing feature-specific reef/wetland/vegetation/ice physics with one
+  generic habitat rule.
+- No `features-plan-shared`, `score-shared` admission policy, or generic
+  planner router.
+
+## Verification Gates
+
+- focused ecology planner tests;
+- recipe-level ecology balance tests;
+- `bun run --cwd mods/mod-swooper-maps check`;
+- `bun run openspec -- validate bound-ecology-feature-intent-planners --strict`;
+- `bun run openspec:validate`;
+- `bun run build`;
+- `bun run deploy:mods`;
+- `git diff --check`.

--- a/openspec/changes/bound-ecology-feature-intent-planners/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/bound-ecology-feature-intent-planners/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Ecology Feature Scores Become Sparse Intents
+
+Ecology feature-family planners SHALL convert continuous per-tile suitability
+scores into sparse feature intents through a documented planner admission
+policy while preserving feature-family-specific habitat rules.
+
+#### Scenario: A tile has only weak positive suitability
+- **WHEN** a feature score is positive but does not satisfy the owning
+  feature-family admission policy
+- **THEN** the planner does not emit a feature placement for that tile
+- **AND** the tile remains available for later feature families according to
+  the current occupancy chain
+
+#### Scenario: Feature families share the score-to-intent category
+- **WHEN** reef, wetland, vegetation, or ice planning consumes continuous
+  suitability scores and occupancy snapshots
+- **THEN** tests cover the shared weak-positive category rather than only one
+  named feature
+- **AND** each family owns a local policy instead of routing through generic
+  feature-planner shared machinery
+- **AND** those policies do not replace reef, wetland, vegetation, or ice
+  habitat physics
+
+#### Scenario: A planner evaluates a tile
+- **WHEN** a feature-family planner evaluates a candidate tile
+- **THEN** feature-family habitat eligibility is evaluated before the
+  family-local admission policy
+- **AND** occupancy/reservation claim and artifact publish happen after the
+  admitted feature intent is selected

--- a/openspec/changes/bound-ecology-feature-intent-planners/tasks.md
+++ b/openspec/changes/bound-ecology-feature-intent-planners/tasks.md
@@ -1,0 +1,41 @@
+## 1. Investigation And Review
+
+- [x] 1.1 Inspect fresh Civ7 logs and classify this as behavior, not load
+      failure.
+- [x] 1.2 Record that the shared root issue is weak-positive score admission.
+- [x] 1.3 Split planner admission from reef/wetland feature physics without
+      creating generic shared machinery.
+- [x] 1.4 Pass adversarial review before implementation.
+
+## 2. Implementation
+
+- [x] 2.1 Add local `policies/` owners for reef, wetland, vegetation, and ice
+      score-to-intent admission.
+- [x] 2.2 Apply family-local policy functions to reef, wetland, vegetation, and
+      ice planners where they share the positive-score admission category.
+- [x] 2.3 Keep generic score math separate from admission ownership; do not land
+      admission in `score-shared`, `features-plan-shared`, or a generic
+      `shared` bucket.
+- [x] 2.4 Ensure each planner applies feature-family habitat eligibility before
+      family-local admission and occupancy publish.
+- [x] 2.5 Add why/what comments at policy owners and non-obvious call sites.
+
+## 3. Tests And Docs
+
+- [x] 3.1 Add categorical planner tests for positive-but-not-confident scores.
+- [x] 3.2 Add guard coverage that prevents generic feature-planner shared
+      admission and proves each in-kind planner owns a local policy.
+- [x] 3.3 Run the existing normalization guardrails or focused ecology import
+      guard that proves the new owner does not break import direction.
+- [x] 3.4 Add recipe-level balance coverage without manual step wiring.
+- [x] 3.5 Update Ecology docs and implementation evidence.
+
+## 4. Verification
+
+- [x] 4.1 Run focused ecology tests.
+- [x] 4.2 Run `bun run --cwd mods/mod-swooper-maps check`.
+- [x] 4.3 Run `bun run openspec -- validate bound-ecology-feature-intent-planners --strict`.
+- [x] 4.4 Run `bun run openspec:validate`.
+- [x] 4.5 Run `bun run build`.
+- [x] 4.6 Run `bun run deploy:mods`.
+- [x] 4.7 Run `git diff --check`.

--- a/openspec/changes/constrain-reef-habitat-eligibility/.openspec.yaml
+++ b/openspec/changes/constrain-reef-habitat-eligibility/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-30

--- a/openspec/changes/constrain-reef-habitat-eligibility/design.md
+++ b/openspec/changes/constrain-reef-habitat-eligibility/design.md
@@ -1,0 +1,35 @@
+## Reef Physics
+
+The reef-family predicates use source fields already available to
+`ecology-features`: `landMask`, `surfaceTemperature`, `bathymetry`,
+`coastalWater`, `shelfMask`, and `distanceToCoast`.
+
+- `FEATURE_REEF`: water tile, warm tropical/subtropical temperature, shallow
+  shelf bathymetry, and coastal/shelf structure (`shelfMask = 1` and near-coast
+  water by `distanceToCoast`).
+- `FEATURE_COLD_REEF`: water tile, cold temperature, deep or shelf-edge
+  bathymetry, and not a warm shallow reef relabeling.
+- `FEATURE_ATOLL`: water tile, warm temperature, shallow shelf/bank bathymetry,
+  isolated from existing land coast (`distanceToCoast` above the atoll
+  isolation threshold and `coastalWater = 0`).
+- `FEATURE_LOTUS`: exact Civ7 feature id; water tile, warm temperature,
+  shallow calm near-land water (`coastalWater = 1`) and distinct from coral reef
+  and atoll habitats.
+
+These predicates are categorical habitat gates. Numeric defaults may be tuned
+inside owning reef op contracts, but the code must not alias one reef-family
+feature to another or use probability thinning to compensate for broad scores.
+
+## Owner Shape
+
+Reef-specific eligibility belongs beside reef scoring/planning ops. The
+reef-family planner policy only rejects weak-positive scores; reef ops decide
+what counts as reef habitat.
+
+## Review Lanes
+
+- Physics: habitat rules match real-world expectations at map resolution.
+- Architecture: reef truth remains Ecology-owned.
+- Gameplay: coastal water remains readable and navigable.
+- Adversarial: no chance thinning, no map special case, no projection truth
+  logic.

--- a/openspec/changes/constrain-reef-habitat-eligibility/implementation.md
+++ b/openspec/changes/constrain-reef-habitat-eligibility/implementation.md
@@ -1,0 +1,56 @@
+## Implementation Evidence
+
+Reef-family score ops now consume coastline structure from the Ecology
+score-layers step:
+
+- `shelfMask`
+- `coastalWater`
+- `distanceToCoast`
+
+Feature-specific behavior remains in owning reef score ops:
+
+- `reef-score-reef`: warm, shallow, near-coast shelf water.
+- `reef-score-cold-reef`: cold, deeper shelf/edge water rather than shallow
+  warm-reef relabeling, with a bounded depth window rather than "deeper is
+  always better."
+- `reef-score-atoll`: warm shallow shelf/bank water isolated from existing
+  land coast.
+- `reef-score-lotus`: exact `FEATURE_LOTUS`, warm shallow near-land water.
+
+The Earthlike preset/config was tightened to match the owner defaults and avoid
+retaining broad legacy depth bands.
+
+## Research Evidence
+
+The algorithm design used external formation constraints from NOAA/USGS-style
+sources gathered during the research pass: warm reef-building corals need warm,
+clear, shallow tropical/subtropical water; atolls are isolated reef structures
+formed around subsiding volcanic islands rather than fringing coast; cold-water
+corals occupy colder deeper shelf/slope/seamount habitats.
+
+## Guard Evidence
+
+- `mods/mod-swooper-maps/test/ecology/feature-habitat-eligibility.test.ts`
+  verifies warm reef, cold reef, atoll, and `FEATURE_LOTUS` habitat partitioning.
+- `mods/mod-swooper-maps/test/ecology/earthlike-balance-smoke.test.ts` bounds
+  reef-family and atoll density through `standardRecipe.run`.
+- Repaired Earthlike smoke metrics for seed `1018`, `32x20`: reef family
+  `8/610` water tiles, atolls `0/610`.
+
+Adversarial review P2 on unbounded cold-reef depth scoring was accepted and
+repaired.
+
+## Verification
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/ecology/no-fudging-static-scan.test.ts test/ecology/ecology-step-import-guardrails.test.ts test/ecology/score-shared-physics-selection.test.ts test/ecology/feature-planner-policies.test.ts test/ecology/feature-habitat-eligibility.test.ts test/ecology/earthlike-balance-smoke.test.ts test/ecology/op-contracts.test.ts`
+  passed, 32/32 tests.
+- `bun run --cwd mods/mod-swooper-maps check` passed.
+- `bun run openspec -- validate constrain-reef-habitat-eligibility --strict`
+  passed.
+- `bun run openspec:validate` passed.
+- `bun run build` passed.
+- `bun run deploy:mods` passed and deployed `mod-swooper-maps`.
+- `git diff --check` passed.
+- Fresh `Scripting.log` evidence after deploy shows the standard recipe reached
+  `[50/50] ok mod-swooper-maps.standard.placement.placement` and destroyed the
+  `MapGeneration` context cleanly.

--- a/openspec/changes/constrain-reef-habitat-eligibility/proposal.md
+++ b/openspec/changes/constrain-reef-habitat-eligibility/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Reefs are oversaturated because broad water suitability fields become
+reef-family intents. The family-local weak-positive admission fix is necessary
+but not sufficient: warm reefs, cold reefs, atolls, and exact `FEATURE_LOTUS`
+need reef-family-specific physical habitat semantics.
+
+## Target Authority Refs
+
+- `mods/mod-swooper-maps/AGENTS.md`: Ecology owns
+  `artifact:ecology.featureIntents.reefs`.
+- `docs/system/libs/mapgen/reference/domains/ECOLOGY.md`: `map-ecology` applies
+  planned intents but does not plan truth.
+- Direct user guidance: keep feature-specific physics anchored in sensible
+  real-world expectations.
+
+## What Changes
+
+- Add reef-family habitat eligibility for warm reefs, cold reefs, atolls, and
+  exact `FEATURE_LOTUS`.
+- Keep reef scoring/planning in Ecology truth ops.
+- Add focused and recipe-level tests that reject blanket reef coverage.
+
+## Dependencies
+
+- Requires `bound-ecology-feature-intent-planners`.
+
+## Forbidden Non-Goals
+
+- No chance thinning, generated-output edits, map special casing, or
+  projection-stage truth scoring.
+
+## Verification Gates
+
+- focused reef tests;
+- recipe-level reef balance tests;
+- `bun run --cwd mods/mod-swooper-maps check`;
+- `bun run openspec -- validate constrain-reef-habitat-eligibility --strict`;
+- `bun run openspec:validate`;
+- `bun run build`;
+- `bun run deploy:mods`;
+- `git diff --check`.

--- a/openspec/changes/constrain-reef-habitat-eligibility/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/constrain-reef-habitat-eligibility/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Reef Intent Planning Uses Reef-Specific Habitat Eligibility
+
+Reef-family feature planning SHALL apply reef-specific habitat eligibility
+rather than treating every shallow or temperature-suitable water tile as reef
+intent.
+
+#### Scenario: Broad water has weak reef structure
+- **WHEN** water tiles have broad positive temperature/depth suitability but no
+  reef-family habitat structure
+- **THEN** reef planning does not emit blanket reef placements
+
+#### Scenario: Reef-family features differ physically
+- **WHEN** warm reefs, cold reefs, atolls, or lotus features are planned
+- **THEN** each feature follows its named physical habitat rule
+- **AND** reef-family planner admission does not erase those distinctions
+
+#### Scenario: Atolls are evaluated
+- **WHEN** `FEATURE_ATOLL` is considered for a water tile
+- **THEN** the tile must satisfy isolated shallow-bank habitat rather than
+  generic reef or near-coast water habitat
+- **AND** atoll density is bounded by the same sparse-intent proof as other
+  reef-family features

--- a/openspec/changes/constrain-reef-habitat-eligibility/tasks.md
+++ b/openspec/changes/constrain-reef-habitat-eligibility/tasks.md
@@ -1,0 +1,32 @@
+## 1. Reef Diagnosis
+
+- [x] 1.1 Identify broad positive water suitability plus weak planner
+      admission as the current reef saturation cause.
+- [x] 1.2 Quantify current and repaired Earthlike reef-family density from
+      recipe-level execution.
+
+## 2. Reef Habitat Implementation
+
+- [x] 2.1 Add reef-family eligibility fields or scoring terms at the reef op
+      owner.
+- [x] 2.2 Apply reef-family eligibility during reef intent planning.
+- [x] 2.3 Add why/what comments for reef physics tradeoffs.
+
+## 3. Tests And Docs
+
+- [x] 3.1 Add focused reef score/plan tests for broad warm shallow water
+      without shelf/structure, cold-water eligibility, isolated atoll
+      structure, and exact `FEATURE_LOTUS` calm-water habitat.
+- [x] 3.2 Add recipe-level reef density assertions that run `standardRecipe`
+      through the standard runtime/config rather than direct step wiring.
+- [x] 3.3 Update Ecology docs and implementation evidence.
+
+## 4. Verification
+
+- [x] 4.1 Run focused reef/ecology tests.
+- [x] 4.2 Run `bun run --cwd mods/mod-swooper-maps check`.
+- [x] 4.3 Run `bun run openspec -- validate constrain-reef-habitat-eligibility --strict`.
+- [x] 4.4 Run `bun run openspec:validate`.
+- [x] 4.5 Run `bun run build`.
+- [x] 4.6 Run `bun run deploy:mods`.
+- [x] 4.7 Run `git diff --check`.

--- a/openspec/changes/partition-wetland-habitats/.openspec.yaml
+++ b/openspec/changes/partition-wetland-habitats/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-30

--- a/openspec/changes/partition-wetland-habitats/design.md
+++ b/openspec/changes/partition-wetland-habitats/design.md
@@ -1,0 +1,39 @@
+## Wetland Physics
+
+Shared substrate may expose only named physical invariants derived from
+`landMask`, `elevation`, `seaLevel`, `riverClass`, `discharge`, `sinkMask`, and
+coastal adjacency:
+
+- `lowlandMask`: land whose elevation is close to sea level.
+- `floodplainMask`: lowland land near a river with a meaningful flow signal.
+- `intertidalCoastMask`: low coastal land adjacent to water.
+- `sinkBasinMask`: lowland sink/drainage-basin land.
+- `hydromorphicMask`: `floodplainMask OR intertidalCoastMask OR sinkBasinMask`.
+- `wellDrainedMask`: land that is not hydromorphic.
+
+Feature-specific predicates remain with the owning wet feature ops:
+
+- `FEATURE_MARSH`: `hydromorphicMask = 1` plus existing temperate/moist/fertile
+  suitability; generic humid highland is not eligible.
+- `FEATURE_TUNDRA_BOG`: `hydromorphicMask = 1` plus cold/freeze-compatible
+  suitability.
+- `FEATURE_MANGROVE`: `intertidalCoastMask = 1` plus warm/coastal suitability;
+  inland river adjacency is not eligible.
+- `FEATURE_OASIS`: arid isolated water signal from the existing isolated-river
+  substrate and aridity score; it is not a generic wetland floodplain.
+- `FEATURE_WATERING_HOLE`: arid or semi-arid isolated water signal with
+  fertility context; it is not a marsh/bog/mangrove alias.
+
+## Owner Shape
+
+Feature substrate may expose named eligibility fields only when multiple
+wetland score ops share a real invariant. Feature-specific schemas and scoring
+remain beside owning op contracts.
+
+## Review Lanes
+
+- Physics: wetland classes match real-world expectations at map resolution.
+- Architecture: substrate fields are named invariants, not config buckets.
+- Gameplay: wetlands add texture without dominating land features.
+- Adversarial: no fallback, chance thinning, or broad shared schema dumping
+  ground.

--- a/openspec/changes/partition-wetland-habitats/implementation.md
+++ b/openspec/changes/partition-wetland-habitats/implementation.md
@@ -1,0 +1,58 @@
+## Implementation Evidence
+
+Wetland-family habitat now starts with named substrate policies in
+`compute-feature-substrate/policies/wetland-substrate-masks.ts`.
+
+Published substrate fields:
+
+- `lowlandMask`
+- `floodplainMask`
+- `intertidalCoastMask`
+- `sinkBasinMask`
+- `hydromorphicMask`
+- `wellDrainedMask`
+- `isolatedWaterPointMask`
+
+Feature-specific scoring remains in owning wet feature ops:
+
+- `scoreWetMarsh`: requires `hydromorphicMask`.
+- `scoreWetTundraBog`: requires `hydromorphicMask` plus cold/freeze scoring.
+- `scoreWetMangrove`: requires `intertidalCoastMask`.
+- `scoreWetOasis`: requires `isolatedWaterPointMask` plus arid and positive
+  local-water scoring.
+- `scoreWetWateringHole`: requires `isolatedWaterPointMask` plus its own drier
+  local-water and fertility scoring.
+
+## Research Evidence
+
+The algorithm design used EPA/NRCS/USGS-style wetland constraints gathered
+during the research pass: wetlands require persistent saturation/flooding or
+hydric substrate; mangroves are warm intertidal coastal wetlands; bogs require
+cold waterlogged/peat-like conditions; oases and watering holes are arid local
+water-source features rather than generic floodplains.
+
+## Guard Evidence
+
+- `mods/mod-swooper-maps/test/ecology/feature-habitat-eligibility.test.ts`
+  verifies hydromorphic, intertidal, and isolated water-source gates.
+- `mods/mod-swooper-maps/test/ecology/earthlike-balance-smoke.test.ts` bounds
+  wetland density through `standardRecipe.run`.
+- Repaired Earthlike smoke metrics for seed `1018`, `32x20`: wetland family
+  `7/30` land tiles.
+
+Adversarial review P1 on inverted oasis/watering-hole water scoring was
+accepted and repaired.
+
+## Verification
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/ecology/no-fudging-static-scan.test.ts test/ecology/ecology-step-import-guardrails.test.ts test/ecology/score-shared-physics-selection.test.ts test/ecology/feature-planner-policies.test.ts test/ecology/feature-habitat-eligibility.test.ts test/ecology/earthlike-balance-smoke.test.ts test/ecology/op-contracts.test.ts`
+  passed, 32/32 tests.
+- `bun run --cwd mods/mod-swooper-maps check` passed.
+- `bun run openspec -- validate partition-wetland-habitats --strict` passed.
+- `bun run openspec:validate` passed.
+- `bun run build` passed.
+- `bun run deploy:mods` passed and deployed `mod-swooper-maps`.
+- `git diff --check` passed.
+- Fresh `Scripting.log` evidence after deploy shows the standard recipe reached
+  `[50/50] ok mod-swooper-maps.standard.placement.placement` and destroyed the
+  `MapGeneration` context cleanly.

--- a/openspec/changes/partition-wetland-habitats/proposal.md
+++ b/openspec/changes/partition-wetland-habitats/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Marshes and wetland-family features are oversaturated because near-river humid
+or fertile land is too broad a habitat proxy. Wetlands need hydromorphic,
+lowland, floodplain, intertidal, cold-bog, and arid water-point distinctions.
+
+## Target Authority Refs
+
+- `mods/mod-swooper-maps/AGENTS.md`: Ecology owns
+  `artifact:ecology.featureIntents.wetlands`.
+- `docs/system/libs/mapgen/reference/domains/ECOLOGY.md`: feature planning is
+  Ecology truth.
+- Direct user guidance: keep feature-specific physics real and avoid lazy
+  generic fixes.
+
+## What Changes
+
+- Partition wetland-family habitat: marsh, tundra bog, mangrove, oasis, and
+  watering-hole features must each follow the physical context they represent.
+- Keep wetland substrate/scoring/planning in Ecology truth ops.
+- Add focused and recipe-level tests that prevent blanket marsh from river
+  adjacency alone.
+
+## Dependencies
+
+- Requires `bound-ecology-feature-intent-planners`.
+
+## Forbidden Non-Goals
+
+- No chance thinning, generated-output edits, map special casing, projection
+  truth planning, or broad shared config schema buckets.
+
+## Verification Gates
+
+- focused wetland tests;
+- recipe-level wetland balance tests;
+- `bun run --cwd mods/mod-swooper-maps check`;
+- `bun run openspec -- validate partition-wetland-habitats --strict`;
+- `bun run openspec:validate`;
+- `bun run build`;
+- `bun run deploy:mods`;
+- `git diff --check`.

--- a/openspec/changes/partition-wetland-habitats/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/partition-wetland-habitats/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Wetland Intent Planning Uses Wetland-Specific Habitat Partitions
+
+Wetland-family feature planning SHALL distinguish hydromorphic, intertidal,
+cold-bog, and arid water-point habitats instead of treating broad near-river
+moisture as generic wetland intent.
+
+#### Scenario: Humid highland is near a river
+- **WHEN** a land tile is moist and river-adjacent but lacks wetland habitat
+  eligibility such as lowland, floodplain, waterlogged, or intertidal context
+- **THEN** marsh planning does not emit a marsh intent for that tile
+
+#### Scenario: Wetland-family features differ physically
+- **WHEN** marsh, tundra bog, mangrove, oasis, or watering-hole features are
+  planned
+- **THEN** each feature follows its named habitat partition
+- **AND** wetland-family planner admission does not erase those distinctions
+
+#### Scenario: Wetland substrate is shared
+- **WHEN** feature substrate publishes hydromorphic or well-drained eligibility
+- **THEN** the field names represent physical invariants with concrete wetland
+  and vegetation consumers
+- **AND** feature-specific wetland rules remain in owning wet feature ops

--- a/openspec/changes/partition-wetland-habitats/tasks.md
+++ b/openspec/changes/partition-wetland-habitats/tasks.md
@@ -1,0 +1,34 @@
+## 1. Wetland Diagnosis
+
+- [x] 1.1 Identify near-river humid/fertile scoring plus weak planner
+      admission as the current marsh saturation cause.
+- [x] 1.2 Quantify current and repaired Earthlike wetland-family density from
+      recipe-level execution.
+
+## 2. Wetland Habitat Implementation
+
+- [x] 2.1 Add named substrate eligibility fields only where multiple wetland
+      ops share the invariant.
+- [x] 2.2 Keep feature-specific wetland scoring config beside the owning op.
+- [x] 2.3 Apply wetland eligibility during wetland intent planning.
+- [x] 2.4 Add why/what comments for hydromorphic/intertidal policy logic.
+
+## 3. Tests And Docs
+
+- [x] 3.1 Add focused tests for humid highland near river rejection, mangrove
+      coastal/intertidal eligibility, oasis arid isolated water eligibility,
+      watering-hole arid/semi-arid local water plus fertility context, and
+      tundra bog cold waterlogged terrain.
+- [x] 3.2 Add recipe-level wetland density assertions that run `standardRecipe`
+      through the standard runtime/config rather than direct step wiring.
+- [x] 3.3 Update Ecology docs and implementation evidence.
+
+## 4. Verification
+
+- [x] 4.1 Run focused wetland/ecology tests.
+- [x] 4.2 Run `bun run --cwd mods/mod-swooper-maps check`.
+- [x] 4.3 Run `bun run openspec -- validate partition-wetland-habitats --strict`.
+- [x] 4.4 Run `bun run openspec:validate`.
+- [x] 4.5 Run `bun run build`.
+- [x] 4.6 Run `bun run deploy:mods`.
+- [x] 4.7 Run `git diff --check`.


### PR DESCRIPTION
Three completed ecology behavior fixes and one new agent skill are landing together.

---

**Bound ecology feature intent planners**

Feature planners were treating any positive suitability score as a placement command. Each ecology feature family (reefs, wetlands, vegetation, ice) now owns a local `policies/` directory with an explicit score-to-intent admission function. Weak positive scores no longer produce feature intents. The former `confidenceBeatsStress` helper in `score-shared` and any path toward a generic `features-plan-shared` owner have been removed. Every concrete planner strategy imports its family-local policy. Tests cover the weak-positive category across all four feature families, verify that each planner owns a local policy directory, and confirm no generic shared admission machinery exists.

**Constrain reef habitat eligibility**

Reef saturation was caused by broad water suitability fields becoming reef intents even without reef-specific physical structure. All four reef score ops (`scoreReef`, `scoreColdReef`, `scoreReefAtoll`, `scoreReefLotus`) now require `shelfMask`, `coastalWater`, and `distanceToCoast` inputs. Warm reefs require shallow near-coast shelf water. Cold reefs use a bounded depth window on colder shelf/edge water rather than a shallow warm-reef relabeling. Atolls require isolated shallow-bank habitat away from existing coastlines. `FEATURE_LOTUS` requires warm shallow near-land water and is explicitly separated from atoll habitat. Depth parameter names and defaults were corrected to match the physical intent of each reef type. The Earthlike preset and config were updated to match. Recipe-level smoke tests now bound reef-family and atoll density.

**Partition wetland habitats**

Marsh saturation was caused by near-river moisture being too broad a habitat proxy. `compute-feature-substrate` now derives and publishes named wetland substrate masks: `lowlandMask`, `floodplainMask`, `intertidalCoastMask`, `sinkBasinMask`, `hydromorphicMask`, `wellDrainedMask`, and `isolatedWaterPointMask`. These require `elevation`, `seaLevel`, `discharge`, and `sinkMask` inputs. Marsh and tundra bog scoring now gate on `hydromorphicMask` instead of `nearRiverMask`. Mangrove scoring gates on `intertidalCoastMask` instead of generic `coastalLandMask`. Oasis and watering-hole scoring gate on `isolatedWaterPointMask` instead of `isolatedRiverMask`, and their water scoring was corrected from an inverted proxy to a direct local-water signal. The wetland density ceiling in the balance smoke test was tightened from 75% to 35% of land tiles.

**Add `civ7-operational-debugging` agent skill**

A new repo-local agent skill documents the evidence loop for debugging Civ7 mod behavior across source builds, generated output, deployed Mods folders, Civ7 logs, and official resources. It defines a standard debugging workflow, a reference map of operational paths for all supported platforms, and a proof-boundary taxonomy that labels claims as built, generated, deployed, logged, in-game observed, resource-backed, or unresolved. The skill routes architecture, product, OpenSpec, and Graphite authority to their existing owners and explicitly prohibits storing task-specific findings or editing generated output.