### PR TITLE
test(direct-control): add notification view procedure

### DIFF
--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -2281,6 +2281,26 @@ runtime/direct-control claims.
         `packages/civ7-control-orpc`, implement the in-game controller router,
         claim runtime/live-game proof, accept Task 2.9.4, or start Tasks
         6.1-6.9.
+  - [x] 4.36 Add the adjacent notification-view procedure atom in
+        `src/play/notifications/view-procedure.ts`, with TypeBox input/output
+        schemas beside the existing notification read atom in
+        `src/play/notifications/view.ts`, focused proof in
+        `test/play-notification-view-procedure.test.ts`, adjacent atom schema
+        proof in `test/play-notification-view.test.ts`, and public facade proof
+        in `test/public-api.test.ts`. This composes the local procedure-core
+        call primitive with the existing `getCiv7PlayNotificationView` atom,
+        validates bounded `maxNotifications` input before atom dependencies
+        run, keeps endpoint/session/state/raw-command selection out of
+        procedure input, validates notification/decision/HUD output through
+        descriptor schema artifacts, forwards direct-control options to the
+        atom, and keeps procedure diagnostics separate from notification-view
+        output. This is local no-network proof over fake atom dependencies
+        only; it does not change CLI output, notification classification, or
+        dismissal behavior, execute live direct-control atoms, add a
+        router/registry/transport adapter, choose Effect Schema, add
+        Effect/oRPC source, add `packages/civ7-control-orpc`, implement the
+        in-game controller router, claim runtime/live-game proof, accept Task
+        2.9.4, or start Tasks 6.1-6.9.
 
 ## 5. CLI Semantic Surface Lane
 
@@ -2344,10 +2364,14 @@ authority are recorded.
     empty procedure input schema that leaves endpoint/session/state selection
     in context and local no-network proof over a fake App UI command
     dependency.
+    Task 4.36 adds an adjacent read-atom schema/descriptor/call artifact for
+    `notifications.view` over the notification read atom, including bounded
+    `maxNotifications` input, notification/decision/HUD output schema proof,
+    and local no-network proof over fake atom dependencies.
     Task 6.1 remains blocked until Task 2.9.4 row acceptance names final
     procedure/schema/proof owners and tests over concrete procedure
     inputs/outputs beyond the ready-unit, ready-city, unit move-preview, and
-    runtime-support schema seeds, descriptor schema-reference binding/resolution,
+    runtime-support and notification-view schema seeds, descriptor schema-reference binding/resolution,
     adjacent descriptor/call artifacts, and resolver field-list guard.
 - [ ] 6.2 Evaluate TypeBox versus Effect Schema before adding or rewriting
       procedure-core/direct-control contract schemas. The decision must cover

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -2301,6 +2301,28 @@ runtime/direct-control claims.
         Effect/oRPC source, add `packages/civ7-control-orpc`, implement the
         in-game controller router, claim runtime/live-game proof, accept Task
         2.9.4, or start Tasks 6.1-6.9.
+  - [x] 4.37 Add the adjacent settlement-recommendations procedure atom in
+        `src/play/tactical/settlement-procedure.ts`, with TypeBox input/output
+        schemas beside the existing read-only settlement recommendation atom
+        in `src/play/tactical/settlement.ts`, focused proof in
+        `test/settlement-recommendations-procedure.test.ts`, adjacent atom
+        schema proof in `test/settlement-recommendations.test.ts`, and public
+        facade proof in `test/public-api.test.ts`. This composes the local
+        procedure-core call primitive with the existing
+        `getCiv7SettlementRecommendations` atom under the existing `strategy`
+        procedure family, validates bounded `count` and map-location input
+        before atom dependencies run, keeps endpoint/session/state/raw-command
+        selection out of procedure input, validates origin/suggestion output
+        through descriptor schema artifacts, forwards direct-control options
+        to the atom, and keeps procedure diagnostics separate from settlement
+        recommendation output. This is local no-network proof over fake atom
+        dependencies only; it does not change CLI output, reinterpret
+        recommendations as actions, add city-founding/send behavior, execute
+        live direct-control atoms, add a router/registry/transport adapter,
+        choose Effect Schema, add Effect/oRPC source, add
+        `packages/civ7-control-orpc`, implement the in-game controller router,
+        claim runtime/live-game proof, accept Task 2.9.4, or start Tasks
+        5.1-5.7 or 6.1-6.9.
 
 ## 5. CLI Semantic Surface Lane
 
@@ -2368,11 +2390,17 @@ authority are recorded.
     `notifications.view` over the notification read atom, including bounded
     `maxNotifications` input, notification/decision/HUD output schema proof,
     and local no-network proof over fake atom dependencies.
+    Task 4.37 adds an adjacent read-atom schema/descriptor/call artifact for
+    `strategy.settlement.recommendations` over the settlement recommendation
+    atom, including bounded `count` input, map-location input, origin/
+    suggestion output schema proof, and local no-network proof over fake atom
+    dependencies.
     Task 6.1 remains blocked until Task 2.9.4 row acceptance names final
     procedure/schema/proof owners and tests over concrete procedure
-    inputs/outputs beyond the ready-unit, ready-city, unit move-preview, and
-    runtime-support and notification-view schema seeds, descriptor schema-reference binding/resolution,
-    adjacent descriptor/call artifacts, and resolver field-list guard.
+    inputs/outputs beyond the ready-unit, ready-city, unit move-preview,
+    runtime-support, notification-view, and settlement-recommendations schema
+    seeds, descriptor schema-reference binding/resolution, adjacent
+    descriptor/call artifacts, and resolver field-list guard.
 - [ ] 6.2 Evaluate TypeBox versus Effect Schema before adding or rewriting
       procedure-core/direct-control contract schemas. The decision must cover
       encode/decode affordances, typed errors, oRPC compatibility, test

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -757,7 +757,8 @@ Intake rejection conditions:
   owner exists; descriptor context-policy metadata, payload validation, and a
   local injected-handler call primitive now exist for current schema/descriptor
   seeds; concrete ready-unit, ready-city, unit move-preview, playable-status,
-  and App UI snapshot procedure call wrappers exist adjacent to their
+  App UI snapshot, Tuner health, and notification-view procedure call wrappers
+  exist adjacent to their
   direct-control atoms; final procedure-core/schema/runtime-context,
   middleware, error, and correlation owners remain pending
 - `proofOwner`: `packages/civ7-direct-control/test/procedure-core.test.ts`
@@ -781,6 +782,9 @@ Intake rejection conditions:
   `packages/civ7-direct-control/test/tuner-health-procedure.test.ts` now also
   proves the adjacent concrete Tuner health procedure call wrapper with fake
   session/reconnect dependencies.
+  `packages/civ7-direct-control/test/play-notification-view-procedure.test.ts`
+  now also proves the adjacent concrete notification-view procedure call
+  wrapper with fake atom dependencies.
 - `playerScope`: per-procedure; local-player and agent-slot scoped for
   mutation; debug/observer scoped for diagnostics
 - `consumerClass`: Effect/oRPC procedure core; in-game controller service
@@ -872,6 +876,13 @@ Intake rejection conditions:
   third adjacent runtime-support descriptor artifact is now
   `packages/civ7-direct-control/src/runtime/tuner-health-procedure.ts`, with
   proof in `packages/civ7-direct-control/test/tuner-health-procedure.test.ts`.
+  The adjacent notification read descriptor artifact is now
+  `packages/civ7-direct-control/src/play/notifications/view-procedure.ts`,
+  with TypeBox schema ownership in
+  `packages/civ7-direct-control/src/play/notifications/view.ts` and proof in
+  `packages/civ7-direct-control/test/play-notification-view-procedure.test.ts`
+  plus adjacent atom schema proof in
+  `packages/civ7-direct-control/test/play-notification-view.test.ts`.
   The descriptor owner also records `schemaTechnology`, requires current
   adjacent descriptors to declare `typebox`, and rejects unaccepted
   `effect-schema` or `zod-adapter` claims before procedure promotion. The
@@ -886,10 +897,12 @@ Intake rejection conditions:
   output-after-handler validation, separated output/diagnostics, generated and
   caller-provided correlation IDs, and handler failure normalization. The
   concrete ready-unit, ready-city, unit move-preview, playable-status, App UI
-  snapshot, and Tuner health procedure call wrappers now compose that primitive with
+  snapshot, Tuner health, and notification-view procedure call wrappers now
+  compose that primitive with
   `getCiv7ReadyUnitView`, `getCiv7ReadyCityView`,
   `getCiv7UnitMovePreview`, `getCiv7PlayableStatus`, and
-  `getCiv7AppUiSnapshot`, and `checkCiv7TunerHealth` through fake
+  `getCiv7AppUiSnapshot`, `checkCiv7TunerHealth`, and
+  `getCiv7PlayNotificationView` through fake
   direct-control dependencies in focused proof.
   Missing before acceptance: final procedure-core schema owner, proof owner,
   accepted TypeBox versus Effect Schema disposition for final procedure
@@ -897,9 +910,9 @@ Intake rejection conditions:
   concrete procedure owners, and explicit owner boundaries for the in-game
   controller router, external direct-control bridge, and future AI services.
 - `writeSet`: current write set is the direct-control procedure descriptor
-  owner, adjacent descriptor metadata declaring current TypeBox schema
-  technology, focused descriptor/public facade proof, and docs/OpenSpec
-  records.
+  owner, adjacent descriptor/call metadata declaring current TypeBox schema
+  technology, notification-view TypeBox schemas, focused descriptor/atom/public
+  facade proof, and docs/OpenSpec records.
   Future implementation write sets must name the exact procedure-core module or
   package, typed schema artifact, middleware/context/error/correlation tests,
   and narrow adapters to stable direct-control atom owners. No transport adapter,
@@ -985,6 +998,17 @@ Intake rejection conditions:
   validate empty input, invoke the stable runtime-support atom, validate raw
   App UI diagnostic output, and return diagnostics separately from the atom
   output.
+  The current source artifact now also adds TypeBox input/output schemas for
+  the existing `getCiv7PlayNotificationView` read atom, including bounded
+  `maxNotifications` input, endpoint/session/state/raw-command exclusion from
+  procedure input, notification/decision/HUD output shape validation, and
+  root-level output shape separation from raw command fields. The adjacent
+  notification-view procedure artifact records that read atom's procedure
+  metadata and schema artifact map without registering a router, and exports a
+  concrete `notifications.view` call wrapper that uses the local call primitive
+  to validate input, invoke the stable read atom, validate output, forward
+  direct-control options, and return diagnostics separately from the atom
+  output.
 - `schemaOwner`: current TypeBox descriptor shape is now runtime-validated in
   the direct-control descriptor owner before semantic guards, with local proof
   for malformed projection, consumer-class, array-field, and extra-property
@@ -1016,7 +1040,11 @@ Intake rejection conditions:
   and raw command/session selection. Current App UI snapshot procedure proof
   also checks the empty input schema rejects host/port/state and raw
   command/session selection while the output field list resolves against the
-  App UI snapshot result schema. Current procedure-core payload validation
+  App UI snapshot result schema. Current notification-view schema/procedure
+  proof also checks bounded `maxNotifications` input, host/port/state/raw
+  command exclusion from procedure input, fake notification/decision/HUD output
+  validation, raw root-field rejection, and descriptor output-field resolution
+  against the notification-view result schema. Current procedure-core payload validation
   proof validates ready-unit input/output payloads and unit move-preview
   validator-equivalent map-location inputs against resolved descriptor schema
   artifacts, including raw root-field rejection. Current procedure-call proof
@@ -1029,17 +1057,21 @@ Intake rejection conditions:
   router schema registration.
 - `concreteProcedureOwner`: current concrete procedure proof exists for
   `unit.ready.view`, `city.ready.view`, `unit.move.preview`,
