### PR TITLE
feat(direct-control): repair fresh-log reader to reset to byte 0 when Civ rewrites Scripting.log beyond the pre-run snapshot offset

### DIFF
--- a/apps/mapgen-studio/scripts/check-worker-bundle.mjs
+++ b/apps/mapgen-studio/scripts/check-worker-bundle.mjs
@@ -30,13 +30,13 @@ try {
 
   const forbidden = [
     {
-      label: "/base-standard/ import specifiers",
-      pattern: /["'`]\/base-standard\//,
+      label: "/base-standard/ imports",
+      pattern: /\b(?:import\s*(?:\(|["'])|from\s*["'])\/base-standard\//,
     },
-    { label: "Civ7 engine globals", pattern: /GameplayMap/ },
-    { label: "Node builtins (node:fs)", pattern: /node:fs/ },
-    { label: "Node builtins (node:path)", pattern: /node:path/ },
-    { label: "Node builtins (node:process)", pattern: /node:process/ },
+    { label: "Civ7 engine globals", pattern: /\bGameplayMap\b/ },
+    { label: "Node builtins (node:fs)", pattern: /["']node:fs["']/ },
+    { label: "Node builtins (node:path)", pattern: /["']node:path["']/ },
+    { label: "Node builtins (node:process)", pattern: /["']node:process["']/ },
   ];
 
   const hits = [];
@@ -45,13 +45,13 @@ try {
     for (const { label, pattern } of forbidden) {
       const match = text.match(pattern);
       if (match) {
-        hits.push({ file, label, needle: match[0] });
+        hits.push({ file, label, pattern, match: match[0] });
       }
     }
   }
 
   if (hits.length) {
-    const lines = hits.map((h) => `- ${h.label}: ${h.needle} in ${h.file}`);
+    const lines = hits.map((h) => `- ${h.label}: ${h.match} in ${h.file}`);
     fail(`worker bundle contains forbidden references:\n${lines.join("\n")}`);
   }
 } catch (e) {

--- a/apps/mapgen-studio/vite.config.ts
+++ b/apps/mapgen-studio/vite.config.ts
@@ -26,6 +26,7 @@ import {
   runCiv7SinglePlayerFromSetup,
   startCiv7Autoplay,
   stopCiv7Autoplay,
+  logTextFromSnapshot,
   snapshotFile,
   waitForFreshLogMarkers,
 } from "@civ7/direct-control";
@@ -110,9 +111,7 @@ async function readFreshLogText(logPath: string, snapshot: Awaited<ReturnType<ty
   const current = await snapshotFile(logPath);
   if (!current.exists) return "";
   const fullText = await readFile(logPath, "utf8");
-  if (current.size > snapshot.size) return fullText.slice(snapshot.size);
-  if (current.mtimeMs > snapshot.mtimeMs) return fullText;
-  return "";
+  return logTextFromSnapshot({ fullText, snapshot, current }).text;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -138,6 +138,23 @@
     failed in `waiting-for-proof` as `log-timeout` because `[mapgen-complete]`
     was absent. No exact-authorship packet, final-surface parity proof, or
     product acceptance proof was produced.
+  - Post-SDK-marker request `studio-run-in-game-mq3omoo3-8oj` used the same
+    request body, with post response
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-sdk-completion-marker-post.json`
+    (`sha256:b4771cf60933177152524fa6b2b7f8f5ff4ab9f76c2c6fc4f2613235918c4b1f`)
+    and terminal status
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-sdk-completion-marker-status.json`
+    (`sha256:0e7ce1c2cec43ba6bc482a455af56d620be49e3e0d2d1721fcb3ee7d450e1f7d`).
+    It passed materialize/deploy, process-restart recovery, setup preparation,
+    map-script load, and map generation through all `50/50` recipe steps.
+    Scripting.log records `[mapgen-proof]`, bounded `WATER_DRIFT_POLICY_V1`,
+    `NATURAL_WONDER_PLACEMENT_V1`, `RESOURCE_PLACEMENT_V1`, and
+    `[mapgen-complete]` for request `studio-run-in-game-mq3omoo3-8oj`.
+    Studio still failed in `waiting-for-proof` as `log-timeout` because the
+    direct-control fresh-log waiter carried pre-restart offset `31578` into a
+    Civ-rewritten log file and sliced past the proof markers. No
+    exact-authorship packet, final-surface parity proof, or product acceptance
+    proof was produced.
 - [ ] 2.42 Repair remaining proven package or MapGen owners.
   - Current branch `codex/swooper-map-elevation-drift-policy-drain` repairs the
     locally proven map-elevation owner mismatch: `buildElevation` now applies
@@ -146,7 +163,13 @@
   - Current branch `codex/swooper-sdk-mapgen-completion-marker-drain` repairs
     the locally proven SDK marker gap: `createMap` now emits
     `[mapgen-complete]` after successful recipe execution. Focused SDK
-    tests/checks pass, but runtime proof is still pending.
+    tests/checks pass, and runtime logs prove the marker is emitted, but Studio
+    proof closure is still pending the log-rewrite reader repair.
+  - Current follow-on slice repairs the locally proven direct-control/Studio
+    log reader gap: `snapshotFile` now preserves a log prefix, and fresh-log
+    readers use byte `0` when Civ rewrites `Scripting.log` beyond the old
+    offset. Focused direct-control and Studio tests/checks pass, but a
+    committed post-repair Studio/Civ rerun is still pending.
 - [ ] 2.43 Preserve resource spacing, age legality, and diversity expectations.
 
 ## 3. Verification
@@ -176,6 +199,11 @@
   - Current branch locally repairs the next blocker by emitting the SDK
     `[mapgen-complete]` marker after successful recipe execution. No
     post-repair Studio/Civ rerun has been completed yet.
+  - Post-SDK-marker runtime logs prove `[mapgen-complete]` is emitted, but the
+    Studio operation still timed out because the proof waiter used a stale
+    pre-restart byte offset after Civ rewrote `Scripting.log`. Current
+    follow-on code repairs that log boundary, but no post-repair Studio/Civ
+    rerun has been completed yet.
 - [x] 3.9 Run focused adapter/Swooper checks and tests for natural-wonder
   rejection telemetry.
 - [x] 3.10 Preserve source-recorded exact-authored final-surface parity after

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,11 +6,13 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
-  `codex/swooper-sdk-mapgen-completion-marker-drain`, stacked above
+  `codex/swooper-studio-log-rewrite-reader-drain`, stacked above
+  `codex/swooper-sdk-mapgen-completion-marker-drain` and
   `codex/swooper-map-elevation-drift-policy-drain`; this slice repairs the
-  locally proven SDK completion-marker gap after restart-launch retry,
-  start-log grace, same-size `Scripting.log` rewrite fixes, map-policy bundling
-  for Civ map scripts, and map-elevation bounded drift policy repair.
+  locally proven direct-control/Studio fresh-log reader gap after
+  restart-launch retry, start-log grace, same-size `Scripting.log` rewrite
+  fixes, map-policy bundling for Civ map scripts, map-elevation bounded drift
+  policy repair, and SDK completion-marker repair.
 - Started: 2026-06-06
 - Status: active. The adjacent-land resource class is classified and repaired
   in the repo-owned adapter/map-policy surface. The natural-wonder
@@ -35,9 +37,14 @@
   `map-elevation/build-elevation`, emitted bounded `WATER_DRIFT_POLICY_V1`
   telemetry, ran all `50/50` recipe steps, and emitted `[mapgen-proof]`.
   It timed out in `waiting-for-proof` because `[mapgen-complete]` was absent.
-  The current branch repairs that SDK marker gap locally, but no current
-  final-surface parity proof exists until Studio/Civ is rerun. Resource classes
-  remain pending source-authority classification.
+  The SDK marker repair was then proven in deployed runtime logs by request
+  `studio-run-in-game-mq3omoo3-8oj`, but Studio still failed in
+  `waiting-for-proof` because the direct-control log waiter sliced a
+  Civ-rewritten `Scripting.log` from the stale pre-restart byte offset. The
+  current slice repairs that fresh-log reader boundary locally, but no current
+  final-surface parity proof exists until Studio/Civ is rerun from the
+  committed repair. Resource classes remain pending source-authority
+  classification.
 
 ## Objective
 
@@ -949,10 +956,11 @@
   current `[mapgen-proof]`, `[mapgen-complete]`, exact-authorship packet,
   final-surface parity proof, or product acceptance proof was produced.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
-- Next action: diagnose and repair the current
-  `map-elevation/build-elevation` drift before another final-surface parity
-  proof attempt, then continue classifying the remaining feature/resource rows
-  by source authority: official data, adapter/map-policy, MapGen
+- Next action: commit the current direct-control/Studio fresh-log reader repair,
+  restart Studio from that committed head, and rerun the same Studio/Civ request
+  before another final-surface parity proof claim. Then continue classifying
+  the remaining feature/resource rows by source authority: official data,
+  adapter/map-policy, MapGen
   planning/materialization, accepted engine materialization, or readback
   limitation. Terrain edge rows may enter this slice only if diagnostics prove
   shared materialization ownership. The unchanged resource mismatch count after

--- a/openspec/changes/studio-live-mapgen-log-completion-proof/tasks.md
+++ b/openspec/changes/studio-live-mapgen-log-completion-proof/tasks.md
@@ -8,9 +8,17 @@
     `[mapgen-proof]`, causing Studio to time out in `waiting-for-proof`.
 - [x] 1.3 Reject fresh failure markers during verification.
 - [x] 1.4 Include mapgen log proof in the verifier output.
+- [x] 1.5 Treat a Civ-rewritten `Scripting.log` as fresh from byte `0` when
+  the current log no longer matches the pre-run prefix, even if the rewritten
+  file grows beyond the old byte offset.
 
 ## 2. Verification
 
 - [x] 2.1 Run the verifier help/smoke path.
 - [x] 2.2 Run focused direct-control tests.
 - [x] 2.3 Run focused SDK mapgen marker test and SDK typecheck.
+- [x] 2.4 Run focused Studio run-in-game tests and Studio typecheck after the
+  direct-control log reader repair.
+- [x] 2.5 Run the Studio production build; keep the worker-bundle guard focused
+  on actual virtual `/base-standard/...` imports rather than official
+  `Base/modules/base-standard/...` source-path metadata.

--- a/openspec/changes/studio-live-mapgen-log-completion-proof/workstream/phase-record.md
+++ b/openspec/changes/studio-live-mapgen-log-completion-proof/workstream/phase-record.md
@@ -2,8 +2,9 @@
 
 ## Status
 
-Repaired on `codex/swooper-sdk-mapgen-completion-marker-drain`; current
-Studio/Civ rerun is still pending.
+Repaired locally through `codex/swooper-sdk-mapgen-completion-marker-drain` and
+the follow-on direct-control log-rewrite reader slice; a committed Studio/Civ
+rerun is still pending.
 
 ## Evidence
 
@@ -15,9 +16,34 @@ Studio/Civ rerun is still pending.
 - The current slice emits `[mapgen-complete]` from the SDK `createMap` wrapper
   only after `recipe.run` returns successfully, with the same
   request/config/envelope/seed/dimensions payload as `[mapgen-proof]`.
+- Post-SDK-marker request `studio-run-in-game-mq3omoo3-8oj` proved the marker
+  is emitted in the deployed Civ map script: Scripting.log records
+  `[mapgen-proof]`, all `50/50` recipe steps, bounded
+  `WATER_DRIFT_POLICY_V1`, `NATURAL_WONDER_PLACEMENT_V1`,
+  `RESOURCE_PLACEMENT_V1`, and `[mapgen-complete]` for the same request,
+  config hash, envelope hash, seed, and dimensions. Studio still returned
+  `log-timeout` because the status waiter used pre-restart byte offset
+  `31578` against a Civ-rewritten `Scripting.log`, slicing past the proof
+  markers in the fresh file.
 - `@civ7/direct-control` already owns `snapshotFile` and
   `waitForFreshLogMarkers`.
+- The follow-on direct-control repair stores a small log prefix in
+  `snapshotFile` and starts from byte `0` when the current log no longer begins
+  with the pre-run prefix. Studio's fresh-log reader now uses the same helper
+  as `waitForFreshLogMarkers`, so marker waiting and exact proof parsing agree
+  on rewritten-log boundaries.
 - The verifier previously launched and collected setup/map reads without
   proving fresh mapgen completion after the launch request.
 - Focused local proof: `bun run --cwd packages/sdk test -- mapgen-create-map`
   and `bun run --cwd packages/sdk check`.
+- Focused local proof for the rewritten-log repair:
+  `bun run --cwd packages/civ7-direct-control test`,
+  `bun run --cwd packages/civ7-direct-control check`,
+  `bun run --cwd packages/civ7-direct-control build`,
+  `bun run --cwd apps/mapgen-studio test -- runInGame`, and
+  `bun run --cwd apps/mapgen-studio check`.
+- Studio production build note: the worker-bundle guard now matches actual
+  virtual `/base-standard/...` import forms instead of official
+  `Base/modules/base-standard/...` source-path metadata embedded from
+  `@civ7/map-policy`; this keeps the guard aligned to runtime import leakage
+  without rejecting source-evidence strings.

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, stat } from "node:fs/promises";
+import { open, readdir, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, extname, join, resolve } from "node:path";
 import { Socket, createConnection } from "node:net";
@@ -2761,6 +2761,8 @@ export type FileSnapshot = Readonly<{
   exists: boolean;
   size: number;
   mtimeMs: number;
+  prefix: string;
+  prefixBytes: number;
 }>;
 
 export type FreshLogMarkerProof = Readonly<{
@@ -2776,8 +2778,46 @@ export async function snapshotFile(path: string): Promise<FileSnapshot> {
     throw err;
   });
   return info
-    ? { exists: true, size: info.size, mtimeMs: info.mtimeMs }
-    : { exists: false, size: 0, mtimeMs: 0 };
+    ? {
+        exists: true,
+        size: info.size,
+        mtimeMs: info.mtimeMs,
+        ...(await filePrefixSnapshot(path, info.size)),
+      }
+    : { exists: false, size: 0, mtimeMs: 0, prefix: "", prefixBytes: 0 };
+}
+
+async function filePrefixSnapshot(path: string, size: number): Promise<Pick<FileSnapshot, "prefix" | "prefixBytes">> {
+  const prefixBytes = Math.min(size, 4096);
+  if (prefixBytes === 0) return { prefix: "", prefixBytes: 0 };
+  const handle = await open(path, "r");
+  try {
+    const buffer = Buffer.alloc(prefixBytes);
+    const { bytesRead } = await handle.read(buffer, 0, prefixBytes, 0);
+    return {
+      prefix: buffer.subarray(0, bytesRead).toString("utf8"),
+      prefixBytes: bytesRead,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+export function logTextFromSnapshot(args: {
+  fullText: string;
+  snapshot: FileSnapshot;
+  current: FileSnapshot;
+}): { text: string; startOffset: number; rewritten: boolean } {
+  const { fullText, snapshot, current } = args;
+  if (!snapshot.exists) return { text: fullText, startOffset: 0, rewritten: true };
+
+  const rewritten = snapshot.prefixBytes > 0 && !fullText.startsWith(snapshot.prefix);
+  if (rewritten) return { text: fullText, startOffset: 0, rewritten };
+  if (current.size > snapshot.size) {
+    return { text: fullText.slice(snapshot.size), startOffset: snapshot.size, rewritten: false };
+  }
+  if (current.mtimeMs > snapshot.mtimeMs) return { text: fullText, startOffset: 0, rewritten: true };
+  return { text: "", startOffset: snapshot.size, rewritten: false };
 }
 
 export async function waitForFreshLogMarkers(options: {
@@ -2791,22 +2831,24 @@ export async function waitForFreshLogMarkers(options: {
   const timeoutMs = options.timeoutMs ?? 90_000;
   const pollIntervalMs = options.pollIntervalMs ?? 1_000;
   const startedAt = Date.now();
-  const startOffset = options.snapshot.size;
+  const snapshotOffset = options.snapshot.size;
+  let lastStartOffset = snapshotOffset;
   let lastError: string | undefined;
 
   while (Date.now() - startedAt <= timeoutMs) {
     const current = await snapshotFile(options.logPath);
-    if (current.exists && (current.size > startOffset || current.mtimeMs > options.snapshot.mtimeMs)) {
+    if (current.exists && (current.size > snapshotOffset || current.mtimeMs > options.snapshot.mtimeMs)) {
       const fullText = await readFile(options.logPath, "utf8");
-      const newText = current.size > startOffset ? fullText.slice(startOffset) : fullText;
-      const proof = matchOrderedMarkers(newText, options.markers);
-      const rejected = options.rejectPattern?.exec(newText);
+      const freshLog = logTextFromSnapshot({ fullText, snapshot: options.snapshot, current });
+      lastStartOffset = freshLog.startOffset;
+      const proof = matchOrderedMarkers(freshLog.text, options.markers);
+      const rejected = options.rejectPattern?.exec(freshLog.text);
       if (rejected) lastError = `Log contains ${rejected[0]}`;
       if (proof.ok && !rejected) {
         return {
           logPath: options.logPath,
           observedAt: new Date().toISOString(),
-          startOffset,
+          startOffset: freshLog.startOffset,
           matched: proof.matched,
         };
       }
@@ -2817,7 +2859,7 @@ export async function waitForFreshLogMarkers(options: {
   throw new Civ7DirectControlError(
     "log-timeout",
     lastError ?? `Timed out waiting for fresh log markers in ${options.logPath}`,
-    { details: { markers: options.markers, startOffset } },
+    { details: { markers: options.markers, startOffset: lastStartOffset, snapshotOffset } },
   );
 }
 

--- a/packages/civ7-direct-control/test/direct-control.test.ts
+++ b/packages/civ7-direct-control/test/direct-control.test.ts
@@ -1179,6 +1179,26 @@ describe("Civ7 direct control", () => {
 
     expect(proof.matched).toEqual(["fresh", "marker"]);
   });
+
+  test("waits for markers when Civ rewrites the log beyond the old offset", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "civ7-direct-control-log-"));
+    const logPath = join(dir, "Scripting.log");
+    await writeFile(logPath, `old\n${"x".repeat(160)}\n`);
+    const snapshot = await snapshotFile(logPath);
+    await writeFile(logPath, `fresh\nmarker\n${"y".repeat(snapshot.size + 40)}\n`);
+    await utimes(logPath, new Date(snapshot.mtimeMs + 1_000), new Date(snapshot.mtimeMs + 1_000));
+
+    const proof = await waitForFreshLogMarkers({
+      logPath,
+      snapshot,
+      markers: ["fresh", "marker"],
+      timeoutMs: 100,
+      pollIntervalMs: 10,
+    });
+
+    expect(proof.startOffset).toBe(0);
+    expect(proof.matched).toEqual(["fresh", "marker"]);
+  });
 });
 
 function extractMapGridInput(message: string):


### PR DESCRIPTION
When Civ rewrites `Scripting.log` after a process restart, the file's new content starts from byte `0`, but the direct-control log waiter was still slicing from the pre-restart byte offset. This caused Studio to miss `[mapgen-proof]` and `[mapgen-complete]` markers that were present in the rewritten file, resulting in a `log-timeout` failure even though map generation completed successfully.

`snapshotFile` now reads and stores up to 4 KB of the file's leading bytes at snapshot time. `logTextFromSnapshot` uses that prefix to detect when Civ has rewritten the log: if the current file no longer starts with the recorded prefix, the fresh text is read from byte `0` rather than the stale offset. Both `waitForFreshLogMarkers` and Studio's `readFreshLogText` now delegate to `logTextFromSnapshot`, so marker waiting and proof parsing agree on rewritten-log boundaries.

The worker-bundle guard patterns are tightened to match only actual virtual `/base-standard/...` import forms (not source-path metadata strings embedded from `@civ7/map-policy`), word-boundary `GameplayMap` references, and quoted `node:*` specifiers, preventing false positives in the production build check.

A new test covers the rewritten-log case: the log file is replaced with content that starts differently and grows beyond the old snapshot offset, and the waiter is expected to find markers from byte `0` with `startOffset: 0`.