### PR TITLE
docs(direct-control): add capability inventory workstream reports

### DIFF
--- a/docs/projects/civ7-direct-control/workstream/capability-inventory/app-ui-surface-report.md
+++ b/docs/projects/civ7-direct-control/workstream/capability-inventory/app-ui-surface-report.md
@@ -1,0 +1,296 @@
+# App UI Surface Report
+
+Date: 2026-05-31
+Lane: App UI Surface Investigator
+Runtime state inspected: `65535` / `App UI`
+Runtime phase: post-Begin Game, `UI.getGameLoadingState()` = `8` / `GameStarted`
+
+## Summary
+
+`App UI` is a distinct direct-control surface, not a synonym for `Tuner`.
+Current evidence shows `App UI` owns the most useful developer-control API:
+restart/begin flow, loading state, network/session status, autoplay fields and
+mutators, UI status, map reads, player reads, database/catalog reads, and a
+large set of UI/world/debug helpers. `Tuner` remains important as a post-Begin
+gameplay canary, but `Network`, `UI`, `GameContext`, `WorldBuilder`, `WorldUI`,
+and many UI-facing roots are App UI evidence until separately proven elsewhere.
+
+The near-term `@civ7/direct-control` surface should wrap curated read-only App
+UI snapshots and a few explicit game-control commands. Deeper map editing,
+player operations, world UI effects, save/load, multiplayer/account actions, and
+option writes should stay as raw/elevated research commands until each has
+bounded runtime proof and a narrow product contract.
+
+## Sources Searched
+
+Repo/project docs:
+
+- `docs/projects/civ7-direct-control/workstream/capability-inventory/investigation-brief.md`
+- `docs/projects/civ7-direct-control/workstream/capability-inventory/team-plan.md`
+- `docs/projects/civ7-direct-control/workstream/discovery/app-ui-api-inventory.md`
+- `docs/projects/civ7-direct-control/workstream/discovery/tuner-api-inventory.md`
+- `docs/projects/civ7-direct-control/workstream/discovery/runtime-protocol-report.md`
+- `docs/projects/civ7-direct-control/workstream/discovery/public-corpus-report.md`
+- `docs/projects/civ7-direct-control/PROJECT-civ7-direct-control.md`
+- `docs/system/libs/mapgen/reference/STUDIO-INTEGRATION.md`
+- `docs/system/libs/mapgen/reference/OBSERVABILITY.md`
+
+Repo source:
+
+- `packages/civ7-direct-control/src/index.ts`
+- `packages/civ7-direct-control/README.md`
+- `packages/civ7-direct-control/AGENTS.md`
+- `packages/civ7-types/index.d.ts`
+- `packages/civ7-types/AGENTS.md`
+
+Official resources:
+
+- `.civ7/outputs/resources/Base/modules/base-standard/ui-next/screens/pause-menu/pause-menu-bootstrap.js`
+- `.civ7/outputs/resources/Base/modules/base-standard/ui-next/screens/load-screen/load-screen-model.chunk.js`
+- `.civ7/outputs/resources/Base/modules/base-standard/ui/tuner-input/tuner-input.js`
+- `.civ7/outputs/resources/Base/modules/core/ui/utilities/utilities-tuner.js`
+- `.civ7/outputs/resources/Base/modules/base-standard/maps/map-debug-helpers.js`
+- `.civ7/outputs/resources/Base/modules/base-standard/maps/*.js`
+- `.civ7/outputs/resources/Base/modules/base-standard/ui/debug/hud-debug-widgets.chunk.js`
+- `.civ7/outputs/resources/Base/Assets/schema/**`
+
+Commands searched/run:
+
+- `rg --files docs/projects/civ7-direct-control packages/civ7-direct-control packages/civ7-types .civ7/outputs/resources`
+- `rg -n "Network\\.restartGame|Autoplay\\.|UI\\.notifyUIReady|WorldBuilder|MapPlots|MapConstructibles|GameplayMap\\.|MapAreas\\.|MapRegions\\.|WorldUI\\.|Game\\.PlayerOperations|tunerUtilities|g_TunerState|UI\\.Debug" .civ7/outputs/resources -g '*.js' -g '*.xml'`
+- Read-only live App UI probe through `@civ7/direct-control`:
+  `inspectCiv7RuntimeApi({ state: { role: "app-ui" }, roots: [...] })`
+- Read-only live App UI snapshot:
+  `getCiv7AppUiSnapshot({ timeoutMs: 5000 })`
+
+## App UI Global / Root Inventory
+
+Live root inventory from the selected App UI state:
+
+| Root | Status | Useful surface |
+|---|---|---|
+| `Network` | confirmed object | session status, player readiness, restart, save/load, multiplayer/account/chat actions |
+| `Autoplay` | confirmed object | autoplay status and explicit autoplay mutators |
+| `Game` | confirmed object | turn/date/age/hash, manager namespaces, player/unit operation namespaces |
+| `UI` | confirmed object | loading state, shell/game state, option reads/writes, clipboard/cursor/icon/audio/debug helpers |
+| `GameContext` | confirmed object | local player/observer ids, pause/retire/turn-complete requests |
+| `PlayerIds` | confirmed object | `NO_PLAYER`, `WORLD_PLAYER`, `OBSERVER_ID` constants |
+| `Players` | confirmed object | player collections, alive/human/AI predicates, player lookup, some grant mutators |
+| `GameplayMap` | confirmed object | dimensions, seed, plot facts, owner/reveal/area/region/terrain/resource predicates |
+| `GameInfo` | confirmed object | dynamic database table surface; not enumerable by own keys |
+| `Database` | confirmed object | hash, SQL/query/table metadata helpers |
+| `Configuration` | confirmed object | game/player/map/user/debug config access and edit handles |
+| `WorldBuilder` | confirmed object | `MapPlots`, `isActive`, block wrappers; mutation evidence from official tuner UI |
+| `WorldUI` | confirmed object | overlays, sprites, models, VFX, camera, markers, assets, screen/world coordinate helpers |
+| `MapAreas` | confirmed object | area ids, area plots, area info |
+| `MapRegions` | confirmed object | region ids, region plots, region info |
+| `MapUnits` | confirmed object | units at plot/layer |
+| `MapCities` | confirmed object | city/district lookup at plot |
+| `MapConstructibles` | confirmed object | constructible reads plus route/discovery/independent/constructible add/remove commands |
+| `Cities` | confirmed object | city lookup by id/location |
+| `Districts` | confirmed object | district lookup, locations, free constructible lookup |
+| `InterfaceMode` | absent as top-level in live probe | used by official UI modules but not a current App UI global in this probe |
+| `Tuner` | absent as top-level in live probe | FireTuner/client concept, not an App UI root observed here |
+| `Debug` | absent as top-level in live probe | debug widgets are nested under `UI.Debug` |
+
+Nested App UI roots observed or source-evidenced:
+
+- `UI.Player`, `UI.Debug`, `UI.Control`, `UI.Color`
+- `WorldBuilder.MapPlots`
+- `WorldUI.ForegroundCamera`
+- `Game.PlayerOperations`, `Game.UnitOperations`, `Game.UnitCommands`, and
+  other manager namespaces
+- `Players.*` manager namespaces such as `Players.Units`, `Players.Districts`,
+  `Players.Resources`, `Players.Treasury`
+
+## Useful Reads
+
+Wrap-ready read groups:
+
+| Group | Reads | Evidence |
+|---|---|---|
+| App UI status | `UI.isInGame()`, `UI.isInShell()`, `UI.isInLoading()`, `UI.getGameLoadingState()` | live snapshot and direct-control package |
+| Begin readiness | loading states `WaitingForUIReady` / `WaitingToStart`, `typeof UI.notifyUIReady` | direct-control package and load-screen resource |
+| Network/session | `Network.isInSession`, `getNumPlayers()`, `getHostPlayerId()`, `isConnectedToNetwork()`, `isAuthenticated()`, `isLoggedIn()` | live snapshot |
+| Autoplay status | `Autoplay.isActive`, `turns`, `isPaused`, `isPausedOrPending`, `observeAsPlayer`, `returnAsPlayer` | live snapshot |
+| Game summary | `Game.turn`, `Game.age`, `Game.maxTurns`, `Game.getTurnDate()`, `Game.getHash()` | live snapshot |
+| Local context | `GameContext.localPlayerID`, `localObserverID`, `hasRequestedPause()` | live snapshot |
+| Player summary | `Players.getAliveIds()`, `getAliveHumanIds()`, `getNumAliveHumans()`, `isAlive()`, `isHuman()`, `isAI()` | live probe |
+| Map summary | `GameplayMap.getGridWidth()`, `getGridHeight()`, `getPlotCount()`, `getMapSize()`, `getRandomSeed()` | live snapshot |
+| Plot reads | terrain, biome, feature, resource, elevation, rainfall, river, yield, owner, revealed state, tags, area/landmass/region | live probe and official map scripts |
+| Areas/regions | `MapAreas.getAreaIds()`, `getAreaPlots()`, `getAreaInfo()`, `MapRegions.*` equivalents | live probe |
+| City/unit lookup | `MapCities.getCity()`, `MapCities.getDistrict()`, `MapUnits.getUnits()`, `Cities.getAtLocation()`, `Districts.getAtLocation()` | live probe and official tuner UI |
+| Catalog/schema | `Database.getTableNames()`, `getTableData()`, `getPrimaryKeys()`, `Database.makeHash()`, targeted `GameInfo.<Table>` reads | live probe and existing `civ7-types` |
+
+Map-generation development value is highest for map summary, plot facts, area
+and region reads, `GameInfo`/`Database` catalog reads, and fresh post-restart
+status. These let Studio compare browser-run MapGen truth/artifacts to the
+actual loaded Civ7 projection without editing the running game.
+
+## Useful Writes / Commands
+
+Mutation confidence:
+
+| Command family | Examples | Confidence | Notes |
+|---|---|---:|---|
+| Restart current game | `Network.restartGame()` | confirmed | Live prior proof returned `true`; official pause menu calls it. Already wrapped as `restartCiv7Game()`. |
+| Native begin game | `UI.notifyUIReady()` | confirmed | Live prior proof moved App UI to `GameStarted`; official load screen calls it. Already wrapped as `beginCiv7Game()` / restart-and-begin. |
+| Autoplay control | `Autoplay.setTurns`, `setReturnAsPlayer`, `setObserveAsPlayer`, `setActive`, `setPause`, `setAsAI`, `setAsHuman` | plausible | Official/runtime methods exist; official automation scripts use the core setters. Keep explicit and bounded. |
+| Pause/turn/retire requests | `GameContext.sendPauseRequest`, `sendTurnComplete`, `sendUnreadyTurn`, `sendRetireRequest` | plausible | Method names and pause-menu source indicate state changes. Need bounded proof before wrapping. |
+| Map plot edits | `WorldBuilder.MapPlots.setFeature`, `setTerrain`, `setResource`, `setFertility`, `setOwnership`, `setBiome` | plausible | Official tuner input calls them from App UI. Do not wrap until mutation semantics and undo/save boundaries are known. |
+| Constructible edits | `MapConstructibles.addRoute`, `removeRoute`, `addDiscoveryType`, `addIndependentType`, `addConstructible`, `addDiscovery` | plausible | Official tuner input uses route/discovery/independent methods. Needs explicit map-edit contract. |
+| Create/destroy elements | `Game.PlayerOperations.sendRequest(..., "CREATE_ELEMENT" / "DESTROY_ELEMENT", ...)` | plausible | Official tuner input uses units, towns, districts, improvements, buildings, wonders. High blast radius. |
+| City plot purchase | `Cities.get(...).purchasePlot(loc)` | plausible | Official tuner input calls it. Needs live proof and ownership validation. |
+| Player grants | `Players.grantYield`, `grantCultureSlot`, `grantGreatWork`, distance mutators | unknown/plausible | Exposed by runtime names, not probed. |
+| UI options/profile | `UI.setApplicationOption`, `commitApplicationOptions`, `setOption`, `reloadUI`, `refreshInput` | plausible | Clearly mutating; avoid as direct-control convenience wrappers. |
+| Save/load/delete/network/account | `Network.saveGame`, `loadGame`, `deleteGame`, `join*`, `host*`, `sendChat`, `attemptLogin`, URL openers | plausible | Exposed by App UI. Useful for a separate game-control product, not map-generation core. |
+| World UI effects | `WorldUI.createOverlayGroup`, `createSpriteGrid`, `triggerVFXAtPlot`, camera/filter/asset methods | plausible | Useful debug visualization but mutates UI scene. Wrap later only with cleanup/lifetime handles. |
+| Raw SQL | `Database.query(...)` | unknown | Could be read-only with `SELECT`, but safety depends on accepted SQL and database context. Treat as raw/elevated. |
+
+No new mutating live commands were run for this report.
+
+## Map / Studio / Debug Candidates
+
+Map-generation candidates:
+
+- `getMapSummary()` from `GameplayMap` dimensions, plot count, size hash, seed.
+- `getPlotSample(locations | radius | all?)` for terrain, biome, feature,
+  resource, elevation, rainfall, river, owner, revealed state, region, area,
+  landmass, and plot tags.
+- `getAreaRegionSummary()` from `MapAreas`, `MapRegions`, and
+  `GameplayMap.getAreaId/getRegionId/getLandmassId`.
+- `getResourceFeatureBiomeCounts()` as a direct runtime projection comparator
+  against MapGen artifacts and official `map-debug-helpers.js`.
+- `getGameInfoRows(tableNames)` using targeted `GameInfo`/`Database` reads for
+  map-relevant tables.
+
+Studio workflow candidates:
+
+- After deploy/restart/begin, call one App UI read bundle and one Tuner canary:
+  App UI proves UI/session/loading state; Tuner proves gameplay command
+  readiness.
+- Add a Studio "loaded game summary" endpoint backed by App UI reads:
+  seed, dimensions, turn/date, local player, alive players, map size, and
+  high-level counts.
+- Add a projection-compare endpoint later: sample or count the runtime map and
+  compare it to current Studio/MapGen run artifacts. This should remain
+  read-only.
+- Use `Database.getTableNames/getPrimaryKeys/getTableData` or targeted
+  `GameInfo` lookups to populate Studio catalog/debug panels, with provenance
+  labels.
+
+Debug candidates:
+
+- `UI.Debug.registerWidget(...)` is official resource evidence for debug widget
+  support, but direct-control should not become an in-game debug UI product in
+  this slice.
+- Official `map-debug-helpers.js` is a good shape reference for textual map
+  dumps, but direct-control should prefer structured JSON returns over huge
+  console logs.
+- `WorldUI` overlay/sprite/VFX APIs could become excellent visual debug tools,
+  but only after lifecycle cleanup is proven (`releaseMarker`, asset release,
+  overlay group disposal/clear behavior).
+- `tunerUtilities` flattens `GameValue` trees in official resources, but it was
+  not visible as an App UI global in prior direct probes. Treat it as source
+  reference, not a callable root.
+
+## Recommendations
+
+Wrap now:
+
+- Keep `restartCiv7Game()`, `beginCiv7Game()`,
+  `restartCiv7GameAndBegin()`, `getCiv7AppUiSnapshot()`, and
+  `inspectCiv7RuntimeApi()` as the core App UI API.
+- Add typed convenience helpers for read-only summaries:
+  `getCiv7MapSummary()`, `getCiv7PlayerSummary()`,
+  `getCiv7AreaRegionSummary()`, and `getCiv7PlotFacts(...)`.
+- Keep helper names state-explicit where ambiguity matters:
+  `getCiv7AppUiSnapshot`, `checkCiv7TunerHealth`, not generic "runtime health".
+
+Raw command:
+
+- `Database.query`, `Configuration.edit*`, `Game.PlayerOperations.*`,
+  `WorldBuilder.*`, `MapConstructibles.add*/remove*`, `WorldUI.*`,
+  `GameContext.send*`, and `Players.grant*`.
+- Advanced `Network` actions other than restart, especially save/load/delete,
+  account, chat, invite, kick, multiplayer, URL, and legal-document methods.
+- UI option writes and reload/refresh commands.
+
+Research later:
+
+- Bounded autoplay helpers:
+  `setAutoplay({ turns, observeAsPlayer, returnAsPlayer })`,
+  `startAutoplay()`, `stopAutoplay()`, with explicit max-turn caps and a status
+  read before/after.
+- Map edit mode using `WorldBuilder.startBlock/endBlock` and
+  `WorldBuilder.MapPlots.*`, only in a disposable/restarted session.
+- WorldUI debug overlay handles with creation and cleanup proof.
+- Structured runtime catalog generation from `Database`/`GameInfo` plus
+  selected root introspection.
+- Whether `g_TunerState` can be intentionally initialized over direct-control
+  without FireTuner panel injection.
+
+Avoid for this workstream:
+
+- FireTuner clone, in-game command console, or broad autocomplete browser.
+- Any helper that mixes read-only health polling with mutation.
+- Automatic retries/replays for mutating commands.
+- Treating App UI roots as available in Tuner or Tuner roots as available in
+  App UI without fresh state-scoped proof.
+- Broad global dumps in regular CLI/Studio paths; they produce huge payloads
+  and can hide state-specific failures.
+
+## Type-Generation Implications
+
+- Runtime introspection is useful for root/method discovery, not full type
+  signatures. Native methods report `[native code]`, and `function.length` is
+  not reliable enough to generate call contracts.
+- Generated catalog entries should carry provenance:
+  `state` (`App UI`, `Tuner`, unknown), `source` (runtime probe, official
+  resource, repo type, community), `confidence`, and `mutation` classification.
+- Existing `packages/civ7-types/index.d.ts` mostly models map-generation and
+  base runtime globals. It does not yet model the App UI control surface:
+  `Network`, `Autoplay`, full `UI`, `GameContext`, `WorldUI`, `WorldBuilder`,
+  `MapAreas`, `MapRegions`, `MapConstructibles`, `Cities`, `Districts`, or full
+  `Database`.
+- `GameInfo` table names and row types should be generated from official
+  resources and/or `Database.getTableNames/getPrimaryKeys/getTableData`, not
+  from `Object.getOwnPropertyNames(GameInfo)`, because the runtime object is
+  dynamic and its own keys are empty.
+- Recommended type output shape:
+  - type-only package additions in `packages/civ7-types`
+  - generated/provenance catalog data outside the type package, or clearly
+    generated source with a reproducible script
+  - state-scoped namespaces such as `Civ7AppUiRuntime` and
+    `Civ7TunerRuntime` instead of one ambient "everything exists" declaration
+
+## Unknowns And Reframe Triggers
+
+Unknowns:
+
+- Whether App UI root availability changes materially at main menu, before
+  Begin Game, during loading, during age transition, in multiplayer, or after
+  repeated restarts.
+- Whether `WorldBuilder.MapPlots` works safely outside dedicated tuner/world
+  builder modes, and whether `startBlock/endBlock` are required for atomicity.
+- Whether `WorldUI` resources/overlays can be cleaned up reliably from
+  direct-control without leaking visual state.
+- Whether `Database.query` is constrained to reads in this context.
+- Whether `Configuration.edit*` edits only setup state or can affect a live
+  game unpredictably.
+- Whether official tuner panel state (`g_TunerState`) can be injected safely
+  through direct-control, or whether it depends on FireTuner UI/panel wiring.
+
+Reframe triggers:
+
+- Fresh runtime evidence shows `Network.restartGame()` or `UI.notifyUIReady()`
+  moving off App UI or becoming unavailable in a supported lifecycle phase.
+- App UI and Tuner state contents diverge by game version or DLC enough that
+  helper defaults need version gating.
+- Runtime probes show method metadata cannot be made stable enough for useful
+  catalogs.
+- Useful Studio/debug operations require event/input paths outside
+  `CMD:<stateId>:<javascript>`.
+- Any mutating map/player command has persistent side effects that survive
+  restart or corrupt save/session state.
+