-  `runtime.playable.status`, and `runtime.app.ui.snapshot`, where the adjacent
+  `runtime.playable.status`, `runtime.app.ui.snapshot`,
+  `runtime.tuner.health`, and `notifications.view`, where the adjacent
   procedure wrappers compose
   `getCiv7ReadyUnitView`, `getCiv7ReadyCityView`,
-  `getCiv7UnitMovePreview`, `getCiv7PlayableStatus`, and
-  `getCiv7AppUiSnapshot` with the
+  `getCiv7UnitMovePreview`, `getCiv7PlayableStatus`,
+  `getCiv7AppUiSnapshot`, `checkCiv7TunerHealth`, and
+  `getCiv7PlayNotificationView` with the
   procedure-core call primitive through fake dependencies. They prove input
   rejection before atom dependencies run, direct-control option forwarding into
   the atoms, atom output validation, separated diagnostics, neutral
   move-preview relationship-policy preservation, and playable-status
-  readiness/error/tuner-absence output validation, and App UI snapshot raw
-  diagnostic output validation. Broader concrete procedures, runtime router
+  readiness/error/tuner-absence output validation, App UI snapshot raw
+  diagnostic output validation, Tuner health raw diagnostic output validation,
+  and notification-view context-input rejection plus notification/decision/HUD
+  output validation. Broader concrete procedures, runtime router
   registration, and oRPC handler registration remain pending.
 - `errorOwner`: current descriptor-owner failures now use
   `Civ7DirectControlError` with code `procedure-descriptor-invalid` and
@@ -1088,9 +1120,9 @@ Intake rejection conditions:
   move-preview descriptors, local injected-handler procedure-call proof for
   input-before-handler/output-after-handler sequencing, separated
   output/diagnostics, correlation-id policy, and handler failure normalization,
-  adjacent ready-unit, ready-city, unit move-preview, playable-status, and
-  App UI snapshot procedure call proof over stable direct-control atoms with
-  fake dependencies,
+  adjacent ready-unit, ready-city, unit move-preview, playable-status,
+  App UI snapshot, Tuner health, and notification-view procedure call proof
+  over stable direct-control atoms with fake dependencies,
   mutation approval/validator/postcondition/no-repeat gate requirements,
   telemetry projection as an Effect/oRPC middleware hook rather than a separate
   transport surface, and schema-technology proof that current descriptors
@@ -1123,8 +1155,9 @@ Intake rejection conditions:
   after handler execution on invalid output, requires caller-provided
   correlation IDs where descriptor policy says so, and wraps injected-handler
   failures with procedure/correlation details. The adjacent ready-unit,
-  ready-city, unit move-preview, playable-status, and App UI snapshot wrappers
-  fail before their atom dependencies run when procedure input is invalid.
+  ready-city, unit move-preview, playable-status, App UI snapshot, Tuner
+  health, and notification-view wrappers fail before their atom dependencies
+  run when procedure input is invalid.
   Current descriptors also fail before promotion if they claim unaccepted
   `effect-schema` or `zod-adapter` ownership instead of the current TypeBox
   descriptor contract.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/compatibility-matrix.md
@@ -757,8 +757,8 @@ Intake rejection conditions:
   owner exists; descriptor context-policy metadata, payload validation, and a
   local injected-handler call primitive now exist for current schema/descriptor
   seeds; concrete ready-unit, ready-city, unit move-preview, playable-status,
-  App UI snapshot, Tuner health, and notification-view procedure call wrappers
-  exist adjacent to their
+  App UI snapshot, Tuner health, notification-view, and
+  settlement-recommendations procedure call wrappers exist adjacent to their
   direct-control atoms; final procedure-core/schema/runtime-context,
   middleware, error, and correlation owners remain pending
 - `proofOwner`: `packages/civ7-direct-control/test/procedure-core.test.ts`
@@ -785,6 +785,9 @@ Intake rejection conditions:
   `packages/civ7-direct-control/test/play-notification-view-procedure.test.ts`
   now also proves the adjacent concrete notification-view procedure call
   wrapper with fake atom dependencies.
+  `packages/civ7-direct-control/test/settlement-recommendations-procedure.test.ts`
+  now also proves the adjacent concrete settlement-recommendations procedure
+  call wrapper with fake atom dependencies.
 - `playerScope`: per-procedure; local-player and agent-slot scoped for
   mutation; debug/observer scoped for diagnostics
 - `consumerClass`: Effect/oRPC procedure core; in-game controller service
@@ -883,6 +886,13 @@ Intake rejection conditions:
   `packages/civ7-direct-control/test/play-notification-view-procedure.test.ts`
   plus adjacent atom schema proof in
   `packages/civ7-direct-control/test/play-notification-view.test.ts`.
+  The adjacent settlement-recommendations descriptor artifact is now
+  `packages/civ7-direct-control/src/play/tactical/settlement-procedure.ts`,
+  with TypeBox schema ownership in
+  `packages/civ7-direct-control/src/play/tactical/settlement.ts` and proof in
+  `packages/civ7-direct-control/test/settlement-recommendations-procedure.test.ts`
+  plus adjacent atom schema proof in
+  `packages/civ7-direct-control/test/settlement-recommendations.test.ts`.
   The descriptor owner also records `schemaTechnology`, requires current
   adjacent descriptors to declare `typebox`, and rejects unaccepted
   `effect-schema` or `zod-adapter` claims before procedure promotion. The
@@ -897,22 +907,25 @@ Intake rejection conditions:
   output-after-handler validation, separated output/diagnostics, generated and
   caller-provided correlation IDs, and handler failure normalization. The
   concrete ready-unit, ready-city, unit move-preview, playable-status, App UI
-  snapshot, Tuner health, and notification-view procedure call wrappers now
+  snapshot, Tuner health, notification-view, and
+  settlement-recommendations procedure call wrappers now
   compose that primitive with
   `getCiv7ReadyUnitView`, `getCiv7ReadyCityView`,
-  `getCiv7UnitMovePreview`, `getCiv7PlayableStatus`, and
-  `getCiv7AppUiSnapshot`, `checkCiv7TunerHealth`, and
-  `getCiv7PlayNotificationView` through fake
+  `getCiv7UnitMovePreview`, `getCiv7PlayableStatus`,
+  `getCiv7AppUiSnapshot`, `checkCiv7TunerHealth`,
+  `getCiv7PlayNotificationView`, and
+  `getCiv7SettlementRecommendations` through fake
   direct-control dependencies in focused proof.
   Missing before acceptance: final procedure-core schema owner, proof owner,
   accepted TypeBox versus Effect Schema disposition for final procedure
   contracts, runtime-context/middleware/error/correlation owner, broader
   concrete procedure owners, and explicit owner boundaries for the in-game
   controller router, external direct-control bridge, and future AI services.
-- `writeSet`: current write set is the direct-control procedure descriptor
-  owner, adjacent descriptor/call metadata declaring current TypeBox schema
-  technology, notification-view TypeBox schemas, focused descriptor/atom/public
-  facade proof, and docs/OpenSpec records.
+- `writeSet`: current write set is the direct-control settlement
+  recommendation atom schema owner, adjacent
+  `strategy.settlement.recommendations` descriptor/call metadata declaring
+  current TypeBox schema technology, focused descriptor/atom/public facade
+  proof, and docs/OpenSpec records.
   Future implementation write sets must name the exact procedure-core module or
   package, typed schema artifact, middleware/context/error/correlation tests,
   and narrow adapters to stable direct-control atom owners. No transport adapter,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/direct-control-atom-corpus.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/direct-control-atom-corpus.md
@@ -593,6 +593,27 @@ add a router/registry/transport adapter, choose Effect Schema, claim
 runtime/live-game proof, accept Task 2.9.4, or unblock broader AI ingestion,
 debug hierarchy, telemetry persistence, or Effect/oRPC procedure cores.
 
+Settlement-recommendations procedure atom seed update:
+`src/play/tactical/settlement.ts` now owns TypeBox input/output schemas for the
+existing read-only settlement recommendation atom, including bounded `count`,
+shared map-location input, settlement origin/suggestion output, and root output
+separation from raw command fields.
+`src/play/tactical/settlement-procedure.ts` now owns the adjacent
+`strategy.settlement.recommendations` descriptor/schema artifact map and
+concrete call wrapper over `getCiv7SettlementRecommendations` while staying
+under the existing `strategy` procedure family. `test/settlement-recommendations.test.ts`
+proves the fake settlement result matches the schema and rejects invalid
+count/location plus context/raw-command procedure input;
+`test/settlement-recommendations-procedure.test.ts` proves descriptor schema
+resolution, no-network fake-dependency calls, direct-control option forwarding,
+input-before-dependency rejection, output validation, separated diagnostics,
+and preservation of the read-only settlement lens boundary. This is local
+read-atom proof only. It does not change CLI output, reinterpret
+recommendations as actions, add city-founding/send behavior, add a
+router/registry/transport adapter, choose Effect Schema, claim runtime/live-game
+proof, accept Task 2.9.4, or unblock broader AI ingestion, debug hierarchy,
+telemetry persistence, or Effect/oRPC procedure cores.
+
 ## Forbidden Owners
 
 - CLI must not own raw socket framing, state discovery, reconnect polling,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/direct-control-atom-corpus.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/direct-control-atom-corpus.md
@@ -575,6 +575,24 @@ export a public schema, add telemetry persistence, infer runtime/live-game
 proof, accept Task 2.9.4, or unblock broader operation adapters, AI ingestion,
 semantic CLI output, debug hierarchy, or Effect/oRPC procedure cores.
 
+Notification-view procedure atom seed update:
+`src/play/notifications/view.ts` now owns TypeBox input/output schemas for the
+existing read-only notification view atom, including bounded
+`maxNotifications`, notification summaries, decision hints, HUD decision queue
+items, and root output separation from raw command fields.
+`src/play/notifications/view-procedure.ts` now owns the adjacent
+`notifications.view` descriptor/schema artifact map and concrete call wrapper
+over `getCiv7PlayNotificationView`. `test/play-notification-view.test.ts`
+proves the fake notification-view result matches the schema and rejects
+context/raw-command procedure input; `test/play-notification-view-procedure.test.ts`
+proves descriptor schema resolution, no-network fake-dependency calls,
+direct-control option forwarding, input-before-dependency rejection, output
+validation, and separated diagnostics. This is local read-atom proof only. It
+does not change CLI output, notification classification, dismissal behavior,
+add a router/registry/transport adapter, choose Effect Schema, claim
+runtime/live-game proof, accept Task 2.9.4, or unblock broader AI ingestion,
+debug hierarchy, telemetry persistence, or Effect/oRPC procedure cores.
+
 ## Forbidden Owners
 
 - CLI must not own raw socket framing, state discovery, reconnect polling,

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/procedure-core-contract.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/procedure-core-contract.md
@@ -77,8 +77,12 @@ owns the `runtime.tuner.health` descriptor adjacent to the Tuner health atom and
 schema exports. The adjacent notification read descriptor artifact is
 `packages/civ7-direct-control/src/play/notifications/view-procedure.ts`, which
 owns the `notifications.view` descriptor adjacent to the notification read atom
-and schema exports. This is local package proof only; it does not collect
-runtime evidence, add Effect/oRPC dependencies, create
+and schema exports. The adjacent settlement-recommendations descriptor artifact
+is `packages/civ7-direct-control/src/play/tactical/settlement-procedure.ts`,
+which owns the `strategy.settlement.recommendations` descriptor adjacent to the
+read-only settlement recommendation atom and schema exports while staying under
+the existing `strategy` procedure family. This is local package proof only; it
+does not collect runtime evidence, add Effect/oRPC dependencies, create
 `packages/civ7-control-orpc`, implement router/procedure behavior, choose a
 broader schema migration, claim runtime proof, or accept the matrix row.
 
@@ -161,6 +165,23 @@ exported for future procedure-core consumers. This is a read-only notification
 view schema seed; it does not change normal CLI output, notification
 classification, dismissal behavior, runtime proof, or matrix-row acceptance.
 
