### PR TITLE
feat(lakes): expand lake projection readback with terrain, water, and classification drift evidence

### DIFF
--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/artifacts.ts
@@ -8,10 +8,45 @@ export const MapHydrologyEngineProjectionArtifactSchema = Type.Object(
       description:
         "Engine-accepted lake mask attributable to map-hydrology projection (1=accepted lake, 0=not accepted).",
     }),
+    plannedLakeMask: TypedArraySchemas.u8({
+      description: "Hydrology lake intent mask projected through the Civ7 adapter.",
+    }),
+    engineWaterMask: TypedArraySchemas.u8({
+      description: "Civ7 isWater readback after lake terrain stamping and water cache refresh.",
+    }),
+    engineLakeMask: TypedArraySchemas.u8({
+      description: "Civ7 isLake readback after lake terrain stamping and water cache refresh.",
+    }),
+    engineTerrain: TypedArraySchemas.i32({
+      description: "Civ7 terrain type readback after lake terrain stamping.",
+    }),
+    engineAreaId: TypedArraySchemas.i32({
+      description: "Civ7 area id readback after lake terrain stamping and area recalculation.",
+    }),
+    engineElevation: TypedArraySchemas.i16({
+      description: "Civ7 elevation readback at the lake projection boundary.",
+    }),
+    nonWaterMask: TypedArraySchemas.u8({
+      description: "Planned lake tiles that did not read back as water.",
+    }),
+    nonLakeMask: TypedArraySchemas.u8({
+      description: "Planned lake tiles that did not read back as Civ7 lake-classified water.",
+    }),
+    terrainMismatchMask: TypedArraySchemas.u8({
+      description: "Planned lake tiles whose terrain was not TERRAIN_COAST after stamping.",
+    }),
     sinkMismatchCount: Type.Integer({
       minimum: 0,
       description:
         "Count of hydrography sink tiles that remained non-water in the engine snapshot after lake projection.",
+    }),
+    nonLakeTileCount: Type.Integer({
+      minimum: 0,
+      description: "Count of planned lake tiles that did not read back as Civ7 lake-classified tiles.",
+    }),
+    terrainMismatchTileCount: Type.Integer({
+      minimum: 0,
+      description: "Count of planned lake tiles whose terrain readback did not match TERRAIN_COAST.",
     }),
   },
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-hydrology/steps/lakes.ts
@@ -46,7 +46,18 @@ export default createStep(LakesStepContract, {
         width,
         height,
         lakeMask: projection.stampedLakeMask,
+        plannedLakeMask: projection.plannedLakeMask,
+        engineWaterMask: projection.engineWaterMask,
+        engineLakeMask: projection.engineLakeMask,
+        engineTerrain: projection.engineTerrain,
+        engineAreaId: projection.engineAreaId,
+        engineElevation: projection.engineElevation,
+        nonWaterMask: projection.nonWaterMask,
+        nonLakeMask: projection.nonLakeMask,
+        terrainMismatchMask: projection.terrainMismatchMask,
         sinkMismatchCount: projection.rejectedLakeTileCount,
+        nonLakeTileCount: projection.nonLakeTileCount,
+        terrainMismatchTileCount: projection.terrainMismatchTileCount,
       });
 
       deps.artifacts.hydrologyLakesEngineTerrainSnapshot.publish(context, {
@@ -63,6 +74,8 @@ export default createStep(LakesStepContract, {
         plannedLakeTileCount: projection.plannedLakeTileCount,
         stampedLakeTileCount: projection.stampedLakeTileCount,
         rejectedLakeTileCount: projection.rejectedLakeTileCount,
+        nonLakeTileCount: projection.nonLakeTileCount,
+        terrainMismatchTileCount: projection.terrainMismatchTileCount,
         rejectedLakeShare: Number(
           (projection.rejectedLakeTileCount / Math.max(1, projection.plannedLakeTileCount)).toFixed(
             4

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
@@ -52,11 +52,25 @@ const PlacementSurfacePreparationSchema = Type.Object(
       },
       { additionalProperties: false }
     ),
+    acceptedLakeTileCount: Type.Integer({
+      minimum: 0,
+      description: "Lake tiles accepted by map-hydrology projection before placement maintenance.",
+    }),
+    finalLakeWaterDriftCount: Type.Integer({
+      minimum: 0,
+      description:
+        "Accepted lake tiles that no longer read as water after final placement surface maintenance.",
+    }),
+    finalLakeClassificationDriftCount: Type.Integer({
+      minimum: 0,
+      description:
+        "Accepted lake tiles that no longer read as Civ7 lake tiles after final placement surface maintenance.",
+    }),
   },
   {
     additionalProperties: false,
     description:
-      "Transactional placement preparation result. This exists so resource/start/discovery products depend on a named prepared engine surface instead of a broad placement monolith.",
+      "Transactional placement preparation result. This exists so resource/start/discovery products depend on a named prepared engine surface instead of a broad placement monolith, while retaining final evidence that engine maintenance did not dry projected lakes.",
   }
 );
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/contract.ts
@@ -5,6 +5,7 @@ import {
   PLACEMENT_PRODUCT_EFFECT_TAGS,
 } from "../../../../tags.js";
 import { mapArtifacts } from "../../../../map-artifacts.js";
+import { mapHydrologyArtifacts } from "../../../map-hydrology/artifacts.js";
 import { placementArtifacts } from "../../artifacts.js";
 
 /**
@@ -24,6 +25,7 @@ const PreparePlacementSurfaceStepContract = defineStep({
     requires: [
       placementArtifacts.placementInputs,
       placementArtifacts.naturalWonderPlacement,
+      mapHydrologyArtifacts.engineProjectionLakes,
       mapArtifacts.landmassRegionSlotByTile,
     ],
     provides: [placementArtifacts.placementSurfacePreparation],

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/index.ts
@@ -5,6 +5,7 @@ import { normalizeNaturalWonderStampingStats } from "../place-natural-wonders/ma
 import { runPlacementProductStep } from "../product-runtime.js";
 import { logTerrainStats } from "../terrain-diagnostics.js";
 import { applyLandmassRegionSlots } from "./landmass-regions.js";
+import { readFinalLakeProjection } from "./lake-readback.js";
 import { placementArtifacts } from "../../artifacts.js";
 import PreparePlacementSurfaceStepContract from "./contract.js";
 
@@ -15,6 +16,7 @@ export default createStep(PreparePlacementSurfaceStepContract, {
   run: (context, _config, _ops, deps) => {
     const placementInputs = deps.artifacts.placementInputs.read(context);
     const naturalWonderPlacement = deps.artifacts.naturalWonderPlacement.read(context);
+    const engineProjectionLakes = deps.artifacts.engineProjectionLakes.read(context);
     const landmassRegionSlotByTile = deps.artifacts.landmassRegionSlotByTile.read(context);
     const { floodplains } = buildPlacementPlanInput(placementInputs);
     const { adapter, trace } = context;
@@ -50,6 +52,13 @@ export default createStep(PreparePlacementSurfaceStepContract, {
       applyLandmassRegionSlots(adapter, width, height, slotByTile);
       emit({ type: "placement.landmassRegion.restamped" });
     });
+    const finalLakeReadback = readFinalLakeProjection(
+      adapter,
+      width,
+      height,
+      engineProjectionLakes.lakeMask
+    );
+    emit({ type: "placement.lakes.finalReadback", ...finalLakeReadback });
 
     const slotCounts = { none: 0, west: 0, east: 0 };
     for (let i = 0; i < slotByTile.length; i++) {
@@ -59,6 +68,11 @@ export default createStep(PreparePlacementSurfaceStepContract, {
       else slotCounts.none += 1;
     }
 
-    deps.artifacts.placementSurfacePreparation.publish(context, { width, height, slotCounts });
+    deps.artifacts.placementSurfacePreparation.publish(context, {
+      width,
+      height,
+      slotCounts,
+      ...finalLakeReadback,
+    });
   },
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/lake-readback.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/lake-readback.ts
@@ -1,0 +1,48 @@
+import type { EngineAdapter } from "@civ7/adapter";
+
+export type FinalLakeReadback = Readonly<{
+  acceptedLakeTileCount: number;
+  finalLakeWaterDriftCount: number;
+  finalLakeClassificationDriftCount: number;
+}>;
+
+/**
+ * Placement surface preparation is the final engine-maintenance boundary before
+ * starts/resources/discoveries consume the map. Lake truth still belongs to
+ * Hydrology and lake projection still belongs to map-hydrology; this readback
+ * only proves that later Civ7 terrain validation, area recalculation, and water
+ * cache refresh did not dry the already accepted lake tiles.
+ */
+export function readFinalLakeProjection(
+  adapter: EngineAdapter,
+  width: number,
+  height: number,
+  acceptedLakeMask: Uint8Array
+): FinalLakeReadback {
+  const size = Math.max(0, (width | 0) * (height | 0));
+  if (acceptedLakeMask.length !== size) {
+    throw new Error(
+      `[Placement] Invalid accepted lake mask length for final lake readback (expected ${size}, got ${acceptedLakeMask.length}).`
+    );
+  }
+
+  let acceptedLakeTileCount = 0;
+  let finalLakeWaterDriftCount = 0;
+  let finalLakeClassificationDriftCount = 0;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = y * width + x;
+      if (acceptedLakeMask[idx] !== 1) continue;
+      acceptedLakeTileCount += 1;
+      if (!adapter.isWater(x, y)) finalLakeWaterDriftCount += 1;
+      if (!adapter.isLake(x, y)) finalLakeClassificationDriftCount += 1;
+    }
+  }
+
+  return {
+    acceptedLakeTileCount,
+    finalLakeWaterDriftCount,
+    finalLakeClassificationDriftCount,
+  };
+}

--- a/mods/mod-swooper-maps/test/map-hydrology/lakes-store-water-data.test.ts
+++ b/mods/mod-swooper-maps/test/map-hydrology/lakes-store-water-data.test.ts
@@ -68,10 +68,12 @@ class RejectingLakeAdapter extends MockAdapter {
     this.calls.stampLakes.push({ width, height, lakeMask });
     const size = width * height;
     const rejectedLakeMask = new Uint8Array(size);
+    const nonLakeMask = new Uint8Array(size);
     let plannedLakeTileCount = 0;
     for (let i = 0; i < size; i++) {
       if (lakeMask[i] !== 1) continue;
       rejectedLakeMask[i] = 1;
+      nonLakeMask[i] = 1;
       plannedLakeTileCount += 1;
     }
     return {
@@ -80,9 +82,20 @@ class RejectingLakeAdapter extends MockAdapter {
       plannedLakeMask: lakeMask,
       stampedLakeMask: new Uint8Array(size),
       rejectedLakeMask,
+      engineTerrain: new Int32Array(size),
+      engineWaterMask: new Uint8Array(size),
+      engineLakeMask: new Uint8Array(size),
+      engineAreaId: new Int32Array(size),
+      engineElevation: new Int16Array(size),
+      terrainMismatchMask: new Uint8Array(size),
+      nonWaterMask: rejectedLakeMask,
+      nonLakeMask,
       plannedLakeTileCount,
       stampedLakeTileCount: 0,
       rejectedLakeTileCount: plannedLakeTileCount,
+      terrainMismatchTileCount: 0,
+      nonWaterTileCount: plannedLakeTileCount,
+      nonLakeTileCount: plannedLakeTileCount,
     };
   }
 }
@@ -145,6 +158,12 @@ describe("map-hydrology/lakes", () => {
       "storeWaterData",
     ]);
     expect(adapter.isWater(1, 1)).toBe(true);
+
+    const projection = context.artifacts.get("artifact:map.hydrology.engineProjectionLakes") as
+      | { nonLakeTileCount?: number; terrainMismatchTileCount?: number }
+      | undefined;
+    expect(projection?.nonLakeTileCount ?? -1).toBe(0);
+    expect(projection?.terrainMismatchTileCount ?? -1).toBe(0);
   });
 
   it("records projection rejection as diagnostics without throwing", () => {
@@ -169,10 +188,12 @@ describe("map-hydrology/lakes", () => {
     ).not.toThrow();
 
     const projection = context.artifacts.get("artifact:map.hydrology.engineProjectionLakes") as
-      | { sinkMismatchCount: number }
+      | { sinkMismatchCount: number; nonLakeTileCount?: number; terrainMismatchTileCount?: number }
       | undefined;
     expect(projection).toBeDefined();
     expect(projection?.sinkMismatchCount ?? 0).toBe(1);
+    expect(projection?.nonLakeTileCount ?? 0).toBe(1);
+    expect(projection?.terrainMismatchTileCount ?? 0).toBe(0);
   });
 
   it("stamps the Hydrology lake plan directly instead of calling engine lake generation", () => {

--- a/mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts
@@ -80,6 +80,11 @@ describe("world balance stats", () => {
       // Lakes should read as occasional inland basins, not a terrain-wide sink mask.
       expect(stats.lakeShareOfPreLakeLand, `${caseData.label} lake share`).toBeLessThanOrEqual(0.08);
       expect(stats.lakeWaterDriftCount, `${caseData.label} lake water drift`).toBe(0);
+      expect(stats.finalLakeWaterDriftCount, `${caseData.label} final lake water drift`).toBe(0);
+      expect(
+        stats.finalLakeClassificationDriftCount,
+        `${caseData.label} final lake classification drift`
+      ).toBe(0);
       expect(stats.lakeProjectionMismatchCount, `${caseData.label} rejected lake tiles`).toBeLessThanOrEqual(2);
       expect(stats.singleTileLakeShare, `${caseData.label} one-tile lake share`).toBeLessThanOrEqual(0.2);
       expect(stats.lakeComponentCount, `${caseData.label} lake component count`).toBeLessThanOrEqual(24);

--- a/mods/mod-swooper-maps/test/placement/placement-lake-readback.test.ts
+++ b/mods/mod-swooper-maps/test/placement/placement-lake-readback.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+
+import { MockAdapter } from "@civ7/adapter";
+import { COAST_TERRAIN, FLAT_TERRAIN } from "@swooper/mapgen-core";
+import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
+
+import { readFinalLakeProjection } from "../../src/recipes/standard/stages/placement/steps/prepare-placement-surface/lake-readback.js";
+
+describe("placement final lake readback", () => {
+  it("counts accepted lake tiles that placement-time maintenance dries or declassifies", () => {
+    const width = 4;
+    const height = 3;
+    const adapter = new MockAdapter({
+      width,
+      height,
+      rng: createLabelRng(1234),
+      defaultTerrainType: FLAT_TERRAIN,
+      mapInfo: { GridWidth: width, GridHeight: height, MinLatitude: -60, MaxLatitude: 60 },
+      mapSizeId: 1,
+    });
+    const acceptedLakeMask = new Uint8Array(width * height);
+    acceptedLakeMask[1 + width] = 1;
+    acceptedLakeMask[2 + width] = 1;
+
+    // This reproduces the lifecycle problem we care about: map-hydrology accepted
+    // both lakes, but a later engine maintenance pass left one tile no longer
+    // reading as lake water at the final placement surface boundary.
+    adapter.setTerrainType(1, 1, COAST_TERRAIN);
+    adapter.setTerrainType(2, 1, FLAT_TERRAIN);
+
+    expect(readFinalLakeProjection(adapter, width, height, acceptedLakeMask)).toEqual({
+      acceptedLakeTileCount: 2,
+      finalLakeWaterDriftCount: 1,
+      finalLakeClassificationDriftCount: 1,
+    });
+  });
+});

--- a/mods/mod-swooper-maps/test/support/world-balance-stats.ts
+++ b/mods/mod-swooper-maps/test/support/world-balance-stats.ts
@@ -8,6 +8,7 @@ import { ecologyArtifacts } from "../../src/recipes/standard/stages/ecology/arti
 import { hydrologyHydrographyArtifacts } from "../../src/recipes/standard/stages/hydrology-hydrography/artifacts.js";
 import { mapHydrologyArtifacts } from "../../src/recipes/standard/stages/map-hydrology/artifacts.js";
 import { morphologyArtifacts } from "../../src/recipes/standard/stages/morphology/artifacts.js";
+import { placementArtifacts } from "../../src/recipes/standard/stages/placement/artifacts.js";
 
 export type WorldBalanceStats = Readonly<{
   label: string;
@@ -25,6 +26,8 @@ export type WorldBalanceStats = Readonly<{
   singleTileLakeShare: number;
   largestLakeComponentSize: number;
   lakeWaterDriftCount: number;
+  finalLakeWaterDriftCount: number;
+  finalLakeClassificationDriftCount: number;
   lakeProjectionMismatchCount: number;
   wetlandTiles: number;
   wetlandShareOfPreLakeLand: number;
@@ -199,6 +202,9 @@ export function collectWorldBalanceStats(args: Readonly<{
   const engineLakeProjection = context.artifacts.get(mapHydrologyArtifacts.engineProjectionLakes.id) as
     | { lakeMask?: Uint8Array; sinkMismatchCount?: number }
     | undefined;
+  const placementSurface = context.artifacts.get(placementArtifacts.placementSurfacePreparation.id) as
+    | { finalLakeWaterDriftCount?: number; finalLakeClassificationDriftCount?: number }
+    | undefined;
   const classification = context.artifacts.get(ecologyArtifacts.biomeClassification.id);
   if (!(topography?.landMask instanceof Uint8Array)) throw new Error("Missing topography.landMask.");
   if (!(lakePlan?.lakeMask instanceof Uint8Array)) throw new Error("Missing hydrology.lakePlan.");
@@ -254,6 +260,8 @@ export function collectWorldBalanceStats(args: Readonly<{
     singleTileLakeShare: engineLakeTiles === 0 ? 0 : lakeComponents.singleTileCount / engineLakeTiles,
     largestLakeComponentSize: lakeComponents.largestComponentSize,
     lakeWaterDriftCount,
+    finalLakeWaterDriftCount: placementSurface?.finalLakeWaterDriftCount ?? 0,
+    finalLakeClassificationDriftCount: placementSurface?.finalLakeClassificationDriftCount ?? 0,
     lakeProjectionMismatchCount: engineLakeProjection.sinkMismatchCount ?? 0,
     wetlandTiles,
     wetlandShareOfPreLakeLand: preLakeLandTiles === 0 ? 0 : wetlandTiles / preLakeLandTiles,

--- a/openspec/changes/prove-lake-runtime-water-fill/implementation.md
+++ b/openspec/changes/prove-lake-runtime-water-fill/implementation.md
@@ -1,0 +1,27 @@
+## Implementation Record
+
+This slice separates three lake surfaces:
+
+- Hydrology owns planned lake truth (`artifact:hydrology.lakePlan`).
+- `map-hydrology/lakes` owns Civ7 projection and immediate adapter readback.
+- `prepare-placement-surface` owns final placement-time maintenance evidence after Civ7 terrain validation, area recalculation, and water cache refresh.
+
+The adapter now reads terrain, `isWater`, `isLake`, area id, and elevation after lake stamping. `map-hydrology` publishes that evidence without replacing Hydrology truth. Placement surface preparation reads the accepted map-hydrology lake mask and records whether any accepted lake tile no longer reads as water or lake-classified after the final maintenance boundary.
+
+Local official-resource scan found `MapSeaLevels` in the gameplay schema, but no active base/DLC data rows or standard map script usage in the copied resources. Standard scripts continue to use `GameInfo.Maps.lookup(...).LakeGenerationFrequency` for vanilla lake generation. No sea-level logic change is included in this slice.
+
+## Verification
+
+- `bun run --cwd packages/civ7-adapter build`
+- `bun run --cwd packages/civ7-adapter check`
+- `bun run --cwd mods/mod-swooper-maps test -- test/map-hydrology/lakes-store-water-data.test.ts test/map-hydrology/lakes-runtime-fill-drift.test.ts test/placement/placement-lake-readback.test.ts test/pipeline/world-balance-stats.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate prove-lake-runtime-water-fill --strict`
+- `bun run openspec:validate`
+- `git diff --check`
+
+Pending for overall workstream closure:
+
+- `bun run build`
+- `bun run --cwd mods/mod-swooper-maps deploy`
+- Fresh Civ7/FireTuner MapGeneration runtime proof and bounded log evidence.

--- a/openspec/changes/prove-lake-runtime-water-fill/tasks.md
+++ b/openspec/changes/prove-lake-runtime-water-fill/tasks.md
@@ -7,25 +7,25 @@
 
 ## 2. Implementation
 
-- [ ] 2.1 Expand adapter lake readback diagnostics with terrain/water/lake/area/elevation evidence.
-- [ ] 2.2 Add a final lifecycle lake preservation check after later engine terrain/cache calls.
-- [ ] 2.3 Keep `map-hydrology` as projection owner and Hydrology as truth owner.
-- [ ] 2.4 Record any sea-level runtime DB evidence; create a separate change if it is active.
-- [ ] 2.5 Add useful why/what comments at non-obvious projection lifecycle boundaries.
+- [x] 2.1 Expand adapter lake readback diagnostics with terrain/water/lake/area/elevation evidence.
+- [x] 2.2 Add a final lifecycle lake preservation check after later engine terrain/cache calls.
+- [x] 2.3 Keep `map-hydrology` as projection owner and Hydrology as truth owner.
+- [x] 2.4 Record any sea-level runtime DB evidence; create a separate change if it is active.
+- [x] 2.5 Add useful why/what comments at non-obvious projection lifecycle boundaries.
 
 ## 3. Tests
 
-- [ ] 3.1 Add focused adapter/mock tests for terrain/water/lake readback categories.
-- [ ] 3.2 Add map-hydrology tests that distinguish projection rejection from final-lifecycle drying.
-- [ ] 3.3 Extend world-balance stats to include final lake runtime drift where available.
-- [ ] 3.4 Add a guard against reintroducing engine lake generation as standard MapGen truth.
+- [x] 3.1 Add focused adapter/mock tests for terrain/water/lake readback categories.
+- [x] 3.2 Add map-hydrology tests that distinguish projection rejection from final-lifecycle drying.
+- [x] 3.3 Extend world-balance stats to include final lake runtime drift where available.
+- [x] 3.4 Add a guard against reintroducing engine lake generation as standard MapGen truth.
 
 ## 4. Verification
 
-- [ ] 4.1 Run focused map-hydrology/materialization tests.
-- [ ] 4.2 Run shipped-map world-balance stats with lake drift checks.
-- [ ] 4.3 Run `bun run --cwd mods/mod-swooper-maps check`.
-- [ ] 4.4 Run targeted and global OpenSpec validation.
+- [x] 4.1 Run focused map-hydrology/materialization tests.
+- [x] 4.2 Run shipped-map world-balance stats with lake drift checks.
+- [x] 4.3 Run `bun run --cwd mods/mod-swooper-maps check`.
+- [x] 4.4 Run targeted and global OpenSpec validation.
 - [ ] 4.5 Run `bun run build`.
 - [ ] 4.6 Deploy and prove a fresh Civ7 MapGeneration run through FireTuner/logs.
-- [ ] 4.7 Run `git diff --check`.
+- [x] 4.7 Run `git diff --check`.

--- a/packages/civ7-adapter/src/civ7-adapter.ts
+++ b/packages/civ7-adapter/src/civ7-adapter.ts
@@ -160,6 +160,14 @@ export class Civ7Adapter implements EngineAdapter {
     return GameplayMap.isWater(x, y);
   }
 
+  isLake(x: number, y: number): boolean {
+    return GameplayMap.isLake(x, y);
+  }
+
+  getAreaId(x: number, y: number): number {
+    return GameplayMap.getAreaId(x, y);
+  }
+
   isMountain(x: number, y: number): boolean {
     if (typeof GameplayMap.isMountain === "function") {
       return GameplayMap.isMountain(x, y);
@@ -513,31 +521,65 @@ export class Civ7Adapter implements EngineAdapter {
     this.recalculateAreas();
     this.storeWaterData();
 
-    return this.readLakeProjection(width, height, lakeMask);
+    return this.readLakeProjection(width, height, lakeMask, lakeTerrain);
   }
 
   /**
    * Read back what the engine accepted so projection diagnostics remain evidence,
-   * not the source of lake truth.
+   * not the source of lake truth. Terrain, water, lake classification, area, and
+   * elevation are captured together because Civ7 updates those surfaces through
+   * separate caches and a visual lake failure can hide behind a simple water mask.
    */
   private readLakeProjection(
     width: number,
     height: number,
-    plannedLakeMask: Uint8Array
+    plannedLakeMask: Uint8Array,
+    lakeTerrain: number
   ): LakeProjectionResult {
     const size = Math.max(0, (width | 0) * (height | 0));
     const stampedLakeMask = new Uint8Array(size);
     const rejectedLakeMask = new Uint8Array(size);
+    const engineTerrain = new Int32Array(size);
+    const engineWaterMask = new Uint8Array(size);
+    const engineLakeMask = new Uint8Array(size);
+    const engineAreaId = new Int32Array(size);
+    const engineElevation = new Int16Array(size);
+    const terrainMismatchMask = new Uint8Array(size);
+    const nonWaterMask = new Uint8Array(size);
+    const nonLakeMask = new Uint8Array(size);
     let plannedLakeTileCount = 0;
     let stampedLakeTileCount = 0;
     let rejectedLakeTileCount = 0;
+    let terrainMismatchTileCount = 0;
+    let nonWaterTileCount = 0;
+    let nonLakeTileCount = 0;
 
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
         const idx = y * width + x;
+        const terrain = this.getTerrainType(x, y) | 0;
+        const isWater = this.isWater(x, y);
+        const isLake = this.isLake(x, y);
+        engineTerrain[idx] = terrain;
+        engineWaterMask[idx] = isWater ? 1 : 0;
+        engineLakeMask[idx] = isLake ? 1 : 0;
+        engineAreaId[idx] = this.getAreaId(x, y) | 0;
+        engineElevation[idx] = Math.max(-32768, Math.min(32767, this.getElevation(x, y) | 0));
         if (plannedLakeMask[idx] !== 1) continue;
         plannedLakeTileCount += 1;
-        if (this.isWater(x, y)) {
+        if (terrain !== lakeTerrain) {
+          terrainMismatchMask[idx] = 1;
+          terrainMismatchTileCount += 1;
+        }
+        if (!isWater) {
+          nonWaterMask[idx] = 1;
+          nonWaterTileCount += 1;
+        }
+        if (!isLake) {
+          nonLakeMask[idx] = 1;
+          nonLakeTileCount += 1;
+        }
+        if (isWater) {
           stampedLakeMask[idx] = 1;
           stampedLakeTileCount += 1;
         } else {
@@ -553,9 +595,20 @@ export class Civ7Adapter implements EngineAdapter {
       plannedLakeMask,
       stampedLakeMask,
       rejectedLakeMask,
+      engineTerrain,
+      engineWaterMask,
+      engineLakeMask,
+      engineAreaId,
+      engineElevation,
+      terrainMismatchMask,
+      nonWaterMask,
+      nonLakeMask,
       plannedLakeTileCount,
       stampedLakeTileCount,
       rejectedLakeTileCount,
+      terrainMismatchTileCount,
+      nonWaterTileCount,
+      nonLakeTileCount,
     };
   }
 

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -534,6 +534,16 @@ export class MockAdapter implements EngineAdapter {
     return terrain === this.coastTerrainId || terrain === this.oceanTerrainId;
   }
 
+  isLake(x: number, y: number): boolean {
+    // The mock has no engine area classifier, so coast terrain is its lake-classification evidence.
+    return this.terrainTypes[this.idx(x, y)] === this.coastTerrainId;
+  }
+
+  getAreaId(x: number, y: number): number {
+    // Stable coarse ids are enough for tests that need to prove area readback exists.
+    return this.isWater(x, y) ? 1 : 0;
+  }
+
   isMountain(x: number, y: number): boolean {
     const i = this.idx(x, y);
     if (this.mountainMask[i] === 1) return true;
@@ -872,14 +882,45 @@ export class MockAdapter implements EngineAdapter {
 
     const stampedLakeMask = new Uint8Array(expectedSize);
     const rejectedLakeMask = new Uint8Array(expectedSize);
+    const engineTerrain = new Int32Array(expectedSize);
+    const engineWaterMask = new Uint8Array(expectedSize);
+    const engineLakeMask = new Uint8Array(expectedSize);
+    const engineAreaId = new Int32Array(expectedSize);
+    const engineElevation = new Int16Array(expectedSize);
+    const terrainMismatchMask = new Uint8Array(expectedSize);
+    const nonWaterMask = new Uint8Array(expectedSize);
+    const nonLakeMask = new Uint8Array(expectedSize);
     let stampedLakeTileCount = 0;
     let rejectedLakeTileCount = 0;
+    let terrainMismatchTileCount = 0;
+    let nonWaterTileCount = 0;
+    let nonLakeTileCount = 0;
 
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
         const idx = y * width + x;
+        const terrain = this.getTerrainType(x, y) | 0;
+        const isWater = this.isWater(x, y);
+        const isLake = this.isLake(x, y);
+        engineTerrain[idx] = terrain;
+        engineWaterMask[idx] = isWater ? 1 : 0;
+        engineLakeMask[idx] = isLake ? 1 : 0;
+        engineAreaId[idx] = this.getAreaId(x, y) | 0;
+        engineElevation[idx] = Math.max(-32768, Math.min(32767, this.getElevation(x, y) | 0));
         if (lakeMask[idx] !== 1) continue;
-        if (this.isWater(x, y)) {
+        if (terrain !== this.coastTerrainId) {
+          terrainMismatchMask[idx] = 1;
+          terrainMismatchTileCount += 1;
+        }
+        if (!isWater) {
+          nonWaterMask[idx] = 1;
+          nonWaterTileCount += 1;
+        }
+        if (!isLake) {
+          nonLakeMask[idx] = 1;
+          nonLakeTileCount += 1;
+        }
+        if (isWater) {
           stampedLakeMask[idx] = 1;
           stampedLakeTileCount += 1;
         } else {
@@ -895,9 +936,20 @@ export class MockAdapter implements EngineAdapter {
       plannedLakeMask: lakeMask,
       stampedLakeMask,
       rejectedLakeMask,
+      engineTerrain,
+      engineWaterMask,
+      engineLakeMask,
+      engineAreaId,
+      engineElevation,
+      terrainMismatchMask,
+      nonWaterMask,
+      nonLakeMask,
       plannedLakeTileCount,
       stampedLakeTileCount,
       rejectedLakeTileCount,
+      terrainMismatchTileCount,
+      nonWaterTileCount,
+      nonLakeTileCount,
     };
   }
 

--- a/packages/civ7-adapter/src/types.ts
+++ b/packages/civ7-adapter/src/types.ts
@@ -180,8 +180,10 @@ export interface MapInfo {
 /**
  * Adapter readback for deterministic lake projection.
  *
- * The planned mask is MapGen truth; stamped/rejected masks are engine evidence
- * used by projection diagnostics and should not replace the upstream plan.
+ * The planned mask is MapGen truth; readback fields are engine evidence used by
+ * projection diagnostics and final runtime proof. Water and lake classification
+ * are separate because Civ7 can render or cache water without classifying that
+ * tile as a lake, which is exactly the failure mode this contract must expose.
  */
 export interface LakeProjectionResult {
   width: number;
@@ -189,9 +191,20 @@ export interface LakeProjectionResult {
   plannedLakeMask: Uint8Array;
   stampedLakeMask: Uint8Array;
   rejectedLakeMask: Uint8Array;
+  engineTerrain: Int32Array;
+  engineWaterMask: Uint8Array;
+  engineLakeMask: Uint8Array;
+  engineAreaId: Int32Array;
+  engineElevation: Int16Array;
+  terrainMismatchMask: Uint8Array;
+  nonWaterMask: Uint8Array;
+  nonLakeMask: Uint8Array;
   plannedLakeTileCount: number;
   stampedLakeTileCount: number;
   rejectedLakeTileCount: number;
+  terrainMismatchTileCount: number;
+  nonWaterTileCount: number;
+  nonLakeTileCount: number;
 }
 
 // ============================================================================
@@ -297,6 +310,12 @@ export interface EngineAdapter {
 
   /** Check if tile is water */
   isWater(x: number, y: number): boolean;
+
+  /** Check whether Civ7 classifies the tile as lake water */
+  isLake(x: number, y: number): boolean;
+
+  /** Get Civ7's area id for water/land topology readback */
+  getAreaId(x: number, y: number): number;
 
   /** Check if tile is mountain */
   isMountain(x: number, y: number): boolean;


### PR DESCRIPTION
Expands lake projection diagnostics to capture the full Civ7 engine surface after lake stamping and adds a final placement-time readback to prove that later engine maintenance passes do not dry accepted lake tiles.

**Lake projection readback (`map-hydrology`)**

After lake terrain stamping, area recalculation, and water cache refresh, the adapter now reads back terrain type, `isWater`, `isLake`, area id, and elevation for every planned lake tile. Water and lake classification are tracked separately because Civ7 can cache a tile as water without classifying it as a lake, which is the specific failure mode this work targets. The `LakeProjectionResult` contract gains per-tile masks (`engineWaterMask`, `engineLakeMask`, `engineTerrain`, `engineAreaId`, `engineElevation`, `nonWaterMask`, `nonLakeMask`, `terrainMismatchMask`) and aggregate counts (`nonLakeTileCount`, `terrainMismatchTileCount`). These are published through the `engineProjectionLakes` artifact without replacing Hydrology's upstream lake plan as truth.

**Final placement surface readback (`prepare-placement-surface`)**

A new `readFinalLakeProjection` function runs at the placement surface preparation boundary — the last engine maintenance point before starts, resources, and discoveries consume the map. It reads the accepted lake mask from `map-hydrology` and checks whether any accepted tile no longer reads as water or lake-classified after Civ7 terrain validation and cache refresh. The resulting `acceptedLakeTileCount`, `finalLakeWaterDriftCount`, and `finalLakeClassificationDriftCount` are published in the `placementSurfacePreparation` artifact.

**Adapter interface**

`isLake` and `getAreaId` are added to `EngineAdapter`, `Civ7Adapter`, and `MockAdapter`. The mock uses coast terrain as its lake-classification proxy and returns stable coarse area ids sufficient for test coverage.

**Tests and world-balance stats**

The `lakes-store-water-data` tests are extended to assert `nonLakeTileCount` and `terrainMismatchTileCount` on both the happy path and the rejection path. A new `placement-lake-readback` test directly exercises the lifecycle scenario where map-hydrology accepted a tile that a later maintenance pass left non-water. World-balance stats now include `finalLakeWaterDriftCount` and `finalLakeClassificationDriftCount`, and the pipeline test asserts both are zero across all shipped map cases.