### PR TITLE
spec(mapgen): add lake runtime proof, ecology feature families, and world-balance quality gate changes

### DIFF
--- a/openspec/changes/prove-lake-runtime-water-fill/.openspec.yaml
+++ b/openspec/changes/prove-lake-runtime-water-fill/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/prove-lake-runtime-water-fill/design.md
+++ b/openspec/changes/prove-lake-runtime-water-fill/design.md
@@ -1,0 +1,45 @@
+## Context
+
+There are three lake surfaces:
+
+1. Hydrology truth: the planned lake mask from drainage/sink logic.
+2. Map projection: adapter terrain writes and immediate readback.
+3. Civ7 runtime state: final terrain/water/lake/area state after elevation,
+   rivers, validation, placement preparation, and engine cache refresh.
+
+The bug report concerns surface 3. Repairing it by changing surface 1 without
+evidence would hide the owner boundary.
+
+## Design
+
+Keep `map-hydrology/lakes` as the projection orchestrator and the Civ7 adapter
+as the engine boundary. Expand the adapter readback to record enough state to
+distinguish:
+
+- terrain was not stamped as coast;
+- terrain was coast but not water;
+- terrain was water but not lake;
+- lake was accepted early and dried later;
+- lake remained valid but visual proof still disagrees.
+
+Add a final lifecycle parity artifact or diagnostic check after the last engine
+terrain/water maintenance point. The check should compare Hydrology planned
+lakes, map-hydrology accepted lakes, and final `GameplayMap` state. It must
+fail or emit bounded rejection evidence according to a named policy; it must
+not silently accept complete lake rejection.
+
+## FireTuner Proof
+
+Runtime proof should use Scripting.log boundaries plus FireTuner probes of
+`GameplayMap.getTerrainType`, `GameplayMap.isWater`, `GameplayMap.isLake`,
+`GameplayMap.getElevation`, and `GameplayMap.getAreaId` for representative lake
+tiles. If a hidden sea-level setup parameter appears in exported runtime DB
+state, create a separate OpenSpec change before changing map logic for it.
+
+## Review Lanes
+
+- Architecture: Hydrology truth stays upstream; adapter owns engine facts.
+- Product: players see filled lakes, not dry basins.
+- DX: diagnostics explain which lifecycle surface failed.
+- Adversarial: no generator fallback, no manual adapter bypass, no log-only
+  claims without typed evidence where feasible.

