### PR TITLE
feat(vegetation): replace shared admission threshold with per-feature confidence thresholds

### DIFF
--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/contract.ts
@@ -33,12 +33,40 @@ const PlanVegetationContract = defineOp({
   }),
   strategies: {
     default: Type.Object({
-      minConfidence01: Type.Number({
+      forestMinConfidence01: Type.Number({
         minimum: 0,
         maximum: 1,
-        default: 0.18,
+        default: 0.16,
         description:
-          "Family-local admission threshold: vegetation scores below this remain biome cover signal, not placement intent.",
+          "Forest admission threshold: lower-scoring temperate canopy signal remains biome cover, not feature intent.",
+      }),
+      rainforestMinConfidence01: Type.Number({
+        minimum: 0,
+        maximum: 1,
+        default: 0.22,
+        description:
+          "Rainforest admission threshold: keeps tropical closed-canopy intent from absorbing all warm wet land.",
+      }),
+      taigaMinConfidence01: Type.Number({
+        minimum: 0,
+        maximum: 1,
+        default: 0.12,
+        description:
+          "Taiga admission threshold: cold forest scores are lower-amplitude because cold stress is part of the habitat.",
+      }),
+      savannaWoodlandMinConfidence01: Type.Number({
+        minimum: 0,
+        maximum: 1,
+        default: 0.1,
+        description:
+          "Savanna woodland admission threshold: warm seasonal woodland is patchier than closed forest.",
+      }),
+      sagebrushSteppeMinConfidence01: Type.Number({
+        minimum: 0,
+        maximum: 1,
+        default: 0.08,
+        description:
+          "Sagebrush steppe admission threshold: semiarid open-cover scores are intentionally sparse and lower-amplitude.",
       }),
     }),
   },

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/policies/admit-vegetation-intent.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/policies/admit-vegetation-intent.ts
@@ -1,15 +1,49 @@
 /**
- * A vegetation score can mean weak grassland or climate potential, not actual
- * tree/brush cover. The threshold keeps sparse cover features reserved for
- * tiles where moisture, energy, biomass, and stress signals agree strongly
- * enough to read as visible habitat on the playable map.
+ * Vegetation features use different signal amplitudes because closed canopy,
+ * cold conifer forest, warm seasonal woodland, and semiarid shrubland are
+ * different habitats. Admission is therefore feature-local policy, not one
+ * family-wide threshold that lets rainforest erase lower-amplitude ecotypes.
  */
 export function admitVegetationIntent(
-  candidate: Readonly<{ confidence01: number }>,
-  policy: Readonly<{ minConfidence01: number }>
+  candidate: Readonly<{ feature: string; confidence01: number }>,
+  policy: Readonly<{
+    forestMinConfidence01: number;
+    rainforestMinConfidence01: number;
+    taigaMinConfidence01: number;
+    savannaWoodlandMinConfidence01: number;
+    sagebrushSteppeMinConfidence01: number;
+  }>
 ): boolean {
-  const minConfidence01 = Number.isFinite(policy.minConfidence01)
-    ? Math.max(0, Math.min(1, policy.minConfidence01))
-    : 1;
-  return candidate.confidence01 >= minConfidence01;
+  const threshold = minConfidenceForFeature(candidate.feature, policy);
+  return candidate.confidence01 >= threshold;
+}
+
+function clampThreshold(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 1;
+}
+
+export function minConfidenceForFeature(
+  feature: string,
+  policy: Readonly<{
+    forestMinConfidence01: number;
+    rainforestMinConfidence01: number;
+    taigaMinConfidence01: number;
+    savannaWoodlandMinConfidence01: number;
+    sagebrushSteppeMinConfidence01: number;
+  }>
+): number {
+  switch (feature) {
+    case "FEATURE_FOREST":
+      return clampThreshold(policy.forestMinConfidence01);
+    case "FEATURE_RAINFOREST":
+      return clampThreshold(policy.rainforestMinConfidence01);
+    case "FEATURE_TAIGA":
+      return clampThreshold(policy.taigaMinConfidence01);
+    case "FEATURE_SAVANNA_WOODLAND":
+      return clampThreshold(policy.savannaWoodlandMinConfidence01);
+    case "FEATURE_SAGEBRUSH_STEPPE":
+      return clampThreshold(policy.sagebrushSteppeMinConfidence01);
+    default:
+      return 1;
+  }
 }

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-vegetation/strategies/default.ts
@@ -48,7 +48,7 @@ export const defaultStrategy = createStrategy(PlanVegetationContract, "default",
       const savannaConfidence01 = confidenceFromScore01(savannaWoodland);
       const steppeConfidence01 = confidenceFromScore01(sagebrushSteppe);
 
-      const best = choosePhysicalCandidate([
+      const candidates = [
         {
           feature: "FEATURE_FOREST",
           confidence01: forestConfidence01,
@@ -79,9 +79,15 @@ export const defaultStrategy = createStrategy(PlanVegetationContract, "default",
           stress01: stressFromConfidence01(steppeConfidence01),
           tileIndex: i,
         },
-      ]);
+      ] as const;
+
+      // Each vegetation feature owns its own admission amplitude. Filtering
+      // before selection keeps rainforest from winning only because its score
+      // scale is naturally higher than cold or dry open-cover habitats.
+      const best = choosePhysicalCandidate(
+        candidates.filter((candidate) => admitVegetationIntent(candidate, config))
+      );
       if (best === null) continue;
-      if (!admitVegetationIntent(best, config)) continue;
 
       const x = i % width;
       const y = (i / width) | 0;

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/rules/score.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-sagebrush-steppe/rules/score.ts
@@ -32,15 +32,22 @@ export function scoreSagebrushSteppeSuitability(args: {
     const water = args.water01[i];
     const waterStress = args.waterStress01[i];
 
+    const dryHabitat = bandpass(waterStress, 0.45, 0.95, 0.12);
+    const openCover = bandpass(biomass, 0.02, 0.5, 0.12);
+
+    /**
+     * Sagebrush steppe is an open dry shrubland signal. Dryness and low
+     * biomass are part of the target habitat, so this score rewards semiarid
+     * stress instead of multiplying by a canopy-style biomass requirement.
+     */
     const score =
-      biomass *
       bandpass(energy, 0.35, 0.8, 0.12) *
       bandpass(water, 0.05, 0.35, 0.1) *
-      bandpass(waterStress, 0.45, 0.95, 0.1);
+      dryHabitat *
+      (0.45 + 0.55 * openCover);
 
     score01[i] = clamp01(score);
   }
 
   return score01;
 }
-

--- a/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/rules/score.ts
+++ b/mods/mod-swooper-maps/src/domain/ecology/ops/vegetation-score-taiga/rules/score.ts
@@ -34,16 +34,23 @@ export function scoreTaigaSuitability(args: {
     const waterStress = args.waterStress01[i];
     const coldStress = args.coldStress01[i];
 
+    const coldHabitat = bandpass(coldStress, 0.35, 0.9, 0.12);
+    const biomassEvidence = 0.35 + 0.65 * biomass;
+
+    /**
+     * Taiga is cold forest, not failed temperate forest. Biome vegetation
+     * density already falls in cold regions, so cold stress must become habitat
+     * evidence here instead of applying the same penalty twice.
+     */
     const score =
-      biomass *
-      bandpass(energy, 0.1, 0.45, 0.1) *
-      bandpass(water, 0.25, 0.7, 0.1) *
-      (0.4 + 0.6 * coldStress) *
-      (1 - waterStress);
+      biomassEvidence *
+      bandpass(energy, 0.08, 0.5, 0.12) *
+      bandpass(water, 0.22, 0.78, 0.12) *
+      coldHabitat *
+      (1 - 0.75 * waterStress);
 
     score01[i] = clamp01(score);
   }
 
   return score01;
 }
-

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.ts
@@ -338,7 +338,13 @@ export const SHATTERED_RING_CONFIG: StandardRecipeConfig = {
     "plan-vegetation": {
       planVegetation: {
         strategy: "default",
-        config: { minConfidence01: 0.2 },
+        config: {
+          forestMinConfidence01: 0.14,
+          rainforestMinConfidence01: 0.24,
+          taigaMinConfidence01: 0.08,
+          savannaWoodlandMinConfidence01: 0.08,
+          sagebrushSteppeMinConfidence01: 0.06,
+        },
       },
     },
     "plan-plot-effects": {

--- a/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.ts
@@ -338,7 +338,13 @@ export const SUNDERED_ARCHIPELAGO_CONFIG: StandardRecipeConfig = {
     "plan-vegetation": {
       planVegetation: {
         strategy: "default",
-        config: { minConfidence01: 0.18 },
+        config: {
+          forestMinConfidence01: 0.16,
+          rainforestMinConfidence01: 0.22,
+          taigaMinConfidence01: 0.12,
+          savannaWoodlandMinConfidence01: 0.08,
+          sagebrushSteppeMinConfidence01: 0.09,
+        },
       },
     },
     "plan-plot-effects": {

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.ts
@@ -338,7 +338,13 @@ export const SWOOPER_DESERT_MOUNTAINS_CONFIG: StandardRecipeConfig = {
     "plan-vegetation": {
       planVegetation: {
         strategy: "default",
-        config: { minConfidence01: 0.34 },
+        config: {
+          forestMinConfidence01: 0.22,
+          rainforestMinConfidence01: 0.38,
+          taigaMinConfidence01: 0.12,
+          savannaWoodlandMinConfidence01: 0.1,
+          sagebrushSteppeMinConfidence01: 0.04,
+        },
       },
     },
     "plan-plot-effects": {

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -982,7 +982,11 @@
       "planVegetation": {
         "strategy": "default",
         "config": {
-          "minConfidence01": 0.18
+          "forestMinConfidence01": 0.15,
+          "rainforestMinConfidence01": 0.24,
+          "taigaMinConfidence01": 0.08,
+          "savannaWoodlandMinConfidence01": 0.08,
+          "sagebrushSteppeMinConfidence01": 0.06
         }
       }
     },

--- a/mods/mod-swooper-maps/src/presets/standard/earthlike.json
+++ b/mods/mod-swooper-maps/src/presets/standard/earthlike.json
@@ -986,7 +986,11 @@
       "planVegetation": {
         "strategy": "default",
         "config": {
-          "minConfidence01": 0.18
+          "forestMinConfidence01": 0.15,
+          "rainforestMinConfidence01": 0.24,
+          "taigaMinConfidence01": 0.08,
+          "savannaWoodlandMinConfidence01": 0.08,
+          "sagebrushSteppeMinConfidence01": 0.06
         }
       }
     },

--- a/mods/mod-swooper-maps/test/ecology/feature-habitat-eligibility.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/feature-habitat-eligibility.test.ts
@@ -40,7 +40,10 @@ describe("ecology feature habitat eligibility", () => {
         coastalWater,
         distanceToCoast,
       },
-      normalizeOpSelectionOrThrow(ecology.ops.scoreColdReef, { strategy: "default", config: {} })
+      normalizeOpSelectionOrThrow(ecology.ops.scoreColdReef, {
+        strategy: "default",
+        config: { minDepthM: 120, peakDepthM: 300, maxDepthM: 520 },
+      })
     ).score01;
     const abyssalColdReef = ecology.ops.scoreColdReef.run(
       {
@@ -117,5 +120,51 @@ describe("ecology feature habitat eligibility", () => {
     expect(mangrove[1]).toBeGreaterThan(0.2);
     expect(oasis[0]).toBe(0);
     expect(oasis[1]).toBeGreaterThan(0.05);
+  });
+
+  it("keeps cold and dry vegetation habitats from being double-penalized by shared biomass stress", () => {
+    const width = 2;
+    const height = 1;
+    const size = width * height;
+    const landMask = new Uint8Array(size).fill(1);
+    const fertility01 = new Float32Array(size).fill(0.6);
+
+    const taiga = ecology.ops.scoreVegetationTaiga.run(
+      {
+        width,
+        height,
+        landMask,
+        energy01: new Float32Array([0.28, 0.8]),
+        water01: new Float32Array([0.48, 0.48]),
+        waterStress01: new Float32Array([0.1, 0.1]),
+        coldStress01: new Float32Array([0.65, 0.05]),
+        biomass01: new Float32Array([0.12, 0.12]),
+        fertility01,
+      },
+      normalizeOpSelectionOrThrow(ecology.ops.scoreVegetationTaiga, { strategy: "default", config: {} })
+    ).score01;
+
+    const sagebrush = ecology.ops.scoreVegetationSagebrushSteppe.run(
+      {
+        width,
+        height,
+        landMask,
+        energy01: new Float32Array([0.55, 0.55]),
+        water01: new Float32Array([0.2, 0.8]),
+        waterStress01: new Float32Array([0.75, 0.05]),
+        coldStress01: new Float32Array(size),
+        biomass01: new Float32Array([0.12, 0.12]),
+        fertility01,
+      },
+      normalizeOpSelectionOrThrow(ecology.ops.scoreVegetationSagebrushSteppe, {
+        strategy: "default",
+        config: {},
+      })
+    ).score01;
+
+    expect(taiga[0]).toBeGreaterThan(0.1);
+    expect(taiga[1]).toBeLessThan(taiga[0]);
+    expect(sagebrush[0]).toBeGreaterThan(0.05);
+    expect(sagebrush[1]).toBe(0);
   });
 });

--- a/mods/mod-swooper-maps/test/ecology/vegetation-atomic-op.test.ts
+++ b/mods/mod-swooper-maps/test/ecology/vegetation-atomic-op.test.ts
@@ -80,4 +80,53 @@ describe("planVegetation (joint resolver)", () => {
     const b = ecology.ops.planVegetation.run({ ...input, seed: 987654 }, selection);
     expect(b).toEqual(a);
   });
+
+  it("uses feature-local admission thresholds before choosing the vegetation candidate", () => {
+    const width = 1;
+    const height = 2;
+    const size = width * height;
+    const selection = normalizeOpSelectionOrThrow(ecology.ops.planVegetation, {
+      strategy: "default",
+      config: {
+        forestMinConfidence01: 0.2,
+        rainforestMinConfidence01: 0.5,
+        taigaMinConfidence01: 0.1,
+        savannaWoodlandMinConfidence01: 0.1,
+        sagebrushSteppeMinConfidence01: 0.05,
+      },
+    });
+
+    const scoreForest01 = new Float32Array(size);
+    const scoreRainforest01 = new Float32Array(size);
+    const scoreTaiga01 = new Float32Array(size);
+    const scoreSavannaWoodland01 = new Float32Array(size);
+    const scoreSagebrushSteppe01 = new Float32Array(size);
+
+    scoreRainforest01[0] = 0.4;
+    scoreTaiga01[0] = 0.18;
+    scoreForest01[1] = 0.18;
+    scoreSagebrushSteppe01[1] = 0.07;
+
+    const result = ecology.ops.planVegetation.run(
+      {
+        width,
+        height,
+        seed: 1,
+        scoreForest01,
+        scoreRainforest01,
+        scoreTaiga01,
+        scoreSavannaWoodland01,
+        scoreSagebrushSteppe01,
+        landMask: new Uint8Array(size).fill(1),
+        featureIndex: new Uint16Array(size),
+        reserved: new Uint8Array(size),
+      },
+      selection
+    );
+
+    expect(result.placements).toEqual([
+      { x: 0, y: 0, feature: "FEATURE_TAIGA" },
+      { x: 0, y: 1, feature: "FEATURE_SAGEBRUSH_STEPPE" },
+    ]);
+  });
 });


### PR DESCRIPTION
Vegetation admission thresholds are now per-feature rather than a single family-wide value. Previously, one `minConfidence01` threshold was applied after selecting the best candidate, which allowed rainforest — whose signal amplitude is naturally higher — to crowd out lower-amplitude ecotypes like taiga and sagebrush steppe. The new approach filters candidates against their own feature-local thresholds before selection, so each habitat competes only when its own signal is strong enough.

The taiga and sagebrush steppe scoring rules have also been corrected to stop double-penalizing their defining conditions. Taiga cold stress is now treated as habitat evidence rather than a multiplier that suppresses an already-cold biomass signal. Sagebrush steppe no longer multiplies by raw biomass; instead, dryness and open cover are the primary signal, with biomass contributing a soft floor.

Each map config now specifies thresholds for all five vegetation features (`forestMinConfidence01`, `rainforestMinConfidence01`, `taigaMinConfidence01`, `savannaWoodlandMinConfidence01`, `sagebrushSteppeMinConfidence01`), tuned to the expected signal range of each ecotype and the character of each map.