### PR TITLE
feat(run-in-game): add live game source snapshot, Studio state persistence, and sync-from-live-game flow

### DIFF
--- a/apps/mapgen-studio/src/App.tsx
+++ b/apps/mapgen-studio/src/App.tsx
@@ -36,10 +36,13 @@ import { getCiv7MapSizePreset } from "./features/browserRunner/mapSizes";
 import {
   buildRunInGameClientSnapshot,
   buildRunInGameFingerprint,
+  buildRunInGameSourceSnapshot,
   parseRunInGameClientSnapshot,
+  parseRunInGameSourceSnapshot,
   relationForRunInGameOperation,
   type RunInGameClientSnapshot,
   type RunInGameCurrentRelation,
+  type RunInGameSourceSnapshot,
 } from "./features/runInGame/clientState";
 import {
   formatRunInGameDiagnostics,
@@ -75,6 +78,10 @@ import { resolveImportedPreset } from "./features/presets/importFlow";
 import { buildPresetExportFile, downloadPresetFile, parsePresetExportFile } from "./features/presets/importExport";
 import { parsePresetKey, type PresetKey } from "./features/presets/types";
 import { usePresets } from "./features/presets/usePresets";
+import {
+  loadStudioAuthoringState,
+  saveStudioAuthoringState,
+} from "./features/studioState/persistence";
 import {
   DEFAULT_STUDIO_RECIPE_ID,
   findRecipeArtifacts,
@@ -292,7 +299,10 @@ async function requestCiv7Autoplay(action: "start" | "stop"): Promise<{
 
 const RUN_IN_GAME_LAST_REQUEST_KEY = "mapgen-studio.runInGame.lastRequestId.v1";
 const RUN_IN_GAME_LAST_SNAPSHOT_KEY = "mapgen-studio.runInGame.lastSnapshot.v1";
+const RUN_IN_GAME_LAST_SOURCE_KEY = "mapgen-studio.runInGame.lastSource.v1";
 const MAP_CONFIG_SAVE_LAST_REQUEST_KEY = "mapgen-studio.mapConfigSave.lastRequestId.v1";
+const LIVE_GAME_PRESET_ID = "live-game";
+const LIVE_GAME_PRESET_KEY = `live:${LIVE_GAME_PRESET_ID}` as const;
 
 function isNumericPathSegment(segment: string): boolean {
   return /^[0-9]+$/.test(segment);
@@ -430,6 +440,15 @@ function toRepoBackedPreset(args: {
   };
 }
 
+function readStoredRunInGameSourceSnapshot(): RunInGameSourceSnapshot | null {
+  try {
+    if (typeof localStorage === "undefined") return null;
+    return parseRunInGameSourceSnapshot(localStorage.getItem(RUN_IN_GAME_LAST_SOURCE_KEY));
+  } catch {
+    return null;
+  }
+}
+
 function applyPresetConfig(args: {
   schema: TSchema;
   uiMeta: StudioRecipeUiMeta;
@@ -458,6 +477,22 @@ type LastRunSnapshot = {
   pipelineConfig: PipelineConfig;
 };
 
+function liveSourceMatchesStudio(args: {
+  source: RunInGameSourceSnapshot;
+  recipeSettings: RecipeSettings;
+  worldSettings: WorldSettings;
+  pipelineConfig: PipelineConfig;
+}): boolean {
+  return (
+    args.source.recipeSettings.recipe === args.recipeSettings.recipe &&
+    args.source.recipeSettings.seed === args.recipeSettings.seed &&
+    args.source.worldSettings.mapSize === args.worldSettings.mapSize &&
+    args.source.worldSettings.playerCount === args.worldSettings.playerCount &&
+    args.source.worldSettings.resources === args.worldSettings.resources &&
+    configsEqual(args.source.pipelineConfig, args.pipelineConfig)
+  );
+}
+
 type PresetErrorState = Readonly<{
   title: string;
   message: string;
@@ -474,6 +509,11 @@ function AppContent(props: AppContentProps) {
   const { toast } = useToast();
   const { themePreference, isLightMode, cyclePreference } = props;
   const theme = useMemo(() => createTheme(isLightMode), [isLightMode]);
+  const initialAuthoringStateRef = useRef<ReturnType<typeof loadStudioAuthoringState> | undefined>(undefined);
+  if (initialAuthoringStateRef.current === undefined) {
+    initialAuthoringStateRef.current = loadStudioAuthoringState();
+  }
+  const initialAuthoringState = initialAuthoringStateRef.current;
 
   const deckApiRef = useRef<DeckCanvasApi | null>(null);
   const [deckApiReadyTick, setDeckApiReadyTick] = useState(0);
@@ -497,14 +537,14 @@ function AppContent(props: AppContentProps) {
   const autoRunTimerRef = useRef<number | null>(null);
   const autoRunPendingRef = useRef(false);
 
-  const [worldSettings, setWorldSettings] = useState<WorldSettings>({
+  const [worldSettings, setWorldSettings] = useState<WorldSettings>(() => initialAuthoringState?.worldSettings ?? {
     mode: "browser",
     mapSize: "MAPSIZE_STANDARD",
     playerCount: 6,
     resources: "balanced",
   });
 
-  const [recipeSettings, setRecipeSettings] = useState<RecipeSettings>({
+  const [recipeSettings, setRecipeSettings] = useState<RecipeSettings>(() => initialAuthoringState?.recipeSettings ?? {
     recipe: DEFAULT_STUDIO_RECIPE_ID,
     preset: "none",
     seed: "123",
@@ -518,9 +558,15 @@ function AppContent(props: AppContentProps) {
   const [pendingImport, setPendingImport] = useState<StudioPresetExportFileV1 | null>(null);
   const importInputRef = useRef<HTMLInputElement | null>(null);
   const lastAppliedPresetRef = useRef<AppliedPresetSnapshot | null>(null);
+  const lastPresetKeyRef = useRef(recipeSettings.preset);
+  const lastRecipeIdRef = useRef(recipeSettings.recipe);
   const [repoBackedPresetOverridesByRecipe, setRepoBackedPresetOverridesByRecipe] = useState<
     Record<string, Record<string, BuiltInPreset>>
-  >({});
+  >(() => initialAuthoringState?.repoBackedPresetOverridesByRecipe ?? {});
+  const [lastRunInGameSource, setLastRunInGameSource] = useState<RunInGameSourceSnapshot | null>(() =>
+    readStoredRunInGameSourceSnapshot()
+  );
+  const [runInGameOperation, setRunInGameOperation] = useState<RunInGameOperationStatus | null>(null);
 
   const overlaySuggestions = useMemo(() => getOverlaySuggestions(recipeSettings.recipe), [recipeSettings.recipe]);
   const overlaySelection = overlaySuggestions.find((opt) => opt.id === overlaySelectionId) ?? null;
@@ -534,20 +580,56 @@ function AppContent(props: AppContentProps) {
     ),
     [recipeArtifacts.studioBuiltInPresets, recipeSettings.recipe, repoBackedPresetOverridesByRecipe]
   );
+  const provedRunInGameSource = useMemo(
+    () =>
+      lastRunInGameSource &&
+      runInGameOperation?.status === "complete" &&
+      runInGameOperation.requestId === lastRunInGameSource.requestId
+        ? lastRunInGameSource
+        : null,
+    [lastRunInGameSource, runInGameOperation]
+  );
+  const livePresets = useMemo(
+    () =>
+      lastRunInGameSource && lastRunInGameSource.recipeSettings.recipe === recipeSettings.recipe
+        ? [
+            {
+              id: LIVE_GAME_PRESET_ID,
+              label: lastRunInGameSource.materializationMode === "disposable"
+                ? "Live Game"
+                : lastRunInGameSource.selectedConfig?.label
+                  ? `Live Game (${lastRunInGameSource.selectedConfig.label})`
+                  : "Live Game",
+              description: provedRunInGameSource
+                ? "Config and seed last proved through Run in Game."
+                : "Config and seed from the last Studio Run in Game request.",
+              config: lastRunInGameSource.pipelineConfig,
+            },
+          ]
+        : [],
+    [lastRunInGameSource, provedRunInGameSource, recipeSettings.recipe]
+  );
   const { options: presetOptions, resolvePreset, actions: presetActions, loadWarning } = usePresets({
     recipeId: recipeSettings.recipe,
     builtIns: builtInPresets,
+    livePresets,
   });
   const isLocalPresetSelected = parsePresetKey(recipeSettings.preset).kind === "local";
   const [pipelineConfig, setPipelineConfig] = useState<PipelineConfig>(() => {
-    const artifacts = getRecipeArtifacts(DEFAULT_STUDIO_RECIPE_ID);
+    if (initialAuthoringState?.pipelineConfig) return initialAuthoringState.pipelineConfig;
+    const artifacts = recipeArtifacts;
     return buildDefaultConfig(artifacts.configSchema, artifacts.uiMeta, artifacts.defaultConfig);
   });
-  const [overridesDisabled, setOverridesDisabled] = useState(false);
+  const [overridesDisabled, setOverridesDisabled] = useState(() => initialAuthoringState?.overridesDisabled ?? false);
   const [lastRunSnapshot, setLastRunSnapshot] = useState<LastRunSnapshot | null>(null);
 
   useEffect(() => {
+    const previousPreset = lastPresetKeyRef.current;
+    const previousRecipe = lastRecipeIdRef.current;
+    lastPresetKeyRef.current = recipeSettings.preset;
+    lastRecipeIdRef.current = recipeSettings.recipe;
     if (parsePresetKey(recipeSettings.preset).kind !== "none") return;
+    if (previousPreset === recipeSettings.preset && previousRecipe === recipeSettings.recipe) return;
     const base = buildDefaultConfig(
       recipeArtifacts.configSchema,
       recipeArtifacts.uiMeta,
@@ -561,6 +643,7 @@ function AppContent(props: AppContentProps) {
     recipeArtifacts.configSchema,
     recipeArtifacts.defaultConfig,
     recipeArtifacts.uiMeta,
+    recipeSettings.recipe,
     recipeSettings.preset,
   ]);
 
@@ -612,6 +695,16 @@ function AppContent(props: AppContentProps) {
     toast(loadWarning, { variant: "info" });
   }, [loadWarning, toast]);
 
+  useEffect(() => {
+    saveStudioAuthoringState({
+      worldSettings,
+      recipeSettings,
+      pipelineConfig,
+      overridesDisabled,
+      repoBackedPresetOverridesByRecipe,
+    });
+  }, [overridesDisabled, pipelineConfig, recipeSettings, repoBackedPresetOverridesByRecipe, worldSettings]);
+
   const dumpLoader = useDumpLoader();
   const dumpAssetResolver = dumpLoader.state.status === "loaded" ? dumpLoader.state.reader : null;
   const dumpManifest = dumpLoader.state.status === "loaded" ? dumpLoader.state.manifest : null;
@@ -629,7 +722,6 @@ function AppContent(props: AppContentProps) {
   const browserRunning = browserRunner.state.running;
   const [localError, setLocalError] = useState<string | null>(null);
   const [saveDeployOperation, setSaveDeployOperation] = useState<MapConfigSaveDeployStatus | null>(null);
-  const [runInGameOperation, setRunInGameOperation] = useState<RunInGameOperationStatus | null>(null);
   const [runInGameSnapshot, setRunInGameSnapshot] = useState<RunInGameClientSnapshot | null>(null);
   const [lastSaveDeployConfig, setLastSaveDeployConfig] = useState<unknown>(null);
   const lastRunInGameToastRef = useRef<string | null>(null);
@@ -1429,6 +1521,47 @@ function AppContent(props: AppContentProps) {
     [runInGameCurrentFingerprint, runInGameOperation, runInGameSnapshot]
   );
 
+  const liveGameStudioRelation = useMemo<"current" | "stale" | "unknown">(() => {
+    if (liveRuntime.status !== "ok") return "unknown";
+    if (liveRuntime.seed !== undefined && String(liveRuntime.seed) !== recipeSettings.seed) return "stale";
+    if (!provedRunInGameSource) return "unknown";
+    if (
+      liveRuntime.seed !== undefined &&
+      String(liveRuntime.seed) !== provedRunInGameSource.recipeSettings.seed
+    ) {
+      return "unknown";
+    }
+    return liveSourceMatchesStudio({
+      source: provedRunInGameSource,
+      recipeSettings,
+      worldSettings,
+      pipelineConfig: stripSchemaMetadataRoot(pipelineConfig) as PipelineConfig,
+    })
+      ? "current"
+      : "stale";
+  }, [liveRuntime.seed, liveRuntime.status, pipelineConfig, provedRunInGameSource, recipeSettings, worldSettings]);
+
+  const studioMatchesProvedLiveSource = useMemo(() => {
+    if (!provedRunInGameSource) return false;
+    return liveSourceMatchesStudio({
+      source: provedRunInGameSource,
+      recipeSettings,
+      worldSettings,
+      pipelineConfig: stripSchemaMetadataRoot(pipelineConfig) as PipelineConfig,
+    });
+  }, [pipelineConfig, provedRunInGameSource, recipeSettings, worldSettings]);
+
+  const displayedPresetOptions = useMemo(
+    () => {
+      const relabelNoneAsLive =
+        studioMatchesProvedLiveSource && provedRunInGameSource?.materializationMode === "disposable";
+      return presetOptions
+        .filter((option) => !(relabelNoneAsLive && option.value === LIVE_GAME_PRESET_KEY))
+        .map((option) => (option.value === "none" && relabelNoneAsLive ? { ...option, label: "Live / Live Game" } : option));
+    },
+    [presetOptions, provedRunInGameSource?.materializationMode, studioMatchesProvedLiveSource]
+  );
+
   const refreshRunInGameStatus = useCallback(async (requestId: string) => {
     const result = await fetchRunInGameStatus(requestId);
     if (!("requestId" in result)) {
@@ -1558,6 +1691,16 @@ function AppContent(props: AppContentProps) {
     const sanitized = stripSchemaMetadataRoot(pipelineConfig) as PipelineConfig;
     const resolved = resolvePreset(recipeSettings.preset as PresetKey);
     const mapSize = getCiv7MapSizePreset(worldSettings.mapSize);
+    const selectedConfig = resolved
+      ? {
+          id: resolved.id,
+          label: resolved.label,
+          description: resolved.description,
+          sourcePath: resolved.sourcePath,
+          sortIndex: resolved.sortIndex,
+          latitudeBounds: resolved.latitudeBounds,
+        }
+      : undefined;
     const result = await runCurrentConfigInGame({
       recipeId: "mod-swooper-maps/standard",
       seed: recipeSettings.seed,
@@ -1566,16 +1709,7 @@ function AppContent(props: AppContentProps) {
       resources: worldSettings.resources,
       materializationMode: runInGameMaterializationMode,
       restartCivProcess: options?.restartCivProcess,
-      selectedConfig: resolved
-        ? {
-            id: resolved.id,
-            label: resolved.label,
-            description: resolved.description,
-            sourcePath: resolved.sourcePath,
-            sortIndex: resolved.sortIndex,
-            latitudeBounds: resolved.latitudeBounds,
-          }
-        : undefined,
+      selectedConfig,
       config: sanitized,
     });
     if (!("requestId" in result)) {
@@ -1603,9 +1737,19 @@ function AppContent(props: AppContentProps) {
       materializationMode: runInGameMaterializationMode,
     });
     setRunInGameSnapshot(snapshot);
+    const sourceSnapshot = buildRunInGameSourceSnapshot({
+      requestId: result.requestId,
+      recipeSettings,
+      worldSettings,
+      pipelineConfig: sanitized,
+      materializationMode: runInGameMaterializationMode,
+      selectedConfig,
+    });
+    setLastRunInGameSource(sourceSnapshot);
     try {
       localStorage.setItem(RUN_IN_GAME_LAST_REQUEST_KEY, result.requestId);
       localStorage.setItem(RUN_IN_GAME_LAST_SNAPSHOT_KEY, JSON.stringify(snapshot));
+      localStorage.setItem(RUN_IN_GAME_LAST_SOURCE_KEY, JSON.stringify(sourceSnapshot));
     } catch {
       // Server status remains authoritative while the dev server is alive.
     }
@@ -1625,6 +1769,54 @@ function AppContent(props: AppContentProps) {
     worldSettings.playerCount,
     worldSettings.resources,
   ]);
+
+  const syncStudioFromLiveGame = useCallback(() => {
+    if (liveRuntime.status !== "ok") return;
+    if (browserRunning || runInGameRunning || saveDeployRunning) {
+      toast("Finish the current Studio operation before syncing from the live game.", { variant: "info" });
+      return;
+    }
+    if (!provedRunInGameSource) {
+      if (liveRuntime.seed === undefined) {
+        toast("Live game seed is unavailable; run the game through Studio to sync full config.", { variant: "error" });
+        return;
+      }
+      setRecipeSettings((prev) => ({ ...prev, seed: String(liveRuntime.seed) }));
+      toast("Studio seed synced from live game. Full config sync requires a proved Run in Game source.", {
+        variant: "info",
+      });
+      return;
+    }
+    const liveSeed = liveRuntime.seed === undefined ? provedRunInGameSource.recipeSettings.seed : String(liveRuntime.seed);
+    if (liveSeed !== provedRunInGameSource.recipeSettings.seed) {
+      toast("Live game seed no longer matches the last proved Studio run.", { variant: "error" });
+      return;
+    }
+    const durablePresetKey =
+      provedRunInGameSource.materializationMode === "durable" && provedRunInGameSource.selectedConfig?.id
+        ? (`builtin:${provedRunInGameSource.selectedConfig.id}` as PresetKey)
+        : null;
+    const nextPreset = durablePresetKey && resolvePreset(durablePresetKey) ? durablePresetKey : LIVE_GAME_PRESET_KEY;
+
+    lastAppliedPresetRef.current = {
+      key: nextPreset,
+      config: provedRunInGameSource.pipelineConfig,
+    };
+    setWorldSettings({
+      ...provedRunInGameSource.worldSettings,
+      mode: "browser",
+    });
+    setPipelineConfig(provedRunInGameSource.pipelineConfig);
+    setOverridesDisabled(false);
+    setRecipeSettings({
+      ...provedRunInGameSource.recipeSettings,
+      seed: liveSeed,
+      preset: nextPreset,
+    });
+    toast(nextPreset === LIVE_GAME_PRESET_KEY ? "Studio synced to live game config" : "Studio synced to live game preset", {
+      variant: "success",
+    });
+  }, [browserRunning, liveRuntime, provedRunInGameSource, resolvePreset, runInGameRunning, saveDeployRunning, toast]);
 
   const handleToggleAutoplay = useCallback(async () => {
     if (autoplayActionRunning || browserRunning || runInGameRunning || saveDeployRunning) return;
@@ -2235,7 +2427,7 @@ function AppContent(props: AppContentProps) {
         )
       }
       recipeOptions={recipeOptions}
-      presetOptions={presetOptions}
+      presetOptions={displayedPresetOptions}
       theme={theme}
       lightMode={isLightMode}
       selectedStep={selectedStageId}
@@ -2344,6 +2536,8 @@ function AppContent(props: AppContentProps) {
       isDirty={isDirty}
       lightMode={isLightMode}
       liveRuntime={liveRuntime}
+      liveGameStudioRelation={liveGameStudioRelation}
+      onSyncFromLiveGame={syncStudioFromLiveGame}
       onToggleAutoplay={handleToggleAutoplay}
       onToast={(message) => toast(message, { variant: "success" })}
       autoRunEnabled={autoRunEnabled}

--- a/apps/mapgen-studio/src/features/presets/types.ts
+++ b/apps/mapgen-studio/src/features/presets/types.ts
@@ -1,11 +1,12 @@
-export type PresetKey = "none" | `builtin:${string}` | `local:${string}`;
+export type PresetKey = "none" | `builtin:${string}` | `local:${string}` | `live:${string}`;
 
-export type PresetSource = "builtin" | "local";
+export type PresetSource = "builtin" | "local" | "live";
 
 export type ParsedPresetKey =
   | { kind: "none" }
   | { kind: "builtin"; id: string }
-  | { kind: "local"; id: string };
+  | { kind: "local"; id: string }
+  | { kind: "live"; id: string };
 
 export type ResolvedPreset = Readonly<{
   source: PresetSource;
@@ -25,5 +26,6 @@ export function parsePresetKey(key: string): ParsedPresetKey {
   if (key === "none") return { kind: "none" };
   if (key.startsWith("builtin:")) return { kind: "builtin", id: key.slice("builtin:".length) };
   if (key.startsWith("local:")) return { kind: "local", id: key.slice("local:".length) };
+  if (key.startsWith("live:")) return { kind: "live", id: key.slice("live:".length) };
   return { kind: "none" };
 }

--- a/apps/mapgen-studio/src/features/presets/usePresets.ts
+++ b/apps/mapgen-studio/src/features/presets/usePresets.ts
@@ -11,6 +11,13 @@ import {
 } from "./storage";
 import { parsePresetKey, type PresetKey, type ResolvedPreset } from "./types";
 
+export type LivePreset = Readonly<{
+  id: string;
+  label: string;
+  description?: string;
+  config: unknown;
+}>;
+
 export type PresetActions = Readonly<{
   saveAsNew: (args: {
     recipeId: string;
@@ -51,8 +58,9 @@ function createLocalPresetId(existing: ReadonlyArray<LocalPresetV1>): string {
 export function usePresets(args: {
   recipeId: string;
   builtIns: ReadonlyArray<BuiltInPreset>;
+  livePresets?: ReadonlyArray<LivePreset>;
 }): UsePresetsResult {
-  const { recipeId, builtIns } = args;
+  const { recipeId, builtIns, livePresets = [] } = args;
   const [{ store, warning }, setStoreState] = useState(() => {
     const result = loadPresetStore();
     return { store: result.store, warning: result.warning };
@@ -70,8 +78,12 @@ export function usePresets(args: {
       value: `local:${preset.id}`,
       label: `Scratch / ${preset.label}`,
     }));
-    return [...base, ...builtInOptions, ...localOptions];
-  }, [builtIns, localPresets]);
+    const liveOptions = livePresets.map((preset) => ({
+      value: `live:${preset.id}`,
+      label: `Live / ${preset.label}`,
+    }));
+    return [...base, ...liveOptions, ...builtInOptions, ...localOptions];
+  }, [builtIns, livePresets, localPresets]);
 
   const resolvePreset = useCallback((key: PresetKey): ResolvedPreset | null => {
     const parsed = parsePresetKey(key);
@@ -96,8 +108,14 @@ export function usePresets(args: {
         ? { source: "local", id: preset.id, label: preset.label, description: preset.description, config: preset.config }
         : null;
     }
+    if (parsed.kind === "live") {
+      const preset = livePresets.find((p) => p.id === parsed.id);
+      return preset
+        ? { source: "live", id: preset.id, label: preset.label, description: preset.description, config: preset.config }
+        : null;
+    }
     return null;
-  }, [builtIns, localPresets]);
+  }, [builtIns, livePresets, localPresets]);
 
   const setStore = useCallback((next: StudioPresetStoreV1): string | undefined => {
     setStoreState((prev) => ({ store: next, warning: prev.warning }));

--- a/apps/mapgen-studio/src/features/runInGame/clientState.ts
+++ b/apps/mapgen-studio/src/features/runInGame/clientState.ts
@@ -14,6 +14,21 @@ export type RunInGameClientSnapshot = Readonly<{
   materializationMode: "durable" | "disposable";
 }>;
 
+export type RunInGameSourceSnapshot = Readonly<{
+  requestId: string;
+  createdAt: string;
+  recipeSettings: RecipeSettings;
+  worldSettings: WorldSettings;
+  pipelineConfig: PipelineConfig;
+  materializationMode: "durable" | "disposable";
+  selectedConfig?: {
+    id?: string;
+    label?: string;
+    description?: string;
+    sourcePath?: string;
+  };
+}>;
+
 export type RunInGameCurrentRelation = "current" | "stale" | "unknown";
 
 export function buildRunInGameFingerprint(args: {
@@ -56,6 +71,26 @@ export function buildRunInGameClientSnapshot(args: {
   };
 }
 
+export function buildRunInGameSourceSnapshot(args: {
+  requestId: string;
+  recipeSettings: RecipeSettings;
+  worldSettings: WorldSettings;
+  pipelineConfig: PipelineConfig;
+  materializationMode: "durable" | "disposable";
+  selectedConfig?: RunInGameSourceSnapshot["selectedConfig"];
+  now?: () => Date;
+}): RunInGameSourceSnapshot {
+  return {
+    requestId: args.requestId,
+    createdAt: (args.now ?? (() => new Date()))().toISOString(),
+    recipeSettings: args.recipeSettings,
+    worldSettings: args.worldSettings,
+    pipelineConfig: args.pipelineConfig,
+    materializationMode: args.materializationMode,
+    ...(args.selectedConfig === undefined ? {} : { selectedConfig: args.selectedConfig }),
+  };
+}
+
 export function relationForRunInGameOperation(args: {
   status?: RunInGameOperationStatus | null;
   snapshot?: RunInGameClientSnapshot | null;
@@ -64,6 +99,52 @@ export function relationForRunInGameOperation(args: {
   if (!args.status) return "unknown";
   if (!args.snapshot || args.snapshot.requestId !== args.status.requestId) return "unknown";
   return args.snapshot.fingerprint === args.currentFingerprint ? "current" : "stale";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseRecipeSettings(value: unknown): RecipeSettings | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.recipe !== "string" || typeof value.preset !== "string" || typeof value.seed !== "string") {
+    return null;
+  }
+  return {
+    recipe: value.recipe,
+    preset: value.preset,
+    seed: value.seed,
+  };
+}
+
+function parseWorldSettings(value: unknown): WorldSettings | null {
+  if (!isRecord(value)) return null;
+  if (
+    value.mode !== "browser" &&
+    value.mode !== "dump"
+  ) {
+    return null;
+  }
+  if (typeof value.mapSize !== "string" || typeof value.playerCount !== "number" || typeof value.resources !== "string") {
+    return null;
+  }
+  return {
+    mode: value.mode,
+    mapSize: value.mapSize as WorldSettings["mapSize"],
+    playerCount: value.playerCount,
+    resources: value.resources as WorldSettings["resources"],
+  };
+}
+
+function parseSelectedConfig(value: unknown): RunInGameSourceSnapshot["selectedConfig"] | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) return undefined;
+  return {
+    ...(typeof value.id === "string" ? { id: value.id } : {}),
+    ...(typeof value.label === "string" ? { label: value.label } : {}),
+    ...(typeof value.description === "string" ? { description: value.description } : {}),
+    ...(typeof value.sourcePath === "string" ? { sourcePath: value.sourcePath } : {}),
+  };
 }
 
 export function parseRunInGameClientSnapshot(value: string | null): RunInGameClientSnapshot | null {
@@ -85,6 +166,37 @@ export function parseRunInGameClientSnapshot(value: string | null): RunInGameCli
       return null;
     }
     return parsed as RunInGameClientSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+export function parseRunInGameSourceSnapshot(value: string | null): RunInGameSourceSnapshot | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!isRecord(parsed)) return null;
+    const recipeSettings = parseRecipeSettings(parsed.recipeSettings);
+    const worldSettings = parseWorldSettings(parsed.worldSettings);
+    if (
+      typeof parsed.requestId !== "string" ||
+      typeof parsed.createdAt !== "string" ||
+      !recipeSettings ||
+      !worldSettings ||
+      !isRecord(parsed.pipelineConfig) ||
+      (parsed.materializationMode !== "durable" && parsed.materializationMode !== "disposable")
+    ) {
+      return null;
+    }
+    return {
+      requestId: parsed.requestId,
+      createdAt: parsed.createdAt,
+      recipeSettings,
+      worldSettings,
+      pipelineConfig: parsed.pipelineConfig as PipelineConfig,
+      materializationMode: parsed.materializationMode,
+      ...(parsed.selectedConfig === undefined ? {} : { selectedConfig: parseSelectedConfig(parsed.selectedConfig) }),
+    };
   } catch {
     return null;
   }

--- a/apps/mapgen-studio/src/features/studioState/persistence.ts
+++ b/apps/mapgen-studio/src/features/studioState/persistence.ts
@@ -1,0 +1,134 @@
+import type { BuiltInPreset } from "../../recipes/catalog";
+import type { PipelineConfig, RecipeSettings, WorldSettings } from "../../ui/types";
+
+export const STUDIO_AUTHORING_STATE_KEY = "mapgen-studio.authoring-state.v1";
+
+export type StudioAuthoringStateSnapshot = Readonly<{
+  schemaVersion: 1;
+  savedAt: string;
+  worldSettings: WorldSettings;
+  recipeSettings: RecipeSettings;
+  pipelineConfig: PipelineConfig;
+  overridesDisabled: boolean;
+  repoBackedPresetOverridesByRecipe: Record<string, Record<string, BuiltInPreset>>;
+}>;
+
+type KeyValueStorage = Pick<Storage, "getItem" | "setItem">;
+
+function browserStorage(): KeyValueStorage | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return window.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseWorldSettings(value: unknown): WorldSettings | null {
+  if (!isRecord(value)) return null;
+  if (value.mode !== "browser" && value.mode !== "dump") return null;
+  if (typeof value.mapSize !== "string" || typeof value.playerCount !== "number" || typeof value.resources !== "string") {
+    return null;
+  }
+  return {
+    mode: value.mode,
+    mapSize: value.mapSize as WorldSettings["mapSize"],
+    playerCount: value.playerCount,
+    resources: value.resources as WorldSettings["resources"],
+  };
+}
+
+function parseRecipeSettings(value: unknown): RecipeSettings | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.recipe !== "string" || typeof value.preset !== "string" || typeof value.seed !== "string") {
+    return null;
+  }
+  return {
+    recipe: value.recipe,
+    preset: value.preset,
+    seed: value.seed,
+  };
+}
+
+function parseBuiltInPreset(value: unknown): BuiltInPreset | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.id !== "string" || typeof value.label !== "string" || !isRecord(value.config)) return null;
+  return {
+    id: value.id,
+    label: value.label,
+    ...(typeof value.description === "string" ? { description: value.description } : {}),
+    ...(typeof value.sourcePath === "string" ? { sourcePath: value.sourcePath } : {}),
+    ...(typeof value.sortIndex === "number" ? { sortIndex: value.sortIndex } : {}),
+    ...(isRecord(value.latitudeBounds) ? { latitudeBounds: value.latitudeBounds as BuiltInPreset["latitudeBounds"] } : {}),
+    config: value.config,
+  };
+}
+
+function parseRepoBackedOverrides(value: unknown): Record<string, Record<string, BuiltInPreset>> {
+  if (!isRecord(value)) return {};
+  const out: Record<string, Record<string, BuiltInPreset>> = {};
+  for (const [recipeId, presets] of Object.entries(value)) {
+    if (!isRecord(presets)) continue;
+    const recipePresets: Record<string, BuiltInPreset> = {};
+    for (const [presetId, preset] of Object.entries(presets)) {
+      const parsed = parseBuiltInPreset(preset);
+      if (parsed) recipePresets[presetId] = parsed;
+    }
+    if (Object.keys(recipePresets).length > 0) out[recipeId] = recipePresets;
+  }
+  return out;
+}
+
+export function parseStudioAuthoringState(value: string | null): StudioAuthoringStateSnapshot | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!isRecord(parsed) || parsed.schemaVersion !== 1 || typeof parsed.savedAt !== "string") return null;
+    const worldSettings = parseWorldSettings(parsed.worldSettings);
+    const recipeSettings = parseRecipeSettings(parsed.recipeSettings);
+    if (!worldSettings || !recipeSettings || !isRecord(parsed.pipelineConfig)) return null;
+    return {
+      schemaVersion: 1,
+      savedAt: parsed.savedAt,
+      worldSettings,
+      recipeSettings,
+      pipelineConfig: parsed.pipelineConfig as PipelineConfig,
+      overridesDisabled: parsed.overridesDisabled === true,
+      repoBackedPresetOverridesByRecipe: parseRepoBackedOverrides(parsed.repoBackedPresetOverridesByRecipe),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function loadStudioAuthoringState(storage: KeyValueStorage | null = browserStorage()): StudioAuthoringStateSnapshot | null {
+  if (!storage) return null;
+  try {
+    return parseStudioAuthoringState(storage.getItem(STUDIO_AUTHORING_STATE_KEY));
+  } catch {
+    return null;
+  }
+}
+
+export function saveStudioAuthoringState(
+  args: Omit<StudioAuthoringStateSnapshot, "schemaVersion" | "savedAt">,
+  storage: KeyValueStorage | null = browserStorage()
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(
+      STUDIO_AUTHORING_STATE_KEY,
+      JSON.stringify({
+        schemaVersion: 1,
+        savedAt: new Date().toISOString(),
+        ...args,
+      })
+    );
+  } catch {
+    // Persistence is a refresh recovery aid; it must not break authoring.
+  }
+}

--- a/apps/mapgen-studio/src/ui/components/AppFooter.tsx
+++ b/apps/mapgen-studio/src/ui/components/AppFooter.tsx
@@ -63,6 +63,10 @@ export interface AppFooterProps {
     updatedAt?: string;
     error?: string;
   };
+  /** Whether the current Studio config/seed matches the proved live game source. */
+  liveGameStudioRelation?: "current" | "stale" | "unknown";
+  /** Callback to apply the proved live game seed/config back into Studio. */
+  onSyncFromLiveGame?: () => void;
   /** Whether a Civ7 autoplay start/stop request is in flight */
   isAutoplayActionRunning?: boolean;
   /** Callback to start or stop Civ7 native autoplay */
@@ -95,6 +99,8 @@ export const AppFooter: React.FC<AppFooterProps> = ({
   isDirty,
   lightMode,
   liveRuntime,
+  liveGameStudioRelation = "unknown",
+  onSyncFromLiveGame,
   isAutoplayActionRunning = false,
   onToggleAutoplay,
   onToast,
@@ -157,6 +163,14 @@ export const AppFooter: React.FC<AppFooterProps> = ({
           : "bg-gray-400";
   const runInGameButtonText = runInGamePrimaryActionLabel(runInGameStatus, runInGameCurrentRelation);
   const operationControlsDisabled = isRunning || isRunInGameRunning || isSaveDeployRunning;
+  const liveSyncAvailable =
+    liveRuntime?.status === "ok" &&
+    liveGameStudioRelation === "stale" &&
+    Boolean(onSyncFromLiveGame) &&
+    !operationControlsDisabled;
+  const liveSyncTitle = liveSyncAvailable
+    ? "Sync Studio seed and config from the live game"
+    : liveRuntime?.readiness ?? liveRuntime?.error ?? "Civ7 live runtime status";
   const autoplayControlDisabled = operationControlsDisabled || isAutoplayActionRunning || liveRuntime?.status !== "ok" || !onToggleAutoplay;
   const autoplayButtonText = isAutoplayActionRunning
     ? "Autoplay..."
@@ -253,18 +267,30 @@ export const AppFooter: React.FC<AppFooterProps> = ({
       {/* Live Civ7 Panel */}
       <div
         className={`h-10 inline-flex min-w-0 max-w-[420px] items-center gap-2 px-3 rounded-lg border backdrop-blur-sm ${panelBg} ${panelBorder}`}
-        title={liveRuntime?.readiness ?? liveRuntime?.error ?? "Civ7 live runtime status"}>
+        title={liveSyncTitle}>
 
-        <Radio className={`w-3.5 h-3.5 ${textMuted}`} />
-        <div className={`w-2 h-2 shrink-0 rounded-full ${liveDotClass}`} />
-        <span className={`truncate text-[11px] font-medium ${textPrimary}`}>
-          {liveText}
-        </span>
-        {liveRuntime?.autoplayActive ? (
-          <span className="shrink-0 rounded border border-amber-400/40 px-1.5 py-0.5 text-[10px] text-amber-500">
-            Auto
+        <button
+          type="button"
+          onClick={onSyncFromLiveGame}
+          disabled={!liveSyncAvailable}
+          title={liveSyncTitle}
+          className={`inline-flex h-7 min-w-0 items-center gap-2 rounded border px-2 transition-colors ${
+            liveGameStudioRelation === "stale"
+              ? "border-orange-400 text-orange-500 ring-2 ring-orange-400/40"
+              : "border-transparent"
+          } ${liveSyncAvailable ? "cursor-pointer hover:bg-orange-400/10" : "cursor-default disabled:opacity-100"}`}>
+
+          <Radio className={`w-3.5 h-3.5 ${liveGameStudioRelation === "stale" ? "text-orange-500" : textMuted}`} />
+          <div className={`w-2 h-2 shrink-0 rounded-full ${liveDotClass}`} />
+          <span className={`truncate text-[11px] font-medium ${liveGameStudioRelation === "stale" ? "text-orange-500" : textPrimary}`}>
+            {liveText}
           </span>
-        ) : null}
+          {liveRuntime?.autoplayActive ? (
+            <span className="shrink-0 rounded border border-amber-400/40 px-1.5 py-0.5 text-[10px] text-amber-500">
+              Auto
+            </span>
+          ) : null}
+        </button>
         <Button
           variant="outline"
           size="sm"

--- a/apps/mapgen-studio/test/devServer/watchIgnores.test.ts
+++ b/apps/mapgen-studio/test/devServer/watchIgnores.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import viteConfig from "../../vite.config";
+
+async function loadServeConfig() {
+  if (typeof viteConfig === "function") {
+    return await viteConfig({
+      command: "serve",
+      mode: "development",
+      isSsrBuild: false,
+      isPreview: false,
+    });
+  }
+  return viteConfig;
+}
+
+describe("Studio dev server watch ignores", () => {
+  it("ignores Studio-written map config JSON files so Save/Run does not full-reload the tab", async () => {
+    const config = await loadServeConfig();
+    const ignored = config.server?.watch?.ignored;
+
+    expect(Array.isArray(ignored)).toBe(true);
+    expect(ignored).toContain("**/mods/mod-swooper-maps/src/maps/configs/*.config.json");
+  });
+});

--- a/apps/mapgen-studio/test/presets/presetKeys.test.ts
+++ b/apps/mapgen-studio/test/presets/presetKeys.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePresetKey } from "../../src/features/presets/types";
+
+describe("preset keys", () => {
+  it("parses live game presets as first-class preset keys", () => {
+    expect(parsePresetKey("live:live-game")).toEqual({ kind: "live", id: "live-game" });
+  });
+
+  it("keeps unknown preset keys on the safe none path", () => {
+    expect(parsePresetKey("live")).toEqual({ kind: "none" });
+    expect(parsePresetKey("")).toEqual({ kind: "none" });
+  });
+});

--- a/apps/mapgen-studio/test/runInGame/AppFooter.test.tsx
+++ b/apps/mapgen-studio/test/runInGame/AppFooter.test.tsx
@@ -208,4 +208,32 @@ describe("AppFooter Run in Game status", () => {
     expect(html).toContain("Stop Civ7 autoplay");
     expect(html).toContain("Auto");
   });
+
+  it("highlights live seed status when a proved live game is out of sync with Studio", () => {
+    const html = renderToStaticMarkup(
+      <AppFooter
+        status="ready"
+        lastRunSettings={recipeSettings}
+        lastGlobalSettings={worldSettings}
+        currentSettings={{ ...recipeSettings, seed: "456" }}
+        onSettingsChange={vi.fn()}
+        onRun={vi.fn()}
+        onRunInGame={vi.fn()}
+        onReroll={vi.fn()}
+        isRunning={false}
+        isRunInGameRunning={false}
+        isDirty={true}
+        lightMode={false}
+        liveRuntime={{ status: "ok", turn: 12, seed: 123 }}
+        liveGameStudioRelation="stale"
+        onSyncFromLiveGame={vi.fn()}
+        autoRunEnabled={false}
+        onAutoRunEnabledChange={vi.fn()}
+      />
+    );
+
+    expect(html).toContain("Sync Studio seed and config from the live game");
+    expect(html).toContain("border-orange-400");
+    expect(html).toContain("Seed 123");
+  });
 });

--- a/apps/mapgen-studio/test/runInGame/clientState.test.ts
+++ b/apps/mapgen-studio/test/runInGame/clientState.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildRunInGameClientSnapshot,
   buildRunInGameFingerprint,
+  buildRunInGameSourceSnapshot,
   parseRunInGameClientSnapshot,
+  parseRunInGameSourceSnapshot,
   relationForRunInGameOperation,
 } from "../../src/features/runInGame/clientState";
 import type { RunInGameOperationStatus } from "../../src/features/runInGame/status";
@@ -109,5 +111,29 @@ describe("Run in Game client state", () => {
     }))).toMatchObject({ requestId: "request" });
     expect(parseRunInGameClientSnapshot('{"requestId":"request"}')).toBeNull();
     expect(parseRunInGameClientSnapshot("not json")).toBeNull();
+  });
+
+  it("round-trips the stored source snapshot used to sync Studio from a proved live game", () => {
+    const source = buildRunInGameSourceSnapshot({
+      requestId: status.requestId,
+      recipeSettings,
+      worldSettings,
+      pipelineConfig,
+      materializationMode: "disposable",
+      selectedConfig: {
+        id: "studio-current",
+        label: "Live Game",
+      },
+      now: () => new Date("2026-06-01T00:00:00.000Z"),
+    });
+
+    expect(parseRunInGameSourceSnapshot(JSON.stringify(source))).toEqual(source);
+    expect(parseRunInGameSourceSnapshot(JSON.stringify({
+      requestId: status.requestId,
+      createdAt: "2026-06-01T00:00:00.000Z",
+      recipeSettings,
+      worldSettings,
+      materializationMode: "disposable",
+    }))).toBeNull();
   });
 });

--- a/apps/mapgen-studio/test/studioState/persistence.test.ts
+++ b/apps/mapgen-studio/test/studioState/persistence.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  STUDIO_AUTHORING_STATE_KEY,
+  loadStudioAuthoringState,
+  parseStudioAuthoringState,
+  saveStudioAuthoringState,
+} from "../../src/features/studioState/persistence";
+import type { PipelineConfig, RecipeSettings, WorldSettings } from "../../src/ui/types";
+
+function memoryStorage() {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+  };
+}
+
+const worldSettings: WorldSettings = {
+  mode: "browser",
+  mapSize: "MAPSIZE_STANDARD",
+  playerCount: 6,
+  resources: "balanced",
+};
+
+const recipeSettings: RecipeSettings = {
+  recipe: "mod-swooper-maps/standard",
+  preset: "builtin:swooper-earthlike",
+  seed: "987654321",
+};
+
+const pipelineConfig = {
+  morphology: {
+    knobs: {
+      landmasses: "earthlike",
+    },
+  },
+} as unknown as PipelineConfig;
+
+describe("Studio authoring-state persistence", () => {
+  it("saves and reloads selected config, seed, world settings, and repo-backed overrides", () => {
+    const storage = memoryStorage();
+    saveStudioAuthoringState({
+      worldSettings,
+      recipeSettings,
+      pipelineConfig,
+      overridesDisabled: false,
+      repoBackedPresetOverridesByRecipe: {
+        "mod-swooper-maps/standard": {
+          "swooper-earthlike": {
+            id: "swooper-earthlike",
+            label: "Swooper Earthlike",
+            sourcePath: "mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json",
+            config: pipelineConfig,
+          },
+        },
+      },
+    }, storage);
+
+    const saved = storage.getItem(STUDIO_AUTHORING_STATE_KEY);
+    expect(saved).toContain("987654321");
+    expect(loadStudioAuthoringState(storage)).toMatchObject({
+      worldSettings,
+      recipeSettings,
+      pipelineConfig,
+      overridesDisabled: false,
+      repoBackedPresetOverridesByRecipe: {
+        "mod-swooper-maps/standard": {
+          "swooper-earthlike": {
+            id: "swooper-earthlike",
+            label: "Swooper Earthlike",
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects partial snapshots instead of falling back to none/123-shaped data", () => {
+    expect(parseStudioAuthoringState(JSON.stringify({
+      schemaVersion: 1,
+      savedAt: "2026-06-01T00:00:00.000Z",
+      recipeSettings,
+      pipelineConfig,
+    }))).toBeNull();
+  });
+});

--- a/apps/mapgen-studio/vite.config.ts
+++ b/apps/mapgen-studio/vite.config.ts
@@ -908,7 +908,7 @@ export default defineConfig(({ command }) => ({
         "**/mods/mod-swooper-maps/dist/**",
         "**/mods/mod-swooper-maps/mod/**",
         "**/mods/mod-swooper-maps/src/maps/generated/**",
-        "**/mods/mod-swooper-maps/src/maps/configs/studio-current.config.json",
+        "**/mods/mod-swooper-maps/src/maps/configs/*.config.json",
         "**/packages/*/dist/**",
         "**/packages/*/types/**",
       ],


### PR DESCRIPTION
## Live Game ↔ Studio Sync

Introduces bidirectional awareness between the Studio authoring session and the active Civ7 game, allowing Studio to detect when its current config diverges from what is running in-game and sync back from a proved live source.

### Live Game Preset

Adds a `live:` preset key kind alongside the existing `builtin:` and `local:` kinds. When a Run in Game request has been made, a "Live Game" preset appears in the preset dropdown reflecting the config and seed that was sent to the game. The preset label includes the selected config name when the materialization mode is durable.

### Run in Game Source Snapshot

Introduces `RunInGameSourceSnapshot`, a new persisted record written to `localStorage` after each Run in Game request. It captures the full authoring state at the time of the request — recipe settings, world settings, pipeline config, materialization mode, and selected config — alongside the request ID. A snapshot is considered "proved" once the corresponding Run in Game operation completes successfully, linking it to a known game state.

### Live Game / Studio Relation

Computes a `liveGameStudioRelation` of `"current"`, `"stale"`, or `"unknown"` by comparing the proved source snapshot against the current Studio seed, world settings, and pipeline config. The relation is `"stale"` when the live game seed or config no longer matches what Studio has loaded.

### Sync from Live Game

Adds a `syncStudioFromLiveGame` callback that applies the proved source snapshot back into Studio — restoring world settings, pipeline config, seed, and preset selection. If no proved source is available but the live runtime exposes a seed, only the seed is synced with an explanatory toast. The sync is blocked while any operation is in flight.

### Footer Sync Button

The live runtime indicator in `AppFooter` becomes an interactive button when a stale relation is detected. It gains an orange highlight ring and border, and its tooltip changes to prompt the user to sync. The button is disabled and visually inert when the relation is current or unknown.

### Studio Authoring State Persistence

Adds `saveStudioAuthoringState` / `loadStudioAuthoringState` in a new `studioState/persistence` module. World settings, recipe settings, pipeline config, overrides-disabled flag, and repo-backed preset overrides are written to `localStorage` on every change and restored as initial state on load, so the authoring session survives page refreshes.

### Watch Ignore Broadening

Expands the Vite dev server watch ignore pattern from a single `studio-current.config.json` to all `*.config.json` files under the maps configs directory, preventing full tab reloads when any map config file is written by a Save or Run operation.