--- a/openspec/changes/prove-lake-runtime-water-fill/proposal.md
+++ b/openspec/changes/prove-lake-runtime-water-fill/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+Hydrology lake intent now exists and the map materialization order matches the
+official Civ7 lifecycle more closely, but screenshots still show basins that
+may not visibly fill as water. Current tests prove mock adapter cache refresh
+and early `isWater` readback; they do not prove visible Civ7 lake
+materialization after elevation, rivers, validation, placement preparation, and
+the final runtime state.
+
+Official resources show lakes are interior `TERRAIN_COAST` plus engine area
+classification: terrain is assigned first, `AreaBuilder.recalculateAreas()` is
+called, elevation is built afterward, and `GameplayMap.isLake()`/water state is
+the runtime evidence. The recovery needs runtime proof and stronger typed
+diagnostics, not a Hydrology compensation path.
+
+## Target Authority Refs
+
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`:
+  Hydrology owns lake truth; `map-hydrology` owns projection/materialization.
+- `openspec/changes/archive/2026-05-30-normalize-projection-lakes/`: lake
+  stamping/readback capability exists before fail-hard gates.
+- `.civ7/outputs/resources/Base/modules/base-standard/maps/elevation-terrain-generator.js`:
+  official lakes are stamped as coast terrain and areas are recalculated.
+- User direction: no manual adapter bypasses, no reintroducing engine generator
+  authority, no fallbacks.
+
+## What Changes
+
+- Expand lake projection diagnostics to prove terrain, water, lake, area, and
+  post-lifecycle state instead of only planned/stamped count readback.
+- Add final lifecycle lake preservation checks after engine calls that can
+  rewrite terrain or caches.
+- Use FireTuner/runtime logs to prove deployed maps reach placement and lake
+  runtime state has no current fill drift.
+- Keep Hydrology lake planning untouched unless evidence shows truth itself is
+  wrong.
+
+## Forbidden Non-Goals
+
+- No `adapter.generateLakes(...)` as deterministic MapGen truth.
+- No Hydrology-side dry-basin compensation.
+- No manual step invocation as proof.
+- No treating screenshots alone as closure evidence.
+- No modeling Civ7 sea level as active map control without runtime DB evidence.
+
+## Verification Gates
+
+- focused map-hydrology and materialization-order tests;
+- runtime-lake diagnostics from deployed Civ7/FireTuner;
+- bounded `Scripting.log`/sibling log inspection;
+- `bun run --cwd mods/mod-swooper-maps check`;
+- targeted/global OpenSpec validation;
+- `bun run build`;
+- deploy;
+- `git diff --check`.

--- a/openspec/changes/prove-lake-runtime-water-fill/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/prove-lake-runtime-water-fill/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Lake Projection Is Proven At Runtime Lifecycle Boundaries
+
+MapGen lake projection SHALL prove that Hydrology lake intent remains visible
+as Civ7 water/lake runtime state after the engine terrain lifecycle, not only
+immediately after adapter terrain writes in tests.
+
+#### Scenario: A planned lake tile is projected
+- **WHEN** `map-hydrology/lakes` asks the Civ7 adapter to stamp a planned lake
+  tile
+- **THEN** projection diagnostics record terrain type, water state, lake state,
+  area evidence, and elevation evidence where the runtime exposes them
+- **AND** the diagnostic distinguishes terrain-write failure, water
+  classification failure, lake classification failure, and later drying
+
+#### Scenario: Later engine calls can rewrite terrain or water caches
+- **WHEN** elevation, river modeling, validation, placement preparation, or
+  cache refresh runs after lake projection
+- **THEN** a final lifecycle check compares accepted lake projection against
+  final runtime state
+- **AND** unexpected lake drying is reported as a bounded projection failure
+  rather than silently accepted
+
+#### Scenario: Sea-level behavior is suspected
+- **WHEN** official resources or runtime DB state show an active Civ7 sea-level
+  setup control
+- **THEN** a dedicated OpenSpec change defines how that control affects MapGen
+  water projection
+- **AND** this lake proof change does not bake in speculative sea-level logic

--- a/openspec/changes/prove-lake-runtime-water-fill/tasks.md
+++ b/openspec/changes/prove-lake-runtime-water-fill/tasks.md
@@ -1,0 +1,31 @@
+## 1. Investigation And Spec
+
+- [x] 1.1 Run fresh lake projection/runtime investigator.
+- [x] 1.2 Run official-resource/runtime investigator for Civ7 lake/sea-level evidence.
+- [x] 1.3 Classify the issue as runtime projection/materialization proof unless evidence proves Hydrology truth is wrong.
+- [x] 1.4 Draft OpenSpec proposal/design/spec before implementation.
+
+## 2. Implementation
+
+- [ ] 2.1 Expand adapter lake readback diagnostics with terrain/water/lake/area/elevation evidence.
+- [ ] 2.2 Add a final lifecycle lake preservation check after later engine terrain/cache calls.
+- [ ] 2.3 Keep `map-hydrology` as projection owner and Hydrology as truth owner.
+- [ ] 2.4 Record any sea-level runtime DB evidence; create a separate change if it is active.
+- [ ] 2.5 Add useful why/what comments at non-obvious projection lifecycle boundaries.
+
+## 3. Tests
+
+- [ ] 3.1 Add focused adapter/mock tests for terrain/water/lake readback categories.
+- [ ] 3.2 Add map-hydrology tests that distinguish projection rejection from final-lifecycle drying.
+- [ ] 3.3 Extend world-balance stats to include final lake runtime drift where available.
+- [ ] 3.4 Add a guard against reintroducing engine lake generation as standard MapGen truth.
+
+## 4. Verification
+
+- [ ] 4.1 Run focused map-hydrology/materialization tests.
+- [ ] 4.2 Run shipped-map world-balance stats with lake drift checks.
+- [ ] 4.3 Run `bun run --cwd mods/mod-swooper-maps check`.
+- [ ] 4.4 Run targeted and global OpenSpec validation.
+- [ ] 4.5 Run `bun run build`.
+- [ ] 4.6 Deploy and prove a fresh Civ7 MapGeneration run through FireTuner/logs.
+- [ ] 4.7 Run `git diff --check`.

--- a/openspec/changes/recover-ecology-feature-families/.openspec.yaml
+++ b/openspec/changes/recover-ecology-feature-families/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/recover-ecology-feature-families/design.md
+++ b/openspec/changes/recover-ecology-feature-families/design.md
@@ -1,0 +1,48 @@
+## Context
+
+Vegetation scoring currently treats all visible vegetation as one planner
+family, but the features represent different physical niches. Rainforest is
+warm and wet closed canopy; taiga is cold but still forested; sagebrush steppe
+is dry, open shrubland; savanna woodland is warm, seasonal, and patchy. A
+single biomass multiplier and single planner threshold collapse those niches.
+
+The right unit of ownership is still Ecology:
+
+- each score op owns its habitat math;
+- `features-plan-vegetation` owns score-to-intent admission and selection;
+- shipped configs tune strategy contracts directly;
+- `map-ecology` only projects accepted intents into Civ7.
+
+## Design
+
+Repair the family by separating stress from habitat identity. Cold and arid
+features may use cold or aridity as positive habitat evidence instead of
+receiving the same stress penalty twice. Forest and rainforest continue to use
+biomass and moisture as strong canopy evidence.
+
+Add explicit vegetation admission policy per feature inside the vegetation
+planner. The policy is not a quota and not a fallback. It defines the minimum
+confidence for each feature's own physical signal. If a feature's score does
+not pass its own policy, the planner does not emit it.
+
+The strategy should remain deterministic: compute candidates, filter by
+feature-local admission, choose the best remaining physical candidate, then
+claim occupancy. Do not add randomness to hide bad scoring.
+
+## Product Targets
+
+- Earthlike maps should show a latitudinal succession: rainforest, savanna
+  shoulders, temperate forest, boreal/taiga, sparse tundra or ice where the
+  map reaches polar/cold bands.
+- Desert-mountain identities should show sagebrush/steppe or dry shrubland
+  more readily than rainforest.
+- Archipelago identities may emphasize warm wet vegetation but still must not
+  erase all non-rainforest families unless their climate identity excludes
+  them.
+
+## Review Lanes
+
+- Product/domain: feature presence matches physical habitat and map identity.
+- Architecture: policies stay owner-local; shared helpers stay mechanical.
+- DX: configs expose current strategy contracts without aliases.
+- Adversarial: no compensation paths, no generic routing, no one-seed proof.

--- a/openspec/changes/recover-ecology-feature-families/proposal.md
+++ b/openspec/changes/recover-ecology-feature-families/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+Fresh recipe probes and in-game screenshots show an inverse ecology-feature
+failure: rainforest appears, but taiga, sagebrush steppe, and often savanna
+woodland disappear. Existing world-balance tests pass because they only prove
+aggregate vegetation and upper budgets, not distinct habitat outcomes.
+
+The failure is categorical. Taiga and sagebrush score ops multiply by a
+shared biomass proxy that has already been suppressed by the same cold or dry
+stress those features are meant to represent. The vegetation planner then uses
+one threshold and one winner policy for all vegetation ecotypes, so rainforest
+dominates the family while cold/dry vegetation never reaches intent.
+
+## Target Authority Refs
+
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`:
+  Ecology truth belongs in owner-local ops and policies; map stages project.
+- `mods/mod-swooper-maps/AGENTS.md`: Ecology feature planning publishes split
+  intents before `map-ecology` writes engine state.
+- `docs/system/libs/mapgen/reference/domains/ECOLOGY.md`: feature-family
+  habitat physics belong to Ecology ops/contracts.
+- User direction: rules are policies; keep feature-specific policies near the
+  strategies they modulate and do not create generic routers or shared buckets.
+
+## What Changes
+
+- Repair vegetation-family scoring so cold and dry ecotypes are not erased by
+  duplicated stress penalties.
+- Give vegetation-family planning per-feature admission policy/config where
+  one threshold cannot represent rainforest, forest, taiga, savanna, and
+  sagebrush together.
+- Keep habitat physics and policy code with the owning vegetation feature ops
+  and planner, not `score-shared`, `features-plan-shared`, or a generic bucket.
+- Update shipped map configs/presets to use valid current strategies and
+  identity-specific values.
+- Extend stats/tests so each required vegetation family is measured as a
+  product outcome, not hidden inside aggregate vegetation.
+
+## Dependencies
+
+- Builds on archived `normalize-ecology-topology`,
+  `bound-ecology-feature-intent-planners`, and
+  `align-map-terrain-materialization-order`.
+
+## Forbidden Non-Goals
+
+- No fallback "place any vegetation" behavior.
+- No generic feature router, shared policy bucket, alias, shim, or compatibility
+  lane.
+- No moving feature-specific habitat physics into MapGen core or broad config.
+- No special-casing Swooper Earthlike as the only map product.
+- No proof from screenshots alone.
+
+## Verification Gates
+
+- focused vegetation score/planner policy tests;
+- shipped-map world-balance tests across configs/seeds;
+- config/preset schema and identity tests;
+- `bun run --cwd mods/mod-swooper-maps check`;
+- `bun run openspec -- validate recover-ecology-feature-families --strict`;
+- `bun run openspec:validate`;
+- `bun run build`;
+- deploy and Civ7/FireTuner runtime proof when combined with the stack;
+- `git diff --check`.

