### PR TITLE
feat(run-in-game): bind resource placement coordinate proof into exact-authorship log parsing and parity proof intake

### DIFF
--- a/apps/mapgen-studio/src/features/runInGame/status.ts
+++ b/apps/mapgen-studio/src/features/runInGame/status.ts
@@ -139,6 +139,16 @@ export type RunInGameExactAuthorshipProof = Readonly<{
     dimensions: Readonly<{ width: number; height: number }>;
     proofPayload: unknown;
     completionPayload: unknown;
+    resourcePlacement?: Readonly<{
+      marker: "RESOURCE_PLACEMENT_V1";
+      payload: unknown;
+      coordinateProof?: Readonly<{
+        version: number;
+        placed: Readonly<{ count: number; hash32: string }>;
+        rejected?: Readonly<{ count: number; hash32: string }>;
+        mismatch?: Readonly<{ count: number; hash32: string }>;
+      }>;
+    }>;
     matched: ReadonlyArray<string>;
   }>;
   unresolvedLinks: ReadonlyArray<string>;

--- a/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
+++ b/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
@@ -218,9 +218,14 @@ export function parseSwooperMapgenLogProof(args: {
   envelopeHash: string;
   seed: number;
 }): RunInGameExactAuthorshipProof["log"] | undefined {
-  const proofPayload = lastSwooperPayload(args.text, "[mapgen-proof]", args);
-  const completionPayload = lastSwooperPayload(args.text, "[mapgen-complete]", args);
-  if (!proofPayload || !completionPayload) return undefined;
+  const lines = args.text.split(/\r?\n/);
+  const completionLine = lastSwooperPayloadLine(lines, "[mapgen-complete]", args);
+  const proofLine = completionLine
+    ? lastSwooperPayloadLine(lines, "[mapgen-proof]", args, { beforeIndex: completionLine.index })
+    : lastSwooperPayloadLine(lines, "[mapgen-proof]", args);
+  if (!proofLine || !completionLine) return undefined;
+  const proofPayload = proofLine.payload;
+  const completionPayload = completionLine.payload;
   const proofDimensions = dimensionsFromPayload(proofPayload);
   const completionDimensions = dimensionsFromPayload(completionPayload);
   if (
@@ -231,6 +236,11 @@ export function parseSwooperMapgenLogProof(args: {
   ) {
     return undefined;
   }
+  const resourcePlacement = parseResourcePlacementTelemetryBetween(
+    lines,
+    proofLine.index,
+    completionLine.index
+  );
   return {
     ...(args.logPath ? { logPath: args.logPath } : {}),
     ...(args.observedAt ? { observedAt: args.observedAt } : {}),
@@ -242,6 +252,7 @@ export function parseSwooperMapgenLogProof(args: {
     dimensions: proofDimensions,
     proofPayload,
     completionPayload,
+    ...(resourcePlacement ? { resourcePlacement } : {}),
     matched: ["[mapgen-proof]", args.requestId, args.configHash, args.envelopeHash, "[mapgen-complete]"],
   };
 }
@@ -339,22 +350,79 @@ function hasRows(rowProof: unknown): boolean {
   return count !== undefined && count > 0;
 }
 
-function lastSwooperPayload(
-  text: string,
+function lastSwooperPayloadLine(
+  lines: readonly string[],
   marker: "[mapgen-proof]" | "[mapgen-complete]",
   expected: Pick<Parameters<typeof parseSwooperMapgenLogProof>[0], "requestId" | "configHash" | "envelopeHash" | "seed">,
-): Record<string, unknown> | null {
-  const lines = text.split(/\r?\n/).filter((line) => line.includes(marker));
-  for (const line of lines.reverse()) {
+  options: { beforeIndex?: number } = {},
+): { index: number; payload: Record<string, unknown> } | null {
+  const startIndex = options.beforeIndex === undefined
+    ? lines.length - 1
+    : Math.min(options.beforeIndex - 1, lines.length - 1);
+  for (let index = startIndex; index >= 0; index -= 1) {
+    const line = lines[index] ?? "";
+    if (!line.includes(marker)) continue;
     const payload = parsePayloadAfterMarker(line, marker);
     if (!payload) continue;
     if (payload.requestId !== expected.requestId) continue;
     if (payload.configHash !== expected.configHash) continue;
     if (payload.envelopeHash !== expected.envelopeHash) continue;
     if (payload.seed !== expected.seed) continue;
-    return payload;
+    return { index, payload };
   }
   return null;
+}
+
+function parseResourcePlacementTelemetryBetween(
+  lines: readonly string[],
+  proofIndex: number,
+  completionIndex: number
+): NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["resourcePlacement"]> | undefined {
+  for (let index = completionIndex - 1; index > proofIndex; index -= 1) {
+    const line = lines[index] ?? "";
+    if (!line.includes("RESOURCE_PLACEMENT_V1")) continue;
+    const payload = parsePayloadAfterMarker(line, "RESOURCE_PLACEMENT_V1");
+    if (!payload) continue;
+    return {
+      marker: "RESOURCE_PLACEMENT_V1",
+      payload,
+      ...(resourcePlacementCoordinateProof(payload) ?? {}),
+    };
+  }
+  return undefined;
+}
+
+function resourcePlacementCoordinateProof(
+  payload: Record<string, unknown>
+):
+  | {
+      coordinateProof: NonNullable<
+        NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["resourcePlacement"]>["coordinateProof"]
+      >;
+    }
+  | undefined {
+  const coordinateProof = isRecord(payload.coordinateProof) ? payload.coordinateProof : undefined;
+  if (!coordinateProof) return undefined;
+  const version = numberValue(coordinateProof.version);
+  const placedCount = numberValue(coordinateProof.placedCount);
+  const placedHash32 = hash32Value(coordinateProof.placedHash32);
+  if (version === undefined || placedCount === undefined || placedHash32 === undefined) return undefined;
+  const rejectedCount = numberValue(coordinateProof.rejectedCount);
+  const rejectedHash32 = hash32Value(coordinateProof.rejectedHash32);
+  const mismatchCount = numberValue(coordinateProof.mismatchCount);
+  const mismatchHash32 = hash32Value(coordinateProof.mismatchHash32);
+  return {
+    coordinateProof: {
+      version,
+      placed: { count: placedCount, hash32: placedHash32 },
+      ...(rejectedCount === undefined || rejectedHash32 === undefined
+        ? {}
+        : { rejected: { count: rejectedCount, hash32: rejectedHash32 } }),
+      ...(mismatchCount === undefined || mismatchHash32 === undefined
+        ? {}
+        : { mismatch: { count: mismatchCount, hash32: mismatchHash32 } }),
+    },
+  };
 }
 
 function parsePayloadAfterMarker(line: string, marker: string): Record<string, unknown> | null {
@@ -368,6 +436,10 @@ function parsePayloadAfterMarker(line: string, marker: string): Record<string, u
   } catch {
     return null;
   }
+}
+
+function hash32Value(value: unknown): string | undefined {
+  return typeof value === "string" && /^[0-9a-f]{8}$/.test(value) ? value : undefined;
 }
 
 function dimensionsFromPayload(payload: Record<string, unknown>): { width: number; height: number } | null {

--- a/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
+++ b/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
@@ -91,6 +91,18 @@ describe("Run in Game exact authorship proof identity", () => {
       text: [
         `[mapgen-proof] ${JSON.stringify({ requestId: "old", configHash, envelopeHash, seed: 42, dimensions: { width: 1, height: 1 } })}`,
         `[mapgen-proof] ${JSON.stringify({ requestId, configHash, envelopeHash, seed: 42, mapSize: "MAPSIZE_STANDARD", dimensions: { width: 84, height: 54 } })}`,
+        `[SWOOPER_MOD] RESOURCE_PLACEMENT_V1 ${JSON.stringify({
+          version: 1,
+          plannedCount: 4,
+          placedCount: 4,
+          rejectedCount: 0,
+          mismatchCount: 0,
+          coordinateProof: {
+            version: 1,
+            placedCount: 4,
+            placedHash32: "3c3530cb",
+          },
+        })}`,
         `[mapgen-complete] ${JSON.stringify({ requestId, configHash, envelopeHash, seed: 42, dimensions: { width: 84, height: 54 } })}`,
       ].join("\n"),
       logPath: "/tmp/Scripting.log",
@@ -110,6 +122,13 @@ describe("Run in Game exact authorship proof identity", () => {
       dimensions: { width: 84, height: 54 },
       matched: ["[mapgen-proof]", requestId, configHash, envelopeHash, "[mapgen-complete]"],
     });
+    expect(logProof?.resourcePlacement).toMatchObject({
+      marker: "RESOURCE_PLACEMENT_V1",
+      coordinateProof: {
+        version: 1,
+        placed: { count: 4, hash32: "3c3530cb" },
+      },
+    });
     expect(parseSwooperMapgenLogProof({
       text: `[mapgen-proof] ${JSON.stringify({ requestId, configHash, envelopeHash, seed: 41, dimensions: { width: 84, height: 54 } })}`,
       requestId,
@@ -127,6 +146,25 @@ describe("Run in Game exact authorship proof identity", () => {
       envelopeHash,
       seed: 42,
     })).toBeUndefined();
+  });
+
+  it("ignores resource placement telemetry outside the matching proof section", () => {
+    const logProof = parseSwooperMapgenLogProof({
+      text: [
+        `[SWOOPER_MOD] RESOURCE_PLACEMENT_V1 ${JSON.stringify({
+          version: 1,
+          coordinateProof: { version: 1, placedCount: 4, placedHash32: "aaaaaaaa" },
+        })}`,
+        `[mapgen-proof] ${JSON.stringify({ requestId, configHash, envelopeHash, seed: 42, dimensions: { width: 84, height: 54 } })}`,
+        `[mapgen-complete] ${JSON.stringify({ requestId, configHash, envelopeHash, seed: 42, dimensions: { width: 84, height: 54 } })}`,
+      ].join("\n"),
+      requestId,
+      configHash,
+      envelopeHash,
+      seed: 42,
+    });
+
+    expect(logProof?.resourcePlacement).toBeUndefined();
   });
 
   it("marks exact authorship complete only when every required identity and equality link resolves", () => {

--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -153,6 +153,14 @@ export type ExactAuthorshipProofLike = Readonly<{
     envelopeHash?: string;
     seed?: number;
     dimensions?: Readonly<{ width?: number; height?: number }>;
+    resourcePlacement?: Readonly<{
+      coordinateProof?: Readonly<{
+        version?: number;
+        placed?: Readonly<{ count?: number; hash32?: string }>;
+        rejected?: Readonly<{ count?: number; hash32?: string }>;
+        mismatch?: Readonly<{ count?: number; hash32?: string }>;
+      }>;
+    }>;
   }>;
 }>;
 
@@ -484,6 +492,7 @@ export function buildFinalSurfaceParityProof(args: {
     ) {
       unresolvedLinks.push("exact-authorship-proof.materialization-envelope-hash.local-envelope-hash");
     }
+    addResourcePlacementCoordinateProofLinks(unresolvedLinks, exact, args.local);
   }
 
   for (const diff of diffs) {
@@ -689,6 +698,82 @@ function addFullGridEvidenceLinks(unresolvedLinks: string[], live: FinalSurfaceS
   }
   const identityCheck = isPlainObject(fullGrid.identityCheck) ? fullGrid.identityCheck : undefined;
   if (identityCheck?.stable !== true) unresolvedLinks.push("live.full-grid.identity-check");
+}
+
+function addResourcePlacementCoordinateProofLinks(
+  unresolvedLinks: string[],
+  exact: ExactAuthorshipProofLike,
+  local: FinalSurfaceSnapshot
+): void {
+  const localCoordinateProof = localResourcePlacementCoordinateProof(local);
+  if (!localCoordinateProof) return;
+  const logCoordinateProof = exact.log?.resourcePlacement?.coordinateProof;
+  if (!logCoordinateProof) {
+    unresolvedLinks.push("resource-placement-coordinate-proof.log");
+    return;
+  }
+  compareCoordinateDigest(
+    unresolvedLinks,
+    localCoordinateProof.placed,
+    logCoordinateProof.placed,
+    "resource-placement-coordinate-proof.placed"
+  );
+  compareCoordinateDigest(
+    unresolvedLinks,
+    localCoordinateProof.rejected,
+    logCoordinateProof.rejected,
+    "resource-placement-coordinate-proof.rejected"
+  );
+  compareCoordinateDigest(
+    unresolvedLinks,
+    localCoordinateProof.mismatch,
+    logCoordinateProof.mismatch,
+    "resource-placement-coordinate-proof.mismatch"
+  );
+}
+
+function compareCoordinateDigest(
+  unresolvedLinks: string[],
+  local: { count?: number; hash32?: string } | undefined,
+  log: { count?: number; hash32?: string } | undefined,
+  link: string
+): void {
+  if (!local) return;
+  if (!log) {
+    if ((local.count ?? 0) > 0) unresolvedLinks.push(link);
+    return;
+  }
+  if (local.count !== log.count || local.hash32 !== log.hash32) unresolvedLinks.push(link);
+}
+
+function localResourcePlacementCoordinateProof(local: FinalSurfaceSnapshot):
+  | {
+      placed?: { count?: number; hash32?: string };
+      rejected?: { count?: number; hash32?: string };
+      mismatch?: { count?: number; hash32?: string };
+    }
+  | undefined {
+  const resourcePlacementOutcomes = isPlainObject(local.evidence?.resourcePlacementOutcomes)
+    ? local.evidence.resourcePlacementOutcomes
+    : undefined;
+  const summary = isPlainObject(resourcePlacementOutcomes?.summary)
+    ? resourcePlacementOutcomes.summary
+    : undefined;
+  const coordinateProof = isPlainObject(summary?.coordinateProof) ? summary.coordinateProof : undefined;
+  if (!coordinateProof) return undefined;
+  return {
+    placed: coordinateDigest(coordinateProof.placed),
+    rejected: coordinateDigest(coordinateProof.rejected),
+    mismatch: coordinateDigest(coordinateProof.mismatch),
+  };
+}
+
+function coordinateDigest(value: unknown): { count?: number; hash32?: string } | undefined {
+  if (!isPlainObject(value)) return undefined;
+  return {
+    ...(numberValue(value.count) === undefined ? {} : { count: numberValue(value.count) }),
+    ...(typeof value.hash32 === "string" ? { hash32: value.hash32 } : {}),
+  };
 }
 
 function probeNumberValue(value: unknown): number | null {

--- a/mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
@@ -64,6 +64,14 @@ function exactProof(overrides: Partial<ExactAuthorshipProofLike> = {}): ExactAut
       envelopeHash: "envelope-1",
       seed: 1234,
       dimensions: { width: 2, height: 1 },
+      resourcePlacement: {
+        coordinateProof: {
+          version: 1,
+          placed: { count: 2, hash32: "aaaaaaaa" },
+          rejected: { count: 0, hash32: "811c9dc5" },
+          mismatch: { count: 0, hash32: "811c9dc5" },
+        },
+      },
     },
     ...overrides,
   };
@@ -75,6 +83,7 @@ function snapshot(args: {
   gameHash?: number;
   omitted?: number;
   localTerrain?: ReadonlyArray<number | null>;
+  resourceCoordinateProof?: boolean;
 }): FinalSurfaceSnapshot {
   const width = 2;
   const height = 1;
@@ -104,7 +113,20 @@ function snapshot(args: {
             },
           },
         }
-      : {},
+      : args.resourceCoordinateProof
+        ? {
+            resourcePlacementOutcomes: {
+              summary: {
+                coordinateProof: {
+                  version: 1,
+                  placed: { count: 2, hash32: "aaaaaaaa" },
+                  rejected: { count: 0, hash32: "811c9dc5" },
+                  mismatch: { count: 0, hash32: "811c9dc5" },
+                },
+              },
+            },
+          }
+        : {},
   };
 }
 
@@ -112,7 +134,7 @@ describe("final-surface parity proof", () => {
   test("marks a fully bound matching grid complete", () => {
     const proof = buildFinalSurfaceParityProof({
       exactAuthorship: exactProof(),
-      local: snapshot({ source: "local-mapgen" }),
+      local: snapshot({ source: "local-mapgen", resourceCoordinateProof: true }),
       live: snapshot({ source: "live-civ7" }),
       now: () => new Date("2026-06-06T00:00:00.000Z"),
     });
@@ -120,6 +142,50 @@ describe("final-surface parity proof", () => {
     expect(proof.status).toBe("complete");
     expect(proof.unresolvedLinks).toEqual([]);
     expect(proof.diffs.every((diff) => diff.status === "match")).toBe(true);
+  });
+
+  test("keeps parity unresolved when local resource coordinate proof lacks matching exact log evidence", () => {
+    const proof = buildFinalSurfaceParityProof({
+      exactAuthorship: exactProof({
+        log: {
+          requestId: "run-1",
+          configHash,
+          envelopeHash: "envelope-1",
+          seed: 1234,
+          dimensions: { width: 2, height: 1 },
+        },
+      }),
+      local: snapshot({ source: "local-mapgen", resourceCoordinateProof: true }),
+      live: snapshot({ source: "live-civ7" }),
+    });
+
+    expect(proof.status).toBe("unresolved");
+    expect(proof.unresolvedLinks).toContain("resource-placement-coordinate-proof.log");
+  });
+
+  test("keeps parity unresolved when resource coordinate proof hash differs", () => {
+    const proof = buildFinalSurfaceParityProof({
+      exactAuthorship: exactProof({
+        log: {
+          requestId: "run-1",
+          configHash,
+          envelopeHash: "envelope-1",
+          seed: 1234,
+          dimensions: { width: 2, height: 1 },
+          resourcePlacement: {
+            coordinateProof: {
+              version: 1,
+              placed: { count: 2, hash32: "bbbbbbbb" },
+            },
+          },
+        },
+      }),
+      local: snapshot({ source: "local-mapgen", resourceCoordinateProof: true }),
+      live: snapshot({ source: "live-civ7" }),
+    });
+
+    expect(proof.status).toBe("unresolved");
+    expect(proof.unresolvedLinks).toContain("resource-placement-coordinate-proof.placed");
   });
 
   test("rejects hash-only exact-authorship source snapshots", () => {

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -40,8 +40,10 @@
 - [x] 2.17 Add local resource materialization consistency context.
 - [x] 2.18 Add immediate resource placement coordinate proof instrumentation for
   the next exact-authored run.
-- [ ] 2.19 Repair remaining proven package or MapGen owners.
-- [ ] 2.20 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.19 Bind immediate resource placement coordinate proof into exact/parity
+  proof intake.
+- [ ] 2.20 Repair remaining proven package or MapGen owners.
+- [ ] 2.21 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -578,6 +578,24 @@ source-authority state remains open until a fresh exact-authored run binds local
 typed placement coordinate identity to runtime log evidence, or another bounded
 proof assigns the remaining subclasses to a concrete owner.
 
+### Resource Placement Coordinate Proof Intake
+
+Diagnostic repair:
+Studio exact-authorship parsing now accepts the `RESOURCE_PLACEMENT_V1`
+coordinate proof only from the bounded log section between the matching
+`[mapgen-proof]` and `[mapgen-complete]` payloads for the same
+request/config/envelope/seed chain. Final-surface parity proof then compares
+that exact log coordinate proof against local
+`resourcePlacementOutcomes.summary.coordinateProof` when the local artifact
+contains one.
+
+Boundary:
+missing or mismatched coordinate proof now keeps parity/source-authority proof
+unresolved with named `resource-placement-coordinate-proof.*` links. This
+prevents a fresh parity artifact from silently reusing local coordinate
+placement evidence without exact live log binding. The saved `mq20rbzr`
+artifact still predates this log proof and remains open.
+
 ## Required Next Diagnostics
 
 - Extract local row context for every feature/resource mismatch: terrain,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,18 +5,18 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-coordinate-proof-drain`
-  stacked above `codex/swooper-resource-local-materialization-context-drain`;
-  this slice carries immediate resource placement coordinate proof
-  instrumentation for the next exact-authored run.
+- Branch/Graphite stack: `codex/swooper-resource-coordinate-proof-intake-drain`
+  stacked above `codex/swooper-resource-coordinate-proof-drain`; this slice
+  carries exact/parity proof intake for immediate resource placement coordinate
+  identity.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
   feasibility plus row/static-policy/live-plot, assignment-order, and
   ResourceBuilder diagnostic/subclassification/policy context plus
   assignment-class, distribution-count, same-resource position, local
-  materialization, and future coordinate-proof instrumentation now narrow the
-  next resource repair class.
+  materialization, future coordinate-proof instrumentation, and coordinate-proof
+  intake now narrow the next resource repair class.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -316,6 +316,15 @@
   identity needed by the next exact-authored run. It does not retroactively
   classify request `studio-run-in-game-mq20rbzr-1fhc`, because that saved proof
   predates the coordinate digest.
+- Resource placement coordinate proof intake progress:
+  Studio exact-authorship log parsing now captures the bounded
+  `RESOURCE_PLACEMENT_V1` telemetry line only when it appears between the
+  matching `[mapgen-proof]` and `[mapgen-complete]` payloads for the same
+  request/config/envelope/seed chain. Final-surface parity proof now compares
+  the local `resourcePlacementOutcomes.summary.coordinateProof` digest against
+  the exact log coordinate digest when local evidence carries one. Missing or
+  mismatched coordinate proof keeps parity unresolved with named
+  `resource-placement-coordinate-proof.*` links.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -340,13 +349,13 @@
   matches all `69` local-authored delta resources to same-resource live delta
   rows, mostly at long distance. Local materialization context proves the local
   final resource surface still matches every typed local placement outcome.
-  Current code now emits immediate placement coordinate digests for future exact
-  runs, but the current `mq20rbzr` artifact still lacks that digest. No resource
-  tuning, static-policy repair, scarce-floor repair, or assignment-order repair
-  is authorized until a fresh exact-authored run binds local and live immediate
-  placement coordinate identity or otherwise assigns those subclasses to a
-  concrete source owner. The single substitution row where both probed values are
-  infeasible remains an individual evidence row with no repair authority until
-  row-level context assigns source ownership.
+  Current code now emits and parses immediate placement coordinate digests for
+  future exact runs, but the current `mq20rbzr` artifact still lacks that digest.
+  No resource tuning, static-policy repair, scarce-floor repair, or
+  assignment-order repair is authorized until a fresh exact-authored run binds
+  local and live immediate placement coordinate identity or otherwise assigns
+  those subclasses to a concrete source owner. The single substitution row where
+  both probed values are infeasible remains an individual evidence row with no
+  repair authority until row-level context assigns source ownership.
 - Stop condition: source authority is not known for any row outside the
   classified adjacent-land resource class.


### PR DESCRIPTION
Binds the `RESOURCE_PLACEMENT_V1` coordinate proof telemetry into exact-authorship log parsing and final-surface parity proof verification.

**Exact-authorship log parsing**

`parseSwooperMapgenLogProof` now splits the log into indexed lines so it can locate the `[mapgen-proof]` and `[mapgen-complete]` payloads by position. A `RESOURCE_PLACEMENT_V1` telemetry line is accepted only when it appears between those two matching payloads for the same request/config/envelope/seed chain. Telemetry outside that bounded section is ignored. The parsed coordinate proof is attached to the returned log entry as `resourcePlacement.coordinateProof`, carrying `placed`, `rejected`, and `mismatch` digests (each a `count` + 8-hex-char `hash32`).

**Parity proof verification**

`buildFinalSurfaceParityProof` now calls `addResourcePlacementCoordinateProofLinks` when the local snapshot carries `resourcePlacementOutcomes.summary.coordinateProof` evidence. It compares each digest field against the exact log coordinate proof. A missing log proof pushes `resource-placement-coordinate-proof.log` onto `unresolvedLinks`; a count or hash mismatch on any individual digest pushes the corresponding `resource-placement-coordinate-proof.placed/rejected/mismatch` link. This prevents a parity artifact from resolving while local coordinate placement evidence is unbound to exact live log identity.

**Type surface**

`RunInGameExactAuthorshipProof` gains an optional `resourcePlacement` field on the log entry. `ExactAuthorshipProofLike` gains a matching optional `resourcePlacement.coordinateProof` shape for parity proof consumption.

The existing `mq20rbzr` artifact predates the coordinate digest and remains open.