+`packages/civ7-direct-control/src/play/tactical/settlement.ts` now owns
+TypeBox schemas for `getCiv7SettlementRecommendations` input, settlement
+recommendation factors, origins, suggestions, recommendations, and output. The
+input schema preserves the existing bounded `count` contract and uses the
+shared bounded map-location schema for requested locations; endpoint/session/
+state selection and raw command fields remain procedure context/debug
+concerns. Focused proof in
+`packages/civ7-direct-control/test/settlement-recommendations.test.ts`
+validates the existing fake settlement recommendation result against the
+output schema, rejects out-of-bound `count`, invalid map locations,
+context/raw-command input, and root-level raw command output fields. Public
+facade proof in `packages/civ7-direct-control/test/public-api.test.ts`
+verifies the schemas are exported for future procedure-core consumers. This is
+a read-only settlement recommendation schema seed; it does not change normal
+CLI output, reinterpret recommendations as actions, add city-founding/send
+behavior, claim runtime proof, or accept the matrix row.
+
 The adjacent ready-unit descriptor artifact reuses those schema exports and
 records root input/output field names from the actual TypeBox schemas,
 including `legalOperations` for the ready-unit operation candidates. Focused
@@ -238,14 +259,32 @@ schema exports and records `notifications.view` beside
 checks the descriptor's input/output field lists against resolved schema root
 properties, including notifications, decisions, HUD, and limits, without
 registering a router or transport adapter. The same artifact exports a concrete
-call wrapper composed through the local procedure-core call primitive. Focused
-proof uses fake atom dependencies to prove direct-control option forwarding,
-bounded input validation before atom dependencies run, output validation after
-the atom returns, and separated output/diagnostics. This is local no-network
-read-atom proof only; it does not execute live notification reads, add a router,
-add Effect/oRPC dependencies, choose Effect Schema, claim runtime proof, change
-CLI output, change notification classification/dismissal behavior, or accept
-the matrix row.
+call wrapper over `getCiv7PlayNotificationView`, composed through the local
+procedure-core call primitive. Focused proof uses fake atom dependencies to
+prove direct-control option forwarding, input validation before atom
+dependencies run, output validation after the atom returns, and separated
+output/diagnostics. This is local no-network read-atom proof only; it does not
+change CLI output, notification classification, dismissal behavior, add a
+router, add Effect/oRPC dependencies, choose Effect Schema, claim runtime
+proof, or accept the matrix row.
+
+The adjacent settlement-recommendations procedure artifact reuses the
+settlement recommendation schema exports and records
+`strategy.settlement.recommendations` beside
+`getCiv7SettlementRecommendations`. Focused proof in
+`packages/civ7-direct-control/test/settlement-recommendations-procedure.test.ts`
+checks the descriptor's input/output field lists against resolved schema root
+properties, including requested locations, origins, recommendations, and notes,
+without registering a router or transport adapter. The same artifact exports a
+concrete call wrapper over `getCiv7SettlementRecommendations`, composed
+through the local procedure-core call primitive. Focused proof uses fake atom
+dependencies to prove direct-control option forwarding, input validation before
+atom dependencies run, output validation after the atom returns, separated
+output/diagnostics, and preservation of the read-only settlement lens boundary.
+This is local no-network read-atom proof only; it does not change CLI output,
+reinterpret recommendations as actions, add city-founding/send behavior, add
+a router, add Effect/oRPC dependencies, choose Effect Schema, claim runtime
+proof, or accept the matrix row.
 
 Local procedure-core payload validation now lives in
 `packages/civ7-direct-control/src/procedure-core.ts`. Focused proof in
@@ -387,12 +426,13 @@ gaps for the current TypeBox descriptor shape, generic raw fields,
 repo-local command-source/session-execute
 owners, context-owned endpoint/state input fields, and adjacent ready-unit,
 ready-city, unit move-preview, playable-status, App UI snapshot, Tuner
-health, and notification-view descriptor artifacts with
+health, notification-view, and settlement-recommendations descriptor artifacts with
 schema-root field-list validation plus local payload validation against
 resolved schema artifacts plus a local injected-handler call primitive in the
 Effect/oRPC Procedure Cores row, plus concrete ready-unit, ready-city,
 unit move-preview, playable-status, App UI snapshot, Tuner health, and
-notification-view procedure call wrappers, but they do not accept the row.
+notification-view and settlement-recommendations procedure call wrappers, but
+they do not accept the row.
 Acceptance still needs:
 
 - final concrete procedure schema and proof owners;
@@ -400,7 +440,7 @@ Acceptance still needs:
   procedure contracts;
 - concrete procedure input/output owners over stable direct-control atoms
   beyond the current ready-read, move-preview, runtime-support, and
-  notification-view call wrappers;
+  notification-view and settlement-recommendations call wrappers;
 - final middleware/error/correlation owners and runtime context construction
   beyond descriptor context-policy metadata and the local injected-handler call
   helper;

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/procedure-core-contract.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/procedure-core-contract.md
@@ -71,7 +71,13 @@ playable-status atom and schema exports. The second adjacent runtime-support
 descriptor artifact is
 `packages/civ7-direct-control/src/runtime/app-ui-snapshot-procedure.ts`, which
 owns the `runtime.app.ui.snapshot` descriptor adjacent to the App UI snapshot
-atom and schema exports. This is local package proof only; it does not collect
+atom and schema exports. The third adjacent runtime-support descriptor artifact
+is `packages/civ7-direct-control/src/runtime/tuner-health-procedure.ts`, which
+owns the `runtime.tuner.health` descriptor adjacent to the Tuner health atom and
+schema exports. The adjacent notification read descriptor artifact is
+`packages/civ7-direct-control/src/play/notifications/view-procedure.ts`, which
+owns the `notifications.view` descriptor adjacent to the notification read atom
+and schema exports. This is local package proof only; it does not collect
 runtime evidence, add Effect/oRPC dependencies, create
 `packages/civ7-control-orpc`, implement router/procedure behavior, choose a
 broader schema migration, claim runtime proof, or accept the matrix row.
@@ -140,6 +146,20 @@ input. Focused proof in
 the empty input and the existing App UI snapshot result schema through the
 adjacent descriptor artifact, rejects endpoint/session/raw-command input
 fields, and rejects root-level raw command output fields.
+
+`packages/civ7-direct-control/src/play/notifications/view.ts` now owns TypeBox
+schemas for `getCiv7PlayNotificationView` input, notification decision hints,
+notification summaries, HUD decision queue items, and output. The input schema
+admits only bounded `maxNotifications`; endpoint/session/state selection and
+raw command fields remain procedure context/debug concerns. Focused proof in
+`packages/civ7-direct-control/test/play-notification-view.test.ts` validates
+the existing fake notification-view result against the output schema, rejects
+out-of-bound input plus host/port/state/raw-command input, and rejects
+root-level raw command output fields. Public facade proof in
+`packages/civ7-direct-control/test/public-api.test.ts` verifies the schemas are
+exported for future procedure-core consumers. This is a read-only notification
+view schema seed; it does not change normal CLI output, notification
+classification, dismissal behavior, runtime proof, or matrix-row acceptance.
 
 The adjacent ready-unit descriptor artifact reuses those schema exports and
 records root input/output field names from the actual TypeBox schemas,
@@ -210,6 +230,22 @@ separated output/diagnostics. This is local no-network runtime-support proof
 only; it does not execute live App UI reads, add a router, add Effect/oRPC
 dependencies, choose Effect Schema, claim runtime proof, or accept the matrix
 row.
+
+The adjacent notification-view procedure artifact reuses the notification-view
+schema exports and records `notifications.view` beside
+`getCiv7PlayNotificationView`. Focused proof in
+`packages/civ7-direct-control/test/play-notification-view-procedure.test.ts`
+checks the descriptor's input/output field lists against resolved schema root
+properties, including notifications, decisions, HUD, and limits, without
+registering a router or transport adapter. The same artifact exports a concrete
+call wrapper composed through the local procedure-core call primitive. Focused
+proof uses fake atom dependencies to prove direct-control option forwarding,
+bounded input validation before atom dependencies run, output validation after
+the atom returns, and separated output/diagnostics. This is local no-network
+read-atom proof only; it does not execute live notification reads, add a router,
+add Effect/oRPC dependencies, choose Effect Schema, claim runtime proof, change
+CLI output, change notification classification/dismissal behavior, or accept
+the matrix row.
 
 Local procedure-core payload validation now lives in
 `packages/civ7-direct-control/src/procedure-core.ts`. Focused proof in
@@ -350,21 +386,21 @@ context-policy, descriptor schema-technology guard, and no-raw-tunnel proof
 gaps for the current TypeBox descriptor shape, generic raw fields,
 repo-local command-source/session-execute
 owners, context-owned endpoint/state input fields, and adjacent ready-unit,
-ready-city, unit move-preview, playable-status, App UI snapshot, and Tuner
-health descriptor artifacts with
+ready-city, unit move-preview, playable-status, App UI snapshot, Tuner
+health, and notification-view descriptor artifacts with
 schema-root field-list validation plus local payload validation against
 resolved schema artifacts plus a local injected-handler call primitive in the
 Effect/oRPC Procedure Cores row, plus concrete ready-unit, ready-city,
-unit move-preview, playable-status, App UI snapshot, and Tuner health procedure call
-wrappers, but they do not accept the row.
+unit move-preview, playable-status, App UI snapshot, Tuner health, and
+notification-view procedure call wrappers, but they do not accept the row.
 Acceptance still needs:
 
 - final concrete procedure schema and proof owners;
 - accepted TypeBox versus Effect Schema/Zod adapter disposition for final
   procedure contracts;
 - concrete procedure input/output owners over stable direct-control atoms
-  beyond the current ready-read, move-preview, and runtime-support call
-  wrappers;
+  beyond the current ready-read, move-preview, runtime-support, and
+  notification-view call wrappers;
 - final middleware/error/correlation owners and runtime context construction
   beyond descriptor context-policy metadata and the local injected-handler call
   helper;

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -3503,3 +3503,23 @@ All future agent waves must be framed before delegation:
   proof only; it does not migrate schemas, deprecate TypeBox, add Effect
   Schema artifacts, add a Zod adapter, implement Effect/oRPC source, claim
   runtime/live-game proof, accept Task 2.9.4, or start Tasks 6.1-6.9.
+- Notification-view procedure atom seed:
+  `packages/civ7-direct-control/src/play/notifications/view.ts` now owns
+  TypeBox input/output schemas for the existing read-only notification view
+  atom, and
+  `packages/civ7-direct-control/src/play/notifications/view-procedure.ts`
+  records the adjacent `notifications.view` descriptor/schema artifact map and
+  concrete call wrapper over `getCiv7PlayNotificationView`. Focused proof in
+  `packages/civ7-direct-control/test/play-notification-view.test.ts` validates
+  the fake notification-view result against the schema and rejects endpoint/
+  session/state/raw-command procedure input; proof in
+  `packages/civ7-direct-control/test/play-notification-view-procedure.test.ts`
+  covers descriptor schema resolution, no-network fake-dependency calls,
+  direct-control option forwarding, input-before-dependency rejection, output
+  validation, and separated diagnostics. Public facade proof in
+  `packages/civ7-direct-control/test/public-api.test.ts` covers the schema,
+  descriptor, artifact map, and call-wrapper exports. This is local read-atom
+  proof only; it does not change CLI output, notification classification,
+  dismissal behavior, add a router/registry/transport adapter, choose Effect
+  Schema, claim runtime/live-game proof, accept Task 2.9.4, or start Tasks
+  6.1-6.9.

--- a/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/workstream/workstream-record.md
@@ -3523,3 +3523,27 @@ All future agent waves must be framed before delegation:
   dismissal behavior, add a router/registry/transport adapter, choose Effect
   Schema, claim runtime/live-game proof, accept Task 2.9.4, or start Tasks
   6.1-6.9.
