### PR TITLE
docs(control-orpc): rebaseline world resource boundary

### DIFF
--- a/openspec/changes/civ7-control-orpc-native-slice/design.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/design.md
@@ -68,8 +68,10 @@ outcome. The workstream is rebaselined around this order:
 3. Freeze facade-only wrapper expansion and move to service-owned procedures.
    - The historical read-only leaves over `unit.summary.read`,
      `map.summary.read`, `player.summary.read`, and `city.summary.read` have
-     been burned down; the direct-control summary atoms remain low-level
-     read capability owners until a real service-owned `world` view moves
+     been burned down. The direct-control summary functions are still
+     service-shaped transitional read debt, not proven low-level runtime
+     resources for `world.current`. A future world service slice must either
+     decompose lower-level Tuner/probe resources first or move semantic summary
      behavior into control-oRPC.
    - The historical `runtime.playable.status` facade leaf has been replaced by
      `readiness.current`, which projects the direct-control playable-status
@@ -103,7 +105,20 @@ outcome. The workstream is rebaselined around this order:
    - Local fake tests prove code boundaries only; mutation/runtime claims still
      require real-game proof or explicit pending-runtime-proof.
 
-5. Promote shared middleware only after repetition is real.
+5. Separate runtime resources from service behavior before world/read
+   composition.
+   - `@civ7/direct-control` may own tuner socket/session lifecycle, state
+     selection, command serialization, raw probe execution, validators,
+     postcondition/proof owners, and resource acquisition/release.
+   - `packages/civ7-control-orpc` owns native service contracts, routers,
+     typed context, tagged errors, middleware, semantic composition, and normal
+     caller-facing projection.
+   - Do not classify a direct-control function as a runtime port merely
+     because it already exists. If it builds semantic summary envelopes, a
+     native service slice must move or consolidate that behavior instead of
+     wrapping it.
+
+6. Promote shared middleware only after repetition is real.
    - Middleware candidates include endpoint defaults, readiness, approval,
      validator-first, postcondition/proof recording, relationship authority,
      safe error projection, correlation, and telemetry hooks.
@@ -112,13 +127,13 @@ outcome. The workstream is rebaselined around this order:
    - Use oRPC/effect-orpc middleware primitives; do not build a parallel
      `beforeHandler`/event/correlation pipeline.
 
-6. Add mutation procedures after middleware proof.
+7. Add mutation procedures after middleware proof.
    - Mutation procedures must preserve approval-first, validator-first,
      separated send receipt, post-read, postcondition classification,
      no-repeat-after-unverified, and honest pending-runtime-proof semantics.
    - Legacy `verified` booleans are source evidence, not proof authority.
 
-7. Add edge adapters last.
+8. Add edge adapters last.
    - CLI and tests call the router in process.
    - Studio browser/server uses `RPCHandler`/`RPCLink` after the shared router
      is stable.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -73,9 +73,10 @@
     and omit raw host/port/state/Tuner/error details from normal output.
   - [x] 4.11.5 Burn down the remaining transitional summary read facade
     leaves: `map.summary.read`, `player.summary.read`, `unit.summary.read`,
-    and `city.summary.read`. Keep direct-control summary atoms as low-level
-    runtime/read capability owners until a real service-owned `world` view is
-    designed and implemented.
+    and `city.summary.read`. Do not rebuild `world.current` by calling those
+    direct-control summary functions as if they were bare runtime resources;
+    first separate tuner/Civ bridge resource mechanics from semantic summary
+    service behavior.
 
 This phase is closed as transitional proof only. It must not be extended by
 adding more read-only facade shells.
@@ -111,6 +112,12 @@ adding more read-only facade shells.
   - [x] 5.4.2 Record turn-completion status as an `attention.current`
     runtime read port and semantic projection owner, not a standalone
     facade-only procedure leaf.
+  - [x] 5.4.3 Rebaseline the world/read boundary: direct-control summary
+    functions are transitional service-shaped read debt, not accepted
+    low-level runtime resources for `world.current`; a world service slice must
+    either decompose lower-level Tuner/probe resources first or move semantic
+    summary behavior into the control-oRPC service owner. See
+    `workstream/world-runtime-resource-boundary.md`.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/native-slice-authority.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/native-slice-authority.md
@@ -20,14 +20,15 @@ router registries, or transport handling.
 
 The product surface is a Civ7 control procedure layer for player support,
 Studio, in-game controller, and future AI callers. It composes stable
