### PR TITLE
docs(earthlike-live-feature-resource-legality-repair): record source-authority synthesis table and narrow repair proof queue to resource/feature/terrain order

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -36,6 +36,17 @@
     live-feasible/no-local-assignment, `53` local-feasible/live-empty, `62`
     local-overaccepted/live-empty, `51` substitution-both-feasible, `27`
     substitution-mixed-feasibility, and `1` substitution-both-infeasible.
+  - Current source-authority synthesis does not close this row. It narrows the
+    next proof targets:
+    terrain remains a projection/readback-owner question (`139` unresolved
+    rows, dominated by coast/flat/hill/navigable-river edge swaps); feature
+    repair authority is strongest for the `78` local-only ecology features that
+    Civ reports infeasible and the `30` local-only ecology features that Civ
+    reports feasible but live omits; resource repair authority is strongest for
+    the `62` local-overaccepted/live-empty rows, especially the `56`
+    scarce-floor rows at target `7`. Live-only resource additions (`114`) and
+    both-feasible substitutions (`51`) remain materialization/projection
+    questions, not tuning authority.
 
 ## 2. Repair
 
@@ -234,6 +245,11 @@
     `[mapgen-complete]` evidence. Keep this row open only as the remaining
     bucket for any future package or MapGen owners proven by the open
     source-authority rows.
+  - Current diagnostics do not yet prove a new owner repair. The candidate
+    proof queue is: resource scarce-floor/local-overaccepted authority first,
+    local-only ecology-feature materialization authority second, terrain
+    projection/readback authority third. Do not tune or repair broader
+    live-only/substitution classes until a source owner is proven.
 - [ ] 2.43 Preserve resource spacing, age legality, and diversity expectations.
   - Current exact log proves `251` planned resources, `250` placed, `1`
     rejected, `0` mismatched, `34` unique planned/placed types, min/max placed
@@ -243,6 +259,10 @@
     `scarce-floor`, and `62` local-overaccepted/live-empty rows subclassified
     as `39` scarce-floor cut-excluded, `17` scarce-floor cut-included rejected,
     and `6` non-scarce-floor local overaccepted.
+  - Any accepted resource repair must preserve the current proof-class
+    separation: exact runtime distribution breadth (`34` placed resource types,
+    min/max placed count by type `7/8`) is a product-health guard, while
+    unresolved coordinate parity is still not product acceptance.
 
 ## 3. Verification
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1237,6 +1237,19 @@ ResourceBuilder diagnostics in groups of `8`; the batched run produced the
 artifact above. This is a diagnostic robustness repair, not a resource behavior
 change.
 
