### PR TITLE
feat(terrain-edge-diagnostics): add runtime-bound live hydrology/area readback verifier with fact-completeness gate and `isLake` readback support

### DIFF
--- a/openspec/changes/earthlike-terrain-edge-diagnostics/proposal.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/proposal.md
@@ -27,6 +27,10 @@ The source proof hash is
 
 - Add terrain-only diagnostic context for local/live terrain mismatches.
 - Classify coast/ocean edge swap row shape and nearby terrain neighborhood.
+- Add a package-owned direct-control `hydrology.lake` readback fact and a
+  runtime-bound terrain-edge verifier that requires successful terrain,
+  water/lake/river, and area/region/landmass facts before producing complete
+  live context.
 - Keep source authority unresolved until shelf/lake/projection-boundary and
   live water/area evidence can distinguish repo projection, hydrology mutation,
   Civ terrain validation, and evidence insufficiency.
@@ -43,6 +47,8 @@ The source proof hash is
 ## Affected Owners
 
 - `mods/mod-swooper-maps/src/dev/diagnostics/**`
+- `packages/civ7-direct-control/**`
+- `scripts/civ7-direct-control/verify-terrain-edge-live-context.ts`
 - `openspec/changes/earthlike-terrain-edge-diagnostics/**`
 - Parity/OpenSpec records that route terrain deltas.
 
@@ -56,13 +62,19 @@ The source proof hash is
 
 - The exact-authored source proof is missing or identity-unstable.
 - Terrain rows cannot be tied to a current proof artifact.
+- Live readback rows are present but requested terrain/hydrology/area facts are
+  missing or failed.
 - Records start treating context as repair authority or parity closure.
 
 ## Verification Gates
 
 - Focused terrain diagnostic test.
 - Terrain edge context artifact for `studio-run-in-game-mq20rbzr-1fhc`.
+- Runtime-bound terrain-edge live readback artifact for
+  `studio-run-in-game-mq20rbzr-1fhc`.
+- Fact-completeness regression for terrain-edge live readback.
 - `bun run --cwd mods/mod-swooper-maps check`.
+- `bun run --cwd packages/civ7-direct-control check`.
 - `bun run openspec -- validate earthlike-terrain-edge-diagnostics --strict`.
 - `bun run openspec:validate`.
 - `git diff --check`.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/specs/mapgen-normalization-workstreams/spec.md
@@ -7,6 +7,7 @@ terrain row context and projection/readback evidence that identifies the owner
 of each coast/ocean mismatch.
 
 #### Scenario: Coast/ocean terrain edge rows are observed
+
 - **WHEN** final-surface parity reports local/live terrain mismatches involving
   `TERRAIN_COAST` and `TERRAIN_OCEAN`
 - **THEN** diagnostics record the exact request identity, row coordinates,
@@ -15,7 +16,19 @@ of each coast/ocean mismatch.
   projection-boundary, validation, or live water/area evidence identifies the
   owner
 
+#### Scenario: Live terrain edge facts are read from Civ
+
+- **WHEN** a verifier records live water/lake/area context for terrain edge
+  rows
+- **THEN** the artifact is bound to the saved exact-authored request and
+  current runtime identity
+- **AND** each row has successful facts for terrain, water, lake, river type,
+  area id, region id, and landmass id
+- **AND** missing or failed requested facts keep the artifact blocked rather
+  than complete
+
 #### Scenario: Terrain repair is proposed
+
 - **WHEN** a change proposes a coast/ocean terrain repair
 - **THEN** it cites the classified row owner
 - **AND** it does not use feature/resource legality evidence as terrain repair

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
@@ -10,7 +10,7 @@
 - [x] 2.2 Add neighborhood classification for coast/ocean edge swaps.
 - [x] 2.3 Produce the terrain-edge context artifact.
 - [x] 2.4 Add or link shelf/coast/lake/projection-boundary mask evidence.
-- [ ] 2.5 Add or link live water/lake/area readback evidence.
+- [x] 2.5 Add or link live water/lake/area readback evidence.
 - [ ] 2.6 Classify source authority for each row.
 
 ## 3. Repair

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
@@ -5,11 +5,12 @@
 - Project: Swooper recovery
 - Phase: terrain-edge diagnostics
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-terrain-edge-mask-context-drain`
+- Branch/Graphite stack: `codex/swooper-terrain-edge-live-readback-drain`
 - Started: 2026-06-06
-- Status: active. Terrain edge and local projection/mask context exist for the
-  two coast/ocean rows, but live water/area readback and source authority
-  remain unresolved and no repair is authorized.
+- Status: active. Terrain edge, local projection/mask context, and
+  exact-runtime-bound live terrain/hydrology/area readback exist for the two
+  coast/ocean rows, but source authority remains unresolved and no repair is
+  authorized.
 
 ## Objective
 
@@ -33,7 +34,7 @@
 
 - Worktree:
   `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain`.
-- Branch: `codex/swooper-terrain-edge-mask-context-drain`.
+- Branch: `codex/swooper-terrain-edge-live-readback-drain`.
 - Source proof:
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc.json`.
 - Source proof hash:
@@ -56,6 +57,12 @@
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-local-mask-context.json`.
 - Local mask/projection artifact sha256:
   `3b6822d02ddd9844e872dfafa1879860ecfd12d6558df43cfe75a1aed726aec2`.
+- Source-recorded live readback artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-live-readback-context.json`.
+- Live readback artifact sha256:
+  `213134d7020063f53073c2f6f254ae8fc0d153007b0b6e0848c2da4a642262f6`.
+- Live readback proof hash:
+  `aa817119c628d1ecc144c5dd7ed4d3227f6fe3301af1ffab501e26751868c2a8`.
 
 ## Findings
 
@@ -82,6 +89,25 @@
   - Accepted lake count is `137`; final lake water/classification drift counts
     are both `0`. This proves the local projection evidence is internally
     consistent at the placement boundary, not that it matches live Civ.
+- Exact-runtime-bound live readback evidence:
+  - Verifier command:
+    `bun run verify:terrain-edge-live-context -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc.json --context-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-local-mask-context.json --output /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-live-readback-context.json`.
+  - Request identity matched across exact summary, exact packet, source
+    snapshot, and log: `studio-run-in-game-mq20rbzr-1fhc`.
+  - Runtime identity matched saved proof and current readback: `106x66`,
+    `6996` plots, seed `138503614`, turn `1`, game hash `0`.
+  - Required row facts were present and `ok:true` for both rows: `terrain`,
+    `water`, `lake`, `riverType`, `areaId`, `regionId`, and `landmassId`.
+  - `(73,36)` live readback is `TERRAIN_COAST`, `water:true`,
+    `lake:false`, `riverType:-1`, `areaId:720906`, `regionId:-1`,
+    `landmassId:65536`.
+  - `(65,39)` live readback is `TERRAIN_OCEAN`, `water:true`,
+    `lake:false`, `riverType:-1`, `areaId:720906`, `regionId:-1`,
+    `landmassId:65536`.
+  - The second row is the strongest remaining signal: local projection carries
+    `engineLakeMask:1` and `TERRAIN_COAST`, while live Civ readback reports
+    `lake:false` and `TERRAIN_OCEAN`. That narrows the next classification
+    question but does not prove the repair owner.
 
 ## Evidence Boundary
 
@@ -94,8 +120,6 @@
 
 ## Next Evidence
 
-- Link live water/lake/area or equivalent runtime flags for `(73,36)` and
-  `(65,39)`.
 - If live water/area readback does not resolve ownership, add a more granular
   projection-boundary snapshot immediately around `validateAndFixTerrain`.
 - Then classify each row before any repair.
@@ -109,6 +133,12 @@
 - `bun run --cwd mods/mod-swooper-maps check`: passed.
 - `bun scripts/civ7-direct-control/verify-final-surface-parity.ts --help`:
   passed.
+- `bun run verify:terrain-edge-live-context -- --help`: passed.
+- `bun test scripts/civ7-direct-control/verify-terrain-edge-live-context.test.ts`:
+  passed.
+- `bun run --cwd packages/civ7-direct-control test -- direct-control`:
+  passed.
+- `bun run --cwd packages/civ7-direct-control check`: passed.
 - `bun run openspec -- validate earthlike-terrain-edge-diagnostics --strict`:
   passed.
 - `bun run openspec -- validate civ7-map-policy-final-surface-parity --strict`:

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
@@ -14,6 +14,12 @@
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-local-mask-context.json`.
 - Local mask/projection context artifact sha256:
   `3b6822d02ddd9844e872dfafa1879860ecfd12d6558df43cfe75a1aed726aec2`.
+- Live readback context artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-live-readback-context.json`.
+- Live readback context artifact sha256:
+  `213134d7020063f53073c2f6f254ae8fc0d153007b0b6e0848c2da4a642262f6`.
+- Live readback proof hash:
+  `aa817119c628d1ecc144c5dd7ed4d3227f6fe3301af1ffab501e26751868c2a8`.
 - Request: `studio-run-in-game-mq20rbzr-1fhc`.
 - Seed/dimensions: `138503614`, `106x66`, `6996` plots.
 
@@ -24,16 +30,16 @@ authorize repair, prove parity, or prove product acceptance.
 
 ## Rows
 
-| Row | Coordinate | Plot | Local | Live | Class | Neighborhood | Status |
-|---|---|---:|---|---|---|---|---|
-| T1 | `(73,36)` | `3889` | `TERRAIN_OCEAN` | `TERRAIN_COAST` | `local-ocean-live-coast` | local/live both `coast:4`, `ocean:2`, `land:0` | unresolved |
-| T2 | `(65,39)` | `4199` | `TERRAIN_COAST` | `TERRAIN_OCEAN` | `local-coast-live-ocean` | local/live both `coast:2`, `ocean:3`, `land:1` | unresolved |
+| Row | Coordinate |   Plot | Local           | Live            | Class                    | Neighborhood                                   | Status     |
+| --- | ---------- | -----: | --------------- | --------------- | ------------------------ | ---------------------------------------------- | ---------- |
+| T1  | `(73,36)`  | `3889` | `TERRAIN_OCEAN` | `TERRAIN_COAST` | `local-ocean-live-coast` | local/live both `coast:4`, `ocean:2`, `land:0` | unresolved |
+| T2  | `(65,39)`  | `4199` | `TERRAIN_COAST` | `TERRAIN_OCEAN` | `local-coast-live-ocean` | local/live both `coast:2`, `ocean:3`, `land:1` | unresolved |
 
 ## Local Projection Context
 