--- a/docs/projects/civ7-direct-control/workstream/capability-inventory/automation-playability-report.md
+++ b/docs/projects/civ7-direct-control/workstream/capability-inventory/automation-playability-report.md
@@ -1,0 +1,284 @@
+# Automation Playability Report
+
+Date: 2026-05-31
+Lane: Automation Playability Investigator
+
+## Summary
+
+An LLM or agent can already use `@civ7/direct-control` for useful developer
+automation around a running Civ7 session: health, App UI status, restart,
+Begin Game, post-Begin Tuner readiness, map/player summaries, and bounded raw
+JavaScript probes. That is enough for map/studio iteration and for supervised
+"observe and suggest" gameplay assistance.
+
+Full autonomous play is not currently feasible as a repo-supported capability.
+The direct-control package can execute arbitrary JavaScript in Civ7 scripting
+states, and official resources show plausible gameplay action APIs, but the
+repo has not proven enough stable read models, action schemas, validation
+wrappers, turn/event synchronization, or safety policy to let an agent play
+without frequent human supervision.
+
+The practical target is a small set of safe wrappers: richer read snapshots,
+explicit `canStart` validators, dry-run action planning, bounded autoplay, and
+manual-approval command execution. Avoid broad "AI player" or "cheat console"
+work until action schemas and state transitions are proven.
+
+## Evidence Sources
+
+- `packages/civ7-direct-control/src/index.ts`: canonical direct socket
+  transport, state selection, raw command execution, App UI snapshot,
+  restart/begin loop, and Tuner readiness canary.
+- `packages/civ7-direct-control/README.md` and
+  `packages/civ7-direct-control/test/direct-control.test.ts`: current public
+  package contract and mocked protocol/health behavior.
+- Discovery reports in
+  `docs/projects/civ7-direct-control/workstream/discovery/`, especially
+  `runtime-protocol-report.md`, `app-ui-api-inventory.md`,
+  `tuner-api-inventory.md`, and `public-corpus-report.md`.
+- `packages/civ7-types/index.d.ts`: current ambient runtime type coverage,
+  mostly map-generation and lightweight gameplay globals.
+- Official resources under `.civ7/outputs/resources`, especially:
+  - `Base/modules/base-standard/ui/tuner-input/tuner-input.js`
+  - `Base/modules/base-standard/ui/automation/automation-base-play-game.chunk.js`
+  - `Base/modules/base-standard/ui/automation/automation-test-benchmark-ai.js`
+  - `Base/modules/base-standard/ui/automation/automation-test-production.js`
+  - `Base/modules/base-standard/ui/world-input/world-input.js`
+  - `Base/modules/base-standard/ui/interface-modes/interface-mode-move-to.js`
+  - `Base/modules/base-standard/ui/build-queue/model-build-queue.js`
+  - `Base/modules/base-standard/ui/production-chooser/production-chooser-helpers.chunk.js`
+  - `Base/modules/base-standard/ui-next/screens/pause-menu/pause-menu-bootstrap.js`
+  - `Base/modules/base-standard/data/unit-operations.xml`
+  - `Base/modules/base-standard/data/unit-commands.xml`
+  - `Base/modules/base-standard/data/city-commands.xml`
+
+Commands searched included targeted `rg` passes for `Autoplay`,
+`Game.*Operations`, `sendRequest`, `canStart`, `WorldBuilder`, `MapUnits`,
+`Cities`, `UnitOperationTypes`, `CityOperationTypes`, `PlayerOperationTypes`,
+and turn/end-turn terminology. No live mutating gameplay actions were run for
+this lane.
+
+## Game-Reading Capability Needs
+
+An agent that plays or gives useful turn advice needs a read model much richer
+than the current `getCiv7AppUiSnapshot()`:
+
+| Need | Why it matters | Current evidence |
+|---|---|---|
+| Session/readiness state | Know whether commands are legal and which scripting state to use. | Confirmed. `App UI` handles network/loading; `Tuner` becomes command-ready only after Begin Game. |
+| Turn/player identity | Attribute decisions to the local player and current turn. | Confirmed minimal reads: `Game.turn`, `Game.getTurnDate()`, `GameContext.localPlayerID`, `Players.getAliveIds()`. |
+| Map facts | Evaluate movement, settlement, resources, hazards, and visibility. | Plausible/partly confirmed via `GameplayMap` read methods and `packages/civ7-types`. |
+| Fog/revealed state | Avoid acting on hidden information. | Plausible. `world-input.js` checks `GameplayMap.getRevealedState(...)`; not wrapped. |
+| Units and available actions | Decide moves, attacks, fortify, found city, exploration, promotions. | Plausible. Official UI uses `Units`, `MapUnits`, `Game.UnitOperations.canStart`, and `Game.UnitCommands.canStart`. |
+| Cities, queues, yields, plots | Choose production, purchases, expansion, tile development. | Plausible. Official UI uses `Cities`, `MapCities`, `Game.CityOperations`, `Game.CityCommands`, and build-queue models. |
+| Diplomacy/war state | Avoid accidental declarations and select policy/diplomatic actions. | Plausible but high-risk. `world-input.js` checks war declaration before attacks; diplomacy UI uses `Game.PlayerOperations`. |
+| Notifications/required choices | Detect blocking prompts: golden age, pantheon, policies, research, culture, advanced start, narrative choices. | Plausible. Official UI routes many choices through `PlayerOperationTypes`; not inventoried enough for wrappers. |
+| Action result/execution feedback | Verify that a command changed state, failed, or advanced turn. | Mostly missing. Current package returns raw command output, not game-core operation effects. |
+
+The current direct-control read layer is enough for operational automation and
+small canaries, not enough for autonomous strategic play. The next read wrapper
+should be a structured `getPlayableSnapshot()` that stays read-only and has a
+strict size limit.
+
+## Action Capability Needs
+
+Gameplay control needs two levels of actions: ordinary game commands and
+developer/test automation commands.
+
+| Action family | Required for play? | Observed/plausible API | Current status |
+|---|---:|---|---|
+| Restart/begin | No, but essential for test loops. | `Network.restartGame()`, `UI.notifyUIReady()`. | Confirmed and wrapped. |
+| Bounded autoplay | Useful for AI-vs-AI tests and smoke runs. | `Autoplay.setTurns`, `setReturnAsPlayer`, `setObserveAsPlayer`, `setActive`, `setPause`. | Plausible/observed in official automation; not safely wrapped. |
+| Unit movement/combat | Yes. | `Game.UnitOperations.canStart/sendRequest` with `UNITOPERATION_MOVE_TO`, attack operations, skip/sleep/found city; `Game.UnitCommands.canStart/sendRequest`. | Plausible from official UI; not proven through direct-control. |
+| City production/purchase | Yes. | `Game.CityOperations.canStart/sendRequest(..., CityOperationTypes.BUILD, args)`, `Game.CityCommands.PURCHASE`, build queue mutation args. | Plausible from official UI; not proven through direct-control. |
+| Research/culture/government/policies | Yes for nontrivial play. | `Game.PlayerOperations.canStart/sendRequest` with tree and policy operation types. | Plausible only; schemas fragmented across UI resources. |
+| Diplomacy | Yes, but high-risk. | `Game.PlayerOperations.sendRequest` for war, alliance, diplomacy actions. | Plausible; should require explicit approval. |
+| End turn | Yes. | Likely App UI/engine/UI action path or unresolved game operation. | Not identified as a stable direct API in this lane. |
+| Save/load/exit | Useful for sandboxing. | `Network.saveGame`, `Network.loadGame`, `engine.call("exitToMainMenu")`, `engine.call("exitToDesktop")`. | Plausible/high-risk; not gameplay wrappers. |
+| WorldBuilder/tuner edits | No for fair play; useful for developer tools. | `WorldBuilder.MapPlots.*`, `MapConstructibles.*`, `Game.PlayerOperations` create/destroy element. | Plausible but explicitly developer/cheat surface. |
+
+Action wrappers must be validator-first: expose `canStart`/legal-target reads
+before any `sendRequest`, and treat every `sendRequest`, `Network.*` mutation,
+`Autoplay.set*`, `WorldBuilder.*`, `MapConstructibles.*`, `engine.call`, and
+`GameContext.send*Request` as mutating.
+
+## Observed Direct-Control APIs
+
+Confirmed by repo implementation and discovery reports:
+
+- Transport: TCP tuner socket on port `4318`, `LSQ:` for state discovery,
+  `CMD:<stateId>:<javascript>` for execution, little-endian framed messages.
+- State roles:
+  - `App UI`: command-ready, owns `Network`, `UI`, `GameContext`, `Game`,
+    `Autoplay`, `Players`, and `GameplayMap` in observed runs.
+  - `Tuner`: listed before Begin Game but command-ready only after Begin Game;
+    post-Begin canary sees `Game`, `Autoplay`, `GameplayMap`, and `Players`;
+    `Network` is undefined.
+- Wrapped functions: `queryCiv7TunerStates`, `executeCiv7Command`,
+  `executeCiv7AppUiCommand`, `executeCiv7TunerCommand`,
+  `inspectCiv7RuntimeApi`, `getCiv7AppUiSnapshot`, `beginCiv7Game`,
+  `restartCiv7Game`, `restartCiv7GameAndBegin`,
+  `checkCiv7DirectControlHealth`, and `checkCiv7TunerHealth`.
+- Read-only current snapshot: network/session status, autoplay status fields,
+  turn/date/hash, UI loading state, local player/observer ids, alive players,
+  map dimensions/seed.
+- Restart/begin proof: `Network.restartGame()` returned `true`,
+  `UI.notifyUIReady()` returned `null`, App UI reached `GameStarted`, and a
+  post-Begin Tuner canary passed.
+
+These are enough for "control Civ7 as a developer process" and "observe a
+running session." They do not prove gameplay action safety.
+
+## Plausible Gameplay APIs
+
+Official resource usage makes the following surfaces plausible direct-control
+targets, but they should remain research or explicit raw-command territory until
+the repo verifies them in a disposable session:
+
+- Unit control:
+  - `Game.UnitOperations.canStart(unitID, UnitOperationTypes.MOVE_TO, args, false)`
+  - `Game.UnitOperations.sendRequest(unitID, UnitOperationTypes.MOVE_TO, args)`
+  - Attack variants such as `UNITOPERATION_RANGE_ATTACK`,
+    `UNITOPERATION_AIR_ATTACK`, `UNITOPERATION_NAVAL_ATTACK`
+  - Commands such as `UNITCOMMAND_WAKE`, `UNITCOMMAND_CANCEL`,
+    `UNITCOMMAND_ADD_TO_ARMY`, `UNITCOMMAND_PROMOTE`
+- City control:
+  - `Game.CityOperations.canStart(city.id, CityOperationTypes.BUILD, args, false)`
+  - `Game.CityOperations.sendRequest(city.id, CityOperationTypes.BUILD, args)`
+  - `Game.CityCommands.canStart/sendRequest(..., CityCommandTypes.PURCHASE, args)`
+  - Build queue mutations with `InsertMode`, `QueueSourceLocation`, and
+    `QueueDestinationLocation`
+- Player-level choices:
+  - `Game.PlayerOperations.canStart/sendRequest` for golden ages, tech/culture
+    nodes, policies, religions, diplomacy, resources, advanced start, and other
+    notifications.
+- Developer/tuner world edits:
+  - `WorldBuilder.MapPlots.setFeature/setTerrain/setResource/setFertility/setOwnership/setBiome`
+  - `MapConstructibles.addRoute/removeRoute/addDiscoveryType/addIndependentType`
+  - `Game.PlayerOperations.sendRequest(localPlayerID, "CREATE_ELEMENT" | "DESTROY_ELEMENT", args)`
+
+The official UI code is the best schema lead because native functions expose
+weak signatures. A method name or enum row alone is not enough to call the API
+safely.
+
+## LLM Play Feasibility Tiers
+
+| Tier | Feasibility | What an agent can do | Why |
+|---|---|---|---|
+| 0. Developer status assistant | Ready now | Check listener/states, restart/begin, summarize App UI snapshot, inspect selected roots. | Implemented and tested in `@civ7/direct-control`. |
+| 1. Map/studio automation assistant | Ready/near-term | Restart mapgen loops, wait for Tuner readiness, collect map/player/map-summary canaries, run bounded raw reads. | Existing package plus prior reports already support this lane. |
+| 2. Supervised gameplay advisor | Feasible with read wrappers | Read map, units, cities, queues, notifications, then propose actions for a human or a dry-run plan. | Needs richer read-only snapshots and legal-action queries, but avoids mutation risk. |
+| 3. Supervised command executor | Feasible after wrappers | Execute one approved action at a time after `canStart` validation and post-action observation. | Requires action schemas and guardrails; direct-control transport can carry the commands. |
+| 4. Bounded autoplay/test runner | Feasible after explicit wrapper | Start/stop AI autoplay for N turns, observe as player/observer, stop and report result. | Official automation uses `Autoplay.*`; direct-control has not wrapped or proved it. |
+| 5. Autonomous playable agent | Not currently feasible | Play whole turns without approval. | Missing complete state model, end-turn path, action schemas, event feedback, strategy memory, failure recovery, and safety boundaries. |
+| 6. Fair competitive AI replacement | Out of scope | Replace in-game AI or play multiplayer-like sessions. | Would require game-rule modeling and broad mutation rights well beyond this workstream. |
+
+The useful near-term product is tier 2-3, not tier 5.
+
+## Major Blockers
+
+- **Incomplete read model.** Current snapshots do not include units, cities,
+  yields, research/culture state, diplomacy, notifications, visibility, or legal
+  action lists.
+- **Unknown action schemas.** Official UI examples reveal argument shapes, but
+  native function signatures are opaque and operation schemas are scattered.
+- **Unproven end-turn control.** Unit skip/sleep operations exist, but a stable
+  "finish all required choices and end turn" direct command was not established.
+- **State/context mismatch.** `App UI` and `Tuner` differ; `Tuner` can be listed
+  before it is command-ready; `Network` is App UI-only in observed evidence.
+- **Mutation ambiguity.** `canStart` is likely safe, `sendRequest` is mutating,
+  and many helpers have side effects despite benign names.
+- **No transactional safety.** Direct-control can issue JavaScript but cannot
+  automatically roll back a bad game-core operation unless save/load wrappers
+  are added and proven.
+- **Fog-of-war and cheating risk.** Runtime globals may reveal information a
+  human player should not know. Reads must be scoped to local-player-visible
+  state for fair play.
+- **Prompt/notification complexity.** Civ7 turns can be blocked by modal
+  choices, narrative events, age transitions, diplomacy, and production
+  placement requirements.
+- **Output size and latency.** Broad introspection can produce large JSON and
+  timeouts; snapshots need bounded, curated fields.
+
+## Recommended Safe Wrappers
+
+Wrap now or next:
+
+- `getCiv7PlayableStatus()`: extends App UI/Tuner health with selected state,
+  local player, turn/date, map size, alive players, loading state, and autoplay
+  status. Read-only.
+- `getCiv7MapSummary()`: dimensions, seed, area/region counts if available,
+  and optional sampled tile facts. Read-only and bounded.
+- `getCiv7PlayerSummary(playerId = localPlayerID)`: alive/human flags, visible
+  units/cities counts, capital location if safely readable. Read-only.
+- `inspectCiv7Root(root, { state, maxKeys })`: a bounded form of the existing
+  runtime API inspection to prevent huge root dumps.
+- `getAutoplayStatus()` and `setAutoplay({ turns, observeAs, returnAs })` as
+  separate read/write APIs. The setter should require explicit options, max turn
+  caps, and a stop method.
+- `canStartUnitOperation({ unitId, operation, args })`: read-only legal-action
+  validator returning success, plots, and failure fields.
+- `requestUnitOperation(...)`: mutating counterpart that requires a prior
+  `canStart` success token or an explicit `force: true`.
+- Equivalent `canStartCityOperation` / `requestCityOperation` and
+  `canStartPlayerOperation` / `requestPlayerOperation` pairs.
+- `planOnly` helpers that return exact JavaScript to be run, evidence source,
+  expected mutation, and rollback recommendation without executing it.
+
+Safety defaults:
+
+- Read wrappers may retry; mutating wrappers must not automatically retry after
+  partial success or socket reconnect.
+- Mutating wrappers should return before/after snapshots or require the caller
+  to provide a post-condition probe.
+- Default to `App UI` for UI/network/gameplay operation calls and use `Tuner`
+  only for post-Begin gameplay canaries or proven Tuner-local reads.
+- Keep raw `executeCiv7*Command` available for expert debugging, but do not let
+  higher-level agents synthesize arbitrary mutating JavaScript by default.
+
+## Separate Map/Studio Automation From Play
+
+Map/studio developer automation is already a good fit for direct-control:
+restart the current game, begin, wait for map-generation log markers, inspect
+map dimensions/seed/resources, and optionally drive bounded autoplay for smoke
+tests. It can tolerate developer-only commands and generated-map state.
+
+Playable AI control is a different product. It should respect local-player
+visibility, avoid WorldBuilder/tuner edit surfaces, use game-core
+`canStart/sendRequest` APIs instead of UI cheats, and require explicit approval
+for high-impact choices such as war, diplomacy, save/load/delete, account/network
+actions, and irreversible game state changes.
+
+## Avoid / Research Later
+
+Avoid for now:
+
+- FireTuner clone UI, broad command browser, or general cheat console.
+- Autonomous whole-turn play without human approval.
+- Default wrappers for `WorldBuilder.*`, `MapConstructibles.*`,
+  `CREATE_ELEMENT`, `DESTROY_ELEMENT`, `Network.saveGame/loadGame/deleteGame`,
+  multiplayer/account actions, QR/linking, chat/kick/invite, or desktop/menu
+  exit calls.
+- Hidden-information snapshots that dump global state without local-player
+  visibility filters.
+- Caller-local socket implementations outside `@civ7/direct-control`.
+
+Research later:
+
+- Stable end-turn command path.
+- Minimal legal-action snapshot for units/cities/notifications.
+- Schema extraction for operation args from official UI resources plus runtime
+  `canStart` probes.
+- Bounded save/load sandboxing for disposable AI experiments.
+- Event subscription or polling strategy for turn begin/end, operation results,
+  notifications, and autoplay completion.
+- Whether the post-Begin `Tuner` state can execute the same gameplay operations
+  as App UI, or should stay a read/canary surface only.
+
+## Bottom Line
+
+Direct-control is a credible control transport and already useful for developer
+automation. It is not yet an AI gameplay API. Build a small read-first,
+validator-first wrapper layer, prove one or two low-risk operations in a
+disposable session, and keep full autonomous play out of scope until the repo
+has a stable state model, legal-action model, end-turn path, and explicit safety
+policy.

