### PR TITLE
feat(earthlike-legality-repair): add runtime-bound feature feasibility readback via `getCiv7FeaturePlacementFeasibility` and `verify:feature-delta-feasibility`

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -46,8 +46,10 @@
   offset classes.
 - [x] 2.21 Add local feature/natural-wonder evidence context for feature delta
   classes.
-- [ ] 2.22 Repair remaining proven package or MapGen owners.
-- [ ] 2.23 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.22 Add runtime-bound feature feasibility readback for feature delta
+  classes.
+- [ ] 2.23 Repair remaining proven package or MapGen owners.
+- [ ] 2.24 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -668,6 +668,46 @@ materialization policy, or readback semantics. No feature repair, natural-wonder
 repair, parity closure, product acceptance, or mountain-quality claim is
 authorized from this local evidence alone.
 
+### Feature Live Feasibility Readback
+
+Diagnostic repair:
+`@civ7/direct-control` now exposes a package-owned
+`getCiv7FeaturePlacementFeasibility` wrapper over
+`TerrainBuilder.canHaveFeature`, and the root verifier
+`verify:feature-delta-feasibility` binds feature probes to the saved
+exact-authored parity proof before reading the live runtime.
+
+The current feature feasibility artifact is
+`/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-feature-delta-feasibility.json`
+(`sha256:abaff5fe8bcb09fa2e66e95dc640645f4cf59e80d68bddcbba0921e394fbf0a1`,
+`proofHash:ed60244c6ea6548dbf7ff43ea154c38e4276d1ebd5b909860577f6f81c59ea01`).
+It is bound to request `studio-run-in-game-mq20rbzr-1fhc`, saved proof hash
+`f7d91ad72a6c998926fa24fd82266388420de99dbe338bf7d627448a760fe1ba`,
+local-context hash
+`945a49133d0493cc37cf28ff805637aaf5fc7032a6b3461b805a65ff8a861657`, and
+matched live runtime identity `106x66`, `6996` plots, seed `138503614`, turn
+`1`, game hash `0`. It probed all `5` feature delta cells with `0` omitted
+cells and joined the prior local feature/natural-wonder evidence by plot index.
+
+Feature feasibility facts:
+
+| Class | Count | Evidence |
+|---|---:|---|
+| `local-feature-civ-infeasible-live-empty` | `1` | Local `FEATURE_COLD_REEF` at `(48,6)` has local reef intent, but current live `TerrainBuilder.canHaveFeature(48,6,FEATURE_COLD_REEF)` returns `false`. |
+| `natural-wonder-offset-local-civ-infeasible` | `2` | Local natural-wonder footprint cells `(49,13)` / `(52,21)` return `false` for the local wonder feature. |
+| `natural-wonder-offset-live-civ-infeasible` | `2` | Live natural-wonder cells `(48,13)` / `(51,21)` also return `false` for the live wonder feature even though the live grid contains that feature. |
+
+Disposition:
+the feature rows now have runtime-bound `TerrainBuilder.canHaveFeature`
+evidence, but this is post-materialization readback. Because the live
+natural-wonder cells that already contain the feature also return false, the
+probe is not a clean pre-placement acceptance oracle and cannot by itself prove
+that the local cells were invalid at materialization time. The evidence narrows
+the next owner question to materialization-time feature stamping, natural-wonder
+footprint/anchor semantics, runtime state, or readback policy. It does not
+authorize feature repair, natural-wonder repair, parity closure, product
+acceptance, or mountain-quality claims.
+
 ## Required Next Diagnostics
 
 - Extract local row context for every feature/resource mismatch: terrain,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,9 +5,10 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-feature-local-evidence-drain`
-  stacked above `codex/swooper-feature-delta-context-drain`; this slice carries
-  local feature/natural-wonder evidence joins for feature-delta classes.
+- Branch/Graphite stack: `codex/swooper-feature-feasibility-readback-drain`
+  stacked above `codex/swooper-feature-local-evidence-drain`; this slice
+  carries package-owned live feature feasibility readback for feature-delta
+  classes.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
@@ -15,8 +16,8 @@
   ResourceBuilder diagnostic/subclassification/policy context plus
   assignment-class, distribution-count, same-resource position, local
   materialization, future coordinate-proof instrumentation, coordinate-proof
-  intake, feature-delta classification, and local feature/wonder evidence joins
-  now narrow the next repair classes.
+  intake, feature-delta classification, local feature/wonder evidence joins, and
+  feature feasibility readback now narrow the next repair classes.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -354,6 +355,32 @@
   planned local natural-wonder footprints. This narrows, but does not close,
   feature ownership: live `canHaveFeature`/materialization/readback evidence is
   still required before repair authority.
+- Feature live feasibility readback progress:
+  `@civ7/direct-control` now has a package-owned
+  `getCiv7FeaturePlacementFeasibility` wrapper over
+  `TerrainBuilder.canHaveFeature`, and
+  `scripts/civ7-direct-control/verify-feature-delta-feasibility.ts` binds that
+  readback to the saved exact-authored parity proof before probing. The current
+  artifact is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-feature-delta-feasibility.json`
+  (`sha256:abaff5fe8bcb09fa2e66e95dc640645f4cf59e80d68bddcbba0921e394fbf0a1`,
+  `proofHash:ed60244c6ea6548dbf7ff43ea154c38e4276d1ebd5b909860577f6f81c59ea01`).
+  It resolves request identity to `studio-run-in-game-mq20rbzr-1fhc` and
+  matches current runtime identity to the saved proof at `106x66`, `6996`
+  plots, seed `138503614`, turn `1`, and game hash `0`. It probes the `5`
+  feature delta cells with `0` omitted cells and joins the prior local
+  feature-context artifact (`sourceContextHash:
+  945a49133d0493cc37cf28ff805637aaf5fc7032a6b3461b805a65ff8a861657`). All
+  probed candidate values return `TerrainBuilder.canHaveFeature=false`: the
+  local-only cold-reef row is `local-feature-civ-infeasible-live-empty`, and
+  the two natural-wonder one-tile offset pairs split into two
+  `natural-wonder-offset-local-civ-infeasible` and two
+  `natural-wonder-offset-live-civ-infeasible` rows. Because the readback is
+  post-materialization and the live natural-wonder cells also return false, it
+  is not a clean pre-placement acceptance oracle. It narrows the feature owner
+  question toward runtime materialization state, natural-wonder stamping
+  semantics, or readback policy, but it still does not authorize feature,
+  natural-wonder, terrain, parity, product, or tuning repair.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -385,10 +412,12 @@
   local and live immediate placement coordinate identity or otherwise assigns
   those subclasses to a concrete source owner. Feature rows are now split into
   a reef absence and two natural-wonder one-tile offsets, with local intent,
