### PR TITLE
feat(studio): add Civ7 autoplay start/stop toggle to live runtime panel

### DIFF
--- a/apps/mapgen-studio/src/App.tsx
+++ b/apps/mapgen-studio/src/App.tsx
@@ -261,6 +261,35 @@ async function fetchRunInGameStatus(requestId: string): Promise<RunInGameOperati
   }
 }
 
+async function requestCiv7Autoplay(action: "start" | "stop"): Promise<{
+  ok: boolean;
+  action?: "start" | "stop";
+  autoplay?: { isActive?: boolean; isPaused?: boolean; isPausedOrPending?: boolean };
+  game?: { turn?: { ok?: boolean; value?: number } };
+  error?: string;
+}> {
+  try {
+    const res = await fetch("/api/civ7/autoplay", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action }),
+    });
+    const body = (await res.json().catch(() => null)) as {
+      ok?: boolean;
+      action?: "start" | "stop";
+      autoplay?: { isActive?: boolean; isPaused?: boolean; isPausedOrPending?: boolean };
+      game?: { turn?: { ok?: boolean; value?: number } };
+      error?: string;
+    } | null;
+    if (!res.ok || !body?.ok) {
+      return { ok: false, error: body?.error ?? `HTTP ${res.status}` };
+    }
+    return { ok: true, action: body.action, autoplay: body.autoplay, game: body.game };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "Civ7 autoplay request failed" };
+  }
+}
+
 const RUN_IN_GAME_LAST_REQUEST_KEY = "mapgen-studio.runInGame.lastRequestId.v1";
 const RUN_IN_GAME_LAST_SNAPSHOT_KEY = "mapgen-studio.runInGame.lastSnapshot.v1";
 const MAP_CONFIG_SAVE_LAST_REQUEST_KEY = "mapgen-studio.mapConfigSave.lastRequestId.v1";
@@ -610,9 +639,11 @@ function AppContent(props: AppContentProps) {
     seed?: number;
     readiness?: string;
     autoplayActive?: boolean;
+    autoplayPaused?: boolean;
     updatedAt?: string;
     error?: string;
   }>({ status: "idle" });
+  const [autoplayActionRunning, setAutoplayActionRunning] = useState(false);
   const saveDeployRunning = saveDeployOperation?.status === "running";
   const runInGameRunning = runInGameOperation?.status === "running";
 
@@ -684,6 +715,7 @@ function AppContent(props: AppContentProps) {
           seed,
           readiness,
           autoplayActive: body.autoplay?.autoplay?.isActive,
+          autoplayPaused: body.autoplay?.autoplay?.isPaused,
           updatedAt: body.observedAt,
           error: body.ok ? undefined : body.status?.error ?? body.mapSummary?.error,
         });
@@ -1594,6 +1626,31 @@ function AppContent(props: AppContentProps) {
     worldSettings.resources,
   ]);
 
