### PR TITLE
docs(civ7-support-direct-control-modularization): repair stale bridge substrate framing to reflect in-process oRPC/Effect router as shared controller/direct-control/AI substrate

### DIFF
--- a/openspec/changes/civ7-support-direct-control-modularization/design.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/design.md
@@ -40,10 +40,14 @@ strategy/playbook/cookbook generation from human play patterns, and possible
 static native-AI profile shaping. Live play remains routed through
 `@civ7/direct-control`; static native-AI shaping belongs to generated SQL/XML
 profiles. The in-game App UI companion direction is subordinate to
-direct-control: its future shape is a small versioned JSON-envelope RPC such as
-`globalThis.Civ7IntelligenceBridge.invoke(...)`, not a third control plane and
-not the external oRPC boundary. oRPC belongs outside the game at the external
-direct-control boundary. Raw `game exec` remains a diagnostic/probe substrate.
+direct-control: the accepted controller bridge substrate is an in-process
+oRPC/Effect callable router loaded through Civ7 native `scope="game"`
+`UIScripts`. `globalThis.Civ7IntelligenceBridge.invoke(...)` is serialized
+ingress through the existing tuner/App UI command boundary into that router, not
+a hand-maintained App UI method table or ad hoc JSON-envelope product API.
+oRPC/Effect is the shared substrate for the game controller, the external
+direct-control bridge, and future AI services. Raw `game exec` remains a
+diagnostic/probe substrate.
 
 A fuller in-game controller can reduce repeated transport verification only by
 moving proof into lifecycle certification, method allowlists, approval tokens,
@@ -270,7 +274,7 @@ Compatibility matrix seed:
 | Strategy/intelligence ingestion | AI-intelligence database/model layer | stable machine-readable turn state, observations, decisions, action outcomes, playbook/cookbook signals, and proof/telemetry references | do not depend on presentation strings or one-off CLI formatting |
 | Debug/internal service output | direct-control service/debug hierarchy | transport/session state, raw probes, route selection, closeout traces, correlation, and diagnostics | do not expose as normal player-agent or strategy-ingestion output |
 | Operation/proof telemetry | support proof and future procedure middleware | evidence class, approval, validation, send, postcondition, blocker deltas, and runtime observation links | do not claim live/runtime proof from local tests or target-thread evidence alone |
-| Effect/oRPC procedure cores | external direct-control boundary | typed atoms, schemas, context, middleware, approval gates, errors, correlation IDs, and telemetry hooks | do not implement transport-first raw command tunneling |
+| Effect/oRPC procedure cores | shared oRPC/Effect procedure/router substrate over stable direct-control atoms for the in-game controller router, external direct-control bridge, and future AI services | typed atoms, schemas, context, middleware, approval gates, errors, correlation IDs, and telemetry hooks | do not implement transport-first raw command tunneling |
 
 Future atom and envelope rows classify `playerScope`, `consumerClass`,
 `evidenceClass`, `procedureCandidate`, `normalCliProjection`, and
@@ -390,9 +394,11 @@ in-game observations each prove different claims. A later full in-game
 controller can reduce repeated transport verification only by moving proof to
 lifecycle certification, method allowlists, local-player identity, approval
 tokens, and semantic outcome checks; it does not remove proof. If that
-controller exposes an App UI companion bridge, the bridge remains a subordinate
-JSON-envelope endpoint such as `globalThis.Civ7IntelligenceBridge.invoke(...)`;
-oRPC remains outside the game at the external direct-control boundary.
+controller exposes an App UI companion bridge, `Civ7IntelligenceBridge.invoke`
+is only the serialized ingress adapter across the existing tuner/App UI command
+boundary into the in-process oRPC/Effect router. The router/runtime substrate,
+procedure definitions, schemas, policy context, approval checks, proof sinks,
+and future controller internals belong to the shared oRPC/Effect model.
 
 ### Lane H: Review / Gate Lane
 

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -135,12 +135,13 @@
     recorded under 2.9; matrix-row acceptance and source/proof owners for
     hotseat runtime, AI data ingestion, telemetry, CLI semantic output, and
     Effect/oRPC procedures are still unassigned.
