### PR TITLE
docs(morphology): open terrain authorship workstream with corpus, bands, and proof gates

### DIFF
--- a/openspec/changes/morphology-terrain-authorship-control/.openspec.yaml
+++ b/openspec/changes/morphology-terrain-authorship-control/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/morphology-terrain-authorship-control/design.md
+++ b/openspec/changes/morphology-terrain-authorship-control/design.md
@@ -1,0 +1,148 @@
+## Frame
+
+Future state: Swooper Earthlike has evidence-scoped control over terrain
+morphology. Terrain classes, relief structure, volcanoes, engine
+elevation/cliff readback, and downstream feature/resource implications are
+owned, measured, and proved at the correct boundary.
+
+Hard core: terrain truth belongs in Foundation/Morphology-derived artifacts and
+dedicated Morphology operations. Map stages project or read back engine state;
+they do not create terrain truth. Hydrology may mutate terrain for lakes and
+navigable rivers, but that mutation is recorded as projection/readback evidence.
+
+Falsifier: if a stable seed matrix can satisfy mountain share while hills stay
+below the predeclared rough-land band, final flats remain above the flat-budget
+cap, or cliffs/elevation are unmeasured after `buildElevation()`, the workstream
+has not delivered terrain morphology control.
+
+## Diagnosis
+
+The current Earthlike failure is caused by under-authored rough land. The
+foothill op accepts candidates only near ridge skirts or strong deformation and
+uses boundary/uplift-heavy scoring. Config caps are not the bottleneck: seed
+`1018` targeted hundreds of possible hill tiles but admitted only two
+candidates because most non-mountain land had zero driver score. Projection is
+not the primary cause because `plotMountains` directly stamps the planned
+mountain and hill masks.
+
+Competing hypotheses dispositioned:
+
+- Projection erases hills: rejected for the current failure; planned hills are
+  already near-zero.
+- Hill caps are too low: rejected for the scout matrix; targets are high enough
+  but candidates are missing.
+- Volcanoes prove relief: rejected; `plotVolcanoes` stamps
+  `TERRAIN_MOUNTAIN` and `FEATURE_VOLCANO` separately from ridge truth.
+- Existing tests catch this: rejected; available tests can pass with mountains
+  alone and no meaningful hill/rough-land band.
+
+## Corpus Summary
+
+The full corpus is recorded in `workstream/corpus-ledger.md`. Control classes:
+
+- Directly authorable through `TerrainBuilder`: terrain, biome, feature,
+  landmass region id, rainfall, plot tags, plus validation/build/model effects.
+- Indirectly influenced: engine elevation and cliff crossings after terrain,
+  water, and `buildElevation()` effects; resources and feature legality through
+  downstream placement surfaces.
+- Engine-owned/readback-only: `GameplayMap.getElevation(...)`,
+  `GameplayMap.isCliffCrossing(...)`, live water/lake/area classification,
+  visibility, owner/unit/city summaries.
+- Out of scope: generated `mod/` hand edits, caller-local tuner sockets, and
+  Studio setup-write behavior not yet proven.
+
+## Expected Earthlike Bands
+
+Ranges below are predeclared for Swooper Earthlike stable seed matrices before
+rough-land implementation. Percentages are land-relative unless stated
+otherwise and should be computed on both planned truth and final terrain where
+that surface exists.
+
+| Surface | Expected Civ7-scaled band | Reasoning |
+| --- | ---: | --- |
+| Planned ridge/impassable mountains | `4-9%` target, warn outside `3-12%` | Real mountain definitions cover roughly `12.4-30.5%` of land, but Civ7 `TERRAIN_MOUNTAIN` is impassable ridge/peak terrain, not the whole mountain-system footprint. |
+| Final non-volcano mountains | `4-10%` target | Projection may add natural-wonder/volcano mountains; diagnostics must still isolate non-volcano ridge mountains. |
+| Planned hills/rough land | `12-24%` target, hard fail below `8%` | Hammond-style landforms separate hills, low hills, breaks/foothills, escarpments, and low mountains from plains. Civ7 hills should carry this broader eroded/uplifted footprint. |
+| Final hills | `10-24%` target, hard fail below `8%` | Final terrain may lose some planned hills to water/wonder/hydrology mutation, but it must remain the main rough-land expression. |
+| Total rough terrain | `18-32%` target | Ridge mountains plus hills should be visibly broader than impassable mountains alone. |
+| Final flat terrain | `55-78%` target, hard fail above `85%` | Earthlike maps need plains and basins, but continental interiors should not collapse into one broad flat class. |
+| Lakes and rivers | Lakes `1-6%` target, warn above `8%`; navigable rivers topology/readback only | Inland water should be present but not a substitute for relief. River terrain is Hydrology/engine mutation, not Morphology terrain truth. |
+| Volcanoes | Count by configured size budget and tectonic regime; `>=70%` in subduction/rift/hotspot regimes, `<20%` stable-shield-without-hotspot | Volcanism is a sparse point phenomenon; it can stamp mountain terrain but cannot satisfy ridge or rough-land bands. |
+| Coasts/shelves | Coast/ocean as projection/readback budget, not land roughness | Continental shelves are shallow and coastal; their extent should be measured through coast/shelf projection, not Morphology rough-land truth. |
+| Cliffs/elevation | No hard success band until first runtime baseline; must be read back after `buildElevation()` | Cliffs are engine-owned adjacency state. Morphology may influence them but cannot claim them from local truth artifacts alone. |
+
+External references used for predeclaration:
+
+- Nature Scientific Reports: global mountain area depends on definition and
+  ranges from at least `12.4%` to `30.5%` of land
+  (`https://www.nature.com/articles/s41598-021-84784-8`).
+- USGS land-surface forms: flat plains, smooth plains, irregular plains,
+  escarpments, low hills, hills, breaks/foothills, and low mountains are
+  separated by slope and local relief
+  (`https://www.usgs.gov/maps/terrestrial-ecosystems-land-surface-forms-conterminous-united-states`).
+- USGS plateau term: plateaus are extensive elevated surfaces, often bounded by
+  abrupt descent and dissected by valleys/high hills
+  (`https://apps.usgs.gov/thesaurus/term-simple.php?code=832&thcode=3`).
+- USGS volcano FAQ: roughly `1,350` potentially active volcanoes exist
+  worldwide outside continuous ocean-floor spreading belts
+  (`https://www.usgs.gov/faqs/how-many-active-volcanoes-are-there-earth?page=1`).
+- National Geographic/NOAA: continental shelves are shallow coastal ocean
+  surfaces and make up less than `10%` of ocean area
+  (`https://education.nationalgeographic.org/resource/continental-shelf/`,
+  `https://prod-01-alb-www-noaa.woc.noaa.gov/education/resource-collections/ocean-coasts/ocean-floor-features`).
+
+## Architecture Strategy
+
+One causal strategy owns the work:
+
+1. Foundation tectonic history and provenance publish eras, crust, plate
+   boundary regimes, shield stability, volcanism, and stress/uplift/rift
+   signals.
+2. Morphology computes landmask, landmasses, coastline/shelf metrics,
+   topography, substrate, erosion/geomorphic cycle, belt drivers, ridges,
+   foothills, volcanoes, and a new rough-land operation for rolling uplands,
+   old highlands, plateaus, escarpments, basin rims, and craton relief.
+3. Map projection stamps terrain and feature intent, records planned-vs-final
+   drift, and leaves engine-only elevation/cliff state to readback surfaces.
+4. Hydrology owns lakes, rivers, floodplain/navigable-river terrain mutation,
+   and water readback.
+5. Placement/ecology/resources consume final terrain legality and receive
+   explicit downstream realignment gates when rough land changes.
+
+## Implementation Slices
+
+1. `morphology-terrain-authorship-control`:
+   docs/OpenSpec/corpus/expectations/proof records; no behavior changes.
+2. Terrain stats/readback slice:
+   add non-volcano mountain separation, hill component structure, rough/flat
+   budgets, volcano kind/regime counts, stage deltas, and local relief profile
+   gates to world-balance stats.
+3. Rough-land Morphology op slice:
+   add an operation that consumes belt drivers, substrate, erosion, topography,
+   hydrology context, crust/provenance, and age to produce non-foothill hills
+   and rough terrain.
+4. Earthlike range tuning slice:
+   adjust Earthlike config only after slice 2 proves the failure and slice 3
+   provides a causal surface.
+5. Runtime readback slice:
+   prove final terrain/elevation/cliffs through `@civ7/direct-control`; add a
+   first-class cliff-crossing map field or a bounded approved read-only probe.
+6. Downstream feature/resource realignment:
+   re-run and adjust ecology/resource/natural-wonder gates affected by the new
+   terrain distribution.
+
+## Direct-Control Boundary
+
+Use the committed package surface, not caller-local FireTuner commands:
+
+- App UI: lifecycle/status/restart/Begin Game/autoplay.
+- Tuner after Begin: map summary, bounded plot/grid reads, visibility,
+  player/unit/city summaries, `GameInfo` rows, catalog/inspect, and
+  validator-first actions only when approved.
+- CLI/Studio paths: `civ7 game status`, `map`, `gameinfo`, `catalog`,
+  `inspect`, `autoplay`, `restart --begin --wait-tuner --json`, plus Studio
+  `GET /api/civ7/status`, `/map-summary`, and `/gameinfo`.
+
+Runtime closure requires branch, commit, command/API path, request id, bounded
+logs, parsed payload, terrain/elevation/cliff readback, and residual proof
+boundaries.

