### PR TITLE
docs(resource-legality-repair): add assignment-class summary for local-authored resource delta rows

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -32,8 +32,9 @@
   local-overaccepted rows.
 - [x] 2.13 Add official ResourceBuilder row policy context for the focused
   local-overaccepted rows.
-- [ ] 2.14 Repair remaining proven package or MapGen owners.
-- [ ] 2.15 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.14 Add assignment-class summary for local-authored resource delta rows.
+- [ ] 2.15 Repair remaining proven package or MapGen owners.
+- [ ] 2.16 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -320,7 +320,7 @@ Classification labels:
 |---|---|
 | `live-feasible-no-local-assignment` | Civ says the live resource value is feasible, but local assignment did not place it on that cell; investigate assignment ordering/rebalance before repair. |
 | `local-feasible-live-empty` | Local placed a Civ-feasible resource where live has no resource; investigate assignment ordering/rebalance before repair. |
-| `local-overaccepted-live-empty` | Local placed a resource Civ rejects on that cell under loose feasibility; this is the focused `9`-row mock/static-policy overacceptance investigation class. |
+| `local-overaccepted-live-empty` | Local placed a resource Civ rejects on that cell under loose feasibility; this is the focused `9`-row local-overacceptance investigation class. |
 | `substitution-both-feasible` | Local and live resource values are both Civ-feasible; investigate resource type ordering/fallback selection before repair. |
 | `substitution-both-infeasible` | Preserve as an individual unresolved evidence row; no repair authority exists until row-level context/source authority is classified. |
 
@@ -345,8 +345,8 @@ the artifact before row-level feasibility evidence is accepted.
 
 Artifact:
 `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-(`sha256:30e8cf009798e974f733f5bec25fe49baf0bfdd887af10348eca92de88ba233c`,
-`proofHash:e01f679e01db7ce2639b01578cc3b060d5c4f2b5eac8269fcdb4db7564ec44c0`).
+(`sha256:fe54e81bf3aeb88f8f2831791ef5934ea0c0fcc7eed5313af5a1ea4c4506414d`,
+`proofHash:97fdbff7b48641fa1a18d4cb9c386e1f4e7a18c0f01fb283dded58a9286b3f04`).
 
 Source proof:
 `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`.
@@ -372,7 +372,7 @@ returned `106` plots with `0` omitted and `hiddenInfoPolicy:"not-player-scoped"`
 |---|---:|---|
 | `live-feasible-no-local-assignment` | `37` | Assignment ordering/rebalance pending. |
 | `local-feasible-live-empty` | `28` | Assignment ordering/rebalance pending. |
-| `local-overaccepted-live-empty` | `9` | Focused mock/static-policy overacceptance investigation. |
+| `local-overaccepted-live-empty` | `9` | Focused local-overacceptance investigation; source authority remains unresolved. |
 | `substitution-both-feasible` | `31` | Assignment/type-order divergence pending. |
 | `substitution-both-infeasible` | `1` | Individual unresolved row; no repair authority yet. |
 
@@ -390,9 +390,9 @@ with local legal plot counts between `66` and `554`. ResourceBuilder
 diagnostics are read through
 `getCiv7ResourceBuilderDiagnostics` in the runtime-bound full artifact:
 sha256
-`30e8cf009798e974f733f5bec25fe49baf0bfdd887af10348eca92de88ba233c`,
+`fe54e81bf3aeb88f8f2831791ef5934ea0c0fcc7eed5313af5a1ea4c4506414d`,
 proofHash
-`e01f679e01db7ce2639b01578cc3b060d5c4f2b5eac8269fcdb4db7564ec44c0`.
+`97fdbff7b48641fa1a18d4cb9c386e1f4e7a18c0f01fb283dded58a9286b3f04`.
 The source assignment-evidence artifact has sha256
 `ff4aec0701cbeeb031737b68d93a0a48e9168313ef983cc30a3df91cff6f08ab`
 and proofHash
@@ -405,6 +405,22 @@ policy. All `9` focused rows have local `targetMinPerType:7` while official
 `MinimumPerHemisphere` is `3`, so the local floor exceeds the official minimum
 by `4` for each row. This is source-authority context only because the
 ResourceBuilder probes are current post-materialization readback.
+
+Assignment class summary:
+
+| Local-authored resource delta class | Assignment phase | Target floor | Count | Assignment order span |
+|---|---|---:|---:|---|
+| `local-feasible-live-empty` | `scarce-floor` | `7` | `28` | `97..195` |
+| `local-overaccepted-live-empty` | `scarce-floor` | `7` | `9` | `8..152` |
+| `substitution-both-feasible` | `scarce-floor` | `7` | `26` | `15..231` |
+| `substitution-both-feasible` | `strict-spacing` | `7` | `5` | `239..251` |
+| `substitution-both-infeasible` | `scarce-floor` | `7` | `1` | `26..26` |
+
+Of `69` local-authored resource delta rows, `64` (`92.75%`) came from the
+local `scarce-floor` assignment phase. This broadens the owner question from
+the `9` local-overaccepted rows to a general scarce-floor assignment policy
+divergence across most local-authored resource deltas. It remains diagnostic
+context, not repair authority.
 
 | Coordinate | Plot | Local resource | Planned preferred | Assignment order context | Surface | Official/static policy | Nearest local/live resource distance | Live runtime context | Civ loose feasibility | ResourceBuilder policy/cut/count diagnostics | Subclassification |
 |---|---:|---|---|---|---|---|---|---|---|---|---|
@@ -427,8 +443,10 @@ Individual `substitution-both-infeasible` row:
 Disposition:
 the full artifact supersedes the prior summary-only feasibility evidence for
 row-level inspection. It still does not authorize tuning or parity closure.
-The next code repair, if any, must prove whether the `9` focused rows are a
-repo-owned mock/static-policy gap or accepted engine/materialization behavior.
+The next code repair, if any, must first prove whether the `9` focused rows are
+repo-owned mock/static-policy behavior, runtime materialization/state behavior,
+hidden Civ `ResourceBuilder.canHaveResource` constraints, or evidence
+insufficiency.
 The single both-infeasible substitution row remains outside that repair class.
 Because the focused rows are not explained by official surface rows,
 adjacent-land flags, authored spacing, owner, water, plot tags, or river state,
@@ -442,6 +460,10 @@ quota pass, and the official policy context proves the local floor exceeds
 official minimum-per-hemisphere by `4` for each row, but that is still
 diagnostic context rather than repair authority because the ResourceBuilder
 readback is post-materialization.
+The assignment-class summary further shows scarce-floor accounts for `64/69`
+local-authored resource delta rows, so the next owner decision should evaluate
+scarce-floor policy against Civ cut/count materialization behavior before
+making any resource-placement repair.
 
 ## Required Next Diagnostics
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,14 +5,14 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-builder-policy-context-drain`
-  stacked above `codex/swooper-resource-builder-classifier-drain`
+- Branch/Graphite stack: `codex/swooper-resource-assignment-summary-drain`
+  stacked above `codex/swooper-resource-builder-policy-context-drain`
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
   feasibility plus row/static-policy/live-plot, assignment-order, and
