### PR TITLE
feat(mapgen): integrate resource ops rollup

### DIFF
--- a/mods/mod-swooper-maps/src/domain/resources/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/index.ts
@@ -1,2 +1,10 @@
+import { defineDomain } from "@swooper/mapgen-core/authoring";
+
+import ops from "./ops/contracts.js";
+
+const domain = defineDomain({ id: "resources", ops } as const);
+
+export default domain;
+
 export * from "./corpus/index.js";
 export * from "./earthlike-expectations/index.js";

--- a/mods/mod-swooper-maps/src/domain/resources/ops.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops.ts
@@ -1,0 +1,6 @@
+import { createDomain } from "@swooper/mapgen-core/authoring";
+
+import domain from "./index.js";
+import implementations from "./ops/index.js";
+
+export default createDomain(domain, implementations);

--- a/mods/mod-swooper-maps/src/domain/resources/ops/contracts.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/contracts.ts
@@ -1,0 +1,23 @@
+import PlanAquaticResourcesContract from "./plan-aquatic-resources/contract.js";
+import PlanCultivatedResourcesContract from "./plan-cultivated-resources/contract.js";
+import PlanGeologicalResourcesContract from "./plan-geological-resources/contract.js";
+import PlanResourceGroupsContract from "./plan-resource-groups/contract.js";
+import PlanTerrestrialResourcesContract from "./plan-terrestrial-resources/contract.js";
+
+export const contracts = {
+  planAquaticResources: PlanAquaticResourcesContract,
+  planCultivatedResources: PlanCultivatedResourcesContract,
+  planGeologicalResources: PlanGeologicalResourcesContract,
+  planResourceGroups: PlanResourceGroupsContract,
+  planTerrestrialResources: PlanTerrestrialResourcesContract,
+} as const;
+
+export default contracts;
+
+export {
+  PlanAquaticResourcesContract,
+  PlanCultivatedResourcesContract,
+  PlanGeologicalResourcesContract,
+  PlanResourceGroupsContract,
+  PlanTerrestrialResourcesContract,
+};

