### PR TITLE
docs(earthlike-resource-legality-repair): record current Studio/Civ runtime start blocker superseding stale floodplainPlanning schema gate

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -84,6 +84,14 @@
   footprint proof artifact.
 - [ ] 2.41 Produce current exact-authored parity proof after the natural-wonder
   projection/materialization repair.
+  - Current checked-in config attempts `studio-run-in-game-mq3koapx-1qxe` and
+    `studio-run-in-game-mq3kvvfs-1qxe` passed materialize/deploy/setup
+    preparation but failed in `starting-game` with `setup-start-timeout` before
+    `begin` was attempted; restart-backed attempt
+    `studio-run-in-game-mq3l0b8p-1qxe` failed in `restarting-civ` because setup
+    shell was not ready within `180000ms`. This supersedes the old stale
+    `floodplainPlanning` schema blocker but does not produce current exact
+    authorship or parity proof.
 - [ ] 2.42 Repair remaining proven package or MapGen owners.
 - [ ] 2.43 Preserve resource spacing, age legality, and diversity expectations.
 
@@ -99,6 +107,9 @@
   natural-wonder projection/materialization repair.
 - [ ] 3.8 Re-run current exact-authored final-surface parity after natural-wonder
   projection/materialization repair.
+  - Blocked on the current Studio/Civ runtime start/reload boundary above; no
+    current `[mapgen-proof]`, `[mapgen-complete]`, exact-authorship packet, or
+    final-surface parity artifact exists for the current branch.
 - [x] 3.9 Run focused adapter/Swooper checks and tests for natural-wonder
   rejection telemetry.
 - [x] 3.10 Preserve source-recorded exact-authored final-surface parity after

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -878,7 +878,7 @@ Validation:
 | Placement contract tests | Passed `bun test mods/mod-swooper-maps/test/placement/placement-contracts.test.ts`. |
 | Owner checks | Passed `bun run --cwd packages/civ7-adapter check`, `bun run --cwd packages/civ7-adapter build`, and `bun run --cwd mods/mod-swooper-maps check`. |
 | OpenSpec strict validation | Passed `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`. |
-| Current exact parity proof rerun | Blocked before parity evaluation by stale config key `/config/ecology-features/floodplainPlanning`; no parity closure claimed. |
+| Current exact parity proof rerun | Superseded by current checked-in config run attempts: the stale `floodplainPlanning` schema blocker is no longer active, but parity closure is still not claimed. |
 
 ### Natural-Wonder Exact Log Telemetry Binding
 
@@ -908,7 +908,7 @@ Current drain validation:
 | Diagnostics/parity/materialization tests | Passed `bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts`. |
 | Owner checks | Passed `bun run --cwd mods/mod-swooper-maps check` and `bun run --cwd apps/mapgen-studio check`. |
 | OpenSpec strict validation | Passed `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict` and `bun run openspec:validate`. |
-| Current exact parity proof rerun | Blocked before parity evaluation by stale config key `/config/ecology-features/floodplainPlanning`; no parity closure claimed. |
+| Current exact parity proof rerun | Superseded by current checked-in config run attempts: the stale `floodplainPlanning` schema blocker is no longer active, but parity closure is still not claimed. |
 
 ### Source-Recorded Fresh Natural-Wonder Telemetry Proof
 
@@ -984,7 +984,7 @@ Current drain validation:
 | Diagnostics/parity/materialization tests | Passed `bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts`. |
 | Owner checks | Passed `bun run --cwd mods/mod-swooper-maps check` and `bun run --cwd apps/mapgen-studio check`. |
 | OpenSpec strict validation | Passed `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict` and `bun run openspec:validate`. |
-| Current exact parity proof rerun | Blocked before parity evaluation by stale config key `/config/ecology-features/floodplainPlanning`; no parity closure claimed. |
+| Current exact parity proof rerun | Superseded by current checked-in config run attempts: the stale `floodplainPlanning` schema blocker is no longer active, but parity closure is still not claimed. |
 
 ### Source-Recorded Fresh Natural-Wonder Coordinate Proof
 
@@ -1112,10 +1112,28 @@ Current drain validation:
 `git diff --check && git diff --cached --check`.
 
 Current exact parity rerun:
-blocked before parity evaluation. The rerun command
-`bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-direction-repair.json`
-returned
-`Recipe compile failed: /config/ecology-features/floodplainPlanning: Unknown key`.
+the older saved-wrapper rerun was blocked before parity evaluation by stale
+`/config/ecology-features/floodplainPlanning`; that stale-config blocker is no
+longer the active current-config blocker. The current drain rebuilt the request
+from the checked-in Swooper Earthlike config and launched Studio Run in Game
+through the worktree-local endpoint. Requests `studio-run-in-game-mq3koapx-1qxe`
+and `studio-run-in-game-mq3kvvfs-1qxe` both materialized/deployed the current
+`studio-current.js` and prepared setup, then failed in `starting-game` with
+`setup-start-timeout` before `begin` was attempted. The fresh Scripting log
+reported
+`Failed to load file into script system - fs://game/swooper-maps/maps/studio-current.js`.
+Restart-backed request `studio-run-in-game-mq3l0b8p-1qxe` then failed in
+`restarting-civ` because setup shell was not ready within `180000ms`. Current
+status artifacts are
+`/tmp/civ7-recovery-proof/final-surface-parity/current-drain-postwrite-footprint-run-status.json`
+(`sha256:50d01a5ac3fa6fc2f882c8e6f3661ab3d19e447a44d5c76835117065087fc72d`),
+`/tmp/civ7-recovery-proof/final-surface-parity/current-drain-postwrite-footprint-retry-status.json`
+(`sha256:0eeae66d995be2f07cf5b1017e78364cdb33103ffa870af87aa3a9ce426c6d51`),
+and
+`/tmp/civ7-recovery-proof/final-surface-parity/current-drain-postwrite-footprint-restart-status.json`
+(`sha256:cd2a8ab4df93292819f75f1b81de64cbc5c522dcbda79afef5405ff99dc869f7`).
+No current exact-authorship, final-surface parity, or product acceptance proof
+is claimed from these attempts.
 
 Source-recorded post-repair proof:
 request `studio-run-in-game-mq2u6wdg-1z4g` completed exact authorship and
@@ -1387,6 +1405,8 @@ mountain-quality work.
 - Continue resource-row classification using source-recorded coordinate proof
   and runtime-bound row evidence where applicable before changing resource
   tuning, scarcity floors, assignment ordering, or static policy; obtain a
-  current exact-authored run before final closure.
+  current exact-authored run before final closure. The current config now
+  passes the stale schema key boundary, but Studio/Civ runtime start/reload
+  currently blocks before mapgen proof markers.
 - For resource rows, preserve resource spacing, age legality, and diversity
   evidence before any repair.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,10 +6,11 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
-  `codex/swooper-wonder-footprint-proof-record-drain`, stacked above
-  `codex/swooper-wonder-footprint-proof-drain`; this slice preserves
-  source-recorded exact-authored post-write footprint proof above the
-  expected-footprint readback instrumentation layer.
+  `codex/swooper-current-runtime-proof-blocker-drain`, stacked above
+  `codex/swooper-wonder-footprint-proof-record-drain`; this slice records the
+  current checked-in config runtime-proof blocker above the source-recorded
+  post-write footprint proof and expected-footprint readback instrumentation
+  layers.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface. The natural-wonder
@@ -18,8 +19,10 @@
   footprint proof reports `5` placed / `2` rejected, now narrowed to partial
   expected-footprint readback vectors at observed plots `1427` and `2278` for
   Kilimanjaro and Zhangjiajie. The cold-reef feature row is evidence-bound
-  because exact live feature-apply telemetry is absent. Current exact proof
-  still blocks on stale config before parity evaluation, and resource classes
+  because exact live feature-apply telemetry is absent. Current exact proof no
+  longer blocks on the stale `floodplainPlanning` key when launched from the
+  current checked-in config, but it now blocks at the Studio/Civ runtime start
+  boundary before mapgen proof markers or parity evaluation. Resource classes
   remain pending source-authority classification.
 
 ## Objective
@@ -472,7 +475,8 @@
   `bun run --cwd packages/civ7-adapter build`;
   `bun run --cwd mods/mod-swooper-maps check`;
   `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`.
-  Current exact parity rerun remains blocked before parity evaluation:
+  Historical saved-wrapper parity rerun at this slice was blocked before
+  parity evaluation:
   `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-materialization-repair.json`
   returned
   `Recipe compile failed: /config/ecology-features/floodplainPlanning: Unknown key`.
@@ -496,7 +500,8 @@
   `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`;
   `bun run openspec:validate`;
   `git diff --check && git diff --cached --check`.
-  Current exact parity rerun remains blocked before parity evaluation:
+  Historical saved-wrapper parity rerun at this slice was blocked before
+  parity evaluation:
   `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-telemetry.json`
   returned
   `Recipe compile failed: /config/ecology-features/floodplainPlanning: Unknown key`.
@@ -553,7 +558,8 @@
   `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`;
   `bun run openspec:validate`;
   `git diff --check && git diff --cached --check`.
-  Current exact parity rerun remains blocked before parity evaluation:
+  Historical saved-wrapper parity rerun at this slice was blocked before
+  parity evaluation:
   `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-coordinate-proof.json`
   returned
   `Recipe compile failed: /config/ecology-features/floodplainPlanning: Unknown key`.
