### PR TITLE
docs(earthlike-terrain-edge-diagnostics): classify row-level source authority to local mock/materialization parity and add bounded repair task

### DIFF
--- a/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
@@ -12,12 +12,14 @@
 - [x] 2.4 Add or link shelf/coast/lake/projection-boundary mask evidence.
 - [x] 2.5 Add or link live water/lake/area readback evidence.
 - [x] 2.6 Add placement validation-boundary readback evidence.
-- [ ] 2.7 Classify source authority for each row.
+- [x] 2.7 Classify source authority for each row.
 
 ## 3. Repair
 
 - [ ] 3.1 Repair only rows assigned to a repo-owned source authority.
 - [ ] 3.2 Preserve hydrology water mutation and Civ validation boundaries.
+- [ ] 3.3 Open any adapter/mock materialization repair as a separate bounded
+      layer before changing code.
 
 ## 4. Verification
 

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
@@ -5,12 +5,12 @@
 - Project: Swooper recovery
 - Phase: terrain-edge diagnostics
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-terrain-validation-boundary-drain`
+- Branch/Graphite stack: `codex/swooper-terrain-source-owner-drain`
 - Started: 2026-06-06
 - Status: active. Terrain edge, local projection/mask context,
-  exact-runtime-bound live terrain/hydrology/area readback, and local placement
-  validation-boundary readback exist for the two coast/ocean rows. Source
-  authority remains unresolved and no repair is authorized.
+  exact-runtime-bound live terrain/hydrology/area readback, local placement
+  validation-boundary readback, and row-level source-authority classification
+  exist for the two coast/ocean rows. Repair is not started in this layer.
 
 ## Objective
 
@@ -34,7 +34,7 @@
 
 - Worktree:
   `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain`.
-- Branch: `codex/swooper-terrain-validation-boundary-drain`.
+- Branch: `codex/swooper-terrain-source-owner-drain`.
 - Source proof:
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc.json`.
 - Source proof hash:
@@ -77,10 +77,12 @@
     neighborhood local/live counts both `coast:4`, `ocean:2`, `land:0`.
   - `(65,39)`: local `TERRAIN_COAST`, live `TERRAIN_OCEAN`;
     neighborhood local/live counts both `coast:2`, `ocean:3`, `land:1`.
-- Both rows remain `sourceAuthorityStatus:"unresolved"`.
-- Candidate owners remain:
-  `map-morphology-coast-shelf-projection`, `map-hydrology-water-mutation`,
-  `civ-engine-terrain-validation`, and `evidence-insufficient`.
+- Both rows are classified to the repo-owned local mock/materialization parity
+  boundary, not to MapGen coast/shelf tuning.
+- Candidate owners rejected for this row pair:
+  `map-morphology-coast-shelf-projection` as direct row intent,
+  `map-hydrology-water-mutation` as authored lake intent, and
+  `evidence-insufficient`.
 - Local mask/projection evidence:
   - Both rows have morphology `shelfMask:0`, `coastalWater:0`,
     `coastalLand:0`, and `distanceToCoast:18`. They are not locally justified
@@ -125,9 +127,55 @@
     `areaId:1` across `beforeValidate`, `afterValidate`, and
     `afterMaintenance`.
   - This narrows the owner: the local placement validation/maintenance step is
-    not rewriting either row. The unresolved boundary is now local
+    not rewriting either row. The classified boundary is local
     mock/materialization expectation versus live Civ terrain/lake
     materialization, not late local placement mutation.
