### PR TITLE
feat(swooper-diagnostics): add natural-wonder footprint readback context scoring local and live grids across direction alternatives

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -130,6 +130,38 @@ export type NaturalWonderDirectionCandidateContext = Readonly<{
   containsPairedRow: boolean | null;
 }>;
 
+export type NaturalWonderFootprintReadbackContext = Readonly<{
+  anchorPlotIndex: number;
+  anchorX: number;
+  anchorY: number;
+  featureType: number;
+  featureSymbol: string;
+  declaredDirection: number;
+  declaredFootprintPlotIndexes: ReadonlyArray<number>;
+  candidates: ReadonlyArray<NaturalWonderFootprintReadbackCandidate>;
+  bestLocalDirections: ReadonlyArray<number>;
+  bestLiveDirections: ReadonlyArray<number>;
+  declaredLocalMatchCount: number;
+  declaredLiveMatchCount: number;
+  bestLocalMatchCount: number;
+  bestLiveMatchCount: number;
+  classification:
+    | "local-live-same-direction"
+    | "live-direction-differs-from-local"
+    | "live-footprint-missing"
+    | "local-footprint-missing"
+    | "unclassified";
+}>;
+
+export type NaturalWonderFootprintReadbackCandidate = Readonly<{
+  direction: number;
+  footprintPlotIndexes: ReadonlyArray<number>;
+  localMatchCount: number;
+  liveMatchCount: number;
+  localComplete: boolean;
+  liveComplete: boolean;
+}>;
+
 export type ResourceDeltaPlacementContext = Readonly<{
   x: number;
   y: number;
@@ -360,6 +392,70 @@ export function buildFeatureDeltaPlacementContexts(
     };
   });
   return classified.slice(0, maxRows);
