### PR TITLE
feat(swooper-natural-wonders): bind bounded coordinate rows into placement artifact, compact rejected-row telemetry, and Studio exact-authorship proof parsing

### DIFF
--- a/apps/mapgen-studio/src/features/runInGame/status.ts
+++ b/apps/mapgen-studio/src/features/runInGame/status.ts
@@ -70,6 +70,24 @@ export type RunInGameResourcePlacementRejectionRow = Readonly<{
   targetMinPerType?: number;
 }>;
 
+export type RunInGameNaturalWonderPlacementCoordinateRow = Readonly<{
+  status: "placed" | "rejected";
+  featureType: number;
+  plotIndex: number;
+  x: number;
+  y: number;
+  direction: number;
+  elevation?: number;
+  reason: string;
+  observedFeatureType?: number;
+  observedPlotIndex?: number;
+  expectedFootprintReadback?: ReadonlyArray<Readonly<{
+    plotIndex: number;
+    observedFeatureType: number;
+  }>>;
+  expectedFootprintReadbackStatus?: "empty-expected-footprint" | "partial-expected-footprint";
+}>;
+
 export type RunInGameRequestStatus = Readonly<{
   recipeId?: string;
   seed?: number;
@@ -217,6 +235,7 @@ export type RunInGameExactAuthorshipProof = Readonly<{
         placed: Readonly<{ count: number; hash32: string }>;
         rejected?: Readonly<{ count: number; hash32: string }>;
       }>;
+      coordinateRows?: ReadonlyArray<RunInGameNaturalWonderPlacementCoordinateRow>;
     }>;
     matched: ReadonlyArray<string>;
   }>;

--- a/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
+++ b/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
@@ -443,6 +443,7 @@ function parseNaturalWonderPlacementTelemetryBetween(
       payload,
       ...(naturalWonderPlacementStats(payload) ?? {}),
       ...(naturalWonderPlacementCoordinateProof(payload) ?? {}),
+      ...(naturalWonderPlacementCoordinateRows(payload) ?? {}),
     };
   }
   return undefined;
@@ -669,6 +670,146 @@ function naturalWonderPlacementCoordinateProof(
         : { rejected: { count: rejectedCount, hash32: rejectedHash32 } }),
     },
   };