+
+## Source Authority Classification
+
+- Classification status: row-level source authority is classified for the two
+  terrain deltas. The repair owner is the repo-owned local mock/materialization
+  parity boundary in `@civ7/adapter` and adjacent diagnostic projection code,
+  not Earthlike terrain generation, coast/shelf tuning, feature/resource
+  legality, or accepted Civ residual policy.
+- Shared evidence chain:
+  - The exact-authored live proof is request-bound to
+    `studio-run-in-game-mq20rbzr-1fhc`, seed `138503614`, dimensions `106x66`,
+    turn `1`, and game hash `0`.
+  - Live readback succeeded for `terrain`, `water`, `lake`, `riverType`,
+    `areaId`, `regionId`, and `landmassId` for both rows.
+  - Local morphology shelf/coast intent is absent for both rows:
+    `shelfMask:0`, `coastalWater:0`, `coastalLand:0`, and
+    `distanceToCoast:18`.
+  - Local Hydrology lake intent is absent for both rows:
+    `lakeMask:0` and `plannedLakeMask:0`.
+  - Local placement validation and maintenance do not mutate either row.
+  - The live adapter reads lake state from Civ `GameplayMap.isLake`, while the
+    mock adapter currently treats any `TERRAIN_COAST` as lake evidence and uses
+    a local coast-expansion materialization rule as its validation model.
+- T1 `(73,36)` classification:
+  - Local remains `TERRAIN_OCEAN`, `waterMask:1`, `lakeMask:0`, `areaId:1`
+    before validation, after validation, and after maintenance.
+  - Live exact readback is `TERRAIN_COAST`, `water:true`, `lake:false`,
+    `riverType:-1`, `areaId:720906`, `regionId:-1`, `landmassId:65536`.
+  - This assigns source authority to a local mock/materialization terrain
+    parity gap. It does not authorize map-morphology coast/shelf repair because
+    local authored masks do not request shelf/coast terrain at the row.
+- T2 `(65,39)` classification:
+  - Local remains `TERRAIN_COAST`, `waterMask:1`, `lakeMask:1`, `areaId:1`
+    before validation, after validation, and after maintenance despite
+    `plannedLakeMask:0`.
+  - Live exact readback is `TERRAIN_OCEAN`, `water:true`, `lake:false`,
+    `riverType:-1`, `areaId:720906`, `regionId:-1`, `landmassId:65536`.
+  - This assigns source authority to a local mock/materialization lake and
+    terrain parity gap. The lake sub-gap is specifically that mock lake
+    readback is derived from `TERRAIN_COAST`, while live Civ reports the same
+    exact row as non-lake water.
+- Repair boundary:
+  - A later repair layer may target the adapter/mock materialization parity
+    model and its diagnostics after opening a bounded branch/task movement.
+  - This classification does not authorize product tuning, generated output
+    edits, broad coast/shelf changes, parity closure, or product acceptance.
 
 ## Evidence Boundary
 
@@ -140,11 +188,14 @@
 
 ## Next Evidence
 
-- If live water/area readback does not resolve ownership, add a more granular
-  source-authority classification for the mock/local materialization versus
-  live Civ terrain/lake materialization gap.
-- Classify each row before any repair. Current evidence does not authorize
-  coast/shelf tuning or terrain repair.
+- Open a separate bounded repair layer before changing product or adapter code.
+  The first candidate owner surface is adapter/mock materialization parity,
+  including mock lake readback and coast/ocean materialization behavior.
+- Any repair must rerun focused tests and the exact-authored final-surface
+  parity proof before parity, product acceptance, Earthlike quality, or terrain
+  parity closure can be claimed.
+- Continue to keep feature/resource legality, start placement, mountain quality,
+  and generated output outside this terrain-edge layer.
 
 ## Verification
 
@@ -167,3 +218,10 @@
   passed.
 - `bun run openspec:validate`: passed.
 - `git diff --check`: passed.
+- Records-only source-authority classification verification:
+  - `bun run openspec -- validate earthlike-terrain-edge-diagnostics --strict`:
+    passed.
+  - `bun run openspec -- validate civ7-map-policy-final-surface-parity --strict`:
+    passed.
+  - `bun run openspec:validate`: passed.
+  - `git diff --check`: passed.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
@@ -31,27 +31,28 @@
 
 ## Boundary
 
-This ledger records terrain row context. It does not assign source authority,
-authorize repair, prove parity, or prove product acceptance.
+This ledger records terrain row context and row-level source-authority
+classification. It does not authorize repair by itself, prove parity, or prove
+product acceptance.
 
 ## Rows
 
 | Row | Coordinate |   Plot | Local           | Live            | Class                    | Neighborhood                                   | Status     |
 | --- | ---------- | -----: | --------------- | --------------- | ------------------------ | ---------------------------------------------- | ---------- |
