### PR TITLE
docs(sdk): document `mapgen` subpath export boundary and remove from SDK root

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,4 +7,9 @@ export * from './utils';
 export * from './localizations';
 export * from './nodes';
 export * from './presets';
-export * from './mapgen';
+/**
+ * The SDK root is consumed by Node/Bun build tools, playground examples, and
+ * XML mod packages. Civ7 map generation binds to engine globals through the
+ * adapter, so it is intentionally exported only from
+ * `@mateicanavra/civ7-sdk/mapgen` where consumers opt into that runtime.
+ */

--- a/packages/sdk/src/mapgen/createMap.ts
+++ b/packages/sdk/src/mapgen/createMap.ts
@@ -132,6 +132,13 @@ function resolveInitCapture(
   return { mapSizeId, mapInfo, params };
 }
 
+/**
+ * Registers a Civ7 map entrypoint against the game engine events while keeping
+ * map authors on the recipe public config contract. The tradeoff is explicit:
+ * this helper is reusable SDK authoring API, but it is runtime-bound and must
+ * only be imported from the SDK mapgen subpath by code that will execute inside
+ * the Civ7 map loader.
+ */
 export function createMap<const TRecipe extends RecipeModule<ExtendedMapContext, any, any>>(
   def: MapDefinitionInput<TRecipe>
 ): MapDefinition<TRecipe> {

--- a/packages/sdk/src/mapgen/index.ts
+++ b/packages/sdk/src/mapgen/index.ts
@@ -1,2 +1,9 @@
+/**
+ * Civ7 map-runtime SDK entrypoint.
+ *
+ * `createMap` belongs in the SDK so all map mods share one typed authoring
+ * contract, but it is not part of the SDK root because importing it loads the
+ * Civ7 adapter runtime that only resolves inside the game.
+ */
 export { createMap } from "./createMap.js";
 export type { MapDefinition, MapLatitudeBounds } from "./createMap.js";


### PR DESCRIPTION
`createMap` and the mapgen module are removed from the SDK root export and are now only accessible via the `@mateicanavra/civ7-sdk/mapgen` subpath. This prevents the Civ7 adapter runtime — which binds to engine globals and only resolves inside the game — from being inadvertently loaded by Node/Bun build tools, playground examples, or XML mod packages that consume the SDK root. JSDoc comments have been added to the SDK root, the `mapgen` entrypoint, and `createMap` itself to make this boundary explicit for future contributors.