--- a/openspec/changes/morphology-terrain-authorship-control/proposal.md
+++ b/openspec/changes/morphology-terrain-authorship-control/proposal.md
@@ -1,0 +1,80 @@
+## Why
+
+Swooper Earthlike still reads too flat after the previous terrain-relief slice:
+mountain terrain can now appear, but planned/final hills remain near-zero in
+multiple seeds and broad continental interiors are dominated by flat terrain.
+Fresh stats on `codex/agent-dra-morphology-direct-control-objective` confirm
+the scout case: seed `1018` at `106x66` produced planned hills `0.075%`, final
+hills `0.037%`, and final flats `88.798%` of pre-lake land. The `80x50`
+8-seed sweep kept final hills between `0%` and `2.188%`.
+
+The failure is structural, not just config noise. Current hill planning is a
+foothill skirt around ridges or strong boundary deformation; it does not own
+rolling uplands, old highlands, plateau rims, craton relief, basin margins, or
+escarpments. Volcano projection can also stamp mountain terrain separately, so
+final mountain share can improve while ridge/rough-land authorship remains
+weak.
+
+## Target Authority Refs
+
+- `docs/projects/pipeline-realism/resources/runbooks/HANDOFF-MORPHOLOGY-TERRAIN-AUTHORSHIP.md`
+- `docs/projects/pipeline-realism/resources/runbooks/HANDOFF-DIRECT-CONTROL-MORPHOLOGY-OBJECTIVE.md`
+- `docs/system/libs/mapgen/reference/domains/MORPHOLOGY.md`
+- `docs/system/mods/swooper-maps/architecture.md`
+- `openspec/specs/mapgen-normalization-workstreams/spec.md`
+- `packages/civ7-direct-control/README.md`
+- `.civ7/outputs/resources/Base/modules/base-standard/data/terrain.xml`
+
+## What Changes
+
+- Open a systematic terrain-authorship workstream with explicit frame, corpus,
+  expectation, strategy, proof, review, and downstream realignment records.
+- Predeclare Earthlike Civ7-scaled terrain morphology bands before any tuning
+  or rough-land implementation.
+- Record the canonical corpus: Civ7 terrain classes, terrain-linked features
+  and natural wonders, resource implications, Morphology truth artifacts,
+  projection stages, hydrology terrain mutation, engine readback-only surfaces,
+  and direct-control proof surfaces.
+- Require downstream implementation slices to add stats and rough-land
+  authorship before changing Earthlike knobs.
+- Separate local stats proof, engine/runtime readback, Graphite submit, and
+  product proof so completed docs/tests are not mistaken for in-game terrain
+  proof.
+
+## Write Set
+
+- `openspec/changes/morphology-terrain-authorship-control/**`
+- `openspec/specs/mapgen-normalization-workstreams/spec.md`
+- Later slices may touch morphology ops, world-balance stats/tests,
+  direct-control cliff readback, and Swooper Earthlike config only after this
+  workstream predeclares ranges and proof gates.
+
+## Protected Paths
+
+- Generated `mods/mod-swooper-maps/mod/**`, `dist/**`, and lockfiles.
+- Direct-control active work by the other team; this slice only consumes the
+  committed `@civ7/direct-control` surface already downstack.
+- Studio live-sync/setup-write design work; Studio endpoints are evidence, not
+  the runtime proof boundary for this terrain claim.
+
+## Forbidden Non-Goals
+
+- No config-first retuning.
+- No noise-only hill fill.
+- No projection-stage truth planning.
+- No claiming cliffs/elevation without `buildElevation()` readback.
+- No counting volcano-stamped mountain terrain as ridge/belt proof.
+- No stale FireTuner/manual socket bypass; runtime control goes through
+  `@civ7/direct-control` CLI or Studio endpoints that call the package.
+
+## Verification Gates
+
+- `bun run openspec -- validate morphology-terrain-authorship-control --strict`
+- `bun run openspec:validate`
+- Existing local stats/test state recorded without inflating proof claims.
+- Direct-control surface inspected through the package CLI/catalog/status
+  routes; live runtime proof remains unresolved until a game/tuner session is
+  reachable and cliff readback is first-class or bounded through an approved
+  read-only probe.
+- Peer review P1/P2 findings recorded and dispositioned before closure.
+- `git diff --check`

