### PR TITLE
docs(civ7-direct-control): add control-surface expansion workstream reports

### DIFF
--- a/docs/projects/civ7-direct-control/workstream/control-surface-expansion/agent-action-surface.md
+++ b/docs/projects/civ7-direct-control/workstream/control-surface-expansion/agent-action-surface.md
@@ -1,0 +1,386 @@
+# Agent Action Surface Contract
+
+Date: 2026-05-31
+Lane: Mutating action-surface
+Status: contract-ready; no live mutation performed in this lane
+
+## Scope And Evidence
+
+This report turns the prior `wrap-carefully` candidates into first-class
+wrapper contracts for `@civ7/direct-control`. Proof planning and contracts are
+implementation work for this workstream, not optional deferrals. This lane does
+not authorize automatic replay of mutations and did not mutate a live Civ7
+session.
+
+Evidence labels used below:
+
+- `source`: repo source/docs inspected in this lane.
+- `official-resource`: official mirrored Civ7 resource evidence.
+- `recorded-live-proof`: prior workstream live probe evidence already recorded
+  in project docs.
+- `fresh-live-proof`: live proof collected during this lane. None collected.
+- `inference`: design conclusion from source/resource/live evidence.
+- `unresolved`: evidence is insufficient for a claim.
+
+Primary inputs:
+
+- `source`: `docs/projects/civ7-direct-control/workstream/capability-inventory/capability-inventory.md`,
+  `automation-playability-report.md`, `owner-runtime-probes.md`,
+  `app-ui-surface-report.md`, `tuner-surface-report.md`.
+- `source`: `packages/civ7-direct-control/src/index.ts` and package tests show
+  current transport, state selection, App UI snapshot, restart/begin, Tuner
+  readiness, and raw command execution.
+- `official-resource`: `world-input.js`, `unit-actions.js`,
+  `build-queue/model-build-queue.js`, `production-chooser` resources,
+  `tuner-input.js`, automation scripts, `panel-action.js`, pause-menu resources,
+  and operation enum usage.
+- `recorded-live-proof`: prior probes confirmed App UI restart/begin,
+  post-Begin Tuner readiness, root availability, operation routers, operation
+  enum globals, `Autoplay`, `Visibility`, `GameplayMap`, `Players`, `Units`,
+  `Cities`, `GameInfo`, and `Database`.
+
+## System Frame
+
+- `source` / `recorded-live-proof`: App UI owns lifecycle/session controls:
+  `Network.restartGame()`, `UI.notifyUIReady()`, loading state,
+  `GameContext`, `Autoplay`, network/account/session surfaces, and pause-menu
+  flows.
+- `source` / `recorded-live-proof`: Tuner owns post-Begin gameplay/map reads and
+  the safer state role for map/player/unit/city snapshots and operation-router
+  probing.
+- `official-resource` / `inference`: official UI uses a validator-first pattern:
+  `Game.<Domain>Operations.canStart(...)` or
+  `Game.<Domain>Commands.canStart(...)`, then `sendRequest(...)` only when
+  `Success` is true.
+- `inference`: the direct-control API should model three different products,
+  not collapse them: lifecycle automation, supervised gameplay execution, and
+  disposable-session debug/cheat actions.
+
+Dominant feedback loops:
+
+- Reinforcing risk loop: broader raw command exposure encourages agents to
+  synthesize more JS, which increases unvalidated mutation, which increases
+  session-corruption risk.
+- Balancing safety loop: state role selection, validator-first wrappers,
+  explicit approval, postcondition proof, and no replay reduce blast radius
+  while still enabling useful supervised control.
+
+## Universal Mutation Rules
+
+These rules apply to every mutating wrapper.
+
+1. State role is explicit. Lifecycle wrappers use App UI. Gameplay validators
+   and operation sends default to Tuner after post-Begin readiness. App UI may
+   be used only when the required global is App UI-only.
+2. Read wrappers may reconnect and retry. Mutating wrappers must not
+   automatically replay after timeout, disconnect, response parse failure, or
+   unknown postcondition.
+3. A mutating wrapper accepts an `approval` object or validation token and
+   returns the exact operation it will issue before execution in dry-run mode.
+4. `force` is not a normal bypass. If present at all, it must require
+   `approval.mode = "explicit-force"`, carry a reason, mark the result
+   `high-risk`, and still run pre/post snapshots.
+5. A `canStart` failure is a successful wrapper result, not a transport error.
+   The request wrapper must not call `sendRequest` when validation fails unless
+   the explicit-force path is used.
+6. Postcondition proof is mandatory: each request wrapper returns before/after
+   snapshots or an unresolved postcondition with no retry.
+7. Multiplayer/account/network/save/load/delete/exit surfaces are rejected from
+   this action surface unless a later owner decision creates a separate product
+   contract.
+
+## Wrapper Contracts
+
+### Restart And Begin Loop
+
+Contract: `restartCiv7Game()`, `beginCiv7Game()`,
+`restartCiv7GameAndBegin({ waitForTuner })`
+
+- State role: App UI.
+- Evidence: `source` current package constants and wrappers;
+  `official-resource` pause menu calls `Network.restartGame()` and load flow
+  uses `UI.notifyUIReady()`; `recorded-live-proof` restart returned `true`,
+  begin returned `null`, App UI reached `GameStarted`, and Tuner canary passed.
+- Validation sequence: discover states, select App UI, read App UI snapshot,
+  call restart only when App UI is command-ready, wait for loading states
+  `WaitingForUIReady` or `WaitingToStart`, call begin once, then wait for
+  `GameStarted`; optionally run Tuner health canary.
+- Postcondition proof: final App UI snapshot must show `GameStarted` and
+  `inGame`; optional Tuner health must show `ready: true`.
+- Failure behavior: timeout or disconnect leaves the result unresolved. The
+  implementation may reconnect for read polling, but must not issue a second
+  restart or begin after a mutation unless the caller starts a new explicit
+  request.
+- Risk: medium. It destroys current transient session progress but is a core
+  developer loop.
+
+### Autoplay Start, Stop, Status
+
+Contracts: `getAutoplayStatus()`,
+`configureAutoplay({ turns, observeAsPlayer, returnAsPlayer })`,
+`startAutoplay(approval)`, `stopAutoplay(approval)`.
+
+- State role: App UI first; Tuner allowed only after fresh wrapper proof shows
+  identical behavior in the target game phase.
+- Evidence: `source` App UI snapshot already reads autoplay fields;
+  `official-resource` automation scripts call `Autoplay.setTurns`,
+  `setReturnAsPlayer`, `setObserveAsPlayer`, `setActive(true)`,
+  `setPause(...)`, and stop with `setActive(false)`;
+  `recorded-live-proof` runtime probes observed `Autoplay` in App UI and Tuner.
+- Validation sequence: read status; require `turns` integer within package cap;
+  resolve observer/return player from `PlayerIds` where possible; reject
+  multiplayer by default; dry-run returns planned setter sequence.
+- Postcondition proof: after configure/start/stop, read status again and verify
+  `turns`, `observeAsPlayer`, `returnAsPlayer`, `isActive`, and pause state.
+  Completion proof should later use `AutoplayEnded`, `TurnBegin`, or `TurnEnd`
+  signals if an event bridge becomes part of the package.
+- Failure behavior: if start status is ambiguous, do not call stop
+  automatically unless the original command completed and the caller requested
+  `stopOnPostconditionFailure`. Never reissue `setActive(true)` on reconnect.
+- Risk: medium for bounded AI smoke tests; high if turns are uncapped or used
+  in a non-disposable player session.
+
+### Reveal And Explore Map
+
+Contracts: `getVisibilitySummary(playerId)`,
+`revealAllPlots({ playerId }, approval)`,
+`requestUnitExplore({ unitId }, approval)` after validator proof.
+
+- State role: Tuner for visibility reads; App UI or Tuner for
+  `Visibility.revealAllPlots` only after fresh proof identifies the live owner;
+  Tuner for unit explore operations.
+- Evidence: `source` capability reports observed `Visibility` methods and
+  recommend visibility summaries; `official-resource` UI uses
+  `GameplayMap.getRevealedState(...)` and `getRevealedStates(...)` to filter
+  hidden information; `recorded-live-proof` owner probes observed `Visibility`
+  as mutating and `Players.LiveOpsStats.numPlotsRevealed` as a progress read.
+- Validation sequence for reveal: require disposable-session approval, reject
+  multiplayer/account sessions, capture before visibility counts, confirm
+  target player is valid, then call the proven reveal method once.
+- Validation sequence for explore: call `canStartUnitOperation` or
+  `canStartUnitCommand` for the specific explore operation/command; require
+  local-player ownership; execute only if validation succeeds.
+- Postcondition proof: reveal requires increased revealed/visible counts or an
+  explicit already-revealed result. Explore requires unit status/location or
+  automation state change plus visibility/progress read.
+- Failure behavior: reveal failure is high-risk unresolved; do not retry.
+  Explore failure returns validator/request result and after snapshot.
+- Risk: reveal is high cheating/debug risk; explore is medium gameplay risk
+  when validator-backed and human-approved.
+
+### End Turn And Turn Complete
+
+Contracts: `getTurnCompletionStatus()`,
+`requestTurnComplete({ policy }, approval)`,
+`requestTurnUnready(approval)` where supported.
+
+- State role: App UI.
+- Evidence: `official-resource` `panel-action.js` checks
+  `GameContext.hasSentTurnComplete()`, calls `canEndTurn()`, activates
+  blocking notifications, then calls `GameContext.sendTurnComplete()`. It also
+  exposes `sendUnreadyTurn()` and maps `force-end-turn` directly to
+  `sendEndTurn()`. `source` App UI reports list `GameContext.sendTurnComplete`
+  as plausible and unproven.
+- Validation sequence: read local player, player turn-active state,
+  `GameContext.hasSentTurnComplete()`, notification blocker
+  `Game.Notifications.getEndTurnBlockingType(...)`, remaining-move indicators
+  where available, and multiplayer state. Default policy must refuse blockers.
+- Postcondition proof: after request, read `hasSentTurnComplete`, active player
+  turn state, turn number/date, and any blocker status. Success is either
+  `hasSentTurnComplete = true` or observed turn advancement.
+- Failure behavior: if blockers exist, return `blocked` with blocker metadata
+  and do not call `sendTurnComplete`. Do not expose a force-end-turn helper in
+  the first-class action surface.
+- Risk: medium for normal single-player turn completion; high for force-end
+  behavior, multiplayer, or modal-choice bypass.
+- Status: `unresolved` until fresh live proof exercises the read-only status and
+  one approved disposable turn-complete path.
+
+### Unit Validators And Approved Requests
+
+Contracts: `canStartUnitOperation(input)`, `canStartUnitCommand(input)`,
+`requestUnitOperation(input, approval)`, `requestUnitCommand(input, approval)`.
+
+- State role: Tuner.
+- Evidence: `official-resource` `unit-actions.js` iterates visible
+  `GameInfo.UnitOperations` and `GameInfo.UnitCommands`, calls
+  `Game.UnitOperations.canStart(...)` and `Game.UnitCommands.canStart(...)`,
+  and calls `sendRequest(...)` after successful validation. `world-input.js`
+  uses the same pattern for move, ranged/naval/air attack, swap, overrun, and
+  move-to. `recorded-live-proof` Tuner probes observed `Game.UnitOperations`,
+  `Game.UnitCommands`, and enum globals.
+- Validation sequence: resolve unit id; confirm unit exists; confirm owner is
+  the local player unless approval marks debug control; normalize operation or
+  command against observed enum/catalog; build args from a reviewed schema;
+  call `canStart(..., false)`; optionally call exclusion/target query with the
+  official boolean flag only as a read.
+- Postcondition proof: unit snapshot before/after: location, activity/status,
+  health/damage, movement, operation state, sight/reachable plots as relevant.
+- Failure behavior: validation failure returns `valid: false` with failure
+  reasons and no mutation. Request output with unknown postcondition is
+  `executed: unknown` and cannot be replayed automatically.
+- Risk: low for validator reads; medium for skip/sleep/fortify/wake/automate
+  explore; high for attacks, delete, upgrade, create, damage, or direct unit
+  mutation.
+
+### City Validators And Approved Requests
+
+Contracts: `canStartCityOperation(input)`, `canStartCityCommand(input)`,
+`requestCityOperation(input, approval)`, `requestCityCommand(input, approval)`.
+
+- State role: Tuner.
+- Evidence: `official-resource` build queue and production chooser resources
+  use `Game.CityOperations.canStart(city.id, CityOperationTypes.BUILD, args,
+  false)` and `Game.CityCommands.canStart(..., CityCommandTypes.PURCHASE, ...)`
+  before `sendRequest`. `recorded-live-proof` Tuner probes observed city
+  operation and command routers.
+- Validation sequence: resolve city id; confirm ownership/local player; inspect
+  city/build queue before state; normalize operation/command and args from a
+  reviewed schema; run `canStart`; require approval for request.
+- Postcondition proof: city/build queue before/after, production item,
+  purchase/gold/resource deltas where available, city name or growth mode when
+  relevant.
+- Failure behavior: no send on failed validator; no generic build/purchase
+  wrapper without schema and postcondition.
+- Risk: low for validators; medium for production queue reorder/cancel in a
+  disposable or approved session; high for purchases, city naming, growth mode,
+  WMD/ranged attack, expansion, or any irreversible city state.
+
+### Player Validators And Approved Requests
+
+Contracts: `canStartPlayerOperation(input)`,
+`requestPlayerOperation(input, approval)`.
+
+- State role: Tuner for validator/request, with App UI local-player context
+  only when required.
+- Evidence: `official-resource` tree/culture/government/diplomacy screens use
+  `Game.PlayerOperations.canStart(...)` before `sendRequest(...)`; tuner input
+  uses `Game.PlayerOperations.sendRequest(..., "CREATE_ELEMENT" |
+  "DESTROY_ELEMENT", args)` for debug creation/deletion. `recorded-live-proof`
+  Tuner probes observed player operations and operation enum examples.
+- Validation sequence: resolve local player; reject account/network/multiplayer
+  and diplomacy/war by default; normalize operation against enum/catalog and
+  allowlist; run `canStart`; require approval for request.
+- Postcondition proof: player summary before/after, specific progression node,
+  resource assignment, government/policy state, or diplomacy state as relevant.
+- Failure behavior: no generic `PlayerOperations.sendRequest` product wrapper.
+  Unknown schema means validator-only or raw expert command, not first-class
+  request execution.
+- Risk: low for validators; medium for tech/culture target selection after
+  schema proof; high for diplomacy/war, resource assignment, government/policy,
+  create/destroy element, extended game, or live-ops/account-adjacent choices.
+
+## Allowed Selected Actions
+
+Allowed as first implementation targets after their proof recipes pass:
+
+| Action | Class | Rationale |
+|---|---|---|
+| Autoplay configure/start/stop with turn cap | medium | `official-resource` automation uses the setters; bounded and observable. |
+| Unit skip/sleep/fortify/wake | medium | Common unit action family; validator-first and postcondition-friendly. |
+| Unit automate explore | medium | Satisfies explore-map need without direct reveal cheat; requires local-player unit and validator proof. |
+| Unit move to validated reachable plot | medium | Official UI validates movement and can provide target plots; requires visible/local-player filters. |
+| City build queue reorder/cancel | medium/high | Official build queue validates and sends; only allowed in approved/disposable sessions first. |
+| Player tech/culture target selection | medium/high | Official UI uses player operation validators; allowed only after schema proof and approval. |
+| Reveal all plots | high debug | Allowed only as explicit disposable-session debug wrapper, not gameplay assistance. |
+| Turn complete | medium/high | Allowed only when blocker check proves no required choice; no force-end wrapper. |
+
+## Rejected Raw Actions
+
+These remain raw expert/debug commands or rejected product surface:
+
+- Generic `Game.*Operations.sendRequest` or `Game.*Commands.sendRequest`.
+- Generic `Game.PlayerOperations.sendRequest`, especially
+  `CREATE_ELEMENT` / `DESTROY_ELEMENT`.
+- Direct `Units.create`, `Units.setLocation`, `Units.setDamage`,
+  `Units.restoreMovement`, `Units.changeExperience`, `Units.setActivity`.
+- `TerrainBuilder.*`, `ResourceBuilder.setResourceType`,
+  `FertilityBuilder.setFertilityType`, `AreaBuilder.recalculateAreas`.
+- `WorldBuilder.MapPlots.*`, `MapConstructibles.add*` / `remove*`, unless a
+  separate disposable map-edit contract is accepted.
+- `Players.grantYield`, grant great work/culture slot, force unlock/reveal
+  progression helpers, and other grant/cheat helpers.
+- `Database.query` mutation or unconstrained SQL.
+- `Configuration.edit*`, UI option writes, reload/refresh UI commands.
+- `Network.saveGame`, `loadGame`, `deleteGame`, `syncGame`, multiplayer,
+  account, invite, chat, kick, URL, legal, QR/linking, SSO/live-event flows.
+- `engine.call("exitToMainMenu")`, `exitToDesktop`, and implicit
+  save/reload/exit flows.
+
+## Live Proof Recipes
+
+General proof harness for every recipe:
+
+1. Use a disposable single-player session unless the recipe is read-only.
+2. Record App UI snapshot and Tuner health first.
+3. Record the exact command sequence in dry-run form.
+4. Execute at most one mutation per proof case.
+5. Capture before/after snapshots and relevant logs/events.
+6. If transport fails after mutation, mark postcondition `unresolved`; do not
+   replay.
+
+Autoplay proof:
+
+- Before: `getAutoplayStatus`, turn/date, local/observer player, multiplayer
+  flag.
+- Execute: configure `turns = 1`, set return/observe, start.
+- After: status active, then either `TurnEnd`/turn change or explicit stop.
+- Stop proof: call stop once and verify `isActive = false`.
+
+Reveal proof:
+
+- Before: `getVisibilitySummary(playerId)` and a bounded hidden/visible count.
+- Execute only with disposable debug approval.
+- After: visible/revealed count changes or already-revealed classification.
+- Reject proof if reveal affects an unexpected player or persists across
+  restart in a non-disposable way.
+
+Turn-complete proof:
+
+- Before: local player, turn active, `hasSentTurnComplete`, blocker type, turn
+  number/date.
+- Execute only when blocker type is `NONE` and no force policy is requested.
+- After: `hasSentTurnComplete = true` or turn advances. If blocker appears,
+  wrapper returns blocked and does not send.
+
+Unit operation proof:
+
+- Before: unit summary for one local unit, legal target/operation read.
+- Execute: skip/sleep/fortify or automate explore first; movement second only
+  to a validator-approved reachable plot.
+- After: activity/status/location changed as expected; no hidden-info target.
+
+City operation proof:
+
+- Before: city summary and build queue.
+- Execute: validator-only first. Request proof starts with a reversible or
+  disposable queue mutation.
+- After: queue order/progress/item reflects the request or failure is reported.
+
+Player operation proof:
+
+- Before: player summary and operation-specific state.
+- Execute: validator-only for all broad operations. First request proof should
+  target tech/culture selection only in a disposable session.
+- After: specific node/target state changes and no diplomacy/account/network
+  side effects.
+
+## Adversarial Review
+
+- `force-end-turn` is explicitly not a first-class wrapper because official UI
+  maps it directly to `sendEndTurn()` without normal blocker handling.
+- `canStart(..., true)` appears in official UI as an exclusion/target read path;
+  wrappers must not treat that boolean as authorization to bypass validation.
+- Operation enums are not schemas. Enum availability alone cannot authorize
+  request wrappers.
+- Raw `sendRequest` can corrupt a non-disposable session through war,
+  diplomacy, deletes, city production, hidden choices, or debug create/destroy.
+- `Network.save/load/delete/sync` and menu/exit calls can create implicit
+  persistence or reload effects; they are outside this lane.
+- Account, SSO, live-event, invite, chat, kick, URL, and multiplayer surfaces
+  are rejected even if exposed by App UI.
+- Direct map/world edits and grant helpers are developer cheat surfaces. They
+  must not be reachable by gameplay agents through the safe action surface.
+- Fresh live proof is still required before implementation claims any new
+  mutating wrapper as runtime-proven. Current lane evidence is source,
+  official-resource, recorded-live-proof, and inference only.