--- a/mods/mod-swooper-maps/src/domain/resources/ops/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/index.ts
@@ -1,0 +1,26 @@
+import type { DomainOpImplementationsForContracts } from "@swooper/mapgen-core/authoring";
+import type { contracts } from "./contracts.js";
+
+import planAquaticResources from "./plan-aquatic-resources/index.js";
+import planCultivatedResources from "./plan-cultivated-resources/index.js";
+import planGeologicalResources from "./plan-geological-resources/index.js";
+import planResourceGroups from "./plan-resource-groups/index.js";
+import planTerrestrialResources from "./plan-terrestrial-resources/index.js";
+
+const implementations = {
+  planAquaticResources,
+  planCultivatedResources,
+  planGeologicalResources,
+  planResourceGroups,
+  planTerrestrialResources,
+} as const satisfies DomainOpImplementationsForContracts<typeof contracts>;
+
+export default implementations;
+
+export {
+  planAquaticResources,
+  planCultivatedResources,
+  planGeologicalResources,
+  planResourceGroups,
+  planTerrestrialResources,
+};

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-aquatic-resources/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-aquatic-resources/contract.ts
@@ -1,0 +1,138 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+const AquaticResourceTypeSchema = Type.Union([
+  Type.Literal("RESOURCE_FISH"),
+  Type.Literal("RESOURCE_PEARLS"),
+  Type.Literal("RESOURCE_WHALES"),
+  Type.Literal("RESOURCE_CRABS"),
+  Type.Literal("RESOURCE_COWRIE"),
+  Type.Literal("RESOURCE_TURTLES"),
+]);
+
+const ExpectedCountRangeSchema = Type.Object(
+  {
+    baseline: Type.Literal("standard-earthlike-map"),
+    min: Type.Integer({ minimum: 0 }),
+    target: Type.Integer({ minimum: 0 }),
+    max: Type.Integer({ minimum: 0 }),
+    evidence: Type.Union([
+      Type.Literal("source-backed"),
+      Type.Literal("inference-backed"),
+      Type.Literal("blocked"),
+    ]),
+  },
+  { additionalProperties: false }
+);
+
+const AquaticExpectationSchema = Type.Object(
+  {
+    resourceType: AquaticResourceTypeSchema,
+    groupId: Type.Literal("aquatic-coastal-navigable-river"),
+    status: Type.Union([
+      Type.Literal("expected"),
+      Type.Literal("conditional"),
+      Type.Literal("blocked"),
+    ]),
+    earthlikePredicate: Type.String(),
+    expectedCountRange: ExpectedCountRangeSchema,
+    conditionMultipliers: Type.Array(Type.String()),
+    proxyRequirements: Type.Array(Type.String()),
+    caveats: Type.Array(Type.String()),
+  },
+  {
+    additionalProperties: true,
+    description:
+      "Aquatic rows projected from artifact:resources.earthlikeExpectations. Extra source fields may travel with the row, but the op only consumes symbolic expectations.",
+  }
+);
+
+const AquaticPlanRowSchema = Type.Object(
+  {
+    resourceType: AquaticResourceTypeSchema,
+    status: Type.Union([
+      Type.Literal("planned"),
+      Type.Literal("blocked"),
+      Type.Literal("missing-expectation"),
+      Type.Literal("proxy-gap"),
+    ]),
+    eligibilityStatus: Type.Union([
+      Type.Literal("observed"),
+      Type.Literal("proxy-incomplete"),
+      Type.Literal("missing-expectation"),
+      Type.Literal("blocked"),
+    ]),
+    expectedCountRange: ExpectedCountRangeSchema,
+    targetIntentCount: Type.Integer({ minimum: 0 }),
+    eligibleTileCount: Type.Integer({ minimum: 0 }),
+    rangeStatus: Type.Union([
+      Type.Literal("within-range"),
+      Type.Literal("below-range"),
+      Type.Literal("above-range"),
+      Type.Literal("not-gated"),
+    ]),
+    proofStatus: Type.Literal("warning-only"),
+    runtimeIdStatus: Type.Literal("unverified"),
+    earthlikePredicate: Type.String(),
+    conditionMultipliers: Type.Array(Type.String()),
+    proxyRequirements: Type.Array(Type.String()),
+    signalFields: Type.Array(Type.String()),
+    blockers: Type.Array(Type.String()),
+    caveats: Type.Array(Type.String()),
+  },
+  { additionalProperties: false }
+);
+
+const PlanAquaticResourcesContract = defineOp({
+  kind: "plan",
+  id: "resources/plan-aquatic-resources",
+  input: Type.Object(
+    {
+      width: Type.Integer({ minimum: 1 }),
+      height: Type.Integer({ minimum: 1 }),
+      expectations: Type.Array(AquaticExpectationSchema),
+      coastalWaterMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Coastal water eligibility mask." })
+      ),
+      shelfMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Continental shelf or shallow shelf mask." })
+      ),
+      warmShallowWaterMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Warm shallow water or tropical shelf mask." })
+      ),
+      coldProductiveWaterMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Cold or temperate productive shelf/upwelling mask." })
+      ),
+      reefOrProtectedShallowsMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Reef, lagoon, bay, or protected shallows mask." })
+      ),
+      estuaryMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Estuary, delta, brackish bay, or river-mouth mask." })
+      ),
+      navigableRiverMouthMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Navigable-river mouth or floodplain proxy mask." })
+      ),
+      lakeMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Lake mask to suppress marine resources." })
+      ),
+      iceMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Ice-covered water mask to suppress warm/coastal resources." })
+      ),
+    },
+    { additionalProperties: false }
+  ),
+  output: Type.Object(
+    {
+      groupId: Type.Literal("aquatic-coastal-navigable-river"),
+      runtimeIdStatus: Type.Literal("unverified"),
+      proofStatus: Type.Literal("warning-only"),
+      plans: Type.Array(AquaticPlanRowSchema),
+      missingResourceTypes: Type.Array(AquaticResourceTypeSchema),
+    },
+    { additionalProperties: false }
+  ),
+  strategies: {
+    default: Type.Object({}, { additionalProperties: false }),
+  },
+});
+
+export default PlanAquaticResourcesContract;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-aquatic-resources/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-aquatic-resources/index.ts
@@ -1,0 +1,13 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import PlanAquaticResourcesContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const planAquaticResources = createOp(PlanAquaticResourcesContract, {
+  strategies: { default: defaultStrategy },
+});
+
+export type * from "./contract.js";
+export type * from "./types.js";
+
+export default planAquaticResources;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-aquatic-resources/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-aquatic-resources/strategies/default.ts
@@ -1,0 +1,225 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import PlanAquaticResourcesContract from "../contract.js";
+
+type AquaticResourceType =
+  | "RESOURCE_FISH"
+  | "RESOURCE_PEARLS"
+  | "RESOURCE_WHALES"
+  | "RESOURCE_CRABS"
+  | "RESOURCE_COWRIE"
+  | "RESOURCE_TURTLES";
+
+type MaskField =
+  | "coastalWaterMask"
+  | "shelfMask"
+  | "warmShallowWaterMask"
+  | "coldProductiveWaterMask"
+  | "reefOrProtectedShallowsMask"
+  | "estuaryMask"
+  | "navigableRiverMouthMask";
+
+type SuppressionField = "lakeMask" | "iceMask";
+
+type ResourceSignals = {
+  readonly primary: readonly MaskField[];
+  readonly suppress: readonly SuppressionField[];
+};
+
+const DEFAULT_RANGE = {
+  baseline: "standard-earthlike-map" as const,
+  min: 0,
+  target: 0,
+  max: 0,
+  evidence: "blocked" as const,
+};
+
+const AQUATIC_RESOURCE_TYPES: readonly AquaticResourceType[] = [
+  "RESOURCE_FISH",
+  "RESOURCE_PEARLS",
+  "RESOURCE_WHALES",
+  "RESOURCE_CRABS",
+  "RESOURCE_COWRIE",
+  "RESOURCE_TURTLES",
+];
+
+const AQUATIC_SIGNALS: Record<AquaticResourceType, ResourceSignals> = {
+  RESOURCE_FISH: {
+    primary: ["coastalWaterMask", "shelfMask"],
+    suppress: ["lakeMask", "iceMask"],
+  },
+  RESOURCE_PEARLS: {
+    primary: ["warmShallowWaterMask", "reefOrProtectedShallowsMask"],
+    suppress: ["lakeMask", "iceMask"],
+  },
+  RESOURCE_WHALES: {
+    primary: ["coldProductiveWaterMask", "shelfMask"],
+    suppress: ["lakeMask", "iceMask"],
+  },
+  RESOURCE_CRABS: {
+    primary: ["estuaryMask", "navigableRiverMouthMask", "coastalWaterMask"],
+    suppress: ["iceMask"],
+  },
+  RESOURCE_COWRIE: {
+    primary: ["warmShallowWaterMask", "reefOrProtectedShallowsMask"],
+    suppress: ["lakeMask", "iceMask"],
+  },
+  RESOURCE_TURTLES: {
+    primary: ["warmShallowWaterMask", "reefOrProtectedShallowsMask", "coastalWaterMask"],
+    suppress: ["lakeMask", "iceMask"],
+  },
+};
+
+export const defaultStrategy = createStrategy(PlanAquaticResourcesContract, "default", {
+  run: (input) => {
+    const size = validateGrid(input.width, input.height);
+    const expectations = new Map(input.expectations.map((row) => [row.resourceType, row]));
+    const plans = [];
+    const missingResourceTypes: AquaticResourceType[] = [];
+
+    for (const resourceType of AQUATIC_RESOURCE_TYPES) {
+      const expectation = expectations.get(resourceType);
+      if (!expectation) {
+        missingResourceTypes.push(resourceType);
+        plans.push({
+          resourceType,
+          status: "missing-expectation" as const,
+          eligibilityStatus: "missing-expectation" as const,
+          expectedCountRange: DEFAULT_RANGE,
+          targetIntentCount: 0,
+          eligibleTileCount: 0,
+          rangeStatus: "not-gated" as const,
+          proofStatus: "warning-only" as const,
+          runtimeIdStatus: "unverified" as const,
+          earthlikePredicate: "",
+          conditionMultipliers: [],
+          proxyRequirements: [],
+          signalFields: [],
+          blockers: ["Missing aquatic earthlike expectation row."],
+          caveats: [],
+        });
+        continue;
+      }
+
+      if (expectation.status === "blocked") {
+        plans.push({
+          resourceType,
+          status: "blocked" as const,
+          eligibilityStatus: "blocked" as const,
+          expectedCountRange: expectation.expectedCountRange,
+          targetIntentCount: 0,
+          eligibleTileCount: 0,
+          rangeStatus: "not-gated" as const,
+          proofStatus: "warning-only" as const,
+          runtimeIdStatus: "unverified" as const,
+          earthlikePredicate: expectation.earthlikePredicate,
+          conditionMultipliers: [...expectation.conditionMultipliers],
+          proxyRequirements: [...expectation.proxyRequirements],
+          signalFields: [],
+          blockers: ["Expectation row is blocked by official corpus disposition."],
+          caveats: [...expectation.caveats],
+        });
+        continue;
+      }
+
+      const signals = AQUATIC_SIGNALS[resourceType];
+      const signalFields = presentFields(input, signals.primary);
+      const eligibleTileCount = countEligibleTiles(input, size, signals);
+      const proxyIncomplete = signalFields.length === 0;
+      const targetIntentCount = proxyIncomplete
+        ? 0
+        : Math.min(expectation.expectedCountRange.max, eligibleTileCount, expectation.expectedCountRange.target);
+      const blockers = [];
+      if (proxyIncomplete) {
+        blockers.push(`Missing aquatic signal masks: ${signals.primary.join(", ")}.`);
+      }
+      if (!proxyIncomplete && eligibleTileCount === 0) {
+        blockers.push("No eligible aquatic tiles observed for this resource under supplied masks.");
+      }
+
+      plans.push({
+        resourceType,
+        status: proxyIncomplete ? ("proxy-gap" as const) : ("planned" as const),
+        eligibilityStatus: proxyIncomplete ? ("proxy-incomplete" as const) : ("observed" as const),
+        expectedCountRange: expectation.expectedCountRange,
+        targetIntentCount,
+        eligibleTileCount,
+        rangeStatus: proxyIncomplete
+          ? ("not-gated" as const)
+          : compareRange(targetIntentCount, expectation.expectedCountRange),
+        proofStatus: "warning-only" as const,
+        runtimeIdStatus: "unverified" as const,
+        earthlikePredicate: expectation.earthlikePredicate,
+        conditionMultipliers: [...expectation.conditionMultipliers],
+        proxyRequirements: [...expectation.proxyRequirements],
+        signalFields,
+        blockers,
+        caveats: [...expectation.caveats],
+      });
+    }
+
+    return {
+      groupId: "aquatic-coastal-navigable-river" as const,
+      runtimeIdStatus: "unverified" as const,
+      proofStatus: "warning-only" as const,
+      plans,
+      missingResourceTypes,
+    };
+  },
+});
+
+function validateGrid(width: number, height: number): number {
+  const size = width * height;
+  if (!Number.isSafeInteger(size) || size <= 0) {
+    throw new Error(`Invalid grid dimensions for aquatic resource planning: ${width}x${height}.`);
+  }
+  return size;
+}
+
+function presentFields(input: Record<string, unknown>, fields: readonly MaskField[]): string[] {
+  return fields.filter((field) => input[field] !== undefined);
+}
+
+function countEligibleTiles(
+  input: Record<string, unknown>,
+  size: number,
+  signals: ResourceSignals
+): number {
+  const primaryMasks = signals.primary
+    .map((field) => ({ field, mask: readMask(input, field, size) }))
+    .filter((entry): entry is { field: MaskField; mask: Uint8Array } => entry.mask !== undefined);
+  if (primaryMasks.length === 0) return 0;
+
+  const suppressMasks = signals.suppress
+    .map((field) => readMask(input, field, size))
+    .filter((mask): mask is Uint8Array => mask !== undefined);
+
+  let count = 0;
+  for (let i = 0; i < size; i++) {
+    if (!primaryMasks.some(({ mask }) => mask[i] !== 0)) continue;
+    if (suppressMasks.some((mask) => mask[i] !== 0)) continue;
+    count += 1;
+  }
+  return count;
+}
+
+function readMask(input: Record<string, unknown>, field: string, size: number): Uint8Array | undefined {
+  const value = input[field];
+  if (value === undefined) return undefined;
+  if (!(value instanceof Uint8Array)) {
+    throw new Error(`Aquatic resource mask ${field} must be a Uint8Array.`);
+  }
+  if (value.length !== size) {
+    throw new Error(`Aquatic resource mask ${field} length ${value.length} does not match grid size ${size}.`);
+  }
+  return value;
+}
+
+function compareRange(
+  count: number,
+  range: { readonly min: number; readonly max: number }
+): "within-range" | "below-range" | "above-range" {
+  if (count < range.min) return "below-range";
+  if (count > range.max) return "above-range";
+  return "within-range";
+}

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-aquatic-resources/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-aquatic-resources/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-aquatic-resources/types.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-aquatic-resources/types.ts
@@ -1,0 +1,3 @@
+import type { OpTypeBagOf } from "@swooper/mapgen-core/authoring";
+
+export type PlanAquaticResourcesTypes = OpTypeBagOf<typeof import("./contract.js").default>;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/contract.ts
@@ -1,0 +1,186 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+const CultivatedResourceTypeSchema = Type.Union([
+  Type.Literal("RESOURCE_COTTON"),
+  Type.Literal("RESOURCE_DATES"),
+  Type.Literal("RESOURCE_DYES"),
+  Type.Literal("RESOURCE_INCENSE"),
+  Type.Literal("RESOURCE_SILK"),
+  Type.Literal("RESOURCE_WINE"),
+  Type.Literal("RESOURCE_COCOA"),
+  Type.Literal("RESOURCE_SPICES"),
+  Type.Literal("RESOURCE_SUGAR"),
+  Type.Literal("RESOURCE_TEA"),
+  Type.Literal("RESOURCE_COFFEE"),
+  Type.Literal("RESOURCE_TOBACCO"),
+  Type.Literal("RESOURCE_CITRUS"),
+  Type.Literal("RESOURCE_QUININE"),
+  Type.Literal("RESOURCE_MANGOS"),
+  Type.Literal("RESOURCE_RICE"),
+  Type.Literal("RESOURCE_CLOVES"),
+  Type.Literal("RESOURCE_FLAX"),
+]);
+
+const CultivatedLaneIdSchema = Type.Union([
+  Type.Literal("alluvial-irrigated"),
+  Type.Literal("arid-oasis-resin"),
+  Type.Literal("marine-dye"),
+  Type.Literal("temperate-field-orchard"),
+  Type.Literal("humid-tropical-plantation"),
+  Type.Literal("highland-medicinal"),
+  Type.Literal("wetland-paddy"),
+  Type.Literal("blocked-no-valid-biome"),
+]);
+
+const ExpectedCountRangeSchema = Type.Object(
+  {
+    baseline: Type.Literal("standard-earthlike-map"),
+    min: Type.Integer({ minimum: 0 }),
+    target: Type.Integer({ minimum: 0 }),
+    max: Type.Integer({ minimum: 0 }),
+    evidence: Type.Union([
+      Type.Literal("source-backed"),
+      Type.Literal("inference-backed"),
+      Type.Literal("blocked"),
+    ]),
+  },
+  { additionalProperties: false }
+);
+
+const CultivatedExpectationSchema = Type.Object(
+  {
+    resourceType: CultivatedResourceTypeSchema,
+    groupId: Type.Literal("cultivated-plantation-medicinal"),
+    status: Type.Union([
+      Type.Literal("expected"),
+      Type.Literal("conditional"),
+      Type.Literal("blocked"),
+    ]),
+    earthlikePredicate: Type.String(),
+    expectedCountRange: ExpectedCountRangeSchema,
+    conditionMultipliers: Type.Array(Type.String()),
+    proxyRequirements: Type.Array(Type.String()),
+    caveats: Type.Array(Type.String()),
+  },
+  {
+    additionalProperties: true,
+    description:
+      "Cultivated rows projected from artifact:resources.earthlikeExpectations. Extra source fields may travel with the row, but the op only consumes symbolic expectations.",
+  }
+);
+
+const CultivatedPlanRowSchema = Type.Object(
+  {
+    resourceType: CultivatedResourceTypeSchema,
+    laneId: CultivatedLaneIdSchema,
+    status: Type.Union([
+      Type.Literal("planned"),
+      Type.Literal("blocked"),
+      Type.Literal("missing-expectation"),
+      Type.Literal("proxy-gap"),
+    ]),
+    eligibilityStatus: Type.Union([
+      Type.Literal("observed"),
+      Type.Literal("proxy-incomplete"),
+      Type.Literal("missing-expectation"),
+      Type.Literal("blocked"),
+    ]),
+    expectedCountRange: ExpectedCountRangeSchema,
+    targetIntentCount: Type.Integer({ minimum: 0 }),
+    eligibleTileCount: Type.Integer({ minimum: 0 }),
+    rangeStatus: Type.Union([
+      Type.Literal("within-range"),
+      Type.Literal("below-range"),
+      Type.Literal("above-range"),
+      Type.Literal("not-gated"),
+    ]),
+    proofStatus: Type.Literal("warning-only"),
+    runtimeIdStatus: Type.Literal("unverified"),
+    earthlikePredicate: Type.String(),
+    conditionMultipliers: Type.Array(Type.String()),
+    proxyRequirements: Type.Array(Type.String()),
+    signalFields: Type.Array(Type.String()),
+    blockers: Type.Array(Type.String()),
+    caveats: Type.Array(Type.String()),
+  },
+  { additionalProperties: false }
+);
+
+const PlanCultivatedResourcesContract = defineOp({
+  kind: "plan",
+  id: "resources/plan-cultivated-resources",
+  input: Type.Object(
+    {
+      width: Type.Integer({ minimum: 1 }),
+      height: Type.Integer({ minimum: 1 }),
+      expectations: Type.Array(CultivatedExpectationSchema),
+      warmAlluvialMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Warm alluvial, irrigated, or fertile lowland mask." })
+      ),
+      floodplainOrRiverMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Floodplain, river, delta, or irrigation proxy mask." })
+      ),
+      warmGrassPlainsMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Warm grassland or plains crop suitability mask." })
+      ),
+      oasisOrDesertWaterMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Oasis, groundwater, or desert water-source mask." })
+      ),
+      aridDryWoodlandMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Arid woodland, desert edge, or dry resin habitat mask." })
+      ),
+      coastalMarineMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Warm coast, island, or marine biological dye lane mask." })
+      ),
+      humidTropicalForestMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Humid tropical forest, rainforest, or shaded plantation mask." })
+      ),
+      wetTropicsMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Wet tropical or monsoonal crop belt mask." })
+      ),
+      highlandOrReliefMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Highland, hill, relief, or montane plantation proxy mask." })
+      ),
+      temperateDryPlainsMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Temperate or subtropical dry plains crop mask." })
+      ),
+      savannaForestMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Savanna, forest, or warm drained tobacco-like mask." })
+      ),
+      tropicalFruitMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Tropical or subtropical frost-free fruit belt mask." })
+      ),
+      wetlandPaddyMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Wetland, marsh, mangrove, paddy, or monsoon lowland mask." })
+      ),
+      coolTemperatePlainsMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Cool-temperate or mild subtropical well-drained plains mask." })
+      ),
+      coldMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Cold or frost-limited suppression mask." })
+      ),
+      aridWithoutWaterMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Arid-without-water suppression mask." })
+      ),
+      waterloggedMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Waterlogged or excessive-rain suppression mask." })
+      ),
+    },
+    { additionalProperties: false }
+  ),
+  output: Type.Object(
+    {
+      groupId: Type.Literal("cultivated-plantation-medicinal"),
+      runtimeIdStatus: Type.Literal("unverified"),
+      proofStatus: Type.Literal("warning-only"),
+      plans: Type.Array(CultivatedPlanRowSchema),
+      missingResourceTypes: Type.Array(CultivatedResourceTypeSchema),
+    },
+    { additionalProperties: false }
+  ),
+  strategies: {
+    default: Type.Object({}, { additionalProperties: false }),
+  },
+});
+
+export default PlanCultivatedResourcesContract;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/index.ts
@@ -1,0 +1,13 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import PlanCultivatedResourcesContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const planCultivatedResources = createOp(PlanCultivatedResourcesContract, {
+  strategies: { default: defaultStrategy },
+});
+
+export type * from "./contract.js";
+export type * from "./types.js";
+
+export default planCultivatedResources;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/strategies/default.ts
@@ -1,0 +1,336 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import PlanCultivatedResourcesContract from "../contract.js";
+
+type CultivatedResourceType =
+  | "RESOURCE_COTTON"
+  | "RESOURCE_DATES"
+  | "RESOURCE_DYES"
+  | "RESOURCE_INCENSE"
+  | "RESOURCE_SILK"
+  | "RESOURCE_WINE"
+  | "RESOURCE_COCOA"
+  | "RESOURCE_SPICES"
+  | "RESOURCE_SUGAR"
+  | "RESOURCE_TEA"
+  | "RESOURCE_COFFEE"
+  | "RESOURCE_TOBACCO"
+  | "RESOURCE_CITRUS"
+  | "RESOURCE_QUININE"
+  | "RESOURCE_MANGOS"
+  | "RESOURCE_RICE"
+  | "RESOURCE_CLOVES"
+  | "RESOURCE_FLAX";
+
+type MaskField =
+  | "warmAlluvialMask"
+  | "floodplainOrRiverMask"
+  | "warmGrassPlainsMask"
+  | "oasisOrDesertWaterMask"
+  | "aridDryWoodlandMask"
+  | "coastalMarineMask"
+  | "humidTropicalForestMask"
+  | "wetTropicsMask"
+  | "highlandOrReliefMask"
+  | "temperateDryPlainsMask"
+  | "savannaForestMask"
+  | "tropicalFruitMask"
+  | "wetlandPaddyMask"
+  | "coolTemperatePlainsMask";
+
+type SuppressionField = "coldMask" | "aridWithoutWaterMask" | "waterloggedMask";
+
+type ResourceSignals = {
+  readonly laneId:
+    | "alluvial-irrigated"
+    | "arid-oasis-resin"
+    | "marine-dye"
+    | "temperate-field-orchard"
+    | "humid-tropical-plantation"
+    | "highland-medicinal"
+    | "wetland-paddy"
+    | "blocked-no-valid-biome";
+  readonly primary: readonly MaskField[];
+  readonly suppress: readonly SuppressionField[];
+};
+
+const DEFAULT_RANGE = {
+  baseline: "standard-earthlike-map" as const,
+  min: 0,
+  target: 0,
+  max: 0,
+  evidence: "blocked" as const,
+};
+
+const CULTIVATED_RESOURCE_TYPES: readonly CultivatedResourceType[] = [
+  "RESOURCE_COTTON",
+  "RESOURCE_DATES",
+  "RESOURCE_DYES",
+  "RESOURCE_INCENSE",
+  "RESOURCE_SILK",
+  "RESOURCE_WINE",
+  "RESOURCE_COCOA",
+  "RESOURCE_SPICES",
+  "RESOURCE_SUGAR",
+  "RESOURCE_TEA",
+  "RESOURCE_COFFEE",
+  "RESOURCE_TOBACCO",
+  "RESOURCE_CITRUS",
+  "RESOURCE_QUININE",
+  "RESOURCE_MANGOS",
+  "RESOURCE_RICE",
+  "RESOURCE_CLOVES",
+  "RESOURCE_FLAX",
+];
+
+const CULTIVATED_SIGNALS: Record<CultivatedResourceType, ResourceSignals> = {
+  RESOURCE_COTTON: {
+    laneId: "alluvial-irrigated",
+    primary: ["warmAlluvialMask", "floodplainOrRiverMask", "warmGrassPlainsMask"],
+    suppress: ["coldMask"],
+  },
+  RESOURCE_DATES: {
+    laneId: "arid-oasis-resin",
+    primary: ["oasisOrDesertWaterMask"],
+    suppress: ["coldMask"],
+  },
+  RESOURCE_DYES: {
+    laneId: "marine-dye",
+    primary: ["coastalMarineMask"],
+    suppress: [],
+  },
+  RESOURCE_INCENSE: {
+    laneId: "arid-oasis-resin",
+    primary: ["aridDryWoodlandMask"],
+    suppress: [],
+  },
+  RESOURCE_SILK: {
+    laneId: "alluvial-irrigated",
+    primary: ["floodplainOrRiverMask", "warmGrassPlainsMask"],
+    suppress: ["coldMask", "aridWithoutWaterMask"],
+  },
+  RESOURCE_WINE: {
+    laneId: "temperate-field-orchard",
+    primary: ["temperateDryPlainsMask", "warmGrassPlainsMask"],
+    suppress: ["coldMask"],
+  },
+  RESOURCE_COCOA: {
+    laneId: "humid-tropical-plantation",
+    primary: ["humidTropicalForestMask", "wetTropicsMask"],
+    suppress: ["aridWithoutWaterMask", "coldMask"],
+  },
+  RESOURCE_SPICES: {
+    laneId: "humid-tropical-plantation",
+    primary: ["humidTropicalForestMask", "wetTropicsMask"],
+    suppress: ["aridWithoutWaterMask"],
+  },
+  RESOURCE_SUGAR: {
+    laneId: "alluvial-irrigated",
+    primary: ["floodplainOrRiverMask", "wetTropicsMask", "warmAlluvialMask"],
+    suppress: ["coldMask", "aridWithoutWaterMask"],
+  },
+  RESOURCE_TEA: {
+    laneId: "highland-medicinal",
+    primary: ["highlandOrReliefMask", "wetTropicsMask"],
+    suppress: ["aridWithoutWaterMask"],
+  },
+  RESOURCE_COFFEE: {
+    laneId: "highland-medicinal",
+    primary: ["highlandOrReliefMask", "humidTropicalForestMask"],
+    suppress: ["aridWithoutWaterMask", "coldMask"],
+  },
+  RESOURCE_TOBACCO: {
+    laneId: "temperate-field-orchard",
+    primary: ["warmGrassPlainsMask", "savannaForestMask"],
+    suppress: ["coldMask", "waterloggedMask"],
+  },
+  RESOURCE_CITRUS: {
+    laneId: "temperate-field-orchard",
+    primary: ["tropicalFruitMask", "warmGrassPlainsMask", "warmAlluvialMask"],
+    suppress: ["coldMask"],
+  },
+  RESOURCE_QUININE: {
+    laneId: "highland-medicinal",
+    primary: ["highlandOrReliefMask", "humidTropicalForestMask", "savannaForestMask"],
+    suppress: ["aridWithoutWaterMask"],
+  },
+  RESOURCE_MANGOS: {
+    laneId: "humid-tropical-plantation",
+    primary: ["tropicalFruitMask", "wetTropicsMask", "humidTropicalForestMask"],
+    suppress: ["coldMask"],
+  },
+  RESOURCE_RICE: {
+    laneId: "wetland-paddy",
+    primary: ["wetlandPaddyMask", "floodplainOrRiverMask"],
+    suppress: ["aridWithoutWaterMask"],
+  },
+  RESOURCE_CLOVES: {
+    laneId: "blocked-no-valid-biome",
+    primary: [],
+    suppress: [],
+  },
+  RESOURCE_FLAX: {
+    laneId: "temperate-field-orchard",
+    primary: ["coolTemperatePlainsMask", "warmGrassPlainsMask"],
+    suppress: [],
+  },
+};
+
+export const defaultStrategy = createStrategy(PlanCultivatedResourcesContract, "default", {
+  run: (input) => {
+    const size = validateGrid(input.width, input.height);
+    const expectations = new Map(input.expectations.map((row) => [row.resourceType, row]));
+    const plans = [];
+    const missingResourceTypes: CultivatedResourceType[] = [];
+
+    for (const resourceType of CULTIVATED_RESOURCE_TYPES) {
+      const expectation = expectations.get(resourceType);
+      if (!expectation) {
+        const signals = CULTIVATED_SIGNALS[resourceType];
+        missingResourceTypes.push(resourceType);
+        plans.push({
+          resourceType,
+          laneId: signals.laneId,
+          status: "missing-expectation" as const,
+          eligibilityStatus: "missing-expectation" as const,
+          expectedCountRange: DEFAULT_RANGE,
+          targetIntentCount: 0,
+          eligibleTileCount: 0,
+          rangeStatus: "not-gated" as const,
+          proofStatus: "warning-only" as const,
+          runtimeIdStatus: "unverified" as const,
+          earthlikePredicate: "",
+          conditionMultipliers: [],
+          proxyRequirements: [],
+          signalFields: [],
+          blockers: ["Missing cultivated earthlike expectation row."],
+          caveats: [],
+        });
+        continue;
+      }
+
+      if (expectation.status === "blocked") {
+        const signals = CULTIVATED_SIGNALS[resourceType];
+        plans.push({
+          resourceType,
+          laneId: signals.laneId,
+          status: "blocked" as const,
+          eligibilityStatus: "blocked" as const,
+          expectedCountRange: expectation.expectedCountRange,
+          targetIntentCount: 0,
+          eligibleTileCount: 0,
+          rangeStatus: "not-gated" as const,
+          proofStatus: "warning-only" as const,
+          runtimeIdStatus: "unverified" as const,
+          earthlikePredicate: expectation.earthlikePredicate,
+          conditionMultipliers: [...expectation.conditionMultipliers],
+          proxyRequirements: [...expectation.proxyRequirements],
+          signalFields: [],
+          blockers: ["Expectation row is blocked by official corpus disposition."],
+          caveats: [...expectation.caveats],
+        });
+        continue;
+      }
+
+      const signals = CULTIVATED_SIGNALS[resourceType];
+      const signalFields = presentFields(input, signals.primary);
+      const eligibleTileCount = countEligibleTiles(input, size, signals);
+      const proxyIncomplete = signalFields.length === 0;
+      const targetIntentCount = proxyIncomplete
+        ? 0
+        : Math.min(expectation.expectedCountRange.max, eligibleTileCount, expectation.expectedCountRange.target);
+      const blockers = [];
+      if (proxyIncomplete) {
+        blockers.push(`Missing cultivated signal masks: ${signals.primary.join(", ")}.`);
+      }
+      if (!proxyIncomplete && eligibleTileCount === 0) {
+        blockers.push("No eligible cultivated tiles observed for this resource under supplied masks.");
+      }
+
+      plans.push({
+        resourceType,
+        laneId: signals.laneId,
+        status: proxyIncomplete ? ("proxy-gap" as const) : ("planned" as const),
+        eligibilityStatus: proxyIncomplete ? ("proxy-incomplete" as const) : ("observed" as const),
+        expectedCountRange: expectation.expectedCountRange,
+        targetIntentCount,
+        eligibleTileCount,
+        rangeStatus: proxyIncomplete
+          ? ("not-gated" as const)
+          : compareRange(targetIntentCount, expectation.expectedCountRange),
+        proofStatus: "warning-only" as const,
+        runtimeIdStatus: "unverified" as const,
+        earthlikePredicate: expectation.earthlikePredicate,
+        conditionMultipliers: [...expectation.conditionMultipliers],
+        proxyRequirements: [...expectation.proxyRequirements],
+        signalFields,
+        blockers,
+        caveats: [...expectation.caveats],
+      });
+    }
+
+    return {
+      groupId: "cultivated-plantation-medicinal" as const,
+      runtimeIdStatus: "unverified" as const,
+      proofStatus: "warning-only" as const,
+      plans,
+      missingResourceTypes,
+    };
+  },
+});
+
+function validateGrid(width: number, height: number): number {
+  const size = width * height;
+  if (!Number.isSafeInteger(size) || size <= 0) {
+    throw new Error(`Invalid grid dimensions for cultivated resource planning: ${width}x${height}.`);
+  }
+  return size;
+}
+
+function presentFields(input: Record<string, unknown>, fields: readonly MaskField[]): string[] {
+  return fields.filter((field) => input[field] !== undefined);
+}
+
+function countEligibleTiles(
+  input: Record<string, unknown>,
+  size: number,
+  signals: ResourceSignals
+): number {
+  const primaryMasks = signals.primary
+    .map((field) => ({ field, mask: readMask(input, field, size) }))
+    .filter((entry): entry is { field: MaskField; mask: Uint8Array } => entry.mask !== undefined);
+  if (primaryMasks.length === 0) return 0;
+
+  const suppressMasks = signals.suppress
+    .map((field) => readMask(input, field, size))
+    .filter((mask): mask is Uint8Array => mask !== undefined);
+
+  let count = 0;
+  for (let i = 0; i < size; i++) {
+    if (!primaryMasks.some(({ mask }) => mask[i] !== 0)) continue;
+    if (suppressMasks.some((mask) => mask[i] !== 0)) continue;
+    count += 1;
+  }
+  return count;
+}
+
+function readMask(input: Record<string, unknown>, field: string, size: number): Uint8Array | undefined {
+  const value = input[field];
+  if (value === undefined) return undefined;
+  if (!(value instanceof Uint8Array)) {
+    throw new Error(`Cultivated resource mask ${field} must be a Uint8Array.`);
+  }
+  if (value.length !== size) {
+    throw new Error(`Cultivated resource mask ${field} length ${value.length} does not match grid size ${size}.`);
+  }
+  return value;
+}
+
+function compareRange(
+  count: number,
+  range: { readonly min: number; readonly max: number }
+): "within-range" | "below-range" | "above-range" {
+  if (count < range.min) return "below-range";
+  if (count > range.max) return "above-range";
+  return "within-range";
+}

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/types.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/types.ts
@@ -1,0 +1,3 @@
+import type { OpTypeBagOf } from "@swooper/mapgen-core/authoring";
+
+export type PlanCultivatedResourcesTypes = OpTypeBagOf<typeof import("./contract.js").default>;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-geological-resources/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-geological-resources/contract.ts
@@ -1,0 +1,214 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+const GeologicalResourceTypeSchema = Type.Union([
+  Type.Literal("RESOURCE_GOLD"),
+  Type.Literal("RESOURCE_GOLD_DISTANT_LANDS"),
+  Type.Literal("RESOURCE_SILVER"),
+  Type.Literal("RESOURCE_SILVER_DISTANT_LANDS"),
+  Type.Literal("RESOURCE_GYPSUM"),
+  Type.Literal("RESOURCE_JADE"),
+  Type.Literal("RESOURCE_KAOLIN"),
+  Type.Literal("RESOURCE_MARBLE"),
+  Type.Literal("RESOURCE_IRON"),
+  Type.Literal("RESOURCE_SALT"),
+  Type.Literal("RESOURCE_LAPIS_LAZULI"),
+  Type.Literal("RESOURCE_NITER"),
+  Type.Literal("RESOURCE_COAL"),
+  Type.Literal("RESOURCE_NICKEL"),
+  Type.Literal("RESOURCE_OIL"),
+  Type.Literal("RESOURCE_CLAY"),
+  Type.Literal("RESOURCE_LIMESTONE"),
+  Type.Literal("RESOURCE_TIN"),
+  Type.Literal("RESOURCE_PITCH"),
+  Type.Literal("RESOURCE_RUBIES"),
+]);
+
+const GeologicalLaneIdSchema = Type.Union([
+  Type.Literal("orogenic-hydrothermal"),
+  Type.Literal("blocked-derivative"),
+  Type.Literal("evaporite-sedimentary"),
+  Type.Literal("ultramafic-metamorphic"),
+  Type.Literal("weathering-clay"),
+  Type.Literal("carbonate-metamorphic"),
+  Type.Literal("craton-orogen"),
+  Type.Literal("closed-basin-salt"),
+  Type.Literal("blocked-no-valid-biome"),
+  Type.Literal("arid-nitrate"),
+  Type.Literal("sedimentary-fuel"),
+  Type.Literal("wet-alluvial-clay"),
+  Type.Literal("carbonate-industrial"),
+  Type.Literal("granite-orogen-placer"),
+  Type.Literal("hydrocarbon-seep"),
+  Type.Literal("ruby-metamorphic"),
+]);
+
+const ExpectedCountRangeSchema = Type.Object(
+  {
+    baseline: Type.Literal("standard-earthlike-map"),
+    min: Type.Integer({ minimum: 0 }),
+    target: Type.Integer({ minimum: 0 }),
+    max: Type.Integer({ minimum: 0 }),
+    evidence: Type.Union([
+      Type.Literal("source-backed"),
+      Type.Literal("inference-backed"),
+      Type.Literal("blocked"),
+    ]),
+  },
+  { additionalProperties: false }
+);
+
+const GeologicalExpectationSchema = Type.Object(
+  {
+    resourceType: GeologicalResourceTypeSchema,
+    groupId: Type.Literal("geological-mineral-gemstone-industrial"),
+    status: Type.Union([
+      Type.Literal("expected"),
+      Type.Literal("conditional"),
+      Type.Literal("blocked"),
+    ]),
+    earthlikePredicate: Type.String(),
+    expectedCountRange: ExpectedCountRangeSchema,
+    conditionMultipliers: Type.Array(Type.String()),
+    proxyRequirements: Type.Array(Type.String()),
+    caveats: Type.Array(Type.String()),
+  },
+  {
+    additionalProperties: true,
+    description:
+      "Geological rows projected from artifact:resources.earthlikeExpectations. Extra source fields may travel with the row, but the op only consumes symbolic expectations.",
+  }
+);
+
+const GeologicalPlanRowSchema = Type.Object(
+  {
+    resourceType: GeologicalResourceTypeSchema,
+    laneId: GeologicalLaneIdSchema,
+    status: Type.Union([
+      Type.Literal("planned"),
+      Type.Literal("blocked"),
+      Type.Literal("missing-expectation"),
+      Type.Literal("proxy-gap"),
+    ]),
+    eligibilityStatus: Type.Union([
+      Type.Literal("observed"),
+      Type.Literal("proxy-incomplete"),
+      Type.Literal("missing-expectation"),
+      Type.Literal("blocked"),
+    ]),
+    expectedCountRange: ExpectedCountRangeSchema,
+    targetIntentCount: Type.Integer({ minimum: 0 }),
+    eligibleTileCount: Type.Integer({ minimum: 0 }),
+    rangeStatus: Type.Union([
+      Type.Literal("within-range"),
+      Type.Literal("below-range"),
+      Type.Literal("above-range"),
+      Type.Literal("not-gated"),
+    ]),
+    proofStatus: Type.Literal("warning-only"),
+    runtimeIdStatus: Type.Literal("unverified"),
+    earthlikePredicate: Type.String(),
+    conditionMultipliers: Type.Array(Type.String()),
+    proxyRequirements: Type.Array(Type.String()),
+    signalFields: Type.Array(Type.String()),
+    blockers: Type.Array(Type.String()),
+    caveats: Type.Array(Type.String()),
+  },
+  { additionalProperties: false }
+);
+
+const PlanGeologicalResourcesContract = defineOp({
+  kind: "plan",
+  id: "resources/plan-geological-resources",
+  input: Type.Object(
+    {
+      width: Type.Integer({ minimum: 1 }),
+      height: Type.Integer({ minimum: 1 }),
+      expectations: Type.Array(GeologicalExpectationSchema),
+      orogenyMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Orogenic or hydrothermal belt mask." })
+      ),
+      alluvialPlacerMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Alluvial placer or mineralized drainage mask." })
+      ),
+      tundraDesertHillMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Tundra/desert hill exposure mask." })
+      ),
+      evaporiteBasinMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Evaporite basin, playa, or salt-pan mask." })
+      ),
+      sedimentaryBasinMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Sedimentary basin mask." })
+      ),
+      ultramaficMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Ultramafic, serpentinite, or jade-host proxy mask." })
+      ),
+      weatheringClayFlatMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Weathering, clay-flat, or kaolinized terrain mask." })
+      ),
+      carbonateBeltMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Carbonate belt, limestone, or marble source mask." })
+      ),
+      cratonMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Craton, BIF, or stable shield proxy mask." })
+      ),
+      closedBasinMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Closed basin or arid basin mask." })
+      ),
+      aridSoilMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Arid soil or nitrate soil proxy mask." })
+      ),
+      forestWetlandBasinMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Ancient swamp, forest, wetland, or peat basin proxy mask." })
+      ),
+      hydrocarbonBasinMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Hydrocarbon, petroleum system, or tar-sand basin mask." })
+      ),
+      wetAlluvialMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Wet alluvial, water-contact, or floodplain sediment mask." })
+      ),
+      graniteBeltMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Granite, greisen, or cassiterite source mask." })
+      ),
+      oilAdjacencyMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Near-oil, bitumen seep, or asphaltum adjacency mask." })
+      ),
+      metamorphicBeltMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Metamorphic, marble-hosted, or corundum belt mask." })
+      ),
+      collisionBeltMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Collision belt or tropical metamorphic gemstone source mask." })
+      ),
+      flatNonGeologicMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Flat or non-geologic suppression mask." })
+      ),
+      wetSuppressionMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Wet-climate suppression mask for evaporite/arid resources." })
+      ),
+      humidSuppressionMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Humid suppression mask for salt/niter/arid resources." })
+      ),
+      offshoreMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Offshore suppression mask until offshore resources are authorized." })
+      ),
+      igneousTerrainMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Igneous terrain suppression mask for carbonate resources." })
+      ),
+    },
+    { additionalProperties: false }
+  ),
+  output: Type.Object(
+    {
+      groupId: Type.Literal("geological-mineral-gemstone-industrial"),
+      runtimeIdStatus: Type.Literal("unverified"),
+      proofStatus: Type.Literal("warning-only"),
+      plans: Type.Array(GeologicalPlanRowSchema),
+      missingResourceTypes: Type.Array(GeologicalResourceTypeSchema),
+    },
+    { additionalProperties: false }
+  ),
+  strategies: {
+    default: Type.Object({}, { additionalProperties: false }),
+  },
+});
+
+export default PlanGeologicalResourcesContract;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-geological-resources/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-geological-resources/index.ts
@@ -1,0 +1,13 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import PlanGeologicalResourcesContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const planGeologicalResources = createOp(PlanGeologicalResourcesContract, {
+  strategies: { default: defaultStrategy },
+});
+
+export type * from "./contract.js";
+export type * from "./types.js";
+
+export default planGeologicalResources;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-geological-resources/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-geological-resources/strategies/default.ts
@@ -1,0 +1,367 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import PlanGeologicalResourcesContract from "../contract.js";
+
+type GeologicalResourceType =
+  | "RESOURCE_GOLD"
+  | "RESOURCE_GOLD_DISTANT_LANDS"
+  | "RESOURCE_SILVER"
+  | "RESOURCE_SILVER_DISTANT_LANDS"
+  | "RESOURCE_GYPSUM"
+  | "RESOURCE_JADE"
+  | "RESOURCE_KAOLIN"
+  | "RESOURCE_MARBLE"
+  | "RESOURCE_IRON"
+  | "RESOURCE_SALT"
+  | "RESOURCE_LAPIS_LAZULI"
+  | "RESOURCE_NITER"
+  | "RESOURCE_COAL"
+  | "RESOURCE_NICKEL"
+  | "RESOURCE_OIL"
+  | "RESOURCE_CLAY"
+  | "RESOURCE_LIMESTONE"
+  | "RESOURCE_TIN"
+  | "RESOURCE_PITCH"
+  | "RESOURCE_RUBIES";
+
+type GeologicalLaneId =
+  | "orogenic-hydrothermal"
+  | "blocked-derivative"
+  | "evaporite-sedimentary"
+  | "ultramafic-metamorphic"
+  | "weathering-clay"
+  | "carbonate-metamorphic"
+  | "craton-orogen"
+  | "closed-basin-salt"
+  | "blocked-no-valid-biome"
+  | "arid-nitrate"
+  | "sedimentary-fuel"
+  | "wet-alluvial-clay"
+  | "carbonate-industrial"
+  | "granite-orogen-placer"
+  | "hydrocarbon-seep"
+  | "ruby-metamorphic";
+
+type MaskField =
+  | "orogenyMask"
+  | "alluvialPlacerMask"
+  | "tundraDesertHillMask"
+  | "evaporiteBasinMask"
+  | "sedimentaryBasinMask"
+  | "ultramaficMask"
+  | "weatheringClayFlatMask"
+  | "carbonateBeltMask"
+  | "cratonMask"
+  | "closedBasinMask"
+  | "aridSoilMask"
+  | "forestWetlandBasinMask"
+  | "hydrocarbonBasinMask"
+  | "wetAlluvialMask"
+  | "graniteBeltMask"
+  | "oilAdjacencyMask"
+  | "metamorphicBeltMask"
+  | "collisionBeltMask";
+
+type SuppressionField =
+  | "flatNonGeologicMask"
+  | "wetSuppressionMask"
+  | "humidSuppressionMask"
+  | "offshoreMask"
+  | "igneousTerrainMask";
+
+type ResourceSignals = {
+  readonly laneId: GeologicalLaneId;
+  readonly primary: readonly MaskField[];
+  readonly suppress: readonly SuppressionField[];
+};
+
+const DEFAULT_RANGE = {
+  baseline: "standard-earthlike-map" as const,
+  min: 0,
+  target: 0,
+  max: 0,
+  evidence: "blocked" as const,
+};
+
+const GEOLOGICAL_RESOURCE_TYPES: readonly GeologicalResourceType[] = [
+  "RESOURCE_GOLD",
+  "RESOURCE_GOLD_DISTANT_LANDS",
+  "RESOURCE_SILVER",
+  "RESOURCE_SILVER_DISTANT_LANDS",
+  "RESOURCE_GYPSUM",
+  "RESOURCE_JADE",
+  "RESOURCE_KAOLIN",
+  "RESOURCE_MARBLE",
+  "RESOURCE_IRON",
+  "RESOURCE_SALT",
+  "RESOURCE_LAPIS_LAZULI",
+  "RESOURCE_NITER",
+  "RESOURCE_COAL",
+  "RESOURCE_NICKEL",
+  "RESOURCE_OIL",
+  "RESOURCE_CLAY",
+  "RESOURCE_LIMESTONE",
+  "RESOURCE_TIN",
+  "RESOURCE_PITCH",
+  "RESOURCE_RUBIES",
+];
+
+const GEOLOGICAL_SIGNALS: Record<GeologicalResourceType, ResourceSignals> = {
+  RESOURCE_GOLD: {
+    laneId: "orogenic-hydrothermal",
+    primary: ["orogenyMask", "alluvialPlacerMask"],
+    suppress: ["flatNonGeologicMask"],
+  },
+  RESOURCE_GOLD_DISTANT_LANDS: {
+    laneId: "blocked-derivative",
+    primary: [],
+    suppress: [],
+  },
+  RESOURCE_SILVER: {
+    laneId: "orogenic-hydrothermal",
+    primary: ["orogenyMask", "tundraDesertHillMask"],
+    suppress: ["flatNonGeologicMask"],
+  },
+  RESOURCE_SILVER_DISTANT_LANDS: {
+    laneId: "blocked-derivative",
+    primary: [],
+    suppress: [],
+  },
+  RESOURCE_GYPSUM: {
+    laneId: "evaporite-sedimentary",
+    primary: ["evaporiteBasinMask", "sedimentaryBasinMask"],
+    suppress: ["wetSuppressionMask"],
+  },
+  RESOURCE_JADE: {
+    laneId: "ultramafic-metamorphic",
+    primary: ["ultramaficMask", "orogenyMask"],
+    suppress: ["flatNonGeologicMask"],
+  },
+  RESOURCE_KAOLIN: {
+    laneId: "weathering-clay",
+    primary: ["weatheringClayFlatMask", "wetAlluvialMask"],
+    suppress: ["flatNonGeologicMask"],
+  },
+  RESOURCE_MARBLE: {
+    laneId: "carbonate-metamorphic",
+    primary: ["carbonateBeltMask"],
+    suppress: ["flatNonGeologicMask"],
+  },
+  RESOURCE_IRON: {
+    laneId: "craton-orogen",
+    primary: ["cratonMask", "orogenyMask"],
+    suppress: ["flatNonGeologicMask"],
+  },
+  RESOURCE_SALT: {
+    laneId: "closed-basin-salt",
+    primary: ["closedBasinMask", "evaporiteBasinMask"],
+    suppress: ["humidSuppressionMask"],
+  },
+  RESOURCE_LAPIS_LAZULI: {
+    laneId: "blocked-no-valid-biome",
+    primary: [],
+    suppress: [],
+  },
+  RESOURCE_NITER: {
+    laneId: "arid-nitrate",
+    primary: ["closedBasinMask", "aridSoilMask"],
+    suppress: ["humidSuppressionMask"],
+  },
+  RESOURCE_COAL: {
+    laneId: "sedimentary-fuel",
+    primary: ["sedimentaryBasinMask", "forestWetlandBasinMask"],
+    suppress: [],
+  },
+  RESOURCE_NICKEL: {
+    laneId: "blocked-no-valid-biome",
+    primary: [],
+    suppress: [],
+  },
+  RESOURCE_OIL: {
+    laneId: "sedimentary-fuel",
+    primary: ["hydrocarbonBasinMask", "sedimentaryBasinMask"],
+    suppress: ["offshoreMask"],
+  },
+  RESOURCE_CLAY: {
+    laneId: "wet-alluvial-clay",
+    primary: ["wetAlluvialMask", "weatheringClayFlatMask"],
+    suppress: [],
+  },
+  RESOURCE_LIMESTONE: {
+    laneId: "carbonate-industrial",
+    primary: ["carbonateBeltMask"],
+    suppress: ["igneousTerrainMask"],
+  },
+  RESOURCE_TIN: {
+    laneId: "granite-orogen-placer",
+    primary: ["graniteBeltMask", "orogenyMask", "alluvialPlacerMask"],
+    suppress: ["flatNonGeologicMask"],
+  },
+  RESOURCE_PITCH: {
+    laneId: "hydrocarbon-seep",
+    primary: ["hydrocarbonBasinMask", "oilAdjacencyMask"],
+    suppress: [],
+  },
+  RESOURCE_RUBIES: {
+    laneId: "ruby-metamorphic",
+    primary: ["metamorphicBeltMask", "collisionBeltMask"],
+    suppress: ["flatNonGeologicMask"],
+  },
+};
+
+export const defaultStrategy = createStrategy(PlanGeologicalResourcesContract, "default", {
+  run: (input) => {
+    const size = validateGrid(input.width, input.height);
+    const expectations = new Map(input.expectations.map((row) => [row.resourceType, row]));
+    const plans = [];
+    const missingResourceTypes: GeologicalResourceType[] = [];
+
+    for (const resourceType of GEOLOGICAL_RESOURCE_TYPES) {
+      const signals = GEOLOGICAL_SIGNALS[resourceType];
+      const expectation = expectations.get(resourceType);
+      if (!expectation) {
+        missingResourceTypes.push(resourceType);
+        plans.push({
+          resourceType,
+          laneId: signals.laneId,
+          status: "missing-expectation" as const,
+          eligibilityStatus: "missing-expectation" as const,
+          expectedCountRange: DEFAULT_RANGE,
+          targetIntentCount: 0,
+          eligibleTileCount: 0,
+          rangeStatus: "not-gated" as const,
+          proofStatus: "warning-only" as const,
+          runtimeIdStatus: "unverified" as const,
+          earthlikePredicate: "",
+          conditionMultipliers: [],
+          proxyRequirements: [],
+          signalFields: [],
+          blockers: ["Missing geological earthlike expectation row."],
+          caveats: [],
+        });
+        continue;
+      }
+
+      if (expectation.status === "blocked") {
+        plans.push({
+          resourceType,
+          laneId: signals.laneId,
+          status: "blocked" as const,
+          eligibilityStatus: "blocked" as const,
+          expectedCountRange: expectation.expectedCountRange,
+          targetIntentCount: 0,
+          eligibleTileCount: 0,
+          rangeStatus: "not-gated" as const,
+          proofStatus: "warning-only" as const,
+          runtimeIdStatus: "unverified" as const,
+          earthlikePredicate: expectation.earthlikePredicate,
+          conditionMultipliers: [...expectation.conditionMultipliers],
+          proxyRequirements: [...expectation.proxyRequirements],
+          signalFields: [],
+          blockers: ["Expectation row is blocked by official corpus disposition."],
+          caveats: [...expectation.caveats],
+        });
+        continue;
+      }
+
+      const signalFields = presentFields(input, signals.primary);
+      const eligibleTileCount = countEligibleTiles(input, size, signals);
+      const proxyIncomplete = signalFields.length === 0;
+      const targetIntentCount = proxyIncomplete
+        ? 0
+        : Math.min(expectation.expectedCountRange.max, eligibleTileCount, expectation.expectedCountRange.target);
+      const blockers = [];
+      if (proxyIncomplete) {
+        blockers.push(`Missing geological signal masks: ${signals.primary.join(", ")}.`);
+      }
+      if (!proxyIncomplete && eligibleTileCount === 0) {
+        blockers.push("No eligible geological tiles observed for this resource under supplied masks.");
+      }
+
+      plans.push({
+        resourceType,
+        laneId: signals.laneId,
+        status: proxyIncomplete ? ("proxy-gap" as const) : ("planned" as const),
+        eligibilityStatus: proxyIncomplete ? ("proxy-incomplete" as const) : ("observed" as const),
+        expectedCountRange: expectation.expectedCountRange,
+        targetIntentCount,
+        eligibleTileCount,
+        rangeStatus: proxyIncomplete
+          ? ("not-gated" as const)
+          : compareRange(targetIntentCount, expectation.expectedCountRange),
+        proofStatus: "warning-only" as const,
+        runtimeIdStatus: "unverified" as const,
+        earthlikePredicate: expectation.earthlikePredicate,
+        conditionMultipliers: [...expectation.conditionMultipliers],
+        proxyRequirements: [...expectation.proxyRequirements],
+        signalFields,
+        blockers,
+        caveats: [...expectation.caveats],
+      });
+    }
+
+    return {
+      groupId: "geological-mineral-gemstone-industrial" as const,
+      runtimeIdStatus: "unverified" as const,
+      proofStatus: "warning-only" as const,
+      plans,
+      missingResourceTypes,
+    };
+  },
+});
+
+function validateGrid(width: number, height: number): number {
+  const size = width * height;
+  if (!Number.isSafeInteger(size) || size <= 0) {
+    throw new Error(`Invalid grid dimensions for geological resource planning: ${width}x${height}.`);
+  }
+  return size;
+}
+
+function presentFields(input: Record<string, unknown>, fields: readonly MaskField[]): string[] {
+  return fields.filter((field) => input[field] !== undefined);
+}
+
+function countEligibleTiles(
+  input: Record<string, unknown>,
+  size: number,
+  signals: ResourceSignals
+): number {
+  const primaryMasks = signals.primary
+    .map((field) => ({ field, mask: readMask(input, field, size) }))
+    .filter((entry): entry is { field: MaskField; mask: Uint8Array } => entry.mask !== undefined);
+  if (primaryMasks.length === 0) return 0;
+
+  const suppressMasks = signals.suppress
+    .map((field) => readMask(input, field, size))
+    .filter((mask): mask is Uint8Array => mask !== undefined);
+
+  let count = 0;
+  for (let i = 0; i < size; i++) {
+    if (!primaryMasks.some(({ mask }) => mask[i] !== 0)) continue;
+    if (suppressMasks.some((mask) => mask[i] !== 0)) continue;
+    count += 1;
+  }
+  return count;
+}
+
+function readMask(input: Record<string, unknown>, field: string, size: number): Uint8Array | undefined {
+  const value = input[field];
+  if (value === undefined) return undefined;
+  if (!(value instanceof Uint8Array)) {
+    throw new Error(`Geological resource mask ${field} must be a Uint8Array.`);
+  }
+  if (value.length !== size) {
+    throw new Error(`Geological resource mask ${field} length ${value.length} does not match grid size ${size}.`);
+  }
+  return value;
+}
+
+function compareRange(
+  count: number,
+  range: { readonly min: number; readonly max: number }
+): "within-range" | "below-range" | "above-range" {
+  if (count < range.min) return "below-range";
+  if (count > range.max) return "above-range";
+  return "within-range";
+}

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-geological-resources/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-geological-resources/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-geological-resources/types.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-geological-resources/types.ts
@@ -1,0 +1,3 @@
+import type { OpTypeBagOf } from "@swooper/mapgen-core/authoring";
+
+export type PlanGeologicalResourcesTypes = OpTypeBagOf<typeof import("./contract.js").default>;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-resource-groups/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-resource-groups/contract.ts
@@ -1,0 +1,99 @@
+import { Type, defineOp } from "@swooper/mapgen-core/authoring";
+
+const ResourceGroupIdSchema = Type.Union([
+  Type.Literal("aquatic-coastal-navigable-river"),
+  Type.Literal("cultivated-plantation-medicinal"),
+  Type.Literal("terrestrial-animal-forest-wild"),
+  Type.Literal("geological-mineral-gemstone-industrial"),
+]);
+
+const ResourceRowStatusSchema = Type.Union([
+  Type.Literal("planned"),
+  Type.Literal("blocked"),
+  Type.Literal("missing-expectation"),
+  Type.Literal("proxy-gap"),
+]);
+
+const ResourcePlanRowSchema = Type.Object(
+  {
+    resourceType: Type.String({ pattern: "^RESOURCE_[A-Z0-9_]+$" }),
+    status: ResourceRowStatusSchema,
+    runtimeIdStatus: Type.Literal("unverified"),
+    proofStatus: Type.Literal("warning-only"),
+    targetIntentCount: Type.Integer({ minimum: 0 }),
+    eligibleTileCount: Type.Integer({ minimum: 0 }),
+  },
+  {
+    additionalProperties: true,
+    description:
+      "Symbolic row emitted by a resource group planner. Extra lane/proxy fields remain group-owned.",
+  }
+);
+
+const ResourceGroupPlanInputSchema = Type.Object(
+  {
+    groupId: ResourceGroupIdSchema,
+    runtimeIdStatus: Type.Literal("unverified"),
+    proofStatus: Type.Literal("warning-only"),
+    plans: Type.Array(ResourcePlanRowSchema),
+    missingResourceTypes: Type.Array(Type.String({ pattern: "^RESOURCE_[A-Z0-9_]+$" })),
+  },
+  { additionalProperties: false }
+);
+
+const ResourceGroupSummarySchema = Type.Object(
+  {
+    groupId: ResourceGroupIdSchema,
+    inputGroupId: ResourceGroupIdSchema,
+    resourceCount: Type.Integer({ minimum: 0 }),
+    plannedCount: Type.Integer({ minimum: 0 }),
+    blockedCount: Type.Integer({ minimum: 0 }),
+    proxyGapCount: Type.Integer({ minimum: 0 }),
+    missingExpectationCount: Type.Integer({ minimum: 0 }),
+    targetIntentCount: Type.Integer({ minimum: 0 }),
+    eligibleTileCount: Type.Integer({ minimum: 0 }),
+    missingResourceTypes: Type.Array(Type.String({ pattern: "^RESOURCE_[A-Z0-9_]+$" })),
+    blockers: Type.Array(Type.String()),
+    plans: Type.Array(ResourcePlanRowSchema),
+  },
+  { additionalProperties: false }
+);
+
+const PlanResourceGroupsContract = defineOp({
+  kind: "plan",
+  id: "resources/plan-resource-groups",
+  input: Type.Object(
+    {
+      aquaticPlan: ResourceGroupPlanInputSchema,
+      cultivatedPlan: ResourceGroupPlanInputSchema,
+      terrestrialPlan: ResourceGroupPlanInputSchema,
+      geologicalPlan: ResourceGroupPlanInputSchema,
+    },
+    { additionalProperties: false }
+  ),
+  output: Type.Object(
+    {
+      artifactId: Type.Literal("artifact:resources.groupPlans"),
+      runtimeIdStatus: Type.Literal("unverified"),
+      proofStatus: Type.Literal("warning-only"),
+      groupCount: Type.Integer({ minimum: 0 }),
+      resourceCount: Type.Integer({ minimum: 0 }),
+      plannedCount: Type.Integer({ minimum: 0 }),
+      blockedCount: Type.Integer({ minimum: 0 }),
+      proxyGapCount: Type.Integer({ minimum: 0 }),
+      missingExpectationCount: Type.Integer({ minimum: 0 }),
+      targetIntentCount: Type.Integer({ minimum: 0 }),
+      eligibleTileCount: Type.Integer({ minimum: 0 }),
+      duplicateResourceTypes: Type.Array(Type.String({ pattern: "^RESOURCE_[A-Z0-9_]+$" })),
+      missingResourceTypes: Type.Array(Type.String({ pattern: "^RESOURCE_[A-Z0-9_]+$" })),
+      blockers: Type.Array(Type.String()),
+      groups: Type.Array(ResourceGroupSummarySchema),
+    },
+    { additionalProperties: false }
+  ),
+  strategies: {
+    default: Type.Object({}, { additionalProperties: false }),
+  },
+});
+
+export default PlanResourceGroupsContract;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-resource-groups/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-resource-groups/index.ts
@@ -1,0 +1,13 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import PlanResourceGroupsContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const planResourceGroups = createOp(PlanResourceGroupsContract, {
+  strategies: { default: defaultStrategy },
+});
+
+export type * from "./contract.js";
+export type * from "./types.js";
+
+export default planResourceGroups;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-resource-groups/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-resource-groups/strategies/default.ts
@@ -1,0 +1,141 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import PlanResourceGroupsContract from "../contract.js";
+
+type ResourceGroupId =
+  | "aquatic-coastal-navigable-river"
+  | "cultivated-plantation-medicinal"
+  | "terrestrial-animal-forest-wild"
+  | "geological-mineral-gemstone-industrial";
+
+type ResourceRowStatus = "planned" | "blocked" | "missing-expectation" | "proxy-gap";
+
+type ResourcePlanRow = {
+  readonly resourceType: string;
+  readonly status: ResourceRowStatus;
+  readonly runtimeIdStatus: "unverified";
+  readonly proofStatus: "warning-only";
+  readonly targetIntentCount: number;
+  readonly eligibleTileCount: number;
+};
+
+type ResourceGroupPlan = {
+  readonly groupId: ResourceGroupId;
+  readonly plans: readonly ResourcePlanRow[];
+  readonly missingResourceTypes: readonly string[];
+};
+
+const EXPECTED_INPUT_GROUPS = [
+  ["aquaticPlan", "aquatic-coastal-navigable-river"],
+  ["cultivatedPlan", "cultivated-plantation-medicinal"],
+  ["terrestrialPlan", "terrestrial-animal-forest-wild"],
+  ["geologicalPlan", "geological-mineral-gemstone-industrial"],
+] as const satisfies readonly (readonly [string, ResourceGroupId])[];
+
+export const defaultStrategy = createStrategy(PlanResourceGroupsContract, "default", {
+  run: (input) => {
+    const seenResources = new Map<string, ResourceGroupId>();
+    const duplicateResourceTypes = new Set<string>();
+    const groups = [];
+    const blockers = [];
+
+    for (const [inputField, expectedGroupId] of EXPECTED_INPUT_GROUPS) {
+      const groupPlan = input[inputField] as ResourceGroupPlan;
+      if (groupPlan.groupId !== expectedGroupId) {
+        blockers.push(
+          `${inputField} supplied ${groupPlan.groupId}; expected ${expectedGroupId}.`
+        );
+      }
+
+      for (const row of groupPlan.plans) {
+        const priorExpectedGroup = seenResources.get(row.resourceType);
+        if (priorExpectedGroup) {
+          duplicateResourceTypes.add(row.resourceType);
+          if (priorExpectedGroup === expectedGroupId) {
+            blockers.push(`${row.resourceType} appears more than once in ${expectedGroupId}.`);
+          } else {
+            blockers.push(
+              `${row.resourceType} appears in both ${priorExpectedGroup} and ${expectedGroupId}.`
+            );
+          }
+        }
+        seenResources.set(row.resourceType, expectedGroupId);
+      }
+
+      groups.push(summarizeGroup(expectedGroupId, groupPlan));
+    }
+
+    const totals = summarizeTotals(groups);
+    const missingResourceTypes = uniqueSorted(
+      groups.flatMap((group) => group.missingResourceTypes)
+    );
+
+    return {
+      artifactId: "artifact:resources.groupPlans" as const,
+      runtimeIdStatus: "unverified" as const,
+      proofStatus: "warning-only" as const,
+      groupCount: groups.length,
+      ...totals,
+      duplicateResourceTypes: [...duplicateResourceTypes].sort(),
+      missingResourceTypes,
+      blockers,
+      groups,
+    };
+  },
+});
+
+function summarizeGroup(expectedGroupId: ResourceGroupId, groupPlan: ResourceGroupPlan) {
+  const statusCounts = countStatuses(groupPlan.plans);
+  const missingResourceTypes = uniqueSorted(groupPlan.missingResourceTypes);
+  const blockers = [];
+
+  if (missingResourceTypes.length > 0) {
+    blockers.push(
+      `${expectedGroupId} has missing expectation rows: ${missingResourceTypes.join(", ")}.`
+    );
+  }
+
+  return {
+    groupId: expectedGroupId,
+    inputGroupId: groupPlan.groupId,
+    resourceCount: groupPlan.plans.length,
+    plannedCount: statusCounts.planned,
+    blockedCount: statusCounts.blocked,
+    proxyGapCount: statusCounts["proxy-gap"],
+    missingExpectationCount: statusCounts["missing-expectation"],
+    targetIntentCount: sum(groupPlan.plans.map((row) => row.targetIntentCount)),
+    eligibleTileCount: sum(groupPlan.plans.map((row) => row.eligibleTileCount)),
+    missingResourceTypes,
+    blockers,
+    plans: groupPlan.plans.map((row) => ({ ...row })),
+  };
+}
+
+function summarizeTotals(groups: readonly ReturnType<typeof summarizeGroup>[]) {
+  return {
+    resourceCount: sum(groups.map((group) => group.resourceCount)),
+    plannedCount: sum(groups.map((group) => group.plannedCount)),
+    blockedCount: sum(groups.map((group) => group.blockedCount)),
+    proxyGapCount: sum(groups.map((group) => group.proxyGapCount)),
+    missingExpectationCount: sum(groups.map((group) => group.missingExpectationCount)),
+    targetIntentCount: sum(groups.map((group) => group.targetIntentCount)),
+    eligibleTileCount: sum(groups.map((group) => group.eligibleTileCount)),
+  };
+}
+
+function countStatuses(rows: readonly ResourcePlanRow[]): Record<ResourceRowStatus, number> {
+  return {
+    planned: rows.filter((row) => row.status === "planned").length,
+    blocked: rows.filter((row) => row.status === "blocked").length,
+    "missing-expectation": rows.filter((row) => row.status === "missing-expectation").length,
+    "proxy-gap": rows.filter((row) => row.status === "proxy-gap").length,
+  };
+}
+
+function sum(values: readonly number[]): number {
+  return values.reduce((total, value) => total + value, 0);
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort();
+}

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-resource-groups/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-resource-groups/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-resource-groups/types.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-resource-groups/types.ts
@@ -1,0 +1,3 @@
+import type PlanResourceGroupsContract from "./contract.js";
+
+export type PlanResourceGroupsOp = typeof PlanResourceGroupsContract;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-terrestrial-resources/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-terrestrial-resources/contract.ts
@@ -1,0 +1,174 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+const TerrestrialResourceTypeSchema = Type.Union([
+  Type.Literal("RESOURCE_CAMELS"),
+  Type.Literal("RESOURCE_HIDES"),
+  Type.Literal("RESOURCE_HORSES"),
+  Type.Literal("RESOURCE_WOOL"),
+  Type.Literal("RESOURCE_IVORY"),
+  Type.Literal("RESOURCE_FURS"),
+  Type.Literal("RESOURCE_TRUFFLES"),
+  Type.Literal("RESOURCE_RUBBER"),
+  Type.Literal("RESOURCE_HARDWOOD"),
+  Type.Literal("RESOURCE_WILD_GAME"),
+  Type.Literal("RESOURCE_LLAMAS"),
+]);
+
+const TerrestrialLaneIdSchema = Type.Union([
+  Type.Literal("arid-rangeland"),
+  Type.Literal("open-grazing"),
+  Type.Literal("highland-pastoral"),
+  Type.Literal("savanna-megafauna"),
+  Type.Literal("cold-boreal-furs"),
+  Type.Literal("woodland-host"),
+  Type.Literal("tropical-forest-product"),
+  Type.Literal("diverse-wild-habitat"),
+  Type.Literal("tropical-highland-pastoral"),
+]);
+
+const ExpectedCountRangeSchema = Type.Object(
+  {
+    baseline: Type.Literal("standard-earthlike-map"),
+    min: Type.Integer({ minimum: 0 }),
+    target: Type.Integer({ minimum: 0 }),
+    max: Type.Integer({ minimum: 0 }),
+    evidence: Type.Union([
+      Type.Literal("source-backed"),
+      Type.Literal("inference-backed"),
+      Type.Literal("blocked"),
+    ]),
+  },
+  { additionalProperties: false }
+);
+
+const TerrestrialExpectationSchema = Type.Object(
+  {
+    resourceType: TerrestrialResourceTypeSchema,
+    groupId: Type.Literal("terrestrial-animal-forest-wild"),
+    status: Type.Union([
+      Type.Literal("expected"),
+      Type.Literal("conditional"),
+      Type.Literal("blocked"),
+    ]),
+    earthlikePredicate: Type.String(),
+    expectedCountRange: ExpectedCountRangeSchema,
+    conditionMultipliers: Type.Array(Type.String()),
+    proxyRequirements: Type.Array(Type.String()),
+    caveats: Type.Array(Type.String()),
+  },
+  {
+    additionalProperties: true,
+    description:
+      "Terrestrial rows projected from artifact:resources.earthlikeExpectations. Extra source fields may travel with the row, but the op only consumes symbolic expectations.",
+  }
+);
+
+const TerrestrialPlanRowSchema = Type.Object(
+  {
+    resourceType: TerrestrialResourceTypeSchema,
+    laneId: TerrestrialLaneIdSchema,
+    status: Type.Union([
+      Type.Literal("planned"),
+      Type.Literal("blocked"),
+      Type.Literal("missing-expectation"),
+      Type.Literal("proxy-gap"),
+    ]),
+    eligibilityStatus: Type.Union([
+      Type.Literal("observed"),
+      Type.Literal("proxy-incomplete"),
+      Type.Literal("missing-expectation"),
+      Type.Literal("blocked"),
+    ]),
+    expectedCountRange: ExpectedCountRangeSchema,
+    targetIntentCount: Type.Integer({ minimum: 0 }),
+    eligibleTileCount: Type.Integer({ minimum: 0 }),
+    rangeStatus: Type.Union([
+      Type.Literal("within-range"),
+      Type.Literal("below-range"),
+      Type.Literal("above-range"),
+      Type.Literal("not-gated"),
+    ]),
+    proofStatus: Type.Literal("warning-only"),
+    runtimeIdStatus: Type.Literal("unverified"),
+    earthlikePredicate: Type.String(),
+    conditionMultipliers: Type.Array(Type.String()),
+    proxyRequirements: Type.Array(Type.String()),
+    signalFields: Type.Array(Type.String()),
+    blockers: Type.Array(Type.String()),
+    caveats: Type.Array(Type.String()),
+  },
+  { additionalProperties: false }
+);
+
+const PlanTerrestrialResourcesContract = defineOp({
+  kind: "plan",
+  id: "resources/plan-terrestrial-resources",
+  input: Type.Object(
+    {
+      width: Type.Integer({ minimum: 1 }),
+      height: Type.Integer({ minimum: 1 }),
+      expectations: Type.Array(TerrestrialExpectationSchema),
+      aridRangelandMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Arid plains, desert rangeland, or dryland corridor mask." })
+      ),
+      openGrassPlainsMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Open grassland, plains, steppe, or low-tree-cover mask." })
+      ),
+      tundraColdEdgeMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Tundra, cold edge, or cold open habitat mask." })
+      ),
+      hillHighlandMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Hill, highland, or pastoral relief mask." })
+      ),
+      savannaWateringHoleMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Savanna, wooded savanna, watering-hole, or desert-edge mask." })
+      ),
+      tropicalForestEdgeMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Tropical forest-edge or wooded savanna megafauna proxy mask." })
+      ),
+      taigaBorealForestMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Taiga, tundra-bog, boreal forest, or cold woodland mask." })
+      ),
+      moistWoodlandEdgeMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Moist woodland edge or host-tree proxy mask." })
+      ),
+      tropicalForestMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Humid tropical forest, rainforest, mangrove, or hardwood mask." })
+      ),
+      diverseWildHabitatMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Mixed natural habitat, marsh edge, forest/grass mosaic, or low-cultivation mask." })
+      ),
+      tropicalHighlandMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Tropical hill/highland pastoral candidate mask." })
+      ),
+      coldMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Cold suppression mask where the resource is frost-limited." })
+      ),
+      aridWithoutWaterMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Arid-without-water suppression mask." })
+      ),
+      denseForestMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Dense forest suppression mask for open-grazing resources." })
+      ),
+      cultivatedPressureMask: Type.Optional(
+        TypedArraySchemas.u8({ description: "Cultivation or monoculture pressure suppression mask." })
+      ),
+    },
+    { additionalProperties: false }
+  ),
+  output: Type.Object(
+    {
+      groupId: Type.Literal("terrestrial-animal-forest-wild"),
+      runtimeIdStatus: Type.Literal("unverified"),
+      proofStatus: Type.Literal("warning-only"),
+      plans: Type.Array(TerrestrialPlanRowSchema),
+      missingResourceTypes: Type.Array(TerrestrialResourceTypeSchema),
+    },
+    { additionalProperties: false }
+  ),
+  strategies: {
+    default: Type.Object({}, { additionalProperties: false }),
+  },
+});
+
+export default PlanTerrestrialResourcesContract;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-terrestrial-resources/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-terrestrial-resources/index.ts
@@ -1,0 +1,13 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import PlanTerrestrialResourcesContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const planTerrestrialResources = createOp(PlanTerrestrialResourcesContract, {
+  strategies: { default: defaultStrategy },
+});
+
+export type * from "./contract.js";
+export type * from "./types.js";
+
+export default planTerrestrialResources;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-terrestrial-resources/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-terrestrial-resources/strategies/default.ts
@@ -1,0 +1,289 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+
+import PlanTerrestrialResourcesContract from "../contract.js";
+
+type TerrestrialResourceType =
+  | "RESOURCE_CAMELS"
+  | "RESOURCE_HIDES"
+  | "RESOURCE_HORSES"
+  | "RESOURCE_WOOL"
+  | "RESOURCE_IVORY"
+  | "RESOURCE_FURS"
+  | "RESOURCE_TRUFFLES"
+  | "RESOURCE_RUBBER"
+  | "RESOURCE_HARDWOOD"
+  | "RESOURCE_WILD_GAME"
+  | "RESOURCE_LLAMAS";
+
+type MaskField =
+  | "aridRangelandMask"
+  | "openGrassPlainsMask"
+  | "tundraColdEdgeMask"
+  | "hillHighlandMask"
+  | "savannaWateringHoleMask"
+  | "tropicalForestEdgeMask"
+  | "taigaBorealForestMask"
+  | "moistWoodlandEdgeMask"
+  | "tropicalForestMask"
+  | "diverseWildHabitatMask"
+  | "tropicalHighlandMask";
+
+type SuppressionField =
+  | "coldMask"
+  | "aridWithoutWaterMask"
+  | "denseForestMask"
+  | "cultivatedPressureMask";
+
+type TerrestrialLaneId =
+  | "arid-rangeland"
+  | "open-grazing"
+  | "highland-pastoral"
+  | "savanna-megafauna"
+  | "cold-boreal-furs"
+  | "woodland-host"
+  | "tropical-forest-product"
+  | "diverse-wild-habitat"
+  | "tropical-highland-pastoral";
+
+type ResourceSignals = {
+  readonly laneId: TerrestrialLaneId;
+  readonly primary: readonly MaskField[];
+  readonly suppress: readonly SuppressionField[];
+};
+
+const DEFAULT_RANGE = {
+  baseline: "standard-earthlike-map" as const,
+  min: 0,
+  target: 0,
+  max: 0,
+  evidence: "blocked" as const,
+};
+
+const TERRESTRIAL_RESOURCE_TYPES: readonly TerrestrialResourceType[] = [
+  "RESOURCE_CAMELS",
+  "RESOURCE_HIDES",
+  "RESOURCE_HORSES",
+  "RESOURCE_WOOL",
+  "RESOURCE_IVORY",
+  "RESOURCE_FURS",
+  "RESOURCE_TRUFFLES",
+  "RESOURCE_RUBBER",
+  "RESOURCE_HARDWOOD",
+  "RESOURCE_WILD_GAME",
+  "RESOURCE_LLAMAS",
+];
+
+const TERRESTRIAL_SIGNALS: Record<TerrestrialResourceType, ResourceSignals> = {
+  RESOURCE_CAMELS: {
+    laneId: "arid-rangeland",
+    primary: ["aridRangelandMask", "openGrassPlainsMask"],
+    suppress: ["coldMask"],
+  },
+  RESOURCE_HIDES: {
+    laneId: "open-grazing",
+    primary: ["openGrassPlainsMask", "tundraColdEdgeMask"],
+    suppress: ["denseForestMask"],
+  },
+  RESOURCE_HORSES: {
+    laneId: "open-grazing",
+    primary: ["openGrassPlainsMask"],
+    suppress: ["denseForestMask", "aridWithoutWaterMask"],
+  },
+  RESOURCE_WOOL: {
+    laneId: "highland-pastoral",
+    primary: ["hillHighlandMask", "aridRangelandMask", "tundraColdEdgeMask"],
+    suppress: [],
+  },
+  RESOURCE_IVORY: {
+    laneId: "savanna-megafauna",
+    primary: ["savannaWateringHoleMask", "tropicalForestEdgeMask"],
+    suppress: ["coldMask"],
+  },
+  RESOURCE_FURS: {
+    laneId: "cold-boreal-furs",
+    primary: ["taigaBorealForestMask", "tundraColdEdgeMask"],
+    suppress: [],
+  },
+  RESOURCE_TRUFFLES: {
+    laneId: "woodland-host",
+    primary: ["moistWoodlandEdgeMask"],
+    suppress: ["aridWithoutWaterMask"],
+  },
+  RESOURCE_RUBBER: {
+    laneId: "tropical-forest-product",
+    primary: ["tropicalForestMask"],
+    suppress: ["aridWithoutWaterMask", "coldMask"],
+  },
+  RESOURCE_HARDWOOD: {
+    laneId: "tropical-forest-product",
+    primary: ["tropicalForestMask", "taigaBorealForestMask"],
+    suppress: [],
+  },
+  RESOURCE_WILD_GAME: {
+    laneId: "diverse-wild-habitat",
+    primary: ["diverseWildHabitatMask", "tropicalForestMask", "openGrassPlainsMask", "tundraColdEdgeMask"],
+    suppress: ["cultivatedPressureMask"],
+  },
+  RESOURCE_LLAMAS: {
+    laneId: "tropical-highland-pastoral",
+    primary: ["tropicalHighlandMask"],
+    suppress: [],
+  },
+};
+
+export const defaultStrategy = createStrategy(PlanTerrestrialResourcesContract, "default", {
+  run: (input) => {
+    const size = validateGrid(input.width, input.height);
+    const expectations = new Map(input.expectations.map((row) => [row.resourceType, row]));
+    const plans = [];
+    const missingResourceTypes: TerrestrialResourceType[] = [];
+
+    for (const resourceType of TERRESTRIAL_RESOURCE_TYPES) {
+      const signals = TERRESTRIAL_SIGNALS[resourceType];
+      const expectation = expectations.get(resourceType);
+      if (!expectation) {
+        missingResourceTypes.push(resourceType);
+        plans.push({
+          resourceType,
+          laneId: signals.laneId,
+          status: "missing-expectation" as const,
+          eligibilityStatus: "missing-expectation" as const,
+          expectedCountRange: DEFAULT_RANGE,
+          targetIntentCount: 0,
+          eligibleTileCount: 0,
+          rangeStatus: "not-gated" as const,
+          proofStatus: "warning-only" as const,
+          runtimeIdStatus: "unverified" as const,
+          earthlikePredicate: "",
+          conditionMultipliers: [],
+          proxyRequirements: [],
+          signalFields: [],
+          blockers: ["Missing terrestrial earthlike expectation row."],
+          caveats: [],
+        });
+        continue;
+      }
+
+      if (expectation.status === "blocked") {
+        plans.push({
+          resourceType,
+          laneId: signals.laneId,
+          status: "blocked" as const,
+          eligibilityStatus: "blocked" as const,
+          expectedCountRange: expectation.expectedCountRange,
+          targetIntentCount: 0,
+          eligibleTileCount: 0,
+          rangeStatus: "not-gated" as const,
+          proofStatus: "warning-only" as const,
+          runtimeIdStatus: "unverified" as const,
+          earthlikePredicate: expectation.earthlikePredicate,
+          conditionMultipliers: [...expectation.conditionMultipliers],
+          proxyRequirements: [...expectation.proxyRequirements],
+          signalFields: [],
+          blockers: ["Expectation row is blocked by official corpus disposition."],
+          caveats: [...expectation.caveats],
+        });
+        continue;
+      }
+
+      const signalFields = presentFields(input, signals.primary);
+      const eligibleTileCount = countEligibleTiles(input, size, signals);
+      const proxyIncomplete = signalFields.length === 0;
+      const targetIntentCount = proxyIncomplete
+        ? 0
+        : Math.min(expectation.expectedCountRange.max, eligibleTileCount, expectation.expectedCountRange.target);
+      const blockers = [];
+      if (proxyIncomplete) {
+        blockers.push(`Missing terrestrial signal masks: ${signals.primary.join(", ")}.`);
+      }
+      if (!proxyIncomplete && eligibleTileCount === 0) {
+        blockers.push("No eligible terrestrial tiles observed for this resource under supplied masks.");
+      }
+
+      plans.push({
+        resourceType,
+        laneId: signals.laneId,
+        status: proxyIncomplete ? ("proxy-gap" as const) : ("planned" as const),
+        eligibilityStatus: proxyIncomplete ? ("proxy-incomplete" as const) : ("observed" as const),
+        expectedCountRange: expectation.expectedCountRange,
+        targetIntentCount,
+        eligibleTileCount,
+        rangeStatus: proxyIncomplete
+          ? ("not-gated" as const)
+          : compareRange(targetIntentCount, expectation.expectedCountRange),
+        proofStatus: "warning-only" as const,
+        runtimeIdStatus: "unverified" as const,
+        earthlikePredicate: expectation.earthlikePredicate,
+        conditionMultipliers: [...expectation.conditionMultipliers],
+        proxyRequirements: [...expectation.proxyRequirements],
+        signalFields,
+        blockers,
+        caveats: [...expectation.caveats],
+      });
+    }
+
+    return {
+      groupId: "terrestrial-animal-forest-wild" as const,
+      runtimeIdStatus: "unverified" as const,
+      proofStatus: "warning-only" as const,
+      plans,
+      missingResourceTypes,
+    };
+  },
+});
+
+function validateGrid(width: number, height: number): number {
+  const size = width * height;
+  if (!Number.isSafeInteger(size) || size <= 0) {
+    throw new Error(`Invalid grid dimensions for terrestrial resource planning: ${width}x${height}.`);
+  }
+  return size;
+}
+
+function presentFields(input: Record<string, unknown>, fields: readonly MaskField[]): string[] {
+  return fields.filter((field) => input[field] !== undefined);
+}
+
+function countEligibleTiles(
+  input: Record<string, unknown>,
+  size: number,
+  signals: ResourceSignals
+): number {
+  const primaryMasks = signals.primary
+    .map((field) => ({ field, mask: readMask(input, field, size) }))
+    .filter((entry): entry is { field: MaskField; mask: Uint8Array } => entry.mask !== undefined);
+  if (primaryMasks.length === 0) return 0;
+
+  const suppressMasks = signals.suppress
+    .map((field) => readMask(input, field, size))
+    .filter((mask): mask is Uint8Array => mask !== undefined);
+
+  let count = 0;
+  for (let i = 0; i < size; i++) {
+    if (!primaryMasks.some(({ mask }) => mask[i] !== 0)) continue;
+    if (suppressMasks.some((mask) => mask[i] !== 0)) continue;
+    count += 1;
+  }
+  return count;
+}
+
+function readMask(input: Record<string, unknown>, field: string, size: number): Uint8Array | undefined {
+  const value = input[field];
+  if (value === undefined) return undefined;
+  if (!(value instanceof Uint8Array)) {
+    throw new Error(`Terrestrial resource mask ${field} must be a Uint8Array.`);
+  }
+  if (value.length !== size) {
+    throw new Error(`Terrestrial resource mask ${field} length ${value.length} does not match grid size ${size}.`);
+  }
+  return value;
+}
+
+function compareRange(
+  count: number,
+  range: { readonly min: number; readonly max: number }
+): "within-range" | "below-range" | "above-range" {
+  if (count < range.min) return "below-range";
+  if (count > range.max) return "above-range";
+  return "within-range";
+}

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-terrestrial-resources/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-terrestrial-resources/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/domain/resources/ops/plan-terrestrial-resources/types.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/plan-terrestrial-resources/types.ts
@@ -1,0 +1,3 @@
+import type { OpTypeBagOf } from "@swooper/mapgen-core/authoring";
+
+export type PlanTerrestrialResourcesTypes = OpTypeBagOf<typeof import("./contract.js").default>;

