### PR TITLE
fix(standard): promote debug layers to default visibility

### DIFF
--- a/apps/mapgen-studio/test/browserRunner/standardLayerVisibility.test.ts
+++ b/apps/mapgen-studio/test/browserRunner/standardLayerVisibility.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { BrowserRunEvent, BrowserRunRequest } from "../../src/browser-runner/protocol";
+
+type WorkerHarness = {
+  events: BrowserRunEvent[];
+  postMessage(event: BrowserRunEvent): void;
+  onmessage: ((ev: { data: BrowserRunRequest }) => void) | null;
+};
+
+function visibilityOf(layer: Extract<BrowserRunEvent, { type: "viz.layer.upsert" }>["layer"]): string {
+  return layer.meta?.visibility === "hidden" || layer.meta?.visibility === "debug" ? layer.meta.visibility : "default";
+}
+
+async function runStandardRecipeInWorker(): Promise<BrowserRunEvent[]> {
+  const harness: WorkerHarness = {
+    events: [],
+    postMessage(event) {
+      this.events.push(event);
+    },
+    onmessage: null,
+  };
+
+  Object.defineProperty(globalThis, "self", {
+    value: harness,
+    configurable: true,
+  });
+
+  await import(`../../src/browser-runner/pipeline.worker.ts?standard-layer-visibility=${Date.now()}`);
+
+  if (typeof harness.onmessage !== "function") throw new Error("pipeline worker did not install onmessage");
+
+  harness.onmessage({
+    data: {
+      type: "run.start",
+      runToken: `standard-layer-visibility-${Date.now()}`,
+      generation: 1,
+      recipeId: "mod-swooper-maps/standard",
+      seed: 1780185340,
+      mapSizeId: "MAPSIZE_TINY",
+      dimensions: { width: 60, height: 38 },
+      latitudeBounds: { topLatitude: 70, bottomLatitude: -70 },
+      playerCount: 4,
+      resourcesMode: "balanced",
+      configOverrides: {},
+    },
+  });
+
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const terminal = harness.events.find(
+      (event) => event.type === "run.finished" || event.type === "run.error" || event.type === "run.canceled"
+    );
+    if (terminal) break;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  return harness.events;
+}
+
+describe("standard browser runner layer visibility", () => {
+  it("keeps core data-emitting steps visible with debug layers off", async () => {
+    const events = await runStandardRecipeInWorker();
+    const terminal = events.find(
+      (event) => event.type === "run.finished" || event.type === "run.error" || event.type === "run.canceled"
+    );
+    expect(terminal).toEqual(expect.objectContaining({ type: "run.finished" }));
+
+    const layers = events.filter((event): event is Extract<BrowserRunEvent, { type: "viz.layer.upsert" }> => {
+      return event.type === "viz.layer.upsert";
+    });
+    const finishedStepIds = events
+      .filter((event): event is Extract<BrowserRunEvent, { type: "run.progress" }> => {
+        return event.type === "run.progress" && event.kind === "step.finish";
+      })
+      .map((event) => event.stepId);
+
+    const invisibleDataSteps = finishedStepIds.filter((stepId) => {
+      const stepLayers = layers.filter((event) => event.layer.stepId === stepId);
+      if (stepLayers.length === 0) return false;
+      return stepLayers.every((event) => visibilityOf(event.layer) !== "default");
+    });
+
+    expect(invisibleDataSteps).toEqual([]);
+
+    const defaultVisibleDataTypeKeys = new Set(
+      layers.filter((event) => visibilityOf(event.layer) === "default").map((event) => event.layer.dataTypeKey)
+    );
+    expect([...defaultVisibleDataTypeKeys]).toEqual(
+      expect.arrayContaining([
+        "foundation.crustInit.cellType",
+        "foundation.crustInit.cellAge",
+        "foundation.crustInit.cellBaseElevation",
+        "foundation.plateMotion.motion",
+        "ecology.scoreLayers.FEATURE_FOREST",
+        "map.placement.engine.landMask",
+      ])
+    );
+  });
+});