--- a/docs/projects/civ7-direct-control/workstream/capability-inventory/capability-inventory.md
+++ b/docs/projects/civ7-direct-control/workstream/capability-inventory/capability-inventory.md
@@ -1,0 +1,220 @@
+# Civ7 Direct-Control Capability Inventory
+
+Date: 2026-05-31
+
+## Executive Summary
+
+App UI and Tuner are not parity surfaces. They overlap on some gameplay reads,
+but they should be modeled as separate domains:
+
+- `App UI` owns lifecycle and client control: `Network.restartGame()`,
+  `UI.notifyUIReady()`, loading status, session/network status, camera/UI
+  helpers, automation helpers, and App UI-facing map/player reads.
+- `Tuner` is command-ready only after Begin Game, and then becomes the stronger
+  gameplay/map surface: `GameplayMap`, `Players`, `Units`, `Cities`,
+  `MapUnits`, `MapCities`, `MapAreas`, `MapRegions`, `MapConstructibles`,
+  `Database`, `GameInfo`, `TerrainBuilder`, `ResourceBuilder`,
+  `FertilityBuilder`, operation routers, and operation constants.
+- Restart/begin stays App UI-owned. Tuner should be used for post-Begin
+  gameplay readiness, live map reads, map-generation diagnostics, and carefully
+  bounded gameplay command research.
+- We can generate a useful TypeScript-adjacent catalog, but not perfect
+  function signatures from runtime alone. The right artifact is a
+  provenance-aware hybrid catalog that records runtime availability, official
+  resource/schema evidence, current `@civ7/types` declarations, and confidence.
+- Direct-control is already credible for developer automation and supervised
+  gameplay assistance. It is not yet an autonomous AI player API because legal
+  action schemas, end-turn control, event feedback, visibility filtering, and
+  mutation safety are not fully proven.
+
+## Evidence Base
+
+This consolidation uses:
+
+- live read-only `game inspect` and `game exec` probes through the committed
+  CLI/direct-control path;
+- `app-ui-surface-report.md`;
+- `tuner-surface-report.md`;
+- `type-generation-report.md`;
+- `automation-playability-report.md`;
+- official resources under `.civ7/outputs/resources`;
+- current `packages/civ7-direct-control` and `packages/civ7-types`.
+
+No broad gameplay mutations were run for this inventory.
+
+## Surface Matrix
+
+| Capability family | App UI | Tuner | Practical owner |
+|---|---|---|---|
+| State discovery | `LSQ:` lists states | `LSQ:` lists states | Package transport |
+| Restart | `Network.restartGame()` confirmed | absent | App UI |
+| Begin Game | `UI.notifyUIReady()` confirmed | absent | App UI |
+| Loading/shell status | `UI.isInGame`, `isInLoading`, `getGameLoadingState` | absent | App UI |
+| Tuner readiness | can see state, not enough by itself | read-only canary confirmed post-Begin | Tuner |
+| Network/session | rich `Network` surface | absent | App UI |
+| Autoplay | fields and mutators | fields and mutators | App UI first, Tuner plausible |
+| Map reads | present | stronger gameplay surface | Tuner preferred post-Begin |
+| Map generation builders | mostly absent except some WorldBuilder evidence | `TerrainBuilder`, `ResourceBuilder`, `FertilityBuilder`, `AreaBuilder` | Tuner research/raw |
+| Visibility/reveal | `Visibility` present; reads/writes plausible | `Visibility` present; reads/writes plausible | read wrappers now, reveal research later |
+| Units/cities | present | richer gameplay command/read surface | Tuner |
+| Game operations | present in source/runtime roots | `Game.*Operations` and `Game.*Commands` confirmed | Tuner research first |
+| Camera/UI overlays | `Camera`, `WorldUI`, `UI.Debug` evidence | absent | App UI research later |
+| GameInfo/Database | present; dynamic | present; dynamic | Tuner preferred for post-Begin catalogs |
+| Online/account/multiplayer | present | absent | Avoid by default |
+
+## Wrap Now
+
+These are good first-class `@civ7/direct-control` candidates because they are
+read-only or already proven lifecycle controls.
+
+| Wrapper | State | Why |
+|---|---|---|
+| `getCiv7PlayableStatus()` | App UI + optional Tuner | One developer status call: states, selected roles, loading, turn/date, local player, map size, Tuner readiness. |
+| `getCiv7MapSummary()` | Tuner preferred | Dimensions, seed, plot count, map size, age, optional area/region counts. |
+| `getCiv7PlotSnapshot(x, y, playerId?)` | Tuner preferred | Terrain, biome, feature, resource, elevation, rainfall, yields, owner, revealed state, area/region/landmass. |
+| `getCiv7MapGrid({ fields, bounds })` | Tuner preferred | Bounded structured map extraction for Studio/debug comparison. |
+| `getCiv7PlayerSummary(playerId?)` | Tuner preferred | Alive/human/AI flags, civ/leader, team, current-turn flags, resource/unit/city counts where bounded. |
+| `getCiv7UnitSummary(playerId?)` | Tuner preferred | Unit ids/locations/activity/visible action facts. Keep output bounded. |
+| `getCiv7CitySummary(playerId?)` | Tuner preferred | City ids, capital, locations, district facts, production-read facts where available. |
+| `getCiv7VisibilitySummary(playerId)` | Tuner preferred | Revealed/visible counts and optionally a bounded revealed-state grid. |
+| `getCiv7GameInfoRows(table, options)` | Tuner preferred | Targeted `GameInfo`/`Database` rows for resources, terrain, features, maps, operations. |
+| `inspectCiv7Root({ state, root, maxKeys })` | Both | Bounded, safer replacement for huge root dumps. |
+
+Keep the existing lifecycle wrappers:
+
+- `restartCiv7Game()`
+- `beginCiv7Game()`
+- `restartCiv7GameAndBegin({ waitForTuner })`
+- `checkCiv7TunerHealth()`
+- `waitForCiv7TunerReady()`
+
+## Wrap Carefully
+
+These should be explicit mutating APIs with no automatic replay after socket
+failures and with before/after or postcondition evidence.
+
+| Wrapper | State | Contract needed |
+|---|---|---|
+| `setAutoplay({ turns, observeAsPlayer, returnAsPlayer })` | App UI or Tuner | Max-turn cap, status before/after, explicit stop. |
+| `startAutoplay()` / `stopAutoplay()` | App UI or Tuner | No silent long runs; caller accepts simulation mutation. |
+| `revealAllPlots(playerId)` | likely App UI/Tuner `Visibility` | Disposable-session proof first; high cheating risk. |
+| `sendTurnComplete()` | App UI `GameContext` | Needs stable end-turn semantics and blocking-choice handling. |
+| `canStartUnitOperation(...)` | Tuner | Read-only validator first, then optional mutating counterpart. |
+| `requestUnitOperation(...)` | Tuner | Requires prior `canStart` result or explicit `force`. |
+| `canStartCityOperation(...)` / `requestCityOperation(...)` | Tuner | Same validator-first split. |
+| `canStartPlayerOperation(...)` / `requestPlayerOperation(...)` | Tuner | High blast radius; approval-friendly output. |
+
+## Keep Raw For Now
+
+Keep these behind `executeCiv7Command` / `executeCiv7TunerCommand` until a
+specific wrapper earns a contract.
+
+- `Game.*Operations.sendRequest` and `Game.*Commands.sendRequest`.
+- `Units.create`, `Units.setLocation`, `Units.setDamage`,
+  `Units.restoreMovement`, `Units.changeExperience`.
+- `TerrainBuilder.*`, `ResourceBuilder.setResourceType`,
+  `FertilityBuilder.setFertilityType`, `AreaBuilder.recalculateAreas`.
+- `MapConstructibles.add*` / `remove*`.
+- `Players.grantYield`, `grantGreatWork`, `grantCultureSlot`.
+- `Database.query`, except possibly a read-only `SELECT` helper after safety
+  proof.
+- `Configuration.edit*`.
+- `WorldUI.*`, `UI.Debug.*`, camera/overlay/VFX helpers.
+- `Network.saveGame`, `loadGame`, `deleteGame`, `syncGame`, multiplayer,
+  account, invite, chat, kick, URL, and QR flows.
+
+## Useful For Map Generation And Studio
+
+Highest-value direct-control additions for this repo:
+
+1. Live map summary and plot/grid extraction after Studio deploy/restart.
+2. Runtime-vs-MapGen projection comparison: terrain, biome, feature, resource,
+   elevation, rainfall, river, yield, area, region, landmass, and tags.
+3. Resource/table catalog reads from `GameInfo` and official resources:
+   resources, terrains, biomes, features, maps, operations, commands.
+4. Visibility summaries for "what would a player actually see?" debugging.
+5. Player/unit/city overlays for Studio debug panels.
+6. Bounded autoplay for smoke tests after map generation once explicit safety is
+   proven.
+7. Optional disposable-session map-edit experiments for `TerrainBuilder` and
+   `ResourceBuilder`, not normal Studio save flows.
+
+## AI / LLM Play Feasibility
+
+Direct-control can support an assistant that observes, summarizes, plans, and
+executes approved actions. It cannot yet safely support a fully autonomous Civ7
+player.
+
+| Tier | Status | Description |
+|---|---|---|
+| Developer status assistant | ready | Health, states, restart/begin, snapshots, root inspection. |
+| Map/Studio automation assistant | ready/near-term | Restart loops, map summaries, proof logs, runtime comparison. |
+| Supervised gameplay advisor | feasible next | Read map/player/unit/city state and propose actions. |
+| Supervised command executor | feasible after validators | Execute one approved validated action at a time. |
+| Bounded autoplay runner | feasible after wrapper | Run AI/autoplay N turns and report status. |
+| Autonomous playable agent | not ready | Missing full state model, end-turn path, action schemas, event feedback, and safety policy. |
+
+Blocking gaps for autonomous play:
+
+- richer playable snapshots;
+- local-player visibility filters to avoid hidden-information reads;
+- operation argument schemas;
+- stable end-turn path;
+- notification/blocking-choice detection;
+- operation result/event feedback;
+- save/load or rollback sandboxing;
+- explicit safety policy for diplomacy, war, deletes, account/network, and
+  world-edit operations.
+
+## Type And Catalog Strategy
+
+Do not try to generate high-level wrappers directly from runtime methods. Native
+methods often report weak metadata such as `length: 0` and `[native code]`.
+
+Recommended next architecture:
+
+1. Add a TypeBox-validated capability catalog schema in `@civ7/direct-control`.
+2. Generate runtime availability snapshots by state/phase with root allowlists,
+   descriptor-first metadata, method names, native/source fingerprints, and
+   selected read-only sample results.
+3. Parse official SQL/XML resources for `GameInfo` tables, operation rows,
+   command rows, enum-like identifiers, and row schemas.
+4. Compare the generated catalog with `packages/civ7-types/index.d.ts`.
+5. Emit a human-readable reference sheet and, later, reviewed `.d.ts` slices for
+   `@civ7/types`.
+
+Each catalog symbol should carry:
+
+- state role/name/id and phase;
+- path, kind, access classification, risk classification;
+- runtime observed type/descriptors;
+- official resource/type provenance;
+- confidence (`runtime-observed`, `official-resource`, `declared`,
+  `public-hint`, or merged);
+- wrapper recommendation (`wrap-now`, `wrap-carefully`, `raw`, `research`,
+  `avoid`).
+
+## Next Implementation Slices
+
+Recommended order:
+
+1. Read-only snapshot wrappers for Tuner map/player/plot summaries.
+2. Bounded root inspection and catalog snapshot command.
+3. Hybrid capability catalog schema and generator spike.
+4. Autoplay wrapper with max-turn and stop semantics.
+5. `canStart` validators for unit/city/player operations, no send yet.
+6. One disposable-session mutating proof, likely a low-risk unit skip/sleep or
+   autoplay run, with before/after evidence.
+7. Optional Studio endpoint for live map summary and runtime comparison.
+
+## Reframe Triggers
+
+- App UI or Tuner root availability changes materially across fresh restarts,
+  phases, or game versions.
+- Useful gameplay actions require UI event/input state that cannot be produced
+  through `CMD:<stateId>:<javascript>`.
+- `GameInfo`/`Database` result sizes or query semantics are too unstable for
+  bounded wrappers.
+- Direct mutation helpers bypass validation and corrupt save/session state.
+- Runtime metadata proves too weak for a useful generated catalog without
+  official declarations or a better reflection hook.