-| T1  | `(73,36)`  | `3889` | `TERRAIN_OCEAN` | `TERRAIN_COAST` | `local-ocean-live-coast` | local/live both `coast:4`, `ocean:2`, `land:0` | unresolved |
-| T2  | `(65,39)`  | `4199` | `TERRAIN_COAST` | `TERRAIN_OCEAN` | `local-coast-live-ocean` | local/live both `coast:2`, `ocean:3`, `land:1` | unresolved |
+| T1  | `(73,36)`  | `3889` | `TERRAIN_OCEAN` | `TERRAIN_COAST` | `local-ocean-live-coast` | local/live both `coast:4`, `ocean:2`, `land:0` | classified: local mock/materialization terrain parity |
+| T2  | `(65,39)`  | `4199` | `TERRAIN_COAST` | `TERRAIN_OCEAN` | `local-coast-live-ocean` | local/live both `coast:2`, `ocean:3`, `land:1` | classified: local mock/materialization lake+terrain parity |
 
 ## Local Projection Context
 
 | Row          | Morphology shelf/coast                                                 | Hydrology lake intent             | Map-hydrology projection                                               | Placement snapshot                    | Current disposition                                                                                                                                                            |
 | ------------ | ---------------------------------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| T1 `(73,36)` | `shelfMask:0`, `coastalWater:0`, `coastalLand:0`, `distanceToCoast:18` | `lakeMask:0`, `plannedLakeMask:0` | `engineWaterMask:1`, `engineLakeMask:0`, `engineTerrain:TERRAIN_OCEAN` | `landMask:0`, `terrain:TERRAIN_OCEAN` | Local pipeline consistently keeps ocean; live coast needs live water/area readback before owner classification.                                                                |
-| T2 `(65,39)` | `shelfMask:0`, `coastalWater:0`, `coastalLand:0`, `distanceToCoast:18` | `lakeMask:0`, `plannedLakeMask:0` | `engineWaterMask:1`, `engineLakeMask:1`, `engineTerrain:TERRAIN_COAST` | `landMask:0`, `terrain:TERRAIN_COAST` | Local pipeline consistently keeps coast/lake-classified water despite no planned lake mask at this row; live ocean needs live water/area readback before owner classification. |
+| T1 `(73,36)` | `shelfMask:0`, `coastalWater:0`, `coastalLand:0`, `distanceToCoast:18` | `lakeMask:0`, `plannedLakeMask:0` | `engineWaterMask:1`, `engineLakeMask:0`, `engineTerrain:TERRAIN_OCEAN` | `landMask:0`, `terrain:TERRAIN_OCEAN` | Local pipeline consistently keeps ocean and non-lake water; live coast assigns the row to local mock/materialization terrain parity rather than authored shelf/coast intent. |
+| T2 `(65,39)` | `shelfMask:0`, `coastalWater:0`, `coastalLand:0`, `distanceToCoast:18` | `lakeMask:0`, `plannedLakeMask:0` | `engineWaterMask:1`, `engineLakeMask:1`, `engineTerrain:TERRAIN_COAST` | `landMask:0`, `terrain:TERRAIN_COAST` | Local pipeline keeps coast/lake-classified water despite no planned lake mask; live ocean/non-lake assigns the row to local mock/materialization lake+terrain parity. |
 
 The local evidence narrows both rows away from simple morphology shelf/coast
-intent and planned Hydrology lake intent. It does not yet prove whether the
-remaining owner is local projection/materialization, Civ live validation, or a
-readback/evidence gap.
+intent and planned Hydrology lake intent. Combined with exact live readback and
+validation-boundary evidence, the remaining owner is classified as repo-owned
+local mock/materialization parity rather than map-generation tuning.
 
 ## Live Readback Context
 
