### PR TITLE
feat(run-in-game): add natural-wonder placement telemetry emission, exact log binding, and live proof boundary acceptance

### DIFF
--- a/apps/mapgen-studio/src/features/runInGame/status.ts
+++ b/apps/mapgen-studio/src/features/runInGame/status.ts
@@ -149,6 +149,21 @@ export type RunInGameExactAuthorshipProof = Readonly<{
         mismatch?: Readonly<{ count: number; hash32: string }>;
       }>;
     }>;
+    naturalWonderPlacement?: Readonly<{
+      marker: "NATURAL_WONDER_PLACEMENT_V1";
+      payload: unknown;
+      stats?: Readonly<{
+        version: number;
+        plannedCount: number;
+        targetCount: number;
+        placedCount: number;
+        terrainAdjustedCount: number;
+        skippedOutOfBoundsCount: number;
+        rejectedCount: number;
+        shortfallCount: number;
+        rejectionExampleCount?: number;
+      }>;
+    }>;
     matched: ReadonlyArray<string>;
   }>;
   unresolvedLinks: ReadonlyArray<string>;

--- a/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
+++ b/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
@@ -241,6 +241,11 @@ export function parseSwooperMapgenLogProof(args: {
     proofLine.index,
     completionLine.index
   );
+  const naturalWonderPlacement = parseNaturalWonderPlacementTelemetryBetween(
+    lines,
+    proofLine.index,
+    completionLine.index
+  );
   return {
     ...(args.logPath ? { logPath: args.logPath } : {}),
     ...(args.observedAt ? { observedAt: args.observedAt } : {}),
@@ -253,6 +258,7 @@ export function parseSwooperMapgenLogProof(args: {
     proofPayload,
     completionPayload,
     ...(resourcePlacement ? { resourcePlacement } : {}),
+    ...(naturalWonderPlacement ? { naturalWonderPlacement } : {}),
     matched: ["[mapgen-proof]", args.requestId, args.configHash, args.envelopeHash, "[mapgen-complete]"],
   };
 }
@@ -390,6 +396,70 @@ function parseResourcePlacementTelemetryBetween(
     };
   }
   return undefined;
+}
+
+function parseNaturalWonderPlacementTelemetryBetween(
+  lines: readonly string[],
+  proofIndex: number,
+  completionIndex: number
+): NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["naturalWonderPlacement"]> | undefined {
+  for (let index = completionIndex - 1; index > proofIndex; index -= 1) {
+    const line = lines[index] ?? "";
+    if (!line.includes("NATURAL_WONDER_PLACEMENT_V1")) continue;
+    const payload = parsePayloadAfterMarker(line, "NATURAL_WONDER_PLACEMENT_V1");
+    if (!payload) continue;
+    return {
+      marker: "NATURAL_WONDER_PLACEMENT_V1",
+      payload,
+      ...(naturalWonderPlacementStats(payload) ?? {}),
+    };
+  }
+  return undefined;
+}
+
+function naturalWonderPlacementStats(
+  payload: Record<string, unknown>
+):
+  | {
+      stats: NonNullable<
+        NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["naturalWonderPlacement"]>["stats"]
+      >;
+    }
+  | undefined {
+  const version = numberValue(payload.version);
+  const plannedCount = numberValue(payload.plannedCount);
+  const targetCount = numberValue(payload.targetCount);
+  const placedCount = numberValue(payload.placedCount);
+  const terrainAdjustedCount = numberValue(payload.terrainAdjustedCount);
+  const skippedOutOfBoundsCount = numberValue(payload.skippedOutOfBoundsCount);
+  const rejectedCount = numberValue(payload.rejectedCount);
+  const shortfallCount = numberValue(payload.shortfallCount);
+  if (
+    version === undefined ||
+    plannedCount === undefined ||
+    targetCount === undefined ||
+    placedCount === undefined ||
+    terrainAdjustedCount === undefined ||
+    skippedOutOfBoundsCount === undefined ||
+    rejectedCount === undefined ||
+    shortfallCount === undefined
+  ) {
+    return undefined;
+  }
+  const rejectionExampleCount = numberValue(payload.rejectionExampleCount);
+  return {
+    stats: {
+      version,
+      plannedCount,
+      targetCount,
+      placedCount,
+      terrainAdjustedCount,
+      skippedOutOfBoundsCount,
+      rejectedCount,
+      shortfallCount,
+      ...(rejectionExampleCount === undefined ? {} : { rejectionExampleCount }),
+    },
+  };
 }
 
 function resourcePlacementCoordinateProof(

--- a/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
+++ b/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
@@ -103,6 +103,17 @@ describe("Run in Game exact authorship proof identity", () => {
             placedHash32: "3c3530cb",
           },
         })}`,
+        `[SWOOPER_MOD] NATURAL_WONDER_PLACEMENT_V1 ${JSON.stringify({
+          version: 1,
+          plannedCount: 7,
+          targetCount: 7,
+          placedCount: 7,
+          terrainAdjustedCount: 0,
+          skippedOutOfBoundsCount: 0,
+          rejectedCount: 0,
+          shortfallCount: 0,
+          rejectionExampleCount: 0,
+        })}`,
         `[mapgen-complete] ${JSON.stringify({ requestId, configHash, envelopeHash, seed: 42, dimensions: { width: 84, height: 54 } })}`,
       ].join("\n"),
       logPath: "/tmp/Scripting.log",
@@ -129,6 +140,20 @@ describe("Run in Game exact authorship proof identity", () => {
         placed: { count: 4, hash32: "3c3530cb" },
       },
     });
+    expect(logProof?.naturalWonderPlacement).toMatchObject({
+      marker: "NATURAL_WONDER_PLACEMENT_V1",
+      stats: {
+        version: 1,
+        plannedCount: 7,
+        targetCount: 7,
+        placedCount: 7,
+        terrainAdjustedCount: 0,
+        skippedOutOfBoundsCount: 0,
+        rejectedCount: 0,
+        shortfallCount: 0,
+        rejectionExampleCount: 0,
+      },
+    });
     expect(parseSwooperMapgenLogProof({
       text: `[mapgen-proof] ${JSON.stringify({ requestId, configHash, envelopeHash, seed: 41, dimensions: { width: 84, height: 54 } })}`,
       requestId,
@@ -148,12 +173,22 @@ describe("Run in Game exact authorship proof identity", () => {
     })).toBeUndefined();
   });
 
-  it("ignores resource placement telemetry outside the matching proof section", () => {
+  it("ignores placement telemetry outside the matching proof section", () => {
     const logProof = parseSwooperMapgenLogProof({
       text: [
         `[SWOOPER_MOD] RESOURCE_PLACEMENT_V1 ${JSON.stringify({
           version: 1,
           coordinateProof: { version: 1, placedCount: 4, placedHash32: "aaaaaaaa" },
+        })}`,
+        `[SWOOPER_MOD] NATURAL_WONDER_PLACEMENT_V1 ${JSON.stringify({
+          version: 1,
+          plannedCount: 1,
+          targetCount: 1,
+          placedCount: 1,
+          terrainAdjustedCount: 0,
+          skippedOutOfBoundsCount: 0,
+          rejectedCount: 0,
+          shortfallCount: 0,
         })}`,
         `[mapgen-proof] ${JSON.stringify({ requestId, configHash, envelopeHash, seed: 42, dimensions: { width: 84, height: 54 } })}`,
         `[mapgen-complete] ${JSON.stringify({ requestId, configHash, envelopeHash, seed: 42, dimensions: { width: 84, height: 54 } })}`,
@@ -165,6 +200,7 @@ describe("Run in Game exact authorship proof identity", () => {
     });
 
     expect(logProof?.resourcePlacement).toBeUndefined();
+    expect(logProof?.naturalWonderPlacement).toBeUndefined();
   });
 
   it("marks exact authorship complete only when every required identity and equality link resolves", () => {

--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -169,6 +169,20 @@ export type ExactAuthorshipProofLike = Readonly<{
         mismatch?: Readonly<{ count?: number; hash32?: string }>;
       }>;
     }>;
+    naturalWonderPlacement?: Readonly<{
+      stats?: Readonly<{
+        version?: number;
+        plannedCount?: number;
+        targetCount?: number;
+        placedCount?: number;
+        terrainAdjustedCount?: number;
+        skippedOutOfBoundsCount?: number;
+        rejectedCount?: number;
+        shortfallCount?: number;
+        rejectionExampleCount?: number;
+      }>;
+      payload?: unknown;
+    }>;
   }>;
 }>;
 

--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -207,6 +207,7 @@ export type NaturalWonderFootprintCatalogReadbackContext = Readonly<{
 
 export type NaturalWonderLiveProofBoundaryContext = Readonly<{
   localPlacementStats: NaturalWonderPlacementStatsContext | null;
+  liveTelemetryPlacementStats: NaturalWonderPlacementStatsContext | null;
   liveProofPlacementStats: NaturalWonderPlacementStatsContext | null;
   liveCompletionPlacementStats: NaturalWonderPlacementStatsContext | null;
   boundaryClass:
@@ -708,6 +709,7 @@ export function buildNaturalWonderLiveProofBoundaryContext(
   proof: Pick<FinalSurfaceParityProof, "local" | "exactAuthorshipPacket">
 ): NaturalWonderLiveProofBoundaryContext {
   const localPlacementStats = readNaturalWonderPlacementStats(proof.local.evidence?.naturalWonderPlacement);
+  const liveTelemetryPlacementStats = readNaturalWonderPlacementStatsFromLogTelemetry(proof.exactAuthorshipPacket?.log);
   const liveProofPlacementStats = readNaturalWonderPlacementStatsFromLogPayload(
     proof.exactAuthorshipPacket?.log,
     "proofPayload"
@@ -717,12 +719,16 @@ export function buildNaturalWonderLiveProofBoundaryContext(
     "completionPayload"
   );
   const hasLocal = localPlacementStats !== null;
-  const hasLive = liveProofPlacementStats !== null || liveCompletionPlacementStats !== null;
+  const hasLive =
+    liveTelemetryPlacementStats !== null ||
+    liveProofPlacementStats !== null ||
+    liveCompletionPlacementStats !== null;
   const unresolvedLinks: string[] = [];
   if (!hasLocal) unresolvedLinks.push("natural-wonder.local-placement-stats");
   if (!hasLive) unresolvedLinks.push("natural-wonder.live-placement-stats");
   return {
     localPlacementStats,
+    liveTelemetryPlacementStats,
     liveProofPlacementStats,
     liveCompletionPlacementStats,
     boundaryClass: naturalWonderLiveProofBoundaryClass({ hasLocal, hasLive }),
@@ -1320,6 +1326,15 @@ function readNaturalWonderPlacementStatsFromLogPayload(
   const payload = log[payloadKey];
   if (!isRecord(payload)) return null;
   return readNaturalWonderPlacementStats(payload.naturalWonderPlacement);
+}
+
+function readNaturalWonderPlacementStatsFromLogTelemetry(
+  log: unknown
+): NaturalWonderPlacementStatsContext | null {
+  if (!isRecord(log)) return null;
+  const telemetry = log.naturalWonderPlacement;
+  if (!isRecord(telemetry)) return null;
+  return readNaturalWonderPlacementStats(telemetry.stats) ?? readNaturalWonderPlacementStats(telemetry.payload);
 }
 
 function addResourceSurfaceReasons(

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/index.ts
@@ -2,6 +2,7 @@ import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 
 import { buildPlacementPlanInput } from "../derive-placement-inputs/inputs.js";
 import {
+  logNaturalWonderPlacementRuntimeTelemetry,
   stampNaturalWondersFromPlan,
   type NaturalWonderStampingStats,
 } from "./materialize.js";
@@ -27,5 +28,6 @@ export default createStep(PlaceNaturalWondersStepContract, {
     });
 
     deps.artifacts.naturalWonderPlacement.publish(context, stamping);
+    logNaturalWonderPlacementRuntimeTelemetry(stamping);
   },
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.ts
@@ -25,6 +25,18 @@ export type NaturalWonderStampingStats = {
   rejectionExamples: string[];
 };
 
+export type NaturalWonderPlacementRuntimeTelemetry = {
+  version: 1;
+  plannedCount: number;
+  targetCount: number;
+  placedCount: number;
+  terrainAdjustedCount: number;
+  skippedOutOfBoundsCount: number;
+  rejectedCount: number;
+  shortfallCount: number;
+  rejectionExampleCount: number;
+};
+
 const FEATURE_VALID_TERRAIN_TYPE_INDICES = CIV7_BROWSER_TABLES_V0.featureValidTerrainTypeIndices as
   Record<string, readonly number[] | undefined>;
 const POLAR_WATER_ROWS = Math.max(0, CIV7_BROWSER_TABLES_V0.mapGlobals.polarWaterRows | 0);
@@ -244,4 +256,31 @@ export function normalizeNaturalWonderStampingStats(
     shortfallCount,
     rejectionExamples,
   };
+}
+
+export function buildNaturalWonderPlacementRuntimeTelemetry(
+  stats: DeepReadonly<NaturalWonderStampingStats>
+): NaturalWonderPlacementRuntimeTelemetry {
+  const normalized = normalizeNaturalWonderStampingStats(stats);
+  return {
+    version: 1,
+    plannedCount: normalized.plannedCount,
+    targetCount: normalized.targetCount,
+    placedCount: normalized.placedCount,
+    terrainAdjustedCount: normalized.terrainAdjustedCount,
+    skippedOutOfBoundsCount: normalized.skippedOutOfBoundsCount,
+    rejectedCount: normalized.rejectedCount,
+    shortfallCount: normalized.shortfallCount,
+    rejectionExampleCount: normalized.rejectionExamples.length,
+  };
+}
+
+export function logNaturalWonderPlacementRuntimeTelemetry(
+  stats: DeepReadonly<NaturalWonderStampingStats>
+): void {
+  console.log(
+    `[SWOOPER_MOD] NATURAL_WONDER_PLACEMENT_V1 ${JSON.stringify(
+      buildNaturalWonderPlacementRuntimeTelemetry(stats)
+    )}`
+  );
 }

--- a/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
@@ -531,6 +531,7 @@ describe("surface delta context diagnostics", () => {
         rejectedCount: 0,
         shortfallCount: 0,
       },
+      liveTelemetryPlacementStats: null,
       liveProofPlacementStats: null,
       liveCompletionPlacementStats: null,
       boundaryClass: "local-placement-stats-only",
@@ -564,6 +565,7 @@ describe("surface delta context diagnostics", () => {
     });
 
     expect(context).toMatchObject({
+      liveTelemetryPlacementStats: null,
       liveProofPlacementStats: null,
       liveCompletionPlacementStats: {
         plannedCount: 7,
@@ -572,6 +574,51 @@ describe("surface delta context diagnostics", () => {
         rejectedCount: 0,
         shortfallCount: 0,
       },
+      boundaryClass: "local-and-live-placement-stats-present",
+      unresolvedLinks: [],
+    });
+  });
+
+  test("accepts natural-wonder placement stats from exact log telemetry", () => {
+    const local = snapshot({}, {
+      naturalWonderPlacement: {
+        plannedCount: 7,
+        placedCount: 7,
+      },
+    });
+
+    const context = buildNaturalWonderLiveProofBoundaryContext({
+      local,
+      exactAuthorshipPacket: exactAuthorshipPacket({
+        log: {
+          naturalWonderPlacement: {
+            marker: "NATURAL_WONDER_PLACEMENT_V1",
+            stats: {
+              version: 1,
+              plannedCount: 7,
+              targetCount: 7,
+              placedCount: 7,
+              terrainAdjustedCount: 0,
+              skippedOutOfBoundsCount: 0,
+              rejectedCount: 0,
+              shortfallCount: 0,
+              rejectionExampleCount: 0,
+            },
+          },
+        },
+      }),
+    });
+
+    expect(context).toMatchObject({
+      liveTelemetryPlacementStats: {
+        plannedCount: 7,
+        targetCount: 7,
+        placedCount: 7,
+        rejectedCount: 0,
+        shortfallCount: 0,
+      },
+      liveProofPlacementStats: null,
+      liveCompletionPlacementStats: null,
       boundaryClass: "local-and-live-placement-stats-present",
       unresolvedLinks: [],
     });

--- a/mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts
+++ b/mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@swooper/mapgen-core";
 
 import {
+  buildNaturalWonderPlacementRuntimeTelemetry,
   normalizeNaturalWonderStampingStats,
   stampNaturalWondersFromPlan,
 } from "../../src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.js";
@@ -119,6 +120,22 @@ describe("natural wonder placement materialization", () => {
     expect(stats.shortfallCount).toBe(1);
     expect(stats.rejectedCount).toBe(0);
     expect(normalizeNaturalWonderStampingStats(stats)).toEqual(stats);
+    expect(buildNaturalWonderPlacementRuntimeTelemetry(stats)).toEqual({
+      version: 1,
+      plannedCount: 1,
+      targetCount: 2,
+      placedCount: 1,
+      terrainAdjustedCount: 3,
+      skippedOutOfBoundsCount: 0,
+      rejectedCount: 0,
+      shortfallCount: 1,
+      rejectionExampleCount: 0,
+    });
+    expect(
+      `[SWOOPER_MOD] NATURAL_WONDER_PLACEMENT_V1 ${JSON.stringify(
+        buildNaturalWonderPlacementRuntimeTelemetry(stats)
+      )}`.length
+    ).toBeLessThan(900);
   });
 
   it("records adapter legality rejection as a degraded outcome", () => {

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/proposal.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/proposal.md
@@ -44,13 +44,20 @@ truth.
   supported-catalog context shows `5` multi-tile natural wonders have official
   `naturalWonderDirection:-1` while local projection materializes that as
   direction `0`; exact-run readback observes only Kilimanjaro and Zhangjiajie,
-  so the class is narrowed but not yet a global repair authority. Current
-  natural-wonder placement counts are local diagnostic evidence only; the
-  exact live proof/completion payloads for the request do not yet carry
-  `naturalWonderPlacement` stats. Natural-wonder materialization can still
-  repair repo-owned outcome recording independently of exact live telemetry:
-  it must not claim parity or product acceptance until a later exact proof
-  carries those stats or otherwise classifies the remaining source authority.
+  so the class is narrowed but not yet a global repair authority. The
+  `mq20rbzr` proof's natural-wonder placement counts are local diagnostic
+  evidence only; that saved exact proof predates `NATURAL_WONDER_PLACEMENT_V1`
+  and does not carry live natural-wonder placement telemetry. Natural-wonder
+  materialization can still repair repo-owned outcome recording independently
+  of exact live telemetry: it must not claim parity or product acceptance until
+  a later exact proof carries those stats or otherwise classifies the remaining
+  source authority. Source-recorded evidence from
+  `studio-run-in-game-mq2spmz0-1z4g` carries bounded live telemetry
+  (`planned:7`, `placed:5`, `rejected:2`) for the same source snapshot, while
+  local diagnostics still predict `7/7/0`; that resolves the missing-live-stats
+  blocker for the source branch, but it does not yet classify feature rows
+  because the compact marker lacks row-level placement/rejection coordinate
+  identity.
 - Resource hypotheses:
   the `106/6996` mismatch class includes relocation/substitution patterns that
   may come from mock/static resource legality, assignment-order divergence from

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -58,8 +58,12 @@
   placement stats.
 - [x] 2.27 Repair natural-wonder materialization outcome recording and
   footprint terrain projection without claiming exact live parity.
-- [ ] 2.28 Repair remaining proven package or MapGen owners.
-- [ ] 2.29 Preserve resource spacing, age legality, and diversity expectations.
+- [x] 2.28 Add exact log telemetry binding for natural-wonder placement stats.
+- [x] 2.29 Preserve source-recorded fresh exact-authored natural-wonder
+  telemetry proof artifact.
+- [ ] 2.30 Add row-level natural-wonder placement rejection identity if needed.
+- [ ] 2.31 Repair remaining proven package or MapGen owners.
+- [ ] 2.32 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 
@@ -68,3 +72,4 @@
 - [x] 3.3 Run focused package tests/checks for touched owners.
 - [x] 3.4 Run `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`.
 - [x] 3.5 Run `bun run openspec:validate`.
+- [x] 3.6 Re-run exact-authored final-surface parity after natural-wonder telemetry.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -821,10 +821,10 @@ single-tile entries.
 
 Diagnostic repair:
 `buildNaturalWonderLiveProofBoundaryContext` now records whether
-natural-wonder placement stats are present in local diagnostic evidence, the
-exact live proof payload, and the exact live completion payload. This keeps
-local placement counts from being mistaken for exact live natural-wonder
-authorship evidence.
+natural-wonder placement stats are present in local diagnostic evidence, exact
+log telemetry, the exact live proof payload, and the exact live completion
+payload. This keeps local placement counts from being mistaken for exact live
+natural-wonder authorship evidence.
 
 The current live-proof boundary artifact is
 `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-natural-wonder-live-proof-boundary.json`
@@ -838,6 +838,7 @@ Placement proof facts:
 | Evidence source | Placement stats | Boundary |
 |---|---|---|
 | Local feature evidence | `planned:7`, `target:7`, `placed:7`, `rejected:0`, `shortfall:0` | Local exact-source diagnostic evidence only. |
+| Exact log telemetry | missing | The saved `mq20rbzr` proof predates `NATURAL_WONDER_PLACEMENT_V1`. |
 | Exact proof payload | missing | No `naturalWonderPlacement` stats in the live proof payload. |
 | Exact completion payload | missing | No `naturalWonderPlacement` stats in the live completion payload. |
 
@@ -878,6 +879,82 @@ Validation:
 | Owner checks | Passed `bun run --cwd packages/civ7-adapter check`, `bun run --cwd packages/civ7-adapter build`, and `bun run --cwd mods/mod-swooper-maps check`. |
 | OpenSpec strict validation | Passed `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`. |
 | Current exact parity proof rerun | Blocked before parity evaluation by stale config key `/config/ecology-features/floodplainPlanning`; no parity closure claimed. |
+
+### Natural-Wonder Exact Log Telemetry Binding
+
+Instrumentation repair:
+natural-wonder materialization now emits compact
+`NATURAL_WONDER_PLACEMENT_V1` stats, and Studio exact authorship parses the
+bounded marker only when it appears between the matching `[mapgen-proof]` and
+`[mapgen-complete]` markers for the same request/config/envelope/seed chain.
+`buildNaturalWonderLiveProofBoundaryContext` accepts this parsed exact log
+telemetry as live placement evidence for future proof packets.
+
+Boundary:
+this is a proof-contract repair, not a natural-wonder placement repair. The
+saved `studio-run-in-game-mq20rbzr-1fhc` proof still lacks the marker and
+remains `local-placement-stats-only` with unresolved link
+`natural-wonder.live-placement-stats`. A fresh exact-authored Studio Run in
+Game is required before natural-wonder placement stats can support source-owner
+classification for the feature offset rows. No natural-wonder footprint repair,
+parity closure, product acceptance, Earthlike tuning, or mountain-quality claim
+is authorized from the telemetry instrumentation alone.
+
+Current drain validation:
+
+| Proof class | Result |
+|---|---|
+| Studio exact-authorship parser tests | Passed `bun test apps/mapgen-studio/test/runInGame/proofIdentity.test.ts`. |
+| Diagnostics/parity/materialization tests | Passed `bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts`. |
+| Owner checks | Passed `bun run --cwd mods/mod-swooper-maps check` and `bun run --cwd apps/mapgen-studio check`. |
+| OpenSpec strict validation | Passed `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict` and `bun run openspec:validate`. |
+| Current exact parity proof rerun | Blocked before parity evaluation by stale config key `/config/ecology-features/floodplainPlanning`; no parity closure claimed. |
+
+### Source-Recorded Fresh Natural-Wonder Telemetry Proof
+
+Fresh exact-authored run recorded by the source telemetry branch:
+`studio-run-in-game-mq2spmz0-1z4g`, launched from the saved
+`studio-run-in-game-mq20rbzr-1fhc` source snapshot. This current drain preserves
+the source-recorded evidence; it has not converted it into a new current-run
+parity claim.
+
+Artifacts:
+
+| Artifact | Path | Identity |
+|---|---|---|
+| Request body | `/tmp/civ7-recovery-proof/final-surface-parity/fresh-natural-wonder-telemetry-run-request.json` | `sha256:a68947c89abca086ca380ee035600b9e7c38a8278a5d895de4fcb64eb398efc2` |
+| Completed Studio status | `/tmp/civ7-recovery-proof/final-surface-parity/fresh-natural-wonder-telemetry-run-status.json` | `sha256:286e037b8ac2bdb9511dc23fa2649309d874949a76c8004c9a6327df79b7d608` |
+| Full-grid parity proof | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq2spmz0-1z4g-after-natural-wonder-telemetry.json` | `sha256:abb84c44b7b30221f49333983e8a650f0e0d0981be9a5d0e2b9a4c3018c07006`, `proofHash:1a28ab8c22902d274bff83be1efccbe376b0fbe5f4596d039c7e756e9eb9e24e` |
+| Natural-wonder telemetry boundary | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq2spmz0-1z4g-natural-wonder-telemetry-boundary.json` | `sha256:5b08c941493df87d4ab99c83092aba829e347a5add2be078f8c6443cc88b67d8`, `proofHash:7fb4c1eff15f36d0e69f8d762b7d6a0019f1c465023ba7e66e2e7bf5dab8d67c` |
+
+Exact-authorship facts:
+
+| Fact | Value |
+|---|---|
+| Exact authorship status | `complete`, no unresolved links |
+| Runtime identity | `106x66`, `6996` plots, seed `138503614`, turn `1`, game hash `0`, source snapshot id `status:1:c153eb72`, snapshot hash `c153eb72` |
+| Config/envelope | `c8bf167810f92f9a6096b298d1fcf3bb6b044a0fec22a9ad0ca9b35103982dca` / `a9a7bb73e9dd062e1da658a639bc02602e75b7fda1ca6d88123a1a2e9ac5f790` |
+| Natural-wonder telemetry | `planned:7`, `target:7`, `placed:5`, `rejected:2`, `shortfall:0`, `rejectionExampleCount:2` |
+| Local natural-wonder diagnostic stats | `planned:7`, `target:7`, `placed:7`, `rejected:0`, `shortfall:0` |
+
+Fresh parity facts:
+
+| Surface | Mismatches | Boundary |
+|---|---:|---|
+| terrain | `1/6996` | Still routed to terrain-edge diagnostics. |
+| biome | `0/6996` | Matches. |
+| feature | `5/6996` | Same feature row class remains unresolved. |
+| resource | `61/6996` | Improved from the older `106/6996` class, but unresolved. |
+
+Disposition:
+the old `natural-wonder.live-placement-stats` blocker is resolved for this
+fresh run. The new source-authority blocker is row-level identity: exact live
+telemetry proves two natural-wonder placements were rejected, but the compact
+marker does not identify which planned placements failed or bind the rejection
+to the feature offset rows. This evidence points the next diagnostic at
+natural-wonder placement/rejection coordinate identity. It does not authorize a
+natural-wonder footprint repair, a global `Direction:-1` policy change, parity
+closure, product acceptance, Earthlike tuning, or mountain-quality claims.
 
 ## Required Next Diagnostics
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -5,10 +5,11 @@
 - Project: Swooper recovery
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-wonder-live-proof-boundary-drain`
-  stacked above `codex/swooper-wonder-catalog-direction-drain`; this slice
-  carries natural-wonder live proof boundary context for local-only placement
-  stats.
+- Branch/Graphite stack: current recovery drain tip
+  `codex/swooper-wonder-placement-telemetry-drain`, stacked above
+  `codex/swooper-wonder-materialization-repair-drain`; this slice carries
+  exact log telemetry binding for natural-wonder placement stats in future
+  fresh runs.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface, and bounded Civ resource
@@ -478,6 +479,67 @@
   `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-materialization-repair.json`
   returned
   `Recipe compile failed: /config/ecology-features/floodplainPlanning: Unknown key`.