-  ResourceBuilder diagnostic/subclassification/policy context now narrows the
-  next resource repair class.
+  ResourceBuilder diagnostic/subclassification/policy context plus
+  assignment-class summary now narrows the next resource repair class.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -139,8 +139,8 @@
   plot count, seed, turn, or game hash do not match the saved proof identity.
   The current full feasibility artifact is
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-  (`sha256:30e8cf009798e974f733f5bec25fe49baf0bfdd887af10348eca92de88ba233c`,
-  `proofHash:e01f679e01db7ce2639b01578cc3b060d5c4f2b5eac8269fcdb4db7564ec44c0`).
+  (`sha256:fe54e81bf3aeb88f8f2831791ef5934ea0c0fcc7eed5313af5a1ea4c4506414d`,
+  `proofHash:97fdbff7b48641fa1a18d4cb9c386e1f4e7a18c0f01fb283dded58a9286b3f04`).
   Request identity resolves to `studio-run-in-game-mq20rbzr-1fhc`; runtime
   identity is matched to the saved proof at `106x66`, `6996` plots, seed
   `138503614`, turn `1`, and game hash `0`. The artifact preserves the
@@ -186,9 +186,9 @@
   current regenerated runtime-bound artifact
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
   has sha256
-  `30e8cf009798e974f733f5bec25fe49baf0bfdd887af10348eca92de88ba233c`
+  `fe54e81bf3aeb88f8f2831791ef5934ea0c0fcc7eed5313af5a1ea4c4506414d`
   and proofHash
-  `e01f679e01db7ce2639b01578cc3b060d5c4f2b5eac8269fcdb4db7564ec44c0`.
+  `97fdbff7b48641fa1a18d4cb9c386e1f4e7a18c0f01fb283dded58a9286b3f04`.
   It keeps the exact-authored source proof hash
   `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`
   and reads ResourceBuilder diagnostics for the `9` focused cells with `0`
