### PR TITLE
feat(mapgen): integrate resource corpus expectations

### DIFF
--- a/mods/mod-swooper-maps/src/domain/index.ts
+++ b/mods/mod-swooper-maps/src/domain/index.ts
@@ -4,3 +4,4 @@ export * as ecology from "@mapgen/domain/ecology/index.js";
 export * as placement from "@mapgen/domain/placement/index.js";
 export * as narrative from "@mapgen/domain/narrative/index.js";
 export * as foundation from "@mapgen/domain/foundation/index.js";
+export * as resources from "@mapgen/domain/resources/index.js";

--- a/mods/mod-swooper-maps/src/domain/resources/corpus/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/corpus/index.ts
@@ -1,0 +1,25 @@
+export {
+  OFFICIAL_RESOURCE_BY_TYPE,
+  OFFICIAL_RESOURCE_CORPUS,
+  OFFICIAL_RESOURCE_CORPUS_ARTIFACT,
+  OFFICIAL_RESOURCE_TYPE_ORDER,
+} from "./official-base-standard.js";
+export type {
+  OfficialAgeType,
+  OfficialPlacementConstraintSummary,
+  OfficialResourceClassType,
+  OfficialResourceCorpusArtifact,
+  OfficialResourceCorpusEntry,
+  OfficialResourceTag,
+  OfficialResourceType,
+  OfficialYieldType,
+  ResourceClassOverride,
+  ResourceDistributionFacts,
+  ResourcePlaceabilityStatus,
+  ResourceRuntimeId,
+  ResourceRuntimeIdStatus,
+  ResourceSourceRef,
+  ResourceStrategyRequiredStatus,
+  ResourceYieldChange,
+  RuntimeEvidenceRef,
+} from "./types.js";

