### PR TITLE
docs(civ7-live-play-support): add skill asset assembly, runtime state sources, local catalog enrichment, and workstream record

### DIFF
--- a/docs/projects/civ7-live-play-support/SKILL-ASSET-ASSEMBLY.md
+++ b/docs/projects/civ7-live-play-support/SKILL-ASSET-ASSEMBLY.md
@@ -1,0 +1,350 @@
+# Civ7 Live Play Skill Asset Assembly
+
+Status: `active-draft`.
+
+## Purpose
+
+This packet assembles the live-play support artifacts that are ready to become
+Codex skills, skill assets, or CLI play references. It is not itself the skill.
+Its job is to preserve the frame, proof boundaries, topic map, and open gaps so
+future promotion work can copy the stable parts without importing speculative
+play advice.
+
+## Frame
+
+The support model is hybrid:
+
+- Direct-control/runtime polling is the live authority for blockers, selected
+  or ready entities, validators, operation sends, and postconditions. The HUD
+  is a short-lived projection of those live reads, valid only with freshness
+  and invalidation rules attached.
+- Local official resources and SQLite copies are static authority for names,
+  definitions, type ids, UI handler code, localization, and cross-reference
+  joins.
+- Online strategy context is advisory. It can inform the play recommendation,
+  but it cannot override live state, official UI/resource evidence, or validator
+  results.
+
+The skill boundary should therefore be operational, not encyclopedic. A useful
+skill tells an agent what to read, which proof label it has, which shortcut is
+safe to try, and when to stop because the live inputs are missing.
+
+## Loader Order
+
+For future skill conversion, load source material in this order:
+
+1. `topics/runtime-state-sources.md` for authority order and the SQLite/live
+   runtime boundary.
+2. `topics/local-catalog-enrichment.md` for static catalog enrichment and local
+   shortcut boundaries.
+3. `topics/notification-decision-hud.md` and `topics/end-turn-blockers.md` for
+   the turn-blocker control loop.
+4. The domain reference matching the blocker family: progression, production,
+   diplomacy, unit targeting, or informational closeout.
+5. Evidence packs only when the source reference needs provenance detail.
+6. Strategy context last, and only as advisory decision support.
+
+Do not import `workstream-record.md` into a reusable skill except as historical
+context during authoring. It contains thread ids, branch state, and next-packet
+workflow that are useful for handoff but misleading inside a general play skill.
+
+## Proof Classes
+
+| Class | Meaning | Promotion use |
+| --- | --- | --- |
+| Live-proved | Observed in the active game with before/after state or blocker movement. | Safe to encode as a norm when the same preconditions are present. |
+| Official-UI-backed | Confirmed in official resource/UI code but not yet hit in live play. | Safe to document as an available operation family; keep validation and postcondition language explicit. |
+| Static-enrichment | Confirmed in local SQLite/resource data, logs, or catalogs. | Use for names, costs, categories, and contextual joins; do not treat as current legality. |
+| Advisory | Current online or community strategy context. | Use only as a tiebreaker after live legality and local game facts. |
+| Open | Plausible but not yet captured with enough proof. | Keep out of deterministic skill guidance except as a warning or future work item. |
+
+## Status Normalization
+
+The project topics were written during active play, so their local status labels
+are uneven. Skill promotion should normalize them into these categories:
+
+- `promotable-reference`: stable enough to become skill reference material.
+- `reference-with-gap`: useful reference material with one or more named proof
+  gaps that must stay visible.
+- `evidence-only`: provenance or observation material, not user-facing skill
+  guidance.
+- `advisory-only`: strategy context that can age or vary by patch.
+- `do-not-promote-yet`: material whose operation shape or postcondition is not
+  proven enough for deterministic guidance.
+
+## Candidate Skill Families
+
+### Turn Blocker Resolution
+
+Source artifacts:
+
+- `topics/notification-decision-hud.md`
+- `topics/end-turn-blockers.md`
+- `topics/informational-notification-closeout.md`
+
+CLI shortcuts:
+
+- `game play notifications`
+- `game play end-turn`
+- `game play dismiss-notification`
+- `game play advisor-warning`
+
+Norms:
+
+- Always read the HUD before resolving a blocker.
+- Prefer the specialized operation family over notification dismissal.
+- Treat reviewed default-handler notices as dismissible only after the HUD and
+  official handler evidence show no real decision surface remains.
+- Do not use force-end-turn as play-agent guidance.
+
+Promotion readiness: ready for a skill asset, with a required warning that
+diplomacy, narrative, production, population, progression, and unit blockers are
+not generic dismissal candidates.
+
+### Progression And Choice Resolution
+
+Source artifacts:
+
+- `topics/progression-tree-targets.md`
+- `topics/notification-decision-hud.md`
+- `topics/end-turn-blockers.md`
+
+CLI shortcuts:
+
+- `game play choose-tech`
+- `game play set-tech-target`
+- `game play choose-culture`
+- `game play set-culture-target`
+- `game play buy-attribute`
+- `game play consider-attributes`
+- `game play change-tradition`
+- `game play consider-traditions`
+- `game play choose-narrative`
+
+Norms:
+
+- Use runtime `ProgressionTreeNodeType` hashes, not row indexes or visible list
+  positions.
+- Distinguish current-node operations from full-tree target-node operations.
+- Send target-node closeout only when the live UI path or postcondition requires
+  it.
+- Narrative `CLOSE` is an acknowledgement pattern only when the pending story
+  has no links.
+
+Promotion readiness: ready for culture target, traditions, attributes, and
+narrative acknowledgement guidance. Tech target remains official-UI-backed
+until a live tech-target blocker proves the postcondition path.
+
+### City Production And Population
+
+Source artifacts:
+
+- `topics/production-build-placement.md`
+- `topics/ready-city-decision-view.md`
+- `topics/population-placement-expansion.md`
+- `topics/runtime-state-sources.md`
+- `topics/notification-decision-hud.md`
+
+CLI shortcuts:
+
+- `game play build-production`
+- `game play build-unit`
+- `game play ready-city`
+- `game play set-town-focus`
+- `game play consider-town-project`
+- `game play assign-worker`
+- `game play expand-city`
+
+Norms:
+
+- Ordinary production uses `BUILD`, but the args depend on item kind:
+  `UnitType`, `ConstructibleType`, or `ProjectType`.
+- Placement-sensitive constructibles need `X` and `Y` when the validator or
+  placement UI returns legal plots.
+- Town focus is not ordinary production; it uses `CHANGE_GROWTH_MODE`.
+- `NEW_POPULATION` opens acquire-tile mode. Worker assignment uses
+  `ASSIGN_WORKER { Location, Amount: 1 }` for already-workable plots; expansion
+  purchase uses city-command `EXPAND { X, Y }` for expansion plots.
+
+Promotion readiness: ready for production item-kind and constructible placement
+guidance. `ready-city` is ready as a read-only support asset, and population
+placement now has both proven branch shortcuts. Keep tile ranking and better
+candidate cataloging open.
+
+### Tactical Unit Control
+
+Source artifacts:
+
+- `topics/ready-unit-commander-actions.md`
+- `topics/unit-target-actions.md`
+- `topics/early-war-tactical-stale-state-guard.md`
+- `evidence-packs/watcher-latency-observer-mode.md`
+
+CLI shortcuts:
+
+- `game play ready-unit`
+- `game play unit-target`
+- `game play operation`
+
+Norms:
+
+- Re-read before every tactical mutation when human input, latency, or combat
+  animation may have changed the board.
+- Target plots, not target unit ids.
+- Validator success is not proof of tactical effect; require a postcondition.
+- Commanders are support and coordination units first. Do not treat them as
+  default attackers without live evidence.
+
+Promotion readiness: ready as a tactical guard asset. A richer combat-dry-run
+or tactical-snapshot shortcut should be added before this becomes a full combat
+skill.
+
+### Diplomacy And First-Meet
+
+Source artifacts:
+
+- `topics/first-meet-diplomacy.md`
+- `topics/notification-decision-hud.md`
+- `topics/early-war-tactical-stale-state-guard.md`
+
+CLI shortcuts:
+
+- `game play respond-diplomacy`
+- `game play respond-first-meet`
+
+Norms:
+
+- `NOTIFICATION_PLAYER_MET` is a first-meet operation, not a dismissal.
+- Ordinary diplomacy uses `{ ID, Type }`; first-meet greetings use
+  `{ Player1, Player2, Type }`.
+- Prefer neutral first-meet greetings when payoff or Influence cost is unclear.
+- Preserve Influence during war pressure unless the action payoff is proven.
+
+Promotion readiness: ready for first-meet handling and conservative diplomacy
+defaults. Richer diplomacy option reads and cost explanations remain useful
+future assets.
+
+### Runtime Source Authority
+
+Source artifacts:
+
+- `topics/runtime-state-sources.md`
+- `topics/local-catalog-enrichment.md`
+- `evidence-packs/local-on-disk-read-surfaces.md`
+- `evidence-packs/agent-evidence-summary.md`
+
+Norms:
+
+- Poll the game runtime for live decisions because the obvious local SQLite
+  copies are static/debug catalogs, not a proven live-state read model.
+- Use SQLite for enrichment and lower-cost joins.
+- Treat local catalog shortcuts as read-only support surfaces until freshness
+  and live-state semantics are proven.
+- Treat the HUD as the short-lived live decision materialization layer: runtime
+  facts decide legality, local catalog facts make the decision readable.
+- Treat saves as forensic snapshots until a stable parser and freshness
+  contract exist.
+- Treat logs as bounded observations, not proof that something did not happen.
+
+Promotion readiness: ready as an authority preface for every live-play skill.
+
+### Current Online Context
+
+Source artifacts:
+
+- `evidence-packs/current-online-play-context.md`
+- `topics/early-game-decision-context.md`
+- `topics/ready-unit-commander-actions.md`
+
+Norms:
+
+- Treat official current patch notes as the highest online context source, but
+  still below live direct-control and local official resources for exact
+  decisions.
+- Treat older launch-era guides and community pages as advisory hypotheses.
+- Keep current online context date-stamped because balance, yields, and UI
+  affordances can change between patches.
+- Use online context to decide what to inspect next, not to skip validators.
+
+Promotion readiness: ready as an advisory-only asset that must be loaded after
+runtime and local official resource references.
+
+## Topic-To-Asset Map
+
+| Topic | Candidate destination | Promotion state |
+| --- | --- | --- |
+| `topics/notification-decision-hud.md` | HUD/blocker skill reference | Ready |
+| `topics/end-turn-blockers.md` | HUD/blocker skill reference | Ready |
+| `topics/informational-notification-closeout.md` | HUD/blocker skill guardrail | Ready |
+| `topics/progression-tree-targets.md` | Progression skill reference | Ready with tech-target proof note |
+| `topics/production-build-placement.md` | City production skill reference | Ready with city-project gap |
+| `topics/ready-city-decision-view.md` | City blocker read surface | Ready |
+| `topics/population-placement-expansion.md` | Population placement branch reference | Ready with candidate-cataloging gap |
+| `topics/runtime-state-sources.md` | Authority preface asset | Ready |
+| `topics/local-catalog-enrichment.md` | Static catalog enrichment asset | Ready |
+| `topics/first-meet-diplomacy.md` | Diplomacy skill reference | Ready |
+| `topics/ready-unit-commander-actions.md` | Tactical guard reference | Ready as guard, not full combat planner |
+| `topics/unit-target-actions.md` | Tactical operation reference | Ready with postcondition warning |
+| `topics/early-war-tactical-stale-state-guard.md` | Tactical guard and advisory asset | Ready as guard; strategy stays advisory |
+| `topics/early-game-decision-context.md` | Strategy context asset | Advisory only |
+| `evidence-packs/current-online-play-context.md` | Current online context asset | Advisory only |
+| `evidence-packs/local-on-disk-read-surfaces.md` | Runtime-source authority evidence | Ready |
+| `evidence-packs/watcher-latency-observer-mode.md` | Watcher operating-mode asset | Ready |
+| `evidence-packs/agent-evidence-summary.md` | Proof ledger seed | Active draft |
+
+## Materialized HUD Asset Shape
+
+A future skill asset should describe the HUD as a two-source read model:
+
+- live layer: blocker, notification target, selected/ready entity, validator
+  result, candidate args, and postcondition;
+- static enrichment layer: names, costs, categories, UI text, source anchors,
+  and mtime/version metadata from SQLite/resource catalogs;
+- forensic/history layer: logs, saves, and Hall of Fame rows, used only to
+  explain or audit past state.
+
+The live layer expires after every mutation, visible human input, turn advance,
+or long-latency read. The static enrichment layer can be cached. The
+forensic/history layer must keep explicit read bounds and must not be treated as
+current legality. This split is the reason agents should poll direct-control
+for decisions while still using local SQLite/resource indexes to avoid noisy UI
+exploration.
+
+## Open Shortcut Candidates
+
+These should stay out of deterministic skill guidance until the operation shape
+and postcondition are proven:
+
+- `game play tactical-snapshot`: compact read of ready unit, nearby enemies,
+  threatened friendly units, valid target plots, and stale-risk markers.
+- `game play combat-dry-run`: explain the official target resolver result and
+  expected postcondition without sending.
+- `game play diplomacy-options`: read available responses, cost, and likely
+  relationship effects before choosing a response.
+- `game play promote-unit`: read spendable promotion state and send a specific
+  promotion only with live validator-backed args.
+
+## Do-Not-Promote Boundaries
+
+Keep these out of normative skill steps until stronger proof exists:
+
+- Ordinary city-project production postconditions beyond the official item-kind
+  args shape.
+- Commander promotion planning and promotion spend operations.
+- Latency root-cause claims. Current evidence supports runtime-busy and
+  stale-state risk, not a proven focus or OS-level cause.
+- Thread ids, branch names, and active-workstream handoff instructions.
+
+## Promotion Gate
+
+Before converting a topic into a skill or stable asset, require:
+
+1. A source artifact with explicit proof class labels.
+2. A CLI shortcut or a clearly bounded manual fallback.
+3. A validator rule and a postcondition rule for mutations.
+4. A warning for any similar-looking blocker that must not use the same action.
+5. A short verification command or evidence anchor.
+6. Open questions separated from norms.
+
+If any item is missing, keep the material as a project topic or evidence pack
+instead of promoting it into a skill.

