### PR TITLE
test(cli): prove compact priorities omit debug internals

### DIFF
--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -123,13 +123,14 @@
         debug-command boundary, AI-ingestion, telemetry, and
         procedure-diagnostic separation proof remains pending before row
         acceptance. Focused `game health --json`, `game inspect --json`,
-        `game inspect --app-ui-snapshot --json`, and `game status --json`
-        coverage now also proves debug-owned commands emit raw readiness,
-        composed playable-status, App UI snapshot, and runtime inspection fields
-        including host/port/state, state discovery, selected state, network/UI/
-        player/map probes, Tuner health globals, own/prototype/enumerable keys,
-        and method owner/length/signature diagnostics, but the row remains
-        pending.
+        `game inspect --app-ui-snapshot --json`, `game status --json`, and
+        `game catalog --static --json` coverage now also proves debug-owned
+        commands emit raw readiness, composed playable-status, App UI snapshot,
+        runtime inspection, and capability catalog provenance fields including
+        host/port/state, state discovery, selected state, network/UI/player/map
+        probes, Tuner health globals, catalog owner/provenance/confidence,
+        own/prototype/enumerable keys, and method owner/length/signature
+        diagnostics, but the row remains pending.
         The semantic CLI player-agent view row now has a draft acceptance
         intake with current `game play` command/test owners from
         `workstream/cli-play-corpus.md` and missing envelope/schema/proof

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -124,12 +124,13 @@
         procedure-diagnostic separation proof remains pending before row
         acceptance. Focused `game health --json`, `game inspect --json`,
         `game inspect --app-ui-snapshot --json`, `game status --json`,
-        `game catalog --static --json`, `game exec --dry-run --json`, and
-        `game visibility --json` coverage now also proves debug-owned commands
-        emit raw readiness, composed playable-status, App UI snapshot, runtime
-        inspection, capability catalog provenance fields, exec dry-run request
-        routing fields, and visibility counts/grid probes including
-        host/port/state, raw command text, state discovery, selected state,
+        `game catalog --static --json`, `game exec --dry-run --json`,
+        `game visibility --json`, and `game restart --dry-run --json` coverage
+        now also proves debug-owned commands emit raw readiness, composed
+        playable-status, App UI snapshot, runtime inspection, capability
+        catalog provenance fields, exec/restart dry-run request routing fields,
+        and visibility counts/grid probes including host/port/state, request
+        id, agent, raw command text, state discovery, selected state,
         network/UI/player/map probes, Tuner health globals, catalog
         owner/provenance/confidence,
         own/prototype/enumerable keys, and method owner/length/signature

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -124,13 +124,14 @@
         procedure-diagnostic separation proof remains pending before row
         acceptance. Focused `game health --json`, `game inspect --json`,
         `game inspect --app-ui-snapshot --json`, `game status --json`,
-        `game catalog --static --json`, and `game exec --dry-run --json`
-        coverage now also proves debug-owned commands emit raw readiness,
-        composed playable-status, App UI snapshot,
-        runtime inspection, capability catalog provenance fields, and exec
-        dry-run request routing fields including host/port/state, raw command
-        text, state discovery, selected state, network/UI/player/map probes,
-        Tuner health globals, catalog owner/provenance/confidence,
+        `game catalog --static --json`, `game exec --dry-run --json`, and
+        `game visibility --json` coverage now also proves debug-owned commands
+        emit raw readiness, composed playable-status, App UI snapshot, runtime
+        inspection, capability catalog provenance fields, exec dry-run request
+        routing fields, and visibility counts/grid probes including
+        host/port/state, raw command text, state discovery, selected state,
+        network/UI/player/map probes, Tuner health globals, catalog
+        owner/provenance/confidence,
         own/prototype/enumerable keys, and method owner/length/signature
         diagnostics, but the row remains pending.
         The semantic CLI player-agent view row now has a draft acceptance

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -122,9 +122,10 @@
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and
         procedure-diagnostic separation proof remains pending before row
-        acceptance. Focused `game inspect --json` coverage now also proves one
-        debug-owned command emits raw runtime inspection fields including
-        host/port/state, own/prototype/enumerable keys, and method
+        acceptance. Focused `game health --json` and `game inspect --json`
+        coverage now also proves debug-owned commands emit raw readiness and
+        runtime inspection fields including host/port/state, state discovery,
+        selected state, own/prototype/enumerable keys, and method
         owner/length/signature diagnostics, but the row remains pending.
         The semantic CLI player-agent view row now has a draft acceptance
         intake with current `game play` command/test owners from

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -121,7 +121,10 @@
         omits raw transport/session/probe/correlation command internals, but
         broader debug-command boundary, AI-ingestion, telemetry, and
         procedure-diagnostic separation proof remains pending before row
-        acceptance.
+        acceptance. Focused `game inspect --json` coverage now also proves one
+        debug-owned command emits raw runtime inspection fields including
+        host/port/state, own/prototype/enumerable keys, and method
+        owner/length/signature diagnostics, but the row remains pending.
         The semantic CLI player-agent view row now has a draft acceptance
         intake with current `game play` command/test owners from
         `workstream/cli-play-corpus.md` and missing envelope/schema/proof

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -117,8 +117,9 @@
         assigned and passing. The planning contract is now recorded in
         `workstream/debug-service-projection-contract.md`, but it does not
         assign source/proof owners or accept the row. Focused compact
-        `game play priorities` and compact `game play ready-city` coverage now
-        prove two normal play projections omit raw
+        `game play priorities`, compact `game play ready-city`, and compact
+        `game play unit-move-preview` coverage now prove three normal play
+        projections omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and
         procedure-diagnostic separation proof remains pending before row

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -117,9 +117,10 @@
         assigned and passing. The planning contract is now recorded in
         `workstream/debug-service-projection-contract.md`, but it does not
         assign source/proof owners or accept the row. Focused compact
-        `game play priorities` coverage now proves one normal play projection
-        omits raw transport/session/probe/correlation command internals, but
-        broader debug-command boundary, AI-ingestion, telemetry, and
+        `game play priorities` and compact `game play ready-city` coverage now
+        prove two normal play projections omit raw
+        transport/session/probe/correlation command internals, but broader
+        debug-command boundary, AI-ingestion, telemetry, and
         procedure-diagnostic separation proof remains pending before row
         acceptance. Focused `game inspect --json` coverage now also proves one
         debug-owned command emits raw runtime inspection fields including

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -118,8 +118,9 @@
         `workstream/debug-service-projection-contract.md`, but it does not
         assign source/proof owners or accept the row. Focused compact
         `game play priorities`, compact `game play ready-city`, and compact
-        `game play unit-move-preview` coverage now prove three normal play
-        projections omit raw
+        `game play unit-move-preview` coverage, now sharing the
+        `game/play/normal-output-boundary.ts` test helper, prove three normal
+        play projections omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and
         procedure-diagnostic separation proof remains pending before row

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -122,11 +122,13 @@
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and
         procedure-diagnostic separation proof remains pending before row
-        acceptance. Focused `game health --json` and `game inspect --json`
-        coverage now also proves debug-owned commands emit raw readiness and
-        runtime inspection fields including host/port/state, state discovery,
-        selected state, own/prototype/enumerable keys, and method
-        owner/length/signature diagnostics, but the row remains pending.
+        acceptance. Focused `game health --json`, `game inspect --json`, and
+        `game status --json` coverage now also proves debug-owned commands emit
+        raw readiness, composed playable-status, and runtime inspection fields
+        including host/port/state, state discovery, selected state, App UI
+        snapshot probes, Tuner health globals, own/prototype/enumerable keys,
+        and method owner/length/signature diagnostics, but the row remains
+        pending.
         The semantic CLI player-agent view row now has a draft acceptance
         intake with current `game play` command/test owners from
         `workstream/cli-play-corpus.md` and missing envelope/schema/proof

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -123,12 +123,14 @@
         debug-command boundary, AI-ingestion, telemetry, and
         procedure-diagnostic separation proof remains pending before row
         acceptance. Focused `game health --json`, `game inspect --json`,
-        `game inspect --app-ui-snapshot --json`, `game status --json`, and
-        `game catalog --static --json` coverage now also proves debug-owned
-        commands emit raw readiness, composed playable-status, App UI snapshot,
-        runtime inspection, and capability catalog provenance fields including
-        host/port/state, state discovery, selected state, network/UI/player/map
-        probes, Tuner health globals, catalog owner/provenance/confidence,
+        `game inspect --app-ui-snapshot --json`, `game status --json`,
+        `game catalog --static --json`, and `game exec --dry-run --json`
+        coverage now also proves debug-owned commands emit raw readiness,
+        composed playable-status, App UI snapshot,
+        runtime inspection, capability catalog provenance fields, and exec
+        dry-run request routing fields including host/port/state, raw command
+        text, state discovery, selected state, network/UI/player/map probes,
+        Tuner health globals, catalog owner/provenance/confidence,
         own/prototype/enumerable keys, and method owner/length/signature
         diagnostics, but the row remains pending.
         The semantic CLI player-agent view row now has a draft acceptance

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -116,7 +116,12 @@
         until normal/debug/AI separation tests and a debug projection owner are
         assigned and passing. The planning contract is now recorded in
         `workstream/debug-service-projection-contract.md`, but it does not
