### PR TITLE
feat(swooper-natural-wonders): add NATURAL_WONDER_PLAN_INPUT_V1 telemetry binding selected-row input context into exact-authorship and local replay proof

### DIFF
--- a/apps/mapgen-studio/src/features/runInGame/status.ts
+++ b/apps/mapgen-studio/src/features/runInGame/status.ts
@@ -98,6 +98,22 @@ export type RunInGameNaturalWonderPlanRow = Readonly<{
   priorityPpm?: number;
 }>;
 
+export type RunInGameNaturalWonderPlanInputRow = Readonly<{
+  plotIndex: number;
+  x: number;
+  y: number;
+  featureType: number;
+  terrainType: number;
+  biomeType: number;
+  occupiedFeatureType: number;
+  elevation: number;
+  aridityPpm: number;
+  riverClass: number;
+  lakeMask: number;
+  blockedMask: number;
+  landMask: number;
+}>;
+
 export type RunInGameRequestStatus = Readonly<{
   recipeId?: string;
   seed?: number;
@@ -239,6 +255,16 @@ export type RunInGameExactAuthorshipProof = Readonly<{
         planned: Readonly<{ count: number; hash32: string }>;
       }>;
       planRows?: ReadonlyArray<RunInGameNaturalWonderPlanRow>;
+    }>;
+    naturalWonderPlanInput?: Readonly<{
+      marker: "NATURAL_WONDER_PLAN_INPUT_V1";
+      payload: unknown;
+      stats?: Readonly<{
+        version: number;
+        plannedCount: number;
+        rowCount: number;
+      }>;
+      inputRows?: ReadonlyArray<RunInGameNaturalWonderPlanInputRow>;
     }>;
     naturalWonderPlacement?: Readonly<{
       marker: "NATURAL_WONDER_PLACEMENT_V1";

--- a/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
+++ b/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
@@ -246,6 +246,11 @@ export function parseSwooperMapgenLogProof(args: {
     proofLine.index,
     completionLine.index
   );
+  const naturalWonderPlanInput = parseNaturalWonderPlanInputTelemetryBetween(
+    lines,
+    proofLine.index,
+    completionLine.index
+  );
   const naturalWonderPlacement = parseNaturalWonderPlacementTelemetryBetween(
     lines,
     proofLine.index,
@@ -270,6 +275,7 @@ export function parseSwooperMapgenLogProof(args: {
     ...(featureApply ? { featureApply } : {}),
     ...(resourcePlacement ? { resourcePlacement } : {}),
     ...(naturalWonderPlan ? { naturalWonderPlan } : {}),
+    ...(naturalWonderPlanInput ? { naturalWonderPlanInput } : {}),
     ...(naturalWonderPlacement ? { naturalWonderPlacement } : {}),
     matched: ["[mapgen-proof]", args.requestId, args.configHash, args.envelopeHash, "[mapgen-complete]"],
   };
@@ -476,6 +482,26 @@ function parseNaturalWonderPlanTelemetryBetween(
   return undefined;
 }
 
+function parseNaturalWonderPlanInputTelemetryBetween(
+  lines: readonly string[],
+  proofIndex: number,
+  completionIndex: number
+): NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["naturalWonderPlanInput"]> | undefined {
+  for (let index = completionIndex - 1; index > proofIndex; index -= 1) {
+    const line = lines[index] ?? "";
+    if (!line.includes("NATURAL_WONDER_PLAN_INPUT_V1")) continue;
+    const payload = parsePayloadAfterMarker(line, "NATURAL_WONDER_PLAN_INPUT_V1");
+    if (!payload) continue;
+    return {
+      marker: "NATURAL_WONDER_PLAN_INPUT_V1",
+      payload,
+      ...(naturalWonderPlanInputStats(payload) ?? {}),
+      ...(naturalWonderPlanInputRows(payload) ?? {}),
+    };
+  }
+  return undefined;
+}
+
 function featureApplyStats(
   payload: Record<string, unknown>
 ):
@@ -656,6 +682,93 @@ function naturalWonderPlanRows(
     ];
   }).slice(0, 16);
   return planRows.length === 0 ? undefined : { planRows };
+}
+
+function naturalWonderPlanInputStats(
+  payload: Record<string, unknown>
+):
+  | {
+      stats: NonNullable<
+        NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["naturalWonderPlanInput"]>["stats"]
+      >;
+    }
+  | undefined {
+  const version = numberValue(payload.version);
+  const plannedCount = numberValue(payload.plannedCount);
+  if (version === undefined || plannedCount === undefined) return undefined;
+  const rowCount = Array.isArray(payload.inputRows) ? payload.inputRows.length : 0;
+  return {
+    stats: {
+      version,
+      plannedCount,
+      rowCount,
+    },
+  };
+}
+
+function naturalWonderPlanInputRows(
+  payload: Record<string, unknown>
+):
+  | {
+      inputRows: NonNullable<
+        NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["naturalWonderPlanInput"]>["inputRows"]
+      >;
+    }
+  | undefined {
+  if (!Array.isArray(payload.inputRows)) return undefined;
+  const inputRows = payload.inputRows.flatMap((row) => {
+    if (!Array.isArray(row)) return [];
+    const status = row[0] === "p" ? "planned" : undefined;
+    const plotIndex = numberValue(row[1]);
+    const x = numberValue(row[2]);
+    const y = numberValue(row[3]);
+    const featureType = numberValue(row[4]);
+    const terrainType = numberValue(row[5]);
+    const biomeType = numberValue(row[6]);
+    const occupiedFeatureType = numberValue(row[7]);
+    const elevation = numberValue(row[8]);
+    const aridityPpm = numberValue(row[9]);
+    const riverClass = numberValue(row[10]);
+    const lakeMask = numberValue(row[11]);
+    const blockedMask = numberValue(row[12]);
+    const landMask = numberValue(row[13]);
+    if (
+      status === undefined ||
+      plotIndex === undefined ||
+      x === undefined ||
+      y === undefined ||
+      featureType === undefined ||
+      terrainType === undefined ||
+      biomeType === undefined ||
+      occupiedFeatureType === undefined ||
+      elevation === undefined ||
+      aridityPpm === undefined ||
+      riverClass === undefined ||
+      lakeMask === undefined ||
+      blockedMask === undefined ||
+      landMask === undefined
+    ) {
+      return [];
+    }
+    return [
+      {
+        plotIndex,
+        x,
+        y,
+        featureType,
+        terrainType,
+        biomeType,
+        occupiedFeatureType,
+        elevation,
+        aridityPpm,
+        riverClass,
+        lakeMask,
+        blockedMask,
+        landMask,
+      },
+    ];
+  }).slice(0, 16);
+  return inputRows.length === 0 ? undefined : { inputRows };
 }
 
 function resourcePlacementStats(

--- a/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
+++ b/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
@@ -152,6 +152,14 @@ describe("Run in Game exact authorship proof identity", () => {
             plannedHash32: "bbbbbbbb",
           },
         })}`,
+        `[SWOOPER_MOD] NATURAL_WONDER_PLAN_INPUT_V1 ${JSON.stringify({
+          version: 1,
+          plannedCount: 2,
+          inputRows: [
+            ["p", 1320, 60, 15, 35, 2, 5, -1, 120, 330000, 1, 0, 0, 1],
+            ["p", 1405, 61, 16, 36, 3, 5, -1, 90, 660000, 0, 1, 0, 1],
+          ],
+        })}`,
         `[SWOOPER_MOD] NATURAL_WONDER_PLACEMENT_V1 ${JSON.stringify({
           version: 1,
           plannedCount: 7,
@@ -273,6 +281,46 @@ describe("Run in Game exact authorship proof identity", () => {
           direction: 0,
           elevation: 90,
           priorityPpm: 420000,
+        },
+      ],
+    });
+    expect(logProof?.naturalWonderPlanInput).toMatchObject({
+      marker: "NATURAL_WONDER_PLAN_INPUT_V1",
+      stats: {
+        version: 1,
+        plannedCount: 2,
+        rowCount: 2,
+      },
+      inputRows: [
+        {
+          plotIndex: 1320,
+          x: 60,
+          y: 15,
+          featureType: 35,
+          terrainType: 2,
+          biomeType: 5,
+          occupiedFeatureType: -1,
+          elevation: 120,
+          aridityPpm: 330000,
+          riverClass: 1,
+          lakeMask: 0,
+          blockedMask: 0,
+          landMask: 1,
+        },
+        {
+          plotIndex: 1405,
+          x: 61,
+          y: 16,
+          featureType: 36,
+          terrainType: 3,
+          biomeType: 5,
+          occupiedFeatureType: -1,
+          elevation: 90,
+          aridityPpm: 660000,
+          riverClass: 0,
+          lakeMask: 1,
+          blockedMask: 0,
+          landMask: 1,
         },
       ],
     });

--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -301,6 +301,15 @@ export type ExactAuthorshipProofLike = Readonly<{
       }>;
       payload?: unknown;
     }>;
