### PR TITLE
feat(swooper-resource-placement): add deterministic coordinate proof digest to placement summary and runtime telemetry

### DIFF
--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
@@ -222,12 +222,35 @@ const ResourcePlacementResourceSummarySchema = Type.Object(
   { additionalProperties: false }
 );
 
+const ResourcePlacementCoordinateDigestSchema = Type.Object(
+  {
+    count: Type.Integer({ minimum: 0 }),
+    hash32: Type.String({ pattern: "^[0-9a-f]{8}$" }),
+  },
+  { additionalProperties: false }
+);
+
+const ResourcePlacementCoordinateProofSchema = Type.Object(
+  {
+    version: Type.Literal(1),
+    placed: ResourcePlacementCoordinateDigestSchema,
+    rejected: ResourcePlacementCoordinateDigestSchema,
+    mismatch: ResourcePlacementCoordinateDigestSchema,
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Compact deterministic coordinate identity for typed resource placement outcomes, intended for exact-run log/artifact comparison.",
+  }
+);
+
 const ResourcePlacementSummarySchema = Type.Object(
   {
     plannedCount: Type.Integer({ minimum: 0 }),
     placedCount: Type.Integer({ minimum: 0 }),
     rejectedCount: Type.Integer({ minimum: 0 }),
     mismatchCount: Type.Integer({ minimum: 0 }),
+    coordinateProof: ResourcePlacementCoordinateProofSchema,
     byResource: Type.Array(ResourcePlacementResourceSummarySchema),
     byReason: Type.Array(ResourcePlacementReasonCountSchema),
   },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
@@ -35,6 +35,7 @@ type RuntimeResourceRow = {
   readonly ResourceClassType?: unknown;
   readonly Name?: unknown;
 };
+type ResourcePlacementCoordinateDigest = ResourcePlacementSummary["coordinateProof"]["placed"];
 
 type PlaceResourcesWithTypedOutcomesArgs = {
   adapter: ExtendedMapContext["adapter"];
@@ -71,6 +72,8 @@ const RESOURCE_REJECTION_REASONS = new Set<string>([
   "cannot-have-resource",
 ]);
 const RESOURCE_MISMATCH_REASONS = new Set<string>(["wrong-resource-type"]);
+const FNV1A_32_OFFSET = 0x811c9dc5;
+const FNV1A_32_PRIME = 0x01000193;
 
 function expectedTileForIntent(
   width: number,
@@ -96,6 +99,41 @@ function isLegalResourceTile(
 
 function allPlotIndices(size: number): number[] {
   return Array.from({ length: size }, (_value, index) => index);
+}
+
+function hash32Hex(input: string): string {
+  let hash = FNV1A_32_OFFSET;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, FNV1A_32_PRIME);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function buildResourcePlacementCoordinateDigest(
+  outcomes: readonly ResourcePlacementOutcome[],
+  status: ResourcePlacementOutcome["status"]
+): ResourcePlacementCoordinateDigest {
+  const rows = outcomes
+    .filter((outcome) => outcome.status === status)
+    .slice()
+    .sort((a, b) => {
+      if (a.plotIndex !== b.plotIndex) return a.plotIndex - b.plotIndex;
+      if (a.resourceType !== b.resourceType) return a.resourceType - b.resourceType;
+      return (a.observedResourceType ?? -1) - (b.observedResourceType ?? -1);
+    })
+    .map((outcome) =>
+      [
+        outcome.status,
+        outcome.plotIndex,
+        outcome.x,
+        outcome.y,
+        outcome.resourceType,
+        outcome.observedResourceType ?? -1,
+        outcome.status === "placed" ? "placed" : outcome.reason,
+      ].join(":")
+    );
+  return { count: rows.length, hash32: hash32Hex(rows.join("|")) };
 }
 
 function buildCandidatePlotOrder(
@@ -680,6 +718,12 @@ function summarizeResourceOutcomes(
     placedCount,
     rejectedCount,
     mismatchCount,
+    coordinateProof: {
+      version: 1,
+      placed: buildResourcePlacementCoordinateDigest(outcomes, "placed"),
+      rejected: buildResourcePlacementCoordinateDigest(outcomes, "rejected"),
+      mismatch: buildResourcePlacementCoordinateDigest(outcomes, "mismatch"),
+    },
     byResource: Array.from(byResource.entries())
       .sort(([a], [b]) => a - b)
       .map(([resourceType, summary]) => ({
@@ -738,10 +782,18 @@ export function buildResourcePlacementRuntimeTelemetry(
   const plannedResourceTypes = summary.byResource.filter((row) => row.plannedCount > 0);
   const placedResourceTypes = summary.byResource.filter((row) => row.placedCount > 0);
   const rejectedResourceTypes = summary.byResource.filter((row) => row.rejectedCount > 0);
+  const plannedResourceTypeValues = plannedResourceTypes.map((row) => row.resourceType);
+  const placedResourceTypeValues = placedResourceTypes.map((row) => row.resourceType);
+  const rejectedResourceTypeValues = rejectedResourceTypes.map((row) => row.resourceType);
   const placedCounts = placedResourceTypes.map((row) => row.placedCount);
   const unmappedResourceTypes = summary.byResource.filter(
     (row) => row.placedCount > 0 && !runtimeByIndex.has(row.resourceType)
   );
+  const plannedTypeSet = new Set(plannedResourceTypeValues);
+  const coveredTypeSet = new Set([...placedResourceTypeValues, ...rejectedResourceTypeValues]);
+  const plannedTypesCovered =
+    plannedTypeSet.size === coveredTypeSet.size &&
+    plannedResourceTypeValues.every((resourceType) => coveredTypeSet.has(resourceType));
 
   return {
     version: 1,
@@ -754,9 +806,26 @@ export function buildResourcePlacementRuntimeTelemetry(
     minPlacedCountByType: placedCounts.length > 0 ? Math.min(...placedCounts) : 0,
     maxPlacedCountByType: placedCounts.length > 0 ? Math.max(...placedCounts) : 0,
     runtimeCatalogCount: runtimeCatalog.length,
-    plannedResourceTypes: plannedResourceTypes.map((row) => row.resourceType),
-    placedResourceTypes: placedResourceTypes.map((row) => row.resourceType),
-    rejectedResourceTypes: rejectedResourceTypes.map((row) => row.resourceType),
+    coordinateProof: {
+      version: summary.coordinateProof.version,
+      placedCount: summary.coordinateProof.placed.count,
+      placedHash32: summary.coordinateProof.placed.hash32,
+      ...(summary.coordinateProof.rejected.count > 0
+        ? {
+            rejectedCount: summary.coordinateProof.rejected.count,
+            rejectedHash32: summary.coordinateProof.rejected.hash32,
+          }
+        : {}),
+      ...(summary.coordinateProof.mismatch.count > 0
+        ? {
+            mismatchCount: summary.coordinateProof.mismatch.count,
+            mismatchHash32: summary.coordinateProof.mismatch.hash32,
+          }
+        : {}),
+    },
+    ...(plannedTypesCovered ? {} : { plannedResourceTypes: plannedResourceTypeValues }),
+    placedResourceTypes: placedResourceTypeValues,
+    rejectedResourceTypes: rejectedResourceTypeValues,
     unmappedPlacedResourceTypes: unmappedResourceTypes.map((row) => row.resourceType),
     ...(assignment
       ? {

--- a/mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts
+++ b/mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts
@@ -47,6 +47,12 @@ describe("resource placement diagnostics", () => {
       placedCount: 4,
       rejectedCount: 0,
       mismatchCount: 0,
+      coordinateProof: {
+        version: 1,
+        placed: { count: 4, hash32: "3c3530cb" },
+        rejected: { count: 0, hash32: "811c9dc5" },
+        mismatch: { count: 0, hash32: "811c9dc5" },
+      },
       byResource: [
         {
           resourceType: 4,
@@ -59,6 +65,7 @@ describe("resource placement diagnostics", () => {
       ],
       byReason: [],
     });
+    expect(outcomes.summary.coordinateProof.placed.hash32).toMatch(/^[0-9a-f]{8}$/);
     expect(outcomes.assignment).toMatchObject({
       requestedPlannedCount: 4,
       assignedCount: 4,
@@ -171,6 +178,12 @@ describe("resource placement diagnostics", () => {
         placedCount: 3,
         rejectedCount: 1,
         mismatchCount: 0,
+        coordinateProof: {
+          version: 1,
+          placed: { count: 3, hash32: "12345678" },
+          rejected: { count: 1, hash32: "abcdef12" },
+          mismatch: { count: 0, hash32: "811c9dc5" },
+        },
         byResource: [
           {
             resourceType: 4,
@@ -219,12 +232,19 @@ describe("resource placement diagnostics", () => {
       minPlacedCountByType: 1,
       maxPlacedCountByType: 2,
       runtimeCatalogCount: 2,
-      plannedResourceTypes: [4, 44],
+      coordinateProof: {
+        version: 1,
+        placedCount: 3,
+        placedHash32: "12345678",
+        rejectedCount: 1,
+        rejectedHash32: "abcdef12",
+      },
       placedResourceTypes: [4, 44],
       rejectedResourceTypes: [44],
       unmappedPlacedResourceTypes: [],
       byReason: [{ reason: "cannot-have-resource", count: 1 }],
     });
+    expect(telemetry).not.toHaveProperty("plannedResourceTypes");
     expect(JSON.stringify(telemetry).length).toBeLessThan(900);
   });
 
@@ -243,6 +263,12 @@ describe("resource placement diagnostics", () => {
         placedCount: 159,
         rejectedCount: 0,
         mismatchCount: 0,
+        coordinateProof: {
+          version: 1,
+          placed: { count: 159, hash32: "22222222" },
+          rejected: { count: 0, hash32: "811c9dc5" },
+          mismatch: { count: 0, hash32: "811c9dc5" },
+        },
         byResource: resourceRows,
         byReason: [],
       },
@@ -278,7 +304,11 @@ describe("resource placement diagnostics", () => {
       placedCount: 159,
       rejectedCount: 0,
       runtimeCatalogCount: 55,
-      plannedResourceTypes: placedResourceTypes,
+      coordinateProof: {
+        version: 1,
+        placedCount: 159,
+        placedHash32: "22222222",
+      },
       placedResourceTypes,
       rejectedResourceTypes: [],
       unmappedPlacedResourceTypes: [],
@@ -291,6 +321,7 @@ describe("resource placement diagnostics", () => {
         unassignableResourceTypes: [5, 15],
       },
     });
+    expect(telemetry).not.toHaveProperty("plannedResourceTypes");
     expect(JSON.stringify(telemetry).length).toBeLessThan(900);
     expect(`[SWOOPER_MOD] RESOURCE_PLACEMENT_V1 ${JSON.stringify(telemetry)}`.length).toBeLessThan(
       900

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -38,8 +38,10 @@
 - [x] 2.16 Add same-resource position displacement context for local-authored
   resource delta rows.
 - [x] 2.17 Add local resource materialization consistency context.
-- [ ] 2.18 Repair remaining proven package or MapGen owners.
-- [ ] 2.19 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.18 Add immediate resource placement coordinate proof instrumentation for
+  the next exact-authored run.
+- [ ] 2.19 Repair remaining proven package or MapGen owners.
+- [ ] 2.20 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -559,6 +559,25 @@ final resource surface. The next owner decision should therefore evaluate live
 post-placement materialization/readback behavior, or add immediate live
 coordinate evidence, before making any resource-placement repair.
 
+### Resource Placement Coordinate Proof Instrumentation
+
+Diagnostic repair:
+`artifact:placement.resourcePlacementOutcomes` now summarizes placed, rejected,
+and mismatch resource placement outcomes with a deterministic
+`coordinateProof` digest. The digest is computed from sorted typed placement
+outcomes and includes count plus an 8-hex-character `hash32` per status. Runtime
+`RESOURCE_PLACEMENT_V1` telemetry emits the compact placed coordinate
+count/hash, and emits rejected or mismatch hashes when those statuses are
+present.
+
+Boundary:
+this instrumentation is for the next exact-authored live run. It does not
+retroactively classify request `studio-run-in-game-mq20rbzr-1fhc`, because the
+saved proof artifact predates the coordinate digest. The current resource
+source-authority state remains open until a fresh exact-authored run binds local
+typed placement coordinate identity to runtime log evidence, or another bounded
+proof assigns the remaining subclasses to a concrete owner.
+
 ## Required Next Diagnostics
 
 - Extract local row context for every feature/resource mismatch: terrain,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,17 +5,18 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-local-materialization-context-drain`
-  stacked above `codex/swooper-resource-position-context-drain`; this slice
-  carries local resource materialization consistency context for the remaining
-  resource feasibility rows.
+- Branch/Graphite stack: `codex/swooper-resource-coordinate-proof-drain`
+  stacked above `codex/swooper-resource-local-materialization-context-drain`;
+  this slice carries immediate resource placement coordinate proof
+  instrumentation for the next exact-authored run.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
   feasibility plus row/static-policy/live-plot, assignment-order, and
   ResourceBuilder diagnostic/subclassification/policy context plus
-  assignment-class, distribution-count, same-resource position, and local
-  materialization summaries now narrow the next resource repair class.
+  assignment-class, distribution-count, same-resource position, local
+  materialization, and future coordinate-proof instrumentation now narrow the
+  next resource repair class.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -305,6 +306,16 @@
   to live/Civ materialization, live readback timing, or missing immediate
   post-placement live coordinate evidence. This does not itself prove live Civ
   final-surface authorship or authorize product repair.
+- Resource placement coordinate proof progress:
+  `placement.resourcePlacementOutcomes.summary` now carries a deterministic
+  `coordinateProof` block for placed, rejected, and mismatch resource outcomes.
+  Runtime `RESOURCE_PLACEMENT_V1` telemetry now emits the compact placed
+  coordinate hash/count, plus rejected or mismatch hashes when present, while
+  omitting redundant planned-type arrays to stay under the Civ scripting-log
+  truncation guard. This creates the missing immediate-placement coordinate
+  identity needed by the next exact-authored run. It does not retroactively
+  classify request `studio-run-in-game-mq20rbzr-1fhc`, because that saved proof
+  predates the coordinate digest.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -329,13 +340,13 @@
   matches all `69` local-authored delta resources to same-resource live delta
   rows, mostly at long distance. Local materialization context proves the local
   final resource surface still matches every typed local placement outcome.
-  However, the current ResourceBuilder and position facts are still
-  post-materialization/readback classifiers, and immediate post-placement live
-  coordinate evidence is still missing. No resource tuning, static-policy
-  repair, scarce-floor repair, or assignment-order repair is authorized until
-  those subclasses are assigned to a concrete source owner. The single
-  substitution row where both probed values are infeasible remains an individual
-  evidence row with no repair authority until row-level context assigns source
-  ownership.
+  Current code now emits immediate placement coordinate digests for future exact
+  runs, but the current `mq20rbzr` artifact still lacks that digest. No resource
+  tuning, static-policy repair, scarce-floor repair, or assignment-order repair
+  is authorized until a fresh exact-authored run binds local and live immediate
+  placement coordinate identity or otherwise assigns those subclasses to a
+  concrete source owner. The single substitution row where both probed values are
+  infeasible remains an individual evidence row with no repair authority until
+  row-level context assigns source ownership.
 - Stop condition: source authority is not known for any row outside the
   classified adjacent-land resource class.


### PR DESCRIPTION
Adds a deterministic `coordinateProof` digest to resource placement outcomes, providing a compact identity for placed, rejected, and mismatch outcomes that can be compared across exact-authored runs.

Each digest contains a count and an 8-hex-character FNV-1a 32-bit hash computed from sorted, typed placement outcome coordinates. The proof is attached to `ResourcePlacementSummary` under a versioned `coordinateProof` block and is emitted in `RESOURCE_PLACEMENT_V1` runtime telemetry as flattened count/hash fields. Rejected and mismatch hashes are only included in telemetry when those outcome counts are nonzero, keeping the payload under the Civ scripting-log truncation limit.

The `plannedResourceTypes` array is now omitted from telemetry when all planned types are covered by placed or rejected outcomes, further reducing payload size.

This instrumentation targets the next exact-authored run. It does not retroactively classify the `mq20rbzr` saved proof artifact, which predates the coordinate digest.