### PR TITLE
docs(earthlike-live-feature-resource-legality-repair): record exact FEATURE_APPLY_V1 telemetry proof and update parity/phase ledgers

### DIFF
--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -285,6 +285,25 @@
     feature-materialization classification; it does not retroactively change
     the `studio-run-in-game-mq3pfgbe-1doj` proof, map behavior, ecology tuning,
     or product acceptance.
+- [x] 2.46 Preserve current exact-authored feature-apply telemetry proof.
+  - Current branch `codex/swooper-feature-apply-proof-telemetry-drain`
+    (`a992eb243c407f33676de208ee11a8358ea3c3c1`) reran the same Swooper
+    Earthlike source snapshot through a current-worktree Studio server on
+    `127.0.0.1:5175`. Exact request `studio-run-in-game-mq3ryaop-1p7l`
+    completed with no exact-authorship unresolved links.
+  - Exact `FEATURE_APPLY_V1` telemetry reports `1493` attempted features,
+    `1491` applied features, and `2` `canHaveFeature` rejections
+    (`FEATURE_COLD_REEF:1`, `FEATURE_TAIGA:1`). This narrows feature
+    source-authority work away from broad feature-apply legality and toward
+    remaining materialized/readback surface ownership for the `381` feature
+    mismatches.
+  - Status artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-feature-apply-parser-status.json`
+    (`sha256:23e53771a6ce7d8eabf102ce24997f67c87c2c2f1927fc08c05256299daa37fe`)
+    and post artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-feature-apply-parser-post.json`
+    (`sha256:7433af10bbb3197bb1b6608faadff3239179eb86998712702f5e70310ebd77e8`)
+    are exact-run proof inputs. Product acceptance is still not closed.
 
 ## 3. Verification
 
@@ -337,3 +356,17 @@
     because parity remains `unresolved`.
 - [x] 3.16 Run focused Studio proof-identity regression for feature-apply
   telemetry parsing.
+- [x] 3.17 Re-run current exact-authored final-surface parity after
+  feature-apply proof parsing.
+  - Verifier input
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-feature-apply-parser-status.json`
+    wrote
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ryaop-1p7l-current-final-surface-parity-with-feature-apply.json`
+    (`sha256:7d3225aec82c5596a6dd8e58ca1a44aebbdc4b79c5fa6117ca43ad89568dc34b`,
+    `proofHash:89d48831dd981e5144c89e14842b1052d989d3748b011fc7590070075236ba02`).
+  - The verifier exited `2` as expected for unresolved parity. It preserves
+    unchanged mismatch counts: terrain `139/6996`, biome `874/6996`, feature
+    `381/6996`, resource `308/6996`, plus resource coordinate proof mismatch
+    links. The verifier log is
+    `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-current-mq3ryaop.log`
+    (`sha256:95775b27dfaacad92ad3899a2dc69a9edbe43ba77c74075d7ea888c10ee55e7c`).

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1515,8 +1515,12 @@ mountain-quality work.
   source-authority disposition explaining whether the current adapter readback
   oracle is wrong for Civ materialization or whether Civ's footprint behavior
   should be classified as residual.
-- Add or bind exact live feature-apply telemetry/readback before repairing the
-  cold-reef local-only row.
+- Current exact live feature-apply telemetry is now bound by request
+  `studio-run-in-game-mq3ryaop-1p7l`: `1493` attempted, `1491` applied, and `2`
+  `canHaveFeature` rejections (`FEATURE_COLD_REEF:1`, `FEATURE_TAIGA:1`). Use
+  this as the source-authority input for the cold-reef/local-only feature row
+  and remaining feature materialization/readback classification; do not treat it
+  as final-surface parity or product acceptance.
 - Continue resource-row classification using source-recorded coordinate proof
   and runtime-bound row evidence where applicable before changing resource
   tuning, scarcity floors, assignment ordering, or static policy; obtain a

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -1082,12 +1082,33 @@
   raw log text to reparse; it prepares the next exact run to classify
   local-only ecology-feature materialization without relying on local-only
   diagnostics.
