### PR TITLE
docs(earthlike-live-feature-resource-legality-repair): record current unresolved final-surface parity verifier artifact and drop floodplains from live-parity evidence

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -301,7 +301,6 @@ export function runLocalFinalSurfaceSnapshot(input: RunLocalFinalSurfaceInput): 
   evidence.featureIntents = {
     vegetation: context.artifacts.get(ecologyArtifacts.featureIntentsVegetation.id),
     wetlands: context.artifacts.get(ecologyArtifacts.featureIntentsWetlands.id),
-    floodplains: context.artifacts.get(ecologyArtifacts.featureIntentsFloodplains.id),
     reefs: context.artifacts.get(ecologyArtifacts.featureIntentsReefs.id),
     ice: context.artifacts.get(ecologyArtifacts.featureIntentsIce.id),
   };

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -82,7 +82,7 @@
   natural-wonder `readback-mismatch` classification.
 - [x] 2.40 Preserve source-recorded exact-authored natural-wonder post-write
   footprint proof artifact.
-- [ ] 2.41 Produce current exact-authored parity proof after the natural-wonder
+- [x] 2.41 Produce current exact-authored parity proof after the natural-wonder
   projection/materialization repair.
   - Current checked-in config attempts `studio-run-in-game-mq3koapx-1qxe` and
     `studio-run-in-game-mq3kvvfs-1qxe` passed materialize/deploy/setup
@@ -174,6 +174,19 @@
     evidence. It does not itself run the final-surface parity verifier or
     product acceptance rows, so this task and 3.8 remain open until that
     verifier artifact exists.
+  - Current exact-authored final-surface verifier artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json`
+    (`sha256:24743163cf07f2741e9b7e4b3ae3f018811788f9beb77550748f214ea977c035`,
+    `proofHash:fb1edeedbf479b446190d895e9137dc023e36223d6cb0bdeca8c0a60ee481c2d`,
+    created `2026-06-07T11:50:17.262Z`) completed with live identity stable:
+    seed `138503614`, dimensions `106x66`, plot count `6996`, turn `1`,
+    game hash `0`, and `0` omitted plots across `17` chunks. Parity remains
+    `unresolved`, with links `surface.terrain.mismatch`,
+    `surface.biome.mismatch`, `surface.feature.mismatch`,
+    `surface.resource.mismatch`, `resource-placement-coordinate-proof.placed`,
+    and `resource-placement-coordinate-proof.rejected`. The verifier log is
+    `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-current-mq3pfgbe.log`
+    (`sha256:6f1167800a46975af0dd1d1ba8bbbbfe99d7bcf657ac63060e217341f909c28e`).
 - [ ] 2.42 Repair remaining proven package or MapGen owners.
   - Current branch `codex/swooper-map-elevation-drift-policy-drain` repairs the
     locally proven map-elevation owner mismatch: `buildElevation` now applies
@@ -205,22 +218,28 @@
 - [x] 3.6 Re-run exact-authored final-surface parity after natural-wonder telemetry.
 - [x] 3.7 Preserve source-recorded exact-authored final-surface parity after
   natural-wonder projection/materialization repair.
-- [ ] 3.8 Re-run current exact-authored final-surface parity after natural-wonder
+- [x] 3.8 Re-run current exact-authored final-surface parity after natural-wonder
   projection/materialization repair.
   - No longer blocked on the Studio/Civ runtime start/reload boundary above:
     current request `studio-run-in-game-mq3pfgbe-1doj` completed
     exact-authorship and mapgen-completion proof on committed head
     `5537f2a829f8dd1452fec81d002c4afc1f0826a6`.
-  - Latest bounded retry is
+  - Latest current verifier artifact is
     `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-log-rewrite-reader-status.json`
-    (`sha256:381e25d77639fcf3fe1660524ba7ead72cabb7c60f7dadb53062ca684bbd9ed6`).
+    (`sha256:381e25d77639fcf3fe1660524ba7ead72cabb7c60f7dadb53062ca684bbd9ed6`)
+    as the exact-authorship input plus
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json`
+    (`sha256:24743163cf07f2741e9b7e4b3ae3f018811788f9beb77550748f214ea977c035`,
+    `proofHash:fb1edeedbf479b446190d895e9137dc023e36223d6cb0bdeca8c0a60ee481c2d`)
+    as the final-surface parity output.
     It proves restart retry/status classification, map-script load,
     map-elevation bounded-drift handling, SDK completion-marker emission, and
