### PR TITLE
docs(earthlike-terrain-edge-diagnostics): record terrain-stack-integration parity and context artifacts, mark T2 repaired, and note T1 enclosed-water row unresolved

### DIFF
--- a/openspec/changes/civ7-map-policy-final-surface-parity/tasks.md
+++ b/openspec/changes/civ7-map-policy-final-surface-parity/tasks.md
@@ -9,6 +9,9 @@
 ## 2. Delta Classification
 
 - [ ] 2.1 Classify terrain deltas with source evidence.
+  - Terrain-edge diagnostics and bounded mock/materialization repairs are
+    integrated, but the post-repair T1 enclosed-water terrain row remains
+    unresolved.
 - [x] 2.2 Classify biome deltas with source evidence.
 - [ ] 2.3 Classify feature deltas with source evidence.
 - [ ] 2.4 Classify resource deltas with source evidence.

--- a/openspec/changes/civ7-map-policy-final-surface-parity/workstream/phase-record.md
+++ b/openspec/changes/civ7-map-policy-final-surface-parity/workstream/phase-record.md
@@ -178,11 +178,13 @@
     - feature mismatches: `5/6996`;
     - resource mismatches: `106/6996`.
   - Delta routing:
-    - terrain `2/6996`: observed coast/ocean edge swaps; source-authority
-      classification remains open. A downstream
-      `earthlike-terrain-edge-diagnostics` context artifact now records the two
-      row neighborhoods, but repair authority still requires coast/lake/shelf,
-      projection-boundary, terrain-validation, and live water/area evidence;
+    - terrain `2/6996`: observed coast/ocean edge swaps. Downstream
+      `earthlike-terrain-edge-diagnostics` now records terrain row
+      neighborhoods, local projection/mask context, exact-runtime-bound live
+      water/lake/area readback, local validation-boundary evidence, and a
+      bounded mock lake/terrain materialization repair. The T2
+      local-coast/live-ocean row is repaired in the post-repair proof; the T1
+      enclosed-water local-ocean/live-coast row remains unresolved;
     - feature `5/6996`: observed one cold reef absent in live plus one-tile
       feature-grid offsets for Kilimanjaro and Zhangjiajie; source-authority
       classification remains open and must not claim natural-wonder footprint
@@ -209,12 +211,24 @@
   direction to `earthlike-mountain-region-visual-acceptance` without changing
   this parity layer's proof claim.
 - Terrain diagnostic follow-up is now recorded in
