### PR TITLE
feat(civ7-adapter): add complete expected-footprint readback vector and status to natural-wonder readback-mismatch outcomes

### DIFF
--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.ts
@@ -1,5 +1,9 @@
 import { CIV7_BROWSER_TABLES_V0, getNaturalWonderFootprintIndices } from "@civ7/map-policy";
-import type { NaturalWonderPlacementOutcome } from "@civ7/adapter";
+import type {
+  NaturalWonderFootprintReadback,
+  NaturalWonderFootprintReadbackStatus,
+  NaturalWonderPlacementOutcome,
+} from "@civ7/adapter";
 import type { ExtendedMapContext } from "@swooper/mapgen-core";
 import type { DeepReadonly, Static } from "@swooper/mapgen-core/authoring";
 
@@ -77,6 +81,8 @@ type NaturalWonderPlacementCoordinateRow = {
   reason: string;
   observedFeatureType?: number;
   observedPlotIndex?: number;
+  expectedFootprintReadback?: NaturalWonderFootprintReadback[];
+  expectedFootprintReadbackStatus?: NaturalWonderFootprintReadbackStatus;
 };
 
 function hash32Hex(input: string): string {
@@ -113,24 +119,67 @@ function naturalWonderCoordinateDigest(
       ];
       if (row.observedPlotIndex !== undefined) fields.push(`observedPlot=${row.observedPlotIndex}`);
       if (row.observedFeatureType !== undefined) fields.push(`observedFeature=${row.observedFeatureType}`);
+      const footprint = formatExpectedFootprintReadback(row.expectedFootprintReadback);
+      if (footprint !== undefined) fields.push(`footprint=${footprint}`);
+      const readbackStatus = resolveExpectedFootprintReadbackStatus(
+        row.featureType,
+        row.expectedFootprintReadback,
+        row.expectedFootprintReadbackStatus
+      );
+      if (readbackStatus !== undefined) fields.push(`readback=${readbackStatus}`);
       return fields.join(":");
     });
   return { count: coordinateRows.length, hash32: hash32Hex(coordinateRows.join("|")) };
 }
 
+function formatExpectedFootprintReadback(
+  readback: readonly NaturalWonderFootprintReadback[] | undefined
+): string | undefined {
+  if (!Array.isArray(readback) || readback.length === 0) return undefined;
+  return readback
+    .map((row) => `${row.plotIndex | 0}:${row.observedFeatureType | 0}`)
+    .join(",");
+}
+
+function resolveExpectedFootprintReadbackStatus(
+  featureType: number,
+  readback: readonly NaturalWonderFootprintReadback[] | undefined,
+  explicitStatus?: NaturalWonderFootprintReadbackStatus
+): NaturalWonderFootprintReadbackStatus | undefined {
+  if (explicitStatus !== undefined) return explicitStatus;
+  if (!Array.isArray(readback) || readback.length === 0) return undefined;
+  const matchingCells = readback.filter((cell) => (cell.observedFeatureType | 0) === (featureType | 0)).length;
+  if (matchingCells === readback.length) return undefined;
+  return matchingCells === 0 ? "empty-expected-footprint" : "partial-expected-footprint";
+}
+
 function formatNaturalWonderRejectionExample(args: {
   featureType: number;
   plotIndex: number;
+  direction: number;
+  elevation?: number;
   reason: string;
   observedPlotIndex?: number;
   observedFeatureType?: number;
+  expectedFootprintReadback?: readonly NaturalWonderFootprintReadback[];
+  expectedFootprintReadbackStatus?: NaturalWonderFootprintReadbackStatus;
 }): string {
+  const footprint = formatExpectedFootprintReadback(args.expectedFootprintReadback);
+  const readbackStatus = resolveExpectedFootprintReadbackStatus(
+    args.featureType,
+    args.expectedFootprintReadback,
+    args.expectedFootprintReadbackStatus
+  );
   return [
     `feature=${args.featureType}`,
     `plot=${args.plotIndex}`,
+    `direction=${args.direction}`,
+    ...(args.elevation === undefined ? [] : [`elevation=${Math.trunc(args.elevation)}`]),
     `reason=${args.reason}`,
     ...(args.observedPlotIndex === undefined ? [] : [`observedPlot=${args.observedPlotIndex}`]),
     ...(args.observedFeatureType === undefined ? [] : [`observedFeature=${args.observedFeatureType}`]),
+    ...(footprint === undefined ? [] : [`footprint=${footprint}`]),
+    ...(readbackStatus === undefined ? [] : [`readback=${readbackStatus}`]),
   ].join(" ");
 }
 
