### PR TITLE
refactor(op): consolidate `StrategyConfigSchemas`, `StrategySelection`, and `CompileErrorItem` into canonical type modules

### DIFF
--- a/packages/mapgen-core/src/authoring/op/contract.ts
+++ b/packages/mapgen-core/src/authoring/op/contract.ts
@@ -2,10 +2,10 @@ import type { Static, TSchema, TUnsafe } from "typebox";
 
 import { applySchemaConventions } from "../schema.js";
 
-import type { DomainOpKind, OpTypeBag } from "./types.js";
+import type { DomainOpKind, OpTypeBag, StrategyConfigSchemas } from "./types.js";
 import { buildOpEnvelopeSchema } from "./envelope.js";
 
-export type StrategyConfigSchemas = Readonly<Record<string, TSchema>>;
+export type { StrategyConfigSchemas } from "./types.js";
 
 type EnsureSchemaValues<T> = {
   readonly [K in keyof T]: T[K] extends TSchema ? T[K] : never;

--- a/packages/mapgen-core/src/authoring/op/envelope.ts
+++ b/packages/mapgen-core/src/authoring/op/envelope.ts
@@ -1,6 +1,6 @@
 import { Type, type TSchema } from "typebox";
 
-import type { StrategyConfigSchemas } from "./contract.js";
+import type { StrategyConfigSchemas } from "./types.js";
 import { buildDefaultConfigValue } from "./defaults.js";
 
 export type OpEnvelopeBuildResult = Readonly<{

--- a/packages/mapgen-core/src/authoring/op/index.ts
+++ b/packages/mapgen-core/src/authoring/op/index.ts
@@ -3,9 +3,9 @@ export { createOp } from "./create.js";
 export { createStrategy } from "./strategy.js";
 export { opRef } from "./ref.js";
 
-export type { OpContract, StrategyConfigSchemas } from "./contract.js";
+export type { OpContract } from "./contract.js";
 export type { OpContractLike, OpStrategyId, OpTypeBag, OpTypeBagOf } from "./types.js";
-export type { DomainOp, DomainOpKind } from "./types.js";
+export type { DomainOp, DomainOpKind, StrategyConfigSchemas } from "./types.js";
 export type { OpRef } from "./ref.js";
 export type {
   OpStrategy,

--- a/packages/mapgen-core/src/authoring/op/strategy.ts
+++ b/packages/mapgen-core/src/authoring/op/strategy.ts
@@ -44,13 +44,4 @@ export function createStrategy<
   return impl;
 }
 
-type StrategyConfigSchemaOf<T> = T extends { config: infer C extends TSchema } ? C : never;
-
-export type StrategySelection<
-  Strategies extends Record<string, { config: TSchema }>,
-> = {
-  [K in keyof Strategies & string]: Readonly<{
-    strategy: K;
-    config: Static<StrategyConfigSchemaOf<Strategies[K]>>;
-  }>;
-}[keyof Strategies & string];
+export type { StrategySelection } from "./types.js";

--- a/packages/mapgen-core/src/authoring/op/types.ts
+++ b/packages/mapgen-core/src/authoring/op/types.ts
@@ -1,7 +1,6 @@
 import type { Static, TSchema, TUnsafe } from "typebox";
 
 import type { NormalizeContext } from "@mapgen/engine/index.js";
-import type { StrategySelection } from "./strategy.js";
 
 // Allow ops with specific input/config types to flow through generic registries.
 type BivariantCallback<Args extends unknown[], Return> = {
@@ -9,6 +8,18 @@ type BivariantCallback<Args extends unknown[], Return> = {
 }["bivarianceHack"];
 
 type StrategiesLike = Readonly<Record<string, TSchema>>;
+type RuntimeStrategiesLike = Readonly<Record<string, { config: TSchema }>>;
+
+type StrategyConfigSchemaOf<T> = T extends { config: infer C extends TSchema } ? C : never;
+
+export type StrategyConfigSchemas = Readonly<Record<string, TSchema>>;
+
+export type StrategySelection<Strategies extends RuntimeStrategiesLike> = {
+  [K in keyof Strategies & string]: Readonly<{
+    strategy: K;
+    config: Static<StrategyConfigSchemaOf<Strategies[K]>>;
+  }>;
+}[keyof Strategies & string];
 
 export type OpContractLike = Readonly<{
   input: TSchema;
@@ -43,7 +54,7 @@ export type OpTypeBagOf<TContract extends OpContractLike> = OpTypeBag<
   TContract["strategies"]
 >;
 
-export type OpConfigSchema<Strategies extends Record<string, { config: TSchema }>> = TUnsafe<
+export type OpConfigSchema<Strategies extends RuntimeStrategiesLike> = TUnsafe<
   StrategySelection<Strategies>
 >;
 
@@ -69,7 +80,7 @@ export type DomainOpKind = "plan" | "compute" | "score" | "select";
 export type DomainOp<
   InputSchema extends TSchema,
   OutputSchema extends TSchema,
-  Strategies extends Record<string, { config: TSchema }>,
+  Strategies extends RuntimeStrategiesLike,
   Id extends string = string,
 > = Readonly<{
   kind: DomainOpKind;

--- a/packages/mapgen-core/src/compiler/errors.ts
+++ b/packages/mapgen-core/src/compiler/errors.ts
@@ -1,0 +1,19 @@
+export type CompileErrorCode =
+  | "config.invalid"
+  | "stage.compile.failed"
+  | "stage.unknown-step-id"
+  | "op.config.invalid"
+  | "op.missing"
+  | "step.normalize.failed"
+  | "op.normalize.failed"
+  | "normalize.not.shape-preserving";
+
+export type CompileErrorItem = Readonly<{
+  code: CompileErrorCode;
+  path: string;
+  message: string;
+  stageId?: string;
+  stepId?: string;
+  opKey?: string;
+  opId?: string;
+}>;

--- a/packages/mapgen-core/src/compiler/normalize.ts
+++ b/packages/mapgen-core/src/compiler/normalize.ts
@@ -5,7 +5,7 @@ import type { DomainOpCompileAny, OpsById } from "../authoring/bindings.js";
 import { bindCompileOps, OpBindingError } from "../authoring/bindings.js";
 import { applySchemaDefaults } from "../authoring/schema.js";
 import type { StepOpsDecl } from "../authoring/step/ops.js";
-import type { CompileErrorItem } from "./recipe-compile.js";
+import type { CompileErrorItem } from "./errors.js";
 
 export type NormalizeCtx<TEnv = unknown, TKnobs = unknown> = Readonly<{ env: TEnv; knobs: TKnobs }>;
 

--- a/packages/mapgen-core/src/compiler/recipe-compile.ts
+++ b/packages/mapgen-core/src/compiler/recipe-compile.ts
@@ -3,28 +3,11 @@ import type { TSchema } from "typebox";
 import type { DomainOpCompileAny } from "../authoring/bindings.js";
 import type { CompiledRecipeConfigOf, RecipeConfigInputOf } from "../authoring/types.js";
 import type { StepOpsDecl } from "../authoring/step/ops.js";
+import type { CompileErrorItem } from "./errors.js";
 import type { NormalizeCtx } from "./normalize.js";
 import { normalizeOpsTopLevel, normalizeStrict, prefillOpDefaults } from "./normalize.js";
 
-export type CompileErrorCode =
-  | "config.invalid"
-  | "stage.compile.failed"
-  | "stage.unknown-step-id"
-  | "op.config.invalid"
-  | "op.missing"
-  | "step.normalize.failed"
-  | "op.normalize.failed"
-  | "normalize.not.shape-preserving";
-
-export type CompileErrorItem = Readonly<{
-  code: CompileErrorCode;
-  path: string;
-  message: string;
-  stageId?: string;
-  stepId?: string;
-  opKey?: string;
-  opId?: string;
-}>;
+export type { CompileErrorCode, CompileErrorItem } from "./errors.js";
 
 export class RecipeCompileError extends Error {
   readonly errors: CompileErrorItem[];

--- a/packages/sdk/src/nodes/ModifierRequirementNode.ts
+++ b/packages/sdk/src/nodes/ModifierRequirementNode.ts
@@ -3,7 +3,6 @@ import { REQUIREMENT } from "../constants";
 
 import { BaseNode } from "./BaseNode";
 import { ArgumentNode, TArgumentNode } from "./ArgumentNode";
-import { TModifierNode } from "./ModifierNode";
 
 export type TModifierRequirementNode = Pick<ModifierRequirementNode,
     "type" |
@@ -21,7 +20,7 @@ export class ModifierRequirementNode extends BaseNode<TModifierRequirementNode> 
         this.fill(payload);
     }
 
-    fill = (payload: Partial<TModifierNode> = {}) => {
+    fill = (payload: Partial<TModifierRequirementNode> = {}) => {
         for (const [key, value] of Object.entries(payload)) {
             if (this.hasOwnProperty(key)) {
                 this[key] = value;


### PR DESCRIPTION
Moves `StrategyConfigSchemas` and `StrategySelection` type definitions into `types.ts` as the canonical source, replacing the previous definitions scattered across `contract.ts` and `strategy.ts` with re-exports. This resolves a circular dependency where `types.ts` was importing `StrategySelection` from `strategy.ts` while `strategy.ts` depended on types from `types.ts`.

Also extracts `CompileErrorCode` and `CompileErrorItem` from `recipe-compile.ts` into a dedicated `errors.ts` module, with `recipe-compile.ts` re-exporting them for backwards compatibility. `normalize.ts` is updated to import directly from the new `errors.ts`.

Fixes a bug in `ModifierRequirementNode` where the `fill` method accepted `Partial<TModifierNode>` instead of the correct `Partial<TModifierRequirementNode>`.