--- a/docs/projects/civ7-direct-control/workstream/control-surface-expansion/agent-catalog-types.md
+++ b/docs/projects/civ7-direct-control/workstream/control-surface-expansion/agent-catalog-types.md
@@ -1,0 +1,308 @@
+# Agent Catalog/Types Report
+
+Date: 2026-05-31
+Lane: Catalog/types
+Status: report only; no package code changed
+
+## Frame
+
+Objective: design the provenance-aware TypeBox catalog and generation path for
+`@civ7/direct-control`, plus the reviewed declaration path into `@civ7/types`.
+
+Selection: catalog runtime roots, methods, constants, operation metadata, and
+official-resource tables that are useful for developers, Studio/mapgen, players,
+and LLM agents. Foreground provenance, confidence, state role, side-effect risk,
+and review gates. Exterior: generated high-level wrappers, blind ambient
+declarations, native signature claims derived only from `Function.length`, and
+generated-output hand edits.
+
+Structural alternative considered: generate `.d.ts` declarations directly from
+runtime root dumps. Rejected because [source] current runtime inspection records
+presence, keys, owner, `length`, and signature samples, but [recorded-live-proof]
+the inventory says native functions commonly expose weak metadata such as
+`length: 0` and `[native code]`.
+
+Reframe trigger: fresh runtime proof exposes reliable native signature metadata,
+or official resources ship complete declaration metadata for runtime globals.
+
+## Evidence Ledger
+
+- [source] `packages/civ7-direct-control/src/index.ts` owns tuner socket framing,
+  state discovery, command execution, App UI snapshots, Tuner health, runtime
+  root inspection, and restart/begin lifecycle helpers.
+- [source] `packages/civ7-direct-control/package.json` has no TypeBox dependency
+  yet; adding the catalog schema implies a package dependency on `typebox`.
+- [source] `packages/civ7-types/index.d.ts` is type-only, but current public
+  declarations include `any` in `GameInfoTable<T = any>`, row catch-alls,
+  `engine.call(...): any`, and `/base-standard/*` catch-all exports.
+- [source] `packages/civ7-types/AGENTS.md` requires no runtime code in
+  `@civ7/types`.
+- [source] mapgen-core uses TypeBox as schema artifacts with `Static`, strict
+  object `additionalProperties: false`, schema-default helpers, and narrowly
+  documented `Type.Unsafe` escapes for typed arrays.
+- [official-resource] `.civ7/outputs/resources/Base/Assets/schema/gameplay/01_GameplaySchema.sql`
+  declares table columns, defaults, primary keys, and foreign keys for `Maps`,
+  `MapIslandBehavior`, `Types`, `Terrains`, `Biomes`, `Features`, `Resources`,
+  `UnitCommands`, and `UnitOperations`.
+- [official-resource] `maps.xml`, `unit-commands.xml`, and
+  `unit-operations.xml` provide row identifiers and UI metadata such as
+  `MAPSIZE_*`, `UNITCOMMAND_*`, and `UNITOPERATION_*`.
+- [official-resource] `tuner-input.js` shows worldbuilder and player-operation
+  call patterns including `WorldBuilder.MapPlots.*`,
+  `MapConstructibles.*`, and `Game.PlayerOperations.sendRequest(...)`.
+- [recorded-live-proof] `capability-inventory.md` records App UI and Tuner as
+  distinct surfaces: App UI owns lifecycle/client control, while Tuner becomes
+  the stronger gameplay/map surface after Begin Game.
+- [fresh-live-proof] none collected in this lane.
+
+## Recommended Shape
+
+Create a new source-owned schema module in `@civ7/direct-control`:
+
+```text
+packages/civ7-direct-control/src/catalog/schema.ts
+packages/civ7-direct-control/src/catalog/types.ts
+packages/civ7-direct-control/src/catalog/runtime-snapshot.ts
+packages/civ7-direct-control/src/catalog/resources.ts
+packages/civ7-direct-control/src/catalog/merge.ts
+packages/civ7-direct-control/src/catalog/report.ts
+```
+
+Use TypeBox for the catalog contract, not for ambient Civ7 globals. Export schema
+values and inferred types in the mapgen-core style:
+
+```ts
+export const Civ7ControlCatalogV1Schema = Type.Object({...}, {
+  additionalProperties: false,
+});
+export type Civ7ControlCatalogV1 = Static<typeof Civ7ControlCatalogV1Schema>;
+```
+
+Core schema entities:
+
+- `Catalog`: `schemaVersion`, `generatedAt`, `generator`, `resourceSource`,
+  `runtimeSnapshots`, `symbols`, `resourceTables`, `conflicts`, `unknowns`.
+- `EvidenceRef`: `class`, `path`, `line`, `probeId`, `stateRole`, `phase`,
+  `command`, `observedAt`, `notes`.
+- `Symbol`: `id`, `path`, `kind`, `surface`, `access`, `risk`, `availability`,
+  `runtime`, `resource`, `declaration`, `confidence`, `provenance`,
+  `wrapperRecommendation`.
+- `RuntimeMember`: descriptor-first metadata: `owner`, `typeof`, `own`,
+  `prototype`, `enumerable`, `configurable`, `writable`, getter/setter flags,
+  method fingerprint.
+- `ResourceTable`: SQL/XML table shape: columns, primary keys, foreign keys,
+  defaults, source rows, row-count per module set.
+
+Keep type complexity shallow: use discriminated unions for evidence classes,
+access, risk, and symbol kind; avoid recursive conditional types in public
+exports. Opaque runtime samples should be `unknown` inside parsed catalog types,
+not `any`.
+
+## Generated Files
+
+Source-owned files:
+
+- `src/catalog/schema.ts`: TypeBox schemas and `Static` types.
+- `src/catalog/runtime-snapshot.ts`: package-owned runtime probes.
+- `src/catalog/resources.ts`: official resource parser.
+- `src/catalog/merge.ts`: deterministic merge and conflict classification.
+- `src/catalog/report.ts`: human-readable report generation.
+
+Generated files:
+
+- `src/catalog/generated/catalog.generated.json`: normalized catalog, committed
+  only if review decides package distribution needs a checked-in snapshot.
+- `src/catalog/generated/catalog.generated.d.ts`: optional generated catalog
+  consumer types if `tsup --dts` is not sufficient.
+- `src/catalog/generated/gameinfo.generated.d.ts`: candidate declarations for
+  review, not imported blindly by `@civ7/types`.
+- `src/catalog/generated/operation-ids.generated.ts`: const arrays/literal
+  unions for operation and command identifiers, if package APIs need them.
+- `src/catalog/generated/type-generation-report.md`: review diff against
+  `packages/civ7-types/index.d.ts`.
+
+Do not treat `packages/civ7-direct-control/dist/**`, official resources, or
+deployed mod artifacts as source-owned. `dist/` remains generated build output.
+
+## Runtime Snapshot Command Shape
+
+Package API:
+
+```ts
+generateCiv7RuntimeSnapshot({
+  states?: ["app-ui", "tuner"],
+  roots?: { "app-ui"?: string[]; tuner?: string[] },
+  phase?: "shell" | "loading" | "waiting-ui-ready" | "post-begin" | "worldbuilder-active" | "unknown",
+  maxDepth?: number,
+  maxKeysPerObject?: number,
+  includeSamples?: boolean,
+  timeoutMs?: number,
+}): Promise<Civ7RuntimeSnapshotV1>
+```
+
+CLI shape:
+
+```bash
+civ7 game catalog snapshot --state app-ui --roots Network,UI,GameContext --json
+civ7 game catalog snapshot --state tuner --phase post-begin --roots Game,GameplayMap,Players,GameInfo --json
+civ7 game catalog generate --resources .civ7/outputs/resources --states app-ui,tuner --out packages/civ7-direct-control/src/catalog/generated/catalog.generated.json
+civ7 game catalog report --catalog .../catalog.generated.json --types packages/civ7-types/index.d.ts
+```
+
+Snapshot probes must be descriptor-first and bounded. They should use
+`Object.getOwnPropertyDescriptors`, avoid invoking getters by default, record
+accessor presence, and only run allowlisted read-only samples.
+
+## Official Resource Merge Strategy
+
+Merge lanes should remain distinct until the final normalized symbol:
+
+1. Parse SQL schemas from `Base/Assets/schema/**` into table definitions.
+2. Parse XML rows from Base and DLC/module trees into row sets with module
+   provenance and deterministic load-order metadata. If load order is not yet
+   implemented, mark row counts [unresolved] instead of final.
+3. Extract JS call-pattern hints from official scripts as usage evidence only.
+4. Join resource tables to runtime paths by explicit mapping, for example
+   `Maps -> GameInfo.Maps`, `UnitOperations -> GameInfo.UnitOperations`.
+5. Compare generated resource row interfaces with `@civ7/types`.
+6. Emit conflicts rather than resolving silently when declarations, resources,
+   and runtime observations disagree.
+
+Resource evidence can promote data ids and table columns; it cannot prove runtime
+availability, side-effect safety, or native function signatures.
+
+## Confidence And Provenance
+
+Use two fields, not one:
+
+- `confidence`: `fresh-live-proof`, `recorded-live-proof`, `source`,
+  `official-resource`, `declared`, `inference`, `unresolved`.
+- `provenance`: array of evidence refs with path/probe/line/phase details.
+
+Recommended symbol classifications:
+
+- `access`: `read`, `write`, `command`, `data`, `event`, `constructor`,
+  `unknown`.
+- `risk`: `none`, `read-only`, `local-ui`, `game-state`, `file-save-load`,
+  `network-account`, `destructive`, `unknown`.
+- `wrapperRecommendation`: `wrap-now`, `wrap-carefully`, `raw`, `research`,
+  `avoid`.
+
+Do not upgrade a symbol from `source` or `official-resource` to
+`fresh-live-proof` without a probe record from this generation run.
+
+## Selected Defaults
+
+Default runtime roots:
+
+- App UI: `Network`, `UI`, `GameContext`, `Game`, `Autoplay`, `Players`,
+  `PlayerIds`, `GameplayMap`, `Camera`, `WorldUI`, `Visibility`.
+- Tuner: `Game`, `Autoplay`, `GameplayMap`, `Players`, `PlayerIds`,
+  `GameInfo`, `Database`, `Units`, `Cities`, `MapUnits`, `MapCities`,
+  `MapAreas`, `MapRegions`, `MapConstructibles`, `Visibility`,
+  `TerrainBuilder`, `ResourceBuilder`, `FertilityBuilder`, `WorldBuilder`.
+
+Default constants and ids:
+
+- lifecycle/loading: `CIV7_UI_LOADING_STATES`, `UIGameLoadingState`.
+- operation ids: `UNITOPERATION_*`, `UNITCOMMAND_*`.
+- map/data ids: `MAPSIZE_*`, terrain, biome, feature, resource, continent,
+  fertility, player, visibility, landmass/region identifiers where resources or
+  runtime constants corroborate them.
+
+Default resource tables:
+
+- mapgen/Studio: `Maps`, `MapIslandBehavior`,
+  `MapResourceMinimumAmountModifier`, `Terrains`, `Biomes`, `Features`,
+  `Resources`, `Resource_Distribution`, start-bias tables.
+- developer/player/agent: `UnitOperations`, `UnitCommands`, `CityCommands`,
+  `Types`, `Kinds`, `Players`-adjacent operation/catalog tables where present.
+- keep raw/research: worldbuilder/editor mutation surfaces and account/network
+  tables unless a later product slice explicitly needs them.
+
+## Reviewed Declaration Path Into `@civ7/types`
+
+`@civ7/types` should receive reviewed declarations, not raw generator output.
+
+Proposed flow:
+
+1. Generate candidate declarations from catalog/resource slices into
+   `packages/civ7-direct-control/src/catalog/generated/*.d.ts`.
+2. Emit a diff report against `packages/civ7-types/index.d.ts` that flags new
+   symbols, changed property types, removed catch-alls, and remaining unknowns.
+3. Review slices by table/root family.
+4. Copy or promote accepted declarations into `packages/civ7-types/index.d.ts`
+   or future split type-only files.
+5. Keep provenance comments concise at declaration boundaries, for example
+   `// Generated from GameplaySchema.sql + maps.xml; reviewed 2026-05-31`.
+6. Run `bun run --cwd packages/civ7-types check`.
+
+Recommended cleanup direction:
+
+- Replace public `any` with `unknown` or narrower generated row types.
+- Keep catch-alls only where intentionally reviewed and label them as
+  unresolved compatibility surfaces.
+- Avoid ambient declarations for state-specific availability unless the comment
+  clearly says the declaration is not a readiness guarantee.
+
+## Tests And Gates
+
+Direct-control:
+
+- Schema validation tests for minimal/representative catalogs.
+- Merge tests for conflicting runtime/resource/declaration evidence.
+- Snapshot command tests with a fake tuner server that returns descriptor-rich
+  root data and verifies bounded roots/depth.
+- Resource parser tests against small SQL/XML fixtures and selected official
+  files.
+- Report tests ensuring conflicts and `any`/`unknown` leakage are surfaced.
+- `bun run --cwd packages/civ7-direct-control test`
+- `bun run --cwd packages/civ7-direct-control check`
+- `bun run --cwd packages/civ7-direct-control build`
+
+Types:
+
+- Generated declaration diff test or report snapshot.
+- `bun run --cwd packages/civ7-types check`
+
+OpenSpec/workstream:
+
+- `bun run openspec:validate` when an OpenSpec change is added.
+
+Fresh live proof gate:
+
+- Runtime snapshots can be generated without mutating game state.
+- Any command/mutation wrapper remains blocked until separate before/after proof
+  exists and the wrapper contract has explicit validation.
+
+## Review Checklist
+
+- Type-value drift: every exported catalog type must derive from TypeBox schema
+  or literal source values; no parallel hand-authored interfaces for generated
+  payloads.
+- Public `any` leakage: generated/public surfaces should use `unknown` for
+  opaque runtime samples and typed rows for reviewed `GameInfo` tables. Existing
+  `@civ7/types` `any` should be treated as debt to narrow, not copied.
+- Type complexity: prefer simple discriminated unions and data-first APIs.
+  Avoid deep conditional types, overload webs, and schema-to-wrapper metatypes.
+- Native signatures: `Function.length` and `toString()` are fingerprints only.
+  They may support drift detection; they do not define argument schemas.
+- Source versus generated: schema modules, parsers, merge logic, and CLI command
+  code are source-owned. Catalog JSON, declaration candidates, operation id
+  arrays, reports, `dist/`, and official resources are generated/evidence.
+- Wrapper generation: do not generate high-level wrappers from the catalog.
+  Wrapper APIs remain deliberate code with state, timeout, idempotency,
+  validation, and postcondition contracts.
+
+## Next Slice
+
+Open an implementation spec for the catalog foundation only:
+
+1. Add TypeBox dependency to `@civ7/direct-control`.
+2. Add `src/catalog/schema.ts` and schema validation tests.
+3. Add descriptor-first runtime snapshot generation for the selected default
+   roots.
+4. Add a resource parser for `Maps`, `Types`, `UnitCommands`, and
+   `UnitOperations`.
+5. Emit a report comparing generated facts to `@civ7/types`, without promoting
+   declarations until review.

