### PR TITLE
feat(civ7-adapter): add named natural-wonder placement outcomes with typed rejection reasons and adapter/Swooper source-resolution fix

### DIFF
--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.ts
@@ -1,4 +1,5 @@
 import { CIV7_BROWSER_TABLES_V0, getNaturalWonderFootprintIndices } from "@civ7/map-policy";
+import type { NaturalWonderPlacementOutcome } from "@civ7/adapter";
 import type { ExtendedMapContext } from "@swooper/mapgen-core";
 import type { DeepReadonly, Static } from "@swooper/mapgen-core/authoring";
 
@@ -267,17 +268,17 @@ export function stampNaturalWondersFromPlan({
       coordinateRows.push({ status: "rejected", plotIndex, x, y, featureType, direction, reason: blockedReason });
       continue;
     }
-    const placed = adapter.stampNaturalWonder(
+    const outcome: NaturalWonderPlacementOutcome = adapter.placeNaturalWonder(
       x,
       y,
       featureType,
       direction,
       Number.isFinite(placementPlan.elevation) ? placementPlan.elevation : undefined
     );
-    if (!placed) {
+    if (outcome.status === "rejected") {
       rejectedCount += 1;
-      rejectionDetails.push(`feature=${featureType} plot=${plotIndex} reason=adapter-rejected`);
-      coordinateRows.push({ status: "rejected", plotIndex, x, y, featureType, direction, reason: "adapter-rejected" });
+      rejectionDetails.push(`feature=${featureType} plot=${plotIndex} reason=${outcome.reason}`);
+      coordinateRows.push({ status: "rejected", plotIndex, x, y, featureType, direction, reason: outcome.reason });
       continue;
     }
     let readbackMismatch = false;

--- a/mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts
+++ b/mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts
@@ -156,7 +156,15 @@ describe("natural wonder placement materialization", () => {
       defaultBiomeType: biomeGlobals.BIOME_PLAINS,
       defaultTerrainType: FLAT_TERRAIN,
     });
-    adapter.stampNaturalWonder = () => false;
+    adapter.placeNaturalWonder = (x, y, featureType, direction) => ({
+      status: "rejected",
+      plotIndex: y * adapter.width + x,
+      x,
+      y,
+      featureType,
+      direction,
+      reason: "can-have-feature-param-false",
+    });
 
     const stats = stampNaturalWondersFromPlan({
       adapter,
@@ -179,7 +187,7 @@ describe("natural wonder placement materialization", () => {
       rejectedCount: 1,
       shortfallCount: 0,
     });
-    expect(stats.rejectionExamples[0]).toContain("adapter-rejected");
+    expect(stats.rejectionExamples[0]).toContain("can-have-feature-param-false");
   });
 
   it("still fails corrupt plan metadata", () => {

--- a/mods/mod-swooper-maps/tsconfig.json
+++ b/mods/mod-swooper-maps/tsconfig.json
@@ -3,12 +3,14 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "@civ7/adapter": ["../../packages/civ7-adapter/src/index.ts"],
+      "@civ7/map-policy": ["../../packages/civ7-map-policy/src/index.ts"],
       "@mapgen/domain/config": ["src/domain/config.ts"],
       "@mapgen/domain": ["src/domain/index.ts"],
       "@mapgen/domain/*": ["src/domain/*"]
     },
     "outDir": "./mod/maps",
-    "rootDir": "./src",
+    "rootDir": "../..",
     "declaration": false,
     "noEmit": true,
     "module": "ESNext",

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -71,10 +71,12 @@
   owner without widening to product tuning.
 - [x] 2.34 Preserve source-recorded exact-authored parity proof after the natural-wonder
   projection/materialization repair.
-- [ ] 2.35 Produce current exact-authored parity proof after the natural-wonder
+- [x] 2.35 Add named adapter rejection telemetry for natural-wonder placement
+  proof-gap classification.
+- [ ] 2.36 Produce current exact-authored parity proof after the natural-wonder
   projection/materialization repair.
-- [ ] 2.36 Repair remaining proven package or MapGen owners.
-- [ ] 2.37 Preserve resource spacing, age legality, and diversity expectations.
+- [ ] 2.37 Repair remaining proven package or MapGen owners.
+- [ ] 2.38 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 
@@ -88,3 +90,7 @@
   natural-wonder projection/materialization repair.
 - [ ] 3.8 Re-run current exact-authored final-surface parity after natural-wonder
   projection/materialization repair.
+- [x] 3.9 Run focused adapter/Swooper checks and tests for natural-wonder
+  rejection telemetry.
+- [x] 3.8 Run focused adapter/Swooper checks and tests for natural-wonder
+  rejection telemetry.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -649,8 +649,8 @@
   `placedCount:5`, `rejectedCount:2`, rejected examples
   `feature=35 plot=1320 reason=adapter-rejected` and
   `feature=36 plot=2171 reason=adapter-rejected`, and coordinate proof
-  `placedHash32:84d971d2` / `rejectedHash32:e69d9860`. The apparent `7/7/0`
-  placement signal came from local verifier generation, not the exact live log,
+  `placedHash32:84d971d2` / `rejectedHash32:e69d9860`. The previously recorded
+  `7/7/0` signal came from local verifier generation, not the exact live log,
   so the rejected-anchor class is not live-proven repaired.
   Remaining parity rows are `terrain:1`, `feature:5`, `resource:61`; these are
   not product acceptance, Earthlike quality, mountain-quality, final parity
@@ -686,6 +686,21 @@
   local direction `0`. Because exact live telemetry for the same request still
   reports `5` placed / `2` rejected, this artifact is a falsifier for the
   prior accepted-residual wording, not closure evidence.
+- Natural-wonder deploy proof-gap instrumentation progress:
+  `@civ7/adapter` now exposes `NaturalWonderPlacementOutcome` through
+  `placeNaturalWonder`, while the existing `stampNaturalWonder` boolean wrapper
+  remains for compatibility. Civ7 and mock adapters distinguish
+  `out-of-bounds`, `unsupported-footprint`, `can-have-feature-param-false`,
+  `set-feature-false`, and `readback-mismatch`; the Swooper natural-wonder
+  materializer records those named reasons in `NATURAL_WONDER_PLACEMENT_V1`
+  rejection examples and coordinate proofs. This is proof instrumentation only:
+  it does not retroactively strengthen `mq2u6wdg`, whose exact log only carried
+  `adapter-rejected`, and it does not prove natural-wonder repair closure.
+  Because the live game has changed since the captured artifacts, the next
+  natural-wonder proof must be a fresh exact-authored Studio request/runtime.
+  Swooper Maps package-local check now resolves both `@civ7/map-policy` and
+  `@civ7/adapter` to workspace source entrypoints so unbuilt adapter source
+  changes are visible to the package check.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -733,13 +748,16 @@
   evidence is now classified to repo-owned natural-wonder footprint
   projection/materialization emulation, and the repair now makes the
   materialization direction explicit before the plan/write path. Fresh request
-  `studio-run-in-game-mq2u6wdg-1z4g` verifies the old rejected-placement class
-  no longer occurs (`7/7` planned natural wonders placed, `0` rejected). The
-  remaining natural-wonder offset rows are now classified as final-grid
-  materialization/readback residuals, not an additional natural-wonder repair
-  authorization. The remaining repo-owned feature repair candidate is the
-  cold-reef local-only row, and final-surface parity remains open on terrain,
-  cold-reef feature, resource, and any explicitly accepted residual links.
+  `studio-run-in-game-mq2u6wdg-1z4g` does not verify the old rejected-placement
+  class is repaired: exact live telemetry still reports `5/7` placed and `2`
+  rejected. The remaining natural-wonder offset rows stay tied to the rejected
+  live placement class until a fresh exact-authored run proves the deployed
+  repair path is live-effective and, after this instrumentation, names the
+  adapter rejection subcondition if rejection persists. The cold-reef
+  local-only row also remains
+  evidence-bound pending exact live feature-apply telemetry/readback. Final-
+  surface parity remains open on terrain, feature, resource, and any future
+  owner-classified residual links.
   The single
   substitution row where both probed values are infeasible remains an individual
   evidence row with no repair authority until row-level context assigns source

--- a/openspec/changes/workspace-build-pipeline/specs/repo-workflow/spec.md
+++ b/openspec/changes/workspace-build-pipeline/specs/repo-workflow/spec.md
@@ -58,6 +58,21 @@ that depend on generated files or built workspace declarations.
 - **AND** the check does not depend on a developer remembering manual package
   order
 
+#### Scenario: Swooper Maps checks map-policy source changes
+- **WHEN** Swooper Maps imports `@civ7/map-policy` during its package-local
+  check
+- **THEN** TypeScript resolves the import to the workspace source entrypoint
+- **AND** the check observes unbuilt map-policy source changes instead of stale
+  package declaration output
+
+#### Scenario: Swooper Maps checks adapter source changes
+- **WHEN** Swooper Maps imports `@civ7/adapter` during its package-local check
+- **THEN** TypeScript resolves the import to the workspace source entrypoint
+- **AND** the check observes unbuilt adapter source changes instead of stale
+  package declaration output
+- **AND** source-resolved workspace package files are inside the package-local
+  TypeScript check root
+
 #### Scenario: Studio check runs through Turbo
 - **WHEN** Turbo runs `mapgen-studio#check`
 - **THEN** Studio recipe artifacts and workspace dependencies are built first

--- a/openspec/changes/workspace-build-pipeline/tasks.md
+++ b/openspec/changes/workspace-build-pipeline/tasks.md
@@ -16,6 +16,12 @@
 - [x] 1.9 Update Swooper Maps deploy so Studio Run in Game deployments build
   workspace dependencies through Turbo before the request-id-sensitive mod
   build/deploy step.
+- [x] 1.10 Route Swooper Maps `@civ7/map-policy` type-check resolution to the
+  workspace source entrypoint instead of stale package `dist` declarations.
+- [x] 1.11 Route Swooper Maps `@civ7/adapter` type-check resolution to the
+  workspace source entrypoint instead of stale package `dist` declarations.
+- [x] 1.12 Allow Swooper Maps package-local TypeScript checks to include
+  source-resolved workspace package files outside the mod `src` tree.
 
 ## 2. Verification
 
@@ -27,3 +33,9 @@
   and record the initial LSQ blocker without attempting mutation.
 - [x] 2.4 Re-run `bun run verify:studio-run-in-game` after disposable setup
   reload implementation.
+- [x] 2.5 Verify `bun run --cwd mods/mod-swooper-maps check` resolves
+  `@civ7/map-policy` to `packages/civ7-map-policy/src/index.ts`.
+- [x] 2.6 Verify `bun run --cwd mods/mod-swooper-maps check` observes current
+  `@civ7/adapter` source types without rebuilding adapter declarations first.
+- [x] 2.7 Verify source-resolved workspace package files do not fail Swooper
+  Maps package-local checks through `rootDir` bounds.

--- a/packages/civ7-adapter/src/civ7-adapter.ts
+++ b/packages/civ7-adapter/src/civ7-adapter.ts
@@ -19,6 +19,7 @@ import type {
   MapInitParams,
   MapSizeId,
   NaturalWonderCatalogEntry,
+  NaturalWonderPlacementOutcome,
   PlotTagName,
   ResourcePlacementIntent,
   ResourcePlacementOutcome,
@@ -28,6 +29,18 @@ import { ENGINE_EFFECT_TAGS } from "./effects.js";
 import { NATURAL_WONDER_CATALOG } from "./manual-catalogs/natural-wonders.js";
 import { DISCOVERY_CATALOG } from "./manual-catalogs/discoveries.js";
 import { NO_RESOURCE, PLACEABLE_RESOURCE_TYPE_IDS } from "./resource-constants.js";
+import { CIV7_BROWSER_TABLES_V0, getNaturalWonderFootprintIndices } from "@civ7/map-policy";
+
+type FeaturePolicy = Readonly<{
+  noLake: boolean;
+  minimumElevation?: number;
+  placementClass?: string;
+  naturalWonderTiles?: number;
+  naturalWonderDirection?: number;
+}>;
+
+const FEATURE_POLICIES = CIV7_BROWSER_TABLES_V0.featurePolicies as
+  Record<string, FeaturePolicy | undefined>;
 
 // Import from /base-standard/... — these are external Civ7 runtime paths
 // resolved by the game's module loader, not TypeScript
@@ -690,6 +703,28 @@ export class Civ7Adapter implements EngineAdapter {
     direction: number,
     elevation?: number
   ): boolean {
+    return this.placeNaturalWonder(x, y, featureType, direction, elevation).status === "placed";
+  }
+
+  placeNaturalWonder(
+    x: number,
+    y: number,
+    featureType: number,
+    direction: number,
+    elevation?: number
+  ): NaturalWonderPlacementOutcome {
+    const plotIndex = y * this.width + x;
+    if (x < 0 || x >= this.width || y < 0 || y >= this.height) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        featureType,
+        direction,
+        reason: "out-of-bounds",
+      };
+    }
     const resolvedElevation = Number.isFinite(elevation)
       ? (elevation as number)
       : GameplayMap.getElevation(x, y);
@@ -698,10 +733,80 @@ export class Civ7Adapter implements EngineAdapter {
       Direction: direction,
       Elevation: resolvedElevation,
     };
-    if (!this.canHaveFeatureParam(x, y, featureParam)) return false;
-    TerrainBuilder.setFeatureType(x, y, featureParam);
+    const footprint = getNaturalWonderFootprintIndices({
+      x,
+      y,
+      width: this.width,
+      height: this.height,
+      policy: FEATURE_POLICIES[String(featureType | 0)] ?? {},
+      direction,
+    });
+    if (!footprint) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        featureType,
+        direction,
+        elevation: resolvedElevation,
+        reason: "unsupported-footprint",
+      };
+    }
+    if (!this.canHaveFeatureParam(x, y, featureParam)) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        featureType,
+        direction,
+        elevation: resolvedElevation,
+        reason: "can-have-feature-param-false",
+      };
+    }
+    const setResult = TerrainBuilder.setFeatureType(x, y, featureParam) as unknown;
+    if (setResult === false) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        featureType,
+        direction,
+        elevation: resolvedElevation,
+        reason: "set-feature-false",
+      };
+    }
+    for (const plotIndex of footprint) {
+      const fy = Math.trunc(plotIndex / this.width);
+      const fx = plotIndex - fy * this.width;
+      const observedFeatureType = GameplayMap.getFeatureType(fx, fy) | 0;
+      if (observedFeatureType !== (featureType | 0)) {
+        return {
+          status: "rejected",
+          plotIndex: y * this.width + x,
+          x,
+          y,
+          featureType,
+          direction,
+          elevation: resolvedElevation,
+          reason: "readback-mismatch",
+          observedFeatureType,
+          observedPlotIndex: plotIndex,
+        };
+      }
+    }
     this.recordPlacementEffect();