@@ -62,8 +63,8 @@ identity and current runtime identity. It requires successful row facts for
 
 | Row          | Live terrain/hydrology                                      | Live area/region                                   | Local/live contrast                                                                                                                | Current disposition                                                                                                                     |
 | ------------ | ----------------------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| T1 `(73,36)` | `TERRAIN_COAST`, `water:true`, `lake:false`, `riverType:-1` | `areaId:720906`, `regionId:-1`, `landmassId:65536` | local projection `TERRAIN_OCEAN`, `engineLakeMask:0`, `engineAreaId:1`; live is same water body identity class but coast terrain   | Source authority still unresolved; needs projection/validation boundary evidence before repair.                                         |
-| T2 `(65,39)` | `TERRAIN_OCEAN`, `water:true`, `lake:false`, `riverType:-1` | `areaId:720906`, `regionId:-1`, `landmassId:65536` | local projection `TERRAIN_COAST`, `engineLakeMask:1`, `engineAreaId:1`; live reports non-lake ocean in the same live area/landmass | Strongest signal for a projection/materialization vs Civ validation gap, but still no repair authority without boundary classification. |
+| T1 `(73,36)` | `TERRAIN_COAST`, `water:true`, `lake:false`, `riverType:-1` | `areaId:720906`, `regionId:-1`, `landmassId:65536` | local projection `TERRAIN_OCEAN`, `engineLakeMask:0`, `engineAreaId:1`; live is same water body identity class but coast terrain   | Classified as local mock/materialization terrain parity; repair must not tune authored coast/shelf masks. |
+| T2 `(65,39)` | `TERRAIN_OCEAN`, `water:true`, `lake:false`, `riverType:-1` | `areaId:720906`, `regionId:-1`, `landmassId:65536` | local projection `TERRAIN_COAST`, `engineLakeMask:1`, `engineAreaId:1`; live reports non-lake ocean in the same live area/landmass | Classified as local mock/materialization lake+terrain parity; mock lake evidence is over-broad because generic coast reads as lake. |
 
 ## Local Validation Boundary
 
@@ -73,21 +74,30 @@ evidence only.
 
 | Row          | Before validate                                                  | After validate                                                   | After maintenance                                                | Disposition                                                                                                                                                         |
 | ------------ | ---------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| T1 `(73,36)` | `TERRAIN_OCEAN`, `waterMask:1`, `lakeMask:0`, `areaId:1`         | `TERRAIN_OCEAN`, `waterMask:1`, `lakeMask:0`, `areaId:1`         | `TERRAIN_OCEAN`, `waterMask:1`, `lakeMask:0`, `areaId:1`         | Local placement validation/maintenance does not move this row.                                                                                                      |
-| T2 `(65,39)` | `TERRAIN_COAST`, `waterMask:1`, `lakeMask:1`, `areaId:1`         | `TERRAIN_COAST`, `waterMask:1`, `lakeMask:1`, `areaId:1`         | `TERRAIN_COAST`, `waterMask:1`, `lakeMask:1`, `areaId:1`         | Local placement validation/maintenance does not move this row. The live mismatch is now localized to local mock/materialization versus live Civ terrain/lake facts. |
+| T1 `(73,36)` | `TERRAIN_OCEAN`, `waterMask:1`, `lakeMask:0`, `areaId:1`         | `TERRAIN_OCEAN`, `waterMask:1`, `lakeMask:0`, `areaId:1`         | `TERRAIN_OCEAN`, `waterMask:1`, `lakeMask:0`, `areaId:1`         | Local placement validation/maintenance does not move this row; the remaining mismatch is local mock/materialization versus live Civ terrain materialization. |
+| T2 `(65,39)` | `TERRAIN_COAST`, `waterMask:1`, `lakeMask:1`, `areaId:1`         | `TERRAIN_COAST`, `waterMask:1`, `lakeMask:1`, `areaId:1`         | `TERRAIN_COAST`, `waterMask:1`, `lakeMask:1`, `areaId:1`         | Local placement validation/maintenance does not move this row; the remaining mismatch is local mock/materialization versus live Civ terrain/lake facts. |
 
