### PR TITLE
docs(openspec): add civ7 support direct-control modularization workstream

### DIFF
--- a/openspec/changes/civ7-support-direct-control-modularization/.openspec.yaml
+++ b/openspec/changes/civ7-support-direct-control-modularization/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-06-02
+status: draft

--- a/openspec/changes/civ7-support-direct-control-modularization/design.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/design.md
@@ -1,0 +1,197 @@
+## Design
+
+This workstream uses two coupled but separately verified migrations:
+
+- **CLI play ownership migration:** convert the remaining monolith-owned command
+  tests into focused files under `packages/cli/test/commands/game/play/**`.
+- **Direct-control atom migration:** after focused tests exist, split stable
+  runtime atoms out of the large direct-control `index.ts` into named package
+  modules with explicit public types/constants.
+
+Effect/oRPC composition is intentionally last. It consumes direct-control atoms
+through typed procedure cores; it does not own raw socket state, raw JavaScript
+command strings, or gameplay mutation logic.
+
+## Systematic Corpus
+
+### CLI Command/Test Corpus
+
+The CLI play corpus includes:
+
+- remaining monolith command owners:
+  - `GamePlayNotifications`
+  - `GamePlayPriorities`
+  - `GamePlayDismissNotification`
+- already extracted owner suites under `packages/cli/test/commands/game/play/**`;
+- adjacent package-local play suites such as production, narrative, culture,
+  technology, first-meet, operation wrappers, end-turn, population placement,
+  town focus, unit target, progression read, tactical read, watch, topics,
+  promotion readiness, rehydrate, settlement recommendations, ready city,
+  unit move preview, ready unit, notification queue, and dismiss queue;
+- fake tuner fixture ownership and any remaining monolith-only HUD scenario
+  builders.
+
+Every corpus row needs:
+
+- command owner;
+- current test file;
+- target test file;
+- fixture dependency;
+- mutation/read-only proof class;
+- focused suite command;
+- adjacent monolith filter;
+- removal branch;
+- validation status.
+
+### Direct-Control Atom Corpus
+
+The direct-control corpus includes:
+
+- tuner socket/session/framing and state-role selection;
+- JSON command execution and error shaping;
+- play notification/HUD view materialization;
+- notification dismissal and closeout verification;
+- ready unit and ready city views;
+- operation validation/send/postcondition helpers;
+- tactical, progression, settlement, destination, battlefield, and target reads;
+- component ID, schema/type ownership, constants, and public exports;
+- future procedure-core candidates for control-oRPC.
+
+Every atom row needs:
+
+- source region in `packages/civ7-direct-control/src/index.ts`;
+- proposed module owner;
+- public/private exports;
+- existing tests;
+- required new tests;
+- runtime-proof requirement;
+- consumers in CLI/Studio/oRPC.
+
+## Parallel Execution Model
+
+Every delegated lane starts from a framed objective. The spec owner must decide
+whether the agent is a short report-only peer, a long-running investigation, or
+an implementation lane before sending instructions.
+
+Long-running investigation or implementation agents receive a `/goal`-prefixed
+prompt with context, required skills, objective, write permissions, proof
+expectations, and return shape. Existing threads are reused only when their
+prior context is intentionally useful; if the topic changes, the spec owner
+sends `/compact`, waits for completion, and only then sends the new frame.
+
+### Lane A: Systematic Spec Owner
+
+Write set:
+
+- `openspec/changes/civ7-support-direct-control-modularization/**`
+- downstream project workstream records when facts change
+
+Responsibilities:
+
+- maintain corpus ledgers and task status;
+- receive agent reports;
+- decide lane sequence;
+- keep proof labels honest;
+- run OpenSpec validation.
+- own all Graphite sequencing decisions for this change; other agents report
+  findings or contribute non-overlapping files but do not independently mutate
+  the support stack without coordination.
+
+### Lane B: Net-New CLI Suites
+
+Write set:
+
+- new files under `packages/cli/test/commands/game/play/**`
+- `package.json` `test:cli:play` additions
+
+Responsibilities:
+
+- create focused owner suites before monolith removal;
+- use local fakes or named fixtures only when ownership is explicit;
+- do not remove monolith tests in this lane unless it also owns the extraction
+  closure.
+- avoid touching `package.json` unless the spec owner has assigned that file for
+  the current slice.
+
+### Lane C: Monolith Removal / DRA Integration
+
+Write set:
+
+- `packages/cli/test/commands/game.play.test.ts`
+- `package.json` only when wiring/removing suites
+
+Responsibilities:
+
+- remove exactly the coverage already recreated in Lane B;
+- remove obsolete monolith fixture branches only when no remaining monolith test
+  uses them;
+- run adjacent monolith filters and ownership scans;
+- keep each Graphite branch small.
+- act as the only writer to `packages/cli/test/commands/game.play.test.ts` for
+  the active slice.
+
+### Lane D: Direct-Control Atom Planning
+
+Write set:
+
+- OpenSpec corpus/design/task artifacts first
+- direct-control source only after CLI tests stabilize and tasks authorize it
+
+Responsibilities:
+
+- propose module boundaries and public exports;
+- identify constants/types to export after reviewing user TODO stashes;
+- define runtime proof requirements;
+- avoid source edits until focused direct-control tests exist.
+
+### Lane E: Review / Gate Lane
+
+Write set:
+
+- review-disposition ledgers and acceptance packets
+
+Responsibilities:
+
+- audit authority, proof, ownership, and relationship-label invariants;
+- independently rerun required gates before accepting closures;
+- nudge before bad commits, not after.
+
+## Sequencing
+
+1. Import systematic skill and open this OpenSpec change.
+   - Done in two Graphite layers:
+     `0abccba10 docs(skills): add systematic workstream skill` and
+     `66f9af202 docs(skills): apply systematic workstream review fixes`.
+2. Fill CLI and direct-control corpus ledgers from current disk.
+3. Define shared fixture strategy before extracting more notification/priorities
+   suites.
+4. Complete remaining CLI test ownership slices:
+   - exact notification dismissal;
+   - notification HUD materialization;
+   - priorities compact projection;
+   - any residual monolith fixture ownership.
+5. Only after focused tests own behavior, extract direct-control atoms:
+   - notification materialization;
+   - notification dismissal verification;
+   - ready views;
+   - operation validation/send/postconditions;
+   - read-only tactical/progression/destination surfaces;
+   - schemas/types/constants.
+6. Add Effect/oRPC procedure cores over stable atoms.
+
+## Proof Boundaries
+
+- Test-only extraction proves local CLI test ownership, not runtime behavior.
+- Direct-control source movement proves no behavior change only when direct
+  package tests/check/build and focused CLI tests pass.
+- Mutation-facing runtime behavior requires support-owned real-game proof when
+  Civ7 is responsive, or explicit `pending-runtime-proof`.
+- OpenSpec validation proves artifact shape only.
+
+## Review Lanes Required
+
+- Architecture review for package/module ownership and forbidden owners.
+- Product/proof review for player-unblocking behavior and proof labels.
+- Verification review for tests, filters, ownership scans, and runtime proof.
+- Relationship-label review for every tactical/diplomatic/notification surface
+  that could imply hostility, war, opponent, ally, or suzerain.

