### PR TITLE
feat(live-parity): add natural-wonder plan coordinate proof comparison to final-surface parity proof

### DIFF
--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -11,6 +11,7 @@ import {
   sha256Hex,
   stableStringify,
 } from "@swooper/mapgen-core";
+import { hexDistanceOddQPeriodicX } from "@swooper/mapgen-core/lib/grid";
 import type { TraceEvent, TraceSink } from "@swooper/mapgen-core/trace";
 
 import { canonicalRecipeConfig, isPlainObject as isCanonicalMapConfigObject } from "../../maps/configs/canonical.js";
@@ -98,6 +99,42 @@ type ResourcePlacementCoordinateProofComparison = Readonly<{
   mismatchedLinks: ReadonlyArray<string>;
 }>;
 
+type NaturalWonderPlanCoordinateProofComparison = Readonly<{
+  status: "match" | "mismatch" | "missing-exact-log" | "missing-local-plan";
+  local?: Readonly<{
+    planned?: Readonly<{ count?: number; hash32?: string }>;
+  }>;
+  exact?: Readonly<{
+    planned?: Readonly<{ count?: number; hash32?: string }>;
+  }>;
+  rowComparisons: ReadonlyArray<NaturalWonderPlanRowComparison>;
+  mismatchedLinks: ReadonlyArray<string>;
+}>;
+
+type NaturalWonderPlanRowComparison = Readonly<{
+  featureType: number;
+  classification:
+    | "exact-local-same-anchor"
+    | "exact-local-anchor-diverged"
+    | "exact-only"
+    | "local-only";
+  exact?: NaturalWonderPlanRow;
+  local?: NaturalWonderPlanRow;
+  distance?: number;
+  elevationDelta?: number;
+  priorityDeltaPpm?: number;
+}>;
+
+type NaturalWonderPlanRow = Readonly<{
+  plotIndex: number;
+  x: number;
+  y: number;
+  featureType: number;
+  direction: number;
+  elevation?: number;
+  priorityPpm?: number;
+}>;
+
 export type ResourcePlacementRejectionContext = Readonly<{
   exact: Readonly<{
     status: string;
@@ -161,6 +198,7 @@ export type FinalSurfaceParityProof = Readonly<{
   local: FinalSurfaceSnapshot;
   live: FinalSurfaceSnapshot;
   diffs: ReadonlyArray<SurfaceDiffSummary>;
+  naturalWonderPlanCoordinateProof?: NaturalWonderPlanCoordinateProofComparison;
   resourcePlacementCoordinateProof?: ResourcePlacementCoordinateProofComparison;
   resourcePlacementRejectionContexts?: ReadonlyArray<ResourcePlacementRejectionContext>;
   residuals: ReadonlyArray<ParityResidualClassification>;
@@ -252,6 +290,14 @@ export type ExactAuthorshipProofLike = Readonly<{
         version?: number;
         placed?: Readonly<{ count?: number; hash32?: string }>;
         rejected?: Readonly<{ count?: number; hash32?: string }>;
+      }>;
+      payload?: unknown;
+    }>;
+    naturalWonderPlan?: Readonly<{
+      planRows?: ReadonlyArray<unknown>;
+      coordinateProof?: Readonly<{
+        version?: number;
+        planned?: Readonly<{ count?: number; hash32?: string }>;
       }>;
       payload?: unknown;
     }>;
@@ -674,6 +720,8 @@ export function buildFinalSurfaceParityProof(args: {
   const diffs = diffFinalSurfaceSnapshots(args.local, args.live);
   const unresolvedLinks: string[] = [];
   const exact = args.exactAuthorship;
+  const naturalWonderPlanCoordinateProof =
+    exact === undefined ? undefined : buildNaturalWonderPlanCoordinateProofComparison(exact, args.local);
   const resourcePlacementCoordinateProof =
     exact === undefined ? undefined : buildResourcePlacementCoordinateProofComparison(exact, args.local);
   const resourcePlacementRejectionContexts =
@@ -755,6 +803,9 @@ export function buildFinalSurfaceParityProof(args: {
     ) {
       unresolvedLinks.push("exact-authorship-proof.materialization-envelope-hash.local-envelope-hash");
     }
+    if (naturalWonderPlanCoordinateProof) {
+      unresolvedLinks.push(...naturalWonderPlanCoordinateProof.mismatchedLinks);
+    }
     if (resourcePlacementCoordinateProof) {
       unresolvedLinks.push(...resourcePlacementCoordinateProof.mismatchedLinks);
     }
@@ -791,6 +842,9 @@ export function buildFinalSurfaceParityProof(args: {
     local: args.local,
     live: args.live,
     diffs,
+    ...(naturalWonderPlanCoordinateProof === undefined
+      ? {}
+      : { naturalWonderPlanCoordinateProof }),
     ...(resourcePlacementCoordinateProof === undefined ? {} : { resourcePlacementCoordinateProof }),
     ...(resourcePlacementRejectionContexts.length === 0
       ? {}
@@ -967,6 +1021,251 @@ function addFullGridEvidenceLinks(unresolvedLinks: string[], live: FinalSurfaceS
   }
   const identityCheck = isPlainObject(fullGrid.identityCheck) ? fullGrid.identityCheck : undefined;
   if (identityCheck?.stable !== true) unresolvedLinks.push("live.full-grid.identity-check");
+}
+
+function buildNaturalWonderPlanCoordinateProofComparison(
+  exact: ExactAuthorshipProofLike,
+  local: FinalSurfaceSnapshot
+): NaturalWonderPlanCoordinateProofComparison | undefined {
+  const localRows = readLocalNaturalWonderPlanRows(local);
+  const exactRows = readExactNaturalWonderPlanRows(exact);
+  if (localRows.length === 0 && exactRows.length === 0) return undefined;
+
+  const localProof =
+    localRows.length === 0
+      ? undefined
+      : {
+          planned: naturalWonderPlanCoordinateDigest(localRows),
+        };
+  const exactLoggedDigest = exactNaturalWonderPlanLoggedDigest(exact);
+  const exactProof =
+    exactRows.length === 0 && !exactLoggedDigest
+      ? undefined
+      : {
+          planned: exactLoggedDigest ?? naturalWonderPlanCoordinateDigest(exactRows),
+        };
+  const rowComparisons = buildNaturalWonderPlanRowComparisons(exactRows, localRows, local.width);
+  if (!exactProof) {
+    return {
+      status: "missing-exact-log",
+      local: localProof,
+      rowComparisons,
+      mismatchedLinks: (localProof?.planned?.count ?? 0) > 0
+        ? ["natural-wonder-plan-coordinate-proof.log"]
+        : [],
+    };
+  }
+  if (!localProof) {
+    return {
+      status: "missing-local-plan",
+      exact: exactProof,
+      rowComparisons,
+      mismatchedLinks: (exactProof.planned?.count ?? 0) > 0
+        ? ["natural-wonder-plan-coordinate-proof.local"]
+        : [],
+    };
+  }
+  const mismatchedLinks = [
+    coordinateDigestMismatchLink(
+      localProof.planned,
+      exactProof.planned,
+      "natural-wonder-plan-coordinate-proof.planned"
+    ),
+  ].filter((link): link is string => link !== undefined);
+  return {
+    status: mismatchedLinks.length === 0 ? "match" : "mismatch",
+    local: localProof,
+    exact: exactProof,
+    rowComparisons,
+    mismatchedLinks,
+  };
+}
+
+function readExactNaturalWonderPlanRows(exact: ExactAuthorshipProofLike): NaturalWonderPlanRow[] {
+  const rows = exact.log?.naturalWonderPlan?.planRows;
+  return Array.isArray(rows)
+    ? rows.flatMap((row) => readNaturalWonderPlanRow(row))
+    : [];
+}
+
+function readLocalNaturalWonderPlanRows(local: FinalSurfaceSnapshot): NaturalWonderPlanRow[] {
+  const plan = isPlainObject(local.evidence?.naturalWonderPlan)
+    ? local.evidence.naturalWonderPlan
+    : undefined;
+  const placements = Array.isArray(plan?.placements) ? plan.placements : [];
+  return placements.flatMap((placement) => readNaturalWonderPlanRow(placement, local.width));
+}
+
+function readNaturalWonderPlanRow(value: unknown, width?: number): NaturalWonderPlanRow[] {
+  if (Array.isArray(value)) {
+    const status = value[0];
+    const plotIndex = numberValue(value[1]);
+    const x = numberValue(value[2]);
+    const y = numberValue(value[3]);
+    const featureType = numberValue(value[4]);
+    const direction = numberValue(value[5]);
+    if (status !== "p" || plotIndex === undefined || x === undefined || y === undefined || featureType === undefined || direction === undefined) {
+      return [];
+    }
+    return [
+      stripUndefinedNaturalWonderPlanRow({
+        plotIndex,
+        x,
+        y,
+        featureType,
+        direction,
+        elevation: numberOrNullValue(value[6]) ?? undefined,
+        priorityPpm: numberOrNullValue(value[7]) ?? undefined,
+      }),
+    ];
+  }
+  if (!isPlainObject(value)) return [];
+  const plotIndex = numberValue(value.plotIndex);
+  const featureType = numberValue(value.featureType);
+  const direction = numberValue(value.direction);
+  if (plotIndex === undefined || featureType === undefined || direction === undefined) return [];
+  const rowY = numberValue(value.y) ?? (width === undefined ? undefined : Math.floor(plotIndex / width));
+  const rowX = numberValue(value.x) ?? (width === undefined || rowY === undefined ? undefined : plotIndex - rowY * width);
+  if (rowX === undefined || rowY === undefined) return [];
+  return [
+    stripUndefinedNaturalWonderPlanRow({
+      plotIndex,
+      x: rowX,
+      y: rowY,
+      featureType,
+      direction,
+      elevation: numberValue(value.elevation),
+      priorityPpm: priorityPpmValue(value.priorityPpm ?? value.priority),
+    }),
+  ];
+}
+
+function stripUndefinedNaturalWonderPlanRow(
+  row: NaturalWonderPlanRow
+): NaturalWonderPlanRow {
+  return {
+    plotIndex: row.plotIndex,
+    x: row.x,
+    y: row.y,
+    featureType: row.featureType,
+    direction: row.direction,
+    ...(row.elevation === undefined ? {} : { elevation: row.elevation }),
+    ...(row.priorityPpm === undefined ? {} : { priorityPpm: row.priorityPpm }),
+  };
+}
+
+function priorityPpmValue(value: unknown): number | undefined {
+  const numeric = numberValue(value);
+  if (numeric === undefined) return undefined;
+  if (numeric > 1) return Math.max(0, Math.min(1_000_000, Math.trunc(numeric)));
+  return Math.max(0, Math.min(1_000_000, Math.round(numeric * 1_000_000)));
+}
+
+function naturalWonderPlanCoordinateDigest(
+  rows: readonly NaturalWonderPlanRow[]
+): { count: number; hash32: string } {
+  return {
+    count: rows.length,
+    hash32: hash32Hex(
+      rows
+        .slice()
+        .sort((a, b) => {
+          if (a.plotIndex !== b.plotIndex) return a.plotIndex - b.plotIndex;
+          if (a.featureType !== b.featureType) return a.featureType - b.featureType;
+          return a.direction - b.direction;
+        })
+        .map((row) => naturalWonderPlanDigestFields(row).join(":"))
+        .join("|")
+    ),
+  };
+}
+
+function naturalWonderPlanDigestFields(
+  row: NaturalWonderPlanRow
+): ReadonlyArray<string | number | null> {
+  return [
+    "p",
+    row.plotIndex,
+    row.x,
+    row.y,
+    row.featureType,
+    row.direction,
+    row.elevation ?? null,
+    row.priorityPpm ?? null,
+  ];
+}
+
+function exactNaturalWonderPlanLoggedDigest(
+  exact: ExactAuthorshipProofLike
+): { count?: number; hash32?: string } | undefined {
+  const planned = exact.log?.naturalWonderPlan?.coordinateProof?.planned;
+  const plannedDigest = coordinateDigest(planned);
+  if (plannedDigest) return plannedDigest;
+  const payload = isPlainObject(exact.log?.naturalWonderPlan?.payload)
+    ? exact.log?.naturalWonderPlan?.payload
+    : undefined;
+  const coordinateProof = isPlainObject(payload?.coordinateProof) ? payload.coordinateProof : undefined;
+  const count = numberValue(coordinateProof?.plannedCount);
+  const hash32 = typeof coordinateProof?.plannedHash32 === "string"
+    ? coordinateProof.plannedHash32
+    : undefined;
+  return count === undefined && hash32 === undefined ? undefined : { count, hash32 };
+}
+
+function buildNaturalWonderPlanRowComparisons(
+  exactRows: readonly NaturalWonderPlanRow[],
+  localRows: readonly NaturalWonderPlanRow[],
+  width: number
+): NaturalWonderPlanRowComparison[] {
+  const exactByFeature = new Map(exactRows.map((row) => [row.featureType, row] as const));
+  const localByFeature = new Map(localRows.map((row) => [row.featureType, row] as const));
+  const featureTypes = [...new Set([...exactByFeature.keys(), ...localByFeature.keys()])]
+    .sort((a, b) => a - b);
+  return featureTypes.map((featureType) => {
+    const exact = exactByFeature.get(featureType);
+    const local = localByFeature.get(featureType);
+    if (!exact) {
+      return {
+        featureType,
+        classification: "local-only",
+        local,
+      };
+    }
+    if (!local) {
+      return {
+        featureType,
+        classification: "exact-only",
+        exact,
+      };
+    }
+    return {
+      featureType,
+      classification: exact.plotIndex === local.plotIndex && exact.direction === local.direction
+        ? "exact-local-same-anchor"
+        : "exact-local-anchor-diverged",
+      exact,
+      local,
+      distance: hexDistanceOddQPeriodicX(exact.plotIndex, local.plotIndex, width),
+      ...(exact.elevation === undefined || local.elevation === undefined
+        ? {}
+        : { elevationDelta: exact.elevation - local.elevation }),
+      ...(exact.priorityPpm === undefined || local.priorityPpm === undefined
+        ? {}
+        : { priorityDeltaPpm: exact.priorityPpm - local.priorityPpm }),
+    };
+  });
+}
+
+const FNV1A_32_OFFSET = 0x811c9dc5;
+const FNV1A_32_PRIME = 0x01000193;
+
+function hash32Hex(input: string): string {
+  let hash = FNV1A_32_OFFSET;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, FNV1A_32_PRIME);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
 }
 
 function buildResourcePlacementCoordinateProofComparison(

--- a/mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
@@ -85,10 +85,31 @@ function snapshot(args: {
   localTerrain?: ReadonlyArray<number | null>;
   resourceCoordinateProof?: boolean;
   resourceRejectionContext?: boolean;
+  naturalWonderPlan?: "matching" | "diverged";
 }): FinalSurfaceSnapshot {
   const width = 2;
   const height = 1;
   const localEvidence = {
+    ...(args.naturalWonderPlan
+      ? {
+          naturalWonderPlan: {
+            width,
+            height,
+            wondersCount: 1,
+            targetCount: 1,
+            plannedCount: 1,
+            placements: [
+              {
+                plotIndex: args.naturalWonderPlan === "diverged" ? 0 : 1,
+                featureType: 30,
+                direction: 0,
+                elevation: args.naturalWonderPlan === "diverged" ? 3 : 4,
+                priority: args.naturalWonderPlan === "diverged" ? 0.25 : 0.5,
+              },
+            ],
+          },
+        }
+      : {}),
     ...(args.resourceCoordinateProof
       ? {
           resourcePlacementOutcomes: {
@@ -253,6 +274,96 @@ describe("final-surface parity proof", () => {
       exact: { placed: { count: 2, hash32: "bbbbbbbb" } },
     });
     expect(proof.unresolvedLinks).toContain("resource-placement-coordinate-proof.placed");
+  });
+
+  test("compares matching exact and local natural-wonder plan rows", () => {
+    const proof = buildFinalSurfaceParityProof({
+      exactAuthorship: exactProof({
+        log: {
+          requestId: "run-1",
+          configHash,
+          envelopeHash: "envelope-1",
+          seed: 1234,
+          dimensions: { width: 2, height: 1 },
+          naturalWonderPlan: {
+            planRows: [
+              {
+                plotIndex: 1,
+                x: 1,
+                y: 0,
+                featureType: 30,
+                direction: 0,
+                elevation: 4,
+                priorityPpm: 500000,
+              },
+            ],
+          },
+        },
+      }),
+      local: snapshot({ source: "local-mapgen", naturalWonderPlan: "matching" }),
+      live: snapshot({ source: "live-civ7" }),
+    });
+
+    expect(proof.naturalWonderPlanCoordinateProof).toMatchObject({
+      status: "match",
+      rowComparisons: [
+        {
+          featureType: 30,
+          classification: "exact-local-same-anchor",
+          distance: 0,
+          elevationDelta: 0,
+          priorityDeltaPpm: 0,
+        },
+      ],
+      mismatchedLinks: [],
+    });
+    expect(proof.unresolvedLinks).not.toContain("natural-wonder-plan-coordinate-proof.planned");
+  });
+
+  test("keeps parity unresolved when exact and local natural-wonder plan rows diverge", () => {
+    const proof = buildFinalSurfaceParityProof({
+      exactAuthorship: exactProof({
+        log: {
+          requestId: "run-1",
+          configHash,
+          envelopeHash: "envelope-1",
+          seed: 1234,
+          dimensions: { width: 2, height: 1 },
+          naturalWonderPlan: {
+            planRows: [
+              {
+                plotIndex: 1,
+                x: 1,
+                y: 0,
+                featureType: 30,
+                direction: 0,
+                elevation: 4,
+                priorityPpm: 500000,
+              },
+            ],
+          },
+        },
+      }),
+      local: snapshot({ source: "local-mapgen", naturalWonderPlan: "diverged" }),
+      live: snapshot({ source: "live-civ7" }),
+    });
+
+    expect(proof.status).toBe("unresolved");
+    expect(proof.naturalWonderPlanCoordinateProof).toMatchObject({
+      status: "mismatch",
+      rowComparisons: [
+        {
+          featureType: 30,
+          classification: "exact-local-anchor-diverged",
+          exact: { plotIndex: 1, x: 1, y: 0, elevation: 4, priorityPpm: 500000 },
+          local: { plotIndex: 0, x: 0, y: 0, elevation: 3, priorityPpm: 250000 },
+          elevationDelta: 1,
+          priorityDeltaPpm: 250000,
+        },
+      ],
+      mismatchedLinks: ["natural-wonder-plan-coordinate-proof.planned"],
+    });
+    expect(proof.unresolvedLinks).toContain("natural-wonder-plan-coordinate-proof.planned");
   });
 
   test("joins exact resource rejection rows to local placement evidence", () => {

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -582,6 +582,21 @@
     plan-input or engine-surface divergence before post-write readback repair.
     It does not authorize tuning, public config changes, local mock shortcuts,
     final-surface parity, or product acceptance.
+- [x] 2.59 Bind natural-wonder plan-coordinate proof comparison into the
+  final-surface parity proof.
+  - Current branch `codex/swooper-natural-wonder-plan-comparison-drain` adds a
+    `naturalWonderPlanCoordinateProof` comparison to the final-surface parity
+    proof. It compares exact runtime `NATURAL_WONDER_PLAN_V1` rows against the
+    local replay `naturalWonderPlan`, computes matching compact planned-row
+    digests, and exposes row-level classifications:
+    `exact-local-same-anchor`, `exact-local-anchor-diverged`, `exact-only`,
+    and `local-only`.
+  - This is proof comparison only. It does not change natural-wonder planning,
+    materialization, readback disposition, final-surface surfaces, product
+    acceptance, public config, or resource behavior. A mismatch adds the
+    explicit unresolved link `natural-wonder-plan-coordinate-proof.planned`
+    so exact/local plan divergence is not hidden behind generic feature
+    surface mismatches.
 
 ## 3. Verification
 
@@ -809,3 +824,25 @@
   - Verifier log:
     `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq3ze9g3-natural-wonder-plan-rows.log`
     (`sha256:b8a581af6a65a95204b8688e8278ad99eab0a7637ab302cc9cb3537e6d0a21cf`).
+- [x] 3.30 Run focused natural-wonder plan-coordinate comparison regressions
+  and rerun current exact-authored final-surface parity.
+  - Passed `bun test
+    mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
+    mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts
+    apps/mapgen-studio/test/runInGame/proofIdentity.test.ts`.
+  - Passed owner check `bun run --cwd mods/mod-swooper-maps check`.
+  - Verifier input request `studio-run-in-game-mq3ze9g3-1zzu` wrote
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ze9g3-1zzu-current-final-surface-parity-with-natural-wonder-plan-comparison.json`
+    (`sha256:72972c12cd87396c0f1e54793ee7a8e7d7e8aff6f2baa2a307a7161a7a0c2856`,
+    `proofHash:f6e6ad68cd1d48dff4c16465abd63c2e2ec4fa9e04b2df93e0b55a2da684c10f`).
+  - The verifier exited `2` as expected for unresolved parity. It now carries
+    the explicit unresolved link
+    `natural-wonder-plan-coordinate-proof.planned` in addition to the existing
+    resource-coordinate and surface mismatch links. Exact/local plan
+    comparison has `7/7` rows on both sides, exact planned hash `38085c90`,
+    local planned hash `b921cd4f`, and three diverged anchors: feature `30`
+    exact `4130` vs local `1342`, feature `35` exact `1686` vs local `1624`,
+    and feature `36` exact `1785` vs local `2065`.
+  - Verifier log:
+    `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq3ze9g3-natural-wonder-plan-comparison.log`
+    (`sha256:4f996cc6ad19f334910c25e0c545cfba79a7e31a21b9f599f594286f636f0309`).

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1568,21 +1568,27 @@ open.
 | Artifact | Path | Identity |
 | --- | --- | --- |
 | Exact status proof | `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-plan-proof-status.json` | `sha256:a1e25662685fee91916d27a81021ff5bf7ad90f610a79bd1ae75b27b9057fa39` |
-| Final-surface proof | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ze9g3-1zzu-current-final-surface-parity-with-natural-wonder-plan-rows.json` | `sha256:6a16a3273cc0e99120826d5adb74382dad66f0d45fb307c4af073ade9e1fe711`, `proofHash:9c19e242e009dbf89711cba6e5f40ee618e27ea8bdb707d18d2d9d8727d87296` |
-| Verifier log | `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq3ze9g3-natural-wonder-plan-rows.log` | `sha256:b8a581af6a65a95204b8688e8278ad99eab0a7637ab302cc9cb3537e6d0a21cf` |
+| Final-surface proof with raw plan rows | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ze9g3-1zzu-current-final-surface-parity-with-natural-wonder-plan-rows.json` | `sha256:6a16a3273cc0e99120826d5adb74382dad66f0d45fb307c4af073ade9e1fe711`, `proofHash:9c19e242e009dbf89711cba6e5f40ee618e27ea8bdb707d18d2d9d8727d87296` |
+| Final-surface proof with plan comparison | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ze9g3-1zzu-current-final-surface-parity-with-natural-wonder-plan-comparison.json` | `sha256:72972c12cd87396c0f1e54793ee7a8e7d7e8aff6f2baa2a307a7161a7a0c2856`, `proofHash:f6e6ad68cd1d48dff4c16465abd63c2e2ec4fa9e04b2df93e0b55a2da684c10f` |
+| Verifier log | `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq3ze9g3-natural-wonder-plan-comparison.log` | `sha256:4f996cc6ad19f334910c25e0c545cfba79a7e31a21b9f599f594286f636f0309` |
 
 Exact `NATURAL_WONDER_PLAN_V1` is now bound in the exact-authorship packet for
 request `studio-run-in-game-mq3ze9g3-1zzu`. It proves the exact planner rows:
 
-| Feature | Exact plan plot | Exact priority ppm | Local replay plot | Local priority |
-| ---: | ---: | ---: | ---: | ---: |
-| `30` | `4130` | `530579` | `1342` | `0.6107035471190667` |
-| `32` | `1228` | `888087` | `1228` | `0.8862814251333475` |
-| `34` | `1861` | `831121` | `1861` | `0.8319755537371183` |
-| `35` | `1686` | `441272` | `1624` | `0.3040659082346949` |
-| `36` | `1785` | `377995` | `2065` | `0.8272660786093309` |
-| `38` | `1000` | `736723` | `1000` | `0.7338061736703947` |
-| `39` | `5107` | `488668` | `5107` | `0.4857279896736145` |
+The current final-surface proof now carries
+`naturalWonderPlanCoordinateProof.status:mismatch`, exact planned digest
+`7/38085c90`, local planned digest `7/b921cd4f`, and unresolved link
+`natural-wonder-plan-coordinate-proof.planned`.
+
+| Feature | Class | Exact plan plot | Exact priority ppm | Local replay plot | Local priority ppm | Distance |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| `30` | `exact-local-anchor-diverged` | `4130` | `530579` | `1342` | `610704` | `42` |
+| `32` | `exact-local-same-anchor` | `1228` | `888087` | `1228` | `886281` | `0` |
+| `34` | `exact-local-same-anchor` | `1861` | `831121` | `1861` | `831976` | `0` |
+| `35` | `exact-local-anchor-diverged` | `1686` | `441272` | `1624` | `304066` | `44` |
+| `36` | `exact-local-anchor-diverged` | `1785` | `377995` | `2065` | `827266` | `38` |
+| `38` | `exact-local-same-anchor` | `1000` | `736723` | `1000` | `733806` | `0` |
+| `39` | `exact-local-same-anchor` | `5107` | `488668` | `5107` | `485728` | `0` |
 
 Exact placement then reports `7` planned, `5` placed, and `2` rejected. The
 rejected rows are feature `30` at plot `4130` and feature `36` at plot `1785`,
@@ -1596,7 +1602,8 @@ The next owner decision must explain the exact/local plan-input or
 engine-surface divergence before changing readback behavior, local mock policy,
 public Earthlike config, or natural-wonder tuning. Final-surface parity remains
 `unresolved` with terrain `140`, biome `874`, feature `376`, resource `307`,
-and resource coordinate proof links still open.
+resource coordinate proof links, and the natural-wonder plan-coordinate proof
+link still open.
 
 ## Required Next Diagnostics
 

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,6 +6,7 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
+  `codex/swooper-natural-wonder-plan-comparison-drain`, stacked above
   `codex/swooper-natural-wonder-plan-proof-drain`, stacked above
   `codex/swooper-natural-wonder-row-proof-drain`, stacked above
   `codex/swooper-natural-wonder-supported-catalog-drain`, stacked above
@@ -86,6 +87,20 @@
   remains unresolved with terrain `140`, biome `874`, feature `376`, and
   resource `307` mismatches. This is proof plumbing and source-authority
   narrowing only, not behavior repair, parity closure, or product acceptance.
+  Current follow-on proof-comparison branch
+  `codex/swooper-natural-wonder-plan-comparison-drain` makes that
+  exact/local natural-wonder plan divergence a first-class parity proof
+  comparison. The refreshed verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ze9g3-1zzu-current-final-surface-parity-with-natural-wonder-plan-comparison.json`
+  (`sha256:72972c12cd87396c0f1e54793ee7a8e7d7e8aff6f2baa2a307a7161a7a0c2856`,
+  `proofHash:f6e6ad68cd1d48dff4c16465abd63c2e2ec4fa9e04b2df93e0b55a2da684c10f`)
+  records `naturalWonderPlanCoordinateProof.status:mismatch`, exact planned
+  digest `7/38085c90`, local planned digest `7/b921cd4f`, and the explicit
+  unresolved link `natural-wonder-plan-coordinate-proof.planned`. Row
+  comparison keeps four same-anchor features visible and marks feature `30`,
+  `35`, and `36` as `exact-local-anchor-diverged`. This is proof comparison
+  only, not planner tuning, readback repair, final parity, or product
+  acceptance.
   Resource, feature, natural-wonder, and terrain source-authority
   classification remains the active work; product acceptance is not closed.
   Current resource-delta feasibility after the exact/local rejection join now

--- a/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
@@ -85,6 +85,18 @@
     exact/local plan-input or engine-surface divergence before partial
     footprint readback repair; it does not close final parity or product
     acceptance.
+    Follow-on branch `codex/swooper-natural-wonder-plan-comparison-drain`
+    binds that plan divergence as a parity proof comparison instead of leaving
+    it only as ledger prose. Refreshed verifier artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ze9g3-1zzu-current-final-surface-parity-with-natural-wonder-plan-comparison.json`
+    (`sha256:72972c12cd87396c0f1e54793ee7a8e7d7e8aff6f2baa2a307a7161a7a0c2856`,
+    `proofHash:f6e6ad68cd1d48dff4c16465abd63c2e2ec4fa9e04b2df93e0b55a2da684c10f`)
+    remains unresolved and now carries
+    `natural-wonder-plan-coordinate-proof.planned`, exact digest
+    `7/38085c90`, local digest `7/b921cd4f`, and row classifications showing
+    diverged anchors for features `30`, `35`, and `36`. This is still proof
+    comparison only, not source-authority closure, planner repair, final
+    parity, or product acceptance.
 - [ ] 1.2 Audit accepted P1/P2 review findings across recovery changes.
   - Current audit pass found no active review-disposition ledger inside
     `earthlike-live-feature-resource-legality-repair` or
@@ -111,8 +123,8 @@
 ## 3. Verification And Closure
 
 - [ ] 3.1 Run `git status --short --branch`.
-  - Current proof-contract slice must leave
-    `codex/swooper-natural-wonder-plan-proof-drain`
+  - Current proof-comparison slice must leave
+    `codex/swooper-natural-wonder-plan-comparison-drain`
     clean before commit or closure.
 - [ ] 3.2 Inspect Graphite branch/stack state.
   - Current audit snapshot: top branch
@@ -125,8 +137,9 @@
     feature/resource/source-authority proof-record branches.
   - Follow-on implementation branches:
     `codex/swooper-natural-wonder-supported-catalog-drain`,
-    `codex/swooper-natural-wonder-row-proof-drain`, then
-    `codex/swooper-natural-wonder-plan-proof-drain`.
+    `codex/swooper-natural-wonder-row-proof-drain`,
+    `codex/swooper-natural-wonder-plan-proof-drain`, then
+    `codex/swooper-natural-wonder-plan-comparison-drain`.
 - [ ] 3.3 Run `git diff --check`.
 - [ ] 3.4 Run `bun run openspec -- validate swooper-recovery-stack-product-closure --strict`.
 - [ ] 3.5 Run `bun run openspec:validate`.

--- a/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
@@ -6,7 +6,7 @@
 - Phase: product closure planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack:
-  `codex/swooper-natural-wonder-plan-proof-drain`
+  `codex/swooper-natural-wonder-plan-comparison-drain`
 - Started: 2026-06-06
 - Status: blocked until proof and activated repair changes close
 
@@ -29,6 +29,9 @@
 ## Current State
 
 - Repo/Graphite state: current top branch is
+  `codex/swooper-natural-wonder-plan-comparison-drain`, stacked above
+  `codex/swooper-natural-wonder-plan-proof-drain`,
+  `codex/swooper-natural-wonder-row-proof-drain`,
   `codex/swooper-natural-wonder-supported-catalog-drain`, stacked above
   `codex/swooper-resource-delta-feasibility-current-record-drain`,
   `codex/swooper-resource-rejection-local-context-drain`,
@@ -37,7 +40,7 @@
   `codex/swooper-resource-rejection-identity-rerun-record-drain`,
   `codex/swooper-resource-rejection-proof-identity-drain`, and the current
   Swooper proof/diagnostic drain branches.
-- Dirty files and owner: this proof-contract slice owns the current
+- Dirty files and owner: this proof-comparison slice owns the current
   Swooper/Studio telemetry and OpenSpec files and must leave the branch clean
   before commit or closure.
 - Current code evidence: exact-authorship and mapgen-completion proof are
@@ -109,6 +112,17 @@
   remains unresolved with terrain `140`, biome `874`, feature `376`, and
   resource `307` mismatches. This is proof-contract work only; final parity
   and product acceptance remain open.
+  Current follow-on branch `codex/swooper-natural-wonder-plan-comparison-drain`
+  binds that divergence as a final-surface parity proof comparison. Refreshed
+  verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq3ze9g3-1zzu-current-final-surface-parity-with-natural-wonder-plan-comparison.json`
+  (`sha256:72972c12cd87396c0f1e54793ee7a8e7d7e8aff6f2baa2a307a7161a7a0c2856`,
+  `proofHash:f6e6ad68cd1d48dff4c16465abd63c2e2ec4fa9e04b2df93e0b55a2da684c10f`)
+  remains unresolved and now carries explicit link
+  `natural-wonder-plan-coordinate-proof.planned`, exact planned digest
+  `7/38085c90`, local planned digest `7/b921cd4f`, and row classifications
+  showing diverged anchors for features `30`, `35`, and `36`. This is proof
+  comparison only; final parity and product acceptance remain open.
 - Generated outputs affected: none expected.
 - Tests/guards affected: validation and closure audits.
 
@@ -158,9 +172,10 @@
   locally repairs the natural-wonder unsupported-catalog / empty-footprint
   planning leak, and fresh exact runtime proof confirms that unsupported
   footprint rows no longer reach live natural-wonder placement telemetry.
-  Current proof-contract branch also records exact natural-wonder plan rows,
-  proving the remaining natural-wonder source decision begins at exact/local
-  plan-input or engine-surface divergence.
+  Current proof-comparison branch also records exact/local natural-wonder plan
+  coordinate mismatch as a first-class parity proof link, proving the remaining
+  natural-wonder source decision begins at exact/local plan-input or
+  engine-surface divergence.
 - Remaining tasks: final-surface parity, product acceptance, supervisor
   P1/P2 closure review, PR/remote predecessor disposition, and final Graphite
   submit/closure.
@@ -174,7 +189,7 @@
   the current exact-authorship proof.
 - Results: repo snapshot clean before this update; latest verifier artifact is
   unresolved with proof hash
-  `66ed0c2537374e77548ac560eb39434bf481162f3a9024a3986fbf0cc1fc0290`;
+  `f6e6ad68cd1d48dff4c16465abd63c2e2ec4fa9e04b2df93e0b55a2da684c10f`;
   broader review-ledger scan found historical P1/P2 entries but no active
   review ledger under the two current recovery closure changes. Focused local
   validation for the natural-wonder repair passed: `bun test


### PR DESCRIPTION
Adds `naturalWonderPlanCoordinateProof` to the final-surface parity proof by comparing exact runtime `NATURAL_WONDER_PLAN_V1` rows against local replay `naturalWonderPlan` placements.

The comparison computes compact planned-row digests using FNV-1a 32-bit hashing and produces per-feature row classifications: `exact-local-same-anchor`, `exact-local-anchor-diverged`, `exact-only`, and `local-only`. When anchors diverge, the comparison records hex distance (using `hexDistanceOddQPeriodicX`), elevation delta, and priority delta in parts-per-million. A mismatch between exact and local planned digests adds the explicit unresolved link `natural-wonder-plan-coordinate-proof.planned`, so exact/local plan divergence surfaces as a named parity failure rather than being absorbed into generic feature surface mismatches.

The comparison handles both array-encoded log rows and object-encoded local placement rows, normalizes fractional priority values to integer ppm, and falls back to logged digest fields from the exact authorship payload when inline plan rows are absent. Tests cover the matching and diverged cases, verifying digest equality, row classifications, distance and delta fields, and unresolved link propagation.