### PR TITLE
fix(civ7-adapter): repair mock lake readback so ordinary coast terrain is not lake-classified

### DIFF
--- a/openspec/changes/earthlike-terrain-edge-diagnostics/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/specs/mapgen-normalization-workstreams/spec.md
@@ -44,3 +44,13 @@ of each coast/ocean mismatch.
 - **THEN** it cites the classified row owner
 - **AND** it does not use feature/resource legality evidence as terrain repair
   authority unless shared materialization ownership is proven
+
+#### Scenario: Mock lake readback is repaired
+
+- **WHEN** adapter/mock materialization repair changes local lake readback
+- **THEN** ordinary coast terrain remains water but does not automatically read
+  as lake-classified water
+- **AND** planned lake stamping is the path that marks mock lake state
+- **AND** parity status remains open until a current exact-authored parity
+  rerun records whether terrain, feature, or resource mismatches remain
+  unresolved

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
@@ -18,13 +18,20 @@
 
 - [ ] 3.1 Repair only rows assigned to a repo-owned source authority.
 - [ ] 3.2 Preserve hydrology water mutation and Civ validation boundaries.
-- [ ] 3.3 Open any adapter/mock materialization repair as a separate bounded
+- [x] 3.3 Open any adapter/mock materialization repair as a separate bounded
       layer before changing code.
+- [x] 3.4 Repair mock lake readback so ordinary coast terrain is not lake.
+- [ ] 3.5 Classify or repair the remaining mock terrain coast/ocean
+      materialization mismatch.
 
 ## 4. Verification
 
 - [x] 4.1 Run focused terrain diagnostic tests.
 - [ ] 4.2 Re-run exact-authored final-surface parity after any repair.
+      Current drain attempt is blocked by stale exact proof config key
+      `/config/ecology-features/floodplainPlanning`; source-recorded
+      post-repair artifact remains evidence, not fresh proof.
 - [x] 4.3 Run `bun run --cwd mods/mod-swooper-maps check`.
 - [x] 4.4 Run `bun run openspec -- validate earthlike-terrain-edge-diagnostics --strict`.
 - [x] 4.5 Run `bun run openspec:validate`.
+- [x] 4.6 Run focused adapter mock terrain tests and adapter check/build.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
@@ -5,12 +5,13 @@
 - Project: Swooper recovery
 - Phase: terrain-edge diagnostics
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-terrain-source-owner-drain`
+- Branch/Graphite stack: `codex/swooper-mock-lake-readback-drain`
 - Started: 2026-06-06
 - Status: active. Terrain edge, local projection/mask context,
   exact-runtime-bound live terrain/hydrology/area readback, local placement
-  validation-boundary readback, and row-level source-authority classification
-  exist for the two coast/ocean rows. Repair is not started in this layer.
+  validation-boundary readback, row-level source-authority classification, and
+  a bounded mock lake readback repair exist for the two coast/ocean rows.
+  Final-surface parity remains unresolved.
 
 ## Objective
 
@@ -34,7 +35,7 @@
 
 - Worktree:
   `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain`.
-- Branch: `codex/swooper-terrain-source-owner-drain`.
+- Branch: `codex/swooper-mock-lake-readback-drain`.
 - Source proof:
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc.json`.
 - Source proof hash:
@@ -69,6 +70,16 @@
   `033609d9293faf4b86a1da5862247a4c41762e7917069be3f2af7c8e7f55f263`.
 - Local validation-boundary proof hash:
   `e906acdcacb002572586379b98cd00d0eb99529c9b86e2384fc6b8e03703da4e`.
+- Source-recorded post-mock-materialization-repair final-surface parity artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-materialization-repair.json`.
+- Source-recorded post-repair parity artifact sha256:
+  `b91ad36796d627a2d9b7381e3a20dcd5b0b604ba623d81e38235cb1061e950f3`.
+- Source-recorded post-repair parity proof hash:
+  `194dc8d2a22469dfc3612d6038cf1dae26574f35a56b3f6ab67062b55b18a289`.
+- Source-recorded post-repair terrain-edge context artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-materialization-repair-terrain-edge-context.json`.
+- Source-recorded post-repair terrain-edge context artifact sha256:
+  `cc28a662c6270feb053a227fd221c15cd00504e3cf54c67ab1bc21e4611e6aa6`.
 
 ## Findings
 
@@ -177,10 +188,46 @@
   - This classification does not authorize product tuning, generated output
     edits, broad coast/shelf changes, parity closure, or product acceptance.
 
