### PR TITLE
refactor(cli): extract shared `startFakeTunerServer` test fixture

### DIFF
--- a/packages/cli/test/commands/fixtures/tuner-socket-server.ts
+++ b/packages/cli/test/commands/fixtures/tuner-socket-server.ts
@@ -1,0 +1,67 @@
+import { once } from 'node:events';
+import { type AddressInfo, createServer, type Socket } from 'node:net';
+import { encodeCiv7TunerRequest, parseCiv7TunerFrame } from '@civ7/direct-control';
+
+export type FakeTunerRequest = {
+  listenerId: number;
+  message: string;
+  parts: readonly string[];
+};
+
+export type FakeTunerResponse = readonly string[];
+
+export type FakeTunerServer = {
+  received: string[];
+  address(): AddressInfo;
+  close(): Promise<void>;
+};
+
+export async function startFakeTunerServer(options: {
+  states?: FakeTunerResponse;
+  fallback?: FakeTunerResponse | ((request: FakeTunerRequest) => FakeTunerResponse);
+  handle(request: FakeTunerRequest): FakeTunerResponse | undefined;
+}): Promise<FakeTunerServer> {
+  const states = options.states ?? ['65535', 'App UI', '1', 'Tuner'];
+  const fallback = options.fallback ?? [JSON.stringify(null)];
+  const received: string[] = [];
+  const sockets = new Set<Socket>();
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    let buffer = Buffer.alloc(0);
+    socket.on('data', (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      for (;;) {
+        const parsed = parseCiv7TunerFrame(buffer);
+        if (!parsed) return;
+        buffer = buffer.subarray(parsed.bytesRead);
+        const request = {
+          listenerId: parsed.frame.listenerId,
+          message: parsed.frame.parts.join('\0'),
+          parts: parsed.frame.parts,
+        };
+        received.push(request.message);
+        const response = request.message === 'LSQ:'
+          ? states
+          : options.handle(request) ?? (typeof fallback === 'function' ? fallback(request) : fallback);
+        socket.write(encodeCiv7TunerRequest(request.listenerId, response.join('\0')));
+      }
+    });
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address.bind(server);
+  const close = server.close.bind(server);
+  return {
+    received,
+    address(): AddressInfo {
+      return address() as AddressInfo;
+    },
+    async close() {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve, reject) => {
+        close((error) => error ? reject(error) : resolve());
+      });
+    },
+  };
+}

--- a/packages/cli/test/commands/game.play.celebration-government.test.ts
+++ b/packages/cli/test/commands/game.play.celebration-government.test.ts
@@ -1,8 +1,7 @@
-import { once } from 'node:events';
-import { type AddressInfo, createServer, type Socket } from 'node:net';
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayChooseCelebration from '../../src/commands/game/play/choose-celebration';
 import GamePlayChooseGovernment from '../../src/commands/game/play/choose-government';
+import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play celebration and government commands', () => {
   test('wraps celebration choice as CHOOSE_GOLDEN_AGE', async () => {
@@ -159,11 +158,7 @@ describe('game play celebration and government commands', () => {
   });
 });
 
-type CelebrationGovernmentTunerServer = {
-  received: string[];
-  address(): AddressInfo;
-  close(): Promise<void>;
-};
+type CelebrationGovernmentTunerServer = FakeTunerServer;
 
 type CommandClass = {
   run(args: string[]): Promise<unknown>;
@@ -182,47 +177,17 @@ async function runCommand(command: CommandClass, args: string[]) {
 async function startCelebrationGovernmentTunerServer(options: {
   playNotificationMode?: 'celebration-choice' | 'government-choice';
 } = {}): Promise<CelebrationGovernmentTunerServer> {
-  const received: string[] = [];
-  const sockets = new Set<Socket>();
-  const server = createServer((socket) => {
-    sockets.add(socket);
-    socket.on('close', () => sockets.delete(socket));
-    let buffer = Buffer.alloc(0);
-    socket.on('data', (chunk) => {
-      buffer = Buffer.concat([buffer, chunk]);
-      for (;;) {
-        const frame = parseRequest(buffer);
-        if (!frame) return;
-        buffer = buffer.subarray(frame.bytesRead);
-        received.push(frame.message);
-        if (frame.message === 'LSQ:') {
-          socket.write(encodeResponse(frame.listenerId, ['65535', 'App UI', '1', 'Tuner']));
-        } else if (frame.message.includes('return JSON.stringify(validateOperation')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(operationValidation(frame.message))]));
-        } else if (frame.message.includes('readPlayNotifications')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(playNotificationView(options.playNotificationMode ?? 'celebration-choice'))]));
-        } else {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(null)]));
-        }
+  return startFakeTunerServer({
+    handle({ message }) {
+      if (message.includes('return JSON.stringify(validateOperation')) {
+        return [JSON.stringify(operationValidation(message))];
       }
-    });
+      if (message.includes('readPlayNotifications')) {
+        return [JSON.stringify(playNotificationView(options.playNotificationMode ?? 'celebration-choice'))];
+      }
+      return undefined;
+    },
   });
-  server.listen(0, '127.0.0.1');
-  await once(server, 'listening');
-  const address = server.address.bind(server);
-  const close = server.close.bind(server);
-  return {
-    received,
-    address(): AddressInfo {
-      return address() as AddressInfo;
-    },
-    async close() {
-      for (const socket of sockets) socket.destroy();
-      await new Promise<void>((resolve, reject) => {
-        close((error) => error ? reject(error) : resolve());
-      });
-    },
-  };
 }
 
 function operationValidation(message: string) {
@@ -405,25 +370,4 @@ function playNotificationViewForDetails(input: {
     },
     limits: { maxNotifications: 25, truncated: false },
   };
-}
-
-function parseRequest(buffer: Buffer): { listenerId: number; message: string; bytesRead: number } | null {
-  if (buffer.length < 8) return null;
-  const messageLength = buffer.readUInt32LE(0);
-  const bytesRead = 8 + messageLength;
-  if (buffer.length < bytesRead) return null;
-  return {
-    listenerId: buffer.readUInt32LE(4),
-    message: buffer.subarray(8, bytesRead).toString('utf8').replace(/\0$/, ''),
-    bytesRead,
-  };
-}
-
-function encodeResponse(listenerId: number, values: string[]) {
-  const messageBytes = Buffer.from(`${values.join('\0')}\0`, 'utf8');
-  const frame = Buffer.alloc(8 + messageBytes.length);
-  frame.writeUInt32LE(messageBytes.length, 0);
-  frame.writeUInt32LE(listenerId, 4);
-  messageBytes.copy(frame, 8);
-  return frame;
 }

