### PR TITLE
feat(earthlike-terrain-edge-diagnostics): add terrain delta edge context extraction, neighborhood classification, and coast/ocean swap diagnostics

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -316,6 +316,60 @@ export type ResourceFeasibilityRuntimeProbeLike<T> = Readonly<{
   error?: string;
 }>;
 
+export type TerrainDeltaEdgeContext = Readonly<{
+  x: number;
+  y: number;
+  plotIndex: number;
+  localTerrain: Readonly<{
+    value: number | null;
+    symbol: string;
+    context: CellSurfaceContext;
+  }>;
+  liveTerrain: Readonly<{
+    value: number | null;
+    symbol: string;
+    context: CellSurfaceContext;
+  }>;
+  neighborhood: TerrainDeltaNeighborhoodContext;
+  evidenceClass:
+    | "local-ocean-live-coast"
+    | "local-coast-live-ocean"
+    | "water-terrain-edge-swap"
+    | "unclassified";
+  sourceAuthorityStatus: "unresolved";
+  ownerCandidates: ReadonlyArray<
+    | "map-morphology-coast-shelf-projection"
+    | "map-hydrology-water-mutation"
+    | "civ-engine-terrain-validation"
+    | "evidence-insufficient"
+  >;
+}>;
+
+export type TerrainDeltaNeighborhoodContext = Readonly<{
+  neighbors: ReadonlyArray<TerrainDeltaNeighborContext>;
+  localCounts: TerrainNeighborhoodCounts;
+  liveCounts: TerrainNeighborhoodCounts;
+}>;
+
+export type TerrainDeltaNeighborContext = Readonly<{
+  direction: number;
+  x: number;
+  y: number;
+  plotIndex: number;
+  localTerrain: Readonly<{ value: number | null; symbol: string; waterClass: TerrainWaterClass }>;
+  liveTerrain: Readonly<{ value: number | null; symbol: string; waterClass: TerrainWaterClass }>;
+}>;
+
+export type TerrainNeighborhoodCounts = Readonly<{
+  coast: number;
+  ocean: number;
+  otherWater: number;
+  land: number;
+  empty: number;
+}>;
+
+export type TerrainWaterClass = "coast" | "ocean" | "other-water" | "land" | "empty";
+
 export type ResourcePlacementOutcomeContext = Readonly<{
   status: string;
   resourceType: number;
@@ -711,6 +765,48 @@ export function buildResourceDeltaFeasibilityContexts(
       }),
     };
   });
+}
+
+export function buildTerrainDeltaEdgeContexts(
+  proof: Pick<FinalSurfaceParityProof, "local" | "live">,
+  options: { maxRows?: number } = {}
+): ReadonlyArray<TerrainDeltaEdgeContext> {
+  const maxRows = options.maxRows ?? Number.POSITIVE_INFINITY;
+  const rows: TerrainDeltaEdgeContext[] = [];
+  const localValues = proof.local.surfaces.terrain.values;
+  const liveValues = proof.live.surfaces.terrain.values;
+  const length = Math.min(localValues.length, liveValues.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const localTerrain = normalizeSurfaceValue(localValues[index]);
+    const liveTerrain = normalizeSurfaceValue(liveValues[index]);
+    if (localTerrain === liveTerrain) continue;
+    const y = Math.floor(index / proof.local.width);
+    const x = index - y * proof.local.width;
+    const neighborhood = terrainDeltaNeighborhood(proof.local, proof.live, x, y);
+    rows.push({
+      x,
+      y,
+      plotIndex: index,
+      localTerrain: {
+        value: localTerrain,
+        symbol: symbolFor("terrain", localTerrain),
+        context: cellSurfaceContext(proof.local, x, y),
+      },
+      liveTerrain: {
+        value: liveTerrain,
+        symbol: symbolFor("terrain", liveTerrain),
+        context: cellSurfaceContext(proof.live, x, y),
+      },
+      neighborhood,
+      evidenceClass: classifyTerrainDeltaEdge(localTerrain, liveTerrain),
+      sourceAuthorityStatus: "unresolved",
+      ownerCandidates: terrainOwnerCandidates(localTerrain, liveTerrain),
+    });
+    if (rows.length >= maxRows) return rows;
+  }
+
+  return rows;
 }
 
 export function buildSurfaceDeltaContext(
@@ -1283,6 +1379,102 @@ function hasAdjacentLand(snapshot: SnapshotLike, x: number, y: number): boolean 
     if (terrain !== null && !WATER_TERRAINS.has(terrain)) return true;
   }
   return false;
