### PR TITLE
feat(terrain-edge-diagnostics): add local projection/mask evidence to terrain delta edge context

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -16,7 +16,11 @@ import type { TraceEvent, TraceSink } from "@swooper/mapgen-core/trace";
 import { canonicalRecipeConfig, isPlainObject as isCanonicalMapConfigObject } from "../../maps/configs/canonical.js";
 import standardRecipe from "../../recipes/standard/recipe.js";
 import { initializeStandardRuntime } from "../../recipes/standard/runtime.js";
+import { mapArtifacts } from "../../recipes/standard/map-artifacts.js";
 import { ecologyArtifacts } from "../../recipes/standard/stages/ecology/artifacts.js";
+import { hydrologyHydrographyArtifacts } from "../../recipes/standard/stages/hydrology-hydrography/artifacts.js";
+import { mapHydrologyArtifacts } from "../../recipes/standard/stages/map-hydrology/artifacts.js";
+import { morphologyArtifacts } from "../../recipes/standard/stages/morphology/artifacts.js";
 import { placementArtifacts } from "../../recipes/standard/stages/placement/artifacts.js";
 import { isPlainObject, mergeDeep } from "./shared.js";
 
@@ -181,6 +185,7 @@ type LocalTraceEvidence = {
   naturalWonderPlacement?: unknown;
   resourcePlan?: unknown;
   resourcePlacementOutcomes?: unknown;
+  terrainProjection?: unknown;
 };
 
 function createMemoryTraceSink(events: TraceEvent[]): TraceSink {
@@ -293,6 +298,7 @@ export function runLocalFinalSurfaceSnapshot(input: RunLocalFinalSurfaceInput): 
   if (resourcePlacementOutcomes !== undefined) {
     evidence.resourcePlacementOutcomes = resourcePlacementOutcomes;
   }
+  evidence.terrainProjection = buildTerrainProjectionEvidence(context);
 
   return {
     source: "local-mapgen",
@@ -309,6 +315,88 @@ export function runLocalFinalSurfaceSnapshot(input: RunLocalFinalSurfaceInput): 
     },
     evidence,
   };
