### PR TITLE
docs(earthlike-resource-legality): add official ResourceBuilder row policy context for focused local-overaccepted rows

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -30,8 +30,10 @@
   local-overaccepted rows.
 - [x] 2.12 Add structured ResourceBuilder subclassification for the focused
   local-overaccepted rows.
-- [ ] 2.13 Repair remaining proven package or MapGen owners.
-- [ ] 2.14 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.13 Add official ResourceBuilder row policy context for the focused
+  local-overaccepted rows.
+- [ ] 2.14 Repair remaining proven package or MapGen owners.
+- [ ] 2.15 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -345,8 +345,8 @@ the artifact before row-level feasibility evidence is accepted.
 
 Artifact:
 `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-(`sha256:3ed111634243de08bb54f112ab1fb320ec020d65b707a1a9896de7521215e9ad`,
-`proofHash:49e67bfb29691ccc56a37531a7898fcb235ca17c089fe154be209c206c95f921`).
+(`sha256:30e8cf009798e974f733f5bec25fe49baf0bfdd887af10348eca92de88ba233c`,
+`proofHash:e01f679e01db7ce2639b01578cc3b060d5c4f2b5eac8269fcdb4db7564ec44c0`).
 
 Source proof:
 `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`.
@@ -390,9 +390,9 @@ with local legal plot counts between `66` and `554`. ResourceBuilder
 diagnostics are read through
 `getCiv7ResourceBuilderDiagnostics` in the runtime-bound full artifact:
 sha256
-`3ed111634243de08bb54f112ab1fb320ec020d65b707a1a9896de7521215e9ad`,
+`30e8cf009798e974f733f5bec25fe49baf0bfdd887af10348eca92de88ba233c`,
 proofHash
-`49e67bfb29691ccc56a37531a7898fcb235ca17c089fe154be209c206c95f921`.
+`e01f679e01db7ce2639b01578cc3b060d5c4f2b5eac8269fcdb4db7564ec44c0`.
 The source assignment-evidence artifact has sha256
 `ff4aec0701cbeeb031737b68d93a0a48e9168313ef983cc30a3df91cff6f08ab`
 and proofHash
@@ -400,19 +400,23 @@ and proofHash
 The artifact now includes a `resourceBuilderSubclassification` block with `6`
 `scarce-floor-cut-excluded` rows and `3`
 `scarce-floor-cut-included-rejected` rows. This split is diagnostic context,
-not repair authority.
+not repair authority. The same block now carries official ResourceBuilder row
+policy. All `9` focused rows have local `targetMinPerType:7` while official
+`MinimumPerHemisphere` is `3`, so the local floor exceeds the official minimum
+by `4` for each row. This is source-authority context only because the
+ResourceBuilder probes are current post-materialization readback.
 
-| Coordinate | Plot | Local resource | Planned preferred | Assignment order context | Surface | Official/static policy | Nearest local/live resource distance | Live runtime context | Civ loose feasibility | ResourceBuilder cut/count diagnostics | Subclassification |
+| Coordinate | Plot | Local resource | Planned preferred | Assignment order context | Surface | Official/static policy | Nearest local/live resource distance | Live runtime context | Civ loose feasibility | ResourceBuilder policy/cut/count diagnostics | Subclassification |
 |---|---:|---|---|---|---|---|---|---|---|---|---|
-| `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `23`; count before `2/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `6` | `elev416 rain185 fert2 area131073 region65536 landmass131073` | false | cut excludes local; count `8`; required false | `scarce-floor-cut-excluded` |
-| `(31,4)` | `455` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `21`; count before `0/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `5` | `elev238 rain191 fert2 area589832 region524295 landmass589832` | false | cut excludes local; count `8`; required false | `scarce-floor-cut-excluded` |
-| `(56,6)` | `692` | `RESOURCE_GYPSUM` | empty | `scarce-floor`; order `74`; count before `4/7`; legal plots `324`; no rebalance | `TERRAIN_HILL` / `BIOME_TUNDRA` / empty | row match; no flags blocking | `4` / `4` | `elev523 rain197 fert0 area1048591 region720906 landmass196610` | false | cut includes local but `canHaveResource` false; count `8`; required false | `scarce-floor-cut-included-rejected` |
-| `(16,12)` | `1288` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | `scarce-floor`; order `90`; count before `6/7`; legal plots `328`; no rebalance | `TERRAIN_HILL` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `2` / `5` | `elev208 rain193 fert0 area1835035 region1310739 landmass1179665` | false | cut excludes local; count `8`; required true | `scarce-floor-cut-excluded` |
-| `(12,19)` | `2026` | `RESOURCE_JADE` | `RESOURCE_SILK` | `scarce-floor`; order `139`; count before `6/7`; legal plots `525`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `4` / `2` | `elev214 rain194 fert1 area3538997 region2359331 landmass1638424` | false | cut excludes local; count `7`; required true | `scarce-floor-cut-excluded` |
-| `(9,21)` | `2235` | `RESOURCE_HORSES` | `RESOURCE_COWRIE` | `scarce-floor`; order `152`; count before `5/7`; legal plots `554`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / empty | row match; no flags blocking | `4` / `6` | `elev453 rain169 fert1 area3670071 region2555942 landmass1703961` | false | cut excludes local; count `7`; required true | `scarce-floor-cut-excluded` |
-| `(72,35)` | `3782` | `RESOURCE_RICE` | empty | `scarce-floor`; order `14`; count before `0/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `4` / `4` | `elev192 rain184 fert2 area4522052 region3670071 landmass2424868` | false | cut includes local but `canHaveResource` false; count `8`; required false | `scarce-floor-cut-included-rejected` |
-| `(86,38)` | `4114` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `24`; count before `3/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `5` / `5` | `elev232 rain176 fert2 area4915274 region4128830 landmass2752553` | false | cut includes local but `canHaveResource` false; count `8`; required false | `scarce-floor-cut-included-rejected` |
-| `(67,51)` | `5473` | `RESOURCE_KAOLIN` | `RESOURCE_SILVER` | `scarce-floor`; order `8`; count before `1/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / `FEATURE_MARSH` | row match; no flags blocking | `8` / `6` | `elev427 rain172 fert2 area5963866 region5898329 landmass3538997` | false | cut excludes local; count `8`; required true | `scarce-floor-cut-excluded` |
+| `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `23`; count before `2/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `6` | `elev416 rain185 fert2 area131073 region65536 landmass131073` | false | cut excludes local; class `BONUS`; min `3`; target `7`; count `8`; required false | `scarce-floor-cut-excluded` |
+| `(31,4)` | `455` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `21`; count before `0/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `5` | `elev238 rain191 fert2 area589832 region524295 landmass589832` | false | cut excludes local; class `BONUS`; min `3`; target `7`; count `8`; required false | `scarce-floor-cut-excluded` |
+| `(56,6)` | `692` | `RESOURCE_GYPSUM` | empty | `scarce-floor`; order `74`; count before `4/7`; legal plots `324`; no rebalance | `TERRAIN_HILL` / `BIOME_TUNDRA` / empty | row match; no flags blocking | `4` / `4` | `elev523 rain197 fert0 area1048591 region720906 landmass196610` | false | cut includes local but `canHaveResource` false; class `CITY`; min `3`; target `7`; count `8`; required false | `scarce-floor-cut-included-rejected` |
+| `(16,12)` | `1288` | `RESOURCE_WOOL` | `RESOURCE_WOOL` | `scarce-floor`; order `90`; count before `6/7`; legal plots `328`; no rebalance | `TERRAIN_HILL` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `2` / `5` | `elev208 rain193 fert0 area1835035 region1310739 landmass1179665` | false | cut excludes local; class `BONUS`; min `3`; target `7`; count `8`; required true | `scarce-floor-cut-excluded` |
+| `(12,19)` | `2026` | `RESOURCE_JADE` | `RESOURCE_SILK` | `scarce-floor`; order `139`; count before `6/7`; legal plots `525`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / empty | row match; no flags blocking | `4` / `2` | `elev214 rain194 fert1 area3538997 region2359331 landmass1638424` | false | cut excludes local; class `CITY`; min `3`; target `7`; count `7`; required true | `scarce-floor-cut-excluded` |
+| `(9,21)` | `2235` | `RESOURCE_HORSES` | `RESOURCE_COWRIE` | `scarce-floor`; order `152`; count before `5/7`; legal plots `554`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / empty | row match; no flags blocking | `4` / `6` | `elev453 rain169 fert1 area3670071 region2555942 landmass1703961` | false | cut excludes local; class `EMPIRE`; min `3`; target `7`; count `7`; required true | `scarce-floor-cut-excluded` |
+| `(72,35)` | `3782` | `RESOURCE_RICE` | empty | `scarce-floor`; order `14`; count before `0/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `4` / `4` | `elev192 rain184 fert2 area4522052 region3670071 landmass2424868` | false | cut includes local but `canHaveResource` false; class `EMPIRE`; min `3`; target `7`; count `8`; required false | `scarce-floor-cut-included-rejected` |
+| `(86,38)` | `4114` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `24`; count before `3/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TROPICAL` / `FEATURE_MANGROVE` | row match; no flags blocking | `5` / `5` | `elev232 rain176 fert2 area4915274 region4128830 landmass2752553` | false | cut includes local but `canHaveResource` false; class `BONUS`; min `3`; target `7`; count `8`; required false | `scarce-floor-cut-included-rejected` |
+| `(67,51)` | `5473` | `RESOURCE_KAOLIN` | `RESOURCE_SILVER` | `scarce-floor`; order `8`; count before `1/7`; legal plots `66`; no rebalance | `TERRAIN_FLAT` / `BIOME_GRASSLAND` / `FEATURE_MARSH` | row match; no flags blocking | `8` / `6` | `elev427 rain172 fert2 area5963866 region5898329 landmass3538997` | false | cut excludes local; class `CITY`; min `3`; target `7`; count `8`; required true | `scarce-floor-cut-excluded` |
 
 Individual `substitution-both-infeasible` row:
 
@@ -430,11 +434,14 @@ Because the focused rows are not explained by official surface rows,
 adjacent-land flags, authored spacing, owner, water, plot tags, or river state,
 and are not introduced by relaxed spacing or rebalance, the next authority
 check should use the structured `6` cut-excluded / `3` cut-included-but-rejected
-split to determine whether the owner is repo mock/static policy, Civ cut
-ordering/count/landmass policy, runtime materialization state, or evidence
-insufficiency before changing mock policy.
+split plus official row policy to determine whether the owner is repo
+scarce-floor quota policy, Civ cut ordering/count policy, runtime
+materialization state, or evidence insufficiency before changing mock policy.
 The assignment-order context proves these rows came from the local scarce-floor
-quota pass, but that is still diagnostic context rather than repair authority.
+quota pass, and the official policy context proves the local floor exceeds
+official minimum-per-hemisphere by `4` for each row, but that is still
+diagnostic context rather than repair authority because the ResourceBuilder
+readback is post-materialization.
 
 ## Required Next Diagnostics
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,14 +5,14 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-builder-classifier-drain`
-  stacked above `codex/swooper-resource-builder-diagnostics-drain`
+- Branch/Graphite stack: `codex/swooper-resource-builder-policy-context-drain`
+  stacked above `codex/swooper-resource-builder-classifier-drain`
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
   feasibility plus row/static-policy/live-plot, assignment-order, and
