### PR TITLE
feat(swooper-resource-legality): add ResourceBuilder subclassification for focused local-overaccepted rows

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -28,8 +28,10 @@
   local-overaccepted rows.
 - [x] 2.11 Add bounded ResourceBuilder cut/count diagnostics for the focused
   local-overaccepted rows.
-- [ ] 2.12 Repair remaining proven package or MapGen owners.
-- [ ] 2.13 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.12 Add structured ResourceBuilder subclassification for the focused
+  local-overaccepted rows.
+- [ ] 2.13 Repair remaining proven package or MapGen owners.
+- [ ] 2.14 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -345,8 +345,8 @@ the artifact before row-level feasibility evidence is accepted.
 
 Artifact:
 `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-(`sha256:2d8a85cee626ce561ffa0d735ba5b00670ebc6fbda23da2aaddb651d78af4f15`,
-`proofHash:dd2d9868ad7a86f0091a188feed055c40656675301a751bfeb54d0bf3ffaa1a7`).
+(`sha256:3ed111634243de08bb54f112ab1fb320ec020d65b707a1a9896de7521215e9ad`,
+`proofHash:49e67bfb29691ccc56a37531a7898fcb235ca17c089fe154be209c206c95f921`).
 
 Source proof:
 `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`.
@@ -390,21 +390,29 @@ with local legal plot counts between `66` and `554`. ResourceBuilder
 diagnostics are read through
 `getCiv7ResourceBuilderDiagnostics` in the runtime-bound full artifact:
 sha256
-`0106c8aefdd05083159b57e93d2d8f463bfb3c59ee5cb223b7b36d7be381528b`,
+`3ed111634243de08bb54f112ab1fb320ec020d65b707a1a9896de7521215e9ad`,
 proofHash
-`5fb8111e4967bb45f50893adb95d122ca38a2ad5ddb4c8926d2ce2e1f605b7d1`.
+`49e67bfb29691ccc56a37531a7898fcb235ca17c089fe154be209c206c95f921`.
+The source assignment-evidence artifact has sha256
+`ff4aec0701cbeeb031737b68d93a0a48e9168313ef983cc30a3df91cff6f08ab`
+and proofHash
+`e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`.
+The artifact now includes a `resourceBuilderSubclassification` block with `6`
+`scarce-floor-cut-excluded` rows and `3`
+`scarce-floor-cut-included-rejected` rows. This split is diagnostic context,
+not repair authority.
 
-| Coordinate | Plot | Local resource | Planned preferred | Assignment order context | Surface | Official/static policy | Nearest local/live resource distance | Live runtime context | Civ loose feasibility | ResourceBuilder cut/count diagnostics |
-|---|---:|---|---|---|---|---|---|---|---|---|
-| `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `23`; count before `2/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `6` | `elev416 rain185 fert2 area131073 region65536 landmass131073` | false | cut excludes local; count `8`; required false |
-| `(31,4)` | `455` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `21`; count before `0/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `5` | `elev238 rain191 fert2 area589832 region524295 landmass589832` | false | cut excludes local; count `8`; required false |
-| `(56,6)` | `692` | `RESOURCE_GYPSUM` | empty | `scarce-floor`; order `74`; count before `4/7`; legal plots `324`; no rebalance | `TERRAIN_HILL` / `BIOME_TUNDRA` / empty | row match; no flags blocking | `4` / `4` | `elev523 rain197 fert0 area1048591 region720906 landmass196610` | false | cut includes local but `canHaveResource` false; count `8`; required false |
-| `(16,12)` | `1288` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | `scarce-floor`; order `90`; count before `6/7`; legal plots `328`; no rebalance | `TERRAIN_HILL` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `2` / `5` | `elev208 rain193 fert0 area1835035 region1310739 landmass1179665` | false | cut excludes local; count `8`; required true |
-| `(12,19)` | `2026` | `RESOURCE_JADE` | `RESOURCE_SILK` | `scarce-floor`; order `139`; count before `6/7`; legal plots `525`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `4` / `2` | `elev214 rain194 fert1 area3538997 region2359331 landmass1638424` | false | cut excludes local; count `7`; required true |
-| `(9,21)` | `2235` | `RESOURCE_HORSES` | `RESOURCE_COWRIE` | `scarce-floor`; order `152`; count before `5/7`; legal plots `554`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / empty | row match; no flags blocking | `4` / `6` | `elev453 rain169 fert1 area3670071 region2555942 landmass1703961` | false | cut excludes local; count `7`; required true |
-| `(72,35)` | `3782` | `RESOURCE_RICE` | empty | `scarce-floor`; order `14`; count before `0/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `4` / `4` | `elev192 rain184 fert2 area4522052 region3670071 landmass2424868` | false | cut includes local but `canHaveResource` false; count `8`; required false |
-| `(86,38)` | `4114` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `24`; count before `3/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `5` / `5` | `elev232 rain176 fert2 area4915274 region4128830 landmass2752553` | false | cut includes local but `canHaveResource` false; count `8`; required false |
-| `(67,51)` | `5473` | `RESOURCE_KAOLIN` | `RESOURCE_SILVER` | `scarce-floor`; order `8`; count before `1/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / `FEATURE_MARSH` | row match; no flags blocking | `8` / `6` | `elev427 rain172 fert2 area5963866 region5898329 landmass3538997` | false | cut excludes local; count `8`; required true |
+| Coordinate | Plot | Local resource | Planned preferred | Assignment order context | Surface | Official/static policy | Nearest local/live resource distance | Live runtime context | Civ loose feasibility | ResourceBuilder cut/count diagnostics | Subclassification |
+|---|---:|---|---|---|---|---|---|---|---|---|---|
+| `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `23`; count before `2/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `6` | `elev416 rain185 fert2 area131073 region65536 landmass131073` | false | cut excludes local; count `8`; required false | `scarce-floor-cut-excluded` |
+| `(31,4)` | `455` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `21`; count before `0/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `5` | `elev238 rain191 fert2 area589832 region524295 landmass589832` | false | cut excludes local; count `8`; required false | `scarce-floor-cut-excluded` |
+| `(56,6)` | `692` | `RESOURCE_GYPSUM` | empty | `scarce-floor`; order `74`; count before `4/7`; legal plots `324`; no rebalance | `TERRAIN_HILL` / `BIOME_TUNDRA` / empty | row match; no flags blocking | `4` / `4` | `elev523 rain197 fert0 area1048591 region720906 landmass196610` | false | cut includes local but `canHaveResource` false; count `8`; required false | `scarce-floor-cut-included-rejected` |
+| `(16,12)` | `1288` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | `scarce-floor`; order `90`; count before `6/7`; legal plots `328`; no rebalance | `TERRAIN_HILL` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `2` / `5` | `elev208 rain193 fert0 area1835035 region1310739 landmass1179665` | false | cut excludes local; count `8`; required true | `scarce-floor-cut-excluded` |
+| `(12,19)` | `2026` | `RESOURCE_JADE` | `RESOURCE_SILK` | `scarce-floor`; order `139`; count before `6/7`; legal plots `525`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `4` / `2` | `elev214 rain194 fert1 area3538997 region2359331 landmass1638424` | false | cut excludes local; count `7`; required true | `scarce-floor-cut-excluded` |
+| `(9,21)` | `2235` | `RESOURCE_HORSES` | `RESOURCE_COWRIE` | `scarce-floor`; order `152`; count before `5/7`; legal plots `554`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / empty | row match; no flags blocking | `4` / `6` | `elev453 rain169 fert1 area3670071 region2555942 landmass1703961` | false | cut excludes local; count `7`; required true | `scarce-floor-cut-excluded` |
+| `(72,35)` | `3782` | `RESOURCE_RICE` | empty | `scarce-floor`; order `14`; count before `0/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `4` / `4` | `elev192 rain184 fert2 area4522052 region3670071 landmass2424868` | false | cut includes local but `canHaveResource` false; count `8`; required false | `scarce-floor-cut-included-rejected` |
+| `(86,38)` | `4114` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `24`; count before `3/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `5` / `5` | `elev232 rain176 fert2 area4915274 region4128830 landmass2752553` | false | cut includes local but `canHaveResource` false; count `8`; required false | `scarce-floor-cut-included-rejected` |
+| `(67,51)` | `5473` | `RESOURCE_KAOLIN` | `RESOURCE_SILVER` | `scarce-floor`; order `8`; count before `1/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / `FEATURE_MARSH` | row match; no flags blocking | `8` / `6` | `elev427 rain172 fert2 area5963866 region5898329 landmass3538997` | false | cut excludes local; count `8`; required true | `scarce-floor-cut-excluded` |
 
 Individual `substitution-both-infeasible` row:
 
@@ -421,10 +429,10 @@ The single both-infeasible substitution row remains outside that repair class.
 Because the focused rows are not explained by official surface rows,
 adjacent-land flags, authored spacing, owner, water, plot tags, or river state,
 and are not introduced by relaxed spacing or rebalance, the next authority
-check should split the `6` cut-excluded rows from the `3` cut-included but
-still rejected rows and determine whether the owner is repo mock/static policy,
-Civ cut ordering/count/landmass policy, runtime materialization state, or
-evidence insufficiency before changing mock policy.
+check should use the structured `6` cut-excluded / `3` cut-included-but-rejected
+split to determine whether the owner is repo mock/static policy, Civ cut
+ordering/count/landmass policy, runtime materialization state, or evidence
+insufficiency before changing mock policy.
 The assignment-order context proves these rows came from the local scarce-floor
 quota pass, but that is still diagnostic context rather than repair authority.
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,13 +5,14 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-builder-diagnostics-drain`
-  stacked above `codex/swooper-resource-assignment-trace-drain`
+- Branch/Graphite stack: `codex/swooper-resource-builder-classifier-drain`
+  stacked above `codex/swooper-resource-builder-diagnostics-drain`
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
   feasibility plus row/static-policy/live-plot, assignment-order, and
