### PR TITLE
feat(civ7-direct-control): add `getCiv7ResourceBuilderDiagnostics` with cut/count/landmass readback and update workstream ledger with task 2.11 completion

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -26,7 +26,7 @@
 - [x] 2.9 Add local resource assignment-phase trace for resource delta rows.
 - [x] 2.10 Add local assignment-order context for the focused
   local-overaccepted rows.
-- [ ] 2.11 Add bounded ResourceBuilder cut/count diagnostics for the focused
+- [x] 2.11 Add bounded ResourceBuilder cut/count diagnostics for the focused
   local-overaccepted rows.
 - [ ] 2.12 Repair remaining proven package or MapGen owners.
 - [ ] 2.13 Preserve resource spacing, age legality, and diversity expectations.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -386,19 +386,25 @@ non-water, untagged, and have no river. Local assignment trace shows every row
 came from the `scarce-floor` assignment phase and none were changed by
 rebalance. Assignment-order context shows every row was selected before the
 local resource type reached the scarce-floor target (`targetMinPerType:7`),
-with local legal plot counts between `66` and `554`.
+with local legal plot counts between `66` and `554`. ResourceBuilder
+diagnostics are read through
+`getCiv7ResourceBuilderDiagnostics` in the runtime-bound full artifact:
+sha256
+`0106c8aefdd05083159b57e93d2d8f463bfb3c59ee5cb223b7b36d7be381528b`,
+proofHash
+`5fb8111e4967bb45f50893adb95d122ca38a2ad5ddb4c8926d2ce2e1f605b7d1`.
 
