### PR TITLE
feat(sdk): emit `[mapgen-complete]` after successful recipe run and add focused marker test

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -122,11 +122,31 @@
     `mtimeIso:2026-06-07T10:33:26.425Z`). No current `[mapgen-proof]`,
     `[mapgen-complete]`, exact-authorship packet, final-surface parity proof,
     or product acceptance proof was produced.
+  - Post-elevation-policy request `studio-run-in-game-mq3nyiss-8oj` used the
+    same request body, with post response
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-elevation-drift-policy-post.json`
+    (`sha256:4a7736e1688d1c1eca3763f6e34d403830f7bbf5cf690dadb0671d4166565c39`)
+    and terminal status
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-elevation-drift-policy-status.json`
+    (`sha256:e34125c5b73ce1fbd11b5f67cff51a196d35cfc45700b95338a967ef61de4c67`).
+    It passed materialize/deploy, process-restart recovery, setup preparation,
+    map-script load, and map generation through all `50/50` recipe steps.
+    Scripting.log records `[mapgen-proof]` for the same request/config/envelope
+    chain, bounded `WATER_DRIFT_POLICY_V1` at `2/6996` tiles
+    (`withinPolicy:true`), `NATURAL_WONDER_PLACEMENT_V1`,
+    `RESOURCE_PLACEMENT_V1`, and `Destroying Context -  MapGeneration`. It
+    failed in `waiting-for-proof` as `log-timeout` because `[mapgen-complete]`
+    was absent. No exact-authorship packet, final-surface parity proof, or
+    product acceptance proof was produced.
 - [ ] 2.42 Repair remaining proven package or MapGen owners.
   - Current branch `codex/swooper-map-elevation-drift-policy-drain` repairs the
     locally proven map-elevation owner mismatch: `buildElevation` now applies
     the accepted bounded water-drift policy instead of the strict no-drift
     assert. Focused local tests/checks pass, but runtime proof is still pending.
+  - Current branch `codex/swooper-sdk-mapgen-completion-marker-drain` repairs
+    the locally proven SDK marker gap: `createMap` now emits
+    `[mapgen-complete]` after successful recipe execution. Focused SDK
+    tests/checks pass, but runtime proof is still pending.
 - [ ] 2.43 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
@@ -153,6 +173,9 @@
   - Current branch locally repairs that blocker through the accepted
     map-elevation bounded drift policy. No post-repair Studio/Civ rerun has
     been completed yet.
+  - Current branch locally repairs the next blocker by emitting the SDK
+    `[mapgen-complete]` marker after successful recipe execution. No
+    post-repair Studio/Civ rerun has been completed yet.
 - [x] 3.9 Run focused adapter/Swooper checks and tests for natural-wonder
   rejection telemetry.
 - [x] 3.10 Preserve source-recorded exact-authored final-surface parity after

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1192,6 +1192,27 @@ instead of the strict no-drift assert. Focused local proof covers the policy
 boundary only; a fresh Studio/Civ rerun is still required before claiming the
 runtime blocker is cleared.
 
