### PR TITLE
docs(earthlike-resource-legality): add local materialization consistency context and update artifact hashes

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -37,8 +37,9 @@
   delta rows.
 - [x] 2.16 Add same-resource position displacement context for local-authored
   resource delta rows.
-- [ ] 2.17 Repair remaining proven package or MapGen owners.
-- [ ] 2.18 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.17 Add local resource materialization consistency context.
+- [ ] 2.18 Repair remaining proven package or MapGen owners.
+- [ ] 2.19 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -290,19 +290,18 @@ returned false, including resources that the live grid shows as present.
 |---|---:|---|
 | `live-only-no-local-assignment`, live feasible | `37` | Civ says the live value is feasible, but the local assignment algorithm did not assign that cell. This points to assignment ordering/rebalance divergence, not static legality. |
 | `local-assigned-live-empty`, local feasible | `28` | Local assigned a Civ-feasible resource where live has no resource. This also points to assignment ordering/rebalance divergence. |
-| `local-assigned-live-empty`, local infeasible | `9` | Local placement accepted a resource Civ rejects under the loose feasibility probe. This is a focused local-overacceptance investigation class, not repair authority. |
+| `local-assigned-live-empty`, local infeasible | `9` | Local placement accepted a resource Civ rejects under the loose feasibility probe. This is a focused local-overacceptance investigation class only; source authority remains unresolved. |
 | `local-assigned-live-substitution`, both feasible | `31` | Both local and live resource values are Civ-feasible at the tile; this is assignment/type-order divergence, not simple legality. |
 | `local-assigned-live-substitution`, both infeasible | `1` | Preserve as an individual evidence row before repair; neither probed value is feasible under the loose check on the current live map. |
 
 Disposition:
-the feasibility readback narrows but does not close source authority. Most
-remaining rows are now assignment ordering evidence or local-overacceptance
-evidence, not map-policy surface legality. The smaller `9`-row
-local-overacceptance class remains unresolved between repo-owned mock/static
-policy, runtime materialization/state, and hidden Civ
-`ResourceBuilder.canHaveResource` constraints. Current row-level evidence rules
-out official rows/flags, adjacent-land, authored spacing, owner/water/tag/river,
-relaxed spacing, and rebalance as explanations. No repair authority, resource
+the feasibility readback narrows but does not close source authority. The
+`9`-row local-overacceptance class is a focused investigation class, not a
+repair class. Current row-level evidence rules out official rows/flags,
+adjacent-land, authored spacing, owner/water/tag/river, relaxed spacing, and
+rebalance as explanations, while leaving source authority unresolved between
+repo-owned mock/static policy, runtime materialization/state, and hidden Civ
+`ResourceBuilder.canHaveResource` constraints. No repair authority, resource
 density, diversity, terrain, coast, Earthlike tuning, parity closure, or
 product acceptance is authorized.
 