--- a/docs/projects/civ7-direct-control/workstream/capability-inventory/investigation-brief.md
+++ b/docs/projects/civ7-direct-control/workstream/capability-inventory/investigation-brief.md
@@ -1,0 +1,64 @@
+# Civ7 Direct-Control Capability Inventory Brief
+
+## Frame
+
+This investigation extends the direct-control workstream from "can we speak the
+protocol?" to "what useful domain capabilities should the repo expose?" App UI
+and Tuner are treated as separate runtime API surfaces. The output should help
+future package, CLI, Studio, and automation work decide which reads, writes,
+commands, and type/catalog generation paths deserve first-class support.
+
+## Selection And Salience
+
+- In scope: runtime introspection of App UI and Tuner globals; read/write method
+  inventory; game-control, map-generation, Studio-debugging, resource, and
+  AI-player use cases; type/catalog generation strategy.
+- Foregrounded: capabilities useful to developers and tooling, especially map
+  generation iteration, map reveal/inspection, autoplay/restart/begin, game
+  state reads, playable command feasibility, and typed access.
+- Exterior: implementing a FireTuner clone, building an AI player, broad UI
+  automation, or claiming commands are safe without live proof.
+
+## Primary Questions
+
+1. What globals, properties, and methods are available from App UI and Tuner,
+   and how do those surfaces differ after Begin Game?
+2. Which available reads/writes are useful enough to wrap in
+   `@civ7/direct-control` versus leaving as raw JavaScript execution?
+3. Can we generate TypeScript reference/catalog types from runtime
+   introspection, official resources, existing `packages/civ7-types`, or a
+   hybrid source?
+4. What direct-control capabilities would materially help map generation and
+   Studio development?
+5. Could an LLM or other agent read enough context and issue enough commands to
+   play Civ7 through this package, and where are the practical/API limits?
+
+## Evidence Policy
+
+- Runtime observations must name the selected state and whether Civ7 had reached
+  Begin Game.
+- Source/resource claims must cite repo files, official resource paths, or
+  public sources.
+- A method name alone is not proof of safe mutation; mark write capabilities as
+  `confirmed`, `plausible`, or `unknown`.
+- Prefer bounded live probes for high-value commands, but do not mutate game
+  state broadly without a clear reason.
+
+## Artifact Contract
+
+Agents write durable reports into this directory:
+
+- `app-ui-surface-report.md`
+- `tuner-surface-report.md`
+- `type-generation-report.md`
+- `automation-playability-report.md`
+
+The owner consolidates into `capability-inventory.md` with a matrix, use-case
+recommendations, wrap-vs-raw decisions, and next implementation slices.
+
+## Reframe Conditions
+
+- Runtime introspection cannot produce stable enough metadata for useful types.
+- App UI and Tuner expose too much native/opaque behavior to classify safely
+  without a different instrumentation approach.
+- Play/control commands require input/UI event paths outside the tuner socket.

