### PR TITLE
feat(swooper-wonder-catalog): add natural-wonder footprint catalog context with direction classification and readback disposition joins

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -1,5 +1,7 @@
 import {
   CIV7_BROWSER_TABLES_V0,
+  NATURAL_WONDER_CATALOG,
+  getNaturalWonderFootprintOffsets,
   getNaturalWonderFootprintIndices,
   isResourceAdjacentToLandRuntimeOptional,
 } from "@civ7/map-policy";
@@ -160,6 +162,43 @@ export type NaturalWonderFootprintReadbackCandidate = Readonly<{
   liveMatchCount: number;
   localComplete: boolean;
   liveComplete: boolean;
+}>;
+
+export type NaturalWonderFootprintCatalogContext = Readonly<{
+  featureType: number;
+  featureSymbol: string;
+  placementClass: string;
+  naturalWonderTiles: number;
+  declaredDirection: number;
+  localProjectionDirection: number;
+  localProjectionOffsets: ReadonlyArray<Readonly<{ dx: number; dy: number }>>;
+  supportedDirections: ReadonlyArray<NaturalWonderFootprintCatalogDirectionContext>;
+  directionClass:
+    | "single-tile-direction-irrelevant"
+    | "official-fixed-direction"
+    | "unspecified-engine-direction-local-fixed-projection"
+    | "unsupported";
+  observedReadbacks: ReadonlyArray<NaturalWonderFootprintCatalogReadbackContext>;
+  readbackDisposition:
+    | "no-exact-run-evidence"
+    | "observed-live-direction-drift"
+    | "observed-ambiguous-or-partial"
+    | "observed-local-live-aligned";
+}>;
+
+export type NaturalWonderFootprintCatalogDirectionContext = Readonly<{
+  direction: number;
+  offsets: ReadonlyArray<Readonly<{ dx: number; dy: number }>>;
+}>;
+
+export type NaturalWonderFootprintCatalogReadbackContext = Readonly<{
+  anchorPlotIndex: number;
+  declaredDirection: number;
+  bestLocalDirections: ReadonlyArray<number>;
+  bestLiveDirections: ReadonlyArray<number>;
+  bestLocalMatchCount: number;
+  bestLiveMatchCount: number;
+  classification: NaturalWonderFootprintReadbackContext["classification"];
 }>;
 
 export type ResourceDeltaPlacementContext = Readonly<{
@@ -454,6 +493,56 @@ export function buildNaturalWonderFootprintReadbackContexts(
       bestLocalMatchCount,
       bestLiveMatchCount,
       classification,
+    };
+  });
+}
+
+export function buildNaturalWonderFootprintCatalogContexts(
+  readbacks: ReadonlyArray<NaturalWonderFootprintReadbackContext> = []
+): ReadonlyArray<NaturalWonderFootprintCatalogContext> {
+  const readbacksByFeature = new Map<number, NaturalWonderFootprintCatalogReadbackContext[]>();
+  for (const readback of readbacks) {
+    const bucket = readbacksByFeature.get(readback.featureType) ?? [];
+    bucket.push({
+      anchorPlotIndex: readback.anchorPlotIndex,
+      declaredDirection: readback.declaredDirection,
+      bestLocalDirections: readback.bestLocalDirections,
+      bestLiveDirections: readback.bestLiveDirections,
+      bestLocalMatchCount: readback.bestLocalMatchCount,
+      bestLiveMatchCount: readback.bestLiveMatchCount,
+      classification: readback.classification,
+    });
+    readbacksByFeature.set(readback.featureType, bucket);
+  }
+
+  return NATURAL_WONDER_CATALOG.map((entry) => {
+    const policy = CIV7_BROWSER_TABLES_V0.featurePolicies[String(entry.featureType)] ?? {};
+    const naturalWonderTiles = Math.max(1, Math.trunc(numberValue(policy.naturalWonderTiles) ?? 1));
+    const localProjectionDirection = normalizeDirectionForReadback(entry.direction);
+    const localProjectionOffsets = [...(getNaturalWonderFootprintOffsets(policy, entry.direction) ?? [])];
+    const supportedDirections = [0, 1, 2, 3, 4, 5].flatMap((direction) => {
+      const offsets = getNaturalWonderFootprintOffsets(policy, direction);
+      if (!offsets) return [];
+      return [{ direction, offsets: [...offsets] }];
+    });
+    const directionClass = naturalWonderDirectionClass({
+      naturalWonderTiles,
+      declaredDirection: entry.direction,
+      supportedDirections,
+    });
+    const observedReadbacks = readbacksByFeature.get(entry.featureType) ?? [];
+    return {
+      featureType: entry.featureType,
+      featureSymbol: symbolFor("feature", entry.featureType),
+      placementClass: stringValue(policy.placementClass) ?? "ONE",
+      naturalWonderTiles,
+      declaredDirection: entry.direction,
+      localProjectionDirection,
+      localProjectionOffsets,
+      supportedDirections,
+      directionClass,
+      observedReadbacks,
+      readbackDisposition: naturalWonderReadbackDisposition(observedReadbacks),
     };
   });
 }