@@ -345,8 +344,8 @@ the artifact before row-level feasibility evidence is accepted.
 
 Artifact:
 `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-(`sha256:8770c7f465358a97be9213bbbcbf3ac106efbe34cd9d8745e94cb229176acd55`,
-`proofHash:4bb5f364bcf6e3b76ad89712aaf285ca006a1543f48a5dd318947a6a5e98b597`).
+(`sha256:4b6534e577c8d337df66ea42fd33a1d3674b8043a73fbc40c481e16c0cd5324e`,
+`proofHash:cf91a10f32f8a53297058e5712039227869744d8f6354a59ce06b3dc7a8ac259`).
 
 Source proof:
 `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`.
@@ -390,9 +389,9 @@ with local legal plot counts between `66` and `554`. ResourceBuilder
 diagnostics are read through
 `getCiv7ResourceBuilderDiagnostics` in the runtime-bound full artifact:
 sha256
-`8770c7f465358a97be9213bbbcbf3ac106efbe34cd9d8745e94cb229176acd55`,
+`4b6534e577c8d337df66ea42fd33a1d3674b8043a73fbc40c481e16c0cd5324e`,
 proofHash
-`4bb5f364bcf6e3b76ad89712aaf285ca006a1543f48a5dd318947a6a5e98b597`.
+`cf91a10f32f8a53297058e5712039227869744d8f6354a59ce06b3dc7a8ac259`.
 The source assignment-evidence artifact has sha256
 `ff4aec0701cbeeb031737b68d93a0a48e9168313ef983cc30a3df91cff6f08ab`
 and proofHash
@@ -489,6 +488,28 @@ positional cut/order/materialization behavior. It remains diagnostic context
 only; no resource placement repair or product claim is authorized until source
 ownership is classified.
 
+Local materialization consistency context:
+
+The full artifact now compares typed local placement outcomes against the local
+final resource surface.
+
+| Finding | Count | Source-authority implication |
+|---|---:|---|
+| Placed local resource outcomes | `252` | Same population as the typed local placement artifact. |
+| Placed outcomes matching local final surface | `252` | Local final resource surface preserves typed placement outcomes. |
+| Placed outcomes mismatching local final surface | `0` | Local post-placement resource drift is not supported. |
+| Local-authored resource delta outcomes | `69` | Same population as the local-authored resource delta summaries. |
+| Local-authored delta outcomes matching local final surface | `69` | Every local-authored delta row still matches the typed local placement outcome. |
+| Local-authored delta outcomes mismatching local final surface | `0` | The local final resource value is not being rewritten after local placement. |
+
+Disposition: this rules out local post-resource-placement drift inside the
+local artifact for the current resource mismatch class. Combined with
+same-resource live displacement and matching per-resource counts, the remaining
+owner question is bounded to live/Civ materialization, live readback timing, or
+missing immediate post-placement live coordinate evidence. It still does not
+authorize product repair, because immediate post-placement live coordinate
+evidence is not yet captured in the exact-authored proof packet.
+
 | Coordinate | Plot | Local resource | Planned preferred | Assignment order context | Surface | Official/static policy | Nearest local/live resource distance | Live runtime context | Civ loose feasibility | ResourceBuilder policy/cut/count diagnostics | Subclassification |
 |---|---:|---|---|---|---|---|---|---|---|---|---|
 | `(34,2)` | `246` | `RESOURCE_CLAY` | empty | `scarce-floor`; order `23`; count before `2/7`; legal plots `88`; no rebalance | `TERRAIN_FLAT` / `BIOME_TUNDRA` / `FEATURE_TUNDRA_BOG` | row match; no flags blocking | `4` / `6` | `elev416 rain185 fert2 area131073 region65536 landmass131073` | false | cut excludes local; class `BONUS`; min `3`; target `7`; count `8`; required false | `scarce-floor-cut-excluded` |
@@ -532,8 +553,11 @@ local-authored resource delta rows, and the distribution context shows local
 assigned counts match current ResourceBuilder counts for all `26` represented
 local resource types. The same-resource position context then matches all `69`
 local-authored delta resources to same-resource live delta rows, mostly at long
-distance. The next owner decision should therefore evaluate positional
-cut/order/materialization behavior before making any resource-placement repair.
+distance. The local materialization context proves all `252` typed local
+placements and all `69` local-authored delta placements still match the local
+final resource surface. The next owner decision should therefore evaluate live
+post-placement materialization/readback behavior, or add immediate live
+coordinate evidence, before making any resource-placement repair.
 
 ## Required Next Diagnostics
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,17 +5,17 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-position-context-drain`
-  stacked above `codex/swooper-resource-distribution-context-drain`; this
-  slice carries same-resource displacement context for the remaining resource
-  feasibility rows.
+- Branch/Graphite stack: `codex/swooper-resource-local-materialization-context-drain`
+  stacked above `codex/swooper-resource-position-context-drain`; this slice
+  carries local resource materialization consistency context for the remaining
+  resource feasibility rows.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
   feasibility plus row/static-policy/live-plot, assignment-order, and
   ResourceBuilder diagnostic/subclassification/policy context plus