--- a/openspec/changes/recover-ecology-feature-families/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/recover-ecology-feature-families/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Ecology Vegetation Families Remain Distinct Product Outcomes
+
+Ecology vegetation scoring and planning SHALL preserve distinct habitat
+outcomes for forest, rainforest, taiga, savanna woodland, and sagebrush steppe
+instead of collapsing all visible vegetation into the highest generic score.
+
+#### Scenario: A cold forest habitat is evaluated
+- **WHEN** taiga suitability is scored for cold land with enough moisture and
+  biomass to support boreal cover
+- **THEN** cold evidence is not counted as both required habitat and a
+  duplicate penalty that erases the score
+- **AND** the score can exceed the owning taiga planner admission policy
+
+#### Scenario: A dry shrub-steppe habitat is evaluated
+- **WHEN** sagebrush steppe suitability is scored for semiarid, well-drained
+  land with low-to-moderate biomass
+- **THEN** aridity evidence is not counted as both required habitat and a
+  duplicate penalty that erases the score
+- **AND** the score can exceed the owning sagebrush planner admission policy
+
+#### Scenario: Vegetation feature intents are selected
+- **WHEN** the vegetation planner evaluates forest, rainforest, taiga, savanna
+  woodland, and sagebrush candidates for a tile
+- **THEN** each candidate is filtered by its own owner-local admission policy
+- **AND** selection remains deterministic among admitted physical candidates
+- **AND** the planner does not emit fallback, quota, alias, or generic
+  vegetation placements
+
+#### Scenario: Shipped map identities are tested
+- **WHEN** shipped map configs and presets run through the standard recipe
+- **THEN** world-balance tests assert required vegetation-family presence and
+  density bands by map identity across seeds
+- **AND** aggregate vegetation counts alone are insufficient proof