--- a/docs/projects/civ7-live-play-support/topics/local-catalog-enrichment.md
+++ b/docs/projects/civ7-live-play-support/topics/local-catalog-enrichment.md
@@ -1,0 +1,98 @@
+# Local Catalog Enrichment
+
+Status: `active-reference`.
+
+## Frame
+
+The local SQLite files are real and useful. They are not, by current evidence,
+the same thing as a safe live-turn control API.
+
+Use them as static catalog authority: names, type ids, localization, costs,
+categories, UI text, and cross-reference joins. Keep direct-control as the live
+runtime authority for the current blocker, selected entities, validators, send
+args, and postconditions.
+
+The blocker is not SQLite readability. `sqlite3` can read the debug copies from
+disk. The blocker is freshness and semantics: the files found on disk are
+debug/catalog/history surfaces, while the game process owns the mutable turn
+state and the validator APIs.
+
+## Evidence Snapshot
+
+Observed local catalog counts:
+
+| Surface | Evidence |
+| --- | --- |
+| `Debug/gameplay-copy.sqlite` | 492 tables |
+| `Debug/frontend-copy.sqlite` | 118 tables |
+| `Debug/localization-copy.sqlite` | `LocalizedText` has 41,837 rows |
+| `gameplay-copy.sqlite.Types` | 13,714 rows |
+| `gameplay-copy.sqlite.Units` | 103 rows |
+| `gameplay-copy.sqlite.Constructibles` | 107 rows |
+| `gameplay-copy.sqlite.Projects` | 11 rows |
+| `gameplay-copy.sqlite.Traditions` | 500 rows |
+| `gameplay-copy.sqlite.ProgressionTreeNodes` | 230 rows |
+| `gameplay-copy.sqlite.Notifications` | 133 rows |
+| `gameplay-copy.sqlite.DiplomacyActions` | 42 rows |
+
+These are exactly the kinds of tables that should make HUD output more
+readable. They can explain what a type, notification, unit, constructible,
+tradition, or diplomacy action means without asking the UI to enumerate a large
+catalog every time.
+
+## Authority Split
+
+| Question | Preferred authority | Why |
+| --- | --- | --- |
+| What blocker is stopping end turn right now? | Direct-control notification HUD | Needs current runtime queue and freshness after the last click/send. |
+| What selected or first-ready unit/city exists right now? | Direct-control ready views | Selection and ready state are live UI/runtime facts. |
+| Is this operation legal with these args? | Direct-control validator | `canStart` is contextual and can change after mutations, animations, or human input. |
+| What does this type id or hash mean? | Local SQLite or runtime `GameInfo` | Static catalog lookup; safe to cache with source metadata. |
+| What text should explain this notification or item? | Local localization/catalog files | Static enrichment; useful for agent-readable HUD labels. |
+| What happened in a previous completed game? | `HallofFame.sqlite` and logs | Forensic/history evidence, not current legality. |
+| What is in the currently loaded mod/resource set? | Runtime `GameInfo`, then local copies/resources | Runtime wins when loaded set or patch state may differ from copied files. |
+
+## Norm
+
+1. Read the play HUD first for the live decision family.
+2. Enrich the HUD from local SQLite/resource catalogs when ids, hashes, names,
+   categories, costs, or text are missing.
+3. Keep source labels on enriched fields, such as `source: "local-catalog"` or
+   `source: "runtime-gameinfo"`.
+4. Re-run the live validator before any send. A catalog row proves an option
+   exists; it does not prove this player can choose it now.
+5. Invalidate live-layer HUD data after every send, visible human input, turn
+   advance, or long-latency read. Static catalog enrichment can stay cached.
+
+## Shortcut Candidates
+
+Good next CLI surfaces:
+
+- `game local-data inspect --json`: read-only app-support inventory with
+  database paths, mtimes, sizes, table counts, save inventory, and useful log
+  mtimes. This answers "what local evidence exists?" without implying live
+  control.
+- `game local-catalog lookup <table> <key> --json`: bounded local catalog lookup
+  for common tables such as `Types`, `Units`, `Constructibles`, `Notifications`,
+  `Traditions`, and localization text.
+- `game play notifications --json` enrichment: keep the existing live HUD as
+  the agent-facing surface, but attach local labels and explanations when the
+  live blocker exposes ids or hashes.
+
+Avoid a shortcut that reads local SQLite and directly chooses a live action.
+That would collapse static existence into live legality, which is exactly the
+failure mode the HUD is meant to prevent.
+
+## Open Edges
+
+Before promoting local SQLite into more than enrichment, prove:
+
+- which debug-copy files refresh while a live game is running;
+- whether mtimes or transaction behavior give a reliable freshness contract;
+- how mod/DLC/patch resolution differs between runtime `GameInfo` and local
+  copies;
+- whether a save parser can expose current turn state faster than direct-control
+  without stale reads.
+
+Until those are answered, local SQLite should reduce UI enumeration and improve
+explanations, not replace runtime polling.

