### PR TITLE
docs(earthlike): add balance investigation notes and six OpenSpec change drafts

### DIFF
--- a/docs/projects/pipeline-realism/scratch/earthlike-balance-investigation.md
+++ b/docs/projects/pipeline-realism/scratch/earthlike-balance-investigation.md
@@ -1,0 +1,135 @@
+# Earthlike Balance Investigation
+
+Date: 2026-05-30
+
+## Current User-Observed Failures
+
+- Swooper Earthlike remains materially unbalanced in-game.
+- Forest is absent or nearly absent in visible rolls.
+- Taiga is barely visible.
+- Reefs are low and atolls may be absent in visible rolls.
+- Mountains are near-zero and not product-visible.
+- Continents appear as broad central elevation bulges that slope down to coasts,
+  without mountain punctuation or varied relief.
+- Large areas read as flat dry land with little vegetation.
+- Plains/soil/pedology outcomes may be wrong after hydrology changes.
+- Potential root causes include pedology, aridity/dryness, wind, water
+  currents, humidity, biome classification, feature scoring, terrain scoring,
+  or config drift.
+- Potential morphology root causes include thresholding, relief sharpness,
+  erosion smoothing, base topography, shore-distance blending, or foundational
+  plate/topography signal shape.
+
+## Operating Rules
+
+- Runtime proof that FireTuner can restart the map is only pipeline proof, not
+  balance proof.
+- Every behavior/config/code change gets an OpenSpec change before
+  implementation.
+- Do not implement tuning before the relevant OpenSpec proposal/spec/tasks
+  exist.
+- Use Graphite branches and isolated worktrees for independent implementation
+  changes when write sets do not overlap.
+- Assign one intelligent agent per independent change only after the changes
+  are specified and write sets are disjoint.
+- Keep bridge/log evidence mechanical; no narrative diary entries in the
+  FireTuner append-only log.
+
+## Active Team Lanes
+
+- Measures: identify missing product-visible metrics and thresholds.
+- Config authority: ensure Swooper Earthlike map config and standard Earthlike
+  preset are complete, consistent, and use intended strategies.
+- Vegetation: investigate forest, taiga, savanna, sagebrush, and rainforest
+  scoring/admission failures.
+- Reefs/atolls: investigate reef-family scoring, shelf/coast eligibility, and
+  atoll absence.
+- Terrain/mountains: investigate near-zero mountain coverage and weak ridge
+  scoring.
+- Runtime validation: define repeated FireTuner roll evidence and telemetry for
+  balance closure.
+
+## Findings So Far
+
+- `codex-010` proves raw FireTuner restart and full 50/50 Swooper recipe
+  execution, but it does not prove balance.
+- Swooper Earthlike map config and standard Earthlike preset currently diverge:
+  `foundation.projection.computePlates.config.boundaryInfluenceDistance` is `5`
+  in the shipped map config and `7` in the standard preset.
+- Current world-balance gates check vegetation family presence and broad shares,
+  but they do not require product-visible mountain coverage, hill coverage,
+  plains/pedology distribution, climate humidity bands, or per-family density
+  floors.
+- A 10-seed local sample on 106x66 Swooper Earthlike produced only about
+  `0.07%` to `0.32%` mountain coverage of land. That explains the visible
+  near-zero mountain complaint and shows the current mountain probe is too weak.
+- Direct config-only probes lowering mountain thresholds and widening boundary
+  influence did not fix low-mountain seeds consistently, which points to a
+  deeper driver/scoring or upstream tectonic/topography signal issue.
+- The shipped Earthlike config is not fully explicit. Examples:
+  `hydrology-hydrography.lakes` relies on default `planLakes`, `map-hydrology`
+  relies on default `projectionReadback`, and several zero-config projection
+  and placement steps are omitted.
+- `maps/presets/realism/earthlike.config.ts` is a stale lightweight Earthlike
+  source used by tests. It is not equivalent to the shipped Swooper Earthlike
+  JSON/preset path and can hide failures under an "earthlike" name.
+- `foundation.plate-graph.computePlateGraph.config.plateCount` is authored as
+  `8`, but `foundation.knobs.plateCount` is `28` and the plate graph step
+  normalizes from the knob. The duplicate authored value is misleading.
+- Current mock-adapter balance tests can overcount feature success because the
+  mock accepts features broadly. Real engine feature validity depends on
+  official `Feature_ValidTerrains` and `Feature_ValidBiomes`, e.g. forest and
+  taiga require flat terrain and specific engine biome classes.
+- Feature apply records `canHaveFeature=false` rejections but does not fail
+  balance tests. In-game can therefore lose planned forests/taiga while local
+  tests pass unless rejection diagnostics are asserted.
+- Internal biome symbols collapse into coarse engine biomes. Feature scoring is
+  internal-climate based, but engine validity is terrain/engine-biome based; a
+  planned feature can score well and still be rejected after projection.
+- Pedology currently receives land mask, elevation, rainfall, and humidity, but
+  not the optional sediment depth, bedrock age, or slope fields declared by the
+  op contract. The `coastal-shelf` strategy boosts sediment weight, but the
+  sediment signal is zero when not provided.
+- Pedology's relief fallback normalizes absolute elevation magnitude when slope
+  is absent. That can make a smooth central elevation bulge behave like high
+  relief, even when the player sees no mountain punctuation.
+- Current local stats show `BIOME_PLAINS` is effectively absent in Swooper
+  Earthlike samples: `0` to `24` plains tiles on roughly `2,500-2,700` land
+  tiles. That matches the visual complaint that plains are missing.
+- Local pedology stats show no high aridity by the current `aridityIndex > 0.65`
+  threshold, but soil buckets are dominated by `sandy` plus `wet`, with modest
+  fertility. This means the dry/flat visual failure may come from biome binding,
+  terrain/feature rejection, or pedology semantics rather than the current
+  aridity index alone.
+- Reef-family planning is engine-invalid for key families: atolls currently use
+  shelf/coast-projection habitat even though official resources allow atolls on
+  ocean, while cold reefs can be planned on ocean even though official resources
+  allow cold reefs on coast.
+- Mountain root cause is likely upstream of the planner thresholds: Earthlike
+  `boundaryShareTarget` is `0.005`, far below schema default and
+  desert-mountains, so active tectonic belts often fail to overlap land enough
+  for visible mountain belts.
+- Volcanoes can hide the ridge weakness because final terrain receives mountain
+  tiles from volcano stamping even when planned non-volcano mountain belts are
+  nearly absent.
+
+## OpenSpec Changes
+
+- `earthlike-balance-diagnostic-gates`: add multi-dimensional balance metrics
+  for terrain, pedology, climate/humidity, vegetation families, reefs/atolls,
+  and runtime roll evidence before further tuning claims.
+- `earthlike-config-authority`: align Swooper Earthlike map config, standard
+  preset, Studio default config, and tests so the deployed map and authoring
+  preset cannot drift.
+- `earthlike-engine-feature-eligibility`: make feature planning/tests account
+  for engine-valid terrain and biome eligibility before planned intents are
+  counted as product-visible success.
+- `earthlike-terrain-relief-balance`: repair active-margin land overlap,
+  mountain/ridge scoring, and continental elevation-profile shape so
+  Earthlike produces product-visible mountain belts and non-bulge continental
+  relief across representative seeds.
+- `earthlike-pedology-humidity-balance`: verify and repair soil, aridity,
+  humidity, wind, current, and biome inputs after hydrology changes.
+- `earthlike-ecology-feature-density`: repair vegetation and reef-family
+  scoring/admission after upstream terrain/pedology/humidity and engine
+  eligibility facts are stable.