--- a/packages/cli/test/commands/game.play.culture.test.ts
+++ b/packages/cli/test/commands/game.play.culture.test.ts
@@ -1,8 +1,7 @@
-import { once } from 'node:events';
-import { type AddressInfo, createServer, type Socket } from 'node:net';
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayChooseCulture from '../../src/commands/game/play/choose-culture';
 import GamePlaySetCultureTarget from '../../src/commands/game/play/set-culture-target';
+import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play culture commands', () => {
   test('wraps culture choice as SET_CULTURE_TREE_NODE', async () => {
@@ -261,11 +260,7 @@ describe('game play culture commands', () => {
   });
 });
 
-type CultureTunerServer = {
-  received: string[];
-  address(): AddressInfo;
-  close(): Promise<void>;
-};
+type CultureTunerServer = FakeTunerServer;
 
 type CommandClass = {
   run(args: string[]): Promise<unknown>;
@@ -285,62 +280,34 @@ async function startCultureTunerServer(options: {
   playNotificationMode?: 'culture-choice';
   cultureChoiceMode?: 'cleared' | 'sticky' | 'state-changed';
 } = {}): Promise<CultureTunerServer> {
-  const received: string[] = [];
-  const sockets = new Set<Socket>();
   let cultureChoiceSent = false;
-  const server = createServer((socket) => {
-    sockets.add(socket);
-    socket.on('close', () => sockets.delete(socket));
-    let buffer = Buffer.alloc(0);
-    socket.on('data', (chunk) => {
-      buffer = Buffer.concat([buffer, chunk]);
-      for (;;) {
-        const frame = parseRequest(buffer);
-        if (!frame) return;
-        buffer = buffer.subarray(frame.bytesRead);
-        received.push(frame.message);
-        if (frame.message === 'LSQ:') {
-          socket.write(encodeResponse(frame.listenerId, ['65535', 'App UI', '1', 'Tuner']));
-        } else if (frame.message.includes('readPlayNotifications')) {
-          const playMode = options.playNotificationMode === 'culture-choice'
-            && cultureChoiceSent
-            && (options.cultureChoiceMode ?? 'cleared') === 'cleared'
-            ? 'ready-unit'
-            : options.playNotificationMode ?? 'ready-unit';
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(playNotificationView(
-            playMode,
-            cultureChoiceSent && options.cultureChoiceMode === 'state-changed',
-          ))]));
-        } else if (frame.message.includes('sendCultureChoiceCloseout')) {
-          cultureChoiceSent = true;
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(cultureChoiceCloseout())]));
-        } else if (frame.message.includes('return JSON.stringify(validateOperation')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(operationValidation(frame.message))]));
-        } else if (frame.message.includes('return JSON.stringify(sendOperation')) {
-          cultureChoiceSent = true;
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify({ sent: true })]));
-        } else {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(null)]));
-        }
+  return startFakeTunerServer({
+    handle({ message }) {
+      if (message.includes('readPlayNotifications')) {
+        const playMode = options.playNotificationMode === 'culture-choice'
+          && cultureChoiceSent
+          && (options.cultureChoiceMode ?? 'cleared') === 'cleared'
+          ? 'ready-unit'
+          : options.playNotificationMode ?? 'ready-unit';
+        return [JSON.stringify(playNotificationView(
+          playMode,
+          cultureChoiceSent && options.cultureChoiceMode === 'state-changed',
+        ))];
       }
-    });
+      if (message.includes('sendCultureChoiceCloseout')) {
+        cultureChoiceSent = true;
+        return [JSON.stringify(cultureChoiceCloseout())];
+      }
+      if (message.includes('return JSON.stringify(validateOperation')) {
+        return [JSON.stringify(operationValidation(message))];
+      }
+      if (message.includes('return JSON.stringify(sendOperation')) {
+        cultureChoiceSent = true;
+        return [JSON.stringify({ sent: true })];
+      }
+      return undefined;
+    },
   });
-  server.listen(0, '127.0.0.1');
-  await once(server, 'listening');
-  const address = server.address.bind(server);
-  const close = server.close.bind(server);
-  return {
-    received,
-    address(): AddressInfo {
-      return address() as AddressInfo;
-    },
-    async close() {
-      for (const socket of sockets) socket.destroy();
-      await new Promise<void>((resolve, reject) => {
-        close((error) => error ? reject(error) : resolve());
-      });
-    },
-  };
 }
 
 function operationValidation(message: string) {
@@ -548,25 +515,4 @@ function playNotificationView(mode: 'culture-choice' | 'ready-unit', cultureStat
     },
     limits: { maxNotifications: 25, truncated: false },
   };
-}
-
-function parseRequest(buffer: Buffer): { listenerId: number; message: string; bytesRead: number } | null {
-  if (buffer.length < 8) return null;
-  const messageLength = buffer.readUInt32LE(0);
-  const bytesRead = 8 + messageLength;
-  if (buffer.length < bytesRead) return null;
-  return {
-    listenerId: buffer.readUInt32LE(4),
-    message: buffer.subarray(8, bytesRead).toString('utf8').replace(/\0$/, ''),
-    bytesRead,
-  };
-}
-
-function encodeResponse(listenerId: number, values: string[]) {
-  const messageBytes = Buffer.from(`${values.join('\0')}\0`, 'utf8');
-  const frame = Buffer.alloc(8 + messageBytes.length);
-  frame.writeUInt32LE(messageBytes.length, 0);
-  frame.writeUInt32LE(listenerId, 4);
-  messageBytes.copy(frame, 8);
-  return frame;
 }

--- a/packages/cli/test/commands/game.play.diplomacy-response.test.ts
+++ b/packages/cli/test/commands/game.play.diplomacy-response.test.ts
@@ -1,7 +1,6 @@
-import { once } from 'node:events';
-import { type AddressInfo, createServer, type Socket } from 'node:net';
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayRespondDiplomacy from '../../src/commands/game/play/respond-diplomacy';
+import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play diplomacy response commands', () => {
   test('wraps diplomacy response as RESPOND_DIPLOMATIC_ACTION', async () => {
@@ -110,11 +109,7 @@ describe('game play diplomacy response commands', () => {
   });
 });
 
