### PR TITLE
feat(swooper-resource-legality): add same-resource position displacement context for local-authored delta rows

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -35,8 +35,10 @@
 - [x] 2.14 Add assignment-class summary for local-authored resource delta rows.
 - [x] 2.15 Add resource distribution count context for local-authored resource
   delta rows.
-- [ ] 2.16 Repair remaining proven package or MapGen owners.
-- [ ] 2.17 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.16 Add same-resource position displacement context for local-authored
+  resource delta rows.
+- [ ] 2.17 Repair remaining proven package or MapGen owners.
+- [ ] 2.18 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -345,8 +345,8 @@ the artifact before row-level feasibility evidence is accepted.
 
 Artifact:
 `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-(`sha256:2bca5814bebfc2c8fafba2dac6401dd064d16bf46962f4a42958a913f3ed68d5`,
-`proofHash:37a2b5378689bb2af04b065be012e15598d020d41f51f8b3d1413eb9f6368875`).
+(`sha256:8770c7f465358a97be9213bbbcbf3ac106efbe34cd9d8745e94cb229176acd55`,
+`proofHash:4bb5f364bcf6e3b76ad89712aaf285ca006a1543f48a5dd318947a6a5e98b597`).
 
 Source proof:
 `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`.
@@ -390,9 +390,9 @@ with local legal plot counts between `66` and `554`. ResourceBuilder
 diagnostics are read through
 `getCiv7ResourceBuilderDiagnostics` in the runtime-bound full artifact:
 sha256
-`2bca5814bebfc2c8fafba2dac6401dd064d16bf46962f4a42958a913f3ed68d5`,
+`8770c7f465358a97be9213bbbcbf3ac106efbe34cd9d8745e94cb229176acd55`,
 proofHash
-`37a2b5378689bb2af04b065be012e15598d020d41f51f8b3d1413eb9f6368875`.
+`4bb5f364bcf6e3b76ad89712aaf285ca006a1543f48a5dd318947a6a5e98b597`.
 The source assignment-evidence artifact has sha256
 `ff4aec0701cbeeb031737b68d93a0a48e9168313ef983cc30a3df91cff6f08ab`
 and proofHash
@@ -454,6 +454,41 @@ authored run. The ResourceBuilder counts remain current post-materialization
 readback; no scarce-floor repair, resource tuning, parity closure, Earthlike
 acceptance, or product-proof claim is authorized from this context.
 
+Same-resource position context:
+
+The full artifact now greedily pairs each local-authored resource delta row to
+the nearest unmatched live delta row carrying the same resource type. This is a
+position classifier over observed local/live final surfaces; it does not prove
+the internal Civ placement order.
+
+| Finding | Count / value | Source-authority implication |
+|---|---:|---|
+| Local-authored resource delta rows | `69` | Same population as the assignment/distribution summaries. |
+| Same-resource live delta matches | `69` | Every local-authored delta resource reappears elsewhere in the live delta set. |
+| Unmatched local-authored resource rows | `0` | Missing resource instances are not supported for these rows. |
+| Match distance min / p50 / p90 / max | `2 / 27 / 46 / 59` | The displacement is global, not a small local neighbor swap. |
+| Matches at distance `11+` | `53` | Most matching live instances are far from the local-authored coordinate. |
+| Match targets: live-only / substitution | `37 / 32` | Same-resource matches land across both live-only and substituted live rows. |
+
+Match class summary:
+
+| Local feasibility class -> matched live feasibility class | Count |
+|---|---:|
+| `local-feasible-live-empty -> live-feasible-no-local-assignment` | `19` |
+| `local-feasible-live-empty -> substitution-both-feasible` | `9` |
+| `local-overaccepted-live-empty -> live-feasible-no-local-assignment` | `3` |
+| `local-overaccepted-live-empty -> substitution-both-feasible` | `5` |
+| `local-overaccepted-live-empty -> substitution-both-infeasible` | `1` |
+| `substitution-both-feasible -> live-feasible-no-local-assignment` | `14` |
+| `substitution-both-feasible -> substitution-both-feasible` | `17` |
+| `substitution-both-infeasible -> live-feasible-no-local-assignment` | `1` |
+
+Disposition: combined with matched per-resource counts, this points away from
+resource density, missing instances, or broad count/quota mismatch and toward
+positional cut/order/materialization behavior. It remains diagnostic context
+only; no resource placement repair or product claim is authorized until source
+ownership is classified.
+
 | Coordinate | Plot | Local resource | Planned preferred | Assignment order context | Surface | Official/static policy | Nearest local/live resource distance | Live runtime context | Civ loose feasibility | ResourceBuilder policy/cut/count diagnostics | Subclassification |
 |---|---:|---|---|---|---|---|---|---|---|---|---|
 | `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `23`; count before `2/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `6` | `elev416 rain185 fert2 area131073 region65536 landmass131073` | false | cut excludes local; class `BONUS`; min `3`; target `7`; count `8`; required false | `scarce-floor-cut-excluded` |
@@ -495,9 +530,10 @@ readback is post-materialization.
 The assignment-class summary further shows scarce-floor accounts for `64/69`
 local-authored resource delta rows, and the distribution context shows local
 assigned counts match current ResourceBuilder counts for all `26` represented
-local resource types. The next owner decision should therefore evaluate
-positional cut/order/materialization behavior before making any
-resource-placement repair.
+local resource types. The same-resource position context then matches all `69`
+local-authored delta resources to same-resource live delta rows, mostly at long
+distance. The next owner decision should therefore evaluate positional
+cut/order/materialization behavior before making any resource-placement repair.
 
 ## Required Next Diagnostics
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,17 +5,17 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-distribution-context-drain`
-  stacked above `codex/swooper-resource-assignment-summary-drain`; this slice
-  carries ResourceBuilder distribution-count context for the represented local
-  resource delta types.
+- Branch/Graphite stack: `codex/swooper-resource-position-context-drain`
+  stacked above `codex/swooper-resource-distribution-context-drain`; this
+  slice carries same-resource displacement context for the remaining resource
+  feasibility rows.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
   feasibility plus row/static-policy/live-plot, assignment-order, and
   ResourceBuilder diagnostic/subclassification/policy context plus