--- a/openspec/changes/civ7-support-direct-control-modularization/proposal.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/proposal.md
@@ -23,10 +23,16 @@ workstream and parallel lanes.
 - `packages/cli/AGENTS.md`
 - `packages/civ7-direct-control/AGENTS.md`
 - `docs/projects/civ7-direct-control/workstream/support-dra-takeover-reference.md`
-- `docs/projects/civ7-direct-control/workstream/play-agent/hotseat-phase-packet.md`
+- `docs/projects/civ7-direct-control/workstream/control-surface-expansion/phase-record.md`
+- `docs/projects/civ7-direct-control/workstream/control-surface-expansion/implementation-closure.md`
+- `openspec/changes/direct-control-state-role-model/proposal.md`
+- `openspec/changes/direct-control-read-surface/proposal.md`
+- `openspec/changes/direct-control-action-surface/proposal.md`
+- `openspec/changes/direct-control-capability-catalog/proposal.md`
 - `.agents/skills/civ7-systematic-workstream/SKILL.md`
 - `.agents/skills/civ7-open-spec-workstream/SKILL.md`
 - `.agents/skills/civ7-architecture-authority/SKILL.md`
+- `.agents/skills/civ7-product-authority/SKILL.md`
 - `.agents/skills/civ7-operational-debugging/SKILL.md`
 
 ## What Changes

--- a/openspec/changes/civ7-support-direct-control-modularization/proposal.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/proposal.md
@@ -1,0 +1,145 @@
+## Why
+
+Live Civ7 play support accumulated useful fixes faster than the repo structure
+could absorb them. The support stack now needs a systematic migration from
+large CLI play tests and direct-control source concentration into stable,
+reviewable command/test owners and direct-control atoms that future Effect/oRPC
+procedures can compose.
+
+The intended order is deliberate:
+
+1. modularize CLI play command tests and ownership;
+2. extract stable direct-control atoms and public types/constants behind package
+   boundaries;
+3. compose those atoms through Effect/oRPC only after the package boundaries are
+   real.
+
+This change replaces one-off extraction cadence with a systematic OpenSpec
+workstream and parallel lanes.
+
+## Target Authority Refs
+
+- `AGENTS.md`
+- `packages/cli/AGENTS.md`
+- `packages/civ7-direct-control/AGENTS.md`
+- `docs/projects/civ7-direct-control/workstream/support-dra-takeover-reference.md`
+- `docs/projects/civ7-direct-control/workstream/play-agent/hotseat-phase-packet.md`
+- `.agents/skills/civ7-systematic-workstream/SKILL.md`
+- `.agents/skills/civ7-open-spec-workstream/SKILL.md`
+- `.agents/skills/civ7-architecture-authority/SKILL.md`
+- `.agents/skills/civ7-operational-debugging/SKILL.md`
+
+## What Changes
+
+- Establish a systematic corpus of CLI play commands, tests, fixtures,
+  direct-control runtime atoms, schemas/types/constants, and future composition
+  surfaces.
+- Continue CLI play test modularization through focused owner files under
+  `packages/cli/test/commands/game/play/**`, with `test:cli:play` explicitly
+  listing each suite.
+- Build net-new focused suites and any named fixture helpers first, then remove
+  equivalent coverage from `packages/cli/test/commands/game.play.test.ts`.
+- Split direct-control runtime code only after tests and ownership boundaries
+  are stable enough to prove behavior did not change.
+- Treat Effect/oRPC as a later composition lane over direct-control procedure
+  cores, not as a transport-first rewrite.
+
+## Existing Completed Slices
+
+These Graphite layers are implementation evidence for the test-modularization
+lane, not proof that the full change is complete:
+
+- `codex/support-dra-takeover-reference`
+- `codex/extract-tactical-read-play-tests`
+- `codex/extract-watch-play-tests`
+- `codex/extract-topics-play-tests`
+- `codex/extract-promotion-readiness-play-tests`
+- `codex/extract-rehydrate-play-tests`
+- `codex/extract-settlement-recommendations-play-tests`
+- `codex/extract-ready-city-play-tests`
+- `codex/extract-foldered-unit-move-preview-play-tests`
+- `codex/extract-foldered-ready-unit-play-tests`
+- `codex/extract-notification-queue-play-tests`
+- `codex/extract-dismiss-notification-queue-play-tests`
+
+## Requires
+
+- `civ7-systematic-workstream` skill present in the support stack with review
+  fixes from `codex/systematic-skill-review-fixes`.
+- Current support worktree clean before each lane starts.
+- Named user-note stashes remain preserved until deliberately dispositioned.
+- Gameplay remains parked unless the player resumes play.
+- Parallel agents must use disjoint write sets. Worktrees are allowed, but
+  Graphite stack mutation must stay simple and local to the current support
+  stack.
+
+## Enables Parallel Work
+
+- Net-new CLI test/file creation can proceed ahead of monolith removals when
+  test names and fixture ownership are unique.
+- Direct-control atom planning can inventory module boundaries while CLI test
+  extraction continues, but runtime source edits wait for stable test owners.
+- Review agents can audit OpenSpec tasks, ownership scans, and proof claims in
+  parallel with implementation lanes.
+- Agents may work in separate worktrees or in one visible worktree only when
+  their write sets do not overlap. One owner at a time controls
+  `package.json` play-script wiring and `packages/cli/test/commands/game.play.test.ts`.
+
+## Affected Owners
+
+- `packages/cli/src/commands/game/play/**`
+- `packages/cli/test/commands/game.play.test.ts`
+- `packages/cli/test/commands/game.play*.test.ts`
+- `packages/cli/test/commands/game/play/**`
+- `packages/cli/test/commands/fixtures/**`
+- `packages/civ7-direct-control/src/**`
+- `packages/civ7-direct-control/test/**`
+- `packages/civ7-control-orpc/**` only after direct-control atoms exist
+- `openspec/changes/civ7-support-direct-control-modularization/**`
+- `docs/projects/civ7-direct-control/workstream/**` when downstream packets are
+  realigned
+
+## Forbidden Owners
+
+- Caller-local raw JavaScript strings for package-owned runtime reads/actions.
+- CLI or Studio socket/session ownership that belongs in `@civ7/direct-control`.
+- Broad barrels, `shared` buckets, or fixture catalogs without named owners.
+- Effect/oRPC transport surfaces that bypass direct-control procedure cores.
+- Relationship, enemy, hostile, opponent, war, ally, or suzerain labels without
+  official relationship/team/war/suzerain evidence.
+- Generated artifacts, logs, deployed Mods folders, or official resource outputs
+  as edit surfaces.
+
+## Stop Conditions
+
+- A lane needs runtime behavior proof and Civ7 is unavailable; mark
+  `pending-runtime-proof` instead of claiming closure.
+- A proposed shared helper hides command ownership or duplicates monolith
+  coverage.
+- A direct-control extraction changes public behavior before focused tests exist.
+- A review finds relationship/suzerain labels beyond official evidence.
+- Dirty scope includes user/control notes or unrelated files without a named
+  stash/disposition.
+- A parallel lane needs to restack or mutate unrelated Graphite stacks.
+
+## Consumer Impact
+
+Reviewers get smaller, owner-aligned Graphite layers. Future support agents get
+stable direct-control atoms and focused tests instead of relying on a monolith
+or ad hoc live-play fixes. Effect/oRPC work gets a composable server-side core
+rather than raw command tunneling.
+
+## Verification Gates
+
+- `git diff --check`
+- Focused suite for each owner lane
+- Adjacent monolith filter proving removed coverage still has neighboring
+  command support
+- `bun run check:cli`
+- `bun run test:cli:play`
+- `bun run --cwd packages/civ7-direct-control test/check/build` for
+  direct-control source lanes
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Ownership scans for moved command names, moved test names, fixture ownership,
+  and relationship-label invariants
+- Clean final status and Graphite commit with separate subject/body

