### PR TITLE
docs(earthlike-terrain-edge-diagnostics): record bounded mock terrain materialization repair, post-repair parity rerun, and residual T1 classification

### DIFF
--- a/openspec/changes/earthlike-terrain-edge-diagnostics/proposal.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/proposal.md
@@ -1,9 +1,9 @@
 ## Why
 
 Exact-authored final-surface parity for request
-`studio-run-in-game-mq20rbzr-1fhc` still has `2/6996` terrain mismatches. Both
-are coast/ocean edge swaps. They block parity, but they do not belong in the
-feature/resource legality repair lane unless later evidence proves shared
+`studio-run-in-game-mq20rbzr-1fhc` initially had `2/6996` terrain mismatches.
+Both were coast/ocean edge swaps. They block parity, but they do not belong in
+the feature/resource legality repair lane unless later evidence proves shared
 materialization ownership.
 
 ## Activation Gate
@@ -36,11 +36,15 @@ The source proof hash is
 - Keep source authority unresolved until shelf/lake/projection-boundary and
   live water/area evidence can distinguish repo projection, hydrology mutation,
   Civ terrain validation, and evidence insufficiency.
+- After row-level source authority is classified, repair only the bounded
+  `@civ7/adapter` mock lake/terrain materialization gaps and rerun exact-bound
+  final-surface parity. Do not treat a partial terrain repair as parity or
+  product closure.
 
 ## Non-Goals
 
 - No coast/shelf tuning.
-- No terrain generation repair.
+- No Earthlike/coast/shelf terrain generation repair.
 - No feature/resource repair.
 - No parity, product acceptance, Earthlike quality, or mountain-quality closure
   claim.
@@ -49,6 +53,7 @@ The source proof hash is
 ## Affected Owners
 
 - `mods/mod-swooper-maps/src/dev/diagnostics/**`
+- `packages/civ7-adapter/**`
 - `packages/civ7-direct-control/**`
 - `scripts/civ7-direct-control/verify-terrain-edge-live-context.ts`
 - `openspec/changes/earthlike-terrain-edge-diagnostics/**`
@@ -77,6 +82,10 @@ The source proof hash is
 - Local placement validation-boundary artifact for
   `studio-run-in-game-mq20rbzr-1fhc`.
 - Fact-completeness regression for terrain-edge live readback.
+- Focused `@civ7/adapter` mock terrain tests/check/build after any bounded
+  adapter materialization repair.
+- Exact-authored final-surface parity rerun after any bounded terrain repair,
+  with unresolved residuals left open.
 - `bun run --cwd mods/mod-swooper-maps check`.
 - `bun run --cwd packages/civ7-direct-control check`.
 - `bun run openspec -- validate earthlike-terrain-edge-diagnostics --strict`.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
@@ -24,8 +24,10 @@
 - [x] 3.4 Repair mock lake readback so ordinary coast terrain is not lake.
 - [x] 3.5 Classify the remaining mock terrain coast/ocean materialization
       boundary before repair.
-- [ ] 3.6 Repair the remaining mock terrain coast/ocean materialization
-      mismatch in a bounded repair layer.
+- [x] 3.6 Repair the source-authorized land-contact mock terrain
+      materialization subset in a bounded repair layer.
+- [ ] 3.7 Classify or repair the residual enclosed-water
+      local-ocean/live-coast terrain row.
 
 ## 4. Verification
 
@@ -38,3 +40,5 @@
 - [x] 4.4 Run `bun run openspec -- validate earthlike-terrain-edge-diagnostics --strict`.
 - [x] 4.5 Run `bun run openspec:validate`.
 - [x] 4.6 Run focused adapter mock terrain tests and adapter check/build.
+- [x] 4.7 Re-run exact-authored final-surface parity and terrain-edge context
+      after the mock terrain materialization repair.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
@@ -5,14 +5,15 @@
 - Project: Swooper recovery
 - Phase: terrain-edge diagnostics
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-coast-materialization-edge-drain`
+- Branch/Graphite stack: `codex/swooper-mock-terrain-materialization-drain`
+  stacked above `codex/swooper-coast-materialization-edge-drain`
 - Started: 2026-06-06
 - Status: active. Terrain edge, local projection/mask context,
   exact-runtime-bound live terrain/hydrology/area readback, local placement
-  validation-boundary readback, row-level source-authority classification, and
-  a bounded mock lake readback repair, and post-repair coast materialization
-  boundary context exist for the two coast/ocean rows. Final-surface parity
-  remains unresolved.
+  validation-boundary readback, row-level source-authority classification, a
+  bounded mock lake readback repair, post-repair coast materialization boundary
+  context, and a bounded mock terrain materialization repair exist for the
+  coast/ocean rows. Final-surface parity remains unresolved.
 
 ## Objective
 
@@ -36,7 +37,7 @@
 
 - Worktree:
   `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain`.
-- Branch: `codex/swooper-coast-materialization-edge-drain`.
+- Branch: `codex/swooper-mock-terrain-materialization-drain`.
 - Source proof:
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc.json`.
 - Source proof hash:
@@ -93,6 +94,18 @@
   `59378d7c5d90593958e14ecf66f966107499499ef0eb4f616978226e3e3b0b93`.
 - Source-recorded post-repair coast materialization context proof hash:
   `c58aee8b820ac50355705bb500e48863b389776b219acd86ee1c390d2cd76b5e`.
+- Source-recorded post-mock-terrain-materialization-repair final-surface parity artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-terrain-materialization-repair.json`.
+- Source-recorded post-mock-terrain-materialization-repair parity artifact sha256:
+  `8ff6e5ada94fae46b032082f4c7955d480c9ba3b091d8e42c7632c92171b87c8`.
+- Source-recorded post-mock-terrain-materialization-repair parity proof hash:
+  `209aac19056be1717fa58cdf5c6157241bb7a08f0bd1d16b8178634c13039012`.
+- Source-recorded post-mock-terrain-materialization-repair terrain-edge context artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-terrain-materialization-repair-terrain-edge-context.json`.
+- Source-recorded post-mock-terrain-materialization-repair terrain-edge context artifact sha256:
+  `3452fb5922dd7080429295cd6caf41a33747b4657b849fa7cbd4d3f5cca8a7b9`.
+- Source-recorded post-mock-terrain-materialization-repair terrain-edge context proof hash:
+  `bd35969a6c58d07b4ae473935242932c04c6e7d82d791af8338a818cddc1c043`.
 
 ## Findings
 
@@ -276,14 +289,59 @@
   - Classification: the remaining T2 terrain gap is a local
     `validateAndFixTerrain`/mock terrain materialization parity gap, not a
     Hydrology lake gap and not a MapGen coast policy row.
-- Repair authority from this layer is limited to a future bounded mock/local
-  terrain materialization parity slice. This layer does not start that repair.
+- Repair authority from the downstack classification layer was limited to a
+  future bounded mock/local terrain materialization parity slice; this branch
+  is that bounded repair slice.
+
+## Mock Terrain Materialization Repair
+
+- Branch opened after source-authority classification:
+  `codex/swooper-mock-terrain-materialization-drain`.
+- Repair write set:
+  `packages/civ7-adapter/src/mock-adapter.ts` and
+  `packages/civ7-adapter/test/mock-terrain-policy.test.ts`.
+- `MockAdapter.validateAndFixTerrain()` now materializes ocean as coast only
+  for rows touching both land terrain and an existing non-validation-created
+  coast seed.
+- Validation-created coast is tracked separately and cannot seed later
+  validation passes. This prevents the land-contact repair from cascading back
+  into T2 `(65,39)`.
+- `MockAdapter.expandCoasts()` now follows the official standard helper shape:
+  ocean adjacent to existing coast, within the standard ocean-column band,
+  gated by `"Shallow Water Scatter"`.
+- Source-recorded exact-authored proof rerun:
+  - Command:
+    `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-terrain-materialization-repair.json`.
+  - Result: exited `2` with `parityStatus:"unresolved"`, proof hash
+    `209aac19056be1717fa58cdf5c6157241bb7a08f0bd1d16b8178634c13039012`.
+  - Runtime identity remained exact-bound and stable: seed `138503614`,
+    dimensions `106x66`, turn `1`, game hash `0`, omitted live plots `0`.
+  - Terrain improves from `2/6996` to `1/6996`; only T1 `(73,36)` remains
+    local `TERRAIN_OCEAN` versus live `TERRAIN_COAST`.
+  - T2 `(65,39)` is now local/live `TERRAIN_OCEAN`.
+  - Feature remains `5/6996` mismatched and resource remains `61/6996`
+    mismatched; those remain in their feature/resource legality lanes.
+- Source-recorded post-repair terrain context:
+  - Command:
+    `bun run verify:terrain-edge-live-context -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-terrain-materialization-repair.json --output /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-terrain-materialization-repair-terrain-edge-context.json`.
+  - Result: status `complete`, proof hash
+    `bd35969a6c58d07b4ae473935242932c04c6e7d82d791af8338a818cddc1c043`,
+    one row `(73,36)` with successful `terrain`, `water`, `lake`,
+    `riverType`, `areaId`, `regionId`, and `landmassId` readback.
+- Residual terrain boundary:
+  - T1 `(73,36)` remains unresolved because local source evidence has
+    `shelfMask:0`, `coastalWater:0`, `coastalLand:0`, `lakeMask:0`,
+    `plannedLakeMask:0`, and local/live neighborhoods both `coast:4`,
+    `ocean:2`, `land:0`.
+  - The current evidence does not distinguish T1 from other enclosed-water
+    rows that live Civ keeps ocean, so no further repair authority is claimed
+    in this layer.
 
 ## Evidence Boundary
 
 - This layer proves only row-level terrain context and local projection/mask