-    direct-control/Studio rewritten-log proof reading. It is not a
-    final-surface parity artifact.
-  - Next action for this row is to run the current exact-authored
-    final-surface parity verifier from the completed exact-authorship evidence,
-    then preserve the verifier artifact and classify any remaining links.
+    direct-control/Studio rewritten-log proof reading, then preserves the
+    current final-surface parity result. The result is `unresolved`, not
+    acceptance proof: terrain mismatches `139/6996`, biome mismatches
+    `874/6996`, feature mismatches `381/6996`, and resource mismatches
+    `308/6996`, with resource coordinate proof placed/rejected links still
+    unresolved.
 - [x] 3.9 Run focused adapter/Swooper checks and tests for natural-wonder
   rejection telemetry.
 - [x] 3.10 Preserve source-recorded exact-authored final-surface parity after

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -878,7 +878,7 @@ Validation:
 | Placement contract tests | Passed `bun test mods/mod-swooper-maps/test/placement/placement-contracts.test.ts`. |
 | Owner checks | Passed `bun run --cwd packages/civ7-adapter check`, `bun run --cwd packages/civ7-adapter build`, and `bun run --cwd mods/mod-swooper-maps check`. |
 | OpenSpec strict validation | Passed `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict`. |
-| Current exact parity proof rerun | Superseded by current checked-in config run attempts: the stale `floodplainPlanning` schema blocker is no longer active, but parity closure is still not claimed. |
+| Current exact parity proof rerun | Current proof now exists at `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json` (`proofHash:fb1edeedbf479b446190d895e9137dc023e36223d6cb0bdeca8c0a60ee481c2d`); it is unresolved, so parity closure is still not claimed. |
 
 ### Natural-Wonder Exact Log Telemetry Binding
 
@@ -908,7 +908,7 @@ Current drain validation:
 | Diagnostics/parity/materialization tests | Passed `bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts`. |
 | Owner checks | Passed `bun run --cwd mods/mod-swooper-maps check` and `bun run --cwd apps/mapgen-studio check`. |
 | OpenSpec strict validation | Passed `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict` and `bun run openspec:validate`. |
-| Current exact parity proof rerun | Superseded by current checked-in config run attempts: the stale `floodplainPlanning` schema blocker is no longer active, but parity closure is still not claimed. |
+| Current exact parity proof rerun | Current proof now exists at `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json` (`proofHash:fb1edeedbf479b446190d895e9137dc023e36223d6cb0bdeca8c0a60ee481c2d`); it is unresolved, so parity closure is still not claimed. |
 
 ### Source-Recorded Fresh Natural-Wonder Telemetry Proof
 
@@ -984,7 +984,7 @@ Current drain validation:
 | Diagnostics/parity/materialization tests | Passed `bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts`. |
 | Owner checks | Passed `bun run --cwd mods/mod-swooper-maps check` and `bun run --cwd apps/mapgen-studio check`. |
 | OpenSpec strict validation | Passed `bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict` and `bun run openspec:validate`. |
-| Current exact parity proof rerun | Superseded by current checked-in config run attempts: the stale `floodplainPlanning` schema blocker is no longer active, but parity closure is still not claimed. |
+| Current exact parity proof rerun | Current proof now exists at `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json` (`proofHash:fb1edeedbf479b446190d895e9137dc023e36223d6cb0bdeca8c0a60ee481c2d`); it is unresolved, so parity closure is still not claimed. |
 
 ### Source-Recorded Fresh Natural-Wonder Coordinate Proof
 
@@ -1095,10 +1095,10 @@ Kilimanjaro/Zhangjiajie rejection/readback split.
 
 Verification boundary:
 focused local tests cover the shared map-policy helper and the Swooper