--- a/docs/projects/civ7-direct-control/workstream/control-surface-expansion/agent-integration-cleanup.md
+++ b/docs/projects/civ7-direct-control/workstream/control-surface-expansion/agent-integration-cleanup.md
@@ -1,0 +1,331 @@
+# Integration/Cleanup Lane Report
+
+Date: 2026-05-31
+Lane: Integration/cleanup auditor
+Output contract: map CLI, Studio, docs, tests, and legacy references for the
+expanded `@civ7/direct-control` surface; identify obsolete FireTuner/Windows
+bridge or duplicated direct-control behavior to remove or quarantine once
+parity/better coverage is proven.
+
+## Evidence Labels
+
+- `[source]`: repo source, package docs, workstream docs, OpenSpec records, or
+  local search results inspected in this lane.
+- `[official-resource]`: checked-in official Civ7 resource mirror evidence.
+- `[recorded-live-proof]`: live proof recorded in prior workstream artifacts.
+- `[fresh-live-proof]`: live proof newly collected by this lane. None was
+  collected; this lane was source/documentation analysis only.
+- `[inference]`: recommendation derived from labeled evidence.
+- `[unresolved]`: still needs implementation, proof, or owner decision.
+
+## Summary
+
+- `[source]` The current implementation already routes CLI game commands through
+  `@civ7/direct-control`: `game restart`, `game exec`, `game health`, and
+  `game inspect` import package APIs from `packages/civ7-direct-control/src/index.ts`.
+- `[source]` Studio's Vite dev endpoint in `apps/mapgen-studio/vite.config.ts`
+  imports `restartCiv7GameAndBegin`, `snapshotFile`, and
+  `waitForFreshLogMarkers` from `@civ7/direct-control`; it does not implement
+  raw socket framing locally.
+- `[source]` Active cleanup specs explicitly forbid a FireTuner/Windows bridge
+  fallback and preserve FireTuner only as reference-client evidence:
+  `openspec/changes/remove-firetuner-bridge-legacy/**` and
+  `packages/civ7-direct-control/README.md`.
+- `[recorded-live-proof]` The prior direct-control surface workstream records
+  direct listener discovery, App UI restart/begin, `GameStarted`, Tuner health,
+  and fresh `Scripting.log` proof in
+  `openspec/changes/remove-firetuner-bridge-legacy/workstream/cutover-note.md`
+  and the `civ7-direct-control-surface` verification artifacts.
+- `[inference]` The integration slice should not rebuild transport. It should
+  add thin CLI/Studio consumers over new package wrappers, add focused tests for
+  those consumers, and delete or quarantine any remaining active guidance that
+  tells tools or agents to use bridge fallback behavior.
+
+## Files Inspected
+
+- `[source]` `packages/cli/AGENTS.md`
+- `[source]` `packages/cli/src/commands/game/restart.ts`
+- `[source]` `packages/cli/src/commands/game/exec.ts`
+- `[source]` `packages/cli/src/commands/game/health.ts`
+- `[source]` `packages/cli/src/commands/game/inspect.ts`
+- `[source]` `packages/cli/test/commands/game.control.test.ts`
+- `[source]` `packages/cli/test/commands/game.restart.test.ts`
+- `[source]` `apps/mapgen-studio/vite.config.ts`
+- `[source]` relevant Studio source references from `rg` under
+  `apps/mapgen-studio/**`
+- `[source]` `packages/civ7-direct-control/README.md`
+- `[source]` `packages/civ7-direct-control/AGENTS.md`
+- `[source]` `packages/civ7-direct-control/src/index.ts`
+- `[source]` `packages/civ7-direct-control/test/direct-control.test.ts`
+- `[source]` `docs/system/cli/overview.md`
+- `[source]` `docs/projects/civ7-direct-control/**`
+- `[source]` `openspec/changes/remove-firetuner-bridge-legacy/**`
+- `[source]` targeted `rg` results for `FireTuner`, `firetuner`, `bridge`,
+  `direct-control`, `DirectControl`, `CIV7_FIRETUNER`, `firetunerBridge`, and
+  `firetunerSocket`
+
+## Current Integration Map
+
+### Direct-Control Package
+
+- `[source]` `@civ7/direct-control` currently owns default host/port config,
+  host discovery, `LSQ:` state discovery, `CMD:<stateId>:<javascript>`
+  execution, framed socket parsing/encoding, persistent sessions, state
+  selection by role/name/id, App UI snapshots, Tuner readiness, restart/begin,
+  health polling, and fresh log marker proof helpers.
+- `[source]` Public package helpers already include
+  `executeCiv7Command`, `executeCiv7AppUiCommand`,
+  `executeCiv7TunerCommand`, `inspectCiv7RuntimeApi`,
+  `getCiv7AppUiSnapshot`, `beginCiv7Game`, `restartCiv7Game`,
+  `restartCiv7GameAndBegin`, `checkCiv7DirectControlHealth`,
+  `checkCiv7TunerHealth`, `waitForCiv7DirectControl`,
+  `waitForCiv7TunerReady`, `snapshotFile`, and `waitForFreshLogMarkers`.
+- `[inference]` All expanded wrappers should land here first. CLI, Studio, and
+  agent workflows should consume package-level read/action APIs instead of
+  embedding JavaScript command strings or protocol handling locally.
+
+### CLI
+
+- `[source]` `game restart` is a direct App UI lifecycle wrapper around
+  `Network.restartGame()`, with `--begin` and `--wait-tuner`.
+- `[source]` `game exec` is the raw expert escape hatch for arbitrary command
+  execution against a selected state.
+- `[source]` `game health` checks listener/state readiness and has `--tuner`
+  for the post-Begin Tuner gameplay canary.
+- `[source]` `game inspect` exposes bounded root inspection and
+  `--app-ui-snapshot`.
+- `[source]` CLI tests mock the framed tuner socket directly in tests, but the
+  command implementations use `@civ7/direct-control`; the duplicate protocol
+  code is test fixture code, not production transport.
+- `[inference]` New CLI commands should be presentation layers over wrapper
+  APIs, not new raw command builders. Keep `game exec` for expert debugging,
+  but do not make it the normal path for Studio, mapgen proof, or agents.
+
+### Studio
+
+- `[source]` The current Studio dev server endpoint writes a repo map config,
+  runs `mods/mod-swooper-maps deploy`, calls package restart/begin/Tuner-ready
+  helpers, and optionally waits for fresh log markers.
+- `[source]` Studio UI code currently treats restart as part of save/deploy
+  success/failure messaging. `rg` found no active Studio-owned FireTuner bridge
+  code outside the Vite endpoint's direct-control imports.
+- `[inference]` Studio should receive new direct-control behavior as explicit
+  dev server API endpoints, not browser-side socket access. Browser code should
+  call local `/api/*` endpoints; Vite/server code should call
+  `@civ7/direct-control`.
+
+### Docs And Workstream Records
+
+- `[source]` Active direct-control docs say FireTuner is reference-client
+  evidence only, not a required runtime. The bridge removal OpenSpec says no
+  fallback, no FireTuner clone, and no deletion of official FireTuner binaries.
+- `[source]` `.agents/skills/civ7-operational-debugging/**` still has
+  FireTuner-named reference material, but the inspected active guidance routes
+  runtime commands to `civ7 game restart`, `game exec`, and `game health`.
+- `[source]` `docs/_archive/**` and old engine-refactor archive/project files
+  contain unrelated or historical uses of "bridge" and some old FireTuner
+  references.
+- `[inference]` Active docs should be tightened when wrappers land. Historical
+  archives should not be mass-deleted; at most add archive context if a live
+  path links to stale bridge guidance as current instruction.
+
+## Recommended CLI Command/API Shape
+
+### Package API First
+
+- `[inference]` Add read-only wrappers in `@civ7/direct-control` before CLI:
+  `getCiv7PlayableStatus()`, `getCiv7MapSummary()`,
+  `getCiv7PlotSnapshot(x, y, playerId?)`, `getCiv7MapGrid({ fields, bounds })`,
+  `getCiv7PlayerSummary(playerId?)`, `getCiv7UnitSummary(playerId?)`,
+  `getCiv7CitySummary(playerId?)`, `getCiv7VisibilitySummary(playerId)`, and a
+  bounded `inspectCiv7Root({ state, root, maxKeys })`.
+- `[inference]` Keep lifecycle methods App UI-owned:
+  `restartCiv7Game()`, `beginCiv7Game()`,
+  `restartCiv7GameAndBegin({ waitForTuner })`.
+- `[inference]` Keep Tuner gameplay reads Tuner-preferred after
+  `waitForCiv7TunerReady()`. Do not route restart/begin through Tuner.
+- `[inference]` Mutating wrappers should be validator-first and explicit:
+  `getAutoplayStatus()`, `setAutoplay({ turns, observeAsPlayer, returnAsPlayer })`,
+  `stopAutoplay()`, then later `canStart*Operation` before any `request*Operation`.
+  Mutating wrappers must not auto-retry after reconnect or socket failure.
+
+### CLI Presentation
+
+- `[inference]` Add read commands as stable JSON-first surfaces:
+  - `civ7 game status --json`
+  - `civ7 game map summary --json`
+  - `civ7 game map plot <x> <y> --player <id> --json`
+  - `civ7 game map grid --fields terrain,biome,feature,resource --bounds x,y,w,h --json`
+  - `civ7 game player summary [playerId] --json`
+  - `civ7 game unit summary [playerId] --json`
+  - `civ7 game city summary [playerId] --json`
+  - `civ7 game visibility summary <playerId> --json`
+- `[inference]` Add catalog/inspection commands after the package catalog
+  schema exists:
+  - `civ7 game inspect root <root> --state Tuner --max-keys <n> --json`
+  - `civ7 game catalog snapshot --state Tuner --out <path>`
+- `[inference]` Add mutating commands only after package wrappers and proof:
+  - `civ7 game autoplay status --json`
+  - `civ7 game autoplay start --turns <n> --observe-as <id> --return-as <id> --json`
+  - `civ7 game autoplay stop --json`
+  - later validator-first `game action can-start ...` commands before any
+    `game action request ...`.
+- `[source]` Existing public commands and flags should remain compatible:
+  `game restart`, `game exec`, `game health`, and `game inspect`.
+- `[inference]` Compatibility concern: avoid changing existing JSON envelope
+  fields (`ok`, `request`, `response`, `health`, `inspection`, `snapshot`) in
+  place. Add new command surfaces or additive fields instead.
+
+## Studio Endpoint Candidates
+
+- `[inference]` Add Vite dev server endpoints that call package wrappers:
+  - `GET /api/civ7/status`: wraps `getCiv7PlayableStatus()`.
+  - `GET /api/civ7/map/summary`: wraps `getCiv7MapSummary()`.
+  - `GET /api/civ7/map/plot?x=&y=&playerId=`: wraps `getCiv7PlotSnapshot`.
+  - `POST /api/civ7/map/grid`: bounded fields/bounds request for
+    `getCiv7MapGrid`.
+  - `GET /api/civ7/player/:id/summary`: wraps player summary.
+  - `POST /api/civ7/compare/mapgen-runtime`: later endpoint that compares
+    MapGen browser-run artifacts to runtime grid/summary reads.
+- `[inference]` Keep save/deploy/restart as the current queued POST flow, but
+  extract the direct-control restart/log proof logic behind named server helpers
+  if more endpoints are added. Avoid duplicating marker definitions and error
+  envelope construction across endpoints.
+- `[inference]` Studio endpoints should return bounded JSON and treat direct
+  runtime reads as development-only proof surfaces. They should not expose
+  `game exec`-style arbitrary JavaScript from the browser.
+- `[unresolved]` Whether Studio needs persistent polling/streaming for runtime
+  comparison is not yet proven. Start with request/response endpoints and add
+  streaming only if grid extraction latency demands it.
+
+## Docs Updates Needed
+
+- `[source]` `packages/civ7-direct-control/README.md` currently documents the
+  existing transport, state surfaces, common calls, CLI examples, and bridge
+  policy.
+- `[inference]` When new read wrappers land, update the README with:
+  state ownership, wrapper list, read-only vs mutating labels, proof class, and
+  examples for `getCiv7PlayableStatus`, map/player/plot/grid summaries, and
+  bounded root inspection.
+- `[source]` `packages/cli/AGENTS.md` already lists direct game commands.
+- `[inference]` Update `packages/cli/AGENTS.md` after CLI expansion so agents
+  know normal usage is wrapper commands, while `game exec` stays expert/debug
+  escape hatch.
+- `[source]` `docs/system/cli/overview.md` currently appears to be a
+  mini-roadmap/feature tracker rather than a concise CLI system overview.
+- `[inference]` Reconcile `docs/system/cli/overview.md` with actual CLI
+  command surface. Avoid promising implemented wrapper commands before package
+  APIs and CLI tests exist.
+- `[source]` `docs/system/mods/swooper-maps/architecture.md` already describes
+  direct control as the rapid iteration path and FireTuner as reference-client
+  evidence.
+- `[inference]` Add Studio/runtime comparison guidance there only after live map
+  summary/grid wrappers are implemented and tested.
+- `[inference]` Keep `openspec/changes/remove-firetuner-bridge-legacy/**` as
+  the active cleanup record until all bridge-removal follow-through is closed;
+  do not promote old bridge instructions into canonical docs.
+
+## Cleanup Manifest
+
+| Path/pattern | Evidence | Disposition | Rationale |
+|---|---|---|---|
+| `packages/cli/src/utils/firetunerBridge.ts` | `[source]` listed in removal spec, absent in current tree | delete/keep deleted | Old bridge utility must not return. |
+| `packages/cli/test/utils/firetunerBridge.test.ts` | `[source]` listed in removal spec, absent in current tree | delete/keep deleted | Test should not preserve bridge contract. |
+| `packages/cli/src/utils/firetunerSocket.ts` | `[source]` mentioned in dirty `NOTE-TO-DRA.md`, absent in current tree | unresolved-check/keep deleted if absent | Verify history only if needed; do not recreate socket utility outside package. |
+| CLI `--transport bridge`, `--bridge-log`, `CIV7_FIRETUNER_*` flags/env | `[source]` removal spec and rg show no active CLI matches | delete/keep deleted | No bridge fallback where direct control covers behavior. |
+| `packages/cli/test/commands/game.*.test.ts` local socket fixtures | `[source]` tests implement fake server frame parsing | keep | Test-only fixture. It validates direct-control command behavior without production duplicate transport. |
+| `packages/civ7-direct-control/src/index.ts` socket framing/session code | `[source]` package owner | keep | Canonical owner of direct tuner-socket behavior. |
+| `apps/mapgen-studio/vite.config.ts` direct-control imports | `[source]` current Studio endpoint | keep/extend | Correct boundary: server-side Studio endpoint consumes package APIs. |
+| Studio browser code exposing save/deploy/restart UI | `[source]` App.tsx only consumes endpoint result | keep | UI presentation, not transport ownership. |
+| `packages/civ7-direct-control/README.md` bridge policy | `[source]` explicit no-bridge policy | keep/update | Canonical package-level guidance. |
+| `openspec/changes/remove-firetuner-bridge-legacy/**` | `[source]` active cleanup spec | keep until accepted/closed | Implementation-control record; not obsolete yet. |
+| `openspec/changes/civ7-direct-control-surface/**` | `[source]` downstack implementation record | keep | Recorded proof and decisions for parity. |
+| `.agents/skills/civ7-operational-debugging/references/firetuner-runtime.md` | `[source]` FireTuner-named but direct-control-first guidance | replace selectively | Rename or reframe later if the filename causes routing confusion; preserve FireTuner reference-client notes. |
+| `docs/_archive/**` FireTuner/bridge references | `[source]` archive rg results | archive/leave | Historical material. Do not mass edit unless linked as current guidance. |
+| `docs/projects/engine-refactor-v1/**` unrelated "bridge" references | `[source]` rg results | keep | Mostly MapGen architecture/migration bridge language, not FireTuner runtime bridge. |
+| `.civ7/outputs/resources/**` tuner files | `[official-resource]` official resource mirror | keep/read-only | Official game resource evidence; never cleanup-delete. |
+| External Civ7 Development Tools/FireTuner binaries | `[source]` removal spec says preserve | keep | Development tools and reference-client evidence, not repo-owned runtime code. |
+| `NOTE-TO-DRA.md` | `[source]` pre-existing untracked dirty file | quarantine/do not edit here | User/watcher dirty file; not part of this lane's write set. |
+
+## Tests Needed
+
+- `[inference]` Package unit tests for each read wrapper using the existing fake
+  tuner server fixture: assert state selection, command payload, bounded output,
+  parse failures, and classified errors.
+- `[inference]` Package tests for map/grid wrappers must cover bounds limits,
+  field allowlists, output-size controls, and failed/partial probes.
+- `[inference]` CLI command tests should mirror current
+  `game.control.test.ts`: run commands against a fake tuner server and assert
+  they call wrapper behavior rather than exposing bridge flags or raw
+  production socket code.
+- `[inference]` Studio endpoint tests should exercise the Vite middleware
+  handler shape without requiring a browser: valid payload, invalid bounds,
+  direct-control failure envelope, and no arbitrary JavaScript endpoint.
+- `[inference]` Add regression `rg`/guard check for active bridge fallback
+  strings in CLI/Studio/package docs: `firetunerBridge`, `firetunerSocket`,
+  `--transport bridge`, `--bridge-log`, `CIV7_FIRETUNER`, and "fallback to
+  FireTuner" outside archives or explicit reference-client docs.
+- `[inference]` For mutating wrappers, require fresh live proof in a disposable
+  game state: before snapshot, command result, after snapshot, and no
+  auto-retry after reconnect. Mock tests alone should not claim runtime safety.
+- `[recorded-live-proof]` Existing restart/begin/Tuner health proof can support
+  continued lifecycle behavior, but it does not prove new map/player/action
+  wrappers.
+- `[fresh-live-proof]` None collected by this lane.
+
+## Graphite Slice Sequencing
+
+1. `[inference]` Direct-control read wrapper slice:
+   package APIs, package tests, README update. No CLI/Studio changes except
+   compile fixes if required.
+2. `[inference]` CLI read command slice:
+   add JSON-first commands over package wrappers, CLI tests, CLI docs/AGENTS
+   updates. Preserve existing command compatibility.
+3. `[inference]` Studio runtime-read slice:
+   add `/api/civ7/*` read endpoints and UI consumers for map/runtime comparison
+   only after package wrappers exist. Include endpoint tests or build-level
+   verification plus manual/local proof notes.
+4. `[inference]` Catalog/inspection slice:
+   TypeBox catalog schema and bounded root/catalog snapshot command; update
+   docs with evidence classes.
+5. `[inference]` Mutating wrapper slice:
+   autoplay first, then validator-only operation checks, then one narrow
+   request operation if live proof succeeds. Each mutating slice needs fresh
+   live proof or stays source-only.
+6. `[inference]` Cleanup guard slice:
+   add active-string guard/tests and remove or quarantine any active stale
+   bridge guidance discovered during the above work. Do not edit archives or
+   official resources as cleanup.
+
+## Review Findings And Risks
+
+- `[source]` No active production duplicate socket logic was found in CLI or
+  Studio. The duplicate frame parsing in CLI tests is a local fake server
+  fixture and should stay test-only.
+- `[source]` No active CLI FireTuner bridge flags or bridge utility files were
+  found by targeted search.
+- `[source]` Active docs mostly present direct-control-first guidance, but some
+  FireTuner-named operational references remain and should be reviewed for
+  reader confusion during cleanup.
+- `[inference]` The largest false-promise risk is documenting map/player/action
+  wrappers as implemented before package APIs, tests, and fresh runtime proof
+  exist.
+- `[inference]` The largest compatibility risk is reshaping existing `game`
+  command JSON outputs. Add commands or additive fields rather than changing
+  existing envelopes.
+- `[inference]` The largest cleanup risk is overbroad deletion: official
+  FireTuner development tools, `.civ7/outputs/resources/**`, and historical
+  archive material are evidence or history, not runtime bridge fallbacks.
+
+## Open Items
+
+- `[unresolved]` Exact package wrapper names may shift during the state-role,
+  read-surface, and action-surface lanes; CLI/Studio should follow the final
+  package API names.
+- `[unresolved]` Studio runtime comparison UX is not specified. Endpoint shape
+  can be implemented before detailed UI, but user-facing panels need a separate
+  design pass.
+- `[unresolved]` Direct-control map/grid performance limits need empirical data
+  against real map sizes before Studio should poll or stream them.
+- `[unresolved]` Mutating wrappers beyond restart/begin need fresh live proof
+  in disposable sessions before being documented as supported behavior.