-  ResourceBuilder diagnostic context now narrows the next resource repair class.
+  ResourceBuilder diagnostic/subclassification context now narrows the next
+  resource repair class.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -136,10 +137,10 @@
   blocks if those sources are missing or conflicting. It then reads current
   live map identity through `getCiv7MapSummary` and blocks if width, height,
   plot count, seed, turn, or game hash do not match the saved proof identity.
-  The current assignment-order artifact is
+  The current full feasibility artifact is
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-  (`sha256:2d8a85cee626ce561ffa0d735ba5b00670ebc6fbda23da2aaddb651d78af4f15`,
-  `proofHash:dd2d9868ad7a86f0091a188feed055c40656675301a751bfeb54d0bf3ffaa1a7`).
+  (`sha256:3ed111634243de08bb54f112ab1fb320ec020d65b707a1a9896de7521215e9ad`,
+  `proofHash:49e67bfb29691ccc56a37531a7898fcb235ca17c089fe154be209c206c95f921`).
   Request identity resolves to `studio-run-in-game-mq20rbzr-1fhc`; runtime
   identity is matched to the saved proof at `106x66`, `6996` plots, seed
   `138503614`, turn `1`, and game hash `0`. The artifact preserves the
@@ -179,6 +180,28 @@
   removes relaxed-spacing and rebalance as explanations for the focused class,
   but it still does not identify the hidden Civ feasibility constraint that
   rejected those cells.
