### PR TITLE
feat(swooper-maps): add placement validation-boundary readback artifact with before/after-validate and after-maintenance terrain snapshots

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -330,6 +330,9 @@ function buildTerrainProjectionEvidence(context: ReturnType<typeof createExtende
   const placementTerrainSnapshot = context.artifacts.get(
     mapArtifacts.placementEngineTerrainSnapshot.id
   );
+  const placementValidationBoundary = context.artifacts.get(
+    mapArtifacts.placementSurfaceValidationBoundary.id
+  );
   return stripUndefined({
     coastlineMetrics: pickSerializableFields(coastlineMetrics, [
       "coastalLand",
@@ -376,6 +379,13 @@ function buildTerrainProjectionEvidence(context: ReturnType<typeof createExtende
       "landMask",
       "terrain",
     ]),
+    placementValidationBoundary: pickSerializableFields(placementValidationBoundary, [
+      "width",
+      "height",
+      "beforeValidate",
+      "afterValidate",
+      "afterMaintenance",
+    ]),
   });
 }
 
@@ -390,6 +400,12 @@ function pickSerializableFields(
 function serializeEvidenceValue(value: unknown): unknown {
   if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
     return Array.from(value as ArrayLike<number>);
+  }
+  if (Array.isArray(value)) return value.map((entry) => serializeEvidenceValue(entry));
+  if (isPlainObject(value)) {
+    return stripUndefined(
+      Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, serializeEvidenceValue(entry)]))
+    );
   }
   return value;
 }

