### PR TITLE
feat(mapgen-studio): replace FireTuner bridge log with direct socket transport and Scripting.log verification

### DIFF
--- a/apps/mapgen-studio/vite.config.ts
+++ b/apps/mapgen-studio/vite.config.ts
@@ -1,24 +1,35 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { execFile } from "node:child_process";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
+import {
+  FIRETUNER_RESTART_COMMAND,
+  createFireTunerRequestId,
+} from "../../packages/cli/src/utils/firetunerBridge";
+import {
+  DEFAULT_FIRETUNER_SOCKET_HOST,
+  DEFAULT_FIRETUNER_SOCKET_PORT,
+  DEFAULT_FIRETUNER_SOCKET_TIMEOUT_MS,
+  FIRETUNER_APP_UI_STATE_NAME,
+  runFireTunerSocketCommand,
+} from "../../packages/cli/src/utils/firetunerSocket";
 
 const execFileAsync = promisify(execFile);
 const DEPLOY_TIMEOUT_MS = 120_000;
-const RESTART_TIMEOUT_MS = 60_000;
-const FIRETUNER_WAIT_TIMEOUT_MS = 45_000;
+const SCRIPTING_LOG_WAIT_TIMEOUT_MS = 90_000;
 const MAX_DEPLOY_OUTPUT_CHARS = 8_000;
 const FIRETUNER_AGENT = "DRA-map-config-generation";
