### PR TITLE
docs(civ7-systematic-workstream): add vocabulary block, gate-number citations, companion routing split, worked floodplain example, and pre-OpenSpec N/A handling

### DIFF
--- a/.agents/skills/civ7-systematic-workstream/SKILL.md
+++ b/.agents/skills/civ7-systematic-workstream/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: civ7-systematic-workstream
 description: |
-  Use in the Civ7 Modding Tools repo when running a systematic, evidence-grounded domain workstream that must enumerate a canonical corpus, derive physical/ecological/gameplay/surface expectations, translate each entity/group/action surface into architecture-aligned slices, verify local statistics, prove runtime/log/readback behavior, coordinate reviewer agents, and close cleanly. Trigger phrases include "systematic workstream", "evidence-grounded pass", "canonical corpus", "expected ranges", "resource distribution", "feature placement", "biome pass", "brushing pass", "terrain/tile-type audit", "runtime proof", and "clean Graphite closure". Do not use for ordinary one-off debugging or a bounded OpenSpec phase that does not need corpus-wide systematic evidence.
+  Use in the Civ7 Modding Tools repo when running a systematic, evidence-grounded domain workstream that must enumerate a canonical corpus, derive physical/ecological/gameplay/surface expectations, translate each entity/group/action surface into architecture-aligned slices, verify local statistics, prove runtime/log/readback behavior, coordinate reviewer agents, and close cleanly. Trigger phrases include "systematic workstream", "evidence-grounded pass", "canonical corpus", "expected ranges", "resource distribution pass", "feature placement audit", "biome pass", "brushing pass", "terrain/tile-type audit", "runtime proof", and "clean Graphite closure". Do not use for ordinary one-off debugging, generic project management, or a bounded OpenSpec phase that does not need corpus-wide systematic evidence.
 ---
 
 # Civ7 Systematic Workstream
@@ -18,6 +18,18 @@ This skill owns the systematic evidence loop. It composes with
 `civ7-open-spec-workstream`, `civ7-architecture-authority`,
 `civ7-product-authority`, and `civ7-operational-debugging`; it does not replace
 them.
+
+## Vocabulary
+
+- **Gate**: one of the 12 numbered method steps below. Cite gate numbers in
+  phase records so the next operator sees the current step immediately.
+- **Slice**: a bounded implementation unit mapped to one OpenSpec change and one
+  Graphite branch.
+- **Phase**: the OpenSpec-workstream loop term inherited from
+  `civ7-open-spec-workstream` (a slice plus its review/closure records).
+- **Proof class**: a kind of claim (OpenSpec validation, tests, local stats,
+  deploy, runtime logs, Graphite submit, PR, product proof). A **proof label**
+  is the exact string you write down asserting one proof class is satisfied.
 
 ## When To Use
 
@@ -38,10 +50,10 @@ them.
 
 ## Companion Skill Routing
 
-Load only when the current gate needs them:
+Load only when the current gate needs them.
 
-- `framing-design`: objective, hard core, exterior, falsifier, and handoff frame.
-- `team-design`: multi-agent evidence/review team structure.
+Repo-local companions (always available in this repo under `.agents/skills/`):
+
 - `civ7-open-spec-workstream`: phase records, OpenSpec changes, review ledgers,
   downstream realignment, and handoff packets.
 - `civ7-architecture-authority`: owner, stage, step, artifact, adapter, and
@@ -52,39 +64,33 @@ Load only when the current gate needs them:
   proof.
 - `dra-structural-watcher`: watcher notes, closure drift, and stack/proof audits.
 
+External/global companions (live in the agent skill home, not in this repo; may
+be absent in some runtimes — use the inline fallback if so):
+
+- `framing-design`: objective, hard core, exterior, falsifier, and handoff
+  frame. Fallback if absent: fill the **Frame** block in
+  `assets/workstream-record.md` directly.
+- `team-design`: multi-agent evidence/review team structure. Fallback if absent:
+  use `references/team-review-lanes.md`.
+
 ## Default Workflow
 