--- a/openspec/changes/civ7-support-direct-control-modularization/specs/civ7-direct-control/spec.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/specs/civ7-direct-control/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Civ7 Support Control Workstream Preserves Modularization Before Composition
+
+The support control workstream SHALL migrate accumulated play-support behavior
+through focused CLI ownership and direct-control atoms before adding Effect/oRPC
+transport composition.
+
+#### Scenario: CLI play tests are extracted
+- **WHEN** a CLI play command owner is moved out of the monolith
+- **THEN** the focused suite lives under `packages/cli/test/commands/game/play/**`
+- **AND** `test:cli:play` lists the suite explicitly
+- **AND** equivalent monolith coverage is removed only after the focused suite
+  exists
+- **AND** adjacent monolith filters prove remaining owners still pass
+
+#### Scenario: Direct-control atoms are extracted
+- **WHEN** runtime logic is moved out of `packages/civ7-direct-control/src/index.ts`
+- **THEN** the new module has an owning runtime atom name
+- **AND** callers continue to use package-owned functions rather than raw
+  JavaScript strings or caller-local socket state
+- **AND** package tests and focused CLI consumers verify the move
+
+#### Scenario: Effect/oRPC procedures are added
+- **WHEN** an Effect/oRPC control procedure is introduced
+- **THEN** it composes a stable direct-control atom or procedure core
+- **AND** it does not define the runtime behavior through transport routing
+- **AND** it includes typed input/output schema, context/error shaping,
+  correlation identity, and approval gates when mutation-facing
+
+### Requirement: Civ7 Support Proof Claims Stay Evidence-Scoped
+
+The support control workstream SHALL label test-only, direct-control source,
+and runtime behavior proof separately.
+
+#### Scenario: A test-only slice closes
+- **WHEN** a branch only moves tests or test fixtures
+- **THEN** closure claims local test ownership only
+- **AND** no runtime/direct-control behavior is claimed from local tests
+
+#### Scenario: A mutation-facing runtime slice closes
+- **WHEN** a branch changes mutation-facing direct-control behavior
+- **THEN** it requires approval-first behavior, validator-first behavior,
+  no-repeat-after-unverified semantics, postcondition evidence, and
+  support-owned real-game proof when Civ7 is responsive
+- **AND** if Civ7 is unavailable the closure records `pending-runtime-proof`
+
+### Requirement: Civ7 Support Relationship Labels Require Official Evidence
+
+The support control workstream SHALL treat relationship and city-state labels as
+neutral unless official relationship, team, war, or suzerain evidence proves a
+stronger claim.
+
+#### Scenario: A tactical or notification surface renders actor labels
+- **WHEN** a surface has owner mismatch, proximity, contact, visibility, hidden
+  facts, or a sidecar label
+- **THEN** it does not render hostile, enemy, non-friendly, opponent, threat,
+  war, ally, or suzerain labels from those facts alone
+- **AND** tests include negative guards when the surface could imply those
+  labels

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -3,23 +3,23 @@
 - [x] 1.1 Import `civ7-systematic-workstream` into the support stack.
 - [x] 1.2 Apply systematic skill review fixes from
   `codex/systematic-skill-review-fixes`.
-- [ ] 1.3 Validate this OpenSpec change in strict mode.
-- [ ] 1.4 Fill `workstream/workstream-record.md` from current branch, stack,
+- [x] 1.3 Validate this OpenSpec change in strict mode.
+- [x] 1.4 Fill `workstream/workstream-record.md` from current branch, stack,
   stashes, and proof state.
 - [ ] 1.5 Fill `workstream/cli-play-corpus.md` with every play command/test
   owner row.
 - [ ] 1.6 Fill `workstream/direct-control-atom-corpus.md` with every direct
   control atom candidate.
-- [ ] 1.7 Record reviewer/agent findings in
+- [x] 1.7 Record reviewer/agent findings in
   `workstream/review-disposition-ledger.md`.
 
 ## 2. Parallel Planning Gates
 
-- [ ] 2.1 Collect CLI topology inventory from a peer agent.
-- [ ] 2.2 Collect direct-control atom inventory from a peer agent.
-- [ ] 2.3 Collect OpenSpec/parallelization review from a peer agent.
-- [ ] 2.4 Reconcile peer findings into corpus ledgers and task sequence.
-- [ ] 2.5 Define shared fixture strategy before further notification/priorities
+- [x] 2.1 Collect CLI topology inventory from a peer agent.
+- [x] 2.2 Collect direct-control atom inventory from a peer agent.
+- [x] 2.3 Collect OpenSpec/parallelization review from a peer agent.
+- [x] 2.4 Reconcile peer findings into corpus ledgers and task sequence.
+- [x] 2.5 Define shared fixture strategy before further notification/priorities
   extraction.
 - [ ] 2.6 Assign one owner at a time for `package.json` play-script wiring and
   `packages/cli/test/commands/game.play.test.ts`.
@@ -28,7 +28,17 @@
   write-set policy, `/goal` prefix for long-running work, and
   `/compact` before reused-thread topic switches.
 
+Implementation tasks in sections 3-5 are blocked until the relevant corpus rows
+name the exact write set, fixture owner, validation commands,
+duplicate/removal boundary, and proof class. For `package.json` and
+`packages/cli/test/commands/game.play.test.ts`, the workstream owner must record
+the active single writer before delegation.
+
 ## 3. CLI Play Test Ownership Lane