-type DiplomacyResponseTunerServer = {
-  received: string[];
-  address(): AddressInfo;
-  close(): Promise<void>;
-};
+type DiplomacyResponseTunerServer = FakeTunerServer;
 
 type CommandClass = {
   run(args: string[]): Promise<unknown>;
@@ -133,54 +128,25 @@ async function runCommand(command: CommandClass, args: string[]) {
 async function startDiplomacyResponseTunerServer(options: {
   playNotificationMode?: 'stale-diplomacy';
 } = {}): Promise<DiplomacyResponseTunerServer> {
-  const received: string[] = [];
-  const sockets = new Set<Socket>();
   let diplomacyCloseoutObserved = false;
-  const server = createServer((socket) => {
-    sockets.add(socket);
-    socket.on('close', () => sockets.delete(socket));
-    let buffer = Buffer.alloc(0);
-    socket.on('data', (chunk) => {
-      buffer = Buffer.concat([buffer, chunk]);
-      for (;;) {
-        const frame = parseRequest(buffer);
-        if (!frame) return;
-        buffer = buffer.subarray(frame.bytesRead);
-        received.push(frame.message);
-        if (frame.message === 'LSQ:') {
-          socket.write(encodeResponse(frame.listenerId, ['65535', 'App UI', '1', 'Tuner']));
-        } else if (frame.message.includes('readPlayNotifications')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(playNotificationView(
-            options.playNotificationMode ?? 'stale-diplomacy',
-            diplomacyCloseoutObserved,
-          ))]));
-        } else if (frame.message.includes('sendDiplomacyResponseCloseout')) {
-          diplomacyCloseoutObserved = true;
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(diplomacyResponseCloseout())]));
-        } else if (frame.message.includes('return JSON.stringify(validateOperation')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(operationValidation(frame.message))]));
-        } else {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(null)]));
-        }
+  return startFakeTunerServer({
+    handle({ message }) {
+      if (message.includes('readPlayNotifications')) {
+        return [JSON.stringify(playNotificationView(
+          options.playNotificationMode ?? 'stale-diplomacy',
+          diplomacyCloseoutObserved,
+        ))];
       }
-    });
+      if (message.includes('sendDiplomacyResponseCloseout')) {
+        diplomacyCloseoutObserved = true;
+        return [JSON.stringify(diplomacyResponseCloseout())];
+      }
+      if (message.includes('return JSON.stringify(validateOperation')) {
+        return [JSON.stringify(operationValidation(message))];
+      }
+      return undefined;
+    },
   });
-  server.listen(0, '127.0.0.1');
-  await once(server, 'listening');
-  const address = server.address.bind(server);
-  const close = server.close.bind(server);
-  return {
-    received,
-    address(): AddressInfo {
-      return address() as AddressInfo;
-    },
-    async close() {
-      for (const socket of sockets) socket.destroy();
-      await new Promise<void>((resolve, reject) => {
-        close((error) => error ? reject(error) : resolve());
-      });
-    },
-  };
 }
 
 function operationValidation(message: string) {
@@ -336,25 +302,4 @@ function playNotificationView(mode: 'stale-diplomacy', diplomacyCloseoutObserved
     },
     limits: { maxNotifications: 25, truncated: false },
   };
-}
-
-function parseRequest(buffer: Buffer): { listenerId: number; message: string; bytesRead: number } | null {
-  if (buffer.length < 8) return null;
-  const messageLength = buffer.readUInt32LE(0);
-  const bytesRead = 8 + messageLength;
-  if (buffer.length < bytesRead) return null;
-  return {
-    listenerId: buffer.readUInt32LE(4),
-    message: buffer.subarray(8, bytesRead).toString('utf8').replace(/\0$/, ''),
-    bytesRead,
-  };
-}
-
-function encodeResponse(listenerId: number, values: string[]) {
-  const messageBytes = Buffer.from(`${values.join('\0')}\0`, 'utf8');
-  const frame = Buffer.alloc(8 + messageBytes.length);
-  frame.writeUInt32LE(messageBytes.length, 0);
-  frame.writeUInt32LE(listenerId, 4);
-  messageBytes.copy(frame, 8);
-  return frame;
 }

--- a/packages/cli/test/commands/game.play.first-meet.test.ts
+++ b/packages/cli/test/commands/game.play.first-meet.test.ts
@@ -1,7 +1,6 @@
-import { once } from 'node:events';
-import { type AddressInfo, createServer, type Socket } from 'node:net';
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayRespondFirstMeet from '../../src/commands/game/play/respond-first-meet';
+import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play first-meet diplomacy command', () => {
   test('wraps first-meet diplomacy as RESPOND_DIPLOMATIC_FIRST_MEET', async () => {
@@ -126,11 +125,7 @@ describe('game play first-meet diplomacy command', () => {
   });
 });
 
-type FirstMeetTunerServer = {
-  received: string[];
-  address(): AddressInfo;
-  close(): Promise<void>;
-};
+type FirstMeetTunerServer = FakeTunerServer;
 
 type CommandClass = {
   run(args: string[]): Promise<unknown>;
@@ -147,68 +142,40 @@ async function runCommand(command: CommandClass, args: string[]) {
 }
 
 async function startFirstMeetTunerServer(options: { firstMeetMode?: 'cleared' | 'sticky' } = {}): Promise<FirstMeetTunerServer> {
-  const received: string[] = [];
-  const sockets = new Set<Socket>();
   let firstMeetSent = false;
-  const server = createServer((socket) => {
-    sockets.add(socket);
-    socket.on('close', () => sockets.delete(socket));
-    let buffer = Buffer.alloc(0);
-    socket.on('data', (chunk) => {
-      buffer = Buffer.concat([buffer, chunk]);
-      for (;;) {
-        const frame = parseRequest(buffer);
-        if (!frame) return;
-        buffer = buffer.subarray(frame.bytesRead);
-        received.push(frame.message);
-        if (frame.message === 'LSQ:') {
-          socket.write(encodeResponse(frame.listenerId, ['65535', 'App UI', '1', 'Tuner']));
-        } else if (frame.message.includes('readPlayNotifications')) {
-          const mode = firstMeetSent && (options.firstMeetMode ?? 'cleared') === 'cleared' ? 'ready-unit' : 'first-meet';
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(firstMeetNotificationView(mode))]));
-        } else if (frame.message.includes('DiplomacyPlayerFirstMeets')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify({
-            key: 'PLAYER_REALATIONSHIP_FIRSTMEET_NEUTRAL',
-            value: 673478009,
-          })]));
-        } else if (frame.message.includes('return JSON.stringify(validateOperation')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify({
-            host: '127.0.0.1',
-            port: 0,
-            state: { id: '1', name: 'Tuner', role: 'tuner' },
-            family: 'player-operation',
-            operationType: 'RESPOND_DIPLOMATIC_FIRST_MEET',
-            enumValue: 'RESPOND_DIPLOMATIC_FIRST_MEET',
-            target: { playerId: 0 },
-            args: { Player1: 0, Player2: 2, Type: 673478009 },
-            valid: true,
-            result: { Success: true },
-          })]));
-        } else if (frame.message.includes('return JSON.stringify(sendOperation')) {
-          firstMeetSent = true;
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify({ sent: true })]));
-        } else {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(null)]));
-        }
+  return startFakeTunerServer({
+    handle({ message }) {
+      if (message.includes('readPlayNotifications')) {
+        const mode = firstMeetSent && (options.firstMeetMode ?? 'cleared') === 'cleared' ? 'ready-unit' : 'first-meet';
+        return [JSON.stringify(firstMeetNotificationView(mode))];
       }
-    });
+      if (message.includes('DiplomacyPlayerFirstMeets')) {
+        return [JSON.stringify({
+          key: 'PLAYER_REALATIONSHIP_FIRSTMEET_NEUTRAL',
+          value: 673478009,
+        })];
+      }
+      if (message.includes('return JSON.stringify(validateOperation')) {
+        return [JSON.stringify({
+          host: '127.0.0.1',
+          port: 0,
+          state: { id: '1', name: 'Tuner', role: 'tuner' },
+          family: 'player-operation',
+          operationType: 'RESPOND_DIPLOMATIC_FIRST_MEET',
+          enumValue: 'RESPOND_DIPLOMATIC_FIRST_MEET',
+          target: { playerId: 0 },
+          args: { Player1: 0, Player2: 2, Type: 673478009 },
+          valid: true,
+          result: { Success: true },
+        })];
+      }
+      if (message.includes('return JSON.stringify(sendOperation')) {
+        firstMeetSent = true;
+        return [JSON.stringify({ sent: true })];
+      }
+      return undefined;
+    },
   });
