### PR TITLE
feat(map-policy): add adjacent-land runtime-optional resource exception with mock adapter static legality and surface delta diagnostics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,7 @@
       "name": "@civ7/adapter",
       "version": "0.1.0",
       "dependencies": {
+        "@civ7/map-policy": "workspace:*",
         "@civ7/types": "workspace:*",
       },
       "devDependencies": {

--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -1,0 +1,296 @@
+import {
+  CIV7_BROWSER_TABLES_V0,
+  isResourceAdjacentToLandRuntimeOptional,
+} from "@civ7/map-policy";
+
+import type { FinalSurfaceKey, FinalSurfaceParityProof, FinalSurfaceSnapshot } from "./live-parity.js";
+
+export type ClassifiableSurfaceKey = Extract<FinalSurfaceKey, "feature" | "resource">;
+
+export type StaticSurfaceLegality = Readonly<{
+  kind: ClassifiableSurfaceKey;
+  type: number;
+  symbol: string;
+  terrain: number | null;
+  terrainSymbol: string;
+  biome: number | null;
+  biomeSymbol: string;
+  feature: number | null;
+  featureSymbol: string;
+  validSurface: boolean;
+  reasons: ReadonlyArray<string>;
+}>;
+
+export type SurfaceDeltaContext = Readonly<{
+  key: ClassifiableSurfaceKey;
+  x: number;
+  y: number;
+  local: Readonly<{
+    value: number | null;
+    symbol: string;
+    context: CellSurfaceContext;
+  }>;
+  live: Readonly<{
+    value: number | null;
+    symbol: string;
+    context: CellSurfaceContext;
+  }>;
+  legality: Readonly<{
+    localValueOnLocal?: StaticSurfaceLegality;
+    localValueOnLive?: StaticSurfaceLegality;
+    liveValueOnLocal?: StaticSurfaceLegality;
+    liveValueOnLive?: StaticSurfaceLegality;
+  }>;
+}>;
+
+export type CellSurfaceContext = Readonly<{
+  terrain: number | null;
+  terrainSymbol: string;
+  biome: number | null;
+  biomeSymbol: string;
+  feature: number | null;
+  featureSymbol: string;
+  resource: number | null;
+  resourceSymbol: string;
+}>;
+
+type SurfaceLike = Readonly<{
+  values: ReadonlyArray<number | null>;
+}>;
+
+type SnapshotLike = Readonly<{
+  width: number;
+  height: number;
+  surfaces: Readonly<Record<FinalSurfaceKey, SurfaceLike>>;
+}>;
+
+const TERRAIN_SYMBOL_BY_ID = invertNumberMap(CIV7_BROWSER_TABLES_V0.terrainTypeIndices);
+const BIOME_SYMBOL_BY_ID = invertNumberMap(CIV7_BROWSER_TABLES_V0.biomeGlobals);
+const FEATURE_SYMBOL_BY_ID = invertNumberMap(CIV7_BROWSER_TABLES_V0.featureTypes);
+const RESOURCE_SYMBOL_BY_ID = invertNumberMap(CIV7_BROWSER_TABLES_V0.resourceTypes);
+
+const WATER_TERRAINS = new Set([
+  CIV7_BROWSER_TABLES_V0.terrainTypeIndices.TERRAIN_COAST,
+  CIV7_BROWSER_TABLES_V0.terrainTypeIndices.TERRAIN_OCEAN,
+]);
+
+const ODD_Q_NEIGHBORS_EVEN = [
+  [1, 0],
+  [0, 1],
+  [-1, 0],
+  [-1, -1],
+  [0, -1],
+  [1, -1],
+] as const;
+
+const ODD_Q_NEIGHBORS_ODD = [
+  [1, 1],
+  [0, 1],
+  [-1, 1],
+  [-1, 0],
+  [0, -1],
+  [1, 0],
+] as const;
+
+export function buildSurfaceDeltaContexts(
+  proof: Pick<FinalSurfaceParityProof, "local" | "live">,
+  options: {
+    keys?: ReadonlyArray<ClassifiableSurfaceKey>;
+    maxRows?: number;
+  } = {}
+): ReadonlyArray<SurfaceDeltaContext> {
+  const keys = options.keys ?? ["feature", "resource"];
+  const maxRows = options.maxRows ?? Number.POSITIVE_INFINITY;
+  const rows: SurfaceDeltaContext[] = [];
+
+  for (const key of keys) {
+    const localValues = proof.local.surfaces[key].values;
+    const liveValues = proof.live.surfaces[key].values;
+    const length = Math.min(localValues.length, liveValues.length);
+    for (let index = 0; index < length; index += 1) {
+      const localValue = normalizeSurfaceValue(localValues[index]);
+      const liveValue = normalizeSurfaceValue(liveValues[index]);
+      if (localValue === liveValue) continue;
+      const y = Math.floor(index / proof.local.width);
+      const x = index - y * proof.local.width;
+      rows.push(buildSurfaceDeltaContext(proof.local, proof.live, key, x, y));
+      if (rows.length >= maxRows) return rows;
+    }
+  }
+
+  return rows;
+}
+
+export function buildSurfaceDeltaContext(
+  local: FinalSurfaceSnapshot,
+  live: FinalSurfaceSnapshot,
+  key: ClassifiableSurfaceKey,
+  x: number,
+  y: number
+): SurfaceDeltaContext {
+  const localValue = surfaceValue(local, key, x, y);
+  const liveValue = surfaceValue(live, key, x, y);
+  const localContext = cellSurfaceContext(local, x, y);
+  const liveContext = cellSurfaceContext(live, x, y);
+  return {
+    key,
+    x,
+    y,
+    local: {
+      value: localValue,
+      symbol: symbolFor(key, localValue),
+      context: localContext,
+    },
+    live: {
+      value: liveValue,
+      symbol: symbolFor(key, liveValue),
+      context: liveContext,
+    },
+    legality: {
+      ...(localValue === null ? {} : { localValueOnLocal: staticSurfaceLegality(local, key, x, y, localValue) }),
+      ...(localValue === null ? {} : { localValueOnLive: staticSurfaceLegality(live, key, x, y, localValue) }),
+      ...(liveValue === null ? {} : { liveValueOnLocal: staticSurfaceLegality(local, key, x, y, liveValue) }),
+      ...(liveValue === null ? {} : { liveValueOnLive: staticSurfaceLegality(live, key, x, y, liveValue) }),
+    },
+  };
+}
+
+export function staticSurfaceLegality(
+  snapshot: FinalSurfaceSnapshot,
+  key: ClassifiableSurfaceKey,
+  x: number,
+  y: number,
+  type: number
+): StaticSurfaceLegality {
+  const context = cellSurfaceContext(snapshot, x, y);
+  const reasons: string[] = [];
+  if (key === "feature") {
+    addFeatureSurfaceReasons(reasons, type, context);
+  } else {
+    addResourceSurfaceReasons(reasons, snapshot, x, y, type, context);
+  }
+  return {
+    kind: key,
+    type,
+    symbol: symbolFor(key, type),
+    terrain: context.terrain,
+    terrainSymbol: context.terrainSymbol,
+    biome: context.biome,
+    biomeSymbol: context.biomeSymbol,
+    feature: context.feature,
+    featureSymbol: context.featureSymbol,
+    validSurface: reasons.length === 0,
+    reasons,
+  };
+}
+
+export function cellSurfaceContext(snapshot: SnapshotLike, x: number, y: number): CellSurfaceContext {
+  const terrain = surfaceValue(snapshot, "terrain", x, y);
+  const biome = surfaceValue(snapshot, "biome", x, y);
+  const feature = surfaceValue(snapshot, "feature", x, y);
+  const resource = surfaceValue(snapshot, "resource", x, y);
+  return {
+    terrain,
+    terrainSymbol: symbolFor("terrain", terrain),
+    biome,
+    biomeSymbol: symbolFor("biome", biome),
+    feature,
+    featureSymbol: symbolFor("feature", feature),
+    resource,
+    resourceSymbol: symbolFor("resource", resource),
+  };
+}
+
+function addFeatureSurfaceReasons(
+  reasons: string[],
+  featureType: number,
+  context: CellSurfaceContext
+): void {
+  const terrainRows = CIV7_BROWSER_TABLES_V0.featureValidTerrainTypeIndices[String(featureType)];
+  if (terrainRows?.length && !terrainRows.includes(context.terrain ?? -1)) {
+    reasons.push("feature.terrain");
+  }
+  const biomeRows = CIV7_BROWSER_TABLES_V0.featureValidBiomeTypeIndices[String(featureType)];
+  if (biomeRows?.length && !biomeRows.includes(context.biome ?? -1)) {
+    reasons.push("feature.biome");
+  }
+}
+
+function addResourceSurfaceReasons(
+  reasons: string[],
+  snapshot: FinalSurfaceSnapshot,
+  x: number,
+  y: number,
+  resourceType: number,
+  context: CellSurfaceContext
+): void {
+  const rows = CIV7_BROWSER_TABLES_V0.resourceValidPlacementRows[String(resourceType)];
+  if (!rows?.length) {
+    reasons.push("resource.unknown");
+    return;
+  }
+  const surfaceMatches = rows.some(
+    (row) =>
+      row[0] === context.biome &&
+      row[1] === context.terrain &&
+      row[2] === (context.feature ?? -1)
+  );
+  if (!surfaceMatches) reasons.push("resource.surface");
+  const flags = CIV7_BROWSER_TABLES_V0.resourcePlacementFlags[String(resourceType)];
+  if (
+    flags?.adjacentToLand &&
+    !isResourceAdjacentToLandRuntimeOptional(resourceType) &&
+    !hasAdjacentLand(snapshot, x, y)
+  ) {
+    reasons.push("resource.adjacent-land");
+  }
+}
+
+function hasAdjacentLand(snapshot: SnapshotLike, x: number, y: number): boolean {
+  const offsets = (x & 1) === 1 ? ODD_Q_NEIGHBORS_ODD : ODD_Q_NEIGHBORS_EVEN;
+  for (const [dx, dy] of offsets) {
+    const ny = y + dy;
+    if (ny < 0 || ny >= snapshot.height) continue;
+    const nx = snapshot.width > 0 ? wrapX(x + dx, snapshot.width) : x + dx;
+    const terrain = surfaceValue(snapshot, "terrain", nx, ny);
+    if (terrain !== null && !WATER_TERRAINS.has(terrain)) return true;
+  }
+  return false;
+}
+
+function surfaceValue(
+  snapshot: SnapshotLike,
+  key: FinalSurfaceKey,
+  x: number,
+  y: number
+): number | null {
+  if (x < 0 || y < 0 || x >= snapshot.width || y >= snapshot.height) return null;
+  const value = snapshot.surfaces[key].values[y * snapshot.width + x];
+  return normalizeSurfaceValue(value);
+}
+
+function normalizeSurfaceValue(value: number | null | undefined): number | null {
+  if (value == null || value < 0) return null;
+  return value;
+}
+
+function symbolFor(key: FinalSurfaceKey, value: number | null): string {
+  if (value === null) return "empty";
+  const lookup =
+    key === "terrain"
+      ? TERRAIN_SYMBOL_BY_ID
+      : key === "biome"
+        ? BIOME_SYMBOL_BY_ID
+        : key === "feature"
+          ? FEATURE_SYMBOL_BY_ID
+          : RESOURCE_SYMBOL_BY_ID;
+  return lookup[value] ?? `UNKNOWN_${key.toUpperCase()}_${value}`;
+}
+
+function invertNumberMap(value: Readonly<Record<string, number>>): Readonly<Record<number, string>> {
+  return Object.fromEntries(Object.entries(value).map(([key, id]) => [id, key]));
+}
+
+function wrapX(x: number, width: number): number {
+  return ((x % width) + width) % width;
+}

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+
+import type { FinalSurfaceSnapshot } from "../../src/dev/diagnostics/live-parity";
+import {
+  buildSurfaceDeltaContext,
+  buildSurfaceDeltaContexts,
+  staticSurfaceLegality,
+} from "../../src/dev/diagnostics/surface-delta-context";
+
+function snapshot(overrides: Partial<FinalSurfaceSnapshot["surfaces"]> = {}): FinalSurfaceSnapshot {
+  const width = 3;
+  const height = 2;
+  return {
+    source: "local-mapgen",
+    width,
+    height,
+    surfaces: {
+      terrain: { width, height, values: [3, 3, 2, 2, 2, 3] },
+      biome: { width, height, values: [5, 5, 1, 1, 2, 5] },
+      feature: { width, height, values: [-1, -1, -1, 6, -1, -1] },
+      resource: { width, height, values: [-1, 3, -1, -1, -1, -1] },
+      ...overrides,
+    },
+  };
+}
+
+describe("surface delta context diagnostics", () => {
+  test("extracts feature/resource mismatch rows with symbols", () => {
+    const local = snapshot({
+      feature: { width: 3, height: 2, values: [11, -1, -1, 6, -1, -1] },
+      resource: { width: 3, height: 2, values: [-1, 3, -1, -1, -1, -1] },
+    });
+    const live = snapshot({
+      feature: { width: 3, height: 2, values: [-1, -1, -1, 6, -1, -1] },
+      resource: { width: 3, height: 2, values: [-1, -1, -1, -1, -1, -1] },
+    });
+
+    const rows = buildSurfaceDeltaContexts({ local, live }, { keys: ["feature", "resource"] });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      key: "feature",
+      x: 0,
+      y: 0,
+      local: { value: 11, symbol: "FEATURE_COLD_REEF" },
+      live: { value: null, symbol: "empty" },
+    });
+    expect(rows[1]).toMatchObject({
+      key: "resource",
+      x: 1,
+      y: 0,
+      local: { value: 3, symbol: "RESOURCE_FISH" },
+      live: { value: null, symbol: "empty" },
+    });
+  });
+
+  test("checks static feature and resource surface legality against snapshot context", () => {
+    const surface = snapshot();
+
+    expect(staticSurfaceLegality(surface, "feature", 0, 0, 11)).toMatchObject({
+      symbol: "FEATURE_COLD_REEF",
+      validSurface: true,
+    });
+    expect(staticSurfaceLegality(surface, "feature", 2, 0, 11)).toMatchObject({
+      symbol: "FEATURE_COLD_REEF",
+      validSurface: false,
+      reasons: ["feature.terrain", "feature.biome"],
+    });
+    expect(staticSurfaceLegality(surface, "resource", 1, 0, 3)).toMatchObject({
+      symbol: "RESOURCE_FISH",
+      validSurface: true,
+    });
+    const openCoast = snapshot({
+      terrain: { width: 3, height: 2, values: [3, 3, 3, 3, 3, 3] },
+      biome: { width: 3, height: 2, values: [5, 5, 5, 5, 5, 5] },
+      feature: { width: 3, height: 2, values: [-1, -1, -1, -1, -1, -1] },
+    });
+    expect(staticSurfaceLegality(openCoast, "resource", 1, 0, 3)).toMatchObject({
+      symbol: "RESOURCE_FISH",
+      validSurface: true,
+    });
+    const invalidWhales = staticSurfaceLegality(surface, "resource", 2, 0, 32);
+    expect(invalidWhales).toMatchObject({
+      symbol: "RESOURCE_WHALES",
+      validSurface: false,
+    });
+    expect(invalidWhales.reasons).toContain("resource.surface");
+  });
+
+  test("cross-checks local and live values against both surfaces", () => {
+    const local = snapshot({
+      resource: { width: 3, height: 2, values: [-1, 3, -1, -1, -1, -1] },
+    });
+    const live = snapshot({
+      terrain: { width: 3, height: 2, values: [3, 2, 2, 2, 2, 3] },
+      biome: { width: 3, height: 2, values: [5, 1, 1, 1, 2, 5] },
+      resource: { width: 3, height: 2, values: [-1, -1, -1, -1, -1, -1] },
+    });
+
+    const row = buildSurfaceDeltaContext(local, live, "resource", 1, 0);
+
+    expect(row.legality.localValueOnLocal).toMatchObject({
+      symbol: "RESOURCE_FISH",
+      validSurface: true,
+    });
+    expect(row.legality.localValueOnLive).toMatchObject({
+      symbol: "RESOURCE_FISH",
+      validSurface: false,
+      reasons: ["resource.surface"],
+    });
+  });
+});

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -1,20 +1,26 @@
 ## 1. Activation
 
