### PR TITLE
feat(run-in-game): add grace-window polling for delayed log failures and treat same-size log rewrites as fresh content

### DIFF
--- a/apps/mapgen-studio/src/server/runInGame/logFailure.ts
+++ b/apps/mapgen-studio/src/server/runInGame/logFailure.ts
@@ -55,3 +55,27 @@ export function classifyCiv7MapgenLogFailure(
 
   return undefined;
 }
+
+export async function waitForCiv7MapgenLogFailure(options: {
+  readFreshLogText: () => Promise<string>;
+  sleep: (ms: number) => Promise<void>;
+  timeoutMs: number;
+  pollIntervalMs: number;
+  now?: () => number;
+  mapScript?: string;
+}): Promise<Civ7MapgenLogFailure | undefined> {
+  const now = options.now ?? Date.now;
+  const deadline = now() + Math.max(0, options.timeoutMs);
+
+  while (true) {
+    const failure = classifyCiv7MapgenLogFailure(
+      await options.readFreshLogText().catch(() => ""),
+      { mapScript: options.mapScript },
+    );
+    if (failure) return failure;
+
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0) return undefined;
+    await options.sleep(Math.min(Math.max(1, options.pollIntervalMs), remainingMs));
+  }
+}

--- a/apps/mapgen-studio/test/runInGame/logFailure.test.ts
+++ b/apps/mapgen-studio/test/runInGame/logFailure.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { classifyCiv7MapgenLogFailure } from "../../src/server/runInGame/logFailure";
+import {
+  classifyCiv7MapgenLogFailure,
+  waitForCiv7MapgenLogFailure,
+} from "../../src/server/runInGame/logFailure";
 
 describe("Civ7 mapgen log failure classifier", () => {
   it("classifies missing generated map scripts as notification-dismiss retry failures", () => {
@@ -40,5 +43,32 @@ describe("Civ7 mapgen log failure classifier", () => {
 
   it("ignores unrelated log text", () => {
     expect(classifyCiv7MapgenLogFailure("ordinary shell log text")).toBeUndefined();
+  });
+
+  it("waits briefly for a delayed fatal map script log line", async () => {
+    let nowMs = 0;
+    let reads = 0;
+
+    const failure = await waitForCiv7MapgenLogFailure({
+      readFreshLogText: async () => {
+        reads += 1;
+        return reads < 3
+          ? "ordinary shell log text"
+          : "[2026-06-07 05:58:53]\tFailed to load file into script system - fs://game/swooper-maps/maps/studio-current.js";
+      },
+      sleep: async (ms) => {
+        nowMs += ms;
+      },
+      now: () => nowMs,
+      timeoutMs: 1_000,
+      pollIntervalMs: 250,
+      mapScript: "{swooper-maps}/maps/studio-current.js",
+    });
+
+    expect(failure).toMatchObject({
+      code: "map-script-load-failed",
+      mapScript: "{swooper-maps}/maps/studio-current.js",
+    });
+    expect(reads).toBe(3);
   });
 });

--- a/apps/mapgen-studio/vite.config.ts
+++ b/apps/mapgen-studio/vite.config.ts
@@ -35,7 +35,7 @@ import {
   createRunInGameOperationStore,
   type RunInGameOperationState,
 } from "./src/server/runInGame/operationState";
-import { classifyCiv7MapgenLogFailure } from "./src/server/runInGame/logFailure";
+import { waitForCiv7MapgenLogFailure } from "./src/server/runInGame/logFailure";
 import {
   buildRunInGameExactAuthorshipProof,
   buildRunInGameSourceSnapshotProof,
@@ -57,6 +57,8 @@ import { buildLiveRuntimeStatusState } from "./src/features/liveRuntime/model";
 const execFileAsync = promisify(execFile);
 const DEPLOY_TIMEOUT_MS = 120_000;
 const SCRIPTING_LOG_WAIT_TIMEOUT_MS = 90_000;
+const SCRIPTING_LOG_FAILURE_GRACE_MS = 5_000;
+const SCRIPTING_LOG_FAILURE_POLL_INTERVAL_MS = 250;
 const MAX_DEPLOY_OUTPUT_CHARS = 8_000;
 const RUN_IN_GAME_OPERATION_TTL_MS = 30 * 60_000;
 const CIV7_STEAM_APP_ID = "1295660";
@@ -108,7 +110,9 @@ async function readFreshLogText(logPath: string, snapshot: Awaited<ReturnType<ty
   const current = await snapshotFile(logPath);
   if (!current.exists) return "";
   const fullText = await readFile(logPath, "utf8");
-  return current.size >= snapshot.size ? fullText.slice(snapshot.size) : fullText;
+  if (current.size > snapshot.size) return fullText.slice(snapshot.size);
+  if (current.mtimeMs > snapshot.mtimeMs) return fullText;
+  return "";
 }
 
 function sleep(ms: number): Promise<void> {
@@ -901,8 +905,13 @@ export default defineConfig(({ command }) => ({
                   { timeoutMs: DEFAULT_CIV7_TUNER_TIMEOUT_MS },
                   { approved: true, reason: "Studio Run in Game", disposableSession: true },
                 ).catch(async (err: unknown) => {
-                  const freshLogText = await readFreshLogText(scriptingLogPath, scriptingSnapshot).catch(() => "");
-                  const mapgenFailure = classifyCiv7MapgenLogFailure(freshLogText, { mapScript: launchMapScript });
+                  const mapgenFailure = await waitForCiv7MapgenLogFailure({
+                    readFreshLogText: () => readFreshLogText(scriptingLogPath, scriptingSnapshot),
+                    sleep,
+                    timeoutMs: SCRIPTING_LOG_FAILURE_GRACE_MS,
+                    pollIntervalMs: SCRIPTING_LOG_FAILURE_POLL_INTERVAL_MS,
+                    mapScript: launchMapScript,
+                  });
                   if (mapgenFailure) {
                     throw new RunInGameHttpError(500, mapgenFailure.message, {
                       ...mapgenFailure,
@@ -922,8 +931,13 @@ export default defineConfig(({ command }) => ({
                   timeoutMs: SCRIPTING_LOG_WAIT_TIMEOUT_MS,
                   rejectPattern: /\b(?:TextEncoder|Uncaught|Exception|Error)\b/i,
                 }).catch(async (err: unknown) => {
-                  const freshLogText = await readFreshLogText(scriptingLogPath, scriptingSnapshot).catch(() => "");
-                  const mapgenFailure = classifyCiv7MapgenLogFailure(freshLogText, { mapScript: launchMapScript });
+                  const mapgenFailure = await waitForCiv7MapgenLogFailure({
+                    readFreshLogText: () => readFreshLogText(scriptingLogPath, scriptingSnapshot),
+                    sleep,
+                    timeoutMs: SCRIPTING_LOG_FAILURE_GRACE_MS,
+                    pollIntervalMs: SCRIPTING_LOG_FAILURE_POLL_INTERVAL_MS,
+                    mapScript: launchMapScript,
+                  });
                   if (mapgenFailure) {
                     throw new RunInGameHttpError(500, mapgenFailure.message, {
                       ...mapgenFailure,

--- a/openspec/changes/studio-save-run-state-machine/design.md
+++ b/openspec/changes/studio-save-run-state-machine/design.md
@@ -55,7 +55,11 @@ records the launch attempts in the restart status payload.
 If Civ emits a fatal generated-script load notification during start, Studio
 records `recoveryBoundary: civ-notification-dismiss`; this is a different
 recovery surface from process restart and should not be collapsed into row
-visibility.
+visibility. The fresh-log classifier uses a short bounded grace window after
+start/proof control failures because Civ can write the fatal map-generation log
+line just after the direct-control timeout resolves. It also treats same-size
+`Scripting.log` rewrites as fresh content, because Civ can truncate and rewrite
+the log to the same byte length during restart and map-generation failure.
 
 ## Vite/Turbo
 

--- a/openspec/changes/studio-save-run-state-machine/specs/mapgen-studio/spec.md
+++ b/openspec/changes/studio-save-run-state-machine/specs/mapgen-studio/spec.md
@@ -98,3 +98,21 @@ when Civ reports it while Run in Game is still starting the prepared game.
 - **AND** the fresh Scripting log contains a generated map script load failure
 - **THEN** the operation status records `map-script-load-failed`
 - **AND** the recovery actions include `dismiss-civ-notification-and-retry`
+
+#### Scenario: Fatal script load line trails the control timeout
+- **WHEN** Run in Game start or proof control returns a timeout
+- **AND** Civ writes a generated map script load failure shortly after that
+  timeout
+- **THEN** Studio waits through a bounded fresh-log grace window before
+  classifying the failure
+- **AND** records the generated script load boundary instead of a generic
+  timeout when that line appears within the grace window
+
+#### Scenario: Civ rewrites Scripting.log at the same byte length
+- **WHEN** Run in Game compares the current `Scripting.log` to its pre-run
+  snapshot
+- **AND** Civ has rewritten the log with a newer modification time but the same
+  byte length
+- **THEN** Studio treats the rewritten log contents as fresh
+- **AND** fatal map-generation lines in that rewritten log can classify the
+  operation status

--- a/openspec/changes/studio-save-run-state-machine/tasks.md
+++ b/openspec/changes/studio-save-run-state-machine/tasks.md
@@ -26,6 +26,10 @@
   `starting-game` instead of reducing them to generic setup start timeouts.
 - [x] 2.12 Retry Steam launch during explicit process-restart recovery until the
   Civ process is observed or bounded launch attempts are exhausted.
+- [x] 2.13 Wait through a short bounded fresh-log grace window before reducing
+  start/proof failures to generic timeout status.
+- [x] 2.14 Treat same-size Scripting.log rewrites as fresh log content for
+  start/proof classification.
 
 ## 3. Verification
 
@@ -40,6 +44,8 @@
 - [x] 3.8 Add focused operation-state regression for start-phase map-script
   load failures.
 - [x] 3.9 Add focused macOS restart-launch retry regressions.
+- [x] 3.10 Add focused delayed-log classification regression.
+- [x] 3.11 Add focused fresh-marker regression for same-size log rewrites.
 
 ## 4. Closure
 

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -2798,7 +2798,7 @@ export async function waitForFreshLogMarkers(options: {
     const current = await snapshotFile(options.logPath);
     if (current.exists && (current.size > startOffset || current.mtimeMs > options.snapshot.mtimeMs)) {
       const fullText = await readFile(options.logPath, "utf8");
-      const newText = current.size >= startOffset ? fullText.slice(startOffset) : fullText;
+      const newText = current.size > startOffset ? fullText.slice(startOffset) : fullText;
       const proof = matchOrderedMarkers(newText, options.markers);
       const rejected = options.rejectPattern?.exec(newText);
       if (rejected) lastError = `Log contains ${rejected[0]}`;

--- a/packages/civ7-direct-control/test/direct-control.test.ts
+++ b/packages/civ7-direct-control/test/direct-control.test.ts
@@ -1,7 +1,7 @@
 import { once } from "node:events";
 import { type AddressInfo, createServer } from "node:net";
 import { join } from "node:path";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { describe, expect, test } from "vitest";
 import {
@@ -1159,6 +1159,25 @@ describe("Civ7 direct control", () => {
     });
 
     expect(proof.matched).toEqual(["Creating Context -  MapGeneration", "Destroying Context -  MapGeneration"]);
+  });
+
+  test("waits for markers when Civ rewrites the log at the same byte length", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "civ7-direct-control-log-"));
+    const logPath = join(dir, "Scripting.log");
+    await writeFile(logPath, "old log padding\n");
+    const snapshot = await snapshotFile(logPath);
+    await writeFile(logPath, "fresh\nmarker\n".padEnd(snapshot.size, " "));
+    await utimes(logPath, new Date(snapshot.mtimeMs + 1_000), new Date(snapshot.mtimeMs + 1_000));
+
+    const proof = await waitForFreshLogMarkers({
+      logPath,
+      snapshot,
+      markers: ["fresh", "marker"],
+      timeoutMs: 100,
+      pollIntervalMs: 10,
+    });
+
+    expect(proof.matched).toEqual(["fresh", "marker"]);
   });
 });
 


### PR DESCRIPTION
Adds a short polling grace window after start/proof control failures before classifying them as generic timeouts. When Civ writes a fatal map-script load line just after a direct-control timeout resolves, Studio now polls the scripting log for up to 5 seconds at 250ms intervals and surfaces the specific `map-script-load-failed` boundary rather than a generic timeout error.

Also fixes fresh-log detection for cases where Civ truncates and rewrites `Scripting.log` to the same byte length during restart or map-generation failure. Previously, equal sizes were treated as unchanged; the fix checks `mtimeMs` as a tiebreaker so same-size rewrites are read as fresh content. The same `>=` → `>` correction is applied in `waitForFreshLogMarkers` in the direct-control package.

The `waitForCiv7MapgenLogFailure` helper encapsulates the polling loop and is covered by a new test that simulates a log line arriving on the third read within the grace window. A companion direct-control test verifies marker detection when the log is rewritten at the same byte length with a bumped modification time.