+
+Rows 3.1-3.11 are baseline evidence from already-landed test-only Graphite
+slices. They do not prove this OpenSpec change is complete and do not authorize
+runtime/direct-control claims.
 
 - [x] 3.1 Extract tactical-read play tests.
 - [x] 3.2 Extract watch play tests.

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -1,0 +1,79 @@
+## 1. Workstream Setup
+
+- [x] 1.1 Import `civ7-systematic-workstream` into the support stack.
+- [x] 1.2 Apply systematic skill review fixes from
+  `codex/systematic-skill-review-fixes`.
+- [ ] 1.3 Validate this OpenSpec change in strict mode.
+- [ ] 1.4 Fill `workstream/workstream-record.md` from current branch, stack,
+  stashes, and proof state.
+- [ ] 1.5 Fill `workstream/cli-play-corpus.md` with every play command/test
+  owner row.
+- [ ] 1.6 Fill `workstream/direct-control-atom-corpus.md` with every direct
+  control atom candidate.
+- [ ] 1.7 Record reviewer/agent findings in
+  `workstream/review-disposition-ledger.md`.
+
+## 2. Parallel Planning Gates
+
+- [ ] 2.1 Collect CLI topology inventory from a peer agent.
+- [ ] 2.2 Collect direct-control atom inventory from a peer agent.
+- [ ] 2.3 Collect OpenSpec/parallelization review from a peer agent.
+- [ ] 2.4 Reconcile peer findings into corpus ledgers and task sequence.
+- [ ] 2.5 Define shared fixture strategy before further notification/priorities
+  extraction.
+- [ ] 2.6 Assign one owner at a time for `package.json` play-script wiring and
+  `packages/cli/test/commands/game.play.test.ts`.
+- [ ] 2.7 Apply the agent framing protocol to any new or reused delegation:
+  framing-design context, required skills, objective, reasoning level,
+  write-set policy, `/goal` prefix for long-running work, and
+  `/compact` before reused-thread topic switches.
+
+## 3. CLI Play Test Ownership Lane
+
+- [x] 3.1 Extract tactical-read play tests.
+- [x] 3.2 Extract watch play tests.
+- [x] 3.3 Extract topics play tests.
+- [x] 3.4 Extract promotion-readiness play tests.
+- [x] 3.5 Extract rehydrate play tests.
+- [x] 3.6 Extract settlement-recommendations play tests.
+- [x] 3.7 Extract ready-city play tests.
+- [x] 3.8 Extract unit-move-preview play tests.
+- [x] 3.9 Extract ready-unit play tests.
+- [x] 3.10 Extract notification-queue play tests.
+- [x] 3.11 Extract dismiss-notification-queue play tests.
+- [ ] 3.12 Extract exact dismiss-notification play tests.
+- [ ] 3.13 Extract notification HUD materialization play tests.
+- [ ] 3.14 Extract priorities play tests.
+- [ ] 3.15 Remove residual monolith fixture ownership after the last consumer
+  moves.
+
+## 4. Direct-Control Atom Lane
+
+- [ ] 4.1 Define direct-control module boundaries and forbidden owners.
+- [ ] 4.2 Add or relocate focused direct-control package tests for each atom.
+- [ ] 4.3 Extract notification view/materialization atom.
+- [ ] 4.4 Extract notification dismissal/verification atom.
+- [ ] 4.5 Extract ready unit/city view atoms.
+- [ ] 4.6 Extract operation validation/send/postcondition atoms.
+- [ ] 4.7 Extract tactical/progression/destination/battlefield/target read
+  atoms.
+- [ ] 4.8 Export stable types/constants only after module owners are defined.
+
+## 5. Effect/oRPC Composition Lane
+
+- [ ] 5.1 Define procedure-core inputs/outputs over direct-control atoms.
+- [ ] 5.2 Add TypeBox schema artifacts where procedure surfaces need them.
+- [ ] 5.3 Add approval gates, context, correlation IDs, and error shaping.
+- [ ] 5.4 Expose transport adapters only after procedure cores are testable.
+
+## 6. Verification And Closure
+
+- [ ] 6.1 For every test-only slice, run `git diff --check`, focused suite,
+  adjacent monolith filter, `bun run check:cli`, `bun run test:cli:play`, and
+  ownership scan.
+- [ ] 6.2 For every direct-control source slice, run direct-control
+  tests/check/build plus focused CLI consumers.
+- [ ] 6.3 For every runtime-changing slice, attach real-game proof or explicit
+  `pending-runtime-proof`.
+- [ ] 6.4 Run `bun run openspec -- validate civ7-support-direct-control-modularization --strict`.
+- [ ] 6.5 Run final downstream realignment and closure checklist.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/cli-play-corpus.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/cli-play-corpus.md
@@ -1,21 +1,36 @@
 # CLI Play Corpus
 
-This ledger is intentionally incomplete until the CLI topology agent report is
-merged. Do not close implementation tasks against partial rows.
+This ledger has the completed agent topology findings merged. It is still not
+an implementation closeout ledger: do not start a slice until its row names the
+active single writer, duplicate-removal boundary, validation commands, and
+fixture owner.
 