--- a/openspec/changes/recover-ecology-feature-families/tasks.md
+++ b/openspec/changes/recover-ecology-feature-families/tasks.md
@@ -1,0 +1,32 @@
+## 1. Investigation And Spec
+
+- [x] 1.1 Run fresh agents for vegetation logic, physical habitat targets, and testing design.
+- [x] 1.2 Quantify current shipped-map feature counts across seeds.
+- [x] 1.3 Classify the issue as categorical scoring/admission plus config identity, not only tuning.
+- [x] 1.4 Draft OpenSpec proposal/design/spec before implementation.
+
+## 2. Implementation
+
+- [ ] 2.1 Repair taiga, sagebrush, forest, savanna, and rainforest score logic at their owning score ops.
+- [ ] 2.2 Add owner-local per-feature vegetation admission policy/config without generic routing.
+- [ ] 2.3 Update vegetation planner strategy to apply per-feature policy before deterministic candidate selection.
+- [ ] 2.4 Update shipped map configs/presets to use current strategies and map-identity-specific values.
+- [ ] 2.5 Add useful why/what comments to changed policies/strategies without architecture metanarration.
+
+## 3. Tests And Stats
+
+- [ ] 3.1 Add unit tests for cold/dry vegetation scoring so taiga and sagebrush are not double-penalized.
+- [ ] 3.2 Add planner tests for per-feature admission, not one aggregate vegetation threshold.
+- [ ] 3.3 Extend world-balance stats to report vegetation family counts and habitat/coherence signals.
+- [ ] 3.4 Add shipped-map/config seed-matrix assertions for required feature families by map identity.
+- [ ] 3.5 Update docs/evidence for feature-family targets and config posture.
+
+## 4. Verification
+
+- [ ] 4.1 Run focused ecology and config tests.
+- [ ] 4.2 Run shipped-map world-balance and seed-matrix stats.
+- [ ] 4.3 Run `bun run --cwd mods/mod-swooper-maps check`.
+- [ ] 4.4 Run targeted and global OpenSpec validation.
+- [ ] 4.5 Run `bun run build`.
+- [ ] 4.6 Deploy and verify in Civ7/FireTuner as part of the combined stack.
+- [ ] 4.7 Run `git diff --check`.