--- a/docs/projects/civ7-direct-control/workstream/capability-inventory/owner-runtime-probes.md
+++ b/docs/projects/civ7-direct-control/workstream/capability-inventory/owner-runtime-probes.md
@@ -1,0 +1,90 @@
+# Owner Runtime Probe Notes
+
+Date: 2026-05-31
+
+## Commands
+
+Live probes were run through the committed CLI/direct-control path against the
+current started Civ7 game:
+
+```bash
+bun run --cwd packages/cli dev -- game inspect --state "App UI" --roots "Network,Autoplay,Game,UI,GameContext,Players,GameplayMap,GameInfo,Units,Cities,MapUnits,MapCities,MapFeatures,WorldBuilder,TerrainBuilder,MapPlotEffects,Camera,ComponentID,UnitFlagManager,engine,Configuration,Database,Online" --json
+bun run --cwd packages/cli dev -- game inspect --state "Tuner" --roots "Network,Autoplay,Game,UI,GameContext,Players,GameplayMap,GameInfo,Units,Cities,MapUnits,MapCities,MapFeatures,WorldBuilder,TerrainBuilder,MapPlotEffects,Camera,ComponentID,UnitFlagManager,engine,Configuration,Database,Online" --json
+bun run --cwd packages/cli dev -- game exec 'JSON.stringify(Object.getOwnPropertyNames(globalThis).sort())' --state "App UI" --json
+bun run --cwd packages/cli dev -- game exec 'JSON.stringify(Object.getOwnPropertyNames(globalThis).sort())' --state "Tuner" --json
+```
+
+Additional read-only probes inspected `GameInfo`, operation enum globals,
+builder roots, `Visibility`, and nested `Game.*Operations` routers.
+
+## Surface Size
+
+| State | Top-level global names | Notes |
+|---|---:|---|
+| `App UI` | 549 | Includes DOM/UI/browser-like globals, `Network`, `UI`, `Camera`, `Online`, `Automation`, gameplay read roots, and operation enums. |
+| `Tuner` | 227 | Smaller gameplay/map scripting surface. Lacks `Network`, `UI`, `GameContext`, `Camera`, and `Online`, but includes map builders and gameplay operations. |
+
+## App UI Highlights
+
+| Root | Status | Useful capability |
+|---|---|---|
+| `Network` | 145 methods | Restart, save/load/sync, lobby/network/session reads. `restartGame()` is confirmed. |
+| `UI` | 134 methods | Loading state, Begin Game via `notifyUIReady()`, clipboard, profiling, UI shell/game status. |
+| `GameContext` | 9 methods | Turn complete/unready, pause/retire requests, local player/observer ids. |
+| `Autoplay` | 8 methods | `setActive`, `setTurns`, `setReturnAsPlayer`, `setObserveAsPlayer`, AI/human toggles. Mutating; should be explicit wrappers. |
+| `Camera` | 34 methods | Plot/world picking and camera movement/focus; useful for Studio/debug UI, not core map proof. |
+| `Automation` | 25 methods | Test/automation parameter and log helpers; useful to research before wrapping. |
+| `Visibility` | 10 methods | Reveal/visibility counts and `revealAllPlots`; high-value but mutating. |
+| `GameplayMap`, `Players`, `Units`, `Cities`, `MapUnits`, `MapCities` | present | Read gameplay/map/city/unit state. |
+
+App UI does not expose `TerrainBuilder`, `ResourceBuilder`, `FertilityBuilder`,
+or `AreaBuilder` in this run.
+
+## Tuner Highlights
+
+| Root | Status | Useful capability |
+|---|---|---|
+| `GameplayMap` | 74 methods | Map dimensions, terrain/biome/feature/resource/elevation/rainfall/yields, revealed state, ownership, distances. |
+| `TerrainBuilder` | 21 methods | Map mutation: terrain, biome, feature, rainfall, plot tags, rivers, elevation, validation. |
+| `ResourceBuilder` | 10 methods | Resource counts/eligibility/generated resources and `setResourceType`. |
+| `FertilityBuilder` | 2 methods | Fertility recalculation and `setFertilityType`. |
+| `AreaBuilder` | 5 methods | Area/continent analysis and `recalculateAreas`. |
+| `Visibility` | 10 methods | Reveal and visibility manipulation. |
+| `Game.PlayerOperations` | `canStart`, `sendRequest` | Player-level actions such as tech/culture targets, resource assignment, diplomacy, turn-like decisions. |
+| `Game.UnitOperations` | `canStart`, `canStartAny`, `sendRequest` | Unit operations such as move, attack, fortify, found city, automate explore. |
+| `Game.UnitCommands` | `canStart`, `sendRequest` | Unit commands such as promote, wake, delete, upgrade, automate. |
+| `Game.CityOperations`, `Game.CityCommands` | `canStart`, `canStartQuery`, `sendRequest` | City build/purchase/manage/focus style actions. |
+| `GameInfo`, `Database` | present | Dynamic table access. `GameInfo.Resources.length` returned `55`; first row was `RESOURCE_COTTON`. |
+
+Tuner lacks `Network`, `UI`, `GameContext`, `Camera`, and `Online` in this run.
+
+## Enum/Operation Evidence
+
+Operation enum globals are present in both states, with richer practical use in
+Tuner because `Game.*Operations` routers are present there. Examples observed:
+
+- `UnitOperationTypes.MOVE_TO`, `RANGE_ATTACK`, `FORTIFY`, `FOUND_CITY`,
+  `AUTOMATE_EXPLORE`, `SKIP_TURN`, `SLEEP`, `REPAIR`, `PILLAGE`.
+- `UnitCommandTypes.PROMOTE`, `WAKE`, `DELETE`, `UPGRADE`, `AUTOMATE`,
+  `STOP_AUTOMATION`.
+- `PlayerOperationTypes.SET_TECH_TREE_NODE`, `SET_CULTURE_TREE_NODE`,
+  `ASSIGN_RESOURCE`, `DECLARE_WAR`, `MAKE_PEACE`, `EXTEND_GAME`.
+- `CityOperationTypes.BUILD`; `CityCommandTypes.PURCHASE`, `SET_FOCUS`,
+  `EXPAND`, `RANGE_ATTACK`.
+
+Official UI resources corroborate the operation pattern:
+`Game.<Domain>Operations.canStart(...)` followed by
+`Game.<Domain>Operations.sendRequest(...)`, and similar
+`Game.<Domain>Commands.canStart/sendRequest`.
+
+## Initial Wrap Recommendations
+
+- Wrap now: state-aware health, App UI status, Tuner map summary, map grid
+  sampling, player summary, GameInfo table samples, reveal status summaries,
+  and operation enum catalog export.
+- Wrap carefully: `restartGame`, `notifyUIReady`, autoplay controls,
+  `Visibility.revealAllPlots`, turn-complete, and operation `canStart` queries.
+- Keep raw until proven: operation `sendRequest`, `TerrainBuilder`/`ResourceBuilder`
+  mutation, save/load/network methods, direct unit/city creation or damage.
+- Avoid by default: multiplayer/account/online methods, destructive save/delete,
+  broad map mutation in a normal game session, and unsupported UI internals.

--- a/docs/projects/civ7-direct-control/workstream/capability-inventory/team-plan.md
+++ b/docs/projects/civ7-direct-control/workstream/capability-inventory/team-plan.md
@@ -1,0 +1,39 @@
+# Capability Inventory Team Plan
+
+## Objective
+
+Use parallel evidence lanes to map App UI, Tuner, typed/catalog generation, and
+automation/playability potential without duplicating work or turning exploratory
+commands into premature product commitments.
+
+## Axes
+
+- Objective precision: exploratory but bounded by durable report outputs.
+- Coupling: mostly parallel, with owner synthesis at the end.
+- Autonomy: agents may inspect source, resources, and runtime docs; live
+  mutation should stay conservative.
+- Context distribution: partitioned by surface; shared frame is the
+  investigation brief and direct-control package.
+- Verification mode: process-traced through artifacts, then outcome-checked by
+  owner consolidation.
+
+## Agents And Interfaces
+
+| Lane | Output Path | Accountable For |
+|---|---|---|
+| App UI Surface Investigator | `app-ui-surface-report.md` | App UI globals, methods, read/write candidates, map/studio/debug commands |
+| Tuner Surface Investigator | `tuner-surface-report.md` | Tuner gameplay globals, methods, read/write candidates, map/gameplay/control commands |
+| Type Catalog Investigator | `type-generation-report.md` | Runtime introspection, official resources, `packages/civ7-types`, codegen options |
+| Automation Playability Investigator | `automation-playability-report.md` | LLM/agent play feasibility, required reads/actions, blockers, safe control model |
+
+## Handoff Contract
+
+Each report must include:
+
+- Evidence sources and commands searched.
+- Capability tables grouped by domain.
+- `wrap now`, `raw command`, `research later`, and `avoid` recommendations.
+- Type-generation implications.
+- Unknowns and reframe triggers.
+
+The owner owns consolidation, conflict resolution, and commit hygiene.

