### PR TITLE
feat(swooper-maps): bundle `@civ7/map-policy` into generated map scripts to eliminate bare repo-owned workspace imports

### DIFF
--- a/mods/mod-swooper-maps/tsup.config.ts
+++ b/mods/mod-swooper-maps/tsup.config.ts
@@ -103,7 +103,7 @@ export default defineConfig({
   // Civ7 loads each generated map file as a self-contained game script. SDK/core/adapter
   // authoring packages must be bundled into that script; only engine virtual modules may
   // remain as imports for the game loader to resolve.
-  noExternal: ["@swooper/mapgen-core", "@civ7/adapter", "@mateicanavra/civ7-sdk", "typebox"],
+  noExternal: ["@swooper/mapgen-core", "@civ7/adapter", "@civ7/map-policy", "@mateicanavra/civ7-sdk", "typebox"],
 
   esbuildOptions(options) {
     // Shim TypeBox format registry so no Unicode-property regexes reach the game engine (built-in format validation disabled).

--- a/openspec/changes/workspace-build-pipeline/specs/repo-workflow/spec.md
+++ b/openspec/changes/workspace-build-pipeline/specs/repo-workflow/spec.md
@@ -89,3 +89,11 @@ that depend on generated files or built workspace declarations.
   CLI deploy command through Turbo before the mod-local build/deploy step
 - **AND** request-id-sensitive generated map source is regenerated clean after
   Studio Run in Game proof collection
+
+#### Scenario: Built map scripts are self-contained for Civ MapGeneration
+- **WHEN** Swooper Maps builds generated map scripts for the deployed mod
+- **THEN** repo-owned workspace packages used by those scripts are bundled into
+  the map output
+- **AND** the output scripts do not contain bare `@swooper/*`, `@civ7/*`, or
+  `@mateicanavra/*` imports that Civ MapGeneration cannot resolve
+- **AND** engine virtual imports such as `/base-standard/...` remain external

--- a/openspec/changes/workspace-build-pipeline/tasks.md
+++ b/openspec/changes/workspace-build-pipeline/tasks.md
@@ -22,6 +22,8 @@
   workspace source entrypoint instead of stale package `dist` declarations.
 - [x] 1.12 Allow Swooper Maps package-local TypeScript checks to include
   source-resolved workspace package files outside the mod `src` tree.
+- [x] 1.13 Bundle `@civ7/map-policy` into generated Swooper map scripts so
+  Civ MapGeneration never sees repo-owned workspace package specifiers.
 
 ## 2. Verification
 
@@ -39,3 +41,5 @@
   `@civ7/adapter` source types without rebuilding adapter declarations first.
 - [x] 2.7 Verify source-resolved workspace package files do not fail Swooper
   Maps package-local checks through `rootDir` bounds.
+- [x] 2.8 Verify built Swooper map scripts contain no bare repo-owned workspace
+  imports after the map-policy bundling fix.


### PR DESCRIPTION
Bundles `@civ7/map-policy` into generated Swooper map scripts by adding it to the `noExternal` list in the tsup config. Previously, this package was left as an external import that Civ MapGeneration cannot resolve, which would cause failures at runtime. With this change, all repo-owned workspace packages used by map scripts are fully inlined into the output, leaving only engine virtual imports (e.g. `/base-standard/...`) as external references.