+  const handleToggleAutoplay = useCallback(async () => {
+    if (autoplayActionRunning || browserRunning || runInGameRunning || saveDeployRunning) return;
+    const action = liveRuntime.autoplayActive ? "stop" : "start";
+    setAutoplayActionRunning(true);
+    try {
+      const result = await requestCiv7Autoplay(action);
+      if (!result.ok) {
+        toast(`Autoplay ${action} failed: ${result.error ?? "unknown error"}`, { variant: "error" });
+        return;
+      }
+      setLiveRuntime((current) => ({
+        ...current,
+        status: "ok",
+        autoplayActive: result.autoplay?.isActive ?? action === "start",
+        autoplayPaused: result.autoplay?.isPaused,
+        turn: result.game?.turn?.ok ? result.game.turn.value : current.turn,
+        updatedAt: new Date().toISOString(),
+        error: undefined,
+      }));
+      toast(action === "start" ? "Civ7 autoplay started" : "Civ7 autoplay stopped", { variant: "success" });
+    } finally {
+      setAutoplayActionRunning(false);
+    }
+  }, [autoplayActionRunning, browserRunning, liveRuntime.autoplayActive, runInGameRunning, saveDeployRunning, toast]);
+
   const copyRunInGameDiagnostics = useCallback(async () => {
     if (!runInGameOperation) return;
     try {
@@ -2280,12 +2337,14 @@ function AppContent(props: AppContentProps) {
       isRunning={browserRunning}
       isRunInGameRunning={runInGameRunning}
       isSaveDeployRunning={saveDeployRunning}
+      isAutoplayActionRunning={autoplayActionRunning}
       saveDeployStatus={saveDeployOperation}
       runInGameStatus={runInGameOperation}
       runInGameCurrentRelation={runInGameCurrentRelation}
       isDirty={isDirty}
       lightMode={isLightMode}
       liveRuntime={liveRuntime}
+      onToggleAutoplay={handleToggleAutoplay}
       onToast={(message) => toast(message, { variant: "success" })}
       autoRunEnabled={autoRunEnabled}
       onAutoRunEnabledChange={setAutoRunEnabled}

--- a/apps/mapgen-studio/src/ui/components/AppFooter.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppFooter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bolt, Clipboard, Clock, Dices, MonitorPlay, Play, Radio, RotateCw } from 'lucide-react';
+import { Bolt, Bot, Clipboard, Clock, Dices, MonitorPlay, Play, Radio, RotateCw, Square } from 'lucide-react';
 import { Button, Input } from './ui';
 import { MAP_SIZE_SHORT, LAYOUT } from '../constants';
 import { formatResourceMode } from '../utils';
@@ -59,9 +59,14 @@ export interface AppFooterProps {
     seed?: number;
     readiness?: string;
     autoplayActive?: boolean;
+    autoplayPaused?: boolean;
     updatedAt?: string;
     error?: string;
   };
+  /** Whether a Civ7 autoplay start/stop request is in flight */
+  isAutoplayActionRunning?: boolean;
+  /** Callback to start or stop Civ7 native autoplay */
+  onToggleAutoplay?: () => void;
   /** Toast function for notifications */
   onToast?: (message: string) => void;
   /** When enabled, config changes auto-run the current seed */
@@ -90,6 +95,8 @@ export const AppFooter: React.FC<AppFooterProps> = ({
   isDirty,
   lightMode,
   liveRuntime,
+  isAutoplayActionRunning = false,
+  onToggleAutoplay,
   onToast,
   autoRunEnabled,
   onAutoRunEnabledChange
@@ -150,6 +157,15 @@ export const AppFooter: React.FC<AppFooterProps> = ({
           : "bg-gray-400";
   const runInGameButtonText = runInGamePrimaryActionLabel(runInGameStatus, runInGameCurrentRelation);
   const operationControlsDisabled = isRunning || isRunInGameRunning || isSaveDeployRunning;
+  const autoplayControlDisabled = operationControlsDisabled || isAutoplayActionRunning || liveRuntime?.status !== "ok" || !onToggleAutoplay;
+  const autoplayButtonText = isAutoplayActionRunning
+    ? "Autoplay..."
+    : liveRuntime?.autoplayActive
+      ? "Stop Auto"
+      : "Start Auto";
+  const autoplayTitle = liveRuntime?.autoplayActive
+    ? `Stop Civ7 autoplay${liveRuntime.autoplayPaused ? " (paused)" : ""}`
+    : "Start Civ7 autoplay";
   const saveDeployLabel = saveDeployStatus ? formatMapConfigSaveDeployPhaseLabel(saveDeployStatus.phase) : null;
   const saveDeployTitle = saveDeployStatus
     ? [
@@ -236,7 +252,7 @@ export const AppFooter: React.FC<AppFooterProps> = ({
 
       {/* Live Civ7 Panel */}
       <div
-        className={`h-10 inline-flex min-w-0 max-w-[300px] items-center gap-2 px-3 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}
+        className={`h-10 inline-flex min-w-0 max-w-[420px] items-center gap-2 px-3 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}
         title={liveRuntime?.readiness ?? liveRuntime?.error ?? "Civ7 live runtime status"}>
 
         <Radio className={`w-3.5 h-3.5 ${textMuted}`} />
@@ -249,6 +265,17 @@ export const AppFooter: React.FC<AppFooterProps> = ({
             Auto
           </span>
         ) : null}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onToggleAutoplay}
+          disabled={autoplayControlDisabled}
+          title={autoplayTitle}
+          className={`h-7 px-2 text-[11px] ${liveRuntime?.autoplayActive ? "border-amber-400/60 text-amber-500" : ""}`}>
+
+          {liveRuntime?.autoplayActive ? <Square className="w-3.5 h-3.5" /> : <Bot className="w-3.5 h-3.5" />}
+          <span>{autoplayButtonText}</span>
+        </Button>
       </div>
 
       {/* Run Controls Panel */}

--- a/apps/mapgen-studio/test/runInGame/AppFooter.test.tsx
+++ b/apps/mapgen-studio/test/runInGame/AppFooter.test.tsx
@@ -155,4 +155,57 @@ describe("AppFooter Run in Game status", () => {
     expect(html).toContain("studio-save-deploy-test");
     expect(html).toContain("disabled");
   });
+
+  it("renders a Civ7 autoplay start button from live runtime status", () => {
+    const html = renderToStaticMarkup(
+      <AppFooter
+        status="ready"
+        lastRunSettings={recipeSettings}
+        lastGlobalSettings={worldSettings}
+        currentSettings={recipeSettings}
+        onSettingsChange={vi.fn()}
+        onRun={vi.fn()}
+        onRunInGame={vi.fn()}
+        onReroll={vi.fn()}
+        isRunning={false}
+        isRunInGameRunning={false}
+        isDirty={false}
+        lightMode={false}
+        liveRuntime={{ status: "ok", readiness: "ready", autoplayActive: false }}
+        onToggleAutoplay={vi.fn()}
+        autoRunEnabled={false}
+        onAutoRunEnabledChange={vi.fn()}
+      />
+    );
+
+    expect(html).toContain("Start Auto");
+    expect(html).toContain("Start Civ7 autoplay");
+  });
+
+  it("renders a Civ7 autoplay stop button when autoplay is active", () => {
+    const html = renderToStaticMarkup(
+      <AppFooter
+        status="ready"
+        lastRunSettings={recipeSettings}
+        lastGlobalSettings={worldSettings}
+        currentSettings={recipeSettings}
+        onSettingsChange={vi.fn()}
+        onRun={vi.fn()}
+        onRunInGame={vi.fn()}
+        onReroll={vi.fn()}
+        isRunning={false}
+        isRunInGameRunning={false}
+        isDirty={false}
+        lightMode={false}
+        liveRuntime={{ status: "ok", readiness: "ready", autoplayActive: true }}
+        onToggleAutoplay={vi.fn()}
+        autoRunEnabled={false}
+        onAutoRunEnabledChange={vi.fn()}
+      />
+    );
+
+    expect(html).toContain("Stop Auto");
+    expect(html).toContain("Stop Civ7 autoplay");
+    expect(html).toContain("Auto");
+  });
 });

--- a/apps/mapgen-studio/vite.config.ts
+++ b/apps/mapgen-studio/vite.config.ts
@@ -23,6 +23,8 @@ import {
   getCiv7UnitSummary,
   ensureCiv7SetupMapRowVisible,
   runCiv7SinglePlayerFromSetup,
+  startCiv7Autoplay,
+  stopCiv7Autoplay,
   snapshotFile,
   waitForFreshLogMarkers,
 } from "@civ7/direct-control";
@@ -455,6 +457,66 @@ export default defineConfig(({ command }) => ({
           } catch (err) {
             const error = err instanceof Error ? err.message : "Civ7 live GameInfo request failed";
             writeJson(res, 400, { ok: false, error });
+          }
+        });
+        server.middlewares.use("/api/civ7/autoplay", async (req, res, next) => {
+          if (req.method !== "POST") return next();
+          try {
+            const body = await readJsonBody<{ action?: unknown }>(req);
+            if (body.action !== "start" && body.action !== "stop") {
+              writeJson(res, 400, { ok: false, error: 'Autoplay action must be "start" or "stop"' });
+              return;
+            }
+            const activeRunInGame = runInGameOperations.findActive();
+            if (activeRunInGame) {
+              writeJson(res, 409, {
+                ok: false,
+                error: "Run in Game is running; wait for it to finish before changing autoplay.",
+                details: {
+                  code: "run-in-game-operation-active",
+                  activeRequestId: activeRunInGame.requestId,
+                  activePhase: activeRunInGame.phase,
+                },
+              });
+              return;
+            }
+            const activeSaveDeploy = saveDeployOperations.findActive();
+            if (activeSaveDeploy) {
+              writeJson(res, 409, {
+                ok: false,
+                error: "Save/Deploy is running; wait for it to finish before changing autoplay.",
+                details: {
+                  code: "save-deploy-operation-active",
+                  activeRequestId: activeSaveDeploy.requestId,
+                  activePhase: activeSaveDeploy.phase,
+                },
+              });
+              return;
+            }
+            const approval = {
+              approved: true as const,
+              reason: `Studio autoplay ${body.action}`,
+              disposableSession: true,
+            };
+            const options = {
+              timeoutMs: DEFAULT_CIV7_TUNER_TIMEOUT_MS,
+              waitTimeoutMs: SCRIPTING_LOG_WAIT_TIMEOUT_MS,
+              pollIntervalMs: 1_000,
+            };
+            const result = body.action === "start"
+              ? await startCiv7Autoplay(options, approval)
+              : await stopCiv7Autoplay(options, approval);
+            writeJson(res, 200, {
+              ok: result.verified,
+              action: body.action,
+              autoplay: result.after.autoplay,
+              game: result.after.game,
+              gameContext: result.after.gameContext,
+              result,
+            });
+          } catch (err) {
+            const error = err instanceof Error ? err.message : "Civ7 autoplay request failed";
+            writeJson(res, 500, { ok: false, error });
           }
         });
         server.middlewares.use("/api/studio/server-info", async (req, res, next) => {


### PR DESCRIPTION
Adds a **Start/Stop Autoplay** button to the Live Civ7 panel in the app footer, allowing users to toggle Civ7's native autoplay directly from Mapgen Studio without leaving the app.

### What's new

- **`/api/civ7/autoplay` endpoint** — A new `POST` route in the Vite dev server middleware accepts `{ action: "start" | "stop" }` and calls `startCiv7Autoplay` / `stopCiv7Autoplay` from `@civ7/direct-control`. It returns the resulting autoplay state and current game turn, and rejects with `409` if a Run in Game or Save/Deploy operation is already active.
- **`requestCiv7Autoplay` client function** — Wraps the new endpoint with typed request/response handling and normalized error reporting.
- **`handleToggleAutoplay` callback** — Reads the current `autoplayActive` state from `liveRuntime` to determine whether to start or stop, guards against concurrent operations, updates `liveRuntime` optimistically on success, and surfaces errors via toast notifications.
- **Footer button** — The Live Civ7 panel now renders a toggle button labeled "Start Auto" / "Stop Auto" (with a `Bot` or `Square` icon). The button is styled with amber accents when autoplay is active, disabled during any in-flight operation, and shows "Autoplay..." while the request is pending. The panel's max width is widened to accommodate the new control.
- **`autoplayPaused` state** — The paused state from the autoplay response is tracked and surfaced in the stop button's tooltip (e.g., "Stop Civ7 autoplay (paused)").
- **Tests** — Two new cases verify that the footer renders the correct button label and title attribute depending on whether autoplay is inactive or active.