-  server.listen(0, '127.0.0.1');
-  await once(server, 'listening');
-  const address = server.address.bind(server);
-  const close = server.close.bind(server);
-  return {
-    received,
-    address(): AddressInfo {
-      return address() as AddressInfo;
-    },
-    async close() {
-      for (const socket of sockets) socket.destroy();
-      await new Promise<void>((resolve, reject) => {
-        close((error) => error ? reject(error) : resolve());
-      });
-    },
-  };
 }
 
 function firstMeetNotificationView(mode: 'first-meet' | 'ready-unit') {
@@ -328,32 +295,4 @@ function firstMeetNotificationView(mode: 'first-meet' | 'ready-unit') {
     },
     limits: { maxNotifications: 25, truncated: false },
   };
-}
-
-function parseRequest(buffer: Buffer):
-  | {
-      listenerId: number;
-      message: string;
-      bytesRead: number;
-    }
-  | null {
-  if (buffer.length < 8) return null;
-  const messageLength = buffer.readUInt32LE(0);
-  const listenerId = buffer.readUInt32LE(4);
-  const end = 8 + messageLength;
-  if (buffer.length < end) return null;
-  return {
-    listenerId,
-    message: buffer.subarray(8, end).toString('utf8').replace(/\0$/, ''),
-    bytesRead: end,
-  };
-}
-
-function encodeResponse(listenerId: number, lines: string[]): Buffer {
-  const payload = Buffer.from(`${lines.join('\0')}\0`, 'utf8');
-  const out = Buffer.alloc(8 + payload.length);
-  out.writeUInt32LE(payload.length, 0);
-  out.writeUInt32LE(listenerId, 4);
-  payload.copy(out, 8);
-  return out;
 }

--- a/packages/cli/test/commands/game.play.narrative.test.ts
+++ b/packages/cli/test/commands/game.play.narrative.test.ts
@@ -1,7 +1,6 @@
-import { once } from 'node:events';
-import { type AddressInfo, createServer, type Socket } from 'node:net';
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayChooseNarrative from '../../src/commands/game/play/choose-narrative';
+import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play narrative commands', () => {
   test('wraps narrative story direction choice', async () => {
@@ -337,11 +336,7 @@ describe('game play narrative commands', () => {
   });
 });
 
-type NarrativeTunerServer = {
-  received: string[];
-  address(): AddressInfo;
-  close(): Promise<void>;
-};
+type NarrativeTunerServer = FakeTunerServer;
 
 type CommandClass = {
   run(args: string[]): Promise<unknown>;
@@ -364,56 +359,27 @@ async function startNarrativeTunerServer(options: {
   playNotificationMode?: PlayNotificationMode;
   narrativeChoiceMode?: NarrativeChoiceMode;
 } = {}): Promise<NarrativeTunerServer> {
-  const received: string[] = [];
-  const sockets = new Set<Socket>();
   let narrativeChoiceSent = false;
-  const server = createServer((socket) => {
-    sockets.add(socket);
-    socket.on('close', () => sockets.delete(socket));
-    let buffer = Buffer.alloc(0);
-    socket.on('data', (chunk) => {
-      buffer = Buffer.concat([buffer, chunk]);
-      for (;;) {
-        const frame = parseRequest(buffer);
-        if (!frame) return;
-        buffer = buffer.subarray(frame.bytesRead);
-        received.push(frame.message);
-        if (frame.message === 'LSQ:') {
-          socket.write(encodeResponse(frame.listenerId, ['65535', 'App UI', '1', 'Tuner']));
-        } else if (frame.message.includes('readPlayNotifications')) {
-          const playMode = options.playNotificationMode === 'narrative-choice-visible-panel'
-            && narrativeChoiceSent
-            && (options.narrativeChoiceMode ?? 'panel-cleared') === 'panel-cleared'
-            ? 'ready-unit'
-            : options.playNotificationMode ?? 'narrative-choice';
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(playNotificationView(playMode))]));
-        } else if (frame.message.includes('sendNarrativeChoice')) {
-          narrativeChoiceSent = true;
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(narrativeChoicePayload(options.narrativeChoiceMode ?? 'panel-cleared'))]));
-        } else if (frame.message.includes('return JSON.stringify(validateOperation')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(operationValidation())]));
-        } else {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(null)]));
-        }
+  return startFakeTunerServer({
+    handle({ message }) {
+      if (message.includes('readPlayNotifications')) {
+        const playMode = options.playNotificationMode === 'narrative-choice-visible-panel'
+          && narrativeChoiceSent
+          && (options.narrativeChoiceMode ?? 'panel-cleared') === 'panel-cleared'
+          ? 'ready-unit'
+          : options.playNotificationMode ?? 'narrative-choice';
+        return [JSON.stringify(playNotificationView(playMode))];
       }
-    });
+      if (message.includes('sendNarrativeChoice')) {
+        narrativeChoiceSent = true;
+        return [JSON.stringify(narrativeChoicePayload(options.narrativeChoiceMode ?? 'panel-cleared'))];
+      }
+      if (message.includes('return JSON.stringify(validateOperation')) {
+        return [JSON.stringify(operationValidation())];
+      }
+      return undefined;
+    },
   });