--- a/docs/projects/civ7-direct-control/workstream/capability-inventory/tuner-surface-report.md
+++ b/docs/projects/civ7-direct-control/workstream/capability-inventory/tuner-surface-report.md
@@ -1,0 +1,369 @@
+# Tuner Surface Report
+
+Date: 2026-05-31
+
+## Scope
+
+This report inventories the `Tuner` scripting state as a gameplay API surface
+after Begin Game. `App UI` is referenced only for contrast. FireTuner/resource
+panel code is treated as reference-client evidence, not repo-owned runtime
+authority.
+
+## Sources Searched
+
+- Repo source:
+  - `packages/civ7-direct-control/src/index.ts`
+  - `packages/civ7-direct-control/README.md`
+  - `packages/civ7-direct-control/AGENTS.md`
+  - `packages/cli/src/commands/game/health.ts`
+  - `packages/cli/src/commands/game/inspect.ts`
+  - `packages/cli/src/commands/game/exec.ts`
+  - `packages/civ7-types/index.d.ts`
+- Prior direct-control discovery:
+  - `docs/projects/civ7-direct-control/workstream/discovery/tuner-api-inventory.md`
+  - `docs/projects/civ7-direct-control/workstream/discovery/app-ui-api-inventory.md`
+  - `docs/projects/civ7-direct-control/workstream/capability-inventory/investigation-brief.md`
+  - `docs/projects/civ7-direct-control/workstream/capability-inventory/team-plan.md`
+- Official resource mirror:
+  - `.civ7/outputs/resources/Base/modules/base-standard/ui/tuner-input/tuner-input.js`
+  - `.civ7/outputs/resources/Base/modules/core/ui/utilities/utilities-tuner.js`
+  - `.civ7/outputs/resources/Base/modules/base-standard/maps/map-debug-helpers.js`
+  - selected `Base/modules/base-standard/ui/**` usages of `Game.*Operations`,
+    `Game.*Commands`, `GameplayMap.getRevealedState`, `MapUnits`, `MapCities`,
+    and `Autoplay`
+  - selected `Base/modules/base-standard/maps/**` map builder/debug usages
+- Live read-only runtime commands:
+  - `bun run --cwd packages/cli dev game health --tuner --json`
+  - `bun run --cwd packages/cli dev game inspect --state Tuner --roots ... --json`
+  - `bun run --cwd packages/cli dev game exec <read-only nested-key probe> --state Tuner --json`
+
+No broad game-state mutations, autoplay, map edits, player commands, or unit
+commands were executed for this report.
+
+## Readiness Boundary
+
+`LSQ:` can list both `App UI` and `Tuner` before `Tuner` is command-ready. Prior
+direct-control evidence recorded `CMD:1:1+1` and basic global probes timing out
+before Begin Game. After `App UI` reaches native Begin Game completion
+(`UI.notifyUIReady()` and `GameStarted`), the current live `Tuner` canary
+returns:
+
+```json
+{
+  "state": { "id": "1", "name": "Tuner" },
+  "ready": true,
+  "globals": {
+    "Game": "object",
+    "Autoplay": "object",
+    "GameplayMap": "object",
+    "Players": "object",
+    "Network": "undefined"
+  },
+  "turn": 1,
+  "turnDate": "4000 BCE",
+  "map": "84x54",
+  "aliveIds": [0, 1, 2, 3, 4, 5, 6, 7],
+  "aliveHumanIds": [0]
+}
+```
+
+Conclusion: package readiness checks must execute a read-only Tuner command
+canary. State discovery alone is insufficient.
+
+## Tuner Global/Root Inventory
+
+Confirmed post-Begin roots from live read-only inspection:
+
+| Root | Status in `Tuner` | Useful surface |
+|---|---|---|
+| `Game` | confirmed | turn/date/hash plus `UnitCommands`, `UnitOperations`, `CityCommands`, `CityOperations`, `PlayerOperations`, `Resources`, `Diplomacy`, `ProgressionTrees`, `Unlocks`, many domain managers |
+| `Autoplay` | confirmed | status fields plus mutators such as `setTurns`, `setActive`, `setPause`, `setAsAI`, `setAsHuman` |
+| `Players` | confirmed | alive/player classification reads plus player component gateways |
+| `GameplayMap` | confirmed | broad map read API: dimensions, coordinates, terrain, biome, features, resources, yields, ownership, visibility, areas, regions |
+| `GameInfo` | confirmed but non-enumerable | dynamic DB table gateway; own-key enumeration does not reveal table names |
+| `PlayerIds` | confirmed | `NO_PLAYER`, `WORLD_PLAYER`, `OBSERVER_ID` |
+| `MapUnits` / `Units` | confirmed | unit lookup, path/reachable target reads, and direct mutation helpers on `Units` |
+| `MapCities` / `Cities` / `Districts` | confirmed | city/district lookup by id/location; city objects require founded cities |
+| `MapAreas` / `MapRegions` | confirmed | area/region ids, plots, info, counts |
+| `MapConstructibles` | confirmed | constructible reads plus route/discovery/independent/add mutation methods |
+| `Database` | confirmed | table names/data/query/hash helpers |
+| `Configuration` | confirmed | game/map/player config reads |
+| `UnitOperationTypes`, `UnitCommandTypes`, `CityOperationTypes`, `CityCommandTypes`, `PlayerOperationTypes`, `RevealedStates`, `ConstructibleClasses` | confirmed | constants needed for typed command wrappers and read classification |
+| `Network` | absent | App UI-only in current evidence |
+| `UI`, `GameContext`, `WorldUI`, `Automation`, `WorldBuilder` | absent | App UI/panel/runtime-only in current evidence |
+
+Important difference from `App UI`: `Tuner` has deeper gameplay roots such as
+`Units`, operation constants, `Database`, and command manager families, but it
+does not expose `Network.restartGame()`, `UI.notifyUIReady()`, `GameContext`, or
+`WorldBuilder` in the observed post-Begin session.
+
+## Useful Reads
+
+### Game And Session
+
+- `Game.turn`, `Game.age`, `Game.maxTurns`, `Game.getTurnDate()`, `Game.getHash()`.
+- `Configuration.getGameValue`, `getGameValues`, `getMapValue`, `getMapValues`,
+  `getPlayerValue`, `getPlayerValues`.
+- `Database.getTableNames`, `getTableData`, `getPrimaryKeys`, `query`,
+  `makeHash`.
+
+Wrap-now candidate: `getTunerGameSnapshot()` with turn/date, map config, table
+names, current age, and hash. Keep DB queries bounded and explicit.
+
+### Map Introspection
+
+`GameplayMap` in `Tuner` exposes all high-value map reads observed in App UI,
+plus current inspection confirmed methods including:
+
+- Dimensions/identity: `getGridWidth`, `getGridHeight`, `getPlotCount`,
+  `getMapSize`, `getRandomSeed`.
+- Coordinates: `getIndexFromXY`, `getIndexFromLocation`,
+  `getLocationFromIndex`, `getAdjacentPlotLocation`, `getPlotDistance`,
+  `getPlotIndicesInRadius`, `isValidXY`, `isValidIndex`, `isValidLocation`.
+- Terrain/climate/ecology: `getTerrainType`, `getBiomeType`,
+  `getFeatureType`, `getFeatureClassType`, `getResourceType`,
+  `getFertilityType`, `getElevation`, `getRainfall`, `getPlotLatitude`,
+  `getAppeal`.
+- Hydrology/geography: `getRiverType`, `getRiverName`, `isRiver`,
+  `isNavigableRiver`, `isFreshWater`, `isLake`, `isWater`, `isCoastalLand`,
+  `isMountain`, `isCliffCrossing`, `isImpassable`, `isFerry`.
+- Ownership/visibility: `getOwner`, `getOwnerName`, `getOwnerHostility`,
+  `getOwningCityFromXY`, `getRevealedState`, `getRevealedStates`.
+- Areas/regions: `getAreaId`, `getAreaIsWater`, `getLandmassId`,
+  `getLandmassRegionId`, `getRegionId`, `getContinentType`,
+  `getHemisphere`, `getPrimaryHemisphere`, `findSecondContinent`.
+- Yields/properties/tags: `getYield`, `getYields`, `getYieldWithCity`,
+  `getYieldsWithCity`, `getPlotTag`, `hasPlotTag`, `getProperty`.
+
+Official `map-debug-helpers.js` confirms the same read families are useful for
+terrain/elevation/rainfall/biome/feature/resource/continent debug dumps.
+
+Wrap-now candidates:
+
+- `getTunerMapSummary()`
+- `getTunerPlotSnapshot(x, y, playerId?)`
+- `getTunerMapGrid({ fields })` for bounded read-only extraction
+- `getTunerVisibilitySummary(playerId)` using `getRevealedStates`
+- `getTunerAreaRegionSummary()`
+
+### Players, Units, Cities, Resources
+
+Useful confirmed reads:
+
+- `Players.getAliveIds`, `getAliveHumanIds`, `getAliveMajorIds`,
+  `getAliveMinorIds`, `getAliveIndependentIds`, `getAliveBarbarianIds`,
+  `getNumAliveHumans`, `isHuman`, `isAI`, `isObserver`, `isAlive`,
+  `isParticipant`, `isValid`, `get`.
+- `Players.get(playerId)` exposes identity/status fields: `id`, `name`,
+  civilization/leader names/types, `team`, `isHuman`, `isAI`, `isAlive`,
+  `isTurnActive`, `controlType`, `isMajor`, `isMinor`, `isIndependent`.
+- `Players.Units.get(playerId)` exposes `getUnitIds`, `getUnits`,
+  `getNumUnitsOfType`, `getCost`, `canEverTrain`, `isUnitUnlocked`,
+  `getUnitShadows`.
+- `Units.get(unitId)` exposes unit identity/location/status fields and reads
+  such as `getSightPlots`, `getActivationPlots`, `getOperationParameters`,
+  `getOperationTargets`, `getReachableMovement`, `getPathTo`,
+  `getReachableTargets`, `getReachableTargetsRanged`, `hasAbility`.
+- `MapUnits.getUnits(x, y)` and `getUnitsOnLayer(x, y, layer)` support
+  plot-level unit lookup.
+- `Players.Cities.get(playerId)` exposes `getCityIds`, `getCities`,
+  `getCapital`, `getCountOfCities`, `findClosest`, `getCityLimit`.
+- `Cities.get`, `getAtLocation`, `getIdAtLocation`; `MapCities.getCity`,
+  `getDistrict`; `Districts.get`, `getAtLocation`, `getIdAtLocation`,
+  `getLocations`, `getFreeConstructible`.
+- `Players.Resources.get(playerId)` exposes resource assignment reads:
+  `getResources`, `getCityIDAssigned`, `getCountImportedResources`,
+  `getCountResourcesToAssign`, `getUnassignedResourceYieldBonus`.
+- `Players.LiveOpsStats.get(playerId).numPlotsRevealed` is useful for
+  exploration/progress diagnostics.
+
+Wrap-now candidates:
+
+- `getTunerPlayerSummary(playerId?)`
+- `getTunerUnitSummary(playerId?)`
+- `getTunerCitySummary(playerId?)`
+- `getTunerResourceSummary(playerId?)`
+
+## Useful Writes And Commands
+
+No write was executed during this report. Status labels below mean:
+
+- `confirmed`: live Tuner exposes the method and official UI/resource code shows
+  a real call shape, but this report did not execute it unless noted.
+- `plausible`: live Tuner exposes the method, but call shape/safety needs
+  targeted proof.
+- `unknown`: source evidence exists elsewhere, but raw Tuner availability or
+  post-Begin behavior is not proven.
+
+| Capability | Surface | Status | Notes |
+|---|---|---|---|
+| Autoplay control | `Autoplay.setTurns`, `setActive`, `setPause`, `setObserveAsPlayer`, `setReturnAsPlayer`, `setAsAI`, `setAsHuman`, `setAsLocalPlayer` | confirmed | Official automation UI uses these. Mutating but bounded; good explicit command surface after safety gates. |
+| Unit commands/operations | `Game.UnitCommands.canStart/sendRequest`, `Game.UnitOperations.canStart/canStartAny/sendRequest` | confirmed | Operation constants are available in Tuner. Wrap only after command-specific canStart+request contracts are proven. |
+| City commands/operations | `Game.CityCommands.canStart/canStartQuery/sendRequest`, `Game.CityOperations.canStart/canStartQuery/sendRequest` | confirmed | Useful for production, purchase, growth, expand, ranged attack, WMD. Mutating gameplay actions. |
+| Player operations | `Game.PlayerOperations.canStart/sendRequest` | confirmed | Official UI and tuner-input use this for many actions, including `CREATE_ELEMENT`, `DESTROY_ELEMENT`, `ASSIGN_RESOURCE`, diplomacy, religion, progression, advanced start. Very broad mutation surface. |
+| Tuner element creation/destruction | `Game.PlayerOperations.sendRequest(..., CREATE_ELEMENT/DESTROY_ELEMENT, args)` | confirmed | Official `tuner-input.js` uses for units, towns/cities, districts, constructibles. Powerful developer/debug API; keep raw/research until scoped wrappers exist. |
+| Unit direct mutation | `Units.create`, `setLocation`, `setDamage`, `changeDamage`, `restoreMovement`, `changeExperience`, `setActivity` | plausible | Exposed in Tuner. Needs targeted proof and guardrails; bypasses normal canStart/sendRequest path. |
+| Map constructibles | `MapConstructibles.addRoute/removeRoute/addDiscovery/addDiscoveryType/addIndependentType/addConstructible` | confirmed | Official map scripts use `addDiscovery`; tuner input uses route/discovery/independent variants. Mutates map. |
+| Unlock forcing | `Game.Unlocks.setForceUnlockedForPlayer`, `clearForceUnlockedForPlayer` | plausible | Exposed in Tuner; useful for debugging tech/civic/unlock gates, but mutation semantics need proof. |
+| Progression reveal | `Game.ProgressionTrees.revealTree` | plausible | Exposed in Tuner; name implies mutation or hidden-state side effect. Keep raw/research. |
+| Player grants | `Players.grantYield`, `grantGreatWork`, `grantCultureSlot`, `increaseMaxTradeDistance` | plausible | Exposed in Tuner; likely mutating developer/debug helpers. |
+| Map plot editing through `WorldBuilder.MapPlots` | `WorldBuilder.MapPlots.setFeature/setTerrain/setResource/setFertility/setOwnership/setBiome` | unknown in raw Tuner | Official `tuner-input.js` uses these in App UI event handlers, but `WorldBuilder` was absent from live Tuner. Do not wrap as Tuner API unless a targeted state/panel setup proves availability. |
+| Restart/begin | `Network.restartGame()`, `UI.notifyUIReady()` | not Tuner | Confirmed App UI-only in current evidence. Keep outside Tuner wrappers. |
+
+## Map, Studio, Debug, Gameplay Candidates
+
+### Map/Studio Debug
+
+Best immediate value is read-only map extraction from Tuner:
+
+- full-grid terrain/biome/feature/resource/elevation/rainfall/yield snapshots;
+- visibility overlays with `getRevealedStates(playerId)`;
+- area/region/continent overlays with `MapAreas`, `MapRegions`, and
+  `GameplayMap` ids;
+- unit/city/district overlays with `MapUnits`, `MapCities`, `Cities`,
+  `Districts`;
+- resource assignment overlays from `Players.Resources`.
+
+This gives MapGen Studio a live post-Begin inspection channel without relying
+on FireTuner panels or mutating map state.
+
+### Map Reveal/Explore
+
+Read side is confirmed:
+
+- `GameplayMap.getRevealedState(playerId, x, y)`
+- `GameplayMap.getRevealedStates(playerId)`
+- `Players.LiveOpsStats.get(playerId).numPlotsRevealed`
+- unit sight: `Units.get(...).getSightPlots()`
+
+Write side is not yet a clean map-reveal API. Search found official UI reads and
+events around revealed states, but no proven raw Tuner `revealMap` or
+`setRevealedState` equivalent. Practical exploration can likely be driven by
+unit movement/autoplay, but direct reveal should remain research-later.
+
+### Player/Turn/Unit Actions
+
+The Tuner state looks capable enough for conservative gameplay action wrappers:
+
+- query `canStart` first;
+- issue `sendRequest` only for a named command/operation;
+- return the immediate command result plus a follow-up read snapshot.
+
+The first viable research targets are low-blast-radius actions:
+
+- unit wait/skip/sleep/fortify/automate explore;
+- unit move to a validated reachable plot;
+- city production query/read-only first, then set/build only in a disposable
+  test session;
+- resource assignment only after canStart and argument proof.
+
+Avoid generic `sendRequest(op, args)` wrappers as product API. They are useful
+as raw escape hatches, not stable helpers.
+
+### General Developer Control
+
+Tuner is a good state for:
+
+- post-Begin readiness and health;
+- live gameplay snapshots;
+- bounded DB/config/table reads;
+- debug catalog extraction for constants and native root keys;
+- explicit autoplay control, once marked as mutating.
+
+Tuner is not the right state for restart/load/begin/network lifecycle. Keep
+those on App UI.
+
+## Recommendations
+
+### Wrap Now
+
+- `waitForCiv7TunerReady()` / `checkCiv7TunerHealth()` already exists and should
+  remain the readiness canary.
+- Add read-only wrappers:
+  - `getTunerGameSnapshot()`
+  - `getTunerMapSummary()`
+  - `getTunerPlotSnapshot(x, y, playerId?)`
+  - `getTunerPlayerSummary(playerId?)`
+  - `getTunerUnitSummary(playerId?)`
+  - `getTunerCitySummary(playerId?)`
+  - `getTunerAreaRegionSummary()`
+  - `getTunerVisibilitySummary(playerId)`
+- Add `inspectTunerApiRoots(roots)` as a named convenience over existing
+  `inspectCiv7RuntimeApi({ state: { role: "tuner" } })`.
+
+### Raw Command For Now
+
+- `Database.query` and arbitrary `GameInfo` table reads, until query result
+  shapes and data volume are bounded.
+- `Game.*Commands.canStart` and `Game.*Operations.canStart` for exploratory
+  command feasibility.
+- Narrow `sendRequest` experiments in disposable sessions.
+- `Autoplay` mutators, unless the caller is using an explicit
+  `setAutoplay...` helper that states mutation clearly.
+
+### Research Later
+
+- Direct reveal/explore mutation.
+- Safe first-class unit movement/action wrappers.
+- City production/purchase wrappers.
+- Resource assignment wrappers.
+- `Units.*` direct mutation methods.
+- `MapConstructibles.*` debug placement wrappers.
+- Whether `WorldBuilder` can be made available to raw `Tuner` via specific
+  panel/setup state, or whether it is App UI-only.
+- Whether `g_TunerState`, `g_TunerInput`, or `tunerUtilities` can be accessed
+  from direct-control states after FireTuner panel injection.
+
+### Avoid
+
+- Do not expose generic Tuner `sendRequest` as a safe high-level API.
+- Do not treat FireTuner panel globals as raw `Tuner` globals without live proof.
+- Do not retry mutating commands automatically after socket failures.
+- Do not route restart/begin through `Tuner`; current evidence keeps those on
+  `App UI`.
+- Do not infer function arity from native `length`; observed native functions
+  commonly report `0`.
+
+## Type-Generation Implications
+
+- `packages/civ7-types/index.d.ts` currently focuses on map-generation globals
+  and is incomplete for post-Begin Tuner gameplay APIs. It lacks many confirmed
+  roots such as `Units`, `MapUnits`, `MapCities`, `Cities`, `Districts`,
+  `MapAreas`, `MapRegions`, `MapConstructibles`, `Autoplay`, `Database`, and
+  command/operation constants.
+- Runtime introspection can generate a useful root/method catalog, but not a
+  trustworthy full type surface by itself:
+  - native functions report `[native code]` and usually `length: 0`;
+  - `GameInfo` is dynamic and non-enumerable through own-key inspection;
+  - return object shapes require targeted sample calls;
+  - method names alone do not classify mutation safety.
+- Best path is hybrid:
+  - runtime-generated catalog for roots, constants, and method names;
+  - official resource usage for call shapes;
+  - targeted read-only samples for object shapes;
+  - manual safety labels for read/write/unknown;
+  - generated docs/types marked by evidence level.
+- Split ambient types by state/surface if possible:
+  - map-generation script globals;
+  - App UI control globals;
+  - post-Begin Tuner gameplay globals.
+
+## Unknowns And Reframe Triggers
+
+- Unknown: whether `Tuner` exposes the same roots in multiplayer, later turns,
+  age transition, or after leaving/re-entering the game.
+- Unknown: direct map reveal mutation path. Existing evidence proves visibility
+  reads, not reveal writes.
+- Unknown: whether some Tuner roots are hidden until a FireTuner panel or
+  `g_TunerState` payload is injected.
+- Unknown: which write methods are safe in a normal save versus only worldbuilder
+  or debug sessions.
+- Unknown: exact argument contracts for most `sendRequest`, `Units.*`, and
+  `MapConstructibles.*` writes.
+- Reframe if runtime introspection becomes unstable across sessions or patches.
+- Reframe if `GameInfo`/`Database` queries are too large or unsafe for generic
+  wrappers.
+- Reframe if command wrappers require UI selection/input state outside the
+  tuner socket.
+- Reframe if mutation proof shows direct `Units.*` or `MapConstructibles.*`
+  bypasses simulation validation in ways that corrupt saves.