+    naturalWonderPlanInput?: Readonly<{
+      stats?: Readonly<{
+        version?: number;
+        plannedCount?: number;
+        rowCount?: number;
+      }>;
+      inputRows?: ReadonlyArray<unknown>;
+      payload?: unknown;
+    }>;
   }>;
 }>;
 
@@ -317,6 +326,7 @@ type LocalTraceEvidence = {
   featureIntents?: unknown;
   featureApplyDiagnostics?: unknown;
   naturalWonderPlan?: unknown;
+  naturalWonderPlanInput?: unknown;
   naturalWonderPlacement?: unknown;
   resourcePlan?: unknown;
   resourcePlacementOutcomes?: unknown;
@@ -409,6 +419,7 @@ export function runLocalFinalSurfaceSnapshot(input: RunLocalFinalSurfaceInput): 
   for (const event of traceEvents) {
     if (event.kind !== "step.event" || !isPlainObject(event.data)) continue;
     if (event.data.type === "placement.parity") evidence.placementParity = event.data;
+    if (event.data.type === "naturalWonder.planInput") evidence.naturalWonderPlanInput = event.data;
   }
   evidence.featureIntents = {
     vegetation: context.artifacts.get(ecologyArtifacts.featureIntentsVegetation.id),

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/index.ts
@@ -2,6 +2,11 @@ import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 
 import DerivePlacementInputsContract from "./contract.js";
 import { buildPlacementInputs } from "./inputs.js";
+import {
+  buildNaturalWonderPlanInputRuntimeTelemetry,
+  logNaturalWonderPlanInputRuntimeTelemetry,
+  traceNaturalWonderPlanInputRuntimeTelemetry,
+} from "./natural-wonder-plan-input-telemetry.js";
 import { logNaturalWonderPlanRuntimeTelemetry } from "./natural-wonder-plan-telemetry.js";
 import { placementArtifacts } from "../../artifacts.js";
 
@@ -36,10 +41,22 @@ export default createStep(DerivePlacementInputsContract, {
       biomeClassification,
       pedology,
     });
+    const naturalWonderPlanInputTelemetry = buildNaturalWonderPlanInputRuntimeTelemetry({
+      context,
+      plan: inputs.naturalWonderPlan,
+      physical: {
+        topography,
+        hydrography,
+        lakePlan,
+        biomeClassification,
+      },
+    });
     deps.artifacts.placementInputs.publish(context, inputs);
     deps.artifacts.resourcePlan.publish(context, inputs.resources);
     deps.artifacts.naturalWonderPlan.publish(context, inputs.naturalWonderPlan);
     logNaturalWonderPlanRuntimeTelemetry(inputs.naturalWonderPlan);
+    logNaturalWonderPlanInputRuntimeTelemetry(naturalWonderPlanInputTelemetry);
+    traceNaturalWonderPlanInputRuntimeTelemetry(context, naturalWonderPlanInputTelemetry);
     deps.artifacts.discoveryPlan.publish(context, inputs.discoveryPlan);
   },
 });

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/natural-wonder-plan-input-telemetry.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/natural-wonder-plan-input-telemetry.ts
@@ -1,0 +1,115 @@
+import { CIV7_BROWSER_TABLES_V0 } from "@civ7/map-policy";
+import type { ExtendedMapContext } from "@swooper/mapgen-core";
+import type { Static } from "@swooper/mapgen-core/authoring";
+
+import placement from "@mapgen/domain/placement";
+
+type NaturalWonderPlan = Static<(typeof placement.ops.planNaturalWonders)["output"]>;
+
+export type NaturalWonderPlanInputRuntimeRow = readonly [
+  status: "p",
+  plotIndex: number,
+  x: number,
+  y: number,
+  featureType: number,
+  terrainType: number,
+  biomeType: number,
+  occupiedFeatureType: number,
+  elevation: number,
+  aridityPpm: number,
+  riverClass: number,
+  lakeMask: number,
+  blockedMask: number,
+  landMask: number,
+];
+
+export type NaturalWonderPlanInputRuntimeTelemetry = {
+  version: 1;
+  plannedCount: number;
+  inputRows: NaturalWonderPlanInputRuntimeRow[];
+};
+
+type NaturalWonderPlanInputTelemetryArgs = {
+  context: ExtendedMapContext;
+  plan: NaturalWonderPlan;
+  physical: {
+    topography: {
+      landMask: Uint8Array;
+    };
+    hydrography: {
+      riverClass: Uint8Array;
+    };
+    lakePlan: {
+      lakeMask: Uint8Array;
+    };
+    biomeClassification: {
+      aridityIndex: Float32Array;
+    };
+  };
+};
+
+function normalizePpm(value: unknown): number {
+  return Number.isFinite(value)
+    ? Math.max(0, Math.min(1_000_000, Math.round((value as number) * 1_000_000)))
+    : 0;
+}
+
+function blockedMaskValue(y: number, height: number): number {
+  const polarWaterRows = Math.max(0, CIV7_BROWSER_TABLES_V0.mapGlobals.polarWaterRows | 0);
+  return polarWaterRows > 0 && (y < polarWaterRows || y >= height - polarWaterRows) ? 1 : 0;
+}
+
+export function buildNaturalWonderPlanInputRuntimeTelemetry({
+  context,
+  plan,
+  physical,
+}: NaturalWonderPlanInputTelemetryArgs): NaturalWonderPlanInputRuntimeTelemetry {
+  const { adapter } = context;
+  const { width, height } = context.dimensions;
+  const size = width * height;
+  const inputRows: NaturalWonderPlanInputRuntimeRow[] = [];
+  for (const placementPlan of plan.placements.slice(0, 16)) {
+    const plotIndex = placementPlan.plotIndex | 0;
+    if (plotIndex < 0 || plotIndex >= size) continue;
+    const y = (plotIndex / width) | 0;
+    const x = plotIndex - y * width;
+    inputRows.push([
+      "p",
+      plotIndex,
+      x,
+      y,
+      placementPlan.featureType | 0,
+      adapter.getTerrainType(x, y) | 0,
+      adapter.getBiomeType(x, y) | 0,
+      adapter.getFeatureType(x, y) | 0,
+      context.buffers.heightfield.elevation[plotIndex] ?? 0,
+      normalizePpm(physical.biomeClassification.aridityIndex[plotIndex]),
+      physical.hydrography.riverClass[plotIndex] ?? 0,
+      physical.lakePlan.lakeMask[plotIndex] ?? 0,
+      blockedMaskValue(y, height),
+      physical.topography.landMask[plotIndex] ?? 0,
+    ]);
+  }
+  return {
+    version: 1,
+    plannedCount: Math.max(0, plan.plannedCount | 0),
+    inputRows,
+  };
+}
+
+export function logNaturalWonderPlanInputRuntimeTelemetry(
+  telemetry: NaturalWonderPlanInputRuntimeTelemetry
+): void {
+  console.log(`[SWOOPER_MOD] NATURAL_WONDER_PLAN_INPUT_V1 ${JSON.stringify(telemetry)}`);
+}
+
+export function traceNaturalWonderPlanInputRuntimeTelemetry(
+  context: ExtendedMapContext,
+  telemetry: NaturalWonderPlanInputRuntimeTelemetry
+): void {
+  if (!context.trace?.isVerbose) return;
+  context.trace.event(() => ({
+    type: "naturalWonder.planInput",
+    ...telemetry,
+  }));
+}

