### PR TITLE
fix(foundation): restore tile-space plate motion as default-visible with arrow render

### DIFF
--- a/apps/mapgen-studio/test/browserRunner/standardLayerVisibility.test.ts
+++ b/apps/mapgen-studio/test/browserRunner/standardLayerVisibility.test.ts
@@ -58,7 +58,7 @@ async function runStandardRecipeInWorker(): Promise<BrowserRunEvent[]> {
 }
 
 describe("standard browser runner layer visibility", () => {
-  it("keeps core data-emitting steps visible with debug layers off", async () => {
+  it("keeps core balance layers visible with debug layers off", async () => {
     const events = await runStandardRecipeInWorker();
     const terminal = events.find(
       (event) => event.type === "run.finished" || event.type === "run.error" || event.type === "run.canceled"
@@ -68,20 +68,6 @@ describe("standard browser runner layer visibility", () => {
     const layers = events.filter((event): event is Extract<BrowserRunEvent, { type: "viz.layer.upsert" }> => {
       return event.type === "viz.layer.upsert";
     });
-    const finishedStepIds = events
-      .filter((event): event is Extract<BrowserRunEvent, { type: "run.progress" }> => {
-        return event.type === "run.progress" && event.kind === "step.finish";
-      })
-      .map((event) => event.stepId);
-
-    const invisibleDataSteps = finishedStepIds.filter((stepId) => {
-      const stepLayers = layers.filter((event) => event.layer.stepId === stepId);
-      if (stepLayers.length === 0) return false;
-      return stepLayers.every((event) => visibilityOf(event.layer) !== "default");
-    });
-
-    expect(invisibleDataSteps).toEqual([]);
-
     const defaultVisibleDataTypeKeys = new Set(
       layers.filter((event) => visibilityOf(event.layer) === "default").map((event) => event.layer.dataTypeKey)
     );
@@ -90,10 +76,24 @@ describe("standard browser runner layer visibility", () => {
         "foundation.crustInit.cellType",
         "foundation.crustInit.cellAge",
         "foundation.crustInit.cellBaseElevation",
-        "foundation.plateMotion.motion",
+        "foundation.plates.tileMovement",
         "ecology.scoreLayers.FEATURE_FOREST",
         "map.placement.engine.landMask",
       ])
     );
+
+    const tileMotionLayers = layers.filter((event) => {
+      return event.layer.dataTypeKey === "foundation.plates.tileMovement" && visibilityOf(event.layer) === "default";
+    });
+    expect(tileMotionLayers.map((event) => event.layer.spaceId)).toEqual(
+      expect.arrayContaining(["tile.hexOddR"])
+    );
+    expect(tileMotionLayers.map((event) => `${event.layer.kind}:${event.layer.meta?.role ?? ""}`)).toEqual(
+      expect.arrayContaining(["gridFields:vector", "segments:arrows"])
+    );
+
+    const rawWorldMotionLayers = layers.filter((event) => event.layer.dataTypeKey === "foundation.plateMotion.motion");
+    expect(rawWorldMotionLayers.length).toBeGreaterThan(0);
+    expect(rawWorldMotionLayers.every((event) => visibilityOf(event.layer) === "debug")).toBe(true);
   });
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateMotion.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/plateMotion.ts
@@ -130,6 +130,7 @@ export default createStep(PlateMotionStepContract, {
         label: "Plate Motion (Vectors)",
         group: GROUP_PLATE_MOTION,
         role: "vector",
+        visibility: "debug",
         palette: "continuous",
       }),
     });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/foundation/steps/projection.ts
@@ -267,7 +267,7 @@ export default createStep(ProjectionStepContract, {
       dims: { width, height },
       u: { format: "i8", values: platesResult.plates.movementU },
       v: { format: "i8", values: platesResult.plates.movementV },
-      label: "Plate Movement",
+      label: "Plate Motion",
       group: GROUP_PLATES,
       palette: "continuous",
       magnitude: { debugOnly: true },

--- a/openspec/changes/restore-plate-motion-tile-arrows/proposal.md
+++ b/openspec/changes/restore-plate-motion-tile-arrows/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+The Studio visibility repair exposed the raw foundation plate-motion diagnostic
+as a default-visible world-space vector segment layer. That is the wrong
+authoring surface for balance work: the useful product diagnostic is tile-space
+plate motion with directional arrows, because terrain, coasts, mountains, and
+ecology are inspected on generated map tiles.
+
+## Target Authority Refs
+
+- Direct user decision: plate motion must remain tile-based with directional
+  arrows for normal Studio use.
+- `openspec/changes/earthlike-balance-diagnostic-gates`: balance proof depends
+  on product-visible diagnostics, not only successful execution.
+- `openspec/specs/mapgen-normalization-workstreams/spec.md`: truth and
+  projection/materialization surfaces stay distinct.
+- `mods/mod-swooper-maps/AGENTS.md`: generated outputs are regenerated through
+  package scripts rather than hand-edited.
+
+## What Changes
+
+- Keep raw foundation plate-motion world vectors available only as debug
+  diagnostics.
+- Keep the tile-projected plate-motion vector field default-visible in Studio.
+- Require the default tile surface to include the arrow render mode.
+- Replace the broad "every data-emitting step must be default visible" test
+  with a semantic Studio contract for the core balance diagnostics.
+
+## Write Set
+
+- Foundation plate-motion visualization metadata.
+- Foundation projection visualization label/contract.
+- Studio browser-runner visualization regression test.
+- This OpenSpec change record.
+
+## Forbidden Non-Goals
+
+- No changes to plate-motion generation physics.
+- No changes to map balance tuning.
+- No broad visibility rule that forces internal debug diagnostics into the
+  default Studio surface.
+
+## Verification Gates
+
+- `bun test apps/mapgen-studio/test/browserRunner/standardLayerVisibility.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate restore-plate-motion-tile-arrows --strict`
+- `git diff --check`

--- a/openspec/changes/restore-plate-motion-tile-arrows/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/restore-plate-motion-tile-arrows/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Studio Plate Motion Uses Tile Arrow Surface
+
+Studio SHALL keep product-facing plate-motion diagnostics on the tile-projected
+map surface with directional arrows, while lower-level world-space vector
+diagnostics remain debug-only.
+
+#### Scenario: Default Studio layers are built
+- **WHEN** the standard Swooper Maps recipe emits foundation plate-motion
+  diagnostics
+- **THEN** the default-visible plate-motion surface is tile-space data with a
+  directional arrow render mode
+- **AND** raw world-space plate-motion vector segments are not part of the
+  default Studio layer set

--- a/openspec/changes/restore-plate-motion-tile-arrows/tasks.md
+++ b/openspec/changes/restore-plate-motion-tile-arrows/tasks.md
@@ -1,0 +1,17 @@
+## 1. Specification
+
+- [x] 1.1 Record the Studio plate-motion visualization contract in OpenSpec.
+
+## 2. Implementation
+
+- [x] 2.1 Restore raw world-space plate-motion vectors to debug visibility.
+- [x] 2.2 Keep tile-space plate motion default-visible with directional arrows.
+- [x] 2.3 Replace broad data-step visibility assertions with semantic layer
+  assertions.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused Studio browser-runner regression.
+- [x] 3.2 Run mod type/check gate.
+- [x] 3.3 Run OpenSpec validation for this change.
+- [x] 3.4 Run `git diff --check`.


### PR DESCRIPTION
The raw world-space plate-motion vector layer was incorrectly exposed as a default-visible Studio diagnostic. The useful surface for balance work is the tile-projected plate-motion field with directional arrows, since terrain, coasts, mountains, and ecology are all inspected on generated map tiles.

This restores the raw foundation plate-motion vectors to debug-only visibility and ensures the tile-projected plate-motion layer remains default-visible in Studio with the arrow render mode present. The "Plate Motion" label is also aligned between the projection step and its visualization metadata.

The browser-runner regression test is updated to replace the broad assertion that every data-emitting step must have at least one default-visible layer with a targeted contract: the core balance diagnostics (`foundation.crustInit.*`, `foundation.plates.tileMovement`, `ecology.scoreLayers.FEATURE_FOREST`, `map.placement.engine.landMask`) are default-visible, the tile-motion surface is on the `tile.hexOddR` space with both `gridFields:vector` and `segments:arrows` render modes, and the raw `foundation.plateMotion.motion` layers are confirmed debug-only.