@@ -215,9 +215,9 @@
   The regenerated resource feasibility artifact
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
   has sha256
-  `30e8cf009798e974f733f5bec25fe49baf0bfdd887af10348eca92de88ba233c`
+  `fe54e81bf3aeb88f8f2831791ef5934ea0c0fcc7eed5313af5a1ea4c4506414d`
   and proofHash
-  `e01f679e01db7ce2639b01578cc3b060d5c4f2b5eac8269fcdb4db7564ec44c0`.
+  `97fdbff7b48641fa1a18d4cb9c386e1f4e7a18c0f01fb283dded58a9286b3f04`.
   The `9` focused rows are all scarce-floor assignments made before their local
   resource type reached the floor target (`targetMinPerType:7`), with local
   legal plot counts between `66` and `554`. This proves the local reason those
@@ -245,6 +245,18 @@
   scarce-floor quota policy versus post-materialization Civ count/cut state, but
   the readback still occurs after map materialization and therefore is not, by
   itself, pre-materialization repair authority.
+- Assignment-class summary progress:
+  the full feasibility artifact now also records `assignmentClassSummary` across
+  all local-authored resource delta rows. Of `69` local-authored resource delta
+  rows, `64` (`92.75%`) came from the local `scarce-floor` assignment phase with
+  `targetMinPerType:7`. This includes all `28` local-feasible/live-empty rows,
+  all `9` local-overaccepted/live-empty rows, `26` of `31` both-feasible
+  substitutions, and the single both-infeasible substitution row. The remaining
+  `5` both-feasible substitutions came from `strict-spacing` after their type
+  had already reached the same floor target. This broadens the source-authority
+  question from a 9-row legality anomaly to a scarce-floor assignment policy
+  divergence across most local-authored resource deltas, while still not
+  authorizing a repair without an owner decision.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -261,12 +273,13 @@
   absent from Civ cut lists while `3` local resources are present in cut lists
   but still rejected. Assignment-order and policy context show every focused
   local value came from the scarce-floor quota pass and that the local floor
-  target exceeds the official minimum-per-hemisphere, but the current
-  ResourceBuilder rejection facts are still post-materialization readback. No
-  resource tuning, static-policy repair, scarce-floor repair, or
-  assignment-order repair is authorized until those subclasses are assigned to a
-  concrete source owner. The single substitution row where both probed values
-  are infeasible remains an individual evidence row with no repair authority
-  until row-level context assigns source ownership.
+  target exceeds the official minimum-per-hemisphere. The assignment-class
+  summary also shows scarce-floor accounts for `64/69` local-authored resource
+  delta rows overall. However, the current ResourceBuilder rejection facts are
+  still post-materialization readback. No resource tuning, static-policy repair,
+  scarce-floor repair, or assignment-order repair is authorized until those
+  subclasses are assigned to a concrete source owner. The single substitution
+  row where both probed values are infeasible remains an individual evidence row
+  with no repair authority until row-level context assigns source ownership.
 - Stop condition: source authority is not known for any row outside the
   classified adjacent-land resource class.

--- a/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
+++ b/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
@@ -222,6 +222,7 @@ async function main(): Promise<number> {
     livePlotContext: summarizeLivePlotContext(livePlotContext),
     resourceBuilderDiagnostics: resourceBuilderDiagnosticsSummary,
     resourceBuilderSubclassification,
+    assignmentClassSummary: summarizeAssignmentClasses(ignoreWeightProof.rows),
     strict: summarizeFeasibilityProof(proof, strict),
     ignoreWeight: ignoreWeightProof,
   };
@@ -469,6 +470,95 @@ function summarizeResourceBuilderSubclassification(
     classCounts: countBy(classifiedRows, (row) => row.subclassification),
     rows: classifiedRows,
   };
