### PR TITLE
feat(swooper-wonder): add natural-wonder live proof boundary context for local-only placement stats

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -7,7 +7,11 @@ import {
 } from "@civ7/map-policy";
 import { hexDistanceOddQPeriodicX } from "@swooper/mapgen-core/lib/grid";
 
-import type { FinalSurfaceKey, FinalSurfaceParityProof, FinalSurfaceSnapshot } from "./live-parity.js";
+import type {
+  FinalSurfaceKey,
+  FinalSurfaceParityProof,
+  FinalSurfaceSnapshot,
+} from "./live-parity.js";
 
 export type ClassifiableSurfaceKey = Extract<FinalSurfaceKey, "feature" | "resource">;
 
@@ -199,6 +203,26 @@ export type NaturalWonderFootprintCatalogReadbackContext = Readonly<{
   bestLocalMatchCount: number;
   bestLiveMatchCount: number;
   classification: NaturalWonderFootprintReadbackContext["classification"];
+}>;
+
+export type NaturalWonderLiveProofBoundaryContext = Readonly<{
+  localPlacementStats: NaturalWonderPlacementStatsContext | null;
+  liveProofPlacementStats: NaturalWonderPlacementStatsContext | null;
+  liveCompletionPlacementStats: NaturalWonderPlacementStatsContext | null;
+  boundaryClass:
+    | "local-and-live-placement-stats-present"
+    | "local-placement-stats-only"
+    | "live-placement-stats-only"
+    | "placement-stats-missing";
+  unresolvedLinks: ReadonlyArray<string>;
+}>;
+
+export type NaturalWonderPlacementStatsContext = Readonly<{
+  plannedCount: number | null;
+  targetCount: number | null;
+  placedCount: number | null;
+  rejectedCount: number | null;
+  shortfallCount: number | null;
 }>;
 
 export type ResourceDeltaPlacementContext = Readonly<{
@@ -545,6 +569,32 @@ export function buildNaturalWonderFootprintCatalogContexts(
       readbackDisposition: naturalWonderReadbackDisposition(observedReadbacks),
     };
   });