--- a/mods/mod-swooper-maps/test/resources/resource-aquatic-op-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-aquatic-op-contract.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test";
+import resources from "@mapgen/domain/resources/ops";
+import {
+  EARTHLIKE_RESOURCE_EXPECTATIONS,
+  type EarthlikeResourceExpectation,
+} from "../../src/domain/resources/index.js";
+
+import { TestCompileError, normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
+
+const AQUATIC_RESOURCE_TYPES = [
+  "RESOURCE_FISH",
+  "RESOURCE_PEARLS",
+  "RESOURCE_WHALES",
+  "RESOURCE_CRABS",
+  "RESOURCE_COWRIE",
+  "RESOURCE_TURTLES",
+] as const;
+
+describe("aquatic resource operation contract", () => {
+  it("plans all aquatic resource rows symbolically without runtime ids", () => {
+    const width = 4;
+    const height = 4;
+    const size = width * height;
+    const selection = normalizeOpSelectionOrThrow(resources.ops.planAquaticResources, {
+      strategy: "default",
+      config: {},
+    });
+
+    const result = resources.ops.planAquaticResources.run(
+      {
+        width,
+        height,
+        expectations: aquaticExpectations(),
+        coastalWaterMask: every(size),
+        shelfMask: every(size),
+        warmShallowWaterMask: every(size),
+        coldProductiveWaterMask: every(size),
+        reefOrProtectedShallowsMask: every(size),
+        estuaryMask: every(size),
+        navigableRiverMouthMask: every(size),
+        lakeMask: new Uint8Array(size),
+        iceMask: new Uint8Array(size),
+      },
+      selection
+    );
+
+    expect(result.groupId).toBe("aquatic-coastal-navigable-river");
+    expect(result.runtimeIdStatus).toBe("unverified");
+    expect(result.proofStatus).toBe("warning-only");
+    expect(result.missingResourceTypes).toEqual([]);
+    expect(result.plans.map((plan) => plan.resourceType)).toEqual([...AQUATIC_RESOURCE_TYPES]);
+    expect(result.plans.every((plan) => plan.status === "planned")).toBe(true);
+    expect(result.plans.every((plan) => plan.eligibilityStatus === "observed")).toBe(true);
+    expect(result.plans.every((plan) => plan.targetIntentCount === plan.expectedCountRange.target)).toBe(true);
+
+    for (const row of result.plans) {
+      expect(Object.hasOwn(row, "resourceId")).toBe(false);
+      expect(Object.hasOwn(row, "numericId")).toBe(false);
+      expect(Object.hasOwn(row, "preferredResourceType")).toBe(false);
+    }
+  });
+
+  it("keeps crabs navigable-river proxy visible", () => {
+    const width = 3;
+    const height = 3;
+    const size = width * height;
+    const riverMouths = new Uint8Array(size);
+    riverMouths[4] = 1;
+
+    const result = resources.ops.planAquaticResources.run(
+      {
+        width,
+        height,
+        expectations: aquaticExpectations(),
+        navigableRiverMouthMask: riverMouths,
+      },
+      resources.ops.planAquaticResources.defaultConfig
+    );
+
+    const crabs = result.plans.find((plan) => plan.resourceType === "RESOURCE_CRABS");
+    expect(crabs).toBeDefined();
+    expect(crabs?.signalFields).toContain("navigableRiverMouthMask");
+    expect(crabs?.proxyRequirements).toContain("navigable-river mouth or floodplain proxy");
+    expect(crabs?.eligibleTileCount).toBe(1);
+    expect(crabs?.status).toBe("planned");
+  });
+
+  it("reports missing expectation rows instead of silently dropping resources", () => {
+    const result = resources.ops.planAquaticResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: aquaticExpectations().filter((row) => row.resourceType === "RESOURCE_FISH"),
+        coastalWaterMask: every(4),
+      },
+      resources.ops.planAquaticResources.defaultConfig
+    );
+
+    expect(result.plans).toHaveLength(AQUATIC_RESOURCE_TYPES.length);
+    expect(result.missingResourceTypes).toEqual([
+      "RESOURCE_PEARLS",
+      "RESOURCE_WHALES",
+      "RESOURCE_CRABS",
+      "RESOURCE_COWRIE",
+      "RESOURCE_TURTLES",
+    ]);
+    expect(result.plans.filter((plan) => plan.status === "missing-expectation")).toHaveLength(5);
+  });
+
+  it("does not allow caller config to omit required aquatic resources", () => {
+    expect(() =>
+      normalizeOpSelectionOrThrow(resources.ops.planAquaticResources, {
+        strategy: "default",
+        config: { requiredResourceTypes: ["RESOURCE_FISH"] },
+      })
+    ).toThrow(TestCompileError);
+  });
+
+  it("marks rows as proxy gaps when no aquatic signal mask is supplied", () => {
+    const result = resources.ops.planAquaticResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: aquaticExpectations(),
+      },
+      resources.ops.planAquaticResources.defaultConfig
+    );
+
+    expect(result.missingResourceTypes).toEqual([]);
+    expect(result.plans.every((plan) => plan.status === "proxy-gap")).toBe(true);
+    expect(result.plans.every((plan) => plan.rangeStatus === "not-gated")).toBe(true);
+    expect(result.plans.every((plan) => plan.targetIntentCount === 0)).toBe(true);
+  });
+});
+
+function aquaticExpectations(): EarthlikeResourceExpectation[] {
+  return EARTHLIKE_RESOURCE_EXPECTATIONS.filter(
+    (row) => row.groupId === "aquatic-coastal-navigable-river"
+  );
+}
+
+function every(size: number): Uint8Array {
+  return new Uint8Array(size).fill(1);
+}

