### PR TITLE
feat(cli): route game status through control-oRPC

### DIFF
--- a/apps/mapgen-studio/package.json
+++ b/apps/mapgen-studio/package.json
@@ -15,10 +15,13 @@
   },
   "dependencies": {
     "@civ7/adapter": "workspace:*",
+    "@civ7/control-orpc": "workspace:*",
     "@civ7/direct-control": "workspace:*",
     "@deck.gl/core": "^9.0.43",
     "@deck.gl/layers": "^9.0.43",
     "@deck.gl/react": "^9.0.43",
+    "@orpc/client": "^1.14.4",
+    "@orpc/server": "^1.14.4",
     "@rjsf/core": "^6.2.5",
     "@rjsf/utils": "^6.2.5",
     "@rjsf/validator-ajv8": "^6.2.5",

--- a/apps/mapgen-studio/src/App.tsx
+++ b/apps/mapgen-studio/src/App.tsx
@@ -50,6 +50,7 @@ import {
   type RunInGameFailureDetails,
   type RunInGameOperationStatus,
 } from "./features/runInGame/status";
+import { createStudioCiv7ControlOrpcClient } from "./features/runInGame/civ7ControlOrpcClient";
 import {
   DEFAULT_CIV7_STUDIO_SETUP_CONFIG,
   getLocalPlayerSetup,
@@ -123,6 +124,8 @@ import {
   type StudioRecipeUiMeta,
 } from "./recipes/catalog";
 import { getOverlaySuggestions } from "./recipes/overlaySuggestions";
+
+const civ7ControlOrpcClient = createStudioCiv7ControlOrpcClient();
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -1039,13 +1042,25 @@ function AppContent(props: AppContentProps) {
       statusAbortController?.abort();
       statusAbortController = new AbortController();
       try {
-        const res = await fetch("/api/civ7/live/status", { signal: statusAbortController.signal });
+        const [res, readinessResult] = await Promise.all([
+          fetch("/api/civ7/live/status", { signal: statusAbortController.signal }),
+          civ7ControlOrpcClient.readiness.current({}),
+        ]);
         const body = (await res.json().catch(() => null)) as unknown;
         if (cancelled) return;
         if (!res.ok || !body) throw new Error(isPlainObject(body) && typeof body.error === "string" ? body.error : `HTTP ${res.status}`);
+        const bodyWithOrpcReadiness = isPlainObject(body)
+          ? {
+              ...body,
+              status: {
+                ...(isPlainObject(body.status) ? body.status : {}),
+                readiness: readinessResult.readiness,
+              },
+            }
+          : body;
 
         const statusState = buildLiveRuntimeStatusState({
-          body,
+          body: bodyWithOrpcReadiness,
           observedAtFallback: new Date().toISOString(),
           failureCount: 0,
         });

--- a/apps/mapgen-studio/src/features/runInGame/civ7ControlOrpcClient.ts
+++ b/apps/mapgen-studio/src/features/runInGame/civ7ControlOrpcClient.ts
@@ -1,0 +1,31 @@
+import { createORPCClient } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import type { RouterClient } from "@orpc/server";
+import type { Civ7ControlOrpcRouter } from "@civ7/control-orpc";
+
+import { STUDIO_CIV7_CONTROL_ORPC_PATH } from "../../shared/civ7ControlOrpc";
+
+export { STUDIO_CIV7_CONTROL_ORPC_PATH };
+
+export type StudioCiv7ControlOrpcClient = RouterClient<
+  typeof Civ7ControlOrpcRouter
+>;
+
+export function createStudioCiv7ControlOrpcClient(
+  options: Readonly<{
+    url?: string;
+    fetch?: typeof globalThis.fetch;
+  }> = {},
+): StudioCiv7ControlOrpcClient {
+  const link = new RPCLink({
+    url: options.url ?? STUDIO_CIV7_CONTROL_ORPC_PATH,
+    ...(options.fetch
+      ? {
+          fetch: (request, init) => options.fetch?.(request, init)
+            ?? globalThis.fetch(request, init),
+        }
+      : {}),
+  });
+
+  return createORPCClient<StudioCiv7ControlOrpcClient>(link);
+}

--- a/apps/mapgen-studio/src/server/civ7ControlOrpc.ts
+++ b/apps/mapgen-studio/src/server/civ7ControlOrpc.ts
@@ -1,0 +1,56 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  Civ7ControlOrpcRouter,
+  liveCiv7ControlOrpcDirectControlFacade,
+  type Civ7ControlOrpcContext,
+  type Civ7ControlOrpcDirectControlFacade,
+} from "@civ7/control-orpc";
+import { DEFAULT_CIV7_TUNER_TIMEOUT_MS } from "@civ7/direct-control";
+import { RPCHandler } from "@orpc/server/node";
+
+import { STUDIO_CIV7_CONTROL_ORPC_PATH } from "../shared/civ7ControlOrpc";
+
+export type StudioCiv7ControlOrpcNext = (err?: unknown) => void;
+
+export function createStudioCiv7ControlOrpcContext(
+  options: Readonly<{
+    directControl?: Civ7ControlOrpcDirectControlFacade;
+    timeoutMs?: number;
+  }> = {},
+): Civ7ControlOrpcContext {
+  return {
+    directControl: options.directControl
+      ?? liveCiv7ControlOrpcDirectControlFacade,
+    endpointDefaults: {
+      timeoutMs: options.timeoutMs ?? DEFAULT_CIV7_TUNER_TIMEOUT_MS,
+    },
+  };
+}
+
+export function createStudioCiv7ControlOrpcMiddleware(
+  options: Readonly<{
+    directControl?: Civ7ControlOrpcDirectControlFacade;
+    timeoutMs?: number;
+  }> = {},
+): (
+  req: IncomingMessage,
+  res: ServerResponse,
+  next: StudioCiv7ControlOrpcNext,
+) => Promise<void> {
+  const rpcHandler = new RPCHandler(Civ7ControlOrpcRouter);
+
+  return async (req, res, next) => {
+    try {
+      const result = await rpcHandler.handle(req, res, {
+        prefix: STUDIO_CIV7_CONTROL_ORPC_PATH,
+        context: createStudioCiv7ControlOrpcContext(options),
+      });
+      if (!result.matched) next();
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+export const handleStudioCiv7ControlOrpcRequest =
+  createStudioCiv7ControlOrpcMiddleware();

--- a/apps/mapgen-studio/src/server/runInGame/operationState.ts
+++ b/apps/mapgen-studio/src/server/runInGame/operationState.ts
@@ -136,7 +136,7 @@ export function createRunInGameOperationStore(options: StoreOptions) {
       ok: false,
       phase: status,
       status,
-      error: err instanceof Error ? err.message : String(err),
+      error: publicRunInGameFailureMessage(err, details),
       details,
       ...(materialization === undefined ? {} : { materialization }),
     });
@@ -195,9 +195,12 @@ export function runInGameFailureDetails(
   const failureClass = classifyRunInGameFailure(err, phase);
   const nextMaterialization = materialization ?? (isMaterializationStatus(httpDetails.materialization) ? httpDetails.materialization : undefined);
   const code = directControlCode ?? (typeof httpDetails.code === "string" ? httpDetails.code : undefined);
-  const cause = err instanceof Civ7DirectControlError ? cloneForJson(err.details) : undefined;
+  const publicHttpDetails = sanitizeRunInGameStatusRecord(httpDetails);
+  const cause = err instanceof Civ7DirectControlError
+    ? sanitizeRunInGameStatusValue(err.details)
+    : undefined;
   return {
-    ...httpDetails,
+    ...publicHttpDetails,
     failureClass,
     phase,
     completedPhases: state?.completedPhases ?? [],
@@ -223,6 +226,94 @@ export function classifyRunInGameFailure(err: unknown, phase: RunInGamePhase): "
 function cloneForJson(value: unknown): unknown {
   if (value === undefined) return undefined;
   return JSON.parse(JSON.stringify(value));
+}
+
+function publicRunInGameFailureMessage(
+  err: unknown,
+  details: RunInGameFailureDetails,
+): string {
+  const phase = details.phase ?? "failed";
+  const phaseLabel = publicRunInGamePhaseLabel(phase);
+  if (err instanceof RunInGameHttpError) {
+    return redactRuntimeCommandText(err.message);
+  }
+  if (err instanceof Civ7DirectControlError) {
+    switch (err.code) {
+      case "response-timeout":
+        return `Civ7 did not respond during ${phaseLabel}; status is uncertain.`;
+      case "socket-closed":
+        return `Civ7 tuner connection closed during ${phaseLabel}; status is uncertain.`;
+      case "connection-timeout":
+        return `Timed out connecting to Civ7 during ${phaseLabel}.`;
+      case "all-hosts-unavailable":
+      case "no-hosts":
+        return `No configured Civ7 tuner endpoint was available during ${phaseLabel}.`;
+      default:
+        return `Civ7 direct-control failed during ${phaseLabel}.`;
+    }
+  }
+  return redactRuntimeCommandText(err instanceof Error ? err.message : String(err));
+}
+
+function publicRunInGamePhaseLabel(phase: RunInGamePhase): string {
+  switch (phase) {
+    case "materializing":
+      return "materialization";
+    case "deploying":
+      return "deployment";
+    case "restarting-civ":
+      return "Civ restart";
+    case "checking-civ7":
+      return "Civ7 readiness check";
+    case "reload-needed":
+      return "reload recovery";
+    case "preparing-setup":
+      return "setup preparation";
+    case "starting-game":
+      return "game start";
+    case "waiting-for-proof":
+      return "runtime proof";
+    case "idle":
+    case "complete":
+    case "blocked":
+    case "failed":
+    case "uncertain":
+      return phase;
+  }
+}
+
+function sanitizeRunInGameStatusValue(value: unknown): unknown {
+  if (value === undefined) return undefined;
+  const cloned = cloneForJson(value);
+  return sanitizeClonedRunInGameStatusValue(cloned);
+}
+
+function sanitizeRunInGameStatusRecord(value: Record<string, unknown>): Record<string, unknown> {
+  const sanitized = sanitizeRunInGameStatusValue(value);
+  return isRecord(sanitized) ? sanitized : {};
+}
+
+function sanitizeClonedRunInGameStatusValue(value: unknown): unknown {
+  if (typeof value === "string") return redactRuntimeCommandText(value);
+  if (Array.isArray(value)) return value.map(sanitizeClonedRunInGameStatusValue);
+  if (!isRecord(value)) return value;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, next] of Object.entries(value)) {
+    if (isRawRuntimeCommandDetailKey(key)) continue;
+    out[key] = sanitizeClonedRunInGameStatusValue(next);
+  }
+  return out;
+}
+
+function isRawRuntimeCommandDetailKey(key: string): boolean {
+  return /(?:^|\.)(?:command|rawCommand|jsLiteral|payload|startPayload|state|stateName|session|sessionSelection)(?:$|\.)/i.test(key);
+}
+
+function redactRuntimeCommandText(value: string): string {
+  return value
+    .replace(/CMD:[0-9]+:[\s\S]*/g, "[redacted-runtime-command]")
+    .replace(/LSQ:[\s\S]*/g, "[redacted-runtime-command]");
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/mapgen-studio/src/shared/civ7ControlOrpc.ts
+++ b/apps/mapgen-studio/src/shared/civ7ControlOrpc.ts
@@ -1,0 +1,1 @@
+export const STUDIO_CIV7_CONTROL_ORPC_PATH = "/api/civ7/rpc";

--- a/apps/mapgen-studio/test/runInGame/civ7ControlOrpcClient.test.ts
+++ b/apps/mapgen-studio/test/runInGame/civ7ControlOrpcClient.test.ts
@@ -1,0 +1,145 @@
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, test } from "vitest";
+
+import type {
+  Civ7ControlOrpcContext,
+  Civ7ControlOrpcPlayableStatusResult,
+} from "@civ7/control-orpc";
+import {
+  createStudioCiv7ControlOrpcClient,
+  STUDIO_CIV7_CONTROL_ORPC_PATH,
+} from "../../src/features/runInGame/civ7ControlOrpcClient";
+import { createStudioCiv7ControlOrpcMiddleware } from "../../src/server/civ7ControlOrpc";
+
+const openServers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(openServers.splice(0).map((server) => closeServer(server)));
+});
+
+describe("Studio Civ7 control-oRPC browser edge", () => {
+  test("calls readiness.current through native RPCLink and RPCHandler", async () => {
+    const calls: Array<Civ7ControlOrpcContext["endpointDefaults"]> = [];
+    const middleware = createStudioCiv7ControlOrpcMiddleware({
+      timeoutMs: 321,
+      directControl: {
+        getCiv7PlayableStatus: async (options) => {
+          calls.push(options);
+          return playableStatusResult();
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    });
+    const origin = await listen((req, res) => {
+      void middleware(req, res, () => {
+        res.statusCode = 404;
+        res.end("not found");
+      });
+    });
+
+    const client = createStudioCiv7ControlOrpcClient({
+      url: `${origin}${STUDIO_CIV7_CONTROL_ORPC_PATH}`,
+    });
+    const result = await client.readiness.current({});
+
+    expect(result).toMatchObject({
+      playable: true,
+      readiness: "tuner-ready",
+      capability: {
+        canObserve: true,
+        canMutate: true,
+      },
+    });
+    expect(calls).toEqual([{ timeoutMs: 321 }]);
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("App UI");
+    expect(serialized).not.toContain("Tuner");
+  });
+
+  test("passes non-control paths through to later Studio middleware", async () => {
+    const middleware = createStudioCiv7ControlOrpcMiddleware({
+      directControl: {
+        getCiv7PlayableStatus: async () => playableStatusResult(),
+      } as Civ7ControlOrpcContext["directControl"],
+    });
+    const origin = await listen((req, res) => {
+      void middleware(req, res, () => {
+        res.statusCode = 404;
+        res.end("not found");
+      });
+    });
+
+    const res = await fetch(`${origin}/api/civ7/not-rpc`);
+
+    expect(res.status).toBe(404);
+    await expect(res.text()).resolves.toBe("not found");
+  });
+});
+
+async function listen(
+  handler: Parameters<typeof createServer>[0],
+): Promise<string> {
+  const server = createServer(handler);
+  openServers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected TCP server address");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+function playableStatusResult(): Civ7ControlOrpcPlayableStatusResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    playable: true,
+    readiness: "tuner-ready",
+    appUi: {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      snapshot: {
+        ui: {
+          inGame: probe(true),
+          inShell: probe(false),
+          inLoading: probe(false),
+          canBeginGame: probe(false),
+        },
+      },
+    },
+    tuner: {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "1", name: "Tuner" },
+      ready: true,
+      snapshot: {
+        evalOk: 2,
+        ready: true,
+      },
+    },
+    errors: ["raw runtime detail stays out of readiness.current"],
+  } as Civ7ControlOrpcPlayableStatusResult;
+}
+
+function probe<T>(value: T): { ok: true; value: T } {
+  return { ok: true, value };
+}

--- a/apps/mapgen-studio/test/runInGame/operationState.test.ts
+++ b/apps/mapgen-studio/test/runInGame/operationState.test.ts
@@ -5,6 +5,7 @@ import {
   RunInGameHttpError,
   createRunInGameOperationStore,
 } from "../../src/server/runInGame/operationState";
+import { formatRunInGameDiagnostics } from "../../src/features/runInGame/status";
 
 function createStore() {
   let nowMs = Date.parse("2026-06-01T00:00:00.000Z");
@@ -129,6 +130,56 @@ describe("Run in Game operation store", () => {
     expect(failed.status).toBe("uncertain");
     expect(failed.details?.directControlCode).toBe("socket-closed");
     expect(store.findActive()).toBeUndefined();
+  });
+
+  it("keeps raw tuner command payloads out of public timeout status", () => {
+    const { store } = createStore();
+    store.create("request-1");
+    const failed = store.fail(
+      "request-1",
+      "starting-game",
+      new Civ7DirectControlError(
+        "response-timeout",
+        "Timed out waiting for Civ7 tuner response to CMD:65535:(() => { Game.turn; UI.notifyUIReady(); })()",
+        {
+          details: {
+            message: "Civ7 tuner socket is closed before CMD:1:Game.turn",
+            command: "Game.turn",
+            state: { id: 1, name: "Tuner" },
+            session: { stateName: "App UI", listenerId: 65_535 },
+            nested: {
+              rawCommand: "CMD:65535:UI.notifyUIReady()",
+              sessionSelection: { state: "Tuner" },
+              output: "before LSQ:state-list",
+            },
+          },
+        },
+      ),
+    );
+
+    expect(failed.status).toBe("uncertain");
+    expect(failed.error).toBe("Civ7 did not respond during game start; status is uncertain.");
+    expect(failed.details).toMatchObject({
+      code: "response-timeout",
+      directControlCode: "response-timeout",
+      failureClass: "uncertain",
+      phase: "starting-game",
+    });
+
+    const diagnostics = formatRunInGameDiagnostics(failed);
+    expect(diagnostics).toContain("response-timeout");
+    expect(diagnostics).toContain("redacted-runtime-command");
+    expect(diagnostics).not.toContain("CMD:");
+    expect(diagnostics).not.toContain("Game.turn");
+    expect(diagnostics).not.toContain("UI.notifyUIReady");
+    expect(diagnostics).not.toContain("rawCommand");
+    expect(diagnostics).not.toContain('"command"');
+    expect(diagnostics).not.toContain('"state"');
+    expect(diagnostics).not.toContain('"stateName"');
+    expect(diagnostics).not.toContain('"session"');
+    expect(diagnostics).not.toContain('"sessionSelection"');
+    expect(diagnostics).not.toContain('"Tuner"');
+    expect(diagnostics).not.toContain('"App UI"');
   });
 
   it("prunes stale operation records after the configured ttl", () => {

--- a/apps/mapgen-studio/vite.config.ts
+++ b/apps/mapgen-studio/vite.config.ts
@@ -54,6 +54,7 @@ import { createMapConfigSaveDeployOperationStore } from "./src/server/mapConfigs
 import { parseMapConfigSaveRequest } from "./src/server/mapConfigs/requestValidation";
 import type { RunInGamePhase, RunInGameRequestStatus } from "./src/features/runInGame/status";
 import { buildLiveRuntimeStatusState } from "./src/features/liveRuntime/model";
+import { handleStudioCiv7ControlOrpcRequest } from "./src/server/civ7ControlOrpc";
 
 const execFileAsync = promisify(execFile);
 const DEPLOY_TIMEOUT_MS = 120_000;
@@ -377,6 +378,7 @@ export default defineConfig(({ command }) => ({
     {
       name: "repo-backed-map-configs",
       configureServer(server) {
+        server.middlewares.use(handleStudioCiv7ControlOrpcRequest);
         server.middlewares.use("/api/civ7/status", async (req, res, next) => {
           if (req.method !== "GET") return next();
           try {

--- a/bun.lock
+++ b/bun.lock
@@ -35,10 +35,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@civ7/adapter": "workspace:*",
+        "@civ7/control-orpc": "workspace:*",
         "@civ7/direct-control": "workspace:*",
         "@deck.gl/core": "^9.0.43",
         "@deck.gl/layers": "^9.0.43",
         "@deck.gl/react": "^9.0.43",
+        "@orpc/client": "^1.14.4",
+        "@orpc/server": "^1.14.4",
         "@rjsf/core": "^6.2.5",
         "@rjsf/utils": "^6.2.5",
         "@rjsf/validator-ajv8": "^6.2.5",
@@ -183,6 +186,7 @@
       },
       "dependencies": {
         "@civ7/config": "workspace:*",
+        "@civ7/control-orpc": "workspace:*",
         "@civ7/direct-control": "workspace:*",
         "@civ7/plugin-files": "workspace:*",
         "@civ7/plugin-git": "workspace:*",

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -119,6 +119,19 @@ boundaries.
   unknown, missing-postcondition, and pending-runtime-proof outcomes honestly
 - **AND** unverified or pending proof paths remain no-repeat guarded
 
+#### Scenario: Closeout-style mutation projection is shared
+- **WHEN** notification dismissal, narrative choice, or diplomacy response
+  procedures receive source-owned direct-control postcondition evidence
+- **THEN** the shared control-oRPC mutation projection policy derives the
+  caller-facing postcondition confirmation and no-repeat summary
+- **AND** direct-control remains the source authority for domain
+  classifications, outcomes, and proof-boundary confidence
+- **AND** missing postcondition and pending-runtime-proof inputs project as
+  unconfirmed and no-repeat guarded
+- **AND** this shared projection helper does not accept shared
+  validator/postcondition middleware or parent Task 6.x completion by
+  implication
+
 #### Scenario: Narrative decision request procedure is implemented
 - **WHEN** a narrative choice decision procedure requests a player choice
 - **THEN** it is offered under the semantic `decisions` router

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -16,6 +16,18 @@ errors, and server-side callers.
   postcondition classifiers, command serialization, proof facts, and other
   low-level authority that must remain runtime-owned
 
+#### Scenario: Strategy planning view is added
+- **WHEN** a strategy planning procedure is implemented
+- **THEN** it composes planning evidence from bounded runtime/read ports into a
+  service-owned projection
+- **AND** normal output excludes host, port, state, session, raw command, and
+  debug transport details
+- **AND** planning candidates remain read-only evidence and are not promoted to
+  approved movement, attack, war, or send authority
+- **AND** other-owner contact, proximity, ranking, and action legality preserve
+  relationship-unproven semantics unless official relationship, team, war, or
+  suzerain evidence proves stronger labels
+
 #### Scenario: Transitional facade-only procedure remains
 - **WHEN** a current facade-only read leaf is retained while the native service
   shape is being corrected

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -119,6 +119,20 @@ boundaries.
   unknown, missing-postcondition, and pending-runtime-proof outcomes honestly
 - **AND** unverified or pending proof paths remain no-repeat guarded
 
+#### Scenario: Narrative decision request procedure is implemented
+- **WHEN** a narrative choice decision procedure requests a player choice
+- **THEN** it is offered under the semantic `decisions` router
+- **AND** it checks mutation approval and playable readiness before invoking
+  direct-control runtime authority
+- **AND** it consumes direct-control narrative validators and proof helpers as
+  runtime/proof ports rather than reimplementing postcondition truth
+- **AND** its normal output projects semantic status, validation summary,
+  postcondition summary, and next steps
+- **AND** it excludes endpoint, session, state, raw command, payload, and
+  legacy `verified` details from caller-facing input and output
+- **AND** unverified, stale, missing-postcondition, no-state-change, and
+  not-sent paths remain no-repeat guarded
+
 #### Scenario: Local procedure test passes
 - **WHEN** a local fake-context procedure test passes
 - **THEN** it may prove contract/middleware/projection behavior

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -133,6 +133,23 @@ boundaries.
 - **AND** unverified, stale, missing-postcondition, no-state-change, and
   not-sent paths remain no-repeat guarded
 
+#### Scenario: Diplomacy response request procedure is implemented
+- **WHEN** a diplomacy response decision procedure requests a player response
+- **THEN** it is offered under the semantic `decisions` router
+- **AND** it checks mutation approval and playable readiness before invoking
+  direct-control runtime authority
+- **AND** it consumes direct-control diplomacy validators and proof helpers as
+  runtime/proof ports rather than inferring proof from legacy `verified`
+- **AND** its normal input exposes player, action, response, and optional
+  notification identity rather than direct-control UI toggles
+- **AND** its normal output projects semantic status, validation summary,
+  postcondition summary, and next steps
+- **AND** it excludes endpoint, session, state, raw command, payload,
+  notification internals, UI closeout internals, and legacy `verified` details
+  from caller-facing input and output
+- **AND** unverified, missing-postcondition, no-state-change, validation-changed,
+  and not-sent paths remain no-repeat guarded
+
 #### Scenario: Local procedure test passes
 - **WHEN** a local fake-context procedure test passes
 - **THEN** it may prove contract/middleware/projection behavior

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -231,8 +231,12 @@ adding more read-only facade shells.
     `readiness.current` server-side client. Keep CLI endpoint flags as context
     construction, emit the semantic readiness projection, and keep raw
     direct-control playable-status internals out of normal status output.
-- [ ] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
+- [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
+  - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
+    Node middleware with native `RPCHandler`, add a browser `RPCLink` client,
+    and route the live footer readiness member through
+    `readiness.current` while preserving existing map/autoplay REST fields.
 - [ ] 7.3 Add in-game controller bridge only as serialized ingress into the
   in-process router.
 - [ ] 7.4 Keep OpenAPI/external REST deferred until there is a documented

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -225,8 +225,12 @@ adding more read-only facade shells.
 
 ## 7. Edge Adapters
 
-- [ ] 7.1 Route one CLI caller through the in-process procedure client only
+- [x] 7.1 Route one CLI caller through the in-process procedure client only
   after the service-owned router shape is stable.
+  - [x] 7.1.1 Route `civ7 game status` through the in-process
+    `readiness.current` server-side client. Keep CLI endpoint flags as context
+    construction, emit the semantic readiness projection, and keep raw
+    direct-control playable-status internals out of normal status output.
 - [ ] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
 - [ ] 7.3 Add in-game controller bridge only as serialized ingress into the
@@ -241,4 +245,5 @@ adding more read-only facade shells.
 - [x] 8.2 Run `git diff --check`.
 - [x] 8.3 Run focused package tests/check/build when source implementation is
   added.
-- [ ] 8.4 Run CLI play tests/check when CLI callers change.
+- [x] 8.4 Run CLI play tests/check when a CLI caller is routed through
+  procedures.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -246,6 +246,11 @@ adding more read-only facade shells.
     direct-control diplomacy response runtime port and project source-owned
     diplomacy proof/no-repeat semantics into normal output; keep shared
     validator/postcondition middleware pending.
+  - [x] 6.3.7 Extract repeated closeout-style postcondition projection into a
+    shared control-oRPC mutation policy helper reused by notification,
+    narrative, and diplomacy mutation procedures. Keep direct-control proof
+    classifiers as source authority and keep shared validator/postcondition
+    middleware pending.
 - [ ] 6.4 Add safe error projection and correlation through oRPC/effect-orpc
   context/error primitives, not direct-control-local framework wiring.
   - [x] 6.4.1 Use native effect-orpc tagged error constructors for
@@ -312,3 +317,7 @@ adding more read-only facade shells.
 - [x] 8.6 Run direct-control diplomacy proof, control-oRPC diplomacy response,
   package check/build, OpenSpec strict validation, and diff hygiene gates for
   `decisions.diplomacy.response.request` before closing that slice.
+- [x] 8.7 Run focused control-oRPC mutation projection policy and affected
+  notification/narrative/diplomacy procedure tests, package check/build,
+  strict OpenSpec validates, and diff hygiene when the shared closeout
+  projection helper is extracted.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -129,6 +129,13 @@ adding more read-only facade shells.
     normal proof projection, raw-output exclusion, and no-repeat next steps;
     no direct-control procedure core, broad decisions catalog, runtime proof,
     or parent Task 5.x/6.x acceptance.
+  - [x] 5.4.6 Record `decisions.diplomacy.response.request` as a
+    service-owned decision boundary over direct-control diplomacy runtime,
+    validator, and proof ports. The service owns the caller-facing semantic
+    response shape, normal proof projection, raw-output exclusion, and
+    no-repeat next steps; direct-control-only UI toggles, broad decisions
+    catalogs, runtime proof, and parent Task 5.x/6.x acceptance remain out of
+    scope.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -172,6 +179,11 @@ adding more read-only facade shells.
     readiness, direct-control narrative request authority, and source-owned
     narrative proof classification into semantic output without exposing raw
     command/session/payload details or claiming runtime/live proof.
+  - [x] 5.5.11 Seed `decisions.diplomacy.response.request` as a native
+    service-owned decision procedure that composes approval, playable
+    readiness, direct-control diplomacy response authority, and source-owned
+    diplomacy proof classification into semantic output without exposing raw
+    command/session/payload/UI-closeout details or claiming runtime/live proof.
 
 ## 6. Native Policy Layering
 
@@ -205,6 +217,9 @@ adding more read-only facade shells.
   - [x] 6.2.6 Reuse shared native approval middleware for
     `decisions.narrative.choice.request` while keeping validator-first and
     postcondition/proof middleware pending.
+  - [x] 6.2.7 Reuse shared native approval middleware for
+    `decisions.diplomacy.response.request` while keeping validator-first and
+    postcondition/proof middleware pending.
 - [ ] 6.3 Add validator-first and postcondition/proof middleware before
   mutation sends.
   - [x] 6.3.1 Compose `city.production.choice.request` through the
@@ -226,6 +241,10 @@ adding more read-only facade shells.
   - [x] 6.3.5 Compose `decisions.narrative.choice.request` through the
     direct-control narrative request runtime port and project source-owned
     narrative proof/no-repeat semantics into normal output; keep shared
+    validator/postcondition middleware pending.
+  - [x] 6.3.6 Compose `decisions.diplomacy.response.request` through the
+    direct-control diplomacy response runtime port and project source-owned
+    diplomacy proof/no-repeat semantics into normal output; keep shared
     validator/postcondition middleware pending.
 - [ ] 6.4 Add safe error projection and correlation through oRPC/effect-orpc
   context/error primitives, not direct-control-local framework wiring.
@@ -254,6 +273,10 @@ adding more read-only facade shells.
     `decisions.narrative.choice.request` direct-control runtime-port failures
     while keeping raw direct-control cause, command, session, and payload
     details out of public error data.
+  - [x] 6.4.8 Use native effect-orpc tagged error constructors for
+    `decisions.diplomacy.response.request` direct-control runtime-port
+    failures while keeping raw direct-control cause, command, session, payload,
+    and UI-closeout details out of public error data.
 
 ## 7. Edge Adapters
 
@@ -286,3 +309,6 @@ adding more read-only facade shells.
 - [x] 8.5 Run direct-control narrative proof, control-oRPC narrative decision,
   package check/build, OpenSpec strict validation, and diff hygiene gates for
   `decisions.narrative.choice.request` before closing that slice.
+- [x] 8.6 Run direct-control diplomacy proof, control-oRPC diplomacy response,
+  package check/build, OpenSpec strict validation, and diff hygiene gates for
+  `decisions.diplomacy.response.request` before closing that slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -118,6 +118,11 @@ adding more read-only facade shells.
     either decompose lower-level Tuner/probe resources first or move semantic
     summary behavior into the control-oRPC service owner. See
     `workstream/world-runtime-resource-boundary.md`.
+  - [x] 5.4.4 Record `strategy.frontSummary` as a service-owned planning
+    composition over target-candidate and battlefield-scan runtime/read ports.
+    The service owns the normal projection, next-step wording, raw-output
+    exclusion, and relationship-unproven policy; no strategy catalog, action
+    authority, runtime proof, or parent Task 5.x/6.x acceptance.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -151,6 +156,11 @@ adding more read-only facade shells.
     direct-control proof classifiers, validator summaries, and
     postcondition/no-repeat authority procedure-local; shared
     validator/postcondition middleware remains pending.
+  - [x] 5.5.9 Seed `strategy.frontSummary` as a native service-owned planning
+    procedure that composes target-candidate and battlefield-scan evidence into
+    neutral front planning output without adding same-shaped read wrappers,
+    operation sends, strategy catalogs, relationship labels beyond official
+    evidence, or runtime/live proof claims.
 
 ## 6. Native Policy Layering
 

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -123,6 +123,12 @@ adding more read-only facade shells.
     The service owns the normal projection, next-step wording, raw-output
     exclusion, and relationship-unproven policy; no strategy catalog, action
     authority, runtime proof, or parent Task 5.x/6.x acceptance.
+  - [x] 5.4.5 Record `decisions.narrative.choice.request` as a service-owned
+    decision boundary over direct-control narrative runtime, validator, and
+    proof ports. The service owns the caller-facing semantic choice shape,
+    normal proof projection, raw-output exclusion, and no-repeat next steps;
+    no direct-control procedure core, broad decisions catalog, runtime proof,
+    or parent Task 5.x/6.x acceptance.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -161,6 +167,11 @@ adding more read-only facade shells.
     neutral front planning output without adding same-shaped read wrappers,
     operation sends, strategy catalogs, relationship labels beyond official
     evidence, or runtime/live proof claims.
+  - [x] 5.5.10 Seed `decisions.narrative.choice.request` as a native
+    service-owned decision procedure that composes approval, playable
+    readiness, direct-control narrative request authority, and source-owned
+    narrative proof classification into semantic output without exposing raw
+    command/session/payload details or claiming runtime/live proof.
 
 ## 6. Native Policy Layering
 
@@ -191,6 +202,9 @@ adding more read-only facade shells.
   - [x] 6.2.5 Reuse shared native approval middleware for
     `city.population.place.request` while keeping validator-first and
     postcondition/proof middleware pending.
+  - [x] 6.2.6 Reuse shared native approval middleware for
+    `decisions.narrative.choice.request` while keeping validator-first and
+    postcondition/proof middleware pending.
 - [ ] 6.3 Add validator-first and postcondition/proof middleware before
   mutation sends.
   - [x] 6.3.1 Compose `city.production.choice.request` through the
@@ -209,6 +223,10 @@ adding more read-only facade shells.
     direct-control validator-first player-operation/city-command runtime ports
     and project source-owned population-placement proof/no-repeat semantics
     into normal output; keep shared validator/postcondition middleware pending.
+  - [x] 6.3.5 Compose `decisions.narrative.choice.request` through the
+    direct-control narrative request runtime port and project source-owned
+    narrative proof/no-repeat semantics into normal output; keep shared
+    validator/postcondition middleware pending.
 - [ ] 6.4 Add safe error projection and correlation through oRPC/effect-orpc
   context/error primitives, not direct-control-local framework wiring.
   - [x] 6.4.1 Use native effect-orpc tagged error constructors for
@@ -232,6 +250,10 @@ adding more read-only facade shells.
   - [x] 6.4.5 Use native effect-orpc tagged error constructors for
     `city.population.place.request` direct-control runtime-port failures while
     shared safe-error middleware remains pending.
+  - [x] 6.4.7 Use native effect-orpc tagged error constructors for
+    `decisions.narrative.choice.request` direct-control runtime-port failures
+    while keeping raw direct-control cause, command, session, and payload
+    details out of public error data.
 
 ## 7. Edge Adapters
 
@@ -261,3 +283,6 @@ adding more read-only facade shells.
   added.
 - [x] 8.4 Run CLI play tests/check when a CLI caller is routed through
   procedures.
+- [x] 8.5 Run direct-control narrative proof, control-oRPC narrative decision,
+  package check/build, OpenSpec strict validation, and diff hygiene gates for
+  `decisions.narrative.choice.request` before closing that slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-game-status-edge-adapter-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-game-status-edge-adapter-slice.md
@@ -1,0 +1,89 @@
+# CLI Game Status Edge Adapter Slice
+
+Status: implemented local source slice.
+Date: 2026-06-05.
+
+## Purpose
+
+Route the first existing CLI caller through the native in-process
+`packages/civ7-control-orpc` server-side procedure client after the core router
+shape gained service-owned reads, mutation leaves, approval middleware, safe
+errors, correlation, and readiness guards.
+
+This advances the edge-adapter lane without adding transport. The CLI remains
+the caller/runtime adapter that constructs endpoint context from flags, while
+`readiness.current` remains the service-owned readiness projection.
+
+## Write Set
+
+- `packages/cli/src/commands/game/status.ts`
+- `packages/cli/test/commands/game.control.test.ts`
+- `packages/cli/package.json`
+- `packages/civ7-control-orpc/package.json`
+- `packages/civ7-control-orpc/tsconfig.json`
+- `packages/civ7-control-orpc/tsup.config.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- this workstream note
+
+## Behavior Boundary
+
+`civ7 game status` now:
+
+- constructs `Civ7ControlOrpcContext` with
+  `liveCiv7ControlOrpcDirectControlFacade` and endpoint defaults from CLI
+  flags;
+- calls `createCiv7ControlOrpcServerClient(...).readiness.current({})`
+  in-process;
+- preserves the same underlying direct-control playable-status runtime reads;
+- emits the semantic readiness output owned by `readiness.current`;
+- keeps host, port, state, App UI/Tuner raw names, snapshot globals, and raw
+  runtime errors out of normal JSON status output.
+
+`@civ7/control-orpc` also bundles `effect-orpc` into its built output. The
+published `effect-orpc` package exports runtime entrypoints to TypeScript source
+files, which is valid for the package's own Bun/Vitest source workflow but
+breaks oclif manifest generation when the CommonJS CLI loads built command
+modules. Bundling it at the service package boundary keeps downstream CLI
+callers on the public `@civ7/control-orpc` entrypoint without importing private
+dist paths or adding a custom client wrapper.
+
+## Non-Goals
+
+- no direct-control procedure-core, facade-only read wrapper, or custom oRPC
+  client wrapper;
+- no Studio `RPCHandler`/`RPCLink`, global bridge, in-game controller ingress,
+  OpenAPI, or external transport;
+- no mutation CLI routing, runtime/live-game proof claim, or play-thread action;
+- no Task 5.x/6.x parent acceptance or broader CLI migration by implication.
+
+## Proof
+
+Focused CLI proof covers:
+
+- `game status --json` still drives the same local fake Tuner socket reads
+  needed by the playable-status runtime port;
+- the emitted status shape is the bounded `readiness.current` semantic
+  projection;
+- raw endpoint/state/snapshot fields are absent from normal status JSON.
+
+Closure gates run:
+
+- `bun run --cwd packages/cli test game.control.test.ts`
+- `bun run test:cli`
+- `bun run test:cli:play`
+- `bun run check:cli`
+- `bun run build:cli`
+- `bun run --cwd packages/civ7-control-orpc test readiness-current-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/package proof only. It proves in-process caller composition
+and public projection for one status command, not live Civ7 runtime readiness,
+Studio/browser transport, in-game bridge ingress, OpenAPI, or mutation caller
+migration.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/closeout-projection-policy-native-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/closeout-projection-policy-native-slice.md
@@ -1,0 +1,75 @@
+# Closeout Projection Policy Native Slice
+
+Status: implemented local package slice.
+Date: 2026-06-05.
+
+## Purpose
+
+Promote the repeated closeout-style postcondition projection in
+`packages/civ7-control-orpc` into one shared service policy helper without
+creating a custom procedure framework or accepting shared
+validator/postcondition middleware prematurely.
+
+The repeated behavior is narrow: after a notification dismissal, narrative
+choice, or diplomacy response runtime port returns source-owned direct-control
+postcondition evidence, control-oRPC derives the caller-facing confirmation
+boolean and no-repeat guard fields for semantic procedure output.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/policy/mutation-result.ts`
+- `packages/civ7-control-orpc/src/modules/notifications/procedures/dismiss-request.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/procedures/narrative-choice-request.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/procedures/diplomacy-response-request.ts`
+- `packages/civ7-control-orpc/test/mutation-result-policy.test.ts`
+- this OpenSpec record, `tasks.md`, and `specs/civ7-control-orpc/spec.md`
+
+## Behavior Boundary
+
+The shared helper:
+
+- consumes already-classified direct-control proof postconditions;
+- treats missing postconditions as unverified and no-repeat guarded;
+- preserves `pending-runtime-proof` as unconfirmed and no-repeat guarded;
+- marks a summary confirmed only when confidence is `confirmed` and
+  `noRepeatAfterUnverified` is false;
+- keeps request status and next-step derivation in the existing mutation-result
+  policy owner.
+
+Direct-control remains the source authority for notification, narrative, and
+diplomacy classifications, proof outcomes, and proof-boundary confidence. The
+procedures still own semantic service output and still exclude raw
+command/session/payload/UI-closeout/legacy `verified` fields from normal I/O.
+
+## Non-Goals
+
+- no shared validator-first middleware or postcondition/proof middleware
+  acceptance;
+- no direct-control procedure-core scaffold, operation catalog, or raw operation
+  result public type;
+- no new procedure leaf, transport, CLI, Studio, bridge, or runtime/live proof;
+- no inference from legacy `verified`;
+- no Task 5.x or 6.x parent acceptance beyond the recorded subitem.
+
+## Proof Collected
+
+Planned closure gates:
+
+- `bun run --cwd packages/civ7-control-orpc test test/mutation-result-policy.test.ts test/notification-dismissal-procedure.test.ts test/decisions-narrative-choice-procedure.test.ts test/decisions-diplomacy-response-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+These are local package/OpenSpec proofs only. Runtime proof and live mutation
+closure remain out of scope.
+
+## Residual Risk
+
+The shared projection helper is not yet a native oRPC middleware because the
+current mutation outputs remain domain-shaped. A future middleware slice should
+move only an accepted common proof envelope after the service output boundary is
+stable enough to avoid generic raw operation envelopes or duplicated procedure
+wiring.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/diplomacy-response-decision-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/diplomacy-response-decision-slice.md
@@ -1,0 +1,108 @@
+# Diplomacy Response Decision Procedure Slice
+
+Status: implemented local source slice.
+Date: 2026-06-05.
+
+## Purpose
+
+Seed `decisions.diplomacy.response.request` as a native service-owned decision
+procedure over the existing direct-control diplomacy response runtime/proof
+authority.
+
+This advances the write-capable native procedure lane without adding a broad
+decisions catalog, direct-control procedure core, transport edge, caller-local
+command wiring, or live-game/runtime proof claim.
+
+## Write Set
+
+- `packages/civ7-direct-control/src/index.ts`
+- `packages/civ7-control-orpc/src/dependencies/direct-control.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/contract.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/procedures/diplomacy-response-request.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/router.ts`
+- `packages/civ7-control-orpc/src/errors.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/test/decisions-diplomacy-response-procedure.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/semantic-capability-hierarchy.md`
+- this workstream note
+
+## Behavior Boundary
+
+`decisions.diplomacy.response.request`:
+
+- uses the native decisions router shape
+  `Civ7ControlOrpcRouter.decisions.diplomacy.response.request`;
+- reuses shared native mutation approval and playable-readiness middleware
+  before direct-control runtime authority is invoked;
+- accepts semantic caller input: `playerId`, `actionId`, `responseType`, and
+  optional `notificationId`;
+- does not expose direct-control-only `activateNotification` or `uiCloseout`
+  toggles as normal procedure input;
+- calls the direct-control diplomacy response runtime port with endpoint
+  defaults and approval supplied through oRPC context;
+- consumes source-owned direct-control diplomacy proof helpers for
+  postcondition and no-repeat classification;
+- projects normal output as semantic response status, validation summary,
+  postcondition summary, and next steps;
+- excludes endpoint host/port, state/session controls, raw command strings,
+  raw payloads, notification internals, UI closeout internals, and legacy
+  `verified` details from procedure input and normal output.
+
+Unverified, missing-postcondition, no-state-change, validation-changed,
+validation-blocked, and not-sent paths remain no-repeat guarded. Confirmed
+source-owned diplomacy postconditions may summarize as sent-confirmed.
+
+## Non-Goals
+
+- no broad decisions catalog, operation router, direct-control procedure core,
+  custom middleware/context/correlation/error wiring, or raw command tunnel;
+- no normal input for direct-control UI toggles such as `activateNotification`
+  or `uiCloseout`;
+- no culture/technology closeout procedure; those still need source-owned
+  postcondition/proof policy before native decision exposure;
+- no CLI, Studio, RPCLink, OpenAPI, in-game bridge, transport, or
+  `Civ7IntelligenceBridge` implementation;
+- no telemetry persistence, AI ingestion surface, normal debug projection, or
+  broad validator/postcondition middleware promotion;
+- no runtime/live-game proof claim, play-thread action, or Task 5.x/6.x parent
+  acceptance by implication.
+
+## Proof
+
+Focused package proof covers:
+
+- approval is required before readiness and diplomacy response execution;
+- playable readiness middleware runs before direct-control request authority;
+- confirmed source-owned diplomacy postconditions project as sent-confirmed;
+- validator-blocked and no-state-change paths remain guarded and do not infer
+  repeat safety from legacy `verified`;
+- endpoint/session/state/raw command fields and direct-control UI toggles are
+  rejected as procedure input;
+- raw command, payload, host, port, state, UI closeout, and `verified` details
+  are absent from normal output;
+- direct-control failures map through native effect-oRPC tagged errors without
+  raw command details;
+- the in-process server-side router client can call the same procedure.
+
+Closure gates:
+
+- `bun run --cwd packages/civ7-direct-control test test/diplomacy-response-proof-policy.test.ts`
+- `bun run --cwd packages/civ7-direct-control build`
+- `bun run --cwd packages/civ7-control-orpc test test/decisions-diplomacy-response-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+## Residual Risk
+
+This is local package proof only. It proves native service composition,
+middleware ordering, semantic projection, tagged error shape, and local
+no-repeat preservation. It does not prove live Civ7 diplomacy panel behavior,
+runtime Tuner responsiveness, bridge/transport behavior, full decisions-family
+coverage, shared validator/postcondition middleware, or parent Task 5.x/6.x
+completion.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/narrative-choice-decision-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/narrative-choice-decision-slice.md
@@ -1,0 +1,103 @@
+# Narrative Choice Decision Procedure Slice
+
+Status: implemented local source slice.
+Date: 2026-06-05.
+
+## Purpose
+
+Seed `decisions.narrative.choice.request` as a native service-owned decision
+procedure over the existing direct-control narrative choice runtime/proof
+authority.
+
+This advances the write-capable native procedure lane without adding a broad
+decisions catalog, direct-control procedure core, transport edge, caller-local
+command wiring, or live-game/runtime proof claim.
+
+## Write Set
+
+- `packages/civ7-direct-control/src/index.ts`
+- `packages/civ7-control-orpc/src/dependencies/direct-control.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/contract.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/procedures/narrative-choice-request.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/router.ts`
+- `packages/civ7-control-orpc/src/contract.ts`
+- `packages/civ7-control-orpc/src/router.ts`
+- `packages/civ7-control-orpc/src/errors.ts`
+- `packages/civ7-control-orpc/src/metadata.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/test/decisions-narrative-choice-procedure.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/semantic-capability-hierarchy.md`
+- this workstream note
+
+## Behavior Boundary
+
+`decisions.narrative.choice.request`:
+
+- uses the native decisions router shape
+  `Civ7ControlOrpcRouter.decisions.narrative.choice.request`;
+- reuses shared native mutation approval and playable-readiness middleware
+  before direct-control runtime authority is invoked;
+- calls the direct-control narrative choice runtime port with endpoint
+  defaults and approval supplied through oRPC context;
+- consumes source-owned direct-control narrative proof helpers for
+  postcondition and no-repeat classification;
+- projects normal output as semantic choice status, validation summary,
+  postcondition summary, and next steps;
+- excludes endpoint host/port, state/session controls, raw command strings,
+  raw payloads, and legacy `verified` details from procedure input and normal
+  output.
+
+Unverified, stale, missing-postcondition, no-state-change, validation-blocked,
+and not-sent paths remain no-repeat guarded. Confirmed source-owned narrative
+postconditions may summarize as sent-confirmed.
+
+## Non-Goals
+
+- no broad decisions catalog, operation router, direct-control procedure core,
+  custom middleware/context/correlation/error wiring, or raw command tunnel;
+- no CLI, Studio, RPCLink, OpenAPI, in-game bridge, transport, or
+  `Civ7IntelligenceBridge` implementation;
+- no telemetry persistence, AI ingestion surface, normal debug projection, or
+  broad validator/postcondition middleware promotion;
+- no runtime/live-game proof claim, play-thread action, or Task 5.x/6.x parent
+  acceptance by implication.
+
+## Proof
+
+Focused package proof covers:
+
+- approval is required before readiness and narrative request execution;
+- playable readiness middleware runs before direct-control request authority;
+- confirmed source-owned narrative postconditions project as sent-confirmed;
+- validator-blocked and no-state-change paths remain guarded and do not infer
+  repeat safety from legacy `verified`;
+- endpoint/session/state/raw command fields are rejected as procedure input;
+- raw command, payload, host, port, state, and `verified` details are absent
+  from normal output;
+- direct-control failures map through native effect-oRPC tagged errors without
+  raw command details;
+- the in-process server-side router client can call the same procedure.
+
+Closure gates:
+
+- `bun run --cwd packages/civ7-direct-control test test/narrative-choice-proof-policy.test.ts`
+- `bun run --cwd packages/civ7-direct-control check`
+- `bun run --cwd packages/civ7-direct-control build`
+- `bun run --cwd packages/civ7-control-orpc test test/decisions-narrative-choice-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+## Residual Risk
+
+This is local package proof only. It proves native service composition,
+middleware ordering, semantic projection, tagged error shape, and local
+no-repeat preservation. It does not prove live Civ7 narrative panel behavior,
+runtime Tuner responsiveness, bridge/transport behavior, full decisions-family
+coverage, shared validator/postcondition middleware, or parent Task 5.x/6.x
+completion.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/semantic-capability-hierarchy.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/semantic-capability-hierarchy.md
@@ -183,6 +183,7 @@ Service ownership:
 | `unit.target.action.request` | `unit` |
 | `city.production.choice.request` | `decisions` |
 | `decisions.narrative.choice.request` | `decisions` |
+| `decisions.diplomacy.response.request` | `decisions` |
 | `map.summary.read`, `map.grid.read`, `map.plot.snapshot`, `map.visibility.read` | `map.summary.read` wrapper burned down; future `world` service must not treat direct-control summary envelopes as bare runtime ports |
 | `strategy.*` planning reads | `strategy` |
 | narrative, diplomacy, culture, technology, population closeouts | `decisions` |

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/semantic-capability-hierarchy.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/semantic-capability-hierarchy.md
@@ -182,6 +182,7 @@ Service ownership:
 | `unit.move.preview` | `world` read plus future unit validation evidence |
 | `unit.target.action.request` | `unit` |
 | `city.production.choice.request` | `decisions` |
+| `decisions.narrative.choice.request` | `decisions` |
 | `map.summary.read`, `map.grid.read`, `map.plot.snapshot`, `map.visibility.read` | `map.summary.read` wrapper burned down; future `world` service must not treat direct-control summary envelopes as bare runtime ports |
 | `strategy.*` planning reads | `strategy` |
 | narrative, diplomacy, culture, technology, population closeouts | `decisions` |

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/strategy-front-summary-service-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/strategy-front-summary-service-slice.md
@@ -1,0 +1,94 @@
+# Strategy Front Summary Service Slice
+
+Status: implemented local source slice.
+Date: 2026-06-05.
+
+## Purpose
+
+Seed the first native `strategy` service procedure after the workstream
+rebaseline stopped adding same-shaped read wrappers. `strategy.frontSummary`
+is a planning view for support/player agents that composes target-candidate
+and battlefield-scan evidence into one neutral front summary.
+
+The slice advances semantic capability hierarchy and service-owned behavior
+without adding a strategy catalog, transport edge, direct-control procedure
+core, action authority, or in-game/runtime proof.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/dependencies/direct-control.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/contract.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/procedures/front-summary.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/router.ts`
+- `packages/civ7-control-orpc/src/contract.ts`
+- `packages/civ7-control-orpc/src/router.ts`
+- `packages/civ7-control-orpc/src/errors.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/test/strategy-front-summary-procedure.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- this workstream note
+
+## Behavior Boundary
+
+`strategy.frontSummary`:
+
+- calls `getCiv7TargetCandidates` and `getCiv7BattlefieldScan` as
+  direct-control runtime/read ports through oRPC context;
+- owns the normal service projection in `packages/civ7-control-orpc`;
+- emits source status, target-candidate summaries, points of interest,
+  observed owner summaries, policy notes, and next steps for inspection,
+  visibility reads, and validator-backed action checks;
+- excludes direct-control `host`, `port`, `state`, raw session, raw command,
+  and transport/debug details from normal output;
+- preserves `relationship-unproven` for other owners unless official
+  relationship, team, war, or suzerain evidence proves stronger labels.
+
+The procedure is read-only planning evidence. It does not move units, attack,
+declare war, approve a send, validate a target action, or close a blocker.
+
+## Non-Goals
+
+- no same-shaped `strategy.target.candidates` or `strategy.battlefield.scan`
+  read wrapper;
+- no broad strategy/tactical catalog, world summary revival, or public
+  direct-control summary surface;
+- no mutation behavior, approval policy change, validator/postcondition
+  middleware, telemetry persistence, or raw proof/debug projection;
+- no CLI, Studio, RPCLink, OpenAPI, in-game bridge, transport, or
+  `Civ7IntelligenceBridge` implementation;
+- no runtime/live-game proof claim, play-thread action, or Task 5.x/6.x parent
+  acceptance by implication.
+
+## Proof
+
+Focused package proof covers:
+
+- in-process router calls compose both direct-control runtime/read ports with
+  endpoint defaults supplied through context;
+- normal output omits host, port, state, raw command, and command-source
+  details;
+- other-owner target candidates and observed owners stay
+  `relationship-unproven`;
+- endpoint/session/state/raw command fields are rejected as procedure input;
+- facade failures map through native effect-oRPC tagged errors without raw
+  command details;
+- the contract metadata publishes `family: "strategy"` and
+  `procedureKey: "strategy.frontSummary"`.
+
+Closure gates:
+
+- `bun run --cwd packages/civ7-control-orpc test test/strategy-front-summary-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+## Residual Risk
+
+This is local package proof only. It proves native service composition and
+projection shape, not live Civ7 target-candidate or battlefield evidence, not
+runtime relationship authority, not a complete strategy family, not in-game
+controller bridge viability, and not parent Task 5.x/6.x completion.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/studio-rpc-link-edge-adapter-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/studio-rpc-link-edge-adapter-slice.md
@@ -1,0 +1,102 @@
+# Studio RPCLink Edge Adapter Slice
+
+Status: implemented local source slice.
+Date: 2026-06-05.
+
+## Purpose
+
+Add the first Studio browser/server edge over the shared
+`packages/civ7-control-orpc` router using native oRPC HTTP primitives after the
+router has service-owned readiness, attention, mutation, approval, readiness,
+safe-error, and correlation policy proof.
+
+This advances the edge-adapter lane without adding OpenAPI, external REST,
+Studio-specific service logic, or caller-local direct-control scripts. Studio
+remains the runtime adapter that constructs context; `readiness.current`
+remains the service-owned procedure.
+
+## Write Set
+
+- `apps/mapgen-studio/package.json`
+- `apps/mapgen-studio/src/features/runInGame/civ7ControlOrpcClient.ts`
+- `apps/mapgen-studio/src/server/civ7ControlOrpc.ts`
+- `apps/mapgen-studio/src/shared/civ7ControlOrpc.ts`
+- `apps/mapgen-studio/src/App.tsx`
+- `apps/mapgen-studio/vite.config.ts`
+- `apps/mapgen-studio/test/runInGame/civ7ControlOrpcClient.test.ts`
+- `packages/civ7-direct-control/src/proof/log-markers.ts`
+- `packages/civ7-direct-control/src/index.ts`
+- `bun.lock`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- this workstream note
+
+## Behavior Boundary
+
+Studio now:
+
+- mounts `Civ7ControlOrpcRouter` behind Vite's Node middleware with native
+  `@orpc/server/node` `RPCHandler`;
+- constructs `Civ7ControlOrpcContext` at the Studio edge with the live
+  direct-control facade and timeout defaults;
+- exposes a browser `RPCLink` client pointed at the Studio Civ7 RPC prefix;
+- routes the live footer readiness member through
+  `client.readiness.current({})`;
+- preserves the existing `/api/civ7/live/status` REST aggregate for map
+  summary and autoplay fields in this slice.
+
+The normal browser readiness value is the semantic `readiness.current`
+projection. Endpoint host/port, Tuner/App UI state names, raw snapshots,
+session controls, and raw command payloads remain outside procedure input and
+normal browser output. If the RPC readiness call fails, the footer uses the
+existing live-status error path instead of silently falling back to the old
+REST readiness member.
+
+The slice also makes `logTextFromSnapshot` part of the direct-control public
+log-marker surface because the Studio Vite server already depends on that
+fresh-log slicing helper during run-in-game proof collection. This is a package
+surface repair for the existing Studio build path, not a new runtime/log proof
+claim.
+
+## Non-Goals
+
+- no direct-control procedure-core, custom RPC protocol handler, custom
+  `RPCLink`, custom middleware/correlation wrapper, or caller-local control
+  script;
+- no Studio migration for map summary, autoplay, setup/run operations, save
+  operations, or mutation flows;
+- no OpenAPI/external REST, RPCLink outside Studio, global bridge, or in-game
+  controller ingress;
+- no runtime/live-game proof claim, play-thread action, or Task 5.x/6.x parent
+  acceptance by implication.
+
+## Proof
+
+Focused Studio proof covers:
+
+- browser `RPCLink` can call `readiness.current` through the native Node
+  `RPCHandler` using fake direct-control context;
+- the Studio adapter supplies endpoint defaults through context, not procedure
+  input;
+- the semantic readiness result omits host, port, state, App UI/Tuner names,
+  and raw runtime detail;
+- non-RPC paths pass through to later Studio middleware.
+
+Closure gates run:
+
+- `bun run --cwd apps/mapgen-studio test test/runInGame/civ7ControlOrpcClient.test.ts`
+- `bun run --cwd apps/mapgen-studio test`
+- `bun run --cwd apps/mapgen-studio check`
+- `bun run --cwd apps/mapgen-studio build`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+## Residual Risk
+
+This is local Studio/package proof only. It proves native oRPC HTTP edge
+composition and one browser readiness caller, not live Civ7 runtime readiness,
+the full Studio REST surface migration, in-game bridge ingress, OpenAPI,
+external transport, or mutation caller routing.

--- a/openspec/changes/studio-run-in-game-robustness/specs/civ7-direct-control/spec.md
+++ b/openspec/changes/studio-run-in-game-robustness/specs/civ7-direct-control/spec.md
@@ -28,6 +28,15 @@ mutating phase
 - **THEN** the operation becomes `uncertain` or `failed`
 - **AND** no further mutating command is sent without a new explicit request
 
+#### Scenario: Start timeout includes raw tuner command text
+- **WHEN** direct-control reports a Run in Game timeout or socket failure whose
+  internal error message contains a raw Tuner `CMD:` request
+- **THEN** Studio reports bounded public operation status text
+- **AND** status details preserve phase, failure class, direct-control code,
+  completed phases, and materialization evidence needed for recovery
+- **AND** public status and copyable diagnostics omit raw command, payload,
+  state/session, and JavaScript probe text
+
 ## ADDED Requirements
 
 ### Requirement: Studio Run In Game Is Resumable And Phase-Aware

--- a/openspec/changes/studio-run-in-game-robustness/tasks.md
+++ b/openspec/changes/studio-run-in-game-robustness/tasks.md
@@ -36,6 +36,8 @@
     rendering for stale/completed state; browser click proof for the primary
     disposable route.
   - Still bounded: route-level Vite middleware tests for every HTTP branch.
+  - Follow-up hardening: operation-state helper proof now covers raw Tuner
+    command timeout sanitization in public status and copyable diagnostics.
 
 ## 4. Vite/Turbo Robustness
 

--- a/packages/civ7-control-orpc/package.json
+++ b/packages/civ7-control-orpc/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs && tsc -p tsconfig.json --emitDeclarationOnly",
+    "build": "tsup --config tsup.config.ts && rimraf tsconfig.tsbuildinfo && tsc -p tsconfig.json --emitDeclarationOnly --noEmit false",
     "check": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --config vitest.config.ts",
     "clean": "rimraf dist"

--- a/packages/civ7-control-orpc/src/contract.ts
+++ b/packages/civ7-control-orpc/src/contract.ts
@@ -8,6 +8,10 @@ import {
   type Civ7CityContract as Civ7CityContractType,
 } from "./modules/city/contract";
 import {
+  Civ7DecisionsContract,
+  type Civ7DecisionsContract as Civ7DecisionsContractType,
+} from "./modules/decisions/contract";
+import {
   Civ7ReadinessContract,
   type Civ7ReadinessContract as Civ7ReadinessContractType,
 } from "./modules/readiness/contract";
@@ -27,6 +31,7 @@ import {
 export type Civ7ControlOrpcContract = Readonly<{
   attention: Civ7AttentionContractType;
   city: Civ7CityContractType;
+  decisions: Civ7DecisionsContractType;
   notifications: Civ7NotificationsContractType;
   readiness: Civ7ReadinessContractType;
   strategy: Civ7StrategyContractType;
@@ -37,6 +42,7 @@ export const Civ7ControlOrpcContract: Civ7ControlOrpcContract =
   civ7ControlOrpcContractBase.router({
     attention: Civ7AttentionContract,
     city: Civ7CityContract,
+    decisions: Civ7DecisionsContract,
     notifications: Civ7NotificationsContract,
     readiness: Civ7ReadinessContract,
     strategy: Civ7StrategyContract,

--- a/packages/civ7-control-orpc/src/contract.ts
+++ b/packages/civ7-control-orpc/src/contract.ts
@@ -16,6 +16,10 @@ import {
   type Civ7NotificationsContract as Civ7NotificationsContractType,
 } from "./modules/notifications/contract";
 import {
+  Civ7StrategyContract,
+  type Civ7StrategyContract as Civ7StrategyContractType,
+} from "./modules/strategy/contract";
+import {
   Civ7UnitContract,
   type Civ7UnitContract as Civ7UnitContractType,
 } from "./modules/unit/contract";
@@ -25,6 +29,7 @@ export type Civ7ControlOrpcContract = Readonly<{
   city: Civ7CityContractType;
   notifications: Civ7NotificationsContractType;
   readiness: Civ7ReadinessContractType;
+  strategy: Civ7StrategyContractType;
   unit: Civ7UnitContractType;
 }>;
 
@@ -34,5 +39,6 @@ export const Civ7ControlOrpcContract: Civ7ControlOrpcContract =
     city: Civ7CityContract,
     notifications: Civ7NotificationsContract,
     readiness: Civ7ReadinessContract,
+    strategy: Civ7StrategyContract,
     unit: Civ7UnitContract,
   });

--- a/packages/civ7-control-orpc/src/dependencies/direct-control.ts
+++ b/packages/civ7-control-orpc/src/dependencies/direct-control.ts
@@ -1,8 +1,10 @@
 import {
   getCiv7PlayableStatus,
   getCiv7PlayNotificationView,
+  getCiv7BattlefieldScan,
   getCiv7ReadyCityView,
   getCiv7ReadyUnitView,
+  getCiv7TargetCandidates,
   getCiv7TurnCompletionStatus,
   requestCiv7NotificationDismissal,
   requestCiv7CityCommand,
@@ -12,13 +14,16 @@ import {
   type Civ7ActionApproval,
   type Civ7ComponentId,
   type Civ7DirectControlOptions,
+  Civ7BattlefieldScanResultSchema,
   Civ7PlayNotificationViewResultSchema,
   Civ7PlayableStatusResultSchema,
   Civ7ProductionChoiceResultSchema,
   Civ7ReadyCityViewResultSchema,
   Civ7ReadyUnitViewResultSchema,
+  Civ7TargetCandidatesResultSchema,
   Civ7TurnCompletionStatusResultSchema,
   Civ7UnitTargetActionResultSchema,
+  type Civ7BattlefieldScanInput,
   type Civ7NotificationDismissInput,
   type Civ7NotificationDismissalResult,
   type Civ7OperationInput,
@@ -26,6 +31,7 @@ import {
   type Civ7ProductionChoiceInput,
   type Civ7ReadyCityViewInput,
   type Civ7ReadyUnitViewInput,
+  type Civ7TargetCandidatesInput,
   type Civ7UnitTargetActionInput,
   type PlayNotificationViewOptions,
 } from "@civ7/direct-control";
@@ -47,11 +53,17 @@ export type Civ7ControlOrpcProductionChoiceResult = Static<
 export type Civ7ControlOrpcPlayNotificationViewResult = Static<
   typeof Civ7PlayNotificationViewResultSchema
 >;
+export type Civ7ControlOrpcBattlefieldScanResult = Static<
+  typeof Civ7BattlefieldScanResultSchema
+>;
 export type Civ7ControlOrpcReadyUnitViewResult = Static<
   typeof Civ7ReadyUnitViewResultSchema
 >;
 export type Civ7ControlOrpcReadyCityViewResult = Static<
   typeof Civ7ReadyCityViewResultSchema
+>;
+export type Civ7ControlOrpcTargetCandidatesResult = Static<
+  typeof Civ7TargetCandidatesResultSchema
 >;
 export type Civ7ControlOrpcTurnCompletionStatusResult = Static<
   typeof Civ7TurnCompletionStatusResultSchema
@@ -92,6 +104,10 @@ export type Civ7ControlOrpcDirectControlFacade = Readonly<{
   getCiv7PlayNotificationView(
     options?: PlayNotificationViewOptions,
   ): Promise<Civ7ControlOrpcPlayNotificationViewResult>;
+  getCiv7BattlefieldScan(
+    input?: Civ7BattlefieldScanInput,
+    options?: Civ7DirectControlOptions,
+  ): Promise<Civ7ControlOrpcBattlefieldScanResult>;
   getCiv7ReadyUnitView(
     input?: Civ7ReadyUnitViewInput,
     options?: Civ7DirectControlOptions,
@@ -100,6 +116,10 @@ export type Civ7ControlOrpcDirectControlFacade = Readonly<{
     input?: Civ7ReadyCityViewInput,
     options?: Civ7DirectControlOptions,
   ): Promise<Civ7ControlOrpcReadyCityViewResult>;
+  getCiv7TargetCandidates(
+    input?: Civ7TargetCandidatesInput,
+    options?: Civ7DirectControlOptions,
+  ): Promise<Civ7ControlOrpcTargetCandidatesResult>;
   getCiv7TurnCompletionStatus(
     options?: Civ7DirectControlOptions,
   ): Promise<Civ7ControlOrpcTurnCompletionStatusResult>;
@@ -135,6 +155,10 @@ export const liveCiv7ControlOrpcDirectControlFacade:
     getCiv7PlayNotificationView(options) as Promise<
       Civ7ControlOrpcPlayNotificationViewResult
     >,
+  getCiv7BattlefieldScan: async (input, options) =>
+    getCiv7BattlefieldScan(input, options) as Promise<
+      Civ7ControlOrpcBattlefieldScanResult
+    >,
   getCiv7ReadyUnitView: async (input, options) =>
     getCiv7ReadyUnitView(input, options) as Promise<
       Civ7ControlOrpcReadyUnitViewResult
@@ -142,6 +166,10 @@ export const liveCiv7ControlOrpcDirectControlFacade:
   getCiv7ReadyCityView: async (input, options) =>
     getCiv7ReadyCityView(input, options) as Promise<
       Civ7ControlOrpcReadyCityViewResult
+    >,
+  getCiv7TargetCandidates: async (input, options) =>
+    getCiv7TargetCandidates(input, options) as Promise<
+      Civ7ControlOrpcTargetCandidatesResult
     >,
   getCiv7TurnCompletionStatus: async (options) =>
     getCiv7TurnCompletionStatus(options) as Promise<

--- a/packages/civ7-control-orpc/src/dependencies/direct-control.ts
+++ b/packages/civ7-control-orpc/src/dependencies/direct-control.ts
@@ -6,6 +6,7 @@ import {
   getCiv7ReadyUnitView,
   getCiv7TargetCandidates,
   getCiv7TurnCompletionStatus,
+  requestCiv7DiplomacyResponse,
   requestCiv7NarrativeChoice,
   requestCiv7NotificationDismissal,
   requestCiv7CityCommand,
@@ -16,6 +17,8 @@ import {
   type Civ7ComponentId,
   type Civ7DirectControlOptions,
   Civ7BattlefieldScanResultSchema,
+  type Civ7DiplomacyResponseInput,
+  type Civ7DiplomacyResponseResult,
   type Civ7NarrativeChoiceInput,
   type Civ7NarrativeChoiceResult,
   Civ7PlayNotificationViewResultSchema,
@@ -42,6 +45,8 @@ import type { Static } from "typebox";
 
 export type Civ7ControlOrpcNotificationDismissalResult =
   Civ7NotificationDismissalResult;
+export type Civ7ControlOrpcDiplomacyResponseResult =
+  Civ7DiplomacyResponseResult;
 export type Civ7ControlOrpcNarrativeChoiceResult = Civ7NarrativeChoiceResult;
 type Civ7ControlOrpcPopulationPlacementRuntimeResult =
   Civ7PopulationPlacementProofSource & Readonly<{
@@ -92,6 +97,11 @@ export type Civ7ControlOrpcDirectControlFacade = Readonly<{
     options: Civ7DirectControlOptions | undefined,
     approval: Civ7ActionApproval,
   ): Promise<Civ7ControlOrpcNarrativeChoiceResult>;
+  requestCiv7DiplomacyResponse(
+    input: Civ7DiplomacyResponseInput,
+    options: Civ7DirectControlOptions | undefined,
+    approval: Civ7ActionApproval,
+  ): Promise<Civ7ControlOrpcDiplomacyResponseResult>;
   requestCiv7CityCommand(
     input: Civ7OperationInput & Readonly<{ cityId: Civ7ComponentId }>,
     options: Civ7DirectControlOptions | undefined,
@@ -146,6 +156,8 @@ export const liveCiv7ControlOrpcDirectControlFacade:
     >,
   requestCiv7NarrativeChoice: async (input, options, approval) =>
     requestCiv7NarrativeChoice(input, options, approval),
+  requestCiv7DiplomacyResponse: async (input, options, approval) =>
+    requestCiv7DiplomacyResponse(input, options, approval),
   requestCiv7CityCommand: async (input, options, approval) =>
     requestCiv7CityCommand(input, options, approval) as Promise<
       Civ7ControlOrpcPopulationPlacementRuntimeResult

--- a/packages/civ7-control-orpc/src/dependencies/direct-control.ts
+++ b/packages/civ7-control-orpc/src/dependencies/direct-control.ts
@@ -6,6 +6,7 @@ import {
   getCiv7ReadyUnitView,
   getCiv7TargetCandidates,
   getCiv7TurnCompletionStatus,
+  requestCiv7NarrativeChoice,
   requestCiv7NotificationDismissal,
   requestCiv7CityCommand,
   requestCiv7PlayerOperation,
@@ -15,6 +16,8 @@ import {
   type Civ7ComponentId,
   type Civ7DirectControlOptions,
   Civ7BattlefieldScanResultSchema,
+  type Civ7NarrativeChoiceInput,
+  type Civ7NarrativeChoiceResult,
   Civ7PlayNotificationViewResultSchema,
   Civ7PlayableStatusResultSchema,
   Civ7ProductionChoiceResultSchema,
@@ -39,6 +42,7 @@ import type { Static } from "typebox";
 
 export type Civ7ControlOrpcNotificationDismissalResult =
   Civ7NotificationDismissalResult;
+export type Civ7ControlOrpcNarrativeChoiceResult = Civ7NarrativeChoiceResult;
 type Civ7ControlOrpcPopulationPlacementRuntimeResult =
   Civ7PopulationPlacementProofSource & Readonly<{
     before: Readonly<{ valid: boolean }>;
@@ -83,6 +87,11 @@ export type Civ7ControlOrpcDirectControlFacade = Readonly<{
     options: Civ7DirectControlOptions | undefined,
     approval: Civ7ActionApproval,
   ): Promise<Civ7ControlOrpcNotificationDismissalResult>;
+  requestCiv7NarrativeChoice(
+    input: Civ7NarrativeChoiceInput,
+    options: Civ7DirectControlOptions | undefined,
+    approval: Civ7ActionApproval,
+  ): Promise<Civ7ControlOrpcNarrativeChoiceResult>;
   requestCiv7CityCommand(
     input: Civ7OperationInput & Readonly<{ cityId: Civ7ComponentId }>,
     options: Civ7DirectControlOptions | undefined,
@@ -135,6 +144,8 @@ export const liveCiv7ControlOrpcDirectControlFacade:
     requestCiv7NotificationDismissal(input, options, approval) as Promise<
       Civ7ControlOrpcNotificationDismissalResult
     >,
+  requestCiv7NarrativeChoice: async (input, options, approval) =>
+    requestCiv7NarrativeChoice(input, options, approval),
   requestCiv7CityCommand: async (input, options, approval) =>
     requestCiv7CityCommand(input, options, approval) as Promise<
       Civ7ControlOrpcPopulationPlacementRuntimeResult

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -144,6 +144,28 @@ export class Civ7NarrativeChoiceUnavailableError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7DiplomacyResponseUnavailableErrorDataSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("decisions.diplomacy.response.request"),
+    source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties,
+  },
+  { additionalProperties: false },
+);
+export type Civ7DiplomacyResponseUnavailableErrorData = Static<
+  typeof Civ7DiplomacyResponseUnavailableErrorDataSchema
+>;
+
+export class Civ7DiplomacyResponseUnavailableError extends ORPCTaggedError(
+  "Civ7DiplomacyResponseUnavailableError",
+  {
+    code: "DIPLOMACY_RESPONSE_UNAVAILABLE",
+    message: "Direct-control diplomacy response request failed.",
+    schema: toStandardSchema(Civ7DiplomacyResponseUnavailableErrorDataSchema),
+    status: 503,
+  },
+) {}
+
 export const Civ7MutationApprovalRequiredErrorDataSchema = Type.Object(
   {
     procedureKey: Type.String(),
@@ -283,6 +305,7 @@ export class Civ7CorrelationIdInvalidError extends ORPCTaggedError(
 export const civ7ControlOrpcErrorMap = {
   ATTENTION_CURRENT_UNAVAILABLE: Civ7AttentionCurrentUnavailableError,
   CORRELATION_ID_INVALID: Civ7CorrelationIdInvalidError,
+  DIPLOMACY_RESPONSE_UNAVAILABLE: Civ7DiplomacyResponseUnavailableError,
   MUTATION_APPROVAL_REQUIRED: Civ7MutationApprovalRequiredError,
   MUTATION_READINESS_REQUIRED: Civ7MutationReadinessRequiredError,
   MUTATION_READINESS_UNAVAILABLE: Civ7MutationReadinessUnavailableError,

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -56,6 +56,28 @@ export class Civ7AttentionCurrentUnavailableError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7StrategyFrontSummaryUnavailableErrorDataSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("strategy.frontSummary"),
+    source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties,
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyFrontSummaryUnavailableErrorData = Static<
+  typeof Civ7StrategyFrontSummaryUnavailableErrorDataSchema
+>;
+
+export class Civ7StrategyFrontSummaryUnavailableError extends ORPCTaggedError(
+  "Civ7StrategyFrontSummaryUnavailableError",
+  {
+    code: "STRATEGY_FRONT_SUMMARY_UNAVAILABLE",
+    message: "Strategy front summary failed.",
+    schema: toStandardSchema(Civ7StrategyFrontSummaryUnavailableErrorDataSchema),
+    status: 503,
+  },
+) {}
+
 export const Civ7NotificationDismissalUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("notifications.dismiss.request"),
@@ -246,6 +268,7 @@ export const civ7ControlOrpcErrorMap = {
   POPULATION_PLACEMENT_UNAVAILABLE: Civ7PopulationPlacementUnavailableError,
   PRODUCTION_CHOICE_UNAVAILABLE: Civ7ProductionChoiceUnavailableError,
   READINESS_CURRENT_UNAVAILABLE: Civ7ReadinessCurrentUnavailableError,
+  STRATEGY_FRONT_SUMMARY_UNAVAILABLE: Civ7StrategyFrontSummaryUnavailableError,
   UNIT_TARGET_ACTION_UNAVAILABLE: Civ7UnitTargetActionUnavailableError,
 } satisfies EffectErrorMap;
 

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -122,6 +122,28 @@ export class Civ7UnitTargetActionUnavailableError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7NarrativeChoiceUnavailableErrorDataSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("decisions.narrative.choice.request"),
+    source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties,
+  },
+  { additionalProperties: false },
+);
+export type Civ7NarrativeChoiceUnavailableErrorData = Static<
+  typeof Civ7NarrativeChoiceUnavailableErrorDataSchema
+>;
+
+export class Civ7NarrativeChoiceUnavailableError extends ORPCTaggedError(
+  "Civ7NarrativeChoiceUnavailableError",
+  {
+    code: "NARRATIVE_CHOICE_UNAVAILABLE",
+    message: "Direct-control narrative choice request failed.",
+    schema: toStandardSchema(Civ7NarrativeChoiceUnavailableErrorDataSchema),
+    status: 503,
+  },
+) {}
+
 export const Civ7MutationApprovalRequiredErrorDataSchema = Type.Object(
   {
     procedureKey: Type.String(),
@@ -264,6 +286,7 @@ export const civ7ControlOrpcErrorMap = {
   MUTATION_APPROVAL_REQUIRED: Civ7MutationApprovalRequiredError,
   MUTATION_READINESS_REQUIRED: Civ7MutationReadinessRequiredError,
   MUTATION_READINESS_UNAVAILABLE: Civ7MutationReadinessUnavailableError,
+  NARRATIVE_CHOICE_UNAVAILABLE: Civ7NarrativeChoiceUnavailableError,
   NOTIFICATION_DISMISSAL_UNAVAILABLE: Civ7NotificationDismissalUnavailableError,
   POPULATION_PLACEMENT_UNAVAILABLE: Civ7PopulationPlacementUnavailableError,
   PRODUCTION_CHOICE_UNAVAILABLE: Civ7ProductionChoiceUnavailableError,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -19,6 +19,8 @@ export {
   Civ7AttentionCurrentUnavailableErrorDataSchema,
   Civ7CorrelationIdInvalidError,
   Civ7CorrelationIdInvalidErrorDataSchema,
+  Civ7DiplomacyResponseUnavailableError,
+  Civ7DiplomacyResponseUnavailableErrorDataSchema,
   Civ7MutationApprovalRequiredError,
   Civ7MutationApprovalRequiredErrorDataSchema,
   Civ7MutationReadinessRequiredError,
@@ -44,6 +46,7 @@ export {
   type Civ7ControlOrpcErrorMap,
   type Civ7ControlOrpcEffectErrorMap,
   type Civ7CorrelationIdInvalidErrorData,
+  type Civ7DiplomacyResponseUnavailableErrorData,
   type Civ7MutationApprovalRequiredErrorData,
   type Civ7MutationReadinessRequiredErrorData,
   type Civ7MutationReadinessUnavailableErrorData,
@@ -123,6 +126,17 @@ export { cityPopulationPlaceRequestProcedure } from "./modules/city/procedures/p
 export { cityProductionChoiceRequestProcedure } from "./modules/city/procedures/production-choice-request";
 export {
   Civ7DecisionsContract,
+  Civ7DecisionsDiplomacyResponseContract,
+  Civ7DecisionsDiplomacyResponseInputSchema,
+  Civ7DecisionsDiplomacyResponseInputStandardSchema,
+  Civ7DecisionsDiplomacyResponseNextStepSchema,
+  Civ7DecisionsDiplomacyResponsePostconditionClassificationSchema,
+  Civ7DecisionsDiplomacyResponsePostconditionSummarySchema,
+  Civ7DecisionsDiplomacyResponseProofOutcomeSchema,
+  Civ7DecisionsDiplomacyResponseRequestStatusSchema,
+  Civ7DecisionsDiplomacyResponseResultSchema,
+  Civ7DecisionsDiplomacyResponseResultStandardSchema,
+  Civ7DecisionsDiplomacyResponseValidationSummarySchema,
   Civ7DecisionsNarrativeChoiceContract,
   Civ7DecisionsNarrativeChoiceInputSchema,
   Civ7DecisionsNarrativeChoiceInputStandardSchema,
@@ -137,11 +151,15 @@ export {
 } from "./modules/decisions/contract";
 export type {
   Civ7DecisionsContract as Civ7DecisionsContractType,
+  Civ7DecisionsDiplomacyResponseContract as Civ7DecisionsDiplomacyResponseContractType,
+  Civ7DecisionsDiplomacyResponseInput,
+  Civ7DecisionsDiplomacyResponseResult,
   Civ7DecisionsNarrativeChoiceContract as Civ7DecisionsNarrativeChoiceContractType,
   Civ7DecisionsNarrativeChoiceInput,
   Civ7DecisionsNarrativeChoiceResult,
 } from "./modules/decisions/contract";
 export { decisionsRouter } from "./modules/decisions/router";
+export { decisionsDiplomacyResponseRequestProcedure } from "./modules/decisions/procedures/diplomacy-response-request";
 export { decisionsNarrativeChoiceRequestProcedure } from "./modules/decisions/procedures/narrative-choice-request";
 export {
   Civ7NotificationsContract,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -25,6 +25,8 @@ export {
   Civ7MutationReadinessRequiredErrorDataSchema,
   Civ7MutationReadinessUnavailableError,
   Civ7MutationReadinessUnavailableErrorDataSchema,
+  Civ7NarrativeChoiceUnavailableError,
+  Civ7NarrativeChoiceUnavailableErrorDataSchema,
   Civ7NotificationDismissalUnavailableError,
   Civ7NotificationDismissalUnavailableErrorDataSchema,
   Civ7PopulationPlacementUnavailableError,
@@ -45,6 +47,7 @@ export {
   type Civ7MutationApprovalRequiredErrorData,
   type Civ7MutationReadinessRequiredErrorData,
   type Civ7MutationReadinessUnavailableErrorData,
+  type Civ7NarrativeChoiceUnavailableErrorData,
   type Civ7NotificationDismissalUnavailableErrorData,
   type Civ7PopulationPlacementUnavailableErrorData,
   type Civ7ProductionChoiceUnavailableErrorData,
@@ -118,6 +121,28 @@ export type {
 export { cityRouter } from "./modules/city/router";
 export { cityPopulationPlaceRequestProcedure } from "./modules/city/procedures/population-place-request";
 export { cityProductionChoiceRequestProcedure } from "./modules/city/procedures/production-choice-request";
+export {
+  Civ7DecisionsContract,
+  Civ7DecisionsNarrativeChoiceContract,
+  Civ7DecisionsNarrativeChoiceInputSchema,
+  Civ7DecisionsNarrativeChoiceInputStandardSchema,
+  Civ7DecisionsNarrativeChoiceNextStepSchema,
+  Civ7DecisionsNarrativeChoicePostconditionClassificationSchema,
+  Civ7DecisionsNarrativeChoicePostconditionSummarySchema,
+  Civ7DecisionsNarrativeChoiceProofOutcomeSchema,
+  Civ7DecisionsNarrativeChoiceRequestStatusSchema,
+  Civ7DecisionsNarrativeChoiceResultSchema,
+  Civ7DecisionsNarrativeChoiceResultStandardSchema,
+  Civ7DecisionsNarrativeChoiceValidationSummarySchema,
+} from "./modules/decisions/contract";
+export type {
+  Civ7DecisionsContract as Civ7DecisionsContractType,
+  Civ7DecisionsNarrativeChoiceContract as Civ7DecisionsNarrativeChoiceContractType,
+  Civ7DecisionsNarrativeChoiceInput,
+  Civ7DecisionsNarrativeChoiceResult,
+} from "./modules/decisions/contract";
+export { decisionsRouter } from "./modules/decisions/router";
+export { decisionsNarrativeChoiceRequestProcedure } from "./modules/decisions/procedures/narrative-choice-request";
 export {
   Civ7NotificationsContract,
   Civ7NotificationDismissalContract,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -33,6 +33,8 @@ export {
   Civ7ProductionChoiceUnavailableErrorDataSchema,
   Civ7ReadinessCurrentUnavailableError,
   Civ7ReadinessCurrentUnavailableErrorDataSchema,
+  Civ7StrategyFrontSummaryUnavailableError,
+  Civ7StrategyFrontSummaryUnavailableErrorDataSchema,
   Civ7UnitTargetActionUnavailableError,
   Civ7UnitTargetActionUnavailableErrorDataSchema,
   civ7ControlOrpcErrorMap,
@@ -47,6 +49,7 @@ export {
   type Civ7PopulationPlacementUnavailableErrorData,
   type Civ7ProductionChoiceUnavailableErrorData,
   type Civ7ReadinessCurrentUnavailableErrorData,
+  type Civ7StrategyFrontSummaryUnavailableErrorData,
   type Civ7UnitTargetActionUnavailableErrorData,
 } from "./errors";
 export {
@@ -154,6 +157,29 @@ export type {
 } from "./modules/readiness/contract";
 export { readinessRouter } from "./modules/readiness/router";
 export { readinessCurrentProcedure } from "./modules/readiness/procedures/current";
+export {
+  Civ7StrategyContract,
+  Civ7StrategyFrontSummaryContract,
+  Civ7StrategyFrontSummaryInputSchema,
+  Civ7StrategyFrontSummaryInputStandardSchema,
+  Civ7StrategyFrontSummaryNextStepSchema,
+  Civ7StrategyFrontPointOfInterestSchema,
+  Civ7StrategyFrontSummaryResultSchema,
+  Civ7StrategyFrontSummaryResultStandardSchema,
+  Civ7StrategyFrontSourceStatusSchema,
+  Civ7StrategyFrontTargetCandidateSchema,
+  Civ7StrategyObservedOwnerSchema,
+  Civ7StrategyRelationshipClassificationSchema,
+  Civ7StrategyRelationshipLabelPolicySchema,
+} from "./modules/strategy/contract";
+export type {
+  Civ7StrategyContract as Civ7StrategyContractType,
+  Civ7StrategyFrontSummaryContract as Civ7StrategyFrontSummaryContractType,
+  Civ7StrategyFrontSummaryInput,
+  Civ7StrategyFrontSummaryResult,
+} from "./modules/strategy/contract";
+export { strategyRouter } from "./modules/strategy/router";
+export { strategyFrontSummaryProcedure } from "./modules/strategy/procedures/front-summary";
 export {
   Civ7UnitContract,
   Civ7UnitTargetActionContract,

--- a/packages/civ7-control-orpc/src/metadata.ts
+++ b/packages/civ7-control-orpc/src/metadata.ts
@@ -6,6 +6,7 @@ export type Civ7ControlOrpcProcedureMeta = Readonly<{
     | "notifications"
     | "unit"
     | "city"
+    | "decisions"
     | "map"
     | "player"
     | "strategy";

--- a/packages/civ7-control-orpc/src/modules/decisions/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/contract.ts
@@ -20,12 +20,36 @@ export type Civ7DecisionsNarrativeChoiceInput = Static<
   typeof Civ7DecisionsNarrativeChoiceInputSchema
 >;
 
+export const Civ7DecisionsDiplomacyResponseInputSchema = Type.Object(
+  {
+    playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
+    actionId: Type.Integer(),
+    responseType: Type.Integer(),
+    notificationId: Type.Optional(Civ7ComponentIdSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7DecisionsDiplomacyResponseInput = Static<
+  typeof Civ7DecisionsDiplomacyResponseInputSchema
+>;
+
 export const Civ7DecisionsNarrativeChoicePostconditionClassificationSchema =
   Type.Union([
     Type.Literal("not-sent"),
     Type.Literal("turn-unblocked"),
     Type.Literal("narrative-blocker-cleared"),
     Type.Literal("narrative-panel-cleared"),
+    Type.Literal("validation-changed"),
+    Type.Literal("no-state-change"),
+    Type.Literal("missing-postcondition"),
+  ]);
+
+export const Civ7DecisionsDiplomacyResponsePostconditionClassificationSchema =
+  Type.Union([
+    Type.Literal("not-sent"),
+    Type.Literal("turn-unblocked"),
+    Type.Literal("diplomacy-blocker-cleared"),
+    Type.Literal("blocking-notification-changed"),
     Type.Literal("validation-changed"),
     Type.Literal("no-state-change"),
     Type.Literal("missing-postcondition"),
@@ -40,12 +64,16 @@ export const Civ7DecisionsNarrativeChoiceProofOutcomeSchema = Type.Union([
   Type.Literal("stale"),
   Type.Literal("unknown"),
 ]);
+export const Civ7DecisionsDiplomacyResponseProofOutcomeSchema =
+  Civ7DecisionsNarrativeChoiceProofOutcomeSchema;
 
 export const Civ7DecisionsNarrativeChoiceRequestStatusSchema = Type.Union([
   Type.Literal("not-sent"),
   Type.Literal("sent-confirmed"),
   Type.Literal("sent-unverified"),
 ]);
+export const Civ7DecisionsDiplomacyResponseRequestStatusSchema =
+  Civ7DecisionsNarrativeChoiceRequestStatusSchema;
 
 export const Civ7DecisionsNarrativeChoiceValidationSummarySchema = Type.Object(
   {
@@ -54,6 +82,8 @@ export const Civ7DecisionsNarrativeChoiceValidationSummarySchema = Type.Object(
   },
   { additionalProperties: false },
 );
+export const Civ7DecisionsDiplomacyResponseValidationSummarySchema =
+  Civ7DecisionsNarrativeChoiceValidationSummarySchema;
 
 export const Civ7DecisionsNarrativeChoicePostconditionSummarySchema =
   Type.Object(
@@ -61,6 +91,22 @@ export const Civ7DecisionsNarrativeChoicePostconditionSummarySchema =
       classification: Civ7DecisionsNarrativeChoicePostconditionClassificationSchema,
       reason: Type.String(),
       outcome: Civ7DecisionsNarrativeChoiceProofOutcomeSchema,
+      confidence: Type.Union([
+        Type.Literal("confirmed"),
+        Type.Literal("unverified"),
+        Type.Literal("pending-runtime-proof"),
+      ]),
+      confirmed: Type.Boolean(),
+      noRepeatAfterUnverified: Type.Boolean(),
+    },
+    { additionalProperties: false },
+  );
+export const Civ7DecisionsDiplomacyResponsePostconditionSummarySchema =
+  Type.Object(
+    {
+      classification: Civ7DecisionsDiplomacyResponsePostconditionClassificationSchema,
+      reason: Type.String(),
+      outcome: Civ7DecisionsDiplomacyResponseProofOutcomeSchema,
       confidence: Type.Union([
         Type.Literal("confirmed"),
         Type.Literal("unverified"),
@@ -84,6 +130,18 @@ export const Civ7DecisionsNarrativeChoiceNextStepSchema = Type.Object(
   },
   { additionalProperties: false },
 );
+export const Civ7DecisionsDiplomacyResponseNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("refresh-attention"),
+      Type.Literal("do-not-repeat"),
+      Type.Literal("inspect-diplomacy-response"),
+    ]),
+    source: Type.Literal("decisions.diplomacy.response.request"),
+    label: Type.String(),
+  },
+  { additionalProperties: false },
+);
 
 export const Civ7DecisionsNarrativeChoiceResultSchema = Type.Object(
   {
@@ -103,10 +161,32 @@ export type Civ7DecisionsNarrativeChoiceResult = Static<
   typeof Civ7DecisionsNarrativeChoiceResultSchema
 >;
 
+export const Civ7DecisionsDiplomacyResponseResultSchema = Type.Object(
+  {
+    playerId: Type.Integer({ minimum: 0 }),
+    actionId: Type.Integer(),
+    responseType: Type.Integer(),
+    notificationId: Type.Optional(Civ7ComponentIdSchema),
+    sent: Type.Boolean(),
+    status: Civ7DecisionsDiplomacyResponseRequestStatusSchema,
+    validation: Civ7DecisionsDiplomacyResponseValidationSummarySchema,
+    postcondition: Civ7DecisionsDiplomacyResponsePostconditionSummarySchema,
+    nextSteps: Type.Array(Civ7DecisionsDiplomacyResponseNextStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7DecisionsDiplomacyResponseResult = Static<
+  typeof Civ7DecisionsDiplomacyResponseResultSchema
+>;
+
 export const Civ7DecisionsNarrativeChoiceInputStandardSchema =
   toStandardSchema(Civ7DecisionsNarrativeChoiceInputSchema);
 export const Civ7DecisionsNarrativeChoiceResultStandardSchema =
   toStandardSchema(Civ7DecisionsNarrativeChoiceResultSchema);
+export const Civ7DecisionsDiplomacyResponseInputStandardSchema =
+  toStandardSchema(Civ7DecisionsDiplomacyResponseInputSchema);
+export const Civ7DecisionsDiplomacyResponseResultStandardSchema =
+  toStandardSchema(Civ7DecisionsDiplomacyResponseResultSchema);
 
 export type Civ7DecisionsNarrativeChoiceContract = ContractProcedure<
   typeof Civ7DecisionsNarrativeChoiceInputStandardSchema,
@@ -126,7 +206,30 @@ export const Civ7DecisionsNarrativeChoiceContract:
       risk: "mutation",
     });
 
+export type Civ7DecisionsDiplomacyResponseContract = ContractProcedure<
+  typeof Civ7DecisionsDiplomacyResponseInputStandardSchema,
+  typeof Civ7DecisionsDiplomacyResponseResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export const Civ7DecisionsDiplomacyResponseContract:
+  Civ7DecisionsDiplomacyResponseContract = civ7ControlOrpcContractBase
+    .input(Civ7DecisionsDiplomacyResponseInputStandardSchema)
+    .output(Civ7DecisionsDiplomacyResponseResultStandardSchema)
+    .meta({
+      family: "decisions",
+      procedureKey: "decisions.diplomacy.response.request",
+      proofBoundary: "local-package-test",
+      risk: "mutation",
+    });
+
 export type Civ7DecisionsContract = Readonly<{
+  diplomacy: Readonly<{
+    response: Readonly<{
+      request: Civ7DecisionsDiplomacyResponseContract;
+    }>;
+  }>;
   narrative: Readonly<{
     choice: Readonly<{
       request: Civ7DecisionsNarrativeChoiceContract;
@@ -135,6 +238,11 @@ export type Civ7DecisionsContract = Readonly<{
 }>;
 
 export const Civ7DecisionsContract: Civ7DecisionsContract = {
+  diplomacy: {
+    response: {
+      request: Civ7DecisionsDiplomacyResponseContract,
+    },
+  },
   narrative: {
     choice: {
       request: Civ7DecisionsNarrativeChoiceContract,

--- a/packages/civ7-control-orpc/src/modules/decisions/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/contract.ts
@@ -1,0 +1,143 @@
+import { Civ7ComponentIdSchema } from "@civ7/direct-control";
+import type { ContractProcedure } from "@orpc/contract";
+import { Type, type Static } from "typebox";
+
+import { civ7ControlOrpcContractBase } from "../../contract-base";
+import type { Civ7ControlOrpcErrorMap } from "../../errors";
+import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
+import { toStandardSchema } from "../../typebox-standard-schema";
+
+export const Civ7DecisionsNarrativeChoiceInputSchema = Type.Object(
+  {
+    playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
+    targetType: Type.String({ minLength: 1 }),
+    target: Civ7ComponentIdSchema,
+    action: Type.Integer(),
+  },
+  { additionalProperties: false },
+);
+export type Civ7DecisionsNarrativeChoiceInput = Static<
+  typeof Civ7DecisionsNarrativeChoiceInputSchema
+>;
+
+export const Civ7DecisionsNarrativeChoicePostconditionClassificationSchema =
+  Type.Union([
+    Type.Literal("not-sent"),
+    Type.Literal("turn-unblocked"),
+    Type.Literal("narrative-blocker-cleared"),
+    Type.Literal("narrative-panel-cleared"),
+    Type.Literal("validation-changed"),
+    Type.Literal("no-state-change"),
+    Type.Literal("missing-postcondition"),
+  ]);
+
+export const Civ7DecisionsNarrativeChoiceProofOutcomeSchema = Type.Union([
+  Type.Literal("cleared"),
+  Type.Literal("state-changed"),
+  Type.Literal("still-blocked"),
+  Type.Literal("no-state-change"),
+  Type.Literal("not-sent"),
+  Type.Literal("stale"),
+  Type.Literal("unknown"),
+]);
+
+export const Civ7DecisionsNarrativeChoiceRequestStatusSchema = Type.Union([
+  Type.Literal("not-sent"),
+  Type.Literal("sent-confirmed"),
+  Type.Literal("sent-unverified"),
+]);
+
+export const Civ7DecisionsNarrativeChoiceValidationSummarySchema = Type.Object(
+  {
+    beforeValid: Type.Boolean(),
+    afterValid: Type.Boolean(),
+  },
+  { additionalProperties: false },
+);
+
+export const Civ7DecisionsNarrativeChoicePostconditionSummarySchema =
+  Type.Object(
+    {
+      classification: Civ7DecisionsNarrativeChoicePostconditionClassificationSchema,
+      reason: Type.String(),
+      outcome: Civ7DecisionsNarrativeChoiceProofOutcomeSchema,
+      confidence: Type.Union([
+        Type.Literal("confirmed"),
+        Type.Literal("unverified"),
+        Type.Literal("pending-runtime-proof"),
+      ]),
+      confirmed: Type.Boolean(),
+      noRepeatAfterUnverified: Type.Boolean(),
+    },
+    { additionalProperties: false },
+  );
+
+export const Civ7DecisionsNarrativeChoiceNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("refresh-attention"),
+      Type.Literal("do-not-repeat"),
+      Type.Literal("inspect-narrative-choice"),
+    ]),
+    source: Type.Literal("decisions.narrative.choice.request"),
+    label: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+export const Civ7DecisionsNarrativeChoiceResultSchema = Type.Object(
+  {
+    playerId: Type.Integer({ minimum: 0 }),
+    targetType: Type.String(),
+    target: Civ7ComponentIdSchema,
+    action: Type.Integer(),
+    sent: Type.Boolean(),
+    status: Civ7DecisionsNarrativeChoiceRequestStatusSchema,
+    validation: Civ7DecisionsNarrativeChoiceValidationSummarySchema,
+    postcondition: Civ7DecisionsNarrativeChoicePostconditionSummarySchema,
+    nextSteps: Type.Array(Civ7DecisionsNarrativeChoiceNextStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7DecisionsNarrativeChoiceResult = Static<
+  typeof Civ7DecisionsNarrativeChoiceResultSchema
+>;
+
+export const Civ7DecisionsNarrativeChoiceInputStandardSchema =
+  toStandardSchema(Civ7DecisionsNarrativeChoiceInputSchema);
+export const Civ7DecisionsNarrativeChoiceResultStandardSchema =
+  toStandardSchema(Civ7DecisionsNarrativeChoiceResultSchema);
+
+export type Civ7DecisionsNarrativeChoiceContract = ContractProcedure<
+  typeof Civ7DecisionsNarrativeChoiceInputStandardSchema,
+  typeof Civ7DecisionsNarrativeChoiceResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export const Civ7DecisionsNarrativeChoiceContract:
+  Civ7DecisionsNarrativeChoiceContract = civ7ControlOrpcContractBase
+    .input(Civ7DecisionsNarrativeChoiceInputStandardSchema)
+    .output(Civ7DecisionsNarrativeChoiceResultStandardSchema)
+    .meta({
+      family: "decisions",
+      procedureKey: "decisions.narrative.choice.request",
+      proofBoundary: "local-package-test",
+      risk: "mutation",
+    });
+
+export type Civ7DecisionsContract = Readonly<{
+  narrative: Readonly<{
+    choice: Readonly<{
+      request: Civ7DecisionsNarrativeChoiceContract;
+    }>;
+  }>;
+}>;
+
+export const Civ7DecisionsContract: Civ7DecisionsContract = {
+  narrative: {
+    choice: {
+      request: Civ7DecisionsNarrativeChoiceContract,
+    },
+  },
+};

--- a/packages/civ7-control-orpc/src/modules/decisions/procedures/diplomacy-response-request.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/procedures/diplomacy-response-request.ts
@@ -7,6 +7,7 @@ import { civ7MutationReadinessMiddleware } from "../../../middleware/mutation-re
 import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
 import {
   civ7MutationNextSteps,
+  civ7MutationPostconditionSummary,
   civ7MutationRequestStatusWithoutGuarded,
 } from "../../../policy/mutation-result";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
@@ -87,25 +88,12 @@ function diplomacyResponsePostconditionSummary(
   result: Civ7ControlOrpcDiplomacyResponseResult,
 ): Civ7DecisionsDiplomacyResponseResult["postcondition"] {
   const postcondition = diplomacyResponseProofPostcondition(result, undefined);
-  if (postcondition == null) {
-    return {
+  return civ7MutationPostconditionSummary({
+    postcondition,
+    missing: {
       classification: "missing-postcondition",
       reason: "The diplomacy response result did not include explicit postcondition evidence.",
       outcome: result.sent ? "unknown" : "not-sent",
-      confidence: "unverified",
-      confirmed: false,
-      noRepeatAfterUnverified: true,
-    };
-  }
-
-  return {
-    classification: postcondition.classification as
-      Civ7DecisionsDiplomacyResponseResult["postcondition"]["classification"],
-    reason: postcondition.reason,
-    outcome: postcondition.outcome,
-    confidence: postcondition.confidence,
-    confirmed: postcondition.confidence === "confirmed"
-      && !postcondition.noRepeatAfterUnverified,
-    noRepeatAfterUnverified: postcondition.noRepeatAfterUnverified,
-  };
+    },
+  }) as Civ7DecisionsDiplomacyResponseResult["postcondition"];
 }

--- a/packages/civ7-control-orpc/src/modules/decisions/procedures/diplomacy-response-request.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/procedures/diplomacy-response-request.ts
@@ -1,0 +1,111 @@
+import { diplomacyResponseProofPostcondition } from "@civ7/direct-control";
+import { Effect } from "effect";
+
+import type { Civ7ControlOrpcDiplomacyResponseResult } from "../../../dependencies/direct-control";
+import { civ7MutationApprovalMiddleware } from "../../../middleware/mutation-approval";
+import { civ7MutationReadinessMiddleware } from "../../../middleware/mutation-readiness";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7MutationNextSteps,
+  civ7MutationRequestStatusWithoutGuarded,
+} from "../../../policy/mutation-result";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type {
+  Civ7DecisionsDiplomacyResponseInput,
+  Civ7DecisionsDiplomacyResponseResult,
+} from "../contract";
+
+const decisionsDiplomacyResponseRequestWithApproval =
+  civ7ControlOrpcImplementer.decisions.diplomacy.response.request.use(
+    civ7MutationApprovalMiddleware,
+  );
+const decisionsDiplomacyResponseRequestReady =
+  decisionsDiplomacyResponseRequestWithApproval.use(
+    civ7MutationReadinessMiddleware,
+  );
+
+export const decisionsDiplomacyResponseRequestProcedure =
+  decisionsDiplomacyResponseRequestReady.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const result = await context.directControl.requestCiv7DiplomacyResponse(
+          input,
+          context.endpointDefaults,
+          context.approval,
+        );
+        return diplomacyResponseResult(input, result);
+      },
+      catch: () =>
+        errors.DIPLOMACY_RESPONSE_UNAVAILABLE({
+          data: {
+            procedureKey: "decisions.diplomacy.response.request",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+function diplomacyResponseResult(
+  input: Civ7DecisionsDiplomacyResponseInput,
+  result: Civ7ControlOrpcDiplomacyResponseResult,
+): Civ7DecisionsDiplomacyResponseResult {
+  const postcondition = diplomacyResponsePostconditionSummary(result);
+  const status = civ7MutationRequestStatusWithoutGuarded({
+    sent: result.sent,
+    postcondition,
+  });
+
+  return {
+    playerId: input.playerId,
+    actionId: input.actionId,
+    responseType: input.responseType,
+    ...(input.notificationId === undefined ? {} : { notificationId: input.notificationId }),
+    sent: result.sent,
+    status,
+    validation: {
+      beforeValid: result.beforeValidation.valid,
+      afterValid: result.afterValidation.valid,
+    },
+    postcondition,
+    nextSteps: civ7MutationNextSteps({
+      status,
+      postcondition,
+      source: "decisions.diplomacy.response.request",
+      inspectKind: "inspect-diplomacy-response",
+      inspectLabel: "Inspect current attention and diplomacy response state before attempting another diplomacy request.",
+      doNotRepeatLabel: "Do not repeat this diplomacy response request until fresh attention and diplomacy evidence is read.",
+    }),
+  };
+}
+
+function diplomacyResponsePostconditionSummary(
+  result: Civ7ControlOrpcDiplomacyResponseResult,
+): Civ7DecisionsDiplomacyResponseResult["postcondition"] {
+  const postcondition = diplomacyResponseProofPostcondition(result, undefined);
+  if (postcondition == null) {
+    return {
+      classification: "missing-postcondition",
+      reason: "The diplomacy response result did not include explicit postcondition evidence.",
+      outcome: result.sent ? "unknown" : "not-sent",
+      confidence: "unverified",
+      confirmed: false,
+      noRepeatAfterUnverified: true,
+    };
+  }
+
+  return {
+    classification: postcondition.classification as
+      Civ7DecisionsDiplomacyResponseResult["postcondition"]["classification"],
+    reason: postcondition.reason,
+    outcome: postcondition.outcome,
+    confidence: postcondition.confidence,
+    confirmed: postcondition.confidence === "confirmed"
+      && !postcondition.noRepeatAfterUnverified,
+    noRepeatAfterUnverified: postcondition.noRepeatAfterUnverified,
+  };
+}

--- a/packages/civ7-control-orpc/src/modules/decisions/procedures/narrative-choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/procedures/narrative-choice-request.ts
@@ -1,0 +1,111 @@
+import { narrativeChoiceProofPostcondition } from "@civ7/direct-control";
+import { Effect } from "effect";
+
+import type { Civ7ControlOrpcNarrativeChoiceResult } from "../../../dependencies/direct-control";
+import { civ7MutationApprovalMiddleware } from "../../../middleware/mutation-approval";
+import { civ7MutationReadinessMiddleware } from "../../../middleware/mutation-readiness";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7MutationNextSteps,
+  civ7MutationRequestStatusWithoutGuarded,
+} from "../../../policy/mutation-result";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type {
+  Civ7DecisionsNarrativeChoiceInput,
+  Civ7DecisionsNarrativeChoiceResult,
+} from "../contract";
+
+const decisionsNarrativeChoiceRequestWithApproval =
+  civ7ControlOrpcImplementer.decisions.narrative.choice.request.use(
+    civ7MutationApprovalMiddleware,
+  );
+const decisionsNarrativeChoiceRequestReady =
+  decisionsNarrativeChoiceRequestWithApproval.use(
+    civ7MutationReadinessMiddleware,
+  );
+
+export const decisionsNarrativeChoiceRequestProcedure =
+  decisionsNarrativeChoiceRequestReady.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const result = await context.directControl.requestCiv7NarrativeChoice(
+          input,
+          context.endpointDefaults,
+          context.approval,
+        );
+        return narrativeChoiceResult(input, result);
+      },
+      catch: () =>
+        errors.NARRATIVE_CHOICE_UNAVAILABLE({
+          data: {
+            procedureKey: "decisions.narrative.choice.request",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+function narrativeChoiceResult(
+  input: Civ7DecisionsNarrativeChoiceInput,
+  result: Civ7ControlOrpcNarrativeChoiceResult,
+): Civ7DecisionsNarrativeChoiceResult {
+  const postcondition = narrativeChoicePostconditionSummary(result);
+  const status = civ7MutationRequestStatusWithoutGuarded({
+    sent: result.sent,
+    postcondition,
+  });
+
+  return {
+    playerId: input.playerId,
+    targetType: input.targetType,
+    target: input.target,
+    action: input.action,
+    sent: result.sent,
+    status,
+    validation: {
+      beforeValid: result.beforeValidation.valid,
+      afterValid: result.afterValidation.valid,
+    },
+    postcondition,
+    nextSteps: civ7MutationNextSteps({
+      status,
+      postcondition,
+      source: "decisions.narrative.choice.request",
+      inspectKind: "inspect-narrative-choice",
+      inspectLabel: "Inspect current attention and narrative choice state before attempting another narrative request.",
+      doNotRepeatLabel: "Do not repeat this narrative choice request until fresh attention and narrative evidence is read.",
+    }),
+  };
+}
+
+function narrativeChoicePostconditionSummary(
+  result: Civ7ControlOrpcNarrativeChoiceResult,
+): Civ7DecisionsNarrativeChoiceResult["postcondition"] {
+  const postcondition = narrativeChoiceProofPostcondition(result, undefined);
+  if (postcondition == null) {
+    return {
+      classification: "missing-postcondition",
+      reason: "The narrative choice result did not include explicit postcondition evidence.",
+      outcome: result.sent ? "unknown" : "not-sent",
+      confidence: "unverified",
+      confirmed: false,
+      noRepeatAfterUnverified: true,
+    };
+  }
+
+  return {
+    classification: postcondition.classification as
+      Civ7DecisionsNarrativeChoiceResult["postcondition"]["classification"],
+    reason: postcondition.reason,
+    outcome: postcondition.outcome,
+    confidence: postcondition.confidence,
+    confirmed: postcondition.confidence === "confirmed"
+      && !postcondition.noRepeatAfterUnverified,
+    noRepeatAfterUnverified: postcondition.noRepeatAfterUnverified,
+  };
+}

--- a/packages/civ7-control-orpc/src/modules/decisions/procedures/narrative-choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/procedures/narrative-choice-request.ts
@@ -7,6 +7,7 @@ import { civ7MutationReadinessMiddleware } from "../../../middleware/mutation-re
 import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
 import {
   civ7MutationNextSteps,
+  civ7MutationPostconditionSummary,
   civ7MutationRequestStatusWithoutGuarded,
 } from "../../../policy/mutation-result";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
@@ -87,25 +88,12 @@ function narrativeChoicePostconditionSummary(
   result: Civ7ControlOrpcNarrativeChoiceResult,
 ): Civ7DecisionsNarrativeChoiceResult["postcondition"] {
   const postcondition = narrativeChoiceProofPostcondition(result, undefined);
-  if (postcondition == null) {
-    return {
+  return civ7MutationPostconditionSummary({
+    postcondition,
+    missing: {
       classification: "missing-postcondition",
       reason: "The narrative choice result did not include explicit postcondition evidence.",
       outcome: result.sent ? "unknown" : "not-sent",
-      confidence: "unverified",
-      confirmed: false,
-      noRepeatAfterUnverified: true,
-    };
-  }
-
-  return {
-    classification: postcondition.classification as
-      Civ7DecisionsNarrativeChoiceResult["postcondition"]["classification"],
-    reason: postcondition.reason,
-    outcome: postcondition.outcome,
-    confidence: postcondition.confidence,
-    confirmed: postcondition.confidence === "confirmed"
-      && !postcondition.noRepeatAfterUnverified,
-    noRepeatAfterUnverified: postcondition.noRepeatAfterUnverified,
-  };
+    },
+  }) as Civ7DecisionsNarrativeChoiceResult["postcondition"];
 }

--- a/packages/civ7-control-orpc/src/modules/decisions/router.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/router.ts
@@ -1,0 +1,9 @@
+import { decisionsNarrativeChoiceRequestProcedure } from "./procedures/narrative-choice-request";
+
+export const decisionsRouter = {
+  narrative: {
+    choice: {
+      request: decisionsNarrativeChoiceRequestProcedure,
+    },
+  },
+};

--- a/packages/civ7-control-orpc/src/modules/decisions/router.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/router.ts
@@ -1,6 +1,12 @@
+import { decisionsDiplomacyResponseRequestProcedure } from "./procedures/diplomacy-response-request";
 import { decisionsNarrativeChoiceRequestProcedure } from "./procedures/narrative-choice-request";
 
 export const decisionsRouter = {
+  diplomacy: {
+    response: {
+      request: decisionsDiplomacyResponseRequestProcedure,
+    },
+  },
   narrative: {
     choice: {
       request: decisionsNarrativeChoiceRequestProcedure,

--- a/packages/civ7-control-orpc/src/modules/notifications/procedures/dismiss-request.ts
+++ b/packages/civ7-control-orpc/src/modules/notifications/procedures/dismiss-request.ts
@@ -9,6 +9,7 @@ import { civ7MutationReadinessMiddleware } from "../../../middleware/mutation-re
 import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
 import {
   civ7MutationNextSteps,
+  civ7MutationPostconditionSummary,
   civ7MutationRequestStatusWithoutGuarded,
 } from "../../../policy/mutation-result";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
@@ -85,25 +86,12 @@ function notificationDismissalPostconditionSummary(
     result,
     undefined,
   );
-  if (postcondition == null) {
-    return {
+  return civ7MutationPostconditionSummary({
+    postcondition,
+    missing: {
       classification: "missing-postcondition",
       reason: "The notification dismissal result did not include explicit postcondition evidence.",
       outcome: result.sent ? "unknown" : "not-sent",
-      confidence: "unverified",
-      confirmed: false,
-      noRepeatAfterUnverified: true,
-    };
-  }
-
-  return {
-    classification: postcondition.classification as
-      Civ7NotificationDismissalResult["postcondition"]["classification"],
-    reason: postcondition.reason,
-    outcome: postcondition.outcome,
-    confidence: postcondition.confidence,
-    confirmed: postcondition.confidence === "confirmed"
-      && !postcondition.noRepeatAfterUnverified,
-    noRepeatAfterUnverified: postcondition.noRepeatAfterUnverified,
-  };
+    },
+  }) as Civ7NotificationDismissalResult["postcondition"];
 }

--- a/packages/civ7-control-orpc/src/modules/strategy/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/contract.ts
@@ -1,0 +1,161 @@
+import { Civ7MapLocationSchema } from "@civ7/direct-control";
+import type { ContractProcedure } from "@orpc/contract";
+import { Type, type Static } from "typebox";
+
+import { civ7ControlOrpcContractBase } from "../../contract-base";
+import type { Civ7ControlOrpcErrorMap } from "../../errors";
+import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
+import { toStandardSchema } from "../../typebox-standard-schema";
+
+export const Civ7StrategyFrontSummaryInputSchema = Type.Object(
+  {
+    playerId: Type.Optional(Type.Integer({ minimum: 0, maximum: 1024 })),
+    origins: Type.Optional(Type.Array(Civ7MapLocationSchema)),
+    candidateLimit: Type.Optional(Type.Integer({ minimum: 1, maximum: 8 })),
+    scanRadius: Type.Optional(Type.Integer({ minimum: 1, maximum: 32 })),
+    maxPlayers: Type.Optional(Type.Integer({ minimum: 1, maximum: 128 })),
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyFrontSummaryInput = Static<
+  typeof Civ7StrategyFrontSummaryInputSchema
+>;
+
+export const Civ7StrategyRelationshipClassificationSchema = Type.Union([
+  Type.Literal("self"),
+  Type.Literal("relationship-unproven"),
+]);
+
+export const Civ7StrategyRelationshipLabelPolicySchema = Type.Object(
+  {
+    relationshipSource: Type.Literal("not-classified"),
+    relationshipProof: Type.Literal("none"),
+    unprovenLabel: Type.Literal("relationship-unproven"),
+    guidance: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+export const Civ7StrategyFrontSourceStatusSchema = Type.Object(
+  {
+    targetCandidates: Type.Literal("read"),
+    battlefieldScan: Type.Literal("read"),
+  },
+  { additionalProperties: false },
+);
+
+export const Civ7StrategyFrontTargetCandidateSchema = Type.Object(
+  {
+    owner: Type.Integer({ minimum: 0 }),
+    relationship: Type.Literal("relationship-unproven"),
+    relationshipProof: Type.Literal("none"),
+    nearestDistance: Type.Union([Type.Number(), Type.Null()]),
+    cityCount: Type.Integer({ minimum: 0 }),
+    unitCount: Type.Integer({ minimum: 0 }),
+    nearbyUnitCount: Type.Integer({ minimum: 0 }),
+    apparentStrength: Type.Number(),
+    routeKind: Type.String(),
+    routeHint: Type.String(),
+    reasons: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const Civ7StrategyFrontPointOfInterestSchema = Type.Object(
+  {
+    kind: Type.String(),
+    severity: Type.String(),
+    location: Type.Union([Civ7MapLocationSchema, Type.Null()]),
+    summary: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+export const Civ7StrategyObservedOwnerSchema = Type.Object(
+  {
+    owner: Type.Integer({ minimum: 0 }),
+    relationship: Civ7StrategyRelationshipClassificationSchema,
+    relationshipProof: Type.Union([Type.Literal("self"), Type.Literal("none")]),
+    unitCount: Type.Integer({ minimum: 0 }),
+    cityCount: Type.Integer({ minimum: 0 }),
+    apparentStrength: Type.Number(),
+    nearestDistance: Type.Union([Type.Number(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+export const Civ7StrategyFrontSummaryNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("inspect-target-candidate"),
+      Type.Literal("inspect-battlefield-point"),
+      Type.Literal("read-visibility"),
+      Type.Literal("validate-unit-action"),
+      Type.Literal("observe"),
+    ]),
+    source: Type.Literal("strategy.frontSummary"),
+    label: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+export const Civ7StrategyFrontSummaryResultSchema = Type.Object(
+  {
+    playerId: Type.Integer({ minimum: 0 }),
+    localPlayerId: Type.Integer({ minimum: 0 }),
+    origins: Type.Array(Civ7MapLocationSchema),
+    sourceStatus: Civ7StrategyFrontSourceStatusSchema,
+    relationshipLabelPolicy: Civ7StrategyRelationshipLabelPolicySchema,
+    summary: Type.Object(
+      {
+        targetCandidateCount: Type.Integer({ minimum: 0 }),
+        pointOfInterestCount: Type.Integer({ minimum: 0 }),
+        observedOwnerCount: Type.Integer({ minimum: 0 }),
+        nextStepCount: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    ),
+    targetCandidates: Type.Array(Civ7StrategyFrontTargetCandidateSchema),
+    pointsOfInterest: Type.Array(Civ7StrategyFrontPointOfInterestSchema),
+    observedOwners: Type.Array(Civ7StrategyObservedOwnerSchema),
+    notes: Type.Array(Type.String()),
+    nextSteps: Type.Array(Civ7StrategyFrontSummaryNextStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyFrontSummaryResult = Static<
+  typeof Civ7StrategyFrontSummaryResultSchema
+>;
+
+export const Civ7StrategyFrontSummaryInputStandardSchema = toStandardSchema(
+  Civ7StrategyFrontSummaryInputSchema,
+);
+export const Civ7StrategyFrontSummaryResultStandardSchema = toStandardSchema(
+  Civ7StrategyFrontSummaryResultSchema,
+);
+
+export type Civ7StrategyFrontSummaryContract = ContractProcedure<
+  typeof Civ7StrategyFrontSummaryInputStandardSchema,
+  typeof Civ7StrategyFrontSummaryResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export const Civ7StrategyFrontSummaryContract: Civ7StrategyFrontSummaryContract =
+  civ7ControlOrpcContractBase
+    .input(Civ7StrategyFrontSummaryInputStandardSchema)
+    .output(Civ7StrategyFrontSummaryResultStandardSchema)
+    .meta({
+      family: "strategy",
+      procedureKey: "strategy.frontSummary",
+      proofBoundary: "local-package-test",
+      risk: "read-only",
+    });
+
+export type Civ7StrategyContract = Readonly<{
+  frontSummary: Civ7StrategyFrontSummaryContract;
+}>;
+
+export const Civ7StrategyContract: Civ7StrategyContract = {
+  frontSummary: Civ7StrategyFrontSummaryContract,
+};

--- a/packages/civ7-control-orpc/src/modules/strategy/procedures/front-summary.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/procedures/front-summary.ts
@@ -1,0 +1,238 @@
+import { Effect } from "effect";
+
+import type {
+  Civ7ControlOrpcDirectControlFacade,
+  Civ7ControlOrpcBattlefieldScanResult,
+  Civ7ControlOrpcTargetCandidatesResult,
+} from "../../../dependencies/direct-control";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type {
+  Civ7StrategyFrontSummaryInput,
+  Civ7StrategyFrontSummaryResult,
+} from "../contract";
+
+type Civ7StrategyTargetCandidatesInput = NonNullable<
+  Parameters<Civ7ControlOrpcDirectControlFacade["getCiv7TargetCandidates"]>[0]
+>;
+type Civ7StrategyBattlefieldScanInput = NonNullable<
+  Parameters<Civ7ControlOrpcDirectControlFacade["getCiv7BattlefieldScan"]>[0]
+>;
+
+export const strategyFrontSummaryProcedure =
+  civ7ControlOrpcImplementer.strategy.frontSummary.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const targetInput = targetCandidatesInput(input);
+        const battlefieldInput = battlefieldScanInput(input);
+        const [targetCandidates, battlefieldScan] = await Promise.all([
+          context.directControl.getCiv7TargetCandidates(
+            targetInput,
+            context.endpointDefaults,
+          ),
+          context.directControl.getCiv7BattlefieldScan(
+            battlefieldInput,
+            context.endpointDefaults,
+          ),
+        ]);
+
+        return strategyFrontSummaryResult({
+          input,
+          targetCandidates,
+          battlefieldScan,
+        });
+      },
+      catch: () =>
+        errors.STRATEGY_FRONT_SUMMARY_UNAVAILABLE({
+          data: {
+            procedureKey: "strategy.frontSummary",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+function targetCandidatesInput(
+  input: Civ7StrategyFrontSummaryInput,
+): Civ7StrategyTargetCandidatesInput {
+  return {
+    playerId: input.playerId,
+    origins: input.origins,
+    maxCandidates: input.candidateLimit ?? 5,
+    maxPlayers: input.maxPlayers,
+    unitRadius: Math.min(input.scanRadius ?? 8, 16),
+  };
+}
+
+function battlefieldScanInput(
+  input: Civ7StrategyFrontSummaryInput,
+): Civ7StrategyBattlefieldScanInput {
+  return {
+    playerId: input.playerId,
+    origins: input.origins,
+    radius: input.scanRadius ?? 8,
+    maxPlayers: input.maxPlayers,
+    maxUnits: 48,
+    maxCities: 24,
+  };
+}
+
+function strategyFrontSummaryResult({
+  targetCandidates,
+  battlefieldScan,
+}: Readonly<{
+  input: Civ7StrategyFrontSummaryInput;
+  targetCandidates: Civ7ControlOrpcTargetCandidatesResult;
+  battlefieldScan: Civ7ControlOrpcBattlefieldScanResult;
+}>): Civ7StrategyFrontSummaryResult {
+  const targetCandidateSummaries = targetCandidates.candidates.map(
+    (candidate) => ({
+      owner: candidate.owner,
+      relationship: "relationship-unproven" as const,
+      relationshipProof: "none" as const,
+      nearestDistance: candidate.nearestDistance,
+      cityCount: candidate.cityCount,
+      unitCount: candidate.unitCount,
+      nearbyUnitCount: candidate.nearbyUnitCount,
+      apparentStrength: candidate.apparentStrength,
+      routeKind: candidate.approach.routeKind,
+      routeHint: candidate.approach.routeHint,
+      reasons: [...candidate.reasons],
+    }),
+  );
+  const pointsOfInterest = battlefieldScan.pointsOfInterest.map((point) => ({
+    kind: point.kind,
+    severity: point.severity,
+    location: point.location,
+    summary: normalizeRelationshipSummary(point.summary),
+  }));
+  const observedOwners = battlefieldScan.owners.map((owner) => ({
+    owner: owner.owner,
+    relationship: owner.relationshipProof === "self"
+      ? "self" as const
+      : "relationship-unproven" as const,
+    relationshipProof: owner.relationshipProof === "self"
+      ? "self" as const
+      : "none" as const,
+    unitCount: owner.unitCount,
+    cityCount: owner.cityCount,
+    apparentStrength: owner.apparentStrength,
+    nearestDistance: nearestOwnerDistance(owner),
+  }));
+  const nextSteps = strategyNextSteps({
+    targetCandidates: targetCandidateSummaries,
+    pointsOfInterest,
+  });
+
+  return {
+    playerId: targetCandidates.playerId,
+    localPlayerId: targetCandidates.localPlayerId,
+    origins: targetCandidates.origins.length > 0
+      ? targetCandidates.origins
+      : battlefieldScan.origins,
+    sourceStatus: {
+      targetCandidates: "read",
+      battlefieldScan: "read",
+    },
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "Front summary composes planning evidence only. Other-owner contact, proximity, ranking, and action legality do not prove official diplomatic status.",
+    },
+    summary: {
+      targetCandidateCount: targetCandidateSummaries.length,
+      pointOfInterestCount: pointsOfInterest.length,
+      observedOwnerCount: observedOwners.length,
+      nextStepCount: nextSteps.length,
+    },
+    targetCandidates: targetCandidateSummaries,
+    pointsOfInterest,
+    observedOwners,
+    notes: [
+      "Read-only strategy front summary. It does not move, attack, approve sends, or change diplomacy.",
+      "Use visibility and validator-backed unit action procedures before any mutation.",
+      "Relationship labels stay relationship-unproven unless official diplomatic evidence proves more.",
+    ],
+    nextSteps,
+  };
+}
+
+function nearestOwnerDistance(
+  owner: Civ7ControlOrpcBattlefieldScanResult["owners"][number],
+): number | null {
+  const distances = [
+    distanceFromUnknown(owner.nearestUnit),
+    distanceFromUnknown(owner.nearestCity),
+  ].filter((distance): distance is number => distance != null);
+  if (distances.length === 0) return null;
+  return Math.min(...distances);
+}
+
+function distanceFromUnknown(value: unknown): number | null {
+  if (value == null || typeof value !== "object") return null;
+  if (!("distance" in value) || typeof value.distance !== "number") return null;
+  return value.distance;
+}
+
+function strategyNextSteps({
+  targetCandidates,
+  pointsOfInterest,
+}: Readonly<{
+  targetCandidates: Civ7StrategyFrontSummaryResult["targetCandidates"];
+  pointsOfInterest: Civ7StrategyFrontSummaryResult["pointsOfInterest"];
+}>): Civ7StrategyFrontSummaryResult["nextSteps"] {
+  const nextSteps: Civ7StrategyFrontSummaryResult["nextSteps"] = [];
+  const candidate = targetCandidates[0];
+  if (candidate != null) {
+    nextSteps.push({
+      kind: "inspect-target-candidate",
+      source: "strategy.frontSummary",
+      label: `Inspect owner ${candidate.owner} planning candidate with visibility reads before treating it as actionable.`,
+    });
+  }
+
+  const point = pointsOfInterest[0];
+  if (point != null) {
+    nextSteps.push({
+      kind: "inspect-battlefield-point",
+      source: "strategy.frontSummary",
+      label: `Inspect ${point.kind} battlefield point before choosing a unit action.`,
+    });
+  }
+
+  if (targetCandidates.length > 0 || pointsOfInterest.length > 0) {
+    nextSteps.push({
+      kind: "read-visibility",
+      source: "strategy.frontSummary",
+      label: "Read visibility/map evidence before promoting planning evidence into an action.",
+    });
+    nextSteps.push({
+      kind: "validate-unit-action",
+      source: "strategy.frontSummary",
+      label: "Use unit action validation before any movement or target send.",
+    });
+  }
+
+  if (nextSteps.length === 0) {
+    return [{
+      kind: "observe",
+      source: "strategy.frontSummary",
+      label: "No front planning evidence found; refresh attention or narrow the scan origins.",
+    }];
+  }
+
+  return nextSteps;
+}
+
+function normalizeRelationshipSummary(summary: string): string {
+  return summary
+    .replace(/\bfriendly\b/gi, "own")
+    .replace(/\bpressure\b/gi, "contact")
+    .replace(/\bthreat\b/gi, "contact");
+}

--- a/packages/civ7-control-orpc/src/modules/strategy/router.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/router.ts
@@ -1,0 +1,5 @@
+import { strategyFrontSummaryProcedure } from "./procedures/front-summary";
+
+export const strategyRouter = {
+  frontSummary: strategyFrontSummaryProcedure,
+};

--- a/packages/civ7-control-orpc/src/policy/mutation-result.ts
+++ b/packages/civ7-control-orpc/src/policy/mutation-result.ts
@@ -4,9 +4,30 @@ export type Civ7MutationRequestStatus =
   | "sent-guarded"
   | "sent-unverified";
 
+export type Civ7MutationProofConfidence =
+  | "confirmed"
+  | "pending-runtime-proof"
+  | "unverified";
+
 export type Civ7MutationPostconditionState = Readonly<{
-  confidence: "confirmed" | "pending-runtime-proof" | "unverified";
+  confidence: Civ7MutationProofConfidence;
   noRepeatAfterUnverified: boolean;
+}>;
+
+export type Civ7MutationProofPostcondition<
+  Classification extends string,
+  Outcome extends string,
+> = Civ7MutationPostconditionState & Readonly<{
+  classification: Classification;
+  reason: string;
+  outcome: Outcome;
+}>;
+
+export type Civ7MutationPostconditionSummary<
+  Classification extends string,
+  Outcome extends string,
+> = Civ7MutationProofPostcondition<Classification, Outcome> & Readonly<{
+  confirmed: boolean;
 }>;
 
 export type Civ7MutationNextStep<
@@ -38,6 +59,49 @@ export function civ7MutationRequestStatusWithoutGuarded(
 ): Exclude<Civ7MutationRequestStatus, "sent-guarded"> {
   const status = civ7MutationRequestStatus(input);
   return status === "sent-guarded" ? "sent-unverified" : status;
+}
+
+export function civ7MutationPostconditionSummary<
+  Classification extends string,
+  Outcome extends string,
+  MissingClassification extends string,
+  MissingOutcome extends string,
+>(
+  input: Readonly<{
+    postcondition:
+      | Civ7MutationProofPostcondition<Classification, Outcome>
+      | null
+      | undefined;
+    missing: Readonly<{
+      classification: MissingClassification;
+      reason: string;
+      outcome: MissingOutcome;
+    }>;
+  }>,
+): Civ7MutationPostconditionSummary<
+  Classification | MissingClassification,
+  Outcome | MissingOutcome
+> {
+  if (input.postcondition == null) {
+    return {
+      classification: input.missing.classification,
+      reason: input.missing.reason,
+      outcome: input.missing.outcome,
+      confidence: "unverified",
+      confirmed: false,
+      noRepeatAfterUnverified: true,
+    };
+  }
+
+  return {
+    classification: input.postcondition.classification,
+    reason: input.postcondition.reason,
+    outcome: input.postcondition.outcome,
+    confidence: input.postcondition.confidence,
+    confirmed: input.postcondition.confidence === "confirmed"
+      && !input.postcondition.noRepeatAfterUnverified,
+    noRepeatAfterUnverified: input.postcondition.noRepeatAfterUnverified,
+  };
 }
 
 export function civ7MutationNextSteps<

--- a/packages/civ7-control-orpc/src/router.ts
+++ b/packages/civ7-control-orpc/src/router.ts
@@ -5,6 +5,7 @@ import type { Civ7ControlOrpcContext } from "./context";
 import { civ7ControlOrpcImplementer } from "./procedure";
 import { attentionRouter } from "./modules/attention/router";
 import { cityRouter } from "./modules/city/router";
+import { decisionsRouter } from "./modules/decisions/router";
 import { notificationsRouter } from "./modules/notifications/router";
 import { readinessRouter } from "./modules/readiness/router";
 import { strategyRouter } from "./modules/strategy/router";
@@ -16,6 +17,7 @@ export const Civ7ControlOrpcRouter: Router<
 > = civ7ControlOrpcImplementer.router({
   attention: attentionRouter,
   city: cityRouter,
+  decisions: decisionsRouter,
   notifications: notificationsRouter,
   readiness: readinessRouter,
   strategy: strategyRouter,

--- a/packages/civ7-control-orpc/src/router.ts
+++ b/packages/civ7-control-orpc/src/router.ts
@@ -7,6 +7,7 @@ import { attentionRouter } from "./modules/attention/router";
 import { cityRouter } from "./modules/city/router";
 import { notificationsRouter } from "./modules/notifications/router";
 import { readinessRouter } from "./modules/readiness/router";
+import { strategyRouter } from "./modules/strategy/router";
 import { unitRouter } from "./modules/unit/router";
 
 export const Civ7ControlOrpcRouter: Router<
@@ -17,5 +18,6 @@ export const Civ7ControlOrpcRouter: Router<
   city: cityRouter,
   notifications: notificationsRouter,
   readiness: readinessRouter,
+  strategy: strategyRouter,
   unit: unitRouter,
 });

--- a/packages/civ7-control-orpc/test/decisions-diplomacy-response-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/decisions-diplomacy-response-procedure.test.ts
@@ -1,0 +1,389 @@
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  Civ7DiplomacyResponseUnavailableError,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+  type Civ7ControlOrpcPlayableStatusResult,
+} from "../src/index";
+import type { Civ7ControlOrpcDiplomacyResponseResult } from "../src/dependencies/direct-control";
+
+const diplomacyInput = {
+  playerId: 0,
+  actionId: 8_821,
+  responseType: -1_713_616_684,
+  notificationId: { owner: 0, id: 44, type: 20 },
+} as const;
+
+describe("decisions.diplomacy.response.request control-oRPC procedure", () => {
+  test("projects confirmed diplomacy responses without raw command output", async () => {
+    const fake = fakeContext(diplomacyResponseResult("diplomacy-blocker-cleared"));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.decisions.diplomacy.response.request,
+      diplomacyInput,
+      { context: fake.context },
+    );
+
+    expect(fake.calls.readiness).toHaveLength(1);
+    expect(fake.calls.request).toEqual([{
+      input: diplomacyInput,
+      options: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      approval: {
+        approved: true,
+        reason: "local diplomacy response proof",
+      },
+    }]);
+    expect(result).toEqual({
+      playerId: 0,
+      actionId: 8_821,
+      responseType: -1_713_616_684,
+      notificationId: { owner: 0, id: 44, type: 20 },
+      sent: true,
+      status: "sent-confirmed",
+      validation: {
+        beforeValid: true,
+        afterValid: false,
+      },
+      postcondition: {
+        classification: "diplomacy-blocker-cleared",
+        reason: "diplomacy-blocker-cleared reason",
+        outcome: "cleared",
+        confidence: "confirmed",
+        confirmed: true,
+        noRepeatAfterUnverified: false,
+      },
+      nextSteps: [{
+        kind: "refresh-attention",
+        source: "decisions.diplomacy.response.request",
+        label: "Refresh current attention before choosing the next player action.",
+      }],
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"command\"");
+    expect(serialized).not.toContain("\"payload\"");
+    expect(serialized).not.toContain("\"verified\"");
+    expect(serialized).not.toContain("Game.PlayerOperations.sendRequest");
+  });
+
+  test("keeps sent no-state-change diplomacy responses no-repeat guarded", async () => {
+    const fake = fakeContext(diplomacyResponseResult("no-state-change", {
+      afterValid: true,
+      verified: true,
+    }));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.decisions.diplomacy.response.request,
+      diplomacyInput,
+      { context: fake.context },
+    );
+
+    expect(result.status).toBe("sent-unverified");
+    expect(result.postcondition).toMatchObject({
+      classification: "no-state-change",
+      outcome: "no-state-change",
+      confidence: "unverified",
+      confirmed: false,
+      noRepeatAfterUnverified: true,
+    });
+    expect(result.nextSteps).toEqual([{
+      kind: "do-not-repeat",
+      source: "decisions.diplomacy.response.request",
+      label: "Do not repeat this diplomacy response request until fresh attention and diplomacy evidence is read.",
+    }]);
+  });
+
+  test("projects validator-blocked diplomacy responses as not-sent", async () => {
+    const fake = fakeContext(diplomacyResponseResult("not-sent", {
+      sent: false,
+      beforeValid: false,
+      afterValid: false,
+      verified: false,
+    }));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.decisions.diplomacy.response.request,
+      diplomacyInput,
+      { context: fake.context },
+    );
+
+    expect(result).toMatchObject({
+      sent: false,
+      status: "not-sent",
+      validation: {
+        beforeValid: false,
+        afterValid: false,
+      },
+      postcondition: {
+        classification: "not-sent",
+        outcome: "not-sent",
+        confidence: "unverified",
+        noRepeatAfterUnverified: true,
+      },
+    });
+    expect(result.nextSteps).toEqual([{
+      kind: "inspect-diplomacy-response",
+      source: "decisions.diplomacy.response.request",
+      label: "Inspect current attention and diplomacy response state before attempting another diplomacy request.",
+    }]);
+  });
+
+  test("requires approval before readiness or request execution", async () => {
+    const fake = fakeContext(diplomacyResponseResult("diplomacy-blocker-cleared"), {
+      approved: false,
+    });
+
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.decisions.diplomacy.response.request,
+        diplomacyInput,
+        { context: fake.context },
+      ),
+    ).rejects.toMatchObject({
+      code: "MUTATION_APPROVAL_REQUIRED",
+      data: {
+        procedureKey: "decisions.diplomacy.response.request",
+        source: "context.approval",
+        risk: "mutation",
+      },
+    });
+    expect(fake.calls.readiness).toEqual([]);
+    expect(fake.calls.request).toEqual([]);
+  });
+
+  test("keeps endpoint/session/state/raw command fields and UI toggles out of procedure input", async () => {
+    const invalidInputs = [
+      { ...diplomacyInput, host: "127.0.0.1" },
+      { ...diplomacyInput, port: 4318 },
+      { ...diplomacyInput, state: { role: "tuner" } },
+      { ...diplomacyInput, session: { state: "Tuner" } },
+      { ...diplomacyInput, command: "Game.turn" },
+      { ...diplomacyInput, rawCommand: "Game.turn" },
+      { ...diplomacyInput, activateNotification: false },
+      { ...diplomacyInput, uiCloseout: false },
+    ];
+
+    for (const input of invalidInputs) {
+      const fake = fakeContext(diplomacyResponseResult("diplomacy-blocker-cleared"));
+
+      await expect(
+        call(
+          Civ7ControlOrpcRouter.decisions.diplomacy.response.request,
+          input as never,
+          { context: fake.context },
+        ),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(fake.calls.readiness).toEqual([]);
+      expect(fake.calls.request).toEqual([]);
+    }
+  });
+
+  test("maps source failures to a tagged Effect/oRPC error without raw details", async () => {
+    const context = fakeContext(diplomacyResponseResult("diplomacy-blocker-cleared")).context;
+    const failingContext: Civ7ControlOrpcContext = {
+      ...context,
+      directControl: {
+        ...context.directControl,
+        requestCiv7DiplomacyResponse: async () => {
+          throw new Error(
+            "Timed out waiting for Civ7 tuner response to CMD:1:Game.PlayerOperations.sendRequest(...)",
+          );
+        },
+      },
+    };
+
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.decisions.diplomacy.response.request,
+        diplomacyInput,
+        { context: failingContext },
+      ),
+    ).rejects.toMatchObject({
+      code: "DIPLOMACY_RESPONSE_UNAVAILABLE",
+      status: 503,
+      data: {
+        procedureKey: "decisions.diplomacy.response.request",
+        source: "direct-control-facade",
+      },
+    });
+
+    try {
+      await call(
+        Civ7ControlOrpcRouter.decisions.diplomacy.response.request,
+        diplomacyInput,
+        { context: failingContext },
+      );
+    } catch (err) {
+      const serialized = JSON.stringify(err);
+      expect(serialized).not.toContain("CMD");
+      expect(serialized).not.toContain("Game.PlayerOperations");
+      expect(serialized).not.toContain("rawCommand");
+      expect(serialized).not.toContain("command-failed");
+    }
+  });
+
+  test("supports the in-process server-side router client", async () => {
+    const fake = fakeContext(diplomacyResponseResult("blocking-notification-changed"));
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    const result = await client.decisions.diplomacy.response.request(diplomacyInput);
+
+    expect(result.status).toBe("sent-confirmed");
+    expect(result.postcondition.outcome).toBe("state-changed");
+  });
+
+  test("publishes a contract-first diplomacy decision service leaf", () => {
+    expect(
+      Civ7ControlOrpcContract.decisions.diplomacy.response.request["~orpc"],
+    ).toMatchObject({
+      meta: {
+        family: "decisions",
+        procedureKey: "decisions.diplomacy.response.request",
+        proofBoundary: "local-package-test",
+        risk: "mutation",
+      },
+    });
+    expect(
+      Civ7ControlOrpcContract.decisions.diplomacy.response.request["~orpc"].errorMap,
+    ).toHaveProperty("DIPLOMACY_RESPONSE_UNAVAILABLE");
+    expect(Civ7DiplomacyResponseUnavailableError.code).toBe(
+      "DIPLOMACY_RESPONSE_UNAVAILABLE",
+    );
+  });
+});
+
+function fakeContext(
+  result: Civ7ControlOrpcDiplomacyResponseResult,
+  options: Partial<{ approved: boolean; playable: boolean }> = {},
+): {
+  calls: {
+    readiness: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+    request: Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+      approval: Civ7ControlOrpcContext["approval"];
+    }>>;
+  };
+  context: Civ7ControlOrpcContext;
+} {
+  const calls = {
+    readiness: [] as Array<Civ7ControlOrpcContext["endpointDefaults"]>,
+    request: [] as Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+      approval: Civ7ControlOrpcContext["approval"];
+    }>>,
+  };
+
+  return {
+    calls,
+    context: {
+      approval: options.approved === false
+        ? undefined
+        : { approved: true, reason: "local diplomacy response proof" },
+      endpointDefaults: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      directControl: {
+        getCiv7PlayableStatus: async (endpointDefaults) => {
+          calls.readiness.push(endpointDefaults);
+          return playableStatusResult(options.playable ?? true);
+        },
+        requestCiv7DiplomacyResponse: async (input, endpointDefaults, approval) => {
+          calls.request.push({ input, options: endpointDefaults, approval });
+          return result;
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function diplomacyResponseResult(
+  classification: Civ7ControlOrpcDiplomacyResponseResult["postcondition"]["classification"],
+  options: Partial<{
+    sent: boolean;
+    beforeValid: boolean;
+    afterValid: boolean;
+    verified: boolean;
+  }> = {},
+): Civ7ControlOrpcDiplomacyResponseResult {
+  const sent = options.sent ?? classification !== "not-sent";
+  return {
+    before: {} as Civ7ControlOrpcDiplomacyResponseResult["before"],
+    beforeValidation: {
+      valid: options.beforeValid ?? classification !== "not-sent",
+      result: {},
+    } as Civ7ControlOrpcDiplomacyResponseResult["beforeValidation"],
+    command: sent
+      ? ({
+          host: "127.0.0.1",
+          port: 4318,
+          state: { id: "65535", name: "App UI" },
+          output: "Game.PlayerOperations.sendRequest should remain hidden",
+        } as unknown as Civ7ControlOrpcDiplomacyResponseResult["command"])
+      : undefined,
+    payload: sent
+      ? ({
+          sent: true,
+          rawCommand: "Game.PlayerOperations.sendRequest",
+        } as unknown as Civ7ControlOrpcDiplomacyResponseResult["payload"])
+      : undefined,
+    after: {} as Civ7ControlOrpcDiplomacyResponseResult["after"],
+    afterValidation: {
+      valid: options.afterValid ?? false,
+      result: {},
+    } as Civ7ControlOrpcDiplomacyResponseResult["afterValidation"],
+    sent,
+    verified: options.verified ?? (
+      classification !== "not-sent" && classification !== "no-state-change"
+    ),
+    postcondition: {
+      classification,
+      reason: `${classification} reason`,
+    },
+  };
+}
+
+function playableStatusResult(playable: boolean): Civ7ControlOrpcPlayableStatusResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    playable,
+    readiness: playable ? "tuner-ready" : "shell",
+    appUi: {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      snapshot: {
+        ui: {
+          inGame: { ok: true, value: playable },
+          inShell: { ok: true, value: !playable },
+          inLoading: { ok: true, value: false },
+          canBeginGame: { ok: true, value: false },
+        },
+        errors: [],
+      },
+    },
+    tuner: {
+      host: "127.0.0.1",
+      port: 4318,
+      ready: playable,
+      states: [],
+      errors: [],
+    },
+    errors: [],
+  };
+}

--- a/packages/civ7-control-orpc/test/decisions-narrative-choice-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/decisions-narrative-choice-procedure.test.ts
@@ -1,0 +1,387 @@
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  Civ7NarrativeChoiceUnavailableError,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+  type Civ7ControlOrpcPlayableStatusResult,
+} from "../src/index";
+import type { Civ7ControlOrpcNarrativeChoiceResult } from "../src/dependencies/direct-control";
+
+const narrativeInput = {
+  playerId: 0,
+  targetType: "DISCOVERY_STORY",
+  target: { owner: 0, id: 7_001, type: 12 },
+  action: 1,
+} as const;
+
+describe("decisions.narrative.choice.request control-oRPC procedure", () => {
+  test("projects confirmed narrative choices without raw command output", async () => {
+    const fake = fakeContext(narrativeChoiceResult("narrative-blocker-cleared"));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.decisions.narrative.choice.request,
+      narrativeInput,
+      { context: fake.context },
+    );
+
+    expect(fake.calls.readiness).toHaveLength(1);
+    expect(fake.calls.request).toEqual([{
+      input: narrativeInput,
+      options: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      approval: {
+        approved: true,
+        reason: "local narrative choice proof",
+      },
+    }]);
+    expect(result).toEqual({
+      playerId: 0,
+      targetType: "DISCOVERY_STORY",
+      target: { owner: 0, id: 7_001, type: 12 },
+      action: 1,
+      sent: true,
+      status: "sent-confirmed",
+      validation: {
+        beforeValid: true,
+        afterValid: false,
+      },
+      postcondition: {
+        classification: "narrative-blocker-cleared",
+        reason: "narrative-blocker-cleared reason",
+        outcome: "cleared",
+        confidence: "confirmed",
+        confirmed: true,
+        noRepeatAfterUnverified: false,
+      },
+      nextSteps: [{
+        kind: "refresh-attention",
+        source: "decisions.narrative.choice.request",
+        label: "Refresh current attention before choosing the next player action.",
+      }],
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"command\"");
+    expect(serialized).not.toContain("\"payload\"");
+    expect(serialized).not.toContain("\"verified\"");
+    expect(serialized).not.toContain("Game.turn");
+  });
+
+  test("keeps sent no-state-change narrative choices no-repeat guarded", async () => {
+    const fake = fakeContext(narrativeChoiceResult("no-state-change", {
+      afterValid: true,
+      verified: true,
+    }));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.decisions.narrative.choice.request,
+      narrativeInput,
+      { context: fake.context },
+    );
+
+    expect(result.status).toBe("sent-unverified");
+    expect(result.postcondition).toMatchObject({
+      classification: "no-state-change",
+      outcome: "no-state-change",
+      confidence: "unverified",
+      confirmed: false,
+      noRepeatAfterUnverified: true,
+    });
+    expect(result.nextSteps).toEqual([{
+      kind: "do-not-repeat",
+      source: "decisions.narrative.choice.request",
+      label: "Do not repeat this narrative choice request until fresh attention and narrative evidence is read.",
+    }]);
+  });
+
+  test("projects validator-blocked narrative choices as not-sent", async () => {
+    const fake = fakeContext(narrativeChoiceResult("not-sent", {
+      sent: false,
+      beforeValid: false,
+      afterValid: false,
+      verified: false,
+    }));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.decisions.narrative.choice.request,
+      narrativeInput,
+      { context: fake.context },
+    );
+
+    expect(result).toMatchObject({
+      sent: false,
+      status: "not-sent",
+      validation: {
+        beforeValid: false,
+        afterValid: false,
+      },
+      postcondition: {
+        classification: "not-sent",
+        outcome: "not-sent",
+        confidence: "unverified",
+        noRepeatAfterUnverified: true,
+      },
+    });
+    expect(result.nextSteps).toEqual([{
+      kind: "inspect-narrative-choice",
+      source: "decisions.narrative.choice.request",
+      label: "Inspect current attention and narrative choice state before attempting another narrative request.",
+    }]);
+  });
+
+  test("requires approval before readiness or request execution", async () => {
+    const fake = fakeContext(narrativeChoiceResult("narrative-blocker-cleared"), {
+      approved: false,
+    });
+
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.decisions.narrative.choice.request,
+        narrativeInput,
+        { context: fake.context },
+      ),
+    ).rejects.toMatchObject({
+      code: "MUTATION_APPROVAL_REQUIRED",
+      data: {
+        procedureKey: "decisions.narrative.choice.request",
+        source: "context.approval",
+        risk: "mutation",
+      },
+    });
+    expect(fake.calls.readiness).toEqual([]);
+    expect(fake.calls.request).toEqual([]);
+  });
+
+  test("keeps endpoint/session/state/raw command fields out of procedure input", async () => {
+    const invalidInputs = [
+      { ...narrativeInput, host: "127.0.0.1" },
+      { ...narrativeInput, port: 4318 },
+      { ...narrativeInput, state: { role: "tuner" } },
+      { ...narrativeInput, session: { state: "Tuner" } },
+      { ...narrativeInput, command: "Game.turn" },
+      { ...narrativeInput, rawCommand: "Game.turn" },
+    ];
+
+    for (const input of invalidInputs) {
+      const fake = fakeContext(narrativeChoiceResult("narrative-blocker-cleared"));
+
+      await expect(
+        call(
+          Civ7ControlOrpcRouter.decisions.narrative.choice.request,
+          input as never,
+          { context: fake.context },
+        ),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(fake.calls.readiness).toEqual([]);
+      expect(fake.calls.request).toEqual([]);
+    }
+  });
+
+  test("maps source failures to a tagged Effect/oRPC error without raw details", async () => {
+    const context = fakeContext(narrativeChoiceResult("narrative-blocker-cleared")).context;
+    const failingContext: Civ7ControlOrpcContext = {
+      ...context,
+      directControl: {
+        ...context.directControl,
+        requestCiv7NarrativeChoice: async () => {
+          throw new Error(
+            "Timed out waiting for Civ7 tuner response to CMD:1:Game.turn",
+          );
+        },
+      },
+    };
+
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.decisions.narrative.choice.request,
+        narrativeInput,
+        { context: failingContext },
+      ),
+    ).rejects.toMatchObject({
+      code: "NARRATIVE_CHOICE_UNAVAILABLE",
+      status: 503,
+      data: {
+        procedureKey: "decisions.narrative.choice.request",
+        source: "direct-control-facade",
+      },
+    });
+
+    try {
+      await call(
+        Civ7ControlOrpcRouter.decisions.narrative.choice.request,
+        narrativeInput,
+        { context: failingContext },
+      );
+    } catch (err) {
+      const serialized = JSON.stringify(err);
+      expect(serialized).not.toContain("CMD");
+      expect(serialized).not.toContain("Game.turn");
+      expect(serialized).not.toContain("rawCommand");
+      expect(serialized).not.toContain("command-failed");
+    }
+  });
+
+  test("supports the in-process server-side router client", async () => {
+    const fake = fakeContext(narrativeChoiceResult("narrative-panel-cleared"));
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    const result = await client.decisions.narrative.choice.request(narrativeInput);
+
+    expect(result.status).toBe("sent-confirmed");
+    expect(result.postcondition.outcome).toBe("state-changed");
+  });
+
+  test("publishes a contract-first narrative decision service leaf", () => {
+    expect(
+      Civ7ControlOrpcContract.decisions.narrative.choice.request["~orpc"],
+    ).toMatchObject({
+      meta: {
+        family: "decisions",
+        procedureKey: "decisions.narrative.choice.request",
+        proofBoundary: "local-package-test",
+        risk: "mutation",
+      },
+    });
+    expect(
+      Civ7ControlOrpcContract.decisions.narrative.choice.request["~orpc"].errorMap,
+    ).toHaveProperty("NARRATIVE_CHOICE_UNAVAILABLE");
+    expect(Civ7NarrativeChoiceUnavailableError.code).toBe(
+      "NARRATIVE_CHOICE_UNAVAILABLE",
+    );
+  });
+});
+
+function fakeContext(
+  result: Civ7ControlOrpcNarrativeChoiceResult,
+  options: Partial<{ approved: boolean; playable: boolean }> = {},
+): {
+  calls: {
+    readiness: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+    request: Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+      approval: Civ7ControlOrpcContext["approval"];
+    }>>;
+  };
+  context: Civ7ControlOrpcContext;
+} {
+  const calls = {
+    readiness: [] as Array<Civ7ControlOrpcContext["endpointDefaults"]>,
+    request: [] as Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+      approval: Civ7ControlOrpcContext["approval"];
+    }>>,
+  };
+
+  return {
+    calls,
+    context: {
+      approval: options.approved === false
+        ? undefined
+        : { approved: true, reason: "local narrative choice proof" },
+      endpointDefaults: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      directControl: {
+        getCiv7PlayableStatus: async (endpointDefaults) => {
+          calls.readiness.push(endpointDefaults);
+          return playableStatusResult(options.playable ?? true);
+        },
+        requestCiv7NarrativeChoice: async (input, endpointDefaults, approval) => {
+          calls.request.push({ input, options: endpointDefaults, approval });
+          return result;
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function narrativeChoiceResult(
+  classification: Civ7ControlOrpcNarrativeChoiceResult["postcondition"]["classification"],
+  options: Partial<{
+    sent: boolean;
+    beforeValid: boolean;
+    afterValid: boolean;
+    verified: boolean;
+  }> = {},
+): Civ7ControlOrpcNarrativeChoiceResult {
+  const sent = options.sent ?? classification !== "not-sent";
+  return {
+    before: {} as Civ7ControlOrpcNarrativeChoiceResult["before"],
+    beforeValidation: {
+      valid: options.beforeValid ?? classification !== "not-sent",
+      result: {},
+    } as Civ7ControlOrpcNarrativeChoiceResult["beforeValidation"],
+    command: sent
+      ? ({
+          host: "127.0.0.1",
+          port: 4318,
+          state: { id: "65535", name: "App UI" },
+          output: "Game.turn should remain hidden",
+        } as unknown as Civ7ControlOrpcNarrativeChoiceResult["command"])
+      : undefined,
+    payload: sent
+      ? ({
+          sent: true,
+          rawCommand: "Game.turn",
+        } as unknown as Civ7ControlOrpcNarrativeChoiceResult["payload"])
+      : undefined,
+    after: {} as Civ7ControlOrpcNarrativeChoiceResult["after"],
+    afterValidation: {
+      valid: options.afterValid ?? false,
+      result: {},
+    } as Civ7ControlOrpcNarrativeChoiceResult["afterValidation"],
+    sent,
+    verified: options.verified ?? (
+      classification !== "not-sent" && classification !== "no-state-change"
+    ),
+    postcondition: {
+      classification,
+      reason: `${classification} reason`,
+    },
+  };
+}
+
+function playableStatusResult(playable: boolean): Civ7ControlOrpcPlayableStatusResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    playable,
+    readiness: playable ? "tuner-ready" : "shell",
+    appUi: {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      snapshot: {
+        ui: {
+          inGame: { ok: true, value: playable },
+          inShell: { ok: true, value: !playable },
+          inLoading: { ok: true, value: false },
+          canBeginGame: { ok: true, value: false },
+        },
+        errors: [],
+      },
+    },
+    tuner: {
+      host: "127.0.0.1",
+      port: 4318,
+      ready: playable,
+      states: [],
+      errors: [],
+    },
+    errors: [],
+  };
+}

--- a/packages/civ7-control-orpc/test/mutation-result-policy.test.ts
+++ b/packages/civ7-control-orpc/test/mutation-result-policy.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  civ7MutationPostconditionSummary,
+  civ7MutationRequestStatusWithoutGuarded,
+} from "../src/policy/mutation-result";
+
+describe("control-oRPC mutation result policy", () => {
+  test("keeps missing postcondition summaries no-repeat guarded", () => {
+    const postcondition = civ7MutationPostconditionSummary({
+      postcondition: null,
+      missing: {
+        classification: "missing-postcondition",
+        reason: "No explicit postcondition evidence was returned.",
+        outcome: "unknown",
+      },
+    });
+
+    expect(postcondition).toEqual({
+      classification: "missing-postcondition",
+      reason: "No explicit postcondition evidence was returned.",
+      outcome: "unknown",
+      confidence: "unverified",
+      confirmed: false,
+      noRepeatAfterUnverified: true,
+    });
+    expect(civ7MutationRequestStatusWithoutGuarded({
+      sent: true,
+      postcondition,
+    })).toBe("sent-unverified");
+  });
+
+  test("does not treat pending runtime proof as confirmed or repeat-safe", () => {
+    const postcondition = civ7MutationPostconditionSummary({
+      postcondition: {
+        classification: "pending-runtime-proof",
+        reason: "Live runtime proof has not been collected.",
+        outcome: "unknown",
+        confidence: "pending-runtime-proof",
+        noRepeatAfterUnverified: true,
+      },
+      missing: {
+        classification: "missing-postcondition",
+        reason: "No explicit postcondition evidence was returned.",
+        outcome: "unknown",
+      },
+    });
+
+    expect(postcondition).toEqual({
+      classification: "pending-runtime-proof",
+      reason: "Live runtime proof has not been collected.",
+      outcome: "unknown",
+      confidence: "pending-runtime-proof",
+      confirmed: false,
+      noRepeatAfterUnverified: true,
+    });
+    expect(civ7MutationRequestStatusWithoutGuarded({
+      sent: true,
+      postcondition,
+    })).toBe("sent-unverified");
+  });
+
+  test("marks only confirmed unguarded postconditions as confirmed", () => {
+    const postcondition = civ7MutationPostconditionSummary({
+      postcondition: {
+        classification: "blocker-cleared",
+        reason: "The blocker was cleared.",
+        outcome: "cleared",
+        confidence: "confirmed",
+        noRepeatAfterUnverified: false,
+      },
+      missing: {
+        classification: "missing-postcondition",
+        reason: "No explicit postcondition evidence was returned.",
+        outcome: "unknown",
+      },
+    });
+
+    expect(postcondition).toMatchObject({
+      confidence: "confirmed",
+      confirmed: true,
+      noRepeatAfterUnverified: false,
+    });
+    expect(civ7MutationRequestStatusWithoutGuarded({
+      sent: true,
+      postcondition,
+    })).toBe("sent-confirmed");
+  });
+});

--- a/packages/civ7-control-orpc/test/strategy-front-summary-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/strategy-front-summary-procedure.test.ts
@@ -1,0 +1,405 @@
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  Civ7StrategyFrontSummaryUnavailableError,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+} from "../src/index";
+import type {
+  Civ7ControlOrpcBattlefieldScanResult,
+  Civ7ControlOrpcTargetCandidatesResult,
+} from "../src/dependencies/direct-control";
+
+describe("strategy.frontSummary control-oRPC procedure", () => {
+  test("composes target candidates and battlefield scan into a neutral planning view", async () => {
+    const fake = fakeContext({
+      targetCandidates: targetCandidatesResult(),
+      battlefieldScan: battlefieldScanResult(),
+    });
+
+    const result = await call(Civ7ControlOrpcRouter.strategy.frontSummary, {
+      playerId: 0,
+      origins: [{ x: 10, y: 20 }],
+      candidateLimit: 3,
+      scanRadius: 6,
+      maxPlayers: 12,
+    }, {
+      context: fake.context,
+    });
+
+    expect(fake.calls).toEqual({
+      targetCandidates: [{
+        input: {
+          playerId: 0,
+          origins: [{ x: 10, y: 20 }],
+          maxCandidates: 3,
+          maxPlayers: 12,
+          unitRadius: 6,
+        },
+        options: {
+          host: "127.0.0.1",
+          port: 4318,
+          timeoutMs: 1_000,
+        },
+      }],
+      battlefieldScan: [{
+        input: {
+          playerId: 0,
+          origins: [{ x: 10, y: 20 }],
+          radius: 6,
+          maxPlayers: 12,
+          maxUnits: 48,
+          maxCities: 24,
+        },
+        options: {
+          host: "127.0.0.1",
+          port: 4318,
+          timeoutMs: 1_000,
+        },
+      }],
+    });
+    expect(result).toMatchObject({
+      playerId: 0,
+      localPlayerId: 0,
+      origins: [{ x: 10, y: 20 }],
+      sourceStatus: {
+        targetCandidates: "read",
+        battlefieldScan: "read",
+      },
+      relationshipLabelPolicy: {
+        relationshipSource: "not-classified",
+        relationshipProof: "none",
+        unprovenLabel: "relationship-unproven",
+      },
+      summary: {
+        targetCandidateCount: 1,
+        pointOfInterestCount: 1,
+        observedOwnerCount: 2,
+        nextStepCount: 4,
+      },
+    });
+    expect(result.targetCandidates).toEqual([{
+      owner: 1,
+      relationship: "relationship-unproven",
+      relationshipProof: "none",
+      nearestDistance: 5,
+      cityCount: 1,
+      unitCount: 3,
+      nearbyUnitCount: 2,
+      apparentStrength: 17.5,
+      routeKind: "land",
+      routeHint: "near",
+      reasons: ["nearest target distance 5"],
+    }]);
+    expect(result.pointsOfInterest).toEqual([{
+      kind: "nearby-other-owners",
+      severity: "medium",
+      location: { x: 11, y: 21 },
+      summary: "2 other-owner units within 3 tiles of an origin",
+    }]);
+    expect(result.observedOwners).toEqual([
+      {
+        owner: 0,
+        relationship: "self",
+        relationshipProof: "self",
+        unitCount: 1,
+        cityCount: 1,
+        apparentStrength: 12,
+        nearestDistance: 0,
+      },
+      {
+        owner: 1,
+        relationship: "relationship-unproven",
+        relationshipProof: "none",
+        unitCount: 2,
+        cityCount: 1,
+        apparentStrength: 20,
+        nearestDistance: 2,
+      },
+    ]);
+    expect(result.nextSteps.map((step) => step.kind)).toEqual([
+      "inspect-target-candidate",
+      "inspect-battlefield-point",
+      "read-visibility",
+      "validate-unit-action",
+    ]);
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("Game.turn");
+    expect(serialized).not.toContain("rawCommand");
+    expect(serialized).not.toContain("enemy");
+    expect(serialized).not.toContain("hostile");
+    expect(serialized).not.toContain("opponent");
+    expect(serialized).not.toContain("threat");
+    expect(serialized).not.toContain("war");
+    expect(serialized).not.toContain("ally");
+    expect(serialized).not.toContain("suzerain");
+  });
+
+  test("supports the in-process server-side router client", async () => {
+    const fake = fakeContext({
+      targetCandidates: targetCandidatesResult({ candidates: [] }),
+      battlefieldScan: battlefieldScanResult({
+        owners: [],
+        pointsOfInterest: [],
+      }),
+    });
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    const result = await client.strategy.frontSummary({});
+
+    expect(result.summary).toMatchObject({
+      targetCandidateCount: 0,
+      pointOfInterestCount: 0,
+      observedOwnerCount: 0,
+    });
+    expect(result.nextSteps).toEqual([{
+      kind: "observe",
+      source: "strategy.frontSummary",
+      label: "No front planning evidence found; refresh attention or narrow the scan origins.",
+    }]);
+  });
+
+  test("keeps endpoint/session/state/raw command fields out of procedure input", async () => {
+    const invalidInputs = [
+      { host: "127.0.0.1" },
+      { port: 4318 },
+      { state: { role: "tuner" } },
+      { session: { state: "Tuner" } },
+      { command: "Game.turn" },
+      { rawCommand: "Game.turn" },
+    ];
+
+    for (const input of invalidInputs) {
+      const fake = fakeContext({
+        targetCandidates: targetCandidatesResult(),
+        battlefieldScan: battlefieldScanResult(),
+      });
+
+      await expect(
+        call(Civ7ControlOrpcRouter.strategy.frontSummary, input as never, {
+          context: fake.context,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(fake.calls).toEqual({
+        targetCandidates: [],
+        battlefieldScan: [],
+      });
+    }
+  });
+
+  test("maps source read failures to a tagged Effect/oRPC error without raw details", async () => {
+    const context: Civ7ControlOrpcContext = {
+      directControl: {
+        getCiv7TargetCandidates: async () => {
+          throw new Error(
+            "Timed out waiting for Civ7 tuner response to CMD:1:Game.turn",
+          );
+        },
+        getCiv7BattlefieldScan: async () => battlefieldScanResult(),
+      } as Civ7ControlOrpcContext["directControl"],
+    };
+
+    await expect(
+      call(Civ7ControlOrpcRouter.strategy.frontSummary, {}, { context }),
+    ).rejects.toMatchObject({
+      code: "STRATEGY_FRONT_SUMMARY_UNAVAILABLE",
+      status: 503,
+      data: {
+        procedureKey: "strategy.frontSummary",
+        source: "direct-control-facade",
+      },
+    });
+
+    try {
+      await call(Civ7ControlOrpcRouter.strategy.frontSummary, {}, { context });
+    } catch (err) {
+      const serialized = JSON.stringify(err);
+      expect(serialized).not.toContain("CMD");
+      expect(serialized).not.toContain("Game.turn");
+      expect(serialized).not.toContain("rawCommand");
+      expect(serialized).not.toContain("command-failed");
+    }
+  });
+
+  test("publishes a contract-first strategy.frontSummary service leaf", () => {
+    expect(Civ7ControlOrpcContract.strategy.frontSummary["~orpc"]).toMatchObject({
+      meta: {
+        family: "strategy",
+        procedureKey: "strategy.frontSummary",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      },
+    });
+    expect(
+      Civ7ControlOrpcContract.strategy.frontSummary["~orpc"].errorMap,
+    ).toHaveProperty("STRATEGY_FRONT_SUMMARY_UNAVAILABLE");
+    expect(Civ7StrategyFrontSummaryUnavailableError.code).toBe(
+      "STRATEGY_FRONT_SUMMARY_UNAVAILABLE",
+    );
+  });
+});
+
+function fakeContext(
+  results: Readonly<{
+    targetCandidates: Civ7ControlOrpcTargetCandidatesResult;
+    battlefieldScan: Civ7ControlOrpcBattlefieldScanResult;
+  }>,
+): {
+  calls: {
+    targetCandidates: Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>;
+    battlefieldScan: Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>;
+  };
+  context: Civ7ControlOrpcContext;
+} {
+  const calls = {
+    targetCandidates: [] as Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>,
+    battlefieldScan: [] as Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>,
+  };
+
+  return {
+    calls,
+    context: {
+      endpointDefaults: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      directControl: {
+        getCiv7TargetCandidates: async (input, options) => {
+          calls.targetCandidates.push({ input, options });
+          return results.targetCandidates;
+        },
+        getCiv7BattlefieldScan: async (input, options) => {
+          calls.battlefieldScan.push({ input, options });
+          return results.battlefieldScan;
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function targetCandidatesResult(
+  overrides: Partial<Civ7ControlOrpcTargetCandidatesResult> = {},
+): Civ7ControlOrpcTargetCandidatesResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    playerId: 0,
+    origins: [{ x: 10, y: 20 }],
+    unitRadius: 6,
+    hiddenInfoPolicy: "runtime-debug-summary",
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "neutral",
+    },
+    candidates: [{
+      owner: 1,
+      leaderName: { ok: true, value: "Leader" },
+      civilizationName: { ok: true, value: "Civilization" },
+      isHuman: { ok: true, value: false },
+      cityCount: 1,
+      unitCount: 3,
+      cities: [],
+      nearestCity: null,
+      nearestDistance: 5,
+      nearbyUnits: [],
+      nearbyUnitCount: 2,
+      apparentStrength: 17.5,
+      approach: {
+        nearestOrigin: { x: 10, y: 20 },
+        targetLocation: { x: 15, y: 20 },
+        directGridDistance: 5,
+        routeHint: "near",
+        routeKind: "land",
+        originWater: null,
+        targetWater: null,
+        waterSampleCount: 0,
+        landSampleCount: 4,
+        notes: ["Use validators before sends."],
+      },
+      reasons: ["nearest target distance 5"],
+    }],
+    notes: ["Target candidates are planning support."],
+    ...overrides,
+  };
+}
+
+function battlefieldScanResult(
+  overrides: Partial<Civ7ControlOrpcBattlefieldScanResult> = {},
+): Civ7ControlOrpcBattlefieldScanResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    playerId: 0,
+    origins: [{ x: 10, y: 20 }],
+    radius: 6,
+    hiddenInfoPolicy: "runtime-debug-summary",
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "neutral",
+    },
+    units: [],
+    cities: [],
+    owners: [
+      {
+        owner: 0,
+        stance: "friendly",
+        relationshipProof: "self",
+        relationshipLabel: "friendly",
+        unitCount: 1,
+        cityCount: 1,
+        roles: {},
+        apparentStrength: 12,
+        nearestUnit: { distance: 0 },
+        nearestCity: null,
+      },
+      {
+        owner: 1,
+        stance: "other",
+        relationshipProof: "none",
+        relationshipLabel: "relationship-unproven",
+        unitCount: 2,
+        cityCount: 1,
+        roles: {},
+        apparentStrength: 20,
+        nearestUnit: { distance: 2 },
+        nearestCity: { distance: 4 },
+      },
+    ],
+    pointsOfInterest: [{
+      kind: "nearby-other-owners",
+      severity: "medium",
+      location: { x: 11, y: 21 },
+      summary: "2 other-owner units within 3 tiles of an origin",
+    }],
+    notes: ["Battlefield scan is read-only."],
+    ...overrides,
+  };
+}

--- a/packages/civ7-control-orpc/tsconfig.json
+++ b/packages/civ7-control-orpc/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.plugins.json",
   "compilerOptions": {
+    "noEmit": false,
     "rootDir": "./src",
     "outDir": "./dist",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"

--- a/packages/civ7-control-orpc/tsup.config.ts
+++ b/packages/civ7-control-orpc/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  target: "esnext",
+  clean: true,
+  noExternal: ["effect-orpc"],
+});

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -1144,6 +1144,10 @@ export type {
   Civ7DiplomacyResponsePostcondition,
   Civ7DiplomacyResponsePostconditionClassification,
 } from "./play/operations/diplomacy-postconditions.js";
+export {
+  diplomacyResponseProofOutcome,
+  diplomacyResponseProofPostcondition,
+} from "./proof/diplomacy-response-proof-policy.js";
 export type {
   Civ7NarrativeChoiceCommandPayload,
   Civ7NarrativeChoiceInput,

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -1154,6 +1154,10 @@ export type {
   Civ7NarrativeChoicePostcondition,
   Civ7NarrativeChoicePostconditionClassification,
 } from "./play/operations/narrative-postconditions.js";
+export {
+  narrativeChoiceProofOutcome,
+  narrativeChoiceProofPostcondition,
+} from "./proof/narrative-choice-proof-policy.js";
 
 export { CIV7_SIGNED_INT_SEED_MAX, CIV7_SIGNED_INT_SEED_MIN, assessCiv7SignedIntSeed } from "./policy/setup.js";
 export const DEFAULT_CIV7_RESOURCE_FEASIBILITY_MAX_CELLS = 256;

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -41,6 +41,7 @@ import {
 import { executeSessionCommandWithReconnect } from "./session/reconnect.js";
 import {
   DEFAULT_CIV7_SCRIPTING_LOG,
+  logTextFromSnapshot,
   snapshotFile,
   waitForFreshLogMarkers,
   type FileSnapshot,
@@ -398,6 +399,7 @@ export { createCiv7ControlRequestId } from "./session/request-id.js";
 export { selectCiv7TunerState } from "./session/state.js";
 export {
   DEFAULT_CIV7_SCRIPTING_LOG,
+  logTextFromSnapshot,
   snapshotFile,
   waitForFreshLogMarkers,
 } from "./proof/log-markers.js";

--- a/packages/civ7-direct-control/src/proof/diplomacy-response-proof-policy.ts
+++ b/packages/civ7-direct-control/src/proof/diplomacy-response-proof-policy.ts
@@ -1,10 +1,10 @@
-import type { Civ7DiplomacyResponseResult } from "../play/operations/diplomacy-request";
-import type { Civ7DiplomacyResponsePostconditionClassification } from "../play/operations/diplomacy-postconditions";
+import type { Civ7DiplomacyResponseResult } from "../play/operations/diplomacy-request.js";
+import type { Civ7DiplomacyResponsePostconditionClassification } from "../play/operations/diplomacy-postconditions.js";
 import type {
   Civ7OperationProofBoundary,
   Civ7OperationTelemetryPostcondition,
   Civ7OperationTelemetryPostconditionOutcome,
-} from "./operation-telemetry";
+} from "./operation-telemetry.js";
 
 export function diplomacyResponseProofPostcondition(
   result: Civ7DiplomacyResponseResult,

--- a/packages/civ7-direct-control/src/proof/diplomacy-response-telemetry.ts
+++ b/packages/civ7-direct-control/src/proof/diplomacy-response-telemetry.ts
@@ -8,13 +8,13 @@ import {
   type Civ7OperationTelemetryEvidencePolicy,
   type Civ7OperationTelemetryObservationLink,
   type Civ7OperationTelemetryPlayerScope,
-} from "./operation-telemetry";
-import { diplomacyResponseProofPostcondition } from "./diplomacy-response-proof-policy";
+} from "./operation-telemetry.js";
+import { diplomacyResponseProofPostcondition } from "./diplomacy-response-proof-policy.js";
 
 import type {
   Civ7DiplomacyResponseInput,
   Civ7DiplomacyResponseResult,
-} from "../play/operations/diplomacy-request";
+} from "../play/operations/diplomacy-request.js";
 
 export type Civ7DiplomacyResponseTelemetryAdapterInput = Readonly<{
   input: Civ7DiplomacyResponseInput;

--- a/packages/civ7-direct-control/src/proof/log-markers.ts
+++ b/packages/civ7-direct-control/src/proof/log-markers.ts
@@ -59,7 +59,7 @@ async function filePrefixSnapshot(path: string, size: number): Promise<Pick<File
   }
 }
 
-function logTextFromSnapshot(args: {
+export function logTextFromSnapshot(args: {
   fullText: string;
   snapshot: FileSnapshot;
   current: FileSnapshot;

--- a/packages/civ7-direct-control/src/proof/narrative-choice-proof-policy.ts
+++ b/packages/civ7-direct-control/src/proof/narrative-choice-proof-policy.ts
@@ -1,10 +1,10 @@
-import type { Civ7NarrativeChoiceResult } from "../play/operations/narrative-request";
-import type { Civ7NarrativeChoicePostconditionClassification } from "../play/operations/narrative-postconditions";
+import type { Civ7NarrativeChoiceResult } from "../play/operations/narrative-request.js";
+import type { Civ7NarrativeChoicePostconditionClassification } from "../play/operations/narrative-postconditions.js";
 import type {
   Civ7OperationProofBoundary,
   Civ7OperationTelemetryPostcondition,
   Civ7OperationTelemetryPostconditionOutcome,
-} from "./operation-telemetry";
+} from "./operation-telemetry.js";
 
 export function narrativeChoiceProofPostcondition(
   result: Civ7NarrativeChoiceResult,

--- a/packages/civ7-direct-control/src/proof/narrative-choice-telemetry.ts
+++ b/packages/civ7-direct-control/src/proof/narrative-choice-telemetry.ts
@@ -8,13 +8,13 @@ import {
   type Civ7OperationTelemetryEvidencePolicy,
   type Civ7OperationTelemetryObservationLink,
   type Civ7OperationTelemetryPlayerScope,
-} from "./operation-telemetry";
-import { narrativeChoiceProofPostcondition } from "./narrative-choice-proof-policy";
+} from "./operation-telemetry.js";
+import { narrativeChoiceProofPostcondition } from "./narrative-choice-proof-policy.js";
 
 import type {
   Civ7NarrativeChoiceInput,
   Civ7NarrativeChoiceResult,
-} from "../play/operations/narrative-request";
+} from "../play/operations/narrative-request.js";
 
 export type Civ7NarrativeChoiceTelemetryAdapterInput = Readonly<{
   input: Civ7NarrativeChoiceInput;

--- a/packages/civ7-direct-control/test/diplomacy-response-proof-policy.test.ts
+++ b/packages/civ7-direct-control/test/diplomacy-response-proof-policy.test.ts
@@ -4,11 +4,11 @@ import {
   diplomacyResponsePostconditionConfirmed,
   diplomacyResponseProofOutcome,
   diplomacyResponseProofPostcondition,
-} from "../src/proof/diplomacy-response-proof-policy";
+} from "../src/proof/diplomacy-response-proof-policy.js";
 
-import type { Civ7DiplomacyResponseResult } from "../src/play/operations/diplomacy-request";
-import type { Civ7DiplomacyResponsePostconditionClassification } from "../src/play/operations/diplomacy-postconditions";
-import type { Civ7OperationTelemetryPostconditionOutcome } from "../src/proof/operation-telemetry";
+import type { Civ7DiplomacyResponseResult } from "../src/play/operations/diplomacy-request.js";
+import type { Civ7DiplomacyResponsePostconditionClassification } from "../src/play/operations/diplomacy-postconditions.js";
+import type { Civ7OperationTelemetryPostconditionOutcome } from "../src/proof/operation-telemetry.js";
 
 type DiplomacyResponseProofCase = Readonly<{
   classification: Civ7DiplomacyResponsePostconditionClassification;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@civ7/config": "workspace:*",
+    "@civ7/control-orpc": "workspace:*",
     "@civ7/direct-control": "workspace:*",
     "@civ7/plugin-files": "workspace:*",
     "@civ7/plugin-git": "workspace:*",

--- a/packages/cli/src/commands/game/status.ts
+++ b/packages/cli/src/commands/game/status.ts
@@ -1,11 +1,15 @@
 import { Command, Flags } from '@oclif/core';
-import { getCiv7PlayableStatus } from '@civ7/direct-control';
+import {
+  createCiv7ControlOrpcServerClient,
+  liveCiv7ControlOrpcDirectControlFacade,
+} from '@civ7/control-orpc';
+import type { Civ7DirectControlOptions } from '@civ7/direct-control';
 
 export default class GameStatus extends Command {
   static id = 'game status';
   static summary = 'Report Civ7 App UI and Tuner readiness';
   static description =
-    'Composes App UI lifecycle status and Tuner gameplay readiness through @civ7/direct-control.';
+    'Reports service-owned Civ7 readiness through the in-process control-oRPC router.';
 
   static examples = [
     '<%= config.bin %> game status --json',
@@ -31,11 +35,16 @@ export default class GameStatus extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(GameStatus);
-    const status = await getCiv7PlayableStatus({
+    const endpointDefaults: Civ7DirectControlOptions = {
       host: flags.host,
       port: flags.port,
       timeoutMs: flags['timeout-ms'],
+    };
+    const client = createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults,
     });
+    const status = await client.readiness.current({});
 
     if (flags.json) {
       this.log(JSON.stringify({ ok: status.playable, status }));
@@ -43,8 +52,8 @@ export default class GameStatus extends Command {
     }
 
     this.log(`Civ7 readiness: ${status.readiness}`);
-    this.log(`Direct tuner socket: ${status.host}:${status.port}`);
-    this.log(`Tuner gameplay APIs: ${status.tuner?.ready ? 'ready' : 'not ready'}`);
-    this.log(`App UI loading state: ${status.appUi.snapshot.ui.loadingStateName ?? '<unknown>'}`);
+    this.log(`Observe: ${status.capability.canObserve ? 'ready' : 'not ready'}`);
+    this.log(`Mutate: ${status.capability.canMutate ? 'ready' : 'not ready'}`);
+    this.log(`Next: ${status.nextSteps[0]?.label ?? 'No next step available.'}`);
   }
 }

--- a/packages/cli/test/commands/game.control.test.ts
+++ b/packages/cli/test/commands/game.control.test.ts
@@ -395,76 +395,57 @@ describe('game direct-control commands', () => {
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
         status: {
-          host: string;
-          port: number;
           playable: true;
           readiness: string;
-          errors: string[];
-          appUi: {
-            host: string;
-            port: number;
-            state: { id: string; name: string };
-            snapshot: {
-              network: { isInSession: { ok: true; value: boolean } };
-              ui: { loadingStateName: string; canBeginGame: { ok: true; value: boolean } };
-              gameContext: { localPlayerID: number };
-              players: { aliveHumanIds: { ok: true; value: number[] } };
-              map: { width: { ok: true; value: number }; height: { ok: true; value: number } };
-            };
+          capability: {
+            canObserve: boolean;
+            canMutate: boolean;
+            reason: string;
           };
-          tuner: {
-            host: string;
-            port: number;
-            state: { id: string; name: string };
-            ready: true;
-            snapshot: {
-              ready: true;
-              globals: Record<string, string>;
-              turnDate: { ok: true; value: string };
+          sources: {
+            gameUi: {
+              inGame: true;
+              inShell: false;
+              inLoading: false;
+              canBeginGame: true;
             };
+            runtimeControl: { ready: true };
           };
+          errorCount: number;
+          nextSteps: Array<{ kind: string; source: string; label: string }>;
         };
       };
       expect(payload).toMatchObject({
         ok: true,
         status: {
-          host: '127.0.0.1',
-          port,
           playable: true,
           readiness: 'tuner-ready',
-          errors: [],
+          capability: {
+            canObserve: true,
+            canMutate: true,
+          },
+          sources: {
+            gameUi: {
+              inGame: true,
+              inShell: false,
+              inLoading: false,
+              canBeginGame: true,
+            },
+            runtimeControl: { ready: true },
+          },
+          errorCount: 0,
+          nextSteps: [{
+            kind: 'read-attention',
+            source: 'readiness.current',
+          }],
         },
       });
-      expect(payload.status.appUi).toMatchObject({
-        host: '127.0.0.1',
-        port,
-        state: { id: '65535', name: 'App UI' },
-      });
-      expect(payload.status.appUi.snapshot).toMatchObject({
-        network: { isInSession: { ok: true, value: true } },
-        ui: { loadingStateName: 'WaitingForUIReady', canBeginGame: { ok: true, value: true } },
-        gameContext: { localPlayerID: 0 },
-        players: { aliveHumanIds: { ok: true, value: [0] } },
-        map: { width: { ok: true, value: 84 }, height: { ok: true, value: 54 } },
-      });
-      expect(payload.status.tuner).toMatchObject({
-        host: '127.0.0.1',
-        port,
-        state: { id: '1', name: 'Tuner' },
-        ready: true,
-        snapshot: {
-          ready: true,
-          globals: { Game: 'object', Network: 'undefined' },
-          turnDate: { ok: true, value: '4000 BCE' },
-        },
-      });
-      expectDebugProjectionFields(payload, [
-        { fieldClass: 'transport-session-state', path: ['status', 'host'] },
-        { fieldClass: 'transport-session-state', path: ['status', 'port'] },
-        { fieldClass: 'raw-probe', path: ['status', 'appUi', 'snapshot'] },
-        { fieldClass: 'raw-probe', path: ['status', 'tuner', 'snapshot', 'globals'] },
-        { fieldClass: 'correlation-diagnostic', path: ['status', 'errors'] },
-      ]);
+      expect(JSON.stringify(payload)).not.toContain('"host"');
+      expect(JSON.stringify(payload)).not.toContain('"port"');
+      expect(JSON.stringify(payload)).not.toContain('"state"');
+      expect(JSON.stringify(payload)).not.toContain('App UI');
+      expect(JSON.stringify(payload)).not.toContain('Tuner');
+      expect(JSON.stringify(payload)).not.toContain('globals');
     } finally {
       log.mockRestore();
       await server.close();


### PR DESCRIPTION
feat(cli): route game status through control-oRPC

Refs: openspec/changes/civ7-control-orpc-native-slice

Routes `civ7 game status` through the native in-process `readiness.current` server-side client. The CLI now constructs endpoint defaults as oRPC context, calls the service-owned readiness procedure, and emits the bounded semantic readiness projection instead of raw direct-control playable-status internals.

Adds an explicit CLI dependency on `@civ7/control-orpc` and makes that package build consumable by the CommonJS oclif manifest path by bundling `effect-orpc` and reliably emitting declaration files after clean builds.

OpenSpec records task 7.1/7.1.1 as the first CLI edge adapter while keeping Studio RPCLink, in-game bridge, OpenAPI, mutation CLI migration, runtime/live proof, and parent Task 5.x/6.x acceptance out of scope.

Proof:
- bun run --cwd packages/cli test game.control.test.ts
- bun run test:cli
- bun run test:cli:play
- bun run --cwd packages/cli check
- bun run check:cli
- bun run build:cli
- bun run --cwd packages/civ7-control-orpc test readiness-current-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check
- git diff --cached --check

feat(studio): add control-oRPC RPC link

Refs: openspec/changes/civ7-control-orpc-native-slice

Mounts the shared Civ7ControlOrpcRouter behind Studio's Vite Node middleware with native @orpc/server/node RPCHandler and adds a browser @orpc/client/fetch RPCLink client.

Routes the live footer readiness member through readiness.current as the authoritative readiness source while preserving the existing live REST aggregate for map summary and autoplay fields.

Proof:
- bun run --cwd apps/mapgen-studio test test/runInGame/civ7ControlOrpcClient.test.ts
- bun run --cwd apps/mapgen-studio test
- bun run --cwd apps/mapgen-studio check
- bun run --cwd apps/mapgen-studio build
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check
- git diff --cached --check

Local-only proof. No live Civ7 runtime proof, play-thread action, OpenAPI/external REST, global bridge, in-game controller ingress, custom RPCLink/RPCHandler plumbing, direct-control procedure-core scaffolding, or Task 5.x/6.x parent acceptance.

feat(control-orpc): add strategy front summary

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds a native strategy.frontSummary procedure in packages/civ7-control-orpc that composes target-candidate and battlefield-scan runtime/read ports into a service-owned planning projection.

Normal output excludes endpoint/session/state/raw command details and preserves relationship-unproven semantics for other-owner planning evidence. This is local package proof only: no runtime/live proof, no strategy catalog, no action authority, no transport or in-game bridge work, and no Task 5.x/6.x parent acceptance by implication.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/strategy-front-summary-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check
- git diff --cached --check

feat(control-orpc): add narrative decision procedure

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds decisions.narrative.choice.request as a native service-owned mutation procedure under the decisions router. The procedure reuses shared approval and playable-readiness middleware, calls the direct-control narrative choice runtime/proof port through context, and projects semantic status, validation, postcondition, and next-step output without raw command/session/payload/verified fields.

Exports the direct-control narrative proof helper from the package facade so control-oRPC consumes source-owned proof semantics instead of reimplementing postcondition truth.

Proof:
- bun run --cwd packages/civ7-direct-control test test/narrative-choice-proof-policy.test.ts
- bun run --cwd packages/civ7-direct-control check
- bun run --cwd packages/civ7-direct-control build
- bun run --cwd packages/civ7-control-orpc test test/decisions-narrative-choice-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check
- git diff --cached --check

Local package/OpenSpec proof only. No runtime/live-game proof, play-thread action, transport/CLI/Studio/bridge work, broad decisions catalog, direct-control procedure core, raw command tunnel, shared validator/postcondition middleware acceptance, or parent Task 5.x/6.x acceptance.

fix(studio): sanitize run-in-game public errors

Refs: openspec/changes/studio-run-in-game-robustness

Bounds Run in Game operation status errors so direct-control timeout/socket messages do not publish raw Tuner CMD/LSQ requests, JavaScript probes, command payloads, or state/session fields in public status or copyable diagnostics. Structured recovery evidence remains available through phase, failure class, direct-control code, completed phases, materialization, and reload details.

Proof:
- bun run --cwd apps/mapgen-studio test test/runInGame/operationState.test.ts
- bun run --cwd apps/mapgen-studio check
- bun run --cwd apps/mapgen-studio build
- bun run openspec -- validate studio-run-in-game-robustness --strict
- bun run openspec -- validate studio-operation-state-completion --strict
- git diff --check
- git diff --cached --check

Additional evidence: bun run --cwd apps/mapgen-studio test timed out once in test/browserRunner/standardLayerVisibility.test.ts, unrelated to Run in Game operation state; rerunning that single test passed.

No live/runtime proof, play-thread action, control-oRPC work, transport/router changes, CLI changes, or direct-control error-system refactor.

feat(control-orpc): add diplomacy response decision procedure

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds decisions.diplomacy.response.request as a native service-owned mutation procedure under the decisions router. The procedure reuses shared approval and playable-readiness middleware, calls the direct-control diplomacy response runtime/proof port through context, and projects semantic status, validation, postcondition, and next-step output without raw command/session/payload/UI-closeout/verified fields.

Exports the direct-control diplomacy proof helper from the package facade so control-oRPC consumes source-owned proof semantics instead of inferring proof from legacy verified flags. Direct-control-only UI toggles remain out of normal procedure input.

Proof:
- bun run --cwd packages/civ7-direct-control test test/diplomacy-response-proof-policy.test.ts
- bun run --cwd packages/civ7-direct-control test test/diplomacy-response-proof-policy.test.ts test/diplomacy-response.test.ts
- bun run --cwd packages/civ7-direct-control check
- bun run --cwd packages/civ7-direct-control build
- bun run --cwd packages/civ7-control-orpc test test/decisions-diplomacy-response-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check
- git diff --cached --check

Local package/OpenSpec proof only. No runtime/live-game proof, play-thread action, transport/CLI/Studio/bridge work, broad decisions catalog, direct-control procedure core, raw command tunnel, culture/technology procedure, shared validator/postcondition middleware acceptance, or parent Task 5.x/6.x acceptance.

test(control-orpc): share closeout proof projection

Refs: openspec/changes/civ7-control-orpc-native-slice

Promotes the repeated notification/narrative/diplomacy closeout postcondition projection into the shared control-oRPC mutation result policy. The helper consumes source-owned direct-control proof postconditions, keeps missing and pending-runtime-proof paths unconfirmed/no-repeat guarded, and marks confirmed only when the proof is confirmed and not no-repeat guarded.

Refactors notifications.dismiss.request, decisions.narrative.choice.request, and decisions.diplomacy.response.request through the shared helper while keeping direct-control proof classifiers as source authority and leaving shared validator/postcondition middleware pending.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/mutation-result-policy.test.ts test/notification-dismissal-procedure.test.ts test/decisions-narrative-choice-procedure.test.ts test/decisions-diplomacy-response-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check
- git diff --cached --check

Local package/OpenSpec proof only. No runtime/live-game proof, play-thread action, new procedure leaf, transport/CLI/Studio/bridge work, direct-control procedure-core scaffold, raw operation result public type, inference from legacy verified flags, shared validator/postcondition middleware acceptance, or parent Task 5.x/6.x acceptance.