+}
+
+export function buildNaturalWonderFootprintReadbackContexts(
+  proof: Pick<FinalSurfaceParityProof, "local" | "live">
+): ReadonlyArray<NaturalWonderFootprintReadbackContext> {
+  return readNaturalWonderPlacementEvidence(proof.local).placements.map((placement) => {
+    const policy = CIV7_BROWSER_TABLES_V0.featurePolicies[String(placement.featureType)] ?? {};
+    const candidates = [0, 1, 2, 3, 4, 5].flatMap((direction) => {
+      const footprintPlotIndexes = getNaturalWonderFootprintIndices({
+        x: placement.anchorX,
+        y: placement.anchorY,
+        width: proof.local.width,
+        height: proof.local.height,
+        policy,
+        direction,
+      });
+      if (!footprintPlotIndexes) return [];
+      const localMatchCount = countFeatureMatches(proof.local, footprintPlotIndexes, placement.featureType);
+      const liveMatchCount = countFeatureMatches(proof.live, footprintPlotIndexes, placement.featureType);
+      return [
+        {
+          direction,
+          footprintPlotIndexes,
+          localMatchCount,
+          liveMatchCount,
+          localComplete: localMatchCount === footprintPlotIndexes.length,
+          liveComplete: liveMatchCount === footprintPlotIndexes.length,
+        },
+      ];
+    });
+    const declaredDirection = normalizeDirectionForReadback(placement.direction);
+    const declared = candidates.find((candidate) => candidate.direction === declaredDirection) ?? candidates[0];
+    const bestLocalMatchCount = maxMatchCount(candidates, "localMatchCount");
+    const bestLiveMatchCount = maxMatchCount(candidates, "liveMatchCount");
+    const bestLocalDirections = candidates
+      .filter((candidate) => candidate.localMatchCount === bestLocalMatchCount)
+      .map((candidate) => candidate.direction);
+    const bestLiveDirections = candidates
+      .filter((candidate) => candidate.liveMatchCount === bestLiveMatchCount)
+      .map((candidate) => candidate.direction);
+    const classification = classifyNaturalWonderFootprintReadback({
+      bestLocalMatchCount,
+      bestLiveMatchCount,
+      bestLocalDirections,
+      bestLiveDirections,
+    });
+    return {
+      anchorPlotIndex: placement.anchorPlotIndex,
+      anchorX: placement.anchorX,
+      anchorY: placement.anchorY,
+      featureType: placement.featureType,
+      featureSymbol: symbolFor("feature", placement.featureType),
+      declaredDirection: placement.direction,
+      declaredFootprintPlotIndexes: declared?.footprintPlotIndexes ?? [],
+      candidates,
+      bestLocalDirections,
+      bestLiveDirections,
+      declaredLocalMatchCount: declared?.localMatchCount ?? 0,
+      declaredLiveMatchCount: declared?.liveMatchCount ?? 0,
+      bestLocalMatchCount,
+      bestLiveMatchCount,
+      classification,
+    };
+  });
 }
 
 export function buildResourceDeltaPlacementContexts(
@@ -804,6 +900,47 @@ function buildNaturalWonderDirectionAlternatives(
       .filter((candidate) => candidate.containsPairedRow === true)
       .map((candidate) => candidate.direction),
   };
+}
+
+function countFeatureMatches(
+  snapshot: SnapshotLike,
+  plotIndexes: ReadonlyArray<number>,
+  featureType: number
+): number {
+  let count = 0;
+  for (const plotIndex of plotIndexes) {
+    if (normalizeSurfaceValue(snapshot.surfaces.feature.values[plotIndex]) === featureType) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function maxMatchCount(
+  candidates: ReadonlyArray<NaturalWonderFootprintReadbackCandidate>,
+  key: "localMatchCount" | "liveMatchCount"
+): number {
+  return candidates.reduce((max, candidate) => Math.max(max, candidate[key]), 0);
+}
+
+function normalizeDirectionForReadback(direction: number): number {
+  if (!Number.isFinite(direction) || direction < 0) return 0;
+  return Math.trunc(direction) % 6;
+}
+
+function classifyNaturalWonderFootprintReadback(args: {
+  bestLocalMatchCount: number;
+  bestLiveMatchCount: number;
+  bestLocalDirections: ReadonlyArray<number>;
+  bestLiveDirections: ReadonlyArray<number>;
+}): NaturalWonderFootprintReadbackContext["classification"] {
+  if (args.bestLocalMatchCount === 0 && args.bestLiveMatchCount === 0) return "unclassified";
+  if (args.bestLocalMatchCount === 0) return "local-footprint-missing";
+  if (args.bestLiveMatchCount === 0) return "live-footprint-missing";
+  const sharedDirection = args.bestLocalDirections.some((direction) =>
+    args.bestLiveDirections.includes(direction)
+  );
+  return sharedDirection ? "local-live-same-direction" : "live-direction-differs-from-local";
 }
 
 function addResourceSurfaceReasons(

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { FinalSurfaceSnapshot } from "../../src/dev/diagnostics/live-parity";
 import {
   buildFeatureDeltaPlacementContexts,
+  buildNaturalWonderFootprintReadbackContexts,
   buildResourceDeltaFeasibilityContexts,
   buildResourceDeltaPlacementContexts,
   buildSurfaceDeltaContext,
@@ -150,6 +151,65 @@ describe("surface delta context diagnostics", () => {
       "natural-wonder-offset-live-anchor",
       "natural-wonder-offset-local-anchor",
     ]);
+  });
+
+  test("summarizes natural-wonder footprint readback direction matches", () => {
+    const local = snapshot({
+      feature: { width: 3, height: 2, values: [-1, 35, 35, -1, -1, -1] },
+    }, {
+      naturalWonderPlan: {
+        width: 3,
+        height: 2,
+        wondersCount: 1,
+        targetCount: 1,
+        plannedCount: 1,
+        placements: [
+          { plotIndex: 1, featureType: 35, direction: 0, elevation: 1000, priority: 0.9 },
+        ],
+      },
+    });
+    const live = snapshot({
+      feature: { width: 3, height: 2, values: [-1, 35, 35, -1, -1, -1] },
+    });
+
+    const rows = buildNaturalWonderFootprintReadbackContexts({ local, live });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      featureSymbol: "FEATURE_KILIMANJARO",
+      declaredDirection: 0,
+      bestLocalDirections: expect.arrayContaining([0]),
+      bestLiveDirections: expect.arrayContaining([0]),
+      classification: "local-live-same-direction",
+    });
+  });
+
+  test("classifies natural-wonder footprint direction divergence", () => {
+    const local = snapshot({
+      feature: { width: 3, height: 2, values: [-1, 35, 35, -1, -1, -1] },
+    }, {
+      naturalWonderPlan: {
+        width: 3,
+        height: 2,
+        wondersCount: 1,
+        targetCount: 1,
+        plannedCount: 1,
+        placements: [
+          { plotIndex: 1, featureType: 35, direction: 0, elevation: 1000, priority: 0.9 },
+        ],
+      },
+    });
+    const live = snapshot({
+      feature: { width: 3, height: 2, values: [-1, 35, -1, -1, 35, -1] },
+    });
+
+    const rows = buildNaturalWonderFootprintReadbackContexts({ local, live });
+
+    expect(rows[0]).toMatchObject({
+      bestLocalDirections: expect.arrayContaining([0]),
+      bestLiveDirections: expect.arrayContaining([5]),
+      classification: "live-direction-differs-from-local",
+    });
   });
 
   test("checks static feature and resource surface legality against snapshot context", () => {

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -50,8 +50,10 @@
   classes.
 - [x] 2.23 Add natural-wonder footprint direction context for feature offset
   rows.
-- [ ] 2.24 Repair remaining proven package or MapGen owners.
-- [ ] 2.25 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.24 Add planned natural-wonder footprint readback context across local
+  and live grids.
+- [ ] 2.25 Repair remaining proven package or MapGen owners.
+- [ ] 2.26 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -738,6 +738,39 @@ test the supported wonder catalog so one-row offset evidence does not regress
 other footprint classes. No natural-wonder repair, parity closure, product
 acceptance, or mountain-quality claim is authorized from this context alone.
 
+### Planned Natural-Wonder Footprint Readback
+
+Diagnostic repair:
+`buildNaturalWonderFootprintReadbackContexts` now scores each planned natural
+wonder represented in the local context artifact against local and live feature
+grids across local map-policy direction alternatives `0..5`.
+
+The current planned-footprint readback artifact is
+`/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-natural-wonder-footprint-readback.json`
+(`sha256:50ecdd1bee31c8243dac792b2d8d9fe5faae4d422cf0cae44f95a696d86d16a3`,
+`proofHash:3e0389b5977d997ce40d5888c97e703397b518e5ff034911be70a949afd1d6b4`).
+It is derived from the saved exact parity proof and prior local feature-context
+artifact; it is not a fresh exact-authored parity proof.
+
+Readback facts:
+
+| Feature | Declared direction | Best local direction(s) | Best live direction(s) | Classification |
+|---|---:|---|---|---|
+| `FEATURE_KILIMANJARO` | `-1` | `0` (`3/3` local cells) | `0,1,4,5` (`2/3` live cells) | `local-live-same-direction` with partial/ambiguous live coverage |
+| `FEATURE_ZHANGJIAJIE` | `-1` | `0` (`2/2` local cells) | `5` (`2/2` live cells) | `live-direction-differs-from-local` |
+
+Disposition:
+the planned-footprint readback confirms the natural-wonder offset class is not
+random surface noise: at least one supported multi-tile wonder in this exact
+run has live complete footprint coverage under a different direction than the
+local projection. The readback set is still only `2` planned multi-tile wonders
+from this request, and Kilimanjaro is live-partial/ambiguous, so this evidence
+does not yet authorize a global `Direction:-1` footprint repair. It does
+authorize the next source-owner decision to focus on local map-policy/mock
+natural-wonder projection versus Civ runtime materialization semantics, with a
+broader supported-catalog test or fresh exact-run proof required before repair
+closure.
+
 ## Required Next Diagnostics
 
 - Extract local row context for every feature/resource mismatch: terrain,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,9 +5,10 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-wonder-footprint-direction-drain`
-  stacked above `codex/swooper-feature-feasibility-readback-drain`; this slice
-  carries natural-wonder footprint direction context for feature-delta classes.
+- Branch/Graphite stack: `codex/swooper-wonder-footprint-readback-drain`
+  stacked above `codex/swooper-wonder-footprint-direction-drain`; this slice
+  carries planned natural-wonder footprint readback context across local and
+  live grids.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
@@ -16,8 +17,8 @@
   assignment-class, distribution-count, same-resource position, local
   materialization, future coordinate-proof instrumentation, coordinate-proof
   intake, feature-delta classification, local feature/wonder evidence joins,
-  feature feasibility readback, and natural-wonder footprint-direction context
-  now narrow the next repair classes.
+  feature feasibility readback, natural-wonder footprint-direction context, and
+  planned natural-wonder footprint readback now narrow the next repair classes.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -400,6 +401,25 @@
   projection and Civ runtime materialization. It still does not authorize a
   natural-wonder repair until the source owner is explicitly accepted and tested
   against broader wonder footprint behavior.
+- Planned natural-wonder footprint readback progress:
+  `buildNaturalWonderFootprintReadbackContexts` now scores every planned
+  natural wonder present in the local context artifact against local and live
+  feature grids across local map-policy directions `0..5`. The current
+  readback artifact is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-natural-wonder-footprint-readback.json`
+  (`sha256:50ecdd1bee31c8243dac792b2d8d9fe5faae4d422cf0cae44f95a696d86d16a3`,
+  `proofHash:3e0389b5977d997ce40d5888c97e703397b518e5ff034911be70a949afd1d6b4`).
+  The artifact covers the `2` planned multi-tile natural wonders represented in
+  the current local feature-context artifact. Both have declared direction
+  `-1`; local map-policy projection has best direction `0` for both. Live
+  readback is not uniformly direction `0`: Kilimanjaro has best live directions
+  `0,1,4,5` with partial live coverage (`2/3` cells) while Zhangjiajie has best
+  live direction `5` with complete live coverage (`2/2` cells). This confirms
+  the direction/footprint semantics gap is real for the readback set, but also
+  shows the evidence set is too small and partially ambiguous for a global
+  `Direction:-1` repair. The next repair layer must either collect broader
+  exact-run footprint evidence or explicitly constrain a repair to the accepted
+  owner surface and supported catalog behavior.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -431,9 +451,10 @@
   local and live immediate placement coordinate identity or otherwise assigns
   those subclasses to a concrete source owner. Feature rows are now split into
   a reef absence and two natural-wonder one-tile offsets, with local intent,
-  application, footprint evidence, runtime-bound `canHaveFeature` probes, and
-  footprint-direction alternatives now attached. The direction context points at
-  a likely natural-wonder footprint orientation semantics gap, but no feature or
+  application, footprint evidence, runtime-bound `canHaveFeature` probes,
+  footprint-direction alternatives, and planned-wonder readback context now
+  attached. The direction context points at a real natural-wonder footprint
+  orientation semantics gap in the current readback set, but no feature or
   natural-wonder repair is authorized until source ownership is accepted and the
   change is checked against the supported wonder catalog. The single
   substitution row where both probed values are infeasible remains an individual


### PR DESCRIPTION
Adds `buildNaturalWonderFootprintReadbackContexts`, which scores every planned natural wonder from the local context artifact against both local and live feature grids across all six map-policy direction alternatives (`0..5`). For each wonder, it computes per-direction footprint match counts, identifies the best-matching directions on each grid, and classifies the result as one of `local-live-same-direction`, `live-direction-differs-from-local`, `live-footprint-missing`, `local-footprint-missing`, or `unclassified`.

Supporting helpers include `countFeatureMatches`, `maxMatchCount`, `normalizeDirectionForReadback`, and `classifyNaturalWonderFootprintReadback`. Two new types, `NaturalWonderFootprintReadbackContext` and `NaturalWonderFootprintReadbackCandidate`, describe the per-wonder and per-direction output shapes.

Tests cover the matching case (Kilimanjaro footprint aligns on direction `0` in both grids) and the divergence case (local best direction `0`, live best direction `5`, classified as `live-direction-differs-from-local`).

The current readback artifact over the two planned multi-tile wonders in the active proof confirms the direction/footprint semantics gap is real: Zhangjiajie has complete live coverage under direction `5` while local projects direction `0`, and Kilimanjaro has only partial live coverage. The evidence set is too small and partially ambiguous to authorize a global `Direction:-1` footprint repair; the next step requires either broader exact-run footprint evidence or an explicit repair scoped to the accepted owner surface and supported catalog.