### PR TITLE
feat(swooper-resource-diagnostics): add local resource assignment-phase and assignment-order trace to placement evidence and delta context

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -83,6 +83,7 @@ export type ResourceDeltaPlacementContext = Readonly<{
   plannedPreferredResourceType: number | null;
   plannedPreferredResourceSymbol: string;
   localOutcome: ResourcePlacementOutcomeContext | null;
+  assignmentTrace: ResourceAssignmentTraceContext | null;
   resourceNeighborhood: ResourceDeltaNeighborhoodContext;
   evidenceClass:
     | "local-assigned-live-empty"
@@ -163,6 +164,21 @@ export type ResourcePlacementOutcomeContext = Readonly<{
   observedResourceType: number | null;
   observedResourceSymbol: string;
   reason: string | null;
+}>;
+
+export type ResourceAssignmentTraceContext = Readonly<{
+  resourceType: number;
+  resourceSymbol: string;
+  initialResourceType: number;
+  initialResourceSymbol: string;
+  preferredResourceType: number | null;
+  preferredResourceSymbol: string;
+  assignmentPhase: string;
+  reassignedByRebalance: boolean;
+  assignmentOrder: number | null;
+  perTypeCountBefore: number | null;
+  legalPlotCountForResource: number | null;
+  targetMinPerType: number | null;
 }>;
 
 export type CellSurfaceContext = Readonly<{
@@ -250,6 +266,7 @@ export function buildResourceDeltaPlacementContexts(
   const maxRows = options.maxRows ?? Number.POSITIVE_INFINITY;
   const resourcePlan = readResourcePlanEvidence(proof.local.evidence);
   const outcomes = readResourceOutcomeEvidence(proof.local.evidence);
+  const assignmentTrace = readResourceAssignmentTraceEvidence(proof.local.evidence);
   const rows: ResourceDeltaPlacementContext[] = [];
   const localValues = proof.local.surfaces.resource.values;
   const liveValues = proof.live.surfaces.resource.values;
@@ -296,6 +313,7 @@ export function buildResourceDeltaPlacementContexts(
       plannedPreferredResourceType,
       plannedPreferredResourceSymbol: symbolFor("resource", plannedPreferredResourceType),
       localOutcome,
+      assignmentTrace: assignmentTrace.byPlot.get(index) ?? null,
       resourceNeighborhood: {
         minSpacingTiles: resourcePlan.minSpacingTiles,
         localResourceOnLocal:
@@ -638,6 +656,49 @@ function readResourceOutcomeEvidence(evidence: unknown): {
       observedResourceType,
       observedResourceSymbol: symbolFor("resource", observedResourceType),
       reason: typeof outcome.reason === "string" ? outcome.reason : null,
+    });
+  }
+  return { byPlot };
+}
+
+function readResourceAssignmentTraceEvidence(evidence: unknown): {
+  byPlot: ReadonlyMap<number, ResourceAssignmentTraceContext>;
+} {
+  const byPlot = new Map<number, ResourceAssignmentTraceContext>();
+  const resourcePlacementOutcomes = isRecord(evidence)
+    ? evidence.resourcePlacementOutcomes
+    : undefined;
+  const trace =
+    isRecord(resourcePlacementOutcomes) && Array.isArray(resourcePlacementOutcomes.assignmentTrace)
+      ? resourcePlacementOutcomes.assignmentTrace
+      : [];
+  for (const row of trace) {
+    if (!isRecord(row)) continue;
+    const plotIndex = finiteInteger(row.plotIndex);
+    const resourceType = finiteInteger(row.resourceType);
+    const initialResourceType = finiteInteger(row.initialResourceType);
+    if (
+      plotIndex === null ||
+      resourceType === null ||
+      initialResourceType === null ||
+      byPlot.has(plotIndex)
+    ) {
+      continue;
+    }
+    const preferredResourceType = finiteInteger(row.preferredResourceType);
+    byPlot.set(plotIndex, {
+      resourceType,
+      resourceSymbol: symbolFor("resource", resourceType),
+      initialResourceType,
+      initialResourceSymbol: symbolFor("resource", initialResourceType),
+      preferredResourceType,
+      preferredResourceSymbol: symbolFor("resource", preferredResourceType),
+      assignmentPhase: typeof row.assignmentPhase === "string" ? row.assignmentPhase : "unknown",
+      reassignedByRebalance: row.reassignedByRebalance === true,
+      assignmentOrder: finiteInteger(row.assignmentOrder),
+      perTypeCountBefore: finiteInteger(row.perTypeCountBefore),
+      legalPlotCountForResource: finiteInteger(row.legalPlotCountForResource),
+      targetMinPerType: finiteInteger(row.targetMinPerType),
     });
   }
   return { byPlot };

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
@@ -263,10 +263,37 @@ const ResourceAssignmentSummarySchema = Type.Object(
   { additionalProperties: false }
 );
 
+const ResourceAssignmentTraceSchema = Type.Object(
+  {
+    plotIndex: Type.Integer(),
+    x: Type.Integer(),
+    y: Type.Integer(),
+    resourceType: Type.Integer(),
+    initialResourceType: Type.Integer(),
+    preferredResourceType: Type.Union([Type.Integer(), Type.Null()]),
+    assignmentPhase: Type.Union([
+      Type.Literal("scarce-floor"),
+      Type.Literal("strict-spacing"),
+      Type.Literal("relaxed-spacing"),
+    ]),
+    reassignedByRebalance: Type.Boolean(),
+    assignmentOrder: Type.Integer({ minimum: 0 }),
+    perTypeCountBefore: Type.Integer({ minimum: 0 }),
+    legalPlotCountForResource: Type.Integer({ minimum: 0 }),
+    targetMinPerType: Type.Integer({ minimum: 0 }),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Diagnostic trace for the local resource assignment pass that selected each resource intent before adapter materialization.",
+  }
+);
+
 const ResourcePlacementOutcomesArtifactSchema = Type.Object(
   {
     summary: ResourcePlacementSummarySchema,
     assignment: ResourceAssignmentSummarySchema,
+    assignmentTrace: Type.Array(ResourceAssignmentTraceSchema),
     outcomes: Type.Array(ResourcePlacementOutcomeSchema),
   },
   {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
@@ -42,10 +42,17 @@ type PlaceResourcesWithTypedOutcomesArgs = {
   height: number;
   resources: DeepReadonly<PlanResourcesOutput>;
 };
+type ResourceAssignmentPhase = "scarce-floor" | "strict-spacing" | "relaxed-spacing";
 type ResourceAssignment = {
   plotIndex: number;
   resourceType: number;
+  initialResourceType: number;
   preferredResourceType: number | null;
+  assignmentPhase: ResourceAssignmentPhase;
+  assignmentOrder: number;
+  perTypeCountBefore: number;
+  legalPlotCountForResource: number;
+  targetMinPerType: number;
 };
 type PlacementCandidate = {
   plotIndex: number;
@@ -370,13 +377,24 @@ function assignResourceIntents(args: {
     legalPlotCounts.set(resourceType, count);
   }
 
-  const addAssignment = (plotIndex: number, resourceType: number): void => {
+  const addAssignment = (
+    plotIndex: number,
+    resourceType: number,
+    assignmentPhase: ResourceAssignmentPhase
+  ): void => {
+    const countBefore = perTypeCounts.get(resourceType) ?? 0;
     usedPlots.add(plotIndex);
-    perTypeCounts.set(resourceType, (perTypeCounts.get(resourceType) ?? 0) + 1);
+    perTypeCounts.set(resourceType, countBefore + 1);
     assignments.push({
       plotIndex,
       resourceType,
+      initialResourceType: resourceType,
       preferredResourceType: preferredByPlot.get(plotIndex) ?? null,
+      assignmentPhase,
+      assignmentOrder: assignments.length,
+      perTypeCountBefore: countBefore,
+      legalPlotCountForResource: legalPlotCounts.get(resourceType) ?? 0,
+      targetMinPerType,
     });
   };
 
@@ -411,7 +429,7 @@ function assignResourceIntents(args: {
         });
         spacingBlockedCount += result.spacingBlockedCount;
         if (result.plotIndex === null) break;
-        addAssignment(result.plotIndex, resourceType);
+        addAssignment(result.plotIndex, resourceType, "scarce-floor");
       }
     }
   }
@@ -440,7 +458,7 @@ function assignResourceIntents(args: {
         strictExhaustedResourceTypes.add(resourceType);
         continue;
       }
-      addAssignment(plotIndex, resourceType);
+      addAssignment(plotIndex, resourceType, "strict-spacing");
       progressed = true;
     }
     if (!progressed) break;
@@ -477,7 +495,7 @@ function assignResourceIntents(args: {
         relaxedExhaustedResourceTypes.add(resourceType);
         continue;
       }
-      addAssignment(plotIndex, resourceType);
+      addAssignment(plotIndex, resourceType, "relaxed-spacing");
       progressed = true;
     }
     if (!progressed) break;
@@ -912,6 +930,23 @@ export function placeResourcesWithTypedOutcomes({
   return {
     summary: summarizeResourceOutcomes(outcomes),
     assignment: assignmentResult.assignment,
+    assignmentTrace: assignmentResult.assignments.map((assignment) => {
+      const tile = expectedTileForIntent(width, assignment.plotIndex);
+      return {
+        plotIndex: assignment.plotIndex,
+        x: tile.x,
+        y: tile.y,
+        resourceType: assignment.resourceType,
+        initialResourceType: assignment.initialResourceType,
+        preferredResourceType: assignment.preferredResourceType,
+        assignmentPhase: assignment.assignmentPhase,
+        reassignedByRebalance: assignment.initialResourceType !== assignment.resourceType,
+        assignmentOrder: assignment.assignmentOrder,
+        perTypeCountBefore: assignment.perTypeCountBefore,
+        legalPlotCountForResource: assignment.legalPlotCountForResource,
+        targetMinPerType: assignment.targetMinPerType,
+      };
+    }),
     outcomes,
   };
 }

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -146,6 +146,36 @@ describe("surface delta context diagnostics", () => {
           ],
         },
         resourcePlacementOutcomes: {
+          assignmentTrace: [
+            {
+              plotIndex: 0,
+              x: 0,
+              y: 0,
+              resourceType: 3,
+              initialResourceType: 12,
+              preferredResourceType: 3,
+              assignmentPhase: "scarce-floor",
+              reassignedByRebalance: true,
+              assignmentOrder: 0,
+              perTypeCountBefore: 0,
+              legalPlotCountForResource: 4,
+              targetMinPerType: 2,
+            },
+            {
+              plotIndex: 2,
+              x: 2,
+              y: 0,
+              resourceType: 2,
+              initialResourceType: 2,
+              preferredResourceType: 2,
+              assignmentPhase: "strict-spacing",
+              reassignedByRebalance: false,
+              assignmentOrder: 1,
+              perTypeCountBefore: 0,
+              legalPlotCountForResource: 3,
+              targetMinPerType: 2,
+            },
+          ],
           outcomes: [
             {
               status: "placed",
@@ -190,6 +220,17 @@ describe("surface delta context diagnostics", () => {
       },
       plannedPreferredResourceSymbol: "RESOURCE_FISH",
       localOutcome: { status: "placed", resourceSymbol: "RESOURCE_FISH" },
+      assignmentTrace: {
+        resourceSymbol: "RESOURCE_FISH",
+        initialResourceSymbol: "RESOURCE_PEARLS",
+        preferredResourceSymbol: "RESOURCE_FISH",
+        assignmentPhase: "scarce-floor",
+        reassignedByRebalance: true,
+        assignmentOrder: 0,
+        perTypeCountBefore: 0,
+        legalPlotCountForResource: 4,
+        targetMinPerType: 2,
+      },
       resourceNeighborhood: {
         minSpacingTiles: 2,
         localResourceOnLocal: {
@@ -223,6 +264,7 @@ describe("surface delta context diagnostics", () => {
       liveResource: { symbol: "RESOURCE_FISH" },
       plannedPreferredResourceSymbol: "RESOURCE_FISH",
       localOutcome: null,
+      assignmentTrace: null,
       evidenceClass: "live-only-preferred-but-unassigned",
     });
     expect(rows[2]).toMatchObject({
@@ -230,6 +272,10 @@ describe("surface delta context diagnostics", () => {
       localResource: { symbol: "RESOURCE_DYES" },
       liveResource: { symbol: "RESOURCE_PEARLS" },
       localOutcome: { status: "placed", resourceSymbol: "RESOURCE_DYES" },
+      assignmentTrace: {
+        assignmentPhase: "strict-spacing",
+        reassignedByRebalance: false,
+      },
       evidenceClass: "local-assigned-live-substitution",
     });
   });

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -23,8 +23,13 @@
 - [x] 2.7 Add official resource policy row/flag and spacing-neighborhood
   context for the focused local-overaccepted rows.
 - [x] 2.8 Add live plot runtime context for resource delta feasibility rows.
-- [ ] 2.9 Repair remaining proven package or MapGen owners.
-- [ ] 2.10 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.9 Add local resource assignment-phase trace for resource delta rows.
+- [x] 2.10 Add local assignment-order context for the focused
+  local-overaccepted rows.
+- [ ] 2.11 Add bounded ResourceBuilder cut/count diagnostics for the focused
+  local-overaccepted rows.
+- [ ] 2.12 Repair remaining proven package or MapGen owners.
+- [ ] 2.13 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -223,8 +223,10 @@ Evidence artifacts:
 
 - proof:
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-assignment-evidence.json`
-  (`sha256:e07418f9ab3efbab81beb6d5c6a9b68e1e40460b6d7421b5b1248a1e0578494c`,
-  `proofHash:d95d54d2f208436324d7600a0c8a8a35e899ff82c617be4b719dfc954c6897df`).
+  (current sha256:
+  `ff4aec0701cbeeb031737b68d93a0a48e9168313ef983cc30a3df91cff6f08ab`,
+  current proofHash:
+  `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`).
 - summary:
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-assignment-summary.json`
   (`sha256:e8d1917d657654bc0d494457c62b8c84a4613f22e024cd5ca770f7fbbb645d8b`).
@@ -273,8 +275,8 @@ Evidence artifact:
 
 - `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-feasibility-readback.json`
   (`sha256:139c8e52c2acd91b01415f8daee6b5dd27ee28e2db26857627118d993cc2e96c`).
-- Source proof: assignment-evidence artifact
-  `d95d54d2f208436324d7600a0c8a8a35e899ff82c617be4b719dfc954c6897df`.
+- Source proof: current assignment-evidence artifact
+  `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`.
 - Readback: Tuner state `1`, host `127.0.0.1`, port `4318`, `106` cells,
   `0` omitted cells.
 
@@ -288,17 +290,21 @@ returned false, including resources that the live grid shows as present.
 |---|---:|---|
 | `live-only-no-local-assignment`, live feasible | `37` | Civ says the live value is feasible, but the local assignment algorithm did not assign that cell. This points to assignment ordering/rebalance divergence, not static legality. |
 | `local-assigned-live-empty`, local feasible | `28` | Local assigned a Civ-feasible resource where live has no resource. This also points to assignment ordering/rebalance divergence. |
-| `local-assigned-live-empty`, local infeasible | `9` | Local mock/static policy over-accepted a resource Civ rejects under the loose feasibility probe. This is the next focused adapter/map-policy repair class. |
+| `local-assigned-live-empty`, local infeasible | `9` | Local placement accepted a resource Civ rejects under the loose feasibility probe. This is a focused local-overacceptance investigation class, not repair authority. |
 | `local-assigned-live-substitution`, both feasible | `31` | Both local and live resource values are Civ-feasible at the tile; this is assignment/type-order divergence, not simple legality. |
 | `local-assigned-live-substitution`, both infeasible | `1` | Preserve as an individual evidence row before repair; neither probed value is feasible under the loose check on the current live map. |
 
 Disposition:
 the feasibility readback narrows but does not close source authority. Most
-remaining rows are now assignment ordering/rebalance evidence, not map-policy
-surface legality. A smaller `9`-row local-overacceptance class is likely
-adapter/map-policy-owned, but it still needs row-level symbol/context
-extraction before a focused policy repair. No resource density, diversity,
-terrain, coast, or Earthlike tuning is authorized.
+remaining rows are now assignment ordering evidence or local-overacceptance
+evidence, not map-policy surface legality. The smaller `9`-row
+local-overacceptance class remains unresolved between repo-owned mock/static
+policy, runtime materialization/state, and hidden Civ
+`ResourceBuilder.canHaveResource` constraints. Current row-level evidence rules
+out official rows/flags, adjacent-land, authored spacing, owner/water/tag/river,
+relaxed spacing, and rebalance as explanations. No repair authority, resource
+density, diversity, terrain, coast, Earthlike tuning, parity closure, or
+product acceptance is authorized.
 
 ### Row-Level Feasibility Classification Diagnostic
 
@@ -339,11 +345,11 @@ the artifact before row-level feasibility evidence is accepted.
 
 Artifact:
 `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-(`sha256:e1ae01d0474aa83960f60c4acb73593851a242d06121670fac751664625356bb`,
-`proofHash:de359a53aa4760c915cfae6dfe9f4d57039e585d85df5892b8c7f6bda80ac932`).
+(`sha256:2d8a85cee626ce561ffa0d735ba5b00670ebc6fbda23da2aaddb651d78af4f15`,
+`proofHash:dd2d9868ad7a86f0091a188feed055c40656675301a751bfeb54d0bf3ffaa1a7`).
 
 Source proof:
-`d95d54d2f208436324d7600a0c8a8a35e899ff82c617be4b719dfc954c6897df`.
+`e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`.
 
 Request identity:
 `studio-run-in-game-mq20rbzr-1fhc`, matched across exact-authorship summary,
@@ -376,19 +382,23 @@ All rows below have one exact official `Resource_ValidBiomes` row matching the
 local surface, no adjacent-land requirement, `lakeEligible:true`, and no local
 or live resource neighbor inside the authored `minSpacingTiles:2` bound.
 Live plot context additionally confirms these cells are live-empty, unowned,
-non-water, untagged, and have no river.
+non-water, untagged, and have no river. Local assignment trace shows every row
+came from the `scarce-floor` assignment phase and none were changed by
+rebalance. Assignment-order context shows every row was selected before the
+local resource type reached the scarce-floor target (`targetMinPerType:7`),
+with local legal plot counts between `66` and `554`.
 
-| Coordinate | Plot | Local resource | Planned preferred | Surface | Official/static policy | Nearest local/live resource distance | Live runtime context | Civ loose feasibility |
-|---|---:|---|---|---|---|---|---|---|
-| `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `6` | `elev416 rain185 fert2 area131073 region65536 landmass131073` | false |
-| `(31,4)` | `455` | `RESOURCE_CLAY` | empty | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `5` | `elev238 rain191 fert2 area589832 region524295 landmass589832` | false |
-| `(56,6)` | `692` | `RESOURCE_GYPSUM` | empty | `TERRAIN_HILL` / `BIOME_TUNDRA` / empty | row match; no flags blocking | `4` / `4` | `elev523 rain197 fert0 area1048591 region720906 landmass196610` | false |
-| `(16,12)` | `1288` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | `TERRAIN_HILL` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `2` / `5` | `elev208 rain193 fert0 area1835035 region1310739 landmass1179665` | false |
-| `(12,19)` | `2026` | `RESOURCE_JADE` | `RESOURCE_SILK` | `TERRAIN_FLAT` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `4` / `2` | `elev214 rain194 fert1 area3538997 region2359331 landmass1638424` | false |
-| `(9,21)` | `2235` | `RESOURCE_HORSES` | `RESOURCE_COWRIE` | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / empty | row match; no flags blocking | `4` / `6` | `elev453 rain169 fert1 area3670071 region2555942 landmass1703961` | false |
-| `(72,35)` | `3782` | `RESOURCE_RICE` | empty | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `4` / `4` | `elev192 rain184 fert2 area4522052 region3670071 landmass2424868` | false |
-| `(86,38)` | `4114` | `RESOURCE_CLAY` | empty | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `5` / `5` | `elev232 rain176 fert2 area4915274 region4128830 landmass2752553` | false |
-| `(67,51)` | `5473` | `RESOURCE_KAOLIN` | `RESOURCE_SILVER` | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / `FEATURE_MARSH` | row match; no flags blocking | `8` / `6` | `elev427 rain172 fert2 area5963866 region5898329 landmass3538997` | false |
+| Coordinate | Plot | Local resource | Planned preferred | Assignment order context | Surface | Official/static policy | Nearest local/live resource distance | Live runtime context | Civ loose feasibility |
+|---|---:|---|---|---|---|---|---|---|---|
+| `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `23`; count before `2/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `6` | `elev416 rain185 fert2 area131073 region65536 landmass131073` | false |
+| `(31,4)` | `455` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `21`; count before `0/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `5` | `elev238 rain191 fert2 area589832 region524295 landmass589832` | false |
+| `(56,6)` | `692` | `RESOURCE_GYPSUM` | empty | `scarce-floor`; order `74`; count before `4/7`; legal plots `324`; no rebalance | `TERRAIN_HILL` / `BIOME_TUNDRA` / empty | row match; no flags blocking | `4` / `4` | `elev523 rain197 fert0 area1048591 region720906 landmass196610` | false |
+| `(16,12)` | `1288` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | `scarce-floor`; order `90`; count before `6/7`; legal plots `328`; no rebalance | `TERRAIN_HILL` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `2` / `5` | `elev208 rain193 fert0 area1835035 region1310739 landmass1179665` | false |
+| `(12,19)` | `2026` | `RESOURCE_JADE` | `RESOURCE_SILK` | `scarce-floor`; order `139`; count before `6/7`; legal plots `525`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `4` / `2` | `elev214 rain194 fert1 area3538997 region2359331 landmass1638424` | false |
+| `(9,21)` | `2235` | `RESOURCE_HORSES` | `RESOURCE_COWRIE` | `scarce-floor`; order `152`; count before `5/7`; legal plots `554`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / empty | row match; no flags blocking | `4` / `6` | `elev453 rain169 fert1 area3670071 region2555942 landmass1703961` | false |
+| `(72,35)` | `3782` | `RESOURCE_RICE` | empty | `scarce-floor`; order `14`; count before `0/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `4` / `4` | `elev192 rain184 fert2 area4522052 region3670071 landmass2424868` | false |
+| `(86,38)` | `4114` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `24`; count before `3/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `5` / `5` | `elev232 rain176 fert2 area4915274 region4128830 landmass2752553` | false |
+| `(67,51)` | `5473` | `RESOURCE_KAOLIN` | `RESOURCE_SILVER` | `scarce-floor`; order `8`; count before `1/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / `FEATURE_MARSH` | row match; no flags blocking | `8` / `6` | `elev427 rain172 fert2 area5963866 region5898329 landmass3538997` | false |
 
 Individual `substitution-both-infeasible` row:
 
@@ -404,9 +414,12 @@ repo-owned mock/static-policy gap or accepted engine/materialization behavior.
 The single both-infeasible substitution row remains outside that repair class.
 Because the focused rows are not explained by official surface rows,
 adjacent-land flags, authored spacing, owner, water, plot tags, or river state,
-the next authority check should inspect Civ `ResourceBuilder.canHaveResource`
-constraints that are not present in the static browser tables, or prove a
-runtime-state/materialization disposition before changing mock policy.
+and are not introduced by relaxed spacing or rebalance, the next authority
+check should inspect Civ `ResourceBuilder.canHaveResource` constraints that are
+not present in the static browser tables, or prove a runtime-state/materialization
+disposition before changing mock policy. The assignment-order context proves
+these rows came from the local scarce-floor quota pass, but that is still
+diagnostic context rather than repair authority.
 
 ## Required Next Diagnostics
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,8 +5,8 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-policy-live-context-drain`
-  stacked above `codex/swooper-resource-delta-context-drain`
+- Branch/Graphite stack: `codex/swooper-resource-assignment-trace-drain`
+  stacked above `codex/swooper-resource-policy-live-context-drain`
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
@@ -87,8 +87,10 @@
   typed `resourcePlacementOutcomes` evidence. A rerun with that evidence
   produced
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-assignment-evidence.json`
-  (`sha256:e07418f9ab3efbab81beb6d5c6a9b68e1e40460b6d7421b5b1248a1e0578494c`,
-  `proofHash:d95d54d2f208436324d7600a0c8a8a35e899ff82c617be4b719dfc954c6897df`)
+  (current sha256:
+  `ff4aec0701cbeeb031737b68d93a0a48e9168313ef983cc30a3df91cff6f08ab`,
+  current proofHash:
+  `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`)
   and summary
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-assignment-summary.json`
   (`sha256:e8d1917d657654bc0d494457c62b8c84a4613f22e024cd5ca770f7fbbb645d8b`).
@@ -134,10 +136,10 @@
   blocks if those sources are missing or conflicting. It then reads current
   live map identity through `getCiv7MapSummary` and blocks if width, height,
   plot count, seed, turn, or game hash do not match the saved proof identity.
-  The current artifact is
+  The current assignment-order artifact is
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-  (`sha256:e1ae01d0474aa83960f60c4acb73593851a242d06121670fac751664625356bb`,
-  `proofHash:de359a53aa4760c915cfae6dfe9f4d57039e585d85df5892b8c7f6bda80ac932`).
+  (`sha256:2d8a85cee626ce561ffa0d735ba5b00670ebc6fbda23da2aaddb651d78af4f15`,
+  `proofHash:dd2d9868ad7a86f0091a188feed055c40656675301a751bfeb54d0bf3ffaa1a7`).
   Request identity resolves to `studio-run-in-game-mq20rbzr-1fhc`; runtime
   identity is matched to the saved proof at `106x66`, `6996` plots, seed
   `138503614`, turn `1`, and game hash `0`. The artifact preserves the
@@ -167,6 +169,40 @@
   owner/water/tag/river explanations, but still does not expose the internal
   `ResourceBuilder.canHaveResource` rejection reason or authorize mock/static
   policy repair.
+- Assignment trace progress:
+  local resource placement now records an `assignmentTrace` row for each local
+  resource intent, including assignment phase, initial resource type, final
+  resource type, preferred resource type, and whether rebalance changed the
+  assignment. The regenerated exact-authored resource feasibility artifact
+  shows all `9` focused local-overaccepted/live-empty rows came from the local
+  `scarce-floor` assignment phase and none were changed by rebalance. This
+  removes relaxed-spacing and rebalance as explanations for the focused class,
+  but it still does not identify the hidden Civ feasibility constraint that
+  rejected those cells.
+- Assignment-order context progress:
+  the typed local `resourcePlacementOutcomes.assignmentTrace` now records
+  assignment order, per-type count before assignment, legal local plot count for
+  the resource, and the scarce-floor target. The regenerated local assignment
+  evidence artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-assignment-evidence.json`
+  has sha256
+  `ff4aec0701cbeeb031737b68d93a0a48e9168313ef983cc30a3df91cff6f08ab`
+  and proofHash
+  `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`.
+  The regenerated resource feasibility artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
+  has sha256
+  `2d8a85cee626ce561ffa0d735ba5b00670ebc6fbda23da2aaddb651d78af4f15`
+  and proofHash
+  `dd2d9868ad7a86f0091a188feed055c40656675301a751bfeb54d0bf3ffaa1a7`.
+  The `9` focused rows are all scarce-floor assignments made before their local
+  resource type reached the floor target (`targetMinPerType:7`), with local
+  legal plot counts between `66` and `554`. This proves the local reason those
+  cells were selected: the assignment pass was filling per-type floor quota
+  against local adapter/static legality. It does not yet prove whether repair
+  belongs in the local scarce-floor candidate/cut ordering policy, in an
+  adapter/mock approximation of hidden Civ constraints, or in an accepted
+  materialization-state disposition.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -174,11 +210,17 @@
   limitation. Terrain edge rows may enter this slice only if diagnostics prove
   shared materialization ownership. The unchanged resource mismatch count after
   the adjacent-land repair and the assignment-evidence rerun means the next
-  resource authority gap is assignment ordering/rebalance diagnostics plus
-  focused mock feasibility classification for the `9` local-assigned/live-empty
-  rows where Civ rejects the local value with `ignoreWeight:true`, not resource
-  tuning. The single substitution row where both probed values are infeasible
-  remains an individual evidence row with no repair authority until row-level
-  context assigns source ownership.
+  resource authority gap is broad assignment ordering diagnostics for the
+  feasible live-only/local-empty/substitution classes plus hidden runtime
+  feasibility classification for the `9` local-assigned/live-empty rows where
+  Civ rejects the local value with `ignoreWeight:true`. For those `9` rows,
+  assignment trace rules out relaxed spacing and rebalance, and assignment-order
+  context shows every focused local value came from the scarce-floor quota pass,
+  not strict/relaxed fill or rebalance. No resource tuning, static-policy
+  repair, or assignment-order repair is authorized until those sub-classes are
+  assigned to a concrete source owner. The next diagnostic owner is bounded
+  ResourceBuilder cut/count readback. The single substitution row where both
+  probed values are infeasible remains an individual evidence row with no repair
+  authority until row-level context assigns source ownership.
 - Stop condition: source authority is not known for any row outside the
   classified adjacent-land resource class.


### PR DESCRIPTION
Adds a per-plot resource assignment trace to the local resource placement pipeline and surfaces it in the diagnostic delta context.

Each local resource intent now records the assignment phase (`scarce-floor`, `strict-spacing`, or `relaxed-spacing`), the initial resource type before any rebalance, the final resource type, the preferred resource type, assignment order, per-type count at the time of selection, the local legal plot count for that resource, and the scarce-floor target. A `reassignedByRebalance` flag is derived by comparing the initial and final resource types.

The trace is emitted as `assignmentTrace` in the `resourcePlacementOutcomes` artifact and exposed as `ResourceAssignmentTraceContext` on each `ResourceDeltaPlacementContext` row in the diagnostic surface delta view.

Applying this trace to the 9 focused `local-assigned-live-empty`/local-infeasible rows confirms that every one came from the `scarce-floor` assignment phase with no rebalance change, and that each was selected while its resource type was still below the floor target against local legal plot counts between 66 and 554. This rules out relaxed spacing and rebalance as explanations for that class. The workstream ledger and phase record are updated to reflect the new artifact hashes and to record that the next unresolved diagnostic is bounded `ResourceBuilder` cut/count readback.