-  assignment-class, distribution-count, and same-resource position summaries
-  now narrow the next resource repair class.
+  assignment-class, distribution-count, same-resource position, and local
+  materialization summaries now narrow the next resource repair class.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -142,8 +142,8 @@
   plot count, seed, turn, or game hash do not match the saved proof identity.
   The current full feasibility artifact is
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
-  (`sha256:8770c7f465358a97be9213bbbcbf3ac106efbe34cd9d8745e94cb229176acd55`,
-  `proofHash:4bb5f364bcf6e3b76ad89712aaf285ca006a1543f48a5dd318947a6a5e98b597`).
+  (`sha256:4b6534e577c8d337df66ea42fd33a1d3674b8043a73fbc40c481e16c0cd5324e`,
+  `proofHash:cf91a10f32f8a53297058e5712039227869744d8f6354a59ce06b3dc7a8ac259`).
   Request identity resolves to `studio-run-in-game-mq20rbzr-1fhc`; runtime
   identity is matched to the saved proof at `106x66`, `6996` plots, seed
   `138503614`, turn `1`, and game hash `0`. The artifact preserves the
@@ -189,9 +189,9 @@
   current regenerated runtime-bound artifact
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
   has sha256
-  `8770c7f465358a97be9213bbbcbf3ac106efbe34cd9d8745e94cb229176acd55`
+  `4b6534e577c8d337df66ea42fd33a1d3674b8043a73fbc40c481e16c0cd5324e`
   and proofHash
-  `4bb5f364bcf6e3b76ad89712aaf285ca006a1543f48a5dd318947a6a5e98b597`.
+  `cf91a10f32f8a53297058e5712039227869744d8f6354a59ce06b3dc7a8ac259`.
   It keeps the exact-authored source proof hash
   `e448cad8023b1478aff5fe40d30f23a23f4a71eed47ce614464db88ac01586df`
   and reads ResourceBuilder diagnostics for the `9` focused cells with `0`
@@ -218,9 +218,9 @@
   The regenerated resource feasibility artifact
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
   has sha256
-  `8770c7f465358a97be9213bbbcbf3ac106efbe34cd9d8745e94cb229176acd55`
+  `4b6534e577c8d337df66ea42fd33a1d3674b8043a73fbc40c481e16c0cd5324e`
   and proofHash
-  `4bb5f364bcf6e3b76ad89712aaf285ca006a1543f48a5dd318947a6a5e98b597`.
+  `cf91a10f32f8a53297058e5712039227869744d8f6354a59ce06b3dc7a8ac259`.
   The `9` focused rows are all scarce-floor assignments made before their local
   resource type reached the floor target (`targetMinPerType:7`), with local
   legal plot counts between `66` and `554`. This proves the local reason those
