### PR TITLE
feat(resource-parity): add resource plan and placement outcome evidence to local parity diagnostic with delta classification

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -16,6 +16,7 @@ import type { TraceEvent, TraceSink } from "@swooper/mapgen-core/trace";
 import { canonicalRecipeConfig, isPlainObject as isCanonicalMapConfigObject } from "../../maps/configs/canonical.js";
 import standardRecipe from "../../recipes/standard/recipe.js";
 import { initializeStandardRuntime } from "../../recipes/standard/runtime.js";
+import { placementArtifacts } from "../../recipes/standard/stages/placement/artifacts.js";
 import { isPlainObject, mergeDeep } from "./shared.js";
 
 export const FINAL_SURFACE_KEYS = ["terrain", "biome", "feature", "resource"] as const;
@@ -165,6 +166,8 @@ type FileIdentityLike = Readonly<{
 
 type LocalTraceEvidence = {
   placementParity?: unknown;
+  resourcePlan?: unknown;
+  resourcePlacementOutcomes?: unknown;
 };
 
 function createMemoryTraceSink(events: TraceEvent[]): TraceSink {
@@ -253,6 +256,14 @@ export function runLocalFinalSurfaceSnapshot(input: RunLocalFinalSurfaceInput): 
   for (const event of traceEvents) {
     if (event.kind !== "step.event" || !isPlainObject(event.data)) continue;
     if (event.data.type === "placement.parity") evidence.placementParity = event.data;
+  }
+  const resourcePlan = context.artifacts.get(placementArtifacts.resourcePlan.id);
+  if (resourcePlan !== undefined) evidence.resourcePlan = resourcePlan;
+  const resourcePlacementOutcomes = context.artifacts.get(
+    placementArtifacts.resourcePlacementOutcomes.id
+  );
+  if (resourcePlacementOutcomes !== undefined) {
+    evidence.resourcePlacementOutcomes = resourcePlacementOutcomes;
   }
 
   return {

--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -43,6 +43,32 @@ export type SurfaceDeltaContext = Readonly<{
   }>;
 }>;
 
+export type ResourceDeltaPlacementContext = Readonly<{
+  x: number;
+  y: number;
+  plotIndex: number;
+  localResource: Readonly<{ value: number | null; symbol: string }>;
+  liveResource: Readonly<{ value: number | null; symbol: string }>;
+  plannedPreferredResourceType: number | null;
+  plannedPreferredResourceSymbol: string;
+  localOutcome: ResourcePlacementOutcomeContext | null;
+  evidenceClass:
+    | "local-assigned-live-empty"
+    | "local-assigned-live-substitution"
+    | "live-only-no-local-assignment"
+    | "live-only-preferred-but-unassigned"
+    | "unclassified";
+}>;
+
+export type ResourcePlacementOutcomeContext = Readonly<{
+  status: string;
+  resourceType: number;
+  resourceSymbol: string;
+  observedResourceType: number | null;
+  observedResourceSymbol: string;
+  reason: string | null;
+}>;
+
 export type CellSurfaceContext = Readonly<{
   terrain: number | null;
   terrainSymbol: string;
@@ -116,6 +142,54 @@ export function buildSurfaceDeltaContexts(
       rows.push(buildSurfaceDeltaContext(proof.local, proof.live, key, x, y));
       if (rows.length >= maxRows) return rows;
     }
+  }
+
+  return rows;
+}
+
+export function buildResourceDeltaPlacementContexts(
+  proof: Pick<FinalSurfaceParityProof, "local" | "live">,
+  options: { maxRows?: number } = {}
+): ReadonlyArray<ResourceDeltaPlacementContext> {
+  const maxRows = options.maxRows ?? Number.POSITIVE_INFINITY;
+  const resourcePlan = readResourcePlanEvidence(proof.local.evidence);
+  const outcomes = readResourceOutcomeEvidence(proof.local.evidence);
+  const rows: ResourceDeltaPlacementContext[] = [];
+  const localValues = proof.local.surfaces.resource.values;
+  const liveValues = proof.live.surfaces.resource.values;
+  const length = Math.min(localValues.length, liveValues.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const localResource = normalizeSurfaceValue(localValues[index]);
+    const liveResource = normalizeSurfaceValue(liveValues[index]);
+    if (localResource === liveResource) continue;
+    const y = Math.floor(index / proof.local.width);
+    const x = index - y * proof.local.width;
+    const plannedPreferredResourceType = resourcePlan.preferredByPlot.get(index) ?? null;
+    const localOutcome = outcomes.byPlot.get(index) ?? null;
+    rows.push({
+      x,
+      y,
+      plotIndex: index,
+      localResource: {
+        value: localResource,
+        symbol: symbolFor("resource", localResource),
+      },
+      liveResource: {
+        value: liveResource,
+        symbol: symbolFor("resource", liveResource),
+      },
+      plannedPreferredResourceType,
+      plannedPreferredResourceSymbol: symbolFor("resource", plannedPreferredResourceType),
+      localOutcome,
+      evidenceClass: classifyResourceDeltaPlacement({
+        localResource,
+        liveResource,
+        plannedPreferredResourceType,
+        localOutcome,
+      }),
+    });
+    if (rows.length >= maxRows) return rows;
   }
 
   return rows;
@@ -256,6 +330,83 @@ function hasAdjacentLand(snapshot: SnapshotLike, x: number, y: number): boolean 
     if (terrain !== null && !WATER_TERRAINS.has(terrain)) return true;
   }
   return false;
+}
+
+function readResourcePlanEvidence(evidence: unknown): {
+  preferredByPlot: ReadonlyMap<number, number>;
+} {
+  const preferredByPlot = new Map<number, number>();
+  const plan = isRecord(evidence) ? evidence.resourcePlan : undefined;
+  const placements = isRecord(plan) && Array.isArray(plan.placements) ? plan.placements : [];
+  for (const placement of placements) {
+    if (!isRecord(placement)) continue;
+    const plotIndex = finiteInteger(placement.plotIndex);
+    const preferredResourceType = finiteInteger(placement.preferredResourceType);
+    if (plotIndex === null || preferredResourceType === null || preferredByPlot.has(plotIndex)) {
+      continue;
+    }
+    preferredByPlot.set(plotIndex, preferredResourceType);
+  }
+  return { preferredByPlot };
+}
+
+function readResourceOutcomeEvidence(evidence: unknown): {
+  byPlot: ReadonlyMap<number, ResourcePlacementOutcomeContext>;
+} {
+  const byPlot = new Map<number, ResourcePlacementOutcomeContext>();
+  const resourcePlacementOutcomes = isRecord(evidence)
+    ? evidence.resourcePlacementOutcomes
+    : undefined;
+  const outcomes =
+    isRecord(resourcePlacementOutcomes) && Array.isArray(resourcePlacementOutcomes.outcomes)
+      ? resourcePlacementOutcomes.outcomes
+      : [];
+  for (const outcome of outcomes) {
+    if (!isRecord(outcome)) continue;
+    const plotIndex = finiteInteger(outcome.plotIndex);
+    const resourceType = finiteInteger(outcome.resourceType);
+    if (plotIndex === null || resourceType === null || byPlot.has(plotIndex)) continue;
+    const observedResourceType = finiteInteger(outcome.observedResourceType);
+    byPlot.set(plotIndex, {
+      status: typeof outcome.status === "string" ? outcome.status : "unknown",
+      resourceType,
+      resourceSymbol: symbolFor("resource", resourceType),
+      observedResourceType,
+      observedResourceSymbol: symbolFor("resource", observedResourceType),
+      reason: typeof outcome.reason === "string" ? outcome.reason : null,
+    });
+  }
+  return { byPlot };
+}
+
+function classifyResourceDeltaPlacement(args: {
+  localResource: number | null;
+  liveResource: number | null;
+  plannedPreferredResourceType: number | null;
+  localOutcome: ResourcePlacementOutcomeContext | null;
+}): ResourceDeltaPlacementContext["evidenceClass"] {
+  const localAssigned =
+    args.localResource !== null &&
+    args.localOutcome?.status === "placed" &&
+    args.localOutcome.resourceType === args.localResource;
+  if (localAssigned && args.liveResource === null) return "local-assigned-live-empty";
+  if (localAssigned && args.liveResource !== null && args.liveResource !== args.localResource) {
+    return "local-assigned-live-substitution";
+  }
+  if (args.localResource === null && args.liveResource !== null) {
+    return args.plannedPreferredResourceType === args.liveResource
+      ? "live-only-preferred-but-unassigned"
+      : "live-only-no-local-assignment";
+  }
+  return "unclassified";
+}
+
+function finiteInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function surfaceValue(

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, test } from "bun:test";
 
 import type { FinalSurfaceSnapshot } from "../../src/dev/diagnostics/live-parity";
 import {
+  buildResourceDeltaPlacementContexts,
   buildSurfaceDeltaContext,
   buildSurfaceDeltaContexts,
   staticSurfaceLegality,
 } from "../../src/dev/diagnostics/surface-delta-context";
 
