### PR TITLE
docs(earthlike-live-feature-resource-legality-repair): record map-policy bundle clearing map-script load blocker and new map-elevation drift failure at (34,17)

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -101,6 +101,27 @@
     `Failed to load file into script system - fs://game/swooper-maps/maps/studio-current.js`.
     No current `[mapgen-proof]`, `[mapgen-complete]`, exact-authorship packet,
     final-surface parity proof, or product acceptance proof was produced.
+  - Current post-map-policy-bundling request
+    `studio-run-in-game-mq3n8vkc-1qjg` used the same request body
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-postwrite-footprint-restart-request.json`
+    (`sha256:0e23b919efba651b49d36bd967218414ace31620dee1c375a13a2c245decf914`),
+    with post response
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-map-policy-bundle-post.json`
+    (`sha256:855671f1291ead7c4ed2d8b2addbf784b761a30ac1104c0f71b3aff55b34749c`)
+    and terminal status
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-map-policy-bundle-status.json`
+    (`sha256:6b2997225b0dc872a12ba306fec47c5ad7b1a7767692758b6426b8104ee8ae4c`).
+    It passed materialize/deploy, process-restart recovery, direct-control
+    availability, setup-row visibility, setup preparation, and map-script load.
+    It failed in `starting-game` as `map-generation-script-failed` with fresh
+    Scripting log line:
+    `[2026-06-07 06:34:54] [SWOOPER_MOD] Map generation failed: StepExecutionError: Step "mod-swooper-maps.standard.map-elevation.build-elevation" failed: [map-elevation/build-elevation] drift: expected land but adapter reports water at (34,17).`
+    The deployed script identity was
+    `/Users/mateicanavra/Library/Application Support/Civilization VII/Mods/mod-swooper-maps/maps/studio-current.js`
+    (`sha256:ac3d7a05a4972cb8d264022bbffc4c220f0526e2ff322093bb8da2e0dfa6acdc`,
+    `mtimeIso:2026-06-07T10:33:26.425Z`). No current `[mapgen-proof]`,
+    `[mapgen-complete]`, exact-authorship packet, final-surface parity proof,
+    or product acceptance proof was produced.
 - [ ] 2.42 Repair remaining proven package or MapGen owners.
 - [ ] 2.43 Preserve resource spacing, age legality, and diversity expectations.
 
@@ -120,10 +141,11 @@
     current `[mapgen-proof]`, `[mapgen-complete]`, exact-authorship packet, or
     final-surface parity artifact exists for the current branch.
   - Latest bounded retry is
-    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-same-size-log-fix-status.json`
-    (`sha256:e43e9c2b93575562f5429919f47ddafa033cd305191d12053bfd1cdacc8e3966`).
-    It proves restart retry/status classification behavior, but remains a
-    runtime load blocker rather than final-surface parity proof.
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-map-policy-bundle-status.json`
+    (`sha256:6b2997225b0dc872a12ba306fec47c5ad7b1a7767692758b6426b8104ee8ae4c`).
+    It proves restart retry/status classification behavior and proves the
+    generated map-script load blocker is cleared, but remains a runtime map
+    generation blocker rather than final-surface parity proof.
 - [x] 3.9 Run focused adapter/Swooper checks and tests for natural-wonder
   rejection telemetry.
 - [x] 3.10 Preserve source-recorded exact-authored final-surface parity after

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1158,8 +1158,33 @@ The deployed mod script identity in that status is
 (`sha256:862baf3441a7f98b7a5e38d183a0e64c47890fb1f70385b68e36599e16844a03`,
 `mtimeIso:2026-06-07T10:18:01.268Z`).
 No current exact-authorship, final-surface parity, or product acceptance proof
-is claimed from these attempts. The current blocker is now the Studio/Civ
-generated map-script load boundary, not feature/resource source authority.
+is claimed from these attempts.
+
+The follow-up map-policy bundling slice added `@civ7/map-policy` to the Swooper
+map-script bundle so Civ does not need to resolve a repo-owned bare package
+import at map-script load time. Request `studio-run-in-game-mq3n8vkc-1qjg` used
+the same request body
+`/tmp/civ7-recovery-proof/final-surface-parity/current-drain-postwrite-footprint-restart-request.json`
+(`sha256:0e23b919efba651b49d36bd967218414ace31620dee1c375a13a2c245decf914`),
+with post response
+`/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-map-policy-bundle-post.json`
+(`sha256:855671f1291ead7c4ed2d8b2addbf784b761a30ac1104c0f71b3aff55b34749c`)
+and terminal status
+`/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-map-policy-bundle-status.json`
+(`sha256:6b2997225b0dc872a12ba306fec47c5ad7b1a7767692758b6426b8104ee8ae4c`).
+It passed materialization, deploy, process restart, direct-control availability,
+setup-row visibility, setup preparation, and map-script load. The deployed
+script identity in that status is
+`/Users/mateicanavra/Library/Application Support/Civilization VII/Mods/mod-swooper-maps/maps/studio-current.js`
+(`sha256:ac3d7a05a4972cb8d264022bbffc4c220f0526e2ff322093bb8da2e0dfa6acdc`,
+`mtimeIso:2026-06-07T10:33:26.425Z`). The terminal failure moved to
+`map-generation-script-failed` with recovery boundary
+`civ-notification-dismiss`; matched fresh log line:
+`[2026-06-07 06:34:54] [SWOOPER_MOD] Map generation failed: StepExecutionError: Step "mod-swooper-maps.standard.map-elevation.build-elevation" failed: [map-elevation/build-elevation] drift: expected land but adapter reports water at (34,17).`
+No current exact-authorship, final-surface parity, or product acceptance proof
+is claimed from this attempt. The current blocker is now the Swooper
+map-elevation materialization/runtime boundary, not the Studio/Civ generated
+map-script load boundary.
 
 Source-recorded post-repair proof:
 request `studio-run-in-game-mq2u6wdg-1z4g` completed exact authorship and

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,10 +6,11 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
-  `codex/swooper-current-map-script-load-proof-drain`, stacked above
-  `codex/swooper-studio-start-log-grace-drain`; this slice records the current
-  checked-in config runtime-proof blocker after restart-launch retry,
-  start-log grace, and same-size `Scripting.log` rewrite fixes.
+  `codex/swooper-current-map-generation-blocker-drain`, stacked above
+  `codex/swooper-map-script-bundle-policy-drain`; this slice records the
+  current checked-in config runtime-proof blocker after restart-launch retry,
+  start-log grace, same-size `Scripting.log` rewrite fixes, and map-policy
+  bundling for Civ map scripts.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface. The natural-wonder
@@ -22,9 +23,14 @@
   longer blocks on the stale `floodplainPlanning` key when launched from the
   current checked-in config. It also no longer blocks on unobserved Civ process
   restart: the latest retry records two Steam launch attempts and reaches setup
-  preparation. It now blocks because Civ fails to load the generated
-  `studio-current.js` map script before mapgen proof markers or parity
-  evaluation. Resource classes remain pending source-authority classification.
+  preparation. It also no longer blocks on generated `studio-current.js`
+  map-script loading after `@civ7/map-policy` was bundled into the Civ map
+  script. It now blocks inside map generation: request
+  `studio-run-in-game-mq3n8vkc-1qjg` failed in
+  `mod-swooper-maps.standard.map-elevation.build-elevation` because
+  `map-elevation/build-elevation` expected land but the adapter reported water
+  at `(34,17)`. Resource classes remain pending source-authority
+  classification, and no current final-surface parity proof exists.
 
 ## Objective
 
@@ -911,9 +917,35 @@
   This is a current runtime/control blocker, not a source parity result: no
   current `[mapgen-proof]`, `[mapgen-complete]`, exact-authorship packet,
   final-surface parity proof, or product acceptance proof was produced.
+  A follow-up map-policy bundling slice added `@civ7/map-policy` to the
+  Swooper map-script bundle so Civ does not need to resolve a repo-owned bare
+  package import at map-script load time. Current request
+  `studio-run-in-game-mq3n8vkc-1qjg` used the same restart request body
+  `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-postwrite-footprint-restart-request.json`
+  (`sha256:0e23b919efba651b49d36bd967218414ace31620dee1c375a13a2c245decf914`),
+  with post response
+  `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-map-policy-bundle-post.json`
+  (`sha256:855671f1291ead7c4ed2d8b2addbf784b761a30ac1104c0f71b3aff55b34749c`)
+  and terminal status
+  `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-map-policy-bundle-status.json`
+  (`sha256:6b2997225b0dc872a12ba306fec47c5ad7b1a7767692758b6426b8104ee8ae4c`).
+  It completed materialization, deploy, process restart, direct-control
+  availability, setup-row visibility, setup preparation, and map-script load.
+  The deployed script identity in that status is
+  `/Users/mateicanavra/Library/Application Support/Civilization VII/Mods/mod-swooper-maps/maps/studio-current.js`
+  (`sha256:ac3d7a05a4972cb8d264022bbffc4c220f0526e2ff322093bb8da2e0dfa6acdc`,
+  `mtimeIso:2026-06-07T10:33:26.425Z`). The terminal failure moved to
+  `map-generation-script-failed` with recovery boundary
+  `civ-notification-dismiss`; matched fresh log line:
+  `[2026-06-07 06:34:54] [SWOOPER_MOD] Map generation failed: StepExecutionError: Step "mod-swooper-maps.standard.map-elevation.build-elevation" failed: [map-elevation/build-elevation] drift: expected land but adapter reports water at (34,17).`
+  This is a source/runtime map-generation blocker, not a parity result: no
+  current `[mapgen-proof]`, `[mapgen-complete]`, exact-authorship packet,
+  final-surface parity proof, or product acceptance proof was produced.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
-- Next action: classify the remaining feature/resource rows by source
-  authority: official data, adapter/map-policy, MapGen
+- Next action: diagnose and repair the current
+  `map-elevation/build-elevation` drift before another final-surface parity
+  proof attempt, then continue classifying the remaining feature/resource rows
+  by source authority: official data, adapter/map-policy, MapGen
   planning/materialization, accepted engine materialization, or readback
   limitation. Terrain edge rows may enter this slice only if diagnostics prove
   shared materialization ownership. The unchanged resource mismatch count after


### PR DESCRIPTION
The map-script load blocker has been cleared by bundling `@civ7/map-policy` directly into the Swooper map-script bundle, eliminating the need for Civ to resolve a bare repo-owned package import at load time. Request `studio-run-in-game-mq3n8vkc-1qjg` confirmed that materialization, deploy, process restart, direct-control availability, setup-row visibility, setup preparation, and map-script load all pass with the bundled script (`sha256:ac3d7a05a4972cb8d264022bbffc4c220f0526e2ff322093bb8da2e0dfa6acdc`).

The terminal failure has shifted from the map-script load boundary to a runtime map-generation failure inside `mod-swooper-maps.standard.map-elevation.build-elevation`: the adapter reported water at `(34,17)` where land was expected, producing a `map-generation-script-failed` outcome with recovery boundary `civ-notification-dismiss`. No `[mapgen-proof]`, `[mapgen-complete]`, exact-authorship packet, final-surface parity proof, or product acceptance proof has been produced.

The current branch tip is updated to `codex/swooper-current-map-generation-blocker-drain`, stacked above `codex/swooper-map-script-bundle-policy-drain`. The next action is to diagnose and repair the `map-elevation/build-elevation` land/water drift before another final-surface parity proof attempt, then resume classifying remaining feature/resource rows by source authority.