-- [ ] 1.1 Link concrete classified feature/resource delta rows from
+- [x] 1.1 Link concrete classified feature/resource delta rows from
+  `studio-run-in-game-mq20rbzr-1fhc` for the adjacent-land resource class.
+- [ ] 1.2 Link remaining concrete classified feature/resource delta rows from
   `studio-run-in-game-mq20rbzr-1fhc`.
-- [ ] 1.2 Identify source authority for each row: official data, adapter/map
+- [x] 1.3 Identify source authority for the adjacent-land resource class:
+  adapter/map-policy static runtime divergence.
+- [ ] 1.4 Identify source authority for each remaining row: official data, adapter/map
   policy, MapGen planning, or accepted engine materialization.
 
 ## 2. Repair
 
-- [ ] 2.1 Add focused failing-row tests or diagnostics.
-- [ ] 2.2 Repair the proven package or MapGen owner.
-- [ ] 2.3 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.1 Add focused failing-row tests or diagnostics.
+- [x] 2.2 Repair the proven adapter/map-policy owner for the adjacent-land
+  resource class.
+- [ ] 2.3 Repair remaining proven package or MapGen owners.
+- [ ] 2.4 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 
 - [ ] 3.1 Re-run final-surface feature/resource parity proof.
 - [ ] 3.2 Re-run product acceptance rows for resources/wonders/ecology.