-1. **Frame the workstream.** Name objective, non-goals, hard core, exterior,
-   falsifier, proof gates, write set, protected paths, and closure boundaries.
-2. **Isolate repo state.** Check worktree, branch, Graphite stack, dirty files,
-   downstack dependencies, and generated/read-only paths before editing.
-3. **Diagnose before designing.** Use code, history, stats, tests, logs, official
-   data, and Narsil where useful to prove the observed failure mode.
-4. **Extract the canonical corpus.** Enumerate entities, action surfaces, or
-   materialization targets from official/local authority, with IDs, sources,
-   coverage state, and uncertainty.
-5. **Group the corpus.** Slice by shared inputs, constraints, artifacts,
-   architecture owners, consumers, and verification shape. Keep per-entity
-   obligations visible.
-6. **Predeclare expected behavior.** Record physical, ecological, earthlike,
-   gameplay, surface-legality, readback, or effect-matrix expectations and
-   expected ranges before tuning or implementation.
-7. **Translate into architecture.** Design operations, contracts, artifacts,
-   score layers, planners, projections, or mutation surfaces in the owning
-   boundary.
-8. **Implement or plan slices.** Map each coherent slice to OpenSpec/Graphite
-   work with explicit write sets, review lanes, tests, and stop conditions.
-9. **Verify local statistics.** Compare observed stats against predeclared
-   ranges over stable seeds/configs; prove coverage, diversity, legality,
-   rejection/mismatch counts, and spread.
-10. **Prove runtime behavior.** When runtime proof is required, deploy/restart
-    through the current canonical path and inspect fresh bounded logs tied to
-    exact branch, commit, command/API path, request id, timestamps, and payloads.
-11. **Review as a phase gate.** Use framed peer agents to review specs, code,
-    stats, runtime evidence, closure records, and downstream realignment.
-12. **Close deliberately.** Complete tasks, disposition P1/P2 findings, record
-    proof classes, update stale records, commit via Graphite, and leave the
-    worktree clean or write a precise handoff.
+The 12 gates, one line each. Open `references/method-loop.md` for the full
+procedure, sub-steps, and per-domain examples of any gate. Cite the gate number
+in the phase record so the next operator sees the current step immediately.
+
+1. **Frame the workstream** — objective, non-goals, hard core, exterior, falsifier, proof gates, write set, closure boundaries.
+2. **Isolate repo state** — worktree, branch, Graphite stack, dirty files, downstack deps, generated/read-only paths.
+3. **Diagnose before designing** — prove the observed failure mode from code, history, stats, tests, logs, official data.
+4. **Extract the canonical corpus** — every entity, action surface, or materialization target with IDs, sources, coverage, uncertainty.
+5. **Group the corpus** — by shared inputs, constraints, owners, consumers, and verification shape; keep per-entity obligations visible.
+6. **Predeclare expected behavior** — baselines and expected ranges/legality before tuning.
+7. **Translate into architecture** — operations, contracts, artifacts, planners, projections, or mutation surfaces in the owning boundary.
+8. **Implement or plan slices** — one coherent slice per OpenSpec change / Graphite branch, with write set, review lanes, tests, stop conditions.
+9. **Verify local statistics** — observed vs predeclared over stable seeds/configs; coverage, diversity, legality, rejection/mismatch, spread.
+10. **Prove runtime behavior** — when required, deploy/restart via the current canonical path; bound fresh logs to exact branch/commit/path/request/timestamp/payload.
+11. **Review as a phase gate** — framed peer agents review specs, code, stats, runtime evidence, closure records, downstream realignment.
+12. **Close deliberately** — complete tasks, disposition P1/P2, label proof classes separately, fix stale records, commit via Graphite, clean worktree or precise handoff.
 
 ## Reference Map
 
@@ -137,7 +143,8 @@ Load only when the current gate needs them:
 1. Copy `assets/workstream-record.md` into `openspec/changes/<change-id>/workstream/`
    for an OpenSpec implementation slice, or into `docs/projects/<project>/...`
    for pre-OpenSpec planning. Defer to `civ7-open-spec-workstream` if unsure.
-2. Frame the objective with `framing-design`, then check `git status`,
+2. Frame the objective with `framing-design` if available, otherwise fill the
+   Frame block in `assets/workstream-record.md`; then check `git status`,
    `git worktree list`, and `gt log --no-interactive`.
 3. Spawn only useful peer agents with framed prompts and explicit evidence
    outputs; keep the owner responsible for synthesis.