+}
+
+function naturalWonderPlacementCoordinateRows(
+  payload: Record<string, unknown>
+):
+  | {
+      coordinateRows: NonNullable<
+        NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["naturalWonderPlacement"]>["coordinateRows"]
+      >;
+    }
+  | undefined {
+  const coordinateRows = [
+    ...naturalWonderVerboseCoordinateRows(payload.coordinateRows),
+    ...naturalWonderCompactRejectedRows(payload.rejectedRows),
+  ].slice(0, 16);
+  return coordinateRows.length === 0 ? undefined : { coordinateRows };
+}
+
+function naturalWonderVerboseCoordinateRows(
+  value: unknown
+): NonNullable<
+  NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["naturalWonderPlacement"]>["coordinateRows"]
+> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((value) => {
+    if (!isRecord(value)) return [];
+    const status: "placed" | "rejected" | undefined =
+      value.status === "placed" || value.status === "rejected" ? value.status : undefined;
+    const featureType = numberValue(value.featureType);
+    const plotIndex = numberValue(value.plotIndex);
+    const x = numberValue(value.x);
+    const y = numberValue(value.y);
+    const direction = numberValue(value.direction);
+    if (
+      status === undefined ||
+      featureType === undefined ||
+      plotIndex === undefined ||
+      x === undefined ||
+      y === undefined ||
+      direction === undefined ||
+      stringValue(value.reason) === undefined
+    ) {
+      return [];
+    }
+    const elevation = numberValue(value.elevation);
+    const observedFeatureType = numberValue(value.observedFeatureType);
+    const observedPlotIndex = numberValue(value.observedPlotIndex);
+    const expectedFootprintReadback = naturalWonderFootprintReadbackRows(
+      value.expectedFootprintReadback
+    );
+    const expectedFootprintReadbackStatus = naturalWonderFootprintReadbackStatus(
+      value.expectedFootprintReadbackStatus
+    );
+    return [
+      {
+        status,
+        featureType,
+        plotIndex,
+        x,
+        y,
+        direction,
+        ...(elevation === undefined ? {} : { elevation }),
+        reason: stringValue(value.reason) as string,
+        ...(observedFeatureType === undefined ? {} : { observedFeatureType }),
+        ...(observedPlotIndex === undefined ? {} : { observedPlotIndex }),
+        ...(expectedFootprintReadback.length === 0 ? {} : { expectedFootprintReadback }),
+        ...(expectedFootprintReadbackStatus === undefined ? {} : { expectedFootprintReadbackStatus }),
+      },
+    ];
+  });
+}
+
+function naturalWonderCompactRejectedRows(
+  value: unknown
+): NonNullable<
+  NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["naturalWonderPlacement"]>["coordinateRows"]
+> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((row) => {
+    if (!Array.isArray(row)) return [];
+    const status = row[0] === "r" ? "rejected" : undefined;
+    const plotIndex = numberValue(row[1]);
+    const x = numberValue(row[2]);
+    const y = numberValue(row[3]);
+    const featureType = numberValue(row[4]);
+    const direction = numberValue(row[5]);
+    const elevation = row[6] === null ? undefined : numberValue(row[6]);
+    const reason = stringValue(row[7]);
+    const observedFeatureType = numberValue(row[8]);
+    const observedPlotIndex = numberValue(row[9]);
+    const expectedFootprintReadbackStatus = naturalWonderFootprintReadbackStatus(row[10]);
+    if (
+      status === undefined ||
+      plotIndex === undefined ||
+      x === undefined ||
+      y === undefined ||
+      featureType === undefined ||
+      direction === undefined ||
+      reason === undefined
+    ) {
+      return [];
+    }
+    return [
+      {
+        status,
+        featureType,
+        plotIndex,
+        x,
+        y,
+        direction,
+        ...(elevation === undefined ? {} : { elevation }),
+        reason,
+        ...(observedFeatureType === undefined ? {} : { observedFeatureType }),
+        ...(observedPlotIndex === undefined ? {} : { observedPlotIndex }),
+        ...(expectedFootprintReadbackStatus === undefined ? {} : { expectedFootprintReadbackStatus }),
+      },
+    ];
+  });
+}
+
+function naturalWonderFootprintReadbackRows(value: unknown): ReadonlyArray<{
+  plotIndex: number;
+  observedFeatureType: number;
+}> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!isRecord(entry)) return [];
+    const plotIndex = numberValue(entry.plotIndex);
+    const observedFeatureType = numberValue(entry.observedFeatureType);
+    if (plotIndex === undefined || observedFeatureType === undefined) return [];
+    return [{ plotIndex, observedFeatureType }];
+  }).slice(0, 8);
+}
+
+function naturalWonderFootprintReadbackStatus(
+  value: unknown
+): "empty-expected-footprint" | "partial-expected-footprint" | undefined {
+  return value === "empty-expected-footprint" || value === "partial-expected-footprint"
+    ? value
+    : undefined;
 }
 
 function resourcePlacementCoordinateProof(

--- a/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
+++ b/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
@@ -155,6 +155,9 @@ describe("Run in Game exact authorship proof identity", () => {
             rejectedCount: 1,
             rejectedHash32: "aaaaaaaa",
           },
+          rejectedRows: [
+            ["r", 1320, 60, 15, 35, 0, 120, "readback-mismatch", -1, 1405, "partial-expected-footprint"],
+          ],
         })}`,
         `[mapgen-complete] ${JSON.stringify({ requestId, configHash, envelopeHash, seed: 42, dimensions: { width: 84, height: 54 } })}`,
       ].join("\n"),
@@ -244,6 +247,21 @@ describe("Run in Game exact authorship proof identity", () => {
         placed: { count: 6, hash32: "3c3530cb" },
         rejected: { count: 1, hash32: "aaaaaaaa" },
       },
+      coordinateRows: [
+        {
+          status: "rejected",
+          featureType: 35,
+          plotIndex: 1320,
+          x: 60,
+          y: 15,
+          direction: 0,
+          elevation: 120,
+          reason: "readback-mismatch",
+          observedFeatureType: -1,
+          observedPlotIndex: 1405,
+          expectedFootprintReadbackStatus: "partial-expected-footprint",
+        },
+      ],
     });
     expect(parseSwooperMapgenLogProof({
       text: `[mapgen-proof] ${JSON.stringify({ requestId, configHash, envelopeHash, seed: 41, dimensions: { width: 84, height: 54 } })}`,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
@@ -151,6 +151,41 @@ const NaturalWonderPlacementCoordinateProofSchema = Type.Object(
   }
 );
 
+const NaturalWonderFootprintReadbackSchema = Type.Object(
+  {
+    plotIndex: Type.Integer({ minimum: 0 }),
+    observedFeatureType: Type.Integer(),
+  },
+  { additionalProperties: false }
+);
+
+const NaturalWonderPlacementCoordinateRowSchema = Type.Object(
+  {
+    status: Type.Union([Type.Literal("placed"), Type.Literal("rejected")]),
+    plotIndex: Type.Integer({ minimum: 0 }),
+    x: Type.Integer(),
+    y: Type.Integer(),
+    featureType: Type.Integer(),
+    direction: Type.Integer(),
+    elevation: Type.Optional(Type.Integer()),
+    reason: Type.String(),
+    observedFeatureType: Type.Optional(Type.Integer()),
+    observedPlotIndex: Type.Optional(Type.Integer({ minimum: 0 })),
+    expectedFootprintReadback: Type.Optional(Type.Array(NaturalWonderFootprintReadbackSchema)),
+    expectedFootprintReadbackStatus: Type.Optional(
+      Type.Union([
+        Type.Literal("empty-expected-footprint"),
+        Type.Literal("partial-expected-footprint"),
+      ])
+    ),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Bounded natural-wonder placement row identity for exact/local proof comparison.",
+  }
+);
+
 const NaturalWonderPlacementArtifactSchema = Type.Object(
   {
     plannedCount: Type.Integer({ minimum: 0 }),
@@ -162,6 +197,7 @@ const NaturalWonderPlacementArtifactSchema = Type.Object(
     shortfallCount: Type.Integer({ minimum: 0 }),
     rejectionExamples: Type.Array(Type.String()),
     coordinateProof: NaturalWonderPlacementCoordinateProofSchema,
+    coordinateRows: Type.Array(NaturalWonderPlacementCoordinateRowSchema),
   },
   {
     additionalProperties: false,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.ts
@@ -30,6 +30,21 @@ export type NaturalWonderPlacementCoordinateProof = {
   rejected: NaturalWonderPlacementCoordinateDigest;
 };
 
+export type NaturalWonderPlacementCoordinateRow = {
+  status: "placed" | "rejected";
+  plotIndex: number;
+  x: number;
+  y: number;
+  featureType: number;
+  direction: number;
+  elevation?: number;
+  reason: string;
+  observedFeatureType?: number;
+  observedPlotIndex?: number;
+  expectedFootprintReadback?: NaturalWonderFootprintReadback[];
+  expectedFootprintReadbackStatus?: NaturalWonderFootprintReadbackStatus;
+};
+
 export type NaturalWonderStampingStats = {
   plannedCount: number;
   targetCount: number;
@@ -40,6 +55,7 @@ export type NaturalWonderStampingStats = {
   shortfallCount: number;
   rejectionExamples: string[];
   coordinateProof: NaturalWonderPlacementCoordinateProof;
+  coordinateRows: NaturalWonderPlacementCoordinateRow[];
 };
 
 export type NaturalWonderPlacementRuntimeTelemetry = {
@@ -53,6 +69,7 @@ export type NaturalWonderPlacementRuntimeTelemetry = {
   shortfallCount: number;
   rejectionExampleCount: number;
   rejectionExamples: string[];
+  rejectedRows: NaturalWonderPlacementRuntimeRejectedRow[];
   coordinateProof: {
     version: 1;
     placedCount: number;
@@ -61,6 +78,20 @@ export type NaturalWonderPlacementRuntimeTelemetry = {
     rejectedHash32?: string;
   };
 };
+
+export type NaturalWonderPlacementRuntimeRejectedRow = readonly [
+  status: "r",
+  plotIndex: number,
+  x: number,
+  y: number,
+  featureType: number,
+  direction: number,
+  elevation: number | null,
+  reason: string,
+  observedFeatureType: number | null,
+  observedPlotIndex: number | null,
+  expectedFootprintReadbackStatus: NaturalWonderFootprintReadbackStatus | null,
+];
 
 const FEATURE_VALID_TERRAIN_TYPE_INDICES = CIV7_BROWSER_TABLES_V0.featureValidTerrainTypeIndices as
   Record<string, readonly number[] | undefined>;
@@ -71,19 +102,6 @@ const FEATURE_POLICIES = CIV7_BROWSER_TABLES_V0.featurePolicies as Record<
 >;
 const FNV1A_32_OFFSET = 0x811c9dc5;
 const FNV1A_32_PRIME = 0x01000193;
-type NaturalWonderPlacementCoordinateRow = {
-  status: "placed" | "rejected";
-  plotIndex: number;
-  x: number;
-  y: number;
-  featureType: number;
-  direction: number;
-  reason: string;
-  observedFeatureType?: number;
-  observedPlotIndex?: number;
-  expectedFootprintReadback?: NaturalWonderFootprintReadback[];
-  expectedFootprintReadbackStatus?: NaturalWonderFootprintReadbackStatus;
-};
 
 function hash32Hex(input: string): string {
   let hash = FNV1A_32_OFFSET;
@@ -280,6 +298,7 @@ export function stampNaturalWondersFromPlan({
         y: -1,
         featureType: Number.isFinite(placementPlan.featureType) ? Math.trunc(placementPlan.featureType) : -1,
         direction: Number.isFinite(placementPlan.direction) ? Math.trunc(placementPlan.direction) : -1,
+        ...(Number.isFinite(placementPlan.elevation) ? { elevation: Math.trunc(placementPlan.elevation) } : {}),
         reason: "out-of-bounds",
       });
       continue;
@@ -298,6 +317,9 @@ export function stampNaturalWondersFromPlan({
 
     const featureType = Math.trunc(placementPlan.featureType);
     const direction = Math.trunc(placementPlan.direction);
+    const plannedElevation = Number.isFinite(placementPlan.elevation)
+      ? Math.trunc(placementPlan.elevation)
+      : undefined;
     const y = (plotIndex / width) | 0;
     const x = plotIndex - y * width;
     const footprint = getNaturalWonderFootprintIndices({
@@ -311,7 +333,16 @@ export function stampNaturalWondersFromPlan({
     if (!footprint) {
       rejectedCount += 1;
       rejectionDetails.push(`feature=${featureType} plot=${plotIndex} reason=unsupported-footprint`);
-      coordinateRows.push({ status: "rejected", plotIndex, x, y, featureType, direction, reason: "unsupported-footprint" });
+      coordinateRows.push({
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        featureType,
+        direction,
+        ...(plannedElevation === undefined ? {} : { elevation: plannedElevation }),
+        reason: "unsupported-footprint",
+      });
       continue;
     }
     let footprintBlocked = false;
@@ -335,7 +366,16 @@ export function stampNaturalWondersFromPlan({
     if (footprintBlocked) {
       rejectedCount += 1;
       rejectionDetails.push(`feature=${featureType} plot=${plotIndex} reason=${blockedReason}`);
-      coordinateRows.push({ status: "rejected", plotIndex, x, y, featureType, direction, reason: blockedReason });
+      coordinateRows.push({
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        featureType,
+        direction,
+        ...(plannedElevation === undefined ? {} : { elevation: plannedElevation }),
+        reason: blockedReason,
+      });
       continue;
     }
     const outcome: NaturalWonderPlacementOutcome = adapter.placeNaturalWonder(
@@ -367,6 +407,7 @@ export function stampNaturalWondersFromPlan({
         y,
         featureType,
         direction,
+        ...(outcome.elevation === undefined ? {} : { elevation: Math.trunc(outcome.elevation) }),
         reason: outcome.reason,
         ...(outcome.observedPlotIndex === undefined ? {} : { observedPlotIndex: outcome.observedPlotIndex }),
         ...(outcome.observedFeatureType === undefined ? {} : { observedFeatureType: outcome.observedFeatureType }),
@@ -391,10 +432,28 @@ export function stampNaturalWondersFromPlan({
     if (readbackMismatch) {
       rejectedCount += 1;
       rejectionDetails.push(`feature=${featureType} plot=${plotIndex} reason=readback-mismatch`);
-      coordinateRows.push({ status: "rejected", plotIndex, x, y, featureType, direction, reason: "readback-mismatch" });
+      coordinateRows.push({
+        status: "rejected",
+        plotIndex,
+        x,
+        y,
+        featureType,
+        direction,
+        ...(outcome.elevation === undefined ? {} : { elevation: Math.trunc(outcome.elevation) }),
+        reason: "readback-mismatch",
+      });
     } else {
       placedCount += 1;
-      coordinateRows.push({ status: "placed", plotIndex, x, y, featureType, direction, reason: "placed" });
+      coordinateRows.push({
+        status: "placed",
+        plotIndex,
+        x,
+        y,
+        featureType,
+        direction,
+        ...(outcome.elevation === undefined ? {} : { elevation: Math.trunc(outcome.elevation) }),
+        reason: "placed",
+      });
     }
   }
 
@@ -408,6 +467,7 @@ export function stampNaturalWondersFromPlan({
     shortfallCount,
     rejectionExamples: rejectionDetails.slice(0, 8),
     coordinateProof: naturalWonderCoordinateProof(coordinateRows),
+    coordinateRows,
   };
 }
 
@@ -443,6 +503,9 @@ export function normalizeNaturalWonderStampingStats(
   const coordinateProof = normalizeNaturalWonderCoordinateProof(
     (stats as { coordinateProof?: unknown }).coordinateProof
   );
+  const coordinateRows = normalizeNaturalWonderCoordinateRows(
+    (stats as { coordinateRows?: unknown }).coordinateRows
+  );
   return {
     plannedCount,
     targetCount,
@@ -453,6 +516,7 @@ export function normalizeNaturalWonderStampingStats(
     shortfallCount,
     rejectionExamples,
     coordinateProof,
+    coordinateRows,
   };
 }
 
@@ -486,6 +550,103 @@ function normalizeNaturalWonderCoordinateDigest(
   return { count, hash32 };
 }
 
+function normalizeNaturalWonderCoordinateRows(value: unknown): NaturalWonderPlacementCoordinateRow[] {
+  if (!Array.isArray(value)) return [];
+  const rows: NaturalWonderPlacementCoordinateRow[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as Partial<NaturalWonderPlacementCoordinateRow>;
+    if (record.status !== "placed" && record.status !== "rejected") continue;
+    const plotIndex = normalizeInteger(record.plotIndex);
+    const x = normalizeInteger(record.x);
+    const y = normalizeInteger(record.y);
+    const featureType = normalizeInteger(record.featureType);
+    const direction = normalizeInteger(record.direction);
+    if (
+      plotIndex === undefined ||
+      x === undefined ||
+      y === undefined ||
+      featureType === undefined ||
+      direction === undefined ||
+      typeof record.reason !== "string" ||
+      record.reason.length === 0
+    ) {
+      continue;
+    }
+    const elevation = normalizeInteger(record.elevation);
+    const observedFeatureType = normalizeInteger(record.observedFeatureType);
+    const observedPlotIndex = normalizeInteger(record.observedPlotIndex);
+    const expectedFootprintReadback = normalizeNaturalWonderFootprintReadback(
+      record.expectedFootprintReadback
+    );
+    const expectedFootprintReadbackStatus = normalizeNaturalWonderFootprintReadbackStatus(
+      record.expectedFootprintReadbackStatus
+    );
+    rows.push({
+      status: record.status,
+      plotIndex,
+      x,
+      y,
+      featureType,
+      direction,
+      ...(elevation === undefined ? {} : { elevation }),
+      reason: record.reason,
+      ...(observedFeatureType === undefined ? {} : { observedFeatureType }),
+      ...(observedPlotIndex === undefined ? {} : { observedPlotIndex }),
+      ...(expectedFootprintReadback === undefined ? {} : { expectedFootprintReadback }),
+      ...(expectedFootprintReadbackStatus === undefined ? {} : { expectedFootprintReadbackStatus }),
+    });
+  }
+  return rows;
+}
+
+function normalizeNaturalWonderFootprintReadback(
+  value: unknown
+): NaturalWonderFootprintReadback[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const rows = value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const record = entry as Partial<NaturalWonderFootprintReadback>;
+    const plotIndex = normalizeInteger(record.plotIndex);
+    const observedFeatureType = normalizeInteger(record.observedFeatureType);
+    if (plotIndex === undefined || observedFeatureType === undefined) return [];
+    return [{ plotIndex, observedFeatureType }];
+  });
+  return rows.length > 0 ? rows : undefined;
+}
+
+function normalizeNaturalWonderFootprintReadbackStatus(
+  value: unknown
+): NaturalWonderFootprintReadbackStatus | undefined {
+  return value === "empty-expected-footprint" || value === "partial-expected-footprint"
+    ? value
+    : undefined;
+}
+
+function normalizeInteger(value: unknown): number | undefined {
+  return Number.isFinite(value) ? Math.trunc(value as number) : undefined;
+}
+
+function buildNaturalWonderRuntimeRejectedRows(
+  rows: readonly NaturalWonderPlacementCoordinateRow[]
+): NaturalWonderPlacementRuntimeRejectedRow[] {
+  return rows
+    .filter((row) => row.status === "rejected")
+    .map((row) => [
+      "r",
+      row.plotIndex,
+      row.x,
+      row.y,
+      row.featureType,
+      row.direction,
+      row.elevation ?? null,
+      row.reason,
+      row.observedFeatureType ?? null,
+      row.observedPlotIndex ?? null,
+      row.expectedFootprintReadbackStatus ?? null,
+    ]);
+}
+
 export function buildNaturalWonderPlacementRuntimeTelemetry(
   stats: DeepReadonly<NaturalWonderStampingStats>
 ): NaturalWonderPlacementRuntimeTelemetry {
@@ -501,6 +662,7 @@ export function buildNaturalWonderPlacementRuntimeTelemetry(
     shortfallCount: normalized.shortfallCount,
     rejectionExampleCount: normalized.rejectionExamples.length,
     rejectionExamples: normalized.rejectionExamples,
+    rejectedRows: buildNaturalWonderRuntimeRejectedRows(normalized.coordinateRows),
     coordinateProof: {
       version: normalized.coordinateProof.version,
       placedCount: normalized.coordinateProof.placed.count,

--- a/mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts
+++ b/mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts
@@ -15,6 +15,16 @@ import {
 } from "../../src/recipes/standard/stages/placement/steps/place-natural-wonders/materialize.js";
 
 const { biomeGlobals, featureTypes } = CIV7_BROWSER_TABLES_V0;
+const redwoodRow = {
+  status: "placed",
+  plotIndex: 9,
+  x: 1,
+  y: 2,
+  featureType: featureTypes.FEATURE_REDWOOD_FOREST,
+  direction: -1,
+  elevation: 120,
+  reason: "placed",
+} as const;
 
 function oneWonderPlan(featureType: number, plotIndex: number, width = 4, height = 6) {
   return {
@@ -63,6 +73,7 @@ describe("natural wonder placement materialization", () => {
         placed: { count: 1, hash32: "deae8452" },
         rejected: { count: 0, hash32: "811c9dc5" },
       },
+      coordinateRows: [redwoodRow],
       plannedCount: 1,
       targetCount: 1,
       placedCount: 1,
@@ -136,6 +147,7 @@ describe("natural wonder placement materialization", () => {
       shortfallCount: 1,
       rejectionExampleCount: 0,
       rejectionExamples: [],
+      rejectedRows: [],
       coordinateProof: {
         version: 1,
         placedCount: 1,
@@ -146,7 +158,7 @@ describe("natural wonder placement materialization", () => {
       `[SWOOPER_MOD] NATURAL_WONDER_PLACEMENT_V1 ${JSON.stringify(
         buildNaturalWonderPlacementRuntimeTelemetry(stats)
       )}`.length
-    ).toBeLessThan(900);
+    ).toBeLessThan(1400);
   });
 
   it("records adapter legality rejection as a degraded outcome", () => {
@@ -243,6 +255,21 @@ describe("natural wonder placement materialization", () => {
       rejectionExampleCount: 1,
       rejectionExamples: [
         "feature=35 plot=17 direction=-1 elevation=120 reason=readback-mismatch observedPlot=23 observedFeature=-1 footprint=17:35,23:-1,18:35 readback=partial-expected-footprint",
+      ],
+      rejectedRows: [
+        [
+          "r",
+          17,
+          2,
+          3,
+          featureTypes.FEATURE_KILIMANJARO,
+          -1,
+          120,
+          "readback-mismatch",
+          -1,
+          23,
+          "partial-expected-footprint",
+        ],
       ],
       coordinateProof: {
         rejectedCount: 1,

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -514,6 +514,42 @@
     assignment versus stateful Civ materialization/readback. It does not
     authorize resource tuning, public config changes, static ResourceBuilder
     policy changes, final-surface parity, or product acceptance.
+- [x] 2.55 Bind bounded natural-wonder coordinate rows into future exact-authorship
+  proof packets.
+  - Current proof-contract slice adds verbose `coordinateRows` to the
+    natural-wonder placement artifact, compact rejected-row tuples to
+    `NATURAL_WONDER_PLACEMENT_V1` runtime telemetry, and expanded
+    `coordinateRows` to Studio exact-authorship parsing. Rows carry status,
+    feature type, plot/x/y, direction, elevation where known, reason, and
+    bounded readback context for rejected rows without exceeding Civ's log
+    line cap.
+  - This is proof instrumentation only. It does not change natural-wonder
+    planning, placement, readback disposition, final-surface parity, product
+    acceptance, resource behavior, feature behavior, or terrain behavior. A
+    fresh exact-authored run must consume this row contract before the
+    remaining exact/local natural-wonder plan divergence can be source-owned
+    or dispositioned.
+- [x] 2.56 Preserve current exact-authored natural-wonder rejected-row proof.
+  - Fresh compact exact request `studio-run-in-game-mq3yo4uq-20js` completed
+    with no exact-authorship unresolved links after consuming the compact
+    rejected-row telemetry contract. POST artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-row-proof-compact-post.json`
+    has `sha256:f603328fb9f966cb7f214ae1347e989576e7b2dc11bcbb0339d45bdaf126ac01`;
+    terminal status artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-row-proof-compact-status.json`
+    has `sha256:fe96ff90b76ae4b4b8aa190578b81babf4c2f684e156290aa700be0a93ae6e82`.
+  - Exact `NATURAL_WONDER_PLACEMENT_V1` remains `7` planned / `5` placed /
+    `2` rejected. Studio exact-authorship now preserves parsed
+    `coordinateRows` for the two rejected rows: feature `30` at plot `4130`
+    (`x=102`, `y=38`, observed missing plot `4237`) and feature `36` at plot
+    `1785` (`x=89`, `y=16`, observed missing plot `1892`), both
+    `readback-mismatch` with `partial-expected-footprint`.
+  - Current local replay in the same parity artifact plans feature `30` at
+    plot `1342` and feature `36` at plot `2065`, and locally places all `7`
+    natural wonders. This proves the remaining natural-wonder blocker is not
+    just a post-write footprint readback row; it also includes exact/local
+    plan-input or engine-surface divergence that must be source-owned before
+    behavior repair.
 
 ## 3. Verification
 
@@ -698,3 +734,25 @@
   - Verifier log:
     `/tmp/civ7-recovery-proof/final-surface-parity/verify-resource-delta-feasibility-mq3v6xr9-local-context.log`
     (`sha256:014a6f2ceb3f051f393b7fb62579e8de99f3f548056b8c49e05c92caae8491c0`).
+- [x] 3.26 Run focused natural-wonder coordinate-row proof regressions.
+  - Passed `bun test
+    mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts
+    apps/mapgen-studio/test/runInGame/proofIdentity.test.ts`.
+  - Passed owner checks `bun run --cwd mods/mod-swooper-maps check` and
+    `bun run --cwd apps/mapgen-studio check`.
+- [x] 3.27 Re-run current exact-authored final-surface parity after
+  natural-wonder rejected-row proof parsing.
+  - Verifier input request `studio-run-in-game-mq3yo4uq-20js` wrote
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3yo4uq-20js-current-final-surface-parity-with-natural-wonder-rows.json`
+    (`sha256:b1d7033ef3b8b9e7cf55407ab9cf854dac331ac68953d568515ff19dda91923e`,
+    `proofHash:4abcfde0e6a242395611586e501d6b872b1943d6a3c45f6e09d38c8ffb430a46`,
+    created `2026-06-07T15:55:39.210Z`).
+  - The verifier exited `2` as expected for unresolved parity. It preserves
+    unchanged unresolved links: `resource-placement-coordinate-proof.placed`,
+    `resource-placement-coordinate-proof.rejected`, `surface.biome.mismatch`,
+    `surface.feature.mismatch`, `surface.resource.mismatch`, and
+    `surface.terrain.mismatch`. Mismatch counts are terrain `140`, biome
+    `874`, feature `376`, and resource `307`.
+  - Verifier log:
+    `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq3yo4uq-natural-wonder-rows.log`
+    (`sha256:82d75d59305815f64b4f775a2128bb6e8327f3ae120c4ab347dbd2136022dade`).

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,6 +6,7 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
+  `codex/swooper-natural-wonder-row-proof-drain`, stacked above
   `codex/swooper-natural-wonder-supported-catalog-drain`, stacked above
   `codex/swooper-resource-delta-feasibility-current-record-drain`, stacked
   above `codex/swooper-resource-rejection-local-context-drain`,
