### PR TITLE
feat(swooper-wonder-materialization): replace fatal placement errors with measured outcomes, add footprint terrain projection, and record shortfall/rejection stats

### DIFF
--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
@@ -133,14 +133,18 @@ const AdvancedStartAssignmentArtifactSchema = Type.Object(
 const NaturalWonderPlacementArtifactSchema = Type.Object(
   {
     plannedCount: Type.Integer({ minimum: 0 }),
+    targetCount: Type.Integer({ minimum: 0 }),
     placedCount: Type.Integer({ minimum: 0 }),
+    terrainAdjustedCount: Type.Integer({ minimum: 0 }),
     skippedOutOfBoundsCount: Type.Integer({ minimum: 0 }),
     rejectedCount: Type.Integer({ minimum: 0 }),
+    shortfallCount: Type.Integer({ minimum: 0 }),
+    rejectionExamples: Type.Array(Type.String()),
   },
   {
     additionalProperties: false,
     description:
-      "Verified natural-wonder stamping result. This is a product contract because failed or partial stamping aborts the placement pipeline.",
+      "Measured natural-wonder stamping result. Corrupt plans fail before this artifact, while shortfalls and legality rejections are recorded as placement outcomes.",
   }
 );
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.ts
@@ -1,3 +1,4 @@
+import { CIV7_BROWSER_TABLES_V0, getNaturalWonderFootprintIndices } from "@civ7/map-policy";
 import type { ExtendedMapContext } from "@swooper/mapgen-core";
 import type { DeepReadonly, Static } from "@swooper/mapgen-core/authoring";
 
@@ -15,10 +16,48 @@ type StampNaturalWondersFromPlanArgs = {
 
 export type NaturalWonderStampingStats = {
   plannedCount: number;
+  targetCount: number;
   placedCount: number;
+  terrainAdjustedCount: number;
   skippedOutOfBoundsCount: number;
   rejectedCount: number;
+  shortfallCount: number;
+  rejectionExamples: string[];
 };
+
+const FEATURE_VALID_TERRAIN_TYPE_INDICES = CIV7_BROWSER_TABLES_V0.featureValidTerrainTypeIndices as
+  Record<string, readonly number[] | undefined>;
+const POLAR_WATER_ROWS = Math.max(0, CIV7_BROWSER_TABLES_V0.mapGlobals.polarWaterRows | 0);
+const FEATURE_POLICIES = CIV7_BROWSER_TABLES_V0.featurePolicies as Record<
+  string,
+  { placementClass?: string; naturalWonderTiles?: number; naturalWonderDirection?: number } | undefined
+>;
+
+function getValidTerrainTypesForFeature(featureType: number): readonly number[] {
+  const terrainTypes = FEATURE_VALID_TERRAIN_TYPE_INDICES[String(featureType | 0)];
+  return Array.isArray(terrainTypes) ? terrainTypes : [];
+}
+
+function ensureFeatureValidTerrain(
+  adapter: ExtendedMapContext["adapter"],
+  x: number,
+  y: number,
+  height: number,
+  featureType: number
+): "unchanged" | "adjusted" | "blocked" {
+  const validTerrainTypes = getValidTerrainTypesForFeature(featureType);
+  if (validTerrainTypes.length === 0) return "blocked";
+  if (y < POLAR_WATER_ROWS || y >= height - POLAR_WATER_ROWS) return "blocked";
+
+  const currentTerrain = adapter.getTerrainType(x, y) | 0;
+  if (validTerrainTypes.includes(currentTerrain)) return "unchanged";
+
+  const targetTerrain = validTerrainTypes[0];
+  if (!Number.isFinite(targetTerrain) || targetTerrain < 0) return "blocked";
+
+  adapter.setTerrainType(x, y, targetTerrain | 0);
+  return "adjusted";
+}
 
 /**
  * Materializes natural-wonder intent as the product owned by
@@ -26,8 +65,9 @@ export type NaturalWonderStampingStats = {
  *
  * Natural wonders are not a final-placement side effect anymore: the planner
  * publishes deterministic intent, this step applies it once, and downstream
- * steps consume the published evidence. The all-or-nothing checks prevent
- * maintenance or final summary code from becoming hidden recovery paths.
+ * steps consume the published evidence. Corrupt plans still fail hard, but
+ * adapter legality shortfalls are measured as placement outcomes instead of
+ * killing otherwise playable map generation.
  */
 export function stampNaturalWondersFromPlan({
   adapter,
@@ -49,24 +89,18 @@ export function stampNaturalWondersFromPlan({
       `[Placement] Natural wonder plan metadata mismatch (plannedCount=${declaredPlannedCount}, placements=${plannedCount}).`
     );
   }
-  if (plannedCount < targetCount) {
-    throw new Error(
-      `[Placement] Natural wonder plan cannot satisfy target count (target=${targetCount}, planned=${plannedCount}).`
-    );
-  }
   const requested = Math.max(
     0,
     Number.isFinite(requestedCount) ? (requestedCount as number) | 0 : targetCount
   );
-  if (requested !== plannedCount) {
-    throw new Error(
-      `[Placement] Natural wonder planner could not meet requested count (requested ${requested}, planned ${plannedCount}).`
-    );
-  }
+  const effectiveTargetCount = Math.max(targetCount, requested);
+  const shortfallCount = Math.max(0, effectiveTargetCount - plannedCount);
 
   let placedCount = 0;
+  let terrainAdjustedCount = 0;
   let skippedOutOfBoundsCount = 0;
   let rejectedCount = 0;
+  const rejectionDetails: string[] = [];
 
   for (const placementPlan of wonders.placements) {
     if (!Number.isFinite(placementPlan.plotIndex)) {
@@ -77,6 +111,7 @@ export function stampNaturalWondersFromPlan({
     const plotIndex = placementPlan.plotIndex | 0;
     if (plotIndex < 0 || plotIndex >= width * height) {
       skippedOutOfBoundsCount += 1;
+      rejectionDetails.push(`feature=${placementPlan.featureType} plot=${plotIndex} reason=out-of-bounds`);
       continue;
     }
 
@@ -91,30 +126,82 @@ export function stampNaturalWondersFromPlan({
       );
     }
 
+    const featureType = Math.trunc(placementPlan.featureType);
+    const direction = Math.trunc(placementPlan.direction);
     const y = (plotIndex / width) | 0;
     const x = plotIndex - y * width;
+    const footprint = getNaturalWonderFootprintIndices({
+      x,
+      y,
+      width,
+      height,
+      policy: FEATURE_POLICIES[String(featureType)] ?? {},
+      direction,
+    });
+    if (!footprint) {
+      rejectedCount += 1;
+      rejectionDetails.push(`feature=${featureType} plot=${plotIndex} reason=unsupported-footprint`);
+      continue;
+    }
+    let footprintBlocked = false;
+    let blockedReason = "unknown";
+    for (const footprintPlotIndex of footprint) {
+      const fy = (footprintPlotIndex / width) | 0;
+      const fx = footprintPlotIndex - fy * width;
+      if ((adapter.getFeatureType(fx, fy) | 0) !== (adapter.NO_FEATURE | 0)) {
+        footprintBlocked = true;
+        blockedReason = `occupied:${footprintPlotIndex}`;
+        break;
+      }
+      const terrainStatus = ensureFeatureValidTerrain(adapter, fx, fy, height, featureType);
+      if (terrainStatus === "blocked") {
+        footprintBlocked = true;
+        blockedReason = `terrain-policy:${footprintPlotIndex}`;
+        break;
+      }
+      if (terrainStatus === "adjusted") terrainAdjustedCount += 1;
+    }
+    if (footprintBlocked) {
+      rejectedCount += 1;
+      rejectionDetails.push(`feature=${featureType} plot=${plotIndex} reason=${blockedReason}`);
+      continue;
+    }
     const placed = adapter.stampNaturalWonder(
       x,
       y,
-      Math.trunc(placementPlan.featureType),
-      Math.trunc(placementPlan.direction),
+      featureType,
+      direction,
       Number.isFinite(placementPlan.elevation) ? placementPlan.elevation : undefined
     );
-    if (placed) placedCount += 1;
-    else rejectedCount += 1;
-  }
-
-  if (placedCount !== plannedCount || skippedOutOfBoundsCount > 0 || rejectedCount > 0) {
-    throw new Error(
-      `[Placement] Failed to stamp all natural wonders (placed ${placedCount}/${plannedCount}, target=${targetCount}, outOfBounds=${skippedOutOfBoundsCount}, rejected=${rejectedCount}).`
-    );
+    if (!placed) {
+      rejectedCount += 1;
+      rejectionDetails.push(`feature=${featureType} plot=${plotIndex} reason=adapter-rejected`);
+      continue;
+    }
+    let readbackMismatch = false;
+    for (const footprintPlotIndex of footprint) {
+      const fy = (footprintPlotIndex / width) | 0;
+      const fx = footprintPlotIndex - fy * width;
+      if ((adapter.getFeatureType(fx, fy) | 0) !== featureType) {
+        readbackMismatch = true;
+        break;
+      }
+    }
+    if (readbackMismatch) {
+      rejectedCount += 1;
+      rejectionDetails.push(`feature=${featureType} plot=${plotIndex} reason=readback-mismatch`);
+    } else placedCount += 1;
   }
 
   return {
     plannedCount,
+    targetCount: effectiveTargetCount,
     placedCount,
+    terrainAdjustedCount,
     skippedOutOfBoundsCount,
     rejectedCount,
+    shortfallCount,
+    rejectionExamples: rejectionDetails.slice(0, 8),
   };
 }
 
@@ -122,18 +209,39 @@ export function normalizeNaturalWonderStampingStats(
   stats: DeepReadonly<NaturalWonderStampingStats>
 ): NaturalWonderStampingStats {
   const plannedCount = Math.max(0, stats.plannedCount | 0);
+  const targetCount = Math.max(
+    plannedCount,
+    "targetCount" in stats
+      ? ((stats as { targetCount?: number }).targetCount ?? 0) | 0
+      : plannedCount
+  );
   const placedCount = Math.max(0, stats.placedCount | 0);
+  const terrainAdjustedCount = Math.max(
+    0,
+    "terrainAdjustedCount" in stats
+      ? ((stats as { terrainAdjustedCount?: number }).terrainAdjustedCount ?? 0) | 0
+      : 0
+  );
   const skippedOutOfBoundsCount = Math.max(0, stats.skippedOutOfBoundsCount | 0);
   const rejectedCount = Math.max(0, stats.rejectedCount | 0);
-  if (placedCount !== plannedCount || skippedOutOfBoundsCount > 0 || rejectedCount > 0) {
-    throw new Error(
-      `[Placement] Natural wonder placement artifact is not fully satisfied (placed ${placedCount}/${plannedCount}, outOfBounds=${skippedOutOfBoundsCount}, rejected=${rejectedCount}).`
-    );
-  }
+  const shortfallCount = Math.max(
+    0,
+    "shortfallCount" in stats
+      ? ((stats as { shortfallCount?: number }).shortfallCount ?? 0) | 0
+      : targetCount - plannedCount
+  );
+  const rawRejectionExamples = (stats as { rejectionExamples?: unknown }).rejectionExamples;
+  const rejectionExamples = Array.isArray(rawRejectionExamples)
+    ? rawRejectionExamples.map(String).slice(0, 8)
+    : [];
   return {
     plannedCount,
+    targetCount,
     placedCount,
+    terrainAdjustedCount,
     skippedOutOfBoundsCount,
     rejectedCount,
+    shortfallCount,
+    rejectionExamples,
   };
 }

--- a/mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts
+++ b/mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "bun:test";
+
+import { createMockAdapter } from "@civ7/adapter";
+import { CIV7_BROWSER_TABLES_V0 } from "@civ7/map-policy";
+import {
+  FLAT_TERRAIN,
+  HILL_TERRAIN,
+  MOUNTAIN_TERRAIN,
+} from "@swooper/mapgen-core";
+
+import {
+  normalizeNaturalWonderStampingStats,
+  stampNaturalWondersFromPlan,
+} from "../../src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.js";
+
+const { biomeGlobals, featureTypes } = CIV7_BROWSER_TABLES_V0;
+
+function oneWonderPlan(featureType: number, plotIndex: number, width = 4, height = 6) {
+  return {
+    width,
+    height,
+    targetCount: 1,
+    plannedCount: 1,
+    placements: [
+      {
+        plotIndex,
+        featureType,
+        direction: -1,
+        elevation: 120,
+        priority: 1,
+      },
+    ],
+  };
+}
+
+describe("natural wonder placement materialization", () => {
+  it("projects generated valid-terrain policy before stamping a natural wonder", () => {
+    const adapter = createMockAdapter({
+      width: 4,
+      height: 6,
+      defaultBiomeType: biomeGlobals.BIOME_GRASSLAND,
+      defaultTerrainType: HILL_TERRAIN,
+    });
+
+    const stats = stampNaturalWondersFromPlan({
+      adapter,
+      width: 4,
+      height: 6,
+      wonders: oneWonderPlan(featureTypes.FEATURE_REDWOOD_FOREST, 9),
+      requestedCount: 1,
+    });
+
+    expect(adapter.getTerrainType(1, 2)).toBe(FLAT_TERRAIN);
+    expect(adapter.getTerrainType(2, 2)).toBe(FLAT_TERRAIN);
+    expect(adapter.getTerrainType(2, 3)).toBe(FLAT_TERRAIN);
+    expect(adapter.getFeatureType(1, 2)).toBe(featureTypes.FEATURE_REDWOOD_FOREST);
+    expect(adapter.getFeatureType(2, 2)).toBe(featureTypes.FEATURE_REDWOOD_FOREST);
+    expect(adapter.getFeatureType(2, 3)).toBe(featureTypes.FEATURE_REDWOOD_FOREST);
+    expect(stats).toEqual({
+      plannedCount: 1,
+      targetCount: 1,
+      placedCount: 1,
+      terrainAdjustedCount: 3,
+      skippedOutOfBoundsCount: 0,
+      rejectedCount: 0,
+      shortfallCount: 0,
+      rejectionExamples: [],
+    });
+  });
+
+  it("uses feature-specific terrain policy instead of a generic land-water default", () => {
+    const adapter = createMockAdapter({
+      width: 5,
+      height: 8,
+      defaultBiomeType: biomeGlobals.BIOME_PLAINS,
+      defaultTerrainType: FLAT_TERRAIN,
+    });
+
+    const mountainStats = stampNaturalWondersFromPlan({
+      adapter,
+      width: 5,
+      height: 8,
+      wonders: oneWonderPlan(featureTypes.FEATURE_KILIMANJARO, 17, 5, 8),
+      requestedCount: 1,
+    });
+
+    expect(adapter.getTerrainType(2, 3)).toBe(MOUNTAIN_TERRAIN);
+    expect(adapter.getTerrainType(3, 3)).toBe(MOUNTAIN_TERRAIN);
+    expect(adapter.getTerrainType(3, 4)).toBe(MOUNTAIN_TERRAIN);
+    expect(adapter.getFeatureType(2, 3)).toBe(featureTypes.FEATURE_KILIMANJARO);
+    expect(adapter.getFeatureType(3, 3)).toBe(featureTypes.FEATURE_KILIMANJARO);
+    expect(adapter.getFeatureType(3, 4)).toBe(featureTypes.FEATURE_KILIMANJARO);
+    expect(mountainStats.terrainAdjustedCount).toBe(3);
+  });
+
+  it("records planner shortfalls instead of failing browser/game generation", () => {
+    const adapter = createMockAdapter({
+      width: 4,
+      height: 6,
+      defaultBiomeType: biomeGlobals.BIOME_GRASSLAND,
+      defaultTerrainType: HILL_TERRAIN,
+    });
+    const plan = {
+      ...oneWonderPlan(featureTypes.FEATURE_REDWOOD_FOREST, 9),
+      targetCount: 2,
+    };
+
+    const stats = stampNaturalWondersFromPlan({
+      adapter,
+      width: 4,
+      height: 6,
+      wonders: plan,
+      requestedCount: 2,
+    });
+
+    expect(stats.targetCount).toBe(2);
+    expect(stats.plannedCount).toBe(1);
+    expect(stats.placedCount).toBe(1);
+    expect(stats.shortfallCount).toBe(1);
+    expect(stats.rejectedCount).toBe(0);
+    expect(normalizeNaturalWonderStampingStats(stats)).toEqual(stats);
+  });
+
+  it("records adapter legality rejection as a degraded outcome", () => {
+    const adapter = createMockAdapter({
+      width: 5,
+      height: 8,
+      defaultBiomeType: biomeGlobals.BIOME_PLAINS,
+      defaultTerrainType: FLAT_TERRAIN,
+    });
+    adapter.stampNaturalWonder = () => false;
+
+    const stats = stampNaturalWondersFromPlan({
+      adapter,
+      width: 5,
+      height: 8,
+      wonders: oneWonderPlan(featureTypes.FEATURE_KILIMANJARO, 17, 5, 8),
+      requestedCount: 1,
+    });
+
+    expect(stats).toMatchObject({
+      plannedCount: 1,
+      targetCount: 1,
+      placedCount: 0,
+      skippedOutOfBoundsCount: 0,
+      rejectedCount: 1,
+      shortfallCount: 0,
+    });
+    expect(stats.rejectionExamples[0]).toContain("adapter-rejected");
+  });
+
+  it("still fails corrupt plan metadata", () => {
+    const adapter = createMockAdapter({
+      width: 2,
+      height: 2,
+      defaultBiomeType: biomeGlobals.BIOME_GRASSLAND,
+      defaultTerrainType: FLAT_TERRAIN,
+    });
+
+    expect(() =>
+      stampNaturalWondersFromPlan({
+        adapter,
+        width: 2,
+        height: 2,
+        wonders: {
+          width: 2,
+          height: 2,
+          targetCount: 1,
+          plannedCount: 2,
+          placements: [
+            { plotIndex: 0, featureType: featureTypes.FEATURE_REDWOOD_FOREST, direction: 0 },
+          ],
+        },
+      })
+    ).toThrow(/metadata mismatch/);
+  });
+});

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/proposal.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/proposal.md
@@ -23,6 +23,10 @@ truth.
 - Classify feature/resource deltas by official data, map policy, adapter
   emulation, MapGen planning, or accepted engine materialization.
 - Repair repo-owned legality or distribution behavior in the correct owner.
+- Preserve natural-wonder materialization as a measured placement outcome:
+  corrupt plans still fail, while planner shortfall, terrain projection, and
+  adapter legality rejection are recorded in the placement artifact instead of
+  aborting map generation.
 - Preserve age/resource legality and measured spacing/diversity.
 
 ## Requires
@@ -43,7 +47,10 @@ truth.
   so the class is narrowed but not yet a global repair authority. Current
   natural-wonder placement counts are local diagnostic evidence only; the
   exact live proof/completion payloads for the request do not yet carry
-  `naturalWonderPlacement` stats.
+  `naturalWonderPlacement` stats. Natural-wonder materialization can still
+  repair repo-owned outcome recording independently of exact live telemetry:
+  it must not claim parity or product acceptance until a later exact proof
+  carries those stats or otherwise classifies the remaining source authority.
 - Resource hypotheses:
   the `106/6996` mismatch class includes relocation/substitution patterns that
   may come from mock/static resource legality, assignment-order divergence from

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/specs/mapgen-normalization-workstreams/spec.md
@@ -15,3 +15,14 @@ evidence and the correct official-data, adapter, map-policy, or MapGen owner.
 - **WHEN** a resource repair would silently violate authored spacing,
   age-appropriateness, or diversity expectations
 - **THEN** the repair is rejected before product acceptance reruns
+
+#### Scenario: Natural wonder materialization produces measured outcomes
+- **WHEN** a dimension-valid natural-wonder plan has supported footprint policy
+  but a planner shortfall, feature-valid terrain adjustment, out-of-bounds
+  placement, or adapter rejection occurs
+- **THEN** the placement materializer records target, planned, placed,
+  terrain-adjusted, out-of-bounds, rejected, shortfall, and bounded rejection
+  example counts in the natural-wonder placement artifact
+- **AND** corrupt plan metadata still fails before materialization
+- **AND** the repair does not claim exact live parity or product acceptance
+  without a matching runtime proof class

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -56,8 +56,10 @@
   readback rows.
 - [x] 2.26 Add natural-wonder live proof boundary context for local-only
   placement stats.
-- [ ] 2.27 Repair remaining proven package or MapGen owners.
-- [ ] 2.28 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.27 Repair natural-wonder materialization outcome recording and
+  footprint terrain projection without claiming exact live parity.
+- [ ] 2.28 Repair remaining proven package or MapGen owners.
+- [ ] 2.29 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -850,6 +850,35 @@ corresponding natural-wonder placement stats for the same request/config/seed
 chain. No natural-wonder repair, parity closure, product acceptance, or
 mountain-quality claim is authorized from local placement counts alone.
 
+### Natural-Wonder Materialization Outcome Repair
+
+Repair:
+the natural-wonder materializer now treats planner shortfall, out-of-bounds
+placement, adapter rejection, and footprint readback mismatch as measured
+placement outcomes rather than fatal generation errors. It projects generated
+feature-valid terrain across supported natural-wonder footprints before
+stamping and uses the mock adapter to stamp/read back the full supported
+footprint. Corrupt plan metadata remains fatal.
+
+Accounting:
+this is a synthetic, natural-wonder-only adoption of source behavior from stale
+commit `b9a3e9d50`; it does not replay the stale commit's unrelated Studio,
+package, config, generated, or build-surface changes. The accepted source
+authority is repo-owned materialization behavior. Exact live placement telemetry
+and parity/product acceptance remain separate proof classes.
+
+Validation:
+
+| Proof class | Result |
+|---|---|
+| Focused materialization tests | Passed `bun test mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts`. |
+| Adapter regression tests | Passed `bun test packages/civ7-adapter/test/mock-terrain-policy.test.ts`. |
+| Diagnostics/parity unit tests | Passed `bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts`. |
+| Placement contract tests | Passed `bun test mods/mod-swooper-maps/test/placement/placement-contracts.test.ts`. |
+| Owner checks | Passed `bun run --cwd packages/civ7-adapter check`, `bun run --cwd packages/civ7-adapter build`, and `bun run --cwd mods/mod-swooper-maps check`. |
+| OpenSpec strict validation | Passed `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`. |
+| Current exact parity proof rerun | Blocked before parity evaluation by stale config key `/config/ecology-features/floodplainPlanning`; no parity closure claimed. |
+
 ## Required Next Diagnostics
 
 - Extract local row context for every feature/resource mismatch: terrain,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -454,6 +454,30 @@
   authority from relying on local placement counts alone; the next accepted
   movement must either instrument exact live natural-wonder placement evidence
   or explicitly classify ownership from a stronger exact-run source.
+- Natural-wonder materialization outcome repair progress:
+  `codex/swooper-wonder-materialization-repair-drain` synthetically adopts only
+  the natural-wonder materialization behavior from stale source commit
+  `b9a3e9d50` and excludes its unrelated Studio, package, config, generated,
+  and build-surface churn. The materializer now projects generated
+  feature-valid terrain across supported natural-wonder footprints, stamps
+  multi-tile footprints through the mock adapter, preserves hard failures for
+  corrupt plan metadata, and records planner shortfall/out-of-bounds/adapter
+  rejection/readback mismatch as measured placement outcomes in
+  `artifact:placement.naturalWonderPlacement`. This is a repo-owned
+  materialization repair, not an exact live parity or product-acceptance claim.
+  Validation passed:
+  `bun test mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts`;
+  `bun test packages/civ7-adapter/test/mock-terrain-policy.test.ts`;
+  `bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts`;
+  `bun test mods/mod-swooper-maps/test/placement/placement-contracts.test.ts`;
+  `bun run --cwd packages/civ7-adapter check`;
+  `bun run --cwd packages/civ7-adapter build`;
+  `bun run --cwd mods/mod-swooper-maps check`;
+  `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`.
+  Current exact parity rerun remains blocked before parity evaluation:
+  `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-materialization-repair.json`
+  returned
+  `Recipe compile failed: /config/ecology-features/floodplainPlanning: Unknown key`.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -1233,19 +1233,35 @@ export class MockAdapter implements EngineAdapter {
     elevation?: number
   ): boolean {
     if (x < 0 || x >= this.width || y < 0 || y >= this.height) return false;
-    if (!this.canHaveFeature(x, y, featureType)) return false;
-    const existing = this.getFeatureType(x, y);
-    if (Number.isFinite(existing) && existing >= 0) return false;
+    const policy = FEATURE_POLICIES[String(featureType | 0)];
+    const footprint = getNaturalWonderFootprintIndices({
+      x,
+      y,
+      width: this.width,
+      height: this.height,
+      policy: policy ?? {},
+      direction,
+    });
+    if (!footprint) return false;
+    for (const plotIndex of footprint) {
+      const fy = (plotIndex / this.width) | 0;
+      const fx = plotIndex - fy * this.width;
+      if (!this.canHaveFeature(fx, fy, featureType)) return false;
+    }
 
     const i = this.idx(x, y);
     const resolvedElevation = Number.isFinite(elevation)
       ? (elevation as number)
       : this.elevations[i]!;
-    this.setFeatureType(x, y, {
-      Feature: featureType,
-      Direction: direction,
-      Elevation: resolvedElevation,
-    });
+    for (const plotIndex of footprint) {
+      const fy = (plotIndex / this.width) | 0;
+      const fx = plotIndex - fy * this.width;
+      this.setFeatureType(fx, fy, {
+        Feature: featureType,
+        Direction: direction,
+        Elevation: resolvedElevation,
+      });
+    }
     this.calls.stampNaturalWonder.push({
       x,
       y,


### PR DESCRIPTION
Natural wonder placement failures — planner shortfalls, out-of-bounds plots, adapter rejections, and footprint readback mismatches — previously aborted map generation entirely. This changes the materializer to treat those conditions as measured placement outcomes recorded in the `naturalWonderPlacement` artifact rather than fatal errors. Corrupt plan metadata (dimension or count mismatches) still fails hard.

The materializer now resolves the full multi-tile footprint for each natural wonder before stamping, projects feature-valid terrain across that footprint using the official `featureValidTerrainTypeIndices` policy, and verifies each footprint tile reads back the expected feature type after stamping. Each rejection is captured with a reason string, and up to eight examples are surfaced in the artifact. The artifact gains `targetCount`, `terrainAdjustedCount`, `shortfallCount`, and `rejectionExamples` fields alongside the existing counts.

The mock adapter's `stampNaturalWonder` implementation is updated to apply the same footprint-aware stamping logic, setting the feature type on every tile in the footprint rather than only the origin tile.

Tests cover terrain projection before stamping, feature-specific terrain policy selection, planner shortfall recording, adapter rejection recording, and continued hard failure on corrupt metadata.