### PR TITLE
fix(earthlike): tighten vegetation family balance and add per-identity ecology gates

### DIFF
--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -983,10 +983,10 @@
         "strategy": "default",
         "config": {
           "forestMinConfidence01": 0.15,
-          "rainforestMinConfidence01": 0.24,
+          "rainforestMinConfidence01": 0.28,
           "taigaMinConfidence01": 0.08,
-          "savannaWoodlandMinConfidence01": 0.08,
-          "sagebrushSteppeMinConfidence01": 0.06
+          "savannaWoodlandMinConfidence01": 0.05,
+          "sagebrushSteppeMinConfidence01": 0.04
         }
       }
     },

--- a/mods/mod-swooper-maps/src/presets/standard/earthlike.json
+++ b/mods/mod-swooper-maps/src/presets/standard/earthlike.json
@@ -987,10 +987,10 @@
         "strategy": "default",
         "config": {
           "forestMinConfidence01": 0.15,
-          "rainforestMinConfidence01": 0.24,
+          "rainforestMinConfidence01": 0.28,
           "taigaMinConfidence01": 0.08,
-          "savannaWoodlandMinConfidence01": 0.08,
-          "sagebrushSteppeMinConfidence01": 0.06
+          "savannaWoodlandMinConfidence01": 0.05,
+          "sagebrushSteppeMinConfidence01": 0.04
         }
       }
     },

--- a/mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts
@@ -23,6 +23,15 @@ const CASES = [
     config: unwrapConfig(swooperEarthlikeConfigRaw),
     wetlandMax: 0.08,
     reefMax: 0.04,
+    requiredFeatures: [
+      "FEATURE_FOREST",
+      "FEATURE_RAINFOREST",
+      "FEATURE_TAIGA",
+      "FEATURE_SAVANNA_WOODLAND",
+      "FEATURE_SAGEBRUSH_STEPPE",
+    ],
+    vegetationFamiliesMin: 5,
+    rainforestVegetationShareMax: 0.65,
     requireColdReefs: true,
     requireAtolls: true,
   },
@@ -31,6 +40,15 @@ const CASES = [
     config: unwrapConfig(earthlikePresetRaw),
     wetlandMax: 0.08,
     reefMax: 0.04,
+    requiredFeatures: [
+      "FEATURE_FOREST",
+      "FEATURE_RAINFOREST",
+      "FEATURE_TAIGA",
+      "FEATURE_SAVANNA_WOODLAND",
+      "FEATURE_SAGEBRUSH_STEPPE",
+    ],
+    vegetationFamiliesMin: 5,
+    rainforestVegetationShareMax: 0.65,
     requireColdReefs: true,
     requireAtolls: true,
   },