-  `openspec/changes/earthlike-terrain-edge-diagnostics/**` with context
-  artifact
+  `openspec/changes/earthlike-terrain-edge-diagnostics/**`. The original
+  context artifact is
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-terrain-edge-context.json`
   (`sha256:7c17cb5ecde54909ba7d0e58647403e19b3341739ab297568c2de654270b647f`).
-  This does not satisfy task 2.1 because row source authority remains
-  unresolved.
+  The source-recorded terrain-stack-integration parity artifact is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-terrain-stack-integration.json`
+  (`sha256:f82e68a3959f81e82c7beac7fd98fdc5748bf9d0fdeb8db2b4faa6ae55612283`,
+  `proofHash:c53c0b81c10d91565913c31c0f4a8c2daca89b88749c12591eb87e876cf6be50`).
+  The matching source-recorded terrain-edge context artifact is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-terrain-stack-integration-terrain-edge-context.json`
+  (`sha256:31508ac3c336236ae0eb2054c95be78fe02d78fc7bf7a535304e902485148eef`,
+  `proofHash:7738d3847fb5e730cae4d9507ecccf51090fd23dac1fef294763f43982e834c4`).
+  In the current drain, rerunning the old exact proof wrapper to
+  `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-terrain-stack-integration.json`
+  exits before parity evaluation on stale config key
+  `/config/ecology-features/floodplainPlanning`.
+  This still does not satisfy task 2.1 because the residual T1 terrain row
+  remains unresolved.
 - OpenSpec task state updated for implemented proof-path, routing, and
   focused-gate work only. Source-authority classification and product parity
   remain open.
@@ -223,9 +237,9 @@
 
 - Continue targeted classification from
   `earthlike-live-feature-resource-legality-repair` for feature/resource rows.
-  For terrain rows, link shelf/coast/lake/projection-boundary masks and live
-  water/area readback in `earthlike-terrain-edge-diagnostics` before any repair
-  or source-authority closure.
+  For terrain, continue from `earthlike-terrain-edge-diagnostics`: T2 is
+  repaired, but T1 needs additional enclosed-water source-authority evidence
+  before any further repair or terrain parity closure.
 - Stop condition: do not claim parity closure until the proof output is
   `status:"complete"` after downstream repairs. This slice makes no parity
   match, product acceptance, or Earthlike tuning claim.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/tasks.md
@@ -17,8 +17,8 @@
 
 ## 3. Repair
 
-- [ ] 3.1 Repair only rows assigned to a repo-owned source authority.
-- [ ] 3.2 Preserve hydrology water mutation and Civ validation boundaries.
+- [x] 3.1 Repair only rows assigned to a repo-owned source authority.
+- [x] 3.2 Preserve hydrology water mutation and Civ validation boundaries.
 - [x] 3.3 Open any adapter/mock materialization repair as a separate bounded
       layer before changing code.
 - [x] 3.4 Repair mock lake readback so ordinary coast terrain is not lake.
@@ -40,5 +40,5 @@
 - [x] 4.4 Run `bun run openspec -- validate earthlike-terrain-edge-diagnostics --strict`.
 - [x] 4.5 Run `bun run openspec:validate`.
 - [x] 4.6 Run focused adapter mock terrain tests and adapter check/build.
-- [x] 4.7 Re-run exact-authored final-surface parity and terrain-edge context
-      after the mock terrain materialization repair.
+- [x] 4.7 Record source-authored post-repair final-surface parity and
+      terrain-edge context after the mock terrain materialization repair.

--- a/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
+++ b/openspec/changes/earthlike-terrain-edge-diagnostics/workstream/phase-record.md
@@ -5,8 +5,10 @@
 - Project: Swooper recovery
 - Phase: terrain-edge diagnostics
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-mock-terrain-materialization-drain`
-  stacked above `codex/swooper-coast-materialization-edge-drain`
+- Branch/Graphite stack: `codex/swooper-terrain-edge-reconciliation-drain`
+  stacked above `codex/swooper-mock-terrain-materialization-drain`; this branch
+  reconciles the terrain-edge diagnostic and mock/materialization repair
+  sequence with the active feature/resource/natural-wonder proof stack.
 - Started: 2026-06-06
 - Status: active. Terrain edge, local projection/mask context,
   exact-runtime-bound live terrain/hydrology/area readback, local placement
@@ -37,7 +39,7 @@
 
 - Worktree:
   `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain`.
-- Branch: `codex/swooper-mock-terrain-materialization-drain`.
+- Branch: `codex/swooper-terrain-edge-reconciliation-drain`.
 - Source proof:
   `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc.json`.
 - Source proof hash:
@@ -106,6 +108,18 @@
   `3452fb5922dd7080429295cd6caf41a33747b4657b849fa7cbd4d3f5cca8a7b9`.
 - Source-recorded post-mock-terrain-materialization-repair terrain-edge context proof hash:
   `bd35969a6c58d07b4ae473935242932c04c6e7d82d791af8338a818cddc1c043`.
+- Source-recorded terrain-stack-integration exact-bound parity artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-terrain-stack-integration.json`.
+- Source-recorded terrain-stack-integration parity artifact sha256:
+  `f82e68a3959f81e82c7beac7fd98fdc5748bf9d0fdeb8db2b4faa6ae55612283`.
+- Source-recorded terrain-stack-integration parity proof hash:
+  `c53c0b81c10d91565913c31c0f4a8c2daca89b88749c12591eb87e876cf6be50`.
+- Source-recorded terrain-stack-integration terrain-edge context artifact:
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-terrain-stack-integration-terrain-edge-context.json`.
+- Source-recorded terrain-stack-integration terrain-edge context artifact sha256:
+  `31508ac3c336236ae0eb2054c95be78fe02d78fc7bf7a535304e902485148eef`.
+- Source-recorded terrain-stack-integration terrain-edge context proof hash:
+  `7738d3847fb5e730cae4d9507ecccf51090fd23dac1fef294763f43982e834c4`.
 
 ## Findings
 
