### PR TITLE
fix(natural-wonder-placement): resolve materialization direction explicitly before planning to align local footprint validation with live Civ write path

### DIFF
--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/inputs.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/inputs.ts
@@ -1,7 +1,11 @@
 import type { ExtendedMapContext } from "@swooper/mapgen-core";
 import type { DeepReadonly, Static, StepRuntimeOps } from "@swooper/mapgen-core/authoring";
 import type { DiscoveryCatalogEntry } from "@civ7/adapter";
-import { CIV7_BROWSER_TABLES_V0, getNaturalWonderFootprintOffsets } from "@civ7/map-policy";
+import {
+  CIV7_BROWSER_TABLES_V0,
+  getNaturalWonderFootprintOffsets,
+  resolveNaturalWonderMaterializationDirection,
+} from "@civ7/map-policy";
 import placement from "@mapgen/domain/placement";
 import type { PlacementInputsV1 } from "../../placement-inputs.js";
 import { getStandardRuntime } from "../../../../runtime.js";
@@ -141,9 +145,13 @@ export function buildPlacementInputs(
   const naturalWonderCatalog = context.adapter.getNaturalWonderCatalog().map((entry) => {
     const featureType = entry.featureType | 0;
     const policy = FEATURE_POLICIES[String(featureType)];
+    const materializationDirection = resolveNaturalWonderMaterializationDirection(
+      policy ?? {},
+      entry.direction | 0
+    );
     return {
       featureType,
-      direction: entry.direction | 0,
+      direction: materializationDirection,
       validTerrainTypes: [...(FEATURE_VALID_TERRAIN_TYPE_INDICES[String(featureType)] ?? [])],
       validBiomeTypes: [...(FEATURE_VALID_BIOME_TYPE_INDICES[String(featureType)] ?? [])],
       ...(policy?.minimumElevation !== undefined
@@ -154,7 +162,7 @@ export function buildPlacementInputs(
       ...(policy?.naturalWonderTiles ? { naturalWonderTiles: policy.naturalWonderTiles } : {}),
       featureTags: [...(FEATURE_TAGS_BY_FEATURE_TYPE[String(featureType)] ?? [])],
       footprintOffsets: [
-        ...(getNaturalWonderFootprintOffsets(policy ?? {}, entry.direction | 0) ?? []),
+        ...(getNaturalWonderFootprintOffsets(policy ?? {}, materializationDirection) ?? []),
       ],
     };
   });

--- a/mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts
+++ b/mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "bun:test";
+
+import { createMockAdapter } from "@civ7/adapter";
+import { CIV7_BROWSER_TABLES_V0 } from "@civ7/map-policy";
+
+import { initializeStandardRuntime } from "../../src/recipes/standard/runtime.js";
+import { buildPlacementInputs } from "../../src/recipes/standard/stages/placement/steps/derive-placement-inputs/inputs.js";
+
+const { featureTypes, terrainTypeIndices, biomeGlobals } = CIV7_BROWSER_TABLES_V0;
+
+describe("derive placement inputs", () => {
+  it("passes explicit projected natural-wonder direction to materialization planning", () => {
+    const width = 6;
+    const height = 6;
+    const size = width * height;
+    const mapInfo = {
+      GridWidth: width,
+      GridHeight: height,
+      MinLatitude: -60,
+      MaxLatitude: 60,
+      PlayersLandmass1: 1,
+      PlayersLandmass2: 1,
+      StartSectorRows: 1,
+      StartSectorCols: 1,
+      NumNaturalWonders: 1,
+    };
+    const adapter = createMockAdapter({
+      width,
+      height,
+      mapInfo,
+      mapSizeId: 1,
+      defaultTerrainType: terrainTypeIndices.TERRAIN_MOUNTAIN,
+      defaultBiomeType: biomeGlobals.BIOME_PLAINS,
+      naturalWonderCatalog: [
+        { featureType: featureTypes.FEATURE_KILIMANJARO, direction: -1 },
+      ],
+      resourceTypeCatalog: [],
+      discoveryCatalog: [],
+    });
+    const context = {
+      dimensions: { width, height },
+      adapter,
+      buffers: {
+        heightfield: {
+          elevation: new Int16Array(size).fill(500),
+        },
+      },
+    } as never;
+    initializeStandardRuntime(context, { mapInfo });
+
+    let capturedNaturalWonderInput:
+      | { featureCatalog?: ReadonlyArray<{ direction: number; footprintOffsets?: unknown }> }
+      | undefined;
+    const ops = {
+      wonders: () => ({ wondersCount: 1 }),
+      naturalWonders: (input: typeof capturedNaturalWonderInput & {
+        width: number;
+        height: number;
+        wondersCount: number;
+      }) => {
+        capturedNaturalWonderInput = input;
+        return {
+          width: input.width,
+          height: input.height,
+          wondersCount: input.wondersCount,
+          targetCount: 0,
+          plannedCount: 0,
+          placements: [],
+        };
+      },
+      discoveries: () => ({
+        width,
+        height,
+        targetCount: 0,
+        plannedCount: 0,
+        placements: [],
+      }),
+      resources: () => ({
+        width,
+        height,
+        targetCount: 0,
+        plannedCount: 0,
+        placements: [],
+      }),
+      floodplains: () => ({
+        minLength: 4,
+        maxLength: 10,
+      }),
+    } as never;
+
+    buildPlacementInputs(
+      context,
+      {},
+      ops,
+      {
+        topography: { landMask: new Uint8Array(size).fill(1) },
+        hydrography: { riverClass: new Uint8Array(size) },
+        lakePlan: { lakeMask: new Uint8Array(size) },
+        biomeClassification: {
+          effectiveMoisture: new Float32Array(size).fill(0.5),
+          surfaceTemperature: new Float32Array(size).fill(0.5),
+          aridityIndex: new Float32Array(size).fill(0.5),
+        },
+        pedology: { fertility: new Float32Array(size).fill(0.5) },
+      }
+    );
+
+    expect(capturedNaturalWonderInput?.featureCatalog).toHaveLength(1);
+    expect(capturedNaturalWonderInput?.featureCatalog?.[0]).toMatchObject({
+      direction: 0,
+      footprintOffsets: [
+        { dx: 0, dy: 0 },
+        { dx: 1, dy: 1 },
+        { dx: 1, dy: 0 },
+      ],
+    });
+  });
+});

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/proposal.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/proposal.md
@@ -70,7 +70,11 @@ truth.
   the same exact-authored request rejects that adapter readback path and leaves
   the final feature footprint on an alternate supported direction. Repair
   authority is limited to that owner surface and must not become product
-  tuning, a global catalog rewrite, or acceptance closure.
+  tuning, a global catalog rewrite, or acceptance closure. Current repair keeps
+  official `naturalWonderDirection:-1` as catalog evidence but resolves it to
+  the explicit local projection direction before planning/materialization, so
+  local validation and live writes use the same direction contract instead of
+  letting Civ choose an unspecified footprint at write time.
 - Resource hypotheses:
   the `106/6996` mismatch class includes relocation/substitution patterns that
   may come from mock/static resource legality, assignment-order divergence from

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -67,10 +67,12 @@
   coordinate proof artifact.
 - [x] 2.32 Classify natural-wonder rejected-placement source ownership from
   fresh coordinate proof.
-- [ ] 2.33 Repair the proven natural-wonder footprint projection/materialization
+- [x] 2.33 Repair the proven natural-wonder footprint projection/materialization
   owner without widening to product tuning.
-- [ ] 2.34 Repair remaining proven package or MapGen owners.
-- [ ] 2.35 Preserve resource spacing, age legality, and diversity expectations.
+- [ ] 2.34 Produce fresh exact-authored parity proof after the natural-wonder
+  projection/materialization repair.
+- [ ] 2.35 Repair remaining proven package or MapGen owners.
+- [ ] 2.36 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 
@@ -80,3 +82,5 @@
 - [x] 3.4 Run `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`.
 - [x] 3.5 Run `bun run openspec:validate`.
 - [x] 3.6 Re-run exact-authored final-surface parity after natural-wonder telemetry.
+- [ ] 3.7 Re-run exact-authored final-surface parity after natural-wonder
+  projection/materialization repair.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1067,6 +1067,41 @@ by focused tests plus a fresh exact-authored final-surface proof. This
 classification does not close feature parity, natural-wonder product behavior,
 Earthlike acceptance, mountain quality, or global `Direction:-1` semantics.
 
+### Natural-Wonder Projection/Materialization Repair
+
+Repair:
+the map-policy package now exposes a separate materialization-direction helper.
+The official catalog direction remains `-1` for evidence and policy records,
+but the placement-input derivation resolves that value to the explicit local
+projection direction before natural-wonder planning and materialization. This
+prevents the repaired path from validating footprint offsets for direction `0`
+and then passing `Direction:-1` to Civ, which was the source of the exact-run
+Kilimanjaro/Zhangjiajie rejection/readback split.
+
+Verification boundary:
+focused local tests cover the shared map-policy helper and the Swooper
+derive-placement-inputs handoff into `planNaturalWonders`. This does not prove
+final-surface parity. A fresh Studio Run in Game and exact-authored
+final-surface parity proof are still required before marking the feature rows
+resolved or making any product acceptance claim.
+
+Current drain validation:
+`bun test packages/civ7-map-policy/test/map-policy.test.ts`;
+`bun test mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts`;
+`bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts`;
+`bun run --cwd packages/civ7-map-policy check`;
+`bun run --cwd packages/civ7-map-policy build`;
+`bun run --cwd mods/mod-swooper-maps check`;
+`bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`;
+`bun run openspec:validate`;
+`git diff --check && git diff --cached --check`.
+
+Current exact parity rerun:
+blocked before parity evaluation. The rerun command
+`bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-direction-repair.json`
+returned
+`Recipe compile failed: /config/ecology-features/floodplainPlanning: Unknown key`.
+
 ## Required Next Diagnostics
 
 - Extract local row context for every feature/resource mismatch: terrain,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -612,6 +612,34 @@
   mock/map-policy prediction and live Civ materialization. It does not
   authorize a global `Direction:-1` rewrite, generated output changes, parity
   closure, product acceptance, Earthlike tuning, or mountain-quality closure.
+- Natural-wonder projection/materialization repair progress:
+  `@civ7/map-policy` now separates official placement direction from
+  materialization direction. `resolveNaturalWonderPlacementDirection` still
+  preserves official `naturalWonderDirection:-1` for catalog/evidence records,
+  while `resolveNaturalWonderMaterializationDirection` resolves that
+  unspecified value to the explicit footprint projection used by local policy.
+  The Swooper placement input derivation now passes the explicit materialization
+  direction and matching offsets into `planNaturalWonders`, so the planner,
+  local mock placement, and live Civ write path share the same deterministic
+  direction instead of validating direction `0` locally and then sending
+  `Direction:-1` to Civ. This is a projection/materialization boundary repair,
+  not a natural-wonder density/tuning change. Exact-authored final-surface
+  parity must be rerun before claiming the Kilimanjaro/Zhangjiajie feature rows
+  are resolved.
+  Current drain validation passed:
+  `bun test packages/civ7-map-policy/test/map-policy.test.ts`;
+  `bun test mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts`;
+  `bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts`;
+  `bun run --cwd packages/civ7-map-policy check`;
+  `bun run --cwd packages/civ7-map-policy build`;
+  `bun run --cwd mods/mod-swooper-maps check`;
+  `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`;
+  `bun run openspec:validate`;
+  `git diff --check && git diff --cached --check`.
+  Current exact parity rerun remains blocked before parity evaluation:
+  `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-direction-repair.json`
+  returned
+  `Recipe compile failed: /config/ecology-features/floodplainPlanning: Unknown key`.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -657,9 +685,11 @@
   `studio-run-in-game-mq2t7nqs-1z4g` supplies row-level rejected-placement
   identity for Kilimanjaro plot `1320` and Zhangjiajie plot `2171`. That row
   evidence is now classified to repo-owned natural-wonder footprint
-  projection/materialization emulation. The next repair must stay in that owner
-  surface and be checked against the remaining supported unspecified multi-tile
-  catalog behavior and fresh exact live placement evidence.
+  projection/materialization emulation, and the repair now makes the
+  materialization direction explicit before the plan/write path. The next proof
+  step is a fresh exact-authored final-surface run to verify whether the
+  Kilimanjaro/Zhangjiajie feature deltas resolve without widening to product
+  tuning.
   The single
   substitution row where both probed values are infeasible remains an individual
   evidence row with no repair authority until row-level context assigns source

--- a/packages/civ7-map-policy/src/index.ts
+++ b/packages/civ7-map-policy/src/index.ts
@@ -13,6 +13,7 @@ export {
   getNaturalWonderFootprintIndices,
   getNaturalWonderFootprintOffsets,
   hasUnsupportedNaturalWonderPolicyTags,
+  resolveNaturalWonderMaterializationDirection,
   resolveNaturalWonderPlacementDirection,
 } from "./natural-wonder-footprints.js";
 export type {

--- a/packages/civ7-map-policy/src/natural-wonder-footprints.ts
+++ b/packages/civ7-map-policy/src/natural-wonder-footprints.ts
@@ -49,6 +49,13 @@ export function resolveNaturalWonderPlacementDirection(
   return -1;
 }
 
+export function resolveNaturalWonderMaterializationDirection(
+  policy: NaturalWonderPlacementPolicy,
+  direction = resolveNaturalWonderPlacementDirection(policy)
+): number {
+  return normalizeFootprintDirection(direction);
+}
+
 function normalizeFootprintDirection(direction: number | undefined): number {
   if (!Number.isFinite(direction) || (direction as number) < 0) return 0;
   return Math.trunc(direction as number) % 6;
@@ -66,7 +73,7 @@ export function getNaturalWonderFootprintOffsets(
   const tiles = Math.max(1, policy.naturalWonderTiles ?? 1);
   if (tiles <= 1 || placementClass === "ONE") return ANCHOR;
 
-  const normalizedDirection = normalizeFootprintDirection(direction);
+  const normalizedDirection = resolveNaturalWonderMaterializationDirection(policy, direction);
   const primary = directionOffset(normalizedDirection);
   const clockwise = directionOffset(normalizedDirection + 1);
   switch (placementClass) {

--- a/packages/civ7-map-policy/test/map-policy.test.ts
+++ b/packages/civ7-map-policy/test/map-policy.test.ts
@@ -12,6 +12,7 @@ import {
   applyCiv7CoastClassificationPolicy,
   getNaturalWonderFootprintIndices,
   isResourceAdjacentToLandRuntimeOptional,
+  resolveNaturalWonderMaterializationDirection,
   resolveNaturalWonderPlacementDirection,
 } from "../src/index.js";
 
@@ -97,6 +98,7 @@ describe("@civ7/map-policy", () => {
     expect(catalogFeatureTypes).toContain(featureTypes.FEATURE_VIHREN);
     const redwoodPolicy = policies[String(featureTypes.FEATURE_REDWOOD_FOREST)]!;
     expect(resolveNaturalWonderPlacementDirection(redwoodPolicy)).toBe(-1);
+    expect(resolveNaturalWonderMaterializationDirection(redwoodPolicy)).toBe(0);
     expect(
       getNaturalWonderFootprintIndices({
         x: 64,


### PR DESCRIPTION
Resolve natural-wonder footprint projection/materialization direction mismatch where `Direction:-1` was passed to Civ after local planning validated offsets against direction `0`.

`@civ7/map-policy` now exposes `resolveNaturalWonderMaterializationDirection`, which normalizes an unspecified (`-1`) catalog direction to the explicit local projection direction used for footprint offset computation. The official catalog direction remains `-1` for evidence and policy records via `resolveNaturalWonderPlacementDirection`, preserving existing placement behavior.

The placement input derivation in `derive-placement-inputs` now calls `resolveNaturalWonderMaterializationDirection` once and uses the resulting explicit direction for both the catalog entry's `direction` field and the `footprintOffsets` passed into `planNaturalWonders`. Previously, `getNaturalWonderFootprintOffsets` computed offsets for direction `0` while the catalog entry still carried `Direction:-1`, causing the planner, local mock validation, and the live Civ write path to operate on different direction contracts — the identified source of the Kilimanjaro/Zhangjiajie rejection/readback split.

A focused integration test covering the `buildPlacementInputs` → `planNaturalWonders` handoff verifies that Kilimanjaro's catalog entry resolves to direction `0` with the correct three-tile footprint offsets. A fresh exact-authored final-surface parity run is still required before the Kilimanjaro/Zhangjiajie feature delta rows can be marked resolved.