### PR TITLE
feat(civ7-direct-control): add bounded `getCiv7ResourcePlacementFeasibility` wrapper over `ResourceBuilder.canHaveResource`

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -15,8 +15,9 @@
 - [x] 2.2 Repair the proven adapter/map-policy owner for the adjacent-land
   resource class.
 - [x] 2.3 Add local resource assignment evidence for remaining resource deltas.
-- [ ] 2.4 Repair remaining proven package or MapGen owners.
-- [ ] 2.5 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.4 Add bounded Civ resource feasibility readback for resource deltas.
+- [ ] 2.5 Repair remaining proven package or MapGen owners.
+- [ ] 2.6 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -261,6 +261,45 @@ or equivalent placement-feasibility readback for the delta rows, or an explicit
 engine-materialization policy disposition. No resource density, diversity,
 terrain, coast, or Earthlike tuning is authorized from this evidence.
 
+### Civ Resource Feasibility Readback
+
+Diagnostic repair:
+`@civ7/direct-control` now owns a bounded
+`getCiv7ResourcePlacementFeasibility` wrapper over
+`ResourceBuilder.canHaveResource`; no caller-local tuner script is needed for
+resource legality readback.
+
+Evidence artifact:
+
+- `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-feasibility-readback.json`
+  (`sha256:139c8e52c2acd91b01415f8daee6b5dd27ee28e2db26857627118d993cc2e96c`).
+- Source proof: assignment-evidence artifact
+  `d95d54d2f208436324d7600a0c8a8a35e899ff82c617be4b719dfc954c6897df`.
+- Readback: Tuner state `1`, host `127.0.0.1`, port `4318`, `106` cells,
+  `0` omitted cells.
+
+Strict readback (`ignoreWeight:false`) is not sufficient as a
+post-materialization acceptance oracle: all `69` live non-empty delta probes
+returned false, including resources that the live grid shows as present.
+
+`ignoreWeight:true` readback:
+
+| Class | Count | Source-authority implication |
+|---|---:|---|
+| `live-only-no-local-assignment`, live feasible | `37` | Civ says the live value is feasible, but the local assignment algorithm did not assign that cell. This points to assignment ordering/rebalance divergence, not static legality. |
+| `local-assigned-live-empty`, local feasible | `28` | Local assigned a Civ-feasible resource where live has no resource. This also points to assignment ordering/rebalance divergence. |
+| `local-assigned-live-empty`, local infeasible | `9` | Local mock/static policy over-accepted a resource Civ rejects under the loose feasibility probe. This is the next focused adapter/map-policy repair class. |
+| `local-assigned-live-substitution`, both feasible | `31` | Both local and live resource values are Civ-feasible at the tile; this is assignment/type-order divergence, not simple legality. |
+| `local-assigned-live-substitution`, both infeasible | `1` | Preserve as an individual evidence row before repair; neither probed value is feasible under the loose check on the current live map. |
+
+Disposition:
+the feasibility readback narrows but does not close source authority. Most
+remaining rows are now assignment ordering/rebalance evidence, not map-policy
+surface legality. A smaller `9`-row local-overacceptance class is likely
+adapter/map-policy-owned, but it still needs row-level symbol/context
+extraction before a focused policy repair. No resource density, diversity,
+terrain, coast, or Earthlike tuning is authorized.
+
 ## Required Next Diagnostics
 
 - Extract local row context for every feature/resource mismatch: terrain,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,12 +5,14 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-assignment-evidence-drain`
-  stacked above `codex/swooper-feature-resource-legality-drain`
+- Branch/Graphite stack: `codex/swooper-resource-feasibility-readback-drain`
+  stacked above `codex/swooper-resource-assignment-evidence-drain`
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
-  in the repo-owned adapter/map-policy surface. Remaining feature/resource
-  classes are linked but still pending source-authority classification.
+  in the repo-owned adapter/map-policy surface, and bounded Civ resource
+  feasibility readback now narrows the next resource repair class. Remaining
+  feature/resource classes still need source-authority classification before
+  repair.
 
 ## Objective
 
@@ -97,6 +99,23 @@
   resource owner question to placement feasibility/order differences between
   local mock policy and Civ materialization, not static surface legality,
   density/count, or MapGen product tuning.
+- Civ feasibility readback progress:
+  `@civ7/direct-control` now has a package-owned
+  `getCiv7ResourcePlacementFeasibility` read wrapper over
+  `ResourceBuilder.canHaveResource`. Live readback for the `106` resource
+  delta rows is recorded at
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-feasibility-readback.json`
+  (`sha256:139c8e52c2acd91b01415f8daee6b5dd27ee28e2db26857627118d993cc2e96c`).
+  Strict `ignoreWeight:false` is not a clean post-materialization acceptance
+  oracle because all `69` live non-empty delta probes returned false on the
+  already-materialized map. With `ignoreWeight:true`, `68/69` live values and
+  `59/69` local values are Civ-feasible; `37` live-only rows are feasible but
+  were not locally assigned, `28` local-assigned/live-empty rows are feasible,
+  `31` substitution rows have both local and live values feasible, `9`
+  local-assigned/live-empty rows are local-overaccepted by the mock/static
+  surface, and `1` substitution row remains feasibility-negative for both
+  probed values. This points the next repair investigation at assignment
+  ordering/rebalance and a smaller mock feasibility over-acceptance class.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -104,8 +123,11 @@
   limitation. Terrain edge rows may enter this slice only if diagnostics prove
   shared materialization ownership. The unchanged resource mismatch count after
   the adjacent-land repair and the assignment-evidence rerun means the next