-        assign source/proof owners or accept the row.
+        assign source/proof owners or accept the row. Focused compact
+        `game play priorities` coverage now proves one normal play projection
+        omits raw transport/session/probe/correlation command internals, but
+        broader debug-command boundary, AI-ingestion, telemetry, and
+        procedure-diagnostic separation proof remains pending before row
+        acceptance.
         The semantic CLI player-agent view row now has a draft acceptance
         intake with current `game play` command/test owners from
         `workstream/cli-play-corpus.md` and missing envelope/schema/proof

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -122,11 +122,12 @@
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and
         procedure-diagnostic separation proof remains pending before row
-        acceptance. Focused `game health --json`, `game inspect --json`, and
-        `game status --json` coverage now also proves debug-owned commands emit
-        raw readiness, composed playable-status, and runtime inspection fields
-        including host/port/state, state discovery, selected state, App UI
-        snapshot probes, Tuner health globals, own/prototype/enumerable keys,
+        acceptance. Focused `game health --json`, `game inspect --json`,
+        `game inspect --app-ui-snapshot --json`, and `game status --json`
+        coverage now also proves debug-owned commands emit raw readiness,
+        composed playable-status, App UI snapshot, and runtime inspection fields
+        including host/port/state, state discovery, selected state, network/UI/
+        player/map probes, Tuner health globals, own/prototype/enumerable keys,
         and method owner/length/signature diagnostics, but the row remains
         pending.
         The semantic CLI player-agent view row now has a draft acceptance

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -450,8 +450,11 @@ Intake rejection conditions:
   and operation validation through the package boundary; package proof includes
   `runtime-and-catalog.test.ts` and `session.test.ts`. Focused compact
   `game play priorities` proof now asserts that one normal play projection
-  omits raw transport/session/probe/correlation command internals. Missing
-  proof before acceptance: broader tests proving the raw field classes in
+  omits raw transport/session/probe/correlation command internals. Focused
+  `game inspect --json` proof now asserts that one debug-owned command emits
+  raw runtime inspection fields including host/port/state,
+  own/prototype/enumerable keys, and method owner/length/signature diagnostics.
+  Missing proof before acceptance: broader tests proving the raw field classes in
   `workstream/debug-service-projection-contract.md` are reachable only through
   debug-owned commands, flags, or future debug procedures and are not emitted
   by normal play output or accepted AI-ingestion contracts.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -452,12 +452,13 @@ Intake rejection conditions:
   `game play priorities` and compact `game play ready-city` proof now assert
   that two normal play projections omit raw
   transport/session/probe/correlation command internals. Focused `game health
-  --json`, `game inspect --json`, and `game status --json` proof now assert
-  that debug-owned commands emit raw readiness, composed playable-status, and
-  runtime inspection fields including host/port/state, state discovery,
-  selected state, App UI snapshot probes, Tuner health globals,
-  own/prototype/enumerable keys, and method owner/length/signature diagnostics.
-  Missing proof before acceptance: broader tests proving the raw field classes in
+  --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`, and
+  `game status --json` proof now assert that debug-owned commands emit raw
+  readiness, composed playable-status, App UI snapshot, and runtime inspection
+  fields including host/port/state, state discovery, selected state,
+  network/UI/player/map probes, Tuner health globals, own/prototype/enumerable
+  keys, and method owner/length/signature diagnostics. Missing proof before
+  acceptance: broader tests proving the raw field classes in
   `workstream/debug-service-projection-contract.md` are reachable only through
   debug-owned commands, flags, or future debug procedures and are not emitted
   by normal play output or accepted AI-ingestion contracts.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -453,12 +453,14 @@ Intake rejection conditions:
   that two normal play projections omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
-  `game status --json`, and `game catalog --static --json` proof now assert
-  that debug-owned commands emit raw readiness, composed playable-status, App UI
-  snapshot, runtime inspection, and capability catalog provenance fields
-  including host/port/state, state discovery, selected state, network/UI/player/
-  map probes, Tuner health globals, catalog owner/provenance/confidence,
-  own/prototype/enumerable keys, and method owner/length/signature diagnostics.
+  `game status --json`, `game catalog --static --json`, and
+  `game exec --dry-run --json` proof now assert that debug-owned commands emit
+  raw readiness, composed playable-status, App UI snapshot, runtime inspection,
+  capability catalog provenance fields, and explicit exec dry-run request
+  routing fields including host/port/state, raw command text, state discovery,
+  selected state, network/UI/player/map probes, Tuner health globals, catalog
+  owner/provenance/confidence, own/prototype/enumerable keys, and method
+  owner/length/signature diagnostics.
   Missing proof before acceptance: broader tests proving the raw field classes in
   `workstream/debug-service-projection-contract.md` are reachable only through
   debug-owned commands, flags, or future debug procedures and are not emitted

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -451,11 +451,12 @@ Intake rejection conditions:
   `runtime-and-catalog.test.ts` and `session.test.ts`. Focused compact
   `game play priorities` and compact `game play ready-city` proof now assert
   that two normal play projections omit raw
-  transport/session/probe/correlation command internals. Focused `game inspect
-  --json` proof now asserts that one debug-owned command emits raw runtime
-  inspection fields including host/port/state, own/prototype/enumerable keys,
-  and method owner/length/signature diagnostics. Missing proof before
-  acceptance: broader tests proving the raw field classes in
+  transport/session/probe/correlation command internals. Focused `game health
+  --json` and `game inspect --json` proof now assert that debug-owned commands
+  emit raw readiness and runtime inspection fields including host/port/state,
+  state discovery, selected state, own/prototype/enumerable keys, and method
+  owner/length/signature diagnostics. Missing proof before acceptance: broader
+  tests proving the raw field classes in
   `workstream/debug-service-projection-contract.md` are reachable only through
   debug-owned commands, flags, or future debug procedures and are not emitted
   by normal play output or accepted AI-ingestion contracts.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -453,14 +453,15 @@ Intake rejection conditions:
   that two normal play projections omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
-  `game status --json`, `game catalog --static --json`, and
-  `game exec --dry-run --json` proof now assert that debug-owned commands emit
-  raw readiness, composed playable-status, App UI snapshot, runtime inspection,
-  capability catalog provenance fields, and explicit exec dry-run request
-  routing fields including host/port/state, raw command text, state discovery,
-  selected state, network/UI/player/map probes, Tuner health globals, catalog
-  owner/provenance/confidence, own/prototype/enumerable keys, and method
-  owner/length/signature diagnostics.
+  `game status --json`, `game catalog --static --json`,
+  `game exec --dry-run --json`, and `game visibility --json` proof now assert
+  that debug-owned commands emit raw readiness, composed playable-status, App UI
+  snapshot, runtime inspection, capability catalog provenance fields, explicit
+  exec dry-run request routing fields, and visibility counts/grid probes
+  including host/port/state, raw command text, state discovery, selected state,
+  network/UI/player/map probes, Tuner health globals, catalog
+  owner/provenance/confidence, visibility revealed/visible counts, grid states,
+  own/prototype/enumerable keys, and method owner/length/signature diagnostics.
   Missing proof before acceptance: broader tests proving the raw field classes in
   `workstream/debug-service-projection-contract.md` are reachable only through
   debug-owned commands, flags, or future debug procedures and are not emitted

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -449,8 +449,9 @@ Intake rejection conditions:
   App UI snapshot, playable status, map/GameInfo reads, AI loaded-lever reads,
   and operation validation through the package boundary; package proof includes
   `runtime-and-catalog.test.ts` and `session.test.ts`. Focused compact
-  `game play priorities` and compact `game play ready-city` proof now assert
-  that two normal play projections omit raw
+  `game play priorities`, compact `game play ready-city`, and compact
+  `game play unit-move-preview` proof now assert that three normal play
+  projections omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -448,8 +448,10 @@ Intake rejection conditions:
   `game.control.test.ts` coverage for health diagnostics, runtime inspection,
   App UI snapshot, playable status, map/GameInfo reads, AI loaded-lever reads,
   and operation validation through the package boundary; package proof includes
-  `runtime-and-catalog.test.ts` and `session.test.ts`. Missing proof before
-  acceptance: tests proving the raw field classes in
+  `runtime-and-catalog.test.ts` and `session.test.ts`. Focused compact
+  `game play priorities` proof now asserts that one normal play projection
+  omits raw transport/session/probe/correlation command internals. Missing
+  proof before acceptance: broader tests proving the raw field classes in
   `workstream/debug-service-projection-contract.md` are reachable only through
   debug-owned commands, flags, or future debug procedures and are not emitted
   by normal play output or accepted AI-ingestion contracts.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -452,13 +452,14 @@ Intake rejection conditions:
   `game play priorities` and compact `game play ready-city` proof now assert
   that two normal play projections omit raw
   transport/session/probe/correlation command internals. Focused `game health