-  server.listen(0, '127.0.0.1');
-  await once(server, 'listening');
-  const address = server.address.bind(server);
-  const close = server.close.bind(server);
-  return {
-    received,
-    address(): AddressInfo {
-      return address() as AddressInfo;
-    },
-    async close() {
-      for (const socket of sockets) socket.destroy();
-      await new Promise<void>((resolve, reject) => {
-        close((error) => error ? reject(error) : resolve());
-      });
-    },
-  };
 }
 
 function playNotificationView(mode: PlayNotificationMode = 'narrative-choice') {
@@ -725,25 +691,4 @@ function operationValidation() {
     valid: true,
     result: { Success: true },
   };
-}
-
-function parseRequest(buffer: Buffer): { listenerId: number; message: string; bytesRead: number } | null {
-  if (buffer.length < 8) return null;
-  const messageLength = buffer.readUInt32LE(0);
-  const bytesRead = 8 + messageLength;
-  if (buffer.length < bytesRead) return null;
-  return {
-    listenerId: buffer.readUInt32LE(4),
-    message: buffer.subarray(8, bytesRead).toString('utf8').replace(/\0$/, ''),
-    bytesRead,
-  };
-}
-
-function encodeResponse(listenerId: number, values: string[]) {
-  const messageBytes = Buffer.from(`${values.join('\0')}\0`, 'utf8');
-  const frame = Buffer.alloc(8 + messageBytes.length);
-  frame.writeUInt32LE(messageBytes.length, 0);
-  frame.writeUInt32LE(listenerId, 4);
-  messageBytes.copy(frame, 8);
-  return frame;
 }

--- a/packages/cli/test/commands/game.play.operation-wrappers.test.ts
+++ b/packages/cli/test/commands/game.play.operation-wrappers.test.ts
@@ -1,10 +1,9 @@
-import { once } from 'node:events';
-import { type AddressInfo, createServer, type Socket } from 'node:net';
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayAdvisorWarning from '../../src/commands/game/play/advisor-warning';
 import GamePlayOperation from '../../src/commands/game/play/operation';
 import GamePlayResettleUnit from '../../src/commands/game/play/resettle-unit';
 import GamePlayUpgradeUnit from '../../src/commands/game/play/upgrade-unit';
+import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play operation wrapper commands', () => {
   test('validates friendlier operation family aliases without sending', async () => {
@@ -140,11 +139,7 @@ describe('game play operation wrapper commands', () => {
   });
 });
 
-type OperationTunerServer = {
-  received: string[];
-  address(): AddressInfo;
-  close(): Promise<void>;
-};
+type OperationTunerServer = FakeTunerServer;
 
 type CommandClass = {
   run(args: string[]): Promise<unknown>;
@@ -161,47 +156,17 @@ async function runCommand(command: CommandClass, args: string[]) {
 }
 
 async function startOperationTunerServer(): Promise<OperationTunerServer> {
-  const received: string[] = [];
-  const sockets = new Set<Socket>();
-  const server = createServer((socket) => {
-    sockets.add(socket);
-    socket.on('close', () => sockets.delete(socket));
-    let buffer = Buffer.alloc(0);
-    socket.on('data', (chunk) => {
-      buffer = Buffer.concat([buffer, chunk]);
-      for (;;) {
-        const frame = parseRequest(buffer);
-        if (!frame) return;
-        buffer = buffer.subarray(frame.bytesRead);
-        received.push(frame.message);
-        if (frame.message === 'LSQ:') {
-          socket.write(encodeResponse(frame.listenerId, ['65535', 'App UI', '1', 'Tuner']));
-        } else if (frame.message.includes('return JSON.stringify(validateOperation')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(operationValidation(frame.message))]));
-        } else if (frame.message.includes('return JSON.stringify(sendOperation')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(operationSend(frame.message))]));
-        } else {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(null)]));
-        }
+  return startFakeTunerServer({
+    handle({ message }) {
+      if (message.includes('return JSON.stringify(validateOperation')) {
+        return [JSON.stringify(operationValidation(message))];
       }
-    });
+      if (message.includes('return JSON.stringify(sendOperation')) {
+        return [JSON.stringify(operationSend(message))];
+      }
+      return undefined;
+    },
   });
-  server.listen(0, '127.0.0.1');
-  await once(server, 'listening');
-  const address = server.address.bind(server);
-  const close = server.close.bind(server);
-  return {
-    received,
-    address(): AddressInfo {
-      return address() as AddressInfo;
-    },
-    async close() {
-      for (const socket of sockets) socket.destroy();
-      await new Promise<void>((resolve, reject) => {
-        close((error) => error ? reject(error) : resolve());
-      });
-    },
-  };
 }
 
 function operationSend(message: string) {
@@ -279,25 +244,4 @@ function unitOperationPostconditionSnapshot(firstReadyUnitId: { owner: number; i
     firstReadyUnitId: { ok: true, value: firstReadyUnitId },
     blocker: { ok: true, value: 0 },
   };
-}
-
-function parseRequest(buffer: Buffer): { listenerId: number; message: string; bytesRead: number } | null {
-  if (buffer.length < 8) return null;
-  const messageLength = buffer.readUInt32LE(0);
-  const bytesRead = 8 + messageLength;
-  if (buffer.length < bytesRead) return null;
-  return {
-    listenerId: buffer.readUInt32LE(4),
-    message: buffer.subarray(8, bytesRead).toString('utf8').replace(/\0$/, ''),
-    bytesRead,
-  };
-}
-
-function encodeResponse(listenerId: number, values: string[]) {
-  const messageBytes = Buffer.from(`${values.join('\0')}\0`, 'utf8');
-  const frame = Buffer.alloc(8 + messageBytes.length);
-  frame.writeUInt32LE(messageBytes.length, 0);
-  frame.writeUInt32LE(listenerId, 4);
-  messageBytes.copy(frame, 8);
-  return frame;
 }

--- a/packages/cli/test/commands/game.play.production.test.ts
+++ b/packages/cli/test/commands/game.play.production.test.ts
@@ -1,8 +1,7 @@
-import { once } from 'node:events';
-import { type AddressInfo, createServer, type Socket } from 'node:net';
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayBuildProduction from '../../src/commands/game/play/build-production';
 import GamePlayBuildUnit from '../../src/commands/game/play/build-unit';
+import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play production commands', () => {
   test('wraps city unit production as BUILD with UnitType', async () => {
@@ -151,69 +150,36 @@ describe('game play production commands', () => {
   });
 });
 
-type ProductionTunerServer = {
-  received: string[];
-  address(): AddressInfo;
-  close(): Promise<void>;
-};
+type ProductionTunerServer = FakeTunerServer;
 
 async function startProductionTunerServer(options: {
   productionPostconditionMode?: 'cleared' | 'blocker-still-live';
 } = {}): Promise<ProductionTunerServer> {
-  const received: string[] = [];
-  const sockets = new Set<Socket>();
   let productionChoiceSent = false;
-  const server = createServer((socket) => {
-    sockets.add(socket);
-    socket.on('close', () => sockets.delete(socket));
-    let buffer = Buffer.alloc(0);
-    socket.on('data', (chunk) => {
-      buffer = Buffer.concat([buffer, chunk]);
-      for (;;) {
-        const frame = parseRequest(buffer);
-        if (!frame) return;
-        buffer = buffer.subarray(frame.bytesRead);
-        received.push(frame.message);
-        if (frame.message === 'LSQ:') {
-          socket.write(encodeResponse(frame.listenerId, ['65535', 'App UI', '1', 'Tuner']));
-        } else if (frame.message.includes('readProductionChoice')) {
-          const send = frame.message.includes('"send":true');
-          if (send) productionChoiceSent = true;
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(productionChoicePayload(
-            send,
-            options.productionPostconditionMode ?? 'cleared',
-            productionChoiceSent && !send,
-          ))]));
-        } else if (frame.message.includes('return JSON.stringify(sendOperation')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify({
-            sent: true,
-            beforeProductionPostcondition: productionPostconditionSnapshot('before', options.productionPostconditionMode ?? 'cleared'),
-            afterProductionPostcondition: productionPostconditionSnapshot('after', options.productionPostconditionMode ?? 'cleared'),
-          })]));
-        } else if (frame.message.includes('return JSON.stringify(validateOperation')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(operationValidation(frame.message))]));
-        } else {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(null)]));
-        }
+  return startFakeTunerServer({
+    handle({ message }) {
+      if (message.includes('readProductionChoice')) {
+        const send = message.includes('"send":true');
+        if (send) productionChoiceSent = true;
+        return [JSON.stringify(productionChoicePayload(
+          send,
+          options.productionPostconditionMode ?? 'cleared',
+          productionChoiceSent && !send,
+        ))];
       }
-    });
+      if (message.includes('return JSON.stringify(sendOperation')) {
+        return [JSON.stringify({
+          sent: true,
+          beforeProductionPostcondition: productionPostconditionSnapshot('before', options.productionPostconditionMode ?? 'cleared'),
+          afterProductionPostcondition: productionPostconditionSnapshot('after', options.productionPostconditionMode ?? 'cleared'),
+        })];
+      }
+      if (message.includes('return JSON.stringify(validateOperation')) {
+        return [JSON.stringify(operationValidation(message))];
+      }
+      return undefined;
+    },
   });