-  - App UI companion planning is also blocked from implementation: a possible
-    `globalThis.Civ7IntelligenceBridge.invoke(...)` JSON-envelope RPC remains
-    subordinate to `@civ7/direct-control`, while oRPC stays at the external
-    direct-control boundary. This planning note does not authorize App UI
-    bridge source, transport adapters, AI-ingestion code, or runtime proof
-    claims.
+  - App UI companion planning is also blocked from implementation: the accepted
+    bridge substrate is an in-process oRPC/Effect callable router loaded
+    through Civ7 native `scope="game"` `UIScripts`, with
+    `globalThis.Civ7IntelligenceBridge.invoke(...)` only as serialized ingress
+    through the existing tuner/App UI boundary into that router. This planning
+    note does not authorize controller source, transport adapters,
+    AI-ingestion code, or runtime proof claims.
 
 Implementation tasks in sections 3-5 are blocked until the relevant corpus rows
 name the exact write set, fixture owner, validation commands,
@@ -1149,10 +1150,12 @@ authority are recorded.
 - [ ] 6.8 Ensure procedure-core schemas compose stable direct-control atoms for
       both live hotseat/autoplay control and AI-intelligence data ingestion
       before exposing transport adapters.
-- [ ] 6.9 Keep the in-game App UI companion endpoint subordinate to
-      `@civ7/direct-control` with a small versioned JSON-envelope/RPC shape;
-      keep oRPC at the external direct-control boundary and raw `game exec` as
-      diagnostic/probe substrate only.
+- [ ] 6.9 Plan the in-game controller bridge as an in-process oRPC/Effect
+      callable router loaded through Civ7 native `scope="game"` `UIScripts`;
+      keep `globalThis.Civ7IntelligenceBridge.invoke(...)` as serialized
+      ingress through the existing tuner/App UI boundary into that router, keep
+      raw `game exec` as diagnostic/probe substrate only, and do not create a
+      hand-maintained App UI method table or ad hoc JSON-envelope product API.
 
 ## 7. Verification And Closure
 

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -47,10 +47,10 @@ Global acceptance stop conditions:
   `verified: true`.
 - Stop if Effect/oRPC work starts as a raw command tunnel or transport adapter
   before accepted procedure cores over stable direct-control atoms.
-- Stop if a future App UI companion bridge, such as
-  `globalThis.Civ7IntelligenceBridge.invoke(...)`, becomes the external
-  direct-control boundary or product action authority instead of a subordinate
-  JSON-envelope endpoint under direct-control proof.
+- Stop if a future App UI companion bridge treats
+  `globalThis.Civ7IntelligenceBridge.invoke(...)` as product action authority
+  or an ad hoc JSON-envelope API instead of serialized ingress through the
+  existing tuner/App UI boundary into the in-process oRPC/Effect router.
 
 ## Row Acceptance Intake
 
@@ -260,13 +260,16 @@ Intake rejection conditions:
 - `modelThread`: `019e8b5a-f2ee-7ea2-96bc-8c07dc5ab6cc`
 - `dependencyDirection`: hotseat/autoplay foundation -> AI-intelligence model
 - `surface`: Effect/oRPC procedure cores
-- `primaryConsumer`: external direct-control boundary over stable atoms
+- `primaryConsumer`: shared oRPC/Effect procedure substrate over stable atoms,
+  including the in-game controller router, external direct-control bridge, and
+  future AI services
 - `sourceOwner`: pending procedure-core schema owner
 - `proofOwner`: pending procedure-core schema proof owner
 - `playerScope`: per-procedure; local-player and agent-slot scoped for
   mutation; debug/observer scoped for diagnostics
-- `consumerClass`: Effect/oRPC procedure core; direct-control service boundary;
-  future AI-intelligence and player-agent clients through typed contracts
+- `consumerClass`: Effect/oRPC procedure core; in-game controller service
+  boundary; external direct-control service boundary; future AI-intelligence
+  and player-agent clients through typed contracts
 - `evidenceClass`: repo docs; target-thread evidence; peer reports; local tests
   pending; runtime proof pending for live claims
 - `procedureCandidate`: needs schema/type extraction first