-  ResourceBuilder diagnostic/subclassification context now narrows the next
-  resource repair class.
+  ResourceBuilder diagnostic/subclassification/policy context now narrows the
+  next resource repair class.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -139,8 +139,8 @@
   plot count, seed, turn, or game hash do not match the saved proof identity.
   The current full feasibility artifact is
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-  (`sha256:3ed111634243de08bb54f112ab1fb320ec020d65b707a1a9896de7521215e9ad`,
-  `proofHash:49e67bfb29691ccc56a37531a7898fcb235ca17c089fe154be209c206c95f921`).
+  (`sha256:30e8cf009798e974f733f5bec25fe49baf0bfdd887af10348eca92de88ba233c`,
+  `proofHash:e01f679e01db7ce2639b01578cc3b060d5c4f2b5eac8269fcdb4db7564ec44c0`).
   Request identity resolves to `studio-run-in-game-mq20rbzr-1fhc`; runtime
   identity is matched to the saved proof at `106x66`, `6996` plots, seed
   `138503614`, turn `1`, and game hash `0`. The artifact preserves the
@@ -186,9 +186,9 @@
   current regenerated runtime-bound artifact
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
   has sha256
-  `3ed111634243de08bb54f112ab1fb320ec020d65b707a1a9896de7521215e9ad`
+  `30e8cf009798e974f733f5bec25fe49baf0bfdd887af10348eca92de88ba233c`
   and proofHash