+- ResourceBuilder diagnostics progress:
+  `@civ7/direct-control` now exposes a bounded
+  `getCiv7ResourceBuilderDiagnostics` read wrapper for the focused rows. The
+  current regenerated runtime-bound artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
+  has sha256
+  `3ed111634243de08bb54f112ab1fb320ec020d65b707a1a9896de7521215e9ad`
+  and proofHash
+  `49e67bfb29691ccc56a37531a7898fcb235ca17c089fe154be209c206c95f921`.
+  It keeps the exact-authored source proof hash
+  `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`
+  and reads ResourceBuilder diagnostics for the `9` focused cells with `0`
+  omitted cells. All `9` remain false under both strict and
+  `ignoreWeight:true` `canHaveResource`. Civ `getBestMapResourceCuts` excludes
+  the local resource for `6` rows and includes it for `3` rows that are still
+  rejected, so cut-list exclusion explains part but not all of the class. All
+  probed resource types are age-valid, counts are present, and the
+  ResourceBuilder landmass probe returns `255` for each local resource type.
+  This narrows the next source-authority step to hidden ResourceBuilder cut
+  ordering/landmass/count or materialization-state constraints; it still does
+  not authorize mock/static-policy repair, resource tuning, parity closure, or
+  product acceptance.
 - Assignment-order context progress:
   the typed local `resourcePlacementOutcomes.assignmentTrace` now records
   assignment order, per-type count before assignment, legal local plot count for