-  assignment-class and distribution-count summaries now narrow the next
-  resource repair class.
+  assignment-class, distribution-count, and same-resource position summaries
+  now narrow the next resource repair class.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -142,8 +142,8 @@
   plot count, seed, turn, or game hash do not match the saved proof identity.
   The current full feasibility artifact is
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-  (`sha256:2bca5814bebfc2c8fafba2dac6401dd064d16bf46962f4a42958a913f3ed68d5`,
-  `proofHash:37a2b5378689bb2af04b065be012e15598d020d41f51f8b3d1413eb9f6368875`).
+  (`sha256:8770c7f465358a97be9213bbbcbf3ac106efbe34cd9d8745e94cb229176acd55`,
+  `proofHash:4bb5f364bcf6e3b76ad89712aaf285ca006a1543f48a5dd318947a6a5e98b597`).
   Request identity resolves to `studio-run-in-game-mq20rbzr-1fhc`; runtime
   identity is matched to the saved proof at `106x66`, `6996` plots, seed
   `138503614`, turn `1`, and game hash `0`. The artifact preserves the
@@ -189,9 +189,9 @@
   current regenerated runtime-bound artifact
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
   has sha256
-  `2bca5814bebfc2c8fafba2dac6401dd064d16bf46962f4a42958a913f3ed68d5`
+  `8770c7f465358a97be9213bbbcbf3ac106efbe34cd9d8745e94cb229176acd55`
   and proofHash
-  `37a2b5378689bb2af04b065be012e15598d020d41f51f8b3d1413eb9f6368875`.
+  `4bb5f364bcf6e3b76ad89712aaf285ca006a1543f48a5dd318947a6a5e98b597`.
   It keeps the exact-authored source proof hash
   `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`
   and reads ResourceBuilder diagnostics for the `9` focused cells with `0`