+}
+
+function summarizeAssignmentClasses(rows: ReadonlyArray<ResourceDeltaFeasibilityContext>) {
+  const locallyAssignedRows = rows.filter((row) => row.assignmentTrace !== null);
+  const classAndPhaseRows = locallyAssignedRows.map((row) => ({
+    feasibilityClass: row.feasibilityClass,
+    evidenceClass: row.evidenceClass,
+    assignmentPhase: row.assignmentTrace?.assignmentPhase ?? "missing",
+    targetMinPerType: row.assignmentTrace?.targetMinPerType ?? null,
+    resourceSymbol: row.localResource.symbol,
+    assignmentOrder: row.assignmentTrace?.assignmentOrder ?? null,
+  }));
+  const scarceFloorRows = classAndPhaseRows.filter((row) => row.assignmentPhase === "scarce-floor");
+  return {
+    localAssignedDeltaRowCount: locallyAssignedRows.length,
+    scarceFloorLocalAssignedDeltaRowCount: scarceFloorRows.length,
+    scarceFloorLocalAssignedDeltaShare:
+      locallyAssignedRows.length > 0 ? scarceFloorRows.length / locallyAssignedRows.length : null,
+    classCounts: countBy(rows, (row) => row.feasibilityClass),
+    classPhaseCounts: countBy(
+      classAndPhaseRows,
+      (row) => `${row.feasibilityClass}|${row.assignmentPhase}|target:${row.targetMinPerType ?? "missing"}`
+    ),
+    classPhaseResources: summarizeClassPhaseResources(classAndPhaseRows),
+  };
+}
+
+function summarizeClassPhaseResources(
+  rows: ReadonlyArray<{
+    feasibilityClass: string;
+    assignmentPhase: string;
+    targetMinPerType: number | null;
+    resourceSymbol: string;
+    assignmentOrder: number | null;
+  }>
+) {
+  const groups = new Map<
+    string,
+    {
+      feasibilityClass: string;
+      assignmentPhase: string;
+      targetMinPerType: number | null;
+      count: number;
+      resources: Set<string>;
+      minAssignmentOrder: number | null;
+      maxAssignmentOrder: number | null;
+    }
+  >();
+  for (const row of rows) {
+    const key = `${row.feasibilityClass}|${row.assignmentPhase}|target:${row.targetMinPerType ?? "missing"}`;
+    let group = groups.get(key);
+    if (!group) {
+      group = {
+        feasibilityClass: row.feasibilityClass,
+        assignmentPhase: row.assignmentPhase,
+        targetMinPerType: row.targetMinPerType,
+        count: 0,
+        resources: new Set<string>(),
+        minAssignmentOrder: null,
+        maxAssignmentOrder: null,
+      };
+      groups.set(key, group);
+    }
+    group.count += 1;
+    group.resources.add(row.resourceSymbol);
+    if (row.assignmentOrder !== null) {
+      group.minAssignmentOrder =
+        group.minAssignmentOrder === null ? row.assignmentOrder : Math.min(group.minAssignmentOrder, row.assignmentOrder);
+      group.maxAssignmentOrder =
+        group.maxAssignmentOrder === null ? row.assignmentOrder : Math.max(group.maxAssignmentOrder, row.assignmentOrder);
+    }
+  }
+  return [...groups.values()]
+    .sort((left, right) => {
+      const classDelta = left.feasibilityClass.localeCompare(right.feasibilityClass);
+      if (classDelta !== 0) return classDelta;
+      const phaseDelta = left.assignmentPhase.localeCompare(right.assignmentPhase);
+      if (phaseDelta !== 0) return phaseDelta;
+      return (left.targetMinPerType ?? -1) - (right.targetMinPerType ?? -1);
+    })
+    .map((group) => ({
+      feasibilityClass: group.feasibilityClass,
+      assignmentPhase: group.assignmentPhase,
+      targetMinPerType: group.targetMinPerType,
+      count: group.count,
+      minAssignmentOrder: group.minAssignmentOrder,
+      maxAssignmentOrder: group.maxAssignmentOrder,
+      resources: [...group.resources].sort((left, right) => left.localeCompare(right)),
+    }));
 }
 
 function classifyResourceBuilderFocusedRow(input: {


### PR DESCRIPTION
Adds an assignment-class summary across all local-authored resource delta rows to the feasibility verification artifact and ledger.

The `verify-resource-delta-feasibility` script now computes `assignmentClassSummary` alongside the existing ResourceBuilder diagnostics. The summary groups locally-assigned delta rows by feasibility class, assignment phase, and `targetMinPerType`, recording per-group row counts, resource symbols, and assignment-order spans. This reveals that `64` of `69` local-authored resource delta rows (`92.75%`) originated from the `scarce-floor` assignment phase, broadening the source-authority question from the 9-row `local-overaccepted-live-empty` anomaly to a general scarce-floor policy divergence across nearly all local-authored resource deltas.

The delta-classification ledger is updated with the resulting table and a revised disposition note directing the next owner decision to evaluate scarce-floor policy against Civ cut/count materialization behavior before authorizing any resource-placement repair. The `local-overaccepted-live-empty` class description is also corrected to remove the earlier "mock/static-policy" framing, replacing it with "local-overacceptance" to reflect that source authority remains unresolved. The full feasibility artifact hashes are updated to match the regenerated artifact. Task 2.14 is marked complete and the remaining tasks renumbered accordingly.