@@ -192,9 +215,9 @@
   The regenerated resource feasibility artifact
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
   has sha256
-  `2d8a85cee626ce561ffa0d735ba5b00670ebc6fbda23da2aaddb651d78af4f15`
+  `3ed111634243de08bb54f112ab1fb320ec020d65b707a1a9896de7521215e9ad`
   and proofHash
-  `dd2d9868ad7a86f0091a188feed055c40656675301a751bfeb54d0bf3ffaa1a7`.
+  `49e67bfb29691ccc56a37531a7898fcb235ca17c089fe154be209c206c95f921`.
   The `9` focused rows are all scarce-floor assignments made before their local
   resource type reached the floor target (`targetMinPerType:7`), with local
   legal plot counts between `66` and `554`. This proves the local reason those
@@ -203,28 +226,14 @@
   belongs in the local scarce-floor candidate/cut ordering policy, in an
   adapter/mock approximation of hidden Civ constraints, or in an accepted
   materialization-state disposition.
-- ResourceBuilder diagnostics progress:
-  `@civ7/direct-control` now exposes a bounded
-  `getCiv7ResourceBuilderDiagnostics` read wrapper for the focused rows. The
-  regenerated runtime-bound artifact
-  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-  has sha256
-  `0106c8aefdd05083159b57e93d2d8f463bfb3c59ee5cb223b7b36d7be381528b`
-  and proofHash
-  `5fb8111e4967bb45f50893adb95d122ca38a2ad5ddb4c8926d2ce2e1f605b7d1`.
-  It keeps the same exact-authored source proof hash
-  `43238c33197c3b8d2e06e6209f03101268c4f125dcc33f2e9892c8d2baf7fcab`
-  and reads ResourceBuilder diagnostics for the `9` focused cells with `0`
-  omitted cells. All `9` remain false under both strict and
-  `ignoreWeight:true` `canHaveResource`. Civ `getBestMapResourceCuts` excludes
-  the local resource for `6` rows and includes it for `3` rows that are still
-  rejected, so cut-list exclusion explains part but not all of the class. All
-  probed resource types are age-valid, counts are present, and the
-  ResourceBuilder landmass probe returns `255` for each local resource type.
-  This narrows the next source-authority step to hidden ResourceBuilder cut
-  ordering/landmass/count or materialization-state constraints; it still does
-  not authorize mock/static-policy repair, resource tuning, parity closure, or
-  product acceptance.
+- ResourceBuilder subclassification progress:
+  the full feasibility artifact now carries a structured
+  `resourceBuilderSubclassification` block for the `9` focused rows. It records
+  `6` `scarce-floor-cut-excluded` rows and `3`
+  `scarce-floor-cut-included-rejected` rows, preserving assignment order,
+  per-type floor progress, local legal plot count, cut membership, and
+  `canHaveResource` results per row. This makes the next owner decision
+  auditable without treating either subclass as repair authority.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -236,14 +245,15 @@
   feasible live-only/local-empty/substitution classes plus hidden runtime
   feasibility classification for the `9` local-assigned/live-empty rows where
   Civ rejects the local value with `ignoreWeight:true`. For those `9` rows,
-  assignment trace rules out relaxed spacing and rebalance, assignment-order
-  context shows every focused local value came from the scarce-floor quota pass,
-  and ResourceBuilder diagnostics show `6` local resources absent from Civ cut
-  lists while `3` local resources are present in cut lists but still rejected.
-  No resource tuning, static-policy repair, or assignment-order repair is
-  authorized until those sub-classes are assigned to a concrete source owner.
-  The single substitution row where both probed values are infeasible remains
-  an individual evidence row with no repair authority until row-level context
-  assigns source ownership.
+  assignment trace rules out relaxed spacing and rebalance, and ResourceBuilder
+  diagnostics and the structured subclassification show `6` local resources
+  absent from Civ cut lists while `3` local resources are present in cut lists
+  but still rejected. Assignment-order context shows every focused local value
+  came from the scarce-floor quota pass, not strict/relaxed fill or rebalance.
+  No resource tuning, static-policy repair, scarce-floor repair, or
+  assignment-order repair is authorized until those subclasses are assigned to a
+  concrete source owner. The single substitution row where both probed values
+  are infeasible remains an individual evidence row with no repair authority
+  until row-level context assigns source ownership.
 - Stop condition: source authority is not known for any row outside the
   classified adjacent-land resource class.

