### PR TITLE
feat(swooper-diagnostics): add local feature-intent and natural-wonder footprint evidence joins to feature delta contexts

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -16,6 +16,7 @@ import type { TraceEvent, TraceSink } from "@swooper/mapgen-core/trace";
 import { canonicalRecipeConfig, isPlainObject as isCanonicalMapConfigObject } from "../../maps/configs/canonical.js";
 import standardRecipe from "../../recipes/standard/recipe.js";
 import { initializeStandardRuntime } from "../../recipes/standard/runtime.js";
+import { ecologyArtifacts } from "../../recipes/standard/stages/ecology/artifacts.js";
 import { placementArtifacts } from "../../recipes/standard/stages/placement/artifacts.js";
 import { isPlainObject, mergeDeep } from "./shared.js";
 
@@ -174,6 +175,10 @@ type FileIdentityLike = Readonly<{
 
 type LocalTraceEvidence = {
   placementParity?: unknown;
+  featureIntents?: unknown;
+  featureApplyDiagnostics?: unknown;
+  naturalWonderPlan?: unknown;
+  naturalWonderPlacement?: unknown;
   resourcePlan?: unknown;
   resourcePlacementOutcomes?: unknown;
 };
@@ -265,6 +270,21 @@ export function runLocalFinalSurfaceSnapshot(input: RunLocalFinalSurfaceInput): 
     if (event.kind !== "step.event" || !isPlainObject(event.data)) continue;
     if (event.data.type === "placement.parity") evidence.placementParity = event.data;
   }