--- a/openspec/changes/morphology-terrain-authorship-control/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/morphology-terrain-authorship-control/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Terrain Morphology Authorship Predeclares Ranges
+
+Terrain morphology workstreams SHALL predeclare expected terrain bands before
+changing shipped map config, morphology thresholds, or projection behavior.
+
+#### Scenario: Earthlike terrain relief work starts
+- **WHEN** a change claims Earthlike terrain relief, flatness, rough land,
+  hills, mountain belts, volcanoes, cliffs, or engine elevation behavior
+- **THEN** it records the terrain corpus and expected Earthlike bands before
+  implementation or tuning
+- **AND** it distinguishes Civ7 impassable ridge mountains from the broader
+  hills/rough-land footprint
+- **AND** it does not derive success ranges from current output alone
+
+### Requirement: Terrain Relief Proof Separates Truth Projection And Readback
+
+Terrain morphology workstreams SHALL keep Morphology truth, map projection,
+Hydrology terrain mutation, and engine readback as separate proof surfaces.
+
+#### Scenario: Terrain proof is recorded
+- **WHEN** a change reports planned or final terrain shares
+- **THEN** it compares planned Morphology masks with final terrain readback
+- **AND** it separates volcano-stamped mountains from ridge/belt mountains
+- **AND** it reports lake and navigable-river terrain mutation as Hydrology or
+  engine projection evidence rather than Morphology truth
+
+#### Scenario: Cliff or elevation success is claimed
+- **WHEN** a change claims Civ7 elevation or cliff behavior
+- **THEN** it includes readback after `TerrainBuilder.buildElevation()`
+- **AND** it does not treat Morphology heightfields or local projection plans
+  as proof of engine cliffs
+
+### Requirement: Rough Land Needs A Dedicated Morphology Owner
+
+Earthlike rough-land work SHALL NOT rely only on ridge foothill skirts,
+volcanoes, projection fallback, or noise-only fill.
+
+#### Scenario: Hill coverage remains below the predeclared band
+- **WHEN** diagnostics show planned or final hills below the Earthlike
+  rough-land band
+- **THEN** the next implementation slice adds or reshapes a Morphology-owned
+  operation for non-foothill hills, rolling uplands, old highlands, plateaus,
+  escarpments, basin margins, or craton relief
+- **AND** shipped map config changes wait until that causal surface exists or
+  the change records source evidence that config is the real bottleneck

--- a/openspec/changes/morphology-terrain-authorship-control/tasks.md
+++ b/openspec/changes/morphology-terrain-authorship-control/tasks.md
@@ -1,0 +1,40 @@
+## 1. State And Diagnosis
+
+- [x] 1.1 Isolate the correct Graphite worktree and branch.
+- [x] 1.2 Verify direct-control branch ancestry and avoid the active Studio
+  worktree.
+- [x] 1.3 Reproduce current Earthlike hill/flatness stats for the scout seed
+  and multi-seed matrix.
+- [x] 1.4 Diagnose root cause from source, tests, history/hotspots, Narsil, and
+  peer review before changing behavior.
+
+## 2. Corpus And Expectations
+
+- [x] 2.1 Extract Civ7 terrain classes and terrain-linked official feature,
+  natural-wonder, and resource implications.
+- [x] 2.2 Extract direct/indirect/readback-only API surfaces from
+  `TerrainBuilder`, `GameplayMap`, adapter wrappers, direct-control CLI, and
+  Studio endpoints.
+- [x] 2.3 Extract Morphology truth artifacts, projection stages, hydrology
+  terrain mutation, and engine-only elevation/cliff boundaries.
+- [x] 2.4 Predeclare Earthlike terrain morphology bands before implementation
+  or tuning.
+
+## 3. Architecture And Slices
+
+- [x] 3.1 Record the single causal Foundation/Morphology strategy and forbidden
+  owner boundaries.
+- [x] 3.2 Define downstream implementation slices with write sets and review
+  gates.
+- [x] 3.3 Record peer-agent P1/P2 findings and dispositions.
+- [x] 3.4 Record downstream realignment requirements for ecology, resources,
+  natural wonders, and runtime proof.
+
+## 4. Verification
+
+- [x] 4.1 Run OpenSpec strict validation for this change.
+- [x] 4.2 Run full OpenSpec validation.
+- [x] 4.3 Record focused local checks available to this docs/spec slice.
+- [x] 4.4 Run `git diff --check`.
+- [x] 4.5 Record local commit, Graphite submit, runtime proof, and product
+  proof as separate closure labels.

--- a/openspec/changes/morphology-terrain-authorship-control/workstream/closure-checklist.md
+++ b/openspec/changes/morphology-terrain-authorship-control/workstream/closure-checklist.md
@@ -1,0 +1,31 @@
+# Closure Checklist
+
+## Records
+
+- [x] `tasks.md` reflects current task state.
+- [x] `phase-record.md` reflects branch, parent commit, proof, and blockers.
+- [x] `review-disposition-ledger.md` has accepted P1/P2 findings recorded.
+- [x] `downstream-realignment-ledger.md` records required downstream slices.
+- [x] No `next-packet.md` exists yet; remaining work lives in tasks and ledgers.
+
+## Gates
+
+- [x] Focused checks passed for this docs/spec slice.
+- [x] OpenSpec strict validation passed.
+- [x] Full OpenSpec validation passed.
+- [x] `git diff --check` passed.
+- [ ] Runtime proof recorded, or explicitly unresolved with proof boundary.
+
+## Proof Labels
+
+- [x] Local commit, Graphite submit, PR state, local stats proof, runtime proof,
+  and product proof are labeled separately.
+- [ ] Runtime records include branch, commit, command/API path, downstack
+  control commit, response, logs/payloads or timeout boundary.
+- [ ] No stronger proof claim is made than the evidence supports.
+
+## Repo State
+
+- [ ] Worktree clean or explicitly handed off.
+- [ ] Graphite branch/stack state inspected.
+- [ ] External Graphite submission/PR delivery unclaimed unless evidence exists.