-  server.listen(0, '127.0.0.1');
-  await once(server, 'listening');
-  const address = server.address.bind(server);
-  const close = server.close.bind(server);
-  return {
-    received,
-    address(): AddressInfo {
-      return address() as AddressInfo;
-    },
-    async close() {
-      for (const socket of sockets) socket.destroy();
-      await new Promise<void>((resolve, reject) => {
-        close((error) => error ? reject(error) : resolve());
-      });
-    },
-  };
 }
 
 function operationValidation(message: string) {
@@ -308,25 +274,4 @@ function productionChoicePayload(
     },
     notes: ['This mirrors the official production chooser path.'],
   };
-}
-
-function parseRequest(buffer: Buffer): { listenerId: number; message: string; bytesRead: number } | null {
-  if (buffer.length < 8) return null;
-  const messageLength = buffer.readUInt32LE(0);
-  const bytesRead = 8 + messageLength;
-  if (buffer.length < bytesRead) return null;
-  return {
-    listenerId: buffer.readUInt32LE(4),
-    message: buffer.subarray(8, bytesRead).toString('utf8').replace(/\0$/, ''),
-    bytesRead,
-  };
-}
-
-function encodeResponse(listenerId: number, values: string[]) {
-  const messageBytes = Buffer.from(`${values.join('\0')}\0`, 'utf8');
-  const frame = Buffer.alloc(8 + messageBytes.length);
-  frame.writeUInt32LE(messageBytes.length, 0);
-  frame.writeUInt32LE(listenerId, 4);
-  messageBytes.copy(frame, 8);
-  return frame;
 }

--- a/packages/cli/test/commands/game.play.technology.test.ts
+++ b/packages/cli/test/commands/game.play.technology.test.ts
@@ -1,8 +1,7 @@
-import { once } from 'node:events';
-import { type AddressInfo, createServer, type Socket } from 'node:net';
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayChooseTech from '../../src/commands/game/play/choose-tech';
 import GamePlaySetTechTarget from '../../src/commands/game/play/set-tech-target';
+import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play technology commands', () => {
   test('wraps technology choice as SET_TECH_TREE_NODE', async () => {
@@ -266,11 +265,7 @@ describe('game play technology commands', () => {
   });
 });
 
-type TechnologyTunerServer = {
-  received: string[];
-  address(): AddressInfo;
-  close(): Promise<void>;
-};
+type TechnologyTunerServer = FakeTunerServer;
 
 type CommandClass = {
   run(args: string[]): Promise<unknown>;
@@ -290,59 +285,30 @@ async function startTechnologyTunerServer(options: {
   playNotificationMode?: 'tech-choice';
   technologyChoiceMode?: 'cleared' | 'sticky' | 'state-changed';
 } = {}): Promise<TechnologyTunerServer> {
-  const received: string[] = [];
-  const sockets = new Set<Socket>();
   let technologyChoiceSent = false;
-  const server = createServer((socket) => {
-    sockets.add(socket);
-    socket.on('close', () => sockets.delete(socket));
-    let buffer = Buffer.alloc(0);
-    socket.on('data', (chunk) => {
-      buffer = Buffer.concat([buffer, chunk]);
-      for (;;) {
-        const frame = parseRequest(buffer);
-        if (!frame) return;
-        buffer = buffer.subarray(frame.bytesRead);
-        received.push(frame.message);
-        if (frame.message === 'LSQ:') {
-          socket.write(encodeResponse(frame.listenerId, ['65535', 'App UI', '1', 'Tuner']));
-        } else if (frame.message.includes('readPlayNotifications')) {
-          const playMode = options.playNotificationMode === 'tech-choice'
-            && technologyChoiceSent
-            && (options.technologyChoiceMode ?? 'cleared') === 'cleared'
-            ? 'ready-unit'
-            : options.playNotificationMode ?? 'ready-unit';
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(playNotificationView(
-            playMode,
-            technologyChoiceSent && options.technologyChoiceMode === 'state-changed',
-          ))]));
-        } else if (frame.message.includes('sendTechnologyChoiceCloseout')) {
-          technologyChoiceSent = true;
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(technologyChoiceCloseout())]));
-        } else if (frame.message.includes('return JSON.stringify(validateOperation')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(operationValidation(frame.message))]));
-        } else {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(null)]));
-        }
+  return startFakeTunerServer({
+    handle({ message }) {
+      if (message.includes('readPlayNotifications')) {
+        const playMode = options.playNotificationMode === 'tech-choice'
+          && technologyChoiceSent
+          && (options.technologyChoiceMode ?? 'cleared') === 'cleared'
+          ? 'ready-unit'
+          : options.playNotificationMode ?? 'ready-unit';
+        return [JSON.stringify(playNotificationView(
+          playMode,
+          technologyChoiceSent && options.technologyChoiceMode === 'state-changed',
+        ))];
       }
-    });
+      if (message.includes('sendTechnologyChoiceCloseout')) {
+        technologyChoiceSent = true;
+        return [JSON.stringify(technologyChoiceCloseout())];
+      }
+      if (message.includes('return JSON.stringify(validateOperation')) {
+        return [JSON.stringify(operationValidation(message))];
+      }
+      return undefined;
+    },
   });