-function snapshot(overrides: Partial<FinalSurfaceSnapshot["surfaces"]> = {}): FinalSurfaceSnapshot {
+function snapshot(
+  overrides: Partial<FinalSurfaceSnapshot["surfaces"]> = {},
+  evidence?: Readonly<Record<string, unknown>>
+): FinalSurfaceSnapshot {
   const width = 3;
   const height = 2;
   return {
@@ -21,6 +25,7 @@ function snapshot(overrides: Partial<FinalSurfaceSnapshot["surfaces"]> = {}): Fi
       resource: { width, height, values: [-1, 3, -1, -1, -1, -1] },
       ...overrides,
     },
+    ...(evidence === undefined ? {} : { evidence }),
   };
 }
 
@@ -107,6 +112,73 @@ describe("surface delta context diagnostics", () => {
       symbol: "RESOURCE_FISH",
       validSurface: false,
       reasons: ["resource.surface"],
+    });
+  });
+
+  test("joins resource deltas to local placement plan and assignment outcomes", () => {
+    const local = snapshot(
+      {
+        resource: { width: 3, height: 2, values: [3, -1, 2, -1, -1, -1] },
+      },
+      {
+        resourcePlan: {
+          placements: [
+            { plotIndex: 0, preferredResourceType: 3 },
+            { plotIndex: 1, preferredResourceType: 3 },
+            { plotIndex: 2, preferredResourceType: 2 },
+          ],
+        },
+        resourcePlacementOutcomes: {
+          outcomes: [
+            {
+              status: "placed",
+              plotIndex: 0,
+              x: 0,
+              y: 0,
+              resourceType: 3,
+              observedResourceType: 3,
+            },
+            {
+              status: "placed",
+              plotIndex: 2,
+              x: 2,
+              y: 0,
+              resourceType: 2,
+              observedResourceType: 2,
+            },
+          ],
+        },
+      }
+    );
+    const live = snapshot({
+      resource: { width: 3, height: 2, values: [-1, 3, 12, -1, -1, -1] },
+    });
+
+    const rows = buildResourceDeltaPlacementContexts({ local, live });
+
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({
+      plotIndex: 0,
+      localResource: { symbol: "RESOURCE_FISH" },
+      liveResource: { symbol: "empty" },
+      plannedPreferredResourceSymbol: "RESOURCE_FISH",
+      localOutcome: { status: "placed", resourceSymbol: "RESOURCE_FISH" },
+      evidenceClass: "local-assigned-live-empty",
+    });
+    expect(rows[1]).toMatchObject({
+      plotIndex: 1,
+      localResource: { symbol: "empty" },
+      liveResource: { symbol: "RESOURCE_FISH" },
+      plannedPreferredResourceSymbol: "RESOURCE_FISH",
+      localOutcome: null,
+      evidenceClass: "live-only-preferred-but-unassigned",
+    });
+    expect(rows[2]).toMatchObject({
+      plotIndex: 2,
+      localResource: { symbol: "RESOURCE_DYES" },
+      liveResource: { symbol: "RESOURCE_PEARLS" },
+      localOutcome: { status: "placed", resourceSymbol: "RESOURCE_DYES" },
+      evidenceClass: "local-assigned-live-substitution",
     });
   });
 });

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -14,12 +14,13 @@
 - [x] 2.1 Add focused failing-row tests or diagnostics.
 - [x] 2.2 Repair the proven adapter/map-policy owner for the adjacent-land
   resource class.