--- a/openspec/changes/morphology-terrain-authorship-control/workstream/corpus-ledger.md
+++ b/openspec/changes/morphology-terrain-authorship-control/workstream/corpus-ledger.md
@@ -1,0 +1,103 @@
+# Corpus Ledger
+
+## Terrain Classes
+
+| Key | Official source | Authorship/readback class | Current coverage | Required proof |
+| --- | --- | --- | --- | --- |
+| `TERRAIN_MOUNTAIN` | `.civ7/outputs/resources/Base/modules/base-standard/data/terrain.xml` | Directly authorable by `TerrainBuilder.setTerrainType`; read by `GameplayMap.getTerrainType`/`isMountain`; Civ7 marks impassable | Morphology ridge mask and volcano/natural-wonder projection can stamp it | Planned ridge share, final non-volcano mountain share, volcano-stamped mountain separation, engine terrain readback |
+| `TERRAIN_HILL` | same | Directly authorable terrain; Civ7 marks `Hills=true` | Current foothill mask under-authors it | Planned/final hill share, hill components, rough-land source attribution |
+| `TERRAIN_FLAT` | same | Directly authorable/default terrain | Dominates Earthlike interiors | Flat budget and terrain-stage deltas after hydrology/projection |
+| `TERRAIN_COAST` | same | Directly authorable water terrain; hydrology stamps lakes as coast | Coasts/lakes are projection and hydrology surfaces | Coast/shelf/lake readback and water/lake classification drift |
+| `TERRAIN_OCEAN` | same | Directly authorable water terrain | Projection surface | Ocean/coast budget and shelf separation |
+| `TERRAIN_NAVIGABLE_RIVER` | same | Engine/hydrology terrain mutation through river modeling; readback by terrain/hydrology APIs | Hydrology/engine-owned, not Morphology rough-land truth | River terrain readback after `modelRivers`; excluded from land roughness bands |
+
+## Terrain-Linked Official Features
+
+Source: `.civ7/outputs/resources/Base/modules/base-standard/data/terrain.xml`,
+plus DLC terrain files listed below.
+
+| Terrain | Feature keys |
+| --- | --- |
+| `TERRAIN_FLAT` | `FEATURE_SAGEBRUSH_STEPPE`, `FEATURE_OASIS`, `FEATURE_DESERT_FLOODPLAIN_MINOR`, `FEATURE_FOREST`, `FEATURE_MARSH`, `FEATURE_GRASSLAND_FLOODPLAIN_MINOR`, `FEATURE_SAVANNA_WOODLAND`, `FEATURE_WATERING_HOLE`, `FEATURE_PLAINS_FLOODPLAIN_MINOR`, `FEATURE_RAINFOREST`, `FEATURE_MANGROVE`, `FEATURE_TROPICAL_FLOODPLAIN_MINOR`, `FEATURE_TAIGA`, `FEATURE_TUNDRA_BOG`, `FEATURE_TUNDRA_FLOODPLAIN_MINOR`, `FEATURE_VALLEY_OF_FLOWERS`, `FEATURE_REDWOOD_FOREST`, `FEATURE_GRAND_CANYON` |
+| `TERRAIN_HILL` | `FEATURE_GULLFOSS`, `FEATURE_IGUAZU_FALLS`, `FEATURE_ULURU` |
+| `TERRAIN_MOUNTAIN` | `FEATURE_HOERIKWAGGO`, `FEATURE_KILIMANJARO`, `FEATURE_ZHANGJIAJIE`, `FEATURE_TORRES_DEL_PAINE`, `FEATURE_MOUNT_EVEREST`, `FEATURE_MACHAPUCHARE`, `FEATURE_MOUNT_FUJI`, `FEATURE_VIHREN`, `FEATURE_VINICUNCA` |
+| `TERRAIN_COAST` | `FEATURE_REEF`, `FEATURE_COLD_REEF`, `FEATURE_ICE`, `FEATURE_LOTUS`, `FEATURE_BARRIER_REEF`, `FEATURE_THERA`, `FEATURE_GREAT_BLUE_HOLE`, `FEATURE_MAPU_A_VAEA_BLOWHOLES` |
+| `TERRAIN_OCEAN` | `FEATURE_ICE`, `FEATURE_ATOLL`, `FEATURE_BERMUDA_TRIANGLE` |
+| `TERRAIN_NAVIGABLE_RIVER` | `FEATURE_DESERT_FLOODPLAIN_NAVIGABLE`, `FEATURE_GRASSLAND_FLOODPLAIN_NAVIGABLE`, `FEATURE_PLAINS_FLOODPLAIN_NAVIGABLE`, `FEATURE_TROPICAL_FLOODPLAIN_NAVIGABLE`, `FEATURE_TUNDRA_FLOODPLAIN_NAVIGABLE` |
+
+Natural-wonder add-on sources:
+
+- `.civ7/outputs/resources/Base/modules/base-standard/data/marvelous-mountains-terrain.xml`
+- `.civ7/outputs/resources/Base/modules/base-standard/data/racetowonders-terrain.xml`
+- `.civ7/outputs/resources/DLC/water-wonders/modules/data/terrain.xml`
+- `.civ7/outputs/resources/DLC/mountain-natural-wonders/modules/data/terrain.xml`
+
+Volcano-linked feature keys:
+
+- `FEATURE_VOLCANO` is a standard feature with `PlacementClass="VOLCANO"`.
+- `FEATURE_KILIMANJARO`, `FEATURE_THERA`, and `FEATURE_MOUNT_FUJI` carry
+  volcano semantics through tags or random-event metadata.
+
+## Downstream Resource Implications
+
+Official resource legality in `resources.xml` and `resources-v2.xml` includes
+these hill-dependent resources:
+
+`RESOURCE_CAMELS`, `RESOURCE_COAL`, `RESOURCE_COFFEE`, `RESOURCE_FLAX`,
+`RESOURCE_GOLD`, `RESOURCE_GYPSUM`, `RESOURCE_HARDWOOD`, `RESOURCE_IRON`,
+`RESOURCE_IVORY`, `RESOURCE_LIMESTONE`, `RESOURCE_LLAMAS`,
+`RESOURCE_MARBLE`, `RESOURCE_RUBIES`, `RESOURCE_SILVER`, `RESOURCE_TEA`,
+`RESOURCE_TIN`, `RESOURCE_TRUFFLES`, `RESOURCE_WILD_GAME`, `RESOURCE_WOOL`.
+
+Implication: near-zero hills is not only a terrain visual problem. It constrains
+mining, pastoral, upland agricultural, and geological resource placement and
+must trigger downstream resource-placement realignment.
+
+## Morphology Truth Artifacts And Ops
+
+| Surface | Class | Current source |
+| --- | --- | --- |
+| Land/water/topography/bathymetry | Direct Morphology truth | `morphologyArtifacts.topography` |
+| Landmasses and landmass ids | Direct Morphology truth | `morphologyArtifacts.landmasses` |
+| Coastline/shelf/distance-to-coast metrics | Derived Morphology truth | `morphologyArtifacts.coastlineMetrics` |
+| Belt drivers: boundary closeness/type, uplift, collision, subduction, rift, stress, age | Foundation-derived Morphology truth | `morphologyArtifacts.beltDrivers` |
+| Substrate: erodibility/sediment depth | Morphology truth | `morphologyArtifacts.substrate` |
+| Flow routing and geomorphic cycle | Morphology truth/influence | `compute-flow-routing`, `compute-geomorphic-cycle` |
+| Ridges and foothills | Morphology terrain intent | `plan-ridges`, `plan-foothills`, `morphologyArtifacts.mountains` |
+| Volcanoes | Morphology point intent | `plan-volcanoes`, `morphologyArtifacts.volcanoes` |
+| Island chains | Morphology terrain/topology intent | `plan-island-chains` |
+| Rolling uplands/old highlands/plateaus/escarpments | Missing dedicated owner | Required downstream rough-land op |
+
+## Projection And Hydrology Mutation
+
+| Stage/step | Role | Proof requirement |
+| --- | --- | --- |
+| `map-morphology/plot-mountains` | Projects `mountainMask` and `hillMask` to engine terrain | Planned-vs-final terrain parity and drift |
+| `map-morphology/plot-volcanoes` | Stamps volcano points as `TERRAIN_MOUNTAIN` plus `FEATURE_VOLCANO` | Count separately from ridge mountains |
+| `map-hydrology` lake stamping | Mutates accepted lake mask to `TERRAIN_COAST` and water state | Lake mask/readback parity and water/lake drift |
+| River modeling | Engine/hydrology mutation, including navigable river terrain | Terrain/hydrology readback after engine river calls |
+| `map-elevation/build-elevation` | Calls `TerrainBuilder.buildElevation()` | Engine elevation/cliff readback; no Morphology truth claim |
+
+## Engine APIs And Readback Surfaces
+
+| Surface | Class | Notes |
+| --- | --- | --- |
+| `TerrainBuilder.setTerrainType` | Direct write | terrain classes only; no `setElevation` or `setCliff` |
+| `TerrainBuilder.setBiomeType`, `setFeatureType`, `setRainfall`, `setLandmassRegionId`, plot tags | Direct write | downstream projection/materialization |
+| `TerrainBuilder.validateAndFixTerrain`, `stampContinents`, `buildElevation`, `modelRivers`, `defineNamedRivers`, `storeWaterData` | Engine effect calls | must be treated as effect/readback boundaries |
+| `GameplayMap.getTerrainType`, `getBiomeType`, `getFeatureType`, `getResourceType` | Runtime readback | direct-control plot/grid reads can capture these |
+| `GameplayMap.getElevation`, `getRainfall`, `getTemperature`, `getRiverType` | Runtime readback | elevation exists only after engine build/readback |
+| `GameplayMap.isWater`, `isLake`, `isMountain`, `isNavigableRiver`, `isNaturalWonder`, `isImpassable` | Runtime predicates | prove final engine classification |
+| `GameplayMap.isCliffCrossing(x,y,direction)` | Runtime readback-only | not currently a first-class direct-control map field |
+
+## Direct-Control Surface
+
+| Path | Role | Status |
+| --- | --- | --- |
+| `civ7 game restart --begin --wait-tuner --json` | App UI lifecycle plus Begin Game boundary | Available; does not prove selected Studio config |
+| `civ7 game status --json` | shared/App UI/Tuner readiness | Timed out locally with no ready tuner session |
+| `civ7 game map --summary --json` | Tuner map summary | available after Begin/Tuner readiness |
+| `civ7 game map --bounds ... --fields terrain,climate,hydrology,areaRegion --json` | bounded Tuner terrain/elevation/hydrology readback | no first-class cliffs yet |
+| `civ7 game gameinfo Terrains/Biomes/Features/Resources --json` | runtime official row readback | available after Tuner readiness |
+| `civ7 game catalog --static --json` | static package surface inventory | passed locally |
+| Studio `/api/civ7/status`, `/map-summary`, `/gameinfo` | package-backed read endpoints | available, narrow; not setup/run-in-game proof |

