### PR TITLE
docs(openspec): align map atom corpus status

### DIFF
--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -122,8 +122,8 @@
         `game play ready-unit --json` coverage plus passive
         `game watch --jsonl` coverage and progression-read
         `game play traditions` / `game play progress-dashboard` coverage plus
-        tactical-read coverage, now sharing the
-        `game/play/normal-output-boundary.ts` test helper, prove seven normal
+        tactical-read and settlement-recommendation coverage, now sharing the
+        `game/play/normal-output-boundary.ts` test helper, prove eight normal
         player-agent projection families omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -117,9 +117,10 @@
         assigned and passing. The planning contract is now recorded in
         `workstream/debug-service-projection-contract.md`, but it does not
         assign source/proof owners or accept the row. Focused compact
-        `game play priorities`, compact `game play ready-city`, and compact
-        `game play unit-move-preview` coverage, now sharing the
-        `game/play/normal-output-boundary.ts` test helper, prove three normal
+        `game play priorities`, compact `game play ready-city`, compact
+        `game play unit-move-preview`, and full/read-only
+        `game play ready-unit --json` coverage, now sharing the
+        `game/play/normal-output-boundary.ts` test helper, prove four normal
         play projections omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -121,9 +121,9 @@
         `game play unit-move-preview`, and full/read-only
         `game play ready-unit --json` coverage plus passive
         `game watch --jsonl` coverage and progression-read
-        `game play traditions` / `game play progress-dashboard` coverage, now
-        sharing the
-        `game/play/normal-output-boundary.ts` test helper, prove five normal
+        `game play traditions` / `game play progress-dashboard` coverage plus
+        tactical-read coverage, now sharing the
+        `game/play/normal-output-boundary.ts` test helper, prove seven normal
         player-agent projection families omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -1304,42 +1304,48 @@ runtime/direct-control claims.
         the public facade export surface in `index.ts`, classifying it as
         debug/internal service output with normal CLI projection omitted or
         debug-only and debug service projection as raw diagnostic projection,
-        and leaving App UI snapshot, Tuner health, playable status, bounded root
-        inspection, capability catalog, telemetry, hotseat runtime proof, AI
-        ingestion, CLI semantic projection, and Effect/oRPC procedure-core work
-        pending.
+        while later 4.12 rows now own App UI snapshot, Tuner health, playable
+        status, bounded root inspection, capability catalog, catalog schemas,
+        and runtime inspection constants. Telemetry, hotseat runtime proof, AI
+        ingestion, CLI semantic projection, Effect/oRPC procedure-core work,
+        and Task 2.9.4 matrix-row acceptance remain pending.
   - [x] 4.12.2 Extract App UI snapshot wrapper/source owner while keeping the
         public facade export surface in `index.ts`, leaving lifecycle/setup
         orchestration in the facade while reusing the same internal snapshot
-        builder/parser helpers, and leaving Tuner health, playable status,
-        bounded root inspection, capability catalog, telemetry, hotseat runtime
-        proof, AI ingestion, CLI semantic projection, and Effect/oRPC
-        procedure-core work pending.
+        builder/parser helpers. Later 4.12 rows now own Tuner health, playable
+        status, bounded root inspection, capability catalog, catalog schemas,
+        and runtime inspection constants, while telemetry, hotseat runtime
+        proof, AI ingestion, CLI semantic projection, Effect/oRPC procedure-core
+        work, and Task 2.9.4 matrix-row acceptance remain pending.
   - [x] 4.12.3 Extract Tuner health wrapper/source/parser owner while keeping
         public facade call-through and session lifecycle/reconnect execution in
         `index.ts`, preserving the internal wait/setup helper reuse through
-        injected session-command execution, and leaving playable status, bounded
-        root inspection, capability catalog, telemetry, hotseat runtime proof,
-        AI ingestion, CLI semantic projection, and Effect/oRPC procedure-core
-        work pending.
+        injected session-command execution. Later 4.12 rows now own playable
+        status, bounded root inspection, capability catalog, catalog schemas,
+        and runtime inspection constants, while telemetry, hotseat runtime
+        proof, AI ingestion, CLI semantic projection, Effect/oRPC procedure-core
+        work, and Task 2.9.4 matrix-row acceptance remain pending.
   - [x] 4.12.4 Extract proof/log helper owner while keeping the public facade
         export surface in `index.ts`, preserving `snapshotFile` /
         `waitForFreshLogMarkers` behavior and the default scripting-log path,
-        and leaving capability catalog, operation/proof telemetry, hotseat
-        runtime proof, AI ingestion, CLI semantic projection, and Effect/oRPC
-        procedure-core work pending.
+        while later 4.12 rows now own capability catalog and catalog schemas.
+        Operation/proof telemetry, hotseat runtime proof, AI ingestion, CLI
+        semantic projection, Effect/oRPC procedure-core work, and Task 2.9.4
+        matrix-row acceptance remain pending.
   - [x] 4.12.5 Extract capability catalog source owner while keeping public
         facade exports in `index.ts`, injecting runtime root inspection from the
         facade, preserving static/runtime/official-resource catalog behavior,
-        and leaving TypeBox schema ownership, operation/proof telemetry,
-        hotseat runtime proof, AI ingestion, CLI semantic projection, and
-        Effect/oRPC procedure-core work pending.
+        while 4.12.8 now owns the TypeBox catalog schema. Operation/proof
+        telemetry, hotseat runtime proof, AI ingestion, CLI semantic projection,
+        Effect/oRPC procedure-core work, and Task 2.9.4 matrix-row acceptance
+        remain pending.
   - [x] 4.12.6 Extract playable-status composition owner while keeping public
         facade exports in `index.ts`, preserving App UI/Tuner health
         composition, shell/playable/readiness classification, and unready error
-        capture, and leaving bounded root inspection, TypeBox schema ownership,
-        operation/proof telemetry, hotseat runtime proof, AI ingestion, CLI
-        semantic projection, and Effect/oRPC procedure-core work pending.
+        capture, while later 4.12 rows now own bounded root inspection and
+        catalog schema ownership. Operation/proof telemetry, hotseat runtime
+        proof, AI ingestion, CLI semantic projection, Effect/oRPC procedure-core
+        work, and Task 2.9.4 matrix-row acceptance remain pending.
   - [x] 4.12.7 Extract bounded root inspection owner while keeping public
         facade exports in `index.ts`, preserving root identifier validation,
         bounds, state default, JSON parse label, command serialization, and

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -119,9 +119,10 @@
         assign source/proof owners or accept the row. Focused compact
         `game play priorities`, compact `game play ready-city`, compact
         `game play unit-move-preview`, and full/read-only
-        `game play ready-unit --json` coverage, now sharing the
-        `game/play/normal-output-boundary.ts` test helper, prove four normal
-        play projections omit raw
+        `game play ready-unit --json` coverage plus passive
+        `game watch --jsonl` coverage, now sharing the
+        `game/play/normal-output-boundary.ts` test helper, prove five normal
+        player-agent projections omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and
         procedure-diagnostic separation proof remains pending before row

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -124,9 +124,9 @@
         `game play traditions` / `game play progress-dashboard` coverage plus
         tactical-read, settlement-recommendation, and promotion-readiness
         coverage plus rehydrate continuity, notification-HUD, and