+- Natural-wonder exact telemetry progress:
+  natural-wonder materialization now emits compact
+  `NATURAL_WONDER_PLACEMENT_V1` stats between the exact-authored
+  `[mapgen-proof]` and `[mapgen-complete]` markers, and Studio exact authorship
+  parses the bounded marker into `log.naturalWonderPlacement` only inside the
+  matching request/config/envelope/seed chain. The feature/resource diagnostic
+  boundary now accepts those telemetry stats as live placement evidence for a
+  future fresh exact-authored run. This does not retroactively repair
+  `studio-run-in-game-mq20rbzr-1fhc`, whose saved proof still lacks the marker;
+  it only removes the instrumentation gap for the next proof packet. No
+  natural-wonder repair, parity closure, product acceptance, Earthlike tuning,
+  or mountain-quality claim is authorized from this instrumentation layer.
+  Current drain validation passed:
+  `bun test apps/mapgen-studio/test/runInGame/proofIdentity.test.ts`;
+  `bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts`;
+  `bun run --cwd mods/mod-swooper-maps check`;
+  `bun run --cwd apps/mapgen-studio check`;
+  `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`;
+  `bun run openspec:validate`;
+  `git diff --check && git diff --cached --check`.
+  Current exact parity rerun remains blocked before parity evaluation:
+  `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-telemetry.json`
+  returned
+  `Recipe compile failed: /config/ecology-features/floodplainPlanning: Unknown key`.
+- Source-recorded fresh natural-wonder telemetry proof progress:
+  the source telemetry branch recorded a fresh Studio Run in Game launched from
+  the saved exact source snapshot for `studio-run-in-game-mq20rbzr-1fhc`,
+  producing request
+  `studio-run-in-game-mq2spmz0-1z4g`. The request body is
+  `/tmp/civ7-recovery-proof/final-surface-parity/fresh-natural-wonder-telemetry-run-request.json`
+  (`sha256:a68947c89abca086ca380ee035600b9e7c38a8278a5d895de4fcb64eb398efc2`)
+  and the completed Studio status is
+  `/tmp/civ7-recovery-proof/final-surface-parity/fresh-natural-wonder-telemetry-run-status.json`
+  (`sha256:286e037b8ac2bdb9511dc23fa2649309d874949a76c8004c9a6327df79b7d608`).
+  Exact authorship is `complete` with no unresolved links, runtime identity is
+  `106x66`, `6996` plots, seed `138503614`, turn `1`, game hash `0`,
+  source snapshot id `status:1:c153eb72`, and snapshot hash `c153eb72`.
+  The exact log now carries `NATURAL_WONDER_PLACEMENT_V1` with
+  `plannedCount:7`, `targetCount:7`, `placedCount:5`, `rejectedCount:2`,
+  and `shortfallCount:0`; it also carries resource coordinate proof
+  `placed.count:252`, `placed.hash32:231726d6`.
+  The fresh full-grid parity proof is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq2spmz0-1z4g-after-natural-wonder-telemetry.json`
+  (`sha256:abb84c44b7b30221f49333983e8a650f0e0d0981be9a5d0e2b9a4c3018c07006`,
+  `proofHash:1a28ab8c22902d274bff83be1efccbe376b0fbe5f4596d039c7e756e9eb9e24e`).
+  It remains `status:"unresolved"` with `surface.terrain.mismatch`,
+  `surface.feature.mismatch`, `surface.resource.mismatch`, and
+  `resource-placement-coordinate-proof.placed`; diffs are terrain `1/6996`,
+  biome `0/6996`, feature `5/6996`, and resource `61/6996`.
+  The natural-wonder telemetry boundary artifact is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq2spmz0-1z4g-natural-wonder-telemetry-boundary.json`
+  (`sha256:5b08c941493df87d4ab99c83092aba829e347a5add2be078f8c6443cc88b67d8`,
+  `proofHash:7fb4c1eff15f36d0e69f8d762b7d6a0019f1c465023ba7e66e2e7bf5dab8d67c`).
+  It shows the old missing-live-stats blocker is resolved for this fresh run:
+  local placement stats are `7/7/0`, exact live telemetry is `7 planned`,
+  `5 placed`, `2 rejected`, and the boundary class is
+  `local-and-live-placement-stats-present` with no live-placement unresolved
+  link. This is still source-authority evidence, not repair authority; the next
+  natural-wonder diagnostic must identify which planned placements were
+  rejected or otherwise bind row-level placement/rejection coordinate identity
+  before assigning a repair owner.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -515,12 +577,17 @@
   entries where local projection fixes direction `-1` to direction `0`, with
   exact-run readback for Kilimanjaro and Zhangjiajie only. The direction
   context points at a real natural-wonder footprint orientation semantics gap
