### PR TITLE
feat(verify-resource-delta-feasibility): batch ResourceBuilder diagnostics to avoid timeout and record current unresolved terrain/feature/resource delta context

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -4,10 +4,38 @@
   `studio-run-in-game-mq20rbzr-1fhc` for the adjacent-land resource class.
 - [ ] 1.2 Link remaining concrete classified feature/resource delta rows from
   `studio-run-in-game-mq20rbzr-1fhc`.
+  - Current `studio-run-in-game-mq3pfgbe-1doj` diagnostics now link the current
+    unresolved rows at proof-artifact level, but they do not complete
+    source-authority classification: terrain rows are `139` unresolved,
+    feature rows are `381`, and resource rows are `308`.
 - [x] 1.3 Identify source authority for the adjacent-land resource class:
   adapter/map-policy static runtime divergence.
 - [ ] 1.4 Identify source authority for each remaining row: official data, adapter/map
   policy, MapGen planning, or accepted engine materialization.
+  - Current terrain diagnostic artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-terrain-edge-live-readback-context.json`
+    (`sha256:fb3e0e912897253066d53720ca51346c1ac7c6ef940384028e351935a1f176a4`,
+    `proofHash:fc2226d188385c50e5163256304971893a94210fe6175d60ba28f4b242769876`)
+    preserves `139` terrain rows with matched runtime identity. It leaves all
+    rows source-authority `unresolved` (`138` unclassified, `1`
+    `local-coast-live-ocean`).
+  - Current feature diagnostic artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-feature-delta-feasibility.json`
+    (`sha256:a827a0e0c6560950cf8e944ed7a566911c2b16d3fb79b173ccea2d1e29e1f8ae`,
+    `proofHash:77e2565802122291e9ec50dfb0752dbdb70fd7bf5cd54185e56172a127acf1d0`)
+    preserves `381` feature rows: `166`
+    `live-feature-civ-infeasible-local-empty`, `78`
+    `local-feature-civ-infeasible-live-empty`, `30`
+    `local-feature-civ-feasible-live-empty`, and `107` unclassified swaps.
+  - Current resource diagnostic artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-resource-delta-feasibility-full.json`
+    (`sha256:05512721dba9cb8a9a63d6a87702d7daf8439a658bb9680827c65bfab73be03a`,
+    `proofHash:7eb8a38538bd8c61d7b8cd96f0b01984cd6bb68c4b581c09565e950a78ee9ff9`)
+    preserves `308` resource rows with matched runtime identity. Under
+    `ignoreWeight:true`, class counts are `114`
+    live-feasible/no-local-assignment, `53` local-feasible/live-empty, `62`
+    local-overaccepted/live-empty, `51` substitution-both-feasible, `27`
+    substitution-mixed-feasibility, and `1` substitution-both-infeasible.
 
 ## 2. Repair
 
@@ -207,6 +235,14 @@
     bucket for any future package or MapGen owners proven by the open
     source-authority rows.
 - [ ] 2.43 Preserve resource spacing, age legality, and diversity expectations.
+  - Current exact log proves `251` planned resources, `250` placed, `1`
+    rejected, `0` mismatched, `34` unique planned/placed types, min/max placed
+    count by type `7/8`, and runtime catalog count `55`.
+  - Current resource diagnostics preserve the broader class context but do not
+    yet authorize repair: `194` local-assigned delta rows, `183` from
+    `scarce-floor`, and `62` local-overaccepted/live-empty rows subclassified
+    as `39` scarce-floor cut-excluded, `17` scarce-floor cut-included rejected,
+    and `6` non-scarce-floor local overaccepted.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1215,6 +1215,28 @@ authorship and generate a current final-surface verifier artifact. That
 artifact is unresolved, so no final-surface parity or product acceptance claim
 is authorized.
 
+Current exact-authored final-surface diagnostics:
+request `studio-run-in-game-mq3pfgbe-1doj` produced the current final-surface
+artifact
+`/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json`
+(`sha256:24743163cf07f2741e9b7e4b3ae3f018811788f9beb77550748f214ea977c035`,
+`proofHash:fb1edeedbf479b446190d895e9137dc023e36223d6cb0bdeca8c0a60ee481c2d`).
+Live identity is stable (`106x66`, `6996` plots, seed `138503614`, turn `1`,
+game hash `0`, `0` omitted plots), but parity remains `unresolved`.
+
+| Surface | Count / class summary | Artifact |
+|---|---:|---|
+| Terrain | `139` mismatches; live readback context leaves all source-authority statuses unresolved (`138` unclassified, `1` `local-coast-live-ocean`). | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-terrain-edge-live-readback-context.json` (`sha256:fb3e0e912897253066d53720ca51346c1ac7c6ef940384028e351935a1f176a4`, `proofHash:fc2226d188385c50e5163256304971893a94210fe6175d60ba28f4b242769876`) |
+| Feature | `381` mismatches; `166` live-feature Civ-infeasible/local-empty, `78` local-feature Civ-infeasible/live-empty, `30` local-feature Civ-feasible/live-empty, `107` unclassified swaps. | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-feature-delta-feasibility.json` (`sha256:a827a0e0c6560950cf8e944ed7a566911c2b16d3fb79b173ccea2d1e29e1f8ae`, `proofHash:77e2565802122291e9ec50dfb0752dbdb70fd7bf5cd54185e56172a127acf1d0`) |
+| Resource | `308` mismatches. Under `ignoreWeight:true`: `114` live-feasible/no-local-assignment, `53` local-feasible/live-empty, `62` local-overaccepted/live-empty, `51` substitution-both-feasible, `27` substitution-mixed-feasibility, `1` substitution-both-infeasible. Focused local-overaccepted rows subclassify as `39` scarce-floor cut-excluded, `17` scarce-floor cut-included rejected, `6` non-scarce-floor local overaccepted. | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-resource-delta-feasibility-full.json` (`sha256:05512721dba9cb8a9a63d6a87702d7daf8439a658bb9680827c65bfab73be03a`, `proofHash:7eb8a38538bd8c61d7b8cd96f0b01984cd6bb68c4b581c09565e950a78ee9ff9`) |
+
+Resource diagnostic note:
+the first unbatched ResourceBuilder diagnostics command timed out at
+`180000ms` for `62` focused cells. The current verifier script batches
+ResourceBuilder diagnostics in groups of `8`; the batched run produced the
+artifact above. This is a diagnostic robustness repair, not a resource behavior
+change.
+
 Source-recorded post-repair proof:
 request `studio-run-in-game-mq2u6wdg-1z4g` completed exact authorship and
 generated parity artifact

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -1002,6 +1002,43 @@
   `resource-placement-coordinate-proof.rejected`. This does not close resource
   legality/source-authority rows, feature rows, product acceptance, or final
   product closure.
