### PR TITLE
spec(swooper-maps): add normalize-swooper-map-config-generation change spec

### DIFF
--- a/openspec/changes/README.md
+++ b/openspec/changes/README.md
@@ -25,6 +25,7 @@ Authority:
 | 7 | `normalize-placement-contracts` | D3, Domino 4 contract boundaries | `normalize-import-boundaries`, `normalize-projection-lakes` |
 | 8 | `normalize-placement-reconciliation` | D4, Domino 4 typed reconciliation | `normalize-placement-contracts` |
 | 9 | `normalize-guardrails-promotion` | Domino 5, G1-G9 | cleanup slices whose guards are enabled |
+| 10 | `normalize-swooper-map-config-generation` | Swooper Maps shipped-map config authority and generated map artifacts | `normalize-config-surface`, `normalize-core-studio-dx-boundaries`, `normalize-sdk-mapgen-runtime-entrypoint` |
 
 Parallelism:
 
@@ -36,6 +37,9 @@ Parallelism:
   contracts exist.
 - `normalize-guardrails-promotion` may enable individual guards incrementally,
   but each guard must cite the cleanup change that makes it pass.
+- `normalize-swooper-map-config-generation` is an integrated follow-on to D1:
+  it should start after the flat config surface is available, then can split
+  implementation into config/schema, generator, and Studio repo-save slices.
 
 ## Review Roles
 

--- a/openspec/changes/normalize-swooper-map-config-generation/.openspec.yaml
+++ b/openspec/changes/normalize-swooper-map-config-generation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-30

