### PR TITLE
feat(authoring-surface): add corpus ledger, taxonomy, and OpenSpec foundation slice

### DIFF
--- a/docs/projects/standard-recipe-authoring-surface/PROJECT.md
+++ b/docs/projects/standard-recipe-authoring-surface/PROJECT.md
@@ -1,0 +1,119 @@
+# Project: Standard Recipe Authoring Surface Cleanup
+**Status:** Active
+**Timeline:** 2026-05-31 -> stacked cleanup train
+**Teams:** MapGen / Swooper Maps
+
+## Scope & Objectives
+
+Create and run a systematic cleanup workstream for the Swooper standard recipe
+authoring surface. The target state is that every authored stage schema exposes
+only intentional author-facing controls: semantic public fields, documented
+defaults and bounds, deterministic compilation into internal stage/step/op
+config, and no accidental exposure of private strategy parameters, stale legacy
+options, projection plumbing, generated-only internals, or runtime artifacts.
+
+This project is downstream of existing authority. It does not replace the
+architecture normalization packet, the flat stage config invariant, or the
+public config boundary OpenSpec work.
+
+## Authority
+
+- Current user objective for standard recipe authoring-surface cleanup.
+- `docs/projects/pipeline-realism/resources/runbooks/HANDOFF-STANDARD-RECIPE-AUTHORING-SURFACE.md`
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`
+- `docs/projects/engine-refactor-v1/resources/spec/adr/adr-er1-032-recipe-config-authoring-surface.md`
+- `docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`
+- `docs/system/libs/mapgen/reference/CONFIG-COMPILATION.md`
+- `docs/system/libs/mapgen/policies/SCHEMAS-AND-VALIDATION.md`
+- `openspec/changes/mapgen-public-config-boundary/`
+- `openspec/changes/morphology-public-config-surface/`
+- `openspec/changes/studio-public-config-contract/`
+
+## Non-Negotiables
+
+- Preserve the default flat stage shape: `{ knobs?, [stepId]?: stepConfig }`.
+- Use flat public keys `{ knobs?, [publicKey]?: publicConfig }` only when a
+  stage has an explicit public+compile transform decision and records the
+  public key, internal step key, and reason.
+- Do not add persisted `advanced`, `internal`, dual-shape, or compatibility
+  wrappers.
+- Do not hand edit generated artifacts under generated map/schema outputs.
+- Do not export all step/op config as public just to make Studio render it.
+- Public schema cleanup must be proved by schema, compile, shipped-config, and
+  Studio consumer checks.
+- Runtime or direct-control proof is required only for slices that intentionally
+  change generated map behavior or require live authoring inspection.
+
+## Deliverables
+
+- [x] Corpus ledger generator that mechanically enumerates standard recipe
+  stages, steps, knobs schemas, public/internal schemas, op envelopes,
+  strategy reachability, generated artifacts, shipped configs, Studio focus
+  paths, and runtime read sites.
+- [x] Taxonomy for defects, valid low-level surfaces, solution types, and
+  per-domain slice order.
+- [x] OpenSpec foundation slice:
+  `openspec/changes/authoring-surface-corpus-and-taxonomy/`.
+- [ ] Foundation cleanup slice removing raw public step/op leakage while keeping
+  deterministic compile behavior and migrating/proving all touched consumers.
+- [ ] Morphology alignment slice for documentation, bounds, naming, and any
+  coupled semantic profile cleanup.
+- [ ] Hydrology cleanup slice separating true public knobs from internal
+  climate/hydrography strategy controls.
+- [ ] Ecology and feature cleanup slice separating biome/feature product
+  controls from scoring/planning internals.
+- [ ] Projection `map-*` audit for map materialization controls and misplaced
+  truth-stage settings.
+- [ ] Placement cleanup slice for product-facing placement controls and internal
+  planner parameters.
+- [ ] Shared SDK/Studio guard-hardening slice for cross-cutting raw-envelope
+  leakage checks that remain after each behavior slice has completed its own
+  generated artifact, shipped config, preset, and Studio proof.
+
+## Slice Order
+
+1. `authoring-surface-corpus-and-taxonomy`
+   - No behavior change.
+   - Establishes repeatable ledger, buckets, proof gates, and review lanes.
+2. `foundation-authoring-surface-alignment`
+   - Convert Foundation public raw step keys into semantic public controls plus
+     compile output.
+   - Migrate any touched shipped configs/presets, regenerate owned artifacts,
+     prove Studio/default/schema consumers, prove projection stays internal, and
+     prove compiled config remains deterministic in the same slice.
+3. `morphology-authoring-surface-alignment`
+   - Keep semantic public keys; repair weak docs, ranges, naming, and any
+     coupled low-level fields.
+   - Include any needed config/preset migration, generated artifact updates,
+     Studio/default/schema proof, and unknown-key tests in this same slice.
+4. `hydrology-authoring-surface-alignment`
+   - Decide which climate/hydrography knobs are public and which op strategy
+     details stay internal.
+   - Include config/preset migration, generated artifact updates, Studio proof,
+     and compile/runtime evidence for behavior-changing fields.
+5. `ecology-authoring-surface-alignment`
+   - Collapse scoring/planning internals into semantic biome/feature profiles
+     where product-facing, and hide the rest.
+   - Include generated artifact, shipped config, preset, Studio, and behavior
+     proof for the changed ecology surface.
+6. `projection-authoring-surface-audit`
+   - Ensure `map-*` stages expose only projection/materialization controls.
+   - Include shipped config, generated artifact, Studio, and runtime/projection
+     proof for every changed projection field.
+7. `placement-authoring-surface-alignment`
+   - Separate placement product controls from planner/runtime internals.
+   - Include shipped config/preset migration, generated artifact updates,
+     Studio/default/schema proof, compile determinism, and focused placement
+     output proof.
+8. `studio-sdk-guard-hardening`
+   - Add cross-cutting generated schema/default/uiMeta guard tests and SDK/Studio
+     assertions after behavior slices have already migrated their own consumers.
+
+## Links
+
+- Corpus ledger: `docs/projects/standard-recipe-authoring-surface/corpus-ledger.md`
+- Taxonomy and slice plan:
+  `docs/projects/standard-recipe-authoring-surface/taxonomy-and-slices.md`
+- Proof ledger: `docs/projects/standard-recipe-authoring-surface/proof-ledger.md`
+- Review disposition:
+  `docs/projects/standard-recipe-authoring-surface/review-disposition-ledger.md`

--- a/docs/projects/standard-recipe-authoring-surface/corpus-ledger.md
+++ b/docs/projects/standard-recipe-authoring-surface/corpus-ledger.md
@@ -1,0 +1,108 @@
+# Standard Recipe Authoring Surface Corpus Ledger
+
+This ledger is generated from the live standard recipe stage objects, not from
+hand-entered schema copies. The committed generator is:
+
+```sh
+bun run scripts/report-standard-authoring-surface.ts --format=summary
+bun run scripts/report-standard-authoring-surface.ts --format=markdown
+bun run scripts/report-standard-authoring-surface.ts --format=json
+```
+
+Run it from `mods/mod-swooper-maps/`. The `markdown` and `json` formats include
+every author-facing schema row with path, owner, layer, type, default, range or
+enum, description quality, exposure rationale, gameplay/map impact, coupled
+siblings, compile target, strategy reachability, test/doc refs, and whether the
+field can change compiled or runtime output. Op-envelope config rows are
+strategy-specific (`strategies.<strategy>.config.*`) so multi-strategy ops do
+not collapse different configs onto duplicate paths.
+
+## Corpus Roots
+
+| kind | owner | path |
+| --- | --- | --- |
+| recipe and stage order | standard recipe | `mods/mod-swooper-maps/src/recipes/standard/recipe.ts` |
+| stage creation and public/internal boundary | MapGen core authoring SDK | `packages/mapgen-core/src/authoring/stage.ts` |
+| strict compile/normalize pipeline | MapGen compiler | `packages/mapgen-core/src/compiler/recipe-compile.ts` |
+| op envelope schema | MapGen core op authoring | `packages/mapgen-core/src/authoring/op/envelope.ts` |
+| recipe config schema derivation | MapGen core authoring | `packages/mapgen-core/src/authoring/recipe-config-schema.ts` |
+| generated map artifacts | Swooper Maps scripts | `mods/mod-swooper-maps/scripts/generate-map-artifacts.ts` |
+| generated Studio recipe artifacts | Swooper Maps scripts | `mods/mod-swooper-maps/scripts/generate-studio-recipe-types.ts` |
+| generated schema/default/package artifacts | Swooper Maps dist recipes | `mods/mod-swooper-maps/dist/recipes/standard*.{json,js,d.ts}` and `standard-map-config*` |
+| shipped map configs | Swooper Maps configs | `mods/mod-swooper-maps/src/maps/configs/*.config.json` |
+| shipped realism presets | Swooper Maps presets | `mods/mod-swooper-maps/src/maps/presets/realism/*.config.ts` |
+| Studio recipe catalog | MapGen Studio | `apps/mapgen-studio/src/recipes/catalog.ts` |
+| Studio schema/default consumer | MapGen Studio | `apps/mapgen-studio/src/App.tsx` |
+| Studio runtime consumer | MapGen Studio browser runner | `apps/mapgen-studio/src/browser-runner/recipeRuntime.ts`, `apps/mapgen-studio/src/browser-runner/pipeline.worker.ts` |
+| SDK runtime entrypoint | Civ7 SDK | `packages/sdk/src/mapgen/createMap.ts` |
+
+## Stage Surface Summary
+
+Captured on 2026-05-31 from the current Graphite branch using:
+`bun run scripts/report-standard-authoring-surface.ts --format=summary`.
+
+| stage | layer | public | steps | surface keys | fields | raw envelope rows | desc missing/weak | numeric bounded |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| foundation | semantic-public-config | true | 10 | knobs, mesh, mantle-potential, mantle-forcing, crust, plate-graph, plate-motion, tectonics, crust-evolution, plate-topology | 84 | 72 | 34/27 | 52/54 |
+| morphology-coasts | semantic-public-config | true | 2 | knobs, substrate, relief, waterCoverage, continents, coastlineShape, shelf | 73 | 0 | 7/41 | 38/59 |
+| morphology-routing | semantic-public-config | true | 1 | knobs | 1 | 0 | 0/1 | 0/0 |
+| morphology-erosion | semantic-public-config | true | 1 | knobs, geomorphicCycle | 15 | 0 | 4/10 | 4/6 |
+| morphology-features | semantic-public-config | true | 4 | knobs, islandChains, mountainRanges, volcanoes | 74 | 0 | 3/50 | 66/67 |
+| hydrology-climate-baseline | internal-step-config | false | 1 | knobs, climate-baseline | 102 | 93 | 10/61 | 80/80 |
+| hydrology-hydrography | internal-step-config | false | 2 | knobs, rivers, lakes | 19 | 14 | 5/4 | 11/11 |
+| hydrology-climate-refine | internal-step-config | false | 1 | knobs, climate-refine | 90 | 85 | 8/59 | 73/73 |
+| ecology-pedology | internal-step-config | false | 2 | knobs, pedology, resource-basins | 44 | 41 | 42/2 | 29/29 |
+| ecology-biomes | internal-step-config | false | 1 | knobs, biomes | 35 | 33 | 5/24 | 11/23 |
+| ecology-features | internal-step-config | false | 6 | knobs, score-layers, plan-ice, plan-reefs, plan-wetlands, plan-vegetation, plan-plot-effects | 160 | 153 | 96/38 | 66/106 |
+| map-morphology | internal-step-config | false | 4 | knobs, plot-coasts, plot-continents, plot-mountains, plot-volcanoes | 5 | 0 | 4/0 | 0/0 |
+| map-hydrology | internal-step-config | false | 1 | knobs, lakes | 3 | 0 | 0/0 | 0/0 |
+| map-elevation | internal-step-config | false | 1 | knobs, build-elevation | 2 | 0 | 2/0 | 0/0 |
+| map-rivers | internal-step-config | false | 1 | knobs, plot-rivers | 5 | 0 | 0/0 | 2/2 |
+| map-ecology | internal-step-config | false | 3 | knobs, plot-biomes, features-apply, plot-effects | 16 | 2 | 3/0 | 1/1 |
+| placement | internal-step-config | false | 9 | knobs, derive-placement-inputs, plot-landmass-regions, place-natural-wonders, prepare-placement-surface, place-resources, assign-starts, place-discoveries, assign-advanced-starts, placement | 33 | 23 | 20/4 | 9/13 |
+
+## Ledger Completeness Checks
+
+- Stage rows: 17.
+- Step rows: 50, including step phase, requires/provides tags, artifact
+  requires/provides, schema row counts, and op envelopes.
+- Studio focus path rows: 50, one for every standard step.
+- Field rows: 761.
+- Duplicate field paths after strategy-specific op flattening: 0.
+- Array item schemas are traversed through `.items` rows, including authored
+  arrays of object configs such as ecology resource basin resource entries.
+
+## Initial Diagnosis
+
+- Foundation is the clearest public-surface defect. It declares a
+  `semantic-public-config` layer, but public keys such as `mesh` expose raw
+  step/op envelopes like `computeMesh.strategy` and `computeMesh.config.*`.
+- Morphology is structurally aligned with the desired public+compile model:
+  public keys are semantic and no raw `{ strategy, config }` envelope is
+  exposed. The remaining work is documentation quality, bounds/default review,
+  naming, and profile/coupling cleanup.
+- Hydrology, ecology, and placement are not currently public schemas. Their raw
+  envelopes are default step-key authoring surfaces, not public leakage by
+  themselves. Each domain still needs an acceptance decision for every exposed
+  field: keep only gameplay/execution-meaningful, documented, bounded controls;
+  collapse coupled controls into semantic knobs/profiles; move private strategy
+  or runtime plumbing internal.
+- Projection `map-*` stages expose small internal-as-public projection surfaces.
+  These need owner-layer review, especially `map-hydrology.lakes.projectionReadback`
+  and `map-ecology.features-apply.apply`.
+- The generated schema/default and Studio consumer chain is centralized through
+  the generator scripts, generated `dist/recipes/standard*` artifacts, and
+  `configFocusPathWithinStage`; any cleanup that changes public fields must
+  regenerate and prove those artifacts in the same behavior slice.
+
+## Runtime And Consumer Reachability
+
+| consumer | surface consumed | proof requirement |
+| --- | --- | --- |
+| shipped map configs | standard recipe config schema | Validate after each cleanup and migrate removed/renamed fields. |
+| realism presets | standard recipe config schema | Validate after each cleanup and snapshot deterministic compile output where unchanged. |
+| generated map artifacts | generated SDK map files and dist recipe artifacts | Regenerate only through scripts when source configs or schema/defaults change. |
+| Studio catalog | generated schema/default/uiMeta artifacts | Prove only intended fields appear in schema/default/focus paths. |
+| Studio browser runner | default config, schema, overrides, `recipe.compile` | Prove authoring overrides normalize and compile before runtime. |
+| compiler/runtime | internal compiled stage/step/op config | Prove public input compiles deterministically before runtime. |
+| Civ7 direct control | generated game behavior | Use only for behavior-changing slices or live authoring proof. |

--- a/docs/projects/standard-recipe-authoring-surface/proof-ledger.md
+++ b/docs/projects/standard-recipe-authoring-surface/proof-ledger.md
@@ -1,0 +1,30 @@
+# Standard Recipe Authoring Surface Proof Ledger
+
+## 2026-05-31: Corpus And Taxonomy Slice
+
+| evidence | command or source | result |
+| --- | --- | --- |
+| Graphite isolation | `gt create codex/standard-recipe-authoring-surface-workstream --no-interactive` | New branch on top of the current stack in `wt-agent-dra-authoring-surface-handoff-reference`. |
+| Graphite stack | `gt ls --stack --no-interactive` | Current branch is `codex/standard-recipe-authoring-surface-workstream` above the authoring handoff branch. |
+| Narsil status | restarted `com.rawr.narsil-mcp-civ7` launch agent; used `list_repos`, `get_recent_changes`, `get_hotspots`, `find_symbols`, and `find_references` | Narsil indexed the Civ7 repo and supplied hotspots/references. Hybrid search was avoided after crash risk. |
+| TypeBox/runtime stage inspection | `bun run scripts/report-standard-authoring-surface.ts --format=summary` | Enumerated 17 standard stages, all stage surface keys, field counts, raw-envelope counts, description gaps, step/op strategies, generated artifacts, shipped configs, Studio focus paths, and runtime read sites. |
+| JSON corpus completeness check | `bun run scripts/report-standard-authoring-surface.ts --format=json`; duplicate-path check over `/tmp/standard-authoring-ledger.json` | `stageRows=17`, `fieldRows=761`, `stepRows=50`, `focusRows=50`, `duplicateFieldPathCount=0`. |
+| Foundation raw-envelope proof | direct TypeBox inspection of `foundation.surfaceSchema.properties.mesh` | Public `foundation.mesh.computeMesh` contains raw op envelope `strategy/config` and low-level config fields. |
+| Morphology public-surface proof | stage runtime inspection and existing OpenSpec `morphology-public-config-surface` | Morphology exposes semantic public keys and no raw op-envelope selectors. |
+| Studio consumer path | `apps/mapgen-studio/src/recipes/catalog.ts`, `apps/mapgen-studio/src/App.tsx`, generator scripts | Studio consumes generated schema/default/uiMeta and `configFocusPathWithinStage`. |
+| OpenSpec validation | `bun run openspec -- validate authoring-surface-corpus-and-taxonomy --strict` | Passed. |
+| Peer-agent review | Corpus reviewer and taxonomy/OpenSpec reviewer | P1/P2 findings accepted and repaired; see `review-disposition-ledger.md`. |
+| Whitespace check | `git diff --check` | Passed. |
+| Package TypeScript check | `bun run check` in `mods/mod-swooper-maps` | Not used as a passing gate for this docs/diagnostic slice. It currently fails on existing generated map imports that cannot resolve `@mateicanavra/civ7-sdk/mapgen`. |
+
+## Required Gates For Later Behavior Slices
+
+| gate | command or evidence |
+| --- | --- |
+| OpenSpec validation | `bun run openspec -- validate <change-id> --strict` |
+| TypeScript/schema generator check | Package-local `bun` scripts for touched package and generator scripts that own artifacts. |
+| Config validation | `mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts`, `presets-schema-valid.test.ts`, and `studio-presets-schema-valid.test.ts`. |
+| Compile determinism | Focused compiled-config snapshot or golden tests for touched stages. |
+| Unknown-key failure | Focused tests proving removed fields fail strict validation with clear errors. |
+| Studio proof | Generated schema/default/uiMeta assertions and, when needed, Studio form inspection. |
+| Runtime proof | `@civ7/direct-control` or Studio runtime proof only for behavior-changing slices. |

--- a/docs/projects/standard-recipe-authoring-surface/review-disposition-ledger.md
+++ b/docs/projects/standard-recipe-authoring-surface/review-disposition-ledger.md
@@ -1,0 +1,16 @@
+# Review Disposition Ledger
+
+## 2026-05-31: Corpus And Taxonomy Slice
+
+| reviewer | priority | finding | disposition |
+| --- | --- | --- | --- |
+| taxonomy/OpenSpec peer | P1 | Migration and Studio proof were sequenced too late as a final shared slice. | Accepted. Project and OpenSpec now require shipped config/preset migration, generated artifact updates, Studio/default/schema proof, and unknown-key tests in the same behavior slice that changes the surface. Final shared slice is guard hardening only. |
+| taxonomy/OpenSpec peer | P2 | Flat shape language made `{ knobs?, [publicKey]?: publicConfig }` sound like the default shape. | Accepted. Docs/spec now distinguish default `{ knobs?, [stepId]?: stepConfig }` from justified public+compile transforms with recorded public/internal keys and reason. |
+| taxonomy/OpenSpec peer | P2 | `internal-as-public transitional surface` was used without acceptance criteria. | Accepted. Taxonomy/spec now define accepted internal-as-public low-level surfaces and require gameplay/execution meaning, docs, numeric bounds, and no private runtime/projection plumbing. |
+| taxonomy/OpenSpec peer | P2 | Deferral language was weaker than the proof posture. | Accepted. Deferral now requires accepted owner, authority reference, trigger, and explicit non-claim of behavior proof. |
+| corpus peer | P1 | Strategy coverage collapsed multi-strategy op config leaves onto duplicate paths. | Accepted. Ledger paths now include `strategies.<strategy>.config.*`; duplicate field-path check reports zero duplicates. |
+| corpus peer | P1 | Studio focus paths were not enumerated. | Accepted. Ledger now emits `focusRows` for every standard step and summary output includes a Studio focus path table. |
+| corpus peer | P2 | Generated artifact coverage omitted dist schema/default/config artifacts. | Accepted. Consumer refs now include standard schema/default/preset, standard artifacts, and standard map-config dist outputs. |
+| corpus peer | P2 | Runtime read-site coverage was too narrow. | Accepted. Runtime refs now include core recipe compile/run, standard runtime, Studio runtime recipe registry, Studio worker compile path, and SDK createMap. |
+| corpus peer | P2 | Array item schemas were omitted from field coverage. | Accepted. Schema flattening now traverses `items`, including array item object properties. |
+| corpus peer | P3 | Step handoff dependencies were not represented. | Accepted. Step rows now include phase, requires/provides tags, and artifact requires/provides. |

--- a/docs/projects/standard-recipe-authoring-surface/taxonomy-and-slices.md
+++ b/docs/projects/standard-recipe-authoring-surface/taxonomy-and-slices.md
@@ -1,0 +1,68 @@
+# Authoring Surface Taxonomy And Slice Plan
+
+## Issue Buckets
+
+| bucket | definition | solution type |
+| --- | --- | --- |
+| missing or poor TypeBox documentation | Author-facing object/leaf lacks what/why/impact/default/range context. | Document in schema; add guard coverage for public fields. |
+| internal parameter leakage | Public schema exposes raw step ids, op ids, `{ strategy, config }`, derived fields, or runtime plumbing. | Convert to semantic public schema plus compile, or move internal. |
+| accepted internal-as-public low-level surface | A stage intentionally has no public+compile transform and uses the default flat `{ knobs?, [stepId]?: stepConfig }` authoring shape. This is acceptable only when the step config is gameplay/execution meaningful, documented, bounded, and not merely private strategy/runtime plumbing. | Keep as step-key config with docs and tests, collapse selected controls into semantic knobs/profiles, or move private details internal. |
+| coupled low-level fields | Several numeric implementation fields must be tuned together to make one gameplay decision. | Collapse into semantic knob/profile; compile to low-level config. |
+| dead or disconnected config | Field validates but does not affect compiled config or runtime output. | Remove with migration or add runtime guard if intentionally reserved. |
+| stale legacy strategy surface | Old strategy selector or config remains author-facing after strategy consolidation. | Remove or move internal; add unknown-key failure tests. |
+| misplaced owner layer | Field belongs to run settings, stage knobs, projection, Studio-only metadata, or runtime internals rather than stage public config. | Move to the owning layer; document boundary. |
+| bad naming, ranges, or defaults | Field name, enum, default, min/max, or units do not match product meaning. | Rename/document/range-bound with migration and compile proof. |
+| generated or Studio-only schema leakage | Generated artifacts or UI focus paths expose fields absent from intended public schema. | Regenerate artifacts and add Studio schema/default guard. |
+| behavior-changing public config without proof | Field changes generated output but lacks stats, golden diff, or runtime evidence. | Add focused stats/golden/direct-control proof, or defer only with accepted owner, authority reference, trigger, and an explicit statement that the slice does not claim behavior proof. |
+
+## Current Classification
+
+| domain | finding | bucket | action |
+| --- | --- | --- | --- |
+| foundation | `semantic-public-config` exposes public step keys and raw op envelopes (`mesh.computeMesh`, tectonics ops, etc.). | internal parameter leakage | Convert to semantic public controls plus compile; keep projection internal. |
+| morphology-coasts | Semantic surface exists but many public numeric leaves have weak docs and some lack bounds. | missing or poor documentation; bad ranges/defaults | Document/range review; keep current public+compile shape unless coupled fields should become profiles. |
+| morphology-routing | Public empty knobs surface is weakly described. | missing or poor documentation | Document why routing has no public controls or hide empty surface if not useful. |
+| morphology-erosion | Public `geomorphicCycle` exposes fluvial/diffusion/deposition implementation terms. | coupled low-level fields | Decide whether to retain expert public surface or collapse to erosion-age/profile controls. |
+| morphology-features | Semantic groups exist, but many low-level density/chance fields are profile candidates. | coupled low-level fields; documentation | Keep public groups but audit profile and range semantics. |
+| hydrology | Climate and hydrography expose many strategy configs through internal-as-public step schemas. | accepted internal-as-public low-level surface candidate; stale strategy surface | Decide public climate/water knobs before keeping or hiding selected internals. |
+| ecology | Pedology/biome/feature planning exposes strategy/scoring internals. | coupled low-level fields; stale strategy surface | Collapse author-facing decisions into semantic ecology/feature profiles; hide scoring internals. |
+| projection `map-*` | Projection surfaces are small but owner-layer intent is uneven. | misplaced owner layer; generated or Studio-only leakage | Keep map-materialization fields only when they directly affect Civ7 projection. |
+| placement | Planner and placement inputs expose raw op envelopes and candidate lists. | internal parameter leakage; coupled low-level fields | Create semantic placement controls, compile to internal planner config, and migrate configs. |
+| shared SDK/Studio | Studio renders whatever generated schema exposes. | generated or Studio-only schema leakage | Add guard tests over generated schema/default/uiMeta artifacts. |
+
+## Slice Gates
+
+Each cleanup slice must prove:
+
+- The public schema for touched stages does not expose raw `{ strategy, config }`
+  unless an OpenSpec/design record explicitly accepts that field as public.
+- Touched default step-key surfaces are accepted only if each exposed step/op
+  field is documented, range-bounded where numeric, gameplay/execution
+  meaningful, and not private runtime/projection plumbing.
+- Every public field has author-facing documentation covering what it controls,
+  why it exists, gameplay/map impact, default, and range/enum semantics.
+- First-party shipped configs and presets are migrated and validate in the same
+  behavior slice that changes their schema.
+- Compile output is deterministic.
+- Removed fields fail with clear unknown-key errors.
+- Unchanged slices are behavior-equivalent by compiled-config snapshot.
+- Changed slices have focused stats/golden/runtime evidence appropriate to the
+  behavior changed.
+- Generated schema/default/uiMeta artifacts and Studio consumers expose only
+  intended fields in the same behavior slice that changes those fields.
+
+## Review Lanes
+
+- Architecture authority: flat stage shape, truth/projection split, and owner
+  layer boundaries.
+- Product authority: gameplay meaning, defaults, ranges, and whether a control
+  belongs to authors.
+- Operational debugging: only use direct control or live Studio proof for
+  behavior-changing slices.
+- Narsil/code intelligence: reference and runtime-read-site checks, avoiding
+  hybrid search when it destabilizes the MCP server.
+- TypeScript/TypeBox: schema, default, enum, bound, and compile inference
+  inspection.
+- Graphite/OpenSpec: one logical cleanup slice per branch/change record.
+- Framed peer-agent review: taxonomy, spec, implementation, generated artifacts,
+  migration notes, and proof records before dependent slices.

--- a/mods/mod-swooper-maps/scripts/report-standard-authoring-surface.ts
+++ b/mods/mod-swooper-maps/scripts/report-standard-authoring-surface.ts
@@ -1,0 +1,695 @@
+import { STANDARD_STAGES } from "../src/recipes/standard/recipe.js";
+
+type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+
+interface SchemaLike {
+  type?: string;
+  const?: Json;
+  enum?: Json[];
+  anyOf?: SchemaLike[];
+  items?: SchemaLike;
+  required?: string[];
+  properties?: Record<string, SchemaLike>;
+  default?: Json;
+  minimum?: number;
+  maximum?: number;
+  description?: string;
+}
+
+interface StageLike {
+  id: string;
+  public?: unknown;
+  compile?: unknown;
+  knobsSchema?: SchemaLike;
+  surfaceSchema?: SchemaLike;
+  authoring?: {
+    config?: {
+      layer?: string;
+      focusPathsByStepId?: Record<string, string[]>;
+    };
+  };
+  steps: StepLike[];
+}
+
+interface StepLike {
+  contract: {
+    id: string;
+    phase?: string;
+    requires?: readonly string[];
+    provides?: readonly string[];
+    artifacts?: {
+      requires?: readonly ArtifactLike[];
+      provides?: readonly ArtifactLike[];
+    };
+    schema?: SchemaLike;
+    ops?: Record<string, OpLike>;
+  };
+}
+
+interface ArtifactLike {
+  id?: string;
+  name?: string;
+}
+
+interface OpLike {
+  strategies?: Record<string, unknown>;
+  config?: SchemaLike;
+  defaultConfig?: Json;
+}
+
+interface FlattenedSchemaRow {
+  path: string;
+  type: string;
+  required: boolean;
+  default?: Json;
+  minimum?: number;
+  maximum?: number;
+  enum?: Json[];
+  description?: string;
+  descriptionQuality: "missing" | "weak" | "ok";
+  rawEnvelope: boolean;
+  strategies?: string[];
+}
+
+interface AuthorFieldRow extends FlattenedSchemaRow {
+  stageId: string;
+  owner: string;
+  layer: "knob" | "public" | "internal-as-public" | "internal-envelope";
+  whyExposed: string;
+  gameplayImpact: string;
+  coupledFields: string[];
+  compileTarget: string;
+  selectedStrategyReachability: string[];
+  testsAndDocs: string[];
+  changesCompiledConfig: boolean;
+  changesRuntimeOutput: "yes" | "likely" | "depends" | "no";
+}
+
+interface StageLedgerRow {
+  stageId: string;
+  layer: string;
+  publicSchema: boolean;
+  compileOwner: string;
+  steps: string[];
+  surfaceKeys: string[];
+  fieldCount: number;
+  rawEnvelopeRows: number;
+  missingDescriptions: number;
+  weakDescriptions: number;
+  boundedNumericLeaves: number;
+  numericLeaves: number;
+}
+
+const REPO_REFS = {
+  standardRecipe: "mods/mod-swooper-maps/src/recipes/standard/recipe.ts",
+  standardRuntime: "mods/mod-swooper-maps/src/recipes/standard/runtime.ts",
+  generatedMapArtifacts: "mods/mod-swooper-maps/scripts/generate-map-artifacts.ts",
+  generatedStudioTypes: "mods/mod-swooper-maps/scripts/generate-studio-recipe-types.ts",
+  studioCatalog: "apps/mapgen-studio/src/recipes/catalog.ts",
+  studioForm: "apps/mapgen-studio/src/App.tsx",
+  studioRuntimeRecipe: "apps/mapgen-studio/src/browser-runner/recipeRuntime.ts",
+  studioPipelineWorker: "apps/mapgen-studio/src/browser-runner/pipeline.worker.ts",
+  sdkCreateMap: "packages/sdk/src/mapgen/createMap.ts",
+  coreStage: "packages/mapgen-core/src/authoring/stage.ts",
+  coreRecipe: "packages/mapgen-core/src/authoring/recipe.ts",
+  coreRecipeCompile: "packages/mapgen-core/src/compiler/recipe-compile.ts",
+  standardReference: "docs/system/libs/mapgen/reference/STANDARD-RECIPE.md",
+  compilationReference: "docs/system/libs/mapgen/reference/CONFIG-COMPILATION.md",
+  schemaPolicy: "docs/system/libs/mapgen/policies/SCHEMAS-AND-VALIDATION.md",
+};
+
+const SHIPPED_CONFIG_REFS = [
+  "mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json",
+  "mods/mod-swooper-maps/src/maps/configs/shattered-ring.config.json",
+  "mods/mod-swooper-maps/src/maps/configs/sundered-archipelago.config.json",
+  "mods/mod-swooper-maps/src/maps/configs/swooper-desert-mountains.config.json",
+  "mods/mod-swooper-maps/src/maps/presets/realism/earthlike.config.ts",
+  "mods/mod-swooper-maps/src/maps/presets/realism/old-erosion.config.ts",
+  "mods/mod-swooper-maps/src/maps/presets/realism/young-tectonics.config.ts",
+  "apps/mapgen-studio/src/ui/data/defaultConfig.ts",
+];
+
+const GENERATED_ARTIFACT_REFS = [
+  "mods/mod-swooper-maps/src/recipes/standard/map-artifacts.ts",
+  "mods/mod-swooper-maps/src/maps/generated/swooper-earthlike.ts",
+  "mods/mod-swooper-maps/src/maps/generated/shattered-ring.ts",
+  "mods/mod-swooper-maps/src/maps/generated/sundered-archipelago.ts",
+  "mods/mod-swooper-maps/src/maps/generated/swooper-desert-mountains.ts",
+  "mods/mod-swooper-maps/dist/recipes/standard.schema.json",
+  "mods/mod-swooper-maps/dist/recipes/standard.defaults.json",
+  "mods/mod-swooper-maps/dist/recipes/standard.presets.json",
+  "mods/mod-swooper-maps/dist/recipes/standard.d.ts",
+  "mods/mod-swooper-maps/dist/recipes/standard-artifacts.js",
+  "mods/mod-swooper-maps/dist/recipes/standard-artifacts.d.ts",
+  "mods/mod-swooper-maps/dist/recipes/standard-map-config.schema.json",
+  "mods/mod-swooper-maps/dist/recipes/standard-map-configs.js",
+  "mods/mod-swooper-maps/dist/recipes/standard-map-configs.d.ts",
+];
+
+const TEST_REFS = [
+  "mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts",
+  "mods/mod-swooper-maps/test/config/presets-schema-valid.test.ts",
+  "mods/mod-swooper-maps/test/config/studio-presets-schema-valid.test.ts",
+  "mods/mod-swooper-maps/test/m11-config-knobs-and-presets.test.ts",
+  "mods/mod-swooper-maps/test/standard-compile-errors.test.ts",
+  "apps/mapgen-studio/test/config/defaultConfigSchema.test.ts",
+  "packages/mapgen-core/test/authoring/authoring.test.ts",
+  "packages/mapgen-core/test/compiler/recipe-compile.test.ts",
+];
+
+const STAGE_IMPACT: Record<string, string> = {
+  foundation: "tectonic topology, plate history, crust, and projection seed artifacts",
+  "morphology-coasts": "land/water coverage, coast shape, shelf, substrate, and base relief",
+  "morphology-routing": "terrain routing fields consumed by erosion and drainage",
+  "morphology-erosion": "geomorphic smoothing, incision, deposition, and relief age",
+  "morphology-features": "islands, mountain ranges, volcanoes, rough lands, and landmass summaries",
+  "hydrology-climate-baseline": "baseline temperature, winds, currents, humidity, and precipitation",
+  "hydrology-hydrography": "river discharge/network projection and lake planning",
+  "hydrology-climate-refine": "refined climate, cryosphere, land-water budget, and diagnostics",
+  "ecology-pedology": "soil/resource basin classification inputs for ecology and placement",
+  "ecology-biomes": "biome classification and vegetation/aridity bands",
+  "ecology-features": "feature suitability scores and planned ice/reefs/wetlands/vegetation/effects",
+  "map-morphology": "projection of morphology truth into Civ7 plot terrain/features",
+  "map-hydrology": "projection/materialization of hydrology truth into Civ7 water artifacts",
+  "map-elevation": "projection of elevation truth into Civ7 map height/elevation values",
+  "map-rivers": "projection of river truth into Civ7 river edges/classes",
+  "map-ecology": "projection of ecology truth into Civ7 biomes/features/effects",
+  placement: "natural wonders, resources, starts, discoveries, placement surface, and final SDK map output",
+};
+
+function asStages(): StageLike[] {
+  return STANDARD_STAGES as unknown as StageLike[];
+}
+
+function propertiesOf(schema?: SchemaLike): Record<string, SchemaLike> {
+  return schema?.properties ?? {};
+}
+
+function requiredOf(schema?: SchemaLike): Set<string> {
+  return new Set(Array.isArray(schema?.required) ? schema.required : []);
+}
+
+function typeOf(schema?: SchemaLike): string {
+  if (!schema) return "unknown";
+  if (schema.anyOf) return "union";
+  if (schema.type) return schema.type;
+  if (schema.const !== undefined) return "const";
+  return "unknown";
+}
+
+function enumValues(schema?: SchemaLike): Json[] | undefined {
+  if (!schema) return undefined;
+  if (schema.const !== undefined) return [schema.const];
+  if (schema.enum) return schema.enum;
+  if (schema.anyOf) {
+    const values = schema.anyOf.flatMap((variant) => enumValues(variant) ?? []);
+    return values.length > 0 ? values : undefined;
+  }
+  return undefined;
+}
+
+function descriptionQuality(schema?: SchemaLike): "missing" | "weak" | "ok" {
+  const description = typeof schema?.description === "string" ? schema.description.trim() : "";
+  if (!description) return "missing";
+  if (
+    /(impact|controls|sets|determines|affects|used|author|map|gameplay|density|coverage|shape|terrain|biome|river|lake|coast|plate|climate|feature|placement|derived|projection|coordinate)/i.test(
+      description,
+    )
+  ) {
+    return "ok";
+  }
+  return "weak";
+}
+
+function isRawOpEnvelope(schema?: SchemaLike): boolean {
+  if (!schema) return false;
+  const variants = schema.anyOf ?? [schema];
+  return variants.some((variant) => Boolean(variant.properties?.strategy && variant.properties?.config));
+}
+
+function envelopeStrategies(schema?: SchemaLike): string[] {
+  if (!schema) return [];
+  return (schema.anyOf ?? [schema])
+    .map((variant) => variant.properties?.strategy?.const)
+    .filter((value): value is string => typeof value === "string");
+}
+
+function flattenSchema(
+  schema: SchemaLike | undefined,
+  path: string[],
+  rows: FlattenedSchemaRow[],
+  required: boolean,
+  strategies?: string[],
+): void {
+  if (!schema) return;
+
+  if (isRawOpEnvelope(schema)) {
+    rows.push({
+      path: path.join("."),
+      type: "op-envelope",
+      required,
+      default: schema.default,
+      description: schema.description,
+      descriptionQuality: descriptionQuality(schema),
+      rawEnvelope: true,
+      strategies: envelopeStrategies(schema),
+    });
+
+    for (const variant of schema.anyOf ?? [schema]) {
+      const strategy = variant.properties?.strategy?.const;
+      const configSchema = variant.properties?.config;
+      const requiredConfigKeys = requiredOf(configSchema);
+      for (const [key, childSchema] of Object.entries(propertiesOf(configSchema))) {
+        if (typeof strategy === "string") {
+          flattenSchema(
+            childSchema,
+            [...path, "strategies", strategy, "config", key],
+            rows,
+            requiredConfigKeys.has(key),
+            [strategy],
+          );
+        } else {
+          flattenSchema(childSchema, [...path, "config", key], rows, requiredConfigKeys.has(key));
+        }
+      }
+    }
+    return;
+  }
+
+  const properties = propertiesOf(schema);
+  rows.push({
+    path: path.join("."),
+    type: typeOf(schema),
+    required,
+    default: schema.default,
+    minimum: schema.minimum,
+    maximum: schema.maximum,
+    enum: enumValues(schema),
+    description: schema.description,
+    descriptionQuality: descriptionQuality(schema),
+    rawEnvelope: false,
+    strategies,
+  });
+
+  const requiredKeys = requiredOf(schema);
+  for (const [key, childSchema] of Object.entries(properties)) {
+    flattenSchema(childSchema, [...path, key], rows, requiredKeys.has(key), strategies);
+  }
+
+  if (schema.items) {
+    flattenSchema(schema.items, [...path, "items"], rows, false, strategies);
+  }
+}
+
+function variantForStrategy(schema: SchemaLike | undefined, strategy: string): SchemaLike | undefined {
+  return (schema?.anyOf ?? [schema]).find((variant) => variant?.properties?.strategy?.const === strategy);
+}
+
+function schemaAtPath(root: SchemaLike | undefined, pathSegments: string[]): SchemaLike | undefined {
+  let schema = root;
+  for (let index = 0; index < pathSegments.length; index += 1) {
+    const part = pathSegments[index]!;
+    if (part === "strategies") {
+      const strategy = pathSegments[index + 1];
+      schema = typeof strategy === "string" ? variantForStrategy(schema, strategy) : undefined;
+      index += 1;
+      continue;
+    }
+    if (part === "config") {
+      const variant = schema?.anyOf?.[0] ?? schema;
+      schema = variant?.properties?.config;
+      continue;
+    }
+    if (part === "items") {
+      schema = schema?.items;
+      continue;
+    }
+    schema = schema?.properties?.[part];
+  }
+  return schema;
+}
+
+function directSiblingNames(stage: StageLike, path: string): string[] {
+  const parts = path.split(".");
+  const parentPath = parts.slice(1, -1);
+  const schema = schemaAtPath(stage.surfaceSchema, parentPath);
+  return Object.keys(schema?.properties ?? {}).filter((name) => name !== parts.at(-1));
+}
+
+function stageFieldLayer(stage: StageLike, path: string, rawEnvelope: boolean): AuthorFieldRow["layer"] {
+  const stageRelative = path.split(".").slice(1);
+  if (rawEnvelope || stageRelative.includes("config")) return "internal-envelope";
+  if (stageRelative[0] === "knobs") return "knob";
+  if (stage.public) return "public";
+  return "internal-as-public";
+}
+
+function ownerFor(stage: StageLike, path: string): string {
+  const [surfaceKey, maybeOp] = path.split(".").slice(1);
+  if (surfaceKey === "knobs") return `${stage.id}:stage-knobs`;
+  const step = stage.steps.find((candidate) => candidate.contract.id === surfaceKey);
+  if (!step) return `${stage.id}:stage-public`;
+  if (maybeOp && step.contract.ops?.[maybeOp]) return `${stage.id}:${step.contract.id}:${maybeOp}`;
+  return `${stage.id}:${step.contract.id}`;
+}
+
+function compileTargetFor(stage: StageLike, path: string, layer: AuthorFieldRow["layer"]): string {
+  const surfaceKey = path.split(".")[1];
+  if (layer === "knob") return `${stage.id}.toInternal knobs merge`;
+  if (stage.public) return `${stage.id}.compile(...) -> internal stage config`;
+  return `${stage.id}.${surfaceKey} identity -> internal step config`;
+}
+
+function whyExposedFor(stage: StageLike, layer: AuthorFieldRow["layer"]): string {
+  if (layer === "knob") return "semantic stage-level recipe knob";
+  if (stage.public && layer === "public") return "declared product-facing public stage schema";
+  if (stage.public && layer === "internal-envelope") return "defect candidate: raw step/op envelope is reachable through a public stage schema";
+  if (layer === "internal-envelope") return "transitional internal-as-public step/op parameter";
+  return "transitional internal-as-public step config surface";
+}
+
+function runtimeImpactFor(row: FlattenedSchemaRow, layer: AuthorFieldRow["layer"]): AuthorFieldRow["changesRuntimeOutput"] {
+  if (row.type === "object") return "depends";
+  if (layer === "knob" || layer === "public" || layer === "internal-envelope") return "likely";
+  return "depends";
+}
+
+function strategyReachabilityFor(stage: StageLike, row: FlattenedSchemaRow): string[] {
+  if (row.strategies?.length) return row.strategies;
+
+  const [surfaceKey, opId] = row.path.split(".").slice(1);
+  const step = stage.steps.find((candidate) => candidate.contract.id === surfaceKey);
+  const strategies = opId ? Object.keys(step?.contract.ops?.[opId]?.strategies ?? {}) : [];
+  return strategies;
+}
+
+function artifactRefs(artifacts: readonly ArtifactLike[] | undefined): string[] {
+  return (artifacts ?? []).map((artifact) =>
+    [artifact.name, artifact.id].filter((part): part is string => typeof part === "string").join(":")
+  );
+}
+
+function buildFieldRows(): AuthorFieldRow[] {
+  const rows: AuthorFieldRow[] = [];
+
+  for (const stage of asStages()) {
+    const flattened: FlattenedSchemaRow[] = [];
+    flattenSchema(stage.surfaceSchema, [stage.id], flattened, false);
+
+    for (const flattenedRow of flattened.filter((row) => row.path !== stage.id)) {
+      const layer = stageFieldLayer(stage, flattenedRow.path, flattenedRow.rawEnvelope);
+      rows.push({
+        ...flattenedRow,
+        stageId: stage.id,
+        owner: ownerFor(stage, flattenedRow.path),
+        layer,
+        whyExposed: whyExposedFor(stage, layer),
+        gameplayImpact: STAGE_IMPACT[stage.id] ?? "stage-specific map generation output",
+        coupledFields: directSiblingNames(stage, flattenedRow.path),
+        compileTarget: compileTargetFor(stage, flattenedRow.path, layer),
+        selectedStrategyReachability: strategyReachabilityFor(stage, flattenedRow),
+        testsAndDocs: [
+          REPO_REFS.standardReference,
+          REPO_REFS.compilationReference,
+          REPO_REFS.schemaPolicy,
+          ...TEST_REFS,
+        ],
+        changesCompiledConfig: flattenedRow.type !== "object",
+        changesRuntimeOutput: runtimeImpactFor(flattenedRow, layer),
+      });
+    }
+  }
+
+  return rows;
+}
+
+function buildStageRows(fieldRows: AuthorFieldRow[]): StageLedgerRow[] {
+  return asStages().map((stage) => {
+    const stageFieldRows = fieldRows.filter((row) => row.stageId === stage.id);
+    const numericLeaves = stageFieldRows.filter((row) => row.type === "integer" || row.type === "number");
+    return {
+      stageId: stage.id,
+      layer: stage.authoring?.config?.layer ?? "unknown",
+      publicSchema: Boolean(stage.public),
+      compileOwner: stage.public ? "stage public compile" : "identity internal step config",
+      steps: stage.steps.map((step) => step.contract.id),
+      surfaceKeys: Object.keys(stage.surfaceSchema?.properties ?? {}),
+      fieldCount: stageFieldRows.length,
+      rawEnvelopeRows: stageFieldRows.filter((row) => row.rawEnvelope || row.path.includes(".config.")).length,
+      missingDescriptions: stageFieldRows.filter((row) => row.descriptionQuality === "missing").length,
+      weakDescriptions: stageFieldRows.filter((row) => row.descriptionQuality === "weak").length,
+      boundedNumericLeaves: numericLeaves.filter((row) => row.minimum !== undefined || row.maximum !== undefined).length,
+      numericLeaves: numericLeaves.length,
+    };
+  });
+}
+
+function buildStepRows(): Array<Record<string, Json>> {
+  return asStages().flatMap((stage) =>
+    stage.steps.map((step) => {
+      const schemaRows: FlattenedSchemaRow[] = [];
+      flattenSchema(step.contract.schema, [stage.id, step.contract.id], schemaRows, false);
+      return {
+        kind: "step",
+        stageId: stage.id,
+        stepId: step.contract.id,
+        phase: step.contract.phase ?? "",
+        requires: [...(step.contract.requires ?? [])],
+        provides: [...(step.contract.provides ?? [])],
+        artifactRequires: artifactRefs(step.contract.artifacts?.requires),
+        artifactProvides: artifactRefs(step.contract.artifacts?.provides),
+        schemaOwner: `mods/mod-swooper-maps/src/recipes/standard/stages/${stage.id}/`,
+        schemaFieldCount: schemaRows.length,
+        schemaRawEnvelopeRows: schemaRows.filter((row) => row.rawEnvelope || row.path.includes(".config.")).length,
+        schemaRows: schemaRows as unknown as Json,
+        opEnvelopes: Object.entries(step.contract.ops ?? {}).map(([opId, op]) => ({
+          opId,
+          strategies: Object.keys(op.strategies ?? {}),
+          defaultConfig: op.defaultConfig as Json,
+        })),
+      };
+    }),
+  );
+}
+
+function buildFocusRows(): Array<Record<string, Json>> {
+  return asStages().flatMap((stage) =>
+    stage.steps.map((step) => ({
+      kind: "studio-focus-path",
+      stageId: stage.id,
+      stepId: step.contract.id,
+      configFocusPathWithinStage: [
+        ...(stage.authoring?.config?.focusPathsByStepId?.[step.contract.id] ?? []),
+      ],
+    })),
+  );
+}
+
+function buildConsumerRows(): Array<Record<string, Json>> {
+  return [
+    {
+      kind: "generated-schema-default-artifacts",
+      owner: "mod-swooper-maps scripts",
+      refs: [REPO_REFS.generatedMapArtifacts, REPO_REFS.generatedStudioTypes, ...GENERATED_ARTIFACT_REFS],
+      note: "Generated outputs must be regenerated by scripts; do not hand edit.",
+    },
+    {
+      kind: "shipped-map-and-preset-usage",
+      owner: "mod-swooper-maps configs/presets and Studio default config",
+      refs: SHIPPED_CONFIG_REFS,
+      note: "Each cleanup slice must validate first-party configs and migrate removed or renamed fields.",
+    },
+    {
+      kind: "studio-focus-path-consumer",
+      owner: "MapGen Studio",
+      refs: [REPO_REFS.generatedStudioTypes, REPO_REFS.studioCatalog, REPO_REFS.studioForm],
+      note: "Studio renders recipe artifacts from generated schema/default/uiMeta and configFocusPathWithinStage.",
+    },
+    {
+      kind: "runtime-read-sites",
+      owner: "MapGen compiler/runtime and SDK entrypoints",
+      refs: [
+        REPO_REFS.coreStage,
+        REPO_REFS.coreRecipe,
+        REPO_REFS.coreRecipeCompile,
+        REPO_REFS.standardRuntime,
+        REPO_REFS.studioRuntimeRecipe,
+        REPO_REFS.studioPipelineWorker,
+        REPO_REFS.sdkCreateMap,
+      ],
+      note: "Authoring config is normalized and compiled before internal step/op configs reach runtime.",
+    },
+  ];
+}
+
+function buildLedger() {
+  const fieldRows = buildFieldRows();
+  return {
+    ledgerVersion: 1,
+    source: REPO_REFS.standardRecipe,
+    stageRows: buildStageRows(fieldRows),
+    fieldRows,
+    stepRows: buildStepRows(),
+    focusRows: buildFocusRows(),
+    consumerRows: buildConsumerRows(),
+  };
+}
+
+function markdownTable(headers: string[], rows: string[][]): string {
+  return [
+    `| ${headers.join(" | ")} |`,
+    `| ${headers.map(() => "---").join(" | ")} |`,
+    ...rows.map((row) => `| ${row.map((cell) => cell.replaceAll("\n", "<br>")).join(" | ")} |`),
+  ].join("\n");
+}
+
+function renderSummaryMarkdown(ledger: ReturnType<typeof buildLedger>): string {
+  const stageTable = markdownTable(
+    [
+      "stage",
+      "layer",
+      "public",
+      "steps",
+      "surface keys",
+      "fields",
+      "raw envelope rows",
+      "desc missing/weak",
+      "numeric bounded",
+    ],
+    ledger.stageRows.map((stage) => [
+      stage.stageId,
+      stage.layer,
+      String(stage.publicSchema),
+      String(stage.steps.length),
+      stage.surfaceKeys.join(", "),
+      String(stage.fieldCount),
+      String(stage.rawEnvelopeRows),
+      `${stage.missingDescriptions}/${stage.weakDescriptions}`,
+      `${stage.boundedNumericLeaves}/${stage.numericLeaves}`,
+    ]),
+  );
+
+  const stepTable = markdownTable(
+    ["stage", "steps", "step schema rows", "raw envelope rows", "op envelopes / strategies", "compile owner"],
+    asStages().map((stage) => [
+      stage.id,
+      stage.steps.map((step) => step.contract.id).join(", "),
+      ledger.stepRows
+        .filter((row) => row.stageId === stage.id)
+        .map((row) => `${row.stepId}: ${row.schemaFieldCount}`)
+        .join("<br>"),
+      ledger.stepRows
+        .filter((row) => row.stageId === stage.id)
+        .map((row) => `${row.stepId}: ${row.schemaRawEnvelopeRows}`)
+        .join("<br>"),
+      stage.steps
+        .map((step) => {
+          const ops = Object.entries(step.contract.ops ?? {}).map(
+            ([opId, op]) => `${opId}(${Object.keys(op.strategies ?? {}).join("|") || "none"})`,
+          );
+          return `${step.contract.id}: ${ops.join(", ") || "none"}`;
+        })
+        .join("<br>"),
+      stage.public ? "stage public compile" : "identity internal step config",
+    ]),
+  );
+
+  return [
+    "# Standard Recipe Authoring Surface Ledger",
+    "",
+    `Source: \`${ledger.source}\``,
+    "",
+    "## Stage Surface Summary",
+    "",
+    stageTable,
+    "",
+    "## Step, Op, And Strategy Summary",
+    "",
+    stepTable,
+    "",
+    "## Studio Focus Path Summary",
+    "",
+    markdownTable(
+      ["stage", "step", "config focus path within stage"],
+      ledger.focusRows.map((row) => [
+        String(row.stageId),
+        String(row.stepId),
+        (row.configFocusPathWithinStage as string[]).join("."),
+      ]),
+    ),
+    "",
+    "## Consumer And Artifact Summary",
+    "",
+    markdownTable(
+      ["kind", "owner", "refs", "note"],
+      ledger.consumerRows.map((row) => [
+        String(row.kind),
+        String(row.owner),
+        (row.refs as string[]).map((ref) => `\`${ref}\``).join("<br>"),
+        String(row.note),
+      ]),
+    ),
+  ].join("\n");
+}
+
+function renderFullMarkdown(ledger: ReturnType<typeof buildLedger>): string {
+  const fieldRows = markdownTable(
+    [
+      "path",
+      "layer",
+      "owner",
+      "type",
+      "default",
+      "range/enum",
+      "desc",
+      "why exposed",
+      "impact",
+      "compile target",
+      "strategies",
+      "runtime output",
+    ],
+    ledger.fieldRows.map((row) => [
+      `\`${row.path}\``,
+      row.layer,
+      row.owner,
+      row.type,
+      row.default === undefined ? "" : JSON.stringify(row.default),
+      row.enum
+        ? row.enum.map(String).join(", ")
+        : [row.minimum === undefined ? "" : `min ${row.minimum}`, row.maximum === undefined ? "" : `max ${row.maximum}`]
+            .filter(Boolean)
+            .join(", "),
+      row.descriptionQuality,
+      row.whyExposed,
+      row.gameplayImpact,
+      row.compileTarget,
+      row.selectedStrategyReachability.join(", "),
+      row.changesRuntimeOutput,
+    ]),
+  );
+
+  return `${renderSummaryMarkdown(ledger)}\n\n## Author-Facing Field Rows\n\n${fieldRows}\n`;
+}
+
+function main(): void {
+  const formatFlag = process.argv.find((arg) => arg.startsWith("--format="));
+  const format = formatFlag?.split("=")[1] ?? "summary";
+  const ledger = buildLedger();
+
+  if (format === "json") {
+    console.log(JSON.stringify(ledger, null, 2));
+    return;
+  }
+  if (format === "markdown") {
+    console.log(renderFullMarkdown(ledger));
+    return;
+  }
+  if (format === "summary") {
+    console.log(renderSummaryMarkdown(ledger));
+    return;
+  }
+
+  throw new Error(`Unknown --format=${format}; expected summary, markdown, or json`);
+}
+
+main();

--- a/openspec/changes/authoring-surface-corpus-and-taxonomy/.openspec.yaml
+++ b/openspec/changes/authoring-surface-corpus-and-taxonomy/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/authoring-surface-corpus-and-taxonomy/design.md
+++ b/openspec/changes/authoring-surface-corpus-and-taxonomy/design.md
@@ -1,0 +1,59 @@
+# Design: Standard Recipe Authoring Surface Corpus And Taxonomy
+
+## Approach
+
+The corpus ledger reads `STANDARD_STAGES` directly and walks each stage
+`surfaceSchema`. This keeps the ledger aligned with TypeBox-derived schema
+objects, public+compile surfaces, internal-as-public step schemas, raw op
+envelopes, and current defaults/ranges/enums.
+
+The ledger records four layers:
+
+- `knob`: `stage.knobs` fields.
+- `public`: declared public stage schema fields that are not raw op envelopes.
+- `internal-as-public`: step schema fields surfaced because the stage has no
+  public schema.
+- `internal-envelope`: raw op envelope rows or low-level `config` descendants.
+
+For multi-strategy op envelopes, the ledger records config descendants under
+`strategies.<strategy>.config.*` paths. This preserves which strategy owns each
+field and prevents shared key names from collapsing into duplicate ledger rows.
+
+The ledger also records Studio focus paths separately from schema fields because
+`configFocusPathWithinStage` is a generated UI addressing contract, not a
+runtime config field.
+
+This slice records but does not solve defects. Later cleanup slices must use the
+taxonomy and proof gates to choose one solution type per bucket before editing
+behavior.
+
+## Boundaries
+
+The ledger may inspect:
+
+- Standard recipe stages and step/op contracts.
+- Generated schema/default artifact owners.
+- First-party shipped config/preset owners.
+- Studio schema/default/focus path consumers.
+- Compiler/runtime read sites.
+
+The ledger must not:
+
+- Change stage schemas or compile behavior.
+- Generate or update map artifacts.
+- Migrate shipped configs.
+- Add compatibility shims or wrapper config shapes.
+
+## Review Lanes
+
+- Architecture: verify flat stage shape, owner layer, and truth/projection
+  boundaries.
+- Product: verify issue buckets map to gameplay-meaningful decisions.
+- OpenSpec: verify this slice is diagnostic and downstream slices remain
+  bounded.
+- TypeBox/TypeScript: verify schema walking reflects the current runtime
+  schema objects.
+- Operational debugging: verify no runtime proof is claimed for this
+  behavior-neutral slice.
+- Peer agent: adversarially check corpus completeness and taxonomy fit before
+  dependent cleanup branches start.

--- a/openspec/changes/authoring-surface-corpus-and-taxonomy/proposal.md
+++ b/openspec/changes/authoring-surface-corpus-and-taxonomy/proposal.md
@@ -1,0 +1,91 @@
+# Proposal: Standard Recipe Authoring Surface Corpus And Taxonomy
+
+## Summary
+
+Establish the diagnostic foundation for the standard recipe authoring-surface
+cleanup train before editing stage behavior. This slice adds a repeatable
+ledger generator, project docs, issue taxonomy, slice gates, and proof records
+for all standard recipe stage schemas and consumers.
+
+This slice is intentionally behavior-neutral. It does not rename fields, migrate
+configs, regenerate map outputs, or change compile output.
+
+## Authority
+
+- Current user objective for a systematic standard recipe authoring-surface
+  cleanup workstream.
+- `docs/projects/pipeline-realism/resources/runbooks/HANDOFF-STANDARD-RECIPE-AUTHORING-SURFACE.md`
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`
+  Target Shape and D1 flat config surface.
+- `docs/projects/engine-refactor-v1/resources/spec/adr/adr-er1-032-recipe-config-authoring-surface.md`
+- `docs/system/libs/mapgen/reference/STANDARD-RECIPE.md`
+- `docs/system/libs/mapgen/reference/CONFIG-COMPILATION.md`
+- `docs/system/libs/mapgen/policies/SCHEMAS-AND-VALIDATION.md`
+- `openspec/changes/mapgen-public-config-boundary/`
+- `openspec/changes/morphology-public-config-surface/`
+- `openspec/changes/studio-public-config-contract/`
+
+## Requires
+
+- Current standard recipe source and generator scripts.
+- Existing public config boundary proof in MapGen core.
+- Existing Morphology public surface proof as the known-good example.
+- Narsil/code-intelligence evidence for hotspots and references, excluding
+  unstable hybrid search.
+
+## Enables
+
+- `foundation-authoring-surface-alignment`
+- `morphology-authoring-surface-alignment`
+- `hydrology-authoring-surface-alignment`
+- `ecology-authoring-surface-alignment`
+- `projection-authoring-surface-audit`
+- `placement-authoring-surface-alignment`
+- Per-slice shipped config/preset/generated artifact migration and Studio proof
+  for every behavior-changing cleanup branch.
+- `studio-sdk-guard-hardening`
+
+## Affected Owners
+
+- `mods/mod-swooper-maps/scripts/`
+- `docs/projects/standard-recipe-authoring-surface/`
+- `openspec/changes/authoring-surface-corpus-and-taxonomy/`
+
+## Forbidden Owners
+
+- Standard stage behavior and compile code.
+- Shipped map configs and presets.
+- Generated map artifacts.
+- Studio runtime code.
+- SDK runtime code.
+
+## Write Set
+
+- Add a standard-recipe authoring surface ledger generator.
+- Add project docs for corpus, taxonomy, slices, and proof records.
+- Add this OpenSpec change.
+
+## Consumer Impact
+
+None in runtime behavior. The only consumer impact is a new diagnostic command
+for authors/reviewers:
+
+```sh
+cd mods/mod-swooper-maps
+bun run scripts/report-standard-authoring-surface.ts --format=summary
+```
+
+## Stop Conditions
+
+- The ledger cannot enumerate all standard stages from live `STANDARD_STAGES`.
+- The ledger cannot distinguish public, knobs, internal-as-public, and raw
+  envelope rows.
+- OpenSpec validation fails.
+- Peer review finds a P1/P2 taxonomy gap that would misdirect the next slice.
+
+## Verification Gates
+
+- Run the ledger generator in summary mode.
+- Run OpenSpec validation for this change.
+- Run `git diff --check`.
+- Run framed peer-agent review over taxonomy, ledger, and OpenSpec records.

--- a/openspec/changes/authoring-surface-corpus-and-taxonomy/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/authoring-surface-corpus-and-taxonomy/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Standard Recipe Authoring Surface Corpus Is Complete
+
+The standard recipe authoring-surface cleanup train SHALL begin from a
+repeatable corpus ledger generated from current recipe/stage/schema objects
+rather than from hand-copied schema fragments.
+
+#### Scenario: Corpus ledger is generated
+- **WHEN** the standard recipe authoring surface ledger command is run
+- **THEN** it enumerates every standard recipe stage and step
+- **AND** it records stage knobs, public schemas, internal-as-public step
+  schemas, op envelopes, strategy sets, generated artifact owners, shipped
+  configs and presets, Studio focus-path consumers, and runtime read sites
+
+#### Scenario: Author-facing fields are classified
+- **WHEN** the ledger walks stage surface schemas
+- **THEN** every author-facing schema row is classified as `knob`, `public`,
+  `internal-as-public`, or `internal-envelope`
+- **AND** each row records defaults, bounds or enums, description quality,
+  compile target, strategy reachability, and output impact
+
+### Requirement: Cleanup Buckets Drive Slice Design
+
+The standard recipe authoring-surface cleanup train SHALL classify defects into
+explicit issue buckets and choose one solution type per bucket before editing
+stage behavior.
+
+#### Scenario: A raw public envelope is found
+- **WHEN** a public stage schema exposes raw step/op envelope structure
+- **THEN** the issue is classified as internal parameter leakage
+- **AND** the next behavior slice must convert it to semantic public config
+  plus compile output, move it internal, or explicitly defer it with authority
+  and proof
+
+#### Scenario: A transitional internal-as-public surface is found
+- **WHEN** a stage has no public schema and exposes step/op config directly
+- **THEN** the issue is classified separately from public leakage
+- **AND** the cleanup slice must keep it as accepted low-level step-key
+  authoring only when each exposed field is gameplay/execution meaningful,
+  documented, bounded where numeric, and not private runtime/projection
+  plumbing
+- **AND** otherwise the cleanup slice must collapse it into semantic
+  knobs/profiles or move it internal
+
+### Requirement: Downstream Cleanup Preserves Flat Stage Shape
+
+Downstream cleanup slices SHALL preserve the flat stage config shape and avoid
+persisted advanced/internal wrappers, dual shapes, generated-output hand edits,
+compatibility shims, or broad public exports.
+
+#### Scenario: A stage surface is cleaned
+- **WHEN** a downstream slice changes a standard stage authoring surface
+- **THEN** default persisted config remains `{ knobs?, [stepId]?: stepConfig }`
+- **AND** flat public-key config `{ knobs?, [publicKey]?: publicConfig }` is
+  used only when the slice records a genuine public+compile transform decision,
+  public keys, internal step keys, and reason
+- **AND** public fields compile deterministically into internal stage/step/op
+  config before runtime execution
+
+#### Scenario: A public field is removed or renamed
+- **WHEN** a downstream slice removes or renames an author-facing field
+- **THEN** shipped configs, presets, generated schema/default/uiMeta artifacts,
+  and Studio consumers are migrated or proved in the same behavior slice
+- **AND** strict validation fails unknown old keys with clear errors

--- a/openspec/changes/authoring-surface-corpus-and-taxonomy/tasks.md
+++ b/openspec/changes/authoring-surface-corpus-and-taxonomy/tasks.md
@@ -1,0 +1,24 @@
+## 1. Corpus
+
+- [x] 1.1 Add a repeatable standard recipe authoring surface ledger generator.
+- [x] 1.2 Enumerate every standard stage, step, surface key, op envelope,
+  strategy set, generated artifact owner, shipped config/preset owner, Studio
+  consumer, and runtime read site.
+- [x] 1.3 Record field-level layer, defaults, bounds/enums, documentation
+  quality, exposure rationale, gameplay impact, coupled siblings, compile
+  target, strategy reachability, and output impact in generated ledger output.
+
+## 2. Taxonomy
+
+- [x] 2.1 Classify issue buckets and one solution type per bucket.
+- [x] 2.2 Classify initial stage/domain findings without editing behavior.
+- [x] 2.3 Define slice order and proof gates for downstream cleanup branches.
+
+## 3. Verification
+
+- [x] 3.1 Run the ledger generator in summary mode.
+- [x] 3.2 Run OpenSpec validation for this change.
+- [x] 3.3 Run framed peer-agent review over the ledger, taxonomy, and OpenSpec
+  records.
+- [x] 3.4 Repair accepted P1/P2 findings.
+- [x] 3.5 Run `git diff --check`.


### PR DESCRIPTION
This PR establishes the diagnostic foundation for the standard recipe authoring-surface cleanup train. It is intentionally behavior-neutral: no stage schemas, compile behavior, shipped configs, or generated artifacts are changed.

**What's included:**

- **Ledger generator** (`mods/mod-swooper-maps/scripts/report-standard-authoring-surface.ts`): A script that reads `STANDARD_STAGES` directly and walks each stage's `surfaceSchema` to produce `summary`, `markdown`, and `json` outputs. It enumerates all 17 standard stages, 50 steps, 761 author-facing fields, and 50 Studio focus paths. Fields are classified into four layers (`knob`, `public`, `internal-as-public`, `internal-envelope`), with multi-strategy op config recorded under `strategies.<strategy>.config.*` paths to prevent duplicate ledger rows. Array item schemas are traversed through `.items`. Consumer and runtime read-site coverage spans shipped configs, realism presets, generated dist artifacts, Studio schema/default/uiMeta consumers, the Studio browser runner, and the SDK `createMap` entrypoint.

- **Project docs** (`docs/projects/standard-recipe-authoring-surface/`): A project charter with non-negotiables, an eight-slice ordered workstream, a corpus ledger capturing the initial stage surface summary and diagnosis, a taxonomy defining ten issue buckets with solution types and per-domain findings, a proof ledger recording evidence for this slice and required gates for later behavior slices, and a review disposition ledger recording accepted P1/P2 findings from corpus and taxonomy peer review.

- **OpenSpec change** (`openspec/changes/authoring-surface-corpus-and-taxonomy/`): Proposal, design, tasks, and spec requirements covering corpus completeness, cleanup bucket discipline, and the flat stage shape invariant that all downstream slices must preserve.

**Key findings recorded (not yet fixed):**
- Foundation declares `semantic-public-config` but exposes raw op envelopes through public step keys such as `mesh.computeMesh`.
- Morphology is structurally aligned; remaining work is documentation quality, bounds, and naming.
- Hydrology, ecology, and placement use internal-as-public step schemas that each need an acceptance decision per exposed field.
- Projection `map-*` stages have small but uneven owner-layer surfaces, particularly `map-hydrology.lakes.projectionReadback` and `map-ecology.features-apply.apply`.