+- Settlement-recommendations procedure atom seed:
+  `packages/civ7-direct-control/src/play/tactical/settlement.ts` now owns
+  TypeBox input/output schemas for the existing read-only settlement
+  recommendation atom, and
+  `packages/civ7-direct-control/src/play/tactical/settlement-procedure.ts`
+  records the adjacent `strategy.settlement.recommendations` descriptor/schema
+  artifact map and concrete call wrapper over
+  `getCiv7SettlementRecommendations` while preserving the existing `strategy`
+  procedure family. Focused proof in
+  `packages/civ7-direct-control/test/settlement-recommendations.test.ts`
+  validates the fake settlement result against the schema and rejects invalid
+  count/location plus endpoint/session/state/raw-command procedure input; proof
+  in
+  `packages/civ7-direct-control/test/settlement-recommendations-procedure.test.ts`
+  covers descriptor schema resolution, no-network fake-dependency calls,
+  direct-control option forwarding, input-before-dependency rejection, output
+  validation, separated diagnostics, and preservation of the read-only
+  settlement lens boundary. Public facade proof in
+  `packages/civ7-direct-control/test/public-api.test.ts` covers the schema,
+  descriptor, artifact map, and call-wrapper exports. This is local read-atom
+  proof only; it does not change CLI output, reinterpret recommendations as
+  actions, add city-founding/send behavior, add a router/registry/transport
+  adapter, choose Effect Schema, claim runtime/live-game proof, accept Task
+  2.9.4, or start Tasks 5.1-5.7 or 6.1-6.9.

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -776,8 +776,25 @@ export type {
   Civ7SettlementRecommendationInput,
   Civ7SettlementRecommendationOrigin,
   Civ7SettlementRecommendationResult,
+  SettlementRecommendationDependencies,
 } from "./play/tactical/settlement.js";