-        notification-queue coverage plus technology-option coverage, now
-        sharing the
-        `game/play/normal-output-boundary.ts` test helper, prove thirteen normal
+        notification-queue coverage plus technology- and culture-option
+        coverage, now sharing the
+        `game/play/normal-output-boundary.ts` test helper, prove fourteen normal
         player-agent projection families omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -124,9 +124,9 @@
         `game play traditions` / `game play progress-dashboard` coverage plus
         tactical-read, settlement-recommendation, and promotion-readiness
         coverage plus rehydrate continuity, notification-HUD, and
-        notification-queue coverage plus technology- and culture-option
-        coverage, now sharing the
-        `game/play/normal-output-boundary.ts` test helper, prove fourteen normal
+        notification-queue coverage plus technology-, culture-, celebration-,
+        and government-option coverage, now sharing the
+        `game/play/normal-output-boundary.ts` test helper, prove sixteen normal
         player-agent projection families omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -122,8 +122,9 @@
         `game play ready-unit --json` coverage plus passive
         `game watch --jsonl` coverage and progression-read
         `game play traditions` / `game play progress-dashboard` coverage plus
-        tactical-read and settlement-recommendation coverage, now sharing the
-        `game/play/normal-output-boundary.ts` test helper, prove eight normal
+        tactical-read, settlement-recommendation, and promotion-readiness
+        coverage, now sharing the
+        `game/play/normal-output-boundary.ts` test helper, prove nine normal
         player-agent projection families omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -120,9 +120,11 @@
         `game play priorities`, compact `game play ready-city`, compact
         `game play unit-move-preview`, and full/read-only
         `game play ready-unit --json` coverage plus passive
-        `game watch --jsonl` coverage, now sharing the
+        `game watch --jsonl` coverage and progression-read
+        `game play traditions` / `game play progress-dashboard` coverage, now
+        sharing the
         `game/play/normal-output-boundary.ts` test helper, prove five normal
-        player-agent projections omit raw
+        player-agent projection families omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and
         procedure-diagnostic separation proof remains pending before row

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -123,8 +123,8 @@
         `game watch --jsonl` coverage and progression-read
         `game play traditions` / `game play progress-dashboard` coverage plus
         tactical-read, settlement-recommendation, and promotion-readiness
-        coverage, now sharing the
-        `game/play/normal-output-boundary.ts` test helper, prove nine normal
+        coverage plus rehydrate continuity coverage, now sharing the
+        `game/play/normal-output-boundary.ts` test helper, prove ten normal
         player-agent projection families omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -123,8 +123,9 @@
         `game watch --jsonl` coverage and progression-read
         `game play traditions` / `game play progress-dashboard` coverage plus
         tactical-read, settlement-recommendation, and promotion-readiness
-        coverage plus rehydrate continuity coverage, now sharing the
-        `game/play/normal-output-boundary.ts` test helper, prove ten normal
+        coverage plus rehydrate continuity and notification-HUD coverage, now
+        sharing the
+        `game/play/normal-output-boundary.ts` test helper, prove eleven normal
         player-agent projection families omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -1203,25 +1203,31 @@ runtime/direct-control claims.
         wrapper/source owner while keeping the public facade export surface in
         `index.ts`.
   - [x] 4.11.2 Extract visibility summary read wrapper/source owner while
-        keeping the public facade export surface in `index.ts` and leaving
-        reveal mutation, GameInfo rows, setup map rows, and player/unit/city
-        summaries pending.
+        keeping the public facade export surface in `index.ts`; later 4.11
+        rows now own reveal mutation, GameInfo rows, setup map rows, and
+        player/unit/city summaries, while downstream AI ingestion, semantic
+        CLI, telemetry, hotseat runtime proof, Effect/oRPC procedure-core work,
+        and Task 2.9.4 matrix-row acceptance remain pending.
   - [x] 4.11.3 Extract GameInfo rows read wrapper/source owner while keeping
-        the public facade export surface in `index.ts` and leaving reveal
-        mutation, setup map rows, player/unit/city summaries, AI ingestion, and
-        static profile shaping pending.
+        the public facade export surface in `index.ts`; later 4.11 rows now
+        own reveal mutation, setup map rows, and player/unit/city summaries,
+        while AI ingestion, static profile shaping, semantic CLI, telemetry,
+        hotseat runtime proof, Effect/oRPC procedure-core work, and Task 2.9.4
+        matrix-row acceptance remain pending.
   - [x] 4.11.4 Extract player, unit, and city summary read wrapper/source
         owner with focused package proof while keeping public facade exports in
-        `index.ts` and leaving reveal mutation, setup map rows, AI ingestion,
-        static profile shaping, semantic CLI, telemetry, hotseat runtime proof,
-        and Effect/oRPC procedure-core work pending.
+        `index.ts`; later 4.11 rows now own reveal mutation and setup map rows,
+        while AI ingestion, static profile shaping, semantic CLI, telemetry,
+        hotseat runtime proof, Effect/oRPC procedure-core work, and Task 2.9.4
+        matrix-row acceptance remain pending.
   - [x] 4.11.5 Extract reveal-map mutation wrapper owner while keeping public
         facade exports in `index.ts`, preserving approval-first and
         disposable-session guards, player-id validation, visibility before/after
         reads, `Visibility.revealAllPlots` command text, classification shape,
-        and leaving setup map rows to 4.11.6 plus AI ingestion, static profile
-        shaping, semantic CLI, telemetry, hotseat runtime proof, and
-        Effect/oRPC procedure-core work pending.
+        and leaving setup map rows to the completed 4.11.6 row while AI
+        ingestion, static profile shaping, semantic CLI, telemetry, hotseat
+        runtime proof, Effect/oRPC procedure-core work, and Task 2.9.4
+        matrix-row acceptance remain pending.
   - [x] 4.11.6 Extract setup snapshot and setup map rows read/source owner while
         keeping public facade exports in `index.ts`, preserving setup map script
         validation, `limit` default/bounds, setup-domain/config-db row
@@ -1232,10 +1238,10 @@ runtime/direct-control claims.
         work pending.
   - [x] 4.11.7 Extract map validation helper owner while preserving map
         location `x`/`y` bounds, map-grid `bounds.width`/`bounds.height` hard
-        caps, and existing command-failed messages, and leaving map read source
-        strings, public procedure schemas, telemetry, hotseat runtime proof, AI
-        ingestion, CLI semantic projection, Effect/oRPC procedure-core work,
-        and Task 2.9.4 matrix-row acceptance pending.
+        caps, and existing command-failed messages, while keeping runtime
+        behavior changes, public procedure schemas, telemetry, hotseat runtime
+        proof, AI ingestion, CLI semantic projection, Effect/oRPC procedure-core
+        work, and Task 2.9.4 matrix-row acceptance pending.
   - [x] 4.11.8 Prune map-read facade dependency injection by letting the map
         read owner import existing non-facade executor/parser/validation/source
         helpers directly, while keeping public facade exports stable,

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -123,9 +123,9 @@
         `game watch --jsonl` coverage and progression-read
         `game play traditions` / `game play progress-dashboard` coverage plus
         tactical-read, settlement-recommendation, and promotion-readiness