-const DEFAULT_FIRETUNER_BRIDGE_LOG = join(
+const DEFAULT_CIV7_SCRIPTING_LOG = join(
   homedir(),
-  "Parallels Tunnel",
-  "Sid Meier's Civilization VII Development Tools",
-  "Comms",
-  "civ7-firetuner-bridge.append-only.log",
+  "Library",
+  "Application Support",
+  "Civilization VII",
+  "Logs",
+  "Scripting.log"
 );
 
 let saveDeployRestartQueue = Promise.resolve();
@@ -26,6 +37,23 @@ let saveDeployRestartQueue = Promise.resolve();
 function tail(value: string): string {
   return value.length > MAX_DEPLOY_OUTPUT_CHARS ? value.slice(-MAX_DEPLOY_OUTPUT_CHARS) : value;
 }
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+type ScriptingLogSnapshot = Readonly<{
+  exists: boolean;
+  size: number;
+  mtimeMs: number;
+}>;
+
+type ScriptingLogProof = Readonly<{
+  logPath: string;
+  observedAt: string;
+  startOffset: number;
+  matched: ReadonlyArray<string>;
+}>;
 
 async function deploySwooperMaps(repoRoot: string): Promise<{
   command: string;
@@ -49,66 +77,146 @@ async function deploySwooperMaps(repoRoot: string): Promise<{
   };
 }
 
-async function requestCiv7Restart(repoRoot: string): Promise<{
+async function snapshotScriptingLog(logPath: string): Promise<ScriptingLogSnapshot> {
+  const info = await stat(logPath).catch((err: unknown) => {
+    if (isNodeNotFound(err)) return null;
+    throw err;
+  });
+  return info
+    ? { exists: true, size: info.size, mtimeMs: info.mtimeMs }
+    : { exists: false, size: 0, mtimeMs: 0 };
+}
+
+function hasFreshMapGenerationProof(text: string): {
+  ok: boolean;
+  matched: string[];
+  error?: string;
+} {
+  const markers = [
+    "Creating Context -  MapGeneration",
+    "[SWOOPER_MOD] [recipe:standard] [50/50] ok mod-swooper-maps.standard.placement.placement",
+    "Destroying Context -  MapGeneration",
+  ];
+  const matched: string[] = [];
+  let cursor = 0;
+  for (const marker of markers) {
+    const next = text.indexOf(marker, cursor);
+    if (next < 0) return { ok: false, matched };
+    matched.push(marker);
+    cursor = next + marker.length;
+  }
+  const errorMatch = /\b(?:TextEncoder|Uncaught|Exception|Error)\b/i.exec(text);
+  if (errorMatch) {
+    return { ok: false, matched, error: `Scripting log contains ${errorMatch[0]}` };
+  }
+  return { ok: true, matched };
+}
+
+async function waitForFreshMapGeneration(args: {
+  logPath: string;
+  snapshot: ScriptingLogSnapshot;
+  timeoutMs: number;
+  pollIntervalMs?: number;
+}): Promise<ScriptingLogProof> {
+  const startedAt = Date.now();
+  const pollIntervalMs = args.pollIntervalMs ?? 1_000;
+  const startOffset = args.snapshot.size;
+  let lastError: string | undefined;
+
+  while (Date.now() - startedAt <= args.timeoutMs) {
+    const current = await snapshotScriptingLog(args.logPath);
+    if (current.exists && (current.size > startOffset || current.mtimeMs > args.snapshot.mtimeMs)) {
+      const fullText = await readFile(args.logPath, "utf8");
+      const newText = current.size >= startOffset ? fullText.slice(startOffset) : fullText;
+      const proof = hasFreshMapGenerationProof(newText);
+      if (proof.error) lastError = proof.error;
+      if (proof.ok) {
+        return {
+          logPath: args.logPath,
+          observedAt: new Date().toISOString(),
+          startOffset,
+          matched: proof.matched,
+        };
+      }
+    }
+    await sleep(pollIntervalMs);
+  }
+
+  throw new Error(
+    lastError ?? "Timed out waiting for fresh Civ7 MapGeneration completion in Scripting.log"
+  );
+}
+
+async function requestCiv7Restart(options?: { verify?: boolean }): Promise<{
   requestId: string;
   agent: string;
   command: string;
-  logPath: string;
-  response?: unknown;
+  transport: "firetuner-socket";
+  host: string;
+  port: number;
+  state: unknown;
+  output: ReadonlyArray<string>;
+  scriptingLog?: ScriptingLogProof;
 }> {
-  const logPath = process.env.CIV7_FIRETUNER_BRIDGE_LOG ?? DEFAULT_FIRETUNER_BRIDGE_LOG;
-  const { stdout } = await execFileAsync(
-    "bun",
-    [
-      "run",
-      "--cwd",
-      "packages/cli",
-      "dev",
-      "--",
-      "game",
-      "restart",
-      "--agent",
-      FIRETUNER_AGENT,
-      "--bridge-log",
-      logPath,
-      "--request-id",
-      `studio-${Date.now().toString(36)}-${process.pid.toString(36)}`,
-      "--wait",
-      "--timeout-ms",
-      String(FIRETUNER_WAIT_TIMEOUT_MS),
-      "--json",
-    ],
-    {
-      cwd: repoRoot,
-      timeout: RESTART_TIMEOUT_MS,
-      maxBuffer: 4 * 1024 * 1024,
-    }
-  );
-  const restart = JSON.parse(stdout.trim().split(/\r?\n/).at(-1) ?? "{}") as {
-    ok?: boolean;
-    request?: {
-      requestId?: string;
-      agent?: string;
-      command?: string;
-      logPath?: string;
-    };
-    response?: unknown;
-    timedOut?: boolean;
-  };
-  if (!restart.ok) {
-    throw new Error(restart.timedOut ? "Timed out waiting for FireTuner bridge response" : "FireTuner bridge blocked restart request");
+  const requestId = createFireTunerRequestId("studio-socket");
+  const host = process.env.CIV7_FIRETUNER_HOST ?? DEFAULT_FIRETUNER_SOCKET_HOST;
+  const port = fireTunerSocketPort();
+  const scriptingLogPath = process.env.CIV7_SCRIPTING_LOG ?? DEFAULT_CIV7_SCRIPTING_LOG;
+  const scriptingSnapshot = options?.verify
+    ? await snapshotScriptingLog(scriptingLogPath)
+    : undefined;
+  const response = await runFireTunerSocketCommand({
+    host,
+    port,
+    stateName: FIRETUNER_APP_UI_STATE_NAME,
+    command: FIRETUNER_RESTART_COMMAND,
+    timeoutMs: DEFAULT_FIRETUNER_SOCKET_TIMEOUT_MS,
+  });
+
+  if (response.output[0] !== "true") {
+    throw new Error(
+      `FireTuner socket restart returned: ${response.output.join("\n") || "<empty>"}`
+    );
   }
+
+  const scriptingLog =
+    options?.verify && scriptingSnapshot
+      ? await waitForFreshMapGeneration({
+          logPath: scriptingLogPath,
+          snapshot: scriptingSnapshot,
+          timeoutMs: SCRIPTING_LOG_WAIT_TIMEOUT_MS,
+        })
+      : undefined;
+
   return {
-    requestId: restart.request?.requestId ?? "",
-    agent: restart.request?.agent ?? FIRETUNER_AGENT,
-    command: restart.request?.command ?? "Network.restartGame()",
-    logPath: restart.request?.logPath ?? logPath,
-    response: restart.response,
+    requestId,
+    agent: FIRETUNER_AGENT,
+    command: FIRETUNER_RESTART_COMMAND,
+    transport: "firetuner-socket",
+    host: response.host,
+    port: response.port,
+    state: response.state,
+    output: response.output,
+    scriptingLog,
   };
 }
 
+function fireTunerSocketPort(): number {
+  if (!process.env.CIV7_FIRETUNER_PORT) return DEFAULT_FIRETUNER_SOCKET_PORT;
+  const port = Number(process.env.CIV7_FIRETUNER_PORT);
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    throw new Error(`Invalid CIV7_FIRETUNER_PORT: ${process.env.CIV7_FIRETUNER_PORT}`);
+  }
+  return port;
+}
+
 function isNodeNotFound(err: unknown): boolean {
-  return Boolean(err) && typeof err === "object" && "code" in err && (err as { code?: unknown }).code === "ENOENT";
+  return (
+    Boolean(err) &&
+    typeof err === "object" &&
+    "code" in err &&
+    (err as { code?: unknown }).code === "ENOENT"
+  );
 }
 
 function assertRepoMapEnvelope(envelope: unknown, id: string): void {
@@ -124,7 +232,8 @@ function assertRepoMapEnvelope(envelope: unknown, id: string): void {
     throw new Error("Map config description must be non-empty");
   }
   if (record.recipe !== "standard") throw new Error('Map config recipe must be "standard"');
-  if (!Number.isInteger(record.sortIndex)) throw new Error("Map config sortIndex must be an integer");
+  if (!Number.isInteger(record.sortIndex))
+    throw new Error("Map config sortIndex must be an integer");
   if (!record.config || typeof record.config !== "object" || Array.isArray(record.config)) {
     throw new Error("Map config payload must be a JSON object");
   }
@@ -153,6 +262,7 @@ export default defineConfig(({ command }) => ({
               id?: unknown;
               sourcePath?: unknown;
               envelope?: unknown;
+              verifyRestart?: unknown;
             };
             if (typeof body.id !== "string" || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(body.id)) {
               throw new Error("Map config id must be kebab-case");
@@ -189,7 +299,7 @@ export default defineConfig(({ command }) => ({
               }
               let restart;
               try {
-                restart = await requestCiv7Restart(repoRoot);
+                restart = await requestCiv7Restart({ verify: body.verifyRestart === true });
               } catch (err) {
                 const error = err instanceof Error ? err.message : "Civ7 restart request failed";
                 res.statusCode = 500;

--- a/packages/cli/src/utils/firetunerSocket.ts
+++ b/packages/cli/src/utils/firetunerSocket.ts
@@ -1,0 +1,193 @@
+import { Socket, createConnection } from 'node:net';
+
+export const DEFAULT_FIRETUNER_SOCKET_HOST = '127.0.0.1';
+export const DEFAULT_FIRETUNER_SOCKET_PORT = 4318;
+export const DEFAULT_FIRETUNER_SOCKET_TIMEOUT_MS = 10_000;
+export const FIRETUNER_APP_UI_STATE_NAME = 'App UI';
+
+export type FireTunerSocketState = Readonly<{
+  id: string;
+  name: string;
+}>;
+
+export type FireTunerSocketCommandResult = Readonly<{
+  host: string;
+  port: number;
+  state: FireTunerSocketState;
+  output: ReadonlyArray<string>;
+}>;
+
+type FireTunerSocketFrame = Readonly<{
+  listenerId: number;
+  parts: ReadonlyArray<string>;
+}>;
+
+let nextListenerId = Math.trunc(Date.now() % 1_000_000);
+
+export async function runFireTunerSocketCommand(options: {
+  command: string;
+  host?: string;
+  port?: number;
+  stateName?: string;
+  timeoutMs?: number;
+}): Promise<FireTunerSocketCommandResult> {
+  const host = options.host ?? process.env.CIV7_FIRETUNER_HOST ?? DEFAULT_FIRETUNER_SOCKET_HOST;
+  const port = options.port ?? fireTunerSocketPortFromEnv() ?? DEFAULT_FIRETUNER_SOCKET_PORT;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_FIRETUNER_SOCKET_TIMEOUT_MS;
+  const socket = await openFireTunerSocket({ host, port, timeoutMs });
+  try {
+    const states = await queryFireTunerSocketStates({ socket, timeoutMs });
+    const stateName = options.stateName ?? FIRETUNER_APP_UI_STATE_NAME;
+    const state = states.find((candidate) => candidate.name === stateName);
+    if (!state) {
+      throw new Error(
+        `FireTuner state "${stateName}" was not available; states: ${states.map((s) => s.name).join(', ')}`
+      );
+    }
+    const output = await sendFireTunerSocketMessage({
+      socket,
+      message: `CMD:${state.id}:${options.command}`,
+      timeoutMs,
+    });
+    return {
+      host,
+      port,
+      state,
+      output: output.parts,
+    };
+  } finally {
+    socket.destroy();
+  }
+}
+
+export async function queryFireTunerSocketStates(options?: {
+  host?: string;
+  port?: number;
+  timeoutMs?: number;
+  socket?: Socket;
+}): Promise<ReadonlyArray<FireTunerSocketState>> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_FIRETUNER_SOCKET_TIMEOUT_MS;
+  const host = options?.host ?? process.env.CIV7_FIRETUNER_HOST ?? DEFAULT_FIRETUNER_SOCKET_HOST;
+  const port = options?.port ?? fireTunerSocketPortFromEnv() ?? DEFAULT_FIRETUNER_SOCKET_PORT;
+  const socket = options?.socket ?? (await openFireTunerSocket({ host, port, timeoutMs }));
+  try {
+    const response = await sendFireTunerSocketMessage({ socket, message: 'LSQ:', timeoutMs });
+    const states: FireTunerSocketState[] = [];
+    for (let i = 0; i + 1 < response.parts.length; i += 2) {
+      states.push({ id: response.parts[i], name: response.parts[i + 1] });
+    }
+    return states;
+  } finally {
+    if (!options?.socket) socket.destroy();
+  }
+}
+
+async function openFireTunerSocket(options: {
+  host: string;
+  port: number;
+  timeoutMs: number;
+}): Promise<Socket> {
+  return await new Promise<Socket>((resolve, reject) => {
+    const socket = createConnection({ host: options.host, port: options.port });
+    const timer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`Timed out connecting to FireTuner socket ${options.host}:${options.port}`));
+    }, options.timeoutMs);
+    socket.once('connect', () => {
+      clearTimeout(timer);
+      resolve(socket);
+    });
+    socket.once('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+async function sendFireTunerSocketMessage(options: {
+  socket: Socket;
+  message: string;
+  timeoutMs: number;
+}): Promise<FireTunerSocketFrame> {
+  const listenerId = allocateListenerId();
+  return await new Promise<FireTunerSocketFrame>((resolve, reject) => {
+    let buffer = Buffer.alloc(0);
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for FireTuner socket response to ${options.message}`));
+    }, options.timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      options.socket.off('data', onData);
+      options.socket.off('error', onError);
+      options.socket.off('close', onClose);
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error(`FireTuner socket closed while waiting for ${options.message}`));
+    };
+    const onData = (chunk: Buffer) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      for (;;) {
+        const parsed = parseFireTunerSocketFrame(buffer);
+        if (!parsed) return;
+        buffer = buffer.subarray(parsed.bytesRead);
+        if (parsed.frame.listenerId === listenerId) {
+          cleanup();
+          resolve(parsed.frame);
+          return;
+        }
+      }
+    };
+    options.socket.on('data', onData);
+    options.socket.once('error', onError);
+    options.socket.once('close', onClose);
+    options.socket.write(encodeFireTunerSocketRequest(listenerId, options.message));
+  });
+}
+
+function encodeFireTunerSocketRequest(listenerId: number, message: string): Buffer {
+  const messageBytes = Buffer.from(`${message}\0`, 'utf8');
+  const frame = Buffer.alloc(8 + messageBytes.length);
+  frame.writeUInt32LE(messageBytes.length, 0);
+  frame.writeUInt32LE(listenerId, 4);
+  messageBytes.copy(frame, 8);
+  return frame;
+}
+
+function parseFireTunerSocketFrame(
+  buffer: Buffer
+): { frame: FireTunerSocketFrame; bytesRead: number } | null {
+  if (buffer.length < 8) return null;
+  const messageLength = buffer.readUInt32LE(0);
+  const bytesRead = 8 + messageLength;
+  if (buffer.length < bytesRead) return null;
+  const listenerId = buffer.readUInt32LE(4);
+  const message = buffer.subarray(8, bytesRead).toString('utf8').replace(/\0$/, '');
+  return {
+    bytesRead,
+    frame: {
+      listenerId,
+      parts: message.length > 0 ? message.split('\0') : [],
+    },
+  };
+}
+
+function allocateListenerId(): number {
+  nextListenerId = (nextListenerId + 1) % 0xffff_ffff;
+  if (nextListenerId <= 0) nextListenerId = 1;
+  return nextListenerId;
+}
+
+function fireTunerSocketPortFromEnv(): number | undefined {
+  if (!process.env.CIV7_FIRETUNER_PORT) return undefined;
+  const port = Number(process.env.CIV7_FIRETUNER_PORT);
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    throw new Error(`Invalid CIV7_FIRETUNER_PORT: ${process.env.CIV7_FIRETUNER_PORT}`);
+  }
+  return port;
+}

--- a/packages/cli/test/utils/firetunerSocket.test.ts
+++ b/packages/cli/test/utils/firetunerSocket.test.ts
@@ -1,0 +1,79 @@
+import { once } from 'node:events';
+import { type AddressInfo, createServer } from 'node:net';
+import { describe, expect, test } from 'vitest';
+import { FIRETUNER_RESTART_COMMAND } from '../../src/utils/firetunerBridge';
+import { runFireTunerSocketCommand } from '../../src/utils/firetunerSocket';
+
+describe('FireTuner socket helpers', () => {
+  test('queries states and sends commands using the FireTuner frame protocol', async () => {
+    const received: string[] = [];
+    const server = createServer((socket) => {
+      let buffer = Buffer.alloc(0);
+      socket.on('data', (chunk) => {
+        buffer = Buffer.concat([buffer, chunk]);
+        for (;;) {
+          const frame = parseRequest(buffer);
+          if (!frame) return;
+          buffer = buffer.subarray(frame.bytesRead);
+          received.push(frame.message);
+          if (frame.message === 'LSQ:') {
+            socket.write(encodeResponse(frame.listenerId, ['65535', 'App UI', '1', 'Tuner']));
+          } else if (frame.message === `CMD:65535:${FIRETUNER_RESTART_COMMAND}`) {
+            socket.write(encodeResponse(frame.listenerId, ['true']));
+          } else {
+            socket.write(encodeResponse(frame.listenerId, ['false']));
+          }
+        }
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const { port } = server.address() as AddressInfo;
+      const result = await runFireTunerSocketCommand({
+        host: '127.0.0.1',
+        port,
+        command: FIRETUNER_RESTART_COMMAND,
+        timeoutMs: 1_000,
+      });
+
+      expect(result).toMatchObject({
+        host: '127.0.0.1',
+        port,
+        state: { id: '65535', name: 'App UI' },
+        output: ['true'],
+      });
+      expect(received).toEqual(['LSQ:', `CMD:65535:${FIRETUNER_RESTART_COMMAND}`]);
+    } finally {
+      server.close();
+      await once(server, 'close');
+    }
+  });
+});
+
+function parseRequest(buffer: Buffer):
+  | {
+      listenerId: number;
+      message: string;
+      bytesRead: number;
+    }
+  | null {
+  if (buffer.length < 8) return null;
+  const messageLength = buffer.readUInt32LE(0);
+  const bytesRead = 8 + messageLength;
+  if (buffer.length < bytesRead) return null;
+  return {
+    listenerId: buffer.readUInt32LE(4),
+    message: buffer.subarray(8, bytesRead).toString('utf8').replace(/\0$/, ''),
+    bytesRead,
+  };
+}
+
+function encodeResponse(listenerId: number, parts: string[]): Buffer {
+  const messageBytes = Buffer.from(`${parts.join('\0')}\0`, 'utf8');
+  const frame = Buffer.alloc(8 + messageBytes.length);
+  frame.writeUInt32LE(messageBytes.length, 0);
+  frame.writeUInt32LE(listenerId, 4);
+  messageBytes.copy(frame, 8);
+  return frame;
+}


### PR DESCRIPTION
Replace the FireTuner bridge log-file transport with a direct TCP socket connection to the FireTuner process.

Previously, `requestCiv7Restart` worked by spawning a CLI subprocess that communicated with Civ7 via an append-only log file (`civ7-firetuner-bridge.append-only.log`) shared through a Parallels Tunnel directory. This approach is replaced with a new `firetunerSocket` utility that speaks the FireTuner binary frame protocol directly over a TCP socket (default `127.0.0.1:4318`).

The new flow:
1. Opens a TCP connection to the FireTuner socket.
2. Sends an `LSQ:` query to enumerate available states and selects the `App UI` state.
3. Sends a `CMD:<stateId>:<command>` message and reads the response.
4. Validates that the response is `true`, otherwise throws with the returned output.

An optional `verify` mode is added to the restart endpoint. When `verifyRestart: true` is passed in the request body, the server snapshots `Scripting.log` before issuing the restart, then polls the log until it observes the full `MapGeneration` lifecycle markers (`Creating Context`, the final placement step, and `Destroying Context`) appearing after the snapshot offset, or times out after 90 seconds. Any scripting errors (`TextEncoder`, `Uncaught`, `Exception`, `Error`) found in the new log content cause an immediate failure.

The `CIV7_FIRETUNER_BRIDGE_LOG` environment variable is replaced by `CIV7_FIRETUNER_HOST`, `CIV7_FIRETUNER_PORT`, and `CIV7_SCRIPTING_LOG`. The default scripting log path points to `~/Library/Application Support/Civilization VII/Logs/Scripting.log`.

A unit test spins up a real TCP server that implements the FireTuner frame protocol and verifies that `runFireTunerSocketCommand` correctly performs the `LSQ:` handshake and dispatches the restart command.