+  Current exact run `studio-run-in-game-mq3ryaop-1p7l` on
+  `codex/swooper-feature-apply-proof-telemetry-drain`
+  (`a992eb243c407f33676de208ee11a8358ea3c3c1`) now consumes that parser from a
+  current-worktree Studio server. Exact-authorship completed with no unresolved
+  links. The status artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-feature-apply-parser-status.json`
+  has `sha256:23e53771a6ce7d8eabf102ce24997f67c87c2c2f1927fc08c05256299daa37fe`
+  and records `FEATURE_APPLY_V1` stats: `1493` attempted, `1491` applied, `2`
+  `canHaveFeature` rejections (`FEATURE_COLD_REEF:1`, `FEATURE_TAIGA:1`).
+  Resource telemetry remains stable at `251` planned, `250` placed, `1`
+  rejected, coordinate hashes `9c5eaad8`/`af57eb7b`. The current final-surface
+  verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ryaop-1p7l-current-final-surface-parity-with-feature-apply.json`
+  has `sha256:7d3225aec82c5596a6dd8e58ca1a44aebbdc4b79c5fa6117ca43ad89568dc34b`
+  and
+  `proofHash:89d48831dd981e5144c89e14842b1052d989d3748b011fc7590070075236ba02`.
+  It remains `unresolved` with the same terrain `139`, biome `874`, feature
+  `381`, resource `308`, and resource coordinate proof placed/rejected links.
+  This is proof narrowing only: exact feature-apply legality is no longer a
+  broad blocker, but final-surface parity and product acceptance remain open.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the current unresolved links from
-  `studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity.json` by
+  `studio-run-in-game-mq3ryaop-1p7l-current-final-surface-parity-with-feature-apply.json` by
   proving or rejecting the narrowed repair-owner candidates in order:
-  resource local-overacceptance/scarce-floor materialization, local-only
-  ecology-feature materialization, then terrain projection/readback. Do this
+  resource local-overacceptance/scarce-floor materialization, exact
+  feature-materialization/readback ownership for the two rejected features and
+  remaining `381` feature mismatches, then terrain projection/readback. Do this
   before any final-surface parity or product acceptance claim. The older
   source-recorded context remains useful: for the prior `9` local-assigned
   live-empty rows, assignment trace ruled out relaxed spacing and rebalance,
@@ -1149,10 +1170,11 @@
   readback after the write call, but it still does not classify whether the
   repo should change its local footprint projection/readback oracle or accept
   a Civ engine footprint/materialization semantic as residual.
-  The cold-reef local-only row also remains
-  evidence-bound pending exact live feature-apply telemetry/readback. Final-
-  surface parity remains open on terrain, feature, resource, and any future
-  owner-classified residual links.
+  The cold-reef local-only row is no longer blocked on missing exact
+  feature-apply telemetry: the current exact run proves one cold-reef
+  `canHaveFeature` rejection, while the full feature surface still has `381`
+  mismatches. Final-surface parity remains open on terrain, feature, resource,
+  and any future owner-classified residual links.
   The single
   substitution row where both probed values are infeasible remains an individual
   evidence row with no repair authority until row-level context assigns source

--- a/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
@@ -2,17 +2,19 @@
 
 - [ ] 1.1 Verify exact-authorship, final-surface parity, product acceptance, and
   activated targeted repairs are closed or explicitly out of scope.
-  - Current audit snapshot on `codex/swooper-resource-coordinate-proof-rerun-record-drain`
-    (`c1c860abe4a9998d96d78b4bc009ce03e00ba25a`) verifies exact-authorship
+  - Current audit snapshot on `codex/swooper-feature-apply-proof-telemetry-drain`
+    (`a992eb243c407f33676de208ee11a8358ea3c3c1`) verifies exact-authorship
     and mapgen completion are complete for request