--- a/docs/projects/civ7-direct-control/workstream/control-surface-expansion/agent-state-role-architecture.md
+++ b/docs/projects/civ7-direct-control/workstream/control-surface-expansion/agent-state-role-architecture.md
@@ -1,0 +1,183 @@
+# State-Role Architecture Report
+
+Date: 2026-05-31
+Lane: State-role architect
+Scope: `@civ7/direct-control` control-surface expansion
+
+## Evidence Labels
+
+- [source] Claim comes from repo instructions, project/workstream docs, OpenSpec
+  artifacts, or current source.
+- [official-resource] Claim comes from `.civ7/outputs/resources` evidence
+  described by the inventory reports.
+- [recorded-live-proof] Claim comes from recorded runtime probes/reports already
+  captured in project artifacts.
+- [fresh-live-proof] Claim comes from a live probe run for this report.
+- [inference] Claim is a reasoned architecture conclusion from the labeled
+  evidence.
+- [unresolved] Claim is not proven enough to authorize implementation.
+
+No fresh live probes were run for this report; there are no [fresh-live-proof]
+claims.
+
+## Selected Architecture
+
+- [source] `packages/civ7-direct-control` remains the single repo-owned boundary
+  for Civ7 tuner socket defaults, `LSQ:` state discovery, state selection,
+  `CMD:<stateId>:<javascript>` execution, frame parsing, reconnect polling,
+  health checks, classified errors, restart/begin orchestration, runtime API
+  inspection, and fresh log proof helpers.
+- [source] App UI and Tuner are state roles inside the same direct-control
+  boundary, not interchangeable transports, not caller-selected substitutes,
+  and not a parity surface.
+- [source] App UI owns lifecycle/client/session controls: restart, native begin,
+  loading state, UI shell/game status, network/session status, local context,
+  App UI snapshot, and App UI-facing automation/status reads.
+- [recorded-live-proof] `Network.restartGame()` and `UI.notifyUIReady()` are
+  recorded as App UI commands, while Tuner lacks `Network`, `UI`, and
+  `GameContext` in recorded post-Begin probes.
+- [source] Tuner owns post-Begin gameplay/map/control APIs after a read-only
+  gameplay canary proves readiness; `LSQ:` state presence alone is not readiness.
+- [recorded-live-proof] Recorded Tuner health returned `Game`, `Autoplay`,
+  `GameplayMap`, and `Players` with turn/date, map dimensions, and alive player
+  ids after Begin Game.
+- [inference] The smallest durable architecture is a state-role API layer over
+  the existing direct socket package: shared transport/session/error machinery
+  below, App UI lifecycle domain and Tuner gameplay domains above, and raw
+  command execution kept as an explicit expert escape hatch rather than a safe
+  high-level API.
+
+## Ownership Boundaries
+
+| Owner | Owns | Must not own |
+|---|---|---|
+| [source] `@civ7/direct-control` transport/session core | Socket endpoint config, request framing, state discovery, state selection, command execution, reconnect polling, classified errors, raw state-scoped command helpers. | CLI output formatting, Studio HTTP shape, generated outputs, deployed mods, official resource files, caller-local socket protocol code. |
+| [source] App UI role API | `restartCiv7Game`, `beginCiv7Game`, `restartCiv7GameAndBegin`, App UI snapshot, loading/session/client/local context reads, future bounded App UI automation controls. | Post-Begin gameplay/map ownership, generic gameplay command routers, Tuner readiness proof. |
+| [source] Tuner role API | `checkCiv7TunerHealth`, `waitForCiv7TunerReady`, post-Begin map/player/unit/city/visibility/catalog reads, future validator-first gameplay controls. | Restart, native begin, lifecycle loading flow, network/account/session client controls. |
+| [source] CLI | Command parsing, flags, terminal/JSON output, command names, process exit semantics. | Socket framing, state discovery implementation, reconnect logic, independent state-role semantics. |
+| [source] Studio | HTTP endpoint shape, UI copy, save/deploy workflow, runtime comparison presentation. | Socket framing, direct runtime protocol logic, package-internal wrapper ownership. |
+| [official-resource] Official resources | Game facts, schemas, examples of Firaxis call shapes, reference-client usage evidence. | Repo API ownership, package architecture, product promise, generated source truth. |
+
+## OpenSpec Change Recommendations
+
+- [source] Keep the existing `civ7-direct-control-surface` requirement for one
+  direct-control owner and state-specific App UI/Tuner behavior; do not reopen
+  transport ownership in this lane.
+- [source] Add a new OpenSpec slice for state-role read APIs before mutating
+  action APIs. It should specify App UI lifecycle reads separately from Tuner
+  post-Begin map/gameplay reads.
+- [inference] The read slice should define stable output contracts, bounded
+  result sizes, state role used, proof boundary, and error behavior for each
+  wrapper; implementation can then land in small Graphite layers.
+- [source] Add a later OpenSpec slice for mutating gameplay/action APIs only
+  after read APIs exist, with validator-first contracts, explicit mutation
+  labels, no automatic replay after socket failure, and before/after proof.
+- [inference] Add a catalog/types slice after the read slice, because catalog
+  entries need state-role provenance and read-wrapper experience before they can
+  classify roots, methods, constants, and risk accurately.
+- [source] Avoid spec text that says App UI and Tuner are equivalent surfaces,
+  allows generic state substitution, or implies callers can route lifecycle
+  controls through Tuner.
+- [source] Avoid daemon/service scope until a future accepted decision proves
+  multiple external clients or shared long-lived sessions need process
+  lifecycle ownership.
+
+## Required API Domains
+
+| Priority | Domain | State role | Minimal API shape |
+|---|---|---|---|
+| [source] P1 | Lifecycle/client status | App UI | Existing restart/begin helpers plus `getCiv7AppUiSnapshot`; keep names state-explicit where ambiguity matters. |
+| [source] P1 | Tuner readiness | Tuner | Existing `checkCiv7TunerHealth` and `waitForCiv7TunerReady`; readiness remains a command canary with gameplay globals and basic map/player facts. |
+| [source] P1 | Map summary/grid/plot reads | Tuner | `getCiv7MapSummary`, `getCiv7PlotSnapshot`, `getCiv7MapGrid`, with field/bounds limits and projection-proof wording. |
+| [source] P1 | Player/unit/city reads | Tuner | `getCiv7PlayerSummary`, `getCiv7UnitSummary`, `getCiv7CitySummary`, all bounded by player/filter options and clear visibility semantics. |
+| [source] P1 | Visibility reads | Tuner | `getCiv7VisibilitySummary(playerId)` and optional bounded revealed-state grid; no reveal mutation in the read slice. |
+| [source] P2 | Catalog/table reads | Tuner preferred | `getCiv7GameInfoRows(table, options)` or catalog snapshot helpers with allowlists/limits; raw SQL remains outside first-class safe APIs. |
+| [source] P2 | Runtime inspection | Both | Keep `inspectCiv7RuntimeApi` and add state-role convenience wrappers only if they preserve root allowlists and provenance labels. |
+| [source] P2 | Autoplay controls | App UI or Tuner, explicit | Later mutating API with max-turn cap, before/after status, stop semantics, and caller-visible mutation label. |
+| [source] P2 | Gameplay actions | Tuner | Later validator-first `canStart*` wrappers before any `sendRequest` wrapper; action execution requires named operation contracts and postcondition reads. |
+| [unresolved] P2 | Map editing/builders | Tuner research/raw | `TerrainBuilder`, `ResourceBuilder`, `FertilityBuilder`, `AreaBuilder`, and related map mutation helpers need disposable-session proof and ownership decisions before wrapping. |
+
+## Stop And Reframe Triggers
+
+- [source] Stop if a proposed API duplicates socket/state ownership outside
+  `@civ7/direct-control`.
+- [source] Stop if a proposed spec or implementation treats App UI and Tuner as
+  parity surfaces or permits lifecycle commands to drift into Tuner ownership.
+- [source] Stop if a mutating wrapper can be retried automatically after socket
+  failure or reconnect without an explicit new caller request.
+- [source] Stop if a high-level wrapper is just a generic operation/request
+  launcher without a named state role, validator contract, bounded inputs, and
+  observable result.
+- [source] Reframe if fresh runtime evidence shows App UI no longer owns restart
+  or native begin in supported lifecycle phases.
+- [source] Reframe if fresh runtime evidence shows Tuner cannot reliably provide
+  post-Begin gameplay readiness, map reads, or basic player facts.
+- [unresolved] Reframe if useful gameplay actions require UI selection/input
+  state outside `CMD:<stateId>:<javascript>`.
+- [unresolved] Reframe if `GameInfo`/`Database` result sizes or query semantics
+  cannot be bounded for safe package APIs.
+- [unresolved] Reframe if map/player mutation proof shows persistent corruption
+  or validation bypass that cannot be contained to disposable sessions.
+
+## P1 Risks
+
+- [source] Duplicate ownership: CLI, Studio, or a future service could regain
+  socket/state behavior if wrapper contracts are vague. Mitigation: specs must
+  require imports from `@civ7/direct-control` for runtime control and tests
+  should cover presentation-only callers.
+- [source] State-role collapse: generic helper names can hide whether App UI or
+  Tuner owns behavior. Mitigation: public APIs should encode the role where
+  ambiguity changes semantics, and docs/specs should state the selected role.
+- [source] Mutation replay: reconnect helpers can accidentally replay commands
+  if action wrappers share read-polling machinery. Mitigation: retry only
+  read-only discovery/health probes; each mutation needs one caller-owned
+  attempt plus follow-up proof.
+- [inference] Over-broad service scope: adding a long-running daemon now would
+  create lifecycle, port, concurrency, and auth questions before the API domains
+  are stable. Mitigation: keep this lane inside package/session APIs.
+
+## P2 Risks
+
+- [source] Catalog overclaim: runtime introspection finds roots/method names but
+  weak signatures and native `length` values. Mitigation: catalog entries need
+  provenance, confidence, and manual mutation classification.
+- [source] Raw database/query exposure: `GameInfo` and `Database` are useful but
+  dynamic and potentially large. Mitigation: allowlisted tables, row limits, and
+  safe read helpers before any general query convenience.
+- [source] Hidden-information reads: map/player snapshots may expose facts a
+  player should not see. Mitigation: visibility-aware options and explicit
+  proof labels for omniscient developer reads versus player-visible reads.
+- [source] FireTuner panel globals: official panel code is useful call-shape
+  evidence, but panel globals are not proven direct-control roots. Mitigation:
+  require state-scoped live proof before treating panel globals as callable.
+- [unresolved] Map editing semantics: builder and constructible APIs may require
+  worldbuilder/session modes or cleanup semantics. Mitigation: keep raw until
+  disposable-session proof and postcondition checks exist.
+
+## Review Checklist For Implementation
+
+- [ ] [source] Every new public API states its role: App UI, Tuner, or both with
+  separate behavior.
+- [ ] [source] Lifecycle/client APIs target App UI and do not assume Tuner
+  globals.
+- [ ] [source] Post-Begin gameplay/map APIs target Tuner and require the Tuner
+  readiness canary where appropriate.
+- [ ] [source] CLI and Studio code import package APIs and contain no socket
+  framing, state discovery, or reconnect ownership.
+- [ ] [source] Specs avoid language that makes App UI and Tuner equivalent or
+  allows hidden alternate-control paths.
+- [ ] [source] Mutating APIs are labeled as mutating, bounded, single-attempt,
+  and paired with before/after or postcondition reads.
+- [ ] [source] Read APIs have bounded result sizes, explicit filters, and clear
+  visibility/omniscience semantics.
+- [ ] [source] Catalog/type outputs carry state, source, confidence, risk, and
+  wrapper recommendation; native runtime metadata is not promoted into precise
+  signatures without corroboration.
+- [ ] [source] No daemon/service process is introduced without a separate
+  accepted architecture decision.
+- [ ] [source] Generated outputs, logs, deployed mods, and official resources are
+  used only as evidence, not edited as source.
+- [ ] [source] Tests cover state selection, role-specific failures, output
+  bounds, classified errors, and no replay of mutating commands.
+- [ ] [recorded-live-proof] Runtime proof claims name the exact session/phase
+  they prove and do not generalize beyond that boundary.