+## Mock Lake Readback Repair
+
+- Repair implemented in `packages/civ7-adapter/src/mock-adapter.ts`:
+  - Added explicit mock lake state separate from terrain type.
+  - `MockAdapter.isLake()` now reads that state instead of treating every
+    `TERRAIN_COAST` tile as lake-classified water.
+  - `stampLakes()` is the path that marks planned lake tiles as mock lakes.
+  - Ordinary coast expansion still produces water terrain, but not lake
+    readback.
+- Focused test coverage in
+  `packages/civ7-adapter/test/mock-terrain-policy.test.ts` proves ordinary
+  expanded coast is water/non-lake and stamped lake terrain is water/lake.
+- Source-recorded post-repair parity artifact:
+  - Input exact proof wrapper:
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json`.
+  - Source command:
+    `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-materialization-repair.json`.
+  - Source result: exited `2` with `parityStatus:"unresolved"`, proof hash
+    `194dc8d2a22469dfc3612d6038cf1dae26574f35a56b3f6ab67062b55b18a289`.
+  - Runtime identity remained exact-bound and stable: seed `138503614`,
+    dimensions `106x66`, turn `1`, game hash `0`, omitted live plots `0`.
+  - Terrain remains `2/6996` mismatched at `(73,36)` and `(65,39)`.
+  - T2 post-repair terrain context now has local `engineLakeMask:0` and
+    validation `lakeMask:0`; the lake-readback sub-gap is repaired.
+  - T2 still has local `TERRAIN_COAST` versus live `TERRAIN_OCEAN`; the
+    remaining owner is terrain materialization parity, not lake readback.
+  - Feature remains `5/6996` mismatched and resource remains `61/6996`
+    mismatched; those stay in their own feature/resource legality lanes.
+  - Unresolved links remain
+    `resource-placement-coordinate-proof.log`, `surface.feature.mismatch`,
+    `surface.resource.mismatch`, and `surface.terrain.mismatch`.
+  - Current drain rerun attempt did not reach parity evaluation because the old
+    exact proof wrapper contains stale config key
+    `/config/ecology-features/floodplainPlanning`.
+
 ## Evidence Boundary
 
 - This layer proves only row-level terrain context and local projection/mask
-  context for the exact-authored proof.
+  context plus the focused mock lake readback repair for the exact-authored
+  proof.
 - It does not prove the repo should change coast/shelf policy.
 - It does not prove Civ engine terrain validation is accepted policy.
 - It does not close final-surface parity, product acceptance, Earthlike quality,
@@ -188,12 +235,12 @@
 
 ## Next Evidence
 
-- Open a separate bounded repair layer before changing product or adapter code.
-  The first candidate owner surface is adapter/mock materialization parity,
-  including mock lake readback and coast/ocean materialization behavior.
-- Any repair must rerun focused tests and the exact-authored final-surface
-  parity proof before parity, product acceptance, Earthlike quality, or terrain
-  parity closure can be claimed.
+- Continue terrain work in a separate terrain materialization slice. The lake
+  readback sub-gap is repaired, but coast/ocean materialization still differs
+  from the live exact run at both terrain rows.
+- Any further repair must rerun focused tests and the exact-authored
+  final-surface parity proof before parity, product acceptance, Earthlike
+  quality, or terrain parity closure can be claimed.
 - Continue to keep feature/resource legality, start placement, mountain quality,
   and generated output outside this terrain-edge layer.
 
@@ -219,6 +266,22 @@
 - `bun run openspec:validate`: passed.
 - `git diff --check`: passed.
 - Records-only source-authority classification verification:
+  - `bun run openspec -- validate earthlike-terrain-edge-diagnostics --strict`:
+    passed.
+  - `bun run openspec -- validate civ7-map-policy-final-surface-parity --strict`:
+    passed.
+  - `bun run openspec:validate`: passed.
+  - `git diff --check`: passed.
+- Mock materialization repair verification:
+  - `bun test packages/civ7-adapter/test/mock-terrain-policy.test.ts`: passed.
+  - `bun run --cwd packages/civ7-adapter check`: passed.
+  - `bun run --cwd packages/civ7-adapter build`: passed.
+  - `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-materialization-repair.json`:
+    failed before parity evaluation with stale proof config key
+    `/config/ecology-features/floodplainPlanning`.
+  - `bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts`:
+    passed.
+  - `bun run --cwd mods/mod-swooper-maps check`: passed.
   - `bun run openspec -- validate earthlike-terrain-edge-diagnostics --strict`:
     passed.
   - `bun run openspec -- validate civ7-map-policy-final-surface-parity --strict`:

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
@@ -26,21 +26,31 @@
   `033609d9293faf4b86a1da5862247a4c41762e7917069be3f2af7c8e7f55f263`.
 - Local validation-boundary proof hash:
   `e906acdcacb002572586379b98cd00d0eb99529c9b86e2384fc6b8e03703da4e`.
+- Source-recorded post-mock-materialization-repair final-surface parity artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-materialization-repair.json`.
+- Source-recorded post-repair parity artifact sha256:
+  `b91ad36796d627a2d9b7381e3a20dcd5b0b604ba623d81e38235cb1061e950f3`.
+- Source-recorded post-repair parity proof hash:
+  `194dc8d2a22469dfc3612d6038cf1dae26574f35a56b3f6ab67062b55b18a289`.
+- Source-recorded post-repair terrain-edge context artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-materialization-repair-terrain-edge-context.json`.
+- Source-recorded post-repair terrain-edge context artifact sha256:
+  `cc28a662c6270feb053a227fd221c15cd00504e3cf54c67ab1bc21e4611e6aa6`.
 - Request: `studio-run-in-game-mq20rbzr-1fhc`.
 - Seed/dimensions: `138503614`, `106x66`, `6996` plots.
 
 ## Boundary
 
-This ledger records terrain row context and row-level source-authority
-classification. It does not authorize repair by itself, prove parity, or prove
-product acceptance.
+This ledger records terrain row context, row-level source-authority
+classification, and the bounded mock lake readback repair. It does not prove
+terrain parity, final-surface parity, or product acceptance.
 
 ## Rows
 
 | Row | Coordinate |   Plot | Local           | Live            | Class                    | Neighborhood                                   | Status     |
 | --- | ---------- | -----: | --------------- | --------------- | ------------------------ | ---------------------------------------------- | ---------- |
 | T1  | `(73,36)`  | `3889` | `TERRAIN_OCEAN` | `TERRAIN_COAST` | `local-ocean-live-coast` | local/live both `coast:4`, `ocean:2`, `land:0` | classified: local mock/materialization terrain parity |
-| T2  | `(65,39)`  | `4199` | `TERRAIN_COAST` | `TERRAIN_OCEAN` | `local-coast-live-ocean` | local/live both `coast:2`, `ocean:3`, `land:1` | classified: local mock/materialization lake+terrain parity |
+| T2  | `(65,39)`  | `4199` | `TERRAIN_COAST` | `TERRAIN_OCEAN` | `local-coast-live-ocean` | local/live both `coast:2`, `ocean:3`, `land:1` | lake sub-gap repaired; terrain materialization remains |
 
 ## Local Projection Context
 
@@ -82,7 +92,7 @@ evidence only.
 | Row          | Classified owner                              | Evidence                                                                                                                                        | Repair authority                                                                                                                       |
 | ------------ | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | T1 `(73,36)` | `local-mock-vs-live-civ-terrain-materialization` | Local row is ocean/non-lake through projection and validation; live exact readback is coast/non-lake in the same water body class.               | Bounded adapter/mock materialization parity only. No map-morphology coast/shelf or product tuning authority.                           |
-| T2 `(65,39)` | `local-mock-vs-live-civ-lake-terrain-materialization` | Local row is coast/lake-classified with `plannedLakeMask:0`; live exact readback is ocean/non-lake; mock `isLake` uses coast terrain as lake evidence. | Bounded adapter/mock lake readback and terrain materialization parity only. No broad Hydrology, coast/shelf, or Earthlike tuning authority. |
+| T2 `(65,39)` | `local-mock-vs-live-civ-lake-terrain-materialization` | Pre-repair local row was coast/lake-classified with `plannedLakeMask:0`; live exact readback was ocean/non-lake; mock `isLake` used coast terrain as lake evidence. | Mock lake readback repaired; remaining repair authority is bounded adapter/mock terrain materialization parity only. |
 
 Rejected owner classes for this row pair:
 
@@ -98,6 +108,24 @@ Rejected owner classes for this row pair:
 
 ## Next Classification Evidence
 
-- Open a separate repair lane before changing adapter/mock materialization code.
+- Mock lake readback has been repaired and verified locally.
+- Continue with the remaining terrain materialization parity gap. The source
+  post-repair artifact still shows T1 local ocean/live coast and T2 local
+  coast/live ocean, but the current drain exact rerun is blocked by stale proof
+  config and must be refreshed before any parity claim.
 - Rerun exact-authored final-surface parity after any repair and keep parity
   open until terrain rows match or residuals are explicitly owner-classified.
+
+## Source-Recorded Post-Repair Evidence
+
+| Row          | Post-repair local | Live            | Post-repair lake evidence               | Disposition                                                                 |
+| ------------ | ----------------- | --------------- | --------------------------------------- | --------------------------------------------------------------------------- |
+| T1 `(73,36)` | `TERRAIN_OCEAN`   | `TERRAIN_COAST` | `engineLakeMask:0`, validation `lake:0` | Unchanged terrain materialization mismatch; lake readback is not implicated. |
+| T2 `(65,39)` | `TERRAIN_COAST`   | `TERRAIN_OCEAN` | `engineLakeMask:0`, validation `lake:0` | Mock lake over-read repaired; terrain materialization mismatch remains.      |
+
+The source-recorded post-repair proof remains `parityStatus:"unresolved"` with
+terrain `2/6996`, feature `5/6996`, and resource `61/6996` mismatches. In the
+current drain, `bun run verify:final-surface-parity -- --proof-file ...` is
+blocked by stale exact proof config key
+`/config/ecology-features/floodplainPlanning`, so this layer does not claim
+fresh final-surface parity proof or product acceptance.

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -347,6 +347,7 @@ export class MockAdapter implements EngineAdapter {
   private resources: Int16Array;
   private biomes: Uint8Array;
   private waterMask: Uint8Array;
+  private lakeMask: Uint8Array;
   private mountainMask: Uint8Array;
   private landmassRegionIds: Uint8Array;
   private riverMask: Uint8Array;
@@ -441,6 +442,7 @@ export class MockAdapter implements EngineAdapter {
     this.resources = new Int16Array(size).fill(this.noResourceSentinel);
     this.biomes = new Uint8Array(size).fill(config.defaultBiomeType ?? 0);
     this.waterMask = new Uint8Array(size);
+    this.lakeMask = new Uint8Array(size);
     this.mountainMask = new Uint8Array(size);
     this.riverMask = new Uint8Array(size);
     this.landmassRegionIds = new Uint8Array(size);
@@ -570,8 +572,7 @@ export class MockAdapter implements EngineAdapter {
   }
 
   isLake(x: number, y: number): boolean {
-    // The mock has no engine area classifier, so coast terrain is its lake-classification evidence.
-    return this.terrainTypes[this.idx(x, y)] === this.coastTerrainId;
+    return this.lakeMask[this.idx(x, y)] === 1;
   }
 
   getAreaId(x: number, y: number): number {
@@ -633,6 +634,9 @@ export class MockAdapter implements EngineAdapter {
     this.riverMask[index] =
       terrainType === this.getTerrainTypeIndex("TERRAIN_NAVIGABLE_RIVER") ? 1 : 0;
     this.mountainMask[index] = terrainType === this.mountainTerrainId ? 1 : 0;
+    if (terrainType !== this.coastTerrainId) {
+      this.lakeMask[index] = 0;
+    }
   }
 
   setRainfall(x: number, y: number, value: number): void {
@@ -958,7 +962,15 @@ export class MockAdapter implements EngineAdapter {
   }
 
   storeWaterData(): void {
-    // No-op in mock
+    const size = this.width * this.height;
+    for (let i = 0; i < size; i++) {
+      const terrain = this.terrainTypes[i] ?? 0;
+      this.waterMask[i] =
+        terrain === this.coastTerrainId || terrain === this.oceanTerrainId ? 1 : 0;
+      if (terrain !== this.coastTerrainId) {
+        this.lakeMask[i] = 0;
+      }
+    }
   }
 
   generateLakes(width: number, height: number, tilesPerLake: number): void {
@@ -981,6 +993,7 @@ export class MockAdapter implements EngineAdapter {
     }
 
     let plannedLakeTileCount = 0;
+    this.lakeMask.fill(0);
 
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
@@ -988,6 +1001,7 @@ export class MockAdapter implements EngineAdapter {
         if (lakeMask[idx] !== 1) continue;
         plannedLakeTileCount += 1;
         this.terrainTypes[idx] = this.coastTerrainId & 0xff;
+        this.lakeMask[idx] = 1;
       }
     }
 
@@ -1370,7 +1384,11 @@ export class MockAdapter implements EngineAdapter {
 
   /** Set water mask for testing */
   setWater(x: number, y: number, isWater: boolean): void {
-    this.waterMask[this.idx(x, y)] = isWater ? 1 : 0;
+    const index = this.idx(x, y);
+    this.waterMask[index] = isWater ? 1 : 0;
+    if (!isWater) {
+      this.lakeMask[index] = 0;
+    }
   }
 
   /** Set mountain mask for testing */
@@ -1381,6 +1399,9 @@ export class MockAdapter implements EngineAdapter {
   /** Fill all tiles with water/land */
   fillWater(isWater: boolean): void {
     this.waterMask.fill(isWater ? 1 : 0);
+    if (!isWater) {
+      this.lakeMask.fill(0);
+    }
   }
 
   /** Reset all data to defaults */
@@ -1401,6 +1422,7 @@ export class MockAdapter implements EngineAdapter {
     this.resources.fill(this.NO_RESOURCE);
     this.biomes.fill(config.defaultBiomeType ?? 0);
     this.waterMask.fill(0);
+    this.lakeMask.fill(0);
     this.mountainMask.fill(0);
     this.riverMask.fill(0);
     this.landmassRegionIds.fill(0);

--- a/packages/civ7-adapter/test/mock-terrain-policy.test.ts
+++ b/packages/civ7-adapter/test/mock-terrain-policy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+
+import { createMockAdapter } from "../src/mock-adapter.js";
+
+const TERRAIN_FLAT = 2;
+const TERRAIN_COAST = 3;
+const TERRAIN_OCEAN = 4;
+
+describe("mock adapter terrain policy", () => {
+  it("tracks stamped lakes separately from ordinary coast terrain", () => {
+    const adapter = createMockAdapter({ width: 5, height: 3, defaultTerrainType: TERRAIN_OCEAN });
+
+    adapter.setTerrainType(0, 1, TERRAIN_FLAT);
+    adapter.storeWaterData();
+    adapter.expandCoasts(5, 3);
+
+    expect(adapter.getTerrainType(1, 1)).toBe(TERRAIN_COAST);
+    expect(adapter.isWater(1, 1)).toBe(true);
+    expect(adapter.isLake(1, 1)).toBe(false);
+
+    const lakeMask = new Uint8Array(15);
+    lakeMask[2 + 1 * 5] = 1;
+
+    const projection = adapter.stampLakes(5, 3, lakeMask);
+
+    expect(adapter.getTerrainType(2, 1)).toBe(TERRAIN_COAST);
+    expect(adapter.isWater(2, 1)).toBe(true);
+    expect(adapter.isLake(2, 1)).toBe(true);
+    expect(adapter.isLake(1, 1)).toBe(false);
+    expect(projection.engineLakeMask[2 + 1 * 5]).toBe(1);
+    expect(projection.engineLakeMask[1 + 1 * 5]).toBe(0);
+    expect(projection.nonLakeTileCount).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR repairs the mock adapter's lake readback logic and records the resulting post-repair parity evidence.

Previously, `MockAdapter.isLake()` treated every `TERRAIN_COAST` tile as lake-classified water because the mock had no engine area classifier. This caused ordinary coast expansion to incorrectly read back as lake terrain. The fix introduces a dedicated `lakeMask` array in `MockAdapter`. `isLake()` now reads from that mask instead of inferring lake state from terrain type. `stampLakes()` is the sole path that marks tiles as mock lakes, and setting terrain to a non-coast type or calling `setWater(false)` / `fillWater(false)` clears the lake mask for the affected tiles. `storeWaterData()` is also updated to enforce the same invariant across the full grid.

A focused test in `packages/civ7-adapter/test/mock-terrain-policy.test.ts` verifies that an ordinarily expanded coast tile is water but not lake, while a tile explicitly stamped via `stampLakes()` is both water and lake, and that the `engineLakeMask` projection reflects this distinction correctly.

Post-repair parity evidence shows the lake sub-gap at T2 `(65,39)` is resolved — `engineLakeMask` and validation `lakeMask` both read `0` — but the coast/ocean terrain materialization mismatch at both T1 `(73,36)` and T2 remains. Final-surface parity stays `unresolved` with terrain `2/6996`, feature `5/6996`, and resource `61/6996` mismatches. A fresh exact-authored parity rerun is currently blocked by a stale config key (`/config/ecology-features/floodplainPlanning`) in the proof wrapper, so the source-recorded post-repair artifact is evidence only, not a closed parity proof. The remaining terrain materialization gap is tracked as the next open work item.