### PR TITLE
fix(map-elevation): replace strict no-drift assert with bounded water-drift policy and update phase/ledger records

### DIFF
--- a/mods/mod-swooper-maps/src/recipes/standard/stages/map-elevation/steps/buildElevation.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/map-elevation/steps/buildElevation.ts
@@ -1,7 +1,7 @@
 import { defineVizMeta, logElevationSummary, logLandmassAscii, snapshotEngineHeightfield } from "@swooper/mapgen-core";
 import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import BuildElevationStepContract from "./buildElevation.contract.js";
-import { assertNoWaterDrift } from "../../../projection-policies/noWaterDrift.js";
+import { assertWaterDriftWithinPolicy } from "../../../projection-policies/noWaterDrift.js";
 import { mapElevationArtifacts } from "../artifacts.js";
 
 const GROUP_MAP_ELEVATION = "Map / Elevation (Engine)";
@@ -35,7 +35,7 @@ export default createStep(BuildElevationStepContract, {
     context.adapter.recalculateAreas();
     context.adapter.buildElevation();
     context.adapter.recalculateAreas();
-    assertNoWaterDrift(context, expectedLandMask, "map-elevation/build-elevation");
+    assertWaterDriftWithinPolicy(context, expectedLandMask, "map-elevation/build-elevation");
 
     const physics = context.buffers.heightfield;
     const engine = snapshotEngineHeightfield(context);

--- a/mods/mod-swooper-maps/test/map-elevation/build-elevation-no-water-drift.test.ts
+++ b/mods/mod-swooper-maps/test/map-elevation/build-elevation-no-water-drift.test.ts
@@ -18,6 +18,19 @@ class DriftAfterBuildElevationAdapter extends MockAdapter {
   }
 }
 
+class ExcessiveDriftAfterBuildElevationAdapter extends MockAdapter {
+  buildElevationCalls = 0;
+
+  override buildElevation(): void {
+    this.buildElevationCalls += 1;
+    for (let y = 0; y < this.height; y++) {
+      for (let x = 0; x < this.width; x++) {
+        this.setWater(x, y, true);
+      }
+    }
+  }
+}
+
 class ReliefAfterBuildElevationAdapter extends MockAdapter {
   buildElevationCalls = 0;
   stampContinentsCalls = 0;
@@ -39,9 +52,9 @@ class ReliefAfterBuildElevationAdapter extends MockAdapter {
 }
 
 describe("map-elevation/build-elevation", () => {
-  it("fails when buildElevation changes the projected land/water surface", () => {
-    const width = 4;
-    const height = 3;
+  it("allows bounded buildElevation land/water drift and logs the policy report", () => {
+    const width = 10;
+    const height = 10;
     const seed = 1234;
     const mapInfo = { GridWidth: width, GridHeight: height, MinLatitude: -60, MaxLatitude: 60 };
     const env = {
@@ -80,9 +93,70 @@ describe("map-elevation/build-elevation", () => {
       sinkMismatchCount: 0,
     });
 
-    expect(() =>
-      buildElevation.run(context as any, {}, {} as any, buildTestDeps(buildElevation))
-    ).toThrow(/map-elevation\/build-elevation.*expected land/);
+    const originalLog = console.log;
+    const logs: string[] = [];
+    console.log = (...args: unknown[]) => {
+      logs.push(args.join(" "));
+    };
+
+    try {
+      buildElevation.run(context as any, {}, {} as any, buildTestDeps(buildElevation));
+    } finally {
+      console.log = originalLog;
+    }
+
+    expect(adapter.buildElevationCalls).toBe(1);
+    expect(logs.some((line) => line.includes("WATER_DRIFT_POLICY_V1"))).toBe(true);
+    expect(logs.some((line) => line.includes('"mismatchCount":1'))).toBe(true);
+    expect(logs.some((line) => line.includes('"withinPolicy":true'))).toBe(true);
+  });
+
+  it("fails when buildElevation drift exceeds the policy budget", () => {
+    const width = 4;
+    const height = 3;
+    const seed = 1234;
+    const mapInfo = { GridWidth: width, GridHeight: height, MinLatitude: -60, MaxLatitude: 60 };
+    const env = {
+      seed,
+      dimensions: { width, height },
+      latitudeBounds: { topLatitude: 60, bottomLatitude: -60 },
+    };
+
+    const adapter = new ExcessiveDriftAfterBuildElevationAdapter({
+      width,
+      height,
+      mapInfo,
+      mapSizeId: 1,
+      rng: createLabelRng(seed),
+    });
+    const context = createExtendedMapContext({ width, height }, adapter, env);
+
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        adapter.setTerrainType(x, y, FLAT_TERRAIN);
+        adapter.setWater(x, y, false);
+      }
+    }
+
+    context.artifacts.set("artifact:morphology.topography", {
+      landMask: new Uint8Array(width * height).fill(1),
+    });
+    context.artifacts.set("artifact:map.hydrology.engineProjectionLakes", {
+      width,
+      height,
+      lakeMask: new Uint8Array(width * height),
+      sinkMismatchCount: 0,
+    });
+
+    const originalLog = console.log;
+    console.log = () => {};
+    try {
+      expect(() =>
+        buildElevation.run(context as any, {}, {} as any, buildTestDeps(buildElevation))
+      ).toThrow(/map-elevation\/build-elevation.*land\/water drift .*exceeds policy max/);
+    } finally {
+      console.log = originalLog;
+    }
 
     expect(adapter.buildElevationCalls).toBe(1);
   });

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -123,6 +123,10 @@
     `[mapgen-complete]`, exact-authorship packet, final-surface parity proof,
     or product acceptance proof was produced.
 - [ ] 2.42 Repair remaining proven package or MapGen owners.
+  - Current branch `codex/swooper-map-elevation-drift-policy-drain` repairs the
+    locally proven map-elevation owner mismatch: `buildElevation` now applies
+    the accepted bounded water-drift policy instead of the strict no-drift
+    assert. Focused local tests/checks pass, but runtime proof is still pending.
 - [ ] 2.43 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
@@ -146,6 +150,9 @@
     It proves restart retry/status classification behavior and proves the
     generated map-script load blocker is cleared, but remains a runtime map
     generation blocker rather than final-surface parity proof.
+  - Current branch locally repairs that blocker through the accepted
+    map-elevation bounded drift policy. No post-repair Studio/Civ rerun has
+    been completed yet.
 - [x] 3.9 Run focused adapter/Swooper checks and tests for natural-wonder
   rejection telemetry.
 - [x] 3.10 Preserve source-recorded exact-authored final-surface parity after

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1186,6 +1186,12 @@ is claimed from this attempt. The current blocker is now the Swooper
 map-elevation materialization/runtime boundary, not the Studio/Civ generated
 map-script load boundary.
 
+Local repair on `codex/swooper-map-elevation-drift-policy-drain` wires
+`map-elevation/buildElevation` to the accepted bounded water-drift policy
+instead of the strict no-drift assert. Focused local proof covers the policy
+boundary only; a fresh Studio/Civ rerun is still required before claiming the
+runtime blocker is cleared.
+
 Source-recorded post-repair proof:
 request `studio-run-in-game-mq2u6wdg-1z4g` completed exact authorship and
 generated parity artifact

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,9 +6,9 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
-  `codex/swooper-current-map-generation-blocker-drain`, stacked above
-  `codex/swooper-map-script-bundle-policy-drain`; this slice records the
-  current checked-in config runtime-proof blocker after restart-launch retry,
+  `codex/swooper-map-elevation-drift-policy-drain`, stacked above
+  `codex/swooper-current-map-generation-blocker-drain`; this slice repairs the
+  locally proven map-elevation drift-policy mismatch after restart-launch retry,
   start-log grace, same-size `Scripting.log` rewrite fixes, and map-policy
   bundling for Civ map scripts.
 - Started: 2026-06-06
@@ -25,12 +25,14 @@
   restart: the latest retry records two Steam launch attempts and reaches setup
   preparation. It also no longer blocks on generated `studio-current.js`
   map-script loading after `@civ7/map-policy` was bundled into the Civ map
-  script. It now blocks inside map generation: request
+  script. The latest runtime attempt blocks inside map generation: request
   `studio-run-in-game-mq3n8vkc-1qjg` failed in
   `mod-swooper-maps.standard.map-elevation.build-elevation` because
   `map-elevation/build-elevation` expected land but the adapter reported water
-  at `(34,17)`. Resource classes remain pending source-authority
-  classification, and no current final-surface parity proof exists.
+  at `(34,17)`. The current branch repairs the local policy mismatch by using
+  the accepted bounded water-drift policy in `map-elevation/buildElevation`,
+  but no current final-surface parity proof exists until Studio/Civ is rerun.
+  Resource classes remain pending source-authority classification.
 
 ## Objective
 

--- a/openspec/changes/map-elevation-boundary-policy-reconciliation/workstream/phase-record.md
+++ b/openspec/changes/map-elevation-boundary-policy-reconciliation/workstream/phase-record.md
@@ -2,19 +2,29 @@
 
 ## Status
 
-Closed locally pending verification and Graphite commit.
+Implemented on `codex/swooper-map-elevation-drift-policy-drain`; current
+runtime rerun is still pending.
 
 ## Evidence
 
 - `rg` found `applyCiv7BuildElevationBoundaryPolicy` only in
   `@civ7/map-policy` export/test files.
-- The active `map-elevation/buildElevation` step now reads the post-lake
-  expected land mask, calls `TerrainBuilder.buildElevation`, repairs small
-  drift, refreshes Civ caches, and fails only above the water-drift policy
-  budget.
+- The previous recovered record said the active `map-elevation/buildElevation`
+  step used the lifecycle-aware water-drift policy, but the current drain found
+  it still called the strict no-drift assert. Request
+  `studio-run-in-game-mq3n8vkc-1qjg` then failed with one expected-land /
+  adapter-water mismatch at `(34,17)` after the generated map script loaded.
+- The current slice wires `map-elevation/buildElevation` to
+  `assertWaterDriftWithinPolicy`, preserving a hard failure above the drift
+  budget while allowing bounded drift to emit `WATER_DRIFT_POLICY_V1`
+  telemetry instead of aborting generation.
+- Focused local proof: `bun test
+  mods/mod-swooper-maps/test/map-elevation/build-elevation-no-water-drift.test.ts`
+  and `bun run --cwd mods/mod-swooper-maps check`.
 
 ## Decision
 
 Remove the unused helper. The active policy boundary is the lifecycle-aware
 water-drift policy in the recipe projection layer, not a static preprojection
-helper with no caller.
+helper with no caller. Local tests prove the boundary behavior; in-game proof
+requires a fresh Studio/Civ rerun.


### PR DESCRIPTION
Replace the strict no-drift assertion in `map-elevation/buildElevation` with the accepted bounded water-drift policy.

Previously, `buildElevation` called `assertNoWaterDrift`, which would throw on any land/water mismatch between the projected land mask and the adapter state after elevation was built. A runtime failure in request `studio-run-in-game-mq3n8vkc-1qjg` exposed this: a single mismatch at `(34,17)` aborted map generation entirely.

The step now calls `assertWaterDriftWithinPolicy`, which:
- Allows bounded drift and emits a `WATER_DRIFT_POLICY_V1` telemetry log entry instead of aborting
- Still throws a hard failure when drift exceeds the policy budget

Tests are updated to reflect this behavior:
- The existing "fails on any drift" test is replaced with a test confirming that a single-cell mismatch passes and produces the expected policy log output
- A new `ExcessiveDriftAfterBuildElevationAdapter` is added to cover the case where drift floods the entire grid, verifying that the hard failure path (`land/water drift ... exceeds policy max`) is still enforced

Local focused tests and checks pass. A Studio/Civ rerun is still required before the runtime blocker can be considered cleared.