@@ -218,9 +218,9 @@
   The regenerated resource feasibility artifact
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
   has sha256
-  `2bca5814bebfc2c8fafba2dac6401dd064d16bf46962f4a42958a913f3ed68d5`
+  `8770c7f465358a97be9213bbbcbf3ac106efbe34cd9d8745e94cb229176acd55`
   and proofHash
-  `37a2b5378689bb2af04b065be012e15598d020d41f51f8b3d1413eb9f6368875`.
+  `4bb5f364bcf6e3b76ad89712aaf285ca006a1543f48a5dd318947a6a5e98b597`.
   The `9` focused rows are all scarce-floor assignments made before their local
   resource type reached the floor target (`targetMinPerType:7`), with local
   legal plot counts between `66` and `554`. This proves the local reason those
@@ -268,9 +268,9 @@
   runtime-bound full artifact
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
   has sha256
-  `2bca5814bebfc2c8fafba2dac6401dd064d16bf46962f4a42958a913f3ed68d5`
+  `8770c7f465358a97be9213bbbcbf3ac106efbe34cd9d8745e94cb229176acd55`
   and proofHash
-  `37a2b5378689bb2af04b065be012e15598d020d41f51f8b3d1413eb9f6368875`.
+  `4bb5f364bcf6e3b76ad89712aaf285ca006a1543f48a5dd318947a6a5e98b597`.
   It records `26` local resource types across `69` local-authored delta rows.
   For all `26`, local assigned count equals current ResourceBuilder count
   (`assignedMinusResourceBuilderCount:0`), while `25/26` still have local
@@ -281,6 +281,19 @@
   ResourceBuilder counts remain current post-materialization readback and do
   not authorize scarce-floor, resource tuning, parity closure, Earthlike
   acceptance, or product-proof claims.
+- Resource position context progress:
+  the full artifact now also records a same-resource live-delta match for each
+  local-authored resource delta row. All `69/69` local-authored delta resources
+  have an unmatched live delta row with the same resource type; `0` local rows
+  are unmatched. Distances are broad rather than local swaps: min `2`, p50
+  `27`, p90 `46`, max `59`, with `53/69` matches at distance `11+`. Match
+  targets are `37` live-only/no-local-assignment rows and `32`
+  local-assigned/live-substitution rows. This further weakens missing-resource
+  or broad resource-count explanations and points the next source-authority
+  step at positional cut/order/materialization behavior under the exact-authored
+  run. The matching is a classifier over observed local/live delta rows only;
+  it does not prove Civ placement authorship, authorize scarce-floor or resource
+  tuning repair, close parity, or establish product acceptance.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -301,12 +314,14 @@
   summary also shows scarce-floor accounts for `64/69` local-authored resource
   delta rows overall, while the resource distribution context shows local
   assigned counts match current ResourceBuilder counts for all `26` local
-  resource types represented by those deltas. However, the current
-  ResourceBuilder facts are still post-materialization readback. No resource
-  tuning, static-policy repair, scarce-floor repair, or assignment-order repair
-  is authorized until those subclasses are assigned to a concrete source owner.
-  The single substitution row where both probed values are infeasible remains an
-  individual evidence row with no repair authority until row-level context
-  assigns source ownership.
+  resource types represented by those deltas. The position context now also
+  matches all `69` local-authored delta resources to same-resource live delta
+  rows, mostly at long distance. However, the current ResourceBuilder and
+  position facts are still post-materialization/readback classifiers. No
+  resource tuning, static-policy repair, scarce-floor repair, or
+  assignment-order repair is authorized until those subclasses are assigned to a
+  concrete source owner. The single substitution row where both probed values
+  are infeasible remains an individual evidence row with no repair authority
+  until row-level context assigns source ownership.
 - Stop condition: source authority is not known for any row outside the
   classified adjacent-land resource class.

--- a/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
+++ b/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
@@ -233,6 +233,7 @@ async function main(): Promise<number> {
       ignoreWeightProof.rows,
       resourceBuilderDiagnosticsSummary
     ),