+}
+
+export function buildNaturalWonderLiveProofBoundaryContext(
+  proof: Pick<FinalSurfaceParityProof, "local" | "exactAuthorshipPacket">
+): NaturalWonderLiveProofBoundaryContext {
+  const localPlacementStats = readNaturalWonderPlacementStats(proof.local.evidence?.naturalWonderPlacement);
+  const liveProofPlacementStats = readNaturalWonderPlacementStatsFromLogPayload(
+    proof.exactAuthorshipPacket?.log,
+    "proofPayload"
+  );
+  const liveCompletionPlacementStats = readNaturalWonderPlacementStatsFromLogPayload(
+    proof.exactAuthorshipPacket?.log,
+    "completionPayload"
+  );
+  const hasLocal = localPlacementStats !== null;
+  const hasLive = liveProofPlacementStats !== null || liveCompletionPlacementStats !== null;
+  const unresolvedLinks: string[] = [];
+  if (!hasLocal) unresolvedLinks.push("natural-wonder.local-placement-stats");
+  if (!hasLive) unresolvedLinks.push("natural-wonder.live-placement-stats");
+  return {
+    localPlacementStats,
+    liveProofPlacementStats,
+    liveCompletionPlacementStats,
+    boundaryClass: naturalWonderLiveProofBoundaryClass({ hasLocal, hasLive }),
+    unresolvedLinks,
+  };
 }
 
 export function buildResourceDeltaPlacementContexts(
@@ -1062,6 +1112,38 @@ function naturalWonderReadbackDisposition(
     return "observed-ambiguous-or-partial";
   }
   return "observed-local-live-aligned";
+}
+
+function naturalWonderLiveProofBoundaryClass(args: {
+  hasLocal: boolean;
+  hasLive: boolean;
+}): NaturalWonderLiveProofBoundaryContext["boundaryClass"] {
+  if (args.hasLocal && args.hasLive) return "local-and-live-placement-stats-present";
+  if (args.hasLocal) return "local-placement-stats-only";
+  if (args.hasLive) return "live-placement-stats-only";
+  return "placement-stats-missing";
+}
+
+function readNaturalWonderPlacementStats(value: unknown): NaturalWonderPlacementStatsContext | null {
+  if (!isRecord(value)) return null;
+  const stats = {
+    plannedCount: numberValue(value.plannedCount),
+    targetCount: numberValue(value.targetCount),
+    placedCount: numberValue(value.placedCount),
+    rejectedCount: numberValue(value.rejectedCount),
+    shortfallCount: numberValue(value.shortfallCount),
+  };
+  return Object.values(stats).some((entry) => entry !== null) ? stats : null;
+}
+
+function readNaturalWonderPlacementStatsFromLogPayload(
+  log: unknown,
+  payloadKey: "proofPayload" | "completionPayload"
+): NaturalWonderPlacementStatsContext | null {
+  if (!isRecord(log)) return null;
+  const payload = log[payloadKey];
+  if (!isRecord(payload)) return null;
+  return readNaturalWonderPlacementStats(payload.naturalWonderPlacement);
 }
 
 function addResourceSurfaceReasons(

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -4,6 +4,7 @@ import type { FinalSurfaceSnapshot } from "../../src/dev/diagnostics/live-parity
 import {
   buildFeatureDeltaPlacementContexts,
   buildNaturalWonderFootprintCatalogContexts,
+  buildNaturalWonderLiveProofBoundaryContext,
   buildNaturalWonderFootprintReadbackContexts,
   buildResourceDeltaFeasibilityContexts,
   buildResourceDeltaPlacementContexts,
@@ -278,6 +279,80 @@ describe("surface delta context diagnostics", () => {
           classification: "live-direction-differs-from-local",
         },
       ],
+    });
+  });
+
+  test("keeps natural-wonder placement proof unresolved when stats are local-only", () => {
+    const local = snapshot({}, {
+      naturalWonderPlacement: {
+        plannedCount: 7,
+        targetCount: 7,
+        placedCount: 7,
+        rejectedCount: 0,
+        shortfallCount: 0,
+      },
+    });
+
+    const context = buildNaturalWonderLiveProofBoundaryContext({
+      local,
+      exactAuthorshipPacket: {
+        log: {
+          requestId: "studio-run-in-game-test",
+        },
+      },
+    });
+
+    expect(context).toMatchObject({
+      localPlacementStats: {
+        plannedCount: 7,
+        targetCount: 7,
+        placedCount: 7,
+        rejectedCount: 0,
+        shortfallCount: 0,
+      },
+      liveProofPlacementStats: null,
+      liveCompletionPlacementStats: null,
+      boundaryClass: "local-placement-stats-only",
+      unresolvedLinks: ["natural-wonder.live-placement-stats"],
+    });
+  });
+
+  test("accepts natural-wonder placement stats only when live proof payload carries them", () => {
+    const local = snapshot({}, {
+      naturalWonderPlacement: {
+        plannedCount: 7,
+        placedCount: 7,
+      },
+    });
+
+    const context = buildNaturalWonderLiveProofBoundaryContext({
+      local,
+      exactAuthorshipPacket: exactAuthorshipPacket({
+        log: {
+          completionPayload: {
+            naturalWonderPlacement: {
+              plannedCount: 7,
+              targetCount: 7,
+              placedCount: 7,
+              rejectedCount: 0,
+              shortfallCount: 0,
+            },
+          },
+        },
+      }),
+    });
+
+    expect(context).toMatchObject({
+      liveProofPlacementStats: null,
+      liveCompletionPlacementStats: {
+        plannedCount: 7,
+        targetCount: 7,
+        placedCount: 7,
+        rejectedCount: 0,
+        shortfallCount: 0,
+      },
+      boundaryClass: "local-and-live-placement-stats-present",
+      unresolvedLinks: [],
     });
   });
 
@@ -592,4 +667,12 @@ function feasibilityCell(
       ])
     ),
   };