-- [ ] 2.3 Repair remaining proven package or MapGen owners.
-- [ ] 2.4 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.3 Add local resource assignment evidence for remaining resource deltas.
+- [ ] 2.4 Repair remaining proven package or MapGen owners.
+- [ ] 2.5 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 
-- [ ] 3.1 Re-run final-surface feature/resource parity proof.
+- [x] 3.1 Re-run final-surface feature/resource parity proof.
 - [ ] 3.2 Re-run product acceptance rows for resources/wonders/ecology.
 - [x] 3.3 Run focused package tests/checks for touched owners.
 - [x] 3.4 Run `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -176,11 +176,90 @@ and fallback evidence before owner repair.
 ### Post-Repair Proof Status
 
 The repaired diagnostic helper reports no static surface invalid rows for the
-saved proof packet. A full final-surface verifier rerun against
-`studio-run-in-game-mq20rbzr-1fhc` could not be completed after Studio was
-restarted because the new Studio server instance no longer had that request id
-in memory. This lane therefore has no post-repair exact-authored live parity
-closure artifact yet.
+saved proof packet. The post-repair final-surface verifier rerun was completed
+with the saved exact-authorship packet wrapped as verifier input and current
+live full-grid readback from Studio/Civ:
+
+- exact proof wrapper:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json`
+  (`sha256:93a0c3e2ace18d1f3ab2eac0f9e57d2c9bb2642787afc31acc15815286d0d938`).
+- post-repair artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-adjacent-land-policy.json`
+  (`sha256:c80b0c9e77abb67bec29f84413a94d12b4aa17e9e2cf6fe788e48dd5fa91630b`,
+  `proofHash:cb74141e0c63009ecb086dc73cf6955b457910f751038776c0cbd399f7a77dd3`).
+- runtime proof: exact-authorship summary `status:"complete"`, request
+  `studio-run-in-game-mq20rbzr-1fhc`, config hash
+  `c8bf167810f92f9a6096b298d1fcf3bb6b044a0fec22a9ad0ca9b35103982dca`,
+  envelope hash
+  `a9a7bb73e9dd062e1da658a639bc02602e75b7fda1ca6d88123a1a2e9ac5f790`,
+  seed `138503614`, dimensions `106x66`, runtime turn `1`, game hash `0`,
+  source snapshot id `status:1:c153eb72`, and snapshot hash `c153eb72`.
+- live grid proof: `6996` compared plots, `0` omitted plots, `17` chunks,
+  and stable identity across map width, map height, plot count, random seed,
+  turn, and game hash.
+
+The rerun did not close parity. It remains `status:"unresolved"` with
+`surface.terrain.mismatch`, `surface.feature.mismatch`, and
+`surface.resource.mismatch`. Surface diffs remained: terrain `2/6996`,
+biome `0/6996`, feature `5/6996`, and resource `106/6996`.
+
+Interpretation:
+the adjacent-land repair removed the static-invalid diagnostic class, but it
+did not reduce the final resource coordinate mismatch count. The remaining
+resource rows therefore need placement assignment/order/fallback evidence
+before any further repair. This artifact does not prove product acceptance,
+Earthlike quality, start-placement correctness, river metadata parity, or
+natural-wonder footprint semantics.
+
+### Resource Assignment Evidence Rerun
+
+Diagnostic repair:
+`mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts` now carries local
+`resourcePlan` and typed `resourcePlacementOutcomes` into the local proof
+evidence. `surface-delta-context.ts` can join resource mismatch rows back to
+local planned preferred resource and local typed outcome evidence.
+
+Evidence artifacts:
+
+- proof:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-assignment-evidence.json`
+  (`sha256:e07418f9ab3efbab81beb6d5c6a9b68e1e40460b6d7421b5b1248a1e0578494c`,
+  `proofHash:d95d54d2f208436324d7600a0c8a8a35e899ff82c617be4b719dfc954c6897df`).
+- summary:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-assignment-summary.json`
+  (`sha256:e8d1917d657654bc0d494457c62b8c84a4613f22e024cd5ca770f7fbbb645d8b`).
+
+Resource placement evidence:
+
+| Fact | Value |
+|---|---:|
+| local resource cells | `252` |
+| live resource cells | `252` |
+| local planned placements | `252` |
+| local typed outcomes | `252` |
+| local placed outcomes | `252` |
+| local rejections | `0` |
+| local readback mismatches | `0` |
+| resource delta rows | `106` |
+
+Resource delta evidence classes:
+
+| Evidence class | Count | Implication |
+|---|---:|---|
+| `local-assigned-live-empty` | `37` | Local mock assigned and read back a resource, but live Civ final grid has no resource on that tile. |
+| `live-only-no-local-assignment` | `37` | Live Civ final grid has a resource on a tile with no local assignment/outcome. |
+| `local-assigned-live-substitution` | `32` | Local mock assigned and read back one resource type, but live Civ final grid has a different resource type on that tile. |
+
+Disposition:
+the remaining resource parity problem is not a static-surface legality failure,
+not a local placement count failure, and not local adapter rejection. Local and
+live both materialize `252` resources. The remaining source-authority question
+is why the local mock placement feasibility/order produces a different
+coordinate/type assignment than Civ materialization for the same exact-authored
+request. Before repair, the lane needs bounded Civ `ResourceBuilder.canHaveResource`
+or equivalent placement-feasibility readback for the delta rows, or an explicit
+engine-materialization policy disposition. No resource density, diversity,
+terrain, coast, or Earthlike tuning is authorized from this evidence.
 
 ## Required Next Diagnostics
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,8 +5,8 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-feature-resource-legality-drain`
-  stacked above `codex/swooper-studio-parity-proof-drain`
+- Branch/Graphite stack: `codex/swooper-resource-assignment-evidence-drain`
+  stacked above `codex/swooper-feature-resource-legality-drain`
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface. Remaining feature/resource
@@ -68,16 +68,44 @@
 - Verification progress:
   focused policy/adapter/diagnostic tests, package checks, affected Turbo
   build/check lanes, and strict OpenSpec validation pass for this integration