--- a/openspec/changes/normalize-swooper-map-config-generation/design.md
+++ b/openspec/changes/normalize-swooper-map-config-generation/design.md
@@ -1,0 +1,242 @@
+## Context
+
+The investigation found one user-facing mismatch and one architecture mismatch.
+
+The user-facing mismatch: Studio presents save/update flows as "preset"
+authoring, but the durable shipped-map source is in the repo. Saving a Studio
+variant currently writes browser-local state, so authors do not continue editing
+the file they opened or the config directory they expect.
+
+The architecture mismatch: a shipped map variant is not one thing in source. It
+is a recipe config payload, a TS wrapper, a `tsup` entry, XML map row, modinfo
+import item, localization rows, and Studio built-in preset payload. Those
+surfaces repeat identity and drift independently.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `src/maps/configs/*.config.json` the only authored source for shipped
+  map variants.
+- Encode each shipped map as a full JSON config envelope: metadata plus the
+  complete flat recipe config payload.
+- Generate every Civ7 and Studio projection from the canonical config
+  directory.
+- Make Studio save and save-as operate on repo-backed config files.
+- Remove duplicate map identity/config sources after the generator owns them.
+
+**Non-Goals:**
+
+- Do not redesign the standard recipe, stage topology, ecology truth, placement
+  contracts, or adapter projection.
+- Do not hand-edit generated `mod/` output.
+- Do not prove or adopt a single shared map runtime script in this slice.
+- Do not require comments inside JSON. Pure JSON remains the roundtrippable
+  data source; descriptions belong in schema/docs and generated typing aids.
+
+## Team Design Pass
+
+This change has three review lanes with explicit handoffs.
+
+- OpenSpec/change owner: owns the proposal, target requirements, scope
+  boundaries, and closure criteria. Receives evidence from all lanes and has
+  final accountability for keeping this one integrated change coherent.
+- Config/Studio lane: owns the authoring flow, canonical JSON envelope, schema
+  descriptions, full-config validation, Studio repo-backed load/save/save-as,
+  and scratch/import/export disposition.
+- Generation/mod lane: owns build enumeration, generated entry modules, `tsup`
+  integration, XML/modinfo/text generation, generated-artifact boundaries, and
+  Civ7 one-file-per-map constraints.
+
+Interfaces:
+
+- Config/Studio hands the generation lane a validated registry of map entries:
+  id, display metadata, recipe id, sort order, latitude bounds, output file
+  stem, localization tags/text, and full recipe config.
+- Generation/mod hands Studio the generated built-in config catalog and schema
+  references; Studio does not scrape generated `mod/` output.
+- Both implementation lanes hand the OpenSpec owner tests, searches, generated
+  snapshots, and any stop-condition evidence before closure.
+
+Feedback loops:
+
+- Early generator snapshot review catches duplicate identity before Studio
+  work depends on it.
+- Studio save-path review catches browser-only persistence before config files
+  are converted.
+- Adversarial review searches for active source duplicates: hand-written map
+  wrappers, `.config.ts` shipped map configs, hardcoded `tsup` entries,
+  separate Studio preset payloads, localStorage "real preset" saves, and
+  persisted `advanced` compatibility.
+
+## Decisions
+
+### Canonical Map Config Envelope
+
+Each shipped map config is a JSON document under:
+
+```text
+mods/mod-swooper-maps/src/maps/configs/<map-id>.config.json
+```
+
+The target shape is:
+
+```json
+{
+  "$schema": "../../../dist/recipes/standard-map-config.schema.json",
+  "id": "swooper-earthlike",
+  "name": "Swooper Earthlike",
+  "description": "An Earth-analogue world...",
+  "recipe": "standard",
+  "sortIndex": 501,
+  "latitudeBounds": {
+    "topLatitude": 90,
+    "bottomLatitude": -90
+  },
+  "config": {
+    "foundation": {},
+    "morphology-coasts": {},
+    "ecology-biomes": {}
+  }
+}
+```
+
+The example is structural, not a complete payload. The implementation must
+derive the concrete recipe config schema from the recipe contract and must not
+hand-maintain a second list of valid stage/step keys.
+
+Required metadata:
+
+- `id`: stable map id and file stem. It must match the file name.
+- `name`: English display name source for localization generation.
+- `description`: English display description source for localization
+  generation.
+- `recipe`: recipe id. The first implementation supports `standard`;
+  multi-recipe dispatch requires a separate recipe-dispatch requirement before
+  implementation broadens this field.
+- `sortIndex`: Civ7 map selection order.
+- `config`: full flat recipe config payload.
+
+Optional metadata:
+
+- `latitudeBounds`: forwarded to SDK `createMap` when present.
+- `logPrefix`: only if a shipped map needs a distinct runtime prefix.
+- future localization overrides only after a localization design requires
+  multiple locales.
+
+### Shipped Configs Are Full Configs, Not Preset Overlays
+
+Shipped map files are complete source configs. They are not partial overlays
+that depend on hidden recipe defaults to become meaningful. The implementation
+must provide a validation gate that compiles or materializes each shipped JSON
+file and proves every required stage/step/op strategy envelope and config value
+is concrete before generation emits Civ7 artifacts.
+
+Recipe compilation may still normalize and validate, but omitted strategy
+selection in a shipped map is a source-quality failure, not a generator feature.
+
+### JSON Is The Source; Schema And Generated Aids Carry Documentation
+
+Pure JSON cannot carry JSDoc comments or participate directly in JSDoc
+typechecking. The source of truth remains JSON because Studio must roundtrip it
+without preserving comments or executable code. Documentation and authoring
+help come from:
+
+- generated JSON schemas with descriptions;
+- generated TypeScript types for tooling/tests;
+- docs that explain config fields and strategy envelopes;
+- validation tests that reject unknown or incomplete values.
+
+If an implementation later requires comment-preserving authoring, that is a
+separate authority decision because it would change the canonical source format
+away from JSON.
+
+### Generated Map Entrypoints Remain Per-Map
+
+Civ7 currently registers maps through file-based map script rows and imports.
+This change keeps one generated JS bundle per selectable map. The generator may
+emit transient TS entry modules, virtual tsup entries, or another deterministic
+build input, but authors do not hand-write `src/maps/<map>.ts` wrappers.
+
+Generated entry modules call the existing SDK `createMap` runtime helper with:
+
+- map id and name;
+- selected recipe module;
+- stripped schema metadata and validated recipe config;
+- optional latitude bounds and log prefix.
+
+### One Registry Generates Civ7 And Studio Projections
+
+The generator enumerates canonical JSON configs, validates them, sorts them,
+and produces one registry used for:
+
+- map entry module generation or virtual build entries;
+- `tsup` entry configuration;
+- `mod/config/config.xml` map rows;
+- `.modinfo` `ImportFiles` entries for generated map scripts;
+- `mod/text/en_us/MapText.xml` localization rows;
+- Studio built-in config catalog;
+- tests/snapshots that compare generated outputs against source registry data.
+
+Generated `mod/` files remain read-only outputs. If checked-in generated
+outputs are updated, they must be produced by the generator/build script and
+reviewed as generated artifacts, not edited directly.
+
+### Studio Uses Configs And Scratch, Not Durable Preset Saves
+
+Studio's source-backed model becomes:
+
+- `Configs`: repo-backed map config files discovered from the canonical
+  directory or generated catalog.
+- `Save`: writes the selected repo-backed config file.
+- `Save As`: writes a sibling `<new-id>.config.json` into the same directory.
+- `Scratch`: optional browser-local temporary copies, explicitly labeled as
+  non-source and never treated as shipped map variants.
+- `Export`: optional download/interchange action, not the primary authoring
+  persistence model.
+
+The implementation must choose an explicit write mechanism. Acceptable first
+implementations are a local dev-server write API or the browser File System
+Access API. A browser-only app silently writing repo paths is not a valid
+design because the browser cannot reliably do that.
+
+## Migration Sequence
+
+1. Add the canonical envelope schema and validation helpers.
+2. Convert every shipped map config to `.config.json` using the envelope.
+3. Add full-config completeness validation for shipped map configs.
+4. Add the map registry generator and generated entry-module/tsup integration.
+5. Generate or regenerate XML/modinfo/text/Studio catalog from the registry.
+6. Rewire Studio around repo-backed configs and explicit scratch state.
+7. Delete obsolete TS wrappers, shipped `.config.ts` files, duplicate Studio
+   preset payloads, and stale `advanced` compatibility.
+8. Promote docs/tests so future shipped maps follow the JSON-only path.
+
+## Risks / Trade-offs
+
+- Full JSON configs will be more verbose than partial presets. That verbosity
+  is intentional for shipped maps because it makes generated output
+  reproducible and reviewable.
+- Studio repo writes need a local authority surface. This may require a small
+  dev-server API even if the browser app otherwise remains static.
+- Generated entry modules add a source generation step. This is still simpler
+  than maintaining hand-written wrappers because the generated files have one
+  owner and one registry input.
+- Current XML/modinfo files may not have a source generator. The implementation
+  must create one instead of treating existing `mod/` files as source.
+
+## Review Lanes
+
+- Product/DX review: verifies the authoring flow matches expectations: open a
+  JSON config, edit in Studio, save the same file, save as a sibling, build
+  from that directory.
+- Architecture review: verifies MapGen core remains pure, Swooper Maps owns
+  mod integration and generated deployment outputs, and generated artifacts
+  remain read-only.
+- Generator review: verifies deterministic ordering, file names, localization
+  tags, modinfo imports, one JS bundle per map, and stale-output cleanup.
+- Studio review: verifies browser-local state is scratch-only or removed, and
+  no UI labels imply durable save when the repo file is not written.
+- Adversarial review: searches for duplicate map identity/config authority,
+  partial shipped presets, hidden default dependency, stale `advanced`
+  compatibility, and hardcoded map lists.