--- a/openspec/changes/tighten-world-balance-quality-gates/.openspec.yaml
+++ b/openspec/changes/tighten-world-balance-quality-gates/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/tighten-world-balance-quality-gates/design.md
+++ b/openspec/changes/tighten-world-balance-quality-gates/design.md
@@ -1,0 +1,34 @@
+## Context
+
+World-balance tests should sit at the public standard recipe/runtime boundary.
+That is where shipped configs, feature-family planning, lake projection, and
+engine-facing adapters meet. Unit tests still own local math, but the quality
+gate must describe product-visible geography.
+
+## Design
+
+Keep `mods/mod-swooper-maps/test/support/world-balance-stats.ts` as the single
+collector. Add derived metrics there so pipeline tests can state invariants
+without rebuilding the recipe in multiple ways.
+
+Use three threshold types:
+
+- hard zero for invalid state: missing artifacts, lake water drift, illegal
+  feature land/water placement, unknown feature keys;
+- broad ratio bands for density budgets: lakes, wetlands, reef family,
+  rainforest, total vegetation;
+- presence/distribution expectations by map identity across N-of-M seeds for
+  features that are rare but required for the identity.
+
+Keep config identity proof separate from balance math. Schema validity proves a
+config can compile; identity tests prove shipped maps and presets use current
+strategies and deliberate values.
+
+## Review Lanes
+
+- Product: thresholds reflect map identities, not current accidents.
+- Testing: failures identify the invariant that broke.
+- Architecture: tests run public recipe/runtime boundaries, not manual step
+  wiring.
+- Adversarial: no exact-count snapshots, no one-off single feature tests for a
+  categorical class.

--- a/openspec/changes/tighten-world-balance-quality-gates/proposal.md
+++ b/openspec/changes/tighten-world-balance-quality-gates/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The current tests can pass while maps visibly fail product expectations. They
+cap some over-dense features and prove aggregate vegetation exists, but they
+do not assert per-family visibility, habitat coherence, map identity, or
+runtime lake fill as categorical product outcomes.
+
+This change makes world-balance proof match how players judge the map:
+Earthlike maps should have coherent climate-to-feature succession, desert
+mountain maps should not become rainforest maps, archipelagos should emphasize
+coastal/ocean ecology without reef carpets, and lakes should visibly fill.
+
+## Target Authority Refs
+
+- `docs/system/TESTING.md`: tests should prove behavior at the relevant
+  boundary.
+- `openspec/specs/mapgen-normalization-workstreams/spec.md`: shipped-map stats
+  and materialization-order proof are normalization requirements.
+- User direction: tests must be categorical, not one-off; configs must be
+  updated with code.
+
+## What Changes
+
+- Extend the shared world-balance stats collector rather than duplicating
+  bespoke runners.
+- Add feature-family totals, per-feature counts, habitat/biome coherence
+  signals, and lake final-state drift metrics.
+- Strengthen shipped config/preset identity tests across seeds and map
+  identities.
+- Record runtime/deploy evidence in implementation tasks before closure.
+
+## Forbidden Non-Goals
+
+- No exact tile-count snapshots as balance proof.
+- No one-seed oracle.
+- No screenshot-only closure.
+- No generic "quality score" that hides which invariant failed.
+- No generated-output hand edits.
+
+## Verification Gates
+
+- focused world-balance stats tests;
+- seed/config matrix tests;
+- config/preset schema and identity tests;
+- targeted/global OpenSpec validation;
+- package check/build/deploy/runtime proof;
+- `git diff --check`.