-    `studio-run-in-game-mq3pfgbe-1doj`, but final-surface parity is still
+    `studio-run-in-game-mq3ryaop-1p7l`, but final-surface parity is still
     unresolved. Refreshed parity artifact
-    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity-with-resource-coordinate-summary.json`
-    (`sha256:44dee661491ee3d013a9326745fb30825c6155cdbb45af633f57ebb87fda23df`,
-    `proofHash:ce8a5a568bb91678ceb9f108b525d557cbd6b9820f10ebaad0639800cce6d091`)
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ryaop-1p7l-current-final-surface-parity-with-feature-apply.json`
+    (`sha256:7d3225aec82c5596a6dd8e58ca1a44aebbdc4b79c5fa6117ca43ad89568dc34b`,
+    `proofHash:89d48831dd981e5144c89e14842b1052d989d3748b011fc7590070075236ba02`)
     remains `unresolved` with terrain `139`, biome `874`, feature `381`, and
     resource `308` mismatches plus resource coordinate proof placed/rejected
-    links. Product acceptance is therefore not closed.
+    links. It also records exact `FEATURE_APPLY_V1` telemetry (`1493`
+    attempted, `1491` applied, `2` rejected), narrowing but not closing feature
+    source-authority work. Product acceptance is therefore not closed.
 - [ ] 1.2 Audit accepted P1/P2 review findings across recovery changes.
   - Current audit pass found no active review-disposition ledger inside
     `earthlike-live-feature-resource-legality-repair` or
@@ -23,7 +25,7 @@
     finding remains open inside the closure claim.
 - [ ] 1.3 Audit repo, Graphite, PR, and remote predecessor state.
   - Current repo snapshot is clean on
-    `codex/swooper-resource-coordinate-proof-rerun-record-drain`; Graphite top
+    `codex/swooper-feature-apply-proof-telemetry-drain`; Graphite top
     branch is local and stacked above the Swooper recovery drain. PR/remote
     predecessor disposition remains blocked until proof categories close.
 
@@ -39,12 +41,12 @@
 
 - [ ] 3.1 Run `git status --short --branch`.
   - Current audit snapshot: clean on
-    `codex/swooper-resource-coordinate-proof-rerun-record-drain`.
+    `codex/swooper-feature-apply-proof-telemetry-drain`.
 - [ ] 3.2 Inspect Graphite branch/stack state.
   - Current audit snapshot: top branch
-    `codex/swooper-resource-coordinate-proof-rerun-record-drain` above
-    `codex/swooper-resource-coordinate-proof-summary-drain` and the current
-    source-authority/diagnostic proof-record branches.
+    `codex/swooper-feature-apply-proof-telemetry-drain` above
+    `codex/swooper-product-closure-audit-record-drain` and the current
+    feature/resource/source-authority proof-record branches.
 - [ ] 3.3 Run `git diff --check`.
 - [ ] 3.4 Run `bun run openspec -- validate swooper-recovery-stack-product-closure --strict`.
 - [ ] 3.5 Run `bun run openspec:validate`.