--- a/openspec/changes/earthlike-balance-diagnostic-gates/.openspec.yaml
+++ b/openspec/changes/earthlike-balance-diagnostic-gates/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/earthlike-balance-diagnostic-gates/proposal.md
+++ b/openspec/changes/earthlike-balance-diagnostic-gates/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+The previous closure proof established that FireTuner can trigger a fresh
+Swooper map-generation run and that the recipe completes. It did not establish
+that Swooper Earthlike is product-balanced. Visible map rolls still show missing
+or marginal forests, taiga, reefs, atolls, mountains, broad dry flat land, and
+continents that read as smooth central elevation bulges sloping to the coasts.
+
+The current metrics are too narrow: they prove nonzero or broad feature presence
+for some families, but they do not measure terrain relief, plains/pedology,
+humidity/aridity, climate drivers, per-family density floors, or repeated
+runtime product outcomes. This change creates the diagnostic gate surface needed
+before additional tuning changes can be specified and implemented.
+
+## Target Authority Refs
+
+- `openspec/specs/mapgen-normalization-workstreams/spec.md`: world-balance
+  proof must cover feature families and map identity.
+- `mods/mod-swooper-maps/AGENTS.md`: pedology, biomes, and feature planning own
+  Ecology truth before `map-ecology` projection.
+- `docs/system/mods/swooper-maps/architecture.md`: hydrology, ecology,
+  morphology, and map projection have separate proof boundaries.
+
+## What Changes
+
+- Add product-visible Earthlike balance metrics for mountains, hills, terrain
+  relief, continental elevation profiles, plains/soil/pedology,
+  humidity/aridity, vegetation families, reef-family features, and atolls.
+- Add gates that fail when a feature or terrain class is merely nonzero but not
+  visible enough to matter.
+- Add config-drift checks so Swooper Earthlike map config, standard Earthlike
+  preset, and Studio default posture cannot silently diverge.
+- Define mechanical runtime evidence required for balance closure.
+
+## Requires
+
+- No behavior tuning in this slice.
+- Existing FireTuner bridge remains available for runtime restart proof.
+
+## Enables Parallel Work
+
+- `earthlike-config-authority`
+- `earthlike-engine-feature-eligibility`
+- `earthlike-terrain-relief-balance`
+- `earthlike-pedology-humidity-balance`
+- `earthlike-ecology-feature-density`
+
+## Forbidden Non-Goals
+
+- No quota-based fallback placement.
+- No generated-output hand edits.
+- No claims that FireTuner restart proof equals balance proof.
+- No implementation tuning before the relevant downstream OpenSpec change
+  exists.
+
+## Verification Gates
+
+- `bun run openspec -- validate earthlike-balance-diagnostic-gates --strict`
+- `bun run openspec:validate`
+- Focused config and world-balance tests added by the implementation.
+- `bun run --cwd mods/mod-swooper-maps check`
+- `git diff --check`