--- a/.agents/skills/civ7-systematic-workstream/assets/closure-checklist.md
+++ b/.agents/skills/civ7-systematic-workstream/assets/closure-checklist.md
@@ -2,11 +2,20 @@
 
 ## Records
 
+The `tasks.md`, `phase-record.md`, `review-disposition-ledger.md`,
+`downstream-realignment-ledger.md`, and `next-packet.md` templates are owned by
+`civ7-open-spec-workstream` (see its `assets/`); copy them from there for an
+OpenSpec implementation slice. For a pre-OpenSpec planning slice that has no
+OpenSpec change, mark the OpenSpec-only rows (downstream realignment, next
+packet) `N/A` rather than leaving them unchecked.
+
 - [ ] `tasks.md` reflects actual task state.
 - [ ] `phase-record.md` reflects branch, commit, proof, and closure state.
 - [ ] `review-disposition-ledger.md` has no open accepted P1/P2 blockers.
-- [ ] `downstream-realignment-ledger.md` records patch/no-patch/deferred state.
-- [ ] `next-packet.md` is absent, accurate, or explicitly marks remaining work.
+- [ ] `downstream-realignment-ledger.md` records patch/no-patch/deferred state
+  (or `N/A` for a non-OpenSpec planning slice).
+- [ ] `next-packet.md` is absent, accurate, or explicitly marks remaining work
+  (or `N/A` for a non-OpenSpec planning slice).
 - [ ] Watcher notes are acknowledged or preserved until their boundary is met.
 
 ## Gates

--- a/.agents/skills/civ7-systematic-workstream/assets/corpus-ledger.md
+++ b/.agents/skills/civ7-systematic-workstream/assets/corpus-ledger.md
@@ -1,8 +1,13 @@
 # Corpus Ledger
 
+See `references/corpus-and-expectations.md` for the row contract (what each
+column means and how to choose the corpus shape). Row 1 is a filled example
+(a non-resource entity); replace it and add one row per corpus member.
+
 | Row | Canonical key | Corpus shape | Source path | Authority class | ID/value/action/surface | Group | Current coverage | Uncertainty | Required proof |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 1 |  | entity/action/materialization/effect |  | official/local/current-code/evidence |  |  | planned/modeled/blocked/proxy/missing |  |  |
+| 1 | FEATURE_FLOODPLAIN_GRASSLAND | entity | data/terrain.xml: Features | official | enum FEATURE_FLOODPLAIN_GRASSLAND | wetlands | modeled | runtime feature id unverified | per-feature eligibility mask + runtime readback |
+| 2 |  | entity/action/materialization/effect |  | official/local/current-code/evidence |  |  | planned/modeled/blocked/proxy/missing |  |  |
 
 ## Coverage Summary
 

--- a/.agents/skills/civ7-systematic-workstream/assets/expectation-strategy-ledger.md
+++ b/.agents/skills/civ7-systematic-workstream/assets/expectation-strategy-ledger.md
@@ -1,7 +1,12 @@
 # Expectation And Strategy Ledger
 
+See `references/corpus-and-expectations.md` for the expectation row contract and
+the worked non-distribution example. Row 1 is a filled example (an
+eligibility-shaped, non-distribution expectation); replace it.
+
 | Corpus row/group | Expected behavior | Condition | Evidence strength | Architecture owner | Strategy/artifact | Local stats gate | Runtime proof | Status |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| FEATURE_FLOODPLAIN_* | placed only on flat land adjacent to river; 0 elsewhere | isFlat && adjacentToRiver | high (engine legality) | ecology-features op | floodplain eligibility mask | 0 placements outside legal mask; fill-rate band 0.4–0.7 of eligible river tiles | feature readback via GameplayMap.getFeatureType | proposed |
 |  |  |  | high/medium/low/inferred |  |  |  |  | proposed/implemented/blocked |
 
 ## Notes

--- a/.agents/skills/civ7-systematic-workstream/references/corpus-and-expectations.md
+++ b/.agents/skills/civ7-systematic-workstream/references/corpus-and-expectations.md
@@ -11,15 +11,29 @@ Prefer official and local authority sources before current implementation:
 - accepted project baselines, ADRs, and OpenSpec specs;
 - generated output and runtime logs only as evidence, not source authority.
 
