### PR TITLE
feat(run-in-game): add NATURAL_WONDER_PLAN_V1 runtime telemetry and exact-authorship plan-row parsing

### DIFF
--- a/apps/mapgen-studio/src/features/runInGame/status.ts
+++ b/apps/mapgen-studio/src/features/runInGame/status.ts
@@ -88,6 +88,16 @@ export type RunInGameNaturalWonderPlacementCoordinateRow = Readonly<{
   expectedFootprintReadbackStatus?: "empty-expected-footprint" | "partial-expected-footprint";
 }>;
 
+export type RunInGameNaturalWonderPlanRow = Readonly<{
+  plotIndex: number;
+  x: number;
+  y: number;
+  featureType: number;
+  direction: number;
+  elevation?: number;
+  priorityPpm?: number;
+}>;
+
 export type RunInGameRequestStatus = Readonly<{
   recipeId?: string;
   seed?: number;
@@ -214,6 +224,21 @@ export type RunInGameExactAuthorshipProof = Readonly<{
         rejected?: Readonly<{ count: number; hash32: string }>;
         mismatch?: Readonly<{ count: number; hash32: string }>;
       }>;
+    }>;
+    naturalWonderPlan?: Readonly<{
+      marker: "NATURAL_WONDER_PLAN_V1";
+      payload: unknown;
+      stats?: Readonly<{
+        version: number;
+        wondersCount: number;
+        targetCount: number;
+        plannedCount: number;
+      }>;
+      coordinateProof?: Readonly<{
+        version: number;
+        planned: Readonly<{ count: number; hash32: string }>;
+      }>;
+      planRows?: ReadonlyArray<RunInGameNaturalWonderPlanRow>;
     }>;
     naturalWonderPlacement?: Readonly<{
       marker: "NATURAL_WONDER_PLACEMENT_V1";

--- a/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
+++ b/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
@@ -241,6 +241,11 @@ export function parseSwooperMapgenLogProof(args: {
     proofLine.index,
     completionLine.index
   );
+  const naturalWonderPlan = parseNaturalWonderPlanTelemetryBetween(
+    lines,
+    proofLine.index,
+    completionLine.index
+  );
   const naturalWonderPlacement = parseNaturalWonderPlacementTelemetryBetween(
     lines,
     proofLine.index,
@@ -264,6 +269,7 @@ export function parseSwooperMapgenLogProof(args: {
     completionPayload,
     ...(featureApply ? { featureApply } : {}),
     ...(resourcePlacement ? { resourcePlacement } : {}),
+    ...(naturalWonderPlan ? { naturalWonderPlan } : {}),
     ...(naturalWonderPlacement ? { naturalWonderPlacement } : {}),
     matched: ["[mapgen-proof]", args.requestId, args.configHash, args.envelopeHash, "[mapgen-complete]"],
   };
@@ -449,6 +455,27 @@ function parseNaturalWonderPlacementTelemetryBetween(
   return undefined;
 }
 
+function parseNaturalWonderPlanTelemetryBetween(
+  lines: readonly string[],
+  proofIndex: number,
+  completionIndex: number
+): NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["naturalWonderPlan"]> | undefined {
+  for (let index = completionIndex - 1; index > proofIndex; index -= 1) {
+    const line = lines[index] ?? "";
+    if (!line.includes("NATURAL_WONDER_PLAN_V1")) continue;
+    const payload = parsePayloadAfterMarker(line, "NATURAL_WONDER_PLAN_V1");
+    if (!payload) continue;
+    return {
+      marker: "NATURAL_WONDER_PLAN_V1",
+      payload,
+      ...(naturalWonderPlanStats(payload) ?? {}),
+      ...(naturalWonderPlanCoordinateProof(payload) ?? {}),
+      ...(naturalWonderPlanRows(payload) ?? {}),
+    };
+  }
+  return undefined;
+}
+
 function featureApplyStats(
   payload: Record<string, unknown>
 ):
@@ -477,6 +504,37 @@ function featureApplyStats(
       ...countRecordField(payload, "attemptedByFeature"),
       ...countRecordField(payload, "appliedByFeature"),
       ...countRecordField(payload, "rejectedCanHaveFeatureByFeature"),
+    },
+  };
+}
+
+function naturalWonderPlanStats(
+  payload: Record<string, unknown>
+):
+  | {
+      stats: NonNullable<
+        NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["naturalWonderPlan"]>["stats"]
+      >;
+    }
+  | undefined {
+  const version = numberValue(payload.version);
+  const wondersCount = numberValue(payload.wondersCount);
+  const targetCount = numberValue(payload.targetCount);
+  const plannedCount = numberValue(payload.plannedCount);
+  if (
+    version === undefined ||
+    wondersCount === undefined ||
+    targetCount === undefined ||
+    plannedCount === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    stats: {
+      version,
+      wondersCount,
+      targetCount,
+      plannedCount,
     },
   };
 }
@@ -528,6 +586,76 @@ function naturalWonderPlacementStats(
       ...(rejectionExamples === undefined ? {} : { rejectionExamples }),
     },
   };
+}
+
+function naturalWonderPlanCoordinateProof(
+  payload: Record<string, unknown>
+):
+  | {
+      coordinateProof: NonNullable<
+        NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["naturalWonderPlan"]>["coordinateProof"]
+      >;
+    }
+  | undefined {
+  const coordinateProof = isRecord(payload.coordinateProof) ? payload.coordinateProof : undefined;
+  if (!coordinateProof) return undefined;
+  const version = numberValue(coordinateProof.version);
+  const plannedCount = numberValue(coordinateProof.plannedCount);
+  const plannedHash32 = hash32Value(coordinateProof.plannedHash32);
+  if (version === undefined || plannedCount === undefined || plannedHash32 === undefined) {
+    return undefined;
+  }
+  return {
+    coordinateProof: {
+      version,
+      planned: { count: plannedCount, hash32: plannedHash32 },
+    },
+  };
+}
+
+function naturalWonderPlanRows(
+  payload: Record<string, unknown>
+):
+  | {
+      planRows: NonNullable<
+        NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["naturalWonderPlan"]>["planRows"]
+      >;
+    }
+  | undefined {
+  if (!Array.isArray(payload.planRows)) return undefined;
+  const planRows = payload.planRows.flatMap((row) => {
+    if (!Array.isArray(row)) return [];
+    const status = row[0] === "p" ? "planned" : undefined;
+    const plotIndex = numberValue(row[1]);
+    const x = numberValue(row[2]);
+    const y = numberValue(row[3]);
+    const featureType = numberValue(row[4]);
+    const direction = numberValue(row[5]);
+    const elevation = row[6] === null ? undefined : numberValue(row[6]);
+    const priorityPpm = row[7] === null ? undefined : numberValue(row[7]);
+    if (
+      status === undefined ||
+      plotIndex === undefined ||
+      x === undefined ||
+      y === undefined ||
+      featureType === undefined ||
+      direction === undefined
+    ) {
+      return [];
+    }
+    return [
+      {
+        plotIndex,
+        x,
+        y,
+        featureType,
+        direction,
+        ...(elevation === undefined ? {} : { elevation }),
+        ...(priorityPpm === undefined ? {} : { priorityPpm }),
+      },
+    ];
+  }).slice(0, 16);
+  return planRows.length === 0 ? undefined : { planRows };
 }
 
 function resourcePlacementStats(

--- a/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
+++ b/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
@@ -137,6 +137,21 @@ describe("Run in Game exact authorship proof identity", () => {
             rejectedHash32: "aaaaaaaa",
           },
         })}`,
+        `[SWOOPER_MOD] NATURAL_WONDER_PLAN_V1 ${JSON.stringify({
+          version: 1,
+          wondersCount: 7,
+          targetCount: 7,
+          plannedCount: 2,
+          planRows: [
+            ["p", 1320, 60, 15, 35, 0, 120, 610000],
+            ["p", 1405, 61, 16, 36, 0, 90, 420000],
+          ],
+          coordinateProof: {
+            version: 1,
+            plannedCount: 2,
+            plannedHash32: "bbbbbbbb",
+          },
+        })}`,
         `[SWOOPER_MOD] NATURAL_WONDER_PLACEMENT_V1 ${JSON.stringify({
           version: 1,
           plannedCount: 7,
@@ -228,6 +243,39 @@ describe("Run in Game exact authorship proof identity", () => {
         rejected: { count: 1, hash32: "aaaaaaaa" },
       },
     });
+    expect(logProof?.naturalWonderPlan).toMatchObject({
+      marker: "NATURAL_WONDER_PLAN_V1",
+      stats: {
+        version: 1,
+        wondersCount: 7,
+        targetCount: 7,
+        plannedCount: 2,
+      },
+      coordinateProof: {
+        version: 1,
+        planned: { count: 2, hash32: "bbbbbbbb" },
+      },
+      planRows: [
+        {
+          plotIndex: 1320,
+          x: 60,
+          y: 15,
+          featureType: 35,
+          direction: 0,
+          elevation: 120,
+          priorityPpm: 610000,
+        },
+        {
+          plotIndex: 1405,
+          x: 61,
+          y: 16,
+          featureType: 36,
+          direction: 0,
+          elevation: 90,
+          priorityPpm: 420000,
+        },
+      ],
+    });
     expect(logProof?.naturalWonderPlacement).toMatchObject({
       marker: "NATURAL_WONDER_PLACEMENT_V1",
       stats: {
@@ -295,6 +343,14 @@ describe("Run in Game exact authorship proof identity", () => {
           version: 1,
           coordinateProof: { version: 1, placedCount: 4, placedHash32: "aaaaaaaa" },
         })}`,
+        `[SWOOPER_MOD] NATURAL_WONDER_PLAN_V1 ${JSON.stringify({
+          version: 1,
+          wondersCount: 1,
+          targetCount: 1,
+          plannedCount: 1,
+          planRows: [["p", 0, 0, 0, 35, 0, 1, 1000000]],
+          coordinateProof: { version: 1, plannedCount: 1, plannedHash32: "aaaaaaaa" },
+        })}`,
         `[SWOOPER_MOD] NATURAL_WONDER_PLACEMENT_V1 ${JSON.stringify({
           version: 1,
           plannedCount: 1,
@@ -316,6 +372,7 @@ describe("Run in Game exact authorship proof identity", () => {
 
     expect(logProof?.featureApply).toBeUndefined();
     expect(logProof?.resourcePlacement).toBeUndefined();
+    expect(logProof?.naturalWonderPlan).toBeUndefined();
     expect(logProof?.naturalWonderPlacement).toBeUndefined();
   });
 

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/index.ts
@@ -2,6 +2,7 @@ import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 
 import DerivePlacementInputsContract from "./contract.js";
 import { buildPlacementInputs } from "./inputs.js";
+import { logNaturalWonderPlanRuntimeTelemetry } from "./natural-wonder-plan-telemetry.js";
 import { placementArtifacts } from "../../artifacts.js";
 
 export default createStep(DerivePlacementInputsContract, {
@@ -38,6 +39,7 @@ export default createStep(DerivePlacementInputsContract, {
     deps.artifacts.placementInputs.publish(context, inputs);
     deps.artifacts.resourcePlan.publish(context, inputs.resources);
     deps.artifacts.naturalWonderPlan.publish(context, inputs.naturalWonderPlan);
+    logNaturalWonderPlanRuntimeTelemetry(inputs.naturalWonderPlan);
     deps.artifacts.discoveryPlan.publish(context, inputs.discoveryPlan);
   },
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/natural-wonder-plan-telemetry.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/natural-wonder-plan-telemetry.ts
@@ -1,0 +1,105 @@
+import type { Static } from "@swooper/mapgen-core/authoring";
+
+import placement from "@mapgen/domain/placement";
+
+type NaturalWonderPlan = Static<(typeof placement.ops.planNaturalWonders)["output"]>;
+
+export type NaturalWonderPlanRuntimeRow = readonly [
+  status: "p",
+  plotIndex: number,
+  x: number,
+  y: number,
+  featureType: number,
+  direction: number,
+  elevation: number | null,
+  priorityPpm: number | null,
+];
+
+export type NaturalWonderPlanRuntimeTelemetry = {
+  version: 1;
+  wondersCount: number;
+  targetCount: number;
+  plannedCount: number;
+  planRows: NaturalWonderPlanRuntimeRow[];
+  coordinateProof: {
+    version: 1;
+    plannedCount: number;
+    plannedHash32: string;
+  };
+};
+
+const FNV1A_32_OFFSET = 0x811c9dc5;
+const FNV1A_32_PRIME = 0x01000193;
+
+function hash32Hex(input: string): string {
+  let hash = FNV1A_32_OFFSET;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, FNV1A_32_PRIME);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function normalizeInteger(value: unknown): number | null {
+  return Number.isFinite(value) ? Math.trunc(value as number) : null;
+}
+
+function normalizePriorityPpm(value: unknown): number | null {
+  if (!Number.isFinite(value)) return null;
+  return Math.max(0, Math.min(1_000_000, Math.round((value as number) * 1_000_000)));
+}
+
+function naturalWonderPlanCoordinateHash(rows: readonly NaturalWonderPlanRuntimeRow[]): string {
+  return hash32Hex(
+    rows
+      .slice()
+      .sort((a, b) => {
+        if (a[1] !== b[1]) return a[1] - b[1];
+        if (a[4] !== b[4]) return a[4] - b[4];
+        return a[5] - b[5];
+      })
+      .map((row) => row.join(":"))
+      .join("|")
+  );
+}
+
+export function buildNaturalWonderPlanRuntimeTelemetry(
+  plan: NaturalWonderPlan
+): NaturalWonderPlanRuntimeTelemetry {
+  const width = Math.max(1, plan.width | 0);
+  const planRows: NaturalWonderPlanRuntimeRow[] = plan.placements.slice(0, 16).map((placement) => {
+    const plotIndex = placement.plotIndex | 0;
+    const y = (plotIndex / width) | 0;
+    const x = plotIndex - y * width;
+    return [
+      "p",
+      plotIndex,
+      x,
+      y,
+      placement.featureType | 0,
+      placement.direction | 0,
+      normalizeInteger(placement.elevation),
+      normalizePriorityPpm(placement.priority),
+    ];
+  });
+  return {
+    version: 1,
+    wondersCount: Math.max(0, plan.wondersCount | 0),
+    targetCount: Math.max(0, plan.targetCount | 0),
+    plannedCount: Math.max(0, plan.plannedCount | 0),
+    planRows,
+    coordinateProof: {
+      version: 1,
+      plannedCount: planRows.length,
+      plannedHash32: naturalWonderPlanCoordinateHash(planRows),
+    },
+  };
+}
+
+export function logNaturalWonderPlanRuntimeTelemetry(plan: NaturalWonderPlan): void {
+  console.log(
+    `[SWOOPER_MOD] NATURAL_WONDER_PLAN_V1 ${JSON.stringify(
+      buildNaturalWonderPlanRuntimeTelemetry(plan)
+    )}`
+  );
+}

--- a/mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts
+++ b/mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts
@@ -5,6 +5,7 @@ import { CIV7_BROWSER_TABLES_V0 } from "@civ7/map-policy";
 
 import { initializeStandardRuntime } from "../../src/recipes/standard/runtime.js";
 import { buildPlacementInputs } from "../../src/recipes/standard/stages/placement/steps/derive-placement-inputs/inputs.js";
+import { buildNaturalWonderPlanRuntimeTelemetry } from "../../src/recipes/standard/stages/placement/steps/derive-placement-inputs/natural-wonder-plan-telemetry.js";
 
 const { featureTypes, terrainTypeIndices, biomeGlobals } = CIV7_BROWSER_TABLES_V0;
 
@@ -213,5 +214,48 @@ describe("derive placement inputs", () => {
     );
 
     expect(capturedNaturalWonderInput?.featureCatalog).toEqual([]);
+  });
+
+  it("builds compact natural-wonder plan telemetry for exact runtime proof", () => {
+    const telemetry = buildNaturalWonderPlanRuntimeTelemetry({
+      width: 106,
+      height: 66,
+      wondersCount: 7,
+      targetCount: 7,
+      plannedCount: 2,
+      placements: [
+        {
+          plotIndex: 4130,
+          featureType: 30,
+          direction: 0,
+          elevation: 3,
+          priority: 0.6107035471190667,
+        },
+        {
+          plotIndex: 1785,
+          featureType: 36,
+          direction: 0,
+          elevation: 4,
+          priority: 0.8272660786093309,
+        },
+      ],
+    });
+
+    expect(telemetry).toMatchObject({
+      version: 1,
+      wondersCount: 7,
+      targetCount: 7,
+      plannedCount: 2,
+      planRows: [
+        ["p", 4130, 102, 38, 30, 0, 3, 610704],
+        ["p", 1785, 89, 16, 36, 0, 4, 827266],
+      ],
+      coordinateProof: {
+        version: 1,
+        plannedCount: 2,
+      },
+    });
+    expect(telemetry.coordinateProof.plannedHash32).toMatch(/^[0-9a-f]{8}$/);
+    expect(`[SWOOPER_MOD] NATURAL_WONDER_PLAN_V1 ${JSON.stringify(telemetry)}`.length).toBeLessThan(700);
   });
 });

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -550,6 +550,38 @@
     just a post-write footprint readback row; it also includes exact/local
     plan-input or engine-surface divergence that must be source-owned before
     behavior repair.
+- [x] 2.57 Bind bounded natural-wonder plan rows into future exact-authorship
+  proof packets.
+  - Current branch `codex/swooper-natural-wonder-plan-proof-drain` adds a
+    compact `NATURAL_WONDER_PLAN_V1` runtime marker from the
+    placement-input/natural-wonder-plan owner and expands it in Studio
+    exact-authorship parsing as `naturalWonderPlan`. Rows carry plan status,
+    plot/x/y, feature type, direction, elevation, and priority ppm, plus a
+    compact plan-coordinate digest.
+  - This is proof instrumentation only. It does not change natural-wonder
+    planning, materialization, readback disposition, final-surface parity,
+    product acceptance, resource behavior, feature behavior, terrain behavior,
+    or public config. A fresh exact-authored run must consume this marker
+    before exact/local plan divergence can be source-owned or dispositioned.
+- [x] 2.58 Preserve current exact-authored natural-wonder plan-row proof.
+  - Fresh exact request `studio-run-in-game-mq3ze9g3-1zzu` completed with no
+    exact-authorship unresolved links after consuming
+    `NATURAL_WONDER_PLAN_V1`. POST artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-plan-proof-post.json`
+    has `sha256:8b4d80314bbb06f075148beb2c06253b64e7d8df1a99e4f802e3e98cfce0433f`;
+    terminal status artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-plan-proof-status.json`
+    has `sha256:a1e25662685fee91916d27a81021ff5bf7ad90f610a79bd1ae75b27b9057fa39`.
+  - Exact plan rows are now explicit: feature `30` planned at plot `4130`,
+    feature `35` planned at plot `1686`, and feature `36` planned at plot
+    `1785`, while local replay plans those features at plots `1342`, `1624`,
+    and `2065`. Exact placement still places `5/7` and rejects feature `30`
+    at plot `4130` and feature `36` at plot `1785`, both with
+    `readback-mismatch` / `partial-expected-footprint`.
+  - This proves the remaining natural-wonder blocker includes exact/local
+    plan-input or engine-surface divergence before post-write readback repair.
+    It does not authorize tuning, public config changes, local mock shortcuts,
+    final-surface parity, or product acceptance.
 
 ## 3. Verification
 
@@ -756,3 +788,24 @@
   - Verifier log:
     `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq3yo4uq-natural-wonder-rows.log`
     (`sha256:82d75d59305815f64b4f775a2128bb6e8327f3ae120c4ab347dbd2136022dade`).
+- [x] 3.28 Run focused natural-wonder plan-row proof regressions.
+  - Passed `bun test
+    mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts
+    apps/mapgen-studio/test/runInGame/proofIdentity.test.ts`.
+  - Passed owner checks `bun run --cwd mods/mod-swooper-maps check` and
+    `bun run --cwd apps/mapgen-studio check`.
+- [x] 3.29 Re-run current exact-authored final-surface parity after
+  natural-wonder plan-row proof parsing.
+  - Verifier input request `studio-run-in-game-mq3ze9g3-1zzu` wrote
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ze9g3-1zzu-current-final-surface-parity-with-natural-wonder-plan-rows.json`
+    (`sha256:6a16a3273cc0e99120826d5adb74382dad66f0d45fb307c4af073ade9e1fe711`,
+    `proofHash:9c19e242e009dbf89711cba6e5f40ee618e27ea8bdb707d18d2d9d8727d87296`).
+  - The verifier exited `2` as expected for unresolved parity. It preserves
+    unchanged unresolved links: `resource-placement-coordinate-proof.placed`,
+    `resource-placement-coordinate-proof.rejected`, `surface.biome.mismatch`,
+    `surface.feature.mismatch`, `surface.resource.mismatch`, and
+    `surface.terrain.mismatch`. Mismatch counts are terrain `140`, biome
+    `874`, feature `376`, and resource `307`.
+  - Verifier log:
+    `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq3ze9g3-natural-wonder-plan-rows.log`
+    (`sha256:b8a581af6a65a95204b8688e8278ad99eab0a7637ab302cc9cb3537e6d0a21cf`).

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1560,16 +1560,58 @@ This is a strong owner hypothesis for assignment/materialization reconciliation,
 not an authorization to tune public Earthlike config, change static resource
 policy, or claim final-surface/product acceptance.
 
+### Current Natural-Wonder Exact Plan Rows
+
+Classification status: exact plan-input divergence captured; source owner still
+open.
+
+| Artifact | Path | Identity |
+| --- | --- | --- |
+| Exact status proof | `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-plan-proof-status.json` | `sha256:a1e25662685fee91916d27a81021ff5bf7ad90f610a79bd1ae75b27b9057fa39` |
+| Final-surface proof | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ze9g3-1zzu-current-final-surface-parity-with-natural-wonder-plan-rows.json` | `sha256:6a16a3273cc0e99120826d5adb74382dad66f0d45fb307c4af073ade9e1fe711`, `proofHash:9c19e242e009dbf89711cba6e5f40ee618e27ea8bdb707d18d2d9d8727d87296` |
+| Verifier log | `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq3ze9g3-natural-wonder-plan-rows.log` | `sha256:b8a581af6a65a95204b8688e8278ad99eab0a7637ab302cc9cb3537e6d0a21cf` |
+
+Exact `NATURAL_WONDER_PLAN_V1` is now bound in the exact-authorship packet for
+request `studio-run-in-game-mq3ze9g3-1zzu`. It proves the exact planner rows:
+
+| Feature | Exact plan plot | Exact priority ppm | Local replay plot | Local priority |
+| ---: | ---: | ---: | ---: | ---: |
+| `30` | `4130` | `530579` | `1342` | `0.6107035471190667` |
+| `32` | `1228` | `888087` | `1228` | `0.8862814251333475` |
+| `34` | `1861` | `831121` | `1861` | `0.8319755537371183` |
+| `35` | `1686` | `441272` | `1624` | `0.3040659082346949` |
+| `36` | `1785` | `377995` | `2065` | `0.8272660786093309` |
+| `38` | `1000` | `736723` | `1000` | `0.7338061736703947` |
+| `39` | `5107` | `488668` | `5107` | `0.4857279896736145` |
+
+Exact placement then reports `7` planned, `5` placed, and `2` rejected. The
+rejected rows are feature `30` at plot `4130` and feature `36` at plot `1785`,
+both `readback-mismatch` with `partial-expected-footprint`.
+
+Disposition:
+this proof proves the remaining natural-wonder blocker is not only a post-write
+readback mismatch. The exact planner itself sees a different placement surface
+or input set for three feature rows (`30`, `35`, `36`) before materialization.
+The next owner decision must explain the exact/local plan-input or
+engine-surface divergence before changing readback behavior, local mock policy,
+public Earthlike config, or natural-wonder tuning. Final-surface parity remains
+`unresolved` with terrain `140`, biome `874`, feature `376`, resource `307`,
+and resource coordinate proof links still open.
+
 ## Required Next Diagnostics
 
-- Classify the natural-wonder expected-empty footprint/readback owner from the
-  fresh exact `mq2x1ugm` proof: compare the partial expected-footprint vectors
-  (`1320:35,1427:-1,1321:35` and `2171:36,2278:-1`) to supported footprint
-  alternatives, final live feature cells, and adapter readback semantics before
-  assigning repair authority. A valid repair lane needs an explicit
-  source-authority disposition explaining whether the current adapter readback
-  oracle is wrong for Civ materialization or whether Civ's footprint behavior
-  should be classified as residual.
+- Classify the natural-wonder exact/local plan-input or engine-surface
+  divergence from the fresh exact `mq3ze9g3` proof before changing readback
+  behavior. Exact and local plan rows now differ for features `30`, `35`, and
+  `36`; compare the candidate surfaces, feature occupancy, terrain/biome/lake
+  masks, blocked masks, and priority inputs at the exact/local candidate plots
+  before assigning repair authority.
+- After the plan-input divergence is source-owned or dispositioned, classify
+  the partial expected-footprint readback owner for the exact rejected feature
+  `30` and `36` rows. A valid repair lane needs an explicit source-authority
+  disposition explaining whether the adapter readback oracle is wrong for Civ
+  materialization or whether Civ's footprint behavior should be classified as
+  residual.
 - Current exact live feature-apply telemetry is now bound by request
   `studio-run-in-game-mq3ryaop-1p7l`: `1493` attempted, `1491` applied, and `2`
   `canHaveFeature` rejections (`FEATURE_COLD_REEF:1`, `FEATURE_TAIGA:1`). Use

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,6 +6,7 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
+  `codex/swooper-natural-wonder-plan-proof-drain`, stacked above
   `codex/swooper-natural-wonder-row-proof-drain`, stacked above
   `codex/swooper-natural-wonder-supported-catalog-drain`, stacked above
   `codex/swooper-resource-delta-feasibility-current-record-drain`, stacked
@@ -69,6 +70,22 @@
   plot `1342` and feature `36` at plot `2065`, so the next natural-wonder
   source decision must account for exact/local plan-input or engine-surface
   divergence before treating readback mismatch as a narrow post-write repair.
+  Current follow-on proof-contract branch
+  `codex/swooper-natural-wonder-plan-proof-drain` adds compact
+  `NATURAL_WONDER_PLAN_V1` runtime telemetry and Studio exact-authorship
+  parsing for natural-wonder plan rows. Fresh exact request
+  `studio-run-in-game-mq3ze9g3-1zzu` completed with no exact-authorship
+  unresolved links and proves exact planning selected feature `30` at plot
+  `4130`, feature `35` at plot `1686`, and feature `36` at plot `1785`, while
+  local replay selected those features at plots `1342`, `1624`, and `2065`.
+  Exact placement still rejects feature `30` and feature `36` with
+  `partial-expected-footprint` readback mismatch. The verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ze9g3-1zzu-current-final-surface-parity-with-natural-wonder-plan-rows.json`
+  (`sha256:6a16a3273cc0e99120826d5adb74382dad66f0d45fb307c4af073ade9e1fe711`,
+  `proofHash:9c19e242e009dbf89711cba6e5f40ee618e27ea8bdb707d18d2d9d8727d87296`)
+  remains unresolved with terrain `140`, biome `874`, feature `376`, and
+  resource `307` mismatches. This is proof plumbing and source-authority
+  narrowing only, not behavior repair, parity closure, or product acceptance.
   Resource, feature, natural-wonder, and terrain source-authority
   classification remains the active work; product acceptance is not closed.
   Current resource-delta feasibility after the exact/local rejection join now
@@ -1368,6 +1385,20 @@
   `2065` and places all `7`, so the remaining natural-wonder proof target is
   exact/local plan-input or engine-surface divergence plus post-write partial
   footprint readback, not a simple missing supported-catalog row.
+  Current proof-contract branch
+  `codex/swooper-natural-wonder-plan-proof-drain` adds exact natural-wonder
+  plan-row telemetry. Fresh request `studio-run-in-game-mq3ze9g3-1zzu`
+  proves exact planning selected feature `30` at plot `4130`, feature `35` at
+  plot `1686`, and feature `36` at plot `1785`; local replay selected those
+  features at plots `1342`, `1624`, and `2065`. The current verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ze9g3-1zzu-current-final-surface-parity-with-natural-wonder-plan-rows.json`
+  has `sha256:6a16a3273cc0e99120826d5adb74382dad66f0d45fb307c4af073ade9e1fe711`
+  and
+  `proofHash:9c19e242e009dbf89711cba6e5f40ee618e27ea8bdb707d18d2d9d8727d87296`.
+  The next natural-wonder owner decision is now explicitly plan-input /
+  engine-surface divergence first, then partial expected-footprint readback
+  ownership for the exact rejected feature `30` and `36` rows. No behavior
+  repair, parity closure, or product acceptance is claimed.
   Final-surface parity remains open on terrain (`140` mismatches), biome
   (`874`), feature (`376`), resource (`307`), natural-wonder readback proof,
   resource coordinate proof, and any future owner-classified residual links.

--- a/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
@@ -71,6 +71,20 @@
     at plot `1342` and feature `36` at plot `2065`, so natural-wonder closure
     is blocked on source-owning exact/local plan-input or engine-surface
     divergence before behavior repair.
+    Follow-on branch `codex/swooper-natural-wonder-plan-proof-drain` is a
+    proof-contract slice for exact natural-wonder plan rows. Fresh exact
+    request `studio-run-in-game-mq3ze9g3-1zzu` consumes the plan marker and
+    proves exact planning selected feature `30` at plot `4130`, feature `35`
+    at plot `1686`, and feature `36` at plot `1785`, while local replay
+    selected those features at `1342`, `1624`, and `2065`. Final-surface
+    verifier artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ze9g3-1zzu-current-final-surface-parity-with-natural-wonder-plan-rows.json`
+    (`sha256:6a16a3273cc0e99120826d5adb74382dad66f0d45fb307c4af073ade9e1fe711`,
+    `proofHash:9c19e242e009dbf89711cba6e5f40ee618e27ea8bdb707d18d2d9d8727d87296`)
+    remains unresolved. This narrows the natural-wonder blocker to
+    exact/local plan-input or engine-surface divergence before partial
+    footprint readback repair; it does not close final parity or product
+    acceptance.
 - [ ] 1.2 Audit accepted P1/P2 review findings across recovery changes.
   - Current audit pass found no active review-disposition ledger inside
     `earthlike-live-feature-resource-legality-repair` or
@@ -98,7 +112,7 @@
 
 - [ ] 3.1 Run `git status --short --branch`.
   - Current proof-contract slice must leave
-    `codex/swooper-natural-wonder-supported-catalog-drain`
+    `codex/swooper-natural-wonder-plan-proof-drain`
     clean before commit or closure.
 - [ ] 3.2 Inspect Graphite branch/stack state.
   - Current audit snapshot: top branch
@@ -110,8 +124,9 @@
     `codex/swooper-resource-rejection-proof-identity-drain`, and the current
     feature/resource/source-authority proof-record branches.
   - Follow-on implementation branches:
-    `codex/swooper-natural-wonder-supported-catalog-drain`, then
-    `codex/swooper-natural-wonder-row-proof-drain`.
+    `codex/swooper-natural-wonder-supported-catalog-drain`,
+    `codex/swooper-natural-wonder-row-proof-drain`, then
+    `codex/swooper-natural-wonder-plan-proof-drain`.
 - [ ] 3.3 Run `git diff --check`.
 - [ ] 3.4 Run `bun run openspec -- validate swooper-recovery-stack-product-closure --strict`.
 - [ ] 3.5 Run `bun run openspec:validate`.

--- a/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
@@ -6,7 +6,7 @@
 - Phase: product closure planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack:
-  `codex/swooper-natural-wonder-row-proof-drain`
+  `codex/swooper-natural-wonder-plan-proof-drain`
 - Started: 2026-06-06
 - Status: blocked until proof and activated repair changes close
 
@@ -95,6 +95,20 @@
   plot `1342` and feature `36` at plot `2065`, so the next natural-wonder
   decision is exact/local plan-input or engine-surface divergence before any
   further readback behavior repair.
+  Current follow-on branch `codex/swooper-natural-wonder-plan-proof-drain`
+  exposes exact natural-wonder plan rows through `NATURAL_WONDER_PLAN_V1` and
+  Studio exact-authorship parsing. Fresh exact request
+  `studio-run-in-game-mq3ze9g3-1zzu` completed exact authorship with no
+  unresolved exact links and proves exact planning selected feature `30` at
+  plot `4130`, feature `35` at plot `1686`, and feature `36` at plot `1785`,
+  while local replay selected those features at plots `1342`, `1624`, and
+  `2065`. The final-surface verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ze9g3-1zzu-current-final-surface-parity-with-natural-wonder-plan-rows.json`
+  (`sha256:6a16a3273cc0e99120826d5adb74382dad66f0d45fb307c4af073ade9e1fe711`,
+  `proofHash:9c19e242e009dbf89711cba6e5f40ee618e27ea8bdb707d18d2d9d8727d87296`)
+  remains unresolved with terrain `140`, biome `874`, feature `376`, and
+  resource `307` mismatches. This is proof-contract work only; final parity
+  and product acceptance remain open.
 - Generated outputs affected: none expected.
 - Tests/guards affected: validation and closure audits.
 
@@ -144,6 +158,9 @@
   locally repairs the natural-wonder unsupported-catalog / empty-footprint
   planning leak, and fresh exact runtime proof confirms that unsupported
   footprint rows no longer reach live natural-wonder placement telemetry.
+  Current proof-contract branch also records exact natural-wonder plan rows,
+  proving the remaining natural-wonder source decision begins at exact/local
+  plan-input or engine-surface divergence.
 - Remaining tasks: final-surface parity, product acceptance, supervisor
   P1/P2 closure review, PR/remote predecessor disposition, and final Graphite
   submit/closure.
@@ -185,13 +202,15 @@
 
 ## Next Action
 
-- Exact next step: classify why exact natural-wonder planning/materialization
-  rejects feature `30` at plot `4130` and feature `36` at plot `1785` while
-  local replay plans those feature types at plots `1342` and `2065` and places
-  all `7`. Do not repair readback behavior until that exact/local plan-input
-  or engine-surface divergence is source-owned. Then continue the remaining
-  queue: cross-resource scarce-floor divergence at plot `4838`, and exact
-  `FEATURE_APPLY_V1` materialization/readback ownership.
+- Exact next step: classify the exact/local natural-wonder plan-input or
+  engine-surface divergence now proven by request
+  `studio-run-in-game-mq3ze9g3-1zzu`. Exact plans feature `30` at `4130`,
+  feature `35` at `1686`, and feature `36` at `1785`; local replay plans those
+  features at `1342`, `1624`, and `2065`. Do not repair readback behavior
+  until that divergence is source-owned or deliberately dispositioned. Then
+  continue the remaining queue: partial footprint readback for exact rejected
+  natural-wonder rows, cross-resource scarce-floor divergence at plot `4838`,
+  and exact `FEATURE_APPLY_V1` materialization/readback ownership.
 - First files to inspect: recovery OpenSpec proof ledgers and Graphite branch
   state.
 - Stop condition: accepted P1/P2 findings remain open.


### PR DESCRIPTION
Adds a compact `NATURAL_WONDER_PLAN_V1` runtime telemetry marker emitted from the natural-wonder plan step and parses it into the Studio exact-authorship proof packet as `naturalWonderPlan`.

The mod side introduces `logNaturalWonderPlanRuntimeTelemetry`, which serializes up to 16 plan rows into a compact array format carrying plot index, x/y coordinates, feature type, direction, elevation, and priority in parts-per-million. A FNV-1a 32-bit coordinate digest (`plannedHash32`) is computed over the sorted plan rows and included alongside aggregate stats (`wondersCount`, `targetCount`, `plannedCount`).

The Studio parser adds `parseNaturalWonderPlanTelemetryBetween` to scan log lines between the proof and completion markers for `NATURAL_WONDER_PLAN_V1`, then extracts `stats`, `coordinateProof`, and `planRows` into the `RunInGameExactAuthorshipProof` log structure via the new `RunInGameNaturalWonderPlanRow` type.

This is proof instrumentation only. It does not alter natural-wonder planning logic, materialization, readback disposition, final-surface parity, or any public configuration. A fresh exact-authored run (`studio-run-in-game-mq3ze9g3-1zzu`) completed with no unresolved exact-authorship links after consuming the marker, confirming that exact planning selected features `30`, `35`, and `36` at plots `4130`, `1686`, and `1785` respectively, while local replay selected those features at plots `1342`, `1624`, and `2065`. This narrows the remaining natural-wonder blocker to exact/local plan-input or engine-surface divergence upstream of post-write readback repair.