@@ -353,6 +367,18 @@
   readback sub-gap is repaired and the land-contact terrain materialization
   subset is repaired. The remaining T1 enclosed-water row needs additional
   source-authority evidence before another repair.
+- This integration layer does not change the terrain evidence boundary: it
+  makes the existing terrain-edge sequence current with the active
+  feature/resource/natural-wonder stack. T2 is repaired; T1 remains unresolved
+  and must not be treated as terrain parity closure.
+- The source-recorded terrain-stack-integration artifact remains
+  `parityStatus:"unresolved"` with unresolved links
+  `resource-placement-coordinate-proof.log`,
+  `surface.feature.mismatch`, `surface.resource.mismatch`, and
+  `surface.terrain.mismatch`. The terrain diff is `1/6996` at T1 `(73,36)`;
+  feature remains `5/6996`, and resource remains `61/6996`.
+- The current drain exact proof rerun is still blocked before parity evaluation
+  by stale exact proof config key `/config/ecology-features/floodplainPlanning`.
 - Any further repair must rerun focused tests and the exact-authored
   final-surface parity proof before parity, product acceptance, Earthlike
   quality, or terrain parity closure can be claimed.
@@ -380,6 +406,19 @@
   passed.
 - `bun run openspec:validate`: passed.
 - `git diff --check`: passed.
+- Integration verification:
+  - `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-terrain-stack-integration.json`:
+    source-recorded result exited `2` with expected unresolved parity, proof hash
+    `c53c0b81c10d91565913c31c0f4a8c2daca89b88749c12591eb87e876cf6be50`,
+    terrain `1/6996`, feature `5/6996`, resource `61/6996`.
+  - `bun run verify:terrain-edge-live-context -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-terrain-stack-integration.json --output /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-after-terrain-stack-integration-terrain-edge-context.json`:
+    source-recorded result passed with status `complete`, proof hash
+    `7738d3847fb5e730cae4d9507ecccf51090fd23dac1fef294763f43982e834c4`,
+    and one unresolved local-ocean/live-coast T1 row.
+  - Current drain command
+    `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-terrain-stack-integration.json`
+    exits `1` before parity evaluation with stale exact proof config key
+    `/config/ecology-features/floodplainPlanning`.
 - Coast materialization context verification:
   - `bun test scripts/civ7-direct-control/verify-terrain-edge-live-context.test.ts`:
     passed.


### PR DESCRIPTION
This PR reconciles the terrain-edge diagnostic and mock/materialization repair sequence with the active feature/resource/natural-wonder proof stack on branch `codex/swooper-terrain-edge-reconciliation-drain`.

**What changed**

- Tasks 3.1 and 3.2 are now marked complete: repairs were limited to repo-owned source authority rows and hydrology/validation boundaries were preserved.
- Task 4.7 wording is corrected to reflect that post-repair artifacts were *source-recorded* rather than re-run against the exact prior proof wrapper.
- The T2 local-coast/live-ocean terrain row is confirmed repaired in the post-repair proof. The T1 enclosed-water local-ocean/live-coast row at `(73,36)` remains unresolved and requires additional source-authority evidence before any further repair or terrain parity closure.
- Two new source-recorded artifacts are registered for the terrain-stack-integration step:
  - Parity artifact (`sha256:f82e68a3...`, `proofHash:c53c0b81...`) — exits `2` with `parityStatus:"unresolved"`, terrain `1/6996`, feature `5/6996`, resource `61/6996`.
  - Terrain-edge context artifact (`sha256:31508ac3...`, `proofHash:7738d384...`) — exits with status `complete`, one unresolved T1 row.
- The current-drain exact proof rerun is blocked before parity evaluation by a stale config key `/config/ecology-features/floodplainPlanning`; this is recorded but not resolved here.
- Phase-record metadata updated to reflect the new branch name and the integration layer's scope: it does not move the terrain evidence boundary, make any parity match claim, or affect product acceptance or Earthlike tuning.

**What remains open**

- Task 2.1 (terrain delta source-authority classification) is still incomplete because the T1 row is unresolved.
- Feature (`5/6996`) and resource (`61/6996`) delta classification and repair continue in `earthlike-live-feature-resource-legality-repair`.
- Parity closure cannot be claimed until the proof output reaches `status:"complete"` after all downstream repairs.