--- a/openspec/changes/morphology-terrain-authorship-control/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/morphology-terrain-authorship-control/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,14 @@
+# Downstream Realignment Ledger
+
+| Area | Required realignment | Status |
+| --- | --- | --- |
+| World-balance stats | Add non-volcano mountain separation, hill components, rough/flat budgets, volcano kind/regime counts, stage terrain deltas, and explicit expected-band comparison. | required next slice |
+| Morphology ops | Add or reshape a dedicated rough-land operation for rolling uplands, old highlands, plateau rims, basin margins, escarpments, and craton relief. | required next slice |
+| Earthlike config | Defer tuning until stats prove the candidate deficit and rough-land op exists. Remove stale/noise-only knobs if the op supersedes them. | blocked until rough-land slice |
+| Projection stages | Keep `plotMountains`/`plotVolcanoes` as projection/readback only; record planned-vs-final terrain drift. | required |
+| Hydrology | Preserve lake and navigable-river terrain mutation as Hydrology-owned; compare lake/river terrain drift separately from Morphology roughness. | required |
+| Ecology/features | Re-run feature legality and family-density gates after rough-land distribution changes; hill scarcity currently affects terrain-linked natural wonders. | required |
+| Resources | Re-run hill-dependent resource candidate/placement gates for mining, pastoral, upland agriculture, and geological resources. | required |
+| Natural wonders | Re-evaluate hill/mountain/coast natural-wonder eligibility after terrain rebalancing; do not use natural wonders to satisfy terrain-band proof. | required |
+| Direct control | Add first-class cliff-crossing map readback or use a bounded read-only approved probe before claiming cliff proof. | required for runtime closure |
+| Studio | Treat current setup/run-in-game design as non-proof-ready; runtime proof must use committed direct-control CLI/package paths. | accepted boundary |