+}
+
+function exactAuthorshipPacket(value: unknown): NonNullable<
+  Parameters<typeof buildNaturalWonderLiveProofBoundaryContext>[0]["exactAuthorshipPacket"]
+> {
+  return value as NonNullable<
+    Parameters<typeof buildNaturalWonderLiveProofBoundaryContext>[0]["exactAuthorshipPacket"]
+  >;
 }

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/proposal.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/proposal.md
@@ -40,7 +40,10 @@ truth.
   supported-catalog context shows `5` multi-tile natural wonders have official
   `naturalWonderDirection:-1` while local projection materializes that as
   direction `0`; exact-run readback observes only Kilimanjaro and Zhangjiajie,
-  so the class is narrowed but not yet a global repair authority.
+  so the class is narrowed but not yet a global repair authority. Current
+  natural-wonder placement counts are local diagnostic evidence only; the
+  exact live proof/completion payloads for the request do not yet carry
+  `naturalWonderPlacement` stats.
 - Resource hypotheses:
   the `106/6996` mismatch class includes relocation/substitution patterns that
   may come from mock/static resource legality, assignment-order divergence from

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -54,8 +54,10 @@
   and live grids.
 - [x] 2.25 Add supported-catalog direction context for natural-wonder footprint
   readback rows.
-- [ ] 2.26 Repair remaining proven package or MapGen owners.
-- [ ] 2.27 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.26 Add natural-wonder live proof boundary context for local-only
+  placement stats.
+- [ ] 2.27 Repair remaining proven package or MapGen owners.
+- [ ] 2.28 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -817,6 +817,39 @@ broader exact-run footprint evidence or explicitly constrain its owner claim to
 supported catalog behavior with tests that protect fixed-direction and
 single-tile entries.
 
+### Natural-Wonder Live Proof Boundary
+
+Diagnostic repair:
+`buildNaturalWonderLiveProofBoundaryContext` now records whether
+natural-wonder placement stats are present in local diagnostic evidence, the
+exact live proof payload, and the exact live completion payload. This keeps
+local placement counts from being mistaken for exact live natural-wonder
+authorship evidence.
+
+The current live-proof boundary artifact is
+`/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-natural-wonder-live-proof-boundary.json`
+(`sha256:1cd7da84ac26417f46c851b51e9abe4e146c0b4150c3a5ca104d577f1647ea4a`,
+`proofHash:156386737ebde2b38fee76a3a8d716291acefb285be19a2a226129139ec81557`).
+It is derived from the saved exact parity proof and prior local feature-context
+artifact; it is not a fresh exact-authored parity proof.
+
+Placement proof facts:
+
+| Evidence source | Placement stats | Boundary |
+|---|---|---|
+| Local feature evidence | `planned:7`, `target:7`, `placed:7`, `rejected:0`, `shortfall:0` | Local exact-source diagnostic evidence only. |
+| Exact proof payload | missing | No `naturalWonderPlacement` stats in the live proof payload. |
+| Exact completion payload | missing | No `naturalWonderPlacement` stats in the live completion payload. |
+
+Disposition:
+the boundary class is `local-placement-stats-only` and the artifact carries
+unresolved link `natural-wonder.live-placement-stats`. The local placement
+stats support row classification, but they do not close source authority for a
+natural-wonder repair because the exact live proof packet does not yet carry
+corresponding natural-wonder placement stats for the same request/config/seed
+chain. No natural-wonder repair, parity closure, product acceptance, or
+mountain-quality claim is authorized from local placement counts alone.
+
 ## Required Next Diagnostics
 
 - Extract local row context for every feature/resource mismatch: terrain,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,10 +5,10 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-wonder-catalog-direction-drain`
-  stacked above `codex/swooper-wonder-footprint-readback-drain`; this slice
-  carries supported-catalog direction context for planned natural-wonder
-  readback rows.
+- Branch/Graphite stack: `codex/swooper-wonder-live-proof-boundary-drain`
+  stacked above `codex/swooper-wonder-catalog-direction-drain`; this slice
+  carries natural-wonder live proof boundary context for local-only placement
+  stats.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
@@ -18,8 +18,9 @@
   materialization, future coordinate-proof instrumentation, coordinate-proof
   intake, feature-delta classification, local feature/wonder evidence joins,
   feature feasibility readback, natural-wonder footprint-direction context,
-  planned natural-wonder footprint readback, and supported-catalog direction
-  context now narrow the next repair classes.
+  planned natural-wonder footprint readback, supported-catalog direction
+  context, and natural-wonder live proof boundary context now narrow the next
+  repair classes.
   Remaining feature/resource classes still need source-authority classification
   before repair.
 
@@ -438,6 +439,21 @@
   projection versus Civ runtime materialization semantics, but it still does
   not authorize a global repair because only `2/5` unspecified multi-tile
   catalog entries have exact-run readback evidence in this proof.
+- Natural-wonder live proof boundary progress:
+  `buildNaturalWonderLiveProofBoundaryContext` now compares local
+  natural-wonder placement stats with the exact-authorship proof and completion
+  log payloads. The current boundary artifact is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-natural-wonder-live-proof-boundary.json`
+  (`sha256:1cd7da84ac26417f46c851b51e9abe4e146c0b4150c3a5ca104d577f1647ea4a`,
+  `proofHash:156386737ebde2b38fee76a3a8d716291acefb285be19a2a226129139ec81557`).
+  It preserves the local exact-source placement stats (`plannedCount:7`,
+  `targetCount:7`, `placedCount:7`, `rejectedCount:0`, `shortfallCount:0`) and
+  records that both exact live proof payloads lack `naturalWonderPlacement`
+  stats. The boundary class is `local-placement-stats-only` with unresolved
+  link `natural-wonder.live-placement-stats`. This blocks natural-wonder repair
+  authority from relying on local placement counts alone; the next accepted
+  movement must either instrument exact live natural-wonder placement evidence
+  or explicitly classify ownership from a stronger exact-run source.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -475,10 +491,12 @@
   entries where local projection fixes direction `-1` to direction `0`, with
   exact-run readback for Kilimanjaro and Zhangjiajie only. The direction
   context points at a real natural-wonder footprint orientation semantics gap