--- a/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
+++ b/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
@@ -205,6 +205,12 @@ async function main(): Promise<number> {
           { host: args.host, port: args.port, timeoutMs: args.timeoutMs }
         )
       : null;
+  const resourceBuilderDiagnosticsSummary =
+    resourceBuilderDiagnostics === null ? null : summarizeResourceBuilderDiagnostics(resourceBuilderDiagnostics);
+  const resourceBuilderSubclassification =
+    resourceBuilderDiagnosticsSummary === null
+      ? null
+      : summarizeResourceBuilderSubclassification(ignoreWeightProof.rows, resourceBuilderDiagnosticsSummary);
 
   const outputWithoutHash = {
     ok: true,
@@ -214,8 +220,8 @@ async function main(): Promise<number> {
     runtimeIdentity,
     rowCount: deltaRows.length,
     livePlotContext: summarizeLivePlotContext(livePlotContext),
-    resourceBuilderDiagnostics:
-      resourceBuilderDiagnostics === null ? null : summarizeResourceBuilderDiagnostics(resourceBuilderDiagnostics),
+    resourceBuilderDiagnostics: resourceBuilderDiagnosticsSummary,
+    resourceBuilderSubclassification,
     strict: summarizeFeasibilityProof(proof, strict),
     ignoreWeight: ignoreWeightProof,
   };
@@ -387,6 +393,112 @@ function summarizeResourceBuilderDiagnostics(readback: Civ7ResourceBuilderDiagno
     resources: readback.resources,
     cells: readback.cells,
   };
+}
+
+type ResourceBuilderDiagnosticsSummary = ReturnType<typeof summarizeResourceBuilderDiagnostics>;
+
+function summarizeResourceBuilderSubclassification(
+  rows: ReadonlyArray<ResourceDeltaFeasibilityContext>,
+  diagnostics: ResourceBuilderDiagnosticsSummary
+) {
+  const focusedRows = rows.filter(
+    (row) => row.feasibilityClass === "local-overaccepted-live-empty" && row.localResource.value !== null
+  );
+  const cellsByLocation = new Map(
+    diagnostics.cells.map((cell) => [`${cell.location.x},${cell.location.y}`, cell] as const)
+  );
+  const resourcesByType = new Map(diagnostics.resources.map((resource) => [resource.resourceType, resource] as const));
+  const classifiedRows = focusedRows.map((row) => {
+    const localResourceType = row.localResource.value as number;
+    const cell = cellsByLocation.get(`${row.x},${row.y}`);
+    const cellResource = cell?.resources[String(localResourceType)];
+    const resource = resourcesByType.get(localResourceType);
+    const cutResourceTypes = cutResourceTypeNames(cellResource?.bestMapResourceCuts);
+    const cutIncludesLocal = cutIncludesResource(cellResource?.bestMapResourceCuts, localResourceType);
+    const strict = probeBoolean(cellResource?.canHaveResource.strict);
+    const ignoreWeight = probeBoolean(cellResource?.canHaveResource.ignoreWeight);
+    const assignmentPhase = row.assignmentTrace?.assignmentPhase ?? null;
+    const classification = classifyResourceBuilderFocusedRow({
+      assignmentPhase,
+      cutIncludesLocal,
+      ignoreWeight,
+      hasCellDiagnostics: cellResource !== undefined,
+    });
+
+    return {
+      x: row.x,
+      y: row.y,
+      plotIndex: row.plotIndex,
+      localResource: row.localResource,
+      plannedPreferredResourceSymbol: row.plannedPreferredResourceSymbol,
+      feasibilityClass: row.feasibilityClass,
+      assignmentTrace: row.assignmentTrace,
+      resourceBuilder: {
+        canHaveResource: {
+          strict,
+          ignoreWeight,
+        },
+        cutIncludesLocal,
+        cutResourceTypes,
+        count: probeNumberLike(resource?.count),
+        landmass: probeNumberLike(resource?.landmass),
+        resourceLandmassAtCell: probeNumberLike(cellResource?.resourceLandmassAtCell),
+        validForAge: probeBoolean(resource?.validForAge),
+        requiredForAge: probeBoolean(resource?.requiredForAge),
+        ignoringWeightForRiverPlacement: probeBoolean(resource?.ignoringWeightForRiverPlacement),
+      },
+      subclassification: classification,
+    };
+  });
+
+  return {
+    readback: diagnostics.readback,
+    focusedRowCount: focusedRows.length,
+    classCounts: countBy(classifiedRows, (row) => row.subclassification),
+    rows: classifiedRows,
+  };
+}
+
+function classifyResourceBuilderFocusedRow(input: {
+  assignmentPhase: string | null;
+  cutIncludesLocal: boolean | null;
+  ignoreWeight: boolean | null;
+  hasCellDiagnostics: boolean;
+}):
+  | "scarce-floor-cut-excluded"
+  | "scarce-floor-cut-included-rejected"
+  | "scarce-floor-resource-builder-evidence-missing"
+  | "local-overaccepted-non-scarce-floor" {
+  if (!input.hasCellDiagnostics) return "scarce-floor-resource-builder-evidence-missing";
+  if (input.assignmentPhase !== "scarce-floor") return "local-overaccepted-non-scarce-floor";
+  if (input.cutIncludesLocal === false) return "scarce-floor-cut-excluded";
+  if (input.cutIncludesLocal === true && input.ignoreWeight === false) return "scarce-floor-cut-included-rejected";
+  return "scarce-floor-resource-builder-evidence-missing";
+}
+
+function cutIncludesResource(
+  probe: Civ7RuntimeProbe<ReadonlyArray<{ resourceType?: number }>> | undefined,
+  resourceType: number
+): boolean | null {
+  if (!probe?.ok || !Array.isArray(probe.value)) return null;
+  return probe.value.some((resource) => resource.resourceType === resourceType);
+}
+
+function cutResourceTypeNames(
+  probe: Civ7RuntimeProbe<ReadonlyArray<{ resourceTypeName?: string; resourceType?: number }>> | undefined
+): ReadonlyArray<string> | null {
+  if (!probe?.ok || !Array.isArray(probe.value)) return null;
+  return probe.value.map((resource) => resource.resourceTypeName ?? String(resource.resourceType ?? "unknown"));
+}
+
+function probeBoolean(probe: Civ7RuntimeProbe<boolean> | undefined): boolean | null {
+  if (!probe?.ok || typeof probe.value !== "boolean") return null;
+  return probe.value;
+}
+
+function probeNumberLike(probe: Civ7RuntimeProbe<number> | undefined): number | null {
+  if (!probe?.ok || typeof probe.value !== "number" || !Number.isFinite(probe.value)) return null;
+  return probe.value;
 }
 
 function cellsForResourceBuilderDiagnostics(


### PR DESCRIPTION
Adds a structured `resourceBuilderSubclassification` block to the full feasibility artifact, splitting the 9 focused `local-overaccepted-live-empty` rows into `scarce-floor-cut-excluded` (6 rows) and `scarce-floor-cut-included-rejected` (3 rows) based on whether Civ's `getBestMapResourceCuts` includes the local resource and whether `canHaveResource` with `ignoreWeight:true` returns false. The classification logic, cut membership helpers, and probe utilities are implemented in `verify-resource-delta-feasibility.ts`, and the subclassification output is written alongside the existing `resourceBuilderDiagnostics` field in the artifact.

The delta-classification ledger and phase record are updated to reflect the new artifact hashes, record the subclassification counts and their diagnostic-only status, and advance task 2.12 to complete while renumbering the remaining repair tasks. The subclassification makes the next owner decision auditable but does not authorize mock/static-policy repair, resource tuning, or parity closure.