+Current source-authority synthesis:
+
+| Surface | Current interpretation | Next proof target |
+|---|---|---|
+| Terrain | All `139` rows remain source-authority unresolved. The dominant pairs are coast/flat/hill/navigable-river edge swaps (`24` coast->flat, `24` flat->navigable-river, `23` hill->coast, `21` navigable-river->flat, `15` coast->hill, `13` navigable-river->hill). This is a projection/readback-owner question, not a tuning target. | Prove whether terrain projection/readback belongs to map-rivers, morphology/coast policy, placement-surface validation, or accepted engine materialization before repair. |
+| Feature | `78` local-only ecology features are Civ-infeasible and `30` local-only ecology features are Civ-feasible but live-omitted; these are the strongest local materialization/feature-apply candidate owner buckets. `166` live-only features are Civ-infeasible on the live surface, and `107` swaps remain unclassified, so those do not authorize local tuning. | Prove local-only ecology-feature materialization authority before changing ecology/feature application. |
+| Resource | `62` local-overaccepted/live-empty rows are the strongest repo-owned candidate bucket; `56` come from scarce-floor target `7`, with focused ResourceBuilder classes `39` scarce-floor cut-excluded, `17` scarce-floor cut-included rejected, and `6` non-scarce-floor local overaccepted. `114` live-feasible/no-local-assignment rows and `51` both-feasible substitutions are materialization/projection questions rather than direct scarce-floor tuning authority. | Prove whether scarce-floor target/assignment or local materialization overacceptance owns the `62` local-overaccepted rows while preserving exact runtime resource diversity evidence. |
+
+This synthesis intentionally leaves final-surface parity and product acceptance
+open. It narrows the next repair proof queue to resource local-overacceptance
+first, local-only ecology-feature materialization second, and terrain
+projection/readback third.
+
 Source-recorded post-repair proof:
 request `studio-run-in-game-mq2u6wdg-1z4g` completed exact authorship and
 generated parity artifact

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -1039,31 +1039,36 @@
   --help`; `bun run openspec -- validate
   earthlike-live-feature-resource-legality-repair --strict`; `bun run
   openspec:validate` (`76` passed, `0` failed); and `git diff --check`.
+  Source-authority synthesis after these diagnostics: current final-surface
+  parity remains open, but the next proof queue is narrowed. Resource
+  local-overaccepted/live-empty rows are first because `62` rows have concrete
+  assignment and ResourceBuilder context, including `56` scarce-floor target
+  `7` rows. Local-only ecology-feature materialization is second because `78`
+  local-only rows are Civ-infeasible and `30` are Civ-feasible but live-omitted.
+  Terrain projection/readback is third because all `139` terrain rows still
+  have unresolved ownership and are dominated by coast/flat/hill/navigable-river
+  projection swaps. Live-only resource additions, both-feasible resource
+  substitutions, live-feature Civ-infeasible rows, and unclassified feature
+  swaps do not authorize tuning or direct repair yet.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the current unresolved links from
-  `studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json` before
-  any final-surface parity or product acceptance claim. Then continue
-  classifying the remaining feature/resource rows by source authority:
-  official data,
-  adapter/map-policy, MapGen
-  planning/materialization, accepted engine materialization, or readback
-  limitation. Terrain edge rows may enter this slice only if diagnostics prove
-  shared materialization ownership. The unchanged resource mismatch count after
-  the adjacent-land repair and the assignment-evidence rerun means the next
-  resource authority gap is broad assignment ordering diagnostics for the
-  feasible live-only/local-empty/substitution classes plus hidden runtime
-  feasibility classification for the `9` local-assigned/live-empty rows where
-  Civ rejects the local value with `ignoreWeight:true`. For those `9` rows,
-  assignment trace rules out relaxed spacing and rebalance, and ResourceBuilder
-  diagnostics and the structured subclassification show `6` local resources
-  absent from Civ cut lists while `3` local resources are present in cut lists
-  but still rejected. Assignment-order and policy context show every focused
-  local value came from the scarce-floor quota pass and that the local floor
-  target exceeds the official minimum-per-hemisphere. The assignment-class
-  summary also shows scarce-floor accounts for `64/69` local-authored resource
-  delta rows overall, while the resource distribution context shows local
-  assigned counts match current ResourceBuilder counts for all `26` local
-  resource types represented by those deltas. The position context now also
+  `studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json` by
+  proving or rejecting the narrowed repair-owner candidates in order:
+  resource local-overacceptance/scarce-floor materialization, local-only
+  ecology-feature materialization, then terrain projection/readback. Do this
+  before any final-surface parity or product acceptance claim. The older
+  source-recorded context remains useful: for the prior `9` local-assigned
+  live-empty rows, assignment trace ruled out relaxed spacing and rebalance,
+  and ResourceBuilder diagnostics and structured subclassification showed `6`
+  local resources absent from Civ cut lists while `3` local resources were
+  present in cut lists but still rejected. Assignment-order and policy context
+  showed every focused local value came from the scarce-floor quota pass and
+  that the local floor target exceeded the official minimum-per-hemisphere. The
+  assignment-class summary also showed scarce-floor accounted for `64/69`
+  local-authored resource delta rows overall, while resource distribution
+  context showed local assigned counts matched current ResourceBuilder counts
+  for all `26` local resource types represented by those deltas. The position
+  context now also
   matches all `69` local-authored delta resources to same-resource live delta
   rows, mostly at long distance. Local materialization context proves the local
   final resource surface still matches every typed local placement outcome.
@@ -1072,15 +1077,15 @@
   No resource tuning, static-policy repair, scarce-floor repair, or
   assignment-order repair is authorized until a fresh exact-authored run binds
   local and live immediate placement coordinate identity or otherwise assigns
-  those subclasses to a concrete source owner. Feature rows are now split into
-  a reef absence and two natural-wonder one-tile offsets, with local intent,
-  application, footprint evidence, runtime-bound `canHaveFeature` probes,
-  footprint-direction alternatives, and planned-wonder readback context now
-  attached. Supported-catalog context now shows `5` unspecified multi-tile
-  entries where local projection fixes direction `-1` to direction `0`, with
-  exact-run readback for Kilimanjaro and Zhangjiajie only. The direction
-  context points at a real natural-wonder footprint orientation semantics gap
-  in the current readback set. The fresh `mq2spmz0` exact run now carries live
+  those subclasses to a concrete source owner. Older source-recorded feature
+  rows were split into a reef absence and two natural-wonder one-tile offsets,
+  with local intent, application, footprint evidence, runtime-bound
+  `canHaveFeature` probes, footprint-direction alternatives, and planned-wonder
+  readback context attached. Supported-catalog context showed `5` unspecified
+  multi-tile entries where local projection fixed direction `-1` to direction
+  `0`, with exact-run readback for Kilimanjaro and Zhangjiajie only. That
+  direction context pointed at a natural-wonder footprint orientation semantics
+  gap in the older readback set. The fresh `mq2spmz0` exact run now carries live
   natural-wonder placement telemetry and proves Civ placed `5/7` planned
   natural wonders while rejecting `2`, whereas local source diagnostics still
   predict `7/7/0`. This removes the old missing-telemetry blocker. Current code


### PR DESCRIPTION
Records source-authority synthesis results across the delta-classification ledger, tasks, and phase record after the latest diagnostic run.

The synthesis narrows the next repair proof queue to three ordered candidates without closing final-surface parity or authorizing product acceptance:

1. **Resource local-overacceptance / scarce-floor materialization** — 62 local-overaccepted/live-empty rows are the strongest repo-owned candidate bucket, with 56 coming from scarce-floor target 7 (39 cut-excluded, 17 cut-included rejected, 6 non-scarce-floor). Live-only resource additions (114 rows) and both-feasible substitutions (51 rows) remain materialization/projection questions and do not authorize tuning.

2. **Local-only ecology-feature materialization** — 78 local-only ecology features are Civ-infeasible and 30 are Civ-feasible but live-omitted, making these the strongest local materialization/feature-apply candidate buckets. The 166 live-only Civ-infeasible feature rows and 107 unclassified swaps do not authorize local tuning.

3. **Terrain projection/readback ownership** — All 139 terrain rows remain source-authority unresolved, dominated by coast/flat/hill/navigable-river edge swaps. This is a projection/readback-owner question, not a tuning target.

Any accepted resource repair must preserve the current proof-class separation: exact runtime distribution breadth (34 placed resource types, min/max placed count per type 7/8) is a product-health guard. No tuning, static-policy repair, scarce-floor repair, or assignment-order repair is authorized until a source owner is proven for the relevant subclass.