--- a/openspec/changes/morphology-terrain-authorship-control/workstream/expectation-strategy-ledger.md
+++ b/openspec/changes/morphology-terrain-authorship-control/workstream/expectation-strategy-ledger.md
@@ -1,0 +1,25 @@
+# Expectation And Strategy Ledger
+
+| Corpus row/group | Expected behavior | Condition | Evidence strength | Architecture owner | Strategy/artifact | Local stats gate | Runtime proof | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Impassable ridge mountains | Planned `4-9%`, warn outside `3-12%`; final non-volcano `4-10%` | Earthlike stable seed matrix, land-relative | medium, Civ-scaled from physical mountain definitions | Morphology ridges; map projection readback | `morphology.mountains.mountainMask`; non-volcano final terrain | planned/final/non-volcano shares and components | terrain readback via direct-control map grid | proposed |
+| Hills and rough land | Planned `12-24%`, final `10-24%`, hard fail below `8%` | Earthlike land tiles | medium-high, based on Hammond relief classes and Civ terrain abstraction | New Morphology rough-land op plus foothills | `morphology.mountains.hillMask` or successor rough-land artifact | planned/final hill share, hill components, distance-to-ridge/boundary/coast | terrain readback via direct-control map grid | missing owner |
+| Total rough terrain | `18-32%` land | mountains plus hills | medium | Morphology terrain intent | ridge + rough-land masks | rough share and flat-to-rough ratio | terrain readback | proposed |
+| Final flat terrain | `55-78%`, hard fail above `85%` | Earthlike land tiles after projection/hydrology | medium | Morphology plus map/hydrology projection | final terrain histogram | final flat share and flatland basin budget | terrain readback | proposed |
+| Volcanoes | Regime-correlated sparse points; volcano mountains excluded from ridge proof | active volcanic regimes | medium | Morphology volcanoes; map projection | `morphology.volcanoes` entries with `kind` | counts by `subductionArc`/`rift`/`hotspot`; final volcano terrain separation | feature and terrain readback | partly modeled |
+| Coast/shelf | Coast and ocean as projection/readback, not rough-land truth | shoreline/shelf water | medium | Morphology coast metrics plus map projection | `coastlineMetrics.shelfMask`, terrain histogram | coast/ocean/lake/shelf budgets | water/coast terrain readback | partly modeled |
+| Lakes/rivers | lakes `1-6%`, warn above `8%`; rivers are hydrology topology | post-hydrology | medium | Hydrology | `hydrology.lakePlan`; engine lake projection; river modeling | lake share, component, drift, river topology | hydrology/terrain readback | modeled |
+| Engine elevation/cliffs | no success claim until read back after `buildElevation()` | live runtime or engine-backed adapter | high for boundary, low for band until baseline | Map/elevation projection and direct-control proof | `effect:map.elevationBuilt`; readback artifact or runtime payload | elevation percentiles, local relief, coast-distance profile | `GameplayMap.getElevation`, `isCliffCrossing` bounded sample | unresolved |
+| Downstream features/resources | Hill/mountain/flat/coast legality remains balanced after rough-land changes | after terrain changes | high from official legality tables | Ecology/Placement/Resources | feature/resource legality artifacts | invalid surface count, per-family counts, hill-resource candidates | GameInfo plus feature/resource readback | pending |
+
+## Strategy Rules
+
+- Do not loosen hill thresholds as the primary fix unless the candidate set is
+  already broad enough to satisfy the expected band.
+- Do not add manual output-control knobs that bypass Foundation/Morphology
+  causes.
+- Do add a Morphology-owned rough-land operation if the hill gap remains after
+  stats isolate ridge foothills from non-foothill hills.
+- Do keep `map-*` stages as projection/readback owners only.
+- Do preserve cliffs as engine-owned/readback-only until direct-control captures
+  `isCliffCrossing` samples.

--- a/openspec/changes/morphology-terrain-authorship-control/workstream/phase-record.md
+++ b/openspec/changes/morphology-terrain-authorship-control/workstream/phase-record.md
@@ -1,0 +1,91 @@
+# Morphology Terrain Authorship Phase Record
+
+## Frame
+
+- Objective: create a systematic Civ7 terrain morphology authorship workstream
+  for Swooper Earthlike flatness.
+- Future state: terrain classes, relief structure, volcanoes,
+  engine elevation/cliff readback, and downstream feature/resource implications
+  are owned, measured, and proved.
+- Hard core: Foundation/Morphology own terrain truth; map stages project and
+  read back; hydrology terrain mutation is separate; engine elevation/cliffs
+  are readback-only.
+- Falsifier: hills/rough land remain below the predeclared band, flats remain
+  above budget, or elevation/cliffs are claimed without runtime readback.
+
+## Status
+
+- Last updated: 2026-05-31.
+- Current gate: Gate 8, implementation slice opened after Gates 1-7 were
+  completed for state isolation, diagnosis, corpus, expectations, grouping,
+  and architecture translation.
+- Next gate: Gate 9, local validation for OpenSpec and any stats/proof slice
+  added above this record.
+- Blocked by: runtime proof is not available until a Civ7 tuner session is
+  reachable and cliff-crossing readback is first-class or bounded by an
+  approved read-only probe.
+- Stop condition: do not retune Earthlike terrain config before adding a
+  dedicated rough-land authoring surface or explicit stats gates.
+
+## Repo State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-dra-morphology-direct-control-objective`
+- Branch: `codex/morphology-terrain-authorship-workstream`
+- Local commit: complete after the closure amend for this record; exact branch
+  head is reported from `git rev-parse HEAD` in the final closure message.
+- Parent branch: `codex/agent-dra-morphology-direct-control-objective`
+- Parent commit: `63a077781`
+- Downstack direct-control implementation commit: `cd1e87fa3`
+- Downstack Studio design branch commit: `692a04081`
+- Dirty files and owner: this branch owns only the OpenSpec/workstream files
+  listed in the proposal and the adjacent normalization-workstream spec update.
+- Protected paths: generated `mod/**`, `dist/**`, lockfiles, active external
+  direct-control worktrees, and Studio setup/live-sync implementation paths.
+
+## Diagnosis Evidence
+
+- Scout/current stats:
+  - seed `1018`, `106x66`: final mountains `6.535%`, planned hills `0.075%`,
+    final hills `0.037%`, final flats `88.798%`.
+  - `80x50` seeds `[1,2,3,42,99,1234,7777]`: final hills `0-2.188%`.
+- Candidate diagnosis for seed `1018`: hill target raw `482`, accepted
+  candidates `2`, driver-nonzero share `5.519%`, score-above-threshold share
+  `0.081%`.
+- Source diagnosis:
+  - `plotMountains` stamps `morphology.mountains.mountainMask` and
+    `hillMask`, so near-zero planned hills are upstream of projection.
+  - `plan-foothills` only admits ridge-skirt or strong-boundary-deformation
+    candidates.
+  - `plotVolcanoes` stamps `TERRAIN_MOUNTAIN` and `FEATURE_VOLCANO`
+    separately from ridge truth.
+- Test diagnosis:
+  - low-level mountain tests can pass without meaningful hills.
+  - `world-balance-stats` already collects key terrain metrics but current
+    balance tests do not enforce rough-land bands.
+
+## Current Local Checks
+
+- `bun test test/pipeline/world-balance-stats.test.ts`: failed before this
+  branch due to `FEATURE_SAGEBRUSH_STEPPE` habitat mismatch, not due to new
+  work.
+- `bun test test/pipeline/mountains-nonzero-probe.test.ts`: failed before this
+  branch because a stale helper passes the canonical map envelope to the
+  recipe compiler.
+- `bun test test/morphology/m11-mountains-physics-anchored.test.ts test/morphology/m12-mountains-present.test.ts`:
+  passed before this branch.
+- `packages/cli/bin/run.js game status --json --timeout-ms 3000`: failed with
+  `response-timeout`, indicating no reachable/ready Civ7 tuner session.
+- `packages/cli/bin/run.js game catalog --static --json`: passed and confirmed
+  committed direct-control wrappers and CLI routes.
+
+## Proof Labels
+
+- Local commit complete: yes after closure amend; exact branch head is reported
+  outside this self-referential record.
+- Graphite submitted: no.
+- PR created/updated: no.
+- Local stats proof: partial diagnostic evidence only; expected bands are now
+  predeclared but not satisfied.
+- Runtime proof: unresolved.
+- Product proof: unresolved.