-  server.listen(0, '127.0.0.1');
-  await once(server, 'listening');
-  const address = server.address.bind(server);
-  const close = server.close.bind(server);
-  return {
-    received,
-    address(): AddressInfo {
-      return address() as AddressInfo;
-    },
-    async close() {
-      for (const socket of sockets) socket.destroy();
-      await new Promise<void>((resolve, reject) => {
-        close((error) => error ? reject(error) : resolve());
-      });
-    },
-  };
 }
 
 function operationValidation(message: string) {
@@ -549,25 +515,4 @@ function playNotificationView(mode: 'tech-choice' | 'ready-unit', technologyStat
     },
     limits: { maxNotifications: 25, truncated: false },
   };
-}
-
-function parseRequest(buffer: Buffer): { listenerId: number; message: string; bytesRead: number } | null {
-  if (buffer.length < 8) return null;
-  const messageLength = buffer.readUInt32LE(0);
-  const bytesRead = 8 + messageLength;
-  if (buffer.length < bytesRead) return null;
-  return {
-    listenerId: buffer.readUInt32LE(4),
-    message: buffer.subarray(8, bytesRead).toString('utf8').replace(/\0$/, ''),
-    bytesRead,
-  };
-}
-
-function encodeResponse(listenerId: number, values: string[]) {
-  const messageBytes = Buffer.from(`${values.join('\0')}\0`, 'utf8');
-  const frame = Buffer.alloc(8 + messageBytes.length);
-  frame.writeUInt32LE(messageBytes.length, 0);
-  frame.writeUInt32LE(listenerId, 4);
-  messageBytes.copy(frame, 8);
-  return frame;
 }

--- a/packages/cli/test/commands/game.play.test.ts
+++ b/packages/cli/test/commands/game.play.test.ts
@@ -1,6 +1,4 @@
-import { once } from 'node:events';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
-import { type AddressInfo, createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, test, vi } from 'vitest';
@@ -35,6 +33,7 @@ import GamePlayTraditions from '../../src/commands/game/play/traditions';
 import GamePlayUnitMovePreview from '../../src/commands/game/play/unit-move-preview';
 import GamePlayUnitTarget from '../../src/commands/game/play/unit-target';
 import GameWatch from '../../src/commands/game/watch';
