### PR TITLE
test(mapgen): compare natural wonder plan inputs

### DIFF
--- a/apps/mapgen-studio/src/features/runInGame/status.ts
+++ b/apps/mapgen-studio/src/features/runInGame/status.ts
@@ -114,6 +114,20 @@ export type RunInGameNaturalWonderPlanInputRow = Readonly<{
   landMask: number;
 }>;
 
+export type RunInGameNaturalWonderPlanInputSurfaceDigests = Readonly<{
+  version: number;
+  plotCount: number;
+  landMaskHash32: string;
+  elevationHash32: string;
+  aridityPpmHash32: string;
+  riverClassHash32: string;
+  lakeMaskHash32: string;
+  blockedMaskHash32: string;
+  terrainTypeHash32: string;
+  biomeTypeHash32: string;
+  featureTypeHash32: string;
+}>;
+
 export type RunInGameRequestStatus = Readonly<{
   recipeId?: string;
   seed?: number;
@@ -264,6 +278,7 @@ export type RunInGameExactAuthorshipProof = Readonly<{
         plannedCount: number;
         rowCount: number;
       }>;
+      surfaceDigests?: RunInGameNaturalWonderPlanInputSurfaceDigests;
       inputRows?: ReadonlyArray<RunInGameNaturalWonderPlanInputRow>;
     }>;
     naturalWonderPlacement?: Readonly<{

--- a/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
+++ b/apps/mapgen-studio/src/server/runInGame/proofIdentity.ts
@@ -496,6 +496,7 @@ function parseNaturalWonderPlanInputTelemetryBetween(
       marker: "NATURAL_WONDER_PLAN_INPUT_V1",
       payload,
       ...(naturalWonderPlanInputStats(payload) ?? {}),
+      ...(naturalWonderPlanInputSurfaceDigests(payload) ?? {}),
       ...(naturalWonderPlanInputRows(payload) ?? {}),
     };
   }
@@ -702,6 +703,59 @@ function naturalWonderPlanInputStats(
       version,
       plannedCount,
       rowCount,
+    },
+  };
+}
+
+function naturalWonderPlanInputSurfaceDigests(
+  payload: Record<string, unknown>
+):
+  | {
+      surfaceDigests: NonNullable<
+        NonNullable<NonNullable<RunInGameExactAuthorshipProof["log"]>["naturalWonderPlanInput"]>["surfaceDigests"]
+      >;
+    }
+  | undefined {
+  if (!isRecord(payload.surfaceDigests)) return undefined;
+  const version = numberValue(payload.surfaceDigests.version);
+  const plotCount = numberValue(payload.surfaceDigests.plotCount);
+  const landMaskHash32 = hash32Value(payload.surfaceDigests.landMaskHash32);
+  const elevationHash32 = hash32Value(payload.surfaceDigests.elevationHash32);
+  const aridityPpmHash32 = hash32Value(payload.surfaceDigests.aridityPpmHash32);
+  const riverClassHash32 = hash32Value(payload.surfaceDigests.riverClassHash32);
+  const lakeMaskHash32 = hash32Value(payload.surfaceDigests.lakeMaskHash32);
+  const blockedMaskHash32 = hash32Value(payload.surfaceDigests.blockedMaskHash32);
+  const terrainTypeHash32 = hash32Value(payload.surfaceDigests.terrainTypeHash32);
+  const biomeTypeHash32 = hash32Value(payload.surfaceDigests.biomeTypeHash32);
+  const featureTypeHash32 = hash32Value(payload.surfaceDigests.featureTypeHash32);
+  if (
+    version === undefined ||
+    plotCount === undefined ||
+    landMaskHash32 === undefined ||
+    elevationHash32 === undefined ||
+    aridityPpmHash32 === undefined ||
+    riverClassHash32 === undefined ||
+    lakeMaskHash32 === undefined ||
+    blockedMaskHash32 === undefined ||
+    terrainTypeHash32 === undefined ||
+    biomeTypeHash32 === undefined ||
+    featureTypeHash32 === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    surfaceDigests: {
+      version,
+      plotCount,
+      landMaskHash32,
+      elevationHash32,
+      aridityPpmHash32,
+      riverClassHash32,
+      lakeMaskHash32,
+      blockedMaskHash32,
+      terrainTypeHash32,
+      biomeTypeHash32,
+      featureTypeHash32,
     },
   };
 }

--- a/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
+++ b/apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
@@ -155,6 +155,19 @@ describe("Run in Game exact authorship proof identity", () => {
         `[SWOOPER_MOD] NATURAL_WONDER_PLAN_INPUT_V1 ${JSON.stringify({
           version: 1,
           plannedCount: 2,
+          surfaceDigests: {
+            version: 1,
+            plotCount: 10240,
+            landMaskHash32: "11111111",
+            elevationHash32: "22222222",
+            aridityPpmHash32: "33333333",
+            riverClassHash32: "44444444",
+            lakeMaskHash32: "55555555",
+            blockedMaskHash32: "66666666",
+            terrainTypeHash32: "77777777",
+            biomeTypeHash32: "88888888",
+            featureTypeHash32: "99999999",
+          },
           inputRows: [
             ["p", 1320, 60, 15, 35, 2, 5, -1, 120, 330000, 1, 0, 0, 1],
             ["p", 1405, 61, 16, 36, 3, 5, -1, 90, 660000, 0, 1, 0, 1],
@@ -290,6 +303,19 @@ describe("Run in Game exact authorship proof identity", () => {
         version: 1,
         plannedCount: 2,
         rowCount: 2,
+      },
+      surfaceDigests: {
+        version: 1,
+        plotCount: 10240,
+        landMaskHash32: "11111111",
+        elevationHash32: "22222222",
+        aridityPpmHash32: "33333333",
+        riverClassHash32: "44444444",
+        lakeMaskHash32: "55555555",
+        blockedMaskHash32: "66666666",
+        terrainTypeHash32: "77777777",
+        biomeTypeHash32: "88888888",
+        featureTypeHash32: "99999999",
       },
       inputRows: [
         {

--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -111,6 +111,19 @@ type NaturalWonderPlanCoordinateProofComparison = Readonly<{
   mismatchedLinks: ReadonlyArray<string>;
 }>;
 
+type NaturalWonderPlanInputContextProofComparison = Readonly<{
+  status: "compared" | "missing-exact-log" | "missing-local-input";
+  surfaceDigests?: NaturalWonderPlanInputSurfaceDigestComparison;
+  rowComparisons: ReadonlyArray<NaturalWonderPlanInputRowComparison>;
+}>;
+
+type NaturalWonderPlanInputSurfaceDigestComparison = Readonly<{
+  status: "match" | "mismatch" | "missing-exact-log" | "missing-local-input";
+  exact?: NaturalWonderPlanInputSurfaceDigests;
+  local?: NaturalWonderPlanInputSurfaceDigests;
+  mismatchedFields: ReadonlyArray<keyof NaturalWonderPlanInputSurfaceDigests>;
+}>;
+
 type NaturalWonderPlanRowComparison = Readonly<{
   featureType: number;
   classification:
@@ -134,6 +147,76 @@ type NaturalWonderPlanRow = Readonly<{
   elevation?: number;
   priorityPpm?: number;
 }>;
+
+type NaturalWonderPlanInputRowComparison = Readonly<{
+  featureType: number;
+  classification:
+    | "exact-local-same-anchor-input-match"
+    | "exact-local-same-anchor-input-drift"
+    | "exact-local-anchor-diverged"
+    | "exact-only"
+    | "local-only";
+  exact?: NaturalWonderPlanInputRow;
+  local?: NaturalWonderPlanInputRow;
+  distance?: number;
+  inputDelta?: NaturalWonderPlanInputDelta;
+}>;
+
+type NaturalWonderPlanInputRow = Readonly<{
+  plotIndex: number;
+  x: number;
+  y: number;
+  featureType: number;
+  terrainType: number;
+  biomeType: number;
+  occupiedFeatureType: number;
+  elevation: number;
+  aridityPpm: number;
+  riverClass: number;
+  lakeMask: number;
+  blockedMask: number;
+  landMask: number;
+}>;
+
+type NaturalWonderPlanInputDelta = Readonly<Partial<{
+  terrainType: Readonly<{ exact: number; local: number }>;
+  biomeType: Readonly<{ exact: number; local: number }>;
+  occupiedFeatureType: Readonly<{ exact: number; local: number }>;
+  elevationDelta: number;
+  aridityPpmDelta: number;
+  riverClassDelta: number;
+  lakeMaskDelta: number;
+  blockedMaskDelta: number;
+  landMaskDelta: number;
+}>>;
+
+type NaturalWonderPlanInputSurfaceDigests = Readonly<{
+  version: number;
+  plotCount: number;
+  landMaskHash32: string;
+  elevationHash32: string;
+  aridityPpmHash32: string;
+  riverClassHash32: string;
+  lakeMaskHash32: string;
+  blockedMaskHash32: string;
+  terrainTypeHash32: string;
+  biomeTypeHash32: string;
+  featureTypeHash32: string;
+}>;
+
+const NATURAL_WONDER_PLAN_INPUT_SURFACE_DIGEST_FIELDS: readonly (keyof NaturalWonderPlanInputSurfaceDigests)[] = [
+  "version",
+  "plotCount",
+  "landMaskHash32",
+  "elevationHash32",
+  "aridityPpmHash32",
+  "riverClassHash32",
+  "lakeMaskHash32",
+  "blockedMaskHash32",
+  "terrainTypeHash32",
+  "biomeTypeHash32",
+  "featureTypeHash32",
+];
 
 export type ResourcePlacementRejectionContext = Readonly<{
   exact: Readonly<{
@@ -199,6 +282,7 @@ export type FinalSurfaceParityProof = Readonly<{
   live: FinalSurfaceSnapshot;
   diffs: ReadonlyArray<SurfaceDiffSummary>;
   naturalWonderPlanCoordinateProof?: NaturalWonderPlanCoordinateProofComparison;
+  naturalWonderPlanInputContextProof?: NaturalWonderPlanInputContextProofComparison;
   resourcePlacementCoordinateProof?: ResourcePlacementCoordinateProofComparison;
   resourcePlacementRejectionContexts?: ReadonlyArray<ResourcePlacementRejectionContext>;
   residuals: ReadonlyArray<ParityResidualClassification>;
@@ -307,6 +391,7 @@ export type ExactAuthorshipProofLike = Readonly<{
         plannedCount?: number;
         rowCount?: number;
       }>;
+      surfaceDigests?: unknown;
       inputRows?: ReadonlyArray<unknown>;
       payload?: unknown;
     }>;
@@ -733,6 +818,8 @@ export function buildFinalSurfaceParityProof(args: {
   const exact = args.exactAuthorship;
   const naturalWonderPlanCoordinateProof =
     exact === undefined ? undefined : buildNaturalWonderPlanCoordinateProofComparison(exact, args.local);
+  const naturalWonderPlanInputContextProof =
+    exact === undefined ? undefined : buildNaturalWonderPlanInputContextProofComparison(exact, args.local);
   const resourcePlacementCoordinateProof =
     exact === undefined ? undefined : buildResourcePlacementCoordinateProofComparison(exact, args.local);
   const resourcePlacementRejectionContexts =
@@ -856,6 +943,9 @@ export function buildFinalSurfaceParityProof(args: {
     ...(naturalWonderPlanCoordinateProof === undefined
       ? {}
       : { naturalWonderPlanCoordinateProof }),
+    ...(naturalWonderPlanInputContextProof === undefined
+      ? {}
+      : { naturalWonderPlanInputContextProof }),
     ...(resourcePlacementCoordinateProof === undefined ? {} : { resourcePlacementCoordinateProof }),
     ...(resourcePlacementRejectionContexts.length === 0
       ? {}
@@ -1267,6 +1357,315 @@ function buildNaturalWonderPlanRowComparisons(
   });
 }
 
+function buildNaturalWonderPlanInputContextProofComparison(
+  exact: ExactAuthorshipProofLike,
+  local: FinalSurfaceSnapshot
+): NaturalWonderPlanInputContextProofComparison | undefined {
+  const exactRows = readExactNaturalWonderPlanInputRows(exact);
+  const localRows = readLocalNaturalWonderPlanInputRows(local);
+  const surfaceDigests = buildNaturalWonderPlanInputSurfaceDigestComparison(exact, local);
+  if (exactRows.length === 0 && localRows.length === 0 && surfaceDigests === undefined) return undefined;
+  const rowComparisons = buildNaturalWonderPlanInputRowComparisons(exactRows, localRows, local.width);
+  if (exactRows.length === 0) {
+    return {
+      status: "missing-exact-log",
+      ...(surfaceDigests === undefined ? {} : { surfaceDigests }),
+      rowComparisons,
+    };
+  }
+  if (localRows.length === 0) {
+    return {
+      status: "missing-local-input",
+      ...(surfaceDigests === undefined ? {} : { surfaceDigests }),
+      rowComparisons,
+    };
+  }
+  return {
+    status: "compared",
+    ...(surfaceDigests === undefined ? {} : { surfaceDigests }),
+    rowComparisons,
+  };
+}
+
+function buildNaturalWonderPlanInputSurfaceDigestComparison(
+  exact: ExactAuthorshipProofLike,
+  local: FinalSurfaceSnapshot
+): NaturalWonderPlanInputSurfaceDigestComparison | undefined {
+  const exactSurfaceDigests = readExactNaturalWonderPlanInputSurfaceDigests(exact);
+  const localSurfaceDigests = readLocalNaturalWonderPlanInputSurfaceDigests(local);
+  if (!exactSurfaceDigests && !localSurfaceDigests) return undefined;
+  if (!exactSurfaceDigests) {
+    return {
+      status: "missing-exact-log",
+      local: localSurfaceDigests,
+      mismatchedFields: [],
+    };
+  }
+  if (!localSurfaceDigests) {
+    return {
+      status: "missing-local-input",
+      exact: exactSurfaceDigests,
+      mismatchedFields: [],
+    };
+  }
+  const mismatchedFields = NATURAL_WONDER_PLAN_INPUT_SURFACE_DIGEST_FIELDS.filter(
+    (field) => exactSurfaceDigests[field] !== localSurfaceDigests[field]
+  );
+  return {
+    status: mismatchedFields.length === 0 ? "match" : "mismatch",
+    exact: exactSurfaceDigests,
+    local: localSurfaceDigests,
+    mismatchedFields,
+  };
+}
+
+function readExactNaturalWonderPlanInputSurfaceDigests(
+  exact: ExactAuthorshipProofLike
+): NaturalWonderPlanInputSurfaceDigests | undefined {
+  return readNaturalWonderPlanInputSurfaceDigests(exact.log?.naturalWonderPlanInput?.surfaceDigests);
+}
+
+function readLocalNaturalWonderPlanInputSurfaceDigests(
+  local: FinalSurfaceSnapshot
+): NaturalWonderPlanInputSurfaceDigests | undefined {
+  const input = isPlainObject(local.evidence?.naturalWonderPlanInput)
+    ? local.evidence.naturalWonderPlanInput
+    : undefined;
+  return readNaturalWonderPlanInputSurfaceDigests(input?.surfaceDigests);
+}
+
+function readNaturalWonderPlanInputSurfaceDigests(
+  value: unknown
+): NaturalWonderPlanInputSurfaceDigests | undefined {
+  if (!isPlainObject(value)) return undefined;
+  const version = numberValue(value.version);
+  const plotCount = numberValue(value.plotCount);
+  const landMaskHash32 = hash32Value(value.landMaskHash32);
+  const elevationHash32 = hash32Value(value.elevationHash32);
+  const aridityPpmHash32 = hash32Value(value.aridityPpmHash32);
+  const riverClassHash32 = hash32Value(value.riverClassHash32);
+  const lakeMaskHash32 = hash32Value(value.lakeMaskHash32);
+  const blockedMaskHash32 = hash32Value(value.blockedMaskHash32);
+  const terrainTypeHash32 = hash32Value(value.terrainTypeHash32);
+  const biomeTypeHash32 = hash32Value(value.biomeTypeHash32);
+  const featureTypeHash32 = hash32Value(value.featureTypeHash32);
+  if (
+    version === undefined ||
+    plotCount === undefined ||
+    landMaskHash32 === undefined ||
+    elevationHash32 === undefined ||
+    aridityPpmHash32 === undefined ||
+    riverClassHash32 === undefined ||
+    lakeMaskHash32 === undefined ||
+    blockedMaskHash32 === undefined ||
+    terrainTypeHash32 === undefined ||
+    biomeTypeHash32 === undefined ||
+    featureTypeHash32 === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    version,
+    plotCount,
+    landMaskHash32,
+    elevationHash32,
+    aridityPpmHash32,
+    riverClassHash32,
+    lakeMaskHash32,
+    blockedMaskHash32,
+    terrainTypeHash32,
+    biomeTypeHash32,
+    featureTypeHash32,
+  };
+}
+
+function readExactNaturalWonderPlanInputRows(
+  exact: ExactAuthorshipProofLike
+): NaturalWonderPlanInputRow[] {
+  const rows = exact.log?.naturalWonderPlanInput?.inputRows;
+  return Array.isArray(rows)
+    ? rows.flatMap((row) => readNaturalWonderPlanInputRow(row))
+    : [];
+}
+
+function readLocalNaturalWonderPlanInputRows(
+  local: FinalSurfaceSnapshot
+): NaturalWonderPlanInputRow[] {
+  const input = isPlainObject(local.evidence?.naturalWonderPlanInput)
+    ? local.evidence.naturalWonderPlanInput
+    : undefined;
+  const rows = Array.isArray(input?.inputRows) ? input.inputRows : [];
+  return rows.flatMap((row) => readNaturalWonderPlanInputRow(row));
+}
+
+function readNaturalWonderPlanInputRow(value: unknown): NaturalWonderPlanInputRow[] {
+  if (Array.isArray(value)) {
+    const status = value[0];
+    const plotIndex = numberValue(value[1]);
+    const x = numberValue(value[2]);
+    const y = numberValue(value[3]);
+    const featureType = numberValue(value[4]);
+    const terrainType = numberValue(value[5]);
+    const biomeType = numberValue(value[6]);
+    const occupiedFeatureType = numberValue(value[7]);
+    const elevation = numberValue(value[8]);
+    const aridityPpm = numberValue(value[9]);
+    const riverClass = numberValue(value[10]);
+    const lakeMask = numberValue(value[11]);
+    const blockedMask = numberValue(value[12]);
+    const landMask = numberValue(value[13]);
+    if (
+      status !== "p" ||
+      plotIndex === undefined ||
+      x === undefined ||
+      y === undefined ||
+      featureType === undefined ||
+      terrainType === undefined ||
+      biomeType === undefined ||
+      occupiedFeatureType === undefined ||
+      elevation === undefined ||
+      aridityPpm === undefined ||
+      riverClass === undefined ||
+      lakeMask === undefined ||
+      blockedMask === undefined ||
+      landMask === undefined
+    ) {
+      return [];
+    }
+    return [
+      {
+        plotIndex,
+        x,
+        y,
+        featureType,
+        terrainType,
+        biomeType,
+        occupiedFeatureType,
+        elevation,
+        aridityPpm,
+        riverClass,
+        lakeMask,
+        blockedMask,
+        landMask,
+      },
+    ];
+  }
+  if (!isPlainObject(value)) return [];
+  const plotIndex = numberValue(value.plotIndex);
+  const x = numberValue(value.x);
+  const y = numberValue(value.y);
+  const featureType = numberValue(value.featureType);
+  const terrainType = numberValue(value.terrainType);
+  const biomeType = numberValue(value.biomeType);
+  const occupiedFeatureType = numberValue(value.occupiedFeatureType);
+  const elevation = numberValue(value.elevation);
+  const aridityPpm = numberValue(value.aridityPpm);
+  const riverClass = numberValue(value.riverClass);
+  const lakeMask = numberValue(value.lakeMask);
+  const blockedMask = numberValue(value.blockedMask);
+  const landMask = numberValue(value.landMask);
+  if (
+    plotIndex === undefined ||
+    x === undefined ||
+    y === undefined ||
+    featureType === undefined ||
+    terrainType === undefined ||
+    biomeType === undefined ||
+    occupiedFeatureType === undefined ||
+    elevation === undefined ||
+    aridityPpm === undefined ||
+    riverClass === undefined ||
+    lakeMask === undefined ||
+    blockedMask === undefined ||
+    landMask === undefined
+  ) {
+    return [];
+  }
+  return [
+    {
+      plotIndex,
+      x,
+      y,
+      featureType,
+      terrainType,
+      biomeType,
+      occupiedFeatureType,
+      elevation,
+      aridityPpm,
+      riverClass,
+      lakeMask,
+      blockedMask,
+      landMask,
+    },
+  ];
+}
+
+function buildNaturalWonderPlanInputRowComparisons(
+  exactRows: readonly NaturalWonderPlanInputRow[],
+  localRows: readonly NaturalWonderPlanInputRow[],
+  width: number
+): NaturalWonderPlanInputRowComparison[] {
+  const exactByFeature = new Map(exactRows.map((row) => [row.featureType, row] as const));
+  const localByFeature = new Map(localRows.map((row) => [row.featureType, row] as const));
+  const featureTypes = [...new Set([...exactByFeature.keys(), ...localByFeature.keys()])]
+    .sort((a, b) => a - b);
+  return featureTypes.map((featureType) => {
+    const exact = exactByFeature.get(featureType);
+    const local = localByFeature.get(featureType);
+    if (!exact) {
+      return {
+        featureType,
+        classification: "local-only",
+        local,
+      };
+    }
+    if (!local) {
+      return {
+        featureType,
+        classification: "exact-only",
+        exact,
+      };
+    }
+    const inputDelta = naturalWonderPlanInputDelta(exact, local);
+    const sameAnchor = exact.plotIndex === local.plotIndex;
+    return {
+      featureType,
+      classification: sameAnchor
+        ? Object.keys(inputDelta).length === 0
+          ? "exact-local-same-anchor-input-match"
+          : "exact-local-same-anchor-input-drift"
+        : "exact-local-anchor-diverged",
+      exact,
+      local,
+      distance: hexDistanceOddQPeriodicX(exact.plotIndex, local.plotIndex, width),
+      ...(Object.keys(inputDelta).length === 0 ? {} : { inputDelta }),
+    };
+  });
+}
+
+function naturalWonderPlanInputDelta(
+  exact: NaturalWonderPlanInputRow,
+  local: NaturalWonderPlanInputRow
+): NaturalWonderPlanInputDelta {
+  return stripUndefined({
+    terrainType: exact.terrainType === local.terrainType
+      ? undefined
+      : { exact: exact.terrainType, local: local.terrainType },
+    biomeType: exact.biomeType === local.biomeType
+      ? undefined
+      : { exact: exact.biomeType, local: local.biomeType },
+    occupiedFeatureType: exact.occupiedFeatureType === local.occupiedFeatureType
+      ? undefined
+      : { exact: exact.occupiedFeatureType, local: local.occupiedFeatureType },
+    elevationDelta: exact.elevation === local.elevation ? undefined : exact.elevation - local.elevation,
+    aridityPpmDelta: exact.aridityPpm === local.aridityPpm ? undefined : exact.aridityPpm - local.aridityPpm,
+    riverClassDelta: exact.riverClass === local.riverClass ? undefined : exact.riverClass - local.riverClass,
+    lakeMaskDelta: exact.lakeMask === local.lakeMask ? undefined : exact.lakeMask - local.lakeMask,
+    blockedMaskDelta: exact.blockedMask === local.blockedMask ? undefined : exact.blockedMask - local.blockedMask,
+    landMaskDelta: exact.landMask === local.landMask ? undefined : exact.landMask - local.landMask,
+  }) ?? {};
+}
+
 const FNV1A_32_OFFSET = 0x811c9dc5;
 const FNV1A_32_PRIME = 0x01000193;
 
@@ -1603,6 +2002,10 @@ function indexedSurfaceValue(values: ReadonlyArray<number | null>, index: number
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
+}
+
+function hash32Value(value: unknown): string | undefined {
+  return typeof value === "string" && /^[0-9a-f]{8}$/.test(value) ? value : undefined;
 }
 
 function stringOrNullValue(value: unknown): string | null | undefined {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/natural-wonder-plan-input-telemetry.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/derive-placement-inputs/natural-wonder-plan-input-telemetry.ts
@@ -26,7 +26,22 @@ export type NaturalWonderPlanInputRuntimeRow = readonly [
 export type NaturalWonderPlanInputRuntimeTelemetry = {
   version: 1;
   plannedCount: number;
+  surfaceDigests: NaturalWonderPlanInputSurfaceDigests;
   inputRows: NaturalWonderPlanInputRuntimeRow[];
+};
+
+export type NaturalWonderPlanInputSurfaceDigests = {
+  version: 1;
+  plotCount: number;
+  landMaskHash32: string;
+  elevationHash32: string;
+  aridityPpmHash32: string;
+  riverClassHash32: string;
+  lakeMaskHash32: string;
+  blockedMaskHash32: string;
+  terrainTypeHash32: string;
+  biomeTypeHash32: string;
+  featureTypeHash32: string;
 };
 
 type NaturalWonderPlanInputTelemetryArgs = {
@@ -59,6 +74,21 @@ function blockedMaskValue(y: number, height: number): number {
   return polarWaterRows > 0 && (y < polarWaterRows || y >= height - polarWaterRows) ? 1 : 0;
 }
 
+function hash32Values(values: Iterable<number>): string {
+  let hash = 0x811c9dc5;
+  for (const value of values) {
+    hash ^= value & 0xff;
+    hash = Math.imul(hash, 0x01000193);
+    hash ^= (value >> 8) & 0xff;
+    hash = Math.imul(hash, 0x01000193);
+    hash ^= (value >> 16) & 0xff;
+    hash = Math.imul(hash, 0x01000193);
+    hash ^= (value >> 24) & 0xff;
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
 export function buildNaturalWonderPlanInputRuntimeTelemetry({
   context,
   plan,
@@ -68,6 +98,20 @@ export function buildNaturalWonderPlanInputRuntimeTelemetry({
   const { width, height } = context.dimensions;
   const size = width * height;
   const inputRows: NaturalWonderPlanInputRuntimeRow[] = [];
+  const blockedMask = new Uint8Array(size);
+  const terrainType = new Uint32Array(size);
+  const biomeType = new Uint32Array(size);
+  const featureType = new Int32Array(size);
+  const aridityPpm = new Uint32Array(size);
+  for (let plotIndex = 0; plotIndex < size; plotIndex += 1) {
+    const y = (plotIndex / width) | 0;
+    const x = plotIndex - y * width;
+    blockedMask[plotIndex] = blockedMaskValue(y, height);
+    terrainType[plotIndex] = adapter.getTerrainType(x, y) | 0;
+    biomeType[plotIndex] = adapter.getBiomeType(x, y) | 0;
+    featureType[plotIndex] = adapter.getFeatureType(x, y) | 0;
+    aridityPpm[plotIndex] = normalizePpm(physical.biomeClassification.aridityIndex[plotIndex]);
+  }
   for (const placementPlan of plan.placements.slice(0, 16)) {
     const plotIndex = placementPlan.plotIndex | 0;
     if (plotIndex < 0 || plotIndex >= size) continue;
@@ -79,20 +123,33 @@ export function buildNaturalWonderPlanInputRuntimeTelemetry({
       x,
       y,
       placementPlan.featureType | 0,
-      adapter.getTerrainType(x, y) | 0,
-      adapter.getBiomeType(x, y) | 0,
-      adapter.getFeatureType(x, y) | 0,
+      terrainType[plotIndex] ?? 0,
+      biomeType[plotIndex] ?? 0,
+      featureType[plotIndex] ?? 0,
       context.buffers.heightfield.elevation[plotIndex] ?? 0,
-      normalizePpm(physical.biomeClassification.aridityIndex[plotIndex]),
+      aridityPpm[plotIndex] ?? 0,
       physical.hydrography.riverClass[plotIndex] ?? 0,
       physical.lakePlan.lakeMask[plotIndex] ?? 0,
-      blockedMaskValue(y, height),
+      blockedMask[plotIndex] ?? 0,
       physical.topography.landMask[plotIndex] ?? 0,
     ]);
   }
   return {
     version: 1,
     plannedCount: Math.max(0, plan.plannedCount | 0),
+    surfaceDigests: {
+      version: 1,
+      plotCount: size,
+      landMaskHash32: hash32Values(physical.topography.landMask),
+      elevationHash32: hash32Values(context.buffers.heightfield.elevation),
+      aridityPpmHash32: hash32Values(aridityPpm),
+      riverClassHash32: hash32Values(physical.hydrography.riverClass),
+      lakeMaskHash32: hash32Values(physical.lakePlan.lakeMask),
+      blockedMaskHash32: hash32Values(blockedMask),
+      terrainTypeHash32: hash32Values(terrainType),
+      biomeTypeHash32: hash32Values(biomeType),
+      featureTypeHash32: hash32Values(featureType),
+    },
     inputRows,
   };
 }

--- a/mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
+++ b/mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts
@@ -86,6 +86,8 @@ function snapshot(args: {
   resourceCoordinateProof?: boolean;
   resourceRejectionContext?: boolean;
   naturalWonderPlan?: "matching" | "diverged";
+  naturalWonderPlanInput?: "matching" | "diverged";
+  naturalWonderPlanInputSurfaceDigests?: "matching" | "diverged";
 }): FinalSurfaceSnapshot {
   const width = 2;
   const height = 1;
@@ -106,6 +108,37 @@ function snapshot(args: {
                 elevation: args.naturalWonderPlan === "diverged" ? 3 : 4,
                 priority: args.naturalWonderPlan === "diverged" ? 0.25 : 0.5,
               },
+            ],
+          },
+        }
+      : {}),
+    ...(args.naturalWonderPlanInput
+      ? {
+          naturalWonderPlanInput: {
+            type: "naturalWonder.planInput",
+            version: 1,
+            plannedCount: 1,
+            ...(args.naturalWonderPlanInputSurfaceDigests
+              ? {
+                  surfaceDigests: {
+                    version: 1,
+                    plotCount: 2,
+                    landMaskHash32: "aaaaaaaa",
+                    elevationHash32: args.naturalWonderPlanInputSurfaceDigests === "diverged" ? "bbbbbbbb" : "22222222",
+                    aridityPpmHash32: args.naturalWonderPlanInputSurfaceDigests === "diverged" ? "cccccccc" : "33333333",
+                    riverClassHash32: "44444444",
+                    lakeMaskHash32: "55555555",
+                    blockedMaskHash32: "66666666",
+                    terrainTypeHash32: "77777777",
+                    biomeTypeHash32: "88888888",
+                    featureTypeHash32: "99999999",
+                  },
+                }
+              : {}),
+            inputRows: [
+              args.naturalWonderPlanInput === "diverged"
+                ? ["p", 0, 0, 0, 30, 2, 3, -1, 3, 250000, 1, 0, 0, 1]
+                : ["p", 1, 1, 0, 30, 2, 3, -1, 4, 500000, 1, 0, 0, 1],
             ],
           },
         }
@@ -364,6 +397,88 @@ describe("final-surface parity proof", () => {
       mismatchedLinks: ["natural-wonder-plan-coordinate-proof.planned"],
     });
     expect(proof.unresolvedLinks).toContain("natural-wonder-plan-coordinate-proof.planned");
+  });
+
+  test("compares exact and local natural-wonder plan input context", () => {
+    const proof = buildFinalSurfaceParityProof({
+      exactAuthorship: exactProof({
+        log: {
+          requestId: "run-1",
+          configHash,
+          envelopeHash: "envelope-1",
+          seed: 1234,
+          dimensions: { width: 2, height: 1 },
+          naturalWonderPlanInput: {
+            surfaceDigests: {
+              version: 1,
+              plotCount: 2,
+              landMaskHash32: "aaaaaaaa",
+              elevationHash32: "22222222",
+              aridityPpmHash32: "33333333",
+              riverClassHash32: "44444444",
+              lakeMaskHash32: "55555555",
+              blockedMaskHash32: "66666666",
+              terrainTypeHash32: "77777777",
+              biomeTypeHash32: "88888888",
+              featureTypeHash32: "99999999",
+            },
+            inputRows: [
+              {
+                plotIndex: 1,
+                x: 1,
+                y: 0,
+                featureType: 30,
+                terrainType: 2,
+                biomeType: 3,
+                occupiedFeatureType: -1,
+                elevation: 4,
+                aridityPpm: 500000,
+                riverClass: 1,
+                lakeMask: 0,
+                blockedMask: 0,
+                landMask: 1,
+              },
+            ],
+          },
+        },
+      }),
+      local: snapshot({
+        source: "local-mapgen",
+        naturalWonderPlanInput: "diverged",
+        naturalWonderPlanInputSurfaceDigests: "diverged",
+      }),
+      live: snapshot({ source: "live-civ7" }),
+    });
+
+    expect(proof.naturalWonderPlanInputContextProof).toMatchObject({
+      status: "compared",
+      surfaceDigests: {
+        status: "mismatch",
+        mismatchedFields: ["elevationHash32", "aridityPpmHash32"],
+        exact: {
+          elevationHash32: "22222222",
+          aridityPpmHash32: "33333333",
+        },
+        local: {
+          elevationHash32: "bbbbbbbb",
+          aridityPpmHash32: "cccccccc",
+        },
+      },
+      rowComparisons: [
+        {
+          featureType: 30,
+          classification: "exact-local-anchor-diverged",
+          exact: { plotIndex: 1, x: 1, y: 0, elevation: 4, aridityPpm: 500000 },
+          local: { plotIndex: 0, x: 0, y: 0, elevation: 3, aridityPpm: 250000 },
+          distance: 1,
+          inputDelta: {
+            elevationDelta: 1,
+            aridityPpmDelta: 250000,
+          },
+        },
+      ],
+    });
+    expect(proof.unresolvedLinks).not.toContain("natural-wonder-plan-input-context-proof");
   });
 
   test("joins exact resource rejection rows to local placement evidence", () => {

--- a/mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts
+++ b/mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts
@@ -325,9 +325,22 @@ describe("derive placement inputs", () => {
       },
     });
 
-    expect(telemetry).toEqual({
+    expect(telemetry).toMatchObject({
       version: 1,
       plannedCount: 1,
+      surfaceDigests: {
+        version: 1,
+        plotCount: size,
+        landMaskHash32: expect.stringMatching(/^[0-9a-f]{8}$/),
+        elevationHash32: expect.stringMatching(/^[0-9a-f]{8}$/),
+        aridityPpmHash32: expect.stringMatching(/^[0-9a-f]{8}$/),
+        riverClassHash32: expect.stringMatching(/^[0-9a-f]{8}$/),
+        lakeMaskHash32: expect.stringMatching(/^[0-9a-f]{8}$/),
+        blockedMaskHash32: expect.stringMatching(/^[0-9a-f]{8}$/),
+        terrainTypeHash32: expect.stringMatching(/^[0-9a-f]{8}$/),
+        biomeTypeHash32: expect.stringMatching(/^[0-9a-f]{8}$/),
+        featureTypeHash32: expect.stringMatching(/^[0-9a-f]{8}$/),
+      },
       inputRows: [
         [
           "p",
@@ -347,6 +360,6 @@ describe("derive placement inputs", () => {
         ],
       ],
     });
-    expect(`[SWOOPER_MOD] NATURAL_WONDER_PLAN_INPUT_V1 ${JSON.stringify(telemetry)}`.length).toBeLessThan(500);
+    expect(`[SWOOPER_MOD] NATURAL_WONDER_PLAN_INPUT_V1 ${JSON.stringify(telemetry)}`.length).toBeLessThan(800);
   });
 });

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/tasks.md
@@ -637,6 +637,44 @@
     `resource-placement-coordinate-proof.rejected`,
     `surface.biome.mismatch`, `surface.feature.mismatch`,
     `surface.resource.mismatch`, and `surface.terrain.mismatch`.
+- [x] 2.62 Bind natural-wonder plan-input context comparison into the
+  final-surface parity proof.
+  - Current branch
+    `codex/swooper-natural-wonder-plan-input-comparison-drain` adds
+    `naturalWonderPlanInputContextProof` to compare exact runtime
+    `NATURAL_WONDER_PLAN_INPUT_V1` rows against local replay
+    `naturalWonder.planInput` trace rows by feature type. It classifies
+    same-anchor input match/drift, anchor divergence, exact-only, and
+    local-only rows, and records compact input deltas for terrain, biome,
+    occupied feature, elevation, aridity, river, lake, blocked, and land.
+  - This is proof comparison only. It deliberately does not add a new
+    unresolved link; the active gating link remains
+    `natural-wonder-plan-coordinate-proof.planned`. It does not change
+    natural-wonder planning, candidate scoring, materialization, readback
+    disposition, final-surface surfaces, product acceptance, public config, or
+    resource behavior.
+- [x] 2.63 Bind natural-wonder plan-input surface digests into exact-authorship
+  and final-surface parity proof.
+  - Current branch
+    `codex/swooper-natural-wonder-plan-input-comparison-drain` also adds
+    compact full-surface digests to `NATURAL_WONDER_PLAN_INPUT_V1` and
+    preserves them
+    in Studio exact-authorship proof and local final-surface parity evidence.
+    The digests cover land mask, elevation, aridity ppm, river class, lake
+    mask, polar blocked mask, terrain type, biome type, and feature type for
+    the runtime plot count.
+  - Final-surface parity now compares exact/local input surface digests inside
+    `naturalWonderPlanInputContextProof.surfaceDigests`. This is diagnostic
+    proof only and deliberately adds no new unresolved link. It does not change
+    natural-wonder planning, candidate scoring, materialization, readback
+    disposition, final-surface surfaces, product acceptance, public config, or
+    resource behavior.
+  - Fresh exact request `studio-run-in-game-mq41wza4-1zzu` completed and
+    records exact surface digests for `6996` plots. Exact/local land,
+    elevation, and blocked masks match; aridity ppm, river class, lake mask,
+    terrain type, biome type, and feature type digests mismatch. This narrows
+    the next natural-wonder owner decision toward upstream projection/runtime
+    surface divergence before candidate scoring or readback repair.
 
 ## 3. Verification
 
@@ -904,3 +942,47 @@
     and surface mismatch links open. Verifier log:
     `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq40o844-natural-wonder-plan-input.log`
     (`sha256:b551e06b83996ae920238c898afe00381be9f64148233f86d58a15ea05d404ba`).
+- [x] 3.32 Run focused natural-wonder plan-input comparison regression and
+  rerun current exact-authored final-surface parity.
+  - Passed `bun test
+    mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts`.
+  - Passed owner check `bun run --cwd mods/mod-swooper-maps check`.
+  - Verifier input request `studio-run-in-game-mq40o844-1zzu` wrote
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input-comparison.json`
+    (`sha256:ddc2bd90456a238e4f9952744457fac4d89d22cf3c27729b860c7045e1c0913d`,
+    `proofHash:4868dffcca7b41ac13be1399c545da89b1ba1c53bc5bea2671968a131d3528d1`).
+  - The verifier exited `2` as expected for unresolved parity. The artifact now
+    carries `naturalWonderPlanInputContextProof.status:"compared"` without
+    adding a new unresolved link. Verifier log:
+    `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq40o844-natural-wonder-plan-input-comparison.log`
+    (`sha256:33aca6bfdf6984fc20079774d294f9b20eeb776f8a98d339c406c9e6c630bc4d`).
+- [x] 3.33 Run focused natural-wonder plan-input surface digest regressions and
+  rerun current exact-authored final-surface parity.
+  - Passed `bun test
+    mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts
+    apps/mapgen-studio/test/runInGame/proofIdentity.test.ts
+    mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts`.
+  - Passed owner checks `bun run --cwd mods/mod-swooper-maps check` and
+    `bun run --cwd apps/mapgen-studio check`.
+  - Fresh exact request `studio-run-in-game-mq41wza4-1zzu` completed with
+    exact-authorship proof and `NATURAL_WONDER_PLAN_INPUT_V1.surfaceDigests`.
+    POST artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-input-surface-digest-post.json`
+    has `sha256:1dcffc6082fd8b5cbff6939d1ce142d1a1d94aa8ad263e202ef8034b808e5bea`;
+    terminal status artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-input-surface-digest-status.json`
+    has `sha256:7f96e1f6516d354f361bf414df2417557c842bc40d694a15bcc08f41eb683dc2`.
+  - Verifier input request `studio-run-in-game-mq41wza4-1zzu` wrote
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq41wza4-1zzu-current-final-surface-parity-with-natural-wonder-input-surface-digest.json`
+    (`sha256:edb8a88b09f201dd016b510ae3641472032a7dfca34f2032e8db5849b6524d30`,
+    `proofHash:7b1164396c500028a2d63f23b18880a04f7dff362c6976ca66fb578e9f3f9b71`).
+  - The verifier exited `2` as expected for unresolved parity. It preserves
+    mismatch counts terrain `140`, biome `874`, feature `376`, and resource
+    `307`, and keeps the natural-wonder plan-coordinate, resource-coordinate,
+    and surface mismatch links open. The new digest comparison reports exact/
+    local mismatches for `aridityPpmHash32`, `riverClassHash32`,
+    `lakeMaskHash32`, `terrainTypeHash32`, `biomeTypeHash32`, and
+    `featureTypeHash32`, while land, elevation, and blocked masks match.
+    Verifier log:
+    `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-studio-run-in-game-mq41wza4-1zzu-natural-wonder-input-surface-digest.log`
+    (`sha256:8fefa7750c29b0cb109016a58263d5df9b80047ceb53c46f25a9809e8e8e089f`).

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/delta-classification-ledger.md
@@ -1608,19 +1608,46 @@ link still open.
 ### Natural-Wonder Plan Input Context Proof
 
 Classification status: selected-row input context captured; upstream candidate
-surface/scoring owner still open.
+surface/scoring owner still open; full input-surface digest comparison now
+shows upstream projection/runtime surface drift for non-land/non-elevation
+surfaces.
 
 | Artifact | Path | Identity |
 | --- | --- | --- |
 | Exact status proof | `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-plan-input-status.json` | `sha256:92916fde12abcde0b71d667bb8fdb337b9005ecd8094c8243b487551ad8c9d08` |
 | Final-surface proof with plan-input context | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input.json` | `sha256:f7b3de32589c369c280461d99ad0d1eb9aa0dc1c3806b6f0d67c167a251e2974`, `proofHash:ddf33279f4858dfa1ab0e83ec530720cb5a62b17d35a8d7e9951ce6b595ef595` |
+| Final-surface proof with first-class input comparison | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input-comparison.json` | `sha256:ddc2bd90456a238e4f9952744457fac4d89d22cf3c27729b860c7045e1c0913d`, `proofHash:4868dffcca7b41ac13be1399c545da89b1ba1c53bc5bea2671968a131d3528d1` |
+| Exact status proof with surface digests | `/tmp/civ7-recovery-proof/final-surface-parity/current-drain-after-natural-wonder-input-surface-digest-status.json` | `sha256:7f96e1f6516d354f361bf414df2417557c842bc40d694a15bcc08f41eb683dc2` |
+| Final-surface proof with input-surface digests | `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq41wza4-1zzu-current-final-surface-parity-with-natural-wonder-input-surface-digest.json` | `sha256:edb8a88b09f201dd016b510ae3641472032a7dfca34f2032e8db5849b6524d30`, `proofHash:7b1164396c500028a2d63f23b18880a04f7dff362c6976ca66fb578e9f3f9b71` |
 | Verifier log | `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq40o844-natural-wonder-plan-input.log` | `sha256:b551e06b83996ae920238c898afe00381be9f64148233f86d58a15ea05d404ba` |
+| Verifier log with input comparison | `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-mq40o844-natural-wonder-plan-input-comparison.log` | `sha256:33aca6bfdf6984fc20079774d294f9b20eeb776f8a98d339c406c9e6c630bc4d` |
+| Verifier log with input-surface digest comparison | `/tmp/civ7-recovery-proof/final-surface-parity/verify-final-surface-parity-studio-run-in-game-mq41wza4-1zzu-natural-wonder-input-surface-digest.log` | `sha256:8fefa7750c29b0cb109016a58263d5df9b80047ceb53c46f25a9809e8e8e089f` |
 
 Exact `NATURAL_WONDER_PLAN_INPUT_V1` is now bound in the exact-authorship
 packet for request `studio-run-in-game-mq40o844-1zzu`, and local replay carries
 the matching verbose trace evidence. Rows preserve selected-anchor terrain,
 biome, occupied feature, elevation, aridity ppm, river class, lake mask, polar
 blocked mask, and land mask.
+
+The current final-surface proof now carries
+`naturalWonderPlanInputContextProof.status:"compared"` without adding a new
+unresolved link. The active gating link remains
+`natural-wonder-plan-coordinate-proof.planned`.
+
+Full input-surface digest comparison for fresh request
+`studio-run-in-game-mq41wza4-1zzu`:
+
+| Surface | Exact hash | Local hash | Status |
+| --- | --- | --- | --- |
+| land mask | `c8963145` | `c8963145` | match |
+| elevation | `f86490e0` | `f86490e0` | match |
+| polar blocked mask | `844568c5` | `844568c5` | match |
+| aridity ppm | `e0952008` | `e629213d` | mismatch |
+| river class | `8047dde5` | `fc483f85` | mismatch |
+| lake mask | `8a89ba34` | `c954e385` | mismatch |
+| terrain type | `331c8344` | `e58b1100` | mismatch |
+| biome type | `8ccefeb7` | `a9b31355` | mismatch |
+| feature type | `8eee9833` | `b1b46c04` | mismatch |
 
 Selected diverged-anchor context:
 
@@ -1635,10 +1662,17 @@ the selected exact anchors are not explained by occupied-feature, lake,
 polar-block, or non-land blockers in the selected-row proof. Feature `30` has
 matching terrain/biome/elevation/river masks across exact/local selected
 anchors but a large aridity delta; features `35` and `36` also differ in
-elevation and river class at the selected anchor. This narrows the next owner
-decision toward upstream candidate set/scoring surface divergence, not public
-Earthlike config tuning, static catalog repair, or a simple selected-anchor
-legality failure. Final-surface parity remains `unresolved` with
+elevation and river class at the selected anchor. Same-anchor features
+`32`, `34`, `38`, and `39` also show aridity drift while keeping the selected
+anchor, which points away from a binary terrain/biome/blocked legality
+explanation. The full-surface digest comparison now further separates the
+inputs: land, elevation, and polar-blocked masks match exactly, while aridity,
+river, lake, terrain, biome, and feature input surfaces differ before natural-
+wonder candidate selection is adjudicated. This narrows the next owner
+decision toward upstream projection/runtime surface divergence feeding
+candidate set/scoring, not public Earthlike config tuning, static catalog
+repair, or a simple selected-anchor legality failure. Final-surface parity
+remains `unresolved` with
 `natural-wonder-plan-coordinate-proof.planned`,
 `resource-placement-coordinate-proof.placed`,
 `resource-placement-coordinate-proof.rejected`, and terrain/biome/feature/
@@ -1646,12 +1680,13 @@ resource surface mismatch links still open.
 
 ## Required Next Diagnostics
 
-- Classify the natural-wonder exact/local upstream candidate/scoring or
-  engine-surface divergence from the fresh exact `mq40o844` proof before
-  changing readback behavior. Selected-row input context is now captured for
-  exact and local anchors, but the candidate set, rejection/cut list, and score
-  terms that caused features `30`, `35`, and `36` to choose different anchors
-  are still not source-owned.
+- Classify the natural-wonder exact/local upstream projection/runtime surface
+  divergence from the fresh exact `mq41wza4` digest proof before changing
+  readback behavior. Selected-row input context is captured for exact and local
+  anchors, and full-surface digests now prove aridity, river, lake, terrain,
+  biome, and feature surfaces differ while land/elevation/blocked masks match.
+  The candidate set, rejection/cut list, and score terms that caused features
+  `30`, `35`, and `36` to choose different anchors are still not source-owned.
 - After the plan-input divergence is source-owned or dispositioned, classify
   the partial expected-footprint readback owner for the exact rejected feature
   `30` and `36` rows. A valid repair lane needs an explicit source-authority

--- a/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
+++ b/openspec/changes/earthlike-live-feature-resource-legality-repair/workstream/phase-record.md
@@ -6,6 +6,7 @@
 - Phase: feature/resource legality repair planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack: current recovery drain tip
+  `codex/swooper-natural-wonder-plan-input-comparison-drain`, stacked above
   `codex/swooper-natural-wonder-plan-input-context-drain`, stacked above
   `codex/swooper-natural-wonder-plan-comparison-drain`, stacked above
   `codex/swooper-natural-wonder-plan-proof-drain`, stacked above
@@ -116,6 +117,30 @@
   mismatch links open. This narrows the natural-wonder owner question toward
   upstream candidate/scoring surface divergence; it is not behavior repair,
   final parity, or product acceptance.
+  Current follow-on proof-comparison branch
+  `codex/swooper-natural-wonder-plan-input-comparison-drain` makes selected-row
+  input context first-class in final-surface parity proof as
+  `naturalWonderPlanInputContextProof`. Refreshed verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input-comparison.json`
+  (`sha256:ddc2bd90456a238e4f9952744457fac4d89d22cf3c27729b860c7045e1c0913d`,
+  `proofHash:4868dffcca7b41ac13be1399c545da89b1ba1c53bc5bea2671968a131d3528d1`)
+  remains unresolved with the same gating links. Input-context comparison is
+  explanatory only and adds no new unresolved link; the active natural-wonder
+  gate remains `natural-wonder-plan-coordinate-proof.planned`.
+  Current plan-input comparison branch also adds compact
+  full-surface digests to `NATURAL_WONDER_PLAN_INPUT_V1`, Studio
+  exact-authorship proof, and local final-surface parity comparison. Fresh
+  exact request `studio-run-in-game-mq41wza4-1zzu` completed with
+  `surfaceDigests` for `6996` plots. Refreshed verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq41wza4-1zzu-current-final-surface-parity-with-natural-wonder-input-surface-digest.json`
+  (`sha256:edb8a88b09f201dd016b510ae3641472032a7dfca34f2032e8db5849b6524d30`,
+  `proofHash:7b1164396c500028a2d63f23b18880a04f7dff362c6976ca66fb578e9f3f9b71`)
+  remains unresolved with the same gating links. Digest comparison shows
+  exact/local land, elevation, and blocked masks match, while aridity ppm,
+  river class, lake mask, terrain type, biome type, and feature type digests
+  mismatch. This is explanatory proof only and adds no unresolved link; it
+  narrows the next owner decision toward upstream projection/runtime surface
+  divergence before candidate scoring or readback repair.
   Resource, feature, natural-wonder, and terrain source-authority
   classification remains the active work; product acceptance is not closed.
   Current resource-delta feasibility after the exact/local rejection join now
@@ -1443,6 +1468,16 @@
   surface divergence; selected-row blockers alone do not explain the diverged
   anchors. No behavior repair, parity closure, or product acceptance is
   claimed.
+  Current proof-comparison branch
+  `codex/swooper-natural-wonder-plan-input-comparison-drain` makes that
+  selected-row input context self-describing in the parity artifact. The
+  current verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input-comparison.json`
+  has `sha256:ddc2bd90456a238e4f9952744457fac4d89d22cf3c27729b860c7045e1c0913d`
+  and
+  `proofHash:4868dffcca7b41ac13be1399c545da89b1ba1c53bc5bea2671968a131d3528d1`.
+  It keeps the same unresolved links and does not convert selected-row input
+  drift into closure or repair authority.
   Final-surface parity remains open on terrain (`140` mismatches), biome
   (`874`), feature (`376`), resource (`307`), natural-wonder readback proof,
   resource coordinate proof, and any future owner-classified residual links.

--- a/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/tasks.md
@@ -110,6 +110,28 @@
     resource-coordinate, and terrain/biome/feature/resource surface links
     open. This is still proof-input instrumentation, not source-authority
     closure, planner repair, final parity, or product acceptance.
+    Follow-on branch
+    `codex/swooper-natural-wonder-plan-input-comparison-drain` binds the
+    exact/local selected-row input deltas into final-surface parity proof as
+    `naturalWonderPlanInputContextProof`. Refreshed verifier artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input-comparison.json`
+    (`sha256:ddc2bd90456a238e4f9952744457fac4d89d22cf3c27729b860c7045e1c0913d`,
+    `proofHash:4868dffcca7b41ac13be1399c545da89b1ba1c53bc5bea2671968a131d3528d1`)
+    remains unresolved with the same gating links. This comparison is
+    explanatory and deliberately adds no new unresolved link.
+    The same plan-input comparison branch also binds full-surface
+    natural-wonder plan-input digests into exact-authorship and parity proof.
+    Fresh exact request `studio-run-in-game-mq41wza4-1zzu`
+    completed with `NATURAL_WONDER_PLAN_INPUT_V1.surfaceDigests` for `6996`
+    plots. Final-surface verifier artifact
+    `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq41wza4-1zzu-current-final-surface-parity-with-natural-wonder-input-surface-digest.json`
+    (`sha256:edb8a88b09f201dd016b510ae3641472032a7dfca34f2032e8db5849b6524d30`,
+    `proofHash:7b1164396c500028a2d63f23b18880a04f7dff362c6976ca66fb578e9f3f9b71`)
+    remains unresolved with the same gating links. Digest comparison matches
+    land, elevation, and blocked masks, but mismatches aridity, river, lake,
+    terrain, biome, and feature surfaces. This narrows the natural-wonder
+    blocker to upstream projection/runtime surface divergence feeding
+    candidate/scoring decisions; it is not a repair or acceptance claim.
 - [ ] 1.2 Audit accepted P1/P2 review findings across recovery changes.
   - Current audit pass found no active review-disposition ledger inside
     `earthlike-live-feature-resource-legality-repair` or
@@ -136,8 +158,8 @@
 ## 3. Verification And Closure
 
 - [ ] 3.1 Run `git status --short --branch`.
-  - Current proof-input slice must leave
-    `codex/swooper-natural-wonder-plan-input-context-drain`
+  - Current proof-comparison slice must leave
+    `codex/swooper-natural-wonder-plan-input-comparison-drain`
     clean before commit or closure.
 - [ ] 3.2 Inspect Graphite branch/stack state.
   - Current audit snapshot: top branch
@@ -152,8 +174,9 @@
     `codex/swooper-natural-wonder-supported-catalog-drain`,
     `codex/swooper-natural-wonder-row-proof-drain`,
     `codex/swooper-natural-wonder-plan-proof-drain`,
-    `codex/swooper-natural-wonder-plan-comparison-drain`, then
-    `codex/swooper-natural-wonder-plan-input-context-drain`.
+    `codex/swooper-natural-wonder-plan-comparison-drain`,
+    `codex/swooper-natural-wonder-plan-input-context-drain`, then
+    `codex/swooper-natural-wonder-plan-input-comparison-drain`.
 - [ ] 3.3 Run `git diff --check`.
 - [ ] 3.4 Run `bun run openspec -- validate swooper-recovery-stack-product-closure --strict`.
 - [ ] 3.5 Run `bun run openspec:validate`.

--- a/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
+++ b/openspec/changes/swooper-recovery-stack-product-closure/workstream/phase-record.md
@@ -6,7 +6,7 @@
 - Phase: product closure planning
 - Owner: Product/Development DRA
 - Branch/Graphite stack:
-  `codex/swooper-natural-wonder-plan-input-context-drain`
+  `codex/swooper-natural-wonder-plan-input-comparison-drain`
 - Started: 2026-06-06
 - Status: blocked until proof and activated repair changes close
 
@@ -29,6 +29,7 @@
 ## Current State
 
 - Repo/Graphite state: current top branch is
+  `codex/swooper-natural-wonder-plan-input-comparison-drain`, stacked above
   `codex/swooper-natural-wonder-plan-input-context-drain`, stacked above
   `codex/swooper-natural-wonder-plan-comparison-drain`, stacked above
   `codex/swooper-natural-wonder-plan-proof-drain`,
@@ -138,6 +139,29 @@
   coordinate, and terrain/biome/feature/resource surface links open. This
   narrows the next owner decision toward candidate/scoring surface divergence;
   it is not behavior repair, final parity, or product acceptance.
+  Current follow-on branch
+  `codex/swooper-natural-wonder-plan-input-comparison-drain` binds those
+  exact/local selected-row input deltas into the final-surface parity artifact
+  as `naturalWonderPlanInputContextProof`. Refreshed verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq40o844-1zzu-current-final-surface-parity-with-natural-wonder-plan-input-comparison.json`
+  (`sha256:ddc2bd90456a238e4f9952744457fac4d89d22cf3c27729b860c7045e1c0913d`,
+  `proofHash:4868dffcca7b41ac13be1399c545da89b1ba1c53bc5bea2671968a131d3528d1`)
+  remains unresolved with the same gating links. This is explanatory proof
+  comparison only and does not close source authority, planner repair, final
+  parity, or product acceptance.
+  Current plan-input comparison branch also binds full-surface natural-wonder
+  plan-input digests into exact-authorship and final-surface parity proof.
+  Fresh exact request
+  `studio-run-in-game-mq41wza4-1zzu` completed with
+  `NATURAL_WONDER_PLAN_INPUT_V1.surfaceDigests` for `6996` plots. Final-surface
+  verifier artifact
+  `/tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq41wza4-1zzu-current-final-surface-parity-with-natural-wonder-input-surface-digest.json`
+  (`sha256:edb8a88b09f201dd016b510ae3641472032a7dfca34f2032e8db5849b6524d30`,
+  `proofHash:7b1164396c500028a2d63f23b18880a04f7dff362c6976ca66fb578e9f3f9b71`)
+  remains unresolved with the same gating links. Digest comparison proves
+  exact/local land, elevation, and blocked masks match, while aridity, river,
+  lake, terrain, biome, and feature surfaces differ. This is source-owner
+  narrowing only; final parity and product acceptance remain open.
 - Generated outputs affected: none expected.
 - Tests/guards affected: validation and closure audits.
 
@@ -191,8 +215,11 @@
   coordinate mismatch as a first-class parity proof link, proving the remaining
   natural-wonder source decision begins at exact/local plan-input or
   engine-surface divergence. Current proof-input branch records selected-row
-  natural-wonder input context for that divergence without closing source
-  ownership.
+  natural-wonder input context for that divergence, and current proof-comparison
+  branch exposes exact/local selected-row input deltas first-class. Current
+  proof-comparison branch shows the upstream input surfaces already diverge across
+  aridity, river, lake, terrain, biome, and feature digests, while land,
+  elevation, and blocked masks match. None of this closes source ownership.
 - Remaining tasks: final-surface parity, product acceptance, supervisor
   P1/P2 closure review, PR/remote predecessor disposition, and final Graphite
   submit/closure.
@@ -206,7 +233,7 @@
   the current exact-authorship proof.
 - Results: repo snapshot clean before this update; latest verifier artifact is
   unresolved with proof hash
-  `f6e6ad68cd1d48dff4c16465abd63c2e2ec4fa9e04b2df93e0b55a2da684c10f`;
+  `7b1164396c500028a2d63f23b18880a04f7dff362c6976ca66fb578e9f3f9b71`;
   broader review-ledger scan found historical P1/P2 entries but no active
   review ledger under the two current recovery closure changes. Focused local
   validation for the natural-wonder repair passed: `bun test

--- a/openspec/changes/swooper-stack-recovery-consolidation/tasks.md
+++ b/openspec/changes/swooper-stack-recovery-consolidation/tasks.md
@@ -29,3 +29,16 @@
 - [x] 4.3 Stage and commit through Graphite.
 - [x] 4.4 Confirm Studio is still running from the current worktree after
   commit.
+
+## 5. Accounting Reconciliation Refresh
+
+- [x] 5.1 Refresh current Graphite/worktree facts for the recovery, Earthlike
+  source, toolkit, and live-control lanes.
+- [x] 5.2 Reclassify merged/represented work as `done`, not parked.
+- [x] 5.3 Add explicit planned accounting for the remaining Earthlike
+  floodplain config leaf.
+- [x] 5.4 Add explicit planned support accounting for the systematic
+  workstream skill slice.
+- [x] 5.5 Exclude live-control and GT stack-inspect lanes from Swooper product
+  recovery accounting.
+- [x] 5.6 Validate the ledger against the GT stack-inspect accounting schema.

--- a/openspec/changes/swooper-stack-recovery-consolidation/workstream/branch-accounting-composition.json
+++ b/openspec/changes/swooper-stack-recovery-consolidation/workstream/branch-accounting-composition.json
@@ -1,25 +1,36 @@
 {
-  "fixtureId": "graphite-accounting-composition-2026-06-07T20:35:47.939Z",
+  "fixtureId": "graphite-accounting-composition-2026-06-07T22:19:21.809Z",
   "schemaVersion": "graphite-accounting-composition.v1",
-  "generatedAt": "2026-06-07T20:35:47.939Z",
+  "generatedAt": "2026-06-07T22:19:21.809Z",
   "inputs": {
-    "repoRoot": "/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools",
+    "repoRoot": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain",
     "graphiteCachePath": "/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.git/.graphite_cache_persist",
+    "graphiteStatePath": "/tmp/civ7-current-gt-ls.txt.graphite-state.json",
     "ledgerPath": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-ledger.json",
     "gtLsPath": "/tmp/civ7-current-gt-ls.txt",
-    "gtLsStatusPath": "/tmp/civ7-current-gt-ls.status.json"
+    "gtLsStatusPath": "/tmp/civ7-current-gt-ls.status.json",
+    "relationshipPairs": [],
+    "includeRootRelationships": true,
+    "includeLeafRelationshipCandidates": true,
+    "maxLeafRelationshipCandidates": 80,
+    "semanticOverlapThreshold": 0.24
   },
   "graphite": {
+    "topologySource": "graphite-cache",
+    "cacheSha": "6a16d0524567ef5bfff366cf0480d9492d429f1a",
+    "snapshotCapturedAt": "2026-06-07T22:19:13.521Z",
     "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
     "rootCount": 7,
-    "branchCount": 861
+    "branchCount": 863
   },
   "gtLsStatus": {
-    "refreshedAt": "2026-06-07T20:35:45.366Z",
-    "lineCount": 862,
+    "refreshedAt": "2026-06-07T22:19:13.521Z",
+    "lineCount": 864,
     "repoRoot": "/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools",
     "outputPath": "/tmp/civ7-current-gt-ls.txt",
-    "command": "/opt/homebrew/bin/gt ls --no-interactive"
+    "graphiteStatePath": "/tmp/civ7-current-gt-ls.txt.graphite-state.json",
+    "command": "gt ls --no-interactive",
+    "topologySource": "graphite-cache"
   },
   "ledger": {
     "fixtureId": "swooper-recovery-accounting-2026-06-07",
@@ -47,14 +58,14 @@
     },
     {
       "root": "codex/swooper-mapgen-recovery-drain",
-      "decision": "finish-planned-adoption",
-      "graphiteState": "clean-local",
+      "decision": "clear-dirty-worktree",
+      "graphiteState": "dirty-worktree",
       "accountingState": "planned-sink",
       "branchCount": 79,
       "localOnly": 79,
       "needsRestack": 0,
       "occupied": 1,
-      "dirtyWorktrees": 0,
+      "dirtyWorktrees": 1,
       "accounting": {
         "planned-sink": 1,
         "accounting-sink": 36,
@@ -66,20 +77,20 @@
     },
     {
       "root": "codex/stack-lineage-audit-reference",
-      "decision": "clear-dirty-worktree",
-      "graphiteState": "dirty-worktree",
+      "decision": "submit-or-merge-clean-stack",
+      "graphiteState": "clean-local",
       "accountingState": "accounted-source",
-      "branchCount": 19,
-      "localOnly": 19,
+      "branchCount": 21,
+      "localOnly": 21,
       "needsRestack": 0,
       "occupied": 1,
-      "dirtyWorktrees": 1,
+      "dirtyWorktrees": 0,
       "accounting": {
         "excluded": 13,
-        "unmarked": 6
+        "unmarked": 8
       },
       "leaves": [
-        "codex/gt-stack-inspect-react-parity-interactions"
+        "codex/gt-stack-inspect-react-parity-runtime-verification"
       ]
     },
     {
@@ -94,8 +105,8 @@
       "dirtyWorktrees": 0,
       "accounting": {
         "excluded": 7,
-        "unmarked": 3,
-        "accounted-source": 56,
+        "unmarked": 2,
+        "accounted-source": 57,
         "needs-accounting": 1
       },
       "leaves": [
@@ -1060,7 +1071,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1098,7 +1109,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1161,7 +1172,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1199,7 +1210,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1237,7 +1248,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1275,7 +1286,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1551,7 +1562,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1589,7 +1600,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1627,7 +1638,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1665,7 +1676,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1728,7 +1739,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1766,7 +1777,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1804,7 +1815,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1842,7 +1853,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1880,7 +1891,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1918,7 +1929,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -1956,7 +1967,7 @@
           "sinkKind": "stack-slice",
           "label": "adoption-sink",
           "cleanup": "not-cleanup-relevant",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounting-sink"
@@ -2780,7 +2791,7 @@
       "parent": "codex/swooper-natural-wonder-plan-input-context-drain",
       "children": [],
       "depth": 78,
-      "head": "3a544b5256a8fd2e6d9dc5fb7aa91adc9da5c838",
+      "head": "7a23bc4255016138f77a702defff1b9d3c6f0721",
       "parentRecordedHead": "10280507db72a621d3efb00d4f3d6c7585a1ba58",
       "parentCurrentHead": "10280507db72a621d3efb00d4f3d6c7585a1ba58",
       "validationResult": "VALID",
@@ -2791,15 +2802,15 @@
       "worktree": {
         "path": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain",
         "branch": "codex/swooper-natural-wonder-plan-input-comparison-drain",
-        "head": "3a544b5256a8fd2e6d9dc5fb7aa91adc9da5c838",
-        "dirtyCount": 0,
-        "isMain": false,
+        "head": "7a23bc4255016138f77a702defff1b9d3c6f0721",
+        "dirtyCount": 2,
+        "isMain": true,
         "isDetached": false
       },
       "commit": {
-        "short": "3a544b525",
-        "sha": "3a544b5256a8fd2e6d9dc5fb7aa91adc9da5c838",
-        "iso": "2026-06-07T16:30:13-04:00",
+        "short": "7a23bc425",
+        "sha": "7a23bc4255016138f77a702defff1b9d3c6f0721",
+        "iso": "2026-06-07T16:36:24-04:00",
         "subject": "docs(graphite): compose branch accounting state"
       },
       "accountingLabels": [],
@@ -3402,9 +3413,11 @@
       "branch": "codex/gt-stack-inspect-react-parity-interactions",
       "root": "codex/stack-lineage-audit-reference",
       "parent": "codex/gt-stack-inspect-react-parity-ui-sections",
-      "children": [],
+      "children": [
+        "codex/gt-stack-inspect-react-parity-browser-verification"
+      ],
       "depth": 18,
-      "head": "6b46f7042417848546306f9a7995682c7781c71b",
+      "head": "c2f0a7a7721d9456e7e0b1a6bbb06031f185d7b9",
       "parentRecordedHead": "6b46f7042417848546306f9a7995682c7781c71b",
       "parentCurrentHead": "6b46f7042417848546306f9a7995682c7781c71b",
       "validationResult": "VALID",
@@ -3412,19 +3425,67 @@
       "needsRestack": false,
       "pushedToOrigin": false,
       "localOnly": true,
+      "commit": {
+        "short": "c2f0a7a77",
+        "sha": "c2f0a7a7721d9456e7e0b1a6bbb06031f185d7b9",
+        "iso": "2026-06-07T16:46:20-04:00",
+        "subject": "feat(graphite): wire stack inspect parity interactions Wire the React visualizer interactions over prepared report indexes and facets: broad search, root rail scoping, explicit Covered and Dirty filters, lane/tree expansion, evidence Reveal controls, active copy controls, disclosure help, and accessible result/focus state. Keep React inside the prepared-state boundary by moving structured facet membership into TypeBox filter-index DTOs instead of rebuilding accounting, stale-anchor, work-surface, worktree, or source semantics in client selectors. Verify with focused/full toolkit tests, typecheck, Vite build, focused/full OpenSpec validation, diff checks, and adversarial review disposition."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-react-parity-browser-verification",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-react-parity-interactions",
+      "children": [
+        "codex/gt-stack-inspect-react-parity-runtime-verification"
+      ],
+      "depth": 19,
+      "head": "fcdf0f8c911d815271e66675925c94f77164d725",
+      "parentRecordedHead": "c2f0a7a7721d9456e7e0b1a6bbb06031f185d7b9",
+      "parentCurrentHead": "c2f0a7a7721d9456e7e0b1a6bbb06031f185d7b9",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fcdf0f8c9",
+        "sha": "fcdf0f8c911d815271e66675925c94f77164d725",
+        "iso": "2026-06-07T17:33:28-04:00",
+        "subject": "test(graphite): add stack inspect browser verification Add the fixture-backed browser verification harness under verify:browser, served built React assets, and route same-origin /rpc through createStackInspectRpcHandler. Rename the browser/runtime OpenSpec slices to verification terminology, realign downstream records, and keep fixture browser verification separate from live daemon verification. Includes anchor-copy and toast-overflow UI repairs surfaced by browser checks."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-react-parity-runtime-verification",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-react-parity-browser-verification",
+      "children": [],
+      "depth": 20,
+      "head": "6a9c30458e7228409fd0f271d327f6bb378e103d",
+      "parentRecordedHead": "fcdf0f8c911d815271e66675925c94f77164d725",
+      "parentCurrentHead": "fcdf0f8c911d815271e66675925c94f77164d725",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
       "worktree": {
         "path": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-stack-lineage-audit-reference",
-        "branch": "codex/gt-stack-inspect-react-parity-interactions",
-        "head": "6b46f7042417848546306f9a7995682c7781c71b",
-        "dirtyCount": 12,
+        "branch": "codex/gt-stack-inspect-react-parity-runtime-verification",
+        "head": "6a9c30458e7228409fd0f271d327f6bb378e103d",
+        "dirtyCount": 0,
         "isMain": false,
         "isDetached": false
       },
       "commit": {
-        "short": "6b46f7042",
-        "sha": "6b46f7042417848546306f9a7995682c7781c71b",
-        "iso": "2026-06-07T16:13:19-04:00",
-        "subject": "feat(graphite): render stack inspect parity sections Render the React stack-inspect decision surface from prepared TypeBox DTOs: capture/sidebar, recovery status, work surface, accounting notes, Graphite tracking, accounting actions, action map, stack lanes, parent tree, and worktree occupancy. Keep React inside the display boundary by avoiding PR/accounting/stale reconciliation joins and preserving interaction/browser/runtime proof obligations for downstream slices. Verify with toolkit tests, typecheck, Vite build, focused OpenSpec validation, full OpenSpec validation, and diff whitespace checks."
+        "short": "6a9c30458",
+        "sha": "6a9c30458e7228409fd0f271d327f6bb378e103d",
+        "iso": "2026-06-07T17:57:22-04:00",
+        "subject": "feat(graphite): verify stack inspect live runtime"
       },
       "accountingLabels": [],
       "accountingSummary": "unmarked"
@@ -3994,7 +4055,7 @@
         "branch": "codex/studio-civ7-exact-authorship-proof",
         "head": "8966aba5eb6fb3d2adf7edf38aa2bd0b8cde905f",
         "dirtyCount": 0,
-        "isMain": true,
+        "isMain": false,
         "isDetached": false
       },
       "commit": {
@@ -4850,7 +4911,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -4888,7 +4949,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -4926,7 +4987,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -4964,7 +5025,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5003,7 +5064,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5041,7 +5102,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5079,7 +5140,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5155,7 +5216,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5193,7 +5254,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5231,7 +5292,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5258,8 +5319,21 @@
         "iso": "2026-06-06T16:57:17-04:00",
         "subject": "fix(repo): resolve map policy from source"
       },
-      "accountingLabels": [],
-      "accountingSummary": "unmarked"
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
     },
     {
       "branch": "codex/earthlike-natural-wonder-materialization-repair",
@@ -5294,7 +5368,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5332,7 +5406,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5370,7 +5444,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5408,7 +5482,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5446,7 +5520,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5484,7 +5558,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5522,7 +5596,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -5560,7 +5634,7 @@
           "sinkKind": "stack-slice",
           "label": "covered-by-adoption",
           "cleanup": "blocked-until-sink-lands",
-          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
         }
       ],
       "accountingSummary": "accounted-source"
@@ -23271,6 +23345,3428 @@
       "accountingSummary": "accounted-source"
     }
   ],
+  "history": {
+    "config": {
+      "relationshipPairs": [],
+      "includeRootRelationships": true,
+      "includeLeafRelationshipCandidates": true,
+      "maxLeafRelationshipCandidates": 80,
+      "semanticOverlapThreshold": 0.24
+    },
+    "metrics": {
+      "exactSameHead": 0,
+      "linear": 0,
+      "patchOverlap": 6,
+      "semanticOverlapDiverged": 1,
+      "diverged": 14,
+      "independent": 0
+    },
+    "splitPoints": [
+      {
+        "root": "codex/live-play-settlement-reference",
+        "branch": "codex/civ7-orpc-control-architecture-skill",
+        "children": [
+          "codex/consolidate-play-agent-docs",
+          "codex/play-agent-hotseat-phase-packet"
+        ]
+      },
+      {
+        "root": "codex/local-catalog-enrichment",
+        "branch": "codex/live-traditions-view",
+        "children": [
+          "codex/surface-first-meet-exact-commands",
+          "codex/stale-population-blocker-classification"
+        ]
+      },
+      {
+        "root": "codex/live-play-settlement-reference",
+        "branch": "codex/earthlike-natural-wonder-footprint-readback",
+        "children": [
+          "codex/earthlike-natural-wonder-footprint-catalog-context",
+          "codex/earthlike-terrain-edge-diagnostics"
+        ]
+      },
+      {
+        "root": "codex/local-catalog-enrichment",
+        "branch": "codex/add-production-telemetry-adapter",
+        "children": [
+          "codex/watcher-supervisor-handoff-doc",
+          "codex/guard-telemetry-proof-labels"
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "pairId": "root-pair:codex/systematic-workstream-skill-framing...codex/swooper-mapgen-recovery-drain",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "codex/systematic-workstream-skill-framing",
+        "right": "codex/swooper-mapgen-recovery-drain",
+        "leftRoot": "codex/systematic-workstream-skill-framing",
+        "rightRoot": "codex/swooper-mapgen-recovery-drain",
+        "leftHead": "70604ec945cefae8415972dacb1732ef0f165425",
+        "rightHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "mergeBase": {
+          "sha": "98dca389248d5ddb2777a88105c3ade452b2137c",
+          "short": "98dca3892"
+        },
+        "aheadBehind": {
+          "leftOnly": 1,
+          "rightOnly": 17
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 1,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "70604ec945cefae8415972dacb1732ef0f165425",
+                "subject": "docs(skills): capture systematic workstream skill objective"
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 17,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "647b1e61c8bbd024c97729109e4b04fa4115835d",
+                "subject": "fix(mapgen): plan starts by expansion viability"
+              },
+              {
+                "sha": "bcec62ea3b28c88fac8106db46e616a0a5c56567",
+                "subject": "fix(mapgen): gate initial resource authoring by age"
+              },
+              {
+                "sha": "5f2aa7a732280ba29f99e919f1912ddc8d207f0a",
+                "subject": "feat(studio): load Civ saved setup configs"
+              },
+              {
+                "sha": "93076f453742afb283361e0b137ce66ab6bb5158",
+                "subject": "fix(studio): validate Civ7 setup seeds"
+              },
+              {
+                "sha": "08ee2e7807eb10983870e6256cd49ad23812932b",
+                "subject": "fix(studio): harden live setup and run-in-game sync Commit the Studio-side setup sync, run-in-game failure logging/restart helpers, viz orientation guard, and live parity workstream notes as one coherent runtime integration slice."
+              },
+              {
+                "sha": "61581904ec37ac6c3e3f3097916da75936e1b949",
+                "subject": "refactor(mapgen): align foundation authoring contracts Checkpoint the foundation authoring surface alignment: mesh and plate topology contracts, history normalization docs, generated map config updates, and foundation contract tests."
+              },
+              {
+                "sha": "b410ef219d846294d62cd538bb237113e8650c36",
+                "subject": "fix(mapgen): restore authored RNG authority Move MapGen-authored randomness back behind mapgen-core seeded helpers, document the Civ adapter RNG boundary, update standard-stage imports, and align viz/stamping outputs on OddQ tile space."
+              },
+              {
+                "sha": "a23a36978eb395fb594f6cabdb62c44ea5812ed3",
+                "subject": "feat(mapgen): plan long tectonic mountain regions Add reusable OddQ component helpers, preserve connected belt corridors, trace range-region axes for longer mountain bodies, expose independent morphology knobs, and add an earthlike regression covering range diameter and hill balance."
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.010526315789473684,
+          "subjectTokenJaccard": 0.0045662100456621,
+          "combinedJaccard": 0.006051437216338881,
+          "sharedBranchTokens": [
+            "evidence"
+          ],
+          "sharedSubjectTokens": [
+            "apply",
+            "civ7",
+            "review"
+          ],
+          "sharedCombinedTokens": [
+            "apply",
+            "civ7",
+            "evidence",
+            "review"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/systematic-workstream-skill-framing...codex/stack-lineage-audit-reference",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "codex/systematic-workstream-skill-framing",
+        "right": "codex/stack-lineage-audit-reference",
+        "leftRoot": "codex/systematic-workstream-skill-framing",
+        "rightRoot": "codex/stack-lineage-audit-reference",
+        "leftHead": "70604ec945cefae8415972dacb1732ef0f165425",
+        "rightHead": "be60913515d9fd157858316400e95851bbb71d8c",
+        "mergeBase": {
+          "sha": "98dca389248d5ddb2777a88105c3ade452b2137c",
+          "short": "98dca3892"
+        },
+        "aheadBehind": {
+          "leftOnly": 1,
+          "rightOnly": 12
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 1,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "70604ec945cefae8415972dacb1732ef0f165425",
+                "subject": "docs(skills): capture systematic workstream skill objective"
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 12,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "bb26f5168ad35800b1d325ee65d0e585e44bd57f",
+                "subject": "docs(graphite): clarify stack action taxonomy"
+              },
+              {
+                "sha": "536e478bf7292fbedc5635fcb58c88aa7f2a8272",
+                "subject": "chore(graphite): consolidate stack visualizer toolkit"
+              },
+              {
+                "sha": "d65df9af9d4d1e0fdf816a763622326ff0853e31",
+                "subject": "docs(graphite): capture stack inspect workstream base"
+              },
+              {
+                "sha": "94424ef23522e89c1ece18de9dbd19e50023e1ba",
+                "subject": "docs(graphite): add PR tracking layer to stack visual"
+              },
+              {
+                "sha": "440dad30748ca6fbf40c143bcca313d5870a4417",
+                "subject": "docs(graphite): define stack inspect React workstream"
+              },
+              {
+                "sha": "a62678b091afd4de275458487c914ee03c08dcb3",
+                "subject": "docs(graphite): encode stack recovery phases"
+              },
+              {
+                "sha": "b7bdd75650c31ed3cb391c9b055bd05957b7f512",
+                "subject": "docs(graphite): define effect-orpc visualizer workstream"
+              },
+              {
+                "sha": "967d0657e19278d337854b5d34aece5e745dc92c",
+                "subject": "docs(graphite): refresh stack blocker visual"
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.02127659574468085,
+          "subjectTokenJaccard": 0.002976190476190476,
+          "combinedJaccard": 0.0058309037900874635,
+          "sharedBranchTokens": [
+            "evidence"
+          ],
+          "sharedSubjectTokens": [
+            "review"
+          ],
+          "sharedCombinedTokens": [
+            "evidence",
+            "review"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/systematic-workstream-skill-framing...codex/live-play-settlement-reference",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "codex/systematic-workstream-skill-framing",
+        "right": "codex/live-play-settlement-reference",
+        "leftRoot": "codex/systematic-workstream-skill-framing",
+        "rightRoot": "codex/live-play-settlement-reference",
+        "leftHead": "70604ec945cefae8415972dacb1732ef0f165425",
+        "rightHead": "754f90431964aaac4e266a483012b4711b2f6198",
+        "mergeBase": {
+          "sha": "98dca389248d5ddb2777a88105c3ade452b2137c",
+          "short": "98dca3892"
+        },
+        "aheadBehind": {
+          "leftOnly": 1,
+          "rightOnly": 1
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 1,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "70604ec945cefae8415972dacb1732ef0f165425",
+                "subject": "docs(skills): capture systematic workstream skill objective"
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 1,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "754f90431964aaac4e266a483012b4711b2f6198",
+                "subject": "docs(graphite): prepare live-play settlement reference"
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.01694915254237288,
+          "subjectTokenJaccard": 0.005780346820809248,
+          "combinedJaccard": 0.011049723756906077,
+          "sharedBranchTokens": [
+            "evidence",
+            "skill"
+          ],
+          "sharedSubjectTokens": [
+            "civ7",
+            "workstream"
+          ],
+          "sharedCombinedTokens": [
+            "civ7",
+            "evidence",
+            "skill",
+            "workstream"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/systematic-workstream-skill-framing...codex/local-catalog-enrichment",
+        "scope": "root-pair",
+        "relationshipKind": "patch-overlap-diverged",
+        "left": "codex/systematic-workstream-skill-framing",
+        "right": "codex/local-catalog-enrichment",
+        "leftRoot": "codex/systematic-workstream-skill-framing",
+        "rightRoot": "codex/local-catalog-enrichment",
+        "leftHead": "70604ec945cefae8415972dacb1732ef0f165425",
+        "rightHead": "1689806731331dae56262cfa988fdbc0800b3e88",
+        "mergeBase": {
+          "sha": "929a282ff34033664e1fee71f4f78c977796a3dd",
+          "short": "929a282ff"
+        },
+        "aheadBehind": {
+          "leftOnly": 27,
+          "rightOnly": 34
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 10,
+            "patchEquivalent": 9,
+            "sampleNew": [
+              {
+                "sha": "db52c7aecda06bebb4eba34bee60def035d67249",
+                "subject": "test(mapgen): keep artifact guards package-owned"
+              },
+              {
+                "sha": "9011233676639569d76464166179189b1779a169",
+                "subject": "docs(morphology): integrate live readback boundary"
+              },
+              {
+                "sha": "fde990cb16ee8262722a7b8c89ad3c4414c4cf15",
+                "subject": "fix(ecology): integrate morphology peer repairs"
+              },
+              {
+                "sha": "37ae85d62746e62d31c603a52d357e51e8c82cea",
+                "subject": "feat(mapgen): integrate resource corpus expectations"
+              },
+              {
+                "sha": "b1b1b33f3c0d0911a8ab1242a948a36c7af7947e",
+                "subject": "feat(mapgen): integrate resource ops rollup"
+              },
+              {
+                "sha": "e4b5c995d6b38c06a4e9957ddc2b614cab8b03f2",
+                "subject": "fix(mapgen): integrate resource runtime proof"
+              },
+              {
+                "sha": "caab828e97c7d1ee0716dd2cfc314a4c6ff3fa2c",
+                "subject": "chore(imports): break circular dependency edges"
+              },
+              {
+                "sha": "0507ef8e9108fc58f141c241f214994f221eb4d2",
+                "subject": "fix(mapgen): stabilize integrated stack boundaries"
+              }
+            ],
+            "sampleEquivalent": [
+              {
+                "sha": "cdca71f02ac1bf24757a89f86bc3fe894080b5ce",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "017fbb24931944b4fb4b8a9a587ac94fa196bcc0",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "3433ecb1ed49e9dd6fbf8425064fa2b39adfbb6c",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "49a51198a16237c2debd6fc785824d9e27c92116",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "7eda16891440a90894aac4f860da64b4f047eeac",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "364e7f2880f133b3b47353fb24b2e9ec85424cf7",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "feba6884f8db4273e786bf094f9675afe2bff040",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              },
+              {
+                "sha": "9d40e87281cfca0355a6ea6934906be200eb874b",
+                "subject": "feat(studio): add Civ autoplay control Adds a Studio /api/civ7/autoplay endpoint backed by @civ7/direct-control startCiv7Autoplay and stopCiv7Autoplay. The endpoint rejects malformed actions and blocks autoplay changes while Save/Deploy or Run in Game operations are active. Adds a live Civ footer button that starts unbounded native autoplay when inactive and switches to Stop Auto when Civ reports autoplay active. The UI disables the control during Studio operations and records live autoplay pause/active state. Verification: bun run --cwd apps/mapgen-studio check; bun run --cwd apps/mapgen-studio test -- runInGame; live Studio footer showed Stop Auto for an already-active autoplay game; invalid autoplay action probe returned 400."
+              }
+            ]
+          },
+          "rightComparedToLeft": {
+            "patchNew": 25,
+            "patchEquivalent": 9,
+            "sampleNew": [
+              {
+                "sha": "d186ed978fff01cccc465d429ad9a05310bfd3d3",
+                "subject": "feat(studio): harden Run in Game recovery Adds phase-aware Studio Run in Game operation state, resumable request status, shell-safe direct-control health, guarded Begin evidence, Vite/dev-server hardening, and user-facing recovery diagnostics. Includes the studio-run-in-game-robustness OpenSpec/workstream artifacts and focused direct-control, Studio UI/status, and Swooper authoring-surface test updates."
+              },
+              {
+                "sha": "7c2312708447f9ad7a38245a9feb4bb7dfb3339f",
+                "subject": "test(mapgen): keep artifact guards package-owned"
+              },
+              {
+                "sha": "ff740d9bcbef882409802eff6a6d96ec7866657d",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "df1b81532c7fcb4930c07fceee1e2ff748d05840",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "1e6267722ab07485f2b1ef938cae7d84fc29d041",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "761e4e1a7e5569b9252df00b7e2412603ac8561a",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "218d602c199f3d4455ef50133e870ad8885d3f6d",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "1020ae667a1ea973aa273e91f6c0bb3eaf4643a5",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              }
+            ],
+            "sampleEquivalent": [
+              {
+                "sha": "c8a09fedb1ad508e6e284945467631dfbe601140",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "3141acd40ead97ffbdcc1bda463a344585e23036",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "2bd8060613c51faa96421d8f1629938450030b90",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "913779e988091c7ce7ec16a7998c57986864a199",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "d09439a575d67dd1ceb39ac438921dfba8e782c9",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "1dc806e926ab2a5711ea43358a2e07889833b0b8",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "c5fa90ef27207333e4dca2af4c8cc494788f0dc5",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              },
+              {
+                "sha": "49a93be73254e3be443ee35cfa16b2add7d908e3",
+                "subject": "feat(studio): add Civ autoplay control Adds a Studio /api/civ7/autoplay endpoint backed by @civ7/direct-control startCiv7Autoplay and stopCiv7Autoplay. The endpoint rejects malformed actions and blocks autoplay changes while Save/Deploy or Run in Game operations are active. Adds a live Civ footer button that starts unbounded native autoplay when inactive and switches to Stop Auto when Civ reports autoplay active. The UI disables the control during Studio operations and records live autoplay pause/active state. Verification: bun run --cwd apps/mapgen-studio check; bun run --cwd apps/mapgen-studio test -- runInGame; live Studio footer showed Stop Auto for an already-active autoplay game; invalid autoplay action probe returned 400."
+              }
+            ]
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.018469656992084433,
+          "subjectTokenJaccard": 0.01951219512195122,
+          "combinedJaccard": 0.022988505747126436,
+          "sharedBranchTokens": [
+            "evidence",
+            "fixes",
+            "framing",
+            "review",
+            "skill",
+            "systematic",
+            "workstream"
+          ],
+          "sharedSubjectTokens": [
+            "apply",
+            "civ7",
+            "fixes",
+            "review",
+            "skill",
+            "skills",
+            "systematic",
+            "workstream"
+          ],
+          "sharedCombinedTokens": [
+            "apply",
+            "civ7",
+            "evidence",
+            "fixes",
+            "framing",
+            "review",
+            "skill",
+            "skills",
+            "systematic",
+            "workstream"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "left-has-novel-patches",
+          "left-has-patch-equivalent-in-right",
+          "patch-overlap-diverged",
+          "right-has-novel-patches",
+          "right-has-patch-equivalent-in-left"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/systematic-workstream-skill-framing...agent-watch-civ7-live-play-reference-assembly",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "codex/systematic-workstream-skill-framing",
+        "right": "agent-watch-civ7-live-play-reference-assembly",
+        "leftRoot": "codex/systematic-workstream-skill-framing",
+        "rightRoot": "agent-watch-civ7-live-play-reference-assembly",
+        "leftHead": "70604ec945cefae8415972dacb1732ef0f165425",
+        "rightHead": "9e67f53645597dfd9d7299bb5beb9509fa7569fe",
+        "mergeBase": {
+          "sha": "0507ef8e9108fc58f141c241f214994f221eb4d2",
+          "short": "0507ef8e9"
+        },
+        "aheadBehind": {
+          "leftOnly": 19,
+          "rightOnly": 19
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 11,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "cdca71f02ac1bf24757a89f86bc3fe894080b5ce",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "017fbb24931944b4fb4b8a9a587ac94fa196bcc0",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "3433ecb1ed49e9dd6fbf8425064fa2b39adfbb6c",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "49a51198a16237c2debd6fc785824d9e27c92116",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "d39ab4613f878969857aeee533c00af3c4a56263",
+                "subject": "feat(studio): harden Run in Game recovery Adds phase-aware Studio Run in Game operation state, resumable request status, shell-safe direct-control health, guarded Begin evidence, Vite/dev-server hardening, and user-facing recovery diagnostics. Includes the studio-run-in-game-robustness OpenSpec/workstream artifacts and focused direct-control, Studio UI/status, and Swooper authoring-surface test updates."
+              },
+              {
+                "sha": "7eda16891440a90894aac4f860da64b4f047eeac",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "364e7f2880f133b3b47353fb24b2e9ec85424cf7",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "feba6884f8db4273e786bf094f9675afe2bff040",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 19,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "54a01a354418e1c4115cecea758772be9bced2c6",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "86e33ada1ee886c3c2ee3c79f1a98781052a0748",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "d3c61d35a37b7b2465cbf2e473ead9073d2ffd5c",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "3e363eb0fcdf6a39bb4fbf201372a7e97e915814",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "8616c6643651e572b2a3f05781447610c554c9f3",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "b8ef45082366776f785aeb8c994df3a4c24af024",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "941d5debf94302679a60f7f0db84865e0ee2bf13",
+                "subject": "feat(cli): add live Civ play support"
+              },
+              {
+                "sha": "fd69c477767358f259e8c9a00ee561dacd67cc68",
+                "subject": "feat(cli): add live Civ tactical support"
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0,
+          "subjectTokenJaccard": 0.07142857142857142,
+          "combinedJaccard": 0.05263157894736842,
+          "sharedBranchTokens": [],
+          "sharedSubjectTokens": [
+            "civ7"
+          ],
+          "sharedCombinedTokens": [
+            "civ7"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/systematic-workstream-skill-framing...codex/foundation-architecture-packet",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "codex/systematic-workstream-skill-framing",
+        "right": "codex/foundation-architecture-packet",
+        "leftRoot": "codex/systematic-workstream-skill-framing",
+        "rightRoot": "codex/foundation-architecture-packet",
+        "leftHead": "70604ec945cefae8415972dacb1732ef0f165425",
+        "rightHead": "eaba8d5c707c3e84396bdd002583e21b9cb0d6f3",
+        "mergeBase": {
+          "sha": "98dca389248d5ddb2777a88105c3ade452b2137c",
+          "short": "98dca3892"
+        },
+        "aheadBehind": {
+          "leftOnly": 1,
+          "rightOnly": 1
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 1,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "70604ec945cefae8415972dacb1732ef0f165425",
+                "subject": "docs(skills): capture systematic workstream skill objective"
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 1,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "eaba8d5c707c3e84396bdd002583e21b9cb0d6f3",
+                "subject": "docs(foundation): add architecture pipeline packet Capture the current Foundation stage, step, op, artifact, projection, validator/test, and downstream consumer model as a source-cited pipeline-realism packet. Record structural coupling around tectonics, final-only crust evolution, projection-derived surfaces, Morphology belt synthesis, missing landform intent layers, and validation/readback gates. References: docs/projects/pipeline-realism/resources/packets/foundation-architecture-generative-pipeline/README.md"
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0,
+          "subjectTokenJaccard": 0,
+          "combinedJaccard": 0,
+          "sharedBranchTokens": [],
+          "sharedSubjectTokens": [],
+          "sharedCombinedTokens": []
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/swooper-mapgen-recovery-drain...codex/stack-lineage-audit-reference",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "codex/swooper-mapgen-recovery-drain",
+        "right": "codex/stack-lineage-audit-reference",
+        "leftRoot": "codex/swooper-mapgen-recovery-drain",
+        "rightRoot": "codex/stack-lineage-audit-reference",
+        "leftHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "rightHead": "be60913515d9fd157858316400e95851bbb71d8c",
+        "mergeBase": {
+          "sha": "98dca389248d5ddb2777a88105c3ade452b2137c",
+          "short": "98dca3892"
+        },
+        "aheadBehind": {
+          "leftOnly": 17,
+          "rightOnly": 12
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 17,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "647b1e61c8bbd024c97729109e4b04fa4115835d",
+                "subject": "fix(mapgen): plan starts by expansion viability"
+              },
+              {
+                "sha": "bcec62ea3b28c88fac8106db46e616a0a5c56567",
+                "subject": "fix(mapgen): gate initial resource authoring by age"
+              },
+              {
+                "sha": "5f2aa7a732280ba29f99e919f1912ddc8d207f0a",
+                "subject": "feat(studio): load Civ saved setup configs"
+              },
+              {
+                "sha": "93076f453742afb283361e0b137ce66ab6bb5158",
+                "subject": "fix(studio): validate Civ7 setup seeds"
+              },
+              {
+                "sha": "08ee2e7807eb10983870e6256cd49ad23812932b",
+                "subject": "fix(studio): harden live setup and run-in-game sync Commit the Studio-side setup sync, run-in-game failure logging/restart helpers, viz orientation guard, and live parity workstream notes as one coherent runtime integration slice."
+              },
+              {
+                "sha": "61581904ec37ac6c3e3f3097916da75936e1b949",
+                "subject": "refactor(mapgen): align foundation authoring contracts Checkpoint the foundation authoring surface alignment: mesh and plate topology contracts, history normalization docs, generated map config updates, and foundation contract tests."
+              },
+              {
+                "sha": "b410ef219d846294d62cd538bb237113e8650c36",
+                "subject": "fix(mapgen): restore authored RNG authority Move MapGen-authored randomness back behind mapgen-core seeded helpers, document the Civ adapter RNG boundary, update standard-stage imports, and align viz/stamping outputs on OddQ tile space."
+              },
+              {
+                "sha": "a23a36978eb395fb594f6cabdb62c44ea5812ed3",
+                "subject": "feat(mapgen): plan long tectonic mountain regions Add reusable OddQ component helpers, preserve connected belt corridors, trace range-region axes for longer mountain bodies, expose independent morphology knobs, and add an earthlike regression covering range diameter and hill balance."
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 12,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "bb26f5168ad35800b1d325ee65d0e585e44bd57f",
+                "subject": "docs(graphite): clarify stack action taxonomy"
+              },
+              {
+                "sha": "536e478bf7292fbedc5635fcb58c88aa7f2a8272",
+                "subject": "chore(graphite): consolidate stack visualizer toolkit"
+              },
+              {
+                "sha": "d65df9af9d4d1e0fdf816a763622326ff0853e31",
+                "subject": "docs(graphite): capture stack inspect workstream base"
+              },
+              {
+                "sha": "94424ef23522e89c1ece18de9dbd19e50023e1ba",
+                "subject": "docs(graphite): add PR tracking layer to stack visual"
+              },
+              {
+                "sha": "440dad30748ca6fbf40c143bcca313d5870a4417",
+                "subject": "docs(graphite): define stack inspect React workstream"
+              },
+              {
+                "sha": "a62678b091afd4de275458487c914ee03c08dcb3",
+                "subject": "docs(graphite): encode stack recovery phases"
+              },
+              {
+                "sha": "b7bdd75650c31ed3cb391c9b055bd05957b7f512",
+                "subject": "docs(graphite): define effect-orpc visualizer workstream"
+              },
+              {
+                "sha": "967d0657e19278d337854b5d34aece5e745dc92c",
+                "subject": "docs(graphite): refresh stack blocker visual"
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.04838709677419355,
+          "subjectTokenJaccard": 0.13048498845265588,
+          "combinedJaccard": 0.13302752293577982,
+          "sharedBranchTokens": [
+            "audit",
+            "evidence",
+            "live",
+            "parity",
+            "proof",
+            "runtime"
+          ],
+          "sharedSubjectTokens": [
+            "accounting",
+            "across",
+            "age",
+            "bind",
+            "boundary",
+            "bounded",
+            "cached",
+            "claim",
+            "claiming",
+            "classes",
+            "classify",
+            "clean",
+            "close",
+            "closure",
+            "context",
+            "contract",
+            "contracts",
+            "core",
+            "counts",
+            "decision",
+            "dependencies",
+            "diagnostics",
+            "disposition",
+            "downstream",
+            "effect",
+            "embedded",
+            "evidence",
+            "existing",
+            "expand",
+            "expected",
+            "explicit",
+            "expose"
+          ],
+          "sharedCombinedTokens": [
+            "accounting",
+            "across",
+            "age",
+            "audit",
+            "bind",
+            "boundary",
+            "bounded",
+            "cached",
+            "claim",
+            "claiming",
+            "classes",
+            "classify",
+            "clean",
+            "close",
+            "closure",
+            "context",
+            "contract",
+            "contracts",
+            "core",
+            "counts",
+            "decision",
+            "dependencies",
+            "diagnostics",
+            "disposition",
+            "downstream",
+            "effect",
+            "embedded",
+            "evidence",
+            "existing",
+            "expand",
+            "expected",
+            "explicit",
+            "expose",
+            "filter",
+            "focused",
+            "for",
+            "found",
+            "full",
+            "gate",
+            "guard",
+            "help",
+            "identity",
+            "imports",
+            "includes",
+            "including",
+            "inside",
+            "instead",
+            "integrate"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/swooper-mapgen-recovery-drain...codex/live-play-settlement-reference",
+        "scope": "root-pair",
+        "relationshipKind": "semantic-overlap-diverged",
+        "left": "codex/swooper-mapgen-recovery-drain",
+        "right": "codex/live-play-settlement-reference",
+        "leftRoot": "codex/swooper-mapgen-recovery-drain",
+        "rightRoot": "codex/live-play-settlement-reference",
+        "leftHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "rightHead": "754f90431964aaac4e266a483012b4711b2f6198",
+        "mergeBase": {
+          "sha": "98dca389248d5ddb2777a88105c3ade452b2137c",
+          "short": "98dca3892"
+        },
+        "aheadBehind": {
+          "leftOnly": 17,
+          "rightOnly": 1
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 17,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "647b1e61c8bbd024c97729109e4b04fa4115835d",
+                "subject": "fix(mapgen): plan starts by expansion viability"
+              },
+              {
+                "sha": "bcec62ea3b28c88fac8106db46e616a0a5c56567",
+                "subject": "fix(mapgen): gate initial resource authoring by age"
+              },
+              {
+                "sha": "5f2aa7a732280ba29f99e919f1912ddc8d207f0a",
+                "subject": "feat(studio): load Civ saved setup configs"
+              },
+              {
+                "sha": "93076f453742afb283361e0b137ce66ab6bb5158",
+                "subject": "fix(studio): validate Civ7 setup seeds"
+              },
+              {
+                "sha": "08ee2e7807eb10983870e6256cd49ad23812932b",
+                "subject": "fix(studio): harden live setup and run-in-game sync Commit the Studio-side setup sync, run-in-game failure logging/restart helpers, viz orientation guard, and live parity workstream notes as one coherent runtime integration slice."
+              },
+              {
+                "sha": "61581904ec37ac6c3e3f3097916da75936e1b949",
+                "subject": "refactor(mapgen): align foundation authoring contracts Checkpoint the foundation authoring surface alignment: mesh and plate topology contracts, history normalization docs, generated map config updates, and foundation contract tests."
+              },
+              {
+                "sha": "b410ef219d846294d62cd538bb237113e8650c36",
+                "subject": "fix(mapgen): restore authored RNG authority Move MapGen-authored randomness back behind mapgen-core seeded helpers, document the Civ adapter RNG boundary, update standard-stage imports, and align viz/stamping outputs on OddQ tile space."
+              },
+              {
+                "sha": "a23a36978eb395fb594f6cabdb62c44ea5812ed3",
+                "subject": "feat(mapgen): plan long tectonic mountain regions Add reusable OddQ component helpers, preserve connected belt corridors, trace range-region axes for longer mountain bodies, expose independent morphology knobs, and add an earthlike regression covering range diameter and hill balance."
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 1,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "754f90431964aaac4e266a483012b4711b2f6198",
+                "subject": "docs(graphite): prepare live-play settlement reference"
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.4027777777777778,
+          "subjectTokenJaccard": 0.2890625,
+          "combinedJaccard": 0.2919334186939821,
+          "sharedBranchTokens": [
+            "assignment",
+            "authorship",
+            "boundary",
+            "builder",
+            "catalog",
+            "classification",
+            "coast",
+            "completion",
+            "context",
+            "coordinate",
+            "delta",
+            "diagnostics",
+            "direction",
+            "distribution",
+            "edge",
+            "evidence",
+            "exact",
+            "feasibility",
+            "feature",
+            "final",
+            "footprint",
+            "intake",
+            "lake",
+            "legality",
+            "live",
+            "local",
+            "map",
+            "mask",
+            "materialization",
+            "mock",
+            "named",
+            "natural"
+          ],
+          "sharedSubjectTokens": [
+            "1fhc",
+            "acceptance",
+            "accepted",
+            "adjacent",
+            "age",
+            "align",
+            "apps",
+            "artifact",
+            "artifacts",
+            "assignment",
+            "authored",
+            "authoritative",
+            "authority",
+            "authorship",
+            "bind",
+            "binds",
+            "blocked",
+            "both",
+            "bound",
+            "boundary",
+            "bounded",
+            "canhaveresource",
+            "catalog",
+            "cells",
+            "change",
+            "changes",
+            "civ",
+            "civ7",
+            "claim",
+            "class",
+            "classes",
+            "classification"
+          ],
+          "sharedCombinedTokens": [
+            "1fhc",
+            "acceptance",
+            "accepted",
+            "adjacent",
+            "age",
+            "align",
+            "apps",
+            "artifact",
+            "artifacts",
+            "assignment",
+            "authored",
+            "authoritative",
+            "authority",
+            "authorship",
+            "bind",
+            "binds",
+            "blocked",
+            "both",
+            "bound",
+            "boundary",
+            "bounded",
+            "builder",
+            "canhaveresource",
+            "catalog",
+            "cells",
+            "change",
+            "changes",
+            "civ",
+            "civ7",
+            "claim",
+            "class",
+            "classes",
+            "classification",
+            "classified",
+            "classify",
+            "closure",
+            "coast",
+            "completion",
+            "config",
+            "configs",
+            "context",
+            "contract",
+            "control",
+            "coordinate",
+            "correct",
+            "count",
+            "cut",
+            "cuts"
+          ]
+        },
+        "signals": [
+          "branch-name-overlap",
+          "cross-root",
+          "left-has-novel-patches",
+          "right-has-novel-patches",
+          "semantic-overlap-diverged",
+          "subject-overlap"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/swooper-mapgen-recovery-drain...codex/local-catalog-enrichment",
+        "scope": "root-pair",
+        "relationshipKind": "patch-overlap-diverged",
+        "left": "codex/swooper-mapgen-recovery-drain",
+        "right": "codex/local-catalog-enrichment",
+        "leftRoot": "codex/swooper-mapgen-recovery-drain",
+        "rightRoot": "codex/local-catalog-enrichment",
+        "leftHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "rightHead": "1689806731331dae56262cfa988fdbc0800b3e88",
+        "mergeBase": {
+          "sha": "929a282ff34033664e1fee71f4f78c977796a3dd",
+          "short": "929a282ff"
+        },
+        "aheadBehind": {
+          "leftOnly": 43,
+          "rightOnly": 34
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 26,
+            "patchEquivalent": 9,
+            "sampleNew": [
+              {
+                "sha": "db52c7aecda06bebb4eba34bee60def035d67249",
+                "subject": "test(mapgen): keep artifact guards package-owned"
+              },
+              {
+                "sha": "9011233676639569d76464166179189b1779a169",
+                "subject": "docs(morphology): integrate live readback boundary"
+              },
+              {
+                "sha": "fde990cb16ee8262722a7b8c89ad3c4414c4cf15",
+                "subject": "fix(ecology): integrate morphology peer repairs"
+              },
+              {
+                "sha": "37ae85d62746e62d31c603a52d357e51e8c82cea",
+                "subject": "feat(mapgen): integrate resource corpus expectations"
+              },
+              {
+                "sha": "b1b1b33f3c0d0911a8ab1242a948a36c7af7947e",
+                "subject": "feat(mapgen): integrate resource ops rollup"
+              },
+              {
+                "sha": "e4b5c995d6b38c06a4e9957ddc2b614cab8b03f2",
+                "subject": "fix(mapgen): integrate resource runtime proof"
+              },
+              {
+                "sha": "caab828e97c7d1ee0716dd2cfc314a4c6ff3fa2c",
+                "subject": "chore(imports): break circular dependency edges"
+              },
+              {
+                "sha": "0507ef8e9108fc58f141c241f214994f221eb4d2",
+                "subject": "fix(mapgen): stabilize integrated stack boundaries"
+              }
+            ],
+            "sampleEquivalent": [
+              {
+                "sha": "cdca71f02ac1bf24757a89f86bc3fe894080b5ce",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "017fbb24931944b4fb4b8a9a587ac94fa196bcc0",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "3433ecb1ed49e9dd6fbf8425064fa2b39adfbb6c",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "49a51198a16237c2debd6fc785824d9e27c92116",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "7eda16891440a90894aac4f860da64b4f047eeac",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "364e7f2880f133b3b47353fb24b2e9ec85424cf7",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "feba6884f8db4273e786bf094f9675afe2bff040",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              },
+              {
+                "sha": "9d40e87281cfca0355a6ea6934906be200eb874b",
+                "subject": "feat(studio): add Civ autoplay control Adds a Studio /api/civ7/autoplay endpoint backed by @civ7/direct-control startCiv7Autoplay and stopCiv7Autoplay. The endpoint rejects malformed actions and blocks autoplay changes while Save/Deploy or Run in Game operations are active. Adds a live Civ footer button that starts unbounded native autoplay when inactive and switches to Stop Auto when Civ reports autoplay active. The UI disables the control during Studio operations and records live autoplay pause/active state. Verification: bun run --cwd apps/mapgen-studio check; bun run --cwd apps/mapgen-studio test -- runInGame; live Studio footer showed Stop Auto for an already-active autoplay game; invalid autoplay action probe returned 400."
+              }
+            ]
+          },
+          "rightComparedToLeft": {
+            "patchNew": 25,
+            "patchEquivalent": 9,
+            "sampleNew": [
+              {
+                "sha": "d186ed978fff01cccc465d429ad9a05310bfd3d3",
+                "subject": "feat(studio): harden Run in Game recovery Adds phase-aware Studio Run in Game operation state, resumable request status, shell-safe direct-control health, guarded Begin evidence, Vite/dev-server hardening, and user-facing recovery diagnostics. Includes the studio-run-in-game-robustness OpenSpec/workstream artifacts and focused direct-control, Studio UI/status, and Swooper authoring-surface test updates."
+              },
+              {
+                "sha": "7c2312708447f9ad7a38245a9feb4bb7dfb3339f",
+                "subject": "test(mapgen): keep artifact guards package-owned"
+              },
+              {
+                "sha": "ff740d9bcbef882409802eff6a6d96ec7866657d",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "df1b81532c7fcb4930c07fceee1e2ff748d05840",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "1e6267722ab07485f2b1ef938cae7d84fc29d041",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "761e4e1a7e5569b9252df00b7e2412603ac8561a",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "218d602c199f3d4455ef50133e870ad8885d3f6d",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "1020ae667a1ea973aa273e91f6c0bb3eaf4643a5",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              }
+            ],
+            "sampleEquivalent": [
+              {
+                "sha": "c8a09fedb1ad508e6e284945467631dfbe601140",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "3141acd40ead97ffbdcc1bda463a344585e23036",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "2bd8060613c51faa96421d8f1629938450030b90",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "913779e988091c7ce7ec16a7998c57986864a199",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "d09439a575d67dd1ceb39ac438921dfba8e782c9",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "1dc806e926ab2a5711ea43358a2e07889833b0b8",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "c5fa90ef27207333e4dca2af4c8cc494788f0dc5",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              },
+              {
+                "sha": "49a93be73254e3be443ee35cfa16b2add7d908e3",
+                "subject": "feat(studio): add Civ autoplay control Adds a Studio /api/civ7/autoplay endpoint backed by @civ7/direct-control startCiv7Autoplay and stopCiv7Autoplay. The endpoint rejects malformed actions and blocks autoplay changes while Save/Deploy or Run in Game operations are active. Adds a live Civ footer button that starts unbounded native autoplay when inactive and switches to Stop Auto when Civ reports autoplay active. The UI disables the control during Studio operations and records live autoplay pause/active state. Verification: bun run --cwd apps/mapgen-studio check; bun run --cwd apps/mapgen-studio test -- runInGame; live Studio footer showed Stop Auto for an already-active autoplay game; invalid autoplay action probe returned 400."
+              }
+            ]
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.09090909090909091,
+          "subjectTokenJaccard": 0.14224137931034483,
+          "combinedJaccard": 0.14889123548046462,
+          "sharedBranchTokens": [
+            "apply",
+            "audit",
+            "authority",
+            "blocker",
+            "boundary",
+            "builder",
+            "catalog",
+            "classification",
+            "completion",
+            "context",
+            "diagnostics",
+            "drift",
+            "evidence",
+            "exact",
+            "input",
+            "intake",
+            "live",
+            "local",
+            "log",
+            "map",
+            "materialization",
+            "owner",
+            "placement",
+            "plan",
+            "policy",
+            "proof",
+            "queue",
+            "repair",
+            "resource",
+            "restart",
+            "row",
+            "runtime"
+          ],
+          "sharedSubjectTokens": [
+            "acceptance",
+            "adapter",
+            "align",
+            "apply",
+            "artifact",
+            "artifacts",
+            "audit",
+            "authority",
+            "bind",
+            "binding",
+            "blocked",
+            "blocker",
+            "boundary",
+            "bounded",
+            "candidates",
+            "catalog",
+            "civ7",
+            "claims",
+            "class",
+            "classify",
+            "close",
+            "compact",
+            "compatibility",
+            "completion",
+            "config",
+            "context",
+            "contract",
+            "control",
+            "core",
+            "decision",
+            "dependencies",
+            "derive"
+          ],
+          "sharedCombinedTokens": [
+            "acceptance",
+            "adapter",
+            "align",
+            "apply",
+            "artifact",
+            "artifacts",
+            "audit",
+            "authority",
+            "bind",
+            "binding",
+            "blocked",
+            "blocker",
+            "boundary",
+            "bounded",
+            "builder",
+            "candidates",
+            "catalog",
+            "civ7",
+            "claims",
+            "class",
+            "classification",
+            "classify",
+            "close",
+            "compact",
+            "compatibility",
+            "complete",
+            "completion",
+            "config",
+            "context",
+            "contract",
+            "control",
+            "core",
+            "decision",
+            "dependencies",
+            "derive",
+            "diagnostics",
+            "direct",
+            "directions",
+            "disposition",
+            "downstream",
+            "drift",
+            "effect",
+            "evaluation",
+            "evidence",
+            "exact",
+            "explain",
+            "export",
+            "expose"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "left-has-novel-patches",
+          "left-has-patch-equivalent-in-right",
+          "patch-overlap-diverged",
+          "right-has-novel-patches",
+          "right-has-patch-equivalent-in-left"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/swooper-mapgen-recovery-drain...agent-watch-civ7-live-play-reference-assembly",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "codex/swooper-mapgen-recovery-drain",
+        "right": "agent-watch-civ7-live-play-reference-assembly",
+        "leftRoot": "codex/swooper-mapgen-recovery-drain",
+        "rightRoot": "agent-watch-civ7-live-play-reference-assembly",
+        "leftHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "rightHead": "9e67f53645597dfd9d7299bb5beb9509fa7569fe",
+        "mergeBase": {
+          "sha": "0507ef8e9108fc58f141c241f214994f221eb4d2",
+          "short": "0507ef8e9"
+        },
+        "aheadBehind": {
+          "leftOnly": 35,
+          "rightOnly": 19
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 27,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "cdca71f02ac1bf24757a89f86bc3fe894080b5ce",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "017fbb24931944b4fb4b8a9a587ac94fa196bcc0",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "3433ecb1ed49e9dd6fbf8425064fa2b39adfbb6c",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "49a51198a16237c2debd6fc785824d9e27c92116",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "d39ab4613f878969857aeee533c00af3c4a56263",
+                "subject": "feat(studio): harden Run in Game recovery Adds phase-aware Studio Run in Game operation state, resumable request status, shell-safe direct-control health, guarded Begin evidence, Vite/dev-server hardening, and user-facing recovery diagnostics. Includes the studio-run-in-game-robustness OpenSpec/workstream artifacts and focused direct-control, Studio UI/status, and Swooper authoring-surface test updates."
+              },
+              {
+                "sha": "7eda16891440a90894aac4f860da64b4f047eeac",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "364e7f2880f133b3b47353fb24b2e9ec85424cf7",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "feba6884f8db4273e786bf094f9675afe2bff040",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 19,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "54a01a354418e1c4115cecea758772be9bced2c6",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "86e33ada1ee886c3c2ee3c79f1a98781052a0748",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "d3c61d35a37b7b2465cbf2e473ead9073d2ffd5c",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "3e363eb0fcdf6a39bb4fbf201372a7e97e915814",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "8616c6643651e572b2a3f05781447610c554c9f3",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "b8ef45082366776f785aeb8c994df3a4c24af024",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "941d5debf94302679a60f7f0db84865e0ee2bf13",
+                "subject": "feat(cli): add live Civ play support"
+              },
+              {
+                "sha": "fd69c477767358f259e8c9a00ee561dacd67cc68",
+                "subject": "feat(cli): add live Civ tactical support"
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.010752688172043012,
+          "subjectTokenJaccard": 0.006125574272588055,
+          "combinedJaccard": 0.006069802731411229,
+          "sharedBranchTokens": [
+            "live"
+          ],
+          "sharedSubjectTokens": [
+            "authority",
+            "civ7",
+            "live",
+            "source"
+          ],
+          "sharedCombinedTokens": [
+            "authority",
+            "civ7",
+            "live",
+            "source"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/swooper-mapgen-recovery-drain...codex/foundation-architecture-packet",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "codex/swooper-mapgen-recovery-drain",
+        "right": "codex/foundation-architecture-packet",
+        "leftRoot": "codex/swooper-mapgen-recovery-drain",
+        "rightRoot": "codex/foundation-architecture-packet",
+        "leftHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "rightHead": "eaba8d5c707c3e84396bdd002583e21b9cb0d6f3",
+        "mergeBase": {
+          "sha": "98dca389248d5ddb2777a88105c3ade452b2137c",
+          "short": "98dca3892"
+        },
+        "aheadBehind": {
+          "leftOnly": 17,
+          "rightOnly": 1
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 17,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "647b1e61c8bbd024c97729109e4b04fa4115835d",
+                "subject": "fix(mapgen): plan starts by expansion viability"
+              },
+              {
+                "sha": "bcec62ea3b28c88fac8106db46e616a0a5c56567",
+                "subject": "fix(mapgen): gate initial resource authoring by age"
+              },
+              {
+                "sha": "5f2aa7a732280ba29f99e919f1912ddc8d207f0a",
+                "subject": "feat(studio): load Civ saved setup configs"
+              },
+              {
+                "sha": "93076f453742afb283361e0b137ce66ab6bb5158",
+                "subject": "fix(studio): validate Civ7 setup seeds"
+              },
+              {
+                "sha": "08ee2e7807eb10983870e6256cd49ad23812932b",
+                "subject": "fix(studio): harden live setup and run-in-game sync Commit the Studio-side setup sync, run-in-game failure logging/restart helpers, viz orientation guard, and live parity workstream notes as one coherent runtime integration slice."
+              },
+              {
+                "sha": "61581904ec37ac6c3e3f3097916da75936e1b949",
+                "subject": "refactor(mapgen): align foundation authoring contracts Checkpoint the foundation authoring surface alignment: mesh and plate topology contracts, history normalization docs, generated map config updates, and foundation contract tests."
+              },
+              {
+                "sha": "b410ef219d846294d62cd538bb237113e8650c36",
+                "subject": "fix(mapgen): restore authored RNG authority Move MapGen-authored randomness back behind mapgen-core seeded helpers, document the Civ adapter RNG boundary, update standard-stage imports, and align viz/stamping outputs on OddQ tile space."
+              },
+              {
+                "sha": "a23a36978eb395fb594f6cabdb62c44ea5812ed3",
+                "subject": "feat(mapgen): plan long tectonic mountain regions Add reusable OddQ component helpers, preserve connected belt corridors, trace range-region axes for longer mountain bodies, expose independent morphology knobs, and add an earthlike regression covering range diameter and hill balance."
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 1,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "eaba8d5c707c3e84396bdd002583e21b9cb0d6f3",
+                "subject": "docs(foundation): add architecture pipeline packet Capture the current Foundation stage, step, op, artifact, projection, validator/test, and downstream consumer model as a source-cited pipeline-realism packet. Record structural coupling around tectonics, final-only crust evolution, projection-derived surfaces, Morphology belt synthesis, missing landform intent layers, and validation/readback gates. References: docs/projects/pipeline-realism/resources/packets/foundation-architecture-generative-pipeline/README.md"
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0,
+          "subjectTokenJaccard": 0.0206794682422452,
+          "combinedJaccard": 0.020588235294117647,
+          "sharedBranchTokens": [],
+          "sharedSubjectTokens": [
+            "artifact",
+            "downstream",
+            "final",
+            "intent",
+            "morphology",
+            "packets",
+            "pipeline",
+            "projection",
+            "projects",
+            "readback",
+            "source",
+            "stage",
+            "synthesis",
+            "validation"
+          ],
+          "sharedCombinedTokens": [
+            "artifact",
+            "downstream",
+            "final",
+            "intent",
+            "morphology",
+            "packets",
+            "pipeline",
+            "projection",
+            "projects",
+            "readback",
+            "source",
+            "stage",
+            "synthesis",
+            "validation"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/stack-lineage-audit-reference...codex/live-play-settlement-reference",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "codex/stack-lineage-audit-reference",
+        "right": "codex/live-play-settlement-reference",
+        "leftRoot": "codex/stack-lineage-audit-reference",
+        "rightRoot": "codex/live-play-settlement-reference",
+        "leftHead": "be60913515d9fd157858316400e95851bbb71d8c",
+        "rightHead": "754f90431964aaac4e266a483012b4711b2f6198",
+        "mergeBase": {
+          "sha": "98dca389248d5ddb2777a88105c3ade452b2137c",
+          "short": "98dca3892"
+        },
+        "aheadBehind": {
+          "leftOnly": 12,
+          "rightOnly": 1
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 12,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "bb26f5168ad35800b1d325ee65d0e585e44bd57f",
+                "subject": "docs(graphite): clarify stack action taxonomy"
+              },
+              {
+                "sha": "536e478bf7292fbedc5635fcb58c88aa7f2a8272",
+                "subject": "chore(graphite): consolidate stack visualizer toolkit"
+              },
+              {
+                "sha": "d65df9af9d4d1e0fdf816a763622326ff0853e31",
+                "subject": "docs(graphite): capture stack inspect workstream base"
+              },
+              {
+                "sha": "94424ef23522e89c1ece18de9dbd19e50023e1ba",
+                "subject": "docs(graphite): add PR tracking layer to stack visual"
+              },
+              {
+                "sha": "440dad30748ca6fbf40c143bcca313d5870a4417",
+                "subject": "docs(graphite): define stack inspect React workstream"
+              },
+              {
+                "sha": "a62678b091afd4de275458487c914ee03c08dcb3",
+                "subject": "docs(graphite): encode stack recovery phases"
+              },
+              {
+                "sha": "b7bdd75650c31ed3cb391c9b055bd05957b7f512",
+                "subject": "docs(graphite): define effect-orpc visualizer workstream"
+              },
+              {
+                "sha": "967d0657e19278d337854b5d34aece5e745dc92c",
+                "subject": "docs(graphite): refresh stack blocker visual"
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 1,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "754f90431964aaac4e266a483012b4711b2f6198",
+                "subject": "docs(graphite): prepare live-play settlement reference"
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.06206896551724138,
+          "subjectTokenJaccard": 0.1266891891891892,
+          "combinedJaccard": 0.12950819672131147,
+          "sharedBranchTokens": [
+            "contract",
+            "evidence",
+            "integration",
+            "live",
+            "orpc",
+            "parity",
+            "proof",
+            "reference",
+            "runtime"
+          ],
+          "sharedSubjectTokens": [
+            "age",
+            "anchor",
+            "bind",
+            "boundary",
+            "bounded",
+            "claim",
+            "classes",
+            "classify",
+            "closure",
+            "command",
+            "context",
+            "contract",
+            "diagnostics",
+            "disposition",
+            "effect",
+            "evidence",
+            "existing",
+            "expansion",
+            "expose",
+            "fixture",
+            "focused",
+            "for",
+            "full",
+            "gate",
+            "help",
+            "identity",
+            "implementation",
+            "including",
+            "integration",
+            "joins",
+            "keep",
+            "lane"
+          ],
+          "sharedCombinedTokens": [
+            "age",
+            "anchor",
+            "bind",
+            "boundary",
+            "bounded",
+            "claim",
+            "classes",
+            "classify",
+            "closure",
+            "command",
+            "context",
+            "contract",
+            "correction",
+            "diagnostics",
+            "disposition",
+            "effect",
+            "evidence",
+            "existing",
+            "expansion",
+            "expose",
+            "fixture",
+            "focused",
+            "for",
+            "full",
+            "gate",
+            "help",
+            "identity",
+            "implementation",
+            "including",
+            "integration",
+            "joins",
+            "keep",
+            "lane",
+            "lanes",
+            "live",
+            "load",
+            "local",
+            "map",
+            "metadata",
+            "not",
+            "notes",
+            "openspec",
+            "orpc",
+            "owned",
+            "ownership",
+            "package",
+            "parity",
+            "policy"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/stack-lineage-audit-reference...codex/local-catalog-enrichment",
+        "scope": "root-pair",
+        "relationshipKind": "patch-overlap-diverged",
+        "left": "codex/stack-lineage-audit-reference",
+        "right": "codex/local-catalog-enrichment",
+        "leftRoot": "codex/stack-lineage-audit-reference",
+        "rightRoot": "codex/local-catalog-enrichment",
+        "leftHead": "be60913515d9fd157858316400e95851bbb71d8c",
+        "rightHead": "1689806731331dae56262cfa988fdbc0800b3e88",
+        "mergeBase": {
+          "sha": "929a282ff34033664e1fee71f4f78c977796a3dd",
+          "short": "929a282ff"
+        },
+        "aheadBehind": {
+          "leftOnly": 38,
+          "rightOnly": 34
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 21,
+            "patchEquivalent": 9,
+            "sampleNew": [
+              {
+                "sha": "db52c7aecda06bebb4eba34bee60def035d67249",
+                "subject": "test(mapgen): keep artifact guards package-owned"
+              },
+              {
+                "sha": "9011233676639569d76464166179189b1779a169",
+                "subject": "docs(morphology): integrate live readback boundary"
+              },
+              {
+                "sha": "fde990cb16ee8262722a7b8c89ad3c4414c4cf15",
+                "subject": "fix(ecology): integrate morphology peer repairs"
+              },
+              {
+                "sha": "37ae85d62746e62d31c603a52d357e51e8c82cea",
+                "subject": "feat(mapgen): integrate resource corpus expectations"
+              },
+              {
+                "sha": "b1b1b33f3c0d0911a8ab1242a948a36c7af7947e",
+                "subject": "feat(mapgen): integrate resource ops rollup"
+              },
+              {
+                "sha": "e4b5c995d6b38c06a4e9957ddc2b614cab8b03f2",
+                "subject": "fix(mapgen): integrate resource runtime proof"
+              },
+              {
+                "sha": "caab828e97c7d1ee0716dd2cfc314a4c6ff3fa2c",
+                "subject": "chore(imports): break circular dependency edges"
+              },
+              {
+                "sha": "0507ef8e9108fc58f141c241f214994f221eb4d2",
+                "subject": "fix(mapgen): stabilize integrated stack boundaries"
+              }
+            ],
+            "sampleEquivalent": [
+              {
+                "sha": "cdca71f02ac1bf24757a89f86bc3fe894080b5ce",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "017fbb24931944b4fb4b8a9a587ac94fa196bcc0",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "3433ecb1ed49e9dd6fbf8425064fa2b39adfbb6c",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "49a51198a16237c2debd6fc785824d9e27c92116",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "7eda16891440a90894aac4f860da64b4f047eeac",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "364e7f2880f133b3b47353fb24b2e9ec85424cf7",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "feba6884f8db4273e786bf094f9675afe2bff040",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              },
+              {
+                "sha": "9d40e87281cfca0355a6ea6934906be200eb874b",
+                "subject": "feat(studio): add Civ autoplay control Adds a Studio /api/civ7/autoplay endpoint backed by @civ7/direct-control startCiv7Autoplay and stopCiv7Autoplay. The endpoint rejects malformed actions and blocks autoplay changes while Save/Deploy or Run in Game operations are active. Adds a live Civ footer button that starts unbounded native autoplay when inactive and switches to Stop Auto when Civ reports autoplay active. The UI disables the control during Studio operations and records live autoplay pause/active state. Verification: bun run --cwd apps/mapgen-studio check; bun run --cwd apps/mapgen-studio test -- runInGame; live Studio footer showed Stop Auto for an already-active autoplay game; invalid autoplay action probe returned 400."
+              }
+            ]
+          },
+          "rightComparedToLeft": {
+            "patchNew": 25,
+            "patchEquivalent": 9,
+            "sampleNew": [
+              {
+                "sha": "d186ed978fff01cccc465d429ad9a05310bfd3d3",
+                "subject": "feat(studio): harden Run in Game recovery Adds phase-aware Studio Run in Game operation state, resumable request status, shell-safe direct-control health, guarded Begin evidence, Vite/dev-server hardening, and user-facing recovery diagnostics. Includes the studio-run-in-game-robustness OpenSpec/workstream artifacts and focused direct-control, Studio UI/status, and Swooper authoring-surface test updates."
+              },
+              {
+                "sha": "7c2312708447f9ad7a38245a9feb4bb7dfb3339f",
+                "subject": "test(mapgen): keep artifact guards package-owned"
+              },
+              {
+                "sha": "ff740d9bcbef882409802eff6a6d96ec7866657d",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "df1b81532c7fcb4930c07fceee1e2ff748d05840",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "1e6267722ab07485f2b1ef938cae7d84fc29d041",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "761e4e1a7e5569b9252df00b7e2412603ac8561a",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "218d602c199f3d4455ef50133e870ad8885d3f6d",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "1020ae667a1ea973aa273e91f6c0bb3eaf4643a5",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              }
+            ],
+            "sampleEquivalent": [
+              {
+                "sha": "c8a09fedb1ad508e6e284945467631dfbe601140",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "3141acd40ead97ffbdcc1bda463a344585e23036",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "2bd8060613c51faa96421d8f1629938450030b90",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "913779e988091c7ce7ec16a7998c57986864a199",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "d09439a575d67dd1ceb39ac438921dfba8e782c9",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "1dc806e926ab2a5711ea43358a2e07889833b0b8",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "c5fa90ef27207333e4dca2af4c8cc494788f0dc5",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              },
+              {
+                "sha": "49a93be73254e3be443ee35cfa16b2add7d908e3",
+                "subject": "feat(studio): add Civ autoplay control Adds a Studio /api/civ7/autoplay endpoint backed by @civ7/direct-control startCiv7Autoplay and stopCiv7Autoplay. The endpoint rejects malformed actions and blocks autoplay changes while Save/Deploy or Run in Game operations are active. Adds a live Civ footer button that starts unbounded native autoplay when inactive and switches to Stop Auto when Civ reports autoplay active. The UI disables the control during Studio operations and records live autoplay pause/active state. Verification: bun run --cwd apps/mapgen-studio check; bun run --cwd apps/mapgen-studio test -- runInGame; live Studio footer showed Stop Auto for an already-active autoplay game; invalid autoplay action probe returned 400."
+              }
+            ]
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.04738154613466334,
+          "subjectTokenJaccard": 0.15517241379310345,
+          "combinedJaccard": 0.16012084592145015,
+          "sharedBranchTokens": [
+            "alignment",
+            "audit",
+            "contract",
+            "core",
+            "effect",
+            "evidence",
+            "inspect",
+            "inspection",
+            "live",
+            "orpc",
+            "proof",
+            "rebaseline",
+            "reference",
+            "router",
+            "rpc",
+            "runtime",
+            "service",
+            "state",
+            "verification"
+          ],
+          "sharedSubjectTokens": [
+            "action",
+            "actions",
+            "bind",
+            "boundary",
+            "bounded",
+            "classify",
+            "close",
+            "command",
+            "component",
+            "context",
+            "contract",
+            "core",
+            "decision",
+            "define",
+            "dependencies",
+            "dependency",
+            "descriptor",
+            "descriptors",
+            "diagnostics",
+            "discovery",
+            "disposition",
+            "downstream",
+            "effect",
+            "enrich",
+            "error",
+            "errors",
+            "evidence",
+            "execute",
+            "expose",
+            "facade",
+            "field",
+            "fields"
+          ],
+          "sharedCombinedTokens": [
+            "action",
+            "actions",
+            "alignment",
+            "audit",
+            "bind",
+            "boundary",
+            "bounded",
+            "classify",
+            "close",
+            "command",
+            "component",
+            "context",
+            "contract",
+            "core",
+            "data",
+            "decision",
+            "define",
+            "dependencies",
+            "dependency",
+            "descriptor",
+            "descriptors",
+            "diagnostics",
+            "discovery",
+            "disposition",
+            "downstream",
+            "effect",
+            "enrich",
+            "error",
+            "errors",
+            "evidence",
+            "execute",
+            "expose",
+            "facade",
+            "field",
+            "fields",
+            "fixture",
+            "focus",
+            "for",
+            "gate",
+            "guard",
+            "harden",
+            "helpers",
+            "implementation",
+            "import",
+            "imports",
+            "inspect",
+            "inspection",
+            "install"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "left-has-novel-patches",
+          "left-has-patch-equivalent-in-right",
+          "patch-overlap-diverged",
+          "right-has-novel-patches",
+          "right-has-patch-equivalent-in-left"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/stack-lineage-audit-reference...agent-watch-civ7-live-play-reference-assembly",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "codex/stack-lineage-audit-reference",
+        "right": "agent-watch-civ7-live-play-reference-assembly",
+        "leftRoot": "codex/stack-lineage-audit-reference",
+        "rightRoot": "agent-watch-civ7-live-play-reference-assembly",
+        "leftHead": "be60913515d9fd157858316400e95851bbb71d8c",
+        "rightHead": "9e67f53645597dfd9d7299bb5beb9509fa7569fe",
+        "mergeBase": {
+          "sha": "0507ef8e9108fc58f141c241f214994f221eb4d2",
+          "short": "0507ef8e9"
+        },
+        "aheadBehind": {
+          "leftOnly": 30,
+          "rightOnly": 19
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 22,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "cdca71f02ac1bf24757a89f86bc3fe894080b5ce",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "017fbb24931944b4fb4b8a9a587ac94fa196bcc0",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "3433ecb1ed49e9dd6fbf8425064fa2b39adfbb6c",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "49a51198a16237c2debd6fc785824d9e27c92116",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "d39ab4613f878969857aeee533c00af3c4a56263",
+                "subject": "feat(studio): harden Run in Game recovery Adds phase-aware Studio Run in Game operation state, resumable request status, shell-safe direct-control health, guarded Begin evidence, Vite/dev-server hardening, and user-facing recovery diagnostics. Includes the studio-run-in-game-robustness OpenSpec/workstream artifacts and focused direct-control, Studio UI/status, and Swooper authoring-surface test updates."
+              },
+              {
+                "sha": "7eda16891440a90894aac4f860da64b4f047eeac",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "364e7f2880f133b3b47353fb24b2e9ec85424cf7",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "feba6884f8db4273e786bf094f9675afe2bff040",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 19,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "54a01a354418e1c4115cecea758772be9bced2c6",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "86e33ada1ee886c3c2ee3c79f1a98781052a0748",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "d3c61d35a37b7b2465cbf2e473ead9073d2ffd5c",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "3e363eb0fcdf6a39bb4fbf201372a7e97e915814",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "8616c6643651e572b2a3f05781447610c554c9f3",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "b8ef45082366776f785aeb8c994df3a4c24af024",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "941d5debf94302679a60f7f0db84865e0ee2bf13",
+                "subject": "feat(cli): add live Civ play support"
+              },
+              {
+                "sha": "fd69c477767358f259e8c9a00ee561dacd67cc68",
+                "subject": "feat(cli): add live Civ tactical support"
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.045454545454545456,
+          "subjectTokenJaccard": 0.006024096385542169,
+          "combinedJaccard": 0.008823529411764706,
+          "sharedBranchTokens": [
+            "live",
+            "reference"
+          ],
+          "sharedSubjectTokens": [
+            "live",
+            "source"
+          ],
+          "sharedCombinedTokens": [
+            "live",
+            "reference",
+            "source"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/stack-lineage-audit-reference...codex/foundation-architecture-packet",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "codex/stack-lineage-audit-reference",
+        "right": "codex/foundation-architecture-packet",
+        "leftRoot": "codex/stack-lineage-audit-reference",
+        "rightRoot": "codex/foundation-architecture-packet",
+        "leftHead": "be60913515d9fd157858316400e95851bbb71d8c",
+        "rightHead": "eaba8d5c707c3e84396bdd002583e21b9cb0d6f3",
+        "mergeBase": {
+          "sha": "98dca389248d5ddb2777a88105c3ade452b2137c",
+          "short": "98dca3892"
+        },
+        "aheadBehind": {
+          "leftOnly": 12,
+          "rightOnly": 1
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 12,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "bb26f5168ad35800b1d325ee65d0e585e44bd57f",
+                "subject": "docs(graphite): clarify stack action taxonomy"
+              },
+              {
+                "sha": "536e478bf7292fbedc5635fcb58c88aa7f2a8272",
+                "subject": "chore(graphite): consolidate stack visualizer toolkit"
+              },
+              {
+                "sha": "d65df9af9d4d1e0fdf816a763622326ff0853e31",
+                "subject": "docs(graphite): capture stack inspect workstream base"
+              },
+              {
+                "sha": "94424ef23522e89c1ece18de9dbd19e50023e1ba",
+                "subject": "docs(graphite): add PR tracking layer to stack visual"
+              },
+              {
+                "sha": "440dad30748ca6fbf40c143bcca313d5870a4417",
+                "subject": "docs(graphite): define stack inspect React workstream"
+              },
+              {
+                "sha": "a62678b091afd4de275458487c914ee03c08dcb3",
+                "subject": "docs(graphite): encode stack recovery phases"
+              },
+              {
+                "sha": "b7bdd75650c31ed3cb391c9b055bd05957b7f512",
+                "subject": "docs(graphite): define effect-orpc visualizer workstream"
+              },
+              {
+                "sha": "967d0657e19278d337854b5d34aece5e745dc92c",
+                "subject": "docs(graphite): refresh stack blocker visual"
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 1,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "eaba8d5c707c3e84396bdd002583e21b9cb0d6f3",
+                "subject": "docs(foundation): add architecture pipeline packet Capture the current Foundation stage, step, op, artifact, projection, validator/test, and downstream consumer model as a source-cited pipeline-realism packet. Record structural coupling around tectonics, final-only crust evolution, projection-derived surfaces, Morphology belt synthesis, missing landform intent layers, and validation/readback gates. References: docs/projects/pipeline-realism/resources/packets/foundation-architecture-generative-pipeline/README.md"
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0,
+          "subjectTokenJaccard": 0.013774104683195593,
+          "combinedJaccard": 0.013550135501355014,
+          "sharedBranchTokens": [],
+          "sharedSubjectTokens": [
+            "downstream",
+            "layers",
+            "model",
+            "source",
+            "validation"
+          ],
+          "sharedCombinedTokens": [
+            "downstream",
+            "layers",
+            "model",
+            "source",
+            "validation"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/live-play-settlement-reference...codex/local-catalog-enrichment",
+        "scope": "root-pair",
+        "relationshipKind": "patch-overlap-diverged",
+        "left": "codex/live-play-settlement-reference",
+        "right": "codex/local-catalog-enrichment",
+        "leftRoot": "codex/live-play-settlement-reference",
+        "rightRoot": "codex/local-catalog-enrichment",
+        "leftHead": "754f90431964aaac4e266a483012b4711b2f6198",
+        "rightHead": "1689806731331dae56262cfa988fdbc0800b3e88",
+        "mergeBase": {
+          "sha": "929a282ff34033664e1fee71f4f78c977796a3dd",
+          "short": "929a282ff"
+        },
+        "aheadBehind": {
+          "leftOnly": 27,
+          "rightOnly": 34
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 10,
+            "patchEquivalent": 9,
+            "sampleNew": [
+              {
+                "sha": "db52c7aecda06bebb4eba34bee60def035d67249",
+                "subject": "test(mapgen): keep artifact guards package-owned"
+              },
+              {
+                "sha": "9011233676639569d76464166179189b1779a169",
+                "subject": "docs(morphology): integrate live readback boundary"
+              },
+              {
+                "sha": "fde990cb16ee8262722a7b8c89ad3c4414c4cf15",
+                "subject": "fix(ecology): integrate morphology peer repairs"
+              },
+              {
+                "sha": "37ae85d62746e62d31c603a52d357e51e8c82cea",
+                "subject": "feat(mapgen): integrate resource corpus expectations"
+              },
+              {
+                "sha": "b1b1b33f3c0d0911a8ab1242a948a36c7af7947e",
+                "subject": "feat(mapgen): integrate resource ops rollup"
+              },
+              {
+                "sha": "e4b5c995d6b38c06a4e9957ddc2b614cab8b03f2",
+                "subject": "fix(mapgen): integrate resource runtime proof"
+              },
+              {
+                "sha": "caab828e97c7d1ee0716dd2cfc314a4c6ff3fa2c",
+                "subject": "chore(imports): break circular dependency edges"
+              },
+              {
+                "sha": "0507ef8e9108fc58f141c241f214994f221eb4d2",
+                "subject": "fix(mapgen): stabilize integrated stack boundaries"
+              }
+            ],
+            "sampleEquivalent": [
+              {
+                "sha": "cdca71f02ac1bf24757a89f86bc3fe894080b5ce",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "017fbb24931944b4fb4b8a9a587ac94fa196bcc0",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "3433ecb1ed49e9dd6fbf8425064fa2b39adfbb6c",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "49a51198a16237c2debd6fc785824d9e27c92116",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "7eda16891440a90894aac4f860da64b4f047eeac",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "364e7f2880f133b3b47353fb24b2e9ec85424cf7",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "feba6884f8db4273e786bf094f9675afe2bff040",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              },
+              {
+                "sha": "9d40e87281cfca0355a6ea6934906be200eb874b",
+                "subject": "feat(studio): add Civ autoplay control Adds a Studio /api/civ7/autoplay endpoint backed by @civ7/direct-control startCiv7Autoplay and stopCiv7Autoplay. The endpoint rejects malformed actions and blocks autoplay changes while Save/Deploy or Run in Game operations are active. Adds a live Civ footer button that starts unbounded native autoplay when inactive and switches to Stop Auto when Civ reports autoplay active. The UI disables the control during Studio operations and records live autoplay pause/active state. Verification: bun run --cwd apps/mapgen-studio check; bun run --cwd apps/mapgen-studio test -- runInGame; live Studio footer showed Stop Auto for an already-active autoplay game; invalid autoplay action probe returned 400."
+              }
+            ]
+          },
+          "rightComparedToLeft": {
+            "patchNew": 25,
+            "patchEquivalent": 9,
+            "sampleNew": [
+              {
+                "sha": "d186ed978fff01cccc465d429ad9a05310bfd3d3",
+                "subject": "feat(studio): harden Run in Game recovery Adds phase-aware Studio Run in Game operation state, resumable request status, shell-safe direct-control health, guarded Begin evidence, Vite/dev-server hardening, and user-facing recovery diagnostics. Includes the studio-run-in-game-robustness OpenSpec/workstream artifacts and focused direct-control, Studio UI/status, and Swooper authoring-surface test updates."
+              },
+              {
+                "sha": "7c2312708447f9ad7a38245a9feb4bb7dfb3339f",
+                "subject": "test(mapgen): keep artifact guards package-owned"
+              },
+              {
+                "sha": "ff740d9bcbef882409802eff6a6d96ec7866657d",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "df1b81532c7fcb4930c07fceee1e2ff748d05840",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "1e6267722ab07485f2b1ef938cae7d84fc29d041",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "761e4e1a7e5569b9252df00b7e2412603ac8561a",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "218d602c199f3d4455ef50133e870ad8885d3f6d",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "1020ae667a1ea973aa273e91f6c0bb3eaf4643a5",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              }
+            ],
+            "sampleEquivalent": [
+              {
+                "sha": "c8a09fedb1ad508e6e284945467631dfbe601140",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "3141acd40ead97ffbdcc1bda463a344585e23036",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "2bd8060613c51faa96421d8f1629938450030b90",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "913779e988091c7ce7ec16a7998c57986864a199",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "d09439a575d67dd1ceb39ac438921dfba8e782c9",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "1dc806e926ab2a5711ea43358a2e07889833b0b8",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "c5fa90ef27207333e4dca2af4c8cc494788f0dc5",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              },
+              {
+                "sha": "49a93be73254e3be443ee35cfa16b2add7d908e3",
+                "subject": "feat(studio): add Civ autoplay control Adds a Studio /api/civ7/autoplay endpoint backed by @civ7/direct-control startCiv7Autoplay and stopCiv7Autoplay. The endpoint rejects malformed actions and blocks autoplay changes while Save/Deploy or Run in Game operations are active. Adds a live Civ footer button that starts unbounded native autoplay when inactive and switches to Stop Auto when Civ reports autoplay active. The UI disables the control during Studio operations and records live autoplay pause/active state. Verification: bun run --cwd apps/mapgen-studio check; bun run --cwd apps/mapgen-studio test -- runInGame; live Studio footer showed Stop Auto for an already-active autoplay game; invalid autoplay action probe returned 400."
+              }
+            ]
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.12585812356979406,
+          "subjectTokenJaccard": 0.18354430379746836,
+          "combinedJaccard": 0.19364599092284418,
+          "sharedBranchTokens": [
+            "api",
+            "artifact",
+            "boundary",
+            "builder",
+            "catalog",
+            "class",
+            "classification",
+            "completion",
+            "config",
+            "context",
+            "contract",
+            "control",
+            "diagnostics",
+            "dra",
+            "evidence",
+            "exact",
+            "handoff",
+            "hotseat",
+            "intake",
+            "intelligence",
+            "live",
+            "local",
+            "map",
+            "materialization",
+            "openspec",
+            "orpc",
+            "output",
+            "packet",
+            "phase",
+            "placement",
+            "plan",
+            "play"
+          ],
+          "sharedSubjectTokens": [
+            "acceptance",
+            "align",
+            "api",
+            "artifact",
+            "artifacts",
+            "authority",
+            "bind",
+            "blocked",
+            "boundary",
+            "bounded",
+            "bridge",
+            "builder",
+            "catalog",
+            "civ7",
+            "class",
+            "classify",
+            "command",
+            "completion",
+            "config",
+            "context",
+            "contract",
+            "control",
+            "controller",
+            "diagnostics",
+            "direct",
+            "directions",
+            "disposition",
+            "effect",
+            "evidence",
+            "exact",
+            "export",
+            "expose"
+          ],
+          "sharedCombinedTokens": [
+            "acceptance",
+            "align",
+            "api",
+            "architecture",
+            "artifact",
+            "artifacts",
+            "authority",
+            "bind",
+            "blocked",
+            "boundary",
+            "bounded",
+            "bridge",
+            "builder",
+            "catalog",
+            "civ7",
+            "class",
+            "classification",
+            "classify",
+            "command",
+            "completion",
+            "config",
+            "context",
+            "contract",
+            "control",
+            "controller",
+            "diagnostics",
+            "direct",
+            "directions",
+            "disposition",
+            "dra",
+            "effect",
+            "evidence",
+            "exact",
+            "export",
+            "expose",
+            "first",
+            "fixture",
+            "for",
+            "frame",
+            "game",
+            "gate",
+            "handoff",
+            "helper",
+            "hotseat",
+            "implementation",
+            "inputs",
+            "intake",
+            "intelligence"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "left-has-novel-patches",
+          "left-has-patch-equivalent-in-right",
+          "patch-overlap-diverged",
+          "right-has-novel-patches",
+          "right-has-patch-equivalent-in-left"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/live-play-settlement-reference...agent-watch-civ7-live-play-reference-assembly",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "codex/live-play-settlement-reference",
+        "right": "agent-watch-civ7-live-play-reference-assembly",
+        "leftRoot": "codex/live-play-settlement-reference",
+        "rightRoot": "agent-watch-civ7-live-play-reference-assembly",
+        "leftHead": "754f90431964aaac4e266a483012b4711b2f6198",
+        "rightHead": "9e67f53645597dfd9d7299bb5beb9509fa7569fe",
+        "mergeBase": {
+          "sha": "0507ef8e9108fc58f141c241f214994f221eb4d2",
+          "short": "0507ef8e9"
+        },
+        "aheadBehind": {
+          "leftOnly": 19,
+          "rightOnly": 19
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 11,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "cdca71f02ac1bf24757a89f86bc3fe894080b5ce",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "017fbb24931944b4fb4b8a9a587ac94fa196bcc0",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "3433ecb1ed49e9dd6fbf8425064fa2b39adfbb6c",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "49a51198a16237c2debd6fc785824d9e27c92116",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "d39ab4613f878969857aeee533c00af3c4a56263",
+                "subject": "feat(studio): harden Run in Game recovery Adds phase-aware Studio Run in Game operation state, resumable request status, shell-safe direct-control health, guarded Begin evidence, Vite/dev-server hardening, and user-facing recovery diagnostics. Includes the studio-run-in-game-robustness OpenSpec/workstream artifacts and focused direct-control, Studio UI/status, and Swooper authoring-surface test updates."
+              },
+              {
+                "sha": "7eda16891440a90894aac4f860da64b4f047eeac",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "364e7f2880f133b3b47353fb24b2e9ec85424cf7",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "feba6884f8db4273e786bf094f9675afe2bff040",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 19,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "54a01a354418e1c4115cecea758772be9bced2c6",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "86e33ada1ee886c3c2ee3c79f1a98781052a0748",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "d3c61d35a37b7b2465cbf2e473ead9073d2ffd5c",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "3e363eb0fcdf6a39bb4fbf201372a7e97e915814",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "8616c6643651e572b2a3f05781447610c554c9f3",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "b8ef45082366776f785aeb8c994df3a4c24af024",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "941d5debf94302679a60f7f0db84865e0ee2bf13",
+                "subject": "feat(cli): add live Civ play support"
+              },
+              {
+                "sha": "fd69c477767358f259e8c9a00ee561dacd67cc68",
+                "subject": "feat(cli): add live Civ tactical support"
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.03508771929824561,
+          "subjectTokenJaccard": 0.011730205278592375,
+          "combinedJaccard": 0.01675977653631285,
+          "sharedBranchTokens": [
+            "civ7",
+            "live",
+            "play",
+            "reference"
+          ],
+          "sharedSubjectTokens": [
+            "authority",
+            "civ7",
+            "live",
+            "source"
+          ],
+          "sharedCombinedTokens": [
+            "authority",
+            "civ7",
+            "live",
+            "play",
+            "reference",
+            "source"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/live-play-settlement-reference...codex/foundation-architecture-packet",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "codex/live-play-settlement-reference",
+        "right": "codex/foundation-architecture-packet",
+        "leftRoot": "codex/live-play-settlement-reference",
+        "rightRoot": "codex/foundation-architecture-packet",
+        "leftHead": "754f90431964aaac4e266a483012b4711b2f6198",
+        "rightHead": "eaba8d5c707c3e84396bdd002583e21b9cb0d6f3",
+        "mergeBase": {
+          "sha": "98dca389248d5ddb2777a88105c3ade452b2137c",
+          "short": "98dca3892"
+        },
+        "aheadBehind": {
+          "leftOnly": 1,
+          "rightOnly": 1
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 1,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "754f90431964aaac4e266a483012b4711b2f6198",
+                "subject": "docs(graphite): prepare live-play settlement reference"
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 1,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "eaba8d5c707c3e84396bdd002583e21b9cb0d6f3",
+                "subject": "docs(foundation): add architecture pipeline packet Capture the current Foundation stage, step, op, artifact, projection, validator/test, and downstream consumer model as a source-cited pipeline-realism packet. Record structural coupling around tectonics, final-only crust evolution, projection-derived surfaces, Morphology belt synthesis, missing landform intent layers, and validation/readback gates. References: docs/projects/pipeline-realism/resources/packets/foundation-architecture-generative-pipeline/README.md"
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.017543859649122806,
+          "subjectTokenJaccard": 0.024324324324324326,
+          "combinedJaccard": 0.028645833333333332,
+          "sharedBranchTokens": [
+            "architecture",
+            "packet"
+          ],
+          "sharedSubjectTokens": [
+            "artifact",
+            "final",
+            "gates",
+            "missing",
+            "morphology",
+            "pipeline",
+            "readback",
+            "source",
+            "validation"
+          ],
+          "sharedCombinedTokens": [
+            "architecture",
+            "artifact",
+            "final",
+            "gates",
+            "missing",
+            "morphology",
+            "packet",
+            "pipeline",
+            "readback",
+            "source",
+            "validation"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/local-catalog-enrichment...agent-watch-civ7-live-play-reference-assembly",
+        "scope": "root-pair",
+        "relationshipKind": "patch-overlap-diverged",
+        "left": "codex/local-catalog-enrichment",
+        "right": "agent-watch-civ7-live-play-reference-assembly",
+        "leftRoot": "codex/local-catalog-enrichment",
+        "rightRoot": "agent-watch-civ7-live-play-reference-assembly",
+        "leftHead": "1689806731331dae56262cfa988fdbc0800b3e88",
+        "rightHead": "9e67f53645597dfd9d7299bb5beb9509fa7569fe",
+        "mergeBase": {
+          "sha": "929a282ff34033664e1fee71f4f78c977796a3dd",
+          "short": "929a282ff"
+        },
+        "aheadBehind": {
+          "leftOnly": 34,
+          "rightOnly": 27
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 16,
+            "patchEquivalent": 18,
+            "sampleNew": [
+              {
+                "sha": "c8a09fedb1ad508e6e284945467631dfbe601140",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "3141acd40ead97ffbdcc1bda463a344585e23036",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "2bd8060613c51faa96421d8f1629938450030b90",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "913779e988091c7ce7ec16a7998c57986864a199",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "d186ed978fff01cccc465d429ad9a05310bfd3d3",
+                "subject": "feat(studio): harden Run in Game recovery Adds phase-aware Studio Run in Game operation state, resumable request status, shell-safe direct-control health, guarded Begin evidence, Vite/dev-server hardening, and user-facing recovery diagnostics. Includes the studio-run-in-game-robustness OpenSpec/workstream artifacts and focused direct-control, Studio UI/status, and Swooper authoring-surface test updates."
+              },
+              {
+                "sha": "d09439a575d67dd1ceb39ac438921dfba8e782c9",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "1dc806e926ab2a5711ea43358a2e07889833b0b8",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "c5fa90ef27207333e4dca2af4c8cc494788f0dc5",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              }
+            ],
+            "sampleEquivalent": [
+              {
+                "sha": "ff740d9bcbef882409802eff6a6d96ec7866657d",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "df1b81532c7fcb4930c07fceee1e2ff748d05840",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "1e6267722ab07485f2b1ef938cae7d84fc29d041",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "761e4e1a7e5569b9252df00b7e2412603ac8561a",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "218d602c199f3d4455ef50133e870ad8885d3f6d",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "1020ae667a1ea973aa273e91f6c0bb3eaf4643a5",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "8bfd5f66c3bd1afa8ea8e082f6d8fdd88b5b2fdb",
+                "subject": "feat(cli): add live Civ tactical support"
+              },
+              {
+                "sha": "08eb8d9b4c708a326ebd0fcff5c9d7a610ca8c97",
+                "subject": "feat(cli): add notification decision HUD Expand the live play notification materialized view with decision HUD data: ordered blocker queue, required inputs, common safe actions, and CLI rendering. Document the blocker-family frame and narrative CLOSE fallback for later skill promotion."
+              }
+            ]
+          },
+          "rightComparedToLeft": {
+            "patchNew": 9,
+            "patchEquivalent": 18,
+            "sampleNew": [
+              {
+                "sha": "db52c7aecda06bebb4eba34bee60def035d67249",
+                "subject": "test(mapgen): keep artifact guards package-owned"
+              },
+              {
+                "sha": "9011233676639569d76464166179189b1779a169",
+                "subject": "docs(morphology): integrate live readback boundary"
+              },
+              {
+                "sha": "fde990cb16ee8262722a7b8c89ad3c4414c4cf15",
+                "subject": "fix(ecology): integrate morphology peer repairs"
+              },
+              {
+                "sha": "37ae85d62746e62d31c603a52d357e51e8c82cea",
+                "subject": "feat(mapgen): integrate resource corpus expectations"
+              },
+              {
+                "sha": "b1b1b33f3c0d0911a8ab1242a948a36c7af7947e",
+                "subject": "feat(mapgen): integrate resource ops rollup"
+              },
+              {
+                "sha": "e4b5c995d6b38c06a4e9957ddc2b614cab8b03f2",
+                "subject": "fix(mapgen): integrate resource runtime proof"
+              },
+              {
+                "sha": "caab828e97c7d1ee0716dd2cfc314a4c6ff3fa2c",
+                "subject": "chore(imports): break circular dependency edges"
+              },
+              {
+                "sha": "0507ef8e9108fc58f141c241f214994f221eb4d2",
+                "subject": "fix(mapgen): stabilize integrated stack boundaries"
+              }
+            ],
+            "sampleEquivalent": [
+              {
+                "sha": "54a01a354418e1c4115cecea758772be9bced2c6",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "86e33ada1ee886c3c2ee3c79f1a98781052a0748",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "d3c61d35a37b7b2465cbf2e473ead9073d2ffd5c",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "3e363eb0fcdf6a39bb4fbf201372a7e97e915814",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "8616c6643651e572b2a3f05781447610c554c9f3",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "b8ef45082366776f785aeb8c994df3a4c24af024",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "fd69c477767358f259e8c9a00ee561dacd67cc68",
+                "subject": "feat(cli): add live Civ tactical support"
+              },
+              {
+                "sha": "5434eb63c6c98cff7d2f93fd92b6a296bc326566",
+                "subject": "feat(cli): add notification decision HUD Expand the live play notification materialized view with decision HUD data: ordered blocker queue, required inputs, common safe actions, and CLI rendering. Document the blocker-family frame and narrative CLOSE fallback for later skill promotion."
+              }
+            ]
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.007874015748031496,
+          "subjectTokenJaccard": 0.012195121951219513,
+          "combinedJaccard": 0.01839080459770115,
+          "sharedBranchTokens": [
+            "live",
+            "play",
+            "reference"
+          ],
+          "sharedSubjectTokens": [
+            "authority",
+            "civ7",
+            "clarify",
+            "hud",
+            "source"
+          ],
+          "sharedCombinedTokens": [
+            "authority",
+            "civ7",
+            "clarify",
+            "hud",
+            "live",
+            "play",
+            "reference",
+            "source"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "left-has-novel-patches",
+          "left-has-patch-equivalent-in-right",
+          "patch-overlap-diverged",
+          "right-has-novel-patches",
+          "right-has-patch-equivalent-in-left"
+        ]
+      },
+      {
+        "pairId": "root-pair:codex/local-catalog-enrichment...codex/foundation-architecture-packet",
+        "scope": "root-pair",
+        "relationshipKind": "patch-overlap-diverged",
+        "left": "codex/local-catalog-enrichment",
+        "right": "codex/foundation-architecture-packet",
+        "leftRoot": "codex/local-catalog-enrichment",
+        "rightRoot": "codex/foundation-architecture-packet",
+        "leftHead": "1689806731331dae56262cfa988fdbc0800b3e88",
+        "rightHead": "eaba8d5c707c3e84396bdd002583e21b9cb0d6f3",
+        "mergeBase": {
+          "sha": "929a282ff34033664e1fee71f4f78c977796a3dd",
+          "short": "929a282ff"
+        },
+        "aheadBehind": {
+          "leftOnly": 34,
+          "rightOnly": 27
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 25,
+            "patchEquivalent": 9,
+            "sampleNew": [
+              {
+                "sha": "d186ed978fff01cccc465d429ad9a05310bfd3d3",
+                "subject": "feat(studio): harden Run in Game recovery Adds phase-aware Studio Run in Game operation state, resumable request status, shell-safe direct-control health, guarded Begin evidence, Vite/dev-server hardening, and user-facing recovery diagnostics. Includes the studio-run-in-game-robustness OpenSpec/workstream artifacts and focused direct-control, Studio UI/status, and Swooper authoring-surface test updates."
+              },
+              {
+                "sha": "7c2312708447f9ad7a38245a9feb4bb7dfb3339f",
+                "subject": "test(mapgen): keep artifact guards package-owned"
+              },
+              {
+                "sha": "ff740d9bcbef882409802eff6a6d96ec7866657d",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "df1b81532c7fcb4930c07fceee1e2ff748d05840",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "1e6267722ab07485f2b1ef938cae7d84fc29d041",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "761e4e1a7e5569b9252df00b7e2412603ac8561a",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "218d602c199f3d4455ef50133e870ad8885d3f6d",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "1020ae667a1ea973aa273e91f6c0bb3eaf4643a5",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              }
+            ],
+            "sampleEquivalent": [
+              {
+                "sha": "c8a09fedb1ad508e6e284945467631dfbe601140",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "3141acd40ead97ffbdcc1bda463a344585e23036",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "2bd8060613c51faa96421d8f1629938450030b90",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "913779e988091c7ce7ec16a7998c57986864a199",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "d09439a575d67dd1ceb39ac438921dfba8e782c9",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "1dc806e926ab2a5711ea43358a2e07889833b0b8",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "c5fa90ef27207333e4dca2af4c8cc494788f0dc5",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              },
+              {
+                "sha": "49a93be73254e3be443ee35cfa16b2add7d908e3",
+                "subject": "feat(studio): add Civ autoplay control Adds a Studio /api/civ7/autoplay endpoint backed by @civ7/direct-control startCiv7Autoplay and stopCiv7Autoplay. The endpoint rejects malformed actions and blocks autoplay changes while Save/Deploy or Run in Game operations are active. Adds a live Civ footer button that starts unbounded native autoplay when inactive and switches to Stop Auto when Civ reports autoplay active. The UI disables the control during Studio operations and records live autoplay pause/active state. Verification: bun run --cwd apps/mapgen-studio check; bun run --cwd apps/mapgen-studio test -- runInGame; live Studio footer showed Stop Auto for an already-active autoplay game; invalid autoplay action probe returned 400."
+              }
+            ]
+          },
+          "rightComparedToLeft": {
+            "patchNew": 10,
+            "patchEquivalent": 9,
+            "sampleNew": [
+              {
+                "sha": "db52c7aecda06bebb4eba34bee60def035d67249",
+                "subject": "test(mapgen): keep artifact guards package-owned"
+              },
+              {
+                "sha": "9011233676639569d76464166179189b1779a169",
+                "subject": "docs(morphology): integrate live readback boundary"
+              },
+              {
+                "sha": "fde990cb16ee8262722a7b8c89ad3c4414c4cf15",
+                "subject": "fix(ecology): integrate morphology peer repairs"
+              },
+              {
+                "sha": "37ae85d62746e62d31c603a52d357e51e8c82cea",
+                "subject": "feat(mapgen): integrate resource corpus expectations"
+              },
+              {
+                "sha": "b1b1b33f3c0d0911a8ab1242a948a36c7af7947e",
+                "subject": "feat(mapgen): integrate resource ops rollup"
+              },
+              {
+                "sha": "e4b5c995d6b38c06a4e9957ddc2b614cab8b03f2",
+                "subject": "fix(mapgen): integrate resource runtime proof"
+              },
+              {
+                "sha": "caab828e97c7d1ee0716dd2cfc314a4c6ff3fa2c",
+                "subject": "chore(imports): break circular dependency edges"
+              },
+              {
+                "sha": "0507ef8e9108fc58f141c241f214994f221eb4d2",
+                "subject": "fix(mapgen): stabilize integrated stack boundaries"
+              }
+            ],
+            "sampleEquivalent": [
+              {
+                "sha": "cdca71f02ac1bf24757a89f86bc3fe894080b5ce",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "017fbb24931944b4fb4b8a9a587ac94fa196bcc0",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "3433ecb1ed49e9dd6fbf8425064fa2b39adfbb6c",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "49a51198a16237c2debd6fc785824d9e27c92116",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "7eda16891440a90894aac4f860da64b4f047eeac",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "364e7f2880f133b3b47353fb24b2e9ec85424cf7",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "feba6884f8db4273e786bf094f9675afe2bff040",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              },
+              {
+                "sha": "9d40e87281cfca0355a6ea6934906be200eb874b",
+                "subject": "feat(studio): add Civ autoplay control Adds a Studio /api/civ7/autoplay endpoint backed by @civ7/direct-control startCiv7Autoplay and stopCiv7Autoplay. The endpoint rejects malformed actions and blocks autoplay changes while Save/Deploy or Run in Game operations are active. Adds a live Civ footer button that starts unbounded native autoplay when inactive and switches to Stop Auto when Civ reports autoplay active. The UI disables the control during Studio operations and records live autoplay pause/active state. Verification: bun run --cwd apps/mapgen-studio check; bun run --cwd apps/mapgen-studio test -- runInGame; live Studio footer showed Stop Auto for an already-active autoplay game; invalid autoplay action probe returned 400."
+              }
+            ]
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0.0026246719160104987,
+          "subjectTokenJaccard": 0.01583710407239819,
+          "combinedJaccard": 0.017167381974248927,
+          "sharedBranchTokens": [
+            "packet"
+          ],
+          "sharedSubjectTokens": [
+            "architecture",
+            "artifact",
+            "downstream",
+            "projection",
+            "references",
+            "source",
+            "validation"
+          ],
+          "sharedCombinedTokens": [
+            "architecture",
+            "artifact",
+            "downstream",
+            "packet",
+            "projection",
+            "references",
+            "source",
+            "validation"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "left-has-novel-patches",
+          "left-has-patch-equivalent-in-right",
+          "patch-overlap-diverged",
+          "right-has-novel-patches",
+          "right-has-patch-equivalent-in-left"
+        ]
+      },
+      {
+        "pairId": "root-pair:agent-watch-civ7-live-play-reference-assembly...codex/foundation-architecture-packet",
+        "scope": "root-pair",
+        "relationshipKind": "diverged",
+        "left": "agent-watch-civ7-live-play-reference-assembly",
+        "right": "codex/foundation-architecture-packet",
+        "leftRoot": "agent-watch-civ7-live-play-reference-assembly",
+        "rightRoot": "codex/foundation-architecture-packet",
+        "leftHead": "9e67f53645597dfd9d7299bb5beb9509fa7569fe",
+        "rightHead": "eaba8d5c707c3e84396bdd002583e21b9cb0d6f3",
+        "mergeBase": {
+          "sha": "0507ef8e9108fc58f141c241f214994f221eb4d2",
+          "short": "0507ef8e9"
+        },
+        "aheadBehind": {
+          "leftOnly": 19,
+          "rightOnly": 19
+        },
+        "ancestry": {
+          "leftIsAncestorOfRight": false,
+          "rightIsAncestorOfLeft": false
+        },
+        "cherry": {
+          "leftComparedToRight": {
+            "patchNew": 19,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "54a01a354418e1c4115cecea758772be9bced2c6",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "86e33ada1ee886c3c2ee3c79f1a98781052a0748",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "d3c61d35a37b7b2465cbf2e473ead9073d2ffd5c",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "3e363eb0fcdf6a39bb4fbf201372a7e97e915814",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "8616c6643651e572b2a3f05781447610c554c9f3",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "b8ef45082366776f785aeb8c994df3a4c24af024",
+                "subject": "feat(cli): add live Civ play shortcuts"
+              },
+              {
+                "sha": "941d5debf94302679a60f7f0db84865e0ee2bf13",
+                "subject": "feat(cli): add live Civ play support"
+              },
+              {
+                "sha": "fd69c477767358f259e8c9a00ee561dacd67cc68",
+                "subject": "feat(cli): add live Civ tactical support"
+              }
+            ],
+            "sampleEquivalent": []
+          },
+          "rightComparedToLeft": {
+            "patchNew": 11,
+            "patchEquivalent": 0,
+            "sampleNew": [
+              {
+                "sha": "cdca71f02ac1bf24757a89f86bc3fe894080b5ce",
+                "subject": "docs: refresh integration gate record Capture the refreshed Gate 1-8 operating record for graphite-stack-integration, including current worktree dirty state, conflict model, proposed branch order, validation lanes, stop conditions, and framed sub-agent objective rule."
+              },
+              {
+                "sha": "017fbb24931944b4fb4b8a9a587ac94fa196bcc0",
+                "subject": "docs: record Studio Run in Game recovery UX"
+              },
+              {
+                "sha": "3433ecb1ed49e9dd6fbf8425064fa2b39adfbb6c",
+                "subject": "docs: report Studio Vite robustness findings"
+              },
+              {
+                "sha": "49a51198a16237c2debd6fc785824d9e27c92116",
+                "subject": "docs(civ7): add Studio verification gap matrix"
+              },
+              {
+                "sha": "d39ab4613f878969857aeee533c00af3c4a56263",
+                "subject": "feat(studio): harden Run in Game recovery Adds phase-aware Studio Run in Game operation state, resumable request status, shell-safe direct-control health, guarded Begin evidence, Vite/dev-server hardening, and user-facing recovery diagnostics. Includes the studio-run-in-game-robustness OpenSpec/workstream artifacts and focused direct-control, Studio UI/status, and Swooper authoring-surface test updates."
+              },
+              {
+                "sha": "7eda16891440a90894aac4f860da64b4f047eeac",
+                "subject": "chore(mapgen): preserve Studio earthlike config state Commits the current Swooper Earthlike config edits separately from the Studio Run in Game robustness work so follow-up reliability changes can stay scoped."
+              },
+              {
+                "sha": "364e7f2880f133b3b47353fb24b2e9ec85424cf7",
+                "subject": "feat(studio): complete Run in Game operation state"
+              },
+              {
+                "sha": "feba6884f8db4273e786bf094f9675afe2bff040",
+                "subject": "feat(studio): harden save and run state machine Adds the studio-save-run-state-machine OpenSpec/workstream slice, server-owned Save/Deploy operation status, API conflict guards between Save/Deploy and Run in Game, and shared dependency-aware Studio deploy commands. Save/Deploy no longer requests Civ lifecycle changes; Run in Game owns Civ restart/recovery. Studio disables conflicting Browser Run, reroll, auto-run, Save/Deploy, and Run in Game controls while operations are active, and durable Run in Game materialization now considers saved/deployed config provenance. Verification: bun run verify:studio-run-in-game; focused mapConfigSave/runInGame tests; browser Run proof on localhost:5173; live save-route restart rejection/status probes."
+              }
+            ],
+            "sampleEquivalent": []
+          }
+        },
+        "semanticOverlap": {
+          "branchTokenJaccard": 0,
+          "subjectTokenJaccard": 0.022222222222222223,
+          "combinedJaccard": 0.020833333333333332,
+          "sharedBranchTokens": [],
+          "sharedSubjectTokens": [
+            "source"
+          ],
+          "sharedCombinedTokens": [
+            "source"
+          ]
+        },
+        "signals": [
+          "cross-root",
+          "diverged",
+          "left-has-novel-patches",
+          "right-has-novel-patches"
+        ]
+      }
+    ]
+  },
+  "metadataWarnings": [],
   "staleAnchorWarnings": [
     {
       "moveId": "done-adopt-studio-live-runtime-snapshot-completion",
@@ -23500,6 +26996,7 @@
         "codex/earthlike-natural-wonder-live-telemetry",
         "codex/earthlike-natural-wonder-coordinate-proof",
         "codex/earthlike-natural-wonder-source-classification",
+        "codex/workspace-source-package-resolution",
         "codex/earthlike-natural-wonder-materialization-repair",
         "codex/earthlike-natural-wonder-repair-proof-record",
         "codex/earthlike-feature-post-wonder-repair-context",
@@ -23528,7 +27025,7 @@
         "codex/swooper-wonder-footprint-proof-drain",
         "codex/swooper-wonder-footprint-proof-record-drain"
       ],
-      "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+      "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
     },
     {
       "moveId": "planned-adopt-earthlike-floodplain-config-leaf",

--- a/openspec/changes/swooper-stack-recovery-consolidation/workstream/branch-accounting-composition.json
+++ b/openspec/changes/swooper-stack-recovery-consolidation/workstream/branch-accounting-composition.json
@@ -1,0 +1,23620 @@
+{
+  "fixtureId": "graphite-accounting-composition-2026-06-07T20:35:47.939Z",
+  "schemaVersion": "graphite-accounting-composition.v1",
+  "generatedAt": "2026-06-07T20:35:47.939Z",
+  "inputs": {
+    "repoRoot": "/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools",
+    "graphiteCachePath": "/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools/.git/.graphite_cache_persist",
+    "ledgerPath": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-ledger.json",
+    "gtLsPath": "/tmp/civ7-current-gt-ls.txt",
+    "gtLsStatusPath": "/tmp/civ7-current-gt-ls.status.json"
+  },
+  "graphite": {
+    "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+    "rootCount": 7,
+    "branchCount": 861
+  },
+  "gtLsStatus": {
+    "refreshedAt": "2026-06-07T20:35:45.366Z",
+    "lineCount": 862,
+    "repoRoot": "/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools",
+    "outputPath": "/tmp/civ7-current-gt-ls.txt",
+    "command": "/opt/homebrew/bin/gt ls --no-interactive"
+  },
+  "ledger": {
+    "fixtureId": "swooper-recovery-accounting-2026-06-07",
+    "capturedAt": "2026-06-07T15:03:52-04:00",
+    "schemaVersion": "gt-stack-inspect.accounting-ledger.v1",
+    "moveCount": 18
+  },
+  "roots": [
+    {
+      "root": "codex/systematic-workstream-skill-framing",
+      "decision": "drain-to-main",
+      "graphiteState": "clean-local",
+      "accountingState": "planned-main-adoption-source",
+      "branchCount": 3,
+      "localOnly": 3,
+      "needsRestack": 0,
+      "occupied": 0,
+      "dirtyWorktrees": 0,
+      "accounting": {
+        "needs-accounting": 3
+      },
+      "leaves": [
+        "codex/systematic-skill-review-fixes"
+      ]
+    },
+    {
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "decision": "finish-planned-adoption",
+      "graphiteState": "clean-local",
+      "accountingState": "planned-sink",
+      "branchCount": 79,
+      "localOnly": 79,
+      "needsRestack": 0,
+      "occupied": 1,
+      "dirtyWorktrees": 0,
+      "accounting": {
+        "planned-sink": 1,
+        "accounting-sink": 36,
+        "unmarked": 42
+      },
+      "leaves": [
+        "codex/swooper-natural-wonder-plan-input-comparison-drain"
+      ]
+    },
+    {
+      "root": "codex/stack-lineage-audit-reference",
+      "decision": "clear-dirty-worktree",
+      "graphiteState": "dirty-worktree",
+      "accountingState": "accounted-source",
+      "branchCount": 19,
+      "localOnly": 19,
+      "needsRestack": 0,
+      "occupied": 1,
+      "dirtyWorktrees": 1,
+      "accounting": {
+        "excluded": 13,
+        "unmarked": 6
+      },
+      "leaves": [
+        "codex/gt-stack-inspect-react-parity-interactions"
+      ]
+    },
+    {
+      "root": "codex/live-play-settlement-reference",
+      "decision": "adopt-into-sink",
+      "graphiteState": "clean-local",
+      "accountingState": "planned-local-adoption-source",
+      "branchCount": 67,
+      "localOnly": 67,
+      "needsRestack": 0,
+      "occupied": 2,
+      "dirtyWorktrees": 0,
+      "accounting": {
+        "excluded": 7,
+        "unmarked": 3,
+        "accounted-source": 56,
+        "needs-accounting": 1
+      },
+      "leaves": [
+        "codex/earthlike-natural-wonder-postwrite-footprint-proof-record",
+        "codex/earthlike-terrain-edge-mock-terrain-materialization-repair",
+        "codex/play-agent-hotseat-phase-packet"
+      ]
+    },
+    {
+      "root": "codex/local-catalog-enrichment",
+      "decision": "restack-before-drain",
+      "graphiteState": "needs-restack",
+      "accountingState": "unmarked",
+      "branchCount": 691,
+      "localOnly": 691,
+      "needsRestack": 1,
+      "occupied": 1,
+      "dirtyWorktrees": 0,
+      "accounting": {
+        "unmarked": 691
+      },
+      "leaves": [
+        "codex/watcher-supervisor-handoff-doc",
+        "codex/require-controller-mutation-proof",
+        "codex/add-orpc-map-grid-procedure"
+      ]
+    },
+    {
+      "root": "agent-watch-civ7-live-play-reference-assembly",
+      "decision": "restack-before-drain",
+      "graphiteState": "needs-restack",
+      "accountingState": "unmarked",
+      "branchCount": 1,
+      "localOnly": 1,
+      "needsRestack": 1,
+      "occupied": 0,
+      "dirtyWorktrees": 0,
+      "accounting": {
+        "unmarked": 1
+      },
+      "leaves": [
+        "agent-watch-civ7-live-play-reference-assembly"
+      ]
+    },
+    {
+      "root": "codex/foundation-architecture-packet",
+      "decision": "submit-or-merge-clean-stack",
+      "graphiteState": "clean-local",
+      "accountingState": "accounted-source",
+      "branchCount": 1,
+      "localOnly": 1,
+      "needsRestack": 0,
+      "occupied": 0,
+      "dirtyWorktrees": 0,
+      "accounting": {
+        "accounted-source": 1
+      },
+      "leaves": [
+        "codex/foundation-architecture-packet"
+      ]
+    }
+  ],
+  "branches": [
+    {
+      "branch": "codex/systematic-workstream-skill-framing",
+      "root": "codex/systematic-workstream-skill-framing",
+      "parent": "main",
+      "children": [
+        "codex/systematic-evidence-workstream-skill"
+      ],
+      "depth": 0,
+      "head": "70604ec945cefae8415972dacb1732ef0f165425",
+      "parentRecordedHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+      "parentCurrentHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "70604ec94",
+        "sha": "70604ec945cefae8415972dacb1732ef0f165425",
+        "iso": "2026-06-07T15:00:50-04:00",
+        "subject": "docs(skills): capture systematic workstream skill objective"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "planned-adopt-systematic-workstream-skill-support-slice",
+          "state": "planned",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "main",
+          "label": "needs-adoption",
+          "cleanup": "pending",
+          "note": "The repo-local systematic workstream skill is not in main or in the Swooper recovery stack. It is useful support tooling and needs a dedicated support adoption slice; it is not part of the Swooper product recovery drain."
+        }
+      ],
+      "accountingSummary": "needs-accounting"
+    },
+    {
+      "branch": "codex/systematic-evidence-workstream-skill",
+      "root": "codex/systematic-workstream-skill-framing",
+      "parent": "codex/systematic-workstream-skill-framing",
+      "children": [
+        "codex/systematic-skill-review-fixes"
+      ],
+      "depth": 1,
+      "head": "7775b77cdedad1aa7141846f01cdc5fb20ef0a59",
+      "parentRecordedHead": "70604ec945cefae8415972dacb1732ef0f165425",
+      "parentCurrentHead": "70604ec945cefae8415972dacb1732ef0f165425",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7775b77cd",
+        "sha": "7775b77cdedad1aa7141846f01cdc5fb20ef0a59",
+        "iso": "2026-06-07T15:00:50-04:00",
+        "subject": "docs(skills): add systematic workstream skill"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "planned-adopt-systematic-workstream-skill-support-slice",
+          "state": "planned",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "main",
+          "label": "needs-adoption",
+          "cleanup": "pending",
+          "note": "The repo-local systematic workstream skill is not in main or in the Swooper recovery stack. It is useful support tooling and needs a dedicated support adoption slice; it is not part of the Swooper product recovery drain."
+        }
+      ],
+      "accountingSummary": "needs-accounting"
+    },
+    {
+      "branch": "codex/systematic-skill-review-fixes",
+      "root": "codex/systematic-workstream-skill-framing",
+      "parent": "codex/systematic-evidence-workstream-skill",
+      "children": [],
+      "depth": 2,
+      "head": "9db0631579f0c8b4fa538add828e7f47e4b659e7",
+      "parentRecordedHead": "7775b77cdedad1aa7141846f01cdc5fb20ef0a59",
+      "parentCurrentHead": "7775b77cdedad1aa7141846f01cdc5fb20ef0a59",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9db063157",
+        "sha": "9db0631579f0c8b4fa538add828e7f47e4b659e7",
+        "iso": "2026-06-07T15:00:50-04:00",
+        "subject": "docs(skills): apply review fixes to civ7-systematic-workstream skill"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "planned-adopt-systematic-workstream-skill-support-slice",
+          "state": "planned",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "main",
+          "label": "needs-adoption",
+          "cleanup": "pending",
+          "note": "The repo-local systematic workstream skill is not in main or in the Swooper recovery stack. It is useful support tooling and needs a dedicated support adoption slice; it is not part of the Swooper product recovery drain."
+        }
+      ],
+      "accountingSummary": "needs-accounting"
+    },
+    {
+      "branch": "codex/swooper-mapgen-recovery-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "main",
+      "children": [
+        "codex/swooper-studio-parity-proof-drain"
+      ],
+      "depth": 0,
+      "head": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+      "parentRecordedHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+      "parentCurrentHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d77f7e3d0",
+        "sha": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "iso": "2026-06-07T02:03:31-04:00",
+        "subject": "fix(mapgen): stabilize Swooper recovery drain Repair selective-replay gaps in the clean main-based Swooper recovery drain: restore direct-control dist/DTS packaging, re-add ctxStepSeed at the MapGen core boundary, compose map and engine river effect tags, restore ecology score-layer morphology artifact dependencies, strip stale non-Earthlike config keys, and regenerate downstream map/config fixtures from the accepted shipped configs. Validation: bun test packages/civ7-map-policy/test/map-policy.test.ts mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts; bunx turbo run check --filter=@civ7/map-policy --filter=mod-swooper-maps --filter=mapgen-studio; git diff --check."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-supersede-pr1421-swooper-earthlike",
+          "state": "done",
+          "kind": "supersede",
+          "method": "semantic",
+          "sourceKind": "pr",
+          "sinkKind": "branch",
+          "label": "supersession-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Published Swooper Earthlike PR #1421 is superseded locally by the recovery stack's semantic synthesis. Keep it as fallback/reference until the recovery stack lands; do not merge it as-is."
+        },
+        {
+          "role": "sink",
+          "moveId": "done-adopt-start-placement-and-initial-resource-policy",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Start expansion viability and initial age-gated resource policy were replayed into the recovery base."
+        },
+        {
+          "role": "sink",
+          "moveId": "done-adopt-studio-setup-config-sync",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Studio setup/config loading, setup seed validation, save/deploy/run-in-game sync, and adjacent Swooper recovery behavior were synthesized into the recovery base."
+        },
+        {
+          "role": "sink",
+          "moveId": "done-reference-swooper-recovery-planning-context",
+          "state": "done",
+          "kind": "reference",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "accounting-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The recovery handoff and OpenSpec planning branches were consumed as planning/reference input for the Swooper recovery stack. They are not pending product branches."
+        },
+        {
+          "role": "sink",
+          "moveId": "planned-adopt-earthlike-floodplain-config-leaf",
+          "state": "planned",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "branch",
+          "sinkKind": "branch",
+          "label": "planned-adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Latest Earthlike floodplainPlanning config/hash leaf is not present in the recovery stack. Adopt this config leaf before claiming the Earthlike source config is fully covered."
+        }
+      ],
+      "accountingSummary": "planned-sink"
+    },
+    {
+      "branch": "codex/swooper-studio-parity-proof-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-mapgen-recovery-drain",
+      "children": [
+        "codex/swooper-feature-resource-legality-drain"
+      ],
+      "depth": 1,
+      "head": "eeccd5a9eb52bd30e7545e3324fe359d21ded7a4",
+      "parentRecordedHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+      "parentCurrentHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "eeccd5a9e",
+        "sha": "eeccd5a9eb52bd30e7545e3324fe359d21ded7a4",
+        "iso": "2026-06-07T02:24:25-04:00",
+        "subject": "feat(studio): integrate exact parity proof drain Replay and synthesize the Studio live-runtime, exact-authorship, and final-surface parity proof lane above the Swooper recovery drain. Keep accepted runtime/proof behavior, add the adapter map-size metadata prerequisite needed by parity diagnostics, route unresolved terrain/feature/resource deltas to downstream repair workstreams, and remove stale handoff/control records from the integrated OpenSpec state. Validation: bun run --cwd apps/mapgen-studio check; bun run --cwd packages/civ7-direct-control check; bun run --cwd packages/civ7-adapter check; bun run --cwd mods/mod-swooper-maps check; bun run --cwd apps/mapgen-studio test -- liveRuntime runInGame/proofIdentity runInGame/AppFooter; bun run --cwd packages/civ7-direct-control test -- direct-control; bun run --cwd mods/mod-swooper-maps test -- test/diagnostics/live-parity.test.ts; bun test scripts/civ7-direct-control/verify-final-surface-parity.test.ts; bunx turbo run check --filter=@civ7/adapter --filter=@civ7/direct-control --filter=mapgen-studio --filter=mod-swooper-maps; bun run openspec:validate; git diff --check; git diff --cached --check."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-studio-exact-authorship-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "branch",
+          "sinkKind": "branch",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Studio exact-authorship parsing/proof behavior is represented in the Swooper Studio parity proof drain."
+        },
+        {
+          "role": "sink",
+          "moveId": "done-adopt-map-policy-final-surface-parity",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "branch",
+          "sinkKind": "branch",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Final-surface parity proof path and routing records are represented in the Swooper Studio parity proof drain and later current parity record branches."
+        },
+        {
+          "role": "sink",
+          "moveId": "done-adopt-studio-live-runtime-snapshot-completion",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "branch",
+          "sinkKind": "branch",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Live runtime snapshot completion is represented in the Studio parity proof drain and follow-up current exact-authorship proof branches."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-feature-resource-legality-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-studio-parity-proof-drain",
+      "children": [
+        "codex/swooper-resource-assignment-evidence-drain"
+      ],
+      "depth": 2,
+      "head": "f51bdbf8d02c0b41b8b75248b0396f8badf75d04",
+      "parentRecordedHead": "eeccd5a9eb52bd30e7545e3324fe359d21ded7a4",
+      "parentCurrentHead": "eeccd5a9eb52bd30e7545e3324fe359d21ded7a4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f51bdbf8d",
+        "sha": "f51bdbf8d02c0b41b8b75248b0396f8badf75d04",
+        "iso": "2026-06-07T02:39:07-04:00",
+        "subject": "fix(civ7): align adjacent-land resource legality Integrate the feature/resource legality repair lane above the Swooper Studio parity drain. Add static surface delta diagnostics, classify the live-only adjacent-land resource class to the repo-owned map-policy/adapter surface, wire @civ7/adapter to @civ7/map-policy, and preserve remaining feature/resource mismatch classes as pending source-authority work instead of tuning them blindly. Validation: bun test packages/civ7-map-policy/test/map-policy.test.ts; bun test packages/civ7-adapter/test/placement-outcomes.test.ts; bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts; bun run --cwd packages/civ7-map-policy check; bun run --cwd packages/civ7-adapter check; bun run --cwd mods/mod-swooper-maps check; bunx turbo run build --filter=@civ7/adapter --filter=@civ7/map-policy; bunx turbo run check --filter=@civ7/adapter --filter=@civ7/map-policy --filter=mod-swooper-maps; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-assignment-evidence-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-feature-resource-legality-drain",
+      "children": [
+        "codex/swooper-resource-feasibility-readback-drain"
+      ],
+      "depth": 3,
+      "head": "4c803c521038a5b6640e53db5ecc8538cc5e732c",
+      "parentRecordedHead": "f51bdbf8d02c0b41b8b75248b0396f8badf75d04",
+      "parentCurrentHead": "f51bdbf8d02c0b41b8b75248b0396f8badf75d04",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4c803c521",
+        "sha": "4c803c521038a5b6640e53db5ecc8538cc5e732c",
+        "iso": "2026-06-07T02:43:02-04:00",
+        "subject": "test(mapgen): expose resource assignment evidence Integrate the adjacent-land rerun record and resource assignment evidence above the Swooper feature/resource legality drain. Carry local resource plan and typed placement outcomes into final-surface parity diagnostics, classify the remaining resource mismatch shape as assignment/order/feasibility evidence work, and keep parity/product acceptance unresolved. Validation: bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-feasibility-readback-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-assignment-evidence-drain",
+      "children": [
+        "codex/swooper-resource-feasibility-classification-drain"
+      ],
+      "depth": 4,
+      "head": "15bdcf054c4ed680b5f3624dff25250f20760732",
+      "parentRecordedHead": "4c803c521038a5b6640e53db5ecc8538cc5e732c",
+      "parentCurrentHead": "4c803c521038a5b6640e53db5ecc8538cc5e732c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "15bdcf054",
+        "sha": "15bdcf054c4ed680b5f3624dff25250f20760732",
+        "iso": "2026-06-07T02:45:32-04:00",
+        "subject": "feat(civ7): add resource feasibility readback Integrate the direct-control ResourceBuilder.canHaveResource read wrapper above the resource assignment evidence slice. Record the bounded feasibility artifact for the 106 resource delta cells, preserve strict ignoreWeight:false as non-authoritative post-materialization evidence, and narrow the next repair investigation to assignment ordering/rebalance plus the smaller mock overacceptance class. Validation: bun test packages/civ7-direct-control/test/direct-control.test.ts --test-name-pattern 'resource placement feasibility'; bun run --cwd packages/civ7-direct-control check; bun run --cwd packages/civ7-direct-control test -- direct-control; bun run --cwd packages/civ7-direct-control build; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-feasibility-classification-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-feasibility-readback-drain",
+      "children": [
+        "codex/swooper-resource-delta-context-drain"
+      ],
+      "depth": 5,
+      "head": "d29f36155985a6a220558ffd9675a735565e5a61",
+      "parentRecordedHead": "15bdcf054c4ed680b5f3624dff25250f20760732",
+      "parentCurrentHead": "15bdcf054c4ed680b5f3624dff25250f20760732",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d29f36155",
+        "sha": "d29f36155985a6a220558ffd9675a735565e5a61",
+        "iso": "2026-06-07T02:48:22-04:00",
+        "subject": "feat(civ7): verify resource delta feasibility Integrate the resource feasibility classification helper and verifier script above the bounded direct-control readback slice. The verifier binds saved final-surface proof identity to live map summary before probing ResourceBuilder.canHaveResource, and the records preserve the 37/28/9/31/1 feasibility split without changing generation, tuning, parity status, or product acceptance. Validation: bun run verify:resource-delta-feasibility -- --help; bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run --cwd packages/civ7-direct-control check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Live verifier execution was not rerun in this integration slice."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-delta-context-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-feasibility-classification-drain",
+      "children": [
+        "codex/swooper-resource-policy-live-context-drain"
+      ],
+      "depth": 6,
+      "head": "cbecf2ee15356e86b6a131e481158698e92bfd5c",
+      "parentRecordedHead": "d29f36155985a6a220558ffd9675a735565e5a61",
+      "parentCurrentHead": "d29f36155985a6a220558ffd9675a735565e5a61",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cbecf2ee1",
+        "sha": "cbecf2ee15356e86b6a131e481158698e92bfd5c",
+        "iso": "2026-06-07T02:53:20-04:00",
+        "subject": "test(mapgen): bind resource delta row context Integrate the row-level resource feasibility context above the feasibility classifier slice. The diagnostic joins resource deltas to saved local/live surface facts, static legality context, and exact request identity so the remaining resource mismatch classes stay evidence-separated instead of turning into tuning or parity claims. Validation: bun run verify:resource-delta-feasibility -- --help; bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run --cwd packages/civ7-direct-control check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Live verifier execution was not rerun in this integration slice."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-policy-live-context-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-delta-context-drain",
+      "children": [
+        "codex/swooper-resource-assignment-trace-drain"
+      ],
+      "depth": 7,
+      "head": "20ff45ae70d817ad842dee4f0992916deefa10ed",
+      "parentRecordedHead": "cbecf2ee15356e86b6a131e481158698e92bfd5c",
+      "parentCurrentHead": "cbecf2ee15356e86b6a131e481158698e92bfd5c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "20ff45ae7",
+        "sha": "20ff45ae70d817ad842dee4f0992916deefa10ed",
+        "iso": "2026-06-07T02:55:05-04:00",
+        "subject": "test(civ7): add resource policy live context Integrate the resource policy spacing and live plot context proof slice above the row-context drain. The verifier and diagnostics now preserve official placement-row evidence, authored spacing neighborhood context, and live plot facts for resource delta rows while keeping the remaining 9 local-overaccepted rows unresolved and outside tuning or parity acceptance. Validation: bun run verify:resource-delta-feasibility -- --help; bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run --cwd packages/civ7-direct-control check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Live verifier execution was not rerun in this integration slice."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-assignment-trace-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-policy-live-context-drain",
+      "children": [
+        "codex/swooper-resource-builder-diagnostics-drain"
+      ],
+      "depth": 8,
+      "head": "19822dd2c9eda11414c35ff197369dc091e15fa3",
+      "parentRecordedHead": "20ff45ae70d817ad842dee4f0992916deefa10ed",
+      "parentCurrentHead": "20ff45ae70d817ad842dee4f0992916deefa10ed",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "19822dd2c",
+        "sha": "19822dd2c9eda11414c35ff197369dc091e15fa3",
+        "iso": "2026-06-07T02:59:06-04:00",
+        "subject": "test(mapgen): trace resource assignment mechanics Integrate local resource assignment trace and assignment-order diagnostics above the policy/live context slice. The placement artifact now records assignment phase, rebalance, assignment order, prior per-type count, legal local plot count, and scarce-floor target for resource delta rows without changing generation policy or tuning. Validation: bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts mods/mod-swooper-maps/test/standard-run.test.ts; bun run verify:resource-delta-feasibility -- --help; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Live verifier execution was not rerun in this integration slice, and ResourceBuilder cut diagnostics remain pending."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-builder-diagnostics-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-assignment-trace-drain",
+      "children": [
+        "codex/swooper-resource-builder-classifier-drain"
+      ],
+      "depth": 9,
+      "head": "d44bcb340e6aa2208fd9c0d87c5da5f7ee2ea449",
+      "parentRecordedHead": "19822dd2c9eda11414c35ff197369dc091e15fa3",
+      "parentCurrentHead": "19822dd2c9eda11414c35ff197369dc091e15fa3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d44bcb340",
+        "sha": "d44bcb340e6aa2208fd9c0d87c5da5f7ee2ea449",
+        "iso": "2026-06-07T03:04:42-04:00",
+        "subject": "test(civ7): add ResourceBuilder diagnostics Integrate the bounded package-owned ResourceBuilder cut/count diagnostics readback above the assignment trace slice. The verifier now attaches cut-list, count, age, and landmass diagnostics for the focused local-overaccepted resource rows while preserving assignment-order evidence and keeping repair authority unresolved. Validation: bun test packages/civ7-direct-control/test/direct-control.test.ts --test-name-pattern 'ResourceBuilder|resource placement feasibility'; bun run --cwd packages/civ7-direct-control check; bun run verify:resource-delta-feasibility -- --help; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Live verifier execution was not rerun in this integration slice."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-builder-classifier-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-builder-diagnostics-drain",
+      "children": [
+        "codex/swooper-resource-builder-policy-context-drain"
+      ],
+      "depth": 10,
+      "head": "9a5ff3369522c71c39173b20390b58f7248cd0fb",
+      "parentRecordedHead": "d44bcb340e6aa2208fd9c0d87c5da5f7ee2ea449",
+      "parentCurrentHead": "d44bcb340e6aa2208fd9c0d87c5da5f7ee2ea449",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9a5ff3369",
+        "sha": "9a5ff3369522c71c39173b20390b58f7248cd0fb",
+        "iso": "2026-06-07T03:07:27-04:00",
+        "subject": "test(civ7): classify ResourceBuilder cuts Add structured ResourceBuilder subclassification to the resource delta verifier and records. The focused local-overaccepted rows now split into six scarce-floor cut-excluded rows and three cut-included-but-rejected rows while preserving assignment-order context and keeping repair authority unresolved. Validation: bun run verify:resource-delta-feasibility -- --help; bun run --cwd packages/civ7-direct-control check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Live verifier execution was not rerun in this integration slice."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-builder-policy-context-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-builder-classifier-drain",
+      "children": [
+        "codex/swooper-resource-assignment-summary-drain"
+      ],
+      "depth": 11,
+      "head": "e66c65d64a8833fc503f4abbf3ae09458b343a9b",
+      "parentRecordedHead": "9a5ff3369522c71c39173b20390b58f7248cd0fb",
+      "parentCurrentHead": "9a5ff3369522c71c39173b20390b58f7248cd0fb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e66c65d64",
+        "sha": "e66c65d64a8833fc503f4abbf3ae09458b343a9b",
+        "iso": "2026-06-07T03:09:20-04:00",
+        "subject": "test(civ7): record ResourceBuilder policy context Add official ResourceBuilder row-policy context to the focused resource subclassification. The verifier and records now show local targetMinPerType 7 versus official MinimumPerHemisphere 3 for the nine focused rows, preserving the source-authority question without authorizing tuning, scarce-floor repair, or parity closure. Validation: bun run verify:resource-delta-feasibility -- --help; bun run --cwd packages/civ7-direct-control check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Live verifier execution was not rerun in this integration slice."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-assignment-summary-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-builder-policy-context-drain",
+      "children": [
+        "codex/swooper-resource-distribution-context-drain"
+      ],
+      "depth": 12,
+      "head": "b524632d1f3c2781ae49f5bb553bc915011999be",
+      "parentRecordedHead": "e66c65d64a8833fc503f4abbf3ae09458b343a9b",
+      "parentCurrentHead": "e66c65d64a8833fc503f4abbf3ae09458b343a9b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b524632d1",
+        "sha": "b524632d1f3c2781ae49f5bb553bc915011999be",
+        "iso": "2026-06-07T03:11:41-04:00",
+        "subject": "test(civ7): summarize resource assignment classes Add assignment-class summary reporting to the resource delta verifier and records. The artifact now shows 64 of 69 local-authored resource delta rows came from scarce-floor with targetMinPerType 7, broadening the source-authority question without authorizing tuning, scarce-floor repair, or parity closure. Validation: bun run verify:resource-delta-feasibility -- --help; bun run --cwd packages/civ7-direct-control check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Live verifier execution was not rerun in this integration slice."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-distribution-context-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-assignment-summary-drain",
+      "children": [
+        "codex/swooper-resource-position-context-drain"
+      ],
+      "depth": 13,
+      "head": "71c2bb71c2ab549318d3adbfdf100ce8b1eaa954",
+      "parentRecordedHead": "b524632d1f3c2781ae49f5bb553bc915011999be",
+      "parentCurrentHead": "b524632d1f3c2781ae49f5bb553bc915011999be",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "71c2bb71c",
+        "sha": "71c2bb71c2ab549318d3adbfdf100ce8b1eaa954",
+        "iso": "2026-06-07T03:15:17-04:00",
+        "subject": "test(civ7): summarize resource distribution context Add ResourceBuilder distribution-count context for the local resource types represented by resource delta rows. The verifier now reads metadata-only ResourceBuilder rows and counts without widening focused per-cell probes, and the OpenSpec records preserve the result as source-authority evidence rather than repair, tuning, parity, or product-proof closure. Validation: bun run verify:resource-delta-feasibility -- --help; bun test packages/civ7-direct-control/test/direct-control.test.ts --test-name-pattern 'ResourceBuilder|resource placement feasibility'; bun run --cwd packages/civ7-direct-control check; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Live verifier execution was not rerun in this integration slice."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-position-context-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-distribution-context-drain",
+      "children": [
+        "codex/swooper-resource-local-materialization-context-drain"
+      ],
+      "depth": 14,
+      "head": "fd6b144d071bb27b2a5e49f4a8ed8a5b2003aaac",
+      "parentRecordedHead": "71c2bb71c2ab549318d3adbfdf100ce8b1eaa954",
+      "parentCurrentHead": "71c2bb71c2ab549318d3adbfdf100ce8b1eaa954",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fd6b144d0",
+        "sha": "fd6b144d071bb27b2a5e49f4a8ed8a5b2003aaac",
+        "iso": "2026-06-07T03:17:18-04:00",
+        "subject": "test(civ7): summarize resource position context Add same-resource live-delta displacement context to the resource delta verifier and records. The artifact can now pair local-authored resource deltas with nearest unmatched live deltas of the same type, preserving positional evidence while keeping the remaining source-owner decision open. Validation: bun run verify:resource-delta-feasibility -- --help; bun run --cwd packages/civ7-direct-control check; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Live verifier execution was not rerun in this integration slice."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-local-materialization-context-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-position-context-drain",
+      "children": [
+        "codex/swooper-resource-coordinate-proof-drain"
+      ],
+      "depth": 15,
+      "head": "cf8891202e838408e918a5bee5dd46b3b815815d",
+      "parentRecordedHead": "fd6b144d071bb27b2a5e49f4a8ed8a5b2003aaac",
+      "parentCurrentHead": "fd6b144d071bb27b2a5e49f4a8ed8a5b2003aaac",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cf8891202",
+        "sha": "cf8891202e838408e918a5bee5dd46b3b815815d",
+        "iso": "2026-06-07T03:18:53-04:00",
+        "subject": "test(civ7): summarize local resource materialization Add local materialization consistency context to the resource delta verifier and records. The verifier now compares typed local placement outcomes against the local final resource surface so remaining resource deltas can rule out local post-placement drift without claiming live Civ authorship. Validation: bun run verify:resource-delta-feasibility -- --help; bun run --cwd packages/civ7-direct-control check; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Live verifier execution was not rerun in this integration slice."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-coordinate-proof-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-local-materialization-context-drain",
+      "children": [
+        "codex/swooper-resource-coordinate-proof-intake-drain"
+      ],
+      "depth": 16,
+      "head": "985e29bf069046e9c241d65904985aac07d9a600",
+      "parentRecordedHead": "cf8891202e838408e918a5bee5dd46b3b815815d",
+      "parentCurrentHead": "cf8891202e838408e918a5bee5dd46b3b815815d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "985e29bf0",
+        "sha": "985e29bf069046e9c241d65904985aac07d9a600",
+        "iso": "2026-06-07T03:21:11-04:00",
+        "subject": "test(civ7): add resource placement coordinate proof Add deterministic coordinateProof digests to resource placement outcomes and compact RESOURCE_PLACEMENT_V1 telemetry. This gives the next exact-authored live run immediate placement coordinate identity while keeping the existing mq20rbzr artifact open because it predates the digest. Validation: bun test mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts; bun test mods/mod-swooper-maps/test/placement/placement-contracts.test.ts mods/mod-swooper-maps/test/standard-run.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Live exact-authored verifier execution was not rerun in this integration slice."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-coordinate-proof-intake-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-coordinate-proof-drain",
+      "children": [
+        "codex/swooper-feature-delta-context-drain"
+      ],
+      "depth": 17,
+      "head": "d02f6b0c81ef2c4bac6850f500052007a96b8341",
+      "parentRecordedHead": "985e29bf069046e9c241d65904985aac07d9a600",
+      "parentCurrentHead": "985e29bf069046e9c241d65904985aac07d9a600",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d02f6b0c8",
+        "sha": "d02f6b0c81ef2c4bac6850f500052007a96b8341",
+        "iso": "2026-06-07T03:23:03-04:00",
+        "subject": "test(civ7): bind resource coordinate proof intake Parse RESOURCE_PLACEMENT_V1 coordinate proof only from the bounded exact-authorship log section and carry it into final-surface parity checks. Parity now stays unresolved when local resource placement coordinate evidence lacks matching exact live log binding. Validation: bun test apps/mapgen-studio/test/runInGame/proofIdentity.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts; bun run --cwd apps/mapgen-studio check; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. The existing mq20rbzr proof predates coordinate-proof intake, so live/product/parity closure was not claimed."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-feature-delta-context-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-coordinate-proof-intake-drain",
+      "children": [
+        "codex/swooper-feature-local-evidence-drain"
+      ],
+      "depth": 18,
+      "head": "7fefeff9b8f201017d537daa08a639fdd79d8b64",
+      "parentRecordedHead": "d02f6b0c81ef2c4bac6850f500052007a96b8341",
+      "parentCurrentHead": "d02f6b0c81ef2c4bac6850f500052007a96b8341",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7fefeff9b",
+        "sha": "7fefeff9b8f201017d537daa08a639fdd79d8b64",
+        "iso": "2026-06-07T03:26:00-04:00",
+        "subject": "test(civ7): classify feature delta context Add feature-delta diagnostic context for exact-authored final-surface mismatches. The classifier separates the local-only ecology feature row from paired one-tile natural-wonder offsets so repair ownership stays evidence-gated. Validation: bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. No feature repair, wonder footprint proof, parity closure, or product acceptance was claimed."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-feature-local-evidence-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-feature-delta-context-drain",
+      "children": [
+        "codex/swooper-feature-feasibility-readback-drain"
+      ],
+      "depth": 19,
+      "head": "1be695c540504386bf1f77efe1bba6f77497dae5",
+      "parentRecordedHead": "7fefeff9b8f201017d537daa08a639fdd79d8b64",
+      "parentCurrentHead": "7fefeff9b8f201017d537daa08a639fdd79d8b64",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1be695c54",
+        "sha": "1be695c540504386bf1f77efe1bba6f77497dae5",
+        "iso": "2026-06-07T03:27:41-04:00",
+        "subject": "test(civ7): expose feature local evidence context Export local feature intent families, feature-apply diagnostics, natural-wonder plan, and natural-wonder placement stats from local final-surface snapshots, then join that evidence into feature delta context when present. The evidence narrows cold-reef and natural-wonder offset classes while preserving compatibility with older proof files. Validation: bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. This is local exact-source evidence joined to saved live grid, not fresh exact-authored live parity proof or product closure."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-feature-feasibility-readback-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-feature-local-evidence-drain",
+      "children": [
+        "codex/swooper-wonder-footprint-direction-drain"
+      ],
+      "depth": 20,
+      "head": "7c7fee21f4a238be98ccc51f8b44b107bd546a14",
+      "parentRecordedHead": "1be695c540504386bf1f77efe1bba6f77497dae5",
+      "parentCurrentHead": "1be695c540504386bf1f77efe1bba6f77497dae5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7c7fee21f",
+        "sha": "7c7fee21f4a238be98ccc51f8b44b107bd546a14",
+        "iso": "2026-06-07T03:29:50-04:00",
+        "subject": "test(civ7): bind feature feasibility readback Add package-owned TerrainBuilder.canHaveFeature readback through @civ7/direct-control, plus a root feature-delta verifier bound to saved final-surface parity proof identity. The recorded evidence remains post-materialization feasibility context, not repair authority. Validation: bun run --cwd packages/civ7-direct-control test -- direct-control; bun run --cwd packages/civ7-direct-control check; bun run verify:feature-delta-feasibility -- --help; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. No feature, natural-wonder, terrain, parity, product, or tuning repair was authorized from this layer."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-wonder-footprint-direction-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-feature-feasibility-readback-drain",
+      "children": [
+        "codex/swooper-wonder-footprint-readback-drain"
+      ],
+      "depth": 21,
+      "head": "21bd0b3a9663b52f0c70150369035e275b4deded",
+      "parentRecordedHead": "7c7fee21f4a238be98ccc51f8b44b107bd546a14",
+      "parentCurrentHead": "7c7fee21f4a238be98ccc51f8b44b107bd546a14",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "21bd0b3a9",
+        "sha": "21bd0b3a9663b52f0c70150369035e275b4deded",
+        "iso": "2026-06-07T03:31:48-04:00",
+        "subject": "test(civ7): classify wonder footprint directions Add natural-wonder direction alternatives to feature delta diagnostics so offset rows can show whether local map-policy direction semantics explain local rows, live rows, or both. This narrows the owner question toward footprint-orientation semantics without authorizing repair. Validation: bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. No natural-wonder repair, parity closure, product acceptance, or tuning was claimed."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-wonder-footprint-readback-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-footprint-direction-drain",
+      "children": [
+        "codex/swooper-wonder-catalog-direction-drain"
+      ],
+      "depth": 22,
+      "head": "b2391097566fa26af64241c3f5c725903132f60a",
+      "parentRecordedHead": "21bd0b3a9663b52f0c70150369035e275b4deded",
+      "parentCurrentHead": "21bd0b3a9663b52f0c70150369035e275b4deded",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b23910975",
+        "sha": "b2391097566fa26af64241c3f5c725903132f60a",
+        "iso": "2026-06-07T03:33:37-04:00",
+        "subject": "test(civ7): add wonder footprint readback context Add planned natural-wonder footprint readback diagnostics that score local plans against local and live feature grids across map-policy directions. The evidence confirms a footprint orientation gap for the current planned multi-tile wonders while remaining too small for a global Direction:-1 repair. Validation: bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. No natural-wonder repair, parity closure, product acceptance, or tuning was claimed."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-wonder-catalog-direction-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-footprint-readback-drain",
+      "children": [
+        "codex/swooper-wonder-live-proof-boundary-drain"
+      ],
+      "depth": 23,
+      "head": "7f3a75114a49fcd62a87c8da23b885fcc9e4df79",
+      "parentRecordedHead": "b2391097566fa26af64241c3f5c725903132f60a",
+      "parentCurrentHead": "b2391097566fa26af64241c3f5c725903132f60a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7f3a75114",
+        "sha": "7f3a75114a49fcd62a87c8da23b885fcc9e4df79",
+        "iso": "2026-06-07T03:35:57-04:00",
+        "subject": "test(civ7): classify wonder catalog directions Add natural-wonder footprint catalog context diagnostics for supported direction classes and exact-run readback joins. The context separates single-tile, fixed-direction, and official Direction:-1 multi-tile entries while keeping projection evidence separate from repair authority. Validation: bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. No natural-wonder repair, parity closure, product acceptance, generated output, or mountain-quality claim was made."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-wonder-live-proof-boundary-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-catalog-direction-drain",
+      "children": [
+        "codex/swooper-terrain-edge-delta-context-drain"
+      ],
+      "depth": 24,
+      "head": "e486a6be9ca54a36af9294a6469ee2bb6df5d7a0",
+      "parentRecordedHead": "7f3a75114a49fcd62a87c8da23b885fcc9e4df79",
+      "parentCurrentHead": "7f3a75114a49fcd62a87c8da23b885fcc9e4df79",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e486a6be9",
+        "sha": "e486a6be9ca54a36af9294a6469ee2bb6df5d7a0",
+        "iso": "2026-06-07T03:37:30-04:00",
+        "subject": "test(civ7): classify wonder live proof boundary Add natural-wonder live proof boundary diagnostics that separate local placement stats from exact live proof/completion payload evidence. Local planned/placed/rejected stats no longer imply repair authority when live payload stats are absent. Validation: bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Natural-wonder repair, parity closure, and product acceptance remain blocked on live placement stats."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-terrain-edge-delta-context-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-live-proof-boundary-drain",
+      "children": [
+        "codex/swooper-terrain-edge-mask-context-drain"
+      ],
+      "depth": 25,
+      "head": "f51759255cd71c443841eadb213e966c71cf07d4",
+      "parentRecordedHead": "e486a6be9ca54a36af9294a6469ee2bb6df5d7a0",
+      "parentCurrentHead": "e486a6be9ca54a36af9294a6469ee2bb6df5d7a0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f51759255",
+        "sha": "f51759255cd71c443841eadb213e966c71cf07d4",
+        "iso": "2026-06-07T03:41:46-04:00",
+        "subject": "test(civ7): classify terrain edge deltas Add terrain-only final-surface delta diagnostics for the exact-authored studio-run-in-game-mq20rbzr-1fhc proof. The helper records coast/ocean swap rows, neighborhood water-class context, and unresolved owner candidates without changing generation or tuning."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-terrain-edge-mask-context-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-terrain-edge-delta-context-drain",
+      "children": [
+        "codex/swooper-terrain-edge-live-readback-drain"
+      ],
+      "depth": 26,
+      "head": "bf7e98fb7b04914a536664a303bce08d6e337edc",
+      "parentRecordedHead": "f51759255cd71c443841eadb213e966c71cf07d4",
+      "parentCurrentHead": "f51759255cd71c443841eadb213e966c71cf07d4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bf7e98fb7",
+        "sha": "bf7e98fb7b04914a536664a303bce08d6e337edc",
+        "iso": "2026-06-07T03:43:51-04:00",
+        "subject": "test(civ7): add terrain edge mask context Carry local terrain projection evidence through final-surface parity diagnostics and summarize it on terrain edge rows. The row context now includes morphology shelf/coast masks, Hydrology lake intent, map-hydrology projection readback, and placement terrain snapshots."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-terrain-edge-live-readback-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-terrain-edge-mask-context-drain",
+      "children": [
+        "codex/swooper-terrain-validation-boundary-drain"
+      ],
+      "depth": 27,
+      "head": "3cfa7b766df15160f7ad54ca69077ca43045ff8d",
+      "parentRecordedHead": "bf7e98fb7b04914a536664a303bce08d6e337edc",
+      "parentCurrentHead": "bf7e98fb7b04914a536664a303bce08d6e337edc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3cfa7b766",
+        "sha": "3cfa7b766df15160f7ad54ca69077ca43045ff8d",
+        "iso": "2026-06-07T03:47:25-04:00",
+        "subject": "test(civ7): bind terrain edge live readback Add a package-owned terrain-edge live context verifier that binds the two coast/ocean rows for studio-run-in-game-mq20rbzr-1fhc to the saved exact-authored proof and runtime identity before reading row facts."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-terrain-validation-boundary-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-terrain-edge-live-readback-drain",
+      "children": [
+        "codex/swooper-terrain-source-owner-drain"
+      ],
+      "depth": 28,
+      "head": "4380070c8ff9435b0688dad840ae1c4a9cd7fa8b",
+      "parentRecordedHead": "3cfa7b766df15160f7ad54ca69077ca43045ff8d",
+      "parentCurrentHead": "3cfa7b766df15160f7ad54ca69077ca43045ff8d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4380070c8",
+        "sha": "4380070c8ff9435b0688dad840ae1c4a9cd7fa8b",
+        "iso": "2026-06-07T03:49:30-04:00",
+        "subject": "test(civ7): trace terrain validation boundary Add diagnostic placement surface validation-boundary readback that records local engine terrain, water, lake, and area facts before validateAndFixTerrain, after validation, and after placement surface maintenance."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-terrain-source-owner-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-terrain-validation-boundary-drain",
+      "children": [
+        "codex/swooper-mock-lake-readback-drain"
+      ],
+      "depth": 29,
+      "head": "57f7ca10c8943bfbab966d939df39054b617550e",
+      "parentRecordedHead": "4380070c8ff9435b0688dad840ae1c4a9cd7fa8b",
+      "parentCurrentHead": "4380070c8ff9435b0688dad840ae1c4a9cd7fa8b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "57f7ca10c",
+        "sha": "57f7ca10c8943bfbab966d939df39054b617550e",
+        "iso": "2026-06-07T03:50:50-04:00",
+        "subject": "docs(openspec): classify terrain edge source owner Classify the two exact-authored terrain edge rows from studio-run-in-game-mq20rbzr-1fhc to the repo-owned local mock/materialization parity boundary before any repair code moves."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-mock-lake-readback-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-terrain-source-owner-drain",
+      "children": [
+        "codex/swooper-coast-materialization-edge-drain"
+      ],
+      "depth": 30,
+      "head": "1407889dc00a571dde0df064cce751bbfc41ace9",
+      "parentRecordedHead": "57f7ca10c8943bfbab966d939df39054b617550e",
+      "parentCurrentHead": "57f7ca10c8943bfbab966d939df39054b617550e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1407889dc",
+        "sha": "1407889dc00a571dde0df064cce751bbfc41ace9",
+        "iso": "2026-06-07T03:57:06-04:00",
+        "subject": "fix(civ7): separate mock lake readback Repair the adapter/mock materialization sub-gap found in the terrain-edge diagnostics: ordinary coast terrain no longer reads as lake-classified water in MockAdapter, while stampLakes remains the path that marks planned lake state."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-coast-materialization-edge-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-mock-lake-readback-drain",
+      "children": [
+        "codex/swooper-mock-terrain-materialization-drain"
+      ],
+      "depth": 31,
+      "head": "fe54c98c8bc8825803a0f00ec7602db81a70ea0f",
+      "parentRecordedHead": "1407889dc00a571dde0df064cce751bbfc41ace9",
+      "parentCurrentHead": "1407889dc00a571dde0df064cce751bbfc41ace9",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fe54c98c8",
+        "sha": "fe54c98c8bc8825803a0f00ec7602db81a70ea0f",
+        "iso": "2026-06-07T04:05:31-04:00",
+        "subject": "test(civ7): trace coast materialization edge"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-mock-terrain-materialization-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-coast-materialization-edge-drain",
+      "children": [
+        "codex/swooper-terrain-edge-reconciliation-drain"
+      ],
+      "depth": 32,
+      "head": "c8ce9e94ffeb1b03af2aeb5f373b56d6886abcab",
+      "parentRecordedHead": "fe54c98c8bc8825803a0f00ec7602db81a70ea0f",
+      "parentCurrentHead": "fe54c98c8bc8825803a0f00ec7602db81a70ea0f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c8ce9e94f",
+        "sha": "c8ce9e94ffeb1b03af2aeb5f373b56d6886abcab",
+        "iso": "2026-06-07T04:10:24-04:00",
+        "subject": "fix(civ7): align mock terrain materialization"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-terrain-edge-reconciliation-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-mock-terrain-materialization-drain",
+      "children": [
+        "codex/swooper-wonder-materialization-repair-drain"
+      ],
+      "depth": 33,
+      "head": "aabc73aba17cf25af7471a8e7746fcd7a8bc9ad7",
+      "parentRecordedHead": "c8ce9e94ffeb1b03af2aeb5f373b56d6886abcab",
+      "parentCurrentHead": "c8ce9e94ffeb1b03af2aeb5f373b56d6886abcab",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "aabc73aba",
+        "sha": "aabc73aba17cf25af7471a8e7746fcd7a8bc9ad7",
+        "iso": "2026-06-07T04:13:49-04:00",
+        "subject": "docs(openspec): reconcile terrain edge integration"
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-terrain-edge-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Terrain-edge diagnostics, mock lake/materialization repairs, and reconciliation records are represented in the Swooper terrain-edge drain."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-wonder-materialization-repair-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-terrain-edge-reconciliation-drain",
+      "children": [
+        "codex/swooper-wonder-placement-telemetry-drain"
+      ],
+      "depth": 34,
+      "head": "90ac9900dbc271aef3dc6c96443bc0d3590c9f23",
+      "parentRecordedHead": "aabc73aba17cf25af7471a8e7746fcd7a8bc9ad7",
+      "parentCurrentHead": "aabc73aba17cf25af7471a8e7746fcd7a8bc9ad7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "90ac9900d",
+        "sha": "90ac9900dbc271aef3dc6c96443bc0d3590c9f23",
+        "iso": "2026-06-07T04:26:31-04:00",
+        "subject": "fix(civ7): record natural-wonder placement outcomes Adopt only the natural-wonder materialization behavior from stale source commit b9a3e9d50. The materializer now projects feature-valid terrain across supported footprints, records degraded placement outcomes, and keeps corrupt plan metadata as a hard failure. MockAdapter stamps/readbacks supported natural-wonder footprints so tests match the placement artifact contract. Validation: bun test mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts; bun test packages/civ7-adapter/test/mock-terrain-policy.test.ts; bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts; bun test mods/mod-swooper-maps/test/placement/placement-contracts.test.ts; bun run --cwd packages/civ7-adapter check; bun run --cwd packages/civ7-adapter build; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate. Exact parity rerun remains blocked before parity evaluation by stale /config/ecology-features/floodplainPlanning."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-wonder-placement-telemetry-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-materialization-repair-drain",
+      "children": [
+        "codex/swooper-wonder-coordinate-proof-drain"
+      ],
+      "depth": 35,
+      "head": "fd4e45e44b080bb46d777a4711f95befd2399eca",
+      "parentRecordedHead": "90ac9900dbc271aef3dc6c96443bc0d3590c9f23",
+      "parentCurrentHead": "90ac9900dbc271aef3dc6c96443bc0d3590c9f23",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fd4e45e44",
+        "sha": "fd4e45e44b080bb46d777a4711f95befd2399eca",
+        "iso": "2026-06-07T04:31:28-04:00",
+        "subject": "test(civ7): bind natural-wonder placement telemetry Emit NATURAL_WONDER_PLACEMENT_V1 from natural-wonder materialization, parse it inside the bounded Studio exact-authorship log section, and let feature/resource diagnostics consume exact log telemetry as live placement evidence. Preserve the source-recorded fresh telemetry proof separately from current parity closure. Validation: bun test apps/mapgen-studio/test/runInGame/proofIdentity.test.ts; bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run --cwd apps/mapgen-studio check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check && git diff --cached --check. Exact parity rerun remains blocked before parity evaluation by stale /config/ecology-features/floodplainPlanning."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-wonder-coordinate-proof-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-placement-telemetry-drain",
+      "children": [
+        "codex/swooper-wonder-source-classification-drain"
+      ],
+      "depth": 36,
+      "head": "80fca64296a853b15dda62a206ae0077be364fce",
+      "parentRecordedHead": "fd4e45e44b080bb46d777a4711f95befd2399eca",
+      "parentCurrentHead": "fd4e45e44b080bb46d777a4711f95befd2399eca",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "80fca6429",
+        "sha": "80fca64296a853b15dda62a206ae0077be364fce",
+        "iso": "2026-06-07T04:35:22-04:00",
+        "subject": "test(civ7): bind natural-wonder coordinate proof Extend NATURAL_WONDER_PLACEMENT_V1 with bounded rejection examples and deterministic placed/rejected coordinate digests. Studio exact-authorship parsing and Swooper diagnostics now preserve the coordinate proof so natural-wonder rejection identity can be classified before repair. Validation: bun test apps/mapgen-studio/test/runInGame/proofIdentity.test.ts; bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run --cwd apps/mapgen-studio check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check && git diff --cached --check. Exact parity rerun remains blocked before parity evaluation by stale /config/ecology-features/floodplainPlanning."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-wonder-source-classification-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-coordinate-proof-drain",
+      "children": [
+        "codex/swooper-wonder-direction-repair-drain"
+      ],
+      "depth": 37,
+      "head": "a9b6bbfa63bbf18644d4842401085a12521b886a",
+      "parentRecordedHead": "80fca64296a853b15dda62a206ae0077be364fce",
+      "parentCurrentHead": "80fca64296a853b15dda62a206ae0077be364fce",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a9b6bbfa6",
+        "sha": "a9b6bbfa63bbf18644d4842401085a12521b886a",
+        "iso": "2026-06-07T04:37:16-04:00",
+        "subject": "docs(openspec): classify wonder coordinate source Classify the source-recorded natural-wonder coordinate proof as repo-owned footprint projection/materialization emulation. Keep the repair authority narrow: it may address unspecified-direction natural-wonder projection, but it does not authorize product tuning, global catalog rewrites, generated output churn, parity closure, or acceptance. Validation: bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check && git diff --cached --check."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-wonder-direction-repair-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-source-classification-drain",
+      "children": [
+        "codex/swooper-wonder-proof-record-drain"
+      ],
+      "depth": 38,
+      "head": "75c54453524fbac73a60ac94cb37a9771c9762e9",
+      "parentRecordedHead": "a9b6bbfa63bbf18644d4842401085a12521b886a",
+      "parentCurrentHead": "a9b6bbfa63bbf18644d4842401085a12521b886a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "75c544535",
+        "sha": "75c54453524fbac73a60ac94cb37a9771c9762e9",
+        "iso": "2026-06-07T04:44:16-04:00",
+        "subject": "fix(civ7): materialize projected wonder direction Keep official natural-wonder catalog direction as evidence while resolving unspecified direction to an explicit materialization direction before Swooper planning and Civ writes. This aligns the local footprint offsets, mock placement, and live write path for the classified Kilimanjaro/Zhangjiajie projection class without widening to product tuning. Updates earthlike-live-feature-resource-legality-repair records to mark the projection/materialization owner repaired while leaving fresh exact-authored parity proof open. Validation: bun test packages/civ7-map-policy/test/map-policy.test.ts; bun test mods/mod-swooper-maps/test/placement/derive-placement-inputs.test.ts mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts; bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts; bun run --cwd packages/civ7-map-policy check; bun run --cwd packages/civ7-map-policy build; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check. Exact parity rerun remains blocked before parity evaluation by stale config key: /config/ecology-features/floodplainPlanning."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-wonder-proof-record-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-direction-repair-drain",
+      "children": [
+        "codex/swooper-post-wonder-feature-classification-drain"
+      ],
+      "depth": 39,
+      "head": "e4d84a60cb18a9f9124b6a35dd135a4caa0f8812",
+      "parentRecordedHead": "75c54453524fbac73a60ac94cb37a9771c9762e9",
+      "parentCurrentHead": "75c54453524fbac73a60ac94cb37a9771c9762e9",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e4d84a60c",
+        "sha": "e4d84a60cb18a9f9124b6a35dd135a4caa0f8812",
+        "iso": "2026-06-07T05:00:04-04:00",
+        "subject": "docs(openspec): preserve wonder repair proof record Replay the old post-repair exact-authored natural-wonder proof as source-recorded evidence instead of current-drain parity closure. The record keeps studio-run-in-game-mq2u6wdg-1z4g visible while correcting the proof class: exact live telemetry still carried 5 placed and 2 rejected natural wonders, while the 7/7/0 signal came from local verifier generation. Current exact parity rerun still remains open and blocked before parity evaluation by stale config key /config/ecology-features/floodplainPlanning. Validation: bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-post-wonder-feature-classification-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-proof-record-drain",
+      "children": [
+        "codex/swooper-wonder-rejection-outcomes-drain"
+      ],
+      "depth": 40,
+      "head": "42f065f9ef57df6939b86ae16fba40f6e6e8455b",
+      "parentRecordedHead": "e4d84a60cb18a9f9124b6a35dd135a4caa0f8812",
+      "parentCurrentHead": "e4d84a60cb18a9f9124b6a35dd135a4caa0f8812",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "42f065f9e",
+        "sha": "42f065f9ef57df6939b86ae16fba40f6e6e8455b",
+        "iso": "2026-06-07T05:02:34-04:00",
+        "subject": "docs(openspec): classify post-wonder proof gap Replay the post-repair feature-row context as source-recorded evidence while correcting the owner classification. The exact live log still carried 5 placed and 2 rejected natural wonders, so the natural-wonder offsets remain a materialization/deploy proof gap rather than accepted residuals. The cold-reef row is evidence-bound, not repair-authorized, until exact live feature-apply telemetry or readback is bound. Current exact parity rerun still blocks before parity evaluation on /config/ecology-features/floodplainPlanning. Validation: bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-wonder-rejection-outcomes-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-post-wonder-feature-classification-drain",
+      "children": [
+        "codex/swooper-wonder-named-rejection-proof-drain"
+      ],
+      "depth": 41,
+      "head": "67617bbca60d4d2e9d2a11799383abed76afa05f",
+      "parentRecordedHead": "42f065f9ef57df6939b86ae16fba40f6e6e8455b",
+      "parentCurrentHead": "42f065f9ef57df6939b86ae16fba40f6e6e8455b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "67617bbca",
+        "sha": "67617bbca60d4d2e9d2a11799383abed76afa05f",
+        "iso": "2026-06-07T05:06:04-04:00",
+        "subject": "feat(civ7): name wonder placement rejections Expose NaturalWonderPlacementOutcome through the adapter boundary so Swooper natural-wonder telemetry records named rejection reasons instead of aggregate adapter-rejected outcomes. The boolean stampNaturalWonder wrapper remains for compatibility. Correct the source-recorded post-repair proof interpretation: the 7/7/0 signal came from local verifier generation, while exact live telemetry still carried 5 placed and 2 rejected natural wonders. Natural-wonder offsets and cold reef stay proof-bound pending fresh exact telemetry. Swooper Maps package-local checks now resolve @civ7/map-policy and @civ7/adapter to workspace source and widen the no-emit check root so source-resolved workspace files are valid inputs. Validation: bun test packages/civ7-adapter/test/placement-outcomes.test.ts packages/civ7-adapter/test/static-catalogs.test.ts; bun test mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts; bun run --cwd packages/civ7-adapter check; bun run --cwd packages/civ7-adapter build; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec -- validate workspace-build-pipeline --strict; bun run openspec:validate; git diff --check; git diff --cached --check."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-wonder-named-rejection-proof-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-rejection-outcomes-drain",
+      "children": [
+        "codex/swooper-wonder-readback-context-drain"
+      ],
+      "depth": 42,
+      "head": "b241e71212d388c9bde1914aab74f331563380f2",
+      "parentRecordedHead": "67617bbca60d4d2e9d2a11799383abed76afa05f",
+      "parentCurrentHead": "67617bbca60d4d2e9d2a11799383abed76afa05f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b241e7121",
+        "sha": "b241e71212d388c9bde1914aab74f331563380f2",
+        "iso": "2026-06-07T05:09:54-04:00",
+        "subject": "docs(openspec): preserve named wonder rejection proof Preserve source-recorded exact-authored request studio-run-in-game-mq2vqhg6-1z4g after natural-wonder rejection telemetry. The proof narrows the remaining Kilimanjaro and Zhangjiajie rejected anchors to readback-mismatch while keeping exact live telemetry authoritative over local verifier generation. This is proof-record movement only: it does not close natural-wonder repair, feature parity, final-surface parity, Earthlike acceptance, product acceptance, generated-output ownership, or mountain-quality work. The current exact parity rerun remains open and blocked before parity evaluation by stale config key /config/ecology-features/floodplainPlanning. Validation: bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-wonder-readback-context-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-named-rejection-proof-drain",
+      "children": [
+        "codex/swooper-wonder-footprint-proof-drain"
+      ],
+      "depth": 43,
+      "head": "3c4990f1f01f5fa42e72adb3e0ce885ec0b89420",
+      "parentRecordedHead": "b241e71212d388c9bde1914aab74f331563380f2",
+      "parentCurrentHead": "b241e71212d388c9bde1914aab74f331563380f2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3c4990f1f",
+        "sha": "3c4990f1f01f5fa42e72adb3e0ce885ec0b89420",
+        "iso": "2026-06-07T05:12:27-04:00",
+        "subject": "test(civ7): preserve wonder readback context Carry adapter-observed natural-wonder readback-mismatch details into Swooper rejection examples and coordinate digests. The existing digest identity remains stable for rows without observed readback facts. Preserve source-recorded exact-authored request studio-run-in-game-mq2w5548-1z4g as proof context only: it narrows the remaining Kilimanjaro and Zhangjiajie failures to empty expected-footprint readbacks at observed plots 1427 and 2278, while keeping current exact proof and parity closure open. Validation: bun test mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-wonder-footprint-proof-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-readback-context-drain",
+      "children": [
+        "codex/swooper-wonder-footprint-proof-record-drain"
+      ],
+      "depth": 44,
+      "head": "c39404744a6c14597a09149615d43748a5e998fd",
+      "parentRecordedHead": "3c4990f1f01f5fa42e72adb3e0ce885ec0b89420",
+      "parentCurrentHead": "3c4990f1f01f5fa42e72adb3e0ce885ec0b89420",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c39404744",
+        "sha": "c39404744a6c14597a09149615d43748a5e998fd",
+        "iso": "2026-06-07T05:14:46-04:00",
+        "subject": "test(civ7): capture wonder footprint readback Extend natural-wonder placement outcomes so readback-mismatch telemetry can carry the complete expected-footprint readback vector plus empty/partial footprint status. Swooper rejection examples and coordinate digests now expose the requested direction, resolved elevation, observed readback facts, and compact footprint readback details. This is proof instrumentation only. It does not change natural-wonder placement direction, config, tuning, generated output, materialization behavior, final-surface parity, Earthlike acceptance, product acceptance, natural-wonder repair closure, or mountain-quality closure. Current exact proof remains open before parity evaluation. Validation: bun test packages/civ7-adapter/test/placement-outcomes.test.ts; bun run --cwd packages/civ7-adapter check; bun run --cwd packages/civ7-adapter build; bun test mods/mod-swooper-maps/test/placement/natural-wonder-placement.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-wonder-footprint-proof-record-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-footprint-proof-drain",
+      "children": [
+        "codex/swooper-current-runtime-proof-blocker-drain"
+      ],
+      "depth": 45,
+      "head": "2d90d3295d537ea2ef8bf888b0d9b1c74abca62f",
+      "parentRecordedHead": "c39404744a6c14597a09149615d43748a5e998fd",
+      "parentCurrentHead": "c39404744a6c14597a09149615d43748a5e998fd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2d90d3295",
+        "sha": "2d90d3295d537ea2ef8bf888b0d9b1c74abca62f",
+        "iso": "2026-06-07T05:17:10-04:00",
+        "subject": "docs(openspec): preserve wonder footprint proof Preserve source-recorded exact-authored request studio-run-in-game-mq2x1ugm-1z4g after the post-write footprint telemetry contract. The proof consumed direction, elevation, and full expected-footprint readback vectors while keeping exact live natural-wonder telemetry at 5 placed and 2 rejected. This is a proof-record layer only. It keeps final-surface parity unresolved, separates exact live telemetry from local verifier generation at 7 placed and 0 rejected, and does not claim natural-wonder repair, source-owner closure, Earthlike acceptance, product acceptance, generated-output ownership, or mountain-quality closure. Current exact proof remains open before parity evaluation. Validation: bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check; git diff --cached --check."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-current-runtime-proof-blocker-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-wonder-footprint-proof-record-drain",
+      "children": [
+        "codex/swooper-studio-start-log-failure-drain"
+      ],
+      "depth": 46,
+      "head": "0e8b1a7eeab39e6c16bf592d43ce3ac411e35419",
+      "parentRecordedHead": "2d90d3295d537ea2ef8bf888b0d9b1c74abca62f",
+      "parentCurrentHead": "2d90d3295d537ea2ef8bf888b0d9b1c74abca62f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0e8b1a7ee",
+        "sha": "0e8b1a7eeab39e6c16bf592d43ce3ac411e35419",
+        "iso": "2026-06-07T05:39:03-04:00",
+        "subject": "docs(openspec): record current runtime proof blocker"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-studio-start-log-failure-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-current-runtime-proof-blocker-drain",
+      "children": [
+        "codex/swooper-studio-restart-launch-drain"
+      ],
+      "depth": 47,
+      "head": "db2bf1c5411ceae509be76ef655833ae5348ab8d",
+      "parentRecordedHead": "0e8b1a7eeab39e6c16bf592d43ce3ac411e35419",
+      "parentCurrentHead": "0e8b1a7eeab39e6c16bf592d43ce3ac411e35419",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "db2bf1c54",
+        "sha": "db2bf1c5411ceae509be76ef655833ae5348ab8d",
+        "iso": "2026-06-07T05:41:58-04:00",
+        "subject": "fix(studio): classify start-phase map script load failures"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-studio-restart-launch-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-studio-start-log-failure-drain",
+      "children": [
+        "codex/swooper-studio-start-log-grace-drain"
+      ],
+      "depth": 48,
+      "head": "9751a21371b7f2198aa50fe6e5e753f41a7330be",
+      "parentRecordedHead": "db2bf1c5411ceae509be76ef655833ae5348ab8d",
+      "parentCurrentHead": "db2bf1c5411ceae509be76ef655833ae5348ab8d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9751a2137",
+        "sha": "9751a21371b7f2198aa50fe6e5e753f41a7330be",
+        "iso": "2026-06-07T05:54:20-04:00",
+        "subject": "fix(studio): retry Civ Steam launch during restart recovery"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-studio-start-log-grace-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-studio-restart-launch-drain",
+      "children": [
+        "codex/swooper-current-map-script-load-proof-drain"
+      ],
+      "depth": 49,
+      "head": "1c4257735e6bb1288a7c7073b9ec3785101b7e67",
+      "parentRecordedHead": "9751a21371b7f2198aa50fe6e5e753f41a7330be",
+      "parentCurrentHead": "9751a21371b7f2198aa50fe6e5e753f41a7330be",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1c4257735",
+        "sha": "1c4257735e6bb1288a7c7073b9ec3785101b7e67",
+        "iso": "2026-06-07T06:15:12-04:00",
+        "subject": "fix(studio): wait for delayed map script load logs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-current-map-script-load-proof-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-studio-start-log-grace-drain",
+      "children": [
+        "codex/swooper-map-script-bundle-policy-drain"
+      ],
+      "depth": 50,
+      "head": "3f5a90b58e1e65ffa01d1e8a64c9d5dae0fe666b",
+      "parentRecordedHead": "1c4257735e6bb1288a7c7073b9ec3785101b7e67",
+      "parentCurrentHead": "1c4257735e6bb1288a7c7073b9ec3785101b7e67",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3f5a90b58",
+        "sha": "3f5a90b58e1e65ffa01d1e8a64c9d5dae0fe666b",
+        "iso": "2026-06-07T06:25:03-04:00",
+        "subject": "docs(openspec): record current map script load blocker"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-map-script-bundle-policy-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-current-map-script-load-proof-drain",
+      "children": [
+        "codex/swooper-current-map-generation-blocker-drain"
+      ],
+      "depth": 51,
+      "head": "019715dce2a2139104bebffead432157639fc99a",
+      "parentRecordedHead": "3f5a90b58e1e65ffa01d1e8a64c9d5dae0fe666b",
+      "parentCurrentHead": "3f5a90b58e1e65ffa01d1e8a64c9d5dae0fe666b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "019715dce",
+        "sha": "019715dce2a2139104bebffead432157639fc99a",
+        "iso": "2026-06-07T06:30:35-04:00",
+        "subject": "fix(mapgen): bundle map policy into Civ map scripts"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-current-map-generation-blocker-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-map-script-bundle-policy-drain",
+      "children": [
+        "codex/swooper-map-elevation-drift-policy-drain"
+      ],
+      "depth": 52,
+      "head": "b0957cce69501b4d3f28d7604d718bda272cd0fe",
+      "parentRecordedHead": "019715dce2a2139104bebffead432157639fc99a",
+      "parentCurrentHead": "019715dce2a2139104bebffead432157639fc99a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b0957cce6",
+        "sha": "b0957cce69501b4d3f28d7604d718bda272cd0fe",
+        "iso": "2026-06-07T06:43:06-04:00",
+        "subject": "docs(openspec): record current map generation blocker"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-map-elevation-drift-policy-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-current-map-generation-blocker-drain",
+      "children": [
+        "codex/swooper-sdk-mapgen-completion-marker-drain"
+      ],
+      "depth": 53,
+      "head": "b539748b73ee74e5c63ab2464b5313f79797b464",
+      "parentRecordedHead": "b0957cce69501b4d3f28d7604d718bda272cd0fe",
+      "parentCurrentHead": "b0957cce69501b4d3f28d7604d718bda272cd0fe",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b539748b7",
+        "sha": "b539748b73ee74e5c63ab2464b5313f79797b464",
+        "iso": "2026-06-07T06:49:43-04:00",
+        "subject": "fix(mapgen): honor bounded elevation drift policy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-sdk-mapgen-completion-marker-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-map-elevation-drift-policy-drain",
+      "children": [
+        "codex/swooper-studio-log-rewrite-reader-drain"
+      ],
+      "depth": 54,
+      "head": "56a1f000d4375f120faf3f6d1a6fb328057115ce",
+      "parentRecordedHead": "b539748b73ee74e5c63ab2464b5313f79797b464",
+      "parentCurrentHead": "b539748b73ee74e5c63ab2464b5313f79797b464",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "56a1f000d",
+        "sha": "56a1f000d4375f120faf3f6d1a6fb328057115ce",
+        "iso": "2026-06-07T07:07:43-04:00",
+        "subject": "fix(sdk): emit mapgen completion marker"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-studio-log-rewrite-reader-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-sdk-mapgen-completion-marker-drain",
+      "children": [
+        "codex/swooper-current-exact-authorship-proof-record-drain"
+      ],
+      "depth": 55,
+      "head": "5537f2a829f8dd1452fec81d002c4afc1f0826a6",
+      "parentRecordedHead": "56a1f000d4375f120faf3f6d1a6fb328057115ce",
+      "parentCurrentHead": "56a1f000d4375f120faf3f6d1a6fb328057115ce",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5537f2a82",
+        "sha": "5537f2a829f8dd1452fec81d002c4afc1f0826a6",
+        "iso": "2026-06-07T07:32:57-04:00",
+        "subject": "fix(studio): handle rewritten Scripting logs Teach direct-control log snapshots to preserve a small prefix and treat a Civ-rewritten Scripting.log as fresh from byte 0 when the prefix no longer matches. MapGen Studio now uses the same fresh-log boundary helper for marker waiting and proof parsing, so restart-created logs do not get sliced from stale pre-restart offsets. Refine the Studio worker-bundle guard to flag actual /base-standard/... virtual imports without rejecting official Base/modules/base-standard/... source-path metadata embedded as policy evidence."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-current-exact-authorship-proof-record-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-studio-log-rewrite-reader-drain",
+      "children": [
+        "codex/swooper-current-final-surface-parity-record-drain"
+      ],
+      "depth": 56,
+      "head": "0cd111b48cc7311b01d78277b75daad7ca2d172e",
+      "parentRecordedHead": "5537f2a829f8dd1452fec81d002c4afc1f0826a6",
+      "parentCurrentHead": "5537f2a829f8dd1452fec81d002c4afc1f0826a6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0cd111b48",
+        "sha": "0cd111b48cc7311b01d78277b75daad7ca2d172e",
+        "iso": "2026-06-07T07:45:49-04:00",
+        "subject": "docs(openspec): record current exact authorship proof Record the committed Studio/Civ request studio-run-in-game-mq3pfgbe-1doj as the current exact-authorship and mapgen-completion proof after the SDK completion-marker and direct-control log-rewrite reader repairs. Keep current final-surface parity and product acceptance explicitly open until a verifier artifact exists."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-current-final-surface-parity-record-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-current-exact-authorship-proof-record-drain",
+      "children": [
+        "codex/swooper-current-diagnostics-classification-drain"
+      ],
+      "depth": 57,
+      "head": "56978ef81f873271bb9a36138879e0c617795e83",
+      "parentRecordedHead": "0cd111b48cc7311b01d78277b75daad7ca2d172e",
+      "parentCurrentHead": "0cd111b48cc7311b01d78277b75daad7ca2d172e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "56978ef81",
+        "sha": "56978ef81f873271bb9a36138879e0c617795e83",
+        "iso": "2026-06-07T07:54:20-04:00",
+        "subject": "fix(mapgen): record current final-surface parity proof Remove the stale floodplains ecology-intent lookup from the final-surface parity local evidence collector, which unblocked the current verifier against the accepted public/stage boundary. Record the unresolved studio-run-in-game-mq3pfgbe-1doj final-surface parity artifact, including stable live identity, mismatch counts, resource coordinate proof links, and remaining source-authority/product acceptance boundaries."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-current-diagnostics-classification-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-current-final-surface-parity-record-drain",
+      "children": [
+        "codex/swooper-current-source-authority-queue-drain"
+      ],
+      "depth": 58,
+      "head": "0b2f8207be1415f8631f088aa28868e9a5346713",
+      "parentRecordedHead": "56978ef81f873271bb9a36138879e0c617795e83",
+      "parentCurrentHead": "56978ef81f873271bb9a36138879e0c617795e83",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0b2f8207b",
+        "sha": "0b2f8207be1415f8631f088aa28868e9a5346713",
+        "iso": "2026-06-07T08:11:47-04:00",
+        "subject": "fix(mapgen): record current parity diagnostics Batch ResourceBuilder diagnostic reads for the current exact-authored final-surface proof and record terrain, feature, and resource classification artifacts for studio-run-in-game-mq3pfgbe-1doj. This is a diagnostic/proof-record slice only: final-surface parity, resource legality, and product acceptance remain unresolved until source authority is classified and repaired."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-current-source-authority-queue-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-current-diagnostics-classification-drain",
+      "children": [
+        "codex/swooper-resource-coordinate-proof-summary-drain"
+      ],
+      "depth": 59,
+      "head": "2d753db3d570e7e0e10d0895f4d299a1dc6703ea",
+      "parentRecordedHead": "0b2f8207be1415f8631f088aa28868e9a5346713",
+      "parentCurrentHead": "0b2f8207be1415f8631f088aa28868e9a5346713",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2d753db3d",
+        "sha": "2d753db3d570e7e0e10d0895f4d299a1dc6703ea",
+        "iso": "2026-06-07T08:17:53-04:00",
+        "subject": "docs(openspec): narrow current source authority queue Record the current exact-authored parity diagnostic synthesis for terrain, feature, and resource mismatches without closing final-surface parity or product acceptance. The next repair-proof queue is resource local-overacceptance/scarce-floor authority, local-only ecology-feature materialization, then terrain projection/readback ownership."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-resource-coordinate-proof-summary-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-current-source-authority-queue-drain",
+      "children": [
+        "codex/swooper-resource-coordinate-proof-rerun-record-drain"
+      ],
+      "depth": 60,
+      "head": "33cc555a661a4c9045481868fa77e1d694fc2696",
+      "parentRecordedHead": "2d753db3d570e7e0e10d0895f4d299a1dc6703ea",
+      "parentCurrentHead": "2d753db3d570e7e0e10d0895f4d299a1dc6703ea",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "33cc555a6",
+        "sha": "33cc555a661a4c9045481868fa77e1d694fc2696",
+        "iso": "2026-06-07T08:25:03-04:00",
+        "subject": "test(mapgen): summarize resource coordinate proof Expose the existing local-vs-exact resource coordinate proof comparison in final-surface parity artifacts, including local/exact digests and mismatched proof links. This keeps the resource coordinate gate behavior unchanged: parity remains unresolved when exact runtime materialization diverges from local proof, and this slice makes that boundary explicit for the current source-authority drain."
+      },
+      "accountingLabels": [
+        {
+          "role": "sink",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "adoption-sink",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounting-sink"
+    },
+    {
+      "branch": "codex/swooper-resource-coordinate-proof-rerun-record-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-coordinate-proof-summary-drain",
+      "children": [
+        "codex/swooper-product-closure-audit-record-drain"
+      ],
+      "depth": 61,
+      "head": "c1c860abe4a9998d96d78b4bc009ce03e00ba25a",
+      "parentRecordedHead": "33cc555a661a4c9045481868fa77e1d694fc2696",
+      "parentCurrentHead": "33cc555a661a4c9045481868fa77e1d694fc2696",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c1c860abe",
+        "sha": "c1c860abe4a9998d96d78b4bc009ce03e00ba25a",
+        "iso": "2026-06-07T08:27:41-04:00",
+        "subject": "docs(openspec): record resource coordinate proof rerun Record the refreshed studio-run-in-game-mq3pfgbe-1doj final-surface parity artifact after adding resourcePlacementCoordinateProof summary. The artifact is still unresolved and preserves the resource local-vs-exact coordinate mismatch as proof context, not product acceptance."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-product-closure-audit-record-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-coordinate-proof-rerun-record-drain",
+      "children": [
+        "codex/swooper-feature-apply-proof-telemetry-drain"
+      ],
+      "depth": 62,
+      "head": "05ed58969226f414fb1f166fab63174a97a3b7b6",
+      "parentRecordedHead": "c1c860abe4a9998d96d78b4bc009ce03e00ba25a",
+      "parentCurrentHead": "c1c860abe4a9998d96d78b4bc009ce03e00ba25a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "05ed58969",
+        "sha": "05ed58969226f414fb1f166fab63174a97a3b7b6",
+        "iso": "2026-06-07T08:30:57-04:00",
+        "subject": "docs(openspec): record current product closure audit Update swooper-recovery-stack-product-closure with the actual current top branch, clean Graphite snapshot, unresolved final-surface parity artifact, and review-ledger audit boundary. This is a closure-audit record only: product closure remains blocked on unresolved final-surface parity, product acceptance, final P1/P2 closure review, and PR/remote predecessor disposition."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-feature-apply-proof-telemetry-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-product-closure-audit-record-drain",
+      "children": [
+        "codex/swooper-current-feature-apply-proof-rerun-record-drain"
+      ],
+      "depth": 63,
+      "head": "a992eb243c407f33676de208ee11a8358ea3c3c1",
+      "parentRecordedHead": "05ed58969226f414fb1f166fab63174a97a3b7b6",
+      "parentCurrentHead": "05ed58969226f414fb1f166fab63174a97a3b7b6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a992eb243",
+        "sha": "a992eb243c407f33676de208ee11a8358ea3c3c1",
+        "iso": "2026-06-07T08:35:48-04:00",
+        "subject": "test(studio): parse feature apply telemetry Bind bounded FEATURE_APPLY_V1 telemetry into Studio exact-authorship proof packets for future Swooper runs, preserving attempted/applied/rejected counts and per-feature maps. This is proof instrumentation only: it does not change map generation, ecology tuning, current mq3pfgbe proof state, or product acceptance."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-current-feature-apply-proof-rerun-record-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-feature-apply-proof-telemetry-drain",
+      "children": [
+        "codex/swooper-resource-rejection-proof-telemetry-drain"
+      ],
+      "depth": 64,
+      "head": "4f1155771d7b2d36652cf0af0479cfe14290fb7e",
+      "parentRecordedHead": "a992eb243c407f33676de208ee11a8358ea3c3c1",
+      "parentCurrentHead": "a992eb243c407f33676de208ee11a8358ea3c3c1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4f1155771",
+        "sha": "4f1155771d7b2d36652cf0af0479cfe14290fb7e",
+        "iso": "2026-06-07T08:53:25-04:00",
+        "subject": "docs(openspec): record current feature apply proof rerun Record current exact-authored Studio run studio-run-in-game-mq3ryaop-1p7l after feature-apply telemetry parsing. The proof narrows feature materialization/source-authority work but keeps final-surface parity and product acceptance unresolved."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-resource-rejection-proof-telemetry-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-current-feature-apply-proof-rerun-record-drain",
+      "children": [
+        "codex/swooper-resource-rejection-proof-rerun-record-drain"
+      ],
+      "depth": 65,
+      "head": "96b94a13e4b7b7665b38c8b7c0701e253cfc8b38",
+      "parentRecordedHead": "4f1155771d7b2d36652cf0af0479cfe14290fb7e",
+      "parentCurrentHead": "4f1155771d7b2d36652cf0af0479cfe14290fb7e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "96b94a13e",
+        "sha": "96b94a13e4b7b7665b38c8b7c0701e253cfc8b38",
+        "iso": "2026-06-07T08:59:29-04:00",
+        "subject": "test(mapgen): expose resource rejection telemetry Add bounded RESOURCE_PLACEMENT_V1 rejection examples and parse aggregate resource placement stats into Studio exact-authorship proof packets. This is proof instrumentation for the next exact resource materialization classification; it does not change resource planning, scarce-floor assignment, tuning, final-surface parity, or product acceptance."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-resource-rejection-proof-rerun-record-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-rejection-proof-telemetry-drain",
+      "children": [
+        "codex/swooper-resource-rejection-proof-identity-drain"
+      ],
+      "depth": 66,
+      "head": "7d5e2bc2178f4ecc84bce5e80a25f21f2d8ec88e",
+      "parentRecordedHead": "96b94a13e4b7b7665b38c8b7c0701e253cfc8b38",
+      "parentCurrentHead": "96b94a13e4b7b7665b38c8b7c0701e253cfc8b38",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7d5e2bc21",
+        "sha": "7d5e2bc2178f4ecc84bce5e80a25f21f2d8ec88e",
+        "iso": "2026-06-07T09:08:51-04:00",
+        "subject": "docs(openspec): record resource rejection proof rerun Record exact Studio run studio-run-in-game-mq3sk0ck-1vl after resource rejection telemetry. The proof identifies the exact RESOURCE_WINE rejection row while preserving unresolved final-surface parity and product acceptance boundaries."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-resource-rejection-proof-identity-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-rejection-proof-rerun-record-drain",
+      "children": [
+        "codex/swooper-resource-rejection-identity-rerun-record-drain"
+      ],
+      "depth": 67,
+      "head": "7891fee11850543e9e06a21222d822853cb58ca0",
+      "parentRecordedHead": "7d5e2bc2178f4ecc84bce5e80a25f21f2d8ec88e",
+      "parentCurrentHead": "7d5e2bc2178f4ecc84bce5e80a25f21f2d8ec88e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7891fee11",
+        "sha": "7891fee11850543e9e06a21222d822853cb58ca0",
+        "iso": "2026-06-07T09:37:00-04:00",
+        "subject": "test(mapgen): identify resource rejection proof rows"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-resource-rejection-identity-rerun-record-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-rejection-proof-identity-drain",
+      "children": [
+        "codex/swooper-resource-rejection-assignment-context-drain"
+      ],
+      "depth": 68,
+      "head": "f8db43d7974df22d3d2f780e54e3d8cc856c0bf3",
+      "parentRecordedHead": "7891fee11850543e9e06a21222d822853cb58ca0",
+      "parentCurrentHead": "7891fee11850543e9e06a21222d822853cb58ca0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f8db43d79",
+        "sha": "f8db43d7974df22d3d2f780e54e3d8cc856c0bf3",
+        "iso": "2026-06-07T09:55:42-04:00",
+        "subject": "docs(openspec): record resource rejection identity proof rerun"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-resource-rejection-assignment-context-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-rejection-identity-rerun-record-drain",
+      "children": [
+        "codex/swooper-resource-rejection-assignment-context-rerun-record-drain"
+      ],
+      "depth": 69,
+      "head": "5843318ae1ea428fc23cd5a4028ab7e7276da5df",
+      "parentRecordedHead": "f8db43d7974df22d3d2f780e54e3d8cc856c0bf3",
+      "parentCurrentHead": "f8db43d7974df22d3d2f780e54e3d8cc856c0bf3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5843318ae",
+        "sha": "5843318ae1ea428fc23cd5a4028ab7e7276da5df",
+        "iso": "2026-06-07T10:09:20-04:00",
+        "subject": "test(mapgen): bind resource rejection assignment context"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-resource-rejection-assignment-context-rerun-record-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-rejection-assignment-context-drain",
+      "children": [
+        "codex/swooper-resource-rejection-local-context-drain"
+      ],
+      "depth": 70,
+      "head": "155d782fdbf870a70cfc14fea36442d5d2869176",
+      "parentRecordedHead": "5843318ae1ea428fc23cd5a4028ab7e7276da5df",
+      "parentCurrentHead": "5843318ae1ea428fc23cd5a4028ab7e7276da5df",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "155d782fd",
+        "sha": "155d782fdbf870a70cfc14fea36442d5d2869176",
+        "iso": "2026-06-07T10:25:54-04:00",
+        "subject": "docs(openspec): record resource assignment-context proof rerun"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-resource-rejection-local-context-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-rejection-assignment-context-rerun-record-drain",
+      "children": [
+        "codex/swooper-resource-delta-feasibility-current-record-drain"
+      ],
+      "depth": 71,
+      "head": "44d263b6e44155624c0cbfd090cfff8d80e0ed5d",
+      "parentRecordedHead": "155d782fdbf870a70cfc14fea36442d5d2869176",
+      "parentCurrentHead": "155d782fdbf870a70cfc14fea36442d5d2869176",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "44d263b6e",
+        "sha": "44d263b6e44155624c0cbfd090cfff8d80e0ed5d",
+        "iso": "2026-06-07T10:37:29-04:00",
+        "subject": "test(mapgen): join resource rejection local context"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-resource-delta-feasibility-current-record-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-rejection-local-context-drain",
+      "children": [
+        "codex/swooper-natural-wonder-supported-catalog-drain"
+      ],
+      "depth": 72,
+      "head": "ead47071661a6b75bc9c8f051b90dbcb0ad00a5f",
+      "parentRecordedHead": "44d263b6e44155624c0cbfd090cfff8d80e0ed5d",
+      "parentCurrentHead": "44d263b6e44155624c0cbfd090cfff8d80e0ed5d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ead470716",
+        "sha": "ead47071661a6b75bc9c8f051b90dbcb0ad00a5f",
+        "iso": "2026-06-07T10:47:43-04:00",
+        "subject": "docs(openspec): record current resource feasibility proof Record the mq3v6xr9 resource-delta feasibility verifier result after the exact/local resource rejection context join. This keeps the current source-authority evidence durable: resource deltas are dominated by scarce-floor assignment and stateful Civ materialization/readback behavior, while final parity and product acceptance remain explicitly open."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-natural-wonder-supported-catalog-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-resource-delta-feasibility-current-record-drain",
+      "children": [
+        "codex/swooper-natural-wonder-row-proof-drain"
+      ],
+      "depth": 73,
+      "head": "690a5ac7a48eae7d62a885a0b0ff5724f348a098",
+      "parentRecordedHead": "ead47071661a6b75bc9c8f051b90dbcb0ad00a5f",
+      "parentCurrentHead": "ead47071661a6b75bc9c8f051b90dbcb0ad00a5f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "690a5ac7a",
+        "sha": "690a5ac7a48eae7d62a885a0b0ff5724f348a098",
+        "iso": "2026-06-07T11:26:54-04:00",
+        "subject": "fix(mapgen): filter unsupported natural wonders Align the production Civ7 adapter with the shared @civ7/map-policy supported natural-wonder catalog and remove the stale manual catalog. Keep unsupported footprint policies out of placement inputs, make explicit empty footprint arrays non-plannable instead of falling back to a one-tile candidate, and realign the placement catalog verifier to the supported map-policy catalog. Fresh exact request studio-run-in-game-mq3x46sy-20js proves the unsupported-footprint natural-wonder class is gone from runtime telemetry: natural wonders now report 7 planned, 5 placed, and 2 readback-mismatch rejections. Final-surface parity remains unresolved and product acceptance is not claimed."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-natural-wonder-row-proof-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-natural-wonder-supported-catalog-drain",
+      "children": [
+        "codex/swooper-natural-wonder-plan-proof-drain"
+      ],
+      "depth": 74,
+      "head": "9f9deb4864b1e924cd7d4fc6dbf3a5925bf970be",
+      "parentRecordedHead": "690a5ac7a48eae7d62a885a0b0ff5724f348a098",
+      "parentCurrentHead": "690a5ac7a48eae7d62a885a0b0ff5724f348a098",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9f9deb486",
+        "sha": "9f9deb4864b1e924cd7d4fc6dbf3a5925bf970be",
+        "iso": "2026-06-07T11:58:26-04:00",
+        "subject": "test(mapgen): expose natural wonder rejected rows Add verbose natural-wonder coordinate rows to the placement artifact and compact rejected-row tuples to NATURAL_WONDER_PLACEMENT_V1 runtime telemetry, then expand those tuples into Studio exact-authorship coordinateRows. The compact log contract keeps the exact proof line under Civ's observed log cap while making the remaining natural-wonder rejected-row identity inspectable. Fresh exact request studio-run-in-game-mq3yo4uq-20js consumes the row contract and preserves the two remaining rejected rows: feature 30 at plot 4130 and feature 36 at plot 1785, both readback-mismatch / partial-expected-footprint. The matching parity artifact remains unresolved and shows local replay plans those feature types at plots 1342 and 2065, so the next natural-wonder owner decision is exact/local plan-input or engine-surface divergence before further behavior repair. This is proof plumbing only: it does not change natural-wonder planning, placement, readback disposition, final-surface parity, product acceptance, or resource/feature/terrain behavior. Validated with focused natural-wonder placement and Studio proof parser tests, owner package checks, strict OpenSpec validations for the recovery changes, full OpenSpec validation, git diff hygiene, a synthetic exact-style log line-length check of 892 characters, exact request studio-run-in-game-mq3yo4uq-20js, and final-surface verifier artifact proofHash 4abcfde0e6a242395611586e501d6b872b1943d6a3c45f6e09d38c8ffb430a46."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-natural-wonder-plan-proof-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-natural-wonder-row-proof-drain",
+      "children": [
+        "codex/swooper-natural-wonder-plan-comparison-drain"
+      ],
+      "depth": 75,
+      "head": "a3e797c1ee0db2bba98cba25170077de09bbad74",
+      "parentRecordedHead": "9f9deb4864b1e924cd7d4fc6dbf3a5925bf970be",
+      "parentCurrentHead": "9f9deb4864b1e924cd7d4fc6dbf3a5925bf970be",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a3e797c1e",
+        "sha": "a3e797c1ee0db2bba98cba25170077de09bbad74",
+        "iso": "2026-06-07T12:24:05-04:00",
+        "subject": "test(mapgen): expose natural wonder plan rows"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-natural-wonder-plan-comparison-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-natural-wonder-plan-proof-drain",
+      "children": [
+        "codex/swooper-natural-wonder-plan-input-context-drain"
+      ],
+      "depth": 76,
+      "head": "a6c2461b018898c98d2f3625a413059b08a0cd88",
+      "parentRecordedHead": "a3e797c1ee0db2bba98cba25170077de09bbad74",
+      "parentCurrentHead": "a3e797c1ee0db2bba98cba25170077de09bbad74",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a6c2461b0",
+        "sha": "a6c2461b018898c98d2f3625a413059b08a0cd88",
+        "iso": "2026-06-07T12:40:09-04:00",
+        "subject": "test(mapgen): compare natural wonder plan proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-natural-wonder-plan-input-context-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-natural-wonder-plan-comparison-drain",
+      "children": [
+        "codex/swooper-natural-wonder-plan-input-comparison-drain"
+      ],
+      "depth": 77,
+      "head": "10280507db72a621d3efb00d4f3d6c7585a1ba58",
+      "parentRecordedHead": "a6c2461b018898c98d2f3625a413059b08a0cd88",
+      "parentCurrentHead": "a6c2461b018898c98d2f3625a413059b08a0cd88",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "10280507d",
+        "sha": "10280507db72a621d3efb00d4f3d6c7585a1ba58",
+        "iso": "2026-06-07T13:02:36-04:00",
+        "subject": "test(mapgen): expose natural wonder plan inputs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/swooper-natural-wonder-plan-input-comparison-drain",
+      "root": "codex/swooper-mapgen-recovery-drain",
+      "parent": "codex/swooper-natural-wonder-plan-input-context-drain",
+      "children": [],
+      "depth": 78,
+      "head": "3a544b5256a8fd2e6d9dc5fb7aa91adc9da5c838",
+      "parentRecordedHead": "10280507db72a621d3efb00d4f3d6c7585a1ba58",
+      "parentCurrentHead": "10280507db72a621d3efb00d4f3d6c7585a1ba58",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "worktree": {
+        "path": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain",
+        "branch": "codex/swooper-natural-wonder-plan-input-comparison-drain",
+        "head": "3a544b5256a8fd2e6d9dc5fb7aa91adc9da5c838",
+        "dirtyCount": 0,
+        "isMain": false,
+        "isDetached": false
+      },
+      "commit": {
+        "short": "3a544b525",
+        "sha": "3a544b5256a8fd2e6d9dc5fb7aa91adc9da5c838",
+        "iso": "2026-06-07T16:30:13-04:00",
+        "subject": "docs(graphite): compose branch accounting state"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/stack-lineage-audit-reference",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "main",
+      "children": [
+        "codex/stack-visualizer-ui-integration"
+      ],
+      "depth": 0,
+      "head": "be60913515d9fd157858316400e95851bbb71d8c",
+      "parentRecordedHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+      "parentCurrentHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "be6091351",
+        "sha": "be60913515d9fd157858316400e95851bbb71d8c",
+        "iso": "2026-06-06T23:59:53-04:00",
+        "subject": "docs(graphite): simplify accounting overlay model"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/stack-visualizer-ui-integration",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/stack-lineage-audit-reference",
+      "children": [
+        "codex/gt-stack-inspect-spec-alignment"
+      ],
+      "depth": 1,
+      "head": "c8c1a9b8df4890f8953ef36007fef2688c8c5496",
+      "parentRecordedHead": "be60913515d9fd157858316400e95851bbb71d8c",
+      "parentCurrentHead": "be60913515d9fd157858316400e95851bbb71d8c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c8c1a9b8d",
+        "sha": "c8c1a9b8df4890f8953ef36007fef2688c8c5496",
+        "iso": "2026-06-07T00:51:45-04:00",
+        "subject": "docs(graphite): integrate stack visualizer UI refinements"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-spec-alignment",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/stack-visualizer-ui-integration",
+      "children": [
+        "codex/gt-stack-inspect-visual-contract"
+      ],
+      "depth": 2,
+      "head": "77ee392f2fa7332e2a2bc7e6df889cfd7e25a137",
+      "parentRecordedHead": "c8c1a9b8df4890f8953ef36007fef2688c8c5496",
+      "parentCurrentHead": "c8c1a9b8df4890f8953ef36007fef2688c8c5496",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "77ee392f2",
+        "sha": "77ee392f2fa7332e2a2bc7e6df889cfd7e25a137",
+        "iso": "2026-06-07T01:42:09-04:00",
+        "subject": "docs(graphite): harden stack inspect spec alignment"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-visual-contract",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-spec-alignment",
+      "children": [
+        "codex/gt-stack-inspect-effect-service-core"
+      ],
+      "depth": 3,
+      "head": "736d7f4e4f5c87376dbe2a5810eb4af1469e090e",
+      "parentRecordedHead": "77ee392f2fa7332e2a2bc7e6df889cfd7e25a137",
+      "parentCurrentHead": "77ee392f2fa7332e2a2bc7e6df889cfd7e25a137",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "736d7f4e4",
+        "sha": "736d7f4e4f5c87376dbe2a5810eb4af1469e090e",
+        "iso": "2026-06-07T02:11:09-04:00",
+        "subject": "test(graphite): repair stack inspect contract boundary Classify the embedded stack-data fixture as raw source evidence, add a prepared topology fixture for mapped action state, and expand the legacy-label guard across root, leaf, node, and leaf disposition fields. Keep PR/range/patch diagnostics separate from sparse accounting move assertions and close the watcher correction with focused visual-contract verification."
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-effect-service-core",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-visual-contract",
+      "children": [
+        "codex/gt-stack-inspect-inspection-adapters"
+      ],
+      "depth": 4,
+      "head": "1e5ef687e2f07a4b9a5cc208eef3dbd93b569a19",
+      "parentRecordedHead": "736d7f4e4f5c87376dbe2a5810eb4af1469e090e",
+      "parentCurrentHead": "736d7f4e4f5c87376dbe2a5810eb4af1469e090e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1e5ef687e",
+        "sha": "1e5ef687e2f07a4b9a5cc208eef3dbd93b569a19",
+        "iso": "2026-06-07T02:21:17-04:00",
+        "subject": "feat(graphite): add stack inspect service core Add TypeBox service contracts, native effect-orpc expected error classes, read-only command policy descriptors, Effect service shells, fixture-mode guardrails, field ownership rules, and preparation helpers for sparse accounting overlays. Register tools/gt-stack-inspect as a workspace package, add the Bun release-age gate, and validate the service-core OpenSpec slice."
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-inspection-adapters",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-effect-service-core",
+      "children": [
+        "codex/gt-stack-inspect-effect-orpc-router"
+      ],
+      "depth": 5,
+      "head": "a1f22a064d099c1b3595e07195a8ae1834aa6f3b",
+      "parentRecordedHead": "1e5ef687e2f07a4b9a5cc208eef3dbd93b569a19",
+      "parentCurrentHead": "1e5ef687e2f07a4b9a5cc208eef3dbd93b569a19",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a1f22a064",
+        "sha": "a1f22a064d099c1b3595e07195a8ae1834aa6f3b",
+        "iso": "2026-06-07T02:34:39-04:00",
+        "subject": "fix(graphite): preserve gt command discovery Repair the stack-inspect command service so approved Graphite descriptors execute with a controlled executable search PATH while keeping descriptor env allowlists strict, shell disabled, and structured argv unchanged."
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-effect-orpc-router",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-inspection-adapters",
+      "children": [
+        "codex/gt-stack-inspect-live-event-stream"
+      ],
+      "depth": 6,
+      "head": "c70a96935232e9a0826aa6ca0df74d19da7e693b",
+      "parentRecordedHead": "a1f22a064d099c1b3595e07195a8ae1834aa6f3b",
+      "parentCurrentHead": "a1f22a064d099c1b3595e07195a8ae1834aa6f3b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c70a96935",
+        "sha": "c70a96935232e9a0826aa6ca0df74d19da7e693b",
+        "iso": "2026-06-07T02:39:27-04:00",
+        "subject": "feat(graphite): expose stack inspect orpc router Add the TypeBox-backed stack-inspect procedure contract matrix, effect-oRPC router, RPC handler/client factory, and no-network router tests over fake Effect service layers."
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-live-event-stream",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-effect-orpc-router",
+      "children": [
+        "codex/gt-stack-inspect-react-rpc-vite-shell"
+      ],
+      "depth": 7,
+      "head": "500bb3471cfcdbac7a17b9400a26a469707ca079",
+      "parentRecordedHead": "c70a96935232e9a0826aa6ca0df74d19da7e693b",
+      "parentCurrentHead": "c70a96935232e9a0826aa6ca0df74d19da7e693b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "500bb3471",
+        "sha": "500bb3471cfcdbac7a17b9400a26a469707ca079",
+        "iso": "2026-06-07T02:58:05-04:00",
+        "subject": "feat(graphite): add stack inspect live events Add the stack-inspect live-event contract, bounded EventBusService, read-only RepoWatchService facade, events.subscribe stream wiring, and client invalidation contract for later React slices."
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-react-rpc-vite-shell",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-live-event-stream",
+      "children": [
+        "codex/gt-stack-inspect-react-rpc-client-state"
+      ],
+      "depth": 8,
+      "head": "7214583afcee6898b3afa006b0d69f58a0f8df6f",
+      "parentRecordedHead": "500bb3471cfcdbac7a17b9400a26a469707ca079",
+      "parentCurrentHead": "500bb3471cfcdbac7a17b9400a26a469707ca079",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7214583af",
+        "sha": "7214583afcee6898b3afa006b0d69f58a0f8df6f",
+        "iso": "2026-06-07T03:12:50-04:00",
+        "subject": "feat(gt-stack-inspect): add React RPC Vite shell Add a toolkit-local React/Vite shell that mounts through RPCLink, oRPC TanStack Query, and React Query for prepared report loading plus live event subscription wiring. Keep the browser boundary typed and client-only: no server implementation imports, no raw Git/Graphite parsing, no @orpc/react, and no broad UI-library dependencies. Add shell rendering tests for loading, typed expected errors, defects, prepared reports, query identity, live-event modes, and import/dependency guards. Record dependency adoption evidence for the React shell, including minimumReleaseAge, frozen install, build/test/type/OpenSpec proof, an explicit Bun scanner unavailable deferral because this repo has no [install.security].scanner configured, and browser smoke evidence scoped to graceful NOT_FOUND rendering without claiming console-clean RPC integration."
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-react-rpc-client-state",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-react-rpc-vite-shell",
+      "children": [
+        "codex/gt-stack-inspect-react-topology-ui"
+      ],
+      "depth": 9,
+      "head": "62c37d99955d10965928cdd2a4b5defe51bc923f",
+      "parentRecordedHead": "7214583afcee6898b3afa006b0d69f58a0f8df6f",
+      "parentCurrentHead": "7214583afcee6898b3afa006b0d69f58a0f8df6f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "62c37d999",
+        "sha": "62c37d99955d10965928cdd2a4b5defe51bc923f",
+        "iso": "2026-06-07T03:16:14-04:00",
+        "subject": "feat(gt-stack-inspect): add React client view state Add a small Zustand vanilla store for view-local stack inspection interactions: search, filters, expansion, selection, focus, result status, and request metadata. Add prepared-topology selectors for visible nodes, counts, leaf jump context, and cached topology indexes without storing TanStack Query payloads or deriving server-owned recovery semantics in the client. Cover the state boundary with focused tests for filtering, leaf focus, large-fixture index caching, forbidden semantic derivation, and dependency/import scope. Record zustand dependency review under the existing Bun scanner deferral."
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-react-topology-ui",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-react-rpc-client-state",
+      "children": [
+        "codex/gt-stack-inspect-cross-repo-runner"
+      ],
+      "depth": 10,
+      "head": "2643eadbedf625fa9207308c0f33aee2c36d740e",
+      "parentRecordedHead": "62c37d99955d10965928cdd2a4b5defe51bc923f",
+      "parentCurrentHead": "62c37d99955d10965928cdd2a4b5defe51bc923f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2643eadbe",
+        "sha": "2643eadbedf625fa9207308c0f33aee2c36d740e",
+        "iso": "2026-06-07T03:35:19-04:00",
+        "subject": "feat(gt-stack-inspect): render React topology UI Add prepared-data React topology components for decision summary, keys, recovery heuristics, work-surface rows, filters, stack lanes, branch rows, source-labeled diagnostics, sparse accounting move pills, stale-anchor readouts, and leaf jump controls. Integrate the topology report into the prepared shell state and add an optional Vite dev RPC proxy for browser smoke against a real local oRPC handler without adding a client fixture bypass. Cover visual semantics and boundary rules with component tests, browser smoke proof, accessibility/focus checks, and OpenSpec task closure while keeping PR/patch diagnostics separate from sparse accounting moves. The browser smoke proof excludes the bare Vite favicon 404 resource noise from the application/RPC console-clean claim."
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-cross-repo-runner",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-react-topology-ui",
+      "children": [
+        "codex/gt-stack-inspect-react-parity-workstreams"
+      ],
+      "depth": 11,
+      "head": "76f02ff13a56c24af05fa38b5d4d37238d8f66f1",
+      "parentRecordedHead": "2643eadbedf625fa9207308c0f33aee2c36d740e",
+      "parentCurrentHead": "2643eadbedf625fa9207308c0f33aee2c36d740e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "76f02ff13",
+        "sha": "76f02ff13a56c24af05fa38b5d4d37238d8f66f1",
+        "iso": "2026-06-07T14:02:25-04:00",
+        "subject": "feat(gt-stack-inspect): add cross-repo runner"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-react-parity-workstreams",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-cross-repo-runner",
+      "children": [
+        "codex/gt-stack-inspect-react-parity-proof-rebaseline"
+      ],
+      "depth": 12,
+      "head": "4cfd8c19323062a9061ab12e855c10e11a6ada93",
+      "parentRecordedHead": "76f02ff13a56c24af05fa38b5d4d37238d8f66f1",
+      "parentCurrentHead": "76f02ff13a56c24af05fa38b5d4d37238d8f66f1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4cfd8c193",
+        "sha": "4cfd8c19323062a9061ab12e855c10e11a6ada93",
+        "iso": "2026-06-07T14:45:45-04:00",
+        "subject": "feat(gt-stack-inspect): load recovery accounting ledgers"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-react-parity-proof-rebaseline",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-react-parity-workstreams",
+      "children": [
+        "codex/gt-stack-inspect-react-parity-contract"
+      ],
+      "depth": 13,
+      "head": "b4c163616deb32d91102a58bb819e55b086b1d59",
+      "parentRecordedHead": "4cfd8c19323062a9061ab12e855c10e11a6ada93",
+      "parentCurrentHead": "4cfd8c19323062a9061ab12e855c10e11a6ada93",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b4c163616",
+        "sha": "b4c163616deb32d91102a58bb819e55b086b1d59",
+        "iso": "2026-06-07T14:59:02-04:00",
+        "subject": "docs(graphite): rebaseline stack inspect parity proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-react-parity-contract",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-react-parity-proof-rebaseline",
+      "children": [
+        "codex/gt-stack-inspect-react-parity-router-logic"
+      ],
+      "depth": 14,
+      "head": "a1832d75b78ad0ca0200517135b066fad89cbf44",
+      "parentRecordedHead": "b4c163616deb32d91102a58bb819e55b086b1d59",
+      "parentCurrentHead": "b4c163616deb32d91102a58bb819e55b086b1d59",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a1832d75b",
+        "sha": "a1832d75b78ad0ca0200517135b066fad89cbf44",
+        "iso": "2026-06-07T15:16:42-04:00",
+        "subject": "feat(graphite): define stack inspect parity contract"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-react-parity-router-logic",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-react-parity-contract",
+      "children": [
+        "codex/gt-stack-inspect-react-parity-live-evidence"
+      ],
+      "depth": 15,
+      "head": "2f73bb59ccbcd063c7a1b26e81a11a18207d17ab",
+      "parentRecordedHead": "a1832d75b78ad0ca0200517135b066fad89cbf44",
+      "parentCurrentHead": "a1832d75b78ad0ca0200517135b066fad89cbf44",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2f73bb59c",
+        "sha": "2f73bb59ccbcd063c7a1b26e81a11a18207d17ab",
+        "iso": "2026-06-07T15:27:52-04:00",
+        "subject": "feat(graphite): bind stack inspect parity router"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-react-parity-live-evidence",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-react-parity-router-logic",
+      "children": [
+        "codex/gt-stack-inspect-react-parity-ui-sections"
+      ],
+      "depth": 16,
+      "head": "55f350e438246eb1422dd42e75292670cfe05396",
+      "parentRecordedHead": "2f73bb59ccbcd063c7a1b26e81a11a18207d17ab",
+      "parentCurrentHead": "2f73bb59ccbcd063c7a1b26e81a11a18207d17ab",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "55f350e43",
+        "sha": "55f350e438246eb1422dd42e75292670cfe05396",
+        "iso": "2026-06-07T15:38:40-04:00",
+        "subject": "feat(graphite): enrich stack inspect live evidence"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-react-parity-ui-sections",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-react-parity-live-evidence",
+      "children": [
+        "codex/gt-stack-inspect-react-parity-interactions"
+      ],
+      "depth": 17,
+      "head": "6b46f7042417848546306f9a7995682c7781c71b",
+      "parentRecordedHead": "55f350e438246eb1422dd42e75292670cfe05396",
+      "parentCurrentHead": "55f350e438246eb1422dd42e75292670cfe05396",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6b46f7042",
+        "sha": "6b46f7042417848546306f9a7995682c7781c71b",
+        "iso": "2026-06-07T16:13:19-04:00",
+        "subject": "feat(graphite): render stack inspect parity sections Render the React stack-inspect decision surface from prepared TypeBox DTOs: capture/sidebar, recovery status, work surface, accounting notes, Graphite tracking, accounting actions, action map, stack lanes, parent tree, and worktree occupancy. Keep React inside the display boundary by avoiding PR/accounting/stale reconciliation joins and preserving interaction/browser/runtime proof obligations for downstream slices. Verify with toolkit tests, typecheck, Vite build, focused OpenSpec validation, full OpenSpec validation, and diff whitespace checks."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/gt-stack-inspect-react-parity-interactions",
+      "root": "codex/stack-lineage-audit-reference",
+      "parent": "codex/gt-stack-inspect-react-parity-ui-sections",
+      "children": [],
+      "depth": 18,
+      "head": "6b46f7042417848546306f9a7995682c7781c71b",
+      "parentRecordedHead": "6b46f7042417848546306f9a7995682c7781c71b",
+      "parentCurrentHead": "6b46f7042417848546306f9a7995682c7781c71b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "worktree": {
+        "path": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-stack-lineage-audit-reference",
+        "branch": "codex/gt-stack-inspect-react-parity-interactions",
+        "head": "6b46f7042417848546306f9a7995682c7781c71b",
+        "dirtyCount": 12,
+        "isMain": false,
+        "isDetached": false
+      },
+      "commit": {
+        "short": "6b46f7042",
+        "sha": "6b46f7042417848546306f9a7995682c7781c71b",
+        "iso": "2026-06-07T16:13:19-04:00",
+        "subject": "feat(graphite): render stack inspect parity sections Render the React stack-inspect decision surface from prepared TypeBox DTOs: capture/sidebar, recovery status, work surface, accounting notes, Graphite tracking, accounting actions, action map, stack lanes, parent tree, and worktree occupancy. Keep React inside the display boundary by avoiding PR/accounting/stale reconciliation joins and preserving interaction/browser/runtime proof obligations for downstream slices. Verify with toolkit tests, typecheck, Vite build, focused OpenSpec validation, full OpenSpec validation, and diff whitespace checks."
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/live-play-settlement-reference",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "main",
+      "children": [
+        "codex/unit-movement-api-investigation"
+      ],
+      "depth": 0,
+      "head": "754f90431964aaac4e266a483012b4711b2f6198",
+      "parentRecordedHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+      "parentCurrentHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "754f90431",
+        "sha": "754f90431964aaac4e266a483012b4711b2f6198",
+        "iso": "2026-06-01T14:01:00-04:00",
+        "subject": "docs(graphite): prepare live-play settlement reference"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-civ7-intelligence-and-control-doc-train",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Control/intelligence documentation and live-play setup branches are outside the Swooper mapgen recovery accounting. They are not source work to adopt into the recovery stack."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/unit-movement-api-investigation",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/live-play-settlement-reference",
+      "children": [
+        "codex/play-agent-output-contract"
+      ],
+      "depth": 1,
+      "head": "af05f5e8484441e6988a1e5544b94e02da15a43f",
+      "parentRecordedHead": "754f90431964aaac4e266a483012b4711b2f6198",
+      "parentCurrentHead": "754f90431964aaac4e266a483012b4711b2f6198",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "af05f5e84",
+        "sha": "af05f5e8484441e6988a1e5544b94e02da15a43f",
+        "iso": "2026-06-01T19:24:24-04:00",
+        "subject": "docs(direct-control): record unit movement API findings"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-civ7-intelligence-and-control-doc-train",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Control/intelligence documentation and live-play setup branches are outside the Swooper mapgen recovery accounting. They are not source work to adopt into the recovery stack."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/play-agent-output-contract",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/unit-movement-api-investigation",
+      "children": [
+        "codex/civ7-orpc-control-architecture-skill"
+      ],
+      "depth": 2,
+      "head": "2c5a743faddb0f15d255680531bc84e8942ac32d",
+      "parentRecordedHead": "af05f5e8484441e6988a1e5544b94e02da15a43f",
+      "parentCurrentHead": "af05f5e8484441e6988a1e5544b94e02da15a43f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2c5a743fa",
+        "sha": "2c5a743faddb0f15d255680531bc84e8942ac32d",
+        "iso": "2026-06-01T22:59:10-04:00",
+        "subject": "docs(civ7): persist play-agent session strategy notes"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-civ7-intelligence-and-control-doc-train",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Control/intelligence documentation and live-play setup branches are outside the Swooper mapgen recovery accounting. They are not source work to adopt into the recovery stack."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/civ7-orpc-control-architecture-skill",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/play-agent-output-contract",
+      "children": [
+        "codex/consolidate-play-agent-docs",
+        "codex/play-agent-hotseat-phase-packet"
+      ],
+      "depth": 3,
+      "head": "d3d49b48fbbb541c0fc6ff273014f86cf84af10d",
+      "parentRecordedHead": "2c5a743faddb0f15d255680531bc84e8942ac32d",
+      "parentCurrentHead": "2c5a743faddb0f15d255680531bc84e8942ac32d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d3d49b48f",
+        "sha": "d3d49b48fbbb541c0fc6ff273014f86cf84af10d",
+        "iso": "2026-06-02T06:02:55-04:00",
+        "subject": "Add effect-orpc direct-control procedures"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/consolidate-play-agent-docs",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/civ7-orpc-control-architecture-skill",
+      "children": [
+        "codex/frame-civ7-intelligence-layer"
+      ],
+      "depth": 4,
+      "head": "c965762044039b7e8f52ee651a9326648660c23b",
+      "parentRecordedHead": "d3d49b48fbbb541c0fc6ff273014f86cf84af10d",
+      "parentCurrentHead": "d3d49b48fbbb541c0fc6ff273014f86cf84af10d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c96576204",
+        "sha": "c965762044039b7e8f52ee651a9326648660c23b",
+        "iso": "2026-06-02T19:09:46-04:00",
+        "subject": "docs(direct-control): consolidate play-agent workstream docs"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-civ7-intelligence-and-control-doc-train",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Control/intelligence documentation and live-play setup branches are outside the Swooper mapgen recovery accounting. They are not source work to adopt into the recovery stack."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/frame-civ7-intelligence-layer",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/consolidate-play-agent-docs",
+      "children": [
+        "codex/shape-civ7-intelligence-solution"
+      ],
+      "depth": 5,
+      "head": "251ce6f4db1db8107897d4bd2641bf04a6c455c2",
+      "parentRecordedHead": "c965762044039b7e8f52ee651a9326648660c23b",
+      "parentCurrentHead": "c965762044039b7e8f52ee651a9326648660c23b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "251ce6f4d",
+        "sha": "251ce6f4db1db8107897d4bd2641bf04a6c455c2",
+        "iso": "2026-06-02T23:17:19-04:00",
+        "subject": "docs(civ7): frame intelligence layer workstream"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-civ7-intelligence-and-control-doc-train",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Control/intelligence documentation and live-play setup branches are outside the Swooper mapgen recovery accounting. They are not source work to adopt into the recovery stack."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/shape-civ7-intelligence-solution",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/frame-civ7-intelligence-layer",
+      "children": [
+        "codex/investigate-civ7-intelligence-threads"
+      ],
+      "depth": 6,
+      "head": "9c3f87b3a4283c670aec1e3aa996c5c141237d9b",
+      "parentRecordedHead": "251ce6f4db1db8107897d4bd2641bf04a6c455c2",
+      "parentCurrentHead": "251ce6f4db1db8107897d4bd2641bf04a6c455c2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9c3f87b3a",
+        "sha": "9c3f87b3a4283c670aec1e3aa996c5c141237d9b",
+        "iso": "2026-06-03T00:01:02-04:00",
+        "subject": "docs(civ7): refine intelligence solution frame"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-civ7-intelligence-and-control-doc-train",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Control/intelligence documentation and live-play setup branches are outside the Swooper mapgen recovery accounting. They are not source work to adopt into the recovery stack."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/investigate-civ7-intelligence-threads",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/shape-civ7-intelligence-solution",
+      "children": [
+        "codex/start-placement-viability"
+      ],
+      "depth": 7,
+      "head": "0ef887b0b52d24cae97283ff55fbd252f0efe0b4",
+      "parentRecordedHead": "9c3f87b3a4283c670aec1e3aa996c5c141237d9b",
+      "parentCurrentHead": "9c3f87b3a4283c670aec1e3aa996c5c141237d9b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0ef887b0b",
+        "sha": "0ef887b0b52d24cae97283ff55fbd252f0efe0b4",
+        "iso": "2026-06-03T17:50:39-04:00",
+        "subject": "docs(civ7): update controller bridge handoff metadata"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-exclude-civ7-intelligence-and-control-doc-train",
+          "state": "done",
+          "kind": "exclude",
+          "sourceKind": "stack-slice",
+          "label": "excluded",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Control/intelligence documentation and live-play setup branches are outside the Swooper mapgen recovery accounting. They are not source work to adopt into the recovery stack."
+        }
+      ],
+      "accountingSummary": "excluded"
+    },
+    {
+      "branch": "codex/start-placement-viability",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/investigate-civ7-intelligence-threads",
+      "children": [
+        "codex/resource-initial-map-policy"
+      ],
+      "depth": 8,
+      "head": "4cb03e3943a6db93492875930c3f6afda6a17057",
+      "parentRecordedHead": "0ef887b0b52d24cae97283ff55fbd252f0efe0b4",
+      "parentCurrentHead": "0ef887b0b52d24cae97283ff55fbd252f0efe0b4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4cb03e394",
+        "sha": "4cb03e3943a6db93492875930c3f6afda6a17057",
+        "iso": "2026-06-04T02:41:24-04:00",
+        "subject": "fix(mapgen): plan starts by expansion viability"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-start-placement-and-initial-resource-policy",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Start expansion viability and initial age-gated resource policy were replayed into the recovery base."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/resource-initial-map-policy",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/start-placement-viability",
+      "children": [
+        "codex/studio-setup-config-sync"
+      ],
+      "depth": 9,
+      "head": "c4e3e3ee81ce16bc9bea58e4ab2627c160a936d7",
+      "parentRecordedHead": "4cb03e3943a6db93492875930c3f6afda6a17057",
+      "parentCurrentHead": "4cb03e3943a6db93492875930c3f6afda6a17057",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c4e3e3ee8",
+        "sha": "c4e3e3ee81ce16bc9bea58e4ab2627c160a936d7",
+        "iso": "2026-06-04T03:12:39-04:00",
+        "subject": "fix(mapgen): gate initial resource authoring by age"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-start-placement-and-initial-resource-policy",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Start expansion viability and initial age-gated resource policy were replayed into the recovery base."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/studio-setup-config-sync",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/resource-initial-map-policy",
+      "children": [
+        "06-05-fix_studio_validate_civ7_setup_seeds"
+      ],
+      "depth": 10,
+      "head": "bbd313378ec13fda4dd324e0a74a4f13b7596d40",
+      "parentRecordedHead": "c4e3e3ee81ce16bc9bea58e4ab2627c160a936d7",
+      "parentCurrentHead": "c4e3e3ee81ce16bc9bea58e4ab2627c160a936d7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bbd313378",
+        "sha": "bbd313378ec13fda4dd324e0a74a4f13b7596d40",
+        "iso": "2026-06-04T23:58:25-04:00",
+        "subject": "feat(studio): load Civ saved setup configs"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-studio-setup-config-sync",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Studio setup/config loading, setup seed validation, save/deploy/run-in-game sync, and adjacent Swooper recovery behavior were synthesized into the recovery base."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "06-05-fix_studio_validate_civ7_setup_seeds",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/studio-setup-config-sync",
+      "children": [
+        "codex/swooper-dra-takeover-handoff"
+      ],
+      "depth": 11,
+      "head": "58b8e35f5e357674e312c9744858362329df288f",
+      "parentRecordedHead": "bbd313378ec13fda4dd324e0a74a4f13b7596d40",
+      "parentCurrentHead": "bbd313378ec13fda4dd324e0a74a4f13b7596d40",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "58b8e35f5",
+        "sha": "58b8e35f5e357674e312c9744858362329df288f",
+        "iso": "2026-06-06T00:24:49-04:00",
+        "subject": "fix(mapgen): consolidate Swooper stack recovery Recover the missing semantic deltas from adjacent Swooper work without replaying stale branches wholesale: isolate transient Studio configs, restore the Earthlike range-system count baseline, add live mapgen log completion proof, align natural-wonder contract wording, and remove the unused build-elevation boundary policy export. Record the stack-recovery OpenSpec ledger, including branch/worktree dispositions and the current product-visible proof gaps for mountain-region shape, missing rivers, and Studio deploy/config identity. Rebaseline generated map and morphology fixture artifacts from source after the intentional Earthlike tuning change. Also record the local predecessor cleanup disposition: the stale Swooper Earthlike worktree and local Graphite branch were removed, while remote PR #1421 is kept only as a published fallback/reference until this replacement stack is submitted or merged. Verified with focused map-policy, map-elevation, natural-wonder, direct-control, config/schema, mountain-region, terrain-balance, package check/build, full OpenSpec validation gates, and cleanup topology checks."
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-studio-setup-config-sync",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Studio setup/config loading, setup seed validation, save/deploy/run-in-game sync, and adjacent Swooper recovery behavior were synthesized into the recovery base."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/swooper-dra-takeover-handoff",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "06-05-fix_studio_validate_civ7_setup_seeds",
+      "children": [
+        "codex/swooper-recovery-openspec-plan"
+      ],
+      "depth": 12,
+      "head": "70faecfd1d1c271fdc54c91b3e88a5d72cad2daa",
+      "parentRecordedHead": "58b8e35f5e357674e312c9744858362329df288f",
+      "parentCurrentHead": "58b8e35f5e357674e312c9744858362329df288f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "70faecfd1",
+        "sha": "70faecfd1d1c271fdc54c91b3e88a5d72cad2daa",
+        "iso": "2026-06-06T01:16:05-04:00",
+        "subject": "docs(graphite): visualize stack recovery topology"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-reference-swooper-recovery-planning-context",
+          "state": "done",
+          "kind": "reference",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "reference-consumed",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The recovery handoff and OpenSpec planning branches were consumed as planning/reference input for the Swooper recovery stack. They are not pending product branches."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/swooper-recovery-openspec-plan",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/swooper-dra-takeover-handoff",
+      "children": [
+        "codex/studio-live-runtime-snapshot-completion"
+      ],
+      "depth": 13,
+      "head": "26747873be074ad5d700c22b88fcfe1d5ce423c6",
+      "parentRecordedHead": "70faecfd1d1c271fdc54c91b3e88a5d72cad2daa",
+      "parentCurrentHead": "70faecfd1d1c271fdc54c91b3e88a5d72cad2daa",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "26747873b",
+        "sha": "26747873be074ad5d700c22b88fcfe1d5ce423c6",
+        "iso": "2026-06-06T01:17:03-04:00",
+        "subject": "docs(openspec): plan Swooper recovery workstreams Add the normative Swooper recovery takeover anchor and proof-led OpenSpec planning changes for live snapshot completion, exact authorship proof, final-surface parity, Earthlike acceptance, evidence-gated repair lanes, and product closure.\\n\\nKeep the first recovery goal at workstream creation only: implementation remains blocked until the relevant category goal and supervisor lane are started.\\n\\nVerification:\\n- bun run openspec:validate\\n- git diff --check\\n\\nNote: bun run lint:mapgen-docs was also run and failed on pre-existing docs/system/libs/mapgen/pipeline-visualization-deckgl.md missing anchor apps/mapgen-studio/src/features/dumpViewer/manifest.ts."
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-reference-swooper-recovery-planning-context",
+          "state": "done",
+          "kind": "reference",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "reference-consumed",
+          "cleanup": "not-cleanup-relevant",
+          "note": "The recovery handoff and OpenSpec planning branches were consumed as planning/reference input for the Swooper recovery stack. They are not pending product branches."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/studio-live-runtime-snapshot-completion",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/swooper-recovery-openspec-plan",
+      "children": [
+        "codex/studio-civ7-exact-authorship-proof"
+      ],
+      "depth": 14,
+      "head": "5fd0a81955d52568328555702ec88e99bb64e679",
+      "parentRecordedHead": "26747873be074ad5d700c22b88fcfe1d5ce423c6",
+      "parentCurrentHead": "26747873be074ad5d700c22b88fcfe1d5ce423c6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5fd0a8195",
+        "sha": "5fd0a81955d52568328555702ec88e99bb64e679",
+        "iso": "2026-06-06T01:45:46-04:00",
+        "subject": "fix(studio): key live runtime snapshots"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-studio-live-runtime-snapshot-completion",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "branch",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Live runtime snapshot completion is represented in the Studio parity proof drain and follow-up current exact-authorship proof branches."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/studio-civ7-exact-authorship-proof",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/studio-live-runtime-snapshot-completion",
+      "children": [
+        "codex/civ7-map-policy-final-surface-parity"
+      ],
+      "depth": 15,
+      "head": "8966aba5eb6fb3d2adf7edf38aa2bd0b8cde905f",
+      "parentRecordedHead": "5fd0a81955d52568328555702ec88e99bb64e679",
+      "parentCurrentHead": "5fd0a81955d52568328555702ec88e99bb64e679",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "worktree": {
+        "path": "/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools",
+        "branch": "codex/studio-civ7-exact-authorship-proof",
+        "head": "8966aba5eb6fb3d2adf7edf38aa2bd0b8cde905f",
+        "dirtyCount": 0,
+        "isMain": true,
+        "isDetached": false
+      },
+      "commit": {
+        "short": "8966aba5e",
+        "sha": "8966aba5eb6fb3d2adf7edf38aa2bd0b8cde905f",
+        "iso": "2026-06-06T02:37:14-04:00",
+        "subject": "fix(studio): prove exact run authorship"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-studio-exact-authorship-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "branch",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Studio exact-authorship parsing/proof behavior is represented in the Swooper Studio parity proof drain."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/civ7-map-policy-final-surface-parity",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/studio-civ7-exact-authorship-proof",
+      "children": [
+        "codex/earthlike-live-feature-resource-legality-repair"
+      ],
+      "depth": 16,
+      "head": "70a22c815bd8918febe2750043e4db920cf2bcb6",
+      "parentRecordedHead": "8966aba5eb6fb3d2adf7edf38aa2bd0b8cde905f",
+      "parentCurrentHead": "8966aba5eb6fb3d2adf7edf38aa2bd0b8cde905f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "70a22c815",
+        "sha": "70a22c815bd8918febe2750043e4db920cf2bcb6",
+        "iso": "2026-06-06T04:02:54-04:00",
+        "subject": "docs(openspec): route parity proof deltas"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-map-policy-final-surface-parity",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "branch",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Final-surface parity proof path and routing records are represented in the Swooper Studio parity proof drain and later current parity record branches."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-live-feature-resource-legality-repair",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/civ7-map-policy-final-surface-parity",
+      "children": [
+        "codex/earthlike-adjacent-land-rerun-record"
+      ],
+      "depth": 17,
+      "head": "e67fd07ef0bee273f7822aba8ed84ad6c30763ac",
+      "parentRecordedHead": "70a22c815bd8918febe2750043e4db920cf2bcb6",
+      "parentCurrentHead": "70a22c815bd8918febe2750043e4db920cf2bcb6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e67fd07ef",
+        "sha": "e67fd07ef0bee273f7822aba8ed84ad6c30763ac",
+        "iso": "2026-06-06T05:41:51-04:00",
+        "subject": "fix(civ7): align adjacent-land resource policy"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-adjacent-land-rerun-record",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-live-feature-resource-legality-repair",
+      "children": [
+        "codex/earthlike-resource-assignment-evidence"
+      ],
+      "depth": 18,
+      "head": "9a7110db62429770254e51ada484d40a1fe35844",
+      "parentRecordedHead": "e67fd07ef0bee273f7822aba8ed84ad6c30763ac",
+      "parentCurrentHead": "e67fd07ef0bee273f7822aba8ed84ad6c30763ac",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9a7110db6",
+        "sha": "9a7110db62429770254e51ada484d40a1fe35844",
+        "iso": "2026-06-06T05:49:53-04:00",
+        "subject": "docs(openspec): record adjacent-land parity rerun"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-assignment-evidence",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-adjacent-land-rerun-record",
+      "children": [
+        "codex/earthlike-resource-feasibility-readback"
+      ],
+      "depth": 19,
+      "head": "f8368a08f7eda6b122e5f7225e422a893c10577c",
+      "parentRecordedHead": "9a7110db62429770254e51ada484d40a1fe35844",
+      "parentCurrentHead": "9a7110db62429770254e51ada484d40a1fe35844",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f8368a08f",
+        "sha": "f8368a08f7eda6b122e5f7225e422a893c10577c",
+        "iso": "2026-06-06T05:57:21-04:00",
+        "subject": "test(mapgen): expose resource delta assignment evidence"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-feasibility-readback",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-assignment-evidence",
+      "children": [
+        "codex/earthlike-resource-feasibility-classification"
+      ],
+      "depth": 20,
+      "head": "d0091d86d8bd1faf73e9aa769b1504d408c99b36",
+      "parentRecordedHead": "f8368a08f7eda6b122e5f7225e422a893c10577c",
+      "parentCurrentHead": "f8368a08f7eda6b122e5f7225e422a893c10577c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d0091d86d",
+        "sha": "d0091d86d8bd1faf73e9aa769b1504d408c99b36",
+        "iso": "2026-06-06T06:07:51-04:00",
+        "subject": "feat(civ7): add resource feasibility readback Add a package-owned direct-control ResourceBuilder.canHaveResource read wrapper for bounded resource placement feasibility checks, with coverage for bounded inputs and tuner command construction. Record the exact-authored studio-run-in-game-mq20rbzr-1fhc feasibility artifact for 106 resource delta cells: strict ignoreWeight:false is preserved as non-authoritative post-materialization evidence, while ignoreWeight:true separates assignment/rebalance divergence from the 9-row local-overacceptance investigation class. The single both-infeasible substitution row remains unresolved with no repair authority until row-level ownership is classified. This layer does not claim final-surface parity, Earthlike tuning quality, product acceptance, or generated-output authority. Verification: bun test packages/civ7-direct-control/test/direct-control.test.ts --test-name-pattern 'resource placement feasibility'; bun run --cwd packages/civ7-direct-control check; bun run --cwd packages/civ7-direct-control test -- direct-control; bun run --cwd packages/civ7-direct-control build; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-feasibility-classification",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-feasibility-readback",
+      "children": [
+        "codex/earthlike-resource-feasibility-artifact"
+      ],
+      "depth": 21,
+      "head": "977fe8a8bc59cbe9a34cfe397110e03988b6cc6c",
+      "parentRecordedHead": "d0091d86d8bd1faf73e9aa769b1504d408c99b36",
+      "parentCurrentHead": "d0091d86d8bd1faf73e9aa769b1504d408c99b36",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "977fe8a8b",
+        "sha": "977fe8a8bc59cbe9a34cfe397110e03988b6cc6c",
+        "iso": "2026-06-06T06:13:08-04:00",
+        "subject": "test(mapgen): classify resource feasibility deltas Add a pure Swooper diagnostic helper that joins local resource delta placement evidence to a provided Civ resource feasibility readback. The helper preserves separate classes for live-feasible assignment gaps, local-feasible live-empty rows, local-overaccepted live-empty rows, both-feasible substitutions, and the individual both-infeasible substitution case. Update the earthlike-live-feature-resource-legality-repair records to keep the 9-row mock/static-policy investigation separate from the single both-infeasible substitution row. This is source-authority classification support only; it does not change resource generation, static policy, tuning, generated output, parity status, or product acceptance. Verification: bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-feasibility-artifact",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-feasibility-classification",
+      "children": [
+        "codex/earthlike-resource-feasibility-row-context"
+      ],
+      "depth": 22,
+      "head": "efce0b82bb3740f0dbbf039c505c727435306c58",
+      "parentRecordedHead": "977fe8a8bc59cbe9a34cfe397110e03988b6cc6c",
+      "parentCurrentHead": "977fe8a8bc59cbe9a34cfe397110e03988b6cc6c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "efce0b82b",
+        "sha": "efce0b82bb3740f0dbbf039c505c727435306c58",
+        "iso": "2026-06-06T06:20:11-04:00",
+        "subject": "feat(civ7): verify resource delta feasibility Add a resource-delta feasibility verifier that reads a saved final-surface parity proof, binds the current live runtime through package-owned map summary identity, and only then probes the delta cells through ResourceBuilder.canHaveResource. Missing or mismatched width, height, plot count, seed, turn, or game hash produces a blocked artifact before feasibility rows are accepted. Record the runtime-bound studio-run-in-game-mq20rbzr-1fhc artifact and its row classes for the earthlike-live-feature-resource-legality-repair lane. The loose feasibility split remains 37 live-feasible/no-local-assignment, 28 local-feasible/live-empty, 9 local-overaccepted/live-empty, 31 substitution-both-feasible, and 1 substitution-both-infeasible. The single both-infeasible substitution row remains outside repair authority. This layer is read-only proof tooling and records only. It does not change resource generation, static policy, tuning, generated output, final-surface parity status, Earthlike quality, or product acceptance. Verification: bun run verify:resource-delta-feasibility -- --help; bun run verify:resource-delta-feasibility -- --proof-file /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-assignment-evidence.json --host 127.0.0.1 --port 4318 --output /tmp/civ7-recovery-proof/final-surface-parity/studio-run-in-game-mq20rbzr-1fhc-resource-delta-feasibility-full.json; bun test mods/mod-swooper-maps/test/diagnostics/surface-delta-context.test.ts mods/mod-swooper-maps/test/diagnostics/live-parity.test.ts; bun run --cwd mods/mod-swooper-maps check; bun run --cwd packages/civ7-direct-control check; bun run openspec -- validate earthlike-live-feature-resource-legality-repair --strict; bun run openspec:validate; git diff --check"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-feasibility-row-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-feasibility-artifact",
+      "children": [
+        "codex/earthlike-resource-policy-spacing-context"
+      ],
+      "depth": 23,
+      "head": "fcdbeb8022f18ad5f464a6668843fc37af0b7d45",
+      "parentRecordedHead": "efce0b82bb3740f0dbbf039c505c727435306c58",
+      "parentCurrentHead": "efce0b82bb3740f0dbbf039c505c727435306c58",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fcdbeb802",
+        "sha": "fcdbeb8022f18ad5f464a6668843fc37af0b7d45",
+        "iso": "2026-06-06T06:30:24-04:00",
+        "subject": "test(mapgen): bind resource feasibility row context"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-policy-spacing-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-feasibility-row-context",
+      "children": [
+        "codex/earthlike-resource-live-plot-context"
+      ],
+      "depth": 24,
+      "head": "0e5b89ede52f4be3d7ad472df8e81834d9052dbc",
+      "parentRecordedHead": "fcdbeb8022f18ad5f464a6668843fc37af0b7d45",
+      "parentCurrentHead": "fcdbeb8022f18ad5f464a6668843fc37af0b7d45",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0e5b89ede",
+        "sha": "0e5b89ede52f4be3d7ad472df8e81834d9052dbc",
+        "iso": "2026-06-06T06:38:16-04:00",
+        "subject": "test(mapgen): expose resource policy spacing context"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-live-plot-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-policy-spacing-context",
+      "children": [
+        "codex/earthlike-resource-assignment-trace"
+      ],
+      "depth": 25,
+      "head": "c3230f1cd55192cedf9ef0b29dc995c5558af3cb",
+      "parentRecordedHead": "0e5b89ede52f4be3d7ad472df8e81834d9052dbc",
+      "parentCurrentHead": "0e5b89ede52f4be3d7ad472df8e81834d9052dbc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c3230f1cd",
+        "sha": "c3230f1cd55192cedf9ef0b29dc995c5558af3cb",
+        "iso": "2026-06-06T06:43:10-04:00",
+        "subject": "test(civ7): bind resource deltas to live plot context"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-assignment-trace",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-live-plot-context",
+      "children": [
+        "codex/earthlike-resource-builder-diagnostics"
+      ],
+      "depth": 26,
+      "head": "68f75976fa6c684f5ba3db6b2e47a55affe013f5",
+      "parentRecordedHead": "c3230f1cd55192cedf9ef0b29dc995c5558af3cb",
+      "parentCurrentHead": "c3230f1cd55192cedf9ef0b29dc995c5558af3cb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "68f75976f",
+        "sha": "68f75976fa6c684f5ba3db6b2e47a55affe013f5",
+        "iso": "2026-06-06T06:56:04-04:00",
+        "subject": "test(mapgen): trace resource assignment deltas"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-builder-diagnostics",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-assignment-trace",
+      "children": [
+        "codex/earthlike-resource-assignment-order-context"
+      ],
+      "depth": 27,
+      "head": "ba587053435cad8f55355399b0f5e05d4b580721",
+      "parentRecordedHead": "68f75976fa6c684f5ba3db6b2e47a55affe013f5",
+      "parentCurrentHead": "68f75976fa6c684f5ba3db6b2e47a55affe013f5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ba5870534",
+        "sha": "ba587053435cad8f55355399b0f5e05d4b580721",
+        "iso": "2026-06-06T07:07:05-04:00",
+        "subject": "test(civ7): read ResourceBuilder cut diagnostics"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-assignment-order-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-builder-diagnostics",
+      "children": [
+        "codex/earthlike-resource-builder-subclassification"
+      ],
+      "depth": 28,
+      "head": "5636b12971b6adf4d942450af40fd6dbe81a573a",
+      "parentRecordedHead": "ba587053435cad8f55355399b0f5e05d4b580721",
+      "parentCurrentHead": "ba587053435cad8f55355399b0f5e05d4b580721",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5636b1297",
+        "sha": "5636b12971b6adf4d942450af40fd6dbe81a573a",
+        "iso": "2026-06-06T07:13:27-04:00",
+        "subject": "test(mapgen): trace resource assignment order"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-builder-subclassification",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-assignment-order-context",
+      "children": [
+        "codex/earthlike-resource-builder-policy-context"
+      ],
+      "depth": 29,
+      "head": "7e20f5c866789ac3711be4b2a2130141b658d505",
+      "parentRecordedHead": "5636b12971b6adf4d942450af40fd6dbe81a573a",
+      "parentCurrentHead": "5636b12971b6adf4d942450af40fd6dbe81a573a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7e20f5c86",
+        "sha": "7e20f5c866789ac3711be4b2a2130141b658d505",
+        "iso": "2026-06-06T07:21:47-04:00",
+        "subject": "test(civ7): classify resource builder cuts"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-builder-policy-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-builder-subclassification",
+      "children": [
+        "codex/earthlike-resource-assignment-class-summary"
+      ],
+      "depth": 30,
+      "head": "9f800479916133c9d20fe8cb8563ca5137e627b0",
+      "parentRecordedHead": "7e20f5c866789ac3711be4b2a2130141b658d505",
+      "parentCurrentHead": "7e20f5c866789ac3711be4b2a2130141b658d505",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9f8004799",
+        "sha": "9f800479916133c9d20fe8cb8563ca5137e627b0",
+        "iso": "2026-06-06T07:27:21-04:00",
+        "subject": "test(civ7): record resource builder policy context"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-assignment-class-summary",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-builder-policy-context",
+      "children": [
+        "codex/earthlike-resource-distribution-context"
+      ],
+      "depth": 31,
+      "head": "54f07a365e0dcafa676fbbad5abb2133a5035e24",
+      "parentRecordedHead": "9f800479916133c9d20fe8cb8563ca5137e627b0",
+      "parentCurrentHead": "9f800479916133c9d20fe8cb8563ca5137e627b0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "54f07a365",
+        "sha": "54f07a365e0dcafa676fbbad5abb2133a5035e24",
+        "iso": "2026-06-06T07:34:47-04:00",
+        "subject": "test(civ7): summarize resource assignment classes"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-distribution-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-assignment-class-summary",
+      "children": [
+        "codex/earthlike-resource-position-context"
+      ],
+      "depth": 32,
+      "head": "22a8980bd906af3c569aef61c3ce8d5e23367fd1",
+      "parentRecordedHead": "54f07a365e0dcafa676fbbad5abb2133a5035e24",
+      "parentCurrentHead": "54f07a365e0dcafa676fbbad5abb2133a5035e24",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "22a8980bd",
+        "sha": "22a8980bd906af3c569aef61c3ce8d5e23367fd1",
+        "iso": "2026-06-06T07:44:36-04:00",
+        "subject": "test(civ7): summarize resource distribution context"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-position-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-distribution-context",
+      "children": [
+        "codex/earthlike-resource-local-materialization-context"
+      ],
+      "depth": 33,
+      "head": "6b976a4172df0462bfafac8335545dc711b20c6c",
+      "parentRecordedHead": "22a8980bd906af3c569aef61c3ce8d5e23367fd1",
+      "parentCurrentHead": "22a8980bd906af3c569aef61c3ce8d5e23367fd1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6b976a417",
+        "sha": "6b976a4172df0462bfafac8335545dc711b20c6c",
+        "iso": "2026-06-06T07:50:06-04:00",
+        "subject": "test(civ7): summarize resource position context"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-local-materialization-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-position-context",
+      "children": [
+        "codex/earthlike-resource-placement-coordinate-proof"
+      ],
+      "depth": 34,
+      "head": "5c293be1281b2522e19c2923ab45db6081fac2f0",
+      "parentRecordedHead": "6b976a4172df0462bfafac8335545dc711b20c6c",
+      "parentCurrentHead": "6b976a4172df0462bfafac8335545dc711b20c6c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5c293be12",
+        "sha": "5c293be1281b2522e19c2923ab45db6081fac2f0",
+        "iso": "2026-06-06T07:58:26-04:00",
+        "subject": "test(civ7): summarize local resource materialization"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-placement-coordinate-proof",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-local-materialization-context",
+      "children": [
+        "codex/earthlike-resource-coordinate-proof-intake"
+      ],
+      "depth": 35,
+      "head": "b2c8f88d5407cabd2ce94152b5f985f8824bd056",
+      "parentRecordedHead": "5c293be1281b2522e19c2923ab45db6081fac2f0",
+      "parentCurrentHead": "5c293be1281b2522e19c2923ab45db6081fac2f0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b2c8f88d5",
+        "sha": "b2c8f88d5407cabd2ce94152b5f985f8824bd056",
+        "iso": "2026-06-06T08:05:02-04:00",
+        "subject": "test(civ7): add resource placement coordinate proof"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-resource-coordinate-proof-intake",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-placement-coordinate-proof",
+      "children": [
+        "codex/earthlike-feature-delta-context"
+      ],
+      "depth": 36,
+      "head": "88055a5ec7de6e0d3ca86f48e05b502cc6c745d4",
+      "parentRecordedHead": "b2c8f88d5407cabd2ce94152b5f985f8824bd056",
+      "parentCurrentHead": "b2c8f88d5407cabd2ce94152b5f985f8824bd056",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "88055a5ec",
+        "sha": "88055a5ec7de6e0d3ca86f48e05b502cc6c745d4",
+        "iso": "2026-06-06T08:11:13-04:00",
+        "subject": "test(civ7): bind resource coordinate proof intake"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-feature-delta-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-resource-coordinate-proof-intake",
+      "children": [
+        "codex/earthlike-feature-local-evidence-context"
+      ],
+      "depth": 37,
+      "head": "c74412d6e665b0831df53d7d9436996c3b10f9a0",
+      "parentRecordedHead": "88055a5ec7de6e0d3ca86f48e05b502cc6c745d4",
+      "parentCurrentHead": "88055a5ec7de6e0d3ca86f48e05b502cc6c745d4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c74412d6e",
+        "sha": "c74412d6e665b0831df53d7d9436996c3b10f9a0",
+        "iso": "2026-06-06T08:24:02-04:00",
+        "subject": "test(civ7): classify feature delta context"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-feature-local-evidence-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-feature-delta-context",
+      "children": [
+        "codex/earthlike-feature-live-feasibility-readback"
+      ],
+      "depth": 38,
+      "head": "089bb47c2ecf0309f13646b4159d57e9b9c170ea",
+      "parentRecordedHead": "c74412d6e665b0831df53d7d9436996c3b10f9a0",
+      "parentCurrentHead": "c74412d6e665b0831df53d7d9436996c3b10f9a0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "089bb47c2",
+        "sha": "089bb47c2ecf0309f13646b4159d57e9b9c170ea",
+        "iso": "2026-06-06T08:30:20-04:00",
+        "subject": "test(civ7): expose feature local evidence context"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-feature-live-feasibility-readback",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-feature-local-evidence-context",
+      "children": [
+        "codex/earthlike-feature-footprint-direction-context"
+      ],
+      "depth": 39,
+      "head": "826e736b37fe515bb6c3715ff71af6ffdec89eb1",
+      "parentRecordedHead": "089bb47c2ecf0309f13646b4159d57e9b9c170ea",
+      "parentCurrentHead": "089bb47c2ecf0309f13646b4159d57e9b9c170ea",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "826e736b3",
+        "sha": "826e736b37fe515bb6c3715ff71af6ffdec89eb1",
+        "iso": "2026-06-06T08:40:47-04:00",
+        "subject": "test(civ7): bind feature feasibility readback"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-feature-footprint-direction-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-feature-live-feasibility-readback",
+      "children": [
+        "codex/earthlike-natural-wonder-footprint-readback"
+      ],
+      "depth": 40,
+      "head": "085ab295534cc689ade853f6e9029e0283fd0693",
+      "parentRecordedHead": "826e736b37fe515bb6c3715ff71af6ffdec89eb1",
+      "parentCurrentHead": "826e736b37fe515bb6c3715ff71af6ffdec89eb1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "085ab2955",
+        "sha": "085ab295534cc689ade853f6e9029e0283fd0693",
+        "iso": "2026-06-06T08:47:28-04:00",
+        "subject": "test(civ7): classify wonder footprint directions"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-natural-wonder-footprint-readback",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-feature-footprint-direction-context",
+      "children": [
+        "codex/earthlike-natural-wonder-footprint-catalog-context",
+        "codex/earthlike-terrain-edge-diagnostics"
+      ],
+      "depth": 41,
+      "head": "5b4b4e39a85131b1441e86999a51b31a0b98cbba",
+      "parentRecordedHead": "085ab295534cc689ade853f6e9029e0283fd0693",
+      "parentCurrentHead": "085ab295534cc689ade853f6e9029e0283fd0693",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5b4b4e39a",
+        "sha": "5b4b4e39a85131b1441e86999a51b31a0b98cbba",
+        "iso": "2026-06-06T08:51:57-04:00",
+        "subject": "test(civ7): add wonder footprint readback context"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-natural-wonder-footprint-catalog-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-natural-wonder-footprint-readback",
+      "children": [
+        "codex/earthlike-natural-wonder-live-proof-boundary"
+      ],
+      "depth": 42,
+      "head": "03455aaccc9f4293d56f79ba86722ffa9c75c2dc",
+      "parentRecordedHead": "5b4b4e39a85131b1441e86999a51b31a0b98cbba",
+      "parentCurrentHead": "5b4b4e39a85131b1441e86999a51b31a0b98cbba",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "03455aacc",
+        "sha": "03455aaccc9f4293d56f79ba86722ffa9c75c2dc",
+        "iso": "2026-06-06T15:48:24-04:00",
+        "subject": "test(civ7): classify wonder catalog directions"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-natural-wonder-live-proof-boundary",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-natural-wonder-footprint-catalog-context",
+      "children": [
+        "codex/earthlike-terrain-edge-stack-integration"
+      ],
+      "depth": 43,
+      "head": "98ebc47d57613f21935e8630268b6b4ea27aa3d0",
+      "parentRecordedHead": "03455aaccc9f4293d56f79ba86722ffa9c75c2dc",
+      "parentCurrentHead": "03455aaccc9f4293d56f79ba86722ffa9c75c2dc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "98ebc47d5",
+        "sha": "98ebc47d57613f21935e8630268b6b4ea27aa3d0",
+        "iso": "2026-06-06T15:59:15-04:00",
+        "subject": "test(civ7): classify wonder live proof boundary"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-terrain-edge-stack-integration",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-natural-wonder-live-proof-boundary",
+      "children": [
+        "codex/earthlike-natural-wonder-live-telemetry"
+      ],
+      "depth": 44,
+      "head": "9137689da849ba227f4057aa941c20a502d92e80",
+      "parentRecordedHead": "98ebc47d57613f21935e8630268b6b4ea27aa3d0",
+      "parentCurrentHead": "98ebc47d57613f21935e8630268b6b4ea27aa3d0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9137689da",
+        "sha": "9137689da849ba227f4057aa941c20a502d92e80",
+        "iso": "2026-06-06T16:06:53-04:00",
+        "subject": "docs(openspec): reconcile terrain edge integration"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-terrain-edge-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Terrain-edge diagnostics, mock lake/materialization repairs, and reconciliation records are represented in the Swooper terrain-edge drain."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-natural-wonder-live-telemetry",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-terrain-edge-stack-integration",
+      "children": [
+        "codex/earthlike-natural-wonder-coordinate-proof"
+      ],
+      "depth": 45,
+      "head": "2ee5a01319bf2e9d57e328c3c76689fc7a9e14bc",
+      "parentRecordedHead": "9137689da849ba227f4057aa941c20a502d92e80",
+      "parentCurrentHead": "9137689da849ba227f4057aa941c20a502d92e80",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2ee5a0131",
+        "sha": "2ee5a01319bf2e9d57e328c3c76689fc7a9e14bc",
+        "iso": "2026-06-06T16:23:45-04:00",
+        "subject": "test(civ7): bind wonder placement telemetry"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-natural-wonder-coordinate-proof",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-natural-wonder-live-telemetry",
+      "children": [
+        "codex/earthlike-natural-wonder-source-classification"
+      ],
+      "depth": 46,
+      "head": "88d761f69453a8e50a58b0d65c1af3335a715c0a",
+      "parentRecordedHead": "2ee5a01319bf2e9d57e328c3c76689fc7a9e14bc",
+      "parentCurrentHead": "2ee5a01319bf2e9d57e328c3c76689fc7a9e14bc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "88d761f69",
+        "sha": "88d761f69453a8e50a58b0d65c1af3335a715c0a",
+        "iso": "2026-06-06T16:39:30-04:00",
+        "subject": "test(civ7): bind wonder placement coordinates"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-natural-wonder-source-classification",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-natural-wonder-coordinate-proof",
+      "children": [
+        "codex/workspace-source-package-resolution"
+      ],
+      "depth": 47,
+      "head": "94f18673fc16718b94a1e33184f28070693b3b7b",
+      "parentRecordedHead": "88d761f69453a8e50a58b0d65c1af3335a715c0a",
+      "parentCurrentHead": "88d761f69453a8e50a58b0d65c1af3335a715c0a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "94f18673f",
+        "sha": "94f18673fc16718b94a1e33184f28070693b3b7b",
+        "iso": "2026-06-06T16:42:40-04:00",
+        "subject": "docs(openspec): classify wonder coordinate source"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/workspace-source-package-resolution",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-natural-wonder-source-classification",
+      "children": [
+        "codex/earthlike-natural-wonder-materialization-repair"
+      ],
+      "depth": 48,
+      "head": "ca60fac8ee711ad7d2a977787ed2689dd9524e29",
+      "parentRecordedHead": "94f18673fc16718b94a1e33184f28070693b3b7b",
+      "parentCurrentHead": "94f18673fc16718b94a1e33184f28070693b3b7b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ca60fac8e",
+        "sha": "ca60fac8ee711ad7d2a977787ed2689dd9524e29",
+        "iso": "2026-06-06T16:57:17-04:00",
+        "subject": "fix(repo): resolve map policy from source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/earthlike-natural-wonder-materialization-repair",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/workspace-source-package-resolution",
+      "children": [
+        "codex/earthlike-natural-wonder-repair-proof-record"
+      ],
+      "depth": 49,
+      "head": "87b9f238eb5877f707eaad538b404f86fb200fcc",
+      "parentRecordedHead": "ca60fac8ee711ad7d2a977787ed2689dd9524e29",
+      "parentCurrentHead": "ca60fac8ee711ad7d2a977787ed2689dd9524e29",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "87b9f238e",
+        "sha": "87b9f238eb5877f707eaad538b404f86fb200fcc",
+        "iso": "2026-06-06T16:59:01-04:00",
+        "subject": "fix(civ7): materialize projected wonder direction"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-natural-wonder-repair-proof-record",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-natural-wonder-materialization-repair",
+      "children": [
+        "codex/earthlike-feature-post-wonder-repair-context"
+      ],
+      "depth": 50,
+      "head": "a9a76792b6525b79b6f8ced25e96c59dbce9cf96",
+      "parentRecordedHead": "87b9f238eb5877f707eaad538b404f86fb200fcc",
+      "parentCurrentHead": "87b9f238eb5877f707eaad538b404f86fb200fcc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a9a76792b",
+        "sha": "a9a76792b6525b79b6f8ced25e96c59dbce9cf96",
+        "iso": "2026-06-06T17:03:35-04:00",
+        "subject": "docs(openspec): record wonder repair proof"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-feature-post-wonder-repair-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-natural-wonder-repair-proof-record",
+      "children": [
+        "codex/earthlike-feature-proof-correction"
+      ],
+      "depth": 51,
+      "head": "cf21b6d1c775bed31b2f611d98afaba73cf484dc",
+      "parentRecordedHead": "a9a76792b6525b79b6f8ced25e96c59dbce9cf96",
+      "parentCurrentHead": "a9a76792b6525b79b6f8ced25e96c59dbce9cf96",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cf21b6d1c",
+        "sha": "cf21b6d1c775bed31b2f611d98afaba73cf484dc",
+        "iso": "2026-06-06T17:09:55-04:00",
+        "subject": "docs(openspec): classify post-repair feature deltas"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-feature-proof-correction",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-feature-post-wonder-repair-context",
+      "children": [
+        "codex/earthlike-natural-wonder-deploy-proof-gap"
+      ],
+      "depth": 52,
+      "head": "a164ae6680b5313162e15884f9f47e1355e17e36",
+      "parentRecordedHead": "cf21b6d1c775bed31b2f611d98afaba73cf484dc",
+      "parentCurrentHead": "cf21b6d1c775bed31b2f611d98afaba73cf484dc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a164ae668",
+        "sha": "a164ae6680b5313162e15884f9f47e1355e17e36",
+        "iso": "2026-06-06T17:20:29-04:00",
+        "subject": "docs(openspec): correct feature proof classification"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-natural-wonder-deploy-proof-gap",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-feature-proof-correction",
+      "children": [
+        "codex/earthlike-natural-wonder-named-rejection-proof"
+      ],
+      "depth": 53,
+      "head": "da385a004552f4999318cb331d12c80ade505731",
+      "parentRecordedHead": "a164ae6680b5313162e15884f9f47e1355e17e36",
+      "parentCurrentHead": "a164ae6680b5313162e15884f9f47e1355e17e36",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "da385a004",
+        "sha": "da385a004552f4999318cb331d12c80ade505731",
+        "iso": "2026-06-06T17:39:59-04:00",
+        "subject": "feat(civ7): name natural wonder rejection outcomes"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-natural-wonder-named-rejection-proof",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-natural-wonder-deploy-proof-gap",
+      "children": [
+        "codex/earthlike-natural-wonder-readback-mismatch-context"
+      ],
+      "depth": 54,
+      "head": "d259f31475e25be988a223cf40d408b393688b75",
+      "parentRecordedHead": "da385a004552f4999318cb331d12c80ade505731",
+      "parentCurrentHead": "da385a004552f4999318cb331d12c80ade505731",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d259f3147",
+        "sha": "d259f31475e25be988a223cf40d408b393688b75",
+        "iso": "2026-06-06T17:49:15-04:00",
+        "subject": "docs(openspec): record named wonder rejection proof"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-natural-wonder-readback-mismatch-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-natural-wonder-named-rejection-proof",
+      "children": [
+        "codex/earthlike-natural-wonder-postwrite-footprint-proof"
+      ],
+      "depth": 55,
+      "head": "7dc0c18bedd3c65ee3cb91e20f1a867c2cb90e8e",
+      "parentRecordedHead": "d259f31475e25be988a223cf40d408b393688b75",
+      "parentCurrentHead": "d259f31475e25be988a223cf40d408b393688b75",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7dc0c18be",
+        "sha": "7dc0c18bedd3c65ee3cb91e20f1a867c2cb90e8e",
+        "iso": "2026-06-06T18:02:55-04:00",
+        "subject": "test(civ7): preserve wonder readback context"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-natural-wonder-postwrite-footprint-proof",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-natural-wonder-readback-mismatch-context",
+      "children": [
+        "codex/earthlike-natural-wonder-postwrite-footprint-proof-record"
+      ],
+      "depth": 56,
+      "head": "47b5ccb35983c8b2c55435074bc17dd1ff90561a",
+      "parentRecordedHead": "7dc0c18bedd3c65ee3cb91e20f1a867c2cb90e8e",
+      "parentCurrentHead": "7dc0c18bedd3c65ee3cb91e20f1a867c2cb90e8e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "47b5ccb35",
+        "sha": "47b5ccb35983c8b2c55435074bc17dd1ff90561a",
+        "iso": "2026-06-06T18:19:21-04:00",
+        "subject": "test(civ7): capture wonder readback footprint"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "stack-slice",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-natural-wonder-postwrite-footprint-proof-record",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-natural-wonder-postwrite-footprint-proof",
+      "children": [],
+      "depth": 57,
+      "head": "cbe4943babf131389c892ddd8527b90f52355ab8",
+      "parentRecordedHead": "47b5ccb35983c8b2c55435074bc17dd1ff90561a",
+      "parentCurrentHead": "47b5ccb35983c8b2c55435074bc17dd1ff90561a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "worktree": {
+        "path": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-civ7-map-policy-final-surface-parity",
+        "branch": "codex/earthlike-natural-wonder-postwrite-footprint-proof-record",
+        "head": "cbe4943babf131389c892ddd8527b90f52355ab8",
+        "dirtyCount": 0,
+        "isMain": false,
+        "isDetached": false
+      },
+      "commit": {
+        "short": "cbe4943ba",
+        "sha": "cbe4943babf131389c892ddd8527b90f52355ab8",
+        "iso": "2026-06-06T22:07:40-04:00",
+        "subject": "fix(mapgen): preserve earthlike floodplain surface"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "planned-adopt-earthlike-floodplain-config-leaf",
+          "state": "planned",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "branch",
+          "sinkKind": "branch",
+          "label": "needs-adoption",
+          "cleanup": "pending",
+          "note": "Latest Earthlike floodplainPlanning config/hash leaf is not present in the recovery stack. Adopt this config leaf before claiming the Earthlike source config is fully covered."
+        }
+      ],
+      "accountingSummary": "needs-accounting"
+    },
+    {
+      "branch": "codex/earthlike-terrain-edge-diagnostics",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-natural-wonder-footprint-readback",
+      "children": [
+        "codex/earthlike-terrain-edge-local-mask-context"
+      ],
+      "depth": 42,
+      "head": "6ccbd8c717817d89ca19caffb363465a8e0fb497",
+      "parentRecordedHead": "5b4b4e39a85131b1441e86999a51b31a0b98cbba",
+      "parentCurrentHead": "5b4b4e39a85131b1441e86999a51b31a0b98cbba",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6ccbd8c71",
+        "sha": "6ccbd8c717817d89ca19caffb363465a8e0fb497",
+        "iso": "2026-06-06T14:12:35-04:00",
+        "subject": "test(civ7): classify terrain edge deltas"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-terrain-edge-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Terrain-edge diagnostics, mock lake/materialization repairs, and reconciliation records are represented in the Swooper terrain-edge drain."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-terrain-edge-local-mask-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-terrain-edge-diagnostics",
+      "children": [
+        "codex/earthlike-terrain-edge-live-readback"
+      ],
+      "depth": 43,
+      "head": "35c55eee84de2d62319b6a678adf45802092b0c3",
+      "parentRecordedHead": "6ccbd8c717817d89ca19caffb363465a8e0fb497",
+      "parentCurrentHead": "6ccbd8c717817d89ca19caffb363465a8e0fb497",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "35c55eee8",
+        "sha": "35c55eee84de2d62319b6a678adf45802092b0c3",
+        "iso": "2026-06-06T14:19:52-04:00",
+        "subject": "test(civ7): add terrain edge mask context"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-terrain-edge-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Terrain-edge diagnostics, mock lake/materialization repairs, and reconciliation records are represented in the Swooper terrain-edge drain."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-terrain-edge-live-readback",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-terrain-edge-local-mask-context",
+      "children": [
+        "codex/earthlike-terrain-edge-validation-boundary"
+      ],
+      "depth": 44,
+      "head": "560be926b93b8ed82c10c7ed5ed908d2e26b5d66",
+      "parentRecordedHead": "35c55eee84de2d62319b6a678adf45802092b0c3",
+      "parentCurrentHead": "35c55eee84de2d62319b6a678adf45802092b0c3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "560be926b",
+        "sha": "560be926b93b8ed82c10c7ed5ed908d2e26b5d66",
+        "iso": "2026-06-06T14:32:52-04:00",
+        "subject": "test(civ7): bind terrain edge live readback"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-terrain-edge-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Terrain-edge diagnostics, mock lake/materialization repairs, and reconciliation records are represented in the Swooper terrain-edge drain."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-terrain-edge-validation-boundary",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-terrain-edge-live-readback",
+      "children": [
+        "codex/earthlike-terrain-edge-mock-lake-classification"
+      ],
+      "depth": 45,
+      "head": "d1d4965791e7820d790decdec4119c08a03e16de",
+      "parentRecordedHead": "560be926b93b8ed82c10c7ed5ed908d2e26b5d66",
+      "parentCurrentHead": "560be926b93b8ed82c10c7ed5ed908d2e26b5d66",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d1d496579",
+        "sha": "d1d4965791e7820d790decdec4119c08a03e16de",
+        "iso": "2026-06-06T14:41:19-04:00",
+        "subject": "test(civ7): trace terrain validation boundary"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-terrain-edge-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Terrain-edge diagnostics, mock lake/materialization repairs, and reconciliation records are represented in the Swooper terrain-edge drain."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-terrain-edge-mock-lake-classification",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-terrain-edge-validation-boundary",
+      "children": [
+        "codex/earthlike-terrain-edge-mock-materialization-repair"
+      ],
+      "depth": 46,
+      "head": "16d99f753f0c3a6f3268b34cb3a3599872e02b20",
+      "parentRecordedHead": "d1d4965791e7820d790decdec4119c08a03e16de",
+      "parentCurrentHead": "d1d4965791e7820d790decdec4119c08a03e16de",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "16d99f753",
+        "sha": "16d99f753f0c3a6f3268b34cb3a3599872e02b20",
+        "iso": "2026-06-06T14:50:30-04:00",
+        "subject": "docs(openspec): classify terrain edge source owner"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-terrain-edge-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Terrain-edge diagnostics, mock lake/materialization repairs, and reconciliation records are represented in the Swooper terrain-edge drain."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-terrain-edge-mock-materialization-repair",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-terrain-edge-mock-lake-classification",
+      "children": [
+        "codex/earthlike-terrain-edge-coast-materialization-context"
+      ],
+      "depth": 47,
+      "head": "2722eddbb7c288bf15fb33119c4f041a9ee03bb2",
+      "parentRecordedHead": "16d99f753f0c3a6f3268b34cb3a3599872e02b20",
+      "parentCurrentHead": "16d99f753f0c3a6f3268b34cb3a3599872e02b20",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2722eddbb",
+        "sha": "2722eddbb7c288bf15fb33119c4f041a9ee03bb2",
+        "iso": "2026-06-06T14:59:42-04:00",
+        "subject": "fix(civ7): separate mock lake readback"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-terrain-edge-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Terrain-edge diagnostics, mock lake/materialization repairs, and reconciliation records are represented in the Swooper terrain-edge drain."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-terrain-edge-coast-materialization-context",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-terrain-edge-mock-materialization-repair",
+      "children": [
+        "codex/earthlike-terrain-edge-mock-terrain-materialization-repair"
+      ],
+      "depth": 48,
+      "head": "a0df33e8d147fddcc95dc9925d4ab8e93a11b643",
+      "parentRecordedHead": "2722eddbb7c288bf15fb33119c4f041a9ee03bb2",
+      "parentCurrentHead": "2722eddbb7c288bf15fb33119c4f041a9ee03bb2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a0df33e8d",
+        "sha": "a0df33e8d147fddcc95dc9925d4ab8e93a11b643",
+        "iso": "2026-06-06T15:15:52-04:00",
+        "subject": "test(civ7): trace coast materialization edge"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-terrain-edge-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Terrain-edge diagnostics, mock lake/materialization repairs, and reconciliation records are represented in the Swooper terrain-edge drain."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/earthlike-terrain-edge-mock-terrain-materialization-repair",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/earthlike-terrain-edge-coast-materialization-context",
+      "children": [],
+      "depth": 49,
+      "head": "4f2d0399a292f0d8b521de777a1119711ed8c449",
+      "parentRecordedHead": "a0df33e8d147fddcc95dc9925d4ab8e93a11b643",
+      "parentCurrentHead": "a0df33e8d147fddcc95dc9925d4ab8e93a11b643",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4f2d0399a",
+        "sha": "4f2d0399a292f0d8b521de777a1119711ed8c449",
+        "iso": "2026-06-06T15:36:08-04:00",
+        "subject": "fix(civ7): align mock terrain materialization"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-adopt-earthlike-terrain-edge-stack",
+          "state": "done",
+          "kind": "adopt",
+          "method": "semantic",
+          "sourceKind": "stack-slice",
+          "sinkKind": "branch",
+          "label": "covered-by-adoption",
+          "cleanup": "blocked-until-sink-lands",
+          "note": "Terrain-edge diagnostics, mock lake/materialization repairs, and reconciliation records are represented in the Swooper terrain-edge drain."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    },
+    {
+      "branch": "codex/play-agent-hotseat-phase-packet",
+      "root": "codex/live-play-settlement-reference",
+      "parent": "codex/civ7-orpc-control-architecture-skill",
+      "children": [],
+      "depth": 4,
+      "head": "547b81e13d5bbd004132d0e5ffe915723c431ff1",
+      "parentRecordedHead": "d3d49b48fbbb541c0fc6ff273014f86cf84af10d",
+      "parentCurrentHead": "d3d49b48fbbb541c0fc6ff273014f86cf84af10d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "547b81e13",
+        "sha": "547b81e13d5bbd004132d0e5ffe915723c431ff1",
+        "iso": "2026-06-02T06:02:55-04:00",
+        "subject": "docs(direct-control): frame hotseat proof phase"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/local-catalog-enrichment",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "main",
+      "children": [
+        "codex/disaster-notification-closeout"
+      ],
+      "depth": 0,
+      "head": "1689806731331dae56262cfa988fdbc0800b3e88",
+      "parentRecordedHead": "b3013fe5ea0073897aa88e9147cde4d860ebfb7d",
+      "parentCurrentHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+      "validationResult": "VALID",
+      "alignedToParent": false,
+      "needsRestack": true,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "168980673",
+        "sha": "1689806731331dae56262cfa988fdbc0800b3e88",
+        "iso": "2026-06-01T13:47:41-04:00",
+        "subject": "docs(civ7): frame local catalog enrichment"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/disaster-notification-closeout",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/local-catalog-enrichment",
+      "children": [
+        "codex/local-data-inspect"
+      ],
+      "depth": 1,
+      "head": "0a75deffa34de7158008b7071d8db60ec99d0be4",
+      "parentRecordedHead": "1689806731331dae56262cfa988fdbc0800b3e88",
+      "parentCurrentHead": "1689806731331dae56262cfa988fdbc0800b3e88",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0a75deffa",
+        "sha": "0a75deffa34de7158008b7071d8db60ec99d0be4",
+        "iso": "2026-06-01T13:53:35-04:00",
+        "subject": "feat(civ7): classify disaster report closeouts"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/local-data-inspect",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/disaster-notification-closeout",
+      "children": [
+        "codex/unit-target-postcondition-status"
+      ],
+      "depth": 2,
+      "head": "b3d051029f86e5cf03aad2d47cbc2a1584e9e852",
+      "parentRecordedHead": "0a75deffa34de7158008b7071d8db60ec99d0be4",
+      "parentCurrentHead": "0a75deffa34de7158008b7071d8db60ec99d0be4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b3d051029",
+        "sha": "b3d051029f86e5cf03aad2d47cbc2a1584e9e852",
+        "iso": "2026-06-01T14:01:34-04:00",
+        "subject": "feat(civ7): inspect local disk evidence"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/unit-target-postcondition-status",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/local-data-inspect",
+      "children": [
+        "codex/play-rehydrate-snapshot"
+      ],
+      "depth": 3,
+      "head": "bde5e6650ad6e6fb3f0aef6f758a78ddd6bccc60",
+      "parentRecordedHead": "b3d051029f86e5cf03aad2d47cbc2a1584e9e852",
+      "parentCurrentHead": "b3d051029f86e5cf03aad2d47cbc2a1584e9e852",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bde5e6650",
+        "sha": "bde5e6650ad6e6fb3f0aef6f758a78ddd6bccc60",
+        "iso": "2026-06-01T14:09:05-04:00",
+        "subject": "feat(civ7): explain unit-target postcondition misses"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/play-rehydrate-snapshot",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/unit-target-postcondition-status",
+      "children": [
+        "codex/live-traditions-view"
+      ],
+      "depth": 4,
+      "head": "bf41af4c1f34dcdc9b5f3a6532832b8f2b995b70",
+      "parentRecordedHead": "bde5e6650ad6e6fb3f0aef6f758a78ddd6bccc60",
+      "parentCurrentHead": "bde5e6650ad6e6fb3f0aef6f758a78ddd6bccc60",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bf41af4c1",
+        "sha": "bf41af4c1f34dcdc9b5f3a6532832b8f2b995b70",
+        "iso": "2026-06-01T19:39:23-04:00",
+        "subject": "docs(civ7): track support research threads"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/live-traditions-view",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/play-rehydrate-snapshot",
+      "children": [
+        "codex/surface-first-meet-exact-commands",
+        "codex/stale-population-blocker-classification"
+      ],
+      "depth": 5,
+      "head": "332270a377b91f1cd7ef8c75c2f8d1a0a1ae62ef",
+      "parentRecordedHead": "bf41af4c1f34dcdc9b5f3a6532832b8f2b995b70",
+      "parentCurrentHead": "bf41af4c1f34dcdc9b5f3a6532832b8f2b995b70",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "332270a37",
+        "sha": "332270a377b91f1cd7ef8c75c2f8d1a0a1ae62ef",
+        "iso": "2026-06-02T15:42:56-04:00",
+        "subject": "fix(civ7): verify first-meet response closeouts"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/surface-first-meet-exact-commands",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/live-traditions-view",
+      "children": [
+        "codex/clarify-formation-relationship-policy-live"
+      ],
+      "depth": 6,
+      "head": "a1dba098ddbf59215046de79fdb125606be6a24b",
+      "parentRecordedHead": "332270a377b91f1cd7ef8c75c2f8d1a0a1ae62ef",
+      "parentCurrentHead": "332270a377b91f1cd7ef8c75c2f8d1a0a1ae62ef",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a1dba098d",
+        "sha": "a1dba098ddbf59215046de79fdb125606be6a24b",
+        "iso": "2026-06-02T16:00:11-04:00",
+        "subject": "fix(civ7): surface exact first-meet commands"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/clarify-formation-relationship-policy-live",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/surface-first-meet-exact-commands",
+      "children": [
+        "codex/extract-first-meet-play-tests-live"
+      ],
+      "depth": 7,
+      "head": "e09182144dbcd55e6f247b6fab57e7a5506c92ef",
+      "parentRecordedHead": "a1dba098ddbf59215046de79fdb125606be6a24b",
+      "parentCurrentHead": "a1dba098ddbf59215046de79fdb125606be6a24b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e09182144",
+        "sha": "e09182144dbcd55e6f247b6fab57e7a5506c92ef",
+        "iso": "2026-06-02T16:05:55-04:00",
+        "subject": "fix(civ7): clarify formation relationship policy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-first-meet-play-tests-live",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/clarify-formation-relationship-policy-live",
+      "children": [
+        "codex/extract-operation-wrapper-play-tests-live"
+      ],
+      "depth": 8,
+      "head": "4736522f1d29860b5278f7005fc391563764f013",
+      "parentRecordedHead": "e09182144dbcd55e6f247b6fab57e7a5506c92ef",
+      "parentCurrentHead": "e09182144dbcd55e6f247b6fab57e7a5506c92ef",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4736522f1",
+        "sha": "4736522f1d29860b5278f7005fc391563764f013",
+        "iso": "2026-06-02T16:13:59-04:00",
+        "subject": "test(cli): extract first-meet play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-operation-wrapper-play-tests-live",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-first-meet-play-tests-live",
+      "children": [
+        "codex/extract-technology-play-tests-live"
+      ],
+      "depth": 9,
+      "head": "cd795053c8511bac39ee2a3225e5a88c716a968c",
+      "parentRecordedHead": "4736522f1d29860b5278f7005fc391563764f013",
+      "parentCurrentHead": "4736522f1d29860b5278f7005fc391563764f013",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cd795053c",
+        "sha": "cd795053c8511bac39ee2a3225e5a88c716a968c",
+        "iso": "2026-06-02T16:19:34-04:00",
+        "subject": "test(cli): extract operation wrapper play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-technology-play-tests-live",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-operation-wrapper-play-tests-live",
+      "children": [
+        "codex/extract-culture-play-tests-live"
+      ],
+      "depth": 10,
+      "head": "ae952d6c925f6beb3f0e704a1f14eb378346d34e",
+      "parentRecordedHead": "cd795053c8511bac39ee2a3225e5a88c716a968c",
+      "parentCurrentHead": "cd795053c8511bac39ee2a3225e5a88c716a968c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ae952d6c9",
+        "sha": "ae952d6c925f6beb3f0e704a1f14eb378346d34e",
+        "iso": "2026-06-02T16:29:18-04:00",
+        "subject": "test(cli): extract technology play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-culture-play-tests-live",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-technology-play-tests-live",
+      "children": [
+        "codex/extract-celebration-government-play-tests-live"
+      ],
+      "depth": 11,
+      "head": "38a56c16f3eb49164333fc76fe1dc0f9aec7faa4",
+      "parentRecordedHead": "ae952d6c925f6beb3f0e704a1f14eb378346d34e",
+      "parentCurrentHead": "ae952d6c925f6beb3f0e704a1f14eb378346d34e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "38a56c16f",
+        "sha": "38a56c16f3eb49164333fc76fe1dc0f9aec7faa4",
+        "iso": "2026-06-02T16:35:52-04:00",
+        "subject": "test(cli): extract culture play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-celebration-government-play-tests-live",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-culture-play-tests-live",
+      "children": [
+        "codex/extract-narrative-play-tests-live"
+      ],
+      "depth": 12,
+      "head": "b8b647993e7210e5b56f4d19525de6ab126fc0f4",
+      "parentRecordedHead": "38a56c16f3eb49164333fc76fe1dc0f9aec7faa4",
+      "parentCurrentHead": "38a56c16f3eb49164333fc76fe1dc0f9aec7faa4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b8b647993",
+        "sha": "b8b647993e7210e5b56f4d19525de6ab126fc0f4",
+        "iso": "2026-06-02T16:42:31-04:00",
+        "subject": "test(cli): extract celebration government play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-narrative-play-tests-live",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-celebration-government-play-tests-live",
+      "children": [
+        "codex/extract-diplomacy-response-play-tests-live"
+      ],
+      "depth": 13,
+      "head": "71217b3333d048391c2511260a8e921de48696c1",
+      "parentRecordedHead": "b8b647993e7210e5b56f4d19525de6ab126fc0f4",
+      "parentCurrentHead": "b8b647993e7210e5b56f4d19525de6ab126fc0f4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "71217b333",
+        "sha": "71217b3333d048391c2511260a8e921de48696c1",
+        "iso": "2026-06-02T16:50:06-04:00",
+        "subject": "test(cli): extract narrative play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-diplomacy-response-play-tests-live",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-narrative-play-tests-live",
+      "children": [
+        "codex/extract-production-play-tests-live"
+      ],
+      "depth": 14,
+      "head": "53eacd7b4b18a4bab860b3ed131efb365548a5db",
+      "parentRecordedHead": "71217b3333d048391c2511260a8e921de48696c1",
+      "parentCurrentHead": "71217b3333d048391c2511260a8e921de48696c1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "53eacd7b4",
+        "sha": "53eacd7b4b18a4bab860b3ed131efb365548a5db",
+        "iso": "2026-06-02T16:57:55-04:00",
+        "subject": "test(cli): extract diplomacy response play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-production-play-tests-live",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-diplomacy-response-play-tests-live",
+      "children": [
+        "codex/extract-tuner-socket-test-fixture"
+      ],
+      "depth": 15,
+      "head": "d1cb850920661f360b5984f5d7fbcf56ffe47cc1",
+      "parentRecordedHead": "53eacd7b4b18a4bab860b3ed131efb365548a5db",
+      "parentCurrentHead": "53eacd7b4b18a4bab860b3ed131efb365548a5db",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d1cb85092",
+        "sha": "d1cb850920661f360b5984f5d7fbcf56ffe47cc1",
+        "iso": "2026-06-02T17:05:36-04:00",
+        "subject": "test(cli): extract production play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-tuner-socket-test-fixture",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-production-play-tests-live",
+      "children": [
+        "codex/reuse-tuner-fixture-progression-tests"
+      ],
+      "depth": 16,
+      "head": "13998558578e712cf894049c8c50120d5372eb4a",
+      "parentRecordedHead": "d1cb850920661f360b5984f5d7fbcf56ffe47cc1",
+      "parentCurrentHead": "d1cb850920661f360b5984f5d7fbcf56ffe47cc1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "139985585",
+        "sha": "13998558578e712cf894049c8c50120d5372eb4a",
+        "iso": "2026-06-02T17:17:03-04:00",
+        "subject": "test(cli): extract tuner socket test fixture"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/reuse-tuner-fixture-progression-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-tuner-socket-test-fixture",
+      "children": [
+        "codex/reuse-tuner-fixture-celebration-government-tests"
+      ],
+      "depth": 17,
+      "head": "09d1ce895994dc0eb61eea38f3aa00668ae00ce3",
+      "parentRecordedHead": "13998558578e712cf894049c8c50120d5372eb4a",
+      "parentCurrentHead": "13998558578e712cf894049c8c50120d5372eb4a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "09d1ce895",
+        "sha": "09d1ce895994dc0eb61eea38f3aa00668ae00ce3",
+        "iso": "2026-06-02T17:22:28-04:00",
+        "subject": "test(cli): reuse tuner fixture for progression tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/reuse-tuner-fixture-celebration-government-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/reuse-tuner-fixture-progression-tests",
+      "children": [
+        "codex/reuse-tuner-fixture-operation-tests"
+      ],
+      "depth": 18,
+      "head": "0c844695c10fcf2f621c0955fe66156d7cf9ae53",
+      "parentRecordedHead": "09d1ce895994dc0eb61eea38f3aa00668ae00ce3",
+      "parentCurrentHead": "09d1ce895994dc0eb61eea38f3aa00668ae00ce3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0c844695c",
+        "sha": "0c844695c10fcf2f621c0955fe66156d7cf9ae53",
+        "iso": "2026-06-02T17:27:02-04:00",
+        "subject": "test(cli): reuse tuner fixture for celebration tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/reuse-tuner-fixture-operation-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/reuse-tuner-fixture-celebration-government-tests",
+      "children": [
+        "codex/reuse-tuner-fixture-first-meet-tests"
+      ],
+      "depth": 19,
+      "head": "c24a09e7eda916a4bea204f4b9eecbb8fd63690c",
+      "parentRecordedHead": "0c844695c10fcf2f621c0955fe66156d7cf9ae53",
+      "parentCurrentHead": "0c844695c10fcf2f621c0955fe66156d7cf9ae53",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c24a09e7e",
+        "sha": "c24a09e7eda916a4bea204f4b9eecbb8fd63690c",
+        "iso": "2026-06-02T17:31:42-04:00",
+        "subject": "test(cli): reuse tuner fixture for operation tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/reuse-tuner-fixture-first-meet-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/reuse-tuner-fixture-operation-tests",
+      "children": [
+        "codex/reuse-tuner-fixture-narrative-tests"
+      ],
+      "depth": 20,
+      "head": "5df66aa926b31479ab0575572f48dff7f6106d16",
+      "parentRecordedHead": "c24a09e7eda916a4bea204f4b9eecbb8fd63690c",
+      "parentCurrentHead": "c24a09e7eda916a4bea204f4b9eecbb8fd63690c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5df66aa92",
+        "sha": "5df66aa926b31479ab0575572f48dff7f6106d16",
+        "iso": "2026-06-02T17:35:32-04:00",
+        "subject": "test(cli): reuse tuner fixture for first-meet tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/reuse-tuner-fixture-narrative-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/reuse-tuner-fixture-first-meet-tests",
+      "children": [
+        "codex/reuse-tuner-fixture-play-monolith-tests"
+      ],
+      "depth": 21,
+      "head": "a60f4d004b4bd9ea5b69bd7e2502ac558961e681",
+      "parentRecordedHead": "5df66aa926b31479ab0575572f48dff7f6106d16",
+      "parentCurrentHead": "5df66aa926b31479ab0575572f48dff7f6106d16",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a60f4d004",
+        "sha": "a60f4d004b4bd9ea5b69bd7e2502ac558961e681",
+        "iso": "2026-06-02T17:38:18-04:00",
+        "subject": "test(cli): reuse tuner fixture for narrative tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/reuse-tuner-fixture-play-monolith-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/reuse-tuner-fixture-narrative-tests",
+      "children": [
+        "codex/extract-end-turn-play-tests"
+      ],
+      "depth": 22,
+      "head": "aa161ae32f9257627f0c08829e6940505f640734",
+      "parentRecordedHead": "a60f4d004b4bd9ea5b69bd7e2502ac558961e681",
+      "parentCurrentHead": "a60f4d004b4bd9ea5b69bd7e2502ac558961e681",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "aa161ae32",
+        "sha": "aa161ae32f9257627f0c08829e6940505f640734",
+        "iso": "2026-06-02T17:45:04-04:00",
+        "subject": "test(cli): reuse tuner fixture for play monolith"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-end-turn-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/reuse-tuner-fixture-play-monolith-tests",
+      "children": [
+        "codex/extract-population-placement-play-tests"
+      ],
+      "depth": 23,
+      "head": "b8b22e570917f3bf6191ea381e05884e0ff8e7e3",
+      "parentRecordedHead": "aa161ae32f9257627f0c08829e6940505f640734",
+      "parentCurrentHead": "aa161ae32f9257627f0c08829e6940505f640734",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b8b22e570",
+        "sha": "b8b22e570917f3bf6191ea381e05884e0ff8e7e3",
+        "iso": "2026-06-02T17:54:12-04:00",
+        "subject": "test(cli): extract end-turn play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-population-placement-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-end-turn-play-tests",
+      "children": [
+        "codex/extract-attribute-tradition-play-tests"
+      ],
+      "depth": 24,
+      "head": "77dcd023ce166b6323ce1718bb5665d239aba14e",
+      "parentRecordedHead": "b8b22e570917f3bf6191ea381e05884e0ff8e7e3",
+      "parentCurrentHead": "b8b22e570917f3bf6191ea381e05884e0ff8e7e3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "77dcd023c",
+        "sha": "77dcd023ce166b6323ce1718bb5665d239aba14e",
+        "iso": "2026-06-02T18:03:07-04:00",
+        "subject": "test(cli): extract population placement play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-attribute-tradition-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-population-placement-play-tests",
+      "children": [
+        "codex/extract-town-focus-play-tests"
+      ],
+      "depth": 25,
+      "head": "e57181f38f1f71873f1b1f4f60d2da1ea0dc040a",
+      "parentRecordedHead": "77dcd023ce166b6323ce1718bb5665d239aba14e",
+      "parentCurrentHead": "77dcd023ce166b6323ce1718bb5665d239aba14e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e57181f38",
+        "sha": "e57181f38f1f71873f1b1f4f60d2da1ea0dc040a",
+        "iso": "2026-06-02T18:11:32-04:00",
+        "subject": "test(cli): extract attribute tradition play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-town-focus-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-attribute-tradition-play-tests",
+      "children": [
+        "codex/extract-unit-target-play-tests"
+      ],
+      "depth": 26,
+      "head": "8d9dade49222254a05355c432416e3cc4cf962db",
+      "parentRecordedHead": "e57181f38f1f71873f1b1f4f60d2da1ea0dc040a",
+      "parentCurrentHead": "e57181f38f1f71873f1b1f4f60d2da1ea0dc040a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8d9dade49",
+        "sha": "8d9dade49222254a05355c432416e3cc4cf962db",
+        "iso": "2026-06-02T18:14:32-04:00",
+        "subject": "test(cli): extract town focus play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-unit-target-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-town-focus-play-tests",
+      "children": [
+        "codex/extract-progression-read-play-tests"
+      ],
+      "depth": 27,
+      "head": "04770bf9387b14bc54c4e74439ed3060d63ed4c6",
+      "parentRecordedHead": "8d9dade49222254a05355c432416e3cc4cf962db",
+      "parentCurrentHead": "8d9dade49222254a05355c432416e3cc4cf962db",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "04770bf93",
+        "sha": "04770bf9387b14bc54c4e74439ed3060d63ed4c6",
+        "iso": "2026-06-02T18:18:33-04:00",
+        "subject": "test(cli): extract unit target play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-progression-read-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-unit-target-play-tests",
+      "children": [
+        "codex/support-dra-takeover-reference"
+      ],
+      "depth": 28,
+      "head": "fe70c90fc07d35fd6615f2e7481dc491ace13cfb",
+      "parentRecordedHead": "04770bf9387b14bc54c4e74439ed3060d63ed4c6",
+      "parentCurrentHead": "04770bf9387b14bc54c4e74439ed3060d63ed4c6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fe70c90fc",
+        "sha": "fe70c90fc07d35fd6615f2e7481dc491ace13cfb",
+        "iso": "2026-06-02T18:26:50-04:00",
+        "subject": "test(cli): extract progression read play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/support-dra-takeover-reference",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-progression-read-play-tests",
+      "children": [
+        "codex/extract-tactical-read-play-tests"
+      ],
+      "depth": 29,
+      "head": "0d6f8c90196d0cba039662c7d2aaeb0e85ad2092",
+      "parentRecordedHead": "fe70c90fc07d35fd6615f2e7481dc491ace13cfb",
+      "parentCurrentHead": "fe70c90fc07d35fd6615f2e7481dc491ace13cfb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0d6f8c901",
+        "sha": "0d6f8c90196d0cba039662c7d2aaeb0e85ad2092",
+        "iso": "2026-06-02T18:35:54-04:00",
+        "subject": "docs(civ7): add support DRA takeover frame"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-tactical-read-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/support-dra-takeover-reference",
+      "children": [
+        "codex/extract-watch-play-tests"
+      ],
+      "depth": 30,
+      "head": "e340ffaf44fde031ec18c68c614ca776cffaff3c",
+      "parentRecordedHead": "0d6f8c90196d0cba039662c7d2aaeb0e85ad2092",
+      "parentCurrentHead": "0d6f8c90196d0cba039662c7d2aaeb0e85ad2092",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e340ffaf4",
+        "sha": "e340ffaf44fde031ec18c68c614ca776cffaff3c",
+        "iso": "2026-06-02T18:45:36-04:00",
+        "subject": "test(cli): extract tactical read play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-watch-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-tactical-read-play-tests",
+      "children": [
+        "codex/extract-topics-play-tests"
+      ],
+      "depth": 31,
+      "head": "280811b95e2abdf3c5dcbafad9016f925253e428",
+      "parentRecordedHead": "e340ffaf44fde031ec18c68c614ca776cffaff3c",
+      "parentCurrentHead": "e340ffaf44fde031ec18c68c614ca776cffaff3c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "280811b95",
+        "sha": "280811b95e2abdf3c5dcbafad9016f925253e428",
+        "iso": "2026-06-02T18:53:18-04:00",
+        "subject": "test(cli): extract watch play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-topics-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-watch-play-tests",
+      "children": [
+        "codex/extract-promotion-readiness-play-tests"
+      ],
+      "depth": 32,
+      "head": "8b86b6bf8babb12c3a21bd355a5e0ed6ebbb3a09",
+      "parentRecordedHead": "280811b95e2abdf3c5dcbafad9016f925253e428",
+      "parentCurrentHead": "280811b95e2abdf3c5dcbafad9016f925253e428",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8b86b6bf8",
+        "sha": "8b86b6bf8babb12c3a21bd355a5e0ed6ebbb3a09",
+        "iso": "2026-06-02T18:56:03-04:00",
+        "subject": "test(cli): extract topics play test"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-promotion-readiness-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-topics-play-tests",
+      "children": [
+        "codex/extract-rehydrate-play-tests"
+      ],
+      "depth": 33,
+      "head": "1034cf6adc4dd6d979e5c0e35c485be446df48cb",
+      "parentRecordedHead": "8b86b6bf8babb12c3a21bd355a5e0ed6ebbb3a09",
+      "parentCurrentHead": "8b86b6bf8babb12c3a21bd355a5e0ed6ebbb3a09",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1034cf6ad",
+        "sha": "1034cf6adc4dd6d979e5c0e35c485be446df48cb",
+        "iso": "2026-06-02T18:59:19-04:00",
+        "subject": "test(cli): extract promotion readiness play test"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-rehydrate-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-promotion-readiness-play-tests",
+      "children": [
+        "codex/extract-settlement-recommendations-play-tests"
+      ],
+      "depth": 34,
+      "head": "02049d1ba8422f04a8f9224f66d202e2c21ed9b6",
+      "parentRecordedHead": "1034cf6adc4dd6d979e5c0e35c485be446df48cb",
+      "parentCurrentHead": "1034cf6adc4dd6d979e5c0e35c485be446df48cb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "02049d1ba",
+        "sha": "02049d1ba8422f04a8f9224f66d202e2c21ed9b6",
+        "iso": "2026-06-02T19:03:03-04:00",
+        "subject": "test(cli): extract rehydrate play test"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-settlement-recommendations-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-rehydrate-play-tests",
+      "children": [
+        "codex/extract-ready-city-play-tests"
+      ],
+      "depth": 35,
+      "head": "f0309149dc71a022d4487a54960236987427a53c",
+      "parentRecordedHead": "02049d1ba8422f04a8f9224f66d202e2c21ed9b6",
+      "parentCurrentHead": "02049d1ba8422f04a8f9224f66d202e2c21ed9b6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f0309149d",
+        "sha": "f0309149dc71a022d4487a54960236987427a53c",
+        "iso": "2026-06-02T19:07:22-04:00",
+        "subject": "test(cli): extract settlement recommendations play test"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-ready-city-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-settlement-recommendations-play-tests",
+      "children": [
+        "codex/extract-foldered-unit-move-preview-play-tests"
+      ],
+      "depth": 36,
+      "head": "036bbb4b3120f8aee6a22fb465fbfa8cd53cb8ca",
+      "parentRecordedHead": "f0309149dc71a022d4487a54960236987427a53c",
+      "parentCurrentHead": "f0309149dc71a022d4487a54960236987427a53c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "036bbb4b3",
+        "sha": "036bbb4b3120f8aee6a22fb465fbfa8cd53cb8ca",
+        "iso": "2026-06-02T19:14:34-04:00",
+        "subject": "test(cli): extract ready city play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-foldered-unit-move-preview-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-ready-city-play-tests",
+      "children": [
+        "codex/extract-foldered-ready-unit-play-tests"
+      ],
+      "depth": 37,
+      "head": "0c574f33b73b276a2c4367848f6c7e98146c85ae",
+      "parentRecordedHead": "036bbb4b3120f8aee6a22fb465fbfa8cd53cb8ca",
+      "parentCurrentHead": "036bbb4b3120f8aee6a22fb465fbfa8cd53cb8ca",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0c574f33b",
+        "sha": "0c574f33b73b276a2c4367848f6c7e98146c85ae",
+        "iso": "2026-06-02T19:21:35-04:00",
+        "subject": "test(cli): extract unit move preview play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-foldered-ready-unit-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-foldered-unit-move-preview-play-tests",
+      "children": [
+        "codex/extract-notification-queue-play-tests"
+      ],
+      "depth": 38,
+      "head": "2c1c91bae935f2495b957f47509cc619e1a6402b",
+      "parentRecordedHead": "0c574f33b73b276a2c4367848f6c7e98146c85ae",
+      "parentCurrentHead": "0c574f33b73b276a2c4367848f6c7e98146c85ae",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2c1c91bae",
+        "sha": "2c1c91bae935f2495b957f47509cc619e1a6402b",
+        "iso": "2026-06-02T19:28:35-04:00",
+        "subject": "test(cli): extract ready unit play test"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-notification-queue-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-foldered-ready-unit-play-tests",
+      "children": [
+        "codex/extract-dismiss-notification-queue-play-tests"
+      ],
+      "depth": 39,
+      "head": "a255f6fc597f99d409247665ee7ef193cd177f87",
+      "parentRecordedHead": "2c1c91bae935f2495b957f47509cc619e1a6402b",
+      "parentCurrentHead": "2c1c91bae935f2495b957f47509cc619e1a6402b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a255f6fc5",
+        "sha": "a255f6fc597f99d409247665ee7ef193cd177f87",
+        "iso": "2026-06-02T19:36:10-04:00",
+        "subject": "test(cli): extract notification queue play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-dismiss-notification-queue-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-notification-queue-play-tests",
+      "children": [
+        "codex/add-systematic-workstream-skill-to-support-stack"
+      ],
+      "depth": 40,
+      "head": "4c02bfe71d35e66811adc3c4faf7ebebf4b0abce",
+      "parentRecordedHead": "a255f6fc597f99d409247665ee7ef193cd177f87",
+      "parentCurrentHead": "a255f6fc597f99d409247665ee7ef193cd177f87",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4c02bfe71",
+        "sha": "4c02bfe71d35e66811adc3c4faf7ebebf4b0abce",
+        "iso": "2026-06-02T19:50:21-04:00",
+        "subject": "test(cli): extract dismiss notification queue play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-systematic-workstream-skill-to-support-stack",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-dismiss-notification-queue-play-tests",
+      "children": [
+        "codex/apply-systematic-workstream-review-fixes"
+      ],
+      "depth": 41,
+      "head": "0abccba10d9148f6e105b2e235467664fbe7983a",
+      "parentRecordedHead": "4c02bfe71d35e66811adc3c4faf7ebebf4b0abce",
+      "parentCurrentHead": "4c02bfe71d35e66811adc3c4faf7ebebf4b0abce",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0abccba10",
+        "sha": "0abccba10d9148f6e105b2e235467664fbe7983a",
+        "iso": "2026-06-02T19:54:43-04:00",
+        "subject": "docs(skills): add systematic workstream skill"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/apply-systematic-workstream-review-fixes",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-systematic-workstream-skill-to-support-stack",
+      "children": [
+        "codex/add-support-modularization-openspec-workstream"
+      ],
+      "depth": 42,
+      "head": "66f9af2026e9fea8dc0de300f50b340b984f74a5",
+      "parentRecordedHead": "0abccba10d9148f6e105b2e235467664fbe7983a",
+      "parentCurrentHead": "0abccba10d9148f6e105b2e235467664fbe7983a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "66f9af202",
+        "sha": "66f9af2026e9fea8dc0de300f50b340b984f74a5",
+        "iso": "2026-06-02T19:58:32-04:00",
+        "subject": "docs(skills): apply systematic workstream review fixes"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-support-modularization-openspec-workstream",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/apply-systematic-workstream-review-fixes",
+      "children": [
+        "codex/reconcile-support-workstream-agent-reports"
+      ],
+      "depth": 43,
+      "head": "d2c01f03b3b7e204b030f14b7e9fef20ca693443",
+      "parentRecordedHead": "66f9af2026e9fea8dc0de300f50b340b984f74a5",
+      "parentCurrentHead": "66f9af2026e9fea8dc0de300f50b340b984f74a5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d2c01f03b",
+        "sha": "d2c01f03b3b7e204b030f14b7e9fef20ca693443",
+        "iso": "2026-06-02T20:00:36-04:00",
+        "subject": "docs(openspec): add support modularization workstream"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/reconcile-support-workstream-agent-reports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-support-modularization-openspec-workstream",
+      "children": [
+        "codex/extract-exact-dismiss-notification-play-tests"
+      ],
+      "depth": 44,
+      "head": "55f11269ff4a04d2614ac903ec1dc682d244ef31",
+      "parentRecordedHead": "d2c01f03b3b7e204b030f14b7e9fef20ca693443",
+      "parentCurrentHead": "d2c01f03b3b7e204b030f14b7e9fef20ca693443",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "55f11269f",
+        "sha": "55f11269ff4a04d2614ac903ec1dc682d244ef31",
+        "iso": "2026-06-02T20:10:06-04:00",
+        "subject": "docs(openspec): reconcile support workstream agent reports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-exact-dismiss-notification-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/reconcile-support-workstream-agent-reports",
+      "children": [
+        "codex/extract-notification-hud-play-tests"
+      ],
+      "depth": 45,
+      "head": "813689fdddf1195e0ee9646cc10b9db59ad804d4",
+      "parentRecordedHead": "55f11269ff4a04d2614ac903ec1dc682d244ef31",
+      "parentCurrentHead": "55f11269ff4a04d2614ac903ec1dc682d244ef31",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "813689fdd",
+        "sha": "813689fdddf1195e0ee9646cc10b9db59ad804d4",
+        "iso": "2026-06-02T20:17:02-04:00",
+        "subject": "test(cli): extract exact dismiss notification play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-notification-hud-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-exact-dismiss-notification-play-tests",
+      "children": [
+        "codex/extract-priorities-play-tests"
+      ],
+      "depth": 46,
+      "head": "cdf9389e7616db7449886de3d79066069b767e69",
+      "parentRecordedHead": "813689fdddf1195e0ee9646cc10b9db59ad804d4",
+      "parentCurrentHead": "813689fdddf1195e0ee9646cc10b9db59ad804d4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cdf9389e7",
+        "sha": "cdf9389e7616db7449886de3d79066069b767e69",
+        "iso": "2026-06-02T20:30:10-04:00",
+        "subject": "test(cli): extract notification HUD play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-priorities-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-notification-hud-play-tests",
+      "children": [
+        "codex/record-direct-control-planning-reports"
+      ],
+      "depth": 47,
+      "head": "8f686f0d9e1bb087fa7b0b50d755707e9f8fb88e",
+      "parentRecordedHead": "cdf9389e7616db7449886de3d79066069b767e69",
+      "parentCurrentHead": "cdf9389e7616db7449886de3d79066069b767e69",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8f686f0d9",
+        "sha": "8f686f0d9e1bb087fa7b0b50d755707e9f8fb88e",
+        "iso": "2026-06-02T20:44:01-04:00",
+        "subject": "test(cli): extract priorities play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-direct-control-planning-reports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-priorities-play-tests",
+      "children": [
+        "codex/extract-direct-control-public-api-tests"
+      ],
+      "depth": 48,
+      "head": "cd3ed464e7ea2299d3a27b38071e2df16959830b",
+      "parentRecordedHead": "8f686f0d9e1bb087fa7b0b50d755707e9f8fb88e",
+      "parentCurrentHead": "8f686f0d9e1bb087fa7b0b50d755707e9f8fb88e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cd3ed464e",
+        "sha": "cd3ed464e7ea2299d3a27b38071e2df16959830b",
+        "iso": "2026-06-02T20:55:53-04:00",
+        "subject": "docs(openspec): record direct-control planning reports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-public-api-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-direct-control-planning-reports",
+      "children": [
+        "codex/add-direct-control-unit-move-preview-tests"
+      ],
+      "depth": 49,
+      "head": "d3f2140f3be3dc1b6c000d4fa72004a0c2e3074b",
+      "parentRecordedHead": "cd3ed464e7ea2299d3a27b38071e2df16959830b",
+      "parentCurrentHead": "cd3ed464e7ea2299d3a27b38071e2df16959830b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d3f2140f3",
+        "sha": "d3f2140f3be3dc1b6c000d4fa72004a0c2e3074b",
+        "iso": "2026-06-02T21:02:01-04:00",
+        "subject": "test(direct-control): extract public API tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-direct-control-unit-move-preview-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-public-api-tests",
+      "children": [
+        "codex/extract-direct-control-session-tests"
+      ],
+      "depth": 50,
+      "head": "517bae3ff4c2649a33274978565adf5caa050272",
+      "parentRecordedHead": "d3f2140f3be3dc1b6c000d4fa72004a0c2e3074b",
+      "parentCurrentHead": "d3f2140f3be3dc1b6c000d4fa72004a0c2e3074b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "517bae3ff",
+        "sha": "517bae3ff4c2649a33274978565adf5caa050272",
+        "iso": "2026-06-02T21:10:52-04:00",
+        "subject": "test(direct-control): add unit move preview tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-session-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-direct-control-unit-move-preview-tests",
+      "children": [
+        "codex/extract-direct-control-ready-view-tests"
+      ],
+      "depth": 51,
+      "head": "6df7c94ace4549032ac35ad2652fd6526680172f",
+      "parentRecordedHead": "517bae3ff4c2649a33274978565adf5caa050272",
+      "parentCurrentHead": "517bae3ff4c2649a33274978565adf5caa050272",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6df7c94ac",
+        "sha": "6df7c94ace4549032ac35ad2652fd6526680172f",
+        "iso": "2026-06-02T21:17:01-04:00",
+        "subject": "test(direct-control): extract session framing tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-ready-view-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-session-tests",
+      "children": [
+        "codex/extract-direct-control-notification-tests"
+      ],
+      "depth": 52,
+      "head": "7b1d877bf67d310c660dc52cbd7c5cbd5d26e340",
+      "parentRecordedHead": "6df7c94ace4549032ac35ad2652fd6526680172f",
+      "parentCurrentHead": "6df7c94ace4549032ac35ad2652fd6526680172f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7b1d877bf",
+        "sha": "7b1d877bf67d310c660dc52cbd7c5cbd5d26e340",
+        "iso": "2026-06-02T21:24:12-04:00",
+        "subject": "test(direct-control): extract ready view tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-notification-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-ready-view-tests",
+      "children": [
+        "codex/extract-direct-control-operation-tests"
+      ],
+      "depth": 53,
+      "head": "f4c4270c34e72bf7d8c043e6a9dfc4cc2566ff3b",
+      "parentRecordedHead": "7b1d877bf67d310c660dc52cbd7c5cbd5d26e340",
+      "parentCurrentHead": "7b1d877bf67d310c660dc52cbd7c5cbd5d26e340",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f4c4270c3",
+        "sha": "f4c4270c34e72bf7d8c043e6a9dfc4cc2566ff3b",
+        "iso": "2026-06-02T21:32:03-04:00",
+        "subject": "test(direct-control): extract notification package tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-operation-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-notification-tests",
+      "children": [
+        "codex/harden-direct-control-send-tests"
+      ],
+      "depth": 54,
+      "head": "01a6238d69b89f9cf8c35ba606c8d1aa25d6d952",
+      "parentRecordedHead": "f4c4270c34e72bf7d8c043e6a9dfc4cc2566ff3b",
+      "parentCurrentHead": "f4c4270c34e72bf7d8c043e6a9dfc4cc2566ff3b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "01a6238d6",
+        "sha": "01a6238d69b89f9cf8c35ba606c8d1aa25d6d952",
+        "iso": "2026-06-02T21:40:07-04:00",
+        "subject": "test(direct-control): extract operation request tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/harden-direct-control-send-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-operation-tests",
+      "children": [
+        "codex/extract-direct-control-target-closeout-tests"
+      ],
+      "depth": 55,
+      "head": "fca3db7f125a35350cdb7a11f7142b30eca08ac5",
+      "parentRecordedHead": "01a6238d69b89f9cf8c35ba606c8d1aa25d6d952",
+      "parentCurrentHead": "01a6238d69b89f9cf8c35ba606c8d1aa25d6d952",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fca3db7f1",
+        "sha": "fca3db7f125a35350cdb7a11f7142b30eca08ac5",
+        "iso": "2026-06-02T21:50:56-04:00",
+        "subject": "test(direct-control): harden operation send tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-target-closeout-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/harden-direct-control-send-tests",
+      "children": [
+        "codex/add-direct-control-diplomacy-narrative-tests"
+      ],
+      "depth": 56,
+      "head": "f16830048ca030d47f9692bd4f42c9f4eff1c2b4",
+      "parentRecordedHead": "fca3db7f125a35350cdb7a11f7142b30eca08ac5",
+      "parentCurrentHead": "fca3db7f125a35350cdb7a11f7142b30eca08ac5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f16830048",
+        "sha": "f16830048ca030d47f9692bd4f42c9f4eff1c2b4",
+        "iso": "2026-06-02T22:00:46-04:00",
+        "subject": "test(direct-control): extract target and closeout tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-direct-control-diplomacy-narrative-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-target-closeout-tests",
+      "children": [
+        "codex/retire-windows-vm-bridge-guidance"
+      ],
+      "depth": 57,
+      "head": "dfb76b50c21ef63605d309752ec7f0e42bc515e5",
+      "parentRecordedHead": "f16830048ca030d47f9692bd4f42c9f4eff1c2b4",
+      "parentCurrentHead": "f16830048ca030d47f9692bd4f42c9f4eff1c2b4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "dfb76b50c",
+        "sha": "dfb76b50c21ef63605d309752ec7f0e42bc515e5",
+        "iso": "2026-06-02T22:11:02-04:00",
+        "subject": "test(direct-control): add diplomacy narrative tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/retire-windows-vm-bridge-guidance",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-direct-control-diplomacy-narrative-tests",
+      "children": [
+        "codex/add-direct-control-read-surface-tests"
+      ],
+      "depth": 58,
+      "head": "c410d6db3c065687dfa512b9ee08fc704ccdb046",
+      "parentRecordedHead": "dfb76b50c21ef63605d309752ec7f0e42bc515e5",
+      "parentCurrentHead": "dfb76b50c21ef63605d309752ec7f0e42bc515e5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c410d6db3",
+        "sha": "c410d6db3c065687dfa512b9ee08fc704ccdb046",
+        "iso": "2026-06-02T22:12:18-04:00",
+        "subject": "docs(skills): retire Windows VM bridge guidance"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-direct-control-read-surface-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/retire-windows-vm-bridge-guidance",
+      "children": [
+        "codex/add-direct-control-lifecycle-runtime-tests"
+      ],
+      "depth": 59,
+      "head": "4bdce5eb79f534c2ce299a28f505de369b27f5e2",
+      "parentRecordedHead": "c410d6db3c065687dfa512b9ee08fc704ccdb046",
+      "parentCurrentHead": "c410d6db3c065687dfa512b9ee08fc704ccdb046",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4bdce5eb7",
+        "sha": "4bdce5eb79f534c2ce299a28f505de369b27f5e2",
+        "iso": "2026-06-02T22:21:40-04:00",
+        "subject": "test(direct-control): add read surface tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-direct-control-lifecycle-runtime-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-direct-control-read-surface-tests",
+      "children": [
+        "codex/plan-effect-cli-surface-workstream"
+      ],
+      "depth": 60,
+      "head": "b7f0db64eda8607ad736d1eee62552a2691bb96a",
+      "parentRecordedHead": "4bdce5eb79f534c2ce299a28f505de369b27f5e2",
+      "parentCurrentHead": "4bdce5eb79f534c2ce299a28f505de369b27f5e2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b7f0db64e",
+        "sha": "b7f0db64eda8607ad736d1eee62552a2691bb96a",
+        "iso": "2026-06-02T22:33:04-04:00",
+        "subject": "test(direct-control): add lifecycle runtime tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/plan-effect-cli-surface-workstream",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-direct-control-lifecycle-runtime-tests",
+      "children": [
+        "codex/repair-progress-dashboard-proof-title"
+      ],
+      "depth": 61,
+      "head": "cb3075ce5137b1aeba6f15e962e31aebdc2ae4a6",
+      "parentRecordedHead": "b7f0db64eda8607ad736d1eee62552a2691bb96a",
+      "parentCurrentHead": "b7f0db64eda8607ad736d1eee62552a2691bb96a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cb3075ce5",
+        "sha": "cb3075ce5137b1aeba6f15e962e31aebdc2ae4a6",
+        "iso": "2026-06-02T22:38:03-04:00",
+        "subject": "docs(openspec): plan Effect and CLI surface lanes"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/repair-progress-dashboard-proof-title",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/plan-effect-cli-surface-workstream",
+      "children": [
+        "codex/extract-direct-control-restart-lifecycle-tests"
+      ],
+      "depth": 62,
+      "head": "2e7d347b1f6cfb2a6383f7e83db9bee5e6a14c3c",
+      "parentRecordedHead": "cb3075ce5137b1aeba6f15e962e31aebdc2ae4a6",
+      "parentCurrentHead": "cb3075ce5137b1aeba6f15e962e31aebdc2ae4a6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2e7d347b1",
+        "sha": "2e7d347b1f6cfb2a6383f7e83db9bee5e6a14c3c",
+        "iso": "2026-06-02T22:51:35-04:00",
+        "subject": "test(direct-control): clarify progress dashboard proof wording"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-restart-lifecycle-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/repair-progress-dashboard-proof-title",
+      "children": [
+        "codex/extract-direct-control-component-id-primitive"
+      ],
+      "depth": 63,
+      "head": "643ccc6b2955a085b15ac86dfad87ae086220082",
+      "parentRecordedHead": "2e7d347b1f6cfb2a6383f7e83db9bee5e6a14c3c",
+      "parentCurrentHead": "2e7d347b1f6cfb2a6383f7e83db9bee5e6a14c3c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "643ccc6b2",
+        "sha": "643ccc6b2955a085b15ac86dfad87ae086220082",
+        "iso": "2026-06-02T22:55:08-04:00",
+        "subject": "test(direct-control): extract restart lifecycle tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-component-id-primitive",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-restart-lifecycle-tests",
+      "children": [
+        "codex/extract-direct-control-tuner-framing"
+      ],
+      "depth": 64,
+      "head": "5589377ec5be60aa00c5800d99c36aae8b22cbdf",
+      "parentRecordedHead": "643ccc6b2955a085b15ac86dfad87ae086220082",
+      "parentCurrentHead": "643ccc6b2955a085b15ac86dfad87ae086220082",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5589377ec",
+        "sha": "5589377ec5be60aa00c5800d99c36aae8b22cbdf",
+        "iso": "2026-06-02T23:02:21-04:00",
+        "subject": "refactor(direct-control): extract component id primitive"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-tuner-framing",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-component-id-primitive",
+      "children": [
+        "codex/extract-direct-control-settlement-source"
+      ],
+      "depth": 65,
+      "head": "2b5d5b52f45f0b16f936377e153769dad4126f28",
+      "parentRecordedHead": "5589377ec5be60aa00c5800d99c36aae8b22cbdf",
+      "parentCurrentHead": "5589377ec5be60aa00c5800d99c36aae8b22cbdf",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2b5d5b52f",
+        "sha": "2b5d5b52f45f0b16f936377e153769dad4126f28",
+        "iso": "2026-06-02T23:05:52-04:00",
+        "subject": "refactor(direct-control): extract tuner framing helpers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-settlement-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-tuner-framing",
+      "children": [
+        "codex/extract-direct-control-traditions-source"
+      ],
+      "depth": 66,
+      "head": "3c0dee1a3d1df5c1aa0dca10f1d42ee634a07f6f",
+      "parentRecordedHead": "2b5d5b52f45f0b16f936377e153769dad4126f28",
+      "parentCurrentHead": "2b5d5b52f45f0b16f936377e153769dad4126f28",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3c0dee1a3",
+        "sha": "3c0dee1a3d1df5c1aa0dca10f1d42ee634a07f6f",
+        "iso": "2026-06-02T23:09:08-04:00",
+        "subject": "refactor(direct-control): extract settlement recommendation source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-traditions-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-settlement-source",
+      "children": [
+        "codex/extract-direct-control-unit-move-preview-source"
+      ],
+      "depth": 67,
+      "head": "7b8bb45e4b6542eb68d578a4adba60bf7e8379df",
+      "parentRecordedHead": "3c0dee1a3d1df5c1aa0dca10f1d42ee634a07f6f",
+      "parentCurrentHead": "3c0dee1a3d1df5c1aa0dca10f1d42ee634a07f6f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7b8bb45e4",
+        "sha": "7b8bb45e4b6542eb68d578a4adba60bf7e8379df",
+        "iso": "2026-06-02T23:13:27-04:00",
+        "subject": "refactor(direct-control): extract traditions view source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-unit-move-preview-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-traditions-source",
+      "children": [
+        "codex/extract-direct-control-progress-dashboard-source"
+      ],
+      "depth": 68,
+      "head": "a850e300d5c3bf288dc7eeaec016c575666a4d63",
+      "parentRecordedHead": "7b8bb45e4b6542eb68d578a4adba60bf7e8379df",
+      "parentCurrentHead": "7b8bb45e4b6542eb68d578a4adba60bf7e8379df",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a850e300d",
+        "sha": "a850e300d5c3bf288dc7eeaec016c575666a4d63",
+        "iso": "2026-06-02T23:19:51-04:00",
+        "subject": "refactor(direct-control): extract unit move preview source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-progress-dashboard-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-unit-move-preview-source",
+      "children": [
+        "codex/extract-direct-control-ready-unit-source"
+      ],
+      "depth": 69,
+      "head": "55c3ae7510186dbdaaa33cddb094332d37651cdd",
+      "parentRecordedHead": "a850e300d5c3bf288dc7eeaec016c575666a4d63",
+      "parentCurrentHead": "a850e300d5c3bf288dc7eeaec016c575666a4d63",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "55c3ae751",
+        "sha": "55c3ae7510186dbdaaa33cddb094332d37651cdd",
+        "iso": "2026-06-02T23:22:53-04:00",
+        "subject": "refactor(direct-control): extract progress dashboard source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-ready-unit-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-progress-dashboard-source",
+      "children": [
+        "codex/extract-direct-control-ready-city-source"
+      ],
+      "depth": 70,
+      "head": "b066b9b5dcae7fb2d3373d20b5b3aa2f64c8c09f",
+      "parentRecordedHead": "55c3ae7510186dbdaaa33cddb094332d37651cdd",
+      "parentCurrentHead": "55c3ae7510186dbdaaa33cddb094332d37651cdd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b066b9b5d",
+        "sha": "b066b9b5dcae7fb2d3373d20b5b3aa2f64c8c09f",
+        "iso": "2026-06-02T23:26:22-04:00",
+        "subject": "refactor(direct-control): extract ready unit source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-ready-city-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-ready-unit-source",
+      "children": [
+        "codex/extract-direct-control-target-candidates-source"
+      ],
+      "depth": 71,
+      "head": "f3aaa1bb2fe6ce35b17f7d2e32caad8fc5b8ecce",
+      "parentRecordedHead": "b066b9b5dcae7fb2d3373d20b5b3aa2f64c8c09f",
+      "parentCurrentHead": "b066b9b5dcae7fb2d3373d20b5b3aa2f64c8c09f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f3aaa1bb2",
+        "sha": "f3aaa1bb2fe6ce35b17f7d2e32caad8fc5b8ecce",
+        "iso": "2026-06-02T23:30:25-04:00",
+        "subject": "refactor(direct-control): extract ready city source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-target-candidates-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-ready-city-source",
+      "children": [
+        "codex/extract-direct-control-battlefield-source"
+      ],
+      "depth": 72,
+      "head": "4d2685a1753153e20e4f2b0e9aebc0bb2aec4a9d",
+      "parentRecordedHead": "f3aaa1bb2fe6ce35b17f7d2e32caad8fc5b8ecce",
+      "parentCurrentHead": "f3aaa1bb2fe6ce35b17f7d2e32caad8fc5b8ecce",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4d2685a17",
+        "sha": "4d2685a1753153e20e4f2b0e9aebc0bb2aec4a9d",
+        "iso": "2026-06-02T23:32:22-04:00",
+        "subject": "refactor(direct-control): extract target candidates source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-battlefield-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-target-candidates-source",
+      "children": [
+        "codex/extract-direct-control-destination-source"
+      ],
+      "depth": 73,
+      "head": "2aadddcd2086fc733341b86adf907ab27db180a8",
+      "parentRecordedHead": "4d2685a1753153e20e4f2b0e9aebc0bb2aec4a9d",
+      "parentCurrentHead": "4d2685a1753153e20e4f2b0e9aebc0bb2aec4a9d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2aadddcd2",
+        "sha": "2aadddcd2086fc733341b86adf907ab27db180a8",
+        "iso": "2026-06-02T23:34:12-04:00",
+        "subject": "refactor(direct-control): extract battlefield scan source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-destination-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-battlefield-source",
+      "children": [
+        "codex/extract-direct-control-notification-dismissal-source"
+      ],
+      "depth": 74,
+      "head": "67301713ab16df57fd57702ebb8f6e8074bdc331",
+      "parentRecordedHead": "2aadddcd2086fc733341b86adf907ab27db180a8",
+      "parentCurrentHead": "2aadddcd2086fc733341b86adf907ab27db180a8",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "67301713a",
+        "sha": "67301713ab16df57fd57702ebb8f6e8074bdc331",
+        "iso": "2026-06-02T23:36:04-04:00",
+        "subject": "refactor(direct-control): extract destination analysis source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-notification-dismissal-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-destination-source",
+      "children": [
+        "codex/extract-direct-control-notification-view-source"
+      ],
+      "depth": 75,
+      "head": "de95e16d7f62f8c3333171dd0b649720fe87dcb8",
+      "parentRecordedHead": "67301713ab16df57fd57702ebb8f6e8074bdc331",
+      "parentCurrentHead": "67301713ab16df57fd57702ebb8f6e8074bdc331",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "de95e16d7",
+        "sha": "de95e16d7f62f8c3333171dd0b649720fe87dcb8",
+        "iso": "2026-06-02T23:41:28-04:00",
+        "subject": "refactor(direct-control): extract notification dismissal source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-notification-view-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-notification-dismissal-source",
+      "children": [
+        "codex/extract-direct-control-operation-router-source"
+      ],
+      "depth": 76,
+      "head": "2ade95f8d8f91e51bee82004808b6ad7c8e96828",
+      "parentRecordedHead": "de95e16d7f62f8c3333171dd0b649720fe87dcb8",
+      "parentCurrentHead": "de95e16d7f62f8c3333171dd0b649720fe87dcb8",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2ade95f8d",
+        "sha": "2ade95f8d8f91e51bee82004808b6ad7c8e96828",
+        "iso": "2026-06-02T23:44:35-04:00",
+        "subject": "refactor(direct-control): extract notification view source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-operation-router-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-notification-view-source",
+      "children": [
+        "codex/extract-direct-control-progression-closeout-sources"
+      ],
+      "depth": 77,
+      "head": "66474c0f60ff1c9b7e7c14130ccb99a3feb19864",
+      "parentRecordedHead": "2ade95f8d8f91e51bee82004808b6ad7c8e96828",
+      "parentCurrentHead": "2ade95f8d8f91e51bee82004808b6ad7c8e96828",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "66474c0f6",
+        "sha": "66474c0f60ff1c9b7e7c14130ccb99a3feb19864",
+        "iso": "2026-06-02T23:47:14-04:00",
+        "subject": "refactor(direct-control): extract operation router source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-progression-closeout-sources",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-operation-router-source",
+      "children": [
+        "codex/extract-direct-control-production-choice-source"
+      ],
+      "depth": 78,
+      "head": "05096d78ca0bbe28161bfc76596e487b20c05c56",
+      "parentRecordedHead": "66474c0f60ff1c9b7e7c14130ccb99a3feb19864",
+      "parentCurrentHead": "66474c0f60ff1c9b7e7c14130ccb99a3feb19864",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "05096d78c",
+        "sha": "05096d78ca0bbe28161bfc76596e487b20c05c56",
+        "iso": "2026-06-02T23:51:04-04:00",
+        "subject": "refactor(direct-control): extract progression closeout sources"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-production-choice-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-progression-closeout-sources",
+      "children": [
+        "codex/extract-direct-control-unit-postconditions"
+      ],
+      "depth": 79,
+      "head": "243b5a78677e2581bcebb58f605d01bbeab1805e",
+      "parentRecordedHead": "05096d78ca0bbe28161bfc76596e487b20c05c56",
+      "parentCurrentHead": "05096d78ca0bbe28161bfc76596e487b20c05c56",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "243b5a786",
+        "sha": "243b5a78677e2581bcebb58f605d01bbeab1805e",
+        "iso": "2026-06-03T01:51:44-04:00",
+        "subject": "refactor(direct-control): extract production choice source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-unit-postconditions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-production-choice-source",
+      "children": [
+        "codex/extract-direct-control-population-postconditions"
+      ],
+      "depth": 80,
+      "head": "06b3b4182e99ea0ea65fd88235000b1836b323d2",
+      "parentRecordedHead": "243b5a78677e2581bcebb58f605d01bbeab1805e",
+      "parentCurrentHead": "243b5a78677e2581bcebb58f605d01bbeab1805e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "06b3b4182",
+        "sha": "06b3b4182e99ea0ea65fd88235000b1836b323d2",
+        "iso": "2026-06-03T01:59:06-04:00",
+        "subject": "refactor(direct-control): extract unit operation postconditions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-population-postconditions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-unit-postconditions",
+      "children": [
+        "codex/extract-direct-control-production-postconditions"
+      ],
+      "depth": 81,
+      "head": "b53b18150b8498bc635a7d3496146addfa1dffa0",
+      "parentRecordedHead": "06b3b4182e99ea0ea65fd88235000b1836b323d2",
+      "parentCurrentHead": "06b3b4182e99ea0ea65fd88235000b1836b323d2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b53b18150",
+        "sha": "b53b18150b8498bc635a7d3496146addfa1dffa0",
+        "iso": "2026-06-03T02:07:34-04:00",
+        "subject": "refactor(direct-control): extract population placement postconditions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-production-postconditions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-population-postconditions",
+      "children": [
+        "codex/extract-direct-control-notification-verification"
+      ],
+      "depth": 82,
+      "head": "b726c7b68555bc4cf47f673a537aa7e135d737dd",
+      "parentRecordedHead": "b53b18150b8498bc635a7d3496146addfa1dffa0",
+      "parentCurrentHead": "b53b18150b8498bc635a7d3496146addfa1dffa0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b726c7b68",
+        "sha": "b726c7b68555bc4cf47f673a537aa7e135d737dd",
+        "iso": "2026-06-03T02:17:15-04:00",
+        "subject": "refactor(direct-control): extract production postconditions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-notification-verification",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-production-postconditions",
+      "children": [
+        "codex/extract-direct-control-narrative-postconditions"
+      ],
+      "depth": 83,
+      "head": "f1a556de2e18dd157649714655d7304f708f42d2",
+      "parentRecordedHead": "b726c7b68555bc4cf47f673a537aa7e135d737dd",
+      "parentCurrentHead": "b726c7b68555bc4cf47f673a537aa7e135d737dd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f1a556de2",
+        "sha": "f1a556de2e18dd157649714655d7304f708f42d2",
+        "iso": "2026-06-03T02:23:21-04:00",
+        "subject": "refactor(direct-control): extract notification verification"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-narrative-postconditions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-notification-verification",
+      "children": [
+        "codex/extract-direct-control-diplomacy-postconditions"
+      ],
+      "depth": 84,
+      "head": "6632b692c432efe1e64b4748c63617c6d1533835",
+      "parentRecordedHead": "f1a556de2e18dd157649714655d7304f708f42d2",
+      "parentCurrentHead": "f1a556de2e18dd157649714655d7304f708f42d2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6632b692c",
+        "sha": "6632b692c432efe1e64b4748c63617c6d1533835",
+        "iso": "2026-06-03T02:40:10-04:00",
+        "subject": "refactor(direct-control): extract narrative choice verification"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-diplomacy-postconditions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-narrative-postconditions",
+      "children": [
+        "codex/extract-direct-control-notification-dismissal-wrapper"
+      ],
+      "depth": 85,
+      "head": "810f452e9c6b3eb6197ff4b0aaa1f78d74be0079",
+      "parentRecordedHead": "6632b692c432efe1e64b4748c63617c6d1533835",
+      "parentCurrentHead": "6632b692c432efe1e64b4748c63617c6d1533835",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "810f452e9",
+        "sha": "810f452e9c6b3eb6197ff4b0aaa1f78d74be0079",
+        "iso": "2026-06-03T02:55:53-04:00",
+        "subject": "refactor(direct-control): extract diplomacy response verification"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-notification-dismissal-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-diplomacy-postconditions",
+      "children": [
+        "codex/extract-direct-control-diplomacy-wrapper"
+      ],
+      "depth": 86,
+      "head": "97f5daa7311c95fcf0785e24e4495090f4e4b4db",
+      "parentRecordedHead": "810f452e9c6b3eb6197ff4b0aaa1f78d74be0079",
+      "parentCurrentHead": "810f452e9c6b3eb6197ff4b0aaa1f78d74be0079",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "97f5daa73",
+        "sha": "97f5daa7311c95fcf0785e24e4495090f4e4b4db",
+        "iso": "2026-06-03T03:08:40-04:00",
+        "subject": "refactor(direct-control): extract notification dismissal wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-diplomacy-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-notification-dismissal-wrapper",
+      "children": [
+        "codex/extract-direct-control-narrative-wrapper"
+      ],
+      "depth": 87,
+      "head": "08add3b555a9ec50d4b301745cdb9d0b4322ef7c",
+      "parentRecordedHead": "97f5daa7311c95fcf0785e24e4495090f4e4b4db",
+      "parentCurrentHead": "97f5daa7311c95fcf0785e24e4495090f4e4b4db",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "08add3b55",
+        "sha": "08add3b555a9ec50d4b301745cdb9d0b4322ef7c",
+        "iso": "2026-06-03T03:19:40-04:00",
+        "subject": "refactor(direct-control): extract diplomacy response wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-narrative-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-diplomacy-wrapper",
+      "children": [
+        "codex/extract-direct-control-progression-read-wrappers"
+      ],
+      "depth": 88,
+      "head": "d0687de8f9fc4cd6492bef5a681e3d45f5c1c554",
+      "parentRecordedHead": "08add3b555a9ec50d4b301745cdb9d0b4322ef7c",
+      "parentCurrentHead": "08add3b555a9ec50d4b301745cdb9d0b4322ef7c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d0687de8f",
+        "sha": "d0687de8f9fc4cd6492bef5a681e3d45f5c1c554",
+        "iso": "2026-06-03T03:31:52-04:00",
+        "subject": "refactor(direct-control): extract narrative choice wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-progression-read-wrappers",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-narrative-wrapper",
+      "children": [
+        "codex/extract-direct-control-settlement-read-wrapper"
+      ],
+      "depth": 89,
+      "head": "e4c7a248c5812ad3ff32b0de51c2bb243ddcd3e6",
+      "parentRecordedHead": "d0687de8f9fc4cd6492bef5a681e3d45f5c1c554",
+      "parentCurrentHead": "d0687de8f9fc4cd6492bef5a681e3d45f5c1c554",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e4c7a248c",
+        "sha": "e4c7a248c5812ad3ff32b0de51c2bb243ddcd3e6",
+        "iso": "2026-06-03T03:41:34-04:00",
+        "subject": "refactor(direct-control): extract progression read wrappers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-settlement-read-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-progression-read-wrappers",
+      "children": [
+        "codex/extract-direct-control-target-candidates-read-wrapper"
+      ],
+      "depth": 90,
+      "head": "1dc2a542a304fe690ae74507d1f5ebbb15a08ff6",
+      "parentRecordedHead": "e4c7a248c5812ad3ff32b0de51c2bb243ddcd3e6",
+      "parentCurrentHead": "e4c7a248c5812ad3ff32b0de51c2bb243ddcd3e6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1dc2a542a",
+        "sha": "1dc2a542a304fe690ae74507d1f5ebbb15a08ff6",
+        "iso": "2026-06-03T03:53:13-04:00",
+        "subject": "refactor(direct-control): extract settlement read wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-target-candidates-read-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-settlement-read-wrapper",
+      "children": [
+        "codex/extract-direct-control-battlefield-read-wrapper"
+      ],
+      "depth": 91,
+      "head": "f0c2a7ed523eb7c11827605a1676d7cdb71854a9",
+      "parentRecordedHead": "1dc2a542a304fe690ae74507d1f5ebbb15a08ff6",
+      "parentCurrentHead": "1dc2a542a304fe690ae74507d1f5ebbb15a08ff6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f0c2a7ed5",
+        "sha": "f0c2a7ed523eb7c11827605a1676d7cdb71854a9",
+        "iso": "2026-06-03T03:57:27-04:00",
+        "subject": "refactor(direct-control): extract target candidates read wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-battlefield-read-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-target-candidates-read-wrapper",
+      "children": [
+        "codex/extract-direct-control-destination-read-wrapper"
+      ],
+      "depth": 92,
+      "head": "9946d0c5046e6c4c12a14661cfcf9e6dceca431b",
+      "parentRecordedHead": "f0c2a7ed523eb7c11827605a1676d7cdb71854a9",
+      "parentCurrentHead": "f0c2a7ed523eb7c11827605a1676d7cdb71854a9",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9946d0c50",
+        "sha": "9946d0c5046e6c4c12a14661cfcf9e6dceca431b",
+        "iso": "2026-06-03T04:01:56-04:00",
+        "subject": "refactor(direct-control): extract battlefield read wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-destination-read-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-battlefield-read-wrapper",
+      "children": [
+        "codex/extract-direct-control-unit-move-preview-wrapper"
+      ],
+      "depth": 93,
+      "head": "ca0cee35011c3edca31456daf28e94c9e94b7b3e",
+      "parentRecordedHead": "9946d0c5046e6c4c12a14661cfcf9e6dceca431b",
+      "parentCurrentHead": "9946d0c5046e6c4c12a14661cfcf9e6dceca431b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ca0cee350",
+        "sha": "ca0cee35011c3edca31456daf28e94c9e94b7b3e",
+        "iso": "2026-06-03T04:11:05-04:00",
+        "subject": "refactor(direct-control): extract destination read wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-unit-move-preview-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-destination-read-wrapper",
+      "children": [
+        "codex/extract-direct-control-ready-unit-wrapper"
+      ],
+      "depth": 94,
+      "head": "0ebf5e29fcc0d2d5158756bb5848a998e9cbf886",
+      "parentRecordedHead": "ca0cee35011c3edca31456daf28e94c9e94b7b3e",
+      "parentCurrentHead": "ca0cee35011c3edca31456daf28e94c9e94b7b3e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0ebf5e29f",
+        "sha": "0ebf5e29fcc0d2d5158756bb5848a998e9cbf886",
+        "iso": "2026-06-03T04:16:11-04:00",
+        "subject": "refactor(direct-control): extract unit move preview wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-ready-unit-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-unit-move-preview-wrapper",
+      "children": [
+        "codex/extract-direct-control-ready-city-wrapper"
+      ],
+      "depth": 95,
+      "head": "32cbb594bbad523642addf89dc7f5be05e1c9513",
+      "parentRecordedHead": "0ebf5e29fcc0d2d5158756bb5848a998e9cbf886",
+      "parentCurrentHead": "0ebf5e29fcc0d2d5158756bb5848a998e9cbf886",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "32cbb594b",
+        "sha": "32cbb594bbad523642addf89dc7f5be05e1c9513",
+        "iso": "2026-06-03T04:21:07-04:00",
+        "subject": "refactor(direct-control): extract ready unit wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-ready-city-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-ready-unit-wrapper",
+      "children": [
+        "codex/extract-direct-control-notification-view-wrapper"
+      ],
+      "depth": 96,
+      "head": "5751d74d317d4148172dbac6706cd4eb87d33322",
+      "parentRecordedHead": "32cbb594bbad523642addf89dc7f5be05e1c9513",
+      "parentCurrentHead": "32cbb594bbad523642addf89dc7f5be05e1c9513",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5751d74d3",
+        "sha": "5751d74d317d4148172dbac6706cd4eb87d33322",
+        "iso": "2026-06-03T04:28:40-04:00",
+        "subject": "refactor(direct-control): extract ready city wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-notification-view-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-ready-city-wrapper",
+      "children": [
+        "codex/extract-direct-control-unit-target-action"
+      ],
+      "depth": 97,
+      "head": "15d88033ded087154e7eb60118921e7b0197d471",
+      "parentRecordedHead": "5751d74d317d4148172dbac6706cd4eb87d33322",
+      "parentCurrentHead": "5751d74d317d4148172dbac6706cd4eb87d33322",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "15d88033d",
+        "sha": "15d88033ded087154e7eb60118921e7b0197d471",
+        "iso": "2026-06-03T04:33:34-04:00",
+        "subject": "refactor(direct-control): extract notification view wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-unit-target-action",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-notification-view-wrapper",
+      "children": [
+        "codex/extract-direct-control-map-read-wrapper"
+      ],
+      "depth": 98,
+      "head": "0c8401a34b0b67f4517a836585775bd697f53609",
+      "parentRecordedHead": "15d88033ded087154e7eb60118921e7b0197d471",
+      "parentCurrentHead": "15d88033ded087154e7eb60118921e7b0197d471",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0c8401a34",
+        "sha": "0c8401a34b0b67f4517a836585775bd697f53609",
+        "iso": "2026-06-03T04:54:51-04:00",
+        "subject": "refactor(direct-control): extract unit target action"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-map-read-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-unit-target-action",
+      "children": [
+        "codex/plan-direct-control-ai-intelligence-compatibility"
+      ],
+      "depth": 99,
+      "head": "72e0f7e55664ef07b7fa918e29e4c126120535c2",
+      "parentRecordedHead": "0c8401a34b0b67f4517a836585775bd697f53609",
+      "parentCurrentHead": "0c8401a34b0b67f4517a836585775bd697f53609",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "72e0f7e55",
+        "sha": "72e0f7e55664ef07b7fa918e29e4c126120535c2",
+        "iso": "2026-06-03T05:08:20-04:00",
+        "subject": "refactor(direct-control): extract map read wrappers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/plan-direct-control-ai-intelligence-compatibility",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-map-read-wrapper",
+      "children": [
+        "codex/extract-direct-control-visibility-read-wrapper"
+      ],
+      "depth": 100,
+      "head": "dab79a7cb4763d2138fe5c0d94d76cfb8d2c2c66",
+      "parentRecordedHead": "72e0f7e55664ef07b7fa918e29e4c126120535c2",
+      "parentCurrentHead": "72e0f7e55664ef07b7fa918e29e4c126120535c2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "dab79a7cb",
+        "sha": "dab79a7cb4763d2138fe5c0d94d76cfb8d2c2c66",
+        "iso": "2026-06-03T05:20:15-04:00",
+        "subject": "docs(direct-control): disposition AI compatibility reports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-visibility-read-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/plan-direct-control-ai-intelligence-compatibility",
+      "children": [
+        "codex/extract-direct-control-gameinfo-read-wrapper"
+      ],
+      "depth": 101,
+      "head": "699c14b1580b67357246ec5f573a26d5d0ceb77f",
+      "parentRecordedHead": "dab79a7cb4763d2138fe5c0d94d76cfb8d2c2c66",
+      "parentCurrentHead": "dab79a7cb4763d2138fe5c0d94d76cfb8d2c2c66",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "699c14b15",
+        "sha": "699c14b1580b67357246ec5f573a26d5d0ceb77f",
+        "iso": "2026-06-03T05:27:14-04:00",
+        "subject": "refactor(direct-control): extract visibility read wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-gameinfo-read-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-visibility-read-wrapper",
+      "children": [
+        "codex/extract-direct-control-summary-read-wrapper"
+      ],
+      "depth": 102,
+      "head": "e6b3ab21e6241ac87a5e385f5e0555501f3df19c",
+      "parentRecordedHead": "699c14b1580b67357246ec5f573a26d5d0ceb77f",
+      "parentCurrentHead": "699c14b1580b67357246ec5f573a26d5d0ceb77f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e6b3ab21e",
+        "sha": "e6b3ab21e6241ac87a5e385f5e0555501f3df19c",
+        "iso": "2026-06-03T05:36:57-04:00",
+        "subject": "refactor(direct-control): extract GameInfo read wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-summary-read-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-gameinfo-read-wrapper",
+      "children": [
+        "codex/plan-direct-control-hotseat-ai-compatibility"
+      ],
+      "depth": 103,
+      "head": "dac2c1fd23c9166bb365c1da5d46484791bdc996",
+      "parentRecordedHead": "e6b3ab21e6241ac87a5e385f5e0555501f3df19c",
+      "parentCurrentHead": "e6b3ab21e6241ac87a5e385f5e0555501f3df19c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "dac2c1fd2",
+        "sha": "dac2c1fd23c9166bb365c1da5d46484791bdc996",
+        "iso": "2026-06-03T05:46:51-04:00",
+        "subject": "refactor(direct-control): extract summary read wrappers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/plan-direct-control-hotseat-ai-compatibility",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-summary-read-wrapper",
+      "children": [
+        "codex/extract-direct-control-runtime-inspection-wrapper"
+      ],
+      "depth": 104,
+      "head": "bc2e71c3b6e9927a0f83c1c40d7961fa2423cedf",
+      "parentRecordedHead": "dac2c1fd23c9166bb365c1da5d46484791bdc996",
+      "parentCurrentHead": "dac2c1fd23c9166bb365c1da5d46484791bdc996",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bc2e71c3b",
+        "sha": "bc2e71c3b6e9927a0f83c1c40d7961fa2423cedf",
+        "iso": "2026-06-03T05:56:21-04:00",
+        "subject": "docs(direct-control): refine hotseat AI compatibility disposition"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-runtime-inspection-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/plan-direct-control-hotseat-ai-compatibility",
+      "children": [
+        "codex/extract-direct-control-app-ui-snapshot-wrapper"
+      ],
+      "depth": 105,
+      "head": "6d066794d4b45d34c95b1abd8a1118444fe4b1b9",
+      "parentRecordedHead": "bc2e71c3b6e9927a0f83c1c40d7961fa2423cedf",
+      "parentCurrentHead": "bc2e71c3b6e9927a0f83c1c40d7961fa2423cedf",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6d066794d",
+        "sha": "6d066794d4b45d34c95b1abd8a1118444fe4b1b9",
+        "iso": "2026-06-03T06:03:39-04:00",
+        "subject": "refactor(direct-control): extract runtime inspection wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-app-ui-snapshot-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-runtime-inspection-wrapper",
+      "children": [
+        "codex/refine-direct-control-ai-hotseat-direct-read-status"
+      ],
+      "depth": 106,
+      "head": "75945ca8e48fb4d350118f3d886eae9e8a7dfec9",
+      "parentRecordedHead": "6d066794d4b45d34c95b1abd8a1118444fe4b1b9",
+      "parentCurrentHead": "6d066794d4b45d34c95b1abd8a1118444fe4b1b9",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "75945ca8e",
+        "sha": "75945ca8e48fb4d350118f3d886eae9e8a7dfec9",
+        "iso": "2026-06-03T06:11:47-04:00",
+        "subject": "refactor(direct-control): extract App UI snapshot wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/refine-direct-control-ai-hotseat-direct-read-status",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-app-ui-snapshot-wrapper",
+      "children": [
+        "codex/extract-direct-control-tuner-health-wrapper"
+      ],
+      "depth": 107,
+      "head": "e6d290c3dbe8eea8c4a4caff198584c3dbbbb859",
+      "parentRecordedHead": "75945ca8e48fb4d350118f3d886eae9e8a7dfec9",
+      "parentCurrentHead": "75945ca8e48fb4d350118f3d886eae9e8a7dfec9",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e6d290c3d",
+        "sha": "e6d290c3dbe8eea8c4a4caff198584c3dbbbb859",
+        "iso": "2026-06-03T06:15:38-04:00",
+        "subject": "docs(direct-control): refine AI hotseat direct-read status"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-tuner-health-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/refine-direct-control-ai-hotseat-direct-read-status",
+      "children": [
+        "codex/define-direct-control-ai-hotseat-compatibility-gate"
+      ],
+      "depth": 108,
+      "head": "16640e7e74473ea781eb91c0c86d5b336dfe72f7",
+      "parentRecordedHead": "e6d290c3dbe8eea8c4a4caff198584c3dbbbb859",
+      "parentCurrentHead": "e6d290c3dbe8eea8c4a4caff198584c3dbbbb859",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "16640e7e7",
+        "sha": "16640e7e74473ea781eb91c0c86d5b336dfe72f7",
+        "iso": "2026-06-03T06:23:18-04:00",
+        "subject": "refactor(direct-control): extract Tuner health wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/define-direct-control-ai-hotseat-compatibility-gate",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-tuner-health-wrapper",
+      "children": [
+        "codex/repair-direct-control-ai-hotseat-hard-gate"
+      ],
+      "depth": 109,
+      "head": "c92bf96deea9bcccea99d4c18269b1179460c8f1",
+      "parentRecordedHead": "16640e7e74473ea781eb91c0c86d5b336dfe72f7",
+      "parentCurrentHead": "16640e7e74473ea781eb91c0c86d5b336dfe72f7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c92bf96de",
+        "sha": "c92bf96deea9bcccea99d4c18269b1179460c8f1",
+        "iso": "2026-06-03T06:26:45-04:00",
+        "subject": "docs(direct-control): define AI hotseat compatibility gate"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/repair-direct-control-ai-hotseat-hard-gate",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/define-direct-control-ai-hotseat-compatibility-gate",
+      "children": [
+        "codex/add-direct-control-ai-hotseat-matrix-rows"
+      ],
+      "depth": 110,
+      "head": "3b8a0c0994bf9c7d6110c94491e9a8748bfaefa2",
+      "parentRecordedHead": "c92bf96deea9bcccea99d4c18269b1179460c8f1",
+      "parentCurrentHead": "c92bf96deea9bcccea99d4c18269b1179460c8f1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3b8a0c099",
+        "sha": "3b8a0c0994bf9c7d6110c94491e9a8748bfaefa2",
+        "iso": "2026-06-03T06:30:38-04:00",
+        "subject": "docs(direct-control): harden AI hotseat compatibility gate"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-direct-control-ai-hotseat-matrix-rows",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/repair-direct-control-ai-hotseat-hard-gate",
+      "children": [
+        "codex/extract-direct-control-proof-log-helpers"
+      ],
+      "depth": 111,
+      "head": "436891b22db79a224fc08b3820cd94f49356ff6f",
+      "parentRecordedHead": "3b8a0c0994bf9c7d6110c94491e9a8748bfaefa2",
+      "parentCurrentHead": "3b8a0c0994bf9c7d6110c94491e9a8748bfaefa2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "436891b22",
+        "sha": "436891b22db79a224fc08b3820cd94f49356ff6f",
+        "iso": "2026-06-03T06:36:29-04:00",
+        "subject": "docs(direct-control): add AI hotseat matrix rows"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-proof-log-helpers",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-direct-control-ai-hotseat-matrix-rows",
+      "children": [
+        "codex/extract-direct-control-capability-catalog"
+      ],
+      "depth": 112,
+      "head": "b98ff6cc77ab0f50fc015eb4d28846fc9b6d7934",
+      "parentRecordedHead": "436891b22db79a224fc08b3820cd94f49356ff6f",
+      "parentCurrentHead": "436891b22db79a224fc08b3820cd94f49356ff6f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b98ff6cc7",
+        "sha": "b98ff6cc77ab0f50fc015eb4d28846fc9b6d7934",
+        "iso": "2026-06-03T06:41:55-04:00",
+        "subject": "refactor(direct-control): extract proof log helpers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-capability-catalog",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-proof-log-helpers",
+      "children": [
+        "codex/extract-direct-control-playable-status"
+      ],
+      "depth": 113,
+      "head": "4a45084577084b23f7fdc5eb177db4a05cd4e70a",
+      "parentRecordedHead": "b98ff6cc77ab0f50fc015eb4d28846fc9b6d7934",
+      "parentCurrentHead": "b98ff6cc77ab0f50fc015eb4d28846fc9b6d7934",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4a4508457",
+        "sha": "4a45084577084b23f7fdc5eb177db4a05cd4e70a",
+        "iso": "2026-06-03T06:48:57-04:00",
+        "subject": "refactor(direct-control): extract capability catalog owner"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-playable-status",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-capability-catalog",
+      "children": [
+        "codex/extract-direct-control-bounded-root-inspection"
+      ],
+      "depth": 114,
+      "head": "394a71fea04b70b09bfb8e3e2c8e9a8cfa3c0410",
+      "parentRecordedHead": "4a45084577084b23f7fdc5eb177db4a05cd4e70a",
+      "parentCurrentHead": "4a45084577084b23f7fdc5eb177db4a05cd4e70a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "394a71fea",
+        "sha": "394a71fea04b70b09bfb8e3e2c8e9a8cfa3c0410",
+        "iso": "2026-06-03T06:55:58-04:00",
+        "subject": "refactor(direct-control): extract playable status owner"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-bounded-root-inspection",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-playable-status",
+      "children": [
+        "codex/extract-direct-control-capability-catalog-schemas"
+      ],
+      "depth": 115,
+      "head": "9a07f5c6eff561b59c3b5833f4e0b0fc2024749a",
+      "parentRecordedHead": "394a71fea04b70b09bfb8e3e2c8e9a8cfa3c0410",
+      "parentCurrentHead": "394a71fea04b70b09bfb8e3e2c8e9a8cfa3c0410",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9a07f5c6e",
+        "sha": "9a07f5c6eff561b59c3b5833f4e0b0fc2024749a",
+        "iso": "2026-06-03T07:02:54-04:00",
+        "subject": "refactor(direct-control): extract bounded root inspection"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-capability-catalog-schemas",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-bounded-root-inspection",
+      "children": [
+        "codex/extract-direct-control-runtime-inspection-constants"
+      ],
+      "depth": 116,
+      "head": "6a7eddf9cb771e99a1fd8f36080637584f966103",
+      "parentRecordedHead": "9a07f5c6eff561b59c3b5833f4e0b0fc2024749a",
+      "parentCurrentHead": "9a07f5c6eff561b59c3b5833f4e0b0fc2024749a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6a7eddf9c",
+        "sha": "6a7eddf9cb771e99a1fd8f36080637584f966103",
+        "iso": "2026-06-03T07:10:07-04:00",
+        "subject": "refactor(direct-control): extract capability catalog schemas"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-runtime-inspection-constants",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-capability-catalog-schemas",
+      "children": [
+        "codex/extract-direct-control-turn-completion"
+      ],
+      "depth": 117,
+      "head": "af0dd6ec6cef9f71eededb52adb745d84cf74c6a",
+      "parentRecordedHead": "6a7eddf9cb771e99a1fd8f36080637584f966103",
+      "parentCurrentHead": "6a7eddf9cb771e99a1fd8f36080637584f966103",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "af0dd6ec6",
+        "sha": "af0dd6ec6cef9f71eededb52adb745d84cf74c6a",
+        "iso": "2026-06-03T07:16:39-04:00",
+        "subject": "refactor(direct-control): extract runtime inspection constants"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-turn-completion",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-runtime-inspection-constants",
+      "children": [
+        "codex/extract-direct-control-autoplay"
+      ],
+      "depth": 118,
+      "head": "878ed7cb91326aebc7b6e8410e2bdcb44b9e52d9",
+      "parentRecordedHead": "af0dd6ec6cef9f71eededb52adb745d84cf74c6a",
+      "parentCurrentHead": "af0dd6ec6cef9f71eededb52adb745d84cf74c6a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "878ed7cb9",
+        "sha": "878ed7cb91326aebc7b6e8410e2bdcb44b9e52d9",
+        "iso": "2026-06-03T07:22:52-04:00",
+        "subject": "refactor(direct-control): extract turn completion owner"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-autoplay",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-turn-completion",
+      "children": [
+        "codex/extract-direct-control-map-reveal"
+      ],
+      "depth": 119,
+      "head": "44d64171441a200eaf7812983acb9a35dfeda0ee",
+      "parentRecordedHead": "878ed7cb91326aebc7b6e8410e2bdcb44b9e52d9",
+      "parentCurrentHead": "878ed7cb91326aebc7b6e8410e2bdcb44b9e52d9",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "44d641714",
+        "sha": "44d64171441a200eaf7812983acb9a35dfeda0ee",
+        "iso": "2026-06-03T07:32:45-04:00",
+        "subject": "refactor(direct-control): extract autoplay owner"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-map-reveal",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-autoplay",
+      "children": [
+        "codex/extract-direct-control-setup-reads"
+      ],
+      "depth": 120,
+      "head": "f05ff9581b845b8dc3a1d92ed650291aa0cc62db",
+      "parentRecordedHead": "44d64171441a200eaf7812983acb9a35dfeda0ee",
+      "parentCurrentHead": "44d64171441a200eaf7812983acb9a35dfeda0ee",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f05ff9581",
+        "sha": "f05ff9581b845b8dc3a1d92ed650291aa0cc62db",
+        "iso": "2026-06-03T07:37:09-04:00",
+        "subject": "refactor(direct-control): extract map reveal owner"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-setup-reads",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-map-reveal",
+      "children": [
+        "codex/extract-direct-control-setup-refresh"
+      ],
+      "depth": 121,
+      "head": "d0e425480d2eb17148c52bff0297990945cd7e68",
+      "parentRecordedHead": "f05ff9581b845b8dc3a1d92ed650291aa0cc62db",
+      "parentCurrentHead": "f05ff9581b845b8dc3a1d92ed650291aa0cc62db",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d0e425480",
+        "sha": "d0e425480d2eb17148c52bff0297990945cd7e68",
+        "iso": "2026-06-03T07:43:33-04:00",
+        "subject": "refactor(direct-control): extract setup read owner"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-setup-refresh",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-setup-reads",
+      "children": [
+        "codex/extract-direct-control-setup-prepare"
+      ],
+      "depth": 122,
+      "head": "d2d1012c937d9ff3a71a3e2c3b7beef1aa92025f",
+      "parentRecordedHead": "d0e425480d2eb17148c52bff0297990945cd7e68",
+      "parentCurrentHead": "d0e425480d2eb17148c52bff0297990945cd7e68",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d2d1012c9",
+        "sha": "d2d1012c937d9ff3a71a3e2c3b7beef1aa92025f",
+        "iso": "2026-06-03T07:50:39-04:00",
+        "subject": "refactor(direct-control): extract setup refresh owner"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-setup-prepare",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-setup-refresh",
+      "children": [
+        "codex/extract-direct-control-setup-start"
+      ],
+      "depth": 123,
+      "head": "72324eb25ebdc3847a58e830116c70810b47e711",
+      "parentRecordedHead": "d2d1012c937d9ff3a71a3e2c3b7beef1aa92025f",
+      "parentCurrentHead": "d2d1012c937d9ff3a71a3e2c3b7beef1aa92025f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "72324eb25",
+        "sha": "72324eb25ebdc3847a58e830116c70810b47e711",
+        "iso": "2026-06-03T07:57:44-04:00",
+        "subject": "refactor(direct-control): extract setup prepare owner"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-setup-start",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-setup-prepare",
+      "children": [
+        "codex/extract-direct-control-setup-run"
+      ],
+      "depth": 124,
+      "head": "8b8b8c40ff95f46a80c728dec2f979f58c8d2f75",
+      "parentRecordedHead": "72324eb25ebdc3847a58e830116c70810b47e711",
+      "parentCurrentHead": "72324eb25ebdc3847a58e830116c70810b47e711",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8b8b8c40f",
+        "sha": "8b8b8c40ff95f46a80c728dec2f979f58c8d2f75",
+        "iso": "2026-06-03T08:05:57-04:00",
+        "subject": "refactor(direct-control): extract setup start owner"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-setup-run",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-setup-start",
+      "children": [
+        "codex/extract-direct-control-restart-begin"
+      ],
+      "depth": 125,
+      "head": "d6294bef3067d9c16ebb0b41366b2344eaf8ce6e",
+      "parentRecordedHead": "8b8b8c40ff95f46a80c728dec2f979f58c8d2f75",
+      "parentCurrentHead": "8b8b8c40ff95f46a80c728dec2f979f58c8d2f75",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d6294bef3",
+        "sha": "d6294bef3067d9c16ebb0b41366b2344eaf8ce6e",
+        "iso": "2026-06-03T08:12:05-04:00",
+        "subject": "refactor(direct-control): extract setup run owner"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-restart-begin",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-setup-run",
+      "children": [
+        "codex/extract-direct-control-production-choice-wrapper"
+      ],
+      "depth": 126,
+      "head": "2dad7098a054966aa46fa57e3d1081315297a760",
+      "parentRecordedHead": "d6294bef3067d9c16ebb0b41366b2344eaf8ce6e",
+      "parentCurrentHead": "d6294bef3067d9c16ebb0b41366b2344eaf8ce6e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2dad7098a",
+        "sha": "2dad7098a054966aa46fa57e3d1081315297a760",
+        "iso": "2026-06-03T08:19:13-04:00",
+        "subject": "refactor(direct-control): extract restart begin owner"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-production-choice-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-restart-begin",
+      "children": [
+        "codex/extract-direct-control-operation-wrapper"
+      ],
+      "depth": 127,
+      "head": "97de075dc65fe0f490de43d75f859ded2d13445c",
+      "parentRecordedHead": "2dad7098a054966aa46fa57e3d1081315297a760",
+      "parentCurrentHead": "2dad7098a054966aa46fa57e3d1081315297a760",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "97de075dc",
+        "sha": "97de075dc65fe0f490de43d75f859ded2d13445c",
+        "iso": "2026-06-03T08:26:35-04:00",
+        "subject": "refactor(direct-control): extract production choice wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-operation-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-production-choice-wrapper",
+      "children": [
+        "codex/extract-direct-control-diplomacy-closeout-source"
+      ],
+      "depth": 128,
+      "head": "e8eb5ebf55c82d5f8de4e667de4de30afaa7e26e",
+      "parentRecordedHead": "97de075dc65fe0f490de43d75f859ded2d13445c",
+      "parentCurrentHead": "97de075dc65fe0f490de43d75f859ded2d13445c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e8eb5ebf5",
+        "sha": "e8eb5ebf55c82d5f8de4e667de4de30afaa7e26e",
+        "iso": "2026-06-03T08:35:36-04:00",
+        "subject": "refactor(direct-control): extract operation request wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-diplomacy-closeout-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-operation-wrapper",
+      "children": [
+        "codex/extract-direct-control-narrative-choice-source"
+      ],
+      "depth": 129,
+      "head": "dff4bca7085c578066697ecb71d67e90bdc525f2",
+      "parentRecordedHead": "e8eb5ebf55c82d5f8de4e667de4de30afaa7e26e",
+      "parentCurrentHead": "e8eb5ebf55c82d5f8de4e667de4de30afaa7e26e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "dff4bca70",
+        "sha": "dff4bca7085c578066697ecb71d67e90bdc525f2",
+        "iso": "2026-06-03T08:41:03-04:00",
+        "subject": "refactor(direct-control): extract diplomacy closeout source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-narrative-choice-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-diplomacy-closeout-source",
+      "children": [
+        "codex/extract-direct-control-technology-closeout-builder"
+      ],
+      "depth": 130,
+      "head": "37d4cac28648bc8728eeace59ec2678e15c73b17",
+      "parentRecordedHead": "dff4bca7085c578066697ecb71d67e90bdc525f2",
+      "parentCurrentHead": "dff4bca7085c578066697ecb71d67e90bdc525f2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "37d4cac28",
+        "sha": "37d4cac28648bc8728eeace59ec2678e15c73b17",
+        "iso": "2026-06-03T08:47:26-04:00",
+        "subject": "refactor(direct-control): extract narrative choice source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-technology-closeout-builder",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-narrative-choice-source",
+      "children": [
+        "codex/extract-direct-control-culture-closeout-builder"
+      ],
+      "depth": 131,
+      "head": "89d165bf11cefc2414998b2eae2556a084eb2d0a",
+      "parentRecordedHead": "37d4cac28648bc8728eeace59ec2678e15c73b17",
+      "parentCurrentHead": "37d4cac28648bc8728eeace59ec2678e15c73b17",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "89d165bf1",
+        "sha": "89d165bf11cefc2414998b2eae2556a084eb2d0a",
+        "iso": "2026-06-03T08:51:41-04:00",
+        "subject": "refactor(direct-control): extract technology closeout builder"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-culture-closeout-builder",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-technology-closeout-builder",
+      "children": [
+        "codex/extract-direct-control-notification-dismissal-builder"
+      ],
+      "depth": 132,
+      "head": "220155ec6c00a56c4317d3dd9031efb2794dcbed",
+      "parentRecordedHead": "89d165bf11cefc2414998b2eae2556a084eb2d0a",
+      "parentCurrentHead": "89d165bf11cefc2414998b2eae2556a084eb2d0a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "220155ec6",
+        "sha": "220155ec6c00a56c4317d3dd9031efb2794dcbed",
+        "iso": "2026-06-03T08:54:09-04:00",
+        "subject": "refactor(direct-control): extract culture closeout builder"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-notification-dismissal-builder",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-culture-closeout-builder",
+      "children": [
+        "codex/prune-direct-control-facade-postcondition-helpers"
+      ],
+      "depth": 133,
+      "head": "aadf3f8db8a2ee6afbf97b06ce2fbd55321ce393",
+      "parentRecordedHead": "220155ec6c00a56c4317d3dd9031efb2794dcbed",
+      "parentCurrentHead": "220155ec6c00a56c4317d3dd9031efb2794dcbed",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "aadf3f8db",
+        "sha": "aadf3f8db8a2ee6afbf97b06ce2fbd55321ce393",
+        "iso": "2026-06-03T08:58:44-04:00",
+        "subject": "refactor(direct-control): extract notification dismissal builder"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-direct-control-facade-postcondition-helpers",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-notification-dismissal-builder",
+      "children": [
+        "codex/extract-direct-control-setup-constants"
+      ],
+      "depth": 134,
+      "head": "4eac3f9468e177dab0b421055060d3f8fb0c49ac",
+      "parentRecordedHead": "aadf3f8db8a2ee6afbf97b06ce2fbd55321ce393",
+      "parentCurrentHead": "aadf3f8db8a2ee6afbf97b06ce2fbd55321ce393",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4eac3f946",
+        "sha": "4eac3f9468e177dab0b421055060d3f8fb0c49ac",
+        "iso": "2026-06-03T09:05:20-04:00",
+        "subject": "refactor(direct-control): prune facade postcondition helpers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-setup-constants",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-direct-control-facade-postcondition-helpers",
+      "children": [
+        "codex/extract-direct-control-session-constants"
+      ],
+      "depth": 135,
+      "head": "de467e835b313d39f93e5254cf584d35b8b64d20",
+      "parentRecordedHead": "4eac3f9468e177dab0b421055060d3f8fb0c49ac",
+      "parentCurrentHead": "4eac3f9468e177dab0b421055060d3f8fb0c49ac",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "de467e835",
+        "sha": "de467e835b313d39f93e5254cf584d35b8b64d20",
+        "iso": "2026-06-03T09:09:41-04:00",
+        "subject": "refactor(direct-control): extract setup constants"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-session-constants",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-setup-constants",
+      "children": [
+        "codex/extract-direct-control-map-constants"
+      ],
+      "depth": 136,
+      "head": "de7b9b9cf1313e253264e868c00b38e5567431f4",
+      "parentRecordedHead": "de467e835b313d39f93e5254cf584d35b8b64d20",
+      "parentCurrentHead": "de467e835b313d39f93e5254cf584d35b8b64d20",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "de7b9b9cf",
+        "sha": "de7b9b9cf1313e253264e868c00b38e5567431f4",
+        "iso": "2026-06-03T09:13:01-04:00",
+        "subject": "refactor(direct-control): extract session constants"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-map-constants",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-session-constants",
+      "children": [
+        "codex/extract-direct-control-capability-constants"
+      ],
+      "depth": 137,
+      "head": "72147ceb383862bc30bc13b3ff2bf2a194712b2b",
+      "parentRecordedHead": "de7b9b9cf1313e253264e868c00b38e5567431f4",
+      "parentCurrentHead": "de7b9b9cf1313e253264e868c00b38e5567431f4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "72147ceb3",
+        "sha": "72147ceb383862bc30bc13b3ff2bf2a194712b2b",
+        "iso": "2026-06-03T09:16:24-04:00",
+        "subject": "refactor(direct-control): extract map constants"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-capability-constants",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-map-constants",
+      "children": [
+        "codex/extract-direct-control-autoplay-constants"
+      ],
+      "depth": 138,
+      "head": "abcf6b32e9159e2368ff667766bb308fb2bb39c4",
+      "parentRecordedHead": "72147ceb383862bc30bc13b3ff2bf2a194712b2b",
+      "parentCurrentHead": "72147ceb383862bc30bc13b3ff2bf2a194712b2b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "abcf6b32e",
+        "sha": "abcf6b32e9159e2368ff667766bb308fb2bb39c4",
+        "iso": "2026-06-03T09:21:49-04:00",
+        "subject": "refactor(direct-control): extract capability constants"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-autoplay-constants",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-capability-constants",
+      "children": [
+        "codex/extract-direct-control-unit-target-constants"
+      ],
+      "depth": 139,
+      "head": "8127b82aa6f393aa3d8925659086653e8b332ebd",
+      "parentRecordedHead": "abcf6b32e9159e2368ff667766bb308fb2bb39c4",
+      "parentCurrentHead": "abcf6b32e9159e2368ff667766bb308fb2bb39c4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8127b82aa",
+        "sha": "8127b82aa6f393aa3d8925659086653e8b332ebd",
+        "iso": "2026-06-03T09:25:59-04:00",
+        "subject": "refactor(direct-control): extract autoplay constants"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-unit-target-constants",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-autoplay-constants",
+      "children": [
+        "codex/extract-direct-control-log-constant"
+      ],
+      "depth": 140,
+      "head": "6a035bed3476caffa8785a814102d632d1149477",
+      "parentRecordedHead": "8127b82aa6f393aa3d8925659086653e8b332ebd",
+      "parentCurrentHead": "8127b82aa6f393aa3d8925659086653e8b332ebd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6a035bed3",
+        "sha": "6a035bed3476caffa8785a814102d632d1149477",
+        "iso": "2026-06-03T09:29:59-04:00",
+        "subject": "refactor(direct-control): extract unit-target constants"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-log-constant",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-unit-target-constants",
+      "children": [
+        "codex/extract-direct-control-session-types"
+      ],
+      "depth": 141,
+      "head": "07a9f884dbe069c06e1857d206ff0165d634e1b4",
+      "parentRecordedHead": "6a035bed3476caffa8785a814102d632d1149477",
+      "parentCurrentHead": "6a035bed3476caffa8785a814102d632d1149477",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "07a9f884d",
+        "sha": "07a9f884dbe069c06e1857d206ff0165d634e1b4",
+        "iso": "2026-06-03T09:34:10-04:00",
+        "subject": "refactor(direct-control): extract scripting log constant"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-session-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-log-constant",
+      "children": [
+        "codex/extract-direct-control-runtime-types"
+      ],
+      "depth": 142,
+      "head": "fe0ef6a1af98858ae3508f5ba8bbef10dd34cd4c",
+      "parentRecordedHead": "07a9f884dbe069c06e1857d206ff0165d634e1b4",
+      "parentCurrentHead": "07a9f884dbe069c06e1857d206ff0165d634e1b4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fe0ef6a1a",
+        "sha": "fe0ef6a1af98858ae3508f5ba8bbef10dd34cd4c",
+        "iso": "2026-06-03T09:39:26-04:00",
+        "subject": "refactor(direct-control): extract session types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-runtime-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-session-types",
+      "children": [
+        "codex/extract-direct-control-map-types"
+      ],
+      "depth": 143,
+      "head": "c6acf7875166ad8a272a100d8452273c8a4d98c0",
+      "parentRecordedHead": "fe0ef6a1af98858ae3508f5ba8bbef10dd34cd4c",
+      "parentCurrentHead": "fe0ef6a1af98858ae3508f5ba8bbef10dd34cd4c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c6acf7875",
+        "sha": "c6acf7875166ad8a272a100d8452273c8a4d98c0",
+        "iso": "2026-06-03T09:48:37-04:00",
+        "subject": "refactor(direct-control): extract runtime types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-map-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-runtime-types",
+      "children": [
+        "codex/extract-direct-control-map-read-types"
+      ],
+      "depth": 144,
+      "head": "c563f8d67599158c51d53fc42e66727071273fb6",
+      "parentRecordedHead": "c6acf7875166ad8a272a100d8452273c8a4d98c0",
+      "parentCurrentHead": "c6acf7875166ad8a272a100d8452273c8a4d98c0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c563f8d67",
+        "sha": "c563f8d67599158c51d53fc42e66727071273fb6",
+        "iso": "2026-06-03T09:53:58-04:00",
+        "subject": "refactor(direct-control): extract map primitive types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-map-read-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-map-types",
+      "children": [
+        "codex/extract-direct-control-summary-read-types"
+      ],
+      "depth": 145,
+      "head": "e37dfd7d3c89da4152820dcc56d07f556ab91afe",
+      "parentRecordedHead": "c563f8d67599158c51d53fc42e66727071273fb6",
+      "parentCurrentHead": "c563f8d67599158c51d53fc42e66727071273fb6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e37dfd7d3",
+        "sha": "e37dfd7d3c89da4152820dcc56d07f556ab91afe",
+        "iso": "2026-06-03T10:00:26-04:00",
+        "subject": "refactor(direct-control): extract map read types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-summary-read-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-map-read-types",
+      "children": [
+        "codex/extract-direct-control-gameinfo-row-types"
+      ],
+      "depth": 146,
+      "head": "82f8b7ce70836d8f0e81e6e53b408fdef2d45955",
+      "parentRecordedHead": "e37dfd7d3c89da4152820dcc56d07f556ab91afe",
+      "parentCurrentHead": "e37dfd7d3c89da4152820dcc56d07f556ab91afe",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "82f8b7ce7",
+        "sha": "82f8b7ce70836d8f0e81e6e53b408fdef2d45955",
+        "iso": "2026-06-03T10:05:28-04:00",
+        "subject": "refactor(direct-control): extract summary read types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-gameinfo-row-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-summary-read-types",
+      "children": [
+        "codex/extract-direct-control-visibility-read-types"
+      ],
+      "depth": 147,
+      "head": "478107e3f01b430b1eae34922ad81dacd781fc9a",
+      "parentRecordedHead": "82f8b7ce70836d8f0e81e6e53b408fdef2d45955",
+      "parentCurrentHead": "82f8b7ce70836d8f0e81e6e53b408fdef2d45955",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "478107e3f",
+        "sha": "478107e3f01b430b1eae34922ad81dacd781fc9a",
+        "iso": "2026-06-03T10:10:14-04:00",
+        "subject": "refactor(direct-control): extract GameInfo row types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-visibility-read-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-gameinfo-row-types",
+      "children": [
+        "codex/extract-direct-control-setup-read-types"
+      ],
+      "depth": 148,
+      "head": "bef9fd77b70848569ccaec819a0d0176a6922dac",
+      "parentRecordedHead": "478107e3f01b430b1eae34922ad81dacd781fc9a",
+      "parentCurrentHead": "478107e3f01b430b1eae34922ad81dacd781fc9a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bef9fd77b",
+        "sha": "bef9fd77b70848569ccaec819a0d0176a6922dac",
+        "iso": "2026-06-03T10:14:50-04:00",
+        "subject": "refactor(direct-control): extract visibility read types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-setup-read-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-visibility-read-types",
+      "children": [
+        "codex/extract-direct-control-setup-lifecycle-types"
+      ],
+      "depth": 149,
+      "head": "79149cbb30a5b7e7aa34fb72aa0df04d7406ebb2",
+      "parentRecordedHead": "bef9fd77b70848569ccaec819a0d0176a6922dac",
+      "parentCurrentHead": "bef9fd77b70848569ccaec819a0d0176a6922dac",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "79149cbb3",
+        "sha": "79149cbb30a5b7e7aa34fb72aa0df04d7406ebb2",
+        "iso": "2026-06-03T10:21:53-04:00",
+        "subject": "refactor(direct-control): extract setup read types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-setup-lifecycle-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-setup-read-types",
+      "children": [
+        "codex/extract-direct-control-autoplay-turn-types"
+      ],
+      "depth": 150,
+      "head": "55a8da33373d9f4e9f50aee274c49342500e39ca",
+      "parentRecordedHead": "79149cbb30a5b7e7aa34fb72aa0df04d7406ebb2",
+      "parentCurrentHead": "79149cbb30a5b7e7aa34fb72aa0df04d7406ebb2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "55a8da333",
+        "sha": "55a8da33373d9f4e9f50aee274c49342500e39ca",
+        "iso": "2026-06-03T10:27:36-04:00",
+        "subject": "refactor(direct-control): extract setup lifecycle types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-autoplay-turn-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-setup-lifecycle-types",
+      "children": [
+        "codex/extract-direct-control-notification-types"
+      ],
+      "depth": 151,
+      "head": "895defa5e9998d7e7d08d05e1b355acf253df74c",
+      "parentRecordedHead": "55a8da33373d9f4e9f50aee274c49342500e39ca",
+      "parentCurrentHead": "55a8da33373d9f4e9f50aee274c49342500e39ca",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "895defa5e",
+        "sha": "895defa5e9998d7e7d08d05e1b355acf253df74c",
+        "iso": "2026-06-03T10:33:05-04:00",
+        "subject": "refactor(direct-control): extract autoplay and turn types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-notification-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-autoplay-turn-types",
+      "children": [
+        "codex/extract-direct-control-progression-read-types"
+      ],
+      "depth": 152,
+      "head": "c868b4c227e4d0d98e7206bbd1bd61fefd93c7ac",
+      "parentRecordedHead": "895defa5e9998d7e7d08d05e1b355acf253df74c",
+      "parentCurrentHead": "895defa5e9998d7e7d08d05e1b355acf253df74c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c868b4c22",
+        "sha": "c868b4c227e4d0d98e7206bbd1bd61fefd93c7ac",
+        "iso": "2026-06-03T10:42:20-04:00",
+        "subject": "refactor(direct-control): extract notification types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-progression-read-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-notification-types",
+      "children": [
+        "codex/extract-direct-control-tactical-read-types"
+      ],
+      "depth": 153,
+      "head": "ec49d1a6c4251e5904818e8ebac22d85a08a90f6",
+      "parentRecordedHead": "c868b4c227e4d0d98e7206bbd1bd61fefd93c7ac",
+      "parentCurrentHead": "c868b4c227e4d0d98e7206bbd1bd61fefd93c7ac",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ec49d1a6c",
+        "sha": "ec49d1a6c4251e5904818e8ebac22d85a08a90f6",
+        "iso": "2026-06-03T10:48:06-04:00",
+        "subject": "refactor(direct-control): extract progression read types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-tactical-read-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-progression-read-types",
+      "children": [
+        "codex/extract-direct-control-ready-read-types"
+      ],
+      "depth": 154,
+      "head": "15cdae61c659ee78f5e60cb06f8044a801d64383",
+      "parentRecordedHead": "ec49d1a6c4251e5904818e8ebac22d85a08a90f6",
+      "parentCurrentHead": "ec49d1a6c4251e5904818e8ebac22d85a08a90f6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "15cdae61c",
+        "sha": "15cdae61c659ee78f5e60cb06f8044a801d64383",
+        "iso": "2026-06-03T10:54:20-04:00",
+        "subject": "refactor(direct-control): extract tactical read types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-ready-read-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-tactical-read-types",
+      "children": [
+        "codex/extract-direct-control-progression-closeout-types"
+      ],
+      "depth": 155,
+      "head": "1366a891e5fa1666dbd5dc408c15b05168d1eecd",
+      "parentRecordedHead": "15cdae61c659ee78f5e60cb06f8044a801d64383",
+      "parentCurrentHead": "15cdae61c659ee78f5e60cb06f8044a801d64383",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1366a891e",
+        "sha": "1366a891e5fa1666dbd5dc408c15b05168d1eecd",
+        "iso": "2026-06-03T11:02:08-04:00",
+        "subject": "refactor(direct-control): extract ready read types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-progression-closeout-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-ready-read-types",
+      "children": [
+        "codex/extract-direct-control-unit-target-types"
+      ],
+      "depth": 156,
+      "head": "756e87e899a8359682a500be0dd2c2cc90487071",
+      "parentRecordedHead": "1366a891e5fa1666dbd5dc408c15b05168d1eecd",
+      "parentCurrentHead": "1366a891e5fa1666dbd5dc408c15b05168d1eecd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "756e87e89",
+        "sha": "756e87e899a8359682a500be0dd2c2cc90487071",
+        "iso": "2026-06-03T11:07:52-04:00",
+        "subject": "refactor(direct-control): extract progression closeout types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-unit-target-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-progression-closeout-types",
+      "children": [
+        "codex/extract-direct-control-operation-primitive-types"
+      ],
+      "depth": 157,
+      "head": "64be6b09f1fe704542d88edb3fa0831fcabe7589",
+      "parentRecordedHead": "756e87e899a8359682a500be0dd2c2cc90487071",
+      "parentCurrentHead": "756e87e899a8359682a500be0dd2c2cc90487071",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "64be6b09f",
+        "sha": "64be6b09f1fe704542d88edb3fa0831fcabe7589",
+        "iso": "2026-06-03T11:12:48-04:00",
+        "subject": "refactor(direct-control): extract unit-target action types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-operation-primitive-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-unit-target-types",
+      "children": [
+        "codex/extract-direct-control-operation-result-types"
+      ],
+      "depth": 158,
+      "head": "04ff264285412d922c08b7c759bb6ffb30688b37",
+      "parentRecordedHead": "64be6b09f1fe704542d88edb3fa0831fcabe7589",
+      "parentCurrentHead": "64be6b09f1fe704542d88edb3fa0831fcabe7589",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "04ff26428",
+        "sha": "04ff264285412d922c08b7c759bb6ffb30688b37",
+        "iso": "2026-06-03T11:21:46-04:00",
+        "subject": "refactor(direct-control): extract operation primitive types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-operation-result-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-operation-primitive-types",
+      "children": [
+        "codex/extract-direct-control-production-choice-types"
+      ],
+      "depth": 159,
+      "head": "06d529ed53cf647891dd1ea613e0077c96b6a648",
+      "parentRecordedHead": "04ff264285412d922c08b7c759bb6ffb30688b37",
+      "parentCurrentHead": "04ff264285412d922c08b7c759bb6ffb30688b37",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "06d529ed5",
+        "sha": "06d529ed53cf647891dd1ea613e0077c96b6a648",
+        "iso": "2026-06-03T11:27:52-04:00",
+        "subject": "refactor(direct-control): extract operation result types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-production-choice-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-operation-result-types",
+      "children": [
+        "codex/extract-direct-control-diplomacy-response-types"
+      ],
+      "depth": 160,
+      "head": "032ee97c4505d9ee4a1e575d029ebb95167a62bd",
+      "parentRecordedHead": "06d529ed53cf647891dd1ea613e0077c96b6a648",
+      "parentCurrentHead": "06d529ed53cf647891dd1ea613e0077c96b6a648",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "032ee97c4",
+        "sha": "032ee97c4505d9ee4a1e575d029ebb95167a62bd",
+        "iso": "2026-06-03T11:31:56-04:00",
+        "subject": "refactor(direct-control): extract production choice types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-diplomacy-response-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-production-choice-types",
+      "children": [
+        "codex/extract-direct-control-narrative-choice-types"
+      ],
+      "depth": 161,
+      "head": "6d7396edb2eb3f661e53a8f4456ff3680b8dacd0",
+      "parentRecordedHead": "032ee97c4505d9ee4a1e575d029ebb95167a62bd",
+      "parentCurrentHead": "032ee97c4505d9ee4a1e575d029ebb95167a62bd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6d7396edb",
+        "sha": "6d7396edb2eb3f661e53a8f4456ff3680b8dacd0",
+        "iso": "2026-06-03T11:38:34-04:00",
+        "subject": "refactor(direct-control): extract diplomacy response types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-narrative-choice-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-diplomacy-response-types",
+      "children": [
+        "codex/extract-direct-control-capability-catalog-options"
+      ],
+      "depth": 162,
+      "head": "41c8ac82a068d1de78b2f210b28fde5109531843",
+      "parentRecordedHead": "6d7396edb2eb3f661e53a8f4456ff3680b8dacd0",
+      "parentCurrentHead": "6d7396edb2eb3f661e53a8f4456ff3680b8dacd0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "41c8ac82a",
+        "sha": "41c8ac82a068d1de78b2f210b28fde5109531843",
+        "iso": "2026-06-03T11:43:50-04:00",
+        "subject": "refactor(direct-control): extract narrative choice types"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-capability-catalog-options",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-narrative-choice-types",
+      "children": [
+        "codex/extract-direct-control-restart-begin-result-type"
+      ],
+      "depth": 163,
+      "head": "967a14eca0f87f2adca87f5bdb67b22d75725c63",
+      "parentRecordedHead": "41c8ac82a068d1de78b2f210b28fde5109531843",
+      "parentCurrentHead": "41c8ac82a068d1de78b2f210b28fde5109531843",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "967a14eca",
+        "sha": "967a14eca0f87f2adca87f5bdb67b22d75725c63",
+        "iso": "2026-06-03T11:47:51-04:00",
+        "subject": "refactor(direct-control): extract capability catalog options"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-restart-begin-result-type",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-capability-catalog-options",
+      "children": [
+        "codex/extract-direct-control-health-type"
+      ],
+      "depth": 164,
+      "head": "788f087de5c42b7f308d66f022dba223a14a3dd4",
+      "parentRecordedHead": "967a14eca0f87f2adca87f5bdb67b22d75725c63",
+      "parentCurrentHead": "967a14eca0f87f2adca87f5bdb67b22d75725c63",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "788f087de",
+        "sha": "788f087de5c42b7f308d66f022dba223a14a3dd4",
+        "iso": "2026-06-03T11:52:44-04:00",
+        "subject": "refactor(direct-control): extract restart begin result type"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-health-type",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-restart-begin-result-type",
+      "children": [
+        "codex/extract-direct-control-ui-loading-state-type"
+      ],
+      "depth": 165,
+      "head": "e8808f98b9ea6f06824226ee1f2397e071c1d9ae",
+      "parentRecordedHead": "788f087de5c42b7f308d66f022dba223a14a3dd4",
+      "parentCurrentHead": "788f087de5c42b7f308d66f022dba223a14a3dd4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e8808f98b",
+        "sha": "e8808f98b9ea6f06824226ee1f2397e071c1d9ae",
+        "iso": "2026-06-03T11:58:07-04:00",
+        "subject": "refactor(direct-control): extract health result type"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-ui-loading-state-type",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-health-type",
+      "children": [
+        "codex/extract-direct-control-session-state-selection"
+      ],
+      "depth": 166,
+      "head": "25f6ba81ba577c9659a90b80d37c84e4bc38b653",
+      "parentRecordedHead": "e8808f98b9ea6f06824226ee1f2397e071c1d9ae",
+      "parentCurrentHead": "e8808f98b9ea6f06824226ee1f2397e071c1d9ae",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "25f6ba81b",
+        "sha": "25f6ba81ba577c9659a90b80d37c84e4bc38b653",
+        "iso": "2026-06-03T12:01:24-04:00",
+        "subject": "refactor(direct-control): extract ui loading state type"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-session-state-selection",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-ui-loading-state-type",
+      "children": [
+        "codex/extract-direct-control-session-config"
+      ],
+      "depth": 167,
+      "head": "ba1f4fb4467bc251bf9fd1f6fe351161385d1aa2",
+      "parentRecordedHead": "25f6ba81ba577c9659a90b80d37c84e4bc38b653",
+      "parentCurrentHead": "25f6ba81ba577c9659a90b80d37c84e4bc38b653",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ba1f4fb44",
+        "sha": "ba1f4fb4467bc251bf9fd1f6fe351161385d1aa2",
+        "iso": "2026-06-03T12:05:07-04:00",
+        "subject": "refactor(direct-control): extract session state selection"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-session-config",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-session-state-selection",
+      "children": [
+        "codex/extract-direct-control-request-id"
+      ],
+      "depth": 168,
+      "head": "3fdc467ae172fbad97c6013bd70e70f65b304e0f",
+      "parentRecordedHead": "ba1f4fb4467bc251bf9fd1f6fe351161385d1aa2",
+      "parentCurrentHead": "ba1f4fb4467bc251bf9fd1f6fe351161385d1aa2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3fdc467ae",
+        "sha": "3fdc467ae172fbad97c6013bd70e70f65b304e0f",
+        "iso": "2026-06-03T12:08:34-04:00",
+        "subject": "refactor(direct-control): extract session config"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-request-id",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-session-config",
+      "children": [
+        "codex/extract-direct-control-endpoint-discovery"
+      ],
+      "depth": 169,
+      "head": "4aa10fd35406618e1297b11f1ac3c497a0a2c96b",
+      "parentRecordedHead": "3fdc467ae172fbad97c6013bd70e70f65b304e0f",
+      "parentCurrentHead": "3fdc467ae172fbad97c6013bd70e70f65b304e0f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4aa10fd35",
+        "sha": "4aa10fd35406618e1297b11f1ac3c497a0a2c96b",
+        "iso": "2026-06-03T12:13:20-04:00",
+        "subject": "refactor(direct-control): extract request id helper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-endpoint-discovery",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-request-id",
+      "children": [
+        "codex/extract-direct-control-session-socket"
+      ],
+      "depth": 170,
+      "head": "71858975b1f2e9f05a73b45bcdaf037898ed6e3c",
+      "parentRecordedHead": "4aa10fd35406618e1297b11f1ac3c497a0a2c96b",
+      "parentCurrentHead": "4aa10fd35406618e1297b11f1ac3c497a0a2c96b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "71858975b",
+        "sha": "71858975b1f2e9f05a73b45bcdaf037898ed6e3c",
+        "iso": "2026-06-03T12:19:33-04:00",
+        "subject": "refactor(direct-control): extract endpoint discovery helper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-session-socket",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-endpoint-discovery",
+      "children": [
+        "codex/extract-direct-control-session-state-parser"
+      ],
+      "depth": 171,
+      "head": "5f6fc5a5aa75f1eccb4aaf7cef5f5a18d6c4f780",
+      "parentRecordedHead": "71858975b1f2e9f05a73b45bcdaf037898ed6e3c",
+      "parentCurrentHead": "71858975b1f2e9f05a73b45bcdaf037898ed6e3c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5f6fc5a5a",
+        "sha": "5f6fc5a5aa75f1eccb4aaf7cef5f5a18d6c4f780",
+        "iso": "2026-06-03T12:24:24-04:00",
+        "subject": "refactor(direct-control): extract session socket helper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-session-state-parser",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-session-socket",
+      "children": [
+        "codex/extract-direct-control-listener-id"
+      ],
+      "depth": 172,
+      "head": "751f4906498da10856c9bc3d6f11de75f4f634fd",
+      "parentRecordedHead": "5f6fc5a5aa75f1eccb4aaf7cef5f5a18d6c4f780",
+      "parentCurrentHead": "5f6fc5a5aa75f1eccb4aaf7cef5f5a18d6c4f780",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "751f49064",
+        "sha": "751f4906498da10856c9bc3d6f11de75f4f634fd",
+        "iso": "2026-06-03T12:28:19-04:00",
+        "subject": "refactor(direct-control): extract tuner state parser"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-listener-id",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-session-state-parser",
+      "children": [
+        "codex/remove-unused-tuner-message-helper"
+      ],
+      "depth": 173,
+      "head": "f41355a856f3cfe25e8bc262291c810de9e4e610",
+      "parentRecordedHead": "751f4906498da10856c9bc3d6f11de75f4f634fd",
+      "parentCurrentHead": "751f4906498da10856c9bc3d6f11de75f4f634fd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f41355a85",
+        "sha": "f41355a856f3cfe25e8bc262291c810de9e4e610",
+        "iso": "2026-06-03T12:32:10-04:00",
+        "subject": "refactor(direct-control): extract listener id allocator"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-unused-tuner-message-helper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-listener-id",
+      "children": [
+        "codex/extract-direct-control-session-class"
+      ],
+      "depth": 174,
+      "head": "c15a695806829e97c55034e97bf7fdfe6a2ea22e",
+      "parentRecordedHead": "f41355a856f3cfe25e8bc262291c810de9e4e610",
+      "parentCurrentHead": "f41355a856f3cfe25e8bc262291c810de9e4e610",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c15a69580",
+        "sha": "c15a695806829e97c55034e97bf7fdfe6a2ea22e",
+        "iso": "2026-06-03T12:39:12-04:00",
+        "subject": "refactor(direct-control): remove unused tuner message helper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-session-class",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-unused-tuner-message-helper",
+      "children": [
+        "codex/extract-direct-control-session-execute"
+      ],
+      "depth": 175,
+      "head": "d791ae86ced77e68adbded5bc39993ee8d9396b5",
+      "parentRecordedHead": "c15a695806829e97c55034e97bf7fdfe6a2ea22e",
+      "parentCurrentHead": "c15a695806829e97c55034e97bf7fdfe6a2ea22e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d791ae86c",
+        "sha": "d791ae86ced77e68adbded5bc39993ee8d9396b5",
+        "iso": "2026-06-03T12:45:06-04:00",
+        "subject": "refactor(direct-control): extract session class owner"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-session-execute",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-session-class",
+      "children": [
+        "codex/extract-direct-control-endpoint-wrapper"
+      ],
+      "depth": 176,
+      "head": "8c96a3ad7cdef34c3fbbee1f59fc7e4b37fca5f0",
+      "parentRecordedHead": "d791ae86ced77e68adbded5bc39993ee8d9396b5",
+      "parentCurrentHead": "d791ae86ced77e68adbded5bc39993ee8d9396b5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8c96a3ad7",
+        "sha": "8c96a3ad7cdef34c3fbbee1f59fc7e4b37fca5f0",
+        "iso": "2026-06-03T12:48:34-04:00",
+        "subject": "refactor(direct-control): extract session execute wrappers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-endpoint-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-session-execute",
+      "children": [
+        "codex/extract-direct-control-session-reconnect"
+      ],
+      "depth": 177,
+      "head": "e3d7f1407c23e97e1b93aec25e3ff590ebbaea73",
+      "parentRecordedHead": "8c96a3ad7cdef34c3fbbee1f59fc7e4b37fca5f0",
+      "parentCurrentHead": "8c96a3ad7cdef34c3fbbee1f59fc7e4b37fca5f0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e3d7f1407",
+        "sha": "e3d7f1407c23e97e1b93aec25e3ff590ebbaea73",
+        "iso": "2026-06-03T12:53:21-04:00",
+        "subject": "refactor(direct-control): extract endpoint discovery wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-session-reconnect",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-endpoint-wrapper",
+      "children": [
+        "codex/extract-direct-control-session-health"
+      ],
+      "depth": 178,
+      "head": "ff64f8285447d603af3a5a65bc4b5df8b1fb60a3",
+      "parentRecordedHead": "e3d7f1407c23e97e1b93aec25e3ff590ebbaea73",
+      "parentCurrentHead": "e3d7f1407c23e97e1b93aec25e3ff590ebbaea73",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ff64f8285",
+        "sha": "ff64f8285447d603af3a5a65bc4b5df8b1fb60a3",
+        "iso": "2026-06-03T12:59:33-04:00",
+        "subject": "refactor(direct-control): extract session reconnect helper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-session-health",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-session-reconnect",
+      "children": [
+        "codex/extract-direct-control-session-wait"
+      ],
+      "depth": 179,
+      "head": "3bd28c23a9bc611b5fba7b7219e1710649ca7754",
+      "parentRecordedHead": "ff64f8285447d603af3a5a65bc4b5df8b1fb60a3",
+      "parentCurrentHead": "ff64f8285447d603af3a5a65bc4b5df8b1fb60a3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3bd28c23a",
+        "sha": "3bd28c23a9bc611b5fba7b7219e1710649ca7754",
+        "iso": "2026-06-03T13:03:30-04:00",
+        "subject": "refactor(direct-control): extract session health wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-session-wait",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-session-health",
+      "children": [
+        "codex/extract-direct-control-tuner-ready-wait"
+      ],
+      "depth": 180,
+      "head": "7a3850b86a67ab6c64c71c40d8a640d983180385",
+      "parentRecordedHead": "3bd28c23a9bc611b5fba7b7219e1710649ca7754",
+      "parentCurrentHead": "3bd28c23a9bc611b5fba7b7219e1710649ca7754",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7a3850b86",
+        "sha": "7a3850b86a67ab6c64c71c40d8a640d983180385",
+        "iso": "2026-06-03T13:07:17-04:00",
+        "subject": "refactor(direct-control): extract session wait wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-tuner-ready-wait",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-session-wait",
+      "children": [
+        "codex/extract-direct-control-setup-phase-wait"
+      ],
+      "depth": 181,
+      "head": "c50d364d0778a79ea5b4ba3557c6170ab78dc17d",
+      "parentRecordedHead": "7a3850b86a67ab6c64c71c40d8a640d983180385",
+      "parentCurrentHead": "7a3850b86a67ab6c64c71c40d8a640d983180385",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c50d364d0",
+        "sha": "c50d364d0778a79ea5b4ba3557c6170ab78dc17d",
+        "iso": "2026-06-03T13:13:43-04:00",
+        "subject": "refactor(direct-control): extract tuner ready wait"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-setup-phase-wait",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-tuner-ready-wait",
+      "children": [
+        "codex/extract-direct-control-runtime-probe-helpers"
+      ],
+      "depth": 182,
+      "head": "58a47125eaa2901c956ead0bb167c6fb57b0ec69",
+      "parentRecordedHead": "c50d364d0778a79ea5b4ba3557c6170ab78dc17d",
+      "parentCurrentHead": "c50d364d0778a79ea5b4ba3557c6170ab78dc17d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "58a47125e",
+        "sha": "58a47125eaa2901c956ead0bb167c6fb57b0ec69",
+        "iso": "2026-06-03T13:20:35-04:00",
+        "subject": "refactor(direct-control): extract setup phase wait helper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-runtime-probe-helpers",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-setup-phase-wait",
+      "children": [
+        "codex/extract-direct-control-action-approval"
+      ],
+      "depth": 183,
+      "head": "4ac912d787c27d727c57723abafb3d29a9e15fb7",
+      "parentRecordedHead": "58a47125eaa2901c956ead0bb167c6fb57b0ec69",
+      "parentCurrentHead": "58a47125eaa2901c956ead0bb167c6fb57b0ec69",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4ac912d78",
+        "sha": "4ac912d787c27d727c57723abafb3d29a9e15fb7",
+        "iso": "2026-06-03T13:24:49-04:00",
+        "subject": "refactor(direct-control): extract runtime probe helpers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-action-approval",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-runtime-probe-helpers",
+      "children": [
+        "codex/extract-direct-control-command-result-parser"
+      ],
+      "depth": 184,
+      "head": "33587c26e70b93532eb7d6eaccd0d4897e6e509b",
+      "parentRecordedHead": "4ac912d787c27d727c57723abafb3d29a9e15fb7",
+      "parentCurrentHead": "4ac912d787c27d727c57723abafb3d29a9e15fb7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "33587c26e",
+        "sha": "33587c26e70b93532eb7d6eaccd0d4897e6e509b",
+        "iso": "2026-06-03T13:32:35-04:00",
+        "subject": "refactor(direct-control): extract action approval primitive"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-command-result-parser",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-action-approval",
+      "children": [
+        "codex/extract-direct-control-command-serializer"
+      ],
+      "depth": 185,
+      "head": "7fab78ae2083e2e81e52ac8c81b3c8ac109766b2",
+      "parentRecordedHead": "33587c26e70b93532eb7d6eaccd0d4897e6e509b",
+      "parentCurrentHead": "33587c26e70b93532eb7d6eaccd0d4897e6e509b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7fab78ae2",
+        "sha": "7fab78ae2083e2e81e52ac8c81b3c8ac109766b2",
+        "iso": "2026-06-03T13:36:24-04:00",
+        "subject": "refactor(direct-control): extract command result parser"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-command-serializer",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-command-result-parser",
+      "children": [
+        "codex/extract-direct-control-validation-primitives"
+      ],
+      "depth": 186,
+      "head": "5d3f19943dfb3f6e797b3ce4915c0cb05faf40a2",
+      "parentRecordedHead": "7fab78ae2083e2e81e52ac8c81b3c8ac109766b2",
+      "parentCurrentHead": "7fab78ae2083e2e81e52ac8c81b3c8ac109766b2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5d3f19943",
+        "sha": "5d3f19943dfb3f6e797b3ce4915c0cb05faf40a2",
+        "iso": "2026-06-03T13:40:23-04:00",
+        "subject": "refactor(direct-control): extract command source serializer"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-validation-primitives",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-command-serializer",
+      "children": [
+        "codex/extract-direct-control-map-validation"
+      ],
+      "depth": 187,
+      "head": "3f9f9cf2d7376d524705d259ae0bca73de1c4a33",
+      "parentRecordedHead": "5d3f19943dfb3f6e797b3ce4915c0cb05faf40a2",
+      "parentCurrentHead": "5d3f19943dfb3f6e797b3ce4915c0cb05faf40a2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3f9f9cf2d",
+        "sha": "3f9f9cf2d7376d524705d259ae0bca73de1c4a33",
+        "iso": "2026-06-03T13:44:40-04:00",
+        "subject": "refactor(direct-control): extract validation primitives"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-map-validation",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-validation-primitives",
+      "children": [
+        "codex/extract-direct-control-facade-dependency-primitives"
+      ],
+      "depth": 188,
+      "head": "7e492c488454857db8b6228fc447ff8984c04203",
+      "parentRecordedHead": "3f9f9cf2d7376d524705d259ae0bca73de1c4a33",
+      "parentCurrentHead": "3f9f9cf2d7376d524705d259ae0bca73de1c4a33",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7e492c488",
+        "sha": "7e492c488454857db8b6228fc447ff8984c04203",
+        "iso": "2026-06-03T13:49:49-04:00",
+        "subject": "refactor(direct-control): extract map validation helpers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-facade-dependency-primitives",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-map-validation",
+      "children": [
+        "codex/cite-direct-control-orpc-authority"
+      ],
+      "depth": 189,
+      "head": "c1ca4d73c5e5136af644de68b67d34829a2b2389",
+      "parentRecordedHead": "7e492c488454857db8b6228fc447ff8984c04203",
+      "parentCurrentHead": "7e492c488454857db8b6228fc447ff8984c04203",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c1ca4d73c",
+        "sha": "c1ca4d73c5e5136af644de68b67d34829a2b2389",
+        "iso": "2026-06-03T13:55:36-04:00",
+        "subject": "refactor(direct-control): extract facade dependency primitives"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/cite-direct-control-orpc-authority",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-facade-dependency-primitives",
+      "children": [
+        "codex/prune-action-approval-facade-backimports"
+      ],
+      "depth": 190,
+      "head": "b076e3d046382a259ac97934c0503ed7b0a9598d",
+      "parentRecordedHead": "c1ca4d73c5e5136af644de68b67d34829a2b2389",
+      "parentCurrentHead": "c1ca4d73c5e5136af644de68b67d34829a2b2389",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b076e3d04",
+        "sha": "b076e3d046382a259ac97934c0503ed7b0a9598d",
+        "iso": "2026-06-03T14:01:24-04:00",
+        "subject": "docs(direct-control): cite oRPC architecture authority"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-action-approval-facade-backimports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/cite-direct-control-orpc-authority",
+      "children": [
+        "codex/prune-session-type-facade-backimports"
+      ],
+      "depth": 191,
+      "head": "e713b10b165ab7920c39af746497170cfa29e883",
+      "parentRecordedHead": "b076e3d046382a259ac97934c0503ed7b0a9598d",
+      "parentCurrentHead": "b076e3d046382a259ac97934c0503ed7b0a9598d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e713b10b1",
+        "sha": "e713b10b165ab7920c39af746497170cfa29e883",
+        "iso": "2026-06-03T14:22:30-04:00",
+        "subject": "refactor(direct-control): prune action approval facade imports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-session-type-facade-backimports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-action-approval-facade-backimports",
+      "children": [
+        "codex/prune-stale-facade-fs-import"
+      ],
+      "depth": 192,
+      "head": "286051a54b4397444e89c09f8ff70f19a9127625",
+      "parentRecordedHead": "e713b10b165ab7920c39af746497170cfa29e883",
+      "parentCurrentHead": "e713b10b165ab7920c39af746497170cfa29e883",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "286051a54",
+        "sha": "286051a54b4397444e89c09f8ff70f19a9127625",
+        "iso": "2026-06-03T14:28:11-04:00",
+        "subject": "refactor(direct-control): prune session facade type imports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-stale-facade-fs-import",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-session-type-facade-backimports",
+      "children": [
+        "codex/extract-direct-control-progression-closeout-wrappers"
+      ],
+      "depth": 193,
+      "head": "158602f9986a5ed0e92095edb166760170d9aae9",
+      "parentRecordedHead": "286051a54b4397444e89c09f8ff70f19a9127625",
+      "parentCurrentHead": "286051a54b4397444e89c09f8ff70f19a9127625",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "158602f99",
+        "sha": "158602f9986a5ed0e92095edb166760170d9aae9",
+        "iso": "2026-06-03T14:32:55-04:00",
+        "subject": "refactor(direct-control): prune stale facade fs import"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-progression-closeout-wrappers",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-stale-facade-fs-import",
+      "children": [
+        "codex/extract-direct-control-session-resource-helper"
+      ],
+      "depth": 194,
+      "head": "9af4d492e06f16fcdc056509e20c47f2acdd0b7f",
+      "parentRecordedHead": "158602f9986a5ed0e92095edb166760170d9aae9",
+      "parentCurrentHead": "158602f9986a5ed0e92095edb166760170d9aae9",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9af4d492e",
+        "sha": "9af4d492e06f16fcdc056509e20c47f2acdd0b7f",
+        "iso": "2026-06-03T14:39:25-04:00",
+        "subject": "refactor(direct-control): extract progression closeout wrappers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-session-resource-helper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-progression-closeout-wrappers",
+      "children": [
+        "codex/reuse-session-resource-helper-in-execute"
+      ],
+      "depth": 195,
+      "head": "2d9789aa4b062fd40aab647484a20e141e49e3d1",
+      "parentRecordedHead": "9af4d492e06f16fcdc056509e20c47f2acdd0b7f",
+      "parentCurrentHead": "9af4d492e06f16fcdc056509e20c47f2acdd0b7f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2d9789aa4",
+        "sha": "2d9789aa4b062fd40aab647484a20e141e49e3d1",
+        "iso": "2026-06-03T14:45:23-04:00",
+        "subject": "refactor(direct-control): extract session resource helper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/reuse-session-resource-helper-in-execute",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-session-resource-helper",
+      "children": [
+        "codex/mark-direct-control-atom-groups-complete"
+      ],
+      "depth": 196,
+      "head": "e121237e9bfbfa60e62066cacfe218d8fa6db194",
+      "parentRecordedHead": "2d9789aa4b062fd40aab647484a20e141e49e3d1",
+      "parentCurrentHead": "2d9789aa4b062fd40aab647484a20e141e49e3d1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e121237e9",
+        "sha": "e121237e9bfbfa60e62066cacfe218d8fa6db194",
+        "iso": "2026-06-03T14:50:09-04:00",
+        "subject": "refactor(direct-control): reuse session resource helper in execute"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/mark-direct-control-atom-groups-complete",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/reuse-session-resource-helper-in-execute",
+      "children": [
+        "codex/fill-cli-play-corpus"
+      ],
+      "depth": 197,
+      "head": "247dfd37afe4028f11d2d08780e3af3d19eb8691",
+      "parentRecordedHead": "e121237e9bfbfa60e62066cacfe218d8fa6db194",
+      "parentCurrentHead": "e121237e9bfbfa60e62066cacfe218d8fa6db194",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "247dfd37a",
+        "sha": "247dfd37afe4028f11d2d08780e3af3d19eb8691",
+        "iso": "2026-06-03T15:12:57-04:00",
+        "subject": "docs(direct-control): close extracted atom task groups"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/fill-cli-play-corpus",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/mark-direct-control-atom-groups-complete",
+      "children": [
+        "codex/prune-health-facade-callthrough"
+      ],
+      "depth": 198,
+      "head": "016b86bbf9012bda647ef571e7a69af64c2b7584",
+      "parentRecordedHead": "247dfd37afe4028f11d2d08780e3af3d19eb8691",
+      "parentCurrentHead": "247dfd37afe4028f11d2d08780e3af3d19eb8691",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "016b86bbf",
+        "sha": "016b86bbf9012bda647ef571e7a69af64c2b7584",
+        "iso": "2026-06-03T15:17:24-04:00",
+        "subject": "docs(direct-control): fill CLI play corpus"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-health-facade-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/fill-cli-play-corpus",
+      "children": [
+        "codex/align-atom-corpus-type-status"
+      ],
+      "depth": 199,
+      "head": "6fbcfa098ba730314e3c8ddb23c132928357e796",
+      "parentRecordedHead": "016b86bbf9012bda647ef571e7a69af64c2b7584",
+      "parentCurrentHead": "016b86bbf9012bda647ef571e7a69af64c2b7584",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6fbcfa098",
+        "sha": "6fbcfa098ba730314e3c8ddb23c132928357e796",
+        "iso": "2026-06-03T15:21:49-04:00",
+        "subject": "refactor(direct-control): prune health facade callthroughs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/align-atom-corpus-type-status",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-health-facade-callthrough",
+      "children": [
+        "codex/prune-static-catalog-facade-callthrough"
+      ],
+      "depth": 200,
+      "head": "9585a27254cbe7cd1398aa0bec6d227b883f43d2",
+      "parentRecordedHead": "6fbcfa098ba730314e3c8ddb23c132928357e796",
+      "parentCurrentHead": "6fbcfa098ba730314e3c8ddb23c132928357e796",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9585a2725",
+        "sha": "9585a27254cbe7cd1398aa0bec6d227b883f43d2",
+        "iso": "2026-06-03T15:26:15-04:00",
+        "subject": "docs(openspec): align atom corpus type status"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-static-catalog-facade-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/align-atom-corpus-type-status",
+      "children": [
+        "codex/clarify-effect-wait-roadmap"
+      ],
+      "depth": 201,
+      "head": "61f16002fe9114d9528e1dbd7b7ab750ab9bd185",
+      "parentRecordedHead": "9585a27254cbe7cd1398aa0bec6d227b883f43d2",
+      "parentCurrentHead": "9585a27254cbe7cd1398aa0bec6d227b883f43d2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "61f16002f",
+        "sha": "61f16002fe9114d9528e1dbd7b7ab750ab9bd185",
+        "iso": "2026-06-03T15:30:36-04:00",
+        "subject": "refactor(direct-control): prune static catalog facade callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/clarify-effect-wait-roadmap",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-static-catalog-facade-callthrough",
+      "children": [
+        "codex/normalize-compatibility-matrix-statuses"
+      ],
+      "depth": 202,
+      "head": "429930d4ffcf5ef2e45dcb81428c2189b5400f36",
+      "parentRecordedHead": "61f16002fe9114d9528e1dbd7b7ab750ab9bd185",
+      "parentCurrentHead": "61f16002fe9114d9528e1dbd7b7ab750ab9bd185",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "429930d4f",
+        "sha": "429930d4ffcf5ef2e45dcb81428c2189b5400f36",
+        "iso": "2026-06-03T15:33:46-04:00",
+        "subject": "docs(direct-control): clarify Effect wait roadmap"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-compatibility-matrix-statuses",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/clarify-effect-wait-roadmap",
+      "children": [
+        "codex/disposition-schema-evaluation-report"
+      ],
+      "depth": 203,
+      "head": "f468e16fcbab37254bccd2f82f8ee502a36e94bb",
+      "parentRecordedHead": "429930d4ffcf5ef2e45dcb81428c2189b5400f36",
+      "parentCurrentHead": "429930d4ffcf5ef2e45dcb81428c2189b5400f36",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f468e16fc",
+        "sha": "f468e16fcbab37254bccd2f82f8ee502a36e94bb",
+        "iso": "2026-06-03T15:39:52-04:00",
+        "subject": "docs(direct-control): normalize compatibility matrix statuses"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/disposition-schema-evaluation-report",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-compatibility-matrix-statuses",
+      "children": [
+        "codex/record-direct-control-verification-checkpoint"
+      ],
+      "depth": 204,
+      "head": "83aebdb45568827becb46885c699e14515063789",
+      "parentRecordedHead": "f468e16fcbab37254bccd2f82f8ee502a36e94bb",
+      "parentCurrentHead": "f468e16fcbab37254bccd2f82f8ee502a36e94bb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "83aebdb45",
+        "sha": "83aebdb45568827becb46885c699e14515063789",
+        "iso": "2026-06-03T15:58:11-04:00",
+        "subject": "docs(direct-control): disposition schema evaluation report"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-direct-control-verification-checkpoint",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/disposition-schema-evaluation-report",
+      "children": [
+        "codex/record-runtime-proof-disposition"
+      ],
+      "depth": 205,
+      "head": "31ed672a1eeb49a5c8c72265fbffb756ed9b7a6b",
+      "parentRecordedHead": "83aebdb45568827becb46885c699e14515063789",
+      "parentCurrentHead": "83aebdb45568827becb46885c699e14515063789",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "31ed672a1",
+        "sha": "31ed672a1eeb49a5c8c72265fbffb756ed9b7a6b",
+        "iso": "2026-06-03T16:03:29-04:00",
+        "subject": "docs(direct-control): record source verification checkpoint"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-runtime-proof-disposition",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-direct-control-verification-checkpoint",
+      "children": [
+        "codex/record-cli-test-verification-checkpoint"
+      ],
+      "depth": 206,
+      "head": "ce980a41b115c3379d133715df8077016d0fa7a1",
+      "parentRecordedHead": "31ed672a1eeb49a5c8c72265fbffb756ed9b7a6b",
+      "parentCurrentHead": "31ed672a1eeb49a5c8c72265fbffb756ed9b7a6b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ce980a41b",
+        "sha": "ce980a41b115c3379d133715df8077016d0fa7a1",
+        "iso": "2026-06-03T16:05:04-04:00",
+        "subject": "docs(direct-control): record runtime proof disposition"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-cli-test-verification-checkpoint",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-runtime-proof-disposition",
+      "children": [
+        "codex/record-blocked-lane-verification-disposition"
+      ],
+      "depth": 207,
+      "head": "b99a3cea35b5cdea99527b3971495dc8e81942dd",
+      "parentRecordedHead": "ce980a41b115c3379d133715df8077016d0fa7a1",
+      "parentCurrentHead": "ce980a41b115c3379d133715df8077016d0fa7a1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b99a3cea3",
+        "sha": "b99a3cea35b5cdea99527b3971495dc8e81942dd",
+        "iso": "2026-06-03T16:07:10-04:00",
+        "subject": "docs(direct-control): record CLI test verification checkpoint"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-blocked-lane-verification-disposition",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-cli-test-verification-checkpoint",
+      "children": [
+        "codex/record-downstream-realignment-checkpoint"
+      ],
+      "depth": 208,
+      "head": "274f52d04a17b59feb4441630b146bd04531dc01",
+      "parentRecordedHead": "b99a3cea35b5cdea99527b3971495dc8e81942dd",
+      "parentCurrentHead": "b99a3cea35b5cdea99527b3971495dc8e81942dd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "274f52d04",
+        "sha": "274f52d04a17b59feb4441630b146bd04531dc01",
+        "iso": "2026-06-03T16:08:55-04:00",
+        "subject": "docs(direct-control): record blocked lane proof disposition"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-downstream-realignment-checkpoint",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-blocked-lane-verification-disposition",
+      "children": [
+        "codex/record-compatibility-matrix-acceptance-backlog"
+      ],
+      "depth": 209,
+      "head": "1233d2bc04b64bc865031e19f005986ef3391b00",
+      "parentRecordedHead": "274f52d04a17b59feb4441630b146bd04531dc01",
+      "parentCurrentHead": "274f52d04a17b59feb4441630b146bd04531dc01",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1233d2bc0",
+        "sha": "1233d2bc04b64bc865031e19f005986ef3391b00",
+        "iso": "2026-06-03T16:11:35-04:00",
+        "subject": "docs(direct-control): record downstream realignment checkpoint"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-compatibility-matrix-acceptance-backlog",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-downstream-realignment-checkpoint",
+      "children": [
+        "codex/record-ai-hotseat-bridge-boundary"
+      ],
+      "depth": 210,
+      "head": "c125762e1c97e3e3b134a515452a6b66b60509f3",
+      "parentRecordedHead": "1233d2bc04b64bc865031e19f005986ef3391b00",
+      "parentCurrentHead": "1233d2bc04b64bc865031e19f005986ef3391b00",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c125762e1",
+        "sha": "c125762e1c97e3e3b134a515452a6b66b60509f3",
+        "iso": "2026-06-03T16:17:00-04:00",
+        "subject": "docs(direct-control): record matrix acceptance backlog"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-ai-hotseat-bridge-boundary",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-compatibility-matrix-acceptance-backlog",
+      "children": [
+        "codex/record-compatibility-row-intake"
+      ],
+      "depth": 211,
+      "head": "a05cbc031c2f7980b83fcc012b59d6e7b8dbaf6f",
+      "parentRecordedHead": "c125762e1c97e3e3b134a515452a6b66b60509f3",
+      "parentCurrentHead": "c125762e1c97e3e3b134a515452a6b66b60509f3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a05cbc031",
+        "sha": "a05cbc031c2f7980b83fcc012b59d6e7b8dbaf6f",
+        "iso": "2026-06-03T16:21:12-04:00",
+        "subject": "docs(direct-control): record AI bridge boundary"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-compatibility-row-intake",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-ai-hotseat-bridge-boundary",
+      "children": [
+        "codex/prune-map-read-facade-dependencies"
+      ],
+      "depth": 212,
+      "head": "75b61f52603c23a91470df5c1c609291d1ddd9d7",
+      "parentRecordedHead": "a05cbc031c2f7980b83fcc012b59d6e7b8dbaf6f",
+      "parentCurrentHead": "a05cbc031c2f7980b83fcc012b59d6e7b8dbaf6f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "75b61f526",
+        "sha": "75b61f52603c23a91470df5c1c609291d1ddd9d7",
+        "iso": "2026-06-03T16:24:33-04:00",
+        "subject": "docs(direct-control): record matrix row intake gate"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-map-read-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-compatibility-row-intake",
+      "children": [
+        "codex/prune-summary-read-facade-dependencies"
+      ],
+      "depth": 213,
+      "head": "ee59af5c069e73ebeeeda5fcc86be26e1147e830",
+      "parentRecordedHead": "75b61f52603c23a91470df5c1c609291d1ddd9d7",
+      "parentCurrentHead": "75b61f52603c23a91470df5c1c609291d1ddd9d7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ee59af5c0",
+        "sha": "ee59af5c069e73ebeeeda5fcc86be26e1147e830",
+        "iso": "2026-06-03T16:35:05-04:00",
+        "subject": "refactor(direct-control): prune map read facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-summary-read-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-map-read-facade-dependencies",
+      "children": [
+        "codex/prune-gameinfo-read-facade-dependencies"
+      ],
+      "depth": 214,
+      "head": "8292bfa0a9c169e4d051201e41f9517dd0a262f6",
+      "parentRecordedHead": "ee59af5c069e73ebeeeda5fcc86be26e1147e830",
+      "parentCurrentHead": "ee59af5c069e73ebeeeda5fcc86be26e1147e830",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8292bfa0a",
+        "sha": "8292bfa0a9c169e4d051201e41f9517dd0a262f6",
+        "iso": "2026-06-03T16:41:12-04:00",
+        "subject": "refactor(direct-control): prune summary read facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-gameinfo-read-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-summary-read-facade-dependencies",
+      "children": [
+        "codex/prune-visibility-read-facade-dependencies"
+      ],
+      "depth": 215,
+      "head": "b3bed3492b7c909fb4f50c0397a98c27813f22dd",
+      "parentRecordedHead": "8292bfa0a9c169e4d051201e41f9517dd0a262f6",
+      "parentCurrentHead": "8292bfa0a9c169e4d051201e41f9517dd0a262f6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b3bed3492",
+        "sha": "b3bed3492b7c909fb4f50c0397a98c27813f22dd",
+        "iso": "2026-06-03T17:00:17-04:00",
+        "subject": "refactor(direct-control): prune GameInfo read facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-visibility-read-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-gameinfo-read-facade-dependencies",
+      "children": [
+        "codex/prune-root-inspection-facade-dependencies"
+      ],
+      "depth": 216,
+      "head": "cbe9e095862f215b57067d6e9004c804160396a0",
+      "parentRecordedHead": "b3bed3492b7c909fb4f50c0397a98c27813f22dd",
+      "parentCurrentHead": "b3bed3492b7c909fb4f50c0397a98c27813f22dd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cbe9e0958",
+        "sha": "cbe9e095862f215b57067d6e9004c804160396a0",
+        "iso": "2026-06-03T17:05:09-04:00",
+        "subject": "refactor(direct-control): prune visibility read facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-root-inspection-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-visibility-read-facade-dependencies",
+      "children": [
+        "codex/prune-notification-view-facade-dependencies"
+      ],
+      "depth": 217,
+      "head": "84f01fe8c6bd41ee07f7d0a322703162960c6477",
+      "parentRecordedHead": "cbe9e095862f215b57067d6e9004c804160396a0",
+      "parentCurrentHead": "cbe9e095862f215b57067d6e9004c804160396a0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "84f01fe8c",
+        "sha": "84f01fe8c6bd41ee07f7d0a322703162960c6477",
+        "iso": "2026-06-03T17:08:55-04:00",
+        "subject": "refactor(direct-control): prune root inspection facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-notification-view-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-root-inspection-facade-dependencies",
+      "children": [
+        "codex/prune-ready-read-facade-dependencies"
+      ],
+      "depth": 218,
+      "head": "422eabd29a9e086f94103010e864cb105e5166b3",
+      "parentRecordedHead": "84f01fe8c6bd41ee07f7d0a322703162960c6477",
+      "parentCurrentHead": "84f01fe8c6bd41ee07f7d0a322703162960c6477",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "422eabd29",
+        "sha": "422eabd29a9e086f94103010e864cb105e5166b3",
+        "iso": "2026-06-03T17:14:23-04:00",
+        "subject": "refactor(direct-control): prune notification view facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-ready-read-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-notification-view-facade-dependencies",
+      "children": [
+        "codex/prune-tactical-progression-read-facade-dependencies"
+      ],
+      "depth": 219,
+      "head": "9613ba7aa4ae7a1bb1666ab248e1e583e356e50b",
+      "parentRecordedHead": "422eabd29a9e086f94103010e864cb105e5166b3",
+      "parentCurrentHead": "422eabd29a9e086f94103010e864cb105e5166b3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9613ba7aa",
+        "sha": "9613ba7aa4ae7a1bb1666ab248e1e583e356e50b",
+        "iso": "2026-06-03T17:18:35-04:00",
+        "subject": "refactor(direct-control): prune ready read facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-tactical-progression-read-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-ready-read-facade-dependencies",
+      "children": [
+        "codex/prune-turn-completion-facade-dependencies"
+      ],
+      "depth": 220,
+      "head": "a46a2576b22fd4236acb9031ac39771cfb9895f7",
+      "parentRecordedHead": "9613ba7aa4ae7a1bb1666ab248e1e583e356e50b",
+      "parentCurrentHead": "9613ba7aa4ae7a1bb1666ab248e1e583e356e50b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a46a2576b",
+        "sha": "a46a2576b22fd4236acb9031ac39771cfb9895f7",
+        "iso": "2026-06-03T17:23:22-04:00",
+        "subject": "refactor(direct-control): prune tactical read facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-turn-completion-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-tactical-progression-read-facade-dependencies",
+      "children": [
+        "codex/prune-notification-dismissal-facade-dependencies"
+      ],
+      "depth": 221,
+      "head": "d73d0bfb3e133326c160aa39f3ee8ef820ab7acc",
+      "parentRecordedHead": "a46a2576b22fd4236acb9031ac39771cfb9895f7",
+      "parentCurrentHead": "a46a2576b22fd4236acb9031ac39771cfb9895f7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d73d0bfb3",
+        "sha": "d73d0bfb3e133326c160aa39f3ee8ef820ab7acc",
+        "iso": "2026-06-03T17:29:04-04:00",
+        "subject": "refactor(direct-control): prune turn completion facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-notification-dismissal-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-turn-completion-facade-dependencies",
+      "children": [
+        "codex/prune-generic-operation-facade-dependencies"
+      ],
+      "depth": 222,
+      "head": "821b2a5ff4fd2c03583f053df5cd48eafc0175d1",
+      "parentRecordedHead": "d73d0bfb3e133326c160aa39f3ee8ef820ab7acc",
+      "parentCurrentHead": "d73d0bfb3e133326c160aa39f3ee8ef820ab7acc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "821b2a5ff",
+        "sha": "821b2a5ff4fd2c03583f053df5cd48eafc0175d1",
+        "iso": "2026-06-03T17:33:59-04:00",
+        "subject": "refactor(direct-control): prune notification dismissal facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-generic-operation-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-notification-dismissal-facade-dependencies",
+      "children": [
+        "codex/realign-controller-bridge-substrate"
+      ],
+      "depth": 223,
+      "head": "6fbf126b896234c71a71dc4d6701378e31162d8c",
+      "parentRecordedHead": "821b2a5ff4fd2c03583f053df5cd48eafc0175d1",
+      "parentCurrentHead": "821b2a5ff4fd2c03583f053df5cd48eafc0175d1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6fbf126b8",
+        "sha": "6fbf126b896234c71a71dc4d6701378e31162d8c",
+        "iso": "2026-06-03T17:40:27-04:00",
+        "subject": "refactor(direct-control): prune generic operation facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/realign-controller-bridge-substrate",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-generic-operation-facade-dependencies",
+      "children": [
+        "codex/prune-setup-read-facade-dependencies"
+      ],
+      "depth": 224,
+      "head": "0a571d36cdddf8587b372facbfbc3da1d92d7df7",
+      "parentRecordedHead": "6fbf126b896234c71a71dc4d6701378e31162d8c",
+      "parentCurrentHead": "6fbf126b896234c71a71dc4d6701378e31162d8c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0a571d36c",
+        "sha": "0a571d36cdddf8587b372facbfbc3da1d92d7df7",
+        "iso": "2026-06-03T17:46:00-04:00",
+        "subject": "docs(direct-control): realign controller bridge substrate"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-setup-read-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/realign-controller-bridge-substrate",
+      "children": [
+        "codex/prune-setup-prepare-facade-dependencies"
+      ],
+      "depth": 225,
+      "head": "3c0ed19f7b65edf8efec94f81b4cbf868b93cec0",
+      "parentRecordedHead": "0a571d36cdddf8587b372facbfbc3da1d92d7df7",
+      "parentCurrentHead": "0a571d36cdddf8587b372facbfbc3da1d92d7df7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3c0ed19f7",
+        "sha": "3c0ed19f7b65edf8efec94f81b4cbf868b93cec0",
+        "iso": "2026-06-03T17:52:10-04:00",
+        "subject": "refactor(direct-control): prune setup read facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-setup-prepare-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-setup-read-facade-dependencies",
+      "children": [
+        "codex/prune-setup-start-facade-dependencies"
+      ],
+      "depth": 226,
+      "head": "d3a620247f671d4c885e271058269111a3467e6c",
+      "parentRecordedHead": "3c0ed19f7b65edf8efec94f81b4cbf868b93cec0",
+      "parentCurrentHead": "3c0ed19f7b65edf8efec94f81b4cbf868b93cec0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d3a620247",
+        "sha": "d3a620247f671d4c885e271058269111a3467e6c",
+        "iso": "2026-06-03T17:56:11-04:00",
+        "subject": "refactor(direct-control): prune setup prepare facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-setup-start-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-setup-prepare-facade-dependencies",
+      "children": [
+        "codex/prune-setup-run-facade-dependencies"
+      ],
+      "depth": 227,
+      "head": "8661f5e5a8846361f0f1d351b0fa3efb2f2173b6",
+      "parentRecordedHead": "d3a620247f671d4c885e271058269111a3467e6c",
+      "parentCurrentHead": "d3a620247f671d4c885e271058269111a3467e6c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8661f5e5a",
+        "sha": "8661f5e5a8846361f0f1d351b0fa3efb2f2173b6",
+        "iso": "2026-06-03T18:03:00-04:00",
+        "subject": "refactor(direct-control): prune setup start facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-setup-run-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-setup-start-facade-dependencies",
+      "children": [
+        "codex/prune-setup-restart-facade-dependencies"
+      ],
+      "depth": 228,
+      "head": "9102f39eaa6088f80c5b9e84bfd446e0a9381856",
+      "parentRecordedHead": "8661f5e5a8846361f0f1d351b0fa3efb2f2173b6",
+      "parentCurrentHead": "8661f5e5a8846361f0f1d351b0fa3efb2f2173b6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9102f39ea",
+        "sha": "9102f39eaa6088f80c5b9e84bfd446e0a9381856",
+        "iso": "2026-06-03T18:07:59-04:00",
+        "subject": "refactor(direct-control): prune setup run facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-setup-restart-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-setup-run-facade-dependencies",
+      "children": [
+        "codex/prune-autoplay-facade-dependencies"
+      ],
+      "depth": 229,
+      "head": "737bb051d63d8ff50ecb554f81ed204c8b6cfa9b",
+      "parentRecordedHead": "9102f39eaa6088f80c5b9e84bfd446e0a9381856",
+      "parentCurrentHead": "9102f39eaa6088f80c5b9e84bfd446e0a9381856",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "737bb051d",
+        "sha": "737bb051d63d8ff50ecb554f81ed204c8b6cfa9b",
+        "iso": "2026-06-03T18:13:42-04:00",
+        "subject": "refactor(direct-control): prune setup restart facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-autoplay-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-setup-restart-facade-dependencies",
+      "children": [
+        "codex/prune-progression-closeout-facade-dependencies"
+      ],
+      "depth": 230,
+      "head": "c1c92d98b27eb988417a96dbab5b20154637e317",
+      "parentRecordedHead": "737bb051d63d8ff50ecb554f81ed204c8b6cfa9b",
+      "parentCurrentHead": "737bb051d63d8ff50ecb554f81ed204c8b6cfa9b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c1c92d98b",
+        "sha": "c1c92d98b27eb988417a96dbab5b20154637e317",
+        "iso": "2026-06-03T18:20:53-04:00",
+        "subject": "refactor(direct-control): prune autoplay facade dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-progression-closeout-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-autoplay-facade-dependencies",
+      "children": [
+        "codex/prune-production-choice-facade-dependencies"
+      ],
+      "depth": 231,
+      "head": "9c9ac86125a72f31579c9167ef88ee4a6c2b8e2c",
+      "parentRecordedHead": "c1c92d98b27eb988417a96dbab5b20154637e317",
+      "parentCurrentHead": "c1c92d98b27eb988417a96dbab5b20154637e317",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9c9ac8612",
+        "sha": "9c9ac86125a72f31579c9167ef88ee4a6c2b8e2c",
+        "iso": "2026-06-03T18:29:04-04:00",
+        "subject": "refactor(direct-control): prune progression closeout dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-production-choice-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-progression-closeout-facade-dependencies",
+      "children": [
+        "codex/prune-diplomacy-response-facade-dependencies"
+      ],
+      "depth": 232,
+      "head": "f31bb2e6b1939cb647c59a3a0b8d3a2ae2dcf556",
+      "parentRecordedHead": "9c9ac86125a72f31579c9167ef88ee4a6c2b8e2c",
+      "parentCurrentHead": "9c9ac86125a72f31579c9167ef88ee4a6c2b8e2c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f31bb2e6b",
+        "sha": "f31bb2e6b1939cb647c59a3a0b8d3a2ae2dcf556",
+        "iso": "2026-06-03T18:32:22-04:00",
+        "subject": "refactor(direct-control): prune production choice dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-diplomacy-response-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-production-choice-facade-dependencies",
+      "children": [
+        "codex/prune-narrative-choice-facade-dependencies"
+      ],
+      "depth": 233,
+      "head": "64f6f5257228a7045a29a3bc1a6fe0907f99ac6c",
+      "parentRecordedHead": "f31bb2e6b1939cb647c59a3a0b8d3a2ae2dcf556",
+      "parentCurrentHead": "f31bb2e6b1939cb647c59a3a0b8d3a2ae2dcf556",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "64f6f5257",
+        "sha": "64f6f5257228a7045a29a3bc1a6fe0907f99ac6c",
+        "iso": "2026-06-03T18:39:33-04:00",
+        "subject": "refactor(direct-control): prune diplomacy response dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-narrative-choice-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-diplomacy-response-facade-dependencies",
+      "children": [
+        "codex/prune-unit-target-facade-dependencies"
+      ],
+      "depth": 234,
+      "head": "032a262a9a508bdb7fee8080fb563a73f1cf75fd",
+      "parentRecordedHead": "64f6f5257228a7045a29a3bc1a6fe0907f99ac6c",
+      "parentCurrentHead": "64f6f5257228a7045a29a3bc1a6fe0907f99ac6c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "032a262a9",
+        "sha": "032a262a9a508bdb7fee8080fb563a73f1cf75fd",
+        "iso": "2026-06-03T18:43:52-04:00",
+        "subject": "refactor(direct-control): prune narrative choice dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-unit-target-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-narrative-choice-facade-dependencies",
+      "children": [
+        "codex/prune-capability-catalog-facade-dependencies"
+      ],
+      "depth": 235,
+      "head": "35e0f7c04853e4f2627645597aaeda4e34a7e5d7",
+      "parentRecordedHead": "032a262a9a508bdb7fee8080fb563a73f1cf75fd",
+      "parentCurrentHead": "032a262a9a508bdb7fee8080fb563a73f1cf75fd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "35e0f7c04",
+        "sha": "35e0f7c04853e4f2627645597aaeda4e34a7e5d7",
+        "iso": "2026-06-03T18:49:08-04:00",
+        "subject": "refactor(direct-control): prune unit-target dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-capability-catalog-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-unit-target-facade-dependencies",
+      "children": [
+        "codex/prune-app-ui-snapshot-facade-dependencies"
+      ],
+      "depth": 236,
+      "head": "4ca7b6bd55dbfeaa1551ca748b1f41b94d8013e7",
+      "parentRecordedHead": "35e0f7c04853e4f2627645597aaeda4e34a7e5d7",
+      "parentCurrentHead": "35e0f7c04853e4f2627645597aaeda4e34a7e5d7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4ca7b6bd5",
+        "sha": "4ca7b6bd55dbfeaa1551ca748b1f41b94d8013e7",
+        "iso": "2026-06-03T18:55:42-04:00",
+        "subject": "refactor(direct-control): prune capability catalog dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-app-ui-snapshot-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-capability-catalog-facade-dependencies",
+      "children": [
+        "codex/prune-tuner-health-facade-dependencies"
+      ],
+      "depth": 237,
+      "head": "7026f32ed23fb4f2fdfe9be573282b2b47e275bf",
+      "parentRecordedHead": "4ca7b6bd55dbfeaa1551ca748b1f41b94d8013e7",
+      "parentCurrentHead": "4ca7b6bd55dbfeaa1551ca748b1f41b94d8013e7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7026f32ed",
+        "sha": "7026f32ed23fb4f2fdfe9be573282b2b47e275bf",
+        "iso": "2026-06-03T19:02:20-04:00",
+        "subject": "refactor(direct-control): prune App UI snapshot dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-tuner-health-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-app-ui-snapshot-facade-dependencies",
+      "children": [
+        "codex/prune-playable-status-facade-dependencies"
+      ],
+      "depth": 238,
+      "head": "b13dbaef4fef6c9c24881c03329cf77c43bc35ea",
+      "parentRecordedHead": "7026f32ed23fb4f2fdfe9be573282b2b47e275bf",
+      "parentCurrentHead": "7026f32ed23fb4f2fdfe9be573282b2b47e275bf",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b13dbaef4",
+        "sha": "b13dbaef4fef6c9c24881c03329cf77c43bc35ea",
+        "iso": "2026-06-03T19:05:46-04:00",
+        "subject": "refactor(direct-control): prune Tuner health dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-playable-status-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-tuner-health-facade-dependencies",
+      "children": [
+        "codex/prune-runtime-inspection-facade-dependencies"
+      ],
+      "depth": 239,
+      "head": "90f792fa43830e9ff9e2389a8df5c638f584d88e",
+      "parentRecordedHead": "b13dbaef4fef6c9c24881c03329cf77c43bc35ea",
+      "parentCurrentHead": "b13dbaef4fef6c9c24881c03329cf77c43bc35ea",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "90f792fa4",
+        "sha": "90f792fa43830e9ff9e2389a8df5c638f584d88e",
+        "iso": "2026-06-03T19:10:58-04:00",
+        "subject": "refactor(direct-control): prune playable-status dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-runtime-inspection-facade-dependencies",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-playable-status-facade-dependencies",
+      "children": [
+        "codex/prune-setup-read-facade-helper"
+      ],
+      "depth": 240,
+      "head": "0d7ed038af5851f40b23670e798901e1fc047100",
+      "parentRecordedHead": "90f792fa43830e9ff9e2389a8df5c638f584d88e",
+      "parentCurrentHead": "90f792fa43830e9ff9e2389a8df5c638f584d88e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0d7ed038a",
+        "sha": "0d7ed038af5851f40b23670e798901e1fc047100",
+        "iso": "2026-06-03T19:14:16-04:00",
+        "subject": "refactor(direct-control): prune runtime inspection dependencies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-setup-read-facade-helper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-runtime-inspection-facade-dependencies",
+      "children": [
+        "codex/align-root-inspection-dependency-record"
+      ],
+      "depth": 241,
+      "head": "7b8604e500c9044f22ef017b31992b4a5455fe23",
+      "parentRecordedHead": "0d7ed038af5851f40b23670e798901e1fc047100",
+      "parentCurrentHead": "0d7ed038af5851f40b23670e798901e1fc047100",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7b8604e50",
+        "sha": "7b8604e500c9044f22ef017b31992b4a5455fe23",
+        "iso": "2026-06-03T19:21:22-04:00",
+        "subject": "refactor(direct-control): prune setup-read facade helper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/align-root-inspection-dependency-record",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-setup-read-facade-helper",
+      "children": [
+        "codex/prune-facade-stale-value-imports"
+      ],
+      "depth": 242,
+      "head": "a25c7f8237e21e8dfaf15bf12984cac017362e8f",
+      "parentRecordedHead": "7b8604e500c9044f22ef017b31992b4a5455fe23",
+      "parentCurrentHead": "7b8604e500c9044f22ef017b31992b4a5455fe23",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a25c7f823",
+        "sha": "a25c7f8237e21e8dfaf15bf12984cac017362e8f",
+        "iso": "2026-06-03T19:23:06-04:00",
+        "subject": "docs(direct-control): align root inspection dependency records"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-facade-stale-value-imports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/align-root-inspection-dependency-record",
+      "children": [
+        "codex/prune-facade-reexport-imports"
+      ],
+      "depth": 243,
+      "head": "613ee52b3dd8488e0df54b840d1ed172761d7cfb",
+      "parentRecordedHead": "a25c7f8237e21e8dfaf15bf12984cac017362e8f",
+      "parentCurrentHead": "a25c7f8237e21e8dfaf15bf12984cac017362e8f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "613ee52b3",
+        "sha": "613ee52b3dd8488e0df54b840d1ed172761d7cfb",
+        "iso": "2026-06-03T19:26:50-04:00",
+        "subject": "refactor(direct-control): prune stale facade value imports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-facade-reexport-imports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-facade-stale-value-imports",
+      "children": [
+        "codex/prune-map-constant-reexport-imports"
+      ],
+      "depth": 244,
+      "head": "6d24e09dbaa656a26fdfbc67d18e80608e1cdfa5",
+      "parentRecordedHead": "613ee52b3dd8488e0df54b840d1ed172761d7cfb",
+      "parentCurrentHead": "613ee52b3dd8488e0df54b840d1ed172761d7cfb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6d24e09db",
+        "sha": "6d24e09dbaa656a26fdfbc67d18e80608e1cdfa5",
+        "iso": "2026-06-03T19:31:56-04:00",
+        "subject": "refactor(direct-control): prune facade re-export imports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-map-constant-reexport-imports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-facade-reexport-imports",
+      "children": [
+        "codex/prune-map-type-reexport-imports"
+      ],
+      "depth": 245,
+      "head": "f18893e5bf6d49b7e2d82d49e037da9371f2eb3b",
+      "parentRecordedHead": "6d24e09dbaa656a26fdfbc67d18e80608e1cdfa5",
+      "parentCurrentHead": "6d24e09dbaa656a26fdfbc67d18e80608e1cdfa5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f18893e5b",
+        "sha": "f18893e5bf6d49b7e2d82d49e037da9371f2eb3b",
+        "iso": "2026-06-03T19:35:26-04:00",
+        "subject": "refactor(direct-control): prune map constant re-export imports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-map-type-reexport-imports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-map-constant-reexport-imports",
+      "children": [
+        "codex/prune-production-postcondition-type-reexport"
+      ],
+      "depth": 246,
+      "head": "629c23cd073ab0c108bde881be344429de6284ec",
+      "parentRecordedHead": "f18893e5bf6d49b7e2d82d49e037da9371f2eb3b",
+      "parentCurrentHead": "f18893e5bf6d49b7e2d82d49e037da9371f2eb3b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "629c23cd0",
+        "sha": "629c23cd073ab0c108bde881be344429de6284ec",
+        "iso": "2026-06-03T19:38:14-04:00",
+        "subject": "refactor(direct-control): prune map type re-export imports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-production-postcondition-type-reexport",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-map-type-reexport-imports",
+      "children": [
+        "codex/prune-runtime-type-reexport-imports"
+      ],
+      "depth": 247,
+      "head": "d76cd7e226d65e8231339c764a14cb206b7f99a7",
+      "parentRecordedHead": "629c23cd073ab0c108bde881be344429de6284ec",
+      "parentCurrentHead": "629c23cd073ab0c108bde881be344429de6284ec",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d76cd7e22",
+        "sha": "d76cd7e226d65e8231339c764a14cb206b7f99a7",
+        "iso": "2026-06-03T19:41:08-04:00",
+        "subject": "refactor(direct-control): prune production postcondition type re-export"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-runtime-type-reexport-imports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-production-postcondition-type-reexport",
+      "children": [
+        "codex/prune-session-type-reexport-imports"
+      ],
+      "depth": 248,
+      "head": "7cc693c490e94ecde38efb8d513962f2f2a0bc6b",
+      "parentRecordedHead": "d76cd7e226d65e8231339c764a14cb206b7f99a7",
+      "parentCurrentHead": "d76cd7e226d65e8231339c764a14cb206b7f99a7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7cc693c49",
+        "sha": "7cc693c490e94ecde38efb8d513962f2f2a0bc6b",
+        "iso": "2026-06-03T19:44:08-04:00",
+        "subject": "refactor(direct-control): prune runtime type re-export imports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-session-type-reexport-imports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-runtime-type-reexport-imports",
+      "children": [
+        "codex/prune-notification-view-type-reexport-imports"
+      ],
+      "depth": 249,
+      "head": "79ce8e05263b7c9d85d4ea7534b61ecb0b0fb0b8",
+      "parentRecordedHead": "7cc693c490e94ecde38efb8d513962f2f2a0bc6b",
+      "parentCurrentHead": "7cc693c490e94ecde38efb8d513962f2f2a0bc6b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "79ce8e052",
+        "sha": "79ce8e05263b7c9d85d4ea7534b61ecb0b0fb0b8",
+        "iso": "2026-06-03T19:48:24-04:00",
+        "subject": "refactor(direct-control): prune session type re-export imports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-notification-view-type-reexport-imports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-session-type-reexport-imports",
+      "children": [
+        "codex/prune-notification-dismissal-type-reexport-import"
+      ],
+      "depth": 250,
+      "head": "15a0863342bd4a95498f1f154006c18a837a8f12",
+      "parentRecordedHead": "79ce8e05263b7c9d85d4ea7534b61ecb0b0fb0b8",
+      "parentCurrentHead": "79ce8e05263b7c9d85d4ea7534b61ecb0b0fb0b8",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "15a086334",
+        "sha": "15a0863342bd4a95498f1f154006c18a837a8f12",
+        "iso": "2026-06-03T19:52:15-04:00",
+        "subject": "refactor(direct-control): prune notification view type imports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-notification-dismissal-type-reexport-import",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-notification-view-type-reexport-imports",
+      "children": [
+        "codex/prune-progression-read-type-reexport-imports"
+      ],
+      "depth": 251,
+      "head": "e7cf16fbebc6c094f0083c68b6c9f32b34e27e69",
+      "parentRecordedHead": "15a0863342bd4a95498f1f154006c18a837a8f12",
+      "parentCurrentHead": "15a0863342bd4a95498f1f154006c18a837a8f12",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e7cf16fbe",
+        "sha": "e7cf16fbebc6c094f0083c68b6c9f32b34e27e69",
+        "iso": "2026-06-03T19:54:50-04:00",
+        "subject": "refactor(direct-control): prune notification dismissal type import"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-progression-read-type-reexport-imports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-notification-dismissal-type-reexport-import",
+      "children": [
+        "codex/prune-production-choice-type-reexport-import"
+      ],
+      "depth": 252,
+      "head": "fbaae62f8a4b636a88e4c6d7a8eb009206013bbe",
+      "parentRecordedHead": "e7cf16fbebc6c094f0083c68b6c9f32b34e27e69",
+      "parentCurrentHead": "e7cf16fbebc6c094f0083c68b6c9f32b34e27e69",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fbaae62f8",
+        "sha": "fbaae62f8a4b636a88e4c6d7a8eb009206013bbe",
+        "iso": "2026-06-03T19:58:17-04:00",
+        "subject": "refactor(direct-control): prune progression read type imports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-production-choice-type-reexport-import",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-progression-read-type-reexport-imports",
+      "children": [
+        "codex/prune-setup-read-type-reexport-imports"
+      ],
+      "depth": 253,
+      "head": "34114bafe8b6eaaf8209b80d5a1bcee627040cbd",
+      "parentRecordedHead": "fbaae62f8a4b636a88e4c6d7a8eb009206013bbe",
+      "parentCurrentHead": "fbaae62f8a4b636a88e4c6d7a8eb009206013bbe",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "34114bafe",
+        "sha": "34114bafe8b6eaaf8209b80d5a1bcee627040cbd",
+        "iso": "2026-06-03T20:01:52-04:00",
+        "subject": "refactor(direct-control): prune production choice payload type import"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-setup-read-type-reexport-imports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-production-choice-type-reexport-import",
+      "children": [
+        "codex/prune-autoplay-poll-type-reexport-import"
+      ],
+      "depth": 254,
+      "head": "09d139ed54f65dea6ca7e471a93ce7df683f5403",
+      "parentRecordedHead": "34114bafe8b6eaaf8209b80d5a1bcee627040cbd",
+      "parentCurrentHead": "34114bafe8b6eaaf8209b80d5a1bcee627040cbd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "09d139ed5",
+        "sha": "09d139ed54f65dea6ca7e471a93ce7df683f5403",
+        "iso": "2026-06-03T20:04:42-04:00",
+        "subject": "refactor(direct-control): prune setup read helper type imports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-autoplay-poll-type-reexport-import",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-setup-read-type-reexport-imports",
+      "children": [
+        "codex/align-parser-serializer-dependency-record"
+      ],
+      "depth": 255,
+      "head": "782dc074abfa22c3ea5e2398f6c1d243a8fe2e63",
+      "parentRecordedHead": "09d139ed54f65dea6ca7e471a93ce7df683f5403",
+      "parentCurrentHead": "09d139ed54f65dea6ca7e471a93ce7df683f5403",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "782dc074a",
+        "sha": "782dc074abfa22c3ea5e2398f6c1d243a8fe2e63",
+        "iso": "2026-06-03T20:08:38-04:00",
+        "subject": "refactor(direct-control): prune autoplay poll type import"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/align-parser-serializer-dependency-record",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-autoplay-poll-type-reexport-import",
+      "children": [
+        "codex/record-debug-service-row-intake"
+      ],
+      "depth": 256,
+      "head": "d793eace0c69472b2faf381b6b939ceeca3cc07f",
+      "parentRecordedHead": "782dc074abfa22c3ea5e2398f6c1d243a8fe2e63",
+      "parentCurrentHead": "782dc074abfa22c3ea5e2398f6c1d243a8fe2e63",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d793eace0",
+        "sha": "d793eace0c69472b2faf381b6b939ceeca3cc07f",
+        "iso": "2026-06-03T20:13:13-04:00",
+        "subject": "docs(openspec): align parser serializer dependency records"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-debug-service-row-intake",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/align-parser-serializer-dependency-record",
+      "children": [
+        "codex/record-semantic-cli-row-intake"
+      ],
+      "depth": 257,
+      "head": "9100caa3fb30c6cd59880d4aad487ac6357b02c2",
+      "parentRecordedHead": "d793eace0c69472b2faf381b6b939ceeca3cc07f",
+      "parentCurrentHead": "d793eace0c69472b2faf381b6b939ceeca3cc07f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9100caa3f",
+        "sha": "9100caa3fb30c6cd59880d4aad487ac6357b02c2",
+        "iso": "2026-06-03T20:15:52-04:00",
+        "subject": "docs(openspec): record debug service row intake"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-semantic-cli-row-intake",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-debug-service-row-intake",
+      "children": [
+        "codex/record-telemetry-row-intake"
+      ],
+      "depth": 258,
+      "head": "b9c67b0e3a481676ec58e0d8ef388f4304ee6638",
+      "parentRecordedHead": "9100caa3fb30c6cd59880d4aad487ac6357b02c2",
+      "parentCurrentHead": "9100caa3fb30c6cd59880d4aad487ac6357b02c2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b9c67b0e3",
+        "sha": "b9c67b0e3a481676ec58e0d8ef388f4304ee6638",
+        "iso": "2026-06-03T20:22:02-04:00",
+        "subject": "docs(openspec): record semantic cli row intake"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-telemetry-row-intake",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-semantic-cli-row-intake",
+      "children": [
+        "codex/record-ai-ingestion-row-intake"
+      ],
+      "depth": 259,
+      "head": "f773aff133ec0b0d415703d197157257bf21d1fb",
+      "parentRecordedHead": "b9c67b0e3a481676ec58e0d8ef388f4304ee6638",
+      "parentCurrentHead": "b9c67b0e3a481676ec58e0d8ef388f4304ee6638",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f773aff13",
+        "sha": "f773aff133ec0b0d415703d197157257bf21d1fb",
+        "iso": "2026-06-03T20:25:14-04:00",
+        "subject": "docs(openspec): record telemetry row intake"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-ai-ingestion-row-intake",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-telemetry-row-intake",
+      "children": [
+        "codex/record-hotseat-row-intake"
+      ],
+      "depth": 260,
+      "head": "646e6d6faf5c67479b36fa0976fee508686109f9",
+      "parentRecordedHead": "f773aff133ec0b0d415703d197157257bf21d1fb",
+      "parentCurrentHead": "f773aff133ec0b0d415703d197157257bf21d1fb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "646e6d6fa",
+        "sha": "646e6d6faf5c67479b36fa0976fee508686109f9",
+        "iso": "2026-06-03T20:29:02-04:00",
+        "subject": "docs(openspec): record ai ingestion row intake"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-hotseat-row-intake",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-ai-ingestion-row-intake",
+      "children": [
+        "codex/record-procedure-core-row-intake"
+      ],
+      "depth": 261,
+      "head": "3f2c5ab22c24b049a6bd7a86969b55c49b39db23",
+      "parentRecordedHead": "646e6d6faf5c67479b36fa0976fee508686109f9",
+      "parentCurrentHead": "646e6d6faf5c67479b36fa0976fee508686109f9",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3f2c5ab22",
+        "sha": "3f2c5ab22c24b049a6bd7a86969b55c49b39db23",
+        "iso": "2026-06-03T20:32:16-04:00",
+        "subject": "docs(openspec): record hotseat row intake"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-procedure-core-row-intake",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-hotseat-row-intake",
+      "children": [
+        "codex/prune-runtime-status-facade-callthroughs"
+      ],
+      "depth": 262,
+      "head": "430f4af73fa2680a805a906062f21e91032096a2",
+      "parentRecordedHead": "3f2c5ab22c24b049a6bd7a86969b55c49b39db23",
+      "parentCurrentHead": "3f2c5ab22c24b049a6bd7a86969b55c49b39db23",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "430f4af73",
+        "sha": "430f4af73fa2680a805a906062f21e91032096a2",
+        "iso": "2026-06-03T20:40:07-04:00",
+        "subject": "docs(openspec): record procedure core row intake"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-runtime-status-facade-callthroughs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-procedure-core-row-intake",
+      "children": [
+        "codex/prune-map-read-facade-callthroughs"
+      ],
+      "depth": 263,
+      "head": "afa3523ad33f6975cff896b581bc6ee305d01d94",
+      "parentRecordedHead": "430f4af73fa2680a805a906062f21e91032096a2",
+      "parentCurrentHead": "430f4af73fa2680a805a906062f21e91032096a2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "afa3523ad",
+        "sha": "afa3523ad33f6975cff896b581bc6ee305d01d94",
+        "iso": "2026-06-03T20:45:23-04:00",
+        "subject": "refactor(direct-control): prune runtime status facade callthroughs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-map-read-facade-callthroughs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-runtime-status-facade-callthroughs",
+      "children": [
+        "codex/prune-tactical-progression-read-callthroughs"
+      ],
+      "depth": 264,
+      "head": "ed702505d8ea05d9ebfdf3a75e66f1afc9b2ba5c",
+      "parentRecordedHead": "afa3523ad33f6975cff896b581bc6ee305d01d94",
+      "parentCurrentHead": "afa3523ad33f6975cff896b581bc6ee305d01d94",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ed702505d",
+        "sha": "ed702505d8ea05d9ebfdf3a75e66f1afc9b2ba5c",
+        "iso": "2026-06-03T20:51:51-04:00",
+        "subject": "refactor(direct-control): prune map read facade callthroughs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-tactical-progression-read-callthroughs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-map-read-facade-callthroughs",
+      "children": [
+        "codex/prune-ready-read-callthroughs"
+      ],
+      "depth": 265,
+      "head": "551ec7d7528b95d9efafffed946c99448782ea13",
+      "parentRecordedHead": "ed702505d8ea05d9ebfdf3a75e66f1afc9b2ba5c",
+      "parentCurrentHead": "ed702505d8ea05d9ebfdf3a75e66f1afc9b2ba5c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "551ec7d75",
+        "sha": "551ec7d7528b95d9efafffed946c99448782ea13",
+        "iso": "2026-06-03T20:56:38-04:00",
+        "subject": "refactor(direct-control): prune tactical read facade callthroughs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-ready-read-callthroughs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-tactical-progression-read-callthroughs",
+      "children": [
+        "codex/prune-notification-view-callthrough"
+      ],
+      "depth": 266,
+      "head": "5d5bac5f92de95d20fc8a3055b4be3f2353bb7b4",
+      "parentRecordedHead": "551ec7d7528b95d9efafffed946c99448782ea13",
+      "parentCurrentHead": "551ec7d7528b95d9efafffed946c99448782ea13",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5d5bac5f9",
+        "sha": "5d5bac5f92de95d20fc8a3055b4be3f2353bb7b4",
+        "iso": "2026-06-03T21:00:13-04:00",
+        "subject": "refactor(direct-control): prune ready read facade callthroughs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-notification-view-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-ready-read-callthroughs",
+      "children": [
+        "codex/prune-capability-catalog-callthrough"
+      ],
+      "depth": 267,
+      "head": "2b3bb05436e6048370c08160aba522272003b65d",
+      "parentRecordedHead": "5d5bac5f92de95d20fc8a3055b4be3f2353bb7b4",
+      "parentCurrentHead": "5d5bac5f92de95d20fc8a3055b4be3f2353bb7b4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2b3bb0543",
+        "sha": "2b3bb05436e6048370c08160aba522272003b65d",
+        "iso": "2026-06-03T21:03:39-04:00",
+        "subject": "refactor(direct-control): prune notification view callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-capability-catalog-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-notification-view-callthrough",
+      "children": [
+        "codex/prune-visibility-read-callthrough"
+      ],
+      "depth": 268,
+      "head": "8d6a289d973f8344d5ddead43d4e7515973da38d",
+      "parentRecordedHead": "2b3bb05436e6048370c08160aba522272003b65d",
+      "parentCurrentHead": "2b3bb05436e6048370c08160aba522272003b65d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8d6a289d9",
+        "sha": "8d6a289d973f8344d5ddead43d4e7515973da38d",
+        "iso": "2026-06-03T21:10:22-04:00",
+        "subject": "refactor(direct-control): prune capability catalog callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-visibility-read-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-capability-catalog-callthrough",
+      "children": [
+        "codex/prune-setup-read-callthroughs"
+      ],
+      "depth": 269,
+      "head": "f0f4db8d1cb92db03d2d4ef07cd823e87840e553",
+      "parentRecordedHead": "8d6a289d973f8344d5ddead43d4e7515973da38d",
+      "parentCurrentHead": "8d6a289d973f8344d5ddead43d4e7515973da38d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f0f4db8d1",
+        "sha": "f0f4db8d1cb92db03d2d4ef07cd823e87840e553",
+        "iso": "2026-06-03T21:13:49-04:00",
+        "subject": "refactor(direct-control): prune visibility read callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-setup-read-callthroughs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-visibility-read-callthrough",
+      "children": [
+        "codex/prune-autoplay-status-callthrough"
+      ],
+      "depth": 270,
+      "head": "ad41308cd1d4fd6ca8d16bbe4866fe180970cc70",
+      "parentRecordedHead": "f0f4db8d1cb92db03d2d4ef07cd823e87840e553",
+      "parentCurrentHead": "f0f4db8d1cb92db03d2d4ef07cd823e87840e553",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ad41308cd",
+        "sha": "ad41308cd1d4fd6ca8d16bbe4866fe180970cc70",
+        "iso": "2026-06-03T21:17:55-04:00",
+        "subject": "refactor(direct-control): prune setup read callthroughs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-autoplay-status-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-setup-read-callthroughs",
+      "children": [
+        "codex/prune-turn-completion-status-callthrough"
+      ],
+      "depth": 271,
+      "head": "da711d04880c52216dbaec32830c63a6a8e89763",
+      "parentRecordedHead": "ad41308cd1d4fd6ca8d16bbe4866fe180970cc70",
+      "parentCurrentHead": "ad41308cd1d4fd6ca8d16bbe4866fe180970cc70",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "da711d048",
+        "sha": "da711d04880c52216dbaec32830c63a6a8e89763",
+        "iso": "2026-06-03T21:23:41-04:00",
+        "subject": "refactor(direct-control): prune autoplay status callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-turn-completion-status-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-autoplay-status-callthrough",
+      "children": [
+        "codex/prune-notification-dismissal-read-callthrough"
+      ],
+      "depth": 272,
+      "head": "0fb96ed9f437cb2ef5893f93396fa2bfe4660a7a",
+      "parentRecordedHead": "da711d04880c52216dbaec32830c63a6a8e89763",
+      "parentCurrentHead": "da711d04880c52216dbaec32830c63a6a8e89763",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0fb96ed9f",
+        "sha": "0fb96ed9f437cb2ef5893f93396fa2bfe4660a7a",
+        "iso": "2026-06-03T21:27:56-04:00",
+        "subject": "refactor(direct-control): prune turn completion status callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-notification-dismissal-read-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-turn-completion-status-callthrough",
+      "children": [
+        "codex/prune-unit-target-plan-callthrough"
+      ],
+      "depth": 273,
+      "head": "1d37036bbc69c3021deaa0a72cb705d681ee440a",
+      "parentRecordedHead": "0fb96ed9f437cb2ef5893f93396fa2bfe4660a7a",
+      "parentCurrentHead": "0fb96ed9f437cb2ef5893f93396fa2bfe4660a7a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1d37036bb",
+        "sha": "1d37036bbc69c3021deaa0a72cb705d681ee440a",
+        "iso": "2026-06-03T21:31:54-04:00",
+        "subject": "refactor(direct-control): prune notification dismissal read callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-unit-target-plan-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-notification-dismissal-read-callthrough",
+      "children": [
+        "codex/prune-operation-validation-callthroughs"
+      ],
+      "depth": 274,
+      "head": "e32b10fb1dbef2ca924c590b56bf2b146c3189fa",
+      "parentRecordedHead": "1d37036bbc69c3021deaa0a72cb705d681ee440a",
+      "parentCurrentHead": "1d37036bbc69c3021deaa0a72cb705d681ee440a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e32b10fb1",
+        "sha": "e32b10fb1dbef2ca924c590b56bf2b146c3189fa",
+        "iso": "2026-06-03T21:36:04-04:00",
+        "subject": "refactor(direct-control): prune unit target plan callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-operation-validation-callthroughs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-unit-target-plan-callthrough",
+      "children": [
+        "codex/prune-autoplay-action-callthroughs"
+      ],
+      "depth": 275,
+      "head": "ca71c1e4d67ec257b2caff8a013a4a5e9ca44b24",
+      "parentRecordedHead": "e32b10fb1dbef2ca924c590b56bf2b146c3189fa",
+      "parentCurrentHead": "e32b10fb1dbef2ca924c590b56bf2b146c3189fa",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ca71c1e4d",
+        "sha": "ca71c1e4d67ec257b2caff8a013a4a5e9ca44b24",
+        "iso": "2026-06-03T21:43:47-04:00",
+        "subject": "refactor(direct-control): prune operation validation callthroughs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-autoplay-action-callthroughs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-operation-validation-callthroughs",
+      "children": [
+        "codex/prune-turn-completion-action-callthroughs"
+      ],
+      "depth": 276,
+      "head": "ab3103cb4da608fd9719e8e53d239ec0062f4c24",
+      "parentRecordedHead": "ca71c1e4d67ec257b2caff8a013a4a5e9ca44b24",
+      "parentCurrentHead": "ca71c1e4d67ec257b2caff8a013a4a5e9ca44b24",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ab3103cb4",
+        "sha": "ab3103cb4da608fd9719e8e53d239ec0062f4c24",
+        "iso": "2026-06-03T21:48:21-04:00",
+        "subject": "refactor(direct-control): prune autoplay action callthroughs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-turn-completion-action-callthroughs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-autoplay-action-callthroughs",
+      "children": [
+        "codex/prune-notification-dismissal-request-callthrough"
+      ],
+      "depth": 277,
+      "head": "b5c1c52e4f3341cb832f2e0129234ecd47136779",
+      "parentRecordedHead": "ab3103cb4da608fd9719e8e53d239ec0062f4c24",
+      "parentCurrentHead": "ab3103cb4da608fd9719e8e53d239ec0062f4c24",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b5c1c52e4",
+        "sha": "b5c1c52e4f3341cb832f2e0129234ecd47136779",
+        "iso": "2026-06-03T21:52:20-04:00",
+        "subject": "refactor(direct-control): prune turn completion action callthroughs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-notification-dismissal-request-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-turn-completion-action-callthroughs",
+      "children": [
+        "codex/prune-reveal-map-callthrough"
+      ],
+      "depth": 278,
+      "head": "5f2416398b45ff77424e4cecb26baa34eef423aa",
+      "parentRecordedHead": "b5c1c52e4f3341cb832f2e0129234ecd47136779",
+      "parentCurrentHead": "b5c1c52e4f3341cb832f2e0129234ecd47136779",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5f2416398",
+        "sha": "5f2416398b45ff77424e4cecb26baa34eef423aa",
+        "iso": "2026-06-03T21:57:28-04:00",
+        "subject": "refactor(direct-control): prune notification dismissal request callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-reveal-map-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-notification-dismissal-request-callthrough",
+      "children": [
+        "codex/prune-operation-request-callthroughs"
+      ],
+      "depth": 279,
+      "head": "e22005f4d53ec526ff34db5c3f9cd5269520132d",
+      "parentRecordedHead": "5f2416398b45ff77424e4cecb26baa34eef423aa",
+      "parentCurrentHead": "5f2416398b45ff77424e4cecb26baa34eef423aa",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e22005f4d",
+        "sha": "e22005f4d53ec526ff34db5c3f9cd5269520132d",
+        "iso": "2026-06-03T22:03:57-04:00",
+        "subject": "refactor(direct-control): prune reveal map callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-operation-request-callthroughs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-reveal-map-callthrough",
+      "children": [
+        "codex/prune-production-choice-callthrough"
+      ],
+      "depth": 280,
+      "head": "4ed23c1115e2472ac8c21fae55a1f2c69d40921d",
+      "parentRecordedHead": "e22005f4d53ec526ff34db5c3f9cd5269520132d",
+      "parentCurrentHead": "e22005f4d53ec526ff34db5c3f9cd5269520132d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4ed23c111",
+        "sha": "4ed23c1115e2472ac8c21fae55a1f2c69d40921d",
+        "iso": "2026-06-03T22:08:55-04:00",
+        "subject": "refactor(direct-control): prune operation request callthroughs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-production-choice-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-operation-request-callthroughs",
+      "children": [
+        "codex/prune-progression-closeout-callthroughs"
+      ],
+      "depth": 281,
+      "head": "1b02da249f55e4fbedad1d3a6aab7db027a2521d",
+      "parentRecordedHead": "4ed23c1115e2472ac8c21fae55a1f2c69d40921d",
+      "parentCurrentHead": "4ed23c1115e2472ac8c21fae55a1f2c69d40921d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1b02da249",
+        "sha": "1b02da249f55e4fbedad1d3a6aab7db027a2521d",
+        "iso": "2026-06-03T22:11:42-04:00",
+        "subject": "refactor(direct-control): prune production choice callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-progression-closeout-callthroughs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-production-choice-callthrough",
+      "children": [
+        "codex/prune-diplomacy-narrative-callthroughs"
+      ],
+      "depth": 282,
+      "head": "adc053b1fee851127ff7c6a4c0b70a5680fb440c",
+      "parentRecordedHead": "1b02da249f55e4fbedad1d3a6aab7db027a2521d",
+      "parentCurrentHead": "1b02da249f55e4fbedad1d3a6aab7db027a2521d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "adc053b1f",
+        "sha": "adc053b1fee851127ff7c6a4c0b70a5680fb440c",
+        "iso": "2026-06-03T22:15:22-04:00",
+        "subject": "refactor(direct-control): prune progression closeout callthroughs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-diplomacy-narrative-callthroughs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-progression-closeout-callthroughs",
+      "children": [
+        "codex/prune-unit-target-request-callthrough"
+      ],
+      "depth": 283,
+      "head": "fd7b6430d42a9fca8a9aee70f83501daf85aa3b1",
+      "parentRecordedHead": "adc053b1fee851127ff7c6a4c0b70a5680fb440c",
+      "parentCurrentHead": "adc053b1fee851127ff7c6a4c0b70a5680fb440c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fd7b6430d",
+        "sha": "fd7b6430d42a9fca8a9aee70f83501daf85aa3b1",
+        "iso": "2026-06-03T22:18:20-04:00",
+        "subject": "refactor(direct-control): prune diplomacy narrative callthroughs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-unit-target-request-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-diplomacy-narrative-callthroughs",
+      "children": [
+        "codex/prune-restart-lifecycle-callthroughs"
+      ],
+      "depth": 284,
+      "head": "b4c1b0957f4b30240235b10b1b8c41f8d827f7bb",
+      "parentRecordedHead": "fd7b6430d42a9fca8a9aee70f83501daf85aa3b1",
+      "parentCurrentHead": "fd7b6430d42a9fca8a9aee70f83501daf85aa3b1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b4c1b0957",
+        "sha": "b4c1b0957f4b30240235b10b1b8c41f8d827f7bb",
+        "iso": "2026-06-03T22:24:44-04:00",
+        "subject": "refactor(direct-control): prune unit target request callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-restart-lifecycle-callthroughs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-unit-target-request-callthrough",
+      "children": [
+        "codex/prune-setup-map-row-visibility-callthrough"
+      ],
+      "depth": 285,
+      "head": "0f3390d370140dd3483dcc42131d58ddc7e30cda",
+      "parentRecordedHead": "b4c1b0957f4b30240235b10b1b8c41f8d827f7bb",
+      "parentCurrentHead": "b4c1b0957f4b30240235b10b1b8c41f8d827f7bb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0f3390d37",
+        "sha": "0f3390d370140dd3483dcc42131d58ddc7e30cda",
+        "iso": "2026-06-03T22:29:28-04:00",
+        "subject": "refactor(direct-control): prune restart lifecycle callthroughs"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-setup-map-row-visibility-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-restart-lifecycle-callthroughs",
+      "children": [
+        "codex/prune-setup-prepare-callthrough"
+      ],
+      "depth": 286,
+      "head": "f37bd59d5cef00009bf6d457149cdc0e9d61e711",
+      "parentRecordedHead": "0f3390d370140dd3483dcc42131d58ddc7e30cda",
+      "parentCurrentHead": "0f3390d370140dd3483dcc42131d58ddc7e30cda",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f37bd59d5",
+        "sha": "f37bd59d5cef00009bf6d457149cdc0e9d61e711",
+        "iso": "2026-06-03T22:33:24-04:00",
+        "subject": "refactor(direct-control): prune setup map row callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-setup-prepare-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-setup-map-row-visibility-callthrough",
+      "children": [
+        "codex/prune-setup-start-callthrough"
+      ],
+      "depth": 287,
+      "head": "f9556fca8ddb462dbbcc11ffa6fc338581d70ab4",
+      "parentRecordedHead": "f37bd59d5cef00009bf6d457149cdc0e9d61e711",
+      "parentCurrentHead": "f37bd59d5cef00009bf6d457149cdc0e9d61e711",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f9556fca8",
+        "sha": "f9556fca8ddb462dbbcc11ffa6fc338581d70ab4",
+        "iso": "2026-06-03T22:38:17-04:00",
+        "subject": "refactor(direct-control): prune setup prepare callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-setup-start-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-setup-prepare-callthrough",
+      "children": [
+        "codex/prune-setup-run-callthrough"
+      ],
+      "depth": 288,
+      "head": "da72580b30bc0c433493b6fe8368615dc3f1fe31",
+      "parentRecordedHead": "f9556fca8ddb462dbbcc11ffa6fc338581d70ab4",
+      "parentCurrentHead": "f9556fca8ddb462dbbcc11ffa6fc338581d70ab4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "da72580b3",
+        "sha": "da72580b30bc0c433493b6fe8368615dc3f1fe31",
+        "iso": "2026-06-03T22:42:39-04:00",
+        "subject": "refactor(direct-control): prune setup start callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-setup-run-callthrough",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-setup-start-callthrough",
+      "children": [
+        "codex/normalize-unit-move-preview-command-sources"
+      ],
+      "depth": 289,
+      "head": "e91fcbb44110d795a34f292f74069527dac14699",
+      "parentRecordedHead": "da72580b30bc0c433493b6fe8368615dc3f1fe31",
+      "parentCurrentHead": "da72580b30bc0c433493b6fe8368615dc3f1fe31",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e91fcbb44",
+        "sha": "e91fcbb44110d795a34f292f74069527dac14699",
+        "iso": "2026-06-03T22:45:47-04:00",
+        "subject": "refactor(direct-control): prune setup run callthrough"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-unit-move-preview-command-sources",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-setup-run-callthrough",
+      "children": [
+        "codex/normalize-ready-read-command-sources"
+      ],
+      "depth": 290,
+      "head": "2f214e900e63461639b48009e043a25f70726204",
+      "parentRecordedHead": "e91fcbb44110d795a34f292f74069527dac14699",
+      "parentCurrentHead": "e91fcbb44110d795a34f292f74069527dac14699",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2f214e900",
+        "sha": "2f214e900e63461639b48009e043a25f70726204",
+        "iso": "2026-06-03T22:50:36-04:00",
+        "subject": "refactor(direct-control): normalize move preview command sources"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-ready-read-command-sources",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-unit-move-preview-command-sources",
+      "children": [
+        "codex/normalize-tactical-read-command-sources"
+      ],
+      "depth": 291,
+      "head": "f3e70a6a716f4bf9b02c5f5500e576ae8fa6a64a",
+      "parentRecordedHead": "2f214e900e63461639b48009e043a25f70726204",
+      "parentCurrentHead": "2f214e900e63461639b48009e043a25f70726204",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f3e70a6a7",
+        "sha": "f3e70a6a716f4bf9b02c5f5500e576ae8fa6a64a",
+        "iso": "2026-06-03T22:55:31-04:00",
+        "subject": "refactor(direct-control): normalize ready read command sources"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-tactical-read-command-sources",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-ready-read-command-sources",
+      "children": [
+        "codex/normalize-progression-read-command-sources"
+      ],
+      "depth": 292,
+      "head": "28e54132e9aa167c260cbefc56116785a31ba6df",
+      "parentRecordedHead": "f3e70a6a716f4bf9b02c5f5500e576ae8fa6a64a",
+      "parentCurrentHead": "f3e70a6a716f4bf9b02c5f5500e576ae8fa6a64a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "28e54132e",
+        "sha": "28e54132e9aa167c260cbefc56116785a31ba6df",
+        "iso": "2026-06-03T22:59:47-04:00",
+        "subject": "refactor(direct-control): normalize tactical read command sources"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-progression-read-command-sources",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-tactical-read-command-sources",
+      "children": [
+        "codex/normalize-notification-view-command-source"
+      ],
+      "depth": 293,
+      "head": "84557394479439e380b7598ebe3d7ca8239148d2",
+      "parentRecordedHead": "28e54132e9aa167c260cbefc56116785a31ba6df",
+      "parentCurrentHead": "28e54132e9aa167c260cbefc56116785a31ba6df",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "845573944",
+        "sha": "84557394479439e380b7598ebe3d7ca8239148d2",
+        "iso": "2026-06-03T23:03:43-04:00",
+        "subject": "refactor(direct-control): normalize progression read command sources"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-notification-view-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-progression-read-command-sources",
+      "children": [
+        "codex/normalize-notification-dismissal-command-source"
+      ],
+      "depth": 294,
+      "head": "528439bbf5ee46b84b666851367ef5131fa7b14a",
+      "parentRecordedHead": "84557394479439e380b7598ebe3d7ca8239148d2",
+      "parentCurrentHead": "84557394479439e380b7598ebe3d7ca8239148d2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "528439bbf",
+        "sha": "528439bbf5ee46b84b666851367ef5131fa7b14a",
+        "iso": "2026-06-03T23:07:32-04:00",
+        "subject": "refactor(direct-control): normalize notification view command source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-notification-dismissal-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-notification-view-command-source",
+      "children": [
+        "codex/normalize-progression-closeout-command-sources"
+      ],
+      "depth": 295,
+      "head": "878a6d58a399ca8bd314798d77e8e0a755d163c6",
+      "parentRecordedHead": "528439bbf5ee46b84b666851367ef5131fa7b14a",
+      "parentCurrentHead": "528439bbf5ee46b84b666851367ef5131fa7b14a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "878a6d58a",
+        "sha": "878a6d58a399ca8bd314798d77e8e0a755d163c6",
+        "iso": "2026-06-03T23:12:38-04:00",
+        "subject": "refactor(direct-control): normalize notification dismissal command source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-progression-closeout-command-sources",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-notification-dismissal-command-source",
+      "children": [
+        "codex/normalize-turn-completion-command-source"
+      ],
+      "depth": 296,
+      "head": "3d6de29b06ed67e2612d65bdaba052f28088bcb7",
+      "parentRecordedHead": "878a6d58a399ca8bd314798d77e8e0a755d163c6",
+      "parentCurrentHead": "878a6d58a399ca8bd314798d77e8e0a755d163c6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3d6de29b0",
+        "sha": "3d6de29b06ed67e2612d65bdaba052f28088bcb7",
+        "iso": "2026-06-03T23:16:50-04:00",
+        "subject": "refactor(direct-control): normalize progression closeout command sources"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-turn-completion-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-progression-closeout-command-sources",
+      "children": [
+        "codex/normalize-operation-router-command-source"
+      ],
+      "depth": 297,
+      "head": "d311f93d54bf99ad8d2ff6a2189e8542240ca406",
+      "parentRecordedHead": "3d6de29b06ed67e2612d65bdaba052f28088bcb7",
+      "parentCurrentHead": "3d6de29b06ed67e2612d65bdaba052f28088bcb7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d311f93d5",
+        "sha": "d311f93d54bf99ad8d2ff6a2189e8542240ca406",
+        "iso": "2026-06-03T23:20:37-04:00",
+        "subject": "refactor(direct-control): normalize turn completion command source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-operation-router-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-turn-completion-command-source",
+      "children": [
+        "codex/normalize-production-choice-command-source"
+      ],
+      "depth": 298,
+      "head": "662f12e7d9dcd92fb288cb4c4409967e8bfb4ca7",
+      "parentRecordedHead": "d311f93d54bf99ad8d2ff6a2189e8542240ca406",
+      "parentCurrentHead": "d311f93d54bf99ad8d2ff6a2189e8542240ca406",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "662f12e7d",
+        "sha": "662f12e7d9dcd92fb288cb4c4409967e8bfb4ca7",
+        "iso": "2026-06-03T23:24:03-04:00",
+        "subject": "refactor(direct-control): normalize operation router command source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-production-choice-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-operation-router-command-source",
+      "children": [
+        "codex/normalize-diplomacy-narrative-command-sources"
+      ],
+      "depth": 299,
+      "head": "a57c90dbb1539a7c842891b4130060182a941be5",
+      "parentRecordedHead": "662f12e7d9dcd92fb288cb4c4409967e8bfb4ca7",
+      "parentCurrentHead": "662f12e7d9dcd92fb288cb4c4409967e8bfb4ca7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a57c90dbb",
+        "sha": "a57c90dbb1539a7c842891b4130060182a941be5",
+        "iso": "2026-06-03T23:27:44-04:00",
+        "subject": "refactor(direct-control): normalize production choice command source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-diplomacy-narrative-command-sources",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-production-choice-command-source",
+      "children": [
+        "codex/normalize-unit-target-command-source"
+      ],
+      "depth": 300,
+      "head": "d2a52b439ce8d7d36eb4353fd0af68776347af05",
+      "parentRecordedHead": "a57c90dbb1539a7c842891b4130060182a941be5",
+      "parentCurrentHead": "a57c90dbb1539a7c842891b4130060182a941be5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d2a52b439",
+        "sha": "d2a52b439ce8d7d36eb4353fd0af68776347af05",
+        "iso": "2026-06-03T23:33:25-04:00",
+        "subject": "refactor(direct-control): normalize diplomacy narrative command sources"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-unit-target-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-diplomacy-narrative-command-sources",
+      "children": [
+        "codex/normalize-runtime-status-command-sources"
+      ],
+      "depth": 301,
+      "head": "92e1f09d73915c0566f102f0a6f0f50443846217",
+      "parentRecordedHead": "d2a52b439ce8d7d36eb4353fd0af68776347af05",
+      "parentCurrentHead": "d2a52b439ce8d7d36eb4353fd0af68776347af05",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "92e1f09d7",
+        "sha": "92e1f09d73915c0566f102f0a6f0f50443846217",
+        "iso": "2026-06-03T23:37:15-04:00",
+        "subject": "refactor(direct-control): normalize unit target command source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-runtime-status-command-sources",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-unit-target-command-source",
+      "children": [
+        "codex/extract-operation-stable-json-helper"
+      ],
+      "depth": 302,
+      "head": "e78a9e4e005ee62ac4ab217f97eaa3728bce5d86",
+      "parentRecordedHead": "92e1f09d73915c0566f102f0a6f0f50443846217",
+      "parentCurrentHead": "92e1f09d73915c0566f102f0a6f0f50443846217",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e78a9e4e0",
+        "sha": "e78a9e4e005ee62ac4ab217f97eaa3728bce5d86",
+        "iso": "2026-06-03T23:40:32-04:00",
+        "subject": "refactor(direct-control): normalize runtime status command sources"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-operation-stable-json-helper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-runtime-status-command-sources",
+      "children": [
+        "codex/extract-operation-probe-helper"
+      ],
+      "depth": 303,
+      "head": "57c43309cc9eb247c60302e32f8fb4f590915ee9",
+      "parentRecordedHead": "e78a9e4e005ee62ac4ab217f97eaa3728bce5d86",
+      "parentCurrentHead": "e78a9e4e005ee62ac4ab217f97eaa3728bce5d86",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "57c43309c",
+        "sha": "57c43309cc9eb247c60302e32f8fb4f590915ee9",
+        "iso": "2026-06-03T23:48:30-04:00",
+        "subject": "refactor(direct-control): extract operation stable json helper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-operation-probe-helper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-operation-stable-json-helper",
+      "children": [
+        "codex/extract-operation-component-id-helper"
+      ],
+      "depth": 304,
+      "head": "3f212b1cd2f94f96315b9e07ef0db3ffaf5b8ff2",
+      "parentRecordedHead": "57c43309cc9eb247c60302e32f8fb4f590915ee9",
+      "parentCurrentHead": "57c43309cc9eb247c60302e32f8fb4f590915ee9",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3f212b1cd",
+        "sha": "3f212b1cd2f94f96315b9e07ef0db3ffaf5b8ff2",
+        "iso": "2026-06-03T23:53:42-04:00",
+        "subject": "refactor(direct-control): extract operation probe helper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-operation-component-id-helper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-operation-probe-helper",
+      "children": [
+        "codex/prune-autoplay-turn-status-type-imports"
+      ],
+      "depth": 305,
+      "head": "6a3f259168c95c1a81ff7f02cc2bdf8a344bb9ac",
+      "parentRecordedHead": "3f212b1cd2f94f96315b9e07ef0db3ffaf5b8ff2",
+      "parentCurrentHead": "3f212b1cd2f94f96315b9e07ef0db3ffaf5b8ff2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6a3f25916",
+        "sha": "6a3f259168c95c1a81ff7f02cc2bdf8a344bb9ac",
+        "iso": "2026-06-03T23:57:27-04:00",
+        "subject": "refactor(direct-control): extract operation component id helper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-autoplay-turn-status-type-imports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-operation-component-id-helper",
+      "children": [
+        "codex/record-direct-control-implementation-guard-audit"
+      ],
+      "depth": 306,
+      "head": "c17eef7a015d00ffa278a0b0e74f50b6257178bf",
+      "parentRecordedHead": "6a3f259168c95c1a81ff7f02cc2bdf8a344bb9ac",
+      "parentCurrentHead": "6a3f259168c95c1a81ff7f02cc2bdf8a344bb9ac",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c17eef7a0",
+        "sha": "c17eef7a015d00ffa278a0b0e74f50b6257178bf",
+        "iso": "2026-06-04T00:06:25-04:00",
+        "subject": "refactor(direct-control): prune autoplay turn status type imports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-direct-control-implementation-guard-audit",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-autoplay-turn-status-type-imports",
+      "children": [
+        "codex/define-semantic-cli-envelope-contract"
+      ],
+      "depth": 307,
+      "head": "edc740ff21f7c1632e1a03abaf8b21e39433b0df",
+      "parentRecordedHead": "c17eef7a015d00ffa278a0b0e74f50b6257178bf",
+      "parentCurrentHead": "c17eef7a015d00ffa278a0b0e74f50b6257178bf",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "edc740ff2",
+        "sha": "edc740ff21f7c1632e1a03abaf8b21e39433b0df",
+        "iso": "2026-06-04T00:10:50-04:00",
+        "subject": "docs(direct-control): record implementation guard audit"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/define-semantic-cli-envelope-contract",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-direct-control-implementation-guard-audit",
+      "children": [
+        "codex/define-debug-service-projection-contract"
+      ],
+      "depth": 308,
+      "head": "c70b46f4a9436d5b63b333950c2ece4265cfba2b",
+      "parentRecordedHead": "edc740ff21f7c1632e1a03abaf8b21e39433b0df",
+      "parentCurrentHead": "edc740ff21f7c1632e1a03abaf8b21e39433b0df",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c70b46f4a",
+        "sha": "c70b46f4a9436d5b63b333950c2ece4265cfba2b",
+        "iso": "2026-06-04T00:15:20-04:00",
+        "subject": "docs(direct-control): define semantic CLI envelope contract"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/define-debug-service-projection-contract",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/define-semantic-cli-envelope-contract",
+      "children": [
+        "codex/define-operation-proof-telemetry-contract"
+      ],
+      "depth": 309,
+      "head": "0d48f7d0603d343abcc8a9702bca4eb5c72eeb0d",
+      "parentRecordedHead": "c70b46f4a9436d5b63b333950c2ece4265cfba2b",
+      "parentCurrentHead": "c70b46f4a9436d5b63b333950c2ece4265cfba2b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0d48f7d06",
+        "sha": "0d48f7d0603d343abcc8a9702bca4eb5c72eeb0d",
+        "iso": "2026-06-04T00:17:58-04:00",
+        "subject": "docs(direct-control): define debug service projection contract"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/define-operation-proof-telemetry-contract",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/define-debug-service-projection-contract",
+      "children": [
+        "codex/define-ai-ingestion-contract"
+      ],
+      "depth": 310,
+      "head": "9e75ddbf017ba4628178745f7761b9b8caec0b8b",
+      "parentRecordedHead": "0d48f7d0603d343abcc8a9702bca4eb5c72eeb0d",
+      "parentCurrentHead": "0d48f7d0603d343abcc8a9702bca4eb5c72eeb0d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9e75ddbf0",
+        "sha": "9e75ddbf017ba4628178745f7761b9b8caec0b8b",
+        "iso": "2026-06-04T00:20:31-04:00",
+        "subject": "docs(direct-control): define operation proof telemetry contract"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/define-ai-ingestion-contract",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/define-operation-proof-telemetry-contract",
+      "children": [
+        "codex/define-hotseat-handoff-contract"
+      ],
+      "depth": 311,
+      "head": "2b7b4088e1838ee4d90eea3d1f437381fb82a854",
+      "parentRecordedHead": "9e75ddbf017ba4628178745f7761b9b8caec0b8b",
+      "parentCurrentHead": "9e75ddbf017ba4628178745f7761b9b8caec0b8b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2b7b4088e",
+        "sha": "2b7b4088e1838ee4d90eea3d1f437381fb82a854",
+        "iso": "2026-06-04T00:23:32-04:00",
+        "subject": "docs(direct-control): define AI ingestion contract"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/define-hotseat-handoff-contract",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/define-ai-ingestion-contract",
+      "children": [
+        "codex/define-procedure-core-contract"
+      ],
+      "depth": 312,
+      "head": "c49aa84b74e2f976ff620c5b5d53dbbd0227ca22",
+      "parentRecordedHead": "2b7b4088e1838ee4d90eea3d1f437381fb82a854",
+      "parentCurrentHead": "2b7b4088e1838ee4d90eea3d1f437381fb82a854",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c49aa84b7",
+        "sha": "c49aa84b74e2f976ff620c5b5d53dbbd0227ca22",
+        "iso": "2026-06-04T00:25:57-04:00",
+        "subject": "docs(direct-control): define hotseat handoff contract"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/define-procedure-core-contract",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/define-hotseat-handoff-contract",
+      "children": [
+        "codex/align-procedure-schema-blocker-record"
+      ],
+      "depth": 313,
+      "head": "f5f9b42e7600cfc8a1a598f5239f5862065cc975",
+      "parentRecordedHead": "c49aa84b74e2f976ff620c5b5d53dbbd0227ca22",
+      "parentCurrentHead": "c49aa84b74e2f976ff620c5b5d53dbbd0227ca22",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f5f9b42e7",
+        "sha": "f5f9b42e7600cfc8a1a598f5239f5862065cc975",
+        "iso": "2026-06-04T00:28:45-04:00",
+        "subject": "docs(direct-control): define procedure core contract"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/align-procedure-schema-blocker-record",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/define-procedure-core-contract",
+      "children": [
+        "codex/record-compatibility-contract-artifact-status"
+      ],
+      "depth": 314,
+      "head": "8c00860b38a6cfa400c87a5fff44da31108e639d",
+      "parentRecordedHead": "f5f9b42e7600cfc8a1a598f5239f5862065cc975",
+      "parentCurrentHead": "f5f9b42e7600cfc8a1a598f5239f5862065cc975",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8c00860b3",
+        "sha": "8c00860b38a6cfa400c87a5fff44da31108e639d",
+        "iso": "2026-06-04T00:30:49-04:00",
+        "subject": "docs(direct-control): align procedure schema blocker record"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-compatibility-contract-artifact-status",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/align-procedure-schema-blocker-record",
+      "children": [
+        "codex/align-stale-facade-dependency-records"
+      ],
+      "depth": 315,
+      "head": "70d4f7615437f4aaeb3507e5450012ba2cb31c01",
+      "parentRecordedHead": "8c00860b38a6cfa400c87a5fff44da31108e639d",
+      "parentCurrentHead": "8c00860b38a6cfa400c87a5fff44da31108e639d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "70d4f7615",
+        "sha": "70d4f7615437f4aaeb3507e5450012ba2cb31c01",
+        "iso": "2026-06-04T00:32:50-04:00",
+        "subject": "docs(direct-control): record compatibility contract artifact status"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/align-stale-facade-dependency-records",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-compatibility-contract-artifact-status",
+      "children": [
+        "codex/add-priorities-debug-separation-proof"
+      ],
+      "depth": 316,
+      "head": "f583f5ae076dcb60b029c61b76d7b53a27d129fa",
+      "parentRecordedHead": "70d4f7615437f4aaeb3507e5450012ba2cb31c01",
+      "parentCurrentHead": "70d4f7615437f4aaeb3507e5450012ba2cb31c01",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f583f5ae0",
+        "sha": "f583f5ae076dcb60b029c61b76d7b53a27d129fa",
+        "iso": "2026-06-04T00:39:00-04:00",
+        "subject": "docs(direct-control): align stale facade dependency records"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-priorities-debug-separation-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/align-stale-facade-dependency-records",
+      "children": [
+        "codex/add-inspect-debug-projection-proof"
+      ],
+      "depth": 317,
+      "head": "5c03a7f3c538abb74d02f3000f3ac4f63b28d906",
+      "parentRecordedHead": "f583f5ae076dcb60b029c61b76d7b53a27d129fa",
+      "parentCurrentHead": "f583f5ae076dcb60b029c61b76d7b53a27d129fa",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5c03a7f3c",
+        "sha": "5c03a7f3c538abb74d02f3000f3ac4f63b28d906",
+        "iso": "2026-06-04T00:44:27-04:00",
+        "subject": "test(cli): prove compact priorities omit debug internals"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-inspect-debug-projection-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-priorities-debug-separation-proof",
+      "children": [
+        "codex/add-watch-normal-output-boundary-proof"
+      ],
+      "depth": 318,
+      "head": "2ea6d269f0effea8dc01e29ec9a8569e34db510e",
+      "parentRecordedHead": "5c03a7f3c538abb74d02f3000f3ac4f63b28d906",
+      "parentCurrentHead": "5c03a7f3c538abb74d02f3000f3ac4f63b28d906",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2ea6d269f",
+        "sha": "2ea6d269f0effea8dc01e29ec9a8569e34db510e",
+        "iso": "2026-06-04T00:50:25-04:00",
+        "subject": "test(cli): prove inspect emits debug projection"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-watch-normal-output-boundary-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-inspect-debug-projection-proof",
+      "children": [
+        "codex/add-health-debug-projection-proof"
+      ],
+      "depth": 319,
+      "head": "29a5c1abe51c9880ca0721989e0eccd284f96cd7",
+      "parentRecordedHead": "2ea6d269f0effea8dc01e29ec9a8569e34db510e",
+      "parentCurrentHead": "2ea6d269f0effea8dc01e29ec9a8569e34db510e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "29a5c1abe",
+        "sha": "29a5c1abe51c9880ca0721989e0eccd284f96cd7",
+        "iso": "2026-06-04T00:54:26-04:00",
+        "subject": "test(cli): prove ready-city omits debug internals"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-health-debug-projection-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-watch-normal-output-boundary-proof",
+      "children": [
+        "codex/add-status-debug-projection-proof"
+      ],
+      "depth": 320,
+      "head": "bf314b251dfa3c79a3e20a4d3a094914b163d85d",
+      "parentRecordedHead": "29a5c1abe51c9880ca0721989e0eccd284f96cd7",
+      "parentCurrentHead": "29a5c1abe51c9880ca0721989e0eccd284f96cd7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bf314b251",
+        "sha": "bf314b251dfa3c79a3e20a4d3a094914b163d85d",
+        "iso": "2026-06-04T00:57:06-04:00",
+        "subject": "test(cli): prove health emits debug projection"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-status-debug-projection-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-health-debug-projection-proof",
+      "children": [
+        "codex/add-app-ui-snapshot-debug-proof"
+      ],
+      "depth": 321,
+      "head": "fabff2e4b2130afdd1e49b5cabc48bebbe3487de",
+      "parentRecordedHead": "bf314b251dfa3c79a3e20a4d3a094914b163d85d",
+      "parentCurrentHead": "bf314b251dfa3c79a3e20a4d3a094914b163d85d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fabff2e4b",
+        "sha": "fabff2e4b2130afdd1e49b5cabc48bebbe3487de",
+        "iso": "2026-06-04T01:02:17-04:00",
+        "subject": "test(cli): prove status emits debug projection"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-app-ui-snapshot-debug-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-status-debug-projection-proof",
+      "children": [
+        "codex/add-catalog-debug-projection-proof"
+      ],
+      "depth": 322,
+      "head": "5bd5a32cab9d3cf05051eb871fb99a8eac3e1664",
+      "parentRecordedHead": "fabff2e4b2130afdd1e49b5cabc48bebbe3487de",
+      "parentCurrentHead": "fabff2e4b2130afdd1e49b5cabc48bebbe3487de",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5bd5a32ca",
+        "sha": "5bd5a32cab9d3cf05051eb871fb99a8eac3e1664",
+        "iso": "2026-06-04T01:06:12-04:00",
+        "subject": "test(cli): prove App UI snapshot debug projection"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-catalog-debug-projection-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-app-ui-snapshot-debug-proof",
+      "children": [
+        "codex/add-exec-debug-projection-proof"
+      ],
+      "depth": 323,
+      "head": "df2429e4fb789ca2fd4738d0ec0020c462dbb237",
+      "parentRecordedHead": "5bd5a32cab9d3cf05051eb871fb99a8eac3e1664",
+      "parentCurrentHead": "5bd5a32cab9d3cf05051eb871fb99a8eac3e1664",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "df2429e4f",
+        "sha": "df2429e4fb789ca2fd4738d0ec0020c462dbb237",
+        "iso": "2026-06-04T01:10:01-04:00",
+        "subject": "test(cli): prove catalog emits debug projection"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-exec-debug-projection-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-catalog-debug-projection-proof",
+      "children": [
+        "codex/add-visibility-debug-projection-proof"
+      ],
+      "depth": 324,
+      "head": "6edf51c2e1f63a899823ac3399c82f7d307087d2",
+      "parentRecordedHead": "df2429e4fb789ca2fd4738d0ec0020c462dbb237",
+      "parentCurrentHead": "df2429e4fb789ca2fd4738d0ec0020c462dbb237",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6edf51c2e",
+        "sha": "6edf51c2e1f63a899823ac3399c82f7d307087d2",
+        "iso": "2026-06-04T01:15:29-04:00",
+        "subject": "test(cli): prove exec dry-run debug projection"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-visibility-debug-projection-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-exec-debug-projection-proof",
+      "children": [
+        "codex/add-restart-dry-run-debug-proof"
+      ],
+      "depth": 325,
+      "head": "944446c50a514ee698ed3358df79dc3f2354174c",
+      "parentRecordedHead": "6edf51c2e1f63a899823ac3399c82f7d307087d2",
+      "parentCurrentHead": "6edf51c2e1f63a899823ac3399c82f7d307087d2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "944446c50",
+        "sha": "944446c50a514ee698ed3358df79dc3f2354174c",
+        "iso": "2026-06-04T01:19:33-04:00",
+        "subject": "test(cli): prove visibility emits debug projection"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-restart-dry-run-debug-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-visibility-debug-projection-proof",
+      "children": [
+        "codex/add-unit-move-compact-boundary-proof"
+      ],
+      "depth": 326,
+      "head": "cc51a81e725f456066952298691a3451e55be237",
+      "parentRecordedHead": "944446c50a514ee698ed3358df79dc3f2354174c",
+      "parentCurrentHead": "944446c50a514ee698ed3358df79dc3f2354174c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cc51a81e7",
+        "sha": "cc51a81e725f456066952298691a3451e55be237",
+        "iso": "2026-06-04T01:24:15-04:00",
+        "subject": "test(cli): prove restart dry-run debug projection"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-unit-move-compact-boundary-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-restart-dry-run-debug-proof",
+      "children": [
+        "codex/extract-normal-output-boundary-test-helper"
+      ],
+      "depth": 327,
+      "head": "0bbf471d2a5dd79b2f9f721fbcabd19a5f9a3736",
+      "parentRecordedHead": "cc51a81e725f456066952298691a3451e55be237",
+      "parentCurrentHead": "cc51a81e725f456066952298691a3451e55be237",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0bbf471d2",
+        "sha": "0bbf471d2a5dd79b2f9f721fbcabd19a5f9a3736",
+        "iso": "2026-06-04T01:30:08-04:00",
+        "subject": "test(cli): prove unit move compact boundary"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-normal-output-boundary-test-helper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-unit-move-compact-boundary-proof",
+      "children": [
+        "codex/align-map-atom-corpus-status"
+      ],
+      "depth": 328,
+      "head": "92824c090e69977baf194a5e9486b4c489b4c280",
+      "parentRecordedHead": "0bbf471d2a5dd79b2f9f721fbcabd19a5f9a3736",
+      "parentCurrentHead": "0bbf471d2a5dd79b2f9f721fbcabd19a5f9a3736",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "92824c090",
+        "sha": "92824c090e69977baf194a5e9486b4c489b4c280",
+        "iso": "2026-06-04T01:34:32-04:00",
+        "subject": "test(cli): extract normal output boundary helper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/align-map-atom-corpus-status",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-normal-output-boundary-test-helper",
+      "children": [
+        "codex/align-map-task-status"
+      ],
+      "depth": 329,
+      "head": "ee7db0ca048458849ff4af310e96f9da517d1afc",
+      "parentRecordedHead": "92824c090e69977baf194a5e9486b4c489b4c280",
+      "parentCurrentHead": "92824c090e69977baf194a5e9486b4c489b4c280",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ee7db0ca0",
+        "sha": "ee7db0ca048458849ff4af310e96f9da517d1afc",
+        "iso": "2026-06-04T01:38:25-04:00",
+        "subject": "docs(openspec): align map atom corpus status"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/align-map-task-status",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/align-map-atom-corpus-status",
+      "children": [
+        "codex/align-runtime-task-status"
+      ],
+      "depth": 330,
+      "head": "fd79ef2fb2ce98071d7725a87a664adf687c4b39",
+      "parentRecordedHead": "ee7db0ca048458849ff4af310e96f9da517d1afc",
+      "parentCurrentHead": "ee7db0ca048458849ff4af310e96f9da517d1afc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fd79ef2fb",
+        "sha": "fd79ef2fb2ce98071d7725a87a664adf687c4b39",
+        "iso": "2026-06-04T01:42:21-04:00",
+        "subject": "docs(openspec): align map task status"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/align-runtime-task-status",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/align-map-task-status",
+      "children": [
+        "codex/add-ready-unit-normal-output-proof"
+      ],
+      "depth": 331,
+      "head": "f3b7dc3beaf059fb3b921378510882dd0e31a8a7",
+      "parentRecordedHead": "fd79ef2fb2ce98071d7725a87a664adf687c4b39",
+      "parentCurrentHead": "fd79ef2fb2ce98071d7725a87a664adf687c4b39",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f3b7dc3be",
+        "sha": "f3b7dc3beaf059fb3b921378510882dd0e31a8a7",
+        "iso": "2026-06-04T01:45:43-04:00",
+        "subject": "docs(openspec): align runtime task status"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-ready-unit-normal-output-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/align-runtime-task-status",
+      "children": [
+        "codex/add-game-watch-normal-output-proof"
+      ],
+      "depth": 332,
+      "head": "4a0c613e78a18f5070a94de3216d5f78855b36fc",
+      "parentRecordedHead": "f3b7dc3beaf059fb3b921378510882dd0e31a8a7",
+      "parentCurrentHead": "f3b7dc3beaf059fb3b921378510882dd0e31a8a7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4a0c613e7",
+        "sha": "4a0c613e78a18f5070a94de3216d5f78855b36fc",
+        "iso": "2026-06-04T01:51:39-04:00",
+        "subject": "test(cli): add ready-unit normal output proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-game-watch-normal-output-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-ready-unit-normal-output-proof",
+      "children": [
+        "codex/add-progression-normal-output-proof"
+      ],
+      "depth": 333,
+      "head": "f21d019baf7d72fd683aa6519221acd430a952f6",
+      "parentRecordedHead": "4a0c613e78a18f5070a94de3216d5f78855b36fc",
+      "parentCurrentHead": "4a0c613e78a18f5070a94de3216d5f78855b36fc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f21d019ba",
+        "sha": "f21d019baf7d72fd683aa6519221acd430a952f6",
+        "iso": "2026-06-04T01:55:19-04:00",
+        "subject": "test(cli): add watch normal output proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-progression-normal-output-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-game-watch-normal-output-proof",
+      "children": [
+        "codex/add-tactical-read-normal-output-proof"
+      ],
+      "depth": 334,
+      "head": "4747de7c6fa29fdc45a837e18c253c56574cdcf6",
+      "parentRecordedHead": "f21d019baf7d72fd683aa6519221acd430a952f6",
+      "parentCurrentHead": "f21d019baf7d72fd683aa6519221acd430a952f6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4747de7c6",
+        "sha": "4747de7c6fa29fdc45a837e18c253c56574cdcf6",
+        "iso": "2026-06-04T01:58:13-04:00",
+        "subject": "test(cli): add progression normal output proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-tactical-read-normal-output-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-progression-normal-output-proof",
+      "children": [
+        "codex/add-settlement-normal-output-proof"
+      ],
+      "depth": 335,
+      "head": "6c0145edcb78108419095a7ee628de6e09cb0794",
+      "parentRecordedHead": "4747de7c6fa29fdc45a837e18c253c56574cdcf6",
+      "parentCurrentHead": "4747de7c6fa29fdc45a837e18c253c56574cdcf6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6c0145edc",
+        "sha": "6c0145edcb78108419095a7ee628de6e09cb0794",
+        "iso": "2026-06-04T02:01:52-04:00",
+        "subject": "test(cli): add tactical read normal output proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-settlement-normal-output-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-tactical-read-normal-output-proof",
+      "children": [
+        "codex/add-promotion-readiness-normal-output-proof"
+      ],
+      "depth": 336,
+      "head": "0bd443a88b035b21f3be51fcbd737c72592bc4bb",
+      "parentRecordedHead": "6c0145edcb78108419095a7ee628de6e09cb0794",
+      "parentCurrentHead": "6c0145edcb78108419095a7ee628de6e09cb0794",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0bd443a88",
+        "sha": "0bd443a88b035b21f3be51fcbd737c72592bc4bb",
+        "iso": "2026-06-04T02:05:02-04:00",
+        "subject": "test(cli): add settlement normal output proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-promotion-readiness-normal-output-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-settlement-normal-output-proof",
+      "children": [
+        "codex/add-rehydrate-normal-output-proof"
+      ],
+      "depth": 337,
+      "head": "cb4371581c737e7be9477fda49794f16ddb0ea48",
+      "parentRecordedHead": "0bd443a88b035b21f3be51fcbd737c72592bc4bb",
+      "parentCurrentHead": "0bd443a88b035b21f3be51fcbd737c72592bc4bb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cb4371581",
+        "sha": "cb4371581c737e7be9477fda49794f16ddb0ea48",
+        "iso": "2026-06-04T02:10:30-04:00",
+        "subject": "test(cli): add promotion-readiness normal output proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-rehydrate-normal-output-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-promotion-readiness-normal-output-proof",
+      "children": [
+        "codex/add-notification-hud-normal-output-proof"
+      ],
+      "depth": 338,
+      "head": "0b8a7c8cf3769a10be6c1cabfd0067872258af9c",
+      "parentRecordedHead": "cb4371581c737e7be9477fda49794f16ddb0ea48",
+      "parentCurrentHead": "cb4371581c737e7be9477fda49794f16ddb0ea48",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0b8a7c8cf",
+        "sha": "0b8a7c8cf3769a10be6c1cabfd0067872258af9c",
+        "iso": "2026-06-04T02:12:37-04:00",
+        "subject": "test(cli): add rehydrate normal output proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-notification-hud-normal-output-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-rehydrate-normal-output-proof",
+      "children": [
+        "codex/add-notification-queue-normal-output-proof"
+      ],
+      "depth": 339,
+      "head": "798e03b81c2d374425bfdd6c64b948e36e574dc5",
+      "parentRecordedHead": "0b8a7c8cf3769a10be6c1cabfd0067872258af9c",
+      "parentCurrentHead": "0b8a7c8cf3769a10be6c1cabfd0067872258af9c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "798e03b81",
+        "sha": "798e03b81c2d374425bfdd6c64b948e36e574dc5",
+        "iso": "2026-06-04T02:15:14-04:00",
+        "subject": "test(cli): add notification HUD normal output proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-notification-queue-normal-output-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-notification-hud-normal-output-proof",
+      "children": [
+        "codex/add-technology-options-normal-output-proof"
+      ],
+      "depth": 340,
+      "head": "1ab45611ebf4148560c1033c904c7d4b0011eb76",
+      "parentRecordedHead": "798e03b81c2d374425bfdd6c64b948e36e574dc5",
+      "parentCurrentHead": "798e03b81c2d374425bfdd6c64b948e36e574dc5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1ab45611e",
+        "sha": "1ab45611ebf4148560c1033c904c7d4b0011eb76",
+        "iso": "2026-06-04T02:18:28-04:00",
+        "subject": "test(cli): add notification queue normal output proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-technology-options-normal-output-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-notification-queue-normal-output-proof",
+      "children": [
+        "codex/add-culture-options-normal-output-proof"
+      ],
+      "depth": 341,
+      "head": "43c186ea203b6d5cedaa5ed2b7c7886cd77b4cab",
+      "parentRecordedHead": "1ab45611ebf4148560c1033c904c7d4b0011eb76",
+      "parentCurrentHead": "1ab45611ebf4148560c1033c904c7d4b0011eb76",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "43c186ea2",
+        "sha": "43c186ea203b6d5cedaa5ed2b7c7886cd77b4cab",
+        "iso": "2026-06-04T03:27:40-04:00",
+        "subject": "test(cli): add technology options normal output proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-culture-options-normal-output-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-technology-options-normal-output-proof",
+      "children": [
+        "codex/add-celebration-government-normal-output-proof"
+      ],
+      "depth": 342,
+      "head": "292f11ab3c2e5790c167c9096eae078ffd5e41c4",
+      "parentRecordedHead": "43c186ea203b6d5cedaa5ed2b7c7886cd77b4cab",
+      "parentCurrentHead": "43c186ea203b6d5cedaa5ed2b7c7886cd77b4cab",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "292f11ab3",
+        "sha": "292f11ab3c2e5790c167c9096eae078ffd5e41c4",
+        "iso": "2026-06-04T03:32:49-04:00",
+        "subject": "test(cli): add culture options normal output proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-celebration-government-normal-output-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-culture-options-normal-output-proof",
+      "children": [
+        "codex/seed-semantic-cli-envelope-owner"
+      ],
+      "depth": 343,
+      "head": "b56ab7f511855c541f87aad0f5af64d40ab2eb8c",
+      "parentRecordedHead": "292f11ab3c2e5790c167c9096eae078ffd5e41c4",
+      "parentCurrentHead": "292f11ab3c2e5790c167c9096eae078ffd5e41c4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b56ab7f51",
+        "sha": "b56ab7f511855c541f87aad0f5af64d40ab2eb8c",
+        "iso": "2026-06-04T03:38:01-04:00",
+        "subject": "test(cli): add celebration government normal output proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/seed-semantic-cli-envelope-owner",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-celebration-government-normal-output-proof",
+      "children": [
+        "codex/add-priorities-semantic-envelope"
+      ],
+      "depth": 344,
+      "head": "2979a4349e0023fe566815163663dd585482093a",
+      "parentRecordedHead": "b56ab7f511855c541f87aad0f5af64d40ab2eb8c",
+      "parentCurrentHead": "b56ab7f511855c541f87aad0f5af64d40ab2eb8c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2979a4349",
+        "sha": "2979a4349e0023fe566815163663dd585482093a",
+        "iso": "2026-06-04T04:00:58-04:00",
+        "subject": "test(cli): seed semantic envelope owner proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-priorities-semantic-envelope",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/seed-semantic-cli-envelope-owner",
+      "children": [
+        "codex/seed-operation-telemetry-owner"
+      ],
+      "depth": 345,
+      "head": "2c6346667569a985288c7a773eaec0b82a35063d",
+      "parentRecordedHead": "2979a4349e0023fe566815163663dd585482093a",
+      "parentCurrentHead": "2979a4349e0023fe566815163663dd585482093a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2c6346667",
+        "sha": "2c6346667569a985288c7a773eaec0b82a35063d",
+        "iso": "2026-06-04T04:11:18-04:00",
+        "subject": "feat(cli): add priorities semantic envelope proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/seed-operation-telemetry-owner",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-priorities-semantic-envelope",
+      "children": [
+        "codex/seed-debug-projection-owner"
+      ],
+      "depth": 346,
+      "head": "865f014c3eb5e2866d12e8e7075cbf26e25b5e3d",
+      "parentRecordedHead": "2c6346667569a985288c7a773eaec0b82a35063d",
+      "parentCurrentHead": "2c6346667569a985288c7a773eaec0b82a35063d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "865f014c3",
+        "sha": "865f014c3eb5e2866d12e8e7075cbf26e25b5e3d",
+        "iso": "2026-06-04T04:31:40-04:00",
+        "subject": "test(direct-control): seed operation telemetry owner proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/seed-debug-projection-owner",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/seed-operation-telemetry-owner",
+      "children": [
+        "codex/add-unit-target-telemetry-adapter"
+      ],
+      "depth": 347,
+      "head": "0b6cf14c4cf18524a64b872db9ee8a3027687a8e",
+      "parentRecordedHead": "865f014c3eb5e2866d12e8e7075cbf26e25b5e3d",
+      "parentCurrentHead": "865f014c3eb5e2866d12e8e7075cbf26e25b5e3d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0b6cf14c4",
+        "sha": "0b6cf14c4cf18524a64b872db9ee8a3027687a8e",
+        "iso": "2026-06-04T04:43:37-04:00",
+        "subject": "test(cli): seed debug projection owner proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-unit-target-telemetry-adapter",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/seed-debug-projection-owner",
+      "children": [
+        "codex/add-production-telemetry-adapter"
+      ],
+      "depth": 348,
+      "head": "af9f139a26defd3857434e7494b993d2892a7517",
+      "parentRecordedHead": "0b6cf14c4cf18524a64b872db9ee8a3027687a8e",
+      "parentCurrentHead": "0b6cf14c4cf18524a64b872db9ee8a3027687a8e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "af9f139a2",
+        "sha": "af9f139a26defd3857434e7494b993d2892a7517",
+        "iso": "2026-06-04T04:56:09-04:00",
+        "subject": "test(direct-control): add unit-target telemetry adapter proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-production-telemetry-adapter",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-unit-target-telemetry-adapter",
+      "children": [
+        "codex/watcher-supervisor-handoff-doc",
+        "codex/guard-telemetry-proof-labels"
+      ],
+      "depth": 349,
+      "head": "af67a482e98a617de5d311288f873adc50708096",
+      "parentRecordedHead": "af9f139a26defd3857434e7494b993d2892a7517",
+      "parentCurrentHead": "af9f139a26defd3857434e7494b993d2892a7517",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "af67a482e",
+        "sha": "af67a482e98a617de5d311288f873adc50708096",
+        "iso": "2026-06-04T05:06:16-04:00",
+        "subject": "test(direct-control): add production telemetry adapter proof"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/watcher-supervisor-handoff-doc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-production-telemetry-adapter",
+      "children": [],
+      "depth": 350,
+      "head": "f09a7caccc70ce77034e57c4b3aa63a32718c00e",
+      "parentRecordedHead": "af67a482e98a617de5d311288f873adc50708096",
+      "parentCurrentHead": "af67a482e98a617de5d311288f873adc50708096",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f09a7cacc",
+        "sha": "f09a7caccc70ce77034e57c4b3aa63a32718c00e",
+        "iso": "2026-06-04T05:13:32-04:00",
+        "subject": "docs(openspec): add watcher supervisor handoff"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/guard-telemetry-proof-labels",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-production-telemetry-adapter",
+      "children": [
+        "codex/seed-procedure-core-owner"
+      ],
+      "depth": 350,
+      "head": "6c280fea86ba46596516d1537e73ba2bc3f404ab",
+      "parentRecordedHead": "af67a482e98a617de5d311288f873adc50708096",
+      "parentCurrentHead": "af67a482e98a617de5d311288f873adc50708096",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6c280fea8",
+        "sha": "6c280fea86ba46596516d1537e73ba2bc3f404ab",
+        "iso": "2026-06-04T05:13:12-04:00",
+        "subject": "test(direct-control): guard telemetry proof labels"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/seed-procedure-core-owner",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/guard-telemetry-proof-labels",
+      "children": [
+        "codex/validate-procedure-core-descriptor"
+      ],
+      "depth": 351,
+      "head": "2b3f6c386938c58afed2c9b83017037a38e7c432",
+      "parentRecordedHead": "6c280fea86ba46596516d1537e73ba2bc3f404ab",
+      "parentCurrentHead": "6c280fea86ba46596516d1537e73ba2bc3f404ab",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2b3f6c386",
+        "sha": "2b3f6c386938c58afed2c9b83017037a38e7c432",
+        "iso": "2026-06-04T05:29:21-04:00",
+        "subject": "test(direct-control): seed procedure core owner"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/validate-procedure-core-descriptor",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/seed-procedure-core-owner",
+      "children": [
+        "codex/type-procedure-core-errors"
+      ],
+      "depth": 352,
+      "head": "6e1442db3e243bdb8ea0075ee49c7b6e9d9d7225",
+      "parentRecordedHead": "2b3f6c386938c58afed2c9b83017037a38e7c432",
+      "parentCurrentHead": "2b3f6c386938c58afed2c9b83017037a38e7c432",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6e1442db3",
+        "sha": "6e1442db3e243bdb8ea0075ee49c7b6e9d9d7225",
+        "iso": "2026-06-04T05:38:49-04:00",
+        "subject": "test(direct-control): validate procedure descriptors"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/type-procedure-core-errors",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/validate-procedure-core-descriptor",
+      "children": [
+        "codex/add-procedure-correlation-policy"
+      ],
+      "depth": 353,
+      "head": "7b793860d2defd7f2b70e3e47787751d9de23e22",
+      "parentRecordedHead": "6e1442db3e243bdb8ea0075ee49c7b6e9d9d7225",
+      "parentCurrentHead": "6e1442db3e243bdb8ea0075ee49c7b6e9d9d7225",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7b793860d",
+        "sha": "7b793860d2defd7f2b70e3e47787751d9de23e22",
+        "iso": "2026-06-04T05:44:08-04:00",
+        "subject": "test(direct-control): type procedure descriptor errors"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-procedure-correlation-policy",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/type-procedure-core-errors",
+      "children": [
+        "codex/guard-procedure-runtime-proof-claims"
+      ],
+      "depth": 354,
+      "head": "c408667223a592b5c7b63c317cb766a7bc4c678f",
+      "parentRecordedHead": "7b793860d2defd7f2b70e3e47787751d9de23e22",
+      "parentCurrentHead": "7b793860d2defd7f2b70e3e47787751d9de23e22",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c40866722",
+        "sha": "c408667223a592b5c7b63c317cb766a7bc4c678f",
+        "iso": "2026-06-04T05:48:41-04:00",
+        "subject": "test(direct-control): add procedure correlation policy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/guard-procedure-runtime-proof-claims",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-procedure-correlation-policy",
+      "children": [
+        "codex/seed-ready-unit-procedure-schemas"
+      ],
+      "depth": 355,
+      "head": "01d830dd33b564fbb2e8c97de56a6f9aa6cadac0",
+      "parentRecordedHead": "c408667223a592b5c7b63c317cb766a7bc4c678f",
+      "parentCurrentHead": "c408667223a592b5c7b63c317cb766a7bc4c678f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "01d830dd3",
+        "sha": "01d830dd33b564fbb2e8c97de56a6f9aa6cadac0",
+        "iso": "2026-06-04T05:55:44-04:00",
+        "subject": "test(direct-control): guard procedure runtime proof claims"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/seed-ready-unit-procedure-schemas",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/guard-procedure-runtime-proof-claims",
+      "children": [
+        "codex/add-procedure-schema-references"
+      ],
+      "depth": 356,
+      "head": "348f5e05d1636b01fd57269150691ba3f947df80",
+      "parentRecordedHead": "01d830dd33b564fbb2e8c97de56a6f9aa6cadac0",
+      "parentCurrentHead": "01d830dd33b564fbb2e8c97de56a6f9aa6cadac0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "348f5e05d",
+        "sha": "348f5e05d1636b01fd57269150691ba3f947df80",
+        "iso": "2026-06-04T06:03:36-04:00",
+        "subject": "test(direct-control): seed ready-unit procedure schemas"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-procedure-schema-references",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/seed-ready-unit-procedure-schemas",
+      "children": [
+        "codex/resolve-procedure-schema-references"
+      ],
+      "depth": 357,
+      "head": "46ce0cae7e51f432a4eae873e9f3d8f33750c841",
+      "parentRecordedHead": "348f5e05d1636b01fd57269150691ba3f947df80",
+      "parentCurrentHead": "348f5e05d1636b01fd57269150691ba3f947df80",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "46ce0cae7",
+        "sha": "46ce0cae7e51f432a4eae873e9f3d8f33750c841",
+        "iso": "2026-06-04T06:11:32-04:00",
+        "subject": "test(direct-control): bind procedure schema references"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/resolve-procedure-schema-references",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-procedure-schema-references",
+      "children": [
+        "codex/add-ready-unit-procedure-descriptor"
+      ],
+      "depth": 358,
+      "head": "52b9910087ff976e7830508c54834923266e8573",
+      "parentRecordedHead": "46ce0cae7e51f432a4eae873e9f3d8f33750c841",
+      "parentCurrentHead": "46ce0cae7e51f432a4eae873e9f3d8f33750c841",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "52b991008",
+        "sha": "52b9910087ff976e7830508c54834923266e8573",
+        "iso": "2026-06-04T06:17:36-04:00",
+        "subject": "test(direct-control): resolve procedure schema references"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-ready-unit-procedure-descriptor",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/resolve-procedure-schema-references",
+      "children": [
+        "codex/guard-procedure-schema-field-lists"
+      ],
+      "depth": 359,
+      "head": "3ee679ba0c4e222d29da019e81b46f384d49677e",
+      "parentRecordedHead": "52b9910087ff976e7830508c54834923266e8573",
+      "parentCurrentHead": "52b9910087ff976e7830508c54834923266e8573",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3ee679ba0",
+        "sha": "3ee679ba0c4e222d29da019e81b46f384d49677e",
+        "iso": "2026-06-04T06:23:32-04:00",
+        "subject": "test(direct-control): add ready-unit procedure descriptor"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/guard-procedure-schema-field-lists",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-ready-unit-procedure-descriptor",
+      "children": [
+        "codex/add-ready-city-procedure-descriptor"
+      ],
+      "depth": 360,
+      "head": "dcf213f77e43314b3935c8afd1c3788a15996a54",
+      "parentRecordedHead": "3ee679ba0c4e222d29da019e81b46f384d49677e",
+      "parentCurrentHead": "3ee679ba0c4e222d29da019e81b46f384d49677e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "dcf213f77",
+        "sha": "dcf213f77e43314b3935c8afd1c3788a15996a54",
+        "iso": "2026-06-04T06:28:03-04:00",
+        "subject": "test(direct-control): guard procedure schema field lists"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-ready-city-procedure-descriptor",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/guard-procedure-schema-field-lists",
+      "children": [
+        "codex/add-unit-move-preview-procedure-descriptor"
+      ],
+      "depth": 361,
+      "head": "2b4e5fc2d238067b37efdae54ee8f50b7dba1faf",
+      "parentRecordedHead": "dcf213f77e43314b3935c8afd1c3788a15996a54",
+      "parentCurrentHead": "dcf213f77e43314b3935c8afd1c3788a15996a54",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2b4e5fc2d",
+        "sha": "2b4e5fc2d238067b37efdae54ee8f50b7dba1faf",
+        "iso": "2026-06-04T06:37:36-04:00",
+        "subject": "test(direct-control): add ready-city procedure descriptor"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-unit-move-preview-procedure-descriptor",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-ready-city-procedure-descriptor",
+      "children": [
+        "codex/add-playable-status-procedure-descriptor"
+      ],
+      "depth": 362,
+      "head": "ca2e3874f1a16557b76a34a3c2d4bc0e67bf059d",
+      "parentRecordedHead": "2b4e5fc2d238067b37efdae54ee8f50b7dba1faf",
+      "parentCurrentHead": "2b4e5fc2d238067b37efdae54ee8f50b7dba1faf",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ca2e3874f",
+        "sha": "ca2e3874f1a16557b76a34a3c2d4bc0e67bf059d",
+        "iso": "2026-06-04T06:46:15-04:00",
+        "subject": "test(direct-control): add unit move preview procedure descriptor"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-playable-status-procedure-descriptor",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-unit-move-preview-procedure-descriptor",
+      "children": [
+        "codex/seed-procedure-context-policy"
+      ],
+      "depth": 363,
+      "head": "153c3afc71fb149e388449b5264411fb9a87e785",
+      "parentRecordedHead": "ca2e3874f1a16557b76a34a3c2d4bc0e67bf059d",
+      "parentCurrentHead": "ca2e3874f1a16557b76a34a3c2d4bc0e67bf059d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "153c3afc7",
+        "sha": "153c3afc71fb149e388449b5264411fb9a87e785",
+        "iso": "2026-06-04T07:02:52-04:00",
+        "subject": "test(direct-control): add playable status procedure descriptor"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/seed-procedure-context-policy",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-playable-status-procedure-descriptor",
+      "children": [
+        "codex/validate-procedure-core-payloads"
+      ],
+      "depth": 364,
+      "head": "bf286977b758d159be25bfef2e4e77436384d92d",
+      "parentRecordedHead": "153c3afc71fb149e388449b5264411fb9a87e785",
+      "parentCurrentHead": "153c3afc71fb149e388449b5264411fb9a87e785",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bf286977b",
+        "sha": "bf286977b758d159be25bfef2e4e77436384d92d",
+        "iso": "2026-06-04T07:13:12-04:00",
+        "subject": "test(direct-control): seed procedure context policy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/validate-procedure-core-payloads",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/seed-procedure-context-policy",
+      "children": [
+        "codex/seed-procedure-core-call"
+      ],
+      "depth": 365,
+      "head": "242079dc241cc860fcac0a62228f4a71f6c5df46",
+      "parentRecordedHead": "bf286977b758d159be25bfef2e4e77436384d92d",
+      "parentCurrentHead": "bf286977b758d159be25bfef2e4e77436384d92d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "242079dc2",
+        "sha": "242079dc241cc860fcac0a62228f4a71f6c5df46",
+        "iso": "2026-06-04T07:21:58-04:00",
+        "subject": "test(direct-control): validate procedure payload schemas"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/seed-procedure-core-call",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/validate-procedure-core-payloads",
+      "children": [
+        "codex/add-ready-unit-procedure-call"
+      ],
+      "depth": 366,
+      "head": "ec9144b633e0589c59b98ccbbc0e72f0fdfa24a2",
+      "parentRecordedHead": "242079dc241cc860fcac0a62228f4a71f6c5df46",
+      "parentCurrentHead": "242079dc241cc860fcac0a62228f4a71f6c5df46",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ec9144b63",
+        "sha": "ec9144b633e0589c59b98ccbbc0e72f0fdfa24a2",
+        "iso": "2026-06-04T07:29:52-04:00",
+        "subject": "test(direct-control): seed procedure core call"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-ready-unit-procedure-call",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/seed-procedure-core-call",
+      "children": [
+        "codex/add-ready-city-procedure-call"
+      ],
+      "depth": 367,
+      "head": "e9bf21d4741a7e992f6362edbf04f20f9e0e2aff",
+      "parentRecordedHead": "ec9144b633e0589c59b98ccbbc0e72f0fdfa24a2",
+      "parentCurrentHead": "ec9144b633e0589c59b98ccbbc0e72f0fdfa24a2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e9bf21d47",
+        "sha": "e9bf21d4741a7e992f6362edbf04f20f9e0e2aff",
+        "iso": "2026-06-04T07:37:52-04:00",
+        "subject": "test(direct-control): add ready-unit procedure call"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-ready-city-procedure-call",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-ready-unit-procedure-call",
+      "children": [
+        "codex/add-unit-move-preview-procedure-call"
+      ],
+      "depth": 368,
+      "head": "da11bf83dd89ba04145970ad4da9dea68d08351b",
+      "parentRecordedHead": "e9bf21d4741a7e992f6362edbf04f20f9e0e2aff",
+      "parentCurrentHead": "e9bf21d4741a7e992f6362edbf04f20f9e0e2aff",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "da11bf83d",
+        "sha": "da11bf83dd89ba04145970ad4da9dea68d08351b",
+        "iso": "2026-06-04T07:44:06-04:00",
+        "subject": "test(direct-control): add ready-city procedure call"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-unit-move-preview-procedure-call",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-ready-city-procedure-call",
+      "children": [
+        "codex/add-playable-status-procedure-call"
+      ],
+      "depth": 369,
+      "head": "bc45aa868c47356e92442bd3e4febe278f7d0b29",
+      "parentRecordedHead": "da11bf83dd89ba04145970ad4da9dea68d08351b",
+      "parentCurrentHead": "da11bf83dd89ba04145970ad4da9dea68d08351b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bc45aa868",
+        "sha": "bc45aa868c47356e92442bd3e4febe278f7d0b29",
+        "iso": "2026-06-04T07:49:40-04:00",
+        "subject": "test(direct-control): add unit move-preview procedure call"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-playable-status-procedure-call",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-unit-move-preview-procedure-call",
+      "children": [
+        "codex/add-app-ui-snapshot-procedure-call"
+      ],
+      "depth": 370,
+      "head": "76f0dd2221d13ef0d8daab911b00e33239b6d849",
+      "parentRecordedHead": "bc45aa868c47356e92442bd3e4febe278f7d0b29",
+      "parentCurrentHead": "bc45aa868c47356e92442bd3e4febe278f7d0b29",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "76f0dd222",
+        "sha": "76f0dd2221d13ef0d8daab911b00e33239b6d849",
+        "iso": "2026-06-04T07:59:12-04:00",
+        "subject": "test(direct-control): add playable-status procedure call"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-app-ui-snapshot-procedure-call",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-playable-status-procedure-call",
+      "children": [
+        "codex/add-tuner-health-procedure-call"
+      ],
+      "depth": 371,
+      "head": "483bcbe139dc49b4f3b1fa8b3736027c0c6fac2e",
+      "parentRecordedHead": "76f0dd2221d13ef0d8daab911b00e33239b6d849",
+      "parentCurrentHead": "76f0dd2221d13ef0d8daab911b00e33239b6d849",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "483bcbe13",
+        "sha": "483bcbe139dc49b4f3b1fa8b3736027c0c6fac2e",
+        "iso": "2026-06-04T08:09:13-04:00",
+        "subject": "test(direct-control): add app-ui snapshot procedure call"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-tuner-health-procedure-call",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-app-ui-snapshot-procedure-call",
+      "children": [
+        "codex/add-diplomacy-response-telemetry"
+      ],
+      "depth": 372,
+      "head": "2fc9ca2469a41c4855f64403955776bf0695a0eb",
+      "parentRecordedHead": "483bcbe139dc49b4f3b1fa8b3736027c0c6fac2e",
+      "parentCurrentHead": "483bcbe139dc49b4f3b1fa8b3736027c0c6fac2e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2fc9ca246",
+        "sha": "2fc9ca2469a41c4855f64403955776bf0695a0eb",
+        "iso": "2026-06-04T08:19:42-04:00",
+        "subject": "test(direct-control): add tuner-health procedure call"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-diplomacy-response-telemetry",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-tuner-health-procedure-call",
+      "children": [
+        "codex/add-narrative-choice-telemetry"
+      ],
+      "depth": 373,
+      "head": "a514d0fda7061440d8390d69cbaa9f3698e9d7ea",
+      "parentRecordedHead": "2fc9ca2469a41c4855f64403955776bf0695a0eb",
+      "parentCurrentHead": "2fc9ca2469a41c4855f64403955776bf0695a0eb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a514d0fda",
+        "sha": "a514d0fda7061440d8390d69cbaa9f3698e9d7ea",
+        "iso": "2026-06-04T08:27:55-04:00",
+        "subject": "test(direct-control): add diplomacy-response telemetry adapter"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-narrative-choice-telemetry",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-diplomacy-response-telemetry",
+      "children": [
+        "codex/add-notification-dismissal-postcondition"
+      ],
+      "depth": 374,
+      "head": "0ac3ad164f2478fbaa70cc5272f738ddf309aeab",
+      "parentRecordedHead": "a514d0fda7061440d8390d69cbaa9f3698e9d7ea",
+      "parentCurrentHead": "a514d0fda7061440d8390d69cbaa9f3698e9d7ea",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0ac3ad164",
+        "sha": "0ac3ad164f2478fbaa70cc5272f738ddf309aeab",
+        "iso": "2026-06-04T08:40:56-04:00",
+        "subject": "test(direct-control): add narrative-choice telemetry adapter"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-notification-dismissal-postcondition",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-narrative-choice-telemetry",
+      "children": [
+        "codex/add-notification-dismissal-telemetry"
+      ],
+      "depth": 375,
+      "head": "05f1f057d77d8da18b1e91270a484d35d0d6074f",
+      "parentRecordedHead": "0ac3ad164f2478fbaa70cc5272f738ddf309aeab",
+      "parentCurrentHead": "0ac3ad164f2478fbaa70cc5272f738ddf309aeab",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "05f1f057d",
+        "sha": "05f1f057d77d8da18b1e91270a484d35d0d6074f",
+        "iso": "2026-06-04T08:51:44-04:00",
+        "subject": "test(direct-control): classify notification dismissal postconditions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-notification-dismissal-telemetry",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-notification-dismissal-postcondition",
+      "children": [
+        "codex/guard-operation-telemetry-projections"
+      ],
+      "depth": 376,
+      "head": "28937c5bf6fb281d1e76e4f661c6a32da1cfe8cc",
+      "parentRecordedHead": "05f1f057d77d8da18b1e91270a484d35d0d6074f",
+      "parentCurrentHead": "05f1f057d77d8da18b1e91270a484d35d0d6074f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "28937c5bf",
+        "sha": "28937c5bf6fb281d1e76e4f661c6a32da1cfe8cc",
+        "iso": "2026-06-04T09:00:19-04:00",
+        "subject": "test(direct-control): add notification-dismissal telemetry adapter"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/guard-operation-telemetry-projections",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-notification-dismissal-telemetry",
+      "children": [
+        "codex/record-procedure-schema-technology"
+      ],
+      "depth": 377,
+      "head": "0d826ca54c2d3bd8ed5e1af4799853209b7d9a3e",
+      "parentRecordedHead": "28937c5bf6fb281d1e76e4f661c6a32da1cfe8cc",
+      "parentCurrentHead": "28937c5bf6fb281d1e76e4f661c6a32da1cfe8cc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0d826ca54",
+        "sha": "0d826ca54c2d3bd8ed5e1af4799853209b7d9a3e",
+        "iso": "2026-06-04T09:07:40-04:00",
+        "subject": "test(direct-control): guard telemetry projections"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/record-procedure-schema-technology",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/guard-operation-telemetry-projections",
+      "children": [
+        "codex/add-notifications-view-procedure"
+      ],
+      "depth": 378,
+      "head": "5d8a561fa2061e40ed77725ea9e3d572a091f3f4",
+      "parentRecordedHead": "0d826ca54c2d3bd8ed5e1af4799853209b7d9a3e",
+      "parentCurrentHead": "0d826ca54c2d3bd8ed5e1af4799853209b7d9a3e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5d8a561fa",
+        "sha": "5d8a561fa2061e40ed77725ea9e3d572a091f3f4",
+        "iso": "2026-06-04T09:19:46-04:00",
+        "subject": "test(direct-control): record procedure schema technology"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-notifications-view-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/record-procedure-schema-technology",
+      "children": [
+        "codex/add-settlement-recommendations-procedure"
+      ],
+      "depth": 379,
+      "head": "e31c4013fa735dcf8edaa12d52b3af483b74a884",
+      "parentRecordedHead": "5d8a561fa2061e40ed77725ea9e3d572a091f3f4",
+      "parentCurrentHead": "5d8a561fa2061e40ed77725ea9e3d572a091f3f4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e31c4013f",
+        "sha": "e31c4013fa735dcf8edaa12d52b3af483b74a884",
+        "iso": "2026-06-04T09:34:30-04:00",
+        "subject": "test(direct-control): add notification view procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-settlement-recommendations-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-notifications-view-procedure",
+      "children": [
+        "codex/add-target-candidates-procedure"
+      ],
+      "depth": 380,
+      "head": "c4e484b21c9bcb3e5ac3987e5256b5334a700f50",
+      "parentRecordedHead": "e31c4013fa735dcf8edaa12d52b3af483b74a884",
+      "parentCurrentHead": "e31c4013fa735dcf8edaa12d52b3af483b74a884",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c4e484b21",
+        "sha": "c4e484b21c9bcb3e5ac3987e5256b5334a700f50",
+        "iso": "2026-06-04T09:46:31-04:00",
+        "subject": "test(direct-control): add settlement recommendations procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-target-candidates-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-settlement-recommendations-procedure",
+      "children": [
+        "codex/add-battlefield-scan-procedure"
+      ],
+      "depth": 381,
+      "head": "25dd113e7d247fbfaee4780924ce434e4a0924c5",
+      "parentRecordedHead": "c4e484b21c9bcb3e5ac3987e5256b5334a700f50",
+      "parentCurrentHead": "c4e484b21c9bcb3e5ac3987e5256b5334a700f50",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "25dd113e7",
+        "sha": "25dd113e7d247fbfaee4780924ce434e4a0924c5",
+        "iso": "2026-06-04T09:56:16-04:00",
+        "subject": "test(direct-control): add target candidates procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-battlefield-scan-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-target-candidates-procedure",
+      "children": [
+        "codex/add-destination-analysis-procedure"
+      ],
+      "depth": 382,
+      "head": "3353fec8e6307e70096d0d1c1843ef3778e0e2f7",
+      "parentRecordedHead": "25dd113e7d247fbfaee4780924ce434e4a0924c5",
+      "parentCurrentHead": "25dd113e7d247fbfaee4780924ce434e4a0924c5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3353fec8e",
+        "sha": "3353fec8e6307e70096d0d1c1843ef3778e0e2f7",
+        "iso": "2026-06-04T10:06:17-04:00",
+        "subject": "test(direct-control): add battlefield scan procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-destination-analysis-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-battlefield-scan-procedure",
+      "children": [
+        "codex/add-traditions-view-procedure"
+      ],
+      "depth": 383,
+      "head": "e2b8dd81e9847f9e7bb1ece329d73bff269c9aa3",
+      "parentRecordedHead": "3353fec8e6307e70096d0d1c1843ef3778e0e2f7",
+      "parentCurrentHead": "3353fec8e6307e70096d0d1c1843ef3778e0e2f7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e2b8dd81e",
+        "sha": "e2b8dd81e9847f9e7bb1ece329d73bff269c9aa3",
+        "iso": "2026-06-04T10:17:05-04:00",
+        "subject": "test(direct-control): add destination analysis procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-traditions-view-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-destination-analysis-procedure",
+      "children": [
+        "codex/add-progress-dashboard-procedure"
+      ],
+      "depth": 384,
+      "head": "a1143f922386589c982edd4c31f877f8465fd34d",
+      "parentRecordedHead": "e2b8dd81e9847f9e7bb1ece329d73bff269c9aa3",
+      "parentCurrentHead": "e2b8dd81e9847f9e7bb1ece329d73bff269c9aa3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a1143f922",
+        "sha": "a1143f922386589c982edd4c31f877f8465fd34d",
+        "iso": "2026-06-04T10:24:58-04:00",
+        "subject": "test(direct-control): add traditions view procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-progress-dashboard-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-traditions-view-procedure",
+      "children": [
+        "codex/add-map-summary-procedure"
+      ],
+      "depth": 385,
+      "head": "5217efeaa14487494450ab1a5f3de80b5e817f07",
+      "parentRecordedHead": "a1143f922386589c982edd4c31f877f8465fd34d",
+      "parentCurrentHead": "a1143f922386589c982edd4c31f877f8465fd34d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5217efeaa",
+        "sha": "5217efeaa14487494450ab1a5f3de80b5e817f07",
+        "iso": "2026-06-04T10:31:34-04:00",
+        "subject": "test(direct-control): add progress dashboard procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-map-summary-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-progress-dashboard-procedure",
+      "children": [
+        "codex/add-plot-snapshot-procedure"
+      ],
+      "depth": 386,
+      "head": "f9315bb663e4cc4d5fc19fa5fe3185a06509403a",
+      "parentRecordedHead": "5217efeaa14487494450ab1a5f3de80b5e817f07",
+      "parentCurrentHead": "5217efeaa14487494450ab1a5f3de80b5e817f07",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f9315bb66",
+        "sha": "f9315bb663e4cc4d5fc19fa5fe3185a06509403a",
+        "iso": "2026-06-04T10:44:10-04:00",
+        "subject": "test(direct-control): add map summary procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-plot-snapshot-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-map-summary-procedure",
+      "children": [
+        "codex/add-map-grid-procedure"
+      ],
+      "depth": 387,
+      "head": "2f97dc6b31aa52f79e11a92cdc19b54cfb1fbde7",
+      "parentRecordedHead": "f9315bb663e4cc4d5fc19fa5fe3185a06509403a",
+      "parentCurrentHead": "f9315bb663e4cc4d5fc19fa5fe3185a06509403a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2f97dc6b3",
+        "sha": "2f97dc6b31aa52f79e11a92cdc19b54cfb1fbde7",
+        "iso": "2026-06-04T10:55:08-04:00",
+        "subject": "test(direct-control): add plot snapshot procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-map-grid-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-plot-snapshot-procedure",
+      "children": [
+        "codex/add-gameinfo-rows-procedure"
+      ],
+      "depth": 388,
+      "head": "f5c364d056589adfda68afcd89158dae26ef9694",
+      "parentRecordedHead": "2f97dc6b31aa52f79e11a92cdc19b54cfb1fbde7",
+      "parentCurrentHead": "2f97dc6b31aa52f79e11a92cdc19b54cfb1fbde7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f5c364d05",
+        "sha": "f5c364d056589adfda68afcd89158dae26ef9694",
+        "iso": "2026-06-04T11:03:32-04:00",
+        "subject": "test(direct-control): add map grid procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-gameinfo-rows-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-map-grid-procedure",
+      "children": [
+        "codex/add-visibility-summary-procedure"
+      ],
+      "depth": 389,
+      "head": "2102b93c9ef2097a190fd3d63411af10bef554d3",
+      "parentRecordedHead": "f5c364d056589adfda68afcd89158dae26ef9694",
+      "parentCurrentHead": "f5c364d056589adfda68afcd89158dae26ef9694",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2102b93c9",
+        "sha": "2102b93c9ef2097a190fd3d63411af10bef554d3",
+        "iso": "2026-06-04T11:14:48-04:00",
+        "subject": "test(direct-control): add GameInfo rows procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-visibility-summary-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-gameinfo-rows-procedure",
+      "children": [
+        "codex/harden-command-serializer-errors"
+      ],
+      "depth": 390,
+      "head": "64c30b6e84eef97e3905c34640d0c29a3a9f593d",
+      "parentRecordedHead": "2102b93c9ef2097a190fd3d63411af10bef554d3",
+      "parentCurrentHead": "2102b93c9ef2097a190fd3d63411af10bef554d3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "64c30b6e8",
+        "sha": "64c30b6e84eef97e3905c34640d0c29a3a9f593d",
+        "iso": "2026-06-04T11:30:44-04:00",
+        "subject": "test(direct-control): add visibility summary procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/harden-command-serializer-errors",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-visibility-summary-procedure",
+      "children": [
+        "codex/add-turn-completion-status-procedure"
+      ],
+      "depth": 391,
+      "head": "4d29f891ea56110706c8d96d6bac08e551b69250",
+      "parentRecordedHead": "64c30b6e84eef97e3905c34640d0c29a3a9f593d",
+      "parentCurrentHead": "64c30b6e84eef97e3905c34640d0c29a3a9f593d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4d29f891e",
+        "sha": "4d29f891ea56110706c8d96d6bac08e551b69250",
+        "iso": "2026-06-04T11:35:39-04:00",
+        "subject": "fix(direct-control): harden command serializer errors"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-turn-completion-status-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/harden-command-serializer-errors",
+      "children": [
+        "codex/add-unit-summary-procedure"
+      ],
+      "depth": 392,
+      "head": "3ce365123dd45025f4fd66c410ab54fdbaacf58c",
+      "parentRecordedHead": "4d29f891ea56110706c8d96d6bac08e551b69250",
+      "parentCurrentHead": "4d29f891ea56110706c8d96d6bac08e551b69250",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3ce365123",
+        "sha": "3ce365123dd45025f4fd66c410ab54fdbaacf58c",
+        "iso": "2026-06-04T11:48:11-04:00",
+        "subject": "test(direct-control): add turn completion status procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-unit-summary-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-turn-completion-status-procedure",
+      "children": [
+        "codex/add-city-summary-procedure"
+      ],
+      "depth": 393,
+      "head": "2fde7608c6a1ec63192eacca4df5b385803926fb",
+      "parentRecordedHead": "3ce365123dd45025f4fd66c410ab54fdbaacf58c",
+      "parentCurrentHead": "3ce365123dd45025f4fd66c410ab54fdbaacf58c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2fde7608c",
+        "sha": "2fde7608c6a1ec63192eacca4df5b385803926fb",
+        "iso": "2026-06-04T12:05:16-04:00",
+        "subject": "test(direct-control): add unit summary procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-city-summary-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-unit-summary-procedure",
+      "children": [
+        "codex/add-player-summary-procedure"
+      ],
+      "depth": 394,
+      "head": "e4bed737c6e1d94d0ab0826767a2fcb40e64b2f7",
+      "parentRecordedHead": "2fde7608c6a1ec63192eacca4df5b385803926fb",
+      "parentCurrentHead": "2fde7608c6a1ec63192eacca4df5b385803926fb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e4bed737c",
+        "sha": "e4bed737c6e1d94d0ab0826767a2fcb40e64b2f7",
+        "iso": "2026-06-04T12:14:20-04:00",
+        "subject": "test(direct-control): add city summary procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-player-summary-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-city-summary-procedure",
+      "children": [
+        "codex/align-player-summary-matrix-intake"
+      ],
+      "depth": 395,
+      "head": "8ac480bc5b54a78ccb1b515b2d01349cf92998c2",
+      "parentRecordedHead": "e4bed737c6e1d94d0ab0826767a2fcb40e64b2f7",
+      "parentCurrentHead": "e4bed737c6e1d94d0ab0826767a2fcb40e64b2f7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8ac480bc5",
+        "sha": "8ac480bc5b54a78ccb1b515b2d01349cf92998c2",
+        "iso": "2026-06-04T12:27:14-04:00",
+        "subject": "test(direct-control): add player summary procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/align-player-summary-matrix-intake",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-player-summary-procedure",
+      "children": [
+        "codex/add-unit-target-action-procedure"
+      ],
+      "depth": 396,
+      "head": "608e70766f5130d4486795bea292c7cdd7049c9f",
+      "parentRecordedHead": "8ac480bc5b54a78ccb1b515b2d01349cf92998c2",
+      "parentCurrentHead": "8ac480bc5b54a78ccb1b515b2d01349cf92998c2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "608e70766",
+        "sha": "608e70766f5130d4486795bea292c7cdd7049c9f",
+        "iso": "2026-06-04T12:30:48-04:00",
+        "subject": "docs(openspec): align player summary matrix intake"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-unit-target-action-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/align-player-summary-matrix-intake",
+      "children": [
+        "codex/add-production-choice-procedure"
+      ],
+      "depth": 397,
+      "head": "ae1efb535552bb0306aa0512674e6b18970e1a14",
+      "parentRecordedHead": "608e70766f5130d4486795bea292c7cdd7049c9f",
+      "parentCurrentHead": "608e70766f5130d4486795bea292c7cdd7049c9f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ae1efb535",
+        "sha": "ae1efb535552bb0306aa0512674e6b18970e1a14",
+        "iso": "2026-06-04T12:44:43-04:00",
+        "subject": "test(direct-control): add unit target action procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-production-choice-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-unit-target-action-procedure",
+      "children": [
+        "codex/add-notification-dismissal-procedure"
+      ],
+      "depth": 398,
+      "head": "e761f01f148406fc484f25c1acba448c9d3acfe4",
+      "parentRecordedHead": "ae1efb535552bb0306aa0512674e6b18970e1a14",
+      "parentCurrentHead": "ae1efb535552bb0306aa0512674e6b18970e1a14",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e761f01f1",
+        "sha": "e761f01f148406fc484f25c1acba448c9d3acfe4",
+        "iso": "2026-06-04T13:00:25-04:00",
+        "subject": "test(direct-control): add production choice procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-notification-dismissal-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-production-choice-procedure",
+      "children": [
+        "codex/add-procedure-diagnostics-projection-metadata"
+      ],
+      "depth": 399,
+      "head": "fc990fe3ebbdba8e521eadfc248602e509247176",
+      "parentRecordedHead": "e761f01f148406fc484f25c1acba448c9d3acfe4",
+      "parentCurrentHead": "e761f01f148406fc484f25c1acba448c9d3acfe4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fc990fe3e",
+        "sha": "fc990fe3ebbdba8e521eadfc248602e509247176",
+        "iso": "2026-06-04T13:16:26-04:00",
+        "subject": "test(direct-control): add notification dismissal procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-procedure-diagnostics-projection-metadata",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-notification-dismissal-procedure",
+      "children": [
+        "codex/add-procedure-core-error-shape"
+      ],
+      "depth": 400,
+      "head": "4ad93707c672937f5fe4c5ce56fc1d4cecc6e121",
+      "parentRecordedHead": "fc990fe3ebbdba8e521eadfc248602e509247176",
+      "parentCurrentHead": "fc990fe3ebbdba8e521eadfc248602e509247176",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4ad93707c",
+        "sha": "4ad93707c672937f5fe4c5ce56fc1d4cecc6e121",
+        "iso": "2026-06-04T13:23:23-04:00",
+        "subject": "test(direct-control): add procedure diagnostics projection metadata"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-procedure-core-error-shape",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-procedure-diagnostics-projection-metadata",
+      "children": [
+        "codex/add-procedure-core-result-envelope"
+      ],
+      "depth": 401,
+      "head": "7912f26baf81ab10a0c624a546fb061b5678cc75",
+      "parentRecordedHead": "4ad93707c672937f5fe4c5ce56fc1d4cecc6e121",
+      "parentCurrentHead": "4ad93707c672937f5fe4c5ce56fc1d4cecc6e121",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7912f26ba",
+        "sha": "7912f26baf81ab10a0c624a546fb061b5678cc75",
+        "iso": "2026-06-04T13:35:31-04:00",
+        "subject": "test(direct-control): add procedure core error shape"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-procedure-core-result-envelope",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-procedure-core-error-shape",
+      "children": [
+        "codex/add-procedure-core-context-schema"
+      ],
+      "depth": 402,
+      "head": "d1b1dae7b737b0ca7b9f3a03d993ae291ea774a4",
+      "parentRecordedHead": "7912f26baf81ab10a0c624a546fb061b5678cc75",
+      "parentCurrentHead": "7912f26baf81ab10a0c624a546fb061b5678cc75",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d1b1dae7b",
+        "sha": "d1b1dae7b737b0ca7b9f3a03d993ae291ea774a4",
+        "iso": "2026-06-04T13:42:57-04:00",
+        "subject": "test(direct-control): add procedure call envelope"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-procedure-core-context-schema",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-procedure-core-result-envelope",
+      "children": [
+        "codex/add-control-orpc-openspec-slice"
+      ],
+      "depth": 403,
+      "head": "6905c71e8283cd02199b335452305685d7ee1473",
+      "parentRecordedHead": "d1b1dae7b737b0ca7b9f3a03d993ae291ea774a4",
+      "parentCurrentHead": "d1b1dae7b737b0ca7b9f3a03d993ae291ea774a4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6905c71e8",
+        "sha": "6905c71e8283cd02199b335452305685d7ee1473",
+        "iso": "2026-06-04T13:50:26-04:00",
+        "subject": "test(direct-control): add procedure context schema"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-openspec-slice",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-procedure-core-context-schema",
+      "children": [
+        "codex/add-control-orpc-atom-inventory"
+      ],
+      "depth": 404,
+      "head": "35658f8e0bd02801a342f906d46698284b3a4f98",
+      "parentRecordedHead": "6905c71e8283cd02199b335452305685d7ee1473",
+      "parentCurrentHead": "6905c71e8283cd02199b335452305685d7ee1473",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "35658f8e0",
+        "sha": "35658f8e0bd02801a342f906d46698284b3a4f98",
+        "iso": "2026-06-04T14:10:20-04:00",
+        "subject": "docs(openspec): define native control orpc slice"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-atom-inventory",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-openspec-slice",
+      "children": [
+        "codex/add-control-orpc-playable-status"
+      ],
+      "depth": 405,
+      "head": "7622afdc7561cf1af4d30351ec62bf85cb5e2183",
+      "parentRecordedHead": "35658f8e0bd02801a342f906d46698284b3a4f98",
+      "parentCurrentHead": "35658f8e0bd02801a342f906d46698284b3a4f98",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7622afdc7",
+        "sha": "7622afdc7561cf1af4d30351ec62bf85cb5e2183",
+        "iso": "2026-06-04T14:19:26-04:00",
+        "subject": "docs(openspec): inventory control orpc atoms"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-playable-status",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-atom-inventory",
+      "children": [
+        "codex/add-control-orpc-notifications-view"
+      ],
+      "depth": 406,
+      "head": "2e298e72ce7e36b3c4c986e0ef780daa0780d532",
+      "parentRecordedHead": "7622afdc7561cf1af4d30351ec62bf85cb5e2183",
+      "parentCurrentHead": "7622afdc7561cf1af4d30351ec62bf85cb5e2183",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2e298e72c",
+        "sha": "2e298e72ce7e36b3c4c986e0ef780daa0780d532",
+        "iso": "2026-06-04T14:41:07-04:00",
+        "subject": "feat(control-orpc): add playable status procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-notifications-view",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-playable-status",
+      "children": [
+        "codex/add-control-orpc-ready-unit-view"
+      ],
+      "depth": 407,
+      "head": "11e450557ef61055880b75335865ac1f1003f5b4",
+      "parentRecordedHead": "2e298e72ce7e36b3c4c986e0ef780daa0780d532",
+      "parentCurrentHead": "2e298e72ce7e36b3c4c986e0ef780daa0780d532",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "11e450557",
+        "sha": "11e450557ef61055880b75335865ac1f1003f5b4",
+        "iso": "2026-06-04T14:55:38-04:00",
+        "subject": "feat(control-orpc): add notifications view procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-ready-unit-view",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-notifications-view",
+      "children": [
+        "codex/add-control-orpc-tagged-error-projection"
+      ],
+      "depth": 408,
+      "head": "474c9ee8a63ebf03cd4a9ac661b450c46d4b93ff",
+      "parentRecordedHead": "11e450557ef61055880b75335865ac1f1003f5b4",
+      "parentCurrentHead": "11e450557ef61055880b75335865ac1f1003f5b4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "474c9ee8a",
+        "sha": "474c9ee8a63ebf03cd4a9ac661b450c46d4b93ff",
+        "iso": "2026-06-04T15:01:56-04:00",
+        "subject": "feat(control-orpc): add ready unit view procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-tagged-error-projection",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-ready-unit-view",
+      "children": [
+        "codex/add-control-orpc-map-summary-read"
+      ],
+      "depth": 409,
+      "head": "dca365b68577a201a70849dffdf81016a3091a0d",
+      "parentRecordedHead": "474c9ee8a63ebf03cd4a9ac661b450c46d4b93ff",
+      "parentCurrentHead": "474c9ee8a63ebf03cd4a9ac661b450c46d4b93ff",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "dca365b68",
+        "sha": "dca365b68577a201a70849dffdf81016a3091a0d",
+        "iso": "2026-06-04T16:30:22-04:00",
+        "subject": "feat(control-orpc): use native tagged error projection"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-map-summary-read",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-tagged-error-projection",
+      "children": [
+        "codex/add-control-orpc-player-summary-read"
+      ],
+      "depth": 410,
+      "head": "660f22703b704fac9a6c09aad91a735185c4a114",
+      "parentRecordedHead": "dca365b68577a201a70849dffdf81016a3091a0d",
+      "parentCurrentHead": "dca365b68577a201a70849dffdf81016a3091a0d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "660f22703",
+        "sha": "660f22703b704fac9a6c09aad91a735185c4a114",
+        "iso": "2026-06-04T16:38:13-04:00",
+        "subject": "feat(control-orpc): add map summary read procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-player-summary-read",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-map-summary-read",
+      "children": [
+        "codex/add-control-orpc-unit-summary-read"
+      ],
+      "depth": 411,
+      "head": "1b9dc06a7ca8bf3f6e77f7fb2e01d89a956d330d",
+      "parentRecordedHead": "660f22703b704fac9a6c09aad91a735185c4a114",
+      "parentCurrentHead": "660f22703b704fac9a6c09aad91a735185c4a114",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1b9dc06a7",
+        "sha": "1b9dc06a7ca8bf3f6e77f7fb2e01d89a956d330d",
+        "iso": "2026-06-04T16:46:48-04:00",
+        "subject": "feat(control-orpc): add player summary read procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-unit-summary-read",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-player-summary-read",
+      "children": [
+        "codex/add-control-orpc-city-summary-read"
+      ],
+      "depth": 412,
+      "head": "67b2c7b4c039b7eec6e0b7d342aa2c2ea82f39f3",
+      "parentRecordedHead": "1b9dc06a7ca8bf3f6e77f7fb2e01d89a956d330d",
+      "parentCurrentHead": "1b9dc06a7ca8bf3f6e77f7fb2e01d89a956d330d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "67b2c7b4c",
+        "sha": "67b2c7b4c039b7eec6e0b7d342aa2c2ea82f39f3",
+        "iso": "2026-06-04T16:52:41-04:00",
+        "subject": "feat(control-orpc): add unit summary read procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-city-summary-read",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-unit-summary-read",
+      "children": [
+        "codex/add-control-orpc-city-ready-view"
+      ],
+      "depth": 413,
+      "head": "2b75e9cd9199f95a593f4a8327c66ed70d8b8968",
+      "parentRecordedHead": "67b2c7b4c039b7eec6e0b7d342aa2c2ea82f39f3",
+      "parentCurrentHead": "67b2c7b4c039b7eec6e0b7d342aa2c2ea82f39f3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2b75e9cd9",
+        "sha": "2b75e9cd9199f95a593f4a8327c66ed70d8b8968",
+        "iso": "2026-06-04T16:59:46-04:00",
+        "subject": "feat(control-orpc): add city summary read procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-city-ready-view",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-city-summary-read",
+      "children": [
+        "codex/add-control-orpc-service-ownership-guard"
+      ],
+      "depth": 414,
+      "head": "c2115de48f9aefbb9d24fee1951c850a7f3a76c2",
+      "parentRecordedHead": "2b75e9cd9199f95a593f4a8327c66ed70d8b8968",
+      "parentCurrentHead": "2b75e9cd9199f95a593f4a8327c66ed70d8b8968",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c2115de48",
+        "sha": "c2115de48f9aefbb9d24fee1951c850a7f3a76c2",
+        "iso": "2026-06-04T17:09:19-04:00",
+        "subject": "feat(control-orpc): add ready city view procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-service-ownership-guard",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-city-ready-view",
+      "children": [
+        "codex/modularize-production-choice-proof"
+      ],
+      "depth": 415,
+      "head": "aa56ded093c4a2c6b15edff30b6901adbc69315e",
+      "parentRecordedHead": "c2115de48f9aefbb9d24fee1951c850a7f3a76c2",
+      "parentCurrentHead": "c2115de48f9aefbb9d24fee1951c850a7f3a76c2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "aa56ded09",
+        "sha": "aa56ded093c4a2c6b15edff30b6901adbc69315e",
+        "iso": "2026-06-04T17:27:36-04:00",
+        "subject": "docs(control-orpc): rebaseline service ownership workstream"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/modularize-production-choice-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-service-ownership-guard",
+      "children": [
+        "codex/modularize-notification-dismissal-proof"
+      ],
+      "depth": 416,
+      "head": "f99d2c8b7ccc803b1b93df03ff44817fb4222581",
+      "parentRecordedHead": "aa56ded093c4a2c6b15edff30b6901adbc69315e",
+      "parentCurrentHead": "aa56ded093c4a2c6b15edff30b6901adbc69315e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f99d2c8b7",
+        "sha": "f99d2c8b7ccc803b1b93df03ff44817fb4222581",
+        "iso": "2026-06-04T17:33:00-04:00",
+        "subject": "refactor(direct-control): modularize production choice proof policy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/modularize-notification-dismissal-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/modularize-production-choice-proof",
+      "children": [
+        "codex/modularize-unit-target-proof"
+      ],
+      "depth": 417,
+      "head": "6043542eca4c15bcfd2c629c771b6d8e562a8901",
+      "parentRecordedHead": "f99d2c8b7ccc803b1b93df03ff44817fb4222581",
+      "parentCurrentHead": "f99d2c8b7ccc803b1b93df03ff44817fb4222581",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6043542ec",
+        "sha": "6043542eca4c15bcfd2c629c771b6d8e562a8901",
+        "iso": "2026-06-04T17:38:34-04:00",
+        "subject": "refactor(direct-control): modularize notification dismissal proof policy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/modularize-unit-target-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/modularize-notification-dismissal-proof",
+      "children": [
+        "codex/modularize-closeout-proof-policy"
+      ],
+      "depth": 418,
+      "head": "2b7b44b64ad4e5544db9470b57b60a44408e95d3",
+      "parentRecordedHead": "6043542eca4c15bcfd2c629c771b6d8e562a8901",
+      "parentCurrentHead": "6043542eca4c15bcfd2c629c771b6d8e562a8901",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2b7b44b64",
+        "sha": "2b7b44b64ad4e5544db9470b57b60a44408e95d3",
+        "iso": "2026-06-04T17:44:17-04:00",
+        "subject": "refactor(direct-control): modularize unit target proof policy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/modularize-closeout-proof-policy",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/modularize-unit-target-proof",
+      "children": [
+        "codex/add-control-orpc-semantic-hierarchy"
+      ],
+      "depth": 419,
+      "head": "5ddf1eeb979e505efb2507661d73b6aaf22d7ba5",
+      "parentRecordedHead": "2b7b44b64ad4e5544db9470b57b60a44408e95d3",
+      "parentCurrentHead": "2b7b44b64ad4e5544db9470b57b60a44408e95d3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5ddf1eeb9",
+        "sha": "5ddf1eeb979e505efb2507661d73b6aaf22d7ba5",
+        "iso": "2026-06-04T17:52:23-04:00",
+        "subject": "refactor(direct-control): modularize closeout proof policies"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-semantic-hierarchy",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/modularize-closeout-proof-policy",
+      "children": [
+        "codex/modularize-population-placement-proof"
+      ],
+      "depth": 420,
+      "head": "e2638f164d0f5cc54173b4ec61700e5a951bfee5",
+      "parentRecordedHead": "5ddf1eeb979e505efb2507661d73b6aaf22d7ba5",
+      "parentCurrentHead": "5ddf1eeb979e505efb2507661d73b6aaf22d7ba5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e2638f164",
+        "sha": "e2638f164d0f5cc54173b4ec61700e5a951bfee5",
+        "iso": "2026-06-04T17:59:17-04:00",
+        "subject": "docs(control-orpc): define semantic capability hierarchy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/modularize-population-placement-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-semantic-hierarchy",
+      "children": [
+        "codex/add-control-orpc-attention-current"
+      ],
+      "depth": 421,
+      "head": "2cbf6170f6cd2c9b8fcdc2781c3cbcee2dbf6ae1",
+      "parentRecordedHead": "e2638f164d0f5cc54173b4ec61700e5a951bfee5",
+      "parentCurrentHead": "e2638f164d0f5cc54173b4ec61700e5a951bfee5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2cbf6170f",
+        "sha": "2cbf6170f6cd2c9b8fcdc2781c3cbcee2dbf6ae1",
+        "iso": "2026-06-04T18:04:26-04:00",
+        "subject": "refactor(direct-control): modularize population placement proof policy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-attention-current",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/modularize-population-placement-proof",
+      "children": [
+        "codex/add-attention-turn-completion-status"
+      ],
+      "depth": 422,
+      "head": "74196d40c0d04a417d967dc7b1ef542ed495bee8",
+      "parentRecordedHead": "2cbf6170f6cd2c9b8fcdc2781c3cbcee2dbf6ae1",
+      "parentCurrentHead": "2cbf6170f6cd2c9b8fcdc2781c3cbcee2dbf6ae1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "74196d40c",
+        "sha": "74196d40c0d04a417d967dc7b1ef542ed495bee8",
+        "iso": "2026-06-04T18:23:16-04:00",
+        "subject": "feat(control-orpc): add attention current procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-attention-turn-completion-status",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-attention-current",
+      "children": [
+        "codex/add-production-choice-orpc-procedure"
+      ],
+      "depth": 423,
+      "head": "a03714ead7e117f3754bda2d6d4d2f2de118ca65",
+      "parentRecordedHead": "74196d40c0d04a417d967dc7b1ef542ed495bee8",
+      "parentCurrentHead": "74196d40c0d04a417d967dc7b1ef542ed495bee8",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a03714ead",
+        "sha": "a03714ead7e117f3754bda2d6d4d2f2de118ca65",
+        "iso": "2026-06-04T18:37:54-04:00",
+        "subject": "feat(control-orpc): enrich attention turn status"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-production-choice-orpc-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-attention-turn-completion-status",
+      "children": [
+        "codex/add-notification-dismissal-orpc-procedure"
+      ],
+      "depth": 424,
+      "head": "13241fa5cebe87bcc8a4c97b6d1d4e6cbd4631d2",
+      "parentRecordedHead": "a03714ead7e117f3754bda2d6d4d2f2de118ca65",
+      "parentCurrentHead": "a03714ead7e117f3754bda2d6d4d2f2de118ca65",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "13241fa5c",
+        "sha": "13241fa5cebe87bcc8a4c97b6d1d4e6cbd4631d2",
+        "iso": "2026-06-04T18:58:29-04:00",
+        "subject": "feat(control-orpc): add production choice procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-notification-dismissal-orpc-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-production-choice-orpc-procedure",
+      "children": [
+        "codex/promote-control-orpc-approval-middleware"
+      ],
+      "depth": 425,
+      "head": "e850b9d6bf929a99e6edf4fddb5e0a4478fd1583",
+      "parentRecordedHead": "13241fa5cebe87bcc8a4c97b6d1d4e6cbd4631d2",
+      "parentCurrentHead": "13241fa5cebe87bcc8a4c97b6d1d4e6cbd4631d2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e850b9d6b",
+        "sha": "e850b9d6bf929a99e6edf4fddb5e0a4478fd1583",
+        "iso": "2026-06-04T19:14:36-04:00",
+        "subject": "feat(control-orpc): add notification dismissal procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/promote-control-orpc-approval-middleware",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-notification-dismissal-orpc-procedure",
+      "children": [
+        "codex/add-unit-target-action-orpc-procedure"
+      ],
+      "depth": 426,
+      "head": "22ac4ad84f818ad7cb45dc627d9e811e5dd3da15",
+      "parentRecordedHead": "e850b9d6bf929a99e6edf4fddb5e0a4478fd1583",
+      "parentCurrentHead": "e850b9d6bf929a99e6edf4fddb5e0a4478fd1583",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "22ac4ad84",
+        "sha": "22ac4ad84f818ad7cb45dc627d9e811e5dd3da15",
+        "iso": "2026-06-04T19:26:47-04:00",
+        "subject": "refactor(control-orpc): share mutation approval middleware"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-unit-target-action-orpc-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/promote-control-orpc-approval-middleware",
+      "children": [
+        "codex/add-population-placement-orpc-procedure"
+      ],
+      "depth": 427,
+      "head": "941f91af2065af6489b68ce5253b68e5bca573b1",
+      "parentRecordedHead": "22ac4ad84f818ad7cb45dc627d9e811e5dd3da15",
+      "parentCurrentHead": "22ac4ad84f818ad7cb45dc627d9e811e5dd3da15",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "941f91af2",
+        "sha": "941f91af2065af6489b68ce5253b68e5bca573b1",
+        "iso": "2026-06-04T19:50:17-04:00",
+        "subject": "feat(control-orpc): add unit target action procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-population-placement-orpc-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-unit-target-action-orpc-procedure",
+      "children": [
+        "codex/move-unit-target-action-to-unit-router"
+      ],
+      "depth": 428,
+      "head": "fe5086697d19d283f1adc0c3117c870564097794",
+      "parentRecordedHead": "941f91af2065af6489b68ce5253b68e5bca573b1",
+      "parentCurrentHead": "941f91af2065af6489b68ce5253b68e5bca573b1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fe5086697",
+        "sha": "fe5086697d19d283f1adc0c3117c870564097794",
+        "iso": "2026-06-04T20:06:31-04:00",
+        "subject": "feat(control-orpc): add population placement procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/move-unit-target-action-to-unit-router",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-population-placement-orpc-procedure",
+      "children": [
+        "codex/burn-down-unit-ready-view-orpc-wrapper"
+      ],
+      "depth": 429,
+      "head": "1f1b6e118a2d6e7ec7ed492dea394f5c20b25198",
+      "parentRecordedHead": "fe5086697d19d283f1adc0c3117c870564097794",
+      "parentCurrentHead": "fe5086697d19d283f1adc0c3117c870564097794",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1f1b6e118",
+        "sha": "1f1b6e118a2d6e7ec7ed492dea394f5c20b25198",
+        "iso": "2026-06-04T22:55:22-04:00",
+        "subject": "refactor(control-orpc): move unit target action to unit router"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/burn-down-unit-ready-view-orpc-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/move-unit-target-action-to-unit-router",
+      "children": [
+        "codex/burn-down-city-ready-view-orpc-wrapper"
+      ],
+      "depth": 430,
+      "head": "f1c2e63eab665c7b577267ebd6ccaa5a6779ea1c",
+      "parentRecordedHead": "1f1b6e118a2d6e7ec7ed492dea394f5c20b25198",
+      "parentCurrentHead": "1f1b6e118a2d6e7ec7ed492dea394f5c20b25198",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f1c2e63ea",
+        "sha": "f1c2e63eab665c7b577267ebd6ccaa5a6779ea1c",
+        "iso": "2026-06-04T23:05:34-04:00",
+        "subject": "refactor(control-orpc): burn down unit ready view wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/burn-down-city-ready-view-orpc-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/burn-down-unit-ready-view-orpc-wrapper",
+      "children": [
+        "codex/burn-down-notifications-view-orpc-wrapper"
+      ],
+      "depth": 431,
+      "head": "d4f92c3a8138d10d1e256165b6c06954e965aef5",
+      "parentRecordedHead": "f1c2e63eab665c7b577267ebd6ccaa5a6779ea1c",
+      "parentCurrentHead": "f1c2e63eab665c7b577267ebd6ccaa5a6779ea1c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d4f92c3a8",
+        "sha": "d4f92c3a8138d10d1e256165b6c06954e965aef5",
+        "iso": "2026-06-04T23:12:24-04:00",
+        "subject": "refactor(control-orpc): burn down city ready view wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/burn-down-notifications-view-orpc-wrapper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/burn-down-city-ready-view-orpc-wrapper",
+      "children": [
+        "codex/add-readiness-current-service"
+      ],
+      "depth": 432,
+      "head": "fe32f23cddada5c17863d69ed390175a4b4e1d35",
+      "parentRecordedHead": "d4f92c3a8138d10d1e256165b6c06954e965aef5",
+      "parentCurrentHead": "d4f92c3a8138d10d1e256165b6c06954e965aef5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fe32f23cd",
+        "sha": "fe32f23cddada5c17863d69ed390175a4b4e1d35",
+        "iso": "2026-06-04T23:15:51-04:00",
+        "subject": "refactor(control-orpc): burn down notifications view wrapper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-readiness-current-service",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/burn-down-notifications-view-orpc-wrapper",
+      "children": [
+        "codex/burn-down-summary-read-wrappers"
+      ],
+      "depth": 433,
+      "head": "9bcff084f7d7cc9bb4c0286c5e39a9213b9fef3e",
+      "parentRecordedHead": "fe32f23cddada5c17863d69ed390175a4b4e1d35",
+      "parentCurrentHead": "fe32f23cddada5c17863d69ed390175a4b4e1d35",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9bcff084f",
+        "sha": "9bcff084f7d7cc9bb4c0286c5e39a9213b9fef3e",
+        "iso": "2026-06-04T23:25:01-04:00",
+        "subject": "feat(control-orpc): add readiness current service"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/burn-down-summary-read-wrappers",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-readiness-current-service",
+      "children": [
+        "codex/rebaseline-world-resource-boundary"
+      ],
+      "depth": 434,
+      "head": "430b15d0ddce19bb34a4cc938dcedaa46b8299e8",
+      "parentRecordedHead": "9bcff084f7d7cc9bb4c0286c5e39a9213b9fef3e",
+      "parentCurrentHead": "9bcff084f7d7cc9bb4c0286c5e39a9213b9fef3e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "430b15d0d",
+        "sha": "430b15d0ddce19bb34a4cc938dcedaa46b8299e8",
+        "iso": "2026-06-04T23:35:24-04:00",
+        "subject": "refactor(control-orpc): burn down summary read wrappers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/rebaseline-world-resource-boundary",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/burn-down-summary-read-wrappers",
+      "children": [
+        "codex/promote-control-orpc-safe-error-middleware"
+      ],
+      "depth": 435,
+      "head": "05c1330c28e55e6e4c7abd6f327c38d6cdd8dcc0",
+      "parentRecordedHead": "430b15d0ddce19bb34a4cc938dcedaa46b8299e8",
+      "parentCurrentHead": "430b15d0ddce19bb34a4cc938dcedaa46b8299e8",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "05c1330c2",
+        "sha": "05c1330c28e55e6e4c7abd6f327c38d6cdd8dcc0",
+        "iso": "2026-06-04T23:59:45-04:00",
+        "subject": "docs(control-orpc): rebaseline world resource boundary"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/promote-control-orpc-safe-error-middleware",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/rebaseline-world-resource-boundary",
+      "children": [
+        "codex/add-control-orpc-correlation-context"
+      ],
+      "depth": 436,
+      "head": "013a6b4c3994b8afe391b99ae69471ccc96ed69c",
+      "parentRecordedHead": "05c1330c28e55e6e4c7abd6f327c38d6cdd8dcc0",
+      "parentCurrentHead": "05c1330c28e55e6e4c7abd6f327c38d6cdd8dcc0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "013a6b4c3",
+        "sha": "013a6b4c3994b8afe391b99ae69471ccc96ed69c",
+        "iso": "2026-06-05T03:34:44-04:00",
+        "subject": "feat(control-orpc): promote safe error middleware"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-correlation-context",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/promote-control-orpc-safe-error-middleware",
+      "children": [
+        "codex/add-control-orpc-mutation-result-policy"
+      ],
+      "depth": 437,
+      "head": "3205bf18310aae4d2392cc510f1e1910747a66da",
+      "parentRecordedHead": "013a6b4c3994b8afe391b99ae69471ccc96ed69c",
+      "parentCurrentHead": "013a6b4c3994b8afe391b99ae69471ccc96ed69c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3205bf183",
+        "sha": "3205bf18310aae4d2392cc510f1e1910747a66da",
+        "iso": "2026-06-05T03:52:57-04:00",
+        "subject": "feat(control-orpc): add correlation context"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-mutation-result-policy",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-correlation-context",
+      "children": [
+        "codex/add-control-orpc-mutation-readiness-middleware"
+      ],
+      "depth": 438,
+      "head": "86e4d289b840f3d61ab37e194f590490ed8c776b",
+      "parentRecordedHead": "3205bf18310aae4d2392cc510f1e1910747a66da",
+      "parentCurrentHead": "3205bf18310aae4d2392cc510f1e1910747a66da",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "86e4d289b",
+        "sha": "86e4d289b840f3d61ab37e194f590490ed8c776b",
+        "iso": "2026-06-05T03:57:44-04:00",
+        "subject": "refactor(control-orpc): share mutation result policy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-mutation-readiness-middleware",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-mutation-result-policy",
+      "children": [
+        "codex/route-game-status-through-control-orpc"
+      ],
+      "depth": 439,
+      "head": "59b2a62a6e8b91b3d8280b8924b95da3cdb9dbb7",
+      "parentRecordedHead": "86e4d289b840f3d61ab37e194f590490ed8c776b",
+      "parentCurrentHead": "86e4d289b840f3d61ab37e194f590490ed8c776b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "59b2a62a6",
+        "sha": "59b2a62a6e8b91b3d8280b8924b95da3cdb9dbb7",
+        "iso": "2026-06-05T04:05:10-04:00",
+        "subject": "feat(control-orpc): guard mutations with readiness middleware"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-game-status-through-control-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-mutation-readiness-middleware",
+      "children": [
+        "codex/add-studio-control-orpc-rpc-link"
+      ],
+      "depth": 440,
+      "head": "88b846c08f42a6e5a2daabfc00e0dad69c87b306",
+      "parentRecordedHead": "59b2a62a6e8b91b3d8280b8924b95da3cdb9dbb7",
+      "parentCurrentHead": "59b2a62a6e8b91b3d8280b8924b95da3cdb9dbb7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "88b846c08",
+        "sha": "88b846c08f42a6e5a2daabfc00e0dad69c87b306",
+        "iso": "2026-06-05T04:19:45-04:00",
+        "subject": "feat(cli): route game status through control-oRPC"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-studio-control-orpc-rpc-link",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-game-status-through-control-orpc",
+      "children": [
+        "codex/add-strategy-front-summary-service"
+      ],
+      "depth": 441,
+      "head": "24619e8d892cba53cb839f0f2e784f2953650de1",
+      "parentRecordedHead": "88b846c08f42a6e5a2daabfc00e0dad69c87b306",
+      "parentCurrentHead": "88b846c08f42a6e5a2daabfc00e0dad69c87b306",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "24619e8d8",
+        "sha": "24619e8d892cba53cb839f0f2e784f2953650de1",
+        "iso": "2026-06-05T04:46:57-04:00",
+        "subject": "feat(studio): add control-oRPC RPC link"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-strategy-front-summary-service",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-studio-control-orpc-rpc-link",
+      "children": [
+        "codex/add-narrative-choice-decision-procedure"
+      ],
+      "depth": 442,
+      "head": "14a25b890f505541e3f3f5f58402a7fde1734a90",
+      "parentRecordedHead": "24619e8d892cba53cb839f0f2e784f2953650de1",
+      "parentCurrentHead": "24619e8d892cba53cb839f0f2e784f2953650de1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "14a25b890",
+        "sha": "14a25b890f505541e3f3f5f58402a7fde1734a90",
+        "iso": "2026-06-05T05:06:34-04:00",
+        "subject": "feat(control-orpc): add strategy front summary"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-narrative-choice-decision-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-strategy-front-summary-service",
+      "children": [
+        "codex/sanitize-studio-run-in-game-errors"
+      ],
+      "depth": 443,
+      "head": "f66a874a553346d7a080e4428ce1430d8e085614",
+      "parentRecordedHead": "14a25b890f505541e3f3f5f58402a7fde1734a90",
+      "parentCurrentHead": "14a25b890f505541e3f3f5f58402a7fde1734a90",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f66a874a5",
+        "sha": "f66a874a553346d7a080e4428ce1430d8e085614",
+        "iso": "2026-06-05T05:22:19-04:00",
+        "subject": "feat(control-orpc): add narrative decision procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/sanitize-studio-run-in-game-errors",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-narrative-choice-decision-procedure",
+      "children": [
+        "codex/add-diplomacy-response-decision-procedure"
+      ],
+      "depth": 444,
+      "head": "03bb64e747ae6f25fb9c2db4839b0865dec53b73",
+      "parentRecordedHead": "f66a874a553346d7a080e4428ce1430d8e085614",
+      "parentCurrentHead": "f66a874a553346d7a080e4428ce1430d8e085614",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "03bb64e74",
+        "sha": "03bb64e747ae6f25fb9c2db4839b0865dec53b73",
+        "iso": "2026-06-05T05:43:05-04:00",
+        "subject": "fix(studio): sanitize run-in-game public errors"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-diplomacy-response-decision-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/sanitize-studio-run-in-game-errors",
+      "children": [
+        "codex/promote-control-orpc-proof-projection-policy"
+      ],
+      "depth": 445,
+      "head": "ea7ad20825fa1b31905b11f51cceff8f62fae7a5",
+      "parentRecordedHead": "03bb64e747ae6f25fb9c2db4839b0865dec53b73",
+      "parentCurrentHead": "03bb64e747ae6f25fb9c2db4839b0865dec53b73",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ea7ad2082",
+        "sha": "ea7ad20825fa1b31905b11f51cceff8f62fae7a5",
+        "iso": "2026-06-05T06:13:52-04:00",
+        "subject": "feat(control-orpc): add diplomacy response decision procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/promote-control-orpc-proof-projection-policy",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-diplomacy-response-decision-procedure",
+      "children": [
+        "codex/plan-control-orpc-controller-bridge"
+      ],
+      "depth": 446,
+      "head": "e38a09db456ee5bbc486f6fa4e2919c136b42e32",
+      "parentRecordedHead": "ea7ad20825fa1b31905b11f51cceff8f62fae7a5",
+      "parentCurrentHead": "ea7ad20825fa1b31905b11f51cceff8f62fae7a5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e38a09db4",
+        "sha": "e38a09db456ee5bbc486f6fa4e2919c136b42e32",
+        "iso": "2026-06-05T06:35:12-04:00",
+        "subject": "test(control-orpc): share closeout proof projection"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/plan-control-orpc-controller-bridge",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/promote-control-orpc-proof-projection-policy",
+      "children": [
+        "codex/seed-control-orpc-controller-ingress"
+      ],
+      "depth": 447,
+      "head": "d2efb9a0cc0fa9bd62d680f060d64ca6f6060c9c",
+      "parentRecordedHead": "e38a09db456ee5bbc486f6fa4e2919c136b42e32",
+      "parentCurrentHead": "e38a09db456ee5bbc486f6fa4e2919c136b42e32",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d2efb9a0c",
+        "sha": "d2efb9a0cc0fa9bd62d680f060d64ca6f6060c9c",
+        "iso": "2026-06-05T06:45:15-04:00",
+        "subject": "docs(control-orpc): plan controller bridge ingress"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/seed-control-orpc-controller-ingress",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/plan-control-orpc-controller-bridge",
+      "children": [
+        "codex/install-controller-global-bridge"
+      ],
+      "depth": 448,
+      "head": "5111528dba05c304dd89a92b47c656d61534c4d6",
+      "parentRecordedHead": "d2efb9a0cc0fa9bd62d680f060d64ca6f6060c9c",
+      "parentCurrentHead": "d2efb9a0cc0fa9bd62d680f060d64ca6f6060c9c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5111528db",
+        "sha": "5111528dba05c304dd89a92b47c656d61534c4d6",
+        "iso": "2026-06-05T07:10:27-04:00",
+        "subject": "feat(control-orpc): seed controller readiness ingress"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/install-controller-global-bridge",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/seed-control-orpc-controller-ingress",
+      "children": [
+        "codex/allow-controller-attention-ingress"
+      ],
+      "depth": 449,
+      "head": "4c13e25abff5de5679c2a46f3e1dfb06b48016f5",
+      "parentRecordedHead": "5111528dba05c304dd89a92b47c656d61534c4d6",
+      "parentCurrentHead": "5111528dba05c304dd89a92b47c656d61534c4d6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4c13e25ab",
+        "sha": "4c13e25abff5de5679c2a46f3e1dfb06b48016f5",
+        "iso": "2026-06-05T07:38:20-04:00",
+        "subject": "feat(control-orpc): install controller bridge binding"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/allow-controller-attention-ingress",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/install-controller-global-bridge",
+      "children": [
+        "codex/burn-down-control-orpc-raw-root-types"
+      ],
+      "depth": 450,
+      "head": "7641dd9a1b2ac1d81fae54d700a78b9b75101fad",
+      "parentRecordedHead": "4c13e25abff5de5679c2a46f3e1dfb06b48016f5",
+      "parentCurrentHead": "4c13e25abff5de5679c2a46f3e1dfb06b48016f5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7641dd9a1",
+        "sha": "7641dd9a1b2ac1d81fae54d700a78b9b75101fad",
+        "iso": "2026-06-05T07:56:13-04:00",
+        "subject": "feat(control-orpc): allow controller attention ingress"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/burn-down-control-orpc-raw-root-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/allow-controller-attention-ingress",
+      "children": [
+        "codex/split-control-orpc-runtime-entrypoint"
+      ],
+      "depth": 451,
+      "head": "607b94f07c31637e893cacc6aa69cc3f183f93ff",
+      "parentRecordedHead": "7641dd9a1b2ac1d81fae54d700a78b9b75101fad",
+      "parentCurrentHead": "7641dd9a1b2ac1d81fae54d700a78b9b75101fad",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "607b94f07",
+        "sha": "607b94f07c31637e893cacc6aa69cc3f183f93ff",
+        "iso": "2026-06-05T08:11:43-04:00",
+        "subject": "chore(control-orpc): burn down raw root type exports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/split-control-orpc-runtime-entrypoint",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/burn-down-control-orpc-raw-root-types",
+      "children": [
+        "codex/own-control-orpc-primitive-schemas"
+      ],
+      "depth": 452,
+      "head": "a74a923e094547bc8272964527899e47e3e587ce",
+      "parentRecordedHead": "607b94f07c31637e893cacc6aa69cc3f183f93ff",
+      "parentCurrentHead": "607b94f07c31637e893cacc6aa69cc3f183f93ff",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a74a923e0",
+        "sha": "a74a923e094547bc8272964527899e47e3e587ce",
+        "iso": "2026-06-05T08:32:04-04:00",
+        "subject": "chore(control-orpc): split runtime facade entrypoint"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/own-control-orpc-primitive-schemas",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/split-control-orpc-runtime-entrypoint",
+      "children": [
+        "codex/own-notification-dismissal-service-contract"
+      ],
+      "depth": 453,
+      "head": "1478ac29a1ea9e66ca13d87e5340106031285b24",
+      "parentRecordedHead": "a74a923e094547bc8272964527899e47e3e587ce",
+      "parentCurrentHead": "a74a923e094547bc8272964527899e47e3e587ce",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1478ac29a",
+        "sha": "1478ac29a1ea9e66ca13d87e5340106031285b24",
+        "iso": "2026-06-05T08:53:17-04:00",
+        "subject": "chore(control-orpc): own primitive service schemas"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/own-notification-dismissal-service-contract",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/own-control-orpc-primitive-schemas",
+      "children": [
+        "codex/own-production-choice-service-contract"
+      ],
+      "depth": 454,
+      "head": "87b82ecdfc3956d5be1c5dffd0254f14089ee1a6",
+      "parentRecordedHead": "1478ac29a1ea9e66ca13d87e5340106031285b24",
+      "parentCurrentHead": "1478ac29a1ea9e66ca13d87e5340106031285b24",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "87b82ecdf",
+        "sha": "87b82ecdfc3956d5be1c5dffd0254f14089ee1a6",
+        "iso": "2026-06-05T09:12:28-04:00",
+        "subject": "chore(control-orpc): own notification dismissal contract"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/own-production-choice-service-contract",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/own-notification-dismissal-service-contract",
+      "children": [
+        "codex/own-unit-target-action-service-contract"
+      ],
+      "depth": 455,
+      "head": "0c148bd1736535f4e1efc9a09cf1219371126295",
+      "parentRecordedHead": "87b82ecdfc3956d5be1c5dffd0254f14089ee1a6",
+      "parentCurrentHead": "87b82ecdfc3956d5be1c5dffd0254f14089ee1a6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0c148bd17",
+        "sha": "0c148bd1736535f4e1efc9a09cf1219371126295",
+        "iso": "2026-06-05T09:27:36-04:00",
+        "subject": "chore(control-orpc): own production choice contract"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/own-unit-target-action-service-contract",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/own-production-choice-service-contract",
+      "children": [
+        "codex/guard-control-orpc-contract-ownership"
+      ],
+      "depth": 456,
+      "head": "9c137afd5148a824488182f9ce9c1809b543dce1",
+      "parentRecordedHead": "0c148bd1736535f4e1efc9a09cf1219371126295",
+      "parentCurrentHead": "0c148bd1736535f4e1efc9a09cf1219371126295",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9c137afd5",
+        "sha": "9c137afd5148a824488182f9ce9c1809b543dce1",
+        "iso": "2026-06-05T09:46:49-04:00",
+        "subject": "chore(control-orpc): own unit target action contract"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/guard-control-orpc-contract-ownership",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/own-unit-target-action-service-contract",
+      "children": [
+        "codex/own-progression-choice-proof-policy"
+      ],
+      "depth": 457,
+      "head": "16074fb7213327c0f5eebb43707862252b2084c5",
+      "parentRecordedHead": "9c137afd5148a824488182f9ce9c1809b543dce1",
+      "parentCurrentHead": "9c137afd5148a824488182f9ce9c1809b543dce1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "16074fb72",
+        "sha": "16074fb7213327c0f5eebb43707862252b2084c5",
+        "iso": "2026-06-05T10:18:58-04:00",
+        "subject": "test(control-orpc): guard service contract ownership"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/own-progression-choice-proof-policy",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/guard-control-orpc-contract-ownership",
+      "children": [
+        "codex/add-progression-choice-decision-procedure"
+      ],
+      "depth": 458,
+      "head": "a8c2a352c2595c8db81c5f54b94acb5d787f10d6",
+      "parentRecordedHead": "16074fb7213327c0f5eebb43707862252b2084c5",
+      "parentCurrentHead": "16074fb7213327c0f5eebb43707862252b2084c5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a8c2a352c",
+        "sha": "a8c2a352c2595c8db81c5f54b94acb5d787f10d6",
+        "iso": "2026-06-05T11:02:10-04:00",
+        "subject": "chore(direct-control): own progression choice proof policy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-progression-choice-decision-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/own-progression-choice-proof-policy",
+      "children": [
+        "codex/guard-progression-choice-after-read"
+      ],
+      "depth": 459,
+      "head": "e09bf74457378d3abd301e41d30a4db66037a0a3",
+      "parentRecordedHead": "a8c2a352c2595c8db81c5f54b94acb5d787f10d6",
+      "parentCurrentHead": "a8c2a352c2595c8db81c5f54b94acb5d787f10d6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e09bf7445",
+        "sha": "e09bf74457378d3abd301e41d30a4db66037a0a3",
+        "iso": "2026-06-05T11:41:54-04:00",
+        "subject": "feat(control-orpc): add progression choice decision procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/guard-progression-choice-after-read",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-progression-choice-decision-procedure",
+      "children": [
+        "codex/extend-closeout-projection-policy"
+      ],
+      "depth": 460,
+      "head": "48524802ce364136f9e721abc6b69d089d1f29c6",
+      "parentRecordedHead": "e09bf74457378d3abd301e41d30a4db66037a0a3",
+      "parentCurrentHead": "e09bf74457378d3abd301e41d30a4db66037a0a3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "48524802c",
+        "sha": "48524802ce364136f9e721abc6b69d089d1f29c6",
+        "iso": "2026-06-05T12:06:38-04:00",
+        "subject": "fix(control-orpc): guard progression choice after-read failures"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extend-closeout-projection-policy",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/guard-progression-choice-after-read",
+      "children": [
+        "codex/own-turn-completion-proof-policy"
+      ],
+      "depth": 461,
+      "head": "e944afa27039144a61891ae12dcf5515a2b46861",
+      "parentRecordedHead": "48524802ce364136f9e721abc6b69d089d1f29c6",
+      "parentCurrentHead": "48524802ce364136f9e721abc6b69d089d1f29c6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e944afa27",
+        "sha": "e944afa27039144a61891ae12dcf5515a2b46861",
+        "iso": "2026-06-05T12:40:05-04:00",
+        "subject": "feat(control-orpc): extend closeout projection policy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/own-turn-completion-proof-policy",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extend-closeout-projection-policy",
+      "children": [
+        "codex/add-turn-completion-procedure"
+      ],
+      "depth": 462,
+      "head": "c9141ede4ca8a8bf1083a614cd2a68f84321ab8c",
+      "parentRecordedHead": "e944afa27039144a61891ae12dcf5515a2b46861",
+      "parentCurrentHead": "e944afa27039144a61891ae12dcf5515a2b46861",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c9141ede4",
+        "sha": "c9141ede4ca8a8bf1083a614cd2a68f84321ab8c",
+        "iso": "2026-06-05T12:54:30-04:00",
+        "subject": "feat(direct-control): own turn completion proof policy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-turn-completion-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/own-turn-completion-proof-policy",
+      "children": [
+        "codex/route-cli-end-turn-through-orpc"
+      ],
+      "depth": 463,
+      "head": "8229940368153a18a623d6da906efa360fca8776",
+      "parentRecordedHead": "c9141ede4ca8a8bf1083a614cd2a68f84321ab8c",
+      "parentCurrentHead": "c9141ede4ca8a8bf1083a614cd2a68f84321ab8c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "822994036",
+        "sha": "8229940368153a18a623d6da906efa360fca8776",
+        "iso": "2026-06-05T13:18:50-04:00",
+        "subject": "feat(control-orpc): add turn completion procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-cli-end-turn-through-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-turn-completion-procedure",
+      "children": [
+        "codex/route-cli-dismiss-notification-through-orpc"
+      ],
+      "depth": 464,
+      "head": "fe7658d59fbbcfc03030e987d0ac2b72d45a9a4d",
+      "parentRecordedHead": "8229940368153a18a623d6da906efa360fca8776",
+      "parentCurrentHead": "8229940368153a18a623d6da906efa360fca8776",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fe7658d59",
+        "sha": "fe7658d59fbbcfc03030e987d0ac2b72d45a9a4d",
+        "iso": "2026-06-05T13:44:25-04:00",
+        "subject": "feat(cli): route end-turn sends through control oRPC"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-cli-dismiss-notification-through-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-cli-end-turn-through-orpc",
+      "children": [
+        "codex/route-cli-unit-target-through-orpc"
+      ],
+      "depth": 465,
+      "head": "89954b8c694e4e362fd72b04f29379a1bf63b8a3",
+      "parentRecordedHead": "fe7658d59fbbcfc03030e987d0ac2b72d45a9a4d",
+      "parentCurrentHead": "fe7658d59fbbcfc03030e987d0ac2b72d45a9a4d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "89954b8c6",
+        "sha": "89954b8c694e4e362fd72b04f29379a1bf63b8a3",
+        "iso": "2026-06-05T13:57:54-04:00",
+        "subject": "feat(cli): route notification dismissal through control oRPC"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-cli-unit-target-through-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-cli-dismiss-notification-through-orpc",
+      "children": [
+        "codex/route-cli-build-production-through-orpc"
+      ],
+      "depth": 466,
+      "head": "c704c7930c8d7c91cfef9c628a7b127de61d859b",
+      "parentRecordedHead": "89954b8c694e4e362fd72b04f29379a1bf63b8a3",
+      "parentCurrentHead": "89954b8c694e4e362fd72b04f29379a1bf63b8a3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c704c7930",
+        "sha": "c704c7930c8d7c91cfef9c628a7b127de61d859b",
+        "iso": "2026-06-05T14:03:54-04:00",
+        "subject": "feat(cli): route unit target sends through control oRPC"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-cli-build-production-through-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-cli-unit-target-through-orpc",
+      "children": [
+        "codex/route-cli-diplomacy-response-through-orpc"
+      ],
+      "depth": 467,
+      "head": "991ff017461b1eb48ae2bcb35acbf57ed60f4ee4",
+      "parentRecordedHead": "c704c7930c8d7c91cfef9c628a7b127de61d859b",
+      "parentCurrentHead": "c704c7930c8d7c91cfef9c628a7b127de61d859b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "991ff0174",
+        "sha": "991ff017461b1eb48ae2bcb35acbf57ed60f4ee4",
+        "iso": "2026-06-05T14:08:17-04:00",
+        "subject": "feat(cli): route build-production sends through control oRPC"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-cli-diplomacy-response-through-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-cli-build-production-through-orpc",
+      "children": [
+        "codex/route-cli-narrative-choice-through-orpc"
+      ],
+      "depth": 468,
+      "head": "84c0ee248f122872cd764fafd782e35c454b2a95",
+      "parentRecordedHead": "991ff017461b1eb48ae2bcb35acbf57ed60f4ee4",
+      "parentCurrentHead": "991ff017461b1eb48ae2bcb35acbf57ed60f4ee4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "84c0ee248",
+        "sha": "84c0ee248f122872cd764fafd782e35c454b2a95",
+        "iso": "2026-06-05T14:18:42-04:00",
+        "subject": "feat(cli): route diplomacy responses through control oRPC"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-cli-narrative-choice-through-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-cli-diplomacy-response-through-orpc",
+      "children": [
+        "codex/rehome-progression-choice-domain"
+      ],
+      "depth": 469,
+      "head": "d26973924d6f229960c9f231790885969926fe66",
+      "parentRecordedHead": "84c0ee248f122872cd764fafd782e35c454b2a95",
+      "parentCurrentHead": "84c0ee248f122872cd764fafd782e35c454b2a95",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "d26973924",
+        "sha": "d26973924d6f229960c9f231790885969926fe66",
+        "iso": "2026-06-05T14:28:25-04:00",
+        "subject": "feat(cli): route narrative choices through control oRPC"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/rehome-progression-choice-domain",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-cli-narrative-choice-through-orpc",
+      "children": [
+        "codex/rehome-diplomacy-response-domain"
+      ],
+      "depth": 470,
+      "head": "85ad48c01c98182e89ee11556e8b9c216396d7ef",
+      "parentRecordedHead": "d26973924d6f229960c9f231790885969926fe66",
+      "parentCurrentHead": "d26973924d6f229960c9f231790885969926fe66",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "85ad48c01",
+        "sha": "85ad48c01c98182e89ee11556e8b9c216396d7ef",
+        "iso": "2026-06-05T14:44:50-04:00",
+        "subject": "feat(control-orpc): rehome progression choices"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/rehome-diplomacy-response-domain",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/rehome-progression-choice-domain",
+      "children": [
+        "codex/rehome-narrative-choice-domain"
+      ],
+      "depth": 471,
+      "head": "9eb4a382bdc1ba92b7198da854fcf1442b4d5467",
+      "parentRecordedHead": "85ad48c01c98182e89ee11556e8b9c216396d7ef",
+      "parentCurrentHead": "85ad48c01c98182e89ee11556e8b9c216396d7ef",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9eb4a382b",
+        "sha": "9eb4a382bdc1ba92b7198da854fcf1442b4d5467",
+        "iso": "2026-06-05T14:56:38-04:00",
+        "subject": "feat(control-orpc): rehome diplomacy responses"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/rehome-narrative-choice-domain",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/rehome-diplomacy-response-domain",
+      "children": [
+        "codex/remove-decisions-root-openspec-drift"
+      ],
+      "depth": 472,
+      "head": "e61455330f6366a778e6246f1410fa7835aebd55",
+      "parentRecordedHead": "9eb4a382bdc1ba92b7198da854fcf1442b4d5467",
+      "parentCurrentHead": "9eb4a382bdc1ba92b7198da854fcf1442b4d5467",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e61455330",
+        "sha": "e61455330f6366a778e6246f1410fa7835aebd55",
+        "iso": "2026-06-05T15:08:16-04:00",
+        "subject": "feat(control-orpc): rehome narrative choices"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-decisions-root-openspec-drift",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/rehome-narrative-choice-domain",
+      "children": [
+        "codex/allow-notification-dismissal-controller-ingress"
+      ],
+      "depth": 473,
+      "head": "7626255dbad86424d47edc2f30110aed3e45d2c2",
+      "parentRecordedHead": "e61455330f6366a778e6246f1410fa7835aebd55",
+      "parentCurrentHead": "e61455330f6366a778e6246f1410fa7835aebd55",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7626255db",
+        "sha": "7626255dbad86424d47edc2f30110aed3e45d2c2",
+        "iso": "2026-06-05T15:12:03-04:00",
+        "subject": "docs(control-orpc): remove decisions root drift"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/allow-notification-dismissal-controller-ingress",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-decisions-root-openspec-drift",
+      "children": [
+        "codex/narrow-population-placement-runtime-facade"
+      ],
+      "depth": 474,
+      "head": "1ef9c6edada6db4df1608a4f4dc66b6216d46df0",
+      "parentRecordedHead": "7626255dbad86424d47edc2f30110aed3e45d2c2",
+      "parentCurrentHead": "7626255dbad86424d47edc2f30110aed3e45d2c2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1ef9c6eda",
+        "sha": "1ef9c6edada6db4df1608a4f4dc66b6216d46df0",
+        "iso": "2026-06-05T15:24:30-04:00",
+        "subject": "feat(control-orpc): allow notification dismissal controller ingress"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/narrow-population-placement-runtime-facade",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/allow-notification-dismissal-controller-ingress",
+      "children": [
+        "codex/rebaseline-control-orpc-authority-docs"
+      ],
+      "depth": 475,
+      "head": "3adcb8606b550f6f574f2c61894ac5c920d43068",
+      "parentRecordedHead": "1ef9c6edada6db4df1608a4f4dc66b6216d46df0",
+      "parentCurrentHead": "1ef9c6edada6db4df1608a4f4dc66b6216d46df0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3adcb8606",
+        "sha": "3adcb8606b550f6f574f2c61894ac5c920d43068",
+        "iso": "2026-06-05T15:29:05-04:00",
+        "subject": "refactor(control-orpc): narrow population placement runtime facade"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/rebaseline-control-orpc-authority-docs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/narrow-population-placement-runtime-facade",
+      "children": [
+        "codex/allow-turn-completion-controller-ingress"
+      ],
+      "depth": 476,
+      "head": "01824b01c62f9f0c96c4d34d0e44f057ae523744",
+      "parentRecordedHead": "3adcb8606b550f6f574f2c61894ac5c920d43068",
+      "parentCurrentHead": "3adcb8606b550f6f574f2c61894ac5c920d43068",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "01824b01c",
+        "sha": "01824b01c62f9f0c96c4d34d0e44f057ae523744",
+        "iso": "2026-06-05T15:33:51-04:00",
+        "subject": "docs(control-orpc): rebaseline native authority records"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/allow-turn-completion-controller-ingress",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/rebaseline-control-orpc-authority-docs",
+      "children": [
+        "codex/promote-control-orpc-mutation-helper"
+      ],
+      "depth": 477,
+      "head": "fb4e5e55e89e8cad26d7fe8bde7652602dc71d60",
+      "parentRecordedHead": "01824b01c62f9f0c96c4d34d0e44f057ae523744",
+      "parentCurrentHead": "01824b01c62f9f0c96c4d34d0e44f057ae523744",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fb4e5e55e",
+        "sha": "fb4e5e55e89e8cad26d7fe8bde7652602dc71d60",
+        "iso": "2026-06-05T15:44:02-04:00",
+        "subject": "feat(control-orpc): allow turn completion controller ingress"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/promote-control-orpc-mutation-helper",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/allow-turn-completion-controller-ingress",
+      "children": [
+        "codex/allow-unit-target-controller-ingress"
+      ],
+      "depth": 478,
+      "head": "045fa6415b628166b9dd9e8adc8c5a110aadf99a",
+      "parentRecordedHead": "fb4e5e55e89e8cad26d7fe8bde7652602dc71d60",
+      "parentCurrentHead": "fb4e5e55e89e8cad26d7fe8bde7652602dc71d60",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "045fa6415",
+        "sha": "045fa6415b628166b9dd9e8adc8c5a110aadf99a",
+        "iso": "2026-06-05T15:56:55-04:00",
+        "subject": "refactor(control-orpc): promote mutation procedure helper"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/allow-unit-target-controller-ingress",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/promote-control-orpc-mutation-helper",
+      "children": [
+        "codex/allow-production-choice-controller-ingress"
+      ],
+      "depth": 479,
+      "head": "a09ec261069fc10e73f168a39067ceb736016dd8",
+      "parentRecordedHead": "045fa6415b628166b9dd9e8adc8c5a110aadf99a",
+      "parentCurrentHead": "045fa6415b628166b9dd9e8adc8c5a110aadf99a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a09ec2610",
+        "sha": "a09ec261069fc10e73f168a39067ceb736016dd8",
+        "iso": "2026-06-05T16:07:47-04:00",
+        "subject": "feat(control-orpc): allow unit target controller ingress"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/allow-production-choice-controller-ingress",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/allow-unit-target-controller-ingress",
+      "children": [
+        "codex/allow-population-placement-controller-ingress"
+      ],
+      "depth": 480,
+      "head": "fedd070da636256db08ddd6bbc719fa74764ccd0",
+      "parentRecordedHead": "a09ec261069fc10e73f168a39067ceb736016dd8",
+      "parentCurrentHead": "a09ec261069fc10e73f168a39067ceb736016dd8",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fedd070da",
+        "sha": "fedd070da636256db08ddd6bbc719fa74764ccd0",
+        "iso": "2026-06-05T16:11:49-04:00",
+        "subject": "feat(control-orpc): allow production choice controller ingress"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/allow-population-placement-controller-ingress",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/allow-production-choice-controller-ingress",
+      "children": [
+        "codex/allow-narrative-choice-controller-ingress"
+      ],
+      "depth": 481,
+      "head": "11040fd3c7649f266108a7f56b2f0ce40147fbfb",
+      "parentRecordedHead": "fedd070da636256db08ddd6bbc719fa74764ccd0",
+      "parentCurrentHead": "fedd070da636256db08ddd6bbc719fa74764ccd0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "11040fd3c",
+        "sha": "11040fd3c7649f266108a7f56b2f0ce40147fbfb",
+        "iso": "2026-06-05T16:19:14-04:00",
+        "subject": "feat(control-orpc): allow population placement controller ingress"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/allow-narrative-choice-controller-ingress",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/allow-population-placement-controller-ingress",
+      "children": [
+        "codex/allow-diplomacy-response-controller-ingress"
+      ],
+      "depth": 482,
+      "head": "54b33be9dd0ceede162de73234d0ef759108a055",
+      "parentRecordedHead": "11040fd3c7649f266108a7f56b2f0ce40147fbfb",
+      "parentCurrentHead": "11040fd3c7649f266108a7f56b2f0ce40147fbfb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "54b33be9d",
+        "sha": "54b33be9dd0ceede162de73234d0ef759108a055",
+        "iso": "2026-06-05T16:23:50-04:00",
+        "subject": "feat(control-orpc): allow narrative choice controller ingress"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/allow-diplomacy-response-controller-ingress",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/allow-narrative-choice-controller-ingress",
+      "children": [
+        "codex/own-progression-choice-local-player-evidence"
+      ],
+      "depth": 483,
+      "head": "dc19b42f85cd3d1887be25a668a40b8cb4adcd09",
+      "parentRecordedHead": "54b33be9dd0ceede162de73234d0ef759108a055",
+      "parentCurrentHead": "54b33be9dd0ceede162de73234d0ef759108a055",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "dc19b42f8",
+        "sha": "dc19b42f85cd3d1887be25a668a40b8cb4adcd09",
+        "iso": "2026-06-05T16:28:18-04:00",
+        "subject": "feat(control-orpc): allow diplomacy response controller ingress"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/own-progression-choice-local-player-evidence",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/allow-diplomacy-response-controller-ingress",
+      "children": [
+        "codex/allow-progression-choice-controller-ingress"
+      ],
+      "depth": 484,
+      "head": "6ee6614a03e0788dd0a3b838bb45fd0c32d264c4",
+      "parentRecordedHead": "dc19b42f85cd3d1887be25a668a40b8cb4adcd09",
+      "parentCurrentHead": "dc19b42f85cd3d1887be25a668a40b8cb4adcd09",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6ee6614a0",
+        "sha": "6ee6614a03e0788dd0a3b838bb45fd0c32d264c4",
+        "iso": "2026-06-05T16:39:32-04:00",
+        "subject": "fix(control-orpc): bind progression choices to local-player evidence"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/allow-progression-choice-controller-ingress",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/own-progression-choice-local-player-evidence",
+      "children": [
+        "codex/seed-controller-game-ui-bootstrap"
+      ],
+      "depth": 485,
+      "head": "fd853924c0731a8517f0b38f941e8f9159287459",
+      "parentRecordedHead": "6ee6614a03e0788dd0a3b838bb45fd0c32d264c4",
+      "parentCurrentHead": "6ee6614a03e0788dd0a3b838bb45fd0c32d264c4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fd853924c",
+        "sha": "fd853924c0731a8517f0b38f941e8f9159287459",
+        "iso": "2026-06-05T16:45:00-04:00",
+        "subject": "feat(control-orpc): allow progression choice controller ingress"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/seed-controller-game-ui-bootstrap",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/allow-progression-choice-controller-ingress",
+      "children": [
+        "codex/derive-game-ui-controller-proof"
+      ],
+      "depth": 486,
+      "head": "c34c951e8c6e729de7b408c0432683be76ea8746",
+      "parentRecordedHead": "fd853924c0731a8517f0b38f941e8f9159287459",
+      "parentCurrentHead": "fd853924c0731a8517f0b38f941e8f9159287459",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c34c951e8",
+        "sha": "c34c951e8c6e729de7b408c0432683be76ea8746",
+        "iso": "2026-06-05T17:11:13-04:00",
+        "subject": "feat(control-orpc): seed controller game UI bootstrap"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/derive-game-ui-controller-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/seed-controller-game-ui-bootstrap",
+      "children": [
+        "codex/add-game-ui-notification-dismissal-port"
+      ],
+      "depth": 487,
+      "head": "1a0e355664a5e85ad9805211884febf339642cda",
+      "parentRecordedHead": "c34c951e8c6e729de7b408c0432683be76ea8746",
+      "parentCurrentHead": "c34c951e8c6e729de7b408c0432683be76ea8746",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1a0e35566",
+        "sha": "1a0e355664a5e85ad9805211884febf339642cda",
+        "iso": "2026-06-05T17:22:34-04:00",
+        "subject": "feat(control-orpc): derive controller proof from context"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-game-ui-notification-dismissal-port",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/derive-game-ui-controller-proof",
+      "children": [
+        "codex/expose-game-ui-controller-capabilities"
+      ],
+      "depth": 488,
+      "head": "fc32ee701b006db19cb66f30294464f2cc60c862",
+      "parentRecordedHead": "1a0e355664a5e85ad9805211884febf339642cda",
+      "parentCurrentHead": "1a0e355664a5e85ad9805211884febf339642cda",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fc32ee701",
+        "sha": "fc32ee701b006db19cb66f30294464f2cc60c862",
+        "iso": "2026-06-05T17:37:56-04:00",
+        "subject": "feat(control-orpc): add game UI notification dismissal port"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/expose-game-ui-controller-capabilities",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-game-ui-notification-dismissal-port",
+      "children": [
+        "codex/add-game-ui-attention-read-port"
+      ],
+      "depth": 489,
+      "head": "8c09c067cc30191fce90e4100e18c0e41a5bd3bf",
+      "parentRecordedHead": "fc32ee701b006db19cb66f30294464f2cc60c862",
+      "parentCurrentHead": "fc32ee701b006db19cb66f30294464f2cc60c862",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8c09c067c",
+        "sha": "8c09c067cc30191fce90e4100e18c0e41a5bd3bf",
+        "iso": "2026-06-05T17:45:20-04:00",
+        "subject": "feat(control-orpc): expose controller capabilities in readiness"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-game-ui-attention-read-port",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/expose-game-ui-controller-capabilities",
+      "children": [
+        "codex/add-game-ui-turn-completion-port"
+      ],
+      "depth": 490,
+      "head": "cff79fe64da26371a9824daf154bd4fd93a2008e",
+      "parentRecordedHead": "8c09c067cc30191fce90e4100e18c0e41a5bd3bf",
+      "parentCurrentHead": "8c09c067cc30191fce90e4100e18c0e41a5bd3bf",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cff79fe64",
+        "sha": "cff79fe64da26371a9824daf154bd4fd93a2008e",
+        "iso": "2026-06-05T18:25:36-04:00",
+        "subject": "feat(control-orpc): add game UI attention adapter"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-game-ui-turn-completion-port",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-game-ui-attention-read-port",
+      "children": [
+        "codex/route-first-meet-orpc-send"
+      ],
+      "depth": 491,
+      "head": "ec1793b84d142e1570b82da2e6870588cb1610c8",
+      "parentRecordedHead": "cff79fe64da26371a9824daf154bd4fd93a2008e",
+      "parentCurrentHead": "cff79fe64da26371a9824daf154bd4fd93a2008e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ec1793b84",
+        "sha": "ec1793b84d142e1570b82da2e6870588cb1610c8",
+        "iso": "2026-06-05T22:44:04-04:00",
+        "subject": "feat(control-orpc): add unit upgrade and resettle procedures"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-first-meet-orpc-send",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-game-ui-turn-completion-port",
+      "children": [
+        "codex/route-progression-target-orpc-send"
+      ],
+      "depth": 492,
+      "head": "4a5e8e6f5316950c9d2ed0857bd0e0cd206aa5a2",
+      "parentRecordedHead": "ec1793b84d142e1570b82da2e6870588cb1610c8",
+      "parentCurrentHead": "ec1793b84d142e1570b82da2e6870588cb1610c8",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4a5e8e6f5",
+        "sha": "4a5e8e6f5316950c9d2ed0857bd0e0cd206aa5a2",
+        "iso": "2026-06-05T22:58:11-04:00",
+        "subject": "feat(cli): route first-meet sends through orpc"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-progression-target-orpc-send",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-first-meet-orpc-send",
+      "children": [
+        "codex/route-government-choice-orpc-send"
+      ],
+      "depth": 493,
+      "head": "0fc06e776555a7d1e3eec48ac93a8aa4698094f2",
+      "parentRecordedHead": "4a5e8e6f5316950c9d2ed0857bd0e0cd206aa5a2",
+      "parentCurrentHead": "4a5e8e6f5316950c9d2ed0857bd0e0cd206aa5a2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0fc06e776",
+        "sha": "0fc06e776555a7d1e3eec48ac93a8aa4698094f2",
+        "iso": "2026-06-05T23:23:37-04:00",
+        "subject": "feat(cli): route progression target sends through orpc"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-government-choice-orpc-send",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-progression-target-orpc-send",
+      "children": [
+        "codex/route-progression-player-choice-orpc-send"
+      ],
+      "depth": 494,
+      "head": "8ea68becb97ebf61fdba56444cf0cca1dff55e41",
+      "parentRecordedHead": "0fc06e776555a7d1e3eec48ac93a8aa4698094f2",
+      "parentCurrentHead": "0fc06e776555a7d1e3eec48ac93a8aa4698094f2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8ea68becb",
+        "sha": "8ea68becb97ebf61fdba56444cf0cca1dff55e41",
+        "iso": "2026-06-05T23:43:57-04:00",
+        "subject": "feat(cli): route government choice sends through orpc"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-progression-player-choice-orpc-send",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-government-choice-orpc-send",
+      "children": [
+        "codex/route-town-focus-orpc-send"
+      ],
+      "depth": 495,
+      "head": "1e01bc33737b6d06c5f7ebedbe197cfa4f0e7524",
+      "parentRecordedHead": "8ea68becb97ebf61fdba56444cf0cca1dff55e41",
+      "parentCurrentHead": "8ea68becb97ebf61fdba56444cf0cca1dff55e41",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1e01bc337",
+        "sha": "1e01bc33737b6d06c5f7ebedbe197cfa4f0e7524",
+        "iso": "2026-06-06T00:18:00-04:00",
+        "subject": "feat(cli): route progression player choices through orpc"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-town-focus-orpc-send",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-progression-player-choice-orpc-send",
+      "children": [
+        "codex/add-game-ui-town-focus-port"
+      ],
+      "depth": 496,
+      "head": "cfab00166e8f8f11ad9ca5ad9b1f3ee6ccbd5d0d",
+      "parentRecordedHead": "1e01bc33737b6d06c5f7ebedbe197cfa4f0e7524",
+      "parentCurrentHead": "1e01bc33737b6d06c5f7ebedbe197cfa4f0e7524",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cfab00166",
+        "sha": "cfab00166e8f8f11ad9ca5ad9b1f3ee6ccbd5d0d",
+        "iso": "2026-06-06T00:37:45-04:00",
+        "subject": "feat(cli): route town focus sends through orpc"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-game-ui-town-focus-port",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-town-focus-orpc-send",
+      "children": [
+        "codex/add-game-ui-progression-runtime-ports"
+      ],
+      "depth": 497,
+      "head": "e1fac756049589c65fe1fd4e48660acf2c2a96cd",
+      "parentRecordedHead": "cfab00166e8f8f11ad9ca5ad9b1f3ee6ccbd5d0d",
+      "parentCurrentHead": "cfab00166e8f8f11ad9ca5ad9b1f3ee6ccbd5d0d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e1fac7560",
+        "sha": "e1fac756049589c65fe1fd4e48660acf2c2a96cd",
+        "iso": "2026-06-06T00:56:58-04:00",
+        "subject": "feat(control-orpc): add game-ui town focus port"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-game-ui-progression-runtime-ports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-game-ui-town-focus-port",
+      "children": [
+        "codex/source-first-meet-local-player"
+      ],
+      "depth": 498,
+      "head": "38d2f5f7d825aadd58f9ea3e974029efbac63e17",
+      "parentRecordedHead": "e1fac756049589c65fe1fd4e48660acf2c2a96cd",
+      "parentCurrentHead": "e1fac756049589c65fe1fd4e48660acf2c2a96cd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "38d2f5f7d",
+        "sha": "38d2f5f7d825aadd58f9ea3e974029efbac63e17",
+        "iso": "2026-06-06T01:23:43-04:00",
+        "subject": "feat(control-orpc): add game-ui progression ports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/source-first-meet-local-player",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-game-ui-progression-runtime-ports",
+      "children": [
+        "codex/remove-control-orpc-schema-exports"
+      ],
+      "depth": 499,
+      "head": "82bda43a05b53ac706ee2c3d440567fe548b2bed",
+      "parentRecordedHead": "38d2f5f7d825aadd58f9ea3e974029efbac63e17",
+      "parentCurrentHead": "38d2f5f7d825aadd58f9ea3e974029efbac63e17",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "82bda43a0",
+        "sha": "82bda43a05b53ac706ee2c3d440567fe548b2bed",
+        "iso": "2026-06-06T01:38:59-04:00",
+        "subject": "fix(control-orpc): source first-meet player from local evidence"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-control-orpc-schema-exports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/source-first-meet-local-player",
+      "children": [
+        "codex/remove-approval-vocabulary"
+      ],
+      "depth": 500,
+      "head": "a4b0e8ea8ad0a4c00c38e5f6821209680acb3012",
+      "parentRecordedHead": "82bda43a05b53ac706ee2c3d440567fe548b2bed",
+      "parentCurrentHead": "82bda43a05b53ac706ee2c3d440567fe548b2bed",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a4b0e8ea8",
+        "sha": "a4b0e8ea8ad0a4c00c38e5f6821209680acb3012",
+        "iso": "2026-06-06T01:49:55-04:00",
+        "subject": "fix(control-orpc): stop exporting contract schemas"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-approval-vocabulary",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-control-orpc-schema-exports",
+      "children": [
+        "codex/own-game-ui-notification-adapter"
+      ],
+      "depth": 501,
+      "head": "f2ed3fe1935b9e25373a94bb6eb06bbd75dd3b5e",
+      "parentRecordedHead": "a4b0e8ea8ad0a4c00c38e5f6821209680acb3012",
+      "parentCurrentHead": "a4b0e8ea8ad0a4c00c38e5f6821209680acb3012",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f2ed3fe19",
+        "sha": "f2ed3fe1935b9e25373a94bb6eb06bbd75dd3b5e",
+        "iso": "2026-06-06T01:59:49-04:00",
+        "subject": "fix(control-orpc): remove approval wording from strategy output"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/own-game-ui-notification-adapter",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-approval-vocabulary",
+      "children": [
+        "codex/keep-contract-schemas-private"
+      ],
+      "depth": 502,
+      "head": "3c84e7455bc15999ac7f05f2309b51b42e85bd28",
+      "parentRecordedHead": "f2ed3fe1935b9e25373a94bb6eb06bbd75dd3b5e",
+      "parentCurrentHead": "f2ed3fe1935b9e25373a94bb6eb06bbd75dd3b5e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3c84e7455",
+        "sha": "3c84e7455bc15999ac7f05f2309b51b42e85bd28",
+        "iso": "2026-06-06T02:31:47-04:00",
+        "subject": "refactor(control-orpc): own game-ui notification dismissal"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/keep-contract-schemas-private",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/own-game-ui-notification-adapter",
+      "children": [
+        "codex/add-game-ui-government-runtime"
+      ],
+      "depth": 503,
+      "head": "11dd7688ca6894ad6d3c7217d7bbcc68671bd5f3",
+      "parentRecordedHead": "3c84e7455bc15999ac7f05f2309b51b42e85bd28",
+      "parentCurrentHead": "3c84e7455bc15999ac7f05f2309b51b42e85bd28",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "11dd7688c",
+        "sha": "11dd7688ca6894ad6d3c7217d7bbcc68671bd5f3",
+        "iso": "2026-06-06T02:38:25-04:00",
+        "subject": "fix(control-orpc): keep contract schemas private"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-game-ui-government-runtime",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/keep-contract-schemas-private",
+      "children": [
+        "codex/add-game-ui-first-meet-runtime"
+      ],
+      "depth": 504,
+      "head": "dfc181d7db8c6e6a7555ac949694a79072dfc65f",
+      "parentRecordedHead": "11dd7688ca6894ad6d3c7217d7bbcc68671bd5f3",
+      "parentCurrentHead": "11dd7688ca6894ad6d3c7217d7bbcc68671bd5f3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "dfc181d7d",
+        "sha": "dfc181d7db8c6e6a7555ac949694a79072dfc65f",
+        "iso": "2026-06-06T02:55:39-04:00",
+        "subject": "feat(control-orpc): add game-ui government runtime"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-game-ui-first-meet-runtime",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-game-ui-government-runtime",
+      "children": [
+        "codex/add-game-ui-unit-command-runtime"
+      ],
+      "depth": 505,
+      "head": "e4013a4e3ddfd93bae7a83c5444d8170c2016186",
+      "parentRecordedHead": "dfc181d7db8c6e6a7555ac949694a79072dfc65f",
+      "parentCurrentHead": "dfc181d7db8c6e6a7555ac949694a79072dfc65f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e4013a4e3",
+        "sha": "e4013a4e3ddfd93bae7a83c5444d8170c2016186",
+        "iso": "2026-06-06T03:10:20-04:00",
+        "subject": "feat(control-orpc): add game-ui first meet runtime"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-game-ui-unit-command-runtime",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-game-ui-first-meet-runtime",
+      "children": [
+        "codex/close-read-wrapper-burndown"
+      ],
+      "depth": 506,
+      "head": "88c6f68fe1aef298300b17ea8787f8028f8ab8aa",
+      "parentRecordedHead": "e4013a4e3ddfd93bae7a83c5444d8170c2016186",
+      "parentCurrentHead": "e4013a4e3ddfd93bae7a83c5444d8170c2016186",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "88c6f68fe",
+        "sha": "88c6f68fe1aef298300b17ea8787f8028f8ab8aa",
+        "iso": "2026-06-06T03:33:54-04:00",
+        "subject": "feat(control-orpc): add game-ui unit command runtime"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/close-read-wrapper-burndown",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-game-ui-unit-command-runtime",
+      "children": [
+        "codex/narrow-game-ui-notification-types"
+      ],
+      "depth": 507,
+      "head": "f5e5efe1f6d98e3533a1edb956748380ad73ed72",
+      "parentRecordedHead": "88c6f68fe1aef298300b17ea8787f8028f8ab8aa",
+      "parentCurrentHead": "88c6f68fe1aef298300b17ea8787f8028f8ab8aa",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f5e5efe1f",
+        "sha": "f5e5efe1f6d98e3533a1edb956748380ad73ed72",
+        "iso": "2026-06-06T03:38:22-04:00",
+        "subject": "docs(control-orpc): close completed ledger rows"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/narrow-game-ui-notification-types",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/close-read-wrapper-burndown",
+      "children": [
+        "codex/add-game-ui-ready-city-attention"
+      ],
+      "depth": 508,
+      "head": "3a89610c06219a5e5ac55c3074309418f683e08d",
+      "parentRecordedHead": "f5e5efe1f6d98e3533a1edb956748380ad73ed72",
+      "parentCurrentHead": "f5e5efe1f6d98e3533a1edb956748380ad73ed72",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3a89610c0",
+        "sha": "3a89610c06219a5e5ac55c3074309418f683e08d",
+        "iso": "2026-06-06T03:42:05-04:00",
+        "subject": "fix(control-orpc): narrow game-ui notification type imports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-game-ui-ready-city-attention",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/narrow-game-ui-notification-types",
+      "children": [
+        "codex/add-world-current-service"
+      ],
+      "depth": 509,
+      "head": "c64787a4e8fc6bbb3320737d040ee3326e35a29a",
+      "parentRecordedHead": "3a89610c06219a5e5ac55c3074309418f683e08d",
+      "parentCurrentHead": "3a89610c06219a5e5ac55c3074309418f683e08d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c64787a4e",
+        "sha": "c64787a4e8fc6bbb3320737d040ee3326e35a29a",
+        "iso": "2026-06-06T03:59:29-04:00",
+        "subject": "feat(control-orpc): add game-ui ready city attention"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-world-current-service",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-game-ui-ready-city-attention",
+      "children": [
+        "codex/route-game-map-summary-orpc"
+      ],
+      "depth": 510,
+      "head": "27ddd686d72874d0c3eccba43b79b2081f4a84c7",
+      "parentRecordedHead": "c64787a4e8fc6bbb3320737d040ee3326e35a29a",
+      "parentCurrentHead": "c64787a4e8fc6bbb3320737d040ee3326e35a29a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "27ddd686d",
+        "sha": "27ddd686d72874d0c3eccba43b79b2081f4a84c7",
+        "iso": "2026-06-06T04:23:27-04:00",
+        "subject": "feat(control-orpc): add world current service"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-game-map-summary-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-world-current-service",
+      "children": [
+        "codex/route-game-map-plot-grid-orpc"
+      ],
+      "depth": 511,
+      "head": "2033310842f88fddf68fee5c05fd7cca7babc925",
+      "parentRecordedHead": "27ddd686d72874d0c3eccba43b79b2081f4a84c7",
+      "parentCurrentHead": "27ddd686d72874d0c3eccba43b79b2081f4a84c7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "203331084",
+        "sha": "2033310842f88fddf68fee5c05fd7cca7babc925",
+        "iso": "2026-06-06T04:31:44-04:00",
+        "subject": "feat(cli): route map summary through world current"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-game-map-plot-grid-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-game-map-summary-orpc",
+      "children": [
+        "codex/add-game-ui-world-map-reads"
+      ],
+      "depth": 512,
+      "head": "ca204fc1c27ea4ac78d397113737f6526365a23c",
+      "parentRecordedHead": "2033310842f88fddf68fee5c05fd7cca7babc925",
+      "parentCurrentHead": "2033310842f88fddf68fee5c05fd7cca7babc925",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ca204fc1c",
+        "sha": "ca204fc1c27ea4ac78d397113737f6526365a23c",
+        "iso": "2026-06-06T04:49:33-04:00",
+        "subject": "feat(cli): route map plot and grid through world service"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-game-ui-world-map-reads",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-game-map-plot-grid-orpc",
+      "children": [
+        "codex/route-front-summary-orpc"
+      ],
+      "depth": 513,
+      "head": "0ea42cfa112a37fbc96272e47796b5a7f126fb78",
+      "parentRecordedHead": "ca204fc1c27ea4ac78d397113737f6526365a23c",
+      "parentCurrentHead": "ca204fc1c27ea4ac78d397113737f6526365a23c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0ea42cfa1",
+        "sha": "0ea42cfa112a37fbc96272e47796b5a7f126fb78",
+        "iso": "2026-06-06T05:02:17-04:00",
+        "subject": "feat(control-orpc): add game-ui world map reads"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-front-summary-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-game-ui-world-map-reads",
+      "children": [
+        "codex/route-priorities-attention-orpc"
+      ],
+      "depth": 514,
+      "head": "dc46d64034bbe09e5197666cc31fbb6450d37931",
+      "parentRecordedHead": "0ea42cfa112a37fbc96272e47796b5a7f126fb78",
+      "parentCurrentHead": "0ea42cfa112a37fbc96272e47796b5a7f126fb78",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "dc46d6403",
+        "sha": "dc46d64034bbe09e5197666cc31fbb6450d37931",
+        "iso": "2026-06-06T05:25:54-04:00",
+        "subject": "feat(cli): route front summary through strategy service"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-priorities-attention-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-front-summary-orpc",
+      "children": [
+        "codex/route-civilian-triage-orpc"
+      ],
+      "depth": 515,
+      "head": "13d8e237f6dea359be504d66189570e4339bc35f",
+      "parentRecordedHead": "dc46d64034bbe09e5197666cc31fbb6450d37931",
+      "parentCurrentHead": "dc46d64034bbe09e5197666cc31fbb6450d37931",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "13d8e237f",
+        "sha": "13d8e237f6dea359be504d66189570e4339bc35f",
+        "iso": "2026-06-06T05:48:58-04:00",
+        "subject": "feat(cli): route priorities through attention service"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-civilian-triage-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-priorities-attention-orpc",
+      "children": [
+        "codex/route-formation-snapshot-orpc"
+      ],
+      "depth": 516,
+      "head": "965a5b85ed34ab75956ac1728eecf65b0d40da6e",
+      "parentRecordedHead": "13d8e237f6dea359be504d66189570e4339bc35f",
+      "parentCurrentHead": "13d8e237f6dea359be504d66189570e4339bc35f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "965a5b85e",
+        "sha": "965a5b85ed34ab75956ac1728eecf65b0d40da6e",
+        "iso": "2026-06-06T06:03:42-04:00",
+        "subject": "feat(cli): route civilian triage through strategy service"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-formation-snapshot-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-civilian-triage-orpc",
+      "children": [
+        "codex/route-notification-queue-orpc"
+      ],
+      "depth": 517,
+      "head": "78b940caa523b4c27d181821cd3f594bfd372c83",
+      "parentRecordedHead": "965a5b85ed34ab75956ac1728eecf65b0d40da6e",
+      "parentCurrentHead": "965a5b85ed34ab75956ac1728eecf65b0d40da6e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "78b940caa",
+        "sha": "78b940caa523b4c27d181821cd3f594bfd372c83",
+        "iso": "2026-06-06T06:16:03-04:00",
+        "subject": "feat(cli): route formation snapshot through strategy service"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-notification-queue-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-formation-snapshot-orpc",
+      "children": [
+        "codex/route-advisor-warning-orpc"
+      ],
+      "depth": 518,
+      "head": "18230fbdf1430f3884bcb54120e008b75db5da8c",
+      "parentRecordedHead": "78b940caa523b4c27d181821cd3f594bfd372c83",
+      "parentCurrentHead": "78b940caa523b4c27d181821cd3f594bfd372c83",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "18230fbdf",
+        "sha": "18230fbdf1430f3884bcb54120e008b75db5da8c",
+        "iso": "2026-06-06T06:38:09-04:00",
+        "subject": "feat(cli): route notification queue through notifications service"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-advisor-warning-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-notification-queue-orpc",
+      "children": [
+        "codex/route-progress-dashboard-orpc"
+      ],
+      "depth": 519,
+      "head": "44df6d641e04df1e029c7c74e3f7f15d487c0754",
+      "parentRecordedHead": "18230fbdf1430f3884bcb54120e008b75db5da8c",
+      "parentCurrentHead": "18230fbdf1430f3884bcb54120e008b75db5da8c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "44df6d641",
+        "sha": "44df6d641e04df1e029c7c74e3f7f15d487c0754",
+        "iso": "2026-06-06T06:56:22-04:00",
+        "subject": "feat(cli): route advisor warning through notifications service"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-progress-dashboard-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-advisor-warning-orpc",
+      "children": [
+        "codex/route-traditions-orpc"
+      ],
+      "depth": 520,
+      "head": "c654d984cc27f7998451c32858eb9773e85a725b",
+      "parentRecordedHead": "44df6d641e04df1e029c7c74e3f7f15d487c0754",
+      "parentCurrentHead": "44df6d641e04df1e029c7c74e3f7f15d487c0754",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c654d984c",
+        "sha": "c654d984cc27f7998451c32858eb9773e85a725b",
+        "iso": "2026-06-06T07:08:27-04:00",
+        "subject": "feat(cli): route progress dashboard through progression service"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-traditions-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-progress-dashboard-orpc",
+      "children": [
+        "codex/route-strategy-tactical-reads-orpc"
+      ],
+      "depth": 521,
+      "head": "5c0e986efb577e5ddba49a6c10b548cc099d6f9e",
+      "parentRecordedHead": "c654d984cc27f7998451c32858eb9773e85a725b",
+      "parentCurrentHead": "c654d984cc27f7998451c32858eb9773e85a725b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5c0e986ef",
+        "sha": "5c0e986efb577e5ddba49a6c10b548cc099d6f9e",
+        "iso": "2026-06-06T07:20:36-04:00",
+        "subject": "feat(cli): route traditions through progression service"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-strategy-tactical-reads-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-traditions-orpc",
+      "children": [
+        "codex/route-battlefield-scan-orpc"
+      ],
+      "depth": 522,
+      "head": "6dc06e3b8e7a98e95f208989eb225881b83770d2",
+      "parentRecordedHead": "5c0e986efb577e5ddba49a6c10b548cc099d6f9e",
+      "parentCurrentHead": "5c0e986efb577e5ddba49a6c10b548cc099d6f9e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6dc06e3b8",
+        "sha": "6dc06e3b8e7a98e95f208989eb225881b83770d2",
+        "iso": "2026-06-06T07:34:09-04:00",
+        "subject": "feat(cli): route strategy tactical reads through orpc"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/route-battlefield-scan-orpc",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-strategy-tactical-reads-orpc",
+      "children": [
+        "codex/remove-government-choice-player-input"
+      ],
+      "depth": 523,
+      "head": "9a39e4254b423199b12f6c5846062b89da8193e9",
+      "parentRecordedHead": "6dc06e3b8e7a98e95f208989eb225881b83770d2",
+      "parentCurrentHead": "6dc06e3b8e7a98e95f208989eb225881b83770d2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9a39e4254",
+        "sha": "9a39e4254b423199b12f6c5846062b89da8193e9",
+        "iso": "2026-06-06T07:43:35-04:00",
+        "subject": "feat(cli): route battlefield scan through strategy service"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-government-choice-player-input",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/route-battlefield-scan-orpc",
+      "children": [
+        "codex/remove-progression-target-player-input"
+      ],
+      "depth": 524,
+      "head": "fd049173a71952fd029c4a6c2963ce24c7b0a3e1",
+      "parentRecordedHead": "9a39e4254b423199b12f6c5846062b89da8193e9",
+      "parentCurrentHead": "9a39e4254b423199b12f6c5846062b89da8193e9",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fd049173a",
+        "sha": "fd049173a71952fd029c4a6c2963ce24c7b0a3e1",
+        "iso": "2026-06-06T07:56:09-04:00",
+        "subject": "fix(control-orpc): remove government choice player input"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-progression-target-player-input",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-government-choice-player-input",
+      "children": [
+        "codex/remove-progression-choice-player-input"
+      ],
+      "depth": 525,
+      "head": "af7cd33126581a7854f83f42493150c111910c4a",
+      "parentRecordedHead": "fd049173a71952fd029c4a6c2963ce24c7b0a3e1",
+      "parentCurrentHead": "fd049173a71952fd029c4a6c2963ce24c7b0a3e1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "af7cd3312",
+        "sha": "af7cd33126581a7854f83f42493150c111910c4a",
+        "iso": "2026-06-06T08:06:09-04:00",
+        "subject": "fix(control-orpc): remove progression target player input"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-progression-choice-player-input",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-progression-target-player-input",
+      "children": [
+        "codex/remove-narrative-diplomacy-player-input"
+      ],
+      "depth": 526,
+      "head": "4ed72a8fbce474d99d06ac25f96814d3d480954d",
+      "parentRecordedHead": "af7cd33126581a7854f83f42493150c111910c4a",
+      "parentCurrentHead": "af7cd33126581a7854f83f42493150c111910c4a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4ed72a8fb",
+        "sha": "4ed72a8fbce474d99d06ac25f96814d3d480954d",
+        "iso": "2026-06-06T08:20:57-04:00",
+        "subject": "fix(control-orpc): remove progression choice player input"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-narrative-diplomacy-player-input",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-progression-choice-player-input",
+      "children": [
+        "codex/remove-population-placement-player-input"
+      ],
+      "depth": 527,
+      "head": "493560bee1bc7f36c183cb7de447ee728d6d04dc",
+      "parentRecordedHead": "4ed72a8fbce474d99d06ac25f96814d3d480954d",
+      "parentCurrentHead": "4ed72a8fbce474d99d06ac25f96814d3d480954d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "493560bee",
+        "sha": "493560bee1bc7f36c183cb7de447ee728d6d04dc",
+        "iso": "2026-06-06T08:40:33-04:00",
+        "subject": "fix(control-orpc): remove narrative diplomacy player input"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-population-placement-player-input",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-narrative-diplomacy-player-input",
+      "children": [
+        "codex/remove-progression-player-send-hint-player-id"
+      ],
+      "depth": 528,
+      "head": "ecdebf916f54baf0ad1f11b8250fe94003529647",
+      "parentRecordedHead": "493560bee1bc7f36c183cb7de447ee728d6d04dc",
+      "parentCurrentHead": "493560bee1bc7f36c183cb7de447ee728d6d04dc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ecdebf916",
+        "sha": "ecdebf916f54baf0ad1f11b8250fe94003529647",
+        "iso": "2026-06-06T08:57:03-04:00",
+        "subject": "fix(control-orpc): remove population placement player input"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-progression-player-send-hint-player-id",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-population-placement-player-input",
+      "children": [
+        "codex/simplify-notification-action-hints"
+      ],
+      "depth": 529,
+      "head": "87674635c2bc53994a02a913bf9f1221bc4756ed",
+      "parentRecordedHead": "ecdebf916f54baf0ad1f11b8250fe94003529647",
+      "parentCurrentHead": "ecdebf916f54baf0ad1f11b8250fe94003529647",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "87674635c",
+        "sha": "87674635c2bc53994a02a913bf9f1221bc4756ed",
+        "iso": "2026-06-06T14:13:41-04:00",
+        "subject": "fix(control): simplify progression action hints"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-notification-action-hints",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-progression-player-send-hint-player-id",
+      "children": [
+        "codex/simplify-notification-queue-next-actions"
+      ],
+      "depth": 530,
+      "head": "bb755804f18e0a7553f5d18e4c3c0f243c7c6e02",
+      "parentRecordedHead": "87674635c2bc53994a02a913bf9f1221bc4756ed",
+      "parentCurrentHead": "87674635c2bc53994a02a913bf9f1221bc4756ed",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bb755804f",
+        "sha": "bb755804f18e0a7553f5d18e4c3c0f243c7c6e02",
+        "iso": "2026-06-06T14:20:54-04:00",
+        "subject": "fix(control): simplify notification action hints"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-notification-queue-next-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-notification-action-hints",
+      "children": [
+        "codex/simplify-traditions-omitted-metadata"
+      ],
+      "depth": 531,
+      "head": "cc6c58dc29ac6d8acb139f30d80f17462ffaf118",
+      "parentRecordedHead": "bb755804f18e0a7553f5d18e4c3c0f243c7c6e02",
+      "parentCurrentHead": "bb755804f18e0a7553f5d18e4c3c0f243c7c6e02",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cc6c58dc2",
+        "sha": "cc6c58dc29ac6d8acb139f30d80f17462ffaf118",
+        "iso": "2026-06-06T14:28:56-04:00",
+        "subject": "fix(cli): simplify notification queue next actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-traditions-omitted-metadata",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-notification-queue-next-actions",
+      "children": [
+        "codex/simplify-civilian-route-next-actions"
+      ],
+      "depth": 532,
+      "head": "179f3f11c0b1fd55a194dd9c02728028d8d3bc9b",
+      "parentRecordedHead": "cc6c58dc29ac6d8acb139f30d80f17462ffaf118",
+      "parentCurrentHead": "cc6c58dc29ac6d8acb139f30d80f17462ffaf118",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "179f3f11c",
+        "sha": "179f3f11c0b1fd55a194dd9c02728028d8d3bc9b",
+        "iso": "2026-06-06T14:33:58-04:00",
+        "subject": "fix(control): simplify traditions omitted metadata"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-civilian-route-next-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-traditions-omitted-metadata",
+      "children": [
+        "codex/simplify-formation-next-actions"
+      ],
+      "depth": 533,
+      "head": "2959ee2bd324ac2d544b2b2b78aecb9920135fb1",
+      "parentRecordedHead": "179f3f11c0b1fd55a194dd9c02728028d8d3bc9b",
+      "parentCurrentHead": "179f3f11c0b1fd55a194dd9c02728028d8d3bc9b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2959ee2bd",
+        "sha": "2959ee2bd324ac2d544b2b2b78aecb9920135fb1",
+        "iso": "2026-06-06T14:39:05-04:00",
+        "subject": "fix(cli): simplify civilian route next actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-formation-next-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-civilian-route-next-actions",
+      "children": [
+        "codex/simplify-front-summary-next-actions"
+      ],
+      "depth": 534,
+      "head": "88a273bafa307e3fcb8b3c2b8dff8a686a31555d",
+      "parentRecordedHead": "2959ee2bd324ac2d544b2b2b78aecb9920135fb1",
+      "parentCurrentHead": "2959ee2bd324ac2d544b2b2b78aecb9920135fb1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "88a273baf",
+        "sha": "88a273bafa307e3fcb8b3c2b8dff8a686a31555d",
+        "iso": "2026-06-06T14:42:33-04:00",
+        "subject": "fix(cli): simplify formation next actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-front-summary-next-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-formation-next-actions",
+      "children": [
+        "codex/simplify-unit-move-preview-actions"
+      ],
+      "depth": 535,
+      "head": "31fff92ffeeb5065b6444177b89b784a6b99c56a",
+      "parentRecordedHead": "88a273bafa307e3fcb8b3c2b8dff8a686a31555d",
+      "parentCurrentHead": "88a273bafa307e3fcb8b3c2b8dff8a686a31555d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "31fff92ff",
+        "sha": "31fff92ffeeb5065b6444177b89b784a6b99c56a",
+        "iso": "2026-06-06T14:47:48-04:00",
+        "subject": "fix(cli): simplify front summary next actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-unit-move-preview-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-front-summary-next-actions",
+      "children": [
+        "codex/simplify-compact-priority-actions"
+      ],
+      "depth": 536,
+      "head": "8eb2d5ccd58fd8640a1f02c8a2c09ed27a2f902b",
+      "parentRecordedHead": "31fff92ffeeb5065b6444177b89b784a6b99c56a",
+      "parentCurrentHead": "31fff92ffeeb5065b6444177b89b784a6b99c56a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8eb2d5ccd",
+        "sha": "8eb2d5ccd58fd8640a1f02c8a2c09ed27a2f902b",
+        "iso": "2026-06-06T14:52:41-04:00",
+        "subject": "fix(cli): simplify unit move preview actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-compact-priority-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-unit-move-preview-actions",
+      "children": [
+        "codex/simplify-traditions-compact-actions"
+      ],
+      "depth": 537,
+      "head": "15013cb8f49ef7f8598f3ee612d9d1cd8260f8af",
+      "parentRecordedHead": "8eb2d5ccd58fd8640a1f02c8a2c09ed27a2f902b",
+      "parentCurrentHead": "8eb2d5ccd58fd8640a1f02c8a2c09ed27a2f902b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "15013cb8f",
+        "sha": "15013cb8f49ef7f8598f3ee612d9d1cd8260f8af",
+        "iso": "2026-06-06T15:03:23-04:00",
+        "subject": "fix(cli): simplify compact priority actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-traditions-compact-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-compact-priority-actions",
+      "children": [
+        "codex/simplify-ready-city-compact-actions"
+      ],
+      "depth": 538,
+      "head": "e142ca6cb39d90c33db6e1965a7bf0e4b979d4ae",
+      "parentRecordedHead": "15013cb8f49ef7f8598f3ee612d9d1cd8260f8af",
+      "parentCurrentHead": "15013cb8f49ef7f8598f3ee612d9d1cd8260f8af",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e142ca6cb",
+        "sha": "e142ca6cb39d90c33db6e1965a7bf0e4b979d4ae",
+        "iso": "2026-06-06T15:57:29-04:00",
+        "subject": "fix(cli): simplify compact traditions actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-ready-city-compact-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-traditions-compact-actions",
+      "children": [
+        "codex/simplify-progression-choice-option-actions"
+      ],
+      "depth": 539,
+      "head": "73f6cd0a2212f4cc31a6b05a3bd5e5782db8ffba",
+      "parentRecordedHead": "e142ca6cb39d90c33db6e1965a7bf0e4b979d4ae",
+      "parentCurrentHead": "e142ca6cb39d90c33db6e1965a7bf0e4b979d4ae",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "73f6cd0a2",
+        "sha": "73f6cd0a2212f4cc31a6b05a3bd5e5782db8ffba",
+        "iso": "2026-06-06T15:59:46-04:00",
+        "subject": "fix(cli): simplify compact ready-city actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-progression-choice-option-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-ready-city-compact-actions",
+      "children": [
+        "codex/simplify-government-option-actions"
+      ],
+      "depth": 540,
+      "head": "5158e25e665a1e9d89b6f2270b569ad4039f435a",
+      "parentRecordedHead": "73f6cd0a2212f4cc31a6b05a3bd5e5782db8ffba",
+      "parentCurrentHead": "73f6cd0a2212f4cc31a6b05a3bd5e5782db8ffba",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5158e25e6",
+        "sha": "5158e25e665a1e9d89b6f2270b569ad4039f435a",
+        "iso": "2026-06-06T15:59:47-04:00",
+        "subject": "fix(cli): simplify progression option actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-government-option-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-progression-choice-option-actions",
+      "children": [
+        "codex/simplify-narrative-option-actions"
+      ],
+      "depth": 541,
+      "head": "e4a6c4d3a94e4f44eb3d8b57f4b373a8c8570deb",
+      "parentRecordedHead": "5158e25e665a1e9d89b6f2270b569ad4039f435a",
+      "parentCurrentHead": "5158e25e665a1e9d89b6f2270b569ad4039f435a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e4a6c4d3a",
+        "sha": "e4a6c4d3a94e4f44eb3d8b57f4b373a8c8570deb",
+        "iso": "2026-06-06T15:59:47-04:00",
+        "subject": "fix(cli): simplify government option actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-narrative-option-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-government-option-actions",
+      "children": [
+        "codex/simplify-rehydrate-actions"
+      ],
+      "depth": 542,
+      "head": "3bd649c6f6ea3bb91eca26ab910600d0d6daa5ee",
+      "parentRecordedHead": "e4a6c4d3a94e4f44eb3d8b57f4b373a8c8570deb",
+      "parentCurrentHead": "e4a6c4d3a94e4f44eb3d8b57f4b373a8c8570deb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3bd649c6f",
+        "sha": "3bd649c6f6ea3bb91eca26ab910600d0d6daa5ee",
+        "iso": "2026-06-06T15:59:47-04:00",
+        "subject": "fix(cli): simplify narrative option actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-rehydrate-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-narrative-option-actions",
+      "children": [
+        "codex/simplify-notifications-text-actions"
+      ],
+      "depth": 543,
+      "head": "e1470e4cdb531278cba80f2734254d21a222138d",
+      "parentRecordedHead": "3bd649c6f6ea3bb91eca26ab910600d0d6daa5ee",
+      "parentCurrentHead": "3bd649c6f6ea3bb91eca26ab910600d0d6daa5ee",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e1470e4cd",
+        "sha": "e1470e4cdb531278cba80f2734254d21a222138d",
+        "iso": "2026-06-06T15:59:47-04:00",
+        "subject": "fix(cli): simplify rehydrate actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-notifications-text-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-rehydrate-actions",
+      "children": [
+        "codex/simplify-notification-hud-json-actions"
+      ],
+      "depth": 544,
+      "head": "0d09410622e3fa6847eef496e741746b9ee6e1fb",
+      "parentRecordedHead": "e1470e4cdb531278cba80f2734254d21a222138d",
+      "parentCurrentHead": "e1470e4cdb531278cba80f2734254d21a222138d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0d0941062",
+        "sha": "0d09410622e3fa6847eef496e741746b9ee6e1fb",
+        "iso": "2026-06-06T15:59:48-04:00",
+        "subject": "fix(cli): simplify notifications text actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-notification-hud-json-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-notifications-text-actions",
+      "children": [
+        "codex/remove-game-ui-attention-cli-fields"
+      ],
+      "depth": 545,
+      "head": "99576c2a3fc2e37164e337b7285f6ff3a3970e1f",
+      "parentRecordedHead": "0d09410622e3fa6847eef496e741746b9ee6e1fb",
+      "parentCurrentHead": "0d09410622e3fa6847eef496e741746b9ee6e1fb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "99576c2a3",
+        "sha": "99576c2a3fc2e37164e337b7285f6ff3a3970e1f",
+        "iso": "2026-06-06T15:59:48-04:00",
+        "subject": "fix(cli): simplify notification json actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-game-ui-attention-cli-fields",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-notification-hud-json-actions",
+      "children": [
+        "codex/guard-ready-city-compact-actions"
+      ],
+      "depth": 546,
+      "head": "87be363645d769b292865991386c5d73fe5c8ffd",
+      "parentRecordedHead": "99576c2a3fc2e37164e337b7285f6ff3a3970e1f",
+      "parentCurrentHead": "99576c2a3fc2e37164e337b7285f6ff3a3970e1f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "87be36364",
+        "sha": "87be363645d769b292865991386c5d73fe5c8ffd",
+        "iso": "2026-06-06T15:59:48-04:00",
+        "subject": "fix(control-orpc): remove game-ui attention cli fields"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/guard-ready-city-compact-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-game-ui-attention-cli-fields",
+      "children": [
+        "codex/guard-priority-validation-actions"
+      ],
+      "depth": 547,
+      "head": "67f6b898481cf71dfce02ecb217bf45c3538c539",
+      "parentRecordedHead": "87be363645d769b292865991386c5d73fe5c8ffd",
+      "parentCurrentHead": "87be363645d769b292865991386c5d73fe5c8ffd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "67f6b8984",
+        "sha": "67f6b898481cf71dfce02ecb217bf45c3538c539",
+        "iso": "2026-06-06T15:59:48-04:00",
+        "subject": "fix(cli): guard ready-city compact actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/guard-priority-validation-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/guard-ready-city-compact-actions",
+      "children": [
+        "codex/guard-rehydrate-decision-actions"
+      ],
+      "depth": 548,
+      "head": "8643ea53103ab0939f6c698ffb74046fbbbfdc18",
+      "parentRecordedHead": "67f6b898481cf71dfce02ecb217bf45c3538c539",
+      "parentCurrentHead": "67f6b898481cf71dfce02ecb217bf45c3538c539",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8643ea531",
+        "sha": "8643ea53103ab0939f6c698ffb74046fbbbfdc18",
+        "iso": "2026-06-06T15:59:48-04:00",
+        "subject": "fix(cli): guard priority validation actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/guard-rehydrate-decision-actions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/guard-priority-validation-actions",
+      "children": [
+        "codex/simplify-notification-option-notes"
+      ],
+      "depth": 549,
+      "head": "022df34398d92bb68dacb07b986fea7ee72c5c69",
+      "parentRecordedHead": "8643ea53103ab0939f6c698ffb74046fbbbfdc18",
+      "parentCurrentHead": "8643ea53103ab0939f6c698ffb74046fbbbfdc18",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "022df3439",
+        "sha": "022df34398d92bb68dacb07b986fea7ee72c5c69",
+        "iso": "2026-06-06T15:59:49-04:00",
+        "subject": "fix(cli): guard rehydrate decision actions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-notification-option-notes",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/guard-rehydrate-decision-actions",
+      "children": [
+        "codex/remove-first-meet-recommended-cli"
+      ],
+      "depth": 550,
+      "head": "1e63f529366d846610ffffcebb64d97bad952102",
+      "parentRecordedHead": "022df34398d92bb68dacb07b986fea7ee72c5c69",
+      "parentCurrentHead": "022df34398d92bb68dacb07b986fea7ee72c5c69",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1e63f5293",
+        "sha": "1e63f529366d846610ffffcebb64d97bad952102",
+        "iso": "2026-06-06T16:05:21-04:00",
+        "subject": "fix(control): simplify notification option notes"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-first-meet-recommended-cli",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-notification-option-notes",
+      "children": [
+        "codex/remove-traditions-recommended-cli"
+      ],
+      "depth": 551,
+      "head": "38bbcb4d3ab3003382357cfcbc438bd81a9c543c",
+      "parentRecordedHead": "1e63f529366d846610ffffcebb64d97bad952102",
+      "parentCurrentHead": "1e63f529366d846610ffffcebb64d97bad952102",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "38bbcb4d3",
+        "sha": "38bbcb4d3ab3003382357cfcbc438bd81a9c543c",
+        "iso": "2026-06-06T16:10:27-04:00",
+        "subject": "fix(control): remove first-meet recommended cli"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-traditions-recommended-cli",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-first-meet-recommended-cli",
+      "children": [
+        "codex/simplify-notification-action-directions"
+      ],
+      "depth": 552,
+      "head": "029cbb3dc3b6242b085b5231c95e4bb1a51711f9",
+      "parentRecordedHead": "38bbcb4d3ab3003382357cfcbc438bd81a9c543c",
+      "parentCurrentHead": "38bbcb4d3ab3003382357cfcbc438bd81a9c543c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "029cbb3dc",
+        "sha": "029cbb3dc3b6242b085b5231c95e4bb1a51711f9",
+        "iso": "2026-06-06T16:16:27-04:00",
+        "subject": "fix(control): remove traditions recommended cli"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-notification-action-directions",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-traditions-recommended-cli",
+      "children": [
+        "codex/remove-notification-decision-cli"
+      ],
+      "depth": 553,
+      "head": "57c7412f02a010f66d484fb63723cadc3e2d8291",
+      "parentRecordedHead": "029cbb3dc3b6242b085b5231c95e4bb1a51711f9",
+      "parentCurrentHead": "029cbb3dc3b6242b085b5231c95e4bb1a51711f9",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "57c7412f0",
+        "sha": "57c7412f02a010f66d484fb63723cadc3e2d8291",
+        "iso": "2026-06-06T16:21:47-04:00",
+        "subject": "fix(control): simplify notification action directions"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-notification-decision-cli",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-notification-action-directions",
+      "children": [
+        "codex/remove-ready-city-cli-fields"
+      ],
+      "depth": 554,
+      "head": "9334ea90a90ffc95d547b049604c09bca31b686a",
+      "parentRecordedHead": "57c7412f02a010f66d484fb63723cadc3e2d8291",
+      "parentCurrentHead": "57c7412f02a010f66d484fb63723cadc3e2d8291",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9334ea90a",
+        "sha": "9334ea90a90ffc95d547b049604c09bca31b686a",
+        "iso": "2026-06-06T16:27:26-04:00",
+        "subject": "fix(control): remove notification decision cli"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-ready-city-cli-fields",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-notification-decision-cli",
+      "children": [
+        "codex/remove-notification-detail-cli-fields"
+      ],
+      "depth": 555,
+      "head": "c33e9c6911f2e0538590f194d34e68dcf431bcf1",
+      "parentRecordedHead": "9334ea90a90ffc95d547b049604c09bca31b686a",
+      "parentCurrentHead": "9334ea90a90ffc95d547b049604c09bca31b686a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c33e9c691",
+        "sha": "c33e9c6911f2e0538590f194d34e68dcf431bcf1",
+        "iso": "2026-06-06T16:34:35-04:00",
+        "subject": "fix(control): remove ready-city cli fields"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-notification-detail-cli-fields",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-ready-city-cli-fields",
+      "children": [
+        "codex/remove-tradition-action-hint-cli"
+      ],
+      "depth": 556,
+      "head": "395634483e718a1adbc91a88a35bf5d88df7bc7c",
+      "parentRecordedHead": "c33e9c6911f2e0538590f194d34e68dcf431bcf1",
+      "parentCurrentHead": "c33e9c6911f2e0538590f194d34e68dcf431bcf1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "395634483",
+        "sha": "395634483e718a1adbc91a88a35bf5d88df7bc7c",
+        "iso": "2026-06-06T16:40:18-04:00",
+        "subject": "fix(control): remove notification detail cli fields"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-tradition-action-hint-cli",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-notification-detail-cli-fields",
+      "children": [
+        "codex/remove-game-watch-cli-field"
+      ],
+      "depth": 557,
+      "head": "ca201ef057bd8ccc3b016412e4e37cf9e790a0ac",
+      "parentRecordedHead": "395634483e718a1adbc91a88a35bf5d88df7bc7c",
+      "parentCurrentHead": "395634483e718a1adbc91a88a35bf5d88df7bc7c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ca201ef05",
+        "sha": "ca201ef057bd8ccc3b016412e4e37cf9e790a0ac",
+        "iso": "2026-06-06T16:45:38-04:00",
+        "subject": "fix(control): remove tradition action hint cli"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-game-watch-cli-field",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-tradition-action-hint-cli",
+      "children": [
+        "codex/remove-compact-action-meta-notes"
+      ],
+      "depth": 558,
+      "head": "110b9749ddc7311323a4bd3d41466a82907997c1",
+      "parentRecordedHead": "ca201ef057bd8ccc3b016412e4e37cf9e790a0ac",
+      "parentCurrentHead": "ca201ef057bd8ccc3b016412e4e37cf9e790a0ac",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "110b9749d",
+        "sha": "110b9749ddc7311323a4bd3d41466a82907997c1",
+        "iso": "2026-06-06T16:51:43-04:00",
+        "subject": "fix(cli): remove watch command recipe field"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-compact-action-meta-notes",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-game-watch-cli-field",
+      "children": [
+        "codex/simplify-compact-omission-reasons"
+      ],
+      "depth": 559,
+      "head": "192565aaa928fd59ba4b59d61eb68267b9126308",
+      "parentRecordedHead": "110b9749ddc7311323a4bd3d41466a82907997c1",
+      "parentCurrentHead": "110b9749ddc7311323a4bd3d41466a82907997c1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "192565aaa",
+        "sha": "192565aaa928fd59ba4b59d61eb68267b9126308",
+        "iso": "2026-06-06T16:55:18-04:00",
+        "subject": "fix(cli): remove compact action meta notes"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-compact-omission-reasons",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-compact-action-meta-notes",
+      "children": [
+        "codex/simplify-choice-option-guidance"
+      ],
+      "depth": 560,
+      "head": "ba6935fc0a35fa03bc4291efb3d88a5d6abfd547",
+      "parentRecordedHead": "192565aaa928fd59ba4b59d61eb68267b9126308",
+      "parentCurrentHead": "192565aaa928fd59ba4b59d61eb68267b9126308",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ba6935fc0",
+        "sha": "ba6935fc0a35fa03bc4291efb3d88a5d6abfd547",
+        "iso": "2026-06-06T16:58:30-04:00",
+        "subject": "fix(cli): simplify compact omission reasons"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-choice-option-guidance",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-compact-omission-reasons",
+      "children": [
+        "codex/simplify-notification-queue-service-guidance"
+      ],
+      "depth": 561,
+      "head": "8cc1d16e8b8be705e1e0e963de0f91b83a10ad1a",
+      "parentRecordedHead": "ba6935fc0a35fa03bc4291efb3d88a5d6abfd547",
+      "parentCurrentHead": "ba6935fc0a35fa03bc4291efb3d88a5d6abfd547",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8cc1d16e8",
+        "sha": "8cc1d16e8b8be705e1e0e963de0f91b83a10ad1a",
+        "iso": "2026-06-06T17:07:50-04:00",
+        "subject": "fix(cli): simplify choice option guidance"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-notification-queue-service-guidance",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-choice-option-guidance",
+      "children": [
+        "codex/simplify-service-mutation-guidance"
+      ],
+      "depth": 562,
+      "head": "16af93d06f3aa8ad200a1614e4a8829c4a873a07",
+      "parentRecordedHead": "8cc1d16e8b8be705e1e0e963de0f91b83a10ad1a",
+      "parentCurrentHead": "8cc1d16e8b8be705e1e0e963de0f91b83a10ad1a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "16af93d06",
+        "sha": "16af93d06f3aa8ad200a1614e4a8829c4a873a07",
+        "iso": "2026-06-06T17:17:36-04:00",
+        "subject": "fix(control-orpc): simplify notification queue guidance"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-service-mutation-guidance",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-notification-queue-service-guidance",
+      "children": [
+        "codex/simplify-strategy-action-labels"
+      ],
+      "depth": 563,
+      "head": "07da003733388af174b9a3ff5730ec369e0dd26f",
+      "parentRecordedHead": "16af93d06f3aa8ad200a1614e4a8829c4a873a07",
+      "parentCurrentHead": "16af93d06f3aa8ad200a1614e4a8829c4a873a07",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "07da00373",
+        "sha": "07da003733388af174b9a3ff5730ec369e0dd26f",
+        "iso": "2026-06-06T17:31:30-04:00",
+        "subject": "fix(control-orpc): simplify mutation guidance wording"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-strategy-action-labels",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-service-mutation-guidance",
+      "children": [
+        "codex/prune-control-orpc-procedure-type-exports"
+      ],
+      "depth": 564,
+      "head": "a51df0c97750f76f6d33fe32c3dfe8cb72542d17",
+      "parentRecordedHead": "07da003733388af174b9a3ff5730ec369e0dd26f",
+      "parentCurrentHead": "07da003733388af174b9a3ff5730ec369e0dd26f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a51df0c97",
+        "sha": "a51df0c97750f76f6d33fe32c3dfe8cb72542d17",
+        "iso": "2026-06-06T17:39:11-04:00",
+        "subject": "fix(control-orpc): simplify strategy action labels"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/prune-control-orpc-procedure-type-exports",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-strategy-action-labels",
+      "children": [
+        "codex/simplify-direct-control-action-guidance"
+      ],
+      "depth": 565,
+      "head": "252582e422c0ca87d602adaf9ba6d500f98e2ccf",
+      "parentRecordedHead": "a51df0c97750f76f6d33fe32c3dfe8cb72542d17",
+      "parentCurrentHead": "a51df0c97750f76f6d33fe32c3dfe8cb72542d17",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "252582e42",
+        "sha": "252582e422c0ca87d602adaf9ba6d500f98e2ccf",
+        "iso": "2026-06-06T17:53:33-04:00",
+        "subject": "fix(control-orpc): prune procedure DTO root exports"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/simplify-direct-control-action-guidance",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/prune-control-orpc-procedure-type-exports",
+      "children": [
+        "codex/require-controller-mutation-proof"
+      ],
+      "depth": 566,
+      "head": "c07e860a71a0991af8a73c3b73f7860b346b67cc",
+      "parentRecordedHead": "252582e422c0ca87d602adaf9ba6d500f98e2ccf",
+      "parentCurrentHead": "252582e422c0ca87d602adaf9ba6d500f98e2ccf",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c07e860a7",
+        "sha": "c07e860a71a0991af8a73c3b73f7860b346b67cc",
+        "iso": "2026-06-06T18:11:45-04:00",
+        "subject": "docs(control): simplify direct-control action guidance"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/require-controller-mutation-proof",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/simplify-direct-control-action-guidance",
+      "children": [],
+      "depth": 567,
+      "head": "6ed40e57d5795db47847490791b7425beb8051fe",
+      "parentRecordedHead": "c07e860a71a0991af8a73c3b73f7860b346b67cc",
+      "parentCurrentHead": "c07e860a71a0991af8a73c3b73f7860b346b67cc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "worktree": {
+        "path": "/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-watch-civ7-live-play-reference-assembly",
+        "branch": "codex/require-controller-mutation-proof",
+        "head": "6ed40e57d5795db47847490791b7425beb8051fe",
+        "dirtyCount": 0,
+        "isMain": false,
+        "isDetached": false
+      },
+      "commit": {
+        "short": "6ed40e57d",
+        "sha": "6ed40e57d5795db47847490791b7425beb8051fe",
+        "iso": "2026-06-06T18:20:47-04:00",
+        "subject": "fix(control-orpc): require controller proof for mutation readiness"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/stale-population-blocker-classification",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/live-traditions-view",
+      "children": [
+        "codex/dismissible-popup-closeout"
+      ],
+      "depth": 6,
+      "head": "32a9ab64efe703f5e43ccf88e7e009a804650cf3",
+      "parentRecordedHead": "332270a377b91f1cd7ef8c75c2f8d1a0a1ae62ef",
+      "parentCurrentHead": "332270a377b91f1cd7ef8c75c2f8d1a0a1ae62ef",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "32a9ab64e",
+        "sha": "32a9ab64efe703f5e43ccf88e7e009a804650cf3",
+        "iso": "2026-06-02T15:43:57-04:00",
+        "subject": "fix(civ7): classify stale population blockers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/dismissible-popup-closeout",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/stale-population-blocker-classification",
+      "children": [
+        "codex/extract-popup-play-tests"
+      ],
+      "depth": 7,
+      "head": "266788a884e0e0448cd4207b08cb9d7f1e3b4d70",
+      "parentRecordedHead": "32a9ab64efe703f5e43ccf88e7e009a804650cf3",
+      "parentCurrentHead": "32a9ab64efe703f5e43ccf88e7e009a804650cf3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "266788a88",
+        "sha": "266788a884e0e0448cd4207b08cb9d7f1e3b4d70",
+        "iso": "2026-06-02T15:44:30-04:00",
+        "subject": "fix(civ7): add dismissible popup closeout"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-popup-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/dismissible-popup-closeout",
+      "children": [
+        "codex/stale-unit-command-queue"
+      ],
+      "depth": 8,
+      "head": "11832f796b744008eb77ccd691d1e1470b3cd8a6",
+      "parentRecordedHead": "266788a884e0e0448cd4207b08cb9d7f1e3b4d70",
+      "parentCurrentHead": "266788a884e0e0448cd4207b08cb9d7f1e3b4d70",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "11832f796",
+        "sha": "11832f796b744008eb77ccd691d1e1470b3cd8a6",
+        "iso": "2026-06-02T15:45:13-04:00",
+        "subject": "test(civ7): extract popup play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/stale-unit-command-queue",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-popup-play-tests",
+      "children": [
+        "codex/unit-target-reachability"
+      ],
+      "depth": 9,
+      "head": "0920b6dc9ae902ffbd52e36b41fd5a2d4351f42c",
+      "parentRecordedHead": "11832f796b744008eb77ccd691d1e1470b3cd8a6",
+      "parentCurrentHead": "11832f796b744008eb77ccd691d1e1470b3cd8a6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0920b6dc9",
+        "sha": "0920b6dc9ae902ffbd52e36b41fd5a2d4351f42c",
+        "iso": "2026-06-02T15:45:14-04:00",
+        "subject": "fix(civ7): classify stale unit command queue"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/unit-target-reachability",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/stale-unit-command-queue",
+      "children": [
+        "codex/modularize-notification-dismissal-runtime"
+      ],
+      "depth": 10,
+      "head": "b3143773435473d5e05ceea806c32a2820dca7d3",
+      "parentRecordedHead": "0920b6dc9ae902ffbd52e36b41fd5a2d4351f42c",
+      "parentCurrentHead": "0920b6dc9ae902ffbd52e36b41fd5a2d4351f42c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b31437734",
+        "sha": "b3143773435473d5e05ceea806c32a2820dca7d3",
+        "iso": "2026-06-02T15:45:14-04:00",
+        "subject": "feat(civ7): expose unit target reachability"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/modularize-notification-dismissal-runtime",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/unit-target-reachability",
+      "children": [
+        "codex/extract-unit-move-preview-play-tests"
+      ],
+      "depth": 11,
+      "head": "a95fa3ee0c1c8a8ea3b3aee0724bd5a33c7f1c7c",
+      "parentRecordedHead": "b3143773435473d5e05ceea806c32a2820dca7d3",
+      "parentCurrentHead": "b3143773435473d5e05ceea806c32a2820dca7d3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a95fa3ee0",
+        "sha": "a95fa3ee0c1c8a8ea3b3aee0724bd5a33c7f1c7c",
+        "iso": "2026-06-02T15:45:14-04:00",
+        "subject": "refactor(civ7): extract notification dismissal runtime"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-unit-move-preview-play-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/modularize-notification-dismissal-runtime",
+      "children": [
+        "codex/extract-autoplay-command-source"
+      ],
+      "depth": 12,
+      "head": "bd26de6ba38f6f798234b2349108d301b485b772",
+      "parentRecordedHead": "a95fa3ee0c1c8a8ea3b3aee0724bd5a33c7f1c7c",
+      "parentCurrentHead": "a95fa3ee0c1c8a8ea3b3aee0724bd5a33c7f1c7c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bd26de6ba",
+        "sha": "bd26de6ba38f6f798234b2349108d301b485b772",
+        "iso": "2026-06-02T15:45:14-04:00",
+        "subject": "test(cli): extract unit move preview play tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-autoplay-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-unit-move-preview-play-tests",
+      "children": [
+        "codex/extract-unit-move-preview-runtime"
+      ],
+      "depth": 13,
+      "head": "51218dd5358f3219b939d1756cad659b8868b6e5",
+      "parentRecordedHead": "bd26de6ba38f6f798234b2349108d301b485b772",
+      "parentCurrentHead": "bd26de6ba38f6f798234b2349108d301b485b772",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "51218dd53",
+        "sha": "51218dd5358f3219b939d1756cad659b8868b6e5",
+        "iso": "2026-06-02T15:45:14-04:00",
+        "subject": "refactor(civ7): extract autoplay command source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-unit-move-preview-runtime",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-autoplay-command-source",
+      "children": [
+        "codex/default-lean-play-json"
+      ],
+      "depth": 14,
+      "head": "61ab38e4bca59e51a446918a800ab912d235c0ff",
+      "parentRecordedHead": "51218dd5358f3219b939d1756cad659b8868b6e5",
+      "parentCurrentHead": "51218dd5358f3219b939d1756cad659b8868b6e5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "61ab38e4b",
+        "sha": "61ab38e4bca59e51a446918a800ab912d235c0ff",
+        "iso": "2026-06-02T15:45:14-04:00",
+        "subject": "refactor(civ7): extract unit move preview runtime"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/default-lean-play-json",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-unit-move-preview-runtime",
+      "children": [
+        "codex/play-dashboard-raw-log"
+      ],
+      "depth": 15,
+      "head": "64ac6640646d2e88e23bf9aadbd02f9ade7c4f60",
+      "parentRecordedHead": "61ab38e4bca59e51a446918a800ab912d235c0ff",
+      "parentCurrentHead": "61ab38e4bca59e51a446918a800ab912d235c0ff",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "64ac66406",
+        "sha": "64ac6640646d2e88e23bf9aadbd02f9ade7c4f60",
+        "iso": "2026-06-02T15:45:15-04:00",
+        "subject": "feat(cli): default play dashboards to lean JSON"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/play-dashboard-raw-log",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/default-lean-play-json",
+      "children": [
+        "codex/notification-capability-modules"
+      ],
+      "depth": 16,
+      "head": "86d36499129df72c6611dc74b2a0ef2aa87cf8af",
+      "parentRecordedHead": "64ac6640646d2e88e23bf9aadbd02f9ade7c4f60",
+      "parentCurrentHead": "64ac6640646d2e88e23bf9aadbd02f9ade7c4f60",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "86d364991",
+        "sha": "86d36499129df72c6611dc74b2a0ef2aa87cf8af",
+        "iso": "2026-06-02T15:45:15-04:00",
+        "subject": "feat(cli): add raw log artifacts for play dashboards"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/notification-capability-modules",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/play-dashboard-raw-log",
+      "children": [
+        "codex/split-game-play-shared-facade"
+      ],
+      "depth": 17,
+      "head": "386f74891c3334d5837080aee32ec0468bf0d2df",
+      "parentRecordedHead": "86d36499129df72c6611dc74b2a0ef2aa87cf8af",
+      "parentCurrentHead": "86d36499129df72c6611dc74b2a0ef2aa87cf8af",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "386f74891",
+        "sha": "386f74891c3334d5837080aee32ec0468bf0d2df",
+        "iso": "2026-06-02T15:45:15-04:00",
+        "subject": "refactor(cli): extract notification capability modules"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/split-game-play-shared-facade",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/notification-capability-modules",
+      "children": [
+        "codex/remove-game-play-shared-facade"
+      ],
+      "depth": 18,
+      "head": "bb70a621bb546b79ab76efbba0247ffce3b33a60",
+      "parentRecordedHead": "386f74891c3334d5837080aee32ec0468bf0d2df",
+      "parentCurrentHead": "386f74891c3334d5837080aee32ec0468bf0d2df",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bb70a621b",
+        "sha": "bb70a621bb546b79ab76efbba0247ffce3b33a60",
+        "iso": "2026-06-02T15:45:15-04:00",
+        "subject": "refactor(cli): split game play shared helpers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-game-play-shared-facade",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/split-game-play-shared-facade",
+      "children": [
+        "codex/extract-progress-dashboard-presentation"
+      ],
+      "depth": 19,
+      "head": "380bde424e17faa7fbbd0ceefdd18907f4f840c4",
+      "parentRecordedHead": "bb70a621bb546b79ab76efbba0247ffce3b33a60",
+      "parentCurrentHead": "bb70a621bb546b79ab76efbba0247ffce3b33a60",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "380bde424",
+        "sha": "380bde424e17faa7fbbd0ceefdd18907f4f840c4",
+        "iso": "2026-06-02T15:45:51-04:00",
+        "subject": "refactor(cli): remove game play shared facade"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-progress-dashboard-presentation",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-game-play-shared-facade",
+      "children": [
+        "codex/extract-progress-dashboard-command-tests"
+      ],
+      "depth": 20,
+      "head": "0f7a5721285a1dfc54a419e7204533f89399b43b",
+      "parentRecordedHead": "380bde424e17faa7fbbd0ceefdd18907f4f840c4",
+      "parentCurrentHead": "380bde424e17faa7fbbd0ceefdd18907f4f840c4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0f7a57212",
+        "sha": "0f7a5721285a1dfc54a419e7204533f89399b43b",
+        "iso": "2026-06-02T15:45:51-04:00",
+        "subject": "refactor(cli): extract progress dashboard presentation"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-progress-dashboard-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-progress-dashboard-presentation",
+      "children": [
+        "codex/extract-priorities-dashboard-module"
+      ],
+      "depth": 21,
+      "head": "c104edcec18817cfcd79818409708d504fc900d8",
+      "parentRecordedHead": "0f7a5721285a1dfc54a419e7204533f89399b43b",
+      "parentCurrentHead": "0f7a5721285a1dfc54a419e7204533f89399b43b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c104edcec",
+        "sha": "c104edcec18817cfcd79818409708d504fc900d8",
+        "iso": "2026-06-02T15:45:52-04:00",
+        "subject": "test(cli): extract progress dashboard command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-priorities-dashboard-module",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-progress-dashboard-command-tests",
+      "children": [
+        "codex/extract-priorities-command-tests"
+      ],
+      "depth": 22,
+      "head": "818eb24ce766e82a56754012027db44c1a5ddd7b",
+      "parentRecordedHead": "c104edcec18817cfcd79818409708d504fc900d8",
+      "parentCurrentHead": "c104edcec18817cfcd79818409708d504fc900d8",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "818eb24ce",
+        "sha": "818eb24ce766e82a56754012027db44c1a5ddd7b",
+        "iso": "2026-06-02T15:45:52-04:00",
+        "subject": "refactor(cli): extract priorities dashboard module"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-priorities-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-priorities-dashboard-module",
+      "children": [
+        "codex/extract-ready-unit-command-tests"
+      ],
+      "depth": 23,
+      "head": "e27fe3ba4e4f9d3054085a8a7d1d3402adf45558",
+      "parentRecordedHead": "818eb24ce766e82a56754012027db44c1a5ddd7b",
+      "parentCurrentHead": "818eb24ce766e82a56754012027db44c1a5ddd7b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e27fe3ba4",
+        "sha": "e27fe3ba4e4f9d3054085a8a7d1d3402adf45558",
+        "iso": "2026-06-02T15:45:52-04:00",
+        "subject": "test(cli): extract priorities command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-ready-unit-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-priorities-command-tests",
+      "children": [
+        "codex/extract-ready-city-command-tests"
+      ],
+      "depth": 24,
+      "head": "e54c5cd13c40bfcb2f541d60b28be17cb2f06939",
+      "parentRecordedHead": "e27fe3ba4e4f9d3054085a8a7d1d3402adf45558",
+      "parentCurrentHead": "e27fe3ba4e4f9d3054085a8a7d1d3402adf45558",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e54c5cd13",
+        "sha": "e54c5cd13c40bfcb2f541d60b28be17cb2f06939",
+        "iso": "2026-06-02T15:45:52-04:00",
+        "subject": "test(cli): extract ready-unit command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-ready-city-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-ready-unit-command-tests",
+      "children": [
+        "codex/extract-unit-target-command-tests"
+      ],
+      "depth": 25,
+      "head": "ae7685f941bcad636ca589edc245e3f93ab420fd",
+      "parentRecordedHead": "e54c5cd13c40bfcb2f541d60b28be17cb2f06939",
+      "parentCurrentHead": "e54c5cd13c40bfcb2f541d60b28be17cb2f06939",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ae7685f94",
+        "sha": "ae7685f941bcad636ca589edc245e3f93ab420fd",
+        "iso": "2026-06-02T15:45:52-04:00",
+        "subject": "test(cli): extract ready-city command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-unit-target-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-ready-city-command-tests",
+      "children": [
+        "codex/extract-watch-command-tests"
+      ],
+      "depth": 26,
+      "head": "f72f70cbcbc3c313c3229e59ef16f9fade94f181",
+      "parentRecordedHead": "ae7685f941bcad636ca589edc245e3f93ab420fd",
+      "parentCurrentHead": "ae7685f941bcad636ca589edc245e3f93ab420fd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f72f70cbc",
+        "sha": "f72f70cbcbc3c313c3229e59ef16f9fade94f181",
+        "iso": "2026-06-02T15:45:52-04:00",
+        "subject": "test(cli): extract unit-target command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-watch-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-unit-target-command-tests",
+      "children": [
+        "codex/extract-topics-command-tests"
+      ],
+      "depth": 27,
+      "head": "3c171cca84872863bf7014c98df7d16c736cbe3f",
+      "parentRecordedHead": "f72f70cbcbc3c313c3229e59ef16f9fade94f181",
+      "parentCurrentHead": "f72f70cbcbc3c313c3229e59ef16f9fade94f181",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3c171cca8",
+        "sha": "3c171cca84872863bf7014c98df7d16c736cbe3f",
+        "iso": "2026-06-02T15:45:52-04:00",
+        "subject": "test(cli): extract watch command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-topics-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-watch-command-tests",
+      "children": [
+        "codex/extract-end-turn-command-tests"
+      ],
+      "depth": 28,
+      "head": "7b391f487a6175c3be6262c109d72b1665b26b9f",
+      "parentRecordedHead": "3c171cca84872863bf7014c98df7d16c736cbe3f",
+      "parentCurrentHead": "3c171cca84872863bf7014c98df7d16c736cbe3f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7b391f487",
+        "sha": "7b391f487a6175c3be6262c109d72b1665b26b9f",
+        "iso": "2026-06-02T15:45:52-04:00",
+        "subject": "test(cli): extract topics command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-end-turn-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-topics-command-tests",
+      "children": [
+        "codex/extract-notifications-command-tests"
+      ],
+      "depth": 29,
+      "head": "657fd9e3ef68a8bfa092aa0029f6e70b68ba8db6",
+      "parentRecordedHead": "7b391f487a6175c3be6262c109d72b1665b26b9f",
+      "parentCurrentHead": "7b391f487a6175c3be6262c109d72b1665b26b9f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "657fd9e3e",
+        "sha": "657fd9e3ef68a8bfa092aa0029f6e70b68ba8db6",
+        "iso": "2026-06-02T15:45:53-04:00",
+        "subject": "test(cli): extract end-turn command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-notifications-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-end-turn-command-tests",
+      "children": [
+        "codex/extract-tactical-read-command-tests"
+      ],
+      "depth": 30,
+      "head": "aa5e2f0254199ae3a4df6add89e7beec7a4a4d9e",
+      "parentRecordedHead": "657fd9e3ef68a8bfa092aa0029f6e70b68ba8db6",
+      "parentCurrentHead": "657fd9e3ef68a8bfa092aa0029f6e70b68ba8db6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "aa5e2f025",
+        "sha": "aa5e2f0254199ae3a4df6add89e7beec7a4a4d9e",
+        "iso": "2026-06-02T15:45:53-04:00",
+        "subject": "test(cli): extract notification read command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-tactical-read-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-notifications-command-tests",
+      "children": [
+        "codex/extract-operation-wrapper-command-tests"
+      ],
+      "depth": 31,
+      "head": "cddd116a085d7edac123fcff25c856093b965d55",
+      "parentRecordedHead": "aa5e2f0254199ae3a4df6add89e7beec7a4a4d9e",
+      "parentCurrentHead": "aa5e2f0254199ae3a4df6add89e7beec7a4a4d9e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cddd116a0",
+        "sha": "cddd116a085d7edac123fcff25c856093b965d55",
+        "iso": "2026-06-02T15:45:53-04:00",
+        "subject": "test(cli): extract tactical read command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-operation-wrapper-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-tactical-read-command-tests",
+      "children": [
+        "codex/extract-turn-completion-source"
+      ],
+      "depth": 32,
+      "head": "e9d5cd26e43cfb5840c593b4893eb58a1c2d79aa",
+      "parentRecordedHead": "cddd116a085d7edac123fcff25c856093b965d55",
+      "parentCurrentHead": "cddd116a085d7edac123fcff25c856093b965d55",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e9d5cd26e",
+        "sha": "e9d5cd26e43cfb5840c593b4893eb58a1c2d79aa",
+        "iso": "2026-06-02T15:45:53-04:00",
+        "subject": "test(cli): extract operation wrapper command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-turn-completion-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-operation-wrapper-command-tests",
+      "children": [
+        "codex/extract-play-notification-source"
+      ],
+      "depth": 33,
+      "head": "a0ceb99f1c12014be5fdff70f3962d3287b9b6c1",
+      "parentRecordedHead": "e9d5cd26e43cfb5840c593b4893eb58a1c2d79aa",
+      "parentCurrentHead": "e9d5cd26e43cfb5840c593b4893eb58a1c2d79aa",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a0ceb99f1",
+        "sha": "a0ceb99f1c12014be5fdff70f3962d3287b9b6c1",
+        "iso": "2026-06-02T15:45:53-04:00",
+        "subject": "refactor(direct-control): extract turn completion source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-play-notification-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-turn-completion-source",
+      "children": [
+        "codex/extract-ready-unit-source"
+      ],
+      "depth": 34,
+      "head": "a9308d36cac307f0510f40b1a9941919eace6896",
+      "parentRecordedHead": "a0ceb99f1c12014be5fdff70f3962d3287b9b6c1",
+      "parentCurrentHead": "a0ceb99f1c12014be5fdff70f3962d3287b9b6c1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a9308d36c",
+        "sha": "a9308d36cac307f0510f40b1a9941919eace6896",
+        "iso": "2026-06-02T15:45:53-04:00",
+        "subject": "refactor(direct-control): extract play notification source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-ready-unit-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-play-notification-source",
+      "children": [
+        "codex/extract-unit-target-source"
+      ],
+      "depth": 35,
+      "head": "b21fd247b0124d26580974fe0ef38b79d5306ffb",
+      "parentRecordedHead": "a9308d36cac307f0510f40b1a9941919eace6896",
+      "parentCurrentHead": "a9308d36cac307f0510f40b1a9941919eace6896",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b21fd247b",
+        "sha": "b21fd247b0124d26580974fe0ef38b79d5306ffb",
+        "iso": "2026-06-02T15:45:53-04:00",
+        "subject": "refactor(direct-control): extract ready unit source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-unit-target-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-ready-unit-source",
+      "children": [
+        "codex/extract-ready-city-source"
+      ],
+      "depth": 36,
+      "head": "ce034ca8306e2cbca920b266ed2c48e9942717e1",
+      "parentRecordedHead": "b21fd247b0124d26580974fe0ef38b79d5306ffb",
+      "parentCurrentHead": "b21fd247b0124d26580974fe0ef38b79d5306ffb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ce034ca83",
+        "sha": "ce034ca8306e2cbca920b266ed2c48e9942717e1",
+        "iso": "2026-06-02T15:45:53-04:00",
+        "subject": "refactor(direct-control): extract unit target source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-ready-city-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-unit-target-source",
+      "children": [
+        "codex/extract-operation-router-source"
+      ],
+      "depth": 37,
+      "head": "409f42bc437b514000303652b01c80bb38107a5b",
+      "parentRecordedHead": "ce034ca8306e2cbca920b266ed2c48e9942717e1",
+      "parentCurrentHead": "ce034ca8306e2cbca920b266ed2c48e9942717e1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "409f42bc4",
+        "sha": "409f42bc437b514000303652b01c80bb38107a5b",
+        "iso": "2026-06-02T15:45:54-04:00",
+        "subject": "refactor(direct-control): extract ready city source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-operation-router-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-ready-city-source",
+      "children": [
+        "codex/extract-settlement-recommendations-source"
+      ],
+      "depth": 38,
+      "head": "69ad58eaf0baaa26226f9a03a0f8ebc85f725172",
+      "parentRecordedHead": "409f42bc437b514000303652b01c80bb38107a5b",
+      "parentCurrentHead": "409f42bc437b514000303652b01c80bb38107a5b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "69ad58eaf",
+        "sha": "69ad58eaf0baaa26226f9a03a0f8ebc85f725172",
+        "iso": "2026-06-02T15:45:54-04:00",
+        "subject": "refactor(direct-control): extract operation router source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-settlement-recommendations-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-operation-router-source",
+      "children": [
+        "codex/extract-target-candidates-source"
+      ],
+      "depth": 39,
+      "head": "35b4a0f83838ce540fbbf850ad7cc04115754f96",
+      "parentRecordedHead": "69ad58eaf0baaa26226f9a03a0f8ebc85f725172",
+      "parentCurrentHead": "69ad58eaf0baaa26226f9a03a0f8ebc85f725172",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "35b4a0f83",
+        "sha": "35b4a0f83838ce540fbbf850ad7cc04115754f96",
+        "iso": "2026-06-02T15:45:54-04:00",
+        "subject": "refactor(direct-control): extract settlement recommendation source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-target-candidates-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-settlement-recommendations-source",
+      "children": [
+        "codex/extract-battlefield-scan-source"
+      ],
+      "depth": 40,
+      "head": "b980c47a1ef4112d6c8d9d2129627a854418df23",
+      "parentRecordedHead": "35b4a0f83838ce540fbbf850ad7cc04115754f96",
+      "parentCurrentHead": "35b4a0f83838ce540fbbf850ad7cc04115754f96",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b980c47a1",
+        "sha": "b980c47a1ef4112d6c8d9d2129627a854418df23",
+        "iso": "2026-06-02T15:45:54-04:00",
+        "subject": "refactor(direct-control): extract target candidates source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-battlefield-scan-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-target-candidates-source",
+      "children": [
+        "codex/extract-destination-analysis-source"
+      ],
+      "depth": 41,
+      "head": "495755ccf1c8ae0e3b64c736084f7ed64c1c8734",
+      "parentRecordedHead": "b980c47a1ef4112d6c8d9d2129627a854418df23",
+      "parentCurrentHead": "b980c47a1ef4112d6c8d9d2129627a854418df23",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "495755ccf",
+        "sha": "495755ccf1c8ae0e3b64c736084f7ed64c1c8734",
+        "iso": "2026-06-02T15:45:54-04:00",
+        "subject": "refactor(direct-control): extract battlefield scan source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-destination-analysis-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-battlefield-scan-source",
+      "children": [
+        "codex/extract-traditions-view-source"
+      ],
+      "depth": 42,
+      "head": "034060551a431b9bfd12c878fe61722c10c9844c",
+      "parentRecordedHead": "495755ccf1c8ae0e3b64c736084f7ed64c1c8734",
+      "parentCurrentHead": "495755ccf1c8ae0e3b64c736084f7ed64c1c8734",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "034060551",
+        "sha": "034060551a431b9bfd12c878fe61722c10c9844c",
+        "iso": "2026-06-02T15:45:54-04:00",
+        "subject": "refactor(direct-control): extract destination analysis source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-traditions-view-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-destination-analysis-source",
+      "children": [
+        "codex/extract-progress-dashboard-source"
+      ],
+      "depth": 43,
+      "head": "c1b251095a4a90aa641fe9afa27e8827f0fda5e5",
+      "parentRecordedHead": "034060551a431b9bfd12c878fe61722c10c9844c",
+      "parentCurrentHead": "034060551a431b9bfd12c878fe61722c10c9844c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c1b251095",
+        "sha": "c1b251095a4a90aa641fe9afa27e8827f0fda5e5",
+        "iso": "2026-06-02T15:45:54-04:00",
+        "subject": "refactor(direct-control): extract traditions view source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-progress-dashboard-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-traditions-view-source",
+      "children": [
+        "codex/extract-plot-snapshot-source"
+      ],
+      "depth": 44,
+      "head": "3b04c8099756fb7409eba27e17af4135bf33acce",
+      "parentRecordedHead": "c1b251095a4a90aa641fe9afa27e8827f0fda5e5",
+      "parentCurrentHead": "c1b251095a4a90aa641fe9afa27e8827f0fda5e5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3b04c8099",
+        "sha": "3b04c8099756fb7409eba27e17af4135bf33acce",
+        "iso": "2026-06-02T15:45:54-04:00",
+        "subject": "refactor(direct-control): extract progress dashboard source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-plot-snapshot-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-progress-dashboard-source",
+      "children": [
+        "codex/extract-culture-choice-closeout-source"
+      ],
+      "depth": 45,
+      "head": "532277707c3b515141da0fc03c6dbe7d85b9efa7",
+      "parentRecordedHead": "3b04c8099756fb7409eba27e17af4135bf33acce",
+      "parentCurrentHead": "3b04c8099756fb7409eba27e17af4135bf33acce",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "532277707",
+        "sha": "532277707c3b515141da0fc03c6dbe7d85b9efa7",
+        "iso": "2026-06-02T15:45:55-04:00",
+        "subject": "refactor(direct-control): extract plot snapshot source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-culture-choice-closeout-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-plot-snapshot-source",
+      "children": [
+        "codex/extract-technology-choice-closeout-source"
+      ],
+      "depth": 46,
+      "head": "bed445142997e8b82a9e679ecb7822305e8f5970",
+      "parentRecordedHead": "532277707c3b515141da0fc03c6dbe7d85b9efa7",
+      "parentCurrentHead": "532277707c3b515141da0fc03c6dbe7d85b9efa7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bed445142",
+        "sha": "bed445142997e8b82a9e679ecb7822305e8f5970",
+        "iso": "2026-06-02T15:45:55-04:00",
+        "subject": "refactor(direct-control): extract culture choice closeout source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-technology-choice-closeout-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-culture-choice-closeout-source",
+      "children": [
+        "codex/extract-production-choice-source"
+      ],
+      "depth": 47,
+      "head": "bddb6725d190882db6db12b078bcf3dbb8506663",
+      "parentRecordedHead": "bed445142997e8b82a9e679ecb7822305e8f5970",
+      "parentCurrentHead": "bed445142997e8b82a9e679ecb7822305e8f5970",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bddb6725d",
+        "sha": "bddb6725d190882db6db12b078bcf3dbb8506663",
+        "iso": "2026-06-02T15:45:55-04:00",
+        "subject": "refactor(direct-control): extract technology choice closeout source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-production-choice-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-technology-choice-closeout-source",
+      "children": [
+        "codex/extract-narrative-choice-source"
+      ],
+      "depth": 48,
+      "head": "f88a3be092400a4d859e54b20404c44c963190d7",
+      "parentRecordedHead": "bddb6725d190882db6db12b078bcf3dbb8506663",
+      "parentCurrentHead": "bddb6725d190882db6db12b078bcf3dbb8506663",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f88a3be09",
+        "sha": "f88a3be092400a4d859e54b20404c44c963190d7",
+        "iso": "2026-06-02T15:45:55-04:00",
+        "subject": "refactor(direct-control): extract production choice source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-narrative-choice-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-production-choice-source",
+      "children": [
+        "codex/extract-diplomacy-response-source"
+      ],
+      "depth": 49,
+      "head": "383cf3a241868ee60bbd33a888462cb7ddec1000",
+      "parentRecordedHead": "f88a3be092400a4d859e54b20404c44c963190d7",
+      "parentCurrentHead": "f88a3be092400a4d859e54b20404c44c963190d7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "383cf3a24",
+        "sha": "383cf3a241868ee60bbd33a888462cb7ddec1000",
+        "iso": "2026-06-02T15:45:55-04:00",
+        "subject": "refactor(direct-control): extract narrative choice source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-diplomacy-response-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-narrative-choice-source",
+      "children": [
+        "codex/extract-setup-snapshot-source"
+      ],
+      "depth": 50,
+      "head": "632d1296e730025c7a70fc535b8890430bf49fa6",
+      "parentRecordedHead": "383cf3a241868ee60bbd33a888462cb7ddec1000",
+      "parentCurrentHead": "383cf3a241868ee60bbd33a888462cb7ddec1000",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "632d1296e",
+        "sha": "632d1296e730025c7a70fc535b8890430bf49fa6",
+        "iso": "2026-06-02T15:45:55-04:00",
+        "subject": "refactor(direct-control): extract diplomacy response source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-setup-snapshot-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-diplomacy-response-source",
+      "children": [
+        "codex/extract-first-meet-command-tests"
+      ],
+      "depth": 51,
+      "head": "72b57c3b46274f3f3c140152ecdba9f63e98dfa8",
+      "parentRecordedHead": "632d1296e730025c7a70fc535b8890430bf49fa6",
+      "parentCurrentHead": "632d1296e730025c7a70fc535b8890430bf49fa6",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "72b57c3b4",
+        "sha": "72b57c3b46274f3f3c140152ecdba9f63e98dfa8",
+        "iso": "2026-06-02T15:45:55-04:00",
+        "subject": "refactor(direct-control): extract setup snapshot source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-first-meet-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-setup-snapshot-source",
+      "children": [
+        "codex/extract-build-unit-command-tests"
+      ],
+      "depth": 52,
+      "head": "6d85fdbefe625ec1d259de5f2774258b422ff4e0",
+      "parentRecordedHead": "72b57c3b46274f3f3c140152ecdba9f63e98dfa8",
+      "parentCurrentHead": "72b57c3b46274f3f3c140152ecdba9f63e98dfa8",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6d85fdbef",
+        "sha": "6d85fdbefe625ec1d259de5f2774258b422ff4e0",
+        "iso": "2026-06-02T15:49:16-04:00",
+        "subject": "test(cli): extract first-meet command test"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-build-unit-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-first-meet-command-tests",
+      "children": [
+        "codex/extract-build-production-command-tests"
+      ],
+      "depth": 53,
+      "head": "6f821f24a379c36dea0f8947f1cbf02be54ca45b",
+      "parentRecordedHead": "6d85fdbefe625ec1d259de5f2774258b422ff4e0",
+      "parentCurrentHead": "6d85fdbefe625ec1d259de5f2774258b422ff4e0",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6f821f24a",
+        "sha": "6f821f24a379c36dea0f8947f1cbf02be54ca45b",
+        "iso": "2026-06-02T15:49:16-04:00",
+        "subject": "test(cli): extract build-unit command test"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-build-production-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-build-unit-command-tests",
+      "children": [
+        "codex/extract-population-placement-command-tests"
+      ],
+      "depth": 54,
+      "head": "1961bcb4c281fe0bee9c7e8946253b36cb291595",
+      "parentRecordedHead": "6f821f24a379c36dea0f8947f1cbf02be54ca45b",
+      "parentCurrentHead": "6f821f24a379c36dea0f8947f1cbf02be54ca45b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "1961bcb4c",
+        "sha": "1961bcb4c281fe0bee9c7e8946253b36cb291595",
+        "iso": "2026-06-02T15:49:16-04:00",
+        "subject": "test(cli): extract build-production command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-population-placement-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-build-production-command-tests",
+      "children": [
+        "codex/extract-town-project-command-tests"
+      ],
+      "depth": 55,
+      "head": "ea20cf79b865f7eac49a457af8a1543ace4ef0b5",
+      "parentRecordedHead": "1961bcb4c281fe0bee9c7e8946253b36cb291595",
+      "parentCurrentHead": "1961bcb4c281fe0bee9c7e8946253b36cb291595",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ea20cf79b",
+        "sha": "ea20cf79b865f7eac49a457af8a1543ace4ef0b5",
+        "iso": "2026-06-02T15:49:17-04:00",
+        "subject": "test(cli): extract population placement command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-town-project-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-population-placement-command-tests",
+      "children": [
+        "codex/extract-traditions-command-tests"
+      ],
+      "depth": 56,
+      "head": "b91c42b70268d193bca972b111639a22484a8ee1",
+      "parentRecordedHead": "ea20cf79b865f7eac49a457af8a1543ace4ef0b5",
+      "parentCurrentHead": "ea20cf79b865f7eac49a457af8a1543ace4ef0b5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b91c42b70",
+        "sha": "b91c42b70268d193bca972b111639a22484a8ee1",
+        "iso": "2026-06-02T15:49:17-04:00",
+        "subject": "test(cli): extract town project command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-traditions-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-town-project-command-tests",
+      "children": [
+        "codex/extract-celebration-government-command-tests"
+      ],
+      "depth": 57,
+      "head": "c3f10b1537d562e34be467537696e4d22878dd99",
+      "parentRecordedHead": "b91c42b70268d193bca972b111639a22484a8ee1",
+      "parentCurrentHead": "b91c42b70268d193bca972b111639a22484a8ee1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c3f10b153",
+        "sha": "c3f10b1537d562e34be467537696e4d22878dd99",
+        "iso": "2026-06-02T15:49:17-04:00",
+        "subject": "test(cli): extract traditions command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-celebration-government-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-traditions-command-tests",
+      "children": [
+        "codex/extract-notification-hud-materialization-tests"
+      ],
+      "depth": 58,
+      "head": "8472f6744199068df630a6720a76835bb9465035",
+      "parentRecordedHead": "c3f10b1537d562e34be467537696e4d22878dd99",
+      "parentCurrentHead": "c3f10b1537d562e34be467537696e4d22878dd99",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8472f6744",
+        "sha": "8472f6744199068df630a6720a76835bb9465035",
+        "iso": "2026-06-02T15:49:17-04:00",
+        "subject": "test(cli): extract celebration government command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-notification-hud-materialization-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-celebration-government-command-tests",
+      "children": [
+        "codex/extract-technology-command-tests"
+      ],
+      "depth": 59,
+      "head": "30eeb216e20f2a7b185ead0fa8cec6e392a20774",
+      "parentRecordedHead": "8472f6744199068df630a6720a76835bb9465035",
+      "parentCurrentHead": "8472f6744199068df630a6720a76835bb9465035",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "30eeb216e",
+        "sha": "30eeb216e20f2a7b185ead0fa8cec6e392a20774",
+        "iso": "2026-06-02T15:49:17-04:00",
+        "subject": "test(cli): extract notification HUD materialization tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-technology-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-notification-hud-materialization-tests",
+      "children": [
+        "codex/extract-culture-command-tests"
+      ],
+      "depth": 60,
+      "head": "cf0a8849ebc604c844541ce28185947b760e971a",
+      "parentRecordedHead": "30eeb216e20f2a7b185ead0fa8cec6e392a20774",
+      "parentCurrentHead": "30eeb216e20f2a7b185ead0fa8cec6e392a20774",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "cf0a8849e",
+        "sha": "cf0a8849ebc604c844541ce28185947b760e971a",
+        "iso": "2026-06-02T15:49:17-04:00",
+        "subject": "test(cli): extract technology command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-culture-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-technology-command-tests",
+      "children": [
+        "codex/extract-diplomacy-response-command-tests"
+      ],
+      "depth": 61,
+      "head": "61d42d1db2eedeebb3807b7774c434f5e453f810",
+      "parentRecordedHead": "cf0a8849ebc604c844541ce28185947b760e971a",
+      "parentCurrentHead": "cf0a8849ebc604c844541ce28185947b760e971a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "61d42d1db",
+        "sha": "61d42d1db2eedeebb3807b7774c434f5e453f810",
+        "iso": "2026-06-02T15:49:17-04:00",
+        "subject": "test(cli): extract culture command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-diplomacy-response-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-culture-command-tests",
+      "children": [
+        "codex/extract-narrative-command-tests"
+      ],
+      "depth": 62,
+      "head": "245d5347d02e71f27cc0dbf32e5779087b47b36e",
+      "parentRecordedHead": "61d42d1db2eedeebb3807b7774c434f5e453f810",
+      "parentCurrentHead": "61d42d1db2eedeebb3807b7774c434f5e453f810",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "245d5347d",
+        "sha": "245d5347d02e71f27cc0dbf32e5779087b47b36e",
+        "iso": "2026-06-02T15:49:17-04:00",
+        "subject": "test(cli): extract diplomacy response command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-narrative-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-diplomacy-response-command-tests",
+      "children": [
+        "codex/extract-notification-queue-command-tests"
+      ],
+      "depth": 63,
+      "head": "4314ac030df333df1e69374b526bb5f88b7cd92c",
+      "parentRecordedHead": "245d5347d02e71f27cc0dbf32e5779087b47b36e",
+      "parentCurrentHead": "245d5347d02e71f27cc0dbf32e5779087b47b36e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4314ac030",
+        "sha": "4314ac030df333df1e69374b526bb5f88b7cd92c",
+        "iso": "2026-06-02T15:49:18-04:00",
+        "subject": "test(cli): extract narrative command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-notification-queue-command-tests",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-narrative-command-tests",
+      "children": [
+        "codex/extract-unit-target-verification"
+      ],
+      "depth": 64,
+      "head": "050238ed957c5fe91d6a122624246b9703cae596",
+      "parentRecordedHead": "4314ac030df333df1e69374b526bb5f88b7cd92c",
+      "parentCurrentHead": "4314ac030df333df1e69374b526bb5f88b7cd92c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "050238ed9",
+        "sha": "050238ed957c5fe91d6a122624246b9703cae596",
+        "iso": "2026-06-02T15:49:18-04:00",
+        "subject": "test(cli): extract notification queue command tests"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-unit-target-verification",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-notification-queue-command-tests",
+      "children": [
+        "codex/extract-notification-dismissal-verification"
+      ],
+      "depth": 65,
+      "head": "bac25dc123e8440a6472f6be53f81643fa9de326",
+      "parentRecordedHead": "050238ed957c5fe91d6a122624246b9703cae596",
+      "parentCurrentHead": "050238ed957c5fe91d6a122624246b9703cae596",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bac25dc12",
+        "sha": "bac25dc123e8440a6472f6be53f81643fa9de326",
+        "iso": "2026-06-02T15:49:18-04:00",
+        "subject": "refactor(direct-control): extract unit target verification"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-notification-dismissal-verification",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-unit-target-verification",
+      "children": [
+        "codex/clarify-formation-relationship-policy"
+      ],
+      "depth": 66,
+      "head": "5f8132e54a512cdcd0d95900e7a5df4f33b2e564",
+      "parentRecordedHead": "bac25dc123e8440a6472f6be53f81643fa9de326",
+      "parentCurrentHead": "bac25dc123e8440a6472f6be53f81643fa9de326",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5f8132e54",
+        "sha": "5f8132e54a512cdcd0d95900e7a5df4f33b2e564",
+        "iso": "2026-06-02T15:49:18-04:00",
+        "subject": "refactor(direct-control): extract notification dismissal verification"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/clarify-formation-relationship-policy",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-notification-dismissal-verification",
+      "children": [
+        "codex/clarify-tactical-relationship-docs"
+      ],
+      "depth": 67,
+      "head": "e79026a66e9d6fcc767e3bdf4ba40b9cf7a232c8",
+      "parentRecordedHead": "5f8132e54a512cdcd0d95900e7a5df4f33b2e564",
+      "parentCurrentHead": "5f8132e54a512cdcd0d95900e7a5df4f33b2e564",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e79026a66",
+        "sha": "e79026a66e9d6fcc767e3bdf4ba40b9cf7a232c8",
+        "iso": "2026-06-02T15:49:18-04:00",
+        "subject": "feat(cli): expose formation relationship policy"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/clarify-tactical-relationship-docs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/clarify-formation-relationship-policy",
+      "children": [
+        "codex/priorities-exact-ready-unit-command"
+      ],
+      "depth": 68,
+      "head": "f2158b38f2228c63e80cd238a9776fd19841d379",
+      "parentRecordedHead": "e79026a66e9d6fcc767e3bdf4ba40b9cf7a232c8",
+      "parentCurrentHead": "e79026a66e9d6fcc767e3bdf4ba40b9cf7a232c8",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f2158b38f",
+        "sha": "f2158b38f2228c63e80cd238a9776fd19841d379",
+        "iso": "2026-06-02T15:49:18-04:00",
+        "subject": "docs(play): clarify tactical relationship wording"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/priorities-exact-ready-unit-command",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/clarify-tactical-relationship-docs",
+      "children": [
+        "codex/extract-runtime-inspection-source"
+      ],
+      "depth": 69,
+      "head": "e0f5e91dd8677f6dedd82e64e16a8105b1302c7b",
+      "parentRecordedHead": "f2158b38f2228c63e80cd238a9776fd19841d379",
+      "parentCurrentHead": "f2158b38f2228c63e80cd238a9776fd19841d379",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e0f5e91dd",
+        "sha": "e0f5e91dd8677f6dedd82e64e16a8105b1302c7b",
+        "iso": "2026-06-02T15:49:18-04:00",
+        "subject": "feat(cli): use exact ready unit priority commands"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-runtime-inspection-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/priorities-exact-ready-unit-command",
+      "children": [
+        "codex/extract-map-gameinfo-source"
+      ],
+      "depth": 70,
+      "head": "84950b80c4d85bb8cb457acbdadc425f9d6897ce",
+      "parentRecordedHead": "e0f5e91dd8677f6dedd82e64e16a8105b1302c7b",
+      "parentCurrentHead": "e0f5e91dd8677f6dedd82e64e16a8105b1302c7b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "84950b80c",
+        "sha": "84950b80c4d85bb8cb457acbdadc425f9d6897ce",
+        "iso": "2026-06-02T15:49:19-04:00",
+        "subject": "refactor(direct-control): extract runtime inspection source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-map-gameinfo-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-runtime-inspection-source",
+      "children": [
+        "codex/extract-plot-map-command-source"
+      ],
+      "depth": 71,
+      "head": "7561b0a547ca2ff91c21e9a998461320b473fdae",
+      "parentRecordedHead": "84950b80c4d85bb8cb457acbdadc425f9d6897ce",
+      "parentCurrentHead": "84950b80c4d85bb8cb457acbdadc425f9d6897ce",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7561b0a54",
+        "sha": "7561b0a547ca2ff91c21e9a998461320b473fdae",
+        "iso": "2026-06-02T15:49:19-04:00",
+        "subject": "refactor(direct-control): extract map gameinfo source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-plot-map-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-map-gameinfo-source",
+      "children": [
+        "codex/extract-setup-read-command-source"
+      ],
+      "depth": 72,
+      "head": "6fcc66b10678899b1b72ddfced93396f4521b852",
+      "parentRecordedHead": "7561b0a547ca2ff91c21e9a998461320b473fdae",
+      "parentCurrentHead": "7561b0a547ca2ff91c21e9a998461320b473fdae",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6fcc66b10",
+        "sha": "6fcc66b10678899b1b72ddfced93396f4521b852",
+        "iso": "2026-06-02T15:49:19-04:00",
+        "subject": "refactor(direct-control): extract plot map command source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-setup-read-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-plot-map-command-source",
+      "children": [
+        "codex/extract-root-inspection-source"
+      ],
+      "depth": 73,
+      "head": "f39801354592b283f8fdfcec449105a28ec57a32",
+      "parentRecordedHead": "6fcc66b10678899b1b72ddfced93396f4521b852",
+      "parentCurrentHead": "6fcc66b10678899b1b72ddfced93396f4521b852",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "f39801354",
+        "sha": "f39801354592b283f8fdfcec449105a28ec57a32",
+        "iso": "2026-06-02T15:49:19-04:00",
+        "subject": "refactor(direct-control): extract setup read command source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-root-inspection-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-setup-read-command-source",
+      "children": [
+        "codex/extract-play-notification-read-command-source"
+      ],
+      "depth": 74,
+      "head": "895de526d3a7138db6a7197133224a038f10716c",
+      "parentRecordedHead": "f39801354592b283f8fdfcec449105a28ec57a32",
+      "parentCurrentHead": "f39801354592b283f8fdfcec449105a28ec57a32",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "895de526d",
+        "sha": "895de526d3a7138db6a7197133224a038f10716c",
+        "iso": "2026-06-02T15:49:19-04:00",
+        "subject": "refactor(direct-control): extract root inspection source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-play-notification-read-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-root-inspection-source",
+      "children": [
+        "codex/extract-ready-unit-read-command-source"
+      ],
+      "depth": 75,
+      "head": "5b55bad9046b19a4413d504ed9033e38aaa9ac9b",
+      "parentRecordedHead": "895de526d3a7138db6a7197133224a038f10716c",
+      "parentCurrentHead": "895de526d3a7138db6a7197133224a038f10716c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5b55bad90",
+        "sha": "5b55bad9046b19a4413d504ed9033e38aaa9ac9b",
+        "iso": "2026-06-02T15:49:19-04:00",
+        "subject": "refactor(direct-control): extract play notification read command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-ready-unit-read-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-play-notification-read-command-source",
+      "children": [
+        "codex/extract-ready-city-read-command-source"
+      ],
+      "depth": 76,
+      "head": "95db071a4e0e2671479294d807754fe26d251ca1",
+      "parentRecordedHead": "5b55bad9046b19a4413d504ed9033e38aaa9ac9b",
+      "parentCurrentHead": "5b55bad9046b19a4413d504ed9033e38aaa9ac9b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "95db071a4",
+        "sha": "95db071a4e0e2671479294d807754fe26d251ca1",
+        "iso": "2026-06-02T15:49:19-04:00",
+        "subject": "refactor(direct-control): extract ready unit read command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-ready-city-read-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-ready-unit-read-command-source",
+      "children": [
+        "codex/extract-settlement-recommendations-read-command-source"
+      ],
+      "depth": 77,
+      "head": "044a9eaa36047195cd4e769a118b9ccc909aa199",
+      "parentRecordedHead": "95db071a4e0e2671479294d807754fe26d251ca1",
+      "parentCurrentHead": "95db071a4e0e2671479294d807754fe26d251ca1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "044a9eaa3",
+        "sha": "044a9eaa36047195cd4e769a118b9ccc909aa199",
+        "iso": "2026-06-02T15:49:19-04:00",
+        "subject": "refactor(direct-control): extract ready city read command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-settlement-recommendations-read-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-ready-city-read-command-source",
+      "children": [
+        "codex/extract-target-candidates-read-command-source"
+      ],
+      "depth": 78,
+      "head": "85ea8d635ad0a378833a912c2f4e7e6099680bd7",
+      "parentRecordedHead": "044a9eaa36047195cd4e769a118b9ccc909aa199",
+      "parentCurrentHead": "044a9eaa36047195cd4e769a118b9ccc909aa199",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "85ea8d635",
+        "sha": "85ea8d635ad0a378833a912c2f4e7e6099680bd7",
+        "iso": "2026-06-02T15:49:19-04:00",
+        "subject": "refactor(direct-control): extract settlement read command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-target-candidates-read-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-settlement-recommendations-read-command-source",
+      "children": [
+        "codex/extract-traditions-view-read-command-source"
+      ],
+      "depth": 79,
+      "head": "3bc7dbd04d1d9def1b86f16533a1db7d4b8939df",
+      "parentRecordedHead": "85ea8d635ad0a378833a912c2f4e7e6099680bd7",
+      "parentCurrentHead": "85ea8d635ad0a378833a912c2f4e7e6099680bd7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3bc7dbd04",
+        "sha": "3bc7dbd04d1d9def1b86f16533a1db7d4b8939df",
+        "iso": "2026-06-02T15:49:20-04:00",
+        "subject": "refactor(direct-control): extract target candidates read command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-traditions-view-read-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-target-candidates-read-command-source",
+      "children": [
+        "codex/extract-progress-dashboard-read-command-source"
+      ],
+      "depth": 80,
+      "head": "25de75655d22193070dde5302412a25ed6769d3b",
+      "parentRecordedHead": "3bc7dbd04d1d9def1b86f16533a1db7d4b8939df",
+      "parentCurrentHead": "3bc7dbd04d1d9def1b86f16533a1db7d4b8939df",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "25de75655",
+        "sha": "25de75655d22193070dde5302412a25ed6769d3b",
+        "iso": "2026-06-02T15:49:20-04:00",
+        "subject": "refactor(direct-control): extract traditions read command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-progress-dashboard-read-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-traditions-view-read-command-source",
+      "children": [
+        "codex/extract-battlefield-scan-read-command-source"
+      ],
+      "depth": 81,
+      "head": "05b260d7ce439ce1e0332e5a4966010989be13c2",
+      "parentRecordedHead": "25de75655d22193070dde5302412a25ed6769d3b",
+      "parentCurrentHead": "25de75655d22193070dde5302412a25ed6769d3b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "05b260d7c",
+        "sha": "05b260d7ce439ce1e0332e5a4966010989be13c2",
+        "iso": "2026-06-02T15:49:20-04:00",
+        "subject": "refactor(direct-control): extract progress dashboard read command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-battlefield-scan-read-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-progress-dashboard-read-command-source",
+      "children": [
+        "codex/extract-destination-analysis-read-command-source"
+      ],
+      "depth": 82,
+      "head": "aedd8247b77fd9a7af5c28117f72d62055d7913b",
+      "parentRecordedHead": "05b260d7ce439ce1e0332e5a4966010989be13c2",
+      "parentCurrentHead": "05b260d7ce439ce1e0332e5a4966010989be13c2",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "aedd8247b",
+        "sha": "aedd8247b77fd9a7af5c28117f72d62055d7913b",
+        "iso": "2026-06-02T15:49:20-04:00",
+        "subject": "refactor(direct-control): extract battlefield scan read command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-destination-analysis-read-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-battlefield-scan-read-command-source",
+      "children": [
+        "codex/extract-operation-router-command-source"
+      ],
+      "depth": 83,
+      "head": "05dfaa2ba6ac8084459a0a569de2c606aeacb33f",
+      "parentRecordedHead": "aedd8247b77fd9a7af5c28117f72d62055d7913b",
+      "parentCurrentHead": "aedd8247b77fd9a7af5c28117f72d62055d7913b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "05dfaa2ba",
+        "sha": "05dfaa2ba6ac8084459a0a569de2c606aeacb33f",
+        "iso": "2026-06-02T15:49:20-04:00",
+        "subject": "refactor(direct-control): extract destination analysis read command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-operation-router-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-destination-analysis-read-command-source",
+      "children": [
+        "codex/extract-unit-target-command-source"
+      ],
+      "depth": 84,
+      "head": "fc8d927e983006cc1ef19f07d29de163ab310a87",
+      "parentRecordedHead": "05dfaa2ba6ac8084459a0a569de2c606aeacb33f",
+      "parentCurrentHead": "05dfaa2ba6ac8084459a0a569de2c606aeacb33f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "fc8d927e9",
+        "sha": "fc8d927e983006cc1ef19f07d29de163ab310a87",
+        "iso": "2026-06-02T15:49:20-04:00",
+        "subject": "refactor(direct-control): extract operation router commands"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-unit-target-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-operation-router-command-source",
+      "children": [
+        "codex/extract-production-choice-command-source"
+      ],
+      "depth": 85,
+      "head": "a8c5309a91fae8ffaaac3e356c1e24a82001811a",
+      "parentRecordedHead": "fc8d927e983006cc1ef19f07d29de163ab310a87",
+      "parentCurrentHead": "fc8d927e983006cc1ef19f07d29de163ab310a87",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a8c5309a9",
+        "sha": "a8c5309a91fae8ffaaac3e356c1e24a82001811a",
+        "iso": "2026-06-02T15:49:20-04:00",
+        "subject": "refactor(direct-control): extract unit target command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-production-choice-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-unit-target-command-source",
+      "children": [
+        "codex/extract-technology-choice-command-source"
+      ],
+      "depth": 86,
+      "head": "7a8588b68e19d2eb7d0100244763ffaebe305bc3",
+      "parentRecordedHead": "a8c5309a91fae8ffaaac3e356c1e24a82001811a",
+      "parentCurrentHead": "a8c5309a91fae8ffaaac3e356c1e24a82001811a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "7a8588b68",
+        "sha": "7a8588b68e19d2eb7d0100244763ffaebe305bc3",
+        "iso": "2026-06-02T15:49:20-04:00",
+        "subject": "refactor(direct-control): extract production choice command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-technology-choice-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-production-choice-command-source",
+      "children": [
+        "codex/extract-culture-choice-command-source"
+      ],
+      "depth": 87,
+      "head": "772c33c1d04e628b9034fc419e02e0d70909b363",
+      "parentRecordedHead": "7a8588b68e19d2eb7d0100244763ffaebe305bc3",
+      "parentCurrentHead": "7a8588b68e19d2eb7d0100244763ffaebe305bc3",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "772c33c1d",
+        "sha": "772c33c1d04e628b9034fc419e02e0d70909b363",
+        "iso": "2026-06-02T15:49:21-04:00",
+        "subject": "refactor(direct-control): extract technology choice command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-culture-choice-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-technology-choice-command-source",
+      "children": [
+        "codex/extract-narrative-choice-command-source"
+      ],
+      "depth": 88,
+      "head": "28d8376163226b3f34806733736f841d022d0682",
+      "parentRecordedHead": "772c33c1d04e628b9034fc419e02e0d70909b363",
+      "parentCurrentHead": "772c33c1d04e628b9034fc419e02e0d70909b363",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "28d837616",
+        "sha": "28d8376163226b3f34806733736f841d022d0682",
+        "iso": "2026-06-02T15:49:21-04:00",
+        "subject": "refactor(direct-control): extract culture choice command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-narrative-choice-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-culture-choice-command-source",
+      "children": [
+        "codex/extract-diplomacy-response-command-source"
+      ],
+      "depth": 89,
+      "head": "a056e86d8c90ab42c2185c19b995d34e803e43b8",
+      "parentRecordedHead": "28d8376163226b3f34806733736f841d022d0682",
+      "parentCurrentHead": "28d8376163226b3f34806733736f841d022d0682",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a056e86d8",
+        "sha": "a056e86d8c90ab42c2185c19b995d34e803e43b8",
+        "iso": "2026-06-02T15:49:21-04:00",
+        "subject": "refactor(direct-control): extract narrative choice command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-diplomacy-response-command-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-narrative-choice-command-source",
+      "children": [
+        "codex/remove-notification-dismissal-command-shim"
+      ],
+      "depth": 90,
+      "head": "8b271a8985aecfe0d63d83536afd41fec3c262dc",
+      "parentRecordedHead": "a056e86d8c90ab42c2185c19b995d34e803e43b8",
+      "parentCurrentHead": "a056e86d8c90ab42c2185c19b995d34e803e43b8",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8b271a898",
+        "sha": "8b271a8985aecfe0d63d83536afd41fec3c262dc",
+        "iso": "2026-06-02T15:49:21-04:00",
+        "subject": "refactor(direct-control): extract diplomacy response command"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/remove-notification-dismissal-command-shim",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-diplomacy-response-command-source",
+      "children": [
+        "codex/group-play-choice-commands"
+      ],
+      "depth": 91,
+      "head": "86a54b66ef9f9794283a565fdac66e22e1db503b",
+      "parentRecordedHead": "8b271a8985aecfe0d63d83536afd41fec3c262dc",
+      "parentCurrentHead": "8b271a8985aecfe0d63d83536afd41fec3c262dc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "86a54b66e",
+        "sha": "86a54b66ef9f9794283a565fdac66e22e1db503b",
+        "iso": "2026-06-02T15:49:21-04:00",
+        "subject": "refactor(direct-control): remove notification dismissal shim"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/group-play-choice-commands",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/remove-notification-dismissal-command-shim",
+      "children": [
+        "codex/extract-decision-choice-options"
+      ],
+      "depth": 92,
+      "head": "6b704cfab8b55106741369639af8d6779a902f6d",
+      "parentRecordedHead": "86a54b66ef9f9794283a565fdac66e22e1db503b",
+      "parentCurrentHead": "86a54b66ef9f9794283a565fdac66e22e1db503b",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6b704cfab",
+        "sha": "6b704cfab8b55106741369639af8d6779a902f6d",
+        "iso": "2026-06-02T15:49:21-04:00",
+        "subject": "refactor(cli): extract progression choice options"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-decision-choice-options",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/group-play-choice-commands",
+      "children": [
+        "codex/extract-notification-queue-fixture"
+      ],
+      "depth": 93,
+      "head": "108c709a6387c09afbe21206d5bf5c0db184452f",
+      "parentRecordedHead": "6b704cfab8b55106741369639af8d6779a902f6d",
+      "parentCurrentHead": "6b704cfab8b55106741369639af8d6779a902f6d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "108c709a6",
+        "sha": "108c709a6387c09afbe21206d5bf5c0db184452f",
+        "iso": "2026-06-02T15:49:21-04:00",
+        "subject": "refactor(cli): extract decision choice options"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-notification-queue-fixture",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-decision-choice-options",
+      "children": [
+        "codex/extract-narrative-command-fixture"
+      ],
+      "depth": 94,
+      "head": "e551d523307d673ca7a823a02609651596ffcaf5",
+      "parentRecordedHead": "108c709a6387c09afbe21206d5bf5c0db184452f",
+      "parentCurrentHead": "108c709a6387c09afbe21206d5bf5c0db184452f",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e551d5233",
+        "sha": "e551d523307d673ca7a823a02609651596ffcaf5",
+        "iso": "2026-06-02T15:49:21-04:00",
+        "subject": "test(cli): extract notification queue fixture"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-narrative-command-fixture",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-notification-queue-fixture",
+      "children": [
+        "codex/extract-tactical-read-fixture"
+      ],
+      "depth": 95,
+      "head": "ef87a097ff04965ba0e82b28e70834a862cfe8bc",
+      "parentRecordedHead": "e551d523307d673ca7a823a02609651596ffcaf5",
+      "parentCurrentHead": "e551d523307d673ca7a823a02609651596ffcaf5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "ef87a097f",
+        "sha": "ef87a097ff04965ba0e82b28e70834a862cfe8bc",
+        "iso": "2026-06-02T15:49:22-04:00",
+        "subject": "test(cli): extract narrative command fixture"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-tactical-read-fixture",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-narrative-command-fixture",
+      "children": [
+        "codex/extract-tuner-socket-framing"
+      ],
+      "depth": 96,
+      "head": "4b1a0307018d097a1e7b8d0772c62c0f00b0157d",
+      "parentRecordedHead": "ef87a097ff04965ba0e82b28e70834a862cfe8bc",
+      "parentCurrentHead": "ef87a097ff04965ba0e82b28e70834a862cfe8bc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "4b1a03070",
+        "sha": "4b1a0307018d097a1e7b8d0772c62c0f00b0157d",
+        "iso": "2026-06-02T15:49:22-04:00",
+        "subject": "test(cli): extract tactical read fixture"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-tuner-socket-framing",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-tactical-read-fixture",
+      "children": [
+        "codex/extract-log-proof-helpers"
+      ],
+      "depth": 97,
+      "head": "c6bf3729fa4d5b28cdb8148ea96945dcde9d0445",
+      "parentRecordedHead": "4b1a0307018d097a1e7b8d0772c62c0f00b0157d",
+      "parentCurrentHead": "4b1a0307018d097a1e7b8d0772c62c0f00b0157d",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c6bf3729f",
+        "sha": "c6bf3729fa4d5b28cdb8148ea96945dcde9d0445",
+        "iso": "2026-06-02T15:49:22-04:00",
+        "subject": "refactor(direct-control): extract tuner socket framing"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-log-proof-helpers",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-tuner-socket-framing",
+      "children": [
+        "codex/extract-direct-control-error-helpers"
+      ],
+      "depth": 98,
+      "head": "8dc3186b7d8ae6c46a44ebaf800469f2725655ee",
+      "parentRecordedHead": "c6bf3729fa4d5b28cdb8148ea96945dcde9d0445",
+      "parentCurrentHead": "c6bf3729fa4d5b28cdb8148ea96945dcde9d0445",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8dc3186b7",
+        "sha": "8dc3186b7d8ae6c46a44ebaf800469f2725655ee",
+        "iso": "2026-06-02T15:49:22-04:00",
+        "subject": "refactor(direct-control): extract log proof helpers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-direct-control-error-helpers",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-log-proof-helpers",
+      "children": [
+        "codex/extract-tuner-session"
+      ],
+      "depth": 99,
+      "head": "3923e5d41a3e4bdd1e582dcb510d16980e864e99",
+      "parentRecordedHead": "8dc3186b7d8ae6c46a44ebaf800469f2725655ee",
+      "parentCurrentHead": "8dc3186b7d8ae6c46a44ebaf800469f2725655ee",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "3923e5d41",
+        "sha": "3923e5d41a3e4bdd1e582dcb510d16980e864e99",
+        "iso": "2026-06-02T15:49:22-04:00",
+        "subject": "refactor(direct-control): extract error helpers"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-tuner-session",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-direct-control-error-helpers",
+      "children": [
+        "codex/extract-health-status-source"
+      ],
+      "depth": 100,
+      "head": "86d3371e83001f51a508b2b11b19b07c65472054",
+      "parentRecordedHead": "3923e5d41a3e4bdd1e582dcb510d16980e864e99",
+      "parentCurrentHead": "3923e5d41a3e4bdd1e582dcb510d16980e864e99",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "86d3371e8",
+        "sha": "86d3371e83001f51a508b2b11b19b07c65472054",
+        "iso": "2026-06-02T15:49:22-04:00",
+        "subject": "refactor(direct-control): extract tuner session"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-health-status-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-tuner-session",
+      "children": [
+        "codex/extract-capability-catalog-source"
+      ],
+      "depth": 101,
+      "head": "9a967aa2650873182fd1590183de589fcd9ce3c7",
+      "parentRecordedHead": "86d3371e83001f51a508b2b11b19b07c65472054",
+      "parentCurrentHead": "86d3371e83001f51a508b2b11b19b07c65472054",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9a967aa26",
+        "sha": "9a967aa2650873182fd1590183de589fcd9ce3c7",
+        "iso": "2026-06-02T15:49:22-04:00",
+        "subject": "refactor(direct-control): extract health status source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-capability-catalog-source",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-health-status-source",
+      "children": [
+        "codex/extract-root-inspection-runtime"
+      ],
+      "depth": 102,
+      "head": "e3a720ca7f3ff91d2361773daec7b480780ce647",
+      "parentRecordedHead": "9a967aa2650873182fd1590183de589fcd9ce3c7",
+      "parentCurrentHead": "9a967aa2650873182fd1590183de589fcd9ce3c7",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e3a720ca7",
+        "sha": "e3a720ca7f3ff91d2361773daec7b480780ce647",
+        "iso": "2026-06-02T15:49:22-04:00",
+        "subject": "refactor(direct-control): extract capability catalog source"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-root-inspection-runtime",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-capability-catalog-source",
+      "children": [
+        "codex/extract-component-id-primitive"
+      ],
+      "depth": 103,
+      "head": "2ce035eae1664813f1b14520371ab6659b53931c",
+      "parentRecordedHead": "e3a720ca7f3ff91d2361773daec7b480780ce647",
+      "parentCurrentHead": "e3a720ca7f3ff91d2361773daec7b480780ce647",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "2ce035eae",
+        "sha": "2ce035eae1664813f1b14520371ab6659b53931c",
+        "iso": "2026-06-02T15:49:23-04:00",
+        "subject": "refactor(direct-control): extract root inspection runtime"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-component-id-primitive",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-root-inspection-runtime",
+      "children": [
+        "codex/extract-map-gameinfo-runtime"
+      ],
+      "depth": 104,
+      "head": "6bb422f789a4a9bb5d300379942b7b37babb8d13",
+      "parentRecordedHead": "2ce035eae1664813f1b14520371ab6659b53931c",
+      "parentCurrentHead": "2ce035eae1664813f1b14520371ab6659b53931c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6bb422f78",
+        "sha": "6bb422f789a4a9bb5d300379942b7b37babb8d13",
+        "iso": "2026-06-02T15:49:23-04:00",
+        "subject": "refactor(direct-control): extract component id primitive"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-map-gameinfo-runtime",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-component-id-primitive",
+      "children": [
+        "codex/extract-tactical-read-runtime"
+      ],
+      "depth": 105,
+      "head": "5d80a4223dab11b3de41b03e88ebb39357602d94",
+      "parentRecordedHead": "6bb422f789a4a9bb5d300379942b7b37babb8d13",
+      "parentCurrentHead": "6bb422f789a4a9bb5d300379942b7b37babb8d13",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5d80a4223",
+        "sha": "5d80a4223dab11b3de41b03e88ebb39357602d94",
+        "iso": "2026-06-02T15:49:23-04:00",
+        "subject": "refactor(direct-control): extract map gameinfo runtime"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-tactical-read-runtime",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-map-gameinfo-runtime",
+      "children": [
+        "codex/extract-progression-read-runtime"
+      ],
+      "depth": 106,
+      "head": "5a63cc5205f8eb3727e54128640508dd676d7270",
+      "parentRecordedHead": "5d80a4223dab11b3de41b03e88ebb39357602d94",
+      "parentCurrentHead": "5d80a4223dab11b3de41b03e88ebb39357602d94",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "5a63cc520",
+        "sha": "5a63cc5205f8eb3727e54128640508dd676d7270",
+        "iso": "2026-06-02T15:49:23-04:00",
+        "subject": "refactor(direct-control): extract tactical read runtime"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-progression-read-runtime",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-tactical-read-runtime",
+      "children": [
+        "codex/extract-ready-views-runtime"
+      ],
+      "depth": 107,
+      "head": "17f915d0c2378389d8843123e148aa5e7374799c",
+      "parentRecordedHead": "5a63cc5205f8eb3727e54128640508dd676d7270",
+      "parentCurrentHead": "5a63cc5205f8eb3727e54128640508dd676d7270",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "17f915d0c",
+        "sha": "17f915d0c2378389d8843123e148aa5e7374799c",
+        "iso": "2026-06-02T15:49:23-04:00",
+        "subject": "refactor(direct-control): extract progression read runtime"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-ready-views-runtime",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-progression-read-runtime",
+      "children": [
+        "codex/extract-play-notification-runtime"
+      ],
+      "depth": 108,
+      "head": "37895d0c0ee228491edd95525867fd00554a3e79",
+      "parentRecordedHead": "17f915d0c2378389d8843123e148aa5e7374799c",
+      "parentCurrentHead": "17f915d0c2378389d8843123e148aa5e7374799c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "37895d0c0",
+        "sha": "37895d0c0ee228491edd95525867fd00554a3e79",
+        "iso": "2026-06-02T15:49:23-04:00",
+        "subject": "refactor(direct-control): extract ready view runtime"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-play-notification-runtime",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-ready-views-runtime",
+      "children": [
+        "codex/extract-notification-closeout-runtime"
+      ],
+      "depth": 109,
+      "head": "c45f4059ed0d224f6f484bd80cc69eee0503d70a",
+      "parentRecordedHead": "37895d0c0ee228491edd95525867fd00554a3e79",
+      "parentCurrentHead": "37895d0c0ee228491edd95525867fd00554a3e79",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "c45f4059e",
+        "sha": "c45f4059ed0d224f6f484bd80cc69eee0503d70a",
+        "iso": "2026-06-02T15:49:23-04:00",
+        "subject": "refactor(direct-control): extract play notification runtime"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-notification-closeout-runtime",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-play-notification-runtime",
+      "children": [
+        "codex/extract-unit-target-runtime"
+      ],
+      "depth": 110,
+      "head": "45cf818f024d8787e6df1b11198b8d6aeb65edfc",
+      "parentRecordedHead": "c45f4059ed0d224f6f484bd80cc69eee0503d70a",
+      "parentCurrentHead": "c45f4059ed0d224f6f484bd80cc69eee0503d70a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "45cf818f0",
+        "sha": "45cf818f024d8787e6df1b11198b8d6aeb65edfc",
+        "iso": "2026-06-02T15:49:23-04:00",
+        "subject": "refactor(direct-control): extract notification closeout runtime"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-unit-target-runtime",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-notification-closeout-runtime",
+      "children": [
+        "codex/add-orpc-control-alignment-packet"
+      ],
+      "depth": 111,
+      "head": "e31bb3196aa1c717f566e5d69bf6e1fecc3b333e",
+      "parentRecordedHead": "45cf818f024d8787e6df1b11198b8d6aeb65edfc",
+      "parentCurrentHead": "45cf818f024d8787e6df1b11198b8d6aeb65edfc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e31bb3196",
+        "sha": "e31bb3196aa1c717f566e5d69bf6e1fecc3b333e",
+        "iso": "2026-06-02T15:49:24-04:00",
+        "subject": "refactor(direct-control): extract unit target runtime"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-orpc-control-alignment-packet",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-unit-target-runtime",
+      "children": [
+        "codex/add-control-orpc-session-core"
+      ],
+      "depth": 112,
+      "head": "87f2d9c4e5dbf70517f891de584c789d0956db62",
+      "parentRecordedHead": "e31bb3196aa1c717f566e5d69bf6e1fecc3b333e",
+      "parentCurrentHead": "e31bb3196aa1c717f566e5d69bf6e1fecc3b333e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "87f2d9c4e",
+        "sha": "87f2d9c4e5dbf70517f891de584c789d0956db62",
+        "iso": "2026-06-02T15:49:24-04:00",
+        "subject": "docs(direct-control): map oRPC control atoms"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-session-core",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-orpc-control-alignment-packet",
+      "children": [
+        "codex/add-control-orpc-notifications-read"
+      ],
+      "depth": 113,
+      "head": "dc85d94168bb6be95ec1f860e90beee727b14748",
+      "parentRecordedHead": "87f2d9c4e5dbf70517f891de584c789d0956db62",
+      "parentCurrentHead": "87f2d9c4e5dbf70517f891de584c789d0956db62",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "dc85d9416",
+        "sha": "dc85d94168bb6be95ec1f860e90beee727b14748",
+        "iso": "2026-06-02T15:49:24-04:00",
+        "subject": "feat(control-orpc): add session playable status procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-notifications-read",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-session-core",
+      "children": [
+        "codex/describe-component-id-schema"
+      ],
+      "depth": 114,
+      "head": "614d8ce68d5ee7abf74beab37167620ace9261bf",
+      "parentRecordedHead": "dc85d94168bb6be95ec1f860e90beee727b14748",
+      "parentCurrentHead": "dc85d94168bb6be95ec1f860e90beee727b14748",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "614d8ce68",
+        "sha": "614d8ce68d5ee7abf74beab37167620ace9261bf",
+        "iso": "2026-06-02T15:49:24-04:00",
+        "subject": "feat(control-orpc): add notifications read procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/describe-component-id-schema",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-notifications-read",
+      "children": [
+        "codex/add-control-orpc-unit-ready"
+      ],
+      "depth": 115,
+      "head": "a1197942b114d842543cd2f3935f629cf0b80afc",
+      "parentRecordedHead": "614d8ce68d5ee7abf74beab37167620ace9261bf",
+      "parentCurrentHead": "614d8ce68d5ee7abf74beab37167620ace9261bf",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "a1197942b",
+        "sha": "a1197942b114d842543cd2f3935f629cf0b80afc",
+        "iso": "2026-06-02T15:49:24-04:00",
+        "subject": "refactor(direct-control): describe component id schema"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-unit-ready",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/describe-component-id-schema",
+      "children": [
+        "codex/extract-map-location-schema"
+      ],
+      "depth": 116,
+      "head": "bc3b253c2a304b9934d0aa8ce24ad08c88d743eb",
+      "parentRecordedHead": "a1197942b114d842543cd2f3935f629cf0b80afc",
+      "parentCurrentHead": "a1197942b114d842543cd2f3935f629cf0b80afc",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "bc3b253c2",
+        "sha": "bc3b253c2a304b9934d0aa8ce24ad08c88d743eb",
+        "iso": "2026-06-02T15:49:24-04:00",
+        "subject": "feat(control-orpc): add unit ready procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-map-location-schema",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-unit-ready",
+      "children": [
+        "codex/add-control-orpc-unit-move-preview"
+      ],
+      "depth": 117,
+      "head": "29ce8ebc7cf9085b29258ee6f884a59b2dfbd1e4",
+      "parentRecordedHead": "bc3b253c2a304b9934d0aa8ce24ad08c88d743eb",
+      "parentCurrentHead": "bc3b253c2a304b9934d0aa8ce24ad08c88d743eb",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "29ce8ebc7",
+        "sha": "29ce8ebc7cf9085b29258ee6f884a59b2dfbd1e4",
+        "iso": "2026-06-02T15:49:24-04:00",
+        "subject": "refactor(direct-control): extract map location schema"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-unit-move-preview",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-map-location-schema",
+      "children": [
+        "codex/add-control-orpc-city-ready"
+      ],
+      "depth": 118,
+      "head": "6f3bf3e378ee2fc28a6f5cc3f08884d2eccc9211",
+      "parentRecordedHead": "29ce8ebc7cf9085b29258ee6f884a59b2dfbd1e4",
+      "parentCurrentHead": "29ce8ebc7cf9085b29258ee6f884a59b2dfbd1e4",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "6f3bf3e37",
+        "sha": "6f3bf3e378ee2fc28a6f5cc3f08884d2eccc9211",
+        "iso": "2026-06-02T15:49:24-04:00",
+        "subject": "feat(control-orpc): add unit move preview procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-city-ready",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-unit-move-preview",
+      "children": [
+        "codex/extract-player-id-primitive"
+      ],
+      "depth": 119,
+      "head": "b116e3065d192311d11cf73ed31030b27c8cdca5",
+      "parentRecordedHead": "6f3bf3e378ee2fc28a6f5cc3f08884d2eccc9211",
+      "parentCurrentHead": "6f3bf3e378ee2fc28a6f5cc3f08884d2eccc9211",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "b116e3065",
+        "sha": "b116e3065d192311d11cf73ed31030b27c8cdca5",
+        "iso": "2026-06-02T15:49:25-04:00",
+        "subject": "feat(control-orpc): add city ready procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-player-id-primitive",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-city-ready",
+      "children": [
+        "codex/add-control-orpc-progression-reads"
+      ],
+      "depth": 120,
+      "head": "24e3fd48e7965e60becbb39a867aeb1dd43ed0b1",
+      "parentRecordedHead": "b116e3065d192311d11cf73ed31030b27c8cdca5",
+      "parentCurrentHead": "b116e3065d192311d11cf73ed31030b27c8cdca5",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "24e3fd48e",
+        "sha": "24e3fd48e7965e60becbb39a867aeb1dd43ed0b1",
+        "iso": "2026-06-02T15:49:25-04:00",
+        "subject": "refactor(direct-control): extract player id primitive"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-control-orpc-progression-reads",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-player-id-primitive",
+      "children": [
+        "codex/extract-map-bounds-primitive"
+      ],
+      "depth": 121,
+      "head": "18976094d9e3b6d5153a298eae6f05f30727f81c",
+      "parentRecordedHead": "24e3fd48e7965e60becbb39a867aeb1dd43ed0b1",
+      "parentCurrentHead": "24e3fd48e7965e60becbb39a867aeb1dd43ed0b1",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "18976094d",
+        "sha": "18976094d9e3b6d5153a298eae6f05f30727f81c",
+        "iso": "2026-06-02T15:49:25-04:00",
+        "subject": "feat(control-orpc): add progression read procedures"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/extract-map-bounds-primitive",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-control-orpc-progression-reads",
+      "children": [
+        "codex/add-orpc-map-visibility-procedure"
+      ],
+      "depth": 122,
+      "head": "e2511f7d36aec95406e26eedfb8e3c2481af6afd",
+      "parentRecordedHead": "18976094d9e3b6d5153a298eae6f05f30727f81c",
+      "parentCurrentHead": "18976094d9e3b6d5153a298eae6f05f30727f81c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e2511f7d3",
+        "sha": "e2511f7d36aec95406e26eedfb8e3c2481af6afd",
+        "iso": "2026-06-02T15:49:25-04:00",
+        "subject": "refactor(direct-control): extract map bounds primitive"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-orpc-map-visibility-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/extract-map-bounds-primitive",
+      "children": [
+        "codex/normalize-control-orpc-procedure-inputs"
+      ],
+      "depth": 123,
+      "head": "8336a85ae6f5beafe2a7e89916bcb52b162bad0e",
+      "parentRecordedHead": "e2511f7d36aec95406e26eedfb8e3c2481af6afd",
+      "parentCurrentHead": "e2511f7d36aec95406e26eedfb8e3c2481af6afd",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "8336a85ae",
+        "sha": "8336a85ae6f5beafe2a7e89916bcb52b162bad0e",
+        "iso": "2026-06-02T15:49:25-04:00",
+        "subject": "feat(control-orpc): add map visibility procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/normalize-control-orpc-procedure-inputs",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-orpc-map-visibility-procedure",
+      "children": [
+        "codex/add-orpc-map-summary-procedure"
+      ],
+      "depth": 124,
+      "head": "58caa3528edd340aa4f94b603634f7a3996e8edf",
+      "parentRecordedHead": "8336a85ae6f5beafe2a7e89916bcb52b162bad0e",
+      "parentCurrentHead": "8336a85ae6f5beafe2a7e89916bcb52b162bad0e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "58caa3528",
+        "sha": "58caa3528edd340aa4f94b603634f7a3996e8edf",
+        "iso": "2026-06-02T15:49:25-04:00",
+        "subject": "refactor(control-orpc): inline procedure input schemas"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-orpc-map-summary-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/normalize-control-orpc-procedure-inputs",
+      "children": [
+        "codex/add-orpc-map-plot-procedure"
+      ],
+      "depth": 125,
+      "head": "e171292ff815651ab5fa768e97363438b335d32a",
+      "parentRecordedHead": "58caa3528edd340aa4f94b603634f7a3996e8edf",
+      "parentCurrentHead": "58caa3528edd340aa4f94b603634f7a3996e8edf",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "e171292ff",
+        "sha": "e171292ff815651ab5fa768e97363438b335d32a",
+        "iso": "2026-06-02T15:49:25-04:00",
+        "subject": "feat(control-orpc): add map summary procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-orpc-map-plot-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-orpc-map-summary-procedure",
+      "children": [
+        "codex/add-orpc-map-grid-procedure"
+      ],
+      "depth": 126,
+      "head": "24bb5030dc72fabf097b79c433157f1290ca6c2e",
+      "parentRecordedHead": "e171292ff815651ab5fa768e97363438b335d32a",
+      "parentCurrentHead": "e171292ff815651ab5fa768e97363438b335d32a",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "24bb5030d",
+        "sha": "24bb5030dc72fabf097b79c433157f1290ca6c2e",
+        "iso": "2026-06-02T15:49:25-04:00",
+        "subject": "feat(control-orpc): add map plot procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/add-orpc-map-grid-procedure",
+      "root": "codex/local-catalog-enrichment",
+      "parent": "codex/add-orpc-map-plot-procedure",
+      "children": [],
+      "depth": 127,
+      "head": "0b4a812e43dce67d699698f1ac2311c721a8fb71",
+      "parentRecordedHead": "24bb5030dc72fabf097b79c433157f1290ca6c2e",
+      "parentCurrentHead": "24bb5030dc72fabf097b79c433157f1290ca6c2e",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "0b4a812e4",
+        "sha": "0b4a812e43dce67d699698f1ac2311c721a8fb71",
+        "iso": "2026-06-02T15:49:26-04:00",
+        "subject": "feat(control-orpc): add map grid procedure"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "agent-watch-civ7-live-play-reference-assembly",
+      "root": "agent-watch-civ7-live-play-reference-assembly",
+      "parent": "main",
+      "children": [],
+      "depth": 0,
+      "head": "9e67f53645597dfd9d7299bb5beb9509fa7569fe",
+      "parentRecordedHead": "0507ef8e9108fc58f141c241f214994f221eb4d2",
+      "parentCurrentHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+      "validationResult": "VALID",
+      "alignedToParent": false,
+      "needsRestack": true,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "9e67f5364",
+        "sha": "9e67f53645597dfd9d7299bb5beb9509fa7569fe",
+        "iso": "2026-06-01T10:10:33-04:00",
+        "subject": "docs(civ7): clarify live HUD source authority"
+      },
+      "accountingLabels": [],
+      "accountingSummary": "unmarked"
+    },
+    {
+      "branch": "codex/foundation-architecture-packet",
+      "root": "codex/foundation-architecture-packet",
+      "parent": "main",
+      "children": [],
+      "depth": 0,
+      "head": "eaba8d5c707c3e84396bdd002583e21b9cb0d6f3",
+      "parentRecordedHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+      "parentCurrentHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+      "validationResult": "VALID",
+      "alignedToParent": true,
+      "needsRestack": false,
+      "pushedToOrigin": false,
+      "localOnly": true,
+      "commit": {
+        "short": "eaba8d5c7",
+        "sha": "eaba8d5c707c3e84396bdd002583e21b9cb0d6f3",
+        "iso": "2026-06-07T16:16:55-04:00",
+        "subject": "docs(foundation): add architecture pipeline packet Capture the current Foundation stage, step, op, artifact, projection, validator/test, and downstream consumer model as a source-cited pipeline-realism packet. Record structural coupling around tectonics, final-only crust evolution, projection-derived surfaces, Morphology belt synthesis, missing landform intent layers, and validation/readback gates. References: docs/projects/pipeline-realism/resources/packets/foundation-architecture-generative-pipeline/README.md"
+      },
+      "accountingLabels": [
+        {
+          "role": "source",
+          "moveId": "done-reference-foundation-architecture-packet",
+          "state": "done",
+          "kind": "reference",
+          "sourceKind": "branch",
+          "label": "reference-consumed",
+          "cleanup": "not-cleanup-relevant",
+          "note": "Foundation architecture packet remains reference/support material, not a source branch replayed into the Swooper recovery stack."
+        }
+      ],
+      "accountingSummary": "accounted-source"
+    }
+  ],
+  "staleAnchorWarnings": [
+    {
+      "moveId": "done-adopt-studio-live-runtime-snapshot-completion",
+      "branch": "codex/studio-live-runtime-snapshot-completion",
+      "expected": "5fd0a81955d5e8bcbdfe8147e893bb9b79b41d93",
+      "observed": "5fd0a81955d52568328555702ec88e99bb64e679"
+    }
+  ],
+  "moves": [
+    {
+      "moveId": "done-supersede-pr1421-swooper-earthlike",
+      "state": "done",
+      "kind": "supersede",
+      "method": "semantic",
+      "sourceTargets": [
+        "PR #1421"
+      ],
+      "sinkTargets": [
+        "codex/swooper-mapgen-recovery-drain"
+      ],
+      "note": "Published Swooper Earthlike PR #1421 is superseded locally by the recovery stack's semantic synthesis. Keep it as fallback/reference until the recovery stack lands; do not merge it as-is."
+    },
+    {
+      "moveId": "done-adopt-start-placement-and-initial-resource-policy",
+      "state": "done",
+      "kind": "adopt",
+      "method": "semantic",
+      "sourceTargets": [
+        "codex/start-placement-viability",
+        "codex/resource-initial-map-policy"
+      ],
+      "sinkTargets": [
+        "codex/swooper-mapgen-recovery-drain"
+      ],
+      "note": "Start expansion viability and initial age-gated resource policy were replayed into the recovery base."
+    },
+    {
+      "moveId": "done-adopt-studio-setup-config-sync",
+      "state": "done",
+      "kind": "adopt",
+      "method": "semantic",
+      "sourceTargets": [
+        "codex/studio-setup-config-sync",
+        "06-05-fix_studio_validate_civ7_setup_seeds"
+      ],
+      "sinkTargets": [
+        "codex/swooper-mapgen-recovery-drain"
+      ],
+      "note": "Studio setup/config loading, setup seed validation, save/deploy/run-in-game sync, and adjacent Swooper recovery behavior were synthesized into the recovery base."
+    },
+    {
+      "moveId": "done-adopt-pr1402-authoring-morphology-resource-train",
+      "state": "done",
+      "kind": "adopt",
+      "method": "semantic",
+      "sourceTargets": [
+        "codex/resource-distribution-planning",
+        "codex/resource-distribution-root-cause",
+        "codex/resource-stage-architecture",
+        "codex/resource-corpus-contract",
+        "codex/resource-earthlike-expectations",
+        "codex/resource-earthlike-expectations-artifact",
+        "codex/resource-aquatic-operation-contract",
+        "codex/resource-cultivated-operation-contract",
+        "codex/resource-terrestrial-operation-contract",
+        "codex/resource-geological-operation-contract",
+        "codex/resource-group-plan-rollup",
+        "codex/resource-placement-diversity",
+        "codex/resource-diversity-stats-gate",
+        "codex/resource-runtime-proof",
+        "codex/morphology-live-readback-boundary",
+        "codex/morphology-peer-review-repairs"
+      ],
+      "sinkTargets": [
+        "PR #1402"
+      ],
+      "note": "Resource, morphology, and authoring predecessor branches are represented by merged aggregate PR #1402. Shard PRs #1414-#1419 were closed after the aggregate landed, so this train is done for accounting and must not be replayed wholesale into the Swooper recovery stack."
+    },
+    {
+      "moveId": "done-adopt-live-play-online-context-merged-studio-prs",
+      "state": "done",
+      "kind": "adopt",
+      "method": "semantic",
+      "sourceTargets": [
+        "codex/live-play-online-context"
+      ],
+      "sinkTargets": [
+        "main"
+      ],
+      "note": "Graphite still shows this as a local root needing restack, but its relevant Studio/run-in-game PR range #1407-#1413 is merged to main. Treat needs-restack here as stale local metadata, not a pending product adoption source."
+    },
+    {
+      "moveId": "done-adopt-studio-exact-authorship-proof",
+      "state": "done",
+      "kind": "adopt",
+      "method": "semantic",
+      "sourceTargets": [
+        "codex/studio-civ7-exact-authorship-proof"
+      ],
+      "sinkTargets": [
+        "codex/swooper-studio-parity-proof-drain"
+      ],
+      "note": "Studio exact-authorship parsing/proof behavior is represented in the Swooper Studio parity proof drain."
+    },
+    {
+      "moveId": "done-adopt-map-policy-final-surface-parity",
+      "state": "done",
+      "kind": "adopt",
+      "method": "semantic",
+      "sourceTargets": [
+        "codex/civ7-map-policy-final-surface-parity"
+      ],
+      "sinkTargets": [
+        "codex/swooper-studio-parity-proof-drain"
+      ],
+      "note": "Final-surface parity proof path and routing records are represented in the Swooper Studio parity proof drain and later current parity record branches."
+    },
+    {
+      "moveId": "done-adopt-studio-live-runtime-snapshot-completion",
+      "state": "done",
+      "kind": "adopt",
+      "method": "semantic",
+      "sourceTargets": [
+        "codex/studio-live-runtime-snapshot-completion"
+      ],
+      "sinkTargets": [
+        "codex/swooper-studio-parity-proof-drain"
+      ],
+      "note": "Live runtime snapshot completion is represented in the Studio parity proof drain and follow-up current exact-authorship proof branches."
+    },
+    {
+      "moveId": "done-reference-swooper-recovery-planning-context",
+      "state": "done",
+      "kind": "reference",
+      "method": "semantic",
+      "sourceTargets": [
+        "codex/swooper-dra-takeover-handoff",
+        "codex/swooper-recovery-openspec-plan"
+      ],
+      "sinkTargets": [
+        "codex/swooper-mapgen-recovery-drain"
+      ],
+      "note": "The recovery handoff and OpenSpec planning branches were consumed as planning/reference input for the Swooper recovery stack. They are not pending product branches."
+    },
+    {
+      "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+      "state": "done",
+      "kind": "adopt",
+      "method": "semantic",
+      "sourceTargets": [
+        "codex/earthlike-live-feature-resource-legality-repair",
+        "codex/earthlike-adjacent-land-rerun-record",
+        "codex/earthlike-resource-assignment-evidence",
+        "codex/earthlike-resource-feasibility-readback",
+        "codex/earthlike-resource-feasibility-classification",
+        "codex/earthlike-resource-feasibility-artifact",
+        "codex/earthlike-resource-feasibility-row-context",
+        "codex/earthlike-resource-policy-spacing-context",
+        "codex/earthlike-resource-live-plot-context",
+        "codex/earthlike-resource-assignment-trace",
+        "codex/earthlike-resource-builder-diagnostics",
+        "codex/earthlike-resource-assignment-order-context",
+        "codex/earthlike-resource-builder-subclassification",
+        "codex/earthlike-resource-builder-policy-context",
+        "codex/earthlike-resource-assignment-class-summary",
+        "codex/earthlike-resource-distribution-context",
+        "codex/earthlike-resource-position-context",
+        "codex/earthlike-resource-local-materialization-context",
+        "codex/earthlike-resource-placement-coordinate-proof",
+        "codex/earthlike-resource-coordinate-proof-intake"
+      ],
+      "sinkTargets": [
+        "codex/swooper-feature-resource-legality-drain",
+        "codex/swooper-resource-assignment-evidence-drain",
+        "codex/swooper-resource-feasibility-readback-drain",
+        "codex/swooper-resource-feasibility-classification-drain",
+        "codex/swooper-resource-delta-context-drain",
+        "codex/swooper-resource-policy-live-context-drain",
+        "codex/swooper-resource-assignment-trace-drain",
+        "codex/swooper-resource-builder-diagnostics-drain",
+        "codex/swooper-resource-builder-classifier-drain",
+        "codex/swooper-resource-builder-policy-context-drain",
+        "codex/swooper-resource-assignment-summary-drain",
+        "codex/swooper-resource-distribution-context-drain",
+        "codex/swooper-resource-position-context-drain",
+        "codex/swooper-resource-local-materialization-context-drain",
+        "codex/swooper-resource-coordinate-proof-drain",
+        "codex/swooper-resource-coordinate-proof-intake-drain",
+        "codex/swooper-resource-coordinate-proof-summary-drain"
+      ],
+      "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+    },
+    {
+      "moveId": "done-adopt-earthlike-terrain-edge-stack",
+      "state": "done",
+      "kind": "adopt",
+      "method": "semantic",
+      "sourceTargets": [
+        "codex/earthlike-terrain-edge-diagnostics",
+        "codex/earthlike-terrain-edge-local-mask-context",
+        "codex/earthlike-terrain-edge-live-readback",
+        "codex/earthlike-terrain-edge-validation-boundary",
+        "codex/earthlike-terrain-edge-mock-lake-classification",
+        "codex/earthlike-terrain-edge-mock-materialization-repair",
+        "codex/earthlike-terrain-edge-coast-materialization-context",
+        "codex/earthlike-terrain-edge-mock-terrain-materialization-repair",
+        "codex/earthlike-terrain-edge-stack-integration"
+      ],
+      "sinkTargets": [
+        "codex/swooper-terrain-edge-reconciliation-drain"
+      ],
+      "note": "Terrain-edge diagnostics, mock lake/materialization repairs, and reconciliation records are represented in the Swooper terrain-edge drain."
+    },
+    {
+      "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+      "state": "done",
+      "kind": "adopt",
+      "method": "semantic",
+      "sourceTargets": [
+        "codex/earthlike-natural-wonder-footprint-readback",
+        "codex/earthlike-feature-footprint-direction-context",
+        "codex/earthlike-feature-live-feasibility-readback",
+        "codex/earthlike-feature-local-evidence-context",
+        "codex/earthlike-feature-delta-context",
+        "codex/earthlike-natural-wonder-footprint-catalog-context",
+        "codex/earthlike-natural-wonder-live-proof-boundary",
+        "codex/earthlike-natural-wonder-live-telemetry",
+        "codex/earthlike-natural-wonder-coordinate-proof",
+        "codex/earthlike-natural-wonder-source-classification",
+        "codex/earthlike-natural-wonder-materialization-repair",
+        "codex/earthlike-natural-wonder-repair-proof-record",
+        "codex/earthlike-feature-post-wonder-repair-context",
+        "codex/earthlike-feature-proof-correction",
+        "codex/earthlike-natural-wonder-deploy-proof-gap",
+        "codex/earthlike-natural-wonder-named-rejection-proof",
+        "codex/earthlike-natural-wonder-readback-mismatch-context",
+        "codex/earthlike-natural-wonder-postwrite-footprint-proof"
+      ],
+      "sinkTargets": [
+        "codex/swooper-wonder-footprint-readback-drain",
+        "codex/swooper-wonder-footprint-direction-drain",
+        "codex/swooper-feature-local-evidence-drain",
+        "codex/swooper-feature-delta-context-drain",
+        "codex/swooper-wonder-catalog-direction-drain",
+        "codex/swooper-wonder-live-proof-boundary-drain",
+        "codex/swooper-wonder-placement-telemetry-drain",
+        "codex/swooper-wonder-coordinate-proof-drain",
+        "codex/swooper-wonder-source-classification-drain",
+        "codex/swooper-wonder-materialization-repair-drain",
+        "codex/swooper-wonder-proof-record-drain",
+        "codex/swooper-post-wonder-feature-classification-drain",
+        "codex/swooper-wonder-rejection-outcomes-drain",
+        "codex/swooper-wonder-named-rejection-proof-drain",
+        "codex/swooper-wonder-readback-context-drain",
+        "codex/swooper-wonder-footprint-proof-drain",
+        "codex/swooper-wonder-footprint-proof-record-drain"
+      ],
+      "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+    },
+    {
+      "moveId": "planned-adopt-earthlike-floodplain-config-leaf",
+      "state": "planned",
+      "kind": "adopt",
+      "method": "semantic",
+      "sourceTargets": [
+        "codex/earthlike-natural-wonder-postwrite-footprint-proof-record"
+      ],
+      "sinkTargets": [
+        "codex/swooper-mapgen-recovery-drain"
+      ],
+      "note": "Latest Earthlike floodplainPlanning config/hash leaf is not present in the recovery stack. Adopt this config leaf before claiming the Earthlike source config is fully covered."
+    },
+    {
+      "moveId": "done-exclude-non-earthlike-config-drift",
+      "state": "done",
+      "kind": "exclude",
+      "sourceTargets": [
+        "non-earthlike-config-drift-from-predecessor-sources"
+      ],
+      "sinkTargets": [],
+      "note": "Non-Earthlike config drift was intentionally dropped from the recovery stack."
+    },
+    {
+      "moveId": "planned-adopt-systematic-workstream-skill-support-slice",
+      "state": "planned",
+      "kind": "adopt",
+      "method": "semantic",
+      "sourceTargets": [
+        "codex/systematic-workstream-skill-framing",
+        "codex/systematic-evidence-workstream-skill",
+        "codex/systematic-skill-review-fixes"
+      ],
+      "sinkTargets": [
+        "main"
+      ],
+      "note": "The repo-local systematic workstream skill is not in main or in the Swooper recovery stack. It is useful support tooling and needs a dedicated support adoption slice; it is not part of the Swooper product recovery drain."
+    },
+    {
+      "moveId": "done-reference-foundation-architecture-packet",
+      "state": "done",
+      "kind": "reference",
+      "sourceTargets": [
+        "codex/foundation-architecture-packet"
+      ],
+      "sinkTargets": [],
+      "note": "Foundation architecture packet remains reference/support material, not a source branch replayed into the Swooper recovery stack."
+    },
+    {
+      "moveId": "done-exclude-civ7-intelligence-and-control-doc-train",
+      "state": "done",
+      "kind": "exclude",
+      "sourceTargets": [
+        "codex/frame-civ7-intelligence-layer",
+        "codex/shape-civ7-intelligence-solution",
+        "codex/investigate-civ7-intelligence-threads",
+        "codex/consolidate-play-agent-docs",
+        "codex/play-agent-output-contract",
+        "codex/unit-movement-api-investigation",
+        "codex/live-play-settlement-reference"
+      ],
+      "sinkTargets": [],
+      "note": "Control/intelligence documentation and live-play setup branches are outside the Swooper mapgen recovery accounting. They are not source work to adopt into the recovery stack."
+    },
+    {
+      "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+      "state": "done",
+      "kind": "exclude",
+      "sourceTargets": [
+        "codex/stack-lineage-audit-reference",
+        "codex/stack-visualizer-ui-integration",
+        "codex/gt-stack-inspect-spec-alignment",
+        "codex/gt-stack-inspect-visual-contract",
+        "codex/gt-stack-inspect-effect-service-core",
+        "codex/gt-stack-inspect-inspection-adapters",
+        "codex/gt-stack-inspect-effect-orpc-router",
+        "codex/gt-stack-inspect-live-event-stream",
+        "codex/gt-stack-inspect-react-rpc-vite-shell",
+        "codex/gt-stack-inspect-react-rpc-client-state",
+        "codex/gt-stack-inspect-react-topology-ui",
+        "codex/gt-stack-inspect-cross-repo-runner",
+        "codex/gt-stack-inspect-react-parity-workstreams"
+      ],
+      "sinkTargets": [],
+      "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
+    }
+  ]
+}

--- a/openspec/changes/swooper-stack-recovery-consolidation/workstream/branch-accounting-composition.md
+++ b/openspec/changes/swooper-stack-recovery-consolidation/workstream/branch-accounting-composition.md
@@ -1,0 +1,161 @@
+# Branch Accounting Composition
+
+Generated: `2026-06-07T20:35:47.939Z`
+Graphite main head: `98dca389248d5ddb2777a88105c3ade452b2137c`
+Ledger: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-ledger.json`
+GTLS status: `/tmp/civ7-current-gt-ls.status.json` refreshed at `2026-06-07T20:35:45.366Z`
+
+## Root Rollup
+
+| Root | Recommended action | Graphite | Accounting | Branches | Needs restack | Worktrees | Dirty | Counts |
+|---|---|---|---|---:|---:|---:|---:|---|
+| `codex/systematic-workstream-skill-framing` | `drain-to-main` | `clean-local` | `planned-main-adoption-source` | 3 | 0 | 0 | 0 | needs-accounting:3 |
+| `codex/swooper-mapgen-recovery-drain` | `finish-planned-adoption` | `clean-local` | `planned-sink` | 79 | 0 | 1 | 0 | planned-sink:1, accounting-sink:36, unmarked:42 |
+| `codex/stack-lineage-audit-reference` | `clear-dirty-worktree` | `dirty-worktree` | `accounted-source` | 19 | 0 | 1 | 1 | excluded:13, unmarked:6 |
+| `codex/live-play-settlement-reference` | `adopt-into-sink` | `clean-local` | `planned-local-adoption-source` | 67 | 0 | 2 | 0 | excluded:7, unmarked:3, accounted-source:56, needs-accounting:1 |
+| `codex/local-catalog-enrichment` | `restack-before-drain` | `needs-restack` | `unmarked` | 691 | 1 | 1 | 0 | unmarked:691 |
+| `agent-watch-civ7-live-play-reference-assembly` | `restack-before-drain` | `needs-restack` | `unmarked` | 1 | 1 | 0 | 0 | unmarked:1 |
+| `codex/foundation-architecture-packet` | `submit-or-merge-clean-stack` | `clean-local` | `accounted-source` | 1 | 0 | 0 | 0 | accounted-source:1 |
+
+## Active Accounting Rows
+
+| Branch | Root | State | Labels | Restack | Worktree |
+|---|---|---|---|---:|---|
+| `codex/systematic-workstream-skill-framing` | `codex/systematic-workstream-skill-framing` | `needs-accounting` | `source:needs-adoption:planned-adopt-systematic-workstream-skill-support-slice` | no |  |
+| `codex/systematic-evidence-workstream-skill` | `codex/systematic-workstream-skill-framing` | `needs-accounting` | `source:needs-adoption:planned-adopt-systematic-workstream-skill-support-slice` | no |  |
+| `codex/systematic-skill-review-fixes` | `codex/systematic-workstream-skill-framing` | `needs-accounting` | `source:needs-adoption:planned-adopt-systematic-workstream-skill-support-slice` | no |  |
+| `codex/swooper-mapgen-recovery-drain` | `codex/swooper-mapgen-recovery-drain` | `planned-sink` | `sink:supersession-sink:done-supersede-pr1421-swooper-earthlike`<br>`sink:adoption-sink:done-adopt-start-placement-and-initial-resource-policy`<br>`sink:adoption-sink:done-adopt-studio-setup-config-sync`<br>`sink:accounting-sink:done-reference-swooper-recovery-planning-context`<br>`sink:planned-adoption-sink:planned-adopt-earthlike-floodplain-config-leaf` | no |  |
+| `codex/swooper-studio-parity-proof-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-studio-exact-authorship-proof`<br>`sink:adoption-sink:done-adopt-map-policy-final-surface-parity`<br>`sink:adoption-sink:done-adopt-studio-live-runtime-snapshot-completion` | no |  |
+| `codex/swooper-feature-resource-legality-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-assignment-evidence-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-feasibility-readback-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-feasibility-classification-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-delta-context-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-policy-live-context-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-assignment-trace-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-builder-diagnostics-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-builder-classifier-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-builder-policy-context-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-assignment-summary-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-distribution-context-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-position-context-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-local-materialization-context-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-coordinate-proof-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-resource-coordinate-proof-intake-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-feature-delta-context-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-feature-local-evidence-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-wonder-footprint-direction-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-wonder-footprint-readback-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-wonder-catalog-direction-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-wonder-live-proof-boundary-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-terrain-edge-reconciliation-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-terrain-edge-stack` | no |  |
+| `codex/swooper-wonder-materialization-repair-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-wonder-placement-telemetry-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-wonder-coordinate-proof-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-wonder-source-classification-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-wonder-proof-record-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-post-wonder-feature-classification-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-wonder-rejection-outcomes-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-wonder-named-rejection-proof-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-wonder-readback-context-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-wonder-footprint-proof-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-wonder-footprint-proof-record-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/swooper-resource-coordinate-proof-summary-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/swooper-natural-wonder-plan-input-comparison-drain` | `codex/swooper-mapgen-recovery-drain` | `unmarked` |  | no | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain` |
+| `codex/stack-lineage-audit-reference` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
+| `codex/stack-visualizer-ui-integration` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
+| `codex/gt-stack-inspect-spec-alignment` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
+| `codex/gt-stack-inspect-visual-contract` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
+| `codex/gt-stack-inspect-effect-service-core` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
+| `codex/gt-stack-inspect-inspection-adapters` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
+| `codex/gt-stack-inspect-effect-orpc-router` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
+| `codex/gt-stack-inspect-live-event-stream` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
+| `codex/gt-stack-inspect-react-rpc-vite-shell` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
+| `codex/gt-stack-inspect-react-rpc-client-state` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
+| `codex/gt-stack-inspect-react-topology-ui` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
+| `codex/gt-stack-inspect-cross-repo-runner` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
+| `codex/gt-stack-inspect-react-parity-workstreams` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
+| `codex/gt-stack-inspect-react-parity-interactions` | `codex/stack-lineage-audit-reference` | `unmarked` |  | no | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-stack-lineage-audit-reference` (12) |
+| `codex/live-play-settlement-reference` | `codex/live-play-settlement-reference` | `excluded` | `source:excluded:done-exclude-civ7-intelligence-and-control-doc-train` | no |  |
+| `codex/unit-movement-api-investigation` | `codex/live-play-settlement-reference` | `excluded` | `source:excluded:done-exclude-civ7-intelligence-and-control-doc-train` | no |  |
+| `codex/play-agent-output-contract` | `codex/live-play-settlement-reference` | `excluded` | `source:excluded:done-exclude-civ7-intelligence-and-control-doc-train` | no |  |
+| `codex/consolidate-play-agent-docs` | `codex/live-play-settlement-reference` | `excluded` | `source:excluded:done-exclude-civ7-intelligence-and-control-doc-train` | no |  |
+| `codex/frame-civ7-intelligence-layer` | `codex/live-play-settlement-reference` | `excluded` | `source:excluded:done-exclude-civ7-intelligence-and-control-doc-train` | no |  |
+| `codex/shape-civ7-intelligence-solution` | `codex/live-play-settlement-reference` | `excluded` | `source:excluded:done-exclude-civ7-intelligence-and-control-doc-train` | no |  |
+| `codex/investigate-civ7-intelligence-threads` | `codex/live-play-settlement-reference` | `excluded` | `source:excluded:done-exclude-civ7-intelligence-and-control-doc-train` | no |  |
+| `codex/start-placement-viability` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-start-placement-and-initial-resource-policy` | no |  |
+| `codex/resource-initial-map-policy` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-start-placement-and-initial-resource-policy` | no |  |
+| `codex/studio-setup-config-sync` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-studio-setup-config-sync` | no |  |
+| `06-05-fix_studio_validate_civ7_setup_seeds` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-studio-setup-config-sync` | no |  |
+| `codex/swooper-dra-takeover-handoff` | `codex/live-play-settlement-reference` | `accounted-source` | `source:reference-consumed:done-reference-swooper-recovery-planning-context` | no |  |
+| `codex/swooper-recovery-openspec-plan` | `codex/live-play-settlement-reference` | `accounted-source` | `source:reference-consumed:done-reference-swooper-recovery-planning-context` | no |  |
+| `codex/studio-live-runtime-snapshot-completion` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-studio-live-runtime-snapshot-completion` | no |  |
+| `codex/studio-civ7-exact-authorship-proof` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-studio-exact-authorship-proof` | no | `/Users/mateicanavra/Documents/.nosync/DEV/civ7/civ7-modding-tools` |
+| `codex/civ7-map-policy-final-surface-parity` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-map-policy-final-surface-parity` | no |  |
+| `codex/earthlike-live-feature-resource-legality-repair` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-adjacent-land-rerun-record` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-assignment-evidence` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-feasibility-readback` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-feasibility-classification` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-feasibility-artifact` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-feasibility-row-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-policy-spacing-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-live-plot-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-assignment-trace` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-builder-diagnostics` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-assignment-order-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-builder-subclassification` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-builder-policy-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-assignment-class-summary` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-distribution-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-position-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-local-materialization-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-placement-coordinate-proof` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-resource-coordinate-proof-intake` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
+| `codex/earthlike-feature-delta-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-feature-local-evidence-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-feature-live-feasibility-readback` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-feature-footprint-direction-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-natural-wonder-footprint-readback` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-natural-wonder-footprint-catalog-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-natural-wonder-live-proof-boundary` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-terrain-edge-stack-integration` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-terrain-edge-stack` | no |  |
+| `codex/earthlike-natural-wonder-live-telemetry` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-natural-wonder-coordinate-proof` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-natural-wonder-source-classification` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-natural-wonder-materialization-repair` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-natural-wonder-repair-proof-record` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-feature-post-wonder-repair-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-feature-proof-correction` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-natural-wonder-deploy-proof-gap` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-natural-wonder-named-rejection-proof` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-natural-wonder-readback-mismatch-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-natural-wonder-postwrite-footprint-proof` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/earthlike-natural-wonder-postwrite-footprint-proof-record` | `codex/live-play-settlement-reference` | `needs-accounting` | `source:needs-adoption:planned-adopt-earthlike-floodplain-config-leaf` | no | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-civ7-map-policy-final-surface-parity` |
+| `codex/earthlike-terrain-edge-diagnostics` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-terrain-edge-stack` | no |  |
+| `codex/earthlike-terrain-edge-local-mask-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-terrain-edge-stack` | no |  |
+| `codex/earthlike-terrain-edge-live-readback` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-terrain-edge-stack` | no |  |
+| `codex/earthlike-terrain-edge-validation-boundary` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-terrain-edge-stack` | no |  |
+| `codex/earthlike-terrain-edge-mock-lake-classification` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-terrain-edge-stack` | no |  |
+| `codex/earthlike-terrain-edge-mock-materialization-repair` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-terrain-edge-stack` | no |  |
+| `codex/earthlike-terrain-edge-coast-materialization-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-terrain-edge-stack` | no |  |
+| `codex/earthlike-terrain-edge-mock-terrain-materialization-repair` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-terrain-edge-stack` | no |  |
+| `codex/local-catalog-enrichment` | `codex/local-catalog-enrichment` | `unmarked` |  | yes |  |
+| `codex/require-controller-mutation-proof` | `codex/local-catalog-enrichment` | `unmarked` |  | no | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-watch-civ7-live-play-reference-assembly` |
+| `agent-watch-civ7-live-play-reference-assembly` | `agent-watch-civ7-live-play-reference-assembly` | `unmarked` |  | yes |  |
+| `codex/foundation-architecture-packet` | `codex/foundation-architecture-packet` | `accounted-source` | `source:reference-consumed:done-reference-foundation-architecture-packet` | no |  |
+
+## Stale Direct Anchors
+
+| Move | Branch | Expected | Observed |
+|---|---|---|---|
+| `done-adopt-studio-live-runtime-snapshot-completion` | `codex/studio-live-runtime-snapshot-completion` | `5fd0a81955d5e8bc` | `5fd0a81955d52568` |
+
+## Decision Notes
+
+- The watcher/GTLS capture remains raw Graphite evidence; this file is the composed decision surface.
+- `needs-accounting` marks a ledger-planned source branch, not a generic uninspected branch.
+- `accounted-source` means the ledger says the source intent is covered; cleanup can still be blocked when the sink is a local recovery branch.
+- `accounting-sink` marks where accepted intent was adopted; it is not the same as source cleanup.
+- Branches with no accounting label are not automatically pending; they are just unmarked by this ledger.
+- Root recommended actions are generic combinations of raw Graphite state and explicit ledger moves; they do not special-case branch names.

--- a/openspec/changes/swooper-stack-recovery-consolidation/workstream/branch-accounting-composition.md
+++ b/openspec/changes/swooper-stack-recovery-consolidation/workstream/branch-accounting-composition.md
@@ -1,21 +1,46 @@
 # Branch Accounting Composition
 
-Generated: `2026-06-07T20:35:47.939Z`
+Generated: `2026-06-07T22:19:21.809Z`
 Graphite main head: `98dca389248d5ddb2777a88105c3ade452b2137c`
+Topology source: `graphite-cache`
 Ledger: `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-ledger.json`
-GTLS status: `/tmp/civ7-current-gt-ls.status.json` refreshed at `2026-06-07T20:35:45.366Z`
+Graphite state snapshot: `/tmp/civ7-current-gt-ls.txt.graphite-state.json`
+GTLS status: `/tmp/civ7-current-gt-ls.status.json` refreshed at `2026-06-07T22:19:13.521Z`
 
 ## Root Rollup
 
 | Root | Recommended action | Graphite | Accounting | Branches | Needs restack | Worktrees | Dirty | Counts |
 |---|---|---|---|---:|---:|---:|---:|---|
 | `codex/systematic-workstream-skill-framing` | `drain-to-main` | `clean-local` | `planned-main-adoption-source` | 3 | 0 | 0 | 0 | needs-accounting:3 |
-| `codex/swooper-mapgen-recovery-drain` | `finish-planned-adoption` | `clean-local` | `planned-sink` | 79 | 0 | 1 | 0 | planned-sink:1, accounting-sink:36, unmarked:42 |
-| `codex/stack-lineage-audit-reference` | `clear-dirty-worktree` | `dirty-worktree` | `accounted-source` | 19 | 0 | 1 | 1 | excluded:13, unmarked:6 |
-| `codex/live-play-settlement-reference` | `adopt-into-sink` | `clean-local` | `planned-local-adoption-source` | 67 | 0 | 2 | 0 | excluded:7, unmarked:3, accounted-source:56, needs-accounting:1 |
+| `codex/swooper-mapgen-recovery-drain` | `clear-dirty-worktree` | `dirty-worktree` | `planned-sink` | 79 | 0 | 1 | 1 | planned-sink:1, accounting-sink:36, unmarked:42 |
+| `codex/stack-lineage-audit-reference` | `submit-or-merge-clean-stack` | `clean-local` | `accounted-source` | 21 | 0 | 1 | 0 | excluded:13, unmarked:8 |
+| `codex/live-play-settlement-reference` | `adopt-into-sink` | `clean-local` | `planned-local-adoption-source` | 67 | 0 | 2 | 0 | excluded:7, unmarked:2, accounted-source:57, needs-accounting:1 |
 | `codex/local-catalog-enrichment` | `restack-before-drain` | `needs-restack` | `unmarked` | 691 | 1 | 1 | 0 | unmarked:691 |
 | `agent-watch-civ7-live-play-reference-assembly` | `restack-before-drain` | `needs-restack` | `unmarked` | 1 | 1 | 0 | 0 | unmarked:1 |
 | `codex/foundation-architecture-packet` | `submit-or-merge-clean-stack` | `clean-local` | `accounted-source` | 1 | 0 | 0 | 0 | accounted-source:1 |
+
+## History Relationship Signals
+
+These rows are diagnostic only. They do not mark accounting complete; they show history/patch/name evidence that may justify an explicit accounting move.
+
+| Scope | Relationship | Left | Right | Ahead/behind | Cherry overlap | Semantic overlap | Shared tokens |
+|---|---|---|---|---:|---|---:|---|
+| `root-pair` | `patch-overlap-diverged` | `codex/systematic-workstream-skill-framing` | `codex/local-catalog-enrichment` | 27/34 | left +10/-9<br>right +25/-9 | 0.02 | `apply` `civ7` `evidence` `fixes` `framing` `review` `skill` `skills` `systematic` `workstream` |
+| `root-pair` | `semantic-overlap-diverged` | `codex/swooper-mapgen-recovery-drain` | `codex/live-play-settlement-reference` | 17/1 | left +17/-0<br>right +1/-0 | 0.29 | `1fhc` `acceptance` `accepted` `adjacent` `age` `align` `apps` `artifact` `artifacts` `assignment` `authored` `authoritative` |
+| `root-pair` | `patch-overlap-diverged` | `codex/swooper-mapgen-recovery-drain` | `codex/local-catalog-enrichment` | 43/34 | left +26/-9<br>right +25/-9 | 0.15 | `acceptance` `adapter` `align` `apply` `artifact` `artifacts` `audit` `authority` `bind` `binding` `blocked` `blocker` |
+| `root-pair` | `patch-overlap-diverged` | `codex/stack-lineage-audit-reference` | `codex/local-catalog-enrichment` | 38/34 | left +21/-9<br>right +25/-9 | 0.16 | `action` `actions` `alignment` `audit` `bind` `boundary` `bounded` `classify` `close` `command` `component` `context` |
+| `root-pair` | `patch-overlap-diverged` | `codex/live-play-settlement-reference` | `codex/local-catalog-enrichment` | 27/34 | left +10/-9<br>right +25/-9 | 0.19 | `acceptance` `align` `api` `architecture` `artifact` `artifacts` `authority` `bind` `blocked` `boundary` `bounded` `bridge` |
+| `root-pair` | `patch-overlap-diverged` | `codex/local-catalog-enrichment` | `agent-watch-civ7-live-play-reference-assembly` | 34/27 | left +16/-18<br>right +9/-18 | 0.02 | `authority` `civ7` `clarify` `hud` `live` `play` `reference` `source` |
+| `root-pair` | `patch-overlap-diverged` | `codex/local-catalog-enrichment` | `codex/foundation-architecture-packet` | 34/27 | left +25/-9<br>right +10/-9 | 0.02 | `architecture` `artifact` `downstream` `packet` `projection` `references` `source` `validation` |
+
+## Graphite Split Points
+
+| Root | Branch | Children |
+|---|---|---|
+| `codex/live-play-settlement-reference` | `codex/civ7-orpc-control-architecture-skill` | `codex/consolidate-play-agent-docs`<br>`codex/play-agent-hotseat-phase-packet` |
+| `codex/local-catalog-enrichment` | `codex/live-traditions-view` | `codex/surface-first-meet-exact-commands`<br>`codex/stale-population-blocker-classification` |
+| `codex/live-play-settlement-reference` | `codex/earthlike-natural-wonder-footprint-readback` | `codex/earthlike-natural-wonder-footprint-catalog-context`<br>`codex/earthlike-terrain-edge-diagnostics` |
+| `codex/local-catalog-enrichment` | `codex/add-production-telemetry-adapter` | `codex/watcher-supervisor-handoff-doc`<br>`codex/guard-telemetry-proof-labels` |
 
 ## Active Accounting Rows
 
@@ -61,7 +86,7 @@ GTLS status: `/tmp/civ7-current-gt-ls.status.json` refreshed at `2026-06-07T20:3
 | `codex/swooper-wonder-footprint-proof-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
 | `codex/swooper-wonder-footprint-proof-record-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
 | `codex/swooper-resource-coordinate-proof-summary-drain` | `codex/swooper-mapgen-recovery-drain` | `accounting-sink` | `sink:adoption-sink:done-adopt-earthlike-feature-resource-proof-stack` | no |  |
-| `codex/swooper-natural-wonder-plan-input-comparison-drain` | `codex/swooper-mapgen-recovery-drain` | `unmarked` |  | no | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain` |
+| `codex/swooper-natural-wonder-plan-input-comparison-drain` | `codex/swooper-mapgen-recovery-drain` | `unmarked` |  | no | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-codex-swooper-mapgen-recovery-drain` (2) |
 | `codex/stack-lineage-audit-reference` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
 | `codex/stack-visualizer-ui-integration` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
 | `codex/gt-stack-inspect-spec-alignment` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
@@ -75,7 +100,7 @@ GTLS status: `/tmp/civ7-current-gt-ls.status.json` refreshed at `2026-06-07T20:3
 | `codex/gt-stack-inspect-react-topology-ui` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
 | `codex/gt-stack-inspect-cross-repo-runner` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
 | `codex/gt-stack-inspect-react-parity-workstreams` | `codex/stack-lineage-audit-reference` | `excluded` | `source:excluded:done-exclude-gt-stack-inspect-toolkit-lane` | no |  |
-| `codex/gt-stack-inspect-react-parity-interactions` | `codex/stack-lineage-audit-reference` | `unmarked` |  | no | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-stack-lineage-audit-reference` (12) |
+| `codex/gt-stack-inspect-react-parity-runtime-verification` | `codex/stack-lineage-audit-reference` | `unmarked` |  | no | `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-stack-lineage-audit-reference` |
 | `codex/live-play-settlement-reference` | `codex/live-play-settlement-reference` | `excluded` | `source:excluded:done-exclude-civ7-intelligence-and-control-doc-train` | no |  |
 | `codex/unit-movement-api-investigation` | `codex/live-play-settlement-reference` | `excluded` | `source:excluded:done-exclude-civ7-intelligence-and-control-doc-train` | no |  |
 | `codex/play-agent-output-contract` | `codex/live-play-settlement-reference` | `excluded` | `source:excluded:done-exclude-civ7-intelligence-and-control-doc-train` | no |  |
@@ -123,6 +148,7 @@ GTLS status: `/tmp/civ7-current-gt-ls.status.json` refreshed at `2026-06-07T20:3
 | `codex/earthlike-natural-wonder-live-telemetry` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
 | `codex/earthlike-natural-wonder-coordinate-proof` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
 | `codex/earthlike-natural-wonder-source-classification` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
+| `codex/workspace-source-package-resolution` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
 | `codex/earthlike-natural-wonder-materialization-repair` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
 | `codex/earthlike-natural-wonder-repair-proof-record` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
 | `codex/earthlike-feature-post-wonder-repair-context` | `codex/live-play-settlement-reference` | `accounted-source` | `source:covered-by-adoption:done-adopt-earthlike-natural-wonder-stack-through-footprint-proof` | no |  |
@@ -151,11 +177,18 @@ GTLS status: `/tmp/civ7-current-gt-ls.status.json` refreshed at `2026-06-07T20:3
 |---|---|---|---|
 | `done-adopt-studio-live-runtime-snapshot-completion` | `codex/studio-live-runtime-snapshot-completion` | `5fd0a81955d5e8bc` | `5fd0a81955d52568` |
 
+## Metadata Consistency
+
+No Graphite cache parent/child consistency warnings.
+
 ## Decision Notes
 
-- The watcher/GTLS capture remains raw Graphite evidence; this file is the composed decision surface.
+- Graphite topology is read from Graphite's persisted cache (`parentBranchName`, `children`, branch revisions), not from `gt ls` ASCII layout.
+- The watcher/GTLS text capture is human display evidence only; the composed decision surface does not infer parentage from terminal graph columns.
 - `needs-accounting` marks a ledger-planned source branch, not a generic uninspected branch.
 - `accounted-source` means the ledger says the source intent is covered; cleanup can still be blocked when the sink is a local recovery branch.
 - `accounting-sink` marks where accepted intent was adopted; it is not the same as source cleanup.
 - Branches with no accounting label are not automatically pending; they are just unmarked by this ledger.
 - Root recommended actions are generic combinations of raw Graphite state and explicit ledger moves; they do not special-case branch names.
+- History relationship signals are diagnostic facts from Git and Graphite: ancestry, ahead/behind, `git cherry`, split points, and token overlap.
+- Patch-equivalence or semantic overlap is not adoption. Adoption is recorded only by explicit ledger moves.

--- a/openspec/changes/swooper-stack-recovery-consolidation/workstream/branch-recovery-ledger.md
+++ b/openspec/changes/swooper-stack-recovery-consolidation/workstream/branch-recovery-ledger.md
@@ -30,10 +30,12 @@
 
 | Source | Reason |
 |---|---|
-| old resource trains through `codex/resource-runtime-proof` | Already represented as provenance or owned by separate resource/runtime proof stacks. |
-| old morphology train | Already represented by current morphology behavior and docs. |
+| resource/morphology/authoring predecessor train through `codex/resource-runtime-proof`, `codex/morphology-live-readback-boundary`, and `codex/morphology-peer-review-repairs` | Done through merged aggregate PR `#1402`; shard PRs `#1414`-`#1419` were closed after the aggregate landed. Not parked and not a wholesale replay source. |
+| Studio/run-in-game predecessor range around `codex/live-play-online-context` | Done through merged PRs `#1407`-`#1413`; local Graphite `needs restack` is stale metadata for this accounting pass, not pending product adoption. |
+| systematic workstream skill support slice | Pending separate support adoption if we want `.agents/skills/civ7-systematic-workstream` durable on main; not product recovery. |
 | live-play/control worktrees | Active non-mapgen/control work; leave alone. |
 | foundation architecture packet worktree | Supporting docs/reference unless a specific current delta is needed. |
+| GT stack-inspect/toolkit lane | Active separate tooling stack; excluded from Swooper product cleanup. |
 
 ## Open Evidence Captured During Recovery
 
@@ -81,11 +83,13 @@
   merged, to avoid removing review references before replacement is durable.
 - Current sparse accounting state lives in
   `recovery-accounting-ledger.json` and
-  `recovery-accounting-state.md`. As of `2026-06-07T14:00:05-04:00`, covered
-  source branches are not cleanup-safe because the recovery stack has not
-  landed, and `codex/earthlike-natural-wonder-postwrite-footprint-proof-record`
+  `recovery-accounting-state.md`. As of `2026-06-07T15:03:52-04:00`, sources
+  represented by merged PRs are done and should not be called parked. Sources
+  whose sink is the local recovery stack are still cleanup-blocked until the
+  recovery stack lands. `codex/earthlike-natural-wonder-postwrite-footprint-proof-record`
   remains a planned adoption for the latest Earthlike floodplain config/hash
-  leaf.
+  leaf, and the systematic workstream skill support slice remains a separate
+  planned support adoption outside Swooper product recovery.
 
 ## Cleanup Actions
 
@@ -99,3 +103,24 @@
   published review reference until this replacement stack is submitted or
   merged. That remote should not be merged as-is; it is superseded by this
   recovery stack but remains a non-local fallback/reference.
+- Deleted local Graphite metadata/branches for the resource/morphology
+  predecessor train represented by merged aggregate PR `#1402`:
+  `codex/resource-distribution-planning`,
+  `codex/resource-distribution-root-cause`,
+  `codex/resource-stage-architecture`, `codex/resource-corpus-contract`,
+  `codex/resource-earthlike-expectations`,
+  `codex/resource-earthlike-expectations-artifact`,
+  `codex/resource-aquatic-operation-contract`,
+  `codex/resource-cultivated-operation-contract`,
+  `codex/resource-terrestrial-operation-contract`,
+  `codex/resource-geological-operation-contract`,
+  `codex/resource-group-plan-rollup`,
+  `codex/resource-placement-diversity`,
+  `codex/resource-diversity-stats-gate`, `codex/resource-runtime-proof`,
+  `codex/morphology-live-readback-boundary`, and
+  `codex/morphology-peer-review-repairs`.
+- Deleted local Graphite metadata/branch `codex/live-play-online-context` after
+  confirming the relevant Studio/run-in-game predecessor PR range `#1407`-
+  `#1413` is merged. This exposed `codex/local-catalog-enrichment` as a
+  live-play support branch needing restack; a narrow restack conflicts in
+  live-play docs and is deliberately left to the live-play/control lane.

--- a/openspec/changes/swooper-stack-recovery-consolidation/workstream/branch-recovery-ledger.md
+++ b/openspec/changes/swooper-stack-recovery-consolidation/workstream/branch-recovery-ledger.md
@@ -79,6 +79,13 @@
 - Branches with active PR/Graphite ownership should be deleted only after their
   semantic deltas are committed here and the current stack is submitted or
   merged, to avoid removing review references before replacement is durable.
+- Current sparse accounting state lives in
+  `recovery-accounting-ledger.json` and
+  `recovery-accounting-state.md`. As of `2026-06-07T14:00:05-04:00`, covered
+  source branches are not cleanup-safe because the recovery stack has not
+  landed, and `codex/earthlike-natural-wonder-postwrite-footprint-proof-record`
+  remains a planned adoption for the latest Earthlike floodplain config/hash
+  leaf.
 
 ## Cleanup Actions
 

--- a/openspec/changes/swooper-stack-recovery-consolidation/workstream/phase-record.md
+++ b/openspec/changes/swooper-stack-recovery-consolidation/workstream/phase-record.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Implementation complete locally; verification and Graphite commit pending.
+Recovery consolidation is complete locally. The current accounting refresh is
+committed and records durable-done, local-done, pending, and excluded branch
+sets separately.
 
 ## Objective
 
@@ -17,6 +19,27 @@ stale duplicate paths, and keep unrelated stacks out of scope.
 - Remove unused policy code rather than preserve dead exports.
 - Treat visible mountain-region failures and Studio deploy identity mismatches
   as open proof gaps even if current tests are green.
+- Treat merged/represented branches as done, not parked. The parked set is only
+  for actually pending or owner-held work.
+- Keep PR/patch overlap diagnostics separate from sparse accounting moves.
+
+## Accounting Refresh
+
+- Merged aggregate PR `#1402` accounts for the resource/morphology/authoring
+  predecessor train, including the local `resource-*` and `morphology-*`
+  branches represented by closed shard PRs `#1414`-`#1419`.
+- Merged PRs `#1407`-`#1413` account for the Studio/run-in-game range visible
+  around `codex/live-play-online-context`; local `needs restack` there is stale
+  metadata for this recovery accounting pass.
+- The recovery stack locally accounts for the predecessor Swooper Earthlike,
+  Studio setup/exact-authorship/final-surface, feature/resource, terrain-edge,
+  and natural-wonder proof trains listed in `recovery-accounting-ledger.json`.
+- `codex/earthlike-natural-wonder-postwrite-footprint-proof-record` remains the
+  only Swooper product source adoption still planned for this accounting pass.
+- The systematic workstream skill slice remains planned as a separate support
+  adoption to main, not as Swooper product work.
+- Live-control and GT stack-inspect/toolkit lanes are explicitly excluded from
+  Swooper product recovery accounting.
 
 ## Verification Plan
 
@@ -24,3 +47,30 @@ stale duplicate paths, and keep unrelated stacks out of scope.
 - OpenSpec strict validation for each new changeset.
 - `git diff --check`.
 - Clean Graphite commit.
+
+## Accounting Verification
+
+- `recovery-accounting-ledger.json` validated against
+  `AccountingMoveSchema`/`WorkSurfaceRowSchema` with 18 moves and 5 work rows.
+- GT stack-inspect service-core tests passed after stack-slice label projection
+  was added so branch/leaf labels are not hidden on aggregate endpoints.
+- GT stack-inspect runner tests and TypeScript check passed for explicit
+  `--accounting-ledger` ingestion.
+
+## Local Cleanup Execution
+
+- `gt sync` has no dry-run in the installed CLI and is not stack-scoped; global
+  `gt sync --force` was not used.
+- Confirmed PR `#1402` is merged and PRs `#1407`-`#1413` are merged through
+  `gh pr view`.
+- Deleted the local Graphite metadata/branches for the merged/represented
+  resource train from `codex/resource-distribution-planning` through
+  `codex/resource-runtime-proof`, plus
+  `codex/morphology-live-readback-boundary`,
+  `codex/morphology-peer-review-repairs`, and
+  `codex/live-play-online-context`.
+- `codex/local-catalog-enrichment` remains a live-play support branch needing
+  restack after `codex/live-play-online-context` deletion. A narrow
+  `gt restack --branch codex/local-catalog-enrichment --only` conflicted in
+  live-play support docs and was aborted; resolving that belongs to the
+  live-play/control lane, not Swooper cleanup.

--- a/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-ledger.json
+++ b/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-ledger.json
@@ -1,0 +1,390 @@
+{
+  "fixtureId": "swooper-recovery-accounting-2026-06-07",
+  "fixtureClass": "accounting-ledger",
+  "schemaVersion": "gt-stack-inspect.accounting-ledger.v1",
+  "capturedAt": "2026-06-07T14:00:05-04:00",
+  "scope": {
+    "recoveryRoot": "codex/swooper-mapgen-recovery-drain",
+    "recoveryTop": "codex/swooper-natural-wonder-plan-input-comparison-drain",
+    "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+    "excludedFamilies": [
+      "live-play/control",
+      "GT stack-inspect/toolkit"
+    ],
+    "policy": "Sparse reconciliation moves only. Done means source intent is represented in the local recovery stack; cleanup remains blocked until the recovery stack is submitted or merged."
+  },
+  "moves": [
+    {
+      "moveId": "done-supersede-pr1421-swooper-earthlike",
+      "state": "done",
+      "kind": "supersede",
+      "source": {
+        "kind": "pr",
+        "number": 1421
+      },
+      "sink": {
+        "kind": "branch",
+        "branch": "codex/swooper-mapgen-recovery-drain"
+      },
+      "method": "semantic",
+      "anchors": {
+        "toHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:00:05-04:00"
+      },
+      "note": "Published Swooper Earthlike PR #1421 is superseded locally by the recovery stack's semantic synthesis. Keep it as fallback/reference until the recovery stack lands; do not merge it as-is."
+    },
+    {
+      "moveId": "done-adopt-start-placement-and-initial-resource-policy",
+      "state": "done",
+      "kind": "adopt",
+      "source": {
+        "kind": "stack-slice",
+        "id": "predecessor-start-resource-policy",
+        "root": "codex/start-placement-viability",
+        "branches": [
+          "codex/start-placement-viability",
+          "codex/resource-initial-map-policy"
+        ]
+      },
+      "sink": {
+        "kind": "branch",
+        "branch": "codex/swooper-mapgen-recovery-drain"
+      },
+      "method": "semantic",
+      "anchors": {
+        "toHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:00:05-04:00"
+      },
+      "note": "Start expansion viability and initial age-gated resource policy were replayed into the recovery base."
+    },
+    {
+      "moveId": "done-adopt-studio-setup-config-sync",
+      "state": "done",
+      "kind": "adopt",
+      "source": {
+        "kind": "stack-slice",
+        "id": "studio-setup-and-seed-sync",
+        "root": "codex/studio-setup-config-sync",
+        "branches": [
+          "codex/studio-setup-config-sync",
+          "06-05-fix_studio_validate_civ7_setup_seeds"
+        ]
+      },
+      "sink": {
+        "kind": "branch",
+        "branch": "codex/swooper-mapgen-recovery-drain"
+      },
+      "method": "semantic",
+      "anchors": {
+        "toHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:00:05-04:00"
+      },
+      "note": "Studio setup/config loading, setup seed validation, save/deploy/run-in-game sync, and adjacent Swooper recovery behavior were synthesized into the recovery base."
+    },
+    {
+      "moveId": "done-supersede-morphology-peer-review-repairs",
+      "state": "done",
+      "kind": "supersede",
+      "source": {
+        "kind": "branch",
+        "branch": "codex/morphology-peer-review-repairs"
+      },
+      "sink": {
+        "kind": "branch",
+        "branch": "codex/swooper-mapgen-recovery-drain"
+      },
+      "anchors": {
+        "fromHead": "c886b4fa8d6896a0fdc0154c021da338f5b81d7e",
+        "toHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:00:05-04:00"
+      },
+      "note": "The old morphology peer-review repair train is treated as represented/superseded by current recovery morphology/Earthlike behavior. Open mountain-quality/product proof remains in the recovery lane; do not replay the old train wholesale."
+    },
+    {
+      "moveId": "done-reference-resource-runtime-proof-train",
+      "state": "done",
+      "kind": "reference",
+      "source": {
+        "kind": "branch",
+        "branch": "codex/resource-runtime-proof"
+      },
+      "terminalState": "parked-reference",
+      "anchors": {
+        "fromHead": "b4dd7160838261077765bc0b6d00d8a331564f8d",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:00:05-04:00"
+      },
+      "note": "Old resource-runtime stack remains provenance/reference. Current recovery resource work uses the Earthlike proof stack and current verifier rows, not a wholesale replay of this old train."
+    },
+    {
+      "moveId": "done-adopt-studio-exact-authorship-proof",
+      "state": "done",
+      "kind": "adopt",
+      "source": {
+        "kind": "branch",
+        "branch": "codex/studio-civ7-exact-authorship-proof"
+      },
+      "sink": {
+        "kind": "branch",
+        "branch": "codex/swooper-studio-parity-proof-drain"
+      },
+      "method": "semantic",
+      "anchors": {
+        "fromHead": "8966aba5eb6fb3d2adf7edf38aa2bd0b8cde905f",
+        "toHead": "eeccd5a9eb52bd30e7545e3324fe359d21ded7a4",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:00:05-04:00"
+      },
+      "note": "Studio exact-authorship parsing/proof behavior is represented in the Swooper Studio parity proof drain."
+    },
+    {
+      "moveId": "done-adopt-map-policy-final-surface-parity",
+      "state": "done",
+      "kind": "adopt",
+      "source": {
+        "kind": "branch",
+        "branch": "codex/civ7-map-policy-final-surface-parity"
+      },
+      "sink": {
+        "kind": "branch",
+        "branch": "codex/swooper-studio-parity-proof-drain"
+      },
+      "method": "semantic",
+      "anchors": {
+        "fromHead": "70a22c815bd8918febe2750043e4db920cf2bcb6",
+        "toHead": "eeccd5a9eb52bd30e7545e3324fe359d21ded7a4",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:00:05-04:00"
+      },
+      "note": "Final-surface parity proof path and routing records are represented in the Swooper Studio parity proof drain and later current parity record branches."
+    },
+    {
+      "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
+      "state": "done",
+      "kind": "adopt",
+      "source": {
+        "kind": "stack-slice",
+        "id": "earthlike-feature-resource-proof-through-coordinate-intake",
+        "root": "codex/earthlike-live-feature-resource-legality-repair",
+        "branches": [
+          "codex/earthlike-live-feature-resource-legality-repair",
+          "codex/earthlike-adjacent-land-rerun-record",
+          "codex/earthlike-resource-assignment-evidence",
+          "codex/earthlike-resource-feasibility-readback",
+          "codex/earthlike-resource-feasibility-classification",
+          "codex/earthlike-resource-feasibility-artifact",
+          "codex/earthlike-resource-feasibility-row-context",
+          "codex/earthlike-resource-policy-spacing-context",
+          "codex/earthlike-resource-live-plot-context",
+          "codex/earthlike-resource-assignment-trace",
+          "codex/earthlike-resource-builder-diagnostics",
+          "codex/earthlike-resource-assignment-order-context",
+          "codex/earthlike-resource-builder-subclassification",
+          "codex/earthlike-resource-builder-policy-context",
+          "codex/earthlike-resource-assignment-class-summary",
+          "codex/earthlike-resource-distribution-context",
+          "codex/earthlike-resource-position-context",
+          "codex/earthlike-resource-local-materialization-context",
+          "codex/earthlike-resource-placement-coordinate-proof",
+          "codex/earthlike-resource-coordinate-proof-intake"
+        ]
+      },
+      "sink": {
+        "kind": "stack-slice",
+        "id": "swooper-resource-proof-drain-through-coordinate-summary",
+        "root": "codex/swooper-feature-resource-legality-drain",
+        "branches": [
+          "codex/swooper-feature-resource-legality-drain",
+          "codex/swooper-resource-assignment-evidence-drain",
+          "codex/swooper-resource-feasibility-readback-drain",
+          "codex/swooper-resource-feasibility-classification-drain",
+          "codex/swooper-resource-delta-context-drain",
+          "codex/swooper-resource-policy-live-context-drain",
+          "codex/swooper-resource-assignment-trace-drain",
+          "codex/swooper-resource-builder-diagnostics-drain",
+          "codex/swooper-resource-builder-classifier-drain",
+          "codex/swooper-resource-builder-policy-context-drain",
+          "codex/swooper-resource-assignment-summary-drain",
+          "codex/swooper-resource-distribution-context-drain",
+          "codex/swooper-resource-position-context-drain",
+          "codex/swooper-resource-local-materialization-context-drain",
+          "codex/swooper-resource-coordinate-proof-drain",
+          "codex/swooper-resource-coordinate-proof-intake-drain",
+          "codex/swooper-resource-coordinate-proof-summary-drain"
+        ]
+      },
+      "method": "semantic",
+      "anchors": {
+        "fromHead": "88055a5ec7de6e0d3ca86f48e05b502cc6c745d4",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:00:05-04:00"
+      },
+      "note": "Earthlike feature/resource legality and resource proof intent through coordinate intake is represented by the Swooper resource proof drain. Later Swooper resource rejection branches are new continuation work, not source-stack cleanup."
+    },
+    {
+      "moveId": "done-adopt-earthlike-terrain-edge-stack",
+      "state": "done",
+      "kind": "adopt",
+      "source": {
+        "kind": "stack-slice",
+        "id": "earthlike-terrain-edge-stack",
+        "root": "codex/earthlike-terrain-edge-diagnostics",
+        "branches": [
+          "codex/earthlike-terrain-edge-diagnostics",
+          "codex/earthlike-terrain-edge-local-mask-context",
+          "codex/earthlike-terrain-edge-live-readback",
+          "codex/earthlike-terrain-edge-validation-boundary",
+          "codex/earthlike-terrain-edge-mock-lake-classification",
+          "codex/earthlike-terrain-edge-mock-materialization-repair",
+          "codex/earthlike-terrain-edge-coast-materialization-context",
+          "codex/earthlike-terrain-edge-mock-terrain-materialization-repair",
+          "codex/earthlike-terrain-edge-stack-integration"
+        ]
+      },
+      "sink": {
+        "kind": "branch",
+        "branch": "codex/swooper-terrain-edge-reconciliation-drain"
+      },
+      "method": "semantic",
+      "anchors": {
+        "fromHead": "9137689da849ba227f4057aa941c20a502d92e80",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:00:05-04:00"
+      },
+      "note": "Terrain-edge diagnostics, mock lake/materialization repairs, and reconciliation records are represented in the Swooper terrain-edge drain."
+    },
+    {
+      "moveId": "done-adopt-earthlike-natural-wonder-stack-through-footprint-proof",
+      "state": "done",
+      "kind": "adopt",
+      "source": {
+        "kind": "stack-slice",
+        "id": "earthlike-natural-wonder-through-footprint-proof",
+        "root": "codex/earthlike-natural-wonder-footprint-readback",
+        "branches": [
+          "codex/earthlike-natural-wonder-footprint-readback",
+          "codex/earthlike-feature-footprint-direction-context",
+          "codex/earthlike-feature-live-feasibility-readback",
+          "codex/earthlike-feature-local-evidence-context",
+          "codex/earthlike-feature-delta-context",
+          "codex/earthlike-natural-wonder-footprint-catalog-context",
+          "codex/earthlike-natural-wonder-live-proof-boundary",
+          "codex/earthlike-natural-wonder-live-telemetry",
+          "codex/earthlike-natural-wonder-coordinate-proof",
+          "codex/earthlike-natural-wonder-source-classification",
+          "codex/earthlike-natural-wonder-materialization-repair",
+          "codex/earthlike-natural-wonder-repair-proof-record",
+          "codex/earthlike-feature-post-wonder-repair-context",
+          "codex/earthlike-feature-proof-correction",
+          "codex/earthlike-natural-wonder-deploy-proof-gap",
+          "codex/earthlike-natural-wonder-named-rejection-proof",
+          "codex/earthlike-natural-wonder-readback-mismatch-context",
+          "codex/earthlike-natural-wonder-postwrite-footprint-proof"
+        ]
+      },
+      "sink": {
+        "kind": "stack-slice",
+        "id": "swooper-natural-wonder-drain-through-footprint-proof-record",
+        "root": "codex/swooper-wonder-footprint-readback-drain",
+        "branches": [
+          "codex/swooper-wonder-footprint-readback-drain",
+          "codex/swooper-wonder-footprint-direction-drain",
+          "codex/swooper-feature-local-evidence-drain",
+          "codex/swooper-feature-delta-context-drain",
+          "codex/swooper-wonder-catalog-direction-drain",
+          "codex/swooper-wonder-live-proof-boundary-drain",
+          "codex/swooper-wonder-placement-telemetry-drain",
+          "codex/swooper-wonder-coordinate-proof-drain",
+          "codex/swooper-wonder-source-classification-drain",
+          "codex/swooper-wonder-materialization-repair-drain",
+          "codex/swooper-wonder-proof-record-drain",
+          "codex/swooper-post-wonder-feature-classification-drain",
+          "codex/swooper-wonder-rejection-outcomes-drain",
+          "codex/swooper-wonder-named-rejection-proof-drain",
+          "codex/swooper-wonder-readback-context-drain",
+          "codex/swooper-wonder-footprint-proof-drain",
+          "codex/swooper-wonder-footprint-proof-record-drain"
+        ]
+      },
+      "method": "semantic",
+      "anchors": {
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:00:05-04:00"
+      },
+      "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+    },
+    {
+      "moveId": "planned-adopt-earthlike-floodplain-config-leaf",
+      "state": "planned",
+      "kind": "adopt",
+      "source": {
+        "kind": "branch",
+        "branch": "codex/earthlike-natural-wonder-postwrite-footprint-proof-record"
+      },
+      "sink": {
+        "kind": "branch",
+        "branch": "codex/swooper-mapgen-recovery-drain"
+      },
+      "method": "semantic",
+      "anchors": {
+        "fromHead": "cbe4943babf131389c892ddd8527b90f52355ab8",
+        "toHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:00:05-04:00"
+      },
+      "note": "Latest Earthlike floodplainPlanning config/hash leaf is not present in the recovery stack. Adopt this config leaf before claiming the Earthlike source config is fully covered."
+    },
+    {
+      "moveId": "done-exclude-non-earthlike-config-drift",
+      "state": "done",
+      "kind": "exclude",
+      "source": {
+        "kind": "reference",
+        "id": "non-earthlike-config-drift-from-predecessor-sources"
+      },
+      "terminalState": "retired",
+      "anchors": {
+        "toHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:00:05-04:00"
+      },
+      "note": "Non-Earthlike config drift was intentionally dropped from the recovery stack."
+    },
+    {
+      "moveId": "done-reference-foundation-architecture-packet",
+      "state": "done",
+      "kind": "reference",
+      "source": {
+        "kind": "branch",
+        "branch": "codex/foundation-architecture-packet"
+      },
+      "terminalState": "parked-reference",
+      "anchors": {
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:00:05-04:00"
+      },
+      "note": "Foundation architecture packet remains reference/support material, not a source branch replayed into the Swooper recovery stack."
+    }
+  ],
+  "workSurfaceRows": [
+    {
+      "rowId": "planned-adopt-earthlike-floodplain-config-leaf",
+      "kind": "planned-move",
+      "target": "codex/earthlike-natural-wonder-postwrite-footprint-proof-record",
+      "sourceRef": "codex/earthlike-natural-wonder-postwrite-footprint-proof-record",
+      "moveId": "planned-adopt-earthlike-floodplain-config-leaf",
+      "blocker": "Recovery stack lacks latest Earthlike floodplainPlanning config/hash leaf."
+    },
+    {
+      "rowId": "cleanup-blocked-until-recovery-lands",
+      "kind": "done-move",
+      "target": "codex/swooper-mapgen-recovery-drain",
+      "sourceRef": "swooper-recovery-covered-sources",
+      "blocker": "Covered source cleanup is unsafe until recovery stack is submitted or merged."
+    }
+  ]
+}

--- a/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-ledger.json
+++ b/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-ledger.json
@@ -348,6 +348,7 @@
           "codex/earthlike-natural-wonder-live-telemetry",
           "codex/earthlike-natural-wonder-coordinate-proof",
           "codex/earthlike-natural-wonder-source-classification",
+          "codex/workspace-source-package-resolution",
           "codex/earthlike-natural-wonder-materialization-repair",
           "codex/earthlike-natural-wonder-repair-proof-record",
           "codex/earthlike-feature-post-wonder-repair-context",
@@ -387,7 +388,7 @@
         "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
         "capturedAt": "2026-06-07T14:00:05-04:00"
       },
-      "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. Later Swooper plan-input comparison branches are new continuation work."
+      "note": "Natural-wonder proof/materialization intent through the footprint proof record is represented in the Swooper natural-wonder drain. The workspace source-package resolution branch is covered by the recovery-side package-local source-resolution expansion for @civ7/map-policy and @civ7/adapter. Later Swooper plan-input comparison branches are new continuation work."
     },
     {
       "moveId": "planned-adopt-earthlike-floodplain-config-leaf",

--- a/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-ledger.json
+++ b/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-ledger.json
@@ -2,7 +2,7 @@
   "fixtureId": "swooper-recovery-accounting-2026-06-07",
   "fixtureClass": "accounting-ledger",
   "schemaVersion": "gt-stack-inspect.accounting-ledger.v1",
-  "capturedAt": "2026-06-07T14:00:05-04:00",
+  "capturedAt": "2026-06-07T15:03:52-04:00",
   "scope": {
     "recoveryRoot": "codex/swooper-mapgen-recovery-drain",
     "recoveryTop": "codex/swooper-natural-wonder-plan-input-comparison-drain",
@@ -11,7 +11,7 @@
       "live-play/control",
       "GT stack-inspect/toolkit"
     ],
-    "policy": "Sparse reconciliation moves only. Done means source intent is represented in the local recovery stack; cleanup remains blocked until the recovery stack is submitted or merged."
+    "policy": "Sparse reconciliation moves only. Done means source intent is represented by an explicit sink: the local recovery stack, merged mainline PRs, or an explicit terminal exclusion. Already-merged/represented work is not parked. Cleanup remains gated by the sink: source branches adopted only by the local recovery stack cannot be pruned until the recovery stack is submitted or merged."
   },
   "moves": [
     {
@@ -85,40 +85,64 @@
       "note": "Studio setup/config loading, setup seed validation, save/deploy/run-in-game sync, and adjacent Swooper recovery behavior were synthesized into the recovery base."
     },
     {
-      "moveId": "done-supersede-morphology-peer-review-repairs",
+      "moveId": "done-adopt-pr1402-authoring-morphology-resource-train",
       "state": "done",
-      "kind": "supersede",
+      "kind": "adopt",
       "source": {
-        "kind": "branch",
-        "branch": "codex/morphology-peer-review-repairs"
+        "kind": "stack-slice",
+        "id": "resource-morphology-authoring-local-predecessor-train",
+        "root": "codex/resource-distribution-planning",
+        "branches": [
+          "codex/resource-distribution-planning",
+          "codex/resource-distribution-root-cause",
+          "codex/resource-stage-architecture",
+          "codex/resource-corpus-contract",
+          "codex/resource-earthlike-expectations",
+          "codex/resource-earthlike-expectations-artifact",
+          "codex/resource-aquatic-operation-contract",
+          "codex/resource-cultivated-operation-contract",
+          "codex/resource-terrestrial-operation-contract",
+          "codex/resource-geological-operation-contract",
+          "codex/resource-group-plan-rollup",
+          "codex/resource-placement-diversity",
+          "codex/resource-diversity-stats-gate",
+          "codex/resource-runtime-proof",
+          "codex/morphology-live-readback-boundary",
+          "codex/morphology-peer-review-repairs"
+        ]
       },
       "sink": {
-        "kind": "branch",
-        "branch": "codex/swooper-mapgen-recovery-drain"
+        "kind": "pr",
+        "number": 1402
       },
-      "anchors": {
-        "fromHead": "c886b4fa8d6896a0fdc0154c021da338f5b81d7e",
-        "toHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
-        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
-        "capturedAt": "2026-06-07T14:00:05-04:00"
-      },
-      "note": "The old morphology peer-review repair train is treated as represented/superseded by current recovery morphology/Earthlike behavior. Open mountain-quality/product proof remains in the recovery lane; do not replay the old train wholesale."
-    },
-    {
-      "moveId": "done-reference-resource-runtime-proof-train",
-      "state": "done",
-      "kind": "reference",
-      "source": {
-        "kind": "branch",
-        "branch": "codex/resource-runtime-proof"
-      },
-      "terminalState": "parked-reference",
+      "method": "semantic",
       "anchors": {
         "fromHead": "b4dd7160838261077765bc0b6d00d8a331564f8d",
         "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
-        "capturedAt": "2026-06-07T14:00:05-04:00"
+        "capturedAt": "2026-06-07T14:36:32-04:00"
       },
-      "note": "Old resource-runtime stack remains provenance/reference. Current recovery resource work uses the Earthlike proof stack and current verifier rows, not a wholesale replay of this old train."
+      "note": "Resource, morphology, and authoring predecessor branches are represented by merged aggregate PR #1402. Shard PRs #1414-#1419 were closed after the aggregate landed, so this train is done for accounting and must not be replayed wholesale into the Swooper recovery stack."
+    },
+    {
+      "moveId": "done-adopt-live-play-online-context-merged-studio-prs",
+      "state": "done",
+      "kind": "adopt",
+      "source": {
+        "kind": "branch",
+        "branch": "codex/live-play-online-context"
+      },
+      "sink": {
+        "kind": "main",
+        "label": "main via merged Studio/run-in-game PRs #1407-#1413",
+        "commit": "98dca389248d5ddb2777a88105c3ade452b2137c"
+      },
+      "method": "semantic",
+      "anchors": {
+        "fromHead": "b3013fe5ea00d03fdb7bcc18c7dd5fe537340612",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:36:32-04:00"
+      },
+      "note": "Graphite still shows this as a local root needing restack, but its relevant Studio/run-in-game PR range #1407-#1413 is merged to main. Treat needs-restack here as stale local metadata, not a pending product adoption source."
     },
     {
       "moveId": "done-adopt-studio-exact-authorship-proof",
@@ -161,6 +185,54 @@
         "capturedAt": "2026-06-07T14:00:05-04:00"
       },
       "note": "Final-surface parity proof path and routing records are represented in the Swooper Studio parity proof drain and later current parity record branches."
+    },
+    {
+      "moveId": "done-adopt-studio-live-runtime-snapshot-completion",
+      "state": "done",
+      "kind": "adopt",
+      "source": {
+        "kind": "branch",
+        "branch": "codex/studio-live-runtime-snapshot-completion"
+      },
+      "sink": {
+        "kind": "branch",
+        "branch": "codex/swooper-studio-parity-proof-drain"
+      },
+      "method": "semantic",
+      "anchors": {
+        "fromHead": "5fd0a81955d5e8bcbdfe8147e893bb9b79b41d93",
+        "toHead": "eeccd5a9eb52bd30e7545e3324fe359d21ded7a4",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:36:32-04:00"
+      },
+      "note": "Live runtime snapshot completion is represented in the Studio parity proof drain and follow-up current exact-authorship proof branches."
+    },
+    {
+      "moveId": "done-reference-swooper-recovery-planning-context",
+      "state": "done",
+      "kind": "reference",
+      "source": {
+        "kind": "stack-slice",
+        "id": "swooper-recovery-planning-context",
+        "root": "codex/swooper-dra-takeover-handoff",
+        "branches": [
+          "codex/swooper-dra-takeover-handoff",
+          "codex/swooper-recovery-openspec-plan"
+        ]
+      },
+      "sink": {
+        "kind": "branch",
+        "branch": "codex/swooper-mapgen-recovery-drain"
+      },
+      "method": "semantic",
+      "terminalState": "retired",
+      "anchors": {
+        "fromHead": "26747873be07c8f3bdb4ce73d4a9b81083b9cc53",
+        "toHead": "d77f7e3d01b332af344345909c10a9cebbce25ae",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:36:32-04:00"
+      },
+      "note": "The recovery handoff and OpenSpec planning branches were consumed as planning/reference input for the Swooper recovery stack. They are not pending product branches."
     },
     {
       "moveId": "done-adopt-earthlike-feature-resource-proof-stack",
@@ -355,6 +427,33 @@
       "note": "Non-Earthlike config drift was intentionally dropped from the recovery stack."
     },
     {
+      "moveId": "planned-adopt-systematic-workstream-skill-support-slice",
+      "state": "planned",
+      "kind": "adopt",
+      "source": {
+        "kind": "stack-slice",
+        "id": "systematic-workstream-skill-support-slice",
+        "root": "codex/systematic-workstream-skill-framing",
+        "branches": [
+          "codex/systematic-workstream-skill-framing",
+          "codex/systematic-evidence-workstream-skill",
+          "codex/systematic-skill-review-fixes"
+        ]
+      },
+      "sink": {
+        "kind": "main",
+        "label": "main support adoption",
+        "commit": "98dca389248d5ddb2777a88105c3ade452b2137c"
+      },
+      "method": "semantic",
+      "anchors": {
+        "fromHead": "7b9a16aa4eac8fe319a816bcebc73e574c31f0b6",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:36:32-04:00"
+      },
+      "note": "The repo-local systematic workstream skill is not in main or in the Swooper recovery stack. It is useful support tooling and needs a dedicated support adoption slice; it is not part of the Swooper product recovery drain."
+    },
+    {
       "moveId": "done-reference-foundation-architecture-packet",
       "state": "done",
       "kind": "reference",
@@ -362,12 +461,68 @@
         "kind": "branch",
         "branch": "codex/foundation-architecture-packet"
       },
-      "terminalState": "parked-reference",
+      "terminalState": "retired",
       "anchors": {
         "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
-        "capturedAt": "2026-06-07T14:00:05-04:00"
+        "capturedAt": "2026-06-07T14:36:32-04:00"
       },
       "note": "Foundation architecture packet remains reference/support material, not a source branch replayed into the Swooper recovery stack."
+    },
+    {
+      "moveId": "done-exclude-civ7-intelligence-and-control-doc-train",
+      "state": "done",
+      "kind": "exclude",
+      "source": {
+        "kind": "stack-slice",
+        "id": "civ7-intelligence-and-control-doc-train",
+        "root": "codex/frame-civ7-intelligence-layer",
+        "branches": [
+          "codex/frame-civ7-intelligence-layer",
+          "codex/shape-civ7-intelligence-solution",
+          "codex/investigate-civ7-intelligence-threads",
+          "codex/consolidate-play-agent-docs",
+          "codex/play-agent-output-contract",
+          "codex/unit-movement-api-investigation",
+          "codex/live-play-settlement-reference"
+        ]
+      },
+      "anchors": {
+        "fromHead": "754f90431964fe6439090a0ed03c9546d9e96bc1",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:36:32-04:00"
+      },
+      "note": "Control/intelligence documentation and live-play setup branches are outside the Swooper mapgen recovery accounting. They are not source work to adopt into the recovery stack."
+    },
+    {
+      "moveId": "done-exclude-gt-stack-inspect-toolkit-lane",
+      "state": "done",
+      "kind": "exclude",
+      "source": {
+        "kind": "stack-slice",
+        "id": "gt-stack-inspect-toolkit-lane",
+        "root": "codex/stack-lineage-audit-reference",
+        "branches": [
+          "codex/stack-lineage-audit-reference",
+          "codex/stack-visualizer-ui-integration",
+          "codex/gt-stack-inspect-spec-alignment",
+          "codex/gt-stack-inspect-visual-contract",
+          "codex/gt-stack-inspect-effect-service-core",
+          "codex/gt-stack-inspect-inspection-adapters",
+          "codex/gt-stack-inspect-effect-orpc-router",
+          "codex/gt-stack-inspect-live-event-stream",
+          "codex/gt-stack-inspect-react-rpc-vite-shell",
+          "codex/gt-stack-inspect-react-rpc-client-state",
+          "codex/gt-stack-inspect-react-topology-ui",
+          "codex/gt-stack-inspect-cross-repo-runner",
+          "codex/gt-stack-inspect-react-parity-workstreams"
+        ]
+      },
+      "anchors": {
+        "fromHead": "76f02ff13a56c24af05fa38b5d4d37238d8f66f1",
+        "mainHead": "98dca389248d5ddb2777a88105c3ade452b2137c",
+        "capturedAt": "2026-06-07T14:36:32-04:00"
+      },
+      "note": "The GT stack-inspect/toolkit stack is an active separate tooling lane owned outside the Swooper product recovery drain. It is excluded from product recovery cleanup decisions."
     }
   ],
   "workSurfaceRows": [
@@ -378,6 +533,14 @@
       "sourceRef": "codex/earthlike-natural-wonder-postwrite-footprint-proof-record",
       "moveId": "planned-adopt-earthlike-floodplain-config-leaf",
       "blocker": "Recovery stack lacks latest Earthlike floodplainPlanning config/hash leaf."
+    },
+    {
+      "rowId": "planned-adopt-systematic-workstream-skill-support-slice",
+      "kind": "planned-move",
+      "target": "codex/systematic-skill-review-fixes",
+      "sourceRef": "systematic-workstream-skill-support-slice",
+      "moveId": "planned-adopt-systematic-workstream-skill-support-slice",
+      "blocker": "Systematic workstream skill is useful support tooling but is not in main; adopt separately from the Swooper product drain."
     },
     {
       "rowId": "cleanup-blocked-until-recovery-lands",

--- a/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-state.md
+++ b/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-state.md
@@ -1,11 +1,11 @@
 # Recovery Accounting State
 
-Capture: `2026-06-07T14:00:05-04:00`
+Capture: `2026-06-07T15:03:52-04:00`
 
 Recovery stack:
 
 - Base: `codex/swooper-mapgen-recovery-drain` at `d77f7e3d01b3`
-- Current top: `codex/swooper-natural-wonder-plan-input-comparison-drain` at `4df442761979`
+- Current top: `codex/swooper-natural-wonder-plan-input-comparison-drain` at `6dc5acd2992b`
 - Main base: `98dca389248d`
 
 This is the human-readable companion to
@@ -16,9 +16,13 @@ This is the human-readable companion to
 
 - Product mutation is frozen for this accounting pass.
 - `done` means source intent is represented in the local recovery stack.
-- `done` does not mean cleanup is safe. Cleanup remains blocked until the
-  recovery stack is submitted or merged.
-- No live-play/control branches are classified here.
+- `done` may also mean source intent is represented by a merged aggregate PR.
+- `done` does not always mean cleanup is safe. Cleanup is safe only when the
+  accounting sink is already durable, or after the recovery stack is submitted
+  or merged when the sink is the local recovery stack.
+- Already-merged or explicitly represented branches are not parked. The parked
+  set is reserved for actually pending or owner-held work.
+- No active live-play/control continuation branches are classified here.
 - GT stack-inspect/toolkit branches are not classified here; they are a
   separate owned lane.
 - No source branch should be replayed wholesale when the ledger marks it
@@ -31,25 +35,32 @@ This is the human-readable companion to
 | PR `#1421` / Swooper Earthlike predecessor | `done/supersede` | `codex/swooper-mapgen-recovery-drain` | Keep as fallback/reference until recovery lands; do not merge as-is. |
 | `codex/start-placement-viability` + `codex/resource-initial-map-policy` | `done/adopt` | `codex/swooper-mapgen-recovery-drain` | Covered locally; cleanup gated on recovery landing. |
 | `codex/studio-setup-config-sync` + `06-05-fix_studio_validate_civ7_setup_seeds` | `done/adopt` | `codex/swooper-mapgen-recovery-drain` | Covered locally; cleanup gated on recovery landing. |
-| `codex/morphology-peer-review-repairs` | `done/supersede` | `codex/swooper-mapgen-recovery-drain` | Do not replay wholesale; old train is represented/superseded, while product-quality proof remains in recovery. |
-| `codex/resource-runtime-proof` | `done/reference` | reference only | Do not treat as product source replay; keep as provenance until source cleanup is deliberate. |
+| Resource/morphology/authoring predecessor train through `codex/resource-runtime-proof`, `codex/morphology-live-readback-boundary`, and `codex/morphology-peer-review-repairs` | `done/adopt` | merged PR `#1402` | Done. Shard PRs `#1414`-`#1419` were closed after the aggregate landed; local Graphite metadata/branches were deleted on `2026-06-07`. |
+| `codex/live-play-online-context` Studio/run-in-game range | `done/adopt` | `main` via merged PRs `#1407`-`#1413` | Done; local Graphite metadata/branch was deleted on `2026-06-07`. The exposed `codex/local-catalog-enrichment` restack belongs to live-play/control. |
 | `codex/studio-civ7-exact-authorship-proof` | `done/adopt` | `codex/swooper-studio-parity-proof-drain` | Studio exact-auth proof intent is represented in recovery. |
 | `codex/civ7-map-policy-final-surface-parity` | `done/adopt` | `codex/swooper-studio-parity-proof-drain` | Final-surface proof path intent is represented in recovery. |
+| `codex/studio-live-runtime-snapshot-completion` | `done/adopt` | `codex/swooper-studio-parity-proof-drain` | Live runtime snapshot proof intent is represented in recovery. |
+| `codex/swooper-dra-takeover-handoff` + `codex/swooper-recovery-openspec-plan` | `done/reference` | `codex/swooper-mapgen-recovery-drain` | Planning context consumed; not a pending product branch. |
 | Earthlike feature/resource proof stack through `codex/earthlike-resource-coordinate-proof-intake` | `done/adopt` | Swooper resource proof drain | Covered locally; later Swooper resource rejection branches are continuation work, not old-source cleanup. |
 | Earthlike terrain-edge stack through `codex/earthlike-terrain-edge-stack-integration` | `done/adopt` | `codex/swooper-terrain-edge-reconciliation-drain` | Covered locally; cleanup gated on recovery landing. |
 | Earthlike natural-wonder stack through `codex/earthlike-natural-wonder-postwrite-footprint-proof` | `done/adopt` | Swooper natural-wonder drain | Covered locally through footprint proof; later plan-input branches are continuation work. |
 | `codex/earthlike-natural-wonder-postwrite-footprint-proof-record` | `planned/adopt` | `codex/swooper-mapgen-recovery-drain` | Not finished: latest Earthlike `floodplainPlanning` config/hash leaf is missing from recovery. |
 | Non-Earthlike predecessor config drift | `done/exclude` | retired | Intentionally dropped. |
+| Systematic workstream skill support slice | `planned/adopt` | `main` | Not product recovery; adopt separately if we want repo-local skill support durable on main. |
 | `codex/foundation-architecture-packet` | `done/reference` | reference only | Not part of product recovery adoption. |
+| Civ7 intelligence/control doc train | `done/exclude` | outside this drain | Not source work for Swooper recovery. |
+| GT stack-inspect/toolkit lane | `done/exclude` | outside this drain | Active separate tooling lane. |
 
 ## Immediate Work Surface
 
 1. Adopt `codex/earthlike-natural-wonder-postwrite-footprint-proof-record`
    into the recovery stack, specifically the latest Swooper Earthlike
    `floodplainPlanning` config/hash leaf.
-2. Do not delete or Graphite-sync source branches yet. All covered-source
-   cleanup is blocked until the recovery stack is submitted or merged.
-3. Do not add more proof branches before deciding whether to fold/reduce the
+2. Adopt the systematic workstream skill separately if the repo-local skill
+   should be durable on main; do not mix it into Swooper product closure.
+3. Do not delete recovery-adopted source branches yet. Cleanup for sources whose
+   sink is the local recovery stack is blocked until recovery submits or merges.
+4. Do not add more proof branches before deciding whether to fold/reduce the
    current recovery stack.
 
 ## Current Finished Boundary
@@ -60,10 +71,17 @@ Finished locally:
   Earthlike, Studio setup, exact-authorship, final-surface proof, feature/resource
   proof, terrain-edge, and natural-wonder proof/materialization slices listed
   above.
+- Resource/morphology/authoring predecessor trains are done through merged
+  aggregate PR `#1402`, not parked, and their local Graphite branches were
+  deleted.
+- Studio/run-in-game predecessor range is done through merged PRs `#1407`-`#1413`,
+  not parked, and `codex/live-play-online-context` was deleted locally.
 
 Not finished:
 
 - The recovery stack has not landed.
-- Source cleanup is not safe.
+- Source cleanup for branches adopted only by the local recovery stack is not
+  safe until the recovery stack lands.
 - Latest Earthlike floodplain config leaf is not adopted.
+- Systematic workstream skill support slice is not adopted to main.
 - Product closure/final parity is not claimed.

--- a/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-state.md
+++ b/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-state.md
@@ -1,0 +1,69 @@
+# Recovery Accounting State
+
+Capture: `2026-06-07T14:00:05-04:00`
+
+Recovery stack:
+
+- Base: `codex/swooper-mapgen-recovery-drain` at `d77f7e3d01b3`
+- Current top: `codex/swooper-natural-wonder-plan-input-comparison-drain` at `4df442761979`
+- Main base: `98dca389248d`
+
+This is the human-readable companion to
+`recovery-accounting-ledger.json`. The JSON file uses the sparse
+`gt-stack-inspect.accounting-ledger.v1` move model.
+
+## Policy
+
+- Product mutation is frozen for this accounting pass.
+- `done` means source intent is represented in the local recovery stack.
+- `done` does not mean cleanup is safe. Cleanup remains blocked until the
+  recovery stack is submitted or merged.
+- No live-play/control branches are classified here.
+- GT stack-inspect/toolkit branches are not classified here; they are a
+  separate owned lane.
+- No source branch should be replayed wholesale when the ledger marks it
+  `done/adopt` or `done/supersede`.
+
+## State Update
+
+| Source | State-machine move | Sink | Cleanup meaning |
+|---|---|---|---|
+| PR `#1421` / Swooper Earthlike predecessor | `done/supersede` | `codex/swooper-mapgen-recovery-drain` | Keep as fallback/reference until recovery lands; do not merge as-is. |
+| `codex/start-placement-viability` + `codex/resource-initial-map-policy` | `done/adopt` | `codex/swooper-mapgen-recovery-drain` | Covered locally; cleanup gated on recovery landing. |
+| `codex/studio-setup-config-sync` + `06-05-fix_studio_validate_civ7_setup_seeds` | `done/adopt` | `codex/swooper-mapgen-recovery-drain` | Covered locally; cleanup gated on recovery landing. |
+| `codex/morphology-peer-review-repairs` | `done/supersede` | `codex/swooper-mapgen-recovery-drain` | Do not replay wholesale; old train is represented/superseded, while product-quality proof remains in recovery. |
+| `codex/resource-runtime-proof` | `done/reference` | reference only | Do not treat as product source replay; keep as provenance until source cleanup is deliberate. |
+| `codex/studio-civ7-exact-authorship-proof` | `done/adopt` | `codex/swooper-studio-parity-proof-drain` | Studio exact-auth proof intent is represented in recovery. |
+| `codex/civ7-map-policy-final-surface-parity` | `done/adopt` | `codex/swooper-studio-parity-proof-drain` | Final-surface proof path intent is represented in recovery. |
+| Earthlike feature/resource proof stack through `codex/earthlike-resource-coordinate-proof-intake` | `done/adopt` | Swooper resource proof drain | Covered locally; later Swooper resource rejection branches are continuation work, not old-source cleanup. |
+| Earthlike terrain-edge stack through `codex/earthlike-terrain-edge-stack-integration` | `done/adopt` | `codex/swooper-terrain-edge-reconciliation-drain` | Covered locally; cleanup gated on recovery landing. |
+| Earthlike natural-wonder stack through `codex/earthlike-natural-wonder-postwrite-footprint-proof` | `done/adopt` | Swooper natural-wonder drain | Covered locally through footprint proof; later plan-input branches are continuation work. |
+| `codex/earthlike-natural-wonder-postwrite-footprint-proof-record` | `planned/adopt` | `codex/swooper-mapgen-recovery-drain` | Not finished: latest Earthlike `floodplainPlanning` config/hash leaf is missing from recovery. |
+| Non-Earthlike predecessor config drift | `done/exclude` | retired | Intentionally dropped. |
+| `codex/foundation-architecture-packet` | `done/reference` | reference only | Not part of product recovery adoption. |
+
+## Immediate Work Surface
+
+1. Adopt `codex/earthlike-natural-wonder-postwrite-footprint-proof-record`
+   into the recovery stack, specifically the latest Swooper Earthlike
+   `floodplainPlanning` config/hash leaf.
+2. Do not delete or Graphite-sync source branches yet. All covered-source
+   cleanup is blocked until the recovery stack is submitted or merged.
+3. Do not add more proof branches before deciding whether to fold/reduce the
+   current recovery stack.
+
+## Current Finished Boundary
+
+Finished locally:
+
+- The recovery stack has local semantic coverage for the predecessor Swooper
+  Earthlike, Studio setup, exact-authorship, final-surface proof, feature/resource
+  proof, terrain-edge, and natural-wonder proof/materialization slices listed
+  above.
+
+Not finished:
+
+- The recovery stack has not landed.
+- Source cleanup is not safe.
+- Latest Earthlike floodplain config leaf is not adopted.
+- Product closure/final parity is not claimed.

--- a/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-state.md
+++ b/openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-state.md
@@ -44,6 +44,7 @@ This is the human-readable companion to
 | Earthlike feature/resource proof stack through `codex/earthlike-resource-coordinate-proof-intake` | `done/adopt` | Swooper resource proof drain | Covered locally; later Swooper resource rejection branches are continuation work, not old-source cleanup. |
 | Earthlike terrain-edge stack through `codex/earthlike-terrain-edge-stack-integration` | `done/adopt` | `codex/swooper-terrain-edge-reconciliation-drain` | Covered locally; cleanup gated on recovery landing. |
 | Earthlike natural-wonder stack through `codex/earthlike-natural-wonder-postwrite-footprint-proof` | `done/adopt` | Swooper natural-wonder drain | Covered locally through footprint proof; later plan-input branches are continuation work. |
+| `codex/workspace-source-package-resolution` | `done/adopt` | Swooper natural-wonder drain | Covered locally by the recovery-side workspace source-resolution expansion for `@civ7/map-policy` and `@civ7/adapter`; this is an accounting-label correction, not new product adoption. |
 | `codex/earthlike-natural-wonder-postwrite-footprint-proof-record` | `planned/adopt` | `codex/swooper-mapgen-recovery-drain` | Not finished: latest Earthlike `floodplainPlanning` config/hash leaf is missing from recovery. |
 | Non-Earthlike predecessor config drift | `done/exclude` | retired | Intentionally dropped. |
 | Systematic workstream skill support slice | `planned/adopt` | `main` | Not product recovery; adopt separately if we want repo-local skill support durable on main. |
@@ -69,8 +70,8 @@ Finished locally:
 
 - The recovery stack has local semantic coverage for the predecessor Swooper
   Earthlike, Studio setup, exact-authorship, final-surface proof, feature/resource
-  proof, terrain-edge, and natural-wonder proof/materialization slices listed
-  above.
+  proof, terrain-edge, natural-wonder proof/materialization, and workspace
+  source-resolution slices listed above.
 - Resource/morphology/authoring predecessor trains are done through merged
   aggregate PR `#1402`, not parked, and their local Graphite branches were
   deleted.


### PR DESCRIPTION
test(mapgen): compare natural wonder plan inputs

Bind NATURAL_WONDER_PLAN_INPUT_V1 selected-row and surface-digest telemetry into Studio exact-authorship proof and local final-surface parity comparison. Keep the comparison diagnostic-only: it adds no new unresolved final-parity link and does not change natural-wonder planning, candidate scoring, materialization, public config, or product acceptance.

Fresh exact request studio-run-in-game-mq40o844-1zzu preserved selected-row plan-input context; fresh exact request studio-run-in-game-mq41wza4-1zzu preserved full input-surface digests. The digest comparison shows exact/local land, elevation, and blocked masks match while aridity, river, lake, terrain, biome, and feature surfaces diverge before natural-wonder candidate/scoring ownership is resolved. Final-surface parity remains unresolved with natural-wonder plan-coordinate, resource-coordinate, and terrain/biome/feature/resource surface links open.

Validated with focused natural-wonder plan-input proof tests, Studio proof parser tests, final-surface parity proof tests, owner package checks, strict OpenSpec validation for the recovery changes, full OpenSpec validation, git diff hygiene, exact requests studio-run-in-game-mq40o844-1zzu and studio-run-in-game-mq41wza4-1zzu, and final-surface verifier artifact proof hashes 4868dffcca7b41ac13be1399c545da89b1ba1c53bc5bea2671968a131d3528d1 and 7b1164396c500028a2d63f23b18880a04f7dff362c6976ca66fb578e9f3f9b71.

docs(graphite): account Swooper recovery adoption

Record sparse gt-stack-inspect accounting moves for the source stacks and slices adopted or superseded by the local Swooper recovery stack. Keep live-play/control and GT stack-inspect lanes explicitly out of scope, preserve covered-source cleanup as blocked until recovery lands, and mark the latest Earthlike floodplain config leaf as planned adoption rather than covered.

Validation:
- python3 -m json.tool openspec/changes/swooper-stack-recovery-consolidation/workstream/recovery-accounting-ledger.json
- branch endpoint existence validator
- structural accounting move validator
- bun run openspec -- validate swooper-stack-recovery-consolidation --strict
- bun run openspec:validate
- git diff --check

docs(graphite): refresh Swooper recovery accounting

docs(graphite): compose branch accounting state

docs(graphite): correct recovery accounting label