-| Row | Morphology shelf/coast | Hydrology lake intent | Map-hydrology projection | Placement snapshot | Current disposition |
-|---|---|---|---|---|---|
-| T1 `(73,36)` | `shelfMask:0`, `coastalWater:0`, `coastalLand:0`, `distanceToCoast:18` | `lakeMask:0`, `plannedLakeMask:0` | `engineWaterMask:1`, `engineLakeMask:0`, `engineTerrain:TERRAIN_OCEAN` | `landMask:0`, `terrain:TERRAIN_OCEAN` | Local pipeline consistently keeps ocean; live coast needs live water/area readback before owner classification. |
+| Row          | Morphology shelf/coast                                                 | Hydrology lake intent             | Map-hydrology projection                                               | Placement snapshot                    | Current disposition                                                                                                                                                            |
+| ------------ | ---------------------------------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| T1 `(73,36)` | `shelfMask:0`, `coastalWater:0`, `coastalLand:0`, `distanceToCoast:18` | `lakeMask:0`, `plannedLakeMask:0` | `engineWaterMask:1`, `engineLakeMask:0`, `engineTerrain:TERRAIN_OCEAN` | `landMask:0`, `terrain:TERRAIN_OCEAN` | Local pipeline consistently keeps ocean; live coast needs live water/area readback before owner classification.                                                                |
 | T2 `(65,39)` | `shelfMask:0`, `coastalWater:0`, `coastalLand:0`, `distanceToCoast:18` | `lakeMask:0`, `plannedLakeMask:0` | `engineWaterMask:1`, `engineLakeMask:1`, `engineTerrain:TERRAIN_COAST` | `landMask:0`, `terrain:TERRAIN_COAST` | Local pipeline consistently keeps coast/lake-classified water despite no planned lake mask at this row; live ocean needs live water/area readback before owner classification. |
 
 The local evidence narrows both rows away from simple morphology shelf/coast
@@ -41,18 +47,28 @@ intent and planned Hydrology lake intent. It does not yet prove whether the
 remaining owner is local projection/materialization, Civ live validation, or a
 readback/evidence gap.
 
+## Live Readback Context
+
+The live readback verifier is bound to the saved final-surface proof by request
+identity and current runtime identity. It requires successful row facts for
+`terrain`, `water`, `lake`, `riverType`, `areaId`, `regionId`, and
+`landmassId`; missing or failed facts block the packet.
+
+| Row          | Live terrain/hydrology                                      | Live area/region                                   | Local/live contrast                                                                                                                | Current disposition                                                                                                                     |
+| ------------ | ----------------------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| T1 `(73,36)` | `TERRAIN_COAST`, `water:true`, `lake:false`, `riverType:-1` | `areaId:720906`, `regionId:-1`, `landmassId:65536` | local projection `TERRAIN_OCEAN`, `engineLakeMask:0`, `engineAreaId:1`; live is same water body identity class but coast terrain   | Source authority still unresolved; needs projection/validation boundary evidence before repair.                                         |
+| T2 `(65,39)` | `TERRAIN_OCEAN`, `water:true`, `lake:false`, `riverType:-1` | `areaId:720906`, `regionId:-1`, `landmassId:65536` | local projection `TERRAIN_COAST`, `engineLakeMask:1`, `engineAreaId:1`; live reports non-lake ocean in the same live area/landmass | Strongest signal for a projection/materialization vs Civ validation gap, but still no repair authority without boundary classification. |
+
 ## Owner Candidates
 
-| Candidate | Current disposition |
-|---|---|
-| `map-morphology-coast-shelf-projection` | possible; needs local shelf/coast masks and projection-boundary terrain snapshots |
-| `map-hydrology-water-mutation` | possible; needs lake/river/water mutation evidence at the rows |
-| `civ-engine-terrain-validation` | possible; needs before/after `validateAndFixTerrain` and live water/area readback |
-| `evidence-insufficient` | current status until the evidence above exists |
+| Candidate                               | Current disposition                                                                                                                                       |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `map-morphology-coast-shelf-projection` | less likely as direct row intent; local shelf/coast masks are `0` with distance-to-coast `18`, but projection-boundary terrain snapshots are still needed |
+| `map-hydrology-water-mutation`          | still possible through local engine lake/terrain projection, especially T2 where local `engineLakeMask:1` contrasts with live `lake:false`                |
+| `civ-engine-terrain-validation`         | still possible; needs before/after `validateAndFixTerrain` or equivalent materialization boundary evidence                                                |
+| `evidence-insufficient`                 | current status until the evidence above exists                                                                                                            |
 
 ## Next Classification Evidence
 
-- Local shelf/coast/lake/water-protection masks for both rows.
 - Projection-boundary engine terrain snapshots around terrain validation.