+Post-elevation-policy request `studio-run-in-game-mq3nyiss-8oj` used the same
+request body, with post response
+`/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-elevation-drift-policy-post.json`
+(`sha256:4a7736e1688d1c1eca3763f6e34d403830f7bbf5cf690dadb0671d4166565c39`)
+and terminal status
+`/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-elevation-drift-policy-status.json`
+(`sha256:e34125c5b73ce1fbd11b5f67cff51a196d35cfc45700b95338a967ef61de4c67`).
+It passed materialization, deploy, process restart, setup preparation,
+map-script load, and all `50/50` recipe steps. Scripting.log records
+`[mapgen-proof]`, bounded `WATER_DRIFT_POLICY_V1` at `2/6996` tiles
+(`withinPolicy:true`), `NATURAL_WONDER_PLACEMENT_V1`,
+`RESOURCE_PLACEMENT_V1`, and `Destroying Context -  MapGeneration`, but no
+`[mapgen-complete]`. The current blocker is now the SDK mapgen completion
+marker boundary, not map-elevation.
+
+Local repair on `codex/swooper-sdk-mapgen-completion-marker-drain` emits
+`[mapgen-complete]` from SDK `createMap` after `recipe.run` returns
+successfully. Focused local proof covers marker emission only; a fresh
+Studio/Civ rerun is still required before claiming exact authorship or
+final-surface parity.
+
 Source-recorded post-repair proof:
 request `studio-run-in-game-mq2u6wdg-1z4g` completed exact authorship and
 generated parity artifact

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,11 +6,11 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
-  `codex/swooper-map-elevation-drift-policy-drain`, stacked above
-  `codex/swooper-current-map-generation-blocker-drain`; this slice repairs the
-  locally proven map-elevation drift-policy mismatch after restart-launch retry,
-  start-log grace, same-size `Scripting.log` rewrite fixes, and map-policy
-  bundling for Civ map scripts.
+  `codex/swooper-sdk-mapgen-completion-marker-drain`, stacked above
+  `codex/swooper-map-elevation-drift-policy-drain`; this slice repairs the
+  locally proven SDK completion-marker gap after restart-launch retry,
+  start-log grace, same-size `Scripting.log` rewrite fixes, map-policy bundling
+  for Civ map scripts, and map-elevation bounded drift policy repair.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface. The natural-wonder
@@ -25,14 +25,19 @@
   restart: the latest retry records two Steam launch attempts and reaches setup
   preparation. It also no longer blocks on generated `studio-current.js`
   map-script loading after `@civ7/map-policy` was bundled into the Civ map
-  script. The latest runtime attempt blocks inside map generation: request
+  script. Request
   `studio-run-in-game-mq3n8vkc-1qjg` failed in
   `mod-swooper-maps.standard.map-elevation.build-elevation` because
   `map-elevation/build-elevation` expected land but the adapter reported water
   at `(34,17)`. The current branch repairs the local policy mismatch by using
   the accepted bounded water-drift policy in `map-elevation/buildElevation`,
-  but no current final-surface parity proof exists until Studio/Civ is rerun.
-  Resource classes remain pending source-authority classification.
+  and the next request `studio-run-in-game-mq3nyiss-8oj` then passed
+  `map-elevation/build-elevation`, emitted bounded `WATER_DRIFT_POLICY_V1`
+  telemetry, ran all `50/50` recipe steps, and emitted `[mapgen-proof]`.
+  It timed out in `waiting-for-proof` because `[mapgen-complete]` was absent.
+  The current branch repairs that SDK marker gap locally, but no current
+  final-surface parity proof exists until Studio/Civ is rerun. Resource classes
+  remain pending source-authority classification.
 
 ## Objective
 

--- a/openspec/changes/studio-live-mapgen-log-completion-proof/tasks.md
+++ b/openspec/changes/studio-live-mapgen-log-completion-proof/tasks.md
@@ -3,6 +3,9 @@
 - [x] 1.1 Restore fresh Scripting.log snapshotting before live launch.
 - [x] 1.2 Wait for fresh `[mapgen-complete]` evidence tied to the requested
   seed.
+  - Current repair emits `[mapgen-complete]` from SDK `createMap` after a
+    successful recipe run; previous recovered state only emitted
+    `[mapgen-proof]`, causing Studio to time out in `waiting-for-proof`.
 - [x] 1.3 Reject fresh failure markers during verification.
 - [x] 1.4 Include mapgen log proof in the verifier output.
 
@@ -10,3 +13,4 @@
 
 - [x] 2.1 Run the verifier help/smoke path.
 - [x] 2.2 Run focused direct-control tests.
+- [x] 2.3 Run focused SDK mapgen marker test and SDK typecheck.

--- a/openspec/changes/studio-live-mapgen-log-completion-proof/workstream/phase-record.md
+++ b/openspec/changes/studio-live-mapgen-log-completion-proof/workstream/phase-record.md
@@ -2,13 +2,22 @@
 
 ## Status
 