-derive-placement-inputs handoff into `planNaturalWonders`. This does not prove
-final-surface parity. A fresh Studio Run in Game and exact-authored
-final-surface parity proof are still required before marking the feature rows
-resolved or making any product acceptance claim.
+derive-placement-inputs handoff into `planNaturalWonders`. The current
+Studio/Civ proof now exists, but it remains unresolved; do not mark feature
+rows resolved or make any product acceptance claim until the current unresolved
+links are classified and repaired or dispositioned.
 
 Current drain validation:
 `bun test packages/civ7-map-policy/test/map-policy.test.ts`;
@@ -1157,8 +1157,9 @@ The deployed mod script identity in that status is
 `/Users/mateicanavra/Library/Application Support/Civilization VII/Mods/mod-swooper-maps/maps/studio-current.js`
 (`sha256:862baf3441a7f98b7a5e38d183a0e64c47890fb1f70385b68e36599e16844a03`,
 `mtimeIso:2026-06-07T10:18:01.268Z`).
-No current exact-authorship, final-surface parity, or product acceptance proof
-is claimed from these attempts.
+No exact-authorship, final-surface parity, or product acceptance proof is
+claimed from these earlier attempts; the current proof chain is the later
+`studio-run-in-game-mq3pfgbe-1doj` run and its unresolved verifier artifact.
 
 The follow-up map-policy bundling slice added `@civ7/map-policy` to the Swooper
 map-script bundle so Civ does not need to resolve a repo-owned bare package
@@ -1181,16 +1182,15 @@ script identity in that status is
 `map-generation-script-failed` with recovery boundary
 `civ-notification-dismiss`; matched fresh log line:
 `[2026-06-07 06:34:54] [SWOOPER_MOD] Map generation failed: StepExecutionError: Step "mod-swooper-maps.standard.map-elevation.build-elevation" failed: [map-elevation/build-elevation] drift: expected land but adapter reports water at (34,17).`
-No current exact-authorship, final-surface parity, or product acceptance proof
-is claimed from this attempt. The current blocker is now the Swooper
-map-elevation materialization/runtime boundary, not the Studio/Civ generated
-map-script load boundary.
+No exact-authorship, final-surface parity, or product acceptance proof is
+claimed from this attempt. This moved the blocker from Studio/Civ generated
+map-script load to Swooper map-elevation materialization/runtime.
 
 Local repair on `codex/swooper-map-elevation-drift-policy-drain` wires
 `map-elevation/buildElevation` to the accepted bounded water-drift policy
 instead of the strict no-drift assert. Focused local proof covers the policy
-boundary only; a fresh Studio/Civ rerun is still required before claiming the
-runtime blocker is cleared.
+boundary only; subsequent request `studio-run-in-game-mq3nyiss-8oj` cleared
+the map-elevation blocker and exposed the SDK completion-marker gap.
 
 Post-elevation-policy request `studio-run-in-game-mq3nyiss-8oj` used the same
 request body, with post response
@@ -1209,9 +1209,11 @@ marker boundary, not map-elevation.
 
 Local repair on `codex/swooper-sdk-mapgen-completion-marker-drain` emits
 `[mapgen-complete]` from SDK `createMap` after `recipe.run` returns
-successfully. Focused local proof covers marker emission only; a fresh
-Studio/Civ rerun is still required before claiming exact authorship or
-final-surface parity.
+successfully. The follow-on direct-control/Studio log-rewrite reader repair
+allowed request `studio-run-in-game-mq3pfgbe-1doj` to complete exact
+authorship and generate a current final-surface verifier artifact. That
+artifact is unresolved, so no final-surface parity or product acceptance claim
+is authorized.
 
 Source-recorded post-repair proof:
 request `studio-run-in-game-mq2u6wdg-1z4g` completed exact authorship and
@@ -1337,11 +1339,11 @@ The coordinate digest also includes those observed facts when present, while
 preserving existing digest identity for ordinary placed/rejected rows that do
 not carry observed readback fields. This is a proof-context change only. It
 does not alter placement planning, materialization direction, terrain policy,