-For Civ7 examples:
+For Civ7 examples (concrete paths under
+`.civ7/outputs/resources/Base/modules/base-standard/`):
 
-- resources: `Base/modules/base-standard/data/resources.xml` and
-  `resources-v2.xml`;
-- features, biomes, terrain, natural wonders, and yields: official terrain and
-  feature/yield tables plus local stage artifacts;
+- resources: `data/resources.xml` and `data/resources-v2.xml`;
+- features, biomes, terrain, natural wonders: `data/terrain.xml` holds
+  `Features`, `FeatureClasses`, `Feature_ValidTerrains`, `Feature_ValidBiomes`,
+  `Feature_NaturalWonders`, `Biomes`, and `Biome_ValidTerrains`;
+- biome/feature generation logic: `maps/feature-biome-generator.js`;
+- yields/effects: the `*_YieldChanges` and `Feature_CityYields` tables in the
+  same `data/` directory;
 - brushing/stamping: adapter methods, `TerrainBuilder` surfaces, projection
-  steps, and readback APIs;
+  steps, and readback APIs (no official "brush" catalog exists; see the action
+  corpus shape below);
 - ecology: sub-corpora for pedology, biomes, feature families, and projection.
+
+Corpus completeness is the first gate, not an assumption. The extraction under
+`.civ7/outputs/` currently materializes only the `resources/` tree at top level,
+even though that tree nests the full `base-standard` data above. If no extracted
+corpus exists for the domain you are working (or the official tables are only
+reachable through a nested path), **the first corpus task is to produce a clean
+extraction** — name the source XML/JS, the extraction command, and the output
+path convention (e.g. extend `.civ7/outputs/<domain>/`) before any grouping or
+tuning. A domain with no enumerated corpus has not passed gate 4.
 
 ## Corpus Row Contract
 
@@ -66,3 +80,29 @@ bands, binary legality gates, or confidence labels.
 | Wetlands | filtered feature corpus and hydromorphic masks | drainage, lowland hydrology, river/lake/coast adjacency, biome | habitat eligibility, wet/vegetated overlap, runtime feature readback |
 | Natural wonders | feature rows and natural-wonder shape/validity tables | landform, adjacency, terrain, biome, tile shape | eligibility, placement outcome/rejection, multi-tile readback |
 | Yield/effect matrices | terrain/biome/feature yield and effect tables | matrix completeness and gameplay legality | missing/duplicate combinations, age/DLC deltas, generated XML/runtime verification |
+
+## Worked Example: A Non-Distribution Expectation
+
+Not every domain proves correctness with a distribution. For legality- or
+eligibility-shaped domains (features, brushing, natural wonders), predeclare a
+binary/categorical expectation and prove it with eligibility and before/after
+checks, not spread statistics. Example for the `FEATURE_FLOODPLAIN_*` family:
+
+- **Baseline (physical):** floodplains form only on flat land adjacent to a
+  river; never on desert-only or ocean tiles; never on slope/hill/mountain.
+- **Predeclared expectation:** for every floodplain feature, eligibility is
+  `true` only where `isFlat && adjacentToRiver`; expected count on
+  desert-without-river and on ocean tiles is exactly `0`; eligible-tile fill
+  rate falls in a declared band (e.g. 0.4–0.7 of eligible river tiles).
+- **Proof shape:** per-feature eligibility mask coverage; a hard gate asserting
+  `0` placements outside the legal mask; a before/after diff over stable seeds;
+  runtime feature readback via `GameplayMap.getFeatureType` for one bounded
+  sample.
+- **Why not distribution stats:** "even spread across the map" is the wrong
+  expectation here — a floodplain that is evenly spread is *wrong*. The legality
+  gate is the proof; the fill-rate band is a secondary sanity check, not the
+  primary claim.
+
+Use this pattern whenever the domain has a binary legality rule. Use the
+resource-style distribution pattern only when even/weighted spread is itself the
+correctness claim.

--- a/.agents/skills/civ7-systematic-workstream/references/evidence-and-proof.md
+++ b/.agents/skills/civ7-systematic-workstream/references/evidence-and-proof.md
@@ -52,6 +52,9 @@ Do not claim a stronger label than the evidence supports.
 
 ## Exact Closure Language
 