--- a/docs/projects/civ7-direct-control/workstream/capability-inventory/type-generation-report.md
+++ b/docs/projects/civ7-direct-control/workstream/capability-inventory/type-generation-report.md
@@ -1,0 +1,441 @@
+# Type Generation Report
+
+Date: 2026-05-31
+Lane: Type Catalog Investigator
+
+## Scope And Claim
+
+`@civ7/direct-control` should eventually own a generated capability catalog for
+the runtime surfaces it can exercise through App UI and Tuner. That catalog
+should not pretend to be a complete Civ7 SDK. It should record what a selected
+runtime state exposed, what official resources declare, what `@civ7/types`
+already models, and what remains unknown.
+
+The recommended path is a hybrid schema/codegen artifact:
+
+- runtime introspection proves state-specific presence, property descriptors,
+  prototype members, native-function metadata, and selected read-only probes;
+- official resources provide durable data schemas, enum/type rows, and examples
+  of operation/command shapes;
+- `packages/civ7-types` remains the type-only ambient declaration package, but
+  should consume generated/corroborated catalog slices rather than grow by
+  hand-maintained guesses;
+- public/community corpora stay as discovery hints unless corroborated by fresh
+  runtime probes or official resources.
+
+No generator implementation was added in this lane.
+
+## Evidence Sources And Commands
+
+Repo-local files inspected:
+
+- `packages/civ7-direct-control/src/index.ts`
+- `packages/civ7-direct-control/README.md`
+- `packages/civ7-direct-control/AGENTS.md`
+- `packages/civ7-types/index.d.ts`
+- `packages/civ7-types/AGENTS.md`
+- `.civ7/outputs/resources/Base/Assets/schema/**`
+- `.civ7/outputs/resources/Base/modules/base-standard/data/*.xml`
+- `.civ7/outputs/resources/Base/modules/base-standard/ui/tuner-input/tuner-input.js`
+- `.civ7/outputs/resources/Base/modules/core/ui/utilities/utilities-tuner.js`
+- `docs/projects/civ7-direct-control/workstream/discovery/public-corpus-report.md`
+- `docs/projects/civ7-direct-control/workstream/discovery/app-ui-api-inventory.md`
+- `docs/projects/civ7-direct-control/workstream/discovery/tuner-api-inventory.md`
+
+Search/read commands used:
+
+- `git status --short --branch` and `gt status`
+- `find packages/civ7-types -maxdepth 4 -type f`
+- `find .civ7/outputs/resources/Base -path '*schema*' -type f`
+- `rg -n "inspectCiv7RuntimeApi|Civ7RuntimeApi|Object\\.getOwn|getOwnProperty|GameInfo|TypeBox|typebox|generate|schema" ...`
+- targeted `sed`/`nl` reads of the files above
+
+No new public web search was needed. Public-source conclusions below rely on the
+checked-in public corpus report and inherit its source classification.
+
+## Source Inventory
+
+### Runtime Introspection Evidence
+
+`@civ7/direct-control` already exposes a small runtime inspection shape:
+`Civ7RuntimeApiRoot`, `Civ7RuntimeApiMethod`, and
+`inspectCiv7RuntimeApi(...)`. The current probe records root existence,
+`typeof`, own keys, prototype keys, enumerable keys, method owner, function
+`length`, and a short `Function.prototype.toString` signature sample.
+
+This is the strongest evidence for:
+
+- whether a root exists in `App UI` or `Tuner`;
+- whether a member is own, prototype, or enumerable;
+- whether a member is callable at all;
+- selected status values such as map size, turn, alive players, and loading
+  state when paired with explicit read-only probes.
+
+It is weak evidence for:
+
+- native function argument names and required parameters;
+- return types beyond sampled calls;
+- safety of mutation;
+- availability outside the probed state and phase.
+
+Existing runtime reports establish the key context split:
+
+- App UI can execute from state id `65535` in the observed session and exposes
+  App UI-only roots such as `Network`, `UI`, and `GameContext`.
+- Tuner may appear in `LSQ:` before it is command-ready; after Begin Game it
+  can evaluate gameplay canaries and exposes gameplay roots such as `Game`,
+  `Autoplay`, `GameplayMap`, and `Players`.
+- `GameInfo` is dynamic and not discoverable by broad own-key enumeration.
+
+### Official Resource Evidence
+
+Official resources under `.civ7/outputs/resources` are game-data evidence, not
+repo architecture. They are still the best local source for data schemas and
+stable string identifiers.
+
+High-value inputs:
+
+- `Base/Assets/schema/gameplay/01_GameplaySchema.sql` declares gameplay tables,
+  columns, defaults, primary keys, and foreign keys.
+- `Base/modules/base-standard/data/maps.xml` shows `Kinds`, `Types`, `Maps`,
+  `MapIslandBehavior`, and map/resource modifier rows.
+- `Base/modules/base-standard/data/unit-commands.xml` and
+  `unit-operations.xml` define command/operation type rows plus UI metadata.
+- UI scripts show real call patterns, for example
+  `Game.PlayerOperations.canStart(...)`, `sendRequest(...)`,
+  `Network.restartGame()`, `UI.notifyUIReady()`, and `GameplayMap` queries.
+- `ui/tuner-input/tuner-input.js` is concrete evidence for mutating tuner-panel
+  flows via `WorldBuilder.MapPlots.*`, `MapConstructibles.*`, and
+  `Game.PlayerOperations.sendRequest(...)`.
+
+Resource evidence is strong for `GameInfo` row/table shape and enum-like
+identifiers. It does not prove runtime state availability, function arity, or
+that a command is safe to wrap.
+
+### `packages/civ7-types`
+
+`@civ7/types` is currently a type-only ambient package. It models selected
+runtime globals, map-generation globals, `GameInfoTable<T>`, map rows, and
+virtual `/base-standard/...` imports. The package router says it owns Civ7
+runtime type definitions and must keep exports type-only.
+
+This is useful declaration evidence and a natural output target, but the file
+is partly hand-curated. For the direct-control catalog, it should be treated as
+an existing declaration layer to compare against, not as runtime proof. The
+future generator can produce proposed `.d.ts` slices or validation diffs for
+this package.
+
+### Public Corpus
+
+The public corpus report found no complete public Civ7 `.d.ts` declaration
+source. It identified useful discovery inputs: CDC completions, WildW runtime
+dumps, event lists, official/public resource examples, and secondary community
+docs. These sources are good autocomplete seeds and sanity checks, but entries
+should be labeled `public-community` or `external-hint` until corroborated.
+
+## Generator Options
+
+### Option 1: Runtime Introspection Only
+
+Generate a catalog by running direct-control probes against selected roots in
+App UI and Tuner.
+
+Pros:
+
+- closest to what direct-control can actually execute;
+- naturally records state id, state name, phase, observed availability, own vs
+  prototype members, and live probe failures;
+- useful for drift detection across Civ7 updates.
+
+Cons:
+
+- native functions usually expose `length: 0` and `[native code]`, so parameter
+  lists remain unknown;
+- object graphs can be huge or circular without descriptor-based limits;
+- state and phase matter: shell, loading, WaitingForUIReady, post-Begin,
+  age-transition, multiplayer, and worldbuilder panels can differ;
+- runtime probes can observe mutating methods but cannot classify safety by
+  name alone.
+
+Use for: presence, descriptor metadata, observed read-only values, availability
+matrices, drift snapshots.
+
+Do not use for: authoritative signatures, complete `GameInfo` table lists, or
+automatic write wrappers.
+
+### Option 2: Official Resource Schema/Data Generator
+
+Parse official SQL/XML/JS resource files into table, row, enum, and usage
+catalogs.
+
+Pros:
+
+- best source for `GameInfo` schemas, key columns, defaults, foreign keys, and
+  enum/type identifiers;
+- deterministic and can run without Civ7;
+- can produce TypeScript literal unions for operation names, unit commands, map
+  sizes, terrain/resource/feature ids, and table row interfaces.
+
+Cons:
+
+- official resources are data evidence, not runtime API proof;
+- XML rows may be partial overlays across Base/DLC/modules and require load
+  order rules;
+- JavaScript call-pattern extraction can infer usage shapes, not native
+  signatures;
+- generated resource declarations can become very large if every table and row
+  literal is emitted.
+
+Use for: `GameInfo` table schemas, enum-like identifiers, operation catalogs,
+resource provenance.
+
+Do not use for: proving App UI/Tuner availability or side-effect safety.
+
+### Option 3: `packages/civ7-types` Uplift/Diff
+
+Treat `@civ7/types` as the declaration package and generate candidate diffs
+from the runtime/resource catalog.
+
+Pros:
+
+- aligns with existing package ownership;
+- keeps direct-control from owning ambient modding declarations;
+- supports editor and mod-author ergonomics.
+
+Cons:
+
+- current declarations include hand-authored assumptions and catch-alls;
+- generated ambient declarations may overpromise if they do not carry
+  provenance/state annotations;
+- TypeScript declarations alone cannot express runtime state availability well.
+
+Use for: stable/corroborated declarations and generated review diffs.
+
+Do not use for: the source-of-truth capability catalog itself.
+
+### Option 4: Public Corpus Index
+
+Ingest CDC completions, WildW dumps, public event lists, and secondary docs into
+a provenance-labeled index.
+
+Pros:
+
+- broad discovery surface;
+- helpful for autocomplete and search before the runtime/resource generator is
+  complete;
+- WildW-style descriptor dumps are a good model for better runtime probes.
+
+Cons:
+
+- community data may be stale, partial, or from a different game build/state;
+- licensing/source provenance must be tracked;
+- not authoritative enough for package-owned declarations without
+  corroboration.
+
+Use for: hints, search terms, candidate roots, and comparison.
+
+Do not use for: generated first-class types unless promoted by official or
+runtime evidence.
+
+### Option 5: Hybrid Schema/Codegen Catalog
+
+Generate one normalized catalog from multiple evidence lanes, then emit
+secondary artifacts.
+
+Pros:
+
+- lets runtime observations and resource declarations coexist without blurring
+  evidence classes;
+- supports JSON catalog, TypeBox schemas, TypeScript type helpers, and
+  `@civ7/types` declaration candidates from the same model;
+- can mark availability, risk, read/write posture, and confidence per symbol.
+
+Cons:
+
+- requires careful schema design before implementation;
+- merge rules must be explicit when runtime, resources, and declarations
+  disagree;
+- generated outputs need stable ownership and review gates.
+
+Use for: package-owned direct-control catalog and later generated type outputs.
+
+This is the recommended option.
+
+## Recommended Catalog Shape
+
+The source artifact should be a normalized JSON catalog with a checked schema,
+owned by `@civ7/direct-control` when implemented. Generated `.d.ts` or ambient
+declaration patches should be emitted to, or proposed for, `@civ7/types`.
+
+Suggested top-level fields:
+
+| Field | Meaning |
+|---|---|
+| `schemaVersion` | Catalog schema version controlled by the package. |
+| `generatedAt` | Generation timestamp; avoid using as semantic authority. |
+| `gameBuild` | Civ7 build/version if available from runtime/resource metadata. |
+| `resourceSource` | Official resources path, submodule commit, and module set. |
+| `probeRuns` | Runtime probe ids, host/port, state ids/names, phase labels. |
+| `symbols` | Normalized roots, properties, methods, tables, operations, events. |
+| `resourceTables` | SQL/XML-derived table schemas and row metadata. |
+| `conflicts` | Explicit disagreements between evidence sources. |
+| `unknowns` | Known missing metadata and reframe triggers. |
+
+Suggested fields per symbol:
+
+| Field | Meaning |
+|---|---|
+| `id` | Stable catalog id, for example `runtime.AppUI.Network.restartGame`. |
+| `path` | Runtime path such as `Network.restartGame` or `GameInfo.Maps`. |
+| `kind` | `root`, `property`, `method`, `table`, `rowType`, `operation`, `event`, `moduleExport`. |
+| `surface` | `app-ui`, `tuner`, `map-generation`, `official-resource`, `ambient-types`, or `public-hint`. |
+| `availability` | State/phase matrix with observed `present`, `absent`, `timeout`, or `not-probed`. |
+| `valueType` | Runtime `typeof`, resource type, and/or TypeScript type. |
+| `descriptor` | Own/prototype/enumerable/configurable/writable/getter/setter metadata when observed. |
+| `call` | Function metadata: native flag, `length`, sampled source text, inferred params, return probes. |
+| `access` | `read`, `write`, `command`, `constructor`, `event`, `data`, or `unknown`. |
+| `risk` | Side-effect/risk tier; see below. |
+| `confidence` | `runtime-observed`, `official-resource`, `declared`, `public-hint`, or merged values. |
+| `provenance` | File paths, line anchors where available, probe id, command snippet, and source class. |
+| `examples` | Official resource call examples or safe read-only probe examples. |
+| `notes` | Human review notes for limitations or wrapper decisions. |
+
+For `GameInfo` tables, include:
+
+- table name and runtime access path;
+- primary key columns;
+- columns with SQLite/XML type, nullability, default, and foreign keys;
+- row id/type column when known, such as `MapSizeType`, `CommandType`, or
+  `OperationType`;
+- row count and source modules if generation loads XML overlays;
+- emitted TypeScript row interface name and optional literal union name.
+
+## Read/Write/Risk/Availability Marking
+
+Read/write classification should be separate from confidence. A method can be
+runtime-observed and still have unknown or high-risk side effects.
+
+Recommended `access` values:
+
+- `read`: getter/property/query with read-only proof or strong naming/resource
+  evidence.
+- `write`: mutates game/runtime state, such as `WorldBuilder.MapPlots.set*`.
+- `command`: sends a game operation/command request, restart, save/load, begin,
+  network call, autoplay control, or UI action.
+- `data`: resource rows, table schemas, constants, enum-like type ids.
+- `event`: event subscription or emitted event names.
+- `unknown`: callable or property exists but safety is not established.
+
+Recommended `risk` values:
+
+- `none`: static data or pure local conversion.
+- `read-only`: sampled read-only runtime query.
+- `local-ui`: affects UI/client state but not save/game state.
+- `game-state`: mutates game state, map, units, players, autoplay, or turn flow.
+- `file-save-load`: save/load/delete/restart operations.
+- `network-account`: online, account, invite, chat, multiplayer, QR, or URL
+  actions.
+- `destructive`: delete, destroy, kick, reset, overwrite, or irreversible flows.
+- `unknown`: insufficient evidence.
+
+Recommended availability dimensions:
+
+- `stateRole`: `app-ui` or `tuner`.
+- `stateName` and `stateId`: record observed id but do not treat it as stable.
+- `phase`: `shell`, `loading`, `waiting-ui-ready`, `post-begin`,
+  `age-transition`, `map-generation`, `worldbuilder-active`, `multiplayer`,
+  or `unknown`.
+- `result`: `present`, `absent`, `timeout`, `throws`, `not-probed`.
+- `evidence`: probe id, source file, or declaration/resource path.
+
+## TypeScript And TypeBox Integration
+
+Use TypeBox for the catalog schema, not as the main way to express Civ7 ambient
+globals. This repo already uses TypeBox in MapGen-facing packages, so a
+TypeBox-backed catalog schema would give:
+
+- runtime validation for generated JSON catalogs;
+- static `Static<typeof CatalogSchema>` TypeScript types for package APIs;
+- a JSON-schema export if CLI/Studio/editor tools need to consume the catalog.
+
+Keep the generated ambient declarations type-only in `@civ7/types`. Good later
+outputs are:
+
+- `catalog.generated.json` for direct-control/search/UI tools;
+- `catalog.generated.d.ts` or source types for catalog consumers;
+- `gameinfo.generated.d.ts` for `GameInfo` table row declarations;
+- `operations.generated.ts` as literal unions or const arrays for command ids;
+- a review report diffing generated declarations against current
+  `packages/civ7-types/index.d.ts`.
+
+Do not generate direct-control wrapper methods from the catalog automatically.
+Wrapper APIs should still be deliberate package code with explicit state,
+timeout, idempotency, and side-effect contracts.
+
+## Recommended Package Ownership
+
+- `@civ7/direct-control` owns the runtime probe implementation, state/phase
+  availability evidence, direct-control capability catalog schema, and generated
+  catalog artifact.
+- `@civ7/types` owns ambient declarations for Civ7 runtime globals and virtual
+  modules. It may consume generated resource/runtime facts, but should remain
+  type-only.
+- Official resources remain evidence inputs under `.civ7/outputs/resources`;
+  do not hand-edit them.
+- CLI and Studio should consume the package catalog and direct-control helpers;
+  they should not implement socket probes or local catalog generation.
+
+## Unknowns And Limits
+
+- Native function signatures remain opaque. `Function.prototype.toString` and
+  `length` are useful fingerprints, not reliable argument schemas.
+- Opaque runtime objects may have getters with side effects or throw on access;
+  descriptor-first probing should avoid invoking getters unless explicitly
+  requested.
+- `GameInfo` tables are dynamic. Runtime own-key enumeration does not reveal the
+  schema; resource parsing and targeted `GameInfo.<Table>.lookup(...)` probes
+  are required.
+- State availability is contextual. `LSQ:` presence does not prove Tuner command
+  readiness, and App UI/Tuner roots differ before and after Begin Game.
+- Official SQL/XML schemas may require module/DLC overlay/load-order semantics
+  before row counts and final unions are correct.
+- Public corpora can seed searches, but should not silently become authoritative
+  package declarations.
+- Broad runtime dumps can be too large for the tuner socket or terminal output;
+  probes need root allowlists, depth limits, cycle handling, output truncation
+  flags, and timeout controls.
+
+## Reframe Triggers
+
+- A fresh runtime probe shows Civ7 exposes reliable parameter metadata through a
+  native reflection API not currently used.
+- Official resources gain complete `.d.ts` or schema metadata for runtime
+  globals.
+- `GameInfo` table availability differs materially by game state, DLC set, age,
+  or mod load order.
+- Tuner-panel actions require a FireTuner-injected `g_TunerState` or UI event
+  path that direct socket eval cannot create safely.
+- Generated catalog size becomes too large for package distribution, forcing a
+  split between compact runtime capability catalog and separate resource data
+  indexes.
+- Wrapper generation is proposed for mutating commands; require a separate
+  design/review because catalog evidence is not enough to prove safety.
+
+## Recommendation
+
+Build the future artifact as a provenance-aware hybrid catalog first, then
+generate TypeScript declarations from reviewed slices. The catalog should make
+uncertainty explicit: runtime-observed availability is not the same thing as an
+official resource declaration, and neither is the same thing as a safe
+direct-control wrapper.
+
+Near-term implementation order when this becomes package work:
+
+1. Define a TypeBox catalog schema in `@civ7/direct-control`.
+2. Upgrade runtime probes to descriptor-first metadata with phase labels and
+   root allowlists.
+3. Add an official-resource parser for SQL table schemas and selected XML type
+   rows.
+4. Emit a generated JSON catalog and a human-readable diff/report.
+5. Feed stable/corroborated declaration slices into `@civ7/types` only after
+   review.