-Closed locally pending verification and Graphite commit.
+Repaired on `codex/swooper-sdk-mapgen-completion-marker-drain`; current
+Studio/Civ rerun is still pending.
 
 ## Evidence
 
-- `@mateicanavra/civ7-sdk` emits `[mapgen-complete]` and `[mapgen-failure]`
-  markers with the map seed.
+- The recovered record said `@mateicanavra/civ7-sdk` emitted
+  `[mapgen-complete]`, but current runtime request
+  `studio-run-in-game-mq3nyiss-8oj` disproved that: Scripting.log contained
+  `[mapgen-proof]`, all `50/50` recipe step `ok` lines, and
+  `Destroying Context -  MapGeneration`, but no `[mapgen-complete]`.
+- The current slice emits `[mapgen-complete]` from the SDK `createMap` wrapper
+  only after `recipe.run` returns successfully, with the same
+  request/config/envelope/seed/dimensions payload as `[mapgen-proof]`.
 - `@civ7/direct-control` already owns `snapshotFile` and
   `waitForFreshLogMarkers`.
 - The verifier previously launched and collected setup/map reads without
   proving fresh mapgen completion after the launch request.
+- Focused local proof: `bun run --cwd packages/sdk test -- mapgen-create-map`
+  and `bun run --cwd packages/sdk check`.

--- a/packages/sdk/src/mapgen/createMap.ts
+++ b/packages/sdk/src/mapgen/createMap.ts
@@ -180,22 +180,22 @@ export function createMap<const TRecipe extends RecipeModule<ExtendedMapContext,
     const context = createExtendedMapContext({ width, height }, adapter, env);
 
     const prefix = def.logPrefix ?? "[SWOOPER_MOD]";