-| Owner | Current Tests | Target Owner File | Fixture Owner | Proof Class | Status |
-|---|---|---|---|---|---|
-| Tactical read | extracted | `game.play.tactical-read.test.ts` | local/existing | test-only | Completed before this change. |
-| Watch | extracted | `game.play.watch.test.ts` | local/existing | test-only | Completed before this change. |
-| Topics | extracted | `game.play.topics.test.ts` | local/existing | test-only | Completed before this change. |
-| Promotion readiness | extracted | `game.play.promotion-readiness.test.ts` | local/existing | test-only | Completed before this change. |
-| Rehydrate | extracted | `game.play.rehydrate.test.ts` | local/existing | test-only | Completed before this change. |
-| Settlement recommendations | extracted | `game.play.settlement-recommendations.test.ts` | local/existing | test-only | Completed before this change. |
-| Ready city | extracted | `game/play/ready-city.test.ts` | local/existing | test-only | Completed before this change. |
-| Unit move preview | extracted | `game/play/unit-move-preview.test.ts` | local/existing | test-only | Completed before this change. |
-| Ready unit | extracted | `game/play/ready-unit.test.ts` | local/existing | test-only | Completed before this change. |
-| Notification queue | extracted | `game/play/notification/queue.test.ts` | local fake | test-only | Completed before this change. |
-| Dismiss notification queue | extracted | `game/play/notification/dismiss-queue.test.ts` | local fake | test-only | Completed before this change. |
-| Exact dismiss notification | `game.play.test.ts` | `game/play/notification/dismiss.test.ts` | local fake | test-only, mutation-facing fake | Planned. |
-| Notification HUD materialization | `game.play.test.ts` | `game/play/notification/hud.test.ts` | TBD | test-only | Planned. |
-| Priorities | `game.play.test.ts` | `game/play/priorities.test.ts` or deeper split | TBD | test-only | Planned. |
+| Owner | Current Tests | Target Owner File | Fixture Owner | Proof Class | Validation / Stop Condition | Status |
+|---|---|---|---|---|---|---|
+| Tactical read | extracted | `game.play.tactical-read.test.ts` | local/existing | test-only | Baseline evidence only. | Completed before this change. |
+| Watch | extracted | `game.play.watch.test.ts` | local/existing | test-only | Baseline evidence only. | Completed before this change. |
+| Topics | extracted | `game.play.topics.test.ts` | local/existing | test-only | Baseline evidence only. | Completed before this change. |
+| Promotion readiness | extracted | `game.play.promotion-readiness.test.ts` | local/existing | test-only | Baseline evidence only. | Completed before this change. |
+| Rehydrate | extracted | `game.play.rehydrate.test.ts` | local/existing | test-only | Baseline evidence only. | Completed before this change. |
+| Settlement recommendations | extracted | `game.play.settlement-recommendations.test.ts` | local/existing | test-only | Baseline evidence only. | Completed before this change. |
+| Ready city | extracted | `game/play/ready-city.test.ts` | local/existing | test-only | Baseline evidence only. | Completed before this change. |
+| Unit move preview | extracted | `game/play/unit-move-preview.test.ts` | local/existing | test-only | Baseline evidence only; preserve host/port user note. | Completed before this change. |
+| Ready unit | extracted | `game/play/ready-unit.test.ts` | local/existing | test-only | Baseline evidence only. | Completed before this change. |
+| Notification queue | extracted | `game/play/notification/queue.test.ts` | local fake | test-only | Baseline evidence only. | Completed before this change. |
+| Dismiss notification queue | extracted | `game/play/notification/dismiss-queue.test.ts` | local fake | test-only | Baseline evidence only. | Completed before this change. |
+| Exact dismiss notification | `GamePlayDismissNotification` in `game.play.test.ts`: `dismisses reviewed notifications only with explicit approval reason`; `does not verify dismissal from stale nonblocking front evidence`; `does not verify dismissal from train absence while engine queue still fronts the target`; `does not verify dismissal from dismissed flag while engine queue still fronts the target` | `game/play/notification/dismiss.test.ts` | start local with exact `notificationDismissal` fake; promote only if reused by queue/direct-control atom tests | test-only, mutation-facing fake; no runtime claim | Focused filter: `dismisses reviewed notifications|does not verify dismissal`; adjacent with `game/play/notification/dismiss-queue.test.ts`; ownership scan for `GamePlayDismissNotification`, `readNotificationDismissal`, and test names. | Planned next CLI slice after fixture strategy. |
+| Notification HUD materialization | `GamePlayNotifications` in `game.play.test.ts`: materializes diplomacy response, technology, culture, celebration, government, narrative, stale command-units; reads materialized notifications without sending; classifies invalid-target notices and valid reports | `game/play/notification/hud.test.ts` | named notification HUD fixture split by surface/mode; no broad 24-mode catalog | test-only | Focused filter: `materializes|classifies .* notices|classifies valid diplomatic`; adjacent with `notification/queue.test.ts`; scan `GamePlayNotifications`, `readPlayNotifications`, `playNotificationMode`. | Planned after exact dismiss. |
+| Priorities | `GamePlayPriorities` in `game.play.test.ts`: 21 compact priority/routing tests across clean-read, unit-command, exact operations, chooser options, dismissal diagnostics, ready-city blockers, and stale command-units | `game/play/priorities.test.ts` or deeper split after fixture strategy | named priority scenario builder only after HUD/ready/dismiss fixtures have owners | test-only; high relationship-label risk | Focused filter: `priorit|surfaces|routes|classifies stale`; adjacent with ready-city, ready-unit, tactical-read; scan relationship-label terms and duplicate coverage. | Planned last; do not extract before HUD. |
+
+## Fixture Strategy From Agent Reports
+
+- Keep `packages/cli/test/commands/fixtures/tuner-socket-server.ts` as the
+  shared transport fake.
+- Split monolith-local notification HUD builders by named surface/mode before
+  HUD extraction; do not import a broad 24-mode catalog into every suite.
+- Keep command-specific send validation/postcondition fakes local until two or
+  more owners require the same fixture.
+- Keep tactical/relationship fixtures isolated and preserve
+  `relationship-unproven`, `relationshipProof: none`, and no
+  `enemy|hostile|opponent|threat|war|ally|suzerain` wording without official
+  evidence.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/cli-play-corpus.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/cli-play-corpus.md
@@ -1,0 +1,21 @@
+# CLI Play Corpus
+
+This ledger is intentionally incomplete until the CLI topology agent report is
+merged. Do not close implementation tasks against partial rows.
+
+| Owner | Current Tests | Target Owner File | Fixture Owner | Proof Class | Status |
+|---|---|---|---|---|---|
+| Tactical read | extracted | `game.play.tactical-read.test.ts` | local/existing | test-only | Completed before this change. |
+| Watch | extracted | `game.play.watch.test.ts` | local/existing | test-only | Completed before this change. |
+| Topics | extracted | `game.play.topics.test.ts` | local/existing | test-only | Completed before this change. |
+| Promotion readiness | extracted | `game.play.promotion-readiness.test.ts` | local/existing | test-only | Completed before this change. |
+| Rehydrate | extracted | `game.play.rehydrate.test.ts` | local/existing | test-only | Completed before this change. |
+| Settlement recommendations | extracted | `game.play.settlement-recommendations.test.ts` | local/existing | test-only | Completed before this change. |
+| Ready city | extracted | `game/play/ready-city.test.ts` | local/existing | test-only | Completed before this change. |
+| Unit move preview | extracted | `game/play/unit-move-preview.test.ts` | local/existing | test-only | Completed before this change. |
+| Ready unit | extracted | `game/play/ready-unit.test.ts` | local/existing | test-only | Completed before this change. |
+| Notification queue | extracted | `game/play/notification/queue.test.ts` | local fake | test-only | Completed before this change. |
+| Dismiss notification queue | extracted | `game/play/notification/dismiss-queue.test.ts` | local fake | test-only | Completed before this change. |
+| Exact dismiss notification | `game.play.test.ts` | `game/play/notification/dismiss.test.ts` | local fake | test-only, mutation-facing fake | Planned. |
+| Notification HUD materialization | `game.play.test.ts` | `game/play/notification/hud.test.ts` | TBD | test-only | Planned. |
+| Priorities | `game.play.test.ts` | `game/play/priorities.test.ts` or deeper split | TBD | test-only | Planned. |

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/direct-control-atom-corpus.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/direct-control-atom-corpus.md
@@ -1,0 +1,14 @@
+# Direct-Control Atom Corpus
+
+This ledger is intentionally incomplete until the direct-control atom agent
+report is merged. Do not edit direct-control source against partial rows.
+
+| Atom Candidate | Current Owner | Proposed Owner | Existing Evidence | Runtime Proof | Status |
+|---|---|---|---|---|---|
+| Tuner socket/session/framing | `packages/civ7-direct-control/src/index.ts` and tests | named session/framing modules | existing direct-control tests | not needed for pure move if tests pass | Inventory pending. |
+| Play notification HUD view | `index.ts` | notification/play-view module | CLI notification tests | required only for behavior changes | Inventory pending. |
+| Notification dismissal verification | `index.ts` | notification/dismissal module | CLI exact/queue dismissal tests | required for behavior changes | Inventory pending. |
+| Ready unit/city views | `index.ts` | ready-view modules | CLI ready-unit/ready-city tests | required for behavior changes | Inventory pending. |
+| Operation validation/send/postconditions | `index.ts` | operation modules | CLI operation/unit-target tests | required for mutation behavior changes | Inventory pending. |
+| Tactical/progression/destination reads | `index.ts` | read modules | CLI read tests | read-only live proof when claiming runtime behavior | Inventory pending. |
+| Schemas/types/constants | `index.ts` | schema/type modules | TypeScript/checks | not runtime proof | Inventory pending. |

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/direct-control-atom-corpus.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/direct-control-atom-corpus.md
@@ -1,14 +1,29 @@
 # Direct-Control Atom Corpus
 
