### PR TITLE
feat(resource-delta-context): add surface context, static legality, and request identity resolution to resource delta placement rows

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -49,6 +49,14 @@ export type ResourceDeltaPlacementContext = Readonly<{
   plotIndex: number;
   localResource: Readonly<{ value: number | null; symbol: string }>;
   liveResource: Readonly<{ value: number | null; symbol: string }>;
+  localContext: CellSurfaceContext;
+  liveContext: CellSurfaceContext;
+  legality: Readonly<{
+    localValueOnLocal?: StaticSurfaceLegality;
+    localValueOnLive?: StaticSurfaceLegality;
+    liveValueOnLocal?: StaticSurfaceLegality;
+    liveValueOnLive?: StaticSurfaceLegality;
+  }>;
   plannedPreferredResourceType: number | null;
   plannedPreferredResourceSymbol: string;
   localOutcome: ResourcePlacementOutcomeContext | null;
@@ -207,6 +215,8 @@ export function buildResourceDeltaPlacementContexts(
     const x = index - y * proof.local.width;
     const plannedPreferredResourceType = resourcePlan.preferredByPlot.get(index) ?? null;
     const localOutcome = outcomes.byPlot.get(index) ?? null;
+    const localContext = cellSurfaceContext(proof.local, x, y);
+    const liveContext = cellSurfaceContext(proof.live, x, y);
     rows.push({
       x,
       y,
@@ -218,6 +228,22 @@ export function buildResourceDeltaPlacementContexts(
       liveResource: {
         value: liveResource,
         symbol: symbolFor("resource", liveResource),
+      },
+      localContext,
+      liveContext,
+      legality: {
+        ...(localResource === null
+          ? {}
+          : { localValueOnLocal: staticSurfaceLegality(proof.local, "resource", x, y, localResource) }),
+        ...(localResource === null
+          ? {}
+          : { localValueOnLive: staticSurfaceLegality(proof.live, "resource", x, y, localResource) }),
+        ...(liveResource === null
+          ? {}
+          : { liveValueOnLocal: staticSurfaceLegality(proof.local, "resource", x, y, liveResource) }),
+        ...(liveResource === null
+          ? {}
+          : { liveValueOnLive: staticSurfaceLegality(proof.live, "resource", x, y, liveResource) }),
       },
       plannedPreferredResourceType,
       plannedPreferredResourceSymbol: symbolFor("resource", plannedPreferredResourceType),

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -162,8 +162,25 @@ describe("surface delta context diagnostics", () => {
       plotIndex: 0,
       localResource: { symbol: "RESOURCE_FISH" },
       liveResource: { symbol: "empty" },
+      localContext: {
+        terrainSymbol: "TERRAIN_COAST",
+        biomeSymbol: "BIOME_MARINE",
+        resourceSymbol: "RESOURCE_FISH",
+      },
+      liveContext: {
+        terrainSymbol: "TERRAIN_COAST",
+        biomeSymbol: "BIOME_MARINE",
+        resourceSymbol: "empty",
+      },
       plannedPreferredResourceSymbol: "RESOURCE_FISH",
       localOutcome: { status: "placed", resourceSymbol: "RESOURCE_FISH" },
+      legality: {
+        localValueOnLocal: {
+          symbol: "RESOURCE_FISH",
+          validSurface: true,
+          reasons: [],
+        },
+      },
       evidenceClass: "local-assigned-live-empty",
     });
     expect(rows[1]).toMatchObject({

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -330,19 +330,24 @@ Verifier:
 `scripts/civ7-direct-control/verify-resource-delta-feasibility.ts`.
 
 Runtime binding:
-before probing resource feasibility, the verifier reads current live map
-identity through package-owned `getCiv7MapSummary` and compares it to the saved
-final-surface proof. Missing or mismatched width, height, plot count, seed,
-turn, or game hash blocks the artifact before row-level feasibility evidence is
-accepted.
+before probing resource feasibility, the verifier resolves request id from
+exact-authorship summary, packet, source snapshot, and log fields, then reads
+current live map identity through package-owned `getCiv7MapSummary` and compares
+it to the saved final-surface proof. Missing/conflicting request id or
+missing/mismatched width, height, plot count, seed, turn, or game hash blocks
+the artifact before row-level feasibility evidence is accepted.
 
 Artifact:
 `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-(`sha256:8ea0fcbf898c4cacd7bf1a19f8955e846e4c18631af4a7673ffc7cf058d8c35d`,
-`proofHash:b066b90c41d89e5be0cec575218b0e14351a18f8a1c416f5948249c5acfbd2b2`).
+(`sha256:2ec76e1329ab0b103e4f210c38d57ea3ea562616bad101ada0825d7cc10f8b6b`,
+`proofHash:08f5092303026bb0dd3bbc161bd2adff2984c6bb996cba6ab4758fd581118c8e`).
 
 Source proof:
 `d95d54d2f208436324d7600a0c8a8a35e899ff82c617be4b719dfc954c6897df`.
+
+Request identity:
+`studio-run-in-game-mq20rbzr-1fhc`, matched across exact-authorship summary,
+exact-authorship packet, source snapshot, and log request id.
 
 Runtime identity:
 saved and observed identities match at width `106`, height `66`, plot count
@@ -364,17 +369,17 @@ cells.
 
 Focused `local-overaccepted-live-empty` rows:
 
-| Coordinate | Plot | Local resource | Planned preferred | Local outcome | Civ loose feasibility |
-|---|---:|---|---|---|---|
-| `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `RESOURCE_CLAY` | false |
-| `(31,4)` | `455` | `RESOURCE_CLAY` | empty | `RESOURCE_CLAY` | false |
-| `(56,6)` | `692` | `RESOURCE_GYPSUM` | empty | `RESOURCE_GYPSUM` | false |
-| `(16,12)` | `1288` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | false |
-| `(12,19)` | `2026` | `RESOURCE_JADE` | `RESOURCE_SILK` | `RESOURCE_JADE` | false |
-| `(9,21)` | `2235` | `RESOURCE_HORSES` | `RESOURCE_COWRIE` | `RESOURCE_HORSES` | false |
-| `(72,35)` | `3782` | `RESOURCE_RICE` | empty | `RESOURCE_RICE` | false |
-| `(86,38)` | `4114` | `RESOURCE_CLAY` | empty | `RESOURCE_CLAY` | false |
-| `(67,51)` | `5473` | `RESOURCE_KAOLIN` | `RESOURCE_SILVER` | `RESOURCE_KAOLIN` | false |
+| Coordinate | Plot | Local resource | Planned preferred | Surface | Static local legality | Civ loose feasibility |
+|---|---:|---|---|---|---|---|
+| `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | true / none | false |
+| `(31,4)` | `455` | `RESOURCE_CLAY` | empty | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | true / none | false |
+| `(56,6)` | `692` | `RESOURCE_GYPSUM` | empty | `TERRAIN_HILL` / `BIOME_TUNDRA` / empty | true / none | false |
+| `(16,12)` | `1288` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | `TERRAIN_HILL` / `BIOME_TROPICAL` / empty | true / none | false |
+| `(12,19)` | `2026` | `RESOURCE_JADE` | `RESOURCE_SILK` | `TERRAIN_FLAT` / `BIOME_TROPICAL` / empty | true / none | false |
+| `(9,21)` | `2235` | `RESOURCE_HORSES` | `RESOURCE_COWRIE` | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / empty | true / none | false |
+| `(72,35)` | `3782` | `RESOURCE_RICE` | empty | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | true / none | false |
+| `(86,38)` | `4114` | `RESOURCE_CLAY` | empty | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | true / none | false |
+| `(67,51)` | `5473` | `RESOURCE_KAOLIN` | `RESOURCE_SILVER` | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / `FEATURE_MARSH` | true / none | false |
 
 Individual `substitution-both-infeasible` row:
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,12 +5,13 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-feasibility-classification-drain`
-  stacked above `codex/swooper-resource-feasibility-readback-drain`
+- Branch/Graphite stack: `codex/swooper-resource-delta-context-drain`
+  stacked above `codex/swooper-resource-feasibility-classification-drain`
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
-  feasibility classification now narrows the next resource repair class.
+  feasibility plus row/static-policy/live-plot diagnostic context now narrows
+  the next resource repair class.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -128,19 +129,23 @@
 - Full feasibility artifact progress:
   `scripts/civ7-direct-control/verify-resource-delta-feasibility.ts` now emits
   a complete row-level resource feasibility proof from a saved final-surface
-  proof using package-owned direct-control readback. It first reads current
+  proof using package-owned direct-control readback. It resolves request id
+  from exact-authorship summary, packet, source snapshot, and log fields, and
+  blocks if those sources are missing or conflicting. It then reads current
   live map identity through `getCiv7MapSummary` and blocks if width, height,
   plot count, seed, turn, or game hash do not match the saved proof identity.
   The current artifact is
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-  (`sha256:8ea0fcbf898c4cacd7bf1a19f8955e846e4c18631af4a7673ffc7cf058d8c35d`,
-  `proofHash:b066b90c41d89e5be0cec575218b0e14351a18f8a1c416f5948249c5acfbd2b2`).
-  Runtime identity is matched to the saved proof at `106x66`, `6996` plots,
-  seed `138503614`, turn `1`, and game hash `0`. The artifact preserves the
-  strict-readback caveat and records the `ignoreWeight:true` split: `37`
-  live-feasible/no-local-assignment, `28` local-feasible/live-empty, `9`
-  local-overaccepted/live-empty, `31` substitution-both-feasible, and `1`
-  substitution-both-infeasible.
+  (`sha256:2ec76e1329ab0b103e4f210c38d57ea3ea562616bad101ada0825d7cc10f8b6b`,
+  `proofHash:08f5092303026bb0dd3bbc161bd2adff2984c6bb996cba6ab4758fd581118c8e`).
+  Request identity resolves to `studio-run-in-game-mq20rbzr-1fhc`; runtime
+  identity is matched to the saved proof at `106x66`, `6996` plots, seed
+  `138503614`, turn `1`, and game hash `0`. The artifact preserves the
+  strict-readback caveat, carries local/live surface context and static legality
+  reasons for every resource delta row, and records the `ignoreWeight:true`
+  split: `37` live-feasible/no-local-assignment, `28`
+  local-feasible/live-empty, `9` local-overaccepted/live-empty, `31`
+  substitution-both-feasible, and `1` substitution-both-infeasible.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen

--- a/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
+++ b/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
@@ -110,14 +110,34 @@ async function main(): Promise<number> {
   if (!args.proofFile) throw new Error("Expected --proof-file");
 
   const proof = extractFinalSurfaceParityProof(JSON.parse(readFileSync(args.proofFile, "utf8")));
+  const requestIdentity = resolveRequestIdentity(proof);
+  if (requestIdentity.blockedBy.length > 0) {
+    const outputWithoutHash = {
+      ok: false,
+      status: "blocked" as const,
+      requestId: requestIdentity.requestId,
+      sourceProofHash: hashParityValue(proof),
+      blockedBy: requestIdentity.blockedBy,
+      requestIdentity,
+    };
+    const output = {
+      ...outputWithoutHash,
+      proofHash: hashParityValue(outputWithoutHash),
+    };
+    writeOutput(args.output, output);
+    console.log(stableParityProofStringify(output));
+    return 2;
+  }
+
   const runtimeIdentity = await readAndCompareRuntimeIdentity(proof, args);
   if (runtimeIdentity.blockedBy.length > 0) {
     const outputWithoutHash = {
       ok: false,
       status: "blocked" as const,
-      requestId: proof.exactAuthorship?.requestId,
+      requestId: requestIdentity.requestId,
       sourceProofHash: hashParityValue(proof),
       blockedBy: runtimeIdentity.blockedBy,
+      requestIdentity,
       runtimeIdentity,
     };
     const output = {
@@ -154,8 +174,9 @@ async function main(): Promise<number> {
 
   const outputWithoutHash = {
     ok: true,
-    requestId: proof.exactAuthorship?.requestId,
+    requestId: requestIdentity.requestId,
     sourceProofHash: hashParityValue(proof),
+    requestIdentity,
     runtimeIdentity,
     rowCount: deltaRows.length,
     strict: summarizeFeasibilityProof(proof, strict),
@@ -177,6 +198,32 @@ function extractFinalSurfaceParityProof(payload: unknown): FinalSurfaceParityPro
     throw new Error("Expected final-surface parity proof with local/live snapshots");
   }
   return proof as FinalSurfaceParityProof;
+}
+
+function resolveRequestIdentity(proof: FinalSurfaceParityProof) {
+  const packet = isRecord(proof.exactAuthorshipPacket) ? proof.exactAuthorshipPacket : {};
+  const sourceSnapshot = isRecord(packet.sourceSnapshot) ? packet.sourceSnapshot : {};
+  const log = isRecord(packet.log) ? packet.log : {};
+  const sources = {
+    exactAuthorshipSummary: stringValue(proof.exactAuthorshipSummary.requestId),
+    exactAuthorshipPacket: stringValue(packet.requestId),
+    sourceSnapshot: stringValue(sourceSnapshot.requestId),
+    log: stringValue(log.requestId),
+  };
+  const values = Object.values(sources).filter((value): value is string => value !== undefined);
+  const uniqueValues = [...new Set(values)].sort((left, right) => left.localeCompare(right));
+  const blockedBy =
+    uniqueValues.length === 0
+      ? ["request-identity.missing"]
+      : uniqueValues.length > 1
+        ? ["request-identity.conflict"]
+        : [];
+  return {
+    requestId: uniqueValues.length === 1 ? uniqueValues[0] : undefined,
+    status: blockedBy.length === 0 ? "matched" as const : "blocked" as const,
+    blockedBy,
+    sources,
+  };
 }
 
 async function readAndCompareRuntimeIdentity(
@@ -295,6 +342,10 @@ function uniqueNumbers(values: ReadonlyArray<number | null>): number[] {
 
 function numberValue(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function probeNumber(value: Civ7RuntimeProbe<number>): number | undefined {


### PR DESCRIPTION
## Add surface context and static legality to resource delta placement rows, and validate request identity in feasibility verifier

### Resource delta context enrichment

`ResourceDeltaPlacementContext` now carries `localContext`, `liveContext`, and a `legality` object for each resource delta row. The `legality` object records the static surface legality of the local and live resource values evaluated against both the local and live surfaces, omitting entries where the resource value is absent. `buildResourceDeltaPlacementContexts` populates these fields using `cellSurfaceContext` and `staticSurfaceLegality` at build time.

### Feasibility verifier request identity resolution

Before the verifier checks runtime map identity, it now resolves a request ID by reading from four sources: the exact-authorship summary, the exact-authorship packet, the source snapshot, and the log. If no source provides a request ID, or if the sources disagree, the verifier blocks and emits a `blocked` artifact before any row-level feasibility evidence is accepted. The resolved `requestIdentity` object (including per-source breakdown) is included in all output artifacts. The `requestId` field at the top level of each output is now drawn from this resolved identity rather than directly from `exactAuthorship`.

### Diagnostic ledger updates

The `local-overaccepted-live-empty` focused rows in the delta classification ledger now include terrain, biome, and feature surface context alongside static local legality results, replacing the previous column layout. Artifact hashes and the runtime binding description are updated to reflect the new artifact content and request identity resolution step.