@@ -302,9 +351,13 @@ export function stampNaturalWondersFromPlan({
         formatNaturalWonderRejectionExample({
           featureType,
           plotIndex,
+          direction,
+          elevation: outcome.elevation,
           reason: outcome.reason,
           observedPlotIndex: outcome.observedPlotIndex,
           observedFeatureType: outcome.observedFeatureType,
+          expectedFootprintReadback: outcome.expectedFootprintReadback,
+          expectedFootprintReadbackStatus: outcome.expectedFootprintReadbackStatus,
         })
       );
       coordinateRows.push({
@@ -317,6 +370,12 @@ export function stampNaturalWondersFromPlan({
         reason: outcome.reason,
         ...(outcome.observedPlotIndex === undefined ? {} : { observedPlotIndex: outcome.observedPlotIndex }),
         ...(outcome.observedFeatureType === undefined ? {} : { observedFeatureType: outcome.observedFeatureType }),
+        ...(outcome.expectedFootprintReadback === undefined
+          ? {}
+          : { expectedFootprintReadback: outcome.expectedFootprintReadback }),
+        ...(outcome.expectedFootprintReadbackStatus === undefined
+          ? {}
+          : { expectedFootprintReadbackStatus: outcome.expectedFootprintReadbackStatus }),
       });
       continue;
     }

--- a/mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts
+++ b/mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts
@@ -178,7 +178,7 @@ describe("natural wonder placement materialization", () => {
       coordinateProof: {
         version: 1,
         placed: { count: 0, hash32: "811c9dc5" },
-        rejected: { count: 1 },
+        rejected: { count: 1, hash32: "55a47896" },
       },
       plannedCount: 1,
       targetCount: 1,
@@ -197,16 +197,23 @@ describe("natural wonder placement materialization", () => {
       defaultBiomeType: biomeGlobals.BIOME_PLAINS,
       defaultTerrainType: FLAT_TERRAIN,
     });
-    adapter.placeNaturalWonder = (x, y, featureType, direction) => ({
+    adapter.placeNaturalWonder = (x, y, featureType, direction, elevation) => ({
       status: "rejected",
       plotIndex: y * adapter.width + x,
       x,
       y,
       featureType,
       direction,
+      elevation,
       reason: "readback-mismatch",
       observedPlotIndex: 23,
       observedFeatureType: adapter.NO_FEATURE,
+      expectedFootprintReadback: [
+        { plotIndex: 17, observedFeatureType: featureType },
+        { plotIndex: 23, observedFeatureType: adapter.NO_FEATURE },
+        { plotIndex: 18, observedFeatureType: featureType },
+      ],
+      expectedFootprintReadbackStatus: "partial-expected-footprint",
     });
 
     const stats = stampNaturalWondersFromPlan({
@@ -221,7 +228,7 @@ describe("natural wonder placement materialization", () => {
       coordinateProof: {
         version: 1,
         placed: { count: 0, hash32: "811c9dc5" },
-        rejected: { count: 1, hash32: "5fa1cc6e" },
+        rejected: { count: 1, hash32: "6f806eb2" },
       },
       plannedCount: 1,
       targetCount: 1,
@@ -230,16 +237,16 @@ describe("natural wonder placement materialization", () => {
       shortfallCount: 0,
     });
     expect(stats.rejectionExamples[0]).toBe(
-      "feature=35 plot=17 reason=readback-mismatch observedPlot=23 observedFeature=-1"
+      "feature=35 plot=17 direction=-1 elevation=120 reason=readback-mismatch observedPlot=23 observedFeature=-1 footprint=17:35,23:-1,18:35 readback=partial-expected-footprint"
     );
     expect(buildNaturalWonderPlacementRuntimeTelemetry(stats)).toMatchObject({
       rejectionExampleCount: 1,
       rejectionExamples: [
-        "feature=35 plot=17 reason=readback-mismatch observedPlot=23 observedFeature=-1",
+        "feature=35 plot=17 direction=-1 elevation=120 reason=readback-mismatch observedPlot=23 observedFeature=-1 footprint=17:35,23:-1,18:35 readback=partial-expected-footprint",
       ],
       coordinateProof: {
         rejectedCount: 1,
-        rejectedHash32: "5fa1cc6e",
+        rejectedHash32: "6f806eb2",
       },
     });
   });

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -78,10 +78,12 @@
 - [x] 2.37 Add natural-wonder readback-mismatch observed-context telemetry.
 - [x] 2.38 Preserve source-recorded exact-authored natural-wonder
   readback-context proof.
-- [ ] 2.39 Produce current exact-authored parity proof after the natural-wonder
+- [x] 2.39 Add complete expected-footprint post-write readback telemetry for
+  natural-wonder `readback-mismatch` classification.
+- [ ] 2.40 Produce current exact-authored parity proof after the natural-wonder
   projection/materialization repair.
-- [ ] 2.40 Repair remaining proven package or MapGen owners.
-- [ ] 2.41 Preserve resource spacing, age legality, and diversity expectations.
+- [ ] 2.41 Repair remaining proven package or MapGen owners.
+- [ ] 2.42 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
 
@@ -102,3 +104,5 @@
 - [x] 3.11 Run focused natural-wonder telemetry regression for readback context.
 - [x] 3.12 Preserve source-recorded exact-authored final-surface parity after
   readback-context telemetry.
+- [x] 3.13 Run focused adapter/Swooper expected-footprint telemetry
+  regressions.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1301,6 +1301,33 @@ repair complete, does not authorize cold-reef repair, and does not close
 feature parity, final-surface parity, Earthlike acceptance, product acceptance,
 generated-output ownership, or mountain-quality work.
 
+### Natural-Wonder Post-Write Footprint Proof Contract
+
+Classification status: proof instrumentation only; source authority remains
+open.
+
+The active `earthlike-natural-wonder-postwrite-footprint-proof` layer adds a
+compact adapter/Swooper readback contract for future exact runs. On
+`readback-mismatch`, the adapter can now return the complete expected
+footprint readback vector as `plotIndex:observedFeatureType`, and Swooper
+telemetry carries that vector with a derived `empty-expected-footprint` or
+`partial-expected-footprint` label. Rejection examples also expose the
+requested direction and resolved elevation so the exact log can bind write-call
+inputs to footprint readback outputs. This is the missing evidence needed after
+`mq2w5548`: the predecessor proof had the first expected-empty cell
+(`1427`, `2278`) plus full-grid adjacent live cells (`1426`, `2277`), but not
+the complete immediate post-write footprint readback.
+
+Boundary:
+the new contract does not change placement direction, footprint policy,
+natural-wonder config, generated output, or Civ materialization behavior. It
+does not retroactively classify `mq2w5548`, close natural-wonder repair, close
+feature parity, authorize a placement repair, or improve product acceptance by
+itself. A fresh exact-authored Studio Run in Game must emit the new footprint
+vector before the expected-empty subcondition can be assigned to adapter
+readback oracle, local footprint projection, Civ engine semantics, or evidence
+insufficiency.
+
 ## Required Next Diagnostics
 
 - Classify the natural-wonder expected-empty footprint/readback owner from the

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,10 +6,10 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
-  `codex/swooper-wonder-readback-context-drain`, stacked above
-  `codex/swooper-wonder-named-rejection-proof-drain`; this slice adds
-  readback-mismatch observed-context telemetry and preserves source-recorded
-  exact-authored readback-context evidence.
+  `codex/swooper-wonder-footprint-proof-drain`, stacked above
+  `codex/swooper-wonder-readback-context-drain`; this slice adds complete
+  expected-footprint readback instrumentation above the source-recorded
+  natural-wonder readback-context proof.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface. The natural-wonder
@@ -794,6 +794,21 @@
   not close natural-wonder repair, feature parity, final-surface parity,
   Earthlike acceptance, product acceptance, generated-output ownership, or
   mountain quality.
+- Natural-wonder post-write footprint proof-contract progress:
+  the active proof-instrumentation layer now extends the adapter
+  `NaturalWonderPlacementOutcome` and Swooper `NATURAL_WONDER_PLACEMENT_V1`
+  telemetry so `readback-mismatch` outcomes can carry the complete expected
+  footprint readback vector (`plotIndex:observedFeatureType`) plus an
+  `empty-expected-footprint` or `partial-expected-footprint` label. The visible
+  rejection example also includes the requested direction and resolved
+  elevation, so a fresh exact log can bind the write call to the footprint
+  readback facts without relying on hidden digest inputs. This is
+  instrumentation only. It does not change `Direction` resolution, placement
+  policy, natural-wonder config, generated output, materialization behavior, or
+  parity status. A fresh exact-authored Studio Run in Game must consume this
+  contract before the expected-empty Kilimanjaro/Zhangjiajie subcondition can
+  be classified to adapter readback, local footprint projection, Civ
+  materialization semantics, or evidence insufficiency.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen
@@ -856,6 +871,9 @@
   until the expected-empty footprint/readback owner is source-classified and
   repaired or dispositioned from exact-bound evidence that explains the
   adapter's post-write readback oracle versus Civ's materialized footprint.
+  Current proof instrumentation now records the full expected-footprint
+  readback vector needed by that next exact run, but this local schema/test
+  layer does not itself classify the owner.
   The cold-reef local-only row also remains
   evidence-bound pending exact live feature-apply telemetry/readback. Final-
   surface parity remains open on terrain, feature, resource, and any future

--- a/packages/civ7-adapter/src/civ7-adapter.ts
+++ b/packages/civ7-adapter/src/civ7-adapter.ts
@@ -778,11 +778,19 @@ export class Civ7Adapter implements EngineAdapter {
         reason: "set-feature-false",
       };
     }
-    for (const plotIndex of footprint) {
+    const expectedFootprintReadback = footprint.map((plotIndex) => {
       const fy = Math.trunc(plotIndex / this.width);
       const fx = plotIndex - fy * this.width;
-      const observedFeatureType = GameplayMap.getFeatureType(fx, fy) | 0;
-      if (observedFeatureType !== (featureType | 0)) {
+      return {
+        plotIndex,
+        observedFeatureType: GameplayMap.getFeatureType(fx, fy) | 0,
+      };
+    });
+    for (const readback of expectedFootprintReadback) {
+      if (readback.observedFeatureType !== (featureType | 0)) {
+        const matchingFootprintCells = expectedFootprintReadback.filter(
+          (cell) => cell.observedFeatureType === (featureType | 0)
+        ).length;
         return {
           status: "rejected",
           plotIndex: y * this.width + x,
@@ -792,8 +800,13 @@ export class Civ7Adapter implements EngineAdapter {
           direction,
           elevation: resolvedElevation,
           reason: "readback-mismatch",
-          observedFeatureType,
-          observedPlotIndex: plotIndex,
+          observedFeatureType: readback.observedFeatureType,
+          observedPlotIndex: readback.plotIndex,
+          expectedFootprintReadback,
+          expectedFootprintReadbackStatus:
+            matchingFootprintCells === 0
+              ? "empty-expected-footprint"
+              : "partial-expected-footprint",
         };
       }
     }

--- a/packages/civ7-adapter/src/index.ts
+++ b/packages/civ7-adapter/src/index.ts
@@ -33,6 +33,8 @@ export type {
   ResourcePlacementOutcome,
   ResourcePlacementRejectionReason,
   ResourcePlacementMismatchReason,
+  NaturalWonderFootprintReadback,
+  NaturalWonderFootprintReadbackStatus,
   NaturalWonderPlacementOutcome,
   NaturalWonderPlacementRejectionReason,
   DiscoveryPlacementIntent,

--- a/packages/civ7-adapter/src/types.ts
+++ b/packages/civ7-adapter/src/types.ts
@@ -136,6 +136,15 @@ export type NaturalWonderPlacementRejectionReason =
   | "set-feature-false"
   | "readback-mismatch";
 
+export type NaturalWonderFootprintReadback = {
+  plotIndex: number;
+  observedFeatureType: number;
+};
+
+export type NaturalWonderFootprintReadbackStatus =
+  | "empty-expected-footprint"
+  | "partial-expected-footprint";
+
 export type NaturalWonderPlacementOutcome =
   | {
       status: "placed";
@@ -157,6 +166,8 @@ export type NaturalWonderPlacementOutcome =
       reason: NaturalWonderPlacementRejectionReason;
       observedFeatureType?: number;
       observedPlotIndex?: number;
+      expectedFootprintReadback?: NaturalWonderFootprintReadback[];
+      expectedFootprintReadbackStatus?: NaturalWonderFootprintReadbackStatus;
     };
 
 /**


### PR DESCRIPTION
When a natural wonder placement is rejected due to a `readback-mismatch`, the adapter previously returned only the first mismatched cell (`observedPlotIndex`, `observedFeatureType`). This left the complete post-write footprint state unobservable, making it impossible to distinguish between a fully empty footprint and a partially written one without running another exact Studio session.

This change extends the `readback-mismatch` rejection path to capture and surface the full expected footprint readback:

- Two new types are introduced in the adapter: `NaturalWonderFootprintReadback` (a `plotIndex`/`observedFeatureType` pair) and `NaturalWonderFootprintReadbackStatus` (`"empty-expected-footprint"` or `"partial-expected-footprint"`).
- On a `readback-mismatch`, the adapter now reads back every plot in the expected footprint before returning, attaches the complete vector as `expectedFootprintReadback`, and derives a `expectedFootprintReadbackStatus` based on how many cells matched the expected feature type.
- Swooper's materialization layer propagates both fields through `NaturalWonderPlacementCoordinateRow`, includes them in the coordinate digest hash, and emits them in rejection example strings alongside the requested direction and resolved elevation.
- The rejection example format now reads: `feature=… plot=… direction=… elevation=… reason=… observedPlot=… observedFeature=… footprint=<plotIndex:featureType,…> readback=<status>`.

Tests are updated to reflect the new rejection example format and the revised coordinate proof hashes that result from the additional digest fields.