-## Owner Candidates
+## Owner Classification
 
-| Candidate                               | Current disposition                                                                                                                                       |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `map-morphology-coast-shelf-projection` | less likely as direct row intent; local shelf/coast masks are `0` with distance-to-coast `18`                                                             |
-| `map-hydrology-water-mutation`          | still possible through local engine lake/terrain projection, especially T2 where local `engineLakeMask:1` contrasts with live `lake:false`                |
-| `local-mock-vs-live-civ-materialization` | strongest current class; local rows remain stable through placement validation while live Civ reports different terrain/lake facts                         |
-| `civ-engine-terrain-validation`         | still possible as the live-side materialization owner, but not yet enough to label it accepted engine policy or repair local policy                       |
-| `evidence-insufficient`                 | current status until mock/local versus live Civ materialization owner is classified                                                                        |
+| Row          | Classified owner                              | Evidence                                                                                                                                        | Repair authority                                                                                                                       |
+| ------------ | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| T1 `(73,36)` | `local-mock-vs-live-civ-terrain-materialization` | Local row is ocean/non-lake through projection and validation; live exact readback is coast/non-lake in the same water body class.               | Bounded adapter/mock materialization parity only. No map-morphology coast/shelf or product tuning authority.                           |
+| T2 `(65,39)` | `local-mock-vs-live-civ-lake-terrain-materialization` | Local row is coast/lake-classified with `plannedLakeMask:0`; live exact readback is ocean/non-lake; mock `isLake` uses coast terrain as lake evidence. | Bounded adapter/mock lake readback and terrain materialization parity only. No broad Hydrology, coast/shelf, or Earthlike tuning authority. |
+
+Rejected owner classes for this row pair:
+
+- `map-morphology-coast-shelf-projection`: local morphology masks do not mark
+  either row as shelf/coast intent.
+- `map-hydrology-water-mutation`: Hydrology lake intent and planned lake masks
+  are `0` for both rows; the T2 lake signal appears in mock readback, not in
+  authored lake intent.
+- `accepted-civ-engine-residual`: not classified as accepted residual because
+  the exact live run gives concrete non-lake water facts and the local proof
+  path is expected to model the deployed materialization boundary before parity
+  closure.
 
 ## Next Classification Evidence
 
-- Explicit owner disposition for the mock/local materialization versus live Civ
-  terrain/lake materialization gap.
-- No coast/shelf policy repair until that owner is classified.
+- Open a separate repair lane before changing adapter/mock materialization code.
+- Rerun exact-authored final-surface parity after any repair and keep parity
+  open until terrain rows match or residuals are explicitly owner-classified.


### PR DESCRIPTION
Row-level source authority classification is now complete for the two terrain delta rows (`(73,36)` and `(65,39)`). Both rows are classified to the repo-owned local mock/materialization parity boundary rather than to MapGen coast/shelf tuning, Hydrology lake intent, or accepted Civ engine residual policy.

**T1 `(73,36)`** is classified as `local-mock-vs-live-civ-terrain-materialization`: the local pipeline holds ocean/non-lake through projection and validation, while the live exact readback reports coast/non-lake in the same water body class. No authored shelf or coast mask justifies the local value.

**T2 `(65,39)`** is classified as `local-mock-vs-live-civ-lake-terrain-materialization`: the local pipeline holds coast with `engineLakeMask:1` despite `plannedLakeMask:0`, while the live exact readback reports ocean/non-lake. The lake sub-gap is specifically that the mock adapter derives lake state from `TERRAIN_COAST` presence, while Civ reports the same row as non-lake water.

Rejected owner classes for both rows: `map-morphology-coast-shelf-projection` (shelf/coast masks are `0`, distance-to-coast is `18`), `map-hydrology-water-mutation` (planned lake masks are `0`), and `evidence-insufficient`.

A new repair task (`3.3`) is added requiring that any adapter/mock materialization repair be opened as a separate bounded layer before changing code. The branch is updated to `codex/swooper-terrain-source-owner-drain` to reflect the completed classification phase. No repair is authorized or started in this layer.