-  context plus the focused mock lake readback repair for the exact-authored
-  proof.
+  context plus the focused mock lake readback and mock terrain materialization
+  repairs for the exact-authored proof.
 - It does not prove the repo should change coast/shelf policy.
 - It does not prove Civ engine terrain validation is accepted policy.
 - It does not close final-surface parity, product acceptance, Earthlike quality,
@@ -292,8 +350,9 @@
 ## Next Evidence
 
 - Continue terrain work in a separate terrain materialization slice. The lake
-  readback sub-gap is repaired, and the remaining coast/ocean materialization
-  boundary is classified, but a terrain materialization repair has not started.
+  readback sub-gap is repaired and the land-contact terrain materialization
+  subset is repaired. The remaining T1 enclosed-water row needs additional
+  source-authority evidence before another repair.
 - Any further repair must rerun focused tests and the exact-authored
   final-surface parity proof before parity, product acceptance, Earthlike
   quality, or terrain parity closure can be claimed.
@@ -343,8 +402,9 @@
     passed.
   - `bun run openspec:validate`: passed.
   - `git diff --check`: passed.
-- Mock materialization repair verification:
-  - `bun test packages/civ7-adapter/test/mock-terrain-policy.test.ts`: passed.
+- Mock lake materialization repair verification:
+  - `bun test packages/civ7-adapter/test/mock-terrain-policy.test.ts`: passed,
+    4 tests.
   - `bun run --cwd packages/civ7-adapter check`: passed.
   - `bun run --cwd packages/civ7-adapter build`: passed.
   - `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-materialization-repair.json`:
@@ -358,4 +418,20 @@
   - `bun run openspec -- validate civ7-map-policy-final-surface-parity --strict`:
     passed.
   - `bun run openspec:validate`: passed.
+  - `git diff --check`: passed.
+- Mock terrain materialization repair verification:
+  - `bun test packages/civ7-adapter/test/mock-terrain-policy.test.ts`: passed,
+    7 tests.
+  - `bun run --cwd packages/civ7-adapter check`: passed.
+  - `bun run --cwd packages/civ7-adapter build`: passed.
+  - `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-terrain-materialization-repair.json`:
+    source-recorded result exited `2` with exact-bound unresolved proof hash
+    `209aac19056be1717fa58cdf5c6157241bb7a08f0bd1d16b8178634c13039012`.
+  - Current drain command
+    `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-mock-terrain-materialization-repair.json`
+    exits `1` before parity evaluation with stale exact proof config key
+    `/config/ecology-features/floodplainPlanning`.
+  - `bun run verify:terrain-edge-live-context -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-terrain-materialization-repair.json --output /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-terrain-materialization-repair-terrain-edge-context.json`:
+    source-recorded result passed with proof hash
+    `bd35969a6c58d07b4ae473935242932c04c6e7d82d791af8338a818cddc1c043`.
   - `git diff --check`: passed.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/terrain-edge-ledger.md
@@ -48,21 +48,34 @@
   `59378d7c5d90593958e14ecf66f966107499499ef0eb4f616978226e3e3b0b93`.
 - Post-repair coast materialization context proof hash:
   `c58aee8b820ac50355705bb500e48863b389776b219acd86ee1c390d2cd76b5e`.