+Every `<...>` placeholder below must be replaced with real evidence. A closure
+statement that still contains an unfilled `<...>` is not a valid claim.
+
 Local commit:
 
 ```text
@@ -87,10 +90,13 @@ Before closure, compare actual state against:
 - `tasks.md`;
 - `workstream/phase-record.md`;
 - `workstream/review-disposition-ledger.md`;
-- `workstream/downstream-realignment-ledger.md`;
-- `workstream/next-packet.md`;
+- `workstream/downstream-realignment-ledger.md` (OpenSpec slices only);
+- `workstream/next-packet.md` (OpenSpec slices only);
 - live `NOTE-TO-DRA*.md` or watcher notes;
 - `git status`, `git log -1`, and `gt log --no-interactive`.
+
+The `workstream/*` record templates are owned by `civ7-open-spec-workstream`;
+for a pre-OpenSpec planning slice, audit only the records that exist.
 
 Stale unchecked commit tasks, "ready to commit" phase text after commit, and
 next packets that tell the next agent to redo complete work are closure

--- a/.agents/skills/civ7-systematic-workstream/references/team-review-lanes.md
+++ b/.agents/skills/civ7-systematic-workstream/references/team-review-lanes.md
@@ -30,8 +30,8 @@ Every agent prompt should include:
 
 ## Evidence Wave Examples
 
-- Session-method extractor: derives workflow primitives from transcript and
-  durable records.
+For a domain workstream, the standing evidence lanes are:
+
 - Corpus researcher: enumerates official/local entities, action surfaces, and
   uncertainty.
 - Physical expectation researcher: proposes ranges and evidence strength.
@@ -40,6 +40,10 @@ Every agent prompt should include:
 - Stats/proof designer: identifies deterministic gates and runtime telemetry.
 - Future-use stress tester: checks that the method applies beyond the seed
   domain.
+
+(One-off bootstrap lane, used only when authoring or revising this skill itself:
+a session-method extractor that derives workflow primitives from a prior
+transcript and durable records. Not a standing lane for domain workstreams.)
 
 ## Review Lanes
 


### PR DESCRIPTION
This PR refines the `civ7-systematic-workstream` skill with clearer vocabulary, better companion skill routing, and more actionable reference material throughout.

**Vocabulary section added** — defines Gate, Slice, Phase, and Proof class/label so operators and agents share a consistent language when citing progress in phase records.

**Companion skill routing split into repo-local vs. external** — `framing-design` and `team-design` are now marked as external/global companions that may be absent, each with an explicit inline fallback (`assets/workstream-record.md` Frame block and `references/team-review-lanes.md` respectively). Repo-local companions remain unconditionally available.

**12-gate workflow condensed to one-liners** — the full procedure, sub-steps, and per-domain examples now live in `references/method-loop.md`, keeping the SKILL.md scannable while preserving depth in the reference layer.

**Trigger phrase and exclusion language tightened** — "resource distribution pass" and "feature placement audit" replace the vaguer originals; "generic project management" added as an explicit non-trigger.

**Corpus ledger and expectation ledger seeded with a filled example row** — `FEATURE_FLOODPLAIN_GRASSLAND` is used as a concrete non-distribution entity so operators see the expected column shape immediately rather than staring at a blank template.

**Corpus-and-expectations reference expanded** — concrete file paths under `.civ7/outputs/resources/Base/modules/base-standard/` are named for features, biomes, terrain, yields, and generation logic. A new section makes explicit that a domain with no enumerated corpus has not passed gate 4, and instructs operators to produce a clean extraction before any grouping or tuning.

**Worked non-distribution example added** — the `FEATURE_FLOODPLAIN_*` family illustrates when to use a binary legality gate and fill-rate band instead of spread statistics, and explains why even distribution would be the *wrong* correctness claim for placement-constrained features.

**Closure checklist and evidence proof references clarified** — OpenSpec-only records (`downstream-realignment-ledger.md`, `next-packet.md`) are marked `N/A` for pre-OpenSpec planning slices rather than left unchecked. Unfilled `<...>` placeholders in closure statements are now explicitly invalid. The session-method extractor lane is moved out of the standing evidence lanes and annotated as a one-off bootstrap lane used only when authoring the skill itself.