--- a/mods/mod-swooper-maps/test/resources/resource-cultivated-op-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-cultivated-op-contract.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "bun:test";
+import resources from "@mapgen/domain/resources/ops";
+import {
+  EARTHLIKE_RESOURCE_EXPECTATIONS,
+  type EarthlikeResourceExpectation,
+} from "../../src/domain/resources/index.js";
+
+import { TestCompileError, normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
+
+const CULTIVATED_RESOURCE_TYPES = [
+  "RESOURCE_COTTON",
+  "RESOURCE_DATES",
+  "RESOURCE_DYES",
+  "RESOURCE_INCENSE",
+  "RESOURCE_SILK",
+  "RESOURCE_WINE",
+  "RESOURCE_COCOA",
+  "RESOURCE_SPICES",
+  "RESOURCE_SUGAR",
+  "RESOURCE_TEA",
+  "RESOURCE_COFFEE",
+  "RESOURCE_TOBACCO",
+  "RESOURCE_CITRUS",
+  "RESOURCE_QUININE",
+  "RESOURCE_MANGOS",
+  "RESOURCE_RICE",
+  "RESOURCE_CLOVES",
+  "RESOURCE_FLAX",
+] as const;
+
+describe("cultivated resource operation contract", () => {
+  it("plans all cultivated resource rows symbolically without runtime ids", () => {
+    const width = 5;
+    const height = 5;
+    const size = width * height;
+    const selection = normalizeOpSelectionOrThrow(resources.ops.planCultivatedResources, {
+      strategy: "default",
+      config: {},
+    });
+
+    const result = resources.ops.planCultivatedResources.run(
+      {
+        width,
+        height,
+        expectations: cultivatedExpectations(),
+        warmAlluvialMask: every(size),
+        floodplainOrRiverMask: every(size),
+        warmGrassPlainsMask: every(size),
+        oasisOrDesertWaterMask: every(size),
+        aridDryWoodlandMask: every(size),
+        coastalMarineMask: every(size),
+        humidTropicalForestMask: every(size),
+        wetTropicsMask: every(size),
+        highlandOrReliefMask: every(size),
+        temperateDryPlainsMask: every(size),
+        savannaForestMask: every(size),
+        tropicalFruitMask: every(size),
+        wetlandPaddyMask: every(size),
+        coolTemperatePlainsMask: every(size),
+        coldMask: new Uint8Array(size),
+        aridWithoutWaterMask: new Uint8Array(size),
+        waterloggedMask: new Uint8Array(size),
+      },
+      selection
+    );
+
+    expect(result.groupId).toBe("cultivated-plantation-medicinal");
+    expect(result.runtimeIdStatus).toBe("unverified");
+    expect(result.proofStatus).toBe("warning-only");
+    expect(result.missingResourceTypes).toEqual([]);
+    expect(result.plans.map((plan) => plan.resourceType)).toEqual([...CULTIVATED_RESOURCE_TYPES]);
+    expect(result.plans.filter((plan) => plan.status === "planned")).toHaveLength(17);
+    expect(result.plans.find((plan) => plan.resourceType === "RESOURCE_CLOVES")?.status).toBe(
+      "blocked"
+    );
+
+    for (const row of result.plans) {
+      expect(Object.hasOwn(row, "resourceId")).toBe(false);
+      expect(Object.hasOwn(row, "numericId")).toBe(false);
+      expect(Object.hasOwn(row, "preferredResourceType")).toBe(false);
+    }
+  });
+
+  it("keeps highland and coastal proxy requirements visible", () => {
+    const width = 3;
+    const height = 3;
+    const size = width * height;
+    const highlands = new Uint8Array(size);
+    const coast = new Uint8Array(size);
+    highlands[4] = 1;
+    coast[2] = 1;
+
+    const result = resources.ops.planCultivatedResources.run(
+      {
+        width,
+        height,
+        expectations: cultivatedExpectations(),
+        highlandOrReliefMask: highlands,
+        coastalMarineMask: coast,
+      },
+      resources.ops.planCultivatedResources.defaultConfig
+    );
+
+    const tea = result.plans.find((plan) => plan.resourceType === "RESOURCE_TEA");
+    const dyes = result.plans.find((plan) => plan.resourceType === "RESOURCE_DYES");
+    expect(tea?.signalFields).toContain("highlandOrReliefMask");
+    expect(tea?.proxyRequirements).toContain("highland or relief proxy");
+    expect(tea?.eligibleTileCount).toBe(1);
+    expect(dyes?.signalFields).toContain("coastalMarineMask");
+    expect(dyes?.laneId).toBe("marine-dye");
+    expect(dyes?.proxyRequirements).toContain("marine/coast lane despite cultivated group");
+    expect(dyes?.eligibleTileCount).toBe(1);
+  });
+
+  it("keeps oasis and wetland proxy families visible", () => {
+    const width = 3;
+    const height = 3;
+    const size = width * height;
+    const oasis = new Uint8Array(size);
+    const wetland = new Uint8Array(size);
+    oasis[0] = 1;
+    wetland[8] = 1;
+
+    const result = resources.ops.planCultivatedResources.run(
+      {
+        width,
+        height,
+        expectations: cultivatedExpectations(),
+        oasisOrDesertWaterMask: oasis,
+        wetlandPaddyMask: wetland,
+      },
+      resources.ops.planCultivatedResources.defaultConfig
+    );
+
+    const dates = result.plans.find((plan) => plan.resourceType === "RESOURCE_DATES");
+    const rice = result.plans.find((plan) => plan.resourceType === "RESOURCE_RICE");
+    expect(dates?.signalFields).toContain("oasisOrDesertWaterMask");
+    expect(dates?.eligibleTileCount).toBe(1);
+    expect(rice?.signalFields).toContain("wetlandPaddyMask");
+    expect(rice?.eligibleTileCount).toBe(1);
+  });
+
+  it("keeps blocked cloves visible and active-zero", () => {
+    const result = resources.ops.planCultivatedResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: cultivatedExpectations(),
+        warmGrassPlainsMask: every(4),
+      },
+      resources.ops.planCultivatedResources.defaultConfig
+    );
+
+    const cloves = result.plans.find((plan) => plan.resourceType === "RESOURCE_CLOVES");
+    expect(cloves).toBeDefined();
+    expect(cloves?.status).toBe("blocked");
+    expect(cloves?.expectedCountRange).toMatchObject({ min: 0, target: 0, max: 0 });
+    expect(cloves?.targetIntentCount).toBe(0);
+    expect(cloves?.conditionMultipliers).toEqual([]);
+  });
+
+  it("reports missing expectation rows instead of silently dropping resources", () => {
+    const result = resources.ops.planCultivatedResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: cultivatedExpectations().filter((row) => row.resourceType === "RESOURCE_COTTON"),
+        warmGrassPlainsMask: every(4),
+      },
+      resources.ops.planCultivatedResources.defaultConfig
+    );
+
+    expect(result.plans).toHaveLength(CULTIVATED_RESOURCE_TYPES.length);
+    expect(result.missingResourceTypes).toEqual(CULTIVATED_RESOURCE_TYPES.slice(1));
+    expect(result.plans.filter((plan) => plan.status === "missing-expectation")).toHaveLength(17);
+  });
+
+  it("does not allow caller config to omit required cultivated resources", () => {
+    for (const selector of ["requiredResourceTypes", "resourceTypes", "includeResources"]) {
+      expect(() =>
+        normalizeOpSelectionOrThrow(resources.ops.planCultivatedResources, {
+          strategy: "default",
+          config: { [selector]: ["RESOURCE_COTTON"] },
+        })
+      ).toThrow(TestCompileError);
+    }
+  });
+
+  it("marks active rows as proxy gaps when no cultivated signal mask is supplied", () => {
+    const result = resources.ops.planCultivatedResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: cultivatedExpectations(),
+      },
+      resources.ops.planCultivatedResources.defaultConfig
+    );
+
+    expect(result.missingResourceTypes).toEqual([]);
+    expect(result.plans.filter((plan) => plan.status === "proxy-gap")).toHaveLength(17);
+    expect(result.plans.find((plan) => plan.resourceType === "RESOURCE_CLOVES")?.status).toBe(
+      "blocked"
+    );
+    expect(result.plans.every((plan) => plan.rangeStatus === "not-gated")).toBe(true);
+  });
+});
+
+function cultivatedExpectations(): EarthlikeResourceExpectation[] {
+  return EARTHLIKE_RESOURCE_EXPECTATIONS.filter(
+    (row) => row.groupId === "cultivated-plantation-medicinal"
+  );
+}
+
+function every(size: number): Uint8Array {
+  return new Uint8Array(size).fill(1);
+}

--- a/mods/mod-swooper-maps/test/resources/resource-geological-op-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-geological-op-contract.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from "bun:test";
+import resources from "@mapgen/domain/resources/ops";
+import {
+  EARTHLIKE_RESOURCE_EXPECTATIONS,
+  type EarthlikeResourceExpectation,
+} from "../../src/domain/resources/index.js";
+
+import { TestCompileError, normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
+
+const GEOLOGICAL_RESOURCE_TYPES = [
+  "RESOURCE_GOLD",
+  "RESOURCE_GOLD_DISTANT_LANDS",
+  "RESOURCE_SILVER",
+  "RESOURCE_SILVER_DISTANT_LANDS",
+  "RESOURCE_GYPSUM",
+  "RESOURCE_JADE",
+  "RESOURCE_KAOLIN",
+  "RESOURCE_MARBLE",
+  "RESOURCE_IRON",
+  "RESOURCE_SALT",
+  "RESOURCE_LAPIS_LAZULI",
+  "RESOURCE_NITER",
+  "RESOURCE_COAL",
+  "RESOURCE_NICKEL",
+  "RESOURCE_OIL",
+  "RESOURCE_CLAY",
+  "RESOURCE_LIMESTONE",
+  "RESOURCE_TIN",
+  "RESOURCE_PITCH",
+  "RESOURCE_RUBIES",
+] as const;
+
+const BLOCKED_GEOLOGICAL_RESOURCE_TYPES = [
+  "RESOURCE_GOLD_DISTANT_LANDS",
+  "RESOURCE_SILVER_DISTANT_LANDS",
+  "RESOURCE_LAPIS_LAZULI",
+  "RESOURCE_NICKEL",
+] as const;
+
+describe("geological resource operation contract", () => {
+  it("plans all geological resource rows symbolically without runtime ids", () => {
+    const width = 5;
+    const height = 5;
+    const size = width * height;
+    const selection = normalizeOpSelectionOrThrow(resources.ops.planGeologicalResources, {
+      strategy: "default",
+      config: {},
+    });
+
+    const result = resources.ops.planGeologicalResources.run(
+      {
+        width,
+        height,
+        expectations: geologicalExpectations(),
+        orogenyMask: every(size),
+        alluvialPlacerMask: every(size),
+        tundraDesertHillMask: every(size),
+        evaporiteBasinMask: every(size),
+        sedimentaryBasinMask: every(size),
+        ultramaficMask: every(size),
+        weatheringClayFlatMask: every(size),
+        carbonateBeltMask: every(size),
+        cratonMask: every(size),
+        closedBasinMask: every(size),
+        aridSoilMask: every(size),
+        forestWetlandBasinMask: every(size),
+        hydrocarbonBasinMask: every(size),
+        wetAlluvialMask: every(size),
+        graniteBeltMask: every(size),
+        oilAdjacencyMask: every(size),
+        metamorphicBeltMask: every(size),
+        collisionBeltMask: every(size),
+        flatNonGeologicMask: new Uint8Array(size),
+        wetSuppressionMask: new Uint8Array(size),
+        humidSuppressionMask: new Uint8Array(size),
+        offshoreMask: new Uint8Array(size),
+        igneousTerrainMask: new Uint8Array(size),
+      },
+      selection
+    );
+
+    expect(result.groupId).toBe("geological-mineral-gemstone-industrial");
+    expect(result.runtimeIdStatus).toBe("unverified");
+    expect(result.proofStatus).toBe("warning-only");
+    expect(result.missingResourceTypes).toEqual([]);
+    expect(result.plans.map((plan) => plan.resourceType)).toEqual([...GEOLOGICAL_RESOURCE_TYPES]);
+    expect(result.plans.filter((plan) => plan.status === "planned")).toHaveLength(16);
+
+    for (const blockedResourceType of BLOCKED_GEOLOGICAL_RESOURCE_TYPES) {
+      expect(result.plans.find((plan) => plan.resourceType === blockedResourceType)?.status).toBe(
+        "blocked"
+      );
+    }
+
+    for (const row of result.plans) {
+      expect(Object.hasOwn(row, "resourceId")).toBe(false);
+      expect(Object.hasOwn(row, "numericId")).toBe(false);
+      expect(Object.hasOwn(row, "preferredResourceType")).toBe(false);
+    }
+  });
+
+  it("keeps blocked official rows visible and active-zero", () => {
+    const result = resources.ops.planGeologicalResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: geologicalExpectations(),
+        orogenyMask: every(4),
+      },
+      resources.ops.planGeologicalResources.defaultConfig
+    );
+
+    for (const blockedResourceType of BLOCKED_GEOLOGICAL_RESOURCE_TYPES) {
+      const row = result.plans.find((plan) => plan.resourceType === blockedResourceType);
+      expect(row).toBeDefined();
+      expect(row?.status).toBe("blocked");
+      expect(row?.expectedCountRange).toMatchObject({ min: 0, target: 0, max: 0 });
+      expect(row?.targetIntentCount).toBe(0);
+      expect(row?.eligibleTileCount).toBe(0);
+      expect(row?.rangeStatus).toBe("not-gated");
+      expect(row?.conditionMultipliers).toEqual([]);
+    }
+  });
+
+  it("preserves hydrothermal, carbonate, hydrocarbon, granite, and metamorphic proxy families", () => {
+    const size = 9;
+    const alluvial = new Uint8Array(size);
+    const closedBasin = new Uint8Array(size);
+    const hydrocarbon = new Uint8Array(size);
+    const granite = new Uint8Array(size);
+    const carbonate = new Uint8Array(size);
+    const metamorphic = new Uint8Array(size);
+    alluvial[0] = 1;
+    closedBasin[1] = 1;
+    hydrocarbon[2] = 1;
+    granite[3] = 1;
+    carbonate[4] = 1;
+    metamorphic[5] = 1;
+
+    const result = resources.ops.planGeologicalResources.run(
+      {
+        width: 3,
+        height: 3,
+        expectations: geologicalExpectations(),
+        alluvialPlacerMask: alluvial,
+        closedBasinMask: closedBasin,
+        hydrocarbonBasinMask: hydrocarbon,
+        graniteBeltMask: granite,
+        carbonateBeltMask: carbonate,
+        metamorphicBeltMask: metamorphic,
+      },
+      resources.ops.planGeologicalResources.defaultConfig
+    );
+
+    const gold = result.plans.find((plan) => plan.resourceType === "RESOURCE_GOLD");
+    const salt = result.plans.find((plan) => plan.resourceType === "RESOURCE_SALT");
+    const oil = result.plans.find((plan) => plan.resourceType === "RESOURCE_OIL");
+    const pitch = result.plans.find((plan) => plan.resourceType === "RESOURCE_PITCH");
+    const tin = result.plans.find((plan) => plan.resourceType === "RESOURCE_TIN");
+    const limestone = result.plans.find((plan) => plan.resourceType === "RESOURCE_LIMESTONE");
+    const rubies = result.plans.find((plan) => plan.resourceType === "RESOURCE_RUBIES");
+
+    expect(gold?.signalFields).toContain("alluvialPlacerMask");
+    expect(gold?.proxyRequirements).toContain("orogeny or alluvial proxy");
+    expect(salt?.signalFields).toContain("closedBasinMask");
+    expect(salt?.proxyRequirements).toContain("closed basin or evaporite proxy");
+    expect(oil?.signalFields).toContain("hydrocarbonBasinMask");
+    expect(oil?.proxyRequirements).toContain("sedimentary basin or hydrocarbon basin proxy");
+    expect(pitch?.signalFields).toContain("hydrocarbonBasinMask");
+    expect(pitch?.proxyRequirements).toContain("hydrocarbon basin proxy");
+    expect(tin?.signalFields).toContain("graniteBeltMask");
+    expect(tin?.proxyRequirements).toContain("granite, orogeny, or placer proxy");
+    expect(limestone?.signalFields).toContain("carbonateBeltMask");
+    expect(limestone?.proxyRequirements).toContain("carbonate basin proxy");
+    expect(rubies?.signalFields).toContain("metamorphicBeltMask");
+    expect(rubies?.proxyRequirements).toContain("metamorphic, marble, or collision-belt proxy");
+  });
+
+  it("keeps narrow geological proxies from broadening into generic terrain signals", () => {
+    const result = resources.ops.planGeologicalResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: geologicalExpectations(),
+        alluvialPlacerMask: every(4),
+        tundraDesertHillMask: every(4),
+        sedimentaryBasinMask: every(4),
+        forestWetlandBasinMask: every(4),
+        wetAlluvialMask: every(4),
+        carbonateBeltMask: every(4),
+      },
+      resources.ops.planGeologicalResources.defaultConfig
+    );
+
+    const jade = result.plans.find((plan) => plan.resourceType === "RESOURCE_JADE");
+    const silver = result.plans.find((plan) => plan.resourceType === "RESOURCE_SILVER");
+    const coal = result.plans.find((plan) => plan.resourceType === "RESOURCE_COAL");
+    const niter = result.plans.find((plan) => plan.resourceType === "RESOURCE_NITER");
+    const limestone = result.plans.find((plan) => plan.resourceType === "RESOURCE_LIMESTONE");
+    const rubies = result.plans.find((plan) => plan.resourceType === "RESOURCE_RUBIES");
+
+    expect(jade?.status).toBe("proxy-gap");
+    expect(jade?.signalFields).not.toContain("alluvialPlacerMask");
+    expect(silver?.signalFields).toEqual(["tundraDesertHillMask"]);
+    expect(silver?.signalFields).not.toContain("hillMask");
+    expect(coal?.signalFields).toEqual(["sedimentaryBasinMask", "forestWetlandBasinMask"]);
+    expect(coal?.signalFields).not.toContain("forestMask");
+    expect(coal?.signalFields).not.toContain("wetlandMask");
+    expect(niter?.status).toBe("proxy-gap");
+    expect(niter?.signalFields).not.toContain("wetAlluvialMask");
+    expect(limestone?.signalFields).toEqual(["carbonateBeltMask"]);
+    expect(limestone?.signalFields).not.toContain("tundraDesertHillMask");
+    expect(rubies?.status).toBe("proxy-gap");
+    expect(rubies?.signalFields).not.toContain("carbonateBeltMask");
+  });
+
+  it("suppression masks reduce observed geological eligibility", () => {
+    const size = 4;
+    const all = every(size);
+    const flat = new Uint8Array(size);
+    const offshore = new Uint8Array(size);
+    const igneous = new Uint8Array(size);
+    flat[0] = 1;
+    offshore[1] = 1;
+    igneous[2] = 1;
+
+    const result = resources.ops.planGeologicalResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: geologicalExpectations(),
+        orogenyMask: all,
+        hydrocarbonBasinMask: all,
+        carbonateBeltMask: all,
+        flatNonGeologicMask: flat,
+        offshoreMask: offshore,
+        igneousTerrainMask: igneous,
+      },
+      resources.ops.planGeologicalResources.defaultConfig
+    );
+
+    expect(result.plans.find((plan) => plan.resourceType === "RESOURCE_GOLD")?.eligibleTileCount).toBe(3);
+    expect(result.plans.find((plan) => plan.resourceType === "RESOURCE_OIL")?.eligibleTileCount).toBe(3);
+    expect(result.plans.find((plan) => plan.resourceType === "RESOURCE_LIMESTONE")?.eligibleTileCount).toBe(3);
+  });
+
+  it("reports missing expectation rows instead of silently dropping resources", () => {
+    const result = resources.ops.planGeologicalResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: geologicalExpectations().filter((row) => row.resourceType === "RESOURCE_GOLD"),
+        orogenyMask: every(4),
+      },
+      resources.ops.planGeologicalResources.defaultConfig
+    );
+
+    expect(result.plans).toHaveLength(GEOLOGICAL_RESOURCE_TYPES.length);
+    expect(result.missingResourceTypes).toEqual(GEOLOGICAL_RESOURCE_TYPES.slice(1));
+    expect(result.plans.filter((plan) => plan.status === "missing-expectation")).toHaveLength(19);
+  });
+
+  it("does not allow caller config to omit required geological resources", () => {
+    for (const selector of ["requiredResourceTypes", "resourceTypes", "includeResources"]) {
+      expect(() =>
+        normalizeOpSelectionOrThrow(resources.ops.planGeologicalResources, {
+          strategy: "default",
+          config: { [selector]: ["RESOURCE_GOLD"] },
+        })
+      ).toThrow(TestCompileError);
+    }
+  });
+
+  it("marks active rows as proxy gaps when no geological signal mask is supplied", () => {
+    const result = resources.ops.planGeologicalResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: geologicalExpectations(),
+      },
+      resources.ops.planGeologicalResources.defaultConfig
+    );
+
+    expect(result.missingResourceTypes).toEqual([]);
+    expect(result.plans.filter((plan) => plan.status === "proxy-gap")).toHaveLength(16);
+    for (const blockedResourceType of BLOCKED_GEOLOGICAL_RESOURCE_TYPES) {
+      expect(result.plans.find((plan) => plan.resourceType === blockedResourceType)?.status).toBe(
+        "blocked"
+      );
+    }
+    expect(result.plans.every((plan) => plan.rangeStatus === "not-gated")).toBe(true);
+  });
+});
+
+function geologicalExpectations(): EarthlikeResourceExpectation[] {
+  return EARTHLIKE_RESOURCE_EXPECTATIONS.filter(
+    (row) => row.groupId === "geological-mineral-gemstone-industrial"
+  );
+}
+
+function every(size: number): Uint8Array {
+  return new Uint8Array(size).fill(1);
+}