+- Source-recorded post-mock-terrain-materialization-repair final-surface parity artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-terrain-materialization-repair.json`.
+- Source-recorded post-mock-terrain-materialization-repair parity artifact sha256:
+  `8ff6e5ada94fae46b032082f4c7955d480c9ba3b091d8e42c7632c92171b87c8`.
+- Source-recorded post-mock-terrain-materialization-repair parity proof hash:
+  `209aac19056be1717fa58cdf5c6157241bb7a08f0bd1d16b8178634c13039012`.
+- Source-recorded post-mock-terrain-materialization-repair terrain-edge context artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-mock-terrain-materialization-repair-terrain-edge-context.json`.
+- Source-recorded post-mock-terrain-materialization-repair terrain-edge context artifact sha256:
+  `3452fb5922dd7080429295cd6caf41a33747b4657b849fa7cbd4d3f5cca8a7b9`.
+- Source-recorded post-mock-terrain-materialization-repair terrain-edge context proof hash:
+  `bd35969a6c58d07b4ae473935242932c04c6e7d82d791af8338a818cddc1c043`.
 - Request: `studio-run-in-game-mq20rbzr-1fhc`.
 - Seed/dimensions: `138503614`, `106x66`, `6996` plots.
 
 ## Boundary
 
 This ledger records terrain row context, row-level source-authority
-classification, and the bounded mock lake readback repair. It does not prove
-terrain parity, final-surface parity, or product acceptance.
+classification, the bounded mock lake readback repair, and the bounded mock
+terrain materialization repair. It does not prove terrain parity,
+final-surface parity, or product acceptance.
 
 ## Rows
 
 | Row | Coordinate |   Plot | Local           | Live            | Class                    | Neighborhood                                   | Status     |
 | --- | ---------- | -----: | --------------- | --------------- | ------------------------ | ---------------------------------------------- | ---------- |
-| T1  | `(73,36)`  | `3889` | `TERRAIN_OCEAN` | `TERRAIN_COAST` | `local-ocean-live-coast` | local/live both `coast:4`, `ocean:2`, `land:0` | classified: local mock/materialization terrain parity |
-| T2  | `(65,39)`  | `4199` | `TERRAIN_COAST` | `TERRAIN_OCEAN` | `local-coast-live-ocean` | local/live both `coast:2`, `ocean:3`, `land:1` | lake sub-gap repaired; terrain materialization remains |
+| T1  | `(73,36)`  | `3889` | `TERRAIN_OCEAN` | `TERRAIN_COAST` | `local-ocean-live-coast` | local/live both `coast:4`, `ocean:2`, `land:0` | residual enclosed-water materialization row remains unresolved |
+| T2  | `(65,39)`  | `4199` | `TERRAIN_COAST` | `TERRAIN_OCEAN` | `local-coast-live-ocean` | local/live both `coast:2`, `ocean:3`, `land:1` | lake and terrain materialization sub-gaps repaired |
 
 ## Pre-Repair Local Projection Context
 
@@ -121,14 +134,19 @@ Rejected owner classes for this row pair:
 ## Next Classification Evidence
 
 - Mock lake readback has been repaired and verified locally.
-- Continue with the remaining terrain materialization parity gap. The source
-  post-repair artifact still shows T1 local ocean/live coast and T2 local
-  coast/live ocean, but the current drain exact rerun is blocked by stale proof
-  config and must be refreshed before any parity claim.
-- Rerun exact-authored final-surface parity after any repair and keep parity
-  open until terrain rows match or residuals are explicitly owner-classified.
+- Mock terrain materialization has been partially repaired and verified
+  by source-recorded exact-bound artifacts. The land-contact local validation
+  subset is repaired there; only T1 local ocean/live coast remains in the
+  post-repair exact-bound parity artifact.
+- In the current drain, exact proof rerun to
+  `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-mock-terrain-materialization-repair.json`
+  exits `1` before parity evaluation with stale proof config key
+  `/config/ecology-features/floodplainPlanning`; refresh that wrapper before
+  making any fresh parity claim.
+- Keep parity open until terrain rows match or residuals are explicitly
+  owner-classified.
 
-## Source-Recorded Post-Repair Evidence
+## Source-Recorded Post-Lake-Repair Evidence
 
 | Row          | Post-repair local | Live            | Post-repair lake evidence               | Disposition                                                                 |
 | ------------ | ----------------- | --------------- | --------------------------------------- | --------------------------------------------------------------------------- |
@@ -158,3 +176,33 @@ parity at the adapter terrain-validation boundary. This does not authorize a
 MapGen coast/shelf tuning change. A repair, if opened, must be a separate
 bounded terrain materialization parity layer followed by exact-authored parity
 rerun.
