### PR TITLE
feat(resource-delta-diagnostics): add resource policy row/flag, spacing-neighborhood, and live plot runtime context to surface delta and feasibility artifacts

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -2,6 +2,7 @@ import {
   CIV7_BROWSER_TABLES_V0,
   isResourceAdjacentToLandRuntimeOptional,
 } from "@civ7/map-policy";
+import { hexDistanceOddQPeriodicX } from "@swooper/mapgen-core/lib/grid";
 
 import type { FinalSurfaceKey, FinalSurfaceParityProof, FinalSurfaceSnapshot } from "./live-parity.js";
 
@@ -19,6 +20,28 @@ export type StaticSurfaceLegality = Readonly<{
   featureSymbol: string;
   validSurface: boolean;
   reasons: ReadonlyArray<string>;
+  resourcePolicy?: ResourceStaticPolicyContext;
+}>;
+
+export type ResourceStaticPolicyContext = Readonly<{
+  matchingRows: ReadonlyArray<ResourcePlacementRowContext>;
+  flags: ResourcePlacementFlagsContext | null;
+  hasAdjacentLand: boolean;
+}>;
+
+export type ResourcePlacementRowContext = Readonly<{
+  biome: number;
+  biomeSymbol: string;
+  terrain: number;
+  terrainSymbol: string;
+  feature: number | null;
+  featureSymbol: string;
+}>;
+
+export type ResourcePlacementFlagsContext = Readonly<{
+  adjacentToLand: boolean;
+  adjacentToLandRuntimeOptional: boolean;
+  lakeEligible: boolean;
 }>;
 
 export type SurfaceDeltaContext = Readonly<{
@@ -60,12 +83,37 @@ export type ResourceDeltaPlacementContext = Readonly<{
   plannedPreferredResourceType: number | null;
   plannedPreferredResourceSymbol: string;
   localOutcome: ResourcePlacementOutcomeContext | null;
+  resourceNeighborhood: ResourceDeltaNeighborhoodContext;
   evidenceClass:
     | "local-assigned-live-empty"
     | "local-assigned-live-substitution"
     | "live-only-no-local-assignment"
     | "live-only-preferred-but-unassigned"
     | "unclassified";
+}>;
+
+export type ResourceDeltaNeighborhoodContext = Readonly<{
+  minSpacingTiles: number | null;
+  localResourceOnLocal: ResourceNeighborhoodContext | null;
+  localResourceOnLive: ResourceNeighborhoodContext | null;
+  liveResourceOnLocal: ResourceNeighborhoodContext | null;
+  liveResourceOnLive: ResourceNeighborhoodContext | null;
+}>;
+
+export type ResourceNeighborhoodContext = Readonly<{
+  nearestSameType: ResourceNeighborContext | null;
+  nearestAnyResource: ResourceNeighborContext | null;
+  sameTypeWithinMinSpacing: boolean | null;
+  anyResourceWithinMinSpacing: boolean | null;
+}>;
+
+export type ResourceNeighborContext = Readonly<{
+  distance: number;
+  x: number;
+  y: number;
+  plotIndex: number;
+  resourceType: number;
+  resourceSymbol: string;
 }>;
 
 export type ResourceDeltaFeasibilityContext = ResourceDeltaPlacementContext &
@@ -248,6 +296,25 @@ export function buildResourceDeltaPlacementContexts(
       plannedPreferredResourceType,
       plannedPreferredResourceSymbol: symbolFor("resource", plannedPreferredResourceType),
       localOutcome,
+      resourceNeighborhood: {
+        minSpacingTiles: resourcePlan.minSpacingTiles,
+        localResourceOnLocal:
+          localResource === null
+            ? null
+            : resourceNeighborhood(proof.local, x, y, localResource, resourcePlan.minSpacingTiles),
+        localResourceOnLive:
+          localResource === null
+            ? null
+            : resourceNeighborhood(proof.live, x, y, localResource, resourcePlan.minSpacingTiles),
+        liveResourceOnLocal:
+          liveResource === null
+            ? null
+            : resourceNeighborhood(proof.local, x, y, liveResource, resourcePlan.minSpacingTiles),
+        liveResourceOnLive:
+          liveResource === null
+            ? null
+            : resourceNeighborhood(proof.live, x, y, liveResource, resourcePlan.minSpacingTiles),
+      },
       evidenceClass: classifyResourceDeltaPlacement({
         localResource,
         liveResource,
@@ -350,6 +417,9 @@ export function staticSurfaceLegality(
     featureSymbol: context.featureSymbol,
     validSurface: reasons.length === 0,
     reasons,
+    ...(key === "resource"
+      ? { resourcePolicy: resourceStaticPolicyContext(snapshot, x, y, type, context) }
+      : {}),
   };
 }
 
@@ -415,6 +485,103 @@ function addResourceSurfaceReasons(
   }
 }
 
+function resourceStaticPolicyContext(
+  snapshot: FinalSurfaceSnapshot,
+  x: number,
+  y: number,
+  resourceType: number,
+  context: CellSurfaceContext
+): ResourceStaticPolicyContext {
+  const rows = CIV7_BROWSER_TABLES_V0.resourceValidPlacementRows[String(resourceType)] ?? [];
+  const matchingRows = rows
+    .filter(
+      (row) =>
+        row[0] === context.biome &&
+        row[1] === context.terrain &&
+        row[2] === (context.feature ?? -1)
+    )
+    .map((row) => ({
+      biome: row[0],
+      biomeSymbol: symbolFor("biome", row[0]),
+      terrain: row[1],
+      terrainSymbol: symbolFor("terrain", row[1]),
+      feature: row[2] < 0 ? null : row[2],
+      featureSymbol: symbolFor("feature", row[2] < 0 ? null : row[2]),
+    }));
+  const flags = CIV7_BROWSER_TABLES_V0.resourcePlacementFlags[String(resourceType)];
+  return {
+    matchingRows,
+    flags:
+      flags === undefined
+        ? null
+        : {
+            adjacentToLand: flags.adjacentToLand,
+            adjacentToLandRuntimeOptional: isResourceAdjacentToLandRuntimeOptional(resourceType),
+            lakeEligible: flags.lakeEligible,
+          },
+    hasAdjacentLand: hasAdjacentLand(snapshot, x, y),
+  };
+}
+
+function resourceNeighborhood(
+  snapshot: SnapshotLike,
+  x: number,
+  y: number,
+  resourceType: number,
+  minSpacingTiles: number | null
+): ResourceNeighborhoodContext {
+  const plotIndex = y * snapshot.width + x;
+  const nearestSameType = nearestResourceNeighbor(snapshot, plotIndex, resourceType);
+  const nearestAnyResource = nearestResourceNeighbor(snapshot, plotIndex, null);
+  return {
+    nearestSameType,
+    nearestAnyResource,
+    sameTypeWithinMinSpacing: isWithinMinSpacing(nearestSameType, minSpacingTiles),
+    anyResourceWithinMinSpacing: isWithinMinSpacing(nearestAnyResource, minSpacingTiles),
+  };
+}
+
+function nearestResourceNeighbor(
+  snapshot: SnapshotLike,
+  originPlotIndex: number,
+  resourceType: number | null
+): ResourceNeighborContext | null {
+  let best: ResourceNeighborContext | null = null;
+  for (let plotIndex = 0; plotIndex < snapshot.width * snapshot.height; plotIndex += 1) {
+    if (plotIndex === originPlotIndex) continue;
+    const value = normalizeSurfaceValue(snapshot.surfaces.resource.values[plotIndex]);
+    if (value === null) continue;
+    if (resourceType !== null && value !== resourceType) continue;
+    const y = Math.floor(plotIndex / snapshot.width);
+    const x = plotIndex - y * snapshot.width;
+    const distance = hexDistanceOddQPeriodicX(originPlotIndex, plotIndex, snapshot.width);
+    const candidate = {
+      distance,
+      x,
+      y,
+      plotIndex,
+      resourceType: value,
+      resourceSymbol: symbolFor("resource", value),
+    };
+    if (
+      best === null ||
+      candidate.distance < best.distance ||
+      (candidate.distance === best.distance && candidate.plotIndex < best.plotIndex)
+    ) {
+      best = candidate;
+    }
+  }
+  return best;
+}
+
+function isWithinMinSpacing(
+  neighbor: ResourceNeighborContext | null,
+  minSpacingTiles: number | null
+): boolean | null {
+  if (minSpacingTiles === null) return null;
+  return neighbor !== null && neighbor.distance < minSpacingTiles;
+}
+
 function hasAdjacentLand(snapshot: SnapshotLike, x: number, y: number): boolean {
   const offsets = (x & 1) === 1 ? ODD_Q_NEIGHBORS_ODD : ODD_Q_NEIGHBORS_EVEN;
   for (const [dx, dy] of offsets) {
@@ -429,10 +596,12 @@ function hasAdjacentLand(snapshot: SnapshotLike, x: number, y: number): boolean 
 
 function readResourcePlanEvidence(evidence: unknown): {
   preferredByPlot: ReadonlyMap<number, number>;
+  minSpacingTiles: number | null;
 } {
   const preferredByPlot = new Map<number, number>();
   const plan = isRecord(evidence) ? evidence.resourcePlan : undefined;
   const placements = isRecord(plan) && Array.isArray(plan.placements) ? plan.placements : [];
+  const minSpacingTiles = isRecord(plan) ? finiteInteger(plan.minSpacingTiles) : null;
   for (const placement of placements) {
     if (!isRecord(placement)) continue;
     const plotIndex = finiteInteger(placement.plotIndex);
@@ -442,7 +611,7 @@ function readResourcePlanEvidence(evidence: unknown): {
     }
     preferredByPlot.set(plotIndex, preferredResourceType);
   }
-  return { preferredByPlot };
+  return { preferredByPlot, minSpacingTiles };
 }
 
 function readResourceOutcomeEvidence(evidence: unknown): {

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -75,6 +75,21 @@ describe("surface delta context diagnostics", () => {
     expect(staticSurfaceLegality(surface, "resource", 1, 0, 3)).toMatchObject({
       symbol: "RESOURCE_FISH",
       validSurface: true,
+      resourcePolicy: {
+        matchingRows: [
+          {
+            biomeSymbol: "BIOME_MARINE",
+            terrainSymbol: "TERRAIN_COAST",
+            featureSymbol: "empty",
+          },
+        ],
+        flags: {
+          adjacentToLand: true,
+          adjacentToLandRuntimeOptional: true,
+          lakeEligible: true,
+        },
+        hasAdjacentLand: true,
+      },
     });
     const openCoast = snapshot({
       terrain: { width: 3, height: 2, values: [3, 3, 3, 3, 3, 3] },
@@ -123,6 +138,7 @@ describe("surface delta context diagnostics", () => {
       },
       {
         resourcePlan: {
+          minSpacingTiles: 2,
           placements: [
             { plotIndex: 0, preferredResourceType: 3 },
             { plotIndex: 1, preferredResourceType: 3 },
@@ -174,6 +190,24 @@ describe("surface delta context diagnostics", () => {
       },
       plannedPreferredResourceSymbol: "RESOURCE_FISH",
       localOutcome: { status: "placed", resourceSymbol: "RESOURCE_FISH" },
+      resourceNeighborhood: {
+        minSpacingTiles: 2,
+        localResourceOnLocal: {
+          nearestSameType: null,
+          nearestAnyResource: {
+            plotIndex: 2,
+            resourceSymbol: "RESOURCE_DYES",
+          },
+          anyResourceWithinMinSpacing: true,
+        },
+        localResourceOnLive: {
+          nearestSameType: {
+            plotIndex: 1,
+            resourceSymbol: "RESOURCE_FISH",
+          },
+          sameTypeWithinMinSpacing: true,
+        },
+      },
       legality: {
         localValueOnLocal: {
           symbol: "RESOURCE_FISH",

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -20,8 +20,11 @@
   resource deltas.
 - [x] 2.6 Produce full row-level feasibility artifact for remaining resource
   deltas.
-- [ ] 2.7 Repair remaining proven package or MapGen owners.
-- [ ] 2.8 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.7 Add official resource policy row/flag and spacing-neighborhood
+  context for the focused local-overaccepted rows.
+- [x] 2.8 Add live plot runtime context for resource delta feasibility rows.
+- [ ] 2.9 Repair remaining proven package or MapGen owners.
+- [ ] 2.10 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -339,8 +339,8 @@ the artifact before row-level feasibility evidence is accepted.
 
 Artifact:
 `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-(`sha256:2ec76e1329ab0b103e4f210c38d57ea3ea562616bad101ada0825d7cc10f8b6b`,
-`proofHash:08f5092303026bb0dd3bbc161bd2adff2984c6bb996cba6ab4758fd581118c8e`).
+(`sha256:e1ae01d0474aa83960f60c4acb73593851a242d06121670fac751664625356bb`,
+`proofHash:de359a53aa4760c915cfae6dfe9f4d57039e585d85df5892b8c7f6bda80ac932`).
 
 Source proof:
 `d95d54d2f208436324d7600a0c8a8a35e899ff82c617be4b719dfc954c6897df`.
@@ -355,7 +355,10 @@ saved and observed identities match at width `106`, height `66`, plot count
 
 Readback:
 Tuner state `1`, host `127.0.0.1`, port `4318`, `106` cells, `0` omitted
-cells.
+cells. The artifact also includes `getCiv7MapGrid` plot context for the same
+`106` locations with fields `terrain`, `biome`, `feature`, `resource`,
+`climate`, `hydrology`, `areaRegion`, `tags`, and `owner`; this readback also
+returned `106` plots with `0` omitted and `hiddenInfoPolicy:"not-player-scoped"`.
 
 `ignoreWeight:true` row classes:
 
@@ -369,17 +372,23 @@ cells.
 
 Focused `local-overaccepted-live-empty` rows:
 
-| Coordinate | Plot | Local resource | Planned preferred | Surface | Static local legality | Civ loose feasibility |
-|---|---:|---|---|---|---|---|
-| `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | true / none | false |
-| `(31,4)` | `455` | `RESOURCE_CLAY` | empty | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | true / none | false |
-| `(56,6)` | `692` | `RESOURCE_GYPSUM` | empty | `TERRAIN_HILL` / `BIOME_TUNDRA` / empty | true / none | false |
-| `(16,12)` | `1288` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | `TERRAIN_HILL` / `BIOME_TROPICAL` / empty | true / none | false |
-| `(12,19)` | `2026` | `RESOURCE_JADE` | `RESOURCE_SILK` | `TERRAIN_FLAT` / `BIOME_TROPICAL` / empty | true / none | false |
-| `(9,21)` | `2235` | `RESOURCE_HORSES` | `RESOURCE_COWRIE` | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / empty | true / none | false |
-| `(72,35)` | `3782` | `RESOURCE_RICE` | empty | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | true / none | false |
-| `(86,38)` | `4114` | `RESOURCE_CLAY` | empty | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | true / none | false |
-| `(67,51)` | `5473` | `RESOURCE_KAOLIN` | `RESOURCE_SILVER` | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / `FEATURE_MARSH` | true / none | false |
+All rows below have one exact official `Resource_ValidBiomes` row matching the
+local surface, no adjacent-land requirement, `lakeEligible:true`, and no local
+or live resource neighbor inside the authored `minSpacingTiles:2` bound.
+Live plot context additionally confirms these cells are live-empty, unowned,
+non-water, untagged, and have no river.
+
+| Coordinate | Plot | Local resource | Planned preferred | Surface | Official/static policy | Nearest local/live resource distance | Live runtime context | Civ loose feasibility |
+|---|---:|---|---|---|---|---|---|---|
+| `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `6` | `elev416 rain185 fert2 area131073 region65536 landmass131073` | false |
+| `(31,4)` | `455` | `RESOURCE_CLAY` | empty | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `5` | `elev238 rain191 fert2 area589832 region524295 landmass589832` | false |
+| `(56,6)` | `692` | `RESOURCE_GYPSUM` | empty | `TERRAIN_HILL` / `BIOME_TUNDRA` / empty | row match; no flags blocking | `4` / `4` | `elev523 rain197 fert0 area1048591 region720906 landmass196610` | false |
+| `(16,12)` | `1288` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | `TERRAIN_HILL` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `2` / `5` | `elev208 rain193 fert0 area1835035 region1310739 landmass1179665` | false |
+| `(12,19)` | `2026` | `RESOURCE_JADE` | `RESOURCE_SILK` | `TERRAIN_FLAT` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `4` / `2` | `elev214 rain194 fert1 area3538997 region2359331 landmass1638424` | false |
+| `(9,21)` | `2235` | `RESOURCE_HORSES` | `RESOURCE_COWRIE` | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / empty | row match; no flags blocking | `4` / `6` | `elev453 rain169 fert1 area3670071 region2555942 landmass1703961` | false |
+| `(72,35)` | `3782` | `RESOURCE_RICE` | empty | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `4` / `4` | `elev192 rain184 fert2 area4522052 region3670071 landmass2424868` | false |
+| `(86,38)` | `4114` | `RESOURCE_CLAY` | empty | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `5` / `5` | `elev232 rain176 fert2 area4915274 region4128830 landmass2752553` | false |
+| `(67,51)` | `5473` | `RESOURCE_KAOLIN` | `RESOURCE_SILVER` | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / `FEATURE_MARSH` | row match; no flags blocking | `8` / `6` | `elev427 rain172 fert2 area5963866 region5898329 landmass3538997` | false |
 
 Individual `substitution-both-infeasible` row:
 
@@ -393,6 +402,11 @@ row-level inspection. It still does not authorize tuning or parity closure.
 The next code repair, if any, must prove whether the `9` focused rows are a
 repo-owned mock/static-policy gap or accepted engine/materialization behavior.
 The single both-infeasible substitution row remains outside that repair class.
+Because the focused rows are not explained by official surface rows,
+adjacent-land flags, authored spacing, owner, water, plot tags, or river state,
+the next authority check should inspect Civ `ResourceBuilder.canHaveResource`
+constraints that are not present in the static browser tables, or prove a
+runtime-state/materialization disposition before changing mock policy.
 
 ## Required Next Diagnostics
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,8 +5,8 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-delta-context-drain`
-  stacked above `codex/swooper-resource-feasibility-classification-drain`
+- Branch/Graphite stack: `codex/swooper-resource-policy-live-context-drain`
+  stacked above `codex/swooper-resource-delta-context-drain`
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
@@ -136,16 +136,37 @@
   plot count, seed, turn, or game hash do not match the saved proof identity.
   The current artifact is
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-  (`sha256:2ec76e1329ab0b103e4f210c38d57ea3ea562616bad101ada0825d7cc10f8b6b`,
-  `proofHash:08f5092303026bb0dd3bbc161bd2adff2984c6bb996cba6ab4758fd581118c8e`).
+  (`sha256:e1ae01d0474aa83960f60c4acb73593851a242d06121670fac751664625356bb`,
+  `proofHash:de359a53aa4760c915cfae6dfe9f4d57039e585d85df5892b8c7f6bda80ac932`).
   Request identity resolves to `studio-run-in-game-mq20rbzr-1fhc`; runtime
   identity is matched to the saved proof at `106x66`, `6996` plots, seed
   `138503614`, turn `1`, and game hash `0`. The artifact preserves the
-  strict-readback caveat, carries local/live surface context and static legality
-  reasons for every resource delta row, and records the `ignoreWeight:true`
+  strict-readback caveat, carries local/live surface context, official
+  resource policy row/flag evidence, static legality reasons, and
+  spacing-neighborhood context for every resource delta row, adds live plot
+  runtime context for the same `106` cells, and records the `ignoreWeight:true`
   split: `37` live-feasible/no-local-assignment, `28`
   local-feasible/live-empty, `9` local-overaccepted/live-empty, `31`
   substitution-both-feasible, and `1` substitution-both-infeasible.
+- Official-policy and spacing context progress:
+  the `9` local-overaccepted/live-empty rows all have exactly one official
+  resource placement row matching the local terrain/biome/feature surface, no
+  adjacent-land requirement, `lakeEligible:true`, and no local or live resource
+  neighbor inside the authored `minSpacingTiles:2` spacing bound. This removes
+  simple official row, adjacent-land, and authored spacing explanations for the
+  class, but does not yet prove whether the owner is mock/static policy,
+  runtime materialization state, placement order, or another Civ
+  `ResourceBuilder.canHaveResource` constraint.
+- Live plot context progress:
+  the verifier now reads package-owned `getCiv7MapGrid` context for the same
+  `106` resource delta cells before feasibility probes. For the `9`
+  local-overaccepted/live-empty rows, the live runtime facts confirm the cells
+  are live-empty, unowned, non-water, untagged, and have no river. Their
+  elevations, rainfall, fertility, area ids, region ids, and landmass ids are
+  preserved in the artifact for row-level comparison. This removes obvious
+  owner/water/tag/river explanations, but still does not expose the internal
+  `ResourceBuilder.canHaveResource` rejection reason or authorize mock/static
+  policy repair.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen

--- a/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
+++ b/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
@@ -4,8 +4,11 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 
 import {
+  getCiv7MapGrid,
   getCiv7MapSummary,
   getCiv7ResourcePlacementFeasibility,
+  type Civ7MapGridResult,
+  type Civ7PlotSnapshotField,
   type Civ7MapSummaryResult,
   type Civ7ResourcePlacementFeasibilityResult,
   type Civ7RuntimeProbe,
@@ -41,6 +44,18 @@ Options:
   --max-cells <n>     Safety cap for resource delta cells (default: 256)
   --output <path>     Write full proof JSON to path
 `;
+
+const LIVE_RESOURCE_CONTEXT_FIELDS = [
+  "terrain",
+  "biome",
+  "feature",
+  "resource",
+  "climate",
+  "hydrology",
+  "areaRegion",
+  "tags",
+  "owner",
+] as const satisfies ReadonlyArray<Civ7PlotSnapshotField>;
 
 function parseArgs(argv: string[]): Args {
   const args: {
@@ -155,6 +170,14 @@ async function main(): Promise<number> {
     throw new Error(`Resource delta row count ${deltaRows.length} exceeds --max-cells ${args.maxCells}`);
   }
 
+  const livePlotContext = await getCiv7MapGrid(
+    {
+      locations: deltaRows.map((row) => ({ x: row.x, y: row.y })),
+      fields: LIVE_RESOURCE_CONTEXT_FIELDS,
+      maxPlots: args.maxCells,
+    },
+    { host: args.host, port: args.port, timeoutMs: args.timeoutMs }
+  );
   const cells = deltaRows.map((row) => ({
     x: row.x,
     y: row.y,
@@ -179,6 +202,7 @@ async function main(): Promise<number> {
     requestIdentity,
     runtimeIdentity,
     rowCount: deltaRows.length,
+    livePlotContext: summarizeLivePlotContext(livePlotContext),
     strict: summarizeFeasibilityProof(proof, strict),
     ignoreWeight: summarizeFeasibilityProof(proof, ignoreWeight),
   };
@@ -316,6 +340,25 @@ function summarizeFeasibilityProof(
         `${row.evidenceClass}|local:${feasibilityValue(row.localFeasibleInCiv)}|live:${feasibilityValue(row.liveFeasibleInCiv)}`
     ),
     rows,
+  };
+}
+
+function summarizeLivePlotContext(readback: Civ7MapGridResult) {
+  return {
+    readback: {
+      host: readback.host,
+      port: readback.port,
+      state: readback.state,
+      fields: readback.fields,
+      plotCount: readback.plotCount,
+      omitted: readback.omitted,
+      hiddenInfoPolicy: readback.hiddenInfoPolicy,
+    },
+    rows: readback.plots.map((plot) => ({
+      location: plot.location,
+      hiddenInfoPolicy: plot.hiddenInfoPolicy,
+      facts: plot.facts,
+    })),
   };
 }
 


### PR DESCRIPTION
This PR extends the resource delta diagnostics context with two new categories of evidence needed to investigate the 9 `local-overaccepted/live-empty` rows that remain unexplained after prior classification work.

**Official resource policy and spacing neighborhood context**

`staticSurfaceLegality` now attaches a `resourcePolicy` field when the surface key is `"resource"`. This field exposes the matching `Resource_ValidBiomes` placement rows for the cell's terrain/biome/feature combination, the resource's placement flags (`adjacentToLand`, `adjacentToLandRuntimeOptional`, `lakeEligible`), and whether the cell has adjacent land. This makes it possible to confirm directly from the artifact whether a surface mismatch, an adjacent-land requirement, or a lake-eligibility restriction explains a given row.

`buildResourceDeltaPlacementContexts` now attaches a `resourceNeighborhood` field to every resource delta placement context. This field records the authored `minSpacingTiles` from the resource plan and, for each of the four local/live resource × local/live snapshot combinations, the nearest same-type neighbor, the nearest any-resource neighbor, and whether either falls inside the spacing bound. The `readResourcePlanEvidence` helper is extended to extract `minSpacingTiles` from the plan evidence alongside the existing preferred-by-plot map.

**Live plot runtime context in the feasibility verification script**

The `verify-resource-delta-feasibility` script now calls `getCiv7MapGrid` for all delta cell locations before running feasibility probes, requesting terrain, biome, feature, resource, climate, hydrology, areaRegion, tags, and owner. The result is summarized and written into the output artifact under `livePlotContext`, giving row-level access to elevation, rainfall, fertility, area/region/landmass IDs, owner, and tag state for each cell without requiring a separate readback pass.

**Findings recorded in the workstream ledger**

For all 9 focused rows: each has exactly one matching official placement row, no adjacent-land requirement, `lakeEligible:true`, and no local or live resource neighbor inside the `minSpacingTiles:2` bound. Live plot context confirms the cells are live-empty, unowned, non-water, untagged, and riverless. The ledger is updated to reflect that simple official-row, adjacent-land, authored-spacing, owner, water, tag, and river explanations are now ruled out, and that the next authority check should target `ResourceBuilder.canHaveResource` constraints not present in the static browser tables.