--- a/openspec/changes/morphology-terrain-authorship-control/workstream/review-disposition-ledger.md
+++ b/openspec/changes/morphology-terrain-authorship-control/workstream/review-disposition-ledger.md
@@ -1,0 +1,19 @@
+# Review Disposition Ledger
+
+| Finding | Severity | Disposition | Repair Evidence |
+| --- | --- | --- | --- |
+| Wrong initial worktree was the Studio branch, not the morphology handoff branch. | P1 | cleared | Switched to `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-dra-morphology-direct-control-objective`, branch `codex/agent-dra-morphology-direct-control-objective`; closed prior agents. |
+| Hills are structurally under-authored, not just under-tuned. | P1 | accepted | `design.md` records the root cause; downstream rough-land op slice is required before config tuning. |
+| Existing tests can pass with nearly no hills. | P1 | accepted | `design.md` and `tasks.md` require terrain stats/readback gates before closure. |
+| Final terrain counts are misleading because volcanoes stamp mountains separately. | P1 | accepted | Corpus and expectation ledgers require non-volcano mountain separation and volcano-kind stats. |
+| Elevation/cliff proof is incomplete. | P1 | accepted | Runtime proof ledger marks cliff/elevation proof unresolved; design requires direct-control cliff field or bounded approved read-only probe. |
+| Studio setup/run-in-game is not proof-ready. | P1 | accepted | Direct-control boundary excludes selected Studio setup proof and uses package CLI/App UI/Tuner surfaces. |
+| Direct-control `game map` lacks first-class cliff/crossing field. | P1 | accepted | Runtime proof ledger marks this as a closure boundary. |
+| Diagnostics helpers are stale: canonical envelope passed as recipe config, dump analyzer path mismatch. | P2 | accepted | Downstream stats/readback slice must repair diagnostics before using those paths as proof. |
+| Studio endpoints are narrow and `/api/civ7/live/*` is design-only. | P2 | accepted | Corpus ledger records only implemented endpoints: `/status`, `/map-summary`, `/gameinfo`. |
+| CLI `game inspect` should use narrow roots. | P2 | accepted | Runtime proof path restricts inspection to targeted roots such as `GameplayMap`. |
+
+## Agent Closure
+
+- `019e800d-0b7a-7773-bd48-a62e4fd605e3` closed after read-only root-cause review.
+- `019e800d-21a0-7ec3-bf22-7da2d9f4e61a` closed after read-only direct-control surface review.

--- a/openspec/changes/morphology-terrain-authorship-control/workstream/verification-and-runtime-proof.md
+++ b/openspec/changes/morphology-terrain-authorship-control/workstream/verification-and-runtime-proof.md
@@ -1,0 +1,95 @@
+# Verification And Runtime Proof
+
+## Local Statistics
+
+- Branch/commit: `codex/morphology-terrain-authorship-workstream`; exact
+  branch head is reported from `git rev-parse HEAD` in the final closure
+  message.
+- Seeds/configs:
+  - Swooper Earthlike, seed `1018`, `106x66`.
+  - Swooper Earthlike, seeds `[1,2,3,42,99,1234,7777]`, `80x50`.
+- Command shape: `bun --eval` using `collectWorldBalanceStats` from
+  `mods/mod-swooper-maps/test/support/world-balance-stats.ts`.
+- Expected range source: `design.md` and `expectation-strategy-ledger.md`.
+- Observed results:
+  - seed `1018`: final mountains `6.535%`, planned hills `0.075%`, final
+    hills `0.037%`, final flats `88.798%`.
+  - 8-seed `80x50`: final hills `0-2.188%`, final flats about `84.968-94.301%`.
+- Pass/fail: diagnostic fail against newly predeclared hill/flat bands.
+- What this proves: local generated pipeline output under-authors hills/rough
+  land before runtime.
+- What this does not prove: live game terrain, engine elevation, cliffs,
+  selected Studio setup, or downstream resource balance.
+
+## Local Tests
+
+- This branch is a docs/OpenSpec workstream slice. Focused local validation for
+  this branch is OpenSpec strict validation, full OpenSpec validation, and
+  `git diff --check`; no behavior files are changed in this slice.
+- `bun test test/morphology/m11-mountains-physics-anchored.test.ts test/morphology/m12-mountains-present.test.ts`:
+  passed before this branch.
+- `bun test test/pipeline/world-balance-stats.test.ts`: failed before this
+  branch due to `FEATURE_SAGEBRUSH_STEPPE` habitat mismatch.
+- `bun test test/pipeline/mountains-nonzero-probe.test.ts`: failed before this
+  branch due to stale recipe envelope handling.
+
+## Direct-Control Surface Proof
+
+- Branch/commit: `codex/agent-dra-morphology-direct-control-objective@63a077781`
+  before opening this branch.
+- Downstack package commit: `cd1e87fa3`
+  `feat(civ7-direct-control): expand direct control surface`.
+- Build path:
+  - `bun run --cwd packages/civ7-direct-control build`
+  - `bunx turbo run build --filter=@mateicanavra/civ7-cli`
+- Static command: `packages/cli/bin/run.js game catalog --static --json`
+- Result: passed; confirmed committed wrappers for restart/begin, playable
+  status, map summary, plot grid, GameInfo rows, runtime catalog, autoplay, and
+  validator-backed operations.
+
+## Runtime Proof
+
+- Branch/commit: `codex/morphology-terrain-authorship-workstream`; exact
+  branch head is reported from `git rev-parse HEAD` in the final closure
+  message.
+- Downstack restart/control branch and commit:
+  `codex/studio-run-in-game-workstream@692a04081`, but Studio setup is not
+  proof-ready; committed package surface comes from downstack direct-control
+  implementation.
+- Command/API path attempted:
+  `packages/cli/bin/run.js game status --json --timeout-ms 3000`.
+- Request id: unavailable; status command timed out before a parsed runtime
+  response.
+- Response: `Civ7DirectControlError: Timed out waiting for Civ7 tuner response to LSQ`.
+- Manual boundary: no reachable/ready Civ7 tuner session during local proof.
+- Log paths: none fresh/bounded.
+- Parsed payload: none.
+- Readback API/surface: unresolved.
+- Claim satisfied: no runtime terrain/elevation/cliff proof.
+- Residual risk: product proof remains open until a live game session is
+  restarted/begun through `@civ7/direct-control`, bounded map/grid/GameInfo
+  payloads are captured, and cliff crossings are read through a first-class
+  field or bounded read-only probe.
+
+## Required Runtime Proof Path
+
+1. `civ7 game restart --begin --wait-tuner --json`
+2. `civ7 game status --json`
+3. `civ7 game map --summary --json`
+4. `civ7 game gameinfo Terrains --json`, plus `Biomes`, `Features`, and
+   `Resources`.
+5. `civ7 game map --bounds x,y,w,h --fields terrain,climate,hydrology,areaRegion --player-id 0 --max-plots 512 --json`
+6. For cliffs, either:
+   - add a first-class direct-control `cliffCrossings` map field, or
+   - run a validator-approved, bounded, read-only `GameplayMap.isCliffCrossing`
+     probe over explicit `{x,y,direction}` samples.
+
+## Proof Label
+
+- Local commit complete: yes after closure amend; exact branch head is reported
+  outside this self-referential record.
+- Graphite submitted: no.
+- PR created/updated: no.
+- Local stats proof: diagnostic fail only.
+- Runtime proof: unresolved.
+- Product proof: unresolved.