-        coverage plus rehydrate continuity and notification-HUD coverage, now
-        sharing the
-        `game/play/normal-output-boundary.ts` test helper, prove eleven normal
+        coverage plus rehydrate continuity, notification-HUD, and
+        notification-queue coverage, now sharing the
+        `game/play/normal-output-boundary.ts` test helper, prove twelve normal
         player-agent projection families omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -124,8 +124,9 @@
         `game play traditions` / `game play progress-dashboard` coverage plus
         tactical-read, settlement-recommendation, and promotion-readiness
         coverage plus rehydrate continuity, notification-HUD, and
-        notification-queue coverage, now sharing the
-        `game/play/normal-output-boundary.ts` test helper, prove twelve normal
+        notification-queue coverage plus technology-option coverage, now
+        sharing the
+        `game/play/normal-output-boundary.ts` test helper, prove thirteen normal
         player-agent projection families omit raw
         transport/session/probe/correlation command internals, but broader
         debug-command boundary, AI-ingestion, telemetry, and

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -455,9 +455,9 @@ Intake rejection conditions:
   and progression-read `game play traditions` / `game play progress-dashboard`
   proof plus tactical-read, settlement-recommendation, and promotion-readiness
   proof plus rehydrate continuity, notification-HUD, and notification-queue
-  proof now assert through the shared
+  proof plus technology-option proof now assert through the shared
   `packages/cli/test/commands/game/play/normal-output-boundary.ts` helper that
-  twelve normal player-agent projection families omit raw
+  thirteen normal player-agent projection families omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -453,10 +453,10 @@ Intake rejection conditions:
   `game play unit-move-preview`, and full/read-only
   `game play ready-unit --json` proof plus passive `game watch --jsonl` proof
   and progression-read `game play traditions` / `game play progress-dashboard`
-  proof plus tactical-read and settlement-recommendation proof now assert
-  through the shared
+  proof plus tactical-read, settlement-recommendation, and promotion-readiness
+  proof now assert through the shared
   `packages/cli/test/commands/game/play/normal-output-boundary.ts` helper that
-  eight normal player-agent projection families omit raw
+  nine normal player-agent projection families omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -455,9 +455,9 @@ Intake rejection conditions:
   and progression-read `game play traditions` / `game play progress-dashboard`
   proof plus tactical-read, settlement-recommendation, and promotion-readiness
   proof plus rehydrate continuity, notification-HUD, and notification-queue
-  proof plus technology-option proof now assert through the shared
+  proof plus technology- and culture-option proof now assert through the shared
   `packages/cli/test/commands/game/play/normal-output-boundary.ts` helper that
-  thirteen normal player-agent projection families omit raw
+  fourteen normal player-agent projection families omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -454,9 +454,9 @@ Intake rejection conditions:
   `game play ready-unit --json` proof plus passive `game watch --jsonl` proof
   and progression-read `game play traditions` / `game play progress-dashboard`
   proof plus tactical-read, settlement-recommendation, and promotion-readiness
-  proof now assert through the shared
+  proof plus rehydrate continuity proof now assert through the shared
   `packages/cli/test/commands/game/play/normal-output-boundary.ts` helper that
-  nine normal player-agent projection families omit raw
+  ten normal player-agent projection families omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -449,10 +449,11 @@ Intake rejection conditions:
   App UI snapshot, playable status, map/GameInfo reads, AI loaded-lever reads,
   and operation validation through the package boundary; package proof includes
   `runtime-and-catalog.test.ts` and `session.test.ts`. Focused compact
-  `game play priorities`, compact `game play ready-city`, and compact
-  `game play unit-move-preview` proof now assert through the shared
+  `game play priorities`, compact `game play ready-city`, compact
+  `game play unit-move-preview`, and full/read-only
+  `game play ready-unit --json` proof now assert through the shared
   `packages/cli/test/commands/game/play/normal-output-boundary.ts` helper that
-  three normal play projections omit raw
+  four normal play projections omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -451,9 +451,10 @@ Intake rejection conditions:
   `runtime-and-catalog.test.ts` and `session.test.ts`. Focused compact
   `game play priorities`, compact `game play ready-city`, compact
   `game play unit-move-preview`, and full/read-only
-  `game play ready-unit --json` proof now assert through the shared
+  `game play ready-unit --json` proof plus passive `game watch --jsonl` proof
+  now assert through the shared
   `packages/cli/test/commands/game/play/normal-output-boundary.ts` helper that
-  four normal play projections omit raw
+  five normal player-agent projections omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -453,9 +453,10 @@ Intake rejection conditions:
   `game play unit-move-preview`, and full/read-only
   `game play ready-unit --json` proof plus passive `game watch --jsonl` proof
   and progression-read `game play traditions` / `game play progress-dashboard`
-  proof plus tactical-read proof now assert through the shared
+  proof plus tactical-read and settlement-recommendation proof now assert
+  through the shared
   `packages/cli/test/commands/game/play/normal-output-boundary.ts` helper that
-  seven normal player-agent projection families omit raw
+  eight normal player-agent projection families omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -452,9 +452,10 @@ Intake rejection conditions:
   `game play priorities`, compact `game play ready-city`, compact
   `game play unit-move-preview`, and full/read-only
   `game play ready-unit --json` proof plus passive `game watch --jsonl` proof
-  now assert through the shared
+  and progression-read `game play traditions` / `game play progress-dashboard`
+  proof now assert through the shared
   `packages/cli/test/commands/game/play/normal-output-boundary.ts` helper that
-  five normal player-agent projections omit raw
+  five normal player-agent projection families omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -454,10 +454,10 @@ Intake rejection conditions:
   `game play ready-unit --json` proof plus passive `game watch --jsonl` proof
   and progression-read `game play traditions` / `game play progress-dashboard`
   proof plus tactical-read, settlement-recommendation, and promotion-readiness
-  proof plus rehydrate continuity and notification-HUD proof now assert through
-  the shared
+  proof plus rehydrate continuity, notification-HUD, and notification-queue
+  proof now assert through the shared
   `packages/cli/test/commands/game/play/normal-output-boundary.ts` helper that
-  eleven normal player-agent projection families omit raw
+  twelve normal player-agent projection families omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -454,9 +454,10 @@ Intake rejection conditions:
   `game play ready-unit --json` proof plus passive `game watch --jsonl` proof
   and progression-read `game play traditions` / `game play progress-dashboard`
   proof plus tactical-read, settlement-recommendation, and promotion-readiness
-  proof plus rehydrate continuity proof now assert through the shared
+  proof plus rehydrate continuity and notification-HUD proof now assert through
+  the shared
   `packages/cli/test/commands/game/play/normal-output-boundary.ts` helper that
-  ten normal player-agent projection families omit raw
+  eleven normal player-agent projection families omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -455,9 +455,10 @@ Intake rejection conditions:
   and progression-read `game play traditions` / `game play progress-dashboard`
   proof plus tactical-read, settlement-recommendation, and promotion-readiness
   proof plus rehydrate continuity, notification-HUD, and notification-queue