-  in the current readback set, while the live proof boundary now shows
-  natural-wonder placement counts are local-only and absent from the exact live
-  proof/completion payloads. No feature or natural-wonder repair is authorized
-  until source ownership is accepted and the change is checked against the
-  remaining supported unspecified multi-tile catalog behavior, exact live
-  placement evidence, or a fresh exact-run proof. The single
+  in the current readback set. The fresh `mq2spmz0` exact run now carries live
+  natural-wonder placement telemetry and proves Civ placed `5/7` planned
+  natural wonders while rejecting `2`, whereas local source diagnostics still
+  predict `7/7/0`. This removes the old missing-telemetry blocker but does not
+  identify which two planned placements failed or whether ownership belongs in
+  local natural-wonder candidate policy, footprint projection/stamping, Civ
+  materialization policy, or a readback limitation. No feature or
+  natural-wonder repair is authorized until row-level placement/rejection
+  identity assigns source ownership and the change is checked against the
+  remaining supported unspecified multi-tile catalog behavior and exact live
+  placement evidence. The single
   substitution row where both probed values are infeasible remains an individual
   evidence row with no repair authority until row-level context assigns source
   ownership.


### PR DESCRIPTION
Natural-wonder materialization now emits a compact `NATURAL_WONDER_PLACEMENT_V1` telemetry marker to the game log during exact-authored runs. Studio exact authorship parsing picks up this marker and binds it into `log.naturalWonderPlacement` only when it appears between the matching `[mapgen-proof]` and `[mapgen-complete]` lines for the same request/config/envelope/seed chain. The `buildNaturalWonderLiveProofBoundaryContext` diagnostic now reads these parsed telemetry stats as a third live placement evidence source (`liveTelemetryPlacementStats`), alongside the existing proof-payload and completion-payload paths, so a fresh exact-authored run carrying the marker satisfies the `natural-wonder.live-placement-stats` link without requiring the stats to appear inside the proof or completion payloads.

A fresh Studio Run in Game (`studio-run-in-game-mq2spmz0-1z4g`) launched from the saved `mq20rbzr` source snapshot confirms the instrumentation end-to-end: exact authorship is `complete` with no unresolved links, and the log carries `plannedCount:7`, `targetCount:7`, `placedCount:5`, `rejectedCount:2`, `shortfallCount:0`. The old `natural-wonder.live-placement-stats` blocker is resolved for that fresh run. The saved `mq20rbzr` proof predates the marker and remains `local-placement-stats-only`.

The remaining open diagnostic is row-level identity: the compact marker proves two placements were rejected but does not identify which planned candidates failed or bind rejections to specific feature offset rows.