-  --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`, and
-  `game status --json` proof now assert that debug-owned commands emit raw
-  readiness, composed playable-status, App UI snapshot, and runtime inspection
-  fields including host/port/state, state discovery, selected state,
-  network/UI/player/map probes, Tuner health globals, own/prototype/enumerable
-  keys, and method owner/length/signature diagnostics. Missing proof before
-  acceptance: broader tests proving the raw field classes in
+  --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
+  `game status --json`, and `game catalog --static --json` proof now assert
+  that debug-owned commands emit raw readiness, composed playable-status, App UI
+  snapshot, runtime inspection, and capability catalog provenance fields
+  including host/port/state, state discovery, selected state, network/UI/player/
+  map probes, Tuner health globals, catalog owner/provenance/confidence,
+  own/prototype/enumerable keys, and method owner/length/signature diagnostics.
+  Missing proof before acceptance: broader tests proving the raw field classes in
   `workstream/debug-service-projection-contract.md` are reachable only through
   debug-owned commands, flags, or future debug procedures and are not emitted
   by normal play output or accepted AI-ingestion contracts.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -452,11 +452,12 @@ Intake rejection conditions:
   `game play priorities` and compact `game play ready-city` proof now assert
   that two normal play projections omit raw
   transport/session/probe/correlation command internals. Focused `game health
-  --json` and `game inspect --json` proof now assert that debug-owned commands
-  emit raw readiness and runtime inspection fields including host/port/state,
-  state discovery, selected state, own/prototype/enumerable keys, and method
-  owner/length/signature diagnostics. Missing proof before acceptance: broader
-  tests proving the raw field classes in
+  --json`, `game inspect --json`, and `game status --json` proof now assert
+  that debug-owned commands emit raw readiness, composed playable-status, and
+  runtime inspection fields including host/port/state, state discovery,
+  selected state, App UI snapshot probes, Tuner health globals,
+  own/prototype/enumerable keys, and method owner/length/signature diagnostics.
+  Missing proof before acceptance: broader tests proving the raw field classes in
   `workstream/debug-service-projection-contract.md` are reachable only through
   debug-owned commands, flags, or future debug procedures and are not emitted
   by normal play output or accepted AI-ingestion contracts.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -450,8 +450,9 @@ Intake rejection conditions:
   and operation validation through the package boundary; package proof includes
   `runtime-and-catalog.test.ts` and `session.test.ts`. Focused compact
   `game play priorities`, compact `game play ready-city`, and compact
-  `game play unit-move-preview` proof now assert that three normal play
-  projections omit raw
+  `game play unit-move-preview` proof now assert through the shared
+  `packages/cli/test/commands/game/play/normal-output-boundary.ts` helper that
+  three normal play projections omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -454,12 +454,13 @@ Intake rejection conditions:
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,
-  `game exec --dry-run --json`, and `game visibility --json` proof now assert
-  that debug-owned commands emit raw readiness, composed playable-status, App UI
-  snapshot, runtime inspection, capability catalog provenance fields, explicit
-  exec dry-run request routing fields, and visibility counts/grid probes
-  including host/port/state, raw command text, state discovery, selected state,
-  network/UI/player/map probes, Tuner health globals, catalog
+  `game exec --dry-run --json`, `game visibility --json`, and
+  `game restart --dry-run --json` proof now assert that debug-owned commands
+  emit raw readiness, composed playable-status, App UI snapshot, runtime
+  inspection, capability catalog provenance fields, explicit exec/restart
+  dry-run request routing fields, and visibility counts/grid probes including
+  host/port/state, request id, agent, raw command text, state discovery,
+  selected state, network/UI/player/map probes, Tuner health globals, catalog
   owner/provenance/confidence, visibility revealed/visible counts, grid states,
   own/prototype/enumerable keys, and method owner/length/signature diagnostics.
   Missing proof before acceptance: broader tests proving the raw field classes in

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -449,12 +449,13 @@ Intake rejection conditions:
   App UI snapshot, playable status, map/GameInfo reads, AI loaded-lever reads,
   and operation validation through the package boundary; package proof includes
   `runtime-and-catalog.test.ts` and `session.test.ts`. Focused compact
-  `game play priorities` proof now asserts that one normal play projection
-  omits raw transport/session/probe/correlation command internals. Focused
-  `game inspect --json` proof now asserts that one debug-owned command emits
-  raw runtime inspection fields including host/port/state,
-  own/prototype/enumerable keys, and method owner/length/signature diagnostics.
-  Missing proof before acceptance: broader tests proving the raw field classes in
+  `game play priorities` and compact `game play ready-city` proof now assert
+  that two normal play projections omit raw
+  transport/session/probe/correlation command internals. Focused `game inspect
+  --json` proof now asserts that one debug-owned command emits raw runtime
+  inspection fields including host/port/state, own/prototype/enumerable keys,
+  and method owner/length/signature diagnostics. Missing proof before
+  acceptance: broader tests proving the raw field classes in
   `workstream/debug-service-projection-contract.md` are reachable only through
   debug-owned commands, flags, or future debug procedures and are not emitted
   by normal play output or accepted AI-ingestion contracts.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -48,10 +48,14 @@ Debug/internal service projection partial proof: completed as a narrow
 normal/debug separation test over compact `game play priorities` output. The
 focused CLI test now asserts that the normal play projection omits raw
 transport/session/probe/correlation command internals while preserving the
-existing compact player-agent priority summary. This reduces the
-debug/internal service row proof gap but does not accept Task 2.9.4, assign a
-debug projection owner, prove AI-ingestion or telemetry separation, implement
-debug/service hierarchy, or claim runtime/live-game proof.
+existing compact player-agent priority summary. Follow-up focused
+`game inspect --json` proof now asserts that a debug-owned command emits raw
+runtime inspection fields including host/port/state,
+own/prototype/enumerable keys, and method owner/length/signature diagnostics.
+These reduce the debug/internal service row proof gap but do not accept Task
+2.9.4, assign a debug projection owner, prove AI-ingestion or telemetry
+separation, implement debug/service hierarchy, or claim runtime/live-game
+proof.
 
 ## Current State
 

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -2898,6 +2898,15 @@ All future agent waves must be framed before delegation:
   runtime/live-game proof, create telemetry or AI-ingestion contracts, or
   unblock normal CLI semantic envelopes, hotseat runtime, schema migration, or
   Effect/oRPC procedure-core work.
+- Exec dry-run debug proof increment:
+  focused `game exec --dry-run --json` coverage now proves the debug-owned exec
+  command can emit raw request routing fields, including raw command text,
+  hosts, port, and state, without sending to the tuner socket. This remains
+  partial local CLI proof for the Debug/Internal Service Output row only; it
+  does not accept Task 2.9.4, claim runtime/live-game proof, create telemetry
+  or AI-ingestion contracts, promote raw command strings to product authority,
+  or unblock normal CLI semantic envelopes, hotseat runtime, schema migration,
+  or Effect/oRPC procedure-core work.
 - Operation/proof telemetry contract planning:
   `workstream/operation-proof-telemetry-contract.md` now records the planned
   action/proof telemetry record slots, projection boundaries, proof-class

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -2871,6 +2871,15 @@ All future agent waves must be framed before delegation:
   AI-ingestion contract, assign source/proof owners, or unblock normal CLI
   semantic envelopes, hotseat runtime, schema migration, or Effect/oRPC
   procedure-core implementation.
+- Debug projection proof increment:
+  focused `game status --json` coverage now joins `game health --json` and
+  `game inspect --json` in proving that debug-owned commands can emit raw
+  host/port/state, composed playable status, App UI snapshot probes, Tuner
+  health globals, and runtime inspection diagnostics. This remains partial
+  local CLI/package proof for the Debug/Internal Service Output row only; it
+  does not accept Task 2.9.4, claim runtime/live-game proof, create telemetry
+  or AI-ingestion contracts, or unblock normal CLI semantic envelopes,
+  hotseat runtime, schema migration, or Effect/oRPC procedure-core work.
 - Operation/proof telemetry contract planning:
   `workstream/operation-proof-telemetry-contract.md` now records the planned
   action/proof telemetry record slots, projection boundaries, proof-class

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -48,14 +48,16 @@ Debug/internal service projection partial proof: completed as a narrow
 normal/debug separation test over compact `game play priorities` output. The
 focused CLI test now asserts that the normal play projection omits raw
 transport/session/probe/correlation command internals while preserving the