-This ledger is intentionally incomplete until the direct-control atom agent
-report is merged. Do not edit direct-control source against partial rows.
+This ledger has the completed direct-control inventory reports merged. It is
+still pre-code planning: do not edit direct-control source until the target atom
+row names exact source ranges, module owner, public/private exports, required
+tests, consumers, and proof class for the slice.
 
-| Atom Candidate | Current Owner | Proposed Owner | Existing Evidence | Runtime Proof | Status |
-|---|---|---|---|---|---|
-| Tuner socket/session/framing | `packages/civ7-direct-control/src/index.ts` and tests | named session/framing modules | existing direct-control tests | not needed for pure move if tests pass | Inventory pending. |
-| Play notification HUD view | `index.ts` | notification/play-view module | CLI notification tests | required only for behavior changes | Inventory pending. |
-| Notification dismissal verification | `index.ts` | notification/dismissal module | CLI exact/queue dismissal tests | required for behavior changes | Inventory pending. |
-| Ready unit/city views | `index.ts` | ready-view modules | CLI ready-unit/ready-city tests | required for behavior changes | Inventory pending. |
-| Operation validation/send/postconditions | `index.ts` | operation modules | CLI operation/unit-target tests | required for mutation behavior changes | Inventory pending. |
-| Tactical/progression/destination reads | `index.ts` | read modules | CLI read tests | read-only live proof when claiming runtime behavior | Inventory pending. |
-| Schemas/types/constants | `index.ts` | schema/type modules | TypeScript/checks | not runtime proof | Inventory pending. |
+| Atom Candidate | Source Region | Proposed Owner | Existing Evidence / Consumers | Required Before Extraction | Runtime Proof | Status |
+|---|---|---|---|---|---|---|
+| Public constants/types/schemas | `index.ts` lines 8-1780: tuner defaults, state names, command constants, API roots, bounds, `Civ7ComponentIdSchema`, runtime probe and play result/input types, operation/postcondition types, capability catalog schemas | `src/primitives/*`, `src/types/*`, `src/constants/*` with package barrel compatibility | Direct package type/check tests; CLI and Studio import public barrel | Inspect protected direct-control TODO stash; add API-shape tests before moves | not runtime proof for type-only extraction | Planned after CLI tests stabilize. |
+| Transport/session/framing | `index.ts` lines 1817-2076 and 3758-3904: config, endpoint discovery, `Civ7DirectControlSession`, state selection, frame encode/parse, socket lifecycle, pending requests | `src/session/{config,error,state,frame,socket,session,execute}.ts` | Direct package tests around health/session/framing; all CLI/Studio consumers through package API | Focused session/framing package suite and unchanged exports | no live proof for pure move; runtime proof for reconnect/state behavior changes | Planned; direct-control owned only. |
+| Runtime command source builders | `index.ts` lines 3909+ and 4714-4847: command builders and embedded JS helpers | `src/runtime-sources/*` and atom-local source modules | Direct package tests often match function names; CLI consumers invoke package wrappers | Exact string/source behavior equivalence tests before moves | runtime proof required for embedded JS behavior changes | Planned; high-risk source surface. |
+| Notification HUD/materialization | Play types around 913-1000, wrapper around 2925, builder around 4714, source around 5119+ | `src/play/notifications/{view,details,decision-hints}.ts` | CLI notification HUD/queue tests; direct package notification tests | Finish CLI HUD extraction and add focused direct-control notification tests | runtime proof for live HUD/source behavior changes | Planned after CLI HUD suite. |
+| Notification dismissal/verification | Types around 1005-1045, wrappers around 2935/2946, source around 7491, polling/identity verification around 10472-10534 | `src/play/notifications/{dismissal,verification}.ts` | CLI exact dismiss and dismiss-queue tests; direct package dismissal tests | Finish exact dismiss CLI extraction; add package verification tests | runtime proof for timing/routes/identity behavior changes | Planned after exact dismiss suite. |
+| Operation validation/send/postconditions | Operation types around 1190-1341, wrappers around 2996-3130, builders 4722/4729, router around 7753, classifiers 10660-11224 | `src/play/operations/{families,validate-request,postconditions,production-choice,chooser-closeouts}.ts` | CLI operation wrappers/unit-target/production/population/progression tests; `game-play-shared.ts` remains CLI-owned | Focused package operation/postcondition tests; preserve approval-first semantics | runtime proof for mutation/postcondition behavior changes | Planned after CLI command surfaces stabilize. |
+| Ready unit/city/move preview | Ready-unit types 1392-1449, move preview 1451-1482, ready-city 1484-1549, wrappers 3313/3328/3344, sources 9094/9343/9481 | `src/play/ready/{unit,city,move-preview}.ts` | CLI ready-unit, ready-city, unit-move-preview suites; direct package tests | Preserve host/port fixture note; add package atom tests before source moves | runtime proof for live read/source behavior changes | Planned. |
+| Tactical/progression/read lenses | Unit target source 8041, settlement 8258, target candidates 8349, battlefield 8637, destination 8927, traditions 4864, progress dashboard 4975 | `src/play/tactical/*` and `src/play/progression/*` | CLI tactical/progression/settlement/unit-target suites; direct package tests | Relationship-label review and proof boundaries before stronger labels | read-only live proof only when claiming runtime behavior | Planned; relationship invariant protected. |
+| Capability catalog and proof/log support | Static entries around 10089, catalog exports 3594/3616, file/log proof helpers 3694-3758 | `src/catalog/*` and `src/proof/*` | Direct package catalog/proof tests and Studio consumers | Source owner and generated-output boundary review | runtime proof only for live proof behavior claims | Planned. |
+
+## Forbidden Owners
+
+- CLI must not own raw socket framing, state discovery, reconnect polling,
+  embedded runtime JS, or postcondition classification.
+- Direct-control must not own CLI flag parsing, compact envelope formatting,
+  batch dismissal policy, or command-specific human guardrail prose.
+- oRPC must compose stable direct-control atoms; it must not fork runtime source
+  strings or define new proof semantics.
+- Effect can be evaluated for transport/stream/fixture mechanics, not introduced
+  as gameplay policy ownership before atom seams exist.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/review-disposition-ledger.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/review-disposition-ledger.md
@@ -2,6 +2,11 @@
 
 | Finding | Source | Severity | Disposition | Evidence |
 |---|---|---:|---|---|
