### PR TITLE
feat(swooper-wonder-footprint): add natural-wonder footprint direction alternatives context to feature delta placement rows

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -73,6 +73,7 @@ export type FeatureDeltaPlacementContext = SurfaceDeltaContext &
     plotIndex: number;
     localFeatureIntent: FeatureIntentContext | null;
     naturalWonderFootprint: NaturalWonderFootprintContext | null;
+    naturalWonderDirectionAlternatives: NaturalWonderDirectionAlternativesContext | null;
     pairedSameFeatureDelta: FeatureDeltaPairContext | null;
     evidenceClass:
       | "local-only-ecology-feature"
@@ -106,6 +107,27 @@ export type NaturalWonderFootprintContext = Readonly<{
   direction: number;
   priority: number | null;
   footprintDistanceFromAnchor: number;
+}>;
+
+export type NaturalWonderDirectionAlternativesContext = Readonly<{
+  anchorPlotIndex: number;
+  anchorX: number;
+  anchorY: number;
+  featureType: number;
+  featureSymbol: string;
+  declaredDirection: number;
+  rowPlotIndex: number;
+  pairedPlotIndex: number | null;
+  candidates: ReadonlyArray<NaturalWonderDirectionCandidateContext>;
+  directionsContainingRow: ReadonlyArray<number>;
+  directionsContainingPairedRow: ReadonlyArray<number>;
+}>;
+
+export type NaturalWonderDirectionCandidateContext = Readonly<{
+  direction: number;
+  footprintPlotIndexes: ReadonlyArray<number>;
+  containsRow: boolean;
+  containsPairedRow: boolean | null;
 }>;
 
 export type ResourceDeltaPlacementContext = Readonly<{
@@ -308,6 +330,7 @@ export function buildFeatureDeltaPlacementContexts(
   const maxRows = options.maxRows ?? Number.POSITIVE_INFINITY;
   const featureIntents = readFeatureIntentEvidence(proof.local);
   const naturalWonderFootprints = readNaturalWonderFootprintEvidence(proof.local);
+  const naturalWonderPlacements = readNaturalWonderPlacementEvidence(proof.local);
   const rows = buildSurfaceDeltaContexts(proof, { keys: ["feature"] }).map((row) => {
     const plotIndex = row.y * proof.local.width + row.x;
     return {
@@ -316,6 +339,7 @@ export function buildFeatureDeltaPlacementContexts(
       plotIndex,
       localFeatureIntent: featureIntents.byPlot.get(plotIndex) ?? null,
       naturalWonderFootprint: naturalWonderFootprints.byPlot.get(plotIndex) ?? null,
+      naturalWonderDirectionAlternatives: null,
       pairedSameFeatureDelta: null,
       evidenceClass: "unclassified" as const,
     };
@@ -325,6 +349,13 @@ export function buildFeatureDeltaPlacementContexts(
     return {
       ...row,
       pairedSameFeatureDelta,
+      naturalWonderDirectionAlternatives: buildNaturalWonderDirectionAlternatives(
+        row,
+        pairedSameFeatureDelta,
+        naturalWonderPlacements.placements,
+        proof.local.width,
+        proof.local.height
+      ),
       evidenceClass: classifyFeatureDelta(row, pairedSameFeatureDelta),
     };
   });
@@ -650,12 +681,48 @@ function readNaturalWonderFootprintEvidence(snapshot: FinalSurfaceSnapshot): {
   byPlot: ReadonlyMap<number, NaturalWonderFootprintContext>;
 } {
   const byPlot = new Map<number, NaturalWonderFootprintContext>();
+  for (const placement of readNaturalWonderPlacementEvidence(snapshot).placements) {
+    const footprint = getNaturalWonderFootprintIndices({
+      x: placement.anchorX,
+      y: placement.anchorY,
+      width: snapshot.width,
+      height: snapshot.height,
+      policy: CIV7_BROWSER_TABLES_V0.featurePolicies[String(placement.featureType)] ?? {},
+      direction: placement.direction,
+    }) ?? [placement.anchorPlotIndex];
+    for (const plotIndex of footprint) {
+      byPlot.set(plotIndex, {
+        anchorPlotIndex: placement.anchorPlotIndex,
+        anchorX: placement.anchorX,
+        anchorY: placement.anchorY,
+        featureType: placement.featureType,
+        featureSymbol: symbolFor("feature", placement.featureType),
+        direction: placement.direction,
+        priority: placement.priority,
+        footprintDistanceFromAnchor: hexDistanceOddQPeriodicX(placement.anchorPlotIndex, plotIndex, snapshot.width),
+      });
+    }
+  }
+  return { byPlot };
+}
+
+function readNaturalWonderPlacementEvidence(snapshot: FinalSurfaceSnapshot): {
+  placements: ReadonlyArray<{
+    anchorPlotIndex: number;
+    anchorX: number;
+    anchorY: number;
+    featureType: number;
+    direction: number;
+    priority: number | null;
+  }>;
+} {
+  const placements = [];
   const evidence = snapshot.evidence;
   const naturalWonderPlan = isRecord(evidence) ? evidence.naturalWonderPlan : undefined;
-  const placements = isRecord(naturalWonderPlan) && Array.isArray(naturalWonderPlan.placements)
+  const rawPlacements = isRecord(naturalWonderPlan) && Array.isArray(naturalWonderPlan.placements)
     ? naturalWonderPlan.placements
     : [];
-  for (const rawPlacement of placements) {
+  for (const rawPlacement of rawPlacements) {
     if (!isRecord(rawPlacement)) continue;
     const anchorPlotIndex = finiteInteger(rawPlacement.plotIndex);
     const featureType = finiteInteger(rawPlacement.featureType);
@@ -663,28 +730,80 @@ function readNaturalWonderFootprintEvidence(snapshot: FinalSurfaceSnapshot): {
     if (anchorPlotIndex === null || featureType === null || direction === null) continue;
     const anchorY = Math.floor(anchorPlotIndex / snapshot.width);
     const anchorX = anchorPlotIndex - anchorY * snapshot.width;
-    const footprint = getNaturalWonderFootprintIndices({
-      x: anchorX,
-      y: anchorY,
-      width: snapshot.width,
-      height: snapshot.height,
-      policy: CIV7_BROWSER_TABLES_V0.featurePolicies[String(featureType)] ?? {},
+    placements.push({
+      anchorPlotIndex,
+      anchorX,
+      anchorY,
+      featureType,
       direction,
-    }) ?? [anchorPlotIndex];
-    for (const plotIndex of footprint) {
-      byPlot.set(plotIndex, {
-        anchorPlotIndex,
-        anchorX,
-        anchorY,
-        featureType,
-        featureSymbol: symbolFor("feature", featureType),
-        direction,
-        priority: numberValue(rawPlacement.priority),
-        footprintDistanceFromAnchor: hexDistanceOddQPeriodicX(anchorPlotIndex, plotIndex, snapshot.width),
-      });
-    }
+      priority: numberValue(rawPlacement.priority),
+    });
   }
-  return { byPlot };
+  return { placements };
+}
+
+function buildNaturalWonderDirectionAlternatives(
+  row: Pick<FeatureDeltaPlacementContext, "plotIndex" | "local" | "live">,
+  pairedSameFeatureDelta: FeatureDeltaPairContext | null,
+  placements: ReadonlyArray<{
+    anchorPlotIndex: number;
+    anchorX: number;
+    anchorY: number;
+    featureType: number;
+    direction: number;
+  }>,
+  width: number,
+  height: number
+): NaturalWonderDirectionAlternativesContext | null {
+  const featureType = row.local.value ?? row.live.value;
+  if (featureType === null || !isNaturalWonderFeature(featureType)) return null;
+  const placement = placements
+    .filter((candidate) => candidate.featureType === featureType)
+    .sort(
+      (left, right) =>
+        hexDistanceOddQPeriodicX(left.anchorPlotIndex, row.plotIndex, width) -
+        hexDistanceOddQPeriodicX(right.anchorPlotIndex, row.plotIndex, width)
+    )[0];
+  if (!placement) return null;
+  const pairedPlotIndex = pairedSameFeatureDelta?.plotIndex ?? null;
+  const policy = CIV7_BROWSER_TABLES_V0.featurePolicies[String(featureType)] ?? {};
+  const candidates = [0, 1, 2, 3, 4, 5].flatMap((direction) => {
+    const footprintPlotIndexes = getNaturalWonderFootprintIndices({
+      x: placement.anchorX,
+      y: placement.anchorY,
+      width,
+      height,
+      policy,
+      direction,
+    });
+    if (!footprintPlotIndexes) return [];
+    return [
+      {
+        direction,
+        footprintPlotIndexes,
+        containsRow: footprintPlotIndexes.includes(row.plotIndex),
+        containsPairedRow:
+          pairedPlotIndex === null ? null : footprintPlotIndexes.includes(pairedPlotIndex),
+      },
+    ];
+  });
+  return {
+    anchorPlotIndex: placement.anchorPlotIndex,
+    anchorX: placement.anchorX,
+    anchorY: placement.anchorY,
+    featureType,
+    featureSymbol: symbolFor("feature", featureType),
+    declaredDirection: placement.direction,
+    rowPlotIndex: row.plotIndex,
+    pairedPlotIndex,
+    candidates,
+    directionsContainingRow: candidates
+      .filter((candidate) => candidate.containsRow)
+      .map((candidate) => candidate.direction),
+    directionsContainingPairedRow: candidates
+      .filter((candidate) => candidate.containsPairedRow === true)
+      .map((candidate) => candidate.direction),
+  };
 }
 
 function addResourceSurfaceReasons(

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -110,6 +110,12 @@ describe("surface delta context diagnostics", () => {
         featureSymbol: "FEATURE_KILIMANJARO",
         priority: 0.9,
       },
+      naturalWonderDirectionAlternatives: {
+        anchorPlotIndex: 1,
+        declaredDirection: 0,
+        directionsContainingRow: expect.arrayContaining([0]),
+        directionsContainingPairedRow: expect.arrayContaining([0]),
+      },
       pairedSameFeatureDelta: {
         x: 2,
         y: 0,
@@ -123,6 +129,12 @@ describe("surface delta context diagnostics", () => {
       y: 0,
       local: { symbol: "empty" },
       live: { symbol: "FEATURE_KILIMANJARO" },
+      naturalWonderDirectionAlternatives: {
+        anchorPlotIndex: 1,
+        declaredDirection: 0,
+        directionsContainingRow: expect.arrayContaining([0]),
+        directionsContainingPairedRow: expect.arrayContaining([0]),
+      },
       pairedSameFeatureDelta: {
         x: 1,
         y: 0,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -48,8 +48,10 @@
   classes.
 - [x] 2.22 Add runtime-bound feature feasibility readback for feature delta
   classes.
-- [ ] 2.23 Repair remaining proven package or MapGen owners.
-- [ ] 2.24 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.23 Add natural-wonder footprint direction context for feature offset
+  rows.
+- [ ] 2.24 Repair remaining proven package or MapGen owners.
+- [ ] 2.25 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -708,6 +708,36 @@ footprint/anchor semantics, runtime state, or readback policy. It does not
 authorize feature repair, natural-wonder repair, parity closure, product
 acceptance, or mountain-quality claims.
 
+### Natural-Wonder Footprint Direction Context
+
+Diagnostic repair:
+`buildFeatureDeltaPlacementContexts` now records all six local map-policy
+footprint direction alternatives for natural-wonder feature delta rows. This
+does not change natural-wonder placement; it makes the direction/footprint
+semantics visible for source-authority classification.
+
+The current footprint direction artifact is
+`/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-feature-footprint-direction-context.json`
+(`sha256:bbb9b1ce680af7e6f456cb7fb594b88d892a1fa3a8e1287982fb9a560b918c42`).
+It is derived from the saved exact parity proof and the prior local
+feature-context artifact; it is not a fresh exact-authored parity proof.
+
+Direction facts:
+
+| Feature | Local row | Live row | Local helper direction evidence | Live offset evidence |
+|---|---|---|---|---|
+| `FEATURE_KILIMANJARO` | `(49,13)` | `(48,13)` | Direction `0` contains the local row. | Directions `4` and `5` contain the live row; direction `5` contains both local and live delta cells. |
+| `FEATURE_ZHANGJIAJIE` | `(52,21)` | `(51,21)` | Direction `0` contains the local row. | Direction `5` contains the live row. |
+
+Disposition:
+the natural-wonder rows now point at a likely `Direction:-1` / footprint
+orientation semantics gap between local map-policy projection and Civ runtime
+materialization. This is still classification evidence, not repair authority:
+a natural-wonder repair must first accept the source owner explicitly, then
+test the supported wonder catalog so one-row offset evidence does not regress
+other footprint classes. No natural-wonder repair, parity closure, product
+acceptance, or mountain-quality claim is authorized from this context alone.
+
 ## Required Next Diagnostics
 
 - Extract local row context for every feature/resource mismatch: terrain,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,10 +5,9 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-feature-feasibility-readback-drain`
-  stacked above `codex/swooper-feature-local-evidence-drain`; this slice
-  carries package-owned live feature feasibility readback for feature-delta
-  classes.
+- Branch/Graphite stack: `codex/swooper-wonder-footprint-direction-drain`
+  stacked above `codex/swooper-feature-feasibility-readback-drain`; this slice
+  carries natural-wonder footprint direction context for feature-delta classes.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
@@ -16,8 +15,9 @@
   ResourceBuilder diagnostic/subclassification/policy context plus
   assignment-class, distribution-count, same-resource position, local
   materialization, future coordinate-proof instrumentation, coordinate-proof
-  intake, feature-delta classification, local feature/wonder evidence joins, and
-  feature feasibility readback now narrow the next repair classes.
+  intake, feature-delta classification, local feature/wonder evidence joins,
+  feature feasibility readback, and natural-wonder footprint-direction context
+  now narrow the next repair classes.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -381,6 +381,25 @@
   question toward runtime materialization state, natural-wonder stamping
   semantics, or readback policy, but it still does not authorize feature,
   natural-wonder, terrain, parity, product, or tuning repair.
+- Feature footprint direction context progress:
+  `buildFeatureDeltaPlacementContexts` now records all six local
+  map-policy footprint direction alternatives for planned natural-wonder rows.
+  The current direction-context artifact is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-feature-footprint-direction-context.json`
+  (`sha256:bbb9b1ce680af7e6f456cb7fb594b88d892a1fa3a8e1287982fb9a560b918c42`).
+  It is derived from the saved exact parity proof plus the prior local feature
+  context artifact; it is not a fresh parity proof and does not mutate product
+  code. For both affected natural wonders, the current local policy helper's
+  normalized declared direction `0` contains the local feature row. The live
+  offset row is explained by a different direction alternative: Kilimanjaro's
+  live row `(48,13)` is contained by directions `4` and `5`, while direction
+  `5` contains both local/live delta cells; Zhangjiajie's live row `(51,21)` is
+  contained by direction `5` while direction `0` contains the local row
+  `(52,21)`. This narrows the natural-wonder source-owner question toward
+  `Direction:-1` / footprint-orientation semantics between local map-policy
+  projection and Civ runtime materialization. It still does not authorize a
+  natural-wonder repair until the source owner is explicitly accepted and tested
+  against broader wonder footprint behavior.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -412,12 +431,13 @@
   local and live immediate placement coordinate identity or otherwise assigns
   those subclasses to a concrete source owner. Feature rows are now split into
   a reef absence and two natural-wonder one-tile offsets, with local intent,
-  application, footprint evidence, and runtime-bound `canHaveFeature` probes
-  now attached. Since post-materialization `canHaveFeature=false` also applies
-  to the live natural-wonder cells that contain those features, no feature
-  repair is authorized until materialization/readback evidence assigns
-  ownership beyond the post-state feasibility caveat. The single substitution
-  row where both probed values are infeasible remains an individual evidence row
-  with no repair authority until row-level context assigns source ownership.
+  application, footprint evidence, runtime-bound `canHaveFeature` probes, and
+  footprint-direction alternatives now attached. The direction context points at
+  a likely natural-wonder footprint orientation semantics gap, but no feature or
+  natural-wonder repair is authorized until source ownership is accepted and the
+  change is checked against the supported wonder catalog. The single
+  substitution row where both probed values are infeasible remains an individual
+  evidence row with no repair authority until row-level context assigns source
+  ownership.
 - Stop condition: source authority is not known for any row outside the
   classified adjacent-land resource class.


### PR DESCRIPTION
Adds `NaturalWonderDirectionAlternativesContext` to `FeatureDeltaPlacementContext`, exposing all six local map-policy footprint direction alternatives for natural-wonder feature delta rows.

`readNaturalWonderFootprintEvidence` is refactored to extract a shared `readNaturalWonderPlacementEvidence` helper, which is then consumed both by the footprint-by-plot index and by the new `buildNaturalWonderDirectionAlternatives` function. For each natural-wonder delta row, `buildNaturalWonderDirectionAlternatives` finds the nearest matching placement, iterates all six directions, computes each direction's footprint plot indexes, and records which directions contain the current row and which contain the paired same-feature delta row. The result is attached to each `FeatureDeltaPlacementContext` as `naturalWonderDirectionAlternatives`.

This makes footprint orientation semantics visible for source-authority classification. For the two affected wonders, the declared direction `0` contains the local feature row while the live offset row is explained by a different direction, narrowing the discrepancy toward a `Direction:-1` / footprint-orientation gap between local map-policy projection and Civ runtime materialization. No natural-wonder repair is authorized from this context alone.