+
+## Mock Terrain Materialization Repair
+
+The bounded mock terrain repair was opened after the row-level classification
+above. It changes only `@civ7/adapter` mock terrain materialization behavior
+and focused mock terrain tests.
+
+- `validateAndFixTerrain()` now materializes ocean as coast only when the row
+  touches both land terrain and an existing non-validation-created coast seed.
+- Validation-created coast is tracked separately and cannot seed later
+  validation passes, preventing self-cascade back into T2.
+- `expandCoasts()` is aligned with the official standard helper shape: ocean
+  adjacent to existing coast, within the standard ocean-column band, gated by
+  `"Shallow Water Scatter"`.
+- Focused adapter test coverage proves land-only validation does not convert,
+  land+coast validation does convert, validation-created coast does not seed a
+  later pass, ordinary coast is non-lake, and stamped lakes remain lake.
+
+Source-recorded exact-authored post-repair parity remains unresolved but
+improves terrain from `2/6996` to `1/6996`:
+
+| Row          | Post-terrain-repair local | Live            | Current disposition |
+| ------------ | ------------------------- | --------------- | ------------------- |
+| T1 `(73,36)` | `TERRAIN_OCEAN`           | `TERRAIN_COAST` | Still unresolved. Local and live neighborhoods both have `coast:4`, `ocean:2`, `land:0`; local morphology/hydrology/validation evidence does not distinguish this row from other live-ocean enclosed-water rows. |
+| T2 `(65,39)` | `TERRAIN_OCEAN`           | `TERRAIN_OCEAN` | Repaired by preventing validation-created coast from cascading into later validation passes. |
+
+This repair does not claim terrain parity, final-surface parity, coast/shelf
+tuning correctness, Earthlike quality, or product acceptance. Feature remains
+`5/6996` mismatched and resource remains `61/6996` mismatched in the same
+exact-bound proof.

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -214,6 +214,7 @@ const DEFAULT_DISCOVERY_CATALOG: DiscoveryCatalogEntry[] = [
 
 const DEFAULT_NO_RESOURCE = ADAPTER_NO_RESOURCE;
 const DEFAULT_RESOURCE_TYPE_CATALOG: number[] = [...PLACEABLE_RESOURCE_TYPE_IDS];
+const STANDARD_OCEAN_WATER_COLUMNS = 4;
 
 function sanitizeResourceTypeCatalog(input: number[] | undefined, noResource: number): number[] {
   const source = Array.isArray(input) ? input : DEFAULT_RESOURCE_TYPE_CATALOG;
@@ -272,6 +273,16 @@ const ODD_Q_NEIGHBORS_ODD: readonly (readonly [number, number])[] = [
 
 function wrapMockX(x: number, width: number): number {
   return ((x % width) + width) % width;
+}
+
+function isWithinStandardCoastExpansionBand(x: number, width: number): boolean {
+  const halfOceanColumns = STANDARD_OCEAN_WATER_COLUMNS / 2;
+  return (
+    x > halfOceanColumns &&
+    (x < (width - STANDARD_OCEAN_WATER_COLUMNS) / 2 ||
+      x > (width + STANDARD_OCEAN_WATER_COLUMNS) / 2) &&
+    x < width - halfOceanColumns
+  );
 }
 
 export interface MockAdapterConfig {
@@ -348,6 +359,7 @@ export class MockAdapter implements EngineAdapter {
   private biomes: Uint8Array;
   private waterMask: Uint8Array;
   private lakeMask: Uint8Array;
+  private validationMaterializedCoastMask: Uint8Array;
   private mountainMask: Uint8Array;
   private landmassRegionIds: Uint8Array;
   private riverMask: Uint8Array;
@@ -443,6 +455,7 @@ export class MockAdapter implements EngineAdapter {
     this.biomes = new Uint8Array(size).fill(config.defaultBiomeType ?? 0);
     this.waterMask = new Uint8Array(size);
     this.lakeMask = new Uint8Array(size);
+    this.validationMaterializedCoastMask = new Uint8Array(size);
     this.mountainMask = new Uint8Array(size);
     this.riverMask = new Uint8Array(size);
     this.landmassRegionIds = new Uint8Array(size);
@@ -634,6 +647,7 @@ export class MockAdapter implements EngineAdapter {
     this.riverMask[index] =
       terrainType === this.getTerrainTypeIndex("TERRAIN_NAVIGABLE_RIVER") ? 1 : 0;
     this.mountainMask[index] = terrainType === this.mountainTerrainId ? 1 : 0;
+    this.validationMaterializedCoastMask[index] = 0;
     if (terrainType !== this.coastTerrainId) {
       this.lakeMask[index] = 0;
     }
@@ -897,7 +911,8 @@ export class MockAdapter implements EngineAdapter {
   }
 
   validateAndFixTerrain(): void {
-    // No-op in mock
+    this.materializeValidationCoasts(this.width, this.height);
+    this.storeWaterData();
   }
 
   recalculateAreas(): void {
@@ -1084,28 +1099,86 @@ export class MockAdapter implements EngineAdapter {
   expandCoasts(width: number, height: number): void {
     this.calls.expandCoasts.push({ width, height });
 
+    const resolvedWidth = Math.max(0, Math.min(this.width, width | 0));
+    const resolvedHeight = Math.max(0, Math.min(this.height, height | 0));
+    if (resolvedWidth <= 0 || resolvedHeight <= 0) return;
+
     const coastTerrain = this.coastTerrainId;
-    for (let y = 0; y < height; y++) {
-      for (let x = 0; x < width; x++) {
-        if (!this.isWater(x, y)) continue;
-        let adjacentLand = false;
-        for (let dy = -1; dy <= 1 && !adjacentLand; dy++) {
-          for (let dx = -1; dx <= 1; dx++) {
-            if (dx === 0 && dy === 0) continue;
-            const nx = x + dx;
-            const ny = y + dy;
-            if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
-            if (!this.isWater(nx, ny)) {
-              adjacentLand = true;
-              break;
-            }
-          }
-        }
-        if (adjacentLand) {
-          this.terrainTypes[this.idx(x, y)] = coastTerrain & 0xff;
-        }
+    for (let y = 0; y < resolvedHeight; y++) {
+      for (let x = 0; x < resolvedWidth; x++) {
+        if (!isWithinStandardCoastExpansionBand(x, resolvedWidth)) continue;
+        const idx = this.idx(x, y);
+        if ((this.terrainTypes[idx] | 0) !== this.oceanTerrainId) continue;
+        const adjacentCoastRegionId = this.adjacentCoastRegionId(x, y, resolvedWidth, resolvedHeight);
+        if (adjacentCoastRegionId === null) continue;
+        if (this.rngFn(4, "Shallow Water Scatter") !== 0) continue;
+        this.terrainTypes[idx] = coastTerrain & 0xff;
+        this.landmassRegionIds[idx] = adjacentCoastRegionId & 0xff;
       }
     }
+  }
+
+  private materializeValidationCoasts(width: number, height: number): void {
+    const nextTerrain = new Uint8Array(this.terrainTypes);
+    const nextLandmassRegionIds = new Uint8Array(this.landmassRegionIds);
+    const nextValidationMaterializedCoastMask = new Uint8Array(
+      this.validationMaterializedCoastMask
+    );
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const idx = this.idx(x, y);
+        if ((this.terrainTypes[idx] | 0) !== this.oceanTerrainId) continue;
+        if (!this.hasAdjacentLandTerrain(x, y, width, height)) continue;
+        const adjacentCoastRegionId = this.adjacentCoastRegionId(x, y, width, height, {
+          includeValidationMaterializedCoast: false,
+        });
+        if (adjacentCoastRegionId === null) continue;
+        nextTerrain[idx] = this.coastTerrainId & 0xff;
+        nextLandmassRegionIds[idx] = adjacentCoastRegionId & 0xff;
+        nextValidationMaterializedCoastMask[idx] = 1;
+      }
+    }
+    this.terrainTypes = nextTerrain;
+    this.landmassRegionIds = nextLandmassRegionIds;
+    this.validationMaterializedCoastMask = nextValidationMaterializedCoastMask;
+  }
+
+  private adjacentCoastRegionId(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    options: Readonly<{ includeValidationMaterializedCoast?: boolean }> = {}
+  ): number | null {
+    const neighbors = (x & 1) === 1 ? ODD_Q_NEIGHBORS_ODD : ODD_Q_NEIGHBORS_EVEN;
+    for (const [dx, dy] of neighbors) {
+      const ny = y + dy;
+      if (ny < 0 || ny >= height) continue;
+      const nx = wrapMockX(x + dx, width);
+      const neighborIndex = this.idx(nx, ny);
+      if ((this.terrainTypes[neighborIndex] | 0) === this.coastTerrainId) {
+        if (
+          options.includeValidationMaterializedCoast === false &&
+          this.validationMaterializedCoastMask[neighborIndex] === 1
+        ) {
+          continue;
+        }
+        return this.landmassRegionIds[neighborIndex] | 0;
+      }
+    }
+    return null;
+  }
+
+  private hasAdjacentLandTerrain(x: number, y: number, width: number, height: number): boolean {
+    const neighbors = (x & 1) === 1 ? ODD_Q_NEIGHBORS_ODD : ODD_Q_NEIGHBORS_EVEN;
+    for (const [dx, dy] of neighbors) {
+      const ny = y + dy;
+      if (ny < 0 || ny >= height) continue;
+      const nx = wrapMockX(x + dx, width);
+      const terrain = this.terrainTypes[this.idx(nx, ny)] | 0;
+      if (terrain !== this.coastTerrainId && terrain !== this.oceanTerrainId) return true;
+    }
+    return false;
   }
 
   // === BIOMES ===
@@ -1423,6 +1496,7 @@ export class MockAdapter implements EngineAdapter {
     this.biomes.fill(config.defaultBiomeType ?? 0);
     this.waterMask.fill(0);
     this.lakeMask.fill(0);
+    this.validationMaterializedCoastMask.fill(0);
     this.mountainMask.fill(0);
     this.riverMask.fill(0);
     this.landmassRegionIds.fill(0);

--- a/packages/civ7-adapter/test/mock-terrain-policy.test.ts
+++ b/packages/civ7-adapter/test/mock-terrain-policy.test.ts
@@ -2,17 +2,124 @@ import { describe, expect, it } from "bun:test";
 
 import { createMockAdapter } from "../src/mock-adapter.js";
 
+const TERRAIN_MOUNTAIN = 0;
 const TERRAIN_FLAT = 2;
 const TERRAIN_COAST = 3;
 const TERRAIN_OCEAN = 4;
 
 describe("mock adapter terrain policy", () => {
+  it("does not expand coast solely from land adjacency during terrain validation", () => {
+    const adapter = createMockAdapter({
+      width: 16,
+      height: 3,
+      defaultTerrainType: TERRAIN_OCEAN,
+      rng: () => 0,
+    });
+
+    adapter.setTerrainType(4, 1, TERRAIN_FLAT);
+    adapter.storeWaterData();
+
+    adapter.validateAndFixTerrain();
+
+    expect(adapter.getTerrainType(5, 1)).toBe(TERRAIN_OCEAN);
+    expect(adapter.isWater(5, 1)).toBe(true);
+    expect(adapter.isLake(5, 1)).toBe(false);
+  });
+
+  it("materializes coast for ocean touching both land and existing coast during terrain validation", () => {
+    const adapter = createMockAdapter({
+      width: 16,
+      height: 3,
+      defaultTerrainType: TERRAIN_OCEAN,
+      rng: () => 1,
+    });
+
+    adapter.setTerrainType(4, 1, TERRAIN_FLAT);
+    adapter.setTerrainType(5, 0, TERRAIN_COAST);
+    adapter.storeWaterData();
+
+    adapter.validateAndFixTerrain();
+
+    expect(adapter.getTerrainType(5, 1)).toBe(TERRAIN_COAST);
+    expect(adapter.isWater(5, 1)).toBe(true);
+    expect(adapter.isLake(5, 1)).toBe(false);
+  });
+
+  it("does not use validation-materialized coast as a seed on later validation passes", () => {
+    const adapter = createMockAdapter({
+      width: 16,
+      height: 4,
+      defaultTerrainType: TERRAIN_OCEAN,
+      rng: () => 1,
+    });
+
+    adapter.setTerrainType(5, 0, TERRAIN_COAST);
+    adapter.setTerrainType(4, 2, TERRAIN_FLAT);
+    adapter.storeWaterData();
+
+    adapter.validateAndFixTerrain();
+    adapter.validateAndFixTerrain();
+
+    expect(adapter.getTerrainType(5, 1)).toBe(TERRAIN_COAST);
+    expect(adapter.getTerrainType(5, 2)).toBe(TERRAIN_OCEAN);
+  });
+
+  it("expands ocean next to existing coast when shallow-water scatter accepts it", () => {
+    const adapter = createMockAdapter({
+      width: 16,
+      height: 3,
+      defaultTerrainType: TERRAIN_OCEAN,
+      rng: () => 0,
+    });
+
+    adapter.setTerrainType(4, 1, TERRAIN_COAST);
+    adapter.storeWaterData();
+
+    adapter.expandCoasts(16, 3);
+
+    expect(adapter.getTerrainType(5, 1)).toBe(TERRAIN_COAST);
+    expect(adapter.isWater(5, 1)).toBe(true);
+    expect(adapter.isLake(5, 1)).toBe(false);
+  });
+
+  it("keeps adjacent ocean unchanged when shallow-water scatter rejects it", () => {
+    const adapter = createMockAdapter({
+      width: 16,
+      height: 3,
+      defaultTerrainType: TERRAIN_OCEAN,
+      rng: () => 1,
+    });
+
+    adapter.setTerrainType(4, 1, TERRAIN_COAST);
+    adapter.storeWaterData();
+
+    adapter.expandCoasts(16, 3);
+
+    expect(adapter.getTerrainType(5, 1)).toBe(TERRAIN_OCEAN);
+  });
+
+  it("does not treat mountain or land terrain as a coast expansion seed", () => {
+    const adapter = createMockAdapter({
+      width: 16,
+      height: 3,
+      defaultTerrainType: TERRAIN_OCEAN,
+      rng: () => 0,
+    });
+
+    adapter.setTerrainType(4, 1, TERRAIN_MOUNTAIN);
+    adapter.setTerrainType(4, 2, TERRAIN_FLAT);
+    adapter.storeWaterData();
+
+    adapter.validateAndFixTerrain();
+
+    expect(adapter.getTerrainType(5, 1)).toBe(TERRAIN_OCEAN);
+  });
+
   it("tracks stamped lakes separately from ordinary coast terrain", () => {
     const adapter = createMockAdapter({ width: 5, height: 3, defaultTerrainType: TERRAIN_OCEAN });
 
-    adapter.setTerrainType(0, 1, TERRAIN_FLAT);
+    adapter.setTerrainType(1, 1, TERRAIN_COAST);
     adapter.storeWaterData();
-    adapter.expandCoasts(5, 3);
 
     expect(adapter.getTerrainType(1, 1)).toBe(TERRAIN_COAST);
     expect(adapter.isWater(1, 1)).toBe(true);


### PR DESCRIPTION
This PR advances the bounded `@civ7/adapter` mock terrain materialization repair slice for the two coast/ocean terrain mismatches in request `studio-run-in-game-mq20rbzr-1fhc`.

**What changed in `MockAdapter`:**

- `validateAndFixTerrain()` is no longer a no-op. It now calls `materializeValidationCoasts()`, which converts ocean to coast only when a plot touches both a land-terrain neighbor and an existing, non-validation-created coast seed. This prevents the repair from cascading into enclosed-water rows that have no pre-existing coast anchor.
- A `validationMaterializedCoastMask` tracks every coast tile produced by validation. Validation-created coast tiles are excluded as seeds in subsequent validation passes, preventing self-cascade back into T2 `(65,39)`.
- `expandCoasts()` is rewritten to follow the official standard helper shape: ocean adjacent to existing coast, within the standard ocean-column band, gated by the `"Shallow Water Scatter"` RNG roll.
- `adjacentCoastRegionId()` and `hasAdjacentLandTerrain()` are extracted as private helpers using the correct odd-q hex neighbor offsets and wrapping.

**Test coverage added (`mock-terrain-policy.test.ts`):**

Three existing tests are joined by six new cases covering: land-only adjacency does not produce coast during validation; land + existing coast adjacency does produce coast; validation-created coast does not seed a later pass; `expandCoasts` converts ocean when scatter accepts; `expandCoasts` leaves ocean unchanged when scatter rejects; mountain/land terrain is not treated as a coast expansion seed.

**Parity outcome:**

Source-recorded exact-authored final-surface parity improves from `2/6996` to `1/6996` terrain mismatches. T2 `(65,39)` is now local/live `TERRAIN_OCEAN`. T1 `(73,36)` remains unresolved — local and live neighborhoods are identical (`coast:4`, `ocean:2`, `land:0`) with no hydrology, shelf, or coastal-land signal to distinguish it from other enclosed-water rows that live Civ keeps ocean. No further repair authority is claimed for T1 in this layer.

Final-surface parity, product acceptance, Earthlike quality, and coast/shelf policy are not closed. Feature (`5/6996`) and resource (`61/6996`) mismatches remain in their respective lanes.