@@ -642,7 +648,8 @@
   `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`;
   `bun run openspec:validate`;
   `git diff --check && git diff --cached --check`.
-  Current exact parity rerun remains blocked before parity evaluation:
+  Historical saved-wrapper parity rerun at this slice was blocked before
+  parity evaluation:
   `bun run verify:final-surface-parity -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-exact-proof-wrapper.json --output /tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-direction-repair.json`
   returned
   `Recipe compile failed: /config/ecology-features/floodplainPlanning: Unknown key`.
@@ -843,6 +850,40 @@
   the requested feature. It narrows the owner question to Civ natural-wonder
   footprint/materialization semantics versus the local/adapter post-write
   readback oracle, but it does not yet classify repair authority.
+- Current exact-authored proof attempt after post-write footprint telemetry:
+  the current drain launched the checked-in Swooper Earthlike config through the
+  worktree-local Studio endpoint on branch
+  `codex/swooper-wonder-footprint-proof-record-drain` /
+  `codex/swooper-current-runtime-proof-blocker-drain` using request body
+  `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-postwrite-footprint-run-request.json`
+  (`sha256:13f93c6b30f0ed3d41f83854c6e08de39fb501aab9c86c92207f2cb5990fffa3`).
+  This proves the current config surface no longer fails the old
+  `/config/ecology-features/floodplainPlanning` schema gate. The first request
+  `studio-run-in-game-mq3koapx-1qxe` and normal retry
+  `studio-run-in-game-mq3kvvfs-1qxe` both completed materialization, deploy,
+  direct-control availability, setup-row visibility, and setup preparation,
+  then failed in `starting-game` with direct-control code
+  `setup-start-timeout`. Their status artifacts are
+  `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-postwrite-footprint-run-status.json`
+  (`sha256:50d01a5ac3fa6fc2f882c8e6f3661ab3d19e447a44d5c76835117065087fc72d`)
+  and
+  `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-postwrite-footprint-retry-status.json`
+  (`sha256:0eeae66d995be2f07cf5b1017e78364cdb33103ffa870af87aa3a9ce426c6d51`).
+  Both captured `beginAttempted:false`; Civ briefly entered loading states
+  `WaitingForGameplayData` and `WaitingForConfiguration` and then returned to
+  shell. Fresh `Scripting.log` lines for the same window reported
+  `Failed to load file into script system - fs://game/swooper-maps/maps/studio-current.js`
+  even though the local and deployed `studio-current.js` hashes matched the
+  Studio materialization record. A restart-backed request
+  `studio-run-in-game-mq3l0b8p-1qxe` then completed materialization and deploy
+  but failed in `restarting-civ` with
+  `Civ7 process restarted but setup shell was not ready within 180000ms`; its
+  status artifact is
+  `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-postwrite-footprint-restart-status.json`
+  (`sha256:cd2a8ab4df93292819f75f1b81de64cbc5c522dcbda79afef5405ff99dc869f7`).
+  This is a current runtime/control blocker, not a source parity result: no
+  current `[mapgen-proof]`, `[mapgen-complete]`, exact-authorship packet,
+  final-surface parity proof, or product acceptance proof was produced.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the remaining feature/resource rows by source
   authority: official data, adapter/map-policy, MapGen


### PR DESCRIPTION
Three Studio Run in Game attempts were made against the current checked-in Swooper Earthlike config to produce a current exact-authored parity proof after the post-write footprint telemetry work.

The stale `/config/ecology-features/floodplainPlanning` schema key is no longer the active blocker — the current config passes that gate. However, parity closure is still not claimed. Requests `studio-run-in-game-mq3koapx-1qxe` and `studio-run-in-game-mq3kvvfs-1qxe` completed materialization, deploy, and setup preparation but failed in `starting-game` with `setup-start-timeout` before `begin` was attempted; both captured `beginAttempted:false`. The Scripting log reported `Failed to load file into script system - fs://game/swooper-maps/maps/studio-current.js` despite local and deployed hash agreement with the Studio materialization record. A restart-backed attempt `studio-run-in-game-mq3l0b8p-1qxe` completed materialization and deploy but failed in `restarting-civ` because the setup shell was not ready within `180000ms`.

Status artifacts with their SHA-256 hashes are recorded for all three attempts. No current `[mapgen-proof]`, `[mapgen-complete]`, exact-authorship packet, final-surface parity proof, or product acceptance proof was produced. The branch is updated from `codex/swooper-wonder-footprint-proof-record-drain` to `codex/swooper-current-runtime-proof-blocker-drain` to reflect that the active blocker is now the Studio/Civ runtime start/reload boundary rather than the stale schema key. All prior phase-record and ledger entries that attributed the block to `floodplainPlanning` are updated to clarify they describe the historical saved-wrapper rerun, not the current config state.