### PR TITLE
feat(morphology): expose semantic public config surface and compile to internal step envelopes

### DIFF
--- a/apps/mapgen-studio/src/App.tsx
+++ b/apps/mapgen-studio/src/App.tsx
@@ -922,10 +922,51 @@ function AppContent(props: AppContentProps) {
     }
     if (result.persistenceError) {
       toast(`Scratch config updated but could not persist: ${result.persistenceError}`, { variant: "error" });
-    } else {
-      toast("Scratch config updated", { variant: "success" });
+      return;
     }
-  }, [handleSaveAsNew, pipelineConfig, presetActions, recipeSettings.preset, recipeSettings.recipe, rememberRepoBackedConfig, resolvePreset, toast]);
+
+    const label = result.preset?.label ?? resolved?.label ?? "Scratch Config";
+    const description = result.preset?.description ?? resolved?.description;
+    const baseId = toConfigId(label);
+    const id = builtInPresets.some((preset) => preset.id === baseId) ? `scratch-${baseId}` : baseId;
+    const repoResult = await saveRepoBackedConfig({
+      id,
+      name: label,
+      description,
+      sortIndex: (resolved?.sortIndex ?? 900) + 1000,
+      latitudeBounds: resolved?.latitudeBounds,
+      config: sanitized,
+    });
+    if (repoResult.ok || repoResult.saved) {
+      rememberRepoBackedConfig(
+        recipeSettings.recipe,
+        toRepoBackedPreset({
+          id,
+          label,
+          description,
+          sourcePath: repoResult.path ?? `mods/mod-swooper-maps/src/maps/configs/${id}.config.json`,
+          sortIndex: (resolved?.sortIndex ?? 900) + 1000,
+          latitudeBounds: resolved?.latitudeBounds,
+          config: sanitized,
+        })
+      );
+      setRecipeSettings((prev) => ({ ...prev, preset: `builtin:${id}` }));
+      lastAppliedPresetRef.current = { key: `builtin:${id}`, config: sanitized };
+      setPipelineConfig(sanitized as PipelineConfig);
+    }
+    if (!repoResult.ok) {
+      toast(
+        repoResult.saved && repoResult.deployed
+          ? `Config saved and deployed from ${repoResult.path ?? `${id}.config.json`} but Civ7 restart request failed: ${repoResult.error}`
+          : repoResult.saved
+            ? `Config saved to ${repoResult.path ?? `${id}.config.json`} but deploy failed: ${repoResult.error}`
+            : `Config save failed: ${repoResult.error}`,
+        { variant: "error" },
+      );
+    } else {
+      toast(`Config saved, deployed, and restart requested from ${repoResult.path ?? `${id}.config.json`}`, { variant: "success" });
+    }
+  }, [builtInPresets, handleSaveAsNew, pipelineConfig, presetActions, recipeSettings.preset, recipeSettings.recipe, rememberRepoBackedConfig, resolvePreset, toast]);
 
   const handleDeletePreset = useCallback(() => {
     const parsed = parsePresetKey(recipeSettings.preset);

--- a/apps/mapgen-studio/src/App.tsx
+++ b/apps/mapgen-studio/src/App.tsx
@@ -110,7 +110,7 @@ async function saveRepoBackedConfig(args: {
     $schema: "../../../dist/recipes/standard-map-config.schema.json",
     id: args.id,
     name: args.name,
-    description: args.description ?? "",
+    description: args.description?.trim() || args.name,
     recipe: "standard",
     sortIndex: args.sortIndex,
     ...(args.latitudeBounds ? { latitudeBounds: args.latitudeBounds } : {}),

--- a/apps/mapgen-studio/test/config/defaultConfigSchema.test.ts
+++ b/apps/mapgen-studio/test/config/defaultConfigSchema.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { normalizeStrict } from "@swooper/mapgen-core/compiler/normalize";
 
-import { STANDARD_RECIPE_CONFIG, STANDARD_RECIPE_CONFIG_SCHEMA } from "mod-swooper-maps/recipes/standard-artifacts";
+import {
+  STANDARD_RECIPE_CONFIG,
+  STANDARD_RECIPE_CONFIG_SCHEMA,
+  studioRecipeUiMeta as STANDARD_RECIPE_UI_META,
+} from "mod-swooper-maps/recipes/standard-artifacts";
 
 function getSchemaAtPath(schema: unknown, path: readonly string[]): unknown {
   let current: any = schema as any;
@@ -52,6 +56,75 @@ describe("Studio default config", () => {
     expect(STANDARD_RECIPE_CONFIG.foundation).not.toHaveProperty("profiles");
     expect(STANDARD_RECIPE_CONFIG.foundation).not.toHaveProperty("advanced");
     expect(STANDARD_RECIPE_CONFIG.foundation).not.toHaveProperty("projection");
+  });
+
+  it("exposes semantic Morphology authoring keys instead of internal op envelopes", () => {
+    const expected: Record<string, readonly string[]> = {
+      "morphology-coasts": [
+        "knobs",
+        "substrate",
+        "relief",
+        "waterCoverage",
+        "continents",
+        "coastlineShape",
+        "shelf",
+      ],
+      "morphology-routing": ["knobs"],
+      "morphology-erosion": ["knobs", "geomorphicCycle"],
+      "morphology-features": ["knobs", "islandChains", "mountainRanges", "volcanoes"],
+    };
+
+    for (const [stageId, expectedKeys] of Object.entries(expected)) {
+      const schemaProps =
+        (getSchemaAtPath(STANDARD_RECIPE_CONFIG_SCHEMA, [stageId]) as {
+          properties?: Record<string, unknown>;
+        }).properties ?? {};
+      expect(Object.keys(schemaProps).sort()).toEqual([...expectedKeys].sort());
+      expect(JSON.stringify(schemaProps)).not.toContain("\"strategy\"");
+      expect(JSON.stringify(schemaProps)).not.toContain("\"config\"");
+
+      const config = (STANDARD_RECIPE_CONFIG as Record<string, Record<string, unknown>>)[stageId] ?? {};
+      for (const key of Object.keys(config)) {
+        expect(expectedKeys).toContain(key);
+      }
+    }
+  });
+
+  it("keeps Morphology runtime steps visible even when public config keys are semantic", () => {
+    const expectedSteps: Record<string, readonly string[]> = {
+      "morphology-coasts": ["landmass-plates", "rugged-coasts"],
+      "morphology-routing": ["routing"],
+      "morphology-erosion": ["geomorphology"],
+      "morphology-features": ["islands", "mountains", "volcanoes", "landmasses"],
+    };
+
+    const publicKeysByStage: Record<string, readonly string[]> = {
+      "morphology-coasts": [
+        "substrate",
+        "relief",
+        "waterCoverage",
+        "continents",
+        "coastlineShape",
+        "shelf",
+      ],
+      "morphology-routing": [],
+      "morphology-erosion": ["geomorphicCycle"],
+      "morphology-features": ["islandChains", "mountainRanges", "volcanoes"],
+    };
+
+    for (const [stageId, stepIds] of Object.entries(expectedSteps)) {
+      const stage = STANDARD_RECIPE_UI_META.stages.find((entry) => entry.stageId === stageId);
+      expect(stage?.steps.map((step) => step.stepId)).toEqual(stepIds);
+
+      const publicKeys = publicKeysByStage[stageId] ?? [];
+      for (const step of stage?.steps ?? []) {
+        const [focusKey, ...rest] = step.configFocusPathWithinStage;
+        expect(rest).toEqual([]);
+        if (focusKey) {
+          expect(publicKeys).toContain(focusKey);
+        }
+      }
+    }
   });
 
   it("exposes the split foundation authoring surface (no legacy advanced/profile fields)", () => {

--- a/apps/mapgen-studio/vite.config.ts
+++ b/apps/mapgen-studio/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { execFile } from "node:child_process";
-import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { promisify } from "node:util";
@@ -9,9 +9,10 @@ import { fileURLToPath } from "node:url";
 
 const execFileAsync = promisify(execFile);
 const DEPLOY_TIMEOUT_MS = 120_000;
+const RESTART_TIMEOUT_MS = 60_000;
+const FIRETUNER_WAIT_TIMEOUT_MS = 45_000;
 const MAX_DEPLOY_OUTPUT_CHARS = 8_000;
 const FIRETUNER_AGENT = "DRA-map-config-generation";
-const FIRETUNER_RESTART_COMMAND = "Network.restartGame()";
 const DEFAULT_FIRETUNER_BRIDGE_LOG = join(
   homedir(),
   "Parallels Tunnel",
@@ -20,7 +21,7 @@ const DEFAULT_FIRETUNER_BRIDGE_LOG = join(
   "civ7-firetuner-bridge.append-only.log",
 );
 
-let deployQueue = Promise.resolve();
+let saveDeployRestartQueue = Promise.resolve();
 
 function tail(value: string): string {
   return value.length > MAX_DEPLOY_OUTPUT_CHARS ? value.slice(-MAX_DEPLOY_OUTPUT_CHARS) : value;
@@ -32,48 +33,109 @@ async function deploySwooperMaps(repoRoot: string): Promise<{
   stderr: string;
 }> {
   const command = "bun run --cwd mods/mod-swooper-maps deploy";
-  const run = async () => {
-    const { stdout, stderr } = await execFileAsync(
-      "bun",
-      ["run", "--cwd", "mods/mod-swooper-maps", "deploy"],
-      {
-        cwd: repoRoot,
-        timeout: DEPLOY_TIMEOUT_MS,
-        maxBuffer: 16 * 1024 * 1024,
-      }
-    );
-    return {
-      command,
-      stdout: tail(stdout),
-      stderr: tail(stderr),
-    };
-  };
-  const next = deployQueue.then(run, run);
-  deployQueue = next.then(
-    () => undefined,
-    () => undefined
+  const { stdout, stderr } = await execFileAsync(
+    "bun",
+    ["run", "--cwd", "mods/mod-swooper-maps", "deploy"],
+    {
+      cwd: repoRoot,
+      timeout: DEPLOY_TIMEOUT_MS,
+      maxBuffer: 16 * 1024 * 1024,
+    }
   );
-  return next;
+  return {
+    command,
+    stdout: tail(stdout),
+    stderr: tail(stderr),
+  };
 }
 
-async function requestCiv7Restart(): Promise<{
+async function requestCiv7Restart(repoRoot: string): Promise<{
   requestId: string;
   agent: string;
   command: string;
   logPath: string;
+  response?: unknown;
 }> {
   const logPath = process.env.CIV7_FIRETUNER_BRIDGE_LOG ?? DEFAULT_FIRETUNER_BRIDGE_LOG;
-  const requestId = `studio-${Date.now().toString(36)}-${process.pid.toString(36)}`;
-  await appendFile(
-    logPath,
-    `\nREQ ${requestId} AGENT=${FIRETUNER_AGENT} RUN ${FIRETUNER_RESTART_COMMAND}\n`
+  const { stdout } = await execFileAsync(
+    "bun",
+    [
+      "run",
+      "--cwd",
+      "packages/cli",
+      "dev",
+      "--",
+      "game",
+      "restart",
+      "--agent",
+      FIRETUNER_AGENT,
+      "--bridge-log",
+      logPath,
+      "--request-id",
+      `studio-${Date.now().toString(36)}-${process.pid.toString(36)}`,
+      "--wait",
+      "--timeout-ms",
+      String(FIRETUNER_WAIT_TIMEOUT_MS),
+      "--json",
+    ],
+    {
+      cwd: repoRoot,
+      timeout: RESTART_TIMEOUT_MS,
+      maxBuffer: 4 * 1024 * 1024,
+    }
   );
-  return {
-    requestId,
-    agent: FIRETUNER_AGENT,
-    command: FIRETUNER_RESTART_COMMAND,
-    logPath,
+  const restart = JSON.parse(stdout.trim().split(/\r?\n/).at(-1) ?? "{}") as {
+    ok?: boolean;
+    request?: {
+      requestId?: string;
+      agent?: string;
+      command?: string;
+      logPath?: string;
+    };
+    response?: unknown;
+    timedOut?: boolean;
   };
+  if (!restart.ok) {
+    throw new Error(restart.timedOut ? "Timed out waiting for FireTuner bridge response" : "FireTuner bridge blocked restart request");
+  }
+  return {
+    requestId: restart.request?.requestId ?? "",
+    agent: restart.request?.agent ?? FIRETUNER_AGENT,
+    command: restart.request?.command ?? "Network.restartGame()",
+    logPath: restart.request?.logPath ?? logPath,
+    response: restart.response,
+  };
+}
+
+function isNodeNotFound(err: unknown): boolean {
+  return Boolean(err) && typeof err === "object" && "code" in err && (err as { code?: unknown }).code === "ENOENT";
+}
+
+function assertRepoMapEnvelope(envelope: unknown, id: string): void {
+  if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)) {
+    throw new Error("Map config envelope must be a JSON object");
+  }
+  const record = envelope as Record<string, unknown>;
+  if (record.id !== id) throw new Error("Map config envelope id must match the requested id");
+  if (typeof record.name !== "string" || record.name.trim().length === 0) {
+    throw new Error("Map config name must be non-empty");
+  }
+  if (typeof record.description !== "string" || record.description.trim().length === 0) {
+    throw new Error("Map config description must be non-empty");
+  }
+  if (record.recipe !== "standard") throw new Error('Map config recipe must be "standard"');
+  if (!Number.isInteger(record.sortIndex)) throw new Error("Map config sortIndex must be an integer");
+  if (!record.config || typeof record.config !== "object" || Array.isArray(record.config)) {
+    throw new Error("Map config payload must be a JSON object");
+  }
+}
+
+async function restoreRepoConfig(target: string, previous: string | null): Promise<void> {
+  if (previous === null) {
+    await rm(target, { force: true });
+    return;
+  }
+  await writeFile(target, previous);
 }
 
 export default defineConfig(({ command }) => ({
@@ -95,6 +157,7 @@ export default defineConfig(({ command }) => ({
             if (typeof body.id !== "string" || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(body.id)) {
               throw new Error("Map config id must be kebab-case");
             }
+            assertRepoMapEnvelope(body.envelope, body.id);
             const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
             const configRoot = resolve(repoRoot, "mods/mod-swooper-maps/src/maps/configs");
             const target = body.sourcePath
@@ -105,34 +168,47 @@ export default defineConfig(({ command }) => ({
                 "Map config writes must stay in mods/mod-swooper-maps/src/maps/configs"
               );
             }
-            await mkdir(dirname(target), { recursive: true });
-            await writeFile(target, `${JSON.stringify(body.envelope, null, 2)}\n`);
             const path = relative(repoRoot, target);
-            let deploy;
-            try {
-              deploy = await deploySwooperMaps(repoRoot);
-            } catch (err) {
-              const error = err instanceof Error ? err.message : "Deploy failed";
-              res.statusCode = 500;
+            const run = async () => {
+              const previous = await readFile(target, "utf8").catch((err: unknown) => {
+                if (isNodeNotFound(err)) return null;
+                throw err;
+              });
+              await mkdir(dirname(target), { recursive: true });
+              await writeFile(target, `${JSON.stringify(body.envelope, null, 2)}\n`);
+              let deploy;
+              try {
+                deploy = await deploySwooperMaps(repoRoot);
+              } catch (err) {
+                await restoreRepoConfig(target, previous);
+                const error = err instanceof Error ? err.message : "Deploy failed";
+                res.statusCode = 500;
+                res.setHeader("Content-Type", "application/json");
+                res.end(JSON.stringify({ ok: false, saved: false, path, error }));
+                return;
+              }
+              let restart;
+              try {
+                restart = await requestCiv7Restart(repoRoot);
+              } catch (err) {
+                const error = err instanceof Error ? err.message : "Civ7 restart request failed";
+                res.statusCode = 500;
+                res.setHeader("Content-Type", "application/json");
+                res.end(
+                  JSON.stringify({ ok: false, saved: true, deployed: true, path, deploy, error })
+                );
+                return;
+              }
+              res.statusCode = 200;
               res.setHeader("Content-Type", "application/json");
-              res.end(JSON.stringify({ ok: false, saved: true, path, error }));
-              return;
-            }
-            let restart;
-            try {
-              restart = await requestCiv7Restart();
-            } catch (err) {
-              const error = err instanceof Error ? err.message : "Civ7 restart request failed";
-              res.statusCode = 500;
-              res.setHeader("Content-Type", "application/json");
-              res.end(
-                JSON.stringify({ ok: false, saved: true, deployed: true, path, deploy, error })
-              );
-              return;
-            }
-            res.statusCode = 200;
-            res.setHeader("Content-Type", "application/json");
-            res.end(JSON.stringify({ ok: true, path, deploy, restart }));
+              res.end(JSON.stringify({ ok: true, path, deploy, restart }));
+            };
+            const nextRun = saveDeployRestartQueue.then(run, run);
+            saveDeployRestartQueue = nextRun.then(
+              () => undefined,
+              () => undefined
+            );
+            await nextRun;
           } catch (err) {
             const error = err instanceof Error ? err.message : "Save failed";
             res.statusCode = 400;

--- a/mods/mod-swooper-maps/scripts/generate-studio-recipe-types.ts
+++ b/mods/mod-swooper-maps/scripts/generate-studio-recipe-types.ts
@@ -7,8 +7,10 @@ import type { TObject, TSchema } from "typebox";
 import {
   derivePresetLabel,
   deriveRecipeConfigSchema,
+  deriveStageAuthoringModel,
   stripSchemaMetadataRoot,
   type RecipePresetDefinitionV1,
+  type StageAuthoringModel,
 } from "@swooper/mapgen-core/authoring";
 import { normalizeStrict } from "@swooper/mapgen-core/compiler/normalize";
 import { validateCanonicalMapConfig } from "../src/maps/configs/canonical.js";
@@ -33,12 +35,6 @@ function isPlainObject(value: unknown): value is JsonObject {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
-function typeboxObjectProperties(schema: unknown): Record<string, unknown> {
-  if (!schema || typeof schema !== "object") return {};
-  const props = (schema as { properties?: unknown }).properties;
-  return isPlainObject(props) ? props : {};
-}
-
 function stableJson(value: unknown): JsonObject {
   const text = JSON.stringify(value);
   if (!text) throw new Error("schema is not JSON-serializable");
@@ -53,6 +49,7 @@ type StageLike = Readonly<{
   steps: readonly Readonly<{ contract: Readonly<{ id: string; schema: TSchema }> }>[];
   public?: TObject;
   surfaceSchema: TObject;
+  authoring: StageAuthoringModel;
   toInternal: (args: { env: unknown; stageConfig: unknown }) => { rawSteps: Record<string, unknown> };
 }>;
 
@@ -101,21 +98,7 @@ function deriveStageStepConfigFocusMap(args: {
   stage: StageLike;
 }): Readonly<Record<string, readonly string[]>> {
   const { stage } = args;
-  const stepIds = stage.steps.map((s) => s.contract.id);
-
-  if (!stage.public) {
-    return Object.fromEntries(stepIds.map((stepId) => [stepId, [stepId]])) as Record<
-      string,
-      readonly string[]
-    >;
-  }
-
-  const publicProps = typeboxObjectProperties(stage.public);
-  return Object.fromEntries(
-    stepIds
-      .filter((stepId) => Object.prototype.hasOwnProperty.call(publicProps, stepId))
-      .map((stepId) => [stepId, [stepId]])
-  ) as Record<string, readonly string[]>;
+  return deriveStageAuthoringModel(stage).config.focusPathsByStepId;
 }
 
 function readPresetWrapper(args: {
@@ -299,22 +282,20 @@ function deriveStudioRecipeUiMeta(args: {
       const stageId = stage.id;
       const stageLabel = STAGE_LABEL_OVERRIDES[stageId] ?? formatKebabIdLabel(stageId);
       const stepFocus = deriveStageStepConfigFocusMap({ namespace, recipeId, stage });
+      const authoring = deriveStageAuthoringModel(stage);
       return {
         stageId,
         stageLabel,
-        steps: stage.steps.flatMap((s) => {
-          const stepId = s.contract.id;
-          const configFocusPathWithinStage = stepFocus[stepId];
-          if (!configFocusPathWithinStage) {
-            return [];
-          }
+        steps: authoring.runtime.steps.map((s) => {
+          const stepId = s.stepId;
+          const configFocusPathWithinStage = stepFocus[stepId] ?? [];
           const stepLabel = STEP_LABEL_OVERRIDES[stepId] ?? formatKebabIdLabel(stepId);
-          return [{
+          return {
             stepId,
             stepLabel,
             fullStepId: `${namespace}.${recipeId}.${stageId}.${stepId}`,
             configFocusPathWithinStage,
-          }];
+          };
         }),
       };
     }),

--- a/mods/mod-swooper-maps/src/domain/morphology/config.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/config.ts
@@ -1,3 +1,13 @@
 export * from "./shared/knobs.js";
 export * from "./shared/knob-multipliers.js";
+export { ReliefConfigSchema } from "./ops/compute-base-topography/config.js";
+export { CoastConfigSchema } from "./ops/compute-coastline-metrics/config.js";
+export { GeomorphicCycleConfigSchema } from "./ops/compute-geomorphic-cycle/config.js";
+export { HypsometryConfigSchema } from "./ops/compute-sea-level/config.js";
+export { IslandChainsConfigSchema, IslandsConfigSchema } from "./ops/plan-island-chains/config.js";
+export { MountainsConfigSchema } from "./ops/mountains-shared/config.js";
+export { SubstrateConfigSchema } from "./ops/compute-substrate/contract.js";
+export { LandmaskConfigSchema } from "./ops/compute-landmask/contract.js";
+export { ShelfMaskConfigSchema } from "./ops/compute-shelf-mask/contract.js";
+export { VolcanoesConfigSchema } from "./ops/plan-volcanoes/config.js";
 export { assertSameMountainFamilySelection } from "./ops/mountains-shared/config.js";

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-landmask/contract.ts
@@ -1,6 +1,6 @@
 import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
 
-const LandmaskConfigSchema = Type.Object(
+export const LandmaskConfigSchema = Type.Object(
   {
     continentPotentialGrain: Type.Integer({
       default: 4,

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-shelf-mask/contract.ts
@@ -1,6 +1,6 @@
 import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
 
-const ShelfMaskConfigSchema = Type.Object(
+export const ShelfMaskConfigSchema = Type.Object(
   {
     nearshoreDistance: Type.Integer({
       default: 3,

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/compute-substrate/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/compute-substrate/contract.ts
@@ -1,6 +1,6 @@
 import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
 
-const SubstrateConfigSchema = Type.Object(
+export const SubstrateConfigSchema = Type.Object(
   {
     continentalBaseErodibility: Type.Number({
       description: "Baseline erodibility for continental crust tiles.",

--- a/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.json
@@ -171,297 +171,181 @@
       "plate-topology": {}
     },
     "morphology-coasts": {
-      "landmass-plates": {
-        "substrate": {
-          "strategy": "default",
-          "config": {
-            "continentalBaseErodibility": 0.65,
-            "oceanicBaseErodibility": 0.55,
-            "continentalBaseSediment": 0.15,
-            "oceanicBaseSediment": 0.25,
-            "upliftErodibilityBoost": 0.3,
-            "riftSedimentBoost": 0.2,
-            "ageErodibilityReduction": 0.25,
-            "ageSedimentBoost": 0.15,
-            "convergentBoundaryErodibilityBoost": 0.12,
-            "divergentBoundaryErodibilityBoost": 0.18,
-            "transformBoundaryErodibilityBoost": 0.08,
-            "convergentBoundarySedimentBoost": 0.05,
-            "divergentBoundarySedimentBoost": 0.1,
-            "transformBoundarySedimentBoost": 0.03
-          }
-        },
-        "baseTopography": {
-          "strategy": "default",
-          "config": {
-            "clusteringBias": 0.15,
-            "crustEdgeBlend": 0.18,
-            "crustNoiseAmplitude": 0.18,
-            "continentalHeight": 0.5,
-            "oceanicHeight": -0.85,
-            "boundaryBias": 0.6,
-            "tectonics": {
-              "boundaryArcWeight": 0.7,
-              "boundaryArcNoiseWeight": 0.55,
-              "interiorNoiseWeight": 0.4,
-              "fractalGrain": 5
-            }
-          }
-        },
-        "seaLevel": {
-          "strategy": "default",
-          "config": {
-            "targetWaterPercent": 60,
-            "targetScalar": 1,
-            "variance": 0,
-            "boundaryShareTarget": 0.45,
-            "continentalFraction": 0.3
-          }
-        },
-        "landmask": {
-          "strategy": "default",
-          "config": {
-            "continentPotentialGrain": 8,
-            "continentPotentialBlurSteps": 3,
-            "keepLandComponentFraction": 0.985,
-            "cratonStepsPerEra": 2,
-            "cratonNucleationScale": 0.9,
-            "cratonDiffusion": 0.25,
-            "cratonAdvection": 0.15,
-            "cratonHalfSaturation": 0.35,
-            "cratonPotentialWeight": 0.12
-          }
-        },
-        "beltDrivers": {
-          "strategy": "default",
-          "config": {}
+      "substrate": {
+        "continentalBaseErodibility": 0.65,
+        "oceanicBaseErodibility": 0.55,
+        "continentalBaseSediment": 0.15,
+        "oceanicBaseSediment": 0.25,
+        "upliftErodibilityBoost": 0.3,
+        "riftSedimentBoost": 0.2,
+        "ageErodibilityReduction": 0.25,
+        "ageSedimentBoost": 0.15,
+        "convergentBoundaryErodibilityBoost": 0.12,
+        "divergentBoundaryErodibilityBoost": 0.18,
+        "transformBoundaryErodibilityBoost": 0.08,
+        "convergentBoundarySedimentBoost": 0.05,
+        "divergentBoundarySedimentBoost": 0.1,
+        "transformBoundarySedimentBoost": 0.03
+      },
+      "relief": {
+        "clusteringBias": 0.15,
+        "crustEdgeBlend": 0.18,
+        "crustNoiseAmplitude": 0.18,
+        "continentalHeight": 0.5,
+        "oceanicHeight": -0.85,
+        "boundaryBias": 0.6,
+        "tectonics": {
+          "boundaryArcWeight": 0.7,
+          "boundaryArcNoiseWeight": 0.55,
+          "interiorNoiseWeight": 0.4,
+          "fractalGrain": 5
         }
       },
-      "rugged-coasts": {
-        "coastlines": {
-          "strategy": "default",
-          "config": {
-            "coast": {
-              "plateBias": {
-                "threshold": 0.4,
-                "power": 1.4,
-                "convergent": 2.2,
-                "transform": 0.3,
-                "divergent": -0.3,
-                "interior": 0.5,
-                "bayWeight": 0.9,
-                "bayNoiseBonus": 0.6,
-                "fjordWeight": 0.7
-              },
-              "bay": {
-                "noiseGateAdd": 0,
-                "rollDenActive": 4,
-                "rollDenDefault": 5
-              },
-              "fjord": {
-                "baseDenom": 12,
-                "activeBonus": 1,
-                "passiveBonus": 2
-              }
-            }
-          }
+      "waterCoverage": {
+        "targetWaterPercent": 60,
+        "targetScalar": 1,
+        "variance": 0,
+        "boundaryShareTarget": 0.45,
+        "continentalFraction": 0.3
+      },
+      "continents": {
+        "continentPotentialGrain": 8,
+        "continentPotentialBlurSteps": 3,
+        "keepLandComponentFraction": 0.985,
+        "cratonStepsPerEra": 2,
+        "cratonNucleationScale": 0.9,
+        "cratonDiffusion": 0.25,
+        "cratonAdvection": 0.15,
+        "cratonHalfSaturation": 0.35,
+        "cratonPotentialWeight": 0.12
+      },
+      "coastlineShape": {
+        "plateBias": {
+          "threshold": 0.4,
+          "power": 1.4,
+          "convergent": 2.2,
+          "transform": 0.3,
+          "divergent": -0.3,
+          "interior": 0.5,
+          "bayWeight": 0.9,
+          "bayNoiseBonus": 0.6,
+          "fjordWeight": 0.7
         },
-        "shelfMask": {
-          "strategy": "default",
-          "config": {
-            "nearshoreDistance": 3,
-            "shallowQuantile": 0.7,
-            "activeClosenessThreshold": 0.45,
-            "capTilesActive": 2,
-            "capTilesPassive": 4,
-            "capTilesMax": 8
-          }
+        "bay": {
+          "noiseGateAdd": 0,
+          "rollDenActive": 4,
+          "rollDenDefault": 5
+        },
+        "fjord": {
+          "baseDenom": 12,
+          "activeBonus": 1,
+          "passiveBonus": 2
         }
+      },
+      "shelf": {
+        "nearshoreDistance": 3,
+        "shallowQuantile": 0.7,
+        "activeClosenessThreshold": 0.45,
+        "capTilesActive": 2,
+        "capTilesPassive": 4,
+        "capTilesMax": 8
       }
     },
-    "morphology-routing": {
-      "routing": {
-        "routing": {
-          "strategy": "default",
-          "config": {}
-        }
-      }
-    },
+    "morphology-routing": {},
     "morphology-erosion": {
-      "geomorphology": {
+      "geomorphicCycle": {
         "geomorphology": {
-          "strategy": "default",
-          "config": {
-            "geomorphology": {
-              "fluvial": {
-                "rate": 0.15,
-                "m": 0.5,
-                "n": 1
-              },
-              "diffusion": {
-                "rate": 0.2,
-                "talus": 0.5
-              },
-              "deposition": {
-                "rate": 0.1
-              },
-              "eras": 2
-            },
-            "worldAge": "mature"
-          }
-        }
+          "fluvial": {
+            "rate": 0.15,
+            "m": 0.5,
+            "n": 1
+          },
+          "diffusion": {
+            "rate": 0.2,
+            "talus": 0.5
+          },
+          "deposition": {
+            "rate": 0.1
+          },
+          "eras": 2
+        },
+        "worldAge": "mature"
       }
     },
     "morphology-features": {
-      "islands": {
-        "islands": {
-          "strategy": "default",
-          "config": {
-            "islands": {
-              "fractalThresholdPercent": 92,
-              "minDistFromLandRadius": 2,
-              "baseIslandDenNearActive": 4,
-              "baseIslandDenElse": 5,
-              "hotspotSeedDenom": 2,
-              "clusterMax": 3,
-              "microcontinentChance": 0.1
-            }
-          }
-        }
+      "islandChains": {
+        "fractalThresholdPercent": 92,
+        "minDistFromLandRadius": 2,
+        "baseIslandDenNearActive": 4,
+        "baseIslandDenElse": 5,
+        "hotspotSeedDenom": 2,
+        "clusterMax": 3,
+        "microcontinentChance": 0.1
       },
-      "mountains": {
-        "ridges": {
-          "strategy": "default",
-          "config": {
-            "tectonicIntensity": 0.85,
-            "mountainThreshold": 0.5,
-            "hillThreshold": 0.3,
-            "upliftWeight": 0.45,
-            "fractalWeight": 0.3,
-            "riftDepth": 0.3,
-            "boundaryWeight": 1.35,
-            "boundaryGate": 0.1,
-            "boundaryExponent": 2,
-            "interiorPenaltyWeight": 0.1,
-            "convergenceBonus": 0.95,
-            "transformPenalty": 0.5,
-            "riftPenalty": 0.7,
-            "hillBoundaryWeight": 0.45,
-            "hillRiftBonus": 0.35,
-            "hillConvergentFoothill": 0.5,
-            "hillInteriorFalloff": 0.2,
-            "hillUpliftWeight": 0.3,
-            "driverSignalByteMin": 30,
-            "driverExponent": 1,
-            "mountainMaxFraction": 0.07,
-            "hillMaxFraction": 0.18,
-            "mountainSpineFraction": 0.015,
-            "mountainSpineDilationSteps": 1,
-            "oldBeltMountainScale": 0.4,
-            "oldBeltHillScale": 1.1,
-            "foothillMaxDistance": 2,
-            "orogenyCollisionStressWeight": 0.6,
-            "orogenyCollisionUpliftWeight": 0.4,
-            "orogenyTransformStressWeight": 0.4,
-            "orogenyDivergentRiftWeight": 0.55,
-            "orogenyDivergentStressWeight": 0.15,
-            "fractureBoundaryWeight": 0.7,
-            "fractureStressWeight": 0.2,
-            "fractureRiftWeight": 0.1,
-            "mountainCollisionStressWeight": 0.5,
-            "mountainCollisionUpliftWeight": 0.5,
-            "mountainSubductionUpliftWeight": 0.25,
-            "mountainInteriorUpliftScale": 0.25,
-            "mountainFractalScale": 0.3,
-            "mountainConvergenceFractalBase": 0.6,
-            "mountainConvergenceFractalSpan": 0.4,
-            "hillFoothillBase": 0.5,
-            "hillFoothillFractalGain": 0.5,
-            "hillFractalScale": 0.8,
-            "hillUpliftScale": 0.3,
-            "hillRiftBonusScale": 0.5,
-            "hillRiftDepthScale": 0.5
-          }
-        },
-        "foothills": {
-          "strategy": "default",
-          "config": {
-            "tectonicIntensity": 0.85,
-            "mountainThreshold": 0.5,
-            "hillThreshold": 0.3,
-            "upliftWeight": 0.45,
-            "fractalWeight": 0.3,
-            "riftDepth": 0.3,
-            "boundaryWeight": 1.35,
-            "boundaryGate": 0.1,
-            "boundaryExponent": 2,
-            "interiorPenaltyWeight": 0.1,
-            "convergenceBonus": 0.95,
-            "transformPenalty": 0.5,
-            "riftPenalty": 0.7,
-            "hillBoundaryWeight": 0.45,
-            "hillRiftBonus": 0.35,
-            "hillConvergentFoothill": 0.5,
-            "hillInteriorFalloff": 0.2,
-            "hillUpliftWeight": 0.3,
-            "driverSignalByteMin": 30,
-            "driverExponent": 1,
-            "mountainMaxFraction": 0.07,
-            "hillMaxFraction": 0.18,
-            "mountainSpineFraction": 0.015,
-            "mountainSpineDilationSteps": 1,
-            "oldBeltMountainScale": 0.4,
-            "oldBeltHillScale": 1.1,
-            "foothillMaxDistance": 2,
-            "orogenyCollisionStressWeight": 0.6,
-            "orogenyCollisionUpliftWeight": 0.4,
-            "orogenyTransformStressWeight": 0.4,
-            "orogenyDivergentRiftWeight": 0.55,
-            "orogenyDivergentStressWeight": 0.15,
-            "fractureBoundaryWeight": 0.7,
-            "fractureStressWeight": 0.2,
-            "fractureRiftWeight": 0.1,
-            "mountainCollisionStressWeight": 0.5,
-            "mountainCollisionUpliftWeight": 0.5,
-            "mountainSubductionUpliftWeight": 0.25,
-            "mountainInteriorUpliftScale": 0.25,
-            "mountainFractalScale": 0.3,
-            "mountainConvergenceFractalBase": 0.6,
-            "mountainConvergenceFractalSpan": 0.4,
-            "hillFoothillBase": 0.5,
-            "hillFoothillFractalGain": 0.5,
-            "hillFractalScale": 0.8,
-            "hillUpliftScale": 0.3,
-            "hillRiftBonusScale": 0.5,
-            "hillRiftDepthScale": 0.5
-          }
-        }
+      "mountainRanges": {
+        "tectonicIntensity": 0.85,
+        "mountainThreshold": 0.5,
+        "hillThreshold": 0.3,
+        "upliftWeight": 0.45,
+        "fractalWeight": 0.3,
+        "riftDepth": 0.3,
+        "boundaryWeight": 1.35,
+        "boundaryGate": 0.1,
+        "boundaryExponent": 2,
+        "interiorPenaltyWeight": 0.1,
+        "convergenceBonus": 0.95,
+        "transformPenalty": 0.5,
+        "riftPenalty": 0.7,
+        "hillBoundaryWeight": 0.45,
+        "hillRiftBonus": 0.35,
+        "hillConvergentFoothill": 0.5,
+        "hillInteriorFalloff": 0.2,
+        "hillUpliftWeight": 0.3,
+        "driverSignalByteMin": 30,
+        "driverExponent": 1,
+        "mountainMaxFraction": 0.07,
+        "hillMaxFraction": 0.18,
+        "mountainSpineFraction": 0.015,
+        "mountainSpineDilationSteps": 1,
+        "oldBeltMountainScale": 0.4,
+        "oldBeltHillScale": 1.1,
+        "foothillMaxDistance": 2,
+        "orogenyCollisionStressWeight": 0.6,
+        "orogenyCollisionUpliftWeight": 0.4,
+        "orogenyTransformStressWeight": 0.4,
+        "orogenyDivergentRiftWeight": 0.55,
+        "orogenyDivergentStressWeight": 0.15,
+        "fractureBoundaryWeight": 0.7,
+        "fractureStressWeight": 0.2,
+        "fractureRiftWeight": 0.1,
+        "mountainCollisionStressWeight": 0.5,
+        "mountainCollisionUpliftWeight": 0.5,
+        "mountainSubductionUpliftWeight": 0.25,
+        "mountainInteriorUpliftScale": 0.25,
+        "mountainFractalScale": 0.3,
+        "mountainConvergenceFractalBase": 0.6,
+        "mountainConvergenceFractalSpan": 0.4,
+        "hillFoothillBase": 0.5,
+        "hillFoothillFractalGain": 0.5,
+        "hillFractalScale": 0.8,
+        "hillUpliftScale": 0.3,
+        "hillRiftBonusScale": 0.5,
+        "hillRiftDepthScale": 0.5
       },
       "volcanoes": {
-        "volcanoes": {
-          "strategy": "default",
-          "config": {
-            "enabled": true,
-            "baseDensity": 0.008333333333333333,
-            "minSpacing": 3,
-            "boundaryThreshold": 0.22,
-            "boundaryWeight": 1.5,
-            "convergentMultiplier": 3,
-            "transformMultiplier": 1.1,
-            "divergentMultiplier": 0.45,
-            "hotspotWeight": 0.55,
-            "shieldPenalty": 0.35,
-            "randomJitter": 0.14,
-            "minVolcanoes": 10,
-            "maxVolcanoes": 45
-          }
-        }
-      },
-      "landmasses": {
-        "landmasses": {
-          "strategy": "default",
-          "config": {}
-        }
+        "enabled": true,
+        "baseDensity": 0.008333333333333333,
+        "minSpacing": 3,
+        "boundaryThreshold": 0.22,
+        "boundaryWeight": 1.5,
+        "convergentMultiplier": 3,
+        "transformMultiplier": 1.1,
+        "divergentMultiplier": 0.45,
+        "hotspotWeight": 0.55,
+        "shieldPenalty": 0.35,
+        "randomJitter": 0.14,
+        "minVolcanoes": 10,
+        "maxVolcanoes": 45
       }
     },
     "hydrology-climate-baseline": {

--- a/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.json
@@ -171,297 +171,181 @@
       "plate-topology": {}
     },
     "morphology-coasts": {
-      "landmass-plates": {
-        "substrate": {
-          "strategy": "default",
-          "config": {
-            "continentalBaseErodibility": 0.65,
-            "oceanicBaseErodibility": 0.55,
-            "continentalBaseSediment": 0.15,
-            "oceanicBaseSediment": 0.25,
-            "upliftErodibilityBoost": 0.3,
-            "riftSedimentBoost": 0.2,
-            "ageErodibilityReduction": 0.25,
-            "ageSedimentBoost": 0.15,
-            "convergentBoundaryErodibilityBoost": 0.12,
-            "divergentBoundaryErodibilityBoost": 0.18,
-            "transformBoundaryErodibilityBoost": 0.08,
-            "convergentBoundarySedimentBoost": 0.05,
-            "divergentBoundarySedimentBoost": 0.1,
-            "transformBoundarySedimentBoost": 0.03
-          }
-        },
-        "baseTopography": {
-          "strategy": "default",
-          "config": {
-            "clusteringBias": 0.05,
-            "crustEdgeBlend": 0.12,
-            "crustNoiseAmplitude": 0.3,
-            "continentalHeight": 0.38,
-            "oceanicHeight": -0.62,
-            "boundaryBias": 0.8,
-            "tectonics": {
-              "boundaryArcWeight": 0.9,
-              "boundaryArcNoiseWeight": 0.8,
-              "interiorNoiseWeight": 0.1,
-              "fractalGrain": 9
-            }
-          }
-        },
-        "seaLevel": {
-          "strategy": "default",
-          "config": {
-            "targetWaterPercent": 80,
-            "targetScalar": 1,
-            "variance": 0,
-            "boundaryShareTarget": 0.75,
-            "continentalFraction": 0.28
-          }
-        },
-        "landmask": {
-          "strategy": "default",
-          "config": {
-            "continentPotentialGrain": 8,
-            "continentPotentialBlurSteps": 3,
-            "keepLandComponentFraction": 0.985,
-            "cratonStepsPerEra": 2,
-            "cratonNucleationScale": 0.9,
-            "cratonDiffusion": 0.25,
-            "cratonAdvection": 0.15,
-            "cratonHalfSaturation": 0.35,
-            "cratonPotentialWeight": 0.12
-          }
-        },
-        "beltDrivers": {
-          "strategy": "default",
-          "config": {}
+      "substrate": {
+        "continentalBaseErodibility": 0.65,
+        "oceanicBaseErodibility": 0.55,
+        "continentalBaseSediment": 0.15,
+        "oceanicBaseSediment": 0.25,
+        "upliftErodibilityBoost": 0.3,
+        "riftSedimentBoost": 0.2,
+        "ageErodibilityReduction": 0.25,
+        "ageSedimentBoost": 0.15,
+        "convergentBoundaryErodibilityBoost": 0.12,
+        "divergentBoundaryErodibilityBoost": 0.18,
+        "transformBoundaryErodibilityBoost": 0.08,
+        "convergentBoundarySedimentBoost": 0.05,
+        "divergentBoundarySedimentBoost": 0.1,
+        "transformBoundarySedimentBoost": 0.03
+      },
+      "relief": {
+        "clusteringBias": 0.05,
+        "crustEdgeBlend": 0.12,
+        "crustNoiseAmplitude": 0.3,
+        "continentalHeight": 0.38,
+        "oceanicHeight": -0.62,
+        "boundaryBias": 0.8,
+        "tectonics": {
+          "boundaryArcWeight": 0.9,
+          "boundaryArcNoiseWeight": 0.8,
+          "interiorNoiseWeight": 0.1,
+          "fractalGrain": 9
         }
       },
-      "rugged-coasts": {
-        "coastlines": {
-          "strategy": "default",
-          "config": {
-            "coast": {
-              "plateBias": {
-                "threshold": 0.35,
-                "power": 1.5,
-                "convergent": 2,
-                "transform": 0.5,
-                "divergent": -0.2,
-                "interior": 0.3,
-                "bayWeight": 1.2,
-                "bayNoiseBonus": 0.8,
-                "fjordWeight": 0.9
-              },
-              "bay": {
-                "noiseGateAdd": 0,
-                "rollDenActive": 4,
-                "rollDenDefault": 5
-              },
-              "fjord": {
-                "baseDenom": 12,
-                "activeBonus": 1,
-                "passiveBonus": 2
-              }
-            }
-          }
+      "waterCoverage": {
+        "targetWaterPercent": 80,
+        "targetScalar": 1,
+        "variance": 0,
+        "boundaryShareTarget": 0.75,
+        "continentalFraction": 0.28
+      },
+      "continents": {
+        "continentPotentialGrain": 8,
+        "continentPotentialBlurSteps": 3,
+        "keepLandComponentFraction": 0.985,
+        "cratonStepsPerEra": 2,
+        "cratonNucleationScale": 0.9,
+        "cratonDiffusion": 0.25,
+        "cratonAdvection": 0.15,
+        "cratonHalfSaturation": 0.35,
+        "cratonPotentialWeight": 0.12
+      },
+      "coastlineShape": {
+        "plateBias": {
+          "threshold": 0.35,
+          "power": 1.5,
+          "convergent": 2,
+          "transform": 0.5,
+          "divergent": -0.2,
+          "interior": 0.3,
+          "bayWeight": 1.2,
+          "bayNoiseBonus": 0.8,
+          "fjordWeight": 0.9
         },
-        "shelfMask": {
-          "strategy": "default",
-          "config": {
-            "nearshoreDistance": 3,
-            "shallowQuantile": 0.7,
-            "activeClosenessThreshold": 0.45,
-            "capTilesActive": 2,
-            "capTilesPassive": 4,
-            "capTilesMax": 8
-          }
+        "bay": {
+          "noiseGateAdd": 0,
+          "rollDenActive": 4,
+          "rollDenDefault": 5
+        },
+        "fjord": {
+          "baseDenom": 12,
+          "activeBonus": 1,
+          "passiveBonus": 2
         }
+      },
+      "shelf": {
+        "nearshoreDistance": 3,
+        "shallowQuantile": 0.7,
+        "activeClosenessThreshold": 0.45,
+        "capTilesActive": 2,
+        "capTilesPassive": 4,
+        "capTilesMax": 8
       }
     },
-    "morphology-routing": {
-      "routing": {
-        "routing": {
-          "strategy": "default",
-          "config": {}
-        }
-      }
-    },
+    "morphology-routing": {},
     "morphology-erosion": {
-      "geomorphology": {
+      "geomorphicCycle": {
         "geomorphology": {
-          "strategy": "default",
-          "config": {
-            "geomorphology": {
-              "fluvial": {
-                "rate": 0.15,
-                "m": 0.5,
-                "n": 1
-              },
-              "diffusion": {
-                "rate": 0.2,
-                "talus": 0.5
-              },
-              "deposition": {
-                "rate": 0.1
-              },
-              "eras": 2
-            },
-            "worldAge": "mature"
-          }
-        }
+          "fluvial": {
+            "rate": 0.15,
+            "m": 0.5,
+            "n": 1
+          },
+          "diffusion": {
+            "rate": 0.2,
+            "talus": 0.5
+          },
+          "deposition": {
+            "rate": 0.1
+          },
+          "eras": 2
+        },
+        "worldAge": "mature"
       }
     },
     "morphology-features": {
-      "islands": {
-        "islands": {
-          "strategy": "default",
-          "config": {
-            "islands": {
-              "fractalThresholdPercent": 82,
-              "minDistFromLandRadius": 1,
-              "baseIslandDenNearActive": 7,
-              "baseIslandDenElse": 12,
-              "hotspotSeedDenom": 1,
-              "clusterMax": 6,
-              "microcontinentChance": 0.2
-            }
-          }
-        }
+      "islandChains": {
+        "fractalThresholdPercent": 82,
+        "minDistFromLandRadius": 1,
+        "baseIslandDenNearActive": 7,
+        "baseIslandDenElse": 12,
+        "hotspotSeedDenom": 1,
+        "clusterMax": 6,
+        "microcontinentChance": 0.2
       },
-      "mountains": {
-        "ridges": {
-          "strategy": "default",
-          "config": {
-            "tectonicIntensity": 0.65,
-            "mountainThreshold": 0.6,
-            "hillThreshold": 0.32,
-            "upliftWeight": 0.25,
-            "fractalWeight": 0.3,
-            "riftDepth": 0.35,
-            "boundaryWeight": 1.1,
-            "boundaryGate": 0.1,
-            "boundaryExponent": 1.6,
-            "interiorPenaltyWeight": 0.2,
-            "convergenceBonus": 1,
-            "transformPenalty": 0.5,
-            "riftPenalty": 0.7,
-            "hillBoundaryWeight": 0.55,
-            "hillRiftBonus": 0.4,
-            "hillConvergentFoothill": 0.45,
-            "hillInteriorFalloff": 0.25,
-            "hillUpliftWeight": 0.28,
-            "driverSignalByteMin": 30,
-            "driverExponent": 1,
-            "mountainMaxFraction": 0.07,
-            "hillMaxFraction": 0.18,
-            "mountainSpineFraction": 0.015,
-            "mountainSpineDilationSteps": 1,
-            "oldBeltMountainScale": 0.4,
-            "oldBeltHillScale": 1.1,
-            "foothillMaxDistance": 2,
-            "orogenyCollisionStressWeight": 0.6,
-            "orogenyCollisionUpliftWeight": 0.4,
-            "orogenyTransformStressWeight": 0.4,
-            "orogenyDivergentRiftWeight": 0.55,
-            "orogenyDivergentStressWeight": 0.15,
-            "fractureBoundaryWeight": 0.7,
-            "fractureStressWeight": 0.2,
-            "fractureRiftWeight": 0.1,
-            "mountainCollisionStressWeight": 0.5,
-            "mountainCollisionUpliftWeight": 0.5,
-            "mountainSubductionUpliftWeight": 0.25,
-            "mountainInteriorUpliftScale": 0.25,
-            "mountainFractalScale": 0.3,
-            "mountainConvergenceFractalBase": 0.6,
-            "mountainConvergenceFractalSpan": 0.4,
-            "hillFoothillBase": 0.5,
-            "hillFoothillFractalGain": 0.5,
-            "hillFractalScale": 0.8,
-            "hillUpliftScale": 0.3,
-            "hillRiftBonusScale": 0.5,
-            "hillRiftDepthScale": 0.5
-          }
-        },
-        "foothills": {
-          "strategy": "default",
-          "config": {
-            "tectonicIntensity": 0.65,
-            "mountainThreshold": 0.6,
-            "hillThreshold": 0.32,
-            "upliftWeight": 0.25,
-            "fractalWeight": 0.3,
-            "riftDepth": 0.35,
-            "boundaryWeight": 1.1,
-            "boundaryGate": 0.1,
-            "boundaryExponent": 1.6,
-            "interiorPenaltyWeight": 0.2,
-            "convergenceBonus": 1,
-            "transformPenalty": 0.5,
-            "riftPenalty": 0.7,
-            "hillBoundaryWeight": 0.55,
-            "hillRiftBonus": 0.4,
-            "hillConvergentFoothill": 0.45,
-            "hillInteriorFalloff": 0.25,
-            "hillUpliftWeight": 0.28,
-            "driverSignalByteMin": 30,
-            "driverExponent": 1,
-            "mountainMaxFraction": 0.07,
-            "hillMaxFraction": 0.18,
-            "mountainSpineFraction": 0.015,
-            "mountainSpineDilationSteps": 1,
-            "oldBeltMountainScale": 0.4,
-            "oldBeltHillScale": 1.1,
-            "foothillMaxDistance": 2,
-            "orogenyCollisionStressWeight": 0.6,
-            "orogenyCollisionUpliftWeight": 0.4,
-            "orogenyTransformStressWeight": 0.4,
-            "orogenyDivergentRiftWeight": 0.55,
-            "orogenyDivergentStressWeight": 0.15,
-            "fractureBoundaryWeight": 0.7,
-            "fractureStressWeight": 0.2,
-            "fractureRiftWeight": 0.1,
-            "mountainCollisionStressWeight": 0.5,
-            "mountainCollisionUpliftWeight": 0.5,
-            "mountainSubductionUpliftWeight": 0.25,
-            "mountainInteriorUpliftScale": 0.25,
-            "mountainFractalScale": 0.3,
-            "mountainConvergenceFractalBase": 0.6,
-            "mountainConvergenceFractalSpan": 0.4,
-            "hillFoothillBase": 0.5,
-            "hillFoothillFractalGain": 0.5,
-            "hillFractalScale": 0.8,
-            "hillUpliftScale": 0.3,
-            "hillRiftBonusScale": 0.5,
-            "hillRiftDepthScale": 0.5
-          }
-        }
+      "mountainRanges": {
+        "tectonicIntensity": 0.65,
+        "mountainThreshold": 0.6,
+        "hillThreshold": 0.32,
+        "upliftWeight": 0.25,
+        "fractalWeight": 0.3,
+        "riftDepth": 0.35,
+        "boundaryWeight": 1.1,
+        "boundaryGate": 0.1,
+        "boundaryExponent": 1.6,
+        "interiorPenaltyWeight": 0.2,
+        "convergenceBonus": 1,
+        "transformPenalty": 0.5,
+        "riftPenalty": 0.7,
+        "hillBoundaryWeight": 0.55,
+        "hillRiftBonus": 0.4,
+        "hillConvergentFoothill": 0.45,
+        "hillInteriorFalloff": 0.25,
+        "hillUpliftWeight": 0.28,
+        "driverSignalByteMin": 30,
+        "driverExponent": 1,
+        "mountainMaxFraction": 0.07,
+        "hillMaxFraction": 0.18,
+        "mountainSpineFraction": 0.015,
+        "mountainSpineDilationSteps": 1,
+        "oldBeltMountainScale": 0.4,
+        "oldBeltHillScale": 1.1,
+        "foothillMaxDistance": 2,
+        "orogenyCollisionStressWeight": 0.6,
+        "orogenyCollisionUpliftWeight": 0.4,
+        "orogenyTransformStressWeight": 0.4,
+        "orogenyDivergentRiftWeight": 0.55,
+        "orogenyDivergentStressWeight": 0.15,
+        "fractureBoundaryWeight": 0.7,
+        "fractureStressWeight": 0.2,
+        "fractureRiftWeight": 0.1,
+        "mountainCollisionStressWeight": 0.5,
+        "mountainCollisionUpliftWeight": 0.5,
+        "mountainSubductionUpliftWeight": 0.25,
+        "mountainInteriorUpliftScale": 0.25,
+        "mountainFractalScale": 0.3,
+        "mountainConvergenceFractalBase": 0.6,
+        "mountainConvergenceFractalSpan": 0.4,
+        "hillFoothillBase": 0.5,
+        "hillFoothillFractalGain": 0.5,
+        "hillFractalScale": 0.8,
+        "hillUpliftScale": 0.3,
+        "hillRiftBonusScale": 0.5,
+        "hillRiftDepthScale": 0.5
       },
       "volcanoes": {
-        "volcanoes": {
-          "strategy": "default",
-          "config": {
-            "enabled": true,
-            "baseDensity": 0.0125,
-            "minSpacing": 2,
-            "boundaryThreshold": 0.18,
-            "boundaryWeight": 1.7,
-            "convergentMultiplier": 3.4,
-            "transformMultiplier": 1.4,
-            "divergentMultiplier": 0.7,
-            "hotspotWeight": 0.7,
-            "shieldPenalty": 0.2,
-            "randomJitter": 0.18,
-            "minVolcanoes": 16,
-            "maxVolcanoes": 70
-          }
-        }
-      },
-      "landmasses": {
-        "landmasses": {
-          "strategy": "default",
-          "config": {}
-        }
+        "enabled": true,
+        "baseDensity": 0.0125,
+        "minSpacing": 2,
+        "boundaryThreshold": 0.18,
+        "boundaryWeight": 1.7,
+        "convergentMultiplier": 3.4,
+        "transformMultiplier": 1.4,
+        "divergentMultiplier": 0.7,
+        "hotspotWeight": 0.7,
+        "shieldPenalty": 0.2,
+        "randomJitter": 0.18,
+        "minVolcanoes": 16,
+        "maxVolcanoes": 70
       }
     },
     "hydrology-climate-baseline": {

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.json
@@ -175,297 +175,181 @@
       "plate-topology": {}
     },
     "morphology-coasts": {
-      "landmass-plates": {
-        "substrate": {
-          "strategy": "default",
-          "config": {
-            "continentalBaseErodibility": 0.65,
-            "oceanicBaseErodibility": 0.55,
-            "continentalBaseSediment": 0.15,
-            "oceanicBaseSediment": 0.25,
-            "upliftErodibilityBoost": 0.3,
-            "riftSedimentBoost": 0.2,
-            "ageErodibilityReduction": 0.25,
-            "ageSedimentBoost": 0.15,
-            "convergentBoundaryErodibilityBoost": 0.12,
-            "divergentBoundaryErodibilityBoost": 0.18,
-            "transformBoundaryErodibilityBoost": 0.08,
-            "convergentBoundarySedimentBoost": 0.05,
-            "divergentBoundarySedimentBoost": 0.1,
-            "transformBoundarySedimentBoost": 0.03
-          }
-        },
-        "baseTopography": {
-          "strategy": "default",
-          "config": {
-            "boundaryBias": 0.18,
-            "clusteringBias": 0.35,
-            "crustEdgeBlend": 0.35,
-            "crustNoiseAmplitude": 0.14,
-            "continentalHeight": 0.52,
-            "oceanicHeight": -0.6,
-            "tectonics": {
-              "interiorNoiseWeight": 0.45,
-              "boundaryArcWeight": 0.5,
-              "boundaryArcNoiseWeight": 0.35,
-              "fractalGrain": 5
-            }
-          }
-        },
-        "seaLevel": {
-          "strategy": "default",
-          "config": {
-            "targetWaterPercent": 48,
-            "targetScalar": 1,
-            "variance": 0,
-            "boundaryShareTarget": 0.22,
-            "continentalFraction": 0.3
-          }
-        },
-        "landmask": {
-          "strategy": "default",
-          "config": {
-            "continentPotentialGrain": 8,
-            "continentPotentialBlurSteps": 3,
-            "keepLandComponentFraction": 0.985,
-            "cratonStepsPerEra": 2,
-            "cratonNucleationScale": 0.9,
-            "cratonDiffusion": 0.25,
-            "cratonAdvection": 0.15,
-            "cratonHalfSaturation": 0.35,
-            "cratonPotentialWeight": 0.12
-          }
-        },
-        "beltDrivers": {
-          "strategy": "default",
-          "config": {}
+      "substrate": {
+        "continentalBaseErodibility": 0.65,
+        "oceanicBaseErodibility": 0.55,
+        "continentalBaseSediment": 0.15,
+        "oceanicBaseSediment": 0.25,
+        "upliftErodibilityBoost": 0.3,
+        "riftSedimentBoost": 0.2,
+        "ageErodibilityReduction": 0.25,
+        "ageSedimentBoost": 0.15,
+        "convergentBoundaryErodibilityBoost": 0.12,
+        "divergentBoundaryErodibilityBoost": 0.18,
+        "transformBoundaryErodibilityBoost": 0.08,
+        "convergentBoundarySedimentBoost": 0.05,
+        "divergentBoundarySedimentBoost": 0.1,
+        "transformBoundarySedimentBoost": 0.03
+      },
+      "relief": {
+        "boundaryBias": 0.18,
+        "clusteringBias": 0.35,
+        "crustEdgeBlend": 0.35,
+        "crustNoiseAmplitude": 0.14,
+        "continentalHeight": 0.52,
+        "oceanicHeight": -0.6,
+        "tectonics": {
+          "interiorNoiseWeight": 0.45,
+          "boundaryArcWeight": 0.5,
+          "boundaryArcNoiseWeight": 0.35,
+          "fractalGrain": 5
         }
       },
-      "rugged-coasts": {
-        "coastlines": {
-          "strategy": "default",
-          "config": {
-            "coast": {
-              "plateBias": {
-                "threshold": 0.15,
-                "power": 1.3,
-                "convergent": 3,
-                "transform": 0.2,
-                "divergent": 0.5,
-                "interior": 0.35,
-                "bayWeight": 0.75,
-                "bayNoiseBonus": 0.1,
-                "fjordWeight": 0.8
-              },
-              "bay": {
-                "noiseGateAdd": 0,
-                "rollDenActive": 4,
-                "rollDenDefault": 5
-              },
-              "fjord": {
-                "baseDenom": 12,
-                "activeBonus": 1,
-                "passiveBonus": 2
-              }
-            }
-          }
+      "waterCoverage": {
+        "targetWaterPercent": 48,
+        "targetScalar": 1,
+        "variance": 0,
+        "boundaryShareTarget": 0.22,
+        "continentalFraction": 0.3
+      },
+      "continents": {
+        "continentPotentialGrain": 8,
+        "continentPotentialBlurSteps": 3,
+        "keepLandComponentFraction": 0.985,
+        "cratonStepsPerEra": 2,
+        "cratonNucleationScale": 0.9,
+        "cratonDiffusion": 0.25,
+        "cratonAdvection": 0.15,
+        "cratonHalfSaturation": 0.35,
+        "cratonPotentialWeight": 0.12
+      },
+      "coastlineShape": {
+        "plateBias": {
+          "threshold": 0.15,
+          "power": 1.3,
+          "convergent": 3,
+          "transform": 0.2,
+          "divergent": 0.5,
+          "interior": 0.35,
+          "bayWeight": 0.75,
+          "bayNoiseBonus": 0.1,
+          "fjordWeight": 0.8
         },
-        "shelfMask": {
-          "strategy": "default",
-          "config": {
-            "nearshoreDistance": 3,
-            "shallowQuantile": 0.7,
-            "activeClosenessThreshold": 0.45,
-            "capTilesActive": 2,
-            "capTilesPassive": 4,
-            "capTilesMax": 8
-          }
+        "bay": {
+          "noiseGateAdd": 0,
+          "rollDenActive": 4,
+          "rollDenDefault": 5
+        },
+        "fjord": {
+          "baseDenom": 12,
+          "activeBonus": 1,
+          "passiveBonus": 2
         }
+      },
+      "shelf": {
+        "nearshoreDistance": 3,
+        "shallowQuantile": 0.7,
+        "activeClosenessThreshold": 0.45,
+        "capTilesActive": 2,
+        "capTilesPassive": 4,
+        "capTilesMax": 8
       }
     },
-    "morphology-routing": {
-      "routing": {
-        "routing": {
-          "strategy": "default",
-          "config": {}
-        }
-      }
-    },
+    "morphology-routing": {},
     "morphology-erosion": {
-      "geomorphology": {
+      "geomorphicCycle": {
         "geomorphology": {
-          "strategy": "default",
-          "config": {
-            "geomorphology": {
-              "fluvial": {
-                "rate": 0.08,
-                "m": 0.5,
-                "n": 1
-              },
-              "diffusion": {
-                "rate": 0.12,
-                "talus": 0.45
-              },
-              "deposition": {
-                "rate": 0.07
-              },
-              "eras": 3
-            },
-            "worldAge": "old"
-          }
-        }
+          "fluvial": {
+            "rate": 0.08,
+            "m": 0.5,
+            "n": 1
+          },
+          "diffusion": {
+            "rate": 0.12,
+            "talus": 0.45
+          },
+          "deposition": {
+            "rate": 0.07
+          },
+          "eras": 3
+        },
+        "worldAge": "old"
       }
     },
     "morphology-features": {
-      "islands": {
-        "islands": {
-          "strategy": "default",
-          "config": {
-            "islands": {
-              "fractalThresholdPercent": 96,
-              "minDistFromLandRadius": 4,
-              "baseIslandDenNearActive": 2,
-              "baseIslandDenElse": 2,
-              "hotspotSeedDenom": 6,
-              "clusterMax": 1,
-              "microcontinentChance": 0
-            }
-          }
-        }
+      "islandChains": {
+        "fractalThresholdPercent": 96,
+        "minDistFromLandRadius": 4,
+        "baseIslandDenNearActive": 2,
+        "baseIslandDenElse": 2,
+        "hotspotSeedDenom": 6,
+        "clusterMax": 1,
+        "microcontinentChance": 0
       },
-      "mountains": {
-        "ridges": {
-          "strategy": "default",
-          "config": {
-            "tectonicIntensity": 0.63,
-            "mountainThreshold": 0.64,
-            "hillThreshold": 0.36,
-            "upliftWeight": 0.2,
-            "fractalWeight": 0.9,
-            "riftDepth": 0.45,
-            "boundaryWeight": 0.38,
-            "boundaryGate": 0.14,
-            "boundaryExponent": 1.1,
-            "interiorPenaltyWeight": 0.16,
-            "convergenceBonus": 0.6,
-            "transformPenalty": 0.55,
-            "riftPenalty": 0.65,
-            "hillBoundaryWeight": 0.22,
-            "hillRiftBonus": 0.5,
-            "hillConvergentFoothill": 0.36,
-            "hillInteriorFalloff": 0.2,
-            "hillUpliftWeight": 0.2,
-            "driverSignalByteMin": 30,
-            "driverExponent": 1,
-            "mountainMaxFraction": 0.07,
-            "hillMaxFraction": 0.18,
-            "mountainSpineFraction": 0.015,
-            "mountainSpineDilationSteps": 1,
-            "oldBeltMountainScale": 0.4,
-            "oldBeltHillScale": 1.1,
-            "foothillMaxDistance": 2,
-            "orogenyCollisionStressWeight": 0.6,
-            "orogenyCollisionUpliftWeight": 0.4,
-            "orogenyTransformStressWeight": 0.4,
-            "orogenyDivergentRiftWeight": 0.55,
-            "orogenyDivergentStressWeight": 0.15,
-            "fractureBoundaryWeight": 0.7,
-            "fractureStressWeight": 0.2,
-            "fractureRiftWeight": 0.1,
-            "mountainCollisionStressWeight": 0.5,
-            "mountainCollisionUpliftWeight": 0.5,
-            "mountainSubductionUpliftWeight": 0.25,
-            "mountainInteriorUpliftScale": 0.25,
-            "mountainFractalScale": 0.3,
-            "mountainConvergenceFractalBase": 0.6,
-            "mountainConvergenceFractalSpan": 0.4,
-            "hillFoothillBase": 0.5,
-            "hillFoothillFractalGain": 0.5,
-            "hillFractalScale": 0.8,
-            "hillUpliftScale": 0.3,
-            "hillRiftBonusScale": 0.5,
-            "hillRiftDepthScale": 0.5
-          }
-        },
-        "foothills": {
-          "strategy": "default",
-          "config": {
-            "tectonicIntensity": 0.63,
-            "mountainThreshold": 0.64,
-            "hillThreshold": 0.36,
-            "upliftWeight": 0.2,
-            "fractalWeight": 0.9,
-            "riftDepth": 0.45,
-            "boundaryWeight": 0.38,
-            "boundaryGate": 0.14,
-            "boundaryExponent": 1.1,
-            "interiorPenaltyWeight": 0.16,
-            "convergenceBonus": 0.6,
-            "transformPenalty": 0.55,
-            "riftPenalty": 0.65,
-            "hillBoundaryWeight": 0.22,
-            "hillRiftBonus": 0.5,
-            "hillConvergentFoothill": 0.36,
-            "hillInteriorFalloff": 0.2,
-            "hillUpliftWeight": 0.2,
-            "driverSignalByteMin": 30,
-            "driverExponent": 1,
-            "mountainMaxFraction": 0.07,
-            "hillMaxFraction": 0.18,
-            "mountainSpineFraction": 0.015,
-            "mountainSpineDilationSteps": 1,
-            "oldBeltMountainScale": 0.4,
-            "oldBeltHillScale": 1.1,
-            "foothillMaxDistance": 2,
-            "orogenyCollisionStressWeight": 0.6,
-            "orogenyCollisionUpliftWeight": 0.4,
-            "orogenyTransformStressWeight": 0.4,
-            "orogenyDivergentRiftWeight": 0.55,
-            "orogenyDivergentStressWeight": 0.15,
-            "fractureBoundaryWeight": 0.7,
-            "fractureStressWeight": 0.2,
-            "fractureRiftWeight": 0.1,
-            "mountainCollisionStressWeight": 0.5,
-            "mountainCollisionUpliftWeight": 0.5,
-            "mountainSubductionUpliftWeight": 0.25,
-            "mountainInteriorUpliftScale": 0.25,
-            "mountainFractalScale": 0.3,
-            "mountainConvergenceFractalBase": 0.6,
-            "mountainConvergenceFractalSpan": 0.4,
-            "hillFoothillBase": 0.5,
-            "hillFoothillFractalGain": 0.5,
-            "hillFractalScale": 0.8,
-            "hillUpliftScale": 0.3,
-            "hillRiftBonusScale": 0.5,
-            "hillRiftDepthScale": 0.5
-          }
-        }
+      "mountainRanges": {
+        "tectonicIntensity": 0.63,
+        "mountainThreshold": 0.64,
+        "hillThreshold": 0.36,
+        "upliftWeight": 0.2,
+        "fractalWeight": 0.9,
+        "riftDepth": 0.45,
+        "boundaryWeight": 0.38,
+        "boundaryGate": 0.14,
+        "boundaryExponent": 1.1,
+        "interiorPenaltyWeight": 0.16,
+        "convergenceBonus": 0.6,
+        "transformPenalty": 0.55,
+        "riftPenalty": 0.65,
+        "hillBoundaryWeight": 0.22,
+        "hillRiftBonus": 0.5,
+        "hillConvergentFoothill": 0.36,
+        "hillInteriorFalloff": 0.2,
+        "hillUpliftWeight": 0.2,
+        "driverSignalByteMin": 30,
+        "driverExponent": 1,
+        "mountainMaxFraction": 0.07,
+        "hillMaxFraction": 0.18,
+        "mountainSpineFraction": 0.015,
+        "mountainSpineDilationSteps": 1,
+        "oldBeltMountainScale": 0.4,
+        "oldBeltHillScale": 1.1,
+        "foothillMaxDistance": 2,
+        "orogenyCollisionStressWeight": 0.6,
+        "orogenyCollisionUpliftWeight": 0.4,
+        "orogenyTransformStressWeight": 0.4,
+        "orogenyDivergentRiftWeight": 0.55,
+        "orogenyDivergentStressWeight": 0.15,
+        "fractureBoundaryWeight": 0.7,
+        "fractureStressWeight": 0.2,
+        "fractureRiftWeight": 0.1,
+        "mountainCollisionStressWeight": 0.5,
+        "mountainCollisionUpliftWeight": 0.5,
+        "mountainSubductionUpliftWeight": 0.25,
+        "mountainInteriorUpliftScale": 0.25,
+        "mountainFractalScale": 0.3,
+        "mountainConvergenceFractalBase": 0.6,
+        "mountainConvergenceFractalSpan": 0.4,
+        "hillFoothillBase": 0.5,
+        "hillFoothillFractalGain": 0.5,
+        "hillFractalScale": 0.8,
+        "hillUpliftScale": 0.3,
+        "hillRiftBonusScale": 0.5,
+        "hillRiftDepthScale": 0.5
       },
       "volcanoes": {
-        "volcanoes": {
-          "strategy": "default",
-          "config": {
-            "enabled": true,
-            "baseDensity": 0.006,
-            "minSpacing": 5,
-            "boundaryThreshold": 0.32,
-            "boundaryWeight": 1.4,
-            "convergentMultiplier": 2.2,
-            "transformMultiplier": 0.7,
-            "divergentMultiplier": 0.2,
-            "hotspotWeight": 0.15,
-            "shieldPenalty": 0.3,
-            "randomJitter": 0.08,
-            "minVolcanoes": 6,
-            "maxVolcanoes": 18
-          }
-        }
-      },
-      "landmasses": {
-        "landmasses": {
-          "strategy": "default",
-          "config": {}
-        }
+        "enabled": true,
+        "baseDensity": 0.006,
+        "minSpacing": 5,
+        "boundaryThreshold": 0.32,
+        "boundaryWeight": 1.4,
+        "convergentMultiplier": 2.2,
+        "transformMultiplier": 0.7,
+        "divergentMultiplier": 0.2,
+        "hotspotWeight": 0.15,
+        "shieldPenalty": 0.3,
+        "randomJitter": 0.08,
+        "minVolcanoes": 6,
+        "maxVolcanoes": 18
       }
     },
     "hydrology-climate-baseline": {

--- a/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
+++ b/mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json
@@ -14,10 +14,10 @@
         "computeMesh": {
           "strategy": "default",
           "config": {
-            "plateCount": 28,
-            "cellsPerPlate": 7,
-            "referenceArea": 6996,
-            "plateScalePower": 0.7,
+            "plateCount": 23,
+            "cellsPerPlate": 13,
+            "referenceArea": 4536,
+            "plateScalePower": 0.8,
             "relaxationSteps": 2,
             "cellCount": 196
           }
@@ -27,12 +27,12 @@
         "computeMantlePotential": {
           "strategy": "default",
           "config": {
-            "plumeCount": 10,
-            "downwellingCount": 3,
-            "plumeRadius": 0.28,
-            "downwellingRadius": 0.18,
-            "plumeAmplitude": 1,
-            "downwellingAmplitude": -1,
+            "plumeCount": 17,
+            "downwellingCount": 7,
+            "plumeRadius": 0.1,
+            "downwellingRadius": 0.28,
+            "plumeAmplitude": 1.5,
+            "downwellingAmplitude": -1.5,
             "smoothingIterations": 1,
             "smoothingAlpha": 0.35,
             "minSeparationScale": 0.85
@@ -43,11 +43,11 @@
         "computeMantleForcing": {
           "strategy": "default",
           "config": {
-            "velocityScale": 1,
+            "velocityScale": 1.5,
             "rotationScale": 0.2,
             "stressNorm": 1,
-            "curvatureWeight": 0.35,
-            "upwellingThreshold": 0.35,
+            "curvatureWeight": 0.45,
+            "upwellingThreshold": 0.25,
             "downwellingThreshold": 0.35
           }
         }
@@ -68,10 +68,10 @@
           "strategy": "default",
           "config": {
             "plateCount": 37,
-            "referenceArea": 4000,
-            "plateScalePower": 0.5,
+            "referenceArea": 4536,
+            "plateScalePower": 0.8,
             "polarCaps": {
-              "capFraction": 0.1,
+              "capFraction": 0.08,
               "microplateBandFraction": 0.2,
               "microplatesPerPole": 0,
               "microplatesMinPlateCount": 14,
@@ -179,305 +179,188 @@
         "coastRuggedness": "normal",
         "shelfWidth": "normal"
       },
-      "landmass-plates": {
-        "beltDrivers": {
-          "strategy": "default",
-          "config": {}
-        },
-        "substrate": {
-          "strategy": "default",
-          "config": {
-            "continentalBaseErodibility": 0.63,
-            "oceanicBaseErodibility": 0.53,
-            "continentalBaseSediment": 0.19,
-            "oceanicBaseSediment": 0.29,
-            "ageErodibilityReduction": 0.25,
-            "ageSedimentBoost": 0.15,
-            "upliftErodibilityBoost": 0.35,
-            "riftSedimentBoost": 0.34,
-            "convergentBoundaryErodibilityBoost": 0.12,
-            "divergentBoundaryErodibilityBoost": 0.18,
-            "transformBoundaryErodibilityBoost": 0.08,
-            "convergentBoundarySedimentBoost": 0.05,
-            "divergentBoundarySedimentBoost": 0.1,
-            "transformBoundarySedimentBoost": 0.03
-          }
-        },
-        "baseTopography": {
-          "strategy": "default",
-          "config": {
-            "boundaryBias": 0.12,
-            "clusteringBias": 0.7,
-            "crustEdgeBlend": 0.6,
-            "crustNoiseAmplitude": 0.36,
-            "continentalHeight": 0.54,
-            "oceanicHeight": -0.75,
-            "tectonics": {
-              "interiorNoiseWeight": 0.5,
-              "boundaryArcWeight": 0.32,
-              "boundaryArcNoiseWeight": 0.26,
-              "fractalGrain": 3
-            }
-          }
-        },
-        "seaLevel": {
-          "strategy": "default",
-          "config": {
-            "targetWaterPercent": 63,
-            "targetScalar": 1,
-            "variance": 1.5,
-            "boundaryShareTarget": 0.005,
-            "continentalFraction": 0.39
-          }
-        },
-        "landmask": {
-          "strategy": "default",
-          "config": {
-            "continentPotentialGrain": 4,
-            "continentPotentialBlurSteps": 4,
-            "keepLandComponentFraction": 0.985,
-            "cratonStepsPerEra": 2,
-            "cratonNucleationScale": 0.9,
-            "cratonDiffusion": 0.25,
-            "cratonAdvection": 0.15,
-            "cratonHalfSaturation": 0.35,
-            "cratonPotentialWeight": 0.12
-          }
+      "substrate": {
+        "continentalBaseErodibility": 0.63,
+        "oceanicBaseErodibility": 0.53,
+        "continentalBaseSediment": 0.19,
+        "oceanicBaseSediment": 0.29,
+        "ageErodibilityReduction": 0.25,
+        "ageSedimentBoost": 0.15,
+        "upliftErodibilityBoost": 0.35,
+        "riftSedimentBoost": 0.34,
+        "convergentBoundaryErodibilityBoost": 0.12,
+        "divergentBoundaryErodibilityBoost": 0.18,
+        "transformBoundaryErodibilityBoost": 0.08,
+        "convergentBoundarySedimentBoost": 0.05,
+        "divergentBoundarySedimentBoost": 0.1,
+        "transformBoundarySedimentBoost": 0.03
+      },
+      "relief": {
+        "boundaryBias": 0.12,
+        "clusteringBias": 0.7,
+        "crustEdgeBlend": 0.6,
+        "crustNoiseAmplitude": 0.36,
+        "continentalHeight": 0.54,
+        "oceanicHeight": -0.75,
+        "tectonics": {
+          "interiorNoiseWeight": 0.5,
+          "boundaryArcWeight": 0.32,
+          "boundaryArcNoiseWeight": 0.26,
+          "fractalGrain": 3
         }
       },
-      "rugged-coasts": {
-        "coastlines": {
-          "strategy": "default",
-          "config": {
-            "coast": {
-              "bay": {
-                "noiseGateAdd": 0.05,
-                "rollDenActive": 4,
-                "rollDenDefault": 7
-              },
-              "fjord": {
-                "baseDenom": 15,
-                "activeBonus": 2,
-                "passiveBonus": 1
-              },
-              "plateBias": {
-                "threshold": 0.42,
-                "power": 1.3,
-                "convergent": 1.5,
-                "transform": 0.35,
-                "divergent": -0.45,
-                "interior": 0.35,
-                "bayWeight": 0.9,
-                "bayNoiseBonus": 0.45,
-                "fjordWeight": 0.85
-              }
-            }
-          }
+      "waterCoverage": {
+        "targetWaterPercent": 63,
+        "targetScalar": 1,
+        "variance": 1.5,
+        "boundaryShareTarget": 0.005,
+        "continentalFraction": 0.39
+      },
+      "continents": {
+        "continentPotentialGrain": 4,
+        "continentPotentialBlurSteps": 4,
+        "keepLandComponentFraction": 0.985,
+        "cratonStepsPerEra": 2,
+        "cratonNucleationScale": 0.9,
+        "cratonDiffusion": 0.25,
+        "cratonAdvection": 0.15,
+        "cratonHalfSaturation": 0.35,
+        "cratonPotentialWeight": 0.12
+      },
+      "coastlineShape": {
+        "bay": {
+          "noiseGateAdd": 0.05,
+          "rollDenActive": 4,
+          "rollDenDefault": 7
         },
-        "shelfMask": {
-          "strategy": "default",
-          "config": {
-            "nearshoreDistance": 3,
-            "shallowQuantile": 0.7,
-            "activeClosenessThreshold": 0.45,
-            "capTilesActive": 2,
-            "capTilesPassive": 4,
-            "capTilesMax": 8
-          }
+        "fjord": {
+          "baseDenom": 15,
+          "activeBonus": 2,
+          "passiveBonus": 1
+        },
+        "plateBias": {
+          "threshold": 0.42,
+          "power": 1.3,
+          "convergent": 1.5,
+          "transform": 0.35,
+          "divergent": -0.45,
+          "interior": 0.35,
+          "bayWeight": 0.9,
+          "bayNoiseBonus": 0.45,
+          "fjordWeight": 0.85
         }
+      },
+      "shelf": {
+        "nearshoreDistance": 3,
+        "shallowQuantile": 0.7,
+        "activeClosenessThreshold": 0.45,
+        "capTilesActive": 2,
+        "capTilesPassive": 4,
+        "capTilesMax": 8
       }
     },
-    "morphology-routing": {
-      "knobs": {},
-      "routing": {
-        "routing": {
-          "strategy": "default",
-          "config": {}
-        }
-      }
-    },
+    "morphology-routing": {},
     "morphology-erosion": {
       "knobs": {
-        "erosion": "normal"
+        "erosion": "high"
       },
-      "geomorphology": {
+      "geomorphicCycle": {
         "geomorphology": {
-          "strategy": "default",
-          "config": {
-            "geomorphology": {
-              "fluvial": {
-                "rate": 0.26,
-                "m": 0.5,
-                "n": 1
-              },
-              "diffusion": {
-                "rate": 0.23,
-                "talus": 0.5
-              },
-              "deposition": {
-                "rate": 0.11
-              },
-              "eras": 3
-            },
-            "worldAge": "mature"
-          }
-        }
+          "fluvial": {
+            "rate": 0.26,
+            "m": 0.5,
+            "n": 1
+          },
+          "diffusion": {
+            "rate": 0.23,
+            "talus": 0.5
+          },
+          "deposition": {
+            "rate": 0.21
+          },
+          "eras": 3
+        },
+        "worldAge": "young"
       }
     },
     "morphology-features": {
       "knobs": {
-        "orogeny": "normal",
-        "volcanism": "normal"
+        "orogeny": "high",
+        "volcanism": "high"
       },
-      "islands": {
-        "islands": {
-          "strategy": "default",
-          "config": {
-            "islands": {
-              "fractalThresholdPercent": 96,
-              "minDistFromLandRadius": 5,
-              "baseIslandDenNearActive": 2,
-              "baseIslandDenElse": 2,
-              "hotspotSeedDenom": 3,
-              "clusterMax": 12,
-              "microcontinentChance": 0.12
-            }
-          }
-        }
+      "islandChains": {
+        "fractalThresholdPercent": 96,
+        "minDistFromLandRadius": 5,
+        "baseIslandDenNearActive": 2,
+        "baseIslandDenElse": 2,
+        "hotspotSeedDenom": 3,
+        "clusterMax": 12,
+        "microcontinentChance": 0.12
       },
-      "mountains": {
-        "ridges": {
-          "strategy": "default",
-          "config": {
-            "tectonicIntensity": 1.25,
-            "driverSignalByteMin": 30,
-            "driverExponent": 1,
-            "mountainMaxFraction": 0.1,
-            "hillMaxFraction": 0.18,
-            "mountainSpineFraction": 0.02,
-            "mountainSpineDilationSteps": 2,
-            "oldBeltMountainScale": 0.4,
-            "oldBeltHillScale": 1.1,
-            "foothillMaxDistance": 2,
-            "mountainThreshold": 0.42,
-            "hillThreshold": 0.12,
-            "upliftWeight": 0.35,
-            "fractalWeight": 0.15,
-            "orogenyCollisionStressWeight": 0.6,
-            "orogenyCollisionUpliftWeight": 0.4,
-            "orogenyTransformStressWeight": 0.4,
-            "orogenyDivergentRiftWeight": 0.55,
-            "orogenyDivergentStressWeight": 0.15,
-            "fractureBoundaryWeight": 0.7,
-            "fractureStressWeight": 0.2,
-            "fractureRiftWeight": 0.1,
-            "mountainCollisionStressWeight": 0.5,
-            "mountainCollisionUpliftWeight": 0.5,
-            "mountainSubductionUpliftWeight": 0.25,
-            "mountainInteriorUpliftScale": 0.25,
-            "mountainFractalScale": 0.3,
-            "mountainConvergenceFractalBase": 0.6,
-            "mountainConvergenceFractalSpan": 0.4,
-            "riftDepth": 0.2,
-            "boundaryWeight": 1,
-            "boundaryGate": 0.1,
-            "boundaryExponent": 1.6,
-            "interiorPenaltyWeight": 0,
-            "convergenceBonus": 1,
-            "transformPenalty": 0.6,
-            "riftPenalty": 1,
-            "hillBoundaryWeight": 0.35,
-            "hillRiftBonus": 0.25,
-            "hillFoothillBase": 0.5,
-            "hillFoothillFractalGain": 0.5,
-            "hillConvergentFoothill": 0.35,
-            "hillInteriorFalloff": 0.1,
-            "hillUpliftWeight": 0.2,
-            "hillFractalScale": 0.8,
-            "hillUpliftScale": 0.3,
-            "hillRiftBonusScale": 0.5,
-            "hillRiftDepthScale": 0.5
-          }
-        },
-        "foothills": {
-          "strategy": "default",
-          "config": {
-            "tectonicIntensity": 1.25,
-            "driverSignalByteMin": 30,
-            "driverExponent": 1,
-            "mountainMaxFraction": 0.1,
-            "hillMaxFraction": 0.18,
-            "mountainSpineFraction": 0.02,
-            "mountainSpineDilationSteps": 2,
-            "oldBeltMountainScale": 0.4,
-            "oldBeltHillScale": 1.1,
-            "foothillMaxDistance": 2,
-            "mountainThreshold": 0.42,
-            "hillThreshold": 0.12,
-            "upliftWeight": 0.35,
-            "fractalWeight": 0.15,
-            "orogenyCollisionStressWeight": 0.6,
-            "orogenyCollisionUpliftWeight": 0.4,
-            "orogenyTransformStressWeight": 0.4,
-            "orogenyDivergentRiftWeight": 0.55,
-            "orogenyDivergentStressWeight": 0.15,
-            "fractureBoundaryWeight": 0.7,
-            "fractureStressWeight": 0.2,
-            "fractureRiftWeight": 0.1,
-            "mountainCollisionStressWeight": 0.5,
-            "mountainCollisionUpliftWeight": 0.5,
-            "mountainSubductionUpliftWeight": 0.25,
-            "mountainInteriorUpliftScale": 0.25,
-            "mountainFractalScale": 0.3,
-            "mountainConvergenceFractalBase": 0.6,
-            "mountainConvergenceFractalSpan": 0.4,
-            "riftDepth": 0.2,
-            "boundaryWeight": 1,
-            "boundaryGate": 0.1,
-            "boundaryExponent": 1.6,
-            "interiorPenaltyWeight": 0,
-            "convergenceBonus": 1,
-            "transformPenalty": 0.6,
-            "riftPenalty": 1,
-            "hillBoundaryWeight": 0.35,
-            "hillRiftBonus": 0.25,
-            "hillFoothillBase": 0.5,
-            "hillFoothillFractalGain": 0.5,
-            "hillConvergentFoothill": 0.35,
-            "hillInteriorFalloff": 0.1,
-            "hillUpliftWeight": 0.2,
-            "hillFractalScale": 0.8,
-            "hillUpliftScale": 0.3,
-            "hillRiftBonusScale": 0.5,
-            "hillRiftDepthScale": 0.5
-          }
-        }
+      "mountainRanges": {
+        "tectonicIntensity": 1.25,
+        "driverSignalByteMin": 30,
+        "driverExponent": 1,
+        "mountainMaxFraction": 0.1,
+        "hillMaxFraction": 0.18,
+        "mountainSpineFraction": 0.02,
+        "mountainSpineDilationSteps": 2,
+        "oldBeltMountainScale": 0.4,
+        "oldBeltHillScale": 1.1,
+        "foothillMaxDistance": 2,
+        "mountainThreshold": 0.42,
+        "hillThreshold": 0.12,
+        "upliftWeight": 0.35,
+        "fractalWeight": 0.15,
+        "orogenyCollisionStressWeight": 0.6,
+        "orogenyCollisionUpliftWeight": 0.4,
+        "orogenyTransformStressWeight": 0.4,
+        "orogenyDivergentRiftWeight": 0.55,
+        "orogenyDivergentStressWeight": 0.15,
+        "fractureBoundaryWeight": 0.7,
+        "fractureStressWeight": 0.2,
+        "fractureRiftWeight": 0.1,
+        "mountainCollisionStressWeight": 0.5,
+        "mountainCollisionUpliftWeight": 0.5,
+        "mountainSubductionUpliftWeight": 0.25,
+        "mountainInteriorUpliftScale": 0.25,
+        "mountainFractalScale": 0.3,
+        "mountainConvergenceFractalBase": 0.6,
+        "mountainConvergenceFractalSpan": 0.4,
+        "riftDepth": 0.2,
+        "boundaryWeight": 1,
+        "boundaryGate": 0.1,
+        "boundaryExponent": 1.6,
+        "interiorPenaltyWeight": 0,
+        "convergenceBonus": 1,
+        "transformPenalty": 0.6,
+        "riftPenalty": 1,
+        "hillBoundaryWeight": 0.35,
+        "hillRiftBonus": 0.25,
+        "hillFoothillBase": 0.5,
+        "hillFoothillFractalGain": 0.5,
+        "hillConvergentFoothill": 0.35,
+        "hillInteriorFalloff": 0.1,
+        "hillUpliftWeight": 0.2,
+        "hillFractalScale": 0.8,
+        "hillUpliftScale": 0.3,
+        "hillRiftBonusScale": 0.5,
+        "hillRiftDepthScale": 0.5
       },
       "volcanoes": {
-        "volcanoes": {
-          "strategy": "default",
-          "config": {
-            "enabled": true,
-            "baseDensity": 0.00625,
-            "minSpacing": 6,
-            "boundaryThreshold": 0.32,
-            "boundaryWeight": 1.35,
-            "convergentMultiplier": 3.3,
-            "transformMultiplier": 0.8,
-            "divergentMultiplier": 0.32,
-            "hotspotWeight": 0.32,
-            "shieldPenalty": 0.55,
-            "randomJitter": 0.04,
-            "minVolcanoes": 12,
-            "maxVolcanoes": 42
-          }
-        }
-      },
-      "landmasses": {
-        "landmasses": {
-          "strategy": "default",
-          "config": {}
-        }
+        "enabled": true,
+        "baseDensity": 0.00625,
+        "minSpacing": 6,
+        "boundaryThreshold": 0.32,
+        "boundaryWeight": 1.35,
+        "convergentMultiplier": 3.3,
+        "transformMultiplier": 0.8,
+        "divergentMultiplier": 0.32,
+        "hotspotWeight": 0.32,
+        "shieldPenalty": 0.55,
+        "randomJitter": 0.04,
+        "minVolcanoes": 12,
+        "maxVolcanoes": 42
       }
     },
     "hydrology-climate-baseline": {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-coasts/index.ts
@@ -1,9 +1,15 @@
 import { Type, createStage } from "@swooper/mapgen-core/authoring";
 import { landmassPlates, ruggedCoasts } from "./steps/index.js";
 import {
+  CoastConfigSchema,
+  HypsometryConfigSchema,
+  LandmaskConfigSchema,
   MorphologyCoastRuggednessKnobSchema,
   MorphologySeaLevelKnobSchema,
   MorphologyShelfWidthKnobSchema,
+  ReliefConfigSchema,
+  ShelfMaskConfigSchema,
+  SubstrateConfigSchema,
 } from "@mapgen/domain/morphology/config.js";
 
 /**
@@ -22,8 +28,41 @@ const knobsSchema = Type.Object(
   }
 );
 
+const publicSchema = Type.Object(
+  {
+    substrate: Type.Optional(SubstrateConfigSchema),
+    relief: Type.Optional(ReliefConfigSchema),
+    waterCoverage: Type.Optional(HypsometryConfigSchema),
+    continents: Type.Optional(LandmaskConfigSchema),
+    coastlineShape: Type.Optional(CoastConfigSchema),
+    shelf: Type.Optional(ShelfMaskConfigSchema),
+  },
+  {
+    description:
+      "Morphology coast and land/sea shaping controls. Public keys are semantic authoring inputs; stage compilation lowers them to internal morphology step/op config.",
+  }
+);
+
+function defaultEnvelope(config: unknown): { strategy: "default"; config: unknown } {
+  return { strategy: "default", config: config ?? {} };
+}
+
 export default createStage({
   id: "morphology-coasts",
   knobsSchema,
+  public: publicSchema,
   steps: [landmassPlates, ruggedCoasts],
+  compile: ({ config }: { config: Record<string, unknown> }) => ({
+    "landmass-plates": {
+      beltDrivers: defaultEnvelope({}),
+      substrate: defaultEnvelope(config.substrate),
+      baseTopography: defaultEnvelope(config.relief),
+      seaLevel: defaultEnvelope(config.waterCoverage),
+      landmask: defaultEnvelope(config.continents),
+    },
+    "rugged-coasts": {
+      coastlines: defaultEnvelope({ coast: config.coastlineShape ?? {} }),
+      shelfMask: defaultEnvelope(config.shelf),
+    },
+  }),
 } as const);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-erosion/index.ts
@@ -1,6 +1,9 @@
 import { Type, createStage } from "@swooper/mapgen-core/authoring";
 import { geomorphology } from "./steps/index.js";
-import { MorphologyErosionKnobSchema } from "@mapgen/domain/morphology/config.js";
+import {
+  GeomorphicCycleConfigSchema,
+  MorphologyErosionKnobSchema,
+} from "@mapgen/domain/morphology/config.js";
 
 /**
  * Morphology-erosion knobs (erosion). Knobs apply after defaulted step config as deterministic transforms.
@@ -18,5 +21,20 @@ const knobsSchema = Type.Object(
 export default createStage({
   id: "morphology-erosion",
   knobsSchema,
+  public: Type.Object(
+    {
+      geomorphicCycle: Type.Optional(GeomorphicCycleConfigSchema),
+    },
+    {
+      additionalProperties: false,
+      description:
+        "Morphology geomorphic-cycle controls. Public config compiles to the internal erosion step/op envelope.",
+    }
+  ),
   steps: [geomorphology],
+  compile: ({ config }: { config: Record<string, unknown> }) => ({
+    geomorphology: {
+      geomorphology: { strategy: "default", config: config.geomorphicCycle ?? {} },
+    },
+  }),
 } as const);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/index.ts
@@ -1,8 +1,11 @@
 import { Type, createStage } from "@swooper/mapgen-core/authoring";
 import { islands, landmasses, mountains, volcanoes } from "./steps/index.js";
 import {
+  IslandsConfigSchema,
+  MountainsConfigSchema,
   MorphologyOrogenyKnobSchema,
   MorphologyVolcanismKnobSchema,
+  VolcanoesConfigSchema,
 } from "@mapgen/domain/morphology/config.js";
 
 /**
@@ -21,8 +24,41 @@ const knobsSchema = Type.Object(
   }
 );
 
+const publicSchema = Type.Object(
+  {
+    islandChains: Type.Optional(IslandsConfigSchema),
+    mountainRanges: Type.Optional(MountainsConfigSchema),
+    volcanoes: Type.Optional(VolcanoesConfigSchema),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Morphology landform intent controls. Public keys compile to internal island, mountain-family, volcano, and landmass step/op config.",
+  }
+);
+
+function defaultEnvelope(config: unknown): { strategy: "default"; config: unknown } {
+  return { strategy: "default", config: config ?? {} };
+}
+
 export default createStage({
   id: "morphology-features",
   knobsSchema,
+  public: publicSchema,
   steps: [islands, mountains, volcanoes, landmasses],
+  compile: ({ config }: { config: Record<string, unknown> }) => ({
+    islands: {
+      islands: defaultEnvelope({ islands: config.islandChains ?? {} }),
+    },
+    mountains: {
+      ridges: defaultEnvelope(config.mountainRanges),
+      foothills: defaultEnvelope(config.mountainRanges),
+    },
+    volcanoes: {
+      volcanoes: defaultEnvelope(config.volcanoes),
+    },
+    landmasses: {
+      landmasses: defaultEnvelope({}),
+    },
+  }),
 } as const);

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-routing/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-routing/index.ts
@@ -12,5 +12,11 @@ const knobsSchema = Type.Object(
 export default createStage({
   id: "morphology-routing",
   knobsSchema,
+  public: Type.Object({}, { additionalProperties: false, description: "Morphology routing has no authored controls today." }),
   steps: [routing],
+  compile: () => ({
+    routing: {
+      routing: { strategy: "default", config: {} },
+    },
+  }),
 } as const);

--- a/mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts
+++ b/mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { deriveRecipeConfigSchema } from "@swooper/mapgen-core/authoring";
 import { normalizeStrict } from "@swooper/mapgen-core/compiler/normalize";
-import { STANDARD_STAGES } from "../../src/recipes/standard/recipe";
+import standardRecipe, { STANDARD_STAGES } from "../../src/recipes/standard/recipe";
 import {
   validateCanonicalMapConfig,
   type CanonicalMapConfigEnvelope,
@@ -20,6 +20,47 @@ const shippedMapConfigs = [
   ["swooper-earthlike.config.json", swooperEarthlikeConfig],
 ] as const satisfies readonly (readonly [string, CanonicalMapConfigEnvelope])[];
 
+const MORPHOLOGY_PUBLIC_KEYS: Record<string, readonly string[]> = {
+  "morphology-coasts": [
+    "knobs",
+    "substrate",
+    "relief",
+    "waterCoverage",
+    "continents",
+    "coastlineShape",
+    "shelf",
+  ],
+  "morphology-routing": ["knobs"],
+  "morphology-erosion": ["knobs", "geomorphicCycle"],
+  "morphology-features": ["knobs", "islandChains", "mountainRanges", "volcanoes"],
+};
+
+const MORPHOLOGY_INTERNAL_STAGE_KEYS = [
+  "landmass-plates",
+  "rugged-coasts",
+  "routing",
+  "geomorphology",
+  "islands",
+  "mountains",
+  "landmasses",
+];
+
+function stageProps(schema: unknown, stageId: string): Record<string, unknown> {
+  const stage = (schema as { properties?: Record<string, { properties?: Record<string, unknown> }> })
+    .properties?.[stageId];
+  return stage?.properties ?? {};
+}
+
+function hasRawOpEnvelope(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  if (Array.isArray(value)) return value.some(hasRawOpEnvelope);
+  const obj = value as Record<string, unknown>;
+  if (Object.prototype.hasOwnProperty.call(obj, "strategy") && Object.prototype.hasOwnProperty.call(obj, "config")) {
+    return true;
+  }
+  return Object.values(obj).some(hasRawOpEnvelope);
+}
+
 describe("Shipped map configs", () => {
   it("stay canonical, complete, and schema-valid (prevents Civ pipeline compile failures)", () => {
     const schema = deriveRecipeConfigSchema(STANDARD_STAGES);
@@ -33,6 +74,52 @@ describe("Shipped map configs", () => {
       });
       expect(validated.id).toBe(fileName.replace(/\.config\.json$/, ""));
     }
+  });
+
+  it("exposes Morphology public schema keys instead of internal step/op envelope paths", () => {
+    const schema = deriveRecipeConfigSchema(STANDARD_STAGES);
+
+    for (const [stageId, expectedKeys] of Object.entries(MORPHOLOGY_PUBLIC_KEYS)) {
+      const props = stageProps(schema, stageId);
+      expect(Object.keys(props).sort()).toEqual([...expectedKeys].sort());
+      for (const internalKey of MORPHOLOGY_INTERNAL_STAGE_KEYS) {
+        expect(props).not.toHaveProperty(internalKey);
+      }
+      expect(JSON.stringify(props)).not.toContain("\"strategy\"");
+      expect(JSON.stringify(props)).not.toContain("\"config\"");
+    }
+  });
+
+  it("keeps shipped Morphology configs on the semantic public surface", () => {
+    for (const [, raw] of shippedMapConfigs) {
+      for (const [stageId, expectedKeys] of Object.entries(MORPHOLOGY_PUBLIC_KEYS)) {
+        const stageConfig = (raw.config as Record<string, Record<string, unknown>>)[stageId] ?? {};
+        for (const key of Object.keys(stageConfig)) {
+          expect(expectedKeys).toContain(key);
+        }
+        expect(hasRawOpEnvelope(stageConfig)).toBe(false);
+      }
+    }
+  });
+
+  it("compiles public Morphology config to internal executable step/op envelopes", () => {
+    const compiled = standardRecipe.compileConfig(
+      {
+        seed: 123,
+        dimensions: { width: 80, height: 60 },
+        latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
+      },
+      swooperEarthlikeConfig.config
+    ) as any;
+
+    expect(compiled["morphology-coasts"]["landmass-plates"].seaLevel.strategy).toBe("default");
+    expect(compiled["morphology-coasts"]["rugged-coasts"].coastlines.strategy).toBe("default");
+    expect(compiled["morphology-routing"].routing.routing.strategy).toBe("default");
+    expect(compiled["morphology-erosion"].geomorphology.geomorphology.strategy).toBe("default");
+    expect(compiled["morphology-features"].islands.islands.strategy).toBe("default");
+    expect(compiled["morphology-features"].mountains.ridges.strategy).toBe("default");
+    expect(compiled["morphology-features"].mountains.foothills.strategy).toBe("default");
+    expect(compiled["morphology-features"].volcanoes.volcanoes.strategy).toBe("default");
   });
 
   it("rejects legacy map-morphology alias keys", () => {

--- a/mods/mod-swooper-maps/test/m11-config-knobs-and-presets.test.ts
+++ b/mods/mod-swooper-maps/test/m11-config-knobs-and-presets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { stableStringify } from "@swooper/mapgen-core";
 import { deriveRecipeConfigSchema } from "@swooper/mapgen-core/authoring";
+import { RecipeCompileError } from "@swooper/mapgen-core/compiler/recipe-compile";
 
 import standardRecipe, { STANDARD_STAGES } from "../src/recipes/standard/recipe.js";
 
@@ -58,67 +59,39 @@ describe("M11 config layering: knobs-last (foundation + morphology)", () => {
       },
       "morphology-coasts": {
         knobs: { seaLevel: "water-heavy", coastRuggedness: "rugged" },
-        "landmass-plates": {
-          seaLevel: { strategy: "default", config: { targetWaterPercent: 60 } },
-        },
-        "rugged-coasts": {
-          coastlines: {
-            strategy: "default",
-            config: {
-              coast: {
-                plateBias: {
-                  threshold: 0.4,
-                  power: 1.4,
-                  convergent: 2.2,
-                  transform: 0.3,
-                  divergent: -0.3,
-                  interior: 0.5,
-                  bayWeight: 1.0,
-                  bayNoiseBonus: 0.6,
-                  fjordWeight: 0.7,
-                },
-                bay: { noiseGateAdd: 0, rollDenActive: 4, rollDenDefault: 5 },
-                fjord: { baseDenom: 12, activeBonus: 1, passiveBonus: 2 },
-              },
-            },
+        waterCoverage: { targetWaterPercent: 60 },
+        coastlineShape: {
+          plateBias: {
+            threshold: 0.4,
+            power: 1.4,
+            convergent: 2.2,
+            transform: 0.3,
+            divergent: -0.3,
+            interior: 0.5,
+            bayWeight: 1.0,
+            bayNoiseBonus: 0.6,
+            fjordWeight: 0.7,
           },
+          bay: { noiseGateAdd: 0, rollDenActive: 4, rollDenDefault: 5 },
+          fjord: { baseDenom: 12, activeBonus: 1, passiveBonus: 2 },
         },
       },
       "morphology-erosion": {
         knobs: { erosion: "high" },
-        geomorphology: {
+        geomorphicCycle: {
           geomorphology: {
-            strategy: "default",
-            config: {
-              geomorphology: {
-                fluvial: { rate: 0.2, m: 0.5, n: 1.0 },
-                diffusion: { rate: 0.2, talus: 0.5 },
-                deposition: { rate: 0.1 },
-                eras: 2,
-              },
-              worldAge: "mature",
-            },
+            fluvial: { rate: 0.2, m: 0.5, n: 1.0 },
+            diffusion: { rate: 0.2, talus: 0.5 },
+            deposition: { rate: 0.1 },
+            eras: 2,
           },
+          worldAge: "mature",
         },
       },
       "morphology-features": {
         knobs: { volcanism: "high", orogeny: "high" },
-        mountains: {
-          ridges: {
-            strategy: "default",
-            config: { tectonicIntensity: 1.0, mountainThreshold: 0.6, hillThreshold: 0.35 },
-          },
-          foothills: {
-            strategy: "default",
-            config: { tectonicIntensity: 1.0, mountainThreshold: 0.6, hillThreshold: 0.35 },
-          },
-        },
-        volcanoes: {
-          volcanoes: {
-            strategy: "default",
-            config: { baseDensity: 0.01, hotspotWeight: 0.12, convergentMultiplier: 2.4 },
-          },
-        },
+        mountainRanges: { tectonicIntensity: 1.0, mountainThreshold: 0.6, hillThreshold: 0.35 },
+        volcanoes: { baseDensity: 0.01, hotspotWeight: 0.12, convergentMultiplier: 2.4 },
       },
       "map-morphology": {},
     });
@@ -225,7 +198,7 @@ describe("M11 config layering: knobs-last (foundation + morphology)", () => {
     expect(stableStringify(first.foundation)).toBe(stableStringify(second.foundation));
   });
 
-  it("rejects divergent ridge/foothill mountain-family configs", () => {
+  it("rejects stale internal ridge/foothill mountain-family config on the public surface", () => {
     expect(() =>
       standardRecipe.compileConfig(env, {
         "morphology-features": {
@@ -241,6 +214,6 @@ describe("M11 config layering: knobs-last (foundation + morphology)", () => {
           },
         },
       })
-    ).toThrow(/Mountain-family config requires identical ridge\/foothill config/);
+    ).toThrow(RecipeCompileError);
   });
 });

--- a/openspec/changes/guard-morphology-public-config-boundary/.openspec.yaml
+++ b/openspec/changes/guard-morphology-public-config-boundary/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/guard-morphology-public-config-boundary/proposal.md
+++ b/openspec/changes/guard-morphology-public-config-boundary/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The Morphology public surface fix needs durable guardrails that prove the public
+schema stays semantic while the compiler still produces internal executable
+config. The guardrails must target boundaries, not mutable tuning values.
+
+## Target Authority Refs
+
+- Direct user decision: do not use brittle tests over mutable config values;
+  use compiler/SDK tests for compiler behavior and product/world tests for
+  product outcomes.
+- `docs/system/TESTING.md`: proof boundaries must match what tests exercise.
+- `openspec/changes/mapgen-public-config-boundary`
+- `openspec/changes/morphology-public-config-surface`
+
+## What Changes
+
+- Add static/schema tests that prevent Morphology raw op envelopes from
+  reappearing in public recipe schemas, shipped configs, and Studio defaults.
+- Keep existing math-transform tests separate from public-boundary proof.
+- Validate that compiled config still contains internal step/op envelopes after
+  public config compilation.
+
+## Requires
+
+- `mapgen-public-config-boundary`
+- `morphology-public-config-surface`
+- `migrate-swooper-morphology-public-configs`
+- `studio-public-config-contract`
+
+## Enables Parallel Work
+
+- Earthlike balancing work on a stable authoring surface.
+
+## Forbidden Non-Goals
+
+- No exact assertions over mutable product tuning values as public-boundary
+  proof.
+- No replacing product world-balance tests with tiny schema tests.
+- No UI-only filter as boundary enforcement.
+
+## Verification Gates
+
+- Focused core compiler tests.
+- Focused shipped-config and Studio config schema tests.
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate guard-morphology-public-config-boundary --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/guard-morphology-public-config-boundary/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/guard-morphology-public-config-boundary/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Morphology Public Boundary Is Guarded By Contract Tests
+
+Morphology public-boundary tests SHALL prove schema and compiler ownership
+without pinning mutable tuning values.
+
+#### Scenario: Public schema is tested
+- **WHEN** standard recipe public schema tests inspect Morphology stages
+- **THEN** they assert semantic public keys and absence of raw internal
+  step/op envelope paths
+- **AND** they do not assert product tuning constants as boundary proof
+
+#### Scenario: Compiler output is tested
+- **WHEN** public Morphology config is compiled
+- **THEN** internal step/op envelopes exist in compiled config for execution
+- **AND** the test distinguishes compiled internal shape from persisted public
+  config

--- a/openspec/changes/guard-morphology-public-config-boundary/tasks.md
+++ b/openspec/changes/guard-morphology-public-config-boundary/tasks.md
@@ -1,0 +1,17 @@
+## 1. Specification
+
+- [x] 1.1 Record Morphology public-boundary guardrail requirements.
+
+## 2. Implementation
+
+- [x] 2.1 Add core compiler/authoring boundary tests.
+- [x] 2.2 Add Swooper shipped-config public-surface tests.
+- [x] 2.3 Add Studio generated-schema public-surface tests.
+- [x] 2.4 Keep mutable tuning assertions out of public-boundary tests.
+
+## 3. Verification
+
+- [x] 3.1 Run focused core, Swooper, and Studio tests.
+- [x] 3.2 Run Swooper Maps check.
+- [x] 3.3 Run all OpenSpec validation.
+- [x] 3.4 Run `git diff --check`.

--- a/openspec/changes/mapgen-public-config-boundary/.openspec.yaml
+++ b/openspec/changes/mapgen-public-config-boundary/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/mapgen-public-config-boundary/proposal.md
+++ b/openspec/changes/mapgen-public-config-boundary/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+The MapGen authoring SDK already supports explicit stage `public + compile`
+surfaces, but the regression showed that product-facing recipes can fall back to
+raw internal step/op schemas when a genuine public transform is removed. That
+leaks op envelopes such as `{ strategy, config }` into Studio and persisted map
+configs.
+
+This change records and verifies the SDK boundary: public recipe config is the
+stage surface; internal step/op contracts are compiler/runtime input after
+stage compilation.
+
+## Target Authority Refs
+
+- Direct user decision: public config is semantic authoring input compiled into
+  internal step/op config; projection/internal config is not public config.
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`:
+  Target Shape, Problem Layer 2, and D1.
+- `openspec/specs/mapgen-normalization-workstreams/spec.md`: flat config
+  migration and genuine public transforms remain explicit.
+
+## What Changes
+
+- Add SDK/compiler-level coverage proving explicit public stage schemas hide
+  internal op envelopes from the recipe surface.
+- Keep the normal flat shape `{ knobs?, [publicKey]?: publicConfig }`.
+- Keep raw step schemas as internal compiled config for execution.
+
+## Requires
+
+- Existing `createStage` `public + compile` support.
+
+## Enables Parallel Work
+
+- `morphology-public-config-surface`
+- `studio-public-config-contract`
+
+## Forbidden Non-Goals
+
+- No persisted `advanced` wrapper.
+- No Studio-only schema patching to hide internal fields.
+- No broad removal of internal no-public stages that are not product-facing.
+
+## Verification Gates
+
+- `bun test packages/mapgen-core/test/authoring/authoring.test.ts packages/mapgen-core/test/compiler/recipe-compile.test.ts`
+- `bun run openspec -- validate mapgen-public-config-boundary --strict`
+- `git diff --check`

--- a/openspec/changes/mapgen-public-config-boundary/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/mapgen-public-config-boundary/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Explicit Public Stage Surface Hides Internal Step Contracts
+
+MapGen recipe config schemas SHALL expose an explicit stage public schema when a
+stage declares `public + compile`, and SHALL keep internal step/op config
+schemas behind stage compilation.
+
+#### Scenario: Product-facing stage declares public compile
+- **WHEN** a stage declares a public schema and compile function
+- **THEN** the derived recipe config schema exposes `knobs` plus public schema
+  keys
+- **AND** it does not expose hidden step ids or op-envelope keys unless those
+  keys are explicitly part of the public schema
+
+#### Scenario: Public config compiles to internal step config
+- **WHEN** the recipe compiler receives public stage config
+- **THEN** stage compilation produces declared internal step ids
+- **AND** op defaults and op normalization run after that compilation

--- a/openspec/changes/mapgen-public-config-boundary/tasks.md
+++ b/openspec/changes/mapgen-public-config-boundary/tasks.md
@@ -1,0 +1,14 @@
+## 1. Specification
+
+- [x] 1.1 Record the SDK/compiler public-vs-internal config boundary.
+
+## 2. Implementation
+
+- [x] 2.1 Add compiler/authoring tests proving public stage schemas hide
+  internal op envelopes and compile to internal step config.
+
+## 3. Verification
+
+- [x] 3.1 Run focused MapGen core authoring/compiler tests.
+- [x] 3.2 Run OpenSpec validation for this change.
+- [x] 3.3 Run `git diff --check`.

--- a/openspec/changes/migrate-swooper-morphology-public-configs/.openspec.yaml
+++ b/openspec/changes/migrate-swooper-morphology-public-configs/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/migrate-swooper-morphology-public-configs/proposal.md
+++ b/openspec/changes/migrate-swooper-morphology-public-configs/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+The regression already polluted first-party shipped map configs with raw
+Morphology op envelopes. The correct repair is a one-way migration of known
+first-party configs to the new semantic public surface, followed by hard
+validation failures for stale raw envelopes.
+
+## Target Authority Refs
+
+- Direct user decision: authored configs are public knobs/stage schema compiled
+  internally; internal op envelopes are not public config.
+- `openspec/changes/morphology-public-config-surface`: Morphology public schema
+  owner.
+- `openspec/changes/normalize-swooper-map-config-generation`: shipped JSON map
+  configs are first-party source authority.
+
+## What Changes
+
+- Migrate shipped map configs from Morphology step/op envelopes to semantic
+  public keys.
+- Preserve existing authored tuning intent by mapping every known raw envelope
+  path to one public field or rejecting it during migration.
+- Keep normal validation strict after migration; no dual persisted shape.
+
+## Requires
+
+- `morphology-public-config-surface`
+
+## Enables Parallel Work
+
+- Studio repo-backed config editing on a clean public surface.
+- Later world-balance tuning without internal envelope churn.
+
+## Forbidden Non-Goals
+
+- No silent runtime dual-read compatibility.
+- No generated output hand edits.
+- No public retention of raw `{ strategy, config }` Morphology envelopes.
+
+## Verification Gates
+
+- `bun test mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts`
+- `bun run --cwd mods/mod-swooper-maps build:studio-recipes`
+- `bun run openspec -- validate migrate-swooper-morphology-public-configs --strict`
+- `git diff --check`

--- a/openspec/changes/migrate-swooper-morphology-public-configs/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/migrate-swooper-morphology-public-configs/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: First-Party Morphology Config Migration Is One-Way
+
+First-party shipped Swooper map configs SHALL be migrated from raw Morphology
+step/op envelopes to the semantic Morphology public config surface.
+
+#### Scenario: Shipped config is migrated
+- **WHEN** a first-party shipped map config previously contains raw Morphology
+  op envelopes
+- **THEN** each known stale envelope path is mapped to a semantic public key
+- **AND** the resulting config validates against the public recipe schema
+
+#### Scenario: Raw envelope remains after migration
+- **WHEN** shipped map config validation scans Morphology stages after migration
+- **THEN** raw internal Morphology step ids and op envelope keys are rejected
+- **AND** runtime compilation is not used as a silent compatibility lane

--- a/openspec/changes/migrate-swooper-morphology-public-configs/tasks.md
+++ b/openspec/changes/migrate-swooper-morphology-public-configs/tasks.md
@@ -1,0 +1,17 @@
+## 1. Specification
+
+- [x] 1.1 Record the one-way first-party Morphology config migration policy.
+
+## 2. Implementation
+
+- [x] 2.1 Migrate shipped map configs to semantic Morphology public keys.
+- [x] 2.2 Add config validation coverage rejecting stale raw Morphology
+  envelopes.
+- [x] 2.3 Regenerate Studio recipe artifacts from migrated configs.
+
+## 3. Verification
+
+- [x] 3.1 Run shipped map config validation.
+- [x] 3.2 Run Studio recipe artifact generation.
+- [x] 3.3 Run OpenSpec validation for this change.
+- [x] 3.4 Run `git diff --check`.

--- a/openspec/changes/morphology-public-config-surface/.openspec.yaml
+++ b/openspec/changes/morphology-public-config-surface/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/morphology-public-config-surface/proposal.md
+++ b/openspec/changes/morphology-public-config-surface/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+Morphology stages are product-facing Earth-shape authoring surfaces, but their
+current schemas expose internal step/op envelopes to Studio. That makes normal
+authoring edits validate against implementation details and blocks the intended
+semantic config workflow.
+
+This change gives Morphology explicit flat public schemas and deterministic
+compile functions that produce internal step/op config.
+
+## Target Authority Refs
+
+- Direct user decision: all public config is semantic knobs/stage schema that
+  compiles to internal schemas; raw projection/op config is not public surface.
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`:
+  Target Shape, D1, and stage promotion rule.
+- `mods/mod-swooper-maps/AGENTS.md`: Swooper Maps owns source recipe content;
+  generated outputs are not edited by hand.
+
+## What Changes
+
+- Add explicit public schemas for `morphology-coasts`,
+  `morphology-routing`, `morphology-erosion`, and `morphology-features`.
+- Compile semantic public keys to internal step/op envelopes.
+- Define the target semantic public surface consumed by the shipped-config
+  migration workstream.
+- Preserve existing semantic knobs and first-party tuning values.
+
+## Requires
+
+- `mapgen-public-config-boundary`
+
+## Enables Parallel Work
+
+- `studio-public-config-contract`
+- `migrate-swooper-morphology-public-configs`
+- Later Earthlike balance tuning on a stable authoring surface.
+
+## Forbidden Non-Goals
+
+- No `advanced` wrapper.
+- No dual persisted morphology shapes.
+- No raw `{ strategy, config }` envelopes in Morphology public config.
+- No change to Morphology stage topology or runtime physics in this slice.
+
+## Verification Gates
+
+- `bun test mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts mods/mod-swooper-maps/test/m11-config-knobs-and-presets.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate morphology-public-config-surface --strict`
+- `git diff --check`

--- a/openspec/changes/morphology-public-config-surface/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/morphology-public-config-surface/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Morphology Public Config Is Semantic And Flat
+
+The standard Swooper Morphology stages SHALL expose flat product-facing public
+config keys and SHALL compile those keys into internal step/op envelopes before
+execution.
+
+#### Scenario: Morphology schema is generated
+- **WHEN** the standard recipe config schema is derived
+- **THEN** `morphology-coasts`, `morphology-routing`,
+  `morphology-erosion`, and `morphology-features` expose `knobs` plus
+  semantic public keys
+- **AND** those public stage schemas do not expose raw op-envelope
+  `strategy/config` selectors
+
+#### Scenario: Morphology config is compiled
+- **WHEN** a shipped map config supplies Morphology public config
+- **THEN** recipe compilation emits declared Morphology step ids with default
+  op envelopes for runtime execution
+- **AND** omitted public keys are defaulted by the compiler rather than
+  persisted as hidden internal config
+
+### Requirement: Shipped Morphology Configs Use Only The Public Surface
+
+First-party shipped map configs SHALL persist Morphology config only through the
+public Morphology authoring surface.
+
+#### Scenario: Shipped map configs are validated
+- **WHEN** shipped Swooper map configs are validated against the standard recipe
+  schema
+- **THEN** Morphology stages contain semantic public keys
+- **AND** raw internal step ids and op envelopes are absent from persisted
+  Morphology config

--- a/openspec/changes/morphology-public-config-surface/tasks.md
+++ b/openspec/changes/morphology-public-config-surface/tasks.md
@@ -1,0 +1,19 @@
+## 1. Specification
+
+- [x] 1.1 Record Morphology public config surface requirements.
+
+## 2. Implementation
+
+- [x] 2.1 Promote Morphology public config schemas through the domain config
+  surface.
+- [x] 2.2 Add explicit `public + compile` surfaces for Morphology stages.
+- [x] 2.3 Verify public schemas accept the shipped-config migration output.
+- [x] 2.4 Update tests to prove public shape and compiled internal shape without
+  asserting mutable product tuning values.
+
+## 3. Verification
+
+- [x] 3.1 Run focused shipped-config and Morphology config tests.
+- [x] 3.2 Run the Swooper Maps check gate.
+- [x] 3.3 Run OpenSpec validation for this change.
+- [x] 3.4 Run `git diff --check`.

--- a/openspec/changes/normalize-swooper-map-config-generation/design.md
+++ b/openspec/changes/normalize-swooper-map-config-generation/design.md
@@ -201,6 +201,34 @@ implementations are a local dev-server write API or the browser File System
 Access API. A browser-only app silently writing repo paths is not a valid
 design because the browser cannot reliably do that.
 
+### FireTuner Restart Is A CLI-Owned Operation
+
+The append-only bridge log remains the protocol boundary with Windows-side
+FireTuner automation, but repo code should not duplicate request formatting in
+each caller. The CLI owns the Mac-side operation:
+
+```text
+civ7 game restart --agent <agent> [--bridge-log <path>] [--request-id <id>] [--wait] [--json]
+```
+
+The command appends exactly one bridge request:
+
+```text
+REQ <id> AGENT=<agent> RUN Network.restartGame()
+```
+
+It resolves the bridge log from `--bridge-log`, then
+`CIV7_FIRETUNER_BRIDGE_LOG`, then the Parallels shared-folder default. The
+Windows bridge remains responsible for focusing FireTuner, submitting the
+command, and writing `ACK`, `RESULT`, or `BLOCKED`. Civ7 logs remain the proof
+boundary for actual game reload behavior.
+
+Studio's dev-server save API calls this command after a successful deploy and
+uses `--wait --json` so a successful save can distinguish "restart request was
+submitted by Windows" from "restart request was only appended." Manual agent
+work uses the same command instead of hand-writing log lines, while the
+append-only log format remains supported for emergency/manual use.
+
 ## Migration Sequence
 
 1. Add the canonical envelope schema and validation helpers.
@@ -209,9 +237,11 @@ design because the browser cannot reliably do that.
 4. Add the map registry generator and generated entry-module/tsup integration.
 5. Generate or regenerate XML/modinfo/text/Studio catalog from the registry.
 6. Rewire Studio around repo-backed configs and explicit scratch state.
-7. Delete obsolete TS wrappers, shipped `.config.ts` files, duplicate Studio
+7. Add the CLI FireTuner restart command and route Studio save/deploy/restart
+   through it.
+8. Delete obsolete TS wrappers, shipped `.config.ts` files, duplicate Studio
    preset payloads, and stale `advanced` compatibility.
-8. Promote docs/tests so future shipped maps follow the JSON-only path.
+9. Promote docs/tests so future shipped maps follow the JSON-only path.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/normalize-swooper-map-config-generation/implementation.md
+++ b/openspec/changes/normalize-swooper-map-config-generation/implementation.md
@@ -20,8 +20,12 @@ Implemented:
 - `tsup` map bundle entries now come from generated entry modules.
 - Studio loads shipped maps as Configs, keeps local storage as Scratch, and uses
   a Vite dev-server write API for repo-backed Save and Save As. Successful
-  repo-backed saves run the Swooper Maps deploy script and append a named
-  FireTuner restart request for the running Civ7 session.
+  repo-backed saves run the Swooper Maps deploy script and then call
+  `civ7 game restart` to append and wait for a named FireTuner restart request
+  for the running Civ7 session.
+- Manual FireTuner restart requests are now available through
+  `bun run --filter @mateicanavra/civ7-cli dev -- game restart --agent <agent>`
+  while preserving the existing append-only bridge log protocol.
 - Legacy shipped TS map wrappers, shipped `.config.ts` files, duplicate standard
   built-in preset JSON, and legacy Studio `advanced` focus compatibility mapping
   were removed.
@@ -35,13 +39,17 @@ Local evidence:
 - `bun run --cwd mods/mod-swooper-maps build:studio-recipes`
 - `bun run --cwd mods/mod-swooper-maps build`
 - `bunx vitest run apps/mapgen-studio/test/presets/presetStore.test.ts apps/mapgen-studio/test/presets/importFlow.test.ts apps/mapgen-studio/test/config/defaultConfigSchema.test.ts`
+- `bun run --filter @mateicanavra/civ7-cli test -- test/utils/firetunerBridge.test.ts test/commands/game.restart.test.ts`
+- `bun run --filter @mateicanavra/civ7-cli check`
+- `bun run --filter @mateicanavra/civ7-cli build`
+- `bun run --cwd packages/cli dev -- game restart --agent Codex --dry-run --json`
 - `bun run --cwd apps/mapgen-studio build`
 - `bun run --cwd mods/mod-swooper-maps deploy`
 - Studio save API smoke against
   `mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json`
   returned `200`, ran `bun run --cwd mods/mod-swooper-maps deploy`, and
-  appended FireTuner restart requests including `studio-mpswts66-sgg` and
-  `studio-mpsx0njo-sgg`.
+  appended FireTuner restart requests including `studio-mpswts66-sgg`,
+  `studio-mpsx0njo-sgg`, and `studio-mptc5eme-f7e`.
 
 Runtime evidence:
 
@@ -74,6 +82,20 @@ Runtime evidence:
   was acknowledged and submitted at `2026-05-30T18:30:37`; Civ7 logs then
   showed fresh Swooper generation at `2026-05-30 18:31:29`, completing
   `[50/50] ok mod-swooper-maps.standard.placement.placement`.
+- CLI restart proof
+  `REQ codex-cli-wait-complete-1780205200 AGENT=Codex RUN Network.restartGame()`
+  returned `ok: true` after the bridge wrote `WINDOWS_SUBMITTED_AT
+  2026-05-31T01:22:57`.
+- Studio save API proof against
+  `mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json`
+  returned `200` after deploy and `civ7 game restart --wait --json`; the bridge
+  submitted
+  `REQ studio-mptc5eme-f7e AGENT=DRA-map-config-generation RUN Network.restartGame()`
+  with `WINDOWS_SUBMITTED_AT 2026-05-31T01:24:58`.
+- Deployed mod artifacts under
+  `~/Library/Application Support/Civilization VII/Mods/mod-swooper-maps/`
+  had fresh `2026-05-31 01:24:53` to `2026-05-31 01:24:55` mtimes after the
+  Studio save API smoke.
 
 Scoped caveat:
 
@@ -85,3 +107,7 @@ Scoped caveat:
   `~/Parallels Tunnel/Sid Meier's Civilization VII Development Tools/Comms/`;
   the stale `/Volumes/[C] Windows 11` SMB mount entry is not the authoritative
   access path for this environment.
+- The `2026-05-31 01:24` Studio save smoke proves source save, build/deploy,
+  deployed file mtimes, and Windows FireTuner bridge submission. It does not add
+  a new fresh `Scripting.log` MapGeneration proof beyond the earlier runtime
+  evidence recorded above.

--- a/openspec/changes/normalize-swooper-map-config-generation/proposal.md
+++ b/openspec/changes/normalize-swooper-map-config-generation/proposal.md
@@ -51,6 +51,9 @@ that directory.
 - Rework Studio's save model so repo-backed configs can be loaded, edited,
   saved in place, and saved as sibling config files; browser-local storage is
   either removed or clearly demoted to scratch state.
+- Provide a repo CLI command for the FireTuner restart bridge so Studio saves
+  and manual agent restarts use one request format, one AGENT attribution path,
+  and one optional wait-for-Windows-result implementation.
 - Remove duplicate built-in preset payloads and stale `advanced` compatibility
   logic that only exists for obsolete persisted config shapes.
 

--- a/openspec/changes/normalize-swooper-map-config-generation/tasks.md
+++ b/openspec/changes/normalize-swooper-map-config-generation/tasks.md
@@ -60,6 +60,9 @@
   with no shipped-map authority.
 - [x] 5.6 Keep export/import as optional interchange actions, not primary
   source persistence.
+- [x] 5.7 Route repo-backed save restarts through the reusable
+  `civ7 game restart` command instead of duplicating FireTuner bridge append
+  logic in Studio.
 
 ## 6. Deletion And Realignment
 
@@ -88,3 +91,5 @@
   `bun run openspec -- validate normalize-swooper-map-config-generation --strict`.
 - [x] 7.8 Run `bun run openspec:validate`.
 - [x] 7.9 Run `git diff --check`.
+- [x] 7.10 Run focused CLI restart command tests and a `--dry-run` command
+  smoke before collecting live FireTuner bridge evidence.

--- a/openspec/changes/studio-public-config-contract/.openspec.yaml
+++ b/openspec/changes/studio-public-config-contract/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-30
+status: draft

--- a/openspec/changes/studio-public-config-contract/proposal.md
+++ b/openspec/changes/studio-public-config-contract/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+MapGen Studio renders and saves the recipe config schema it receives from the
+recipe artifacts. Once Morphology exposes a real public surface, Studio must be
+verified against that public contract so the UI cannot regress to raw internal
+step/op envelopes.
+
+## Target Authority Refs
+
+- Direct user decision: Studio edits semantic public authoring config, not
+  internal op/projection schemas.
+- `openspec/specs/mapgen-normalization-workstreams/spec.md`: Studio contract
+  source is explicit.
+- `openspec/changes/morphology-public-config-surface`: Morphology public schema
+  owner.
+
+## What Changes
+
+- Add Studio-facing contract coverage proving generated standard recipe
+  artifacts expose Morphology public keys and hide raw op-envelope selectors.
+- Keep Studio as a schema consumer; the recipe/core layers own the public schema.
+
+## Requires
+
+- `mapgen-public-config-boundary`
+- `morphology-public-config-surface`
+
+## Enables Parallel Work
+
+- Studio-based Morphology and Earthlike tuning through repo-backed configs.
+
+## Forbidden Non-Goals
+
+- No UI-only filtering of internal schemas.
+- No browser-local shipped-map authority.
+- No raw Morphology op envelopes in Studio default or repo-backed config saves.
+
+## Verification Gates
+
+- `bun test apps/mapgen-studio/test/config/defaultConfigSchema.test.ts`
+- `bun run --cwd mods/mod-swooper-maps build:studio-recipes`
+- `bun run --cwd apps/mapgen-studio build`
+- `bun run openspec -- validate studio-public-config-contract --strict`
+- `git diff --check`

--- a/openspec/changes/studio-public-config-contract/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/studio-public-config-contract/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Studio Consumes Morphology Public Schema
+
+MapGen Studio SHALL render and validate Morphology authoring config from the
+standard recipe public schema, not from raw internal step/op schemas.
+
+#### Scenario: Studio standard recipe artifacts are generated
+- **WHEN** Studio loads the standard Swooper recipe config schema
+- **THEN** Morphology stages expose semantic public keys suitable for authoring
+- **AND** hidden internal Morphology step ids and op-envelope selectors are not
+  present in the Studio schema surface
+
+#### Scenario: Studio default config is validated
+- **WHEN** the Studio default/repo-backed config is validated
+- **THEN** Morphology config validates through the public schema
+- **AND** recipe compilation remains responsible for producing internal step/op
+  config

--- a/openspec/changes/studio-public-config-contract/tasks.md
+++ b/openspec/changes/studio-public-config-contract/tasks.md
@@ -1,0 +1,17 @@
+## 1. Specification
+
+- [x] 1.1 Record the Studio Morphology public-schema contract.
+
+## 2. Implementation
+
+- [x] 2.1 Add Studio config-schema coverage for Morphology public keys and
+  hidden internal op envelopes.
+- [x] 2.2 Regenerate Studio recipe artifacts after Morphology schema migration.
+
+## 3. Verification
+
+- [x] 3.1 Run focused Studio config schema tests.
+- [x] 3.2 Run Studio recipe artifact generation.
+- [x] 3.3 Run Studio build.
+- [x] 3.4 Run OpenSpec validation for this change.
+- [x] 3.5 Run `git diff --check`.

--- a/openspec/changes/studio-runtime-step-navigation/.openspec.yaml
+++ b/openspec/changes/studio-runtime-step-navigation/.openspec.yaml
@@ -1,0 +1,1 @@
+status: implemented

--- a/openspec/changes/studio-runtime-step-navigation/proposal.md
+++ b/openspec/changes/studio-runtime-step-navigation/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+Studio uses generated recipe `uiMeta` for stage and step navigation before and
+during browser runs. A public config surface change must not remove runtime
+pipeline steps from that navigation surface.
+
+The Morphology public config fix exposed a boundary error: the Studio artifact
+generator filtered `uiMeta.steps` through public schema property names. Semantic
+public keys such as `mountainRanges` and `islandChains` stopped matching runtime
+step IDs such as `mountains` and `islands`, so Studio hid valid visualization
+steps.
+
+## Target Authority Refs
+
+- Direct user decision: public config is semantic authoring input; runtime
+  projection, step, and visualization machinery are internal execution surfaces.
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`:
+  stage topology is recipe-owned runtime architecture.
+- `docs/system/ADR.md`: Studio visualization state is owned by the runtime
+  manifest and ingested events, not config editor schema.
+
+## What Changes
+
+- Add a dedicated SDK stage authoring model that separates public authoring
+  config from runtime step navigation metadata.
+- Treat generated Studio `uiMeta.stages[].steps` as runtime/navigation metadata
+  derived from that SDK model rather than public schema property names.
+- Keep config-focus paths as editor hints only; they may point at a public key
+  when there is an exact public property match, or at the stage root otherwise.
+- Make Studio recipe preflight refresh stale generated artifacts instead of
+  accepting any existing artifact set as current.
+- Add tests proving Morphology runtime steps remain visible in Studio artifacts
+  while the public authoring schema remains semantic.
+
+## Requires
+
+- `mapgen-public-config-boundary`
+- `morphology-public-config-surface`
+- `studio-public-config-contract`
+
+## Forbidden Non-Goals
+
+- Do not reintroduce raw internal step/op envelope keys into public config.
+- Do not couple runtime step visibility to public schema property names.
+- Do not make Studio infer SDK authoring-layer boundaries locally.
+- Do not add one-off mutable config value assertions as proof.
+
+## Verification Gates
+
+- `bun test apps/mapgen-studio/test/config/defaultConfigSchema.test.ts`
+- `bun run --cwd mods/mod-swooper-maps build:studio-recipes`
+- `bun run --cwd apps/mapgen-studio build`
+- `bun run openspec -- validate studio-runtime-step-navigation --strict`
+- `git diff --check`

--- a/openspec/changes/studio-runtime-step-navigation/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/studio-runtime-step-navigation/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Stages Publish Separate SDK Authoring Layers
+
+SDK-authored stages MUST publish separate authoring metadata for public config
+schema and runtime step navigation.
+
+#### Scenario: A stage has semantic public config
+
+- **GIVEN** a stage declares executable steps
+- **AND** it exposes a semantic public authoring schema
+- **WHEN** consumers inspect the stage authoring model
+- **THEN** the config layer identifies the semantic public schema
+- **AND** the runtime layer lists declared executable step ids independently
+- **AND** editor/config focus hints are not stored on runtime step entries.
+
+### Requirement: Studio Runtime Step Navigation Is Independent Of Public Config Keys
+
+Generated Studio recipe metadata MUST include declared runtime steps for stage
+and step navigation independently of public authoring schema property names.
+
+#### Scenario: Semantic public keys differ from runtime step ids
+
+- **GIVEN** a stage declares runtime steps `islands`, `mountains`, `volcanoes`,
+  and `landmasses`
+- **AND** its public authoring schema exposes semantic keys such as
+  `islandChains`, `mountainRanges`, and `volcanoes`
+- **WHEN** Studio recipe artifacts are generated
+- **THEN** `uiMeta.stages[].steps` includes all declared runtime steps
+- **AND** public config defaults and schema do not expose raw internal step/op
+  envelope keys.
+
+### Requirement: Config Focus Paths Are Editor Hints Only
+
+Generated Studio config-focus paths MUST NOT decide whether a runtime step is
+available for navigation or visualization.
+
+#### Scenario: A runtime step has no exact public authoring key
+
+- **GIVEN** a runtime step whose id does not exactly match a public schema
+  property
+- **WHEN** Studio recipe artifacts are generated
+- **THEN** the step remains present in `uiMeta.stages[].steps`
+- **AND** its config-focus path may be the stage root
+- **AND** default public config remains valid against the public authoring
+  schema.
+
+#### Scenario: A public authoring key has no runtime step
+
+- **GIVEN** a public schema property that does not correspond to a declared
+  executable step
+- **WHEN** Studio recipe artifacts are generated
+- **THEN** that public property does not create a Studio runtime step.
+
+### Requirement: Manifest And Diagnostic Surfaces Do Not Derive From Authoring Keys
+
+Studio layer navigation and world diagnostics MUST derive from runtime
+manifest/events, artifacts, compiled config, or diagnostics outputs, not editor
+schema property names or default config skeletons.
+
+#### Scenario: Studio displays layers for a browser run
+
+- **GIVEN** a browser run emits manifest step and layer events
+- **WHEN** Studio builds layer navigation
+- **THEN** available layers are derived from the runtime manifest/events
+- **AND** public authoring config keys do not add, remove, or rename layers.
+
+#### Scenario: world diagnostics inspect generated outcomes
+
+- **GIVEN** diagnostics or balance gates inspect generated world products
+- **WHEN** they evaluate morphology, projection, or ecology outcomes
+- **THEN** they consume runtime artifacts, compiled config, manifest/events, or
+  explicit diagnostic outputs
+- **AND** they do not infer product truth from Studio editor schema/default
+  skeletons.
+
+### Requirement: Studio Recipe Preflight Refreshes Stale Generated Artifacts
+
+Studio preflight MUST NOT treat existing generated recipe artifacts as current
+when source inputs or SDK distribution files are newer than those artifacts.
+
+#### Scenario: recipe source changes after artifacts were generated
+
+- **GIVEN** Studio recipe artifacts already exist
+- **AND** a recipe source, artifact generator, recipe package config, or consumed
+  SDK distribution file is newer than at least one generated artifact
+- **WHEN** Studio preflight runs
+- **THEN** it rebuilds Studio recipe artifacts before Studio consumes them.
+
+#### Scenario: consumed SDK source is newer than SDK distribution files
+
+- **GIVEN** the local SDK source is newer than the local SDK distribution output
+- **WHEN** Studio preflight runs
+- **THEN** it fails with an actionable build instruction instead of consuming
+  stale generated recipe artifacts.

--- a/openspec/changes/studio-runtime-step-navigation/tasks.md
+++ b/openspec/changes/studio-runtime-step-navigation/tasks.md
@@ -1,0 +1,19 @@
+## 1. Specification
+
+- [x] 1.1 Record Studio runtime step navigation boundary requirements.
+
+## 2. Implementation
+
+- [x] 2.1 Decouple generated `uiMeta.steps` from public schema property names.
+- [x] 2.2 Preserve config-focus paths as editor hints without adding internal
+  keys to default public config.
+- [x] 2.3 Refresh stale Studio recipe artifacts during Studio preflight.
+- [x] 2.4 Regenerate Studio recipe artifacts.
+
+## 3. Verification
+
+- [x] 3.1 Add/adjust tests for Morphology Studio step visibility and semantic
+  public config separation.
+- [x] 3.2 Run the focused Studio artifact test.
+- [x] 3.3 Run Studio recipe generation and app build gates.
+- [x] 3.4 Run OpenSpec validation and `git diff --check`.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -53,6 +53,10 @@ This document orients AI agents and contributors to the `@civ7-modding/cli` pack
   - Flags: `--config`
   - Example: `civ7 data unzip default ./resources.zip ./resources`
 
+- **game restart**: Request a fresh Civ7 restart through the FireTuner bridge.
+  - Flags: `--agent`, `--bridge-log`, `--request-id`, `--wait`, `--timeout-ms`, `--json`, `--dry-run`
+  - Example: `civ7 game restart --agent Codex --wait`
+
 Tip: All commands support `--help` via oclif.
 Status-style commands (e.g., `git status`, `mod status`) also accept `--json` for machine-readable output.
 
@@ -99,7 +103,7 @@ Status-style commands (e.g., `git status`, `mod status`) also accept `--json` fo
 ### Code structure (key paths)
 
  - `src/base/` & `src/base/subtree/` — abstract oclif commands for git subtree flows (configure, import, push, pull, setup). Domain commands extend these to supply prefixes and defaults.
- - `src/commands/` — oclif commands grouped by topic: `data/` (crawl, explore, render, slice, zip, unzip), `docs/`, `git/subtree/` for git subtree helpers, and `mod/` (`git/` hosts subtree operations like `clear`, `list`, `remove`, `update`, `setup`, `import`, `pull`, `push`, `status` with aliases `link:*`, and `manage/` for local utilities)
+ - `src/commands/` — oclif commands grouped by topic: `data/` (crawl, explore, render, slice, zip, unzip), `docs/`, `game/` (running-session helpers such as FireTuner restart requests), `git/subtree/` for git subtree helpers, and `mod/` (`git/` hosts subtree operations like `clear`, `list`, `remove`, `update`, `setup`, `import`, `pull`, `push`, `status` with aliases `link:*`, and `manage/` for local utilities)
  - `src/utils/` — config/path resolution helpers; generic git helpers (configureRemote, importSubtree, pushSubtree, pullSubtree, logRemotePushConfig, findRemoteNameForSlug/requireRemoteNameForSlug, resolveBranch/requireBranch, isNonEmptyDir) live in `utils/git.ts` and centralize logging, argument defaults, and remote/branch inference for git operations
  - Subtree command classes expose only the flags they consume; `repoUrl` is required only for `update`, `import`, and `setup` flows, while `push`/`pull` rely on saved config.
  - `repoUrl` or missing `slug` values may be provided interactively when running subtree commands; a `prerun` hook prompts for them in a TTY if omitted.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -74,6 +74,9 @@
       "git:subtree": {
         "description": "Configure remotes, import repos, pull, push, setup and view status via git subtree"
       },
+      "game": {
+        "description": "Operate a running Civilization VII session through local tooling"
+      },
       "mod": {
         "description": "Manage Civilization VII mods"
       },

--- a/packages/cli/src/commands/game/restart.ts
+++ b/packages/cli/src/commands/game/restart.ts
@@ -1,0 +1,113 @@
+import { Command, Flags } from '@oclif/core';
+import {
+  FIRETUNER_RESTART_COMMAND,
+  appendFireTunerBridgeRequest,
+  defaultFireTunerBridgeLog,
+  formatFireTunerBridgeRequest,
+  waitForFireTunerBridgeResponse,
+} from '../../utils/firetunerBridge';
+
+export default class GameRestart extends Command {
+  static id = 'game restart';
+  static summary = 'Request a Civ7 restart through the FireTuner bridge';
+  static description =
+    'Appends a Network.restartGame() request to the FireTuner bridge log. The Windows-side bridge remains the executor and audit authority.';
+
+  static examples = [
+    '<%= config.bin %> game restart --agent Codex',
+    '<%= config.bin %> game restart --agent DRA-map-config-generation --wait',
+    '<%= config.bin %> game restart --bridge-log ~/Parallels\\ Tunnel/.../civ7-firetuner-bridge.append-only.log',
+  ];
+
+  static flags = {
+    agent: Flags.string({
+      char: 'a',
+      description: 'Agent name written to the bridge request audit fields',
+    }),
+    'request-id': Flags.string({
+      description: 'Explicit bridge request id. Defaults to civ7-restart-<time>-<pid>.',
+    }),
+    'bridge-log': Flags.string({
+      description: 'Override the FireTuner bridge append-only log path',
+      default: defaultFireTunerBridgeLog(),
+    }),
+    wait: Flags.boolean({
+      description: 'Wait for the Windows bridge to append RESULT or BLOCKED for this request',
+      default: false,
+    }),
+    'timeout-ms': Flags.integer({
+      description: 'How long --wait should wait for RESULT or BLOCKED',
+      default: 45_000,
+    }),
+    json: Flags.boolean({
+      description: 'Emit machine-readable JSON',
+      default: false,
+    }),
+    'dry-run': Flags.boolean({
+      description: 'Print the request that would be appended without writing to the bridge log',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(GameRestart);
+    const agent = flags.agent ?? process.env.CIV7_FIRETUNER_AGENT ?? 'Codex';
+    const requestId = flags['request-id'];
+    const logPath = flags['bridge-log'];
+
+    const request = flags['dry-run']
+      ? {
+          requestId: requestId ?? 'civ7-restart-dry-run',
+          agent,
+          command: FIRETUNER_RESTART_COMMAND,
+          logPath,
+          line: formatFireTunerBridgeRequest({
+            requestId: requestId ?? 'civ7-restart-dry-run',
+            agent,
+            command: FIRETUNER_RESTART_COMMAND,
+          }),
+        }
+      : await appendFireTunerBridgeRequest({
+          logPath,
+          requestId,
+          agent,
+          command: FIRETUNER_RESTART_COMMAND,
+        });
+
+    const response =
+      flags.wait && !flags['dry-run']
+        ? await waitForFireTunerBridgeResponse({
+            logPath: request.logPath,
+            requestId: request.requestId,
+            timeoutMs: flags['timeout-ms'],
+          })
+        : undefined;
+
+    if (flags.json) {
+      this.log(
+        JSON.stringify({
+          ok: response?.status === 'blocked' || response === null ? false : true,
+          request,
+          response,
+          timedOut: flags.wait && response === null,
+        })
+      );
+      return;
+    }
+
+    if (flags['dry-run']) {
+      this.log(request.line);
+      return;
+    }
+
+    this.log(`Requested Civ7 restart: ${request.requestId}`);
+    this.log(`Bridge log: ${request.logPath}`);
+    if (response?.status === 'submitted') {
+      this.log(`Windows bridge submitted: ${response.command ?? request.command}`);
+    } else if (response?.status === 'blocked') {
+      this.error(`Windows bridge blocked request: ${response.reason ?? 'unknown reason'}`);
+    } else if (response === null) {
+      this.error(`Timed out waiting for FireTuner bridge response after ${flags['timeout-ms']}ms`);
+    }
+  }
+}

--- a/packages/cli/src/utils/firetunerBridge.ts
+++ b/packages/cli/src/utils/firetunerBridge.ts
@@ -1,0 +1,152 @@
+import { mkdir, readFile, appendFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+
+export const FIRETUNER_RESTART_COMMAND = 'Network.restartGame()';
+
+export type FireTunerBridgeRequest = {
+  requestId: string;
+  agent: string;
+  command: string;
+  logPath: string;
+  line: string;
+};
+
+export type FireTunerBridgeResponse =
+  | {
+      status: 'submitted';
+      requestId: string;
+      agent?: string;
+      command?: string;
+      raw: string;
+    }
+  | {
+      status: 'blocked';
+      requestId: string;
+      agent?: string;
+      reason?: string;
+      raw: string;
+    };
+
+export function defaultFireTunerBridgeLog(): string {
+  return join(
+    homedir(),
+    'Parallels Tunnel',
+    "Sid Meier's Civilization VII Development Tools",
+    'Comms',
+    'civ7-firetuner-bridge.append-only.log',
+  );
+}
+
+export function createFireTunerRequestId(prefix = 'civ7-restart'): string {
+  return `${prefix}-${Date.now().toString(36)}-${process.pid.toString(36)}`;
+}
+
+export function formatFireTunerBridgeRequest(request: {
+  requestId: string;
+  agent: string;
+  command: string;
+}): string {
+  assertBridgeToken('request id', request.requestId);
+  assertBridgeToken('agent', request.agent);
+  const command = request.command.trim();
+  if (!command) throw new Error('FireTuner command must not be empty');
+  return `REQ ${request.requestId} AGENT=${request.agent} RUN ${command}`;
+}
+
+export async function appendFireTunerBridgeRequest(options: {
+  logPath?: string;
+  requestId?: string;
+  requestIdPrefix?: string;
+  agent: string;
+  command?: string;
+}): Promise<FireTunerBridgeRequest> {
+  const logPath = options.logPath ?? process.env.CIV7_FIRETUNER_BRIDGE_LOG ?? defaultFireTunerBridgeLog();
+  const requestId = options.requestId ?? createFireTunerRequestId(options.requestIdPrefix);
+  const command = options.command ?? FIRETUNER_RESTART_COMMAND;
+  const line = formatFireTunerBridgeRequest({ requestId, agent: options.agent, command });
+  await mkdir(dirname(logPath), { recursive: true });
+  await appendFile(logPath, `\n${line}\n`);
+  return {
+    requestId,
+    agent: options.agent,
+    command,
+    logPath,
+    line,
+  };
+}
+
+export async function waitForFireTunerBridgeResponse(options: {
+  logPath: string;
+  requestId: string;
+  timeoutMs: number;
+  pollIntervalMs?: number;
+}): Promise<FireTunerBridgeResponse | null> {
+  const startedAt = Date.now();
+  const pollIntervalMs = options.pollIntervalMs ?? 1_000;
+  while (Date.now() - startedAt <= options.timeoutMs) {
+    const text = await readFile(options.logPath, 'utf8').catch((err: unknown) => {
+      if (isNodeError(err) && err.code === 'ENOENT') return '';
+      throw err;
+    });
+    const response = parseFireTunerBridgeResponse(text, options.requestId);
+    if (response) return response;
+    await sleep(pollIntervalMs);
+  }
+  return null;
+}
+
+export function parseFireTunerBridgeResponse(
+  text: string,
+  requestId: string,
+): FireTunerBridgeResponse | null {
+  const escapedId = escapeRegExp(requestId);
+  const blockPattern = new RegExp(`(?:^|\\n)(RESULT|BLOCKED)[ \\t]+${escapedId}\\b[\\s\\S]*?(?=\\n(?:REQ|ACK|RESULT|BLOCKED)[ \\t]+|$)`, 'gi');
+  let match: RegExpExecArray | null;
+  let latest: FireTunerBridgeResponse | null = null;
+  while ((match = blockPattern.exec(text))) {
+    const raw = match[0].replace(/^\n/, '').trimEnd();
+    if (match[1].toUpperCase() === 'RESULT') {
+      if (!matchField(raw, 'WINDOWS_SUBMITTED_AT')) continue;
+      latest = {
+        status: 'submitted',
+        requestId,
+        agent: matchField(raw, 'AGENT'),
+        command: matchField(raw, 'REQUESTED_COMMAND') ?? matchField(raw, 'CONSOLE_LINE'),
+        raw,
+      };
+    } else {
+      latest = {
+        status: 'blocked',
+        requestId,
+        agent: matchField(raw, 'AGENT'),
+        reason: matchField(raw, 'REASON'),
+        raw,
+      };
+    }
+  }
+  return latest;
+}
+
+function assertBridgeToken(label: string, value: string): void {
+  if (!/^[A-Za-z0-9_.-]+$/.test(value)) {
+    throw new Error(`FireTuner ${label} may only contain letters, numbers, dot, underscore, or dash`);
+  }
+}
+
+function matchField(raw: string, field: string): string | undefined {
+  const re = new RegExp(`(?:^|\\n)${escapeRegExp(field)}[ \\t]+([^\\r\\n]+)`, 'i');
+  return re.exec(raw)?.[1]?.trim();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err !== null && typeof err === 'object' && 'code' in err;
+}

--- a/packages/cli/test/commands/game.restart.test.ts
+++ b/packages/cli/test/commands/game.restart.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+import { mkdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import GameRestart from '../../src/commands/game/restart';
+
+describe('game restart command', () => {
+  test('appends a FireTuner restart request to the requested bridge log', async () => {
+    const dir = join(tmpdir(), `civ7-game-restart-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(dir, { recursive: true });
+    const logPath = join(dir, 'bridge.log');
+
+    await GameRestart.run([
+      '--bridge-log',
+      logPath,
+      '--request-id',
+      'codex-cli-test',
+      '--agent',
+      'Codex',
+      '--json',
+    ]);
+
+    const text = await readFile(logPath, 'utf8');
+    expect(text).toContain('REQ codex-cli-test AGENT=Codex RUN Network.restartGame()');
+  });
+
+  test('dry-run validates and prints without writing', async () => {
+    await expect(
+      GameRestart.run([
+        '--bridge-log',
+        join(tmpdir(), 'civ7-dry-run-bridge.log'),
+        '--request-id',
+        'codex-dry-run',
+        '--agent',
+        'Codex',
+        '--dry-run',
+      ])
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/test/utils/firetunerBridge.test.ts
+++ b/packages/cli/test/utils/firetunerBridge.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'vitest';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  FIRETUNER_RESTART_COMMAND,
+  appendFireTunerBridgeRequest,
+  formatFireTunerBridgeRequest,
+  parseFireTunerBridgeResponse,
+} from '../../src/utils/firetunerBridge';
+
+describe('FireTuner bridge helpers', () => {
+  test('formats restart requests with AGENT attribution', () => {
+    expect(
+      formatFireTunerBridgeRequest({
+        requestId: 'codex-001',
+        agent: 'Codex',
+        command: FIRETUNER_RESTART_COMMAND,
+      })
+    ).toBe('REQ codex-001 AGENT=Codex RUN Network.restartGame()');
+  });
+
+  test('appends a bridge request without editing existing log content', async () => {
+    const dir = join(tmpdir(), `civ7-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(dir, { recursive: true });
+    const logPath = join(dir, 'civ7-firetuner-bridge.append-only.log');
+    await writeFile(logPath, 'REQ old AGENT=Codex RUN console.log("old")\n');
+
+    const request = await appendFireTunerBridgeRequest({
+      logPath,
+      requestId: 'codex-002',
+      agent: 'Codex',
+    });
+
+    const text = await readFile(logPath, 'utf8');
+    expect(request.line).toBe('REQ codex-002 AGENT=Codex RUN Network.restartGame()');
+    expect(text).toContain('REQ old AGENT=Codex RUN console.log("old")');
+    expect(text).toContain('REQ codex-002 AGENT=Codex RUN Network.restartGame()');
+  });
+
+  test('parses Windows RESULT and BLOCKED records for a request id', () => {
+    const submitted = parseFireTunerBridgeResponse(
+      [
+        'REQ codex-003 AGENT=Codex RUN Network.restartGame()',
+        'ACK codex-003 2026-05-31T01:00:00 AGENT=Codex STATUS starting',
+        'RESULT codex-003 2026-05-31T01:00:01',
+        'AGENT Codex',
+        'STATUS submitted',
+        'REQUESTED_COMMAND Network.restartGame()',
+        'CONSOLE_LINE Network.restartGame()',
+        'WINDOWS_ACK_AT 2026-05-31T01:00:00',
+        'WINDOWS_SUBMITTED_AT 2026-05-31T01:00:01',
+      ].join('\n'),
+      'codex-003'
+    );
+    expect(submitted).toMatchObject({
+      status: 'submitted',
+      requestId: 'codex-003',
+      agent: 'Codex',
+      command: 'Network.restartGame()',
+    });
+
+    const blocked = parseFireTunerBridgeResponse(
+      ['BLOCKED codex-004 2026-05-31T01:00:01', 'AGENT unknown', 'REASON FireTuner window not found'].join('\n'),
+      'codex-004'
+    );
+    expect(blocked).toMatchObject({
+      status: 'blocked',
+      requestId: 'codex-004',
+      agent: 'unknown',
+      reason: 'FireTuner window not found',
+    });
+  });
+
+  test('does not treat a partially appended RESULT block as complete', () => {
+    const partial = parseFireTunerBridgeResponse(
+      [
+        'RESULT codex-005 2026-05-31T01:00:01',
+        'AGENT Codex',
+        'STATUS submitted',
+        'REQUESTED_COMMAND Network.restartGame()',
+        'CONSOLE_LINE Network.restartGame()',
+      ].join('\n'),
+      'codex-005'
+    );
+    expect(partial).toBeNull();
+  });
+});

--- a/packages/mapgen-core/src/authoring/index.ts
+++ b/packages/mapgen-core/src/authoring/index.ts
@@ -1,6 +1,6 @@
 export { createStep, createStepFor, defineStep } from "./step/index.js";
 export { defineArtifact, implementArtifacts } from "./artifact/index.js";
-export { createStage } from "./stage.js";
+export { createStage, deriveStageAuthoringModel } from "./stage.js";
 export { createRecipe } from "./recipe.js";
 export { deriveRecipeConfigSchema } from "./recipe-config-schema.js";
 export { stripSchemaMetadataRoot } from "./sanitize-config-root.js";
@@ -53,6 +53,9 @@ export type {
   RecipeModule,
   Stage,
   StageModule,
+  StageAuthoringConfigLayer,
+  StageAuthoringModel,
+  StageAuthoringRuntimeStep,
   StepDeps,
   Step,
   StepModule,

--- a/packages/mapgen-core/src/authoring/recipe-config-schema.ts
+++ b/packages/mapgen-core/src/authoring/recipe-config-schema.ts
@@ -4,9 +4,10 @@ import type { StageContractAny } from "./types.js";
 
 type StageStepLike = Readonly<{ contract: Readonly<{ id: string; schema: TSchema }> }>;
 type StageLike = Pick<StageContractAny, "id" | "surfaceSchema" | "knobsSchema" | "steps"> &
-  Readonly<{ public?: unknown; steps: readonly StageStepLike[] }>;
+  Readonly<{ public?: unknown; authoring?: StageContractAny["authoring"]; steps: readonly StageStepLike[] }>;
 
 function deriveStageSurfaceSchema(stage: StageLike): TObject {
+  if (stage.authoring) return stage.authoring.config.schema;
   if (stage.public) return stage.surfaceSchema;
 
   const props: Record<string, TSchema> = {

--- a/packages/mapgen-core/src/authoring/stage.ts
+++ b/packages/mapgen-core/src/authoring/stage.ts
@@ -4,7 +4,9 @@ import type { ExtendedMapContext } from "@mapgen/core/types.js";
 
 import {
   RESERVED_STAGE_KEY,
+  type StageAuthoringModel,
   type StageContract,
+  type StageContractAny,
   type StageDef,
   type StageToInternalResult,
 } from "./types.js";
@@ -88,6 +90,46 @@ function buildPublicSurfaceSchema(publicSchema: TObject, knobsSchema: TObject): 
   );
 }
 
+function buildStageAuthoringModel(args: {
+  stageId: string;
+  steps: readonly Readonly<{
+    contract: Readonly<{
+      id: string;
+    }>;
+  }>[];
+  surfaceSchema: TObject;
+  publicSchema?: TObject | undefined;
+}): StageAuthoringModel {
+  const publicProps = args.publicSchema ? objectProperties(args.publicSchema) : null;
+  const focusPathsByStepId = Object.fromEntries(
+    args.steps
+      .filter((step) => step.contract.id !== RESERVED_STAGE_KEY)
+      .map((step) => [
+        step.contract.id,
+        publicProps === null
+          ? [step.contract.id]
+          : Object.prototype.hasOwnProperty.call(publicProps, step.contract.id)
+            ? [step.contract.id]
+            : [],
+      ])
+  );
+  return {
+    stageId: args.stageId,
+    config: {
+      layer: args.publicSchema ? "semantic-public-config" : "internal-step-config",
+      schema: args.surfaceSchema,
+      focusPathsByStepId,
+    },
+    runtime: {
+      steps: args.steps
+        .filter((step) => step.contract.id !== RESERVED_STAGE_KEY)
+        .map((step) => ({
+          stepId: step.contract.id,
+        })),
+    },
+  };
+}
+
 type StepsArray<TContext extends ExtendedMapContext> = readonly Readonly<{
   contract: Readonly<{
     id: string;
@@ -142,6 +184,12 @@ export function createStage(def: any): any {
   const surfaceSchema = def.public
     ? buildPublicSurfaceSchema(def.public, def.knobsSchema)
     : buildInternalAsPublicSurfaceSchema(def.steps, def.knobsSchema);
+  const authoring = buildStageAuthoringModel({
+    stageId: def.id,
+    steps: def.steps,
+    surfaceSchema,
+    publicSchema: def.public,
+  });
 
   const toInternal = ({
     env,
@@ -161,5 +209,11 @@ export function createStage(def: any): any {
     return { knobs: resolvedKnobs, rawSteps };
   };
 
-  return { ...(def as any), surfaceSchema, toInternal };
+  return { ...(def as any), surfaceSchema, authoring, toInternal };
+}
+
+export function deriveStageAuthoringModel<TStage extends Pick<StageContractAny, "authoring">>(
+  stage: TStage
+): TStage["authoring"] {
+  return stage.authoring;
 }

--- a/packages/mapgen-core/src/authoring/types.ts
+++ b/packages/mapgen-core/src/authoring/types.ts
@@ -151,6 +151,27 @@ export type StageCompileFn<PublicSchema extends TObject, StepId extends string, 
   config: Static<PublicSchema>;
 }) => Partial<Record<StepId, unknown>>;
 
+export type StageAuthoringConfigLayer = "semantic-public-config" | "internal-step-config";
+
+export type StageAuthoringRuntimeStep<StepId extends string = string> = Readonly<{
+  stepId: StepId;
+}>;
+
+export type StageAuthoringModel<
+  StageId extends string = string,
+  StepId extends string = string,
+> = Readonly<{
+  stageId: StageId;
+  config: Readonly<{
+    layer: StageAuthoringConfigLayer;
+    schema: TObject;
+    focusPathsByStepId: Readonly<Partial<Record<StepId, readonly string[]>>>;
+  }>;
+  runtime: Readonly<{
+    steps: readonly StageAuthoringRuntimeStep<StepId>[];
+  }>;
+}>;
+
 type StageDefBase<
   Id extends string,
   TContext extends ExtendedMapContext,
@@ -209,6 +230,7 @@ export type StageContract<
 > = StageDef<Id, TContext, KnobsSchema, Knobs, TSteps, PublicSchema> &
   Readonly<{
     surfaceSchema: TObject;
+    authoring: StageAuthoringModel<Id, NonReservedStepIdOf<TSteps>>;
     toInternal: (args: { env: unknown; stageConfig: unknown }) => StageToInternalResult<
       NonReservedStepIdOf<TSteps>,
       Knobs

--- a/packages/mapgen-core/src/compiler/recipe-compile.ts
+++ b/packages/mapgen-core/src/compiler/recipe-compile.ts
@@ -58,6 +58,11 @@ export type StageToInternalResult<StepId extends string = string, Knobs = unknow
 export type StageContractAny = Readonly<{
   id: string;
   surfaceSchema: TSchema;
+  authoring?: Readonly<{
+    config: Readonly<{
+      schema: TSchema;
+    }>;
+  }>;
   toInternal: (args: { env: unknown; stageConfig: unknown }) => StageToInternalResult;
   steps: readonly StepModuleAny[];
 }>;
@@ -97,9 +102,10 @@ export function compileRecipeConfig<const TStages extends readonly StageContract
   for (const stage of recipe.stages) {
     const stageId = stage.id;
     const stagePath = `/config/${stageId}`;
+    const configSchema = stage.authoring?.config.schema ?? stage.surfaceSchema;
 
     const { value: stageConfig, errors: stageErrors } = normalizeStrict(
-      stage.surfaceSchema as TSchema,
+      configSchema as TSchema,
       config[stageId],
       stagePath
     );

--- a/packages/mapgen-core/test/authoring/authoring.test.ts
+++ b/packages/mapgen-core/test/authoring/authoring.test.ts
@@ -19,6 +19,7 @@ import {
   defineArtifact,
   defineOp,
   defineStep,
+  deriveRecipeConfigSchema,
   implementArtifacts,
   runtimeOp,
 } from "@mapgen/authoring/index.js";
@@ -189,9 +190,11 @@ describe("authoring SDK", () => {
 
   it("createStage supports public schema with compile mapping", () => {
     const step = createStep(makeContract("alpha"), { run: () => {} });
+    const beta = createStep(makeContract("beta"), { run: () => {} });
     const publicSchema = Type.Object(
       {
         climate: Type.Number(),
+        beta: Type.Object({}, { additionalProperties: false }),
       },
       { additionalProperties: false, default: {} }
     );
@@ -200,15 +203,74 @@ describe("authoring SDK", () => {
       knobsSchema: EmptyKnobsSchema,
       public: publicSchema,
       compile: ({ config }) => ({ alpha: { value: config.climate } }),
-      steps: [step],
+      steps: [step, beta],
     });
     const props = (stage.surfaceSchema as any).properties as Record<string, unknown>;
     expect(props).toHaveProperty("knobs");
     expect(props).toHaveProperty("climate");
     expect(props).not.toHaveProperty("alpha");
+    expect(stage.authoring.config.layer).toBe("semantic-public-config");
+    expect(stage.authoring.config.schema).toBe(stage.surfaceSchema);
+    expect(stage.authoring.config.focusPathsByStepId).toEqual({
+      alpha: [],
+      beta: ["beta"],
+    });
+    expect(stage.authoring.runtime.steps).toEqual([
+      { stepId: "alpha" },
+      { stepId: "beta" },
+    ]);
 
     const internal = stage.toInternal({ env: {}, stageConfig: { knobs: {}, climate: 2 } });
     expect(internal.rawSteps).toEqual({ alpha: { value: 2 } });
+  });
+
+  it("derives recipe schemas from explicit stage public surfaces, not internal op envelopes", () => {
+    const op = defineOp({
+      kind: "compute",
+      id: "test/op/private-envelope",
+      input: Type.Object({}, { additionalProperties: false }),
+      output: Type.Object({}, { additionalProperties: false }),
+      strategies: {
+        default: Type.Object(
+          { internalRate: Type.Number({ default: 1 }) },
+          { additionalProperties: false, default: {} }
+        ),
+      },
+    } as const);
+    const step = createStep(
+      defineStep({
+        id: "internal-step",
+        phase: "foundation",
+        requires: [],
+        provides: [],
+        ops: { privateOp: op },
+        schema: Type.Object({}, { additionalProperties: false }),
+      }),
+      { run: () => {} }
+    );
+    const stage = createStage({
+      id: "foundation",
+      knobsSchema: EmptyKnobsSchema,
+      public: Type.Object(
+        { productRate: Type.Number({ default: 1 }) },
+        { additionalProperties: false, default: {} }
+      ),
+      compile: ({ config }) => ({
+        "internal-step": {
+          privateOp: { strategy: "default", config: { internalRate: config.productRate } },
+        },
+      }),
+      steps: [step],
+    });
+
+    const stageProps = ((deriveRecipeConfigSchema([stage]) as any).properties.foundation as any)
+      .properties as Record<string, unknown>;
+
+    expect(stageProps).toHaveProperty("knobs");
+    expect(stageProps).toHaveProperty("productRate");
+    expect(stageProps).not.toHaveProperty("internal-step");
+    expect(JSON.stringify(stageProps)).not.toContain("privateOp");
+    expect(JSON.stringify(stageProps)).not.toContain("strategy");
   });
 
   it("createStage rejects reserved knobs key in steps or public schema", () => {

--- a/packages/mapgen-core/test/compiler/recipe-compile.test.ts
+++ b/packages/mapgen-core/test/compiler/recipe-compile.test.ts
@@ -97,6 +97,78 @@ describe("compileRecipeConfig", () => {
     });
   });
 
+  it("compiles public stage config into internal step op envelopes", () => {
+    const op = defineOp({
+      kind: "plan",
+      id: "test/public-boundary-op",
+      input: Type.Object({}, { additionalProperties: false }),
+      output: Type.Object({}, { additionalProperties: false }),
+      strategies: {
+        default: Type.Object(
+          { internalRate: Type.Number({ default: 1 }) },
+          { additionalProperties: false, default: {} }
+        ),
+      },
+    } as const);
+
+    const stage = {
+      id: "stage",
+      surfaceSchema: Type.Object(
+        {
+          knobs: Type.Optional(Type.Object({}, { additionalProperties: false, default: {} })),
+          productRate: Type.Optional(Type.Number({ default: 2 })),
+        },
+        { additionalProperties: false, default: {} }
+      ),
+      toInternal: ({ stageConfig }: { stageConfig: { productRate?: number } }) => ({
+        knobs: {},
+        rawSteps: {
+          alpha: {
+            terrain: {
+              strategy: "default",
+              config: { internalRate: stageConfig.productRate ?? 2 },
+            },
+          },
+        },
+      }),
+      steps: [
+        {
+          contract: {
+            id: "alpha",
+            schema: Type.Object(
+              { terrain: op.config },
+              { additionalProperties: false, default: {} }
+            ),
+            ops: { terrain: op },
+          },
+        },
+      ],
+    };
+
+    const result = compileRecipeConfig({
+      env: {},
+      recipe: { stages: [stage] },
+      config: { stage: { productRate: 4 } },
+      compileOpsById: {
+        [op.id]: {
+          id: op.id,
+          normalize: (envelope: unknown) => envelope,
+        } as DomainOpCompileAny,
+      },
+    });
+
+    expect(result).toEqual({
+      stage: {
+        alpha: {
+          terrain: {
+            strategy: "default",
+            config: { internalRate: 4 },
+          },
+        },
+      },
+    });
+  });
+
   it("rejects unknown step ids returned by stage compilation", () => {
     const stage = {
       id: "stage",

--- a/scripts/preflight/ensure-studio-recipe-artifacts.mjs
+++ b/scripts/preflight/ensure-studio-recipe-artifacts.mjs
@@ -1,5 +1,5 @@
-import { existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -31,7 +31,63 @@ const requiredArtifacts = [
 
 const missingArtifacts = requiredArtifacts.filter((rel) => !existsSync(join(repoRoot, rel)));
 
-if (missingArtifacts.length === 0) {
+const artifactSources = [
+  "mods/mod-swooper-maps/src/domain",
+  "mods/mod-swooper-maps/src/maps/configs",
+  "mods/mod-swooper-maps/src/maps/presets",
+  "mods/mod-swooper-maps/src/recipes",
+  "mods/mod-swooper-maps/scripts/generate-map-artifacts.ts",
+  "mods/mod-swooper-maps/scripts/generate-studio-recipe-types.ts",
+  "mods/mod-swooper-maps/package.json",
+  "mods/mod-swooper-maps/tsup.studio-recipes.config.ts",
+  "packages/mapgen-core/dist",
+];
+
+const coreSourceRoots = ["packages/mapgen-core/src"];
+const coreDistRoots = ["packages/mapgen-core/dist"];
+
+function newestMtimeMs(rel) {
+  return newestPathMtimeMs(join(repoRoot, rel));
+}
+
+function newestPathMtimeMs(path) {
+  if (!existsSync(path)) {
+    return 0;
+  }
+
+  const stat = statSync(path);
+  if (!stat.isDirectory()) {
+    return stat.mtimeMs;
+  }
+
+  let newest = stat.mtimeMs;
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === ".git") {
+      continue;
+    }
+    newest = Math.max(newest, newestPathMtimeMs(join(path, entry.name)));
+  }
+  return newest;
+}
+
+function oldestMtimeMs(rels) {
+  return Math.min(...rels.map((rel) => statSync(join(repoRoot, rel)).mtimeMs));
+}
+
+const newestCoreSourceMtime = Math.max(...coreSourceRoots.map(newestMtimeMs));
+const newestCoreDistMtime = Math.max(...coreDistRoots.map(newestMtimeMs));
+if (newestCoreSourceMtime > newestCoreDistMtime) {
+  console.error(
+    "[preflight] @swooper/mapgen-core dist is older than source. Run `bun run --cwd packages/mapgen-core build`, then retry Studio."
+  );
+  process.exit(1);
+}
+
+const artifactsAreStale =
+  missingArtifacts.length === 0 &&
+  Math.max(...artifactSources.map(newestMtimeMs)) > oldestMtimeMs(requiredArtifacts);
+
+if (missingArtifacts.length === 0 && !artifactsAreStale) {
   process.exit(0);
 }
 
@@ -45,6 +101,10 @@ if (!hasTsup) {
     "[preflight] missing dev deps (tsup) for studio recipe artifacts. Run `bun install` at repo root (and/or in mods/mod-swooper-maps if using isolated linking), then retry."
   );
   process.exit(1);
+}
+
+if (artifactsAreStale) {
+  console.log("[preflight] studio recipe artifacts are stale; rebuilding.");
 }
 
 const result = spawnSync("bun", ["run", "build:studio-recipes"], {
@@ -63,4 +123,3 @@ if (stillMissing.length > 0) {
   );
   process.exit(1);
 }
-


### PR DESCRIPTION
This PR introduces a semantic public config surface for Morphology stages, migrates all first-party shipped map configs to that surface, wires the Studio save flow through a new CLI-owned FireTuner restart command, and adds contract tests guarding each boundary.

**Morphology public config surface**

`morphology-coasts`, `morphology-routing`, `morphology-erosion`, and `morphology-features` now declare explicit `public` schemas with semantic authoring keys (`substrate`, `relief`, `waterCoverage`, `continents`, `coastlineShape`, `shelf`, `geomorphicCycle`, `islandChains`, `mountainRanges`, `volcanoes`) and deterministic `compile` functions that lower those keys into internal step/op envelopes at recipe compile time. Raw `{ strategy, config }` op envelopes no longer appear in the public recipe schema or in persisted map configs.

**Shipped config migration**

`shattered-ring`, `sundered-archipelago`, `swooper-desert-mountains`, and `swooper-earthlike` are migrated from the old nested step/op envelope shape to the new flat semantic keys. The `swooper-earthlike` config also receives updated tectonic, mantle, and erosion tuning values.

**SDK authoring model**

`createStage` now builds and attaches a `StageAuthoringModel` that separates the public config layer (schema, focus-path hints per step) from the runtime layer (declared executable step ids). `deriveStageAuthoringModel` is exported from the authoring index. The recipe config schema derivation and the compiler both use `authoring.config.schema` when present so the public surface is authoritative for validation and normalization.

**Studio runtime step navigation**

The Studio artifact generator (`generate-studio-recipe-types.ts`) now derives `uiMeta.stages[].steps` from `authoring.runtime.steps` rather than filtering through public schema property names. This keeps Morphology runtime steps such as `islands`, `mountains`, and `geomorphology` visible in Studio navigation even when their public authoring keys differ.

**FireTuner restart CLI command**

A new `civ7 game restart` command in `packages/cli` owns the Mac-side FireTuner bridge operation. It appends a `REQ … AGENT=… RUN Network.restartGame()` line, optionally waits for a `RESULT` or `BLOCKED` response from the Windows bridge, and emits structured JSON. The Studio dev-server save handler now calls this command via `execFileAsync` with `--wait --json` instead of duplicating bridge-append logic inline. On deploy failure the config file is restored to its previous state before responding.

**Studio save flow**

After a successful scratch-config update the Studio save handler now derives a stable config ID from the preset label, saves the config as a repo-backed file, runs the Swooper Maps deploy script, and calls `civ7 game restart --wait --json`. The preset store is updated and the active preset is switched to the newly saved repo-backed config. Error toasts distinguish save failure, deploy failure, and restart failure.

**Preflight staleness detection**

The `ensure-studio-recipe-artifacts` preflight script now checks whether any artifact source file (recipe source, map configs, generator scripts, `mapgen-core` dist) is newer than the oldest existing artifact and rebuilds if so. It also fails fast with an actionable message when `mapgen-core` source is newer than its dist output.

**Contract tests**

New tests in `packages/mapgen-core`, `mods/mod-swooper-maps`, and `apps/mapgen-studio` assert that Morphology public schemas expose only semantic keys, that compiled output contains internal step/op envelopes, that shipped configs contain no raw op envelopes, and that Studio-generated artifacts reflect Morphology runtime steps independently of public schema property names. The `packages/cli` test suite covers `formatFireTunerBridgeRequest`, `appendFireTunerBridgeRequest`, `parseFireTunerBridgeResponse`, and the `game restart` command including dry-run behavior.