@@ -39,6 +57,13 @@ const CASES = [
     config: realismEarthlikeConfig,
     wetlandMax: 0.08,
     reefMax: 0.03,
+    requiredFeatures: [
+      "FEATURE_FOREST",
+      "FEATURE_RAINFOREST",
+      "FEATURE_SAVANNA_WOODLAND",
+      "FEATURE_SAGEBRUSH_STEPPE",
+    ],
+    vegetationFamiliesMin: 4,
     requireAtolls: true,
   },
   {
@@ -46,6 +71,8 @@ const CASES = [
     config: SHATTERED_RING_CONFIG,
     wetlandMax: 0.12,
     reefMax: 0.02,
+    requiredFeatures: ["FEATURE_FOREST", "FEATURE_RAINFOREST", "FEATURE_SAGEBRUSH_STEPPE"],
+    vegetationFamiliesMin: 3,
     requireAtolls: true,
   },
   {
@@ -53,6 +80,8 @@ const CASES = [
     config: SUNDERED_ARCHIPELAGO_CONFIG,
     wetlandMax: 0.22,
     reefMax: 0.02,
+    requiredFeatures: ["FEATURE_FOREST", "FEATURE_RAINFOREST", "FEATURE_MANGROVE"],
+    vegetationFamiliesMin: 2,
     requireColdReefs: true,
     requireAtolls: true,
   },
@@ -61,6 +90,8 @@ const CASES = [
     config: SWOOPER_DESERT_MOUNTAINS_CONFIG,
     wetlandMax: 0.08,
     reefMax: 0.03,
+    requiredFeatures: ["FEATURE_SAVANNA_WOODLAND", "FEATURE_SAGEBRUSH_STEPPE"],
+    vegetationFamiliesMin: 2,
     requireAtolls: true,
     rainforestMax: 20,
   },
@@ -112,6 +143,19 @@ describe("world balance stats", () => {
       if (caseData.requireAtolls) {
         expect(stats.featureCounts.FEATURE_ATOLL, `${caseData.label} atolls`).toBeGreaterThan(0);
       }
+      for (const feature of caseData.requiredFeatures) {
+        expect(stats.featureCounts[feature], `${caseData.label} ${feature}`).toBeGreaterThan(0);
+      }
+      expect(
+        stats.vegetationFeatureFamiliesPresent,
+        `${caseData.label} vegetation family count`
+      ).toBeGreaterThanOrEqual(caseData.vegetationFamiliesMin);
+      if ("rainforestVegetationShareMax" in caseData) {
+        expect(
+          stats.featureCounts.FEATURE_RAINFOREST / Math.max(1, stats.vegetationFamilyTiles),
+          `${caseData.label} rainforest share of vegetation`
+        ).toBeLessThanOrEqual(caseData.rainforestVegetationShareMax);
+      }
       if ("rainforestMax" in caseData) {
         expect(stats.featureCounts.FEATURE_RAINFOREST, `${caseData.label} rainforest`).toBeLessThanOrEqual(
           caseData.rainforestMax
@@ -143,6 +187,10 @@ describe("world balance stats", () => {
       expect(stats.vegetationFeatureFamiliesPresent, `${stats.label} vegetation families present`).toBeGreaterThanOrEqual(4);
       expect(stats.vegetationFamilyShareOfPreLakeLand, `${stats.label} vegetation share`).toBeGreaterThan(0.08);
       expect(stats.vegetationFamilyShareOfPreLakeLand, `${stats.label} vegetation share`).toBeLessThan(0.55);
+      expect(
+        stats.featureCounts.FEATURE_RAINFOREST / Math.max(1, stats.vegetationFamilyTiles),
+        `${stats.label} rainforest share of vegetation`
+      ).toBeLessThanOrEqual(0.7);
       expect(stats.featureCounts.FEATURE_RAINFOREST, `${stats.label} rainforest`).toBeLessThanOrEqual(
         Math.max(1, Math.floor(stats.preLakeLandTiles * 0.35))
       );

--- a/openspec/changes/archive/2026-05-30-finish-mapgen-world-balancing/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-30-finish-mapgen-world-balancing/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/archive/2026-05-30-finish-mapgen-world-balancing/proposal.md
+++ b/openspec/changes/archive/2026-05-30-finish-mapgen-world-balancing/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+The prior balance gates prove lakes are stable and aggregate vegetation exists,
+but fresh shipped-map stats still show ecology balance is not finished:
+rainforest can dominate earthlike rolls while savanna/steppe are marginal, and
+some shipped identities pass with only two or three visible vegetation
+families.
+
+This change finishes the product-visible balancing slice by making map-identity
+vegetation expectations explicit, tuning configs/policies to meet those
+expectations, and keeping hydrology lake projection gates green as the
+regression boundary.
+
+## Target Authority Refs
+
+- `openspec/specs/mapgen-normalization-workstreams/spec.md`: world-balance
+  proof must cover feature families and map identity.
+- `mods/mod-swooper-maps/AGENTS.md`: Ecology feature planning owns split
+  feature intents before `map-ecology` projection.
+- `docs/system/mods/swooper-maps/architecture.md`: hydrology lake plans and
+  ecology feature intents are pipeline truth; map stages project them.
+
+## What Changes
+
+- Tighten world-balance assertions so map identities cannot pass on aggregate
+  vegetation alone.
+- Tune shipped ecology configs and/or owner-local feature-family policies to
+  improve forest/rainforest/taiga/savanna/steppe distribution without fallback
+  quotas.
+- Preserve lake projection and visual-scatter gates while changing ecology.
+- Record focused before/after stats and close with build/deploy evidence.
+
+## Forbidden Non-Goals
+
+- No quota-based or fallback feature placement.
+- No exact tile-count snapshots as acceptance proof.
+- No generated-output hand edits.
+- No weakening lake projection, drift, or scatter assertions to make ecology
+  tuning pass.
+
+## Verification Gates
+
+- focused world-balance stats tests;
+- config/preset schema and identity tests;
+- focused ecology planner/policy tests where changed;
+- `bun run --cwd mods/mod-swooper-maps check`;
+- `bun run openspec -- validate finish-mapgen-world-balancing --strict`;
+- `bun run openspec:validate`;
+- `bun run build`;
+- `bun run --cwd mods/mod-swooper-maps deploy`;
+- FireTuner `Network.restartGame()` runtime map-generation proof from the
+  deployed final tree;
+- `git diff --check`.

--- a/openspec/changes/archive/2026-05-30-finish-mapgen-world-balancing/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/archive/2026-05-30-finish-mapgen-world-balancing/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Shipped Ecology Balance Has Map-Identity Minimums
+
+World-balance proof SHALL assert the vegetation-family outcomes that define
+each shipped map identity, not only aggregate vegetation coverage or broad
+upper budgets.
+
+#### Scenario: Earthlike vegetation distribution regresses
+- **WHEN** Swooper Earthlike or the standard Earthlike preset runs across
+  representative seeds
+- **THEN** forest, rainforest, taiga, savanna woodland, and sagebrush steppe
+  remain visible as distinct product outcomes
+- **AND** no single vegetation family is allowed to stand in for overall
+  ecology balance
+
+#### Scenario: Non-earthlike identities have narrower expected families
+- **WHEN** a shipped specialty identity such as archipelago, ring, or desert
+  mountains is generated
+- **THEN** tests assert the vegetation families and density bands appropriate
+  to that identity
+- **AND** aggregate vegetation presence alone is insufficient proof
+
+#### Scenario: Ecology tuning preserves hydrology quality
+- **WHEN** ecology config or feature-family policy is tuned
+- **THEN** existing lake share, lake component, projection mismatch, and final
+  lake drift assertions remain active
+- **AND** ecology balancing does not weaken hydrology proof to pass

--- a/openspec/changes/archive/2026-05-30-finish-mapgen-world-balancing/tasks.md
+++ b/openspec/changes/archive/2026-05-30-finish-mapgen-world-balancing/tasks.md
@@ -1,0 +1,27 @@
+## 1. Investigation And Spec
+
+- [x] 1.1 Run fresh shipped-map stats across current configs and representative earthlike seeds.
+- [x] 1.2 Identify remaining product-visible balance gaps after archived quality gates.
+- [x] 1.3 Draft OpenSpec proposal/spec before implementation edits.
+
+## 2. Implementation
+
+- [x] 2.1 Strengthen world-balance tests so vegetation-family distribution is map-identity specific.
+- [x] 2.2 Tune shipped ecology config and/or owner-local feature policies to satisfy the stronger gates.
+- [x] 2.3 Keep hydrology lake shape/projection assertions intact and green.
+- [x] 2.4 Update adjacent docs/specs only if durable product behavior changes.
+
+## 3. Verification
+
+- [x] 3.1 Run focused world-balance and config tests.
+- [x] 3.2 Run focused ecology planner/policy tests affected by the change.
+- [x] 3.3 Run `bun run --cwd mods/mod-swooper-maps check`.
+- [x] 3.4 Run targeted and global OpenSpec validation.
+- [x] 3.5 Run `bun run build`.
+- [x] 3.6 Deploy the mod from the final tree and verify deployed artifact parity.
+- [x] 3.7 Run `git diff --check`.
+- [x] 3.8 Run fresh FireTuner restart proof from the deployed final tree:
+  `codex-010` submitted raw `Network.restartGame()` at 2026-05-30 17:04:27,
+  Civ7 created `MapGeneration` at 2026-05-30 17:04:33, Swooper completed
+  50/50 recipe steps by 2026-05-30 17:04:35, and the bounded Swooper log window
+  had no Swooper error/failure lines.

--- a/openspec/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/specs/mapgen-normalization-workstreams/spec.md
@@ -747,3 +747,30 @@ seeds.
 - **THEN** config identity tests fail even if schema validation passes
 - **AND** implementation updates configs/presets in the same workstream as
   code changes
+
+### Requirement: Shipped Ecology Balance Has Map-Identity Minimums
+
+World-balance proof SHALL assert the vegetation-family outcomes that define
+each shipped map identity, not only aggregate vegetation coverage or broad
+upper budgets.
+
+#### Scenario: Earthlike vegetation distribution regresses
+- **WHEN** Swooper Earthlike or the standard Earthlike preset runs across
+  representative seeds
+- **THEN** forest, rainforest, taiga, savanna woodland, and sagebrush steppe
+  remain visible as distinct product outcomes
+- **AND** no single vegetation family is allowed to stand in for overall
+  ecology balance
+
+#### Scenario: Non-earthlike identities have narrower expected families
+- **WHEN** a shipped specialty identity such as archipelago, ring, or desert
+  mountains is generated
+- **THEN** tests assert the vegetation families and density bands appropriate
+  to that identity
+- **AND** aggregate vegetation presence alone is insufficient proof
+
+#### Scenario: Ecology tuning preserves hydrology quality
+- **WHEN** ecology config or feature-family policy is tuned
+- **THEN** existing lake share, lake component, projection mismatch, and final
+  lake drift assertions remain active
+- **AND** ecology balancing does not weaken hydrology proof to pass


### PR DESCRIPTION
This PR finishes the product-visible ecology balancing slice for shipped map identities by making vegetation-family expectations explicit per identity and tuning configs to meet those expectations.

## Motivation

Prior balance gates confirmed lake stability and aggregate vegetation presence, but earthlike map rolls showed rainforest dominating while savanna woodland and sagebrush steppe remained marginal. Some shipped identities were passing with only two or three visible vegetation families, which is insufficient proof of ecology balance.

## Ecology Config Tuning

To reduce rainforest dominance and improve savanna/steppe presence on earthlike maps, the minimum confidence thresholds were adjusted:

- `rainforestMinConfidence01`: `0.24` → `0.28` (raises the bar for rainforest placement, reducing its spread)
- `savannaWoodlandMinConfidence01`: `0.08` → `0.05` (lowers the bar, allowing savanna woodland to appear more readily)
- `sagebrushSteppeMinConfidence01`: `0.06` → `0.04` (lowers the bar, allowing sagebrush steppe to appear more readily)

These changes apply to both the Swooper Earthlike config and the standard Earthlike preset.

## Strengthened Test Assertions

World-balance tests now enforce map-identity-specific vegetation expectations rather than relying solely on aggregate coverage:

- Each map identity now declares `requiredFeatures` that must be present and a `vegetationFamiliesMin` floor that must be met.
- Earthlike identities additionally enforce a `rainforestVegetationShareMax` of 0.65, preventing rainforest from crowding out other families.
- A global cap of 0.70 rainforest share of vegetation tiles is enforced across all map types.
- Required features per identity reflect the ecological character of each map type (e.g., desert mountains requires savanna woodland and sagebrush steppe but not taiga; archipelago requires mangrove).

## Spec

A new OpenSpec requirement codifies that world-balance proof must assert vegetation-family outcomes per shipped map identity, not only aggregate vegetation coverage, and that ecology tuning must not weaken hydrology proof to pass.