-existing compact player-agent priority summary. Follow-up focused
-`game inspect --json` proof now asserts that a debug-owned command emits raw
-runtime inspection fields including host/port/state,
-own/prototype/enumerable keys, and method owner/length/signature diagnostics.
-These reduce the debug/internal service row proof gap but do not accept Task
-2.9.4, assign a debug projection owner, prove AI-ingestion or telemetry
-separation, implement debug/service hierarchy, or claim runtime/live-game
-proof.
+existing compact player-agent priority summary. Follow-up compact
+`game play ready-city` proof now asserts that another normal play projection
+omits those same raw internals while preserving the player-agent city decision
+summary. Follow-up focused `game inspect --json` proof now asserts that a
+debug-owned command emits raw runtime inspection fields including
+host/port/state, own/prototype/enumerable keys, and method
+owner/length/signature diagnostics. These reduce the debug/internal service row
+proof gap but do not accept Task 2.9.4, assign a debug projection owner, prove
+AI-ingestion or telemetry separation, implement debug/service hierarchy, or
+claim runtime/live-game proof.
 
 ## Current State
 

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -2936,6 +2936,15 @@ All future agent waves must be framed before delegation:
   create telemetry or AI-ingestion contracts, promote raw debug fields to
   product output, or unblock normal CLI semantic envelopes, hotseat runtime,
   schema migration, or Effect/oRPC procedure-core work.
+- Normal-output boundary test-helper ownership:
+  `packages/cli/test/commands/game/play/normal-output-boundary.ts` now owns the
+  shared compact play projection marker-omission assertion used by priorities,
+  ready-city, and unit-move-preview proof. This removes duplicated marker lists
+  from focused tests and gives later normal/debug separation proof a named test
+  helper, but it remains local CLI test-helper ownership only: it does not
+  accept Task 2.9.4, assign a production source owner, claim runtime/live-game
+  proof, implement semantic envelopes, create telemetry or AI-ingestion
+  contracts, or unblock Effect/oRPC procedure-core work.
 - Operation/proof telemetry contract planning:
   `workstream/operation-proof-telemetry-contract.md` now records the planned
   action/proof telemetry record slots, projection boundaries, proof-class

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -44,6 +44,15 @@ implementation.
   transport/proof internals as normal play output; relationship labels outrun
   official evidence.
 
+Debug/internal service projection partial proof: completed as a narrow
+normal/debug separation test over compact `game play priorities` output. The
+focused CLI test now asserts that the normal play projection omits raw
+transport/session/probe/correlation command internals while preserving the
+existing compact player-agent priority summary. This reduces the
+debug/internal service row proof gap but does not accept Task 2.9.4, assign a
+debug projection owner, prove AI-ingestion or telemetry separation, implement
+debug/service hierarchy, or claim runtime/live-game proof.
+
 ## Current State
 
 - Worktree:

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -2926,6 +2926,16 @@ All future agent waves must be framed before delegation:
   telemetry or AI-ingestion contracts, promote raw command strings to product
   authority, or unblock normal CLI semantic envelopes, hotseat runtime, schema
   migration, or Effect/oRPC procedure-core work.
+- Unit-move compact normal-output boundary proof increment:
+  focused `game play unit-move-preview --compact --json` coverage now proves a
+  third normal player-agent projection omits raw transport/session/probe,
+  correlation, closeout, and command-internal markers while preserving the
+  compact official movement-preview fields and neutral relationship policy.
+  This remains partial local CLI proof for the Debug/Internal Service Output
+  row only; it does not accept Task 2.9.4, claim runtime/live-game proof,
+  create telemetry or AI-ingestion contracts, promote raw debug fields to
+  product output, or unblock normal CLI semantic envelopes, hotseat runtime,
+  schema migration, or Effect/oRPC procedure-core work.
 - Operation/proof telemetry contract planning:
   `workstream/operation-proof-telemetry-contract.md` now records the planned
   action/proof telemetry record slots, projection boundaries, proof-class

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -2880,6 +2880,15 @@ All future agent waves must be framed before delegation:
   does not accept Task 2.9.4, claim runtime/live-game proof, create telemetry
   or AI-ingestion contracts, or unblock normal CLI semantic envelopes,
   hotseat runtime, schema migration, or Effect/oRPC procedure-core work.
+- App UI snapshot debug proof increment:
+  focused `game inspect --app-ui-snapshot --json` coverage now proves the
+  debug-owned inspect command emits the package-owned raw App UI snapshot shape,
+  including host/port/state, network, UI, game, player, and map probes. This
+  remains partial local CLI/package proof for the Debug/Internal Service Output
+  row only; it does not accept Task 2.9.4, claim runtime/live-game proof,
+  create telemetry or AI-ingestion contracts, or unblock normal CLI semantic
+  envelopes, hotseat runtime, schema migration, or Effect/oRPC procedure-core
+  work.
 - Operation/proof telemetry contract planning:
   `workstream/operation-proof-telemetry-contract.md` now records the planned
   action/proof telemetry record slots, projection boundaries, proof-class

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -2889,6 +2889,15 @@ All future agent waves must be framed before delegation:
   create telemetry or AI-ingestion contracts, or unblock normal CLI semantic
   envelopes, hotseat runtime, schema migration, or Effect/oRPC procedure-core
   work.
+- Capability catalog debug proof increment:
+  focused `game catalog --static --json` coverage now proves the debug-owned
+  catalog command emits raw package capability provenance fields, including
+  owner, risk, provenance, confidence, wrapper, and GameInfo table source
+  evidence. This remains partial local CLI/package proof for the Debug/Internal
+  Service Output row only; it does not accept Task 2.9.4, claim
+  runtime/live-game proof, create telemetry or AI-ingestion contracts, or
+  unblock normal CLI semantic envelopes, hotseat runtime, schema migration, or
+  Effect/oRPC procedure-core work.
 - Operation/proof telemetry contract planning:
   `workstream/operation-proof-telemetry-contract.md` now records the planned
   action/proof telemetry record slots, projection boundaries, proof-class

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -2907,6 +2907,15 @@ All future agent waves must be framed before delegation:
   or AI-ingestion contracts, promote raw command strings to product authority,
   or unblock normal CLI semantic envelopes, hotseat runtime, schema migration,
   or Effect/oRPC procedure-core work.
+- Visibility debug proof increment:
+  focused `game visibility --json` coverage now proves the debug-owned
+  visibility command emits raw visibility summary fields, including
+  host/port/state, revealed/visible counts, bounds, grid states, and omitted
+  count. This remains partial local CLI/package proof for the Debug/Internal
+  Service Output row only; it does not exercise reveal mutation, accept Task
+  2.9.4, claim runtime/live-game proof, create telemetry or AI-ingestion
+  contracts, or unblock normal CLI semantic envelopes, hotseat runtime, schema
+  migration, or Effect/oRPC procedure-core work.
 - Operation/proof telemetry contract planning:
   `workstream/operation-proof-telemetry-contract.md` now records the planned
   action/proof telemetry record slots, projection boundaries, proof-class

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -51,13 +51,14 @@ transport/session/probe/correlation command internals while preserving the
 existing compact player-agent priority summary. Follow-up compact
 `game play ready-city` proof now asserts that another normal play projection
 omits those same raw internals while preserving the player-agent city decision
-summary. Follow-up focused `game inspect --json` proof now asserts that a
-debug-owned command emits raw runtime inspection fields including
-host/port/state, own/prototype/enumerable keys, and method
-owner/length/signature diagnostics. These reduce the debug/internal service row
-proof gap but do not accept Task 2.9.4, assign a debug projection owner, prove
-AI-ingestion or telemetry separation, implement debug/service hierarchy, or
-claim runtime/live-game proof.
+summary. Follow-up focused `game health --json` and `game inspect --json`
+proof now asserts that debug-owned commands emit raw readiness and runtime
+inspection fields including host/port/state, state discovery, selected state,
+own/prototype/enumerable keys, and method owner/length/signature diagnostics.
+These reduce the debug/internal service row proof gap but do not accept Task
+2.9.4, assign a debug projection owner, prove AI-ingestion or telemetry
+separation, implement debug/service hierarchy, or claim runtime/live-game
+proof.
 
 ## Current State
 

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -2916,6 +2916,16 @@ All future agent waves must be framed before delegation:
   2.9.4, claim runtime/live-game proof, create telemetry or AI-ingestion
   contracts, or unblock normal CLI semantic envelopes, hotseat runtime, schema
   migration, or Effect/oRPC procedure-core work.
+- Restart dry-run debug proof increment:
+  focused `game restart --dry-run --json` coverage now proves the
+  support/lifecycle restart command emits raw dry-run request routing fields,
+  including request id, agent, host/port/state, and the restart command text,
+  without sending to the tuner socket. This remains partial local CLI proof for
+  the Debug/Internal Service Output row only; it does not exercise restart or
+  begin-game mutation, accept Task 2.9.4, claim runtime/live-game proof, create
+  telemetry or AI-ingestion contracts, promote raw command strings to product
+  authority, or unblock normal CLI semantic envelopes, hotseat runtime, schema
+  migration, or Effect/oRPC procedure-core work.
 - Operation/proof telemetry contract planning:
   `workstream/operation-proof-telemetry-contract.md` now records the planned
   action/proof telemetry record slots, projection boundaries, proof-class