-- Live water/lake/area readback for both rows.
 - Explicit owner disposition before any coast/shelf policy repair.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "verify:final-surface-parity": "bun scripts/civ7-direct-control/verify-final-surface-parity.ts",
     "verify:resource-delta-feasibility": "bun scripts/civ7-direct-control/verify-resource-delta-feasibility.ts",
     "verify:feature-delta-feasibility": "bun scripts/civ7-direct-control/verify-feature-delta-feasibility.ts",
+    "verify:terrain-edge-live-context": "bun scripts/civ7-direct-control/verify-terrain-edge-live-context.ts",
     "build:mapgen": "turbo run build --filter=@swooper/mapgen-core",
     "lint:adapter-boundary": "./scripts/lint/lint-adapter-boundary.sh",
     "lint:domain-refactor-guardrails": "./scripts/lint/lint-domain-refactor-guardrails.sh",

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -4159,6 +4159,7 @@ function plotSnapshotScriptSource(): string {
         if (fields.includes("hydrology")) {
           add("riverType", safeMapCall("getRiverType", input.x, input.y));
           add("water", safeMapCall("isWater", input.x, input.y));
+          add("lake", safeMapCall("isLake", input.x, input.y));
         }
         if (fields.includes("yields")) add("yields", safeMapCall("getYields", input.x, input.y));
         if (fields.includes("owner")) {

--- a/packages/civ7-direct-control/test/direct-control.test.ts
+++ b/packages/civ7-direct-control/test/direct-control.test.ts
@@ -333,7 +333,12 @@ describe("Civ7 direct control", () => {
         timeoutMs: 1_000,
       });
       const plot = await getCiv7PlotSnapshot(
-        { x: 3, y: 4, playerId: 0, fields: ["terrain", "resource", "visibility"] },
+        {
+          x: 3,
+          y: 4,
+          playerId: 0,
+          fields: ["terrain", "resource", "hydrology", "visibility"],
+        },
         { host: "127.0.0.1", port, timeoutMs: 1_000 },
       );
 
@@ -346,6 +351,9 @@ describe("Civ7 direct control", () => {
         facts: {
           terrain: { ok: true, value: 4 },
           resource: { ok: true, value: -1 },
+          riverType: { ok: true, value: -1 },
+          water: { ok: true, value: false },
+          lake: { ok: true, value: false },
         },
       });
     } finally {
@@ -1624,7 +1632,7 @@ async function startTunerServer(options: {
                   ...(fields.includes("biome") ? { biome: { ok: true, value: 1 } } : {}),
                   ...(fields.includes("feature") ? { feature: { ok: true, value: -1 } } : {}),
                   ...(fields.includes("resource") ? { resource: { ok: true, value: -1 } } : {}),
-                  ...(fields.includes("hydrology") ? { riverType: { ok: true, value: -1 }, water: { ok: true, value: false } } : {}),
+                  ...(fields.includes("hydrology") ? { riverType: { ok: true, value: -1 }, water: { ok: true, value: false }, lake: { ok: true, value: false } } : {}),
                 },
               });
               if (selectedPlots.length >= maxPlots) break outer;
@@ -1748,6 +1756,9 @@ async function startTunerServer(options: {
                 facts: {
                   terrain: { ok: true, value: 4 },
                   resource: { ok: true, value: -1 },
+                  riverType: { ok: true, value: -1 },
+                  water: { ok: true, value: false },
+                  lake: { ok: true, value: false },
                   revealedState: { ok: true, value: 1 },
                   visible: { ok: true, value: true },
                 },

--- a/scripts/civ7-direct-control/verify-terrain-edge-live-context.test.ts
+++ b/scripts/civ7-direct-control/verify-terrain-edge-live-context.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { summarizeTerrainEdgeReadbackCompleteness } from "./verify-terrain-edge-live-context";
+
+type TerrainRows = Parameters<typeof summarizeTerrainEdgeReadbackCompleteness>[0];
+type MapGrid = Parameters<typeof summarizeTerrainEdgeReadbackCompleteness>[1];
+
+describe("terrain-edge live context verifier", () => {
+  test("blocks complete readback when requested row facts are missing or failed", () => {
+    const completeness = summarizeTerrainEdgeReadbackCompleteness(
+      [
+        {
+          x: 73,
+          y: 36,
+          plotIndex: 3889,
+        },
+      ] as TerrainRows,
+      {
+        host: "127.0.0.1",
+        port: 4318,
+        state: { id: "1", name: "Tuner" },
+        fields: ["terrain", "hydrology", "areaRegion"],
+        plotCount: 1,
+        omitted: 0,
+        hiddenInfoPolicy: "not-player-scoped",
+        plots: [
+          {
+            location: { x: 73, y: 36, index: { ok: true, value: 3889 } },
+            hiddenInfoPolicy: "not-player-scoped",
+            facts: {
+              terrain: { ok: true, value: 3 },
+              water: { ok: true, value: true },
+              lake: { ok: true, value: false },
+              riverType: { ok: true, value: -1 },
+              areaId: { ok: false, error: "MapAreas unavailable" },
+              regionId: { ok: true, value: -1 },
+            },
+          },
+        ],
+      } as MapGrid
+    );
+
+    expect(completeness.status).toBe("blocked");
+    expect(completeness.blockedBy).toEqual([
+      "live-terrain-readback.areaId.failed",
+      "live-terrain-readback.landmassId.missing",
+    ]);
+    expect(completeness.factIssues).toMatchObject([
+      { x: 73, y: 36, plotIndex: 3889, field: "areaId", status: "failed" },
+      { x: 73, y: 36, plotIndex: 3889, field: "landmassId", status: "missing" },
+    ]);
+  });
+});

--- a/scripts/civ7-direct-control/verify-terrain-edge-live-context.ts
+++ b/scripts/civ7-direct-control/verify-terrain-edge-live-context.ts
@@ -1,0 +1,506 @@
+#!/usr/bin/env bun
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import {
+  getCiv7MapGrid,
+  getCiv7MapSummary,
+  type Civ7MapGridResult,
+  type Civ7MapSummaryResult,
+  type Civ7PlotSnapshot,
+  type Civ7PlotSnapshotField,
+} from "../../packages/civ7-direct-control/src/index.ts";
+import {
+  hashParityValue,
+  stableParityProofStringify,
+  type FinalSurfaceParityProof,
+} from "../../mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts";
+import {
+  buildTerrainDeltaEdgeContexts,
+  type TerrainDeltaEdgeContext,
+} from "../../mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts";
+
+type Args = Readonly<{
+  proofFile?: string;
+  contextFile?: string;
+  host?: string;
+  port?: number;
+  timeoutMs: number;
+  maxCells: number;
+  output?: string;
+  help: boolean;
+}>;
+
+const usage = `Usage:
+  bun scripts/civ7-direct-control/verify-terrain-edge-live-context.ts --proof-file <final-surface-proof.json>
+
+Options:
+  --context-file <path> Optional terrain edge context artifact to join by plot index
+  --host <host>       Civ7 tuner host
+  --port <port>       Civ7 tuner port
+  --timeout-ms <ms>   Direct-control timeout (default: 45000)
+  --max-cells <n>     Safety cap for terrain delta cells (default: 16)
+  --output <path>     Write full proof JSON to path
+`;
+
+const LIVE_TERRAIN_EDGE_FIELDS = [
+  "terrain",
+  "hydrology",
+  "areaRegion",
+] as const satisfies ReadonlyArray<Civ7PlotSnapshotField>;
+
+const REQUIRED_LIVE_TERRAIN_EDGE_FACTS = [
+  "terrain",
+  "water",
+  "lake",
+  "riverType",
+  "areaId",
+  "regionId",
+  "landmassId",
+] as const;
+
+function parseArgs(argv: string[]): Args {
+  const args: {
+    proofFile?: string;
+    contextFile?: string;
+    host?: string;
+    port?: number;
+    timeoutMs: number;
+    maxCells: number;
+    output?: string;
+    help: boolean;
+  } = {
+    timeoutMs: 45_000,
+    maxCells: 16,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = () => {
+      const next = argv[index + 1];
+      if (!next || next.startsWith("--")) throw new Error(`Missing value for ${arg}`);
+      index += 1;
+      return next;
+    };
+    switch (arg) {
+      case "--help":
+      case "-h":
+        args.help = true;
+        break;
+      case "--proof-file":
+        args.proofFile = value();
+        break;
+      case "--context-file":
+        args.contextFile = value();
+        break;
+      case "--host":
+        args.host = value();
+        break;
+      case "--port":
+        args.port = parseInteger(value(), arg);
+        break;
+      case "--timeout-ms":
+        args.timeoutMs = parseInteger(value(), arg);
+        break;
+      case "--max-cells":
+        args.maxCells = parseInteger(value(), arg);
+        break;
+      case "--output":
+        args.output = value();
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function parseInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) throw new Error(`${label} must be an integer: ${value}`);
+  return parsed;
+}
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage);
+    return 0;
+  }
+  if (!args.proofFile) throw new Error("Expected --proof-file");
+
+  const proof = extractFinalSurfaceParityProof(JSON.parse(readFileSync(args.proofFile, "utf8")));
+  const contextArtifact = args.contextFile
+    ? JSON.parse(readFileSync(args.contextFile, "utf8"))
+    : undefined;
+  const contextRowsByPlot = readContextRowsByPlot(contextArtifact);
+  const requestIdentity = resolveRequestIdentity(proof);
+  if (requestIdentity.blockedBy.length > 0) {
+    const outputWithoutHash = {
+      ok: false,
+      status: "blocked" as const,
+      requestId: requestIdentity.requestId,
+      sourceProofHash: hashParityValue(proof),
+      sourceContextHash: contextArtifact === undefined ? null : hashParityValue(contextArtifact),
+      blockedBy: requestIdentity.blockedBy,
+      requestIdentity,
+    };
+    const output = { ...outputWithoutHash, proofHash: hashParityValue(outputWithoutHash) };
+    writeOutput(args.output, output);
+    console.log(stableParityProofStringify(output));
+    return 2;
+  }
+
+  const runtimeIdentity = await readAndCompareRuntimeIdentity(proof, args);
+  if (runtimeIdentity.blockedBy.length > 0) {
+    const outputWithoutHash = {
+      ok: false,
+      status: "blocked" as const,
+      requestId: requestIdentity.requestId,
+      sourceProofHash: hashParityValue(proof),
+      sourceContextHash: contextArtifact === undefined ? null : hashParityValue(contextArtifact),
+      blockedBy: runtimeIdentity.blockedBy,
+      requestIdentity,
+      runtimeIdentity,
+    };
+    const output = { ...outputWithoutHash, proofHash: hashParityValue(outputWithoutHash) };
+    writeOutput(args.output, output);
+    console.log(stableParityProofStringify(output));
+    return 2;
+  }
+
+  const terrainRows = buildTerrainDeltaEdgeContexts({ local: proof.local, live: proof.live });
+  if (terrainRows.length === 0) throw new Error("Expected at least one terrain edge delta row");
+  if (terrainRows.length > args.maxCells) {
+    throw new Error(
+      `Terrain edge row count ${terrainRows.length} exceeds --max-cells ${args.maxCells}`
+    );
+  }
+
+  const livePlotContext = await getCiv7MapGrid(
+    {
+      locations: terrainRows.map((row) => ({ x: row.x, y: row.y })),
+      fields: LIVE_TERRAIN_EDGE_FIELDS,
+      maxPlots: args.maxCells,
+    },
+    { host: args.host, port: args.port, timeoutMs: args.timeoutMs }
+  );
+  const completeness = summarizeTerrainEdgeReadbackCompleteness(terrainRows, livePlotContext);
+  if (completeness.blockedBy.length > 0) {
+    const outputWithoutHash = {
+      ok: false,
+      status: "blocked" as const,
+      requestId: requestIdentity.requestId,
+      sourceProofHash: hashParityValue(proof),
+      sourceContextHash: contextArtifact === undefined ? null : hashParityValue(contextArtifact),
+      blockedBy: completeness.blockedBy,
+      requestIdentity,
+      runtimeIdentity,
+      livePlotContext: summarizeLivePlotContext(livePlotContext),
+      completeness,
+    };
+    const output = { ...outputWithoutHash, proofHash: hashParityValue(outputWithoutHash) };
+    writeOutput(args.output, output);
+    console.log(stableParityProofStringify(output));
+    return 2;
+  }
+
+  const outputWithoutHash = {
+    ok: true,
+    status: "complete" as const,
+    requestId: requestIdentity.requestId,
+    sourceProofHash: hashParityValue(proof),
+    sourceContextHash: contextArtifact === undefined ? null : hashParityValue(contextArtifact),
+    evidenceBoundary:
+      "Diagnostic context only: live terrain/hydrology/area readback is exact-runtime-bound evidence for terrain edge source-authority classification. It does not authorize terrain repair, parity closure, product acceptance, or tuning by itself.",
+    requestIdentity,
+    runtimeIdentity,
+    rowCount: terrainRows.length,
+    livePlotContext: summarizeLivePlotContext(livePlotContext),
+    rows: summarizeRows(terrainRows, livePlotContext, contextRowsByPlot),
+  };
+  const output = { ...outputWithoutHash, proofHash: hashParityValue(outputWithoutHash) };
+  writeOutput(args.output, output);
+  console.log(stableParityProofStringify(output));
+  return 0;
+}
+
+function extractFinalSurfaceParityProof(payload: unknown): FinalSurfaceParityProof {
+  if (!isRecord(payload)) throw new Error("Proof payload must be an object");
+  const proof = isRecord(payload.proof) ? payload.proof : payload;
+  if (!isRecord(proof.local) || !isRecord(proof.live)) {
+    throw new Error("Expected final-surface parity proof with local/live snapshots");
+  }
+  return proof as FinalSurfaceParityProof;
+}
+
+function resolveRequestIdentity(proof: FinalSurfaceParityProof) {
+  const packet = isRecord(proof.exactAuthorshipPacket) ? proof.exactAuthorshipPacket : {};
+  const sourceSnapshot = isRecord(packet.sourceSnapshot) ? packet.sourceSnapshot : {};
+  const log = isRecord(packet.log) ? packet.log : {};
+  const sources = {
+    exactAuthorshipSummary: stringValue(recordValue(proof.exactAuthorshipSummary, "requestId")),
+    exactAuthorshipPacket: stringValue(packet.requestId),
+    sourceSnapshot: stringValue(sourceSnapshot.requestId),
+    log: stringValue(log.requestId),
+  };
+  const values = Object.values(sources).filter((value): value is string => value !== undefined);
+  const uniqueValues = [...new Set(values)].sort((left, right) => left.localeCompare(right));
+  const blockedBy =
+    uniqueValues.length === 0
+      ? ["request-identity.missing"]
+      : uniqueValues.length > 1
+        ? ["request-identity.conflict"]
+        : [];
+  return {
+    requestId: uniqueValues.length === 1 ? uniqueValues[0] : undefined,
+    status: blockedBy.length === 0 ? ("matched" as const) : ("blocked" as const),
+    blockedBy,
+    sources,
+  };
+}
+
+async function readAndCompareRuntimeIdentity(
+  proof: FinalSurfaceParityProof,
+  args: Pick<Args, "host" | "port" | "timeoutMs">
+) {
+  const current = await getCiv7MapSummary({
+    host: args.host,
+    port: args.port,
+    timeoutMs: args.timeoutMs,
+  });
+  const saved = savedRuntimeIdentity(proof);
+  const observed = observedRuntimeIdentity(current);
+  const comparisons = {
+    width: compareIdentityValue(saved.width, observed.width),
+    height: compareIdentityValue(saved.height, observed.height),
+    plotCount: compareIdentityValue(saved.plotCount, observed.plotCount),
+    seed: compareIdentityValue(saved.seed, observed.seed),
+    turn: compareIdentityValue(saved.turn, observed.turn),
+    gameHash: compareIdentityValue(saved.gameHash, observed.gameHash),
+  };
+  const blockedBy = Object.entries(comparisons)
+    .filter(([, comparison]) => comparison.status !== "matched")
+    .map(([key, comparison]) => `runtime-identity.${key}.${comparison.status}`)
+    .sort((left, right) => left.localeCompare(right));
+
+  return {
+    status: blockedBy.length === 0 ? ("matched" as const) : ("blocked" as const),
+    blockedBy,
+    saved,
+    observed,
+    comparisons,
+  };
+}
+
+function savedRuntimeIdentity(proof: FinalSurfaceParityProof) {
+  const evidence = isRecord(proof.live.evidence) ? proof.live.evidence : {};
+  const runtime = isRecord(evidence.runtime) ? evidence.runtime : {};
+  const fullGrid = isRecord(evidence.fullGrid) ? evidence.fullGrid : {};
+  const initialSummary = isRecord(fullGrid.initialSummary) ? fullGrid.initialSummary : {};
+  return {
+    width: numberValue(runtime.width) ?? numberValue(initialSummary.width) ?? proof.live.width,
+    height: numberValue(runtime.height) ?? numberValue(initialSummary.height) ?? proof.live.height,
+    plotCount: numberValue(runtime.plotCount) ?? numberValue(initialSummary.plotCount),
+    seed: numberValue(runtime.seed) ?? numberValue(initialSummary.seed) ?? proof.live.seed,
+    turn: numberValue(runtime.turn) ?? numberValue(initialSummary.turn),
+    gameHash: numberValue(runtime.gameHash) ?? numberValue(initialSummary.gameHash),
+  };
+}
+
+function observedRuntimeIdentity(summary: Civ7MapSummaryResult) {
+  return {
+    host: summary.host,
+    port: summary.port,
+    state: summary.state,
+    width: probeNumber(summary.map.width),
+    height: probeNumber(summary.map.height),
+    plotCount: probeNumber(summary.map.plotCount),
+    seed: probeNumber(summary.map.randomSeed),
+    turn: probeNumber(summary.game.turn),
+    gameHash: probeNumber(summary.game.hash),
+  };
+}
+
+function compareIdentityValue(saved: number | undefined, observed: number | undefined) {
+  if (saved === undefined) return { status: "missing-saved" as const, saved, observed };
+  if (observed === undefined) return { status: "missing-observed" as const, saved, observed };
+  if (saved !== observed) return { status: "mismatch" as const, saved, observed };
+  return { status: "matched" as const, saved, observed };
+}
+
+export function summarizeTerrainEdgeReadbackCompleteness(
+  rows: ReadonlyArray<TerrainDeltaEdgeContext>,
+  readback: Civ7MapGridResult
+) {
+  const plotsByLocation = plotsByLocationKey(readback.plots);
+  const missingRows = rows.filter((row) => !plotsByLocation.has(locationKey(row.x, row.y)));
+  const factIssues = rows.flatMap((row) => {
+    const plot = plotsByLocation.get(locationKey(row.x, row.y));
+    if (plot === undefined) return [];
+    return REQUIRED_LIVE_TERRAIN_EDGE_FACTS.flatMap((field) => {
+      const fact = plot.facts[field];
+      if (fact === undefined) {
+        return [
+          {
+            x: row.x,
+            y: row.y,
+            plotIndex: row.plotIndex,
+            field,
+            status: "missing" as const,
+            link: `live-terrain-readback.${field}.missing`,
+          },
+        ];
+      }
+      if (!isRecord(fact) || fact.ok !== true || !("value" in fact)) {
+        return [
+          {
+            x: row.x,
+            y: row.y,
+            plotIndex: row.plotIndex,
+            field,
+            status: "failed" as const,
+            link: `live-terrain-readback.${field}.failed`,
+            fact,
+          },
+        ];
+      }
+      return [];
+    });
+  });
+  const blockedBy = [
+    ...(readback.omitted > 0 ? ["live-terrain-readback.omitted"] : []),
+    ...(missingRows.length > 0 ? ["live-terrain-readback.missing-rows"] : []),
+    ...factIssues.map((issue) => issue.link),
+  ]
+    .filter((link, index, links) => links.indexOf(link) === index)
+    .sort((left, right) => left.localeCompare(right));
+  return {
+    status: blockedBy.length === 0 ? ("complete" as const) : ("blocked" as const),
+    blockedBy,
+    expectedRows: rows.length,
+    observedRows: readback.plots.length,
+    omitted: readback.omitted,
+    missingRows: missingRows.map((row) => ({ x: row.x, y: row.y, plotIndex: row.plotIndex })),
+    factIssues,
+  };
+}
+
+function summarizeLivePlotContext(readback: Civ7MapGridResult) {
+  return {
+    readback: {
+      host: readback.host,
+      port: readback.port,
+      state: readback.state,
+      fields: readback.fields,
+      plotCount: readback.plotCount,
+      omitted: readback.omitted,
+      hiddenInfoPolicy: readback.hiddenInfoPolicy,
+    },
+    rows: readback.plots.map((plot) => ({
+      location: plot.location,
+      hiddenInfoPolicy: plot.hiddenInfoPolicy,
+      facts: plot.facts,
+    })),
+  };
+}
+
+function summarizeRows(
+  rows: ReadonlyArray<TerrainDeltaEdgeContext>,
+  readback: Civ7MapGridResult,
+  contextRowsByPlot: ReadonlyMap<number, Record<string, unknown>>
+) {
+  const plotsByLocation = plotsByLocationKey(readback.plots);
+  return rows.map((row) => {
+    const plot = plotsByLocation.get(locationKey(row.x, row.y));
+    const contextRow = contextRowsByPlot.get(row.plotIndex);
+    return {
+      x: row.x,
+      y: row.y,
+      plotIndex: row.plotIndex,
+      localTerrain: row.localTerrain,
+      liveTerrain: row.liveTerrain,
+      evidenceClass: row.evidenceClass,
+      neighborhood: row.neighborhood,
+      localProjection: contextRow?.localProjection ?? row.localProjection ?? null,
+      liveReadback:
+        plot === undefined
+          ? null
+          : {
+              location: plot.location,
+              hiddenInfoPolicy: plot.hiddenInfoPolicy,
+              terrain: plot.facts.terrain,
+              water: plot.facts.water,
+              lake: plot.facts.lake,
+              riverType: plot.facts.riverType,
+              areaId: plot.facts.areaId,
+              regionId: plot.facts.regionId,
+              landmassId: plot.facts.landmassId,
+            },
+      sourceAuthorityStatus: "unresolved",
+    };
+  });
+}
+
+function plotsByLocationKey(plots: ReadonlyArray<Civ7PlotSnapshot>): Map<string, Civ7PlotSnapshot> {
+  return new Map(
+    plots.map((plot) => [locationKey(plot.location.x, plot.location.y), plot] as const)
+  );
+}
+
+function locationKey(x: number, y: number): string {
+  return `${x},${y}`;
+}
+
+function readContextRowsByPlot(payload: unknown): ReadonlyMap<number, Record<string, unknown>> {
+  const byPlot = new Map<number, Record<string, unknown>>();
+  if (!isRecord(payload) || !Array.isArray(payload.rows)) return byPlot;
+  for (const row of payload.rows) {
+    if (!isRecord(row)) continue;
+    const plotIndex = numberValue(row.plotIndex);
+    if (plotIndex === undefined) continue;
+    byPlot.set(plotIndex, row);
+  }
+  return byPlot;
+}
+
+function writeOutput(path: string | undefined, output: unknown): void {
+  if (!path) return;
+  const absolute = resolve(path);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, `${stableParityProofStringify(output)}\n`);
+}
+
+function probeNumber(value: unknown): number | undefined {
+  if (isRecord(value) && value.ok === true && typeof value.value === "number") return value.value;
+  return undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function recordValue(value: unknown, key: string): unknown {
+  return isRecord(value) ? value[key] : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+if (import.meta.main) {
+  main()
+    .then((code) => {
+      process.exitCode = code;
+    })
+    .catch((error: unknown) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
Adds exact-runtime-bound live terrain/hydrology/area readback for terrain edge diagnostic rows as part of the earthlike terrain edge diagnostics workstream.

A new `verify:terrain-edge-live-context` script reads the final-surface parity proof, matches request identity across all proof sources, verifies the current runtime matches the saved proof (dimensions, seed, turn, game hash), then queries live Civ for `terrain`, `water`, `lake`, `riverType`, `areaId`, `regionId`, and `landmassId` facts for each coast/ocean mismatch row. The artifact is blocked rather than complete if any required fact is missing or failed.

The `hydrology` field group in `civ7-direct-control` now includes `isLake` alongside the existing `getRiverType` and `isWater` calls. Tests and the mock tuner server are updated to expect the `lake` fact when `hydrology` is requested.

Live readback results for `studio-run-in-game-mq20rbzr-1fhc` are recorded: both rows share `areaId:720906` and `landmassId:65536` with no lake or river. Row T2 `(65,39)` is the strongest remaining signal — local projection carries `engineLakeMask:1` and `TERRAIN_COAST` while live Civ reports `lake:false` and `TERRAIN_OCEAN` — narrowing the classification toward a projection/materialization vs. Civ validation gap, but source authority remains unresolved pending projection-boundary snapshots around `validateAndFixTerrain`.

Task 2.5 (live water/lake/area readback evidence) is marked complete. The next classification step is a projection-boundary engine terrain snapshot before any repair is authorized.