-    console.log(
-      `${prefix} [mapgen-proof] ${JSON.stringify({
-        mapId: def.id,
-        sourceConfigId: def.sourceConfigId ?? def.id,
-        requestId: def.requestId ?? null,
-        configHash: def.configHash ?? null,
-        envelopeHash: def.envelopeHash ?? null,
-        seed,
-        mapSize: captured.mapSizeId,
-        dimensions: { width, height },
-      })}`
-    );
+    const proofPayload = {
+      mapId: def.id,
+      sourceConfigId: def.sourceConfigId ?? def.id,
+      requestId: def.requestId ?? null,
+      configHash: def.configHash ?? null,
+      envelopeHash: def.envelopeHash ?? null,
+      seed,
+      mapSize: captured.mapSizeId,
+      dimensions: { width, height },
+    };
+    console.log(`${prefix} [mapgen-proof] ${JSON.stringify(proofPayload)}`);
     try {
       def.recipe.run(context, env, def.config, {
         log: (message) => console.log(prefix, message),
       });
+      console.log(`${prefix} [mapgen-complete] ${JSON.stringify(proofPayload)}`);
     } catch (err) {
       console.error(prefix, "Map generation failed:", err);
       throw err;

--- a/packages/sdk/test/mapgen-create-map.test.ts
+++ b/packages/sdk/test/mapgen-create-map.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@civ7/adapter/civ7", async () => {
+  const { MockAdapter } = await vi.importActual<typeof import("@civ7/adapter")>("@civ7/adapter");
+  return {
+    createCiv7Adapter: vi.fn(() => new MockAdapter({
+      width: 2,
+      height: 2,
+      mapSizeId: 4,
+      mapInfo: {
+        GridWidth: 2,
+        GridHeight: 2,
+        MinLatitude: -60,
+        MaxLatitude: 60,
+      },
+    })),
+  };
+});
+
+describe("createMap", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as any).engine;
+    delete (globalThis as any).GameplayMap;
+  });
+
+  test("emits exact-authorship proof and completion markers around a successful recipe run", async () => {
+    const handlers = new Map<string, (...args: unknown[]) => void>();
+    const engineCalls: Array<{ method: string; args: unknown[] }> = [];
+    (globalThis as any).engine = {
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        handlers.set(event, handler);
+      }),
+      call: vi.fn((method: string, ...args: unknown[]) => {
+        engineCalls.push({ method, args });
+      }),
+    };
+    (globalThis as any).GameplayMap = {
+      getMapSize: vi.fn(() => 4),
+      getRandomSeed: vi.fn(() => 999),
+    };
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.join(" "));
+    };
+
+    try {
+      const { createMap } = await import("../src/mapgen/createMap");
+      const recipeRun = vi.fn(() => {
+        logs.push("recipe-run");
+      });
+
+      createMap({
+        id: "test-map",
+        name: "Test Map",
+        sourceConfigId: "studio-current",
+        requestId: "studio-run-in-game-test",
+        configHash: "config-hash",
+        envelopeHash: "envelope-hash",
+        seed: 123,
+        config: {},
+        recipe: { run: recipeRun } as any,
+      });
+
+      handlers.get("RequestMapInitData")?.([{ mapSize: 4, width: 2, height: 2 }]);
+      handlers.get("GenerateMap")?.();
+
+      expect(engineCalls).toContainEqual({
+        method: "SetMapInitData",
+        args: [{ width: 2, height: 2, topLatitude: 60, bottomLatitude: -60, mapSize: 4 }],
+      });
+      expect(recipeRun).toHaveBeenCalledTimes(1);
+
+      const proofIndex = logs.findIndex((line) => line.includes("[mapgen-proof]"));
+      const recipeIndex = logs.findIndex((line) => line === "recipe-run");
+      const completeIndex = logs.findIndex((line) => line.includes("[mapgen-complete]"));
+      expect(proofIndex).toBeGreaterThanOrEqual(0);
+      expect(recipeIndex).toBeGreaterThan(proofIndex);
+      expect(completeIndex).toBeGreaterThan(recipeIndex);
+
+      const proofPayload = payloadAfter(logs[proofIndex]!, "[mapgen-proof]");
+      const completePayload = payloadAfter(logs[completeIndex]!, "[mapgen-complete]");
+      expect(completePayload).toEqual(proofPayload);
+      expect(proofPayload).toMatchObject({
+        mapId: "test-map",
+        sourceConfigId: "studio-current",
+        requestId: "studio-run-in-game-test",
+        configHash: "config-hash",
+        envelopeHash: "envelope-hash",
+        seed: 123,
+        mapSize: 4,
+        dimensions: { width: 2, height: 2 },
+      });
+    } finally {
+      console.log = originalLog;
+    }
+  });
+});
+
+function payloadAfter(line: string, marker: string): unknown {
+  return JSON.parse(line.slice(line.indexOf(marker) + marker.length).trim());
+}


### PR DESCRIPTION
The SDK `createMap` function previously emitted only `[mapgen-proof]` before executing the recipe, with no corresponding completion marker after a successful run. A post-elevation-policy runtime request (`studio-run-in-game-mq3nyiss-8oj`) confirmed this gap: Scripting.log contained `[mapgen-proof]`, all 50/50 recipe step `ok` lines, and `Destroying Context - MapGeneration`, but no `[mapgen-complete]`, causing Studio to time out in `waiting-for-proof`.

This branch fixes that by emitting `[mapgen-complete]` from `createMap` immediately after `recipe.run` returns successfully, using the same proof payload already constructed for `[mapgen-proof]`. The marker is only emitted on the success path; the existing error branch re-throws without emitting it.

A focused SDK test (`mapgen-create-map.test.ts`) verifies the ordering invariant: `[mapgen-proof]` is logged before the recipe runs, the recipe runs, and `[mapgen-complete]` is logged after, with both markers carrying identical payloads. SDK typecheck also passes. A full Studio/Civ rerun is still required to confirm the runtime blocker is cleared and produce final-surface parity proof.