--- a/openspec/changes/earthlike-balance-diagnostic-gates/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/earthlike-balance-diagnostic-gates/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Earthlike Balance Proof Is Multi-Dimensional
+
+Swooper Earthlike balance proof SHALL measure the terrain, pedology, climate,
+hydrology, and ecology dimensions that shape product-visible map quality.
+
+#### Scenario: Earthlike balance is evaluated
+- **WHEN** Swooper Earthlike runs across representative seeds
+- **THEN** proof includes product-visible metrics for mountain coverage, hill
+  coverage, terrain relief, continental elevation-profile shape,
+  plains/soil/pedology distribution, humidity/aridity, vegetation-family
+  density, reef-family density, and atolls
+- **AND** nonzero presence alone is insufficient for a terrain or feature class
+  that must visibly define the map
+
+#### Scenario: Continents collapse into smooth elevation bulges
+- **WHEN** Earthlike terrain relief is evaluated
+- **THEN** proof distinguishes broad coast-to-center elevation gradients from
+  punctuated mountain belts, foothills, basins, plains, and eroded relief
+- **AND** a continent-shaped elevation bulge without visible relief punctuation
+  is treated as a balance failure even if total land and elevation ranges pass
+
+#### Scenario: Hydrology changes affect ecology inputs
+- **WHEN** hydrology, wind, current, humidity, or aridity behavior changes
+- **THEN** pedology, biome classification, and feature-family outputs are
+  re-measured in the same balance proof
+- **AND** the change cannot close on lake or pipeline completion evidence alone
+
+### Requirement: Earthlike Config Sources Cannot Drift
+
+Swooper Earthlike config sources SHALL remain aligned for intended Earthlike
+strategy and tuning values unless a change explicitly records a product reason
+for divergence.
+
+#### Scenario: Earthlike config is changed
+- **WHEN** any Earthlike recipe config source changes
+- **THEN** tests compare the intended shared posture across shipped map config,
+  standard preset config, and Studio default config
+- **AND** any intentional divergence is named and verified rather than left as
+  silent default drift
+
+### Requirement: Balance Runtime Proof Is Product Evidence
+
+Runtime balance proof SHALL record repeated product-relevant map rolls, not only
+successful recipe execution.
+
+#### Scenario: FireTuner restart proof is collected
+- **WHEN** FireTuner submits `Network.restartGame()` for balance closure
+- **THEN** the evidence includes the submitted command timestamp, the bounded
+  MapGeneration log window, recipe completion, Swooper error scan, and the
+  balance telemetry for the generated map
+- **AND** recipe completion without balance telemetry is only pipeline proof

--- a/openspec/changes/earthlike-balance-diagnostic-gates/tasks.md
+++ b/openspec/changes/earthlike-balance-diagnostic-gates/tasks.md
@@ -1,0 +1,26 @@
+## 1. Investigation And Spec
+
+- [ ] 1.1 Record current observed Earthlike balance failures and proof boundary.
+- [ ] 1.2 Audit existing world-balance metrics and identify missing dimensions.
+- [ ] 1.3 Split downstream behavior repairs into separate OpenSpec changes before
+  implementation.
+
+## 2. Implementation
+
+- [ ] 2.1 Extend world-balance stats with terrain relief, mountain/hill coverage,
+  continental elevation-profile diagnostics, pedology/soil, humidity/aridity,
+  and per-family feature density outputs.
+- [ ] 2.2 Add Earthlike gates that require product-visible mountains, forests,
+  taiga, reefs, and atolls across representative seeds.
+- [ ] 2.3 Add config parity checks for shipped Swooper Earthlike, standard
+  Earthlike preset, and Studio default posture.
+- [ ] 2.4 Add mechanical runtime evidence requirements for balance closure.
+
+## 3. Verification
+
+- [ ] 3.1 Run focused world-balance diagnostics tests.
+- [ ] 3.2 Run config schema/parity tests.
+- [ ] 3.3 Run `bun run --cwd mods/mod-swooper-maps check`.
+- [ ] 3.4 Run `bun run openspec -- validate earthlike-balance-diagnostic-gates --strict`.
+- [ ] 3.5 Run `bun run openspec:validate`.
+- [ ] 3.6 Run `git diff --check`.