--- a/mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts
+++ b/mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts
@@ -5,6 +5,7 @@ import { CIV7_BROWSER_TABLES_V0 } from "@civ7/map-policy";
 
 import { initializeStandardRuntime } from "../../src/recipes/standard/runtime.js";
 import { buildPlacementInputs } from "../../src/recipes/standard/stages/placement/steps/derive-placement-inputs/inputs.js";
+import { buildNaturalWonderPlanInputRuntimeTelemetry } from "../../src/recipes/standard/stages/placement/steps/derive-placement-inputs/natural-wonder-plan-input-telemetry.js";
 import { buildNaturalWonderPlanRuntimeTelemetry } from "../../src/recipes/standard/stages/placement/steps/derive-placement-inputs/natural-wonder-plan-telemetry.js";
 
 const { featureTypes, terrainTypeIndices, biomeGlobals } = CIV7_BROWSER_TABLES_V0;
@@ -257,5 +258,95 @@ describe("derive placement inputs", () => {
     });
     expect(telemetry.coordinateProof.plannedHash32).toMatch(/^[0-9a-f]{8}$/);
     expect(`[SWOOPER_MOD] NATURAL_WONDER_PLAN_V1 ${JSON.stringify(telemetry)}`.length).toBeLessThan(700);
+  });
+
+  it("builds compact natural-wonder plan input telemetry for exact runtime proof", () => {
+    const width = 4;
+    const height = 4;
+    const size = width * height;
+    const mapInfo = {
+      GridWidth: width,
+      GridHeight: height,
+      MinLatitude: -60,
+      MaxLatitude: 60,
+      PlayersLandmass1: 1,
+      PlayersLandmass2: 1,
+      StartSectorRows: 1,
+      StartSectorCols: 1,
+      NumNaturalWonders: 1,
+    };
+    const adapter = createMockAdapter({
+      width,
+      height,
+      mapInfo,
+      mapSizeId: 1,
+      defaultTerrainType: terrainTypeIndices.TERRAIN_MOUNTAIN,
+      defaultBiomeType: biomeGlobals.BIOME_PLAINS,
+      resourceTypeCatalog: [],
+      discoveryCatalog: [],
+    });
+    adapter.setFeatureType(1, 1, featureTypes.FEATURE_ICE);
+    const elevation = new Int16Array(size).fill(100);
+    elevation[5] = 240;
+    const context = {
+      dimensions: { width, height },
+      adapter,
+      buffers: {
+        heightfield: {
+          elevation,
+        },
+      },
+    } as never;
+    const telemetry = buildNaturalWonderPlanInputRuntimeTelemetry({
+      context,
+      plan: {
+        width,
+        height,
+        wondersCount: 1,
+        targetCount: 1,
+        plannedCount: 1,
+        placements: [
+          {
+            plotIndex: 5,
+            featureType: featureTypes.FEATURE_KILIMANJARO,
+            direction: 0,
+            elevation: 240,
+            priority: 0.5,
+          },
+        ],
+      },
+      physical: {
+        topography: { landMask: new Uint8Array(size).fill(1) },
+        hydrography: { riverClass: new Uint8Array(size).fill(2) },
+        lakePlan: { lakeMask: new Uint8Array(size) },
+        biomeClassification: {
+          aridityIndex: new Float32Array(size).fill(0.25),
+        },
+      },
+    });
+
+    expect(telemetry).toEqual({
+      version: 1,
+      plannedCount: 1,
+      inputRows: [
+        [
+          "p",
+          5,
+          1,
+          1,
+          featureTypes.FEATURE_KILIMANJARO,
+          terrainTypeIndices.TERRAIN_MOUNTAIN,
+          biomeGlobals.BIOME_PLAINS,
+          0,
+          240,
+          250000,
+          2,
+          0,
+          1,
+          1,
+        ],
+      ],
+    });
+    expect(`[SWOOPER_MOD] NATURAL_WONDER_PLAN_INPUT_V1 ${JSON.stringify(telemetry)}`.length).toBeLessThan(500);
   });
 });

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -597,6 +597,46 @@
     explicit unresolved link `natural-wonder-plan-coordinate-proof.planned`
     so exact/local plan divergence is not hidden behind generic feature
     surface mismatches.