+}
+
+function buildTerrainProjectionEvidence(context: ReturnType<typeof createExtendedMapContext>): unknown {
+  const coastlineMetrics = context.artifacts.get(morphologyArtifacts.coastlineMetrics.id);
+  const hydrologyLakePlan = context.artifacts.get(hydrologyHydrographyArtifacts.lakePlan.id);
+  const mapHydrologyProjection = context.artifacts.get(mapHydrologyArtifacts.engineProjectionLakes.id);
+  const hydrologyTerrainSnapshot = context.artifacts.get(
+    mapHydrologyArtifacts.hydrologyLakesEngineTerrainSnapshot.id
+  );
+  const placementSurfacePreparation = context.artifacts.get(
+    placementArtifacts.placementSurfacePreparation.id
+  );
+  const placementTerrainSnapshot = context.artifacts.get(
+    mapArtifacts.placementEngineTerrainSnapshot.id
+  );
+  return stripUndefined({
+    coastlineMetrics: pickSerializableFields(coastlineMetrics, [
+      "coastalLand",
+      "coastalWater",
+      "shelfMask",
+      "distanceToCoast",
+    ]),
+    hydrologyLakePlan: pickSerializableFields(hydrologyLakePlan, [
+      "lakeMask",
+      "plannedLakeTileCount",
+      "sinkLakeCount",
+    ]),
+    mapHydrologyProjection: pickSerializableFields(mapHydrologyProjection, [
+      "width",
+      "height",
+      "lakeMask",
+      "plannedLakeMask",
+      "engineWaterMask",
+      "engineLakeMask",
+      "engineTerrain",
+      "engineAreaId",
+      "terrainMismatchMask",
+      "sinkMismatchCount",
+      "nonLakeTileCount",
+      "terrainMismatchTileCount",
+      "morphologyProtectedLakeTileCount",
+    ]),
+    hydrologyTerrainSnapshot: pickSerializableFields(hydrologyTerrainSnapshot, [
+      "stage",
+      "width",
+      "height",
+      "landMask",
+      "terrain",
+    ]),
+    placementSurfacePreparation: pickSerializableFields(placementSurfacePreparation, [
+      "acceptedLakeTileCount",
+      "finalLakeWaterDriftCount",
+      "finalLakeClassificationDriftCount",
+    ]),
+    placementTerrainSnapshot: pickSerializableFields(placementTerrainSnapshot, [
+      "stage",
+      "width",
+      "height",
+      "landMask",
+      "terrain",
+    ]),
+  });
+}
+
+function pickSerializableFields(
+  value: unknown,
+  fields: ReadonlyArray<string>
+): Readonly<Record<string, unknown>> | undefined {
+  if (!isPlainObject(value)) return undefined;
+  return stripUndefined(Object.fromEntries(fields.map((field) => [field, serializeEvidenceValue(value[field])])));
+}
+
+function serializeEvidenceValue(value: unknown): unknown {
+  if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+    return Array.from(value as ArrayLike<number>);
+  }
+  return value;
+}
+
+function stripUndefined(value: Record<string, unknown>): Readonly<Record<string, unknown>> | undefined {
+  const entries = Object.entries(value).filter(([, entryValue]) => entryValue !== undefined);
+  return entries.length === 0 ? undefined : Object.fromEntries(entries);
 }
 
 export function liveGridToFinalSurfaceSnapshot(args: {

--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -331,6 +331,7 @@ export type TerrainDeltaEdgeContext = Readonly<{
     context: CellSurfaceContext;
   }>;
   neighborhood: TerrainDeltaNeighborhoodContext;
+  localProjection: TerrainProjectionRowContext | null;
   evidenceClass:
     | "local-ocean-live-coast"
     | "local-coast-live-ocean"
@@ -369,6 +370,55 @@ export type TerrainNeighborhoodCounts = Readonly<{
 }>;
 
 export type TerrainWaterClass = "coast" | "ocean" | "other-water" | "land" | "empty";
+
+export type TerrainProjectionRowContext = Readonly<{
+  morphology: TerrainMorphologyProjectionRowContext | null;
+  hydrologyLakePlan: TerrainHydrologyLakePlanRowContext | null;
+  mapHydrologyProjection: TerrainMapHydrologyProjectionRowContext | null;
+  hydrologyTerrainSnapshot: TerrainProjectionSnapshotRowContext | null;
+  placementSurfacePreparation: TerrainPlacementPreparationContext | null;
+  placementTerrainSnapshot: TerrainProjectionSnapshotRowContext | null;
+}>;
+
+export type TerrainMorphologyProjectionRowContext = Readonly<{
+  coastalLand: number | null;
+  coastalWater: number | null;
+  shelfMask: number | null;
+  distanceToCoast: number | null;
+}>;
+
+export type TerrainHydrologyLakePlanRowContext = Readonly<{
+  lakeMask: number | null;
+  plannedLakeTileCount: number | null;
+  sinkLakeCount: number | null;
+}>;
+
+export type TerrainMapHydrologyProjectionRowContext = Readonly<{
+  lakeMask: number | null;
+  plannedLakeMask: number | null;
+  engineWaterMask: number | null;
+  engineLakeMask: number | null;
+  engineTerrain: number | null;
+  engineTerrainSymbol: string;
+  engineAreaId: number | null;
+  terrainMismatchMask: number | null;
+  terrainMismatchTileCount: number | null;
+  nonLakeTileCount: number | null;
+  morphologyProtectedLakeTileCount: number | null;
+}>;
+
+export type TerrainProjectionSnapshotRowContext = Readonly<{
+  stage: string | null;
+  landMask: number | null;
+  terrain: number | null;
+  terrainSymbol: string;
+}>;
+
+export type TerrainPlacementPreparationContext = Readonly<{
+  acceptedLakeTileCount: number | null;
+  finalLakeWaterDriftCount: number | null;
+  finalLakeClassificationDriftCount: number | null;
+}>;
 
 export type ResourcePlacementOutcomeContext = Readonly<{
   status: string;
@@ -799,6 +849,7 @@ export function buildTerrainDeltaEdgeContexts(
         context: cellSurfaceContext(proof.live, x, y),
       },
       neighborhood,
+      localProjection: terrainProjectionRowContext(proof.local, index),
       evidenceClass: classifyTerrainDeltaEdge(localTerrain, liveTerrain),
       sourceAuthorityStatus: "unresolved",
       ownerCandidates: terrainOwnerCandidates(localTerrain, liveTerrain),
@@ -1475,6 +1526,103 @@ function terrainWaterClass(value: number | null): TerrainWaterClass {
   if (value === CIV7_BROWSER_TABLES_V0.terrainTypeIndices.TERRAIN_COAST) return "coast";
   if (value === CIV7_BROWSER_TABLES_V0.terrainTypeIndices.TERRAIN_OCEAN) return "ocean";
   return WATER_TERRAINS.has(value) ? "other-water" : "land";
+}
+
+function terrainProjectionRowContext(
+  snapshot: FinalSurfaceSnapshot,
+  plotIndex: number
+): TerrainProjectionRowContext | null {
+  const projection = isRecord(snapshot.evidence) && isRecord(snapshot.evidence.terrainProjection)
+    ? snapshot.evidence.terrainProjection
+    : undefined;
+  if (!projection) return null;
+  const morphology = isRecord(projection.coastlineMetrics) ? projection.coastlineMetrics : undefined;
+  const hydrologyLakePlan = isRecord(projection.hydrologyLakePlan) ? projection.hydrologyLakePlan : undefined;
+  const mapHydrologyProjection = isRecord(projection.mapHydrologyProjection)
+    ? projection.mapHydrologyProjection
+    : undefined;
+  const hydrologyTerrainSnapshot = isRecord(projection.hydrologyTerrainSnapshot)
+    ? projection.hydrologyTerrainSnapshot
+    : undefined;
+  const placementSurfacePreparation = isRecord(projection.placementSurfacePreparation)
+    ? projection.placementSurfacePreparation
+    : undefined;
+  const placementTerrainSnapshot = isRecord(projection.placementTerrainSnapshot)
+    ? projection.placementTerrainSnapshot
+    : undefined;
+  return {
+    morphology: morphology
+      ? {
+          coastalLand: indexedInteger(morphology.coastalLand, plotIndex),
+          coastalWater: indexedInteger(morphology.coastalWater, plotIndex),
+          shelfMask: indexedInteger(morphology.shelfMask, plotIndex),
+          distanceToCoast: indexedInteger(morphology.distanceToCoast, plotIndex),
+        }
+      : null,
+    hydrologyLakePlan: hydrologyLakePlan
+      ? {
+          lakeMask: indexedInteger(hydrologyLakePlan.lakeMask, plotIndex),
+          plannedLakeTileCount: finiteInteger(hydrologyLakePlan.plannedLakeTileCount),
+          sinkLakeCount: finiteInteger(hydrologyLakePlan.sinkLakeCount),
+        }
+      : null,
+    mapHydrologyProjection: mapHydrologyProjection
+      ? {
+          lakeMask: indexedInteger(mapHydrologyProjection.lakeMask, plotIndex),
+          plannedLakeMask: indexedInteger(mapHydrologyProjection.plannedLakeMask, plotIndex),
+          engineWaterMask: indexedInteger(mapHydrologyProjection.engineWaterMask, plotIndex),
+          engineLakeMask: indexedInteger(mapHydrologyProjection.engineLakeMask, plotIndex),
+          engineTerrain: indexedInteger(mapHydrologyProjection.engineTerrain, plotIndex),
+          engineTerrainSymbol: symbolFor(
+            "terrain",
+            indexedInteger(mapHydrologyProjection.engineTerrain, plotIndex)
+          ),
+          engineAreaId: indexedInteger(mapHydrologyProjection.engineAreaId, plotIndex),
+          terrainMismatchMask: indexedInteger(mapHydrologyProjection.terrainMismatchMask, plotIndex),
+          terrainMismatchTileCount: finiteInteger(mapHydrologyProjection.terrainMismatchTileCount),
+          nonLakeTileCount: finiteInteger(mapHydrologyProjection.nonLakeTileCount),
+          morphologyProtectedLakeTileCount: finiteInteger(
+            mapHydrologyProjection.morphologyProtectedLakeTileCount
+          ),
+        }
+      : null,
+    hydrologyTerrainSnapshot: projectionSnapshotRowContext(hydrologyTerrainSnapshot, plotIndex),
+    placementSurfacePreparation: placementSurfacePreparation
+      ? {
+          acceptedLakeTileCount: finiteInteger(placementSurfacePreparation.acceptedLakeTileCount),
+          finalLakeWaterDriftCount: finiteInteger(
+            placementSurfacePreparation.finalLakeWaterDriftCount
+          ),
+          finalLakeClassificationDriftCount: finiteInteger(
+            placementSurfacePreparation.finalLakeClassificationDriftCount
+          ),
+        }
+      : null,
+    placementTerrainSnapshot: projectionSnapshotRowContext(placementTerrainSnapshot, plotIndex),
+  };
+}
+
+function projectionSnapshotRowContext(
+  snapshot: Record<string, unknown> | undefined,
+  plotIndex: number
+): TerrainProjectionSnapshotRowContext | null {
+  if (!snapshot) return null;
+  const terrain = indexedInteger(snapshot.terrain, plotIndex);
+  return {
+    stage: typeof snapshot.stage === "string" ? snapshot.stage : null,
+    landMask: indexedInteger(snapshot.landMask, plotIndex),
+    terrain,
+    terrainSymbol: symbolFor("terrain", terrain),
+  };
+}
+
+function indexedInteger(value: unknown, index: number): number | null {
+  if (Array.isArray(value)) return finiteInteger(value[index]);
+  if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+    return finiteInteger((value as ArrayLike<number>)[index]);
+  }
+  if (isRecord(value)) return finiteInteger(value[String(index)]);
+  return null;
 }
 
 function readResourcePlanEvidence(evidence: unknown): {

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -66,9 +66,53 @@ describe("surface delta context diagnostics", () => {
   });
 
   test("classifies coast/ocean terrain edge swaps with neighborhood context", () => {
-    const local = snapshot({
-      terrain: { width: 3, height: 2, values: [3, 4, 3, 2, 3, 4] },
-    });
+    const local = snapshot(
+      {
+        terrain: { width: 3, height: 2, values: [3, 4, 3, 2, 3, 4] },
+      },
+      {
+        terrainProjection: {
+          coastlineMetrics: {
+            coastalLand: [0, 0, 0, 1, 0, 0],
+            coastalWater: [1, 1, 1, 0, 1, 1],
+            shelfMask: [1, 0, 1, 0, 1, 0],
+            distanceToCoast: [0, 1, 0, 0, 0, 1],
+          },
+          hydrologyLakePlan: {
+            lakeMask: [0, 0, 0, 0, 0, 0],
+            plannedLakeTileCount: 0,
+            sinkLakeCount: 0,
+          },
+          mapHydrologyProjection: {
+            lakeMask: [0, 0, 0, 0, 0, 0],
+            plannedLakeMask: [0, 0, 0, 0, 0, 0],
+            engineWaterMask: [1, 1, 1, 0, 1, 1],
+            engineLakeMask: [0, 0, 0, 0, 0, 0],
+            engineTerrain: [3, 4, 3, 2, 3, 4],
+            engineAreaId: [1, 1, 1, 2, 1, 1],
+            terrainMismatchMask: [0, 0, 0, 0, 0, 0],
+            terrainMismatchTileCount: 0,
+            nonLakeTileCount: 0,
+            morphologyProtectedLakeTileCount: 0,
+          },
+          hydrologyTerrainSnapshot: {
+            stage: "map-hydrology/lakes",
+            landMask: [0, 0, 0, 1, 0, 0],
+            terrain: [3, 4, 3, 2, 3, 4],
+          },
+          placementSurfacePreparation: {
+            acceptedLakeTileCount: 0,
+            finalLakeWaterDriftCount: 0,
+            finalLakeClassificationDriftCount: 0,
+          },
+          placementTerrainSnapshot: {
+            stage: "placement/placement",
+            landMask: [0, 0, 0, 1, 0, 0],
+            terrain: [3, 4, 3, 2, 3, 4],
+          },
+        },
+      }
+    );
     const live = snapshot({
       terrain: { width: 3, height: 2, values: [3, 3, 3, 2, 3, 4] },
     });
@@ -99,6 +143,32 @@ describe("surface delta context diagnostics", () => {
           coast: 3,
           ocean: 1,
           land: 1,
+        },
+      },
+      localProjection: {
+        morphology: {
+          coastalWater: 1,
+          shelfMask: 0,
+          distanceToCoast: 1,
+        },
+        hydrologyLakePlan: {
+          lakeMask: 0,
+          plannedLakeTileCount: 0,
+        },
+        mapHydrologyProjection: {
+          engineWaterMask: 1,
+          engineLakeMask: 0,
+          engineTerrainSymbol: "TERRAIN_OCEAN",
+          engineAreaId: 1,
+        },
+        hydrologyTerrainSnapshot: {
+          stage: "map-hydrology/lakes",
+          landMask: 0,
+          terrainSymbol: "TERRAIN_OCEAN",
+        },
+        placementTerrainSnapshot: {
+          stage: "placement/placement",
+          terrainSymbol: "TERRAIN_OCEAN",
         },
       },
     });

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
@@ -9,7 +9,7 @@
 - [x] 2.1 Add terrain-only mismatch context extraction.
 - [x] 2.2 Add neighborhood classification for coast/ocean edge swaps.
 - [x] 2.3 Produce the terrain-edge context artifact.
-- [ ] 2.4 Add or link shelf/coast/lake/projection-boundary mask evidence.
+- [x] 2.4 Add or link shelf/coast/lake/projection-boundary mask evidence.
 - [ ] 2.5 Add or link live water/lake/area readback evidence.
 - [ ] 2.6 Classify source authority for each row.
 

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
@@ -5,10 +5,11 @@
 - Project: Swooper recovery
 - Phase: terrain-edge diagnostics
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-terrain-edge-delta-context-drain`
+- Branch/Graphite stack: `codex/swooper-terrain-edge-mask-context-drain`
 - Started: 2026-06-06
-- Status: active. Terrain edge context exists for the two coast/ocean rows, but
-  source authority remains unresolved and no repair is authorized.
+- Status: active. Terrain edge and local projection/mask context exist for the
+  two coast/ocean rows, but live water/area readback and source authority
+  remain unresolved and no repair is authorized.
 
 ## Objective
 
@@ -32,7 +33,7 @@
 
 - Worktree:
   `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain`.
-- Branch: `codex/swooper-terrain-edge-delta-context-drain`.
+- Branch: `codex/swooper-terrain-edge-mask-context-drain`.
 - Source proof:
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc.json`.
 - Source proof hash:
@@ -51,6 +52,10 @@
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-context.json`.
 - Artifact sha256:
   `7c17cb5ecde54909ba7d0e58647403e19b3341739ab297568c2de654270b647f`.
+- Source-recorded local mask/projection artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-local-mask-context.json`.
+- Local mask/projection artifact sha256:
+  `3b6822d02ddd9844e872dfafa1879860ecfd12d6558df43cfe75a1aed726aec2`.
 
 ## Findings
 
@@ -63,10 +68,25 @@
 - Candidate owners remain:
   `map-morphology-coast-shelf-projection`, `map-hydrology-water-mutation`,
   `civ-engine-terrain-validation`, and `evidence-insufficient`.
+- Local mask/projection evidence:
+  - Both rows have morphology `shelfMask:0`, `coastalWater:0`,
+    `coastalLand:0`, and `distanceToCoast:18`. They are not locally justified
+    by morphology shelf/coastline intent alone.
+  - Both rows have Hydrology lake intent `lakeMask:0` and map-hydrology
+    `plannedLakeMask:0`.
+  - `(73,36)` remains local `TERRAIN_OCEAN` through map-hydrology and
+    placement terrain snapshots; local engine water is `1`, lake is `0`.
+  - `(65,39)` remains local `TERRAIN_COAST` through map-hydrology and
+    placement terrain snapshots; local engine water is `1`, lake is `1`,
+    despite `plannedLakeMask:0` at the row.
+  - Accepted lake count is `137`; final lake water/classification drift counts
+    are both `0`. This proves the local projection evidence is internally
+    consistent at the placement boundary, not that it matches live Civ.
 
 ## Evidence Boundary
 
-- This layer proves only row-level terrain context for the exact-authored proof.
+- This layer proves only row-level terrain context and local projection/mask
+  context for the exact-authored proof.
 - It does not prove the repo should change coast/shelf policy.
 - It does not prove Civ engine terrain validation is accepted policy.
 - It does not close final-surface parity, product acceptance, Earthlike quality,
@@ -74,21 +94,24 @@
 
 ## Next Evidence
 
-- Link local shelf/coast/lake/water-protection masks at `(73,36)` and
+- Link live water/lake/area or equivalent runtime flags for `(73,36)` and
   `(65,39)`.
-- Link projection-boundary engine terrain snapshots before and after
-  `validateAndFixTerrain`.
-- Link live water/lake/area or equivalent runtime flags for the same rows.
+- If live water/area readback does not resolve ownership, add a more granular
+  projection-boundary snapshot immediately around `validateAndFixTerrain`.
 - Then classify each row before any repair.
 
 ## Verification
 
 - `bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts`:
-  passed, 9 tests.
+  passed.
+- `bun test mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts`:
+  passed.
 - `bun run --cwd mods/mod-swooper-maps check`: passed.
+- `bun scripts/civ7-direct-control/verify-final-surface-parity.ts --help`:
+  passed.
 - `bun run openspec -- validate earthlike-terrain-edge-diagnostics --strict`:
   passed.
 - `bun run openspec -- validate civ7-map-policy-final-surface-parity --strict`:
   passed.
-- `bun run openspec:validate`: passed, 77/77.
+- `bun run openspec:validate`: passed.
 - `git diff --check`: passed.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
@@ -10,6 +10,10 @@
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-context.json`.
 - Terrain context artifact sha256:
   `7c17cb5ecde54909ba7d0e58647403e19b3341739ab297568c2de654270b647f`.
+- Local mask/projection context artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-local-mask-context.json`.
+- Local mask/projection context artifact sha256:
+  `3b6822d02ddd9844e872dfafa1879860ecfd12d6558df43cfe75a1aed726aec2`.
 - Request: `studio-run-in-game-mq20rbzr-1fhc`.
 - Seed/dimensions: `138503614`, `106x66`, `6996` plots.
 
@@ -24,6 +28,18 @@ authorize repair, prove parity, or prove product acceptance.
 |---|---|---:|---|---|---|---|---|
 | T1 | `(73,36)` | `3889` | `TERRAIN_OCEAN` | `TERRAIN_COAST` | `local-ocean-live-coast` | local/live both `coast:4`, `ocean:2`, `land:0` | unresolved |
 | T2 | `(65,39)` | `4199` | `TERRAIN_COAST` | `TERRAIN_OCEAN` | `local-coast-live-ocean` | local/live both `coast:2`, `ocean:3`, `land:1` | unresolved |
+
+## Local Projection Context
+
+| Row | Morphology shelf/coast | Hydrology lake intent | Map-hydrology projection | Placement snapshot | Current disposition |
+|---|---|---|---|---|---|
+| T1 `(73,36)` | `shelfMask:0`, `coastalWater:0`, `coastalLand:0`, `distanceToCoast:18` | `lakeMask:0`, `plannedLakeMask:0` | `engineWaterMask:1`, `engineLakeMask:0`, `engineTerrain:TERRAIN_OCEAN` | `landMask:0`, `terrain:TERRAIN_OCEAN` | Local pipeline consistently keeps ocean; live coast needs live water/area readback before owner classification. |
+| T2 `(65,39)` | `shelfMask:0`, `coastalWater:0`, `coastalLand:0`, `distanceToCoast:18` | `lakeMask:0`, `plannedLakeMask:0` | `engineWaterMask:1`, `engineLakeMask:1`, `engineTerrain:TERRAIN_COAST` | `landMask:0`, `terrain:TERRAIN_COAST` | Local pipeline consistently keeps coast/lake-classified water despite no planned lake mask at this row; live ocean needs live water/area readback before owner classification. |
+
+The local evidence narrows both rows away from simple morphology shelf/coast
+intent and planned Hydrology lake intent. It does not yet prove whether the
+remaining owner is local projection/materialization, Civ live validation, or a
+readback/evidence gap.
 
 ## Owner Candidates
 


### PR DESCRIPTION
Adds per-tile local projection and mask evidence to terrain edge delta context for coast/ocean mismatch diagnostics.

`buildTerrainProjectionEvidence` collects artifacts from the morphology, hydrology lake plan, map-hydrology projection, hydrology terrain snapshot, placement surface preparation, and placement terrain snapshot stages, serializing typed array fields to plain arrays so they can be stored as JSON evidence on the local snapshot.

`terrainProjectionRowContext` and supporting helpers (`projectionSnapshotRowContext`, `indexedInteger`, `pickSerializableFields`, `serializeEvidenceValue`, `stripUndefined`) decode that stored evidence back into per-plot typed context rows, including human-readable terrain symbols, and attach the result as `localProjection` on each `TerrainDeltaEdgeContext`.

New types (`TerrainProjectionRowContext`, `TerrainMorphologyProjectionRowContext`, `TerrainHydrologyLakePlanRowContext`, `TerrainMapHydrologyProjectionRowContext`, `TerrainProjectionSnapshotRowContext`, `TerrainPlacementPreparationContext`) describe the shape of that per-row context.

Tests are extended to supply full projection evidence in the snapshot fixture and assert the decoded `localProjection` fields on the resulting edge context rows.

Findings recorded in the ledger show that both mismatched rows (`(73,36)` and `(65,39)`) have `shelfMask:0`, `coastalWater:0`, and no planned lake mask, ruling out simple morphology shelf/coast intent and planned hydrology lake intent as owners. Live water/area readback remains the next required evidence step before source authority can be classified.