@@ -50,6 +51,24 @@
   rejections and two remaining `readback-mismatch` rows. The verifier artifact
   remains unresolved with proof hash
   `ea9a8d88f8fbbe7b86d1b06f1f5893acaf579b46ddf534ae9a5f328277fdc5ee`.
+  Current follow-on proof-contract branch
+  `codex/swooper-natural-wonder-row-proof-drain` exposes bounded
+  natural-wonder row identity through verbose local placement artifact rows,
+  compact `NATURAL_WONDER_PLACEMENT_V1` rejected-row telemetry, and expanded
+  Studio exact-authorship `coordinateRows`. This gives the next exact run
+  inspectable natural-wonder rejected-row identity without exceeding Civ's log
+  line cap; it does not change behavior, close final parity, or claim product
+  acceptance. Fresh exact request `studio-run-in-game-mq3yo4uq-20js`
+  consumed the compact row contract and preserves exact rejected rows for
+  feature `30` at plot `4130` and feature `36` at plot `1785`, both
+  `readback-mismatch` with `partial-expected-footprint`. The verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3yo4uq-20js-current-final-surface-parity-with-natural-wonder-rows.json`
+  (`sha256:b1d7033ef3b8b9e7cf55407ab9cf854dac331ac68953d568515ff19dda91923e`,
+  `proofHash:4abcfde0e6a242395611586e501d6b872b1943d6a3c45f6e09d38c8ffb430a46`)
+  remains unresolved. Local replay in that artifact plans feature `30` at
+  plot `1342` and feature `36` at plot `2065`, so the next natural-wonder
+  source decision must account for exact/local plan-input or engine-surface
+  divergence before treating readback mismatch as a narrow post-write repair.
   Resource, feature, natural-wonder, and terrain source-authority
   classification remains the active work; product acceptance is not closed.
   Current resource-delta feasibility after the exact/local rejection join now
@@ -1336,6 +1355,19 @@
   `studio-run-in-game-mq3x46sy-20js` confirms the unsupported-footprint rows
   are gone and leaves only natural-wonder readback-mismatch rows:
   `feature=30` at plot `4130` and `feature=36` at plot `1785`.
+  Current proof-contract branch
+  `codex/swooper-natural-wonder-row-proof-drain` adds bounded
+  `coordinateRows` to the local natural-wonder placement artifact, compact
+  rejected-row tuples to runtime telemetry, and expanded `coordinateRows` to
+  Studio exact-authorship proof parsing so the next exact run can compare
+  exact and local natural-wonder rejected-row identity directly instead of
+  inferring from aggregate counts, hashes, and rejection examples. Fresh
+  request `studio-run-in-game-mq3yo4uq-20js` now preserves those exact rows:
+  feature `30` rejected at plot `4130`, and feature `36` rejected at plot
+  `1785`. Local replay plans those same feature types at plots `1342` and
+  `2065` and places all `7`, so the remaining natural-wonder proof target is
+  exact/local plan-input or engine-surface divergence plus post-write partial
+  footprint readback, not a simple missing supported-catalog row.
   Final-surface parity remains open on terrain (`140` mismatches), biome
   (`874`), feature (`376`), resource (`307`), natural-wonder readback proof,
   resource coordinate proof, and any future owner-classified residual links.

--- a/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
@@ -51,6 +51,26 @@
     `proofHash:ea9a8d88f8fbbe7b86d1b06f1f5893acaf579b46ddf534ae9a5f328277fdc5ee`)
     remains unresolved with terrain, biome, feature, resource, and resource
     coordinate proof links still open.
+    Follow-on branch `codex/swooper-natural-wonder-row-proof-drain` is a
+    proof-contract slice for the next exact run: it exposes bounded
+    natural-wonder row identity through placement artifact `coordinateRows`,
+    compact runtime rejected-row telemetry, and expanded Studio
+    exact-authorship `coordinateRows`. It does not close natural-wonder
+    readback mismatch, exact/local natural-wonder plan divergence,
+    final-surface parity, product acceptance, or any resource / feature /
+    terrain claim.
+    Fresh exact request `studio-run-in-game-mq3yo4uq-20js` consumes the row
+    contract and preserves exact natural-wonder rejected rows: feature `30` at
+    plot `4130` and feature `36` at plot `1785`, both
+    `readback-mismatch` with `partial-expected-footprint`. The corresponding
+    final-surface verifier artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3yo4uq-20js-current-final-surface-parity-with-natural-wonder-rows.json`
+    (`sha256:b1d7033ef3b8b9e7cf55407ab9cf854dac331ac68953d568515ff19dda91923e`,
+    `proofHash:4abcfde0e6a242395611586e501d6b872b1943d6a3c45f6e09d38c8ffb430a46`)
+    remains unresolved. Local replay in that same artifact plans feature `30`
+    at plot `1342` and feature `36` at plot `2065`, so natural-wonder closure
+    is blocked on source-owning exact/local plan-input or engine-surface
+    divergence before behavior repair.
 - [ ] 1.2 Audit accepted P1/P2 review findings across recovery changes.
   - Current audit pass found no active review-disposition ledger inside
     `earthlike-live-feature-resource-legality-repair` or