+    resourcePositionContext: summarizeResourcePositionContext(proof, ignoreWeightProof.rows),
     assignmentClassSummary: summarizeAssignmentClasses(ignoreWeightProof.rows),
     strict: summarizeFeasibilityProof(proof, strict),
     ignoreWeight: ignoreWeightProof,
@@ -602,6 +603,152 @@ function summarizeResourceDistributionContext(
         row.comparisons.targetMinPerTypeMinusOfficialMinimum > 0
     ).length,
     rows: resourceRows,
+  };
+}
+
+function summarizeResourcePositionContext(
+  proof: Pick<FinalSurfaceParityProof, "local">,
+  rows: ReadonlyArray<ResourceDeltaFeasibilityContext>
+) {
+  const localAssignedRows = rows.filter(
+    (row) => row.assignmentTrace !== null && row.localResource.value !== null
+  );
+  const liveRowsByResource = new Map<number, ResourceDeltaFeasibilityContext[]>();
+  for (const row of rows) {
+    const resourceType = row.liveResource.value;
+    if (resourceType === null || row.localResource.value === resourceType) continue;
+    const bucket = liveRowsByResource.get(resourceType) ?? [];
+    bucket.push(row);
+    liveRowsByResource.set(resourceType, bucket);
+  }
+
+  const matchedLivePlotIndexes = new Set<number>();
+  const matchedRows = localAssignedRows.map((row) => {
+    const resourceType = row.localResource.value as number;
+    const candidates = (liveRowsByResource.get(resourceType) ?? []).filter(
+      (candidate) => !matchedLivePlotIndexes.has(candidate.plotIndex)
+    );
+    const match = nearestResourceDeltaMatch(row, candidates, proof.local.width);
+    if (match !== null) matchedLivePlotIndexes.add(match.row.plotIndex);
+    return {
+      local: {
+        x: row.x,
+        y: row.y,
+        plotIndex: row.plotIndex,
+        resourceSymbol: row.localResource.symbol,
+        feasibilityClass: row.feasibilityClass,
+        assignmentPhase: row.assignmentTrace?.assignmentPhase ?? null,
+        assignmentOrder: row.assignmentTrace?.assignmentOrder ?? null,
+      },
+      matchedLive:
+        match === null
+          ? null
+          : {
+              x: match.row.x,
+              y: match.row.y,
+              plotIndex: match.row.plotIndex,
+              distance: match.distance,
+              evidenceClass: match.row.evidenceClass,
+              feasibilityClass: match.row.feasibilityClass,
+              localResourceSymbol: match.row.localResource.symbol,
+              liveResourceSymbol: match.row.liveResource.symbol,
+            },
+    };
+  });
+  const unmatchedRows = matchedRows.filter((row) => row.matchedLive === null);
+  const matchedDistances = matchedRows.flatMap((row) =>
+    row.matchedLive === null ? [] : [row.matchedLive.distance]
+  );
+
+  return {
+    evidenceBoundary:
+      "Diagnostic context only: nearest same-resource live delta matching is a positional classifier and does not prove Civ placement authorship or authorize repair without source-owner classification.",
+    localAssignedDeltaRowCount: localAssignedRows.length,
+    matchedSameResourceLiveDeltaRowCount: matchedRows.length - unmatchedRows.length,
+    unmatchedLocalAssignedDeltaRowCount: unmatchedRows.length,
+    distanceSummary: summarizeDistances(matchedDistances),
+    matchClassCounts: countBy(matchedRows, (row) =>
+      row.matchedLive === null
+        ? `${row.local.feasibilityClass}->unmatched`
+        : `${row.local.feasibilityClass}->${row.matchedLive.feasibilityClass}`
+    ),
+    targetEvidenceClassCounts: countBy(
+      matchedRows.filter((row) => row.matchedLive !== null),
+      (row) => row.matchedLive?.evidenceClass ?? "unmatched"
+    ),
+    rows: matchedRows,
+  };
+}
+
+function nearestResourceDeltaMatch(
+  row: ResourceDeltaFeasibilityContext,
+  candidates: ReadonlyArray<ResourceDeltaFeasibilityContext>,
+  width: number
+): { row: ResourceDeltaFeasibilityContext; distance: number } | null {
+  let best: { row: ResourceDeltaFeasibilityContext; distance: number } | null = null;
+  for (const candidate of candidates) {
+    const distance = hexDistanceOddQPeriodicX(row.plotIndex, candidate.plotIndex, width);
+    if (
+      best === null ||
+      distance < best.distance ||
+      (distance === best.distance && candidate.plotIndex < best.row.plotIndex)
+    ) {
+      best = { row: candidate, distance };
+    }
+  }
+  return best;
+}
+
+function hexDistanceOddQPeriodicX(aIndex: number, bIndex: number, width: number): number {
+  const ay = Math.trunc(aIndex / width);
+  const ax = aIndex - ay * width;
+  const by = Math.trunc(bIndex / width);
+  const bx = bIndex - by * width;
+  const wrappedBx = ax + wrapDeltaPeriodic(bx - ax, width);
+  const aCube = oddqToCube(ax, ay);
+  const bCube = oddqToCube(wrappedBx, by);
+  return Math.max(
+    Math.abs(aCube.x - bCube.x),
+    Math.abs(aCube.y - bCube.y),
+    Math.abs(aCube.z - bCube.z)
+  );
+}
+
+function oddqToCube(x: number, y: number): Readonly<{ x: number; y: number; z: number }> {
+  const z = y - (x - (x & 1)) / 2;
+  const xCube = x;
+  const zCube = z;
+  const yCube = -xCube - zCube;
+  return { x: xCube, y: yCube, z: zCube };
+}
+
+function wrapDeltaPeriodic(delta: number, width: number): number {
+  if (width <= 0) return delta;
+  const half = width / 2;
+  let wrapped = ((delta % width) + width) % width;
+  if (wrapped > half) wrapped -= width;
+  return wrapped;
+}
+
+function summarizeDistances(distances: ReadonlyArray<number>) {
+  const sorted = [...distances].sort((left, right) => left - right);
+  const quantile = (fraction: number): number | null => {
+    if (sorted.length === 0) return null;
+    const index = Math.min(sorted.length - 1, Math.max(0, Math.floor((sorted.length - 1) * fraction)));
+    return sorted[index];
+  };
+  return {
+    count: sorted.length,
+    min: sorted[0] ?? null,
+    p50: quantile(0.5),
+    p90: quantile(0.9),
+    max: sorted[sorted.length - 1] ?? null,
+    buckets: {
+      "0-2": sorted.filter((distance) => distance <= 2).length,
+      "3-5": sorted.filter((distance) => distance >= 3 && distance <= 5).length,
+      "6-10": sorted.filter((distance) => distance >= 6 && distance <= 10).length,
+      "11+": sorted.filter((distance) => distance >= 11).length,
+    },
   };
 }
 


### PR DESCRIPTION
Adds same-resource position displacement context to the resource delta feasibility artifact. Each local-authored resource delta row is now greedily paired to the nearest unmatched live delta row carrying the same resource type, using hex distance with periodic X wrapping (`hexDistanceOddQPeriodicX` / `oddqToCube`).

For the current run, all 69/69 local-authored delta resources match a same-resource live delta row, with 0 unmatched. Distances are broad (min 2, p50 27, p90 46, max 59), with 53/69 matches at distance 11+, pointing away from missing-resource or count/quota explanations and toward positional cut/order/materialization behavior.

The artifact records per-row match details (coordinates, distance, feasibility class, evidence class) along with aggregate summaries: match class cross-counts, target evidence class counts, and a distance bucket/quantile breakdown. The artifact hash is updated to reflect the new fields.

Task 2.16 is marked complete and the former 2.16–2.17 renumber to 2.17–2.18. The phase record and delta classification ledger are updated to reflect the new context and disposition.