### PR TITLE
feat(swooper-resources): add structured numeric rejection rows to resource placement telemetry and exact-authorship proof parsing

### DIFF
--- a/apps/mapgen-studio/src/features/runInGame/status.ts
+++ b/apps/mapgen-studio/src/features/runInGame/status.ts
@@ -51,6 +51,18 @@ export type RunInGameSourceSnapshotProof = Readonly<{
   envelopeHash?: string;
 }>;
 
+export type RunInGameResourcePlacementRejectionRow = Readonly<{
+  status: "rejected" | "mismatch";
+  resourceType: number;
+  resource?: string;
+  plotIndex: number;
+  x: number;
+  y: number;
+  reason?: string;
+  observedResourceType?: number;
+  observedResource?: string;
+}>;
+
 export type RunInGameRequestStatus = Readonly<{
   recipeId?: string;
   seed?: number;
@@ -169,6 +181,7 @@ export type RunInGameExactAuthorshipProof = Readonly<{
         mismatchCount: number;
         rejectionExampleCount?: number;
         rejectionExamples?: ReadonlyArray<string>;
+        rejectionRows?: ReadonlyArray<RunInGameResourcePlacementRejectionRow>;
       }>;
       coordinateProof?: Readonly<{
         version: number;

--- a/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
+++ b/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
@@ -301,6 +301,10 @@ function numberValue(value: unknown): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 function setupParameterValue(snapshot: unknown, id: string): unknown {
   if (!isRecord(snapshot) || !isRecord(snapshot.setup) || !Array.isArray(snapshot.setup.parameters)) return undefined;
   const parameter = snapshot.setup.parameters.find((item) =>
@@ -552,6 +556,7 @@ function resourcePlacementStats(
     return undefined;
   }
   const rejectionExampleCount = numberValue(payload.rejectionExampleCount);
+  const rejectionRows = resourcePlacementRejectionRows(payload);
   return {
     stats: {
       version,
@@ -561,8 +566,53 @@ function resourcePlacementStats(
       mismatchCount,
       ...(rejectionExampleCount === undefined ? {} : { rejectionExampleCount }),
       ...(rejectionExamples === undefined ? {} : { rejectionExamples }),
+      ...(rejectionRows.length === 0 ? {} : { rejectionRows }),
     },
   };
+}
+
+function resourcePlacementRejectionRows(
+  payload: Record<string, unknown>
+): NonNullable<
+  NonNullable<
+    NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["resourcePlacement"]>["stats"]
+  >["rejectionRows"]
+> {
+  if (!Array.isArray(payload.rejectionRows)) return [];
+  return payload.rejectionRows.flatMap((value) => {
+    if (!isRecord(value)) return [];
+    const status: "rejected" | "mismatch" | undefined =
+      value.status === "rejected" || value.status === "mismatch" ? value.status : undefined;
+    const resourceType = numberValue(value.resourceType);
+    const plotIndex = numberValue(value.plotIndex);
+    const x = numberValue(value.x);
+    const y = numberValue(value.y);
+    if (
+      status === undefined ||
+      resourceType === undefined ||
+      plotIndex === undefined ||
+      x === undefined ||
+      y === undefined
+    ) {
+      return [];
+    }
+    const observedResourceType = numberValue(value.observedResourceType);
+    return [
+      {
+        status,
+        resourceType,
+        ...(stringValue(value.resource) === undefined ? {} : { resource: stringValue(value.resource) }),
+        plotIndex,
+        x,
+        y,
+        ...(stringValue(value.reason) === undefined ? {} : { reason: stringValue(value.reason) }),
+        ...(observedResourceType === undefined ? {} : { observedResourceType }),
+        ...(stringValue(value.observedResource) === undefined
+          ? {}
+          : { observedResource: stringValue(value.observedResource) }),
+      },
+    ];
+  }).slice(0, 8);
 }
 
 function naturalWonderPlacementCoordinateProof(

--- a/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
+++ b/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
@@ -107,7 +107,21 @@ describe("Run in Game exact authorship proof identity", () => {
           rejectedCount: 1,
           mismatchCount: 0,
           rejectionExampleCount: 1,
-          rejectionExamples: ["status=rejected resource=RESOURCE_WINE plot=67 x=12 y=3 reason=cannot-have-resource observed=-1"],
+          rejectionExamples: [
+            "status=rejected resource=RESOURCE_WINE resourceType=16 plot=67 x=12 y=3 reason=cannot-have-resource observed=-1",
+          ],
+          rejectionRows: [
+            {
+              status: "rejected",
+              resourceType: 16,
+              resource: "RESOURCE_WINE",
+              plotIndex: 67,
+              x: 12,
+              y: 3,
+              reason: "cannot-have-resource",
+              observedResourceType: -1,
+            },
+          ],
           coordinateProof: {
             version: 1,
             placedCount: 3,
@@ -175,7 +189,21 @@ describe("Run in Game exact authorship proof identity", () => {
         rejectedCount: 1,
         mismatchCount: 0,
         rejectionExampleCount: 1,
-        rejectionExamples: ["status=rejected resource=RESOURCE_WINE plot=67 x=12 y=3 reason=cannot-have-resource observed=-1"],
+        rejectionExamples: [
+          "status=rejected resource=RESOURCE_WINE resourceType=16 plot=67 x=12 y=3 reason=cannot-have-resource observed=-1",
+        ],
+        rejectionRows: [
+          {
+            status: "rejected",
+            resourceType: 16,
+            resource: "RESOURCE_WINE",
+            plotIndex: 67,
+            x: 12,
+            y: 3,
+            reason: "cannot-have-resource",
+            observedResourceType: -1,
+          },
+        ],
       },
       coordinateProof: {
         version: 1,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
@@ -23,6 +23,17 @@ type ResourcePlacementReason = ResourcePlacementRejectionReason | ResourcePlacem
 type ResourcePlacementSummary = ResourcePlacementOutcomes["summary"];
 type ResourceAssignmentSummary = ResourcePlacementOutcomes["assignment"];
 type ResourcePlacementRuntimeTelemetryOutcome = ResourcePlacementOutcomes["outcomes"][number];
+type ResourcePlacementRuntimeRejectionExample = {
+  readonly status: Exclude<ResourcePlacementRuntimeTelemetryOutcome["status"], "placed">;
+  readonly resourceType: number;
+  readonly resource: string | null;
+  readonly plotIndex: number;
+  readonly x: number;
+  readonly y: number;
+  readonly reason: ResourcePlacementReason | null;
+  readonly observedResourceType?: number;
+  readonly observedResource?: string | null;
+};
 type RuntimeResourceCatalogEntry = {
   readonly index: number;
   readonly resourceType: string;
@@ -796,7 +807,9 @@ export function buildResourcePlacementRuntimeTelemetry(
   const plannedTypesCovered =
     plannedTypeSet.size === coveredTypeSet.size &&
     plannedResourceTypeValues.every((resourceType) => coveredTypeSet.has(resourceType));
-  const rejectionExamples = resourcePlacementRejectionExamples(outcomes, runtimeByIndex);
+  const rejectionRows = resourcePlacementRejectionRows(outcomes, runtimeByIndex);
+  const rejectionExamples = rejectionRows.map(formatResourcePlacementRejectionExample);
+  const hasNonPlacedExamples = rejectionRows.length > 0;
 
   return {
     version: 1,
@@ -827,16 +840,19 @@ export function buildResourcePlacementRuntimeTelemetry(
         : {}),
     },
     ...(plannedTypesCovered ? {} : { plannedResourceTypes: plannedResourceTypeValues }),
-    placedResourceTypes: placedResourceTypeValues,
+    ...(hasNonPlacedExamples ? {} : { placedResourceTypes: placedResourceTypeValues }),
     rejectedResourceTypes: rejectedResourceTypeValues,
     ...(rejectionExamples.length === 0
       ? {}
       : {
           rejectionExampleCount: rejectionExamples.length,
           rejectionExamples,
+          rejectionRows,
         }),
-    unmappedPlacedResourceTypes: unmappedResourceTypes.map((row) => row.resourceType),
-    ...(assignment
+    ...(unmappedResourceTypes.length === 0
+      ? {}
+      : { unmappedPlacedResourceTypes: unmappedResourceTypes.map((row) => row.resourceType) }),
+    ...(assignment && !hasNonPlacedExamples
       ? {
           assignment: {
             requestedPlannedCount: assignment.requestedPlannedCount,
@@ -868,29 +884,55 @@ export function logResourcePlacementRuntimeTelemetry(
   );
 }
 
-function resourcePlacementRejectionExamples(
+function resourcePlacementRejectionRows(
   outcomes: readonly ResourcePlacementRuntimeTelemetryOutcome[],
   runtimeByIndex: ReadonlyMap<number, RuntimeResourceCatalogEntry>
-): string[] {
+): ResourcePlacementRuntimeRejectionExample[] {
   return outcomes
-    .filter((outcome) => outcome.status !== "placed")
+    .filter(isResourcePlacementNonPlacedOutcome)
     .slice(0, 8)
-    .map((outcome) => {
-      const resource =
-        runtimeByIndex.get(outcome.resourceType)?.resourceType ?? String(outcome.resourceType);
-      const fields = [
-        `status=${outcome.status}`,
-        `resource=${resource}`,
-        `plot=${outcome.plotIndex}`,
-        `x=${outcome.x}`,
-        `y=${outcome.y}`,
-        `reason=${outcome.reason}`,
-      ];
-      if (outcome.observedResourceType !== undefined) {
-        fields.push(`observed=${outcome.observedResourceType}`);
-      }
-      return fields.join(" ");
-    });
+    .map((outcome) => ({
+      status: outcome.status,
+      resourceType: outcome.resourceType,
+      resource: runtimeByIndex.get(outcome.resourceType)?.resourceType ?? null,
+      plotIndex: outcome.plotIndex,
+      x: outcome.x,
+      y: outcome.y,
+      reason: outcome.reason ?? null,
+      ...(outcome.observedResourceType === undefined
+        ? {}
+        : {
+            observedResourceType: outcome.observedResourceType,
+            observedResource: runtimeByIndex.get(outcome.observedResourceType)?.resourceType ?? null,
+          }),
+    }));
+}
+
+function isResourcePlacementNonPlacedOutcome(
+  outcome: ResourcePlacementRuntimeTelemetryOutcome
+): outcome is ResourcePlacementRuntimeTelemetryOutcome & { status: "rejected" | "mismatch" } {
+  return outcome.status !== "placed";
+}
+
+function formatResourcePlacementRejectionExample(
+  row: ResourcePlacementRuntimeRejectionExample
+): string {
+  const fields = [
+    `status=${row.status}`,
+    `resource=${row.resource ?? "unknown"}`,
+    `resourceType=${row.resourceType}`,
+    `plot=${row.plotIndex}`,
+    `x=${row.x}`,
+    `y=${row.y}`,
+    `reason=${row.reason ?? "unknown"}`,
+  ];
+  if (row.observedResourceType !== undefined) {
+    fields.push(`observed=${row.observedResourceType}`);
+  }
+  if (row.observedResource !== undefined && row.observedResource !== null) {
+    fields.push(`observedResource=${row.observedResource}`);
+  }
+  return fields.join(" ");
 }
 
 function assertResourceOutcomeMatchesIntent(

--- a/mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts
+++ b/mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts
@@ -250,15 +250,29 @@ describe("resource placement diagnostics", () => {
         rejectedCount: 1,
         rejectedHash32: "abcdef12",
       },
-      placedResourceTypes: [4, 44],
       rejectedResourceTypes: [44],
       rejectionExampleCount: 1,
       rejectionExamples: [
-        "status=rejected resource=RESOURCE_RUBIES plot=67 x=12 y=3 reason=cannot-have-resource observed=-1",
+        "status=rejected resource=RESOURCE_RUBIES resourceType=44 plot=67 x=12 y=3 reason=cannot-have-resource observed=-1",
       ],
-      unmappedPlacedResourceTypes: [],
+      rejectionRows: [
+        {
+          status: "rejected",
+          resourceType: 44,
+          resource: "RESOURCE_RUBIES",
+          plotIndex: 67,
+          x: 12,
+          y: 3,
+          reason: "cannot-have-resource",
+          observedResourceType: -1,
+          observedResource: null,
+        },
+      ],
       byReason: [{ reason: "cannot-have-resource", count: 1 }],
     });
+    expect(telemetry).not.toHaveProperty("placedResourceTypes");
+    expect(telemetry).not.toHaveProperty("assignment");
+    expect(telemetry).not.toHaveProperty("unmappedPlacedResourceTypes");
     expect(telemetry).not.toHaveProperty("plannedResourceTypes");
     expect(JSON.stringify(telemetry).length).toBeLessThan(900);
   });
@@ -326,7 +340,6 @@ describe("resource placement diagnostics", () => {
       },
       placedResourceTypes,
       rejectedResourceTypes: [],
-      unmappedPlacedResourceTypes: [],
       assignment: {
         requestedPlannedCount: 159,
         assignedCount: 159,
@@ -336,6 +349,7 @@ describe("resource placement diagnostics", () => {
         unassignableResourceTypes: [5, 15],
       },
     });
+    expect(telemetry).not.toHaveProperty("unmappedPlacedResourceTypes");
     expect(telemetry).not.toHaveProperty("plannedResourceTypes");
     expect(JSON.stringify(telemetry).length).toBeLessThan(900);
     expect(`[SWOOPER_MOD] RESOURCE_PLACEMENT_V1 ${JSON.stringify(telemetry)}`.length).toBeLessThan(

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -323,8 +323,15 @@
     completed with no exact-authorship unresolved links.
   - Exact `RESOURCE_PLACEMENT_V1` telemetry reports `251` planned resources,
     `250` placed, `1` rejected, and `0` mismatches. The rejected row is now
-    identified as `RESOURCE_WINE` at plot `4838` (`x=68`, `y=45`), rejected by
-    `canHaveResource` with observed readback `-1`.
+    identified by the string telemetry as `RESOURCE_WINE` at plot `4838`
+    (`x=68`, `y=45`), rejected by `canHaveResource` with observed readback
+    `-1`. This exact run predates the structured numeric rejection-row proof
+    contract, so the string name is not yet sufficient source-authority proof
+    where runtime catalog names and repo-generated numeric ids must be compared.
+    Local evidence for the same plot records numeric resource type `46`, which
+    the repo-generated table maps to `RESOURCE_LIMESTONE`; the next exact run
+    must carry both numeric id and runtime symbol before this row can authorize
+    repair.
   - Status artifact
     `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-resource-rejection-telemetry-status.json`
     (`sha256:beb4b23053dcbee73ce2b5bf0c191e44525f60a9592a92efaa42fbaefa5fe166`)
@@ -333,6 +340,19 @@
     (`sha256:5b88aaa0c54c88161dfdde447a05b75f359d53d8435185ee9de977306b6a4020`)
     are exact-run proof inputs. Resource parity and product acceptance are still
     not closed.
+- [x] 2.49 Bind numeric resource rejection rows into future exact-authorship
+  proof packets.
+  - Current branch `codex/swooper-resource-rejection-proof-identity-drain`
+    adds structured bounded `rejectionRows` to `RESOURCE_PLACEMENT_V1` runtime
+    telemetry and Studio exact-authorship parsing. Each non-placed resource row
+    now carries status, numeric `resourceType`, runtime resource symbol when
+    available, plot index, x/y, reason, and observed numeric/resource identity.
+  - Compact `rejectionExamples` now also include `resourceType=<number>` so log
+    readers can distinguish runtime symbol names from repo-local numeric ids.
+    This is proof instrumentation only. It does not change resource planning,
+    scarce-floor assignment, candidate ordering, resource tuning, final-surface
+    parity, or product acceptance. A fresh exact-authored run is still required
+    to classify the plot `4838` rejection with the repaired proof contract.
 
 ## 3. Verification
 
@@ -419,3 +439,11 @@
     links. The verifier log is
     `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-current-mq3sk0ck.log`
     (`sha256:8217718d3c115b2160635980e6d5eebd4e1cf509d8225de9e60cfdc040e47fcb`).
+- [x] 3.20 Run focused resource rejection identity regressions.
+  - Passed `bun test apps/mapgen-studio/test/runInGame/proofIdentity.test.ts`
+    and
+    `bun test mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts`.
+  - Passed owner checks `bun run --cwd apps/mapgen-studio check` and
+    `bun run --cwd mods/mod-swooper-maps check`.
+  - Full OpenSpec validation remains required before committing this
+    proof-contract slice.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -1127,16 +1127,26 @@
   `proofHash:4184a136601dbc3768fe175ab9f4f896bdd3754f2fcaf9e65c249d0d79f6a5f1`.
   It remains `unresolved` with unchanged terrain `139`, biome `874`, feature
   `381`, resource `308`, and resource coordinate proof placed/rejected links.
-  This narrows the resource boundary to a concrete exact rejection row without
-  authorizing resource tuning or parity closure.
+  This narrows the resource boundary to a concrete exact rejection coordinate
+  but does not yet make the resource symbol source-authoritative: the run
+  predates structured numeric rejection rows, and local evidence for plot
+  `4838` records numeric resource type `46`, which the repo-generated table
+  maps to `RESOURCE_LIMESTONE`. Current branch
+  `codex/swooper-resource-rejection-proof-identity-drain` adds bounded
+  structured `rejectionRows` to `RESOURCE_PLACEMENT_V1` and Studio proof
+  parsing, preserving numeric `resourceType`, runtime symbol, plot, x/y,
+  reason, and observed resource identity in future exact-authorship packets.
+  This is proof instrumentation only and does not authorize resource tuning,
+  scarce-floor repair, parity closure, or product acceptance.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the current unresolved links from
   `studio-run-in-game-mq3ryaop-1p7l-current-final-surface-parity-with-feature-apply.json` by
+  first rerunning exact proof with structured resource rejection rows, then
   proving or rejecting the narrowed repair-owner candidates in order:
   resource local-overacceptance/scarce-floor materialization using the exact
-  `RESOURCE_WINE` rejection row at plot `4838`, exact feature-materialization
-  /readback ownership for the two rejected features and remaining `381` feature
-  mismatches, then terrain projection/readback. Do this before any
+  plot `4838` rejection row with numeric/runtime identity, exact
+  feature-materialization/readback ownership for the two rejected features and
+  remaining `381` feature mismatches, then terrain projection/readback. Do this before any
   final-surface parity or product acceptance claim. The older
   source-recorded context remains useful: for the prior `9` local-assigned
   live-empty rows, assignment trace ruled out relaxed spacing and rebalance,
@@ -1156,9 +1166,9 @@
   Current code now emits and parses immediate placement coordinate digests for
   future exact runs, but the current `mq20rbzr` artifact still lacks that digest.
   No resource tuning, static-policy repair, scarce-floor repair, or
-  assignment-order repair is authorized until the exact `RESOURCE_WINE` row and
-  local assignment/resource-builder context are source-classified to a concrete
-  owner. Older source-recorded feature
+  assignment-order repair is authorized until the exact plot `4838` rejection
+  row and local assignment/resource-builder context are source-classified to a
+  concrete owner. Older source-recorded feature
   rows were split into a reef absence and two natural-wonder one-tile offsets,
   with local intent, application, footprint evidence, runtime-bound
   `canHaveFeature` probes, footprint-direction alternatives, and planned-wonder

--- a/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
@@ -2,9 +2,8 @@
 
 - [ ] 1.1 Verify exact-authorship, final-surface parity, product acceptance, and
   activated targeted repairs are closed or explicitly out of scope.
-  - Current audit snapshot on `codex/swooper-resource-rejection-proof-telemetry-drain`
-    (`96b94a13e4b7b7665b38c8b7c0701e253cfc8b38`) verifies exact-authorship
-    and mapgen completion are complete for request
+  - Current audit snapshot on `codex/swooper-resource-rejection-proof-identity-drain`
+    verifies exact-authorship and mapgen completion are complete for request
     `studio-run-in-game-mq3sk0ck-1vl`, but final-surface parity is still
     unresolved. Refreshed parity artifact
     `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3sk0ck-1vl-current-final-surface-parity-with-resource-rejection-example.json`
@@ -12,11 +11,15 @@
     `proofHash:4184a136601dbc3768fe175ab9f4f896bdd3754f2fcaf9e65c249d0d79f6a5f1`)
     remains `unresolved` with terrain `139`, biome `874`, feature `381`, and
     resource `308` mismatches plus resource coordinate proof placed/rejected
-    links. It also records exact resource rejection row identity
+    links. It also records an exact string-only resource rejection row
     (`RESOURCE_WINE`, plot `4838`, `x=68`, `y=45`, `cannot-have-resource`) and
     exact `FEATURE_APPLY_V1` telemetry (`1493` attempted, `1491` applied, `2`
-    rejected), narrowing but not closing source-authority work. Product
-    acceptance is therefore not closed.
+    rejected), narrowing but not closing source-authority work. The current top
+    branch adds structured numeric rejection-row proof for future exact runs
+    because local evidence for plot `4838` records numeric resource type `46`,
+    mapped by the repo table to `RESOURCE_LIMESTONE`; the old string label is
+    therefore not sufficient repair authority. Product acceptance is therefore
+    not closed.
 - [ ] 1.2 Audit accepted P1/P2 review findings across recovery changes.
   - Current audit pass found no active review-disposition ledger inside
     `earthlike-live-feature-resource-legality-repair` or
@@ -27,7 +30,7 @@
     finding remains open inside the closure claim.
 - [ ] 1.3 Audit repo, Graphite, PR, and remote predecessor state.
   - Current repo snapshot is clean on
-    `codex/swooper-resource-rejection-proof-telemetry-drain`; Graphite top
+    `codex/swooper-resource-rejection-proof-identity-drain`; Graphite top
     branch is local and stacked above the Swooper recovery drain. PR/remote
     predecessor disposition remains blocked until proof categories close.
 
@@ -43,10 +46,10 @@
 
 - [ ] 3.1 Run `git status --short --branch`.
   - Current audit snapshot: clean on
-    `codex/swooper-resource-rejection-proof-telemetry-drain`.
+    `codex/swooper-resource-rejection-proof-identity-drain`.
 - [ ] 3.2 Inspect Graphite branch/stack state.
   - Current audit snapshot: top branch
-    `codex/swooper-resource-rejection-proof-telemetry-drain` above
+    `codex/swooper-resource-rejection-proof-identity-drain` above
     `codex/swooper-current-feature-apply-proof-rerun-record-drain` and the
     current feature/resource/source-authority proof-record branches.
 - [ ] 3.3 Run `git diff --check`.

--- a/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
@@ -5,7 +5,7 @@
 - Project: Swooper recovery
 - Phase: product closure planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack: `codex/swooper-resource-rejection-proof-telemetry-drain`
+- Branch/Graphite stack: `codex/swooper-resource-rejection-proof-identity-drain`
 - Started: 2026-06-06
 - Status: blocked until proof and activated repair changes close
 
@@ -28,9 +28,8 @@
 ## Current State
 
 - Repo/Graphite state: current top branch is
-  `codex/swooper-resource-coordinate-proof-rerun-record-drain`
-  (`c1c860abe4a9998d96d78b4bc009ce03e00ba25a`), stacked above the current
-  Swooper proof/diagnostic drain branches.
+  `codex/swooper-resource-rejection-proof-identity-drain`, stacked above the
+  current Swooper proof/diagnostic drain branches.
 - Dirty files and owner: current audit snapshot was clean before this closure
   record update; this planning goal owns the current OpenSpec docs.
 - Current code evidence: exact-authorship and mapgen-completion proof are
@@ -42,11 +41,14 @@
   `proofHash:4184a136601dbc3768fe175ab9f4f896bdd3754f2fcaf9e65c249d0d79f6a5f1`).
   It preserves unresolved terrain `139`, biome `874`, feature `381`, and
   resource `308` mismatch counts plus resource coordinate proof placed/rejected
-  links. Exact resource telemetry identifies the rejected row as
+  links. Exact resource telemetry identifies a string-only rejected row as
   `RESOURCE_WINE` at plot `4838` (`x=68`, `y=45`), rejected by
   `canHaveResource`; exact `FEATURE_APPLY_V1` reports `1493` attempted,
-  `1491` applied, and `2` `canHaveFeature` rejections. These narrow but do not
-  close source-authority or product acceptance.
+  `1491` applied, and `2` `canHaveFeature` rejections. Current top branch adds
+  structured numeric rejection rows for future exact runs because local
+  evidence for plot `4838` records numeric resource type `46`, mapped by the
+  repo table to `RESOURCE_LIMESTONE`. These narrow but do not close
+  source-authority or product acceptance.
 - Generated outputs affected: none expected.
 - Tests/guards affected: validation and closure audits.
 
@@ -89,7 +91,8 @@
 ## Implementation
 
 - Completed tasks: planning record created; current proof/Graphite audit
-  snapshot recorded, including the current exact feature-apply telemetry rerun.
+  snapshot recorded, including the current exact feature-apply telemetry rerun
+  and resource rejection numeric-identity proof-contract repair.
 - Remaining tasks: final-surface parity, product acceptance, supervisor
   P1/P2 closure review, PR/remote predecessor disposition, and final Graphite
   submit/closure.
@@ -103,7 +106,7 @@
   the current exact-authorship proof.
 - Results: repo snapshot clean before this update; latest verifier artifact is
   unresolved with proof hash
-  `89d48831dd981e5144c89e14842b1052d989d3748b011fc7590070075236ba02`;
+  `4184a136601dbc3768fe175ab9f4f896bdd3754f2fcaf9e65c249d0d79f6a5f1`;
   broader review-ledger scan found historical P1/P2 entries but no active
   review ledger under the two current recovery closure changes.
 - Skipped gates and rationale: closure gates wait for proof closure.
@@ -119,10 +122,10 @@
 ## Next Action
 
 - Exact next step: continue the proof-led drain from
-  `earthlike-live-feature-resource-legality-repair`, starting with the resource
-  `RESOURCE_WINE` rejection row, then using the current exact
-  `FEATURE_APPLY_V1` telemetry to classify feature materialization/readback
-  ownership.
+  `earthlike-live-feature-resource-legality-repair`, starting with a fresh exact
+  run that consumes structured resource rejection rows for plot `4838`, then
+  use the current exact `FEATURE_APPLY_V1` telemetry to classify feature
+  materialization/readback ownership.
 - First files to inspect: recovery OpenSpec proof ledgers and Graphite branch
   state.
 - Stop condition: accepted P1/P2 findings remain open.


### PR DESCRIPTION
Adds structured `rejectionRows` to `RESOURCE_PLACEMENT_V1` runtime telemetry and Studio exact-authorship proof parsing so that future exact runs carry numeric resource type, runtime symbol, plot index, x/y coordinates, rejection reason, and observed resource identity as discrete fields rather than only as a formatted string.

The existing `rejectionExamples` string format is preserved and extended to include `resourceType=<number>` so log readers can distinguish runtime symbol names from repo-local numeric ids. When non-placed rejection rows are present, `placedResourceTypes`, `assignment`, and `unmappedPlacedResourceTypes` are omitted from the telemetry payload to keep packet size bounded.

The `resourcePlacementRejectionRows` parser in Studio validates and normalises each row, requiring `status`, `resourceType`, `plotIndex`, `x`, and `y` to be present, and caps the result at eight rows. Optional fields (`resource`, `reason`, `observedResourceType`, `observedResource`) are included only when non-empty.

This is proof instrumentation only. It does not change resource planning, scarce-floor assignment, candidate ordering, resource tuning, final-surface parity, or product acceptance. A fresh exact-authored run is required to classify the plot `4838` rejection with the repaired proof contract, because local evidence records numeric resource type `46` (mapped to `RESOURCE_LIMESTONE`) while the prior run's string-only label reported `RESOURCE_WINE`, and the old format is not sufficient repair authority.