### PR TITLE
feat(swooper-maps): expose resource placement coordinate proof comparison in final-surface parity artifacts

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -83,6 +83,21 @@ export type ParityResidualClassification = Readonly<{
   evidence: string;
 }>;
 
+type ResourcePlacementCoordinateProofComparison = Readonly<{
+  status: "match" | "mismatch" | "missing-exact-log";
+  local: Readonly<{
+    placed?: Readonly<{ count?: number; hash32?: string }>;
+    rejected?: Readonly<{ count?: number; hash32?: string }>;
+    mismatch?: Readonly<{ count?: number; hash32?: string }>;
+  }>;
+  exact?: Readonly<{
+    placed?: Readonly<{ count?: number; hash32?: string }>;
+    rejected?: Readonly<{ count?: number; hash32?: string }>;
+    mismatch?: Readonly<{ count?: number; hash32?: string }>;
+  }>;
+  mismatchedLinks: ReadonlyArray<string>;
+}>;
+
 export type FinalSurfaceParityProof = Readonly<{
   status: "complete" | "unresolved";
   createdAt: string;
@@ -100,6 +115,7 @@ export type FinalSurfaceParityProof = Readonly<{
   local: FinalSurfaceSnapshot;
   live: FinalSurfaceSnapshot;
   diffs: ReadonlyArray<SurfaceDiffSummary>;
+  resourcePlacementCoordinateProof?: ResourcePlacementCoordinateProofComparison;
   residuals: ReadonlyArray<ParityResidualClassification>;
   unresolvedLinks: ReadonlyArray<string>;
 }>;
@@ -608,6 +624,8 @@ export function buildFinalSurfaceParityProof(args: {
   const diffs = diffFinalSurfaceSnapshots(args.local, args.live);
   const unresolvedLinks: string[] = [];
   const exact = args.exactAuthorship;
+  const resourcePlacementCoordinateProof =
+    exact === undefined ? undefined : buildResourcePlacementCoordinateProofComparison(exact, args.local);
 
   unresolvedLinks.push(...validateExactAuthorshipProofPacket(exact).unresolvedLinks);
   addSurfaceShapeLinks(unresolvedLinks, args.local, "local", exact?.runtime?.width, exact?.runtime?.height);
@@ -685,7 +703,9 @@ export function buildFinalSurfaceParityProof(args: {
     ) {
       unresolvedLinks.push("exact-authorship-proof.materialization-envelope-hash.local-envelope-hash");
     }
-    addResourcePlacementCoordinateProofLinks(unresolvedLinks, exact, args.local);
+    if (resourcePlacementCoordinateProof) {
+      unresolvedLinks.push(...resourcePlacementCoordinateProof.mismatchedLinks);
+    }
   }
 
   for (const diff of diffs) {
@@ -719,6 +739,7 @@ export function buildFinalSurfaceParityProof(args: {
     local: args.local,
     live: args.live,
     diffs,
+    ...(resourcePlacementCoordinateProof === undefined ? {} : { resourcePlacementCoordinateProof }),
     residuals,
     unresolvedLinks: [...new Set(unresolvedLinks)].sort((a, b) => a.localeCompare(b)),
   };
@@ -893,50 +914,60 @@ function addFullGridEvidenceLinks(unresolvedLinks: string[], live: FinalSurfaceS
   if (identityCheck?.stable !== true) unresolvedLinks.push("live.full-grid.identity-check");
 }
 
-function addResourcePlacementCoordinateProofLinks(
-  unresolvedLinks: string[],
+function buildResourcePlacementCoordinateProofComparison(
   exact: ExactAuthorshipProofLike,
   local: FinalSurfaceSnapshot
-): void {
+): ResourcePlacementCoordinateProofComparison | undefined {
   const localCoordinateProof = localResourcePlacementCoordinateProof(local);
-  if (!localCoordinateProof) return;
+  if (!localCoordinateProof) return undefined;
   const logCoordinateProof = exact.log?.resourcePlacement?.coordinateProof;
   if (!logCoordinateProof) {
-    unresolvedLinks.push("resource-placement-coordinate-proof.log");
-    return;
+    return {
+      status: "missing-exact-log",
+      local: localCoordinateProof,
+      mismatchedLinks: ["resource-placement-coordinate-proof.log"],
+    };
   }
-  compareCoordinateDigest(
-    unresolvedLinks,
-    localCoordinateProof.placed,
-    logCoordinateProof.placed,
-    "resource-placement-coordinate-proof.placed"
-  );
-  compareCoordinateDigest(
-    unresolvedLinks,
-    localCoordinateProof.rejected,
-    logCoordinateProof.rejected,
-    "resource-placement-coordinate-proof.rejected"
-  );
-  compareCoordinateDigest(
-    unresolvedLinks,
-    localCoordinateProof.mismatch,
-    logCoordinateProof.mismatch,
-    "resource-placement-coordinate-proof.mismatch"
-  );
+  const exactCoordinateProof = {
+    placed: coordinateDigest(logCoordinateProof.placed),
+    rejected: coordinateDigest(logCoordinateProof.rejected),
+    mismatch: coordinateDigest(logCoordinateProof.mismatch),
+  };
+  const mismatchedLinks = [
+    coordinateDigestMismatchLink(
+      localCoordinateProof.placed,
+      exactCoordinateProof.placed,
+      "resource-placement-coordinate-proof.placed"
+    ),
+    coordinateDigestMismatchLink(
+      localCoordinateProof.rejected,
+      exactCoordinateProof.rejected,
+      "resource-placement-coordinate-proof.rejected"
+    ),
+    coordinateDigestMismatchLink(
+      localCoordinateProof.mismatch,
+      exactCoordinateProof.mismatch,
+      "resource-placement-coordinate-proof.mismatch"
+    ),
+  ].filter((link): link is string => link !== undefined);
+  return {
+    status: mismatchedLinks.length === 0 ? "match" : "mismatch",
+    local: localCoordinateProof,
+    exact: exactCoordinateProof,
+    mismatchedLinks,
+  };
 }
 
-function compareCoordinateDigest(
-  unresolvedLinks: string[],
+function coordinateDigestMismatchLink(
   local: { count?: number; hash32?: string } | undefined,
   log: { count?: number; hash32?: string } | undefined,
   link: string
-): void {
-  if (!local) return;
+): string | undefined {
+  if (!local) return undefined;
   if (!log) {
-    if ((local.count ?? 0) > 0) unresolvedLinks.push(link);
-    return;
+    return (local.count ?? 0) > 0 ? link : undefined;
   }
-  if (local.count !== log.count || local.hash32 !== log.hash32) unresolvedLinks.push(link);
+  return local.count !== log.count || local.hash32 !== log.hash32 ? link : undefined;
 }
 
 function localResourcePlacementCoordinateProof(local: FinalSurfaceSnapshot):

--- a/mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
@@ -140,6 +140,18 @@ describe("final-surface parity proof", () => {
     });
 
     expect(proof.status).toBe("complete");
+    expect(proof.resourcePlacementCoordinateProof).toMatchObject({
+      status: "match",
+      mismatchedLinks: [],
+      local: {
+        placed: { count: 2, hash32: "aaaaaaaa" },
+        rejected: { count: 0, hash32: "811c9dc5" },
+      },
+      exact: {
+        placed: { count: 2, hash32: "aaaaaaaa" },
+        rejected: { count: 0, hash32: "811c9dc5" },
+      },
+    });
     expect(proof.unresolvedLinks).toEqual([]);
     expect(proof.diffs.every((diff) => diff.status === "match")).toBe(true);
   });
@@ -160,6 +172,10 @@ describe("final-surface parity proof", () => {
     });
 
     expect(proof.status).toBe("unresolved");
+    expect(proof.resourcePlacementCoordinateProof).toMatchObject({
+      status: "missing-exact-log",
+      mismatchedLinks: ["resource-placement-coordinate-proof.log"],
+    });
     expect(proof.unresolvedLinks).toContain("resource-placement-coordinate-proof.log");
   });
 
@@ -185,6 +201,12 @@ describe("final-surface parity proof", () => {
     });
 
     expect(proof.status).toBe("unresolved");
+    expect(proof.resourcePlacementCoordinateProof).toMatchObject({
+      status: "mismatch",
+      mismatchedLinks: ["resource-placement-coordinate-proof.placed"],
+      local: { placed: { count: 2, hash32: "aaaaaaaa" } },
+      exact: { placed: { count: 2, hash32: "bbbbbbbb" } },
+    });
     expect(proof.unresolvedLinks).toContain("resource-placement-coordinate-proof.placed");
   });
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -263,6 +263,13 @@
     separation: exact runtime distribution breadth (`34` placed resource types,
     min/max placed count by type `7/8`) is a product-health guard, while
     unresolved coordinate parity is still not product acceptance.
+- [x] 2.44 Expose local-vs-exact resource coordinate proof comparison in
+  final-surface parity artifacts.
+  - This is proof instrumentation only. It makes the existing
+    `resource-placement-coordinate-proof.*` gate self-describing by preserving
+    local and exact coordinate digests plus mismatched links in the parity
+    artifact. It does not change final-surface parity status, resource tuning,
+    scarce-floor assignment, or product acceptance.
 
 ## 3. Verification
 
@@ -307,3 +314,5 @@
   regressions.
 - [x] 3.14 Preserve source-recorded exact-authored final-surface parity after
   post-write footprint telemetry.
+- [x] 3.15 Run focused final-surface parity proof regression for resource
+  coordinate proof comparison.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -1050,6 +1050,14 @@
   projection swaps. Live-only resource additions, both-feasible resource
   substitutions, live-feature Civ-infeasible rows, and unclassified feature
   swaps do not authorize tuning or direct repair yet.
+  Follow-up implementation on
+  `codex/swooper-current-source-authority-queue-drain` exposes that first
+  resource proof boundary directly in final-surface parity artifacts:
+  `resourcePlacementCoordinateProof` now summarizes local coordinate proof,
+  exact runtime log coordinate proof, and mismatched
+  `resource-placement-coordinate-proof.*` links. This is proof instrumentation
+  only. It does not alter parity status, resource assignment, scarce-floor
+  behavior, runtime materialization, or product acceptance.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the current unresolved links from
   `studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json` by


### PR DESCRIPTION
The `resourcePlacementCoordinateProof` field is now included in `FinalSurfaceParityProof`, exposing the local coordinate proof, exact runtime log coordinate proof, and any mismatched `resource-placement-coordinate-proof.*` links directly in the parity artifact.

Previously, `addResourcePlacementCoordinateProofLinks` mutated an `unresolvedLinks` array as a side effect with no structured output. This has been replaced by `buildResourcePlacementCoordinateProofComparison`, which returns a typed `ResourcePlacementCoordinateProofComparison` value carrying a `status` (`match`, `mismatch`, or `missing-exact-log`), the local and exact coordinate digests, and the list of mismatched links. The mismatched links are then pushed into `unresolvedLinks` from the call site, preserving existing parity gate behavior exactly.

This is proof instrumentation only. It does not change parity status determination, resource assignment, scarce-floor behavior, runtime materialization, or product acceptance. Regression tests covering the match, missing-exact-log, and mismatch cases have been added.