@@ -89,8 +109,9 @@
     `codex/swooper-resource-rejection-identity-rerun-record-drain`,
     `codex/swooper-resource-rejection-proof-identity-drain`, and the current
     feature/resource/source-authority proof-record branches.
-  - Follow-on implementation branch:
-    `codex/swooper-natural-wonder-supported-catalog-drain`.
+  - Follow-on implementation branches:
+    `codex/swooper-natural-wonder-supported-catalog-drain`, then
+    `codex/swooper-natural-wonder-row-proof-drain`.
 - [ ] 3.3 Run `git diff --check`.
 - [ ] 3.4 Run `bun run openspec -- validate swooper-recovery-stack-product-closure --strict`.
 - [ ] 3.5 Run `bun run openspec:validate`.

--- a/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
@@ -6,7 +6,7 @@
 - Phase: product closure planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack:
-  `codex/swooper-natural-wonder-supported-catalog-drain`
+  `codex/swooper-natural-wonder-row-proof-drain`
 - Started: 2026-06-06
 - Status: blocked until proof and activated repair changes close
 
@@ -78,7 +78,23 @@
   changed: exact authorship completed with no unresolved exact links, and
   natural-wonder telemetry is `7` planned / `5` placed / `2` rejected, with the
   two previous unsupported-footprint rejections gone. Final-surface parity and