@@ -941,6 +1030,38 @@ function classifyNaturalWonderFootprintReadback(args: {
     args.bestLiveDirections.includes(direction)
   );
   return sharedDirection ? "local-live-same-direction" : "live-direction-differs-from-local";
+}
+
+function naturalWonderDirectionClass(args: {
+  naturalWonderTiles: number;
+  declaredDirection: number;
+  supportedDirections: ReadonlyArray<NaturalWonderFootprintCatalogDirectionContext>;
+}): NaturalWonderFootprintCatalogContext["directionClass"] {
+  if (args.supportedDirections.length === 0) return "unsupported";
+  if (args.naturalWonderTiles <= 1) return "single-tile-direction-irrelevant";
+  if (args.declaredDirection >= 0) return "official-fixed-direction";
+  return "unspecified-engine-direction-local-fixed-projection";
+}
+
+function naturalWonderReadbackDisposition(
+  observedReadbacks: ReadonlyArray<NaturalWonderFootprintCatalogReadbackContext>
+): NaturalWonderFootprintCatalogContext["readbackDisposition"] {
+  if (observedReadbacks.length === 0) return "no-exact-run-evidence";
+  if (observedReadbacks.some((readback) => readback.classification === "live-direction-differs-from-local")) {
+    return "observed-live-direction-drift";
+  }
+  if (
+    observedReadbacks.some(
+      (readback) =>
+        readback.classification === "live-footprint-missing" ||
+        readback.classification === "local-footprint-missing" ||
+        readback.bestLiveDirections.length > 1 ||
+        readback.bestLocalDirections.length > 1
+    )
+  ) {
+    return "observed-ambiguous-or-partial";
+  }
+  return "observed-local-live-aligned";
 }
 
 function addResourceSurfaceReasons(

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { FinalSurfaceSnapshot } from "../../src/dev/diagnostics/live-parity";
 import {
   buildFeatureDeltaPlacementContexts,
+  buildNaturalWonderFootprintCatalogContexts,
   buildNaturalWonderFootprintReadbackContexts,
   buildResourceDeltaFeasibilityContexts,
   buildResourceDeltaPlacementContexts,
@@ -209,6 +210,74 @@ describe("surface delta context diagnostics", () => {
       bestLocalDirections: expect.arrayContaining([0]),
       bestLiveDirections: expect.arrayContaining([5]),
       classification: "live-direction-differs-from-local",
+    });
+  });
+
+  test("exposes unsupported repair authority for unspecified multi-tile wonder directions", () => {
+    const rows = buildNaturalWonderFootprintCatalogContexts();
+    const kilimanjaro = rows.find((row) => row.featureSymbol === "FEATURE_KILIMANJARO");
+    const fuji = rows.find((row) => row.featureSymbol === "FEATURE_MOUNT_FUJI");
+    const uluru = rows.find((row) => row.featureSymbol === "FEATURE_ULURU");
+
+    expect(kilimanjaro).toMatchObject({
+      declaredDirection: -1,
+      localProjectionDirection: 0,
+      naturalWonderTiles: 3,
+      directionClass: "unspecified-engine-direction-local-fixed-projection",
+      readbackDisposition: "no-exact-run-evidence",
+    });
+    expect(kilimanjaro?.supportedDirections.map((row) => row.direction)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(kilimanjaro?.localProjectionOffsets).toEqual([
+      { dx: 0, dy: 0 },
+      { dx: 1, dy: 1 },
+      { dx: 1, dy: 0 },
+    ]);
+    expect(fuji).toMatchObject({
+      declaredDirection: 2,
+      localProjectionDirection: 2,
+      directionClass: "official-fixed-direction",
+    });
+    expect(uluru).toMatchObject({
+      naturalWonderTiles: 1,
+      directionClass: "single-tile-direction-irrelevant",
+    });
+  });
+
+  test("joins exact-run readback evidence to natural-wonder catalog direction classes", () => {
+    const local = snapshot({
+      feature: { width: 3, height: 2, values: [-1, 36, -1, -1, -1, 36] },
+    }, {
+      naturalWonderPlan: {
+        width: 3,
+        height: 2,
+        wondersCount: 1,
+        targetCount: 1,
+        plannedCount: 1,
+        placements: [
+          { plotIndex: 1, featureType: 36, direction: -1, elevation: 1000, priority: 0.9 },
+        ],
+      },
+    });
+    const live = snapshot({
+      feature: { width: 3, height: 2, values: [-1, 36, -1, -1, 36, -1] },
+    });
+    const readbacks = buildNaturalWonderFootprintReadbackContexts({ local, live });
+
+    const catalog = buildNaturalWonderFootprintCatalogContexts(readbacks);
+    const zhangjiajie = catalog.find((row) => row.featureSymbol === "FEATURE_ZHANGJIAJIE");
+
+    expect(zhangjiajie).toMatchObject({
+      declaredDirection: -1,
+      directionClass: "unspecified-engine-direction-local-fixed-projection",
+      readbackDisposition: "observed-live-direction-drift",
+      observedReadbacks: [
+        {
+          declaredDirection: -1,
+          bestLocalDirections: [0],
+          bestLiveDirections: [5],
+          classification: "live-direction-differs-from-local",
+        },
+      ],
     });
   });
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/proposal.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/proposal.md
@@ -36,8 +36,11 @@ truth.
 - Feature hypotheses:
   one `FEATURE_COLD_REEF` local-only row may indicate Civ feature legality
   beyond mock/static policy; Kilimanjaro and Zhangjiajie one-tile offsets may
-  indicate natural-wonder footprint anchor/direction semantics drift. Neither
-  hypothesis is a completed source-authority classification.
+  indicate natural-wonder footprint anchor/direction semantics drift. Current
+  supported-catalog context shows `5` multi-tile natural wonders have official
+  `naturalWonderDirection:-1` while local projection materializes that as
+  direction `0`; exact-run readback observes only Kilimanjaro and Zhangjiajie,
+  so the class is narrowed but not yet a global repair authority.
 - Resource hypotheses:
   the `106/6996` mismatch class includes relocation/substitution patterns that
   may come from mock/static resource legality, assignment-order divergence from

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -52,8 +52,10 @@
   rows.
 - [x] 2.24 Add planned natural-wonder footprint readback context across local
   and live grids.
-- [ ] 2.25 Repair remaining proven package or MapGen owners.
-- [ ] 2.26 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.25 Add supported-catalog direction context for natural-wonder footprint
+  readback rows.
+- [ ] 2.26 Repair remaining proven package or MapGen owners.
+- [ ] 2.27 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -771,6 +771,52 @@ natural-wonder projection versus Civ runtime materialization semantics, with a
 broader supported-catalog test or fresh exact-run proof required before repair
 closure.
 
+### Supported Natural-Wonder Footprint Catalog Context
+
+Diagnostic repair:
+`buildNaturalWonderFootprintCatalogContexts` now exposes the supported
+natural-wonder catalog direction classes and joins exact-run footprint readback
+rows by feature type. This records where official `naturalWonderDirection:-1`
+is currently projected locally as direction `0`, without changing placement or
+stamping behavior.
+
+The current catalog context artifact is
+`/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-natural-wonder-footprint-catalog-context.json`
+(`sha256:34211c105979d84b780278e76e838102cea47c7c45e3fb9c24499cf5e34046ab`,
+`proofHash:6ace44be42fc7b2a87d4a393d1ecb2c52af7bcb58dd90acdcc6e553e6338c009`).
+It is derived from the planned-footprint readback artifact; it is not a fresh
+exact-authored parity proof.
+
+Catalog facts:
+
+| Direction class | Count | Meaning |
+|---|---:|---|
+| `single-tile-direction-irrelevant` | `3` | Supported one-tile wonders where direction cannot move the footprint. |
+| `official-fixed-direction` | `2` | Supported multi-tile wonders with explicit official direction values. |
+| `unspecified-engine-direction-local-fixed-projection` | `5` | Supported multi-tile wonders with official `naturalWonderDirection:-1`; local projection currently uses direction `0`. |
+
+Unspecified multi-tile catalog entries:
+`FEATURE_REDWOOD_FOREST`, `FEATURE_KILIMANJARO`, `FEATURE_ZHANGJIAJIE`,
+`FEATURE_TORRES_DEL_PAINE`, and `FEATURE_MACHAPUCHARE`.
+
+Exact-run observed rows:
+
+| Feature | Direction class | Readback disposition | Evidence |
+|---|---|---|---|
+| `FEATURE_KILIMANJARO` | `unspecified-engine-direction-local-fixed-projection` | `observed-ambiguous-or-partial` | local best direction `0` with `3/3`; live best directions `0,1,4,5` with `2/3`. |
+| `FEATURE_ZHANGJIAJIE` | `unspecified-engine-direction-local-fixed-projection` | `observed-live-direction-drift` | local best direction `0` with `2/2`; live best direction `5` with `2/2`. |
+
+Disposition:
+the catalog context strengthens the classification that the natural-wonder
+offset class belongs at the map-policy/mock natural-wonder projection versus
+Civ runtime materialization boundary, not ecology feature density or resource
+legality. It still does not authorize a global `Direction:-1` repair: only
+`2/5` unspecified multi-tile entries have exact-run readback evidence here, and
+Kilimanjaro remains ambiguous/partial. A repair layer must either collect
+broader exact-run footprint evidence or explicitly constrain its owner claim to
+supported catalog behavior with tests that protect fixed-direction and
+single-tile entries.
+
 ## Required Next Diagnostics
 
 - Extract local row context for every feature/resource mismatch: terrain,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,10 +5,10 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-wonder-footprint-readback-drain`
-  stacked above `codex/swooper-wonder-footprint-direction-drain`; this slice
-  carries planned natural-wonder footprint readback context across local and
-  live grids.
+- Branch/Graphite stack: `codex/swooper-wonder-catalog-direction-drain`
+  stacked above `codex/swooper-wonder-footprint-readback-drain`; this slice
+  carries supported-catalog direction context for planned natural-wonder
+  readback rows.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
@@ -17,8 +17,9 @@
   assignment-class, distribution-count, same-resource position, local
   materialization, future coordinate-proof instrumentation, coordinate-proof
   intake, feature-delta classification, local feature/wonder evidence joins,
-  feature feasibility readback, natural-wonder footprint-direction context, and
-  planned natural-wonder footprint readback now narrow the next repair classes.
+  feature feasibility readback, natural-wonder footprint-direction context,
+  planned natural-wonder footprint readback, and supported-catalog direction
+  context now narrow the next repair classes.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -420,6 +421,23 @@
   `Direction:-1` repair. The next repair layer must either collect broader
   exact-run footprint evidence or explicitly constrain a repair to the accepted
   owner surface and supported catalog behavior.
+- Supported natural-wonder catalog context progress:
+  `buildNaturalWonderFootprintCatalogContexts` now exposes the supported
+  natural-wonder catalog direction classes and joins the exact-run footprint
+  readback rows by feature type. The current catalog context artifact is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-natural-wonder-footprint-catalog-context.json`
+  (`sha256:34211c105979d84b780278e76e838102cea47c7c45e3fb9c24499cf5e34046ab`,
+  `proofHash:6ace44be42fc7b2a87d4a393d1ecb2c52af7bcb58dd90acdcc6e553e6338c009`).
+  It records `10` supported natural-wonder catalog entries: `3`
+  single-tile entries where direction is irrelevant, `2` fixed-direction
+  multi-tile entries, and `5` multi-tile entries with official
+  `naturalWonderDirection:-1` that the local projection currently materializes
+  as direction `0`. The exact run observes `FEATURE_KILIMANJARO` as ambiguous
+  or partial and `FEATURE_ZHANGJIAJIE` as live direction drift. This strengthens
+  the source-owner focus toward local map-policy/mock natural-wonder
+  projection versus Civ runtime materialization semantics, but it still does
+  not authorize a global repair because only `2/5` unspecified multi-tile
+  catalog entries have exact-run readback evidence in this proof.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -453,10 +471,14 @@
   a reef absence and two natural-wonder one-tile offsets, with local intent,
   application, footprint evidence, runtime-bound `canHaveFeature` probes,
   footprint-direction alternatives, and planned-wonder readback context now
-  attached. The direction context points at a real natural-wonder footprint
-  orientation semantics gap in the current readback set, but no feature or
-  natural-wonder repair is authorized until source ownership is accepted and the
-  change is checked against the supported wonder catalog. The single
+  attached. Supported-catalog context now shows `5` unspecified multi-tile
+  entries where local projection fixes direction `-1` to direction `0`, with
+  exact-run readback for Kilimanjaro and Zhangjiajie only. The direction
+  context points at a real natural-wonder footprint orientation semantics gap
+  in the current readback set, but no feature or natural-wonder repair is
+  authorized until source ownership is accepted and the change is checked
+  against the remaining supported unspecified multi-tile catalog behavior or a
+  fresh exact-run proof. The single
   substitution row where both probed values are infeasible remains an individual
   evidence row with no repair authority until row-level context assigns source
   ownership.


### PR DESCRIPTION
Adds `buildNaturalWonderFootprintCatalogContexts`, which joins the full supported natural-wonder catalog against exact-run footprint readback rows by feature type. Each catalog entry exposes its direction class (`single-tile-direction-irrelevant`, `official-fixed-direction`, or `unspecified-engine-direction-local-fixed-projection`), supported per-direction offset sets, local projection direction and offsets, and a readback disposition derived from any observed exact-run evidence.

The catalog reveals 5 multi-tile natural wonders with official `naturalWonderDirection:-1` that local projection currently materializes as direction `0` (`FEATURE_REDWOOD_FOREST`, `FEATURE_KILIMANJARO`, `FEATURE_ZHANGJIAJIE`, `FEATURE_TORRES_DEL_PAINE`, `FEATURE_MACHAPUCHARE`). Of these, only Kilimanjaro and Zhangjiajie have exact-run readback evidence in the current proof set: Kilimanjaro is ambiguous/partial and Zhangjiajie shows live direction drift. This strengthens the source-owner focus toward the map-policy/mock natural-wonder projection boundary but does not authorize a global `Direction:-1` repair, since only 2 of 5 unspecified multi-tile entries have exact-run coverage.

Tests cover direction class assignment across representative wonders (Kilimanjaro, Fuji, Uluru) and verify that exact-run readback evidence is correctly joined and reflected in the readback disposition.