--- a/openspec/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/specs/mapgen-normalization-workstreams/spec.md
@@ -48,6 +48,52 @@ where the accepted packet names real input/handoff surfaces.
   `ecology-features` as truth stages
 - **AND** it treats `map-ecology` as projection/materialization only
 
+### Requirement: Terrain Morphology Authorship Predeclares Ranges
+
+Terrain morphology workstreams SHALL predeclare expected terrain bands before
+changing shipped map config, morphology thresholds, or projection behavior.
+
+#### Scenario: Earthlike terrain relief work starts
+- **WHEN** a change claims Earthlike terrain relief, flatness, rough land,
+  hills, mountain belts, volcanoes, cliffs, or engine elevation behavior
+- **THEN** it records the terrain corpus and expected Earthlike bands before
+  implementation or tuning
+- **AND** it distinguishes Civ7 impassable ridge mountains from the broader
+  hills/rough-land footprint
+- **AND** it does not derive success ranges from current output alone
+
+### Requirement: Terrain Relief Proof Separates Truth Projection And Readback
+
+Terrain morphology workstreams SHALL keep Morphology truth, map projection,
+Hydrology terrain mutation, and engine readback as separate proof surfaces.
+
+#### Scenario: Terrain proof is recorded
+- **WHEN** a change reports planned or final terrain shares
+- **THEN** it compares planned Morphology masks with final terrain readback
+- **AND** it separates volcano-stamped mountains from ridge/belt mountains
+- **AND** it reports lake and navigable-river terrain mutation as Hydrology or
+  engine projection evidence rather than Morphology truth
+
+#### Scenario: Cliff or elevation success is claimed
+- **WHEN** a change claims Civ7 elevation or cliff behavior
+- **THEN** it includes readback after `TerrainBuilder.buildElevation()`
+- **AND** it does not treat Morphology heightfields or local projection plans
+  as proof of engine cliffs
+
+### Requirement: Rough Land Needs A Dedicated Morphology Owner
+
+Earthlike rough-land work SHALL NOT rely only on ridge foothill skirts,
+volcanoes, projection fallback, or noise-only fill.
+
+#### Scenario: Hill coverage remains below the predeclared band
+- **WHEN** diagnostics show planned or final hills below the Earthlike
+  rough-land band
+- **THEN** the next implementation slice adds or reshapes a Morphology-owned
+  operation for non-foothill hills, rolling uplands, old highlands, plateaus,
+  escarpments, basin margins, or craton relief
+- **AND** shipped map config changes wait until that causal surface exists or
+  the change records source evidence that config is the real bottleneck
+
 #### Scenario: Feature-family wrappers are folded
 - **WHEN** feature-family stage wrappers are merged into `ecology-features`
 - **THEN** the change includes output-equivalence or golden artifact checks for


### PR DESCRIPTION
Opens a systematic terrain morphology authorship workstream for Swooper Earthlike maps, addressing the structural root cause of near-zero hills and excessive flat terrain across stable seed matrices.

## Problem

Swooper Earthlike maps produce critically under-authored rough land. Seed `1018` at `106x66` yields planned hills at `0.075%`, final hills at `0.037%`, and final flats at `88.798%` of pre-lake land. An 8-seed `80x50` sweep keeps final hills between `0%` and `2.188%`. The failure is structural: the current foothill operation only admits candidates near ridge skirts or strong boundary deformation, leaving rolling uplands, old highlands, plateau rims, craton relief, basin margins, and escarpments without a Morphology owner. Volcano projection can independently stamp mountain terrain, masking the weakness of ridge and rough-land authorship in aggregate stats.

## What This PR Does

- Establishes a formal workstream frame with a falsifier: if a stable seed matrix satisfies mountain share while hills stay below the predeclared rough-land band, final flats remain above the flat-budget cap, or cliffs and elevation are unmeasured after `buildElevation()`, the workstream has not delivered terrain morphology control.
- Predeclares Civ7-scaled Earthlike terrain bands before any tuning or rough-land implementation: planned ridge mountains `4–9%`, final non-volcano mountains `4–10%`, planned hills `12–24%` (hard fail below `8%`), final hills `10–24%` (hard fail below `8%`), total rough terrain `18–32%`, and final flat terrain `55–78%` (hard fail above `85%`).
- Records the full terrain corpus: Civ7 terrain classes, terrain-linked features and natural wonders, hill-dependent resources, Morphology truth artifacts and ops, projection and hydrology mutation stages, engine API and readback surfaces, and the committed `@civ7/direct-control` proof surface.
- Defines the causal architecture: Foundation and Morphology own terrain truth; map stages project and read back; Hydrology owns lake and navigable-river terrain mutation; engine elevation and cliffs are readback-only after `buildElevation()`.
- Sequences implementation into explicit downstream slices — terrain stats and readback, a new dedicated rough-land Morphology operation, Earthlike config tuning (blocked until the prior two slices exist), runtime cliff readback, and downstream ecology and resource realignment — with config changes explicitly gated behind causal proof.
- Adds normalization-workstream spec requirements enforcing that terrain morphology work predeclares ranges, separates Morphology truth from projection and engine readback, and does not rely solely on foothill skirts, volcanoes, or noise fill to satisfy rough-land bands.
- Records all P1 and P2 review findings, including stale diagnostics helpers, the absence of a first-class cliff-crossing map field in direct-control, and the non-proof-ready status of Studio setup paths.

## What This PR Does Not Do

- No behavior, config, morphology op, or test changes in this slice.
- No Earthlike knob retuning.
- Runtime terrain, elevation, and cliff proof remain unresolved pending a reachable Civ7 tuner session and a first-class or bounded approved `isCliffCrossing` readback path.