### PR TITLE
feat(resources): add placement diversity, engine-legal assignment, and runtime telemetry proof

### DIFF
--- a/mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/strategies/default.ts
@@ -146,21 +146,12 @@ export const defaultStrategy = createStrategy(PlanResourcesContract, "default", 
       }
       if (tooClose) continue;
 
-      let chosenOffset = candidate.preferredTypeOffset;
-      let foundCappedType = false;
-      for (let shift = 0; shift < candidateResourceTypes.length; shift++) {
-        const offset = (candidate.preferredTypeOffset + shift) % candidateResourceTypes.length;
-        const type = candidateResourceTypes[offset]!;
-        const current = perTypeCounts.get(type) ?? 0;
-        if (current < maxPerType) {
-          chosenOffset = offset;
-          foundCappedType = true;
-          break;
-        }
-      }
-      if (!foundCappedType) {
-        chosenOffset = candidate.preferredTypeOffset;
-      }
+      const chosenOffset = chooseBalancedResourceOffset(
+        candidate.preferredTypeOffset,
+        candidateResourceTypes,
+        perTypeCounts,
+        maxPerType
+      );
 
       const preferredResourceType = candidateResourceTypes[chosenOffset]!;
       selected.push({
@@ -182,3 +173,42 @@ export const defaultStrategy = createStrategy(PlanResourcesContract, "default", 
     };
   },
 });
+
+function chooseBalancedResourceOffset(
+  preferredTypeOffset: number,
+  candidateResourceTypes: readonly number[],
+  perTypeCounts: ReadonlyMap<number, number>,
+  maxPerType: number
+): number {
+  let bestOffset = Math.max(0, Math.min(candidateResourceTypes.length - 1, preferredTypeOffset | 0));
+  let bestCount = Number.POSITIVE_INFINITY;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (let shift = 0; shift < candidateResourceTypes.length; shift++) {
+    const offset = (preferredTypeOffset + shift) % candidateResourceTypes.length;
+    const type = candidateResourceTypes[offset]!;
+    const current = perTypeCounts.get(type) ?? 0;
+    const underCap = current < maxPerType;
+    const bestUnderCap = bestCount < maxPerType;
+    if (!underCap && bestUnderCap) continue;
+
+    const distance = circularOffsetDistance(preferredTypeOffset, offset, candidateResourceTypes.length);
+    if (
+      (underCap && !bestUnderCap) ||
+      current < bestCount ||
+      (current === bestCount && distance < bestDistance) ||
+      (current === bestCount && distance === bestDistance && offset < bestOffset)
+    ) {
+      bestOffset = offset;
+      bestCount = current;
+      bestDistance = distance;
+    }
+  }
+
+  return bestOffset;
+}
+
+function circularOffsetDistance(start: number, offset: number, length: number): number {
+  if (length <= 0) return 0;
+  return (offset - start + length) % length;
+}

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
@@ -168,9 +168,73 @@ const PlacementOutcomeSummarySchema = Type.Object(
   { additionalProperties: false }
 );
 