+}
+
+function terrainDeltaNeighborhood(
+  local: SnapshotLike,
+  live: SnapshotLike,
+  x: number,
+  y: number
+): TerrainDeltaNeighborhoodContext {
+  const offsets = (x & 1) === 1 ? ODD_Q_NEIGHBORS_ODD : ODD_Q_NEIGHBORS_EVEN;
+  const neighbors = offsets.flatMap(([dx, dy], direction): ReadonlyArray<TerrainDeltaNeighborContext> => {
+    const ny = y + dy;
+    if (ny < 0 || ny >= local.height) return [];
+    const nx = local.width > 0 ? wrapX(x + dx, local.width) : x + dx;
+    const plotIndex = ny * local.width + nx;
+    const localTerrain = surfaceValue(local, "terrain", nx, ny);
+    const liveTerrain = surfaceValue(live, "terrain", nx, ny);
+    return [
+      {
+        direction,
+        x: nx,
+        y: ny,
+        plotIndex,
+        localTerrain: {
+          value: localTerrain,
+          symbol: symbolFor("terrain", localTerrain),
+          waterClass: terrainWaterClass(localTerrain),
+        },
+        liveTerrain: {
+          value: liveTerrain,
+          symbol: symbolFor("terrain", liveTerrain),
+          waterClass: terrainWaterClass(liveTerrain),
+        },
+      },
+    ];
+  });
+  return {
+    neighbors,
+    localCounts: countTerrainNeighborClasses(neighbors, "localTerrain"),
+    liveCounts: countTerrainNeighborClasses(neighbors, "liveTerrain"),
+  };
+}
+
+function countTerrainNeighborClasses(
+  neighbors: ReadonlyArray<TerrainDeltaNeighborContext>,
+  side: "localTerrain" | "liveTerrain"
+): TerrainNeighborhoodCounts {
+  const counts = { coast: 0, ocean: 0, otherWater: 0, land: 0, empty: 0 };
+  for (const neighbor of neighbors) {
+    const waterClass = neighbor[side].waterClass;
+    if (waterClass === "coast") counts.coast += 1;
+    else if (waterClass === "ocean") counts.ocean += 1;
+    else if (waterClass === "other-water") counts.otherWater += 1;
+    else if (waterClass === "land") counts.land += 1;
+    else counts.empty += 1;
+  }
+  return counts;
+}
+
+function classifyTerrainDeltaEdge(
+  localTerrain: number | null,
+  liveTerrain: number | null
+): TerrainDeltaEdgeContext["evidenceClass"] {
+  const localClass = terrainWaterClass(localTerrain);
+  const liveClass = terrainWaterClass(liveTerrain);
+  if (localClass === "ocean" && liveClass === "coast") return "local-ocean-live-coast";
+  if (localClass === "coast" && liveClass === "ocean") return "local-coast-live-ocean";
+  if (isWaterClass(localClass) && isWaterClass(liveClass)) return "water-terrain-edge-swap";
+  return "unclassified";
+}
+
+function terrainOwnerCandidates(
+  localTerrain: number | null,
+  liveTerrain: number | null
+): TerrainDeltaEdgeContext["ownerCandidates"] {
+  const localClass = terrainWaterClass(localTerrain);
+  const liveClass = terrainWaterClass(liveTerrain);
+  if (isWaterClass(localClass) && isWaterClass(liveClass)) {
+    return [
+      "map-morphology-coast-shelf-projection",
+      "map-hydrology-water-mutation",
+      "civ-engine-terrain-validation",
+      "evidence-insufficient",
+    ];
+  }
+  return ["evidence-insufficient"];
+}
+
+function isWaterClass(value: TerrainWaterClass): boolean {
+  return value === "coast" || value === "ocean" || value === "other-water";
+}
+
+function terrainWaterClass(value: number | null): TerrainWaterClass {
+  if (value === null) return "empty";
+  if (value === CIV7_BROWSER_TABLES_V0.terrainTypeIndices.TERRAIN_COAST) return "coast";
+  if (value === CIV7_BROWSER_TABLES_V0.terrainTypeIndices.TERRAIN_OCEAN) return "ocean";
+  return WATER_TERRAINS.has(value) ? "other-water" : "land";
 }
 
 function readResourcePlanEvidence(evidence: unknown): {

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -10,6 +10,7 @@ import {
   buildResourceDeltaPlacementContexts,
   buildSurfaceDeltaContext,
   buildSurfaceDeltaContexts,
+  buildTerrainDeltaEdgeContexts,
   staticSurfaceLegality,
 } from "../../src/dev/diagnostics/surface-delta-context";
 
@@ -62,6 +63,59 @@ describe("surface delta context diagnostics", () => {
       local: { value: 3, symbol: "RESOURCE_FISH" },
       live: { value: null, symbol: "empty" },
     });
+  });
+
+  test("classifies coast/ocean terrain edge swaps with neighborhood context", () => {
+    const local = snapshot({
+      terrain: { width: 3, height: 2, values: [3, 4, 3, 2, 3, 4] },
+    });
+    const live = snapshot({
+      terrain: { width: 3, height: 2, values: [3, 3, 3, 2, 3, 4] },
+    });
+
+    const rows = buildTerrainDeltaEdgeContexts({ local, live });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      x: 1,
+      y: 0,
+      plotIndex: 1,
+      localTerrain: { symbol: "TERRAIN_OCEAN" },
+      liveTerrain: { symbol: "TERRAIN_COAST" },
+      evidenceClass: "local-ocean-live-coast",
+      sourceAuthorityStatus: "unresolved",
+      ownerCandidates: expect.arrayContaining([
+        "map-morphology-coast-shelf-projection",
+        "civ-engine-terrain-validation",
+        "evidence-insufficient",
+      ]),
+      neighborhood: {
+        localCounts: {
+          coast: 3,
+          ocean: 1,
+          land: 1,
+        },
+        liveCounts: {
+          coast: 3,
+          ocean: 1,
+          land: 1,
+        },
+      },
+    });
+    expect(rows[0].neighborhood.neighbors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          x: 0,
+          y: 0,
+          localTerrain: expect.objectContaining({ symbol: "TERRAIN_COAST", waterClass: "coast" }),
+        }),
+        expect.objectContaining({
+          x: 0,
+          y: 1,
+          localTerrain: expect.objectContaining({ symbol: "TERRAIN_FLAT", waterClass: "land" }),
+        }),
+      ])
+    );
   });
 
   test("classifies feature deltas into reef absences and nearby natural-wonder offsets", () => {

--- a/openspec/changes/civ7-map-policy-final-surface-parity/workstream/phase-record.md
+++ b/openspec/changes/civ7-map-policy-final-surface-parity/workstream/phase-record.md
@@ -179,8 +179,10 @@
     - resource mismatches: `106/6996`.
   - Delta routing:
     - terrain `2/6996`: observed coast/ocean edge swaps; source-authority
-      classification remains open and should start with terrain-edge
-      diagnostics against coast/lake/shelf/validation masks;
+      classification remains open. A downstream
+      `earthlike-terrain-edge-diagnostics` context artifact now records the two
+      row neighborhoods, but repair authority still requires coast/lake/shelf,
+      projection-boundary, terrain-validation, and live water/area evidence;
     - feature `5/6996`: observed one cold reef absent in live plus one-tile
       feature-grid offsets for Kilimanjaro and Zhangjiajie; source-authority
       classification remains open and must not claim natural-wonder footprint
@@ -206,16 +208,24 @@
   proves shared materialization ownership; routed mountain aesthetics product
   direction to `earthlike-mountain-region-visual-acceptance` without changing
   this parity layer's proof claim.
+- Terrain diagnostic follow-up is now recorded in
+  `openspec/changes/earthlike-terrain-edge-diagnostics/**` with context
+  artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-context.json`
+  (`sha256:7c17cb5ecde54909ba7d0e58647403e19b3341739ab297568c2de654270b647f`).
+  This does not satisfy task 2.1 because row source authority remains
+  unresolved.
 - OpenSpec task state updated for implemented proof-path, routing, and
   focused-gate work only. Source-authority classification and product parity
   remain open.
 
 ## Next Action
 
-- Start targeted repair from `earthlike-live-feature-resource-legality-repair`
-  for feature/resource rows, and keep terrain-edge coast/ocean rows as a
-  terrain-policy diagnostic unless evidence proves they share the same repair
-  owner.
+- Continue targeted classification from
+  `earthlike-live-feature-resource-legality-repair` for feature/resource rows.
+  For terrain rows, link shelf/coast/lake/projection-boundary masks and live
+  water/area readback in `earthlike-terrain-edge-diagnostics` before any repair
+  or source-authority closure.
 - Stop condition: do not claim parity closure until the proof output is
   `status:"complete"` after downstream repairs. This slice makes no parity
   match, product acceptance, or Earthlike tuning claim.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/.openspec.yaml
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-06-06
+status: draft

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/proposal.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+Exact-authored final-surface parity for request
+`studio-run-in-game-mq20rbzr-1fhc` still has `2/6996` terrain mismatches. Both
+are coast/ocean edge swaps. They block parity, but they do not belong in the
+feature/resource legality repair lane unless later evidence proves shared
+materialization ownership.
+
+## Activation Gate
+
+This change is evidence-gated by the completed exact-authorship/full-grid
+parity artifact:
+
+`/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc.json`
+
+The source proof hash is
+`4973f47b8dd83e9710088d33485b2a985fcdf4dee71b140f2aa23b4bc55ac1dc`.
+
+## Target Authority Refs
+
+- `openspec/changes/civ7-map-policy-final-surface-parity/**`
+- `openspec/changes/studio-live-civ7-map-sync/workstream/parity-verification-and-runtime-proof.md`
+- `openspec/changes/morphology-terrain-authorship-control/**`
+- `docs/projects/mapgen-studio/workstream/SWOOPER-RECOVERY-TAKEOVER.md`
+
+## What Changes
+
+- Add terrain-only diagnostic context for local/live terrain mismatches.
+- Classify coast/ocean edge swap row shape and nearby terrain neighborhood.
+- Keep source authority unresolved until shelf/lake/projection-boundary and
+  live water/area evidence can distinguish repo projection, hydrology mutation,
+  Civ terrain validation, and evidence insufficiency.
+
+## Non-Goals
+
+- No coast/shelf tuning.
+- No terrain generation repair.
+- No feature/resource repair.
+- No parity, product acceptance, Earthlike quality, or mountain-quality closure
+  claim.
+- No generated output hand edits.
+
+## Affected Owners
+
+- `mods/mod-swooper-maps/src/dev/diagnostics/**`
+- `openspec/changes/earthlike-terrain-edge-diagnostics/**`
+- Parity/OpenSpec records that route terrain deltas.
+
+## Forbidden Owners
+
+- `mods/mod-swooper-maps/mod/**`
+- Swooper Earthlike config/generated map output.
+- Feature/resource legality repair, unless later evidence proves shared owner.
+
+## Stop Conditions
+
+- The exact-authored source proof is missing or identity-unstable.
+- Terrain rows cannot be tied to a current proof artifact.
+- Records start treating context as repair authority or parity closure.
+
+## Verification Gates
+
+- Focused terrain diagnostic test.
+- Terrain edge context artifact for `studio-run-in-game-mq20rbzr-1fhc`.
+- `bun run --cwd mods/mod-swooper-maps check`.
+- `bun run openspec -- validate earthlike-terrain-edge-diagnostics --strict`.
+- `bun run openspec:validate`.
+- `git diff --check`.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Terrain Edge Deltas Require Projection Evidence Before Repair
+
+Swooper recovery terrain edge repairs SHALL be preceded by exact-authored
+terrain row context and projection/readback evidence that identifies the owner
+of each coast/ocean mismatch.
+
+#### Scenario: Coast/ocean terrain edge rows are observed
+- **WHEN** final-surface parity reports local/live terrain mismatches involving
+  `TERRAIN_COAST` and `TERRAIN_OCEAN`
+- **THEN** diagnostics record the exact request identity, row coordinates,
+  local/live terrain symbols, neighborhood water classes, and candidate owners
+- **AND** source authority remains unresolved until shelf/coast/lake,
+  projection-boundary, validation, or live water/area evidence identifies the
+  owner
+
+#### Scenario: Terrain repair is proposed
+- **WHEN** a change proposes a coast/ocean terrain repair
+- **THEN** it cites the classified row owner
+- **AND** it does not use feature/resource legality evidence as terrain repair
+  authority unless shared materialization ownership is proven

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
@@ -1,0 +1,27 @@
+## 1. Activation
+
+- [x] 1.1 Link the exact-authored full-grid parity proof for
+  `studio-run-in-game-mq20rbzr-1fhc`.
+- [x] 1.2 Extract the concrete terrain mismatch rows and pair counts.
+
+## 2. Diagnostics
+
+- [x] 2.1 Add terrain-only mismatch context extraction.
+- [x] 2.2 Add neighborhood classification for coast/ocean edge swaps.
+- [x] 2.3 Produce the terrain-edge context artifact.
+- [ ] 2.4 Add or link shelf/coast/lake/projection-boundary mask evidence.
+- [ ] 2.5 Add or link live water/lake/area readback evidence.
+- [ ] 2.6 Classify source authority for each row.
+
+## 3. Repair
+
+- [ ] 3.1 Repair only rows assigned to a repo-owned source authority.
+- [ ] 3.2 Preserve hydrology water mutation and Civ validation boundaries.
+
+## 4. Verification
+
+- [x] 4.1 Run focused terrain diagnostic tests.
+- [ ] 4.2 Re-run exact-authored final-surface parity after any repair.
+- [x] 4.3 Run `bun run --cwd mods/mod-swooper-maps check`.
+- [x] 4.4 Run `bun run openspec -- validate earthlike-terrain-edge-diagnostics --strict`.
+- [x] 4.5 Run `bun run openspec:validate`.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
@@ -1,0 +1,94 @@
+# Phase Record
+
+## Phase
+
+- Project: Swooper recovery
+- Phase: terrain-edge diagnostics
+- Owner: Product/Development DRA
+- Branch/Graphite stack: `codex/swooper-terrain-edge-delta-context-drain`
+- Started: 2026-06-06
+- Status: active. Terrain edge context exists for the two coast/ocean rows, but
+  source authority remains unresolved and no repair is authorized.
+
+## Objective
+
+- Target movement: classify the `2/6996` terrain deltas from the exact-authored
+  final-surface proof without pulling them into feature/resource repair.
+- Non-goals: no tuning, no generated output edits, no parity/product closure.
+- Done condition: each terrain row is either assigned to a concrete repair
+  owner with evidence or owner-classified as accepted engine/readback residual.
+
+## Authority
+
+- Root/subtree `AGENTS.md`: Graphite, generated-output, and diagnostic hygiene.
+- `openspec/changes/civ7-map-policy-final-surface-parity/**`: parity remains
+  open until all deltas match or are owner-classified.
+- `openspec/changes/studio-live-civ7-map-sync/workstream/parity-verification-and-runtime-proof.md`:
+  terrain rows route to terrain-policy diagnostics.
+- `openspec/changes/morphology-terrain-authorship-control/**`: coast/ocean
+  terrain is projection/readback terrain policy, not feature/resource repair.
+
+## Current State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain`.
+- Branch: `codex/swooper-terrain-edge-delta-context-drain`.
+- Source proof:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc.json`.
+- Source proof hash:
+  `4973f47b8dd83e9710088d33485b2a985fcdf4dee71b140f2aa23b4bc55ac1dc`.
+- Exact request: `studio-run-in-game-mq20rbzr-1fhc`.
+- Seed/dimensions: `138503614`, `106x66`, `6996` plots.
+- Runtime identity: stable full-grid readback with omitted plots `0`, turn `1`,
+  and game hash `0`.
+
+## Implementation
+
+- Added `buildTerrainDeltaEdgeContexts` to
+  `mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts`.
+- Added focused test coverage for coast/ocean edge swap neighborhood context.
+- Source-recorded terrain context artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-context.json`.
+- Artifact sha256:
+  `7c17cb5ecde54909ba7d0e58647403e19b3341739ab297568c2de654270b647f`.
+
+## Findings
+
+- The terrain rows are exactly two water-edge swaps:
+  - `(73,36)`: local `TERRAIN_OCEAN`, live `TERRAIN_COAST`;
+    neighborhood local/live counts both `coast:4`, `ocean:2`, `land:0`.
+  - `(65,39)`: local `TERRAIN_COAST`, live `TERRAIN_OCEAN`;
+    neighborhood local/live counts both `coast:2`, `ocean:3`, `land:1`.
+- Both rows remain `sourceAuthorityStatus:"unresolved"`.
+- Candidate owners remain:
+  `map-morphology-coast-shelf-projection`, `map-hydrology-water-mutation`,
+  `civ-engine-terrain-validation`, and `evidence-insufficient`.
+
+## Evidence Boundary
+
+- This layer proves only row-level terrain context for the exact-authored proof.
+- It does not prove the repo should change coast/shelf policy.
+- It does not prove Civ engine terrain validation is accepted policy.
+- It does not close final-surface parity, product acceptance, Earthlike quality,
+  river metadata parity, feature/resource legality, or mountain-region quality.
+
+## Next Evidence
+
+- Link local shelf/coast/lake/water-protection masks at `(73,36)` and
+  `(65,39)`.
+- Link projection-boundary engine terrain snapshots before and after
+  `validateAndFixTerrain`.
+- Link live water/lake/area or equivalent runtime flags for the same rows.
+- Then classify each row before any repair.
+
+## Verification
+
+- `bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts`:
+  passed, 9 tests.
+- `bun run --cwd mods/mod-swooper-maps check`: passed.
+- `bun run openspec -- validate earthlike-terrain-edge-diagnostics --strict`:
+  passed.
+- `bun run openspec -- validate civ7-map-policy-final-surface-parity --strict`:
+  passed.
+- `bun run openspec:validate`: passed, 77/77.
+- `git diff --check`: passed.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
@@ -1,0 +1,42 @@
+# Terrain Edge Ledger
+
+## Scope
+
+- Source proof:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc.json`.
+- Source proof hash:
+  `4973f47b8dd83e9710088d33485b2a985fcdf4dee71b140f2aa23b4bc55ac1dc`.
+- Terrain context artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-context.json`.
+- Terrain context artifact sha256:
+  `7c17cb5ecde54909ba7d0e58647403e19b3341739ab297568c2de654270b647f`.
+- Request: `studio-run-in-game-mq20rbzr-1fhc`.
+- Seed/dimensions: `138503614`, `106x66`, `6996` plots.
+
+## Boundary
+
+This ledger records terrain row context. It does not assign source authority,
+authorize repair, prove parity, or prove product acceptance.
+
+## Rows
+
+| Row | Coordinate | Plot | Local | Live | Class | Neighborhood | Status |
+|---|---|---:|---|---|---|---|---|
+| T1 | `(73,36)` | `3889` | `TERRAIN_OCEAN` | `TERRAIN_COAST` | `local-ocean-live-coast` | local/live both `coast:4`, `ocean:2`, `land:0` | unresolved |
+| T2 | `(65,39)` | `4199` | `TERRAIN_COAST` | `TERRAIN_OCEAN` | `local-coast-live-ocean` | local/live both `coast:2`, `ocean:3`, `land:1` | unresolved |
+
+## Owner Candidates
+
+| Candidate | Current disposition |
+|---|---|
+| `map-morphology-coast-shelf-projection` | possible; needs local shelf/coast masks and projection-boundary terrain snapshots |
+| `map-hydrology-water-mutation` | possible; needs lake/river/water mutation evidence at the rows |
+| `civ-engine-terrain-validation` | possible; needs before/after `validateAndFixTerrain` and live water/area readback |
+| `evidence-insufficient` | current status until the evidence above exists |
+
+## Next Classification Evidence
+
+- Local shelf/coast/lake/water-protection masks for both rows.
+- Projection-boundary engine terrain snapshots around terrain validation.
+- Live water/lake/area readback for both rows.
+- Explicit owner disposition before any coast/shelf policy repair.


### PR DESCRIPTION
Adds terrain-edge diagnostic infrastructure for the two `TERRAIN_COAST`/`TERRAIN_OCEAN` mismatches (`2/6996`) observed in the exact-authored final-surface parity proof for `studio-run-in-game-mq20rbzr-1fhc`.

Introduces `buildTerrainDeltaEdgeContexts`, which iterates local/live terrain value pairs, identifies mismatched plots, and builds a structured context for each: coordinates, terrain symbols, hex neighborhood counts by water class (`coast`, `ocean`, `other-water`, `land`, `empty`), an `evidenceClass` label (`local-ocean-live-coast`, `local-coast-live-ocean`, `water-terrain-edge-swap`, or `unclassified`), and a list of `ownerCandidates`. Supporting types (`TerrainDeltaEdgeContext`, `TerrainDeltaNeighborhoodContext`, `TerrainDeltaNeighborContext`, `TerrainNeighborhoodCounts`, `TerrainWaterClass`) and internal helpers (`terrainDeltaNeighborhood`, `classifyTerrainDeltaEdge`, `terrainOwnerCandidates`, `terrainWaterClass`, `countTerrainNeighborClasses`) are added alongside.

All rows are emitted with `sourceAuthorityStatus: "unresolved"`. The two observed rows — `(73,36)` local `TERRAIN_OCEAN`/live `TERRAIN_COAST` and `(65,39)` local `TERRAIN_COAST`/live `TERRAIN_OCEAN` — remain unresolved pending shelf/coast/lake/projection-boundary mask evidence and live water/area readback. No repair is authorized and no parity, product acceptance, or Earthlike quality claim is made.

Opens the `earthlike-terrain-edge-diagnostics` OpenSpec workstream to track the remaining classification tasks (tasks 2.4–2.6, 3.x, 4.2) and records the terrain-edge context artifact with its sha256 in the phase record and ledger.