@@ -277,15 +280,18 @@ Intake rejection conditions:
 - `proofLabel`: `pending-procedure-core-schema`
 - `acceptanceStatus`: `pending-procedure-core-schema`; schema owner, proof
   owner, procedure contract, middleware boundary, and tests not assigned
-- `blockingDependents`: tasks 6.1-6.9, transport adapters, procedure middleware,
-  Effect/Bun resource/concurrency implementation, oRPC package behavior
+- `blockingDependents`: tasks 6.1-6.9, in-game controller router modules,
+  transport adapters, procedure middleware, Effect/Bun resource/concurrency
+  implementation, oRPC package behavior
 - `stopCondition`: stop if transport adapters or `packages/civ7-control-orpc`
   behavior appears before testable procedure cores over stable direct-control
-  atoms, if raw command tunneling is used as the architecture, or if an App UI
-  bridge such as `globalThis.Civ7IntelligenceBridge.invoke(...)` becomes the
-  external direct-control substrate instead of a subordinate JSON-envelope
-  endpoint; stop if procedure-core schema work starts before a TypeBox versus
-  Effect Schema disposition records encode/decode, typed-error, oRPC
+  atoms, if raw command tunneling is used as the architecture, if the in-game
+  controller is implemented as a hand-maintained App UI method table or ad hoc
+  JSON-envelope product API, or if
+  `globalThis.Civ7IntelligenceBridge.invoke(...)` is treated as anything other
+  than serialized ingress through the existing tuner/App UI boundary into the
+  in-process oRPC/Effect router; stop if procedure-core schema work starts
+  before a TypeBox versus Effect Schema disposition records encode/decode, typed-error, oRPC
   compatibility, test ergonomics, existing TypeBox coverage, runtime
   validation, duplication cost, migration blast radius, and shared
   internal-service/AI/CLI semantic projection ownership criteria; stop if Zod

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -1,8 +1,9 @@
 # Civ7 Support Direct-Control Modularization Workstream
 
-## Active Watcher Correction - P1 Controller Bridge Substrate
+## Watcher Correction Disposition - P1 Controller Bridge Substrate
 
-Status: active; blocks controller/AI/oRPC planning closure until repaired.
+Status: dispositioned in this support workstream's planning records; still
+planning evidence only and not controller/runtime proof.
 
 The main repo accepted a controller bridge substrate correction at
 `c7111b120e92e80ccc9e944442020d9e1d5674c7`:
@@ -12,23 +13,19 @@ before any downstream bridge, AI-ingestion, semantic CLI, telemetry,
 schema/procedure-core, or Effect/oRPC planning depends on this support
 workstream.
 
-The active support records still contain stale framing that treats
-`globalThis.Civ7IntelligenceBridge.invoke(...)` as a small/custom
-JSON-envelope RPC and keeps oRPC outside the game at the external
-direct-control boundary. The corrected model is: the in-game controller mod API
-is an in-process oRPC/Effect callable router loaded through Civ7 native
-`scope="game"` `UIScripts`; `Civ7IntelligenceBridge.invoke(...)` is serialized
-ingress through the existing tuner/App UI command boundary into that router;
-oRPC/Effect is the shared substrate for the game controller, external
-direct-control bridge, and future AI services.
+This pass repairs the stale support records and records the corrected model:
+the in-game controller mod API is an in-process oRPC/Effect callable router
+loaded through Civ7 native `scope="game"` `UIScripts`;
+`Civ7IntelligenceBridge.invoke(...)` is serialized ingress through the existing
+tuner/App UI command boundary into that router; oRPC/Effect is the shared
+substrate for the game controller, external direct-control bridge, and future
+AI services.
 