-export { getCiv7SettlementRecommendations };
+export {
+  Civ7SettlementRecommendationFactorSchema,
+  Civ7SettlementRecommendationInputSchema,
+  Civ7SettlementRecommendationOriginSchema,
+  Civ7SettlementRecommendationResultSchema,
+  Civ7SettlementRecommendationSchema,
+  Civ7SettlementSuggestionSchema,
+  getCiv7SettlementRecommendations,
+} from "./play/tactical/settlement.js";
+export {
+  callCiv7SettlementRecommendationsProcedure,
+  Civ7SettlementRecommendationsProcedureDescriptor,
+  Civ7SettlementRecommendationsProcedureSchemaArtifacts,
+} from "./play/tactical/settlement-procedure.js";
+export type {
+  Civ7SettlementRecommendationsProcedureCallOptions,
+} from "./play/tactical/settlement-procedure.js";
 export type {
   Civ7TargetCandidate,
   Civ7TargetCandidatesInput,

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -714,13 +714,39 @@ export {
 export type { Civ7ReadyCityViewProcedureCallOptions } from "./play/ready/city-procedure.js";
 export type {
   Civ7PlayDecisionAction,
+  Civ7PlayDecisionActionContract,
   Civ7PlayDecisionHint,
+  Civ7PlayDecisionHintContract,
   Civ7PlayDecisionInput,
+  Civ7PlayDecisionInputContract,
   Civ7PlayDecisionQueueItem,
+  Civ7PlayDecisionQueueItemContract,
   Civ7PlayNotificationSummary,
+  Civ7PlayNotificationSummaryContract,
+  Civ7PlayNotificationViewInput,
+  Civ7PlayNotificationViewResultContract,
   Civ7PlayNotificationViewResult,
+  PlayNotificationViewDependencies,
+  PlayNotificationViewOptions,
 } from "./play/notifications/view.js";
-export { getCiv7PlayNotificationView } from "./play/notifications/view.js";
+export {
+  Civ7PlayDecisionActionSchema,
+  Civ7PlayDecisionHintSchema,
+  Civ7PlayDecisionInputSchema,
+  Civ7PlayDecisionQueueItemSchema,
+  Civ7PlayNotificationSummarySchema,
+  Civ7PlayNotificationViewInputSchema,
+  Civ7PlayNotificationViewResultSchema,
+  getCiv7PlayNotificationView,
+} from "./play/notifications/view.js";
+export {
+  callCiv7PlayNotificationViewProcedure,
+  Civ7PlayNotificationViewProcedureDescriptor,
+  Civ7PlayNotificationViewProcedureSchemaArtifacts,
+} from "./play/notifications/view-procedure.js";
+export type {
+  Civ7PlayNotificationViewProcedureCallOptions,
+} from "./play/notifications/view-procedure.js";
 export type {
   Civ7NotificationDismissInput,
   Civ7NotificationDismissalResult,

--- a/packages/civ7-direct-control/src/play/notifications/view-procedure.ts
+++ b/packages/civ7-direct-control/src/play/notifications/view-procedure.ts
@@ -1,0 +1,107 @@
+import {
+  callCiv7ProcedureCore,
+  civ7ProcedureSchemaReferenceKey,
+  createCiv7ProcedureCoreDescriptor,
+  type Civ7ProcedureCoreCallOptions,
+  type Civ7ProcedureCoreCallResult,
+  type Civ7ProcedureSchemaArtifactMap,
+} from "../../procedure-core.js";
+import type { Civ7DirectControlOptions } from "../../session/types.js";
+import {
+  getCiv7PlayNotificationView,
+  Civ7PlayNotificationViewInputSchema,
+  Civ7PlayNotificationViewResultSchema,
+  type Civ7PlayNotificationViewInput,
+  type Civ7PlayNotificationViewResult,
+  type PlayNotificationViewDependencies,
+} from "./view.js";
+
+export const Civ7PlayNotificationViewProcedureDescriptor = createCiv7ProcedureCoreDescriptor({
+  procedureKey: "notifications.view",
+  family: "notifications",
+  risk: "read",
+  atomOwner: "packages/civ7-direct-control/src/play/notifications/view.ts",
+  atomFunction: "getCiv7PlayNotificationView",
+  schemaTechnology: "typebox",
+  inputSchema: {
+    owner: "packages/civ7-direct-control/src/play/notifications/view.ts",
+    exportName: "Civ7PlayNotificationViewInputSchema",
+  },
+  outputSchema: {
+    owner: "packages/civ7-direct-control/src/play/notifications/view.ts",
+    exportName: "Civ7PlayNotificationViewResultSchema",
+  },
+  inputFields: ["maxNotifications"],
+  outputFields: [
+    "localPlayerId",
+    "turn",
+    "turnDate",
+    "hasSentTurnComplete",
+    "canEndTurn",
+    "blocker",
+    "blockingNotificationId",
+    "selectedUnitId",
+    "selectedCityId",
+    "firstReadyUnitId",
+    "notifications",
+    "decisions",
+    "hud",
+    "limits",
+  ],
+  playerScope: "local-player-scoped",
+  consumerClasses: [
+    "normal-cli-player-agent-view",
+    "effect-orpc-procedure-core",
+  ],
+  proofBoundary: "local-package-test",
+  projection: {
+    normalCli: "semantic-projection",
+    debugService: "omitted",
+    aiIngestion: "blocked-until-ingestion-contract",
+    telemetry: "blocked-until-procedure-middleware",
+    procedureCore: "typed-procedure-core",
+  },
+  correlation: {
+    idSource: "generated-per-call",
+    normalCli: "omitted-by-default",
+    debugService: "included-in-diagnostics",
+    telemetry: "omitted",
+  },
+  context: [
+    "direct-control-facade",
+    "endpoint-defaults",
+    "state-selection",
+    "logger",
+    "evidence-sink",
+  ],
+});
+
+export const Civ7PlayNotificationViewProcedureSchemaArtifacts = {
+  [civ7ProcedureSchemaReferenceKey(Civ7PlayNotificationViewProcedureDescriptor.inputSchema)]: Civ7PlayNotificationViewInputSchema,
+  [civ7ProcedureSchemaReferenceKey(Civ7PlayNotificationViewProcedureDescriptor.outputSchema)]: Civ7PlayNotificationViewResultSchema,
+} satisfies Civ7ProcedureSchemaArtifactMap;
+
+export type Civ7PlayNotificationViewProcedureCallOptions = Readonly<{
+  directControl?: Civ7DirectControlOptions;
+  procedure?: Civ7ProcedureCoreCallOptions;
+  dependencies?: PlayNotificationViewDependencies;
+}>;
+
+export function callCiv7PlayNotificationViewProcedure(
+  input: Civ7PlayNotificationViewInput = {},
+  options: Civ7PlayNotificationViewProcedureCallOptions = {},
+): Promise<Civ7ProcedureCoreCallResult<Civ7PlayNotificationViewResult>> {
+  return callCiv7ProcedureCore<Civ7PlayNotificationViewInput, Civ7PlayNotificationViewResult>(
+    Civ7PlayNotificationViewProcedureDescriptor,
+    Civ7PlayNotificationViewProcedureSchemaArtifacts,
+    input,
+    (validInput) => getCiv7PlayNotificationView(
+      {
+        ...options.directControl,
+        ...validInput,
+      },
+      options.dependencies,
+    ),
+    options.procedure,
+  );
+}

--- a/packages/civ7-direct-control/src/play/notifications/view.ts
+++ b/packages/civ7-direct-control/src/play/notifications/view.ts
@@ -1,8 +1,10 @@
+import { Type, type Static } from "typebox";
+
+import { Civ7ComponentIdSchema, type Civ7ComponentId } from "../../civ7-component-id.js";
 import { jsLiteral } from "../../runtime/command-serialization.js";
-import { probeHelperSource } from "../../runtime/probe.js";
+import { Civ7RuntimeProbeSchema, probeHelperSource } from "../../runtime/probe.js";
 
 import type { Civ7OperationFamily } from "../operations/types.js";
-import type { Civ7ComponentId } from "../../civ7-component-id.js";
 import type { Civ7RuntimeProbe } from "../../runtime/probe.js";
 import type {
   Civ7CommandResult,
@@ -11,6 +13,126 @@ import type {
 } from "../../session/types.js";
 import { jsonPayloadFromCommandResult } from "../../session/command-result.js";
 import { executeCiv7AppUiCommand } from "../../session/execute.js";
+
+const nullableComponentIdSchema = Type.Union([Civ7ComponentIdSchema, Type.Null()]);
+const Civ7PlayOperationFamilySchema = Type.Union([
+  Type.Literal("unit-operation"),
+  Type.Literal("unit-command"),
+  Type.Literal("city-operation"),
+  Type.Literal("city-command"),
+  Type.Literal("player-operation"),
+  Type.Literal("app-ui-action"),
+]);
+
+export const Civ7PlayNotificationViewInputSchema = Type.Object({
+  maxNotifications: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+}, { additionalProperties: false });
+export type Civ7PlayNotificationViewInput = Static<typeof Civ7PlayNotificationViewInputSchema>;
+
+export const Civ7PlayDecisionInputSchema = Type.Object({
+  name: Type.String(),
+  source: Type.String(),
+  required: Type.Boolean(),
+  note: Type.Optional(Type.String()),
+}, { additionalProperties: false });
+export type Civ7PlayDecisionInputContract = Static<typeof Civ7PlayDecisionInputSchema>;
+
+export const Civ7PlayDecisionActionSchema = Type.Object({
+  label: Type.Optional(Type.String()),
+  cli: Type.Optional(Type.String()),
+  operationFamily: Type.Optional(Civ7PlayOperationFamilySchema),
+  operationType: Type.Optional(Type.String()),
+  argsShape: Type.Optional(Type.String()),
+  when: Type.Optional(Type.String()),
+}, { additionalProperties: false });
+export type Civ7PlayDecisionActionContract = Static<typeof Civ7PlayDecisionActionSchema>;
+
+export const Civ7PlayDecisionHintSchema = Type.Object({
+  category: Type.String(),
+  operationFamily: Type.Optional(Civ7PlayOperationFamilySchema),
+  operationType: Type.Optional(Type.String()),
+  argsShape: Type.Optional(Type.String()),
+  cli: Type.Optional(Type.String()),
+  requiredInputs: Type.Array(Civ7PlayDecisionInputSchema),
+  commonActions: Type.Array(Civ7PlayDecisionActionSchema),
+  confidence: Type.Union([
+    Type.Literal("live-proof"),
+    Type.Literal("official-ui"),
+    Type.Literal("heuristic"),
+  ]),
+  notes: Type.Array(Type.String()),
+}, { additionalProperties: false });
+export type Civ7PlayDecisionHintContract = Static<typeof Civ7PlayDecisionHintSchema>;
+
+export const Civ7PlayNotificationSummarySchema = Type.Object({
+  id: nullableComponentIdSchema,
+  type: Type.Unknown(),
+  typeName: Type.Union([Type.String(), Type.Null()]),
+  groupType: Type.Unknown(),
+  player: Type.Unknown(),
+  summary: Type.Union([Type.String(), Type.Null()]),
+  message: Type.Union([Type.String(), Type.Null()]),
+  target: Type.Unknown(),
+  location: Type.Unknown(),
+  canUserDismiss: Type.Unknown(),
+  expired: Type.Unknown(),
+  dismissed: Type.Unknown(),
+  isEndTurnBlocking: Type.Boolean(),
+  decision: Civ7PlayDecisionHintSchema,
+  details: Type.Optional(Type.Unknown()),
+}, { additionalProperties: false });
+export type Civ7PlayNotificationSummaryContract = Static<typeof Civ7PlayNotificationSummarySchema>;
+
+export const Civ7PlayDecisionQueueItemSchema = Type.Object({
+  notificationId: nullableComponentIdSchema,
+  isEndTurnBlocking: Type.Boolean(),
+  typeName: Type.Union([Type.String(), Type.Null()]),
+  summary: Type.Union([Type.String(), Type.Null()]),
+  message: Type.Union([Type.String(), Type.Null()]),
+  target: Type.Unknown(),
+  location: Type.Unknown(),
+  player: Type.Unknown(),
+  category: Type.String(),
+  operationFamily: Type.Optional(Civ7PlayOperationFamilySchema),
+  operationType: Type.Optional(Type.String()),
+  argsShape: Type.Optional(Type.String()),
+  cli: Type.Optional(Type.String()),
+  requiredInputs: Type.Array(Civ7PlayDecisionInputSchema),
+  commonActions: Type.Array(Civ7PlayDecisionActionSchema),
+  notes: Type.Array(Type.String()),
+  details: Type.Optional(Type.Unknown()),
+}, { additionalProperties: false });
+export type Civ7PlayDecisionQueueItemContract = Static<typeof Civ7PlayDecisionQueueItemSchema>;
+
+export const Civ7PlayNotificationViewResultSchema = Type.Object({
+  host: Type.String(),
+  port: Type.Number(),
+  state: Type.Object({
+    id: Type.String(),
+    name: Type.String(),
+  }, { additionalProperties: false }),
+  localPlayerId: Type.Number(),
+  turn: Civ7RuntimeProbeSchema(Type.Number()),
+  turnDate: Civ7RuntimeProbeSchema(Type.String()),
+  hasSentTurnComplete: Civ7RuntimeProbeSchema(Type.Boolean()),
+  canEndTurn: Civ7RuntimeProbeSchema(Type.Boolean()),
+  blocker: Civ7RuntimeProbeSchema(Type.Unknown()),
+  blockingNotificationId: Civ7RuntimeProbeSchema(nullableComponentIdSchema),
+  selectedUnitId: Civ7RuntimeProbeSchema(nullableComponentIdSchema),
+  selectedCityId: Civ7RuntimeProbeSchema(nullableComponentIdSchema),
+  firstReadyUnitId: Civ7RuntimeProbeSchema(nullableComponentIdSchema),
+  notifications: Type.Array(Civ7PlayNotificationSummarySchema),
+  decisions: Type.Array(Civ7PlayDecisionHintSchema),
+  hud: Type.Object({
+    nextDecision: Type.Union([Civ7PlayDecisionQueueItemSchema, Type.Null()]),
+    decisionQueue: Type.Array(Civ7PlayDecisionQueueItemSchema),
+  }, { additionalProperties: false }),
+  limits: Type.Object({
+    maxNotifications: Type.Number(),
+    truncated: Type.Boolean(),
+  }, { additionalProperties: false }),
+}, { additionalProperties: false });
+export type Civ7PlayNotificationViewResultContract = Static<typeof Civ7PlayNotificationViewResultSchema>;
 
 export type Civ7PlayDecisionHint = Readonly<{
   category: string;
@@ -104,11 +226,11 @@ export type Civ7PlayNotificationViewResult = Readonly<{
   }>;
 }>;
 
-type PlayNotificationViewOptions = Civ7DirectControlOptions & Readonly<{
+export type PlayNotificationViewOptions = Civ7DirectControlOptions & Readonly<{
   maxNotifications?: number;
 }>;
 
-type PlayNotificationViewDependencies = Readonly<{
+export type PlayNotificationViewDependencies = Readonly<{
   executeAppUiCommand: (
     options: Civ7DirectControlOptions & Readonly<{ command: string }>,
   ) => Promise<Civ7CommandResult>;

--- a/packages/civ7-direct-control/src/play/tactical/settlement-procedure.ts
+++ b/packages/civ7-direct-control/src/play/tactical/settlement-procedure.ts
@@ -1,0 +1,102 @@
+import {
+  callCiv7ProcedureCore,
+  civ7ProcedureSchemaReferenceKey,
+  createCiv7ProcedureCoreDescriptor,
+  type Civ7ProcedureCoreCallOptions,
+  type Civ7ProcedureCoreCallResult,
+  type Civ7ProcedureSchemaArtifactMap,
+} from "../../procedure-core.js";
+import type { Civ7DirectControlOptions } from "../../session/types.js";
+import {
+  Civ7SettlementRecommendationInputSchema,
+  Civ7SettlementRecommendationResultSchema,
+  getCiv7SettlementRecommendations,
+  type Civ7SettlementRecommendationInput,
+  type Civ7SettlementRecommendationResult,
+  type SettlementRecommendationDependencies,
+} from "./settlement.js";
+
+export const Civ7SettlementRecommendationsProcedureDescriptor = createCiv7ProcedureCoreDescriptor({
+  procedureKey: "strategy.settlement.recommendations",
+  family: "strategy",
+  risk: "read",
+  atomOwner: "packages/civ7-direct-control/src/play/tactical/settlement.ts",
+  atomFunction: "getCiv7SettlementRecommendations",
+  schemaTechnology: "typebox",
+  inputSchema: {
+    owner: "packages/civ7-direct-control/src/play/tactical/settlement.ts",
+    exportName: "Civ7SettlementRecommendationInputSchema",
+  },
+  outputSchema: {
+    owner: "packages/civ7-direct-control/src/play/tactical/settlement.ts",
+    exportName: "Civ7SettlementRecommendationResultSchema",
+  },
+  inputFields: [
+    "playerId",
+    "locations",
+    "count",
+    "includeSettlers",
+    "includeCities",
+  ],
+  outputFields: [
+    "localPlayerId",
+    "playerId",
+    "count",
+    "requestedLocations",
+    "origins",
+    "recommendations",
+    "notes",
+  ],
+  playerScope: "local-player-scoped",
+  consumerClasses: [
+    "normal-cli-player-agent-view",
+    "effect-orpc-procedure-core",
+  ],
+  proofBoundary: "local-package-test",
+  projection: {
+    normalCli: "semantic-projection",
+    debugService: "omitted",
+    aiIngestion: "blocked-until-ingestion-contract",
+    telemetry: "blocked-until-procedure-middleware",
+    procedureCore: "typed-procedure-core",
+  },
+  correlation: {
+    idSource: "generated-per-call",
+    normalCli: "omitted-by-default",
+    debugService: "included-in-diagnostics",
+    telemetry: "omitted",
+  },
+  context: [
+    "direct-control-facade",
+    "endpoint-defaults",
+    "state-selection",
+    "logger",
+    "evidence-sink",
+  ],
+});
+
+export const Civ7SettlementRecommendationsProcedureSchemaArtifacts = {
+  [civ7ProcedureSchemaReferenceKey(Civ7SettlementRecommendationsProcedureDescriptor.inputSchema)]:
+    Civ7SettlementRecommendationInputSchema,
+  [civ7ProcedureSchemaReferenceKey(Civ7SettlementRecommendationsProcedureDescriptor.outputSchema)]:
+    Civ7SettlementRecommendationResultSchema,
+} satisfies Civ7ProcedureSchemaArtifactMap;
+
+export type Civ7SettlementRecommendationsProcedureCallOptions = Readonly<{
+  directControl?: Civ7DirectControlOptions;
+  procedure?: Civ7ProcedureCoreCallOptions;
+  dependencies?: SettlementRecommendationDependencies;
+}>;
+
+export function callCiv7SettlementRecommendationsProcedure(
+  input: Civ7SettlementRecommendationInput = {},
+  options: Civ7SettlementRecommendationsProcedureCallOptions = {},
+): Promise<Civ7ProcedureCoreCallResult<Civ7SettlementRecommendationResult>> {
+  return callCiv7ProcedureCore<Civ7SettlementRecommendationInput, Civ7SettlementRecommendationResult>(
+    Civ7SettlementRecommendationsProcedureDescriptor,
+    Civ7SettlementRecommendationsProcedureSchemaArtifacts,
+    input,
+    (validInput) => getCiv7SettlementRecommendations(validInput, options.directControl, options.dependencies),
+    options.procedure,
+  );
+}

--- a/packages/civ7-direct-control/src/play/tactical/settlement.ts
+++ b/packages/civ7-direct-control/src/play/tactical/settlement.ts
@@ -1,8 +1,12 @@
+import { Type } from "typebox";
+
+import { Civ7ComponentIdSchema } from "../../civ7-component-id.js";
 import { jsLiteral } from "../../runtime/command-serialization.js";
-import { probeHelperSource } from "../../runtime/probe.js";
+import { Civ7RuntimeProbeSchema, probeHelperSource } from "../../runtime/probe.js";
 import { jsonPayloadFromCommandResult } from "../../session/command-result.js";
 import { executeCiv7AppUiCommand } from "../../session/execute.js";
 import { boundedInteger } from "../../validation.js";
+import { Civ7MapLocationSchema } from "../map/types.js";
 
 import type {
   Civ7CommandResult,
@@ -12,6 +16,19 @@ import type {
 import type { Civ7ComponentId } from "../../civ7-component-id.js";
 import type { Civ7RuntimeProbe } from "../../runtime/probe.js";
 
+const civ7TunerStateSchema = Type.Object({
+  id: Type.String(),
+  name: Type.String(),
+}, { additionalProperties: false });
+
+export const Civ7SettlementRecommendationInputSchema = Type.Object({
+  playerId: Type.Optional(Type.Integer({ minimum: 0 })),
+  locations: Type.Optional(Type.Array(Civ7MapLocationSchema)),
+  count: Type.Optional(Type.Integer({ minimum: 1, maximum: 12 })),
+  includeSettlers: Type.Optional(Type.Boolean()),
+  includeCities: Type.Optional(Type.Boolean()),
+}, { additionalProperties: false });
+
 export type Civ7SettlementRecommendationInput = Readonly<{
   playerId?: number;
   locations?: ReadonlyArray<Readonly<{ x: number; y: number }>>;
@@ -20,11 +37,30 @@ export type Civ7SettlementRecommendationInput = Readonly<{
   includeCities?: boolean;
 }>;
 
+export const Civ7SettlementRecommendationFactorSchema = Type.Object({
+  positive: Type.Boolean(),
+  title: Type.Union([Type.String(), Type.Null()]),
+  description: Type.Union([Type.String(), Type.Null()]),
+}, { additionalProperties: false });
+
 export type Civ7SettlementRecommendationFactor = Readonly<{
   positive: boolean;
   title: string | null;
   description: string | null;
 }>;
+
+export const Civ7SettlementRecommendationOriginSchema = Type.Object({
+  kind: Type.Union([
+    Type.Literal("requested"),
+    Type.Literal("settler"),
+    Type.Literal("city"),
+  ]),
+  location: Civ7MapLocationSchema,
+  plotIndex: Civ7RuntimeProbeSchema(Type.Number()),
+  unitId: Type.Optional(Civ7ComponentIdSchema),
+  cityId: Type.Optional(Civ7ComponentIdSchema),
+  name: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+}, { additionalProperties: false });
 
 export type Civ7SettlementRecommendationOrigin = Readonly<{
   kind: "requested" | "settler" | "city";
@@ -35,6 +71,17 @@ export type Civ7SettlementRecommendationOrigin = Readonly<{
   name?: string | null;
 }>;
 
+export const Civ7SettlementSuggestionSchema = Type.Object({
+  location: Type.Union([Civ7MapLocationSchema, Type.Null()]),
+  plotIndex: Civ7RuntimeProbeSchema(Type.Number()),
+  factors: Type.Array(Civ7SettlementRecommendationFactorSchema),
+}, { additionalProperties: false });
+
+export const Civ7SettlementRecommendationSchema = Type.Object({
+  origin: Civ7SettlementRecommendationOriginSchema,
+  suggestions: Civ7RuntimeProbeSchema(Type.Array(Civ7SettlementSuggestionSchema)),
+}, { additionalProperties: false });
+
 export type Civ7SettlementRecommendation = Readonly<{
   origin: Civ7SettlementRecommendationOrigin;
   suggestions: Civ7RuntimeProbe<ReadonlyArray<Readonly<{
@@ -43,6 +90,19 @@ export type Civ7SettlementRecommendation = Readonly<{
     factors: ReadonlyArray<Civ7SettlementRecommendationFactor>;
   }>>>;
 }>;
+
+export const Civ7SettlementRecommendationResultSchema = Type.Object({
+  host: Type.String(),
+  port: Type.Number(),
+  state: civ7TunerStateSchema,
+  localPlayerId: Type.Number(),
+  playerId: Type.Number(),
+  count: Type.Number(),
+  requestedLocations: Type.Array(Civ7MapLocationSchema),
+  origins: Type.Array(Civ7SettlementRecommendationOriginSchema),
+  recommendations: Type.Array(Civ7SettlementRecommendationSchema),
+  notes: Type.Array(Type.String()),
+}, { additionalProperties: false });
 
 export type Civ7SettlementRecommendationResult = Readonly<{
   host: string;
@@ -57,7 +117,7 @@ export type Civ7SettlementRecommendationResult = Readonly<{
   notes: ReadonlyArray<string>;
 }>;
 
-type SettlementRecommendationDependencies = Readonly<{
+export type SettlementRecommendationDependencies = Readonly<{
   boundedInteger: (value: number, min: number, max: number, label: string) => number;
   executeAppUiCommand: (
     options: Civ7DirectControlOptions & Readonly<{ command: string }>,

--- a/packages/civ7-direct-control/test/play-notification-view-procedure.test.ts
+++ b/packages/civ7-direct-control/test/play-notification-view-procedure.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from "vitest";
+import { Value } from "typebox/value";
+
+import {
+  Civ7PlayNotificationViewProcedureDescriptor,
+  Civ7PlayNotificationViewProcedureSchemaArtifacts,
+  callCiv7PlayNotificationViewProcedure,
+  getCiv7PlayNotificationView,
+  resolveCiv7ProcedureCoreSchemas,
+  summarizeCiv7ProcedureCoreDescriptor,
+  type PlayNotificationViewDependencies,
+} from "../src/index";
+
+describe("Civ7 play-notification view procedure descriptor", () => {
+  test("records the notification read atom and resolves its schemas", () => {
+    const summary = summarizeCiv7ProcedureCoreDescriptor(Civ7PlayNotificationViewProcedureDescriptor);
+    expect(summary).toMatchObject({
+      procedureKey: "notifications.view",
+      family: "notifications",
+      risk: "read",
+      atomOwner: "packages/civ7-direct-control/src/play/notifications/view.ts",
+      atomFunction: "getCiv7PlayNotificationView",
+      normalCliProjection: "semantic-projection",
+      debugServiceProjection: "omitted",
+      aiIngestionProjection: "blocked-until-ingestion-contract",
+      telemetryProjection: "blocked-until-procedure-middleware",
+      procedureCoreProjection: "typed-procedure-core",
+    });
+    expect(getCiv7PlayNotificationView.name).toBe(summary.atomFunction);
+
+    const resolved = resolveCiv7ProcedureCoreSchemas(
+      Civ7PlayNotificationViewProcedureDescriptor,
+      Civ7PlayNotificationViewProcedureSchemaArtifacts,
+    );
+    expect(Object.keys(resolved.inputSchema.properties ?? {})).toEqual(
+      expect.arrayContaining(Civ7PlayNotificationViewProcedureDescriptor.inputFields),
+    );
+    expect(Object.keys(resolved.outputSchema.properties ?? {})).toEqual(
+      expect.arrayContaining(Civ7PlayNotificationViewProcedureDescriptor.outputFields),
+    );
+    expect(Value.Check(resolved.inputSchema, { maxNotifications: 12 })).toBe(true);
+    expect(Value.Check(resolved.inputSchema, { maxNotifications: 101 })).toBe(false);
+    expect(Value.Check(resolved.inputSchema, { host: "127.0.0.1" })).toBe(false);
+    expect(Value.Check(resolved.inputSchema, { rawCommand: "readPlayNotifications()" })).toBe(false);
+    expect(Value.Check(resolved.outputSchema, playNotificationViewResult())).toBe(true);
+    expect(Value.Check(resolved.outputSchema, {
+      ...playNotificationViewResult(),
+      rawCommand: "readPlayNotifications()",
+    })).toBe(false);
+  });
+
+  test("calls the notification view atom through the procedure core without touching the live tuner", async () => {
+    const executeCalls: Array<{ host?: string; port?: number; command: string }> = [];
+    const dependencies: PlayNotificationViewDependencies = {
+      executeAppUiCommand: async (options) => {
+        executeCalls.push({
+          host: options.host,
+          port: options.port,
+          command: options.command,
+        });
+        return {
+          host: options.host ?? "127.0.0.1",
+          port: options.port ?? 4318,
+          state: { id: "65535", name: "App UI" },
+          output: ["{}"],
+        };
+      },
+      parsePlayNotificationView: () => playNotificationViewResult(12),
+    };
+
+    const result = await callCiv7PlayNotificationViewProcedure({
+      maxNotifications: 12,
+    }, {
+      directControl: {
+        host: "127.0.0.1",
+        port: 4318,
+      },
+      procedure: {
+        correlationId: "notifications-view-procedure-test",
+      },
+      dependencies,
+    });
+
+    expect(result.output).toEqual(playNotificationViewResult(12));
+    expect(result.diagnostics).toMatchObject({
+      procedureKey: "notifications.view",
+      correlationId: "notifications-view-procedure-test",
+      proofBoundary: "local-package-test",
+      playerScope: "local-player-scoped",
+      debugServiceCorrelation: true,
+      telemetryCorrelation: false,
+    });
+    expect(executeCalls).toHaveLength(1);
+    expect(executeCalls[0]).toMatchObject({
+      host: "127.0.0.1",
+      port: 4318,
+    });
+    expect(executeCalls[0]?.command).toContain("readPlayNotifications");
+    expect(executeCalls[0]?.command).toContain('"maxNotifications":12');
+  });
+
+  test("rejects invalid procedure input before notification atom dependencies run", async () => {
+    let executed = false;
+    const dependencies: PlayNotificationViewDependencies = {
+      executeAppUiCommand: async () => {
+        executed = true;
+        throw new Error("executeAppUiCommand should not run after procedure input rejection");
+      },
+      parsePlayNotificationView: () => playNotificationViewResult(),
+    };
+
+    await expect(callCiv7PlayNotificationViewProcedure({ maxNotifications: 101 }, {
+      procedure: { correlationId: "notifications-view-invalid-input" },
+      dependencies,
+    })).rejects.toMatchObject({
+      code: "procedure-descriptor-invalid",
+      details: {
+        reason: "input-schema-invalid",
+        procedureKey: "notifications.view",
+        role: "input",
+      },
+    });
+    await expect(callCiv7PlayNotificationViewProcedure({
+      host: "127.0.0.1",
+    } as never, {
+      procedure: { correlationId: "notifications-view-context-input" },
+      dependencies,
+    })).rejects.toMatchObject({
+      code: "procedure-descriptor-invalid",
+      details: {
+        reason: "input-schema-invalid",
+        procedureKey: "notifications.view",
+        role: "input",
+      },
+    });
+    expect(executed).toBe(false);
+  });
+});
+
+function playNotificationViewResult(maxNotifications = 25) {
+  const notificationId = { owner: 0, id: 42, type: 20 };
+  const cityId = { owner: 0, id: 131073, type: 1 };
+  const requiredInputs = [
+    { name: "City", source: "notification target or selected city", required: true },
+    { name: "Type", source: "live town focus option", required: true },
+    { name: "ProjectType", source: "live town focus option", required: true },
+  ];
+  const commonActions = [
+    {
+      label: "Set town focus",
+      cli: "game play set-town-focus --city-id '<city-id>' --growth-type <type> --project-type <project-type>",
+      when: "after choosing a live town focus option",
+    },
+  ];
+  const notes = [
+    "Town focus is not city-operation BUILD; use --closeout when one caller action should apply the focus and clear the review surface.",
+  ];
+  const decision = {
+    category: "town-focus",
+    operationFamily: "city-command",
+    operationType: "CHANGE_GROWTH_MODE",
+    requiredInputs,
+    commonActions,
+    confidence: "live-proof" as const,
+    notes,
+  };
+  const notification = {
+    id: notificationId,
+    type: -123,
+    typeName: "NOTIFICATION_CHOOSE_TOWN_PROJECT",
+    groupType: null,
+    player: 0,
+    summary: "Choose Town Project",
+    message: "Choose a town focus project",
+    target: cityId,
+    location: null,
+    canUserDismiss: false,
+    expired: false,
+    dismissed: false,
+    isEndTurnBlocking: true,
+    decision,
+  };
+
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    turn: { ok: true, value: 80 },
+    turnDate: { ok: true, value: "2025 BCE" },
+    hasSentTurnComplete: { ok: true, value: false },
+    canEndTurn: { ok: true, value: false },
+    blocker: { ok: true, value: -2026570723 },
+    blockingNotificationId: { ok: true, value: notificationId },
+    selectedUnitId: { ok: true, value: null },
+    selectedCityId: { ok: true, value: cityId },
+    firstReadyUnitId: { ok: true, value: null },
+    notifications: [notification],
+    decisions: [decision],
+    hud: {
+      nextDecision: {
+        notificationId,
+        isEndTurnBlocking: true,
+        typeName: "NOTIFICATION_CHOOSE_TOWN_PROJECT",
+        summary: "Choose Town Project",
+        message: "Choose a town focus project",
+        target: cityId,
+        location: null,
+        player: 0,
+        category: "town-focus",
+        operationFamily: "city-command",
+        operationType: "CHANGE_GROWTH_MODE",
+        requiredInputs,
+        commonActions,
+        notes,
+      },
+      decisionQueue: [],
+    },
+    limits: {
+      maxNotifications,
+      truncated: false,
+    },
+  };
+}

--- a/packages/civ7-direct-control/test/play-notification-view.test.ts
+++ b/packages/civ7-direct-control/test/play-notification-view.test.ts
@@ -1,8 +1,13 @@
 import { once } from "node:events";
 import { type AddressInfo, createServer } from "node:net";
 import { describe, expect, test } from "vitest";
+import { Value } from "typebox/value";
 
-import { getCiv7PlayNotificationView } from "../src/index";
+import {
+  Civ7PlayNotificationViewInputSchema,
+  Civ7PlayNotificationViewResultSchema,
+  getCiv7PlayNotificationView,
+} from "../src/index";
 
 type FakeTunerServer = {
   received: string[];
@@ -11,6 +16,17 @@ type FakeTunerServer = {
 };
 
 describe("getCiv7PlayNotificationView", () => {
+  test("keeps procedure input bounded and context-owned", () => {
+    expect(Value.Check(Civ7PlayNotificationViewInputSchema, {})).toBe(true);
+    expect(Value.Check(Civ7PlayNotificationViewInputSchema, { maxNotifications: 25 })).toBe(true);
+    expect(Value.Check(Civ7PlayNotificationViewInputSchema, { maxNotifications: 0 })).toBe(false);
+    expect(Value.Check(Civ7PlayNotificationViewInputSchema, { maxNotifications: 101 })).toBe(false);
+    expect(Value.Check(Civ7PlayNotificationViewInputSchema, { host: "127.0.0.1" })).toBe(false);
+    expect(Value.Check(Civ7PlayNotificationViewInputSchema, { port: 4318 })).toBe(false);
+    expect(Value.Check(Civ7PlayNotificationViewInputSchema, { state: { name: "App UI" } })).toBe(false);
+    expect(Value.Check(Civ7PlayNotificationViewInputSchema, { rawCommand: "readPlayNotifications()" })).toBe(false);
+  });
+
   test("materializes play notifications with decision hints", async () => {
     const server = await startPlayNotificationTunerServer();
     try {
@@ -50,6 +66,11 @@ describe("getCiv7PlayNotificationView", () => {
           },
         },
       });
+      expect(Value.Check(Civ7PlayNotificationViewResultSchema, view)).toBe(true);
+      expect(Value.Check(Civ7PlayNotificationViewResultSchema, {
+        ...view,
+        rawCommand: "readPlayNotifications()",
+      })).toBe(false);
       expect(view.decisions.some((decision) => decision.category === "town-focus")).toBe(true);
       expect(server.received.some((message) => message.includes("readPlayNotifications"))).toBe(true);
       const notificationRead = server.received.find((message) => message.includes("readPlayNotifications")) ?? "";
@@ -99,6 +120,7 @@ function playNotificationView() {
     type: -123,
     typeName: "NOTIFICATION_CHOOSE_TOWN_PROJECT",
     groupType: null,
+    player: 0,
     summary: "Choose Town Project",
     message: "Choose a town focus project",
     target: { owner: 0, id: 131073, type: 1 },
@@ -118,7 +140,9 @@ function playNotificationView() {
       ],
       commonActions: [
         {
+          label: "Set town focus",
           cli: "game play set-town-focus --city-id '<city-id>' --growth-type <type> --project-type <project-type>",
+          when: "after choosing a live town focus option",
         },
       ],
       confidence: "live-proof" as const,
@@ -154,9 +178,13 @@ function playNotificationView() {
         message: "Choose a town focus project",
         target: { owner: 0, id: 131073, type: 1 },
         location: null,
+        player: 0,
         category: "town-focus",
         operationFamily: "city-command",
         operationType: "CHANGE_GROWTH_MODE",
+        requiredInputs: notification.decision.requiredInputs,
+        commonActions: notification.decision.commonActions,
+        notes: notification.decision.notes,
       },
       decisionQueue: [],
     },

--- a/packages/civ7-direct-control/test/public-api.test.ts
+++ b/packages/civ7-direct-control/test/public-api.test.ts
@@ -38,6 +38,10 @@ import {
   Civ7ReadyUnitViewProcedureSchemaArtifacts,
   Civ7ReadyUnitViewInputSchema,
   Civ7ReadyUnitViewResultSchema,
+  Civ7SettlementRecommendationInputSchema,
+  Civ7SettlementRecommendationResultSchema,
+  Civ7SettlementRecommendationsProcedureDescriptor,
+  Civ7SettlementRecommendationsProcedureSchemaArtifacts,
   Civ7TunerHealthInputSchema,
   Civ7TunerHealthProcedureDescriptor,
   Civ7TunerHealthProcedureSchemaArtifacts,
@@ -76,6 +80,7 @@ import {
   callCiv7ProcedureCore,
   callCiv7ReadyCityViewProcedure,
   callCiv7ReadyUnitViewProcedure,
+  callCiv7SettlementRecommendationsProcedure,
   callCiv7TunerHealthProcedure,
   callCiv7UnitMovePreviewProcedure,
   civ7ProcedureSchemaReferenceKey,
@@ -349,6 +354,33 @@ describe("Civ7 direct control public API", () => {
     });
   });
 
+  test("exports settlement recommendation procedure candidate schemas from the public facade", () => {
+    expect(Value.Check(Civ7SettlementRecommendationInputSchema, {
+      locations: [{ x: 18, y: 27 }],
+      count: 3,
+      includeSettlers: false,
+      includeCities: false,
+    })).toBe(true);
+    expect(Value.Check(Civ7SettlementRecommendationInputSchema, { count: 13 })).toBe(false);
+    expect(Value.Check(Civ7SettlementRecommendationInputSchema, { locations: [{ x: 1.5, y: 0 }] })).toBe(false);
+    expect(Value.Check(Civ7SettlementRecommendationInputSchema, { host: "127.0.0.1" })).toBe(false);
+    expect(Value.Check(Civ7SettlementRecommendationInputSchema, { rawCommand: "readSettlementRecommendations()" })).toBe(false);
+    expect(Civ7SettlementRecommendationResultSchema).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+      required: expect.arrayContaining([
+        "state",
+        "localPlayerId",
+        "playerId",
+        "count",
+        "requestedLocations",
+        "origins",
+        "recommendations",
+        "notes",
+      ]),
+    });
+  });
+
   test("exports procedure schema reference schema from the public facade", () => {
     expect(Value.Check(Civ7ProcedureContextRequirementSchema, "direct-control-facade")).toBe(true);
     expect(Value.Check(Civ7ProcedureContextRequirementSchema, "raw-socket")).toBe(false);
@@ -477,6 +509,24 @@ describe("Civ7 direct control public API", () => {
     expect(Civ7PlayNotificationViewProcedureSchemaArtifacts[
       civ7ProcedureSchemaReferenceKey(Civ7PlayNotificationViewProcedureDescriptor.outputSchema)
     ]).toBe(Civ7PlayNotificationViewResultSchema);
+  });
+
+  test("exports the settlement recommendations procedure descriptor artifact from the public facade", () => {
+    expect(Civ7SettlementRecommendationsProcedureDescriptor).toMatchObject({
+      procedureKey: "strategy.settlement.recommendations",
+      family: "strategy",
+      atomFunction: "getCiv7SettlementRecommendations",
+      schemaTechnology: "typebox",
+      proofBoundary: "local-package-test",
+      context: expect.arrayContaining(["direct-control-facade", "endpoint-defaults", "state-selection"]),
+    });
+    expect(typeof callCiv7SettlementRecommendationsProcedure).toBe("function");
+    expect(Civ7SettlementRecommendationsProcedureSchemaArtifacts[
+      civ7ProcedureSchemaReferenceKey(Civ7SettlementRecommendationsProcedureDescriptor.inputSchema)
+    ]).toBe(Civ7SettlementRecommendationInputSchema);
+    expect(Civ7SettlementRecommendationsProcedureSchemaArtifacts[
+      civ7ProcedureSchemaReferenceKey(Civ7SettlementRecommendationsProcedureDescriptor.outputSchema)
+    ]).toBe(Civ7SettlementRecommendationResultSchema);
   });
 
   test("exports the playable-status procedure descriptor artifact from the public facade", () => {

--- a/packages/civ7-direct-control/test/public-api.test.ts
+++ b/packages/civ7-direct-control/test/public-api.test.ts
@@ -17,6 +17,10 @@ import {
   Civ7CapabilityCatalogSchema,
   Civ7ComponentIdSchema,
   Civ7MapLocationSchema,
+  Civ7PlayNotificationViewInputSchema,
+  Civ7PlayNotificationViewProcedureDescriptor,
+  Civ7PlayNotificationViewProcedureSchemaArtifacts,
+  Civ7PlayNotificationViewResultSchema,
   Civ7PlayableStatusInputSchema,
   Civ7PlayableStatusProcedureDescriptor,
   Civ7PlayableStatusProcedureSchemaArtifacts,
@@ -68,6 +72,7 @@ import {
   assertCiv7ComponentId,
   callCiv7AppUiSnapshotProcedure,
   callCiv7PlayableStatusProcedure,
+  callCiv7PlayNotificationViewProcedure,
   callCiv7ProcedureCore,
   callCiv7ReadyCityViewProcedure,
   callCiv7ReadyUnitViewProcedure,
@@ -325,6 +330,25 @@ describe("Civ7 direct control public API", () => {
     });
   });
 
+  test("exports play-notification view procedure candidate schemas from the public facade", () => {
+    expect(Value.Check(Civ7PlayNotificationViewInputSchema, { maxNotifications: 25 })).toBe(true);
+    expect(Value.Check(Civ7PlayNotificationViewInputSchema, { maxNotifications: 101 })).toBe(false);
+    expect(Value.Check(Civ7PlayNotificationViewInputSchema, { host: "127.0.0.1" })).toBe(false);
+    expect(Value.Check(Civ7PlayNotificationViewInputSchema, { rawCommand: "readPlayNotifications()" })).toBe(false);
+    expect(Civ7PlayNotificationViewResultSchema).toMatchObject({
+      type: "object",
+      additionalProperties: false,
+      required: expect.arrayContaining([
+        "state",
+        "localPlayerId",
+        "notifications",
+        "decisions",
+        "hud",
+        "limits",
+      ]),
+    });
+  });
+
   test("exports procedure schema reference schema from the public facade", () => {
     expect(Value.Check(Civ7ProcedureContextRequirementSchema, "direct-control-facade")).toBe(true);
     expect(Value.Check(Civ7ProcedureContextRequirementSchema, "raw-socket")).toBe(false);
@@ -436,6 +460,23 @@ describe("Civ7 direct control public API", () => {
     expect(Civ7UnitMovePreviewProcedureSchemaArtifacts[
       civ7ProcedureSchemaReferenceKey(Civ7UnitMovePreviewProcedureDescriptor.outputSchema)
     ]).toBe(Civ7UnitMovePreviewResultSchema);
+  });
+
+  test("exports the play-notification view procedure descriptor artifact from the public facade", () => {
+    expect(Civ7PlayNotificationViewProcedureDescriptor).toMatchObject({
+      procedureKey: "notifications.view",
+      atomFunction: "getCiv7PlayNotificationView",
+      schemaTechnology: "typebox",
+      proofBoundary: "local-package-test",
+      context: expect.arrayContaining(["direct-control-facade", "endpoint-defaults", "state-selection"]),
+    });
+    expect(typeof callCiv7PlayNotificationViewProcedure).toBe("function");
+    expect(Civ7PlayNotificationViewProcedureSchemaArtifacts[
+      civ7ProcedureSchemaReferenceKey(Civ7PlayNotificationViewProcedureDescriptor.inputSchema)
+    ]).toBe(Civ7PlayNotificationViewInputSchema);
+    expect(Civ7PlayNotificationViewProcedureSchemaArtifacts[
+      civ7ProcedureSchemaReferenceKey(Civ7PlayNotificationViewProcedureDescriptor.outputSchema)
+    ]).toBe(Civ7PlayNotificationViewResultSchema);
   });
 
   test("exports the playable-status procedure descriptor artifact from the public facade", () => {

--- a/packages/civ7-direct-control/test/settlement-recommendations-procedure.test.ts
+++ b/packages/civ7-direct-control/test/settlement-recommendations-procedure.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "vitest";
+import { Value } from "typebox/value";
+
+import {
+  Civ7SettlementRecommendationsProcedureDescriptor,
+  Civ7SettlementRecommendationsProcedureSchemaArtifacts,
+  callCiv7SettlementRecommendationsProcedure,
+  getCiv7SettlementRecommendations,
+  resolveCiv7ProcedureCoreSchemas,
+  summarizeCiv7ProcedureCoreDescriptor,
+  type SettlementRecommendationDependencies,
+} from "../src/index";
+
+describe("Civ7 settlement recommendations procedure descriptor", () => {
+  test("records the read-only settlement atom and resolves its schemas", () => {
+    const summary = summarizeCiv7ProcedureCoreDescriptor(Civ7SettlementRecommendationsProcedureDescriptor);
+    expect(summary).toMatchObject({
+      procedureKey: "strategy.settlement.recommendations",
+      family: "strategy",
+      risk: "read",
+      atomOwner: "packages/civ7-direct-control/src/play/tactical/settlement.ts",
+      atomFunction: "getCiv7SettlementRecommendations",
+      normalCliProjection: "semantic-projection",
+      debugServiceProjection: "omitted",
+      aiIngestionProjection: "blocked-until-ingestion-contract",
+      telemetryProjection: "blocked-until-procedure-middleware",
+      procedureCoreProjection: "typed-procedure-core",
+    });
+    expect(getCiv7SettlementRecommendations.name).toBe(summary.atomFunction);
+
+    const resolved = resolveCiv7ProcedureCoreSchemas(
+      Civ7SettlementRecommendationsProcedureDescriptor,
+      Civ7SettlementRecommendationsProcedureSchemaArtifacts,
+    );
+    expect(Object.keys(resolved.inputSchema.properties ?? {})).toEqual(
+      expect.arrayContaining(Civ7SettlementRecommendationsProcedureDescriptor.inputFields),
+    );
+    expect(Object.keys(resolved.outputSchema.properties ?? {})).toEqual(
+      expect.arrayContaining(Civ7SettlementRecommendationsProcedureDescriptor.outputFields),
+    );
+    expect(Value.Check(resolved.inputSchema, {
+      locations: [{ x: 18, y: 27 }],
+      count: 3,
+      includeSettlers: false,
+      includeCities: false,
+    })).toBe(true);
+    expect(Value.Check(resolved.inputSchema, { count: 13 })).toBe(false);
+    expect(Value.Check(resolved.inputSchema, { locations: [{ x: 1.5, y: 0 }] })).toBe(false);
+    expect(Value.Check(resolved.inputSchema, { host: "127.0.0.1" })).toBe(false);
+    expect(Value.Check(resolved.inputSchema, { rawCommand: "readSettlementRecommendations()" })).toBe(false);
+    expect(Value.Check(resolved.outputSchema, settlementRecommendationsResult(3))).toBe(true);
+    expect(Value.Check(resolved.outputSchema, {
+      ...settlementRecommendationsResult(3),
+      rawCommand: "readSettlementRecommendations()",
+    })).toBe(false);
+  });
+
+  test("calls the settlement recommendation atom through the procedure core without touching the live tuner", async () => {
+    const boundedIntegerCalls: Array<{ value: number; min: number; max: number; label: string }> = [];
+    const executeCalls: Array<{ host?: string; port?: number; command: string }> = [];
+    const dependencies: SettlementRecommendationDependencies = {
+      boundedInteger: (value, min, max, label) => {
+        boundedIntegerCalls.push({ value, min, max, label });
+        return value;
+      },
+      executeAppUiCommand: async (options) => {
+        executeCalls.push({
+          host: options.host,
+          port: options.port,
+          command: options.command,
+        });
+        return {
+          host: options.host ?? "127.0.0.1",
+          port: options.port ?? 4318,
+          state: { id: "65535", name: "App UI" },
+          output: ["{}"],
+        };
+      },
+      parseSettlementRecommendations: () => settlementRecommendationsResult(3),
+    };
+
+    const result = await callCiv7SettlementRecommendationsProcedure({
+      locations: [{ x: 18, y: 27 }],
+      count: 3,
+      includeSettlers: false,
+      includeCities: false,
+    }, {
+      directControl: {
+        host: "127.0.0.1",
+        port: 4318,
+      },
+      procedure: {
+        correlationId: "settlement-recommendations-procedure-test",
+      },
+      dependencies,
+    });
+
+    expect(result.output).toEqual(settlementRecommendationsResult(3));
+    expect(result.diagnostics).toMatchObject({
+      procedureKey: "strategy.settlement.recommendations",
+      correlationId: "settlement-recommendations-procedure-test",
+      proofBoundary: "local-package-test",
+      playerScope: "local-player-scoped",
+      debugServiceCorrelation: true,
+      telemetryCorrelation: false,
+    });
+    expect(boundedIntegerCalls).toEqual([
+      { value: 3, min: 1, max: 12, label: "count" },
+    ]);
+    expect(executeCalls).toHaveLength(1);
+    expect(executeCalls[0]).toMatchObject({
+      host: "127.0.0.1",
+      port: 4318,
+    });
+    expect(executeCalls[0]?.command).toContain("readSettlementRecommendations");
+    expect(executeCalls[0]?.command).toContain('"count":3');
+    expect(executeCalls[0]?.command).toContain('"locations":[{"x":18,"y":27}]');
+    expect(executeCalls[0]?.command).not.toContain("UnitOperations.request");
+    expect(executeCalls[0]?.command).not.toContain("CityOperations.request");
+  });
+
+  test("rejects invalid procedure input before settlement atom dependencies run", async () => {
+    let executed = false;
+    const dependencies: SettlementRecommendationDependencies = {
+      boundedInteger: (value) => value,
+      executeAppUiCommand: async () => {
+        executed = true;
+        throw new Error("executeAppUiCommand should not run after procedure input rejection");
+      },
+      parseSettlementRecommendations: () => settlementRecommendationsResult(),
+    };
+
+    await expect(callCiv7SettlementRecommendationsProcedure({ count: 13 }, {
+      procedure: { correlationId: "settlement-recommendations-invalid-count" },
+      dependencies,
+    })).rejects.toMatchObject({
+      code: "procedure-descriptor-invalid",
+      details: {
+        reason: "input-schema-invalid",
+        procedureKey: "strategy.settlement.recommendations",
+        role: "input",
+      },
+    });
+    await expect(callCiv7SettlementRecommendationsProcedure({
+      host: "127.0.0.1",
+    } as never, {
+      procedure: { correlationId: "settlement-recommendations-context-input" },
+      dependencies,
+    })).rejects.toMatchObject({
+      code: "procedure-descriptor-invalid",
+      details: {
+        reason: "input-schema-invalid",
+        procedureKey: "strategy.settlement.recommendations",
+        role: "input",
+      },
+    });
+    expect(executed).toBe(false);
+  });
+});
+
+function settlementRecommendationsResult(count = 5) {
+  const origin = {
+    kind: "requested" as const,
+    location: { x: 18, y: 27 },
+    plotIndex: { ok: true as const, value: 2718 },
+  };
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    playerId: 0,
+    count,
+    requestedLocations: [origin.location],
+    origins: [origin],
+    recommendations: [
+      {
+        origin,
+        suggestions: {
+          ok: true as const,
+          value: [
+            {
+              location: { x: 19, y: 28 },
+              plotIndex: { ok: true as const, value: 2819 },
+              factors: [
+                {
+                  positive: true,
+                  title: "LOC_SETTLER_LENS_FRESH_WATER_NAME",
+                  description: "LOC_SETTLER_LENS_FRESH_WATER_DESCRIPTION",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+    notes: [
+      "Read-only settlement recommendation view. It wraps the official settlement lens API, not a city-founding operation.",
+      "Recommendations are local-player AI advice for ranking candidate plots; use unit-target/ready-unit validation before moving a Settler.",
+    ],
+  };
+}

--- a/packages/civ7-direct-control/test/settlement-recommendations.test.ts
+++ b/packages/civ7-direct-control/test/settlement-recommendations.test.ts
@@ -1,8 +1,13 @@
 import { once } from "node:events";
 import { type AddressInfo, createServer } from "node:net";
 import { describe, expect, test } from "vitest";
+import { Value } from "typebox/value";
 
-import { getCiv7SettlementRecommendations } from "../src/index";
+import {
+  Civ7SettlementRecommendationInputSchema,
+  Civ7SettlementRecommendationResultSchema,
+  getCiv7SettlementRecommendations,
+} from "../src/index";
 
 type SettlementInput = {
   playerId?: number;
@@ -23,6 +28,29 @@ type FakeTunerServer = {
 };
 
 describe("getCiv7SettlementRecommendations", () => {
+  test("exports TypeBox schemas for the bounded read-only settlement recommendation atom", () => {
+    const requestedInput = {
+      locations: [{ x: 18, y: 27 }],
+      count: 3,
+      includeSettlers: false,
+      includeCities: false,
+    };
+    expect(Value.Check(Civ7SettlementRecommendationInputSchema, requestedInput)).toBe(true);
+    expect(Value.Check(Civ7SettlementRecommendationInputSchema, { count: 0 })).toBe(false);
+    expect(Value.Check(Civ7SettlementRecommendationInputSchema, { count: 13 })).toBe(false);
+    expect(Value.Check(Civ7SettlementRecommendationInputSchema, { playerId: -1 })).toBe(false);
+    expect(Value.Check(Civ7SettlementRecommendationInputSchema, { locations: [{ x: 1.5, y: 0 }] })).toBe(false);
+    expect(Value.Check(Civ7SettlementRecommendationInputSchema, { host: "127.0.0.1" })).toBe(false);
+    expect(Value.Check(Civ7SettlementRecommendationInputSchema, { rawCommand: "readSettlementRecommendations()" })).toBe(false);
+
+    const result = settlementRecommendationsResult(requestedInput);
+    expect(Value.Check(Civ7SettlementRecommendationResultSchema, result)).toBe(true);
+    expect(Value.Check(Civ7SettlementRecommendationResultSchema, {
+      ...result,
+      rawCommand: "readSettlementRecommendations()",
+    })).toBe(false);
+  });
+
   test("routes a requested-location read through App UI settlement recommendations without send operations", async () => {
     const server = await startSettlementRecommendationsTunerServer();
     try {
@@ -243,6 +271,15 @@ function settlementRecommendations(input: SettlementInput) {
       "Recommendations are local-player AI advice for ranking candidate plots; use unit-target/ready-unit validation before moving a Settler.",
       "Official settlement lens seeds recommendations from Settler and city origins; pass --x/--y to focus one live Settler or formation.",
     ],
+  };
+}
+
+function settlementRecommendationsResult(input: SettlementInput) {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    ...settlementRecommendations(input),
   };
 }
 


### PR DESCRIPTION
test(direct-control): add notification view procedure

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds TypeBox schemas for the existing read-only notification view atom and an adjacent notifications.view procedure descriptor/call wrapper over getCiv7PlayNotificationView.

Proof covers schema resolution, bounded maxNotifications input, context/raw-command input rejection, no-network fake-dependency calls, public facade exports, and OpenSpec records.

No runtime/live-game proof claimed. No CLI output, notification classification, dismissal behavior, router/registry/transport, Effect/oRPC source, schema migration, Task 2.9.4 acceptance, or Tasks 6.1-6.9 implementation.

test(direct-control): add settlement recommendations procedure

Refs: openspec/changes/civ7-support-direct-control-modularization

Adds TypeBox input/output schemas beside the read-only settlement recommendation atom and exposes a strategy.settlement.recommendations procedure descriptor/call wrapper.

Proof is local and no-network: focused fake-dependency procedure tests, adjacent atom schema tests, public facade proof, strict OpenSpec validation, package gates, check:cli, and test:cli:play.

No runtime/live-game proof, CLI output rewrite, city-founding/send behavior, router/registry/transport, Effect/oRPC source, Task 2.9.4 acceptance, or 5.x/6.x implementation is claimed.