-- [ ] 3.3 Run focused package tests/checks for touched owners.
-- [ ] 3.4 Run `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`.
-- [ ] 3.5 Run `bun run openspec:validate`.
+- [x] 3.3 Run focused package tests/checks for touched owners.
+- [x] 3.4 Run `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`.
+- [x] 3.5 Run `bun run openspec:validate`.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1,0 +1,197 @@
+# Feature/Resource Delta Classification Ledger
+
+## Scope
+
+- Source proof:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc.json`.
+- Proof hash:
+  `4973f47b8dd83e9710088d33485b2a985fcdf4dee71b140f2aa23b4bc55ac1dc`.
+- Summary hash:
+  `66b0548b9aba5c7a6502c9c92b5d4ca06ef4d5b65c6f98d4d08b81794f99c77e`.
+- Request: `studio-run-in-game-mq20rbzr-1fhc`.
+- Seed/dimensions: `138503614`, `106x66`, `6996` plots.
+- Runtime readback: omitted plots `0`; identity stable across seed,
+  dimensions, plot count, turn, and game hash.
+- Current proof status: `parityStatus:"unresolved"`.
+
+## Boundary
+
+This ledger links concrete rows for source-authority classification. It does
+not classify source authority, authorize repair, prove parity, or prove product
+acceptance. Repairs remain blocked until a row or row class is assigned to a
+specific owner with evidence: official data, adapter/map-policy, MapGen
+planning/materialization, accepted engine materialization, or readback
+limitation.
+
+Terrain rows remain outside this feature/resource lane unless diagnostics prove
+shared materialization ownership.
+
+## Feature Rows
+
+| Row | Coordinate | Local | Live | Source-authority status | Next evidence |
+|---|---|---|---|---|---|
+| F1 | `(48,6)` | `FEATURE_COLD_REEF` (`11`) | empty | pending | Check official/static feature legality for cold reef at this terrain/biome/coast context, then compare local `features-apply` attempted/applied/rejected telemetry against live materialization. |
+| F2 | `(48,13)` | empty | `FEATURE_KILIMANJARO` (`35`) | pending | Treat with F3 as a possible natural-wonder footprint/anchor-direction mismatch; inspect placement plan, stamped anchor, footprint catalog, and live feature footprint. |
+| F3 | `(49,13)` | `FEATURE_KILIMANJARO` (`35`) | empty | pending | Pair with F2 before repair; do not classify as accepted wonder semantics without placement telemetry. |
+| F4 | `(51,21)` | empty | `FEATURE_ZHANGJIAJIE` (`36`) | pending | Treat with F5 as a possible natural-wonder footprint/anchor-direction mismatch; inspect placement plan, stamped anchor, footprint catalog, and live feature footprint. |
+| F5 | `(52,21)` | `FEATURE_ZHANGJIAJIE` (`36`) | empty | pending | Pair with F4 before repair; do not classify as accepted wonder semantics without placement telemetry. |
+
+## Resource Example Rows
+
+The proof contains `106/6996` resource mismatches. The verifier records the
+first 16 examples; pair counts below summarize all mismatched pairs in the
+artifact.
+
+| Row | Coordinate | Local | Live | Source-authority status | Next evidence |
+|---|---|---|---|---|---|
+| R1 | `(34,2)` | `RESOURCE_CLAY` (`42`) | empty | pending | Compare local placement assignment/outcome and Civ live legality for the same tile/resource. |
+| R2 | `(59,3)` | empty | `RESOURCE_CLAY` (`42`) | pending | Determine whether Civ relocated/substituted an authored assignment or local prediction missed an engine placement. |
+| R3 | `(31,4)` | `RESOURCE_CLAY` (`42`) | empty | pending | Same class as R1 unless terrain/biome/feature context differs materially. |
+| R4 | `(56,6)` | `RESOURCE_GYPSUM` (`6`) | empty | pending | Check static and live `canHaveResource` legality at the exact tile. |
+| R5 | `(87,6)` | `RESOURCE_TURTLES` (`53`) | empty | pending | Check aquatic legality, coast/ocean context, and any engine resource spacing conflict. |
+| R6 | `(17,7)` | empty | `RESOURCE_PEARLS` (`12`) | pending | Determine whether live Civ produced an unpredicted legal placement from the same source chain. |
+| R7 | `(36,7)` | empty | `RESOURCE_DYES` (`2`) | pending | Compare local assignment order and live legality. |
+| R8 | `(37,8)` | empty | `RESOURCE_TURTLES` (`53`) | pending | Check whether this pairs with a nearby local-only turtles row. |
+| R9 | `(9,9)` | empty | `RESOURCE_FISH` (`3`) | pending | Check aquatic legality and placement order. |
+| R10 | `(86,9)` | `RESOURCE_FISH` (`3`) | empty | pending | Check whether this pairs with a nearby live-only fish/turtles row. |
+| R11 | `(104,9)` | `RESOURCE_DYES` (`2`) | `RESOURCE_PEARLS` (`12`) | pending | Substitution class; compare local preferred resource, fallback candidate set, and live `canHaveResource` result. |
+| R12 | `(52,10)` | `RESOURCE_SILVER` (`14`) | `RESOURCE_GYPSUM` (`6`) | pending | Substitution class; compare local preferred resource, fallback candidate set, and live `canHaveResource` result. |
+| R13 | `(69,10)` | `RESOURCE_DYES` (`2`) | `RESOURCE_COWRIE` (`52`) | pending | Substitution class; compare local preferred resource, fallback candidate set, and live `canHaveResource` result. |
+| R14 | `(14,11)` | `RESOURCE_COWRIE` (`52`) | empty | pending | Check aquatic/coast context and spacing conflict. |
+| R15 | `(30,11)` | empty | `RESOURCE_PEARLS` (`12`) | pending | Determine whether live Civ produced an unpredicted legal placement from the same source chain. |
+| R16 | `(39,11)` | `RESOURCE_COWRIE` (`52`) | empty | pending | Same class as R14 unless terrain/biome/feature context differs materially. |
+
+## Resource Pair Classes
+
+| Pair class | Count | Source-authority status | Next evidence |
+|---|---:|---|---|
+| `RESOURCE_TURTLES` -> empty | 7 | pending | Aquatic legality, spacing, and engine rejection/relocation evidence. |
+| `RESOURCE_COWRIE` -> empty | 7 | pending | Aquatic legality, spacing, and engine rejection/relocation evidence. |
+| `RESOURCE_PEARLS` -> empty | 7 | pending | Aquatic legality, spacing, and engine rejection/relocation evidence. |
+| empty -> `RESOURCE_DYES` | 6 | adapter/map-policy adjacent-land mismatch | Live exact run placed these rows through typed resource placement, but static local policy rejects them only for `resource.adjacent-land`. Repair belongs to the shared static policy/mock adapter unless live `canHaveResource` evidence later contradicts the final-surface/log proof. |
+| empty -> `RESOURCE_FISH` | 6 | adapter/map-policy adjacent-land mismatch | Live exact run placed these rows through typed resource placement, but static local policy rejects them only for `resource.adjacent-land`. Repair belongs to the shared static policy/mock adapter unless live `canHaveResource` evidence later contradicts the final-surface/log proof. |
+| empty -> `RESOURCE_TURTLES` | 5 | adapter/map-policy adjacent-land mismatch | Live exact run placed these rows through typed resource placement, but static local policy rejects them only for `resource.adjacent-land`. Repair belongs to the shared static policy/mock adapter unless live `canHaveResource` evidence later contradicts the final-surface/log proof. |
+| empty -> `RESOURCE_COWRIE` | 5 | adapter/map-policy adjacent-land mismatch | Live exact run placed these rows through typed resource placement, but static local policy rejects them only for `resource.adjacent-land`. Repair belongs to the shared static policy/mock adapter unless live `canHaveResource` evidence later contradicts the final-surface/log proof. |
+| empty -> `RESOURCE_PEARLS` | 4 | adapter/map-policy adjacent-land mismatch | Live exact run placed these rows through typed resource placement, but static local policy rejects them only for `resource.adjacent-land`. Repair belongs to the shared static policy/mock adapter unless live `canHaveResource` evidence later contradicts the final-surface/log proof. |
+| `RESOURCE_FISH` -> empty | 4 | pending | Aquatic legality, spacing, and engine rejection/relocation evidence. |
+| `RESOURCE_CLAY` -> empty | 3 | pending | Land legality and fallback assignment evidence. |
+| empty -> `RESOURCE_CLAY` | 3 | pending | Determine whether live relocation/extra placement explains clay rows. |
+| `RESOURCE_DYES` -> `RESOURCE_PEARLS` | 3 | pending | Substitution; compare local preferred/fallback candidates with live legality. |
+| `RESOURCE_LIMESTONE` -> `RESOURCE_HORSES` | 2 | pending | Substitution; compare official data and live legality. |
+| `RESOURCE_IVORY` -> `RESOURCE_HARDWOOD` | 2 | pending | Substitution; compare official data and live legality. |
+| `RESOURCE_FISH` -> `RESOURCE_TURTLES` | 2 | pending | Aquatic substitution; compare official data and live legality. |
+| `RESOURCE_HARDWOOD` -> `RESOURCE_JADE` | 2 | pending | Substitution; compare official data and live legality. |
+| `RESOURCE_CLAY` -> `RESOURCE_RICE` | 2 | pending | Substitution; compare official data and live legality. |
+| single-count pairs | 7 | pending | Preserve individually until row context proves they share a class. |
+
+## Static Surface Diagnostic Findings
+
+Diagnostic helper:
+`mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts`.
+
+Focused test:
+`mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts`.
+
+The diagnostic compares each feature/resource delta against the local and live
+terrain/biome/feature surfaces using the static official-derived tables exposed
+through `@civ7/map-policy`. It answers only static surface legality. It does
+not prove placement intent, resource spacing outcome, Civ runtime
+`canHaveResource`/`canHaveFeature`, natural-wonder footprint semantics, or
+accepted engine materialization.
+
+Pre-repair summary for request `studio-run-in-game-mq20rbzr-1fhc`:
+
+| Surface | Delta rows | Local value invalid on local surface | Local value invalid on live surface | Live value invalid on local surface | Live value invalid on live surface |
+|---|---:|---:|---:|---:|---:|
+| feature | 5 | 0 | 0 | 0 | 0 |
+| resource | 106 | 0 | 0 | 26 | 26 |
+
+Current repaired summary for the same proof:
+
+| Surface | Delta rows | Local value invalid on local surface | Local value invalid on live surface | Live value invalid on local surface | Live value invalid on live surface |
+|---|---:|---:|---:|---:|---:|
+| feature | 5 | 0 | 0 | 0 | 0 |
+| resource | 106 | 0 | 0 | 0 | 0 |
+
+Feature row readout:
+
+| Rows | Static finding | Source-authority implication |
+|---|---|---|
+| F1 | `FEATURE_COLD_REEF` is static-legal on local and live `TERRAIN_COAST` / `BIOME_MARINE`. | Not a static feature terrain/biome illegality. Needs feature apply/rejection or Civ materialization evidence. |
+| F2/F3 | `FEATURE_KILIMANJARO` is static-legal on both compared mountain/plain cells. | Treat as natural-wonder footprint/anchor evidence need, not static feature legality repair. |
+| F4/F5 | `FEATURE_ZHANGJIAJIE` is static-legal on both compared mountain/tropical cells. | Treat as natural-wonder footprint/anchor evidence need, not static feature legality repair. |
+
+Resource row readout:
+
+| Class | Count | Static finding | Source-authority implication |
+|---|---:|---|---|
+| Local resource values on local surface | 80 | All static-legal. | Local predictions are not contradicted by static surface legality; still need placement intent/outcome and spacing evidence. |
+| Live resource values on live surface | 52 | `26` static-legal; `26` fail only `resource.adjacent-land`. | The live-only aquatic rows expose an adapter/policy/readback question around adjacent-land semantics; do not classify as MapGen repair without live `canHaveResource` or engine-rule evidence. |
+| Live invalid by resource | 26 | `RESOURCE_DYES` `6`, `RESOURCE_FISH` `6`, `RESOURCE_TURTLES` `5`, `RESOURCE_COWRIE` `5`, `RESOURCE_PEARLS` `4`. | Preserve as a policy/adapter investigation class before changing generation. |
+
+The pre-repair `resource.adjacent-land` finding was diagnostic pressure until
+the exact-authored placement log and matching live resource count proved Civ
+accepted the rows through the typed resource placement path. After the narrow
+policy repair, this class no longer appears as a static surface invalidity.
+
+## Source-Authority Classification Progress
+
+### Adapter/Map-Policy Adjacent-Land Class
+
+Rows classified:
+`empty -> RESOURCE_DYES` (`6`), `empty -> RESOURCE_FISH` (`6`),
+`empty -> RESOURCE_TURTLES` (`5`), `empty -> RESOURCE_COWRIE` (`5`), and
+`empty -> RESOURCE_PEARLS` (`4`).
+
+Evidence:
+
+- Official-derived `@civ7/map-policy` rows require
+  `Resource_ValidBiomes` coast/marine/no-feature plus `AdjacentToLand=true`
+  for these resource ids.
+- The exact-authored live run
+  `studio-run-in-game-mq20rbzr-1fhc` logged `RESOURCE_PLACEMENT_V1` with
+  `plannedCount:252`, `placedCount:252`, `rejectedCount:0`, and
+  `mismatchCount:0` at `2026-06-06T03:16:43-04:00`.
+- The live full-grid proof for the same runtime snapshot contains exactly
+  `252` resource cells, matching the typed placement count.
+- The `26` classified live-only rows are coast/marine/no-feature cells with no
+  adjacent non-water tile under the canonical odd-q wrapped topology and fail
+  only the static `resource.adjacent-land` check.
+
+Disposition:
+source authority for this row class is the repo-owned static resource policy
+surface used by local/mock parity, not MapGen product tuning. The immediate
+repair was made in `@civ7/map-policy`, `@civ7/adapter`, and the diagnostic
+helper: the local/mock static resource legality model now reflects observed Civ
+`ResourceBuilder.canHaveResource` behavior for this classified adjacent-land
+class, with tests preserving the official table evidence and preventing silent
+broad relaxation. No resource density, resource diversity, terrain, coast
+generation, or Earthlike tuning changed as part of this class.
+
+Open caveat:
+this classification covers only the `26` live-only rows above. The remaining
+resource substitution/local-only rows still need placement-intent, spacing,
+and fallback evidence before owner repair.
+
+### Post-Repair Proof Status
+
+The repaired diagnostic helper reports no static surface invalid rows for the
+saved proof packet. A full final-surface verifier rerun against
+`studio-run-in-game-mq20rbzr-1fhc` could not be completed after Studio was
+restarted because the new Studio server instance no longer had that request id
+in memory. This lane therefore has no post-repair exact-authored live parity
+closure artifact yet.
+
+## Required Next Diagnostics
+
+- Extract local row context for every feature/resource mismatch: terrain,
+  biome, feature, resource, placement intent, placement assignment, adapter
+  rejection/mismatch reason, and spacing neighbor context.
+- Compare each row against official/static policy and, where available, live
+  `canHaveFeature`/`canHaveResource` behavior for the same tile and candidate
+  type.
+- For natural-wonder rows, compare planned anchor/direction/footprint against
+  local materialized feature grid and live feature grid before accepting an
+  engine-footprint disposition.
+- For resource rows, preserve resource spacing, age legality, and diversity
+  evidence before any repair.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,11 +5,12 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: next implementation branch pending; activation
-  routed from `codex/swooper-studio-parity-proof-drain`
+- Branch/Graphite stack: `codex/swooper-feature-resource-legality-drain`
+  stacked above `codex/swooper-studio-parity-proof-drain`
 - Started: 2026-06-06
-- Status: activated for investigation; concrete final-surface delta rows exist,
-  but source-authority classification remains pending
+- Status: active. The adjacent-land resource class is classified and repaired
+  in the repo-owned adapter/map-policy surface. Remaining feature/resource
+  classes are linked but still pending source-authority classification.
 
 ## Objective
 
@@ -21,6 +22,15 @@
 
 ## Current State
 
+- Single-writer handoff:
+  - `codex/civ7-map-policy-final-surface-parity` remains the committed proof
+    path layer at `70a22c815 docs(openspec): route parity proof deltas`.
+  - This branch intentionally takes over only the downstream feature/resource
+    legality classification lane from that clean parity state.
+  - The branch switch itself is not a parity, acceptance, source-authority, or
+    product-quality closure claim.
+  - Product/tuning edits remain forbidden until concrete rows are classified to
+    a repo-owned source authority.
 - Activation evidence:
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc.json`
   from request `studio-run-in-game-mq20rbzr-1fhc`, exact-authorship status