-  proof plus technology- and culture-option proof now assert through the shared
+  proof plus technology-, culture-, celebration-, and government-option proof
+  now assert through the shared
   `packages/cli/test/commands/game/play/normal-output-boundary.ts` helper that
-  fourteen normal player-agent projection families omit raw
+  sixteen normal player-agent projection families omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -453,9 +453,9 @@ Intake rejection conditions:
   `game play unit-move-preview`, and full/read-only
   `game play ready-unit --json` proof plus passive `game watch --jsonl` proof
   and progression-read `game play traditions` / `game play progress-dashboard`
-  proof now assert through the shared
+  proof plus tactical-read proof now assert through the shared
   `packages/cli/test/commands/game/play/normal-output-boundary.ts` helper that
-  five normal player-agent projection families omit raw
+  seven normal player-agent projection families omit raw
   transport/session/probe/correlation command internals. Focused `game health
   --json`, `game inspect --json`, `game inspect --app-ui-snapshot --json`,
   `game status --json`, `game catalog --static --json`,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/direct-control-atom-corpus.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/direct-control-atom-corpus.md
@@ -118,37 +118,46 @@ pending.
 Map row update: `src/play/map/reads.ts` now owns `getCiv7MapSummary`,
 `getCiv7PlotSnapshot`, and `getCiv7MapGrid` orchestration plus their map
 summary, plot snapshot, and bounded grid command/source helpers while public
-facade exports stay in `index.ts`. Visibility summary, reveal mutation,
-GameInfo rows, setup map rows, and player/unit/city summaries remain pending
-separate owner slices.
+facade exports stay in `index.ts`. Later 4.11 slices now own visibility
+summary, reveal mutation, GameInfo rows, setup map rows, and player/unit/city
+summaries in their named modules; AI ingestion, static profile shaping,
+semantic CLI projection, telemetry, hotseat runtime proof, Effect/oRPC
+procedure-core work, and Task 2.9.4 matrix-row acceptance remain pending
+separate lanes.
 
 Map validation row update: `src/play/map/validation.ts` now owns map
 location/bounds validation while `src/validation.ts` owns generic integer
 validation. This preserves the existing location and map-grid hard-cap
-messages/classification; map read source strings, runtime behavior, telemetry,
-AI ingestion, semantic CLI projection, hotseat runtime proof, Effect/oRPC
-procedure-core work, and Task 2.9.4 matrix-row acceptance remain pending.
+messages/classification; runtime behavior changes, telemetry, AI ingestion,
+semantic CLI projection, hotseat runtime proof, Effect/oRPC procedure-core
+work, and Task 2.9.4 matrix-row acceptance remain pending.
 
 Visibility row update: `src/play/map/visibility.ts` now owns
 `getCiv7VisibilitySummary` orchestration plus its bounded visibility-grid
 command/source helper while the public facade export stays in `index.ts`.
-Reveal mutation, GameInfo rows, setup map rows, and player/unit/city summaries
-remain pending separate owner/proof slices.
+Later 4.11 slices now own reveal mutation, GameInfo rows, setup map rows, and
+player/unit/city summaries in their named modules; runtime/live-game proof for
+mutation claims, AI ingestion, static profile shaping, semantic CLI,
+telemetry, hotseat runtime proof, and Effect/oRPC procedure cores remain
+pending separate owner/proof slices.
 
 GameInfo row update: `src/play/map/gameinfo.ts` now owns
 `getCiv7GameInfoRows` orchestration plus its bounded GameInfo table row
 command/source helper while the public facade export stays in `index.ts`.
-Reveal mutation, setup map rows, player/unit/city summaries, AI ingestion, and
-static profile shaping remain pending separate owner/proof slices.
+Later 4.11 slices now own reveal mutation, setup map rows, and player/unit/city
+summaries; AI ingestion, static profile shaping, semantic CLI projection,
+telemetry, hotseat runtime proof, Effect/oRPC procedure-core work, and Task
+2.9.4 matrix-row acceptance remain pending separate owner/proof slices.
 
 Summary read update: `src/play/summaries.ts` now owns
 `getCiv7PlayerSummary`, `getCiv7UnitSummary`, and `getCiv7CitySummary`
 orchestration plus their command/source helpers while public facade exports stay
 in `index.ts`. `test/summary-reads.test.ts` repairs the focused package proof
 gap for command routing/source shape, validation and bounds, read-only/no-send
-behavior, and unchanged component-id pass-through. Reveal mutation, setup map
-rows, AI ingestion, static profile shaping, semantic CLI, telemetry, hotseat
-runtime proof, and Effect/oRPC procedure cores remain pending separate slices.
+behavior, and unchanged component-id pass-through. Later 4.11 slices now own
+reveal mutation and setup map rows; AI ingestion, static profile shaping,
+semantic CLI, telemetry, hotseat runtime proof, Effect/oRPC procedure cores,
+and Task 2.9.4 matrix-row acceptance remain pending separate slices.
 
 Runtime API inspection update: `src/runtime/inspection.ts` now owns
 `inspectCiv7RuntimeApi`, its default-root selector, and the generated runtime

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -58,8 +58,9 @@ passive `game watch --jsonl` proof now exercises the boundary over watch
 observation output, and progression-read proof now covers traditions and
 progress-dashboard JSON surfaces. Tactical-read proof now covers civilian route
 triage, target candidates, front summary, battlefield scan, formation snapshot,
-and destination analysis through the focused tactical helper. Follow-up focused
-`game health --json` and
+and destination analysis through the focused tactical helper.
+Settlement-recommendation proof now covers its read-only settlement lens output.
+Follow-up focused `game health --json` and
 `game inspect --json`
 proof now asserts that debug-owned commands emit raw readiness and runtime
 inspection fields including host/port/state, state discovery, selected state,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -54,7 +54,8 @@ omits those same raw internals while preserving the player-agent city decision
 summary. Follow-up compact `game play unit-move-preview` proof and
 full/read-only `game play ready-unit --json` proof now exercise the same shared
 normal-output boundary over movement and ready-unit projections. Follow-up
-focused `game health --json` and
+passive `game watch --jsonl` proof now exercises the boundary over watch
+observation output. Follow-up focused `game health --json` and
 `game inspect --json`
 proof now asserts that debug-owned commands emit raw readiness and runtime
 inspection fields including host/port/state, state discovery, selected state,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -55,7 +55,8 @@ summary. Follow-up compact `game play unit-move-preview` proof and
 full/read-only `game play ready-unit --json` proof now exercise the same shared
 normal-output boundary over movement and ready-unit projections. Follow-up
 passive `game watch --jsonl` proof now exercises the boundary over watch
-observation output. Follow-up focused `game health --json` and
+observation output, and progression-read proof now covers traditions and
+progress-dashboard JSON surfaces. Follow-up focused `game health --json` and
 `game inspect --json`
 proof now asserts that debug-owned commands emit raw readiness and runtime
 inspection fields including host/port/state, state discovery, selected state,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -51,7 +51,11 @@ transport/session/probe/correlation command internals while preserving the
 existing compact player-agent priority summary. Follow-up compact
 `game play ready-city` proof now asserts that another normal play projection
 omits those same raw internals while preserving the player-agent city decision