-  `49e67bfb29691ccc56a37531a7898fcb235ca17c089fe154be209c206c95f921`.
+  `e01f679e01db7ce2639b01578cc3b060d5c4f2b5eac8269fcdb4db7564ec44c0`.
   It keeps the exact-authored source proof hash
   `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`
   and reads ResourceBuilder diagnostics for the `9` focused cells with `0`
@@ -215,9 +215,9 @@
   The regenerated resource feasibility artifact
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
   has sha256
-  `3ed111634243de08bb54f112ab1fb320ec020d65b707a1a9896de7521215e9ad`
+  `30e8cf009798e974f733f5bec25fe49baf0bfdd887af10348eca92de88ba233c`
   and proofHash
-  `49e67bfb29691ccc56a37531a7898fcb235ca17c089fe154be209c206c95f921`.
+  `e01f679e01db7ce2639b01578cc3b060d5c4f2b5eac8269fcdb4db7564ec44c0`.
   The `9` focused rows are all scarce-floor assignments made before their local
   resource type reached the floor target (`targetMinPerType:7`), with local
   legal plot counts between `66` and `554`. This proves the local reason those
@@ -234,6 +234,17 @@
   per-type floor progress, local legal plot count, cut membership, and
   `canHaveResource` results per row. This makes the next owner decision
   auditable without treating either subclass as repair authority.