@@ -28,9 +38,46 @@
   stable turn/game-hash identity, and unresolved links
   `surface.terrain.mismatch`, `surface.feature.mismatch`, and
   `surface.resource.mismatch`.
+- Row evidence:
+  `openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md`
+  records the concrete feature rows, resource example rows, and resource pair
+  classes extracted from the exact-authored proof artifact. The adjacent-land
+  resource class is classified; remaining feature/resource classes stay
+  `source-authority: pending`.
+- Static surface diagnostics:
+  `mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts`
+  cross-checks feature/resource deltas against local and live terrain/biome/
+  feature surfaces using `@civ7/map-policy` static official-derived tables.
+  Pre-repair finding: feature rows were all static surface-legal; local
+  resource values were static-legal; `26` live resource values failed only
+  `resource.adjacent-land`. Current repaired finding: feature and resource
+  deltas have no static surface invalid rows under the narrow runtime-observed
+  adjacent-land exception.
+- Classification progress:
+  the `26` live-only adjacent-land rows are now classified to repo-owned
+  adapter/map-policy static resource legality, based on exact-authored
+  `RESOURCE_PLACEMENT_V1` evidence (`placedCount:252`, `rejectedCount:0`,
+  `mismatchCount:0`) and matching live full-grid resource count. This
+  authorized and received a narrow policy/mock parity repair only; all other
+  resource substitution/local-only classes and all feature rows remain pending.
+- Repair progress:
+  `@civ7/map-policy` now records the live-observed adjacent-land exception
+  narrowly for `RESOURCE_DYES`, `RESOURCE_FISH`, `RESOURCE_PEARLS`,
+  `RESOURCE_COWRIE`, and `RESOURCE_TURTLES`; `@civ7/adapter` mock resource
+  legality and the Swooper diagnostic helper consume that shared policy.
+- Verification progress:
+  focused policy/adapter/diagnostic tests, package checks, affected Turbo
+  build/check lanes, and strict OpenSpec validation pass for this integration
+  slice. No fresh final-surface runtime verifier proof was produced on
+  `codex/swooper-feature-resource-legality-drain`; task 3.1 remains open and
+  the next full parity proof needs a fresh Studio Run in Game exact-authorship
+  request.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
-- Next action: classify feature/resource rows by source authority before repair:
-  official data, adapter/map-policy, MapGen planning/materialization, accepted
-  engine materialization, or readback limitation. Terrain edge rows may enter
-  this slice only if diagnostics prove shared materialization ownership.
-- Stop condition: delta source authority is not known.
+- Next action: run a fresh Studio Run in Game exact-authorship request, rerun
+  final-surface parity against that request, then classify remaining
+  feature/resource rows by source authority: official data, adapter/map-policy,
+  MapGen planning/materialization, accepted engine materialization, or readback
+  limitation. Terrain edge rows may enter this slice only if diagnostics prove
+  shared materialization ownership.
+- Stop condition: source authority is not known for any row outside the
+  classified adjacent-land resource class.