--- a/docs/projects/civ7-live-play-support/topics/runtime-state-sources.md
+++ b/docs/projects/civ7-live-play-support/topics/runtime-state-sources.md
@@ -1,0 +1,110 @@
+# Runtime State Sources
+
+Status: `active-reference`.
+
+## Frame
+
+Use local disk and direct-control for different jobs:
+
+- Direct-control/HUD is the live-state authority for blockers, selected
+  entities, validators, and sends.
+- Local SQLite/resource files are strong for static definitions, text,
+  enrichment, and offline joins.
+- Autosaves are useful forensic snapshots, but they are not a low-latency,
+  documented live-state API.
+
+This is why the support tools still poll the game UI/runtime directly. The
+question is not whether SQLite exists on disk; it does, and the files are
+readable. The question is whether it is the current game-state database with
+stable live schemas and freshness semantics. Current evidence says the obvious
+SQLite files are static/debug catalogs or forensic stores, not that live
+contract.
+
+## Why Not Just Read SQLite
+
+The direct-control surface is still necessary because the live play question is
+usually not "what does this ruleset contain?" It is "what is the player allowed
+to do right now, against this selected city/unit/notification, after the last
+animation or human click?"
+
+SQLite is good at stable data. It can answer static and historical questions:
+type names, localization, loaded catalog rows, known game-history rows, mod
+inventory, and log-like summaries. It does not currently provide a proven live
+contract for:
+
+- active end-turn blocker type and notification id;
+- selected or first-ready unit/city;
+- current pending modal or notification decision surface;
+- operation validators such as `canStart` and returned placement plots;
+- before/after postconditions after a send;
+- freshness while the game process is still mutating state.
+
+That means local DB reads can reduce lookup cost, but they cannot replace the
+runtime read that decides whether an action is legal and current.
+
+## Local Evidence
+
+Useful SQLite files found under `~/Library/Application Support/Civilization VII`:
+
+- `Debug/gameplay-copy.sqlite`
+- `Debug/frontend-copy.sqlite`
+- `Debug/localization-copy.sqlite`
+- `Debug/images-copy.sqlite`
+- `Debug/colors-copy.sqlite`
+- `Mods.sqlite`
+- `LocalStorage.sqlite`
+- `HallofFame.sqlite`
+
+`Debug/gameplay-copy.sqlite` contains static game catalog tables such as
+`Constructibles`, `Units`, `Notifications`, `TurnPhases`, and balancing tables.
+It is useful for answering "what is this type/id?" and "what official
+definition exists?" It does not expose the current turn's selected unit,
+pending notification queue, city production blocker, or validator result as a
+live, documented table set.
+
+`HallofFame.sqlite` contains historical game and player tables such as `Games`,
+`GamePlayers`, `GameObjects`, and data-point value tables. It can identify
+played games and outcomes, but it is not a live turn-decision API: it does not
+carry the current notification queue, selected entity, modal state, or validator
+answers needed for safe play actions.
+
+Autosaves and manual saves live under `Saves/**` and use `.Civ7Save`; those are
+state snapshots, not a direct read model for the running process. They may lag
+the active UI and require reverse engineering before they can support safe
+agent decisions.
+
+## Norm
+
+For live play:
+
+1. Use `game play notifications`, `game play ready-unit`, and targeted
+   direct-control reads for current blockers and required inputs.
+2. Use local SQLite copies for enrichment: names, categories, definitions,
+   costs, text, and cross-reference joins.
+3. Use validators before sends. A static DB row proves an item exists; it does
+   not prove the current player/city/unit can choose it now.
+4. Treat autosaves as forensic evidence until a stable parser and freshness
+   contract exist.
+
+The durable direction is hybrid: build more local definition indexes to reduce
+expensive UI enumeration, while keeping the runtime HUD as the source of truth
+for the current decision and its legal operation args. See
+`local-catalog-enrichment.md` for the catalog/HUD split and candidate local
+shortcuts.
+
+## Materialized View Policy
+
+The useful materialized view is not a replacement database. It is a short-lived
+decision cache built from live runtime reads, then enriched with local catalogs.
+
+| Field family | Source of truth | Cache use |
+| --- | --- | --- |
+| Current blocker, notification target, selected entity | Direct-control App UI/runtime read | Refresh on every decision loop and after every send |
+| Legal operation args, `canStart` result, placement plots | Direct-control validators | Never reuse after a mutation or visible human input |
+| Type names, costs, categories, localization | SQLite/resource catalogs | Cache freely with file mtime/version metadata |
+| Logs and saves | Bounded forensic reads | Use for explanations, not current legality |
+
+The notification HUD is the first version of this pattern. It reads live
+blockers and required inputs, then presents the smallest useful "what decision
+am I blocked on?" surface to the play agent. Future local data shortcuts should
+feed that HUD with labels and explanations, not bypass it.

