### PR TITLE
feat(run-in-game): parse and bind FEATURE_APPLY_V1 telemetry into exact-authorship proof packets

### DIFF
--- a/apps/mapgen-studio/src/features/runInGame/status.ts
+++ b/apps/mapgen-studio/src/features/runInGame/status.ts
@@ -145,6 +145,19 @@ export type RunInGameExactAuthorshipProof = Readonly<{
     dimensions: Readonly<{ width: number; height: number }>;
     proofPayload: unknown;
     completionPayload: unknown;
+    featureApply?: Readonly<{
+      marker: "FEATURE_APPLY_V1";
+      payload: unknown;
+      stats?: Readonly<{
+        attempted: number;
+        applied: number;
+        rejected: number;
+        rejectedCanHaveFeature: number;
+        attemptedByFeature?: Readonly<Record<string, number>>;
+        appliedByFeature?: Readonly<Record<string, number>>;
+        rejectedCanHaveFeatureByFeature?: Readonly<Record<string, number>>;
+      }>;
+    }>;
     resourcePlacement?: Readonly<{
       marker: "RESOURCE_PLACEMENT_V1";
       payload: unknown;

--- a/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
+++ b/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
@@ -246,6 +246,11 @@ export function parseSwooperMapgenLogProof(args: {
     proofLine.index,
     completionLine.index
   );
+  const featureApply = parseFeatureApplyTelemetryBetween(
+    lines,
+    proofLine.index,
+    completionLine.index
+  );
   return {
     ...(args.logPath ? { logPath: args.logPath } : {}),
     ...(args.observedAt ? { observedAt: args.observedAt } : {}),
@@ -257,6 +262,7 @@ export function parseSwooperMapgenLogProof(args: {
     dimensions: proofDimensions,
     proofPayload,
     completionPayload,
+    ...(featureApply ? { featureApply } : {}),
     ...(resourcePlacement ? { resourcePlacement } : {}),
     ...(naturalWonderPlacement ? { naturalWonderPlacement } : {}),
     matched: ["[mapgen-proof]", args.requestId, args.configHash, args.envelopeHash, "[mapgen-complete]"],
@@ -398,6 +404,25 @@ function parseResourcePlacementTelemetryBetween(
   return undefined;
 }
 
+function parseFeatureApplyTelemetryBetween(
+  lines: readonly string[],
+  proofIndex: number,
+  completionIndex: number
+): NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["featureApply"]> | undefined {
+  for (let index = completionIndex - 1; index > proofIndex; index -= 1) {
+    const line = lines[index] ?? "";
+    if (!line.includes("FEATURE_APPLY_V1")) continue;
+    const payload = parsePayloadAfterMarker(line, "FEATURE_APPLY_V1");
+    if (!payload) continue;
+    return {
+      marker: "FEATURE_APPLY_V1",
+      payload,
+      ...(featureApplyStats(payload) ?? {}),
+    };
+  }
+  return undefined;
+}
+
 function parseNaturalWonderPlacementTelemetryBetween(
   lines: readonly string[],
   proofIndex: number,
@@ -416,6 +441,38 @@ function parseNaturalWonderPlacementTelemetryBetween(
     };
   }
   return undefined;
+}
+
+function featureApplyStats(
+  payload: Record<string, unknown>
+):
+  | {
+      stats: NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["featureApply"]>["stats"];
+    }
+  | undefined {
+  const attempted = numberValue(payload.attempted);
+  const applied = numberValue(payload.applied);
+  const rejected = numberValue(payload.rejected);
+  const rejectedCanHaveFeature = numberValue(payload.rejectedCanHaveFeature);
+  if (
+    attempted === undefined ||
+    applied === undefined ||
+    rejected === undefined ||
+    rejectedCanHaveFeature === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    stats: {
+      attempted,
+      applied,
+      rejected,
+      rejectedCanHaveFeature,
+      ...countRecordField(payload, "attemptedByFeature"),
+      ...countRecordField(payload, "appliedByFeature"),
+      ...countRecordField(payload, "rejectedCanHaveFeatureByFeature"),
+    },
+  };
 }
 
 function naturalWonderPlacementStats(
@@ -526,6 +583,19 @@ function resourcePlacementCoordinateProof(
         : { mismatch: { count: mismatchCount, hash32: mismatchHash32 } }),
     },
   };
+}
+
+function countRecordField(
+  payload: Record<string, unknown>,
+  field: "attemptedByFeature" | "appliedByFeature" | "rejectedCanHaveFeatureByFeature"
+): Partial<Record<typeof field, Readonly<Record<string, number>>>> {
+  const source = isRecord(payload[field]) ? payload[field] : undefined;
+  if (!source) return {};
+  const entries = Object.entries(source)
+    .map(([key, value]) => [key, numberValue(value)] as const)
+    .filter((entry): entry is readonly [string, number] => entry[1] !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return entries.length === 0 ? {} : { [field]: Object.fromEntries(entries) };
 }
 
 function parsePayloadAfterMarker(line: string, marker: string): Record<string, unknown> | null {

--- a/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
+++ b/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
@@ -91,6 +91,15 @@ describe("Run in Game exact authorship proof identity", () => {
       text: [
         `[mapgen-proof] ${JSON.stringify({ requestId: "old", configHash, envelopeHash, seed: 42, dimensions: { width: 1, height: 1 } })}`,
         `[mapgen-proof] ${JSON.stringify({ requestId, configHash, envelopeHash, seed: 42, mapSize: "MAPSIZE_STANDARD", dimensions: { width: 84, height: 54 } })}`,
+        `[SWOOPER_MOD] FEATURE_APPLY_V1 ${JSON.stringify({
+          attempted: 1434,
+          applied: 1430,
+          rejected: 4,
+          rejectedCanHaveFeature: 4,
+          attemptedByFeature: { FEATURE_TAIGA: 305, FEATURE_REEF: 11 },
+          appliedByFeature: { FEATURE_TAIGA: 301, FEATURE_REEF: 11 },
+          rejectedCanHaveFeatureByFeature: { FEATURE_TAIGA: 4 },
+        })}`,
         `[SWOOPER_MOD] RESOURCE_PLACEMENT_V1 ${JSON.stringify({
           version: 1,
           plannedCount: 4,
@@ -141,6 +150,18 @@ describe("Run in Game exact authorship proof identity", () => {
       dimensions: { width: 84, height: 54 },
       matched: ["[mapgen-proof]", requestId, configHash, envelopeHash, "[mapgen-complete]"],
     });
+    expect(logProof?.featureApply).toMatchObject({
+      marker: "FEATURE_APPLY_V1",
+      stats: {
+        attempted: 1434,
+        applied: 1430,
+        rejected: 4,
+        rejectedCanHaveFeature: 4,
+        attemptedByFeature: { FEATURE_REEF: 11, FEATURE_TAIGA: 305 },
+        appliedByFeature: { FEATURE_REEF: 11, FEATURE_TAIGA: 301 },
+        rejectedCanHaveFeatureByFeature: { FEATURE_TAIGA: 4 },
+      },
+    });
     expect(logProof?.resourcePlacement).toMatchObject({
       marker: "RESOURCE_PLACEMENT_V1",
       coordinateProof: {
@@ -190,6 +211,12 @@ describe("Run in Game exact authorship proof identity", () => {
   it("ignores placement telemetry outside the matching proof section", () => {
     const logProof = parseSwooperMapgenLogProof({
       text: [
+        `[SWOOPER_MOD] FEATURE_APPLY_V1 ${JSON.stringify({
+          attempted: 1,
+          applied: 1,
+          rejected: 0,
+          rejectedCanHaveFeature: 0,
+        })}`,
         `[SWOOPER_MOD] RESOURCE_PLACEMENT_V1 ${JSON.stringify({
           version: 1,
           coordinateProof: { version: 1, placedCount: 4, placedHash32: "aaaaaaaa" },
@@ -213,6 +240,7 @@ describe("Run in Game exact authorship proof identity", () => {
       seed: 42,
     });
 
+    expect(logProof?.featureApply).toBeUndefined();
     expect(logProof?.resourcePlacement).toBeUndefined();
     expect(logProof?.naturalWonderPlacement).toBeUndefined();
   });

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -277,6 +277,14 @@
     preserves the current mismatch: local placed `251`/`98393a08`, exact
     placed `250`/`9c5eaad8`; local rejected `0`/`811c9dc5`, exact rejected
     `1`/`af57eb7b`.
+- [x] 2.45 Bind feature-apply runtime telemetry into future exact-authorship
+  proof packets.
+  - Studio exact-authorship log parsing now preserves bounded
+    `FEATURE_APPLY_V1` telemetry between the matched `[mapgen-proof]` and
+    `[mapgen-complete]` markers. This is proof instrumentation for future
+    feature-materialization classification; it does not retroactively change
+    the `studio-run-in-game-mq3pfgbe-1doj` proof, map behavior, ecology tuning,
+    or product acceptance.
 
 ## 3. Verification
 
@@ -327,3 +335,5 @@
     `current-drain-after-log-rewrite-reader-status.json` as exact-authorship
     input and wrote the refreshed artifact above. Exit code `2` is expected
     because parity remains `unresolved`.
+- [x] 3.16 Run focused Studio proof-identity regression for feature-apply
+  telemetry parsing.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -1072,6 +1072,16 @@
   and makes the resource coordinate split explicit: local placed
   `251`/`98393a08` versus exact placed `250`/`9c5eaad8`; local rejected
   `0`/`811c9dc5` versus exact rejected `1`/`af57eb7b`.
+  Follow-up implementation on
+  `codex/swooper-product-closure-audit-record-drain` adds bounded
+  `FEATURE_APPLY_V1` parsing to Studio exact-authorship proof packets for future
+  runs. The parser only accepts telemetry between the matched `[mapgen-proof]`
+  and `[mapgen-complete]` markers and preserves attempted/applied/rejected
+  counts plus per-feature count maps when present. This does not change the
+  current `mq3pfgbe` proof because the saved status artifact does not include
+  raw log text to reparse; it prepares the next exact run to classify
+  local-only ecology-feature materialization without relying on local-only
+  diagnostics.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the current unresolved links from
   `studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json` by


### PR DESCRIPTION
Adds `FEATURE_APPLY_V1` telemetry parsing to the Studio exact-authorship proof pipeline. When a `FEATURE_APPLY_V1` log line appears between the matched `[mapgen-proof]` and `[mapgen-complete]` markers, it is now captured and included in the proof packet under `featureApply`.

The parsed entry includes the raw payload and, when the required fields are present, a structured `stats` block with `attempted`, `applied`, `rejected`, and `rejectedCanHaveFeature` counts. Per-feature breakdowns (`attemptedByFeature`, `appliedByFeature`, `rejectedCanHaveFeatureByFeature`) are included when available, with keys sorted alphabetically. Telemetry outside the bounded proof section is ignored.

This prepares future exact runs to carry feature-materialization counts alongside resource and natural wonder placement data, enabling classification of local-only ecology-feature materialization without relying on local-only diagnostics. It does not affect the current `mq3pfgbe` proof, map behavior, ecology tuning, or product acceptance.

Regression coverage is added to the proof-identity test suite, verifying both correct parsing of a full `FEATURE_APPLY_V1` payload and correct rejection of telemetry outside the proof window.