### PR TITLE
feat(surface-delta-context): add feature delta placement context with ecology-feature and natural-wonder offset classification

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -66,6 +66,28 @@ export type SurfaceDeltaContext = Readonly<{
   }>;
 }>;
 
+export type FeatureDeltaPlacementContext = SurfaceDeltaContext &
+  Readonly<{
+    key: "feature";
+    plotIndex: number;
+    pairedSameFeatureDelta: FeatureDeltaPairContext | null;
+    evidenceClass:
+      | "local-only-ecology-feature"
+      | "live-only-ecology-feature"
+      | "natural-wonder-offset-local-anchor"
+      | "natural-wonder-offset-live-anchor"
+      | "unclassified";
+  }>;
+
+export type FeatureDeltaPairContext = Readonly<{
+  x: number;
+  y: number;
+  plotIndex: number;
+  distance: number;
+  localFeature: Readonly<{ value: number | null; symbol: string }>;
+  liveFeature: Readonly<{ value: number | null; symbol: string }>;
+}>;
+
 export type ResourceDeltaPlacementContext = Readonly<{
   x: number;
   y: number;
@@ -257,6 +279,32 @@ export function buildSurfaceDeltaContexts(
   }
 
   return rows;
+}
+
+export function buildFeatureDeltaPlacementContexts(
+  proof: Pick<FinalSurfaceParityProof, "local" | "live">,
+  options: { maxRows?: number } = {}
+): ReadonlyArray<FeatureDeltaPlacementContext> {
+  const maxRows = options.maxRows ?? Number.POSITIVE_INFINITY;
+  const rows = buildSurfaceDeltaContexts(proof, { keys: ["feature"] }).map((row) => {
+    const plotIndex = row.y * proof.local.width + row.x;
+    return {
+      ...row,
+      key: "feature" as const,
+      plotIndex,
+      pairedSameFeatureDelta: null,
+      evidenceClass: "unclassified" as const,
+    };
+  });
+  const classified = rows.map((row) => {
+    const pairedSameFeatureDelta = findPairedFeatureDelta(row, rows, proof.local.width);
+    return {
+      ...row,
+      pairedSameFeatureDelta,
+      evidenceClass: classifyFeatureDelta(row, pairedSameFeatureDelta),
+    };
+  });
+  return classified.slice(0, maxRows);
 }
 
 export function buildResourceDeltaPlacementContexts(
@@ -471,6 +519,80 @@ function addFeatureSurfaceReasons(
   if (biomeRows?.length && !biomeRows.includes(context.biome ?? -1)) {
     reasons.push("feature.biome");
   }
+}
+
+function findPairedFeatureDelta(
+  row: FeatureDeltaPlacementContext,
+  rows: ReadonlyArray<FeatureDeltaPlacementContext>,
+  width: number
+): FeatureDeltaPairContext | null {
+  const featureType = row.local.value ?? row.live.value;
+  if (featureType === null || !isNaturalWonderFeature(featureType)) return null;
+  let best: FeatureDeltaPairContext | null = null;
+  for (const candidate of rows) {
+    if (candidate.plotIndex === row.plotIndex) continue;
+    const sameFeatureMovedFromLocal =
+      row.local.value === featureType &&
+      row.live.value === null &&
+      candidate.local.value === null &&
+      candidate.live.value === featureType;
+    const sameFeatureMovedFromLive =
+      row.local.value === null &&
+      row.live.value === featureType &&
+      candidate.local.value === featureType &&
+      candidate.live.value === null;
+    if (!sameFeatureMovedFromLocal && !sameFeatureMovedFromLive) continue;
+    const distance = hexDistanceOddQPeriodicX(row.plotIndex, candidate.plotIndex, width);
+    const pair = {
+      x: candidate.x,
+      y: candidate.y,
+      plotIndex: candidate.plotIndex,
+      distance,
+      localFeature: {
+        value: candidate.local.value,
+        symbol: candidate.local.symbol,
+      },
+      liveFeature: {
+        value: candidate.live.value,
+        symbol: candidate.live.symbol,
+      },
+    };
+    if (
+      best === null ||
+      pair.distance < best.distance ||
+      (pair.distance === best.distance && pair.plotIndex < best.plotIndex)
+    ) {
+      best = pair;
+    }
+  }
+  return best;
+}
+
+function classifyFeatureDelta(
+  row: FeatureDeltaPlacementContext,
+  pair: FeatureDeltaPairContext | null
+): FeatureDeltaPlacementContext["evidenceClass"] {
+  const localFeature = row.local.value;
+  const liveFeature = row.live.value;
+  const featureType = localFeature ?? liveFeature;
+  if (featureType === null) return "unclassified";
+  if (pair !== null && pair.distance <= 1 && isNaturalWonderFeature(featureType)) {
+    return localFeature === featureType
+      ? "natural-wonder-offset-local-anchor"
+      : "natural-wonder-offset-live-anchor";
+  }
+  if (localFeature !== null && liveFeature === null && !isNaturalWonderFeature(localFeature)) {
+    return "local-only-ecology-feature";
+  }
+  if (localFeature === null && liveFeature !== null && !isNaturalWonderFeature(liveFeature)) {
+    return "live-only-ecology-feature";
+  }
+  return "unclassified";
+}
+
+function isNaturalWonderFeature(featureType: number): boolean {
+  const policy = CIV7_BROWSER_TABLES_V0.featurePolicies[String(featureType)];
+  return typeof policy?.naturalWonderTiles === "number" && policy.naturalWonderTiles > 0;
 }
 
 function addResourceSurfaceReasons(

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { FinalSurfaceSnapshot } from "../../src/dev/diagnostics/live-parity";
 import {
+  buildFeatureDeltaPlacementContexts,
   buildResourceDeltaFeasibilityContexts,
   buildResourceDeltaPlacementContexts,
   buildSurfaceDeltaContext,
@@ -58,6 +59,60 @@ describe("surface delta context diagnostics", () => {
       local: { value: 3, symbol: "RESOURCE_FISH" },
       live: { value: null, symbol: "empty" },
     });
+  });
+
+  test("classifies feature deltas into reef absences and nearby natural-wonder offsets", () => {
+    const local = snapshot({
+      feature: { width: 3, height: 2, values: [11, 35, -1, -1, -1, 36] },
+    });
+    const live = snapshot({
+      feature: { width: 3, height: 2, values: [-1, -1, 35, -1, 36, -1] },
+    });
+
+    const rows = buildFeatureDeltaPlacementContexts({ local, live });
+
+    expect(rows).toHaveLength(5);
+    expect(rows[0]).toMatchObject({
+      x: 0,
+      y: 0,
+      local: { symbol: "FEATURE_COLD_REEF" },
+      live: { symbol: "empty" },
+      pairedSameFeatureDelta: null,
+      evidenceClass: "local-only-ecology-feature",
+    });
+    expect(rows[1]).toMatchObject({
+      x: 1,
+      y: 0,
+      local: { symbol: "FEATURE_KILIMANJARO" },
+      live: { symbol: "empty" },
+      pairedSameFeatureDelta: {
+        x: 2,
+        y: 0,
+        distance: 1,
+        liveFeature: { symbol: "FEATURE_KILIMANJARO" },
+      },
+      evidenceClass: "natural-wonder-offset-local-anchor",
+    });
+    expect(rows[2]).toMatchObject({
+      x: 2,
+      y: 0,
+      local: { symbol: "empty" },
+      live: { symbol: "FEATURE_KILIMANJARO" },
+      pairedSameFeatureDelta: {
+        x: 1,
+        y: 0,
+        distance: 1,
+        localFeature: { symbol: "FEATURE_KILIMANJARO" },
+      },
+      evidenceClass: "natural-wonder-offset-live-anchor",
+    });
+    expect(rows.map((row) => row.evidenceClass)).toEqual([
+      "local-only-ecology-feature",
+      "natural-wonder-offset-local-anchor",
+      "natural-wonder-offset-live-anchor",
+      "natural-wonder-offset-live-anchor",
+      "natural-wonder-offset-local-anchor",
+    ]);
   });
 
   test("checks static feature and resource surface legality against snapshot context", () => {

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -42,8 +42,10 @@
   the next exact-authored run.
 - [x] 2.19 Bind immediate resource placement coordinate proof into exact/parity
   proof intake.
-- [ ] 2.20 Repair remaining proven package or MapGen owners.
-- [ ] 2.21 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.20 Add feature delta context for ecology-feature and natural-wonder
+  offset classes.
+- [ ] 2.21 Repair remaining proven package or MapGen owners.
+- [ ] 2.22 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -596,6 +596,38 @@ prevents a fresh parity artifact from silently reusing local coordinate
 placement evidence without exact live log binding. The saved `mq20rbzr`
 artifact still predates this log proof and remains open.
 
+### Feature Delta Context
+
+Diagnostic context:
+`buildFeatureDeltaPlacementContexts` now groups feature mismatches into
+evidence classes without assigning repair ownership. The current feature
+context artifact is
+`/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-feature-delta-context.json`
+(`sha256:a4f78cb9987ecf773be2fef9f597c9a1a019292da95f8c70af274c5623c72363`),
+derived from exact-authored request `studio-run-in-game-mq20rbzr-1fhc`.
+
+Feature context rows:
+
+| Coordinate | Plot | Local feature | Live feature | Evidence class | Pair |
+|---|---:|---|---|---|---|
+| `(48,6)` | `684` | `FEATURE_COLD_REEF` | empty | `local-only-ecology-feature` | none |
+| `(48,13)` | `1426` | empty | `FEATURE_KILIMANJARO` | `natural-wonder-offset-live-anchor` | paired with `(49,13)`, distance `1` |
+| `(49,13)` | `1427` | `FEATURE_KILIMANJARO` | empty | `natural-wonder-offset-local-anchor` | paired with `(48,13)`, distance `1` |
+| `(51,21)` | `2277` | empty | `FEATURE_ZHANGJIAJIE` | `natural-wonder-offset-live-anchor` | paired with `(52,21)`, distance `1` |
+| `(52,21)` | `2278` | `FEATURE_ZHANGJIAJIE` | empty | `natural-wonder-offset-local-anchor` | paired with `(51,21)`, distance `1` |
+
+Disposition:
+the feature mismatch class is now split into one local-only ecology-feature
+absence and two same-feature natural-wonder one-tile offsets represented by
+four anchor rows. This is still diagnostic context only. The cold-reef row
+requires local feature-intent/application versus live `canHaveFeature` or
+engine-materialization proof before repair. The Kilimanjaro and Zhangjiajie
+rows require planned anchor/direction/footprint evidence and local-vs-live
+footprint materialization proof before accepting an engine-footprint
+disposition or changing natural-wonder placement. No feature repair, wonder
+footprint proof, parity closure, product acceptance, or mountain-quality claim
+is authorized from this context alone.
+
 ## Required Next Diagnostics
 
 - Extract local row context for every feature/resource mismatch: terrain,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,18 +5,18 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-coordinate-proof-intake-drain`
-  stacked above `codex/swooper-resource-coordinate-proof-drain`; this slice
-  carries exact/parity proof intake for immediate resource placement coordinate
-  identity.
+- Branch/Graphite stack: `codex/swooper-feature-delta-context-drain`
+  stacked above `codex/swooper-resource-coordinate-proof-intake-drain`; this
+  slice carries feature-delta source context for ecology-feature and
+  natural-wonder offset classes.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
   feasibility plus row/static-policy/live-plot, assignment-order, and
   ResourceBuilder diagnostic/subclassification/policy context plus
   assignment-class, distribution-count, same-resource position, local
-  materialization, future coordinate-proof instrumentation, and coordinate-proof
-  intake now narrow the next resource repair class.
+  materialization, future coordinate-proof instrumentation, coordinate-proof
+  intake, and feature-delta classification now narrow the next repair classes.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -325,6 +325,19 @@
   the exact log coordinate digest when local evidence carries one. Missing or
   mismatched coordinate proof keeps parity unresolved with named
   `resource-placement-coordinate-proof.*` links.
+- Feature delta context progress:
+  `mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts` now
+  classifies feature mismatch rows into bounded evidence classes. The current
+  feature context artifact is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-feature-delta-context.json`
+  (`sha256:a4f78cb9987ecf773be2fef9f597c9a1a019292da95f8c70af274c5623c72363`).
+  It splits the `5` feature mismatches into one local-only
+  `FEATURE_COLD_REEF` row and two same-feature one-tile natural-wonder offsets
+  (`FEATURE_KILIMANJARO` and `FEATURE_ZHANGJIAJIE`, each represented by local
+  and live anchor rows). This is classification context only: the reef row
+  still needs feature-intent/application versus live engine proof, and the
+  natural-wonder offsets still need planned anchor/direction/footprint proof
+  before repair ownership can be assigned.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -354,8 +367,11 @@
   No resource tuning, static-policy repair, scarce-floor repair, or
   assignment-order repair is authorized until a fresh exact-authored run binds
   local and live immediate placement coordinate identity or otherwise assigns
-  those subclasses to a concrete source owner. The single substitution row where
-  both probed values are infeasible remains an individual evidence row with no
-  repair authority until row-level context assigns source ownership.
+  those subclasses to a concrete source owner. Feature rows are now split into
+  a reef absence and two natural-wonder one-tile offsets, but no feature repair
+  is authorized until local intent/application and live materialization evidence
+  assigns ownership. The single substitution row where both probed values are
+  infeasible remains an individual evidence row with no repair authority until
+  row-level context assigns source ownership.
 - Stop condition: source authority is not known for any row outside the
   classified adjacent-land resource class.


### PR DESCRIPTION
Adds `buildFeatureDeltaPlacementContexts` to the surface delta diagnostics, which classifies feature mismatch rows into four bounded evidence classes:

- `local-only-ecology-feature` — feature present locally but absent in the live snapshot, and not a natural wonder
- `live-only-ecology-feature` — feature present in the live snapshot but absent locally, and not a natural wonder
- `natural-wonder-offset-local-anchor` — natural wonder feature present locally but absent in the live snapshot, with a matching live-side delta within one tile
- `natural-wonder-offset-live-anchor` — natural wonder feature present in the live snapshot but absent locally, with a matching local-side delta within one tile

The pairing logic (`findPairedFeatureDelta`) finds the closest same-feature delta row for natural wonder features using hex distance, breaking ties by plot index. Classification is determined by `classifyFeatureDelta`, which checks whether the feature is a natural wonder via `featurePolicies.naturalWonderTiles`.

Applied to the `mq20rbzr-1fhc` artifact, this splits the five feature mismatches into one `FEATURE_COLD_REEF` local-only absence and two same-feature one-tile offsets for `FEATURE_KILIMANJARO` and `FEATURE_ZHANGJIAJIE`. This is classification context only — no feature repair, wonder footprint proof, or parity closure is authorized from this output alone.