--- a/docs/projects/civ7-live-play-support/workstream-record.md
+++ b/docs/projects/civ7-live-play-support/workstream-record.md
@@ -1,0 +1,429 @@
+# Civ7 Live Play Support
+
+Status: `active-draft`.
+Branch: `agent-watch-civ7-live-play-reference-assembly`.
+DRA: `Codex watcher`.
+Dates: `2026-06-01 -> active`.
+
+This minimal record preserves state and handoff context for one bounded
+workstream. It is not the purpose of the workstream.
+
+## Frame
+
+Objective:
+
+Watch the active Civ7 play agent, help it while it plays by feeding timely
+direct-control/resource/strategy evidence, and convert the useful discoveries
+into normative reference artifacts and CLI play shortcuts that can later become
+skills or skill assets.
+
+Done means:
+
+- The watcher worktree is based on the latest relevant studio/direct-control
+  branch and remains clean at handoff.
+- The active play thread is trailed with evidence-scoped support notes when the
+  watcher has useful, non-noisy information.
+- Research lanes produce provenance-backed evidence packs for direct-control
+  blocker mechanics, local official game data, and current online strategy
+  context.
+- The CLI gains bounded categorical shortcuts for common play operations where
+  operation shape is supported by direct-control evidence.
+- Durable artifacts separate confirmed normative guidance, inferred guidance,
+  open questions, and future skill assets.
+
+Authority inputs:
+
+- Root `AGENTS.md`.
+- `docs/DOCS.md`.
+- `docs/process/GRAPHITE.md`.
+- `docs/process/resources-submodule.md`.
+- `packages/civ7-direct-control/AGENTS.md`.
+- `.agents/skills/civ7-architecture-authority`.
+- `.agents/skills/civ7-product-authority`.
+- `.agents/skills/civ7-operational-debugging`.
+- `workstream-runner`, `workstream-review-loops`, `team-design`, and
+  `framing-design`.
+- Active play thread `019e821b-364c-72a3-83ef-9263120ece72`.
+
+Non-goals:
+
+- Do not become the play agent or take over live game mutation.
+- Do not add alternate runtime transports or caller-local socket control.
+- Do not hand-edit generated outputs, deployed Mods folders, lockfiles, or
+  official resource outputs.
+- Do not promote online strategy advice above official game data or live
+  direct-control evidence.
+- Do not encode speculative operation schemas as normative shortcuts.
+
+Stop/escalation conditions:
+
+- A proposed CLI shortcut requires undocumented or speculative operation args.
+- Live direct-control evidence contradicts official UI/resource interpretation.
+- The play agent asks for exclusive control or the watcher risks interfering
+  with live mutation sequencing.
+- Graphite/worktree state becomes dirty with unrelated changes.
+
+## Work
+
+Plan:
+
+1. Ground watcher worktree, repo workflow, active thread, and live direct-control
+   status.
+2. Run framed agent lanes for direct-control blocker mechanics, local official
+   resources, and online strategy context.
+3. Add bounded CLI play shortcuts for confirmed/common operation families.
+4. Assemble normative references and topic essays from confirmed evidence.
+5. Review proof boundaries, verify, commit, and leave the worktree clean.
+
+Outputs:
+
+- This workstream record.
+- CLI play shortcut commands and tests:
+  - `game play end-turn`
+  - `game play notifications`
+  - `game play operation`
+  - `game play advisor-warning`
+  - `game play choose-tech`
+  - `game play set-tech-target`
+  - `game play choose-culture`
+  - `game play set-culture-target`
+  - `game play respond-diplomacy`
+  - `game play choose-narrative`
+  - `game play buy-attribute`
+  - `game play consider-attributes`
+  - `game play change-tradition`
+  - `game play consider-traditions`
+  - `game play assign-worker`
+  - `game play set-town-focus`
+  - `game play consider-town-project`
+  - `game play expand-city`
+  - `game play build-production`
+  - `game play ready-city`
+  - `game play build-unit`
+  - `game play ready-unit`
+  - `game play unit-target`
+- Evidence packs and topic/reference artifacts:
+  - `SKILL-ASSET-ASSEMBLY.md`
+  - `topics/end-turn-blockers.md`
+  - `topics/early-game-decision-context.md`
+  - `topics/unit-target-actions.md`
+  - `topics/notification-decision-hud.md`
+  - `topics/ready-unit-commander-actions.md`
+  - `topics/production-build-placement.md`
+  - `topics/ready-city-decision-view.md`
+  - `topics/population-placement-expansion.md`
+  - `topics/progression-tree-targets.md`
+  - `topics/runtime-state-sources.md`
+  - `evidence-packs/current-online-play-context.md`
+  - `evidence-packs/agent-evidence-summary.md`
+- Watcher notes sent to the active play thread when useful.
+
+Evidence:
+
+- Watcher worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-watch-civ7-live-play-reference-assembly`.
+- Base branch:
+  `codex/integrate-authoring-guards-over-studio`.
+- Live game read-only snapshot on 2026-06-01:
+  turn `77`, date `2100 BCE`, Tuner ready, autoplay inactive, map `84 x 54`,
+  local human player `0`.
+- Active play thread proved `VIEWED_ADVISOR_WARNING` can clear advisor blockers
+  when sent through the official player-operation path, then advanced turn
+  `76 -> 77`.
+- Active play thread turn `79` produced exact next-family args:
+  `RESPOND_DIPLOMATIC_ACTION {"ID":56,"Type":-1907089594}`,
+  `SET_CULTURE_TREE_NODE {"ProgressionTreeNodeType":115}`,
+  `CHOOSE_NARRATIVE_STORY_DIRECTION
+  {"TargetType":"TOT_30001B","Target":{"owner":0,"id":45,"type":35},"Action":-1326475004}`,
+  `BUY_ATTRIBUTE_TREE_NODE {"ProgressionTreeNodeType":20}`, and
+  `CONSIDER_ASSIGN_ATTRIBUTE {}`.
+- Active play thread then proved the tradition swap family:
+  `CHANGE_TRADITION {"TraditionType":2057145683,"Action":1318334332}`,
+  `CHANGE_TRADITION {"TraditionType":-331546976,"Action":-1326475004}`,
+  followed by `CONSIDER_ASSIGN_TRADITIONS {}` to move the blocker from
+  `TRADITIONS` to `NONE`.
+- Active play thread turn `80` surfaced town projects as a distinct
+  `city-command CHANGE_GROWTH_MODE` family. Official UI code confirms the
+  town-focus args shape: `{Type, ProjectType, City: cityID.id}`.
+- The exact turn-80 Fishing Town args were
+  `CHANGE_GROWTH_MODE {"Type":-284569333,"ProjectType":-548685232,"City":131073}`
+  on city `{"owner":0,"id":131073,"type":1}`. The production panel close path
+  also uses `city-operation CONSIDER_TOWN_PROJECT {}`, but the live thread
+  showed that closeout alone did not clear `NEW_POPULATION`.
+- The live user click later cleared the town population gate, but direct-control
+  did not capture the exact operation. Official UI evidence says the
+  `NEW_POPULATION` notification enters `INTERFACEMODE_ACQUIRE_TILE`; the click
+  path then sends `ASSIGN_WORKER` for workable plots or city-command `EXPAND`
+  for expansion.
+- A follow-up production-family research lane confirmed the official UI split:
+  ordinary `BUILD` production uses `UnitType`, `ConstructibleType`, or
+  `ProjectType` depending on item kind, while town focus remains a separate
+  `CHANGE_GROWTH_MODE` command.
+- Agent lanes produced evidence packs for direct-control blocker mechanics,
+  local official resource facts, current online strategy context, and CLI
+  shortcut demand.
+- Direct-control now owns a read-only play notification view via
+  `getCiv7PlayNotificationView`; the CLI exposes it as
+  `game play notifications`.
+- The end-turn guard now records `firstReadyUnitId` and accepts the App UI
+  evidence set `hasSentTurnComplete:false`, blocker `0`, ready unit `null` even
+  when the `canEndTurn()` probe is conservative around non-blocking
+  notifications.
+- Turn 81 shifted from blocker resolution into tactical play. Official UI
+  evidence shows right-click unit targeting is not a bare operation choice:
+  `WorldInput.requestMoveOperation` tries naval, air, ranged, overrun, swap,
+  then `MOVE_TO` with attack/unexplored modifiers and uses target plot
+  coordinates. Direct-control now owns `getCiv7UnitTargetAction` /
+  `requestCiv7UnitTargetAction`; the CLI exposes it as
+  `game play unit-target`.
+- The notification materialized view has been upgraded into a decision HUD:
+  `hud.nextDecision` and `hud.decisionQueue` put the current blocker first and
+  list required live inputs, common safe actions, operation family/type, target,
+  location, and notes. This keeps the raw notification facts available while
+  giving the active play agent a smaller "what do I need before acting?"
+  surface.
+- Narrative research for `ATTRIBUTE_QUEST_1004A` showed no official
+  `NarrativeStory_Links` rows. Official narrative UI falls back to a single
+  `CLOSE` option when no links are present, so this family should be treated as
+  an acknowledgement unless validation proves otherwise. The bounded query path
+  is `Stories.getFirstPendingMetId()`, `Stories.find(target)`,
+  `GameInfo.NarrativeStories.lookup(story.type)`, then a narrow
+  `NarrativeStory_Links.filter`.
+- Turn 85 exposed the next `COMMAND_UNITS` support gap: the HUD can identify
+  the ready unit id, but commander play needs the unit's resolved type, legal
+  no-target operation/command candidates, and nearby occupied plots before
+  choosing hold, pack, unpack, promote, move, or attack. Direct-control now owns
+  `getCiv7ReadyUnitView`; the CLI exposes it as `game play ready-unit`.
+- Turn 97 exposed a default-handler notification gap:
+  `NOTIFICATION_WONDER_COMPLETED` blocked end-turn despite having no valid
+  target/location and no specialized registered handler. Direct-control now owns
+  a guarded notification dismissal read/request surface; the CLI exposes it as
+  `game play dismiss-notification` for reviewed, user-dismissible information
+  notices.
+- Turn 62 exposed a first-meet diplomacy gap: `NOTIFICATION_PLAYER_MET` looked
+  like a default-handler notice until the live panel path proved it was a
+  `RESPOND_DIPLOMATIC_FIRST_MEET` player operation with
+  `{ Player1, Player2, Type }`. The HUD now classifies it as
+  `first-meet-diplomacy`, and the CLI exposes `game play respond-first-meet`.
+- Turn 78 exposed a constructible placement gap in ordinary production:
+  `BUILD {"ConstructibleType":713967338}` for Ancient Walls validated but did
+  not clear the blocker; adding the official placement coordinates
+  `{"X":22,"Y":31}` queued production. The CLI now exposes
+  `game play build-production` so agents can send unit, constructible, or
+  project production with explicit item-kind and placement args.
+- Turn 58 exposed a progression-tree target gap: the apparent culture row index
+  `224` was not enough; the operation needed the actual
+  `ProgressionTreeNodeType` hash `-1677668973`, and
+  `SET_CULTURE_TREE_TARGET_NODE` was part of the closeout path. The CLI now
+  exposes `game play set-culture-target` and `game play set-tech-target`.
+- Local on-disk research showed that app-support debug SQLite copies are useful
+  static catalogs (`gameplay-copy.sqlite`, `frontend-copy.sqlite`,
+  localization/images/colors), while current autosaves are opaque `CIV7`
+  binary data and logs are bounded forensic evidence. The support frame is
+  hybrid: direct-control remains live decision authority; local disk becomes a
+  cache/enrichment lane.
+- A read-only `game play ready-city --json` smoke on 2026-06-01 resolved the
+  current blocker city to `{"owner":0,"id":65536,"type":1}`, returned 21
+  actionable production candidates, no town-focus options for that non-town
+  city, `isReadyToPlacePopulation:false`, and sent no operation.
+- Follow-up local DB review confirmed the source split: app-support SQLite
+  files can support catalog/history enrichment, and `HallofFame.sqlite` has
+  recorded game/player/object history tables, but none of the observed local DB
+  surfaces provide a proven live contract for the current notification queue,
+  selected entity, modal state, operation validators, or post-send state.
+  Disposition: keep direct-control as live authority and treat the notification
+  HUD as a short-lived runtime materialized view enriched by local catalogs.
+- Online source review on 2026-06-01 confirmed the current official online
+  context should be date-bound and advisory: the official update notes identify
+  Update 1.4.0 / Test of Time as the latest patch, while 2K's newsroom dates
+  the Test of Time update to 2026-05-19. Reviewer follow-up also identified
+  2K's Test of Time announcement/out-now pages and the support tracker as
+  higher-signal official URLs for the online lane. Disposition: add
+  `evidence-packs/current-online-play-context.md` and keep online advice below
+  direct-control, local official resources, and validators.
+- Turn 79 after rest-of-game autoplay restart proved the open `NEW_POPULATION`
+  expansion branch: `city-command EXPAND {"X":16,"Y":19}` on city
+  `{"owner":0,"id":196610,"type":1}`. This complements the already proven
+  `ASSIGN_WORKER { Location, Amount: 1 }` branch for workable plots.
+  Disposition: add `game play expand-city` and
+  `topics/population-placement-expansion.md`.
+- Turn 80 exposed another first-meet blocker, this time Napoleon. The
+  notification HUD now reads `notification.Player` and materializes
+  first-meet details: `player1:0`, `player2:1`, other-player labels, validated
+  friendly/neutral/unfriendly args, and a conservative neutral
+  `recommendedCli`. A validate-only smoke proved
+  `RESPOND_DIPLOMATIC_FIRST_MEET {"Player1":0,"Player2":1,"Type":673478009}`
+  succeeds without sending. Disposition: enrich `game play notifications` so
+  future agents do not need a separate manual first-meet panel scrape when the
+  notification exposes `Player`.
+- Local SQLite is readable and valuable for static catalog enrichment:
+  `gameplay-copy.sqlite` has 492 tables, `frontend-copy.sqlite` has 118 tables,
+  `Types` has 13,714 rows, and `LocalizedText` has 41,837 rows. Disposition:
+  capture the authority split in `topics/local-catalog-enrichment.md`; use
+  local DBs to enrich HUD labels and shortcuts, not to replace live runtime
+  blockers, validators, or postcondition reads.
+
+Review findings and disposition:
+
+- Finding: a generic `choose-civic` shortcut is not yet supported as a separate
+  concept from the proven turn-79 culture-tree operation.
+  Disposition: added `choose-culture`; keep `choose-civic` deferred unless a
+  future civic surface proves a distinct operation shape.
+- Finding: constructible production can require placement coordinates even when
+  the initial `ConstructibleType` validator succeeds.
+  Disposition: added `game play build-production` with optional `X`/`Y` for
+  constructible placement and documented the turn-78 Ancient Walls proof.
+  Ordinary city-project production still needs more live postcondition proof.
+- Finding: the exact town population click operation is still unknown.
+  Disposition: the original user click stayed unresolved, but a later turn-79
+  live operation proved the expansion branch as `city-command EXPAND { X, Y }`;
+  add a named shortcut while keeping tile ranking and candidate cataloging open.
+- Finding: agents need a fast way to see blocker notifications and candidate
+  operation families before choosing a shortcut.
+  Disposition: added the read-only `game play notifications` materialized view,
+  then expanded it into a decision HUD with required inputs and common safe
+  actions.
+- Finding: validator-success unit actions can still be tactical no-ops.
+  Disposition: added `game play unit-target`, which resolves target actions
+  through official right-click order and returns before/after probes so agents
+  can treat postconditions, not send plumbing, as proof.
+- Finding: stale combat coordinates are now the dominant play-quality risk
+  during the active agent's wartime turns.
+  Disposition: added an early-war stale-state tactical guard topic that combines
+  local tutorial/Civilopedia/unit-stat evidence with official combat and
+  diplomacy framing.
+- Finding: active human play can coincide with long direct-control response
+  times, including read-only calls.
+  Evidence: the active play thread observed ordinary subsecond reads/sends plus
+  7-20 second delays while the human was interacting with Civ. Current evidence
+  supports a runtime-busy/stale-state frame but does not prove foreground focus
+  as the root cause.
+  Disposition: added a watcher-latency observer-mode evidence pack with
+  human-turn watch, agent-turn play, restart recovery, and JSONL observation
+  schema guidance.
+- Finding: `COMMAND_UNITS` is too broad for the notification HUD alone,
+  especially when the ready unit is an Army Commander.
+  Disposition: added the read-only `game play ready-unit` view and a commander
+  topic that separates support-radius anchoring from direct combat.
+- Finding: not every end-turn blocking notification is a gameplay decision.
+  Disposition: added `game play dismiss-notification` for reviewed,
+  user-dismissible default-handler notices, and documented why specialized
+  decision families must not use generic dismissal.
+- Finding: wartime report notifications can block end-turn after all unit
+  readiness is resolved.
+  Evidence: turn 57 showed `NOTIFICATION_UNIT_ATTACKED` with
+  `canUserDismiss:true`, `isEndTurnBlocking:true`, blocker enum `0`, and
+  `firstReadyUnitId:null`. Official resources define unit attacked, district
+  attacked, and volcano eruption notices as expiring report notifications with
+  no specialized registered handler.
+  Disposition: classified these report families as reviewed informational
+  closeout candidates in the HUD while preserving the tactical review
+  requirement before dismissal.
+- Finding: a strict "any end-turn-blocking notification blocks end turn"
+  fallback is too blunt.
+  Evidence: turn 58 showed why expired culture choice must remain blocked until
+  the exact `ProgressionTreeNodeType` enum and target node are corrected; turn
+  59 showed the opposite stale lifecycle case, where `COMMAND_UNITS` remained
+  as an end-turn-blocking notification after blocker `0` and
+  `firstReadyUnitId:null`.
+  Disposition: refined the end-turn fallback so stale `COMMAND_UNITS` can pass
+  only when the ready-unit queue is clean, reviewed default-handler report
+  notifications can pass when user-dismissible, and real decision families
+  still block.
+
+Verification:
+
+- `bun run --cwd packages/civ7-direct-control test` -> pass, 32 tests.
+- `bun run --cwd packages/civ7-direct-control check` -> pass.
+- `bun run --cwd packages/civ7-direct-control build` -> pass; required because
+  the CLI resolves `@civ7/direct-control` through `dist`.
+- `bun run --cwd packages/cli test -- game.play.test.ts` -> pass, 20 tests.
+- `./node_modules/.bin/tsc -p packages/cli/tsconfig.json
+  --noEmitOnError false || true` -> emitted the new CLI command while reporting
+  the pre-existing `@civ7/plugin-mods` declaration errors.
+- `git diff --check` -> pass.
+- `bun run --cwd packages/cli check` -> not passed because existing
+  `@civ7/plugin-mods` declaration/build availability errors block package-wide
+  typecheck in this worktree; the errors are outside the new `game play` files.
+
+## Outcome
+
+Objective outcome: `partially achieved`.
+
+Residual objective gaps:
+
+- The first CLI shortcut family is implemented and verified by focused tests.
+- The second player-operation shortcut family from turn 79 has been added,
+  including tradition and attribute review closeout commands.
+- The first town-focus shortcut from turn 80 has been added as a city-command
+  wrapper rather than a production shortcut, with a separate town-project
+  review closeout shortcut.
+- A read-only notification HUD/materialized view has been added for play agents.
+- A unit-target resolver has been added for tactical plot targeting and
+  validator-success/no-op diagnosis.
+- The end-turn shortcut now checks the notification HUD before using its
+  conservative fallback when `canEndTurn` is false. It permits stale
+  `COMMAND_UNITS` closeout when no ready unit remains and permits reviewed
+  informational report closeout when user-dismissible, but continues to reject
+  real unresolved decision families.
+- Initial normative project artifacts are assembled.
+- A notification-decision HUD topic now captures the blocker-family frame and
+  narrative `CLOSE` lesson for later skill/resource promotion.
+- A ready-unit/commander topic now captures the turn-85 commander decision
+  frame, official local resource anchors, and online commander/Harriet context.
+- An informational-notification topic now captures the wonder-completed
+  and unit-attacked closeout frames, and a local-on-disk evidence pack captures
+  why local SQLite supplements but does not replace runtime polling.
+- An early-war stale-state tactical guard topic now captures ranged-first,
+  wounded-melee preservation, naval postcondition, and influence-conservation
+  norms for play agents.
+- A watcher-latency observer-mode evidence pack now captures low-impact polling,
+  slow-read thresholds, restart recovery, and future timing instrumentation
+  candidates without overclaiming focus causality.
+- A first-meet diplomacy topic now captures `NOTIFICATION_PLAYER_MET` as a real
+  greeting operation, including the conservative neutral-greeting norm and the
+  new `game play respond-first-meet` shortcut. The notification HUD now carries
+  live first-meet details and a neutral recommended command when
+  `notification.Player` exposes the met-player id.
+- A local catalog enrichment topic now captures why readable on-disk SQLite is
+  static support evidence rather than current live-turn authority, plus the
+  candidate local-data and local-catalog shortcuts that can reduce UI polling
+  without bypassing validators.
+- A production placement topic now captures the ordinary production `BUILD`
+  item-kind split, the official placement-mode `X`/`Y` commit path, and the
+  turn-78 Ancient Walls proof.
+- A progression tree target topic now captures the current-node vs target-node
+  operation split and the row-index-vs-node-hash failure mode.
+- A runtime-state-sources topic now captures why local SQLite should enrich
+  play support while direct-control remains the live blocker and validator
+  authority, including the materialized-HUD source split.
+- A skill-asset assembly now groups the support topics and CLI shortcuts into
+  candidate skill families, proof classes, promotion gates, and open shortcut
+  candidates.
+- A ready-city topic and read-only shortcut now materialize city blockers into
+  live city state, production candidate args, constructible placement plots,
+  town focus options, and population placement evidence without sending.
+- A population-placement topic and `game play expand-city` shortcut now capture
+  the proven `NEW_POPULATION` expansion branch alongside `assign-worker`.
+- A current-online-context evidence pack now captures Test of Time / Update
+  1.4.0 as advisory patch context and warns future agents not to promote older
+  launch-era guides above live tooltips, local official rows, or validators.
+- Remaining gaps are promotion/hardening work: richer ready-entity reads,
+  stronger live postcondition polling, civic choice proof, acquire-tile
+  candidate cataloging, and eventual promotion into canonical docs/skills.
+
+Deferred items:
+
+- Prove whether any future civic surface differs from `game play
+  choose-culture`.
+- Prove ordinary non-town city-project production postconditions.
+- Improve acquire-tile candidate cataloging so future reads show whether each
+  plot should use `assign-worker` or `expand-city`.
+- Promote stable topic docs into canonical docs and skill assets after review.
+
+Next Packet:
+
+- Inspect the active play thread first for the newest blocker/action type.
+- Then inspect agent outputs for evidence packs.
+- Then verify CLI shortcuts against tests before promoting any shortcut as
+  normative skill guidance.


### PR DESCRIPTION
Adds skill asset assembly documentation and two new reference topics for the Civ7 live play support project.

`SKILL-ASSET-ASSEMBLY.md` organizes the project's accumulated play support artifacts into candidate skill families — turn blocker resolution, progression and choice resolution, city production and population, tactical unit control, diplomacy and first-meet, runtime source authority, and current online context. It defines proof classes (live-proved, official-UI-backed, static-enrichment, advisory, open), establishes promotion gates that require explicit validator and postcondition rules before any topic becomes normative skill guidance, maps each existing topic and evidence pack to a promotion state, and identifies open shortcut candidates and do-not-promote boundaries.

`topics/runtime-state-sources.md` documents why direct-control polling remains the live authority for blockers, selected entities, validators, and postconditions, while local SQLite files serve as static catalog enrichment. It lists the observable on-disk surfaces under the Civilization VII app support directory, explains what each provides and what it cannot provide, and defines a materialized view policy that separates live decision fields from cacheable catalog fields and forensic reads.

`topics/local-catalog-enrichment.md` captures the authority split between the debug SQLite copies and the runtime HUD in more detail. It records observed table and row counts, defines the norm for enriching live HUD output with local catalog labels without collapsing static existence into live legality, and lists candidate CLI shortcuts — `game local-data inspect` and `game local-catalog lookup` — along with the open questions that must be answered before local SQLite can be treated as more than enrichment.

`workstream-record.md` preserves the full workstream history, branch state, evidence log, review findings, verification results, and deferred items for handoff purposes.