+import { startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play commands', () => {
   test('checks end-turn status without sending turn complete', async () => {
@@ -3437,104 +3436,99 @@ async function startTunerServer(options: {
   unitTargetMode?: 'verified' | 'no-op-after-send' | 'path-shortfall' | 'delayed-after-send';
   notificationDismissalMode?: 'verified' | 'stale-nonblocking' | 'engine-front-train-absent' | 'engine-front-dismissed';
 } = {}) {
-  const received: string[] = [];
   let turnCompleteSent = false;
   let unitTargetSendObserved = false;
   let notificationDismissalSent = false;
-  const server = createServer((socket) => {
-    let buffer = Buffer.alloc(0);
-    socket.on('data', (chunk) => {
-      buffer = Buffer.concat([buffer, chunk]);
-      for (;;) {
-        const frame = parseRequest(buffer);
-        if (!frame) return;
-        buffer = buffer.subarray(frame.bytesRead);
-        received.push(frame.message);
-        if (frame.message === 'LSQ:') {
-          socket.write(encodeResponse(frame.listenerId, ['65535', 'App UI', '1', 'Tuner']));
-        } else if (frame.message.includes('readPlayNotifications')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(playNotificationView(
-            options.playNotificationMode,
-          ))]));
-        } else if (frame.message.includes('DiplomacyPlayerFirstMeets')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify({
-            key: 'PLAYER_REALATIONSHIP_FIRSTMEET_NEUTRAL',
-            value: 673478009,
-          })]));
-        } else if (frame.message.includes('readUnitTargetAction')) {
-          const send = frame.message.includes('"send":true');
-          if (send) unitTargetSendObserved = true;
-          const mode = options.unitTargetMode === 'delayed-after-send' && unitTargetSendObserved && !send
-            ? 'delayed-observed'
-            : options.unitTargetMode;
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(unitTargetAction(send, mode))]));
-        } else if (frame.message.includes('readUnitMovePreview')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(unitMovePreviewView())]));
-        } else if (frame.message.includes('readReadyUnitView')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(readyUnitView())]));
-        } else if (frame.message.includes('readReadyCityView')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(
-            options.playNotificationMode === 'clean-read' ? cleanReadyCityView() : readyCityView(),
-          )]));
-        } else if (frame.message.includes('readSettlementRecommendations')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(settlementRecommendationsView())]));
-        } else if (frame.message.includes('readTargetCandidates')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(targetCandidatesView())]));
-        } else if (frame.message.includes('readTraditionsView')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(traditionsView())]));
-        } else if (frame.message.includes('readProgressDashboard')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(progressDashboardView())]));
-        } else if (frame.message.includes('readDestinationAnalysis')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(destinationAnalysisView())]));
-        } else if (frame.message.includes('readBattlefieldScan')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(battlefieldScanView())]));
-        } else if (frame.message.includes('readNotificationDismissal')) {
-          const send = frame.message.includes('"send":true');
-          if (send) notificationDismissalSent = true;
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(notificationDismissal(
-            send,
-            options.notificationDismissalMode ?? 'verified',
-            notificationDismissalSent && !send,
-          ))]));
-        } else if (frame.message.includes('hasSentTurnComplete')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(turnCompletionStatus(turnCompleteSent, options.canEndTurnBefore ?? true))]));
-        } else if (frame.message === 'CMD:65535:GameContext.sendTurnComplete()') {
-          turnCompleteSent = true;
-          socket.write(encodeResponse(frame.listenerId, ['true']));
-        } else if (frame.message.includes('return JSON.stringify(validateOperation')) {
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(operationValidation(frame.message))]));
-        } else if (frame.message.includes('return JSON.stringify(sendOperation')) {
-          const unitFamily = frame.message.includes('sendOperation("unit-operation"') || frame.message.includes('sendOperation("unit-command"');
-          const operationType = operationTypeFromMessage(frame.message);
-          const populationFamily = operationType === 'ASSIGN_WORKER' || operationType === 'EXPAND';
-          socket.write(encodeResponse(frame.listenerId, [JSON.stringify(unitFamily
+  return startFakeTunerServer({
+    handle({ message }) {
+      if (message.includes('readPlayNotifications')) {
+        return [JSON.stringify(playNotificationView(
+          options.playNotificationMode,
+        ))];
+      }
+      if (message.includes('DiplomacyPlayerFirstMeets')) {
+        return [JSON.stringify({
+          key: 'PLAYER_REALATIONSHIP_FIRSTMEET_NEUTRAL',
+          value: 673478009,
+        })];
+      }
+      if (message.includes('readUnitTargetAction')) {
+        const send = message.includes('"send":true');
+        if (send) unitTargetSendObserved = true;
+        const mode = options.unitTargetMode === 'delayed-after-send' && unitTargetSendObserved && !send
+          ? 'delayed-observed'
+          : options.unitTargetMode;
+        return [JSON.stringify(unitTargetAction(send, mode))];
+      }
+      if (message.includes('readUnitMovePreview')) {
+        return [JSON.stringify(unitMovePreviewView())];
+      }
+      if (message.includes('readReadyUnitView')) {
+        return [JSON.stringify(readyUnitView())];
+      }
+      if (message.includes('readReadyCityView')) {
+        return [JSON.stringify(
+          options.playNotificationMode === 'clean-read' ? cleanReadyCityView() : readyCityView(),
+        )];
+      }
+      if (message.includes('readSettlementRecommendations')) {
+        return [JSON.stringify(settlementRecommendationsView())];
+      }
+      if (message.includes('readTargetCandidates')) {
+        return [JSON.stringify(targetCandidatesView())];
+      }
+      if (message.includes('readTraditionsView')) {
+        return [JSON.stringify(traditionsView())];
+      }
+      if (message.includes('readProgressDashboard')) {
+        return [JSON.stringify(progressDashboardView())];
+      }
+      if (message.includes('readDestinationAnalysis')) {
+        return [JSON.stringify(destinationAnalysisView())];
+      }
+      if (message.includes('readBattlefieldScan')) {
+        return [JSON.stringify(battlefieldScanView())];
+      }
+      if (message.includes('readNotificationDismissal')) {
+        const send = message.includes('"send":true');
+        if (send) notificationDismissalSent = true;
+        return [JSON.stringify(notificationDismissal(
+          send,
+          options.notificationDismissalMode ?? 'verified',
+          notificationDismissalSent && !send,
+        ))];
+      }
+      if (message.includes('hasSentTurnComplete')) {
+        return [JSON.stringify(turnCompletionStatus(turnCompleteSent, options.canEndTurnBefore ?? true))];
+      }
+      if (message === 'CMD:65535:GameContext.sendTurnComplete()') {
+        turnCompleteSent = true;
+        return ['true'];
+      }
+      if (message.includes('return JSON.stringify(validateOperation')) {
+        return [JSON.stringify(operationValidation(message))];
+      }
+      if (message.includes('return JSON.stringify(sendOperation')) {
+        const unitFamily = message.includes('sendOperation("unit-operation"') || message.includes('sendOperation("unit-command"');
+        const operationType = operationTypeFromMessage(message);
+        const populationFamily = operationType === 'ASSIGN_WORKER' || operationType === 'EXPAND';
+        return [JSON.stringify(unitFamily
+          ? {
+              sent: true,
+              beforePostcondition: unitOperationPostconditionSnapshot({ owner: 0, id: 65536, type: 26 }),
+              afterPostcondition: unitOperationPostconditionSnapshot({ owner: 0, id: 131072, type: 26 }),
+            }
+          : populationFamily
             ? {
                 sent: true,
-                beforePostcondition: unitOperationPostconditionSnapshot({ owner: 0, id: 65536, type: 26 }),
-                afterPostcondition: unitOperationPostconditionSnapshot({ owner: 0, id: 131072, type: 26 }),
-                }
-              : populationFamily
-                ? {
-                    sent: true,
-                    beforePopulationPostcondition: populationPlacementPostconditionSnapshot(true),
-                    afterPopulationPostcondition: populationPlacementPostconditionSnapshot(false),
-                  }
-                : { sent: true })]));
-        } else {
-          socket.write(encodeResponse(frame.listenerId, ['null']));
-        }
+                beforePopulationPostcondition: populationPlacementPostconditionSnapshot(true),
+                afterPopulationPostcondition: populationPlacementPostconditionSnapshot(false),
+              }
+            : { sent: true })];
       }
-    });
-  });
-  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-  return {
-    received,
-    address: () => server.address() as AddressInfo,
-    close: async () => {
-      server.close();
-      await once(server, 'close');
+      return undefined;
     },
-  };
+  });
 }
 
 function playNotificationView(
@@ -6869,31 +6863,4 @@ function operationArgs(operationType: string) {
   if (operationType === 'UNITCOMMAND_RESETTLE') return { X: 17, Y: 25 };
   if (operationType === 'UNITCOMMAND_UPGRADE') return {};
   return undefined;
-}
-
-function parseRequest(buffer: Buffer):
-  | {
-      listenerId: number;
-      message: string;
-      bytesRead: number;
-    }
-  | null {
-  if (buffer.length < 8) return null;
-  const messageLength = buffer.readUInt32LE(0);
-  const bytesRead = 8 + messageLength;
-  if (buffer.length < bytesRead) return null;
-  return {
-    listenerId: buffer.readUInt32LE(4),
-    message: buffer.subarray(8, bytesRead).toString('utf8').replace(/\0$/, ''),
-    bytesRead,
-  };
-}
-
-function encodeResponse(listenerId: number, parts: string[]): Buffer {
-  const messageBytes = Buffer.from(`${parts.join('\0')}\0`, 'utf8');
-  const frame = Buffer.alloc(8 + messageBytes.length);
-  frame.writeUInt32LE(messageBytes.length, 0);
-  frame.writeUInt32LE(listenerId, 4);
-  messageBytes.copy(frame, 8);
-  return frame;
 }


### PR DESCRIPTION
Extract the duplicated fake Tuner socket server setup into a shared `startFakeTunerServer` fixture.

Each test file previously contained its own copy of `parseRequest`, `encodeResponse`, and the full TCP server boilerplate for simulating the Civ7 Tuner protocol. This introduces a single `startFakeTunerServer` helper in `packages/cli/test/commands/fixtures/tuner-socket-server.ts` that handles connection management, frame parsing, `LSQ:` state responses, and fallback replies. Test files now pass only a `handle` callback describing their specific message routing logic, and the per-file `TunerServer` type aliases are collapsed to `FakeTunerServer`.