--- a/openspec/changes/normalize-swooper-map-config-generation/proposal.md
+++ b/openspec/changes/normalize-swooper-map-config-generation/proposal.md
@@ -1,0 +1,147 @@
+## Why
+
+Swooper Maps now has the flat recipe config surface, but shipped map variants
+still do not have one durable source of truth. A map's identity and config are
+split across JSON/TS config files, hand-written `src/maps/<map>.ts` wrappers,
+hardcoded `tsup` entries, generated XML/modinfo/text output, and Studio
+browser-local preset storage. That shape makes Studio save behavior misleading:
+saving a "preset" does not update the repo config authors are actually working
+on, and adding or modifying a shipped map requires editing several unrelated
+surfaces by hand.
+
+The next correct slice is to make
+`mods/mod-swooper-maps/src/maps/configs/*.config.json` the only authored source
+for shipped map variants, then generate all Civ7 and Studio projections from
+that directory.
+
+## Target Authority Refs
+
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`:
+  Target Shape, Problem Layer 2, Problem Layer 3, Domino 1, and the generated
+  artifact boundary.
+- `openspec/config.yaml`: default stage config is flat; generated outputs are
+  proof, not policy.
+- `openspec/specs/change-management/spec.md`: OpenSpec is downstream of
+  accepted authority and changes must name owners, protected paths, stop
+  conditions, and verification gates.
+- `openspec/specs/mapgen-normalization-workstreams/spec.md`: first-party
+  persisted config consumers use the flat config surface.
+- `docs/system/mods/swooper-maps/architecture.md`: Swooper Maps owns
+  game-facing map integration, source recipe content, and deployment package
+  generation.
+
+## What Changes
+
+- Define one canonical JSON map config envelope under
+  `mods/mod-swooper-maps/src/maps/configs/*.config.json`.
+- Require shipped map configs to be full source configs, not partial preset
+  overlays: every shipped map file carries metadata plus a complete recipe
+  config payload with concrete strategy envelopes and config values.
+- Convert all shipped map variants to canonical JSON files and remove shipped
+  `.config.ts` variants.
+- Replace hand-written per-map TS wrappers and hardcoded build entries with a
+  generator that enumerates canonical config files and creates the transient or
+  generated map entry modules needed for one Civ7 JS bundle per map.
+- Generate or regenerate Civ7 map registration surfaces from the same registry:
+  `mod/maps/*.js`, `mod/config/config.xml`, `.modinfo` map imports, and map
+  localization rows.
+- Generate Studio's built-in config catalog from the same canonical config
+  files.
+- Rework Studio's save model so repo-backed configs can be loaded, edited,
+  saved in place, and saved as sibling config files; browser-local storage is
+  either removed or clearly demoted to scratch state.
+- Remove duplicate built-in preset payloads and stale `advanced` compatibility
+  logic that only exists for obsolete persisted config shapes.
+
+## Capabilities
+
+### New Capabilities
+
+- Repo-backed shipped map config authoring for Swooper Maps.
+- Config-driven Swooper map artifact generation.
+- Studio save/save-as flow for repo-backed map configs.
+
+### Modified Capabilities
+
+- Swooper Maps map generation: shipped maps are generated from canonical JSON
+  config files instead of hand-written map wrapper files.
+- MapGen Studio config editing: built-in map configs are source-backed configs,
+  not durable browser-local presets.
+- MapGen normalization workstreams: extends D1 from "flat persisted config
+  shape" to "single first-party shipped-map config authority".
+
+## Dependencies
+
+- Requires: `normalize-config-surface` and the completed standard-recipe flat
+  config migration.
+- Requires: `normalize-core-studio-dx-boundaries` so Studio consumes recipe
+  config schema/default contracts from intentional source-visible or generated
+  contract owners.
+- Requires: `normalize-sdk-mapgen-runtime-entrypoint` and current SDK
+  `createMap` runtime entrypoint behavior, because Civ7 still appears to load
+  one JS file per selectable map.
+- Enables parallel work:
+  - independent map tuning through JSON-only config edits;
+  - later Studio UX cleanup after repo-backed config persistence exists;
+  - later generated-mod packaging hardening after map registry generation
+    exists.
+
+## Forbidden Non-Goals
+
+- No hand-edited generated `mod/` artifacts.
+- No single shared runtime JS file for all maps until in-game evidence proves
+  Civ7 can dispatch the selected map safely without one script per map.
+- No durable browser-local "preset" path for shipped maps.
+- No TS config files for shipped map variants once canonical JSON is available.
+- No dual source of truth where map id/name/description/sort order is repeated
+  in TS wrappers, `tsup`, XML, modinfo, text, and Studio payloads.
+- No partial shipped-map preset overlays that rely on hidden default/strategy
+  fill-in to become complete.
+- No revival of persisted `advanced` config wrappers.
+
+## Impact
+
+- Affected owners:
+  - Swooper Maps mod: canonical config files, generated map entry sources,
+    package build scripts, XML/modinfo/text generation.
+  - MapGen core/authoring: config/schema validation and full-config
+    completeness checks if existing validation does not cover them.
+  - MapGen Studio: repo-backed config catalog, load/save/save-as UX, scratch
+    demotion, import/export naming.
+  - SDK runtime: consumed by generated entry modules, but `createMap` behavior
+    should not change unless implementation discovers a bounded runtime API
+    gap.
+- Expected write set:
+  - `openspec/changes/normalize-swooper-map-config-generation/**`
+  - `mods/mod-swooper-maps/src/maps/configs/**`
+  - `mods/mod-swooper-maps/src/maps/**` generated-entry source location or
+    generator-owned replacement
+  - `mods/mod-swooper-maps/scripts/**`
+  - `mods/mod-swooper-maps/tsup.config.ts`
+  - `mods/mod-swooper-maps/test/**`
+  - `apps/mapgen-studio/src/**`
+  - adjacent MapGen/Swooper docs
+- Protected paths:
+  - generated `mods/mod-swooper-maps/mod/**` except through generation scripts;
+  - generated `dist/**`;
+  - recipe stage topology, ecology truth, placement, and adapter projection
+    internals except direct config/schema fallout.
+- Stop conditions:
+  - Civ7 map selection cannot be proven from generated per-map entry files;
+  - Studio cannot write repo files without a dev-server/File-System-Access
+    authority decision;
+  - a shipped config cannot be represented as full JSON without a schema or
+    authoring-contract gap;
+  - generated XML/modinfo/text cannot be reproduced deterministically from the
+    canonical registry.
+- Verification gates:
+  - `bun run openspec -- validate normalize-swooper-map-config-generation --strict`;
+  - `bun run openspec:validate`;
+  - map config schema/completeness tests for every shipped config;
+  - generator tests or snapshots for entry-module registry, `config.xml`,
+    `.modinfo`, and map localization rows;
+  - `bun run --cwd mods/mod-swooper-maps build:studio-recipes`;
+  - `bun run --cwd mods/mod-swooper-maps build`;
+  - relevant Studio config persistence tests or typecheck;
+  - search proving removed duplicate source surfaces are gone or generated;
+  - `git diff --check`.

--- a/openspec/changes/normalize-swooper-map-config-generation/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/normalize-swooper-map-config-generation/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Shipped Maps Use Canonical JSON Config Source
+
+Swooper Maps shipped map variants SHALL use
+`mods/mod-swooper-maps/src/maps/configs/*.config.json` as the only authored
+source for map identity, display metadata, recipe selection, ordering metadata,
+latitude overrides, and recipe config payload.
+
+#### Scenario: A shipped map variant is added
+- **WHEN** a developer adds a shipped Swooper Maps map variant
+- **THEN** the authored source change is a canonical `.config.json` file under
+  `mods/mod-swooper-maps/src/maps/configs/`
+- **AND** the map id, display name, description, recipe id, sort order,
+  optional latitude bounds, and recipe config payload are read from that file
+- **AND** no hand-written per-map TS wrapper, shipped `.config.ts` map config,
+  hardcoded `tsup` entry, XML row, modinfo import, localization row, or Studio
+  preset payload becomes a second source of truth
+
+### Requirement: Shipped Map Configs Are Full Source Configs
+
+Canonical shipped map config files SHALL contain full recipe config payloads
+with concrete stage, step, op strategy, and config values required to generate
+the shipped map.
+
+#### Scenario: Generator consumes a shipped map config
+- **WHEN** the Swooper Maps generator reads a canonical shipped map config
+- **THEN** validation proves the file is schema-valid for its recipe
+- **AND** validation proves required strategy envelopes and config values are
+  concrete before generated Civ7 or Studio artifacts are emitted
+- **AND** missing shipped-map values are reported as source errors rather than
+  silently filled by hidden preset composition
+
+### Requirement: Swooper Map Artifacts Are Generated From The Config Registry
+
+Swooper Maps SHALL generate Civ7 map entry bundles, map registration XML,
+modinfo map imports, map localization rows, and Studio built-in config catalog
+data from the canonical config registry.
+
+#### Scenario: Swooper Maps build runs
+- **WHEN** the Swooper Maps build prepares map artifacts
+- **THEN** it enumerates canonical config files into a deterministic registry
+- **AND** one Civ7-loadable JS map bundle is produced per registry entry
+- **AND** `config.xml`, `.modinfo` map imports, map localization rows, and
+  Studio built-in config catalog data are generated from the same registry
+- **AND** checked-in generated `mod/` artifacts, if updated, are produced by
+  generation scripts rather than hand edits
+
+### Requirement: Studio Saves Repo-Backed Configs
+
+MapGen Studio SHALL distinguish repo-backed shipped map configs from
+browser-local scratch state and SHALL NOT present browser-local preset storage
+as durable shipped-map authoring.
+
+#### Scenario: Author saves an existing map config in Studio
+- **WHEN** a repo-backed canonical map config is selected and edited in Studio
+- **THEN** `Save` writes the selected config file through an explicit local
+  write authority surface
+- **AND** the saved file remains in
+  `mods/mod-swooper-maps/src/maps/configs/`
+- **AND** subsequent generation uses that saved file without an additional
+  preset import/export step
+
+#### Scenario: Author saves a modified config as a new map variant
+- **WHEN** an author uses `Save As` for a repo-backed map config
+- **THEN** Studio creates a sibling canonical `.config.json` file in
+  `mods/mod-swooper-maps/src/maps/configs/`
+- **AND** the new file receives a unique id/file stem and required metadata
+- **AND** browser-local storage, if present, is labeled and treated only as
+  scratch state

--- a/openspec/changes/normalize-swooper-map-config-generation/tasks.md
+++ b/openspec/changes/normalize-swooper-map-config-generation/tasks.md
@@ -1,0 +1,89 @@
+## 1. Authority And Inventory
+
+- [ ] 1.1 Inventory shipped map identity/config occurrences in map wrappers,
+  config files, `tsup`, Studio built-ins, XML, modinfo, localization, tests,
+  and docs.
+- [ ] 1.2 Classify each occurrence as source authority, generated projection,
+  test fixture, historical prose, or deletion candidate.
+- [ ] 1.3 Record the first implementation as `standard`-recipe-only and defer
+  multi-recipe dispatch unless an explicit recipe-dispatch requirement is
+  added before implementation.
+
+## 2. Canonical Config Envelope
+
+- [ ] 2.1 Define the canonical shipped map config envelope schema.
+- [ ] 2.2 Derive the nested recipe config schema from the recipe contract
+  instead of hand-maintaining stage/step keys.
+- [ ] 2.3 Add validation that `id` matches the file stem and that metadata can
+  generate deterministic file names, localization tags, and map rows.
+- [ ] 2.4 Add full-config completeness validation so shipped configs include
+  concrete strategy envelopes and config values.
+- [ ] 2.5 Document the JSON-first authoring policy and the reason JSDoc
+  comments do not live inside canonical JSON.
+
+## 3. Convert Shipped Maps
+
+- [ ] 3.1 Convert `shattered-ring.config.ts`,
+  `sundered-archipelago.config.ts`, and `swooper-desert-mountains.config.ts`
+  into canonical JSON envelope files.
+- [ ] 3.2 Wrap `swooper-earthlike.config.json` in the canonical envelope.
+- [ ] 3.3 Ensure every shipped JSON config validates as full and source-complete.
+- [ ] 3.4 Remove shipped `.config.ts` map configs after their JSON equivalents
+  pass validation.
+
+## 4. Generator And Build Integration
+
+- [ ] 4.1 Add a generator that enumerates canonical config files and emits a
+  sorted map registry.
+- [ ] 4.2 Generate per-map entry modules or virtual build entries from the
+  registry.
+- [ ] 4.3 Replace hardcoded `tsup` map entries with generated registry entries.
+- [ ] 4.4 Generate `config.xml` map rows from registry metadata.
+- [ ] 4.5 Generate `.modinfo` map script imports from registry output files.
+- [ ] 4.6 Generate `MapText.xml` localization rows from registry name and
+  description metadata.
+- [ ] 4.7 Add stale-output cleanup so removed configs cannot leave old map JS,
+  XML rows, modinfo imports, or text rows behind.
+
+## 5. Studio Repo-Backed Config Flow
+
+- [ ] 5.1 Generate Studio's built-in config catalog from canonical map config
+  files.
+- [ ] 5.2 Replace real shipped-map "preset" selection with repo-backed
+  `Configs` selection.
+- [ ] 5.3 Implement `Save` for the selected repo-backed config file using an
+  explicit write authority surface.
+- [ ] 5.4 Implement `Save As` to create a sibling `.config.json` file in the
+  canonical config directory.
+- [ ] 5.5 Remove browser-local preset persistence or relabel it as `Scratch`
+  with no shipped-map authority.
+- [ ] 5.6 Keep export/import as optional interchange actions, not primary
+  source persistence.
+
+## 6. Deletion And Realignment
+
+- [ ] 6.1 Delete hand-written `src/maps/<map>.ts` wrappers for shipped maps
+  after generated entries replace them.
+- [ ] 6.2 Delete duplicate built-in Studio preset JSON payloads that mirror
+  shipped map configs.
+- [ ] 6.3 Delete hardcoded map id/name/description/sort-order lists outside
+  the generator tests or generated outputs.
+- [ ] 6.4 Remove stale persisted `advanced` compatibility paths that no longer
+  have active source consumers.
+- [ ] 6.5 Update adjacent docs and examples so new shipped maps are authored by
+  adding one canonical JSON config file.
+
+## 7. Verification
+
+- [ ] 7.1 Run map config schema/completeness tests for every shipped config.
+- [ ] 7.2 Run generator tests or snapshots for entry registry, `config.xml`,
+  `.modinfo`, and `MapText.xml`.
+- [ ] 7.3 Run `bun run --cwd mods/mod-swooper-maps build:studio-recipes`.
+- [ ] 7.4 Run `bun run --cwd mods/mod-swooper-maps build`.
+- [ ] 7.5 Run relevant Studio config persistence tests or typecheck.
+- [ ] 7.6 Search active source for duplicate map identity/config authority and
+  disposition any remaining hits.
+- [ ] 7.7 Run
+  `bun run openspec -- validate normalize-swooper-map-config-generation --strict`.
+- [ ] 7.8 Run `bun run openspec:validate`.
+- [ ] 7.9 Run `git diff --check`.


### PR DESCRIPTION
Introduces the `normalize-swooper-map-config-generation` OpenSpec change, which establishes `src/maps/configs/*.config.json` as the single authored source for all Swooper Maps shipped map variants and drives every Civ7 and Studio projection from that canonical directory.

**Problem being solved:**
Shipped map identity and configuration are currently fragmented across JSON/TS config files, hand-written per-map TS wrappers, hardcoded `tsup` entries, XML/modinfo/localization outputs, and Studio browser-local preset storage. Studio's save flow is misleading because writing a "preset" does not update the repo config file authors are actually working on, and adding or modifying a shipped map requires touching several unrelated surfaces by hand.

**What this change specifies:**
- A canonical JSON envelope schema (`id`, `name`, `description`, `recipe`, `sortIndex`, `latitudeBounds`, `config`) where each shipped map file carries a complete recipe config payload — not a partial overlay that depends on hidden defaults.
- Conversion of all existing shipped `.config.ts` map configs to canonical JSON envelope files.
- A generator that enumerates canonical config files into a deterministic registry and produces per-map Civ7 JS entry bundles, `config.xml` map rows, `.modinfo` import entries, `MapText.xml` localization rows, and the Studio built-in config catalog from that single registry.
- Replacement of hardcoded `tsup` map entries and hand-written `src/maps/<map>.ts` wrappers with generator-owned outputs.
- A reworked Studio save model where `Save` writes the selected repo-backed config file through an explicit write authority surface, `Save As` creates a sibling `.config.json` in the canonical directory, and browser-local storage is either removed or demoted to clearly labeled scratch state with no shipped-map authority.
- Deletion of duplicate built-in Studio preset payloads, stale `advanced` compatibility paths, and any remaining hardcoded map identity lists outside generator tests.

**Dependencies:** Requires `normalize-config-surface`, `normalize-core-studio-dx-boundaries`, and `normalize-sdk-mapgen-runtime-entrypoint` to be complete before implementation begins. The change is registered as entry 10 in the normalization sequence and is documented as an integrated follow-on to D1, intended to split across config/schema, generator, and Studio repo-save implementation lanes.