### PR TITLE
feat(swooper-earthlike): add row-level resource delta feasibility classification, full artifact verifier, and runtime identity guard

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -60,6 +60,46 @@ export type ResourceDeltaPlacementContext = Readonly<{
     | "unclassified";
 }>;
 
+export type ResourceDeltaFeasibilityContext = ResourceDeltaPlacementContext &
+  Readonly<{
+    localFeasibleInCiv: ResourceFeasibilityProbe | null;
+    liveFeasibleInCiv: ResourceFeasibilityProbe | null;
+    feasibilityClass:
+      | "live-feasible-no-local-assignment"
+      | "local-feasible-live-empty"
+      | "local-overaccepted-live-empty"
+      | "substitution-both-feasible"
+      | "substitution-both-infeasible"
+      | "substitution-mixed-feasibility"
+      | "feasibility-missing"
+      | "unclassified";
+  }>;
+
+export type ResourceFeasibilityProbe = Readonly<{
+  ok: boolean;
+  value: boolean | null;
+  error: string | null;
+}>;
+
+export type ResourceFeasibilityReadbackLike = Readonly<{
+  cells?: ReadonlyArray<ResourceFeasibilityCellLike>;
+}>;
+
+export type ResourceFeasibilityCellLike = Readonly<{
+  location?: Readonly<{
+    x?: number;
+    y?: number;
+    index?: ResourceFeasibilityRuntimeProbeLike<number>;
+  }>;
+  feasibility?: Readonly<Record<string, ResourceFeasibilityRuntimeProbeLike<boolean>>>;
+}>;
+
+export type ResourceFeasibilityRuntimeProbeLike<T> = Readonly<{
+  ok?: boolean;
+  value?: T;
+  error?: string;
+}>;
+
 export type ResourcePlacementOutcomeContext = Readonly<{
   status: string;
   resourceType: number;
@@ -193,6 +233,35 @@ export function buildResourceDeltaPlacementContexts(
   }
 
   return rows;
+}
+
+export function buildResourceDeltaFeasibilityContexts(
+  proof: Pick<FinalSurfaceParityProof, "local" | "live">,
+  feasibility: ResourceFeasibilityReadbackLike,
+  options: { maxRows?: number } = {}
+): ReadonlyArray<ResourceDeltaFeasibilityContext> {
+  const byCell = readResourceFeasibilityByCell(feasibility);
+  return buildResourceDeltaPlacementContexts(proof, options).map((row) => {
+    const cell = byCell.get(resourceFeasibilityCellKey(row.x, row.y, row.plotIndex));
+    const localFeasibleInCiv =
+      row.localResource.value === null
+        ? null
+        : readResourceFeasibilityProbe(cell, row.localResource.value);
+    const liveFeasibleInCiv =
+      row.liveResource.value === null
+        ? null
+        : readResourceFeasibilityProbe(cell, row.liveResource.value);
+    return {
+      ...row,
+      localFeasibleInCiv,
+      liveFeasibleInCiv,
+      feasibilityClass: classifyResourceDeltaFeasibility({
+        evidenceClass: row.evidenceClass,
+        localFeasibleInCiv,
+        liveFeasibleInCiv,
+      }),
+    };
+  });
 }
 
 export function buildSurfaceDeltaContext(
@@ -379,6 +448,38 @@ function readResourceOutcomeEvidence(evidence: unknown): {
   return { byPlot };
 }
 
+function readResourceFeasibilityByCell(
+  feasibility: ResourceFeasibilityReadbackLike
+): ReadonlyMap<string, ResourceFeasibilityCellLike> {
+  const byCell = new Map<string, ResourceFeasibilityCellLike>();
+  const cells = Array.isArray(feasibility.cells) ? feasibility.cells : [];
+  for (const cell of cells) {
+    const location = cell.location;
+    const x = finiteInteger(location?.x);
+    const y = finiteInteger(location?.y);
+    const index = finiteInteger(location?.index?.value);
+    if (x === null || y === null || index === null) continue;
+    byCell.set(resourceFeasibilityCellKey(x, y, index), cell);
+  }
+  return byCell;
+}
+
+function readResourceFeasibilityProbe(
+  cell: ResourceFeasibilityCellLike | undefined,
+  resourceType: number
+): ResourceFeasibilityProbe {
+  const probe = cell?.feasibility?.[String(resourceType)];
+  if (probe === undefined) {
+    return { ok: false, value: null, error: "missing-probe" };
+  }
+  const ok = probe.ok === true;
+  return {
+    ok,
+    value: ok && typeof probe.value === "boolean" ? probe.value : null,
+    error: typeof probe.error === "string" ? probe.error : ok ? null : "probe-failed",
+  };
+}
+
 function classifyResourceDeltaPlacement(args: {
   localResource: number | null;
   liveResource: number | null;
@@ -399,6 +500,38 @@ function classifyResourceDeltaPlacement(args: {
       : "live-only-no-local-assignment";
   }
   return "unclassified";
+}
+
+function classifyResourceDeltaFeasibility(args: {
+  evidenceClass: ResourceDeltaPlacementContext["evidenceClass"];
+  localFeasibleInCiv: ResourceFeasibilityProbe | null;
+  liveFeasibleInCiv: ResourceFeasibilityProbe | null;
+}): ResourceDeltaFeasibilityContext["feasibilityClass"] {
+  const local = args.localFeasibleInCiv;
+  const live = args.liveFeasibleInCiv;
+  if ((local !== null && !local.ok) || (live !== null && !live.ok)) return "feasibility-missing";
+  if (
+    args.evidenceClass === "live-only-no-local-assignment" ||
+    args.evidenceClass === "live-only-preferred-but-unassigned"
+  ) {
+    return live?.value === true ? "live-feasible-no-local-assignment" : "feasibility-missing";
+  }
+  if (args.evidenceClass === "local-assigned-live-empty") {
+    if (local?.value === true) return "local-feasible-live-empty";
+    if (local?.value === false) return "local-overaccepted-live-empty";
+    return "feasibility-missing";
+  }
+  if (args.evidenceClass === "local-assigned-live-substitution") {
+    if (local?.value === true && live?.value === true) return "substitution-both-feasible";
+    if (local?.value === false && live?.value === false) return "substitution-both-infeasible";
+    if (local !== null && live !== null) return "substitution-mixed-feasibility";
+    return "feasibility-missing";
+  }
+  return "unclassified";
+}
+
+function resourceFeasibilityCellKey(x: number, y: number, plotIndex: number): string {
+  return `${plotIndex}:${x},${y}`;
 }
 
 function finiteInteger(value: unknown): number | null {

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { FinalSurfaceSnapshot } from "../../src/dev/diagnostics/live-parity";
 import {
+  buildResourceDeltaFeasibilityContexts,
   buildResourceDeltaPlacementContexts,
   buildSurfaceDeltaContext,
   buildSurfaceDeltaContexts,
@@ -181,4 +182,96 @@ describe("surface delta context diagnostics", () => {
       evidenceClass: "local-assigned-live-substitution",
     });
   });
+
+  test("classifies resource deltas with Civ feasibility readback", () => {
+    const local = snapshot(
+      {
+        resource: {
+          width: 3,
+          height: 2,
+          values: [3, -1, 2, 6, 53, 14],
+        },
+      },
+      {
+        resourcePlan: {
+          placements: [
+            { plotIndex: 0, preferredResourceType: 3 },
+            { plotIndex: 1, preferredResourceType: 3 },
+            { plotIndex: 2, preferredResourceType: 2 },
+            { plotIndex: 3, preferredResourceType: 6 },
+            { plotIndex: 4, preferredResourceType: 53 },
+            { plotIndex: 5, preferredResourceType: 14 },
+          ],
+        },
+        resourcePlacementOutcomes: {
+          outcomes: [
+            { status: "placed", plotIndex: 0, x: 0, y: 0, resourceType: 3, observedResourceType: 3 },
+            { status: "placed", plotIndex: 2, x: 2, y: 0, resourceType: 2, observedResourceType: 2 },
+            { status: "placed", plotIndex: 3, x: 0, y: 1, resourceType: 6, observedResourceType: 6 },
+            { status: "placed", plotIndex: 4, x: 1, y: 1, resourceType: 53, observedResourceType: 53 },
+            { status: "placed", plotIndex: 5, x: 2, y: 1, resourceType: 14, observedResourceType: 14 },
+          ],
+        },
+      }
+    );
+    const live = snapshot({
+      resource: {
+        width: 3,
+        height: 2,
+        values: [-1, 3, 12, -1, -1, 6],
+      },
+    });
+
+    const rows = buildResourceDeltaFeasibilityContexts(
+      { local, live },
+      {
+        cells: [
+          feasibilityCell(0, 0, 0, { 3: true }),
+          feasibilityCell(1, 0, 1, { 3: true }),
+          feasibilityCell(2, 0, 2, { 2: true, 12: true }),
+          feasibilityCell(0, 1, 3, { 6: false }),
+          feasibilityCell(1, 1, 4, { 53: true }),
+          feasibilityCell(2, 1, 5, { 14: false, 6: false }),
+        ],
+      }
+    );
+
+    expect(rows.map((row) => row.feasibilityClass)).toEqual([
+      "local-feasible-live-empty",
+      "live-feasible-no-local-assignment",
+      "substitution-both-feasible",
+      "local-overaccepted-live-empty",
+      "local-feasible-live-empty",
+      "substitution-both-infeasible",
+    ]);
+    expect(rows[3]).toMatchObject({
+      evidenceClass: "local-assigned-live-empty",
+      localResource: { symbol: "RESOURCE_GYPSUM" },
+      liveResource: { symbol: "empty" },
+      localFeasibleInCiv: { ok: true, value: false },
+    });
+    expect(rows[5]).toMatchObject({
+      evidenceClass: "local-assigned-live-substitution",
+      localResource: { symbol: "RESOURCE_SILVER" },
+      liveResource: { symbol: "RESOURCE_GYPSUM" },
+      feasibilityClass: "substitution-both-infeasible",
+    });
+  });
 });
+
+function feasibilityCell(
+  x: number,
+  y: number,
+  index: number,
+  values: Readonly<Record<number, boolean>>
+) {
+  return {
+    location: { x, y, index: { ok: true, value: index } },
+    feasibility: Object.fromEntries(
+      Object.entries(values).map(([resourceType, value]) => [
+        resourceType,
+        { ok: true, value },
+      ])
+    ),
+  };
+}

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -16,8 +16,12 @@
   resource class.
 - [x] 2.3 Add local resource assignment evidence for remaining resource deltas.
 - [x] 2.4 Add bounded Civ resource feasibility readback for resource deltas.
-- [ ] 2.5 Repair remaining proven package or MapGen owners.
-- [ ] 2.6 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.5 Add row-level feasibility classification diagnostics for remaining
+  resource deltas.
+- [x] 2.6 Produce full row-level feasibility artifact for remaining resource
+  deltas.
+- [ ] 2.7 Repair remaining proven package or MapGen owners.
+- [ ] 2.8 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -300,6 +300,95 @@ adapter/map-policy-owned, but it still needs row-level symbol/context
 extraction before a focused policy repair. No resource density, diversity,
 terrain, coast, or Earthlike tuning is authorized.
 
+### Row-Level Feasibility Classification Diagnostic
+
+Diagnostic repair:
+`mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts` now joins
+local resource delta placement context to a provided Civ resource feasibility
+readback. This is an evidence-classifier only; it does not change resource
+planning, placement, static policy, generated maps, or tuning.
+
+Classification labels:
+
+| Diagnostic class | Source-authority implication |
+|---|---|
+| `live-feasible-no-local-assignment` | Civ says the live resource value is feasible, but local assignment did not place it on that cell; investigate assignment ordering/rebalance before repair. |
+| `local-feasible-live-empty` | Local placed a Civ-feasible resource where live has no resource; investigate assignment ordering/rebalance before repair. |
+| `local-overaccepted-live-empty` | Local placed a resource Civ rejects on that cell under loose feasibility; this is the focused `9`-row mock/static-policy overacceptance investigation class. |
+| `substitution-both-feasible` | Local and live resource values are both Civ-feasible; investigate resource type ordering/fallback selection before repair. |
+| `substitution-both-infeasible` | Preserve as an individual unresolved evidence row; no repair authority exists until row-level context/source authority is classified. |
+
+Disposition:
+the diagnostic enforces the proof boundary from the feasibility artifact. It
+keeps the `9` local-overacceptance rows separate from the single both-infeasible
+substitution row and prevents the latter from being folded into mock/static
+policy repair authority.
+
+### Full Resource Delta Feasibility Artifact
+
+Verifier:
+`scripts/civ7-direct-control/verify-resource-delta-feasibility.ts`.
+
+Runtime binding:
+before probing resource feasibility, the verifier reads current live map
+identity through package-owned `getCiv7MapSummary` and compares it to the saved
+final-surface proof. Missing or mismatched width, height, plot count, seed,
+turn, or game hash blocks the artifact before row-level feasibility evidence is
+accepted.
+
+Artifact:
+`/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
+(`sha256:8ea0fcbf898c4cacd7bf1a19f8955e846e4c18631af4a7673ffc7cf058d8c35d`,
+`proofHash:b066b90c41d89e5be0cec575218b0e14351a18f8a1c416f5948249c5acfbd2b2`).
+
+Source proof:
+`d95d54d2f208436324d7600a0c8a8a35e899ff82c617be4b719dfc954c6897df`.
+
+Runtime identity:
+saved and observed identities match at width `106`, height `66`, plot count
+`6996`, seed `138503614`, turn `1`, and game hash `0`.
+
+Readback:
+Tuner state `1`, host `127.0.0.1`, port `4318`, `106` cells, `0` omitted
+cells.
+
+`ignoreWeight:true` row classes:
+
+| Class | Count | Source-authority status |
+|---|---:|---|
+| `live-feasible-no-local-assignment` | `37` | Assignment ordering/rebalance pending. |
+| `local-feasible-live-empty` | `28` | Assignment ordering/rebalance pending. |
+| `local-overaccepted-live-empty` | `9` | Focused mock/static-policy overacceptance investigation. |
+| `substitution-both-feasible` | `31` | Assignment/type-order divergence pending. |
+| `substitution-both-infeasible` | `1` | Individual unresolved row; no repair authority yet. |
+
+Focused `local-overaccepted-live-empty` rows:
+
+| Coordinate | Plot | Local resource | Planned preferred | Local outcome | Civ loose feasibility |
+|---|---:|---|---|---|---|
+| `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `RESOURCE_CLAY` | false |
+| `(31,4)` | `455` | `RESOURCE_CLAY` | empty | `RESOURCE_CLAY` | false |
+| `(56,6)` | `692` | `RESOURCE_GYPSUM` | empty | `RESOURCE_GYPSUM` | false |
+| `(16,12)` | `1288` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | false |
+| `(12,19)` | `2026` | `RESOURCE_JADE` | `RESOURCE_SILK` | `RESOURCE_JADE` | false |
+| `(9,21)` | `2235` | `RESOURCE_HORSES` | `RESOURCE_COWRIE` | `RESOURCE_HORSES` | false |
+| `(72,35)` | `3782` | `RESOURCE_RICE` | empty | `RESOURCE_RICE` | false |
+| `(86,38)` | `4114` | `RESOURCE_CLAY` | empty | `RESOURCE_CLAY` | false |
+| `(67,51)` | `5473` | `RESOURCE_KAOLIN` | `RESOURCE_SILVER` | `RESOURCE_KAOLIN` | false |
+
+Individual `substitution-both-infeasible` row:
+
+| Coordinate | Plot | Local resource | Live resource | Planned preferred | Local outcome | Civ loose feasibility |
+|---|---:|---|---|---|---|---|
+| `(69,32)` | `3461` | `RESOURCE_CLAY` | `RESOURCE_RICE` | empty | `RESOURCE_CLAY` | local false / live false |
+
+Disposition:
+the full artifact supersedes the prior summary-only feasibility evidence for
+row-level inspection. It still does not authorize tuning or parity closure.
+The next code repair, if any, must prove whether the `9` focused rows are a
+repo-owned mock/static-policy gap or accepted engine/materialization behavior.
+The single both-infeasible substitution row remains outside that repair class.
+
 ## Required Next Diagnostics
 
 - Extract local row context for every feature/resource mismatch: terrain,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,14 +5,14 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-feasibility-readback-drain`
-  stacked above `codex/swooper-resource-assignment-evidence-drain`
+- Branch/Graphite stack: `codex/swooper-resource-feasibility-classification-drain`
+  stacked above `codex/swooper-resource-feasibility-readback-drain`
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
-  feasibility readback now narrows the next resource repair class. Remaining
-  feature/resource classes still need source-authority classification before
-  repair.
+  feasibility classification now narrows the next resource repair class.
+  Remaining feature/resource classes still need source-authority classification
+  before repair.
 
 ## Objective
 
@@ -116,6 +116,31 @@
   surface, and `1` substitution row remains feasibility-negative for both
   probed values. This points the next repair investigation at assignment
   ordering/rebalance and a smaller mock feasibility over-acceptance class.
+- Row-level feasibility classification progress:
+  `mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts` now
+  joins local resource delta plan/outcome context to a provided Civ resource
+  feasibility readback. The diagnostic keeps `live-feasible-no-local-assignment`,
+  `local-feasible-live-empty`, `local-overaccepted-live-empty`,
+  `substitution-both-feasible`, and `substitution-both-infeasible` as separate
+  proof classes. This preserves the `9` local-overacceptance investigation
+  class and prevents the single both-infeasible substitution row from being
+  swept into mock/static-policy repair authority.
+- Full feasibility artifact progress:
+  `scripts/civ7-direct-control/verify-resource-delta-feasibility.ts` now emits
+  a complete row-level resource feasibility proof from a saved final-surface
+  proof using package-owned direct-control readback. It first reads current
+  live map identity through `getCiv7MapSummary` and blocks if width, height,
+  plot count, seed, turn, or game hash do not match the saved proof identity.
+  The current artifact is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
+  (`sha256:8ea0fcbf898c4cacd7bf1a19f8955e846e4c18631af4a7673ffc7cf058d8c35d`,
+  `proofHash:b066b90c41d89e5be0cec575218b0e14351a18f8a1c416f5948249c5acfbd2b2`).
+  Runtime identity is matched to the saved proof at `106x66`, `6996` plots,
+  seed `138503614`, turn `1`, and game hash `0`. The artifact preserves the
+  strict-readback caveat and records the `ignoreWeight:true` split: `37`
+  live-feasible/no-local-assignment, `28` local-feasible/live-empty, `9`
+  local-overaccepted/live-empty, `31` substitution-both-feasible, and `1`
+  substitution-both-infeasible.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "verify:studio-run-in-game": "turbo run build check --filter=@civ7/direct-control --filter=@mateicanavra/civ7-sdk --filter=mod-swooper-maps --filter=mapgen-studio && turbo run test --filter=@civ7/direct-control --filter=@mateicanavra/civ7-sdk --filter=mapgen-studio && turbo run test:studio-run-in-game --filter=mod-swooper-maps && bun run openspec -- validate direct-control-new-game-setup --strict && bun run openspec -- validate studio-run-current-map-config --strict && bun run openspec -- validate studio-live-civ7-map-sync --strict && bun run openspec -- validate studio-disposable-setup-reload --strict && bun run openspec -- validate workspace-build-pipeline --strict && bun run openspec -- validate studio-run-in-game-robustness --strict && bun run openspec -- validate studio-operation-state-completion --strict && bun run openspec -- validate studio-save-run-state-machine --strict",
     "verify:studio-run-in-game:live": "bun scripts/civ7-direct-control/verify-studio-run-in-game-live.ts",
     "verify:final-surface-parity": "bun scripts/civ7-direct-control/verify-final-surface-parity.ts",
+    "verify:resource-delta-feasibility": "bun scripts/civ7-direct-control/verify-resource-delta-feasibility.ts",
     "build:mapgen": "turbo run build --filter=@swooper/mapgen-core",
     "lint:adapter-boundary": "./scripts/lint/lint-adapter-boundary.sh",
     "lint:domain-refactor-guardrails": "./scripts/lint/lint-domain-refactor-guardrails.sh",

--- a/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
+++ b/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
@@ -1,0 +1,326 @@
+#!/usr/bin/env bun
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import {
+  getCiv7MapSummary,
+  getCiv7ResourcePlacementFeasibility,
+  type Civ7MapSummaryResult,
+  type Civ7ResourcePlacementFeasibilityResult,
+  type Civ7RuntimeProbe,
+} from "../../packages/civ7-direct-control/src/index.ts";
+import {
+  hashParityValue,
+  stableParityProofStringify,
+  type FinalSurfaceParityProof,
+} from "../../mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts";
+import {
+  buildResourceDeltaFeasibilityContexts,
+  buildResourceDeltaPlacementContexts,
+  type ResourceDeltaFeasibilityContext,
+} from "../../mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts";
+
+type Args = Readonly<{
+  proofFile?: string;
+  host?: string;
+  port?: number;
+  timeoutMs: number;
+  maxCells: number;
+  output?: string;
+  help: boolean;
+}>;
+
+const usage = `Usage:
+  bun scripts/civ7-direct-control/verify-resource-delta-feasibility.ts --proof-file <final-surface-proof.json>
+
+Options:
+  --host <host>       Civ7 tuner host
+  --port <port>       Civ7 tuner port
+  --timeout-ms <ms>   Direct-control timeout (default: 45000)
+  --max-cells <n>     Safety cap for resource delta cells (default: 256)
+  --output <path>     Write full proof JSON to path
+`;
+
+function parseArgs(argv: string[]): Args {
+  const args: {
+    proofFile?: string;
+    host?: string;
+    port?: number;
+    timeoutMs: number;
+    maxCells: number;
+    output?: string;
+    help: boolean;
+  } = {
+    timeoutMs: 45_000,
+    maxCells: 256,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = () => {
+      const next = argv[index + 1];
+      if (!next || next.startsWith("--")) throw new Error(`Missing value for ${arg}`);
+      index += 1;
+      return next;
+    };
+    switch (arg) {
+      case "--help":
+      case "-h":
+        args.help = true;
+        break;
+      case "--proof-file":
+        args.proofFile = value();
+        break;
+      case "--host":
+        args.host = value();
+        break;
+      case "--port":
+        args.port = parseInteger(value(), arg);
+        break;
+      case "--timeout-ms":
+        args.timeoutMs = parseInteger(value(), arg);
+        break;
+      case "--max-cells":
+        args.maxCells = parseInteger(value(), arg);
+        break;
+      case "--output":
+        args.output = value();
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function parseInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) throw new Error(`${label} must be an integer: ${value}`);
+  return parsed;
+}
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage);
+    return 0;
+  }
+  if (!args.proofFile) throw new Error("Expected --proof-file");
+
+  const proof = extractFinalSurfaceParityProof(JSON.parse(readFileSync(args.proofFile, "utf8")));
+  const runtimeIdentity = await readAndCompareRuntimeIdentity(proof, args);
+  if (runtimeIdentity.blockedBy.length > 0) {
+    const outputWithoutHash = {
+      ok: false,
+      status: "blocked" as const,
+      requestId: proof.exactAuthorship?.requestId,
+      sourceProofHash: hashParityValue(proof),
+      blockedBy: runtimeIdentity.blockedBy,
+      runtimeIdentity,
+    };
+    const output = {
+      ...outputWithoutHash,
+      proofHash: hashParityValue(outputWithoutHash),
+    };
+    writeOutput(args.output, output);
+    console.log(stableParityProofStringify(output));
+    return 2;
+  }
+
+  const deltaRows = buildResourceDeltaPlacementContexts({ local: proof.local, live: proof.live });
+  if (deltaRows.length === 0) throw new Error("Expected at least one resource delta row");
+  if (deltaRows.length > args.maxCells) {
+    throw new Error(`Resource delta row count ${deltaRows.length} exceeds --max-cells ${args.maxCells}`);
+  }
+
+  const cells = deltaRows.map((row) => ({
+    x: row.x,
+    y: row.y,
+    resourceTypes: uniqueNumbers([row.localResource.value, row.liveResource.value]),
+  }));
+
+  const [strict, ignoreWeight] = await Promise.all([
+    getCiv7ResourcePlacementFeasibility(
+      { cells, maxCells: args.maxCells, ignoreWeight: false },
+      { host: args.host, port: args.port, timeoutMs: args.timeoutMs }
+    ),
+    getCiv7ResourcePlacementFeasibility(
+      { cells, maxCells: args.maxCells, ignoreWeight: true },
+      { host: args.host, port: args.port, timeoutMs: args.timeoutMs }
+    ),
+  ]);
+
+  const outputWithoutHash = {
+    ok: true,
+    requestId: proof.exactAuthorship?.requestId,
+    sourceProofHash: hashParityValue(proof),
+    runtimeIdentity,
+    rowCount: deltaRows.length,
+    strict: summarizeFeasibilityProof(proof, strict),
+    ignoreWeight: summarizeFeasibilityProof(proof, ignoreWeight),
+  };
+  const output = {
+    ...outputWithoutHash,
+    proofHash: hashParityValue(outputWithoutHash),
+  };
+  writeOutput(args.output, output);
+  console.log(stableParityProofStringify(output));
+  return 0;
+}
+
+function extractFinalSurfaceParityProof(payload: unknown): FinalSurfaceParityProof {
+  if (!isRecord(payload)) throw new Error("Proof payload must be an object");
+  const proof = isRecord(payload.proof) ? payload.proof : payload;
+  if (!isRecord(proof.local) || !isRecord(proof.live)) {
+    throw new Error("Expected final-surface parity proof with local/live snapshots");
+  }
+  return proof as FinalSurfaceParityProof;
+}
+
+async function readAndCompareRuntimeIdentity(
+  proof: FinalSurfaceParityProof,
+  args: Pick<Args, "host" | "port" | "timeoutMs">
+) {
+  const current = await getCiv7MapSummary({
+    host: args.host,
+    port: args.port,
+    timeoutMs: args.timeoutMs,
+  });
+  const saved = savedRuntimeIdentity(proof);
+  const observed = observedRuntimeIdentity(current);
+  const comparisons = {
+    width: compareIdentityValue(saved.width, observed.width),
+    height: compareIdentityValue(saved.height, observed.height),
+    plotCount: compareIdentityValue(saved.plotCount, observed.plotCount),
+    seed: compareIdentityValue(saved.seed, observed.seed),
+    turn: compareIdentityValue(saved.turn, observed.turn),
+    gameHash: compareIdentityValue(saved.gameHash, observed.gameHash),
+  };
+  const blockedBy = Object.entries(comparisons)
+    .filter(([, comparison]) => comparison.status !== "matched")
+    .map(([key, comparison]) => `runtime-identity.${key}.${comparison.status}`)
+    .sort((left, right) => left.localeCompare(right));
+
+  return {
+    status: blockedBy.length === 0 ? "matched" as const : "blocked" as const,
+    blockedBy,
+    saved,
+    observed,
+    comparisons,
+  };
+}
+
+function savedRuntimeIdentity(proof: FinalSurfaceParityProof) {
+  const evidence = isRecord(proof.live.evidence) ? proof.live.evidence : {};
+  const runtime = isRecord(evidence.runtime) ? evidence.runtime : {};
+  const fullGrid = isRecord(evidence.fullGrid) ? evidence.fullGrid : {};
+  const initialSummary = isRecord(fullGrid.initialSummary) ? fullGrid.initialSummary : {};
+  return {
+    width: numberValue(runtime.width) ?? numberValue(initialSummary.width) ?? proof.live.width,
+    height: numberValue(runtime.height) ?? numberValue(initialSummary.height) ?? proof.live.height,
+    plotCount: numberValue(runtime.plotCount) ?? numberValue(initialSummary.plotCount),
+    seed: numberValue(runtime.seed) ?? numberValue(initialSummary.seed) ?? proof.live.seed,
+    turn: numberValue(runtime.turn) ?? numberValue(initialSummary.turn),
+    gameHash: numberValue(runtime.gameHash) ?? numberValue(initialSummary.gameHash),
+  };
+}
+
+function observedRuntimeIdentity(summary: Civ7MapSummaryResult) {
+  return {
+    host: summary.host,
+    port: summary.port,
+    state: summary.state,
+    width: probeNumber(summary.map.width),
+    height: probeNumber(summary.map.height),
+    plotCount: probeNumber(summary.map.plotCount),
+    seed: probeNumber(summary.map.randomSeed),
+    turn: probeNumber(summary.game.turn),
+    gameHash: probeNumber(summary.game.hash),
+  };
+}
+
+function compareIdentityValue(saved: number | undefined, observed: number | undefined) {
+  if (saved === undefined) return { status: "missing-saved" as const, saved, observed };
+  if (observed === undefined) return { status: "missing-observed" as const, saved, observed };
+  if (saved !== observed) return { status: "mismatch" as const, saved, observed };
+  return { status: "matched" as const, saved, observed };
+}
+
+function summarizeFeasibilityProof(
+  proof: Pick<FinalSurfaceParityProof, "local" | "live">,
+  readback: Civ7ResourcePlacementFeasibilityResult
+) {
+  const rows = buildResourceDeltaFeasibilityContexts({ local: proof.local, live: proof.live }, readback);
+  return {
+    readback: {
+      host: readback.host,
+      port: readback.port,
+      state: readback.state,
+      cellCount: readback.cellCount,
+      omittedCells: readback.omittedCells,
+      ignoreWeight: readback.ignoreWeight,
+    },
+    classCounts: countBy(rows, (row) => row.feasibilityClass),
+    evidenceAndFeasibilityCounts: countBy(
+      rows,
+      (row) =>
+        `${row.evidenceClass}|local:${feasibilityValue(row.localFeasibleInCiv)}|live:${feasibilityValue(row.liveFeasibleInCiv)}`
+    ),
+    rows,
+  };
+}
+
+function feasibilityValue(
+  probe: ResourceDeltaFeasibilityContext["localFeasibleInCiv"]
+): "true" | "false" | "not-applicable" | "missing" {
+  if (probe === null) return "not-applicable";
+  if (!probe.ok || probe.value === null) return "missing";
+  return probe.value ? "true" : "false";
+}
+
+function countBy<T>(items: ReadonlyArray<T>, keyFor: (item: T) => string): Readonly<Record<string, number>> {
+  const counts: Record<string, number> = {};
+  for (const item of items) {
+    const key = keyFor(item);
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return Object.fromEntries(Object.entries(counts).sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function uniqueNumbers(values: ReadonlyArray<number | null>): number[] {
+  return [...new Set(values.filter((value): value is number => value !== null))];
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function probeNumber(value: Civ7RuntimeProbe<number>): number | undefined {
+  return value.ok === true && typeof value.value === "number" && Number.isFinite(value.value)
+    ? value.value
+    : undefined;
+}
+
+function writeOutput(path: string | undefined, output: unknown): void {
+  if (!path) return;
+  const absolute = resolve(path);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, JSON.stringify(output, null, 2));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+if (import.meta.main) {
+  main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      console.error(JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error) }, null, 2));
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
Adds row-level feasibility classification to the resource delta diagnostic pipeline and produces a full feasibility artifact from a saved final-surface proof.

**Feasibility classification (`surface-delta-context.ts`)**

Introduces `buildResourceDeltaFeasibilityContexts`, which joins existing placement context rows to a Civ resource feasibility readback and assigns each row one of five `feasibilityClass` labels:

| Class | Meaning |
|---|---|
| `live-feasible-no-local-assignment` | Civ accepts the live resource but local did not assign it |
| `local-feasible-live-empty` | Local placed a Civ-feasible resource where live has none |
| `local-overaccepted-live-empty` | Local placed a resource Civ rejects; focused mock/static-policy overacceptance class |
| `substitution-both-feasible` | Both local and live values are Civ-feasible |
| `substitution-both-infeasible` | Both values are Civ-infeasible; no repair authority yet |

Supporting types (`ResourceDeltaFeasibilityContext`, `ResourceFeasibilityProbe`, `ResourceFeasibilityReadbackLike`, `ResourceFeasibilityCellLike`, `ResourceFeasibilityRuntimeProbeLike`) and private helpers (`readResourceFeasibilityByCell`, `readResourceFeasibilityProbe`, `classifyResourceDeltaFeasibility`, `resourceFeasibilityCellKey`) are added alongside the public builder.

**Full feasibility artifact verifier (`verify-resource-delta-feasibility.ts`)**

A new script exposed as `verify:resource-delta-feasibility` reads a saved final-surface parity proof, verifies live map identity against it (width, height, plot count, seed, turn, and game hash must all match), then calls `getCiv7ResourcePlacementFeasibility` twice in parallel — once with `ignoreWeight:false` and once with `ignoreWeight:true` — and emits a signed JSON artifact containing per-row feasibility context and class-count summaries. A mismatch in any identity field blocks the artifact before row-level evidence is accepted.

The current artifact records the `ignoreWeight:true` split as 37 `live-feasible-no-local-assignment`, 28 `local-feasible-live-empty`, 9 `local-overaccepted-live-empty`, 31 `substitution-both-feasible`, and 1 `substitution-both-infeasible`. The 9 overacceptance rows and the single both-infeasible substitution row are kept as separate proof classes to prevent the latter from being folded into mock/static-policy repair authority.

Tasks 2.5 and 2.6 are marked complete; repair tasks are renumbered to 2.7 and 2.8.