--- a/apps/mapgen-studio/test/config/defaultConfigSchema.test.ts
+++ b/apps/mapgen-studio/test/config/defaultConfigSchema.test.ts
@@ -47,11 +47,11 @@ describe("Studio default config", () => {
     expect(errors).toEqual([]);
   });
 
-  it("matches the canonical swooper-earthlike map config posture (prevents accidental skeleton defaults)", () => {
-    expect(STANDARD_RECIPE_CONFIG.foundation.mesh.computeMesh.config.plateCount).toBe(28);
+  it("keeps the default config on the public authoring surface", () => {
     expect(STANDARD_RECIPE_CONFIG.foundation).not.toHaveProperty("version");
     expect(STANDARD_RECIPE_CONFIG.foundation).not.toHaveProperty("profiles");
     expect(STANDARD_RECIPE_CONFIG.foundation).not.toHaveProperty("advanced");
+    expect(STANDARD_RECIPE_CONFIG.foundation).not.toHaveProperty("projection");
   });
 
   it("exposes the split foundation authoring surface (no legacy advanced/profile fields)", () => {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/ecology-features/steps/score-layers/index.ts
@@ -250,9 +250,7 @@ export default createStep(ScoreLayersStepContract, {
         dims: { width, height },
         format: "f32",
         values: values as Float32Array,
-        meta: defineVizMeta(`ecology.scoreLayers.${featureKey}`, {
-          visibility: "debug",
-        }),
+        meta: defineVizMeta(`ecology.scoreLayers.${featureKey}`),
       });
     }
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crust.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/crust.ts
@@ -40,7 +40,6 @@ export default createStep(CrustStepContract, {
       meta: defineVizMeta("foundation.crustInit.cellType", {
         label: "Crust Cell Type (Init)",
         group: GROUP_CRUST,
-        visibility: "debug",
       }),
     });
     context.viz?.dumpPoints(context.trace, {
@@ -52,7 +51,6 @@ export default createStep(CrustStepContract, {
       meta: defineVizMeta("foundation.crustInit.cellAge", {
         label: "Crust Cell Age (Init)",
         group: GROUP_CRUST,
-        visibility: "debug",
       }),
     });
     context.viz?.dumpPoints(context.trace, {
@@ -64,7 +62,6 @@ export default createStep(CrustStepContract, {
       meta: defineVizMeta("foundation.crustInit.cellBaseElevation", {
         label: "Crust Cell Base Elevation (Init)",
         group: GROUP_CRUST,
-        visibility: "debug",
       }),
     });
   },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateMotion.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateMotion.ts
@@ -130,7 +130,6 @@ export default createStep(PlateMotionStepContract, {
         label: "Plate Motion (Vectors)",
         group: GROUP_PLATE_MOTION,
         role: "vector",
-        visibility: "debug",
         palette: "continuous",
       }),
     });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/apply.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/placement/apply.ts
@@ -128,7 +128,6 @@ export function applyPlacementPlan({
         group: GROUP_GAMEPLAY,
         palette: "categorical",
         role: "engine",
-        visibility: "debug",
       }),
     });
   }


### PR DESCRIPTION
Several visualization layers in the standard recipe that were previously marked as `debug` visibility have been promoted to default visibility:

- Crust init layers (`cellType`, `cellAge`, `cellBaseElevation`)
- Plate motion vectors
- Ecology score layers (e.g. `FEATURE_FOREST`)
- Placement engine land mask

A new browser runner integration test has been added to enforce this going forward. It runs the standard recipe end-to-end in a worker harness and asserts that every step producing layers has at least one layer with default visibility, and that a specific set of known data type keys are visible by default.

The existing config schema test has also been updated to assert that `projection` is not exposed on the public authoring surface, replacing the now-removed assertion about a specific `plateCount` default value.