+- ResourceBuilder policy context progress:
+  the subclassification now also preserves each focused resource's official
+  ResourceBuilder row policy. All `9` rows have local `targetMinPerType:7`
+  while the official `MinimumPerHemisphere` is `3`, so the local scarce-floor
+  target exceeds the official minimum by `4` for every focused row. The `3`
+  cut-included-but-rejected rows are all non-required resources with current
+  ResourceBuilder count `8`; the `6` cut-excluded rows mix required and
+  non-required resources. This sharpens the owner question toward local
+  scarce-floor quota policy versus post-materialization Civ count/cut state, but
+  the readback still occurs after map materialization and therefore is not, by
+  itself, pre-materialization repair authority.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -248,9 +259,11 @@
   assignment trace rules out relaxed spacing and rebalance, and ResourceBuilder
   diagnostics and the structured subclassification show `6` local resources
   absent from Civ cut lists while `3` local resources are present in cut lists
-  but still rejected. Assignment-order context shows every focused local value
-  came from the scarce-floor quota pass, not strict/relaxed fill or rebalance.
-  No resource tuning, static-policy repair, scarce-floor repair, or
+  but still rejected. Assignment-order and policy context show every focused
+  local value came from the scarce-floor quota pass and that the local floor
+  target exceeds the official minimum-per-hemisphere, but the current
+  ResourceBuilder rejection facts are still post-materialization readback. No
+  resource tuning, static-policy repair, scarce-floor repair, or
   assignment-order repair is authorized until those subclasses are assigned to a
   concrete source owner. The single substitution row where both probed values
   are infeasible remains an individual evidence row with no repair authority