-  product acceptance remain open.
+  product acceptance remain open. Current follow-on proof-contract branch
+  `codex/swooper-natural-wonder-row-proof-drain` exposes bounded
+  natural-wonder row identity through local placement artifact
+  `coordinateRows`, compact runtime rejected-row telemetry, and expanded
+  Studio exact-authorship `coordinateRows`. It is not a behavior repair or
+  closure claim. Fresh exact request `studio-run-in-game-mq3yo4uq-20js`
+  consumed the row contract and preserves exact rejected rows for feature `30`
+  at plot `4130` and feature `36` at plot `1785`, both
+  `readback-mismatch` with `partial-expected-footprint`. The final-surface
+  verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3yo4uq-20js-current-final-surface-parity-with-natural-wonder-rows.json`
+  (`sha256:b1d7033ef3b8b9e7cf55407ab9cf854dac331ac68953d568515ff19dda91923e`,
+  `proofHash:4abcfde0e6a242395611586e501d6b872b1943d6a3c45f6e09d38c8ffb430a46`)
+  remains unresolved. Local replay in that artifact plans feature `30` at
+  plot `1342` and feature `36` at plot `2065`, so the next natural-wonder
+  decision is exact/local plan-input or engine-surface divergence before any
+  further readback behavior repair.
 - Generated outputs affected: none expected.
 - Tests/guards affected: validation and closure audits.
 
@@ -169,11 +185,13 @@
 
 ## Next Action
 
-- Exact next step: run strict OpenSpec/git checks and amend this bounded
-  natural-wonder source repair with the fresh proof record. Then continue the
-  remaining queue: natural-wonder readback-mismatch ownership, cross-resource
-  scarce-floor divergence at plot `4838`, and exact `FEATURE_APPLY_V1`
-  materialization/readback ownership.
+- Exact next step: classify why exact natural-wonder planning/materialization
+  rejects feature `30` at plot `4130` and feature `36` at plot `1785` while
+  local replay plans those feature types at plots `1342` and `2065` and places
+  all `7`. Do not repair readback behavior until that exact/local plan-input
+  or engine-surface divergence is source-owned. Then continue the remaining
+  queue: cross-resource scarce-floor divergence at plot `4838`, and exact
+  `FEATURE_APPLY_V1` materialization/readback ownership.
 - First files to inspect: recovery OpenSpec proof ledgers and Graphite branch
   state.
 - Stop condition: accepted P1/P2 findings remain open.


### PR DESCRIPTION
Adds bounded natural-wonder placement coordinate rows to the proof contract so that exact and local rejected-row identity can be compared directly rather than inferred from aggregate counts, hashes, and rejection examples.

**What changed**

- Introduces `NaturalWonderPlacementCoordinateRow` as a shared exported type carrying `status`, `plotIndex`, `x`, `y`, `featureType`, `direction`, optional `elevation`, `reason`, and optional readback context fields (`observedFeatureType`, `observedPlotIndex`, `expectedFootprintReadback`, `expectedFootprintReadbackStatus`).
- `stampNaturalWondersFromPlan` now propagates `elevation` into every coordinate row path (out-of-bounds, unsupported-footprint, footprint-blocked, readback-mismatch, and placed), and the resulting `coordinateRows` array is included in the returned `NaturalWonderStampingStats`.
- Adds `NaturalWonderPlacementRuntimeRejectedRow` as a compact tuple type (`"r"`, plotIndex, x, y, featureType, direction, elevation|null, reason, observedFeatureType|null, observedPlotIndex|null, footprintReadbackStatus|null). `buildNaturalWonderPlacementRuntimeTelemetry` now emits `rejectedRows` using this compact format so rejected-row identity fits within Civ's log-line cap.
- Adds `NaturalWonderPlacementCoordinateRowSchema` and `NaturalWonderFootprintReadbackSchema` TypeBox schemas, and includes `coordinateRows` in `NaturalWonderPlacementArtifactSchema`.
- Studio proof parsing gains `naturalWonderPlacementCoordinateRows`, which merges verbose `coordinateRows` and compact `rejectedRows` from telemetry payloads (capped at 16 rows) into the `coordinateRows` field on `RunInGameExactAuthorshipProof`. The `RunInGameNaturalWonderPlacementCoordinateRow` type is added to the status module.
- Normalization helpers (`normalizeNaturalWonderCoordinateRows`, `normalizeNaturalWonderFootprintReadback`, `normalizeNaturalWonderFootprintReadbackStatus`, `normalizeInteger`) are added to keep deserialized rows well-typed and bounded.
- Test fixtures updated to assert the new `coordinateRows` on stamping stats, `rejectedRows` on runtime telemetry, and parsed `coordinateRows` in Studio proof identity. The telemetry log-line length budget is raised from 900 to 1400 bytes to account for the added rejected-row tuples.

This is proof instrumentation only. It does not change natural-wonder planning, placement decisions, readback disposition, final-surface parity, or product acceptance.