-| Pending CLI topology inventory | peer agent | TBD | Pending | Agent queued from support branch. |
-| Pending direct-control atom inventory | peer agent | TBD | Pending | Agent queued from support branch. |
-| Pending OpenSpec/parallelization review | peer agent | TBD | Pending | Agent queued from support branch. |
+| Full systematic skill absent on old dismiss-queue branch but present in current support stack | `019e8ac1-b9c2-7b22-a1a8-2ef9f8af9e7a` | P2 | Accepted/resolved | Support stack contains `0abccba10` and `66f9af202`; no diff vs `codex/systematic-skill-review-fixes` for the skill directory and README. |
+| Dead authority ref to `docs/projects/civ7-direct-control/workstream/play-agent/hotseat-phase-packet.md` | `019e8ac3-b2ca-7b53-910a-bc6286c4d04b` | P2 | Accepted/repaired | Proposal now cites existing support/control-surface/OpenSpec refs instead of the missing path. |
+| OpenSpec validation state was stale | `019e8ac3-b2ca-7b53-910a-bc6286c4d04b` and `019e8ac9-2938-7a50-87b9-a1915f35d427` | P2 | Accepted/repaired | `bun run openspec -- validate civ7-support-direct-control-modularization --strict` passes in the support worktree; tasks and workstream gate state updated. |
+| Baseline CLI extraction checkboxes could overclaim this OpenSpec change | `019e8ac3-b2ca-7b53-910a-bc6286c4d04b` | P2 | Accepted/repaired | Tasks section 3 now labels 3.1-3.11 as already-landed baseline evidence, not full-change completion. |
+| CLI corpus rows were too thin for implementation | `019e8ac3-b214-7540-a320-309c5f5482ee`, `019e8ac9-2992-73f2-b9dd-0226205390c5` | P1 | Accepted/partially repaired | Remaining monolith owners, exact tests, fixture strategy, and gates folded into `cli-play-corpus.md`; implementation remains blocked until per-slice row status is complete. |
+| Direct-control atom rows were too coarse for source edits | `019e8ac3-b28f-70c2-a98a-60213f5238ec`, `019e8ac9-296c-74a3-9d30-f4e3a4f51545` | P1 | Accepted/partially repaired | Major source regions, proposed owners, forbidden owners, and proof classes folded into `direct-control-atom-corpus.md`; source edits remain blocked. |
+| oRPC authority/source lane is unresolved in current support branch | `019e8ac3-b2ca-7b53-910a-bc6286c4d04b`, `019e8ac9-296c-74a3-9d30-f4e3a4f51545` | P2 | Accepted/deferred | `.agents/skills/civ7-orpc-control-architecture/SKILL.md` is absent here; `codex/civ7-orpc-control-architecture-skill` and `add-control-orpc-*` branches exist. Effect/oRPC stays planning-only until source/skill authority is imported or cited. |
+| Future delegations require durable close-loop discipline | user correction and supervisor `019e8a79-aeee-7dd3-9fd1-1ef616078ef4` | P1 | Accepted/repaired | Workstream record now contains thread ledger with ids, wave, read status, status, and disposition. |

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/review-disposition-ledger.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/review-disposition-ledger.md
@@ -1,0 +1,7 @@
+# Review Disposition Ledger
+
+| Finding | Source | Severity | Disposition | Evidence |
+|---|---|---:|---|---|
+| Pending CLI topology inventory | peer agent | TBD | Pending | Agent queued from support branch. |
+| Pending direct-control atom inventory | peer agent | TBD | Pending | Agent queued from support branch. |
+| Pending OpenSpec/parallelization review | peer agent | TBD | Pending | Agent queued from support branch. |

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -22,6 +22,8 @@
 - Skill import commit: `0abccba10 docs(skills): add systematic workstream skill`
 - Skill review-fix commit:
   `66f9af202 docs(skills): apply systematic workstream review fixes`
+- OpenSpec base commit:
+  `d2c01f03b docs(openspec): add support modularization workstream`
 - Prior test-modularization tip: `4c02bfe71 test(cli): extract dismiss notification queue play tests`
 - Gameplay: parked; no play-thread verification requested.
 
@@ -44,14 +46,19 @@ Treat stash messages and paths as authoritative over indices:
 
 ## Parallel Agent Assignments
 
-- Skill audit agent: find canonical `civ7-systematic-workstream` branch and
-  import boundary.
-- CLI topology agent: enumerate remaining monolith owners, fixtures, and safe
-  extraction order.
-- Direct-control atom agent: enumerate `index.ts` atom candidates, public
-  exports, tests, and runtime-proof boundaries.
-- OpenSpec review agent: audit change shape, lane division, and validation
-  gates.
+All launched report-only threads must be read and dispositioned before their
+topic is treated as closed. Query failure is not absence; use thread ids,
+titles, and parent reports to close the loop.
+
+| Thread id | Title | Wave | Status | Report read | Disposition | Contribution / follow-up |
+|---|---|---|---|---|---|---|
+| `019e8ac1-b9c2-7b22-a1a8-2ef9f8af9e7a` | Audit systematic workstream skill | older pre-framing | completed, archived | yes | Accepted: full reviewed skill is present above `66f9af202`; no new import needed. | Resolves skill-presence blocker; agents parked below `66f9af202` must move upstack. |
+| `019e8ac3-b214-7540-a320-309c5f5482ee` | Inventory CLI play tests | older pre-framing | completed, archived | yes | Accepted as informal inventory; superseded/confirmed by framed CLI thread. | Confirms monolith owners and order: exact dismiss, HUD, priorities. |
+| `019e8ac3-b28f-70c2-a98a-60213f5238ec` | Inspect direct-control atoms | older pre-framing | completed, archived | yes | Accepted as informal inventory; superseded/confirmed by framed direct-control thread. | Seeds atom boundaries, runtime-proof classes, and user TODO stash cautions. |
+| `019e8ac3-b2ca-7b53-910a-bc6286c4d04b` | Plan Civ7 support refactor | older pre-framing | completed, archived | yes | Accepted review findings; concrete P2 blockers recorded in disposition ledger. | Repairs missing authority ref, stale validation state, baseline-task overclaim, and oRPC authority caveat. |
+| `019e8ac9-2992-73f2-b9dd-0226205390c5` | Investigate CLI play topology | framed `/goal` | completed, archived | yes | Accepted as current CLI corpus evidence. | Provides exact test names, fixture strategy, focused/adjacent gates, and relationship-label scans. |
+| `019e8ac9-296c-74a3-9d30-f4e3a4f51545` | Investigate direct-control atoms | framed `/goal` | completed, archived | yes | Accepted as current direct-control corpus evidence; source edits remain blocked. | Provides source regions, proposed owners, forbidden owners, needed tests, and proof boundaries. |
+| `019e8ac9-2938-7a50-87b9-a1915f35d427` | Review OpenSpec workstream | framed `/goal` | completed, archived | yes | Accepted as current pre-code review. | Confirms implementation remains blocked until row detail and single-writer gates are present. |
 
 ## Parallelization Rule
 
@@ -85,9 +92,13 @@ All future agent waves must be framed before delegation:
 
 - Gate 1: framed.
 - Gate 2: repo isolated at skill review-fix commit before draft validation.