-| Coordinate | Plot | Local resource | Planned preferred | Assignment order context | Surface | Official/static policy | Nearest local/live resource distance | Live runtime context | Civ loose feasibility |
-|---|---:|---|---|---|---|---|---|---|---|
-| `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `23`; count before `2/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `6` | `elev416 rain185 fert2 area131073 region65536 landmass131073` | false |
-| `(31,4)` | `455` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `21`; count before `0/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `5` | `elev238 rain191 fert2 area589832 region524295 landmass589832` | false |
-| `(56,6)` | `692` | `RESOURCE_GYPSUM` | empty | `scarce-floor`; order `74`; count before `4/7`; legal plots `324`; no rebalance | `TERRAIN_HILL` / `BIOME_TUNDRA` / empty | row match; no flags blocking | `4` / `4` | `elev523 rain197 fert0 area1048591 region720906 landmass196610` | false |
-| `(16,12)` | `1288` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | `scarce-floor`; order `90`; count before `6/7`; legal plots `328`; no rebalance | `TERRAIN_HILL` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `2` / `5` | `elev208 rain193 fert0 area1835035 region1310739 landmass1179665` | false |
-| `(12,19)` | `2026` | `RESOURCE_JADE` | `RESOURCE_SILK` | `scarce-floor`; order `139`; count before `6/7`; legal plots `525`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `4` / `2` | `elev214 rain194 fert1 area3538997 region2359331 landmass1638424` | false |
-| `(9,21)` | `2235` | `RESOURCE_HORSES` | `RESOURCE_COWRIE` | `scarce-floor`; order `152`; count before `5/7`; legal plots `554`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / empty | row match; no flags blocking | `4` / `6` | `elev453 rain169 fert1 area3670071 region2555942 landmass1703961` | false |
-| `(72,35)` | `3782` | `RESOURCE_RICE` | empty | `scarce-floor`; order `14`; count before `0/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `4` / `4` | `elev192 rain184 fert2 area4522052 region3670071 landmass2424868` | false |
-| `(86,38)` | `4114` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `24`; count before `3/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `5` / `5` | `elev232 rain176 fert2 area4915274 region4128830 landmass2752553` | false |
-| `(67,51)` | `5473` | `RESOURCE_KAOLIN` | `RESOURCE_SILVER` | `scarce-floor`; order `8`; count before `1/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / `FEATURE_MARSH` | row match; no flags blocking | `8` / `6` | `elev427 rain172 fert2 area5963866 region5898329 landmass3538997` | false |
+| Coordinate | Plot | Local resource | Planned preferred | Assignment order context | Surface | Official/static policy | Nearest local/live resource distance | Live runtime context | Civ loose feasibility | ResourceBuilder cut/count diagnostics |
+|---|---:|---|---|---|---|---|---|---|---|---|
+| `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `23`; count before `2/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `6` | `elev416 rain185 fert2 area131073 region65536 landmass131073` | false | cut excludes local; count `8`; required false |
+| `(31,4)` | `455` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `21`; count before `0/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `5` | `elev238 rain191 fert2 area589832 region524295 landmass589832` | false | cut excludes local; count `8`; required false |
+| `(56,6)` | `692` | `RESOURCE_GYPSUM` | empty | `scarce-floor`; order `74`; count before `4/7`; legal plots `324`; no rebalance | `TERRAIN_HILL` / `BIOME_TUNDRA` / empty | row match; no flags blocking | `4` / `4` | `elev523 rain197 fert0 area1048591 region720906 landmass196610` | false | cut includes local but `canHaveResource` false; count `8`; required false |
+| `(16,12)` | `1288` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | `scarce-floor`; order `90`; count before `6/7`; legal plots `328`; no rebalance | `TERRAIN_HILL` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `2` / `5` | `elev208 rain193 fert0 area1835035 region1310739 landmass1179665` | false | cut excludes local; count `8`; required true |
+| `(12,19)` | `2026` | `RESOURCE_JADE` | `RESOURCE_SILK` | `scarce-floor`; order `139`; count before `6/7`; legal plots `525`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `4` / `2` | `elev214 rain194 fert1 area3538997 region2359331 landmass1638424` | false | cut excludes local; count `7`; required true |
+| `(9,21)` | `2235` | `RESOURCE_HORSES` | `RESOURCE_COWRIE` | `scarce-floor`; order `152`; count before `5/7`; legal plots `554`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / empty | row match; no flags blocking | `4` / `6` | `elev453 rain169 fert1 area3670071 region2555942 landmass1703961` | false | cut excludes local; count `7`; required true |
+| `(72,35)` | `3782` | `RESOURCE_RICE` | empty | `scarce-floor`; order `14`; count before `0/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `4` / `4` | `elev192 rain184 fert2 area4522052 region3670071 landmass2424868` | false | cut includes local but `canHaveResource` false; count `8`; required false |
+| `(86,38)` | `4114` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `24`; count before `3/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `5` / `5` | `elev232 rain176 fert2 area4915274 region4128830 landmass2752553` | false | cut includes local but `canHaveResource` false; count `8`; required false |
+| `(67,51)` | `5473` | `RESOURCE_KAOLIN` | `RESOURCE_SILVER` | `scarce-floor`; order `8`; count before `1/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / `FEATURE_MARSH` | row match; no flags blocking | `8` / `6` | `elev427 rain172 fert2 area5963866 region5898329 landmass3538997` | false | cut excludes local; count `8`; required true |
 
 Individual `substitution-both-infeasible` row:
 
@@ -415,11 +421,12 @@ The single both-infeasible substitution row remains outside that repair class.
 Because the focused rows are not explained by official surface rows,
 adjacent-land flags, authored spacing, owner, water, plot tags, or river state,
 and are not introduced by relaxed spacing or rebalance, the next authority