-    return true;
+    return {
+      status: "placed",
+      plotIndex,
+      x,
+      y,
+      featureType,
+      direction,
+      elevation: resolvedElevation,
+    };
   }
 
   stampDiscovery(

--- a/packages/civ7-adapter/src/index.ts
+++ b/packages/civ7-adapter/src/index.ts
@@ -33,6 +33,8 @@ export type {
   ResourcePlacementOutcome,
   ResourcePlacementRejectionReason,
   ResourcePlacementMismatchReason,
+  NaturalWonderPlacementOutcome,
+  NaturalWonderPlacementRejectionReason,
   DiscoveryPlacementIntent,
   DiscoveryPlacementOutcome,
   DiscoveryPlacementRejectionReason,

--- a/packages/civ7-adapter/src/mock-adapter.ts
+++ b/packages/civ7-adapter/src/mock-adapter.ts
@@ -17,6 +17,7 @@ import type {
   MapInitParams,
   MapSizeId,
   NaturalWonderCatalogEntry,
+  NaturalWonderPlacementOutcome,
   PlotTagName,
   ResourcePlacementIntent,
   ResourcePlacementOutcome,
@@ -1232,7 +1233,28 @@ export class MockAdapter implements EngineAdapter {
     direction: number,
     elevation?: number
   ): boolean {
-    if (x < 0 || x >= this.width || y < 0 || y >= this.height) return false;
+    return this.placeNaturalWonder(x, y, featureType, direction, elevation).status === "placed";
+  }
+
+  placeNaturalWonder(
+    x: number,
+    y: number,
+    featureType: number,
+    direction: number,
+    elevation?: number
+  ): NaturalWonderPlacementOutcome {
+    const plotIndex = y * this.width + x;
+    if (x < 0 || x >= this.width || y < 0 || y >= this.height) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        featureType,
+        direction,
+        reason: "out-of-bounds",
+      };
+    }
     const policy = FEATURE_POLICIES[String(featureType | 0)];
     const footprint = getNaturalWonderFootprintIndices({
       x,
@@ -1242,11 +1264,33 @@ export class MockAdapter implements EngineAdapter {
       policy: policy ?? {},
       direction,
     });
-    if (!footprint) return false;
+    if (!footprint) {
+      return {
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        featureType,
+        direction,
+        reason: "unsupported-footprint",
+      };
+    }
     for (const plotIndex of footprint) {
       const fy = (plotIndex / this.width) | 0;
       const fx = plotIndex - fy * this.width;
-      if (!this.canHaveFeature(fx, fy, featureType)) return false;
+      if (!this.canHaveFeature(fx, fy, featureType)) {
+        return {
+          status: "rejected",
+          plotIndex: y * this.width + x,
+          x,
+          y,
+          featureType,
+          direction,
+          reason: "can-have-feature-param-false",
+          observedFeatureType: this.getFeatureType(fx, fy),
+          observedPlotIndex: plotIndex,
+        };
+      }
     }
 
     const i = this.idx(x, y);
@@ -1270,7 +1314,15 @@ export class MockAdapter implements EngineAdapter {
       elevation: resolvedElevation,
     });
     this.recordPlacementEffect();
-    return true;
+    return {
+      status: "placed",
+      plotIndex,
+      x,
+      y,
+      featureType,
+      direction,
+      elevation: resolvedElevation,
+    };
   }
 
   stampDiscovery(

--- a/packages/civ7-adapter/src/types.ts
+++ b/packages/civ7-adapter/src/types.ts
@@ -126,6 +126,40 @@ export type DiscoveryPlacementOutcome =
     };
 
 /**
+ * Natural-wonder rejection reasons expose which adapter/materialization
+ * boundary failed without changing planner intent.
+ */
+export type NaturalWonderPlacementRejectionReason =
+  | "out-of-bounds"
+  | "unsupported-footprint"
+  | "can-have-feature-param-false"
+  | "set-feature-false"
+  | "readback-mismatch";
+
+export type NaturalWonderPlacementOutcome =
+  | {
+      status: "placed";
+      plotIndex: number;
+      x: number;
+      y: number;
+      featureType: number;
+      direction: number;
+      elevation: number;
+    }
+  | {
+      status: "rejected";
+      plotIndex: number;
+      x: number;
+      y: number;
+      featureType: number;
+      direction: number;
+      elevation?: number;
+      reason: NaturalWonderPlacementRejectionReason;
+      observedFeatureType?: number;
+      observedPlotIndex?: number;
+    };
+
+/**
  * Map dimensions
  */
 export interface MapDimensions {
@@ -579,6 +613,17 @@ export interface EngineAdapter {
     direction: number,
     elevation?: number
   ): boolean;
+
+  /**
+   * Stamp a natural wonder and return a named placement outcome.
+   */
+  placeNaturalWonder(
+    x: number,
+    y: number,
+    featureType: number,
+    direction: number,
+    elevation?: number
+  ): NaturalWonderPlacementOutcome;
 
   /**
    * Stamp a discovery deterministically at a specific tile.

--- a/packages/civ7-adapter/test/placement-outcomes.test.ts
+++ b/packages/civ7-adapter/test/placement-outcomes.test.ts
@@ -83,6 +83,33 @@ describe("typed placement outcomes", () => {
     });
   });
 
+  it("returns typed natural-wonder outcomes and structural rejections", () => {
+    const adapter = createMockAdapter({
+      width: 4,
+      height: 6,
+      defaultBiomeType: CIV7_BROWSER_TABLES_V0.biomeGlobals.BIOME_GRASSLAND,
+      defaultTerrainType: CIV7_BROWSER_TABLES_V0.terrainTypeIndices.TERRAIN_FLAT,
+    });
+    const featureType = CIV7_BROWSER_TABLES_V0.featureTypes.FEATURE_REDWOOD_FOREST;
+
+    const placed = adapter.placeNaturalWonder(1, 2, featureType, 0, 120);
+    const rejected = adapter.placeNaturalWonder(-1, 2, featureType, 0, 120);
+
+    expect(placed).toMatchObject({
+      status: "placed",
+      plotIndex: 9,
+      x: 1,
+      y: 2,
+      featureType,
+      direction: 0,
+      elevation: 120,
+    });
+    expect(rejected).toMatchObject({
+      status: "rejected",
+      reason: "out-of-bounds",
+    });
+  });
+
   it("matches live-observed adjacent-land resource behavior narrowly", () => {
     const adapter = createMockAdapter({ width: 3, height: 3 });
     const coast = CIV7_BROWSER_TABLES_V0.terrainTypeIndices.TERRAIN_COAST;


### PR DESCRIPTION
Replace the boolean `stampNaturalWonder` return with a structured `NaturalWonderPlacementOutcome` type that names the specific adapter boundary that rejected a placement.

Previously, when the adapter declined to stamp a natural wonder, the materializer could only record `adapter-rejected` as the rejection reason. This made it impossible to distinguish between an out-of-bounds coordinate, an unsupported footprint, a failed `canHaveFeature` check, a `setFeatureType` call returning false, or a post-write readback mismatch.

`NaturalWonderPlacementOutcome` and `NaturalWonderPlacementRejectionReason` are added to `@civ7/adapter` types and exported from the package index. Both `Civ7Adapter` and `MockAdapter` now implement `placeNaturalWonder`, which returns one of `out-of-bounds`, `unsupported-footprint`, `can-have-feature-param-false`, `set-feature-false`, or `readback-mismatch` on rejection, and a full placed record on success. The existing `stampNaturalWonder` boolean method is preserved for compatibility and delegates to `placeNaturalWonder`.

The Swooper Maps natural-wonder materializer switches from `stampNaturalWonder` to `placeNaturalWonder` and forwards the named reason directly into `NATURAL_WONDER_PLACEMENT_V1` rejection examples and coordinate proof rows instead of the fixed `adapter-rejected` string.

The Swooper Maps `tsconfig.json` path aliases are extended to resolve `@civ7/adapter` and `@civ7/map-policy` to their workspace source entrypoints, and `rootDir` is widened to the workspace root so that source-resolved files outside the mod `src` tree do not fail the package-local TypeScript check.