-service-owned capabilities over direct-control runtime ports; it does not
-replace direct-control runtime authority.
+service-owned capabilities over honest runtime resources; it does not replace
+direct-control runtime authority.
 
 ```text
 Direct-control runtime ports
-  Own Civ7 runtime access, validators, command-source serialization,
-  approval types, postconditions, proof labels, relationship evidence policy,
-  and semantic/debug projection facts.
+  Own Civ7 runtime resource access: socket/session lifecycle, state
+  selection, command-source serialization, raw probe execution, validators,
+  approval types, postconditions, proof labels, and relationship evidence
+  policy.
 
 Control-oRPC package
   Owns the offered service procedures: contracts, product procedure logic,
@@ -58,6 +59,27 @@ The OpenSpec workstream now freezes additional facade-only shells. The existing
 shells remain only as named transitional debt to be retired, moved, or
 rewritten in later slices. Do not add punitive tests for this transient debt;
 if broad enforcement is needed, use the repo lint/guardrail system.
+
+## Runtime Resource Boundary
+
+Do not call a direct-control function a runtime port only because it sits below
+the oRPC package. A valid runtime resource boundary is about tuner/Civ bridge
+mechanics: resource acquisition and release, socket/session protocol,
+buffering, schedules/reconnects, state selection, command serialization, raw
+probe execution, validators, and proof/postcondition ownership.
+
+Semantic service behavior belongs in `packages/civ7-control-orpc`. If a
+direct-control function already builds a semantic summary or service-shaped
+envelope, a native procedure must not simply import it and publish a nicer
+router surface. The implementation must either decompose lower-level runtime
+resources first, or move/consolidate that semantic behavior into the service
+owner.
+
+This especially blocks a naive `world.current` over direct-control
+`getCiv7MapSummary`, `getCiv7PlayerSummary`, `getCiv7UnitSummary`, and
+`getCiv7CitySummary`. Those functions remain useful evidence of fields and
+runtime probes, but they are not accepted as the final runtime-resource split
+for a world service slice.
 
 ## Rebaselined Workstream Order
 
@@ -101,7 +123,9 @@ handlers run:
 
 ```text
 directControl
-  Typed facade over direct-control runtime ports and proof/policy owners.
+  Typed facade over direct-control runtime resources and proof/policy owners.
+  It must not grow facade-only access to service-shaped direct-control
+  summaries as a shortcut around moving service behavior into control-oRPC.
 
 controller
   Optional in-game controller facade for scope="game" router execution.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/semantic-capability-hierarchy.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/semantic-capability-hierarchy.md
@@ -178,11 +178,11 @@ Service ownership:
 | `notifications.dismiss.request` | notification domain mutation; semantic target still needs rebaseline |
 | `unit.ready.view` | burned down; `attention.current` consumes the direct-control ready-unit port |
 | `city.ready.view` | burned down; `attention.current` consumes the direct-control ready-city port |
-| `unit.summary.read`, `city.summary.read`, `player.summary.read` | burned down as public oRPC wrappers; future service-owned `world` view |
+| `unit.summary.read`, `city.summary.read`, `player.summary.read` | burned down as public oRPC wrappers; future `world` service must decompose lower-level runtime/probe resources or move semantic summary behavior into control-oRPC |
 | `unit.move.preview` | `world` read plus future unit validation evidence |
 | `unit.target.action.request` | `unit` |
 | `city.production.choice.request` | `decisions` |
-| `map.summary.read`, `map.grid.read`, `map.plot.snapshot`, `map.visibility.read` | `map.summary.read` wrapper burned down; future service-owned `world` view for map/grid/visibility |
+| `map.summary.read`, `map.grid.read`, `map.plot.snapshot`, `map.visibility.read` | `map.summary.read` wrapper burned down; future `world` service must not treat direct-control summary envelopes as bare runtime ports |
 | `strategy.*` planning reads | `strategy` |
 | narrative, diplomacy, culture, technology, population closeouts | `decisions` |
 | setup, restart, autoplay, reveal-map, turn-send behavior | domain-owned mutation or `debug`, depending on approval/risk class |

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/world-runtime-resource-boundary.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/world-runtime-resource-boundary.md
@@ -1,0 +1,38 @@
+# World Runtime Resource Boundary
+
+Status: rebaselined before source commit.
+Date: 2026-06-04.
+
+## Correction
+
+The attempted `world.current` source slice was stopped before commit because it
+would have treated direct-control summary functions as low-level runtime ports.
+That is not an honest split when those functions already build semantic
+summary envelopes.
+
+The correct split is runtime-resource versus service behavior:
+
+- `@civ7/direct-control` may own tuner/Civ bridge mechanics: socket/session
+  lifecycle, state selection, command serialization, raw probe execution,
+  validators, postcondition/proof owners, and relationship evidence policy.
+- `packages/civ7-control-orpc` owns native service contracts, routers, typed
+  context, tagged errors, middleware, semantic composition, normal output, and
+  in-process procedure behavior.
+
+## World Service Implication
+
+A valid `world.current` slice should not call
+`getCiv7MapSummary`, `getCiv7PlayerSummary`, `getCiv7UnitSummary`, and
+`getCiv7CitySummary` as if those were final runtime resources. It should either
+decompose lower-level Tuner/probe resource access first, or move/consolidate
+the semantic summary/world behavior into the control-oRPC service owner.
+
+The burned-down public summary wrappers remain retired. This correction does
+not revive `map.summary.read`, `player.summary.read`, `unit.summary.read`, or
+`city.summary.read` as public procedure leaves.
+
+## Boundaries
+
+This is an OpenSpec authority correction only. It adds no transport, CLI,
+Studio, in-game bridge, custom oRPC/effect-orpc plumbing, runtime proof claim,
+play-thread action, or Task 5.x/6.x parent acceptance.


### PR DESCRIPTION
Refs: openspec/changes/civ7-control-orpc-native-slice

Stopped the naive world.current path before source commit because direct-control summary functions are service-shaped read debt, not proven low-level runtime resources.

Recorded that a future world service must decompose lower-level Tuner/probe resources or move semantic summary behavior into packages/civ7-control-orpc instead of wrapping existing summary services.

Proof:
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check
- git diff --cached --check