-  slice. No fresh final-surface runtime verifier proof was produced on
-  `codex/swooper-feature-resource-legality-drain`; task 3.1 remains open and
-  the next full parity proof needs a fresh Studio Run in Game exact-authorship
-  request.
+  slice. This slice also integrates the source-recorded post-repair
+  final-surface verifier rerun for `studio-run-in-game-mq20rbzr-1fhc`, which
+  used the saved completed exact-authorship packet from the original proof and
+  live full-grid readback from that Studio/Civ session:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-adjacent-land-policy.json`
+  (`sha256:c80b0c9e77abb67bec29f84413a94d12b4aa17e9e2cf6fe788e48dd5fa91630b`,
+  `proofHash:cb74141e0c63009ecb086dc73cf6955b457910f751038776c0cbd399f7a77dd3`,
+  created `2026-06-06T09:44:55.799Z`). The rerun completed live grid
+  readback with stable runtime identity and zero omitted plots, but it remains
+  `status:"unresolved"` with `surface.terrain.mismatch`,
+  `surface.feature.mismatch`, and `surface.resource.mismatch`.
+- Resource source-authority progress:
+  the local parity diagnostic now carries the exact local `resourcePlan` and
+  typed `resourcePlacementOutcomes` evidence. A rerun with that evidence
+  produced
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-assignment-evidence.json`
+  (`sha256:e07418f9ab3efbab81beb6d5c6a9b68e1e40460b6d7421b5b1248a1e0578494c`,
+  `proofHash:d95d54d2f208436324d7600a0c8a8a35e899ff82c617be4b719dfc954c6897df`)
+  and summary
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-assignment-summary.json`
+  (`sha256:e8d1917d657654bc0d494457c62b8c84a4613f22e024cd5ca770f7fbbb645d8b`).
+  Local and live both contain `252` resource cells; local evidence records
+  `252` planned placements, `252` typed placed outcomes, `0` rejections, and
+  `0` local readback mismatches. The `106` resource deltas classify as
+  `37` local assigned but live empty, `37` live-only with no local assignment,
+  and `32` local assigned but live substituted. This narrows the remaining
+  resource owner question to placement feasibility/order differences between
+  local mock policy and Civ materialization, not static surface legality,
+  density/count, or MapGen product tuning.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
-- Next action: run a fresh Studio Run in Game exact-authorship request, rerun
-  final-surface parity against that request, then classify remaining
-  feature/resource rows by source authority: official data, adapter/map-policy,
-  MapGen planning/materialization, accepted engine materialization, or readback
+- Next action: classify the remaining feature/resource rows by source
+  authority: official data, adapter/map-policy, MapGen
+  planning/materialization, accepted engine materialization, or readback
   limitation. Terrain edge rows may enter this slice only if diagnostics prove
-  shared materialization ownership.
+  shared materialization ownership. The unchanged resource mismatch count after
+  the adjacent-land repair and the assignment-evidence rerun means the next
+  resource authority gap is a bounded Civ `ResourceBuilder.canHaveResource`
+  / placement-feasibility readback surface for the delta rows, not resource
+  tuning.
 - Stop condition: source authority is not known for any row outside the
   classified adjacent-land resource class.


### PR DESCRIPTION
Adds local `resourcePlan` and `resourcePlacementOutcomes` artifacts to the live-parity diagnostic evidence, and introduces `buildResourceDeltaPlacementContexts` to join resource mismatch rows back to planned preferred resource types and typed placement outcomes.

Each delta row is classified into one of four evidence classes: `local-assigned-live-empty`, `local-assigned-live-substitution`, `live-only-preferred-but-unassigned`, or `live-only-no-local-assignment`. A rerun against the saved exact-authorship packet confirms that local and live both materialize 252 resource cells with 0 local rejections and 0 local readback mismatches, and that the 106 resource deltas break down as 37 local-assigned-live-empty, 37 live-only-no-local-assignment, and 32 local-assigned-live-substitution. This rules out static surface legality, density count, and MapGen product tuning as the remaining source-authority gap, narrowing the open question to placement feasibility and ordering differences between the local mock policy and Civ materialization.