--- a/openspec/changes/earthlike-config-authority/.openspec.yaml
+++ b/openspec/changes/earthlike-config-authority/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/earthlike-config-authority/proposal.md
+++ b/openspec/changes/earthlike-config-authority/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Swooper Earthlike has multiple first-party config sources that are not aligned:
+the shipped map JSON, standard Earthlike preset JSON, Studio default posture,
+and stale `realismEarthlikeConfig` test input. Some steps rely on implicit
+defaults, and duplicate authored values can be overwritten by stage knobs. That
+means tests and runtime can exercise different Earthlike behavior.
+
+## Target Authority Refs
+
+- `openspec/changes/earthlike-balance-diagnostic-gates`: config sources cannot
+  drift silently.
+- `openspec/specs/mapgen-normalization-workstreams/spec.md`: flat stage config
+  migration owns first-party persisted consumers.
+- `mods/mod-swooper-maps/AGENTS.md`: generated mod output is read-only and map
+  configs are source truth for shipped Swooper Maps.
+
+## What Changes
+
+- Align shipped Swooper Earthlike config, standard Earthlike preset, and Studio
+  default Earthlike posture.
+- Make Earthlike step choices explicit where omitted defaults hide behavior.
+- Resolve stale `realismEarthlikeConfig` usage so tests do not exercise a weak
+  legacy Earthlike path unless explicitly labeled as such.
+- Add parity tests that fail on unintended Earthlike config drift.
+
+## Write Set
+
+- `mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json`
+- `mods/mod-swooper-maps/src/presets/standard/earthlike.json`
+- `mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts`
+- `apps/mapgen-studio/**` config default tests only if Studio posture is
+  affected
+- Adjacent config tests under `mods/mod-swooper-maps/test/config/**`
+
+## Forbidden Non-Goals
+
+- No generated-output hand edits.
+- No ecology, hydrology, or terrain tuning beyond explicit config-source
+  authority alignment.
+- No preserving a stale Earthlike path under an ambiguous name.
+
+## Verification Gates
+
+- `bun --cwd mods/mod-swooper-maps test test/config/*.test.ts`
+- `bun run openspec -- validate earthlike-config-authority --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/earthlike-config-authority/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/earthlike-config-authority/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Earthlike Config Authority Is Single-Posture
+
+Earthlike config authority SHALL keep shipped map, preset, and first-party test
+postures aligned unless a change records an intentional product distinction.
+
+#### Scenario: Earthlike config sources are compared
+- **WHEN** Swooper Earthlike, standard Earthlike preset, Studio defaults, or
+  realism Earthlike test inputs are loaded
+- **THEN** tests prove whether they share the same intended recipe posture
+- **AND** stale lightweight Earthlike configs cannot silently stand in for the
+  shipped map configuration
+
+#### Scenario: Earthlike defaults affect balance behavior
+- **WHEN** a step default affects lakes, projection, terrain, ecology, or
+  placement balance proof
+- **THEN** the shipped Earthlike config records the intended value explicitly
+- **AND** duplicate authored values that are overwritten by knobs are removed or
+  aligned

--- a/openspec/changes/earthlike-config-authority/tasks.md
+++ b/openspec/changes/earthlike-config-authority/tasks.md
@@ -1,0 +1,20 @@
+## 1. Investigation And Spec
+
+- [ ] 1.1 Confirm the intended canonical Earthlike source for shipped maps,
+  presets, Studio defaults, and legacy realism tests.
+- [ ] 1.2 List every intentional Earthlike divergence, or remove the divergence.
+
+## 2. Implementation
+
+- [ ] 2.1 Align Swooper Earthlike shipped config and standard preset.
+- [ ] 2.2 Make omitted Earthlike step defaults explicit where they affect
+  balance proof or runtime projection.
+- [ ] 2.3 Retire, rename, or replace stale `realismEarthlikeConfig` test usage.
+- [ ] 2.4 Add parity tests for Earthlike config sources.
+
+## 3. Verification
+
+- [ ] 3.1 Run focused config schema/parity tests.
+- [ ] 3.2 Run `bun run openspec -- validate earthlike-config-authority --strict`.
+- [ ] 3.3 Run `bun run openspec:validate`.
+- [ ] 3.4 Run `git diff --check`.

--- a/openspec/changes/earthlike-ecology-feature-density/.openspec.yaml
+++ b/openspec/changes/earthlike-ecology-feature-density/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/earthlike-ecology-feature-density/proposal.md
+++ b/openspec/changes/earthlike-ecology-feature-density/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+After terrain relief, pedology/humidity, and engine eligibility are correct,
+Swooper Earthlike still needs product-visible density targets for forests,
+taiga, reefs, cold reefs, and atolls. Current balance gates can pass on
+presence or broad vegetation families while visible rolls still feel sparse or
+miss key ecology classes.
+
+## Target Authority Refs
+
+- `openspec/changes/earthlike-balance-diagnostic-gates`: balance proof must
+  include vegetation-family density, reef-family density, and atolls.
+- `openspec/changes/earthlike-engine-feature-eligibility`: feature density
+  tuning must count only engine-valid accepted surfaces.
+- `openspec/changes/earthlike-pedology-humidity-balance`: ecology density
+  tuning depends on stable climate, soil, plains, and biome inputs.
+
+## What Changes
+
+- Add explicit Earthlike density floors and upper bounds for key vegetation and
+  reef families.
+- Tune family scoring/admission after engine-valid and upstream ecology inputs
+  are verified.
+- Require per-family multi-seed evidence for forest, taiga, rainforest,
+  savanna/steppe, reefs, cold reefs, and atolls.
+- Add runtime balance telemetry that reports planned, accepted, rejected, and
+  projected counts per feature family.
+
+## Write Set
+
+- Ecology feature family scoring and admission config/code.
+- Reef-family scoring and admission config/code.
+- Balance stats and runtime telemetry for per-family density.
+- Focused ecology density tests and world-balance tests.
+
+## Forbidden Non-Goals
+
+- No density tuning before terrain, pedology/humidity, and engine eligibility
+  facts are measured.
+- No quota-only fill that ignores climate, terrain, biome, or engine validity.
+- No treating a single seed as sufficient balance proof.
+
+## Verification Gates
+
+- Multi-seed ecology density tests.
+- World-balance stats tests with per-family density floors.
+- Runtime FireTuner evidence with per-family telemetry.
+- `bun run openspec -- validate earthlike-ecology-feature-density --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/earthlike-ecology-feature-density/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/earthlike-ecology-feature-density/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Earthlike Ecology Feature Density Is Product-Visible
+
+Swooper Earthlike ecology SHALL produce product-visible accepted densities for
+key vegetation and reef feature families after upstream terrain, climate,
+pedology, biome, and engine-validity facts are stable.
+
+#### Scenario: Vegetation density is evaluated
+- **WHEN** representative Swooper Earthlike seeds run
+- **THEN** accepted forest, taiga, rainforest, and dryland vegetation families
+  meet configured visible density floors without exceeding upper bounds
+- **AND** planned-but-rejected features do not count toward success
+
+#### Scenario: Reef and atoll density is evaluated
+- **WHEN** representative Swooper Earthlike seeds run
+- **THEN** accepted warm reefs, cold reefs, and atolls meet configured visible
+  density floors on engine-valid surfaces
+- **AND** per-family telemetry distinguishes planned, accepted, rejected, and
+  projected counts
+
+#### Scenario: A single lucky seed passes
+- **WHEN** only one generated map satisfies a family density target
+- **THEN** Earthlike ecology density proof remains open until representative
+  multi-seed evidence passes