--- a/mods/mod-swooper-maps/src/domain/resources/corpus/official-base-standard.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/corpus/official-base-standard.ts
@@ -1,0 +1,196 @@
+import type {
+  OfficialAgeType,
+  OfficialResourceClassType,
+  OfficialResourceCorpusArtifact,
+  OfficialResourceCorpusEntry,
+  OfficialResourceType,
+  ResourceClassOverride,
+  ResourceDistributionFacts,
+  ResourcePlaceabilityStatus,
+  ResourceStrategyRequiredStatus,
+  ResourceYieldChange,
+} from "./types.js";
+
+const BASE_STANDARD_RESOURCE_FILES = [
+  "Base/modules/base-standard/data/resources.xml",
+  "Base/modules/base-standard/data/resources-v2.xml",
+] as const;
+
+const UNVERIFIED_RUNTIME_ID_RATIONALE =
+  "Static base-standard Resources row; runtime GameInfo.Resources numeric id is not verified in this slice.";
+
+type OfficialResourceRow = readonly [
+  staticResourceRowSlot: number,
+  resourceType: OfficialResourceType,
+  sourceFile: string,
+  name: string,
+  tooltip: string,
+  baseClass: OfficialResourceClassType,
+  weight: number,
+  validAges: readonly OfficialAgeType[],
+  ageClassOverrides: readonly ResourceClassOverride[],
+  validBiomeConstraintCount: number,
+  yieldChanges: readonly ResourceYieldChange[],
+  typeTags: readonly string[],
+  distribution: ResourceDistributionFacts,
+  placeabilityStatus: ResourcePlaceabilityStatus,
+  strategyRequiredStatus: ResourceStrategyRequiredStatus,
+];
+
+const OFFICIAL_RESOURCE_ROWS = [
+  [0, "RESOURCE_COTTON", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_COTTON_NAME", "LOC_ANT_RESOURCE_COTTON_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_MODERN", resourceClass: "RESOURCECLASS_FACTORY", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 4, [{ YieldType: "YIELD_GOLD", YieldChange: "1" }], [], { staple: true }, "placeable", "required"],
+  [1, "RESOURCE_DATES", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_DATES_NAME", "LOC_ANT_RESOURCE_DATES_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION"], [], 2, [{ YieldType: "YIELD_FOOD", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [2, "RESOURCE_DYES", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_DYES_NAME", "LOC_ANT_RESOURCE_DYES_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION"], [], 1, [{ YieldType: "YIELD_CULTURE", YieldChange: "1" }], [], { adjacentToLand: true }, "placeable", "required"],
+  [3, "RESOURCE_FISH", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_FISH_NAME", "LOC_ANT_RESOURCE_FISH_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [], 1, [{ YieldType: "YIELD_FOOD", YieldChange: "1" }], [], { adjacentToLand: true }, "placeable", "required"],
+  [4, "RESOURCE_GOLD", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_GOLD_NAME", "LOC_ANT_RESOURCE_GOLD_TOOLTIP", "RESOURCECLASS_EMPIRE", 20, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_TREASURE", sourceFile: "Base/modules/age-exploration/data/resources.xml" }], 3, [{ YieldType: "YIELD_GOLD", YieldChange: "1" }], [], { staple: true, minimumPerHemisphere: 8 }, "placeable", "required"],
+  [5, "RESOURCE_GOLD_DISTANT_LANDS", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_GOLD_NAME", "LOC_ANT_RESOURCE_GOLD_DISTANT_LANDS_TOOLTIP", "RESOURCECLASS_EMPIRE", 25, [], [{ age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_TREASURE", sourceFile: "Base/modules/age-exploration/data/resources.xml" }], 0, [{ YieldType: "YIELD_GOLD", YieldChange: "1" }], [], {}, "conditional", "blocked"],
+  [6, "RESOURCE_GYPSUM", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_GYPSUM_NAME", "LOC_ANT_RESOURCE_GYPSUM_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION"], [], 3, [{ YieldType: "YIELD_SCIENCE", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [7, "RESOURCE_INCENSE", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_INCENSE_NAME", "LOC_ANT_RESOURCE_INCENSE_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION"], [], 2, [{ YieldType: "YIELD_SCIENCE", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [8, "RESOURCE_IVORY", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_IVORY_NAME", "LOC_ANT_RESOURCE_IVORY_TOOLTIP", "RESOURCECLASS_EMPIRE", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_BONUS", sourceFile: "Base/modules/age-exploration/data/resources.xml" }, { age: "AGE_MODERN", resourceClass: "RESOURCECLASS_BONUS", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 8, [{ YieldType: "YIELD_CULTURE", YieldChange: "1" }], [], { unlocksCiv: true }, "placeable", "required"],
+  [9, "RESOURCE_JADE", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_JADE_NAME", "LOC_ANT_RESOURCE_JADE_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION"], [], 3, [{ YieldType: "YIELD_CULTURE", YieldChange: "1" }], [], { unlocksCiv: true }, "placeable", "required"],
+  [10, "RESOURCE_KAOLIN", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_KAOLIN_NAME", "LOC_ANT_RESOURCE_KAOLIN_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_MODERN", resourceClass: "RESOURCECLASS_FACTORY", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 3, [{ YieldType: "YIELD_FOOD", YieldChange: "1" }], [], { staple: true }, "placeable", "required"],
+  [11, "RESOURCE_MARBLE", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_MARBLE_NAME", "LOC_ANT_RESOURCE_MARBLE_TOOLTIP", "RESOURCECLASS_EMPIRE", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_MODERN", resourceClass: "RESOURCECLASS_EMPIRE", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 3, [{ YieldType: "YIELD_CULTURE", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [12, "RESOURCE_PEARLS", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_PEARLS_NAME", "LOC_ANT_RESOURCE_PEARLS_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_MODERN", resourceClass: "RESOURCECLASS_CITY", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 1, [{ YieldType: "YIELD_GOLD", YieldChange: "1" }], [], { adjacentToLand: true, unlocksCiv: true }, "placeable", "required"],
+  [13, "RESOURCE_SILK", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_SILK_NAME", "LOC_ANT_RESOURCE_SILK_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_MODERN", resourceClass: "RESOURCECLASS_CITY", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 4, [{ YieldType: "YIELD_CULTURE", YieldChange: "1" }], [], { unlocksCiv: true }, "placeable", "required"],
+  [14, "RESOURCE_SILVER", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_SILVER_NAME", "LOC_ANT_RESOURCE_SILVER_TOOLTIP", "RESOURCECLASS_EMPIRE", 20, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_TREASURE", sourceFile: "Base/modules/age-exploration/data/resources.xml" }], 2, [{ YieldType: "YIELD_GOLD", YieldChange: "1" }], [], { staple: true, minimumPerHemisphere: 8 }, "placeable", "required"],
+  [15, "RESOURCE_SILVER_DISTANT_LANDS", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_SILVER_NAME", "LOC_ANT_RESOURCE_SILVER_DISTANT_LANDS_TOOLTIP", "RESOURCECLASS_EMPIRE", 25, [], [{ age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_TREASURE", sourceFile: "Base/modules/age-exploration/data/resources.xml" }], 0, [{ YieldType: "YIELD_GOLD", YieldChange: "1" }], [], {}, "conditional", "blocked"],
+  [16, "RESOURCE_WINE", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_WINE_NAME", "LOC_ANT_RESOURCE_WINE_TOOLTIP", "RESOURCECLASS_EMPIRE", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_MODERN", resourceClass: "RESOURCECLASS_BONUS", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 2, [{ YieldType: "YIELD_HAPPINESS", YieldChange: "1" }], [], { unlocksCiv: true }, "placeable", "required"],
+  [17, "RESOURCE_CAMELS", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_CAMELS_NAME", "LOC_ANT_RESOURCE_CAMELS_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION"], [], 4, [{ YieldType: "YIELD_GOLD", YieldChange: "1" }], [], { bonusResourceSlots: 2, unlocksCiv: true }, "placeable", "required"],
+  [18, "RESOURCE_HIDES", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_HIDES_NAME", "LOC_ANT_RESOURCE_HIDES_TOOLTIP", "RESOURCECLASS_BONUS", 40, ["AGE_ANTIQUITY"], [], 6, [{ YieldType: "YIELD_PRODUCTION", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [19, "RESOURCE_HORSES", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_HORSES_NAME", "LOC_ANT_RESOURCE_HORSES_TOOLTIP", "RESOURCECLASS_EMPIRE", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_TREASURE", sourceFile: "Base/modules/age-exploration/data/resources.xml" }, { age: "AGE_MODERN", resourceClass: "RESOURCECLASS_BONUS", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 2, [{ YieldType: "YIELD_PRODUCTION", YieldChange: "1" }], [], { staple: true, unlocksCiv: true }, "placeable", "required"],
+  [20, "RESOURCE_IRON", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_IRON_NAME", "LOC_ANT_RESOURCE_IRON_TOOLTIP", "RESOURCECLASS_EMPIRE", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION"], [], 5, [{ YieldType: "YIELD_PRODUCTION", YieldChange: "1" }], [], { staple: true, unlocksCiv: true }, "placeable", "required"],
+  [21, "RESOURCE_SALT", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_SALT_NAME", "LOC_ANT_RESOURCE_SALT_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_ANTIQUITY"], [], 3, [{ YieldType: "YIELD_FOOD", YieldChange: "1" }], [], { unlocksCiv: true }, "placeable", "required"],
+  [22, "RESOURCE_WOOL", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_WOOL_NAME", "LOC_ANT_RESOURCE_WOOL_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_ANTIQUITY"], [], 5, [{ YieldType: "YIELD_PRODUCTION", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [23, "RESOURCE_LAPIS_LAZULI", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_LAPIS_LAZULI_NAME", "LOC_ANT_RESOURCE_LAPIS_LAZULI_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_ANTIQUITY"], [], 0, [], [], { tradeable: false }, "unknown", "blocked"],
+  [24, "RESOURCE_COCOA", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_COCOA_NAME", "LOC_EXP_RESOURCE_COCOA_TOOLTIP", "RESOURCECLASS_EMPIRE", 5, ["AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_TREASURE", sourceFile: "Base/modules/age-exploration/data/resources.xml" }, { age: "AGE_MODERN", resourceClass: "RESOURCECLASS_FACTORY", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 1, [{ YieldType: "YIELD_GOLD", YieldChange: "1" }], [], { minimumPerHemisphere: 8, hemisphereUnique: true }, "placeable", "required"],
+  [25, "RESOURCE_FURS", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_FURS_NAME", "LOC_EXP_RESOURCE_FURS_TOOLTIP", "RESOURCECLASS_EMPIRE", 5, ["AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_TREASURE", sourceFile: "Base/modules/age-exploration/data/resources.xml" }, { age: "AGE_MODERN", resourceClass: "RESOURCECLASS_CITY", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 3, [{ YieldType: "YIELD_GOLD", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [26, "RESOURCE_SPICES", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_SPICES_NAME", "LOC_EXP_RESOURCE_SPICES_TOOLTIP", "RESOURCECLASS_EMPIRE", 5, ["AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_TREASURE", sourceFile: "Base/modules/age-exploration/data/resources.xml" }, { age: "AGE_MODERN", resourceClass: "RESOURCECLASS_BONUS", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 2, [{ YieldType: "YIELD_GOLD", YieldChange: "1" }], [], { minimumPerHemisphere: 8, hemisphereUnique: true }, "placeable", "required"],
+  [27, "RESOURCE_SUGAR", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_SUGAR_NAME", "LOC_EXP_RESOURCE_SUGAR_TOOLTIP", "RESOURCECLASS_EMPIRE", 5, ["AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_TREASURE", sourceFile: "Base/modules/age-exploration/data/resources.xml" }, { age: "AGE_MODERN", resourceClass: "RESOURCECLASS_BONUS", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 4, [{ YieldType: "YIELD_FOOD", YieldChange: "1" }], [], { minimumPerHemisphere: 8, hemisphereUnique: true }, "placeable", "required"],
+  [28, "RESOURCE_TEA", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_TEA_NAME", "LOC_EXP_RESOURCE_TEA_TOOLTIP", "RESOURCECLASS_EMPIRE", 5, ["AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_TREASURE", sourceFile: "Base/modules/age-exploration/data/resources.xml" }, { age: "AGE_MODERN", resourceClass: "RESOURCECLASS_FACTORY", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 3, [{ YieldType: "YIELD_SCIENCE", YieldChange: "1" }], [], { minimumPerHemisphere: 8, hemisphereUnique: true, unlocksCiv: true }, "placeable", "required"],
+  [29, "RESOURCE_TRUFFLES", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_TRUFFLES_NAME", "LOC_EXP_RESOURCE_TRUFFLES_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_EXPLORATION", "AGE_MODERN"], [], 5, [{ YieldType: "YIELD_GOLD", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [30, "RESOURCE_NITER", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_NITER_NAME", "LOC_EXP_RESOURCE_NITER_TOOLTIP", "RESOURCECLASS_EMPIRE", 10, ["AGE_EXPLORATION", "AGE_MODERN"], [], 10, [{ YieldType: "YIELD_PRODUCTION", YieldChange: "1" }], [], { unlocksCiv: true }, "placeable", "required"],
+  [31, "RESOURCE_CLOVES", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_CLOVES_NAME", "LOC_EXP_RESOURCE_CLOVES_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_EXPLORATION"], [], 0, [], [], { tradeable: false }, "unknown", "blocked"],
+  [32, "RESOURCE_WHALES", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_WHALES_NAME", "LOC_EXP_RESOURCE_WHALES_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_EXPLORATION", "AGE_MODERN"], [], 1, [{ YieldType: "YIELD_PRODUCTION", YieldChange: "1" }], [], { adjacentToLand: true, lakeEligible: false }, "placeable", "required"],
+  [33, "RESOURCE_COFFEE", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_COFFEE_NAME", "LOC_MOD_RESOURCE_COFFEE_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_MODERN"], [{ age: "AGE_MODERN", resourceClass: "RESOURCECLASS_FACTORY", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 6, [{ YieldType: "YIELD_SCIENCE", YieldChange: "1" }], [], { minimumPerHemisphere: 8 }, "placeable", "required"],
+  [34, "RESOURCE_TOBACCO", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_TOBACCO_NAME", "LOC_MOD_RESOURCE_TOBACCO_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_MODERN"], [{ age: "AGE_MODERN", resourceClass: "RESOURCECLASS_CITY", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 4, [{ YieldType: "YIELD_GOLD", YieldChange: "1" }], [], { minimumPerHemisphere: 8 }, "placeable", "required"],
+  [35, "RESOURCE_CITRUS", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_CITRUS_NAME", "LOC_MOD_RESOURCE_CITRUS_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_MODERN"], [{ age: "AGE_MODERN", resourceClass: "RESOURCECLASS_FACTORY", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 2, [{ YieldType: "YIELD_FOOD", YieldChange: "1" }], [], { minimumPerHemisphere: 8 }, "placeable", "required"],
+  [36, "RESOURCE_COAL", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_COAL_NAME", "LOC_MOD_RESOURCE_COAL_TOOLTIP", "RESOURCECLASS_EMPIRE", 10, ["AGE_MODERN"], [], 6, [{ YieldType: "YIELD_PRODUCTION", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [37, "RESOURCE_NICKEL", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_NICKEL_NAME", "LOC_MOD_RESOURCE_NICKEL_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_MODERN"], [], 0, [], [], { tradeable: false }, "unknown", "blocked"],
+  [38, "RESOURCE_OIL", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_OIL_NAME", "LOC_MOD_RESOURCE_OIL_TOOLTIP", "RESOURCECLASS_EMPIRE", 10, ["AGE_MODERN"], [], 9, [{ YieldType: "YIELD_PRODUCTION", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [39, "RESOURCE_QUININE", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_QUININE_NAME", "LOC_MOD_RESOURCE_QUININE_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_MODERN"], [{ age: "AGE_MODERN", resourceClass: "RESOURCECLASS_FACTORY", sourceFile: "Base/modules/age-modern/data/resources.xml" }], 2, [{ YieldType: "YIELD_FOOD", YieldChange: "1" }], [], { minimumPerHemisphere: 8 }, "placeable", "required"],
+  [40, "RESOURCE_RUBBER", "Base/modules/base-standard/data/resources.xml", "LOC_RESOURCE_RUBBER_NAME", "LOC_MOD_RESOURCE_RUBBER_TOOLTIP", "RESOURCECLASS_EMPIRE", 10, ["AGE_MODERN"], [], 2, [{ YieldType: "YIELD_PRODUCTION", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [41, "RESOURCE_MANGOS", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_MANGOS_NAME", "LOC_ANT_RESOURCE_MANGOS_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION"], [], 2, [{ YieldType: "YIELD_CULTURE", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [42, "RESOURCE_CLAY", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_CLAY_NAME", "LOC_ANT_RESOURCE_CLAY_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION"], [], 5, [{ YieldType: "YIELD_PRODUCTION", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [43, "RESOURCE_FLAX", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_FLAX_NAME", "LOC_ANT_RESOURCE_FLAX_TOOLTIP", "RESOURCECLASS_CITY", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION"], [{ age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_BONUS", sourceFile: "Base/modules/age-exploration/data/resources-v2.xml" }], 6, [{ YieldType: "YIELD_SCIENCE", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [44, "RESOURCE_RUBIES", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_RUBIES_NAME", "LOC_ANT_RESOURCE_RUBIES_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION"], [{ age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_TREASURE", sourceFile: "Base/modules/age-exploration/data/resources.xml" }, { age: "AGE_EXPLORATION", resourceClass: "RESOURCECLASS_TREASURE", sourceFile: "Base/modules/age-exploration/data/resources-v2.xml" }], 4, [{ YieldType: "YIELD_GOLD", YieldChange: "1" }], [], { staple: true }, "placeable", "required"],
+  [45, "RESOURCE_RICE", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_RICE_NAME", "LOC_ANT_RESOURCE_RICE_TOOLTIP", "RESOURCECLASS_EMPIRE", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [], 3, [{ YieldType: "YIELD_FOOD", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [46, "RESOURCE_LIMESTONE", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_LIMESTONE_NAME", "LOC_ANT_RESOURCE_LIMESTONE_TOOLTIP", "RESOURCECLASS_EMPIRE", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [], 6, [{ YieldType: "YIELD_PRODUCTION", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [47, "RESOURCE_TIN", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_TIN_NAME", "LOC_ANT_RESOURCE_TIN_TOOLTIP", "RESOURCECLASS_BONUS", 25, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [{ age: "AGE_MODERN", resourceClass: "RESOURCECLASS_FACTORY", sourceFile: "Base/modules/age-modern/data/resources-v2.xml" }], 4, [{ YieldType: "YIELD_PRODUCTION", YieldChange: "1" }], [], { staple: true }, "placeable", "required"],
+  [48, "RESOURCE_LLAMAS", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_LLAMAS_NAME", "LOC_ANT_RESOURCE_LLAMAS_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [], 3, [{ YieldType: "YIELD_HAPPINESS", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [49, "RESOURCE_HARDWOOD", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_HARDWOOD_NAME", "LOC_ANT_RESOURCE_HARDWOOD_TOOLTIP", "RESOURCECLASS_EMPIRE", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [], 6, [{ YieldType: "YIELD_CULTURE", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [50, "RESOURCE_WILD_GAME", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_WILD_GAME_NAME", "LOC_ANT_RESOURCE_WILD_GAME_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION"], [], 9, [{ YieldType: "YIELD_FOOD", YieldChange: "1" }], [], {}, "placeable", "required"],
+  [51, "RESOURCE_CRABS", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_CRABS_NAME", "LOC_ANT_RESOURCE_CRABS_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [], 6, [{ YieldType: "YIELD_FOOD", YieldChange: "1" }], ["NAVIGABLE_RIVERS_ELIGIBLE", "IGNORES_WEIGHT_FOR_NAVIGABLE_RIVER_PLACEMENT"], { adjacentToLand: true }, "placeable", "required"],
+  [52, "RESOURCE_COWRIE", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_COWRIE_NAME", "LOC_ANT_RESOURCE_COWRIE_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION", "AGE_MODERN"], [], 1, [{ YieldType: "YIELD_HAPPINESS", YieldChange: "1" }], [], { adjacentToLand: true, lakeEligible: false }, "placeable", "required"],
+  [53, "RESOURCE_TURTLES", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_TURTLES_NAME", "LOC_ANT_RESOURCE_TURTLES_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_ANTIQUITY", "AGE_EXPLORATION"], [], 1, [{ YieldType: "YIELD_CULTURE", YieldChange: "1" }], [], { adjacentToLand: true, lakeEligible: false }, "placeable", "required"],
+  [54, "RESOURCE_PITCH", "Base/modules/base-standard/data/resources-v2.xml", "LOC_RESOURCE_PITCH_NAME", "LOC_ANT_RESOURCE_PITCH_TOOLTIP", "RESOURCECLASS_BONUS", 10, ["AGE_EXPLORATION", "AGE_MODERN"], [], 3, [{ YieldType: "YIELD_PRODUCTION", YieldChange: "1" }, { YieldType: "YIELD_GOLD", YieldChange: "1" }], [], {}, "placeable", "required"],
+] as const satisfies readonly OfficialResourceRow[];
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) {
+    deepFreeze(child);
+  }
+  return Object.freeze(value);
+}
+
+function dispositionRationale(status: ResourcePlaceabilityStatus | ResourceStrategyRequiredStatus): string {
+  if (status === "required") return "Official map-placement constraints exist, so resource strategy coverage is required.";
+  if (status === "blocked") {
+    return "Strategy coverage is blocked until the no-biome-row resource receives a source-backed map-placement disposition.";
+  }
+  if (status === "placeable") return "Official Resource_ValidBiomes rows define map placement constraints.";
+  if (status === "conditional") {
+    return "Official Resources row exists, but no valid age or biome rows were found in the base-standard corpus files.";
+  }
+  return "No official Resource_ValidBiomes rows were found in the base-standard corpus files.";
+}
+
+function toEntry(row: OfficialResourceRow): OfficialResourceCorpusEntry {
+  const [
+    staticResourceRowSlot,
+    resourceType,
+    sourceFile,
+    name,
+    tooltip,
+    baseClass,
+    weight,
+    validAges,
+    ageClassOverrides,
+    validBiomeConstraintCount,
+    yieldChanges,
+    typeTags,
+    distribution,
+    placeabilityStatus,
+    strategyRequiredStatus,
+  ] = row;
+
+  return {
+    resourceType,
+    staticResourceRowSlot,
+    staticSource: { file: sourceFile, table: "Resources" },
+    name,
+    tooltip,
+    baseClass,
+    weight,
+    runtimeId: {
+      status: "unverified",
+      value: null,
+      evidence: [],
+      rationale: UNVERIFIED_RUNTIME_ID_RATIONALE,
+    },
+    validAges,
+    ageClassOverrides,
+    officialPlacementConstraints: {
+      hasOfficialBiomeConstraints: validBiomeConstraintCount > 0,
+      validBiomeConstraintCount,
+      sourceTables:
+        validBiomeConstraintCount > 0
+          ? [{ file: sourceFile, table: "Resource_ValidBiomes" }]
+          : [],
+      placementFlags: distribution,
+    },
+    yieldChanges,
+    typeTags,
+    placeability: {
+      status: placeabilityStatus,
+      rationale: dispositionRationale(placeabilityStatus),
+    },
+    strategyRequired: {
+      status: strategyRequiredStatus,
+      rationale: dispositionRationale(strategyRequiredStatus),
+    },
+  };
+}
+
+export const OFFICIAL_RESOURCE_CORPUS = deepFreeze(OFFICIAL_RESOURCE_ROWS.map(toEntry));
+
+export const OFFICIAL_RESOURCE_CORPUS_ARTIFACT = {
+  source: {
+    authority: "civ7-official-resources",
+    module: "base-standard",
+    order: "base-standard.modinfo Resources row order",
+    runtimeIdStatus: "unverified",
+    sourceFiles: BASE_STANDARD_RESOURCE_FILES,
+  },
+  resources: OFFICIAL_RESOURCE_CORPUS,
+} as const satisfies OfficialResourceCorpusArtifact;
+
+export const OFFICIAL_RESOURCE_TYPE_ORDER = deepFreeze(OFFICIAL_RESOURCE_CORPUS.map(
+  (entry) => entry.resourceType
+) as OfficialResourceType[]);
+
+export const OFFICIAL_RESOURCE_BY_TYPE = deepFreeze(
+  Object.fromEntries(OFFICIAL_RESOURCE_CORPUS.map((entry) => [entry.resourceType, entry]))
+) as Readonly<Record<OfficialResourceType, OfficialResourceCorpusEntry>>;
+
+deepFreeze(OFFICIAL_RESOURCE_CORPUS_ARTIFACT);

--- a/mods/mod-swooper-maps/src/domain/resources/corpus/types.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/corpus/types.ts
@@ -1,0 +1,109 @@
+export type OfficialResourceType = `RESOURCE_${string}`;
+export type OfficialAgeType = `AGE_${string}`;
+export type OfficialResourceClassType = `RESOURCECLASS_${string}`;
+export type OfficialYieldType = `YIELD_${string}`;
+export type OfficialResourceTag = string;
+
+export type ResourceRuntimeIdStatus = "unverified" | "verified" | "mismatch" | "blocked";
+export type ResourcePlaceabilityStatus = "placeable" | "conditional" | "not-map-placed" | "unknown";
+export type ResourceStrategyRequiredStatus = "required" | "not-required" | "blocked";
+
+export type RuntimeEvidenceRef = {
+  readonly source: string;
+  readonly detail: string;
+};
+
+export type ResourceRuntimeId =
+  | {
+      readonly status: "unverified";
+      readonly value: null;
+      readonly evidence: readonly [];
+      readonly rationale: string;
+    }
+  | {
+      readonly status: "verified";
+      readonly value: number;
+      readonly evidence: readonly RuntimeEvidenceRef[];
+      readonly verifiedResourceType: OfficialResourceType;
+    }
+  | {
+      readonly status: "mismatch";
+      readonly value: number;
+      readonly expectedStaticResourceRowSlot: number;
+      readonly observedResourceType: OfficialResourceType;
+      readonly evidence: readonly RuntimeEvidenceRef[];
+    }
+  | {
+      readonly status: "blocked";
+      readonly value: null;
+      readonly blocker: string;
+      readonly nextProof: string;
+    };
+
+export type ResourceSourceRef = {
+  readonly file: string;
+  readonly table: string;
+};
+
+export type ResourceClassOverride = {
+  readonly age: OfficialAgeType;
+  readonly resourceClass: OfficialResourceClassType;
+  readonly sourceFile: string;
+};
+
+export type ResourceYieldChange = {
+  readonly YieldType: OfficialYieldType;
+  readonly YieldChange: string;
+};
+
+export type ResourceDistributionFacts = {
+  readonly adjacentToLand?: boolean;
+  readonly lakeEligible?: boolean;
+  readonly staple?: boolean;
+  readonly minimumPerHemisphere?: number;
+  readonly hemisphereUnique?: boolean;
+  readonly bonusResourceSlots?: number;
+  readonly unlocksCiv?: boolean;
+  readonly tradeable?: boolean;
+};
+
+export type OfficialPlacementConstraintSummary = {
+  readonly hasOfficialBiomeConstraints: boolean;
+  readonly validBiomeConstraintCount: number;
+  readonly sourceTables: readonly ResourceSourceRef[];
+  readonly placementFlags: ResourceDistributionFacts;
+};
+
+export type ResourceDisposition<TStatus extends string> = {
+  readonly status: TStatus;
+  readonly rationale: string;
+};
+
+export type OfficialResourceCorpusEntry = {
+  readonly resourceType: OfficialResourceType;
+  readonly staticResourceRowSlot: number;
+  readonly staticSource: ResourceSourceRef;
+  readonly name: string;
+  readonly tooltip: string;
+  readonly baseClass: OfficialResourceClassType;
+  readonly weight: number;
+  readonly runtimeId: ResourceRuntimeId;
+  readonly validAges: readonly OfficialAgeType[];
+  readonly ageClassOverrides: readonly ResourceClassOverride[];
+  readonly officialPlacementConstraints: OfficialPlacementConstraintSummary;
+  readonly yieldChanges: readonly ResourceYieldChange[];
+  readonly typeTags: readonly OfficialResourceTag[];
+  readonly placeability: ResourceDisposition<ResourcePlaceabilityStatus>;
+  readonly strategyRequired: ResourceDisposition<ResourceStrategyRequiredStatus>;
+};
+
+export type OfficialResourceCorpusArtifact = {
+  readonly source: {
+    readonly authority: "civ7-official-resources";
+    readonly module: "base-standard";
+    readonly order: "base-standard.modinfo Resources row order";
+    readonly runtimeIdStatus: "unverified";
+    readonly sourceFiles: readonly string[];
+  };
+  readonly resources: readonly OfficialResourceCorpusEntry[];
+};

--- a/mods/mod-swooper-maps/src/domain/resources/earthlike-expectations/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/earthlike-expectations/index.ts
@@ -1,0 +1,11 @@
+export * from "./official-earthlike.js";
+export type {
+  EarthlikeResourceExpectation,
+  EarthlikeResourceExpectationsArtifact,
+  ResourceExpectationEvidence,
+  ResourceExpectationEvidenceStrength,
+  ResourceExpectationGroupId,
+  ResourceExpectationRangeEvidence,
+  ResourceExpectationStatus,
+  ResourceExpectedCountRange,
+} from "./types.js";

--- a/mods/mod-swooper-maps/src/domain/resources/earthlike-expectations/official-earthlike.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/earthlike-expectations/official-earthlike.ts
@@ -1,0 +1,236 @@
+import {
+  OFFICIAL_RESOURCE_BY_TYPE,
+  OFFICIAL_RESOURCE_CORPUS,
+} from "../corpus/official-base-standard.js";
+import type { OfficialResourceType } from "../corpus/types.js";
+import type {
+  EarthlikeResourceExpectation,
+  EarthlikeResourceExpectationsArtifact,
+  ResourceExpectationEvidence,
+  ResourceExpectationGroupId,
+  ResourceExpectationRangeEvidence,
+  ResourceExpectationStatus,
+} from "./types.js";
+
+const BASELINE = "standard-earthlike-map" as const;
+const RUNTIME_ID_STATUS = "unverified" as const;
+const BLOCKED_ROW_TYPES = new Set<OfficialResourceType>([
+  "RESOURCE_GOLD_DISTANT_LANDS",
+  "RESOURCE_SILVER_DISTANT_LANDS",
+  "RESOURCE_LAPIS_LAZULI",
+  "RESOURCE_CLOVES",
+  "RESOURCE_NICKEL",
+]);
+
+type ExpectationDefinition = {
+  readonly resourceType: OfficialResourceType;
+  readonly groupId: ResourceExpectationGroupId;
+  readonly earthlikePredicate: string;
+  readonly range: readonly [min: number, target: number, max: number];
+  readonly rangeEvidence?: ResourceExpectationRangeEvidence;
+  readonly conditionMultipliers: readonly string[];
+  readonly scarcityClass: string;
+  readonly habitatEvidence?: ResourceExpectationEvidence["habitat"];
+  readonly rangeStrength?: ResourceExpectationEvidence["range"];
+  readonly proxyRequirements?: readonly string[];
+  readonly caveats?: readonly string[];
+};
+
+const DEFINITIONS = [
+  def("RESOURCE_FISH", "aquatic-coastal-navigable-river", "Broad coastal shelf, estuary, and upwelling fishery.", [6, 9, 12], ["eligible coast/shelf up", "upwelling/estuary up", "ice/deep-ocean/lakes down"], "common"),
+  def("RESOURCE_PEARLS", "aquatic-coastal-navigable-river", "Warm shallow protected coast, reef, lagoon, and shelf.", [2, 3, 5], ["tropical/subtropical reef up", "temperate/cold down", "no warm coast zero"], "scarce"),
+  def("RESOURCE_WHALES", "aquatic-coastal-navigable-river", "Productive cold or temperate coastal shelf, upwelling, banks, and migration corridors.", [1, 2, 3], ["cold/temperate shelf up", "large oceans up", "tropical abundance down", "lakes zero"], "rare signature"),
+  def("RESOURCE_CRABS", "aquatic-coastal-navigable-river", "Estuary, delta, brackish bay, shallow coast, and navigable river mouth or floodplain.", [4, 7, 10], ["estuaries/navigable rivers up", "seagrass/warm shallows up", "cold/deep/open coast down"], "common local", { proxyRequirements: ["navigable-river mouth or floodplain proxy"] }),
+  def("RESOURCE_COWRIE", "aquatic-coastal-navigable-river", "Warm tropical reef, rock, coral coast, and protected shallows.", [1, 2, 4], ["tropical reef/island chains up", "temperate down", "lakes/cold zero"], "scarce local"),
+  def("RESOURCE_TURTLES", "aquatic-coastal-navigable-river", "Warm tropical or subtropical coast with nesting beach, seagrass, and reef habitat.", [1, 2, 3], ["tropical/subtropical shallows up", "seagrass/reef/islands up", "cold/open/deep down", "lakes zero"], "rare signature"),
+
+  def("RESOURCE_COTTON", "cultivated-plantation-medicinal", "Warm frost-free alluvial or irrigated cotton belt.", [6, 8, 12], ["floodplain/river up", "warm grass/plains up", "cold down", "desert only with water"], "common"),
+  def("RESOURCE_DATES", "cultivated-plantation-medicinal", "Hot arid oasis or groundwater-fed desert palm.", [2, 3, 5], ["oasis/desert water up", "humid/cold zero"], "scarce local"),
+  def("RESOURCE_DYES", "cultivated-plantation-medicinal", "Coastal biological dye source under official marine/coast rules.", [2, 3, 5], ["warm coast/islands up", "inland zero"], "scarce coastal", { proxyRequirements: ["marine/coast lane despite cultivated group"] }),
+  def("RESOURCE_INCENSE", "cultivated-plantation-medicinal", "Arid dry woodland or desert-edge incense resin habitat.", [2, 3, 5], ["savanna/desert dry woodland up", "humid/cold down"], "scarce"),
+  def("RESOURCE_SILK", "cultivated-plantation-medicinal", "Warm temperate or subtropical sericulture and mulberry alluvial zone.", [4, 6, 8], ["river/floodplain up", "humid grass/plains up", "arid/cold down"], "moderate"),
+  def("RESOURCE_WINE", "cultivated-plantation-medicinal", "Sunny temperate to subtropical dry-season viticulture.", [4, 6, 8], ["grass/plains up", "dry-summer up", "humid tropics down", "frost down"], "moderate"),
+  def("RESOURCE_COCOA", "cultivated-plantation-medicinal", "Humid tropical shaded forest plantation.", [8, 10, 12], ["rainforest/wet tropics up", "arid/cold zero"], "regional abundant"),
+  def("RESOURCE_SPICES", "cultivated-plantation-medicinal", "Humid forest spice belt in tropical or subtropical conditions.", [8, 10, 12], ["rainforest/forest up", "wet tropics up", "dry plains down"], "regional abundant"),
+  def("RESOURCE_SUGAR", "cultivated-plantation-medicinal", "Warm wet alluvial tropics or subtropics.", [8, 10, 12], ["floodplain/river/wet tropics up", "arid without irrigation zero", "cold zero"], "regional abundant"),
+  def("RESOURCE_TEA", "cultivated-plantation-medicinal", "Humid acidic upland or cool subtropical tea zone.", [8, 10, 12], ["hills up", "wet/cool up", "arid/desert zero"], "regional abundant", { proxyRequirements: ["highland or relief proxy"] }),
+  def("RESOURCE_COFFEE", "cultivated-plantation-medicinal", "Humid tropical or subtropical highland or shaded tropical coffee belt.", [16, 18, 20], ["tropical/hills/forest up", "arid/cold zero"], "common anchored", { proxyRequirements: ["highland or relief proxy"] }),
+  def("RESOURCE_TOBACCO", "cultivated-plantation-medicinal", "Frost-free warm drained soils with drier ripening window.", [16, 18, 20], ["grass/plains up", "savanna/forest up", "waterlogging/excess rain down"], "common anchored"),
+  def("RESOURCE_CITRUS", "cultivated-plantation-medicinal", "Subtropical or tropical sunny orchard, frost-limited and well-drained.", [16, 18, 20], ["warm grass/plains up", "alluvial up", "frost zero", "severe arid down unless irrigated"], "common anchored"),
+  def("RESOURCE_QUININE", "cultivated-plantation-medicinal", "Humid tropical montane medicinal bark constrained to official forest/savanna lanes.", [16, 18, 20], ["wet forest/highland proxy up", "arid/desert zero"], "common anchored ecology-constrained", { proxyRequirements: ["highland or relief proxy"] }),
+  def("RESOURCE_MANGOS", "cultivated-plantation-medicinal", "Tropical or subtropical frost-free fruit belt, often monsoonal.", [3, 5, 7], ["tropical up", "rainforest up", "cold zero", "excessive wet at flowering slightly down"], "moderate tropical"),
+  def("RESOURCE_RICE", "cultivated-plantation-medicinal", "Wetland, paddy, delta, marsh, and monsoon lowland.", [4, 6, 8], ["marsh/mangrove/river/floodplain up", "arid without water zero"], "moderate common"),
+  def("RESOURCE_CLOVES", "cultivated-plantation-medicinal", "Blocked: no official valid biome row in the current corpus.", [0, 0, 0], [], "blocked rare", blockedOptions()),
+  def("RESOURCE_FLAX", "cultivated-plantation-medicinal", "Cool-temperate to mild subtropical flax on well-drained loam.", [5, 7, 9], ["grass/plains up", "cool/mild up", "tropical wet/heat down"], "moderate"),
+
+  def("RESOURCE_CAMELS", "terrestrial-animal-forest-wild", "Arid plains/desert rangeland, sparse vegetation, and dryland corridors.", [2, 3, 5], ["arid/desert/plains up", "humid/forest/cold down"], "uncommon regional"),
+  def("RESOURCE_HIDES", "terrestrial-animal-forest-wild", "Broad grazing or wild-herbivore byproduct on open rangeland and cold-edge habitat.", [8, 11, 14], ["grass/plains/tundra up", "dense tropical/closed forest down"], "common"),
+  def("RESOURCE_HORSES", "terrestrial-animal-forest-wild", "Open temperate grassland/plains, steppe-like pasture, and low tree cover.", [4, 6, 8], ["grass/plains up", "high forest/desert/tundra down"], "standard strategic"),
+  def("RESOURCE_WOOL", "terrestrial-animal-forest-wild", "Hill or highland pastoral terrain with sheep/goat-compatible grazing.", [4, 6, 8], ["hills/highlands/arid/tundra up", "flat wet lowlands down"], "standard"),
+  def("RESOURCE_IVORY", "terrestrial-animal-forest-wild", "Savanna, wooded savanna, tropical forest edge, and watering-hole/desert-edge megafauna habitat.", [2, 3, 5], ["savanna/tropical/watering-hole up", "cold/highland down"], "rare regional"),
+  def("RESOURCE_FURS", "terrestrial-animal-forest-wild", "Cold or boreal forest, taiga, woodland edge, and small patchy pockets.", [2, 3, 5], ["taiga/tundra up", "savanna woodland up", "open tropical/grass down"], "rare patchy"),
+  def("RESOURCE_TRUFFLES", "terrestrial-animal-forest-wild", "Moist woodland-edge or host-tree proxy on legal grass/plains/tundra wet soils.", [2, 3, 5], ["moist wooded edge/grass hills up", "arid/cold down"], "uncommon patchy", { proxyRequirements: ["woodland or host-tree proxy"] }),
+  def("RESOURCE_RUBBER", "terrestrial-animal-forest-wild", "Humid tropical forest/rainforest, lowland high-rainfall forest product.", [2, 3, 4], ["tropical rainforest/forest up", "arid/cold/no tropics down"], "rare modern"),
+  def("RESOURCE_HARDWOOD", "terrestrial-animal-forest-wild", "Legal productive forest: tropical/mangrove hardwood or official tundra/taiga-bog forest analog.", [4, 6, 8], ["tropical forest/mangrove up", "tundra forest analog up", "open plains/grass down"], "standard forest", { caveats: ["Do not broaden to temperate forests without official or runtime proof."] }),
+  def("RESOURCE_WILD_GAME", "terrestrial-animal-forest-wild", "Diverse natural habitat, forest/grassland/tundra/marsh edge, and low cultivation pressure.", [6, 8, 10], ["high habitat diversity up", "monoclimatic/cultivated down"], "common natural"),
+  def("RESOURCE_LLAMAS", "terrestrial-animal-forest-wild", "Legal tropical hill/highland pastoral candidates, preferring hill/highland over rainforest lowland.", [1, 2, 4], ["tropical hills/highlands up", "lowland tropical down", "no tropical legal tiles zero"], "rare regional", { proxyRequirements: ["tropical hill or highland candidate histogram"] }),
+
+  def("RESOURCE_GOLD", "geological-mineral-gemstone-industrial", "Hydrothermal, orogenic, and epithermal lodes; placer only with alluvial proxy.", [16, 18, 20], ["hills/orogen up", "alluvial up", "outside official hills zero"], "common anchored", { proxyRequirements: ["orogeny or alluvial proxy"] }),
+  def("RESOURCE_GOLD_DISTANT_LANDS", "geological-mineral-gemstone-industrial", "Blocked: distant-lands treasure derivative lacks active official placement constraints.", [0, 0, 0], [], "blocked", blockedOptions()),
+  def("RESOURCE_SILVER", "geological-mineral-gemstone-industrial", "Hydrothermal, SEDEX/lithogene, and epithermal exposed cold/arid hills.", [16, 18, 20], ["tundra/desert hills up", "orogen up", "flat zero"], "common anchored", { proxyRequirements: ["orogeny proxy"] }),
+  def("RESOURCE_SILVER_DISTANT_LANDS", "geological-mineral-gemstone-industrial", "Blocked: distant-lands treasure derivative lacks active official placement constraints.", [0, 0, 0], [], "blocked", blockedOptions()),
+  def("RESOURCE_GYPSUM", "geological-mineral-gemstone-industrial", "Evaporite basin, playa, and arid or semiarid sedimentary basin.", [4, 6, 8], ["evaporite/sedimentary basin up", "desert up", "wet down"], "moderate", { proxyRequirements: ["evaporite or sedimentary basin proxy"] }),
+  def("RESOURCE_JADE", "geological-mineral-gemstone-industrial", "Metamorphic, subduction, and serpentinite jade, often drainage-adjacent.", [2, 3, 5], ["ultramafic/orogen up", "tropical/tundra drainage up", "no geology down"], "rare", { proxyRequirements: ["ultramafic or orogeny proxy"] }),
+  def("RESOURCE_KAOLIN", "geological-mineral-gemstone-industrial", "Intense weathering, hydrothermal alteration, and wet clay-rich flats.", [6, 8, 10], ["wetlands up", "tropical weathering up", "arid non-oasis down"], "common", { proxyRequirements: ["weathering or clay-flat proxy"] }),
+  def("RESOURCE_MARBLE", "geological-mineral-gemstone-industrial", "Metamorphosed limestone/carbonate belts near orogeny or contact metamorphism.", [4, 6, 8], ["carbonate plus orogen up", "hills up", "no carbonate down"], "moderate", { proxyRequirements: ["carbonate belt proxy"] }),
+  def("RESOURCE_IRON", "geological-mineral-gemstone-industrial", "BIF, skarn, magmatic, or hydrothermal iron in hills, cratons, and mountain belts.", [8, 11, 14], ["hills up", "craton/orogen up", "flat zero"], "common strategic", { proxyRequirements: ["craton or orogeny proxy"] }),
+  def("RESOURCE_SALT", "geological-mineral-gemstone-industrial", "Halite/evaporite flats, arid closed basins, and salt pans.", [5, 7, 9], ["desert/evaporite basin up", "coastal land-flat salt pan up", "humid down"], "moderate", { proxyRequirements: ["closed basin or evaporite proxy"] }),
+  def("RESOURCE_LAPIS_LAZULI", "geological-mineral-gemstone-industrial", "Blocked: no official valid biome row in the current corpus.", [0, 0, 0], [], "blocked very rare", blockedOptions()),
+  def("RESOURCE_NITER", "geological-mineral-gemstone-industrial", "Nitrate salts in arid soils/playas; cave or soil nitrate abstracted to flats.", [6, 8, 10], ["desert/closed basin up", "floodplain up", "humid down"], "moderate", { proxyRequirements: ["closed basin or arid soil proxy"] }),
+  def("RESOURCE_COAL", "geological-mineral-gemstone-industrial", "Ancient peat-swamp sedimentary basins and buried forest/wetland basins.", [6, 8, 10], ["sedimentary basin up", "forest/wetland up", "desert only with basin"], "common modern", { proxyRequirements: ["sedimentary basin proxy"] }),
+  def("RESOURCE_NICKEL", "geological-mineral-gemstone-industrial", "Blocked: no official valid biome row in the current corpus.", [0, 0, 0], [], "blocked rare", blockedOptions()),
+  def("RESOURCE_OIL", "geological-mineral-gemstone-industrial", "Petroleum system in sedimentary basin: source, reservoir, seal, and trap.", [5, 7, 9], ["sedimentary basin up", "desert/tundra/wetland basin up", "offshore zero unless authorized"], "moderate modern", { proxyRequirements: ["sedimentary basin or hydrocarbon basin proxy"] }),
+  def("RESOURCE_CLAY", "geological-mineral-gemstone-industrial", "Near-surface clay minerals in soils, sediments, water-contact, and weathering zones.", [6, 8, 10], ["wet/alluvial up", "tropical weathering up", "no wet/alluvial feature zero"], "common"),
+  def("RESOURCE_LIMESTONE", "geological-mineral-gemstone-industrial", "Marine carbonate sedimentary deposits, karst, and carbonate platforms.", [6, 9, 12], ["carbonate basin up", "hills/exposure up", "igneous terrain down"], "common industrial", { proxyRequirements: ["carbonate basin proxy"] }),
+  def("RESOURCE_TIN", "geological-mineral-gemstone-industrial", "Cassiterite greisen/granite lodes plus river or valley placers.", [8, 11, 14], ["granite/orogen up", "tropical/alluvial up", "no granite/placer down"], "moderate gameplay-common", { proxyRequirements: ["granite, orogeny, or placer proxy"] }),
+  def("RESOURCE_PITCH", "geological-mineral-gemstone-industrial", "Bitumen/asphaltum seeps, shallow tar sands, and hydrocarbon basin edge.", [3, 4, 6], ["hydrocarbon basin up", "near oil up", "no basin down"], "scarce", { proxyRequirements: ["hydrocarbon basin proxy"] }),
+  def("RESOURCE_RUBIES", "geological-mineral-gemstone-industrial", "Corundum in marble/metamorphic belts; basalt-hosted or placer only with source proxy.", [3, 4, 6], ["marble/metamorphic up", "tropical collision belt up", "flat tropical requires source"], "rare luxury", { proxyRequirements: ["metamorphic, marble, or collision-belt proxy"] }),
+] as const satisfies readonly ExpectationDefinition[];
+
+function def(
+  resourceType: OfficialResourceType,
+  groupId: ResourceExpectationGroupId,
+  earthlikePredicate: string,
+  range: readonly [number, number, number],
+  conditionMultipliers: readonly string[],
+  scarcityClass: string,
+  options: Partial<Omit<ExpectationDefinition, "resourceType" | "groupId" | "earthlikePredicate" | "range" | "conditionMultipliers" | "scarcityClass">> = {}
+): ExpectationDefinition {
+  return {
+    resourceType,
+    groupId,
+    earthlikePredicate,
+    range,
+    conditionMultipliers,
+    scarcityClass,
+    ...options,
+  };
+}
+
+function blockedOptions(): Partial<ExpectationDefinition> {
+  return {
+    rangeEvidence: "blocked",
+    habitatEvidence: "official",
+    rangeStrength: "official",
+    caveats: [
+      "Active expectation range remains zero until source-backed placement disposition changes.",
+    ],
+  };
+}
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) {
+    deepFreeze(child);
+  }
+  return Object.freeze(value);
+}
+
+function toExpectation(definition: ExpectationDefinition): EarthlikeResourceExpectation {
+  const corpusEntry = OFFICIAL_RESOURCE_BY_TYPE[definition.resourceType];
+  if (!corpusEntry) throw new Error(`Missing resource corpus entry for ${definition.resourceType}.`);
+
+  const corpusBlocked = corpusEntry.strategyRequired.status === "blocked";
+  const status: ResourceExpectationStatus = corpusBlocked ? "blocked" : "expected";
+  const [min, target, max] = corpusBlocked ? [0, 0, 0] : definition.range;
+  const rangeEvidence = corpusBlocked
+    ? "blocked"
+    : definition.rangeEvidence ?? "inference-backed";
+
+  if (BLOCKED_ROW_TYPES.has(definition.resourceType) !== corpusBlocked) {
+    throw new Error(`Blocked resource expectation drift for ${definition.resourceType}.`);
+  }
+
+  return {
+    resourceType: definition.resourceType,
+    groupId: definition.groupId,
+    corpusRef: {
+      resourceType: corpusEntry.resourceType,
+      staticResourceRowSlot: corpusEntry.staticResourceRowSlot,
+      runtimeIdStatus: RUNTIME_ID_STATUS,
+    },
+    status,
+    eligibleAges: corpusEntry.validAges,
+    officialConstraintSummary: corpusEntry.officialPlacementConstraints,
+    earthlikePredicate: definition.earthlikePredicate,
+    expectedCountRange: {
+      baseline: BASELINE,
+      min,
+      target,
+      max,
+      evidence: rangeEvidence,
+    },
+    conditionMultipliers: corpusBlocked ? [] : definition.conditionMultipliers,
+    scarcityClass: definition.scarcityClass,
+    operationObligation:
+      status === "blocked"
+        ? "Keep visible as blocked; do not place until source-backed disposition changes."
+        : "Future resource operation must satisfy this per-resource expectation before claiming coverage.",
+    statsProof:
+      status === "blocked"
+        ? "Stats must report zero active expectation and preserve blocked disposition."
+        : "Seed-matrix or in-game telemetry must compare placed counts against eligible-tile denominators before hard closure.",
+    evidenceStrength: {
+      legality: "official",
+      habitat: definition.habitatEvidence ?? "external",
+      range: definition.rangeStrength ?? (rangeEvidence === "blocked" ? "official" : "inferred"),
+    },
+    proxyRequirements: definition.proxyRequirements ?? [],
+    caveats: [
+      ...(definition.caveats ?? []),
+      ...(corpusEntry.typeTags.length > 0
+        ? [`Official type tags: ${corpusEntry.typeTags.join(", ")}.`]
+        : []),
+    ],
+  };
+}
+
+const DEFINITIONS_BY_TYPE = new Map(DEFINITIONS.map((definition) => [
+  definition.resourceType,
+  definition,
+]));
+
+export const EARTHLIKE_RESOURCE_EXPECTATIONS = deepFreeze(
+  OFFICIAL_RESOURCE_CORPUS.map((entry) => {
+    const definition = DEFINITIONS_BY_TYPE.get(entry.resourceType);
+    if (!definition) {
+      throw new Error(`Missing earthlike expectation definition for ${entry.resourceType}.`);
+    }
+    return toExpectation(definition);
+  })
+);
+
+export const EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT = deepFreeze({
+  source: {
+    authority: "resource-earthlike-expectations",
+    corpusArtifactId: "artifact:resources.corpus",
+    artifactId: "artifact:resources.earthlikeExpectations",
+    baseline: BASELINE,
+    runtimeIdStatus: RUNTIME_ID_STATUS,
+    hardCountGateEvidence: "runtime-calibrated",
+  },
+  resources: EARTHLIKE_RESOURCE_EXPECTATIONS,
+} as const satisfies EarthlikeResourceExpectationsArtifact);
+
+const definitionTypes = new Set(DEFINITIONS.map((entry) => entry.resourceType));
+if (definitionTypes.size !== DEFINITIONS.length) {
+  throw new Error("Duplicate resource earthlike expectations.");
+}
+if (EARTHLIKE_RESOURCE_EXPECTATIONS.length !== OFFICIAL_RESOURCE_CORPUS.length) {
+  throw new Error("Resource earthlike expectations must cover the official corpus.");
+}
+for (const corpusEntry of OFFICIAL_RESOURCE_CORPUS) {
+  if (!definitionTypes.has(corpusEntry.resourceType)) {
+    throw new Error(`Missing earthlike expectation for ${corpusEntry.resourceType}.`);
+  }
+}

--- a/mods/mod-swooper-maps/src/domain/resources/earthlike-expectations/types.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/earthlike-expectations/types.ts
@@ -1,0 +1,72 @@
+import type {
+  OfficialAgeType,
+  OfficialPlacementConstraintSummary,
+  OfficialResourceType,
+  ResourceRuntimeIdStatus,
+} from "../corpus/types.js";
+
+export type ResourceExpectationGroupId =
+  | "aquatic-coastal-navigable-river"
+  | "cultivated-plantation-medicinal"
+  | "terrestrial-animal-forest-wild"
+  | "geological-mineral-gemstone-industrial";
+
+export type ResourceExpectationStatus = "expected" | "conditional" | "blocked";
+export type ResourceExpectationRangeEvidence =
+  | "source-backed"
+  | "inference-backed"
+  | "blocked";
+export type ResourceExpectationEvidenceStrength =
+  | "official"
+  | "external"
+  | "inferred";
+
+export type ResourceExpectedCountRange = {
+  readonly baseline: "standard-earthlike-map";
+  readonly min: number;
+  readonly target: number;
+  readonly max: number;
+  readonly evidence: ResourceExpectationRangeEvidence;
+};
+
+export type ResourceExpectationCorpusRef = {
+  readonly resourceType: OfficialResourceType;
+  readonly staticResourceRowSlot: number;
+  readonly runtimeIdStatus: Extract<ResourceRuntimeIdStatus, "unverified">;
+};
+
+export type ResourceExpectationEvidence = {
+  readonly legality: ResourceExpectationEvidenceStrength;
+  readonly habitat: ResourceExpectationEvidenceStrength;
+  readonly range: ResourceExpectationEvidenceStrength;
+};
+
+export type EarthlikeResourceExpectation = {
+  readonly resourceType: OfficialResourceType;
+  readonly groupId: ResourceExpectationGroupId;
+  readonly corpusRef: ResourceExpectationCorpusRef;
+  readonly status: ResourceExpectationStatus;
+  readonly eligibleAges: readonly OfficialAgeType[];
+  readonly officialConstraintSummary: OfficialPlacementConstraintSummary;
+  readonly earthlikePredicate: string;
+  readonly expectedCountRange: ResourceExpectedCountRange;
+  readonly conditionMultipliers: readonly string[];
+  readonly scarcityClass: string;
+  readonly operationObligation: string;
+  readonly statsProof: string;
+  readonly evidenceStrength: ResourceExpectationEvidence;
+  readonly proxyRequirements: readonly string[];
+  readonly caveats: readonly string[];
+};
+
+export type EarthlikeResourceExpectationsArtifact = {
+  readonly source: {
+    readonly authority: "resource-earthlike-expectations";
+    readonly corpusArtifactId: "artifact:resources.corpus";
+    readonly artifactId: "artifact:resources.earthlikeExpectations";
+    readonly baseline: "standard-earthlike-map";
+    readonly runtimeIdStatus: "unverified";
+    readonly hardCountGateEvidence: "runtime-calibrated";
+  };
+  readonly resources: readonly EarthlikeResourceExpectation[];
+};

--- a/mods/mod-swooper-maps/src/domain/resources/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/index.ts
@@ -1,0 +1,2 @@
+export * from "./corpus/index.js";
+export * from "./earthlike-expectations/index.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/resources/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/resources/artifacts.ts
@@ -1,0 +1,343 @@
+import { Type, defineArtifact, type Static } from "@swooper/mapgen-core/authoring";
+import type {
+  EarthlikeResourceExpectationsArtifact,
+  OfficialResourceCorpusArtifact,
+} from "@mapgen/domain/resources";
+
+const SourceRefSchema = Type.Object(
+  {
+    file: Type.String(),
+    table: Type.String(),
+  },
+  { additionalProperties: false }
+);
+
+const RuntimeIdSchema = Type.Object(
+  {
+    status: Type.Literal("unverified"),
+    value: Type.Null(),
+    evidence: Type.Array(Type.Never(), { maxItems: 0 }),
+    rationale: Type.String(),
+  },
+  { additionalProperties: false }
+);
+
+const ResourceClassOverrideSchema = Type.Object(
+  {
+    age: Type.String({ pattern: "^AGE_" }),
+    resourceClass: Type.String({ pattern: "^RESOURCECLASS_" }),
+    sourceFile: Type.String(),
+  },
+  { additionalProperties: false }
+);
+
+const ResourceDistributionFactsSchema = Type.Object(
+  {
+    adjacentToLand: Type.Optional(Type.Boolean()),
+    lakeEligible: Type.Optional(Type.Boolean()),
+    staple: Type.Optional(Type.Boolean()),
+    minimumPerHemisphere: Type.Optional(Type.Integer({ minimum: 0 })),
+    hemisphereUnique: Type.Optional(Type.Boolean()),
+    bonusResourceSlots: Type.Optional(Type.Integer({ minimum: 0 })),
+    unlocksCiv: Type.Optional(Type.Boolean()),
+    tradeable: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false }
+);
+
+const PlacementConstraintsSchema = Type.Object(
+  {
+    hasOfficialBiomeConstraints: Type.Boolean(),
+    validBiomeConstraintCount: Type.Integer({ minimum: 0 }),
+    sourceTables: Type.Array(SourceRefSchema),
+    placementFlags: ResourceDistributionFactsSchema,
+  },
+  { additionalProperties: false }
+);
+
+const YieldChangeSchema = Type.Object(
+  {
+    YieldType: Type.String({ pattern: "^YIELD_" }),
+    YieldChange: Type.String(),
+  },
+  { additionalProperties: false }
+);
+
+const ResourceDispositionSchema = <TStatus extends string>(statuses: readonly TStatus[]) =>
+  Type.Object(
+    {
+      status: Type.Union(statuses.map((status) => Type.Literal(status))),
+      rationale: Type.String(),
+    },
+    { additionalProperties: false }
+  );
+
+const ResourceCorpusEntrySchema = Type.Object(
+  {
+    resourceType: Type.String({ pattern: "^RESOURCE_" }),
+    staticResourceRowSlot: Type.Integer({ minimum: 0 }),
+    staticSource: SourceRefSchema,
+    name: Type.String(),
+    tooltip: Type.String(),
+    baseClass: Type.String({ pattern: "^RESOURCECLASS_" }),
+    weight: Type.Integer({ minimum: 0 }),
+    runtimeId: RuntimeIdSchema,
+    validAges: Type.Array(Type.String({ pattern: "^AGE_" })),
+    ageClassOverrides: Type.Array(ResourceClassOverrideSchema),
+    officialPlacementConstraints: PlacementConstraintsSchema,
+    yieldChanges: Type.Array(YieldChangeSchema),
+    typeTags: Type.Array(Type.String()),
+    placeability: ResourceDispositionSchema([
+      "placeable",
+      "conditional",
+      "not-map-placed",
+      "unknown",
+    ]),
+    strategyRequired: ResourceDispositionSchema(["required", "not-required", "blocked"]),
+  },
+  { additionalProperties: false }
+);
+
+export const ResourceCorpusArtifactSchema = Type.Unsafe<OfficialResourceCorpusArtifact>(
+  Type.Object(
+    {
+      source: Type.Object(
+        {
+          authority: Type.Literal("civ7-official-resources"),
+          module: Type.Literal("base-standard"),
+          order: Type.Literal("base-standard.modinfo Resources row order"),
+          runtimeIdStatus: Type.Literal("unverified"),
+          sourceFiles: Type.Array(Type.String()),
+        },
+        { additionalProperties: false }
+      ),
+      resources: Type.Array(ResourceCorpusEntrySchema),
+    },
+    {
+      additionalProperties: false,
+      description:
+        "Official base-standard resource corpus. Static resource row slots are source evidence only; runtime numeric ids remain unverified until in-game GameInfo.Resources proof is attached.",
+    }
+  )
+);
+
+export type ResourceCorpusArtifact = Static<typeof ResourceCorpusArtifactSchema>;
+
+const ExpectationGroupIdSchema = Type.Union([
+  Type.Literal("aquatic-coastal-navigable-river"),
+  Type.Literal("cultivated-plantation-medicinal"),
+  Type.Literal("terrestrial-animal-forest-wild"),
+  Type.Literal("geological-mineral-gemstone-industrial"),
+]);
+
+const EvidenceStrengthSchema = Type.Union([
+  Type.Literal("official"),
+  Type.Literal("external"),
+  Type.Literal("inferred"),
+]);
+
+const BlockedExpectationResourceTypeSchema = Type.Union([
+  Type.Literal("RESOURCE_CLOVES"),
+  Type.Literal("RESOURCE_GOLD_DISTANT_LANDS"),
+  Type.Literal("RESOURCE_LAPIS_LAZULI"),
+  Type.Literal("RESOURCE_NICKEL"),
+  Type.Literal("RESOURCE_SILVER_DISTANT_LANDS"),
+]);
+
+const ActiveExpectationResourceTypeSchema = Type.Union([
+  Type.Literal("RESOURCE_COTTON"),
+  Type.Literal("RESOURCE_DATES"),
+  Type.Literal("RESOURCE_DYES"),
+  Type.Literal("RESOURCE_FISH"),
+  Type.Literal("RESOURCE_GOLD"),
+  Type.Literal("RESOURCE_GYPSUM"),
+  Type.Literal("RESOURCE_INCENSE"),
+  Type.Literal("RESOURCE_IVORY"),
+  Type.Literal("RESOURCE_JADE"),
+  Type.Literal("RESOURCE_KAOLIN"),
+  Type.Literal("RESOURCE_MARBLE"),
+  Type.Literal("RESOURCE_PEARLS"),
+  Type.Literal("RESOURCE_SILK"),
+  Type.Literal("RESOURCE_SILVER"),
+  Type.Literal("RESOURCE_WINE"),
+  Type.Literal("RESOURCE_CAMELS"),
+  Type.Literal("RESOURCE_HIDES"),
+  Type.Literal("RESOURCE_HORSES"),
+  Type.Literal("RESOURCE_IRON"),
+  Type.Literal("RESOURCE_SALT"),
+  Type.Literal("RESOURCE_WOOL"),
+  Type.Literal("RESOURCE_COCOA"),
+  Type.Literal("RESOURCE_FURS"),
+  Type.Literal("RESOURCE_SPICES"),
+  Type.Literal("RESOURCE_SUGAR"),
+  Type.Literal("RESOURCE_TEA"),
+  Type.Literal("RESOURCE_TRUFFLES"),
+  Type.Literal("RESOURCE_NITER"),
+  Type.Literal("RESOURCE_WHALES"),
+  Type.Literal("RESOURCE_COFFEE"),
+  Type.Literal("RESOURCE_TOBACCO"),
+  Type.Literal("RESOURCE_CITRUS"),
+  Type.Literal("RESOURCE_COAL"),
+  Type.Literal("RESOURCE_OIL"),
+  Type.Literal("RESOURCE_QUININE"),
+  Type.Literal("RESOURCE_RUBBER"),
+  Type.Literal("RESOURCE_MANGOS"),
+  Type.Literal("RESOURCE_CLAY"),
+  Type.Literal("RESOURCE_FLAX"),
+  Type.Literal("RESOURCE_RUBIES"),
+  Type.Literal("RESOURCE_RICE"),
+  Type.Literal("RESOURCE_LIMESTONE"),
+  Type.Literal("RESOURCE_TIN"),
+  Type.Literal("RESOURCE_LLAMAS"),
+  Type.Literal("RESOURCE_HARDWOOD"),
+  Type.Literal("RESOURCE_WILD_GAME"),
+  Type.Literal("RESOURCE_CRABS"),
+  Type.Literal("RESOURCE_COWRIE"),
+  Type.Literal("RESOURCE_TURTLES"),
+  Type.Literal("RESOURCE_PITCH"),
+]);
+
+const ExpectationEvidenceSchema = Type.Object(
+  {
+    legality: EvidenceStrengthSchema,
+    habitat: EvidenceStrengthSchema,
+    range: EvidenceStrengthSchema,
+  },
+  { additionalProperties: false }
+);
+
+const ExpectationCorpusRefSchema = Type.Object(
+  {
+    resourceType: Type.String({ pattern: "^RESOURCE_" }),
+    staticResourceRowSlot: Type.Integer({ minimum: 0 }),
+    runtimeIdStatus: Type.Literal("unverified"),
+  },
+  { additionalProperties: false }
+);
+
+const BlockedExpectedCountRangeSchema = Type.Object(
+  {
+    baseline: Type.Literal("standard-earthlike-map"),
+    min: Type.Literal(0),
+    target: Type.Literal(0),
+    max: Type.Literal(0),
+    evidence: Type.Literal("blocked"),
+  },
+  { additionalProperties: false }
+);
+
+const activeRange = (min: number, target: number, max: number) =>
+  Type.Object(
+    {
+      baseline: Type.Literal("standard-earthlike-map"),
+      min: Type.Literal(min),
+      target: Type.Literal(target),
+      max: Type.Literal(max),
+      evidence: Type.Union([Type.Literal("source-backed"), Type.Literal("inference-backed")]),
+    },
+    { additionalProperties: false }
+  );
+
+const ActiveExpectedCountRangeSchema = Type.Union([
+  activeRange(1, 2, 3),
+  activeRange(1, 2, 4),
+  activeRange(2, 3, 4),
+  activeRange(2, 3, 5),
+  activeRange(3, 4, 6),
+  activeRange(3, 5, 7),
+  activeRange(4, 6, 8),
+  activeRange(4, 7, 10),
+  activeRange(5, 7, 9),
+  activeRange(5, 9, 12),
+  activeRange(6, 8, 10),
+  activeRange(6, 8, 12),
+  activeRange(6, 9, 12),
+  activeRange(8, 10, 12),
+  activeRange(8, 11, 14),
+  activeRange(8, 14, 20),
+  activeRange(16, 18, 20),
+]);
+
+const BaseExpectationFieldsSchema = {
+  resourceType: Type.String({ pattern: "^RESOURCE_" }),
+  groupId: ExpectationGroupIdSchema,
+  corpusRef: ExpectationCorpusRefSchema,
+  eligibleAges: Type.Array(Type.String({ pattern: "^AGE_" })),
+  officialConstraintSummary: PlacementConstraintsSchema,
+  earthlikePredicate: Type.String(),
+  scarcityClass: Type.String(),
+  operationObligation: Type.String(),
+  statsProof: Type.String(),
+  evidenceStrength: ExpectationEvidenceSchema,
+  proxyRequirements: Type.Array(Type.String()),
+  caveats: Type.Array(Type.String()),
+} as const;
+
+const BlockedExpectationEntrySchema = Type.Object(
+  {
+    ...BaseExpectationFieldsSchema,
+    resourceType: BlockedExpectationResourceTypeSchema,
+    status: Type.Literal("blocked"),
+    expectedCountRange: BlockedExpectedCountRangeSchema,
+    conditionMultipliers: Type.Array(Type.Never(), { maxItems: 0 }),
+  },
+  { additionalProperties: false }
+);
+
+const ActiveExpectationEntrySchema = Type.Object(
+  {
+    ...BaseExpectationFieldsSchema,
+    resourceType: ActiveExpectationResourceTypeSchema,
+    status: Type.Union([Type.Literal("expected"), Type.Literal("conditional")]),
+    expectedCountRange: ActiveExpectedCountRangeSchema,
+    conditionMultipliers: Type.Array(Type.String()),
+  },
+  { additionalProperties: false }
+);
+
+const EarthlikeExpectationEntrySchema = Type.Union([
+  BlockedExpectationEntrySchema,
+  ActiveExpectationEntrySchema,
+]);
+
+export const ResourceEarthlikeExpectationsArtifactSchema =
+  Type.Unsafe<EarthlikeResourceExpectationsArtifact>(
+    Type.Object(
+      {
+        source: Type.Object(
+          {
+            authority: Type.Literal("resource-earthlike-expectations"),
+            corpusArtifactId: Type.Literal("artifact:resources.corpus"),
+            artifactId: Type.Literal("artifact:resources.earthlikeExpectations"),
+            baseline: Type.Literal("standard-earthlike-map"),
+            runtimeIdStatus: Type.Literal("unverified"),
+            hardCountGateEvidence: Type.Literal("runtime-calibrated"),
+          },
+          { additionalProperties: false }
+        ),
+        resources: Type.Array(EarthlikeExpectationEntrySchema),
+      },
+      {
+        additionalProperties: false,
+        description:
+          "Per-resource earthlike expectation contract. Ranges remain provisional until runtime-calibrated telemetry exists; runtime numeric ids remain unverified.",
+      }
+    )
+  );
+
+export type ResourceEarthlikeExpectationsArtifact = Static<
+  typeof ResourceEarthlikeExpectationsArtifactSchema
+>;
+
+export const resourceArtifacts = {
+  corpus: defineArtifact({
+    name: "resourceCorpus",
+    id: "artifact:resources.corpus",
+    schema: ResourceCorpusArtifactSchema,
+  }),
+  earthlikeExpectations: defineArtifact({
+    name: "resourceEarthlikeExpectations",
+    id: "artifact:resources.earthlikeExpectations",
+    schema: ResourceEarthlikeExpectationsArtifactSchema,
+  }),
+} as const;

--- a/mods/mod-swooper-maps/test/resources/resource-corpus-artifact.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-corpus-artifact.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { Value } from "typebox/value";
+
+import { OFFICIAL_RESOURCE_CORPUS_ARTIFACT } from "../../src/domain/resources/index.js";
+import {
+  ResourceCorpusArtifactSchema,
+  resourceArtifacts,
+} from "../../src/recipes/standard/stages/resources/artifacts.js";
+
+describe("resources corpus artifact", () => {
+  it("declares the resource-owned corpus artifact id without creating a stage shell", () => {
+    expect(resourceArtifacts.corpus.id).toBe("artifact:resources.corpus");
+    expect(resourceArtifacts.corpus.name).toBe("resourceCorpus");
+  });
+
+  it("publishes a corpus artifact with explicit static/runtime identity boundaries", () => {
+    const artifact = OFFICIAL_RESOURCE_CORPUS_ARTIFACT;
+
+    expect(artifact.source.authority).toBe("civ7-official-resources");
+    expect(artifact.source.order).toBe("base-standard.modinfo Resources row order");
+    expect(artifact.source.runtimeIdStatus).toBe("unverified");
+    expect(artifact.resources).toHaveLength(55);
+    expect(artifact.resources.every((entry) => entry.runtimeId.status === "unverified")).toBe(true);
+    expect(
+      artifact.resources.every(
+        (entry) =>
+          entry.staticSource.table === "Resources" &&
+          entry.placeability.status.length > 0 &&
+          entry.strategyRequired.status.length > 0
+      )
+    ).toBe(true);
+  });
+
+  it("rejects runtime id overclaims at the artifact schema boundary", () => {
+    const invalid = {
+      ...OFFICIAL_RESOURCE_CORPUS_ARTIFACT,
+      resources: [
+        {
+          ...OFFICIAL_RESOURCE_CORPUS_ARTIFACT.resources[0]!,
+          runtimeId: {
+            status: "verified",
+            value: OFFICIAL_RESOURCE_CORPUS_ARTIFACT.resources[0]!.staticResourceRowSlot,
+            evidence: [],
+            verifiedResourceType: OFFICIAL_RESOURCE_CORPUS_ARTIFACT.resources[0]!.resourceType,
+          },
+        },
+      ],
+    };
+
+    expect(Value.Check(ResourceCorpusArtifactSchema, OFFICIAL_RESOURCE_CORPUS_ARTIFACT)).toBe(true);
+    expect(Value.Check(ResourceCorpusArtifactSchema, invalid)).toBe(false);
+  });
+});

--- a/mods/mod-swooper-maps/test/resources/resource-corpus-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-corpus-contract.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  OFFICIAL_RESOURCE_CORPUS,
+  OFFICIAL_RESOURCE_CORPUS_ARTIFACT,
+  OFFICIAL_RESOURCE_TYPE_ORDER,
+  type OfficialResourceType,
+} from "../../src/domain/resources/index.js";
+
+const repoRoot = join(import.meta.dir, "../../../..");
+const officialRoot = join(repoRoot, ".civ7/outputs/resources");
+const baseStandardRoot = join(officialRoot, "Base/modules/base-standard");
+const resourceFiles = [
+  "Base/modules/base-standard/data/resources.xml",
+  "Base/modules/base-standard/data/resources-v2.xml",
+] as const;
+const ageResourceFiles = {
+  AGE_ANTIQUITY: [
+    "Base/modules/age-antiquity/data/resources.xml",
+    "Base/modules/age-antiquity/data/resources-v2.xml",
+  ],
+  AGE_EXPLORATION: [
+    "Base/modules/age-exploration/data/resources.xml",
+    "Base/modules/age-exploration/data/resources-v2.xml",
+  ],
+  AGE_MODERN: [
+    "Base/modules/age-modern/data/resources.xml",
+    "Base/modules/age-modern/data/resources-v2.xml",
+  ],
+} as const;
+
+function readOfficial(relativePath: string): string {
+  return readFileSync(join(officialRoot, relativePath), "utf8");
+}
+
+function extractSection(xml: string, section: string): string {
+  const match = xml.match(new RegExp(`<${section}>[\\s\\S]*?</${section}>`));
+  return match?.[0] ?? "";
+}
+
+function extractResourcesRows(relativePath: string): string[] {
+  const section = extractSection(readOfficial(relativePath), "Resources");
+  return Array.from(section.matchAll(/<Row\s+ResourceType="([^"]+)"/g), (match) => match[1]!);
+}
+
+function extractResourceTypesRows(relativePath: string): string[] {
+  const section = extractSection(readOfficial(relativePath), "Types");
+  return Array.from(section.matchAll(/<Row\s+Type="(RESOURCE_[^"]+)"\s+Kind="KIND_RESOURCE"/g), (match) => match[1]!);
+}
+
+function parseAttrs(row: string): Record<string, string> {
+  return Object.fromEntries(Array.from(row.matchAll(/([A-Za-z_]+)="([^"]*)"/g), (match) => [match[1]!, match[2]!]));
+}
+
+function normalizeDistribution(attrs: Record<string, string>) {
+  const keys = [
+    "AdjacentToLand",
+    "LakeEligible",
+    "Staple",
+    "MinimumPerHemisphere",
+    "HemisphereUnique",
+    "BonusResourceSlots",
+    "UnlocksCiv",
+    "Tradeable",
+  ];
+  const result: Record<string, boolean | number> = {};
+  for (const key of keys) {
+    if (!(key in attrs)) continue;
+    const normalizedKey = `${key[0]!.toLowerCase()}${key.slice(1)}`;
+    const value = attrs[key]!;
+    result[normalizedKey] = /^\d+$/.test(value) ? Number(value) : value === "true";
+  }
+  return result;
+}
+
+function collectOfficialFacts() {
+  const rows = new Map<OfficialResourceType, Record<string, string>>();
+  const ages = new Map<OfficialResourceType, string[]>();
+  const biomeCounts = new Map<OfficialResourceType, number>();
+  const yields = new Map<OfficialResourceType, Array<Record<string, string>>>();
+  const tags = new Map<OfficialResourceType, string[]>();
+
+  for (const file of resourceFiles) {
+    const xml = readOfficial(file);
+    for (const match of extractSection(xml, "Resources").matchAll(/<Row\s+([^>]*ResourceType="RESOURCE_[^"]+"[^>]*)\/>/g)) {
+      const attrs = parseAttrs(match[0]!);
+      attrs.sourceFile = file;
+      rows.set(attrs.ResourceType as OfficialResourceType, attrs);
+    }
+    for (const match of extractSection(xml, "Resource_ValidAges").matchAll(/<Row\s+([^>]*)\/>/g)) {
+      const attrs = parseAttrs(match[0]!);
+      const resourceType = attrs.ResourceType as OfficialResourceType;
+      ages.set(resourceType, [...(ages.get(resourceType) ?? []), attrs.AgeType!]);
+    }
+    for (const match of extractSection(xml, "Resource_ValidBiomes").matchAll(/<Row\s+([^>]*)\/>/g)) {
+      const attrs = parseAttrs(match[0]!);
+      const resourceType = attrs.ResourceType as OfficialResourceType;
+      biomeCounts.set(resourceType, (biomeCounts.get(resourceType) ?? 0) + 1);
+    }
+    for (const match of extractSection(xml, "Resource_YieldChanges").matchAll(/<Row\s+([^>]*)\/>/g)) {
+      const attrs = parseAttrs(match[0]!);
+      const resourceType = attrs.ResourceType as OfficialResourceType;
+      yields.set(resourceType, [
+        ...(yields.get(resourceType) ?? []),
+        { YieldType: attrs.YieldType!, YieldChange: attrs.YieldChange! },
+      ]);
+    }
+    for (const match of extractSection(xml, "TypeTags").matchAll(/<Row\s+([^>]*)\/>/g)) {
+      const attrs = parseAttrs(match[0]!);
+      if (!attrs.Type?.startsWith("RESOURCE_")) continue;
+      const resourceType = attrs.Type as OfficialResourceType;
+      tags.set(resourceType, [...(tags.get(resourceType) ?? []), attrs.Tag!]);
+    }
+  }
+
+  const classOverrides = new Map<OfficialResourceType, Array<Record<string, string>>>();
+  for (const [age, files] of Object.entries(ageResourceFiles)) {
+    for (const file of files) {
+      const resourcesSection = extractSection(readOfficial(file), "Resources");
+      for (const match of resourcesSection.matchAll(
+        /<Update>\s*<Where\s+ResourceType="(RESOURCE_[^"]+)"\/>\s*<Set\s+ResourceClassType="(RESOURCECLASS_[^"]+)"\/>\s*<\/Update>/g
+      )) {
+        const resourceType = match[1] as OfficialResourceType;
+        classOverrides.set(resourceType, [
+          ...(classOverrides.get(resourceType) ?? []),
+          { age, resourceClass: match[2]!, sourceFile: file },
+        ]);
+      }
+    }
+  }
+
+  return { rows, ages, biomeCounts, yields, tags, classOverrides };
+}
+
+describe("official resource corpus contract", () => {
+  it("records the base-standard Resources row-order corpus separately from runtime ids", () => {
+    const officialResourcesRowOrder = resourceFiles.flatMap(extractResourcesRows);
+
+    expect(OFFICIAL_RESOURCE_CORPUS).toHaveLength(55);
+    expect(OFFICIAL_RESOURCE_TYPE_ORDER).toEqual(officialResourcesRowOrder);
+    expect(new Set(OFFICIAL_RESOURCE_TYPE_ORDER).size).toBe(55);
+
+    for (const [index, entry] of OFFICIAL_RESOURCE_CORPUS.entries()) {
+      expect(entry.staticResourceRowSlot).toBe(index);
+      expect(entry.staticSource.table).toBe("Resources");
+      expect(entry.runtimeId.status).toBe("unverified");
+      expect(entry.runtimeId.value).toBeNull();
+      expect(entry.resourceType).toBe(officialResourcesRowOrder[index]);
+    }
+  });
+
+  it("guards against treating Types declaration order as the corpus order", () => {
+    const typesOrder = resourceFiles.flatMap(extractResourceTypesRows);
+
+    expect(new Set(typesOrder)).toEqual(new Set(OFFICIAL_RESOURCE_TYPE_ORDER));
+    expect(typesOrder).not.toEqual(OFFICIAL_RESOURCE_TYPE_ORDER);
+    expect(typesOrder[0]).toBe("RESOURCE_CAMELS");
+    expect(OFFICIAL_RESOURCE_TYPE_ORDER[0]).toBe("RESOURCE_COTTON");
+  });
+
+  it("keeps caveats explicit for runtime id proof and no-biome-row resources", () => {
+    const artifact = OFFICIAL_RESOURCE_CORPUS_ARTIFACT;
+    const rubies = OFFICIAL_RESOURCE_CORPUS.find((entry) => entry.resourceType === "RESOURCE_RUBIES");
+    const lotus = OFFICIAL_RESOURCE_CORPUS.find((entry) => entry.resourceType === "RESOURCE_LOTUS");
+    const blocked = OFFICIAL_RESOURCE_CORPUS.filter(
+      (entry) => entry.strategyRequired.status === "blocked"
+    );
+
+    expect(artifact.source.order).toBe("base-standard.modinfo Resources row order");
+    expect(artifact.source.runtimeIdStatus).toBe("unverified");
+    expect(rubies?.staticResourceRowSlot).toBe(44);
+    expect(rubies?.runtimeId.status).toBe("unverified");
+    expect(rubies?.validAges).toEqual(["AGE_ANTIQUITY", "AGE_EXPLORATION"]);
+    expect(rubies?.officialPlacementConstraints.validBiomeConstraintCount).toBe(4);
+    expect(lotus).toBeUndefined();
+    expect(blocked.map((entry) => entry.resourceType).sort()).toEqual([
+      "RESOURCE_CLOVES",
+      "RESOURCE_GOLD_DISTANT_LANDS",
+      "RESOURCE_LAPIS_LAZULI",
+      "RESOURCE_NICKEL",
+      "RESOURCE_SILVER_DISTANT_LANDS",
+    ]);
+  });
+
+  it("matches source-backed official row fields for every corpus entry", () => {
+    const facts = collectOfficialFacts();
+
+    for (const entry of OFFICIAL_RESOURCE_CORPUS) {
+      const row = facts.rows.get(entry.resourceType);
+      expect(row).toBeDefined();
+      expect(entry.name).toBe(row?.Name);
+      expect(entry.tooltip).toBe(row?.Tooltip);
+      expect(entry.staticSource).toEqual({ file: row?.sourceFile, table: "Resources" });
+      expect(entry.baseClass).toBe(row?.ResourceClassType);
+      expect(entry.weight).toBe(Number(row?.Weight));
+      expect(entry.validAges).toEqual(facts.ages.get(entry.resourceType) ?? []);
+      expect(entry.ageClassOverrides).toEqual(facts.classOverrides.get(entry.resourceType) ?? []);
+      expect(entry.officialPlacementConstraints.validBiomeConstraintCount).toBe(
+        facts.biomeCounts.get(entry.resourceType) ?? 0
+      );
+      expect(entry.officialPlacementConstraints.hasOfficialBiomeConstraints).toBe(
+        (facts.biomeCounts.get(entry.resourceType) ?? 0) > 0
+      );
+      expect(entry.officialPlacementConstraints.sourceTables).toEqual(
+        (facts.biomeCounts.get(entry.resourceType) ?? 0) > 0
+          ? [{ file: row?.sourceFile, table: "Resource_ValidBiomes" }]
+          : []
+      );
+      expect(entry.yieldChanges).toEqual(facts.yields.get(entry.resourceType) ?? []);
+      expect(entry.typeTags).toEqual(facts.tags.get(entry.resourceType) ?? []);
+      expect(entry.officialPlacementConstraints.placementFlags).toEqual(
+        normalizeDistribution(row ?? {})
+      );
+    }
+  });
+
+  it("matches base-standard modinfo resource file load order", () => {
+    const modinfo = readFileSync(join(baseStandardRoot, "base-standard.modinfo"), "utf8");
+    const loadedResourceFiles = Array.from(
+      modinfo.matchAll(/<Item>(data\/resources(?:-v2)?\.xml)<\/Item>/g),
+      (match) => `Base/modules/base-standard/${match[1]!}`
+    );
+
+    expect(loadedResourceFiles).toEqual([...resourceFiles]);
+    expect(OFFICIAL_RESOURCE_CORPUS_ARTIFACT.source.sourceFiles).toEqual([...resourceFiles]);
+  });
+});

--- a/mods/mod-swooper-maps/test/resources/resource-earthlike-expectations-artifact.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-earthlike-expectations-artifact.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Value } from "typebox/value";
+
+import {
+  EARTHLIKE_RESOURCE_EXPECTATIONS,
+  EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT,
+  OFFICIAL_RESOURCE_BY_TYPE,
+  OFFICIAL_RESOURCE_TYPE_ORDER,
+} from "../../src/domain/resources/index.js";
+import {
+  ResourceEarthlikeExpectationsArtifactSchema,
+  resourceArtifacts,
+} from "../../src/recipes/standard/stages/resources/artifacts.js";
+
+const blockedResources = [
+  "RESOURCE_CLOVES",
+  "RESOURCE_GOLD_DISTANT_LANDS",
+  "RESOURCE_LAPIS_LAZULI",
+  "RESOURCE_NICKEL",
+  "RESOURCE_SILVER_DISTANT_LANDS",
+] as const;
+
+const repoRoot = join(import.meta.dir, "../../../..");
+const sourceRoot = join(repoRoot, "mods/mod-swooper-maps/src/domain/resources/earthlike-expectations");
+
+describe("resource earthlike expectations artifact", () => {
+  it("declares the resource-owned earthlike expectations artifact id", () => {
+    expect(resourceArtifacts.earthlikeExpectations.id).toBe(
+      "artifact:resources.earthlikeExpectations"
+    );
+    expect(resourceArtifacts.earthlikeExpectations.name).toBe(
+      "resourceEarthlikeExpectations"
+    );
+  });
+
+  it("covers the official corpus exactly once in corpus order without feature leakage", () => {
+    const order = EARTHLIKE_RESOURCE_EXPECTATIONS.map((entry) => entry.resourceType);
+
+    expect(EARTHLIKE_RESOURCE_EXPECTATIONS).toHaveLength(55);
+    expect(order).toEqual(OFFICIAL_RESOURCE_TYPE_ORDER);
+    expect(new Set(order).size).toBe(55);
+    expect(order.every((resourceType) => resourceType.startsWith("RESOURCE_"))).toBe(true);
+    expect(order.some((resourceType) => resourceType.startsWith("FEATURE_"))).toBe(false);
+    expect(order).not.toContain("FEATURE_LOTUS");
+    expect(order).not.toContain("RESOURCE_LOTUS");
+  });
+
+  it("preserves corpus refs, official constraints, and unverified runtime boundary", () => {
+    for (const row of EARTHLIKE_RESOURCE_EXPECTATIONS) {
+      const corpus = OFFICIAL_RESOURCE_BY_TYPE[row.resourceType]!;
+
+      expect(row.corpusRef).toEqual({
+        resourceType: corpus.resourceType,
+        staticResourceRowSlot: corpus.staticResourceRowSlot,
+        runtimeIdStatus: "unverified",
+      });
+      expect(row.eligibleAges).toEqual(corpus.validAges);
+      expect(row.officialConstraintSummary).toEqual(corpus.officialPlacementConstraints);
+      expect(row.evidenceStrength.legality).toBe("official");
+      expect(row.expectedCountRange.baseline).toBe("standard-earthlike-map");
+      expect(row.expectedCountRange.min).toBeLessThanOrEqual(row.expectedCountRange.target);
+      expect(row.expectedCountRange.target).toBeLessThanOrEqual(row.expectedCountRange.max);
+      expect(Object.hasOwn(row, "runtimeId")).toBe(false);
+      expect(Object.hasOwn(row, "resourceId")).toBe(false);
+      expect(Object.hasOwn(row, "numericId")).toBe(false);
+    }
+  });
+
+  it("keeps corpus-blocked resources visible, blocked, and active-zero", () => {
+    const blocked = EARTHLIKE_RESOURCE_EXPECTATIONS.filter((entry) => entry.status === "blocked");
+
+    expect(blocked.map((entry) => entry.resourceType).sort()).toEqual([...blockedResources]);
+    for (const row of blocked) {
+      expect(OFFICIAL_RESOURCE_BY_TYPE[row.resourceType]!.strategyRequired.status).toBe("blocked");
+      expect(row.expectedCountRange).toEqual({
+        baseline: "standard-earthlike-map",
+        min: 0,
+        target: 0,
+        max: 0,
+        evidence: "blocked",
+      });
+      expect(row.conditionMultipliers).toEqual([]);
+      expect(row.operationObligation).toContain("do not place");
+      expect(row.statsProof).toContain("zero active expectation");
+    }
+  });
+
+  it("preserves crabs navigable-river eligibility as a per-resource caveat", () => {
+    const crabs = EARTHLIKE_RESOURCE_EXPECTATIONS.find(
+      (entry) => entry.resourceType === "RESOURCE_CRABS"
+    );
+
+    expect(crabs?.groupId).toBe("aquatic-coastal-navigable-river");
+    expect(crabs?.caveats.join("\n")).toContain("NAVIGABLE_RIVERS_ELIGIBLE");
+    expect(crabs?.proxyRequirements.join("\n")).toContain("navigable-river");
+  });
+
+  it("validates the artifact with a strict schema and rejects overclaims", () => {
+    expect(
+      Value.Check(ResourceEarthlikeExpectationsArtifactSchema, EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT)
+    ).toBe(true);
+
+    const first = EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT.resources[0]!;
+    const invalidExtraRuntimeField = {
+      ...EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT,
+      resources: [{ ...first, runtimeId: { status: "verified", value: 0 } }],
+    };
+    const invalidFeature = {
+      ...EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT,
+      resources: [{ ...first, resourceType: "FEATURE_LOTUS" }],
+    };
+    const invalidStatus = {
+      ...EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT,
+      resources: [{ ...first, status: "done" }],
+    };
+    const invalidMissingRangeField = {
+      ...EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT,
+      resources: [
+        {
+          ...first,
+          expectedCountRange: {
+            baseline: "standard-earthlike-map",
+            min: 1,
+            target: 2,
+            evidence: "inference-backed",
+          },
+        },
+      ],
+    };
+    const invalidBlockedLeak = {
+      ...EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT,
+      resources: [
+        {
+          ...EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT.resources.find(
+            (entry) => entry.resourceType === "RESOURCE_CLOVES"
+          )!,
+          expectedCountRange: {
+            baseline: "standard-earthlike-map",
+            min: 0,
+            target: 1,
+            max: 3,
+            evidence: "inference-backed",
+          },
+        },
+      ],
+    };
+    const invalidBlockedAsActive = {
+      ...EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT,
+      resources: [
+        {
+          ...EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT.resources.find(
+            (entry) => entry.resourceType === "RESOURCE_CLOVES"
+          )!,
+          status: "expected",
+          expectedCountRange: {
+            baseline: "standard-earthlike-map",
+            min: 2,
+            target: 3,
+            max: 5,
+            evidence: "inference-backed",
+          },
+          conditionMultipliers: ["rainforest up"],
+        },
+      ],
+    };
+    const invalidRangeOrdering = {
+      ...EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT,
+      resources: [
+        {
+          ...first,
+          expectedCountRange: {
+            baseline: "standard-earthlike-map",
+            min: 10,
+            target: 2,
+            max: 1,
+            evidence: "inference-backed",
+          },
+        },
+      ],
+    };
+    const invalidRuntimeCalibratedWithoutTelemetry = {
+      ...EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT,
+      resources: [
+        {
+          ...first,
+          expectedCountRange: {
+            ...first.expectedCountRange,
+            evidence: "runtime-calibrated",
+          },
+        },
+      ],
+    };
+
+    expect(Value.Check(ResourceEarthlikeExpectationsArtifactSchema, invalidExtraRuntimeField)).toBe(false);
+    expect(Value.Check(ResourceEarthlikeExpectationsArtifactSchema, invalidFeature)).toBe(false);
+    expect(Value.Check(ResourceEarthlikeExpectationsArtifactSchema, invalidStatus)).toBe(false);
+    expect(Value.Check(ResourceEarthlikeExpectationsArtifactSchema, invalidMissingRangeField)).toBe(false);
+    expect(Value.Check(ResourceEarthlikeExpectationsArtifactSchema, invalidBlockedLeak)).toBe(false);
+    expect(Value.Check(ResourceEarthlikeExpectationsArtifactSchema, invalidBlockedAsActive)).toBe(false);
+    expect(Value.Check(ResourceEarthlikeExpectationsArtifactSchema, invalidRangeOrdering)).toBe(false);
+    expect(Value.Check(ResourceEarthlikeExpectationsArtifactSchema, invalidRuntimeCalibratedWithoutTelemetry)).toBe(false);
+  });
+
+  it("keeps the expectation artifact outside placement runtime behavior", () => {
+    const source = [
+      "index.ts",
+      "official-earthlike.ts",
+      "types.ts",
+    ].map((file) => readFileSync(join(sourceRoot, file), "utf8")).join("\n");
+
+    expect(source).not.toContain("@civ7/adapter");
+    expect(source).not.toContain("ResourceBuilder");
+    expect(source).not.toContain("placeResourceIntent");
+    expect(source).not.toContain("placement/ops");
+  });
+});

--- a/openspec/changes/resource-corpus-contract/.openspec.yaml
+++ b/openspec/changes/resource-corpus-contract/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-corpus-contract/design.md
+++ b/openspec/changes/resource-corpus-contract/design.md
@@ -1,0 +1,83 @@
+# Resource Corpus Contract Design
+
+## Decision
+
+The resource corpus lives in `mods/mod-swooper-maps/src/domain/resources`.
+It is a Swooper Maps domain contract because it describes official resource
+semantics consumed by future resource-stage strategy work. It is not adapter
+state: the adapter currently owns numeric candidate ids and engine feasibility.
+
+The corpus models `Resources` row order from `base-standard.modinfo` load order:
+
+```text
+Base/modules/base-standard/data/resources.xml
+Base/modules/base-standard/data/resources-v2.xml
+```
+
+This is named `staticResourceRowSlot`. It is source evidence, not runtime id
+proof. The `<Types>` declaration order is deliberately not used as corpus order,
+because it differs from `Resources` row order and would put `RESOURCE_CAMELS`
+before `RESOURCE_COTTON`.
+
+## Runtime Boundary
+
+Every corpus row has:
+
+```text
+runtimeId.status = "unverified"
+runtimeId.value = null
+```
+
+This prevents downstream stats and strategy code from joining adapter numeric
+diagnostics to symbolic resource names until runtime proof is attached. Later
+runtime work must use bounded in-game evidence such as `GameInfo.Resources`
+dump telemetry before a row can move to `verified` or `mismatch`.
+
+## Contract Shape
+
+The corpus entry records:
+
+- `resourceType`
+- `staticResourceRowSlot`
+- `staticSource`
+- display fields (`name`, `tooltip`)
+- `baseClass`
+- `weight`
+- `runtimeId`
+- `validAges`
+- `ageClassOverrides`
+- `officialPlacementConstraints`
+- `yieldChanges`
+- `typeTags`
+- `placeability`
+- `strategyRequired`
+
+The placement constraint field records source-backed constraint coverage and
+placement flags for this slice. Full per-row predicate implementation remains
+owned by downstream strategy batches, but missing official biome rows are
+already visible as `blocked` strategy-required dispositions.
+
+## Caveats Captured
+
+- `RESOURCE_GOLD_DISTANT_LANDS` and `RESOURCE_SILVER_DISTANT_LANDS` have
+  official `Resources` rows but no base-standard valid ages or biome rows in
+  the consulted corpus files.
+- `RESOURCE_LAPIS_LAZULI`, `RESOURCE_CLOVES`, and `RESOURCE_NICKEL` have valid
+  ages but no base-standard `Resource_ValidBiomes` rows in the consulted corpus
+  files.
+- `FEATURE_LOTUS` is not in the resource corpus.
+- SDK resource constants are not treated as authority for this slice.
+
+## Write Set
+
+- `mods/mod-swooper-maps/src/domain/resources/**`
+- `mods/mod-swooper-maps/src/domain/index.ts`
+- `mods/mod-swooper-maps/src/recipes/standard/stages/resources/artifacts.ts`
+- `mods/mod-swooper-maps/test/resources/**`
+- `openspec/changes/resource-corpus-contract/**`
+
+## Downstream Work
+
+The next slices can consume this contract to add earthlike expectations and
+resource-owned input/summary artifacts. Runtime id verification remains a later
+slice and must not be inferred from the static corpus.

--- a/openspec/changes/resource-corpus-contract/proposal.md
+++ b/openspec/changes/resource-corpus-contract/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+The resource distribution workstream needs a durable corpus contract before
+strategy batches can claim per-resource coverage. Current placement diagnostics
+group adapter numeric `resourceType` values, while official resource facts live
+in checked-in Civ7 XML. Without a resource-owned corpus, downstream work can
+accidentally treat static XML order, adapter candidate ids, and runtime
+`GameInfo.Resources` ids as the same thing.
+
+## Target Authority Refs
+
+- `openspec/changes/resource-distribution-planning`: resource corpus proof and
+  per-resource coverage requirements.
+- `openspec/changes/resource-stage-architecture`: `resources` target stage and
+  `artifact:resources.corpus` migration sequence.
+- `.civ7/outputs/resources/Base/modules/base-standard/base-standard.modinfo`:
+  official base-standard load order for `data/resources.xml` then
+  `data/resources-v2.xml`.
+- `.civ7/outputs/resources/Base/modules/base-standard/data/resources.xml` and
+  `resources-v2.xml`: official base-standard `Resources` rows.
+
+## What Changes
+
+- Add a `resources` domain corpus contract under `mods/mod-swooper-maps`.
+- Publish a static 55-row official base-standard corpus artifact with
+  `staticResourceRowSlot`, official source file/table, base class, valid ages,
+  age class overrides, placement constraint summary, distribution facts,
+  placeability disposition, and strategy-required disposition.
+- Keep runtime numeric id status explicit and unverified for every resource.
+- Add `artifact:resources.corpus` declaration without introducing a resource
+  stage shell or moving current placement behavior.
+- Add tests that lock `Resources` row order from `base-standard.modinfo` and
+  prove `<Types>` declaration order is not the corpus order.
+
+## Explicit Non-Goals
+
+- No `resources` stage shell, recipe order change, or movement of
+  `placement/plan-resources`.
+- No resource strategy tuning, group planners, or earthlike expectation ranges.
+- No runtime `GameInfo.Resources` id verification.
+- No generated-output, official submodule, lockfile, adapter constant, or SDK
+  constant edits.
+- No symbolic labels for adapter numeric placement diagnostics while runtime
+  ids remain unverified.
+
+## Verification Gates
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-corpus-contract.test.ts test/resources/resource-corpus-artifact.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate resource-corpus-contract --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/resource-corpus-contract/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-corpus-contract/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Resource Corpus Publishes Static Official Resource Identity
+
+The resource distribution workstream SHALL publish a resource-owned official
+corpus before resource strategies claim per-resource coverage.
+
+#### Scenario: Static corpus is derived
+- **WHEN** official base-standard resources are cataloged
+- **THEN** the corpus records every `Resources` row from
+  `data/resources.xml` and `data/resources-v2.xml` in
+  `base-standard.modinfo` load order
+- **AND** each row records its static source file, source table, row slot,
+  resource symbol, base class, valid ages, class overrides, placement constraint
+  coverage, distribution facts, placeability disposition, and
+  strategy-required disposition
+
+#### Scenario: Static row order is guarded
+- **WHEN** tests verify the corpus order
+- **THEN** they assert `Resources` row order rather than `<Types>` declaration
+  order
+- **AND** they prove `<Types>` order differs so static order cannot be treated
+  as runtime id proof by accident
+
+### Requirement: Resource Corpus Keeps Runtime Numeric IDs Unverified
+
+The resource corpus SHALL separate static official resource identity from
+runtime `GameInfo.Resources` numeric ids.
+
+#### Scenario: Runtime ids are not yet proven
+- **WHEN** the corpus is published before runtime proof exists
+- **THEN** every resource row records runtime id status as `unverified`
+- **AND** runtime numeric id value is null
+- **AND** adapter numeric placement diagnostics are not labeled with symbolic
+  resource names through this corpus
+
+#### Scenario: Resource corpus artifact is declared
+- **WHEN** the corpus artifact is introduced
+- **THEN** its id is `artifact:resources.corpus`
+- **AND** it does not introduce a resource stage shell, move placement resource
+  planning, or change placement behavior

--- a/openspec/changes/resource-corpus-contract/tasks.md
+++ b/openspec/changes/resource-corpus-contract/tasks.md
@@ -1,0 +1,28 @@
+## 1. Corpus Contract
+
+- [x] 1.1 Add a resource domain corpus owner.
+- [x] 1.2 Record all 55 official base-standard `Resources` rows.
+- [x] 1.3 Separate `staticResourceRowSlot` from runtime numeric id status.
+- [x] 1.4 Record source files, base class, valid ages, class overrides,
+  placement constraint summary, distribution facts, placeability disposition,
+  and strategy-required disposition.
+
+## 2. Artifact Boundary
+
+- [x] 2.1 Add `artifact:resources.corpus` declaration.
+- [x] 2.2 Avoid introducing a resources stage shell or moving placement behavior.
+
+## 3. Tests
+
+- [x] 3.1 Assert official corpus count, uniqueness, and row slots.
+- [x] 3.2 Assert base-standard `Resources` row order from modinfo load order.
+- [x] 3.3 Assert `<Types>` declaration order is not used as the corpus order.
+- [x] 3.4 Assert runtime ids remain unverified and caveats stay visible.
+- [x] 3.5 Assert resource corpus artifact id and boundary.
+
+## 4. Review And Verification
+
+- [x] 4.1 Complete framed agent review before implementation.
+- [x] 4.2 Run focused resource tests and package check.
+- [x] 4.3 Run OpenSpec validation and `git diff --check`.
+- [x] 4.4 Commit the Graphite slice and leave the worktree clean.

--- a/openspec/changes/resource-corpus-contract/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-corpus-contract/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,10 @@
+# Downstream Realignment Ledger
+
+| Surface | Disposition | Notes |
+|---|---|---|
+| `resource-earthlike-expectations` slice | patch-needed downstream | Consume `OFFICIAL_RESOURCE_CORPUS` and preserve blocked caveats until source-backed dispositions exist. |
+| `resource-artifact-boundary` slice | patch-needed downstream | Use `artifact:resources.corpus` as a resource-owned artifact input; do not move placement resource plan in this slice. |
+| Runtime proof slice | patch-needed downstream | Verify `GameInfo.Resources` mapping using bounded in-game telemetry before setting runtime ids to `verified` or `mismatch`. |
+| Adapter `PLACEABLE_RESOURCE_TYPE_IDS` | no patch in this slice | Remains numeric candidate catalog only; symbolic mapping deferred to runtime proof. |
+| SDK resource constants | no patch in this slice | Stale constants observed, but corpus contract does not edit SDK constants. |
+| Official `.civ7` resources | no patch | Read-only authority source. |

--- a/openspec/changes/resource-corpus-contract/workstream/phase-record.md
+++ b/openspec/changes/resource-corpus-contract/workstream/phase-record.md
@@ -1,0 +1,52 @@
+# Phase Record: Resource Corpus Contract
+
+## Objective
+
+Create the resource-owned official corpus contract required by the resource
+stage architecture while preserving the runtime numeric id proof boundary.
+
+## Repo State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
+- Branch: `codex/resource-corpus-contract`
+- Parent slice: `codex/resource-stage-architecture`
+- Write set: resource domain corpus, `artifact:resources.corpus`, focused tests,
+  OpenSpec records.
+
+## Agent Wave
+
+- Volta: official corpus authority review. Outcome: use base-standard
+  `Resources` row order from modinfo load order; lock 55 rows; guard against
+  `<Types>` order; lotus is feature, not resource.
+- Fermat: runtime boundary review. Outcome: runtime symbolic id mapping remains
+  unverified; do not label adapter numeric diagnostics symbolically.
+- Lagrange: architecture/spec readiness review. Outcome: add a new
+  `resources` domain and artifact declaration, but no stage shell.
+
+## Implementation Notes
+
+- `staticResourceRowSlot` records official source row order only.
+- Every `runtimeId` is `unverified` with `value: null`.
+- Five no-biome-row caveats are visible as blocked strategy-required
+  dispositions.
+- The artifact id is `artifact:resources.corpus`.
+
+## Verification
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-corpus-contract.test.ts test/resources/resource-corpus-artifact.test.ts`
+  - Passed: 8 tests, 1072 assertions.
+- `bun run --cwd mods/mod-swooper-maps check`
+  - Passed.
+- `bun run openspec -- validate resource-corpus-contract --strict`
+  - Passed.
+- `bun run openspec:validate`
+  - Passed: 20 items.
+- `git diff --check`
+  - Passed.
+
+## Closure State
+
+- Post-implementation and repair reviews completed with no open P1/P2
+  findings.
+- Slice is ready to remain clean after Graphite commit finalization.

--- a/openspec/changes/resource-corpus-contract/workstream/review-disposition-ledger.md
+++ b/openspec/changes/resource-corpus-contract/workstream/review-disposition-ledger.md
@@ -1,0 +1,14 @@
+# Review Disposition Ledger
+
+| Finding | Severity | Disposition | Evidence |
+|---|---:|---|---|
+| Corpus owner should be a new Swooper Maps `resources` domain, not adapter or placement | P2 | accepted | Added `mods/mod-swooper-maps/src/domain/resources/**`; placement behavior unchanged. |
+| Do not introduce a resource stage shell in this slice | P2 | accepted | Added only `src/recipes/standard/stages/resources/artifacts.ts`; no recipe/stage index/order change. |
+| Runtime numeric id mapping is unverified | P2 | accepted | Every corpus row has `runtimeId.status: "unverified"` and `value: null`; tests assert this. |
+| `Types` declaration order differs from `Resources` row order | P2 | accepted | Tests assert corpus uses `Resources` row order and prove `<Types>` order differs. |
+| No-biome-row resources need explicit disposition | P2/P3 | accepted | Distant-lands, lapis lazuli, cloves, and nickel are visible as blocked or conditional/unknown. |
+| Lotus is not a resource | P3 | accepted | Test asserts `RESOURCE_LOTUS` is absent from corpus. |
+| Tests did not prove all source-backed corpus fields | P2 | accepted, repaired, repair-reviewed | Added XML-derived comparator for all corpus rows covering display fields, source file/table, base class, weight, valid ages, class overrides, biome source tables/counts, yields, tags, and placement flags. |
+| `artifact:resources.corpus` schema allowed `resources: Type.Any[]` | P2 | accepted, repaired, repair-reviewed | Added nested schema for resource entries and a schema test rejecting runtime-id overclaims. |
+| Corpus/order exports were mutable surfaces | P3 | accepted, repaired, repair-reviewed | Deep-froze corpus and type order exports; replaced mutable `Map` export with a frozen record. |
+| Spec said runtime id value was absent while implementation uses `null` | P3 | accepted, repaired, repair-reviewed | Spec now says runtime numeric id value is null. |

--- a/openspec/changes/resource-distribution-planning/.openspec.yaml
+++ b/openspec/changes/resource-distribution-planning/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-distribution-planning/design.md
+++ b/openspec/changes/resource-distribution-planning/design.md
@@ -1,0 +1,250 @@
+# Resource Distribution Planning Design
+
+## Frame
+
+- Cynefin domain: complicated-to-complex. The code path is inspectable, but the
+  desired output range depends on official game constraints, earthlike realism,
+  stochastic map generation, and engine feasibility.
+- Object: objective frame.
+- Lifecycle: novel planning frame for a regression workstream.
+- Mode: audience-export for future agents and reviewers.
+- Durability: standalone within this OpenSpec change.
+
+### Selection And Salience
+
+- In scope: official resource corpus, resource-stage architecture, resource
+  group steps, adapter typed reconciliation, per-resource earthlike
+  expectations, local stats gates, generated mod proof, game restart, and
+  scripting logs.
+- Foregrounded: why planned resource intents collapse after adapter
+  materialization, and how each official resource receives dedicated
+  operation-owned strategy coverage with measurable expected ranges.
+- Exterior: unrelated ecology feature balance except where needed to distinguish
+  lotus/reef-family feature visibility from resource placement; unrelated
+  Studio UI work; unrelated map identities unless they supply comparison stats.
+
+### Hard Core
+
+- Official Civ7 resource files are evidence for facts, not architecture.
+- MapGen owns deterministic resource intent and proof claims.
+- The adapter owns engine feasibility, materialization, and readback evidence.
+- Every placeable official resource needs explicit strategy coverage before
+  closure.
+- Resources may become their own stage when the stage has real authoring,
+  input/handoff, placement, enablement, trace, helper-ownership, or projection
+  surfaces.
+- Local stats and in-game runtime logs prove different things and must be
+  labeled separately.
+
+### Structural Alternative Considered
+
+Alternative: keep all resource behavior inside the existing
+`placement/plan-resources` step. Rejected as the default posture after direct
+user correction. It remains an allowable outcome only if the resource-stage
+architecture slice proves a specific blocker, such as no stable artifact
+boundary or unavoidable duplication with placement product/effect steps.
+
+### Falsifier
+
+Reframe if official resource evidence cannot be mapped to stable type ids and
+constraints, if resource groups cannot define coherent input/output artifacts,
+or if in-game readback shows adapter `canHaveResource` accepts a materially
+different legality surface than the official resource tables imply.
+
+## Team Design
+
+### Axes
+
+- Objective precision: specified/verifiable for planning; exploratory only for
+  individual resource realism ranges until evidence is gathered.
+- Coupling: parallel read-only discovery in Wave 1, then tightly integrated
+  implementation slices.
+- Autonomy: agents are empowered inside their evidence packets but do not own
+  final authority or repo integration.
+- Composition stability: wave-based and fluid.
+- Context distribution: partitioned sidecar evidence packets; workstream owner
+  integrates.
+- Verification mode: process-traced for planning and outcome-checked for tests,
+  stats, build/deploy, and runtime logs.
+
+### Roles And Interfaces
+
+| Agent | Accountable Output | Consumes | Hands Off To |
+|---|---|---|---|
+| Workstream owner | Objective, synthesis, phase state, OpenSpec slice map, Graphite cleanup | All evidence packets | Implementers/reviewers |
+| Resource corpus explorer | Complete official resource list and constraints | `.civ7/outputs/resources` | Workstream owner, strategy implementers |
+| Regression hotspot explorer | Ranked root-cause hypotheses with commit/file evidence | git history, placement code, tests | Workstream owner, root-cause slice |
+| Architecture explorer | Owner boundaries, stage/step options, review checklist | AGENTS, architecture packet, OpenSpec, user decisions | Workstream owner, spec reviewer |
+| Verification explorer | Stats, deploy, restart, and log verification matrix | package scripts, tests, CLI/FireTuner code | Workstream owner, verification reviewer |
+| Implementer wave | Bounded code/docs/tests per OpenSpec slice | Planning artifacts and accepted findings | Workstream owner |
+| Review wave | Product, architecture, spec, and verification findings | Slice artifacts and diffs | Workstream owner |
+
+Every delegated prompt must carry the frame fields: objective, selection and
+salience, exterior, hard core, falsifier, expected artifact, and no-edit or
+write-set contract.
+
+## Investigation Brief
+
+### Primary Questions
+
+1. Which official Civ7 resources are placeable, and what terrain, biome,
+   feature, water, age, class, weight, and distribution constraints does each
+   carry?
+2. Where did current MapGen behavior stop matching those constraints?
+3. Why do rubies appear when most resources do not?
+4. Why is lotus visible, and which proof lane should own it as a feature rather
+   than a resource?
+5. What per-resource earthlike count ranges should each strategy target under
+   representative map conditions?
+6. What is the right resource-stage decomposition: which resource groups deserve
+   steps, what artifacts do they consume and publish, and how does the final
+   resource materialization step consume them?
+
+### Secondary Questions
+
+- Do current SDK/adapter constants omit or misorder any official resources?
+- Which tests currently prove only aggregate planned/placed counts rather than
+  per-resource diversity?
+- Which config knobs currently constrain resource candidate catalogs?
+- Which in-game logs can prove runtime materialization after local stats pass?
+
+### Evidence Policy
+
+Authority order: direct user instruction, AGENTS routers, accepted architecture
+baseline, canonical docs, OpenSpec records, current code/tests, official
+resources as evidence, and runtime logs as observation. Claims about root cause
+must cite code or commit evidence. Claims about official constraints must cite
+resource files. Claims about expected earthlike ranges must cite research notes
+or a documented inference rule before becoming gates.
+
+## Official Resource Corpus
+
+Wave 1 parsed 55 official base-standard resources from
+`.civ7/outputs/resources/Base/modules/base-standard/data/resources.xml` and
+`resources-v2.xml`. The corpus is verified as static official file/load order.
+Runtime `GameInfo.Resources` id order remains unverified and is an entry
+condition for `resource-corpus-contract`.
+
+| Class | Resources |
+|---|---|
+| `RESOURCECLASS_BONUS` | `00:COTTON`, `01:DATES`, `02:DYES`, `03:FISH`, `18:HIDES`, `22:WOOL`, `32:WHALES`, `33:COFFEE`, `34:TOBACCO`, `35:CITRUS`, `39:QUININE`, `42:CLAY`, `44:RUBIES`, `47:TIN`, `48:LLAMAS`, `50:WILD_GAME`, `51:CRABS`, `52:COWRIE`, `53:TURTLES`, `54:PITCH` |
+| `RESOURCECLASS_CITY` | `06:GYPSUM`, `07:INCENSE`, `09:JADE`, `10:KAOLIN`, `12:PEARLS`, `13:SILK`, `17:CAMELS`, `21:SALT`, `23:LAPIS_LAZULI`, `29:TRUFFLES`, `31:CLOVES`, `37:NICKEL`, `41:MANGOS`, `43:FLAX` |
+| `RESOURCECLASS_EMPIRE` | `04:GOLD`, `05:GOLD_DISTANT_LANDS`, `08:IVORY`, `11:MARBLE`, `14:SILVER`, `15:SILVER_DISTANT_LANDS`, `16:WINE`, `19:HORSES`, `20:IRON`, `24:COCOA`, `25:FURS`, `26:SPICES`, `27:SUGAR`, `28:TEA`, `30:NITER`, `36:COAL`, `38:OIL`, `40:RUBBER`, `45:RICE`, `46:LIMESTONE`, `49:HARDWOOD` |
+
+Age overrides matter. Exploration can turn resources including rubies into
+`RESOURCECLASS_TREASURE`; Modern introduces `RESOURCECLASS_FACTORY` and updates
+several classes. The downstream corpus slice must capture base facts and
+age-specific overrides separately.
+
+### Corpus Artifact Contract
+
+The downstream corpus artifact must include, for every official resource row:
+
+- `resourceType` and static file-order slot.
+- runtime id verification status: `unverified`, `verified`, or `mismatch`.
+- base class and age-specific class overrides.
+- valid ages.
+- official terrain, biome, feature, water/adjacency, and lake eligibility
+  constraint sources.
+- map distribution facts: weight, staple/minimum fields, hemisphere fields, and
+  map-size modifiers when applicable.
+- placeability status: `placeable`, `conditional`, `not-map-placed`, or
+  `unknown`, with rationale.
+- strategy-required status: `required`, `not-required`, or `blocked`, with
+  rationale and owner.
+
+## Integrated Root-Cause Evidence
+
+- `placement/plan-resources` takes an adapter-owned numeric candidate catalog
+  and physical fields, then chooses a `preferredResourceType` from a generic
+  environmental signature. It does not read official `Resource_ValidBiomes`,
+  feature constraints, water/adjacency flags, age validity, or resource class.
+- `place-resources` materializes the typed intent through
+  `adapter.placeResourceIntent`, and the adapter can reject the intent with
+  `cannot-have-resource` when Civ7 says the tile cannot hold that exact type.
+- Current world-balance stats measure feature families and geography, but they
+  do not yet record per-resource planned, placed, rejected, and mismatch counts.
+- `FEATURE_LOTUS` is defined in `terrain.xml`, not in `Resources`, so lotus
+  visibility belongs to ecology/feature proof unless a downstream slice changes
+  feature strategy.
+- Commit hotspot: `c2e9735aa refactor: reconcile placement intent outcomes`
+  replaced the earlier official-generator resource path with typed intent
+  reconciliation. `1211f7020` had made `generateOfficialResources()` primary
+  because deterministic planning was parity-incomplete.
+- Hypothesis: rubies likely survive because resource type selection maps high environmental
+  signatures into the upper numeric catalog range; `RESOURCE_RUBIES` is id `44`
+  and has broad enough valid placements across plains hills, tropical flat/hill,
+  and desert hills to pass some engine checks. Promote this only after
+  per-resource rejection telemetry confirms the planned/placed/rejected profile.
+- Existing mock-adapter tests allow all resources unless overridden, so they do
+  not catch habitat rejection collapse.
+
+## Resource Stage Candidate
+
+The next architecture slice should design this as the preferred target unless a
+specific blocker is found:
+
+```text
+resources stage
+  derive-resource-corpus
+  score-resource-groups
+  plan-resource-groups
+  reconcile-resource-intents
+  summarize-resource-distribution
+```
+
+Candidate group steps should be based on shared official constraints and shared
+input/output artifacts, not arbitrary names:
+
+- aquatic/coastal resources: fish, whales, crabs, cowrie, turtles, pearls.
+- mineral/stone resources: gold, silver, iron, niter, coal, oil, rubies, tin,
+  limestone, gypsum, marble, kaolin, clay, nickel, salt.
+- cultivated/wetland resources: rice, cotton, flax, sugar, tea, coffee, tobacco,
+  citrus, dates, mangos, quinine.
+- forest/pastoral/wild resources: hardwood, rubber, furs, hides, wild game,
+  wool, horses, camels, llamas, ivory.
+- luxury/cultural/aromatic resources: dyes, incense, jade, silk, wine, cocoa,
+  spices, truffles, cloves, lapis lazuli.
+
+The grouping is provisional. The downstream slice must prove the final groups
+from official constraints and earthlike domain evidence.
+
+Candidate groups are not step candidates until each group can name:
+
+- consumed input artifacts;
+- published output artifact;
+- shared invariant across member resources;
+- downstream consumer;
+- verification boundary.
+
+If those fields cannot be named, keep the bucket as a discovery/research group
+rather than a stage step.
+
+## Verification Matrix
+
+| Rail | Command/Path | Proves | Does Not Prove |
+|---|---|---|---|
+| Local world stats | `bun run --cwd mods/mod-swooper-maps test -- test/pipeline/world-balance-stats.test.ts` | Generator outputs across shipped identities/seeds | Civ7 loaded the mod |
+| Resource count tests | `bun run --cwd mods/mod-swooper-maps test -- test/placement/resources-landmass-region-restamp.test.ts test/map-hydrology/lakes-area-recalc-resources.test.ts test/placement/placement-does-not-call-generate-snow.test.ts` | Expected plan vs mock-adapter placement summary | Live game readback |
+| Config identity | `bun run --cwd mods/mod-swooper-maps test -- test/config/maps-schema-valid.test.ts test/config/shipped-map-identity.test.ts test/config/studio-presets-schema-valid.test.ts` | Shipped config/schema coherence | Runtime map selection |
+| Generated mod proof | `bun run --cwd mods/mod-swooper-maps build` | Source generated local mod artifacts | Deployment or game execution |
+| Deploy proof | `bun run --cwd mods/mod-swooper-maps deploy` | Files copied to Civ7 Mods folder | Game selected/executed them |
+| Runtime proof | deploy plus `bun run --filter @mateicanavra/civ7-cli dev -- game restart --agent Codex --wait` plus bounded logs | Civ7 loaded map script and ran map generation | Balance correctness without resource telemetry |
+
+Expected log paths: `~/Library/Application Support/Civilization VII/Logs/` and
+bridge log `~/Parallels Tunnel/Sid Meier's Civilization VII Development Tools/Comms/civ7-firetuner-bridge.append-only.log`.
+Runtime restart commands must include `AGENT=<agent-name>` in bridge requests.
+
+## Downstream OpenSpec Slice Map
+
+| Slice | Status | Write Set | Protected Paths | Review Lanes | Entry Conditions | Stop Conditions | Required Evidence |
+|---|---|---|---|---|---|---|---|
+| `resource-distribution-root-cause` | planned | placement/resource artifacts, materialize tests, stats support | generated output, corpus strategy tuning | spec, verification | planning branch merged/upstacked; corpus static evidence available | no per-resource telemetry path; runtime id mismatch becomes primary | grouped planned/placed/rejected/mismatch stats by resource id/status/reason |
+| `resource-corpus-contract` | planned | adapter/catalog facts, resource corpus module, corpus tests | official resource submodule, generated constants unless regenerated by script | product, architecture, verification | static corpus source files initialized | runtime id order cannot be verified or mismatches without disposition | 55-resource corpus with runtime id status, placeability, constraints, strategy-required status |
+| `resource-stage-architecture` | planned | recipe/stage docs, contracts, OpenSpec delta, no behavior tuning | generated output, resource tuning configs | architecture, spec, product | root-cause evidence and corpus contract draft available | no coherent resource-stage artifacts can be named | accepted resources-stage/step artifact design or a proven blocker |
+| `resource-strategy-batches` | planned | resource stage/group strategy modules and tests | stage topology unless prior architecture slice lands | product, architecture, verification | corpus and stage architecture accepted | group lacks input artifact, output artifact, shared invariant, or consumer | per-resource strategy coverage and deterministic plan output |
+| `resource-distribution-stats-gates` | planned | world-balance stats/tests, research notes | production strategy code except test hooks | product, verification | strategy batch outputs available | earthlike expected ranges lack evidence or inference notes | seed matrix stats with per-resource expected ranges |
+| `resource-distribution-runtime-proof` | planned | workstream ledgers and runtime evidence, no generated hand edits | generated source artifacts except via build/deploy scripts | verification, product | local stats pass and deployable mod build exists | game restart unavailable or logs lack bounded map-generation window | deploy, restart command with `AGENT=...`, bounded logs, resource telemetry |
+
+Implementation slices may split further by resource group if per-resource
+strategy coverage would make a single branch too broad.

--- a/openspec/changes/resource-distribution-planning/proposal.md
+++ b/openspec/changes/resource-distribution-planning/proposal.md
@@ -1,0 +1,106 @@
+## Why
+
+Latest Swooper map rolls show a resource distribution regression: only a
+minority of placeable resources appear, with rubies visible and lotus also
+visible in some rolls. The current placement planner produces deterministic
+resource intents, but Wave 1 evidence shows it does not model official
+per-resource terrain, biome, feature, water, age, class, and distribution
+constraints before asking the Civ7 adapter to materialize each intent. The
+adapter can then reject most planned exact type/tile pairs as engine-ineligible.
+
+Lotus is also not a resource in the official data. It is `FEATURE_LOTUS`, an
+aquatic feature, so resource closure must keep resource distribution and
+feature-family visibility distinct even when both are visible map content.
+
+This planning change defines the investigation, team structure, evidence
+policy, resource stage architecture question, and Graphite/OpenSpec slice map
+before implementation branches tune or rewrite placement behavior.
+
+## Target Authority Refs
+
+- Direct user decision: use a team of agents, run one wave per workstream
+  phase, frame every agent prompt with `framing-design`, identify all official
+  resources, design a dedicated strategy for each resource, match earthlike
+  expected ranges with stats, then verify through game restart and scripting
+  logs.
+- Direct user decision: resources may become their own stage; resource steps may
+  be resource groups when they have related input/output artifacts. Do not
+  preserve `plan-resources` as a single step unless there is a specific,
+  insurmountable reason.
+- Root `AGENTS.md`: use Graphite stacked PRs, leave repo state clean, update
+  adjacent docs/tests with behavior changes, and treat generated artifacts and
+  lockfiles as read-only.
+- `mods/mod-swooper-maps/AGENTS.md`: placement follows the op-per-concern
+  pattern; placement step orchestrates ops. This is a starting constraint, not
+  an immutable refusal of a resource stage after the direct user decision.
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`:
+  MapGen normalization target shape and owner boundaries.
+- `.civ7/outputs/resources/Base/modules/base-standard/data/resources.xml` and
+  `resources-v2.xml`: official resource evidence.
+
+## What Changes
+
+- Open a planning-only resource distribution workstream.
+- Define the multi-agent team, interfaces, accountability, and wave plan.
+- Define an investigation brief for root-cause diagnosis and per-resource
+  corpus/strategy work.
+- Record early root-cause evidence from the current placement code.
+- Reopen the architecture unit: evaluate a dedicated resource stage with
+  resource-group steps and explicit artifacts rather than assuming
+  `placement/plan-resources` remains the boundary.
+- Split downstream implementation into reviewable OpenSpec/Graphite slices.
+- Define verification gates spanning local stats, generated mod proof, and
+  in-game restart/log proof.
+
+## Requires
+
+- `codex/resource-distribution-planning` remains stacked above
+  `codex/morphology-public-config-surface`.
+- Official resources submodule is initialized in the worktree.
+- Local dependencies are available before running OpenSpec, type, test, and
+  build gates.
+
+## Enables Parallel Work
+
+- `resource-distribution-root-cause`
+- `resource-corpus-contract`
+- `resource-stage-architecture`
+- `resource-strategy-batches`
+- `resource-distribution-stats-gates`
+- `resource-distribution-runtime-proof`
+
+## Forbidden Non-Goals
+
+- No quota-only resource placement.
+- No unreported exclusions when an official resource lacks a modeled strategy.
+- No aggregate "resources placed" success claim without per-resource counts.
+- No generated-output hand edits.
+- No claim that lotus proves resource placement, because lotus is a feature.
+- No implementation tuning before the relevant downstream OpenSpec slice exists.
+- No refusal of a resource stage merely because current code has a
+  `plan-resources` step.
+
+## Verification Gates
+
+- `bun run openspec -- validate resource-distribution-planning --strict`
+- `bun run openspec:validate`
+- `git diff --check`
+- Planning branch cleanly committed as a Graphite child of the current stack
+  top.
+
+## Wave 1 Findings Integrated
+
+- Official corpus: 55 base-standard resources are present in static official
+  file/load order. Runtime `GameInfo.Resources` id order is not yet verified;
+  rubies appear as `RESOURCE_RUBIES` in the static file-order slot currently
+  treated as id `44`.
+- Lotus correction: `FEATURE_LOTUS` is an aquatic feature, not a resource.
+- Root-cause lead: commit `c2e9735aa` moved current resource placement from the
+  official aggregate generator path to deterministic typed intents; the generic
+  planner chooses exact resource ids before Civ7 feasibility checks and records
+  `cannot-have-resource` rejections without alternate-type selection.
+- Test gap: existing mock-adapter tests do not model Civ7 habitat rejection by
+  default, and world-balance stats do not yet report per-resource diversity.
+- Architecture correction after user input: Wave 1 was too conservative about
+  stage boundaries. The next architecture slice must actively design a resource
+  stage and reject it only if a specific blocker is proven.

--- a/openspec/changes/resource-distribution-planning/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-distribution-planning/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Resource Distribution Planning Requires Stage Architecture Review
+
+Resource distribution recovery SHALL treat current `placement/plan-resources`
+topology as implementation evidence rather than target authority.
+
+#### Scenario: Resource distribution work is planned
+- **WHEN** a resource distribution recovery workstream is drafted
+- **THEN** the planning record includes a resource-stage architecture slice
+  that evaluates a dedicated resource stage with resource-group steps
+- **AND** keeping all resource behavior inside the current placement step is
+  allowed only when the architecture slice records a specific blocker
+
+#### Scenario: Resource group steps are proposed
+- **WHEN** a resource group is proposed as a stage step
+- **THEN** the group names consumed input artifacts, a published output
+  artifact, a shared invariant, a downstream consumer, and a verification
+  boundary
+- **AND** groups that cannot name those fields remain discovery or research
+  buckets rather than step candidates
+
+### Requirement: Resource Corpus Proof Separates Static File Order From Runtime IDs
+
+Resource corpus proof SHALL distinguish static official resource file/load order
+from runtime `GameInfo.Resources` id order.
+
+#### Scenario: Official resources are cataloged
+- **WHEN** resource distribution work cites official resource ids
+- **THEN** the corpus records the static official file-order slot separately
+  from runtime id verification status
+- **AND** runtime id order must be verified, mismatched, or blocked with
+  rationale before strategy implementation relies on numeric ids
+
+#### Scenario: Resource strategy coverage is planned
+- **WHEN** a resource is added to the strategy coverage matrix
+- **THEN** the corpus records valid ages, class and age overrides, official
+  placement constraints, placeability status, strategy-required status, and
+  rationale
+- **AND** resources that are not map-placed are excluded only with explicit
+  source evidence and owner disposition
+
+### Requirement: Resource Recovery Closure Requires Per-Resource Evidence
+
+Resource distribution recovery SHALL close on per-resource evidence instead of
+aggregate planned or placed counts.
+
+#### Scenario: Local resource stats are evaluated
+- **WHEN** local stats are used to support a resource distribution claim
+- **THEN** stats include planned, placed, rejected, and mismatch counts grouped
+  by resource id, status, and rejection reason
+- **AND** aggregate resource counts alone are insufficient for closure
+
+#### Scenario: Runtime resource proof is collected
+- **WHEN** game restart and scripting logs are used for runtime proof
+- **THEN** evidence includes the submitted restart command, bounded
+  MapGeneration log window, map script selection, placement step completion,
+  error scan, and resource telemetry for the generated map
+- **AND** recipe completion without resource telemetry is only pipeline proof

--- a/openspec/changes/resource-distribution-planning/tasks.md
+++ b/openspec/changes/resource-distribution-planning/tasks.md
@@ -1,0 +1,38 @@
+## 1. Planning Frame
+
+- [x] 1.1 Create isolated Graphite worktree and planning branch on top of the
+  existing stack.
+- [x] 1.2 Frame the objective, hard core, scope, exterior, structural
+  alternative, and falsifier.
+- [x] 1.3 Define team design and wave interfaces before delegation.
+- [x] 1.4 Define the investigation brief before code or tuning.
+- [x] 1.5 Incorporate direct user correction that resources may become their
+  own stage with resource-group steps.
+
+## 2. Wave 1 Diagnosis
+
+- [x] 2.1 Identify the complete official resource corpus from initialized Civ7
+  resources.
+- [x] 2.2 Analyze file/commit hotspots for resource placement regressions.
+- [x] 2.3 Map architecture/OpenSpec constraints and then correct the map after
+  user authority reopened resource stage design.
+- [x] 2.4 Identify local stats, deploy, game restart, and scripting-log
+  verification rails.
+- [x] 2.5 Integrate agent findings into the phase record.
+
+## 3. Downstream Slice Map
+
+- [x] 3.1 Create or confirm OpenSpec change ids for root cause, resource
+  corpus, resource stage architecture, per-resource strategy batches, stats
+  gates, and runtime proof.
+- [x] 3.2 Define write sets, protected files, and review lanes for each slice.
+- [x] 3.3 Record exact stop conditions and evidence requirements.
+- [x] 3.4 Add strict OpenSpec delta for planning closure requirements.
+- [x] 3.5 Add review disposition for pre-implementation review findings.
+
+## 4. Planning Verification
+
+- [x] 4.1 Validate `resource-distribution-planning` with OpenSpec.
+- [x] 4.2 Validate all OpenSpec records.
+- [x] 4.3 Run `git diff --check`.
+- [x] 4.4 Commit the planning slice with Graphite and leave the worktree clean.

--- a/openspec/changes/resource-distribution-planning/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-distribution-planning/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,43 @@
+# Downstream Realignment Ledger
+
+## Phase
+
+- Project: resource distribution recovery
+- Phase: planning and diagnosis
+- Owner: Codex workstream owner
+- Census run: 2026-05-31
+
+## Pre/Post Census
+
+- Affected project specs/reviews: engine-refactor normalization packet,
+  OpenSpec resource distribution slices to be created
+- Affected issue/milestone artifacts: none identified yet
+- Affected canonical docs: none in planning slice
+- Affected tests/guards/scripts: world-balance stats, placement tests,
+  OpenSpec validation
+- Affected generated-output assumptions: generated mod output must be
+  regenerated only after implementation slices
+- Affected phase records / Next Packets:
+  `openspec/changes/resource-distribution-planning/workstream/phase-record.md`
+
+## Disposition
+
+| Item | Impact | Disposition | Patch/No-Patch Evidence | Owner | Trigger |
+|---|---|---|---|---|---|
+| World-balance stats | Need per-resource planned/placed/rejected counts | deferred | downstream `resource-distribution-stats-gates` slice | Workstream owner | root-cause findings integrated |
+| Resource stage architecture | Need dedicated resource stage or proven blocker | deferred | downstream `resource-stage-architecture` slice | Workstream owner | direct user correction |
+| Resource corpus | Need 55-resource facts and age overrides in repo-owned form | deferred | downstream `resource-corpus-contract` slice | Workstream owner | corpus accepted |
+| Runtime restart/log proof | Needed after local stats pass | deferred | downstream `resource-distribution-runtime-proof` slice | Workstream owner | deployable implementation |
+| Lotus visibility | Must not be counted as resource proof | no patch needed in planning | proposal records lotus as feature | Workstream owner | verification matrix |
+
+## Required Closure Statement
+
+- Downstream assumptions that changed: resource correctness requires
+  per-resource diversity and eligibility evidence, not aggregate placement
+  counts; resources may deserve a dedicated stage.
+- Artifacts patched: planning OpenSpec change and phase record.
+- No-patch rationale: no production code changes belong in planning slice.
+- Blocked/deferred items: all behavior fixes deferred to named downstream
+  slices.
+- Exact next downstream action: open the root-cause diagnostic and resource
+  stage architecture slices.

--- a/openspec/changes/resource-distribution-planning/workstream/phase-record.md
+++ b/openspec/changes/resource-distribution-planning/workstream/phase-record.md
@@ -1,0 +1,219 @@
+# Phase Record
+
+## Phase
+
+- Project: resource distribution recovery
+- Phase: planning and diagnosis
+- Owner: Codex workstream owner
+- Branch/Graphite stack: `codex/resource-distribution-planning` above
+  `codex/morphology-public-config-surface`
+- Started: 2026-05-31
+- Status: active
+
+## Objective
+
+- Target movement: convert the broad resource regression request into a bounded
+  OpenSpec/Graphite workstream with evidence-backed diagnosis, team interfaces,
+  a resource-stage architecture pass, per-resource strategy requirements, and
+  verification rails.
+- Non-goals: no resource tuning, no generated-output hand edits, no runtime
+  proof claim in this planning slice.
+- Done condition: Wave 1 findings are integrated, downstream slices are named,
+  OpenSpec validates, and the planning branch is committed cleanly.
+
+## Authority
+
+- Root/subtree `AGENTS.md`: root router, `mods/mod-swooper-maps/AGENTS.md`,
+  `mods/mod-swooper-maps/src/AGENTS.md`, `packages/mapgen-core/AGENTS.md`,
+  `packages/mapgen-core/src/AGENTS.md`
+- Direct user correction: resources may be their own stage; steps may be
+  resource groups with related input/output artifacts.
+- Product refs: `.agents/skills/civ7-product-authority/SKILL.md`,
+  official resource files as evidence
+- Architecture refs: `.agents/skills/civ7-architecture-authority/SKILL.md`,
+  `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`
+- Project refs: `openspec/changes/README.md`,
+  `openspec/specs/mapgen-normalization-workstreams/spec.md`
+- Excluded/stale inputs: generated `mod/` output, archived project notes unless
+  used only as discovery evidence
+
+## Current State
+
+- Repo/Graphite state: isolated worktree created at
+  `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`;
+  branch tracked with Graphite parent `codex/morphology-public-config-surface`.
+- Dirty files and owner: primary worktree had pre-existing dirty files
+  `mods/mod-swooper-maps/src/maps/configs/swooper-earthlike.config.json` and
+  `NOTE-TO-DRA.md`; this worktree started clean.
+- Current code evidence: `placement/plan-resources` uses generic physical
+  scoring and numeric candidate offsets; `place-resources` records typed
+  adapter outcomes; adapter rejects engine-ineligible resources.
+- Generated outputs affected: none in planning slice.
+- Tests/guards affected: OpenSpec validation and `git diff --check` for
+  planning; downstream stats/tests later.
+
+## Scope
+
+- Write set: `openspec/changes/resource-distribution-planning/**`
+- Protected files: generated outputs, lockfiles, primary worktree dirty files
+- Owners: workstream owner for synthesis; sidecar agents for evidence packets
+- Forbidden owners: generated `mod/`, current code as target authority, resource
+  stage refusal without a proven blocker
+- Consumer impact: no runtime consumer change in planning slice
+- Downstream assumptions: implementation will require per-resource diagnostic
+  stats, official corpus facts, resource-stage architecture, and per-resource
+  strategy coverage before balance claims
+
+## Spec/Tasks
+
+- Spec/proposal: `openspec/changes/resource-distribution-planning/proposal.md`
+- Tasks: `openspec/changes/resource-distribution-planning/tasks.md`
+- Validation status: strict change validation and all-record OpenSpec validation
+  pass after adding the planning delta.
+
+## Review
+
+- Review lanes:
+  - product: pending downstream implementation review
+  - architecture: completed pre-implementation review and repair verification
+  - spec/workstream: completed pre-implementation review and repair
+    verification
+  - verification: pending downstream implementation review
+- Previously blocking findings:
+  - Wave 1 architecture interpretation was too conservative after direct user
+    correction; resource-stage design must be actively explored. This is
+    repaired in the planning design and OpenSpec delta.
+- Accepted review findings:
+  - P2 static resource ids were treated as verified while runtime id order
+    remained open.
+  - P2 downstream slice contracts were not durable enough.
+  - P2 all official resources and placeable resources were not reconciled.
+  - P2 review state was ambiguous for implementation handoff.
+  - P2 resource group examples lacked artifact acceptance rules.
+  - P3 dirty paths and gate outputs were not exact enough.
+  - P3 rubies hypothesis needed explicit hypothesis labeling.
+- Accepted findings repaired:
+  - Planning now includes `resource-stage-architecture` as the next architecture
+    slice and treats `plan-resources` as current code, not target authority.
+  - Static corpus and runtime id verification are separated.
+  - Slice contract table now records status, write set, protected paths, review
+    lanes, entry conditions, stop conditions, and required evidence.
+  - Corpus artifact contract now records placeability and strategy-required
+    status.
+  - Group-step candidates now require input artifact, output artifact, invariant,
+    consumer, and verification boundary.
+- Rejected/invalidated/waived/deferred findings: standalone per-resource stages
+  are still not accepted by default; resource group steps must be artifact-led.
+- Current implementation readiness: no open P1/P2 planning review findings
+  remain after repairing stale handoff state; behavior implementation still
+  requires downstream OpenSpec slices and review lanes.
+
+## Agent Fleet State
+
+- Active agents: none
+- Completed agents:
+  - `Ampere` (`019e7cba-57f8-7461-93c4-ba46e8bede00`): official corpus evidence
+  - `Helmholtz` (`019e7cba-7e27-7540-9100-6e71e515e90e`): regression hotspot/root-cause evidence
+  - `Bacon` (`019e7cba-9948-7813-9f26-3d2aa3b1a43b`): architecture/OpenSpec evidence
+  - `Harvey` (`019e7cba-bf5c-73b0-b7b3-7beda5764876`): verification/runtime evidence
+  - `Herschel` (`019e7cc5-98bd-7551-8c2c-ca2ab5613815`): spec/workstream review
+  - `Jason` (`019e7cc6-499d-7391-9118-a55e8f4f197c`): architecture review
+- Assigned write sets: none; Wave 1 was read-only
+- Latest evidence by agent:
+  - `Ampere`: 55 static file-order resources; rubies appears in static slot
+    currently treated as id `44`; lotus is `FEATURE_LOTUS`; SDK constants are
+    stale/incomplete for v2 resources.
+  - `Helmholtz`: top regression candidate is `c2e9735aa`; current planner picks
+    exact resource types by numeric signature before Civ7 feasibility checks.
+  - `Bacon`: current authority supports `resources` as a concern, but user
+    correction requires resource-stage design rather than conservative refusal.
+  - `Harvey`: verification rails and log paths identified; OpenSpec gates can
+    run in this worktree by placing the primary worktree `node_modules/.bin`
+    on `PATH`.
+  - `Herschel`: static/runtime id separation, placeability fields, resource
+    group artifact rules, stage correction, and OpenSpec validity are
+    substantively repaired; stale handoff state required cleanup.
+  - `Jason`: no P1/P2 findings after architecture repair verification.
+- Open findings by agent:
+  - Confirm runtime `GameInfo.Resources` id order against static `0..54`.
+  - Add telemetry to group placement outcomes by status, reason, and resource id.
+  - Prove final resource group steps from artifact boundaries.
+- Running/stale status: all Wave 1 agents completed
+- Integration owner: Codex workstream owner
+
+## Implementation
+
+- Completed tasks:
+  - Created isolated worktree and Graphite planning branch.
+  - Initialized `.civ7/outputs/resources` submodule in the worktree.
+  - Spawned Wave 1 read-only agents with framing-design prompts.
+  - Recorded root-cause evidence from placement planner and adapter path.
+  - Integrated Wave 1 findings and direct user correction into planning files.
+  - Ran review wave and repaired accepted findings.
+- Remaining tasks:
+  - Commit planning slice.
+- Historical stop conditions resolved:
+  - `bun run openspec -- list` failed before dependency setup because
+    `node_modules` is absent in the new worktree; final gates use the primary
+    worktree's `node_modules/.bin` on `PATH`.
+
+## Verification
+
+- Commands run:
+  - `git status --short --branch`
+  - `gt ls`
+  - `git submodule update --init .civ7/outputs/resources`
+  - `bun run openspec -- list`
+  - `PATH="/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/node_modules/.bin:$PATH" bun run openspec -- validate resource-distribution-planning --strict`
+  - `PATH="/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/node_modules/.bin:$PATH" bun run openspec:validate`
+  - `git diff --check`
+- Results:
+  - Graphite branch is tracked above current stack top.
+  - Official resources submodule initialized.
+  - OpenSpec validation initially failed because `resource-distribution-planning`
+    had no `specs/` delta.
+  - `resource-distribution-planning` strict validation now passes.
+  - all OpenSpec records now pass strict validation.
+  - `git diff --check` passed.
+- Skipped gates and rationale: none for planning gates.
+- Evidence boundary: planning evidence only; no behavior proof yet.
+
+## Wave 1 Evidence Pack
+
+- Official corpus: 55 static file-order resources from `resources.xml` and
+  `resources-v2.xml`; runtime id order remains unverified.
+- Rubies hypothesis: `RESOURCE_RUBIES` appears in static file-order slot
+  currently treated as id `44`; valid on plains hills, tropical flat/hill, and
+  desert hills. It likely survives because numeric signature selection can hit
+  the upper catalog range and rubies have multiple eligible habitats. Promote
+  this only after per-resource rejection telemetry confirms it.
+- Lotus: `FEATURE_LOTUS` aquatic feature, not a resource; current visibility is
+  ecology/feature proof.
+- Root cause: deterministic exact intents are planned without official habitat
+  constraints, then `adapter.placeResourceIntent()` rejects exact type/tile
+  mismatches through `ResourceBuilder.canHaveResource`.
+- Test gap: existing tests do not model live Civ7 resource habitat rejection by
+  default; stats lack per-resource counts.
+- Verification: game restart path is
+  `bun run --filter @mateicanavra/civ7-cli dev -- game restart --agent Codex --wait`;
+  bridge requests must include `AGENT=<agent-name>`.
+
+## Realignment
+
+- Downstream docs/specs/issues updated: planning OpenSpec change
+- Tests/guards updated: pending downstream slices
+- Deferrals/triage updated: not applicable
+- Downstream realignment ledger:
+  `openspec/changes/resource-distribution-planning/workstream/downstream-realignment-ledger.md`
+
+## Next Action
+
+- Exact next step: commit planning slice, then open
+  `resource-distribution-root-cause` and `resource-stage-architecture`.
+- First files to inspect:
+  - `.civ7/outputs/resources/Base/modules/base-standard/data/resources.xml`
+  - `.civ7/outputs/resources/Base/modules/base-standard/data/resources-v2.xml`
+  - `mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/**`
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/placement/**`
+- Stop condition: do not implement resource tuning until downstream OpenSpec
+  slices exist and review lanes are dispositioned.

--- a/openspec/changes/resource-distribution-planning/workstream/review-disposition-ledger.md
+++ b/openspec/changes/resource-distribution-planning/workstream/review-disposition-ledger.md
@@ -1,0 +1,33 @@
+# Review Disposition Ledger
+
+## Phase
+
+- Project: resource distribution recovery
+- Phase: planning and diagnosis
+- Owner: Codex workstream owner
+- Review wave: pre-implementation planning review
+
+## Findings
+
+| Finding | Severity | Disposition | Repair Evidence |
+|---|---|---|---|
+| Static resource ids treated as verified while runtime id order remains open | P2 | accepted | Proposal/design/phase/next packet separate static file-order corpus from runtime id verification; `resource-corpus-contract` owns runtime id status. |
+| Downstream slice contracts were not durable enough | P2 | accepted | Design now includes per-slice status, write set, protected paths, review lanes, entry conditions, stop conditions, and required evidence. |
+| All official resources and placeable resources were not reconciled | P2 | accepted | Design now defines corpus artifact fields for placeability and strategy-required status with rationale. |
+| Review state was ambiguous for implementation handoff | P2 | accepted | Phase record and next packet now record review wave completion, accepted findings, and repair state. |
+| Candidate resource group steps lacked artifact specificity | P2 | accepted | Design now requires consumed artifacts, published artifact, invariant, downstream consumer, and verification boundary before a group becomes a step candidate. |
+| Handoff dirty paths and gate outputs were vague | P3 | accepted | Next packet now lists exact uncommitted files and last gate outputs. |
+| Rubies hypothesis needed explicit hypothesis marker | P3 | accepted | Design and phase record label rubies as a hypothesis pending per-resource rejection telemetry. |
+
+## Closure Gate
+
+Planning implementation must not proceed to behavior code until all accepted P2
+findings above remain repaired after OpenSpec validation.
+
+## Repair Verification
+
+- Architecture review: repair verified with no open P1/P2 findings.
+- Spec/workstream review: substantive repairs verified; a stale handoff-state
+  follow-up was accepted and repaired by removing obsolete blocker and
+  remaining-task text from the phase record and next packet.
+- Final planning gates passed after repair verification updates.

--- a/openspec/changes/resource-earthlike-expectations-artifact/.openspec.yaml
+++ b/openspec/changes/resource-earthlike-expectations-artifact/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-earthlike-expectations-artifact/design.md
+++ b/openspec/changes/resource-earthlike-expectations-artifact/design.md
@@ -1,0 +1,71 @@
+# Resource Earthlike Expectations Artifact Design
+
+## Decision
+
+The typed expectation artifact lives in the resource domain:
+
+```text
+mods/mod-swooper-maps/src/domain/resources/earthlike-expectations
+```
+
+It is exported through `@mapgen/domain/resources` and registered in the
+resource artifact catalog as:
+
+```text
+artifact:resources.earthlikeExpectations
+```
+
+The artifact is built from the official corpus so every row carries:
+
+- official resource symbol;
+- static resource row slot;
+- runtime id status `unverified`;
+- eligible ages;
+- official placement constraint summary.
+
+## Runtime Boundary
+
+The artifact does not include runtime numeric ids and does not import adapter or
+placement runtime code. Tests assert the source avoids `@civ7/adapter`,
+`ResourceBuilder`, `placeResourceIntent`, and placement op imports.
+
+## Blocked Rows
+
+The five corpus-blocked resources stay visible and active-zero:
+
+- `RESOURCE_CLOVES`
+- `RESOURCE_GOLD_DISTANT_LANDS`
+- `RESOURCE_LAPIS_LAZULI`
+- `RESOURCE_NICKEL`
+- `RESOURCE_SILVER_DISTANT_LANDS`
+
+Their expectation rows have:
+
+```text
+status = "blocked"
+min = 0
+target = 0
+max = 0
+evidence = "blocked"
+conditionMultipliers = []
+```
+
+## Schema Boundary
+
+The TypeBox schema is strict:
+
+- `additionalProperties: false` on artifact and row objects;
+- closed group, status, evidence, and source literals;
+- a blocked-row branch that permits only zero ranges and blocked evidence;
+- an active-row branch for `expected` and `conditional` rows.
+
+Schema tests reject runtime/numeric id overclaims, feature rows, invalid status,
+missing range fields, and blocked-row nonzero range leakage.
+
+## Write Set
+
+- `mods/mod-swooper-maps/src/domain/resources/earthlike-expectations/**`
+- `mods/mod-swooper-maps/src/domain/resources/index.ts`
+- `mods/mod-swooper-maps/src/recipes/standard/stages/resources/artifacts.ts`
+- `mods/mod-swooper-maps/test/resources/resource-earthlike-expectations-artifact.test.ts`
+- `openspec/changes/resource-earthlike-expectations-artifact/**`

--- a/openspec/changes/resource-earthlike-expectations-artifact/proposal.md
+++ b/openspec/changes/resource-earthlike-expectations-artifact/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The `resource-earthlike-expectations` slice defined the per-resource
+expectation contract but deliberately stopped before source implementation.
+Future resource operations need a typed artifact to consume before they can
+claim per-resource coverage. This slice publishes that artifact without moving
+placement behavior, verifying runtime numeric ids, or promoting inferred ranges
+to hard count gates.
+
+## Target Authority Refs
+
+- `openspec/changes/resource-earthlike-expectations`: 55-resource partition,
+  per-resource expectation row contract, blocked-row handling, and telemetry
+  gate policy.
+- `openspec/changes/resource-corpus-contract`: official corpus symbols,
+  static row slots, and unverified runtime numeric id boundary.
+- `openspec/changes/resource-stage-architecture`: accepted artifact name
+  `artifact:resources.earthlikeExpectations`.
+
+## What Changes
+
+- Add `mods/mod-swooper-maps/src/domain/resources/earthlike-expectations/**`.
+- Publish `EARTHLIKE_RESOURCE_EXPECTATIONS_ARTIFACT` in official corpus order.
+- Register `resourceArtifacts.earthlikeExpectations` with id
+  `artifact:resources.earthlikeExpectations`.
+- Add a strict TypeBox schema that rejects runtime-id overclaims, feature rows,
+  malformed statuses, missing range fields, and blocked rows with nonzero
+  active ranges.
+- Add focused resource tests for coverage, corpus refs, blocked rows, crabs
+  navigable-river preservation, schema rejection, and placement-runtime
+  boundary.
+
+## Explicit Non-Goals
+
+- No `resources` stage shell or recipe order change.
+- No movement of `placement/plan-resources` or `place-resources`.
+- No runtime `GameInfo.Resources` numeric id verification.
+- No adapter numeric diagnostics joined to resource symbols.
+- No stats closure gates or placement tuning.
+
+## Verification Gates
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-corpus-contract.test.ts test/resources/resource-corpus-artifact.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate resource-earthlike-expectations-artifact --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/resource-earthlike-expectations-artifact/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-earthlike-expectations-artifact/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Resource Earthlike Expectations Artifact Publishes Typed Contract
+
+The resource distribution workstream SHALL publish a typed source artifact for
+earthlike resource expectations before resource operations consume expectation
+rows.
+
+#### Scenario: Artifact is registered
+- **WHEN** the resource artifact catalog is loaded
+- **THEN** it exposes `artifact:resources.earthlikeExpectations`
+- **AND** the artifact name is `resourceEarthlikeExpectations`
+- **AND** no resource stage shell or recipe order change is introduced by this
+  artifact registration
+
+#### Scenario: Artifact covers the official corpus
+- **WHEN** earthlike expectations are published
+- **THEN** the artifact contains exactly the 55 official resource corpus symbols
+  in official corpus order
+- **AND** every row references its official resource symbol, static resource row
+  slot, and `runtimeIdStatus = "unverified"`
+- **AND** no `FEATURE_*` symbol appears in the artifact
+
+#### Scenario: Blocked rows stay active-zero
+- **WHEN** a corpus row has `strategyRequired.status = "blocked"`
+- **THEN** its earthlike expectation row has `status = "blocked"`
+- **AND** its active range is `min = 0`, `target = 0`, and `max = 0`
+- **AND** it has no active condition multipliers
+- **AND** it does not present a future nonzero range as an active expectation
+
+### Requirement: Resource Earthlike Expectations Schema Rejects Overclaims
+
+The resource earthlike expectations artifact schema SHALL reject malformed or
+overclaiming expectation rows.
+
+#### Scenario: Runtime id overclaims are rejected
+- **WHEN** an expectation row includes runtime numeric id fields such as
+  `runtimeId`, `resourceId`, or `numericId`
+- **THEN** schema validation fails
+
+#### Scenario: Feature leakage is rejected
+- **WHEN** an expectation row uses a `FEATURE_*` symbol
+- **THEN** schema validation fails
+
+#### Scenario: Blocked-row leakage is rejected
+- **WHEN** a blocked row has a nonzero active range or non-blocked range evidence
+- **THEN** schema validation fails
+
+### Requirement: Resource Earthlike Expectations Preserve Placement Boundary
+
+The resource earthlike expectations artifact SHALL remain a data contract and
+not a placement behavior change.
+
+#### Scenario: Placement behavior is not moved
+- **WHEN** the artifact source is added
+- **THEN** it does not import adapter runtime modules, `ResourceBuilder`,
+  placement ops, or placement materialization code
+- **AND** current placement resource planning behavior remains unchanged

--- a/openspec/changes/resource-earthlike-expectations-artifact/tasks.md
+++ b/openspec/changes/resource-earthlike-expectations-artifact/tasks.md
@@ -1,0 +1,28 @@
+## 1. Source Artifact
+
+- [x] 1.1 Add typed resource-domain expectation artifact source.
+- [x] 1.2 Preserve official corpus order and static row slots.
+- [x] 1.3 Keep runtime numeric ids unverified and absent from expectation rows.
+- [x] 1.4 Keep blocked/no-biome resources visible and active-zero.
+- [x] 1.5 Preserve crabs navigable-river eligibility.
+
+## 2. Schema And Artifact Registration
+
+- [x] 2.1 Register `artifact:resources.earthlikeExpectations`.
+- [x] 2.2 Add strict TypeBox artifact schema.
+- [x] 2.3 Reject runtime-id overclaims, feature rows, invalid statuses, missing
+  range fields, and blocked-row range leakage.
+
+## 3. Tests And Review
+
+- [x] 3.1 Add focused resource artifact tests.
+- [x] 3.2 Run framed implementation-readiness review before commit.
+- [x] 3.3 Run post-implementation review and repair accepted P1/P2 findings.
+
+## 4. Verification And Closure
+
+- [x] 4.1 Run focused resource tests.
+- [x] 4.2 Run package check.
+- [x] 4.3 Run OpenSpec validation.
+- [x] 4.4 Run `git diff --check`.
+- [x] 4.5 Commit the Graphite slice and leave the worktree clean.

--- a/openspec/changes/resource-earthlike-expectations-artifact/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-earthlike-expectations-artifact/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,7 @@
+# Downstream Realignment Ledger
+
+| Assumption | Downstream Owner | Disposition |
+|---|---|---|
+| Future resource operations can consume a typed expectation artifact. | Resource operation slices | Implemented as `artifact:resources.earthlikeExpectations`; next slices can design per-group ops against row contracts. |
+| Runtime numeric id proof remains separate. | Runtime proof slice | Preserved; expectation rows carry static symbols/slots only and runtime id status is unverified. |
+| Hard count gates require telemetry. | Stats and operation slices | Preserved in row `statsProof` text and parent OpenSpec; this slice does not add closure gates. |

--- a/openspec/changes/resource-earthlike-expectations-artifact/workstream/phase-record.md
+++ b/openspec/changes/resource-earthlike-expectations-artifact/workstream/phase-record.md
@@ -1,0 +1,47 @@
+# Phase Record: Resource Earthlike Expectations Artifact
+
+## Objective
+
+Implement the typed `artifact:resources.earthlikeExpectations` source contract
+from the OpenSpec-only expectation slice without moving placement behavior or
+claiming runtime numeric ids.
+
+## Repo State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
+- Branch: `codex/resource-earthlike-expectations-artifact`
+- Parent slice: `codex/resource-earthlike-expectations`
+- Studio/API pair for this worktree: `http://127.0.0.1:5174/`
+
+## Agent Review
+
+- Carson: implementation-readiness review. Outcome: require strict schema,
+  55-row coverage, blocked-row active-zero checks, no runtime/numeric id fields,
+  no feature leakage, crabs navigable-river preservation, no placement behavior
+  movement, and deep-frozen exports.
+- Carson: post-implementation review. Outcome: accepted P1s for blocked rows
+  validating as active rows and malformed active ranges validating; accepted P2
+  for row-level runtime-calibrated overclaim. Repairs were scoped-reviewed and
+  cleared.
+
+## Verification So Far
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-corpus-contract.test.ts test/resources/resource-corpus-artifact.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+  - Passed: 15 tests, 1673 assertions.
+- `bun run --cwd mods/mod-swooper-maps check`
+  - Passed.
+- `bun run openspec -- validate resource-earthlike-expectations-artifact --strict`
+  - Passed.
+- `bun run openspec:validate`
+  - Passed: 21 items.
+- `git diff --check`
+  - Passed.
+
+## Closure State
+
+- All accepted P1/P2 findings repaired and review-cleared.
+- Source slice was committed in its original resource stack and replayed into
+  `codex/integrate-resource-corpus-expectations` during the Graphite
+  integration workstream. No runtime numeric id proof is claimed by this
+  corpus/expectation replay slice.

--- a/openspec/changes/resource-earthlike-expectations-artifact/workstream/review-disposition-ledger.md
+++ b/openspec/changes/resource-earthlike-expectations-artifact/workstream/review-disposition-ledger.md
@@ -1,0 +1,14 @@
+# Review Disposition Ledger
+
+| Finding | Severity | Disposition | Evidence |
+|---|---:|---|---|
+| Runtime id overclaim must be impossible in expectation rows | P1 | accepted, implemented | Expectation rows omit runtime ids; strict schema rejects extra runtime/numeric fields. |
+| Expectation rows must cover exactly the official corpus | P1 | accepted, implemented | Artifact is generated in `OFFICIAL_RESOURCE_CORPUS` order and tests compare to `OFFICIAL_RESOURCE_TYPE_ORDER`. |
+| Blocked rows must stay active-zero | P1 | accepted, implemented | Blocked schema branch requires zero range and blocked evidence; tests check exact blocked list. |
+| Schema must be strict enough to reject malformed rows | P1 | accepted, implemented | TypeBox schema uses closed objects/enums and rejection tests. |
+| Placement behavior must not move in this slice | P1 | accepted, implemented | Source boundary test rejects adapter/runtime/placement imports. |
+| Groups cannot own aggregate closure gates | P2 | accepted, implemented | No group aggregate objects or group ranges are exported; rows own ranges and proof text. |
+| Crabs navigable-river eligibility must stay visible | P2 | accepted, implemented | Crabs row includes navigable-river proxy and official type-tag caveat; focused test asserts both. |
+| Schema accepted blocked resources as active rows | P1 | accepted, repaired, repair-reviewed | Schema now splits blocked and active resource symbol branches; tests reject `RESOURCE_CLOVES` as active. |
+| Schema accepted malformed active range ordering | P1 | accepted, repaired, repair-reviewed | Active range schema now allows only approved ordered range shapes; tests reject `min > target > max`. |
+| Runtime-calibrated claims validated without telemetry refs | P2 | accepted, repaired, repair-reviewed | Row-level `runtime-calibrated` evidence was removed from this schema/types until telemetry refs exist. |

--- a/openspec/changes/resource-earthlike-expectations/.openspec.yaml
+++ b/openspec/changes/resource-earthlike-expectations/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-earthlike-expectations/design.md
+++ b/openspec/changes/resource-earthlike-expectations/design.md
@@ -1,0 +1,186 @@
+# Resource Earthlike Expectations Design
+
+## Frame
+
+This slice is an expectation contract, not a placement implementation. It turns
+the official 55-row corpus into testable obligations that future resource ops
+must meet. The hard boundary from the corpus slice remains: static official
+symbols are source-backed, but runtime numeric ids remain unverified.
+
+The governing question is:
+
+```text
+For each official resource, what should an earthlike map generation operation
+attempt to place, under which conditions, and how will later stats prove the
+range is being met?
+```
+
+## Resource Group Partition
+
+Every official base-standard resource is assigned to exactly one expectation
+group. Groups organize research and operation design; they do not imply a
+single future implementation file.
+
+| Group | Resources |
+|---|---|
+| Aquatic, coastal, and navigable-river | `RESOURCE_FISH`, `RESOURCE_PEARLS`, `RESOURCE_WHALES`, `RESOURCE_CRABS`, `RESOURCE_COWRIE`, `RESOURCE_TURTLES` |
+| Cultivated, plantation, and medicinal | `RESOURCE_COTTON`, `RESOURCE_DATES`, `RESOURCE_DYES`, `RESOURCE_INCENSE`, `RESOURCE_SILK`, `RESOURCE_WINE`, `RESOURCE_COCOA`, `RESOURCE_SPICES`, `RESOURCE_SUGAR`, `RESOURCE_TEA`, `RESOURCE_COFFEE`, `RESOURCE_TOBACCO`, `RESOURCE_CITRUS`, `RESOURCE_QUININE`, `RESOURCE_MANGOS`, `RESOURCE_RICE`, `RESOURCE_CLOVES`, `RESOURCE_FLAX` |
+| Terrestrial animal, forest, and wild | `RESOURCE_CAMELS`, `RESOURCE_HIDES`, `RESOURCE_HORSES`, `RESOURCE_WOOL`, `RESOURCE_IVORY`, `RESOURCE_FURS`, `RESOURCE_TRUFFLES`, `RESOURCE_RUBBER`, `RESOURCE_HARDWOOD`, `RESOURCE_WILD_GAME`, `RESOURCE_LLAMAS` |
+| Geological, mineral, gemstone, and industrial | `RESOURCE_GOLD`, `RESOURCE_GOLD_DISTANT_LANDS`, `RESOURCE_SILVER`, `RESOURCE_SILVER_DISTANT_LANDS`, `RESOURCE_GYPSUM`, `RESOURCE_JADE`, `RESOURCE_KAOLIN`, `RESOURCE_MARBLE`, `RESOURCE_IRON`, `RESOURCE_SALT`, `RESOURCE_LAPIS_LAZULI`, `RESOURCE_NITER`, `RESOURCE_COAL`, `RESOURCE_NICKEL`, `RESOURCE_OIL`, `RESOURCE_CLAY`, `RESOURCE_LIMESTONE`, `RESOURCE_TIN`, `RESOURCE_PITCH`, `RESOURCE_RUBIES` |
+
+Coverage invariant: `6 + 18 + 11 + 20 = 55`.
+
+## Expectation Row Shape
+
+Each resource expectation row records:
+
+- `resourceType`
+- `groupId`
+- `officialCorpusRef` by resource symbol and static row slot
+- `status`: `expected`, `conditional`, or `blocked`
+- `eligibleAges`
+- `officialConstraintSummary`
+- `earthlikePredicate`
+- `expectedCountRange` for a standard earthlike map baseline, expressed as
+  per-resource `min`, `target`, and `max`
+- `conditionMultipliers`
+- `scarcityClass`
+- `operationObligation`
+- `statsProof`
+- `evidenceStrength`
+- `evidenceRefs`
+- `caveats`
+
+`expectedCountRange` is a per-resource bounded envelope, not a final tuned constant. It
+must be wide enough to tolerate seed variance and map-size differences, but
+narrow enough to catch the current failure mode where only a minority of
+resources appear.
+
+Groups are non-gating research and implementation rollups. They help organize
+evidence packs and future operation files, but they cannot close a stats gate.
+Each `resourceType` row owns its own predicate, `min`/`target`/`max`, evidence
+strength, gate status, and stats proof.
+
+## Status Mapping
+
+Expectation status is derived from corpus disposition before earthlike
+judgment:
+
+- `expected`: allowed only when `strategyRequired.status === "required"` in
+  `artifact:resources.corpus`.
+- `blocked`: inherited when corpus strategy coverage is blocked; this applies
+  to the five no-biome or no-age/no-biome caveat rows until a source-backed
+  map-placement disposition exists.
+- `conditional`: reserved for source-backed placement rows whose expectation
+  depends on age, map shape, or environmental supply. It is not a way to
+  include blocked corpus rows in later placement operations.
+
+## Evidence Policy
+
+Authority order for expectation rows:
+
+1. Official Civ7 corpus rows for ages, valid biome count, flags, resource class,
+   weight, and blocked/no-biome caveats.
+2. Repo-local mapgen field semantics for available map conditions: coast,
+   ocean, river, biome, aridity, forest, hills, mountains, wetland, floodplain,
+   and latitude when present.
+3. External earthlike evidence for real-world distribution and habitat/geologic
+   association.
+4. Explicit inference rules when exact source-backed ranges are unavailable.
+
+Earthlike predicates that depend on derived geologic or ecological concepts
+must name the concrete map field or proxy that later implementation will use.
+Examples include sedimentary basin, carbonate belt, evaporite basin, ultramafic
+belt, orogeny, upwelling, estuary, reef, and navigable-river mouth. If no proxy
+exists, the expectation row records the proxy gap rather than pretending the
+operation can test the condition.
+
+Claim strength:
+
+- `source-backed`: official or external evidence directly supports the
+  placement predicate or relative rarity.
+- `inference-backed`: evidence supports the physical/ecological model, but the
+  count range is derived from Civ7 map size, resource class, weight, and
+  eligible-tile prevalence.
+- `runtime-calibrated`: seed-matrix or in-game telemetry has confirmed the
+  range against generated-map eligible-tile denominators.
+- `blocked`: official Civ7 rows do not currently expose enough map-placement
+  constraints for a responsible operation obligation.
+
+Rows also carry evidence strength by concern:
+
+- `official`: official Civ7 data controls legality, age, class, flags, or
+  distribution facts.
+- `external`: real-world evidence controls habitat or geologic association.
+- `inferred`: count ranges or multipliers are derived from official and
+  external evidence but are not yet telemetry-calibrated.
+- `runtime-calibrated`: generated-map or in-game telemetry has verified the
+  claim.
+
+## Range Derivation Model
+
+Later operation slices shall derive resource count ranges from:
+
+```text
+eligible tile supply
+  * resource class pressure
+  * official weight/flags
+  * age availability
+  * earthlike rarity class
+  * group-specific distribution model used only as a non-gating rollup
+```
+
+The expectation artifact records the result as per-resource ranges and named
+multipliers, not as an opaque formula. Stats gates can then compare actual
+generated resource counts against expected envelopes without knowing
+implementation internals.
+
+Expectation ranges are provisional until seed-matrix telemetry records
+eligible-tile denominators and actual placement outcomes. A later operation
+slice may use these ranges as warning thresholds before calibration, but it
+must not promote them to hard closure gates until the range is
+`runtime-calibrated`. Official evidence can justify legality, visibility,
+blocked status, and warning thresholds, but hard count closure requires
+eligible-tile denominator and placement telemetry.
+
+## Blocked Rows
+
+The following rows remain blocked until a source-backed map-placement
+disposition exists:
+
+- `RESOURCE_GOLD_DISTANT_LANDS`
+- `RESOURCE_SILVER_DISTANT_LANDS`
+- `RESOURCE_LAPIS_LAZULI`
+- `RESOURCE_CLOVES`
+- `RESOURCE_NICKEL`
+
+Blocked expectation rows still appear in the artifact so coverage is complete,
+but later placement operations must not silently pretend they are implemented.
+
+## Official Constraint Preservation
+
+Per-resource rows must carry official tags and placement flags from the corpus
+into expectation design. `RESOURCE_CRABS` specifically keeps its
+`NAVIGABLE_RIVERS_ELIGIBLE` lane visible; a future coastal scorer cannot
+silently drop navigable-river eligibility by treating the whole group as
+coast-only.
+
+## Write Set
+
+- `openspec/changes/resource-earthlike-expectations/**`
+- Optional, after review only:
+  `mods/mod-swooper-maps/src/domain/resources/earthlike-expectations/**`
+- Optional, after review only:
+  `mods/mod-swooper-maps/src/recipes/standard/stages/resources/artifacts.ts`
+- Optional, after review only:
+  `mods/mod-swooper-maps/test/resources/**`
+
+## Review Gates
+
+Before implementation, peer review must confirm:
+
+- the partition covers all 55 resources exactly once;
+- the evidence policy does not overclaim precision;
+- blocked/no-biome rows remain blocked;
+- no runtime numeric id claim enters the expectation contract;
+- the artifact can support future resource-owned operation slices.

--- a/openspec/changes/resource-earthlike-expectations/proposal.md
+++ b/openspec/changes/resource-earthlike-expectations/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+The resource stage cannot safely move from "some resources appear" to
+per-resource operations until each official resource has an explicit earthlike
+expectation envelope. The prior corpus slice proved the 55 official
+base-standard `Resources` rows and kept runtime numeric ids unverified. This
+slice defines the expectation layer that downstream resource ops must satisfy:
+which conditions make each resource eligible, what range is expected on
+standard earthlike maps, and what proof can later show the operation is
+healthy.
+
+## Target Authority Refs
+
+- `openspec/changes/resource-distribution-planning`: per-resource coverage,
+  expected values, and stats proof requirements.
+- `openspec/changes/resource-stage-architecture`: resources target stage and
+  resource-owned artifacts before behavior migration.
+- `openspec/changes/resource-corpus-contract`: official 55-row corpus,
+  `artifact:resources.corpus`, static row slots, and unverified runtime ids.
+- `.civ7/outputs/resources/Base/modules/base-standard/data/resources.xml` and
+  `resources-v2.xml`: official placement constraints, ages, weights, and
+  distribution facts.
+
+## What Changes
+
+- Define resource expectation groups that cover all 55 official resources
+  exactly once.
+- Add a durable expectation artifact design for
+  `artifact:resources.earthlikeExpectations` without moving placement behavior
+  or verifying runtime numeric ids.
+- Record the evidence policy for earthlike expected ranges, including when a
+  range is source-backed, inference-backed, or blocked.
+- Record per-resource obligations that later operation slices must implement:
+  eligibility predicates, expected count/range envelopes, condition
+  multipliers, scarcity class, caveats, and stats proof requirements.
+- Preserve the five blocked/no-biome corpus caveats as blocked expectation
+  rows until a source-backed map-placement disposition exists.
+
+## Explicit Non-Goals
+
+- No movement of `placement/plan-resources` or `place-resources`.
+- No resource stage shell, recipe order change, or runtime behavior change.
+- No runtime `GameInfo.Resources` numeric id verification.
+- No symbolic joining of adapter numeric placement diagnostics to resource
+  symbols.
+- No generated-output, official submodule, lockfile, adapter constant, or SDK
+  constant edits.
+- No final tuning of placement counts; downstream operation slices own tuning
+  and stats proof.
+
+## Verification Gates
+
+- `bun run openspec -- validate resource-earthlike-expectations --strict`
+- `bun run openspec:validate`
+- `git diff --check`
+
+Focused code/tests gates will be added only if this slice introduces typed
+expectation artifacts in source.

--- a/openspec/changes/resource-earthlike-expectations/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-earthlike-expectations/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: Resource Expectations Cover Official Resource Corpus
+
+The resource distribution workstream SHALL define earthlike expectation rows for
+every official resource before resource operations claim per-resource coverage.
+
+#### Scenario: Every corpus row has an expectation disposition
+- **WHEN** the 55-row official resource corpus is converted into expectations
+- **THEN** every `artifact:resources.corpus` resource symbol appears exactly
+  once in the expectation contract
+- **AND** each expectation row records a status of `expected`, `conditional`,
+  or `blocked`
+- **AND** blocked rows remain visible rather than being dropped from coverage
+- **AND** `expected` status is allowed only for corpus rows whose
+  `strategyRequired.status` is `required`
+- **AND** corpus-blocked rows remain `blocked` until source-backed placement
+  evidence changes their disposition
+
+#### Scenario: Resource groups preserve complete coverage
+- **WHEN** resource expectation groups are defined
+- **THEN** the groups cover all 55 official resources exactly once
+- **AND** `FEATURE_LOTUS` and any other non-resource feature is excluded from
+  the resource expectation corpus
+
+### Requirement: Resource Expectations Define Earthlike Placement Envelopes
+
+The resource distribution workstream SHALL define source-backed or
+inference-backed earthlike placement envelopes before implementing
+per-resource operations.
+
+#### Scenario: Expected resources carry operation obligations
+- **WHEN** a resource expectation row has status `expected`
+- **THEN** it records an earthlike placement predicate
+- **AND** it records a standard earthlike expected count range with
+  per-resource `min`, `target`, and `max`
+- **AND** it records condition multipliers that explain how map size and
+  relevant terrain, biome, coast, river, latitude, relief, or age conditions
+  adjust the range
+- **AND** it records the stats proof required for later operation slices
+- **AND** any derived ecological or geologic predicate names the concrete map
+  field or proxy needed to implement and test it
+- **AND** missing proxies are recorded as open proof needs instead of silent
+  implementation assumptions
+- **AND** hard closure gates are not promoted from inferred ranges until
+  seed-matrix or in-game telemetry calibrates them against eligible-tile
+  denominators
+
+#### Scenario: Evidence strength is explicit
+- **WHEN** a resource expectation row records legality, habitat, range, or
+  proof claims
+- **THEN** each claim identifies its evidence strength as `official`,
+  `external`, `inferred`, or `runtime-calibrated`
+- **AND** runtime-calibrated claims cite generated-map or in-game telemetry
+
+#### Scenario: Groups are non-gating rollups
+- **WHEN** resource expectation groups are used for operation design
+- **THEN** each group is treated as a research and implementation rollup
+- **AND** closure gates remain per-resource rather than group-aggregate
+- **AND** every `resourceType` row owns its own predicate, range, evidence
+  strength, gate status, and stats proof
+
+#### Scenario: Official placement lanes are preserved
+- **WHEN** a resource row has official placement flags or type tags
+- **THEN** the expectation row carries those facts forward
+- **AND** `RESOURCE_CRABS` keeps its navigable-river eligibility visible rather
+  than becoming coast-only through group assignment
+
+#### Scenario: Ranges preserve evidence strength
+- **WHEN** an expected count range is recorded
+- **THEN** the row identifies whether the range is `source-backed` or
+  `inference-backed`, or whether it has become `runtime-calibrated`
+- **AND** inference-backed ranges name the inference rule that produced them
+- **AND** the contract does not present inferred ranges as exact real-world
+  prevalence
+
+### Requirement: Resource Expectations Preserve Runtime ID Boundary
+
+The resource expectation contract SHALL not convert static official resource
+symbols into runtime numeric id claims.
+
+#### Scenario: Runtime ids remain unverified
+- **WHEN** resource expectations are recorded before runtime proof exists
+- **THEN** expectation rows reference official resource symbols and static
+  corpus slots only
+- **AND** they do not assign or verify `GameInfo.Resources` numeric ids
+- **AND** adapter numeric placement diagnostics are not labeled with resource
+  symbols through the expectation contract

--- a/openspec/changes/resource-earthlike-expectations/tasks.md
+++ b/openspec/changes/resource-earthlike-expectations/tasks.md
@@ -1,0 +1,31 @@
+## 1. Research And Grouping
+
+- [x] 1.1 Open a resource-expectations phase on a new Graphite branch.
+- [x] 1.2 Partition all 55 official resources into reviewable resource groups.
+- [x] 1.3 Complete framed agent evidence packs for each resource group.
+- [x] 1.4 Complete framed agent review of grouping and evidence policy.
+- [x] 1.5 Repair accepted P1/P2 findings before implementation.
+
+## 2. Expectation Contract
+
+- [x] 2.1 Define the per-resource expectation row contract.
+- [x] 2.2 Record per-resource earthlike predicates and expected count ranges.
+- [x] 2.3 Record condition multipliers and scarcity classes.
+- [x] 2.4 Keep blocked/no-biome resources visible and blocked.
+- [x] 2.5 Preserve runtime numeric id status as unverified.
+
+## 3. Artifact Boundary
+
+- [x] 3.1 Decide whether this slice introduces source code for
+  `artifact:resources.earthlikeExpectations` or remains OpenSpec-only.
+- [x] 3.2 If source is introduced, add focused tests for 55-row coverage,
+  blocked-row visibility, runtime-id non-overclaim, and `FEATURE_*`
+  exclusion.
+
+## 4. Review And Verification
+
+- [x] 4.1 Run OpenSpec validation.
+- [x] 4.2 Run focused code gates if source files are added.
+- [x] 4.3 Run `git diff --check`.
+- [x] 4.4 Complete downstream realignment and closure-record updates.
+- [x] 4.5 Commit the Graphite slice and leave the worktree clean.

--- a/openspec/changes/resource-earthlike-expectations/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-earthlike-expectations/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,8 @@
+# Downstream Realignment Ledger
+
+| Assumption | Downstream Owner | Disposition |
+|---|---|---|
+| Resource operations must be designed by explicit resource or resource group, not by generic numeric sweep alone. | Future resource operation slices | Preserved; groups are non-gating rollups and per-resource rows own predicates/ranges/proof. |
+| Blocked/no-biome official rows stay visible in resource coverage. | Future resource stats and implementation gates | Preserved; blocked rows have active range `0 official; blocked`. |
+| Runtime numeric id proof remains separate from expectation design. | Future runtime proof slice | Preserved; expectation rows reference official symbols and static corpus slots only. |
+| Accepted resource-stage artifact name is `artifact:resources.earthlikeExpectations`. | Current expectation slice and future resource stage shell | Realigned after review; no competing artifact name remains. |

--- a/openspec/changes/resource-earthlike-expectations/workstream/evidence-packs.md
+++ b/openspec/changes/resource-earthlike-expectations/workstream/evidence-packs.md
@@ -1,0 +1,256 @@
+# Evidence Packs
+
+## Aquatic, Coastal, And Navigable-River Resources
+
+Source agent: Kant.
+
+### Group Model
+
+Aquatic resources are nearshore productivity signals rather than generic water
+fill. Official Civ7 eligibility starts from marine/coast and adjacent-land
+constraints, while `RESOURCE_CRABS` also carries a navigable-river floodplain
+lane. Earthlike weighting should narrow by habitat:
+
+- fish and crabs: shelves, estuaries, upwelling, seagrass, reefs, river mouths;
+- pearls, cowrie, turtles: warm shallow reef, lagoon, seagrass, island and
+  protected coast systems;
+- whales: productive cold or temperate shelves, upwelling, banks, and migration
+  corridors.
+
+Lotus remains excluded because local official data defines `FEATURE_LOTUS`, not
+a `Resources` row.
+
+### Ranges
+
+| Resource | Predicate Summary | Standard Earthlike Range | Multipliers | Scarcity |
+|---|---|---:|---|---|
+| `RESOURCE_FISH` | broad coastal shelf, estuary, upwelling fishery | 6-12 | scale by eligible coast/shelf; up for upwelling/estuary; down for ice, deep ocean, lakes | common |
+| `RESOURCE_PEARLS` | warm shallow protected coast, reef, lagoon, shelf | 2-5 | up for tropical/subtropical reefs and lagoons; down for temperate/cold; zero if no warm coast | scarce |
+| `RESOURCE_WHALES` | productive cold/temperate shelf, upwelling, banks | 1-3; Antiquity 0 | up for cold/temperate shelf, upwelling, large oceans; down for tropical abundance; zero lakes | rare/signature |
+| `RESOURCE_CRABS` | estuary, delta, brackish bay, shallow coast, navigable river mouth/floodplain | 4-10 | up for estuaries, navigable rivers, seagrass, warm shallows; down for cold/deep/open coast | common-local |
+| `RESOURCE_COWRIE` | warm tropical reef, rock, coral coast, protected shallows | 1-4 | up for tropical reef/island chains; down for temperate; zero lakes/cold | scarce/local |
+| `RESOURCE_TURTLES` | warm tropical/subtropical coast with nesting beach, seagrass, reef habitat | 1-3; Modern 0 | up for tropical/subtropical shallows, seagrass, reefs, islands; down for cold/open/deep; zero lakes | rare/signature |
+
+### Inference Rules
+
+- Official Civ7 constraints are hard eligibility. External ecology narrows
+  priority; it does not widen legality.
+- Counts scale by eligible habitat, not raw map area.
+- Use soft count gates until seed-matrix telemetry proves variance.
+- Age gates are hard: whales are zero in Antiquity, turtles are zero in Modern.
+- Map size scaling starts from approximate area multipliers: Tiny `0.5x`,
+  Small `0.75x`, Large `1.25x`, Huge `1.55x`, then adjusts for eligible coast
+  and ocean share.
+- Archipelago or shattered-sea maps bias aquatic expectations upward; low-coast
+  or pangaea maps bias them downward.
+
+### Open Proof Needs
+
+- Runtime numeric ids remain unproven; do not join symbolic resource names to
+  adapter numeric outcomes until runtime telemetry verifies `GameInfo.Resources`.
+- Fish, pearls, and crabs need implementation-time lake policy review because
+  official data does not mark them `LakeEligible=false`, while this expectation
+  model is marine/coastal.
+- Do not hard-code these ranges as strict gates until seed-matrix stats include
+  eligible-tile denominators.
+
+## Geological, Mineral, Gemstone, And Industrial Resources
+
+Source agent: Godel.
+
+### Group Model
+
+Geological resources should be geology-first within Civ7 official constraints.
+Official `Resource_ValidBiomes` rows are hard eligibility unless a later
+OpenSpec explicitly authorizes a synthetic predicate. Earthlike scoring then
+ranks eligible plots by geologic province:
+
+- metallic ores and gemstones: orogenic, hydrothermal, epithermal, metamorphic,
+  granite, ultramafic, and placer proxies;
+- carbonate and metamorphic materials: limestone, marble, rubies, and lapis
+  through carbonate/metamorphic belts;
+- evaporites and nitrates: arid closed basins, playas, and evaporite flats;
+- coal, oil, clay, kaolin, and pitch: sedimentary basins, wetlands, weathered
+  flats, and hydrocarbon basin edges.
+
+Pure Civ7-biome placement remains a structural fallback candidate for later
+implementation only if the map lacks the needed proxies; it is not sufficient
+to satisfy the earthlike expectation object by itself.
+
+### Ranges
+
+| Resource | Predicate Summary | Standard Earthlike Range | Multipliers | Scarcity |
+|---|---|---:|---|---|
+| `RESOURCE_GOLD` | hydrothermal, orogenic, epithermal lodes; placer only with alluvial proxy | 16-20 if active | hills/orogen `1.5-2x`; alluvial `1.2x`; outside official hills `0x` | common/anchored |
+| `RESOURCE_GOLD_DISTANT_LANDS` | not independently map-placeable without distant-lands treasure authorization | 0 official; blocked | no active multiplier while corpus-blocked | blocked |
+| `RESOURCE_SILVER` | hydrothermal, SEDEX/lithogene, epithermal exposed cold/arid hills | 16-20 if active | tundra/desert hills `1.4x`; orogen `1.5x`; flat `0x` | common/anchored |
+| `RESOURCE_SILVER_DISTANT_LANDS` | not independently map-placeable without distant-lands treasure authorization | 0 official; blocked | no active multiplier while corpus-blocked | blocked |
+| `RESOURCE_GYPSUM` | evaporite basin, playa, arid or semiarid sedimentary basin | 4-8 | evaporite/sedimentary basin `1.5-2x`; desert `1.4x`; wet `0.5x` | moderate |
+| `RESOURCE_JADE` | metamorphic, subduction, serpentinite jade, often drainage-adjacent | 2-5 | ultramafic/orogen `2x`; tropical/tundra drainage `1.2x`; no geology `0.4x` | rare |
+| `RESOURCE_KAOLIN` | intense weathering, hydrothermal alteration, wet clay-rich flats | 6-10 | wetlands `2x`; tropical weathering `1.5x`; arid non-oasis `0.5x` | common |
+| `RESOURCE_MARBLE` | metamorphosed limestone/carbonate belts near orogeny/contact metamorphism | 4-8 | carbonate plus orogen `2x`; hills `1.3x`; no carbonate `0.4x` | moderate |
+| `RESOURCE_IRON` | BIF, skarn, magmatic, or hydrothermal iron in hills, cratons, mountain belts | 8-14 | hills `1.5x`; craton/orogen `1.5x`; flat `0x` | common strategic |
+| `RESOURCE_SALT` | halite/evaporite flats, arid closed basins, salt pans | 5-9 | desert/evaporite basin `2x`; coastal land-flat salt pan `1.1x`; humid `0.5x` | moderate |
+| `RESOURCE_LAPIS_LAZULI` | rare metamorphic calcite/dolomite/silicate veins in mountains | 0 official; blocked | no active multiplier while corpus-blocked | blocked/very rare |
+| `RESOURCE_NITER` | nitrate salts in arid soils/playas; cave or soil nitrate abstracted to flats | 6-10 | desert/closed basin `1.5-2x`; floodplain `1.3x`; humid `0.7x` | moderate |
+| `RESOURCE_COAL` | ancient peat-swamp sedimentary basins; buried forest/wetland basins | 6-10 | sedimentary basin `2x`; forest/wetland `1.5x`; desert only with basin `1x` | common modern |
+| `RESOURCE_NICKEL` | mafic/ultramafic sulfides or tropical laterite | 0 official; blocked | no active multiplier while corpus-blocked | blocked/rare |
+| `RESOURCE_OIL` | petroleum system in sedimentary basin: source, reservoir, seal, trap | 5-9 | sedimentary basin `2.5x`; desert/tundra/wetland basin `1.3x`; offshore `0x` unless authorized | moderate modern |
+| `RESOURCE_CLAY` | near-surface clay minerals in soils, sediments, water-contact/weathering zones | 6-10 | wet/alluvial `2x`; tropical weathering `1.5x`; no feature `0x` | common |
+| `RESOURCE_LIMESTONE` | marine carbonate sedimentary deposits, karst/carbonate platforms | 6-12 | carbonate basin `2x`; hills/exposure `1.2x`; igneous terrain `0.4x` | common industrial |
+| `RESOURCE_TIN` | cassiterite greisen/granite lodes plus river/valley placers | 8-14 | granite/orogen `1.7x`; tropical/alluvial `1.4x`; no granite/placer `0.6x` | moderate gameplay-common |
+| `RESOURCE_PITCH` | bitumen/asphaltum seeps, shallow tar sands, hydrocarbon basin edge | 3-6 | hydrocarbon basin `2x`; near oil `1.5x`; no basin `0.4x` | scarce |
+| `RESOURCE_RUBIES` | corundum in marble/metamorphic belts; basalt-hosted or placer only with source proxy | 3-6 | marble/metamorphic `2x`; tropical collision belt `1.5x`; flat tropical needs source | rare luxury |
+
+### Inference Rules
+
+- Official `Resource_ValidBiomes` rows are hard eligibility. Earthlike geology
+  ranks within those rows unless a later OpenSpec creates a synthetic placement
+  rule.
+- No-biome rows do not place by default.
+- Distant-lands, lapis lazuli, and nickel ranges above are active blocked
+  states only. Any future nonzero ranges require a later source-backed
+  disposition change and must be recorded outside the current active range.
+- Official `MinimumPerHemisphere` anchors gold and silver. Other ranges derive
+  from official weight, class, valid-row breadth, and geologic rarity.
+- Era gates are hard unless a later slice defines a persistence rule.
+
+### Open Proof Needs
+
+- If official XML adds valid biomes for lapis lazuli, nickel, or distant-lands
+  variants, revise blocked status.
+- If runtime proves `MinimumPerHemisphere` semantics differ from the field name,
+  revise gold and silver ranges.
+- If MapGen lacks proxies for sedimentary basin, carbonate belt, evaporite
+  basin, ultramafic belt, or orogeny, implementation must define proxies or
+  fall back to official biome/terrain with an explicit proof gap.
+
+## Cultivated, Plantation, And Medicinal Resources
+
+Source agent: Hooke.
+
+### Group Model
+
+Cultivated expectations use official Civ7 constraints as hard legality and
+external crop ecology only to rank and target eligible tiles. This group is not
+one ecology: it includes irrigated/alluvial crops, humid tropical plantation
+crops, temperate cultivated crops, arid resin/incense, medicinal bark, and one
+official marine dye lane. `RESOURCE_CLOVES` remains blocked because local
+official data has no `Resource_ValidBiomes` rows.
+
+Baseline ranges are standard-map, eligible-age guidance. Non-eligible ages are
+zero. Ranges are inference-backed unless an official `MinimumPerHemisphere=8`
+floor anchors them.
+
+### Ranges
+
+| Resource | Predicate Summary | Standard Earthlike Range | Multipliers | Scarcity |
+|---|---|---:|---|---|
+| `RESOURCE_COTTON` | warm frost-free alluvial or irrigated cotton belt | 6/8/12 | floodplain/river up; warm grass/plains up; cold down; desert only with water | common |
+| `RESOURCE_DATES` | hot arid oasis or groundwater-fed desert palm | 2/3/5 | oasis/desert water up; humid/cold zero | scarce-local |
+| `RESOURCE_DYES` | coastal biological dye source under official marine/coast rules | 2/3/5 | warm coast/islands up; inland zero | scarce/coastal |
+| `RESOURCE_INCENSE` | arid dry woodland or desert-edge incense resin habitat | 2/3/5 | savanna/desert dry woodland up; humid/cold down | scarce |
+| `RESOURCE_SILK` | warm temperate/subtropical sericulture or mulberry alluvial zone | 4/6/8 | river/floodplain up; humid grass/plains up; arid/cold down | moderate |
+| `RESOURCE_WINE` | sunny temperate to subtropical dry-season viticulture | 4/6/8 | grass/plains up; dry-summer up; humid tropics down; frost down | moderate |
+| `RESOURCE_COCOA` | humid tropical shaded forest plantation | 8/10/12 if active | rainforest/wet tropics up; arid/cold zero | regional abundant |
+| `RESOURCE_SPICES` | humid forest spice belt, tropical/subtropical | 8/10/12 if active | rainforest/forest up; wet tropics up; dry plains down | regional abundant |
+| `RESOURCE_SUGAR` | warm wet alluvial tropics/subtropics | 8/10/12 if active | floodplain/river/wet tropics up; arid without irrigation zero; cold zero | regional abundant |
+| `RESOURCE_TEA` | humid acidic upland or cool subtropical tea zone | 8/10/12 if active | hills up; wet/cool up; arid/desert zero | regional abundant |
+| `RESOURCE_COFFEE` | humid tropical/subtropical highland or shaded tropical coffee belt | 16/18/20 if active | tropical/hills/forest up; arid/cold zero | common anchored |
+| `RESOURCE_TOBACCO` | frost-free warm drained soils with drier ripening window | 16/18/20 if active | grass/plains up; savanna/forest up; waterlogging/excess rain down | common anchored |
+| `RESOURCE_CITRUS` | subtropical/tropical sunny orchard, frost-limited, well-drained | 16/18/20 if active | warm grass/plains up; alluvial up; frost zero; severe arid down unless irrigated | common anchored |
+| `RESOURCE_QUININE` | humid tropical montane medicinal bark, constrained to official forest/savanna lanes | 16/18/20 if active | wet forest/highland proxy up; arid/desert zero | common anchored, ecology-constrained |
+| `RESOURCE_MANGOS` | tropical/subtropical frost-free fruit belt, often monsoonal | 3/5/7 | tropical up; rainforest up; cold zero; excessive wet at flowering slightly down | moderate tropical |
+| `RESOURCE_RICE` | wetland, paddy, delta, marsh, monsoon lowland | 4/6/8 | marsh/mangrove/river/floodplain up; arid without water zero | moderate-common |
+| `RESOURCE_CLOVES` | external predicate would be humid tropical island/rainforest spice tree | 0 official; blocked | no active multiplier while corpus-blocked | blocked/rare |
+| `RESOURCE_FLAX` | cool-temperate to mild subtropical flax on well-drained loam | 5/7/9 | grass/plains up; cool/mild up; tropical wet/heat down | moderate |
+
+### Inference Rules
+
+- Official `Resource_ValidBiomes`, ages, class, weight, and flags are hard
+  constraints.
+- External crop ecology narrows priority within official legality; it does not
+  create new legal tiles.
+- `MinimumPerHemisphere=8` starts floor-backed resources at eight plus official
+  map-size modifiers; non-hemisphere-unique resources can use roughly
+  two-hemisphere standard totals until runtime proves otherwise.
+- Non-floor ranges use weight, class, eligible-tile breadth, and ecological
+  rarity: broad common `6-12`, moderate `4-8`, scarce `2-5`, blocked `0`.
+- If eligible tile supply cannot support a floor without illegal placement,
+  record a proof gap instead of force-placing.
+- Cloves remains an active blocked row. Any future nonzero range requires a
+  later source-backed disposition change and must be recorded outside the
+  current active range.
+
+### Open Proof Needs
+
+- If local official XML adds valid biomes for `RESOURCE_CLOVES`, revise blocked
+  status.
+- Runtime proof is needed for exact `MinimumPerHemisphere` semantics.
+- Seed-matrix stats need eligible-tile denominators before these become hard
+  gates.
+- `RESOURCE_DYES` must stay marine/coastal unless official data changes.
+- `RESOURCE_QUININE`, `RESOURCE_TEA`, and `RESOURCE_COFFEE` need concrete
+  highland/relief proxies or must degrade to official biome/terrain only.
+- `FEATURE_LOTUS` remains excluded.
+
+## Terrestrial Animal, Forest, And Wild Biological Resources
+
+Source agent: Noether.
+
+### Group Model
+
+Terrestrial biological expectations use a legality-first habitat and land-use
+model. Official age, class, and `Resource_ValidBiomes` rows are hard
+constraints; earthlike ecology ranks legal candidates and sets provisional
+ranges. The group has four habitat families:
+
+- open rangeland livestock and herbivores;
+- forest and woodland wildlife;
+- tropical forest products;
+- regional highland pastoral resources.
+
+All resources in this group are placeable and required in the current corpus.
+Count bands are provisional active-age guidance and must stay soft until
+seed-matrix telemetry calibrates candidate and placement counts.
+
+### Ranges
+
+| Resource | Predicate Summary | Standard Earthlike Range | Multipliers | Scarcity |
+|---|---|---:|---|---|
+| `RESOURCE_CAMELS` | legal arid plains/desert rangeland, sparse vegetation, dryland corridors | 2-5 | arid/desert/plains `1.5-2x`; humid/forest/cold `0.3x` | uncommon regional |
+| `RESOURCE_HIDES` | broad grazing/wild-herbivore byproduct on open rangeland and cold-edge habitat | 8-14 | grass/plains/tundra `1.2-1.5x`; dense tropical/closed forest `0.7x` | common |
+| `RESOURCE_HORSES` | open temperate grassland/plains, steppe-like pasture, low tree cover | 4-8 | grass/plains `1.3x`; high forest/desert/tundra `0.5x` | standard strategic |
+| `RESOURCE_WOOL` | hill/highland pastoral terrain with sheep/goat-compatible grazing | 4-8 | hills/highlands/arid/tundra `1.4x`; flat wet lowlands `0.6x` | standard |
+| `RESOURCE_IVORY` | savanna, wooded savanna, tropical forest edge, watering-hole/desert-edge megafauna habitat | 2-5 | savanna/tropical/watering-hole `1.4x`; cold/highland `0.4x` | rare regional |
+| `RESOURCE_FURS` | cold/boreal forest, taiga, woodland edge, small patchy pockets | 2-5 | taiga/tundra `1.5x`; savanna woodland `1.2x`; open tropical/grass `0.5x` | rare/patchy |
+| `RESOURCE_TRUFFLES` | moist woodland-edge/host-tree proxy on legal grass/plains/tundra wet soils | 2-5 | moist wooded edge/grass hills `1.4x`; arid/cold `0.6x` | uncommon patchy |
+| `RESOURCE_RUBBER` | humid tropical forest/rainforest, lowland high-rainfall forest product | 2-4 | tropical rainforest/forest `1.5x`; arid/cold/no tropics `0.3x` | rare modern |
+| `RESOURCE_HARDWOOD` | legal productive forest: tropical/mangrove hardwood or official tundra/taiga-bog forest analog | 4-8 | tropical forest/mangrove and tundra forest analog `1.4x`; open plains/grass `0.6x` | standard forest |
+| `RESOURCE_WILD_GAME` | diverse natural habitat, forest/grassland/tundra/marsh edge, low cultivation pressure | 6-10 | high habitat diversity `1.4-1.6x`; monoclimatic/cultivated `0.6x` | common-natural |
+| `RESOURCE_LLAMAS` | legal tropical hill/highland pastoral candidates, preferring hill/highland over rainforest lowland | 1-4 | tropical hills/highlands `1.4x`; lowland tropical `0.5x`; no tropical legal tiles zero | rare regional |
+
+### Inference Rules
+
+- Start from `standardLandFactor = actualLandTiles / ~1678`, then multiply by
+  legal habitat availability and condition multipliers.
+- Outside official valid ages, expected count is zero.
+- Never place outside official `Resource_ValidBiomes` unless later
+  official/runtime proof changes legality.
+- Commodity resources such as hides, furs, and wild game infer from habitat
+  family and land-use opportunity, not a single species.
+- Rarity combines official weight, habitat breadth, age availability, and
+  real-world geographic specialization.
+
+### Open Proof Needs
+
+- Runtime `ResourceBuilder.canHaveResource` legality should be audited against
+  static XML rows before hard gates.
+- Runtime name-to-index dump is required before numeric strategy constants can
+  be symbolic.
+- `RESOURCE_LLAMAS` needs a tropical hill/highland candidate histogram because
+  real-world Andean habitat and official tropical-only legality are misaligned.
+- `RESOURCE_HARDWOOD` must not broaden to temperate forests without official or
+  runtime proof.
+- `RESOURCE_TRUFFLES` needs a woodland/host proxy before its range becomes a
+  hard assertion.

--- a/openspec/changes/resource-earthlike-expectations/workstream/phase-record.md
+++ b/openspec/changes/resource-earthlike-expectations/workstream/phase-record.md
@@ -1,0 +1,70 @@
+# Phase Record: Resource Earthlike Expectations
+
+## Objective
+
+Define the source-backed expectation layer that future resource operations must
+satisfy for all 55 official base-standard resources, without moving placement
+behavior or claiming runtime numeric ids.
+
+## Repo State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
+- Branch: `codex/resource-earthlike-expectations`
+- Parent slice: `codex/resource-corpus-contract`
+- Running local server pair for this worktree:
+  `http://127.0.0.1:5174/`
+- Write set: OpenSpec/workstream artifacts first; optional resource
+  expectations source and tests only after review.
+
+## Frame
+
+- In scope: resource group partition, per-resource earthlike expectation
+  envelopes, evidence policy, blocked-row visibility, and future stats proof
+  obligations.
+- Foreground: fixing the failure mode where only a minority of resources appear
+  by making every official resource become an explicit future operation
+  obligation.
+- Exterior: no placement behavior movement, no runtime numeric id proof, no
+  feature-resource expansion, no generated-output edits.
+- Falsifier: if research cannot support bounded per-resource envelopes, the
+  slice must record blocked/conditional rows and next proof needs rather than
+  inventing precise ranges.
+
+## Agent Wave
+
+- Kant: aquatic, coastal, and navigable-river resources.
+- Hooke: cultivated, plantation, and medicinal resources.
+- Noether: terrestrial animal, forest, and wild biological resources.
+- Godel: geological, mineral, gemstone, and industrial resources.
+- Ohm: grouping and evidence-policy critic.
+
+## Current Partition
+
+- Aquatic, coastal, and navigable-river: 6 resources.
+- Cultivated, plantation, and medicinal: 18 resources.
+- Terrestrial animal, forest, and wild: 11 resources.
+- Geological, mineral, gemstone, and industrial: 20 resources.
+- Total: 55 resources.
+
+## Verification So Far
+
+- Branch opened with Graphite.
+- Studio/API pair started from this worktree on `http://127.0.0.1:5174/`.
+- `curl -I http://127.0.0.1:5174/`
+  - Passed with `HTTP/1.1 200 OK`.
+- Resource-group evidence packs completed and recorded in
+  `workstream/evidence-packs.md`.
+- `bun run openspec -- validate resource-earthlike-expectations --strict`
+  - Passed.
+- `bun run openspec:validate`
+  - Passed: 21 items.
+- `git diff --check`
+  - Passed.
+
+## Closure State
+
+- Framed agent review completed and accepted P1/P2 findings were repaired.
+- This slice closes as OpenSpec-only. The typed
+  `artifact:resources.earthlikeExpectations` source artifact belongs in the
+  next implementation slice so it can have dedicated tests and review.

--- a/openspec/changes/resource-earthlike-expectations/workstream/review-disposition-ledger.md
+++ b/openspec/changes/resource-earthlike-expectations/workstream/review-disposition-ledger.md
@@ -1,0 +1,15 @@
+# Review Disposition Ledger
+
+| Finding | Severity | Disposition | Evidence |
+|---|---:|---|---|
+| Initial partition omitted `RESOURCE_WINE` and `RESOURCE_QUININE` | P2 | accepted, repaired before spec finalization | Added both to cultivated/plantation/medicinal group; coverage is now `6 + 18 + 11 + 20 = 55`. |
+| Artifact name drifted from accepted resource-stage contract | P2 | accepted, repaired | Replaced noncanonical expectation artifact name with `artifact:resources.earthlikeExpectations`. |
+| Expectation status needed explicit mapping to corpus disposition | P2 | accepted, repaired | Added status mapping: `expected` requires corpus `strategyRequired.status === "required"`; blocked rows inherit corpus blocked status. |
+| Group-level models could become gating obligations | P2 | accepted, repaired | Design/spec now make groups non-gating rollups and require per-resource predicate/range/evidence/gate/stat proof. |
+| Marine/coastal grouping risked dropping crabs navigable-river eligibility | P2 | accepted, repaired | Renamed group to aquatic/coastal/navigable-river and added explicit crabs lane preservation requirement. |
+| Feature exclusion was missing from optional source-test gates | P3 | accepted, repaired | Source-test gate now includes `FEATURE_*` exclusion when source artifacts are added. |
+| Earthlike multipliers need concrete map fields or proxy derivations before implementation | P2 | accepted, repaired | Design/spec now require derived ecological/geologic predicates to name implementation proxies or record proxy gaps. |
+| Expected ranges must remain soft until seed telemetry verifies candidate and placement counts | P2 | accepted, repaired | Design/spec now require seed-matrix or in-game telemetry before inferred ranges become hard closure gates. |
+| Count guidance needs claim-strength markers | P2 | accepted, repaired | Design/spec now require `official`, `external`, `inferred`, or `runtime-calibrated` evidence strength. |
+| Blocked-row evidence rows still carried future nonzero range language | P2 | accepted, repaired | Blocked rows now show active range `0 official; blocked`; any future nonzero range requires a later source-backed disposition outside active range fields. |
+| Hard-gate exception allowed official evidence to bypass telemetry calibration | P2 | accepted, repaired | Design now says hard count closure requires runtime-calibrated evidence with eligible-tile denominator and placement telemetry. |

--- a/openspec/changes/resource-stage-architecture/.openspec.yaml
+++ b/openspec/changes/resource-stage-architecture/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-stage-architecture/design.md
+++ b/openspec/changes/resource-stage-architecture/design.md
@@ -1,0 +1,267 @@
+# Resource Stage Architecture Design
+
+## Decision
+
+`resources` is the accepted target stage for resource distribution recovery.
+Keeping all resource behavior inside the existing `placement` stage is no
+longer the target architecture; it is only the current implementation state.
+
+This decision is based on the stage promotion rule: resources need an
+independent recipe-level trace identity, stage-scoped corpus/helper ownership,
+per-resource and resource-group planning artifacts, materialization/readback
+evidence, local stats gates, and runtime proof hooks. Those are distinct enough
+from starts, discoveries, natural wonders, and final placement summary to be a
+real stage boundary.
+
+## Target Stage Order
+
+The target standard recipe order is:
+
+```text
+...
+map-rivers
+map-ecology
+placement-preparation
+resources
+placement
+```
+
+`placement-preparation` is the required support split. The current placement
+surface preparation work is a shared precondition for resources, starts,
+discoveries, and final placement. It cannot remain hidden inside `resources`,
+because that would make starts and discoveries depend on resource planning for a
+surface they also need.
+
+Target `placement-preparation` scope:
+
+```text
+placement-preparation
+  derive-gameplay-inputs
+  plot-landmass-regions
+  place-natural-wonders
+  prepare-placement-surface
+```
+
+Natural wonders stay before resources during the migration because current
+behavior already stamps natural wonders before resource materialization. A later
+natural-wonders stage may be designed separately, but this resource architecture
+slice does not require that split.
+
+The future `placement` stage remains the gameplay/product stage for starts,
+discoveries, advanced starts, and final placement summary after resource
+materialization has published its outcome artifacts.
+
+## Target Resources Stage
+
+```text
+resources
+  derive-resource-corpus
+  derive-resource-expectations
+  derive-resource-inputs
+  score-resource-groups
+  plan-resource-groups
+  merge-resource-intents
+  place-resources
+  summarize-resource-distribution
+```
+
+### `derive-resource-corpus`
+
+- Consumes: static official resource corpus module, runtime id verification
+  status from the corpus slice.
+- Publishes: `artifact:resources.corpus`.
+- Invariant: every official resource row has placeability, valid ages, class
+  overrides, official placement constraints, and strategy-required disposition.
+- Consumer: `derive-resource-inputs`, `plan-resource-groups`, stats/runtime
+  proof.
+- Verification: corpus tests prove static rows and runtime id status are
+  recorded separately.
+
+### `derive-resource-expectations`
+
+- Consumes: `artifact:resources.corpus`, map identity/size/age context, and
+  resource research notes or documented inference rules.
+- Publishes: `artifact:resources.earthlikeExpectations`.
+- Invariant: each strategy-required resource has an expected range record for
+  the supported map context before that range can become a gate.
+- Consumer: `plan-resource-groups`, `summarize-resource-distribution`, local
+  stats, runtime proof.
+- Verification: expectation tests assert min/target/max, evidence source or
+  inference rule, sample/condition scope, and gate status for every required
+  resource.
+
+### `derive-resource-inputs`
+
+- Consumes: `artifact:resources.corpus`, ecology pedology/biome fields,
+  hydrology fields, morphology/topography fields, map projection fields, and
+  `artifact:placement.surfacePreparation`.
+- Publishes: `artifact:resources.inputs`.
+- Invariant: strategy inputs are resource-owned and do not depend on the broad
+  placement input blob.
+- Consumer: scoring and planning steps.
+- Verification: input tests assert dimensions, typed arrays, corpus coverage,
+  and no symbolic resource names without verified runtime ids.
+
+### `score-resource-groups`
+
+- Consumes: `artifact:resources.inputs`.
+- Publishes: `artifact:resources.groupScores`.
+- Invariant: each provisional group shares official constraints and earthlike
+  evidence axes.
+- Consumer: `plan-resource-groups`.
+- Verification: score tests show each required resource has at least one owning
+  group or an explicit blocked/not-map-placed disposition.
+
+### `plan-resource-groups`
+
+- Consumes: `artifact:resources.groupScores`,
+  `artifact:resources.earthlikeExpectations`, and corpus disposition.
+- Publishes: `artifact:resources.groupPlans`.
+- Invariant: group plans are deterministic, per-resource visible, and explicit
+  about eligible, selected, blocked, and suppressed resources.
+- Consumer: `merge-resource-intents`.
+- Verification: strategy tests assert every required resource has planned
+  coverage or a named blocker.
+
+### `merge-resource-intents`
+
+- Consumes: `artifact:resources.groupPlans`.
+- Publishes: `artifact:resources.intentPlan`.
+- Invariant: cross-group conflicts, spacing, and duplicate tile/resource claims
+  are resolved once before adapter materialization.
+- Consumer: `place-resources`.
+- Verification: merge tests prove all selected group intents either enter the
+  final plan or receive a named suppression/blocking reason.
+
+### `place-resources`
+
+- Consumes: `artifact:resources.intentPlan` and
+  `artifact:placement.surfacePreparation`.
+- Publishes: `artifact:resources.placementOutcomes`.
+- Invariant: adapter materialization remains typed; rejected exact intents are
+  auditable by adapter numeric id and reason; readback mismatches fail hard.
+- Consumer: `summarize-resource-distribution`, final placement summary, runtime
+  proof.
+- Verification: existing typed outcome tests move with the step.
+
+### `summarize-resource-distribution`
+
+- Consumes: `artifact:resources.intentPlan`,
+  `artifact:resources.placementOutcomes`,
+  `artifact:resources.earthlikeExpectations`, and corpus.
+- Publishes: `artifact:resources.distributionSummary`.
+- Invariant: aggregate resource counts cannot satisfy closure without
+  per-resource status against expected ranges.
+- Consumer: world-balance stats, runtime proof, final placement summary.
+- Verification: stats tests assert per-resource planned/placed/rejected/mismatch
+  coverage and expected-range statuses.
+
+The stage also provides `effect:resources.placed` after typed materialization
+and outcome publication. Remaining placement products consume this effect when
+they require resource-aware fertility, start, discovery, or final placement
+evidence.
+
+## Stats And Runtime Proof Boundary
+
+Local stats must consume `artifact:resources.distributionSummary`, not strategy
+internals. They must report every strategy-required resource, including zero
+planned or zero placed resources, so exclusions are visible. Stats compare
+per-resource planned and placed counts against
+`artifact:resources.earthlikeExpectations` and preserve adapter numeric ids
+until runtime id mapping is verified.
+
+Runtime proof must emit resource telemetry in the bounded Civ7 MapGeneration log
+window. Recipe completion without `artifact:resources.distributionSummary`
+telemetry remains pipeline proof only. Runtime logs must label local stats,
+generated mod proof, deploy proof, and in-game proof separately.
+
+## Resource Group Step Criteria
+
+The provisional groups from planning are discovery groups until each group can
+prove all of the following:
+
+- consumed input artifacts;
+- published output artifact;
+- shared official constraint invariant;
+- shared earthlike evidence axes;
+- downstream consumer;
+- verification boundary;
+- owner for expected-range research notes.
+
+Groups that cannot prove those fields remain strategy modules or research
+sections under `score-resource-groups`/`plan-resource-groups`, not stage steps.
+
+## Migration Sequence
+
+1. `resource-corpus-contract`: create `artifact:resources.corpus` and separate
+   static file order from runtime id verification.
+2. `resource-earthlike-expectations`: create researched/inferred expectation
+   ranges before any range becomes a gate.
+3. `resource-artifact-boundary`: introduce resource-owned artifact ids while
+   the implementation still runs inside the current placement stage. Move
+   `artifact:placement.resourcePlan` and
+   `artifact:placement.resourcePlacementOutcomes` toward transitional
+   `artifact:resources.resourcePlan` and
+   `artifact:resources.placementOutcomes`; update placement input/output
+   consumers and resource tests. `artifact:resources.resourcePlan` is a
+   pass-through migration name that preserves current behavior before
+   group-plan merge exists. The final target after `resource-intent-merge` is
+   `artifact:resources.intentPlan`. No stage move happens in this slice.
+4. `placement-preparation-split`: promote placement input/surface preparation
+   artifacts into a shared preparation stage consumed by resources and the
+   remaining placement products. Move `derive-placement-inputs`,
+   `plot-landmass-regions`, `place-natural-wonders`, and
+   `prepare-placement-surface` together unless a separate natural-wonders stage
+   is designed first.
+5. `resources-stage-shell`: add `resources` stage with pass-through behavior
+   equivalent to current resource plan/materialization. Move `place-resources`
+   under the new stage, move the resources-placed effect to resource ownership,
+   and update starts/final placement dependencies.
+6. `resource-inputs-and-summary`: move resource-specific input building and
+   distribution summary out of the broad placement input/output surfaces.
+   Remove resource planning from `PlacementInputsV1`; move resource config from
+   `placement.derive-placement-inputs.resources` to resource-owned step config.
+7. `resource-intent-merge`: add group-plan merge and conflict/suppression
+   evidence before strategy tuning.
+8. `resource-strategy-batches`: add group/resource strategies in batches.
+9. `resource-distribution-stats-gates`: enforce expected ranges.
+10. `resource-distribution-runtime-proof`: deploy, restart, and prove resource
+   telemetry in bounded scripting logs.
+
+## Future Slice Write Sets And Tests
+
+| Slice | Write Set | Required Tests |
+|---|---|---|
+| `resource-artifact-boundary` | `mods/mod-swooper-maps/src/recipes/standard/stages/resources/artifacts.ts`; placement artifact imports/consumers; `derive-placement-inputs`; `place-resources`; final placement summary/apply; resource tests | `placement-contracts.test.ts`, `placement-does-not-call-generate-snow.test.ts`, `resource-placement-diagnostics.test.ts` |
+| `placement-preparation-split` | `mods/mod-swooper-maps/src/recipes/standard/stages/placement-preparation/**`; `recipe.ts`; config schema and shipped map config surfaces; topology tests | `resources-landmass-region-restamp.test.ts`, `lakes-area-recalc-resources.test.ts`, `standard-recipe.test.ts`, config/schema tests |
+| `resources-stage-shell` | `mods/mod-swooper-maps/src/recipes/standard/stages/resources/**`; `tags.ts`; `assign-starts/contract.ts`; `recipe.ts`; configs; tests | pass-through equivalence test comparing same seed/config transitional `resourcePlan`, resource outcome summary, adapter `setResourceType` calls, and final `placementOutputs.resourcesCount`; no-official-generator tests |
+| `resource-inputs-and-summary` | resource input, group planning, summary steps; `PlacementInputsV1`; resource-owned config; stats helper/tests | resource summary tests, world-balance stats diagnostics, config/schema tests |
+
+## Migration Hazards
+
+- Stage id changes alter full step ids, config lookup, traces, and Studio
+  defaults. Do not introduce compatibility aliases in this architecture train.
+- Artifact duplicate providers fail recipe creation; move artifact ownership in
+  one branch before moving stage topology.
+- Resource stage shell must not import placement-stage-local runtime helpers;
+  create resource-local helpers or promote a helper only with an explicit shared
+  invariant and consumers.
+- Starts currently depends on resources being placed. Moving resource effects
+  requires updating start dependencies and final placement summary consumers in
+  the same implementation slice.
+- Mock adapter acceptance still overstates live resource legality; migration
+  tests preserve behavior, while later strategy slices must use corpus/runtime
+  legality proof.
+
+## Stop Conditions
+
+- Runtime numeric id verification mismatches static assumptions and no
+  disposition exists.
+- `placement-preparation` cannot publish a stable shared surface artifact.
+- Pass-through equivalence is missing before moving `place-resources`.
+- Any official resource generator path returns.
+- Typed rejection or mismatch behavior weakens.
+- A proposed resource group lacks consumed inputs, published output, shared
+  invariant, consumer, or verification boundary.
+- A migration step changes resource placement behavior before the pass-through
+  equivalence tests are in place.

--- a/openspec/changes/resource-stage-architecture/proposal.md
+++ b/openspec/changes/resource-stage-architecture/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+The planning slice established that resources may become their own stage when
+they have real authoring, input/handoff, placement, enablement, trace, helper,
+or projection surfaces. The root-cause slice made the current resource collapse
+observable, but current topology still leaves resource planning and
+materialization embedded in the broad `placement` stage. That shape is not
+strong enough for the requested end state: every official resource needs
+explicit earthlike strategy coverage, per-resource expected ranges, and runtime
+proof.
+
+This slice records the target architecture and migration plan for a dedicated
+`resources` stage. It does not move code yet.
+
+## Target Authority Refs
+
+- Direct user correction: resources can be a stage; resource groups can become
+  steps when related input/output artifacts exist.
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`:
+  stage promotion rule and D3/D4 placement reconciliation rules.
+- `openspec/changes/resource-distribution-planning`: resource-stage requirement
+  and group-step acceptance rule.
+- `openspec/changes/resource-distribution-root-cause`: diagnostic-only
+  telemetry by adapter numeric resource id and reason.
+- `mods/mod-swooper-maps/src/recipes/standard/stages/placement/index.ts`:
+  current implementation evidence.
+
+## What Changes
+
+- Accept `resources` as the target stage for resource corpus, resource scoring,
+  resource group planning, resource materialization, and resource distribution
+  summaries.
+- Define the required artifacts and handoffs that make the stage real rather
+  than a folder rename.
+- Define which current `placement` responsibilities must move or split in later
+  implementation slices.
+- Define the criteria for resource group steps and the migration sequence that
+  preserves current behavior while opening per-resource strategy batches.
+
+## Explicit Non-Goals
+
+- No stage topology or recipe code changes in this slice.
+- No resource strategy tuning.
+- No corpus implementation or runtime id verification.
+- No generated output, `.civ7` edits, lockfile edits, or official-data changes.
+- No resource group step becomes accepted without consumed inputs, published
+  output, invariant, downstream consumer, and verification boundary.
+
+## Verification Gates
+
+- `bun run openspec -- validate resource-stage-architecture --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/resource-stage-architecture/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-stage-architecture/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: Resource Distribution Uses A Dedicated Resources Stage Target
+
+Resource distribution recovery SHALL target a dedicated `resources` stage rather
+than treating the current `placement/plan-resources` topology as the final
+architecture.
+
+#### Scenario: Resource stage architecture is designed
+- **WHEN** resource distribution work moves beyond root-cause diagnostics
+- **THEN** the accepted target includes a recipe-level `resources` stage
+- **AND** the stage owns resource corpus handoff, resource input derivation,
+  resource earthlike expectations, resource group scoring, resource group
+  planning, merged resource intents, typed resource materialization, resource
+  placement effects, and resource distribution summaries
+- **AND** current `placement` resource behavior is treated as migration evidence
+  rather than target authority
+
+### Requirement: Resource Stage Depends On Shared Placement Preparation
+
+The dedicated `resources` stage SHALL consume a shared placement preparation
+handoff instead of hiding shared engine-surface maintenance inside resource
+planning.
+
+#### Scenario: Placement preparation is split
+- **WHEN** stage topology is implemented
+- **THEN** shared placement preparation publishes a stable artifact consumed by
+  resources, starts, discoveries, and final placement summary
+- **AND** pre-resource natural-wonder stamping remains before resource
+  materialization until a separate natural-wonders stage is explicitly designed
+- **AND** starts and discoveries do not depend on resource strategy execution
+  merely to receive a prepared engine surface
+
+### Requirement: Resource Group Steps Require Artifact Boundaries
+
+Resource groups SHALL become stage steps only when they prove real artifact and
+verification boundaries.
+
+#### Scenario: A resource group is promoted
+- **WHEN** a resource group is proposed as a `resources` stage step
+- **THEN** it names consumed input artifacts, a published output artifact, a
+  shared official constraint invariant, shared earthlike evidence axes, a
+  downstream consumer, and a verification boundary
+- **AND** groups that cannot prove those fields remain strategy modules or
+  research groups rather than stage steps
+
+### Requirement: Resource Stage Migration Preserves Behavior Before Tuning
+
+Resource stage migration SHALL preserve current behavior until the corpus,
+expected ranges, and strategy batch slices are ready to change behavior.
+
+#### Scenario: Resource artifacts are renamed before topology moves
+- **WHEN** resource-owned artifact ids are introduced
+- **THEN** artifact ownership moves to the resource namespace before the resource
+  stage topology move
+- **AND** duplicate providers or compatibility aliases are not introduced
+
+#### Scenario: Resources stage shell is implemented
+- **WHEN** the `resources` stage is first introduced
+- **THEN** tests prove pass-through equivalence with the current resource
+  planning/materialization behavior
+- **AND** resource tuning, expected-range gates, and symbolic resource id claims
+  remain out of scope until their downstream slices land
+- **AND** no official aggregate resource generator path is reintroduced
+
+#### Scenario: Resource group plans are merged
+- **WHEN** multiple resource group planners publish selected intents
+- **THEN** the resources stage resolves cross-group conflicts through a named
+  merge step before adapter materialization
+- **AND** every selected, suppressed, or blocked intent receives auditable
+  reason evidence
+
+### Requirement: Resource Stage Publishes Expectation And Distribution Evidence
+
+The dedicated `resources` stage SHALL publish product evidence that lets later
+strategy batches, stats gates, and runtime proof evaluate every
+strategy-required resource individually.
+
+#### Scenario: Resource expectations are prepared
+- **WHEN** a resource is strategy-required for a supported map context
+- **THEN** `resources` publishes an expectation record with min/target/max,
+  condition scope, evidence source or inference rule, and gate status
+- **AND** a range cannot become a gate until its research note or inference rule
+  is recorded
+
+#### Scenario: Resource distribution is summarized
+- **WHEN** resource materialization completes
+- **THEN** `resources` publishes per-resource planned, eligible, selected,
+  placed, rejected, mismatch, reason-bucket, and expectation verdict evidence
+- **AND** local stats and runtime proof consume that summary rather than
+  strategy internals
+- **AND** strategy-required resources with zero planned or zero placed outcomes
+  remain visible in the summary
+
+#### Scenario: Runtime proof is collected
+- **WHEN** Civ7 runtime logs are used as resource proof
+- **THEN** the bounded MapGeneration log window includes resource distribution
+  summary telemetry
+- **AND** recipe completion without resource summary telemetry remains pipeline
+  proof only

--- a/openspec/changes/resource-stage-architecture/tasks.md
+++ b/openspec/changes/resource-stage-architecture/tasks.md
@@ -1,0 +1,24 @@
+## 1. Architecture Decision
+
+- [x] 1.1 Establish `resources` as the accepted target stage.
+- [x] 1.2 Define the required support split for placement preparation.
+- [x] 1.3 Define target resources-stage steps and artifact handoffs.
+- [x] 1.4 Define resource group step criteria.
+- [x] 1.5 Define migration sequence and stop conditions.
+- [x] 1.6 Define placement-preparation split and merge-resource-intents step.
+- [x] 1.7 Define future slice write sets, equivalence tests, and migration hazards.
+
+## 2. OpenSpec
+
+- [x] 2.1 Add OpenSpec requirement for resource stage promotion.
+- [x] 2.2 Add OpenSpec requirement for placement-preparation handoff.
+- [x] 2.3 Add OpenSpec requirement for resource group step acceptance.
+- [x] 2.4 Add OpenSpec requirements for artifact-boundary migration,
+  pass-through preservation, resource expectation evidence, and runtime summary
+  proof.
+
+## 3. Review And Verification
+
+- [x] 3.1 Complete agent review of the architecture slice.
+- [x] 3.2 Run OpenSpec validation and `git diff --check`.
+- [x] 3.3 Commit the slice with Graphite and leave the worktree clean.

--- a/openspec/changes/resource-stage-architecture/workstream/phase-record.md
+++ b/openspec/changes/resource-stage-architecture/workstream/phase-record.md
@@ -1,0 +1,69 @@
+# Phase Record
+
+## Phase
+
+- Project: resource distribution recovery
+- Phase: resource stage architecture
+- Owner: Codex workstream owner
+- Branch/Graphite stack: `codex/resource-stage-architecture` above
+  `codex/resource-distribution-root-cause`
+- Started: 2026-05-31
+- Status: committed
+
+## Objective
+
+Accept and specify the target dedicated `resources` stage without changing
+runtime behavior. This slice creates the architecture contract future
+implementation branches must follow.
+
+## Scope
+
+- Write set: `openspec/changes/resource-stage-architecture/**`
+- Protected files: production stage topology, resource strategies, generated
+  output, `.civ7/outputs/resources/**`, lockfiles, shipped tuning configs.
+- Consumer impact: none in this slice.
+
+## Evidence
+
+- Current placement stage already exposes resources as a product step, but the
+  stage still bundles resource concerns with natural wonders, starts,
+  discoveries, advanced starts, surface preparation, and final summary.
+- Root-cause diagnostics now expose per-resource outcome telemetry, enabling a
+  resource-owned summary artifact later.
+- User correction establishes that resources should not be kept in one planning
+  step by default; resource groups can become steps when they have real
+  artifacts and consumers.
+
+## Review
+
+- Product/verification review: Wegener recommended adding
+  `resourceEarthlikeExpectations`, `resourceIntentPlan`, and
+  `resourceDistributionSummary` as proof-producing artifacts, plus explicit
+  local stats and runtime proof boundaries. Integrated into design/spec.
+- Architecture review: Plato recommended accepting `resources` as its own
+  recipe stage, making `placement-preparation` explicit, preserving natural
+  wonders before resource materialization during migration, and adding a
+  `merge-resource-intents` step. Integrated into design/spec.
+- Implementation-safety review: Euler recommended artifact boundary before
+  topology moves, explicit future write sets, pass-through equivalence tests,
+  and hazards around stage ids, duplicate providers, resource-owned effects, and
+  mock legality. Integrated into design/spec.
+- Final review:
+  - Plato: no P1/P2 blockers; prior stage/preparation/merge recommendations
+    integrated.
+  - Wegener: no P1/P2 blockers; expectation, stats, and runtime proof boundary
+    are strong enough.
+  - Euler: no P1/P2 blockers; P3 transitional artifact naming ambiguity
+    repaired by labeling `artifact:resources.resourcePlan` as a pass-through
+    migration artifact before final `artifact:resources.intentPlan`.
+
+## Verification
+
+- Passed:
+  - `bun run openspec -- validate resource-stage-architecture --strict`
+  - `bun run openspec:validate`
+  - `git diff --check`
+
+## Next Action
+
+Proceed to the corpus contract and resource expectation slices.


### PR DESCRIPTION
Replay the resource planning, stage architecture, official corpus, and earthlike expectation artifact slices above the integrated Studio/authoring/morphology stack.

This branch preserves the systematic corpus-before-tuning boundary: static official resource rows and earthlike expectations are visible, runtime numeric ids remain unverified, and no placement behavior or stale root NOTE-TO-DRA handoff state is carried forward.

Stale source next-packet handoff notes that only instructed the old resource worktree to commit or open already-replayed follow-up slices were deleted during integration.

Validation:
- bun test mods/mod-swooper-maps/test/resources/resource-corpus-contract.test.ts mods/mod-swooper-maps/test/resources/resource-corpus-artifact.test.ts mods/mod-swooper-maps/test/resources/resource-earthlike-expectations-artifact.test.ts
- bun run openspec -- validate resource-distribution-planning --strict
- bun run openspec -- validate resource-stage-architecture --strict
- bun run openspec -- validate resource-corpus-contract --strict
- bun run openspec -- validate resource-earthlike-expectations --strict
- bun run openspec -- validate resource-earthlike-expectations-artifact --strict
- bun run --cwd mods/mod-swooper-maps check
- git diff --check