### PR TITLE
feat(morphology): add plan-rough-lands op for non-foothill hill authorship

### DIFF
--- a/mods/mod-swooper-maps/src/domain/morphology/ops/contracts.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/contracts.ts
@@ -11,6 +11,7 @@ import ComputeSubstrateContract from "./compute-substrate/contract.js";
 import PlanIslandChainsContract from "./plan-island-chains/contract.js";
 import PlanFoothillsContract from "./plan-foothills/contract.js";
 import PlanRidgesContract from "./plan-ridges/contract.js";
+import PlanRoughLandsContract from "./plan-rough-lands/contract.js";
 import PlanVolcanoesContract from "./plan-volcanoes/contract.js";
 
 export const contracts = {
@@ -27,6 +28,7 @@ export const contracts = {
   planIslandChains: PlanIslandChainsContract,
   planFoothills: PlanFoothillsContract,
   planRidges: PlanRidgesContract,
+  planRoughLands: PlanRoughLandsContract,
   planVolcanoes: PlanVolcanoesContract,
 } as const;
 

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/index.ts
@@ -14,6 +14,7 @@ import computeSubstrate from "./compute-substrate/index.js";
 import planIslandChains from "./plan-island-chains/index.js";
 import planFoothills from "./plan-foothills/index.js";
 import planRidges from "./plan-ridges/index.js";
+import planRoughLands from "./plan-rough-lands/index.js";
 import planVolcanoes from "./plan-volcanoes/index.js";
 
 const implementations = {
@@ -30,6 +31,7 @@ const implementations = {
   planIslandChains,
   planFoothills,
   planRidges,
+  planRoughLands,
   planVolcanoes,
 } as const satisfies DomainOpImplementationsForContracts<typeof contracts>;
 
@@ -49,5 +51,6 @@ export {
   planIslandChains,
   planFoothills,
   planRidges,
+  planRoughLands,
   planVolcanoes,
 };

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-rough-lands/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-rough-lands/contract.ts
@@ -1,0 +1,64 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+import { MountainsConfigSchema } from "../mountains-shared/config.js";
+
+/**
+ * Plans non-foothill hill terrain from inherited relief surfaces.
+ *
+ * Ridges own mountain spines and foothills own ridge skirts. This op owns the
+ * broader eroded/uplifted rough-land footprint: rolling uplands, old highlands,
+ * plateau rims, basin margins, rift shoulders, and escarpments.
+ */
+const PlanRoughLandsContract = defineOp({
+  kind: "plan",
+  id: "morphology/plan-rough-lands",
+  input: Type.Object({
+    width: Type.Integer({ minimum: 1, description: "Map width in tiles." }),
+    height: Type.Integer({ minimum: 1, description: "Map height in tiles." }),
+    landMask: TypedArraySchemas.u8({ description: "Land mask per tile (1=land, 0=water)." }),
+    mountainMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): mountain tiles to exclude from rough-land hills.",
+    }),
+    foothillMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): ridge-skirt hill tiles to exclude from rough-land hills.",
+    }),
+    elevation: TypedArraySchemas.i16({ description: "Post-erosion Morphology elevation." }),
+    seaLevel: Type.Number({ description: "Morphology sea level datum." }),
+    boundaryCloseness: TypedArraySchemas.u8({
+      description: "Boundary proximity per tile (0..255).",
+    }),
+    boundaryType: TypedArraySchemas.u8({
+      description: "Boundary type per tile (BOUNDARY_TYPE values).",
+    }),
+    upliftPotential: TypedArraySchemas.u8({ description: "Uplift potential per tile (0..255)." }),
+    riftPotential: TypedArraySchemas.u8({ description: "Rift potential per tile (0..255)." }),
+    tectonicStress: TypedArraySchemas.u8({ description: "Tectonic stress per tile (0..255)." }),
+    beltAge: TypedArraySchemas.u8({
+      description: "Normalized belt age proxy per tile (0..255). 0=youngest, 255=oldest.",
+    }),
+    erodibilityK: TypedArraySchemas.f32({
+      description: "Substrate erodibility / resistance proxy.",
+    }),
+    sedimentDepth: TypedArraySchemas.f32({
+      description: "Loose sediment thickness proxy.",
+    }),
+    flowAccum: TypedArraySchemas.f32({ description: "Drainage accumulation proxy." }),
+    distanceToCoast: TypedArraySchemas.u16({ description: "Hex distance to nearest coast." }),
+    fractalRoughLand: TypedArraySchemas.i16({
+      description: "Fractal texture used only to break ties and cluster rough-land patches.",
+    }),
+  }),
+  output: Type.Object({
+    hillMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): non-foothill rough-land hill tiles, excluding mountains.",
+    }),
+    roughnessPotential: TypedArraySchemas.u8({
+      description: "Diagnostic rough-land potential (0..255) before capped selection.",
+    }),
+  }),
+  strategies: {
+    default: MountainsConfigSchema,
+  },
+});
+
+export default PlanRoughLandsContract;

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-rough-lands/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-rough-lands/index.ts
@@ -1,0 +1,15 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import PlanRoughLandsContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const planRoughLands = createOp(PlanRoughLandsContract, {
+  strategies: {
+    default: defaultStrategy,
+  },
+});
+
+export type * from "./contract.js";
+export type * from "./types.js";
+
+export default planRoughLands;

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-rough-lands/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-rough-lands/strategies/default.ts
@@ -1,0 +1,261 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+import { forEachHexNeighborOddQ } from "@swooper/mapgen-core/lib/grid";
+
+import { BOUNDARY_TYPE } from "@mapgen/domain/foundation/constants.js";
+
+import PlanRoughLandsContract from "../contract.js";
+import type { PlanRoughLandsTypes } from "../types.js";
+import {
+  encodeNormalizedToU8,
+  normalizeMountainFractal,
+  resolveDriverStrength,
+} from "../../mountains-shared/rules.js";
+
+type RoughLandInputs = Readonly<{
+  size: number;
+  landMask: Uint8Array;
+  mountainMask: Uint8Array;
+  foothillMask: Uint8Array;
+  elevation: Int16Array;
+  boundaryCloseness: Uint8Array;
+  boundaryType: Uint8Array;
+  upliftPotential: Uint8Array;
+  riftPotential: Uint8Array;
+  tectonicStress: Uint8Array;
+  beltAge: Uint8Array;
+  erodibilityK: Float32Array;
+  sedimentDepth: Float32Array;
+  flowAccum: Float32Array;
+  distanceToCoast: Uint16Array;
+  fractalRoughLand: Int16Array;
+}>;
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function validateRoughLandInputs(input: PlanRoughLandsTypes["input"]): RoughLandInputs {
+  const { width, height } = input;
+  const size = Math.max(0, (width | 0) * (height | 0));
+
+  const landMask = input.landMask as Uint8Array;
+  const mountainMask = input.mountainMask as Uint8Array;
+  const foothillMask = input.foothillMask as Uint8Array;
+  const elevation = input.elevation as Int16Array;
+  const boundaryCloseness = input.boundaryCloseness as Uint8Array;
+  const boundaryType = input.boundaryType as Uint8Array;
+  const upliftPotential = input.upliftPotential as Uint8Array;
+  const riftPotential = input.riftPotential as Uint8Array;
+  const tectonicStress = input.tectonicStress as Uint8Array;
+  const beltAge = input.beltAge as Uint8Array;
+  const erodibilityK = input.erodibilityK as Float32Array;
+  const sedimentDepth = input.sedimentDepth as Float32Array;
+  const flowAccum = input.flowAccum as Float32Array;
+  const distanceToCoast = input.distanceToCoast as Uint16Array;
+  const fractalRoughLand = input.fractalRoughLand as Int16Array;
+
+  if (
+    landMask.length !== size ||
+    mountainMask.length !== size ||
+    foothillMask.length !== size ||
+    elevation.length !== size ||
+    boundaryCloseness.length !== size ||
+    boundaryType.length !== size ||
+    upliftPotential.length !== size ||
+    riftPotential.length !== size ||
+    tectonicStress.length !== size ||
+    beltAge.length !== size ||
+    erodibilityK.length !== size ||
+    sedimentDepth.length !== size ||
+    flowAccum.length !== size ||
+    distanceToCoast.length !== size ||
+    fractalRoughLand.length !== size
+  ) {
+    throw new Error("[PlanRoughLands] Input tensors must match width*height.");
+  }
+
+  return {
+    size,
+    landMask,
+    mountainMask,
+    foothillMask,
+    elevation,
+    boundaryCloseness,
+    boundaryType,
+    upliftPotential,
+    riftPotential,
+    tectonicStress,
+    beltAge,
+    erodibilityK,
+    sedimentDepth,
+    flowAccum,
+    distanceToCoast,
+    fractalRoughLand,
+  };
+}
+
+function computeLocalRelief(params: {
+  index: number;
+  width: number;
+  height: number;
+  elevation: Int16Array;
+  landMask: Uint8Array;
+}): number {
+  const { index, width, height, elevation, landMask } = params;
+  const base = elevation[index] ?? 0;
+  const x = index % width;
+  const y = Math.floor(index / width);
+  let maxRelief = 0;
+  forEachHexNeighborOddQ(x, y, width, height, (nx, ny) => {
+    const ni = ny * width + nx;
+    if (landMask[ni] !== 1) return;
+    maxRelief = Math.max(maxRelief, Math.abs(base - (elevation[ni] ?? base)));
+  });
+  return maxRelief;
+}
+
+function normalizeFlowAccum(value: number): number {
+  return clamp01(Math.log1p(Math.max(0, value)) / 8);
+}
+
+export const defaultStrategy = createStrategy(PlanRoughLandsContract, "default", {
+  run: (input, config) => {
+    const {
+      size,
+      landMask,
+      mountainMask,
+      foothillMask,
+      elevation,
+      boundaryCloseness,
+      boundaryType,
+      upliftPotential,
+      riftPotential,
+      tectonicStress,
+      beltAge,
+      erodibilityK,
+      sedimentDepth,
+      flowAccum,
+      distanceToCoast,
+      fractalRoughLand,
+    } = validateRoughLandInputs(input);
+    const width = input.width | 0;
+    const height = input.height | 0;
+    const hillMask = new Uint8Array(size);
+    const roughnessPotential = new Uint8Array(size);
+    const roughScoreByTile = new Float32Array(size);
+
+    let landCount = 0;
+    let mountainCount = 0;
+    let foothillCount = 0;
+    for (let i = 0; i < size; i++) {
+      if (landMask[i] !== 1) continue;
+      landCount += 1;
+      if (mountainMask[i] === 1) mountainCount += 1;
+      if (foothillMask[i] === 1) foothillCount += 1;
+    }
+
+    const threshold = Math.max(0.08, config.hillThreshold * 0.5);
+    const candidates: number[] = [];
+
+    for (let i = 0; i < size; i++) {
+      if (landMask[i] !== 1) continue;
+      if (mountainMask[i] === 1 || foothillMask[i] === 1) continue;
+
+      const boundary = boundaryType[i] ?? BOUNDARY_TYPE.none;
+      const boundaryNorm = (boundaryCloseness[i] ?? 0) / 255;
+      const uplift = (upliftPotential[i] ?? 0) / 255;
+      const rift = (riftPotential[i] ?? 0) / 255;
+      const stress = (tectonicStress[i] ?? 0) / 255;
+      const ageNorm = (beltAge[i] ?? 0) / 255;
+      const fractal = normalizeMountainFractal(fractalRoughLand[i]);
+      const driverByte = Math.max(
+        upliftPotential[i] ?? 0,
+        riftPotential[i] ?? 0,
+        tectonicStress[i] ?? 0
+      );
+      const driverStrength = resolveDriverStrength({
+        driverByte,
+        driverSignalByteMin: config.driverSignalByteMin,
+        driverExponent: config.driverExponent,
+      });
+      const resistantSubstrate = clamp01(1 - (erodibilityK[i] ?? 0.5));
+      const thinSediment = clamp01(1 - (sedimentDepth[i] ?? 0.5));
+      const coastInterior = clamp01((distanceToCoast[i] ?? 0) / 8);
+      const elevationRelief = clamp01(((elevation[i] ?? 0) - input.seaLevel) / 35);
+      const localRelief = clamp01(
+        computeLocalRelief({ index: i, width, height, elevation, landMask }) / 16
+      );
+      const flowRelief = normalizeFlowAccum(flowAccum[i] ?? 0);
+
+      const oldHighland =
+        driverStrength * (0.35 + ageNorm * 0.65) * (0.45 + resistantSubstrate * 0.55);
+      const rollingUpland =
+        coastInterior *
+        thinSediment *
+        (0.25 + fractal * 0.75) *
+        (0.25 + uplift * 0.35 + stress * 0.2 + ageNorm * 0.2);
+      const riftShoulder =
+        (boundary === BOUNDARY_TYPE.divergent ? 1 : 0.45) *
+        rift *
+        (0.45 + stress * 0.35 + fractal * 0.2);
+      const plateau =
+        elevationRelief * coastInterior * (0.35 + resistantSubstrate * 0.35 + ageNorm * 0.3);
+      const escarpment =
+        localRelief * (0.35 + coastInterior * 0.35 + resistantSubstrate * 0.3);
+      const basinMargin = flowRelief * localRelief * thinSediment;
+      const boundaryShoulder =
+        boundaryNorm *
+        (boundary === BOUNDARY_TYPE.convergent
+          ? uplift
+          : boundary === BOUNDARY_TYPE.divergent
+            ? rift
+            : stress);
+
+      const score = clamp01(
+        (oldHighland * 0.95 +
+          rollingUpland * 0.75 +
+          riftShoulder * 0.7 +
+          plateau * 0.55 +
+          escarpment * 0.65 +
+          basinMargin * 0.4 +
+          boundaryShoulder * 0.45) *
+          Math.max(0, config.tectonicIntensity) *
+          (0.75 + fractal * 0.5)
+      );
+      roughScoreByTile[i] = score;
+      roughnessPotential[i] = encodeNormalizedToU8(score);
+
+      const hasCausalSupport =
+        oldHighland > 0.06 ||
+        rollingUpland > 0.08 ||
+        riftShoulder > 0.08 ||
+        plateau > 0.08 ||
+        escarpment > 0.1 ||
+        basinMargin > 0.06 ||
+        boundaryShoulder > 0.08;
+      if (hasCausalSupport && score >= threshold) candidates.push(i);
+    }
+
+    const hillBudgetRaw = Math.floor(landCount * Math.max(0, Math.min(1, config.hillMaxFraction))) | 0;
+    const hillCapacity = Math.max(0, landCount - mountainCount - foothillCount) | 0;
+    const roughTarget = Math.max(
+      0,
+      Math.min(candidates.length, hillCapacity, hillBudgetRaw - foothillCount)
+    ) | 0;
+
+    candidates.sort((a, b) => {
+      const sa = roughScoreByTile[a] ?? 0;
+      const sb = roughScoreByTile[b] ?? 0;
+      if (sb !== sa) return sb - sa;
+      return a - b;
+    });
+
+    for (let k = 0; k < roughTarget; k++) {
+      const idx = candidates[k]!;
+      hillMask[idx] = 1;
+    }
+
+    return { hillMask, roughnessPotential };
+  },
+});

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-rough-lands/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-rough-lands/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/domain/morphology/ops/plan-rough-lands/types.ts
+++ b/mods/mod-swooper-maps/src/domain/morphology/ops/plan-rough-lands/types.ts
@@ -1,0 +1,5 @@
+import type { OpTypeBagOf } from "@swooper/mapgen-core/authoring";
+
+type Contract = typeof import("./contract.js").default;
+
+export type PlanRoughLandsTypes = OpTypeBagOf<Contract>;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/index.ts
@@ -10,7 +10,7 @@ import {
 
 /**
  * Morphology-features owns landform intent before map projection. Volcanism
- * tunes volcano intent; orogeny tunes ridge/foothill intent before
+ * tunes volcano intent; orogeny tunes ridge/foothill/rough-land intent before
  * map-morphology stamps terrain.
  */
 const knobsSchema = Type.Object(
@@ -53,6 +53,7 @@ export default createStage({
     mountains: {
       ridges: defaultEnvelope(config.mountainRanges),
       foothills: defaultEnvelope(config.mountainRanges),
+      roughLands: defaultEnvelope(config.mountainRanges),
     },
     volcanoes: {
       volcanoes: defaultEnvelope(config.volcanoes),

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/mountains.contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/mountains.contract.ts
@@ -6,9 +6,9 @@ import { morphologyArtifacts } from "../../morphology/artifacts.js";
 /**
  * Mountain planning is Morphology truth, not map projection.
  *
- * Ridges and foothills are planned from belt-driver/topography fields so
- * downstream projection can stamp terrain without deciding where mountains
- * should exist.
+ * Ridges, foothills, and rough-land hills are planned from belt-driver,
+ * topography, substrate, routing, and coastline fields so downstream projection
+ * can stamp terrain without deciding where rough terrain should exist.
  */
 const MountainsStepContract = defineStep({
   id: "mountains",
@@ -16,12 +16,19 @@ const MountainsStepContract = defineStep({
   requires: [],
   provides: [],
   artifacts: {
-    requires: [morphologyArtifacts.beltDrivers, morphologyArtifacts.topography],
+    requires: [
+      morphologyArtifacts.beltDrivers,
+      morphologyArtifacts.topography,
+      morphologyArtifacts.substrate,
+      morphologyArtifacts.routing,
+      morphologyArtifacts.coastlineMetrics,
+    ],
     provides: [morphologyArtifacts.mountains],
   },
   ops: {
     ridges: morphology.ops.planRidges,
     foothills: morphology.ops.planFoothills,
+    roughLands: morphology.ops.planRoughLands,
   },
   schema: Type.Object(
     {},

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/mountains.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology-features/steps/mountains.ts
@@ -44,6 +44,7 @@ export default createStep(MountainsStepContract, {
   }),
   normalize: (config, ctx) => {
     assertSameMountainFamilySelection(config.ridges, config.foothills);
+    assertSameMountainFamilySelection(config.ridges, config.roughLands);
 
     const { orogeny } = ctx.knobs as Readonly<{ orogeny?: MorphologyOrogenyKnob }>;
     const multiplier = MORPHOLOGY_OROGENY_TECTONIC_INTENSITY_MULTIPLIER[orogeny ?? "normal"] ?? 1.0;
@@ -95,16 +96,47 @@ export default createStep(MountainsStepContract, {
           }
         : config.foothills;
 
-    return { ...config, ridges: ridgesSelection, foothills: foothillsSelection };
+    const roughLandsSelection =
+      config.roughLands.strategy === "default"
+        ? {
+            ...config.roughLands,
+            config: {
+              ...config.roughLands.config,
+              tectonicIntensity: clampFinite(
+                config.roughLands.config.tectonicIntensity * multiplier,
+                0
+              ),
+              mountainThreshold: clampFinite(
+                config.roughLands.config.mountainThreshold + mountainThresholdDelta,
+                0
+              ),
+              hillThreshold: clampFinite(
+                config.roughLands.config.hillThreshold + hillThresholdDelta,
+                0
+              ),
+            },
+          }
+        : config.roughLands;
+
+    return {
+      ...config,
+      ridges: ridgesSelection,
+      foothills: foothillsSelection,
+      roughLands: roughLandsSelection,
+    };
   },
   run: (context, config, ops, deps) => {
     const topography = deps.artifacts.topography.read(context);
     const beltDrivers = deps.artifacts.beltDrivers.read(context);
+    const substrate = deps.artifacts.substrate.read(context);
+    const routing = deps.artifacts.routing.read(context);
+    const coastlineMetrics = deps.artifacts.coastlineMetrics.read(context);
     const { width, height } = context.dimensions;
     const baseSeed = deriveStepSeed(context.env.seed, "morphology:planMountains");
 
     const fractalMountain = buildFractalArray(width, height, baseSeed ^ 0x3d, 5);
     const fractalHill = buildFractalArray(width, height, baseSeed ^ 0x5f, 5);
+    const fractalRoughLand = buildFractalArray(width, height, baseSeed ^ 0xa7, 9);
 
     const ridges = ops.ridges(
       {
@@ -141,12 +173,44 @@ export default createStep(MountainsStepContract, {
       },
       config.foothills
     );
+    const roughLands = ops.roughLands(
+      {
+        width,
+        height,
+        landMask: topography.landMask,
+        mountainMask: ridges.mountainMask,
+        foothillMask: foothills.hillMask,
+        elevation: topography.elevation,
+        seaLevel: topography.seaLevel,
+        boundaryCloseness: beltDrivers.boundaryCloseness,
+        boundaryType: beltDrivers.boundaryType,
+        upliftPotential: beltDrivers.upliftPotential,
+        riftPotential: beltDrivers.riftPotential,
+        tectonicStress: beltDrivers.tectonicStress,
+        beltAge: beltDrivers.beltAge,
+        erodibilityK: substrate.erodibilityK,
+        sedimentDepth: substrate.sedimentDepth,
+        flowAccum: routing.flowAccum,
+        distanceToCoast: coastlineMetrics.distanceToCoast,
+        fractalRoughLand,
+      },
+      config.roughLands
+    );
+
+    const size = Math.max(0, (width | 0) * (height | 0));
+    const hillMask = new Uint8Array(size);
+    for (let i = 0; i < size; i++) {
+      hillMask[i] = foothills.hillMask[i] === 1 || roughLands.hillMask[i] === 1 ? 1 : 0;
+    }
 
     const plan = {
       mountainMask: ridges.mountainMask,
-      hillMask: foothills.hillMask,
+      hillMask,
+      foothillMask: foothills.hillMask,
+      roughLandMask: roughLands.hillMask,
       orogenyPotential: ridges.orogenyPotential,
       fracturePotential: ridges.fracturePotential,
+      roughnessPotential: roughLands.roughnessPotential,
     } as const;
 
     // Belt-driver diagnostics stay with the producing landmass-plates step.
@@ -181,6 +245,30 @@ export default createStep(MountainsStepContract, {
       }),
     });
     context.viz?.dumpGrid(context.trace, {
+      dataTypeKey: "morphology.mountains.foothillMask",
+      spaceId: TILE_SPACE_ID,
+      dims: { width, height },
+      format: "u8",
+      values: plan.foothillMask,
+      meta: defineVizMeta("morphology.mountains.foothillMask", {
+        label: "Foothill Mask (Planned)",
+        group: GROUP_MORPHOLOGY_FEATURES,
+        visibility: "debug",
+      }),
+    });
+    context.viz?.dumpGrid(context.trace, {
+      dataTypeKey: "morphology.mountains.roughLandMask",
+      spaceId: TILE_SPACE_ID,
+      dims: { width, height },
+      format: "u8",
+      values: plan.roughLandMask,
+      meta: defineVizMeta("morphology.mountains.roughLandMask", {
+        label: "Rough-Land Hill Mask (Planned)",
+        group: GROUP_MORPHOLOGY_FEATURES,
+        visibility: "debug",
+      }),
+    });
+    context.viz?.dumpGrid(context.trace, {
       dataTypeKey: "morphology.mountains.orogenyPotential",
       spaceId: TILE_SPACE_ID,
       dims: { width, height },
@@ -204,23 +292,42 @@ export default createStep(MountainsStepContract, {
         visibility: "debug",
       }),
     });
+    context.viz?.dumpGrid(context.trace, {
+      dataTypeKey: "morphology.mountains.roughnessPotential",
+      spaceId: TILE_SPACE_ID,
+      dims: { width, height },
+      format: "u8",
+      values: plan.roughnessPotential,
+      meta: defineVizMeta("morphology.mountains.roughnessPotential", {
+        label: "Rough-Land Potential (Planned)",
+        group: GROUP_MORPHOLOGY_FEATURES,
+        palette: "continuous",
+        visibility: "debug",
+      }),
+    });
 
     context.trace.event(() => {
       const size = Math.max(0, (width | 0) * (height | 0));
       let landTiles = 0;
       let mountainTiles = 0;
       let hillTiles = 0;
+      let foothillTiles = 0;
+      let roughLandHillTiles = 0;
       for (let i = 0; i < size; i++) {
         if (topography.landMask[i] !== 1) continue;
         landTiles += 1;
         if (plan.mountainMask[i] === 1) mountainTiles += 1;
         if (plan.hillMask[i] === 1) hillTiles += 1;
+        if (plan.foothillMask[i] === 1) foothillTiles += 1;
+        if (plan.roughLandMask[i] === 1) roughLandHillTiles += 1;
       }
       return {
         kind: "morphology.mountains.summary",
         landTiles,
         mountainTiles,
         hillTiles,
+        foothillTiles,
+        roughLandHillTiles,
       };
     });
     context.trace.event(() => {
@@ -233,14 +340,20 @@ export default createStep(MountainsStepContract, {
           const idx = y * width + x;
           const base = topography.landMask[idx] === 1 ? "." : "~";
           const overlay =
-            plan.mountainMask[idx] === 1 ? "M" : plan.hillMask[idx] === 1 ? "h" : undefined;
+            plan.mountainMask[idx] === 1
+              ? "M"
+              : plan.foothillMask[idx] === 1
+                ? "f"
+                : plan.roughLandMask[idx] === 1
+                  ? "r"
+                  : undefined;
           return { base, overlay };
         },
       });
       return {
         kind: "morphology.mountains.ascii.reliefMask",
         sampleStep,
-        legend: ".=land ~=water M=mountain h=hill",
+        legend: ".=land ~=water M=mountain f=foothill r=rough-land hill",
         rows,
       };
     });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/morphology/artifacts.ts
@@ -152,17 +152,27 @@ const MorphologyMountainsArtifactSchema = Type.Object(
     hillMask: TypedArraySchemas.u8({
       description: "Mask (1/0): Morphology truth intent for hill terrain excluding mountain tiles.",
     }),
+    foothillMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): ridge-skirt hill terrain intent before non-foothill rough-land merge.",
+    }),
+    roughLandMask: TypedArraySchemas.u8({
+      description: "Mask (1/0): non-foothill rough-land hill terrain intent.",
+    }),
     orogenyPotential: TypedArraySchemas.u8({
       description: "Orogeny suitability field used to explain mountain placement.",
     }),
     fracturePotential: TypedArraySchemas.u8({
       description: "Fracture/rift suitability field used to explain hill and mountain placement.",
     }),
+    roughnessPotential: TypedArraySchemas.u8({
+      description:
+        "Rolling-upland, old-highland, plateau-rim, basin-margin, and escarpment roughness field.",
+    }),
   },
   {
     additionalProperties: false,
     description:
-      "Mountain and foothill terrain intent. Morphology owns this truth; map-morphology only projects it into engine terrain.",
+      "Mountain, foothill, and rough-land terrain intent. Morphology owns this truth; map-morphology only projects it into engine terrain.",
   }
 );
 

--- a/mods/mod-swooper-maps/test/pipeline/terrain-relief-balance.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/terrain-relief-balance.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+
+import swooperEarthlikeConfigRaw from "../../src/maps/configs/swooper-earthlike.config.json";
+import { canonicalRecipeConfig, type CanonicalMapConfigWithRecipe } from "../../src/maps/configs/canonical.js";
+import type { StandardRecipeConfig } from "../../src/recipes/standard/recipe.js";
+import { collectWorldBalanceStats } from "../support/world-balance-stats.js";
+
+function recipeConfig(config: CanonicalMapConfigWithRecipe): StandardRecipeConfig {
+  return canonicalRecipeConfig<StandardRecipeConfig>(config);
+}
+
+describe("terrain relief balance", () => {
+  it("lifts Swooper Earthlike hills out of the flatness failure band", { timeout: 30_000 }, () => {
+    const stats = collectWorldBalanceStats({
+      label: "swooper-earthlike:1018",
+      config: recipeConfig(swooperEarthlikeConfigRaw),
+      seed: 1018,
+      width: 106,
+      height: 66,
+    });
+
+    expect(stats.plannedRoughLandHillShareOfPreLakeLand).toBeGreaterThanOrEqual(0.1);
+    expect(stats.plannedHillShareOfPreLakeLand).toBeGreaterThanOrEqual(0.12);
+    expect(stats.finalHillShareOfPreLakeLand).toBeGreaterThanOrEqual(0.1);
+    expect(stats.finalFlatShareOfPreLakeLand).toBeLessThanOrEqual(0.78);
+    expect(stats.finalNonVolcanoRoughTerrainShareOfPreLakeLand).toBeGreaterThanOrEqual(0.18);
+  });
+
+  it("keeps Earthlike hills above the hard-fail band across stable seed rolls", { timeout: 30_000 }, () => {
+    const config = recipeConfig(swooperEarthlikeConfigRaw);
+    const seeds = [1, 42, 99, 7777];
+    const rolls = seeds.map((seed) =>
+      collectWorldBalanceStats({
+        label: `swooper-earthlike:${seed}`,
+        config,
+        seed,
+        width: 80,
+        height: 50,
+      })
+    );
+
+    for (const stats of rolls) {
+      expect(stats.plannedHillShareOfPreLakeLand, `${stats.label} planned hills`).toBeGreaterThanOrEqual(0.12);
+      expect(stats.finalHillShareOfPreLakeLand, `${stats.label} final hills`).toBeGreaterThanOrEqual(0.08);
+      expect(stats.finalFlatShareOfPreLakeLand, `${stats.label} final flats`).toBeLessThanOrEqual(0.85);
+    }
+  });
+});

--- a/mods/mod-swooper-maps/test/pipeline/terrain-relief-diagnostics.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/terrain-relief-diagnostics.test.ts
@@ -38,6 +38,9 @@ describe("terrain relief diagnostics", () => {
     });
 
     expect(stats.plannedRoughTerrainTiles).toBe(stats.plannedMountainTiles + stats.plannedHillTiles);
+    expect(stats.plannedHillTiles).toBe(
+      stats.plannedFoothillTiles + stats.plannedRoughLandHillTiles
+    );
     expect(stats.finalRoughTerrainTiles).toBe(stats.finalMountainTiles + stats.finalHillTiles);
     expect(stats.finalNonVolcanoRoughTerrainTiles).toBe(
       stats.finalNonVolcanoMountainTiles + stats.finalHillTiles
@@ -48,6 +51,14 @@ describe("terrain relief diagnostics", () => {
 
     expect(stats.plannedRoughTerrainShareOfPreLakeLand).toBeCloseTo(
       stats.plannedRoughTerrainTiles / stats.preLakeLandTiles,
+      8
+    );
+    expect(stats.plannedFoothillShareOfPreLakeLand).toBeCloseTo(
+      stats.plannedFoothillTiles / stats.preLakeLandTiles,
+      8
+    );
+    expect(stats.plannedRoughLandHillShareOfPreLakeLand).toBeCloseTo(
+      stats.plannedRoughLandHillTiles / stats.preLakeLandTiles,
       8
     );
     expect(stats.finalRoughTerrainShareOfPreLakeLand).toBeCloseTo(
@@ -96,5 +107,7 @@ describe("terrain relief diagnostics", () => {
     expect(stats.plannedMountainToHillRatio).toBeGreaterThanOrEqual(0);
     expect(stats.finalMountainToHillRatio).toBeGreaterThanOrEqual(0);
     expect(stats.finalNonVolcanoMountainToHillRatio).toBeGreaterThanOrEqual(0);
+    expect(stats.plannedMeanRoughnessPotential).toBeGreaterThanOrEqual(0);
+    expect(stats.plannedMeanRoughnessPotential).toBeLessThanOrEqual(255);
   });
 });

--- a/mods/mod-swooper-maps/test/support/world-balance-stats.ts
+++ b/mods/mod-swooper-maps/test/support/world-balance-stats.ts
@@ -29,6 +29,11 @@ export type WorldBalanceStats = Readonly<{
   plannedHillShareOfPreLakeLand: number;
   plannedHillComponentCount: number;
   plannedLargestHillComponentSize: number;
+  plannedFoothillTiles: number;
+  plannedFoothillShareOfPreLakeLand: number;
+  plannedRoughLandHillTiles: number;
+  plannedRoughLandHillShareOfPreLakeLand: number;
+  plannedMeanRoughnessPotential: number;
   plannedRoughTerrainTiles: number;
   plannedRoughTerrainShareOfPreLakeLand: number;
   plannedMountainToHillRatio: number;
@@ -400,7 +405,13 @@ export function collectWorldBalanceStats(args: Readonly<{
     | { elevation?: Int16Array; landMask?: Uint8Array }
     | undefined;
   const mountains = context.artifacts.get(morphologyArtifacts.mountains.id) as
-    | { mountainMask?: Uint8Array; hillMask?: Uint8Array }
+    | {
+        mountainMask?: Uint8Array;
+        hillMask?: Uint8Array;
+        foothillMask?: Uint8Array;
+        roughLandMask?: Uint8Array;
+        roughnessPotential?: Uint8Array;
+      }
     | undefined;
   const volcanoes = context.artifacts.get(morphologyArtifacts.volcanoes.id) as
     | Partial<VolcanoStatsInput>
@@ -429,7 +440,13 @@ export function collectWorldBalanceStats(args: Readonly<{
   if (!(topography?.landMask instanceof Uint8Array) || !(topography.elevation instanceof Int16Array)) {
     throw new Error("Missing topography fields.");
   }
-  if (!(mountains?.mountainMask instanceof Uint8Array) || !(mountains.hillMask instanceof Uint8Array)) {
+  if (
+    !(mountains?.mountainMask instanceof Uint8Array) ||
+    !(mountains.hillMask instanceof Uint8Array) ||
+    !(mountains.foothillMask instanceof Uint8Array) ||
+    !(mountains.roughLandMask instanceof Uint8Array) ||
+    !(mountains.roughnessPotential instanceof Uint8Array)
+  ) {
     throw new Error("Missing morphology mountain fields.");
   }
   if (!(volcanoes?.volcanoMask instanceof Uint8Array) || !Array.isArray(volcanoes.volcanoes)) {
@@ -578,6 +595,12 @@ export function collectWorldBalanceStats(args: Readonly<{
   const plannedMountainComponents = computeMaskComponents(mountains.mountainMask, width, height);
   const finalMountainComponents = computeMaskComponents(finalMountainMask, width, height);
   const plannedHillTiles = countMask(mountains.hillMask);
+  const plannedFoothillTiles = countMask(mountains.foothillMask);
+  const plannedRoughLandHillTiles = countMask(mountains.roughLandMask);
+  const landRoughnessPotential: number[] = [];
+  for (let i = 0; i < mountains.roughnessPotential.length; i++) {
+    if (topography.landMask[i] === 1) landRoughnessPotential.push(mountains.roughnessPotential[i] ?? 0);
+  }
   const plannedHillComponents = computeMaskComponents(mountains.hillMask, width, height);
   const finalHillComponents = computeMaskComponents(finalHillMask, width, height);
   const plannedRoughTerrainTiles = plannedMountainTiles + plannedHillTiles;
@@ -630,6 +653,14 @@ export function collectWorldBalanceStats(args: Readonly<{
     plannedHillShareOfPreLakeLand: shareOf(plannedHillTiles, preLakeLandTiles),
     plannedHillComponentCount: plannedHillComponents.componentCount,
     plannedLargestHillComponentSize: plannedHillComponents.largestComponentSize,
+    plannedFoothillTiles,
+    plannedFoothillShareOfPreLakeLand: shareOf(plannedFoothillTiles, preLakeLandTiles),
+    plannedRoughLandHillTiles,
+    plannedRoughLandHillShareOfPreLakeLand: shareOf(
+      plannedRoughLandHillTiles,
+      preLakeLandTiles
+    ),
+    plannedMeanRoughnessPotential: roundMetric(mean(landRoughnessPotential)),
     plannedRoughTerrainTiles,
     plannedRoughTerrainShareOfPreLakeLand: shareOf(plannedRoughTerrainTiles, preLakeLandTiles),
     plannedMountainToHillRatio: safeRatio(plannedMountainTiles, plannedHillTiles),

--- a/openspec/changes/morphology-rough-land-owner/.openspec.yaml
+++ b/openspec/changes/morphology-rough-land-owner/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/morphology-rough-land-owner/proof.md
+++ b/openspec/changes/morphology-rough-land-owner/proof.md
@@ -1,0 +1,44 @@
+# Rough-Land Proof
+
+## Local Terrain Stats
+
+- Scout case: Swooper Earthlike, seed `1018`, `106x66`.
+- Result after `morphology/plan-rough-lands`:
+  - planned mountains: `7.991%`
+  - planned hills: `17.999%`
+  - planned rough-land hills: `17.924%`
+  - final mountains: `6.535%`
+  - final non-volcano mountains: `5.639%`
+  - final hills: `15.982%`
+  - final flat terrain: `72.853%`
+  - final non-volcano rough terrain: `21.621%`
+- Stable `80x50` Swooper Earthlike seed matrix
+  `[1,2,3,42,99,1234,7777,1018]`:
+  - planned hills: `17.94-18.00%`
+  - final hills: `14.56-16.61%`
+  - final flat terrain: `71.42-79.58%`
+  - final non-volcano rough terrain: `16.42-23.22%`
+
+## Commands
+
+- `bun test test/pipeline/terrain-relief-diagnostics.test.ts test/pipeline/terrain-relief-balance.test.ts`
+  - passed, `3` tests.
+- `bun test test/morphology/m11-mountains-physics-anchored.test.ts test/morphology/m12-mountains-present.test.ts`
+  - passed, `3` tests.
+- `bun run --cwd packages/sdk build`
+  - passed; required so generated map imports resolve current SDK dts.
+- `bun run --cwd mods/mod-swooper-maps check`
+  - passed.
+
+## Downstream Non-Closure
+
+`bun test test/pipeline/world-balance-stats.test.ts` still fails in the ecology
+surface:
+
+- `swooper-earthlike FEATURE_SAGEBRUSH_STEPPE habitat mismatch`: expected `0`,
+  received `15`.
+- `rainforest seed presence`: expected `8`, received `7`.
+
+This was already a failing downstream surface before the rough-land owner slice
+and remains a required ecology-feature realignment. The rough-land slice does
+not hide or relax that failure.

--- a/openspec/changes/morphology-rough-land-owner/proposal.md
+++ b/openspec/changes/morphology-rough-land-owner/proposal.md
@@ -1,0 +1,28 @@
+# Morphology Rough-Land Owner
+
+## Why
+
+The terrain authorship diagnosis showed that Swooper Earthlike was not failing
+because mountain or hill caps were too low. It was failing because hills had no
+Morphology-owned candidate surface beyond ridge skirts and strong boundary
+deformation. That left broad continental interiors flat even when mountain
+shares looked plausible.
+
+## What Changes
+
+- Add `morphology/plan-rough-lands`, a dedicated Morphology op for non-foothill
+  hills.
+- Feed the op with post-erosion topography, belt drivers, routing, coastline
+  distance, and substrate.
+- Publish separate `foothillMask`, `roughLandMask`, and `roughnessPotential`
+  diagnostics while preserving the existing combined `hillMask` projection
+  contract.
+- Add focused Earthlike relief tests that assert the predeclared hard-fail
+  bands for hills and flatness.
+
+## What Does Not Change
+
+- No shipped map config tuning.
+- No map-projection ownership change; `plotMountains` still stamps Morphology
+  truth only.
+- No claim of runtime engine elevation or cliff proof.

--- a/openspec/changes/morphology-rough-land-owner/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/morphology-rough-land-owner/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Rough Land Has A Dedicated Morphology Owner
+
+Earthlike rough-land hills SHALL be planned by a Morphology-owned operation
+that is separate from ridge mountains, ridge-skirt foothills, volcano stamping,
+and map projection.
+
+#### Scenario: Rough-land hills are authored
+- **WHEN** morphology-features publishes mountain-family terrain intent
+- **THEN** it publishes ridge mountain intent, foothill hill intent, non-foothill
+  rough-land hill intent, and a combined hill mask
+- **AND** rough-land hill intent is derived from Morphology inputs such as
+  topography, belt drivers, routing, coastline distance, and substrate
+- **AND** map projection only materializes the combined Morphology hill mask
+  into engine terrain
+
+#### Scenario: Earthlike flatness is repaired locally
+- **WHEN** Swooper Earthlike terrain relief is measured on the scout seed and
+  stable local seed matrix
+- **THEN** planned and final hills are above the predeclared hard-fail band
+- **AND** final flat terrain is below the predeclared hard-fail ceiling
+- **AND** the proof records broad world-balance failures separately from terrain
+  relief proof

--- a/openspec/changes/morphology-rough-land-owner/tasks.md
+++ b/openspec/changes/morphology-rough-land-owner/tasks.md
@@ -1,0 +1,22 @@
+## 1. Rough-Land Authorship
+
+- [x] 1.1 Add a dedicated Morphology op for non-foothill rough-land hills.
+- [x] 1.2 Wire the op into the morphology-features mountain-family step.
+- [x] 1.3 Publish separate foothill, rough-land, and combined hill masks.
+- [x] 1.4 Extend stats with rough-land hill and roughness-potential metrics.
+
+## 2. Verification
+
+- [x] 2.1 Add focused Earthlike terrain relief balance tests.
+- [x] 2.2 Run focused terrain relief diagnostics and balance tests.
+- [x] 2.3 Run existing morphology mountain tests.
+- [x] 2.4 Run the package type check.
+- [x] 2.5 Run OpenSpec validation.
+- [x] 2.6 Run `git diff --check`.
+- [x] 2.7 Commit this slice on the Graphite branch.
+
+## 3. Downstream Boundaries
+
+- [x] 3.1 Run the broader world-balance stats test.
+- [x] 3.2 Record the remaining ecology-feature failures as downstream
+  realignment, not as terrain proof failures.

--- a/openspec/changes/morphology-terrain-authorship-control/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/morphology-terrain-authorship-control/workstream/downstream-realignment-ledger.md
@@ -2,12 +2,12 @@
 
 | Area | Required realignment | Status |
 | --- | --- | --- |
-| World-balance stats | Add non-volcano mountain separation, hill components, rough/flat budgets, volcano kind/regime counts, stage terrain deltas, and explicit expected-band comparison. | required next slice |
-| Morphology ops | Add or reshape a dedicated rough-land operation for rolling uplands, old highlands, plateau rims, basin margins, escarpments, and craton relief. | required next slice |
+| World-balance stats | Add non-volcano mountain separation, hill components, rough/flat budgets, volcano kind/regime counts, stage terrain deltas, and explicit expected-band comparison. | partial: stats/readback slice added terrain/volcano/hill/rough/flat diagnostics; stage terrain deltas and runtime readback remain required |
+| Morphology ops | Add or reshape a dedicated rough-land operation for rolling uplands, old highlands, plateau rims, basin margins, escarpments, and craton relief. | implemented locally by `morphology/plan-rough-lands`; runtime proof remains unavailable |
 | Earthlike config | Defer tuning until stats prove the candidate deficit and rough-land op exists. Remove stale/noise-only knobs if the op supersedes them. | blocked until rough-land slice |
 | Projection stages | Keep `plotMountains`/`plotVolcanoes` as projection/readback only; record planned-vs-final terrain drift. | required |
 | Hydrology | Preserve lake and navigable-river terrain mutation as Hydrology-owned; compare lake/river terrain drift separately from Morphology roughness. | required |
-| Ecology/features | Re-run feature legality and family-density gates after rough-land distribution changes; hill scarcity currently affects terrain-linked natural wonders. | required |
+| Ecology/features | Re-run feature legality and family-density gates after rough-land distribution changes; hill scarcity currently affects terrain-linked natural wonders. | measured; broad world-balance still fails Sagebrush habitat and Rainforest seed-presence gates |
 | Resources | Re-run hill-dependent resource candidate/placement gates for mining, pastoral, upland agriculture, and geological resources. | required |
 | Natural wonders | Re-evaluate hill/mountain/coast natural-wonder eligibility after terrain rebalancing; do not use natural wonders to satisfy terrain-band proof. | required |
 | Direct control | Add first-class cliff-crossing map readback or use a bounded read-only approved probe before claiming cliff proof. | required for runtime closure |


### PR DESCRIPTION
Adds a dedicated `morphology/plan-rough-lands` operation that owns non-foothill hill terrain in Morphology, separate from ridge mountains, ridge-skirt foothills, volcano stamping, and map projection.

Previously, hills had no Morphology-owned candidate surface beyond ridge skirts and strong boundary deformation, leaving broad continental interiors flat even when mountain shares appeared plausible. The new op derives rough-land hill placement from post-erosion topography, belt drivers, routing, coastline distance, and substrate fields, scoring tiles across several geomorphic archetypes: old highlands, rolling uplands, rift shoulders, plateau rims, escarpments, and basin margins.

The mountains step now wires `planRoughLands` alongside `planRidges` and `planFoothills`, reads the additional artifact dependencies (`substrate`, `routing`, `coastlineMetrics`), and merges the rough-land hill mask with the foothill mask into the existing combined `hillMask` projection contract. The mountains artifact gains separate `foothillMask`, `roughLandMask`, and `roughnessPotential` fields for diagnostics and tracing, while the combined `hillMask` consumed by map projection is unchanged in shape.

World balance stats are extended with `plannedFoothillTiles`, `plannedRoughLandHillTiles`, and `plannedMeanRoughnessPotential`. Two new pipeline tests assert that Swooper Earthlike planned and final hill shares stay above the predeclared hard-fail band and that final flat terrain stays below the hard-fail ceiling, across both a scout seed and a stable seed matrix. The ASCII relief trace distinguishes foothills (`f`) from rough-land hills (`r`).

No shipped map config values are changed. Map projection ownership is unchanged; `plotMountains` continues to stamp Morphology truth only.