--- a/openspec/changes/earthlike-ecology-feature-density/tasks.md
+++ b/openspec/changes/earthlike-ecology-feature-density/tasks.md
@@ -1,0 +1,20 @@
+## 1. Investigation And Spec
+
+- [ ] 1.1 Define accepted-feature density floors and upper bounds by family.
+- [ ] 1.2 Measure current planned, accepted, rejected, and projected counts
+  across representative Earthlike seeds.
+
+## 2. Implementation
+
+- [ ] 2.1 Add per-family ecology density metrics to balance telemetry.
+- [ ] 2.2 Tune forest, taiga, rainforest, savanna/steppe, reef, cold reef, and
+  atoll scoring after upstream legality and climate facts are stable.
+- [ ] 2.3 Add guard tests that fail sparse visible ecology rolls.
+
+## 3. Verification
+
+- [ ] 3.1 Run focused ecology density tests.
+- [ ] 3.2 Run world-balance stats tests.
+- [ ] 3.3 Collect FireTuner runtime roll evidence.
+- [ ] 3.4 Run OpenSpec validation.
+- [ ] 3.5 Run `git diff --check`.

--- a/openspec/changes/earthlike-engine-feature-eligibility/.openspec.yaml
+++ b/openspec/changes/earthlike-engine-feature-eligibility/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/earthlike-engine-feature-eligibility/proposal.md
+++ b/openspec/changes/earthlike-engine-feature-eligibility/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Local mock-adapter balance tests can count planned/applied features that the real
+Civ7 engine rejects. Official feature validity depends on terrain and engine
+biome classes, but vegetation and reef planners currently score mostly from
+internal climate/biome signals. This explains missing forests, taiga, low reefs,
+and absent atolls in-game while tests pass.
+
+## Target Authority Refs
+
+- `openspec/changes/earthlike-balance-diagnostic-gates`: balance proof must use
+  product-visible metrics and runtime evidence.
+- `.civ7/outputs/resources/Base/modules/base-standard/data/terrain.xml`:
+  official feature valid terrain/biome evidence.
+- `docs/system/mods/swooper-maps/architecture.md`: Ecology owns feature intent
+  truth; `map-ecology` only projects/materializes it.
+
+## What Changes
+
+- Add engine-valid symbolic terrain/biome eligibility to feature planning/tests.
+- Track feature apply rejections by feature key, not only aggregate count.
+- Repair vegetation and reef-family planning so planned features land on
+  terrain/biome surfaces the real engine can accept.
+- Add strict mock/runtime-like tests for forest, taiga, reefs, cold reefs, and
+  atolls.
+
+## Write Set
+
+- `packages/civ7-adapter/src/mock-adapter.ts` if strict mock support is needed.
+- `mods/mod-swooper-maps/src/domain/ecology/ops/features-plan-*`
+- `mods/mod-swooper-maps/src/domain/ecology/ops/reef-score-*`
+- `mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/**`
+- `mods/mod-swooper-maps/src/recipes/standard/stages/map-ecology/steps/features-apply/**`
+- Focused ecology and world-balance tests.
+
+## Forbidden Non-Goals
+
+- No quota fallback placement.
+- No weakening real engine validity checks to make tests pass.
+- No treating mock adapter acceptance as product-visible proof.
+
+## Verification Gates
+
+- Focused feature eligibility and reef/vegetation tests.
+- `bun --cwd mods/mod-swooper-maps test test/pipeline/world-balance-stats.test.ts`
+- `bun run openspec -- validate earthlike-engine-feature-eligibility --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/earthlike-engine-feature-eligibility/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/earthlike-engine-feature-eligibility/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Feature Balance Uses Engine-Valid Surfaces
+
+Earthlike feature balance SHALL count a feature family as product-visible only
+when its planned and applied surface is valid for the Civ7 engine terrain and
+biome rules.
+
+#### Scenario: Vegetation feature intents are planned
+- **WHEN** forest, taiga, savanna woodland, sagebrush steppe, or rainforest
+  intents are emitted
+- **THEN** the planner accounts for the projected terrain class and engine biome
+  class needed for that feature family
+- **AND** mock-adapter feature acceptance alone is insufficient proof
+
+#### Scenario: Reef-family intents are planned
+- **WHEN** reef, cold reef, atoll, or lotus intents are emitted
+- **THEN** coast-valid reef families and ocean-valid atoll families use distinct
+  habitat masks
+- **AND** aggregate reef-family counts cannot hide all-atoll or all-cold-reef
+  rejection
+
+#### Scenario: Feature apply rejects intents
+- **WHEN** `canHaveFeature` rejects a planned feature
+- **THEN** diagnostics record the feature key and rejection reason
+- **AND** Earthlike balance gates fail when product-required families are
+  rejected below their visible floor

--- a/openspec/changes/earthlike-engine-feature-eligibility/tasks.md
+++ b/openspec/changes/earthlike-engine-feature-eligibility/tasks.md
@@ -1,0 +1,22 @@
+## 1. Investigation And Spec
+
+- [ ] 1.1 Map official feature valid terrain/biome rules for vegetation and
+  reef-family features.
+- [ ] 1.2 Identify planner/projection boundaries that need symbolic legality
+  inputs.
+
+## 2. Implementation
+
+- [ ] 2.1 Add strict feature legality support to tests or mock adapter.
+- [ ] 2.2 Add per-feature rejection diagnostics to feature apply.
+- [ ] 2.3 Repair vegetation planning for engine-valid forest, taiga, savanna,
+  steppe, and rainforest surfaces.
+- [ ] 2.4 Repair reef-family planning for coast-valid reefs/cold reefs and
+  ocean-valid atolls.
+
+## 3. Verification
+
+- [ ] 3.1 Run focused strict eligibility tests.
+- [ ] 3.2 Run world-balance stats tests.
+- [ ] 3.3 Run OpenSpec validation.
+- [ ] 3.4 Run `git diff --check`.

--- a/openspec/changes/earthlike-pedology-humidity-balance/.openspec.yaml
+++ b/openspec/changes/earthlike-pedology-humidity-balance/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/earthlike-pedology-humidity-balance/proposal.md
+++ b/openspec/changes/earthlike-pedology-humidity-balance/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Earthlike visual rolls show broad flat dry-feeling land with little vegetation
+and few or no plains. Local stats show `BIOME_PLAINS` is nearly absent, while
+pedology does not receive slope, sediment, or bedrock signals despite declaring
+them. Hydrology, wind, currents, humidity, aridity, pedology, and biome binding
+therefore need to be investigated and repaired as an upstream class, not tuned
+only through feature thresholds.
+
+## Target Authority Refs
+
+- `openspec/changes/earthlike-balance-diagnostic-gates`: hydrology changes must
+  re-measure pedology, biome classification, and feature-family outputs.
+- `mods/mod-swooper-maps/AGENTS.md`: `ecology-pedology` and `ecology-biomes`
+  own truth before feature planning.
+- `docs/system/mods/swooper-maps/architecture.md`: Hydrology climate products
+  feed Ecology truth; projection stages do not own climate or soil semantics.
+
+## What Changes
+
+- Add diagnostics for climate indices, soil buckets, fertility, plains/biome
+  distribution, and vegetation-density distribution.
+- Repair pedology inputs so declared slope/sediment/bedrock signals are either
+  provided or removed from authored semantics.
+- Repair plains/biome classification and bindings so Earthlike produces visible
+  temperate dry/plains outcomes.
+- Verify hydrology wind/current/humidity changes do not erase ecology diversity.
+
+## Write Set
+
+- Hydrology climate diagnostics/tests.
+- Ecology pedology and biome classification code/config/tests.
+- World-balance stats support for pedology/climate/biome distributions.
+
+## Forbidden Non-Goals
+
+- No feature threshold tuning as a substitute for broken climate/soil inputs.
+- No silent biome binding changes without tests.
+- No generated-output hand edits.
+
+## Verification Gates
+
+- Focused hydrology/pedology/biome tests.
+- World-balance stats tests with pedology/climate metrics.
+- `bun run openspec -- validate earthlike-pedology-humidity-balance --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/earthlike-pedology-humidity-balance/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/earthlike-pedology-humidity-balance/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Earthlike Pedology And Climate Support Biome Diversity
+
+Earthlike pedology and climate proof SHALL show that hydrology-derived moisture,
+temperature, aridity, soil, fertility, and biome bindings support visible
+temperate, plains, boreal, tropical, and dryland outcomes.
+
+#### Scenario: Pedology is computed after hydrology
+- **WHEN** `ecology-pedology` consumes hydrology and morphology products
+- **THEN** the proof records soil bucket distribution, fertility distribution,
+  and whether declared slope/sediment/bedrock semantics are actually supplied
+- **AND** a strategy cannot claim sediment or relief behavior from missing input
+  signals
+
+#### Scenario: Plains are missing
+- **WHEN** Earthlike biome projection produces few or no `BIOME_PLAINS` tiles
+- **THEN** the change investigates internal biome classification and engine
+  binding separately
+- **AND** feature tuning cannot close the issue until the plains/biome cause is
+  dispositioned
+
+#### Scenario: Dry flat land dominates visually
+- **WHEN** visible land reads as dry and unvegetated
+- **THEN** balance proof compares aridity, humidity, effective moisture,
+  vegetation density, soil fertility, and feature rejection diagnostics
+- **AND** the root cause is assigned to the owning hydrology, pedology, biome,
+  feature, or projection change