--- a/mods/mod-swooper-maps/test/resources/resource-group-rollup-op-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-group-rollup-op-contract.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "bun:test";
+import resources from "@mapgen/domain/resources/ops";
+import {
+  EARTHLIKE_RESOURCE_EXPECTATIONS,
+  type EarthlikeResourceExpectation,
+} from "../../src/domain/resources/index.js";
+
+import { TestCompileError, normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
+
+describe("resource group rollup operation contract", () => {
+  it("publishes one warning-only group plan artifact across all symbolic resource groups", () => {
+    const selection = normalizeOpSelectionOrThrow(resources.ops.planResourceGroups, {
+      strategy: "default",
+      config: {},
+    });
+
+    const result = resources.ops.planResourceGroups.run(allGroupPlans(5, 5), selection);
+
+    expect(result.artifactId).toBe("artifact:resources.groupPlans");
+    expect(result.runtimeIdStatus).toBe("unverified");
+    expect(result.proofStatus).toBe("warning-only");
+    expect(result.groupCount).toBe(4);
+    expect(result.resourceCount).toBe(55);
+    expect(result.plannedCount).toBe(50);
+    expect(result.blockedCount).toBe(5);
+    expect(result.proxyGapCount).toBe(0);
+    expect(result.missingExpectationCount).toBe(0);
+    expect(result.targetIntentCount).toBe(374);
+    expect(result.eligibleTileCount).toBe(1250);
+    expect(result.duplicateResourceTypes).toEqual([]);
+    expect(result.missingResourceTypes).toEqual([]);
+    expect(result.blockers).toEqual([]);
+
+    expect(result.groups.map((group) => group.groupId)).toEqual([
+      "aquatic-coastal-navigable-river",
+      "cultivated-plantation-medicinal",
+      "terrestrial-animal-forest-wild",
+      "geological-mineral-gemstone-industrial",
+    ]);
+    expect(result.groups.map((group) => group.inputGroupId)).toEqual(
+      result.groups.map((group) => group.groupId)
+    );
+    expect(result.groups.map((group) => group.plans.length)).toEqual([6, 18, 11, 20]);
+    expect(result.groups[0]?.plans.map((plan) => plan.resourceType)).toContain("RESOURCE_FISH");
+
+    for (const group of result.groups) {
+      for (const row of group.plans) {
+        expect(Object.hasOwn(row, "resourceId")).toBe(false);
+        expect(Object.hasOwn(row, "numericId")).toBe(false);
+        expect(Object.hasOwn(row, "preferredResourceType")).toBe(false);
+      }
+    }
+  });
+
+  it("preserves group-level blocked, proxy-gap, and missing-expectation counts", () => {
+    const plans = allGroupPlans(2, 2);
+    const result = resources.ops.planResourceGroups.run(
+      {
+        ...plans,
+        geologicalPlan: resources.ops.planGeologicalResources.run(
+          {
+            width: 2,
+            height: 2,
+            expectations: geologicalExpectations().filter(
+              (row) => row.resourceType !== "RESOURCE_RUBIES"
+            ),
+          },
+          resources.ops.planGeologicalResources.defaultConfig
+        ),
+      },
+      resources.ops.planResourceGroups.defaultConfig
+    );
+
+    const geological = result.groups.find(
+      (group) => group.groupId === "geological-mineral-gemstone-industrial"
+    );
+    expect(geological?.blockedCount).toBe(4);
+    expect(geological?.proxyGapCount).toBe(15);
+    expect(geological?.missingExpectationCount).toBe(1);
+    expect(result.missingResourceTypes).toEqual(["RESOURCE_RUBIES"]);
+    expect(geological?.blockers).toEqual([
+      "geological-mineral-gemstone-industrial has missing expectation rows: RESOURCE_RUBIES.",
+    ]);
+  });
+
+  it("reports duplicate resource ownership across group plans", () => {
+    const plans = allGroupPlans(2, 2);
+    const result = resources.ops.planResourceGroups.run(
+      {
+        ...plans,
+        cultivatedPlan: {
+          ...plans.cultivatedPlan,
+          plans: [...plans.cultivatedPlan.plans, plans.aquaticPlan.plans[0]],
+        },
+      },
+      resources.ops.planResourceGroups.defaultConfig
+    );
+
+    expect(result.duplicateResourceTypes).toEqual(["RESOURCE_FISH"]);
+    expect(result.blockers).toEqual([
+      "RESOURCE_FISH appears in both aquatic-coastal-navigable-river and cultivated-plantation-medicinal.",
+    ]);
+  });
+
+  it("reports duplicate rows inside one group plan", () => {
+    const plans = allGroupPlans(2, 2);
+    const result = resources.ops.planResourceGroups.run(
+      {
+        ...plans,
+        aquaticPlan: {
+          ...plans.aquaticPlan,
+          plans: [...plans.aquaticPlan.plans, plans.aquaticPlan.plans[0]],
+        },
+      },
+      resources.ops.planResourceGroups.defaultConfig
+    );
+
+    expect(result.duplicateResourceTypes).toEqual(["RESOURCE_FISH"]);
+    expect(result.blockers).toEqual([
+      "RESOURCE_FISH appears more than once in aquatic-coastal-navigable-river.",
+    ]);
+  });
+
+  it("reports group input miswiring without changing the runtime boundary", () => {
+    const plans = allGroupPlans(2, 2);
+    const result = resources.ops.planResourceGroups.run(
+      {
+        ...plans,
+        aquaticPlan: {
+          ...plans.aquaticPlan,
+          groupId: "cultivated-plantation-medicinal",
+        },
+      },
+      resources.ops.planResourceGroups.defaultConfig
+    );
+
+    expect(result.runtimeIdStatus).toBe("unverified");
+    expect(result.proofStatus).toBe("warning-only");
+    expect(result.blockers).toContain(
+      "aquaticPlan supplied cultivated-plantation-medicinal; expected aquatic-coastal-navigable-river."
+    );
+    expect(result.groups.map((group) => group.groupId)).toEqual([
+      "aquatic-coastal-navigable-river",
+      "cultivated-plantation-medicinal",
+      "terrestrial-animal-forest-wild",
+      "geological-mineral-gemstone-industrial",
+    ]);
+    expect(result.groups[0]?.inputGroupId).toBe("cultivated-plantation-medicinal");
+    expect(result.groups[0]?.plans).toHaveLength(6);
+  });
+
+  it("does not allow caller config to omit resource groups", () => {
+    for (const selector of ["requiredGroupIds", "groupIds", "includeGroups"]) {
+      expect(() =>
+        normalizeOpSelectionOrThrow(resources.ops.planResourceGroups, {
+          strategy: "default",
+          config: { [selector]: ["aquatic-coastal-navigable-river"] },
+        })
+      ).toThrow(TestCompileError);
+    }
+  });
+});
+
+function allGroupPlans(width: number, height: number) {
+  const size = width * height;
+  return {
+    aquaticPlan: resources.ops.planAquaticResources.run(
+      {
+        width,
+        height,
+        expectations: expectationsFor("aquatic-coastal-navigable-river"),
+        coastalWaterMask: every(size),
+        shelfMask: every(size),
+        warmShallowWaterMask: every(size),
+        coldProductiveWaterMask: every(size),
+        reefOrProtectedShallowsMask: every(size),
+        estuaryMask: every(size),
+        navigableRiverMouthMask: every(size),
+        lakeMask: new Uint8Array(size),
+        iceMask: new Uint8Array(size),
+      },
+      resources.ops.planAquaticResources.defaultConfig
+    ),
+    cultivatedPlan: resources.ops.planCultivatedResources.run(
+      {
+        width,
+        height,
+        expectations: expectationsFor("cultivated-plantation-medicinal"),
+        warmAlluvialMask: every(size),
+        floodplainOrRiverMask: every(size),
+        warmGrassPlainsMask: every(size),
+        oasisOrDesertWaterMask: every(size),
+        aridDryWoodlandMask: every(size),
+        coastalMarineMask: every(size),
+        humidTropicalForestMask: every(size),
+        wetTropicsMask: every(size),
+        highlandOrReliefMask: every(size),
+        temperateDryPlainsMask: every(size),
+        savannaForestMask: every(size),
+        tropicalFruitMask: every(size),
+        wetlandPaddyMask: every(size),
+        coolTemperatePlainsMask: every(size),
+        coldMask: new Uint8Array(size),
+        aridWithoutWaterMask: new Uint8Array(size),
+        waterloggedMask: new Uint8Array(size),
+      },
+      resources.ops.planCultivatedResources.defaultConfig
+    ),
+    terrestrialPlan: resources.ops.planTerrestrialResources.run(
+      {
+        width,
+        height,
+        expectations: expectationsFor("terrestrial-animal-forest-wild"),
+        aridRangelandMask: every(size),
+        openGrassPlainsMask: every(size),
+        tundraColdEdgeMask: every(size),
+        hillHighlandMask: every(size),
+        savannaWateringHoleMask: every(size),
+        tropicalForestEdgeMask: every(size),
+        taigaBorealForestMask: every(size),
+        moistWoodlandEdgeMask: every(size),
+        tropicalForestMask: every(size),
+        diverseWildHabitatMask: every(size),
+        tropicalHighlandMask: every(size),
+        coldMask: new Uint8Array(size),
+        aridWithoutWaterMask: new Uint8Array(size),
+        denseForestMask: new Uint8Array(size),
+        cultivatedPressureMask: new Uint8Array(size),
+      },
+      resources.ops.planTerrestrialResources.defaultConfig
+    ),
+    geologicalPlan: resources.ops.planGeologicalResources.run(
+      {
+        width,
+        height,
+        expectations: geologicalExpectations(),
+        orogenyMask: every(size),
+        alluvialPlacerMask: every(size),
+        tundraDesertHillMask: every(size),
+        evaporiteBasinMask: every(size),
+        sedimentaryBasinMask: every(size),
+        ultramaficMask: every(size),
+        weatheringClayFlatMask: every(size),
+        carbonateBeltMask: every(size),
+        cratonMask: every(size),
+        closedBasinMask: every(size),
+        aridSoilMask: every(size),
+        forestWetlandBasinMask: every(size),
+        hydrocarbonBasinMask: every(size),
+        wetAlluvialMask: every(size),
+        graniteBeltMask: every(size),
+        oilAdjacencyMask: every(size),
+        metamorphicBeltMask: every(size),
+        collisionBeltMask: every(size),
+        flatNonGeologicMask: new Uint8Array(size),
+        wetSuppressionMask: new Uint8Array(size),
+        humidSuppressionMask: new Uint8Array(size),
+        offshoreMask: new Uint8Array(size),
+        igneousTerrainMask: new Uint8Array(size),
+      },
+      resources.ops.planGeologicalResources.defaultConfig
+    ),
+  };
+}
+
+function expectationsFor(groupId: EarthlikeResourceExpectation["groupId"]): EarthlikeResourceExpectation[] {
+  return EARTHLIKE_RESOURCE_EXPECTATIONS.filter((row) => row.groupId === groupId);
+}
+
+function geologicalExpectations(): EarthlikeResourceExpectation[] {
+  return expectationsFor("geological-mineral-gemstone-industrial");
+}
+
+function every(size: number): Uint8Array {
+  return new Uint8Array(size).fill(1);
+}

--- a/mods/mod-swooper-maps/test/resources/resource-terrestrial-op-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-terrestrial-op-contract.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "bun:test";
+import resources from "@mapgen/domain/resources/ops";
+import {
+  EARTHLIKE_RESOURCE_EXPECTATIONS,
+  type EarthlikeResourceExpectation,
+} from "../../src/domain/resources/index.js";
+
+import { TestCompileError, normalizeOpSelectionOrThrow } from "../support/compiler-helpers.js";
+
+const TERRESTRIAL_RESOURCE_TYPES = [
+  "RESOURCE_CAMELS",
+  "RESOURCE_HIDES",
+  "RESOURCE_HORSES",
+  "RESOURCE_WOOL",
+  "RESOURCE_IVORY",
+  "RESOURCE_FURS",
+  "RESOURCE_TRUFFLES",
+  "RESOURCE_RUBBER",
+  "RESOURCE_HARDWOOD",
+  "RESOURCE_WILD_GAME",
+  "RESOURCE_LLAMAS",
+] as const;
+
+describe("terrestrial resource operation contract", () => {
+  it("plans all terrestrial resource rows symbolically without runtime ids", () => {
+    const width = 5;
+    const height = 5;
+    const size = width * height;
+    const selection = normalizeOpSelectionOrThrow(resources.ops.planTerrestrialResources, {
+      strategy: "default",
+      config: {},
+    });
+
+    const result = resources.ops.planTerrestrialResources.run(
+      {
+        width,
+        height,
+        expectations: terrestrialExpectations(),
+        aridRangelandMask: every(size),
+        openGrassPlainsMask: every(size),
+        tundraColdEdgeMask: every(size),
+        hillHighlandMask: every(size),
+        savannaWateringHoleMask: every(size),
+        tropicalForestEdgeMask: every(size),
+        taigaBorealForestMask: every(size),
+        moistWoodlandEdgeMask: every(size),
+        tropicalForestMask: every(size),
+        diverseWildHabitatMask: every(size),
+        tropicalHighlandMask: every(size),
+        coldMask: new Uint8Array(size),
+        aridWithoutWaterMask: new Uint8Array(size),
+        denseForestMask: new Uint8Array(size),
+        cultivatedPressureMask: new Uint8Array(size),
+      },
+      selection
+    );
+
+    expect(result.groupId).toBe("terrestrial-animal-forest-wild");
+    expect(result.runtimeIdStatus).toBe("unverified");
+    expect(result.proofStatus).toBe("warning-only");
+    expect(result.missingResourceTypes).toEqual([]);
+    expect(result.plans.map((plan) => plan.resourceType)).toEqual([...TERRESTRIAL_RESOURCE_TYPES]);
+    expect(result.plans.every((plan) => plan.status === "planned")).toBe(true);
+
+    for (const row of result.plans) {
+      expect(Object.hasOwn(row, "resourceId")).toBe(false);
+      expect(Object.hasOwn(row, "numericId")).toBe(false);
+      expect(Object.hasOwn(row, "preferredResourceType")).toBe(false);
+    }
+  });
+
+  it("keeps woodland-host and tropical-highland proxy requirements visible", () => {
+    const width = 3;
+    const height = 3;
+    const size = width * height;
+    const woodland = new Uint8Array(size);
+    const tropicalHighland = new Uint8Array(size);
+    woodland[4] = 1;
+    tropicalHighland[7] = 1;
+
+    const result = resources.ops.planTerrestrialResources.run(
+      {
+        width,
+        height,
+        expectations: terrestrialExpectations(),
+        moistWoodlandEdgeMask: woodland,
+        tropicalHighlandMask: tropicalHighland,
+      },
+      resources.ops.planTerrestrialResources.defaultConfig
+    );
+
+    const truffles = result.plans.find((plan) => plan.resourceType === "RESOURCE_TRUFFLES");
+    const llamas = result.plans.find((plan) => plan.resourceType === "RESOURCE_LLAMAS");
+    expect(truffles?.laneId).toBe("woodland-host");
+    expect(truffles?.signalFields).toContain("moistWoodlandEdgeMask");
+    expect(truffles?.proxyRequirements).toContain("woodland or host-tree proxy");
+    expect(truffles?.eligibleTileCount).toBe(1);
+    expect(llamas?.laneId).toBe("tropical-highland-pastoral");
+    expect(llamas?.signalFields).toContain("tropicalHighlandMask");
+    expect(llamas?.proxyRequirements).toContain("tropical hill or highland candidate histogram");
+    expect(llamas?.eligibleTileCount).toBe(1);
+  });
+
+  it("keeps ivory on savanna or forest-edge proxies instead of broad tropical forest", () => {
+    const width = 3;
+    const height = 3;
+    const size = width * height;
+    const forestEdge = new Uint8Array(size);
+    forestEdge[5] = 1;
+
+    const result = resources.ops.planTerrestrialResources.run(
+      {
+        width,
+        height,
+        expectations: terrestrialExpectations(),
+        tropicalForestEdgeMask: forestEdge,
+        tropicalForestMask: every(size),
+      },
+      resources.ops.planTerrestrialResources.defaultConfig
+    );
+
+    const ivory = result.plans.find((plan) => plan.resourceType === "RESOURCE_IVORY");
+    expect(ivory?.laneId).toBe("savanna-megafauna");
+    expect(ivory?.signalFields).toContain("tropicalForestEdgeMask");
+    expect(ivory?.signalFields).not.toContain("tropicalForestMask");
+    expect(ivory?.eligibleTileCount).toBe(1);
+  });
+
+  it("keeps synthetic blocked rows visible and active-zero", () => {
+    const expectations = terrestrialExpectations();
+    const camels = expectations.find((row) => row.resourceType === "RESOURCE_CAMELS");
+    expect(camels).toBeDefined();
+    const result = resources.ops.planTerrestrialResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: [
+          {
+            ...camels!,
+            status: "blocked",
+            expectedCountRange: { baseline: "standard-earthlike-map", min: 0, target: 0, max: 0, evidence: "blocked" },
+            conditionMultipliers: [],
+          },
+          ...expectations.filter((row) => row.resourceType !== "RESOURCE_CAMELS"),
+        ],
+        aridRangelandMask: every(4),
+      },
+      resources.ops.planTerrestrialResources.defaultConfig
+    );
+
+    const camelsRow = result.plans.find((plan) => plan.resourceType === "RESOURCE_CAMELS");
+    expect(camelsRow?.status).toBe("blocked");
+    expect(camelsRow?.targetIntentCount).toBe(0);
+    expect(camelsRow?.eligibleTileCount).toBe(0);
+    expect(camelsRow?.rangeStatus).toBe("not-gated");
+  });
+
+  it("suppression masks reduce observed eligibility", () => {
+    const size = 4;
+    const open = every(size);
+    const denseForest = new Uint8Array(size);
+    const cultivated = new Uint8Array(size);
+    denseForest[0] = 1;
+    cultivated[1] = 1;
+
+    const result = resources.ops.planTerrestrialResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: terrestrialExpectations(),
+        openGrassPlainsMask: open,
+        diverseWildHabitatMask: open,
+        denseForestMask: denseForest,
+        cultivatedPressureMask: cultivated,
+      },
+      resources.ops.planTerrestrialResources.defaultConfig
+    );
+
+    expect(result.plans.find((plan) => plan.resourceType === "RESOURCE_HORSES")?.eligibleTileCount).toBe(3);
+    expect(result.plans.find((plan) => plan.resourceType === "RESOURCE_WILD_GAME")?.eligibleTileCount).toBe(3);
+  });
+
+  it("keeps hardwood caveat visible", () => {
+    const result = resources.ops.planTerrestrialResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: terrestrialExpectations(),
+        tropicalForestMask: every(4),
+      },
+      resources.ops.planTerrestrialResources.defaultConfig
+    );
+
+    const hardwood = result.plans.find((plan) => plan.resourceType === "RESOURCE_HARDWOOD");
+    expect(hardwood?.laneId).toBe("tropical-forest-product");
+    expect(hardwood?.caveats).toContain(
+      "Do not broaden to temperate forests without official or runtime proof."
+    );
+  });
+
+  it("reports missing expectation rows instead of silently dropping resources", () => {
+    const result = resources.ops.planTerrestrialResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: terrestrialExpectations().filter((row) => row.resourceType === "RESOURCE_CAMELS"),
+        aridRangelandMask: every(4),
+      },
+      resources.ops.planTerrestrialResources.defaultConfig
+    );
+
+    expect(result.plans).toHaveLength(TERRESTRIAL_RESOURCE_TYPES.length);
+    expect(result.missingResourceTypes).toEqual(TERRESTRIAL_RESOURCE_TYPES.slice(1));
+    expect(result.plans.filter((plan) => plan.status === "missing-expectation")).toHaveLength(10);
+  });
+
+  it("does not allow caller config to omit required terrestrial resources", () => {
+    for (const selector of ["requiredResourceTypes", "resourceTypes", "includeResources"]) {
+      expect(() =>
+        normalizeOpSelectionOrThrow(resources.ops.planTerrestrialResources, {
+          strategy: "default",
+          config: { [selector]: ["RESOURCE_CAMELS"] },
+        })
+      ).toThrow(TestCompileError);
+    }
+  });
+
+  it("marks rows as proxy gaps when no terrestrial signal mask is supplied", () => {
+    const result = resources.ops.planTerrestrialResources.run(
+      {
+        width: 2,
+        height: 2,
+        expectations: terrestrialExpectations(),
+      },
+      resources.ops.planTerrestrialResources.defaultConfig
+    );
+
+    expect(result.missingResourceTypes).toEqual([]);
+    expect(result.plans.every((plan) => plan.status === "proxy-gap")).toBe(true);
+    expect(result.plans.every((plan) => plan.rangeStatus === "not-gated")).toBe(true);
+    expect(result.plans.every((plan) => plan.targetIntentCount === 0)).toBe(true);
+  });
+});
+
+function terrestrialExpectations(): EarthlikeResourceExpectation[] {
+  return EARTHLIKE_RESOURCE_EXPECTATIONS.filter(
+    (row) => row.groupId === "terrestrial-animal-forest-wild"
+  );
+}
+
+function every(size: number): Uint8Array {
+  return new Uint8Array(size).fill(1);
+}

