### PR TITLE
feat(run-in-game): classify start-phase map-script load failures with notification-dismiss recovery

### DIFF
--- a/apps/mapgen-studio/test/runInGame/operationState.test.ts
+++ b/apps/mapgen-studio/test/runInGame/operationState.test.ts
@@ -91,6 +91,21 @@ describe("Run in Game operation store", () => {
     expect(failed.recoveryActions).not.toContain("restart-civ-process-and-retry");
   });
 
+  it("surfaces Civ notification dismissal recovery for start-phase map script load failures", () => {
+    const { store } = createStore();
+    store.create("request-1");
+    const failed = store.fail("request-1", "starting-game", new RunInGameHttpError(500, "Civ7 could not load generated map script", {
+      code: "map-script-load-failed",
+      dismissNotificationRequired: true,
+      recoveryBoundary: "civ-notification-dismiss",
+    }));
+
+    expect(failed.status).toBe("failed");
+    expect(failed.phase).toBe("failed");
+    expect(failed.details?.phase).toBe("starting-game");
+    expect(failed.recoveryActions).toContain("dismiss-civ-notification-and-retry");
+  });
+
   it("classifies socket uncertainty after start without replaying the mutation", () => {
     const { store } = createStore();
     store.create("request-1");

--- a/apps/mapgen-studio/vite.config.ts
+++ b/apps/mapgen-studio/vite.config.ts
@@ -881,7 +881,18 @@ export default defineConfig(({ command }) => ({
                   },
                   { timeoutMs: DEFAULT_CIV7_TUNER_TIMEOUT_MS },
                   { approved: true, reason: "Studio Run in Game", disposableSession: true },
-                );
+                ).catch(async (err: unknown) => {
+                  const freshLogText = await readFreshLogText(scriptingLogPath, scriptingSnapshot).catch(() => "");
+                  const mapgenFailure = classifyCiv7MapgenLogFailure(freshLogText, { mapScript: launchMapScript });
+                  if (mapgenFailure) {
+                    throw new RunInGameHttpError(500, mapgenFailure.message, {
+                      ...mapgenFailure,
+                      materialization,
+                      cause: cloneForJson(err instanceof Civ7DirectControlError ? err.details : err),
+                    });
+                  }
+                  throw err;
+                });
 
                 phase = "waiting-for-proof";
                 runInGameOperations.update(requestId, { phase, materialization });

--- a/openspec/changes/studio-save-run-state-machine/design.md
+++ b/openspec/changes/studio-save-run-state-machine/design.md
@@ -29,6 +29,11 @@ Failed to load file into script system - fs://game/swooper-maps/maps/studio-curr
 This is a deploy/load boundary failure, not a map-generation algorithm proof by
 itself. The durable fix is to keep deploys dependency-aware and stop Studio from
 letting Save/Deploy and Run in Game race each other.
+If Civ drops back to shell during `starting-game`, Studio also checks the fresh
+Scripting log window before recording a generic start timeout. A detected
+`studio-current.js` load failure is surfaced as `map-script-load-failed` with
+notification-dismiss recovery, even if the game never reaches the later
+mapgen-proof wait.
 
 ## Save/Deploy
 
@@ -43,6 +48,10 @@ If Run in Game blocks because Civ setup cannot see a disposable row after an
 exit-to-shell refresh, Studio records `reloadBoundary:
 process-restart-required`. The primary action becomes `Restart Civ & Run`, which
 reissues a fresh Run in Game request with explicit process-restart recovery.
+If Civ emits a fatal generated-script load notification during start, Studio
+records `recoveryBoundary: civ-notification-dismiss`; this is a different
+recovery surface from process restart and should not be collapsed into row
+visibility.
 
 ## Vite/Turbo
 

--- a/openspec/changes/studio-save-run-state-machine/specs/mapgen-studio/spec.md
+++ b/openspec/changes/studio-save-run-state-machine/specs/mapgen-studio/spec.md
@@ -79,3 +79,14 @@ newly deployed disposable setup row.
 - **WHEN** Run in Game blocks with `reloadBoundary: process-restart-required`
 - **THEN** Studio offers `Restart Civ & Run` as the primary launch action
 - **AND** the next launch request records explicit process-restart recovery
+
+### Requirement: Start-Phase Map Script Load Failures Are Classified
+
+Mapgen Studio SHALL preserve the fatal generated-map-script load boundary even
+when Civ reports it while Run in Game is still starting the prepared game.
+
+#### Scenario: Civ drops back to shell after failing to load studio-current
+- **WHEN** Run in Game fails during `starting-game`
+- **AND** the fresh Scripting log contains a generated map script load failure
+- **THEN** the operation status records `map-script-load-failed`
+- **AND** the recovery actions include `dismiss-civ-notification-and-retry`

--- a/openspec/changes/studio-save-run-state-machine/tasks.md
+++ b/openspec/changes/studio-save-run-state-machine/tasks.md
@@ -22,6 +22,8 @@
   Game instead of relying only on disabled buttons.
 - [x] 2.10 Base durable Run in Game materialization on saved/deployed config
   provenance rather than browser-preview dirtiness alone.
+- [x] 2.11 Classify fresh map-script load failures during Run in Game
+  `starting-game` instead of reducing them to generic setup start timeouts.
 
 ## 3. Verification
 
@@ -33,6 +35,8 @@
   store behavior.
 - [x] 3.6 Restart Studio dev server and collect browser proof.
 - [x] 3.7 Probe the live save-route lifecycle rejection and status endpoint.
+- [x] 3.8 Add focused operation-state regression for start-phase map-script
+  load failures.
 
 ## 4. Closure
 


### PR DESCRIPTION
When Civ7 drops back to the shell during the `starting-game` phase, Run in Game previously recorded a generic start timeout rather than identifying the underlying cause. This change adds log inspection at that failure boundary: if the fresh Scripting log contains a `studio-current.js` load failure, the operation is now classified as `map-script-load-failed` with `recoveryBoundary: civ-notification-dismiss`, surfacing `dismiss-civ-notification-and-retry` as a recovery action instead of collapsing it into the process-restart path.

A focused regression test covers the new classification, confirming that a `RunInGameHttpError` carrying `map-script-load-failed` and `dismissNotificationRequired: true` during `starting-game` produces the correct status, phase, and recovery actions.