### PR TITLE
docs(earthlike-live-feature-resource-legality-repair): record refreshed final-surface parity artifact with explicit resource coordinate split and verifier rerun details

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -270,6 +270,13 @@
     local and exact coordinate digests plus mismatched links in the parity
     artifact. It does not change final-surface parity status, resource tuning,
     scarce-floor assignment, or product acceptance.
+  - Refreshed artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity-with-resource-coordinate-summary.json`
+    (`sha256:44dee661491ee3d013a9326745fb30825c6155cdbb45af633f57ebb87fda23df`,
+    `proofHash:ce8a5a568bb91678ceb9f108b525d557cbd6b9820f10ebaad0639800cce6d091`)
+    preserves the current mismatch: local placed `251`/`98393a08`, exact
+    placed `250`/`9c5eaad8`; local rejected `0`/`811c9dc5`, exact rejected
+    `1`/`af57eb7b`.
 
 ## 3. Verification
 
@@ -316,3 +323,7 @@
   post-write footprint telemetry.
 - [x] 3.15 Run focused final-surface parity proof regression for resource
   coordinate proof comparison.
+  - Runtime-bound verifier rerun used
+    `current-drain-after-log-rewrite-reader-status.json` as exact-authorship
+    input and wrote the refreshed artifact above. Exit code `2` is expected
+    because parity remains `unresolved`.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -1058,6 +1058,20 @@
   `resource-placement-coordinate-proof.*` links. This is proof instrumentation
   only. It does not alter parity status, resource assignment, scarce-floor
   behavior, runtime materialization, or product acceptance.
+  Runtime-bound verifier rerun on committed head
+  `codex/swooper-resource-coordinate-proof-summary-drain` used exact-authorship
+  input
+  `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-log-rewrite-reader-status.json`
+  and wrote
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity-with-resource-coordinate-summary.json`
+  (`sha256:44dee661491ee3d013a9326745fb30825c6155cdbb45af633f57ebb87fda23df`,
+  `proofHash:ce8a5a568bb91678ceb9f108b525d557cbd6b9820f10ebaad0639800cce6d091`,
+  created `2026-06-07T12:25:56.936Z`). The verifier exited `2` as expected
+  for unresolved parity. The refreshed artifact preserves the same surface
+  mismatch counts (`139` terrain, `874` biome, `381` feature, `308` resource)
+  and makes the resource coordinate split explicit: local placed
+  `251`/`98393a08` versus exact placed `250`/`9c5eaad8`; local rejected
+  `0`/`811c9dc5` versus exact rejected `1`/`af57eb7b`.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the current unresolved links from
   `studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json` by


### PR DESCRIPTION
A runtime-bound verifier rerun on the committed head produced a refreshed final-surface parity artifact (`studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity-with-resource-coordinate-summary.json`, `sha256:44dee661491ee3d013a9326745fb30825c6155cdbb45af633f57ebb87fda23df`, `proofHash:ce8a5a568bb91678ceb9f108b525d557cbd6b9820f10ebaad0639800cce6d091`) using `current-drain-after-log-rewrite-reader-status.json` as exact-authorship input. The verifier exited with code `2` as expected, since parity remains unresolved.

The refreshed artifact preserves the existing surface mismatch counts (139 terrain, 874 biome, 381 feature, 308 resource) and makes the resource coordinate split explicit:

- Local placed: `251` / `98393a08` vs. exact placed: `250` / `9c5eaad8`
- Local rejected: `0` / `811c9dc5` vs. exact rejected: `1` / `af57eb7b`

This is proof instrumentation only and does not affect final-surface parity status, resource tuning, scarce-floor assignment, or product acceptance.