--- a/openspec/changes/resource-aquatic-operation-contract/.openspec.yaml
+++ b/openspec/changes/resource-aquatic-operation-contract/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-aquatic-operation-contract/design.md
+++ b/openspec/changes/resource-aquatic-operation-contract/design.md
@@ -1,0 +1,60 @@
+# Resource Aquatic Operation Contract Design
+
+## Decision
+
+Add a resource-domain operation:
+
+```text
+resources/plan-aquatic-resources
+```
+
+The op is group-level because the six aquatic resources share the same
+water/coast/river input family and output artifact shape. The output remains
+per-resource: fish, pearls, whales, crabs, cowrie, and turtles each receive a
+separate planning row.
+
+The six-resource set is strategy-owned, not caller-configurable. Callers may
+not shrink group coverage through op config.
+
+## Input Boundary
+
+The op consumes symbolic earthlike expectation rows from
+`artifact:resources.earthlikeExpectations`. It may also receive resource-owned
+eligibility masks for coastal water, shelf, warm shallow water, cold productive
+water, reefs/protected shallows, estuaries, navigable-river mouths, lakes, and
+ice.
+
+These masks model the future `artifact:resources.inputs` boundary. They are not
+the placement-domain broad input blob and they do not carry numeric resource
+ids.
+
+## Output Boundary
+
+Each output row carries:
+
+- `resourceType`;
+- active status (`planned`, `proxy-gap`, `missing-expectation`, or `blocked`);
+- `expectedCountRange`;
+- `targetIntentCount` and `eligibleTileCount`;
+- `rangeStatus`;
+- `proofStatus = "warning-only"`;
+- `runtimeIdStatus = "unverified"`;
+- signal fields, proxy requirements, blockers, and caveats.
+
+This is a planning contract, not adapter materialization. It emits no
+`resourceId`, `numericId`, `preferredResourceType`, or tile-level placement
+intent.
+
+## Crabs River Boundary
+
+`RESOURCE_CRABS` remains eligible through estuary and navigable-river-mouth
+signals as well as coastal signals. Tests assert the
+`navigable-river mouth or floodplain proxy` requirement survives planning.
+
+## Write Set
+
+- `mods/mod-swooper-maps/src/domain/resources/index.ts`
+- `mods/mod-swooper-maps/src/domain/resources/ops.ts`
+- `mods/mod-swooper-maps/src/domain/resources/ops/**`
+- `mods/mod-swooper-maps/test/resources/resource-aquatic-op-contract.test.ts`
+- `openspec/changes/resource-aquatic-operation-contract/**`

--- a/openspec/changes/resource-aquatic-operation-contract/proposal.md
+++ b/openspec/changes/resource-aquatic-operation-contract/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The resource stage architecture requires group planning ops that consume
+`artifact:resources.earthlikeExpectations` before resource distribution can
+claim per-resource coverage. The aquatic/coastal/navigable-river group is the
+first bounded group slice because it contains the clearest runtime-id hazard:
+marine and river-adjacent resources must stay symbolic until Civ7 runtime
+resource ids are verified.
+
+## Target Authority Refs
+
+- `openspec/changes/resource-stage-architecture`: resource stage operation
+  sequence, including `plan-resource-groups` and symbolic/runtime proof
+  boundaries.
+- `openspec/changes/resource-earthlike-expectations-artifact`: typed
+  `artifact:resources.earthlikeExpectations` source rows.
+- `openspec/changes/resource-earthlike-expectations`: aquatic group
+  expectations for fish, pearls, whales, crabs, cowrie, and turtles, including
+  crabs navigable-river proxy preservation.
+
+## What Changes
+
+- Add a `resources` domain op surface.
+- Add `resources/plan-aquatic-resources` as the first group-level resource
+  planning op.
+- Preserve every aquatic resource as a symbolic `RESOURCE_*` row with
+  expectation range, proof status, runtime-id status, proxy requirements, and
+  eligibility signal fields.
+- Report missing expectation rows and proxy gaps explicitly instead of dropping
+  resources.
+- Add focused tests proving all six aquatic resources are accounted for without
+  numeric resource ids.
+
+## Explicit Non-Goals
+
+- No placement behavior change.
+- No adapter materialization or `GameInfo.Resources` numeric id verification.
+- No resource stage recipe order change.
+- No hard count closure gate; this slice remains warning-only until runtime
+  telemetry calibrates expectations.
+- No implementation for the cultivated, terrestrial, or geological groups.
+
+## Verification Gates
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-aquatic-op-contract.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate resource-aquatic-operation-contract --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/resource-aquatic-operation-contract/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-aquatic-operation-contract/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Aquatic Resource Operation Preserves Per-Resource Coverage
+
+The resource distribution workstream SHALL expose a symbolic aquatic resource
+planning operation before aquatic resources claim distribution coverage.
+
+#### Scenario: All aquatic expectation rows are planned
+- **WHEN** the aquatic planning op receives the six aquatic earthlike
+  expectation rows
+- **THEN** it emits one planning row each for `RESOURCE_FISH`,
+  `RESOURCE_PEARLS`, `RESOURCE_WHALES`, `RESOURCE_CRABS`, `RESOURCE_COWRIE`,
+  and `RESOURCE_TURTLES`
+- **AND** every row preserves the `resourceType`, expected count range,
+  condition multipliers, proxy requirements, caveats, and
+  `runtimeIdStatus = "unverified"`
+- **AND** no output row contains runtime numeric id fields
+
+#### Scenario: Missing rows are visible
+- **WHEN** an aquatic expectation row is absent
+- **THEN** the operation emits a `missing-expectation` row for that resource
+- **AND** the resource appears in `missingResourceTypes`
+- **AND** the operation does not silently satisfy group coverage by omitting
+  the resource
+
+### Requirement: Aquatic Resource Operation Keeps Runtime Boundary
+
+The aquatic resource operation SHALL remain a symbolic planning contract and
+not a placement materializer.
+
+#### Scenario: No placement behavior changes
+- **WHEN** the aquatic operation is added
+- **THEN** the existing `placement/ops/plan-resources` behavior is unchanged
+- **AND** the new operation does not import adapter runtime modules or
+  `ResourceBuilder`
+- **AND** the operation does not emit `resourceId`, `numericId`,
+  `preferredResourceType`, or tile-level resource placement intents
+
+#### Scenario: Closure remains warning-only
+- **WHEN** the operation compares planned target counts to earthlike ranges
+- **THEN** its proof status remains `warning-only`
+- **AND** inferred earthlike ranges are not promoted to hard count gates
+  without runtime-calibrated telemetry
+
+### Requirement: Crabs Preserve Navigable-River Eligibility
+
+The aquatic resource operation SHALL preserve `RESOURCE_CRABS` river-adjacent
+eligibility rather than collapsing the group to coast-only logic.
+
+#### Scenario: Navigable-river proxy is retained
+- **WHEN** `RESOURCE_CRABS` is planned
+- **THEN** its row includes the navigable-river mouth or floodplain proxy
+  requirement from the expectation artifact
+- **AND** the operation can use a navigable-river-mouth signal field as an
+  eligibility source for crabs

--- a/openspec/changes/resource-aquatic-operation-contract/tasks.md
+++ b/openspec/changes/resource-aquatic-operation-contract/tasks.md
@@ -1,0 +1,33 @@
+## 1. Operation Contract
+
+- [x] 1.1 Add a resource-domain op surface.
+- [x] 1.2 Add `resources/plan-aquatic-resources`.
+- [x] 1.3 Preserve symbolic `RESOURCE_*` identity and unverified runtime-id
+  status.
+- [x] 1.4 Report missing expectation rows and proxy gaps explicitly.
+- [x] 1.5 Keep the output warning-only and non-materializing.
+
+## 2. Aquatic Resource Coverage
+
+- [x] 2.1 Account for `RESOURCE_FISH`.
+- [x] 2.2 Account for `RESOURCE_PEARLS`.
+- [x] 2.3 Account for `RESOURCE_WHALES`.
+- [x] 2.4 Account for `RESOURCE_CRABS`.
+- [x] 2.5 Account for `RESOURCE_COWRIE`.
+- [x] 2.6 Account for `RESOURCE_TURTLES`.
+- [x] 2.7 Preserve the crabs navigable-river proxy.
+
+## 3. Tests And Review
+
+- [x] 3.1 Run focused aquatic operation tests.
+- [x] 3.2 Run package check.
+- [x] 3.3 Run framed peer review and disposition accepted P1/P2 findings.
+
+## 4. Verification And Closure
+
+- [x] 4.1 Run OpenSpec validation.
+- [x] 4.2 Run `git diff --check`.
+- [x] 4.3 Commit the Graphite slice and leave the worktree clean locally.
+
+Note: external Graphite submission/PR delivery remains unclaimed until a
+future `gt submit`/PR state is recorded.

--- a/openspec/changes/resource-aquatic-operation-contract/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-aquatic-operation-contract/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,7 @@
+# Downstream Realignment Ledger
+
+| Affected assumption | Scope | Disposition |
+| --- | --- | --- |
+| Aquatic resources now have a symbolic group-planning op surface. | Future resource group ops and `plan-resource-groups` stage work | Patch-needed downstream: later slices should reuse the same symbolic/proxy/proof row shape instead of extending placement numeric candidates. |
+| Runtime ids remain unverified. | Placement materialization, stats closure, game log proof | No patch in this slice: later runtime proof must verify `GameInfo.Resources` ids before symbolic rows are materialized. |
+| Final resource runtime proof depends on downstack FireTuner socket restart integration. | Runtime-proof slices, game restart evidence, DRA handoff | Boundary recorded here from the downstream resource-runtime-proof boundary: verify `codex/firetuner-socket-studio-restart` at `bb39b3cf7` or successor, restack resource branches on top if it advances, and use the FireTuner socket/API restart path before claiming runtime proof. |

--- a/openspec/changes/resource-aquatic-operation-contract/workstream/firetuner-runtime-proof-boundary.md
+++ b/openspec/changes/resource-aquatic-operation-contract/workstream/firetuner-runtime-proof-boundary.md
@@ -1,0 +1,28 @@
+# FireTuner Runtime-Proof Boundary
+
+This resource operation slice acknowledges the DRA watcher instruction now
+carried by the downstream resource-runtime-proof boundary.
+
+The resource-distribution stack must not claim final runtime proof until it is
+integrated and restacked on top of the active FireTuner restart stack boundary.
+The current known restart boundary is:
+
+- Branch: `codex/firetuner-socket-studio-restart`
+- Commit: `bb39b3cf7 fix: submit Studio restarts through FireTuner socket`
+- Files:
+  - `apps/mapgen-studio/vite.config.ts`
+  - `packages/cli/src/utils/firetunerSocket.ts`
+  - `packages/cli/test/utils/firetunerSocket.test.ts`
+
+Before a future runtime-proof slice closes, it must:
+
+1. Verify whether `codex/firetuner-socket-studio-restart` has advanced beyond
+   `bb39b3cf7`.
+2. Integrate the current restart branch if needed and restack resource branches
+   on top.
+3. Use the FireTuner socket/API restart path for game restart evidence.
+4. Record the exact branch/commit boundary and restart command/path used for
+   runtime proof.
+
+This aquatic operation contract slice is local/spec proof only. It does not
+restart the game and does not claim runtime proof.

--- a/openspec/changes/resource-aquatic-operation-contract/workstream/phase-record.md
+++ b/openspec/changes/resource-aquatic-operation-contract/workstream/phase-record.md
@@ -1,0 +1,72 @@
+# Phase Record: Resource Aquatic Operation Contract
+
+## Objective
+
+Add the first resource-group operation contract for aquatic/coastal/navigable-
+river resources while preserving symbolic identity, proxy visibility, and the
+unverified runtime-id boundary.
+
+## Repo State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
+- Branch: `codex/resource-aquatic-operation-contract`
+- Parent slice: `codex/resource-earthlike-expectations-artifact`
+- Studio/API pair for this worktree: `http://127.0.0.1:5174/`
+
+## Agent Review
+
+- Curie: architecture placement review requested before code completion.
+  Outcome: superseded by Darwin's scoped post-implementation review because the
+  initial advisory agent did not return before closure.
+- Boole: aquatic contract design review requested before code completion.
+  Outcome: superseded by Darwin's scoped post-implementation review because the
+  initial advisory agent did not return before closure.
+- Darwin: post-implementation review found P1 configurable coverage omission.
+  Repair: removed configurable aquatic resource set and added regression test
+  rejecting omission through config.
+- Darwin: repair review. Outcome: P1 repair-cleared; no new P1/P2 findings.
+
+## FireTuner Runtime-Proof Boundary
+
+- Acknowledged watcher note: the downstream resource-runtime-proof boundary.
+- Current downstack restart branch evidence:
+  `codex/firetuner-socket-studio-restart` contains
+  `bb39b3cf7 fix: submit Studio restarts through FireTuner socket`.
+- Restart integration files at that boundary:
+  `apps/mapgen-studio/vite.config.ts`,
+  `packages/cli/src/utils/firetunerSocket.ts`, and
+  `packages/cli/test/utils/firetunerSocket.test.ts`.
+- This aquatic contract slice does not claim runtime proof and does not restart
+  the game.
+- Before any final resource runtime-proof slice claims completion, verify
+  whether the downstack restart branch has advanced, integrate/restack the
+  resource stack on top of it, use the FireTuner socket/API restart path, and
+  record the exact branch/commit and restart command/path used.
+- The downstream resource-runtime-proof boundary remains in place until the final restacked/runtime-proof
+  boundary is recorded.
+
+## Verification So Far
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-aquatic-op-contract.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+  - Passed after P1 repair: 12 tests, 640 assertions.
+- `bun run --cwd mods/mod-swooper-maps check`
+  - Passed after P1 repair.
+- `bun run openspec -- validate resource-aquatic-operation-contract --strict`
+  - Passed after P1 repair.
+- `bun run openspec:validate`
+  - Passed after P1 repair: 23 items.
+- `git diff --check`
+  - Passed after P1 repair.
+
+## Closure State
+
+- Locally committed clean at
+  `ad23eb663b53c4134e962d00781685b1998c4484` on
+  `codex/resource-aquatic-operation-contract`.
+- External Graphite submission/PR delivery is not claimed by this local closure
+  record.
+- This closure-state repair is recorded in follow-up slice
+  `codex/resource-cultivated-operation-contract` because the aquatic commit had
+  already been created and the workstream had moved onto the cultivated branch
+  when the watcher found the stale OpenSpec task/phase state.

--- a/openspec/changes/resource-aquatic-operation-contract/workstream/review-disposition-ledger.md
+++ b/openspec/changes/resource-aquatic-operation-contract/workstream/review-disposition-ledger.md
@@ -1,0 +1,6 @@
+# Review Disposition Ledger
+
+| Finding | Severity | Disposition | Notes |
+| --- | --- | --- | --- |
+| Configurable coverage can hide missing aquatic resources | P1 | accepted, repaired, repair-cleared | Removed `requiredResourceTypes` from strategy config and made the canonical six-resource set strategy-owned. Added regression test rejecting config omission. Darwin repair review cleared the finding with no new P1/P2 issues. |
+| Initial advisory agents did not return before closure | P2 | superseded | Curie and Boole were closed after a scoped Darwin post-implementation review plus repair review supplied the blocking review loop needed for this slice. |

--- a/openspec/changes/resource-cultivated-operation-contract/.openspec.yaml
+++ b/openspec/changes/resource-cultivated-operation-contract/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-cultivated-operation-contract/design.md
+++ b/openspec/changes/resource-cultivated-operation-contract/design.md
@@ -1,0 +1,111 @@
+# Resource Cultivated Operation Contract Design
+
+## Decision
+
+Add a resource-domain operation:
+
+```text
+resources/plan-cultivated-resources
+```
+
+The op is group-level because cultivated, plantation, and medicinal resources
+share agricultural, coastal, wetland, highland, tropical, arid-water, and
+temperate-plains proxy families. The output remains per-resource, with one row
+for every group resource.
+
+The 18-resource set is strategy-owned, not caller-configurable. Callers may not
+shrink group coverage through op config.
+
+## Resource Set
+
+- `RESOURCE_COTTON`
+- `RESOURCE_DATES`
+- `RESOURCE_DYES`
+- `RESOURCE_INCENSE`
+- `RESOURCE_SILK`
+- `RESOURCE_WINE`
+- `RESOURCE_COCOA`
+- `RESOURCE_SPICES`
+- `RESOURCE_SUGAR`
+- `RESOURCE_TEA`
+- `RESOURCE_COFFEE`
+- `RESOURCE_TOBACCO`
+- `RESOURCE_CITRUS`
+- `RESOURCE_QUININE`
+- `RESOURCE_MANGOS`
+- `RESOURCE_RICE`
+- `RESOURCE_CLOVES`
+- `RESOURCE_FLAX`
+
+## Input Boundary
+
+The op consumes symbolic expectation rows from
+`artifact:resources.earthlikeExpectations`. It may also receive resource-owned
+eligibility masks for agricultural proxy families:
+
+- warm alluvial/floodplain/river;
+- warm grass/plains;
+- oasis or desert water;
+- arid dry woodland;
+- coastal/marine;
+- humid tropical forest and wet tropics;
+- highland or relief;
+- temperate dry plains;
+- savanna/forest;
+- tropical fruit belt;
+- wetland/paddy;
+- cool temperate plains.
+
+Suppression masks are advisory local signals only. They do not imply runtime
+placement or numeric resource ids.
+
+## Output Boundary
+
+Each row carries the same symbolic planning contract shape as the aquatic op:
+
+- `resourceType`;
+- `laneId`;
+- status (`planned`, `proxy-gap`, `missing-expectation`, or `blocked`);
+- `expectedCountRange`;
+- `targetIntentCount` and `eligibleTileCount`;
+- `rangeStatus`;
+- `proofStatus = "warning-only"`;
+- `runtimeIdStatus = "unverified"`;
+- signal fields, proxy requirements, blockers, and caveats.
+
+The op emits no runtime numeric id fields, adapter materialization, or tile-level
+resource placement intents.
+
+## Lane Map
+
+- `alluvial-irrigated`: `RESOURCE_COTTON`, `RESOURCE_SILK`,
+  `RESOURCE_SUGAR`
+- `arid-oasis-resin`: `RESOURCE_DATES`, `RESOURCE_INCENSE`
+- `marine-dye`: `RESOURCE_DYES`
+- `temperate-field-orchard`: `RESOURCE_WINE`, `RESOURCE_TOBACCO`,
+  `RESOURCE_CITRUS`, `RESOURCE_FLAX`
+- `humid-tropical-plantation`: `RESOURCE_COCOA`, `RESOURCE_SPICES`,
+  `RESOURCE_MANGOS`
+- `highland-medicinal`: `RESOURCE_TEA`, `RESOURCE_COFFEE`,
+  `RESOURCE_QUININE`
+- `wetland-paddy`: `RESOURCE_RICE`
+- `blocked-no-valid-biome`: `RESOURCE_CLOVES`
+
+## Edge Proxies
+
+- `RESOURCE_DYES` remains in this group but preserves its coastal/marine proxy.
+- `RESOURCE_TEA`, `RESOURCE_COFFEE`, and `RESOURCE_QUININE` preserve highland or
+  relief proxy needs.
+- `RESOURCE_DATES` uses an oasis or desert-water proxy.
+- `RESOURCE_RICE` uses wetland/paddy and floodplain/river proxies.
+- `RESOURCE_CLOVES` is blocked, visible, and active-zero.
+
+## Write Set
+
+- `mods/mod-swooper-maps/src/domain/resources/ops/contracts.ts`
+- `mods/mod-swooper-maps/src/domain/resources/ops/index.ts`
+- `mods/mod-swooper-maps/src/domain/resources/ops/plan-cultivated-resources/**`
+- `mods/mod-swooper-maps/test/resources/resource-cultivated-op-contract.test.ts`
+- `openspec/changes/resource-aquatic-operation-contract/tasks.md`
+- `openspec/changes/resource-aquatic-operation-contract/workstream/phase-record.md`
+- `openspec/changes/resource-cultivated-operation-contract/**`

--- a/openspec/changes/resource-cultivated-operation-contract/proposal.md
+++ b/openspec/changes/resource-cultivated-operation-contract/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+The resource distribution workstream now has a symbolic aquatic group planning
+op. The next resource group with shared input families is
+cultivated/plantation/medicinal. This slice gives those resources a
+per-resource operation contract without moving placement behavior or claiming
+runtime numeric ids.
+
+## Target Authority Refs
+
+- `openspec/changes/resource-stage-architecture`: resource stage operation
+  sequence and `plan-resource-groups` contract boundary.
+- `openspec/changes/resource-earthlike-expectations-artifact`: typed
+  `artifact:resources.earthlikeExpectations` source rows.
+- `openspec/changes/resource-aquatic-operation-contract`: reviewed precedent
+  for symbolic group planning rows, strategy-owned resource sets, and
+  warning-only runtime-id boundaries.
+
+## What Changes
+
+- Add `resources/plan-cultivated-resources`.
+- Account for all 18 cultivated/plantation/medicinal resources separately.
+- Preserve blocked `RESOURCE_CLOVES` as visible active-zero.
+- Preserve edge proxies such as `RESOURCE_DYES` coastal/marine lane,
+  highland/relief for tea/coffee/quinine, oasis dates, and wetland rice.
+- Repair stale aquatic closure metadata in this follow-up slice because the
+  aquatic branch had already been committed before the watcher found it.
+
+## Explicit Non-Goals
+
+- No placement behavior change.
+- No adapter materialization or runtime numeric id verification.
+- No hard closure gates or game restart proof.
+- No implementation for terrestrial animal/forest/wild or geological groups.
+- No external Graphite submission/PR delivery claim.
+
+## Verification Gates
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-cultivated-op-contract.test.ts test/resources/resource-aquatic-op-contract.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate resource-cultivated-operation-contract --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/resource-cultivated-operation-contract/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-cultivated-operation-contract/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Cultivated Resource Operation Preserves Per-Resource Coverage
+
+The resource distribution workstream SHALL expose a symbolic cultivated resource
+planning operation before cultivated resources claim distribution coverage.
+
+#### Scenario: All cultivated expectation rows are planned
+- **WHEN** the cultivated planning op receives the cultivated earthlike
+  expectation rows
+- **THEN** it emits one planning row each for the 18
+  `cultivated-plantation-medicinal` resources
+- **AND** every row preserves the `resourceType`, expected count range,
+  lane id, condition multipliers, proxy requirements, caveats, and
+  `runtimeIdStatus = "unverified"`
+- **AND** no output row contains runtime numeric id fields
+
+#### Scenario: Missing rows are visible
+- **WHEN** a cultivated expectation row is absent
+- **THEN** the operation emits a `missing-expectation` row for that resource
+- **AND** the resource appears in `missingResourceTypes`
+- **AND** the operation does not silently satisfy group coverage by omitting
+  the resource
+
+### Requirement: Cultivated Resource Operation Keeps Blocked Rows Visible
+
+The cultivated resource operation SHALL keep blocked cultivated rows visible
+instead of dropping them from group coverage.
+
+#### Scenario: Cloves remain active-zero
+- **WHEN** `RESOURCE_CLOVES` is planned
+- **THEN** its row has status `blocked`
+- **AND** its target intent count and eligible tile count are zero
+- **AND** its expected count range remains `0/0/0`
+- **AND** it is not reported as missing
+
+### Requirement: Cultivated Resource Operation Keeps Runtime Boundary
+
+The cultivated resource operation SHALL remain a symbolic planning contract and
+not a placement materializer.
+
+#### Scenario: No placement behavior changes
+- **WHEN** the cultivated operation is added
+- **THEN** existing placement resource planning behavior is unchanged
+- **AND** the operation does not import adapter runtime modules or
+  `ResourceBuilder`
+- **AND** the operation does not emit `resourceId`, `numericId`,
+  `preferredResourceType`, or tile-level resource placement intents
+
+#### Scenario: Closure remains warning-only
+- **WHEN** the operation compares planned target counts to earthlike ranges
+- **THEN** its proof status remains `warning-only`
+- **AND** inferred earthlike ranges are not promoted to hard count gates
+  without runtime-calibrated telemetry
+
+### Requirement: Cultivated Resource Operation Preserves Edge Proxies
+
+The cultivated resource operation SHALL preserve the group's non-generic proxy
+families as visible signal fields.
+
+#### Scenario: Coastal and highland proxies survive planning
+- **WHEN** `RESOURCE_DYES` is planned
+- **THEN** its row can use a coastal or marine signal field
+- **AND** the marine/coast proxy requirement remains visible
+- **WHEN** `RESOURCE_TEA`, `RESOURCE_COFFEE`, or `RESOURCE_QUININE` is planned
+- **THEN** its row can use a highland or relief signal field
+
+#### Scenario: Oasis and wetland proxies survive planning
+- **WHEN** `RESOURCE_DATES` is planned
+- **THEN** its row can use an oasis or desert-water signal field
+- **WHEN** `RESOURCE_RICE` is planned
+- **THEN** its row can use a wetland, paddy, river, or floodplain signal field

--- a/openspec/changes/resource-cultivated-operation-contract/tasks.md
+++ b/openspec/changes/resource-cultivated-operation-contract/tasks.md
@@ -1,0 +1,44 @@
+## 1. Operation Contract
+
+- [x] 1.1 Add `resources/plan-cultivated-resources`.
+- [x] 1.2 Preserve symbolic `RESOURCE_*` identity and unverified runtime-id
+  status.
+- [x] 1.3 Make the 18-resource cultivated set strategy-owned.
+- [x] 1.4 Report missing expectation rows and proxy gaps explicitly.
+- [x] 1.5 Keep blocked `RESOURCE_CLOVES` visible and active-zero.
+
+## 2. Cultivated Resource Coverage
+
+- [x] 2.1 Account for `RESOURCE_COTTON`.
+- [x] 2.2 Account for `RESOURCE_DATES`.
+- [x] 2.3 Account for `RESOURCE_DYES`.
+- [x] 2.4 Account for `RESOURCE_INCENSE`.
+- [x] 2.5 Account for `RESOURCE_SILK`.
+- [x] 2.6 Account for `RESOURCE_WINE`.
+- [x] 2.7 Account for `RESOURCE_COCOA`.
+- [x] 2.8 Account for `RESOURCE_SPICES`.
+- [x] 2.9 Account for `RESOURCE_SUGAR`.
+- [x] 2.10 Account for `RESOURCE_TEA`.
+- [x] 2.11 Account for `RESOURCE_COFFEE`.
+- [x] 2.12 Account for `RESOURCE_TOBACCO`.
+- [x] 2.13 Account for `RESOURCE_CITRUS`.
+- [x] 2.14 Account for `RESOURCE_QUININE`.
+- [x] 2.15 Account for `RESOURCE_MANGOS`.
+- [x] 2.16 Account for `RESOURCE_RICE`.
+- [x] 2.17 Account for `RESOURCE_CLOVES`.
+- [x] 2.18 Account for `RESOURCE_FLAX`.
+
+## 3. Tests And Review
+
+- [x] 3.1 Run focused cultivated operation tests.
+- [x] 3.2 Run package check.
+- [x] 3.3 Run framed peer review and disposition accepted P1/P2 findings.
+
+## 4. Verification And Closure
+
+- [x] 4.1 Run OpenSpec validation.
+- [x] 4.2 Run `git diff --check`.
+- [x] 4.3 Commit the Graphite slice and leave the worktree clean locally.
+
+Note: external Graphite submission/PR delivery remains unclaimed until a
+future `gt submit`/PR state is recorded.

--- a/openspec/changes/resource-cultivated-operation-contract/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-cultivated-operation-contract/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,7 @@
+# Downstream Realignment Ledger
+
+| Affected assumption | Scope | Disposition |
+| --- | --- | --- |
+| Cultivated resources now have a symbolic group-planning op surface. | Future resource group ops and `plan-resource-groups` stage work | Patch-needed downstream: later slices should keep per-resource rows, strategy-owned group coverage, and explicit proxy gaps. |
+| Aquatic closure metadata is repaired in this follow-up slice. | Closure audits for `resource-aquatic-operation-contract` | Patched here because the aquatic branch was already locally committed clean at `ad23eb663` before the watcher found stale records. |
+| Runtime ids remain unverified. | Placement materialization, stats closure, game log proof | No patch in this slice: later runtime proof must verify `GameInfo.Resources` ids before symbolic rows are materialized. |