+- [x] 2.60 Bind selected-row natural-wonder plan input context into future
+  exact-authorship and local replay proof packets.
+  - Current branch `codex/swooper-natural-wonder-plan-input-context-drain`
+    adds compact `NATURAL_WONDER_PLAN_INPUT_V1` runtime telemetry from the
+    placement-input owner and binds matching local verbose trace evidence into
+    final-surface parity proof. Rows carry the selected plan anchor, feature
+    type, terrain type, biome type, occupied feature type, elevation, aridity
+    ppm, river class, lake mask, polar blocked mask, and land mask.
+  - This is proof-input instrumentation only. It does not change
+    natural-wonder planning, candidate scoring, materialization, readback
+    disposition, final-surface surfaces, product acceptance, public config, or
+    resource behavior.
+- [x] 2.61 Preserve current exact-authored natural-wonder plan-input proof.
+  - Fresh exact request `studio-run-in-game-mq40o844-1zzu` completed with no
+    exact-authorship unresolved links after consuming
+    `NATURAL_WONDER_PLAN_INPUT_V1`. POST artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-plan-input-post.json`
+    has `sha256:bfbe9dacca8babdf9a9bc8ee251311db0560a2e4889683344a4a4b21d48981f9`;
+    terminal status artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-plan-input-status.json`
+    has `sha256:92916fde12abcde0b71d667bb8fdb337b9005ecd8094c8243b487551ad8c9d08`.
+  - Exact plan-input rows now prove the selected exact anchors for features
+    `30`, `35`, and `36` carry concrete terrain/biome/feature/elevation/
+    aridity/river/lake/blocked/land context, while local replay still selects
+    those feature rows at plots `1342`, `1624`, and `2065`. The exact anchor
+    input rows do not show occupied features, lake blocks, polar blocks, or
+    non-land blockers for the selected exact anchors. This narrows the next
+    owner decision toward upstream candidate/scoring surface divergence rather
+    than a simple selected-anchor legality explanation.
+  - The final-surface verifier artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input.json`
+    has `sha256:f7b3de32589c369c280461d99ad0d1eb9aa0dc1c3806b6f0d67c167a251e2974`
+    and
+    `proofHash:ddf33279f4858dfa1ab0e83ec530720cb5a62b17d35a8d7e9951ce6b595ef595`.
+    The verifier exited `2` as expected for unresolved parity and preserves
+    unresolved links `natural-wonder-plan-coordinate-proof.planned`,
+    `resource-placement-coordinate-proof.placed`,
+    `resource-placement-coordinate-proof.rejected`,
+    `surface.biome.mismatch`, `surface.feature.mismatch`,
+    `surface.resource.mismatch`, and `surface.terrain.mismatch`.
 
 ## 3. Verification
 
@@ -846,3 +886,21 @@
   - Verifier log:
     `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq3ze9g3-natural-wonder-plan-comparison.log`
     (`sha256:4f996cc6ad19f334910c25e0c545cfba79a7e31a21b9f599f594286f636f0309`).
+- [x] 3.31 Run focused natural-wonder plan-input proof regressions and rerun
+  current exact-authored final-surface parity.
+  - Passed `bun test
+    mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts
+    apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
+    mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts`.
+  - Passed owner checks `bun run --cwd mods/mod-swooper-maps check` and
+    `bun run --cwd apps/mapgen-studio check`.
+  - Verifier input request `studio-run-in-game-mq40o844-1zzu` wrote
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input.json`
+    (`sha256:f7b3de32589c369c280461d99ad0d1eb9aa0dc1c3806b6f0d67c167a251e2974`,
+    `proofHash:ddf33279f4858dfa1ab0e83ec530720cb5a62b17d35a8d7e9951ce6b595ef595`).
+  - The verifier exited `2` as expected for unresolved parity. It preserves
+    mismatch counts terrain `140`, biome `874`, feature `376`, and resource
+    `307`, and keeps the natural-wonder plan-coordinate, resource-coordinate,
+    and surface mismatch links open. Verifier log:
+    `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq40o844-natural-wonder-plan-input.log`
+    (`sha256:b551e06b83996ae920238c898afe00381be9f64148233f86d58a15ea05d404ba`).

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1605,14 +1605,53 @@ public Earthlike config, or natural-wonder tuning. Final-surface parity remains
 resource coordinate proof links, and the natural-wonder plan-coordinate proof
 link still open.
 
