### PR TITLE
feat(diagnostics): add terrain relief stats with volcano-separated mountain and hill metrics

### DIFF
--- a/mods/mod-swooper-maps/test/pipeline/terrain-relief-diagnostics.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/terrain-relief-diagnostics.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+
+import swooperEarthlikeConfigRaw from "../../src/maps/configs/swooper-earthlike.config.json";
+import { canonicalRecipeConfig, type CanonicalMapConfigWithRecipe } from "../../src/maps/configs/canonical.js";
+import type { StandardRecipeConfig } from "../../src/recipes/standard/recipe.js";
+import { collectWorldBalanceStats } from "../support/world-balance-stats.js";
+
+function recipeConfig(config: CanonicalMapConfigWithRecipe): StandardRecipeConfig {
+  return canonicalRecipeConfig<StandardRecipeConfig>(config);
+}
+
+function expectComponentMetrics(
+  label: string,
+  tileCount: number,
+  componentCount: number,
+  largestComponentSize: number
+): void {
+  expect(componentCount, `${label} component count`).toBeGreaterThanOrEqual(0);
+  expect(largestComponentSize, `${label} largest component`).toBeGreaterThanOrEqual(0);
+  expect(largestComponentSize, `${label} largest component <= tiles`).toBeLessThanOrEqual(tileCount);
+  if (tileCount === 0) {
+    expect(componentCount, `${label} empty component count`).toBe(0);
+    expect(largestComponentSize, `${label} empty largest component`).toBe(0);
+  } else {
+    expect(componentCount, `${label} nonempty component count`).toBeGreaterThan(0);
+    expect(largestComponentSize, `${label} nonempty largest component`).toBeGreaterThan(0);
+  }
+}
+
+describe("terrain relief diagnostics", () => {
+  it("separates planned hills, final hills, volcano mountains, and flat budgets", { timeout: 30_000 }, () => {
+    const stats = collectWorldBalanceStats({
+      label: "swooper-earthlike:relief-diagnostics",
+      config: recipeConfig(swooperEarthlikeConfigRaw),
+      seed: 1018,
+      width: 106,
+      height: 66,
+    });
+
+    expect(stats.plannedRoughTerrainTiles).toBe(stats.plannedMountainTiles + stats.plannedHillTiles);
+    expect(stats.finalRoughTerrainTiles).toBe(stats.finalMountainTiles + stats.finalHillTiles);
+    expect(stats.finalNonVolcanoRoughTerrainTiles).toBe(
+      stats.finalNonVolcanoMountainTiles + stats.finalHillTiles
+    );
+    expect(stats.finalMountainTiles).toBe(
+      stats.finalNonVolcanoMountainTiles + stats.finalVolcanoMountainTiles
+    );
+
+    expect(stats.plannedRoughTerrainShareOfPreLakeLand).toBeCloseTo(
+      stats.plannedRoughTerrainTiles / stats.preLakeLandTiles,
+      8
+    );
+    expect(stats.finalRoughTerrainShareOfPreLakeLand).toBeCloseTo(
+      stats.finalRoughTerrainTiles / stats.preLakeLandTiles,
+      8
+    );
+    expect(stats.finalNonVolcanoRoughTerrainShareOfPreLakeLand).toBeCloseTo(
+      stats.finalNonVolcanoRoughTerrainTiles / stats.preLakeLandTiles,
+      8
+    );
+
+    expect(stats.finalVolcanoMountainTiles).toBeLessThanOrEqual(stats.finalMountainTiles);
+    expect(stats.finalVolcanoMountainTiles).toBeLessThanOrEqual(stats.volcanoFeatureTiles);
+    expect(stats.volcanoFeatureTiles).toBeLessThanOrEqual(stats.preLakeLandTiles);
+    expect(Object.values(stats.volcanoKindCounts).reduce((sum, count) => sum + count, 0)).toBe(
+      stats.plannedVolcanoTiles
+    );
+
+    expectComponentMetrics(
+      "planned mountains",
+      stats.plannedMountainTiles,
+      stats.plannedMountainComponentCount,
+      stats.plannedLargestMountainComponentSize
+    );
+    expectComponentMetrics(
+      "planned hills",
+      stats.plannedHillTiles,
+      stats.plannedHillComponentCount,
+      stats.plannedLargestHillComponentSize
+    );
+    expectComponentMetrics(
+      "final mountains",
+      stats.finalMountainTiles,
+      stats.finalMountainComponentCount,
+      stats.finalLargestMountainComponentSize
+    );
+    expectComponentMetrics(
+      "final hills",
+      stats.finalHillTiles,
+      stats.finalHillComponentCount,
+      stats.finalLargestHillComponentSize
+    );
+
+    expect(stats.finalFlatToRoughRatio).toBeGreaterThanOrEqual(0);
+    expect(stats.finalFlatToNonVolcanoRoughRatio).toBeGreaterThanOrEqual(0);
+    expect(stats.plannedMountainToHillRatio).toBeGreaterThanOrEqual(0);
+    expect(stats.finalMountainToHillRatio).toBeGreaterThanOrEqual(0);
+    expect(stats.finalNonVolcanoMountainToHillRatio).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/mods/mod-swooper-maps/test/support/world-balance-stats.ts
+++ b/mods/mod-swooper-maps/test/support/world-balance-stats.ts
@@ -27,12 +27,34 @@ export type WorldBalanceStats = Readonly<{
   plannedLargestMountainComponentSize: number;
   plannedHillTiles: number;
   plannedHillShareOfPreLakeLand: number;
+  plannedHillComponentCount: number;
+  plannedLargestHillComponentSize: number;
+  plannedRoughTerrainTiles: number;
+  plannedRoughTerrainShareOfPreLakeLand: number;
+  plannedMountainToHillRatio: number;
+  plannedVolcanoTiles: number;
+  plannedVolcanoShareOfPreLakeLand: number;
+  volcanoKindCounts: Readonly<Record<string, number>>;
   finalMountainTiles: number;
   finalMountainShareOfPreLakeLand: number;
   finalMountainComponentCount: number;
   finalLargestMountainComponentSize: number;
+  finalNonVolcanoMountainTiles: number;
+  finalNonVolcanoMountainShareOfPreLakeLand: number;
+  finalVolcanoMountainTiles: number;
+  volcanoFeatureTiles: number;
   finalHillTiles: number;
   finalHillShareOfPreLakeLand: number;
+  finalHillComponentCount: number;
+  finalLargestHillComponentSize: number;
+  finalRoughTerrainTiles: number;
+  finalRoughTerrainShareOfPreLakeLand: number;
+  finalNonVolcanoRoughTerrainTiles: number;
+  finalNonVolcanoRoughTerrainShareOfPreLakeLand: number;
+  finalMountainToHillRatio: number;
+  finalNonVolcanoMountainToHillRatio: number;
+  finalFlatToRoughRatio: number;
+  finalFlatToNonVolcanoRoughRatio: number;
   finalFlatTiles: number;
   finalFlatShareOfPreLakeLand: number;
   plainsTiles: number;
@@ -131,6 +153,19 @@ type BiomeClassificationStatsInput = Readonly<{
 
 type MockAdapter = ReturnType<typeof createMockAdapter>;
 
+type VolcanoKind = "subductionArc" | "rift" | "hotspot";
+
+type VolcanoStatsInput = Readonly<{
+  volcanoMask: Uint8Array;
+  volcanoes: ReadonlyArray<
+    Readonly<{
+      tileIndex: number;
+      kind: VolcanoKind;
+      strength01: number;
+    }>
+  >;
+}>;
+
 function countMask(mask: Uint8Array): number {
   let count = 0;
   for (const value of mask) {
@@ -153,6 +188,14 @@ function percentile(values: readonly number[], p: number): number {
 
 function roundMetric(value: number): number {
   return Number(value.toFixed(4));
+}
+
+function shareOf(count: number, total: number): number {
+  return total === 0 ? 0 : count / total;
+}
+
+function safeRatio(numerator: number, denominator: number): number {
+  return denominator === 0 ? 0 : roundMetric(numerator / denominator);
 }
 
 function standardDeviation(values: readonly number[]): number {
@@ -359,6 +402,9 @@ export function collectWorldBalanceStats(args: Readonly<{
   const mountains = context.artifacts.get(morphologyArtifacts.mountains.id) as
     | { mountainMask?: Uint8Array; hillMask?: Uint8Array }
     | undefined;
+  const volcanoes = context.artifacts.get(morphologyArtifacts.volcanoes.id) as
+    | Partial<VolcanoStatsInput>
+    | undefined;
   const coastlineMetrics = context.artifacts.get(morphologyArtifacts.coastlineMetrics.id) as
     | { distanceToCoast?: Uint16Array }
     | undefined;
@@ -385,6 +431,9 @@ export function collectWorldBalanceStats(args: Readonly<{
   }
   if (!(mountains?.mountainMask instanceof Uint8Array) || !(mountains.hillMask instanceof Uint8Array)) {
     throw new Error("Missing morphology mountain fields.");
+  }
+  if (!(volcanoes?.volcanoMask instanceof Uint8Array) || !Array.isArray(volcanoes.volcanoes)) {
+    throw new Error("Missing morphology volcano fields.");
   }
   if (!(coastlineMetrics?.distanceToCoast instanceof Uint16Array)) {
     throw new Error("Missing morphology coastline metrics.");
@@ -425,10 +474,13 @@ export function collectWorldBalanceStats(args: Readonly<{
   let finalMountainTiles = 0;
   let finalHillTiles = 0;
   let finalFlatTiles = 0;
+  let finalVolcanoMountainTiles = 0;
+  let volcanoFeatureTiles = 0;
   let plainsTiles = 0;
   let lakeWaterDriftCount = 0;
   let invalidFeatureSurfaceCount = 0;
   const finalMountainMask = new Uint8Array(width * height);
+  const finalHillMask = new Uint8Array(width * height);
   const landElevations: number[] = [];
   const landAridity: number[] = [];
   const landMoisture: number[] = [];
@@ -441,6 +493,7 @@ export function collectWorldBalanceStats(args: Readonly<{
   const hillTerrain = adapter.getTerrainTypeIndex("TERRAIN_HILL");
   const flatTerrain = adapter.getTerrainTypeIndex("TERRAIN_FLAT");
   const plainsBiome = adapter.getBiomeGlobal("BIOME_PLAINS");
+  const volcanoFeatureType = adapter.getFeatureTypeIndex("FEATURE_VOLCANO");
   const featureCounts: Record<string, number> = Object.fromEntries(
     FEATURE_KEYS.map((key) => [key, 0])
   );
@@ -455,6 +508,7 @@ export function collectWorldBalanceStats(args: Readonly<{
       const idx = y * width + x;
       const isWater = adapter.isWater(x, y);
       const terrain = adapter.getTerrainType(x, y);
+      const feature = adapter.getFeatureType(x, y);
       if (isWater) waterTiles += 1;
       else {
         postProjectionLandTiles += 1;
@@ -462,9 +516,16 @@ export function collectWorldBalanceStats(args: Readonly<{
           finalMountainTiles += 1;
           finalMountainMask[idx] = 1;
         }
-        if (terrain === hillTerrain) finalHillTiles += 1;
+        if (terrain === hillTerrain) {
+          finalHillTiles += 1;
+          finalHillMask[idx] = 1;
+        }
         if (terrain === flatTerrain) finalFlatTiles += 1;
         if (adapter.getBiomeType(x, y) === plainsBiome) plainsTiles += 1;
+      }
+      if (feature === volcanoFeatureType) {
+        volcanoFeatureTiles += 1;
+        if (!isWater && terrain === mountainTerrain) finalVolcanoMountainTiles += 1;
       }
       if (topography.landMask[idx] === 1) {
         const elevation = topography.elevation[idx] ?? 0;
@@ -487,7 +548,6 @@ export function collectWorldBalanceStats(args: Readonly<{
       }
       if (engineLakeProjection.lakeMask[idx] === 1 && !isWater) lakeWaterDriftCount += 1;
 
-      const feature = adapter.getFeatureType(x, y);
       for (const key of FEATURE_KEYS) {
         const featureType = featureTypeByKey[key] ?? -1;
         if (featureType < 0 || feature !== featureType) continue;
@@ -518,6 +578,21 @@ export function collectWorldBalanceStats(args: Readonly<{
   const plannedMountainComponents = computeMaskComponents(mountains.mountainMask, width, height);
   const finalMountainComponents = computeMaskComponents(finalMountainMask, width, height);
   const plannedHillTiles = countMask(mountains.hillMask);
+  const plannedHillComponents = computeMaskComponents(mountains.hillMask, width, height);
+  const finalHillComponents = computeMaskComponents(finalHillMask, width, height);
+  const plannedRoughTerrainTiles = plannedMountainTiles + plannedHillTiles;
+  const finalNonVolcanoMountainTiles = Math.max(0, finalMountainTiles - finalVolcanoMountainTiles);
+  const finalRoughTerrainTiles = finalMountainTiles + finalHillTiles;
+  const finalNonVolcanoRoughTerrainTiles = finalNonVolcanoMountainTiles + finalHillTiles;
+  const plannedVolcanoTiles = countMask(volcanoes.volcanoMask);
+  const volcanoKindCounts: Record<VolcanoKind, number> = {
+    subductionArc: 0,
+    rift: 0,
+    hotspot: 0,
+  };
+  for (const entry of volcanoes.volcanoes) {
+    volcanoKindCounts[entry.kind] += 1;
+  }
   const lakeTiles = countMask(lakePlan.lakeMask);
   const engineLakeTiles = countMask(engineLakeProjection.lakeMask);
   const lakeComponents = computeMaskComponents(engineLakeProjection.lakeMask, width, height);
@@ -552,17 +627,45 @@ export function collectWorldBalanceStats(args: Readonly<{
     plannedMountainComponentCount: plannedMountainComponents.componentCount,
     plannedLargestMountainComponentSize: plannedMountainComponents.largestComponentSize,
     plannedHillTiles,
-    plannedHillShareOfPreLakeLand: preLakeLandTiles === 0 ? 0 : plannedHillTiles / preLakeLandTiles,
+    plannedHillShareOfPreLakeLand: shareOf(plannedHillTiles, preLakeLandTiles),
+    plannedHillComponentCount: plannedHillComponents.componentCount,
+    plannedLargestHillComponentSize: plannedHillComponents.largestComponentSize,
+    plannedRoughTerrainTiles,
+    plannedRoughTerrainShareOfPreLakeLand: shareOf(plannedRoughTerrainTiles, preLakeLandTiles),
+    plannedMountainToHillRatio: safeRatio(plannedMountainTiles, plannedHillTiles),
+    plannedVolcanoTiles,
+    plannedVolcanoShareOfPreLakeLand: shareOf(plannedVolcanoTiles, preLakeLandTiles),
+    volcanoKindCounts,
     finalMountainTiles,
-    finalMountainShareOfPreLakeLand: preLakeLandTiles === 0 ? 0 : finalMountainTiles / preLakeLandTiles,
+    finalMountainShareOfPreLakeLand: shareOf(finalMountainTiles, preLakeLandTiles),
     finalMountainComponentCount: finalMountainComponents.componentCount,
     finalLargestMountainComponentSize: finalMountainComponents.largestComponentSize,
+    finalNonVolcanoMountainTiles,
+    finalNonVolcanoMountainShareOfPreLakeLand: shareOf(
+      finalNonVolcanoMountainTiles,
+      preLakeLandTiles
+    ),
+    finalVolcanoMountainTiles,
+    volcanoFeatureTiles,
     finalHillTiles,
-    finalHillShareOfPreLakeLand: preLakeLandTiles === 0 ? 0 : finalHillTiles / preLakeLandTiles,
+    finalHillShareOfPreLakeLand: shareOf(finalHillTiles, preLakeLandTiles),
+    finalHillComponentCount: finalHillComponents.componentCount,
+    finalLargestHillComponentSize: finalHillComponents.largestComponentSize,
+    finalRoughTerrainTiles,
+    finalRoughTerrainShareOfPreLakeLand: shareOf(finalRoughTerrainTiles, preLakeLandTiles),
+    finalNonVolcanoRoughTerrainTiles,
+    finalNonVolcanoRoughTerrainShareOfPreLakeLand: shareOf(
+      finalNonVolcanoRoughTerrainTiles,
+      preLakeLandTiles
+    ),
+    finalMountainToHillRatio: safeRatio(finalMountainTiles, finalHillTiles),
+    finalNonVolcanoMountainToHillRatio: safeRatio(finalNonVolcanoMountainTiles, finalHillTiles),
+    finalFlatToRoughRatio: safeRatio(finalFlatTiles, finalRoughTerrainTiles),
+    finalFlatToNonVolcanoRoughRatio: safeRatio(finalFlatTiles, finalNonVolcanoRoughTerrainTiles),
     finalFlatTiles,
-    finalFlatShareOfPreLakeLand: preLakeLandTiles === 0 ? 0 : finalFlatTiles / preLakeLandTiles,
+    finalFlatShareOfPreLakeLand: shareOf(finalFlatTiles, preLakeLandTiles),
     plainsTiles,
-    plainsShareOfPreLakeLand: preLakeLandTiles === 0 ? 0 : plainsTiles / preLakeLandTiles,
+    plainsShareOfPreLakeLand: shareOf(plainsTiles, preLakeLandTiles),
     meanAridity: roundMetric(mean(landAridity)),
     highAridityLandShare:
       preLakeLandTiles === 0
@@ -583,7 +686,7 @@ export function collectWorldBalanceStats(args: Readonly<{
     elevationByCoastDistance,
     centralBulgeGradient,
     lakeTiles,
-    lakeShareOfPreLakeLand: preLakeLandTiles === 0 ? 0 : lakeTiles / preLakeLandTiles,
+    lakeShareOfPreLakeLand: shareOf(lakeTiles, preLakeLandTiles),
     engineLakeTiles,
     lakeComponentCount: lakeComponents.componentCount,
     singleTileLakeCount: lakeComponents.singleTileCount,

--- a/openspec/changes/morphology-terrain-stats-readback/.openspec.yaml
+++ b/openspec/changes/morphology-terrain-stats-readback/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/morphology-terrain-stats-readback/proposal.md
+++ b/openspec/changes/morphology-terrain-stats-readback/proposal.md
@@ -1,0 +1,29 @@
+# Morphology Terrain Stats Readback
+
+## Why
+
+The morphology authorship workstream found that Swooper Earthlike maps can pass
+existing checks while planned and final hills remain near zero. Current local
+stats also blend ridge mountains with volcano-stamped mountains, making final
+mountain share look healthier than the Morphology ridge surface really is.
+
+## What Changes
+
+- Extend `collectWorldBalanceStats` with measurement-only terrain relief
+  diagnostics:
+  - planned and final hill component structure
+  - planned and final rough terrain shares
+  - final non-volcano mountain and non-volcano rough shares
+  - planned volcano counts by tectonic kind
+  - final volcano-feature and volcano-mountain counts
+  - flat-to-rough ratios
+- Add a focused diagnostic test that validates accounting invariants without
+  asserting the future Earthlike success bands against the currently failing
+  output.
+
+## What Does Not Change
+
+- No map generation behavior.
+- No shipped map config.
+- No runtime Civ7 control transport.
+- No claim of engine elevation or cliff proof.

--- a/openspec/changes/morphology-terrain-stats-readback/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/morphology-terrain-stats-readback/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Terrain Relief Diagnostics Separate Roughness Buckets
+
+World-balance terrain relief diagnostics SHALL report planned Morphology
+terrain intent separately from final engine-projected terrain readback.
+
+#### Scenario: Planned and final rough terrain are measured
+- **WHEN** local world-balance stats are collected for a terrain morphology
+  workstream
+- **THEN** the stats report planned mountain, planned hill, final mountain, and
+  final hill tile counts and shares
+- **AND** the stats report connected-component counts and largest-component
+  sizes for planned and final mountain and hill masks
+- **AND** the stats report rough-terrain shares derived from mountain plus hill
+  buckets rather than relying only on final flatland share
+
+#### Scenario: Volcano-stamped mountains are measured separately
+- **WHEN** local world-balance stats include volcano planning and final terrain
+  projection
+- **THEN** the stats report planned volcano counts by tectonic kind
+- **AND** the stats report final volcano-feature tiles and final mountain tiles
+  carrying volcano features
+- **AND** the stats report final non-volcano mountain and non-volcano rough
+  shares so volcano stamping cannot hide under-authored ridge or hill terrain
+
+#### Scenario: Current failures remain diagnostic
+- **WHEN** the diagnostic test runs before terrain behavior has been tuned
+- **THEN** it validates accounting invariants only
+- **AND** it does not encode the predeclared future Earthlike success bands as
+  passing expectations for the currently failing output

--- a/openspec/changes/morphology-terrain-stats-readback/tasks.md
+++ b/openspec/changes/morphology-terrain-stats-readback/tasks.md
@@ -1,0 +1,13 @@
+## 1. Terrain Relief Diagnostics
+
+- [x] 1.1 Extend world-balance stats with planned/final hill components,
+  rough-terrain shares, volcano-separated mountains, and flat-to-rough ratios.
+- [x] 1.2 Add a focused diagnostic test for accounting invariants.
+- [x] 1.3 Run the focused diagnostic test.
+
+## 2. Validation
+
+- [x] 2.1 Run strict OpenSpec validation for this change.
+- [x] 2.2 Run full OpenSpec validation.
+- [x] 2.3 Run `git diff --check`.
+- [x] 2.4 Commit this slice on the Graphite branch.


### PR DESCRIPTION
Extends `collectWorldBalanceStats` with terrain relief diagnostics that separate planned and final roughness buckets, isolate volcano-stamped mountains from ridge-authored mountains, and expose flat-to-rough ratios.

Previously, hill tiles were counted but had no connected-component tracking, planned and final rough terrain had no combined share metrics, and volcano-stamped mountains were folded into the general final mountain count. This made it possible for maps to pass existing checks while planned and final hills were near zero, and for volcano stamping to inflate the apparent health of ridge terrain.

New stats added:
- Planned and final hill connected-component counts and largest-component sizes
- Planned and final rough terrain tile counts and shares (mountains + hills combined)
- Final non-volcano mountain tiles and non-volcano rough terrain tiles and shares
- Final volcano-feature tile count and final mountain tiles carrying volcano features
- Planned volcano counts broken down by tectonic kind (`subductionArc`, `rift`, `hotspot`)
- Mountain-to-hill and flat-to-rough ratios for both planned and final terrain, with volcano-separated variants

Adds a focused diagnostic test (`terrain-relief-diagnostics.test.ts`) that validates accounting invariants — that rough terrain equals mountains plus hills, that non-volcano rough shares are derived correctly, that component metrics are self-consistent — without asserting future Earthlike success bands against currently failing output.

No map generation behavior, shipped map configs, or runtime control transport is changed.