--- a/openspec/changes/tighten-world-balance-quality-gates/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/tighten-world-balance-quality-gates/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: World Balance Proof Covers Feature Families And Map Identity
+
+World-balance tests SHALL prove product-visible geography through standard
+recipe/runtime execution across shipped map identities and representative
+seeds.
+
+#### Scenario: Vegetation exists only as an aggregate
+- **WHEN** a generated map has rainforest or any vegetation but lacks required
+  forest, taiga, savanna, or sagebrush outcomes for its map identity
+- **THEN** world-balance tests fail with the missing family named
+- **AND** aggregate vegetation presence is not sufficient proof
+
+#### Scenario: Feature density is within broad budgets
+- **WHEN** shipped configs run through the standard recipe
+- **THEN** lake, wetland, reef-family, rainforest, and total vegetation metrics
+  stay within broad map-identity bands
+- **AND** rare required features may be asserted across N-of-M seeds instead
+  of every seed
+
+#### Scenario: Configs compile but drift from product identity
+- **WHEN** shipped map configs or presets use stale strategies, invalid current
+  properties, or values that contradict the map identity
+- **THEN** config identity tests fail even if schema validation passes
+- **AND** implementation updates configs/presets in the same workstream as
+  code changes

--- a/openspec/changes/tighten-world-balance-quality-gates/tasks.md
+++ b/openspec/changes/tighten-world-balance-quality-gates/tasks.md
@@ -1,0 +1,23 @@
+## 1. Investigation And Spec
+
+- [x] 1.1 Run fresh testing/statistics design investigator.
+- [x] 1.2 Compare current tests against visible failure reports.
+- [x] 1.3 Draft OpenSpec proposal/design/spec before implementation.
+
+## 2. Implementation
+
+- [ ] 2.1 Extend the shared world-balance stats collector with feature-family and habitat/coherence metrics.
+- [ ] 2.2 Strengthen shipped config world-balance tests across identities and seeds.
+- [ ] 2.3 Add config/preset identity checks for current strategy/value posture.
+- [ ] 2.4 Keep tests at public recipe/runtime boundaries except for local unit math.
+- [ ] 2.5 Record why/what comments only where helper logic or thresholds encode policy.
+
+## 3. Verification
+
+- [ ] 3.1 Run focused stats/config tests.
+- [ ] 3.2 Run focused ecology/lake tests from sibling OpenSpec changes.
+- [ ] 3.3 Run `bun run --cwd mods/mod-swooper-maps check`.
+- [ ] 3.4 Run targeted and global OpenSpec validation.
+- [ ] 3.5 Run `bun run build`.
+- [ ] 3.6 Deploy and record Civ7/FireTuner runtime evidence.
+- [ ] 3.7 Run `git diff --check`.


### PR DESCRIPTION
Three new OpenSpec change drafts are introduced, each targeting a distinct gap between current test coverage and visible product outcomes.

**prove-lake-runtime-water-fill** addresses the fact that existing tests only verify mock adapter cache refresh and early `isWater` readback, but do not prove that planned lake tiles survive the full Civ7 engine lifecycle—elevation, river modeling, validation, placement preparation, and area recalculation—and remain visible as filled water at runtime. The change expands adapter lake readback diagnostics to record terrain type, water state, lake state, area, and elevation evidence at each lifecycle boundary, adds a final lifecycle preservation check that fails loudly on unexpected lake drying, and requires FireTuner/`Scripting.log` runtime proof from a deployed map. Hydrology lake planning is left untouched unless runtime evidence shows the truth layer itself is wrong. Sea-level behavior is explicitly deferred to a separate OpenSpec change if runtime DB evidence surfaces it.

**recover-ecology-feature-families** targets a categorical scoring failure where taiga and sagebrush steppe score ops apply cold or aridity evidence as both the required habitat signal and a duplicate stress penalty, causing those features to never reach planner admission while rainforest dominates. The fix repairs each feature's score op so cold and dry evidence is not double-counted, introduces per-feature owner-local admission policies inside the vegetation planner instead of a single shared threshold, and updates shipped map configs and presets to reflect current strategies and map-identity-specific values. World-balance tests are extended to assert distinct vegetation family presence by map identity across a seed matrix rather than only aggregate vegetation totals.

**tighten-world-balance-quality-gates** formalizes the testing boundary so that passing tests cannot coexist with visibly broken maps. The shared `world-balance-stats.ts` collector gains feature-family counts, per-feature totals, habitat coherence signals, and lake final-state drift metrics. Three threshold categories are defined: hard-zero guards for invalid state, broad ratio bands for density budgets, and presence/distribution expectations across N-of-M seeds for rare but identity-required features. Config identity tests are added separately from schema validation to catch configs that compile but contradict their declared map identity.