### PR TITLE
docs(earthlike-live-feature-resource-legality-repair): record fresh natural-wonder named rejection proof narrowing rejections to readback-mismatch

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -73,10 +73,12 @@
   projection/materialization repair.
 - [x] 2.35 Add named adapter rejection telemetry for natural-wonder placement
   proof-gap classification.
-- [ ] 2.36 Produce current exact-authored parity proof after the natural-wonder
+- [x] 2.36 Preserve source-recorded exact-authored natural-wonder named
+  rejection proof.
+- [ ] 2.37 Produce current exact-authored parity proof after the natural-wonder
   projection/materialization repair.
-- [ ] 2.37 Repair remaining proven package or MapGen owners.
-- [ ] 2.38 Preserve resource spacing, age legality, and diversity expectations.
+- [ ] 2.38 Repair remaining proven package or MapGen owners.
+- [ ] 2.39 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 
@@ -92,5 +94,5 @@
   projection/materialization repair.
 - [x] 3.9 Run focused adapter/Swooper checks and tests for natural-wonder
   rejection telemetry.
-- [x] 3.8 Run focused adapter/Swooper checks and tests for natural-wonder
-  rejection telemetry.
+- [x] 3.10 Preserve source-recorded exact-authored final-surface parity after
+  named natural-wonder rejection telemetry.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1160,22 +1160,62 @@ the materialization/deploy chain is reconciled by a fresh exact run.
 Boundary:
 this classification does not close feature parity, natural-wonder product
 behavior, Earthlike acceptance, mountain quality, final-surface parity, reef
-feature repair, or natural-wonder repair. The next valid movement is proof
-repair: reconcile why local verifier generation saw `7/7/0` natural-wonder
-placement while exact live telemetry for the same request still reports `5/2`,
-and add exact live feature-apply telemetry/readback before authorizing a
+feature repair, or natural-wonder repair. The next valid movement is
+source-authority classification for named natural-wonder `readback-mismatch`
+evidence, plus exact live feature-apply telemetry/readback before authorizing a
 cold-reef repair.