--- a/openspec/changes/resource-cultivated-operation-contract/workstream/phase-record.md
+++ b/openspec/changes/resource-cultivated-operation-contract/workstream/phase-record.md
@@ -1,0 +1,79 @@
+# Phase Record: Resource Cultivated Operation Contract
+
+## Objective
+
+Add the second resource-group operation contract for
+cultivated/plantation/medicinal resources while preserving per-resource
+coverage, blocked-row visibility, proxy visibility, and the unverified
+runtime-id boundary.
+
+## Repo State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
+- Branch: `codex/resource-cultivated-operation-contract`
+- Parent slice: `codex/resource-aquatic-operation-contract`
+- Parent aquatic local commit:
+  `ad23eb663b53c4134e962d00781685b1998c4484`
+- Studio/API pair for this worktree: `http://127.0.0.1:5174/`
+
+## Follow-Up Repair
+
+- Watcher found stale aquatic closure metadata after the aquatic branch had
+  already been committed cleanly and this cultivated branch had been opened.
+- This slice repairs the aquatic task/phase record as a follow-up instead of
+  rewriting the already-clean downstack branch while cultivated work is active.
+- Local commit closure is distinct from external Graphite submission/PR
+  delivery, which remains unclaimed until submitted.
+
+## Agent Review
+
+- Hypatia: repo-local cultivated resource/proxy inventory. Outcome: confirmed
+  18-resource group, single blocked row `RESOURCE_CLOVES`, and key proxy tests
+  for coastal dyes, highland tea/coffee/quinine, oasis dates, and wetland rice.
+- Beauvoir: contract architecture review requested; pending.
+  Findings accepted:
+  - P1 tests/OpenSpec must exist before closure. Repaired in this slice with
+    focused test file and OpenSpec change.
+  - P1 single cultivated op is acceptable only as symbolic group planning, not
+    one ecology. Repaired through warning-only contract language and
+    per-resource rows.
+  - P2 lane/subgroup should be explicit. Repaired with row-level `laneId` and
+    design lane map.
+- Newton: final scoped P1/P2 review. Outcome: no P1/P2 findings. Residual
+  risk noted that `RESOURCE_CLOVES` blocked behavior depends on the trusted
+  expectation row status, acceptable for this slice boundary.
+
+## FireTuner Runtime-Proof Boundary
+
+- The downstream resource-runtime-proof boundary remains in place.
+- This contract slice does not claim runtime proof and does not restart the
+  game.
+- Final runtime proof still must integrate/restack on top of
+  `codex/firetuner-socket-studio-restart` at `bb39b3cf7` or successor and use
+  the FireTuner socket/API restart path.
+
+## Verification So Far
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-cultivated-op-contract.test.ts test/resources/resource-aquatic-op-contract.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+  - Passed: 19 tests, 727 assertions.
+- `bun run --cwd mods/mod-swooper-maps check`
+  - Passed.
+- `bun run openspec -- validate resource-cultivated-operation-contract --strict`
+  - Passed.
+- `bun run openspec:validate`
+  - Passed: 24 items.
+- `git diff --check`
+  - Passed.
+
+## Closure State
+
+- Locally committed clean at
+  `3494d91ded3ca38471ad560daca184546994e7d6` on
+  `codex/resource-cultivated-operation-contract`.
+- External Graphite submission/PR delivery is not claimed by this local closure
+  record.
+- This closure-state repair is recorded in follow-up slice
+  `codex/resource-terrestrial-operation-contract` because the cultivated commit
+  had already been created and the workstream had moved onto the terrestrial
+  branch when the watcher found the stale OpenSpec task/phase state.

--- a/openspec/changes/resource-cultivated-operation-contract/workstream/review-disposition-ledger.md
+++ b/openspec/changes/resource-cultivated-operation-contract/workstream/review-disposition-ledger.md
@@ -1,0 +1,8 @@
+# Review Disposition Ledger
+
+| Finding | Severity | Disposition | Notes |
+| --- | --- | --- | --- |
+| Cultivated slice needs blocking tests and OpenSpec before closure | P1 | accepted, repaired | Added focused cultivated tests and `resource-cultivated-operation-contract` OpenSpec change. |
+| Single cultivated op must stay symbolic group planning, not one ecology | P1 | accepted, repaired | Contract is warning-only, symbolic, per-resource, and non-materializing; design names the boundary. |
+| Add explicit row-level lane/subgroup visibility | P2 | accepted, repaired | Added `laneId` to cultivated plan rows and documented the lane map. |
+| Final scoped review | P2 | cleared | Newton found no P1/P2 findings after repairs. |

--- a/openspec/changes/resource-geological-operation-contract/.openspec.yaml
+++ b/openspec/changes/resource-geological-operation-contract/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-geological-operation-contract/design.md
+++ b/openspec/changes/resource-geological-operation-contract/design.md
@@ -1,0 +1,131 @@
+# Resource Geological Operation Contract Design
+
+## Decision
+
+Add a resource-domain operation:
+
+```text
+resources/plan-geological-resources
+```
+
+The op is group-level because the current expectation artifact groups these
+resources under `geological-mineral-gemstone-industrial`. The output remains
+per-resource, with one row for every group resource.
+
+The 20-resource set is strategy-owned, not caller-configurable. Callers may not
+shrink group coverage through op config.
+
+## Resource Set
+
+- `RESOURCE_GOLD`
+- `RESOURCE_GOLD_DISTANT_LANDS`
+- `RESOURCE_SILVER`
+- `RESOURCE_SILVER_DISTANT_LANDS`
+- `RESOURCE_GYPSUM`
+- `RESOURCE_JADE`
+- `RESOURCE_KAOLIN`
+- `RESOURCE_MARBLE`
+- `RESOURCE_IRON`
+- `RESOURCE_SALT`
+- `RESOURCE_LAPIS_LAZULI`
+- `RESOURCE_NITER`
+- `RESOURCE_COAL`
+- `RESOURCE_NICKEL`
+- `RESOURCE_OIL`
+- `RESOURCE_CLAY`
+- `RESOURCE_LIMESTONE`
+- `RESOURCE_TIN`
+- `RESOURCE_PITCH`
+- `RESOURCE_RUBIES`
+
+## Lane Map
+
+- `orogenic-hydrothermal`: `RESOURCE_GOLD`, `RESOURCE_SILVER`
+- `blocked-derivative`: `RESOURCE_GOLD_DISTANT_LANDS`,
+  `RESOURCE_SILVER_DISTANT_LANDS`
+- `evaporite-sedimentary`: `RESOURCE_GYPSUM`
+- `ultramafic-metamorphic`: `RESOURCE_JADE`
+- `weathering-clay`: `RESOURCE_KAOLIN`
+- `carbonate-metamorphic`: `RESOURCE_MARBLE`
+- `craton-orogen`: `RESOURCE_IRON`
+- `closed-basin-salt`: `RESOURCE_SALT`
+- `blocked-no-valid-biome`: `RESOURCE_LAPIS_LAZULI`, `RESOURCE_NICKEL`
+- `arid-nitrate`: `RESOURCE_NITER`
+- `sedimentary-fuel`: `RESOURCE_COAL`, `RESOURCE_OIL`
+- `wet-alluvial-clay`: `RESOURCE_CLAY`
+- `carbonate-industrial`: `RESOURCE_LIMESTONE`
+- `granite-orogen-placer`: `RESOURCE_TIN`
+- `hydrocarbon-seep`: `RESOURCE_PITCH`
+- `ruby-metamorphic`: `RESOURCE_RUBIES`
+
+## Input Boundary
+
+The op consumes symbolic expectation rows from
+`artifact:resources.earthlikeExpectations`. It may also receive resource-owned
+eligibility masks for geological proxy families:
+
+- orogenic or hydrothermal belts;
+- alluvial placer drainage;
+- tundra/desert mineralized hill exposure;
+- evaporite and closed basins;
+- sedimentary and hydrocarbon basins;
+- ultramafic, metamorphic, collision, and carbonate belts;
+- craton, granite, weathering clay, wet alluvial, and arid nitrate soils;
+- oil adjacency for pitch.
+
+Suppression masks are advisory local signals only. They do not imply runtime
+placement or numeric resource ids.
+
+## Output Boundary
+
+Each row carries:
+
+- `resourceType`;
+- `laneId`;
+- status (`planned`, `proxy-gap`, `missing-expectation`, or `blocked`);
+- `expectedCountRange`;
+- `targetIntentCount` and `eligibleTileCount`;
+- `rangeStatus`;
+- `proofStatus = "warning-only"`;
+- `runtimeIdStatus = "unverified"`;
+- signal fields, proxy requirements, blockers, and caveats.
+
+The op emits no runtime numeric id fields, adapter materialization, or tile-level
+resource placement intents.
+
+## Edge Proxies
+
+- `RESOURCE_GOLD` and `RESOURCE_SILVER` preserve orogenic/hydrothermal source
+  lanes instead of using generic hills.
+- `RESOURCE_JADE`, `RESOURCE_MARBLE`, `RESOURCE_IRON`, `RESOURCE_NITER`, and
+  `RESOURCE_LIMESTONE` do not let companion terrain signals satisfy source
+  requirements on their own.
+- `RESOURCE_COAL` uses sedimentary or peat-forming basin signals, not generic
+  forest or wetland signals.
+- `RESOURCE_OIL` and `RESOURCE_PITCH` preserve hydrocarbon basin or seep
+  signals; offshore remains suppressed until explicitly authorized.
+- `RESOURCE_LIMESTONE` and `RESOURCE_MARBLE` preserve carbonate source lanes.
+- `RESOURCE_TIN` preserves granite, orogeny, or placer source lanes.
+- `RESOURCE_RUBIES` preserves metamorphic or collision-belt source lanes and
+  does not broaden to generic tropical flats or broad carbonate/limestone
+  signals.
+
+## FireTuner Runtime-Proof Boundary
+
+The downstream resource-runtime-proof boundary remains the control record for final runtime proof. This contract
+slice does not claim runtime proof and does not restart the game.
+
+## Follow-Up Repair Boundary
+
+This slice repairs stale terrestrial closure metadata in a follow-up branch
+because `codex/resource-terrestrial-operation-contract` was already locally
+committed clean at `292629dce` before this geological branch was opened.
+
+## Write Set
+
+- `mods/mod-swooper-maps/src/domain/resources/ops/contracts.ts`
+- `mods/mod-swooper-maps/src/domain/resources/ops/index.ts`
+- `mods/mod-swooper-maps/src/domain/resources/ops/plan-geological-resources/**`
+- `mods/mod-swooper-maps/test/resources/resource-geological-op-contract.test.ts`
+- `openspec/changes/resource-terrestrial-operation-contract/**`
+- `openspec/changes/resource-geological-operation-contract/**`

--- a/openspec/changes/resource-geological-operation-contract/proposal.md
+++ b/openspec/changes/resource-geological-operation-contract/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+Aquatic, cultivated, and terrestrial resources now have symbolic group planning
+operations. The geological/mineral/gemstone/industrial group is the next
+high-impact set because it contains the currently visible ruby path plus many
+resources that are easy to over-broaden if they are treated as generic hills,
+forest, wetland, or desert resources.
+
+This slice gives every geological resource its own warning-only symbolic row
+without changing placement behavior.
+
+## Target Authority Refs
+
+- `openspec/changes/resource-stage-architecture`: resource stage operation
+  sequence and `plan-resource-groups` boundary.
+- `openspec/changes/resource-earthlike-expectations-artifact`: typed
+  `artifact:resources.earthlikeExpectations` source rows.
+- `openspec/changes/resource-aquatic-operation-contract`,
+  `openspec/changes/resource-cultivated-operation-contract`, and
+  `openspec/changes/resource-terrestrial-operation-contract`: reviewed
+  symbolic group-planning precedent.
+
+## What Changes
+
+- Add `resources/plan-geological-resources`.
+- Account for all 20 geological/mineral/gemstone/industrial resources
+  separately.
+- Preserve blocked active-zero rows for distant-lands gold, distant-lands
+  silver, lapis lazuli, and nickel.
+- Preserve strict geological proxy lanes for hydrothermal/orogenic resources,
+  evaporites, carbonates, cratons, sedimentary fuels, granite/placer tin,
+  hydrocarbon seeps, and metamorphic ruby sources.
+- Keep runtime ids unverified and output proof warning-only.
+
+## Explicit Non-Goals
+
+- No placement behavior change.
+- No adapter materialization or runtime numeric id verification.
+- No hard closure gates or game restart proof.
+- No implementation for downstream resource group rollups, scoring, or final
+  stats/runtime proof.
+- No external Graphite submission/PR delivery claim.
+
+## Verification Gates
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-geological-op-contract.test.ts test/resources/resource-terrestrial-op-contract.test.ts test/resources/resource-cultivated-op-contract.test.ts test/resources/resource-aquatic-op-contract.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate resource-geological-operation-contract --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/resource-geological-operation-contract/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-geological-operation-contract/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Geological Resource Operation Preserves Per-Resource Coverage
+
+The resource distribution workstream SHALL expose a symbolic geological resource
+planning operation before geological resources claim distribution coverage.
+
+#### Scenario: All geological expectation rows are planned
+- **WHEN** the geological planning op receives the geological earthlike
+  expectation rows
+- **THEN** it emits one planning row each for the 20
+  `geological-mineral-gemstone-industrial` resources
+- **AND** every row preserves the `resourceType`, lane id, expected count
+  range, condition multipliers, proxy requirements, caveats, and
+  `runtimeIdStatus = "unverified"`
+- **AND** no output row contains runtime numeric id fields
+
+#### Scenario: Missing rows are visible
+- **WHEN** a geological expectation row is absent
+- **THEN** the operation emits a `missing-expectation` row for that resource
+- **AND** the resource appears in `missingResourceTypes`
+- **AND** the operation does not silently satisfy group coverage by omitting
+  the resource
+
+### Requirement: Geological Resource Operation Keeps Runtime Boundary
+
+The geological resource operation SHALL remain a symbolic planning contract and
+not a placement materializer.
+
+#### Scenario: No placement behavior changes
+- **WHEN** the geological operation is added
+- **THEN** existing placement resource planning behavior is unchanged
+- **AND** the operation does not import adapter runtime modules or
+  `ResourceBuilder`
+- **AND** the operation does not emit `resourceId`, `numericId`,
+  `preferredResourceType`, or tile-level resource placement intents
+
+#### Scenario: Closure remains warning-only
+- **WHEN** the operation compares planned target counts to earthlike ranges
+- **THEN** its proof status remains `warning-only`
+- **AND** inferred earthlike ranges are not promoted to hard count gates
+  without runtime-calibrated telemetry
+
+### Requirement: Geological Resource Operation Preserves Strict Proxies
+
+The geological resource operation SHALL preserve non-generic geological proxy
+families as visible signal fields.
+
+#### Scenario: Blocked geological rows stay active-zero
+- **WHEN** distant-lands gold, distant-lands silver, lapis lazuli, or nickel is
+  planned
+- **THEN** each row stays visible with `status = "blocked"`
+- **AND** each blocked row reports `targetIntentCount = 0`,
+  `eligibleTileCount = 0`, and a zero expected range
+
+#### Scenario: Geological source proxies survive planning
+- **WHEN** gold, salt, oil, pitch, limestone, tin, or rubies are planned
+- **THEN** their rows expose the corresponding geological source signal fields
+  and proxy requirements
+
+#### Scenario: Proxy broadening is blocked for narrow rows
+- **WHEN** silver is planned
+- **THEN** generic hills do not satisfy its source lane without
+  tundra/desert-hill exposure or orogenic context
+- **WHEN** coal is planned
+- **THEN** generic forest or wetland masks do not satisfy its source lane
+  without sedimentary or peat-forming basin context
+- **WHEN** rubies are planned
+- **THEN** generic tropical terrain does not satisfy its source lane without a
+  metamorphic, carbonate/marble-hosted, or collision-belt source proxy
+- **AND** broad carbonate/limestone signals do not satisfy ruby eligibility
+  without a metamorphic or collision-belt source proxy

--- a/openspec/changes/resource-geological-operation-contract/tasks.md
+++ b/openspec/changes/resource-geological-operation-contract/tasks.md
@@ -1,0 +1,44 @@
+## 1. Operation Contract
+
+- [x] 1.1 Add `resources/plan-geological-resources`.
+- [x] 1.2 Preserve symbolic `RESOURCE_*` identity and unverified runtime-id
+  status.
+- [x] 1.3 Make the 20-resource geological set strategy-owned.
+- [x] 1.4 Report missing expectation rows and proxy gaps explicitly.
+- [x] 1.5 Keep the output warning-only and non-materializing.
+
+## 2. Geological Resource Coverage
+
+- [x] 2.1 Account for `RESOURCE_GOLD`.
+- [x] 2.2 Account for `RESOURCE_GOLD_DISTANT_LANDS`.
+- [x] 2.3 Account for `RESOURCE_SILVER`.
+- [x] 2.4 Account for `RESOURCE_SILVER_DISTANT_LANDS`.
+- [x] 2.5 Account for `RESOURCE_GYPSUM`.
+- [x] 2.6 Account for `RESOURCE_JADE`.
+- [x] 2.7 Account for `RESOURCE_KAOLIN`.
+- [x] 2.8 Account for `RESOURCE_MARBLE`.
+- [x] 2.9 Account for `RESOURCE_IRON`.
+- [x] 2.10 Account for `RESOURCE_SALT`.
+- [x] 2.11 Account for `RESOURCE_LAPIS_LAZULI`.
+- [x] 2.12 Account for `RESOURCE_NITER`.
+- [x] 2.13 Account for `RESOURCE_COAL`.
+- [x] 2.14 Account for `RESOURCE_NICKEL`.
+- [x] 2.15 Account for `RESOURCE_OIL`.
+- [x] 2.16 Account for `RESOURCE_CLAY`.
+- [x] 2.17 Account for `RESOURCE_LIMESTONE`.
+- [x] 2.18 Account for `RESOURCE_TIN`.
+- [x] 2.19 Account for `RESOURCE_PITCH`.
+- [x] 2.20 Account for `RESOURCE_RUBIES`.
+
+## 3. Tests And Review
+
+- [x] 3.1 Run focused geological operation tests.
+- [x] 3.2 Run package check.
+- [x] 3.3 Run framed peer review and disposition accepted P1/P2 findings.
+
+## 4. Verification And Closure
+
+- [x] 4.1 Run OpenSpec validation.
+- [x] 4.2 Run `git diff --check`.
+- [x] 4.3 Commit the Graphite slice locally and leave the worktree clean, while
+  keeping external Graphite submission/PR delivery unclaimed.

--- a/openspec/changes/resource-geological-operation-contract/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-geological-operation-contract/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,8 @@
+# Downstream Realignment Ledger
+
+| Affected assumption | Scope | Disposition |
+| --- | --- | --- |
+| Geological resources now have a symbolic group-planning op surface. | Future resource group rollup, score, and placement slices | Patch-needed downstream: later slices should preserve per-resource rows, strategy-owned group coverage, row lanes, strict proxy gaps, and blocked active-zero rows. |
+| Terrestrial closure metadata is repaired in this follow-up slice. | Closure audits for `resource-terrestrial-operation-contract` | Patched here because the terrestrial branch was already locally committed clean at `292629dce` before this geological branch was opened. |
+| Runtime ids remain unverified. | Placement materialization, stats closure, game log proof | No patch in this slice: later runtime proof must verify `GameInfo.Resources` ids before symbolic rows are materialized. |
+| FireTuner restart path remains a final-proof dependency. | Runtime-proof slices, game restart evidence, DRA handoff | Boundary already acknowledged in the downstream resource-runtime-proof boundary; final runtime proof must keep using that socket/API restart path. |