--- a/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
@@ -5,7 +5,7 @@
 - Project: Swooper recovery
 - Phase: product closure planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-coordinate-proof-rerun-record-drain`
+- Branch/Graphite stack: `codex/swooper-feature-apply-proof-telemetry-drain`
 - Started: 2026-06-06
 - Status: blocked until proof and activated repair changes close
 
@@ -34,15 +34,16 @@
 - Dirty files and owner: current audit snapshot was clean before this closure
   record update; this planning goal owns the current OpenSpec docs.
 - Current code evidence: exact-authorship and mapgen-completion proof are
-  complete for `studio-run-in-game-mq3pfgbe-1doj`; final-surface parity remains
-  unresolved. The latest parity artifact with resource coordinate proof summary
-  is
-  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3pfgbe-1doj-current-final-surface-parity-with-resource-coordinate-summary.json`
-  (`sha256:44dee661491ee3d013a9326745fb30825c6155cdbb45af633f57ebb87fda23df`,
-  `proofHash:ce8a5a568bb91678ceb9f108b525d557cbd6b9820f10ebaad0639800cce6d091`).
+  complete for `studio-run-in-game-mq3ryaop-1p7l`; final-surface parity remains
+  unresolved. The latest parity artifact with exact feature-apply telemetry is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ryaop-1p7l-current-final-surface-parity-with-feature-apply.json`
+  (`sha256:7d3225aec82c5596a6dd8e58ca1a44aebbdc4b79c5fa6117ca43ad89568dc34b`,
+  `proofHash:89d48831dd981e5144c89e14842b1052d989d3748b011fc7590070075236ba02`).
   It preserves unresolved terrain `139`, biome `874`, feature `381`, and
   resource `308` mismatch counts plus resource coordinate proof placed/rejected
-  links.
+  links. Exact `FEATURE_APPLY_V1` reports `1493` attempted, `1491` applied,
+  and `2` `canHaveFeature` rejections, which narrows but does not close feature
+  source-authority or product acceptance.
 - Generated outputs affected: none expected.
 - Tests/guards affected: validation and closure audits.
 
@@ -85,7 +86,7 @@
 ## Implementation
 
 - Completed tasks: planning record created; current proof/Graphite audit
-  snapshot recorded.
+  snapshot recorded, including the current exact feature-apply telemetry rerun.
 - Remaining tasks: final-surface parity, product acceptance, supervisor
   P1/P2 closure review, PR/remote predecessor disposition, and final Graphite
   submit/closure.
@@ -99,7 +100,7 @@
   the current exact-authorship proof.
 - Results: repo snapshot clean before this update; latest verifier artifact is
   unresolved with proof hash
-  `ce8a5a568bb91678ceb9f108b525d557cbd6b9820f10ebaad0639800cce6d091`;
+  `89d48831dd981e5144c89e14842b1052d989d3748b011fc7590070075236ba02`;
   broader review-ledger scan found historical P1/P2 entries but no active
   review ledger under the two current recovery closure changes.
 - Skipped gates and rationale: closure gates wait for proof closure.
@@ -116,7 +117,9 @@
 
 - Exact next step: continue the proof-led drain from
   `earthlike-live-feature-resource-legality-repair`, starting with the resource
-  coordinate/materialization boundary now summarized in the parity artifact.
+  coordinate/materialization boundary, then using the current exact
+  `FEATURE_APPLY_V1` telemetry to classify feature materialization/readback
+  ownership.
 - First files to inspect: recovery OpenSpec proof ledgers and Graphite branch
   state.
 - Stop condition: accepted P1/P2 findings remain open.


### PR DESCRIPTION
This PR records the exact live `FEATURE_APPLY_V1` telemetry proof from Studio run `studio-run-in-game-mq3ryaop-1p7l` on branch `codex/swooper-feature-apply-proof-telemetry-drain` (`a992eb243c407f33676de208ee11a8358ea3c3c1`) and advances the drain accordingly.

The run completed exact-authorship with no unresolved links and produced confirmed telemetry: `1493` attempted features, `1491` applied, and `2` `canHaveFeature` rejections (`FEATURE_COLD_REEF:1`, `FEATURE_TAIGA:1`). This proves that broad feature-apply legality is no longer a blocker and unblocks the cold-reef local-only row, which was previously held pending this telemetry. Remaining feature source-authority work is now narrowed to the `381` feature mismatches in the materialized/readback surface.

The updated final-surface parity artifact (`sha256:7d3225aec82c5596a6dd8e58ca1a44aebbdc4b79c5fa6117ca43ad89568dc34b`, `proofHash:89d48831dd981e5144c89e14842b1052d989d3748b011fc7590070075236ba02`) preserves unchanged mismatch counts — terrain `139`, biome `874`, feature `381`, resource `308` — and the verifier exited `2` as expected. Resource telemetry remains stable at `251` planned, `250` placed, `1` rejected.

All closure tracking, the delta-classification ledger, and the phase record are updated to reflect this new proof baseline. Final-surface parity and product acceptance remain open.