--- a/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
+++ b/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
@@ -418,6 +418,9 @@ function summarizeResourceBuilderSubclassification(
     const strict = probeBoolean(cellResource?.canHaveResource.strict);
     const ignoreWeight = probeBoolean(cellResource?.canHaveResource.ignoreWeight);
     const assignmentPhase = row.assignmentTrace?.assignmentPhase ?? null;
+    const officialPolicy = summarizeResourcePolicy(resource);
+    const targetMinPerType = row.assignmentTrace?.targetMinPerType ?? null;
+    const officialMinimum = officialPolicy.minimumPerHemisphere;
     const classification = classifyResourceBuilderFocusedRow({
       assignmentPhase,
       cutIncludesLocal,
@@ -446,6 +449,15 @@ function summarizeResourceBuilderSubclassification(
         validForAge: probeBoolean(resource?.validForAge),
         requiredForAge: probeBoolean(resource?.requiredForAge),
         ignoringWeightForRiverPlacement: probeBoolean(resource?.ignoringWeightForRiverPlacement),
+        officialPolicy,
+        localScarceFloor: {
+          targetMinPerType,
+          officialMinimumPerHemisphere: officialMinimum,
+          targetExceedsOfficialMinimum:
+            targetMinPerType !== null && officialMinimum !== null ? targetMinPerType > officialMinimum : null,
+          targetMinusOfficialMinimum:
+            targetMinPerType !== null && officialMinimum !== null ? targetMinPerType - officialMinimum : null,
+        },
       },
       subclassification: classification,
     };
@@ -499,6 +511,29 @@ function probeBoolean(probe: Civ7RuntimeProbe<boolean> | undefined): boolean | n
 function probeNumberLike(probe: Civ7RuntimeProbe<number> | undefined): number | null {
   if (!probe?.ok || typeof probe.value !== "number" || !Number.isFinite(probe.value)) return null;
   return probe.value;
+}
+
+function summarizeResourcePolicy(resource: Civ7ResourceBuilderDiagnosticsResult["resources"][number] | undefined) {
+  const row = resource?.row.ok === true && isRecord(resource.row.value) ? resource.row.value : {};
+  return {
+    resourceType: stringValue(row.ResourceType),
+    resourceClassType: stringValue(row.ResourceClassType),
+    weight: numberValue(row.Weight) ?? null,
+    minimumPerHemisphere: numberValue(row.MinimumPerHemisphere) ?? null,
+    adjacentToLand: booleanValue(row.AdjacentToLand),
+    lakeEligible: booleanValue(row.LakeEligible),
+    requiresRiver: booleanValue(row.RequiresRiver),
+    noRiver: booleanValue(row.NoRiver),
+    clumped: booleanValue(row.Clumped),
+    hemisphereUnique: booleanValue(row.HemisphereUnique),
+    staple: booleanValue(row.Staple),
+    requiredForAge: probeBoolean(resource?.requiredForAge),
+    validForAge: probeBoolean(resource?.validForAge),
+  };
+}
+
+function booleanValue(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
 }
 
 function cellsForResourceBuilderDiagnostics(


### PR DESCRIPTION
This PR completes task 2.13 by adding official ResourceBuilder row policy context to the `resourceBuilderSubclassification` block for all 9 focused local-overaccepted rows.

Each focused row now records its official `ResourceClassType`, `MinimumPerHemisphere`, and the delta between the local `targetMinPerType` (7) and the official minimum (3). All 9 rows show the local scarce-floor target exceeds the official minimum-per-hemisphere by 4. The 3 cut-included-but-rejected rows are all non-required resources with a current ResourceBuilder count of 8; the 6 cut-excluded rows mix required and non-required resources.

This policy context sharpens the owner question toward local scarce-floor quota policy versus post-materialization Civ count/cut state, but remains diagnostic context only — the ResourceBuilder readback occurs after map materialization and does not constitute pre-materialization repair authority.

The feasibility artifact has been regenerated with updated sha256 and proofHash values reflecting the new policy fields. Task 2.13 is marked complete and the former 2.13/2.14 tasks are renumbered to 2.14/2.15.