-check should inspect Civ `ResourceBuilder.canHaveResource` constraints that are
-not present in the static browser tables, or prove a runtime-state/materialization
-disposition before changing mock policy. The assignment-order context proves
-these rows came from the local scarce-floor quota pass, but that is still
-diagnostic context rather than repair authority.
+check should split the `6` cut-excluded rows from the `3` cut-included but
+still rejected rows and determine whether the owner is repo mock/static policy,
+Civ cut ordering/count/landmass policy, runtime materialization state, or
+evidence insufficiency before changing mock policy.
+The assignment-order context proves these rows came from the local scarce-floor
+quota pass, but that is still diagnostic context rather than repair authority.
 
 ## Required Next Diagnostics
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,13 +5,13 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-assignment-trace-drain`
-  stacked above `codex/swooper-resource-policy-live-context-drain`
+- Branch/Graphite stack: `codex/swooper-resource-builder-diagnostics-drain`
+  stacked above `codex/swooper-resource-assignment-trace-drain`
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
-  feasibility plus row/static-policy/live-plot diagnostic context now narrows
-  the next resource repair class.
+  feasibility plus row/static-policy/live-plot, assignment-order, and
+  ResourceBuilder diagnostic context now narrows the next resource repair class.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -203,6 +203,28 @@
   belongs in the local scarce-floor candidate/cut ordering policy, in an
   adapter/mock approximation of hidden Civ constraints, or in an accepted
   materialization-state disposition.
+- ResourceBuilder diagnostics progress:
+  `@civ7/direct-control` now exposes a bounded
+  `getCiv7ResourceBuilderDiagnostics` read wrapper for the focused rows. The
+  regenerated runtime-bound artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
+  has sha256
+  `0106c8aefdd05083159b57e93d2d8f463bfb3c59ee5cb223b7b36d7be381528b`
+  and proofHash
+  `5fb8111e4967bb45f50893adb95d122ca38a2ad5ddb4c8926d2ce2e1f605b7d1`.
+  It keeps the same exact-authored source proof hash
+  `43238c33197c3b8d2e06e6209f03101268c4f125dcc33f2e9892c8d2baf7fcab`
+  and reads ResourceBuilder diagnostics for the `9` focused cells with `0`
+  omitted cells. All `9` remain false under both strict and
+  `ignoreWeight:true` `canHaveResource`. Civ `getBestMapResourceCuts` excludes
+  the local resource for `6` rows and includes it for `3` rows that are still
+  rejected, so cut-list exclusion explains part but not all of the class. All
+  probed resource types are age-valid, counts are present, and the
+  ResourceBuilder landmass probe returns `255` for each local resource type.
+  This narrows the next source-authority step to hidden ResourceBuilder cut
+  ordering/landmass/count or materialization-state constraints; it still does
+  not authorize mock/static-policy repair, resource tuning, parity closure, or
+  product acceptance.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -214,13 +236,14 @@
   feasible live-only/local-empty/substitution classes plus hidden runtime
   feasibility classification for the `9` local-assigned/live-empty rows where
   Civ rejects the local value with `ignoreWeight:true`. For those `9` rows,
-  assignment trace rules out relaxed spacing and rebalance, and assignment-order
+  assignment trace rules out relaxed spacing and rebalance, assignment-order
   context shows every focused local value came from the scarce-floor quota pass,
-  not strict/relaxed fill or rebalance. No resource tuning, static-policy
-  repair, or assignment-order repair is authorized until those sub-classes are
-  assigned to a concrete source owner. The next diagnostic owner is bounded
-  ResourceBuilder cut/count readback. The single substitution row where both
-  probed values are infeasible remains an individual evidence row with no repair
-  authority until row-level context assigns source ownership.
+  and ResourceBuilder diagnostics show `6` local resources absent from Civ cut
+  lists while `3` local resources are present in cut lists but still rejected.
+  No resource tuning, static-policy repair, or assignment-order repair is
+  authorized until those sub-classes are assigned to a concrete source owner.
+  The single substitution row where both probed values are infeasible remains
+  an individual evidence row with no repair authority until row-level context
+  assigns source ownership.
 - Stop condition: source authority is not known for any row outside the
   classified adjacent-land resource class.

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -495,6 +495,59 @@ export type Civ7ResourcePlacementFeasibilityResult = Readonly<{
   cells: ReadonlyArray<Civ7ResourcePlacementFeasibilityCell>;
 }>;
 
+export type Civ7ResourceBuilderCutResource = Readonly<{
+  hash: number;
+  resourceType?: number;
+  resourceTypeName?: string;
+  row?: unknown;
+}>;
+
+export type Civ7ResourceBuilderDiagnosticsResource = Readonly<{
+  resourceType: number;
+  row: Civ7RuntimeProbe<unknown>;
+  hash: Civ7RuntimeProbe<number>;
+  count: Civ7RuntimeProbe<number>;
+  landmass: Civ7RuntimeProbe<number>;
+  validForAge: Civ7RuntimeProbe<boolean>;
+  requiredForAge: Civ7RuntimeProbe<boolean>;
+  ignoringWeightForRiverPlacement: Civ7RuntimeProbe<boolean>;
+}>;
+
+export type Civ7ResourceBuilderDiagnosticsCellResource = Readonly<{
+  canHaveResource: Readonly<{
+    strict: Civ7RuntimeProbe<boolean>;
+    ignoreWeight: Civ7RuntimeProbe<boolean>;
+  }>;
+  resourceLandmassAtCell: Civ7RuntimeProbe<number>;
+  bestMapResourceCutHashes: Civ7RuntimeProbe<ReadonlyArray<number>>;
+  bestMapResourceCuts: Civ7RuntimeProbe<ReadonlyArray<Civ7ResourceBuilderCutResource>>;
+}>;
+
+export type Civ7ResourceBuilderDiagnosticsCell = Readonly<{
+  location: Readonly<Civ7MapLocation & {
+    index: Civ7RuntimeProbe<number>;
+  }>;
+  resourceTypes: ReadonlyArray<number>;
+  omittedResourceTypes: number;
+  resources: Readonly<Record<string, Civ7ResourceBuilderDiagnosticsCellResource>>;
+}>;
+
+export type Civ7ResourceBuilderDiagnosticsInput = Readonly<{
+  cells: ReadonlyArray<Civ7ResourcePlacementFeasibilityCellInput>;
+  maxCells?: number;
+  maxResourceTypesPerCell?: number;
+}>;
+
+export type Civ7ResourceBuilderDiagnosticsResult = Readonly<{
+  host: string;
+  port: number;
+  state: Civ7TunerState;
+  cellCount: number;
+  omittedCells: number;
+  resources: ReadonlyArray<Civ7ResourceBuilderDiagnosticsResource>;
+  cells: ReadonlyArray<Civ7ResourceBuilderDiagnosticsCell>;
+}>;
+
 export type Civ7FullMapGridIdentityCheck = Readonly<{
   stable: boolean;
   checked: ReadonlyArray<string>;
@@ -1723,6 +1776,41 @@ export async function getCiv7ResourcePlacementFeasibility(
   return jsonPayloadFromCommandResult<Civ7ResourcePlacementFeasibilityResult>(
     result,
     "Civ7 resource placement feasibility",
+  );
+}
+
+export async function getCiv7ResourceBuilderDiagnostics(
+  input: Civ7ResourceBuilderDiagnosticsInput,
+  options: Civ7DirectControlOptions = {},
+): Promise<Civ7ResourceBuilderDiagnosticsResult> {
+  const maxCells = boundedInteger(
+    input.maxCells ?? DEFAULT_CIV7_RESOURCE_FEASIBILITY_MAX_CELLS,
+    1,
+    HARD_CIV7_RESOURCE_FEASIBILITY_MAX_CELLS,
+    "maxCells",
+  );
+  const maxResourceTypesPerCell = boundedInteger(
+    input.maxResourceTypesPerCell ?? DEFAULT_CIV7_RESOURCE_FEASIBILITY_MAX_TYPES_PER_CELL,
+    1,
+    HARD_CIV7_RESOURCE_FEASIBILITY_MAX_TYPES_PER_CELL,
+    "maxResourceTypesPerCell",
+  );
+  validateResourcePlacementFeasibilityInput(input, maxCells, maxResourceTypesPerCell);
+  const result = await executeCiv7TunerCommand({
+    ...options,
+    command: buildResourceBuilderDiagnosticsCommand({
+      cells: input.cells.slice(0, maxCells).map((cell) => ({
+        ...cell,
+        resourceTypes: cell.resourceTypes.slice(0, maxResourceTypesPerCell),
+        requestedResourceTypeCount: cell.resourceTypes.length,
+      })),
+      requestedCellCount: input.cells.length,
+      maxResourceTypesPerCell,
+    }),
+  });
+  return jsonPayloadFromCommandResult<Civ7ResourceBuilderDiagnosticsResult>(
+    result,
+    "Civ7 ResourceBuilder diagnostics",
   );
 }
 
@@ -3128,6 +3216,121 @@ function buildResourcePlacementFeasibilityCommand(input: {
   })()`;
 }
 
