### PR TITLE
feat(run-in-game): add Steam launch retry with process-start polling and bounded attempt tracking

### DIFF
--- a/apps/mapgen-studio/src/features/runInGame/status.ts
+++ b/apps/mapgen-studio/src/features/runInGame/status.ts
@@ -66,6 +66,12 @@ export type RunInGameRequestStatus = Readonly<{
   sourceSnapshot?: RunInGameSourceSnapshotProof;
 }>;
 
+export type RunInGameProcessRestartStatus = Readonly<{
+  command?: string;
+  launchAttempts?: unknown;
+  [key: string]: unknown;
+}>;
+
 export type RunInGameFailureDetails = Readonly<{
   failureClass?: string;
   code?: string;
@@ -187,6 +193,7 @@ export type RunInGameOperationStatus = Readonly<{
   completedPhases: ReadonlyArray<RunInGamePhase>;
   request?: RunInGameRequestStatus;
   materialization?: RunInGameMaterializationStatus;
+  processRestart?: RunInGameProcessRestartStatus;
   exactAuthorshipProof?: RunInGameExactAuthorshipProof;
   error?: string;
   details?: RunInGameFailureDetails;
@@ -284,6 +291,7 @@ export function formatRunInGameDiagnostics(status: RunInGameOperationStatus): st
     completedPhases: status.completedPhases,
     request: status.request,
     materialization: status.materialization,
+    processRestart: status.processRestart,
     exactAuthorshipProof: status.exactAuthorshipProof,
     error: status.error,
     details: status.details,

--- a/apps/mapgen-studio/src/server/runInGame/macosProcessRestart.ts
+++ b/apps/mapgen-studio/src/server/runInGame/macosProcessRestart.ts
@@ -17,6 +17,12 @@ export type WaitForMacProcessExitResult = {
   stableAbsentPolls: number;
 };
 
+export type WaitForMacProcessStartResult = {
+  started: boolean;
+  elapsedMs: number;
+  polls: number;
+};
+
 export type Civ7MacProcessShutdownResult = {
   quit: CommandOutput;
   gracefulExit: WaitForMacProcessExitResult;
@@ -38,6 +44,43 @@ export type Civ7MacProcessShutdownOptions = {
   pollIntervalMs: number;
   stableAbsentPolls: number;
 };
+
+export type Civ7MacSteamLaunchAttempt = {
+  attempt: number;
+  command: string;
+  launch: CommandOutput;
+  processStart: WaitForMacProcessStartResult;
+};
+
+export type Civ7MacSteamLaunchResult = {
+  command: string;
+  attempts: Civ7MacSteamLaunchAttempt[];
+  processStart: WaitForMacProcessStartResult;
+};
+
+export type Civ7MacSteamLaunchOptions = {
+  execFileAsync: ExecFileAsync;
+  sleep: (ms: number) => Promise<void>;
+  tail: (value: string) => string;
+  now?: () => number;
+  steamAppId: string;
+  processPattern: string;
+  launchCommandTimeoutMs: number;
+  processStartTimeoutMs: number;
+  pollIntervalMs: number;
+  maxLaunchAttempts: number;
+  retryDelayMs: number;
+};
+
+export class Civ7MacSteamLaunchError extends Error {
+  constructor(
+    message: string,
+    readonly attempts: Civ7MacSteamLaunchAttempt[],
+  ) {
+    super(message);
+    this.name = "Civ7MacSteamLaunchError";
+  }
+}
 
 function commandOutput(command: string, stdout: string, stderr: string, tail: (value: string) => string): CommandOutput {
   return { command, stdout: tail(stdout), stderr: tail(stderr) };
@@ -77,6 +120,38 @@ export async function isMacProcessRunning(
   }
 }
 
+export async function waitForMacProcessStart(options: {
+  execFileAsync: ExecFileAsync;
+  sleep: (ms: number) => Promise<void>;
+  now?: () => number;
+  processPattern: string;
+  timeoutMs: number;
+  pollIntervalMs: number;
+}): Promise<WaitForMacProcessStartResult> {
+  const now = options.now ?? Date.now;
+  const startedAt = now();
+  let polls = 0;
+
+  while (now() - startedAt <= options.timeoutMs) {
+    polls += 1;
+    const running = await isMacProcessRunning(options.execFileAsync, options.processPattern);
+    if (running) {
+      return {
+        started: true,
+        elapsedMs: now() - startedAt,
+        polls,
+      };
+    }
+    await options.sleep(options.pollIntervalMs);
+  }
+
+  return {
+    started: false,
+    elapsedMs: now() - startedAt,
+    polls,
+  };
+}
+
 export async function waitForMacProcessExit(options: {
   execFileAsync: ExecFileAsync;
   sleep: (ms: number) => Promise<void>;
@@ -112,6 +187,52 @@ export async function waitForMacProcessExit(options: {
     polls,
     stableAbsentPolls,
   };
+}
+
+export async function launchCiv7MacViaSteamWithRetries(
+  options: Civ7MacSteamLaunchOptions,
+): Promise<Civ7MacSteamLaunchResult> {
+  const launchCommand = `open steam://rungameid/${options.steamAppId}`;
+  const attempts: Civ7MacSteamLaunchAttempt[] = [];
+  const maxLaunchAttempts = Math.max(1, Math.floor(options.maxLaunchAttempts));
+
+  for (let attempt = 1; attempt <= maxLaunchAttempts; attempt += 1) {
+    const launch = await options.execFileAsync("open", [`steam://rungameid/${options.steamAppId}`], {
+      timeout: options.launchCommandTimeoutMs,
+      maxBuffer: 1024 * 1024,
+    });
+    const processStart = await waitForMacProcessStart({
+      execFileAsync: options.execFileAsync,
+      sleep: options.sleep,
+      now: options.now,
+      processPattern: options.processPattern,
+      timeoutMs: options.processStartTimeoutMs,
+      pollIntervalMs: options.pollIntervalMs,
+    });
+    attempts.push({
+      attempt,
+      command: launchCommand,
+      launch: commandOutput(launchCommand, launch.stdout, launch.stderr, options.tail),
+      processStart,
+    });
+
+    if (processStart.started) {
+      return {
+        command: attempts.length === 1 ? launchCommand : `${launchCommand} (${attempts.length} attempts)`,
+        attempts,
+        processStart,
+      };
+    }
+
+    if (attempt < maxLaunchAttempts) {
+      await options.sleep(options.retryDelayMs);
+    }
+  }
+
+  throw new Civ7MacSteamLaunchError(
+    `Civ7 process did not start after ${attempts.length} Steam launch attempt(s)`,
+    attempts,
+  );
 }
 
 async function runPossiblyEmptyPkill(

--- a/apps/mapgen-studio/test/runInGame/macosProcessRestart.test.ts
+++ b/apps/mapgen-studio/test/runInGame/macosProcessRestart.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  launchCiv7MacViaSteamWithRetries,
   shutdownCiv7MacProcess,
   waitForMacProcessExit,
+  waitForMacProcessStart,
   type ExecFileAsync,
 } from "../../src/server/runInGame/macosProcessRestart";
 
@@ -52,6 +54,67 @@ describe("macOS Civ7 process restart helpers", () => {
       polls: 5,
       stableAbsentPolls: 2,
     });
+  });
+
+  it("waits until the Civ process starts after launch", async () => {
+    const harness = createHarness([false, false, true]);
+
+    const result = await waitForMacProcessStart({
+      execFileAsync: harness.execFileAsync,
+      sleep: harness.sleep,
+      now: harness.now,
+      processPattern: "CivilizationVII.app/Contents/MacOS/CivilizationVII",
+      timeoutMs: 10_000,
+      pollIntervalMs: 1_000,
+    });
+
+    expect(result).toMatchObject({
+      started: true,
+      polls: 3,
+      elapsedMs: 2_000,
+    });
+  });
+
+  it("retries Steam launch when open succeeds but Civ does not start", async () => {
+    const harness = createHarness([false, true]);
+
+    const result = await launchCiv7MacViaSteamWithRetries({
+      execFileAsync: harness.execFileAsync,
+      sleep: harness.sleep,
+      now: harness.now,
+      tail: (value) => value,
+      steamAppId: "1295660",
+      processPattern: "CivilizationVII.app/Contents/MacOS/CivilizationVII",
+      launchCommandTimeoutMs: 10_000,
+      processStartTimeoutMs: 0,
+      pollIntervalMs: 1_000,
+      maxLaunchAttempts: 2,
+      retryDelayMs: 500,
+    });
+
+    expect(result.command).toBe("open steam://rungameid/1295660 (2 attempts)");
+    expect(result.attempts.map((attempt) => attempt.processStart.started)).toEqual([false, true]);
+    expect(harness.calls.filter((call) => call.file === "open")).toHaveLength(2);
+  });
+
+  it("throws when Steam never starts the Civ process", async () => {
+    const harness = createHarness([false, false]);
+
+    await expect(launchCiv7MacViaSteamWithRetries({
+      execFileAsync: harness.execFileAsync,
+      sleep: harness.sleep,
+      now: harness.now,
+      tail: (value) => value,
+      steamAppId: "1295660",
+      processPattern: "CivilizationVII.app/Contents/MacOS/CivilizationVII",
+      launchCommandTimeoutMs: 10_000,
+      processStartTimeoutMs: 0,
+      pollIntervalMs: 1_000,
+      maxLaunchAttempts: 2,
+      retryDelayMs: 500,
+    })).rejects.toThrow("Civ7 process did not start after 2 Steam launch attempt");
+
+    expect(harness.calls.filter((call) => call.file === "open")).toHaveLength(2);
   });
 
   it("escalates to pkill and waits before returning from shutdown", async () => {

--- a/apps/mapgen-studio/test/runInGame/operationState.test.ts
+++ b/apps/mapgen-studio/test/runInGame/operationState.test.ts
@@ -94,6 +94,13 @@ describe("Run in Game operation store", () => {
   it("surfaces Civ notification dismissal recovery for start-phase map script load failures", () => {
     const { store } = createStore();
     store.create("request-1");
+    store.update("request-1", {
+      phase: "restarting-civ",
+      processRestart: {
+        command: "open steam://rungameid/1295660",
+        launchAttempts: [{ attempt: 1, processStart: { started: true } }],
+      },
+    });
     const failed = store.fail("request-1", "starting-game", new RunInGameHttpError(500, "Civ7 could not load generated map script", {
       code: "map-script-load-failed",
       dismissNotificationRequired: true,
@@ -103,6 +110,10 @@ describe("Run in Game operation store", () => {
     expect(failed.status).toBe("failed");
     expect(failed.phase).toBe("failed");
     expect(failed.details?.phase).toBe("starting-game");
+    expect(failed.processRestart).toMatchObject({
+      command: "open steam://rungameid/1295660",
+      launchAttempts: [{ attempt: 1, processStart: { started: true } }],
+    });
     expect(failed.recoveryActions).toContain("dismiss-civ-notification-and-retry");
   });
 

--- a/apps/mapgen-studio/vite.config.ts
+++ b/apps/mapgen-studio/vite.config.ts
@@ -44,7 +44,10 @@ import {
   parseSwooperMapgenLogProof,
 } from "./src/server/runInGame/proofIdentity";
 import { parseRunInGameSetupRequest } from "./src/server/runInGame/requestValidation";
-import { shutdownCiv7MacProcess } from "./src/server/runInGame/macosProcessRestart";
+import {
+  launchCiv7MacViaSteamWithRetries,
+  shutdownCiv7MacProcess,
+} from "./src/server/runInGame/macosProcessRestart";
 import { buildSwooperMapsStudioDeployCommand } from "./src/server/mapConfigs/deploy";
 import { createMapConfigSaveDeployOperationStore } from "./src/server/mapConfigs/operationState";
 import { parseMapConfigSaveRequest } from "./src/server/mapConfigs/requestValidation";
@@ -64,6 +67,10 @@ const CIV7_PROCESS_FORCE_KILL_TIMEOUT_MS = 15_000;
 const CIV7_PROCESS_RESTART_WAIT_TIMEOUT_MS = 180_000;
 const CIV7_PROCESS_RESTART_POLL_INTERVAL_MS = 2_000;
 const CIV7_PROCESS_EXIT_STABLE_POLLS = 2;
+const CIV7_PROCESS_LAUNCH_COMMAND_TIMEOUT_MS = 10_000;
+const CIV7_PROCESS_LAUNCH_START_TIMEOUT_MS = 20_000;
+const CIV7_PROCESS_LAUNCH_ATTEMPTS = 6;
+const CIV7_PROCESS_LAUNCH_RETRY_DELAY_MS = 5_000;
 const STUDIO_SERVER_STARTED_AT = new Date().toISOString();
 const STUDIO_SERVER_INSTANCE_ID = createCiv7ControlRequestId("studio-server");
 
@@ -115,6 +122,7 @@ async function restartCiv7ProcessViaSteam(): Promise<{
   forceKill?: { command: string; stdout: string; stderr: string };
   shutdown: Awaited<ReturnType<typeof shutdownCiv7MacProcess>>;
   launch: { command: string; stdout: string; stderr: string };
+  launchAttempts: Awaited<ReturnType<typeof launchCiv7MacViaSteamWithRetries>>["attempts"];
   setupPhase?: string;
 }> {
   if (process.platform !== "darwin") {
@@ -133,11 +141,20 @@ async function restartCiv7ProcessViaSteam(): Promise<{
     stableAbsentPolls: CIV7_PROCESS_EXIT_STABLE_POLLS,
   });
 
-  const launchCommand = `open steam://rungameid/${CIV7_STEAM_APP_ID}`;
-  const launch = await execFileAsync("open", [`steam://rungameid/${CIV7_STEAM_APP_ID}`], {
-    timeout: 10_000,
-    maxBuffer: 1024 * 1024,
+  const steamLaunch = await launchCiv7MacViaSteamWithRetries({
+    execFileAsync,
+    sleep,
+    tail,
+    steamAppId: CIV7_STEAM_APP_ID,
+    processPattern: CIV7_PROCESS_PATTERN,
+    launchCommandTimeoutMs: CIV7_PROCESS_LAUNCH_COMMAND_TIMEOUT_MS,
+    processStartTimeoutMs: CIV7_PROCESS_LAUNCH_START_TIMEOUT_MS,
+    pollIntervalMs: CIV7_PROCESS_RESTART_POLL_INTERVAL_MS,
+    maxLaunchAttempts: CIV7_PROCESS_LAUNCH_ATTEMPTS,
+    retryDelayMs: CIV7_PROCESS_LAUNCH_RETRY_DELAY_MS,
   });
+  const launch = steamLaunch.attempts[steamLaunch.attempts.length - 1]?.launch;
+  if (!launch) throw new Error("Civ7 Steam launch did not record an attempt");
 
   const startedAt = Date.now();
   let setupPhase: string | undefined;
@@ -157,12 +174,13 @@ async function restartCiv7ProcessViaSteam(): Promise<{
   }
 
   return {
-    command: `${shutdown.quit.command} && ${launchCommand}`,
+    command: `${shutdown.quit.command} && ${steamLaunch.command}`,
     quit: shutdown.quit,
     ...(shutdown.kill === undefined ? {} : { kill: shutdown.kill }),
     ...(shutdown.forceKill === undefined ? {} : { forceKill: shutdown.forceKill }),
     shutdown,
-    launch: { command: launchCommand, stdout: tail(launch.stdout), stderr: tail(launch.stderr) },
+    launch,
+    launchAttempts: steamLaunch.attempts,
     setupPhase,
   };
 }
@@ -817,6 +835,7 @@ export default defineConfig(({ command }) => ({
                   phase = "restarting-civ";
                   runInGameOperations.update(requestId, { phase, materialization });
                   processRestart = await restartCiv7ProcessViaSteam();
+                  runInGameOperations.update(requestId, { phase, materialization, processRestart });
                 }
 
                 phase = "checking-civ7";

--- a/openspec/changes/studio-save-run-state-machine/design.md
+++ b/openspec/changes/studio-save-run-state-machine/design.md
@@ -48,6 +48,10 @@ If Run in Game blocks because Civ setup cannot see a disposable row after an
 exit-to-shell refresh, Studio records `reloadBoundary:
 process-restart-required`. The primary action becomes `Restart Civ & Run`, which
 reissues a fresh Run in Game request with explicit process-restart recovery.
+During process-restart recovery, Studio must treat Steam launch completion as a
+request to launch, not proof that Civ is alive. It retries the Steam launch until
+the Civ process is observed or the bounded launch retry window is exhausted, and
+records the launch attempts in the restart status payload.
 If Civ emits a fatal generated-script load notification during start, Studio
 records `recoveryBoundary: civ-notification-dismiss`; this is a different
 recovery surface from process restart and should not be collapsed into row

--- a/openspec/changes/studio-save-run-state-machine/specs/mapgen-studio/spec.md
+++ b/openspec/changes/studio-save-run-state-machine/specs/mapgen-studio/spec.md
@@ -80,6 +80,14 @@ newly deployed disposable setup row.
 - **THEN** Studio offers `Restart Civ & Run` as the primary launch action
 - **AND** the next launch request records explicit process-restart recovery
 
+#### Scenario: Steam launch returns before Civ process is alive
+- **WHEN** a process-restart recovery request relaunches Civ through Steam
+- **AND** the Steam open command returns without an observable Civ process
+- **THEN** Studio retries the Steam launch within a bounded retry window
+- **AND** records the launch attempts in the restart status payload
+- **AND** fails the operation if Civ still does not start after the bounded
+  attempts
+
 ### Requirement: Start-Phase Map Script Load Failures Are Classified
 
 Mapgen Studio SHALL preserve the fatal generated-map-script load boundary even

--- a/openspec/changes/studio-save-run-state-machine/tasks.md
+++ b/openspec/changes/studio-save-run-state-machine/tasks.md
@@ -24,6 +24,8 @@
   provenance rather than browser-preview dirtiness alone.
 - [x] 2.11 Classify fresh map-script load failures during Run in Game
   `starting-game` instead of reducing them to generic setup start timeouts.
+- [x] 2.12 Retry Steam launch during explicit process-restart recovery until the
+  Civ process is observed or bounded launch attempts are exhausted.
 
 ## 3. Verification
 
@@ -37,6 +39,7 @@
 - [x] 3.7 Probe the live save-route lifecycle rejection and status endpoint.
 - [x] 3.8 Add focused operation-state regression for start-phase map-script
   load failures.
+- [x] 3.9 Add focused macOS restart-launch retry regressions.
 
 ## 4. Closure
 


### PR DESCRIPTION
During process-restart recovery on macOS, the Steam `open` command can return successfully before the Civ VII process is actually alive. Previously, the restart flow issued a single Steam launch command and moved on without verifying the process had started.

This adds retry logic to the macOS Steam launch path so that Studio polls for the Civ process after each `open` invocation and retries up to a configurable maximum number of attempts before failing. The launch command, per-attempt results, and process-start polling outcome are captured in a `Civ7MacSteamLaunchResult` and surfaced through a new `processRestart` field on `RunInGameOperationStatus`, which is also included in diagnostic output. A dedicated `Civ7MacSteamLaunchError` is thrown if the process never becomes observable within the bounded retry window.

The operation store is updated to persist `processRestart` status after the Steam launch completes, so the restart details are visible even if a subsequent phase fails. New test cases cover the polling-until-start behavior, the retry-on-no-process-observed path, and the exhausted-attempts failure case.