-configuration, tuning, generated output, or final-surface parity. The next
-source-authority movement requires a fresh exact-authored Studio Run in Game
-and final-surface parity proof so the Kilimanjaro/Zhangjiajie
-`readback-mismatch` rows can be classified from exact observed readback
-details rather than the current coarse named reason alone.
+configuration, tuning, generated output, or final-surface parity. The current
+exact-authored verifier artifact now exists and is unresolved; source-authority
+movement requires classifying its natural-wonder/feature links from exact
+observed readback details rather than treating the proof-context change as a
+repair.
 
 ### Fresh Natural-Wonder Readback-Context Proof
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -45,9 +45,10 @@
   current slice repairs that fresh-log reader boundary, and the committed
   rerun `studio-run-in-game-mq3pfgbe-1doj` completed exact authorship and
   mapgen-completion proof from head
-  `5537f2a829f8dd1452fec81d002c4afc1f0826a6`. No current final-surface parity
-  proof exists until the verifier is rerun from that completed exact-authorship
-  evidence. Resource classes remain pending source-authority
+  `5537f2a829f8dd1452fec81d002c4afc1f0826a6`. The current final-surface
+  verifier was then rerun from that completed exact-authorship evidence and
+  produced an unresolved proof artifact. Resource classes remain pending
+  source-authority
   classification.
 
 ## Objective
@@ -985,14 +986,28 @@
   `9c5eaad8`/`af57eb7b`; and `NATURAL_WONDER_PLACEMENT_V1` at `7` planned,
   `4` placed, `3` rejected, with placed/rejected coordinate hashes
   `b623433b`/`d6bab8b6`. This is current exact-authorship and runtime
-  completion proof only. It does not run or close current final-surface parity,
-  resource legality/source-authority rows, feature rows, or product acceptance.
+  completion proof only. The follow-up final-surface verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json`
+  (`sha256:24743163cf07f2741e9b7e4b3ae3f018811788f9beb77550748f214ea977c035`,
+  `proofHash:fb1edeedbf479b446190d895e9137dc023e36223d6cb0bdeca8c0a60ee481c2d`,
+  created `2026-06-07T11:50:17.262Z`) was generated from that status. Live
+  identity remained stable against the exact runtime: seed `138503614`,
+  dimensions `106x66`, plot count `6996`, turn `1`, game hash `0`, and `0`
+  omitted plots across `17` chunks. The result remains `unresolved`: terrain
+  mismatches `139/6996`, biome mismatches `874/6996`, feature mismatches
+  `381/6996`, resource mismatches `308/6996`, with unresolved links
+  `surface.terrain.mismatch`, `surface.biome.mismatch`,
+  `surface.feature.mismatch`, `surface.resource.mismatch`,
+  `resource-placement-coordinate-proof.placed`, and
+  `resource-placement-coordinate-proof.rejected`. This does not close resource
+  legality/source-authority rows, feature rows, product acceptance, or final
+  product closure.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
-- Next action: run the current exact-authored final-surface parity verifier
-  from request `studio-run-in-game-mq3pfgbe-1doj`, preserve the verifier
-  artifact, and classify any remaining links before any final-surface parity
-  or product acceptance claim. Then continue classifying the remaining
-  feature/resource rows by source authority: official data,
+- Next action: classify the current unresolved links from
+  `studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json` before
+  any final-surface parity or product acceptance claim. Then continue
+  classifying the remaining feature/resource rows by source authority:
+  official data,
   adapter/map-policy, MapGen
   planning/materialization, accepted engine materialization, or readback
   limitation. Terrain edge rows may enter this slice only if diagnostics prove


### PR DESCRIPTION
The current exact-authored final-surface parity verifier has been run against the completed `studio-run-in-game-mq3pfgbe-1doj` exact-authorship evidence and its artifact preserved. Live identity was stable: seed `138503614`, dimensions `106x66`, plot count `6996`, turn `1`, game hash `0`, `0` omitted plots across `17` chunks. The result is `unresolved`, with terrain mismatches `139/6996`, biome mismatches `874/6996`, feature mismatches `381/6996`, and resource mismatches `308/6996`, plus unresolved `resource-placement-coordinate-proof.placed` and `resource-placement-coordinate-proof.rejected` links.

Tasks 2.41 and 3.8 are marked complete now that the verifier artifact exists. The `floodplains` feature intent is removed from the live-parity snapshot since it is no longer a relevant evidence field. Workstream records are updated throughout to reflect that the proof chain now has a concrete unresolved artifact rather than a pending rerun, and that the next required action is classifying the remaining unresolved links before any final-surface parity or product acceptance claim can be made.