-  resource authority gap is a bounded Civ `ResourceBuilder.canHaveResource`
-  / placement-feasibility readback surface for the delta rows, not resource
-  tuning.
+  resource authority gap is assignment ordering/rebalance diagnostics plus
+  focused mock feasibility classification for the `9` local-assigned/live-empty
+  rows where Civ rejects the local value with `ignoreWeight:true`, not resource
+  tuning. The single substitution row where both probed values are infeasible
+  remains an individual evidence row with no repair authority until row-level
+  context assigns source ownership.
 - Stop condition: source authority is not known for any row outside the
   classified adjacent-land resource class.

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -49,6 +49,7 @@ export const DEFAULT_CIV7_TUNER_API_ROOTS = [
   "Autoplay",
   "Players",
   "GameplayMap",
+  "ResourceBuilder",
   "GameInfo",
   "PlayerIds",
 ] as const;
@@ -76,6 +77,7 @@ export const DEFAULT_CIV7_CAPABILITY_TUNER_ROOTS = [
   "MapUnits",
   "MapCities",
   "Visibility",
+  "ResourceBuilder",
   "GameInfo",
   "Database",
   "UnitOperationTypes",
@@ -141,6 +143,10 @@ export const DEFAULT_CIV7_PLAYER_SETUP_PARAMETER_IDS = [
 ] as const;
 export const DEFAULT_CIV7_MAP_GRID_MAX_PLOTS = 512;
 export const HARD_CIV7_MAP_GRID_MAX_PLOTS = 10_000;
+export const DEFAULT_CIV7_RESOURCE_FEASIBILITY_MAX_CELLS = 256;
+export const HARD_CIV7_RESOURCE_FEASIBILITY_MAX_CELLS = 1_000;
+export const DEFAULT_CIV7_RESOURCE_FEASIBILITY_MAX_TYPES_PER_CELL = 64;
+export const HARD_CIV7_RESOURCE_FEASIBILITY_MAX_TYPES_PER_CELL = 256;
 export const DEFAULT_CIV7_GAMEINFO_LIMIT = 100;
 export const HARD_CIV7_GAMEINFO_LIMIT = 1_000;
 export const DEFAULT_CIV7_ROOT_MAX_KEYS = 100;
@@ -457,6 +463,36 @@ export type Civ7MapGridReadChunk = Readonly<{
   bounds: Civ7MapBounds;
   plotCount: number;
   omitted: number;
+}>;
+
+export type Civ7ResourcePlacementFeasibilityCellInput = Readonly<Civ7MapLocation & {
+  resourceTypes: ReadonlyArray<number>;
+}>;
+
+export type Civ7ResourcePlacementFeasibilityInput = Readonly<{
+  cells: ReadonlyArray<Civ7ResourcePlacementFeasibilityCellInput>;
+  maxCells?: number;
+  maxResourceTypesPerCell?: number;
+  ignoreWeight?: boolean;
+}>;
+
+export type Civ7ResourcePlacementFeasibilityCell = Readonly<{
+  location: Readonly<Civ7MapLocation & {
+    index: Civ7RuntimeProbe<number>;
+  }>;
+  resourceTypes: ReadonlyArray<number>;
+  omittedResourceTypes: number;
+  feasibility: Readonly<Record<string, Civ7RuntimeProbe<boolean>>>;
+}>;
+
+export type Civ7ResourcePlacementFeasibilityResult = Readonly<{
+  host: string;
+  port: number;
+  state: Civ7TunerState;
+  cellCount: number;
+  omittedCells: number;
+  ignoreWeight: boolean;
+  cells: ReadonlyArray<Civ7ResourcePlacementFeasibilityCell>;
 }>;
 
 export type Civ7FullMapGridIdentityCheck = Readonly<{
@@ -1652,6 +1688,42 @@ export async function getCiv7MapGrid(
     }),
   });
   return jsonPayloadFromCommandResult<Civ7MapGridResult>(result, "Civ7 map grid");