--- a/packages/cli/test/commands/game.control.test.ts
+++ b/packages/cli/test/commands/game.control.test.ts
@@ -5,6 +5,7 @@ import GameExec from '../../src/commands/game/exec';
 import GameHealth from '../../src/commands/game/health';
 import GameInspect from '../../src/commands/game/inspect';
 import GameStatus from '../../src/commands/game/status';
+import GameCatalog from '../../src/commands/game/catalog';
 import GameMap from '../../src/commands/game/map';
 import GameGameInfo from '../../src/commands/game/gameinfo';
 import GameAiLoadedLevers from '../../src/commands/game/ai/loaded-levers';
@@ -373,6 +374,62 @@ describe('game direct-control commands', () => {
     } finally {
       log.mockRestore();
       await server.close();
+    }
+  });
+
+  test('prints the static capability catalog debug projection', async () => {
+    const writes: string[] = [];
+    const log = vi.spyOn(GameCatalog.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
+    try {
+      await GameCatalog.run(['--static', '--json']);
+
+      const payload = JSON.parse(writes.join('')) as {
+        ok: true;
+        catalog: {
+          source: string;
+          version: string;
+          entries: Array<{
+            id: string;
+            kind: string;
+            role: string;
+            owner: string;
+            risk: string;
+            provenance: string[];
+            confidence: string;
+            wrapper?: string;
+          }>;
+        };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.catalog).toMatchObject({
+        source: 'static',
+        version: 'direct-control-v1',
+      });
+      expect(payload.catalog.entries).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          id: 'wrapper.playable-status',
+          kind: 'read-wrapper',
+          role: 'shared',
+          owner: '@civ7/direct-control',
+          risk: 'read',
+          provenance: ['getCiv7AppUiSnapshot', 'checkCiv7TunerHealth'],
+          confidence: 'runtime',
+          wrapper: 'getCiv7PlayableStatus',
+        }),
+        expect.objectContaining({
+          id: 'gameinfo.Resources',
+          kind: 'gameinfo-table',
+          role: 'tuner',
+          owner: '@civ7/direct-control',
+          risk: 'read',
+          provenance: ['DEFAULT_CIV7_GAMEINFO_TABLES', 'capability-inventory'],
+          confidence: 'source',
+        }),
+      ]));
+    } finally {
+      log.mockRestore();
     }
   });
 

--- a/packages/cli/test/commands/game.control.test.ts
+++ b/packages/cli/test/commands/game.control.test.ts
@@ -8,6 +8,7 @@ import GameStatus from '../../src/commands/game/status';
 import GameCatalog from '../../src/commands/game/catalog';
 import GameMap from '../../src/commands/game/map';
 import GameGameInfo from '../../src/commands/game/gameinfo';
+import GameVisibility from '../../src/commands/game/visibility';
 import GameAiLoadedLevers from '../../src/commands/game/ai/loaded-levers';
 import GameOperation from '../../src/commands/game/operation';
 
@@ -476,6 +477,75 @@ describe('game direct-control commands', () => {
     }
   });
 