+
+### Fresh Natural-Wonder Named Rejection Proof
+
+Artifacts:
+
+| Artifact | Path | Identity |
+|---|---|---|
+| Request body | `/tmp/civ7-recovery-proof/final-surface-parity/fresh-natural-wonder-named-rejection-run-request.json` | `sha256:a68947c89abca086ca380ee035600b9e7c38a8278a5d895de4fcb64eb398efc2` |
+| Completed Studio status | `/tmp/civ7-recovery-proof/final-surface-parity/fresh-natural-wonder-named-rejection-run-status.json` | `sha256:e1ef7a6449ac7489383d4696f0130a1cba8699e7f8b4b24ab71d53608b145869` |
+| Full-grid parity proof | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq2vqhg6-1z4g-after-natural-wonder-named-rejection-proof.json` | `sha256:631a2120ffaf70e54fdcad8ab3a5b1d0b62ff44b3be1a2f65c8674deb6f46bb3`, `proofHash:75f01f4d92d3b053df9337febea5cc0e266d1f603a024217a7be29e2b0407193` |
+
+Exact-authored request `studio-run-in-game-mq2vqhg6-1z4g` completed exact
+authorship with no unresolved links. Runtime identity is `106x66`, `6996`
+plots, seed `138503614`, turn `1`, game hash `0`, source snapshot id
+`status:1:c153eb72`, and snapshot hash `c153eb72`; the full-grid proof read
+`17` chunks with `0` omitted plots and stable pre/post identity.
+
+Natural-wonder exact live telemetry:
+
+| Field | Value |
+|---|---|
+| Placement stats | `planned:7`, `target:7`, `placed:5`, `rejected:2`, `shortfall:0` |
+| Rejection examples | `feature=35 plot=1320 reason=readback-mismatch`; `feature=36 plot=2171 reason=readback-mismatch` |
+| Coordinate proof | placed `5` / `84d971d2`; rejected `2` / `ebd22c48` |
+| Local verifier generation | `planned:7`, `target:7`, `placed:7`, `rejected:0`, `shortfall:0` |
+
+Parity result:
+
+| Surface | Result |
+|---|---|
+| terrain | `1/6996` mismatch, still routed to terrain-edge diagnostics. |
+| biome | `0/6996` mismatches. |
+| feature | `5/6996` mismatches; natural-wonder rows remain in the same offset/readback class with named rejection reason now available. |
+| resource | `61/6996` mismatches; resource coordinate proof remains a separate blocker. |
+
+Disposition:
+the fresh proof resolves the old aggregate `adapter-rejected` opacity: both
+remaining exact live natural-wonder rejected anchors are now named
+`readback-mismatch`, not `can-have-feature-param-false` or
+`set-feature-false`. This sharpens the next source-authority question toward
+why the adapter write path can call Civ but the exact post-write readback does
+not match the expected footprint at the authored anchor. It does not prove the
+natural-wonder repair complete, does not authorize cold-reef repair, and does
+not close feature parity, final-surface parity, Earthlike acceptance, product
+acceptance, generated-output ownership, or mountain-quality work.
 
 ## Required Next Diagnostics
 
-- Reconcile the natural-wonder materialization/deploy proof gap: local verifier
-  generation reports `7/7/0`, while exact live telemetry for `mq2u6wdg`
-  reports `5/2`.
-- Re-run a fresh exact-authored Studio request after named natural-wonder
-  adapter rejection telemetry is deployed, so any remaining rejection is bound
-  to `can-have-feature-param-false`, `set-feature-false`,
-  `readback-mismatch`, or another named adapter subcondition instead of the old
-  aggregate `adapter-rejected` label.
+- Classify the natural-wonder materialization/deploy proof gap from the fresh
+  named-rejection proof: local verifier generation reports `7/7/0`, while
+  exact live telemetry for `studio-run-in-game-mq2vqhg6-1z4g` reports `5/2`
+  and names both rejected anchors as `readback-mismatch`.
 - Add or bind exact live feature-apply telemetry/readback before repairing the
   cold-reef local-only row.
 - Continue resource-row classification using source-recorded coordinate proof

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,20 +6,21 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
-  `codex/swooper-post-wonder-feature-classification-drain`, stacked above
-  `codex/swooper-wonder-proof-record-drain` and
-  `codex/swooper-wonder-direction-repair-drain`; this slice carries
-  source-recorded post-repair feature-row classification after the
-  natural-wonder projection/materialization repair.
+  `codex/swooper-wonder-named-rejection-proof-drain`, stacked above
+  `codex/swooper-wonder-rejection-outcomes-drain`; this slice preserves
+  source-recorded exact-authored named rejection evidence after the
+  natural-wonder proof-gap instrumentation.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
-  in the repo-owned adapter/map-policy surface. Source-recorded post-repair
-  evidence shows a natural-wonder materialization/deploy proof gap: exact live
-  telemetry still rejected two anchors, while local verifier generation saw
-  `7/7/0`. The remaining natural-wonder feature offsets and cold-reef row are
-  evidence-bound pending fresh exact telemetry. Current exact proof still
-  blocks on stale config before parity evaluation, and resource classes remain
-  pending source-authority classification.
+  in the repo-owned adapter/map-policy surface. The natural-wonder
+  rejected-anchor class remains open after the post-repair proof correction:
+  exact live telemetry is authoritative, and source-recorded named rejection
+  proof still reports `5` placed / `2` rejected, now narrowed to
+  `readback-mismatch` for Kilimanjaro and Zhangjiajie anchors. The cold-reef
+  feature row is evidence-bound because exact live feature-apply telemetry is
+  absent. Current exact proof still blocks on stale config before parity
+  evaluation, and resource classes remain pending source-authority
+  classification.
 
 ## Objective
 
@@ -696,11 +697,38 @@
   rejection examples and coordinate proofs. This is proof instrumentation only:
   it does not retroactively strengthen `mq2u6wdg`, whose exact log only carried
   `adapter-rejected`, and it does not prove natural-wonder repair closure.
-  Because the live game has changed since the captured artifacts, the next
-  natural-wonder proof must be a fresh exact-authored Studio request/runtime.
   Swooper Maps package-local check now resolves both `@civ7/map-policy` and
   `@civ7/adapter` to workspace source entrypoints so unbuilt adapter source
   changes are visible to the package check.
+- Fresh natural-wonder named rejection proof:
+  fresh request `studio-run-in-game-mq2vqhg6-1z4g` completed exact authorship
+  and produced parity artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq2vqhg6-1z4g-after-natural-wonder-named-rejection-proof.json`
+  (`sha256:631a2120ffaf70e54fdcad8ab3a5b1d0b62ff44b3be1a2f65c8674deb6f46bb3`,
+  `proofHash:75f01f4d92d3b053df9337febea5cc0e266d1f603a024217a7be29e2b0407193`).
+  The request body was
+  `/tmp/civ7-recovery-proof/final-surface-parity/fresh-natural-wonder-named-rejection-run-request.json`
+  (`sha256:a68947c89abca086ca380ee035600b9e7c38a8278a5d895de4fcb64eb398efc2`)
+  and the completed Studio status was
+  `/tmp/civ7-recovery-proof/final-surface-parity/fresh-natural-wonder-named-rejection-run-status.json`
+  (`sha256:e1ef7a6449ac7489383d4696f0130a1cba8699e7f8b4b24ab71d53608b145869`).
+  Exact-authorship status is `complete` with no unresolved links, runtime
+  identity is `106x66`, `6996` plots, seed `138503614`, turn `1`, game hash
+  `0`, source snapshot id `status:1:c153eb72`, and snapshot hash `c153eb72`.
+  The exact live `log.naturalWonderPlacement` reports `plannedCount:7`,
+  `placedCount:5`, `rejectedCount:2`, with rejected examples
+  `feature=35 plot=1320 reason=readback-mismatch` and
+  `feature=36 plot=2171 reason=readback-mismatch`; coordinate proof is
+  `placedHash32:84d971d2` / `rejectedHash32:ebd22c48`. Local verifier
+  generation still emits `7/7/0`, so the exact live log remains authoritative.
+  The final-surface proof remains `unresolved`: terrain has `1` mismatch,
+  biome has `0`, feature has `5`, and resource has `61`, with unresolved links
+  `surface.terrain.mismatch`, `surface.feature.mismatch`,
+  `surface.resource.mismatch`, and `resource-placement-coordinate-proof.placed`.
+  This proof resolves the aggregate `adapter-rejected` label into named
+  readback-mismatch evidence only; it does not close natural-wonder repair,
+  feature parity, final-surface parity, Earthlike acceptance, product
+  acceptance, generated-output ownership, or mountain quality.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -750,11 +778,12 @@
   materialization direction explicit before the plan/write path. Fresh request
   `studio-run-in-game-mq2u6wdg-1z4g` does not verify the old rejected-placement
   class is repaired: exact live telemetry still reports `5/7` placed and `2`