### PR DESCRIPTION
This PR adds four workstream design documents for the `civ7-direct-control` control-surface expansion, covering the architecture and contracts needed before any new mutating wrappers are implemented.

**State-Role Architecture** establishes that App UI and Tuner are distinct roles with non-overlapping ownership: App UI owns restart, begin, loading state, and session controls; Tuner owns post-Begin gameplay, map, player, unit, city, and visibility reads. It defines stop/reframe triggers to prevent state-role collapse, duplicate socket ownership, or automatic mutation replay after reconnect.

**Agent Action Surface Contract** promotes prior `wrap-carefully` candidates into first-class wrapper contracts with explicit validation rules. Every mutating wrapper must use a validator-first pattern (`canStart` before `sendRequest`), accept an approval token, return a dry-run description before execution, capture before/after snapshots, and never auto-replay after failure. The document defines contracts for restart/begin, autoplay, map reveal, turn completion, and unit/city/player operations, along with an explicit list of rejected raw surfaces (direct `Units.*` mutation, `TerrainBuilder`, `Network.saveGame`, `Database` mutation, exit/reload flows, and generic `sendRequest` wrappers).

**Agent Catalog/Types Report** designs a provenance-aware TypeBox catalog for `@civ7/direct-control` that merges runtime descriptor snapshots, official SQL/XML resource tables, and existing `@civ7/types` declarations. It specifies the module layout under `src/catalog/`, confidence and provenance fields for every symbol, a descriptor-first snapshot command shape, and a reviewed promotion path into `@civ7/types` that replaces public `any` with `unknown` or narrower generated row types without blindly importing generated output.

**Integration/Cleanup Lane Report** maps how CLI commands and the Studio Vite endpoint currently consume `@civ7/direct-control`, confirms no active FireTuner bridge code remains in production paths, and sequences the implementation slices: read wrappers first, then CLI presentation, then Studio endpoints, then catalog, then mutating wrappers (each requiring fresh live proof in a disposable session), and finally a cleanup guard that adds regression checks for bridge fallback strings.