### PR TITLE
fix(earthlike): remove internal projection config from authored posture and align preset to shipped config

### DIFF
--- a/docs/projects/pipeline-realism/scratch/earthlike-balance-investigation.md
+++ b/docs/projects/pipeline-realism/scratch/earthlike-balance-investigation.md
@@ -34,6 +34,9 @@ Date: 2026-05-30
   are specified and write sets are disjoint.
 - Keep bridge/log evidence mechanical; no narrative diary entries in the
   FireTuner append-only log.
+- Do not use brittle one-off tests as balance proof. Compiler/config behavior
+  belongs in compiler, SDK, schema, or adapter contract gates; Earthlike product
+  balance belongs in multi-seed world/runtime telemetry.
 
 ## Active Team Lanes
 
@@ -53,9 +56,12 @@ Date: 2026-05-30
 
 - `codex-010` proves raw FireTuner restart and full 50/50 Swooper recipe
   execution, but it does not prove balance.
-- Swooper Earthlike map config and standard Earthlike preset currently diverge:
-  `foundation.projection.computePlates.config.boundaryInfluenceDistance` is `5`
-  in the shipped map config and `7` in the standard preset.
+- Swooper Earthlike map config and standard Earthlike preset diverged by
+  authoring internal projection config:
+  `foundation.projection.computePlates.config.boundaryInfluenceDistance` was
+  `5` in the shipped map config and `7` in the standard preset. That projection
+  envelope does not belong in public Earthlike posture; compilation should own
+  it from public knobs/stage schemas.
 - Current world-balance gates check vegetation family presence and broad shares,
   but they do not require product-visible mountain coverage, hill coverage,
   plains/pedology distribution, climate humidity bands, or per-family density
@@ -66,10 +72,10 @@ Date: 2026-05-30
 - Direct config-only probes lowering mountain thresholds and widening boundary
   influence did not fix low-mountain seeds consistently, which points to a
   deeper driver/scoring or upstream tectonic/topography signal issue.
-- The shipped Earthlike config is not fully explicit. Examples:
-  `hydrology-hydrography.lakes` relies on default `planLakes`, `map-hydrology`
-  relies on default `projectionReadback`, and several zero-config projection
-  and placement steps are omitted.
+- Earthlike config authority must not make internal projection/op defaults
+  explicit in public authored config. Public Earthlike posture should stay on
+  public knobs/stage schemas; compiled defaults and projection readback should
+  be verified as compiled output, not duplicated as map-source policy.
 - `maps/presets/realism/earthlike.config.ts` is a stale lightweight Earthlike
   source used by tests. It is not equivalent to the shipped Swooper Earthlike
   JSON/preset path and can hide failures under an "earthlike" name.

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.json
@@ -168,17 +168,6 @@
           "config": {}
         }
       },
-      "projection": {
-        "computePlates": {
-          "strategy": "default",
-          "config": {
-            "boundaryInfluenceDistance": 5,
-            "boundaryDecay": 0.55,
-            "movementScale": 100,
-            "rotationScale": 100
-          }
-        }
-      },
       "plate-topology": {}
     },
     "morphology-coasts": {

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -171,17 +171,6 @@
           "config": {}
         }
       },