+### Natural-Wonder Plan Input Context Proof
+
+Classification status: selected-row input context captured; upstream candidate
+surface/scoring owner still open.
+
+| Artifact | Path | Identity |
+| --- | --- | --- |
+| Exact status proof | `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-plan-input-status.json` | `sha256:92916fde12abcde0b71d667bb8fdb337b9005ecd8094c8243b487551ad8c9d08` |
+| Final-surface proof with plan-input context | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input.json` | `sha256:f7b3de32589c369c280461d99ad0d1eb9aa0dc1c3806b6f0d67c167a251e2974`, `proofHash:ddf33279f4858dfa1ab0e83ec530720cb5a62b17d35a8d7e9951ce6b595ef595` |
+| Verifier log | `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq40o844-natural-wonder-plan-input.log` | `sha256:b551e06b83996ae920238c898afe00381be9f64148233f86d58a15ea05d404ba` |
+
+Exact `NATURAL_WONDER_PLAN_INPUT_V1` is now bound in the exact-authorship
+packet for request `studio-run-in-game-mq40o844-1zzu`, and local replay carries
+the matching verbose trace evidence. Rows preserve selected-anchor terrain,
+biome, occupied feature, elevation, aridity ppm, river class, lake mask, polar
+blocked mask, and land mask.
+
+Selected diverged-anchor context:
+
+| Feature | Exact plot | Exact input `(terrain, biome, occupied, elev, aridity, river, lake, blocked, land)` | Local plot | Local input `(terrain, biome, occupied, elev, aridity, river, lake, blocked, land)` |
+| ---: | ---: | --- | ---: | --- |
+| `30` | `4130` | `(2, 1, -1, 3, 209935, 1, 0, 0, 1)` | `1342` | `(2, 1, -1, 3, 106804, 1, 0, 0, 1)` |
+| `35` | `1686` | `(0, 2, -1, 3, 190369, 2, 0, 0, 1)` | `1624` | `(0, 2, -1, 6, 179790, 0, 0, 0, 1)` |
+| `36` | `1785` | `(0, 3, -1, 4, 117967, 0, 0, 0, 1)` | `2065` | `(0, 3, -1, 19, 117077, 2, 0, 0, 1)` |
+
+Disposition:
+the selected exact anchors are not explained by occupied-feature, lake,
+polar-block, or non-land blockers in the selected-row proof. Feature `30` has
+matching terrain/biome/elevation/river masks across exact/local selected
+anchors but a large aridity delta; features `35` and `36` also differ in
+elevation and river class at the selected anchor. This narrows the next owner
+decision toward upstream candidate set/scoring surface divergence, not public
+Earthlike config tuning, static catalog repair, or a simple selected-anchor
+legality failure. Final-surface parity remains `unresolved` with
+`natural-wonder-plan-coordinate-proof.planned`,
+`resource-placement-coordinate-proof.placed`,
+`resource-placement-coordinate-proof.rejected`, and terrain/biome/feature/
+resource surface mismatch links still open.
+
 ## Required Next Diagnostics
 
-- Classify the natural-wonder exact/local plan-input or engine-surface
-  divergence from the fresh exact `mq3ze9g3` proof before changing readback
-  behavior. Exact and local plan rows now differ for features `30`, `35`, and
-  `36`; compare the candidate surfaces, feature occupancy, terrain/biome/lake
-  masks, blocked masks, and priority inputs at the exact/local candidate plots
-  before assigning repair authority.
+- Classify the natural-wonder exact/local upstream candidate/scoring or
+  engine-surface divergence from the fresh exact `mq40o844` proof before
+  changing readback behavior. Selected-row input context is now captured for
+  exact and local anchors, but the candidate set, rejection/cut list, and score
+  terms that caused features `30`, `35`, and `36` to choose different anchors
+  are still not source-owned.
 - After the plan-input divergence is source-owned or dispositioned, classify
   the partial expected-footprint readback owner for the exact rejected feature
   `30` and `36` rows. A valid repair lane needs an explicit source-authority
@@ -1637,10 +1676,9 @@ link still open.
   resource tuning.
 - Continue resource-row classification using source-recorded coordinate proof
   and runtime-bound row evidence where applicable before changing resource
-  tuning, scarcity floors, assignment ordering, or static policy; obtain a
-  current exact-authored run before final closure. The current config now
-  passes the stale schema key boundary and restart recovery reaches setup
-  preparation with persisted launch telemetry, but Civ currently fails to load
-  `fs://game/swooper-maps/maps/studio-current.js` before mapgen proof markers.
+  tuning, scarcity floors, assignment ordering, or static policy. Current
+  exact-authored runs reach completed mapgen proof and final-surface verifier
+  input; final closure still needs accepted owner repairs plus a current
+  exact-authored acceptance proof, not stale map-script-load blockers.
 - For resource rows, preserve resource spacing, age legality, and diversity
   evidence before any repair.

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,6 +6,7 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
+  `codex/swooper-natural-wonder-plan-input-context-drain`, stacked above
   `codex/swooper-natural-wonder-plan-comparison-drain`, stacked above
   `codex/swooper-natural-wonder-plan-proof-drain`, stacked above
   `codex/swooper-natural-wonder-row-proof-drain`, stacked above