-  rejected. The remaining natural-wonder offset rows stay tied to the rejected
-  live placement class until a fresh exact-authored run proves the deployed
-  repair path is live-effective and, after this instrumentation, names the
-  adapter rejection subcondition if rejection persists. The cold-reef
-  local-only row also remains
+  rejected. Fresh request `studio-run-in-game-mq2vqhg6-1z4g` then proves the
+  rejection subcondition is `readback-mismatch` for the same Kilimanjaro and
+  Zhangjiajie anchors. The remaining natural-wonder offset rows stay tied to
+  the rejected live placement class until that named readback-mismatch owner is
+  source-classified and repaired or dispositioned. The cold-reef local-only row
+  also remains
   evidence-bound pending exact live feature-apply telemetry/readback. Final-
   surface parity remains open on terrain, feature, resource, and any future
   owner-classified residual links.


### PR DESCRIPTION
This PR preserves the source-recorded exact-authored named rejection proof for natural-wonder placement after the proof-gap instrumentation phase.

A fresh exact-authored Studio request (`studio-run-in-game-mq2vqhg6-1z4g`) was completed and its artifacts recorded with full identity and hash anchors. The run confirms that both remaining rejected natural-wonder anchors — Kilimanjaro (`feature=35`, `plot=1320`) and Zhangjiajie (`feature=36`, `plot=2171`) — are now named `readback-mismatch` rather than the previously opaque aggregate `adapter-rejected` label. Placement stats remain `planned:7`, `target:7`, `placed:5`, `rejected:2`, with coordinate proofs `placedHash32:84d971d2` and `rejectedHash32:ebd22c48`. Local verifier generation continues to report `7/7/0`, confirming exact live telemetry remains authoritative.

The delta classification ledger is updated to record the fresh proof artifacts, their SHA-256 identities, and the full parity surface breakdown: terrain `1/6996` mismatch, biome `0/6996`, feature `5/6996`, resource `61/6996`. The required next diagnostics are sharpened from re-running a fresh request (now complete) to classifying why the adapter write path can call Civ but the exact post-write readback does not match the expected footprint at the authored anchor.

The phase record branch tip is updated to `codex/swooper-wonder-named-rejection-proof-drain`, stacked above `codex/swooper-wonder-rejection-outcomes-drain`. Task 2.36 is marked complete, tasks 2.37–2.39 renumbered accordingly, and verification task 3.10 replaces the duplicate 3.8 entry.

This proof does not close natural-wonder repair, cold-reef repair, feature parity, final-surface parity, Earthlike acceptance, or resource-row classification.