@@ -268,9 +268,9 @@
   runtime-bound full artifact
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json`
   has sha256
-  `8770c7f465358a97be9213bbbcbf3ac106efbe34cd9d8745e94cb229176acd55`
+  `4b6534e577c8d337df66ea42fd33a1d3674b8043a73fbc40c481e16c0cd5324e`
   and proofHash
-  `4bb5f364bcf6e3b76ad89712aaf285ca006a1543f48a5dd318947a6a5e98b597`.
+  `cf91a10f32f8a53297058e5712039227869744d8f6354a59ce06b3dc7a8ac259`.
   It records `26` local resource types across `69` local-authored delta rows.
   For all `26`, local assigned count equals current ResourceBuilder count
   (`assignedMinusResourceBuilderCount:0`), while `25/26` still have local
@@ -294,6 +294,17 @@
   run. The matching is a classifier over observed local/live delta rows only;
   it does not prove Civ placement authorship, authorize scarce-floor or resource
   tuning repair, close parity, or establish product acceptance.
+- Local resource materialization context progress:
+  the full artifact now compares typed local resource placement outcomes against
+  the local final resource surface. All `252/252` placed outcomes match the
+  local final resource surface, and all `69/69` local-authored resource delta
+  rows match their typed local placement outcome. This rules out local
+  post-resource placement drift inside the local artifact for the resource
+  mismatch class. Combined with same-resource live displacement and matching
+  per-resource counts, the remaining source-authority question is now bounded
+  to live/Civ materialization, live readback timing, or missing immediate
+  post-placement live coordinate evidence. This does not itself prove live Civ
+  final-surface authorship or authorize product repair.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -316,12 +327,15 @@
   assigned counts match current ResourceBuilder counts for all `26` local
   resource types represented by those deltas. The position context now also
   matches all `69` local-authored delta resources to same-resource live delta
-  rows, mostly at long distance. However, the current ResourceBuilder and
-  position facts are still post-materialization/readback classifiers. No
-  resource tuning, static-policy repair, scarce-floor repair, or
-  assignment-order repair is authorized until those subclasses are assigned to a
-  concrete source owner. The single substitution row where both probed values
-  are infeasible remains an individual evidence row with no repair authority
-  until row-level context assigns source ownership.
+  rows, mostly at long distance. Local materialization context proves the local
+  final resource surface still matches every typed local placement outcome.
+  However, the current ResourceBuilder and position facts are still
+  post-materialization/readback classifiers, and immediate post-placement live
+  coordinate evidence is still missing. No resource tuning, static-policy
+  repair, scarce-floor repair, or assignment-order repair is authorized until
+  those subclasses are assigned to a concrete source owner. The single
+  substitution row where both probed values are infeasible remains an individual
+  evidence row with no repair authority until row-level context assigns source
+  ownership.
 - Stop condition: source authority is not known for any row outside the
   classified adjacent-land resource class.

--- a/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
+++ b/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
@@ -234,6 +234,7 @@ async function main(): Promise<number> {
       resourceBuilderDiagnosticsSummary
     ),
     resourcePositionContext: summarizeResourcePositionContext(proof, ignoreWeightProof.rows),
+    localMaterializationContext: summarizeLocalMaterializationContext(proof, ignoreWeightProof.rows),
     assignmentClassSummary: summarizeAssignmentClasses(ignoreWeightProof.rows),
     strict: summarizeFeasibilityProof(proof, strict),
     ignoreWeight: ignoreWeightProof,
@@ -680,6 +681,95 @@ function summarizeResourcePositionContext(
   };
 }
 
+function summarizeLocalMaterializationContext(
+  proof: Pick<FinalSurfaceParityProof, "local">,
+  rows: ReadonlyArray<ResourceDeltaFeasibilityContext>
+) {
+  const outcomes = readLocalResourcePlacementOutcomes(proof.local.evidence);
+  const localResourceValues = proof.local.surfaces.resource.values;
+  const deltaPlotIndexes = new Set(rows.map((row) => row.plotIndex));
+  const placedOutcomes = outcomes.filter((outcome) => outcome.status === "placed");
+  const placedRows = placedOutcomes.map((outcome) => {
+    const finalLocalValue = normalizeResourceSurfaceValue(localResourceValues[outcome.plotIndex]);
+    const matchesFinalSurface = finalLocalValue === outcome.observedResourceType;
+    return {
+      plotIndex: outcome.plotIndex,
+      x: outcome.x,
+      y: outcome.y,
+      resourceType: outcome.resourceType,
+      observedResourceType: outcome.observedResourceType,
+      finalLocalResourceType: finalLocalValue,
+      matchesFinalSurface,
+      inResourceDeltaSet: deltaPlotIndexes.has(outcome.plotIndex),
+    };
+  });
+  const mismatches = placedRows.filter((row) => !row.matchesFinalSurface);
+  const deltaRows = placedRows.filter((row) => row.inResourceDeltaSet);
+  const deltaMismatches = deltaRows.filter((row) => !row.matchesFinalSurface);
+
+  return {
+    evidenceBoundary:
+      "Diagnostic context only: local typed placement outcomes are compared to the local final resource surface; this does not prove live Civ final-surface authorship.",
+    placedOutcomeCount: placedRows.length,
+    placedOutcomesMatchingLocalFinalSurface: placedRows.length - mismatches.length,
+    placedOutcomesMismatchingLocalFinalSurface: mismatches.length,
+    localAuthoredDeltaPlacedOutcomeCount: deltaRows.length,
+    localAuthoredDeltaOutcomesMatchingLocalFinalSurface: deltaRows.length - deltaMismatches.length,
+    localAuthoredDeltaOutcomesMismatchingLocalFinalSurface: deltaMismatches.length,
+    mismatchRows: mismatches.slice(0, 20),
+  };
+}
+
+function readLocalResourcePlacementOutcomes(evidence: unknown): ReadonlyArray<{
+  status: string;
+  plotIndex: number;
+  x: number;
+  y: number;
+  resourceType: number;
+  observedResourceType: number | null;
+}> {
+  const record = isRecord(evidence) ? evidence : {};
+  const resourcePlacementOutcomes = isRecord(record.resourcePlacementOutcomes)
+    ? record.resourcePlacementOutcomes
+    : {};
+  const outcomes = Array.isArray(resourcePlacementOutcomes.outcomes)
+    ? resourcePlacementOutcomes.outcomes
+    : [];
+  return outcomes.flatMap((outcome) => {
+    if (!isRecord(outcome)) return [];
+    const status = stringValue(outcome.status);
+    const plotIndex = numberValue(outcome.plotIndex);
+    const x = numberValue(outcome.x);
+    const y = numberValue(outcome.y);
+    const resourceType = numberValue(outcome.resourceType);
+    const observedResourceType = nullableNumberValue(outcome.observedResourceType);
+    if (
+      status === undefined ||
+      plotIndex === undefined ||
+      x === undefined ||
+      y === undefined ||
+      resourceType === undefined
+    ) {
+      return [];
+    }
+    return [
+      {
+        status,
+        plotIndex,
+        x,
+        y,
+        resourceType,
+        observedResourceType,
+      },
+    ];
+  });
+}
+
+function normalizeResourceSurfaceValue(value: unknown): number | null {
+  const number = numberValue(value);
+  return number === undefined || number < 0 ? null : number;
+}
+
 function nearestResourceDeltaMatch(
   row: ResourceDeltaFeasibilityContext,
   candidates: ReadonlyArray<ResourceDeltaFeasibilityContext>,
@@ -1014,6 +1104,11 @@ function uniqueNumbers(values: ReadonlyArray<number | null>): number[] {
 
 function numberValue(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function nullableNumberValue(value: unknown): number | null {
+  if (value === null) return null;
+  return numberValue(value) ?? null;
 }
 
 function stringValue(value: unknown): string | undefined {


### PR DESCRIPTION
Adds local resource materialization consistency context (task 2.17) to the feasibility verification script and workstream records.

The verification script now compares typed local resource placement outcomes against the local final resource surface. All 252 placed outcomes and all 69 local-authored delta placements match the local final surface, confirming there is no local post-placement resource drift for the current mismatch class. Combined with same-resource live displacement and matching per-resource counts across all 26 local resource types, the remaining source-authority question is bounded to live/Civ materialization, live readback timing, or missing immediate post-placement live coordinate evidence.

The full feasibility artifact has been regenerated with updated sha256 and proofHash values reflecting the new materialization context fields. The disposition and next-action guidance in the delta classification ledger and phase record are updated accordingly: the next owner decision should evaluate live post-placement materialization or readback behavior, or capture immediate live coordinate evidence, before any resource-placement repair is authorized. Task 2.17 is marked complete and the former 2.17 and 2.18 are renumbered to 2.18 and 2.19.