@@ -101,6 +102,20 @@
   `35`, and `36` as `exact-local-anchor-diverged`. This is proof comparison
   only, not planner tuning, readback repair, final parity, or product
   acceptance.
+  Current follow-on proof-input branch
+  `codex/swooper-natural-wonder-plan-input-context-drain` binds selected-row
+  natural-wonder plan input context into exact-authorship and local replay
+  proof. Fresh exact request `studio-run-in-game-mq40o844-1zzu` completed with
+  no exact-authorship unresolved links and records `NATURAL_WONDER_PLAN_INPUT_V1`
+  for all `7` planned exact rows. The final-surface verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input.json`
+  (`sha256:f7b3de32589c369c280461d99ad0d1eb9aa0dc1c3806b6f0d67c167a251e2974`,
+  `proofHash:ddf33279f4858dfa1ab0e83ec530720cb5a62b17d35a8d7e9951ce6b595ef595`)
+  remains unresolved with `natural-wonder-plan-coordinate-proof.planned`,
+  resource-coordinate proof links, and terrain/biome/feature/resource surface
+  mismatch links open. This narrows the natural-wonder owner question toward
+  upstream candidate/scoring surface divergence; it is not behavior repair,
+  final parity, or product acceptance.
   Resource, feature, natural-wonder, and terrain source-authority
   classification remains the active work; product acceptance is not closed.
   Current resource-delta feasibility after the exact/local rejection join now
@@ -1414,11 +1429,23 @@
   engine-surface divergence first, then partial expected-footprint readback
   ownership for the exact rejected feature `30` and `36` rows. No behavior
   repair, parity closure, or product acceptance is claimed.
+  Current proof-input branch
+  `codex/swooper-natural-wonder-plan-input-context-drain` adds selected-row
+  input context for the exact and local planned anchors. Fresh request
+  `studio-run-in-game-mq40o844-1zzu` proves exact selected anchors have
+  concrete terrain/biome/occupied-feature/elevation/aridity/river/lake/
+  blocked/land context. The current verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input.json`
+  has `sha256:f7b3de32589c369c280461d99ad0d1eb9aa0dc1c3806b6f0d67c167a251e2974`
+  and
+  `proofHash:ddf33279f4858dfa1ab0e83ec530720cb5a62b17d35a8d7e9951ce6b595ef595`.
+  The next natural-wonder owner decision is now upstream candidate/scoring
+  surface divergence; selected-row blockers alone do not explain the diverged
+  anchors. No behavior repair, parity closure, or product acceptance is
+  claimed.
   Final-surface parity remains open on terrain (`140` mismatches), biome
   (`874`), feature (`376`), resource (`307`), natural-wonder readback proof,
   resource coordinate proof, and any future owner-classified residual links.
