### PR TITLE
feat(swooper-natural-wonders): add readback-mismatch observed-context telemetry and preserve readback-context coordinate proof

### DIFF
--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.ts
@@ -75,6 +75,8 @@ type NaturalWonderPlacementCoordinateRow = {
   featureType: number;
   direction: number;
   reason: string;
+  observedFeatureType?: number;
+  observedPlotIndex?: number;
 };
 
 function hash32Hex(input: string): string {
@@ -99,8 +101,8 @@ function naturalWonderCoordinateDigest(
       if (a.direction !== b.direction) return a.direction - b.direction;
       return a.reason.localeCompare(b.reason);
     })
-    .map((row) =>
-      [
+    .map((row) => {
+      const fields: Array<string | number> = [
         row.status,
         row.plotIndex,
         row.x,
@@ -108,9 +110,28 @@ function naturalWonderCoordinateDigest(
         row.featureType,
         row.direction,
         row.reason,
-      ].join(":")
-    );
+      ];
+      if (row.observedPlotIndex !== undefined) fields.push(`observedPlot=${row.observedPlotIndex}`);
+      if (row.observedFeatureType !== undefined) fields.push(`observedFeature=${row.observedFeatureType}`);
+      return fields.join(":");
+    });
   return { count: coordinateRows.length, hash32: hash32Hex(coordinateRows.join("|")) };
+}
+
+function formatNaturalWonderRejectionExample(args: {
+  featureType: number;
+  plotIndex: number;
+  reason: string;
+  observedPlotIndex?: number;
+  observedFeatureType?: number;
+}): string {
+  return [
+    `feature=${args.featureType}`,
+    `plot=${args.plotIndex}`,
+    `reason=${args.reason}`,
+    ...(args.observedPlotIndex === undefined ? [] : [`observedPlot=${args.observedPlotIndex}`]),
+    ...(args.observedFeatureType === undefined ? [] : [`observedFeature=${args.observedFeatureType}`]),
+  ].join(" ");
 }
 
 function naturalWonderCoordinateProof(
@@ -277,8 +298,26 @@ export function stampNaturalWondersFromPlan({
     );
     if (outcome.status === "rejected") {
       rejectedCount += 1;
-      rejectionDetails.push(`feature=${featureType} plot=${plotIndex} reason=${outcome.reason}`);
-      coordinateRows.push({ status: "rejected", plotIndex, x, y, featureType, direction, reason: outcome.reason });
+      rejectionDetails.push(
+        formatNaturalWonderRejectionExample({
+          featureType,
+          plotIndex,
+          reason: outcome.reason,
+          observedPlotIndex: outcome.observedPlotIndex,
+          observedFeatureType: outcome.observedFeatureType,
+        })
+      );
+      coordinateRows.push({
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        featureType,
+        direction,
+        reason: outcome.reason,
+        ...(outcome.observedPlotIndex === undefined ? {} : { observedPlotIndex: outcome.observedPlotIndex }),
+        ...(outcome.observedFeatureType === undefined ? {} : { observedFeatureType: outcome.observedFeatureType }),
+      });
       continue;
     }
     let readbackMismatch = false;

--- a/mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts
+++ b/mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts
@@ -190,6 +190,60 @@ describe("natural wonder placement materialization", () => {
     expect(stats.rejectionExamples[0]).toContain("can-have-feature-param-false");
   });
 
+  it("preserves natural-wonder readback mismatch evidence from the adapter", () => {
+    const adapter = createMockAdapter({
+      width: 5,
+      height: 8,
+      defaultBiomeType: biomeGlobals.BIOME_PLAINS,
+      defaultTerrainType: FLAT_TERRAIN,
+    });
+    adapter.placeNaturalWonder = (x, y, featureType, direction) => ({
+      status: "rejected",
+      plotIndex: y * adapter.width + x,
+      x,
+      y,
+      featureType,
+      direction,
+      reason: "readback-mismatch",
+      observedPlotIndex: 23,
+      observedFeatureType: adapter.NO_FEATURE,
+    });
+
+    const stats = stampNaturalWondersFromPlan({
+      adapter,
+      width: 5,
+      height: 8,
+      wonders: oneWonderPlan(featureTypes.FEATURE_KILIMANJARO, 17, 5, 8),
+      requestedCount: 1,
+    });
+
+    expect(stats).toMatchObject({
+      coordinateProof: {
+        version: 1,
+        placed: { count: 0, hash32: "811c9dc5" },
+        rejected: { count: 1, hash32: "5fa1cc6e" },
+      },
+      plannedCount: 1,
+      targetCount: 1,
+      placedCount: 0,
+      rejectedCount: 1,
+      shortfallCount: 0,
+    });
+    expect(stats.rejectionExamples[0]).toBe(
+      "feature=35 plot=17 reason=readback-mismatch observedPlot=23 observedFeature=-1"
+    );
+    expect(buildNaturalWonderPlacementRuntimeTelemetry(stats)).toMatchObject({
+      rejectionExampleCount: 1,
+      rejectionExamples: [
+        "feature=35 plot=17 reason=readback-mismatch observedPlot=23 observedFeature=-1",
+      ],
+      coordinateProof: {
+        rejectedCount: 1,
+        rejectedHash32: "5fa1cc6e",
+      },
+    });
+  });
+
   it("still fails corrupt plan metadata", () => {
     const adapter = createMockAdapter({
       width: 2,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -75,10 +75,13 @@
   proof-gap classification.
 - [x] 2.36 Preserve source-recorded exact-authored natural-wonder named
   rejection proof.
-- [ ] 2.37 Produce current exact-authored parity proof after the natural-wonder
+- [x] 2.37 Add natural-wonder readback-mismatch observed-context telemetry.
+- [x] 2.38 Preserve source-recorded exact-authored natural-wonder
+  readback-context proof.
+- [ ] 2.39 Produce current exact-authored parity proof after the natural-wonder
   projection/materialization repair.
-- [ ] 2.38 Repair remaining proven package or MapGen owners.
-- [ ] 2.39 Preserve resource spacing, age legality, and diversity expectations.
+- [ ] 2.40 Repair remaining proven package or MapGen owners.
+- [ ] 2.41 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 
@@ -96,3 +99,6 @@
   rejection telemetry.
 - [x] 3.10 Preserve source-recorded exact-authored final-surface parity after
   named natural-wonder rejection telemetry.
+- [x] 3.11 Run focused natural-wonder telemetry regression for readback context.
+- [x] 3.12 Preserve source-recorded exact-authored final-surface parity after
+  readback-context telemetry.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1058,6 +1058,21 @@ footprint. The mismatch therefore belongs to the natural-wonder
 projection/materialization emulation boundary between local map-policy/mock
 prediction and live Civ runtime materialization.
 
+Later boundary:
+this historical classification did not close the subsequent expected-empty
+readback subcondition. Fresh exact request `studio-run-in-game-mq2w5548-1z4g`
+still reports the same `5/2` natural-wonder live outcome, now with
+`readback-mismatch` details showing expected footprint plots `1427` and `2278`
+empty after the write call. The same full-grid proof shows adjacent live
+feature cells for those wonders: Kilimanjaro at plot `1426` while expected plot
+`1427` is empty, and Zhangjiajie at plot `2277` while expected plot `2278` is
+empty. Earlier footprint-direction context shows those adjacent live cells are
+compatible with alternate supported footprint orientations, but this proof does
+not include a complete immediate post-write footprint readback. Source
+authority for that narrower expected-empty/readback-oracle gap remains open
+until classified against supported footprint alternatives, final live feature
+cells, and adapter readback semantics.
+
 Repair authority:
 the next repair may change only the owner surface needed to make
 unspecified-direction natural-wonder footprint projection auditable and
@@ -1210,12 +1225,91 @@ natural-wonder repair complete, does not authorize cold-reef repair, and does
 not close feature parity, final-surface parity, Earthlike acceptance, product
 acceptance, generated-output ownership, or mountain-quality work.
 
+### Natural-Wonder Readback-Mismatch Context Instrumentation
+
+Current code now preserves adapter-provided readback context for
+natural-wonder `readback-mismatch` outcomes. Future
+`NATURAL_WONDER_PLACEMENT_V1` rejection examples can include:
+
+- authored natural-wonder feature id;
+- authored anchor plot;
+- named rejection reason;
+- first observed mismatching footprint plot as `observedPlot`;
+- observed feature id at that plot as `observedFeature`.
+
+The coordinate digest also includes those observed facts when present, while
+preserving existing digest identity for ordinary placed/rejected rows that do
+not carry observed readback fields. This is a proof-context change only. It
+does not alter placement planning, materialization direction, terrain policy,
+configuration, tuning, generated output, or final-surface parity. The next
+source-authority movement requires a fresh exact-authored Studio Run in Game
+and final-surface parity proof so the Kilimanjaro/Zhangjiajie
+`readback-mismatch` rows can be classified from exact observed readback
+details rather than the current coarse named reason alone.
+
+### Fresh Natural-Wonder Readback-Context Proof
+
+Artifacts:
+
+| Artifact | Path | Identity |
+|---|---|---|
+| Request body | `/tmp/civ7-recovery-proof/final-surface-parity/fresh-natural-wonder-readback-context-run-request.json` | `sha256:a68947c89abca086ca380ee035600b9e7c38a8278a5d895de4fcb64eb398efc2` |
+| Completed Studio status | `/tmp/civ7-recovery-proof/final-surface-parity/fresh-natural-wonder-readback-context-run-status.json` | `sha256:b2ad7154db1ab429a7dd35b5d6017b040dfdfdf4e1da0a679706d54dc65dedb9` |
+| Full-grid parity proof | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq2w5548-1z4g-after-natural-wonder-readback-context.json` | `sha256:5f947ae855dbafd870dedf982c438529e16c27e673a1a0bacdbd34b75a088093`, `proofHash:d6148b66043fa26b791029653a375edce945fc6175a1896f0ae6162f8388a1be` |
+
+Exact-authored request `studio-run-in-game-mq2w5548-1z4g` completed exact
+authorship with no unresolved links. Runtime identity is `106x66`, `6996`
+plots, seed `138503614`, turn `1`, game hash `0`, source snapshot id
+`status:1:c153eb72`, and snapshot hash `c153eb72`; the full-grid proof read
+`17` chunks with `0` omitted plots and stable pre/post identity.
+
+Natural-wonder exact live telemetry:
+
+| Field | Value |
+|---|---|
+| Placement stats | `planned:7`, `target:7`, `placed:5`, `rejected:2`, `shortfall:0` |
+| Rejection examples | `feature=35 plot=1320 reason=readback-mismatch observedPlot=1427 observedFeature=-1`; `feature=36 plot=2171 reason=readback-mismatch observedPlot=2278 observedFeature=-1` |
+| Coordinate proof | placed `5` / `84d971d2`; rejected `2` / `523bec4f` |
+| Local verifier generation | `planned:7`, `target:7`, `placed:7`, `rejected:0`, `shortfall:0` |
+
+Parity result:
+
+| Surface | Result |
+|---|---|
+| terrain | `1/6996` mismatch, still routed to terrain-edge diagnostics. |
+| biome | `0/6996` mismatches. |
+| feature | `5/6996` mismatches; natural-wonder rows remain in the same offset/readback class with observed expected-footprint empties now available. |
+| resource | `61/6996` mismatches; resource coordinate proof remains a separate blocker. |
+
+Disposition:
+the fresh proof shows both rejected exact live natural-wonder anchors reached
+the adapter write path but failed because the expected footprint readback cell
+was empty after the write: Kilimanjaro anchor plot `1320` expected plot `1427`,
+and Zhangjiajie anchor plot `2171` expected plot `2278`. This makes the next
+source-authority question narrower than generic adapter rejection: classify
+whether the local expected footprint is wrong for Civ's natural-wonder
+materialization semantics, whether Civ writes an alternate footprint that local
+policy should model, or whether the adapter readback is using an incorrect
+post-write footprint oracle. Full-grid parity binds the expected-empty cells to
+adjacent live feature cells (`1426` for Kilimanjaro and `2277` for
+Zhangjiajie), while earlier footprint-direction artifacts show those live cells
+are supported alternatives. That three-part evidence is a strong hypothesis,
+not a closure: the exact artifact does not yet prove the complete immediate
+post-write footprint that Civ materialized or the exact readback oracle shape
+that should replace the current one. This proof still does not prove the natural-wonder
+repair complete, does not authorize cold-reef repair, and does not close
+feature parity, final-surface parity, Earthlike acceptance, product acceptance,
+generated-output ownership, or mountain-quality work.
+
 ## Required Next Diagnostics
 
-- Classify the natural-wonder materialization/deploy proof gap from the fresh
-  named-rejection proof: local verifier generation reports `7/7/0`, while
-  exact live telemetry for `studio-run-in-game-mq2vqhg6-1z4g` reports `5/2`
-  and names both rejected anchors as `readback-mismatch`.
+- Classify the natural-wonder expected-empty footprint/readback owner from the
+  fresh exact `mq2w5548` proof: compare the expected empty plots `1427` and
+  `2278` to supported footprint alternatives, final live feature cells, and
+  adapter readback semantics before assigning repair authority. A valid repair
+  lane needs either complete post-write footprint telemetry or an explicit
+  source-authority disposition explaining why the current adapter readback
+  oracle is wrong for Civ materialization.
 - Add or bind exact live feature-apply telemetry/readback before repairing the
   cold-reef local-only row.
 - Continue resource-row classification using source-recorded coordinate proof

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,21 +6,21 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
-  `codex/swooper-wonder-named-rejection-proof-drain`, stacked above
-  `codex/swooper-wonder-rejection-outcomes-drain`; this slice preserves
-  source-recorded exact-authored named rejection evidence after the
-  natural-wonder proof-gap instrumentation.
+  `codex/swooper-wonder-readback-context-drain`, stacked above
+  `codex/swooper-wonder-named-rejection-proof-drain`; this slice adds
+  readback-mismatch observed-context telemetry and preserves source-recorded
+  exact-authored readback-context evidence.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface. The natural-wonder
   rejected-anchor class remains open after the post-repair proof correction:
-  exact live telemetry is authoritative, and source-recorded named rejection
-  proof still reports `5` placed / `2` rejected, now narrowed to
-  `readback-mismatch` for Kilimanjaro and Zhangjiajie anchors. The cold-reef
-  feature row is evidence-bound because exact live feature-apply telemetry is
-  absent. Current exact proof still blocks on stale config before parity
-  evaluation, and resource classes remain pending source-authority
-  classification.
+  exact live telemetry is authoritative, and source-recorded readback-context
+  proof still reports `5` placed / `2` rejected, now narrowed to empty expected
+  footprint readback at observed plots `1427` and `2278` for Kilimanjaro and
+  Zhangjiajie. The cold-reef feature row is evidence-bound because exact live
+  feature-apply telemetry is absent. Current exact proof still blocks on stale
+  config before parity evaluation, and resource classes remain pending
+  source-authority classification.
 
 ## Objective
 
@@ -608,6 +608,16 @@
   mock/map-policy prediction and live Civ materialization. It does not
   authorize a global `Direction:-1` rewrite, generated output changes, parity
   closure, product acceptance, Earthlike tuning, or mountain-quality closure.
+  Later exact proof shows that this historical class does not close the
+  expected-empty readback subcondition: after the projection/materialization
+  repair and named telemetry, Civ still reports `readback-mismatch` with
+  expected footprint plots `1427` and `2278` empty. The full-grid proof
+  simultaneously shows adjacent live feature cells for the same wonders:
+  Kilimanjaro live at `(48,13)` while the local expected cell `(49,13)`
+  (`1427`) is empty, and Zhangjiajie live at `(51,21)` while the local
+  expected cell `(52,21)` (`2278`) is empty. Source authority for that
+  narrower readback oracle/materialization semantics gap remains open until
+  classified and repaired or dispositioned.
 - Natural-wonder projection/materialization repair progress:
   `@civ7/map-policy` now separates official placement direction from
   materialization direction. `resolveNaturalWonderPlacementDirection` still
@@ -729,6 +739,61 @@
   readback-mismatch evidence only; it does not close natural-wonder repair,
   feature parity, final-surface parity, Earthlike acceptance, product
   acceptance, generated-output ownership, or mountain quality.
+- Natural-wonder readback-mismatch context progress:
+  the Swooper natural-wonder materializer now preserves adapter-provided
+  readback context in `NATURAL_WONDER_PLACEMENT_V1` rejection examples and
+  coordinate digests. For `readback-mismatch` outcomes, future exact logs can
+  carry `observedPlot` and `observedFeature` beside the authored feature,
+  anchor plot, and named reason. Existing placed/rejected coordinate digests
+  remain stable unless observed readback facts are present. This is proof
+  instrumentation only: it does not change natural-wonder planning,
+  materialization direction, feature placement policy, config, tuning, or
+  generated output ownership. A fresh exact-authored Studio Run in Game and
+  final-surface parity proof are required before using these observed fields
+  for source-authority classification of the Kilimanjaro/Zhangjiajie
+  readback-mismatch rows.
+- Fresh natural-wonder readback-context proof:
+  fresh request `studio-run-in-game-mq2w5548-1z4g` completed exact authorship
+  and produced parity artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq2w5548-1z4g-after-natural-wonder-readback-context.json`
+  (`sha256:5f947ae855dbafd870dedf982c438529e16c27e673a1a0bacdbd34b75a088093`,
+  `proofHash:d6148b66043fa26b791029653a375edce945fc6175a1896f0ae6162f8388a1be`).
+  The request body was
+  `/tmp/civ7-recovery-proof/final-surface-parity/fresh-natural-wonder-readback-context-run-request.json`
+  (`sha256:a68947c89abca086ca380ee035600b9e7c38a8278a5d895de4fcb64eb398efc2`)
+  and the completed Studio status was
+  `/tmp/civ7-recovery-proof/final-surface-parity/fresh-natural-wonder-readback-context-run-status.json`
+  (`sha256:b2ad7154db1ab429a7dd35b5d6017b040dfdfdf4e1da0a679706d54dc65dedb9`).
+  Exact-authorship status is `complete` with no unresolved links, runtime
+  identity is `106x66`, `6996` plots, seed `138503614`, turn `1`, game hash
+  `0`, source snapshot id `status:1:c153eb72`, and snapshot hash `c153eb72`.
+  The exact live `log.naturalWonderPlacement` reports `plannedCount:7`,
+  `placedCount:5`, `rejectedCount:2`, with rejected examples
+  `feature=35 plot=1320 reason=readback-mismatch observedPlot=1427 observedFeature=-1`
+  and
+  `feature=36 plot=2171 reason=readback-mismatch observedPlot=2278 observedFeature=-1`;
+  coordinate proof is `placedHash32:84d971d2` /
+  `rejectedHash32:523bec4f`. The full-grid verifier's local generation still
+  emits `7/7/0`, so the exact live log remains authoritative. The
+  final-surface proof remains `unresolved`: terrain has `1` mismatch, biome
+  has `0`, feature has `5`, and resource has `61`, with unresolved links
+  `surface.terrain.mismatch`, `surface.feature.mismatch`,
+  `surface.resource.mismatch`, and `resource-placement-coordinate-proof.placed`.
+  The full-grid feature rows line up with the exact observed-empty cells:
+  Kilimanjaro is present at `(48,13)` while the local expected plot `1427`
+  (`49,13`) is empty, and Zhangjiajie is present at `(51,21)` while the local
+  expected plot `2278` (`52,21`) is empty. Earlier footprint-direction context
+  shows those live cells are supported by alternate footprint orientations, but
+  the current proof records only the first expected-empty post-write readback
+  cell, not a complete immediate post-write footprint. Therefore the evidence
+  supports an expected-footprint/readback semantics hypothesis but does not yet
+  assign repair authority to placement policy, materialization direction, or
+  adapter readback.
+  This proof sharpens the natural-wonder failure from a coarse readback mismatch
+  to expected footprint cells that are empty after the Civ write call. It does
+  not close natural-wonder repair, feature parity, final-surface parity,
+  Earthlike acceptance, product acceptance, generated-output ownership, or
+  mountain quality.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -775,15 +840,23 @@
   identity for Kilimanjaro plot `1320` and Zhangjiajie plot `2171`. That row
   evidence is now classified to repo-owned natural-wonder footprint
   projection/materialization emulation, and the repair now makes the
-  materialization direction explicit before the plan/write path. Fresh request
+  materialization direction explicit before the plan/write path. That prior
+  classification/repair did not close the subsequent expected-empty readback
+  subcondition proven by `mq2w5548`; it remains a separate source-authority
+  question. Fresh request
   `studio-run-in-game-mq2u6wdg-1z4g` does not verify the old rejected-placement
   class is repaired: exact live telemetry still reports `5/7` placed and `2`
   rejected. Fresh request `studio-run-in-game-mq2vqhg6-1z4g` then proves the
   rejection subcondition is `readback-mismatch` for the same Kilimanjaro and
-  Zhangjiajie anchors. The remaining natural-wonder offset rows stay tied to
-  the rejected live placement class until that named readback-mismatch owner is
-  source-classified and repaired or dispositioned. The cold-reef local-only row
-  also remains
+  Zhangjiajie anchors. Fresh request `studio-run-in-game-mq2w5548-1z4g` then
+  proves those readback mismatches are empty expected footprint plots
+  (`1427`, `2278`) after the write call, while full-grid parity still shows
+  adjacent live natural-wonder cells (`1426`, `2277`). The remaining
+  natural-wonder offset rows stay tied to the rejected live placement class
+  until the expected-empty footprint/readback owner is source-classified and
+  repaired or dispositioned from exact-bound evidence that explains the
+  adapter's post-write readback oracle versus Civ's materialized footprint.
+  The cold-reef local-only row also remains
   evidence-bound pending exact live feature-apply telemetry/readback. Final-
   surface parity remains open on terrain, feature, resource, and any future
   owner-classified residual links.


### PR DESCRIPTION
When a natural-wonder placement is rejected with a `readback-mismatch` reason, the adapter can now supply the first mismatching footprint plot and the feature observed there. These two fields (`observedPlotIndex`, `observedFeatureType`) are threaded through the rejection row type, included in the coordinate digest, and surfaced in `NATURAL_WONDER_PLACEMENT_V1` rejection example strings as `observedPlot=` and `observedFeature=`.

A focused regression test covers the full path: a mock adapter that returns a `readback-mismatch` outcome with observed context produces the expected rejection example string, coordinate proof hashes, and telemetry output.

A fresh exact-authored Studio Run in Game (`studio-run-in-game-mq2w5548-1z4g`) confirms the instrumentation is live. The exact log now shows both rejected anchors with their observed-empty footprint plots: Kilimanjaro anchor `1320` expected plot `1427` empty, Zhangjiajie anchor `2171` expected plot `2278` empty. Full-grid parity simultaneously shows adjacent live natural-wonder cells at plots `1426` and `2277`, consistent with alternate supported footprint orientations.

This is proof instrumentation only. It does not change natural-wonder planning, materialization direction, terrain policy, configuration, tuning, or generated output. The expected-empty footprint/readback oracle gap for Kilimanjaro and Zhangjiajie remains open for source-authority classification before any repair is authorized.