-- OpenSpec validation: pending.
-- CLI corpus ledger: pending.
-- Direct-control atom corpus: pending.
-- Review-disposition ledger: pending.
+- OpenSpec validation: passed with
+  `bun run openspec -- validate civ7-support-direct-control-modularization --strict`.
+- CLI corpus ledger: report findings merged for remaining monolith owners; full
+  per-slice rows still need validation/removal status before implementation.
+- Direct-control atom corpus: report findings merged for top-level atom
+  boundaries; exact atom rows still need package-test and source-region proof
+  before source edits.
+- Review-disposition ledger: agent/reviewer findings recorded.
 - Next implementation lane: blocked until corpus ledgers and fixture strategy
   are filled.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -1,0 +1,93 @@
+# Civ7 Support Direct-Control Modularization Workstream
+
+## Frame
+
+- Objective: migrate accumulated Civ7 play-support behavior from monolithic CLI
+  tests and large direct-control source into focused CLI ownership, stable
+  direct-control atoms, and later Effect/oRPC composition over those atoms.
+- Hard core: player-unblocking authority remains available; proof boundaries
+  stay honest; relationship/suzerain labels require official evidence.
+- Exterior: no play-thread wakeups while gameplay is parked; no runtime proof
+  claims from local tests; no transport-first oRPC; no generated-output edits.
+- Falsifier: implementation starts without corpus/task ownership; dirty user
+  notes are committed or lost; monolith coverage is duplicated; direct-control
+  behavior changes without focused tests/proof; relationship labels outrun
+  official evidence.
+
+## Current State
+
+- Worktree:
+  `/Users/mateicanavra/Documents/.nosync/DEV/worktrees/wt-agent-watch-civ7-live-play-reference-assembly`
+- Stack tip when opened: `codex/add-systematic-workstream-skill-to-support-stack`
+- Skill import commit: `0abccba10 docs(skills): add systematic workstream skill`
+- Skill review-fix commit:
+  `66f9af202 docs(skills): apply systematic workstream review fixes`
+- Prior test-modularization tip: `4c02bfe71 test(cli): extract dismiss notification queue play tests`
+- Gameplay: parked; no play-thread verification requested.
+
+## Protected User Notes
+
+Treat stash messages and paths as authoritative over indices:
+
+- `preserve user direct-control modularization note before dismiss queue slice`
+  - `packages/civ7-direct-control/src/index.ts`
+- `preserve user effect stream fixture note before notification queue slice`
+  - `packages/cli/test/commands/fixtures/tuner-socket-server.ts`
+- `preserve user tuner fixture typing note before next play slice`
+  - `packages/cli/test/commands/fixtures/tuner-socket-server.ts`
+- `preserve user deeper play hierarchy note before ready-unit closure`
+  - `packages/cli/test/commands/game/play/NOTE.md`
+- `preserve user host-port fixture note before unit-move closure`
+  - `packages/cli/test/commands/game/play/unit-move-preview.test.ts`
+- `preserve user test-organization note before settlement slice closeout`
+  - `packages/cli/test/commands/NOTE.md`
+
+## Parallel Agent Assignments
+
+- Skill audit agent: find canonical `civ7-systematic-workstream` branch and
+  import boundary.
+- CLI topology agent: enumerate remaining monolith owners, fixtures, and safe
+  extraction order.
+- Direct-control atom agent: enumerate `index.ts` atom candidates, public
+  exports, tests, and runtime-proof boundaries.
+- OpenSpec review agent: audit change shape, lane division, and validation
+  gates.
+
+## Parallelization Rule
+
+Agents may use separate worktrees or a shared visible worktree, but every lane
+must have a disjoint write set before editing. The spec owner coordinates
+Graphite; no lane may restack, submit, or mutate unrelated stacks. `package.json`
+play-script wiring and `packages/cli/test/commands/game.play.test.ts` are
+single-owner files for each active slice.
+
+## Agent Framing Protocol
+
+All future agent waves must be framed before delegation:
+
+- Use framing design to state context, objective, hard core, exterior,
+  falsifier, required skills, evidence expectations, write-set permissions, and
+  return format.
+- Treat agents as peer investigators or implementers with explicit evidence
+  outputs, not generic helpers.
+- Choose reasoning level by task: lower for mechanical inventory, higher for
+  architecture, proof, or synthesis.
+- Include a `/goal` prefix in instructions for long-running investigation or
+  implementation objectives.
+- Prefer fresh agents for new topics.
+- Reuse an existing agent only when its previous context is intentionally useful.
+  If reusing while switching topics, send `/compact`, wait for completion, then
+  send the new framed instruction.
+- State whether the agent is report-only or may mutate files. Mutating agents
+  need disjoint write sets and explicit Graphite constraints.
+
+## Gate State
+
+- Gate 1: framed.
+- Gate 2: repo isolated at skill review-fix commit before draft validation.
+- OpenSpec validation: pending.
+- CLI corpus ledger: pending.
+- Direct-control atom corpus: pending.
+- Review-disposition ledger: pending.
+- Next implementation lane: blocked until corpus ledgers and fixture strategy
+  are filled.


### PR DESCRIPTION
This PR establishes the OpenSpec workstream for systematically migrating accumulated Civ7 play-support behavior out of the monolithic CLI test file and the large `packages/civ7-direct-control/src/index.ts` into focused, reviewable owners.

The migration follows a deliberate three-phase order: CLI play command test ownership first, direct-control atom extraction second, and Effect/oRPC procedure composition third. Each phase is gated on the previous one being stable enough to prove behavior did not change.

The workstream introduces five parallel lanes with disjoint write sets: a spec owner lane that maintains corpus ledgers and Graphite sequencing, a net-new CLI suite lane that creates focused owner files under `packages/cli/test/commands/game/play/**`, a monolith removal lane that removes coverage only after focused suites exist, a direct-control atom planning lane that proposes module boundaries before touching source, and a review/gate lane that audits proof claims and ownership invariants independently.

Eleven CLI test extraction slices that landed before this change (`tactical-read`, `watch`, `topics`, `promotion-readiness`, `rehydrate`, `settlement-recommendations`, `ready-city`, `unit-move-preview`, `ready-unit`, `notification-queue`, `dismiss-notification-queue`) are recorded as baseline evidence. The remaining monolith owners — exact dismiss notification, notification HUD materialization, and priorities — are catalogued with exact test names, fixture strategies, focused/adjacent filter commands, and relationship-label scan requirements.

The direct-control atom corpus maps major source regions in `index.ts` to proposed module owners across session/framing, runtime command sources, notification view/materialization, notification dismissal/verification, operation validation/send/postconditions, ready unit/city/move-preview views, tactical/progression read lenses, and capability catalog/proof support. Source edits in that package remain blocked until focused package tests and exact source-region ownership are recorded per row.

Proof boundaries are kept separate: test-only extraction claims local ownership only, direct-control source movement requires package tests and focused CLI consumers to pass, and mutation-facing runtime behavior requires real-game proof or an explicit `pending-runtime-proof` label. Relationship and city-state labels are treated as neutral unless official relationship, team, war, or suzerain evidence supports a stronger claim.