+  test('prints visibility summary as debug projection', async () => {
+    const server = await startTunerServer();
+    const writes: string[] = [];
+    const log = vi.spyOn(GameVisibility.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
+    try {
+      const { port } = server.address();
+      await GameVisibility.run([
+        '--host',
+        '127.0.0.1',
+        '--port',
+        String(port),
+        '--player-id',
+        '0',
+        '--bounds',
+        '0,0,2,1',
+        '--json',
+      ]);
+
+      expect(server.received.some((message) => message.includes('GameplayMap.getRevealedState'))).toBe(true);
+      const payload = JSON.parse(writes.join('')) as {
+        ok: true;
+        result: {
+          host: string;
+          port: number;
+          state: { id: string; name: string };
+          playerId: number;
+          numPlotsRevealed: { ok: true; value: number };
+          numPlotsVisible: { ok: true; value: number };
+          counts: Record<string, number>;
+          grid?: {
+            bounds: { x: number; y: number; width: number; height: number };
+            plotCount: number;
+            omitted: number;
+            states: Array<{
+              x: number;
+              y: number;
+              state: { ok: true; value: number };
+              visible: { ok: true; value: boolean };
+            }>;
+          };
+        };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.result).toMatchObject({
+        host: '127.0.0.1',
+        port,
+        state: { id: '1', name: 'Tuner' },
+        playerId: 0,
+        numPlotsRevealed: { ok: true, value: 10 },
+        numPlotsVisible: { ok: true, value: 8 },
+        counts: { '1': 2 },
+        grid: {
+          bounds: { x: 0, y: 0, width: 2, height: 1 },
+          plotCount: 2,
+          omitted: 0,
+          states: [
+            { x: 0, y: 0, state: { ok: true, value: 1 }, visible: { ok: true, value: true } },
+            { x: 1, y: 0, state: { ok: true, value: 1 }, visible: { ok: true, value: false } },
+          ],
+        },
+      });
+    } finally {
+      log.mockRestore();
+      await server.close();
+    }
+  });
+
   test('reads bounded map and GameInfo surfaces', async () => {
     const server = await startTunerServer();
     try {
@@ -659,6 +729,36 @@ async function startTunerServer() {
                   resource: { ok: true, value: -1 },
                   revealedState: { ok: true, value: 1 },
                   visible: { ok: true, value: true },
+                },
+              }),
+            ])
+          );
+        } else if (frame.message.includes('GameplayMap.getRevealedState')) {
+          socket.write(
+            encodeResponse(frame.listenerId, [
+              JSON.stringify({
+                playerId: 0,
+                numPlotsRevealed: { ok: true, value: 10 },
+                numPlotsVisible: { ok: true, value: 8 },
+                counts: { '1': 2 },
+                grid: {
+                  bounds: { x: 0, y: 0, width: 2, height: 1 },
+                  plotCount: 2,
+                  omitted: 0,
+                  states: [
+                    {
+                      x: 0,
+                      y: 0,
+                      state: { ok: true, value: 1 },
+                      visible: { ok: true, value: true },
+                    },
+                    {
+                      x: 1,
+                      y: 0,
+                      state: { ok: true, value: 1 },
+                      visible: { ok: true, value: false },
+                    },
+                  ],
                 },
               }),
             ])

--- a/packages/cli/test/commands/game.control.test.ts
+++ b/packages/cli/test/commands/game.control.test.ts
@@ -106,6 +106,10 @@ describe('game direct-control commands', () => {
 
   test('inspects runtime API roots in a selected state', async () => {
     const server = await startTunerServer();
+    const writes: string[] = [];
+    const log = vi.spyOn(GameInspect.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
     try {
       const { port } = server.address();
       await GameInspect.run([
@@ -121,7 +125,47 @@ describe('game direct-control commands', () => {
       ]);
 
       expect(server.received).toEqual(['LSQ:', expect.stringContaining('CMD:65535:(() =>')]);
+      const payload = JSON.parse(writes.join('')) as {
+        ok: true;
+        inspection: {
+          host: string;
+          port: number;
+          state: { id: string; name: string };
+          roots: Array<{
+            name: string;
+            ownKeys: string[];
+            prototypeKeys: string[];
+            enumerableKeys: string[];
+            methods: Array<{
+              name: string;
+              owner: string;
+              length: number;
+              signature: string;
+            }>;
+          }>;
+        };
+      };
+      expect(payload.inspection).toMatchObject({
+        host: '127.0.0.1',
+        port,
+        state: { id: '65535', name: 'App UI' },
+      });
+      expect(payload.inspection.roots[0]).toMatchObject({
+        name: 'Network',
+        ownKeys: ['isInSession'],
+        prototypeKeys: ['restartGame'],
+        enumerableKeys: ['isInSession', 'restartGame'],
+        methods: [
+          {
+            name: 'restartGame',
+            owner: 'prototype',
+            length: 0,
+            signature: 'function restartGame() { [native code] }',
+          },
+        ],
+      });
     } finally {
+      log.mockRestore();
       await server.close();
     }
   });

--- a/packages/cli/test/commands/game.control.test.ts
+++ b/packages/cli/test/commands/game.control.test.ts
@@ -24,6 +24,49 @@ describe('game direct-control commands', () => {
     }
   });
 
+  test('prints exec dry-run request routing as debug projection', async () => {
+    const writes: string[] = [];
+    const log = vi.spyOn(GameExec.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
+    try {
+      await GameExec.run([
+        'Network.restartGame()',
+        '--host',
+        '127.0.0.1',
+        '--port',
+        '4318',
+        '--state',
+        'App UI',
+        '--dry-run',
+        '--json',
+      ]);
+
+      const payload = JSON.parse(writes.join('')) as {
+        ok: true;
+        dryRun: true;
+        request: {
+          command: string;
+          hosts: string[];
+          port: number;
+          state: string;
+        };
+      };
+      expect(payload).toEqual({
+        ok: true,
+        dryRun: true,
+        request: {
+          command: 'Network.restartGame()',
+          hosts: ['127.0.0.1'],
+          port: 4318,
+          state: 'App UI',
+        },
+      });
+    } finally {
+      log.mockRestore();
+    }
+  });
+
   test('reports direct-control health and available states', async () => {
     const server = await startTunerServer();
     const writes: string[] = [];

--- a/packages/cli/test/commands/game.control.test.ts
+++ b/packages/cli/test/commands/game.control.test.ts
@@ -219,6 +219,10 @@ describe('game direct-control commands', () => {
 
   test('reports composed playable status', async () => {
     const server = await startTunerServer();
+    const writes: string[] = [];
+    const log = vi.spyOn(GameStatus.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
     try {
       const { port } = server.address();
       await GameStatus.run(['--host', '127.0.0.1', '--port', String(port), '--json']);
@@ -229,7 +233,74 @@ describe('game direct-control commands', () => {
         'LSQ:',
         expect.stringContaining('CMD:1:(() =>'),
       ]);
+      const payload = JSON.parse(writes.join('')) as {
+        ok: true;
+        status: {
+          host: string;
+          port: number;
+          playable: true;
+          readiness: string;
+          errors: string[];
+          appUi: {
+            host: string;
+            port: number;
+            state: { id: string; name: string };
+            snapshot: {
+              network: { isInSession: { ok: true; value: boolean } };
+              ui: { loadingStateName: string; canBeginGame: { ok: true; value: boolean } };
+              gameContext: { localPlayerID: number };
+              players: { aliveHumanIds: { ok: true; value: number[] } };
+              map: { width: { ok: true; value: number }; height: { ok: true; value: number } };
+            };
+          };
+          tuner: {
+            host: string;
+            port: number;
+            state: { id: string; name: string };
+            ready: true;
+            snapshot: {
+              ready: true;
+              globals: Record<string, string>;
+              turnDate: { ok: true; value: string };
+            };
+          };
+        };
+      };
+      expect(payload).toMatchObject({
+        ok: true,
+        status: {
+          host: '127.0.0.1',
+          port,
+          playable: true,
+          readiness: 'tuner-ready',
+          errors: [],
+        },
+      });
+      expect(payload.status.appUi).toMatchObject({
+        host: '127.0.0.1',
+        port,
+        state: { id: '65535', name: 'App UI' },
+      });
+      expect(payload.status.appUi.snapshot).toMatchObject({
+        network: { isInSession: { ok: true, value: true } },
+        ui: { loadingStateName: 'WaitingForUIReady', canBeginGame: { ok: true, value: true } },
+        gameContext: { localPlayerID: 0 },
+        players: { aliveHumanIds: { ok: true, value: [0] } },
+        map: { width: { ok: true, value: 84 }, height: { ok: true, value: 54 } },
+      });
+      expect(payload.status.tuner).toMatchObject({
+        host: '127.0.0.1',
+        port,
+        state: { id: '1', name: 'Tuner' },
+        ready: true,
+        snapshot: {
+          ready: true,
+          globals: { Game: 'object', Network: 'undefined' },
+          turnDate: { ok: true, value: '4000 BCE' },
+        },
+      });
     } finally {
+      log.mockRestore();
       await server.close();
     }
   });

--- a/packages/cli/test/commands/game.control.test.ts
+++ b/packages/cli/test/commands/game.control.test.ts
@@ -25,12 +25,40 @@ describe('game direct-control commands', () => {
 
   test('reports direct-control health and available states', async () => {
     const server = await startTunerServer();
+    const writes: string[] = [];
+    const log = vi.spyOn(GameHealth.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
     try {
       const { port } = server.address();
       await GameHealth.run(['--host', '127.0.0.1', '--port', String(port), '--state', 'App UI', '--json']);
 
       expect(server.received).toEqual(['LSQ:']);
+      const payload = JSON.parse(writes.join('')) as {
+        ok: true;
+        health: {
+          ok: true;
+          status: string;
+          host: string;
+          port: number;
+          states: Array<{ id: string; name: string }>;
+          selectedState: { id: string; name: string };
+        };
+      };
+      expect(payload.ok).toBe(true);
+      expect(payload.health).toMatchObject({
+        ok: true,
+        status: 'ready',
+        host: '127.0.0.1',
+        port,
+        selectedState: { id: '65535', name: 'App UI' },
+      });
+      expect(payload.health.states).toEqual([
+        { id: '65535', name: 'App UI' },
+        { id: '1', name: 'Tuner' },
+      ]);
     } finally {
+      log.mockRestore();
       await server.close();
     }
   });

--- a/packages/cli/test/commands/game.control.test.ts
+++ b/packages/cli/test/commands/game.control.test.ts
@@ -200,6 +200,10 @@ describe('game direct-control commands', () => {
 
   test('prints the package-owned App UI snapshot', async () => {
     const server = await startTunerServer();
+    const writes: string[] = [];
+    const log = vi.spyOn(GameInspect.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
     try {
       const { port } = server.address();
       await GameInspect.run([
@@ -212,7 +216,74 @@ describe('game direct-control commands', () => {
       ]);
 
       expect(server.received).toEqual(['LSQ:', expect.stringContaining('CMD:65535:(() =>')]);
+      const payload = JSON.parse(writes.join('')) as {
+        ok: true;
+        snapshot: {
+          host: string;
+          port: number;
+          state: { id: string; name: string };
+          snapshot: {
+            network: {
+              isInSession: { ok: true; value: boolean };
+              hostPlayerId: { ok: true; value: number };
+            };
+            game: {
+              turn: number;
+              turnDate: { ok: true; value: string };
+            };
+            ui: {
+              inGame: { ok: true; value: boolean };
+              loadingStateName: string;
+              canNotifyUIReady: string;
+            };
+            gameContext: { localPlayerID: number; localObserverID: number };
+            players: {
+              aliveIds: { ok: true; value: number[] };
+              aliveHumanIds: { ok: true; value: number[] };
+            };
+            map: {
+              width: { ok: true; value: number };
+              height: { ok: true; value: number };
+              plotCount: { ok: true; value: number };
+            };
+          };
+        };
+      };
+      expect(payload).toMatchObject({
+        ok: true,
+        snapshot: {
+          host: '127.0.0.1',
+          port,
+          state: { id: '65535', name: 'App UI' },
+        },
+      });
+      expect(payload.snapshot.snapshot).toMatchObject({
+        network: {
+          isInSession: { ok: true, value: true },
+          hostPlayerId: { ok: true, value: 0 },
+        },
+        game: {
+          turn: 1,
+          turnDate: { ok: true, value: '4000 BCE' },
+        },
+        ui: {
+          inGame: { ok: true, value: true },
+          loadingStateName: 'WaitingForUIReady',
+          canNotifyUIReady: 'function',
+        },
+        gameContext: { localPlayerID: 0, localObserverID: 0 },
+        players: {
+          aliveIds: { ok: true, value: [0] },
+          aliveHumanIds: { ok: true, value: [0] },
+        },
+        map: {
+          width: { ok: true, value: 84 },
+          height: { ok: true, value: 54 },
+          plotCount: { ok: true, value: 4536 },
+        },
+      });
     } finally {
+      log.mockRestore();
       await server.close();
     }
   });

--- a/packages/cli/test/commands/game.restart.test.ts
+++ b/packages/cli/test/commands/game.restart.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { once } from 'node:events';
 import { type AddressInfo, createServer } from 'node:net';
 import GameRestart from '../../src/commands/game/restart';
@@ -99,8 +99,12 @@ describe('game restart command', () => {
   });
 
   test('dry-run validates direct config without sending', async () => {
-    await expect(
-      GameRestart.run([
+    const writes: string[] = [];
+    const log = vi.spyOn(GameRestart.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
+    try {
+      await expect(GameRestart.run([
         '--host',
         '127.0.0.1',
         '--port',
@@ -110,8 +114,38 @@ describe('game restart command', () => {
         '--agent',
         'Codex',
         '--dry-run',
-      ])
-    ).resolves.toBeUndefined();
+        '--json',
+      ])).resolves.toBeUndefined();
+
+      const payload = JSON.parse(writes.join('')) as {
+        ok: true;
+        dryRun: true;
+        line: string;
+        request: {
+          requestId: string;
+          agent: string;
+          command: string;
+          hosts: string[];
+          port: number;
+          state: string;
+        };
+      };
+      expect(payload).toEqual({
+        ok: true,
+        dryRun: true,
+        line: `DIRECT codex-dry-run AGENT=Codex HOSTS=127.0.0.1 PORT=4318 STATE=App UI RUN ${CIV7_RESTART_COMMAND}`,
+        request: {
+          requestId: 'codex-dry-run',
+          agent: 'Codex',
+          command: CIV7_RESTART_COMMAND,
+          hosts: ['127.0.0.1'],
+          port: 4318,
+          state: 'App UI',
+        },
+      });
+    } finally {
+      log.mockRestore();
+    }
   });
 });
 

--- a/packages/cli/test/commands/game/play/normal-output-boundary.ts
+++ b/packages/cli/test/commands/game/play/normal-output-boundary.ts
@@ -1,0 +1,21 @@
+import { expect } from 'vitest';
+
+const DEBUG_INTERNAL_MARKERS = [
+  'CMD:',
+  'LSQ:',
+  'GameContext.',
+  'sendRequest',
+  'selectedState',
+  'socket',
+  'requestId',
+  'correlationId',
+  'closeoutTrace',
+  'rawProbe',
+] as const;
+
+export function expectNormalPlayPayloadToOmitDebugInternals(payload: unknown): void {
+  const text = JSON.stringify(payload);
+  for (const marker of DEBUG_INTERNAL_MARKERS) {
+    expect(text).not.toContain(marker);
+  }
+}

--- a/packages/cli/test/commands/game/play/priorities.test.ts
+++ b/packages/cli/test/commands/game/play/priorities.test.ts
@@ -75,6 +75,7 @@ describe('game play priorities command', () => {
       expect(payload.priorities.some((item) => item.kind === 'clean-read')).toBe(false);
       expect(payload.priorities.every((item) => item.evidence === undefined)).toBe(true);
       expect(payload.view).toBeUndefined();
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
       await server.close();
@@ -385,6 +386,24 @@ async function runPriorities(
     log.mockRestore();
   }
   return { payload: JSON.parse(writes.join('')), server };
+}
+
+function expectNormalPlayPayloadToOmitDebugInternals(payload: unknown): void {
+  const serialized = JSON.stringify(payload);
+  for (const forbidden of [
+    'CMD:',
+    'LSQ:',
+    'GameContext.',
+    'sendRequest',
+    'selectedState',
+    'socket',
+    'requestId',
+    'correlationId',
+    'closeoutTrace',
+    'rawProbe',
+  ]) {
+    expect(serialized).not.toContain(forbidden);
+  }
 }
 
 async function startPrioritiesTunerServer(mode: PriorityHudMode): Promise<FakeTunerServer> {

--- a/packages/cli/test/commands/game/play/priorities.test.ts
+++ b/packages/cli/test/commands/game/play/priorities.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayPriorities from '../../../../src/commands/game/play/priorities';
 import { type FakeTunerServer, startFakeTunerServer } from '../../fixtures/tuner-socket-server';
+import { expectNormalPlayPayloadToOmitDebugInternals } from './normal-output-boundary';
 
 type PriorityHudMode =
   | 'ready-unit'
@@ -386,24 +387,6 @@ async function runPriorities(
     log.mockRestore();
   }
   return { payload: JSON.parse(writes.join('')), server };
-}
-
-function expectNormalPlayPayloadToOmitDebugInternals(payload: unknown): void {
-  const serialized = JSON.stringify(payload);
-  for (const forbidden of [
-    'CMD:',
-    'LSQ:',
-    'GameContext.',
-    'sendRequest',
-    'selectedState',
-    'socket',
-    'requestId',
-    'correlationId',
-    'closeoutTrace',
-    'rawProbe',
-  ]) {
-    expect(serialized).not.toContain(forbidden);
-  }
 }
 
 async function startPrioritiesTunerServer(mode: PriorityHudMode): Promise<FakeTunerServer> {

--- a/packages/cli/test/commands/game/play/ready-city.test.ts
+++ b/packages/cli/test/commands/game/play/ready-city.test.ts
@@ -105,6 +105,7 @@ describe('game play ready-city command', () => {
       expect(payload.omitted.some((item) => item.path === 'view.productionCandidates[].result')).toBe(true);
       expect(payload.omitted.some((item) => item.path === 'view.populationPlacement.allPlacementInfo')).toBe(true);
       expect(payload.view).toBeUndefined();
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(server.received.some((message) => message.includes('readReadyCityView'))).toBe(true);
     } finally {
       log.mockRestore();
@@ -298,4 +299,22 @@ function readyCityView() {
     },
     notes: ['Read-only ready-city view. This view intentionally does not choose production.'],
   };
+}
+
+function expectNormalPlayPayloadToOmitDebugInternals(payload: unknown): void {
+  const text = JSON.stringify(payload);
+  for (const marker of [
+    'CMD:',
+    'LSQ:',
+    'GameContext.',
+    'sendRequest',
+    'selectedState',
+    'socket',
+    'requestId',
+    'correlationId',
+    'closeoutTrace',
+    'rawProbe',
+  ]) {
+    expect(text).not.toContain(marker);
+  }
 }

--- a/packages/cli/test/commands/game/play/ready-city.test.ts
+++ b/packages/cli/test/commands/game/play/ready-city.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayReadyCity from '../../../../src/commands/game/play/ready-city';
 import { type FakeTunerServer, startFakeTunerServer } from '../../fixtures/tuner-socket-server';
+import { expectNormalPlayPayloadToOmitDebugInternals } from './normal-output-boundary';
 
 describe('game play ready-city command', () => {
   test('reads ready-city decision view without sending operations', async () => {
@@ -299,22 +300,4 @@ function readyCityView() {
     },
     notes: ['Read-only ready-city view. This view intentionally does not choose production.'],
   };
-}
-
-function expectNormalPlayPayloadToOmitDebugInternals(payload: unknown): void {
-  const text = JSON.stringify(payload);
-  for (const marker of [
-    'CMD:',
-    'LSQ:',
-    'GameContext.',
-    'sendRequest',
-    'selectedState',
-    'socket',
-    'requestId',
-    'correlationId',
-    'closeoutTrace',
-    'rawProbe',
-  ]) {
-    expect(text).not.toContain(marker);
-  }
 }

--- a/packages/cli/test/commands/game/play/unit-move-preview.test.ts
+++ b/packages/cli/test/commands/game/play/unit-move-preview.test.ts
@@ -108,6 +108,7 @@ describe('game play unit-move-preview command', () => {
       expect(payload.warnings.join(' ')).toContain('does not classify other-owner relationships');
       expect(payload.omitted.some((item) => item.path === 'view.reachableMovement')).toBe(true);
       expect(payload.view).toBeUndefined();
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(server.received.some((message) => message.includes('readUnitMovePreview'))).toBe(true);
     } finally {
       log.mockRestore();
@@ -115,6 +116,24 @@ describe('game play unit-move-preview command', () => {
     }
   });
 });
+
+function expectNormalPlayPayloadToOmitDebugInternals(payload: unknown): void {
+  const text = JSON.stringify(payload);
+  for (const marker of [
+    'CMD:',
+    'LSQ:',
+    'GameContext.',
+    'sendRequest',
+    'selectedState',
+    'socket',
+    'requestId',
+    'correlationId',
+    'closeoutTrace',
+    'rawProbe',
+  ]) {
+    expect(text).not.toContain(marker);
+  }
+}
 
 async function startUnitMovePreviewTunerServer(): Promise<FakeTunerServer> {
   return startFakeTunerServer({

--- a/packages/cli/test/commands/game/play/unit-move-preview.test.ts
+++ b/packages/cli/test/commands/game/play/unit-move-preview.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayUnitMovePreview from '../../../../src/commands/game/play/unit-move-preview';
 import { type FakeTunerServer, startFakeTunerServer } from '../../fixtures/tuner-socket-server';
+import { expectNormalPlayPayloadToOmitDebugInternals } from './normal-output-boundary';
 
 describe('game play unit-move-preview command', () => {
   test('reads official unit move preview with neutral relationship policy', async () => {
@@ -116,24 +117,6 @@ describe('game play unit-move-preview command', () => {
     }
   });
 });
-
-function expectNormalPlayPayloadToOmitDebugInternals(payload: unknown): void {
-  const text = JSON.stringify(payload);
-  for (const marker of [
-    'CMD:',
-    'LSQ:',
-    'GameContext.',
-    'sendRequest',
-    'selectedState',
-    'socket',
-    'requestId',
-    'correlationId',
-    'closeoutTrace',
-    'rawProbe',
-  ]) {
-    expect(text).not.toContain(marker);
-  }
-}
 
 async function startUnitMovePreviewTunerServer(): Promise<FakeTunerServer> {
   return startFakeTunerServer({


### PR DESCRIPTION
test(cli): prove compact priorities omit debug internals

Refs: openspec/changes/civ7-support-direct-control-modularization

Strengthen the compact game play priorities test so the normal player-agent projection omits raw transport, session, probe, correlation, and command internals. Record this as partial normal/debug separation proof for the Debug/Internal Service Output matrix row.

This does not accept Task 2.9.4, assign a debug projection owner, implement a debug/service hierarchy, prove AI-ingestion or telemetry separation, claim runtime/live-game proof, or unblock telemetry, AI ingestion, semantic CLI, hotseat runtime proof, schema/procedure-core work, or Effect/oRPC implementation.

Validation:
- bun run --cwd packages/cli test -- test/commands/game/play/priorities.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- bun run openspec:validate
- Task 2.9.4 accepted-row leakage guard scan
- relationship-label guard scan
- git diff --check

test(cli): prove inspect emits debug projection

Refs: openspec/changes/civ7-support-direct-control-modularization

Strengthen the game inspect JSON test so the debug-owned command proves raw runtime diagnostic projection fields: host/port/state, own/prototype/enumerable keys, and method owner/length/signature diagnostics. Record this as partial Debug/Internal Service Output matrix-row proof alongside compact priorities normal-output omission proof.

This does not accept Task 2.9.4, assign a debug projection owner, implement debug/service hierarchy, prove AI-ingestion or telemetry separation, claim runtime/live-game proof, or unblock telemetry, AI ingestion, semantic CLI, hotseat runtime proof, schema/procedure-core work, or Effect/oRPC implementation.

Validation:
- bun run --cwd packages/cli test -- test/commands/game.control.test.ts
- bun run test:cli -- --force
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- bun run openspec:validate
- Task 2.9.4 accepted-row leakage guard scan
- relationship-label guard scan
- git diff --check

test(cli): prove ready-city omits debug internals

Refs: openspec/changes/civ7-support-direct-control-modularization

Add compact game play ready-city proof that the normal player-agent projection omits raw debug/internal markers such as tuner command frames, GameContext probes, socket/request/correlation fields, closeout traces, and raw probes while preserving the compact city decision summary.

Record this as partial Debug/Internal Service Output matrix proof only. This does not accept Task 2.9.4, assign a debug projection owner, prove AI-ingestion or telemetry separation, implement debug/service hierarchy, claim runtime/live-game proof, or unblock telemetry, AI ingestion, semantic CLI, hotseat runtime proof, schema/procedure-core work, or Effect/oRPC implementation.

Validation:
- bun run --cwd packages/cli test -- test/commands/game/play/ready-city.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- bun run openspec:validate
- Task 2.9.4 accepted-row leakage guard scan
- relationship-label guard scan
- git diff --check

test(cli): prove health emits debug projection

Refs: openspec/changes/civ7-support-direct-control-modularization

Strengthen the game health JSON test so the debug-owned command proves raw readiness diagnostic projection fields: host, port, state discovery, and selected state. Record this alongside inspect JSON runtime inspection proof and normal play omission proof for the Debug/Internal Service Output row.

This does not accept Task 2.9.4, assign a debug projection owner, prove AI-ingestion or telemetry separation, implement debug/service hierarchy, claim runtime/live-game proof, or unblock telemetry, AI ingestion, semantic CLI, hotseat runtime proof, schema/procedure-core work, or Effect/oRPC implementation.

Validation:
- bun run --cwd packages/cli test -- test/commands/game.control.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- bun run openspec:validate
- Task 2.9.4 accepted-row leakage guard scan
- relationship-label guard scan
- git diff --check

test(cli): prove status emits debug projection

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds focused game status --json coverage proving the debug-owned composed playable-status command emits raw App UI snapshot and Tuner health diagnostics through the CLI control test fixture. Updates the support OpenSpec records to count this as partial Debug/Internal Service Output proof alongside health and inspect.

Proof: bun run --cwd packages/cli test -- test/commands/game.control.test.ts
Proof: bun run check:cli
Proof: bun run test:cli:play
Proof: bun run test:cli -- --force
Proof: bun run openspec -- validate civ7-support-direct-control-modularization --strict
Proof: bun run openspec:validate
Proof: git diff --check

No runtime/live-game proof claimed. Does not accept Task 2.9.4, implement telemetry, AI ingestion, semantic CLI envelopes, schema migration, or Effect/oRPC procedure-core work.

test(cli): prove App UI snapshot debug projection

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds focused game inspect --app-ui-snapshot --json coverage proving the debug-owned inspect command emits the package-owned raw App UI snapshot shape, including network, UI, game, player, and map probes. Updates the support OpenSpec records to count this as partial Debug/Internal Service Output proof.

Proof: bun run --cwd packages/cli test -- test/commands/game.control.test.ts
Proof: bun run check:cli
Proof: bun run test:cli:play
Proof: bun run test:cli -- --force
Proof: bun run openspec -- validate civ7-support-direct-control-modularization --strict
Proof: bun run openspec:validate
Proof: git diff --check

No runtime/live-game proof claimed. Does not accept Task 2.9.4, implement telemetry, AI ingestion, semantic CLI envelopes, schema migration, or Effect/oRPC procedure-core work.

test(cli): prove catalog emits debug projection

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds focused game catalog --static --json coverage proving the debug-owned catalog command emits raw package capability provenance fields, including owner, risk, provenance, confidence, wrapper, and GameInfo table evidence. Updates the support OpenSpec records to count this as partial Debug/Internal Service Output proof.

Proof: bun run --cwd packages/cli test -- test/commands/game.control.test.ts
Proof: bun run check:cli
Proof: bun run test:cli:play
Proof: bun run test:cli -- --force
Proof: bun run openspec -- validate civ7-support-direct-control-modularization --strict
Proof: bun run openspec:validate
Proof: git diff --check

No runtime/live-game proof claimed. Does not accept Task 2.9.4, implement telemetry, AI ingestion, semantic CLI envelopes, schema migration, or Effect/oRPC procedure-core work.

test(cli): prove exec dry-run debug projection

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds focused game exec --dry-run --json coverage proving the debug-owned exec command emits raw request routing fields without sending to the tuner socket. Updates support OpenSpec records to count this as partial Debug/Internal Service Output proof only.

Proof:
- bun run --cwd packages/cli test -- test/commands/game.control.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run test:cli -- --force
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- bun run openspec:validate
- git diff --check

No runtime/live-game proof claimed. Does not accept Task 2.9.4, implement telemetry, AI ingestion, semantic CLI envelopes, schema migration, raw command tunneling, or Effect/oRPC procedure-core work.

test(cli): prove visibility emits debug projection

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds focused game visibility --json coverage proving the debug-owned visibility command emits raw visibility summary fields through the CLI package boundary. Updates support OpenSpec records to count this as partial Debug/Internal Service Output proof only.

Proof:
- bun run --cwd packages/cli test -- test/commands/game.control.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run test:cli -- --force
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- bun run openspec:validate
- git diff --check

No runtime/live-game proof claimed. Does not exercise reveal mutation, accept Task 2.9.4, implement telemetry, AI ingestion, semantic CLI envelopes, schema migration, raw command tunneling, or Effect/oRPC procedure-core work.

test(cli): prove restart dry-run debug projection

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds focused game restart --dry-run --json coverage proving the support restart command emits raw request routing fields without sending to the tuner socket. Updates support OpenSpec records to count this as partial Debug/Internal Service Output proof only.

Proof:
- bun run --cwd packages/cli test -- test/commands/game.restart.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run test:cli -- --force
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- bun run openspec:validate
- git diff --check

No runtime/live-game proof claimed. Does not exercise restart or begin-game mutation, accept Task 2.9.4, implement telemetry, AI ingestion, semantic CLI envelopes, schema migration, raw command tunneling, or Effect/oRPC procedure-core work.

test(cli): prove unit move compact boundary

Refs: openspec/changes/civ7-support-direct-control-modularization

Add compact game play unit-move-preview coverage that asserts the normal player-agent projection omits debug/internal transport, probe, correlation, closeout, and command-internal markers while preserving movement-preview fields and neutral relationship proof.

Update the compatibility matrix, tasks, and workstream record as a partial Debug/Internal Service Output proof increment only. This does not accept Task 2.9.4, claim runtime/live-game proof, create telemetry or AI-ingestion contracts, or unblock semantic CLI, hotseat runtime, schema migration, or Effect/oRPC procedure-core work.

Validation:
- bun run --cwd packages/cli test -- test/commands/game/play/unit-move-preview.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run test:cli -- --force
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- bun run openspec:validate
- git diff --check

test(cli): extract normal output boundary helper

Refs: openspec/changes/civ7-support-direct-control-modularization

Move the compact play projection debug/internal marker omission assertion into packages/cli/test/commands/game/play/normal-output-boundary.ts and reuse it from priorities, ready-city, and unit-move-preview coverage.

Record this as local CLI test-helper ownership for the Debug/Internal Service Output proof lane only. This does not accept Task 2.9.4, assign production source owners, claim runtime/live-game proof, implement semantic envelopes, create telemetry or AI-ingestion contracts, or unblock Effect/oRPC procedure-core work.

Validation:
- bun run --cwd packages/cli test -- test/commands/game/play/priorities.test.ts test/commands/game/play/ready-city.test.ts test/commands/game/play/unit-move-preview.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run test:cli -- --force
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- bun run openspec:validate
- git diff --check