+}
+
+export async function getCiv7ResourcePlacementFeasibility(
+  input: Civ7ResourcePlacementFeasibilityInput,
+  options: Civ7DirectControlOptions = {},
+): Promise<Civ7ResourcePlacementFeasibilityResult> {
+  const maxCells = boundedInteger(
+    input.maxCells ?? DEFAULT_CIV7_RESOURCE_FEASIBILITY_MAX_CELLS,
+    1,
+    HARD_CIV7_RESOURCE_FEASIBILITY_MAX_CELLS,
+    "maxCells",
+  );
+  const maxResourceTypesPerCell = boundedInteger(
+    input.maxResourceTypesPerCell ?? DEFAULT_CIV7_RESOURCE_FEASIBILITY_MAX_TYPES_PER_CELL,
+    1,
+    HARD_CIV7_RESOURCE_FEASIBILITY_MAX_TYPES_PER_CELL,
+    "maxResourceTypesPerCell",
+  );
+  validateResourcePlacementFeasibilityInput(input, maxCells, maxResourceTypesPerCell);
+  const result = await executeCiv7TunerCommand({
+    ...options,
+    command: buildResourcePlacementFeasibilityCommand({
+      cells: input.cells.slice(0, maxCells).map((cell) => ({
+        ...cell,
+        resourceTypes: cell.resourceTypes.slice(0, maxResourceTypesPerCell),
+        requestedResourceTypeCount: cell.resourceTypes.length,
+      })),
+      requestedCellCount: input.cells.length,
+      maxResourceTypesPerCell,
+      ignoreWeight: input.ignoreWeight === true,
+    }),
+  });
+  return jsonPayloadFromCommandResult<Civ7ResourcePlacementFeasibilityResult>(
+    result,
+    "Civ7 resource placement feasibility",
+  );
 }
 
 export async function getCiv7FullMapGrid(
@@ -3012,6 +3084,50 @@ function buildMapGridCommand(input: Civ7MapGridInput & {
   })()`;
 }
 
+function buildResourcePlacementFeasibilityCommand(input: {
+  cells: ReadonlyArray<Civ7ResourcePlacementFeasibilityCellInput & {
+    requestedResourceTypeCount: number;
+  }>;
+  requestedCellCount: number;
+  maxResourceTypesPerCell: number;
+  ignoreWeight: boolean;
+}): string {
+  return `(() => {
+    ${probeHelperSource()}
+    const input = ${jsLiteral(input)};
+    const rb = typeof ResourceBuilder !== "undefined" ? ResourceBuilder : undefined;
+    const canHaveResource = (x, y, resourceType) => {
+      if (!rb || typeof rb.canHaveResource !== "function") {
+        throw new Error("ResourceBuilder.canHaveResource is unavailable");
+      }
+      return rb.canHaveResource(x, y, resourceType, input.ignoreWeight === true);
+    };
+    const readResourcePlacementFeasibility = (cell) => {
+      const resourceTypes = cell.resourceTypes.slice(0, input.maxResourceTypesPerCell);
+      const feasibility = {};
+      for (const resourceType of resourceTypes) {
+        feasibility[String(resourceType)] = probe(() => canHaveResource(cell.x, cell.y, resourceType));
+      }
+      return {
+        location: {
+          x: cell.x,
+          y: cell.y,
+          index: probe(() => GameplayMap.getIndexFromXY(cell.x, cell.y)),
+        },
+        resourceTypes,
+        omittedResourceTypes: Math.max(0, (cell.requestedResourceTypeCount ?? resourceTypes.length) - resourceTypes.length),
+        feasibility,
+      };
+    };
+    return JSON.stringify({
+      cellCount: input.requestedCellCount,
+      omittedCells: Math.max(0, input.requestedCellCount - input.cells.length),
+      ignoreWeight: input.ignoreWeight === true,
+      cells: input.cells.map((cell) => readResourcePlacementFeasibility(cell)),
+    });
+  })()`;
+}
+
 function buildPlayerSummaryCommand(input: Civ7PlayerSummaryInput & { maxItems: number }): string {
   return `(() => {
     ${probeHelperSource()}
@@ -3916,6 +4032,18 @@ const STATIC_CIV7_CAPABILITY_ENTRIES: ReadonlyArray<Civ7CapabilityCatalogEntry> 
     confidence: "recorded-live-proof",
   },
   {
+    id: "wrapper.resource-placement-feasibility",
+    name: "Resource Placement Feasibility",
+    role: "tuner",
+    kind: "read-wrapper",
+    owner: "@civ7/direct-control",
+    risk: "read",
+    provenance: ["ResourceBuilder.canHaveResource", "GameplayMap"],
+    wrapper: "getCiv7ResourcePlacementFeasibility",
+    confidence: "source",
+    description: "Reads bounded per-cell resource feasibility probes for parity/source-authority diagnostics without mutating the map.",
+  },
+  {
     id: "wrapper.autoplay",
     name: "Autoplay Control",
     role: "app-ui",
@@ -3985,6 +4113,43 @@ function validateMapGridInput(input: Civ7MapGridInput, maxPlots: number): void {
     );
   }
   for (const location of locations.slice(0, maxPlots)) validateMapLocation(location);
+}
+
+function validateResourcePlacementFeasibilityInput(
+  input: Civ7ResourcePlacementFeasibilityInput,
+  maxCells: number,
+  maxResourceTypesPerCell: number,
+): void {
+  if (!Array.isArray(input.cells) || input.cells.length === 0) {
+    throw new Civ7DirectControlError(
+      "command-failed",
+      "Resource placement feasibility reads require at least one cell",
+    );
+  }
+  if (input.cells.length > HARD_CIV7_RESOURCE_FEASIBILITY_MAX_CELLS) {
+    throw new Civ7DirectControlError(
+      "command-failed",
+      `Resource placement feasibility cell lists must not exceed ${HARD_CIV7_RESOURCE_FEASIBILITY_MAX_CELLS} entries`,
+    );
+  }
+  for (const cell of input.cells.slice(0, maxCells)) {
+    validateMapLocation(cell);
+    if (!Array.isArray(cell.resourceTypes) || cell.resourceTypes.length === 0) {
+      throw new Civ7DirectControlError(
+        "command-failed",
+        "Resource placement feasibility cells require at least one resource type",
+      );
+    }
+    if (cell.resourceTypes.length > HARD_CIV7_RESOURCE_FEASIBILITY_MAX_TYPES_PER_CELL) {
+      throw new Civ7DirectControlError(
+        "command-failed",
+        `Resource placement feasibility resource type lists must not exceed ${HARD_CIV7_RESOURCE_FEASIBILITY_MAX_TYPES_PER_CELL} entries`,
+      );
+    }
+    for (const resourceType of cell.resourceTypes.slice(0, maxResourceTypesPerCell)) {
+      boundedInteger(resourceType, 0, 1_000_000, "resourceType");
+    }
+  }
 }
 
 export function planCiv7MapGridReadBounds(

--- a/packages/civ7-direct-control/test/direct-control.test.ts
+++ b/packages/civ7-direct-control/test/direct-control.test.ts
@@ -25,6 +25,7 @@ import {
   getCiv7MapSummary,
   getCiv7PlotSnapshot,
   getCiv7PlayableStatus,
+  getCiv7ResourcePlacementFeasibility,
   getCiv7SetupMapRows,
   getCiv7SetupSnapshot,
   getCiv7VisibilitySummary,
@@ -430,6 +431,45 @@ describe("Civ7 direct control", () => {
         code: "command-failed",
         message: expect.stringContaining("Civ7 full-grid identity changed during read: game.hash 0 -> 1"),
       });
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("wraps resource placement feasibility through ResourceBuilder", async () => {
+    const server = await startTunerServer();
+    try {
+      const { port } = server.address();
+      const feasibility = await getCiv7ResourcePlacementFeasibility(
+        {
+          cells: [
+            { x: 9, y: 9, resourceTypes: [3, 12] },
+            { x: 10, y: 9, resourceTypes: [53] },
+          ],
+          maxCells: 1,
+          maxResourceTypesPerCell: 1,
+          ignoreWeight: true,
+        },
+        { host: "127.0.0.1", port, timeoutMs: 1_000 },
+      );
+
+      expect(feasibility).toMatchObject({
+        cellCount: 2,
+        omittedCells: 1,
+        ignoreWeight: true,
+        cells: [
+          {
+            location: { x: 9, y: 9, index: { ok: true, value: 765 } },
+            resourceTypes: [3],
+            omittedResourceTypes: 1,
+            feasibility: {
+              "3": { ok: true, value: true },
+            },
+          },
+        ],
+      });
+      expect(server.received.some((message) => message.includes("ResourceBuilder"))).toBe(true);
+      expect(server.received.some((message) => message.includes("readResourcePlacementFeasibility"))).toBe(true);
     } finally {
       await server.close();
     }
@@ -1492,6 +1532,26 @@ async function startTunerServer(options: {
                 hiddenInfoPolicy: "not-player-scoped",
                 map: { width: { ok: true, value: 84 }, height: { ok: true, value: 54 } },
                 plots: selectedPlots,
+              }),
+            ]),
+          );
+        } else if (frame.message.includes("readResourcePlacementFeasibility")) {
+          socket.write(
+            encodeResponse(frame.listenerId, [
+              JSON.stringify({
+                cellCount: 2,
+                omittedCells: 1,
+                ignoreWeight: true,
+                cells: [
+                  {
+                    location: { x: 9, y: 9, index: { ok: true, value: 765 } },
+                    resourceTypes: [3],
+                    omittedResourceTypes: 1,
+                    feasibility: {
+                      "3": { ok: true, value: true },
+                    },
+                  },
+                ],
               }),
             ]),
           );


### PR DESCRIPTION
Adds a bounded `getCiv7ResourcePlacementFeasibility` wrapper to `@civ7/direct-control` that calls `ResourceBuilder.canHaveResource` via the Tuner for per-cell resource legality probes across a set of delta rows.

The wrapper accepts a list of cells with associated resource type IDs, enforces hard and default limits on cell count (256/1,000) and resource types per cell (64/256), and returns per-cell feasibility probes alongside omission counts. `ResourceBuilder` is added to both the Tuner API roots and capability Tuner roots so it is accessible in the injected command context. A capability catalog entry is registered for the wrapper with `read` risk and `source` confidence.

Live readback against 106 resource delta rows (with `ignoreWeight:true`) shows that most remaining mismatches are assignment ordering or rebalance divergence rather than static map-policy legality failures. A focused class of 9 local-assigned/live-empty rows where Civ rejects the local value under the loose feasibility probe is identified as the next adapter/map-policy repair target. Strict `ignoreWeight:false` readback is ruled out as a post-materialization acceptance oracle because all 69 live non-empty delta probes returned false on the already-materialized map.

The task list is updated to mark the feasibility readback step complete and renumber the remaining tasks accordingly. The phase record and delta classification ledger are updated to reflect the narrowed repair scope.