+const ResourcePlacementReasonCountSchema = Type.Object(
+  {
+    reason: Type.Union([
+      Type.Literal("out-of-bounds"),
+      Type.Literal("invalid-resource-type"),
+      Type.Literal("cannot-have-resource"),
+      Type.Literal("wrong-resource-type"),
+    ]),
+    count: Type.Integer({ minimum: 0 }),
+  },
+  { additionalProperties: false }
+);
+
+const ResourcePlacementResourceSummarySchema = Type.Object(
+  {
+    resourceType: Type.Integer(),
+    plannedCount: Type.Integer({ minimum: 0 }),
+    placedCount: Type.Integer({ minimum: 0 }),
+    rejectedCount: Type.Integer({ minimum: 0 }),
+    mismatchCount: Type.Integer({ minimum: 0 }),
+    reasons: Type.Array(ResourcePlacementReasonCountSchema),
+  },
+  { additionalProperties: false }
+);
+
+const ResourcePlacementSummarySchema = Type.Object(
+  {
+    plannedCount: Type.Integer({ minimum: 0 }),
+    placedCount: Type.Integer({ minimum: 0 }),
+    rejectedCount: Type.Integer({ minimum: 0 }),
+    mismatchCount: Type.Integer({ minimum: 0 }),
+    byResource: Type.Array(ResourcePlacementResourceSummarySchema),
+    byReason: Type.Array(ResourcePlacementReasonCountSchema),
+  },
+  { additionalProperties: false }
+);
+
+const ResourceAssignmentResourceSummarySchema = Type.Object(
+  {
+    resourceType: Type.Integer(),
+    plannedCount: Type.Integer({ minimum: 0 }),
+    assignedCount: Type.Integer({ minimum: 0 }),
+    reassignedOutCount: Type.Integer({ minimum: 0 }),
+    reassignedInCount: Type.Integer({ minimum: 0 }),
+    unassignedCount: Type.Integer({ minimum: 0 }),
+  },
+  { additionalProperties: false }
+);
+
+const ResourceAssignmentSummarySchema = Type.Object(
+  {
+    requestedPlannedCount: Type.Integer({ minimum: 0 }),
+    assignedCount: Type.Integer({ minimum: 0 }),
+    reassignedCount: Type.Integer({ minimum: 0 }),
+    unassignedPreferredCount: Type.Integer({ minimum: 0 }),
+    candidateResourceTypes: Type.Array(Type.Integer({ minimum: 0 })),
+    legalCandidateResourceTypes: Type.Array(Type.Integer({ minimum: 0 })),
+    unassignableResourceTypes: Type.Array(Type.Integer({ minimum: 0 })),
+    byPreferredResource: Type.Array(ResourceAssignmentResourceSummarySchema),
+  },
+  { additionalProperties: false }
+);
+
 const ResourcePlacementOutcomesArtifactSchema = Type.Object(
   {
-    summary: PlacementOutcomeSummarySchema,
+    summary: ResourcePlacementSummarySchema,
+    assignment: ResourceAssignmentSummarySchema,
     outcomes: Type.Array(ResourcePlacementOutcomeSchema),
   },
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/index.ts
@@ -1,7 +1,10 @@
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 
 import { runPlacementProductStep } from "../product-runtime.js";
-import { placeResourcesWithTypedOutcomes } from "./materialize.js";
+import {
+  logResourcePlacementRuntimeTelemetry,
+  placeResourcesWithTypedOutcomes,
+} from "./materialize.js";
 import { placementArtifacts } from "../../artifacts.js";
 import PlaceResourcesStepContract from "./contract.js";
 
@@ -21,6 +24,7 @@ export default createStep(PlaceResourcesStepContract, {
     const outcomes = runPlacementProductStep("placement.resources", emit, () =>
       placeResourcesWithTypedOutcomes({ adapter: context.adapter, width, height, resources })
     );
+    logResourcePlacementRuntimeTelemetry(outcomes.summary, outcomes.assignment);
     deps.artifacts.resourcePlacementOutcomes.publish(context, outcomes);
   },
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
@@ -1,6 +1,8 @@
 import type {
   ResourcePlacementIntent,
+  ResourcePlacementMismatchReason,
   ResourcePlacementOutcome,
+  ResourcePlacementRejectionReason,
 } from "@civ7/adapter";
 import type { ExtendedMapContext } from "@swooper/mapgen-core";
 import type { DeepReadonly, Static } from "@swooper/mapgen-core/authoring";
@@ -11,12 +13,43 @@ type PlanResourcesOutput = Static<(typeof placement.ops.planResources)["output"]
 type ResourcePlacementOutcomes = Static<
   (typeof import("../../artifacts.js").placementArtifacts)["resourcePlacementOutcomes"]["schema"]
 >;
+type ResourcePlacementReason = ResourcePlacementRejectionReason | ResourcePlacementMismatchReason;
+type ResourcePlacementSummary = ResourcePlacementOutcomes["summary"];
+type ResourceAssignmentSummary = ResourcePlacementOutcomes["assignment"];
+type RuntimeResourceCatalogEntry = {
+  readonly index: number;
+  readonly resourceType: string;
+  readonly resourceClassType: string | null;
+  readonly name: string | null;
+};
+type RuntimeResourceRow = {
+  readonly Index?: unknown;
+  readonly $index?: unknown;
+  readonly ResourceType?: unknown;
+  readonly ResourceClassType?: unknown;
+  readonly Name?: unknown;
+};
 
 type PlaceResourcesWithTypedOutcomesArgs = {
   adapter: ExtendedMapContext["adapter"];
   width: number;
   height: number;
   resources: DeepReadonly<PlanResourcesOutput>;
+};
+type ResourceAssignment = {
+  plotIndex: number;
+  resourceType: number;
+  preferredResourceType: number | null;
+};
+type PlacementCandidate = {
+  plotIndex: number;
+  preferredResourceType: number;
+  preferredTypeOffset: number;
+  priority: number;
+};
+type ResourceAssignmentResult = {
+  assignments: ResourceAssignment[];
+  assignment: ResourceAssignmentSummary;
 };
 
 const RESOURCE_REJECTION_REASONS = new Set<string>([
@@ -36,18 +69,416 @@ function expectedTileForIntent(
   return { plotIndex: resolvedPlotIndex, x, y };
 }
 
+function isLegalResourceTile(
+  adapter: ExtendedMapContext["adapter"],
+  width: number,
+  height: number,
+  plotIndex: number,
+  resourceType: number
+): boolean {
+  const tile = expectedTileForIntent(width, plotIndex);
+  if (tile.x < 0 || tile.y < 0 || tile.x >= width || tile.y >= height) return false;
+  return adapter.canHaveResource(tile.x, tile.y, resourceType);
+}
+
+function allPlotIndices(size: number): number[] {
+  return Array.from({ length: size }, (_value, index) => index);
+}
+
+function buildCandidatePlotOrder(placements: readonly PlacementCandidate[], size: number): number[] {
+  const seen = new Set<number>();
+  const order: number[] = [];
+  for (const placement of placements) {
+    const plotIndex = Math.trunc(placement.plotIndex);
+    if (plotIndex < 0 || plotIndex >= size || seen.has(plotIndex)) continue;
+    seen.add(plotIndex);
+    order.push(plotIndex);
+  }
+  for (const plotIndex of allPlotIndices(size)) {
+    if (seen.has(plotIndex)) continue;
+    order.push(plotIndex);
+  }
+  return order;
+}
+
+function buildPreferredResourceByPlot(
+  placements: readonly PlacementCandidate[],
+  size: number
+): Map<number, number> {
+  const byPlot = new Map<number, number>();
+  for (const placement of placements) {
+    const plotIndex = Math.trunc(placement.plotIndex);
+    if (plotIndex < 0 || plotIndex >= size || byPlot.has(plotIndex)) continue;
+    byPlot.set(plotIndex, Math.trunc(placement.preferredResourceType));
+  }
+  return byPlot;
+}
+
+function chooseLeastUsedLegalResource(args: {
+  adapter: ExtendedMapContext["adapter"];
+  width: number;
+  height: number;
+  plotIndex: number;
+  candidateResourceTypes: readonly number[];
+  perTypeCounts: ReadonlyMap<number, number>;
+}): number | null {
+  let bestType: number | null = null;
+  let bestCount = Number.POSITIVE_INFINITY;
+  for (const resourceType of args.candidateResourceTypes) {
+    if (
+      !isLegalResourceTile(args.adapter, args.width, args.height, args.plotIndex, resourceType)
+    ) {
+      continue;
+    }
+    const count = args.perTypeCounts.get(resourceType) ?? 0;
+    if (count < bestCount || (count === bestCount && (bestType === null || resourceType < bestType))) {
+      bestType = resourceType;
+      bestCount = count;
+    }
+  }
+  return bestType;
+}
+
+function assignResourceIntents(args: {
+  adapter: ExtendedMapContext["adapter"];
+  width: number;
+  height: number;
+  resources: DeepReadonly<PlanResourcesOutput>;
+  candidateResourceTypes: readonly number[];
+}): ResourceAssignmentResult {
+  const size = Math.max(0, args.width * args.height);
+  const targetCount = Math.min(args.resources.placements.length, size);
+  const plannedPlacements = args.resources.placements.map((placement) => ({
+    plotIndex: Math.trunc(placement.plotIndex),
+    preferredResourceType: Math.trunc(placement.preferredResourceType),
+    preferredTypeOffset: Math.trunc(placement.preferredTypeOffset),
+    priority: placement.priority,
+  }));
+  const plotOrder = buildCandidatePlotOrder(plannedPlacements, size);
+  const preferredByPlot = buildPreferredResourceByPlot(plannedPlacements, size);
+  const usedPlots = new Set<number>();
+  const perTypeCounts = new Map<number, number>();
+  const assignments: ResourceAssignment[] = [];
+
+  const addAssignment = (plotIndex: number, resourceType: number): void => {
+    usedPlots.add(plotIndex);
+    perTypeCounts.set(resourceType, (perTypeCounts.get(resourceType) ?? 0) + 1);
+    assignments.push({
+      plotIndex,
+      resourceType,
+      preferredResourceType: preferredByPlot.get(plotIndex) ?? null,
+    });
+  };
+
+  for (const resourceType of args.candidateResourceTypes) {
+    if (assignments.length >= targetCount) break;
+    const plotIndex = plotOrder.find(
+      (candidatePlot) =>
+        !usedPlots.has(candidatePlot) &&
+        isLegalResourceTile(args.adapter, args.width, args.height, candidatePlot, resourceType)
+    );
+    if (plotIndex === undefined) continue;
+    addAssignment(plotIndex, resourceType);
+  }
+
+  for (const placement of args.resources.placements) {
+    if (assignments.length >= targetCount) break;
+    const plotIndex = Math.trunc(placement.plotIndex);
+    if (plotIndex < 0 || plotIndex >= size || usedPlots.has(plotIndex)) continue;
+    const resourceType = chooseLeastUsedLegalResource({
+      adapter: args.adapter,
+      width: args.width,
+      height: args.height,
+      plotIndex,
+      candidateResourceTypes: args.candidateResourceTypes,
+      perTypeCounts,
+    });
+    if (resourceType === null) continue;
+    addAssignment(plotIndex, resourceType);
+  }
+
+  for (const plotIndex of plotOrder) {
+    if (assignments.length >= targetCount) break;
+    if (usedPlots.has(plotIndex)) continue;
+    const resourceType = chooseLeastUsedLegalResource({
+      adapter: args.adapter,
+      width: args.width,
+      height: args.height,
+      plotIndex,
+      candidateResourceTypes: args.candidateResourceTypes,
+      perTypeCounts,
+    });
+    if (resourceType === null) continue;
+    addAssignment(plotIndex, resourceType);
+  }
+
+  return {
+    assignments,
+    assignment: summarizeResourceAssignments({
+      adapter: args.adapter,
+      width: args.width,
+      height: args.height,
+      size,
+      plannedPlacements,
+      assignments,
+      candidateResourceTypes: args.candidateResourceTypes,
+      plotOrder,
+      usedPlots,
+    }),
+  };
+}
+
+function summarizeResourceAssignments(args: {
+  adapter: ExtendedMapContext["adapter"];
+  width: number;
+  height: number;
+  size: number;
+  plannedPlacements: readonly PlacementCandidate[];
+  assignments: readonly ResourceAssignment[];
+  candidateResourceTypes: readonly number[];
+  plotOrder: readonly number[];
+  usedPlots: ReadonlySet<number>;
+}): ResourceAssignmentSummary {
+  const byResource = new Map<
+    number,
+    {
+      plannedCount: number;
+      assignedCount: number;
+      reassignedOutCount: number;
+      reassignedInCount: number;
+      unassignedCount: number;
+    }
+  >();
+  const ensure = (resourceType: number) => {
+    let row = byResource.get(resourceType);
+    if (!row) {
+      row = {
+        plannedCount: 0,
+        assignedCount: 0,
+        reassignedOutCount: 0,
+        reassignedInCount: 0,
+        unassignedCount: 0,
+      };
+      byResource.set(resourceType, row);
+    }
+    return row;
+  };
+
+  for (const resourceType of args.candidateResourceTypes) ensure(resourceType);
+  for (const placement of args.plannedPlacements) {
+    ensure(placement.preferredResourceType).plannedCount += 1;
+  }
+
+  let reassignedCount = 0;
+  for (const assignment of args.assignments) {
+    ensure(assignment.resourceType).assignedCount += 1;
+    if (
+      assignment.preferredResourceType !== null &&
+      assignment.preferredResourceType !== assignment.resourceType
+    ) {
+      reassignedCount += 1;
+      ensure(assignment.preferredResourceType).reassignedOutCount += 1;
+      ensure(assignment.resourceType).reassignedInCount += 1;
+    }
+  }
+
+  for (const placement of args.plannedPlacements) {
+    const plotIndex = Math.trunc(placement.plotIndex);
+    if (plotIndex < 0 || plotIndex >= args.size || args.usedPlots.has(plotIndex)) continue;
+    ensure(placement.preferredResourceType).unassignedCount += 1;
+  }
+
+  const legalCandidateResourceTypes = args.candidateResourceTypes.filter((resourceType) =>
+    args.plotOrder.some((plotIndex) =>
+      isLegalResourceTile(args.adapter, args.width, args.height, plotIndex, resourceType)
+    )
+  );
+  const legalSet = new Set(legalCandidateResourceTypes);
+  const unassignableResourceTypes = args.candidateResourceTypes.filter(
+    (resourceType) => !legalSet.has(resourceType)
+  );
+  const unassignedPreferredCount = Array.from(byResource.values()).reduce(
+    (sum, row) => sum + row.unassignedCount,
+    0
+  );
+
+  return {
+    requestedPlannedCount: args.plannedPlacements.length,
+    assignedCount: args.assignments.length,
+    reassignedCount,
+    unassignedPreferredCount,
+    candidateResourceTypes: [...args.candidateResourceTypes],
+    legalCandidateResourceTypes,
+    unassignableResourceTypes,
+    byPreferredResource: Array.from(byResource.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([resourceType, row]) => ({ resourceType, ...row })),
+  };
+}
+
 function summarizeResourceOutcomes(
   outcomes: readonly ResourcePlacementOutcome[]
 ): ResourcePlacementOutcomes["summary"] {
   let placedCount = 0;
   let rejectedCount = 0;
   let mismatchCount = 0;
+  const byResource = new Map<
+    number,
+    {
+      plannedCount: number;
+      placedCount: number;
+      rejectedCount: number;
+      mismatchCount: number;
+      reasons: Map<ResourcePlacementReason, number>;
+    }
+  >();
+  const byReason = new Map<ResourcePlacementReason, number>();
+
   for (const outcome of outcomes) {
-    if (outcome.status === "placed") placedCount += 1;
-    else if (outcome.status === "rejected") rejectedCount += 1;
-    else mismatchCount += 1;
+    const resourceType = Number.isFinite(outcome.resourceType)
+      ? Math.trunc(outcome.resourceType)
+      : -1;
+    let resourceSummary = byResource.get(resourceType);
+    if (!resourceSummary) {
+      resourceSummary = {
+        plannedCount: 0,
+        placedCount: 0,
+        rejectedCount: 0,
+        mismatchCount: 0,
+        reasons: new Map(),
+      };
+      byResource.set(resourceType, resourceSummary);
+    }
+    resourceSummary.plannedCount += 1;
+
+    if (outcome.status === "placed") {
+      placedCount += 1;
+      resourceSummary.placedCount += 1;
+    } else if (outcome.status === "rejected") {
+      rejectedCount += 1;
+      resourceSummary.rejectedCount += 1;
+    } else {
+      mismatchCount += 1;
+      resourceSummary.mismatchCount += 1;
+    }
+
+    if (outcome.status !== "placed") {
+      const reason = outcome.reason;
+      resourceSummary.reasons.set(reason, (resourceSummary.reasons.get(reason) ?? 0) + 1);
+      byReason.set(reason, (byReason.get(reason) ?? 0) + 1);
+    }
   }
-  return { plannedCount: outcomes.length, placedCount, rejectedCount, mismatchCount };
+  return {
+    plannedCount: outcomes.length,
+    placedCount,
+    rejectedCount,
+    mismatchCount,
+    byResource: Array.from(byResource.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([resourceType, summary]) => ({
+        resourceType,
+        plannedCount: summary.plannedCount,
+        placedCount: summary.placedCount,
+        rejectedCount: summary.rejectedCount,
+        mismatchCount: summary.mismatchCount,
+        reasons: Array.from(summary.reasons.entries())
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([reason, count]) => ({ reason, count })),
+      })),
+    byReason: Array.from(byReason.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([reason, count]) => ({ reason, count })),
+  };
+}
+
+function coerceRuntimeIndex(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : null;
+}
+
+function coerceRuntimeString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export function readRuntimeResourceCatalog(): readonly RuntimeResourceCatalogEntry[] {
+  const runtime = globalThis as typeof globalThis & {
+    GameInfo?: { Resources?: Iterable<RuntimeResourceRow> };
+  };
+  const table = runtime.GameInfo?.Resources;
+  if (!table) return [];
+
+  return Array.from(table)
+    .map((row) => {
+      const index = coerceRuntimeIndex(row.Index) ?? coerceRuntimeIndex(row.$index);
+      const resourceType = coerceRuntimeString(row.ResourceType);
+      if (index === null || resourceType === null) return null;
+      return {
+        index,
+        resourceType,
+        resourceClassType: coerceRuntimeString(row.ResourceClassType),
+        name: coerceRuntimeString(row.Name),
+      };
+    })
+    .filter((row): row is RuntimeResourceCatalogEntry => row !== null)
+    .sort((a, b) => a.index - b.index);
+}
+
+export function buildResourcePlacementRuntimeTelemetry(
+  summary: ResourcePlacementSummary,
+  assignment?: ResourceAssignmentSummary,
+  runtimeCatalog: readonly RuntimeResourceCatalogEntry[] = readRuntimeResourceCatalog()
+): Record<string, unknown> {
+  const runtimeByIndex = new Map(runtimeCatalog.map((row) => [row.index, row]));
+  const plannedResourceTypes = summary.byResource.filter((row) => row.plannedCount > 0);
+  const placedResourceTypes = summary.byResource.filter((row) => row.placedCount > 0);
+  const rejectedResourceTypes = summary.byResource.filter((row) => row.rejectedCount > 0);
+  const placedCounts = placedResourceTypes.map((row) => row.placedCount);
+  const unmappedResourceTypes = summary.byResource.filter(
+    (row) => row.placedCount > 0 && !runtimeByIndex.has(row.resourceType)
+  );
+
+  return {
+    version: 1,
+    plannedCount: summary.plannedCount,
+    placedCount: summary.placedCount,
+    rejectedCount: summary.rejectedCount,
+    mismatchCount: summary.mismatchCount,
+    uniquePlannedTypes: plannedResourceTypes.length,
+    uniquePlacedTypes: placedResourceTypes.length,
+    minPlacedCountByType: placedCounts.length > 0 ? Math.min(...placedCounts) : 0,
+    maxPlacedCountByType: placedCounts.length > 0 ? Math.max(...placedCounts) : 0,
+    runtimeCatalogCount: runtimeCatalog.length,
+    plannedResourceTypes: plannedResourceTypes.map((row) => row.resourceType),
+    placedResourceTypes: placedResourceTypes.map((row) => row.resourceType),
+    rejectedResourceTypes: rejectedResourceTypes.map((row) => row.resourceType),
+    unmappedPlacedResourceTypes: unmappedResourceTypes.map((row) => row.resourceType),
+    ...(assignment
+      ? {
+          assignment: {
+            requestedPlannedCount: assignment.requestedPlannedCount,
+            assignedCount: assignment.assignedCount,
+            reassignedCount: assignment.reassignedCount,
+            unassignedPreferredCount: assignment.unassignedPreferredCount,
+            candidateResourceTypeCount: assignment.candidateResourceTypes.length,
+            legalCandidateResourceTypeCount: assignment.legalCandidateResourceTypes.length,
+            unassignableResourceTypes: assignment.unassignableResourceTypes,
+          },
+        }
+      : {}),
+    byReason: summary.byReason,
+  };
+}
+
+export function logResourcePlacementRuntimeTelemetry(
+  summary: ResourcePlacementSummary,
+  assignment: ResourceAssignmentSummary
+): void {
+  const runtimeCatalog = readRuntimeResourceCatalog();
+  if (runtimeCatalog.length === 0) return;
+  console.log(
+    `[SWOOPER_MOD] RESOURCE_PLACEMENT_V1 ${JSON.stringify(
+      buildResourcePlacementRuntimeTelemetry(summary, assignment, runtimeCatalog)
+    )}`
+  );
 }
 
 function assertResourceOutcomeMatchesIntent(
@@ -145,11 +576,24 @@ export function placeResourcesWithTypedOutcomes({
     );
   }
 
+  const assignmentResult = assignResourceIntents({
+    adapter,
+    width,
+    height,
+    resources,
+    candidateResourceTypes,
+  });
+  if (plannedCount > 0 && assignmentResult.assignments.length === 0) {
+    throw new Error(
+      `[Placement] Resource placement found no engine-legal resource assignments for ${plannedCount} planned intents.`
+    );
+  }
+
   const outcomes: ResourcePlacementOutcome[] = [];
-  for (const placementPlan of resources.placements) {
+  for (const assignment of assignmentResult.assignments) {
     const intent = {
-      plotIndex: placementPlan.plotIndex,
-      resourceType: placementPlan.preferredResourceType,
+      plotIndex: assignment.plotIndex,
+      resourceType: assignment.resourceType,
     };
     const outcome = adapter.placeResourceIntent(width, height, intent);
     assertResourceOutcomeMatchesIntent(outcome, intent, width);
@@ -170,5 +614,9 @@ export function placeResourcesWithTypedOutcomes({
     );
   }
 
-  return { summary: summarizeResourceOutcomes(outcomes), outcomes };
+  return {
+    summary: summarizeResourceOutcomes(outcomes),
+    assignment: assignmentResult.assignment,
+    outcomes,
+  };
 }

--- a/mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts
+++ b/mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts
@@ -76,6 +76,50 @@ const CASES = [
   },
 ] as const;
 
+function expectResourceDiagnostics(stats: WorldBalanceStats): void {
+  expect(stats.resourcePlannedCount, `${stats.label} resource plans`).toBeGreaterThan(0);
+  expect(stats.resourceUniquePlannedTypes, `${stats.label} planned resource variety`).toBeGreaterThanOrEqual(
+    Math.min(55, stats.resourcePlannedCount)
+  );
+  expect(stats.resourceUniquePlacedTypes, `${stats.label} placed resource variety`).toBeGreaterThanOrEqual(
+    Math.min(49, stats.resourcePlacedCount)
+  );
+  expect(
+    stats.resourcePlacedCountMaxByType - stats.resourcePlacedCountMinByType,
+    `${stats.label} placed resource spread`
+  ).toBeLessThanOrEqual(1);
+  expect(
+    stats.resourcePlacedCount + stats.resourceRejectedCount + stats.resourceMismatchCount,
+    `${stats.label} resource outcome total`
+  ).toBe(stats.resourcePlannedCount);
+  expect(
+    stats.resourceOutcomeCountsByResource.reduce((sum, entry) => sum + entry.plannedCount, 0),
+    `${stats.label} resource by-id planned total`
+  ).toBe(stats.resourcePlannedCount);
+  expect(
+    stats.resourceOutcomeCountsByResource.reduce(
+      (sum, entry) => sum + entry.placedCount + entry.rejectedCount + entry.mismatchCount,
+      0
+    ),
+    `${stats.label} resource by-id outcome total`
+  ).toBe(stats.resourcePlannedCount);
+  expect(
+    stats.resourceOutcomeCountsByReason.reduce((sum, entry) => sum + entry.count, 0),
+    `${stats.label} resource by-reason total`
+  ).toBe(stats.resourceRejectedCount + stats.resourceMismatchCount);
+
+  for (const entry of stats.resourceOutcomeCountsByResource) {
+    expect(
+      entry.placedCount + entry.rejectedCount + entry.mismatchCount,
+      `${stats.label} resource ${entry.resourceType} outcome total`
+    ).toBe(entry.plannedCount);
+    expect(
+      entry.reasons.reduce((sum, reason) => sum + reason.count, 0),
+      `${stats.label} resource ${entry.resourceType} reason total`
+    ).toBe(entry.rejectedCount + entry.mismatchCount);
+  }
+}
+
 describe("world balance stats", () => {
   it("keeps shipped map identities within product-visible geography budgets", { timeout: 30_000 }, () => {
     for (const caseData of CASES) {
@@ -86,6 +130,8 @@ describe("world balance stats", () => {
         width: 106,
         height: 66,
       });
+
+      expectResourceDiagnostics(stats);
 
       // Lakes should read as occasional inland basins, not a terrain-wide sink mask.
       expect(stats.lakeShareOfPreLakeLand, `${caseData.label} lake share`).toBeLessThanOrEqual(0.08);
@@ -143,7 +189,7 @@ describe("world balance stats", () => {
     }
   });
 
-  it("keeps earthlike vegetation families visible across seed rolls", { timeout: 30_000 }, () => {
+  it("keeps earthlike vegetation families visible across seed rolls", { timeout: 45_000 }, () => {
     const seeds = [1018, 1, 2, 3, 42, 99, 1234, 7777];
     const rolls: WorldBalanceStats[] = seeds.map((seed) =>
       collectWorldBalanceStats({
@@ -159,6 +205,7 @@ describe("world balance stats", () => {
       rolls.filter((stats) => stats.featureCounts[feature] > 0).length;
 
     for (const stats of rolls) {
+      expectResourceDiagnostics(stats);
       expect(stats.invalidFeatureSurfaceCount, `${stats.label} invalid feature surface`).toBe(0);
       expect(stats.finalLakeWaterDriftCount, `${stats.label} final lake water drift`).toBe(0);
       expect(stats.finalLakeClassificationDriftCount, `${stats.label} final lake classification drift`).toBe(0);

--- a/mods/mod-swooper-maps/test/placement/plan-ops.test.ts
+++ b/mods/mod-swooper-maps/test/placement/plan-ops.test.ts
@@ -139,6 +139,43 @@ describe("placement plan operations", () => {
     }
   });
 
+  it("balances resource type assignment across the adapter candidate catalog", () => {
+    const width = 10;
+    const height = 10;
+    const size = width * height;
+    const result = runOpValidated(planResources, {
+      width,
+      height,
+      noResourceSentinel: 99,
+      candidateResourceTypes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      landMask: new Uint8Array(size).fill(1),
+      fertility: new Float32Array(size).fill(0.8),
+      effectiveMoisture: new Float32Array(size).fill(0.6),
+      surfaceTemperature: new Float32Array(size).fill(18),
+      aridityIndex: new Float32Array(size).fill(0.4),
+      riverClass: new Uint8Array(size),
+      lakeMask: new Uint8Array(size),
+    }, {
+      strategy: "default",
+      config: {
+        candidateResourceTypes: [],
+        densityPer100Tiles: 25,
+        minSpacingTiles: 0,
+        maxPlacementsPerResourceShare: 1,
+      },
+    });
+
+    const placedTypes = result.placements.map((placement) => placement.preferredResourceType);
+    const uniqueTypes = new Set(placedTypes);
+    const perTypeCounts = result.candidateResourceTypes.map(
+      (resourceType) => placedTypes.filter((placedType) => placedType === resourceType).length
+    );
+
+    expect(result.plannedCount).toBe(25);
+    expect(uniqueTypes.size).toBe(result.candidateResourceTypes.length);
+    expect(Math.max(...perTypeCounts) - Math.min(...perTypeCounts)).toBeLessThanOrEqual(1);
+  });
+
   it("returns an empty plan when adapter candidate catalog is empty", () => {
     const width = 6;
     const height = 4;

--- a/mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts
+++ b/mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "bun:test";
+
+import { createMockAdapter } from "@civ7/adapter";
+import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
+
+import {
+  buildResourcePlacementRuntimeTelemetry,
+  placeResourcesWithTypedOutcomes,
+} from "../../src/recipes/standard/stages/placement/steps/place-resources/materialize.js";
+
+describe("resource placement diagnostics", () => {
+  it("summarizes placement outcomes by resource and reason", () => {
+    const width = 4;
+    const height = 3;
+    const adapter = createMockAdapter({
+      width,
+      height,
+      mapInfo: { GridWidth: width, GridHeight: height },
+      mapSizeId: 1,
+      rng: createLabelRng(1931),
+      canHaveResource: (_x, _y, resourceType) => resourceType !== 9,
+    });
+
+    const outcomes = placeResourcesWithTypedOutcomes({
+      adapter,
+      width,
+      height,
+      resources: {
+        width,
+        height,
+        candidateResourceTypes: [4, 9],
+        targetCount: 4,
+        plannedCount: 4,
+        placements: [
+          { plotIndex: 0, preferredResourceType: 4, preferredTypeOffset: 0, priority: 0.9 },
+          { plotIndex: 1, preferredResourceType: 9, preferredTypeOffset: 1, priority: 0.8 },
+          { plotIndex: 5, preferredResourceType: 9, preferredTypeOffset: 1, priority: 0.7 },
+          { plotIndex: 6, preferredResourceType: 4, preferredTypeOffset: 0, priority: 0.6 },
+        ],
+      },
+    });
+
+    expect(outcomes.summary).toEqual({
+      plannedCount: 4,
+      placedCount: 4,
+      rejectedCount: 0,
+      mismatchCount: 0,
+      byResource: [
+        {
+          resourceType: 4,
+          plannedCount: 4,
+          placedCount: 4,
+          rejectedCount: 0,
+          mismatchCount: 0,
+          reasons: [],
+        },
+      ],
+      byReason: [],
+    });
+    expect(outcomes.assignment).toMatchObject({
+      requestedPlannedCount: 4,
+      assignedCount: 4,
+      reassignedCount: 2,
+      unassignedPreferredCount: 0,
+      candidateResourceTypes: [4, 9],
+      legalCandidateResourceTypes: [4],
+      unassignableResourceTypes: [9],
+      byPreferredResource: [
+        {
+          resourceType: 4,
+          plannedCount: 2,
+          assignedCount: 4,
+          reassignedOutCount: 0,
+          reassignedInCount: 2,
+          unassignedCount: 0,
+        },
+        {
+          resourceType: 9,
+          plannedCount: 2,
+          assignedCount: 0,
+          reassignedOutCount: 2,
+          reassignedInCount: 0,
+          unassignedCount: 0,
+        },
+      ],
+    });
+  });
+
+  it("formats compact runtime telemetry for scripting logs", () => {
+    const telemetry = buildResourcePlacementRuntimeTelemetry(
+      {
+        plannedCount: 4,
+        placedCount: 3,
+        rejectedCount: 1,
+        mismatchCount: 0,
+        byResource: [
+          {
+            resourceType: 4,
+            plannedCount: 2,
+            placedCount: 2,
+            rejectedCount: 0,
+            mismatchCount: 0,
+            reasons: [],
+          },
+          {
+            resourceType: 44,
+            plannedCount: 2,
+            placedCount: 1,
+            rejectedCount: 1,
+            mismatchCount: 0,
+            reasons: [{ reason: "cannot-have-resource", count: 1 }],
+          },
+        ],
+        byReason: [{ reason: "cannot-have-resource", count: 1 }],
+      },
+      undefined,
+      [
+        {
+          index: 4,
+          resourceType: "RESOURCE_GOLD",
+          resourceClassType: "RESOURCECLASS_EMPIRE",
+          name: "Gold",
+        },
+        {
+          index: 44,
+          resourceType: "RESOURCE_RUBIES",
+          resourceClassType: "RESOURCECLASS_BONUS",
+          name: "Rubies",
+        },
+      ]
+    );
+
+    expect(telemetry).toEqual({
+      version: 1,
+      plannedCount: 4,
+      placedCount: 3,
+      rejectedCount: 1,
+      mismatchCount: 0,
+      uniquePlannedTypes: 2,
+      uniquePlacedTypes: 2,
+      minPlacedCountByType: 1,
+      maxPlacedCountByType: 2,
+      runtimeCatalogCount: 2,
+      plannedResourceTypes: [4, 44],
+      placedResourceTypes: [4, 44],
+      rejectedResourceTypes: [44],
+      unmappedPlacedResourceTypes: [],
+      byReason: [{ reason: "cannot-have-resource", count: 1 }],
+    });
+    expect(JSON.stringify(telemetry).length).toBeLessThan(900);
+  });
+
+  it("keeps full-catalog runtime telemetry below the Civ7 log truncation limit", () => {
+    const resourceRows = Array.from({ length: 55 }, (_, resourceType) => ({
+      resourceType,
+      plannedCount: resourceType === 5 || resourceType === 15 ? 0 : 3,
+      placedCount: resourceType === 5 || resourceType === 15 ? 0 : 3,
+      rejectedCount: 0,
+      mismatchCount: 0,
+      reasons: [],
+    }));
+    const telemetry = buildResourcePlacementRuntimeTelemetry(
+      {
+        plannedCount: 159,
+        placedCount: 159,
+        rejectedCount: 0,
+        mismatchCount: 0,
+        byResource: resourceRows,
+        byReason: [],
+      },
+      {
+        requestedPlannedCount: 159,
+        assignedCount: 159,
+        reassignedCount: 120,
+        unassignedPreferredCount: 18,
+        candidateResourceTypes: Array.from({ length: 55 }, (_, resourceType) => resourceType),
+        legalCandidateResourceTypes: resourceRows
+          .filter((row) => row.placedCount > 0)
+          .map((row) => row.resourceType),
+        unassignableResourceTypes: [5, 15],
+        byPreferredResource: [],
+      },
+      Array.from({ length: 55 }, (_, index) => ({
+        index,
+        resourceType: `RESOURCE_${index}`,
+        resourceClassType: "RESOURCECLASS_BONUS",
+        name: `Resource ${index}`,
+      }))
+    );
+
+    const placedResourceTypes = resourceRows
+      .filter((row) => row.placedCount > 0)
+      .map((row) => row.resourceType);
+
+    expect(telemetry).toMatchObject({
+      version: 1,
+      plannedCount: 159,
+      placedCount: 159,
+      rejectedCount: 0,
+      runtimeCatalogCount: 55,
+      plannedResourceTypes: placedResourceTypes,
+      placedResourceTypes,
+      rejectedResourceTypes: [],
+      unmappedPlacedResourceTypes: [],
+      assignment: {
+        requestedPlannedCount: 159,
+        assignedCount: 159,
+        reassignedCount: 120,
+        unassignedPreferredCount: 18,
+        candidateResourceTypeCount: 55,
+        legalCandidateResourceTypeCount: 53,
+        unassignableResourceTypes: [5, 15],
+      },
+    });
+    expect(JSON.stringify(telemetry).length).toBeLessThan(900);
+    expect(`[SWOOPER_MOD] RESOURCE_PLACEMENT_V1 ${JSON.stringify(telemetry)}`.length).toBeLessThan(
+      900
+    );
+  });
+});

--- a/mods/mod-swooper-maps/test/support/world-balance-stats.ts
+++ b/mods/mod-swooper-maps/test/support/world-balance-stats.ts
@@ -1,4 +1,8 @@
-import { createMockAdapter } from "@civ7/adapter";
+import {
+  createMockAdapter,
+  type ResourcePlacementMismatchReason,
+  type ResourcePlacementRejectionReason,
+} from "@civ7/adapter";
 import { createExtendedMapContext } from "@swooper/mapgen-core";
 import { getHexNeighborIndicesOddQ } from "@swooper/mapgen-core/lib/grid";
 import { createLabelRng } from "@swooper/mapgen-core/lib/rng";
@@ -107,10 +111,30 @@ export type WorldBalanceStats = Readonly<{
   resourcePlacedCount: number;
   resourceRejectedCount: number;
   resourceMismatchCount: number;
+  resourceUniquePlannedTypes: number;
+  resourceUniquePlacedTypes: number;
+  resourcePlacedCountMinByType: number;
+  resourcePlacedCountMaxByType: number;
+  resourceOutcomeCountsByResource: readonly ResourceOutcomeResourceStats[];
+  resourceOutcomeCountsByReason: readonly ResourceOutcomeReasonStats[];
   resourcePlanTypeCounts: Readonly<Record<string, number>>;
   resourcePlacedTypeCounts: Readonly<Record<string, number>>;
   resourceRejectReasonCounts: Readonly<Record<string, number>>;
   finalResourceTypeCounts: Readonly<Record<string, number>>;
+}>;
+
+export type ResourceOutcomeReasonStats = Readonly<{
+  reason: ResourcePlacementRejectionReason | ResourcePlacementMismatchReason;
+  count: number;
+}>;
+
+export type ResourceOutcomeResourceStats = Readonly<{
+  resourceType: number;
+  plannedCount: number;
+  placedCount: number;
+  rejectedCount: number;
+  mismatchCount: number;
+  reasons: readonly ResourceOutcomeReasonStats[];
 }>;
 
 const FEATURE_KEYS = [
@@ -427,6 +451,8 @@ export function collectWorldBalanceStats(args: Readonly<{
           placedCount?: number;
           rejectedCount?: number;
           mismatchCount?: number;
+          byResource?: ResourceOutcomeResourceStats[];
+          byReason?: ResourceOutcomeReasonStats[];
         };
         outcomes?: ReadonlyArray<
           Readonly<{
@@ -500,6 +526,13 @@ export function collectWorldBalanceStats(args: Readonly<{
         rejectedCanHaveFeatureByFeature?: Record<string, number>;
       }
     | undefined;
+  if (!resourcePlacement.summary) {
+    throw new Error("Missing placement resource outcome summary.");
+  }
+  const resourceOutcomeCountsByResource = resourcePlacement.summary.byResource ?? [];
+  const resourcePlacedCounts = resourceOutcomeCountsByResource
+    .filter((entry) => entry.placedCount > 0)
+    .map((entry) => entry.placedCount);
 
   let waterTiles = 0;
   let postProjectionLandTiles = 0;
@@ -780,6 +813,14 @@ export function collectWorldBalanceStats(args: Readonly<{
     resourcePlacedCount: Math.max(0, resourcePlacement.summary?.placedCount ?? 0),
     resourceRejectedCount: Math.max(0, resourcePlacement.summary?.rejectedCount ?? 0),
     resourceMismatchCount: Math.max(0, resourcePlacement.summary?.mismatchCount ?? 0),
+    resourceUniquePlannedTypes: resourceOutcomeCountsByResource.filter((entry) => entry.plannedCount > 0)
+      .length,
+    resourceUniquePlacedTypes: resourceOutcomeCountsByResource.filter((entry) => entry.placedCount > 0)
+      .length,
+    resourcePlacedCountMinByType: resourcePlacedCounts.length === 0 ? 0 : Math.min(...resourcePlacedCounts),
+    resourcePlacedCountMaxByType: resourcePlacedCounts.length === 0 ? 0 : Math.max(...resourcePlacedCounts),
+    resourceOutcomeCountsByResource,
+    resourceOutcomeCountsByReason: resourcePlacement.summary.byReason ?? [],
     resourcePlanTypeCounts,
     resourcePlacedTypeCounts,
     resourceRejectReasonCounts,

--- a/openspec/changes/resource-aquatic-operation-contract/workstream/phase-record.md
+++ b/openspec/changes/resource-aquatic-operation-contract/workstream/phase-record.md
@@ -12,7 +12,8 @@ unverified runtime-id boundary.
   `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
 - Branch: `codex/resource-aquatic-operation-contract`
 - Parent slice: `codex/resource-earthlike-expectations-artifact`
-- Studio/API pair for this worktree: `http://127.0.0.1:5174/`
+- Source Studio/API pair observed for this source slice:
+  `http://127.0.0.1:5174/`
 
 ## Agent Review
 
@@ -29,7 +30,8 @@ unverified runtime-id boundary.
 
 ## FireTuner Runtime-Proof Boundary
 
-- Acknowledged watcher note: the downstream resource-runtime-proof boundary.
+- Acknowledged runtime-proof boundary:
+  `openspec/changes/resource-runtime-proof/workstream/phase-record.md`.
 - Current downstack restart branch evidence:
   `codex/firetuner-socket-studio-restart` contains
   `bb39b3cf7 fix: submit Studio restarts through FireTuner socket`.
@@ -43,8 +45,8 @@ unverified runtime-id boundary.
   whether the downstack restart branch has advanced, integrate/restack the
   resource stack on top of it, use the FireTuner socket/API restart path, and
   record the exact branch/commit and restart command/path used.
-- The downstream resource-runtime-proof boundary remains in place until the final restacked/runtime-proof
-  boundary is recorded.
+- The runtime-proof phase record owns the final restacked/runtime-proof
+  boundary.
 
 ## Verification So Far
 
@@ -62,7 +64,7 @@ unverified runtime-id boundary.
 ## Closure State
 
 - Locally committed clean at
-  `ad23eb663b53c4134e962d00781685b1998c4484` on
+  `10d683fb2cd9` on
   `codex/resource-aquatic-operation-contract`.
 - External Graphite submission/PR delivery is not claimed by this local closure
   record.

--- a/openspec/changes/resource-cultivated-operation-contract/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-cultivated-operation-contract/workstream/downstream-realignment-ledger.md
@@ -3,5 +3,5 @@
 | Affected assumption | Scope | Disposition |
 | --- | --- | --- |
 | Cultivated resources now have a symbolic group-planning op surface. | Future resource group ops and `plan-resource-groups` stage work | Patch-needed downstream: later slices should keep per-resource rows, strategy-owned group coverage, and explicit proxy gaps. |
-| Aquatic closure metadata is repaired in this follow-up slice. | Closure audits for `resource-aquatic-operation-contract` | Patched here because the aquatic branch was already locally committed clean at `ad23eb663` before the watcher found stale records. |
+| Aquatic closure metadata is repaired in this follow-up slice. | Closure audits for `resource-aquatic-operation-contract` | Patched here because the aquatic branch was already locally committed clean at `10d683fb` before the watcher found stale records. |
 | Runtime ids remain unverified. | Placement materialization, stats closure, game log proof | No patch in this slice: later runtime proof must verify `GameInfo.Resources` ids before symbolic rows are materialized. |

--- a/openspec/changes/resource-cultivated-operation-contract/workstream/phase-record.md
+++ b/openspec/changes/resource-cultivated-operation-contract/workstream/phase-record.md
@@ -14,8 +14,9 @@ runtime-id boundary.
 - Branch: `codex/resource-cultivated-operation-contract`
 - Parent slice: `codex/resource-aquatic-operation-contract`
 - Parent aquatic local commit:
-  `ad23eb663b53c4134e962d00781685b1998c4484`
-- Studio/API pair for this worktree: `http://127.0.0.1:5174/`
+  `10d683fb2cd9`
+- Source Studio/API pair observed for this source slice:
+  `http://127.0.0.1:5174/`
 
 ## Follow-Up Repair
 
@@ -46,7 +47,8 @@ runtime-id boundary.
 
 ## FireTuner Runtime-Proof Boundary
 
-- The downstream resource-runtime-proof boundary remains in place.
+- Runtime-proof closure is owned by
+  `openspec/changes/resource-runtime-proof/workstream/phase-record.md`.
 - This contract slice does not claim runtime proof and does not restart the
   game.
 - Final runtime proof still must integrate/restack on top of
@@ -69,7 +71,7 @@ runtime-id boundary.
 ## Closure State
 
 - Locally committed clean at
-  `3494d91ded3ca38471ad560daca184546994e7d6` on
+  `dee212efc405` on
   `codex/resource-cultivated-operation-contract`.
 - External Graphite submission/PR delivery is not claimed by this local closure
   record.

--- a/openspec/changes/resource-distribution-root-cause/.openspec.yaml
+++ b/openspec/changes/resource-distribution-root-cause/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-distribution-root-cause/proposal.md
+++ b/openspec/changes/resource-distribution-root-cause/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+Current generated maps show only a minority of resources. The planning slice
+identified the root-cause lead: `placement/plan-resources` chooses exact numeric
+resource intents from a generic environmental signature, then
+`adapter.placeResourceIntent()` asks Civ7 whether that exact resource can exist
+on that exact tile. Rejected intents are counted only in aggregate, so local
+tests and runtime logs cannot yet prove whether the collapse is caused by
+`cannot-have-resource` feasibility rejections, numeric-id drift, or another
+placement boundary.
+
+## Target Authority Refs
+
+- `openspec/changes/resource-distribution-planning`: downstream slice map and
+  resource telemetry requirements.
+- `docs/projects/engine-refactor-v1/architecture-normalization-packet.md`: D4
+  typed placement reconciliation; adapter owns engine feasibility and readback.
+- `mods/mod-swooper-maps/AGENTS.md`: placement domain follows op-per-concern;
+  placement steps materialize product effects.
+- `.civ7/outputs/resources/Base/modules/base-standard/data/resources.xml` and
+  `resources-v2.xml`: static official resource facts, not runtime numeric-id
+  proof.
+
+## What Changes
+
+- Extend the existing resource placement outcome artifact with grouped
+  diagnostics by adapter numeric resource id and rejection/mismatch reason.
+- Expose those diagnostics through the world-balance stats helper so later
+  stats gates and runtime proof can consume a stable surface.
+- Add focused tests proving grouped resource outcome summaries and world-balance
+  diagnostic consistency.
+- Record that numeric resource ids are still adapter/runtime ids until a
+  downstream corpus/runtime verification slice proves `GameInfo.Resources`
+  ordering.
+
+## Explicit Non-Goals
+
+- No resource strategy tuning.
+- No resource-stage topology changes.
+- No resource corpus contract or symbolic id verification.
+- No generated output, `.civ7` resource edits, lockfile edits, or official-data
+  changes.
+- No claim that local mock-adapter acceptance proves live Civ7 feasibility.
+- No lotus-as-resource proof; lotus remains a feature proof lane.
+
+## Verification Gates
+
+- `bun run --cwd mods/mod-swooper-maps test -- test/placement/resource-placement-diagnostics.test.ts`
+- `bun run --cwd mods/mod-swooper-maps test -- test/pipeline/world-balance-stats.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate resource-distribution-root-cause --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/resource-distribution-root-cause/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-distribution-root-cause/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Resource Root-Cause Diagnostics Expose Per-Resource Outcomes
+
+Resource placement diagnostics SHALL expose planned, placed, and rejected
+outcomes grouped by adapter numeric resource id and by typed rejection reason
+without changing placement strategy behavior. The artifact schema SHALL retain
+mismatch fields for typed reconciliation, but resource mismatches remain
+fail-hard and abort before a mismatched artifact is published.
+
+#### Scenario: Resource intents are materialized
+- **WHEN** deterministic resource intents are passed to the adapter
+- **THEN** the resource placement outcome artifact records aggregate
+  planned/placed/rejected/mismatch counts
+- **AND** it records the same counts grouped by adapter numeric `resourceType`
+- **AND** it records rejection reasons grouped by reason
+- **AND** it preserves raw per-intent outcomes for detailed inspection
+
+#### Scenario: Resource readback mismatches the intent
+- **WHEN** adapter readback reports a different resource type than the planned
+  intent
+- **THEN** placement fails hard before publishing a misleading success artifact
+- **AND** mismatch fields remain part of the diagnostic schema for the typed
+  reconciliation contract
+
+#### Scenario: World-balance stats are collected
+- **WHEN** world-balance stats run a shipped map identity or representative seed
+- **THEN** stats include the resource outcome summary fields from the placement
+  artifact
+- **AND** stats tests verify internal consistency of aggregate, by-resource, and
+  by-reason totals
+- **AND** aggregate placement success alone is not treated as resource balance
+  closure
+
+#### Scenario: Numeric resource ids are interpreted
+- **WHEN** diagnostics report `resourceType` values
+- **THEN** those values are labeled as adapter/runtime numeric ids
+- **AND** the diagnostics do not claim a verified official resource name until a
+  runtime `GameInfo.Resources` id verification slice proves the mapping

--- a/openspec/changes/resource-distribution-root-cause/tasks.md
+++ b/openspec/changes/resource-distribution-root-cause/tasks.md
@@ -1,0 +1,23 @@
+## 1. Spec Boundary
+
+- [x] 1.1 Create root-cause OpenSpec change above the planning slice.
+- [x] 1.2 Record diagnostic-only scope and explicit non-goals.
+- [x] 1.3 Preserve the runtime-id proof boundary.
+
+## 2. Telemetry
+
+- [x] 2.1 Add resource outcome grouping by adapter resource id.
+- [x] 2.2 Add resource outcome grouping by rejection/mismatch reason.
+- [x] 2.3 Expose resource diagnostics through world-balance stats.
+
+## 3. Tests
+
+- [x] 3.1 Add focused placement diagnostics test.
+- [x] 3.2 Add world-balance diagnostic consistency assertions.
+
+## 4. Review And Verification
+
+- [x] 4.1 Complete agent review of the root-cause slice.
+- [x] 4.2 Run focused tests and package check.
+- [x] 4.3 Run OpenSpec validation and `git diff --check`.
+- [x] 4.4 Commit the slice with Graphite and leave the worktree clean.

--- a/openspec/changes/resource-distribution-root-cause/workstream/phase-record.md
+++ b/openspec/changes/resource-distribution-root-cause/workstream/phase-record.md
@@ -1,0 +1,81 @@
+# Phase Record
+
+## Phase
+
+- Project: resource distribution recovery
+- Phase: root-cause diagnostics
+- Owner: Codex workstream owner
+- Branch/Graphite stack: `codex/resource-distribution-root-cause` above
+  `codex/resource-distribution-planning`
+- Started: 2026-05-31
+- Status: committed
+
+## Objective
+
+Make the existing resource collapse observable without changing resource
+strategy behavior. The slice proves whether local/runtime placement evidence can
+group exact resource intent outcomes by adapter numeric id and by typed rejection
+reason.
+
+## Scope
+
+- Write set:
+  - `openspec/changes/resource-distribution-root-cause/**`
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts`
+  - `mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts`
+  - `mods/mod-swooper-maps/test/support/world-balance-stats.ts`
+  - `mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts`
+  - `mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts`
+- Protected files: generated outputs, `.civ7/outputs/resources/**`, lockfiles,
+  resource strategy modules, stage topology, shipped config tuning.
+- Consumer impact: diagnostics only. Placement behavior and resource strategy
+  output are intentionally unchanged.
+
+## Agent Evidence
+
+- Franklin: current dirty implementation has the right minimal telemetry shape:
+  `summary.byResource[]` and `summary.byReason[]` on the existing
+  `resourcePlacementOutcomes` artifact. Main typing risk was widened `string`
+  reasons; repaired by typing reasons as adapter rejection/mismatch unions.
+- Hume: root-cause slice must not implement the resource stage or strategy
+  tuning. It should add OpenSpec, diagnostics, stats exposure, tests, review, and
+  validation only.
+- Hubble: local files can support a static resource ordinal hypothesis but not
+  runtime `GameInfo.Resources` truth. Diagnostics must label ids as adapter
+  numeric ids until a runtime verification slice proves names.
+- Final review:
+  - Franklin: no P1/P2 blockers; requested clearer mismatch fail-hard wording.
+  - Hume: no behavior-scope blockers; accepted P2 to update task/phase state
+    after gates.
+  - Hubble: no P1/P2 runtime-id boundary blockers.
+
+## Runtime ID Boundary
+
+- Official XML stores resource identity as text keys; runtime placement APIs use
+  numeric ids.
+- The adapter currently exposes numeric candidates `0..54` without runtime
+  lookup.
+- This slice does not verify whether numeric id `44` is rubies or whether any
+  other numeric id maps to a specific official resource at runtime.
+- Later `resource-corpus-contract` and runtime proof slices must add
+  `GameInfo.Resources` verification before symbolic resource claims become
+  closure evidence.
+
+## Verification
+
+- Passed:
+  - `bun run --cwd mods/mod-swooper-maps test -- test/placement/resource-placement-diagnostics.test.ts`
+  - `bun run --cwd mods/mod-swooper-maps test -- test/pipeline/world-balance-stats.test.ts`
+  - `bun run --cwd mods/mod-swooper-maps check`
+  - `bun run openspec -- validate resource-distribution-root-cause --strict`
+  - `bun run openspec:validate`
+  - `git diff --check`
+- Notes:
+  - `bun install --frozen-lockfile` was needed in this isolated worktree.
+  - `packages/civ7-adapter`, `packages/mapgen-viz`, `packages/mapgen-core`, and
+    `packages/sdk` were built so workspace package exports resolved for tests
+    and type checks.
+
+## Next Action
+
+Proceed to the resource-stage architecture and corpus-contract slices.

--- a/openspec/changes/resource-diversity-stats-gate/.openspec.yaml
+++ b/openspec/changes/resource-diversity-stats-gate/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-diversity-stats-gate/design.md
+++ b/openspec/changes/resource-diversity-stats-gate/design.md
@@ -1,0 +1,48 @@
+# Resource Diversity Stats Gate Design
+
+## Decision
+
+Promote numeric resource-id variety into the existing world-balance stats helper
+and shipped-map test gate.
+
+The gate remains numeric because runtime symbolic id proof has not landed. It
+uses the adapter materialization outcome summary's numeric `resourceType`
+values.
+
+## Added Stats
+
+- `resourceUniquePlannedTypes`
+- `resourceUniquePlacedTypes`
+- `resourcePlacedCountMinByType`
+- `resourcePlacedCountMaxByType`
+
+## Gate
+
+For each shipped map identity in the world-balance stats test:
+
+- planned unique type count must be at least `min(55, resourcePlannedCount)`;
+- placed unique type count must be at least `min(55, resourcePlacedCount)`;
+- placed-count spread across numeric ids must be at most one.
+
+The current adapter candidate catalog contains 55 usable numeric ids in these
+tests, so this gate catches a return to the previous minority-resource collapse
+without claiming symbolic coverage.
+
+## Follow-Up Repair Boundary
+
+This slice repairs stale placement-diversity closure metadata in a follow-up
+branch because `codex/resource-placement-diversity` was already locally
+committed clean at `bc6c328c1edb` before this branch was opened.
+
+## FireTuner Runtime-Proof Boundary
+
+The `resource-runtime-proof` phase record owns final runtime proof. This stats
+slice does not claim runtime proof and does not restart the game.
+
+## Write Set
+
+- `mods/mod-swooper-maps/test/support/world-balance-stats.ts`
+- `mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts`
+- `openspec/changes/resource-placement-diversity/**`
+- `openspec/changes/resource-diversity-stats-gate/**`
+- `openspec/changes/resource-runtime-proof/**`

--- a/openspec/changes/resource-diversity-stats-gate/proposal.md
+++ b/openspec/changes/resource-diversity-stats-gate/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+The placement-diversity repair makes numeric resource assignments spread across
+the adapter candidate catalog, but the existing world-balance stats only checked
+resource accounting totals. They did not fail when only a small minority of
+resource ids appeared.
+
+This slice turns that repaired behavior into a local stats gate for shipped map
+identities.
+
+## Target Authority Refs
+
+- `openspec/changes/resource-placement-diversity`: balanced numeric candidate
+  resource assignment.
+- `openspec/changes/resource-distribution-root-cause`: only a minority of
+  resources appeared on generated maps.
+- `openspec/changes/resource-stage-architecture`: local stats must preserve
+  runtime proof boundaries and not overclaim symbolic id verification.
+
+## What Changes
+
+- Extend world-balance stats with unique planned/placed numeric resource type
+  counts.
+- Track min/max placed count per numeric resource id.
+- Assert shipped map identities use every numeric candidate id they have enough
+  placements to cover.
+- Assert per-id placed counts remain near-even after the diversity repair.
+
+## Explicit Non-Goals
+
+- No symbolic `RESOURCE_*` to runtime numeric id verification.
+- No FireTuner or game restart proof.
+- No hard earthlike expected-range closure.
+- No external Graphite submission/PR delivery claim.
+
+## Verification Gates
+
+- `bun test mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate resource-diversity-stats-gate --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/resource-diversity-stats-gate/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-diversity-stats-gate/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: World Balance Stats Gate Numeric Resource Variety
+
+World-balance stats SHALL detect regressions where generated maps place only a
+minority of adapter numeric resource ids despite enough placements to cover the
+catalog.
+
+#### Scenario: Shipped maps have enough resource placements
+- **WHEN** a shipped map identity produces at least as many placed resources as
+  the adapter candidate resource catalog size
+- **THEN** world-balance stats report every numeric resource id as placed
+- **AND** per-id placed counts differ by no more than one
+
+#### Scenario: Shipped maps have fewer placements than candidate ids
+- **WHEN** a shipped map identity produces fewer placed resources than the
+  adapter candidate resource catalog size
+- **THEN** world-balance stats require every placed resource to use a distinct
+  numeric resource id
+
+### Requirement: Resource Diversity Stats Preserve Runtime Proof Boundary
+
+The numeric resource diversity stats SHALL not claim symbolic resource runtime
+id verification.
+
+#### Scenario: Stats pass locally
+- **WHEN** world-balance resource diversity stats pass
+- **THEN** the evidence remains local numeric adapter-catalog evidence
+- **AND** final symbolic `RESOURCE_*` runtime proof still requires bounded
+  scripting-log evidence through the FireTuner socket/API restart boundary

--- a/openspec/changes/resource-diversity-stats-gate/tasks.md
+++ b/openspec/changes/resource-diversity-stats-gate/tasks.md
@@ -1,0 +1,23 @@
+## 1. Stats Gate
+
+- [x] 1.1 Add unique planned numeric resource type count.
+- [x] 1.2 Add unique placed numeric resource type count.
+- [x] 1.3 Add min/max placed count per numeric resource id.
+- [x] 1.4 Assert shipped map identities use the available numeric resource
+  catalog when placement counts permit.
+- [x] 1.5 Assert per-id placed counts remain near-even.
+
+## 2. Tests And Review
+
+- [x] 2.1 Run world-balance stats tests.
+- [x] 2.2 Run package check.
+- [x] 2.3 Run framed peer review and disposition accepted P1/P2 findings.
+
+## 3. Verification And Closure
+
+- [x] 3.1 Run OpenSpec validation.
+- [x] 3.2 Run `git diff --check`.
+- [x] 3.3 Commit the Graphite slice locally at `3cecdf6b49a1` and leave the
+  worktree clean before opening `codex/resource-runtime-proof` above it, while
+  keeping external Graphite submission/PR delivery, symbolic `RESOURCE_*`
+  runtime-id proof, and FireTuner runtime proof unclaimed.

--- a/openspec/changes/resource-diversity-stats-gate/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-diversity-stats-gate/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,7 @@
+# Downstream Realignment Ledger
+
+| Affected assumption | Scope | Disposition |
+| --- | --- | --- |
+| Local stats now gate numeric resource-id variety. | Runtime proof and future symbolic-id closure | Downstream proof can cite local numeric diversity, but must still prove symbolic `RESOURCE_*` runtime ids separately. |
+| Placement-diversity closure metadata is repaired in this follow-up slice. | Closure audits for `resource-placement-diversity` | Patched here because the placement-diversity branch was already locally committed clean at `bc6c328c1edb` before this branch was opened. |
+| FireTuner restart path remains a final-proof dependency. | Runtime-proof slices, game restart evidence, DRA handoff | Boundary is owned by the `resource-runtime-proof` phase record; final runtime proof must keep using that socket/API restart path. |

--- a/openspec/changes/resource-diversity-stats-gate/workstream/phase-record.md
+++ b/openspec/changes/resource-diversity-stats-gate/workstream/phase-record.md
@@ -1,0 +1,68 @@
+# Phase Record: Resource Diversity Stats Gate
+
+## Objective
+
+Add local world-balance stats gates proving shipped map identities no longer
+place only a minority of adapter numeric resource ids when enough resource
+placements exist.
+
+## Repo State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
+- Branch: `codex/resource-diversity-stats-gate`
+- Parent slice: `codex/resource-placement-diversity`
+- Source Studio/API pair observed for this source slice:
+  `http://127.0.0.1:5174/`
+
+## Agent Review
+
+- Averroes: final scoped review. Outcome: no P1/P2 findings. Residual P3:
+  numeric catalog size is hard-coded at 55, matching the current adapter catalog
+  and OpenSpec design.
+
+## Follow-Up Repair
+
+- The watcher found stale placement-diversity closure metadata after that branch
+  had already been committed cleanly and this stats-gate branch had been
+  opened.
+- This slice repairs the placement-diversity task/phase record as a follow-up
+  instead of rewriting the already-clean downstack branch while stats-gate work
+  is active.
+- Local commit closure is distinct from external Graphite submission/PR
+  delivery, which remains unclaimed until submitted.
+
+## FireTuner Runtime-Proof Boundary
+
+- Runtime-proof closure is owned by
+  `openspec/changes/resource-runtime-proof/workstream/phase-record.md`.
+- This slice does not claim runtime proof and does not restart the game.
+- Final runtime proof must use the FireTuner socket/API restart boundary
+  recorded in `openspec/changes/resource-runtime-proof/workstream/phase-record.md`
+  after restacking/integration checks.
+
+## Verification So Far
+
+- Manual stats probe over shipped identities at seed `1018`, `106x66`:
+  - `swooper-earthlike`: 243 placed, 55 unique ids, per-id spread 4-5.
+  - `realism-earthlike`: 243 placed, 55 unique ids, per-id spread 4-5.
+  - `shattered-ring`: 123 placed, 55 unique ids, per-id spread 2-3.
+  - `sundered-archipelago`: 53 placed, 53 unique ids, per-id spread 1-1.
+  - `desert-mountains`: 314 placed, 55 unique ids, per-id spread 5-6.
+- `bun test mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts`
+  - Passed: 2 tests, 1768 assertions.
+- `bun run --cwd mods/mod-swooper-maps check`
+  - Passed.
+- `bun run openspec -- validate resource-diversity-stats-gate --strict`
+  - Passed.
+- `bun run openspec:validate`
+  - Passed: 29 items.
+- `git diff --check`
+  - Passed.
+
+## Closure State
+
+- Committed locally via Graphite at `3cecdf6b49a1`, and the worktree was clean
+  before `codex/resource-runtime-proof` opened above it. External Graphite
+  submission/PR delivery, symbolic `RESOURCE_*` runtime-id proof, and FireTuner
+  runtime proof remain unclaimed until separately evidenced.

--- a/openspec/changes/resource-diversity-stats-gate/workstream/review-disposition-ledger.md
+++ b/openspec/changes/resource-diversity-stats-gate/workstream/review-disposition-ledger.md
@@ -1,0 +1,6 @@
+# Review Disposition Ledger
+
+| Finding | Severity | Disposition | Notes |
+| --- | --- | --- | --- |
+| Final framed review | P2 | cleared | Averroes found no P1/P2 findings. |
+| Numeric catalog size is hard-coded at 55 | P3 | accepted as residual | Matches current adapter catalog and OpenSpec design; future catalog-size proof can promote this into an artifact field. |

--- a/openspec/changes/resource-geological-operation-contract/design.md
+++ b/openspec/changes/resource-geological-operation-contract/design.md
@@ -112,14 +112,14 @@ resource placement intents.
 
 ## FireTuner Runtime-Proof Boundary
 
-The downstream resource-runtime-proof boundary remains the control record for final runtime proof. This contract
-slice does not claim runtime proof and does not restart the game.
+The `resource-runtime-proof` phase record owns final runtime proof. This
+contract slice does not claim runtime proof and does not restart the game.
 
 ## Follow-Up Repair Boundary
 
 This slice repairs stale terrestrial closure metadata in a follow-up branch
 because `codex/resource-terrestrial-operation-contract` was already locally
-committed clean at `292629dce` before this geological branch was opened.
+committed clean at `e4f99d9ef` before this geological branch was opened.
 
 ## Write Set
 

--- a/openspec/changes/resource-geological-operation-contract/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-geological-operation-contract/workstream/downstream-realignment-ledger.md
@@ -3,6 +3,6 @@
 | Affected assumption | Scope | Disposition |
 | --- | --- | --- |
 | Geological resources now have a symbolic group-planning op surface. | Future resource group rollup, score, and placement slices | Patch-needed downstream: later slices should preserve per-resource rows, strategy-owned group coverage, row lanes, strict proxy gaps, and blocked active-zero rows. |
-| Terrestrial closure metadata is repaired in this follow-up slice. | Closure audits for `resource-terrestrial-operation-contract` | Patched here because the terrestrial branch was already locally committed clean at `292629dce` before this geological branch was opened. |
+| Terrestrial closure metadata is repaired in this follow-up slice. | Closure audits for `resource-terrestrial-operation-contract` | Patched here because the terrestrial branch was already locally committed clean at `e4f99d9ef` before this geological branch was opened. |
 | Runtime ids remain unverified. | Placement materialization, stats closure, game log proof | No patch in this slice: later runtime proof must verify `GameInfo.Resources` ids before symbolic rows are materialized. |
-| FireTuner restart path remains a final-proof dependency. | Runtime-proof slices, game restart evidence, DRA handoff | Boundary already acknowledged in the downstream resource-runtime-proof boundary; final runtime proof must keep using that socket/API restart path. |
+| FireTuner restart path remains a final-proof dependency. | Runtime-proof slices, game restart evidence, DRA handoff | Boundary is owned by the `resource-runtime-proof` phase record; final runtime proof must keep using that socket/API restart path. |

--- a/openspec/changes/resource-geological-operation-contract/workstream/phase-record.md
+++ b/openspec/changes/resource-geological-operation-contract/workstream/phase-record.md
@@ -13,7 +13,8 @@ unverified runtime-id boundary.
   `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
 - Branch: `codex/resource-geological-operation-contract`
 - Parent slice: `codex/resource-terrestrial-operation-contract`
-- Studio/API pair for this worktree: `http://127.0.0.1:5174/`
+- Source Studio/API pair observed for this source slice:
+  `http://127.0.0.1:5174/`
 
 ## Agent Review
 
@@ -48,11 +49,13 @@ unverified runtime-id boundary.
 
 ## FireTuner Runtime-Proof Boundary
 
-- The downstream resource-runtime-proof boundary remains in place.
+- Runtime-proof closure is owned by
+  `openspec/changes/resource-runtime-proof/workstream/phase-record.md`.
 - This contract slice does not claim runtime proof and does not restart the
   game.
-- Final runtime proof must use the acknowledged FireTuner socket/API restart
-  boundary recorded in the note after restacking/integration checks.
+- Final runtime proof must use the FireTuner socket/API restart boundary
+  recorded in `openspec/changes/resource-runtime-proof/workstream/phase-record.md`
+  after restacking/integration checks.
 
 ## Verification So Far
 
@@ -72,6 +75,6 @@ unverified runtime-id boundary.
 
 ## Closure State
 
-- Committed locally via Graphite at `9c64100ac` and worktree was clean before
+- Committed locally via Graphite at `7864f13bb` and worktree was clean before
   `codex/resource-group-plan-rollup` opened above it. External Graphite
   submission/PR delivery remains unclaimed until submitted.

--- a/openspec/changes/resource-group-plan-rollup/design.md
+++ b/openspec/changes/resource-group-plan-rollup/design.md
@@ -52,15 +52,14 @@ The output artifact records:
 
 ## FireTuner Runtime-Proof Boundary
 
-The downstream resource-runtime-proof boundary remains the control record for
-final runtime proof. This contract slice does not claim runtime proof and does
-not restart the game.
+The `resource-runtime-proof` phase record owns final runtime proof. This
+contract slice does not claim runtime proof and does not restart the game.
 
 ## Follow-Up Repair Boundary
 
 This slice repairs stale geological closure metadata in a follow-up branch
 because `codex/resource-geological-operation-contract` was already locally
-committed clean at `9c64100ac` before this rollup branch was opened.
+committed clean at `7864f13bb` before this rollup branch was opened.
 
 ## Write Set
 

--- a/openspec/changes/resource-group-plan-rollup/workstream/phase-record.md
+++ b/openspec/changes/resource-group-plan-rollup/workstream/phase-record.md
@@ -12,7 +12,8 @@ boundary before later merge, stats, or runtime-proof slices.
   `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
 - Branch: `codex/resource-group-plan-rollup`
 - Parent slice: `codex/resource-geological-operation-contract`
-- Studio/API pair for this worktree: `http://127.0.0.1:5174/`
+- Source Studio/API pair observed for this source slice:
+  `http://127.0.0.1:5174/`
 
 ## Agent Review
 
@@ -30,11 +31,13 @@ boundary before later merge, stats, or runtime-proof slices.
 
 ## FireTuner Runtime-Proof Boundary
 
-- The downstream resource-runtime-proof boundary remains in place.
+- Runtime-proof closure is owned by
+  `openspec/changes/resource-runtime-proof/workstream/phase-record.md`.
 - This contract slice does not claim runtime proof and does not restart the
   game.
-- Final runtime proof must use the acknowledged FireTuner socket/API restart
-  boundary recorded in the note after restacking/integration checks.
+- Final runtime proof must use the FireTuner socket/API restart boundary
+  recorded in `openspec/changes/resource-runtime-proof/workstream/phase-record.md`
+  after restacking/integration checks.
 
 ## Follow-Up Repair
 
@@ -64,7 +67,6 @@ boundary before later merge, stats, or runtime-proof slices.
 
 ## Closure State
 
-- Source slice was committed in its original resource stack and replayed into
-  `codex/integrate-resource-ops-rollup` during the Graphite integration
-  workstream. This branch preserves the symbolic contract boundary and does
-  not claim runtime proof.
+- Committed locally via Graphite at `d4150abe8106` and worktree was clean
+  before `codex/resource-placement-diversity` opened above it. External Graphite
+  submission/PR delivery remains unclaimed until submitted.

--- a/openspec/changes/resource-placement-diversity/.openspec.yaml
+++ b/openspec/changes/resource-placement-diversity/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-placement-diversity/design.md
+++ b/openspec/changes/resource-placement-diversity/design.md
@@ -1,0 +1,56 @@
+# Resource Placement Diversity Design
+
+## Decision
+
+Change `placement/plan-resources` resource type selection from first-under-cap
+offset shifting to balanced offset selection.
+
+Tile candidate scoring remains unchanged. For each selected tile candidate, the
+planner still starts from the environmental signature's preferred resource
+offset, but it chooses the least-used candidate resource type, breaking ties by
+forward circular offset from the preferred type.
+
+## Root Cause Addressed
+
+The old algorithm used:
+
+```text
+preferred offset -> first type under per-type cap -> next type only after cap
+```
+
+On maps where many high-priority tiles share similar fertility, moisture,
+temperature, and aridity signatures, that fills a few adjacent resource ids
+before considering the rest of the adapter catalog. The per-type share cap
+limits a single id but does not guarantee broad catalog coverage.
+
+The new algorithm uses:
+
+```text
+preferred offset -> least-used type under cap -> nearest offset tie-break
+```
+
+That preserves environmental determinism while ensuring a map with enough
+placements spreads assignments across all available candidate resource ids.
+
+## Boundaries
+
+- This is a runtime-facing diversity repair for the transitional placement
+  planner.
+- It does not claim symbolic resource types are verified against runtime numeric
+  ids.
+- It does not use the symbolic group plans as materialization inputs yet.
+- It does not claim earthlike expected ranges are satisfied in-game.
+
+## Follow-Up Repair Boundary
+
+This slice repairs stale rollup closure metadata in a follow-up branch because
+`codex/resource-group-plan-rollup` was already locally committed clean at
+`d4150abe8106` before this branch was opened.
+
+## Write Set
+
+- `mods/mod-swooper-maps/src/domain/placement/ops/plan-resources/strategies/default.ts`
+- `mods/mod-swooper-maps/test/placement/plan-ops.test.ts`
+- `openspec/changes/resource-group-plan-rollup/**`
+- `openspec/changes/resource-placement-diversity/**`
+- `openspec/changes/resource-runtime-proof/**`

--- a/openspec/changes/resource-placement-diversity/proposal.md
+++ b/openspec/changes/resource-placement-diversity/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The symbolic resource contracts now prove that every official resource remains
+visible in planning records, but the runtime-facing placement planner can still
+collapse actual numeric resource assignments into a small adjacent subset. The
+current planner starts from an environmental signature offset and only shifts
+when the current type reaches a high share cap, so maps with similar candidate
+scores can repeatedly choose the same few resource ids.
+
+This slice repairs that distribution bottleneck without changing placement
+candidate scoring, adapter materialization, or runtime id proof.
+
+## Target Authority Refs
+
+- `openspec/changes/resource-distribution-root-cause`: only a minority of
+  resources appear in generated maps.
+- `openspec/changes/resource-group-plan-rollup`: symbolic group plans remain
+  visible upstream of runtime-facing placement.
+- `openspec/changes/resource-stage-architecture`: runtime behavior changes
+  must preserve evidence boundaries and avoid overclaiming hard proof.
+
+## What Changes
+
+- Balance numeric resource type assignment across the adapter-owned candidate
+  resource catalog.
+- Keep existing tile candidate scoring and spacing behavior.
+- Preserve deterministic ordering by preferring the nearest eligible offset when
+  per-type counts tie.
+- Add regression coverage showing uniform candidate pressure uses the full
+  candidate catalog with near-even counts.
+
+## Explicit Non-Goals
+
+- No symbolic-to-runtime id verification.
+- No placement materialization rewrite.
+- No stats hard gate or game restart proof.
+- No change to the expected-count research artifact.
+- No external Graphite submission/PR delivery claim.
+
+## Verification Gates
+
+- `bun test mods/mod-swooper-maps/test/placement/plan-ops.test.ts`
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-group-rollup-op-contract.test.ts test/resources/resource-geological-op-contract.test.ts test/resources/resource-terrestrial-op-contract.test.ts test/resources/resource-cultivated-op-contract.test.ts test/resources/resource-aquatic-op-contract.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `bun run openspec -- validate resource-placement-diversity --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/resource-placement-diversity/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-placement-diversity/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Resource Placement Planner Distributes Candidate Resource Types
+
+The transitional placement resource planner SHALL avoid collapsing numeric
+resource assignments into a small adjacent subset when the adapter candidate
+catalog contains more usable resource ids.
+
+#### Scenario: Candidate pressure is uniform
+- **WHEN** resource placement candidates have uniform environmental suitability
+- **AND** the target placement count is greater than the candidate resource
+  catalog size
+- **THEN** `placement/plan-resources` uses every candidate resource id
+- **AND** per-resource assignment counts differ by no more than one
+
+#### Scenario: Preferred offset remains deterministic
+- **WHEN** multiple resource ids have equal assignment counts
+- **THEN** the planner chooses by forward circular distance from the tile's
+  preferred environmental signature offset
+- **AND** repeated runs with the same inputs produce the same placements
+
+### Requirement: Resource Placement Diversity Does Not Claim Runtime Id Proof
+
+The diversity repair SHALL keep runtime id proof and symbolic resource
+materialization out of scope.
+
+#### Scenario: Runtime proof remains separate
+- **WHEN** resource type assignment becomes more diverse
+- **THEN** the planner still consumes adapter-owned numeric resource candidates
+- **AND** it does not claim `RESOURCE_*` symbolic ids are verified against
+  runtime numeric ids
+- **AND** final runtime proof still requires the FireTuner socket/API restart
+  boundary and bounded scripting-log evidence

--- a/openspec/changes/resource-placement-diversity/tasks.md
+++ b/openspec/changes/resource-placement-diversity/tasks.md
@@ -1,0 +1,20 @@
+## 1. Runtime-Facing Planner Repair
+
+- [x] 1.1 Preserve tile candidate scoring and spacing behavior.
+- [x] 1.2 Replace first-under-cap type selection with balanced type selection.
+- [x] 1.3 Preserve deterministic tie-breaking around the preferred offset.
+- [x] 1.4 Keep adapter candidate catalog ownership unchanged.
+
+## 2. Tests And Review
+
+- [x] 2.1 Add focused placement planner diversity regression coverage.
+- [x] 2.2 Run resource contract regression tests.
+- [x] 2.3 Run package check.
+- [x] 2.4 Run framed peer review and disposition accepted P1/P2 findings.
+
+## 3. Verification And Closure
+
+- [x] 3.1 Run OpenSpec validation.
+- [x] 3.2 Run `git diff --check`.
+- [x] 3.3 Commit the Graphite slice locally and leave the worktree clean, while
+  keeping external Graphite submission/PR delivery unclaimed.

--- a/openspec/changes/resource-placement-diversity/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-placement-diversity/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,7 @@
+# Downstream Realignment Ledger
+
+| Affected assumption | Scope | Disposition |
+| --- | --- | --- |
+| Transitional placement now balances numeric candidate resource ids. | Runtime-facing resource placement before symbolic id proof | Downstream stats/runtime proof should expect broader candidate id usage, but must not treat numeric ids as verified symbolic `RESOURCE_*` coverage yet. |
+| Rollup closure metadata is repaired in this follow-up slice. | Closure audits for `resource-group-plan-rollup` | Patched here because the rollup branch was already locally committed clean at `d4150abe8106` before this branch was opened. |
+| FireTuner restart path remains a final-proof dependency. | Runtime-proof slices, game restart evidence, DRA handoff | Boundary is owned by the `resource-runtime-proof` phase record; final runtime proof must keep using that socket/API restart path. |

--- a/openspec/changes/resource-placement-diversity/workstream/phase-record.md
+++ b/openspec/changes/resource-placement-diversity/workstream/phase-record.md
@@ -1,0 +1,66 @@
+# Phase Record: Resource Placement Diversity
+
+## Objective
+
+Repair the transitional runtime-facing resource planner so selected placements
+spread across the adapter-owned candidate resource catalog instead of repeatedly
+using only a few adjacent numeric ids under common environmental signatures.
+
+## Repo State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
+- Branch: `codex/resource-placement-diversity`
+- Parent slice: `codex/resource-group-plan-rollup`
+- Source Studio/API pair observed for this source slice:
+  `http://127.0.0.1:5174/`
+
+## Agent Review
+
+- Chandrasekhar: final scoped review. Outcome: no P1/P2 findings.
+  - P3 wording issue accepted: tie-break wording now says forward circular
+    distance to match implementation.
+  - P3 note issue accepted: rollup watcher-note evidence now describes the
+    rollup branch state as historical before placement-diversity opened above
+    it.
+
+## Follow-Up Repair
+
+- The watcher found stale rollup closure metadata after the rollup branch had
+  already been committed cleanly and this placement-diversity branch had been
+  opened.
+- This slice repairs the rollup task/phase record as a follow-up instead of
+  rewriting the already-clean downstack branch while placement-diversity work is
+  active.
+- Local commit closure is distinct from external Graphite submission/PR
+  delivery, which remains unclaimed until submitted.
+
+## FireTuner Runtime-Proof Boundary
+
+- Runtime-proof closure is owned by
+  `openspec/changes/resource-runtime-proof/workstream/phase-record.md`.
+- This slice does not claim runtime proof and does not restart the game.
+- Final runtime proof must use the FireTuner socket/API restart boundary
+  recorded in `openspec/changes/resource-runtime-proof/workstream/phase-record.md`
+  after restacking/integration checks.
+
+## Verification So Far
+
+- `bun test mods/mod-swooper-maps/test/placement/plan-ops.test.ts`
+  - Passed: 12 tests, 42 assertions.
+- `bun run --cwd mods/mod-swooper-maps test -- test/resources/resource-group-rollup-op-contract.test.ts test/resources/resource-geological-op-contract.test.ts test/resources/resource-terrestrial-op-contract.test.ts test/resources/resource-cultivated-op-contract.test.ts test/resources/resource-aquatic-op-contract.test.ts test/resources/resource-earthlike-expectations-artifact.test.ts`
+  - Passed: 42 tests, 1139 assertions.
+- `bun run --cwd mods/mod-swooper-maps check`
+  - Passed.
+- `bun run openspec -- validate resource-placement-diversity --strict`
+  - Passed.
+- `bun run openspec:validate`
+  - Passed: 28 items.
+- `git diff --check`
+  - Passed.
+
+## Closure State
+
+- Committed locally via Graphite at `bc6c328c1edb` and worktree was clean
+  before `codex/resource-diversity-stats-gate` opened above it. External
+  Graphite submission/PR delivery remains unclaimed until submitted.

--- a/openspec/changes/resource-placement-diversity/workstream/review-disposition-ledger.md
+++ b/openspec/changes/resource-placement-diversity/workstream/review-disposition-ledger.md
@@ -1,0 +1,7 @@
+# Review Disposition Ledger
+
+| Finding | Severity | Disposition | Notes |
+| --- | --- | --- | --- |
+| Final framed review | P2 | cleared | Chandrasekhar found no P1/P2 findings. |
+| Tie-break wording implied symmetric nearest offset | P3 | accepted, repaired | Spec/design now say forward circular distance, matching implementation. |
+| Rollup watcher note used present-tense branch wording | P3 | accepted, repaired | Note now describes the rollup branch state as historical before placement-diversity opened above it. |

--- a/openspec/changes/resource-runtime-proof/.openspec.yaml
+++ b/openspec/changes/resource-runtime-proof/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-05-31
+status: draft

--- a/openspec/changes/resource-runtime-proof/design.md
+++ b/openspec/changes/resource-runtime-proof/design.md
@@ -1,0 +1,125 @@
+# Resource Runtime Proof Design
+
+## Frame
+
+This slice is a runtime-evidence slice, not another local balance-tuning slice.
+The selected signal is live Civ7 execution after deploy and restart; the
+foreground is whether resource diversity survives in game; the exterior is
+earthlike tuning changes and generated-output hand edits.
+
+Structural alternative considered: rely only on local world-balance stats.
+Rejected because the resource workstream explicitly needs final FireTuner/Civ7
+runtime evidence through the downstack restart integration boundary.
+
+Falsifier: if the post-restart scripting-log window lacks a fresh
+`RESOURCE_PLACEMENT_V1` record or shows only a minority of placed resource
+types when enough placements exist, this runtime-proof slice cannot close.
+
+## Runtime Telemetry
+
+`place-resources` emits a single JSON log line after typed resource placement
+outcomes are available and only when the Civ7 `GameInfo.Resources` table exists:
+
+```text
+[SWOOPER_MOD] RESOURCE_PLACEMENT_V1 {...}
+```
+
+The payload records:
+
+- total planned, placed, rejected, and mismatch counts;
+- assignment diagnostics preserving the original preferred resource ids,
+  reassigned counts, unassigned preferred placement counts, legal candidate
+  count, and unassignable candidate ids;
+- unique planned and placed numeric resource type counts;
+- min/max placed count spread across placed resource ids;
+- runtime GameInfo catalog size;
+- unmapped placed numeric ids, if any;
+- compact planned, placed, and rejected numeric resource id lists; and
+- rejection reason totals.
+
+Full per-preferred-resource assignment diagnostics remain in the local
+placement proof artifact. The runtime log line is intentionally compact because
+Civ7 truncates long `Scripting.log` lines; the `version: 1` payload keeps the
+full-catalog proof parseable.
+
+The log line is intentionally runtime-only. Local tests exercise the formatter
+with injected GameInfo-like rows; Node test runs do not emit the runtime line.
+
+## Engine-Legal Assignment
+
+The first runtime proof attempt exposed a gap between local numeric diversity
+and Civ7 resource legality: the plan had 55 unique numeric ids, but the engine
+placed only 16 symbolic resource types because many preferred ids were tried on
+tiles where `ResourceBuilder.canHaveResource` rejected them.
+
+This slice keeps the plan as the deterministic density/priority source, then
+lets the product-effect materialization step assign resource ids to tiles that
+Civ7 reports as legal:
+
+1. Try to place each candidate resource id at least once on the highest-priority
+   unused legal tile.
+2. Preserve assignment diagnostics for the original preferred ids so rewritten
+   or unassignable ids cannot disappear from the proof artifact.
+3. Fill remaining planned slots with the least-used legal resource id for each
+   planned tile.
+4. If planned tiles cannot satisfy the target, scan remaining map tiles for
+   legal assignments before accepting a lower placed count.
+
+This is not a fallback to official generation. The step still places explicit
+typed intents through the adapter and keeps typed per-resource outcomes.
+
+## FireTuner Restart Boundary
+
+Current checked boundary:
+
+- branch: `codex/firetuner-socket-studio-restart`
+- commit: `bb39b3cf7 fix: submit Studio restarts through FireTuner socket`
+- expected changed files:
+  - `apps/mapgen-studio/vite.config.ts`
+  - `packages/cli/src/utils/firetunerSocket.ts`
+  - `packages/cli/test/utils/firetunerSocket.test.ts`
+
+The active resource stack is above that branch. Before claiming closure, this
+slice must re-check whether a successor downstack restart branch/commit has
+advanced, restack/integrate it if needed, and record the exact command/path
+used.
+
+## Runtime Command
+
+The direct CLI bridge command used for a preliminary probe was:
+
+```bash
+bun run --cwd packages/cli dev -- game restart --agent Codex-resource-runtime-proof --wait --timeout-ms 45000 --json
+```
+
+That command writes to the FireTuner bridge log through
+`packages/cli/src/commands/game/restart.ts` and
+`packages/cli/src/utils/firetunerBridge.ts`, producing a request line of the
+form:
+
+```text
+REQ <request-id> AGENT=Codex-resource-runtime-proof RUN Network.restartGame()
+```
+
+Final proof uses the downstack Studio socket/API path from
+`apps/mapgen-studio/vite.config.ts` by posting the unchanged repo-backed
+`swooper-earthlike` config to:
+
+```text
+POST http://127.0.0.1:5175/api/map-configs
+```
+
+That path deploys, calls `runFireTunerSocketCommand(...)`, receives
+`output: ["true"]`, and can optionally wait for a fresh `Scripting.log`
+MapGeneration window. In the final observed proof, Civ7 stopped at the
+front-end `Begin Game` confirmation boundary after the socket restart returned
+true; FireTuner UI focus plus a local Return keypress advanced that same
+restarted setup into the bounded runtime log window.
+
+## Write Set
+
+- `mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/**`
+- `mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts`
+- `openspec/changes/resource-diversity-stats-gate/**`
+- `openspec/changes/resource-runtime-proof/**`
+- `openspec/changes/resource-runtime-proof/workstream/phase-record.md`

--- a/openspec/changes/resource-runtime-proof/proposal.md
+++ b/openspec/changes/resource-runtime-proof/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+The resource stack now has local numeric diversity gates, but final closure needs
+live Civ7 evidence from the deployed mod and the current FireTuner socket/API
+restart path. Before this slice, the runtime log only proved the placement step
+completed; it did not emit enough resource-specific telemetry to prove the
+repaired diversity held in game.
+
+## Target Authority Refs
+
+- `openspec/changes/resource-distribution-planning`: runtime proof requires
+  deploy, the downstack FireTuner restart boundary, bounded logs, and resource
+  telemetry.
+- `openspec/changes/resource-diversity-stats-gate`: local numeric diversity
+  stats pass but do not by themselves prove runtime behavior.
+- `openspec/changes/resource-runtime-proof/workstream/phase-record.md`: final
+  runtime proof must verify the downstack restart branch, integrate/restack
+  successor restart work if needed, and use the FireTuner socket/API restart
+  path.
+
+## What Changes
+
+- Emit one bounded runtime telemetry line during the `place-resources` product
+  step: `[SWOOPER_MOD] RESOURCE_PLACEMENT_V1 ...`.
+- Assign planned resource ids to engine-legal tiles during product
+  materialization by checking Civ7 `canHaveResource` before placement, so local
+  numeric diversity does not collapse at runtime legality.
+- Include compact GameInfo resource id telemetry: planned/placed/rejected id
+  sets, assignment counts, unique placed type count, min/max placed count
+  spread, runtime catalog size, and unmapped placed ids.
+- Record the verified downstack restart branch/commit and exact restart
+  command/path used for runtime proof.
+- Repair the stale stats-gate closure record in this follow-up slice.
+
+## Explicit Non-Goals
+
+- No hand edits to generated `dist/`, `mod/`, or deployed generated artifacts.
+- No claim that external Graphite submission/PR delivery has occurred.
+- No sidecar control note is required after final restacked runtime-proof
+  evidence is recorded in the phase record.
+
+## Verification Gates
+
+- `bun test mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts`
+- `bun test mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts`
+- `bun run --cwd mods/mod-swooper-maps check`
+- `POST http://127.0.0.1:5175/api/map-configs` from the source resource
+  worktree Studio pair, which deployed with
+  `bun run --cwd mods/mod-swooper-maps deploy` and restarted through the
+  FireTuner socket/API path.
+- bounded inspection of
+  `~/Library/Application Support/Civilization VII/Logs/Scripting.log`
+- bounded inspection of
+  `~/Library/Application Support/Civilization VII/Logs/Modding.log`
+- `bun run openspec -- validate resource-runtime-proof --strict`
+- `bun run openspec:validate`
+- `git diff --check`

--- a/openspec/changes/resource-runtime-proof/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/resource-runtime-proof/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Resource Runtime Proof Emits Placement Telemetry
+
+Runtime resource proof SHALL include bounded resource-placement telemetry from
+the deployed Civ7 map-generation run.
+
+#### Scenario: Resource placement executes in Civ7
+- **WHEN** the deployed Swooper Maps standard recipe reaches
+  `placement.place-resources` in a Civ7 `MapGeneration` context
+- **THEN** the scripting log includes a single
+  `[SWOOPER_MOD] RESOURCE_PLACEMENT_V1` JSON line
+- **AND** the payload includes planned, placed, rejected, and mismatch totals
+- **AND** the payload includes compact planned, placed, and rejected numeric
+  resource id lists from the runtime `GameInfo.Resources` catalog
+- **AND** the payload includes unique placed type count and min/max placed
+  count spread
+- **AND** the payload remains parseable within Civ7 `Scripting.log` line-size
+  limits
+
+### Requirement: Resource Placement Materialization Uses Engine-Legal Assignments
+
+Resource placement materialization SHALL not treat a locally balanced numeric
+plan as sufficient when Civ7 rejects the preferred resource id for a tile.
+
+#### Scenario: Preferred resource id is illegal for a planned tile
+- **WHEN** the resource product step materializes planned resource placements
+- **THEN** it checks Civ7 resource legality before choosing the resource id for
+  that tile
+- **AND** it prioritizes covering each candidate resource id on a legal tile
+  when one exists
+- **AND** it fills remaining placements with least-used legal resource ids
+- **AND** the resource placement artifact preserves original preferred ids,
+  reassignment counts, unassigned preferred placements, legal candidate ids, and
+  unassignable candidate ids separately from final placed outcomes
+- **AND** it still records typed placement outcomes rather than invoking the
+  aggregate official resource generator
+
+### Requirement: Resource Runtime Proof Uses FireTuner Socket Restart Boundary
+
+Final resource runtime proof SHALL use the downstack FireTuner socket/API
+restart path and record its exact branch/commit and command/path.
+
+#### Scenario: Runtime proof is collected
+- **WHEN** final resource runtime proof is attempted
+- **THEN** the resource stack has verified whether
+  `codex/firetuner-socket-studio-restart` at `bb39b3cf7` or a successor is the
+  active downstack restart boundary
+- **AND** successor restart work is integrated/restacked before proof if it
+  exists
+- **AND** the restart request is issued through the Studio FireTuner socket/API
+  path that uses the downstack socket restart integration
+- **AND** the workstream records the exact restart command/path, request id,
+  socket response, branch, and commit used
+- **AND** if Civ7 stops at a front-end confirmation boundary after the socket
+  restart returns true, the workstream records that confirmation step separately
+  from the socket/API restart response

--- a/openspec/changes/resource-runtime-proof/tasks.md
+++ b/openspec/changes/resource-runtime-proof/tasks.md
@@ -1,0 +1,56 @@
+## 1. Runtime Telemetry
+
+- [x] 1.1 Add bounded `RESOURCE_PLACEMENT_V1` runtime telemetry after typed
+  resource placement outcomes are available.
+- [x] 1.2 Include GameInfo symbolic resource rows, per-resource counts, unique
+  placed type count, and placed-count spread.
+- [x] 1.3 Add focused formatter coverage without requiring GameInfo in local
+  tests.
+- [x] 1.4 Assign resource ids to engine-legal tiles during product
+  materialization so runtime legality does not collapse local numeric
+  diversity.
+- [x] 1.5 Preserve original preferred ids, reassignment counts, unassigned
+  preferred placements, legal candidate ids, and unassignable candidate ids in
+  the placement proof artifact.
+
+## 2. Stack And Watcher Boundary
+
+- [x] 2.1 Verify the resource stack is above
+  `codex/firetuner-socket-studio-restart` at `bb39b3cf7`.
+- [x] 2.2 Repair the stale stats-gate local commit-state record at
+  `3cecdf6b49a1`.
+- [x] 2.3 Re-check whether downstack FireTuner restart work advanced before
+  final runtime proof and restack/integrate successor work if needed.
+
+## 3. Runtime Proof
+
+These runtime tasks are historical source-branch proof from
+`codex/resource-runtime-proof@a674a2ee62f08cf1e1fce5d958eb52e2aab07dd7`.
+The integration branch replays the behavior and does not claim a fresh in-game
+run unless new bounded logs are added to the phase record.
+
+- [x] 3.1 Deploy the mod from the source resource worktree.
+- [x] 3.2 Restart Civ7 through the Studio FireTuner socket/API path with
+  agent `DRA-map-config-generation`.
+- [x] 3.3 Record the exact restart request id, command/path, branch/commit
+  boundary, and bridge response.
+- [x] 3.4 Inspect bounded `Scripting.log` and `Modding.log` windows after the
+  restart.
+- [x] 3.5 Confirm source `RESOURCE_PLACEMENT_V1` shows expected runtime resource
+  diversity, no mismatches, and near-even placed counts.
+- [x] 3.6 Record the failed first runtime proof attempt where live Civ7 placed
+  only 16 symbolic resource types from 55 planned candidate ids.
+- [x] 3.7 Record post-repair socket/API attempts that deployed successfully but
+  did not produce a fresh Civ7 MapGeneration window.
+- [x] 3.8 Record the current FireTuner/Civ7 runtime-state diagnosis for the
+  repeated `Network.restartGame()` false return.
+- [x] 3.9 Compact runtime telemetry so Civ7 `Scripting.log` preserves a
+  parseable full-catalog payload.
+
+## 4. Review And Closure
+
+- [x] 4.1 Run framed peer review and disposition accepted P1/P2 findings.
+- [x] 4.2 Run focused tests, package check, OpenSpec validation, and
+  `git diff --check`.
+- [x] 4.3 Commit the Graphite slice locally while keeping external Graphite
+  submission/PR delivery unclaimed until submitted.

--- a/openspec/changes/resource-runtime-proof/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-runtime-proof/workstream/downstream-realignment-ledger.md
@@ -1,0 +1,7 @@
+# Downstream Realignment Ledger
+
+| Affected assumption | Scope | Disposition |
+| --- | --- | --- |
+| Runtime logs did not expose per-resource placement diversity. | Final resource proof and DRA handoff | Patched with `RESOURCE_PLACEMENT_V1` telemetry emitted from `place-resources`. |
+| Stats-gate slice closure record was stale after local commit. | Closure audits for `resource-diversity-stats-gate` | Repaired in this follow-up slice at local committed-clean boundary `3cecdf6b49a1`. |
+| FireTuner restart path remains a final-proof dependency. | Runtime proof and submission handoff | Historical source proof from `codex/resource-runtime-proof@a674a2ee62f08cf1e1fce5d958eb52e2aab07dd7` used Studio API `POST http://127.0.0.1:5175/api/map-configs`, deployed the source resource worktree, and called the downstack FireTuner socket restart path at `bb39b3cf7`; recorded request id `studio-socket-mpttxk5i-x53`, command `Network.restartGame()`, response `["true"]`, the Civ7 `Begin Game` confirmation step, and bounded logs. The integration branch replays that behavior without claiming a fresh runtime run. |

--- a/openspec/changes/resource-runtime-proof/workstream/phase-record.md
+++ b/openspec/changes/resource-runtime-proof/workstream/phase-record.md
@@ -1,0 +1,227 @@
+# Phase Record: Resource Runtime Proof
+
+## Objective
+
+Prove the resource distribution stack in a live Civ7 run after deploy, using the
+current FireTuner socket/API restart boundary, and record resource-specific
+runtime telemetry from the scripting logs.
+
+## Integration Replay State
+
+- Integration worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-civ7-graphite-integration`
+- Integration branch: `codex/integrate-resource-runtime-proof`
+- Integration parent slice: `codex/integrate-resource-ops-rollup`
+- Source behavior/proof branch: `codex/resource-runtime-proof` at
+  `a674a2ee62f08cf1e1fce5d958eb52e2aab07dd7`.
+- This integration replay preserves the source branch's bounded runtime proof
+  as historical source proof. It does not claim a fresh in-game runtime run from
+  the integration branch; integration-local proof classes are tests, package
+  check, OpenSpec validation, and `git diff --check` unless a new runtime run is
+  recorded here.
+
+## Repo State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-civ7-graphite-integration`
+- Branch: `codex/integrate-resource-runtime-proof`
+- Parent slice: `codex/integrate-resource-ops-rollup`
+- Source downstack restart branch checked for historical runtime proof:
+  `codex/firetuner-socket-studio-restart`
+- Source downstack restart commit checked for historical runtime proof:
+  `bb39b3cf7 fix: submit Studio restarts through FireTuner socket`
+- Source Studio/API pair observed for historical runtime proof:
+  `http://127.0.0.1:5175/`
+
+## Verification So Far
+
+- `git show --stat --oneline codex/firetuner-socket-studio-restart -- ...`
+  confirmed `bb39b3cf7` and the expected socket restart files.
+- Source `gt log --no-interactive` showed `codex/resource-runtime-proof`
+  stacked above `codex/firetuner-socket-studio-restart`.
+- Initial ancestry check found the resource stack was still a sibling of
+  `codex/firetuner-socket-studio-restart`; this slice restacked the resource
+  branches on top of `bb39b3cf7` before runtime proof.
+- Post-restack `git merge-base --is-ancestor
+  codex/firetuner-socket-studio-restart HEAD` returned `0`.
+- Source restacked resource branch heads before runtime proof:
+  `codex/resource-distribution-planning` at `84f014445c5b`,
+  `codex/resource-distribution-root-cause` at `25ea6ea9a440`,
+  `codex/resource-stage-architecture` at `c447d4247645`,
+  `codex/resource-corpus-contract` at `526e7f7f6572`,
+  `codex/resource-earthlike-expectations` at `81c6dba2a010`,
+  `codex/resource-earthlike-expectations-artifact` at `3c9628b06313`,
+  `codex/resource-aquatic-operation-contract` at `10d683fb2cd9`,
+  `codex/resource-cultivated-operation-contract` at `dee212efc405`,
+  `codex/resource-terrestrial-operation-contract` at `e4f99d9ef5cc`,
+  `codex/resource-geological-operation-contract` at `7864f13bb9b1`,
+  `codex/resource-group-plan-rollup` at `d4150abe8106`,
+  `codex/resource-placement-diversity` at `bc6c328c1edb`, and
+  `codex/resource-diversity-stats-gate` at `3cecdf6b49a1`.
+- Framed peer review by Dalton found no P1/P2 blockers and cleared proceeding
+  to deploy plus FireTuner runtime proof.
+- Local gates before deploy and final record repair:
+  - `bun test mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts`
+    passed after compact telemetry repair: 3 tests, 7 assertions.
+  - `bun test mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts`
+    passed: 2 tests, 1768 assertions.
+  - `bun run --cwd mods/mod-swooper-maps check` passed.
+  - `bun run openspec -- validate resource-runtime-proof --strict` passed.
+  - `bun run openspec:validate` passed: 30 items.
+  - `git diff --check` passed.
+  - Framed telemetry review found no blocking code/test issue; accepted
+    non-blocking requests by asserting exact full-catalog id arrays and the
+    full prefixed log-line length.
+- `~/Library/Application Support/Civilization VII/Logs/Scripting.log` and
+  `Modding.log` are present.
+- FireTuner bridge log path is
+  `~/Parallels Tunnel/Sid Meier's Civilization VII Development Tools/Comms/civ7-firetuner-bridge.append-only.log`.
+
+## Runtime Proof State
+
+- Direct append-only bridge probe completed with
+  `civ7-restart-mptnr7fc-q81`; the Windows bridge submitted
+  `Network.restartGame()` at `2026-05-31T06:50:15`, but Civ7 did not produce a
+  fresh `Scripting.log` MapGeneration window from that bridge probe.
+- Studio socket/API restart path completed with request id
+  `studio-socket-mptnttrq-oom`, transport `firetuner-socket`, host
+  `127.0.0.1`, port `4318`, state `App UI`, and output `["true"]`.
+- The socket path observed a fresh `Scripting.log` MapGeneration window at
+  `2026-05-31T10:52:00.549Z`, start offset `24128`, and matched:
+  `Creating Context -  MapGeneration`,
+  `[SWOOPER_MOD] [recipe:standard] [50/50] ok mod-swooper-maps.standard.placement.placement`,
+  and `Destroying Context -  MapGeneration`.
+- Failed first resource telemetry proof:
+  - `Scripting.log` mtime: `2026-05-31 06:51:59 -0400`.
+  - `Modding.log` mtime: `2026-05-31 06:51:54 -0400`.
+  - `RESOURCE_PLACEMENT_V1` reported `plannedCount: 141`,
+    `placedCount: 24`, `rejectedCount: 117`, `mismatchCount: 0`,
+    `uniquePlannedTypes: 55`, `uniquePlacedTypes: 16`,
+    `runtimeCatalogCount: 55`, `unmappedPlacedResourceTypes: []`, and placed
+    count spread `1..3`.
+  - This failed the resource runtime proof because only 16 symbolic resource
+    types appeared live despite 55 planned candidate ids.
+- The materialization repair assigned resources to engine-legal tiles with
+  `canHaveResource` before placement, then reran socket/API runtime proof.
+- Socrates review found a P1 after that first repair: rewritten or unassignable
+  preferred resource ids disappeared from the proof artifact. The repair adds an
+  explicit `assignment` summary to `artifact:placement.resourcePlacementOutcomes`
+  so original preferred ids, reassigned counts, unassigned preferred placements,
+  legal candidate ids, and unassignable candidate ids remain visible.
+- A post-repair Studio socket/API proof attempt deployed the mod but returned
+  HTTP 500 with `Timed out waiting for fresh Civ7 MapGeneration completion in
+  Scripting.log`; `Scripting.log` and `Modding.log` did not advance beyond the
+  `06:51` run.
+- A repeat post-repair Studio socket/API proof attempt used
+  `POST http://127.0.0.1:5174/api/map-configs` with `verifyRestart: true`,
+  started at `2026-05-31T11:08:48.826Z`, deployed successfully from this
+  worktree, and returned HTTP 500 with `FireTuner socket restart returned:
+  false`.
+- After the repeat attempt, log mtimes remained:
+  - `Scripting.log`: `2026-05-31 06:51:59 -0400`.
+  - `Modding.log`: `2026-05-31 06:51:54 -0400`.
+- Continued diagnosis found a second Civ7 process showing
+  `AppHost initialized failed in 'WillFinishLaunching' Exit code: 1`; closing
+  that alert quit the duplicate failed process and left the original Civ7
+  process as the sole FireTuner socket owner.
+- The remaining Civ7 process still exposes FireTuner states `App UI` and
+  `Tuner`; direct `App UI` probes showed `Network.restartGame` exists, the
+  session reports `Network.isInSession === true`, one player, host player `0`,
+  local player `0`, map script
+  `{swooper-maps}/maps/swooper-earthlike.js`, non-network multiplayer,
+  non-saved-game, previous age count `0`, and pause-menu restart conditions
+  that appear restartable.
+- Despite that restartable-looking session state, direct socket execution of
+  `Network.restartGame()` returned `false` and did not advance `Scripting.log`
+  or `Modding.log`.
+- A bounded proof attempt through the second worktree Studio/API pair
+  `POST http://127.0.0.1:5175/api/map-configs` with `verifyRestart: true`
+  started at `2026-05-31T11:29:17.936Z`, deployed successfully from this
+  worktree, and returned HTTP 500 with `FireTuner socket restart returned:
+  false`.
+- Runtime telemetry compaction:
+  - Full per-symbolic-resource rows in `RESOURCE_PLACEMENT_V1` were too long
+    for Civ7 `Scripting.log`; the `08:22:35` post-repair payload proved
+    `148/148` placement but was truncated before JSON parse completed.
+  - Runtime logging now emits a compact `version: 1` payload with counts,
+    placed/planned/rejected resource id lists, unmapped placed ids, compact
+    assignment counts, and reason totals. Full per-preferred-resource
+    assignment diagnostics remain in the local placement proof artifact.
+- Final Studio socket/API runtime boundary:
+  - Downstack restart branch/commit used:
+    `codex/firetuner-socket-studio-restart` at
+    `bb39b3cf7 fix: submit Studio restarts through FireTuner socket`.
+  - Source Studio API endpoint used for historical proof:
+    `POST http://127.0.0.1:5175/api/map-configs`.
+  - Deploy/restart request without internal log verification started at
+    `2026-05-31T13:41:42.384Z` and finished at
+    `2026-05-31T13:42:42.355Z` with HTTP `200`.
+  - Deploy command/path:
+    `bun run --cwd mods/mod-swooper-maps deploy`, deploying to
+    `~/Library/Application Support/Civilization VII/Mods/mod-swooper-maps`.
+  - Restart response:
+    request id `studio-socket-mpttxk5i-x53`, agent
+    `DRA-map-config-generation`, command `Network.restartGame()`, transport
+    `firetuner-socket`, host `127.0.0.1`, port `4318`, state `App UI`
+    (`65535`), output `["true"]`.
+  - Civ7 then stopped at the front-end `Begin Game` confirmation boundary.
+    FireTuner socket-side DOM `click()` found the button but did not advance
+    generation; FireTuner socket focus followed by a local Return keypress did
+    advance the same restarted setup into map generation.
+  - Fresh bounded log evidence after that restart boundary:
+    - `Scripting.log` mtime: `2026-05-31 09:45:59 -0400`.
+    - `Modding.log` mtime: `2026-05-31 09:45:56 -0400`.
+    - `Scripting.log` lines `828`, `922`, and `987` show
+      `Creating Context -  MapGeneration`, compact
+      `RESOURCE_PLACEMENT_V1`, and `Destroying Context -  MapGeneration`.
+  - Final compact runtime payload length was `838` characters and parsed
+    successfully:
+    `plannedCount: 155`, `placedCount: 155`, `rejectedCount: 0`,
+    `mismatchCount: 0`, `uniquePlannedTypes: 49`,
+    `uniquePlacedTypes: 49`, placed count spread `1..8`,
+    `runtimeCatalogCount: 55`, `unmappedPlacedResourceTypes: []`,
+    `assignment.requestedPlannedCount: 155`,
+    `assignment.assignedCount: 155`, `assignment.reassignedCount: 134`,
+    `assignment.unassignedPreferredCount: 20`,
+    `assignment.candidateResourceTypeCount: 55`,
+    `assignment.legalCandidateResourceTypeCount: 49`, and
+    `assignment.unassignableResourceTypes: [5, 14, 15, 23, 31, 37]`.
+  - The placed resource id set was
+    `[0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 16, 17, 18, 19, 20, 21, 22,
+    24, 25, 26, 27, 28, 29, 30, 32, 33, 34, 35, 36, 38, 39, 40, 41, 42, 43,
+    44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54]`.
+  - This satisfies the resource-distribution runtime proof for engine-legal
+    runtime ids: all requested placements were placed, no rejections or
+    mismatches remained, no placed runtime resource id was unmapped, and the
+    only absent catalog ids were recorded as unassignable for that map run.
+
+## Integration Replay Verification
+
+- On `2026-06-01`, `codex/integrate-resource-runtime-proof` replayed the source
+  behavior above `codex/integrate-resource-ops-rollup` and verified:
+  - `bun test mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts mods/mod-swooper-maps/test/placement/plan-ops.test.ts mods/mod-swooper-maps/test/pipeline/world-balance-stats.test.ts`
+  - `bun test mods/mod-swooper-maps/test/resources/resource-corpus-contract.test.ts mods/mod-swooper-maps/test/resources/resource-corpus-artifact.test.ts mods/mod-swooper-maps/test/resources/resource-earthlike-expectations-artifact.test.ts mods/mod-swooper-maps/test/resources/resource-aquatic-op-contract.test.ts mods/mod-swooper-maps/test/resources/resource-cultivated-op-contract.test.ts mods/mod-swooper-maps/test/resources/resource-terrestrial-op-contract.test.ts mods/mod-swooper-maps/test/resources/resource-geological-op-contract.test.ts mods/mod-swooper-maps/test/resources/resource-group-rollup-op-contract.test.ts`
+  - `bun test mods/mod-swooper-maps/test/config/standard-authoring-surface-guards.test.ts apps/mapgen-studio/test/config/standardRecipeArtifactGuards.test.ts`
+  - `bun run --cwd mods/mod-swooper-maps check`
+  - strict OpenSpec validation for `resource-distribution-root-cause`,
+    `resource-placement-diversity`, `resource-diversity-stats-gate`,
+    `resource-runtime-proof`, `resource-aquatic-operation-contract`,
+    `resource-cultivated-operation-contract`,
+    `resource-terrestrial-operation-contract`,
+    `resource-geological-operation-contract`, and
+    `resource-group-plan-rollup`
+  - `bun run openspec:validate`
+  - `git diff --check`
+- No fresh in-game runtime run was performed from the integration branch.
+
+## Closure State
+
+- Source runtime behavior was locally committed via Graphite on
+  `codex/resource-runtime-proof` at
+  `a674a2ee62f08cf1e1fce5d958eb52e2aab07dd7`; external Graphite
+  submission/PR delivery remains unclaimed until `gt submit` / PR evidence
+  exists.
+- Historical runtime proof is satisfied on the source resource stack above
+  `bb39b3cf7` using the Studio FireTuner socket/API path plus the observed
+  Civ7 `Begin Game` confirmation step. The integration branch replays that
+  behavior above the Studio stack and keeps fresh in-game proof unclaimed.

--- a/openspec/changes/resource-runtime-proof/workstream/review-disposition-ledger.md
+++ b/openspec/changes/resource-runtime-proof/workstream/review-disposition-ledger.md
@@ -1,0 +1,6 @@
+# Review Disposition Ledger
+
+| Finding | Severity | Disposition | Notes |
+| --- | --- | --- | --- |
+| Dalton framed review | P2 | cleared for source branch | No P1/P2 blockers in the source branch. Historical source runtime telemetry at `2026-05-31 09:45:59` closed the source residual risk: compact `RESOURCE_PLACEMENT_V1` parsed successfully, reported `155/155` placed, `0` rejected, `0` mismatches, and no unmapped placed ids. The integration branch replays this behavior and does not claim fresh in-game runtime proof. |
+| Rewritten or unassignable planned resource ids disappear from the proof artifact | P1 | accepted, repaired | Added assignment diagnostics preserving original preferred ids, reassignment counts, unassigned preferred placements, legal candidate ids, and unassignable candidate ids separately from final placement outcomes; final runtime payload includes compact assignment counts and unassignable ids `[5, 14, 15, 23, 31, 37]`. |

--- a/openspec/changes/resource-terrestrial-operation-contract/workstream/downstream-realignment-ledger.md
+++ b/openspec/changes/resource-terrestrial-operation-contract/workstream/downstream-realignment-ledger.md
@@ -3,6 +3,6 @@
 | Affected assumption | Scope | Disposition |
 | --- | --- | --- |
 | Terrestrial resources now have a symbolic group-planning op surface. | Future resource group ops and `plan-resource-groups` stage work | Patch-needed downstream: later slices should preserve per-resource rows, strategy-owned group coverage, row lanes, and explicit proxy gaps. |
-| Cultivated closure metadata is repaired in this follow-up slice. | Closure audits for `resource-cultivated-operation-contract` | Patched here because the cultivated branch was already locally committed clean at `3494d91de` before the watcher found stale records. |
+| Cultivated closure metadata is repaired in this follow-up slice. | Closure audits for `resource-cultivated-operation-contract` | Patched here because the cultivated branch was already locally committed clean at `dee212efc` before the watcher found stale records. |
 | Runtime ids remain unverified. | Placement materialization, stats closure, game log proof | No patch in this slice: later runtime proof must verify `GameInfo.Resources` ids before symbolic rows are materialized. |
 | FireTuner restart path remains a final-proof dependency. | Runtime-proof slices, game restart evidence, DRA handoff | Boundary acknowledged; final runtime proof must restack/integrate downstack restart work and record exact branch/commit plus restart command/path. |

--- a/openspec/changes/resource-terrestrial-operation-contract/workstream/phase-record.md
+++ b/openspec/changes/resource-terrestrial-operation-contract/workstream/phase-record.md
@@ -12,7 +12,8 @@ proxy visibility, warning-only proof, and the unverified runtime-id boundary.
   `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-resource-distribution-workstream`
 - Branch: `codex/resource-terrestrial-operation-contract`
 - Parent slice: `codex/resource-cultivated-operation-contract`
-- Studio/API pair for this worktree: `http://127.0.0.1:5174/`
+- Source Studio/API pair observed for this source slice:
+  `http://127.0.0.1:5174/`
 
 ## Agent Review
 
@@ -40,7 +41,8 @@ proxy visibility, warning-only proof, and the unverified runtime-id boundary.
 
 ## FireTuner Runtime-Proof Boundary
 
-- The downstream resource-runtime-proof boundary remains in place and this slice acknowledges it.
+- Runtime-proof closure is owned by
+  `openspec/changes/resource-runtime-proof/workstream/phase-record.md`.
 - This contract slice does not claim runtime proof and does not restart the
   game.
 - Final runtime proof must verify the downstack restart branch/commit,
@@ -63,6 +65,6 @@ proxy visibility, warning-only proof, and the unverified runtime-id boundary.
 
 ## Closure State
 
-- Committed locally via Graphite at `292629dce` and worktree was clean before
+- Committed locally via Graphite at `e4f99d9ef` and worktree was clean before
   `codex/resource-geological-operation-contract` opened above it. External
   Graphite submission/PR delivery remains unclaimed until submitted.


### PR DESCRIPTION
This PR delivers resource placement diversity and runtime proof for the Swooper Maps mod.

**Placement diversity repair:** The `plan-resources` default strategy previously selected resource types using a first-under-cap offset shift, which caused maps with similar environmental signatures to repeatedly assign the same few adjacent numeric resource ids. The selection logic is replaced with a balanced offset chooser (`chooseBalancedResourceOffset`) that picks the least-used candidate resource type and breaks ties by forward circular distance from the preferred environmental offset. A regression test confirms that uniform candidate pressure distributes placements across the full catalog with per-type counts differing by at most one.

**Engine-legal assignment:** A new `assignResourceIntents` step runs during product materialization and checks Civ7 `canHaveResource` before committing a resource id to a tile. It first ensures every candidate resource id is placed on at least one legal tile, then fills remaining planned slots with the least-used legal id, and finally scans remaining map tiles if planned tiles are exhausted. This prevents local numeric diversity from collapsing at runtime legality boundaries.

**Placement artifact diagnostics:** The `resourcePlacementOutcomes` artifact is extended with per-resource-type breakdowns of planned, placed, rejected, and mismatch counts alongside per-reason rejection totals. A new `assignment` field records the original preferred resource ids, reassignment counts, unassigned preferred placements, legal candidate ids, and unassignable candidate ids separately from final placement outcomes so rewritten or illegal ids remain visible in the proof artifact.

**Runtime telemetry:** After typed placement outcomes are available, `place-resources` emits a single compact `[SWOOPER_MOD] RESOURCE_PLACEMENT_V1` JSON line when the Civ7 `GameInfo.Resources` table is present. The payload is intentionally compact to stay within Civ7 `Scripting.log` line-size limits while still recording planned/placed/rejected counts, unique placed type count, min/max placed count spread, runtime catalog size, compact resource id lists, assignment diagnostics, and rejection reason totals. Tests verify the formatter stays under 900 characters for a full 55-resource catalog.

**World-balance stats gates:** The stats helper gains `resourceUniquePlannedTypes`, `resourceUniquePlacedTypes`, `resourcePlacedCountMinByType`, and `resourcePlacedCountMaxByType` fields. Shipped map identity tests now assert that every available numeric candidate id is used when enough placements exist and that per-id placed counts remain near-even.

**Runtime proof:** Live Civ7 evidence from the source resource stack confirmed `155/155` placements, zero rejections, zero mismatches, 49 unique placed resource types out of 55 candidates, and no unmapped placed ids. The six absent catalog ids (`[5, 14, 15, 23, 31, 37]`) were recorded as unassignable for that map run.