+  Current diagnostic follow-ups preserve row context for those unresolved
+  links without authorizing repair. Terrain context artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-terrain-edge-live-readback-context.json`
+  (`sha256:fb3e0e912897253066d53720ca51346c1ac7c6ef940384028e351935a1f176a4`,
+  `proofHash:fc2226d188385c50e5163256304971893a94210fe6175d60ba28f4b242769876`)
+  records `139` terrain rows with matched runtime identity and leaves all
+  source-authority statuses unresolved. Feature context artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-feature-delta-feasibility.json`
+  (`sha256:a827a0e0c6560950cf8e944ed7a566911c2b16d3fb79b173ccea2d1e29e1f8ae`,
+  `proofHash:77e2565802122291e9ec50dfb0752dbdb70fd7bf5cd54185e56172a127acf1d0`)
+  records `381` feature rows with Civ feasibility classes: `166`
+  live-feature Civ-infeasible/local-empty, `78` local-feature
+  Civ-infeasible/live-empty, `30` local-feature Civ-feasible/live-empty, and
+  `107` unclassified swaps. Resource context artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-resource-delta-feasibility-full.json`
+  (`sha256:05512721dba9cb8a9a63d6a87702d7daf8439a658bb9680827c65bfab73be03a`,
+  `proofHash:7eb8a38538bd8c61d7b8cd96f0b01984cd6bb68c4b581c09565e950a78ee9ff9`)
+  records `308` resource rows. Its `ignoreWeight:true` classes are `114`
+  live-feasible/no-local-assignment, `53` local-feasible/live-empty, `62`
+  local-overaccepted/live-empty, `51` substitution-both-feasible, `27`
+  substitution-mixed-feasibility, and `1` substitution-both-infeasible. The
+  focused `62` local-overaccepted/live-empty rows subclassify as `39`
+  scarce-floor cut-excluded, `17` scarce-floor cut-included rejected, and `6`
+  non-scarce-floor local overaccepted. The verifier script now batches
+  ResourceBuilder diagnostics in groups of `8`; the unbatched `62`-cell read
+  timed out at `180000ms`.
+  Slice verification on `codex/swooper-current-final-surface-parity-record-drain`
+  before committing the diagnostic record: `bun run --cwd mods/mod-swooper-maps
+  check`; `bun test
+  mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
+  mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts
+  scripts/civ7-direct-control/verify-final-surface-parity.test.ts
+  scripts/civ7-direct-control/verify-terrain-edge-live-context.test.ts` (`26`
+  pass); `bun scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
+  --help`; `bun run openspec -- validate
+  earthlike-live-feature-resource-legality-repair --strict`; `bun run
+  openspec:validate` (`76` passed, `0` failed); and `git diff --check`.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the current unresolved links from
   `studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json` before

--- a/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
+++ b/scripts/civ7-direct-control/verify-resource-delta-feasibility.ts
@@ -11,6 +11,7 @@ import {
   type Civ7MapGridResult,
   type Civ7PlotSnapshotField,
   type Civ7MapSummaryResult,
+  type Civ7ResourcePlacementFeasibilityCellInput,
   type Civ7ResourceBuilderDiagnosticsResult,
   type Civ7ResourcePlacementFeasibilityResult,
   type Civ7RuntimeProbe,
@@ -58,6 +59,8 @@ const LIVE_RESOURCE_CONTEXT_FIELDS = [
   "tags",
   "owner",
 ] as const satisfies ReadonlyArray<Civ7PlotSnapshotField>;
+
+const RESOURCE_BUILDER_DIAGNOSTIC_BATCH_SIZE = 8;
 
 function parseArgs(argv: string[]): Args {
   const args: {
@@ -202,7 +205,7 @@ async function main(): Promise<number> {
     resourceTypesForResourceBuilderDiagnostics(ignoreWeightProof.rows);
   const resourceBuilderDiagnostics =
     resourceBuilderDiagnosticCells.length > 0
-      ? await getCiv7ResourceBuilderDiagnostics(
+      ? await getResourceBuilderDiagnosticsBatched(
           {
             cells: resourceBuilderDiagnosticCells,
             resourceTypes: resourceBuilderDiagnosticResourceTypes,
@@ -246,6 +249,49 @@ async function main(): Promise<number> {
   writeOutput(args.output, output);
   console.log(stableParityProofStringify(output));
   return 0;
+}
+
+async function getResourceBuilderDiagnosticsBatched(
+  input: {
+    cells: ReadonlyArray<Civ7ResourcePlacementFeasibilityCellInput>;
+    resourceTypes: ReadonlyArray<number>;
+    maxCells: number;
+  },
+  options: Pick<Args, "host" | "port" | "timeoutMs">
+): Promise<Civ7ResourceBuilderDiagnosticsResult> {
+  const cells = input.cells.slice(0, input.maxCells);
+  const batches = chunk(cells, RESOURCE_BUILDER_DIAGNOSTIC_BATCH_SIZE);
+  const results: Civ7ResourceBuilderDiagnosticsResult[] = [];
+  for (const batch of batches) {
+    results.push(
+      await getCiv7ResourceBuilderDiagnostics(
+        {
+          cells: batch,
+          resourceTypes: input.resourceTypes,
+          maxCells: batch.length,
+        },
+        options
+      )
+    );
+  }
+  const first = results[0];
+  if (!first) throw new Error("Expected at least one ResourceBuilder diagnostics batch");
+  const resourcesByType = new Map<number, Civ7ResourceBuilderDiagnosticsResult["resources"][number]>();
+  for (const result of results) {
+    for (const resource of result.resources) {
+      resourcesByType.set(resource.resourceType, resource);
+    }
+  }
+  return {
+    host: first.host,
+    port: first.port,
+    state: first.state,
+    cellCount: input.cells.length,
+    omittedCells: Math.max(0, input.cells.length - cells.length) +
+      results.reduce((sum, result) => sum + result.omittedCells, 0),
+    resources: [...resourcesByType.values()].sort((left, right) => left.resourceType - right.resourceType),
+    cells: results.flatMap((result) => result.cells),
+  };
 }
 
 function extractFinalSurfaceParityProof(payload: unknown): FinalSurfaceParityProof {
@@ -1126,6 +1172,14 @@ function writeOutput(path: string | undefined, output: unknown): void {
   const absolute = resolve(path);
   mkdirSync(dirname(absolute), { recursive: true });
   writeFileSync(absolute, JSON.stringify(output, null, 2));
+}
+
+function chunk<T>(values: ReadonlyArray<T>, size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    chunks.push(values.slice(index, index + size));
+  }
+  return chunks;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
The `verify-resource-delta-feasibility.ts` script previously issued a single unbatched `ResourceBuilder` diagnostics request for all focused cells, which timed out at 180,000ms when processing 62 local-overaccepted/live-empty cells. This change introduces a `getResourceBuilderDiagnosticsBatched` helper that splits the cell list into groups of 8 and merges the results, resolving the timeout without changing resource behavior.

The workstream records are updated to reflect the current diagnostic state from run `studio-run-in-game-mq3pfgbe-1doj`: 139 terrain mismatches (all source-authority unresolved), 381 feature mismatches (166 live-feature Civ-infeasible/local-empty, 78 local-feature Civ-infeasible/live-empty, 30 local-feature Civ-feasible/live-empty, 107 unclassified swaps), and 308 resource mismatches (114 live-feasible/no-local-assignment, 53 local-feasible/live-empty, 62 local-overaccepted/live-empty, 51 substitution-both-feasible, 27 substitution-mixed-feasibility, 1 substitution-both-infeasible). The 62 local-overaccepted rows further subclassify as 39 scarce-floor cut-excluded, 17 scarce-floor cut-included rejected, and 6 non-scarce-floor local overaccepted. Proof artifact hashes and paths are recorded for all three surfaces. No source-authority rows are resolved and no repair is authorized by this change.