+function buildResourceBuilderDiagnosticsCommand(input: {
+  cells: ReadonlyArray<Civ7ResourcePlacementFeasibilityCellInput & {
+    requestedResourceTypeCount: number;
+  }>;
+  requestedCellCount: number;
+  maxResourceTypesPerCell: number;
+}): string {
+  return `(() => {
+    ${probeHelperSource()}
+    const input = ${jsLiteral(input)};
+    const rb = typeof ResourceBuilder !== "undefined" ? ResourceBuilder : undefined;
+    if (!rb) throw new Error("ResourceBuilder is unavailable");
+    const toPlain = (row) => {
+      if (row == null || typeof row !== "object") return row;
+      try {
+        return JSON.parse(JSON.stringify(row));
+      } catch {
+        const out = {};
+        for (const key of Object.getOwnPropertyNames(row)) {
+          try {
+            const value = row[key];
+            if (typeof value !== "function") out[key] = value;
+          } catch {}
+        }
+        return out;
+      }
+    };
+    const resourceRows = (() => {
+      const table = typeof GameInfo !== "undefined" ? GameInfo.Resources : undefined;
+      if (!table) return [];
+      try {
+        return Array.from(table).map((row) => toPlain(row));
+      } catch {
+        return [];
+      }
+    })();
+    const resourceRowsByType = new Map();
+    const resourceRowsByHash = new Map();
+    for (const row of resourceRows) {
+      const type = row?.$index ?? row?.Index ?? row?.ResourceType;
+      if (Number.isInteger(type)) resourceRowsByType.set(type, row);
+      const hash = row?.$hash ?? row?.Hash;
+      if (Number.isInteger(hash)) resourceRowsByHash.set(hash, row);
+    }
+    const resourceTypes = [...new Set(input.cells.flatMap((cell) => cell.resourceTypes))].sort((left, right) => left - right);
+    const counts = probe(() => rb.getResourceCounts());
+    const readCount = (resourceType) => {
+      if (!counts.ok || !Array.isArray(counts.value)) return counts.ok ? { ok: false, error: "ResourceBuilder.getResourceCounts did not return an array" } : counts;
+      return { ok: true, value: counts.value[resourceType] };
+    };
+    const readResource = (resourceType) => {
+      const row = resourceRowsByType.get(resourceType);
+      const hash = row?.$hash ?? row?.Hash;
+      return {
+        resourceType,
+        row: row === undefined ? { ok: false, error: "GameInfo.Resources row not found" } : { ok: true, value: row },
+        hash: Number.isInteger(hash) ? { ok: true, value: hash } : { ok: false, error: "GameInfo.Resources hash not found" },
+        count: readCount(resourceType),
+        landmass: probe(() => rb.getResourceLandmass(resourceType)),
+        validForAge: probe(() => rb.isResourceValidForAge(resourceType)),
+        requiredForAge: probe(() => rb.isResourceRequiredForAge(resourceType)),
+        ignoringWeightForRiverPlacement: probe(() => rb.isResourceIgnoringWeightForRiverPlacement(resourceType)),
+      };
+    };
+    const decodeCuts = (cutHashes) => cutHashes.map((hash) => {
+      const row = resourceRowsByHash.get(hash);
+      const type = row?.$index ?? row?.Index ?? row?.ResourceType;
+      return {
+        hash,
+        ...(Number.isInteger(type) ? { resourceType: type } : {}),
+        ...(typeof row?.ResourceType === "string" ? { resourceTypeName: row.ResourceType } : {}),
+        ...(typeof row?.ResourceType === "string" ? {} : typeof row?.ResourceTypeName === "string" ? { resourceTypeName: row.ResourceTypeName } : {}),
+        ...(row !== undefined ? { row } : {}),
+      };
+    });
+    const readCellResource = (cell, resourceType) => {
+      const cutHashes = probe(() => rb.getBestMapResourceCuts(cell.x, cell.y, resourceType));
+      return {
+        canHaveResource: {
+          strict: probe(() => rb.canHaveResource(cell.x, cell.y, resourceType, false)),
+          ignoreWeight: probe(() => rb.canHaveResource(cell.x, cell.y, resourceType, true)),
+        },
+        resourceLandmassAtCell: probe(() => rb.getResourceLandmass(cell.x, cell.y, resourceType)),
+        bestMapResourceCutHashes: cutHashes,
+        bestMapResourceCuts: cutHashes.ok && Array.isArray(cutHashes.value)
+          ? { ok: true, value: decodeCuts(cutHashes.value) }
+          : cutHashes.ok
+            ? { ok: false, error: "ResourceBuilder.getBestMapResourceCuts did not return an array" }
+            : cutHashes,
+      };
+    };
+    const readCell = (cell) => {
+      const resourceTypes = cell.resourceTypes.slice(0, input.maxResourceTypesPerCell);
+      const resources = {};
+      for (const resourceType of resourceTypes) resources[String(resourceType)] = readCellResource(cell, resourceType);
+      return {
+        location: {
+          x: cell.x,
+          y: cell.y,
+          index: probe(() => GameplayMap.getIndexFromXY(cell.x, cell.y)),
+        },
+        resourceTypes,
+        omittedResourceTypes: Math.max(0, (cell.requestedResourceTypeCount ?? resourceTypes.length) - resourceTypes.length),
+        resources,
+      };
+    };
+    return JSON.stringify({
+      cellCount: input.requestedCellCount,
+      omittedCells: Math.max(0, input.requestedCellCount - input.cells.length),
+      resources: resourceTypes.map((resourceType) => readResource(resourceType)),
+      cells: input.cells.map((cell) => readCell(cell)),
+    });
+  })()`;
+}
+
 function buildPlayerSummaryCommand(input: Civ7PlayerSummaryInput & { maxItems: number }): string {
   return `(() => {
     ${probeHelperSource()}
@@ -4038,10 +4241,10 @@ const STATIC_CIV7_CAPABILITY_ENTRIES: ReadonlyArray<Civ7CapabilityCatalogEntry> 
     kind: "read-wrapper",
     owner: "@civ7/direct-control",
     risk: "read",
-    provenance: ["ResourceBuilder.canHaveResource", "GameplayMap"],
-    wrapper: "getCiv7ResourcePlacementFeasibility",
+    provenance: ["ResourceBuilder.canHaveResource", "ResourceBuilder.getBestMapResourceCuts", "ResourceBuilder.getResourceCounts", "GameInfo.Resources", "GameplayMap"],
+    wrapper: "getCiv7ResourcePlacementFeasibility|getCiv7ResourceBuilderDiagnostics",
     confidence: "source",
-    description: "Reads bounded per-cell resource feasibility probes for parity/source-authority diagnostics without mutating the map.",
+    description: "Reads bounded per-cell resource feasibility and ResourceBuilder cut/count diagnostics for parity/source-authority diagnostics without mutating the map.",
   },
   {
     id: "wrapper.autoplay",

--- a/packages/civ7-direct-control/test/direct-control.test.ts
+++ b/packages/civ7-direct-control/test/direct-control.test.ts
@@ -25,6 +25,7 @@ import {
   getCiv7MapSummary,
   getCiv7PlotSnapshot,
   getCiv7PlayableStatus,
+  getCiv7ResourceBuilderDiagnostics,
   getCiv7ResourcePlacementFeasibility,
   getCiv7SetupMapRows,
   getCiv7SetupSnapshot,
@@ -470,6 +471,68 @@ describe("Civ7 direct control", () => {
       });
       expect(server.received.some((message) => message.includes("ResourceBuilder"))).toBe(true);
       expect(server.received.some((message) => message.includes("readResourcePlacementFeasibility"))).toBe(true);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("wraps ResourceBuilder diagnostics through package-owned readback", async () => {
+    const server = await startTunerServer();
+    try {
+      const { port } = server.address();
+      const diagnostics = await getCiv7ResourceBuilderDiagnostics(
+        {
+          cells: [
+            { x: 9, y: 9, resourceTypes: [3, 12] },
+            { x: 10, y: 9, resourceTypes: [53] },
+          ],
+          maxCells: 1,
+          maxResourceTypesPerCell: 1,
+        },
+        { host: "127.0.0.1", port, timeoutMs: 1_000 },
+      );
+
+      expect(diagnostics).toMatchObject({
+        cellCount: 2,
+        omittedCells: 1,
+        resources: [
+          {
+            resourceType: 3,
+            row: { ok: true, value: expect.objectContaining({ ResourceType: "RESOURCE_CLAY" }) },
+            hash: { ok: true, value: 333 },
+            count: { ok: true, value: 7 },
+            landmass: { ok: true, value: 255 },
+            validForAge: { ok: true, value: true },
+            requiredForAge: { ok: true, value: false },
+            ignoringWeightForRiverPlacement: { ok: true, value: false },
+          },
+        ],
+        cells: [
+          {
+            location: { x: 9, y: 9, index: { ok: true, value: 765 } },
+            resourceTypes: [3],
+            omittedResourceTypes: 1,
+            resources: {
+              "3": {
+                canHaveResource: {
+                  strict: { ok: true, value: false },
+                  ignoreWeight: { ok: true, value: true },
+                },
+                resourceLandmassAtCell: { ok: true, value: 255 },
+                bestMapResourceCutHashes: { ok: true, value: [333, 444] },
+                bestMapResourceCuts: {
+                  ok: true,
+                  value: [
+                    expect.objectContaining({ hash: 333, resourceType: 3, resourceTypeName: "RESOURCE_CLAY" }),
+                    expect.objectContaining({ hash: 444, resourceType: 12, resourceTypeName: "RESOURCE_RICE" }),
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      });
+      expect(server.received.some((message) => message.includes("getBestMapResourceCuts"))).toBe(true);
     } finally {
       await server.close();
     }
@@ -1549,6 +1612,51 @@ async function startTunerServer(options: {
                     omittedResourceTypes: 1,
                     feasibility: {
                       "3": { ok: true, value: true },
+                    },
+                  },
+                ],
+              }),
+            ]),
+          );
+        } else if (frame.message.includes("readCellResource")) {
+          socket.write(
+            encodeResponse(frame.listenerId, [
+              JSON.stringify({
+                cellCount: 2,
+                omittedCells: 1,
+                resources: [
+                  {
+                    resourceType: 3,
+                    row: { ok: true, value: { $index: 3, $hash: 333, ResourceType: "RESOURCE_CLAY" } },
+                    hash: { ok: true, value: 333 },
+                    count: { ok: true, value: 7 },
+                    landmass: { ok: true, value: 255 },
+                    validForAge: { ok: true, value: true },
+                    requiredForAge: { ok: true, value: false },
+                    ignoringWeightForRiverPlacement: { ok: true, value: false },
+                  },
+                ],
+                cells: [
+                  {
+                    location: { x: 9, y: 9, index: { ok: true, value: 765 } },
+                    resourceTypes: [3],
+                    omittedResourceTypes: 1,
+                    resources: {
+                      "3": {
+                        canHaveResource: {
+                          strict: { ok: true, value: false },
+                          ignoreWeight: { ok: true, value: true },
+                        },
+                        resourceLandmassAtCell: { ok: true, value: 255 },
+                        bestMapResourceCutHashes: { ok: true, value: [333, 444] },
+                        bestMapResourceCuts: {
+                          ok: true,
+                          value: [
+                            { hash: 333, resourceType: 3, resourceTypeName: "RESOURCE_CLAY" },
+                            { hash: 444, resourceType: 12, resourceTypeName: "RESOURCE_RICE" },
+                          ],
+                        },
+                      },
                     },
                   },
                 ],

--- a/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
+++ b/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
@@ -6,10 +6,12 @@ import { dirname, resolve } from "node:path";
 import {
   getCiv7MapGrid,
   getCiv7MapSummary,
+  getCiv7ResourceBuilderDiagnostics,
   getCiv7ResourcePlacementFeasibility,
   type Civ7MapGridResult,
   type Civ7PlotSnapshotField,
   type Civ7MapSummaryResult,
+  type Civ7ResourceBuilderDiagnosticsResult,
   type Civ7ResourcePlacementFeasibilityResult,
   type Civ7RuntimeProbe,
 } from "../../packages/civ7-direct-control/src/index.ts";
@@ -194,6 +196,15 @@ async function main(): Promise<number> {
       { host: args.host, port: args.port, timeoutMs: args.timeoutMs }
     ),
   ]);
+  const ignoreWeightProof = summarizeFeasibilityProof(proof, ignoreWeight);
+  const focusedCells = cellsForResourceBuilderDiagnostics(ignoreWeightProof.rows);
+  const resourceBuilderDiagnostics =
+    focusedCells.length > 0
+      ? await getCiv7ResourceBuilderDiagnostics(
+          { cells: focusedCells, maxCells: args.maxCells },
+          { host: args.host, port: args.port, timeoutMs: args.timeoutMs }
+        )
+      : null;
 
   const outputWithoutHash = {
     ok: true,
@@ -203,8 +214,10 @@ async function main(): Promise<number> {
     runtimeIdentity,
     rowCount: deltaRows.length,
     livePlotContext: summarizeLivePlotContext(livePlotContext),
+    resourceBuilderDiagnostics:
+      resourceBuilderDiagnostics === null ? null : summarizeResourceBuilderDiagnostics(resourceBuilderDiagnostics),
     strict: summarizeFeasibilityProof(proof, strict),
-    ignoreWeight: summarizeFeasibilityProof(proof, ignoreWeight),
+    ignoreWeight: ignoreWeightProof,
   };
   const output = {
     ...outputWithoutHash,
@@ -360,6 +373,32 @@ function summarizeLivePlotContext(readback: Civ7MapGridResult) {
       facts: plot.facts,
     })),
   };
+}
+
+function summarizeResourceBuilderDiagnostics(readback: Civ7ResourceBuilderDiagnosticsResult) {
+  return {
+    readback: {
+      host: readback.host,
+      port: readback.port,
+      state: readback.state,
+      cellCount: readback.cellCount,
+      omittedCells: readback.omittedCells,
+    },
+    resources: readback.resources,
+    cells: readback.cells,
+  };
+}
+
+function cellsForResourceBuilderDiagnostics(
+  rows: ReadonlyArray<ResourceDeltaFeasibilityContext>
+): ReadonlyArray<{ x: number; y: number; resourceTypes: ReadonlyArray<number> }> {
+  return rows
+    .filter((row) => row.feasibilityClass === "local-overaccepted-live-empty" && row.localResource.value !== null)
+    .map((row) => ({
+      x: row.x,
+      y: row.y,
+      resourceTypes: [row.localResource.value as number],
+    }));
 }
 
 function feasibilityValue(


### PR DESCRIPTION
Adds a bounded `getCiv7ResourceBuilderDiagnostics` read wrapper to `@civ7/direct-control` that probes `ResourceBuilder.canHaveResource`, `getBestMapResourceCuts`, `getResourceCounts`, and related age/landmass/weight APIs for a focused set of cells and resource types. The wrapper follows the same cell/type bounding and validation pattern as the existing feasibility wrapper.

The `verify-resource-delta-feasibility` script is extended to call the new wrapper for the `local-overaccepted-live-empty` rows after the `ignoreWeight` feasibility pass, and to include the results in the output artifact. The regenerated artifact identifies that Civ's cut lists exclude the local resource for 6 of the 9 focused rows, while the remaining 3 rows have the local resource present in cut lists but still fail `canHaveResource`. All probed resource types are age-valid, counts are populated, and the landmass probe returns 255 for each type.

The delta-classification ledger is updated with a new `ResourceBuilder cut/count diagnostics` column for the focused rows, recording per-row cut inclusion/exclusion, count, and required status. The narrative conclusion is revised to split the 6 cut-excluded rows from the 3 cut-included-but-rejected rows as the next source-authority determination step, replacing the prior open question about hidden `canHaveResource` constraints. Task 2.11 is marked complete.