-summary. Follow-up focused `game health --json` and `game inspect --json`
+summary. Follow-up compact `game play unit-move-preview` proof and
+full/read-only `game play ready-unit --json` proof now exercise the same shared
+normal-output boundary over movement and ready-unit projections. Follow-up
+focused `game health --json` and
+`game inspect --json`
 proof now asserts that debug-owned commands emit raw readiness and runtime
 inspection fields including host/port/state, state discovery, selected state,
 own/prototype/enumerable keys, and method owner/length/signature diagnostics.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -60,6 +60,8 @@ progress-dashboard JSON surfaces. Tactical-read proof now covers civilian route
 triage, target candidates, front summary, battlefield scan, formation snapshot,
 and destination analysis through the focused tactical helper.
 Settlement-recommendation proof now covers its read-only settlement lens output.
+Promotion-readiness proof now covers its full/read-only ready-unit-derived
+promotion view output.
 Follow-up focused `game health --json` and
 `game inspect --json`
 proof now asserts that debug-owned commands emit raw readiness and runtime

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -62,6 +62,8 @@ and destination analysis through the focused tactical helper.
 Settlement-recommendation proof now covers its read-only settlement lens output.
 Promotion-readiness proof now covers its full/read-only ready-unit-derived
 promotion view output.
+Rehydrate proof now covers its full/read-only restart-continuity materialization
+output.
 Follow-up focused `game health --json` and
 `game inspect --json`
 proof now asserts that debug-owned commands emit raw readiness and runtime

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -66,6 +66,8 @@ Rehydrate proof now covers its full/read-only restart-continuity materialization
 output.
 Notification-HUD proof now covers materialized notification decision output
 across the focused HUD fixture modes.
+Notification-queue proof now covers read-only notification scheduling output
+across the focused queue fixture modes.
 Follow-up focused `game health --json` and
 `game inspect --json`
 proof now asserts that debug-owned commands emit raw readiness and runtime

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -69,6 +69,7 @@ across the focused HUD fixture modes.
 Notification-queue proof now covers read-only notification scheduling output
 across the focused queue fixture modes.
 Technology-option proof now covers read-only technology chooser option output.
+Culture-option proof now covers read-only culture chooser option output.
 Follow-up focused `game health --json` and
 `game inspect --json`
 proof now asserts that debug-owned commands emit raw readiness and runtime

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -56,7 +56,10 @@ full/read-only `game play ready-unit --json` proof now exercise the same shared
 normal-output boundary over movement and ready-unit projections. Follow-up
 passive `game watch --jsonl` proof now exercises the boundary over watch
 observation output, and progression-read proof now covers traditions and
-progress-dashboard JSON surfaces. Follow-up focused `game health --json` and
+progress-dashboard JSON surfaces. Tactical-read proof now covers civilian route
+triage, target candidates, front summary, battlefield scan, formation snapshot,
+and destination analysis through the focused tactical helper. Follow-up focused
+`game health --json` and
 `game inspect --json`
 proof now asserts that debug-owned commands emit raw readiness and runtime
 inspection fields including host/port/state, state discovery, selected state,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -64,6 +64,8 @@ Promotion-readiness proof now covers its full/read-only ready-unit-derived
 promotion view output.
 Rehydrate proof now covers its full/read-only restart-continuity materialization
 output.
+Notification-HUD proof now covers materialized notification decision output
+across the focused HUD fixture modes.
 Follow-up focused `game health --json` and
 `game inspect --json`
 proof now asserts that debug-owned commands emit raw readiness and runtime

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -68,6 +68,7 @@ Notification-HUD proof now covers materialized notification decision output
 across the focused HUD fixture modes.
 Notification-queue proof now covers read-only notification scheduling output
 across the focused queue fixture modes.
+Technology-option proof now covers read-only technology chooser option output.
 Follow-up focused `game health --json` and
 `game inspect --json`
 proof now asserts that debug-owned commands emit raw readiness and runtime

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -70,6 +70,8 @@ Notification-queue proof now covers read-only notification scheduling output
 across the focused queue fixture modes.
 Technology-option proof now covers read-only technology chooser option output.
 Culture-option proof now covers read-only culture chooser option output.
+Celebration-option proof now covers read-only celebration chooser option output.
+Government-option proof now covers read-only government chooser option output.
 Follow-up focused `game health --json` and
 `game inspect --json`
 proof now asserts that debug-owned commands emit raw readiness and runtime

--- a/packages/cli/test/commands/game.play.celebration-government.test.ts
+++ b/packages/cli/test/commands/game.play.celebration-government.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayChooseCelebration from '../../src/commands/game/play/choose-celebration';
 import GamePlayChooseGovernment from '../../src/commands/game/play/choose-government';
+import { expectNormalPlayPayloadToOmitDebugInternals } from './game/play/normal-output-boundary';
 import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play celebration and government commands', () => {
@@ -60,6 +61,7 @@ describe('game play celebration and government commands', () => {
           details?: unknown;
         };
       };
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(payload.result.enabledOptionCount).toBe(2);
       expect(payload.result.disabledOptionCount).toBe(0);
       expect(payload.result.details).toBeUndefined();
@@ -137,6 +139,7 @@ describe('game play celebration and government commands', () => {
           details?: unknown;
         };
       };
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(payload.result.enabledOptionCount).toBe(3);
       expect(payload.result.disabledOptionCount).toBe(0);
       expect(payload.result.details).toBeUndefined();

--- a/packages/cli/test/commands/game.play.culture.test.ts
+++ b/packages/cli/test/commands/game.play.culture.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayChooseCulture from '../../src/commands/game/play/choose-culture';
 import GamePlaySetCultureTarget from '../../src/commands/game/play/set-culture-target';
+import { expectNormalPlayPayloadToOmitDebugInternals } from './game/play/normal-output-boundary';
 import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play culture commands', () => {
@@ -60,6 +61,7 @@ describe('game play culture commands', () => {
           details?: unknown;
         };
       };
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(payload.result.enabledOptionCount).toBe(2);
       expect(payload.result.disabledOptionCount).toBe(1);
       expect(payload.result.details).toBeUndefined();

--- a/packages/cli/test/commands/game.play.progression-read.test.ts
+++ b/packages/cli/test/commands/game.play.progression-read.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest';
 import GamePlayProgressDashboard from '../../src/commands/game/play/progress-dashboard';
 import GamePlayTraditions from '../../src/commands/game/play/traditions';
 import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