-  in the current readback set, but no feature or natural-wonder repair is
-  authorized until source ownership is accepted and the change is checked
-  against the remaining supported unspecified multi-tile catalog behavior or a
-  fresh exact-run proof. The single
+  in the current readback set, while the live proof boundary now shows
+  natural-wonder placement counts are local-only and absent from the exact live
+  proof/completion payloads. No feature or natural-wonder repair is authorized
+  until source ownership is accepted and the change is checked against the
+  remaining supported unspecified multi-tile catalog behavior, exact live
+  placement evidence, or a fresh exact-run proof. The single
   substitution row where both probed values are infeasible remains an individual
   evidence row with no repair authority until row-level context assigns source
   ownership.


### PR DESCRIPTION
Adds `buildNaturalWonderLiveProofBoundaryContext` to the surface delta diagnostics layer, which compares natural-wonder placement stats from local feature evidence against the exact-authorship proof payload and completion payload. The context produces a `boundaryClass` (`local-and-live-placement-stats-present`, `local-placement-stats-only`, `live-placement-stats-only`, or `placement-stats-missing`) and an `unresolvedLinks` list that flags which sides of the boundary are absent.

The current boundary artifact shows `boundaryClass: local-placement-stats-only` with unresolved link `natural-wonder.live-placement-stats`, meaning the exact live proof and completion payloads do not yet carry `naturalWonderPlacement` stats. This prevents local placement counts (`planned:7`, `target:7`, `placed:7`, `rejected:0`, `shortfall:0`) from being mistaken for exact live authorship evidence, and blocks natural-wonder repair authority until either exact live placement stats are instrumented or ownership is established from a stronger exact-run source.

Tests cover the local-only case (live stats absent, unresolved link emitted) and the case where the completion payload carries placement stats (boundary resolves to `local-and-live-placement-stats-present`, no unresolved links). Task 2.26 is marked complete and the proposal, ledger, and phase record are updated to reflect the boundary finding.