--- a/packages/civ7-adapter/package.json
+++ b/packages/civ7-adapter/package.json
@@ -24,6 +24,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
+    "@civ7/map-policy": "workspace:*",
     "@civ7/types": "workspace:*"
   },
   "devDependencies": {

--- a/packages/civ7-adapter/src/index.ts
+++ b/packages/civ7-adapter/src/index.ts
@@ -39,9 +39,24 @@ export type {
 } from "./types.js";
 export { ENGINE_EFFECT_TAGS } from "./effects.js";
 export type { EngineEffectTagId } from "./effects.js";
-export { NO_RESOURCE, PLACEABLE_RESOURCE_TYPE_IDS } from "./resource-constants.js";
-export { NATURAL_WONDER_CATALOG } from "./manual-catalogs/natural-wonders.js";
-export { DISCOVERY_CATALOG } from "./manual-catalogs/discoveries.js";
+export {
+  CIV7_BROWSER_TABLES_V0,
+  DISCOVERY_CATALOG,
+  NATURAL_WONDER_CATALOG,
+  NO_RESOURCE,
+  PLACEABLE_RESOURCE_TYPE_IDS,
+  RESOURCE_ADJACENT_TO_LAND_RUNTIME_OPTIONAL_TYPE_IDS,
+  getNaturalWonderFootprintIndices,
+  getNaturalWonderFootprintOffsets,
+  hasUnsupportedNaturalWonderPolicyTags,
+  isResourceAdjacentToLandRuntimeOptional,
+  resolveNaturalWonderPlacementDirection,
+} from "@civ7/map-policy";
+export type {
+  Civ7BrowserTablesV0,
+  NaturalWonderFootprintOffset,
+  NaturalWonderPlacementPolicy,
+} from "@civ7/map-policy";
 export {
   CIV7_STANDARD_MAP_SIZE_PRESETS,
   CIV7_STANDARD_ROW_LATITUDE_BOUNDS,

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -29,11 +29,50 @@ import type {
 } from "./types.js";
 import { ENGINE_EFFECT_TAGS } from "./effects.js";
 import {
+  CIV7_BROWSER_TABLES_V0,
+  NATURAL_WONDER_CATALOG,
   NO_RESOURCE as ADAPTER_NO_RESOURCE,
   PLACEABLE_RESOURCE_TYPE_IDS,
-} from "./resource-constants.js";
+  getNaturalWonderFootprintIndices,
+  hasUnsupportedNaturalWonderPolicyTags,
+  isResourceAdjacentToLandRuntimeOptional,
+} from "@civ7/map-policy";
+import { getCiv7RowLatitude } from "./map-metadata.js";
 
 type MockRandomFn = (max: number, label: string) => number;
+type ResourceValidPlacementRow = readonly [
+  biomeType: number,
+  terrainType: number,
+  featureType: number,
+];
+
+type FeaturePolicy = Readonly<{
+  noLake: boolean;
+  minimumElevation?: number;
+  placementClass?: string;
+  naturalWonderTiles?: number;
+  naturalWonderDirection?: number;
+}>;
+
+const FEATURE_VALID_TERRAIN_TYPE_INDICES = CIV7_BROWSER_TABLES_V0.featureValidTerrainTypeIndices as
+  Record<string, readonly number[] | undefined>;
+
+const FEATURE_VALID_BIOME_TYPE_INDICES = CIV7_BROWSER_TABLES_V0.featureValidBiomeTypeIndices as
+  Record<string, readonly number[] | undefined>;
+
+const FEATURE_POLICIES = CIV7_BROWSER_TABLES_V0.featurePolicies as
+  Record<string, FeaturePolicy | undefined>;
+
+const FEATURE_TAGS_BY_FEATURE_TYPE = CIV7_BROWSER_TABLES_V0.featureTagsByFeatureType as
+  Record<string, readonly string[] | undefined>;
+
+const RESOURCE_VALID_PLACEMENT_ROWS = CIV7_BROWSER_TABLES_V0.resourceValidPlacementRows as
+  Record<string, readonly ResourceValidPlacementRow[] | undefined>;
+
+const RESOURCE_PLACEMENT_FLAGS = CIV7_BROWSER_TABLES_V0.resourcePlacementFlags as Record<
+  string,
+  { adjacentToLand: boolean; lakeEligible: boolean } | undefined
+>;
 
 const hashMockRngLabel = (label: string): number => {
   let hash = 5381;
@@ -111,70 +150,21 @@ const DEFAULT_VORONOI_UTILS: VoronoiUtils = {
  * Default biome globals for testing
  */
 export const DEFAULT_BIOME_GLOBALS: Record<string, number> = {
-  BIOME_TUNDRA: 0,
-  BIOME_GRASSLAND: 1,
-  BIOME_PLAINS: 2,
-  BIOME_TROPICAL: 3,
-  BIOME_DESERT: 4,
-  BIOME_MARINE: 5,
+  ...CIV7_BROWSER_TABLES_V0.biomeGlobals,
 };
 
 /**
  * Default feature type indices for testing
  */
 export const DEFAULT_FEATURE_TYPES: Record<string, number> = {
-  FEATURE_SAGEBRUSH_STEPPE: 0,
-  FEATURE_OASIS: 1,
-  FEATURE_DESERT_FLOODPLAIN_MINOR: 2,
-  FEATURE_DESERT_FLOODPLAIN_NAVIGABLE: 3,
-  FEATURE_FOREST: 4,
-  FEATURE_MARSH: 5,
-  FEATURE_GRASSLAND_FLOODPLAIN_MINOR: 6,
-  FEATURE_GRASSLAND_FLOODPLAIN_NAVIGABLE: 7,
-  FEATURE_REEF: 8,
-  FEATURE_COLD_REEF: 9,
-  FEATURE_ICE: 10,
-  FEATURE_SAVANNA_WOODLAND: 11,
-  FEATURE_WATERING_HOLE: 12,
-  FEATURE_PLAINS_FLOODPLAIN_MINOR: 13,
-  FEATURE_PLAINS_FLOODPLAIN_NAVIGABLE: 14,
-  FEATURE_RAINFOREST: 15,
-  FEATURE_MANGROVE: 16,
-  FEATURE_TROPICAL_FLOODPLAIN_MINOR: 17,
-  FEATURE_TROPICAL_FLOODPLAIN_NAVIGABLE: 18,
-  FEATURE_TAIGA: 19,
-  FEATURE_TUNDRA_BOG: 20,
-  FEATURE_TUNDRA_FLOODPLAIN_MINOR: 21,
-  FEATURE_TUNDRA_FLOODPLAIN_NAVIGABLE: 22,
-  FEATURE_VOLCANO: 23,
-  FEATURE_LOTUS: 24,
-  FEATURE_ATOLL: 25,
-  FEATURE_VALLEY_OF_FLOWERS: 26,
-  FEATURE_BARRIER_REEF: 27,
-  FEATURE_REDWOOD_FOREST: 28,
-  FEATURE_GRAND_CANYON: 29,
-  FEATURE_GULLFOSS: 30,
-  FEATURE_HOERIKWAGGO: 31,
-  FEATURE_IGUAZU_FALLS: 32,
-  FEATURE_KILIMANJARO: 33,
-  FEATURE_ZHANGJIAJIE: 34,
-  FEATURE_THERA: 35,
-  FEATURE_TORRES_DEL_PAINE: 36,
-  FEATURE_ULURU: 37,
-  FEATURE_BERMUDA_TRIANGLE: 38,
-  FEATURE_MOUNT_EVEREST: 39,
+  ...CIV7_BROWSER_TABLES_V0.featureTypes,
 };
 
 /**
  * Default terrain type indices for testing
  */
 export const DEFAULT_TERRAIN_TYPE_INDICES: Record<string, number> = {
-  TERRAIN_MOUNTAIN: 0,
-  TERRAIN_HILL: 1,
-  TERRAIN_FLAT: 2,
-  TERRAIN_COAST: 3,
-  TERRAIN_OCEAN: 4,
-  TERRAIN_NAVIGABLE_RIVER: 5,
+  ...CIV7_BROWSER_TABLES_V0.terrainTypeIndices,
 };
 
 /**
@@ -216,9 +206,7 @@ export const DEFAULT_PLOT_EFFECT_TYPES: MockPlotEffectType[] = [
   { id: 4, name: "PLOTEFFECT_BURNED", tags: ["BURNED"] },
 ];
 
-const DEFAULT_NATURAL_WONDER_CATALOG: NaturalWonderCatalogEntry[] = [
-  { featureType: DEFAULT_FEATURE_TYPES.FEATURE_MOUNT_EVEREST, direction: 0 },
-];
+const DEFAULT_NATURAL_WONDER_CATALOG: NaturalWonderCatalogEntry[] = NATURAL_WONDER_CATALOG;
 
 const DEFAULT_DISCOVERY_CATALOG: DiscoveryCatalogEntry[] = [
   { discoveryVisualType: 0, discoveryActivationType: 0 },
@@ -262,6 +250,28 @@ function sanitizeDiscoveryCatalog(
     });
   }
   return catalog;
+}
+
+const ODD_Q_NEIGHBORS_EVEN: readonly (readonly [number, number])[] = [
+  [-1, 0],
+  [1, 0],
+  [0, -1],
+  [0, 1],
+  [-1, -1],
+  [1, -1],
+];
+
+const ODD_Q_NEIGHBORS_ODD: readonly (readonly [number, number])[] = [
+  [-1, 0],
+  [1, 0],
+  [0, -1],
+  [0, 1],
+  [-1, 1],
+  [1, 1],
+];
+
+function wrapMockX(x: number, width: number): number {
+  return ((x % width) + width) % width;
 }
 
 export interface MockAdapterConfig {
@@ -610,15 +620,19 @@ export class MockAdapter implements EngineAdapter {
   }
 
   getLatitude(x: number, y: number): number {
-    // Simple latitude calculation: -90 to 90 based on y position
-    const normalizedY = y / this.height;
-    return 90 - normalizedY * 180;
+    return getCiv7RowLatitude(this.mapInfo, this.height, y);
   }
 
   // === TERRAIN WRITES ===
 
   setTerrainType(x: number, y: number, terrainType: number): void {
-    this.terrainTypes[this.idx(x, y)] = terrainType;
+    const index = this.idx(x, y);
+    this.terrainTypes[index] = terrainType;
+    this.waterMask[index] =
+      terrainType === this.coastTerrainId || terrainType === this.oceanTerrainId ? 1 : 0;
+    this.riverMask[index] =
+      terrainType === this.getTerrainTypeIndex("TERRAIN_NAVIGABLE_RIVER") ? 1 : 0;
+    this.mountainMask[index] = terrainType === this.mountainTerrainId ? 1 : 0;
   }
 
   setRainfall(x: number, y: number, value: number): void {
@@ -664,11 +678,45 @@ export class MockAdapter implements EngineAdapter {
     if (this.canHaveFeatureFn) {
       return this.canHaveFeatureFn(_x, _y, _featureType);
     }
-    return true; // Mock: always allow features
+    return this.canHaveFeatureByStaticPolicy(_x, _y, _featureType);
   }
 
   canHaveFeatureParam(x: number, y: number, featureData: FeatureData): boolean {
     return this.canHaveFeature(x, y, featureData.Feature);
+  }
+
+  private canHaveFeatureByStaticPolicy(x: number, y: number, featureType: number): boolean {
+    if (x < 0 || y < 0 || x >= this.width || y >= this.height) return false;
+    const normalizedFeatureType = featureType | 0;
+    if (normalizedFeatureType < 0) return false;
+    if ((this.getFeatureType(x, y) | 0) !== this.NO_FEATURE) return false;
+
+    const featureKey = String(normalizedFeatureType);
+    const validTerrainTypes = FEATURE_VALID_TERRAIN_TYPE_INDICES[featureKey];
+    if (validTerrainTypes?.length && !validTerrainTypes.includes(this.getTerrainType(x, y) | 0)) {
+      return false;
+    }
+
+    const validBiomeTypes = FEATURE_VALID_BIOME_TYPE_INDICES[featureKey];
+    if (validBiomeTypes?.length && !validBiomeTypes.includes(this.getBiomeType(x, y) | 0)) {
+      return false;
+    }
+
+    const policy = FEATURE_POLICIES[featureKey];
+    if (
+      policy?.naturalWonderTiles !== undefined &&
+      hasUnsupportedNaturalWonderPolicyTags(FEATURE_TAGS_BY_FEATURE_TYPE[featureKey])
+    ) {
+      return false;
+    }
+    if (
+      policy?.minimumElevation !== undefined &&
+      this.getElevation(x, y) < policy.minimumElevation
+    ) {
+      return false;
+    }
+
+    return true;
   }
 
   get NO_RESOURCE(): number {
@@ -696,7 +744,48 @@ export class MockAdapter implements EngineAdapter {
     if (this.canHaveResourceFn) {
       return this.canHaveResourceFn(x, y, resourceType);
     }
+    return this.canHaveResourceByStaticPolicy(x, y, resourceType);
+  }
+
+  private canHaveResourceByStaticPolicy(x: number, y: number, resourceType: number): boolean {
+    if (x < 0 || y < 0 || x >= this.width || y >= this.height) return false;
+    const normalizedResourceType = resourceType | 0;
+    const validRows = RESOURCE_VALID_PLACEMENT_ROWS[String(normalizedResourceType)];
+    if (!validRows?.length) return false;
+
+    const biomeType = this.getBiomeType(x, y) | 0;
+    const terrainType = this.getTerrainType(x, y) | 0;
+    const featureType = this.getFeatureType(x, y) | 0;
+    let validSurface = false;
+    for (const row of validRows) {
+      if (row[0] !== biomeType || row[1] !== terrainType) continue;
+      if (row[2] !== featureType) continue;
+      validSurface = true;
+      break;
+    }
+    if (!validSurface) return false;
+
+    const flags = RESOURCE_PLACEMENT_FLAGS[String(normalizedResourceType)];
+    if (
+      flags?.adjacentToLand &&
+      !isResourceAdjacentToLandRuntimeOptional(normalizedResourceType) &&
+      !this.hasAdjacentLand(x, y)
+    ) {
+      return false;
+    }
+
     return true;
+  }
+
+  private hasAdjacentLand(x: number, y: number): boolean {
+    const offsets = (x & 1) === 1 ? ODD_Q_NEIGHBORS_ODD : ODD_Q_NEIGHBORS_EVEN;
+    for (const [dx, dy] of offsets) {
+      const ny = y + dy;
+      if (ny < 0 || ny >= this.height) continue;
+      const nx = this.width > 0 ? wrapMockX(x + dx, this.width) : x + dx;
+      if (!this.isWater(nx, ny)) return true;
+    }
+    return false;
   }
 
   getPlaceableResourceTypes(): number[] {

--- a/packages/civ7-adapter/test/placement-outcomes.test.ts
+++ b/packages/civ7-adapter/test/placement-outcomes.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
+import { CIV7_BROWSER_TABLES_V0 } from "@civ7/map-policy";
+
 import { createMockAdapter } from "../src/mock-adapter.js";
 
 /**
@@ -11,7 +13,7 @@ import { createMockAdapter } from "../src/mock-adapter.js";
  */
 describe("typed placement outcomes", () => {
   it("returns placed resource outcomes with readback evidence", () => {
-    const adapter = createMockAdapter({ width: 4, height: 3 });
+    const adapter = createMockAdapter({ width: 4, height: 3, canHaveResource: () => true });
 
     const outcome = adapter.placeResourceIntent(4, 3, {
       plotIndex: 5,
@@ -79,5 +81,24 @@ describe("typed placement outcomes", () => {
       status: "rejected",
       reason: "out-of-bounds",
     });
+  });
+
+  it("matches live-observed adjacent-land resource behavior narrowly", () => {
+    const adapter = createMockAdapter({ width: 3, height: 3 });
+    const coast = CIV7_BROWSER_TABLES_V0.terrainTypeIndices.TERRAIN_COAST;
+    const marine = CIV7_BROWSER_TABLES_V0.biomeGlobals.BIOME_MARINE;
+    for (let y = 0; y < 3; y += 1) {
+      for (let x = 0; x < 3; x += 1) {
+        adapter.setTerrainType(x, y, coast);
+        adapter.setBiomeType(x, y, marine);
+      }
+    }
+
+    expect(adapter.canHaveResource(1, 1, CIV7_BROWSER_TABLES_V0.resourceTypes.RESOURCE_FISH)).toBe(
+      true
+    );
+    expect(
+      adapter.canHaveResource(1, 1, CIV7_BROWSER_TABLES_V0.resourceTypes.RESOURCE_WHALES)
+    ).toBe(false);
   });
 });

--- a/packages/civ7-map-policy/src/index.ts
+++ b/packages/civ7-map-policy/src/index.ts
@@ -1,7 +1,12 @@
 export { CIV7_BROWSER_TABLES_V0 } from "./civ7-tables.gen.js";
 export type { Civ7BrowserTablesV0 } from "./civ7-tables.gen.js";
 
-export { NO_RESOURCE, PLACEABLE_RESOURCE_TYPE_IDS } from "./resource-constants.js";
+export {
+  NO_RESOURCE,
+  PLACEABLE_RESOURCE_TYPE_IDS,
+  RESOURCE_ADJACENT_TO_LAND_RUNTIME_OPTIONAL_TYPE_IDS,
+  isResourceAdjacentToLandRuntimeOptional,
+} from "./resource-constants.js";
 export { NATURAL_WONDER_CATALOG } from "./catalogs/natural-wonders.js";
 export { DISCOVERY_CATALOG } from "./catalogs/discoveries.js";
 export {

--- a/packages/civ7-map-policy/src/resource-constants.ts
+++ b/packages/civ7-map-policy/src/resource-constants.ts
@@ -22,3 +22,26 @@ export const PLACEABLE_RESOURCE_TYPE_IDS = [
   40, 41, 42, 43, 44, 45, 46, 47,
   48, 49, 50, 51, 52, 53, 54,
 ] as const;
+
+/**
+ * Resource IDs whose official data has `AdjacentToLand=true`, but whose
+ * exact-authored live Civ7 `ResourceBuilder.canHaveResource`/placement proof
+ * accepted coast/marine/no-feature rows without adjacent land.
+ *
+ * Evidence: `studio-run-in-game-mq20rbzr-1fhc` final-surface parity proof,
+ * 2026-06-06, classified in
+ * `earthlike-live-feature-resource-legality-repair`.
+ */
+export const RESOURCE_ADJACENT_TO_LAND_RUNTIME_OPTIONAL_TYPE_IDS = [
+  2, // RESOURCE_DYES
+  3, // RESOURCE_FISH
+  12, // RESOURCE_PEARLS
+  52, // RESOURCE_COWRIE
+  53, // RESOURCE_TURTLES
+] as const;
+
+export function isResourceAdjacentToLandRuntimeOptional(resourceType: number): boolean {
+  return RESOURCE_ADJACENT_TO_LAND_RUNTIME_OPTIONAL_TYPE_IDS.includes(
+    resourceType as (typeof RESOURCE_ADJACENT_TO_LAND_RUNTIME_OPTIONAL_TYPE_IDS)[number]
+  );
+}

--- a/packages/civ7-map-policy/test/map-policy.test.ts
+++ b/packages/civ7-map-policy/test/map-policy.test.ts
@@ -6,10 +6,12 @@ import {
   CIV7_BROWSER_TABLES_V0,
   CIV7_COAST_CLASSIFICATION_POLICY_V0,
   NATURAL_WONDER_CATALOG,
+  RESOURCE_ADJACENT_TO_LAND_RUNTIME_OPTIONAL_TYPE_IDS,
   WATER_CLASS_COAST,
   WATER_CLASS_OCEAN,
   applyCiv7CoastClassificationPolicy,
   getNaturalWonderFootprintIndices,
+  isResourceAdjacentToLandRuntimeOptional,
   resolveNaturalWonderPlacementDirection,
 } from "../src/index.js";
 
@@ -109,6 +111,21 @@ describe("@civ7/map-policy", () => {
       { x: 65, y: 14 },
       { x: 65, y: 13 },
     ]);
+  });
+
+  it("records the live-observed adjacent-land resource exception narrowly", () => {
+    const { resourceTypes } = CIV7_BROWSER_TABLES_V0;
+
+    expect(RESOURCE_ADJACENT_TO_LAND_RUNTIME_OPTIONAL_TYPE_IDS).toEqual([
+      resourceTypes.RESOURCE_DYES,
+      resourceTypes.RESOURCE_FISH,
+      resourceTypes.RESOURCE_PEARLS,
+      resourceTypes.RESOURCE_COWRIE,
+      resourceTypes.RESOURCE_TURTLES,
+    ]);
+    expect(isResourceAdjacentToLandRuntimeOptional(resourceTypes.RESOURCE_FISH)).toBe(true);
+    expect(isResourceAdjacentToLandRuntimeOptional(resourceTypes.RESOURCE_WHALES)).toBe(false);
+    expect(isResourceAdjacentToLandRuntimeOptional(resourceTypes.RESOURCE_CRABS)).toBe(false);
   });
 
 });


### PR DESCRIPTION
Classifies and repairs the adjacent-land resource parity class identified in the `earthlike-live-feature-resource-legality-repair` workstream.

The exact-authored live run `studio-run-in-game-mq20rbzr-1fhc` placed 252 resources with zero rejections and zero mismatches. Static surface diagnostics showed that 26 live-only coast/marine/no-feature resource cells failed only the `resource.adjacent-land` check under the local static policy, covering `RESOURCE_DYES`, `RESOURCE_FISH`, `RESOURCE_PEARLS`, `RESOURCE_COWRIE`, and `RESOURCE_TURTLES`. These rows are now classified as a repo-owned adapter/map-policy divergence from observed Civ7 `ResourceBuilder.canHaveResource` behavior.

**`@civ7/map-policy`** gains `RESOURCE_ADJACENT_TO_LAND_RUNTIME_OPTIONAL_TYPE_IDS` and `isResourceAdjacentToLandRuntimeOptional`, narrowly recording the five resource IDs whose official data carries `AdjacentToLand=true` but whose live placement proof accepted open-water cells without adjacent land. A test pins the exact set against the official resource type table and verifies that `RESOURCE_WHALES` and `RESOURCE_CRABS` remain outside the exception.

**`@civ7/adapter`** now depends on `@civ7/map-policy` directly. The mock adapter's `canHaveFeature` and `canHaveResource` paths replace their unconditional `return true` stubs with static-policy checks driven by the official-derived browser tables. `setTerrainType` now keeps the water, river, and mountain masks consistent. `getLatitude` delegates to the shared `getCiv7RowLatitude` helper. The hardcoded biome, feature, and terrain constant maps are replaced with spreads from `CIV7_BROWSER_TABLES_V0`, and the natural wonder catalog is replaced with the shared `NATURAL_WONDER_CATALOG`. A new placement-outcomes test verifies the adjacent-land behavior against a fully-water grid.

**`mods/mod-swooper-maps`** gains a `surface-delta-context` diagnostic module that cross-checks feature and resource delta rows against local and live terrain/biome/feature surfaces using the static policy tables, computing per-cell legality with reasons. Tests cover mismatch extraction, static legality classification, and cross-surface value checking.

The delta classification ledger documents all 5 feature rows and 106 resource mismatch rows from the proof artifact. The adjacent-land class is fully classified and repaired. All remaining feature rows and resource substitution/local-only classes remain `source-authority: pending` and are blocked from repair until further placement-intent, spacing, and fallback evidence is gathered.