+import { expectNormalPlayPayloadToOmitDebugInternals } from './game/play/normal-output-boundary';
 
 describe('game play progression reads', () => {
   test('reads live tradition slots and action hints', async () => {
@@ -36,6 +37,7 @@ describe('game play progression reads', () => {
           recommendedCli: string[];
         };
       };
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(payload.view.slots.active).toBe(1);
       expect(payload.view.slots.available).toBe(1);
       expect(payload.view.actions.activate).toBe(-1326475004);
@@ -78,6 +80,7 @@ describe('game play progression reads', () => {
         omitted: Array<{ path: string }>;
         traditions?: unknown;
       };
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(payload.command).toBe('game play traditions');
       expect(payload.traditions).toBeUndefined();
       expect(payload.active[0]).toMatchObject({
@@ -135,6 +138,7 @@ describe('game play progression reads', () => {
         omitted: Array<{ path: string }>;
         view?: unknown;
       };
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(payload.contractVersion).toBe('play-agent-v0');
       expect(payload.command).toBe('game play progress-dashboard');
       expect(payload.summary).toContain('AGE_ANTIQUITY progress');

--- a/packages/cli/test/commands/game.play.promotion-readiness.test.ts
+++ b/packages/cli/test/commands/game.play.promotion-readiness.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayPromotionReadiness from '../../src/commands/game/play/promotion-readiness';
+import { expectNormalPlayPayloadToOmitDebugInternals } from './game/play/normal-output-boundary';
 import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play promotion readiness command', () => {
@@ -23,6 +24,7 @@ describe('game play promotion readiness command', () => {
         ok: true;
         view: { promotionReadiness: { ok: true; value: { canPurchase: boolean } } };
       };
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(payload.view.promotionReadiness.value.canPurchase).toBe(false);
       expect(server.received.some((message) => message.includes('readReadyUnitView'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendRequest'))).toBe(false);

--- a/packages/cli/test/commands/game.play.rehydrate.test.ts
+++ b/packages/cli/test/commands/game.play.rehydrate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayRehydrate from '../../src/commands/game/play/rehydrate';
+import { expectNormalPlayPayloadToOmitDebugInternals } from './game/play/normal-output-boundary';
 import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play rehydrate command', () => {
@@ -28,6 +29,7 @@ describe('game play rehydrate command', () => {
           continuity: { status: string; warnings: string[] };
         };
       };
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(payload.snapshot.readyUnit).not.toBeNull();
       expect(payload.snapshot.continuity.status).toBe('mismatch');
       expect(payload.snapshot.continuity.warnings[0]).toMatch(/turn mismatch/);

--- a/packages/cli/test/commands/game.play.settlement-recommendations.test.ts
+++ b/packages/cli/test/commands/game.play.settlement-recommendations.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import GamePlaySettlementRecommendations from '../../src/commands/game/play/settlement-recommendations';
 import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
+import { expectNormalPlayPayloadToOmitDebugInternals } from './game/play/normal-output-boundary';
 
 describe('game play settlement recommendations command', () => {
   test('reads settlement recommendations without sending operations', async () => {
     const server = await startSettlementRecommendationsTunerServer();
+    const writes: string[] = [];
+    const log = vi.spyOn(GamePlaySettlementRecommendations.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
     try {
       const { port } = server.address();
       await GamePlaySettlementRecommendations.run([
@@ -19,10 +24,13 @@ describe('game play settlement recommendations command', () => {
         '--json',
       ]);
 
+      const payload = JSON.parse(writes.join(''));
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(server.received.some((message) => message.includes('readSettlementRecommendations'))).toBe(true);
       expect(server.received.some((message) => message.includes('"locations":[{"x":15,"y":23}]'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendRequest'))).toBe(false);
     } finally {
+      log.mockRestore();
       await server.close();
     }
   });

--- a/packages/cli/test/commands/game.play.tactical-read.test.ts
+++ b/packages/cli/test/commands/game.play.tactical-read.test.ts
@@ -6,6 +6,7 @@ import GamePlayFormationSnapshot from '../../src/commands/game/play/formation-sn
 import GamePlayFrontSummary from '../../src/commands/game/play/front-summary';
 import GamePlayTargetCandidates from '../../src/commands/game/play/target-candidates';
 import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
+import { expectNormalPlayPayloadToOmitDebugInternals } from './game/play/normal-output-boundary';
 
 describe('game play tactical read commands', () => {
   test('reads civilian route triage without sending operations', async () => {
@@ -235,7 +236,9 @@ async function runJsonCommand(command: CommandClass, server: FakeTunerServer, ar
   try {
     const { port } = server.address();
     await command.run(['--host', '127.0.0.1', '--port', String(port), ...args, '--json']);
-    return JSON.parse(writes.join('')) as { ok: boolean; [key: string]: unknown };
+    const payload = JSON.parse(writes.join('')) as { ok: boolean; [key: string]: unknown };
+    expectNormalPlayPayloadToOmitDebugInternals(payload);
+    return payload;
   } finally {
     log.mockRestore();
   }

--- a/packages/cli/test/commands/game.play.technology.test.ts
+++ b/packages/cli/test/commands/game.play.technology.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayChooseTech from '../../src/commands/game/play/choose-tech';
 import GamePlaySetTechTarget from '../../src/commands/game/play/set-tech-target';
+import { expectNormalPlayPayloadToOmitDebugInternals } from './game/play/normal-output-boundary';
 import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
 describe('game play technology commands', () => {
@@ -60,6 +61,7 @@ describe('game play technology commands', () => {
           details?: unknown;
         };
       };
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(payload.result.enabledOptionCount).toBe(2);
       expect(payload.result.disabledOptionCount).toBe(1);
       expect(payload.result.details).toBeUndefined();

--- a/packages/cli/test/commands/game.play.watch.test.ts
+++ b/packages/cli/test/commands/game.play.watch.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { describe, expect, test, vi } from 'vitest';
 import GameWatch from '../../src/commands/game/watch';
 import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
+import { expectNormalPlayPayloadToOmitDebugInternals } from './game/play/normal-output-boundary';
 
 describe('game watch command', () => {
   test('watches live play as JSONL without sending operations', async () => {
@@ -42,6 +43,7 @@ describe('game watch command', () => {
         readyCity: unknown;
       }>;
       expect(observations).toHaveLength(2);
+      for (const observation of observations) expectNormalPlayPayloadToOmitDebugInternals(observation);
       expect(observations[0].schema).toBe('civ7-watcher-observation.v1');
       expect(observations[0].mode).toBe('human-turn-watch');
       expect(observations[0].wrapper).toBe('getCiv7PlayNotificationView+getCiv7ReadyUnitView+getCiv7ReadyCityView');
@@ -83,6 +85,7 @@ describe('game watch command', () => {
 
       const lines = (await readFile(artifact, 'utf8')).trim().split('\n');
       expect(lines).toHaveLength(2);
+      for (const line of lines) expectNormalPlayPayloadToOmitDebugInternals(JSON.parse(line));
       expect(JSON.parse(lines[0])).toMatchObject({
         schema: 'civ7-watcher-observation.v1',
         ok: true,

--- a/packages/cli/test/commands/game/play/notification/hud.test.ts
+++ b/packages/cli/test/commands/game/play/notification/hud.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayNotifications from '../../../../../src/commands/game/play/notifications';
+import { expectNormalPlayPayloadToOmitDebugInternals } from '../normal-output-boundary';
 import { type FakeTunerServer, startFakeTunerServer } from '../../../fixtures/tuner-socket-server';
 
 type NotificationHudMode =
@@ -214,45 +215,48 @@ async function runNotificationHud(mode: NotificationHudMode = 'default') {
     log.mockRestore();
   }
 
-  return {
-    payload: JSON.parse(writes.join('')) as {
-      ok: true;
-      view: {
-        notifications: Array<{
-          target: { owner: number; id: number; type: number };
-          details?: {
-            kind: string;
-            actionId?: number;
-            classification?: string;
-            responseOptionCount?: number;
-            enabledResponseOptionCount?: number;
-            playerCulture?: unknown;
-            targetStoryId?: { ok: boolean; value?: { owner: number; id: number; type: number } | null };
-            storyLinks?: { ok: boolean; value?: unknown[] };
-            availableNodeTypes?: { ok: boolean; value?: number[] };
-            goldenAgeDuration?: { ok: boolean; value?: number };
-            choices?: { ok: boolean; value?: string[] };
-            startingGovernments?: { ok: boolean; value?: Array<{ GovernmentType: number }> };
-            action?: number;
-            options?: Array<{ title?: string; responseType?: number; enabled?: boolean; disabled?: boolean; cli: string | null }>;
-            enabledOptions?: Array<Record<string, unknown>>;
-            disabledOptions?: Array<Record<string, unknown>>;
-            enabledCloseoutCandidates?: Array<{ unitId: { owner: number; id: number; type: number }; operationType: string; cli: string | null }>;
-            staleReadyPointerSuspected?: boolean;
-          };
-        }>;
-        hud: {
-          nextDecision: {
-            category: string;
-            operationFamily?: string;
-            operationType?: string;
-            cli?: string | null;
-            notes: string[];
-            details?: unknown;
-          };
+  const payload = JSON.parse(writes.join('')) as {
+    ok: true;
+    view: {
+      notifications: Array<{
+        target: { owner: number; id: number; type: number };
+        details?: {
+          kind: string;
+          actionId?: number;
+          classification?: string;
+          responseOptionCount?: number;
+          enabledResponseOptionCount?: number;
+          playerCulture?: unknown;
+          targetStoryId?: { ok: boolean; value?: { owner: number; id: number; type: number } | null };
+          storyLinks?: { ok: boolean; value?: unknown[] };
+          availableNodeTypes?: { ok: boolean; value?: number[] };
+          goldenAgeDuration?: { ok: boolean; value?: number };
+          choices?: { ok: boolean; value?: string[] };
+          startingGovernments?: { ok: boolean; value?: Array<{ GovernmentType: number }> };
+          action?: number;
+          options?: Array<{ title?: string; responseType?: number; enabled?: boolean; disabled?: boolean; cli: string | null }>;
+          enabledOptions?: Array<Record<string, unknown>>;
+          disabledOptions?: Array<Record<string, unknown>>;
+          enabledCloseoutCandidates?: Array<{ unitId: { owner: number; id: number; type: number }; operationType: string; cli: string | null }>;
+          staleReadyPointerSuspected?: boolean;
+        };
+      }>;
+      hud: {
+        nextDecision: {
+          category: string;
+          operationFamily?: string;
+          operationType?: string;
+          cli?: string | null;
+          notes: string[];
+          details?: unknown;
         };
       };
-    },
+    };
+  };
+  expectNormalPlayPayloadToOmitDebugInternals(payload);
+
+  return {
+    payload,
     server,
   };
 }

--- a/packages/cli/test/commands/game/play/notification/queue.test.ts
+++ b/packages/cli/test/commands/game/play/notification/queue.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 import GamePlayNotificationQueue from '../../../../../src/commands/game/play/notification-queue';
+import { expectNormalPlayPayloadToOmitDebugInternals } from '../normal-output-boundary';
 import { type FakeTunerServer, startFakeTunerServer } from '../../../fixtures/tuner-socket-server';
 
 type QueueMode =
@@ -112,21 +113,24 @@ async function runNotificationQueue(mode: QueueMode) {
     log.mockRestore();
   }
 
+  const payload = JSON.parse(writes.join('')) as {
+    ok: true;
+    view: {
+      queueLength: number;
+      schedule: Array<{
+        category: string;
+        command: string | null;
+        disposition: string;
+        isEndTurnBlocking: boolean;
+        safeToBatch: boolean;
+        typeName: string | null;
+      }>;
+    };
+  };
+  expectNormalPlayPayloadToOmitDebugInternals(payload);
+
   return {
-    payload: JSON.parse(writes.join('')) as {
-      ok: true;
-      view: {
-        queueLength: number;
-        schedule: Array<{
-          category: string;
-          command: string | null;
-          disposition: string;
-          isEndTurnBlocking: boolean;
-          safeToBatch: boolean;
-          typeName: string | null;
-        }>;
-      };
-    },
+    payload,
     server,
   };
 }

--- a/packages/cli/test/commands/game/play/ready-unit.test.ts
+++ b/packages/cli/test/commands/game/play/ready-unit.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import GamePlayReadyUnit from '../../../../src/commands/game/play/ready-unit';
 import { type FakeTunerServer, startFakeTunerServer } from '../../fixtures/tuner-socket-server';
+import { expectNormalPlayPayloadToOmitDebugInternals } from './normal-output-boundary';
 
 describe('game play ready-unit command', () => {
   test('reads ready-unit tactical view without sending operations', async () => {
     const server = await startReadyUnitTunerServer();
+    const writes: string[] = [];
+    const log = vi.spyOn(GamePlayReadyUnit.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
     try {
       const { port } = server.address();
       await GamePlayReadyUnit.run([
@@ -15,9 +20,12 @@ describe('game play ready-unit command', () => {
         '--json',
       ]);
 
+      const payload = JSON.parse(writes.join(''));
+      expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(server.received.some((message) => message.includes('readReadyUnitView'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendRequest'))).toBe(false);
     } finally {
+      log.mockRestore();
       await server.close();
     }
   });


### PR DESCRIPTION
docs(openspec): align map atom corpus status

Refs: openspec/changes/civ7-support-direct-control-modularization

Align the map atom corpus paragraphs with the completed later 4.11 owner slices for visibility, reveal, GameInfo, setup map rows, and player/unit/city summaries.

This is docs-only record alignment. It does not change source behavior, claim runtime or live-game proof, accept Task 2.9.4, or unblock telemetry, AI ingestion, semantic CLI projection, schema/procedure-core work, or Effect/oRPC implementation.

docs(openspec): align map task status

Refs: openspec/changes/civ7-support-direct-control-modularization

Align completed 4.11 task rows with later map owner slices for reveal mutation, GameInfo rows, setup map rows, and player/unit/city summaries.

This is docs-only record alignment. It does not change source behavior, claim runtime or live-game proof, accept Task 2.9.4, or unblock telemetry, AI ingestion, semantic CLI projection, schema/procedure-core work, or Effect/oRPC implementation.

docs(openspec): align runtime task status

Refs: openspec/changes/civ7-support-direct-control-modularization

Align early completed 4.12 runtime task rows with later runtime owner slices for App UI snapshot, Tuner health, playable status, bounded root inspection, capability catalog, catalog schemas, and runtime inspection constants.

This is docs-only record alignment. It does not change source behavior, claim runtime or live-game proof, accept Task 2.9.4, or unblock telemetry, AI ingestion, semantic CLI projection, schema/procedure-core work, or Effect/oRPC implementation.

test(cli): add ready-unit normal output proof

Refs: openspec/changes/civ7-support-direct-control-modularization

Extend the shared normal play output boundary assertion to the focused ready-unit play test so ready-unit joins priorities, ready-city, and unit-move-preview as normal projections that omit debug/internal direct-control markers.

This is local CLI proof only. It does not change runtime behavior, claim runtime or live-game proof, accept Task 2.9.4, or unblock telemetry, AI ingestion, semantic CLI projection, schema/procedure-core work, or Effect/oRPC implementation.

test(cli): add watch normal output proof

Refs: openspec/changes/civ7-support-direct-control-modularization

Extend the shared normal output boundary assertion to passive game watch JSONL and artifact observations so the debug/internal separation proof covers watch output alongside the focused play projections.

This is local CLI proof only. It does not change runtime behavior, claim runtime or live-game proof, accept Task 2.9.4, or unblock telemetry, AI ingestion, semantic CLI projection, schema/procedure-core work, or Effect/oRPC implementation.

test(cli): add progression normal output proof

Refs: openspec/changes/civ7-support-direct-control-modularization

Extend the shared normal output boundary assertion to progression-read JSON outputs for traditions and progress-dashboard surfaces so the debug/internal separation proof covers another player-agent projection family.

This is local CLI proof only. It does not change runtime behavior, claim runtime or live-game proof, accept Task 2.9.4, or unblock telemetry, AI ingestion, semantic CLI projection, schema/procedure-core work, or Effect/oRPC implementation.

test(cli): add tactical read normal output proof

Refs: openspec/changes/civ7-support-direct-control-modularization

Extend the shared normal output boundary assertion to the tactical-read command helper so civilian route triage, target candidates, front summary, battlefield scan, formation snapshot, and destination analysis outputs are covered as another player-agent projection family.

This is local CLI proof only. It does not change runtime behavior, claim runtime or live-game proof, accept Task 2.9.4, or unblock telemetry, AI ingestion, semantic CLI projection, schema/procedure-core work, or Effect/oRPC implementation.

test(cli): add settlement normal output proof

Refs: openspec/changes/civ7-support-direct-control-modularization

Extend the shared normal output boundary assertion to the settlement-recommendations read-only command output so settlement lens recommendations are covered as another player-agent projection family.

This is local CLI proof only. It does not change runtime behavior, claim runtime or live-game proof, accept Task 2.9.4, or unblock telemetry, AI ingestion, semantic CLI projection, schema/procedure-core work, or Effect/oRPC implementation.

test(cli): add promotion-readiness normal output proof

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds the shared normal-output debug-internal omission assertion to the promotion-readiness JSON test and updates the OpenSpec workstream records from eight to nine normal player-agent projection families.

Proof: bun run --cwd packages/cli test -- game.play.promotion-readiness.test.ts; bun run check:cli; bun run test:cli:play; bun run openspec -- validate civ7-support-direct-control-modularization --strict; bun run openspec:validate.

Local CLI proof only; no runtime/live-game proof, Task 2.9.4 acceptance, telemetry, AI-ingestion, schema, CLI hierarchy, or Effect/oRPC implementation claim.

test(cli): add rehydrate normal output proof

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds the shared normal-output debug-internal omission assertion to the rehydrate JSON test and updates the OpenSpec workstream records from nine to ten normal player-agent projection families.

Proof: bun run --cwd packages/cli test -- game.play.rehydrate.test.ts; bun run check:cli; bun run test:cli:play; bun run openspec -- validate civ7-support-direct-control-modularization --strict; bun run openspec:validate.

Local CLI proof only; no runtime/live-game proof, Task 2.9.4 acceptance, telemetry, AI-ingestion, schema, CLI hierarchy, or Effect/oRPC implementation claim.

test(cli): add notification HUD normal output proof

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds the shared normal-output debug-internal omission assertion to the notification HUD JSON helper and updates the OpenSpec workstream records from ten to eleven normal player-agent projection families.

Proof: bun run --cwd packages/cli test -- game/play/notification/hud.test.ts; bun run check:cli; bun run test:cli:play; bun run openspec -- validate civ7-support-direct-control-modularization --strict; bun run openspec:validate.

Local CLI proof only; no runtime/live-game proof, Task 2.9.4 acceptance, telemetry, AI-ingestion, schema, CLI hierarchy, or Effect/oRPC implementation claim.

test(cli): add notification queue normal output proof

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds the shared normal-output debug-internal omission assertion to the notification queue JSON helper and updates the OpenSpec workstream records from eleven to twelve normal player-agent projection families.

Proof: bun run --cwd packages/cli test -- game/play/notification/queue.test.ts; bun run check:cli; bun run test:cli:play; bun run openspec -- validate civ7-support-direct-control-modularization --strict; bun run openspec:validate.

Local CLI proof only; no runtime/live-game proof, Task 2.9.4 acceptance, telemetry, AI-ingestion, schema, CLI hierarchy, or Effect/oRPC implementation claim.

test(cli): add technology options normal output proof

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds the shared normal-output debug-internal omission assertion to the technology options JSON test and updates the OpenSpec workstream records from twelve to thirteen normal player-agent projection families.

Proof: bun run --cwd packages/cli test -- game.play.technology.test.ts; bun run check:cli; bun run test:cli:play; bun run openspec -- validate civ7-support-direct-control-modularization --strict; bun run openspec:validate.

Local CLI proof only; no runtime/live-game proof, Task 2.9.4 acceptance, telemetry, AI-ingestion, schema, CLI hierarchy, or Effect/oRPC implementation claim.

test(cli): add culture options normal output proof

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds the shared normal-output debug-internal omission assertion to the culture options JSON test and updates the OpenSpec workstream records from thirteen to fourteen normal player-agent projection families.

Proof: bun run --cwd packages/cli test -- game.play.culture.test.ts; bun run check:cli; bun run test:cli:play; bun run openspec -- validate civ7-support-direct-control-modularization --strict; bun run openspec:validate.

Local CLI proof only; no runtime/live-game proof, Task 2.9.4 acceptance, telemetry, AI-ingestion, schema, CLI hierarchy, or Effect/oRPC implementation claim.

test(cli): add celebration government normal output proof

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds the shared normal-output debug-internal omission assertion to the celebration and government options JSON tests and updates the OpenSpec workstream records from fourteen to sixteen normal player-agent projection families.

Proof: bun run --cwd packages/cli test -- game.play.celebration-government.test.ts; bun run check:cli; bun run test:cli:play; bun run openspec -- validate civ7-support-direct-control-modularization --strict; bun run openspec:validate.

Local CLI proof only; no runtime/live-game proof, Task 2.9.4 acceptance, telemetry, AI-ingestion, schema, CLI hierarchy, or Effect/oRPC implementation claim.