-  application, and footprint evidence now attached. No feature repair is
-  authorized until live feature feasibility/materialization/readback evidence
-  assigns ownership. The single substitution row where both probed values are
-  infeasible remains an individual evidence row with no repair authority until
-  row-level context assigns source ownership.
+  application, footprint evidence, and runtime-bound `canHaveFeature` probes
+  now attached. Since post-materialization `canHaveFeature=false` also applies
+  to the live natural-wonder cells that contain those features, no feature
+  repair is authorized until materialization/readback evidence assigns
+  ownership beyond the post-state feasibility caveat. The single substitution
+  row where both probed values are infeasible remains an individual evidence row
+  with no repair authority until row-level context assigns source ownership.
 - Stop condition: source authority is not known for any row outside the
   classified adjacent-land resource class.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "verify:studio-run-in-game:live": "bun scripts/civ7-direct-control/verify-studio-run-in-game-live.ts",
     "verify:final-surface-parity": "bun scripts/civ7-direct-control/verify-final-surface-parity.ts",
     "verify:resource-delta-feasibility": "bun scripts/civ7-direct-control/verify-resource-delta-feasibility.ts",
+    "verify:feature-delta-feasibility": "bun scripts/civ7-direct-control/verify-feature-delta-feasibility.ts",
     "build:mapgen": "turbo run build --filter=@swooper/mapgen-core",
     "lint:adapter-boundary": "./scripts/lint/lint-adapter-boundary.sh",
     "lint:domain-refactor-guardrails": "./scripts/lint/lint-domain-refactor-guardrails.sh",

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -147,6 +147,10 @@ export const DEFAULT_CIV7_RESOURCE_FEASIBILITY_MAX_CELLS = 256;
 export const HARD_CIV7_RESOURCE_FEASIBILITY_MAX_CELLS = 1_000;
 export const DEFAULT_CIV7_RESOURCE_FEASIBILITY_MAX_TYPES_PER_CELL = 64;
 export const HARD_CIV7_RESOURCE_FEASIBILITY_MAX_TYPES_PER_CELL = 256;
+export const DEFAULT_CIV7_FEATURE_FEASIBILITY_MAX_CELLS = 256;
+export const HARD_CIV7_FEATURE_FEASIBILITY_MAX_CELLS = 1_000;
+export const DEFAULT_CIV7_FEATURE_FEASIBILITY_MAX_TYPES_PER_CELL = 64;
+export const HARD_CIV7_FEATURE_FEASIBILITY_MAX_TYPES_PER_CELL = 256;
 export const DEFAULT_CIV7_GAMEINFO_LIMIT = 100;
 export const HARD_CIV7_GAMEINFO_LIMIT = 1_000;
 export const DEFAULT_CIV7_ROOT_MAX_KEYS = 100;