-Falsifier paths include `design.md:42-45`, `design.md:393-395`,
-`tasks.md:138-139`, `tasks.md:1127-1129`, this record's prior bridge wording,
-and `compatibility-matrix.md:50-53,263-286`. Repair the records before
-preserving those assumptions in any new commit. This is not a request to
-implement controller source, claim runtime proof, touch the play thread,
-foreground Studio HTTP/RPCLink, add a hand-maintained App UI method table, or
-create an ad hoc JSON-envelope product API.
+This is not a controller implementation, runtime proof, play-thread action,
+Studio HTTP/RPCLink foregrounding, hand-maintained App UI method table, or ad
+hoc JSON-envelope product API. Future controller/AI/oRPC work still needs
+owners, schemas/tests, proof boundaries, and accepted tasks before
+implementation.
 
 ## Frame
 
@@ -247,13 +244,16 @@ id, evidence policy, approval reason, `validation_pre`, `send_receipt`,
 largest design risk is training or acting on vague `verified: true` flags
 instead of explicit outcome evidence.
 
-App UI bridge boundary: target-thread synthesis records a possible subordinate
-in-game JSON-envelope RPC such as `globalThis.Civ7IntelligenceBridge.invoke(...)`
-only as a future companion endpoint under direct-control authority. It is not a
-third control plane, not the oRPC boundary, not product action authority, and
-not a substitute for lifecycle certification, method allowlists, approval
-tokens, local-player/hotseat identity checks, semantic outcome checks, or live
-runtime proof.
+App UI bridge boundary: target-thread synthesis now records
+`globalThis.Civ7IntelligenceBridge.invoke(...)` as serialized ingress through
+the existing tuner/App UI command boundary into an in-process oRPC/Effect
+callable router loaded through Civ7 native `scope="game"` `UIScripts`. It is
+not product action authority, not a hand-maintained App UI method table, not an
+ad hoc JSON-envelope product API, and not a substitute for lifecycle
+certification, method allowlists, approval tokens, local-player/hotseat
+identity checks, semantic outcome checks, or live runtime proof. oRPC/Effect is
+the shared substrate for the game controller, external direct-control bridge,
+and future AI services.
 
 Recommended future intelligence artifacts are `StrategyPlan`,
 `ActionCandidate`, `ProfileRecipe`, `LoadedRowProof`, `RunMetric`, and


### PR DESCRIPTION
This PR applies the P1 controller bridge substrate correction across all stale support planning records in the civ7-support-direct-control-modularization workstream.

The prior records treated `globalThis.Civ7IntelligenceBridge.invoke(...)` as a small custom JSON-envelope RPC and kept oRPC outside the game at the external direct-control boundary. The corrected model, already accepted in the main repo at `c7111b120e92e80ccc9e944442020d9e1d5674c7`, is that the in-game controller mod API is an in-process oRPC/Effect callable router loaded through Civ7 native `scope="game"` `UIScripts`. `Civ7IntelligenceBridge.invoke(...)` is only the serialized ingress adapter across the existing tuner/App UI command boundary into that router. oRPC/Effect is the shared substrate for the game controller, the external direct-control bridge, and future AI services — not a boundary that lives exclusively outside the game.

Specific stale framings repaired:

- `design.md` bridge description and compatibility matrix row updated to reflect the in-process router substrate and shared oRPC/Effect model rather than a hand-maintained App UI method table or ad hoc JSON-envelope product API
- `tasks.md` task 6.9 and the App UI companion planning block rewritten to describe the in-process oRPC/Effect router loaded via `UIScripts` and to prohibit a hand-maintained method table or ad hoc envelope API
- `compatibility-matrix.md` stop condition, `primaryConsumer`, `consumerClass`, `blockingDependents`, and `stopCondition` fields updated to name the in-game controller router as a blocking dependent and to correctly characterize `Civ7IntelligenceBridge.invoke` as serialized ingress rather than product action authority
- `workstream-record.md` watcher correction status updated from active/blocking to dispositioned, stale bridge wording replaced with the corrected model, and the App UI bridge boundary section rewritten accordingly

This is planning record repair only. It does not authorize or implement controller source, transport adapters, AI-ingestion code, runtime proof claims, Studio HTTP/RPCLink foregrounding, or any play-thread action.