--- a/openspec/changes/earthlike-pedology-humidity-balance/tasks.md
+++ b/openspec/changes/earthlike-pedology-humidity-balance/tasks.md
@@ -1,0 +1,22 @@
+## 1. Investigation And Spec
+
+- [ ] 1.1 Measure hydrology climate indices, soil buckets, fertility, plains,
+  and vegetation-density distribution across representative Earthlike seeds.
+- [ ] 1.2 Identify whether root causes sit in hydrology, pedology, biome
+  classification, or engine biome bindings.
+
+## 2. Implementation
+
+- [ ] 2.1 Add pedology/climate/biome metrics to balance stats.
+- [ ] 2.2 Repair pedology input semantics for slope, sediment, and bedrock.
+- [ ] 2.3 Repair plains/biome classification or bindings where evidence shows
+  drift.
+- [ ] 2.4 Add regression tests for plains, fertility, aridity/humidity, and
+  vegetation density.
+
+## 3. Verification
+
+- [ ] 3.1 Run focused hydrology, pedology, and biome tests.
+- [ ] 3.2 Run world-balance stats tests.
+- [ ] 3.3 Run OpenSpec validation.
+- [ ] 3.4 Run `git diff --check`.

--- a/openspec/changes/earthlike-terrain-relief-balance/.openspec.yaml
+++ b/openspec/changes/earthlike-terrain-relief-balance/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/earthlike-terrain-relief-balance/proposal.md
+++ b/openspec/changes/earthlike-terrain-relief-balance/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Swooper Earthlike can produce only a handful of planned non-volcano mountains
+across a full 106x66 map. Visible terrain also appears as broad continental
+center bulges sloping to coasts, without mountain belts, foothills, basins, or
+varied relief. The likely upstream cause is insufficient active-margin overlap
+with land plus strict mountain candidate gates.
+
+## Target Authority Refs
+
+- `openspec/changes/earthlike-balance-diagnostic-gates`: terrain balance must
+  measure mountain/hill coverage and continental elevation profile shape.
+- `docs/system/libs/mapgen/MAPGEN.md`: morphology owns terrain truth before
+  map projection.
+- `mods/mod-swooper-maps/AGENTS.md`: generated `mod/` output is regenerated,
+  not hand edited.
+
+## What Changes
+
+- Repair Earthlike active-margin land overlap and ridge candidate availability.
+- Add product-visible mountain, hill, and non-bulge relief gates.
+- Separate planned ridge mountains from volcano-stamped mountain terrain in
+  diagnostics.
+- Add post-projection terrain persistence checks around validation stages.
+
+## Write Set
+
+- Earthlike morphology config.
+- Morphology coasts/landmask and mountain planner code only if config is
+  insufficient.
+- Map-morphology projection diagnostics and terrain tests.
+- World-balance stats support for terrain relief.
+
+## Forbidden Non-Goals
+
+- No noise-only mountain fill.
+- No relying on volcanoes to satisfy mountain-belt balance.
+- No exact visual snapshot as the only acceptance proof.
+
+## Verification Gates
+
+- Multi-seed terrain density tests.
+- World-balance terrain metrics.
+- `bun run openspec -- validate earthlike-terrain-relief-balance --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/earthlike-terrain-relief-balance/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/earthlike-terrain-relief-balance/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Earthlike Terrain Has Visible Relief Structure
+
+Swooper Earthlike terrain SHALL produce visible mountain belts, foothill/rough
+terrain support, and varied continental relief instead of relying on smooth
+continent-center elevation gradients.
+
+#### Scenario: Earthlike mountain coverage is evaluated
+- **WHEN** representative Swooper Earthlike seeds run
+- **THEN** planned non-volcano mountain belts meet a visible coverage floor
+- **AND** volcano-stamped mountain terrain is reported separately from ridge
+  mountain truth
+
+#### Scenario: Active margins miss land
+- **WHEN** active tectonic boundary signal is mostly underwater or off-continent
+- **THEN** Earthlike terrain proof fails before feature or placement tuning can
+  claim map balance
+- **AND** repairs remain driver-anchored rather than noise-only fills
+
+#### Scenario: Continents form smooth bulges
+- **WHEN** elevation is summarized by shore distance or continent interior
+- **THEN** the metrics detect broad unpunctuated elevation domes
+- **AND** such domes fail Earthlike relief balance even when land/water budgets
+  pass

--- a/openspec/changes/earthlike-terrain-relief-balance/tasks.md
+++ b/openspec/changes/earthlike-terrain-relief-balance/tasks.md
@@ -1,0 +1,20 @@
+## 1. Investigation And Spec
+
+- [ ] 1.1 Measure planned ridge mountains, volcano mountains, hills, and
+  elevation profile shape across representative seeds.
+- [ ] 1.2 Determine whether config-only active-margin alignment is sufficient.
+
+## 2. Implementation
+
+- [ ] 2.1 Add terrain relief metrics to balance stats.
+- [ ] 2.2 Tune or repair active-margin land overlap for Earthlike.
+- [ ] 2.3 Repair mountain planner candidate selection only if config is
+  insufficient.
+- [ ] 2.4 Add post-projection/persistence diagnostics for mountains and hills.
+
+## 3. Verification
+
+- [ ] 3.1 Run focused mountain and morphology tests.
+- [ ] 3.2 Run world-balance stats tests.
+- [ ] 3.3 Run OpenSpec validation.
+- [ ] 3.4 Run `git diff --check`.


### PR DESCRIPTION
This PR opens the investigation and planning layer for the Swooper Earthlike balance regression. It documents observed failures (near-zero mountain coverage, absent plains, missing forests and taiga, low or absent reefs and atolls, smooth continental elevation bulges, broad dry flat land) and records the root-cause findings that explain them, including insufficient active-margin land overlap, a `boundaryShareTarget` far below schema default, pedology receiving no slope/sediment/bedrock signals, reef and atoll families planned on engine-invalid terrain/biome surfaces, mock-adapter tests overcounting planned features that the real engine rejects, and config drift between the shipped Swooper Earthlike map JSON, the standard preset, and the stale `realismEarthlikeConfig` test input.

Six OpenSpec changes are introduced as drafts to gate all downstream implementation work:

- **`earthlike-balance-diagnostic-gates`** — extends world-balance proof to cover terrain relief, mountain and hill coverage, continental elevation-profile shape, plains and pedology distribution, humidity and aridity, per-family vegetation density, reef and atoll density, and mechanical runtime roll evidence. Enables all parallel lanes.
- **`earthlike-config-authority`** — aligns the shipped map config, standard preset, Studio default posture, and legacy realism test input so they cannot silently diverge, makes omitted step defaults explicit, and adds parity tests.
- **`earthlike-engine-feature-eligibility`** — requires feature planning and balance tests to account for official `Feature_ValidTerrains` and `Feature_ValidBiomes` rules, adds per-feature rejection diagnostics, and repairs vegetation and reef-family habitat masks so planned intents land on engine-acceptable surfaces.
- **`earthlike-terrain-relief-balance`** — repairs active-margin land overlap and ridge candidate availability, separates volcano-stamped mountain terrain from planned ridge mountains in diagnostics, and adds product-visible mountain belt and non-bulge relief gates.
- **`earthlike-pedology-humidity-balance`** — investigates and repairs the missing slope, sediment, and bedrock inputs to pedology, the near-zero `BIOME_PLAINS` output, and the dry flat visual caused by broken climate and biome binding rather than feature thresholds.
- **`earthlike-ecology-feature-density`** — adds explicit density floors and per-family telemetry for forests, taiga, rainforest, savanna/steppe, reefs, cold reefs, and atolls, gated on stable upstream terrain, climate, and engine-eligibility facts.

No behavior tuning or implementation is included. All implementation work is blocked until the relevant downstream OpenSpec change exists and write sets are confirmed disjoint.