@@ -493,6 +497,34 @@ export type Civ7ResourcePlacementFeasibilityResult = Readonly<{
   omittedCells: number;
   ignoreWeight: boolean;
   cells: ReadonlyArray<Civ7ResourcePlacementFeasibilityCell>;
+}>;
+
+export type Civ7FeaturePlacementFeasibilityCellInput = Readonly<Civ7MapLocation & {
+  featureTypes: ReadonlyArray<number>;
+}>;
+
+export type Civ7FeaturePlacementFeasibilityInput = Readonly<{
+  cells: ReadonlyArray<Civ7FeaturePlacementFeasibilityCellInput>;
+  maxCells?: number;
+  maxFeatureTypesPerCell?: number;
+}>;
+
+export type Civ7FeaturePlacementFeasibilityCell = Readonly<{
+  location: Readonly<Civ7MapLocation & {
+    index: Civ7RuntimeProbe<number>;
+  }>;
+  featureTypes: ReadonlyArray<number>;
+  omittedFeatureTypes: number;
+  feasibility: Readonly<Record<string, Civ7RuntimeProbe<boolean>>>;
+}>;
+
+export type Civ7FeaturePlacementFeasibilityResult = Readonly<{
+  host: string;
+  port: number;
+  state: Civ7TunerState;
+  cellCount: number;
+  omittedCells: number;
+  cells: ReadonlyArray<Civ7FeaturePlacementFeasibilityCell>;
 }>;
 
 export type Civ7ResourceBuilderCutResource = Readonly<{
@@ -1777,6 +1809,41 @@ export async function getCiv7ResourcePlacementFeasibility(
   return jsonPayloadFromCommandResult<Civ7ResourcePlacementFeasibilityResult>(
     result,
     "Civ7 resource placement feasibility",
+  );
+}
+
+export async function getCiv7FeaturePlacementFeasibility(
+  input: Civ7FeaturePlacementFeasibilityInput,
+  options: Civ7DirectControlOptions = {},
+): Promise<Civ7FeaturePlacementFeasibilityResult> {
+  const maxCells = boundedInteger(
+    input.maxCells ?? DEFAULT_CIV7_FEATURE_FEASIBILITY_MAX_CELLS,
+    1,
+    HARD_CIV7_FEATURE_FEASIBILITY_MAX_CELLS,
+    "maxCells",
+  );
+  const maxFeatureTypesPerCell = boundedInteger(
+    input.maxFeatureTypesPerCell ?? DEFAULT_CIV7_FEATURE_FEASIBILITY_MAX_TYPES_PER_CELL,
+    1,
+    HARD_CIV7_FEATURE_FEASIBILITY_MAX_TYPES_PER_CELL,
+    "maxFeatureTypesPerCell",
+  );
+  validateFeaturePlacementFeasibilityInput(input, maxCells, maxFeatureTypesPerCell);
+  const result = await executeCiv7TunerCommand({
+    ...options,
+    command: buildFeaturePlacementFeasibilityCommand({
+      cells: input.cells.slice(0, maxCells).map((cell) => ({
+        ...cell,
+        featureTypes: cell.featureTypes.slice(0, maxFeatureTypesPerCell),
+        requestedFeatureTypeCount: cell.featureTypes.length,
+      })),
+      requestedCellCount: input.cells.length,
+      maxFeatureTypesPerCell,
+    }),
+  });
+  return jsonPayloadFromCommandResult<Civ7FeaturePlacementFeasibilityResult>(
+    result,
+    "Civ7 feature placement feasibility",
   );
 }
 
@@ -3219,6 +3286,48 @@ function buildResourcePlacementFeasibilityCommand(input: {
   })()`;
 }
 
+function buildFeaturePlacementFeasibilityCommand(input: {
+  cells: ReadonlyArray<Civ7FeaturePlacementFeasibilityCellInput & {
+    requestedFeatureTypeCount: number;
+  }>;
+  requestedCellCount: number;
+  maxFeatureTypesPerCell: number;
+}): string {
+  return `(() => {
+    ${probeHelperSource()}
+    const input = ${jsLiteral(input)};
+    const tb = typeof TerrainBuilder !== "undefined" ? TerrainBuilder : undefined;
+    const canHaveFeature = (x, y, featureType) => {
+      if (!tb || typeof tb.canHaveFeature !== "function") {
+        throw new Error("TerrainBuilder.canHaveFeature is unavailable");
+      }
+      return tb.canHaveFeature(x, y, featureType);
+    };
+    const readFeaturePlacementFeasibility = (cell) => {
+      const featureTypes = cell.featureTypes.slice(0, input.maxFeatureTypesPerCell);
+      const feasibility = {};
+      for (const featureType of featureTypes) {
+        feasibility[String(featureType)] = probe(() => canHaveFeature(cell.x, cell.y, featureType));
+      }
+      return {
+        location: {
+          x: cell.x,
+          y: cell.y,
+          index: probe(() => GameplayMap.getIndexFromXY(cell.x, cell.y)),
+        },
+        featureTypes,
+        omittedFeatureTypes: Math.max(0, (cell.requestedFeatureTypeCount ?? featureTypes.length) - featureTypes.length),
+        feasibility,
+      };
+    };
+    return JSON.stringify({
+      cellCount: input.requestedCellCount,
+      omittedCells: Math.max(0, input.requestedCellCount - input.cells.length),
+      cells: input.cells.map((cell) => readFeaturePlacementFeasibility(cell)),
+    });
+  })()`;
+}
+
 function buildResourceBuilderDiagnosticsCommand(input: {
   cells: ReadonlyArray<Civ7ResourcePlacementFeasibilityCellInput & {
     requestedResourceTypeCount: number;
@@ -4251,6 +4360,18 @@ const STATIC_CIV7_CAPABILITY_ENTRIES: ReadonlyArray<Civ7CapabilityCatalogEntry> 
     description: "Reads bounded per-cell resource feasibility and ResourceBuilder cut/count diagnostics for parity/source-authority diagnostics without mutating the map.",
   },
   {
+    id: "wrapper.feature-placement-feasibility",
+    name: "Feature Placement Feasibility",
+    role: "tuner",
+    kind: "read-wrapper",
+    owner: "@civ7/direct-control",
+    risk: "read",
+    provenance: ["TerrainBuilder.canHaveFeature", "GameplayMap"],
+    wrapper: "getCiv7FeaturePlacementFeasibility",
+    confidence: "source",
+    description: "Reads bounded per-cell feature feasibility for parity/source-authority diagnostics without mutating the map.",
+  },
+  {
     id: "wrapper.autoplay",
     name: "Autoplay Control",
     role: "app-ui",
@@ -4355,6 +4476,48 @@ function validateResourcePlacementFeasibilityInput(
     }
     for (const resourceType of cell.resourceTypes.slice(0, maxResourceTypesPerCell)) {
       boundedInteger(resourceType, 0, 1_000_000, "resourceType");
+    }
+  }
+}
+
+function validateFeaturePlacementFeasibilityInput(
+  input: Civ7FeaturePlacementFeasibilityInput,
+  maxCells: number,
+  maxFeatureTypesPerCell: number,
+): void {
+  if (!Array.isArray(input.cells) || input.cells.length === 0) {
+    throw new Civ7DirectControlError(
+      "command-failed",
+      "Feature placement feasibility reads require at least one cell",
+    );
+  }
+  if (input.cells.length > HARD_CIV7_FEATURE_FEASIBILITY_MAX_CELLS) {
+    throw new Civ7DirectControlError(
+      "command-failed",
+      `Feature placement feasibility cell lists must not exceed ${HARD_CIV7_FEATURE_FEASIBILITY_MAX_CELLS} entries`,
+    );
+  }
+  for (const cell of input.cells.slice(0, maxCells)) {
+    validateMapLocation(cell);
+    if (!Array.isArray(cell.featureTypes) || cell.featureTypes.length === 0) {
+      throw new Civ7DirectControlError(
+        "command-failed",
+        "Feature placement feasibility cells require at least one feature type",
+      );
+    }
+    if (cell.featureTypes.length > HARD_CIV7_FEATURE_FEASIBILITY_MAX_TYPES_PER_CELL) {
+      throw new Civ7DirectControlError(
+        "command-failed",
+        `Feature placement feasibility feature type lists must not exceed ${HARD_CIV7_FEATURE_FEASIBILITY_MAX_TYPES_PER_CELL} entries`,
+      );
+    }
+    for (const featureType of cell.featureTypes.slice(0, maxFeatureTypesPerCell)) {
+      if (!Number.isInteger(featureType) || featureType < 0) {
+        throw new Civ7DirectControlError(
+          "command-failed",
+          `Feature placement feasibility feature types must be non-negative integers: ${featureType}`,
+        );
+      }
     }
   }
 }

--- a/packages/civ7-direct-control/test/direct-control.test.ts
+++ b/packages/civ7-direct-control/test/direct-control.test.ts
@@ -19,6 +19,7 @@ import {
   executeCiv7AppUiCommand,
   executeCiv7TunerCommand,
   ensureCiv7SetupMapRowVisible,
+  getCiv7FeaturePlacementFeasibility,
   getCiv7GameInfoRows,
   getCiv7FullMapGrid,
   getCiv7MapGrid,
@@ -471,6 +472,43 @@ describe("Civ7 direct control", () => {
       });
       expect(server.received.some((message) => message.includes("ResourceBuilder"))).toBe(true);
       expect(server.received.some((message) => message.includes("readResourcePlacementFeasibility"))).toBe(true);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("wraps feature placement feasibility through TerrainBuilder", async () => {
+    const server = await startTunerServer();
+    try {
+      const { port } = server.address();
+      const feasibility = await getCiv7FeaturePlacementFeasibility(
+        {
+          cells: [
+            { x: 48, y: 6, featureTypes: [11, 35] },
+            { x: 49, y: 13, featureTypes: [35] },
+          ],
+          maxCells: 1,
+          maxFeatureTypesPerCell: 1,
+        },
+        { host: "127.0.0.1", port, timeoutMs: 1_000 },
+      );
+
+      expect(feasibility).toMatchObject({
+        cellCount: 2,
+        omittedCells: 1,
+        cells: [
+          {
+            location: { x: 48, y: 6, index: { ok: true, value: 684 } },
+            featureTypes: [11],
+            omittedFeatureTypes: 1,
+            feasibility: {
+              "11": { ok: true, value: false },
+            },
+          },
+        ],
+      });
+      expect(server.received.some((message) => message.includes("TerrainBuilder"))).toBe(true);
+      expect(server.received.some((message) => message.includes("readFeaturePlacementFeasibility"))).toBe(true);
     } finally {
       await server.close();
     }
@@ -1619,6 +1657,25 @@ async function startTunerServer(options: {
                     omittedResourceTypes: 1,
                     feasibility: {
                       "3": { ok: true, value: true },
+                    },
+                  },
+                ],
+              }),
+            ]),
+          );
+        } else if (frame.message.includes("readFeaturePlacementFeasibility")) {
+          socket.write(
+            encodeResponse(frame.listenerId, [
+              JSON.stringify({
+                cellCount: 2,
+                omittedCells: 1,
+                cells: [
+                  {
+                    location: { x: 48, y: 6, index: { ok: true, value: 684 } },
+                    featureTypes: [11],
+                    omittedFeatureTypes: 1,
+                    feasibility: {
+                      "11": { ok: true, value: false },
                     },
                   },
                 ],

--- a/scripts/civ7-direct-control/verify-feature-delta-feasibility.ts
+++ b/scripts/civ7-direct-control/verify-feature-delta-feasibility.ts
@@ -1,0 +1,504 @@
+#!/usr/bin/env bun
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import {
+  getCiv7FeaturePlacementFeasibility,
+  getCiv7MapGrid,
+  getCiv7MapSummary,
+  type Civ7FeaturePlacementFeasibilityResult,
+  type Civ7MapGridResult,
+  type Civ7MapSummaryResult,
+  type Civ7PlotSnapshotField,
+} from "../../packages/civ7-direct-control/src/index.ts";
+import {
+  hashParityValue,
+  stableParityProofStringify,
+  type FinalSurfaceParityProof,
+} from "../../mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts";
+import {
+  buildFeatureDeltaPlacementContexts,
+  type FeatureDeltaPlacementContext,
+} from "../../mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts";
+
+type Args = Readonly<{
+  proofFile?: string;
+  contextFile?: string;
+  host?: string;
+  port?: number;
+  timeoutMs: number;
+  maxCells: number;
+  output?: string;
+  help: boolean;
+}>;
+
+type FeatureFeasibilityProbe = Readonly<{
+  ok: boolean;
+  value: boolean | null;
+  error: string | null;
+}>;
+
+const usage = `Usage:
+  bun scripts/civ7-direct-control/verify-feature-delta-feasibility.ts --proof-file <final-surface-proof.json>
+
+Options:
+  --context-file <path> Optional feature delta context artifact to join by plot index
+  --host <host>       Civ7 tuner host
+  --port <port>       Civ7 tuner port
+  --timeout-ms <ms>   Direct-control timeout (default: 45000)
+  --max-cells <n>     Safety cap for feature delta cells (default: 64)
+  --output <path>     Write full proof JSON to path
+`;
+
+const LIVE_FEATURE_CONTEXT_FIELDS = [
+  "terrain",
+  "biome",
+  "feature",
+  "resource",
+  "climate",
+  "hydrology",
+  "areaRegion",
+  "tags",
+  "owner",
+] as const satisfies ReadonlyArray<Civ7PlotSnapshotField>;
+
+function parseArgs(argv: string[]): Args {
+  const args: {
+    proofFile?: string;
+    contextFile?: string;
+    host?: string;
+    port?: number;
+    timeoutMs: number;
+    maxCells: number;
+    output?: string;
+    help: boolean;
+  } = {
+    timeoutMs: 45_000,
+    maxCells: 64,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = () => {
+      const next = argv[index + 1];
+      if (!next || next.startsWith("--")) throw new Error(`Missing value for ${arg}`);
+      index += 1;
+      return next;
+    };
+    switch (arg) {
+      case "--help":
+      case "-h":
+        args.help = true;
+        break;
+      case "--proof-file":
+        args.proofFile = value();
+        break;
+      case "--context-file":
+        args.contextFile = value();
+        break;
+      case "--host":
+        args.host = value();
+        break;
+      case "--port":
+        args.port = parseInteger(value(), arg);
+        break;
+      case "--timeout-ms":
+        args.timeoutMs = parseInteger(value(), arg);
+        break;
+      case "--max-cells":
+        args.maxCells = parseInteger(value(), arg);
+        break;
+      case "--output":
+        args.output = value();
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function parseInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) throw new Error(`${label} must be an integer: ${value}`);
+  return parsed;
+}
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage);
+    return 0;
+  }
+  if (!args.proofFile) throw new Error("Expected --proof-file");
+
+  const proof = extractFinalSurfaceParityProof(JSON.parse(readFileSync(args.proofFile, "utf8")));
+  const contextArtifact = args.contextFile ? JSON.parse(readFileSync(args.contextFile, "utf8")) : undefined;
+  const contextRowsByPlot = readContextRowsByPlot(contextArtifact);
+  const requestIdentity = resolveRequestIdentity(proof);
+  if (requestIdentity.blockedBy.length > 0) {
+    const outputWithoutHash = {
+      ok: false,
+      status: "blocked" as const,
+      requestId: requestIdentity.requestId,
+      sourceProofHash: hashParityValue(proof),
+      blockedBy: requestIdentity.blockedBy,
+      requestIdentity,
+    };
+    const output = { ...outputWithoutHash, proofHash: hashParityValue(outputWithoutHash) };
+    writeOutput(args.output, output);
+    console.log(stableParityProofStringify(output));
+    return 2;
+  }
+
+  const runtimeIdentity = await readAndCompareRuntimeIdentity(proof, args);
+  if (runtimeIdentity.blockedBy.length > 0) {
+    const outputWithoutHash = {
+      ok: false,
+      status: "blocked" as const,
+      requestId: requestIdentity.requestId,
+      sourceProofHash: hashParityValue(proof),
+      blockedBy: runtimeIdentity.blockedBy,
+      requestIdentity,
+      runtimeIdentity,
+    };
+    const output = { ...outputWithoutHash, proofHash: hashParityValue(outputWithoutHash) };
+    writeOutput(args.output, output);
+    console.log(stableParityProofStringify(output));
+    return 2;
+  }
+
+  const deltaRows = buildFeatureDeltaPlacementContexts({ local: proof.local, live: proof.live });
+  if (deltaRows.length === 0) throw new Error("Expected at least one feature delta row");
+  if (deltaRows.length > args.maxCells) {
+    throw new Error(`Feature delta row count ${deltaRows.length} exceeds --max-cells ${args.maxCells}`);
+  }
+
+  const livePlotContext = await getCiv7MapGrid(
+    {
+      locations: deltaRows.map((row) => ({ x: row.x, y: row.y })),
+      fields: LIVE_FEATURE_CONTEXT_FIELDS,
+      maxPlots: args.maxCells,
+    },
+    { host: args.host, port: args.port, timeoutMs: args.timeoutMs }
+  );
+  const cells = deltaRows.map((row) => ({
+    x: row.x,
+    y: row.y,
+    featureTypes: uniqueNumbers([row.local.value, row.live.value]),
+  }));
+  const feasibility = await getCiv7FeaturePlacementFeasibility(
+    { cells, maxCells: args.maxCells },
+    { host: args.host, port: args.port, timeoutMs: args.timeoutMs }
+  );
+
+  const featureFeasibility = summarizeFeatureFeasibility(deltaRows, feasibility, contextRowsByPlot);
+  const outputWithoutHash = {
+    ok: true,
+    requestId: requestIdentity.requestId,
+    sourceProofHash: hashParityValue(proof),
+    sourceContextHash: contextArtifact === undefined ? null : hashParityValue(contextArtifact),
+    evidenceBoundary:
+      "Diagnostic context only: TerrainBuilder.canHaveFeature readback is exact-runtime-bound evidence for feature delta source-authority classification. It does not authorize feature, natural-wonder, terrain, parity, product, or tuning closure by itself.",
+    requestIdentity,
+    runtimeIdentity,
+    rowCount: deltaRows.length,
+    livePlotContext: summarizeLivePlotContext(livePlotContext),
+    featureFeasibility,
+  };
+  const output = { ...outputWithoutHash, proofHash: hashParityValue(outputWithoutHash) };
+  writeOutput(args.output, output);
+  console.log(stableParityProofStringify(output));
+  return 0;
+}
+
+function extractFinalSurfaceParityProof(payload: unknown): FinalSurfaceParityProof {
+  if (!isRecord(payload)) throw new Error("Proof payload must be an object");
+  const proof = isRecord(payload.proof) ? payload.proof : payload;
+  if (!isRecord(proof.local) || !isRecord(proof.live)) {
+    throw new Error("Expected final-surface parity proof with local/live snapshots");
+  }
+  return proof as FinalSurfaceParityProof;
+}
+
+function resolveRequestIdentity(proof: FinalSurfaceParityProof) {
+  const packet = isRecord(proof.exactAuthorshipPacket) ? proof.exactAuthorshipPacket : {};
+  const sourceSnapshot = isRecord(packet.sourceSnapshot) ? packet.sourceSnapshot : {};
+  const log = isRecord(packet.log) ? packet.log : {};
+  const sources = {
+    exactAuthorshipSummary: stringValue(recordValue(proof.exactAuthorshipSummary, "requestId")),
+    exactAuthorshipPacket: stringValue(packet.requestId),
+    sourceSnapshot: stringValue(sourceSnapshot.requestId),
+    log: stringValue(log.requestId),
+  };
+  const values = Object.values(sources).filter((value): value is string => value !== undefined);
+  const uniqueValues = [...new Set(values)].sort((left, right) => left.localeCompare(right));
+  const blockedBy =
+    uniqueValues.length === 0
+      ? ["request-identity.missing"]
+      : uniqueValues.length > 1
+        ? ["request-identity.conflict"]
+        : [];
+  return {
+    requestId: uniqueValues.length === 1 ? uniqueValues[0] : undefined,
+    status: blockedBy.length === 0 ? "matched" as const : "blocked" as const,
+    blockedBy,
+    sources,
+  };
+}
+
+async function readAndCompareRuntimeIdentity(
+  proof: FinalSurfaceParityProof,
+  args: Pick<Args, "host" | "port" | "timeoutMs">
+) {
+  const current = await getCiv7MapSummary({
+    host: args.host,
+    port: args.port,
+    timeoutMs: args.timeoutMs,
+  });
+  const saved = savedRuntimeIdentity(proof);
+  const observed = observedRuntimeIdentity(current);
+  const comparisons = {
+    width: compareIdentityValue(saved.width, observed.width),
+    height: compareIdentityValue(saved.height, observed.height),
+    plotCount: compareIdentityValue(saved.plotCount, observed.plotCount),
+    seed: compareIdentityValue(saved.seed, observed.seed),
+    turn: compareIdentityValue(saved.turn, observed.turn),
+    gameHash: compareIdentityValue(saved.gameHash, observed.gameHash),
+  };
+  const blockedBy = Object.entries(comparisons)
+    .filter(([, comparison]) => comparison.status !== "matched")
+    .map(([key, comparison]) => `runtime-identity.${key}.${comparison.status}`)
+    .sort((left, right) => left.localeCompare(right));
+
+  return {
+    status: blockedBy.length === 0 ? "matched" as const : "blocked" as const,
+    blockedBy,
+    saved,
+    observed,
+    comparisons,
+  };
+}
+
+function savedRuntimeIdentity(proof: FinalSurfaceParityProof) {
+  const evidence = isRecord(proof.live.evidence) ? proof.live.evidence : {};
+  const runtime = isRecord(evidence.runtime) ? evidence.runtime : {};
+  const fullGrid = isRecord(evidence.fullGrid) ? evidence.fullGrid : {};
+  const initialSummary = isRecord(fullGrid.initialSummary) ? fullGrid.initialSummary : {};
+  return {
+    width: numberValue(runtime.width) ?? numberValue(initialSummary.width) ?? proof.live.width,
+    height: numberValue(runtime.height) ?? numberValue(initialSummary.height) ?? proof.live.height,
+    plotCount: numberValue(runtime.plotCount) ?? numberValue(initialSummary.plotCount),
+    seed: numberValue(runtime.seed) ?? numberValue(initialSummary.seed) ?? proof.live.seed,
+    turn: numberValue(runtime.turn) ?? numberValue(initialSummary.turn),
+    gameHash: numberValue(runtime.gameHash) ?? numberValue(initialSummary.gameHash),
+  };
+}
+
+function observedRuntimeIdentity(summary: Civ7MapSummaryResult) {
+  return {
+    host: summary.host,
+    port: summary.port,
+    state: summary.state,
+    width: probeNumber(summary.map.width),
+    height: probeNumber(summary.map.height),
+    plotCount: probeNumber(summary.map.plotCount),
+    seed: probeNumber(summary.map.randomSeed),
+    turn: probeNumber(summary.game.turn),
+    gameHash: probeNumber(summary.game.hash),
+  };
+}
+
+function compareIdentityValue(saved: number | undefined, observed: number | undefined) {
+  if (saved === undefined) return { status: "missing-saved" as const, saved, observed };
+  if (observed === undefined) return { status: "missing-observed" as const, saved, observed };
+  if (saved !== observed) return { status: "mismatch" as const, saved, observed };
+  return { status: "matched" as const, saved, observed };
+}
+
+function summarizeLivePlotContext(readback: Civ7MapGridResult) {
+  return {
+    readback: {
+      host: readback.host,
+      port: readback.port,
+      state: readback.state,
+      fields: readback.fields,
+      plotCount: readback.plotCount,
+      omitted: readback.omitted,
+      hiddenInfoPolicy: readback.hiddenInfoPolicy,
+    },
+    rows: readback.plots.map((plot) => ({
+      location: plot.location,
+      hiddenInfoPolicy: plot.hiddenInfoPolicy,
+      facts: plot.facts,
+    })),
+  };
+}
+
+function summarizeFeatureFeasibility(
+  rows: ReadonlyArray<FeatureDeltaPlacementContext>,
+  readback: Civ7FeaturePlacementFeasibilityResult,
+  contextRowsByPlot: ReadonlyMap<number, Record<string, unknown>>
+) {
+  const cellsByLocation = new Map(
+    readback.cells.map((cell) => [`${cell.location.x},${cell.location.y}`, cell] as const)
+  );
+  const summarizedRows = rows.map((row) => {
+    const cell = cellsByLocation.get(`${row.x},${row.y}`);
+    const localFeasibleInCiv =
+      row.local.value === null ? null : readFeatureFeasibilityProbe(cell, row.local.value);
+    const liveFeasibleInCiv =
+      row.live.value === null ? null : readFeatureFeasibilityProbe(cell, row.live.value);
+    const contextRow = contextRowsByPlot.get(row.plotIndex);
+    return {
+      x: row.x,
+      y: row.y,
+      plotIndex: row.plotIndex,
+      localFeature: row.local,
+      liveFeature: row.live,
+      localContext: row.local.context,
+      liveContext: row.live.context,
+      evidenceClass: row.evidenceClass,
+      localFeatureIntent: contextRow?.localFeatureIntent ?? row.localFeatureIntent,
+      naturalWonderFootprint: contextRow?.naturalWonderFootprint ?? row.naturalWonderFootprint,
+      pairedSameFeatureDelta: row.pairedSameFeatureDelta,
+      localFeasibleInCiv,
+      liveFeasibleInCiv,
+      feasibilityClass: classifyFeatureFeasibility({
+        evidenceClass: row.evidenceClass,
+        localFeasibleInCiv,
+        liveFeasibleInCiv,
+      }),
+    };
+  });
+  return {
+    readback: {
+      host: readback.host,
+      port: readback.port,
+      state: readback.state,
+      cellCount: readback.cellCount,
+      omittedCells: readback.omittedCells,
+    },
+    classCounts: countBy(summarizedRows, (row) => row.feasibilityClass),
+    evidenceAndFeasibilityCounts: countBy(
+      summarizedRows,
+      (row) =>
+        `${row.evidenceClass}|local:${feasibilityValue(row.localFeasibleInCiv)}|live:${feasibilityValue(row.liveFeasibleInCiv)}`
+    ),
+    rows: summarizedRows,
+  };
+}
+
+function readContextRowsByPlot(payload: unknown): ReadonlyMap<number, Record<string, unknown>> {
+  const byPlot = new Map<number, Record<string, unknown>>();
+  if (!isRecord(payload) || !Array.isArray(payload.rows)) return byPlot;
+  for (const row of payload.rows) {
+    if (!isRecord(row)) continue;
+    const plotIndex = numberValue(row.plotIndex);
+    if (plotIndex === undefined) continue;
+    byPlot.set(plotIndex, row);
+  }
+  return byPlot;
+}
+
+function readFeatureFeasibilityProbe(
+  cell: Civ7FeaturePlacementFeasibilityResult["cells"][number] | undefined,
+  featureType: number
+): FeatureFeasibilityProbe {
+  const probe = cell?.feasibility[String(featureType)];
+  if (probe === undefined) return { ok: false, value: null, error: "missing-probe" };
+  const ok = probe.ok === true;
+  return {
+    ok,
+    value: ok && typeof probe.value === "boolean" ? probe.value : null,
+    error: typeof probe.error === "string" ? probe.error : ok ? null : "probe-failed",
+  };
+}
+
+function classifyFeatureFeasibility(args: {
+  evidenceClass: FeatureDeltaPlacementContext["evidenceClass"];
+  localFeasibleInCiv: FeatureFeasibilityProbe | null;
+  liveFeasibleInCiv: FeatureFeasibilityProbe | null;
+}): string {
+  const local = args.localFeasibleInCiv;
+  const live = args.liveFeasibleInCiv;
+  if ((local !== null && !local.ok) || (live !== null && !live.ok)) return "feasibility-missing";
+  if (args.evidenceClass === "local-only-ecology-feature") {
+    if (local?.value === true) return "local-feature-civ-feasible-live-empty";
+    if (local?.value === false) return "local-feature-civ-infeasible-live-empty";
+  }
+  if (args.evidenceClass === "live-only-ecology-feature") {
+    if (live?.value === true) return "live-feature-civ-feasible-local-empty";
+    if (live?.value === false) return "live-feature-civ-infeasible-local-empty";
+  }
+  if (
+    args.evidenceClass === "natural-wonder-offset-local-anchor" ||
+    args.evidenceClass === "natural-wonder-offset-live-anchor"
+  ) {
+    if (local?.value === true && live?.value === true) return "natural-wonder-offset-both-civ-feasible";
+    if (local?.value === true && live === null) return "natural-wonder-offset-local-civ-feasible";
+    if (local === null && live?.value === true) return "natural-wonder-offset-live-civ-feasible";
+    if (local?.value === false && live === null) return "natural-wonder-offset-local-civ-infeasible";
+    if (local === null && live?.value === false) return "natural-wonder-offset-live-civ-infeasible";
+    if (local?.value === false && live?.value === false) return "natural-wonder-offset-both-civ-infeasible";
+  }
+  return "unclassified";
+}
+
+function uniqueNumbers(values: ReadonlyArray<number | null>): ReadonlyArray<number> {
+  return [...new Set(values.filter((value): value is number => typeof value === "number"))];
+}
+
+function countBy<T>(values: ReadonlyArray<T>, keyFor: (value: T) => string): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const value of values) {
+    const key = keyFor(value);
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return Object.fromEntries(Object.entries(counts).sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function feasibilityValue(probe: FeatureFeasibilityProbe | null): string {
+  if (probe === null) return "not-applicable";
+  if (!probe.ok) return `error:${probe.error ?? "unknown"}`;
+  return probe.value === true ? "true" : "false";
+}
+
+function writeOutput(path: string | undefined, output: unknown): void {
+  if (!path) return;
+  const absolute = resolve(path);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, `${stableParityProofStringify(output)}\n`);
+}
+
+function probeNumber(value: unknown): number | undefined {
+  if (isRecord(value) && value.ok === true && typeof value.value === "number") return value.value;
+  return undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function recordValue(value: unknown, key: string): unknown {
+  return isRecord(value) ? value[key] : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
Adds runtime-bound `TerrainBuilder.canHaveFeature` readback for feature delta cells as the next diagnostic step in the Swooper feature/resource legality repair workstream.

A `getCiv7FeaturePlacementFeasibility` wrapper is added to `@civ7/direct-control`, mirroring the existing resource feasibility wrapper. It accepts a bounded list of cells with feature type arrays, builds and executes a tuner command that calls `TerrainBuilder.canHaveFeature` for each requested feature type per cell, and returns per-cell feasibility probes alongside plot index lookups via `GameplayMap`. Input validation, capacity constants, and a capability catalog entry are included.

A new `verify:feature-delta-feasibility` script binds this wrapper to the saved exact-authored parity proof before probing. It resolves request identity from the proof, compares current runtime identity (dimensions, plot count, seed, turn, game hash) against the saved proof to confirm the correct session is targeted, then probes all feature delta cells. Results are joined with the prior local feature/natural-wonder context artifact by plot index and classified into feasibility classes (`local-feature-civ-infeasible-live-empty`, `natural-wonder-offset-local-civ-infeasible`, `natural-wonder-offset-live-civ-infeasible`, etc.).

The current artifact shows that all five probed feature delta cells return `canHaveFeature=false`, including the live natural-wonder cells that already contain those features in the live grid. Because the readback is post-materialization and the live cells also return false, the probe is not a clean pre-placement acceptance oracle. It narrows the open question toward materialization-time feature stamping, natural-wonder footprint/anchor semantics, and readback policy, but does not authorize feature, natural-wonder, terrain, parity, or product repair.

Task 2.22 is marked complete and the former 2.22/2.23 items are renumbered to 2.23/2.24.