-  Final-surface parity remains open on terrain, feature, resource,
-  natural-wonder proof, and any future owner-classified residual links.
   The single
   substitution row where both probed values are infeasible remains an individual
   evidence row with no repair authority until row-level context assigns source

--- a/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
@@ -97,6 +97,19 @@
     diverged anchors for features `30`, `35`, and `36`. This is still proof
     comparison only, not source-authority closure, planner repair, final
     parity, or product acceptance.
+    Follow-on branch `codex/swooper-natural-wonder-plan-input-context-drain`
+    binds selected-row natural-wonder plan input context into exact-authorship
+    and local replay proof. Fresh exact request
+    `studio-run-in-game-mq40o844-1zzu` records `NATURAL_WONDER_PLAN_INPUT_V1`
+    for all `7` exact selected anchors and completes exact authorship with no
+    unresolved exact links. Final-surface verifier artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input.json`
+    (`sha256:f7b3de32589c369c280461d99ad0d1eb9aa0dc1c3806b6f0d67c167a251e2974`,
+    `proofHash:ddf33279f4858dfa1ab0e83ec530720cb5a62b17d35a8d7e9951ce6b595ef595`)
+    remains unresolved with the natural-wonder plan-coordinate,
+    resource-coordinate, and terrain/biome/feature/resource surface links
+    open. This is still proof-input instrumentation, not source-authority
+    closure, planner repair, final parity, or product acceptance.
 - [ ] 1.2 Audit accepted P1/P2 review findings across recovery changes.
   - Current audit pass found no active review-disposition ledger inside
     `earthlike-live-feature-resource-legality-repair` or
@@ -123,8 +136,8 @@
 ## 3. Verification And Closure
 
 - [ ] 3.1 Run `git status --short --branch`.
-  - Current proof-comparison slice must leave
-    `codex/swooper-natural-wonder-plan-comparison-drain`
+  - Current proof-input slice must leave
+    `codex/swooper-natural-wonder-plan-input-context-drain`
     clean before commit or closure.
 - [ ] 3.2 Inspect Graphite branch/stack state.
   - Current audit snapshot: top branch
@@ -138,8 +151,9 @@
   - Follow-on implementation branches:
     `codex/swooper-natural-wonder-supported-catalog-drain`,
     `codex/swooper-natural-wonder-row-proof-drain`,
-    `codex/swooper-natural-wonder-plan-proof-drain`, then
-    `codex/swooper-natural-wonder-plan-comparison-drain`.
+    `codex/swooper-natural-wonder-plan-proof-drain`,
+    `codex/swooper-natural-wonder-plan-comparison-drain`, then
+    `codex/swooper-natural-wonder-plan-input-context-drain`.
 - [ ] 3.3 Run `git diff --check`.
 - [ ] 3.4 Run `bun run openspec -- validate swooper-recovery-stack-product-closure --strict`.
 - [ ] 3.5 Run `bun run openspec:validate`.

--- a/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
@@ -6,7 +6,7 @@
 - Phase: product closure planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack:
-  `codex/swooper-natural-wonder-plan-comparison-drain`
+  `codex/swooper-natural-wonder-plan-input-context-drain`
 - Started: 2026-06-06
 - Status: blocked until proof and activated repair changes close
 
@@ -29,6 +29,7 @@
 ## Current State
 
 - Repo/Graphite state: current top branch is
+  `codex/swooper-natural-wonder-plan-input-context-drain`, stacked above
   `codex/swooper-natural-wonder-plan-comparison-drain`, stacked above
   `codex/swooper-natural-wonder-plan-proof-drain`,
   `codex/swooper-natural-wonder-row-proof-drain`,
@@ -123,6 +124,20 @@
   `7/38085c90`, local planned digest `7/b921cd4f`, and row classifications
   showing diverged anchors for features `30`, `35`, and `36`. This is proof
   comparison only; final parity and product acceptance remain open.
+  Current follow-on branch
+  `codex/swooper-natural-wonder-plan-input-context-drain` binds selected-row
+  natural-wonder plan input context into exact-authorship and local replay
+  proof. Fresh exact request `studio-run-in-game-mq40o844-1zzu` completed
+  exact authorship with no unresolved exact links and records terrain, biome,
+  occupied feature, elevation, aridity, river, lake, blocked, and land masks
+  for all `7` exact selected anchors. Final-surface verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input.json`
+  (`sha256:f7b3de32589c369c280461d99ad0d1eb9aa0dc1c3806b6f0d67c167a251e2974`,
+  `proofHash:ddf33279f4858dfa1ab0e83ec530720cb5a62b17d35a8d7e9951ce6b595ef595`)
+  remains unresolved with the natural-wonder plan-coordinate, resource
+  coordinate, and terrain/biome/feature/resource surface links open. This
+  narrows the next owner decision toward candidate/scoring surface divergence;
+  it is not behavior repair, final parity, or product acceptance.
 - Generated outputs affected: none expected.
 - Tests/guards affected: validation and closure audits.
 