### PR DESCRIPTION
Adds a capability inventory workstream for the `civ7-direct-control` project, covering five investigation areas completed on 2026-05-31.

**Investigation brief and team plan** establish the scope and parallel-lane structure: App UI surface, Tuner surface, type/catalog generation, and automation playability, with an owner consolidation step.

**App UI surface report** documents `App UI` as a distinct runtime surface owning lifecycle and client control — restart, Begin Game, loading state, network/session status, autoplay, camera, and UI helpers. It classifies reads as wrap-ready and mutations as raw/elevated until bounded proof exists.

**Tuner surface report** documents the post-Begin `Tuner` state as the stronger gameplay and map surface, exposing `TerrainBuilder`, `ResourceBuilder`, `FertilityBuilder`, `AreaBuilder`, `Game.*Operations`, `Game.*Commands`, `Units`, `Cities`, `MapUnits`, `MapCities`, `MapAreas`, `MapRegions`, `MapConstructibles`, `Database`, and operation constants absent from App UI. Confirms that `LSQ:` state discovery alone is insufficient — a read-only command canary is required to verify Tuner readiness after Begin Game.

**Type generation report** evaluates four generator options (runtime introspection, official resource parsing, `civ7-types` uplift, public corpus index) and recommends a hybrid provenance-aware catalog backed by TypeBox, owned by `@civ7/direct-control`, with reviewed declaration slices fed into `@civ7/types`. Defines per-symbol fields for state availability, access classification, risk tier, confidence, and provenance.

**Automation playability report** assesses LLM/agent feasibility across six tiers. Developer status assistant and map/Studio automation are ready now. Supervised gameplay advisor and single-action executor are feasible after read wrappers and `canStart` validators are added. Autonomous whole-turn play is not currently feasible due to missing full state model, end-turn path, action schemas, event feedback, visibility filtering, and safety policy.

**Owner runtime probe notes** record the live read-only inspection commands and results: App UI exposes 549 top-level globals including `Network` (145 methods), `UI` (134 methods), `Camera`, `Automation`, and `Visibility`; Tuner exposes 227 globals including `GameplayMap` (74 methods), `TerrainBuilder`, `ResourceBuilder`, `FertilityBuilder`, `AreaBuilder`, and confirmed operation enum constants.

**Capability inventory consolidation** produces the surface matrix, wrap-now list, wrap-carefully list, raw-command list, map/Studio priority candidates, AI play feasibility tiers, type/catalog architecture, and ordered next implementation slices.