### PR TITLE
feat(live-parity): join exact resource rejection rows to local placement evidence in final-surface parity proof

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -98,6 +98,52 @@ type ResourcePlacementCoordinateProofComparison = Readonly<{
   mismatchedLinks: ReadonlyArray<string>;
 }>;
 
+export type ResourcePlacementRejectionContext = Readonly<{
+  exact: Readonly<{
+    status: string;
+    resourceType: number;
+    resource?: string | null;
+    plotIndex: number;
+    x?: number;
+    y?: number;
+    reason?: string | null;
+    observedResourceType?: number | null;
+    observedResource?: string | null;
+    assignmentPhase?: string;
+    assignmentOrder?: number;
+    initialResourceType?: number;
+    preferredResourceType?: number | null;
+    perTypeCountBefore?: number;
+    legalPlotCountForResource?: number;
+    targetMinPerType?: number;
+  }>;
+  local: Readonly<{
+    surfaceResourceType?: number | null;
+    preferredPlacement?: Readonly<{
+      preferredResourceType: number;
+      preferredTypeOffset?: number;
+      priority?: number;
+    }>;
+    outcome?: Readonly<{
+      status: string;
+      resourceType: number;
+      observedResourceType?: number | null;
+      reason?: string | null;
+    }>;
+    assignment?: Readonly<{
+      resourceType: number;
+      initialResourceType: number;
+      preferredResourceType?: number | null;
+      assignmentPhase: string;
+      reassignedByRebalance?: boolean;
+      assignmentOrder?: number;
+      perTypeCountBefore?: number;
+      legalPlotCountForResource?: number;
+      targetMinPerType?: number;
+    }>;
+  }>;
+}>;
+
 export type FinalSurfaceParityProof = Readonly<{
   status: "complete" | "unresolved";
   createdAt: string;
@@ -116,6 +162,7 @@ export type FinalSurfaceParityProof = Readonly<{
   live: FinalSurfaceSnapshot;
   diffs: ReadonlyArray<SurfaceDiffSummary>;
   resourcePlacementCoordinateProof?: ResourcePlacementCoordinateProofComparison;
+  resourcePlacementRejectionContexts?: ReadonlyArray<ResourcePlacementRejectionContext>;
   residuals: ReadonlyArray<ParityResidualClassification>;
   unresolvedLinks: ReadonlyArray<string>;
 }>;
@@ -178,6 +225,9 @@ export type ExactAuthorshipProofLike = Readonly<{
     seed?: number;
     dimensions?: Readonly<{ width?: number; height?: number }>;
     resourcePlacement?: Readonly<{
+      stats?: Readonly<{
+        rejectionRows?: ReadonlyArray<unknown>;
+      }>;
       coordinateProof?: Readonly<{
         version?: number;
         placed?: Readonly<{ count?: number; hash32?: string }>;
@@ -626,6 +676,8 @@ export function buildFinalSurfaceParityProof(args: {
   const exact = args.exactAuthorship;
   const resourcePlacementCoordinateProof =
     exact === undefined ? undefined : buildResourcePlacementCoordinateProofComparison(exact, args.local);
+  const resourcePlacementRejectionContexts =
+    exact === undefined ? [] : buildResourcePlacementRejectionContexts(exact, args.local);
 
   unresolvedLinks.push(...validateExactAuthorshipProofPacket(exact).unresolvedLinks);
   addSurfaceShapeLinks(unresolvedLinks, args.local, "local", exact?.runtime?.width, exact?.runtime?.height);
@@ -740,6 +792,9 @@ export function buildFinalSurfaceParityProof(args: {
     live: args.live,
     diffs,
     ...(resourcePlacementCoordinateProof === undefined ? {} : { resourcePlacementCoordinateProof }),
+    ...(resourcePlacementRejectionContexts.length === 0
+      ? {}
+      : { resourcePlacementRejectionContexts }),
     residuals,
     unresolvedLinks: [...new Set(unresolvedLinks)].sort((a, b) => a.localeCompare(b)),
   };
@@ -998,6 +1053,256 @@ function coordinateDigest(value: unknown): { count?: number; hash32?: string } |
     ...(numberValue(value.count) === undefined ? {} : { count: numberValue(value.count) }),
     ...(typeof value.hash32 === "string" ? { hash32: value.hash32 } : {}),
   };
+}
+
+function buildResourcePlacementRejectionContexts(
+  exact: ExactAuthorshipProofLike,
+  local: FinalSurfaceSnapshot
+): ResourcePlacementRejectionContext[] {
+  const rows = readExactResourcePlacementRejectionRows(exact);
+  if (rows.length === 0) return [];
+  const localEvidence = readLocalResourcePlacementEvidence(local);
+  return rows.map((row) => ({
+    exact: row,
+    local: {
+      ...(indexedSurfaceValue(local.surfaces.resource.values, row.plotIndex) === undefined
+        ? {}
+        : { surfaceResourceType: indexedSurfaceValue(local.surfaces.resource.values, row.plotIndex) }),
+      ...(localEvidence.preferredByPlot.get(row.plotIndex) === undefined
+        ? {}
+        : { preferredPlacement: localEvidence.preferredByPlot.get(row.plotIndex)! }),
+      ...(localEvidence.outcomeByPlot.get(row.plotIndex) === undefined
+        ? {}
+        : { outcome: localEvidence.outcomeByPlot.get(row.plotIndex)! }),
+      ...(localEvidence.assignmentByPlot.get(row.plotIndex) === undefined
+        ? {}
+        : { assignment: localEvidence.assignmentByPlot.get(row.plotIndex)! }),
+    },
+  }));
+}
+
+function readExactResourcePlacementRejectionRows(
+  exact: ExactAuthorshipProofLike
+): ResourcePlacementRejectionContext["exact"][] {
+  const rows = exact.log?.resourcePlacement?.stats?.rejectionRows;
+  if (!Array.isArray(rows)) return [];
+  return rows.flatMap((row) => {
+    if (!isPlainObject(row)) return [];
+    const status = stringValue(row.status);
+    const resourceType = numberValue(row.resourceType);
+    const plotIndex = numberValue(row.plotIndex);
+    if (!status || resourceType === undefined || plotIndex === undefined) return [];
+    return [
+      {
+        status,
+        resourceType,
+        ...(stringOrNullValue(row.resource) === undefined
+          ? {}
+          : { resource: stringOrNullValue(row.resource) }),
+        plotIndex,
+        ...(numberValue(row.x) === undefined ? {} : { x: numberValue(row.x) }),
+        ...(numberValue(row.y) === undefined ? {} : { y: numberValue(row.y) }),
+        ...(stringOrNullValue(row.reason) === undefined
+          ? {}
+          : { reason: stringOrNullValue(row.reason) }),
+        ...(numberOrNullValue(row.observedResourceType) === undefined
+          ? {}
+          : { observedResourceType: numberOrNullValue(row.observedResourceType) }),
+        ...(stringOrNullValue(row.observedResource) === undefined
+          ? {}
+          : { observedResource: stringOrNullValue(row.observedResource) }),
+        ...(stringValue(row.assignmentPhase) === undefined
+          ? {}
+          : { assignmentPhase: stringValue(row.assignmentPhase) }),
+        ...(numberValue(row.assignmentOrder) === undefined
+          ? {}
+          : { assignmentOrder: numberValue(row.assignmentOrder) }),
+        ...(numberValue(row.initialResourceType) === undefined
+          ? {}
+          : { initialResourceType: numberValue(row.initialResourceType) }),
+        ...(numberOrNullValue(row.preferredResourceType) === undefined
+          ? {}
+          : { preferredResourceType: numberOrNullValue(row.preferredResourceType) }),
+        ...(numberValue(row.perTypeCountBefore) === undefined
+          ? {}
+          : { perTypeCountBefore: numberValue(row.perTypeCountBefore) }),
+        ...(numberValue(row.legalPlotCountForResource) === undefined
+          ? {}
+          : { legalPlotCountForResource: numberValue(row.legalPlotCountForResource) }),
+        ...(numberValue(row.targetMinPerType) === undefined
+          ? {}
+          : { targetMinPerType: numberValue(row.targetMinPerType) }),
+      },
+    ];
+  });
+}
+
+function readLocalResourcePlacementEvidence(local: FinalSurfaceSnapshot): {
+  preferredByPlot: ReadonlyMap<
+    number,
+    { preferredResourceType: number; preferredTypeOffset?: number; priority?: number }
+  >;
+  outcomeByPlot: ReadonlyMap<
+    number,
+    {
+      status: string;
+      resourceType: number;
+      observedResourceType?: number | null;
+      reason?: string | null;
+    }
+  >;
+  assignmentByPlot: ReadonlyMap<
+    number,
+    {
+      resourceType: number;
+      initialResourceType: number;
+      preferredResourceType?: number | null;
+      assignmentPhase: string;
+      reassignedByRebalance?: boolean;
+      assignmentOrder?: number;
+      perTypeCountBefore?: number;
+      legalPlotCountForResource?: number;
+      targetMinPerType?: number;
+    }
+  >;
+} {
+  const resourcePlan = isPlainObject(local.evidence?.resourcePlan)
+    ? local.evidence.resourcePlan
+    : undefined;
+  const resourcePlacementOutcomes = isPlainObject(local.evidence?.resourcePlacementOutcomes)
+    ? local.evidence.resourcePlacementOutcomes
+    : undefined;
+  const preferredByPlot = new Map<
+    number,
+    { preferredResourceType: number; preferredTypeOffset?: number; priority?: number }
+  >();
+  const placements = Array.isArray(resourcePlan?.placements) ? resourcePlan.placements : [];
+  for (const placement of placements) {
+    if (!isPlainObject(placement)) continue;
+    const plotIndex = numberValue(placement.plotIndex);
+    const preferredResourceType = numberValue(placement.preferredResourceType);
+    if (plotIndex === undefined || preferredResourceType === undefined || preferredByPlot.has(plotIndex)) {
+      continue;
+    }
+    preferredByPlot.set(plotIndex, {
+      preferredResourceType,
+      ...(numberValue(placement.preferredTypeOffset) === undefined
+        ? {}
+        : { preferredTypeOffset: numberValue(placement.preferredTypeOffset) }),
+      ...(numberValue(placement.priority) === undefined ? {} : { priority: numberValue(placement.priority) }),
+    });
+  }
+
+  const outcomeByPlot = new Map<
+    number,
+    {
+      status: string;
+      resourceType: number;
+      observedResourceType?: number | null;
+      reason?: string | null;
+    }
+  >();
+  const outcomes = Array.isArray(resourcePlacementOutcomes?.outcomes)
+    ? resourcePlacementOutcomes.outcomes
+    : [];
+  for (const outcome of outcomes) {
+    if (!isPlainObject(outcome)) continue;
+    const plotIndex = numberValue(outcome.plotIndex);
+    const status = stringValue(outcome.status);
+    const resourceType = numberValue(outcome.resourceType);
+    if (plotIndex === undefined || !status || resourceType === undefined || outcomeByPlot.has(plotIndex)) {
+      continue;
+    }
+    outcomeByPlot.set(plotIndex, {
+      status,
+      resourceType,
+      ...(numberOrNullValue(outcome.observedResourceType) === undefined
+        ? {}
+        : { observedResourceType: numberOrNullValue(outcome.observedResourceType) }),
+      ...(stringOrNullValue(outcome.reason) === undefined
+        ? {}
+        : { reason: stringOrNullValue(outcome.reason) }),
+    });
+  }
+
+  const assignmentByPlot = new Map<
+    number,
+    {
+      resourceType: number;
+      initialResourceType: number;
+      preferredResourceType?: number | null;
+      assignmentPhase: string;
+      reassignedByRebalance?: boolean;
+      assignmentOrder?: number;
+      perTypeCountBefore?: number;
+      legalPlotCountForResource?: number;
+      targetMinPerType?: number;
+    }
+  >();
+  const assignmentTrace = Array.isArray(resourcePlacementOutcomes?.assignmentTrace)
+    ? resourcePlacementOutcomes.assignmentTrace
+    : [];
+  for (const assignment of assignmentTrace) {
+    if (!isPlainObject(assignment)) continue;
+    const plotIndex = numberValue(assignment.plotIndex);
+    const resourceType = numberValue(assignment.resourceType);
+    const initialResourceType = numberValue(assignment.initialResourceType);
+    const assignmentPhase = stringValue(assignment.assignmentPhase);
+    if (
+      plotIndex === undefined ||
+      resourceType === undefined ||
+      initialResourceType === undefined ||
+      !assignmentPhase ||
+      assignmentByPlot.has(plotIndex)
+    ) {
+      continue;
+    }
+    assignmentByPlot.set(plotIndex, {
+      resourceType,
+      initialResourceType,
+      ...(numberOrNullValue(assignment.preferredResourceType) === undefined
+        ? {}
+        : { preferredResourceType: numberOrNullValue(assignment.preferredResourceType) }),
+      assignmentPhase,
+      ...(typeof assignment.reassignedByRebalance === "boolean"
+        ? { reassignedByRebalance: assignment.reassignedByRebalance }
+        : {}),
+      ...(numberValue(assignment.assignmentOrder) === undefined
+        ? {}
+        : { assignmentOrder: numberValue(assignment.assignmentOrder) }),
+      ...(numberValue(assignment.perTypeCountBefore) === undefined
+        ? {}
+        : { perTypeCountBefore: numberValue(assignment.perTypeCountBefore) }),
+      ...(numberValue(assignment.legalPlotCountForResource) === undefined
+        ? {}
+        : { legalPlotCountForResource: numberValue(assignment.legalPlotCountForResource) }),
+      ...(numberValue(assignment.targetMinPerType) === undefined
+        ? {}
+        : { targetMinPerType: numberValue(assignment.targetMinPerType) }),
+    });
+  }
+
+  return { preferredByPlot, outcomeByPlot, assignmentByPlot };
+}
+
+function indexedSurfaceValue(values: ReadonlyArray<number | null>, index: number): number | null | undefined {
+  if (!Number.isInteger(index) || index < 0 || index >= values.length) return undefined;
+  const value = values[index];
+  return value === undefined ? undefined : value;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function stringOrNullValue(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberOrNullValue(value: unknown): number | null | undefined {
+  if (value === null) return null;
+  return numberValue(value);
 }
 
 function probeNumberValue(value: unknown): number | null {

--- a/mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
@@ -84,9 +84,67 @@ function snapshot(args: {
   omitted?: number;
   localTerrain?: ReadonlyArray<number | null>;
   resourceCoordinateProof?: boolean;
+  resourceRejectionContext?: boolean;
 }): FinalSurfaceSnapshot {
   const width = 2;
   const height = 1;
+  const localEvidence = {
+    ...(args.resourceCoordinateProof
+      ? {
+          resourcePlacementOutcomes: {
+            summary: {
+              coordinateProof: {
+                version: 1,
+                placed: { count: 2, hash32: "aaaaaaaa" },
+                rejected: { count: 0, hash32: "811c9dc5" },
+                mismatch: { count: 0, hash32: "811c9dc5" },
+              },
+            },
+          },
+        }
+      : {}),
+    ...(args.resourceRejectionContext
+      ? {
+          resourcePlan: {
+            placements: [
+              { plotIndex: 1, preferredResourceType: 13, preferredTypeOffset: 2, priority: 0.9 },
+            ],
+          },
+          resourcePlacementOutcomes: {
+            summary: {
+              coordinateProof: {
+                version: 1,
+                placed: { count: 2, hash32: "aaaaaaaa" },
+                rejected: { count: 0, hash32: "811c9dc5" },
+                mismatch: { count: 0, hash32: "811c9dc5" },
+              },
+            },
+            outcomes: [
+              {
+                plotIndex: 1,
+                status: "placed",
+                resourceType: 46,
+                observedResourceType: 46,
+              },
+            ],
+            assignmentTrace: [
+              {
+                plotIndex: 1,
+                resourceType: 46,
+                initialResourceType: 46,
+                preferredResourceType: 13,
+                assignmentPhase: "scarce-floor",
+                reassignedByRebalance: false,
+                assignmentOrder: 168,
+                perTypeCountBefore: 0,
+                legalPlotCountForResource: 660,
+                targetMinPerType: 7,
+              },
+            ],
+          },
+        }
+      : {}),
+  };
   return {
     source: args.source,
     width,
@@ -113,20 +171,7 @@ function snapshot(args: {
             },
           },
         }
-      : args.resourceCoordinateProof
-        ? {
-            resourcePlacementOutcomes: {
-              summary: {
-                coordinateProof: {
-                  version: 1,
-                  placed: { count: 2, hash32: "aaaaaaaa" },
-                  rejected: { count: 0, hash32: "811c9dc5" },
-                  mismatch: { count: 0, hash32: "811c9dc5" },
-                },
-              },
-            },
-          }
-        : {},
+      : localEvidence,
   };
 }
 
@@ -208,6 +253,91 @@ describe("final-surface parity proof", () => {
       exact: { placed: { count: 2, hash32: "bbbbbbbb" } },
     });
     expect(proof.unresolvedLinks).toContain("resource-placement-coordinate-proof.placed");
+  });
+
+  test("joins exact resource rejection rows to local placement evidence", () => {
+    const proof = buildFinalSurfaceParityProof({
+      exactAuthorship: exactProof({
+        log: {
+          requestId: "run-1",
+          configHash,
+          envelopeHash: "envelope-1",
+          seed: 1234,
+          dimensions: { width: 2, height: 1 },
+          resourcePlacement: {
+            stats: {
+              rejectionRows: [
+                {
+                  status: "rejected",
+                  resourceType: 16,
+                  resource: "RESOURCE_WINE",
+                  plotIndex: 1,
+                  x: 1,
+                  y: 0,
+                  reason: "cannot-have-resource",
+                  observedResourceType: -1,
+                  assignmentPhase: "scarce-floor",
+                  assignmentOrder: 85,
+                  initialResourceType: 16,
+                  preferredResourceType: 4,
+                  perTypeCountBefore: 1,
+                  legalPlotCountForResource: 313,
+                  targetMinPerType: 7,
+                },
+              ],
+            },
+            coordinateProof: {
+              version: 1,
+              placed: { count: 1, hash32: "bbbbbbbb" },
+              rejected: { count: 1, hash32: "cccccccc" },
+            },
+          },
+        },
+      }),
+      local: snapshot({ source: "local-mapgen", resourceRejectionContext: true }),
+      live: snapshot({ source: "live-civ7" }),
+    });
+
+    expect(proof.status).toBe("unresolved");
+    expect(proof.resourcePlacementRejectionContexts).toEqual([
+      {
+        exact: {
+          status: "rejected",
+          resourceType: 16,
+          resource: "RESOURCE_WINE",
+          plotIndex: 1,
+          x: 1,
+          y: 0,
+          reason: "cannot-have-resource",
+          observedResourceType: -1,
+          assignmentPhase: "scarce-floor",
+          assignmentOrder: 85,
+          initialResourceType: 16,
+          preferredResourceType: 4,
+          perTypeCountBefore: 1,
+          legalPlotCountForResource: 313,
+          targetMinPerType: 7,
+        },
+        local: {
+          surfaceResourceType: 8,
+          preferredPlacement: { preferredResourceType: 13, preferredTypeOffset: 2, priority: 0.9 },
+          outcome: { status: "placed", resourceType: 46, observedResourceType: 46 },
+          assignment: {
+            resourceType: 46,
+            initialResourceType: 46,
+            preferredResourceType: 13,
+            assignmentPhase: "scarce-floor",
+            reassignedByRebalance: false,
+            assignmentOrder: 168,
+            perTypeCountBefore: 0,
+            legalPlotCountForResource: 660,
+            targetMinPerType: 7,
+          },
+        },
+      },
+    ]);
+    expect(proof.unresolvedLinks).toContain("resource-placement-coordinate-proof.placed");
+    expect(proof.unresolvedLinks).toContain("resource-placement-coordinate-proof.rejected");
   });
 
   test("rejects hash-only exact-authorship source snapshots", () => {

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -423,6 +423,18 @@
     final-surface parity, or product acceptance; it narrows the next repair
     owner decision to reconciling exact scarce-floor assignment/materialization
     with the local resource assignment/resource-builder context.
+- [x] 2.53 Join exact resource rejection rows to local assignment context in
+  final-surface parity proof artifacts.
+  - Current branch `codex/swooper-resource-rejection-local-context-drain` adds
+    compact `resourcePlacementRejectionContexts` to final-surface parity
+    artifacts. The field is emitted only when exact proof carries
+    `RESOURCE_PLACEMENT_V1` rejection rows, and joins each exact row to the
+    local resource surface value, preferred plan row, typed local outcome, and
+    local assignment trace at the same plot.
+  - This is diagnostic/proof context only. It does not add a new unresolved
+    link, change grid parity semantics, change resource planning,
+    materialization, scarce-floor policy, ResourceBuilder policy, final-surface
+    parity, or product acceptance.
 
 ## 3. Verification
 
@@ -575,3 +587,28 @@
     `0`/`811c9dc5`, exact rejected `1`/`af57eb7b`. Verifier log:
     `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-current-mq3v6xr9.log`
     (`sha256:9479c3028e5e59f3c5d33afdf33d05c2e46e6aca31d0de4cef4a1a985c110d44`).
+- [x] 3.24 Run focused resource rejection local-context proof regressions and
+  rerun final-surface parity with local context.
+  - Passed `bun test mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts`
+    and `bun run --cwd mods/mod-swooper-maps check`.
+  - Verifier input
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-resource-rejection-assignment-context-status.json`
+    wrote
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3v6xr9-4w9-current-final-surface-parity-with-resource-rejection-local-context.json`
+    (`sha256:1387bbcc0d645263a068854884acbc7746c7f82a0742650168393e7e3f78e8cf`,
+    `proofHash:66ed0c2537374e77548ac560eb39434bf481162f3a9024a3986fbf0cc1fc0290`,
+    created `2026-06-07T14:33:20.850Z`).
+  - The verifier exited `2` as expected for unresolved parity. Remaining
+    unresolved links are unchanged: `resource-placement-coordinate-proof.placed`,
+    `resource-placement-coordinate-proof.rejected`, `surface.biome.mismatch`,
+    `surface.feature.mismatch`, `surface.resource.mismatch`, and
+    `surface.terrain.mismatch`. The verifier log is
+    `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-current-mq3v6xr9-local-context.log`
+    (`sha256:c661878c2bfbda715750412bff93e592e60af76a619b79628d014e0a9e29cff8`).
+  - The new context proves the exact rejected `RESOURCE_WINE` row at plot
+    `4838` was a scarce-floor assignment at order `85`, while local evidence at
+    the same plot has final/local placed `RESOURCE_LIMESTONE` (`46`), local
+    preferred plan `RESOURCE_SILK` (`13`), local scarce-floor assignment order
+    `168`, local `legalPlotCountForResource:660`, and the same
+    `targetMinPerType:7`. This is cross-resource assignment/materialization
+    divergence at one coordinate, not same-resource local Wine overacceptance.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,8 +6,9 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
+  `codex/swooper-resource-rejection-local-context-drain`, stacked above
   `codex/swooper-resource-rejection-assignment-context-rerun-record-drain`,
-  stacked above `codex/swooper-resource-rejection-assignment-context-drain`,
+  `codex/swooper-resource-rejection-assignment-context-drain`,
   `codex/swooper-resource-rejection-identity-rerun-record-drain`,
   `codex/swooper-resource-rejection-proof-identity-drain`,
   `codex/swooper-resource-rejection-proof-rerun-record-drain`, and the current
@@ -28,13 +29,16 @@
   `assignmentPhase:scarce-floor`, `assignmentOrder:85`,
   `initialResourceType:16`, `preferredResourceType:4`,
   `perTypeCountBefore:1`, `legalPlotCountForResource:313`, and
-  `targetMinPerType:7`. Final-surface parity still remains unresolved on
-  terrain, biome, feature, resource, and resource-coordinate-proof links.
-  Current exact feature telemetry has `1493` attempted, `1491` applied, and
-  `2` `canHaveFeature` rejections; current exact natural-wonder telemetry has
-  `7` planned, `4` placed, and `3` rejected. Resource, feature,
-  natural-wonder, and terrain source-authority classification remains the
-  active work; product acceptance is not closed.
+  `targetMinPerType:7`. The latest proof artifact now joins that exact row to
+  local context and shows the same coordinate locally placed
+  `RESOURCE_LIMESTONE` (`46`) from local scarce-floor order `168`, while the
+  original local preferred plan row was `RESOURCE_SILK` (`13`). Final-surface
+  parity still remains unresolved on terrain, biome, feature, resource, and
+  resource-coordinate-proof links. Current exact feature telemetry has `1493`
+  attempted, `1491` applied, and `2` `canHaveFeature` rejections; current exact
+  natural-wonder telemetry has `7` planned, `4` placed, and `3` rejected.
+  Resource, feature, natural-wonder, and terrain source-authority
+  classification remains the active work; product acceptance is not closed.
 
 ## Objective
 
@@ -1192,9 +1196,23 @@
   assignment selected before materialization. It does not authorize tuning,
   scarce-floor policy repair, ResourceBuilder policy changes, final-surface
   parity, or product acceptance.
+  Current branch `codex/swooper-resource-rejection-local-context-drain` then
+  adds compact `resourcePlacementRejectionContexts` to final-surface parity
+  artifacts. The verifier rerun wrote
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3v6xr9-4w9-current-final-surface-parity-with-resource-rejection-local-context.json`
+  (`sha256:1387bbcc0d645263a068854884acbc7746c7f82a0742650168393e7e3f78e8cf`,
+  `proofHash:66ed0c2537374e77548ac560eb39434bf481162f3a9024a3986fbf0cc1fc0290`,
+  created `2026-06-07T14:33:20.850Z`). It exits `2` as expected with the same
+  unresolved links. The new joined row proves exact `RESOURCE_WINE` at plot
+  `4838` was a scarce-floor assignment at order `85`, while local evidence at
+  the same coordinate has final/local placed `RESOURCE_LIMESTONE` (`46`),
+  preferred plan `RESOURCE_SILK` (`13`), local scarce-floor assignment order
+  `168`, local `legalPlotCountForResource:660`, and the same
+  `targetMinPerType:7`. This is cross-resource assignment/materialization
+  divergence at one coordinate, not same-resource local Wine overacceptance.
 - Protected paths: generated outputs, official resources, unrelated worktrees.
 - Next action: classify the current unresolved links from
-  `studio-run-in-game-mq3v6xr9-4w9-current-final-surface-parity-with-resource-rejection-assignment-context.json`
+  `studio-run-in-game-mq3v6xr9-4w9-current-final-surface-parity-with-resource-rejection-local-context.json`
   by proving or rejecting the narrowed repair-owner candidates in order:
   resource local-overacceptance/scarce-floor materialization using the exact
   plot `4838` `RESOURCE_WINE` scarce-floor assignment row plus the local

--- a/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
@@ -3,13 +3,13 @@
 - [ ] 1.1 Verify exact-authorship, final-surface parity, product acceptance, and
   activated targeted repairs are closed or explicitly out of scope.
   - Current audit snapshot on
-    `codex/swooper-resource-rejection-assignment-context-rerun-record-drain`
+    `codex/swooper-resource-rejection-local-context-drain`
     verifies exact-authorship and mapgen completion are complete for request
     `studio-run-in-game-mq3v6xr9-4w9`, but final-surface parity is still
     unresolved. Refreshed parity artifact
-    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3v6xr9-4w9-current-final-surface-parity-with-resource-rejection-assignment-context.json`
-    (`sha256:d77c9c4d495be9ea048faa6a6f2f0ce667c933a74cc86b7697b5e1fe094043a9`,
-    `proofHash:0ba7fe430c77b99aae8d6b3c514a9a7fc5136990deb763e89f7203cb11568ca7`)
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3v6xr9-4w9-current-final-surface-parity-with-resource-rejection-local-context.json`
+    (`sha256:1387bbcc0d645263a068854884acbc7746c7f82a0742650168393e7e3f78e8cf`,
+    `proofHash:66ed0c2537374e77548ac560eb39434bf481162f3a9024a3986fbf0cc1fc0290`)
     remains `unresolved` with terrain, biome, feature, resource, and
     resource-coordinate proof links open. It records exact resource rejection
     numeric identity: `RESOURCE_WINE`, numeric `resourceType:16`, plot `4838`,
@@ -22,6 +22,11 @@
     rejected) and current `NATURAL_WONDER_PLACEMENT_V1` telemetry (`7`
     planned, `4` placed, `3` rejected). This narrows source-authority work but
     does not close final parity, natural-wonder repair, or product acceptance.
+    Joined local context shows the same coordinate locally placed
+    `RESOURCE_LIMESTONE` (`46`) from scarce-floor assignment order `168`, with
+    original local preferred plan `RESOURCE_SILK` (`13`), so the resource gate
+    is now classified as cross-resource assignment/materialization divergence
+    rather than same-resource local Wine overacceptance.
 - [ ] 1.2 Audit accepted P1/P2 review findings across recovery changes.
   - Current audit pass found no active review-disposition ledger inside
     `earthlike-live-feature-resource-legality-repair` or
@@ -32,7 +37,7 @@
     finding remains open inside the closure claim.
 - [ ] 1.3 Audit repo, Graphite, PR, and remote predecessor state.
   - Current repo snapshot is on
-    `codex/swooper-resource-rejection-assignment-context-rerun-record-drain`;
+    `codex/swooper-resource-rejection-local-context-drain`;
     Graphite top branch is local and stacked above the Swooper recovery drain.
     PR/remote predecessor disposition remains blocked until proof categories
     close.
@@ -49,12 +54,13 @@
 
 - [ ] 3.1 Run `git status --short --branch`.
   - Current proof-contract slice must leave
-    `codex/swooper-resource-rejection-assignment-context-rerun-record-drain`
+    `codex/swooper-resource-rejection-local-context-drain`
     clean before commit or closure.
 - [ ] 3.2 Inspect Graphite branch/stack state.
   - Current audit snapshot: top branch
-    `codex/swooper-resource-rejection-assignment-context-rerun-record-drain`
-    above `codex/swooper-resource-rejection-assignment-context-drain`,
+    `codex/swooper-resource-rejection-local-context-drain` above
+    `codex/swooper-resource-rejection-assignment-context-rerun-record-drain`,
+    `codex/swooper-resource-rejection-assignment-context-drain`,
     `codex/swooper-resource-rejection-identity-rerun-record-drain`,
     `codex/swooper-resource-rejection-proof-identity-drain`, and the current
     feature/resource/source-authority proof-record branches.

--- a/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
@@ -5,8 +5,7 @@
 - Project: Swooper recovery
 - Phase: product closure planning
 - Owner: Product/Development DRA
-- Branch/Graphite stack:
-  `codex/swooper-resource-rejection-assignment-context-rerun-record-drain`
+- Branch/Graphite stack: `codex/swooper-resource-rejection-local-context-drain`
 - Started: 2026-06-06
 - Status: blocked until proof and activated repair changes close
 
@@ -29,8 +28,9 @@
 ## Current State
 
 - Repo/Graphite state: current top branch is
+  `codex/swooper-resource-rejection-local-context-drain`, stacked above
   `codex/swooper-resource-rejection-assignment-context-rerun-record-drain`,
-  stacked above `codex/swooper-resource-rejection-assignment-context-drain`,
+  `codex/swooper-resource-rejection-assignment-context-drain`,
   `codex/swooper-resource-rejection-identity-rerun-record-drain`,
   `codex/swooper-resource-rejection-proof-identity-drain`, and the current
   Swooper proof/diagnostic drain branches.
@@ -39,11 +39,11 @@
   before commit or closure.
 - Current code evidence: exact-authorship and mapgen-completion proof are
   complete for `studio-run-in-game-mq3v6xr9-4w9`; final-surface parity remains
-  unresolved. The latest parity artifact with exact resource rejection
-  assignment context is
-  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3v6xr9-4w9-current-final-surface-parity-with-resource-rejection-assignment-context.json`
-  (`sha256:d77c9c4d495be9ea048faa6a6f2f0ce667c933a74cc86b7697b5e1fe094043a9`,
-  `proofHash:0ba7fe430c77b99aae8d6b3c514a9a7fc5136990deb763e89f7203cb11568ca7`).
+  unresolved. The latest parity artifact with exact resource rejection and
+  local assignment context is
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3v6xr9-4w9-current-final-surface-parity-with-resource-rejection-local-context.json`
+  (`sha256:1387bbcc0d645263a068854884acbc7746c7f82a0742650168393e7e3f78e8cf`,
+  `proofHash:66ed0c2537374e77548ac560eb39434bf481162f3a9024a3986fbf0cc1fc0290`).
   It preserves unresolved terrain, biome, feature, resource, and
   resource-coordinate proof links. Exact resource telemetry identifies the
   structured numeric rejected row as `RESOURCE_WINE` with `resourceType:16` at
@@ -55,8 +55,11 @@
   `targetMinPerType:7`. Exact `FEATURE_APPLY_V1` reports `1493` attempted,
   `1491` applied, and `2` `canHaveFeature` rejections. Current exact
   `NATURAL_WONDER_PLACEMENT_V1` reports `7` planned, `4` placed, and `3`
-  rejected. These narrow but do not close source-authority, natural-wonder
-  repair, final-surface parity, or product acceptance.
+  rejected. Joined local context shows the same coordinate locally placed
+  `RESOURCE_LIMESTONE` (`46`) from scarce-floor assignment order `168`, with
+  original local preferred plan `RESOURCE_SILK` (`13`). These narrow but do
+  not close source-authority, natural-wonder repair, final-surface parity, or
+  product acceptance.
 - Generated outputs affected: none expected.
 - Tests/guards affected: validation and closure audits.
 
@@ -101,8 +104,8 @@
 - Completed tasks: planning record created; current proof/Graphite audit
   snapshot recorded, including current exact feature-apply telemetry,
   natural-wonder telemetry, resource rejection numeric identity, and resource
-  rejection assignment-context proof rerun. Current top branch is a proof-record
-  slice only.
+  rejection assignment/local-context proof rerun. Current top branch is a
+  diagnostic/proof slice only.
 - Remaining tasks: final-surface parity, product acceptance, supervisor
   P1/P2 closure review, PR/remote predecessor disposition, and final Graphite
   submit/closure.
@@ -116,7 +119,7 @@
   the current exact-authorship proof.
 - Results: repo snapshot clean before this update; latest verifier artifact is
   unresolved with proof hash
-  `0ba7fe430c77b99aae8d6b3c514a9a7fc5136990deb763e89f7203cb11568ca7`;
+  `66ed0c2537374e77548ac560eb39434bf481162f3a9024a3986fbf0cc1fc0290`;
   broader review-ledger scan found historical P1/P2 entries but no active
   review ledger under the two current recovery closure changes.
 - Skipped gates and rationale: closure gates wait for proof closure.
@@ -133,10 +136,9 @@
 
 - Exact next step: continue the proof-led drain from
   `earthlike-live-feature-resource-legality-repair`, starting with
-  source-authority classification of the exact `RESOURCE_WINE` scarce-floor
-  row at plot `4838`, then current natural-wonder unsupported-footprint/
-  readback ownership, and exact `FEATURE_APPLY_V1` materialization/readback
-  ownership.
+  source-authority classification of the cross-resource scarce-floor divergence
+  at plot `4838`, then current natural-wonder unsupported-footprint/readback
+  ownership, and exact `FEATURE_APPLY_V1` materialization/readback ownership.
 - First files to inspect: recovery OpenSpec proof ledgers and Graphite branch
   state.
 - Stop condition: accepted P1/P2 findings remain open.


### PR DESCRIPTION
Adds `resourcePlacementRejectionContexts` to final-surface parity proof artifacts. When the exact authorship proof carries `RESOURCE_PLACEMENT_V1` rejection rows, each row is joined to the corresponding local evidence at the same plot index: the local resource surface value, preferred plan row (preferred resource type, offset, priority), typed placement outcome (status, resource type, observed resource type, reason), and assignment trace entry (resource type, initial/preferred resource type, assignment phase, rebalance flag, assignment order, per-type count, legal plot count, target minimum per type). The field is omitted entirely when no rejection rows are present.

The join is read-only diagnostic context. It does not introduce a new unresolved link, alter grid parity semantics, change resource planning or materialization, affect scarce-floor or ResourceBuilder policy, or affect product acceptance.

A focused regression test covers the full join: an exact rejection row for `RESOURCE_WINE` at plot `1` is matched against local preferred plan `RESOURCE_SILK`, local outcome `RESOURCE_LIMESTONE`, and a local scarce-floor assignment trace, and the assembled context is asserted field by field. The test fixture for `resourceCoordinateProof` is refactored to share the `localEvidence` object with the new `resourceRejectionContext` fixture path.

The verifier rerun on the live recovery artifact confirms the joined row at plot `4838` shows exact `RESOURCE_WINE` placed at scarce-floor order `85` while local evidence at the same coordinate has final placed `RESOURCE_LIMESTONE` (`46`), preferred plan `RESOURCE_SILK` (`13`), scarce-floor assignment order `168`, `legalPlotCountForResource:660`, and the same `targetMinPerType:7`. This classifies the resource gate as cross-resource assignment/materialization divergence rather than same-resource local Wine overacceptance.