@@ -175,7 +190,9 @@
   Current proof-comparison branch also records exact/local natural-wonder plan
   coordinate mismatch as a first-class parity proof link, proving the remaining
   natural-wonder source decision begins at exact/local plan-input or
-  engine-surface divergence.
+  engine-surface divergence. Current proof-input branch records selected-row
+  natural-wonder input context for that divergence without closing source
+  ownership.
 - Remaining tasks: final-surface parity, product acceptance, supervisor
   P1/P2 closure review, PR/remote predecessor disposition, and final Graphite
   submit/closure.
@@ -218,10 +235,12 @@
 ## Next Action
 
 - Exact next step: classify the exact/local natural-wonder plan-input or
-  engine-surface divergence now proven by request
-  `studio-run-in-game-mq3ze9g3-1zzu`. Exact plans feature `30` at `4130`,
-  feature `35` at `1686`, and feature `36` at `1785`; local replay plans those
-  features at `1342`, `1624`, and `2065`. Do not repair readback behavior
+  engine-surface divergence now narrowed by request
+  `studio-run-in-game-mq40o844-1zzu`. Selected-row input context is captured
+  for exact and local anchors, but the upstream candidate set, cut/reject list,
+  and score terms that selected feature `30` at `4130` instead of `1342`,
+  feature `35` at `1686` instead of `1624`, and feature `36` at `1785`
+  instead of `2065` are still not source-owned. Do not repair readback behavior
   until that divergence is source-owned or deliberately dispositioned. Then
   continue the remaining queue: partial footprint readback for exact rejected
   natural-wonder rows, cross-resource scarce-floor divergence at plot `4838`,


### PR DESCRIPTION
Adds `NATURAL_WONDER_PLAN_INPUT_V1` telemetry that captures the per-plot input context for each selected natural wonder anchor at the time placement inputs are derived. Each row records the plot index, coordinates, feature type, terrain type, biome type, occupied feature type, elevation, aridity ppm, river class, lake mask, polar blocked mask, and land mask.

The telemetry is emitted as a compact log line consumed by the exact-authorship proof parser and also written as a verbose trace event for local replay parity. The proof parser extracts stats (`version`, `plannedCount`, `rowCount`) and up to 16 input rows from the log payload, binding them into `RunInGameExactAuthorshipProof` alongside the existing natural wonder plan proof. The live-parity diagnostic surface picks up the matching `naturalWonder.planInput` trace event for local evidence.

This is instrumentation only. It does not change natural wonder planning, candidate scoring, materialization, readback disposition, final-surface outputs, public config, or resource behavior.