--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -378,6 +378,7 @@ export type TerrainProjectionRowContext = Readonly<{
   hydrologyTerrainSnapshot: TerrainProjectionSnapshotRowContext | null;
   placementSurfacePreparation: TerrainPlacementPreparationContext | null;
   placementTerrainSnapshot: TerrainProjectionSnapshotRowContext | null;
+  placementValidationBoundary: TerrainValidationBoundaryRowContext | null;
 }>;
 
 export type TerrainMorphologyProjectionRowContext = Readonly<{
@@ -418,6 +419,21 @@ export type TerrainPlacementPreparationContext = Readonly<{
   acceptedLakeTileCount: number | null;
   finalLakeWaterDriftCount: number | null;
   finalLakeClassificationDriftCount: number | null;
+}>;
+
+export type TerrainValidationBoundaryRowContext = Readonly<{
+  beforeValidate: TerrainValidationBoundaryFactContext | null;
+  afterValidate: TerrainValidationBoundaryFactContext | null;
+  afterMaintenance: TerrainValidationBoundaryFactContext | null;
+}>;
+
+export type TerrainValidationBoundaryFactContext = Readonly<{
+  stage: string | null;
+  terrain: number | null;
+  terrainSymbol: string;
+  waterMask: number | null;
+  lakeMask: number | null;
+  areaId: number | null;
 }>;
 
 export type ResourcePlacementOutcomeContext = Readonly<{
@@ -1550,6 +1566,9 @@ function terrainProjectionRowContext(
   const placementTerrainSnapshot = isRecord(projection.placementTerrainSnapshot)
     ? projection.placementTerrainSnapshot
     : undefined;
+  const placementValidationBoundary = isRecord(projection.placementValidationBoundary)
+    ? projection.placementValidationBoundary
+    : undefined;
   return {
     morphology: morphology
       ? {
@@ -1599,6 +1618,38 @@ function terrainProjectionRowContext(
         }
       : null,
     placementTerrainSnapshot: projectionSnapshotRowContext(placementTerrainSnapshot, plotIndex),
+    placementValidationBoundary: validationBoundaryRowContext(placementValidationBoundary, plotIndex),
+  };
+}
+
+function validationBoundaryRowContext(
+  snapshot: Record<string, unknown> | undefined,
+  plotIndex: number
+): TerrainValidationBoundaryRowContext | null {
+  if (!snapshot) return null;
+  const beforeValidate = isRecord(snapshot.beforeValidate) ? snapshot.beforeValidate : undefined;
+  const afterValidate = isRecord(snapshot.afterValidate) ? snapshot.afterValidate : undefined;
+  const afterMaintenance = isRecord(snapshot.afterMaintenance) ? snapshot.afterMaintenance : undefined;
+  return {
+    beforeValidate: validationBoundaryFactContext(beforeValidate, plotIndex),
+    afterValidate: validationBoundaryFactContext(afterValidate, plotIndex),
+    afterMaintenance: validationBoundaryFactContext(afterMaintenance, plotIndex),
+  };
+}
+
+function validationBoundaryFactContext(
+  snapshot: Record<string, unknown> | undefined,
+  plotIndex: number
+): TerrainValidationBoundaryFactContext | null {
+  if (!snapshot) return null;
+  const terrain = indexedInteger(snapshot.terrain, plotIndex);
+  return {
+    stage: stringValue(snapshot.stage) ?? null,
+    terrain,
+    terrainSymbol: symbolFor("terrain", terrain),
+    waterMask: indexedInteger(snapshot.waterMask, plotIndex),
+    lakeMask: indexedInteger(snapshot.lakeMask, plotIndex),
+    areaId: indexedInteger(snapshot.areaId, plotIndex),
   };
 }
 

--- a/mods/mod-swooper-maps/src/recipes/standard/map-artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/map-artifacts.ts
@@ -59,6 +59,45 @@ const EngineTerrainSnapshotArtifactSchema = Type.Object(
   }
 );
 
+const EngineTerrainFactsSnapshotSchema = Type.Object(
+  {
+    stage: Type.String({
+      description: "Step boundary that produced this terrain fact snapshot.",
+    }),
+    terrain: TypedArraySchemas.i32({
+      description: "Engine terrain type readback at this boundary.",
+    }),
+    waterMask: TypedArraySchemas.u8({
+      description: "Engine isWater readback at this boundary (1=water,0=not water).",
+    }),
+    lakeMask: TypedArraySchemas.u8({
+      description: "Engine isLake readback at this boundary (1=lake,0=not lake).",
+    }),
+    areaId: TypedArraySchemas.i32({
+      description: "Engine area id readback at this boundary.",
+    }),
+  },
+  {
+    additionalProperties: false,
+    description: "Engine terrain/water/lake/area facts captured at a maintenance boundary.",
+  }
+);
+
+const PlacementSurfaceValidationBoundaryArtifactSchema = Type.Object(
+  {
+    width: Type.Integer({ minimum: 1 }),
+    height: Type.Integer({ minimum: 1 }),
+    beforeValidate: EngineTerrainFactsSnapshotSchema,
+    afterValidate: EngineTerrainFactsSnapshotSchema,
+    afterMaintenance: EngineTerrainFactsSnapshotSchema,
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Diagnostic placement surface readback around validateAndFixTerrain, area recalculation, and water cache storage.",
+  }
+);
+
 export const mapArtifacts = {
   projectionMeta: defineArtifact({
     name: "projectionMeta",
@@ -99,5 +138,10 @@ export const mapArtifacts = {
     name: "placementEngineTerrainSnapshot",
     id: "artifact:map.placementEngineTerrainSnapshot",
     schema: EngineTerrainSnapshotArtifactSchema,
+  }),
+  placementSurfaceValidationBoundary: defineArtifact({
+    name: "placementSurfaceValidationBoundary",
+    id: "artifact:map.placementSurfaceValidationBoundary",
+    schema: PlacementSurfaceValidationBoundaryArtifactSchema,
   }),
 } as const;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/contract.ts
@@ -28,7 +28,10 @@ const PreparePlacementSurfaceStepContract = defineStep({
       mapHydrologyArtifacts.engineProjectionLakes,
       mapArtifacts.landmassRegionSlotByTile,
     ],
-    provides: [placementArtifacts.placementSurfacePreparation],
+    provides: [
+      placementArtifacts.placementSurfacePreparation,
+      mapArtifacts.placementSurfaceValidationBoundary,
+    ],
   },
   schema: Type.Object({}, { additionalProperties: false }),
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/index.ts
@@ -6,13 +6,19 @@ import { runPlacementProductStep } from "../product-runtime.js";
 import { logTerrainStats } from "../terrain-diagnostics.js";
 import { applyLandmassRegionSlots } from "./landmass-regions.js";
 import { readFinalLakeProjection } from "./lake-readback.js";
+import { readTerrainValidationBoundarySnapshot } from "./terrain-validation-readback.js";
 import { placementArtifacts } from "../../artifacts.js";
+import { mapArtifacts } from "../../../../map-artifacts.js";
 import PreparePlacementSurfaceStepContract from "./contract.js";
 
 export default createStep(PreparePlacementSurfaceStepContract, {
-  artifacts: implementArtifacts([placementArtifacts.placementSurfacePreparation], {
-    placementSurfacePreparation: {},
-  }),
+  artifacts: implementArtifacts(
+    [placementArtifacts.placementSurfacePreparation, mapArtifacts.placementSurfaceValidationBoundary],
+    {
+      placementSurfacePreparation: {},
+      placementSurfaceValidationBoundary: {},
+    }
+  ),
   run: (context, _config, _ops, deps) => {
     const placementInputs = deps.artifacts.placementInputs.read(context);
     const naturalWonderPlacement = deps.artifacts.naturalWonderPlacement.read(context);
@@ -35,8 +41,22 @@ export default createStep(PreparePlacementSurfaceStepContract, {
     runPlacementProductStep("placement.floodplains", emit, () => {
       adapter.addFloodplains(floodplains.minLength, floodplains.maxLength);
     });
+
+    const beforeValidate = readTerrainValidationBoundarySnapshot(
+      adapter,
+      width,
+      height,
+      "placement/prepare-surface/before-validate"
+    );
+    let afterValidate = beforeValidate;
     runPlacementProductStep("placement.terrain.validate", emit, () => {
       adapter.validateAndFixTerrain();
+      afterValidate = readTerrainValidationBoundarySnapshot(
+        adapter,
+        width,
+        height,
+        "placement/prepare-surface/after-validate"
+      );
       emit({ type: "placement.terrain.validated" });
       logTerrainStats(trace, adapter, width, height, "After validateAndFixTerrain");
     });
@@ -52,6 +72,12 @@ export default createStep(PreparePlacementSurfaceStepContract, {
       applyLandmassRegionSlots(adapter, width, height, slotByTile);
       emit({ type: "placement.landmassRegion.restamped" });
     });
+    const afterMaintenance = readTerrainValidationBoundarySnapshot(
+      adapter,
+      width,
+      height,
+      "placement/prepare-surface/after-maintenance"
+    );
     const finalLakeReadback = readFinalLakeProjection(
       adapter,
       width,
@@ -67,6 +93,14 @@ export default createStep(PreparePlacementSurfaceStepContract, {
       else if (slot === 2) slotCounts.east += 1;
       else slotCounts.none += 1;
     }
+
+    deps.artifacts.placementSurfaceValidationBoundary.publish(context, {
+      width,
+      height,
+      beforeValidate,
+      afterValidate,
+      afterMaintenance,
+    });
 
     deps.artifacts.placementSurfacePreparation.publish(context, {
       width,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/terrain-validation-readback.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/prepare-placement-surface/terrain-validation-readback.ts
@@ -1,0 +1,45 @@
+import type { EngineAdapter } from "@civ7/adapter";
+
+export type TerrainValidationBoundarySnapshot = Readonly<{
+  stage: string;
+  terrain: Int32Array;
+  waterMask: Uint8Array;
+  lakeMask: Uint8Array;
+  areaId: Int32Array;
+}>;
+
+/**
+ * Diagnostic readback for placement surface maintenance. This records engine
+ * facts around validation/cache boundaries; it does not mutate terrain or
+ * authorize terrain policy changes by itself.
+ */
+export function readTerrainValidationBoundarySnapshot(
+  adapter: EngineAdapter,
+  width: number,
+  height: number,
+  stage: string
+): TerrainValidationBoundarySnapshot {
+  const size = Math.max(0, (width | 0) * (height | 0));
+  const terrain = new Int32Array(size);
+  const waterMask = new Uint8Array(size);
+  const lakeMask = new Uint8Array(size);
+  const areaId = new Int32Array(size);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const index = y * width + x;
+      terrain[index] = adapter.getTerrainType(x, y) | 0;
+      waterMask[index] = adapter.isWater(x, y) ? 1 : 0;
+      lakeMask[index] = adapter.isLake(x, y) ? 1 : 0;
+      areaId[index] = adapter.getAreaId(x, y) | 0;
+    }
+  }
+
+  return {
+    stage,
+    terrain,
+    waterMask,
+    lakeMask,
+    areaId,
+  };
+}

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -110,6 +110,29 @@ describe("surface delta context diagnostics", () => {
             landMask: [0, 0, 0, 1, 0, 0],
             terrain: [3, 4, 3, 2, 3, 4],
           },
+          placementValidationBoundary: {
+            beforeValidate: {
+              stage: "placement/prepare-surface/before-validate",
+              terrain: [3, 4, 3, 2, 3, 4],
+              waterMask: [1, 1, 1, 0, 1, 1],
+              lakeMask: [0, 1, 0, 0, 0, 0],
+              areaId: [1, 1, 1, 2, 1, 1],
+            },
+            afterValidate: {
+              stage: "placement/prepare-surface/after-validate",
+              terrain: [3, 3, 3, 2, 3, 4],
+              waterMask: [1, 1, 1, 0, 1, 1],
+              lakeMask: [0, 0, 0, 0, 0, 0],
+              areaId: [1, 1, 1, 2, 1, 1],
+            },
+            afterMaintenance: {
+              stage: "placement/prepare-surface/after-maintenance",
+              terrain: [3, 3, 3, 2, 3, 4],
+              waterMask: [1, 1, 1, 0, 1, 1],
+              lakeMask: [0, 0, 0, 0, 0, 0],
+              areaId: [10, 10, 10, 20, 10, 10],
+            },
+          },
         },
       }
     );
@@ -169,6 +192,26 @@ describe("surface delta context diagnostics", () => {
         placementTerrainSnapshot: {
           stage: "placement/placement",
           terrainSymbol: "TERRAIN_OCEAN",
+        },
+        placementValidationBoundary: {
+          beforeValidate: {
+            stage: "placement/prepare-surface/before-validate",
+            terrainSymbol: "TERRAIN_OCEAN",
+            lakeMask: 1,
+            areaId: 1,
+          },
+          afterValidate: {
+            stage: "placement/prepare-surface/after-validate",
+            terrainSymbol: "TERRAIN_COAST",
+            lakeMask: 0,
+            areaId: 1,
+          },
+          afterMaintenance: {
+            stage: "placement/prepare-surface/after-maintenance",
+            terrainSymbol: "TERRAIN_COAST",
+            lakeMask: 0,
+            areaId: 10,
+          },
         },
       },
     });

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/proposal.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/proposal.md
@@ -31,6 +31,8 @@ The source proof hash is
   runtime-bound terrain-edge verifier that requires successful terrain,
   water/lake/river, and area/region/landmass facts before producing complete
   live context.
+- Add local placement validation-boundary readback for terrain, water, lake,
+  and area facts before/after validation and maintenance.
 - Keep source authority unresolved until shelf/lake/projection-boundary and
   live water/area evidence can distinguish repo projection, hydrology mutation,
   Civ terrain validation, and evidence insufficiency.
@@ -71,6 +73,8 @@ The source proof hash is
 - Focused terrain diagnostic test.
 - Terrain edge context artifact for `studio-run-in-game-mq20rbzr-1fhc`.
 - Runtime-bound terrain-edge live readback artifact for
+  `studio-run-in-game-mq20rbzr-1fhc`.
+- Local placement validation-boundary artifact for
   `studio-run-in-game-mq20rbzr-1fhc`.
 - Fact-completeness regression for terrain-edge live readback.
 - `bun run --cwd mods/mod-swooper-maps check`.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/specs/mapgen-normalization-workstreams/spec.md
@@ -27,6 +27,17 @@ of each coast/ocean mismatch.
 - **AND** missing or failed requested facts keep the artifact blocked rather
   than complete
 
+#### Scenario: Local terrain validation boundary facts are recorded
+
+- **WHEN** local terrain diagnostics need to distinguish authored projection
+  from placement validation mutation
+- **THEN** diagnostics record terrain, water, lake, and area facts before
+  placement terrain validation, after validation, and after placement surface
+  maintenance
+- **AND** unchanged local rows narrow the remaining owner to a mock/local
+  materialization versus live Civ materialization gap rather than authorizing a
+  terrain policy repair
+
 #### Scenario: Terrain repair is proposed
 
 - **WHEN** a change proposes a coast/ocean terrain repair

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
@@ -11,7 +11,8 @@
 - [x] 2.3 Produce the terrain-edge context artifact.
 - [x] 2.4 Add or link shelf/coast/lake/projection-boundary mask evidence.
 - [x] 2.5 Add or link live water/lake/area readback evidence.
-- [ ] 2.6 Classify source authority for each row.
+- [x] 2.6 Add placement validation-boundary readback evidence.
+- [ ] 2.7 Classify source authority for each row.
 
 ## 3. Repair
 

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
@@ -5,12 +5,12 @@
 - Project: Swooper recovery
 - Phase: terrain-edge diagnostics
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-terrain-edge-live-readback-drain`
+- Branch/Graphite stack: `codex/swooper-terrain-validation-boundary-drain`
 - Started: 2026-06-06
-- Status: active. Terrain edge, local projection/mask context, and
-  exact-runtime-bound live terrain/hydrology/area readback exist for the two
-  coast/ocean rows, but source authority remains unresolved and no repair is
-  authorized.
+- Status: active. Terrain edge, local projection/mask context,
+  exact-runtime-bound live terrain/hydrology/area readback, and local placement
+  validation-boundary readback exist for the two coast/ocean rows. Source
+  authority remains unresolved and no repair is authorized.
 
 ## Objective
 
@@ -34,7 +34,7 @@
 
 - Worktree:
   `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain`.
-- Branch: `codex/swooper-terrain-edge-live-readback-drain`.
+- Branch: `codex/swooper-terrain-validation-boundary-drain`.
 - Source proof:
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc.json`.
 - Source proof hash:
@@ -63,6 +63,12 @@
   `213134d7020063f53073c2f6f254ae8fc0d153007b0b6e0848c2da4a642262f6`.
 - Live readback proof hash:
   `aa817119c628d1ecc144c5dd7ed4d3227f6fe3301af1ffab501e26751868c2a8`.
+- Source-recorded local validation-boundary artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-validation-boundary-context.json`.
+- Local validation-boundary artifact sha256:
+  `033609d9293faf4b86a1da5862247a4c41762e7917069be3f2af7c8e7f55f263`.
+- Local validation-boundary proof hash:
+  `e906acdcacb002572586379b98cd00d0eb99529c9b86e2384fc6b8e03703da4e`.
 
 ## Findings
 
@@ -108,6 +114,20 @@
     `engineLakeMask:1` and `TERRAIN_COAST`, while live Civ readback reports
     `lake:false` and `TERRAIN_OCEAN`. That narrows the next classification
     question but does not prove the repair owner.
+- Local placement validation-boundary evidence:
+  - New diagnostic artifact records `terrain`, `waterMask`, `lakeMask`, and
+    `areaId` before `placement.terrain.validate`, after
+    `validateAndFixTerrain`, and after area/water-cache maintenance.
+  - `(73,36)` remains `TERRAIN_OCEAN`, `waterMask:1`, `lakeMask:0`,
+    `areaId:1` across `beforeValidate`, `afterValidate`, and
+    `afterMaintenance`.
+  - `(65,39)` remains `TERRAIN_COAST`, `waterMask:1`, `lakeMask:1`,
+    `areaId:1` across `beforeValidate`, `afterValidate`, and
+    `afterMaintenance`.
+  - This narrows the owner: the local placement validation/maintenance step is
+    not rewriting either row. The unresolved boundary is now local
+    mock/materialization expectation versus live Civ terrain/lake
+    materialization, not late local placement mutation.
 
 ## Evidence Boundary
 
@@ -121,8 +141,10 @@
 ## Next Evidence
 
 - If live water/area readback does not resolve ownership, add a more granular
-  projection-boundary snapshot immediately around `validateAndFixTerrain`.
-- Then classify each row before any repair.
+  source-authority classification for the mock/local materialization versus
+  live Civ terrain/lake materialization gap.
+- Classify each row before any repair. Current evidence does not authorize
+  coast/shelf tuning or terrain repair.
 
 ## Verification
 

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
@@ -20,6 +20,12 @@
   `213134d7020063f53073c2f6f254ae8fc0d153007b0b6e0848c2da4a642262f6`.
 - Live readback proof hash:
   `aa817119c628d1ecc144c5dd7ed4d3227f6fe3301af1ffab501e26751868c2a8`.
+- Local validation-boundary context artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-validation-boundary-context.json`.
+- Local validation-boundary context artifact sha256:
+  `033609d9293faf4b86a1da5862247a4c41762e7917069be3f2af7c8e7f55f263`.
+- Local validation-boundary proof hash:
+  `e906acdcacb002572586379b98cd00d0eb99529c9b86e2384fc6b8e03703da4e`.
 - Request: `studio-run-in-game-mq20rbzr-1fhc`.
 - Seed/dimensions: `138503614`, `106x66`, `6996` plots.
 
@@ -59,16 +65,29 @@ identity and current runtime identity. It requires successful row facts for
 | T1 `(73,36)` | `TERRAIN_COAST`, `water:true`, `lake:false`, `riverType:-1` | `areaId:720906`, `regionId:-1`, `landmassId:65536` | local projection `TERRAIN_OCEAN`, `engineLakeMask:0`, `engineAreaId:1`; live is same water body identity class but coast terrain   | Source authority still unresolved; needs projection/validation boundary evidence before repair.                                         |
 | T2 `(65,39)` | `TERRAIN_OCEAN`, `water:true`, `lake:false`, `riverType:-1` | `areaId:720906`, `regionId:-1`, `landmassId:65536` | local projection `TERRAIN_COAST`, `engineLakeMask:1`, `engineAreaId:1`; live reports non-lake ocean in the same live area/landmass | Strongest signal for a projection/materialization vs Civ validation gap, but still no repair authority without boundary classification. |
 
+## Local Validation Boundary
+
+The placement validation-boundary artifact records local engine facts around the
+placement surface maintenance sequence. It is diagnostic source-authority
+evidence only.
+
+| Row          | Before validate                                                  | After validate                                                   | After maintenance                                                | Disposition                                                                                                                                                         |
+| ------------ | ---------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1 `(73,36)` | `TERRAIN_OCEAN`, `waterMask:1`, `lakeMask:0`, `areaId:1`         | `TERRAIN_OCEAN`, `waterMask:1`, `lakeMask:0`, `areaId:1`         | `TERRAIN_OCEAN`, `waterMask:1`, `lakeMask:0`, `areaId:1`         | Local placement validation/maintenance does not move this row.                                                                                                      |
+| T2 `(65,39)` | `TERRAIN_COAST`, `waterMask:1`, `lakeMask:1`, `areaId:1`         | `TERRAIN_COAST`, `waterMask:1`, `lakeMask:1`, `areaId:1`         | `TERRAIN_COAST`, `waterMask:1`, `lakeMask:1`, `areaId:1`         | Local placement validation/maintenance does not move this row. The live mismatch is now localized to local mock/materialization versus live Civ terrain/lake facts. |
+
 ## Owner Candidates
 
 | Candidate                               | Current disposition                                                                                                                                       |
 | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `map-morphology-coast-shelf-projection` | less likely as direct row intent; local shelf/coast masks are `0` with distance-to-coast `18`, but projection-boundary terrain snapshots are still needed |
+| `map-morphology-coast-shelf-projection` | less likely as direct row intent; local shelf/coast masks are `0` with distance-to-coast `18`                                                             |
 | `map-hydrology-water-mutation`          | still possible through local engine lake/terrain projection, especially T2 where local `engineLakeMask:1` contrasts with live `lake:false`                |
-| `civ-engine-terrain-validation`         | still possible; needs before/after `validateAndFixTerrain` or equivalent materialization boundary evidence                                                |
-| `evidence-insufficient`                 | current status until the evidence above exists                                                                                                            |
+| `local-mock-vs-live-civ-materialization` | strongest current class; local rows remain stable through placement validation while live Civ reports different terrain/lake facts                         |
+| `civ-engine-terrain-validation`         | still possible as the live-side materialization owner, but not yet enough to label it accepted engine policy or repair local policy                       |
+| `evidence-insufficient`                 | current status until mock/local versus live Civ materialization owner is classified                                                                        |
 
 ## Next Classification Evidence
 
-- Projection-boundary engine terrain snapshots around terrain validation.
-- Explicit owner disposition before any coast/shelf policy repair.
+- Explicit owner disposition for the mock/local materialization versus live Civ
+  terrain/lake materialization gap.
+- No coast/shelf policy repair until that owner is classified.


### PR DESCRIPTION
Add placement surface validation-boundary diagnostic readback artifact

Introduces a new `placementSurfaceValidationBoundary` artifact that captures engine terrain, water, lake, and area facts at three points during placement surface preparation: before `validateAndFixTerrain`, after `validateAndFixTerrain`, and after area/water-cache maintenance. This allows diagnostics to determine whether local placement validation or maintenance is responsible for terrain mutations observed in coast/ocean mismatch rows.

The readback is implemented in a new `readTerrainValidationBoundarySnapshot` function that iterates all plots and records `terrain`, `waterMask`, `lakeMask`, and `areaId` per tile into typed arrays. The artifact is published from the `prepare-placement-surface` step alongside the existing `placementSurfacePreparation` artifact.

The live parity diagnostic evidence builder is extended to include the new artifact's fields, and `serializeEvidenceValue` is updated to recursively handle plain objects and arrays so nested typed-array fields serialize correctly. The surface delta context adds `TerrainValidationBoundaryRowContext` and `TerrainValidationBoundaryFactContext` types, and the per-plot context extractor resolves terrain symbols for each boundary fact.

Findings from the target run show that both mismatched rows (`(73,36)` and `(65,39)`) are stable across all three boundary snapshots, ruling out local placement validation and maintenance as the mutation source. The remaining unresolved boundary is local mock/materialization versus live Civ terrain and lake materialization.