--- a/openspec/changes/resource-geological-operation-contract/workstream/phase-record.md
+++ b/openspec/changes/resource-geological-operation-contract/workstream/phase-record.md
@@ -1,0 +1,77 @@
+# Phase Record: Resource Geological Operation Contract
+
+## Objective
+
+Add the fourth resource-group operation contract for
+geological/mineral/gemstone/industrial resources while preserving per-resource
+coverage, strict geological proxy visibility, warning-only proof, and the
+unverified runtime-id boundary.
+
+## Repo State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
+- Branch: `codex/resource-geological-operation-contract`
+- Parent slice: `codex/resource-terrestrial-operation-contract`
+- Studio/API pair for this worktree: `http://127.0.0.1:5174/`
+
+## Agent Review
+
+- Heisenberg: geological resource/proxy review. Findings accepted:
+  - Keep this as one symbolic group op; no repo-local falsifier requiring a
+    split now.
+  - Preserve the exact 20-resource group and the four blocked active-zero rows.
+  - Guard against proxy broadening for silver, coal, oil, limestone, tin, and
+    rubies.
+  Repairs: tests cover strict source-family signal fields, no generic
+  forest/wetland or tropical broadening, active-zero blocked rows, missing
+  rows, config selector rejection, proxy gaps, and suppression behavior.
+- Heisenberg: final diff review. Findings accepted:
+  - Tighten companion masks that were acting as standalone geological source
+    eligibility.
+  - Disposition the watcher note so the terrestrial repair is not recorded as
+    unresolved after this slice.
+  Repairs: standalone alluvial jade, orogenic marble, hill-only
+  iron/limestone, wet-alluvial niter, and broad carbonate ruby eligibility were
+  removed; the note records the current-slice repair disposition.
+
+## Follow-Up Repair
+
+- The watcher found stale terrestrial closure metadata after the terrestrial
+  branch had already been committed cleanly and this geological branch had been
+  opened.
+- This slice repairs the terrestrial task/phase record as a follow-up instead
+  of rewriting the already-clean downstack branch while geological work is
+  active.
+- Local commit closure is distinct from external Graphite submission/PR
+  delivery, which remains unclaimed until submitted.
+
+## FireTuner Runtime-Proof Boundary
+
+- The downstream resource-runtime-proof boundary remains in place.
+- This contract slice does not claim runtime proof and does not restart the
+  game.
+- Final runtime proof must use the acknowledged FireTuner socket/API restart
+  boundary recorded in the note after restacking/integration checks.
+
+## Verification So Far
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-geological-op-contract.test.ts`
+  - Passed: 8 tests, 135 assertions.
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-geological-op-contract.test.ts test/resources/resource-terrestrial-op-contract.test.ts test/resources/resource-cultivated-op-contract.test.ts test/resources/resource-aquatic-op-contract.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+  - Passed before final review repairs: 36 tests, 932 assertions.
+  - Passed after final review repairs: 36 tests, 938 assertions.
+- `bun run --cwd mods/mod-swooper-maps check`
+  - Passed.
+- `bun run openspec -- validate resource-geological-operation-contract --strict`
+  - Passed.
+- `bun run openspec:validate`
+  - Passed: 26 items.
+- `git diff --check`
+  - Passed.
+
+## Closure State
+
+- Committed locally via Graphite at `9c64100ac` and worktree was clean before
+  `codex/resource-group-plan-rollup` opened above it. External Graphite
+  submission/PR delivery remains unclaimed until submitted.

--- a/openspec/changes/resource-geological-operation-contract/workstream/review-disposition-ledger.md
+++ b/openspec/changes/resource-geological-operation-contract/workstream/review-disposition-ledger.md
@@ -1,0 +1,10 @@
+# Review Disposition Ledger
+
+| Finding | Severity | Disposition | Notes |
+| --- | --- | --- | --- |
+| Keep geological resources as one symbolic group op | P2 | accepted | The expectation artifact already owns one geological group with per-resource rows; no separate consumed/published artifact boundary exists yet. |
+| Preserve the four blocked active-zero rows | P1 | accepted, repaired | Tests cover distant-lands gold, distant-lands silver, lapis lazuli, and nickel as visible blocked rows with zero expected ranges. |
+| Guard against generic proxy broadening | P1 | accepted, repaired | Tests preserve strict geological signal fields and reject generic forest/wetland or tropical broadening for narrow rows. |
+| Add missing geological tests | P1 | accepted, repaired | Added focused operation contract tests before package and OpenSpec validation. |
+| Companion masks acted as standalone source eligibility | P2 | accepted, repaired | Removed standalone alluvial jade, orogenic marble, hill-only iron/limestone, wet-alluvial niter, and broad carbonate ruby eligibility; added focused regression checks. |
+| Watcher note would remain stale after terrestrial repair | P2 | accepted, repaired | Added the repaired-in-current-slice disposition while preserving the final FireTuner control boundary. |

--- a/openspec/changes/resource-group-plan-rollup/.openspec.yaml
+++ b/openspec/changes/resource-group-plan-rollup/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-group-plan-rollup/design.md
+++ b/openspec/changes/resource-group-plan-rollup/design.md
@@ -1,0 +1,71 @@
+# Resource Group Plan Rollup Design
+
+## Decision
+
+Add a resource-domain operation:
+
+```text
+resources/plan-resource-groups
+```
+
+The op is a rollup boundary, not a strategy tuner. It consumes the four
+symbolic group-planning outputs and publishes
+`artifact:resources.groupPlans`.
+
+## Consumed Inputs
+
+- `aquaticPlan`: `resources/plan-aquatic-resources`
+- `cultivatedPlan`: `resources/plan-cultivated-resources`
+- `terrestrialPlan`: `resources/plan-terrestrial-resources`
+- `geologicalPlan`: `resources/plan-geological-resources`
+
+Each input must preserve warning-only proof and unverified runtime-id status.
+
+## Published Output
+
+The output artifact records:
+
+- group count;
+- stable group summaries for the four expected input boundaries;
+- input group id observed for each boundary;
+- per-resource plan rows for each group;
+- total resource count;
+- total planned, blocked, proxy-gap, and missing-expectation rows;
+- total symbolic target intents and eligible tiles;
+- duplicate resource ownership blockers;
+- missing resource types across groups;
+- one summary row per resource group.
+
+## Invariants
+
+- The required group set is strategy-owned and not caller-configurable.
+- The op does not inspect group-local lane/proxy internals beyond status and
+  counts, but it carries the per-resource rows forward so downstream merge
+  slices do not reach back into individual group ops.
+- Duplicate resource ownership is visible as a blocker instead of silently
+  choosing a winner.
+- Duplicate rows inside one group are visible as blockers.
+- Miswired group inputs are visible as blockers while the output keeps one
+  stable summary for each expected group boundary.
+- The op emits no runtime numeric ids, no placement intents, and no adapter
+  materialization calls.
+
+## FireTuner Runtime-Proof Boundary
+
+The downstream resource-runtime-proof boundary remains the control record for
+final runtime proof. This contract slice does not claim runtime proof and does
+not restart the game.
+
+## Follow-Up Repair Boundary
+
+This slice repairs stale geological closure metadata in a follow-up branch
+because `codex/resource-geological-operation-contract` was already locally
+committed clean at `9c64100ac` before this rollup branch was opened.
+
+## Write Set
+
+- `mods/mod-swooper-maps/src/domain/resources/ops/contracts.ts`
+- `mods/mod-swooper-maps/src/domain/resources/ops/index.ts`
+- `mods/mod-swooper-maps/src/domain/resources/ops/plan-resource-groups/**`
+- `mods/mod-swooper-maps/test/resources/resource-group-rollup-op-contract.test.ts`
+- `openspec/changes/resource-group-plan-rollup/**`

--- a/openspec/changes/resource-group-plan-rollup/proposal.md
+++ b/openspec/changes/resource-group-plan-rollup/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+All four official resource expectation groups now have symbolic planning ops.
+The next architecture boundary is a group-plan rollup artifact that downstream
+merge, stats, and runtime-proof slices can consume without reaching into
+individual group strategy internals.
+
+This slice introduces that rollup without changing placement behavior.
+
+## Target Authority Refs
+
+- `openspec/changes/resource-stage-architecture`: `plan-resource-groups`
+  consumes group plans and publishes `artifact:resources.groupPlans`.
+- `openspec/changes/resource-aquatic-operation-contract`
+- `openspec/changes/resource-cultivated-operation-contract`
+- `openspec/changes/resource-terrestrial-operation-contract`
+- `openspec/changes/resource-geological-operation-contract`
+
+## What Changes
+
+- Add `resources/plan-resource-groups`.
+- Consume the four reviewed symbolic group-plan outputs.
+- Publish `artifact:resources.groupPlans` with deterministic group summaries,
+  total row/status counts, missing-resource rollup, and duplicate ownership
+  blockers.
+- Keep `runtimeIdStatus = "unverified"` and `proofStatus = "warning-only"`.
+
+## Explicit Non-Goals
+
+- No resource placement behavior change.
+- No resource input derivation, scoring, intent merge, or materialization.
+- No runtime numeric id verification.
+- No stats hard gate or game restart proof.
+- No external Graphite submission/PR delivery claim.
+
+## Verification Gates
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-group-rollup-op-contract.test.ts test/resources/resource-geological-op-contract.test.ts test/resources/resource-terrestrial-op-contract.test.ts test/resources/resource-cultivated-op-contract.test.ts test/resources/resource-aquatic-op-contract.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate resource-group-plan-rollup --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/resource-group-plan-rollup/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-group-plan-rollup/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Resource Group Plans Publish A Rollup Artifact
+
+The resource distribution workstream SHALL expose a symbolic group-plan rollup
+before downstream resource intent merge, stats, or runtime proof consumes group
+strategy outputs.
+
+#### Scenario: All group plans are rolled up
+- **WHEN** the rollup receives aquatic, cultivated, terrestrial, and geological
+  group planning outputs
+- **THEN** it publishes `artifact:resources.groupPlans`
+- **AND** the artifact records one summary row for each of the four resource
+  groups
+- **AND** each summary row carries its per-resource planning rows
+- **AND** the artifact records total resource, planned, blocked, proxy-gap, and
+  missing-expectation counts
+- **AND** the artifact preserves `runtimeIdStatus = "unverified"` and
+  `proofStatus = "warning-only"`
+
+#### Scenario: Missing rows remain visible across groups
+- **WHEN** any group plan reports missing expectation rows
+- **THEN** the rollup includes those resource types in the group summary and in
+  the artifact-level `missingResourceTypes`
+- **AND** the rollup does not treat aggregate counts as satisfying coverage
+
+### Requirement: Resource Group Rollup Does Not Materialize Resources
+
+The group-plan rollup SHALL remain a symbolic artifact boundary and not a
+placement or adapter step.
+
+#### Scenario: No placement behavior changes
+- **WHEN** the rollup operation is added
+- **THEN** existing resource placement behavior is unchanged
+- **AND** the operation does not import adapter runtime modules or
+  `ResourceBuilder`
+- **AND** the operation does not emit `resourceId`, `numericId`,
+  `preferredResourceType`, or tile-level resource placement intents
+
+### Requirement: Resource Group Rollup Exposes Wiring Errors
+
+The group-plan rollup SHALL preserve group ownership problems as explicit
+blockers.
+
+#### Scenario: Duplicate ownership is visible
+- **WHEN** a symbolic resource appears in more than one group plan
+- **THEN** the rollup reports the duplicate resource type
+- **AND** the artifact records a blocker naming the conflicting groups
+- **WHEN** a symbolic resource appears more than once inside one group plan
+- **THEN** the rollup reports the duplicate resource type
+- **AND** the artifact records a blocker naming the repeated group
+
+#### Scenario: Group input is miswired
+- **WHEN** a required input field carries a different group id than expected
+- **THEN** the rollup records a blocker for the mismatched field and group id
+- **AND** the rollup still emits one stable summary for each expected group
+  boundary
+- **AND** the rollup does not promote the artifact to hard proof

--- a/openspec/changes/resource-group-plan-rollup/tasks.md
+++ b/openspec/changes/resource-group-plan-rollup/tasks.md
@@ -1,0 +1,31 @@
+## 1. Operation Contract
+
+- [x] 1.1 Add `resources/plan-resource-groups`.
+- [x] 1.2 Publish `artifact:resources.groupPlans`.
+- [x] 1.3 Make the four-group input set strategy-owned.
+- [x] 1.4 Preserve warning-only proof and unverified runtime-id status.
+- [x] 1.5 Keep output non-materializing and placement-free.
+
+## 2. Rollup Coverage
+
+- [x] 2.1 Summarize aquatic group rows.
+- [x] 2.2 Summarize cultivated group rows.
+- [x] 2.3 Summarize terrestrial group rows.
+- [x] 2.4 Summarize geological group rows.
+- [x] 2.5 Report duplicate resource ownership.
+- [x] 2.6 Report miswired group inputs.
+- [x] 2.7 Roll up missing expectation rows.
+
+## 3. Tests And Review
+
+- [x] 3.1 Run focused group-rollup operation tests.
+- [x] 3.2 Run focused resource operation regression tests.
+- [x] 3.3 Run package check.
+- [x] 3.4 Run framed peer review and disposition accepted P1/P2 findings.
+
+## 4. Verification And Closure
+
+- [x] 4.1 Run OpenSpec validation.
+- [x] 4.2 Run `git diff --check`.
+- [x] 4.3 Prepare the Graphite slice for a local commit while keeping external
+  Graphite submission/PR delivery unclaimed.

--- a/openspec/changes/resource-group-plan-rollup/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-group-plan-rollup/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,7 @@
+# Downstream Realignment Ledger
+
+| Affected assumption | Scope | Disposition |
+| --- | --- | --- |
+| Group plan outputs now have a symbolic rollup artifact. | Future resource intent merge, stats, and runtime-proof slices | Patch-needed downstream: consume `artifact:resources.groupPlans` instead of individual group strategy internals. |
+| Runtime ids remain unverified. | Placement materialization, stats closure, game log proof | No patch in this slice: later runtime proof must verify `GameInfo.Resources` ids before symbolic rows are materialized. |
+| FireTuner restart path remains a final-proof dependency. | Runtime-proof slices, game restart evidence, DRA handoff | Boundary already acknowledged in the downstream resource-runtime-proof boundary; final runtime proof must keep using that socket/API restart path. |

--- a/openspec/changes/resource-group-plan-rollup/workstream/phase-record.md
+++ b/openspec/changes/resource-group-plan-rollup/workstream/phase-record.md
@@ -1,0 +1,70 @@
+# Phase Record: Resource Group Plan Rollup
+
+## Objective
+
+Add the symbolic `resources/plan-resource-groups` rollup operation so the four
+resource group planners publish one deterministic `artifact:resources.groupPlans`
+boundary before later merge, stats, or runtime-proof slices.
+
+## Repo State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
+- Branch: `codex/resource-group-plan-rollup`
+- Parent slice: `codex/resource-geological-operation-contract`
+- Studio/API pair for this worktree: `http://127.0.0.1:5174/`
+
+## Agent Review
+
+- Goodall: final scoped review. Findings accepted:
+  - The rollup artifact must carry the actual per-resource plans, not just
+    summary counts.
+  - Duplicate detection must catch same-group duplicates and miswired duplicate
+    ownership.
+  - Miswired inputs must not destabilize the four expected group summary slots.
+  Repairs: group summaries now include `plans`, summaries use the expected input
+  boundary as `groupId`, the supplied group id is preserved as `inputGroupId`,
+  and duplicate detection reports both cross-group and same-group duplicates.
+- Goodall: final repair review. Outcome: no P1/P2 findings remain. Residual
+  note: this remains contract-only and does not claim stats/runtime proof.
+
+## FireTuner Runtime-Proof Boundary
+
+- The downstream resource-runtime-proof boundary remains in place.
+- This contract slice does not claim runtime proof and does not restart the
+  game.
+- Final runtime proof must use the acknowledged FireTuner socket/API restart
+  boundary recorded in the note after restacking/integration checks.
+
+## Follow-Up Repair
+
+- The watcher found stale geological closure metadata after the geological
+  branch had already been committed cleanly and this rollup branch had been
+  opened.
+- This slice repairs the geological task/phase record as a follow-up instead of
+  rewriting the already-clean downstack branch while rollup work is active.
+- Local commit closure is distinct from external Graphite submission/PR
+  delivery, which remains unclaimed until submitted.
+
+## Verification So Far
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-group-rollup-op-contract.test.ts`
+  - Passed: 5 tests, 28 assertions.
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-group-rollup-op-contract.test.ts test/resources/resource-geological-op-contract.test.ts test/resources/resource-terrestrial-op-contract.test.ts test/resources/resource-cultivated-op-contract.test.ts test/resources/resource-aquatic-op-contract.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+  - Passed before review repairs: 41 tests, 966 assertions.
+  - Passed after review repairs: 42 tests, 1139 assertions.
+- `bun run --cwd mods/mod-swooper-maps check`
+  - Passed.
+- `bun run openspec -- validate resource-group-plan-rollup --strict`
+  - Passed.
+- `bun run openspec:validate`
+  - Passed: 27 items.
+- `git diff --check`
+  - Passed.
+
+## Closure State
+
+- Source slice was committed in its original resource stack and replayed into
+  `codex/integrate-resource-ops-rollup` during the Graphite integration
+  workstream. This branch preserves the symbolic contract boundary and does
+  not claim runtime proof.

--- a/openspec/changes/resource-group-plan-rollup/workstream/review-disposition-ledger.md
+++ b/openspec/changes/resource-group-plan-rollup/workstream/review-disposition-ledger.md
@@ -1,0 +1,8 @@
+# Review Disposition Ledger
+
+| Finding | Severity | Disposition | Notes |
+| --- | --- | --- | --- |
+| Rollup artifact dropped per-resource plans | P1 | accepted, repaired | Group summaries now carry per-resource `plans` arrays so downstream merge can consume `artifact:resources.groupPlans` without reaching back to individual group ops. |
+| Duplicate detection missed duplicates inside one group or under miswiring | P2 | accepted, repaired | Duplicate detection now uses the expected input boundary and reports same-group duplicates. |
+| Miswired inputs produced unstable group summaries | P2 | accepted, repaired | Summaries now use the expected group slot while retaining `inputGroupId` for the supplied group id. |
+| Final framed repair review | P2 | cleared | Goodall found no remaining P1/P2 issues after repairs. |

--- a/openspec/changes/resource-terrestrial-operation-contract/.openspec.yaml
+++ b/openspec/changes/resource-terrestrial-operation-contract/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-terrestrial-operation-contract/design.md
+++ b/openspec/changes/resource-terrestrial-operation-contract/design.md
@@ -1,0 +1,106 @@
+# Resource Terrestrial Operation Contract Design
+
+## Decision
+
+Add a resource-domain operation:
+
+```text
+resources/plan-terrestrial-resources
+```
+
+The op is group-level because the current expectation artifact groups these
+resources under `terrestrial-animal-forest-wild`. The output remains
+per-resource, with one row for every group resource.
+
+The 11-resource set is strategy-owned, not caller-configurable. Callers may not
+shrink group coverage through op config.
+
+## Resource Set
+
+- `RESOURCE_CAMELS`
+- `RESOURCE_HIDES`
+- `RESOURCE_HORSES`
+- `RESOURCE_WOOL`
+- `RESOURCE_IVORY`
+- `RESOURCE_FURS`
+- `RESOURCE_TRUFFLES`
+- `RESOURCE_RUBBER`
+- `RESOURCE_HARDWOOD`
+- `RESOURCE_WILD_GAME`
+- `RESOURCE_LLAMAS`
+
+## Lane Map
+
+- `arid-rangeland`: `RESOURCE_CAMELS`
+- `open-grazing`: `RESOURCE_HIDES`, `RESOURCE_HORSES`
+- `highland-pastoral`: `RESOURCE_WOOL`
+- `savanna-megafauna`: `RESOURCE_IVORY`
+- `cold-boreal-furs`: `RESOURCE_FURS`
+- `woodland-host`: `RESOURCE_TRUFFLES`
+- `tropical-forest-product`: `RESOURCE_RUBBER`, `RESOURCE_HARDWOOD`
+- `diverse-wild-habitat`: `RESOURCE_WILD_GAME`
+- `tropical-highland-pastoral`: `RESOURCE_LLAMAS`
+
+## Input Boundary
+
+The op consumes symbolic expectation rows from
+`artifact:resources.earthlikeExpectations`. It may also receive resource-owned
+eligibility masks for terrestrial proxy families:
+
+- arid rangeland;
+- open grass/plains;
+- tundra/cold edge;
+- hills/highlands;
+- savanna/watering-hole;
+- tropical forest edge;
+- taiga/boreal forest;
+- moist woodland edge;
+- tropical forest;
+- diverse wild habitat;
+- tropical highland.
+
+Suppression masks are advisory local signals only. They do not imply runtime
+placement or numeric resource ids.
+
+## Output Boundary
+
+Each row carries:
+
+- `resourceType`;
+- `laneId`;
+- status (`planned`, `proxy-gap`, `missing-expectation`, or `blocked`);
+- `expectedCountRange`;
+- `targetIntentCount` and `eligibleTileCount`;
+- `rangeStatus`;
+- `proofStatus = "warning-only"`;
+- `runtimeIdStatus = "unverified"`;
+- signal fields, proxy requirements, blockers, and caveats.
+
+The op emits no runtime numeric id fields, adapter materialization, or tile-level
+resource placement intents.
+
+## Edge Proxies
+
+- `RESOURCE_TRUFFLES` preserves the woodland or host-tree proxy requirement.
+- `RESOURCE_LLAMAS` preserves the tropical hill/highland candidate histogram
+  requirement.
+- `RESOURCE_IVORY` uses savanna/watering-hole or tropical forest-edge signals,
+  not broad tropical forest.
+- `RESOURCE_HARDWOOD` preserves its caveat against broadening to temperate
+  forests without official or runtime proof.
+
+## FireTuner Runtime-Proof Boundary
+
+This slice acknowledges the downstream resource-runtime-proof boundary: final resource runtime proof must
+verify the downstack restart branch/commit, integrate or restack successor
+restart work if needed, use the FireTuner socket/API restart path rather than
+stale commands or manual bypasses, and record the exact branch/commit plus
+restart command/path used.
+
+## Write Set
+
+- `mods/mod-swooper-maps/src/domain/resources/ops/contracts.ts`
+- `mods/mod-swooper-maps/src/domain/resources/ops/index.ts`
+- `mods/mod-swooper-maps/src/domain/resources/ops/plan-terrestrial-resources/**`
+- `mods/mod-swooper-maps/test/resources/resource-terrestrial-op-contract.test.ts`
+- `openspec/changes/resource-terrestrial-operation-contract/**`

--- a/openspec/changes/resource-terrestrial-operation-contract/proposal.md
+++ b/openspec/changes/resource-terrestrial-operation-contract/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Aquatic and cultivated resources now have symbolic group planning operations.
+The terrestrial/animal/forest/wild group is the next bounded set: it covers
+open-grazing animals, forest products, wild habitat resources, and proxy-heavy
+rows such as truffles and llamas. This slice gives every resource its own
+warning-only symbolic planning row without moving placement behavior.
+
+## Target Authority Refs
+
+- `openspec/changes/resource-stage-architecture`: resource stage operation
+  sequence and `plan-resource-groups` boundary.
+- `openspec/changes/resource-earthlike-expectations-artifact`: typed
+  `artifact:resources.earthlikeExpectations` source rows.
+- `openspec/changes/resource-aquatic-operation-contract` and
+  `openspec/changes/resource-cultivated-operation-contract`: reviewed
+  symbolic group-planning precedent.
+
+## What Changes
+
+- Add `resources/plan-terrestrial-resources`.
+- Account for all 11 terrestrial/animal/forest/wild resources separately.
+- Preserve row-level lanes for arid rangeland, open grazing, highland pastoral,
+  savanna megafauna, cold/boreal furs, woodland host, tropical forest product,
+  diverse wild habitat, and tropical highland pastoral resources.
+- Preserve explicit proxy requirements for truffles and llamas, plus hardwood's
+  caveat against broadening to temperate forests without proof.
+
+## Explicit Non-Goals
+
+- No placement behavior change.
+- No adapter materialization or runtime numeric id verification.
+- No hard closure gates or game restart proof.
+- No implementation for geological/mineral/gemstone/industrial resources.
+- No external Graphite submission/PR delivery claim.
+
+## Verification Gates
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-terrestrial-op-contract.test.ts test/resources/resource-cultivated-op-contract.test.ts test/resources/resource-aquatic-op-contract.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate resource-terrestrial-operation-contract --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/resource-terrestrial-operation-contract/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-terrestrial-operation-contract/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Terrestrial Resource Operation Preserves Per-Resource Coverage
+
+The resource distribution workstream SHALL expose a symbolic terrestrial
+resource planning operation before terrestrial resources claim distribution
+coverage.
+
+#### Scenario: All terrestrial expectation rows are planned
+- **WHEN** the terrestrial planning op receives the terrestrial earthlike
+  expectation rows
+- **THEN** it emits one planning row each for the 11
+  `terrestrial-animal-forest-wild` resources
+- **AND** every row preserves the `resourceType`, lane id, expected count
+  range, condition multipliers, proxy requirements, caveats, and
+  `runtimeIdStatus = "unverified"`
+- **AND** no output row contains runtime numeric id fields
+
+#### Scenario: Missing rows are visible
+- **WHEN** a terrestrial expectation row is absent
+- **THEN** the operation emits a `missing-expectation` row for that resource
+- **AND** the resource appears in `missingResourceTypes`
+- **AND** the operation does not silently satisfy group coverage by omitting
+  the resource
+
+### Requirement: Terrestrial Resource Operation Keeps Runtime Boundary
+
+The terrestrial resource operation SHALL remain a symbolic planning contract and
+not a placement materializer.
+
+#### Scenario: No placement behavior changes
+- **WHEN** the terrestrial operation is added
+- **THEN** existing placement resource planning behavior is unchanged
+- **AND** the operation does not import adapter runtime modules or
+  `ResourceBuilder`
+- **AND** the operation does not emit `resourceId`, `numericId`,
+  `preferredResourceType`, or tile-level resource placement intents
+
+#### Scenario: Closure remains warning-only
+- **WHEN** the operation compares planned target counts to earthlike ranges
+- **THEN** its proof status remains `warning-only`
+- **AND** inferred earthlike ranges are not promoted to hard count gates
+  without runtime-calibrated telemetry
+
+### Requirement: Terrestrial Resource Operation Preserves Edge Proxies
+
+The terrestrial resource operation SHALL preserve the group's non-generic proxy
+families as visible signal fields.
+
+#### Scenario: Woodland and highland proxies survive planning
+- **WHEN** `RESOURCE_TRUFFLES` is planned
+- **THEN** its row can use a woodland or host-tree signal field
+- **AND** the woodland or host-tree proxy requirement remains visible
+- **WHEN** `RESOURCE_LLAMAS` is planned
+- **THEN** its row can use a tropical highland signal field
+- **AND** the tropical hill or highland candidate histogram requirement remains
+  visible
+
+#### Scenario: Hardwood caveat survives planning
+- **WHEN** `RESOURCE_HARDWOOD` is planned
+- **THEN** its row preserves the caveat that temperate forests must not be
+  broadened into eligibility without official or runtime proof
+
+#### Scenario: Proxy broadening is blocked for narrow rows
+- **WHEN** `RESOURCE_TRUFFLES` is planned
+- **THEN** generic grass or tundra masks do not satisfy its woodland-host proxy
+- **WHEN** `RESOURCE_LLAMAS` is planned
+- **THEN** generic highland masks do not satisfy its tropical highland proxy
+- **WHEN** `RESOURCE_IVORY` is planned
+- **THEN** broad tropical forest masks do not satisfy its savanna or forest-edge
+  proxy

--- a/openspec/changes/resource-terrestrial-operation-contract/tasks.md
+++ b/openspec/changes/resource-terrestrial-operation-contract/tasks.md
@@ -1,0 +1,34 @@
+## 1. Operation Contract
+
+- [x] 1.1 Add `resources/plan-terrestrial-resources`.
+- [x] 1.2 Preserve symbolic `RESOURCE_*` identity and unverified runtime-id
+  status.
+- [x] 1.3 Make the 11-resource terrestrial set strategy-owned.
+- [x] 1.4 Report missing expectation rows and proxy gaps explicitly.
+- [x] 1.5 Keep the output warning-only and non-materializing.
+
+## 2. Terrestrial Resource Coverage
+
+- [x] 2.1 Account for `RESOURCE_CAMELS`.
+- [x] 2.2 Account for `RESOURCE_HIDES`.
+- [x] 2.3 Account for `RESOURCE_HORSES`.
+- [x] 2.4 Account for `RESOURCE_WOOL`.
+- [x] 2.5 Account for `RESOURCE_IVORY`.
+- [x] 2.6 Account for `RESOURCE_FURS`.
+- [x] 2.7 Account for `RESOURCE_TRUFFLES`.
+- [x] 2.8 Account for `RESOURCE_RUBBER`.
+- [x] 2.9 Account for `RESOURCE_HARDWOOD`.
+- [x] 2.10 Account for `RESOURCE_WILD_GAME`.
+- [x] 2.11 Account for `RESOURCE_LLAMAS`.
+
+## 3. Tests And Review
+
+- [x] 3.1 Run focused terrestrial operation tests.
+- [x] 3.2 Run package check.
+- [x] 3.3 Run framed peer review and disposition accepted P1/P2 findings.
+
+## 4. Verification And Closure
+
+- [x] 4.1 Run OpenSpec validation.
+- [x] 4.2 Run `git diff --check`.
+- [x] 4.3 Commit the Graphite slice and leave the worktree clean locally.

--- a/openspec/changes/resource-terrestrial-operation-contract/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-terrestrial-operation-contract/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,8 @@
+# Downstream Realignment Ledger
+
+| Affected assumption | Scope | Disposition |
+| --- | --- | --- |
+| Terrestrial resources now have a symbolic group-planning op surface. | Future resource group ops and `plan-resource-groups` stage work | Patch-needed downstream: later slices should preserve per-resource rows, strategy-owned group coverage, row lanes, and explicit proxy gaps. |
+| Cultivated closure metadata is repaired in this follow-up slice. | Closure audits for `resource-cultivated-operation-contract` | Patched here because the cultivated branch was already locally committed clean at `3494d91de` before the watcher found stale records. |
+| Runtime ids remain unverified. | Placement materialization, stats closure, game log proof | No patch in this slice: later runtime proof must verify `GameInfo.Resources` ids before symbolic rows are materialized. |
+| FireTuner restart path remains a final-proof dependency. | Runtime-proof slices, game restart evidence, DRA handoff | Boundary acknowledged; final runtime proof must restack/integrate downstack restart work and record exact branch/commit plus restart command/path. |

--- a/openspec/changes/resource-terrestrial-operation-contract/workstream/phase-record.md
+++ b/openspec/changes/resource-terrestrial-operation-contract/workstream/phase-record.md
@@ -1,0 +1,68 @@
+# Phase Record: Resource Terrestrial Operation Contract
+
+## Objective
+
+Add the third resource-group operation contract for
+terrestrial/animal/forest/wild resources while preserving per-resource coverage,
+proxy visibility, warning-only proof, and the unverified runtime-id boundary.
+
+## Repo State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
+- Branch: `codex/resource-terrestrial-operation-contract`
+- Parent slice: `codex/resource-cultivated-operation-contract`
+- Studio/API pair for this worktree: `http://127.0.0.1:5174/`
+
+## Agent Review
+
+- Mill: terrestrial resource/proxy review. Findings accepted:
+  - Keep this as one symbolic group op; no split falsifier found.
+  - Guard against proxy broadening for `RESOURCE_LLAMAS`,
+    `RESOURCE_TRUFFLES`, and `RESOURCE_IVORY`.
+  - Add synthetic blocked-row and suppression tests.
+  Repairs: llamas now require `tropicalHighlandMask`, truffles require
+  `moistWoodlandEdgeMask`, ivory uses `tropicalForestEdgeMask` rather than
+  broad tropical forest, and focused tests cover these cases.
+- Boyle: final scoped P1/P2 review. Outcome: no P1/P2 findings. Residual risk:
+  this remains contract-only; upstream masks and runtime id/placement proof are
+  outside this slice.
+
+## Follow-Up Repair
+
+- Watcher found stale cultivated closure metadata after the cultivated branch
+  had already been committed cleanly and this terrestrial branch had been
+  opened.
+- This slice repairs the cultivated task/phase record as a follow-up instead of
+  rewriting the already-clean downstack branch while terrestrial work is active.
+- Local commit closure is distinct from external Graphite submission/PR
+  delivery, which remains unclaimed until submitted.
+
+## FireTuner Runtime-Proof Boundary
+
+- The downstream resource-runtime-proof boundary remains in place and this slice acknowledges it.
+- This contract slice does not claim runtime proof and does not restart the
+  game.
+- Final runtime proof must verify the downstack restart branch/commit,
+  integrate or restack successor restart work if needed, use the FireTuner
+  socket/API restart path rather than stale commands or manual bypasses, and
+  record the exact branch/commit plus restart command/path used.
+
+## Verification So Far
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-terrestrial-op-contract.test.ts test/resources/resource-cultivated-op-contract.test.ts test/resources/resource-aquatic-op-contract.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+  - Passed: 28 tests, 797 assertions.
+- `bun run --cwd mods/mod-swooper-maps check`
+  - Passed.
+- `bun run openspec -- validate resource-terrestrial-operation-contract --strict`
+  - Passed.
+- `bun run openspec:validate`
+  - Passed: 25 items.
+- `git diff --check`
+  - Passed.
+
+## Closure State
+
+- Committed locally via Graphite at `292629dce` and worktree was clean before
+  `codex/resource-geological-operation-contract` opened above it. External
+  Graphite submission/PR delivery remains unclaimed until submitted.

--- a/openspec/changes/resource-terrestrial-operation-contract/workstream/review-disposition-ledger.md
+++ b/openspec/changes/resource-terrestrial-operation-contract/workstream/review-disposition-ledger.md
@@ -1,0 +1,8 @@
+# Review Disposition Ledger
+
+| Finding | Severity | Disposition | Notes |
+| --- | --- | --- | --- |
+| Keep terrestrial resources as one symbolic group op | P2 | accepted | No repo-local falsifier requiring a split now; operation remains symbolic and per-resource. |
+| Proxy broadening risks for llamas, truffles, and ivory | P2 | accepted, repaired | Llamas require tropical highland, truffles require woodland/host, and ivory uses savanna or tropical forest-edge rather than broad tropical forest. |
+| Add synthetic blocked-row and suppression tests | P2 | accepted, repaired | Added tests for blocked-row visibility and suppression count reduction. |
+| Final scoped review | P2 | cleared | Boyle found no P1/P2 findings after repairs. |


### PR DESCRIPTION
Replay the symbolic resource operation contracts and group rollup above the corpus/expectation integration slice.

This keeps the operations warning-only and resource-domain owned: all four resource groups preserve per-resource rows, proxy gaps, blocked rows, and unverified runtime-id status, then publish a stable group-plan rollup artifact for later placement/runtime slices.

Stale next-packet handoffs and root NOTE-TO-DRA references were removed or retargeted to the downstream resource-runtime-proof boundary.

Validation:
- bun test mods/mod-swooper-maps/test/resources/resource-aquatic-op-contract.test.ts mods/mod-swooper-maps/test/resources/resource-cultivated-op-contract.test.ts mods/mod-swooper-maps/test/resources/resource-terrestrial-op-contract.test.ts mods/mod-swooper-maps/test/resources/resource-geological-op-contract.test.ts mods/mod-swooper-maps/test/resources/resource-group-rollup-op-contract.test.ts mods/mod-swooper-maps/test/resources/resource-earthlike-expectations-artifact.test.ts
- bun run openspec -- validate resource-aquatic-operation-contract --strict
- bun run openspec -- validate resource-cultivated-operation-contract --strict
- bun run openspec -- validate resource-terrestrial-operation-contract --strict
- bun run openspec -- validate resource-geological-operation-contract --strict
- bun run openspec -- validate resource-group-plan-rollup --strict
- bun run --cwd mods/mod-swooper-maps check
- git diff --check