### PR TITLE
feat(swooper-resources): add bounded rejection examples to resource placement telemetry and parse into Studio exact-authorship stats

### DIFF
--- a/apps/mapgen-studio/src/features/runInGame/status.ts
+++ b/apps/mapgen-studio/src/features/runInGame/status.ts
@@ -161,6 +161,15 @@ export type RunInGameExactAuthorshipProof = Readonly<{
     resourcePlacement?: Readonly<{
       marker: "RESOURCE_PLACEMENT_V1";
       payload: unknown;
+      stats?: Readonly<{
+        version: number;
+        plannedCount: number;
+        placedCount: number;
+        rejectedCount: number;
+        mismatchCount: number;
+        rejectionExampleCount?: number;
+        rejectionExamples?: ReadonlyArray<string>;
+      }>;
       coordinateProof?: Readonly<{
         version: number;
         placed: Readonly<{ count: number; hash32: string }>;

--- a/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
+++ b/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
@@ -398,6 +398,7 @@ function parseResourcePlacementTelemetryBetween(
     return {
       marker: "RESOURCE_PLACEMENT_V1",
       payload,
+      ...(resourcePlacementStats(payload) ?? {}),
       ...(resourcePlacementCoordinateProof(payload) ?? {}),
     };
   }
@@ -518,6 +519,46 @@ function naturalWonderPlacementStats(
       skippedOutOfBoundsCount,
       rejectedCount,
       shortfallCount,
+      ...(rejectionExampleCount === undefined ? {} : { rejectionExampleCount }),
+      ...(rejectionExamples === undefined ? {} : { rejectionExamples }),
+    },
+  };
+}
+
+function resourcePlacementStats(
+  payload: Record<string, unknown>
+):
+  | {
+      stats: NonNullable<
+        NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["resourcePlacement"]>["stats"]
+      >;
+    }
+  | undefined {
+  const version = numberValue(payload.version);
+  const plannedCount = numberValue(payload.plannedCount);
+  const placedCount = numberValue(payload.placedCount);
+  const rejectedCount = numberValue(payload.rejectedCount);
+  const mismatchCount = numberValue(payload.mismatchCount);
+  const rejectionExamples = Array.isArray(payload.rejectionExamples)
+    ? payload.rejectionExamples.filter((entry): entry is string => typeof entry === "string").slice(0, 8)
+    : undefined;
+  if (
+    version === undefined ||
+    plannedCount === undefined ||
+    placedCount === undefined ||
+    rejectedCount === undefined ||
+    mismatchCount === undefined
+  ) {
+    return undefined;
+  }
+  const rejectionExampleCount = numberValue(payload.rejectionExampleCount);
+  return {
+    stats: {
+      version,
+      plannedCount,
+      placedCount,
+      rejectedCount,
+      mismatchCount,
       ...(rejectionExampleCount === undefined ? {} : { rejectionExampleCount }),
       ...(rejectionExamples === undefined ? {} : { rejectionExamples }),
     },

--- a/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
+++ b/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
@@ -103,13 +103,17 @@ describe("Run in Game exact authorship proof identity", () => {
         `[SWOOPER_MOD] RESOURCE_PLACEMENT_V1 ${JSON.stringify({
           version: 1,
           plannedCount: 4,
-          placedCount: 4,
-          rejectedCount: 0,
+          placedCount: 3,
+          rejectedCount: 1,
           mismatchCount: 0,
+          rejectionExampleCount: 1,
+          rejectionExamples: ["status=rejected resource=RESOURCE_WINE plot=67 x=12 y=3 reason=cannot-have-resource observed=-1"],
           coordinateProof: {
             version: 1,
-            placedCount: 4,
+            placedCount: 3,
             placedHash32: "3c3530cb",
+            rejectedCount: 1,
+            rejectedHash32: "aaaaaaaa",
           },
         })}`,
         `[SWOOPER_MOD] NATURAL_WONDER_PLACEMENT_V1 ${JSON.stringify({
@@ -164,9 +168,19 @@ describe("Run in Game exact authorship proof identity", () => {
     });
     expect(logProof?.resourcePlacement).toMatchObject({
       marker: "RESOURCE_PLACEMENT_V1",
+      stats: {
+        version: 1,
+        plannedCount: 4,
+        placedCount: 3,
+        rejectedCount: 1,
+        mismatchCount: 0,
+        rejectionExampleCount: 1,
+        rejectionExamples: ["status=rejected resource=RESOURCE_WINE plot=67 x=12 y=3 reason=cannot-have-resource observed=-1"],
+      },
       coordinateProof: {
         version: 1,
-        placed: { count: 4, hash32: "3c3530cb" },
+        placed: { count: 3, hash32: "3c3530cb" },
+        rejected: { count: 1, hash32: "aaaaaaaa" },
       },
     });
     expect(logProof?.naturalWonderPlacement).toMatchObject({

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/index.ts
@@ -24,7 +24,11 @@ export default createStep(PlaceResourcesStepContract, {
     const outcomes = runPlacementProductStep("placement.resources", emit, () =>
       placeResourcesWithTypedOutcomes({ adapter: context.adapter, width, height, resources })
     );
-    logResourcePlacementRuntimeTelemetry(outcomes.summary, outcomes.assignment);
+    logResourcePlacementRuntimeTelemetry(
+      outcomes.summary,
+      outcomes.assignment,
+      outcomes.outcomes
+    );
     deps.artifacts.resourcePlacementOutcomes.publish(context, outcomes);
   },
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
@@ -22,6 +22,7 @@ type ResourcePlacementOutcomes = Static<
 type ResourcePlacementReason = ResourcePlacementRejectionReason | ResourcePlacementMismatchReason;
 type ResourcePlacementSummary = ResourcePlacementOutcomes["summary"];
 type ResourceAssignmentSummary = ResourcePlacementOutcomes["assignment"];
+type ResourcePlacementRuntimeTelemetryOutcome = ResourcePlacementOutcomes["outcomes"][number];
 type RuntimeResourceCatalogEntry = {
   readonly index: number;
   readonly resourceType: string;
@@ -776,7 +777,8 @@ export function readRuntimeResourceCatalog(): readonly RuntimeResourceCatalogEnt
 export function buildResourcePlacementRuntimeTelemetry(
   summary: ResourcePlacementSummary,
   assignment?: ResourceAssignmentSummary,
-  runtimeCatalog: readonly RuntimeResourceCatalogEntry[] = readRuntimeResourceCatalog()
+  runtimeCatalog: readonly RuntimeResourceCatalogEntry[] = readRuntimeResourceCatalog(),
+  outcomes: readonly ResourcePlacementRuntimeTelemetryOutcome[] = []
 ): Record<string, unknown> {
   const runtimeByIndex = new Map(runtimeCatalog.map((row) => [row.index, row]));
   const plannedResourceTypes = summary.byResource.filter((row) => row.plannedCount > 0);
@@ -794,6 +796,7 @@ export function buildResourcePlacementRuntimeTelemetry(
   const plannedTypesCovered =
     plannedTypeSet.size === coveredTypeSet.size &&
     plannedResourceTypeValues.every((resourceType) => coveredTypeSet.has(resourceType));
+  const rejectionExamples = resourcePlacementRejectionExamples(outcomes, runtimeByIndex);
 
   return {
     version: 1,
@@ -826,6 +829,12 @@ export function buildResourcePlacementRuntimeTelemetry(
     ...(plannedTypesCovered ? {} : { plannedResourceTypes: plannedResourceTypeValues }),
     placedResourceTypes: placedResourceTypeValues,
     rejectedResourceTypes: rejectedResourceTypeValues,
+    ...(rejectionExamples.length === 0
+      ? {}
+      : {
+          rejectionExampleCount: rejectionExamples.length,
+          rejectionExamples,
+        }),
     unmappedPlacedResourceTypes: unmappedResourceTypes.map((row) => row.resourceType),
     ...(assignment
       ? {
@@ -847,15 +856,41 @@ export function buildResourcePlacementRuntimeTelemetry(
 
 export function logResourcePlacementRuntimeTelemetry(
   summary: ResourcePlacementSummary,
-  assignment: ResourceAssignmentSummary
+  assignment: ResourceAssignmentSummary,
+  outcomes: readonly ResourcePlacementRuntimeTelemetryOutcome[] = []
 ): void {
   const runtimeCatalog = readRuntimeResourceCatalog();
   if (runtimeCatalog.length === 0) return;
   console.log(
     `[SWOOPER_MOD] RESOURCE_PLACEMENT_V1 ${JSON.stringify(
-      buildResourcePlacementRuntimeTelemetry(summary, assignment, runtimeCatalog)
+      buildResourcePlacementRuntimeTelemetry(summary, assignment, runtimeCatalog, outcomes)
     )}`
   );
+}
+
+function resourcePlacementRejectionExamples(
+  outcomes: readonly ResourcePlacementRuntimeTelemetryOutcome[],
+  runtimeByIndex: ReadonlyMap<number, RuntimeResourceCatalogEntry>
+): string[] {
+  return outcomes
+    .filter((outcome) => outcome.status !== "placed")
+    .slice(0, 8)
+    .map((outcome) => {
+      const resource =
+        runtimeByIndex.get(outcome.resourceType)?.resourceType ?? String(outcome.resourceType);
+      const fields = [
+        `status=${outcome.status}`,
+        `resource=${resource}`,
+        `plot=${outcome.plotIndex}`,
+        `x=${outcome.x}`,
+        `y=${outcome.y}`,
+        `reason=${outcome.reason}`,
+      ];
+      if (outcome.observedResourceType !== undefined) {
+        fields.push(`observed=${outcome.observedResourceType}`);
+      }
+      return fields.join(" ");
+    });
 }
 
 function assertResourceOutcomeMatchesIntent(

--- a/mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts
+++ b/mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts
@@ -218,6 +218,17 @@ describe("resource placement diagnostics", () => {
           resourceClassType: "RESOURCECLASS_BONUS",
           name: "Rubies",
         },
+      ],
+      [
+        {
+          status: "rejected",
+          plotIndex: 67,
+          x: 12,
+          y: 3,
+          resourceType: 44,
+          reason: "cannot-have-resource",
+          observedResourceType: -1,
+        },
       ]
     );
 
@@ -241,6 +252,10 @@ describe("resource placement diagnostics", () => {
       },
       placedResourceTypes: [4, 44],
       rejectedResourceTypes: [44],
+      rejectionExampleCount: 1,
+      rejectionExamples: [
+        "status=rejected resource=RESOURCE_RUBIES plot=67 x=12 y=3 reason=cannot-have-resource observed=-1",
+      ],
       unmappedPlacedResourceTypes: [],
       byReason: [{ reason: "cannot-have-resource", count: 1 }],
     });

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -304,6 +304,17 @@
     `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-feature-apply-parser-post.json`
     (`sha256:7433af10bbb3197bb1b6608faadff3239179eb86998712702f5e70310ebd77e8`)
     are exact-run proof inputs. Product acceptance is still not closed.
+- [x] 2.47 Add bounded resource rejection telemetry for the next exact run.
+  - `RESOURCE_PLACEMENT_V1` now includes bounded `rejectionExamples` for
+    non-placed resource outcomes, carrying status, resource, plot, x/y, reason,
+    and observed readback where present. Studio exact-authorship parsing now
+    exposes aggregate resource placement stats and those examples from the
+    bounded proof section.
+  - This is a proof-contract repair only. It does not change resource planning,
+    scarce-floor assignment, ResourceBuilder policy, final-surface parity,
+    product acceptance, or resource tuning. A fresh exact-authored run must
+    consume this marker before the current one-rejection resource boundary can
+    be row-classified.
 
 ## 3. Verification
 
@@ -370,3 +381,9 @@
     links. The verifier log is
     `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-current-mq3ryaop.log`
     (`sha256:95775b27dfaacad92ad3899a2dc69a9edbe43ba77c74075d7ea888c10ee55e7c`).
+- [x] 3.18 Run focused resource rejection telemetry regressions.
+  - Passed `bun test apps/mapgen-studio/test/runInGame/proofIdentity.test.ts`
+    and
+    `bun test mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts`.
+  - Passed owner checks `bun run --cwd apps/mapgen-studio check` and
+    `bun run --cwd mods/mod-swooper-maps check`.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1521,6 +1521,12 @@ mountain-quality work.
   this as the source-authority input for the cold-reef/local-only feature row
   and remaining feature materialization/readback classification; do not treat it
   as final-surface parity or product acceptance.
+- Resource rejection row identity remains pending a fresh exact run. The
+  current code now emits bounded `RESOURCE_PLACEMENT_V1.rejectionExamples` and
+  Studio parses them into exact-authorship stats, but no current exact artifact
+  has consumed that contract yet. Use the next exact run to classify the one
+  current resource rejection before changing scarce-floor targets, assignment
+  order, static policy, or resource tuning.
 - Continue resource-row classification using source-recorded coordinate proof
   and runtime-bound row evidence where applicable before changing resource
   tuning, scarcity floors, assignment ordering, or static policy; obtain a

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -1102,11 +1102,20 @@
   `381`, resource `308`, and resource coordinate proof placed/rejected links.
   This is proof narrowing only: exact feature-apply legality is no longer a
   broad blocker, but final-surface parity and product acceptance remain open.
+  Current implementation now extends `RESOURCE_PLACEMENT_V1` with bounded
+  resource rejection examples and parses them into Studio exact-authorship
+  resource placement stats. This is the resource equivalent of the
+  natural-wonder proof-contract repairs: it should let the next exact run name
+  the one currently rejected resource row instead of carrying only count/hash
+  evidence. It does not change resource placement behavior, scarce-floor
+  assignment, ResourceBuilder policy, final-surface parity, or product
+  acceptance.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the current unresolved links from
   `studio-run-in-game-mq3ryaop-1p7l-current-final-surface-parity-with-feature-apply.json` by
   proving or rejecting the narrowed repair-owner candidates in order:
-  resource local-overacceptance/scarce-floor materialization, exact
+  resource local-overacceptance/scarce-floor materialization using a fresh
+  exact run that consumes bounded resource rejection examples, exact
   feature-materialization/readback ownership for the two rejected features and
   remaining `381` feature mismatches, then terrain projection/readback. Do this
   before any final-surface parity or product acceptance claim. The older
@@ -1129,8 +1138,9 @@
   future exact runs, but the current `mq20rbzr` artifact still lacks that digest.
   No resource tuning, static-policy repair, scarce-floor repair, or
   assignment-order repair is authorized until a fresh exact-authored run binds
-  local and live immediate placement coordinate identity or otherwise assigns
-  those subclasses to a concrete source owner. Older source-recorded feature
+  local and live immediate placement coordinate identity, including the new
+  bounded rejection example, or otherwise assigns those subclasses to a
+  concrete source owner. Older source-recorded feature
   rows were split into a reef absence and two natural-wonder one-tile offsets,
   with local intent, application, footprint evidence, runtime-bound
   `canHaveFeature` probes, footprint-direction alternatives, and planned-wonder


### PR DESCRIPTION
Adds bounded resource rejection examples to the `RESOURCE_PLACEMENT_V1` telemetry contract and parses them into Studio exact-authorship proof stats.

**Mod side (`RESOURCE_PLACEMENT_V1` emission):**
- `logResourcePlacementRuntimeTelemetry` and `buildResourcePlacementRuntimeTelemetry` now accept the raw placement `outcomes` array.
- A new `resourcePlacementRejectionExamples` helper filters non-placed outcomes (capped at 8), formats each as a human-readable string carrying `status`, `resource`, `plot`, `x`, `y`, `reason`, and `observed` readback where present, and emits them as `rejectionExamples` alongside a `rejectionExampleCount` in the logged JSON.

**Studio side (exact-authorship proof parsing):**
- `RunInGameExactAuthorshipProof` gains an optional `stats` field on `resourcePlacement` holding `version`, `plannedCount`, `placedCount`, `rejectedCount`, `mismatchCount`, and the optional `rejectionExampleCount`/`rejectionExamples`.
- A new `resourcePlacementStats` parser extracts and validates those fields from the raw payload, mirroring the existing `naturalWonderPlacementStats` pattern. Rejection examples are capped at 8 strings on the parse side as well.

**Scope boundary:** This is a proof-contract extension only. It does not alter resource planning, scarce-floor assignment, `ResourceBuilder` policy, final-surface parity, or product acceptance. A fresh exact-authored run is required to consume this marker and classify the one currently unresolved resource rejection row before any of those downstream decisions are made.