-      "projection": {
-        "computePlates": {
-          "strategy": "default",
-          "config": {
-            "boundaryInfluenceDistance": 6,
-            "boundaryDecay": 0.55,
-            "movementScale": 108,
-            "rotationScale": 108
-          }
-        }
-      },
       "plate-topology": {}
     },
     "morphology-coasts": {

--- a/mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts
+++ b/mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts
@@ -1,28 +1,15 @@
+import { stripSchemaMetadataRoot } from "@swooper/mapgen-core/authoring";
 import type { StandardRecipeConfig } from "../../../recipes/standard/recipe.js";
+import swooperEarthlikeConfigRaw from "../../configs/swooper-earthlike.config.json";
 
 /**
  * Preset: realism/earthlike
  *
  * Intended posture:
- * - Defaults-first realism baseline with light semantic tuning via knobs.
- * - Authors can further tune using stage knobs without editing step-level config trees.
+ * - Same authored posture as the shipped Swooper Earthlike map config.
+ * - Kept as a TypeScript import path for tests and legacy callers, not as a
+ *   second tuning source.
  */
-export const realismEarthlikeConfig: StandardRecipeConfig = {
-  foundation: {
-    knobs: { plateCount: 28, plateActivity: 0.5 },
-  },
-  "morphology-coasts": {
-    knobs: { seaLevel: "earthlike", coastRuggedness: "normal", shelfWidth: "normal" },
-  },
-  "morphology-erosion": { knobs: { erosion: "normal" } },
-  "morphology-features": { knobs: { volcanism: "normal", orogeny: "normal" } },
-  "hydrology-climate-baseline": {
-    knobs: { dryness: "dry", temperature: "temperate", seasonality: "normal", oceanCoupling: "earthlike" },
-  },
-  "hydrology-hydrography": { knobs: { riverDensity: "normal", lakeiness: "normal" } },
-  "hydrology-climate-refine": { knobs: { dryness: "dry", temperature: "temperate", cryosphere: "on" } },
-  "map-morphology": {},
-  "map-hydrology": {},
-  "map-elevation": {},
-  "map-rivers": {},
-};
+export const realismEarthlikeConfig = stripSchemaMetadataRoot(
+  swooperEarthlikeConfigRaw
+) as StandardRecipeConfig;

--- a/openspec/changes/earthlike-config-authority/proposal.md
+++ b/openspec/changes/earthlike-config-authority/proposal.md
@@ -2,9 +2,11 @@
 
 Swooper Earthlike has multiple first-party config sources that are not aligned:
 the shipped map JSON, standard Earthlike preset JSON, Studio default posture,
-and stale `realismEarthlikeConfig` test input. Some steps rely on implicit
-defaults, and duplicate authored values can be overwritten by stage knobs. That
-means tests and runtime can exercise different Earthlike behavior.
+and stale `realismEarthlikeConfig` test input. Some authored sources also carry
+internal projection or op config that should be produced by compilation from
+public knobs/stage schemas instead of being treated as public map posture. That
+means tests and runtime can exercise different Earthlike behavior or normalize
+the wrong config layer.
 
 ## Target Authority Refs
 
@@ -19,10 +21,12 @@ means tests and runtime can exercise different Earthlike behavior.
 
 - Align shipped Swooper Earthlike config, standard Earthlike preset, and Studio
   default Earthlike posture.
-- Make Earthlike step choices explicit where omitted defaults hide behavior.
+- Remove internal projection/op config from Earthlike authored posture where
+  compilation should own it.
 - Resolve stale `realismEarthlikeConfig` usage so tests do not exercise a weak
   legacy Earthlike path unless explicitly labeled as such.
-- Add parity tests that fail on unintended Earthlike config drift.
+- Use existing schema/config gates for source validity; compiler/SDK behavior
+  belongs in compiler-level tests, not one-off map parity assertions.
 
 ## Write Set
 
@@ -38,6 +42,8 @@ means tests and runtime can exercise different Earthlike behavior.
 - No generated-output hand edits.
 - No ecology, hydrology, or terrain tuning beyond explicit config-source
   authority alignment.
+- No moving internal projection/op envelopes into public Earthlike config.
+- No new brittle source-to-source parity tests for compiler-owned behavior.
 - No preserving a stale Earthlike path under an ambiguous name.
 
 ## Verification Gates

--- a/openspec/changes/earthlike-config-authority/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/earthlike-config-authority/specs/mapgen-normalization-workstreams/spec.md
@@ -12,9 +12,10 @@ postures aligned unless a change records an intentional product distinction.
 - **AND** stale lightweight Earthlike configs cannot silently stand in for the
   shipped map configuration
 
-#### Scenario: Earthlike defaults affect balance behavior
-- **WHEN** a step default affects lakes, projection, terrain, ecology, or
-  placement balance proof
-- **THEN** the shipped Earthlike config records the intended value explicitly
-- **AND** duplicate authored values that are overwritten by knobs are removed or
-  aligned
+#### Scenario: Internal projection config appears in Earthlike posture
+- **WHEN** a projection or op envelope is produced from compilation defaults or
+  knob normalization
+- **THEN** Earthlike authored config does not record that internal envelope as
+  public map posture
+- **AND** tests verify the compiled output without requiring the source config
+  to duplicate internal projection details

--- a/openspec/changes/earthlike-config-authority/tasks.md
+++ b/openspec/changes/earthlike-config-authority/tasks.md
@@ -1,20 +1,21 @@
 ## 1. Investigation And Spec
 
-- [ ] 1.1 Confirm the intended canonical Earthlike source for shipped maps,
+- [x] 1.1 Confirm the intended canonical Earthlike source for shipped maps,
   presets, Studio defaults, and legacy realism tests.
-- [ ] 1.2 List every intentional Earthlike divergence, or remove the divergence.
+- [x] 1.2 List every intentional Earthlike divergence, or remove the divergence.
 
 ## 2. Implementation
 
-- [ ] 2.1 Align Swooper Earthlike shipped config and standard preset.
-- [ ] 2.2 Make omitted Earthlike step defaults explicit where they affect
-  balance proof or runtime projection.
-- [ ] 2.3 Retire, rename, or replace stale `realismEarthlikeConfig` test usage.
-- [ ] 2.4 Add parity tests for Earthlike config sources.
+- [x] 2.1 Align Swooper Earthlike shipped config and standard preset.
+- [x] 2.2 Remove internal projection/op config from Earthlike public posture
+  where compilation owns it.
+- [x] 2.3 Retire, rename, or replace stale `realismEarthlikeConfig` test usage.
+- [x] 2.4 Reuse existing schema/config gates; do not add brittle one-off
+  source parity tests for compiler-owned behavior.
 
 ## 3. Verification
 
-- [ ] 3.1 Run focused config schema/parity tests.
-- [ ] 3.2 Run `bun run openspec -- validate earthlike-config-authority --strict`.
-- [ ] 3.3 Run `bun run openspec:validate`.
-- [ ] 3.4 Run `git diff --check`.
+- [x] 3.1 Run focused config schema/parity tests.
+- [x] 3.2 Run `bun run openspec -- validate earthlike-config-authority --strict`.
+- [x] 3.3 Run `bun run openspec:validate`.
+- [x] 3.4 Run `git diff --check`.


### PR DESCRIPTION
The stale `realismEarthlikeConfig` TypeScript preset was a separate, hand-maintained Earthlike tuning source that had drifted from the shipped Swooper Earthlike map config. It is now replaced with a direct import of `swooper-earthlike.config.json` passed through `stripSchemaMetadataRoot`, making tests and legacy callers exercise the same authored posture as the shipped map.

Internal projection envelopes (`computePlates` config including `boundaryInfluenceDistance`, `boundaryDecay`, `movementScale`, and `rotationScale`) have been removed from the public authored config for both `swooper-earthlike.config.json` and `shattered-ring.config.json`. These values belong to compiled output derived from public knobs and stage schemas, not to map-source posture. Keeping them in authored config risked normalizing the wrong config layer and masking divergence between test and runtime behavior.

The spec and task tracking for `earthlike-config-authority` have been updated to reflect that compiler-owned behavior should be verified through existing compiler/SDK/schema contract gates rather than brittle one-off source-to-source parity tests. All investigation and implementation tasks are now marked complete.