+  evidence.featureIntents = {
+    vegetation: context.artifacts.get(ecologyArtifacts.featureIntentsVegetation.id),
+    wetlands: context.artifacts.get(ecologyArtifacts.featureIntentsWetlands.id),
+    floodplains: context.artifacts.get(ecologyArtifacts.featureIntentsFloodplains.id),
+    reefs: context.artifacts.get(ecologyArtifacts.featureIntentsReefs.id),
+    ice: context.artifacts.get(ecologyArtifacts.featureIntentsIce.id),
+  };
+  const featureApplyDiagnostics = context.artifacts.get(ecologyArtifacts.featureApplyDiagnostics.id);
+  if (featureApplyDiagnostics !== undefined) {
+    evidence.featureApplyDiagnostics = featureApplyDiagnostics;
+  }
+  const naturalWonderPlan = context.artifacts.get(placementArtifacts.naturalWonderPlan.id);
+  if (naturalWonderPlan !== undefined) evidence.naturalWonderPlan = naturalWonderPlan;
+  const naturalWonderPlacement = context.artifacts.get(placementArtifacts.naturalWonderPlacement.id);
+  if (naturalWonderPlacement !== undefined) evidence.naturalWonderPlacement = naturalWonderPlacement;
   const resourcePlan = context.artifacts.get(placementArtifacts.resourcePlan.id);
   if (resourcePlan !== undefined) evidence.resourcePlan = resourcePlan;
   const resourcePlacementOutcomes = context.artifacts.get(

--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -1,5 +1,6 @@
 import {
   CIV7_BROWSER_TABLES_V0,
+  getNaturalWonderFootprintIndices,
   isResourceAdjacentToLandRuntimeOptional,
 } from "@civ7/map-policy";
 import { hexDistanceOddQPeriodicX } from "@swooper/mapgen-core/lib/grid";
@@ -70,6 +71,8 @@ export type FeatureDeltaPlacementContext = SurfaceDeltaContext &
   Readonly<{
     key: "feature";
     plotIndex: number;
+    localFeatureIntent: FeatureIntentContext | null;
+    naturalWonderFootprint: NaturalWonderFootprintContext | null;
     pairedSameFeatureDelta: FeatureDeltaPairContext | null;
     evidenceClass:
       | "local-only-ecology-feature"
@@ -86,6 +89,23 @@ export type FeatureDeltaPairContext = Readonly<{
   distance: number;
   localFeature: Readonly<{ value: number | null; symbol: string }>;
   liveFeature: Readonly<{ value: number | null; symbol: string }>;
+}>;
+
+export type FeatureIntentContext = Readonly<{
+  family: string;
+  feature: string;
+  weight: number | null;
+}>;
+
+export type NaturalWonderFootprintContext = Readonly<{
+  anchorPlotIndex: number;
+  anchorX: number;
+  anchorY: number;
+  featureType: number;
+  featureSymbol: string;
+  direction: number;
+  priority: number | null;
+  footprintDistanceFromAnchor: number;
 }>;
 
 export type ResourceDeltaPlacementContext = Readonly<{
@@ -286,12 +306,16 @@ export function buildFeatureDeltaPlacementContexts(
   options: { maxRows?: number } = {}
 ): ReadonlyArray<FeatureDeltaPlacementContext> {
   const maxRows = options.maxRows ?? Number.POSITIVE_INFINITY;
+  const featureIntents = readFeatureIntentEvidence(proof.local);
+  const naturalWonderFootprints = readNaturalWonderFootprintEvidence(proof.local);
   const rows = buildSurfaceDeltaContexts(proof, { keys: ["feature"] }).map((row) => {
     const plotIndex = row.y * proof.local.width + row.x;
     return {
       ...row,
       key: "feature" as const,
       plotIndex,
+      localFeatureIntent: featureIntents.byPlot.get(plotIndex) ?? null,
+      naturalWonderFootprint: naturalWonderFootprints.byPlot.get(plotIndex) ?? null,
       pairedSameFeatureDelta: null,
       evidenceClass: "unclassified" as const,
     };
@@ -593,6 +617,74 @@ function classifyFeatureDelta(
 function isNaturalWonderFeature(featureType: number): boolean {
   const policy = CIV7_BROWSER_TABLES_V0.featurePolicies[String(featureType)];
   return typeof policy?.naturalWonderTiles === "number" && policy.naturalWonderTiles > 0;
+}
+
+function readFeatureIntentEvidence(snapshot: FinalSurfaceSnapshot): {
+  byPlot: ReadonlyMap<number, FeatureIntentContext>;
+} {
+  const byPlot = new Map<number, FeatureIntentContext>();
+  const evidence = snapshot.evidence;
+  const featureIntents = isRecord(evidence) ? evidence.featureIntents : undefined;
+  if (!isRecord(featureIntents)) return { byPlot };
+  for (const [family, rawIntents] of Object.entries(featureIntents)) {
+    if (!Array.isArray(rawIntents)) continue;
+    for (const rawIntent of rawIntents) {
+      if (!isRecord(rawIntent)) continue;
+      const x = finiteInteger(rawIntent.x);
+      const y = finiteInteger(rawIntent.y);
+      const feature = stringValue(rawIntent.feature);
+      if (x === null || y === null || feature === null) continue;
+      if (x < 0 || x >= snapshot.width || y < 0 || y >= snapshot.height) continue;
+      const plotIndex = y * snapshot.width + x;
+      byPlot.set(plotIndex, {
+        family,
+        feature,
+        weight: numberValue(rawIntent.weight),
+      });
+    }
+  }
+  return { byPlot };
+}
+
+function readNaturalWonderFootprintEvidence(snapshot: FinalSurfaceSnapshot): {
+  byPlot: ReadonlyMap<number, NaturalWonderFootprintContext>;
+} {
+  const byPlot = new Map<number, NaturalWonderFootprintContext>();
+  const evidence = snapshot.evidence;
+  const naturalWonderPlan = isRecord(evidence) ? evidence.naturalWonderPlan : undefined;
+  const placements = isRecord(naturalWonderPlan) && Array.isArray(naturalWonderPlan.placements)
+    ? naturalWonderPlan.placements
+    : [];
+  for (const rawPlacement of placements) {
+    if (!isRecord(rawPlacement)) continue;
+    const anchorPlotIndex = finiteInteger(rawPlacement.plotIndex);
+    const featureType = finiteInteger(rawPlacement.featureType);
+    const direction = finiteInteger(rawPlacement.direction);
+    if (anchorPlotIndex === null || featureType === null || direction === null) continue;
+    const anchorY = Math.floor(anchorPlotIndex / snapshot.width);
+    const anchorX = anchorPlotIndex - anchorY * snapshot.width;
+    const footprint = getNaturalWonderFootprintIndices({
+      x: anchorX,
+      y: anchorY,
+      width: snapshot.width,
+      height: snapshot.height,
+      policy: CIV7_BROWSER_TABLES_V0.featurePolicies[String(featureType)] ?? {},
+      direction,
+    }) ?? [anchorPlotIndex];
+    for (const plotIndex of footprint) {
+      byPlot.set(plotIndex, {
+        anchorPlotIndex,
+        anchorX,
+        anchorY,
+        featureType,
+        featureSymbol: symbolFor("feature", featureType),
+        direction,
+        priority: numberValue(rawPlacement.priority),
+        footprintDistanceFromAnchor: hexDistanceOddQPeriodicX(anchorPlotIndex, plotIndex, snapshot.width),
+      });
+    }
+  }
+  return { byPlot };
 }
 
 function addResourceSurfaceReasons(
@@ -914,6 +1006,14 @@ function resourceFeasibilityCellKey(x: number, y: number, plotIndex: number): st
 
 function finiteInteger(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : null;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -64,6 +64,21 @@ describe("surface delta context diagnostics", () => {
   test("classifies feature deltas into reef absences and nearby natural-wonder offsets", () => {
     const local = snapshot({
       feature: { width: 3, height: 2, values: [11, 35, -1, -1, -1, 36] },
+    }, {
+      featureIntents: {
+        reefs: [{ x: 0, y: 0, feature: "FEATURE_COLD_REEF", weight: 0.8 }],
+      },
+      naturalWonderPlan: {
+        width: 3,
+        height: 2,
+        wondersCount: 2,
+        targetCount: 2,
+        plannedCount: 2,
+        placements: [
+          { plotIndex: 1, featureType: 35, direction: 0, elevation: 1000, priority: 0.9 },
+          { plotIndex: 5, featureType: 36, direction: 0, elevation: 900, priority: 0.8 },
+        ],
+      },
     });
     const live = snapshot({
       feature: { width: 3, height: 2, values: [-1, -1, 35, -1, 36, -1] },
@@ -78,6 +93,11 @@ describe("surface delta context diagnostics", () => {
       local: { symbol: "FEATURE_COLD_REEF" },
       live: { symbol: "empty" },
       pairedSameFeatureDelta: null,
+      localFeatureIntent: {
+        family: "reefs",
+        feature: "FEATURE_COLD_REEF",
+        weight: 0.8,
+      },
       evidenceClass: "local-only-ecology-feature",
     });
     expect(rows[1]).toMatchObject({
@@ -85,6 +105,11 @@ describe("surface delta context diagnostics", () => {
       y: 0,
       local: { symbol: "FEATURE_KILIMANJARO" },
       live: { symbol: "empty" },
+      naturalWonderFootprint: {
+        anchorPlotIndex: 1,
+        featureSymbol: "FEATURE_KILIMANJARO",
+        priority: 0.9,
+      },
       pairedSameFeatureDelta: {
         x: 2,
         y: 0,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -44,8 +44,10 @@
   proof intake.
 - [x] 2.20 Add feature delta context for ecology-feature and natural-wonder
   offset classes.
-- [ ] 2.21 Repair remaining proven package or MapGen owners.
-- [ ] 2.22 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.21 Add local feature/natural-wonder evidence context for feature delta
+  classes.
+- [ ] 2.22 Repair remaining proven package or MapGen owners.
+- [ ] 2.23 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -628,6 +628,46 @@ disposition or changing natural-wonder placement. No feature repair, wonder
 footprint proof, parity closure, product acceptance, or mountain-quality claim
 is authorized from this context alone.
 
+### Feature Local Evidence Context
+
+Diagnostic repair:
+`runLocalFinalSurfaceSnapshot` now exports the local feature-intent families,
+feature-apply diagnostics, natural-wonder plan, and natural-wonder placement
+stats from existing schema-backed artifacts. `buildFeatureDeltaPlacementContexts`
+joins that local evidence to feature mismatch rows when it is present, while
+remaining compatible with older proof files that lack it.
+
+The current local-evidence artifact is
+`/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-feature-local-evidence-context.json`
+(`sha256:729cc1d2c3b080177b524293991ceff8b7bc312796dac31a8e59053cda7f1c45`).
+It is a local exact-source rerun joined to the saved live grid from request
+`studio-run-in-game-mq20rbzr-1fhc`; it is not a fresh exact-authored live
+parity proof.
+
+Feature local evidence facts:
+
+| Fact | Value | Boundary |
+|---|---:|---|
+| Feature apply attempted / applied / rejected | `1501 / 1501 / 0` | Local exact-source rerun only. |
+| `FEATURE_COLD_REEF` applied locally | `55` | Includes the local-only row `(48,6)`. |
+| Natural wonders planned / placed / rejected | `7 / 7 / 0` | Local exact-source rerun only. |
+| Local `FEATURE_KILIMANJARO` row `(49,13)` | planned footprint, anchor plot `1320`, distance `2` | Live anchor `(48,13)` still needs live footprint/materialization proof. |
+| Local `FEATURE_ZHANGJIAJIE` row `(52,21)` | planned footprint, anchor plot `2171`, distance `1` | Live anchor `(51,21)` still needs live footprint/materialization proof. |
+
+Disposition:
+the cold-reef mismatch is now proven to be a local planned-and-applied ecology
+feature on the exact source snapshot, with no local feature-apply rejection.
+The remaining source-owner question is whether live Civ materialization or live
+readback removed/omitted that feature, or whether the local mock feature
+eligibility diverges from Civ live `canHaveFeature` for that exact tile. The
+two natural-wonder mismatch pairs are now proven to touch locally planned
+natural-wonder footprints, but the live grid has the same feature one tile away
+from the local footprint row. That keeps ownership unresolved between planned
+anchor/direction/footprint semantics, local mock stamping, Civ live
+materialization policy, or readback semantics. No feature repair, natural-wonder
+repair, parity closure, product acceptance, or mountain-quality claim is
+authorized from this local evidence alone.
+
 ## Required Next Diagnostics
 
 - Extract local row context for every feature/resource mismatch: terrain,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,10 +5,9 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-feature-delta-context-drain`
-  stacked above `codex/swooper-resource-coordinate-proof-intake-drain`; this
-  slice carries feature-delta source context for ecology-feature and
-  natural-wonder offset classes.
+- Branch/Graphite stack: `codex/swooper-feature-local-evidence-drain`
+  stacked above `codex/swooper-feature-delta-context-drain`; this slice carries
+  local feature/natural-wonder evidence joins for feature-delta classes.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
@@ -16,7 +15,8 @@
   ResourceBuilder diagnostic/subclassification/policy context plus
   assignment-class, distribution-count, same-resource position, local
   materialization, future coordinate-proof instrumentation, coordinate-proof
-  intake, and feature-delta classification now narrow the next repair classes.
+  intake, feature-delta classification, and local feature/wonder evidence joins
+  now narrow the next repair classes.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -338,6 +338,22 @@
   still needs feature-intent/application versus live engine proof, and the
   natural-wonder offsets still need planned anchor/direction/footprint proof
   before repair ownership can be assigned.
+- Feature local evidence context progress:
+  `runLocalFinalSurfaceSnapshot` now exports local feature intent families,
+  feature-apply diagnostics, natural-wonder plan, and natural-wonder placement
+  stats from existing artifacts, and the feature delta diagnostic joins that
+  evidence when present. The current local-evidence artifact is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-feature-local-evidence-context.json`
+  (`sha256:729cc1d2c3b080177b524293991ceff8b7bc312796dac31a8e59053cda7f1c45`).
+  It is a local exact-source rerun joined to the saved live grid, not a fresh
+  exact-authored live parity proof. It proves local feature apply attempted and
+  applied `1501/1501` rows with `0` rejections; local `FEATURE_COLD_REEF`
+  applied count is `55`; natural wonders planned/placed/rejected are `7/7/0`.
+  The local cold-reef delta row `(48,6)` has a local reef intent; the local
+  `FEATURE_KILIMANJARO` and `FEATURE_ZHANGJIAJIE` mismatch anchors are within
+  planned local natural-wonder footprints. This narrows, but does not close,
+  feature ownership: live `canHaveFeature`/materialization/readback evidence is
+  still required before repair authority.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -368,8 +384,9 @@
   assignment-order repair is authorized until a fresh exact-authored run binds
   local and live immediate placement coordinate identity or otherwise assigns
   those subclasses to a concrete source owner. Feature rows are now split into
-  a reef absence and two natural-wonder one-tile offsets, but no feature repair
-  is authorized until local intent/application and live materialization evidence
+  a reef absence and two natural-wonder one-tile offsets, with local intent,
+  application, and footprint evidence now attached. No feature repair is
+  authorized until live feature feasibility/materialization/readback evidence
   assigns ownership. The single substitution row where both probed values are
   infeasible remains an individual evidence row with no repair authority until
   row-level context assigns source ownership.


### PR DESCRIPTION
Extends the live parity diagnostic snapshot and feature delta classification to include local feature intent and natural wonder evidence.

`runLocalFinalSurfaceSnapshot` now exports feature intent families (vegetation, wetlands, floodplains, reefs, ice), feature-apply diagnostics, natural wonder plan, and natural wonder placement stats from existing ecology and placement artifacts. `buildFeatureDeltaPlacementContexts` joins that evidence to each feature mismatch row via two new context fields: `localFeatureIntent` (family, feature symbol, weight) and `naturalWonderFootprint` (anchor plot, direction, priority, footprint distance from anchor). The natural wonder footprint is computed using `getNaturalWonderFootprintIndices` against the local snapshot dimensions and feature policy, covering all plots in the wonder's footprint rather than only the anchor.

Both readers degrade gracefully when evidence fields are absent, keeping the diagnostic compatible with older proof files. Helper functions `numberValue` and `stringValue` are extracted to support the new evidence parsing alongside the existing `finiteInteger`.

Tests are updated to supply `featureIntents` and `naturalWonderPlan` evidence in the snapshot fixture and assert the new context fields on the resulting delta rows.