### PR TITLE
docs(control-orpc): plan controller bridge ingress

### DIFF
--- a/apps/mapgen-studio/src/server/civ7ControlOrpc.ts
+++ b/apps/mapgen-studio/src/server/civ7ControlOrpc.ts
@@ -1,10 +1,12 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   Civ7ControlOrpcRouter,
-  liveCiv7ControlOrpcDirectControlFacade,
   type Civ7ControlOrpcContext,
-  type Civ7ControlOrpcDirectControlFacade,
 } from "@civ7/control-orpc";
+import {
+  liveCiv7ControlOrpcDirectControlFacade,
+  type Civ7ControlOrpcDirectControlFacade,
+} from "@civ7/control-orpc/runtime";
 import { DEFAULT_CIV7_TUNER_TIMEOUT_MS } from "@civ7/direct-control";
 import { RPCHandler } from "@orpc/server/node";
 

--- a/apps/mapgen-studio/test/runInGame/civ7ControlOrpcClient.test.ts
+++ b/apps/mapgen-studio/test/runInGame/civ7ControlOrpcClient.test.ts
@@ -1,10 +1,8 @@
 import { createServer, type Server } from "node:http";
 import { afterEach, describe, expect, test } from "vitest";
 
-import type {
-  Civ7ControlOrpcContext,
-  Civ7ControlOrpcPlayableStatusResult,
-} from "@civ7/control-orpc";
+import type { Civ7PlayableStatusResult } from "@civ7/direct-control";
+import type { Civ7ControlOrpcContext } from "@civ7/control-orpc";
 import {
   createStudioCiv7ControlOrpcClient,
   STUDIO_CIV7_CONTROL_ORPC_PATH,
@@ -107,7 +105,7 @@ async function closeServer(server: Server): Promise<void> {
   });
 }
 
-function playableStatusResult(): Civ7ControlOrpcPlayableStatusResult {
+function playableStatusResult(): Civ7PlayableStatusResult {
   return {
     host: "127.0.0.1",
     port: 4318,
@@ -137,7 +135,7 @@ function playableStatusResult(): Civ7ControlOrpcPlayableStatusResult {
       },
     },
     errors: ["raw runtime detail stays out of readiness.current"],
-  } as Civ7ControlOrpcPlayableStatusResult;
+  } as Civ7PlayableStatusResult;
 }
 
 function probe<T>(value: T): { ok: true; value: T } {

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -118,6 +118,23 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** implementation remains pending until source owners, schemas/tests,
   mutation proof policy, and runtime proof boundaries are explicitly accepted
 
+#### Scenario: Read-only controller ingress core is seeded
+- **WHEN** a package-local controller ingress core is implemented before the
+  global UIScript bridge is installed
+- **THEN** it validates a closed serialized request envelope with a stable
+  allowlisted procedure key and procedure input
+- **AND** the first allowlisted procedure is read-only `readiness.current`
+- **AND** it constructs oRPC context through a caller-owned controller runtime
+  factory
+- **AND** it calls the existing in-process router/client rather than
+  implementing a second router or custom procedure runner
+- **AND** raw command/session/tuner endpoint fields and mutation approvals are
+  rejected from the read-only ingress envelope
+- **AND** failures project bounded bridge error data without raw direct-control
+  command details
+- **AND** global bridge installation, UIScript packaging, mutation allowlists,
+  runtime proof, and full `7.3` implementation remain pending
+
 ### Requirement: Mutation Procedures Preserve Direct-Control Proof Semantics
 
 Mutation-capable control procedures SHALL preserve direct-control approval,

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -395,10 +395,24 @@ modules before broad implementation.
   service code inferring from legacy `verified`
 - **AND** turn-complete-sent and already-complete paths remain no-repeat
   guarded until fresh turn/attention evidence is read
-- **AND** native turn completion procedure exposure remains pending until the
-  caller-facing contract, semantic projection, approval/readiness policy, and
-  runtime proof boundary are explicitly accepted
 - **AND** local postcondition tests do not claim live Civ7 runtime proof
+
+#### Scenario: Turn completion request procedure is implemented
+- **WHEN** `turn.complete.request` requests an approved turn-completion send
+- **THEN** it is offered under the semantic `turn` router
+- **AND** it checks context-owned mutation approval and playable readiness
+  before invoking direct-control runtime authority
+- **AND** the procedure consumes the direct-control turn-completion runtime
+  port and turn-completion proof helper rather than inferring from legacy
+  `verified`
+- **AND** normal input is empty and endpoint, session, state, raw command, and
+  approval fields remain context-owned
+- **AND** normal output projects before/after turn facts, postcondition
+  summary, request status, and next steps without raw command/session/tuner
+  details
+- **AND** turn-complete-sent, already-complete, no-state-change, missing, and
+  pending-runtime-proof paths remain no-repeat guarded
+- **AND** local procedure tests do not claim live Civ7 runtime proof
 
 #### Scenario: Data or runtime access is needed
 - **WHEN** a procedure needs data-layer or runtime access beyond pure input

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -52,6 +52,17 @@ errors, and server-side callers.
   helpers may remain direct-control-owned until a later accepted service
   contract slice separates them deliberately
 
+#### Scenario: Notification dismissal service contract is offered
+- **WHEN** `notifications.dismiss.request` exposes its caller-facing contract
+- **THEN** control-oRPC owns the input schema and normal postcondition
+  classification schema for that service procedure
+- **AND** the input admits only the semantic notification ID request shape
+- **AND** raw command/session/tuner endpoint fields remain excluded from
+  procedure input
+- **AND** direct-control remains the runtime/proof owner for notification
+  dismissal sends, validators, postcondition classification, and no-repeat
+  proof semantics consumed by the procedure
+
 #### Scenario: Strategy planning view is added
 - **WHEN** a strategy planning procedure is implemented
 - **THEN** it composes planning evidence from bounded runtime/read ports into a

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -86,6 +86,15 @@ errors, and server-side callers.
   sends, validators, source verification classification, and no-repeat proof
   semantics consumed by the procedure
 
+#### Scenario: Service contract ownership is guarded
+- **WHEN** control-oRPC service contracts are checked
+- **THEN** package verification fails if module contract files import
+  `@civ7/direct-control`
+- **AND** the guard is limited to caller-facing service contract ownership
+- **AND** direct-control runtime/proof imports remain allowed in procedure,
+  dependency, and focused equivalence-test code where they are runtime/proof
+  evidence rather than normal service contract authority
+
 #### Scenario: Strategy planning view is added
 - **WHEN** a strategy planning procedure is implemented
 - **THEN** it composes planning evidence from bounded runtime/read ports into a

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -86,6 +86,20 @@ errors, and server-side callers.
   sends, validators, source verification classification, and no-repeat proof
   semantics consumed by the procedure
 
+#### Scenario: Progression choice service contract is offered
+- **WHEN** `decisions.progression.choice.request` exposes its caller-facing
+  contract
+- **THEN** control-oRPC owns the input, output, postcondition, evidence, and
+  next-step schemas for that service procedure
+- **AND** the input admits only progression kind, player ID, node ID, and
+  optional notification identity
+- **AND** endpoint, session, state, raw command, payload, App UI activation
+  toggles, and direct-control closeout internals remain excluded from procedure
+  input and normal output
+- **AND** direct-control remains the runtime/proof owner for technology/culture
+  closeout sends, command serialization, notification postcondition
+  classifiers, and no-repeat proof semantics consumed by the procedure
+
 #### Scenario: Service contract ownership is guarded
 - **WHEN** control-oRPC service contracts are checked
 - **THEN** package verification fails if module contract files import
@@ -301,6 +315,25 @@ boundaries.
   from caller-facing input and output
 - **AND** unverified, missing-postcondition, no-state-change, validation-changed,
   and not-sent paths remain no-repeat guarded
+
+#### Scenario: Progression choice request procedure is implemented
+- **WHEN** a technology or culture progression choice procedure requests a
+  player node selection
+- **THEN** it is offered under the semantic `decisions` router
+- **AND** it checks mutation approval and playable readiness before invoking
+  direct-control runtime authority
+- **AND** it reads notification evidence before and after the closeout request
+  and consumes direct-control progression postcondition helpers rather than
+  reimplementing blocker proof truth
+- **AND** its normal input exposes progression kind, player, node, and optional
+  notification identity rather than direct-control App UI toggles
+- **AND** its normal output projects semantic status, evidence summary,
+  postcondition summary, and next steps
+- **AND** it excludes endpoint, session, state, raw command, payload, App UI
+  closeout internals, and legacy proof booleans from caller-facing input and
+  output
+- **AND** not-sent, sticky-blocker, state-changed-blocker-still-live, and other
+  unverified paths remain no-repeat guarded
 
 #### Scenario: Local procedure test passes
 - **WHEN** a local fake-context procedure test passes

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -151,6 +151,19 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
   allowlists, local-player/hotseat proof, runtime proof, and full `7.3`
   implementation remain pending
 
+#### Scenario: Controller ingress allows current attention reads
+- **WHEN** the package-local controller ingress expands beyond readiness proof
+- **THEN** it may allowlist the service-owned read-only `attention.current`
+  procedure
+- **AND** `attention.current` requests validate through their existing
+  procedure input schema
+- **AND** `attention.current` invocation delegates to the existing in-process
+  router/client rather than adding a bridge-local dispatcher or read wrapper
+- **AND** raw command/session/tuner endpoint fields and mutation approvals
+  remain rejected from the ingress envelope
+- **AND** mutation allowlists, local-player/hotseat proof, runtime proof, Civ7
+  UIScript/modinfo packaging, and full `7.3` implementation remain pending
+
 ### Requirement: Mutation Procedures Preserve Direct-Control Proof Semantics
 
 Mutation-capable control procedures SHALL preserve direct-control approval,

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -39,6 +39,19 @@ errors, and server-side callers.
 - **AND** the runtime entrypoint does not expose raw command/session/tuner
   payloads or make direct-control result envelopes normal service output
 
+#### Scenario: Shared service primitives are needed by procedure contracts
+- **WHEN** service-owned procedure contracts need common Civ7 primitives such
+  as component IDs or map locations in caller-facing input or output
+- **THEN** `packages/civ7-control-orpc` owns equivalent primitive TypeBox
+  schemas under its service model
+- **AND** focused proof keeps those primitive schemas equivalent to the current
+  direct-control runtime-owner primitives
+- **AND** procedure contracts do not import direct-control primitive value
+  schemas only to describe normal service input or output
+- **AND** operation-specific runtime-port schemas, validators, and proof
+  helpers may remain direct-control-owned until a later accepted service
+  contract slice separates them deliberately
+
 #### Scenario: Strategy planning view is added
 - **WHEN** a strategy planning procedure is implemented
 - **THEN** it composes planning evidence from bounded runtime/read ports into a

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -75,6 +75,17 @@ errors, and server-side callers.
   sends, validators, source postcondition classification, and no-repeat proof
   semantics consumed by the procedure
 
+#### Scenario: Unit target action service contract is offered
+- **WHEN** `unit.target.action.request` exposes its caller-facing contract
+- **THEN** control-oRPC owns the input schema for that service procedure
+- **AND** the input admits only the semantic unit target request shape: unit ID
+  plus bounded integer map coordinates
+- **AND** approval, endpoint, session, state, and raw command fields remain
+  excluded from procedure input
+- **AND** direct-control remains the runtime/proof owner for unit target action
+  sends, validators, source verification classification, and no-repeat proof
+  semantics consumed by the procedure
+
 #### Scenario: Strategy planning view is added
 - **WHEN** a strategy planning procedure is implemented
 - **THEN** it composes planning evidence from bounded runtime/read ports into a

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -93,6 +93,8 @@ errors, and server-side callers.
   next-step schemas for that service procedure
 - **AND** the input admits only progression kind, player ID, node ID, and
   optional notification identity
+- **AND** the evidence summary distinguishes read, failed, and skipped-not-sent
+  post-read states without inventing after-state facts
 - **AND** endpoint, session, state, raw command, payload, App UI activation
   toggles, and direct-control closeout internals remain excluded from procedure
   input and normal output
@@ -329,6 +331,8 @@ boundaries.
   notification identity rather than direct-control App UI toggles
 - **AND** its normal output projects semantic status, evidence summary,
   postcondition summary, and next steps
+- **AND** if the closeout was sent but the post-send notification read fails,
+  the result remains no-repeat guarded as sent-unverified pending runtime proof
 - **AND** it excludes endpoint, session, state, raw command, payload, App UI
   closeout internals, and legacy proof booleans from caller-facing input and
   output

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -275,10 +275,12 @@ boundaries.
 - **AND** unverified or pending proof paths remain no-repeat guarded
 
 #### Scenario: Closeout-style mutation projection is shared
-- **WHEN** notification dismissal, narrative choice, or diplomacy response
-  procedures receive source-owned direct-control postcondition evidence
+- **WHEN** notification dismissal, narrative choice, diplomacy response, or
+  progression choice procedures receive source-owned direct-control
+  postcondition evidence or an explicit local pending-proof boundary
 - **THEN** the shared control-oRPC mutation projection policy derives the
-  caller-facing postcondition confirmation and no-repeat summary
+  caller-facing postcondition confirmation, request status, and no-repeat next
+  steps
 - **AND** direct-control remains the source authority for domain
   classifications, outcomes, and proof-boundary confidence
 - **AND** missing postcondition and pending-runtime-proof inputs project as

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -63,6 +63,18 @@ errors, and server-side callers.
   dismissal sends, validators, postcondition classification, and no-repeat
   proof semantics consumed by the procedure
 
+#### Scenario: Production choice service contract is offered
+- **WHEN** `city.production.choice.request` exposes its caller-facing contract
+- **THEN** control-oRPC owns the input schema and normal postcondition
+  classification schema for that service procedure
+- **AND** the input admits only the semantic city production choice request
+  shape: city ID plus exactly one valid production args variant
+- **AND** approval, endpoint, session, state, and raw command fields remain
+  excluded from procedure input
+- **AND** direct-control remains the runtime/proof owner for production-choice
+  sends, validators, source postcondition classification, and no-repeat proof
+  semantics consumed by the procedure
+
 #### Scenario: Strategy planning view is added
 - **WHEN** a strategy planning procedure is implemented
 - **THEN** it composes planning evidence from bounded runtime/read ports into a

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -16,6 +16,18 @@ errors, and server-side callers.
   postcondition classifiers, command serialization, proof facts, and other
   low-level authority that must remain runtime-owned
 
+#### Scenario: Package root exposes service-owned surface
+- **WHEN** `@civ7/control-orpc` publishes its root entrypoint
+- **THEN** root exports include service contracts, routers, server-side clients,
+  bridge ingress/bindings, semantic procedure input/output schemas, typed
+  errors, and the context/facade types needed by edge adapters
+- **AND** root exports do not publish direct-control runtime-port result
+  aliases such as playable-status, notification, ready-actor, production,
+  target-action, or closeout request result envelopes
+- **AND** direct-control runtime result shapes remain internal service
+  dependency/test details or are imported from `@civ7/direct-control` when a
+  low-level runtime fixture needs the owning type
+
 #### Scenario: Strategy planning view is added
 - **WHEN** a strategy planning procedure is implemented
 - **THEN** it composes planning evidence from bounded runtime/read ports into a

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -104,6 +104,20 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** the adapter does not become an alternate product API or raw command
   tunnel
 
+#### Scenario: In-game controller bridge preflight is recorded
+- **WHEN** the in-game controller bridge is planned before source
+  implementation
+- **THEN** the bridge contract treats `Civ7IntelligenceBridge.invoke(...)` as
+  serialized ingress only
+- **AND** the game-scoped UIScript owns loading an in-process oRPC/Effect
+  router rather than exposing a hand-maintained App UI method table
+- **AND** ingress requests identify an allowlisted procedure key and serialized
+  procedure input, not raw command/session/tuner payloads
+- **AND** controller runtime context owns local-player/hotseat identity,
+  approval tokens, lifecycle certification, and proof/evidence sinks
+- **AND** implementation remains pending until source owners, schemas/tests,
+  mutation proof policy, and runtime proof boundaries are explicitly accepted
+
 ### Requirement: Mutation Procedures Preserve Direct-Control Proof Semantics
 
 Mutation-capable control procedures SHALL preserve direct-control approval,

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -132,8 +132,24 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
   rejected from the read-only ingress envelope
 - **AND** failures project bounded bridge error data without raw direct-control
   command details
-- **AND** global bridge installation, UIScript packaging, mutation allowlists,
+- **AND** Civ7 UIScript/game-scope bridge installation, mutation allowlists,
   runtime proof, and full `7.3` implementation remain pending
+
+#### Scenario: Global intelligence bridge binding delegates to ingress
+- **WHEN** a package-local `Civ7IntelligenceBridge` binding is installed on a
+  caller-provided target before the Civ7 UIScript/modinfo package is
+  implemented
+- **THEN** the binding exposes only `invoke(request)` on a caller-provided
+  target
+- **AND** `invoke(request)` delegates to the existing controller ingress over
+  the native in-process router/client
+- **AND** the installer refuses to overwrite an existing bridge unless
+  replacement is explicit
+- **AND** raw command/session/tuner endpoint fields remain rejected by the
+  ingress envelope after global installation
+- **AND** ambient `globalThis` selection by the Civ7 UIScript adapter, mutation
+  allowlists, local-player/hotseat proof, runtime proof, and full `7.3`
+  implementation remain pending
 
 ### Requirement: Mutation Procedures Preserve Direct-Control Proof Semantics
 

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -20,13 +20,24 @@ errors, and server-side callers.
 - **WHEN** `@civ7/control-orpc` publishes its root entrypoint
 - **THEN** root exports include service contracts, routers, server-side clients,
   bridge ingress/bindings, semantic procedure input/output schemas, typed
-  errors, and the context/facade types needed by edge adapters
+  errors, and the context type needed by native callers
 - **AND** root exports do not publish direct-control runtime-port result
   aliases such as playable-status, notification, ready-actor, production,
   target-action, or closeout request result envelopes
 - **AND** direct-control runtime result shapes remain internal service
   dependency/test details or are imported from `@civ7/direct-control` when a
   low-level runtime fixture needs the owning type
+
+#### Scenario: Runtime facade entrypoint is needed by edge adapters
+- **WHEN** CLI, Studio, or controller edge adapters need to construct a native
+  control-oRPC context with the live direct-control runtime facade
+- **THEN** they import the live facade and facade type from an explicit
+  `@civ7/control-orpc/runtime` entrypoint
+- **AND** the root `@civ7/control-orpc` entrypoint remains focused on
+  caller-facing service contracts, routers, clients, bridge ingress/bindings,
+  typed errors, and semantic procedure schemas/results
+- **AND** the runtime entrypoint does not expose raw command/session/tuner
+  payloads or make direct-control result envelopes normal service output
 
 #### Scenario: Strategy planning view is added
 - **WHEN** a strategy planning procedure is implemented

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -386,6 +386,20 @@ modules before broad implementation.
   behavior are explicitly accepted
 - **AND** local postcondition tests do not claim live Civ7 runtime proof
 
+#### Scenario: Turn completion proof policy is owned before native turn mutation
+- **WHEN** turn completion sends are prepared for future native procedure
+  exposure
+- **THEN** turn-advanced, turn-complete-sent, already-complete,
+  no-state-change, missing-postcondition, and pending-runtime-proof
+  classification belongs to a direct-control proof owner rather than native
+  service code inferring from legacy `verified`
+- **AND** turn-complete-sent and already-complete paths remain no-repeat
+  guarded until fresh turn/attention evidence is read
+- **AND** native turn completion procedure exposure remains pending until the
+  caller-facing contract, semantic projection, approval/readiness policy, and
+  runtime proof boundary are explicitly accepted
+- **AND** local postcondition tests do not claim live Civ7 runtime proof
+
 #### Scenario: Data or runtime access is needed
 - **WHEN** a procedure needs data-layer or runtime access beyond pure input
   values

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -336,6 +336,17 @@ modules before broad implementation.
 - **AND** the future oRPC module can consume those facts without reaching into
   raw command/session internals
 
+#### Scenario: Progression choice proof policy is owned before native decisions
+- **WHEN** technology or culture choice closeouts are prepared for future
+  `decisions` procedure exposure
+- **THEN** blocker-clearing, blocker-transitioned, state-changed-blocker-live,
+  sticky-blocker, and turn-unblocked postcondition classification belongs to a
+  direct-control progression proof owner rather than CLI-only logic
+- **AND** native service procedures remain pending until caller-facing
+  contracts, semantic projection, approval/readiness policy, and no-repeat
+  behavior are explicitly accepted
+- **AND** local postcondition tests do not claim live Civ7 runtime proof
+
 #### Scenario: Data or runtime access is needed
 - **WHEN** a procedure needs data-layer or runtime access beyond pure input
   values

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -150,6 +150,10 @@ adding more read-only facade shells.
     ownership, prove equivalence to direct-control primitives, and switch
     attention, notification, city, unit, decisions, and strategy contracts off
     direct-control primitive value imports.
+  - [x] 5.4.10 Move `notifications.dismiss.request` caller-facing input and
+    normal postcondition classification schemas into control-oRPC service
+    ownership while leaving direct-control notification dismissal runtime/proof
+    helpers authoritative.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -381,3 +385,7 @@ adding more read-only facade shells.
   tests, control-oRPC package test/check/build, strict OpenSpec validates,
   primitive import scan, and diff hygiene for the shared service primitive
   ownership slice.
+- [x] 8.15 Run focused notification dismissal procedure/contract tests,
+  control-oRPC package test/check/build, strict OpenSpec validates,
+  notification contract direct-control import scan, and diff hygiene for the
+  notification dismissal service contract ownership slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -317,6 +317,12 @@ adding more read-only facade shells.
     replaced, delegate to the existing in-process router ingress, and keep
     ambient `globalThis` selection by the Civ7 UIScript adapter, mutation
     allowlists, runtime proof, and full `7.3` implementation pending.
+  - [x] 7.3.4 Allowlist the service-owned read-only `attention.current`
+    procedure through the package-local controller ingress: validate the
+    existing attention input schema, delegate to the existing in-process router
+    client, preserve raw command/session/tuner endpoint rejection, and keep
+    mutation allowlists, local-player/hotseat proof, runtime proof, Civ7
+    UIScript/modinfo packaging, and full `7.3` implementation pending.
 - [ ] 7.4 Keep OpenAPI/external REST deferred until there is a documented
   external consumer.
 
@@ -348,3 +354,6 @@ adding more read-only facade shells.
 - [x] 8.10 Run focused intelligence-bridge/controller-ingress tests, package
   check/build, strict OpenSpec validates, and diff hygiene for the package-local
   global bridge binding source seed.
+- [x] 8.11 Run focused controller-ingress/intelligence-bridge tests, package
+  check/build, strict OpenSpec validates, and diff hygiene for the
+  `attention.current` controller ingress allowlist slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -180,6 +180,12 @@ adding more read-only facade shells.
     owns caller-facing input, semantic evidence/proof projection, raw-output
     exclusion, and no-repeat next steps; broad decisions catalogs, runtime
     proof, and parent Task 5.x/6.x acceptance remain out of scope.
+  - [x] 5.4.15 Record `turn.complete.request` as a service-owned turn
+    mutation boundary over the direct-control turn completion runtime port and
+    turn-completion proof helper. The service owns the empty caller-facing
+    input, semantic before/after proof projection, raw-output exclusion, and
+    no-repeat next steps; CLI end-turn migration, runtime proof, and parent
+    Task 5.x/6.x acceptance remain out of scope.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -239,6 +245,11 @@ adding more read-only facade shells.
     notification read failures as sent-unverified pending runtime proof with
     no-repeat next steps, instead of surfacing a generic unavailable error after
     mutation authority may have been used.
+  - [x] 5.5.14 Seed `turn.complete.request` as a native service-owned turn
+    mutation procedure that composes approval, playable readiness,
+    direct-control turn-completion send authority, and source-owned
+    turn-completion proof classification into semantic output without exposing
+    raw command/session/Tuner details or claiming runtime/live proof.
 
 ## 6. Native Policy Layering
 
@@ -277,6 +288,9 @@ adding more read-only facade shells.
     postcondition/proof middleware pending.
   - [x] 6.2.8 Reuse shared native approval middleware for
     `decisions.progression.choice.request` while keeping validator-first and
+    postcondition/proof middleware pending.
+  - [x] 6.2.9 Reuse shared native approval middleware for
+    `turn.complete.request` while keeping validator-first and
     postcondition/proof middleware pending.
 - [ ] 6.3 Add validator-first and postcondition/proof middleware before
   mutation sends.
@@ -321,6 +335,10 @@ adding more read-only facade shells.
     postconditions and explicit pending-proof boundaries derive normal
     postcondition summaries, request status, and no-repeat next steps without
     accepting shared validator/postcondition middleware.
+  - [x] 6.3.11 Compose `turn.complete.request` through direct-control
+    turn-completion runtime authority and source-owned turn-completion
+    proof/no-repeat semantics; keep live runtime proof and shared
+    validator/postcondition middleware pending.
 - [ ] 6.4 Add safe error projection and correlation through oRPC/effect-orpc
   context/error primitives, not direct-control-local framework wiring.
   - [x] 6.4.1 Use native effect-orpc tagged error constructors for
@@ -356,6 +374,10 @@ adding more read-only facade shells.
     `decisions.progression.choice.request` direct-control runtime-port
     failures while keeping raw direct-control cause, command, session, payload,
     and App UI closeout details out of public error data.
+  - [x] 6.4.10 Use native effect-orpc tagged error constructors for
+    `turn.complete.request` direct-control runtime-port failures while keeping
+    raw direct-control cause, command, session, state, and Tuner details out of
+    public error data.
 
 ## 7. Edge Adapters
 
@@ -474,3 +496,6 @@ adding more read-only facade shells.
 - [x] 8.23 Run focused turn-completion proof-policy tests, direct-control
   package test/check/build, relevant OpenSpec strict validates, and diff
   hygiene for the turn-completion proof/no-repeat ownership slice.
+- [x] 8.24 Run focused control-oRPC turn-completion procedure tests,
+  control-oRPC package test/check/build, relevant OpenSpec strict validates,
+  and diff hygiene for the native turn completion procedure slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -310,6 +310,11 @@ adding more read-only facade shells.
   - [x] 6.3.9 Preserve progression choice no-repeat proof boundaries when
     after-read evidence is unavailable after a sent closeout; keep live
     runtime proof and shared postcondition middleware pending.
+  - [x] 6.3.10 Extend the shared closeout-style mutation projection helper to
+    `decisions.progression.choice.request` so source-owned progression
+    postconditions and explicit pending-proof boundaries derive normal
+    postcondition summaries, request status, and no-repeat next steps without
+    accepting shared validator/postcondition middleware.
 - [ ] 6.4 Add safe error projection and correlation through oRPC/effect-orpc
   context/error primitives, not direct-control-local framework wiring.
   - [x] 6.4.1 Use native effect-orpc tagged error constructors for
@@ -456,3 +461,7 @@ adding more read-only facade shells.
 - [x] 8.21 Run focused control-oRPC progression choice procedure regression,
   package check, relevant OpenSpec strict validates, and diff hygiene for the
   progression choice after-read proof-boundary correction.
+- [x] 8.22 Run focused mutation-result policy regression, affected
+  notification/narrative/diplomacy/progression procedure tests, package
+  test/check/build, relevant OpenSpec strict validates, and diff hygiene for
+  the progression closeout projection helper extension.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -141,6 +141,10 @@ adding more read-only facade shells.
     facade and facade type available for edge-adapter context construction, but
     leave raw result envelopes internal to service dependencies/tests or owned
     by `@civ7/direct-control`.
+  - [x] 5.4.8 Split the live direct-control facade and facade type out of the
+    root `@civ7/control-orpc` service entrypoint and into explicit
+    `@civ7/control-orpc/runtime` context-construction exports for CLI and
+    Studio edge adapters.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -365,3 +369,6 @@ adding more read-only facade shells.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.
+- [x] 8.13 Run control-oRPC package test/check/build, affected CLI/Studio
+  checks/tests, strict OpenSpec validates, root facade-export scan, and diff
+  hygiene for the explicit runtime entrypoint split.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -229,6 +229,10 @@ adding more read-only facade shells.
     classification into semantic output without exposing raw
     command/session/payload/App UI closeout details or claiming runtime/live
     proof.
+  - [x] 5.5.13 Guard `decisions.progression.choice.request` post-send
+    notification read failures as sent-unverified pending runtime proof with
+    no-repeat next steps, instead of surfacing a generic unavailable error after
+    mutation authority may have been used.
 
 ## 6. Native Policy Layering
 
@@ -303,6 +307,9 @@ adding more read-only facade shells.
     direct-control technology/culture closeout runtime ports and source-owned
     progression choice proof/no-repeat semantics; keep shared
     validator/postcondition middleware pending.
+  - [x] 6.3.9 Preserve progression choice no-repeat proof boundaries when
+    after-read evidence is unavailable after a sent closeout; keep live
+    runtime proof and shared postcondition middleware pending.
 - [ ] 6.4 Add safe error projection and correlation through oRPC/effect-orpc
   context/error primitives, not direct-control-local framework wiring.
   - [x] 6.4.1 Use native effect-orpc tagged error constructors for
@@ -446,3 +453,6 @@ adding more read-only facade shells.
   tests, control-oRPC package test/check/build, focused direct-control
   progression proof-policy tests, relevant OpenSpec strict validates, and diff
   hygiene for the progression choice decision procedure slice.
+- [x] 8.21 Run focused control-oRPC progression choice procedure regression,
+  package check, relevant OpenSpec strict validates, and diff hygiene for the
+  progression choice after-read proof-boundary correction.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -104,6 +104,12 @@ adding more read-only facade shells.
     policy out of CLI commands into direct-control progression proof ownership.
     Keep native `decisions` procedures, shared postcondition middleware,
     runtime proof, and parent Task 5.x/6.x acceptance pending.
+  - [x] 5.2.7 Extract turn-completion send proof/no-repeat policy into a
+    direct-control-owned helper. Preserve the existing turn-completion runtime
+    send path while classifying turn-advanced, turn-complete-sent,
+    already-complete, no-state-change, missing-postcondition, and
+    pending-runtime-proof paths before any native turn mutation procedure is
+    accepted.
 - [ ] 5.3 Reorganize the capability hierarchy semantically for Sieve/future
   consumers before adding more procedure leaves.
   - [x] 5.3.1 Define the target semantic capability families and transitional
@@ -465,3 +471,6 @@ adding more read-only facade shells.
   notification/narrative/diplomacy/progression procedure tests, package
   test/check/build, relevant OpenSpec strict validates, and diff hygiene for
   the progression closeout projection helper extension.
+- [x] 8.23 Run focused turn-completion proof-policy tests, direct-control
+  package test/check/build, relevant OpenSpec strict validates, and diff
+  hygiene for the turn-completion proof/no-repeat ownership slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -299,6 +299,12 @@ adding more read-only facade shells.
     `readiness.current` while preserving existing map/autoplay REST fields.
 - [ ] 7.3 Add in-game controller bridge only as serialized ingress into the
   in-process router.
+  - [x] 7.3.1 Record the in-game controller bridge preflight contract:
+    `Civ7IntelligenceBridge.invoke(...)` is serialized ingress only, the
+    game-scoped UIScript loads an in-process oRPC/Effect router, procedure
+    calls are allowlisted, context construction stays in the controller
+    runtime adapter, mutation calls require explicit approval/local-player
+    proof, and source implementation remains pending.
 - [ ] 7.4 Keep OpenAPI/external REST deferred until there is a documented
   external consumer.
 
@@ -321,3 +327,6 @@ adding more read-only facade shells.
   notification/narrative/diplomacy procedure tests, package check/build,
   strict OpenSpec validates, and diff hygiene when the shared closeout
   projection helper is extracted.
+- [x] 8.8 Run strict OpenSpec validates and diff hygiene for the controller
+  bridge preflight record. No source implementation, runtime proof, play-thread
+  action, or `7.3` implementation acceptance is claimed by that record.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -168,6 +168,12 @@ adding more read-only facade shells.
   - [x] 5.4.13 Add a package verification guard that fails if control-oRPC
     module contract files import direct-control, while leaving runtime/proof
     procedure imports and focused equivalence tests out of that guard.
+  - [x] 5.4.14 Record `decisions.progression.choice.request` as a
+    service-owned decision boundary over direct-control technology/culture
+    closeout runtime ports and progression-choice proof helpers. The service
+    owns caller-facing input, semantic evidence/proof projection, raw-output
+    exclusion, and no-repeat next steps; broad decisions catalogs, runtime
+    proof, and parent Task 5.x/6.x acceptance remain out of scope.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -216,6 +222,13 @@ adding more read-only facade shells.
     readiness, direct-control diplomacy response authority, and source-owned
     diplomacy proof classification into semantic output without exposing raw
     command/session/payload/UI-closeout details or claiming runtime/live proof.
+  - [x] 5.5.12 Seed `decisions.progression.choice.request` as a native
+    service-owned decision procedure that composes approval, playable
+    readiness, before/after notification evidence, direct-control
+    technology/culture closeout authority, and source-owned progression proof
+    classification into semantic output without exposing raw
+    command/session/payload/App UI closeout details or claiming runtime/live
+    proof.
 
 ## 6. Native Policy Layering
 
@@ -252,6 +265,9 @@ adding more read-only facade shells.
   - [x] 6.2.7 Reuse shared native approval middleware for
     `decisions.diplomacy.response.request` while keeping validator-first and
     postcondition/proof middleware pending.
+  - [x] 6.2.8 Reuse shared native approval middleware for
+    `decisions.progression.choice.request` while keeping validator-first and
+    postcondition/proof middleware pending.
 - [ ] 6.3 Add validator-first and postcondition/proof middleware before
   mutation sends.
   - [x] 6.3.1 Compose `city.production.choice.request` through the
@@ -283,6 +299,10 @@ adding more read-only facade shells.
     narrative, and diplomacy mutation procedures. Keep direct-control proof
     classifiers as source authority and keep shared validator/postcondition
     middleware pending.
+  - [x] 6.3.8 Compose `decisions.progression.choice.request` through
+    direct-control technology/culture closeout runtime ports and source-owned
+    progression choice proof/no-repeat semantics; keep shared
+    validator/postcondition middleware pending.
 - [ ] 6.4 Add safe error projection and correlation through oRPC/effect-orpc
   context/error primitives, not direct-control-local framework wiring.
   - [x] 6.4.1 Use native effect-orpc tagged error constructors for
@@ -314,6 +334,10 @@ adding more read-only facade shells.
     `decisions.diplomacy.response.request` direct-control runtime-port
     failures while keeping raw direct-control cause, command, session, payload,
     and UI-closeout details out of public error data.
+  - [x] 6.4.9 Use native effect-orpc tagged error constructors for
+    `decisions.progression.choice.request` direct-control runtime-port
+    failures while keeping raw direct-control cause, command, session, payload,
+    and App UI closeout details out of public error data.
 
 ## 7. Edge Adapters
 
@@ -418,3 +442,7 @@ adding more read-only facade shells.
   adjacent CLI technology/culture command tests, direct-control check/build,
   relevant OpenSpec strict validates, and diff hygiene for the progression
   choice proof-policy ownership slice.
+- [x] 8.20 Run focused control-oRPC progression choice decision procedure
+  tests, control-oRPC package test/check/build, focused direct-control
+  progression proof-policy tests, relevant OpenSpec strict validates, and diff
+  hygiene for the progression choice decision procedure slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -145,6 +145,11 @@ adding more read-only facade shells.
     root `@civ7/control-orpc` service entrypoint and into explicit
     `@civ7/control-orpc/runtime` context-construction exports for CLI and
     Studio edge adapters.
+  - [x] 5.4.9 Move shared caller-facing component ID and map-location
+    primitive schemas into `packages/civ7-control-orpc` service model
+    ownership, prove equivalence to direct-control primitives, and switch
+    attention, notification, city, unit, decisions, and strategy contracts off
+    direct-control primitive value imports.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -372,3 +377,7 @@ adding more read-only facade shells.
 - [x] 8.13 Run control-oRPC package test/check/build, affected CLI/Studio
   checks/tests, strict OpenSpec validates, root facade-export scan, and diff
   hygiene for the explicit runtime entrypoint split.
+- [x] 8.14 Run focused primitive-schema equivalence and affected procedure
+  tests, control-oRPC package test/check/build, strict OpenSpec validates,
+  primitive import scan, and diff hygiene for the shared service primitive
+  ownership slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -305,6 +305,12 @@ adding more read-only facade shells.
     calls are allowlisted, context construction stays in the controller
     runtime adapter, mutation calls require explicit approval/local-player
     proof, and source implementation remains pending.
+  - [x] 7.3.2 Seed a package-local read-only controller ingress core for
+    `readiness.current`: validate a closed serialized envelope, allowlist the
+    procedure key, construct context through a caller-owned factory, call the
+    existing in-process router client, and keep global bridge installation,
+    UIScript packaging, mutation allowlists, runtime proof, and full `7.3`
+    implementation pending.
 - [ ] 7.4 Keep OpenAPI/external REST deferred until there is a documented
   external consumer.
 
@@ -330,3 +336,6 @@ adding more read-only facade shells.
 - [x] 8.8 Run strict OpenSpec validates and diff hygiene for the controller
   bridge preflight record. No source implementation, runtime proof, play-thread
   action, or `7.3` implementation acceptance is claimed by that record.
+- [x] 8.9 Run focused controller-ingress package tests, package check/build,
+  strict OpenSpec validates, and diff hygiene for the read-only
+  `readiness.current` controller ingress source seed.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -161,6 +161,9 @@ adding more read-only facade shells.
   - [x] 5.4.12 Move `unit.target.action.request` caller-facing input schema
     into control-oRPC service ownership while leaving direct-control unit
     target action runtime/proof helpers authoritative.
+  - [x] 5.4.13 Add a package verification guard that fails if control-oRPC
+    module contract files import direct-control, while leaving runtime/proof
+    procedure imports and focused equivalence tests out of that guard.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -404,3 +407,6 @@ adding more read-only facade shells.
   control-oRPC package test/check/build, strict OpenSpec validates, unit
   contract direct-control import scan, and diff hygiene for the unit target
   action service contract ownership slice.
+- [x] 8.18 Run the control-oRPC contract-ownership lint guard through package
+  check, control-oRPC package test/build, strict OpenSpec validates, and diff
+  hygiene for the service contract ownership guard slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -136,6 +136,11 @@ adding more read-only facade shells.
     no-repeat next steps; direct-control-only UI toggles, broad decisions
     catalogs, runtime proof, and parent Task 5.x/6.x acceptance remain out of
     scope.
+  - [x] 5.4.7 Burn down root public exports of direct-control runtime-port
+    result aliases from `@civ7/control-orpc`. Keep the live direct-control
+    facade and facade type available for edge-adapter context construction, but
+    leave raw result envelopes internal to service dependencies/tests or owned
+    by `@civ7/direct-control`.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -357,3 +362,6 @@ adding more read-only facade shells.
 - [x] 8.11 Run focused controller-ingress/intelligence-bridge tests, package
   check/build, strict OpenSpec validates, and diff hygiene for the
   `attention.current` controller ingress allowlist slice.
+- [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
+  strict OpenSpec validates, public root-export scan, and diff hygiene for the
+  raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -154,6 +154,10 @@ adding more read-only facade shells.
     normal postcondition classification schemas into control-oRPC service
     ownership while leaving direct-control notification dismissal runtime/proof
     helpers authoritative.
+  - [x] 5.4.11 Move `city.production.choice.request` caller-facing input and
+    normal postcondition classification schemas into control-oRPC service
+    ownership while leaving direct-control production-choice runtime/proof
+    helpers authoritative.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -389,3 +393,7 @@ adding more read-only facade shells.
   control-oRPC package test/check/build, strict OpenSpec validates,
   notification contract direct-control import scan, and diff hygiene for the
   notification dismissal service contract ownership slice.
+- [x] 8.16 Run focused production choice procedure/contract tests,
+  control-oRPC package test/check/build, strict OpenSpec validates, city
+  contract direct-control import scan, and diff hygiene for the production
+  choice service contract ownership slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -308,9 +308,15 @@ adding more read-only facade shells.
   - [x] 7.3.2 Seed a package-local read-only controller ingress core for
     `readiness.current`: validate a closed serialized envelope, allowlist the
     procedure key, construct context through a caller-owned factory, call the
-    existing in-process router client, and keep global bridge installation,
-    UIScript packaging, mutation allowlists, runtime proof, and full `7.3`
+    existing in-process router client, and keep Civ7 UIScript/game-scope bridge
+    installation, mutation allowlists, runtime proof, and full `7.3`
     implementation pending.
+  - [x] 7.3.3 Install a package-local `Civ7IntelligenceBridge` global binding
+    over the existing controller ingress on a caller-provided target:
+    expose only `invoke(request)`, reject accidental overwrite unless explicitly
+    replaced, delegate to the existing in-process router ingress, and keep
+    ambient `globalThis` selection by the Civ7 UIScript adapter, mutation
+    allowlists, runtime proof, and full `7.3` implementation pending.
 - [ ] 7.4 Keep OpenAPI/external REST deferred until there is a documented
   external consumer.
 
@@ -339,3 +345,6 @@ adding more read-only facade shells.
 - [x] 8.9 Run focused controller-ingress package tests, package check/build,
   strict OpenSpec validates, and diff hygiene for the read-only
   `readiness.current` controller ingress source seed.
+- [x] 8.10 Run focused intelligence-bridge/controller-ingress tests, package
+  check/build, strict OpenSpec validates, and diff hygiene for the package-local
+  global bridge binding source seed.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -100,6 +100,10 @@ adding more read-only facade shells.
     policies into proof helpers while preserving current closeout semantics.
   - [x] 5.2.5 Extract population-placement proof/no-repeat policy into
     focused helpers while preserving legacy request `verified` behavior.
+  - [x] 5.2.6 Extract technology/culture progression-choice postcondition
+    policy out of CLI commands into direct-control progression proof ownership.
+    Keep native `decisions` procedures, shared postcondition middleware,
+    runtime proof, and parent Task 5.x/6.x acceptance pending.
 - [ ] 5.3 Reorganize the capability hierarchy semantically for Sieve/future
   consumers before adding more procedure leaves.
   - [x] 5.3.1 Define the target semantic capability families and transitional
@@ -410,3 +414,7 @@ adding more read-only facade shells.
 - [x] 8.18 Run the control-oRPC contract-ownership lint guard through package
   check, control-oRPC package test/build, strict OpenSpec validates, and diff
   hygiene for the service contract ownership guard slice.
+- [x] 8.19 Run focused direct-control progression-choice postcondition tests,
+  adjacent CLI technology/culture command tests, direct-control check/build,
+  relevant OpenSpec strict validates, and diff hygiene for the progression
+  choice proof-policy ownership slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -158,6 +158,9 @@ adding more read-only facade shells.
     normal postcondition classification schemas into control-oRPC service
     ownership while leaving direct-control production-choice runtime/proof
     helpers authoritative.
+  - [x] 5.4.12 Move `unit.target.action.request` caller-facing input schema
+    into control-oRPC service ownership while leaving direct-control unit
+    target action runtime/proof helpers authoritative.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -397,3 +400,7 @@ adding more read-only facade shells.
   control-oRPC package test/check/build, strict OpenSpec validates, city
   contract direct-control import scan, and diff hygiene for the production
   choice service contract ownership slice.
+- [x] 8.17 Run focused unit target action procedure/contract tests,
+  control-oRPC package test/check/build, strict OpenSpec validates, unit
+  contract direct-control import scan, and diff hygiene for the unit target
+  action service contract ownership slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/atom-policy-dependency-inventory.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/atom-policy-dependency-inventory.md
@@ -112,10 +112,12 @@ future package proves repeated use through oRPC/effect-orpc primitives.
   postconditions.
 - Diplomacy, narrative, population placement, and technology/culture closeout
   source capabilities now have bounded native procedure leaves. Turn completion
-  sends, setup actions, autoplay actions, reveal-map, and generic operation
-  request wrappers still exist as source capabilities but are not accepted
-  native procedure atoms in this inventory. Technology/culture closeout
-  postcondition classification remains direct-control-owned in
+  sends now have direct-control-owned proof/no-repeat policy prework, but no
+  accepted native procedure atom yet. Setup actions, autoplay actions,
+  reveal-map, and generic operation request wrappers still exist as source
+  capabilities but are not accepted native procedure atoms in this inventory.
+  Technology/culture closeout postcondition classification remains
+  direct-control-owned in
   `src/play/progression/choice-postconditions.ts`; `decisions.progression.choice.request`
   owns the semantic service contract/projection over those runtime/proof ports.
 
@@ -126,7 +128,7 @@ future package proves repeated use through oRPC/effect-orpc primitives.
 | Approval | `src/action-approval.ts` plus mutation atom inputs carrying `approvalReason` and optional disposable-session intent | oRPC mutation middleware or procedure guard; must not invent approval |
 | Validator-first | `src/play/operations/validate-request.ts`, unit-target/production/notification request owners | oRPC middleware/procedure guard before send when an atom has validator support |
 | Postcondition classification | `src/play/operations/*-postconditions.ts`, `src/play/notifications/postconditions.ts`, `src/play/progression/choice-postconditions.ts` | Direct-control classifier remains owner; oRPC middleware consumes classification |
-| No-repeat-after-unverified | `src/proof/operation-telemetry.ts` plus specialized proof-policy helpers and telemetry adapters; production choice now starts in `src/play/operations/production-choice-proof.ts`, notification dismissal in `src/proof/notification-dismissal-proof-policy.ts`, unit target action in `src/proof/unit-target-proof-policy.ts`, narrative choice in `src/proof/narrative-choice-proof-policy.ts`, diplomacy response in `src/proof/diplomacy-response-proof-policy.ts`, and population placement in `src/play/operations/population-placement-proof.ts` plus `src/proof/population-placement-proof-policy.ts` | oRPC mutation proof middleware consumes, never weakens, and never infers repeat safety from `verified` |
+| No-repeat-after-unverified | `src/proof/operation-telemetry.ts` plus specialized proof-policy helpers and telemetry adapters; production choice now starts in `src/play/operations/production-choice-proof.ts`, notification dismissal in `src/proof/notification-dismissal-proof-policy.ts`, unit target action in `src/proof/unit-target-proof-policy.ts`, narrative choice in `src/proof/narrative-choice-proof-policy.ts`, diplomacy response in `src/proof/diplomacy-response-proof-policy.ts`, population placement in `src/play/operations/population-placement-proof.ts` plus `src/proof/population-placement-proof-policy.ts`, and turn completion in `src/proof/turn-completion-proof-policy.ts` | oRPC mutation proof middleware consumes, never weakens, and never infers repeat safety from `verified` |
 | Relationship authority | current tactical `relationshipLabelPolicy` schemas plus the OpenSpec neutral-relationship invariant | Read projection policy or middleware guard; no hostile/enemy/opponent labels from proximity/owner mismatch |
 | Command serialization | `src/runtime/command-serialization.ts` and atom-local `build*Command` functions | Direct-control-only implementation detail; never procedure input/output |
 | Semantic/debug projection | `workstream/semantic-cli-envelope-contract.md`, `debug-service-projection-contract.md`, descriptor `projection` fields | Output projection per consumer class; normal CLI stays semantic |

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/atom-policy-dependency-inventory.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/atom-policy-dependency-inventory.md
@@ -113,9 +113,11 @@ future package proves repeated use through oRPC/effect-orpc primitives.
 - Diplomacy, narrative, population placement, technology/culture closeout, turn
   completion sends, setup actions, autoplay actions, reveal-map, and generic
   operation request wrappers exist as source capabilities, but they are not
-  accepted native procedure atoms in this inventory. Each needs a separate
-  descriptor/schema/proof slice before `packages/civ7-control-orpc` composes it
-  as a procedure.
+  accepted native procedure atoms in this inventory. Technology/culture
+  closeout postcondition classification is now direct-control-owned in
+  `src/play/progression/choice-postconditions.ts`, but each progression choice
+  still needs a separate native service contract/projection slice before
+  `packages/civ7-control-orpc` composes it as a procedure.
 
 ## Policy Owners
 
@@ -123,7 +125,7 @@ future package proves repeated use through oRPC/effect-orpc primitives.
 |---|---|---|
 | Approval | `src/action-approval.ts` plus mutation atom inputs carrying `approvalReason` and optional disposable-session intent | oRPC mutation middleware or procedure guard; must not invent approval |
 | Validator-first | `src/play/operations/validate-request.ts`, unit-target/production/notification request owners | oRPC middleware/procedure guard before send when an atom has validator support |
-| Postcondition classification | `src/play/operations/*-postconditions.ts`, `src/play/notifications/postconditions.ts` | Direct-control classifier remains owner; oRPC middleware consumes classification |
+| Postcondition classification | `src/play/operations/*-postconditions.ts`, `src/play/notifications/postconditions.ts`, `src/play/progression/choice-postconditions.ts` | Direct-control classifier remains owner; oRPC middleware consumes classification |
 | No-repeat-after-unverified | `src/proof/operation-telemetry.ts` plus specialized proof-policy helpers and telemetry adapters; production choice now starts in `src/play/operations/production-choice-proof.ts`, notification dismissal in `src/proof/notification-dismissal-proof-policy.ts`, unit target action in `src/proof/unit-target-proof-policy.ts`, narrative choice in `src/proof/narrative-choice-proof-policy.ts`, diplomacy response in `src/proof/diplomacy-response-proof-policy.ts`, and population placement in `src/play/operations/population-placement-proof.ts` plus `src/proof/population-placement-proof-policy.ts` | oRPC mutation proof middleware consumes, never weakens, and never infers repeat safety from `verified` |
 | Relationship authority | current tactical `relationshipLabelPolicy` schemas plus the OpenSpec neutral-relationship invariant | Read projection policy or middleware guard; no hostile/enemy/opponent labels from proximity/owner mismatch |
 | Command serialization | `src/runtime/command-serialization.ts` and atom-local `build*Command` functions | Direct-control-only implementation detail; never procedure input/output |

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/atom-policy-dependency-inventory.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/atom-policy-dependency-inventory.md
@@ -110,14 +110,14 @@ future package proves repeated use through oRPC/effect-orpc primitives.
   production postconditions.
 - `notifications.dismiss.request` wraps notification dismissal and dismissal
   postconditions.
-- Diplomacy, narrative, population placement, technology/culture closeout, turn
-  completion sends, setup actions, autoplay actions, reveal-map, and generic
-  operation request wrappers exist as source capabilities, but they are not
-  accepted native procedure atoms in this inventory. Technology/culture
-  closeout postcondition classification is now direct-control-owned in
-  `src/play/progression/choice-postconditions.ts`, but each progression choice
-  still needs a separate native service contract/projection slice before
-  `packages/civ7-control-orpc` composes it as a procedure.
+- Diplomacy, narrative, population placement, and technology/culture closeout
+  source capabilities now have bounded native procedure leaves. Turn completion
+  sends, setup actions, autoplay actions, reveal-map, and generic operation
+  request wrappers still exist as source capabilities but are not accepted
+  native procedure atoms in this inventory. Technology/culture closeout
+  postcondition classification remains direct-control-owned in
+  `src/play/progression/choice-postconditions.ts`; `decisions.progression.choice.request`
+  owns the semantic service contract/projection over those runtime/proof ports.
 
 ## Policy Owners
 

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/closeout-projection-policy-native-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/closeout-projection-policy-native-slice.md
@@ -11,9 +11,11 @@ creating a custom procedure framework or accepting shared
 validator/postcondition middleware prematurely.
 
 The repeated behavior is narrow: after a notification dismissal, narrative
-choice, or diplomacy response runtime port returns source-owned direct-control
-postcondition evidence, control-oRPC derives the caller-facing confirmation
-boolean and no-repeat guard fields for semantic procedure output.
+choice, diplomacy response, or progression choice runtime path returns
+source-owned direct-control postcondition evidence, or the service records an
+explicit local pending-proof boundary, control-oRPC derives the caller-facing
+confirmation boolean, request status, and no-repeat next steps for semantic
+procedure output.
 
 ## Write Set
 
@@ -21,6 +23,7 @@ boolean and no-repeat guard fields for semantic procedure output.
 - `packages/civ7-control-orpc/src/modules/notifications/procedures/dismiss-request.ts`
 - `packages/civ7-control-orpc/src/modules/decisions/procedures/narrative-choice-request.ts`
 - `packages/civ7-control-orpc/src/modules/decisions/procedures/diplomacy-response-request.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/procedures/progression-choice-request.ts`
 - `packages/civ7-control-orpc/test/mutation-result-policy.test.ts`
 - this OpenSpec record, `tasks.md`, and `specs/civ7-control-orpc/spec.md`
 
@@ -29,6 +32,8 @@ boolean and no-repeat guard fields for semantic procedure output.
 The shared helper:
 
 - consumes already-classified direct-control proof postconditions;
+- accepts explicit local pending-proof boundaries when a sent progression
+  closeout cannot collect the post-send notification read;
 - treats missing postconditions as unverified and no-repeat guarded;
 - preserves `pending-runtime-proof` as unconfirmed and no-repeat guarded;
 - marks a summary confirmed only when confidence is `confirmed` and
@@ -36,10 +41,11 @@ The shared helper:
 - keeps request status and next-step derivation in the existing mutation-result
   policy owner.
 
-Direct-control remains the source authority for notification, narrative, and
-diplomacy classifications, proof outcomes, and proof-boundary confidence. The
-procedures still own semantic service output and still exclude raw
-command/session/payload/UI-closeout/legacy `verified` fields from normal I/O.
+Direct-control remains the source authority for notification, narrative,
+diplomacy, and progression classifications, proof outcomes, and proof-boundary
+confidence. The procedures still own semantic service output and still exclude
+raw command/session/payload/UI-closeout/legacy `verified` fields from normal
+I/O.
 
 ## Non-Goals
 
@@ -55,7 +61,7 @@ command/session/payload/UI-closeout/legacy `verified` fields from normal I/O.
 
 Planned closure gates:
 
-- `bun run --cwd packages/civ7-control-orpc test test/mutation-result-policy.test.ts test/notification-dismissal-procedure.test.ts test/decisions-narrative-choice-procedure.test.ts test/decisions-diplomacy-response-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test test/mutation-result-policy.test.ts test/notification-dismissal-procedure.test.ts test/decisions-narrative-choice-procedure.test.ts test/decisions-diplomacy-response-procedure.test.ts test/decisions-progression-choice-procedure.test.ts`
 - `bun run --cwd packages/civ7-control-orpc test`
 - `bun run --cwd packages/civ7-control-orpc check`
 - `bun run --cwd packages/civ7-control-orpc build`

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/contract-ownership-guard-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/contract-ownership-guard-slice.md
@@ -1,0 +1,61 @@
+# Contract Ownership Guard Slice
+
+Status: implemented package verification guard.
+Date: 2026-06-05.
+
+## Purpose
+
+Lock in the completed service-contract ownership burn-down for
+`packages/civ7-control-orpc`.
+
+The control-oRPC module contract files now own caller-facing procedure schemas
+instead of importing direct-control value schemas. This slice turns that stable
+boundary into a package lint guard rather than adding brittle fixture tests.
+
+## Write Set
+
+- `scripts/lint/lint-control-orpc-contract-ownership.mjs`
+- `packages/civ7-control-orpc/package.json`
+- this OpenSpec record, `tasks.md`, and `specs/civ7-control-orpc/spec.md`
+
+## Guard Boundary
+
+The guard scans:
+
+- `packages/civ7-control-orpc/src/modules/**/contract.ts`
+
+It fails when a module contract imports `@civ7/direct-control`.
+
+The guard intentionally does not scan procedure, dependency, middleware,
+runtime, or focused equivalence-test files. Direct-control remains the
+runtime/proof port for validators, command serialization, postcondition
+classifiers, proof/no-repeat policy, relationship authority, and runtime
+evidence.
+
+## Non-Goals
+
+- no procedure behavior change;
+- no direct-control runtime/proof helper change;
+- no controller, CLI, Studio, transport, telemetry, or persistence change;
+- no runtime/live-game proof claim;
+- no play-thread action;
+- no Task 5.x/6.x/7.x parent acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc lint:contract-ownership`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+These are local package/static and OpenSpec proofs only.
+
+## Residual Risk
+
+This guard only protects module service contracts. It does not decide whether
+future procedure behavior is too facade-like, whether a direct-control function
+is truly low-level runtime evidence, or whether controller packaging is ready
+for live runtime proof.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-attention-ingress-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-attention-ingress-slice.md
@@ -1,0 +1,70 @@
+# Controller Attention Ingress Slice
+
+Status: implemented local package source seed.
+Date: 2026-06-05.
+
+## Purpose
+
+Expand the package-local controller ingress from readiness proof to useful
+support-agent attention reads without introducing a new bridge API, mutation
+surface, or controller-local dispatcher.
+
+This slice allowlists the existing service-owned `attention.current` procedure
+beside `readiness.current`. The serialized envelope remains closed, procedure
+inputs reuse the existing procedure schemas, and invocation still delegates to
+`createCiv7ControlOrpcServerClient(context)`.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/bridge/controller-ingress.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts`
+- this OpenSpec record, `tasks.md`, and `specs/civ7-control-orpc/spec.md`
+
+## Behavior Boundary
+
+The controller ingress now:
+
+- accepts `readiness.current` and `attention.current` as read-only allowlisted
+  procedure keys;
+- validates each request against that procedure's existing input schema;
+- calls the existing in-process router client for both procedures;
+- returns the existing semantic procedure outputs;
+- rejects raw host, port, session, state, command, rawCommand, and approval
+  fields from the serialized bridge envelope;
+- rejects mutation procedure keys before context construction.
+
+`attention.current` remains the service-owned composition boundary over
+playable status, notifications, turn completion, ready-unit, and ready-city
+runtime ports. This slice does not add a bridge-local attention read wrapper.
+
+## Non-Goals
+
+- no Civ7 modinfo or UIScript bundle;
+- no ambient `globalThis` selection by this package;
+- no mutation procedure allowlist;
+- no local-player/hotseat proof, approval-token implementation, or evidence
+  sink;
+- no raw command/session/tuner payload ingress;
+- no HTTP/RPCLink/OpenAPI transport;
+- no custom router, procedure runner, middleware, context bus, or error bus;
+- no runtime/live-game proof, play-thread action, or full `7.3` acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/controller-bridge-ingress.test.ts test/intelligence-bridge.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+These are local package/OpenSpec proofs only.
+
+## Residual Risk
+
+The actual game-scope adapter still needs a Civ7 UIScript/mod package and
+runtime-owned context factory before the bridge can be loaded in a running
+game. Mutation ingress remains blocked on local-player/hotseat identity,
+explicit approval, lifecycle certification, and proof/evidence sinks.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-bridge-preflight-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-bridge-preflight-slice.md
@@ -1,0 +1,116 @@
+# Controller Bridge Preflight Slice
+
+Status: planned controller edge boundary, no source implementation.
+Date: 2026-06-05.
+
+## Purpose
+
+Make the in-game controller bridge implementation-ready without creating an
+ad hoc bridge API, raw App UI command surface, or transport-first product
+contract.
+
+The accepted architecture is unchanged: Civ7 loads a game-scoped UIScript from
+a mod `ActionGroup` with `scope="game"` and `<UIScripts>`. That script installs
+`globalThis.Civ7IntelligenceBridge.invoke(...)` only as serialized ingress into
+an in-process oRPC/Effect router. The router is the product/service boundary;
+the global bridge is not.
+
+## Authority Evidence
+
+- `openspec/changes/civ7-control-orpc-native-slice/proposal.md` records the
+  game-scoped UIScript router and serialized ingress model.
+- `openspec/changes/civ7-control-orpc-native-slice/design.md` keeps edge
+  adapters after shared in-process router proof.
+- `openspec/changes/civ7-support-direct-control-modularization/design.md` and
+  `workstream/workstream-record.md` reject a hand-maintained App UI method
+  table or ad hoc JSON-envelope product API.
+- Official modinfo docs show `scope="game"` action groups and `<UIScripts>` as
+  the Civ7 mechanism for loading JavaScript UI scripts.
+
+## Target Ingress Shape
+
+The future serialized ingress envelope should be intentionally small:
+
+```ts
+type Civ7IntelligenceBridgeRequest = Readonly<{
+  procedureKey: string;
+  input: unknown;
+  approval?: unknown;
+  correlationId?: string;
+}>;
+
+type Civ7IntelligenceBridgeResponse = Readonly<
+  | { ok: true; procedureKey: string; output: unknown; correlationId?: string }
+  | { ok: false; procedureKey: string; error: unknown; correlationId?: string }
+>;
+```
+
+This is a planning shape, not a public exported schema in this slice. The source
+implementation must replace `string`/`unknown` with accepted TypeBox or Effect
+Schema contracts before commit.
+
+## Router And Allowlist Boundary
+
+The controller must call the existing shared in-process
+`Civ7ControlOrpcRouter` or a controller-owned router composed from the same
+native oRPC/effect-orpc primitives. It must not implement a second dispatcher.
+
+Initial source implementation should allowlist a small set of procedures by
+stable `procedureKey`, starting with read-only capability proof such as
+`readiness.current` or `attention.current`. Mutations require a separate
+approved slice with explicit approval evidence, local-player/hotseat identity,
+and postcondition/no-repeat proof handling.
+
+Forbidden ingress keys and payloads:
+
+- raw JavaScript, `game exec`, command text, `rawCommand`, `jsLiteral`;
+- tuner socket host/port/session/state selectors as normal input;
+- direct App UI method names as product procedure keys;
+- generic `control.call`, `runtime.execute`, or bridge-local operation
+  dispatch.
+
+## Context Ownership
+
+Controller runtime assembly owns context construction:
+
+- controller-local access to game globals and lifecycle certification;
+- local-player and hotseat identity evidence;
+- explicit approval tokens for mutation procedures;
+- proof/evidence sinks and bounded logging;
+- correlation IDs passed through existing control-oRPC context;
+- any direct-control runtime/proof port adapters needed by the selected
+  procedure.
+
+Procedure modules must still receive dependencies through typed oRPC context.
+They must not read bridge globals directly.
+
+## Source Implementation Stop Conditions
+
+Do not implement source until the slice names:
+
+- file/package owner for the controller UIScript/mod artifact;
+- contract schemas for ingress request and response;
+- procedure allowlist and risk class for each allowed procedure;
+- context construction owner and test doubles;
+- approval/local-player/hotseat proof owner for any mutation procedure;
+- local package tests and, if runtime behavior is claimed, real-game proof plan.
+
+Stop if an implementation:
+
+- exposes raw command/session/tuner payloads in normal ingress;
+- creates a hand-maintained App UI method table;
+- duplicates oRPC router/middleware/error handling;
+- treats `Civ7IntelligenceBridge.invoke(...)` as the product API;
+- marks local tests as runtime/live-game proof;
+- accepts parent Task 5.x/6.x or `7.3` implementation by implication.
+
+## Verification
+
+This preflight slice closes only on OpenSpec validation and diff hygiene:
+
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+No source implementation, runtime/live-game proof, play-thread action, bridge
+packaging, transport adapter, CLI/Studio change, or OpenAPI work is included.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-global-bridge-source-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-global-bridge-source-slice.md
@@ -1,0 +1,73 @@
+# Controller Global Bridge Source Slice
+
+Status: implemented local package source seed.
+Date: 2026-06-05.
+
+## Purpose
+
+Seed the installable `Civ7IntelligenceBridge` binding without creating a
+product API outside the native control-oRPC router.
+
+This slice adds a package-local bridge object with a single
+`invoke(request)` member and an installer that writes it to a caller-provided
+target. The bridge delegates to the existing controller ingress, which
+validates the serialized envelope and calls the in-process router client for
+`readiness.current`.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/bridge/intelligence-bridge.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/test/intelligence-bridge.test.ts`
+- this OpenSpec record, `tasks.md`, and `specs/civ7-control-orpc/spec.md`
+
+## Behavior Boundary
+
+The global bridge source seed:
+
+- exposes only `invoke(request)`;
+- installs on a caller-provided target;
+- refuses accidental overwrite of an existing bridge unless replacement is
+  explicit;
+- delegates requests to the existing controller ingress instead of
+  implementing a second router, dispatcher, or procedure runner;
+- preserves the ingress rejection of raw command, session, state, endpoint, and
+  mutation approval fields for the current read-only allowlist;
+- returns the same bounded success and failure response shapes as the
+  controller ingress.
+
+The actual Civ7 UIScript/modinfo package remains unimplemented and is the
+future owner that may pass ambient `globalThis`. This package does not own game
+global discovery, local-player/hotseat identity,
+approval-token minting, or runtime lifecycle certification in this slice.
+
+## Non-Goals
+
+- no Civ7 modinfo or UIScript bundle;
+- no runtime/live-game proof or play-thread action;
+- no mutation procedure allowlist;
+- no local-player/hotseat proof, approval-token implementation, or evidence
+  sink;
+- no raw command/session/tuner payload ingress;
+- no HTTP/RPCLink/OpenAPI transport;
+- no custom router, procedure runner, middleware, context bus, or error bus;
+- no full `7.3` acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/intelligence-bridge.test.ts test/controller-bridge-ingress.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+These are local package/OpenSpec proofs only.
+
+## Residual Risk
+
+The repository still needs the actual Civ7 controller UIScript/mod package that
+loads this adapter in the `scope="game"` environment. Mutation ingress remains
+blocked until a separate slice owns local-player/hotseat identity, explicit
+approval, lifecycle certification, and proof/evidence sinks.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-readiness-ingress-source-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-readiness-ingress-source-slice.md
@@ -6,8 +6,8 @@ Date: 2026-06-05.
 ## Purpose
 
 Seed the first source-owned in-game controller ingress component without
-installing `globalThis.Civ7IntelligenceBridge`, adding a mod UIScript package,
-or creating a generic bridge API.
+installing an ambient `globalThis.Civ7IntelligenceBridge`, adding a mod
+UIScript package, or creating a generic bridge API.
 
 This slice proves a narrow serialized ingress path into the existing native
 control-oRPC router: a caller-provided controller runtime factory constructs
@@ -42,7 +42,7 @@ own local-player identity, mint approval tokens, or install a global bridge.
 
 ## Non-Goals
 
-- no `globalThis.Civ7IntelligenceBridge` installation;
+- no ambient `globalThis.Civ7IntelligenceBridge` installation;
 - no modinfo, UIScript bundle, or Civ runtime packaging;
 - no mutation procedure allowlist;
 - no local-player/hotseat identity proof or approval-token implementation;
@@ -65,8 +65,8 @@ These are local package/OpenSpec proofs only.
 
 ## Residual Risk
 
-The global bridge and actual Civ7 UIScript loading path are still unimplemented.
-The next source slice must choose the mod/package owner and build shape before
-installing `globalThis.Civ7IntelligenceBridge.invoke(...)`. Mutation ingress
-also remains blocked on controller-owned approval, local-player/hotseat
+The actual Civ7 UIScript loading path is still unimplemented. A later
+game-scope adapter must choose the mod/package owner and build shape before it
+passes ambient `globalThis` to the package-local bridge binding. Mutation
+ingress also remains blocked on controller-owned approval, local-player/hotseat
 identity, lifecycle certification, and proof/evidence sinks.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-readiness-ingress-source-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-readiness-ingress-source-slice.md
@@ -1,0 +1,72 @@
+# Controller Readiness Ingress Source Slice
+
+Status: implemented local package source seed.
+Date: 2026-06-05.
+
+## Purpose
+
+Seed the first source-owned in-game controller ingress component without
+installing `globalThis.Civ7IntelligenceBridge`, adding a mod UIScript package,
+or creating a generic bridge API.
+
+This slice proves a narrow serialized ingress path into the existing native
+control-oRPC router: a caller-provided controller runtime factory constructs
+typed oRPC context, the bridge validates a closed read-only envelope, the
+procedure key is allowlisted to `readiness.current`, and the implementation
+calls the existing in-process router client.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/bridge/controller-ingress.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts`
+- this OpenSpec record, `tasks.md`, and `specs/civ7-control-orpc/spec.md`
+
+## Behavior Boundary
+
+The controller ingress core:
+
+- validates a closed TypeBox envelope for `readiness.current`;
+- rejects unsupported procedure keys before context construction;
+- rejects host, port, session, state, command, rawCommand, and mutation
+  approval fields in the read-only envelope;
+- passes correlation IDs into existing control-oRPC context;
+- calls `createCiv7ControlOrpcServerClient(context).readiness.current({})`;
+- returns semantic readiness output on success;
+- projects procedure failures into bounded bridge error data without raw
+  direct-control command details.
+
+The controller runtime adapter remains responsible for constructing
+`Civ7ControlOrpcContext`. This package-local core does not read game globals,
+own local-player identity, mint approval tokens, or install a global bridge.
+
+## Non-Goals
+
+- no `globalThis.Civ7IntelligenceBridge` installation;
+- no modinfo, UIScript bundle, or Civ runtime packaging;
+- no mutation procedure allowlist;
+- no local-player/hotseat identity proof or approval-token implementation;
+- no raw command/session/tuner payload ingress;
+- no HTTP/RPCLink/OpenAPI transport;
+- no custom router, procedure runner, middleware, or error bus;
+- no runtime/live-game proof, play-thread action, or full `7.3` acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/controller-bridge-ingress.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+These are local package/OpenSpec proofs only.
+
+## Residual Risk
+
+The global bridge and actual Civ7 UIScript loading path are still unimplemented.
+The next source slice must choose the mod/package owner and build shape before
+installing `globalThis.Civ7IntelligenceBridge.invoke(...)`. Mutation ingress
+also remains blocked on controller-owned approval, local-player/hotseat
+identity, lifecycle certification, and proof/evidence sinks.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/notification-dismissal-contract-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/notification-dismissal-contract-slice.md
@@ -1,0 +1,66 @@
+# Notification Dismissal Service Contract Slice
+
+Status: implemented local package/contract ownership slice.
+Date: 2026-06-05.
+
+## Purpose
+
+Move the caller-facing `notifications.dismiss.request` input schema and normal
+postcondition classification enum into `packages/civ7-control-orpc` service
+ownership.
+
+This continues the separation between service contracts and direct-control
+runtime/proof ports. The procedure still calls the direct-control notification
+dismissal runtime facade and consumes the direct-control proof helper for
+postcondition/no-repeat semantics.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/modules/notifications/contract.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/test/notification-dismissal-procedure.test.ts`
+- this OpenSpec record, `tasks.md`, and `specs/civ7-control-orpc/spec.md`
+
+## Behavior Boundary
+
+The service package now owns:
+
+- `Civ7NotificationDismissInputSchema`
+- `Civ7NotificationDismissalPostconditionClassificationSchema`
+
+The input remains the semantic notification dismissal request shape:
+
+- `notificationId`
+
+It remains closed against raw command/session/tuner endpoint fields. The
+classification enum is the normal service projection vocabulary; the
+direct-control proof helper remains the source authority for runtime
+classification and no-repeat semantics.
+
+## Non-Goals
+
+- no notification dismissal procedure behavior change;
+- no direct-control runtime/proof helper change;
+- no telemetry, persistence, CLI/Studio/browser/controller change;
+- no runtime/live-game proof claim;
+- no play-thread action;
+- no Task 5.x/6.x/7.x parent acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/notification-dismissal-procedure.test.ts test/primitive-schemas.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- notification contract direct-control import scan
+- `git diff --check`
+
+These are local package/contract and OpenSpec proofs only.
+
+## Residual Risk
+
+Other mutation procedure contracts still import direct-control operation input
+schemas or proof vocabularies. Those should be separated through similarly
+small domain-specific slices when their service-owned caller shape is clear.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/production-choice-contract-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/production-choice-contract-slice.md
@@ -1,0 +1,74 @@
+# Production Choice Service Contract Slice
+
+Status: implemented local package/contract ownership slice.
+Date: 2026-06-05.
+
+## Purpose
+
+Move the caller-facing `city.production.choice.request` input schema and normal
+postcondition classification enum into `packages/civ7-control-orpc` service
+ownership.
+
+This continues the separation between service contracts and direct-control
+runtime/proof ports. The procedure still calls the direct-control production
+choice runtime facade and consumes the direct-control proof helpers for
+postcondition/no-repeat semantics.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/modules/city/contract.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/test/city-production-choice-procedure.test.ts`
+- this OpenSpec record, `tasks.md`, and `specs/civ7-control-orpc/spec.md`
+
+## Behavior Boundary
+
+The service package now owns:
+
+- `Civ7CityProductionChoiceInputSchema`
+- `Civ7CityProductionChoicePostconditionClassificationSchema`
+
+The input remains the semantic production choice request shape:
+
+- `cityId`
+- `args`
+
+The args schema admits exactly one valid production choice variant:
+
+- `UnitType`
+- `ProjectType`
+- `ConstructibleType`
+- `ConstructibleType` with `X` and `Y`
+
+The input remains closed against approval, endpoint, session, state, and raw
+command fields. The classification enum is the normal service projection
+vocabulary; the direct-control proof helper remains the source authority for
+runtime classification and no-repeat semantics.
+
+## Non-Goals
+
+- no production choice procedure behavior change;
+- no direct-control runtime/proof helper change;
+- no telemetry, persistence, CLI/Studio/browser/controller change;
+- no runtime/live-game proof claim;
+- no play-thread action;
+- no Task 5.x/6.x/7.x parent acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/city-production-choice-procedure.test.ts test/primitive-schemas.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- city contract direct-control import scan
+- `git diff --check`
+
+These are local package/contract and OpenSpec proofs only.
+
+## Residual Risk
+
+Other mutation procedure contracts may still import direct-control operation
+input schemas or proof vocabularies. Those should be separated through small
+domain-specific slices when their service-owned caller shape is clear.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-choice-decision-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-choice-decision-slice.md
@@ -37,6 +37,8 @@ The service procedure owns:
   closeout request;
 - semantic projection to sent status, evidence summary, postcondition summary,
   and next steps;
+- no-repeat guarded pending-runtime-proof projection when a sent closeout cannot
+  complete the post-send notification read;
 - bounded tagged error projection for direct-control runtime-port failures.
 
 Direct-control remains the source authority for:
@@ -84,7 +86,10 @@ remains pending for any future live mutation closure claim.
 ## Residual Risk
 
 The service procedure performs one before and one after notification read around
-the direct-control closeout request. It does not claim bounded live polling or
-runtime certainty. Sticky blocker and state-changed-blocker-still-live paths
-remain no-repeat guarded and require fresh attention/progression evidence before
-another attempt.
+the direct-control closeout request when a closeout is sent. It does not claim
+bounded live polling or runtime certainty. If the closeout was sent but the
+post-send read fails, the caller receives `sent-unverified` with
+`pending-runtime-proof` confidence and a do-not-repeat next step. Sticky
+blocker and state-changed-blocker-still-live paths also remain no-repeat
+guarded and require fresh attention/progression evidence before another
+attempt.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-choice-decision-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-choice-decision-slice.md
@@ -1,0 +1,90 @@
+# Progression Choice Decision Slice
+
+Status: implemented local package/procedure slice.
+Date: 2026-06-05.
+
+## Purpose
+
+Add `decisions.progression.choice.request` as a native service-owned
+control-oRPC decision procedure for technology and culture node choices.
+
+This consumes the direct-control progression closeout runtime ports and the
+source-owned progression choice postcondition classifiers, while keeping the
+caller-facing procedure contract semantic and closed against raw App UI
+closeout internals.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/dependencies/direct-control.ts`
+- `packages/civ7-control-orpc/src/errors.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/contract.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/router.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/procedures/progression-choice-request.ts`
+- `packages/civ7-control-orpc/test/decisions-progression-choice-procedure.test.ts`
+- this OpenSpec record, `tasks.md`, and
+  `specs/civ7-control-orpc/spec.md`
+
+## Behavior Boundary
+
+The service procedure owns:
+
+- the caller-facing progression kind/player/node/notification input shape;
+- the `decisions.progression.choice.request` contract/router/procedure leaf;
+- approval and playable-readiness composition through existing native
+  effect-oRPC middleware;
+- before/after notification evidence collection around the direct-control
+  closeout request;
+- semantic projection to sent status, evidence summary, postcondition summary,
+  and next steps;
+- bounded tagged error projection for direct-control runtime-port failures.
+
+Direct-control remains the source authority for:
+
+- App UI technology/culture closeout command construction and send authority;
+- Tuner/App UI endpoint execution;
+- progression notification postcondition classification;
+- no-repeat proof semantics consumed by the service projection.
+
+## Raw Surface Exclusions
+
+Normal procedure input and output exclude:
+
+- endpoint/session/state selection;
+- raw command or command-source fields;
+- direct-control `command`, `payload`, `host`, `port`, and `state` envelopes;
+- App UI activation toggles and closeout internals;
+- legacy proof booleans such as `verified`.
+
+## Non-Goals
+
+- no direct-control runtime implementation change;
+- no CLI, Studio, RPCLink, bridge, or in-game controller adapter change;
+- no broad decisions catalog or generic operation router;
+- no custom oRPC/context/middleware/procedure-core plumbing;
+- no shared validator/postcondition middleware acceptance;
+- no runtime/live-game proof claim;
+- no play-thread action;
+- no Task 5.x/6.x/7.x parent acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/decisions-progression-choice-procedure.test.ts`
+- `bun run --cwd packages/civ7-direct-control test test/progression-choice-postconditions.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+These are local package/procedure and OpenSpec proofs only. Runtime proof
+remains pending for any future live mutation closure claim.
+
+## Residual Risk
+
+The service procedure performs one before and one after notification read around
+the direct-control closeout request. It does not claim bounded live polling or
+runtime certainty. Sticky blocker and state-changed-blocker-still-live paths
+remain no-repeat guarded and require fresh attention/progression evidence before
+another attempt.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-choice-proof-policy-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-choice-proof-policy-slice.md
@@ -1,0 +1,75 @@
+# Progression Choice Proof Policy Slice
+
+Status: implemented direct-control proof ownership prework.
+Date: 2026-06-05.
+
+## Purpose
+
+Move technology and culture choice blocker postcondition classification out of
+the CLI commands and into `@civ7/direct-control` progression proof ownership.
+
+This is pre-oRPC service work. It makes future native `decisions` procedures
+able to consume source-owned postcondition policy instead of copying
+caller-local CLI logic or inferring success from raw App UI closeout sends.
+
+## Write Set
+
+- `packages/civ7-direct-control/src/play/progression/choice-postconditions.ts`
+- `packages/civ7-direct-control/src/index.ts`
+- `packages/civ7-direct-control/test/progression-choice-postconditions.test.ts`
+- `packages/cli/src/commands/game/play/choose-tech.ts`
+- `packages/cli/src/commands/game/play/choose-culture.ts`
+- this OpenSpec record, `tasks.md`, the control-oRPC spec delta, and the
+  atom/policy inventory
+
+## Behavior Boundary
+
+Direct-control now owns the shared progression-choice postcondition classifiers:
+
+- `technologyChoicePostcondition`
+- `cultureChoicePostcondition`
+- `findTechnologyChoiceNotification`
+- `findCultureChoiceNotification`
+
+The policy classifies:
+
+- turn-unblocked;
+- blocker-cleared;
+- blocker-transitioned;
+- state-changed while the same blocker remains live;
+- sticky blocker/no clear proof.
+
+The CLI still owns shell flags, option display, send orchestration, and normal
+CLI output. The CLI no longer owns the post-send blocker proof policy for
+technology or culture choice closeouts.
+
+## Non-Goals
+
+- no control-oRPC procedure, router, middleware, or transport change;
+- no shared validator/postcondition middleware promotion;
+- no change to technology/culture App UI closeout send behavior;
+- no raw command/session/payload projection into native service outputs;
+- no runtime/live-game proof claim;
+- no play-thread action;
+- no Task 5.x/6.x/7.x parent acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-direct-control test test/progression-choice-postconditions.test.ts`
+- `bun run test:cli:play`
+- `bun run --cwd packages/civ7-direct-control check`
+- `bun run --cwd packages/civ7-direct-control build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+These are local package and CLI proofs only. Runtime proof remains pending for
+any future live mutation closure claim.
+
+## Residual Risk
+
+Technology and culture choice request wrappers still return raw App UI closeout
+payloads from direct-control. A future native `decisions` procedure must own the
+caller-facing semantic contract and projection, consume this proof policy, and
+preserve no-repeat guarding for sticky or state-changed-blocker-still-live
+paths.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/raw-root-type-export-burndown-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/raw-root-type-export-burndown-slice.md
@@ -1,0 +1,75 @@
+# Raw Root Type Export Burn-Down Slice
+
+Status: implemented local package/API hygiene slice.
+Date: 2026-06-05.
+
+## Purpose
+
+Keep `@civ7/control-orpc`'s caller-facing root entrypoint aligned with the
+native service-owner direction by removing public exports of direct-control
+runtime-port result aliases.
+
+The service package still needs a typed direct-control facade in context so
+CLI, Studio, and controller adapters can construct the native oRPC context.
+That facade is a dependency boundary. The raw result envelopes flowing through
+that dependency are not caller-facing service output and should not be
+advertised as package root API.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/index.ts`
+- `apps/mapgen-studio/test/runInGame/civ7ControlOrpcClient.test.ts`
+- this OpenSpec record, `tasks.md`, and `specs/civ7-control-orpc/spec.md`
+
+## Behavior Boundary
+
+This slice removes root exports for raw direct-control runtime result aliases:
+
+- playable status;
+- play notification view;
+- ready-unit and ready-city view;
+- turn completion status;
+- production choice;
+- notification dismissal;
+- unit target action.
+
+The root entrypoint continues to export semantic control-oRPC contracts,
+routers, procedure schemas/results, bridge ingress/bindings, tagged errors,
+server-side clients, `Civ7ControlOrpcContext`,
+`Civ7ControlOrpcDirectControlFacade`, and
+`liveCiv7ControlOrpcDirectControlFacade`.
+
+The Studio RPCLink test now imports its fake runtime playable-status fixture
+type from `@civ7/direct-control`, the package that owns that low-level shape,
+instead of from the control-oRPC root.
+
+## Non-Goals
+
+- no changes to procedure contracts or normal outputs;
+- no changes to direct-control runtime/proof authority;
+- no removal of the context facade type needed by edge adapters;
+- no transport, CLI, Studio behavior, controller bridge, or runtime proof
+  change;
+- no broad package export redesign;
+- no Task 5.x/6.x/7.x parent acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun test apps/mapgen-studio/test/runInGame/civ7ControlOrpcClient.test.ts`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- public root-export scan for `Civ7ControlOrpc*Result` runtime-port aliases
+- `git diff --check`
+
+These are local package/API and OpenSpec proofs only.
+
+## Residual Risk
+
+`packages/civ7-control-orpc/src/dependencies/direct-control.ts` still contains
+runtime-port result aliases because service procedures and package-local tests
+need typed fake port results. That is intentional internal dependency typing,
+not root caller-facing API. A broader dependency module split can happen later
+if repeated runtime-port typing becomes hard to review.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/raw-root-type-export-burndown-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/raw-root-type-export-burndown-slice.md
@@ -35,9 +35,11 @@ This slice removes root exports for raw direct-control runtime result aliases:
 
 The root entrypoint continues to export semantic control-oRPC contracts,
 routers, procedure schemas/results, bridge ingress/bindings, tagged errors,
-server-side clients, `Civ7ControlOrpcContext`,
-`Civ7ControlOrpcDirectControlFacade`, and
-`liveCiv7ControlOrpcDirectControlFacade`.
+server-side clients, and `Civ7ControlOrpcContext`.
+
+Follow-up stack work moved `Civ7ControlOrpcDirectControlFacade` and
+`liveCiv7ControlOrpcDirectControlFacade` behind the explicit
+`@civ7/control-orpc/runtime` entrypoint for edge-adapter context construction.
 
 The Studio RPCLink test now imports its fake runtime playable-status fixture
 type from `@civ7/direct-control`, the package that owns that low-level shape,

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/runtime-entrypoint-split-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/runtime-entrypoint-split-slice.md
@@ -1,0 +1,71 @@
+# Runtime Entrypoint Split Slice
+
+Status: implemented local package/API hygiene slice.
+Date: 2026-06-05.
+
+## Purpose
+
+Keep the `@civ7/control-orpc` root entrypoint focused on native service
+contracts, routers, clients, bridge ingress/bindings, typed errors, and
+semantic procedure schemas/results while preserving a supported import path for
+edge adapters that need the live direct-control runtime facade to construct
+context.
+
+This is not a new runtime abstraction. It is an explicit package boundary:
+`@civ7/control-orpc/runtime` exposes the live direct-control facade and facade
+type for caller/runtime adapter construction; normal service callers use the
+root service API.
+
+## Write Set
+
+- `packages/civ7-control-orpc/package.json`
+- `packages/civ7-control-orpc/tsup.config.ts`
+- `packages/civ7-control-orpc/src/runtime.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/cli/src/commands/game/status.ts`
+- `apps/mapgen-studio/src/server/civ7ControlOrpc.ts`
+- this OpenSpec record, `tasks.md`, `specs/civ7-control-orpc/spec.md`, and the
+  prior root-export burn-down note
+
+## Behavior Boundary
+
+The new `@civ7/control-orpc/runtime` subpath exports:
+
+- `liveCiv7ControlOrpcDirectControlFacade`;
+- `Civ7ControlOrpcDirectControlFacade`.
+
+The root `@civ7/control-orpc` entrypoint no longer exports those runtime
+context-construction dependencies. CLI `game status` and the Studio RPCHandler
+middleware now import service/router/client types from the root entrypoint and
+the live direct-control facade from the runtime subpath.
+
+## Non-Goals
+
+- no change to procedure behavior, router shape, or normal output;
+- no change to direct-control runtime/proof authority;
+- no raw result envelope export from the root or runtime entrypoint;
+- no transport expansion, OpenAPI work, controller mutation ingress, runtime
+  proof, play-thread action, or parent Task 5.x/6.x/7.x acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun test apps/mapgen-studio/test/runInGame/civ7ControlOrpcClient.test.ts`
+- `bun run --cwd apps/mapgen-studio check`
+- `bun run --cwd packages/cli check`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- root facade-export scan for `liveCiv7ControlOrpcDirectControlFacade` and
+  `Civ7ControlOrpcDirectControlFacade`
+- `git diff --check`
+
+These are local package/API, CLI/Studio type, and OpenSpec proofs only.
+
+## Residual Risk
+
+The runtime subpath is still Node/direct-control-facing and should not be used
+from browser or Civ7 game-scope code unless a later adapter proves the bundle
+boundary. Browser clients should keep importing typed RPC clients/contracts from
+the service root, not the runtime subpath.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/service-primitive-schema-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/service-primitive-schema-slice.md
@@ -1,0 +1,70 @@
+# Service Primitive Schema Slice
+
+Status: implemented local package/schema ownership slice.
+Date: 2026-06-05.
+
+## Purpose
+
+Move shared caller-facing primitive schemas for component IDs and map
+locations into `packages/civ7-control-orpc` service model ownership, instead
+of importing direct-control primitive value schemas into service contracts.
+
+This reduces accidental coupling between the service root bundle and
+direct-control runtime exports without changing runtime/proof authority. The
+schemas are intentionally equivalent to the current direct-control primitive
+schemas.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/model/primitives.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- service contracts under `src/modules/{attention,notifications,city,unit,decisions,strategy}/contract.ts`
+- `packages/civ7-control-orpc/test/primitive-schemas.test.ts`
+- this OpenSpec record, `tasks.md`, and `specs/civ7-control-orpc/spec.md`
+
+## Behavior Boundary
+
+The service model now owns:
+
+- `Civ7ControlOrpcComponentIdSchema`
+- `Civ7ControlOrpcMapLocationSchema`
+
+These are used for caller-facing component/map fields in service contracts and
+normal service outputs. Focused proof checks they accept/reject the same
+representative component-id and map-location fixtures as the current
+direct-control primitive schemas.
+
+This slice does not move operation-specific input schemas, validators, or
+proof helpers. Those remain direct-control runtime/proof ports until a later
+service-contract slice separates them deliberately.
+
+## Non-Goals
+
+- no procedure behavior change;
+- no change to direct-control runtime validators, proof helpers, or command
+  authority;
+- no schema migration away from TypeBox;
+- no runtime/live-game proof claim;
+- no play-thread action;
+- no Task 5.x/6.x/7.x parent acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/primitive-schemas.test.ts test/attention-current-procedure.test.ts test/notification-dismissal-procedure.test.ts test/city-population-placement-procedure.test.ts test/strategy-front-summary-procedure.test.ts test/unit-target-action-procedure.test.ts test/decisions-narrative-choice-procedure.test.ts test/decisions-diplomacy-response-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- primitive import scan for `Civ7ComponentIdSchema` and
+  `Civ7MapLocationSchema` in service contracts
+- `git diff --check`
+
+These are local package/schema and OpenSpec proofs only.
+
+## Residual Risk
+
+The root service bundle still imports direct-control value exports for
+operation-specific schemas and proof helpers. That is not closed by this
+primitive slice; it is the next class of service-contract/runtime-port
+separation work and should be handled by smaller domain-specific slices.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/turn-completion-native-procedure-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/turn-completion-native-procedure-slice.md
@@ -1,0 +1,40 @@
+# Turn Completion Native Procedure Slice
+
+## Scope
+
+Add `turn.complete.request` as a native control-oRPC service procedure under
+the semantic `turn` router. The procedure owns the caller-facing empty input,
+semantic turn-completion output projection, request status, and next-step
+wording. `@civ7/direct-control` remains the runtime/proof authority for
+`sendCiv7TurnComplete`, command serialization, and the turn-completion
+postcondition/no-repeat helper.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/modules/turn/contract.ts`
+- `packages/civ7-control-orpc/src/modules/turn/procedures/complete-request.ts`
+- `packages/civ7-control-orpc/src/modules/turn/router.ts`
+- Root control-oRPC contract/router/index/error/runtime-port wiring
+- `packages/civ7-control-orpc/test/turn-completion-procedure.test.ts`
+- This OpenSpec scenario/task/workstream record
+
+## Boundary
+
+- No CLI `game play end-turn` or other edge-adapter migration.
+- No Studio, controller bridge, transport, OpenAPI, or RPCLink work.
+- No direct-control procedure-core scaffolding or caller-local command tunnel.
+- No raw command/session/state/Tuner payloads or legacy `verified` in normal
+  procedure input/output.
+- No play-thread wake and no live-game/runtime proof claim.
+- No parent Task 5.x/6.x/7.x acceptance by implication.
+
+## Proof
+
+- Focused package proof calls the procedure in process with fake context and a
+  fake direct-control runtime port.
+- Tests cover context-owned empty input, approval before readiness/mutation,
+  playable readiness before mutation, server-side client calls, tagged failure
+  projection, raw-output omission, confirmed turn-advanced projection, and
+  guarded turn-complete-sent/no-state-change/missing-postcondition paths.
+- Closure still requires package test/check/build, relevant OpenSpec strict
+  validation, diff hygiene, and a durable Graphite commit.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/turn-completion-proof-policy-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/turn-completion-proof-policy-slice.md
@@ -1,0 +1,76 @@
+# Turn Completion Proof Policy Slice
+
+Status: implemented direct-control proof ownership prework.
+Date: 2026-06-05.
+
+## Purpose
+
+Add a source-owned turn-completion proof/no-repeat helper in
+`@civ7/direct-control` before any native turn completion mutation procedure is
+accepted in `packages/civ7-control-orpc`.
+
+This is service-enabling prework. The existing direct-control runtime send still
+owns the App UI `GameContext.sendTurnComplete()` authority, before/after turn
+completion reads, fallback preflight, approval assertion, and command
+serialization. The new proof helper gives future native procedures a stable
+postcondition/no-repeat port instead of inferring repeat safety from legacy
+`verified`.
+
+## Write Set
+
+- `packages/civ7-direct-control/src/proof/turn-completion-proof-policy.ts`
+- `packages/civ7-direct-control/src/index.ts`
+- `packages/civ7-direct-control/test/turn-completion-proof-policy.test.ts`
+- this OpenSpec record, `tasks.md`, the control-oRPC spec delta, and the
+  atom/policy inventory
+
+## Behavior Boundary
+
+Direct-control now owns turn-completion proof classification for:
+
+- `turn-advanced`;
+- `turn-complete-sent`;
+- `already-complete`;
+- `no-state-change`;
+- `missing-postcondition`;
+- `pending-runtime-proof`.
+
+Only `turn-advanced` is confirmed without a no-repeat guard. A confirmed
+`turn-complete-sent` or `already-complete` postcondition is still no-repeat
+guarded because the player agent must wait for fresh turn/attention evidence
+instead of sending turn completion again. Missing, no-state-change, and pending
+runtime proof paths stay unverified or pending and no-repeat guarded.
+
+## Non-Goals
+
+- no control-oRPC procedure, router, middleware, or transport change;
+- no CLI `game play end-turn` behavior change;
+- no change to direct-control App UI send behavior or fallback preflight;
+- no shared validator/postcondition middleware promotion;
+- no runtime/live-game proof claim;
+- no play-thread action;
+- no Task 5.x/6.x/7.x parent acceptance.
+
+## Proof Collected
+
+Closure gates:
+
+- `bun run --cwd packages/civ7-direct-control test test/turn-completion-proof-policy.test.ts`
+- `bun run --cwd packages/civ7-direct-control test`
+- `bun run --cwd packages/civ7-direct-control check`
+- `bun run --cwd packages/civ7-direct-control build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+These are local package/OpenSpec proofs only. Runtime proof remains pending for
+any future live turn-completion mutation closure claim.
+
+## Residual Risk
+
+`game play end-turn` still calls direct-control directly and emits raw
+direct-control action results when `--send` is used. A future native
+`turn.complete.request` procedure must own the caller-facing semantic contract
+and projection, consume this proof policy, keep approval/readiness in native
+middleware/context, and exclude raw command/session/tuner fields from normal
+input and output.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/unit-target-action-contract-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/unit-target-action-contract-slice.md
@@ -1,0 +1,66 @@
+# Unit Target Action Service Contract Slice
+
+Status: implemented local package/contract ownership slice.
+Date: 2026-06-05.
+
+## Purpose
+
+Move the caller-facing `unit.target.action.request` input schema into
+`packages/civ7-control-orpc` service ownership.
+
+This continues the separation between service contracts and direct-control
+runtime/proof ports. The procedure still calls the direct-control unit target
+action runtime facade and consumes the direct-control proof helper for
+verification/no-repeat semantics.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/modules/unit/contract.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/test/unit-target-action-procedure.test.ts`
+- this OpenSpec record, `tasks.md`, and `specs/civ7-control-orpc/spec.md`
+
+## Behavior Boundary
+
+The service package now owns:
+
+- `Civ7UnitTargetActionInputSchema`
+
+The input remains the semantic unit target action request shape:
+
+- `unitId`
+- bounded integer `x`
+- bounded integer `y`
+
+The input remains closed against approval, endpoint, session, state, and raw
+command fields. Unit target action verification classification, proof outcome,
+and no-repeat semantics remain direct-control proof authority consumed by the
+procedure.
+
+## Non-Goals
+
+- no unit target action procedure behavior change;
+- no direct-control runtime/proof helper change;
+- no telemetry, persistence, CLI/Studio/browser/controller change;
+- no runtime/live-game proof claim;
+- no play-thread action;
+- no Task 5.x/6.x/7.x parent acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/unit-target-action-procedure.test.ts test/primitive-schemas.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- unit contract direct-control import scan
+- `git diff --check`
+
+These are local package/contract and OpenSpec proofs only.
+
+## Residual Risk
+
+Other procedure contracts may still import direct-control operation input
+schemas or proof vocabularies. Those should be separated through small
+domain-specific slices when their service-owned caller shape is clear.

--- a/packages/civ7-control-orpc/package.json
+++ b/packages/civ7-control-orpc/package.json
@@ -34,7 +34,8 @@
   },
   "scripts": {
     "build": "tsup --config tsup.config.ts && rimraf tsconfig.tsbuildinfo && tsc -p tsconfig.json --emitDeclarationOnly --noEmit false",
-    "check": "tsc -p tsconfig.json --noEmit",
+    "check": "tsc -p tsconfig.json --noEmit && bun ../../scripts/lint/lint-control-orpc-contract-ownership.mjs",
+    "lint:contract-ownership": "bun ../../scripts/lint/lint-control-orpc-contract-ownership.mjs",
     "test": "vitest run --config vitest.config.ts",
     "clean": "rimraf dist"
   },

--- a/packages/civ7-control-orpc/package.json
+++ b/packages/civ7-control-orpc/package.json
@@ -7,6 +7,16 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "runtime": [
+        "./dist/runtime.d.ts"
+      ],
+      "*": [
+        "./dist/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],
@@ -15,6 +25,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./runtime": {
+      "types": "./dist/runtime.d.ts",
+      "import": "./dist/runtime.js",
+      "require": "./dist/runtime.cjs"
     }
   },
   "scripts": {

--- a/packages/civ7-control-orpc/src/bridge/controller-ingress.ts
+++ b/packages/civ7-control-orpc/src/bridge/controller-ingress.ts
@@ -6,6 +6,10 @@ import { createCiv7ControlOrpcServerClient } from "../client";
 import type { Civ7ControlOrpcContext } from "../context";
 import { Civ7ControlOrpcCorrelationIdSchema } from "../model/correlation";
 import {
+  Civ7AttentionCurrentInputSchema,
+  Civ7AttentionCurrentResultSchema,
+} from "../modules/attention/contract";
+import {
   Civ7ReadinessCurrentInputSchema,
   Civ7ReadinessCurrentResultSchema,
 } from "../modules/readiness/contract";
@@ -22,10 +26,25 @@ export type Civ7ControllerBridgeReadinessCurrentRequest = Static<
   typeof Civ7ControllerBridgeReadinessCurrentRequestSchema
 >;
 
-export const Civ7ControllerBridgeRequestSchema =
-  Civ7ControllerBridgeReadinessCurrentRequestSchema;
+export const Civ7ControllerBridgeAttentionCurrentRequestSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("attention.current"),
+    input: Civ7AttentionCurrentInputSchema,
+    correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ControllerBridgeAttentionCurrentRequest = Static<
+  typeof Civ7ControllerBridgeAttentionCurrentRequestSchema
+>;
+
+export const Civ7ControllerBridgeRequestSchema = Type.Union([
+  Civ7ControllerBridgeReadinessCurrentRequestSchema,
+  Civ7ControllerBridgeAttentionCurrentRequestSchema,
+]);
 export type Civ7ControllerBridgeRequest =
-  Civ7ControllerBridgeReadinessCurrentRequest;
+  | Civ7ControllerBridgeReadinessCurrentRequest
+  | Civ7ControllerBridgeAttentionCurrentRequest;
 
 export const Civ7ControllerBridgeErrorSchema = Type.Object(
   {
@@ -43,18 +62,41 @@ export type Civ7ControllerBridgeError = Static<
   typeof Civ7ControllerBridgeErrorSchema
 >;
 
-export const Civ7ControllerBridgeSuccessResponseSchema = Type.Object(
-  {
-    ok: Type.Literal(true),
-    procedureKey: Type.Literal("readiness.current"),
-    output: Civ7ReadinessCurrentResultSchema,
-    correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
-  },
-  { additionalProperties: false },
-);
-export type Civ7ControllerBridgeSuccessResponse = Static<
-  typeof Civ7ControllerBridgeSuccessResponseSchema
+export const Civ7ControllerBridgeReadinessCurrentSuccessResponseSchema =
+  Type.Object(
+    {
+      ok: Type.Literal(true),
+      procedureKey: Type.Literal("readiness.current"),
+      output: Civ7ReadinessCurrentResultSchema,
+      correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
+    },
+    { additionalProperties: false },
+  );
+export type Civ7ControllerBridgeReadinessCurrentSuccessResponse = Static<
+  typeof Civ7ControllerBridgeReadinessCurrentSuccessResponseSchema
 >;
+
+export const Civ7ControllerBridgeAttentionCurrentSuccessResponseSchema =
+  Type.Object(
+    {
+      ok: Type.Literal(true),
+      procedureKey: Type.Literal("attention.current"),
+      output: Civ7AttentionCurrentResultSchema,
+      correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
+    },
+    { additionalProperties: false },
+  );
+export type Civ7ControllerBridgeAttentionCurrentSuccessResponse = Static<
+  typeof Civ7ControllerBridgeAttentionCurrentSuccessResponseSchema
+>;
+
+export const Civ7ControllerBridgeSuccessResponseSchema = Type.Union([
+  Civ7ControllerBridgeReadinessCurrentSuccessResponseSchema,
+  Civ7ControllerBridgeAttentionCurrentSuccessResponseSchema,
+]);
+export type Civ7ControllerBridgeSuccessResponse =
+  | Civ7ControllerBridgeReadinessCurrentSuccessResponse
+  | Civ7ControllerBridgeAttentionCurrentSuccessResponse;
 
 export const Civ7ControllerBridgeFailureResponseSchema = Type.Object(
   {
@@ -127,10 +169,22 @@ export async function invokeCiv7ControllerBridgeRequest(
             correlationId: request.correlationId,
           },
     });
-    const output = await client.readiness.current(request.input);
+    if (request.procedureKey === "readiness.current") {
+      const output = await client.readiness.current(request.input);
+      return {
+        ok: true,
+        procedureKey: "readiness.current",
+        output,
+        ...(request.correlationId == null
+          ? {}
+          : { correlationId: request.correlationId }),
+      };
+    }
+
+    const output = await client.attention.current(request.input);
     return {
       ok: true,
-      procedureKey: "readiness.current",
+      procedureKey: "attention.current",
       output,
       ...(request.correlationId == null
         ? {}
@@ -147,7 +201,8 @@ function isUnsupportedProcedureRequest(
   if (request == null || typeof request !== "object") return false;
   if (!("procedureKey" in request)) return false;
   return typeof request.procedureKey === "string"
-    && request.procedureKey !== "readiness.current";
+    && request.procedureKey !== "readiness.current"
+    && request.procedureKey !== "attention.current";
 }
 
 function safeBridgeProcedureError(err: unknown): Civ7ControllerBridgeError {

--- a/packages/civ7-control-orpc/src/bridge/controller-ingress.ts
+++ b/packages/civ7-control-orpc/src/bridge/controller-ingress.ts
@@ -1,0 +1,179 @@
+import { ORPCError } from "@orpc/server";
+import { Type, type Static } from "typebox";
+import { Value } from "typebox/value";
+
+import { createCiv7ControlOrpcServerClient } from "../client";
+import type { Civ7ControlOrpcContext } from "../context";
+import { Civ7ControlOrpcCorrelationIdSchema } from "../model/correlation";
+import {
+  Civ7ReadinessCurrentInputSchema,
+  Civ7ReadinessCurrentResultSchema,
+} from "../modules/readiness/contract";
+
+export const Civ7ControllerBridgeReadinessCurrentRequestSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("readiness.current"),
+    input: Civ7ReadinessCurrentInputSchema,
+    correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ControllerBridgeReadinessCurrentRequest = Static<
+  typeof Civ7ControllerBridgeReadinessCurrentRequestSchema
+>;
+
+export const Civ7ControllerBridgeRequestSchema =
+  Civ7ControllerBridgeReadinessCurrentRequestSchema;
+export type Civ7ControllerBridgeRequest =
+  Civ7ControllerBridgeReadinessCurrentRequest;
+
+export const Civ7ControllerBridgeErrorSchema = Type.Object(
+  {
+    code: Type.String({ minLength: 1 }),
+    message: Type.String({ minLength: 1 }),
+    reason: Type.Union([
+      Type.Literal("invalid-envelope"),
+      Type.Literal("procedure-not-allowed"),
+      Type.Literal("procedure-failed"),
+    ]),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ControllerBridgeError = Static<
+  typeof Civ7ControllerBridgeErrorSchema
+>;
+
+export const Civ7ControllerBridgeSuccessResponseSchema = Type.Object(
+  {
+    ok: Type.Literal(true),
+    procedureKey: Type.Literal("readiness.current"),
+    output: Civ7ReadinessCurrentResultSchema,
+    correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ControllerBridgeSuccessResponse = Static<
+  typeof Civ7ControllerBridgeSuccessResponseSchema
+>;
+
+export const Civ7ControllerBridgeFailureResponseSchema = Type.Object(
+  {
+    ok: Type.Literal(false),
+    error: Civ7ControllerBridgeErrorSchema,
+    correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ControllerBridgeFailureResponse = Static<
+  typeof Civ7ControllerBridgeFailureResponseSchema
+>;
+
+export const Civ7ControllerBridgeResponseSchema = Type.Union([
+  Civ7ControllerBridgeSuccessResponseSchema,
+  Civ7ControllerBridgeFailureResponseSchema,
+]);
+export type Civ7ControllerBridgeResponse = Static<
+  typeof Civ7ControllerBridgeResponseSchema
+>;
+
+export type Civ7ControllerBridgeContextFactory = (
+  request: Civ7ControllerBridgeRequest,
+) => Civ7ControlOrpcContext | Promise<Civ7ControlOrpcContext>;
+
+export type Civ7ControllerBridgeIngress = Readonly<{
+  invoke(request: unknown): Promise<Civ7ControllerBridgeResponse>;
+}>;
+
+export function createCiv7ControllerBridgeIngress(
+  options: Readonly<{
+    createContext: Civ7ControllerBridgeContextFactory;
+  }>,
+): Civ7ControllerBridgeIngress {
+  return {
+    invoke: (request) => invokeCiv7ControllerBridgeRequest(request, options),
+  };
+}
+
+export async function invokeCiv7ControllerBridgeRequest(
+  request: unknown,
+  options: Readonly<{
+    createContext: Civ7ControllerBridgeContextFactory;
+  }>,
+): Promise<Civ7ControllerBridgeResponse> {
+  if (isUnsupportedProcedureRequest(request)) {
+    return bridgeFailure({
+      code: "BRIDGE_PROCEDURE_NOT_ALLOWED",
+      message: "Civ7 controller bridge procedure is not allowlisted.",
+      reason: "procedure-not-allowed",
+    });
+  }
+
+  if (!Value.Check(Civ7ControllerBridgeRequestSchema, request)) {
+    return bridgeFailure({
+      code: "BRIDGE_BAD_REQUEST",
+      message: "Civ7 controller bridge request envelope is invalid.",
+      reason: "invalid-envelope",
+    });
+  }
+
+  try {
+    const context = await options.createContext(request);
+    const client = createCiv7ControlOrpcServerClient({
+      ...context,
+      correlation: request.correlationId == null
+        ? context.correlation
+        : {
+            ...context.correlation,
+            correlationId: request.correlationId,
+          },
+    });
+    const output = await client.readiness.current(request.input);
+    return {
+      ok: true,
+      procedureKey: "readiness.current",
+      output,
+      ...(request.correlationId == null
+        ? {}
+        : { correlationId: request.correlationId }),
+    };
+  } catch (err) {
+    return bridgeFailure(safeBridgeProcedureError(err), request);
+  }
+}
+
+function isUnsupportedProcedureRequest(
+  request: unknown,
+): request is Readonly<{ procedureKey: string }> {
+  if (request == null || typeof request !== "object") return false;
+  if (!("procedureKey" in request)) return false;
+  return typeof request.procedureKey === "string"
+    && request.procedureKey !== "readiness.current";
+}
+
+function safeBridgeProcedureError(err: unknown): Civ7ControllerBridgeError {
+  if (err instanceof ORPCError && typeof err.code === "string") {
+    return {
+      code: err.code,
+      message: err.message || "Civ7 controller bridge procedure failed.",
+      reason: "procedure-failed",
+    };
+  }
+  return {
+    code: "BRIDGE_PROCEDURE_FAILED",
+    message: "Civ7 controller bridge procedure failed.",
+    reason: "procedure-failed",
+  };
+}
+
+function bridgeFailure(
+  error: Civ7ControllerBridgeError,
+  request?: Civ7ControllerBridgeRequest,
+): Civ7ControllerBridgeFailureResponse {
+  return {
+    ok: false,
+    error,
+    ...(request?.correlationId == null
+      ? {}
+      : { correlationId: request.correlationId }),
+  };
+}

--- a/packages/civ7-control-orpc/src/bridge/intelligence-bridge.ts
+++ b/packages/civ7-control-orpc/src/bridge/intelligence-bridge.ts
@@ -1,0 +1,49 @@
+import {
+  createCiv7ControllerBridgeIngress,
+  type Civ7ControllerBridgeContextFactory,
+  type Civ7ControllerBridgeResponse,
+} from "./controller-ingress";
+
+export const CIV7_INTELLIGENCE_BRIDGE_GLOBAL_KEY = "Civ7IntelligenceBridge";
+
+export type Civ7IntelligenceBridge = Readonly<{
+  invoke(request: unknown): Promise<Civ7ControllerBridgeResponse>;
+}>;
+
+export type Civ7IntelligenceBridgeGlobalTarget = {
+  Civ7IntelligenceBridge?: Civ7IntelligenceBridge;
+};
+
+export type Civ7IntelligenceBridgeInstallOptions = Readonly<{
+  createContext: Civ7ControllerBridgeContextFactory;
+  target: Civ7IntelligenceBridgeGlobalTarget;
+  replaceExisting?: boolean;
+}>;
+
+export function createCiv7IntelligenceBridge(
+  options: Readonly<{
+    createContext: Civ7ControllerBridgeContextFactory;
+  }>,
+): Civ7IntelligenceBridge {
+  const ingress = createCiv7ControllerBridgeIngress({
+    createContext: options.createContext,
+  });
+  return {
+    invoke: (request) => ingress.invoke(request),
+  };
+}
+
+export function installCiv7IntelligenceBridge(
+  options: Civ7IntelligenceBridgeInstallOptions,
+): Civ7IntelligenceBridge {
+  const target = options.target;
+  if (target.Civ7IntelligenceBridge != null && options.replaceExisting !== true) {
+    throw new Error("Civ7IntelligenceBridge is already installed.");
+  }
+
+  const bridge = createCiv7IntelligenceBridge({
+    createContext: options.createContext,
+  });
+  target.Civ7IntelligenceBridge = bridge;
+  return bridge;
+}

--- a/packages/civ7-control-orpc/src/contract.ts
+++ b/packages/civ7-control-orpc/src/contract.ts
@@ -24,6 +24,10 @@ import {
   type Civ7StrategyContract as Civ7StrategyContractType,
 } from "./modules/strategy/contract";
 import {
+  Civ7TurnContract,
+  type Civ7TurnContract as Civ7TurnContractType,
+} from "./modules/turn/contract";
+import {
   Civ7UnitContract,
   type Civ7UnitContract as Civ7UnitContractType,
 } from "./modules/unit/contract";
@@ -35,6 +39,7 @@ export type Civ7ControlOrpcContract = Readonly<{
   notifications: Civ7NotificationsContractType;
   readiness: Civ7ReadinessContractType;
   strategy: Civ7StrategyContractType;
+  turn: Civ7TurnContractType;
   unit: Civ7UnitContractType;
 }>;
 
@@ -46,5 +51,6 @@ export const Civ7ControlOrpcContract: Civ7ControlOrpcContract =
     notifications: Civ7NotificationsContract,
     readiness: Civ7ReadinessContract,
     strategy: Civ7StrategyContract,
+    turn: Civ7TurnContract,
     unit: Civ7UnitContract,
   });

--- a/packages/civ7-control-orpc/src/dependencies/direct-control.ts
+++ b/packages/civ7-control-orpc/src/dependencies/direct-control.ts
@@ -6,6 +6,7 @@ import {
   getCiv7ReadyUnitView,
   getCiv7TargetCandidates,
   getCiv7TurnCompletionStatus,
+  sendCiv7TurnComplete,
   requestCiv7DiplomacyResponse,
   requestCiv7CultureChoiceCloseout,
   requestCiv7NarrativeChoice,
@@ -44,6 +45,7 @@ import {
   type Civ7TargetCandidatesInput,
   type Civ7TechnologyChoiceCloseoutInput,
   type Civ7TechnologyChoiceCloseoutResult,
+  type Civ7TurnCompletionActionResult,
   type Civ7UnitTargetActionInput,
   type PlayNotificationViewOptions,
 } from "@civ7/direct-control";
@@ -58,6 +60,8 @@ export type Civ7ControlOrpcCultureChoiceCloseoutResult =
 export type Civ7ControlOrpcNarrativeChoiceResult = Civ7NarrativeChoiceResult;
 export type Civ7ControlOrpcTechnologyChoiceCloseoutResult =
   Civ7TechnologyChoiceCloseoutResult;
+export type Civ7ControlOrpcTurnCompletionActionResult =
+  Civ7TurnCompletionActionResult;
 type Civ7ControlOrpcPopulationPlacementRuntimeResult =
   Civ7PopulationPlacementProofSource & Readonly<{
     before: Readonly<{ valid: boolean }>;
@@ -137,6 +141,10 @@ export type Civ7ControlOrpcDirectControlFacade = Readonly<{
     options: Civ7DirectControlOptions | undefined,
     approval: Civ7ActionApproval,
   ): Promise<Civ7ControlOrpcUnitTargetActionResult>;
+  requestCiv7TurnComplete(
+    options: Civ7DirectControlOptions | undefined,
+    approval: Civ7ActionApproval,
+  ): Promise<Civ7ControlOrpcTurnCompletionActionResult>;
   getCiv7PlayableStatus(
     options?: Civ7DirectControlOptions,
   ): Promise<Civ7ControlOrpcPlayableStatusResult>;
@@ -194,6 +202,8 @@ export const liveCiv7ControlOrpcDirectControlFacade:
     requestCiv7UnitTargetAction(input, options, approval) as Promise<
       Civ7ControlOrpcUnitTargetActionResult
     >,
+  requestCiv7TurnComplete: async (options, approval) =>
+    sendCiv7TurnComplete(options, approval),
   getCiv7PlayableStatus: async (options) =>
     getCiv7PlayableStatus(options) as Promise<
       Civ7ControlOrpcPlayableStatusResult

--- a/packages/civ7-control-orpc/src/dependencies/direct-control.ts
+++ b/packages/civ7-control-orpc/src/dependencies/direct-control.ts
@@ -7,11 +7,13 @@ import {
   getCiv7TargetCandidates,
   getCiv7TurnCompletionStatus,
   requestCiv7DiplomacyResponse,
+  requestCiv7CultureChoiceCloseout,
   requestCiv7NarrativeChoice,
   requestCiv7NotificationDismissal,
   requestCiv7CityCommand,
   requestCiv7PlayerOperation,
   requestCiv7ProductionChoice,
+  requestCiv7TechnologyChoiceCloseout,
   requestCiv7UnitTargetAction,
   type Civ7ActionApproval,
   type Civ7ComponentId,
@@ -19,6 +21,8 @@ import {
   Civ7BattlefieldScanResultSchema,
   type Civ7DiplomacyResponseInput,
   type Civ7DiplomacyResponseResult,
+  type Civ7CultureChoiceCloseoutInput,
+  type Civ7CultureChoiceCloseoutResult,
   type Civ7NarrativeChoiceInput,
   type Civ7NarrativeChoiceResult,
   Civ7PlayNotificationViewResultSchema,
@@ -38,6 +42,8 @@ import {
   type Civ7ReadyCityViewInput,
   type Civ7ReadyUnitViewInput,
   type Civ7TargetCandidatesInput,
+  type Civ7TechnologyChoiceCloseoutInput,
+  type Civ7TechnologyChoiceCloseoutResult,
   type Civ7UnitTargetActionInput,
   type PlayNotificationViewOptions,
 } from "@civ7/direct-control";
@@ -47,7 +53,11 @@ export type Civ7ControlOrpcNotificationDismissalResult =
   Civ7NotificationDismissalResult;
 export type Civ7ControlOrpcDiplomacyResponseResult =
   Civ7DiplomacyResponseResult;
+export type Civ7ControlOrpcCultureChoiceCloseoutResult =
+  Civ7CultureChoiceCloseoutResult;
 export type Civ7ControlOrpcNarrativeChoiceResult = Civ7NarrativeChoiceResult;
+export type Civ7ControlOrpcTechnologyChoiceCloseoutResult =
+  Civ7TechnologyChoiceCloseoutResult;
 type Civ7ControlOrpcPopulationPlacementRuntimeResult =
   Civ7PopulationPlacementProofSource & Readonly<{
     before: Readonly<{ valid: boolean }>;
@@ -102,6 +112,16 @@ export type Civ7ControlOrpcDirectControlFacade = Readonly<{
     options: Civ7DirectControlOptions | undefined,
     approval: Civ7ActionApproval,
   ): Promise<Civ7ControlOrpcDiplomacyResponseResult>;
+  requestCiv7TechnologyChoiceCloseout(
+    input: Civ7TechnologyChoiceCloseoutInput,
+    options: Civ7DirectControlOptions | undefined,
+    approval: Civ7ActionApproval,
+  ): Promise<Civ7ControlOrpcTechnologyChoiceCloseoutResult>;
+  requestCiv7CultureChoiceCloseout(
+    input: Civ7CultureChoiceCloseoutInput,
+    options: Civ7DirectControlOptions | undefined,
+    approval: Civ7ActionApproval,
+  ): Promise<Civ7ControlOrpcCultureChoiceCloseoutResult>;
   requestCiv7CityCommand(
     input: Civ7OperationInput & Readonly<{ cityId: Civ7ComponentId }>,
     options: Civ7DirectControlOptions | undefined,
@@ -158,6 +178,10 @@ export const liveCiv7ControlOrpcDirectControlFacade:
     requestCiv7NarrativeChoice(input, options, approval),
   requestCiv7DiplomacyResponse: async (input, options, approval) =>
     requestCiv7DiplomacyResponse(input, options, approval),
+  requestCiv7TechnologyChoiceCloseout: async (input, options, approval) =>
+    requestCiv7TechnologyChoiceCloseout(input, options, approval),
+  requestCiv7CultureChoiceCloseout: async (input, options, approval) =>
+    requestCiv7CultureChoiceCloseout(input, options, approval),
   requestCiv7CityCommand: async (input, options, approval) =>
     requestCiv7CityCommand(input, options, approval) as Promise<
       Civ7ControlOrpcPopulationPlacementRuntimeResult

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -166,6 +166,28 @@ export class Civ7DiplomacyResponseUnavailableError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7ProgressionChoiceUnavailableErrorDataSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("decisions.progression.choice.request"),
+    source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties,
+  },
+  { additionalProperties: false },
+);
+export type Civ7ProgressionChoiceUnavailableErrorData = Static<
+  typeof Civ7ProgressionChoiceUnavailableErrorDataSchema
+>;
+
+export class Civ7ProgressionChoiceUnavailableError extends ORPCTaggedError(
+  "Civ7ProgressionChoiceUnavailableError",
+  {
+    code: "PROGRESSION_CHOICE_UNAVAILABLE",
+    message: "Direct-control progression choice request failed.",
+    schema: toStandardSchema(Civ7ProgressionChoiceUnavailableErrorDataSchema),
+    status: 503,
+  },
+) {}
+
 export const Civ7MutationApprovalRequiredErrorDataSchema = Type.Object(
   {
     procedureKey: Type.String(),
@@ -312,6 +334,7 @@ export const civ7ControlOrpcErrorMap = {
   NARRATIVE_CHOICE_UNAVAILABLE: Civ7NarrativeChoiceUnavailableError,
   NOTIFICATION_DISMISSAL_UNAVAILABLE: Civ7NotificationDismissalUnavailableError,
   POPULATION_PLACEMENT_UNAVAILABLE: Civ7PopulationPlacementUnavailableError,
+  PROGRESSION_CHOICE_UNAVAILABLE: Civ7ProgressionChoiceUnavailableError,
   PRODUCTION_CHOICE_UNAVAILABLE: Civ7ProductionChoiceUnavailableError,
   READINESS_CURRENT_UNAVAILABLE: Civ7ReadinessCurrentUnavailableError,
   STRATEGY_FRONT_SUMMARY_UNAVAILABLE: Civ7StrategyFrontSummaryUnavailableError,

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -188,6 +188,28 @@ export class Civ7ProgressionChoiceUnavailableError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7TurnCompletionUnavailableErrorDataSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("turn.complete.request"),
+    source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties,
+  },
+  { additionalProperties: false },
+);
+export type Civ7TurnCompletionUnavailableErrorData = Static<
+  typeof Civ7TurnCompletionUnavailableErrorDataSchema
+>;
+
+export class Civ7TurnCompletionUnavailableError extends ORPCTaggedError(
+  "Civ7TurnCompletionUnavailableError",
+  {
+    code: "TURN_COMPLETION_UNAVAILABLE",
+    message: "Direct-control turn completion request failed.",
+    schema: toStandardSchema(Civ7TurnCompletionUnavailableErrorDataSchema),
+    status: 503,
+  },
+) {}
+
 export const Civ7MutationApprovalRequiredErrorDataSchema = Type.Object(
   {
     procedureKey: Type.String(),
@@ -338,6 +360,7 @@ export const civ7ControlOrpcErrorMap = {
   PRODUCTION_CHOICE_UNAVAILABLE: Civ7ProductionChoiceUnavailableError,
   READINESS_CURRENT_UNAVAILABLE: Civ7ReadinessCurrentUnavailableError,
   STRATEGY_FRONT_SUMMARY_UNAVAILABLE: Civ7StrategyFrontSummaryUnavailableError,
+  TURN_COMPLETION_UNAVAILABLE: Civ7TurnCompletionUnavailableError,
   UNIT_TARGET_ACTION_UNAVAILABLE: Civ7UnitTargetActionUnavailableError,
 } satisfies EffectErrorMap;
 

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -57,6 +57,8 @@ export {
   Civ7NotificationDismissalUnavailableErrorDataSchema,
   Civ7PopulationPlacementUnavailableError,
   Civ7PopulationPlacementUnavailableErrorDataSchema,
+  Civ7ProgressionChoiceUnavailableError,
+  Civ7ProgressionChoiceUnavailableErrorDataSchema,
   Civ7ProductionChoiceUnavailableError,
   Civ7ProductionChoiceUnavailableErrorDataSchema,
   Civ7ReadinessCurrentUnavailableError,
@@ -77,6 +79,7 @@ export {
   type Civ7NarrativeChoiceUnavailableErrorData,
   type Civ7NotificationDismissalUnavailableErrorData,
   type Civ7PopulationPlacementUnavailableErrorData,
+  type Civ7ProgressionChoiceUnavailableErrorData,
   type Civ7ProductionChoiceUnavailableErrorData,
   type Civ7ReadinessCurrentUnavailableErrorData,
   type Civ7StrategyFrontSummaryUnavailableErrorData,
@@ -183,6 +186,18 @@ export {
   Civ7DecisionsNarrativeChoiceResultSchema,
   Civ7DecisionsNarrativeChoiceResultStandardSchema,
   Civ7DecisionsNarrativeChoiceValidationSummarySchema,
+  Civ7DecisionsProgressionChoiceContract,
+  Civ7DecisionsProgressionChoiceEvidenceSummarySchema,
+  Civ7DecisionsProgressionChoiceInputSchema,
+  Civ7DecisionsProgressionChoiceInputStandardSchema,
+  Civ7DecisionsProgressionChoiceKindSchema,
+  Civ7DecisionsProgressionChoiceNextStepSchema,
+  Civ7DecisionsProgressionChoicePostconditionClassificationSchema,
+  Civ7DecisionsProgressionChoicePostconditionSummarySchema,
+  Civ7DecisionsProgressionChoiceProofOutcomeSchema,
+  Civ7DecisionsProgressionChoiceRequestStatusSchema,
+  Civ7DecisionsProgressionChoiceResultSchema,
+  Civ7DecisionsProgressionChoiceResultStandardSchema,
 } from "./modules/decisions/contract";
 export type {
   Civ7DecisionsContract as Civ7DecisionsContractType,
@@ -192,10 +207,15 @@ export type {
   Civ7DecisionsNarrativeChoiceContract as Civ7DecisionsNarrativeChoiceContractType,
   Civ7DecisionsNarrativeChoiceInput,
   Civ7DecisionsNarrativeChoiceResult,
+  Civ7DecisionsProgressionChoiceContract as Civ7DecisionsProgressionChoiceContractType,
+  Civ7DecisionsProgressionChoiceInput,
+  Civ7DecisionsProgressionChoiceKind,
+  Civ7DecisionsProgressionChoiceResult,
 } from "./modules/decisions/contract";
 export { decisionsRouter } from "./modules/decisions/router";
 export { decisionsDiplomacyResponseRequestProcedure } from "./modules/decisions/procedures/diplomacy-response-request";
 export { decisionsNarrativeChoiceRequestProcedure } from "./modules/decisions/procedures/narrative-choice-request";
+export { decisionsProgressionChoiceRequestProcedure } from "./modules/decisions/procedures/progression-choice-request";
 export {
   Civ7NotificationsContract,
   Civ7NotificationDismissInputSchema,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -65,6 +65,8 @@ export {
   Civ7ReadinessCurrentUnavailableErrorDataSchema,
   Civ7StrategyFrontSummaryUnavailableError,
   Civ7StrategyFrontSummaryUnavailableErrorDataSchema,
+  Civ7TurnCompletionUnavailableError,
+  Civ7TurnCompletionUnavailableErrorDataSchema,
   Civ7UnitTargetActionUnavailableError,
   Civ7UnitTargetActionUnavailableErrorDataSchema,
   civ7ControlOrpcErrorMap,
@@ -83,6 +85,7 @@ export {
   type Civ7ProductionChoiceUnavailableErrorData,
   type Civ7ReadinessCurrentUnavailableErrorData,
   type Civ7StrategyFrontSummaryUnavailableErrorData,
+  type Civ7TurnCompletionUnavailableErrorData,
   type Civ7UnitTargetActionUnavailableErrorData,
 } from "./errors";
 export {
@@ -281,6 +284,28 @@ export type {
 } from "./modules/strategy/contract";
 export { strategyRouter } from "./modules/strategy/router";
 export { strategyFrontSummaryProcedure } from "./modules/strategy/procedures/front-summary";
+export {
+  Civ7TurnCompletionContract,
+  Civ7TurnCompletionInputSchema,
+  Civ7TurnCompletionInputStandardSchema,
+  Civ7TurnCompletionNextStepSchema,
+  Civ7TurnCompletionPostconditionClassificationSchema,
+  Civ7TurnCompletionPostconditionSummarySchema,
+  Civ7TurnCompletionProbeSummarySchema,
+  Civ7TurnCompletionProofOutcomeSchema,
+  Civ7TurnCompletionRequestStatusSchema,
+  Civ7TurnCompletionResultSchema,
+  Civ7TurnCompletionResultStandardSchema,
+  Civ7TurnContract,
+} from "./modules/turn/contract";
+export type {
+  Civ7TurnCompletionContract as Civ7TurnCompletionContractType,
+  Civ7TurnCompletionInput,
+  Civ7TurnCompletionResult,
+  Civ7TurnContract as Civ7TurnContractType,
+} from "./modules/turn/contract";
+export { turnRouter } from "./modules/turn/router";
+export { turnCompleteRequestProcedure } from "./modules/turn/procedures/complete-request";
 export {
   Civ7UnitContract,
   Civ7UnitTargetActionContract,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -1,4 +1,24 @@
 export { createCiv7ControlOrpcServerClient } from "./client";
+export {
+  Civ7ControllerBridgeErrorSchema,
+  Civ7ControllerBridgeFailureResponseSchema,
+  Civ7ControllerBridgeReadinessCurrentRequestSchema,
+  Civ7ControllerBridgeRequestSchema,
+  Civ7ControllerBridgeResponseSchema,
+  Civ7ControllerBridgeSuccessResponseSchema,
+  createCiv7ControllerBridgeIngress,
+  invokeCiv7ControllerBridgeRequest,
+} from "./bridge/controller-ingress";
+export type {
+  Civ7ControllerBridgeContextFactory,
+  Civ7ControllerBridgeError,
+  Civ7ControllerBridgeFailureResponse,
+  Civ7ControllerBridgeIngress,
+  Civ7ControllerBridgeReadinessCurrentRequest,
+  Civ7ControllerBridgeRequest,
+  Civ7ControllerBridgeResponse,
+  Civ7ControllerBridgeSuccessResponse,
+} from "./bridge/controller-ingress";
 export { civ7ControlOrpcContractBase } from "./contract-base";
 export { Civ7ControlOrpcContract } from "./contract";
 export type { Civ7ControlOrpcContext } from "./context";

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -89,6 +89,14 @@ export {
   type Civ7ControlOrpcCorrelationContext,
   type Civ7ControlOrpcCorrelationId,
 } from "./model/correlation";
+export {
+  Civ7ControlOrpcComponentIdSchema,
+  Civ7ControlOrpcMapLocationSchema,
+} from "./model/primitives";
+export type {
+  Civ7ControlOrpcComponentId,
+  Civ7ControlOrpcMapLocation,
+} from "./model/primitives";
 export type { Civ7ControlOrpcProcedureMeta } from "./metadata";
 export {
   civ7ControlOrpcEffectRuntime,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -19,6 +19,16 @@ export type {
   Civ7ControllerBridgeResponse,
   Civ7ControllerBridgeSuccessResponse,
 } from "./bridge/controller-ingress";
+export {
+  CIV7_INTELLIGENCE_BRIDGE_GLOBAL_KEY,
+  createCiv7IntelligenceBridge,
+  installCiv7IntelligenceBridge,
+} from "./bridge/intelligence-bridge";
+export type {
+  Civ7IntelligenceBridge,
+  Civ7IntelligenceBridgeGlobalTarget,
+  Civ7IntelligenceBridgeInstallOptions,
+} from "./bridge/intelligence-bridge";
 export { civ7ControlOrpcContractBase } from "./contract-base";
 export { Civ7ControlOrpcContract } from "./contract";
 export type { Civ7ControlOrpcContext } from "./context";

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -1,8 +1,11 @@
 export { createCiv7ControlOrpcServerClient } from "./client";
 export {
+  Civ7ControllerBridgeAttentionCurrentRequestSchema,
+  Civ7ControllerBridgeAttentionCurrentSuccessResponseSchema,
   Civ7ControllerBridgeErrorSchema,
   Civ7ControllerBridgeFailureResponseSchema,
   Civ7ControllerBridgeReadinessCurrentRequestSchema,
+  Civ7ControllerBridgeReadinessCurrentSuccessResponseSchema,
   Civ7ControllerBridgeRequestSchema,
   Civ7ControllerBridgeResponseSchema,
   Civ7ControllerBridgeSuccessResponseSchema,
@@ -10,11 +13,14 @@ export {
   invokeCiv7ControllerBridgeRequest,
 } from "./bridge/controller-ingress";
 export type {
+  Civ7ControllerBridgeAttentionCurrentRequest,
+  Civ7ControllerBridgeAttentionCurrentSuccessResponse,
   Civ7ControllerBridgeContextFactory,
   Civ7ControllerBridgeError,
   Civ7ControllerBridgeFailureResponse,
   Civ7ControllerBridgeIngress,
   Civ7ControllerBridgeReadinessCurrentRequest,
+  Civ7ControllerBridgeReadinessCurrentSuccessResponse,
   Civ7ControllerBridgeRequest,
   Civ7ControllerBridgeResponse,
   Civ7ControllerBridgeSuccessResponse,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -40,14 +40,6 @@ export { Civ7ControlOrpcContract } from "./contract";
 export type { Civ7ControlOrpcContext } from "./context";
 export {
   liveCiv7ControlOrpcDirectControlFacade,
-  type Civ7ControlOrpcNotificationDismissalResult,
-  type Civ7ControlOrpcPlayNotificationViewResult,
-  type Civ7ControlOrpcPlayableStatusResult,
-  type Civ7ControlOrpcProductionChoiceResult,
-  type Civ7ControlOrpcReadyCityViewResult,
-  type Civ7ControlOrpcReadyUnitViewResult,
-  type Civ7ControlOrpcTurnCompletionStatusResult,
-  type Civ7ControlOrpcUnitTargetActionResult,
   type Civ7ControlOrpcDirectControlFacade,
 } from "./dependencies/direct-control";
 export {

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -265,6 +265,7 @@ export {
   Civ7UnitContract,
   Civ7UnitTargetActionContract,
   Civ7UnitTargetActionFamilySchema,
+  Civ7UnitTargetActionInputSchema,
   Civ7UnitTargetActionInputStandardSchema,
   Civ7UnitTargetActionNextStepSchema,
   Civ7UnitTargetActionPostconditionSummarySchema,
@@ -279,6 +280,7 @@ export {
 export type {
   Civ7UnitContract as Civ7UnitContractType,
   Civ7UnitTargetActionContract as Civ7UnitTargetActionContractType,
+  Civ7UnitTargetActionInput,
   Civ7UnitTargetActionResult,
 } from "./modules/unit/contract";
 export { unitRouter } from "./modules/unit/router";

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -195,9 +195,11 @@ export { decisionsDiplomacyResponseRequestProcedure } from "./modules/decisions/
 export { decisionsNarrativeChoiceRequestProcedure } from "./modules/decisions/procedures/narrative-choice-request";
 export {
   Civ7NotificationsContract,
+  Civ7NotificationDismissInputSchema,
   Civ7NotificationDismissalContract,
   Civ7NotificationDismissInputStandardSchema,
   Civ7NotificationDismissalNextStepSchema,
+  Civ7NotificationDismissalPostconditionClassificationSchema,
   Civ7NotificationDismissalPostconditionSummarySchema,
   Civ7NotificationDismissalProofOutcomeSchema,
   Civ7NotificationDismissalRequestStatusSchema,
@@ -207,6 +209,7 @@ export {
 } from "./modules/notifications/contract";
 export type {
   Civ7NotificationDismissalContract as Civ7NotificationDismissalContractType,
+  Civ7NotificationDismissInput,
   Civ7NotificationDismissalResult,
   Civ7NotificationsContract as Civ7NotificationsContractType,
 } from "./modules/notifications/contract";

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -136,8 +136,10 @@ export {
   Civ7CityPopulationPlacementSummarySchema,
   Civ7CityPopulationPlacementValidationSummarySchema,
   Civ7CityProductionChoiceContract,
+  Civ7CityProductionChoiceInputSchema,
   Civ7CityProductionChoiceInputStandardSchema,
   Civ7CityProductionChoiceNextStepSchema,
+  Civ7CityProductionChoicePostconditionClassificationSchema,
   Civ7CityProductionChoicePostconditionSummarySchema,
   Civ7CityProductionChoiceProofOutcomeSchema,
   Civ7CityProductionChoiceRequestStatusSchema,
@@ -151,6 +153,7 @@ export type {
   Civ7CityPopulationPlacementInput,
   Civ7CityPopulationPlacementResult,
   Civ7CityProductionChoiceContract as Civ7CityProductionChoiceContractType,
+  Civ7CityProductionChoiceInput,
   Civ7CityProductionChoiceResult,
 } from "./modules/city/contract";
 export { cityRouter } from "./modules/city/router";

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -39,10 +39,6 @@ export { civ7ControlOrpcContractBase } from "./contract-base";
 export { Civ7ControlOrpcContract } from "./contract";
 export type { Civ7ControlOrpcContext } from "./context";
 export {
-  liveCiv7ControlOrpcDirectControlFacade,
-  type Civ7ControlOrpcDirectControlFacade,
-} from "./dependencies/direct-control";
-export {
   Civ7AttentionCurrentUnavailableError,
   Civ7AttentionCurrentUnavailableErrorDataSchema,
   Civ7CorrelationIdInvalidError,

--- a/packages/civ7-control-orpc/src/metadata.ts
+++ b/packages/civ7-control-orpc/src/metadata.ts
@@ -9,7 +9,8 @@ export type Civ7ControlOrpcProcedureMeta = Readonly<{
     | "decisions"
     | "map"
     | "player"
-    | "strategy";
+    | "strategy"
+    | "turn";
   procedureKey?: string;
   proofBoundary?: "local-package-test" | "pending-runtime-proof" | "runtime-proof";
   risk?: "read-only" | "runtime-support" | "mutation";

--- a/packages/civ7-control-orpc/src/model/primitives.ts
+++ b/packages/civ7-control-orpc/src/model/primitives.ts
@@ -1,0 +1,24 @@
+import { Type, type Static } from "typebox";
+
+export const Civ7ControlOrpcComponentIdSchema = Type.Object(
+  {
+    owner: Type.Number(),
+    id: Type.Number(),
+    type: Type.Optional(Type.Number()),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ControlOrpcComponentId = Static<
+  typeof Civ7ControlOrpcComponentIdSchema
+>;
+
+export const Civ7ControlOrpcMapLocationSchema = Type.Object(
+  {
+    x: Type.Integer({ minimum: 0, maximum: 1_000_000 }),
+    y: Type.Integer({ minimum: 0, maximum: 1_000_000 }),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ControlOrpcMapLocation = Readonly<
+  Static<typeof Civ7ControlOrpcMapLocationSchema>
+>;

--- a/packages/civ7-control-orpc/src/modules/attention/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/attention/contract.ts
@@ -1,13 +1,16 @@
-import { Civ7ComponentIdSchema } from "@civ7/direct-control";
 import type { ContractProcedure } from "@orpc/contract";
 import { Type, type Static } from "typebox";
 
 import { civ7ControlOrpcContractBase } from "../../contract-base";
 import type { Civ7ControlOrpcErrorMap } from "../../errors";
 import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
+import { Civ7ControlOrpcComponentIdSchema } from "../../model/primitives";
 import { toStandardSchema } from "../../typebox-standard-schema";
 
-const NullableComponentIdSchema = Type.Union([Civ7ComponentIdSchema, Type.Null()]);
+const NullableComponentIdSchema = Type.Union([
+  Civ7ControlOrpcComponentIdSchema,
+  Type.Null(),
+]);
 
 export const Civ7AttentionCurrentInputSchema = Type.Object(
   {

--- a/packages/civ7-control-orpc/src/modules/city/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/city/contract.ts
@@ -1,6 +1,4 @@
 import {
-  Civ7ComponentIdSchema,
-  Civ7MapLocationSchema,
   Civ7ProductionChoiceInputSchema,
   Civ7ProductionPostconditionClassificationSchema,
 } from "@civ7/direct-control";
@@ -10,6 +8,10 @@ import { Type, type Static } from "typebox";
 import { civ7ControlOrpcContractBase } from "../../contract-base";
 import type { Civ7ControlOrpcErrorMap } from "../../errors";
 import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
+import {
+  Civ7ControlOrpcComponentIdSchema,
+  Civ7ControlOrpcMapLocationSchema,
+} from "../../model/primitives";
 import { toStandardSchema } from "../../typebox-standard-schema";
 
 export const Civ7CityProductionChoiceInputStandardSchema = toStandardSchema(
@@ -28,8 +30,8 @@ export const Civ7CityPopulationPlacementInputSchema = Type.Union([
   Type.Object(
     {
       mode: Type.Literal("expand-city"),
-      cityId: Civ7ComponentIdSchema,
-      destination: Civ7MapLocationSchema,
+      cityId: Civ7ControlOrpcComponentIdSchema,
+      destination: Civ7ControlOrpcMapLocationSchema,
     },
     { additionalProperties: false },
   ),
@@ -85,8 +87,8 @@ export const Civ7CityPopulationPlacementSummarySchema = Type.Union([
   Type.Object(
     {
       mode: Type.Literal("expand-city"),
-      cityId: Civ7ComponentIdSchema,
-      destination: Civ7MapLocationSchema,
+      cityId: Civ7ControlOrpcComponentIdSchema,
+      destination: Civ7ControlOrpcMapLocationSchema,
     },
     { additionalProperties: false },
   ),
@@ -206,7 +208,7 @@ export const Civ7CityProductionChoiceNextStepSchema = Type.Object(
 
 export const Civ7CityProductionChoiceResultSchema = Type.Object(
   {
-    cityId: Civ7ComponentIdSchema,
+    cityId: Civ7ControlOrpcComponentIdSchema,
     args: Type.Record(Type.String(), Type.Number()),
     sent: Type.Boolean(),
     status: Civ7CityProductionChoiceRequestStatusSchema,

--- a/packages/civ7-control-orpc/src/modules/city/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/city/contract.ts
@@ -1,7 +1,3 @@
-import {
-  Civ7ProductionChoiceInputSchema,
-  Civ7ProductionPostconditionClassificationSchema,
-} from "@civ7/direct-control";
 import type { ContractProcedure } from "@orpc/contract";
 import { Type, type Static } from "typebox";
 
@@ -14,8 +10,77 @@ import {
 } from "../../model/primitives";
 import { toStandardSchema } from "../../typebox-standard-schema";
 
+const Civ7CityProductionChoiceArgsSchema = Type.Unsafe<
+  Readonly<Record<string, number>>
+>({
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    UnitType: { type: "integer" },
+    ConstructibleType: { type: "integer" },
+    ProjectType: { type: "integer" },
+    X: { type: "integer" },
+    Y: { type: "integer" },
+  },
+  oneOf: [
+    {
+      required: ["UnitType"],
+      not: {
+        anyOf: [
+          { required: ["ConstructibleType"] },
+          { required: ["ProjectType"] },
+          { required: ["X"] },
+          { required: ["Y"] },
+        ],
+      },
+    },
+    {
+      required: ["ProjectType"],
+      not: {
+        anyOf: [
+          { required: ["UnitType"] },
+          { required: ["ConstructibleType"] },
+          { required: ["X"] },
+          { required: ["Y"] },
+        ],
+      },
+    },
+    {
+      required: ["ConstructibleType"],
+      not: {
+        anyOf: [
+          { required: ["UnitType"] },
+          { required: ["ProjectType"] },
+          { required: ["X"] },
+          { required: ["Y"] },
+        ],
+      },
+    },
+    {
+      required: ["ConstructibleType", "X", "Y"],
+      not: {
+        anyOf: [
+          { required: ["UnitType"] },
+          { required: ["ProjectType"] },
+        ],
+      },
+    },
+  ],
+});
+
+export const Civ7CityProductionChoiceInputSchema = Type.Object(
+  {
+    cityId: Civ7ControlOrpcComponentIdSchema,
+    args: Civ7CityProductionChoiceArgsSchema,
+  },
+  { additionalProperties: false },
+);
+export type Civ7CityProductionChoiceInput = Static<
+  typeof Civ7CityProductionChoiceInputSchema
+>;
+
 export const Civ7CityProductionChoiceInputStandardSchema = toStandardSchema(
-  Civ7ProductionChoiceInputSchema,
+  Civ7CityProductionChoiceInputSchema,
 );
 
 export const Civ7CityPopulationPlacementInputSchema = Type.Union([
@@ -165,10 +230,20 @@ export const Civ7CityProductionChoiceRequestStatusSchema = Type.Union([
   Type.Literal("sent-unverified"),
 ]);
 
+export const Civ7CityProductionChoicePostconditionClassificationSchema =
+  Type.Union([
+    Type.Literal("not-sent"),
+    Type.Literal("production-choice-cleared"),
+    Type.Literal("production-state-changed"),
+    Type.Literal("production-state-changed-blocker-still-live"),
+    Type.Literal("validation-changed"),
+    Type.Literal("no-state-change"),
+  ]);
+
 export const Civ7CityProductionChoicePostconditionSummarySchema = Type.Object(
   {
     classification: Type.Union([
-      Civ7ProductionPostconditionClassificationSchema,
+      Civ7CityProductionChoicePostconditionClassificationSchema,
       Type.Literal("missing-postcondition"),
     ]),
     reason: Type.String(),

--- a/packages/civ7-control-orpc/src/modules/decisions/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/contract.ts
@@ -79,6 +79,7 @@ export const Civ7DecisionsDiplomacyResponsePostconditionClassificationSchema =
 export const Civ7DecisionsProgressionChoicePostconditionClassificationSchema =
   Type.Union([
     Type.Literal("not-sent"),
+    Type.Literal("pending-runtime-proof"),
     Type.Literal("turn-unblocked"),
     Type.Literal("technology-choice-cleared"),
     Type.Literal("technology-choice-transitioned"),
@@ -127,7 +128,12 @@ export const Civ7DecisionsDiplomacyResponseValidationSummarySchema =
 export const Civ7DecisionsProgressionChoiceEvidenceSummarySchema = Type.Object(
   {
     beforeBlockerPresent: Type.Boolean(),
-    afterBlockerPresent: Type.Boolean(),
+    afterReadStatus: Type.Union([
+      Type.Literal("read"),
+      Type.Literal("failed"),
+      Type.Literal("skipped-not-sent"),
+    ]),
+    afterBlockerPresent: Type.Union([Type.Boolean(), Type.Null()]),
     canEndTurnAfter: Type.Union([Type.Boolean(), Type.Null()]),
   },
   { additionalProperties: false },

--- a/packages/civ7-control-orpc/src/modules/decisions/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/contract.ts
@@ -33,6 +33,27 @@ export type Civ7DecisionsDiplomacyResponseInput = Static<
   typeof Civ7DecisionsDiplomacyResponseInputSchema
 >;
 
+export const Civ7DecisionsProgressionChoiceKindSchema = Type.Union([
+  Type.Literal("technology"),
+  Type.Literal("culture"),
+]);
+export type Civ7DecisionsProgressionChoiceKind = Static<
+  typeof Civ7DecisionsProgressionChoiceKindSchema
+>;
+
+export const Civ7DecisionsProgressionChoiceInputSchema = Type.Object(
+  {
+    kind: Civ7DecisionsProgressionChoiceKindSchema,
+    playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
+    node: Type.Integer(),
+    notificationId: Type.Optional(Civ7ControlOrpcComponentIdSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7DecisionsProgressionChoiceInput = Static<
+  typeof Civ7DecisionsProgressionChoiceInputSchema
+>;
+
 export const Civ7DecisionsNarrativeChoicePostconditionClassificationSchema =
   Type.Union([
     Type.Literal("not-sent"),
@@ -55,6 +76,20 @@ export const Civ7DecisionsDiplomacyResponsePostconditionClassificationSchema =
     Type.Literal("missing-postcondition"),
   ]);
 
+export const Civ7DecisionsProgressionChoicePostconditionClassificationSchema =
+  Type.Union([
+    Type.Literal("not-sent"),
+    Type.Literal("turn-unblocked"),
+    Type.Literal("technology-choice-cleared"),
+    Type.Literal("technology-choice-transitioned"),
+    Type.Literal("technology-state-changed-blocker-still-live"),
+    Type.Literal("technology-choice-sticky-blocker"),
+    Type.Literal("culture-choice-cleared"),
+    Type.Literal("culture-choice-transitioned"),
+    Type.Literal("culture-state-changed-blocker-still-live"),
+    Type.Literal("culture-choice-sticky-blocker"),
+  ]);
+
 export const Civ7DecisionsNarrativeChoiceProofOutcomeSchema = Type.Union([
   Type.Literal("cleared"),
   Type.Literal("state-changed"),
@@ -66,6 +101,8 @@ export const Civ7DecisionsNarrativeChoiceProofOutcomeSchema = Type.Union([
 ]);
 export const Civ7DecisionsDiplomacyResponseProofOutcomeSchema =
   Civ7DecisionsNarrativeChoiceProofOutcomeSchema;
+export const Civ7DecisionsProgressionChoiceProofOutcomeSchema =
+  Civ7DecisionsNarrativeChoiceProofOutcomeSchema;
 
 export const Civ7DecisionsNarrativeChoiceRequestStatusSchema = Type.Union([
   Type.Literal("not-sent"),
@@ -73,6 +110,8 @@ export const Civ7DecisionsNarrativeChoiceRequestStatusSchema = Type.Union([
   Type.Literal("sent-unverified"),
 ]);
 export const Civ7DecisionsDiplomacyResponseRequestStatusSchema =
+  Civ7DecisionsNarrativeChoiceRequestStatusSchema;
+export const Civ7DecisionsProgressionChoiceRequestStatusSchema =
   Civ7DecisionsNarrativeChoiceRequestStatusSchema;
 
 export const Civ7DecisionsNarrativeChoiceValidationSummarySchema = Type.Object(
@@ -84,6 +123,15 @@ export const Civ7DecisionsNarrativeChoiceValidationSummarySchema = Type.Object(
 );
 export const Civ7DecisionsDiplomacyResponseValidationSummarySchema =
   Civ7DecisionsNarrativeChoiceValidationSummarySchema;
+
+export const Civ7DecisionsProgressionChoiceEvidenceSummarySchema = Type.Object(
+  {
+    beforeBlockerPresent: Type.Boolean(),
+    afterBlockerPresent: Type.Boolean(),
+    canEndTurnAfter: Type.Union([Type.Boolean(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
 
 export const Civ7DecisionsNarrativeChoicePostconditionSummarySchema =
   Type.Object(
@@ -117,6 +165,23 @@ export const Civ7DecisionsDiplomacyResponsePostconditionSummarySchema =
     },
     { additionalProperties: false },
   );
+export const Civ7DecisionsProgressionChoicePostconditionSummarySchema =
+  Type.Object(
+    {
+      classification:
+        Civ7DecisionsProgressionChoicePostconditionClassificationSchema,
+      reason: Type.String(),
+      outcome: Civ7DecisionsProgressionChoiceProofOutcomeSchema,
+      confidence: Type.Union([
+        Type.Literal("confirmed"),
+        Type.Literal("unverified"),
+        Type.Literal("pending-runtime-proof"),
+      ]),
+      confirmed: Type.Boolean(),
+      noRepeatAfterUnverified: Type.Boolean(),
+    },
+    { additionalProperties: false },
+  );
 
 export const Civ7DecisionsNarrativeChoiceNextStepSchema = Type.Object(
   {
@@ -138,6 +203,18 @@ export const Civ7DecisionsDiplomacyResponseNextStepSchema = Type.Object(
       Type.Literal("inspect-diplomacy-response"),
     ]),
     source: Type.Literal("decisions.diplomacy.response.request"),
+    label: Type.String(),
+  },
+  { additionalProperties: false },
+);
+export const Civ7DecisionsProgressionChoiceNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("refresh-attention"),
+      Type.Literal("do-not-repeat"),
+      Type.Literal("inspect-progression-choice"),
+    ]),
+    source: Type.Literal("decisions.progression.choice.request"),
     label: Type.String(),
   },
   { additionalProperties: false },
@@ -179,6 +256,24 @@ export type Civ7DecisionsDiplomacyResponseResult = Static<
   typeof Civ7DecisionsDiplomacyResponseResultSchema
 >;
 
+export const Civ7DecisionsProgressionChoiceResultSchema = Type.Object(
+  {
+    kind: Civ7DecisionsProgressionChoiceKindSchema,
+    playerId: Type.Integer({ minimum: 0 }),
+    node: Type.Integer(),
+    notificationId: Type.Optional(Civ7ControlOrpcComponentIdSchema),
+    sent: Type.Boolean(),
+    status: Civ7DecisionsProgressionChoiceRequestStatusSchema,
+    evidence: Civ7DecisionsProgressionChoiceEvidenceSummarySchema,
+    postcondition: Civ7DecisionsProgressionChoicePostconditionSummarySchema,
+    nextSteps: Type.Array(Civ7DecisionsProgressionChoiceNextStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7DecisionsProgressionChoiceResult = Static<
+  typeof Civ7DecisionsProgressionChoiceResultSchema
+>;
+
 export const Civ7DecisionsNarrativeChoiceInputStandardSchema =
   toStandardSchema(Civ7DecisionsNarrativeChoiceInputSchema);
 export const Civ7DecisionsNarrativeChoiceResultStandardSchema =
@@ -187,6 +282,10 @@ export const Civ7DecisionsDiplomacyResponseInputStandardSchema =
   toStandardSchema(Civ7DecisionsDiplomacyResponseInputSchema);
 export const Civ7DecisionsDiplomacyResponseResultStandardSchema =
   toStandardSchema(Civ7DecisionsDiplomacyResponseResultSchema);
+export const Civ7DecisionsProgressionChoiceInputStandardSchema =
+  toStandardSchema(Civ7DecisionsProgressionChoiceInputSchema);
+export const Civ7DecisionsProgressionChoiceResultStandardSchema =
+  toStandardSchema(Civ7DecisionsProgressionChoiceResultSchema);
 
 export type Civ7DecisionsNarrativeChoiceContract = ContractProcedure<
   typeof Civ7DecisionsNarrativeChoiceInputStandardSchema,
@@ -224,6 +323,24 @@ export const Civ7DecisionsDiplomacyResponseContract:
       risk: "mutation",
     });
 
+export type Civ7DecisionsProgressionChoiceContract = ContractProcedure<
+  typeof Civ7DecisionsProgressionChoiceInputStandardSchema,
+  typeof Civ7DecisionsProgressionChoiceResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export const Civ7DecisionsProgressionChoiceContract:
+  Civ7DecisionsProgressionChoiceContract = civ7ControlOrpcContractBase
+    .input(Civ7DecisionsProgressionChoiceInputStandardSchema)
+    .output(Civ7DecisionsProgressionChoiceResultStandardSchema)
+    .meta({
+      family: "decisions",
+      procedureKey: "decisions.progression.choice.request",
+      proofBoundary: "local-package-test",
+      risk: "mutation",
+    });
+
 export type Civ7DecisionsContract = Readonly<{
   diplomacy: Readonly<{
     response: Readonly<{
@@ -233,6 +350,11 @@ export type Civ7DecisionsContract = Readonly<{
   narrative: Readonly<{
     choice: Readonly<{
       request: Civ7DecisionsNarrativeChoiceContract;
+    }>;
+  }>;
+  progression: Readonly<{
+    choice: Readonly<{
+      request: Civ7DecisionsProgressionChoiceContract;
     }>;
   }>;
 }>;
@@ -246,6 +368,11 @@ export const Civ7DecisionsContract: Civ7DecisionsContract = {
   narrative: {
     choice: {
       request: Civ7DecisionsNarrativeChoiceContract,
+    },
+  },
+  progression: {
+    choice: {
+      request: Civ7DecisionsProgressionChoiceContract,
     },
   },
 };

--- a/packages/civ7-control-orpc/src/modules/decisions/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/contract.ts
@@ -1,17 +1,17 @@
-import { Civ7ComponentIdSchema } from "@civ7/direct-control";
 import type { ContractProcedure } from "@orpc/contract";
 import { Type, type Static } from "typebox";
 
 import { civ7ControlOrpcContractBase } from "../../contract-base";
 import type { Civ7ControlOrpcErrorMap } from "../../errors";
 import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
+import { Civ7ControlOrpcComponentIdSchema } from "../../model/primitives";
 import { toStandardSchema } from "../../typebox-standard-schema";
 
 export const Civ7DecisionsNarrativeChoiceInputSchema = Type.Object(
   {
     playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
     targetType: Type.String({ minLength: 1 }),
-    target: Civ7ComponentIdSchema,
+    target: Civ7ControlOrpcComponentIdSchema,
     action: Type.Integer(),
   },
   { additionalProperties: false },
@@ -25,7 +25,7 @@ export const Civ7DecisionsDiplomacyResponseInputSchema = Type.Object(
     playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
     actionId: Type.Integer(),
     responseType: Type.Integer(),
-    notificationId: Type.Optional(Civ7ComponentIdSchema),
+    notificationId: Type.Optional(Civ7ControlOrpcComponentIdSchema),
   },
   { additionalProperties: false },
 );
@@ -147,7 +147,7 @@ export const Civ7DecisionsNarrativeChoiceResultSchema = Type.Object(
   {
     playerId: Type.Integer({ minimum: 0 }),
     targetType: Type.String(),
-    target: Civ7ComponentIdSchema,
+    target: Civ7ControlOrpcComponentIdSchema,
     action: Type.Integer(),
     sent: Type.Boolean(),
     status: Civ7DecisionsNarrativeChoiceRequestStatusSchema,
@@ -166,7 +166,7 @@ export const Civ7DecisionsDiplomacyResponseResultSchema = Type.Object(
     playerId: Type.Integer({ minimum: 0 }),
     actionId: Type.Integer(),
     responseType: Type.Integer(),
-    notificationId: Type.Optional(Civ7ComponentIdSchema),
+    notificationId: Type.Optional(Civ7ControlOrpcComponentIdSchema),
     sent: Type.Boolean(),
     status: Civ7DecisionsDiplomacyResponseRequestStatusSchema,
     validation: Civ7DecisionsDiplomacyResponseValidationSummarySchema,

--- a/packages/civ7-control-orpc/src/modules/decisions/procedures/diplomacy-response-request.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/procedures/diplomacy-response-request.ts
@@ -6,9 +6,7 @@ import { civ7MutationApprovalMiddleware } from "../../../middleware/mutation-app
 import { civ7MutationReadinessMiddleware } from "../../../middleware/mutation-readiness";
 import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
 import {
-  civ7MutationNextSteps,
-  civ7MutationPostconditionSummary,
-  civ7MutationRequestStatusWithoutGuarded,
+  civ7CloseoutMutationProjection,
 } from "../../../policy/mutation-result";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
@@ -55,10 +53,18 @@ function diplomacyResponseResult(
   input: Civ7DecisionsDiplomacyResponseInput,
   result: Civ7ControlOrpcDiplomacyResponseResult,
 ): Civ7DecisionsDiplomacyResponseResult {
-  const postcondition = diplomacyResponsePostconditionSummary(result);
-  const status = civ7MutationRequestStatusWithoutGuarded({
+  const projection = civ7CloseoutMutationProjection({
     sent: result.sent,
-    postcondition,
+    postcondition: diplomacyResponseProofPostcondition(result, undefined),
+    missing: {
+      classification: "missing-postcondition",
+      reason: "The diplomacy response result did not include explicit postcondition evidence.",
+      outcome: result.sent ? "unknown" : "not-sent",
+    },
+    source: "decisions.diplomacy.response.request",
+    inspectKind: "inspect-diplomacy-response",
+    inspectLabel: "Inspect current attention and diplomacy response state before attempting another diplomacy request.",
+    doNotRepeatLabel: "Do not repeat this diplomacy response request until fresh attention and diplomacy evidence is read.",
   });
 
   return {
@@ -67,33 +73,12 @@ function diplomacyResponseResult(
     responseType: input.responseType,
     ...(input.notificationId === undefined ? {} : { notificationId: input.notificationId }),
     sent: result.sent,
-    status,
+    status: projection.status,
     validation: {
       beforeValid: result.beforeValidation.valid,
       afterValid: result.afterValidation.valid,
     },
-    postcondition,
-    nextSteps: civ7MutationNextSteps({
-      status,
-      postcondition,
-      source: "decisions.diplomacy.response.request",
-      inspectKind: "inspect-diplomacy-response",
-      inspectLabel: "Inspect current attention and diplomacy response state before attempting another diplomacy request.",
-      doNotRepeatLabel: "Do not repeat this diplomacy response request until fresh attention and diplomacy evidence is read.",
-    }),
+    postcondition: projection.postcondition as Civ7DecisionsDiplomacyResponseResult["postcondition"],
+    nextSteps: projection.nextSteps,
   };
-}
-
-function diplomacyResponsePostconditionSummary(
-  result: Civ7ControlOrpcDiplomacyResponseResult,
-): Civ7DecisionsDiplomacyResponseResult["postcondition"] {
-  const postcondition = diplomacyResponseProofPostcondition(result, undefined);
-  return civ7MutationPostconditionSummary({
-    postcondition,
-    missing: {
-      classification: "missing-postcondition",
-      reason: "The diplomacy response result did not include explicit postcondition evidence.",
-      outcome: result.sent ? "unknown" : "not-sent",
-    },
-  }) as Civ7DecisionsDiplomacyResponseResult["postcondition"];
 }

--- a/packages/civ7-control-orpc/src/modules/decisions/procedures/narrative-choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/procedures/narrative-choice-request.ts
@@ -6,9 +6,7 @@ import { civ7MutationApprovalMiddleware } from "../../../middleware/mutation-app
 import { civ7MutationReadinessMiddleware } from "../../../middleware/mutation-readiness";
 import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
 import {
-  civ7MutationNextSteps,
-  civ7MutationPostconditionSummary,
-  civ7MutationRequestStatusWithoutGuarded,
+  civ7CloseoutMutationProjection,
 } from "../../../policy/mutation-result";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
@@ -55,10 +53,18 @@ function narrativeChoiceResult(
   input: Civ7DecisionsNarrativeChoiceInput,
   result: Civ7ControlOrpcNarrativeChoiceResult,
 ): Civ7DecisionsNarrativeChoiceResult {
-  const postcondition = narrativeChoicePostconditionSummary(result);
-  const status = civ7MutationRequestStatusWithoutGuarded({
+  const projection = civ7CloseoutMutationProjection({
     sent: result.sent,
-    postcondition,
+    postcondition: narrativeChoiceProofPostcondition(result, undefined),
+    missing: {
+      classification: "missing-postcondition",
+      reason: "The narrative choice result did not include explicit postcondition evidence.",
+      outcome: result.sent ? "unknown" : "not-sent",
+    },
+    source: "decisions.narrative.choice.request",
+    inspectKind: "inspect-narrative-choice",
+    inspectLabel: "Inspect current attention and narrative choice state before attempting another narrative request.",
+    doNotRepeatLabel: "Do not repeat this narrative choice request until fresh attention and narrative evidence is read.",
   });
 
   return {
@@ -67,33 +73,12 @@ function narrativeChoiceResult(
     target: input.target,
     action: input.action,
     sent: result.sent,
-    status,
+    status: projection.status,
     validation: {
       beforeValid: result.beforeValidation.valid,
       afterValid: result.afterValidation.valid,
     },
-    postcondition,
-    nextSteps: civ7MutationNextSteps({
-      status,
-      postcondition,
-      source: "decisions.narrative.choice.request",
-      inspectKind: "inspect-narrative-choice",
-      inspectLabel: "Inspect current attention and narrative choice state before attempting another narrative request.",
-      doNotRepeatLabel: "Do not repeat this narrative choice request until fresh attention and narrative evidence is read.",
-    }),
+    postcondition: projection.postcondition as Civ7DecisionsNarrativeChoiceResult["postcondition"],
+    nextSteps: projection.nextSteps,
   };
-}
-
-function narrativeChoicePostconditionSummary(
-  result: Civ7ControlOrpcNarrativeChoiceResult,
-): Civ7DecisionsNarrativeChoiceResult["postcondition"] {
-  const postcondition = narrativeChoiceProofPostcondition(result, undefined);
-  return civ7MutationPostconditionSummary({
-    postcondition,
-    missing: {
-      classification: "missing-postcondition",
-      reason: "The narrative choice result did not include explicit postcondition evidence.",
-      outcome: result.sent ? "unknown" : "not-sent",
-    },
-  }) as Civ7DecisionsNarrativeChoiceResult["postcondition"];
 }

--- a/packages/civ7-control-orpc/src/modules/decisions/procedures/progression-choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/procedures/progression-choice-request.ts
@@ -16,9 +16,8 @@ import { civ7MutationApprovalMiddleware } from "../../../middleware/mutation-app
 import { civ7MutationReadinessMiddleware } from "../../../middleware/mutation-readiness";
 import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
 import {
-  civ7MutationNextSteps,
-  civ7MutationRequestStatusWithoutGuarded,
-  type Civ7MutationProofConfidence,
+  civ7CloseoutMutationProjection,
+  type Civ7MutationProofPostcondition,
 } from "../../../policy/mutation-result";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
@@ -29,6 +28,10 @@ import type {
 type ProgressionChoiceCloseoutResult =
   | Civ7ControlOrpcTechnologyChoiceCloseoutResult
   | Civ7ControlOrpcCultureChoiceCloseoutResult;
+type ProgressionChoicePostcondition = Civ7MutationProofPostcondition<
+  Civ7DecisionsProgressionChoiceResult["postcondition"]["classification"],
+  Civ7DecisionsProgressionChoiceResult["postcondition"]["outcome"]
+>;
 type ApprovedCiv7ControlOrpcContext = Civ7ControlOrpcContext & Readonly<{
   approval: NonNullable<Civ7ControlOrpcContext["approval"]>;
 }>;
@@ -118,15 +121,18 @@ function progressionChoiceResult(
   before: Civ7ControlOrpcPlayNotificationViewResult,
   after: ProgressionChoicePostRead,
 ): Civ7DecisionsProgressionChoiceResult {
-  const postcondition = progressionChoicePostconditionSummary(
-    input,
-    result,
-    before,
-    after,
-  );
-  const status = civ7MutationRequestStatusWithoutGuarded({
+  const projection = civ7CloseoutMutationProjection({
     sent: result.sent,
-    postcondition,
+    postcondition: progressionChoicePostcondition(input, result, before, after),
+    missing: {
+      classification: "pending-runtime-proof",
+      reason: "The progression choice result did not include explicit postcondition evidence.",
+      outcome: "unknown",
+    },
+    source: "decisions.progression.choice.request",
+    inspectKind: "inspect-progression-choice",
+    inspectLabel: "Inspect current attention and progression choice state before attempting another progression request.",
+    doNotRepeatLabel: "Do not repeat this progression choice request until fresh attention and progression evidence is read.",
   });
 
   return {
@@ -137,7 +143,7 @@ function progressionChoiceResult(
       ? {}
       : { notificationId: input.notificationId }),
     sent: result.sent,
-    status,
+    status: projection.status,
     evidence: {
       beforeBlockerPresent: progressionBlockerPresent(input.kind, before),
       afterReadStatus: after.status,
@@ -148,31 +154,23 @@ function progressionChoiceResult(
         ? null
         : booleanProbeValue(after.view.canEndTurn),
     },
-    postcondition,
-    nextSteps: civ7MutationNextSteps({
-      status,
-      postcondition,
-      source: "decisions.progression.choice.request",
-      inspectKind: "inspect-progression-choice",
-      inspectLabel: "Inspect current attention and progression choice state before attempting another progression request.",
-      doNotRepeatLabel: "Do not repeat this progression choice request until fresh attention and progression evidence is read.",
-    }),
+    postcondition: projection.postcondition,
+    nextSteps: projection.nextSteps,
   };
 }
 
-function progressionChoicePostconditionSummary(
+function progressionChoicePostcondition(
   input: Civ7DecisionsProgressionChoiceInput,
   result: ProgressionChoiceCloseoutResult,
   before: Civ7ControlOrpcPlayNotificationViewResult,
   after: ProgressionChoicePostRead,
-): Civ7DecisionsProgressionChoiceResult["postcondition"] {
+): ProgressionChoicePostcondition {
   if (!result.sent) {
     return {
       classification: "not-sent",
       reason: "The progression choice closeout did not send both required App UI progression requests.",
       outcome: "not-sent",
       confidence: "unverified",
-      confirmed: false,
       noRepeatAfterUnverified: true,
     };
   }
@@ -183,7 +181,6 @@ function progressionChoicePostconditionSummary(
       reason: "The progression choice closeout was sent, but the post-send notification read failed; do not repeat until fresh attention evidence is available.",
       outcome: "unknown",
       confidence: "pending-runtime-proof",
-      confirmed: false,
       noRepeatAfterUnverified: true,
     };
   }
@@ -192,16 +189,12 @@ function progressionChoicePostconditionSummary(
     ? technologyChoicePostcondition(before, after.view)
     : cultureChoicePostcondition(before, after.view);
   const outcome = progressionChoiceOutcome(postcondition.classification);
-  const confidence: Civ7MutationProofConfidence = postcondition.verified
-    ? "confirmed"
-    : "unverified";
 
   return {
     classification: postcondition.classification,
     reason: postcondition.reason,
     outcome,
-    confidence,
-    confirmed: postcondition.verified,
+    confidence: postcondition.verified ? "confirmed" : "unverified",
     noRepeatAfterUnverified: !postcondition.verified,
   };
 }

--- a/packages/civ7-control-orpc/src/modules/decisions/procedures/progression-choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/procedures/progression-choice-request.ts
@@ -1,0 +1,224 @@
+import {
+  cultureChoicePostcondition,
+  findCultureChoiceNotification,
+  findTechnologyChoiceNotification,
+  technologyChoicePostcondition,
+} from "@civ7/direct-control";
+import { Effect } from "effect";
+
+import type { Civ7ControlOrpcContext } from "../../../context";
+import type {
+  Civ7ControlOrpcCultureChoiceCloseoutResult,
+  Civ7ControlOrpcPlayNotificationViewResult,
+  Civ7ControlOrpcTechnologyChoiceCloseoutResult,
+} from "../../../dependencies/direct-control";
+import { civ7MutationApprovalMiddleware } from "../../../middleware/mutation-approval";
+import { civ7MutationReadinessMiddleware } from "../../../middleware/mutation-readiness";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7MutationNextSteps,
+  civ7MutationRequestStatusWithoutGuarded,
+  type Civ7MutationProofConfidence,
+} from "../../../policy/mutation-result";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type {
+  Civ7DecisionsProgressionChoiceInput,
+  Civ7DecisionsProgressionChoiceResult,
+} from "../contract";
+
+type ProgressionChoiceCloseoutResult =
+  | Civ7ControlOrpcTechnologyChoiceCloseoutResult
+  | Civ7ControlOrpcCultureChoiceCloseoutResult;
+type ApprovedCiv7ControlOrpcContext = Civ7ControlOrpcContext & Readonly<{
+  approval: NonNullable<Civ7ControlOrpcContext["approval"]>;
+}>;
+
+const decisionsProgressionChoiceRequestWithApproval =
+  civ7ControlOrpcImplementer.decisions.progression.choice.request.use(
+    civ7MutationApprovalMiddleware,
+  );
+const decisionsProgressionChoiceRequestReady =
+  decisionsProgressionChoiceRequestWithApproval.use(
+    civ7MutationReadinessMiddleware,
+  );
+
+export const decisionsProgressionChoiceRequestProcedure =
+  decisionsProgressionChoiceRequestReady.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const before = await context.directControl.getCiv7PlayNotificationView(
+          context.endpointDefaults,
+        );
+        const result = await requestProgressionChoice(input, {
+          context,
+        });
+        const after = await context.directControl.getCiv7PlayNotificationView(
+          context.endpointDefaults,
+        );
+        return progressionChoiceResult(input, result, before, after);
+      },
+      catch: () =>
+        errors.PROGRESSION_CHOICE_UNAVAILABLE({
+          data: {
+            procedureKey: "decisions.progression.choice.request",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+async function requestProgressionChoice(
+  input: Civ7DecisionsProgressionChoiceInput,
+  dependencies: Readonly<{
+    context: ApprovedCiv7ControlOrpcContext;
+  }>,
+): Promise<ProgressionChoiceCloseoutResult> {
+  const requestInput = {
+    playerId: input.playerId,
+    node: input.node,
+    ...(input.notificationId === undefined
+      ? {}
+      : { notificationId: input.notificationId }),
+  };
+
+  if (input.kind === "technology") {
+    return dependencies.context.directControl.requestCiv7TechnologyChoiceCloseout(
+      requestInput,
+      dependencies.context.endpointDefaults,
+      dependencies.context.approval,
+    );
+  }
+
+  return dependencies.context.directControl.requestCiv7CultureChoiceCloseout(
+    requestInput,
+    dependencies.context.endpointDefaults,
+    dependencies.context.approval,
+  );
+}
+
+function progressionChoiceResult(
+  input: Civ7DecisionsProgressionChoiceInput,
+  result: ProgressionChoiceCloseoutResult,
+  before: Civ7ControlOrpcPlayNotificationViewResult,
+  after: Civ7ControlOrpcPlayNotificationViewResult,
+): Civ7DecisionsProgressionChoiceResult {
+  const postcondition = progressionChoicePostconditionSummary(
+    input,
+    result,
+    before,
+    after,
+  );
+  const status = civ7MutationRequestStatusWithoutGuarded({
+    sent: result.sent,
+    postcondition,
+  });
+
+  return {
+    kind: input.kind,
+    playerId: input.playerId,
+    node: input.node,
+    ...(input.notificationId === undefined
+      ? {}
+      : { notificationId: input.notificationId }),
+    sent: result.sent,
+    status,
+    evidence: {
+      beforeBlockerPresent: progressionBlockerPresent(input.kind, before),
+      afterBlockerPresent: progressionBlockerPresent(input.kind, after),
+      canEndTurnAfter: booleanProbeValue(after.canEndTurn),
+    },
+    postcondition,
+    nextSteps: civ7MutationNextSteps({
+      status,
+      postcondition,
+      source: "decisions.progression.choice.request",
+      inspectKind: "inspect-progression-choice",
+      inspectLabel: "Inspect current attention and progression choice state before attempting another progression request.",
+      doNotRepeatLabel: "Do not repeat this progression choice request until fresh attention and progression evidence is read.",
+    }),
+  };
+}
+
+function progressionChoicePostconditionSummary(
+  input: Civ7DecisionsProgressionChoiceInput,
+  result: ProgressionChoiceCloseoutResult,
+  before: Civ7ControlOrpcPlayNotificationViewResult,
+  after: Civ7ControlOrpcPlayNotificationViewResult,
+): Civ7DecisionsProgressionChoiceResult["postcondition"] {
+  if (!result.sent) {
+    return {
+      classification: "not-sent",
+      reason: "The progression choice closeout did not send both required App UI progression requests.",
+      outcome: "not-sent",
+      confidence: "unverified",
+      confirmed: false,
+      noRepeatAfterUnverified: true,
+    };
+  }
+
+  const postcondition = input.kind === "technology"
+    ? technologyChoicePostcondition(before, after)
+    : cultureChoicePostcondition(before, after);
+  const outcome = progressionChoiceOutcome(postcondition.classification);
+  const confidence: Civ7MutationProofConfidence = postcondition.verified
+    ? "confirmed"
+    : "unverified";
+
+  return {
+    classification: postcondition.classification,
+    reason: postcondition.reason,
+    outcome,
+    confidence,
+    confirmed: postcondition.verified,
+    noRepeatAfterUnverified: !postcondition.verified,
+  };
+}
+
+function progressionChoiceOutcome(
+  classification: Civ7DecisionsProgressionChoiceResult["postcondition"]["classification"],
+): Civ7DecisionsProgressionChoiceResult["postcondition"]["outcome"] {
+  switch (classification) {
+    case "turn-unblocked":
+    case "technology-choice-cleared":
+    case "culture-choice-cleared":
+      return "cleared";
+    case "technology-choice-transitioned":
+    case "culture-choice-transitioned":
+      return "state-changed";
+    case "technology-state-changed-blocker-still-live":
+    case "culture-state-changed-blocker-still-live":
+      return "still-blocked";
+    case "not-sent":
+      return "not-sent";
+    case "technology-choice-sticky-blocker":
+    case "culture-choice-sticky-blocker":
+      return "no-state-change";
+  }
+}
+
+function progressionBlockerPresent(
+  kind: Civ7DecisionsProgressionChoiceInput["kind"],
+  view: Civ7ControlOrpcPlayNotificationViewResult,
+): boolean {
+  return kind === "technology"
+    ? findTechnologyChoiceNotification(view) != null
+    : findCultureChoiceNotification(view) != null;
+}
+
+function booleanProbeValue(value: unknown): boolean | null {
+  const unwrapped = probeValue(value);
+  return typeof unwrapped === "boolean" ? unwrapped : null;
+}
+
+function probeValue(value: unknown): unknown {
+  if (value && typeof value === "object" && "ok" in value) {
+    const probe = value as { ok?: unknown; value?: unknown };
+    return probe.ok === true ? probe.value ?? null : null;
+  }
+  return value ?? null;
+}

--- a/packages/civ7-control-orpc/src/modules/decisions/procedures/progression-choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/procedures/progression-choice-request.ts
@@ -32,6 +32,19 @@ type ProgressionChoiceCloseoutResult =
 type ApprovedCiv7ControlOrpcContext = Civ7ControlOrpcContext & Readonly<{
   approval: NonNullable<Civ7ControlOrpcContext["approval"]>;
 }>;
+type ProgressionChoicePostRead =
+  | Readonly<{
+      status: "read";
+      view: Civ7ControlOrpcPlayNotificationViewResult;
+    }>
+  | Readonly<{
+      status: "failed";
+      view: null;
+    }>
+  | Readonly<{
+      status: "skipped-not-sent";
+      view: null;
+    }>;
 
 const decisionsProgressionChoiceRequestWithApproval =
   civ7ControlOrpcImplementer.decisions.progression.choice.request.use(
@@ -56,9 +69,7 @@ export const decisionsProgressionChoiceRequestProcedure =
         const result = await requestProgressionChoice(input, {
           context,
         });
-        const after = await context.directControl.getCiv7PlayNotificationView(
-          context.endpointDefaults,
-        );
+        const after = await readAfterProgressionChoice(context, result);
         return progressionChoiceResult(input, result, before, after);
       },
       catch: () =>
@@ -105,7 +116,7 @@ function progressionChoiceResult(
   input: Civ7DecisionsProgressionChoiceInput,
   result: ProgressionChoiceCloseoutResult,
   before: Civ7ControlOrpcPlayNotificationViewResult,
-  after: Civ7ControlOrpcPlayNotificationViewResult,
+  after: ProgressionChoicePostRead,
 ): Civ7DecisionsProgressionChoiceResult {
   const postcondition = progressionChoicePostconditionSummary(
     input,
@@ -129,8 +140,13 @@ function progressionChoiceResult(
     status,
     evidence: {
       beforeBlockerPresent: progressionBlockerPresent(input.kind, before),
-      afterBlockerPresent: progressionBlockerPresent(input.kind, after),
-      canEndTurnAfter: booleanProbeValue(after.canEndTurn),
+      afterReadStatus: after.status,
+      afterBlockerPresent: after.view == null
+        ? null
+        : progressionBlockerPresent(input.kind, after.view),
+      canEndTurnAfter: after.view == null
+        ? null
+        : booleanProbeValue(after.view.canEndTurn),
     },
     postcondition,
     nextSteps: civ7MutationNextSteps({
@@ -148,7 +164,7 @@ function progressionChoicePostconditionSummary(
   input: Civ7DecisionsProgressionChoiceInput,
   result: ProgressionChoiceCloseoutResult,
   before: Civ7ControlOrpcPlayNotificationViewResult,
-  after: Civ7ControlOrpcPlayNotificationViewResult,
+  after: ProgressionChoicePostRead,
 ): Civ7DecisionsProgressionChoiceResult["postcondition"] {
   if (!result.sent) {
     return {
@@ -161,9 +177,20 @@ function progressionChoicePostconditionSummary(
     };
   }
 
+  if (after.view == null) {
+    return {
+      classification: "pending-runtime-proof",
+      reason: "The progression choice closeout was sent, but the post-send notification read failed; do not repeat until fresh attention evidence is available.",
+      outcome: "unknown",
+      confidence: "pending-runtime-proof",
+      confirmed: false,
+      noRepeatAfterUnverified: true,
+    };
+  }
+
   const postcondition = input.kind === "technology"
-    ? technologyChoicePostcondition(before, after)
-    : cultureChoicePostcondition(before, after);
+    ? technologyChoicePostcondition(before, after.view)
+    : cultureChoicePostcondition(before, after.view);
   const outcome = progressionChoiceOutcome(postcondition.classification);
   const confidence: Civ7MutationProofConfidence = postcondition.verified
     ? "confirmed"
@@ -193,11 +220,31 @@ function progressionChoiceOutcome(
     case "technology-state-changed-blocker-still-live":
     case "culture-state-changed-blocker-still-live":
       return "still-blocked";
+    case "pending-runtime-proof":
+      return "unknown";
     case "not-sent":
       return "not-sent";
     case "technology-choice-sticky-blocker":
     case "culture-choice-sticky-blocker":
       return "no-state-change";
+  }
+}
+
+async function readAfterProgressionChoice(
+  context: Civ7ControlOrpcContext,
+  result: ProgressionChoiceCloseoutResult,
+): Promise<ProgressionChoicePostRead> {
+  if (!result.sent) return { status: "skipped-not-sent", view: null };
+
+  try {
+    return {
+      status: "read",
+      view: await context.directControl.getCiv7PlayNotificationView(
+        context.endpointDefaults,
+      ),
+    };
+  } catch {
+    return { status: "failed", view: null };
   }
 }
 

--- a/packages/civ7-control-orpc/src/modules/decisions/router.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/router.ts
@@ -1,5 +1,6 @@
 import { decisionsDiplomacyResponseRequestProcedure } from "./procedures/diplomacy-response-request";
 import { decisionsNarrativeChoiceRequestProcedure } from "./procedures/narrative-choice-request";
+import { decisionsProgressionChoiceRequestProcedure } from "./procedures/progression-choice-request";
 
 export const decisionsRouter = {
   diplomacy: {
@@ -10,6 +11,11 @@ export const decisionsRouter = {
   narrative: {
     choice: {
       request: decisionsNarrativeChoiceRequestProcedure,
+    },
+  },
+  progression: {
+    choice: {
+      request: decisionsProgressionChoiceRequestProcedure,
     },
   },
 };

--- a/packages/civ7-control-orpc/src/modules/notifications/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/notifications/contract.ts
@@ -1,5 +1,4 @@
 import {
-  Civ7ComponentIdSchema,
   Civ7NotificationDismissInputSchema,
   Civ7NotificationDismissalPostconditionClassificationSchema,
 } from "@civ7/direct-control";
@@ -9,6 +8,7 @@ import { Type, type Static } from "typebox";
 import { civ7ControlOrpcContractBase } from "../../contract-base";
 import type { Civ7ControlOrpcErrorMap } from "../../errors";
 import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
+import { Civ7ControlOrpcComponentIdSchema } from "../../model/primitives";
 import { toStandardSchema } from "../../typebox-standard-schema";
 
 export const Civ7NotificationDismissInputStandardSchema = toStandardSchema(
@@ -74,7 +74,7 @@ export const Civ7NotificationDismissalNextStepSchema = Type.Object(
 
 export const Civ7NotificationDismissalResultSchema = Type.Object(
   {
-    notificationId: Civ7ComponentIdSchema,
+    notificationId: Civ7ControlOrpcComponentIdSchema,
     sent: Type.Boolean(),
     status: Civ7NotificationDismissalRequestStatusSchema,
     validation: Civ7NotificationDismissalValidationSummarySchema,

--- a/packages/civ7-control-orpc/src/modules/notifications/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/notifications/contract.ts
@@ -1,7 +1,3 @@
-import {
-  Civ7NotificationDismissInputSchema,
-  Civ7NotificationDismissalPostconditionClassificationSchema,
-} from "@civ7/direct-control";
 import type { ContractProcedure } from "@orpc/contract";
 import { Type, type Static } from "typebox";
 
@@ -10,6 +6,16 @@ import type { Civ7ControlOrpcErrorMap } from "../../errors";
 import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
 import { Civ7ControlOrpcComponentIdSchema } from "../../model/primitives";
 import { toStandardSchema } from "../../typebox-standard-schema";
+
+export const Civ7NotificationDismissInputSchema = Type.Object(
+  {
+    notificationId: Civ7ControlOrpcComponentIdSchema,
+  },
+  { additionalProperties: false },
+);
+export type Civ7NotificationDismissInput = Static<
+  typeof Civ7NotificationDismissInputSchema
+>;
 
 export const Civ7NotificationDismissInputStandardSchema = toStandardSchema(
   Civ7NotificationDismissInputSchema,
@@ -30,6 +36,20 @@ export const Civ7NotificationDismissalRequestStatusSchema = Type.Union([
   Type.Literal("sent-confirmed"),
   Type.Literal("sent-unverified"),
 ]);
+
+export const Civ7NotificationDismissalPostconditionClassificationSchema =
+  Type.Union([
+    Type.Literal("not-sent"),
+    Type.Literal("missing-after"),
+    Type.Literal("notification-disappeared"),
+    Type.Literal("engine-front-still-live"),
+    Type.Literal("notification-dismissed"),
+    Type.Literal("engine-queue-cleared"),
+    Type.Literal("notification-train-cleared"),
+    Type.Literal("engine-front-moved"),
+    Type.Literal("notification-train-front-moved"),
+    Type.Literal("no-state-change"),
+  ]);
 
 export const Civ7NotificationDismissalPostconditionSummarySchema = Type.Object(
   {

--- a/packages/civ7-control-orpc/src/modules/notifications/procedures/dismiss-request.ts
+++ b/packages/civ7-control-orpc/src/modules/notifications/procedures/dismiss-request.ts
@@ -8,9 +8,7 @@ import { civ7MutationApprovalMiddleware } from "../../../middleware/mutation-app
 import { civ7MutationReadinessMiddleware } from "../../../middleware/mutation-readiness";
 import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
 import {
-  civ7MutationNextSteps,
-  civ7MutationPostconditionSummary,
-  civ7MutationRequestStatusWithoutGuarded,
+  civ7CloseoutMutationProjection,
 } from "../../../policy/mutation-result";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type { Civ7NotificationDismissalResult } from "../contract";
@@ -52,46 +50,30 @@ export const notificationsDismissRequestProcedure =
 function notificationDismissalResult(
   result: Civ7ControlOrpcNotificationDismissalResult,
 ): Civ7NotificationDismissalResult {
-  const postcondition = notificationDismissalPostconditionSummary(result);
-  const status = civ7MutationRequestStatusWithoutGuarded({
+  const projection = civ7CloseoutMutationProjection({
     sent: result.sent,
-    postcondition,
-  });
-
-  return {
-    notificationId: result.notificationId,
-    sent: result.sent,
-    status,
-    validation: {
-      beforeExists: result.before.exists,
-      canDismiss: result.canDismiss,
-      afterExists: result.after?.exists ?? null,
-    },
-    postcondition,
-    nextSteps: civ7MutationNextSteps({
-      status,
-      postcondition,
-      source: "notifications.dismiss.request",
-      inspectKind: "inspect-notification",
-      inspectLabel: "Inspect notification state before attempting another dismissal request.",
-      doNotRepeatLabel: "Do not repeat this dismissal request until fresh attention and notification evidence is read.",
-    }),
-  };
-}
-
-function notificationDismissalPostconditionSummary(
-  result: Civ7ControlOrpcNotificationDismissalResult,
-): Civ7NotificationDismissalResult["postcondition"] {
-  const postcondition = notificationDismissalProofPostcondition(
-    result,
-    undefined,
-  );
-  return civ7MutationPostconditionSummary({
-    postcondition,
+    postcondition: notificationDismissalProofPostcondition(result, undefined),
     missing: {
       classification: "missing-postcondition",
       reason: "The notification dismissal result did not include explicit postcondition evidence.",
       outcome: result.sent ? "unknown" : "not-sent",
     },
-  }) as Civ7NotificationDismissalResult["postcondition"];
+    source: "notifications.dismiss.request",
+    inspectKind: "inspect-notification",
+    inspectLabel: "Inspect notification state before attempting another dismissal request.",
+    doNotRepeatLabel: "Do not repeat this dismissal request until fresh attention and notification evidence is read.",
+  });
+
+  return {
+    notificationId: result.notificationId,
+    sent: result.sent,
+    status: projection.status,
+    validation: {
+      beforeExists: result.before.exists,
+      canDismiss: result.canDismiss,
+      afterExists: result.after?.exists ?? null,
+    },
+    postcondition: projection.postcondition as Civ7NotificationDismissalResult["postcondition"],
+    nextSteps: projection.nextSteps,
+  };
 }

--- a/packages/civ7-control-orpc/src/modules/strategy/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/contract.ts
@@ -1,16 +1,16 @@
-import { Civ7MapLocationSchema } from "@civ7/direct-control";
 import type { ContractProcedure } from "@orpc/contract";
 import { Type, type Static } from "typebox";
 
 import { civ7ControlOrpcContractBase } from "../../contract-base";
 import type { Civ7ControlOrpcErrorMap } from "../../errors";
 import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
+import { Civ7ControlOrpcMapLocationSchema } from "../../model/primitives";
 import { toStandardSchema } from "../../typebox-standard-schema";
 
 export const Civ7StrategyFrontSummaryInputSchema = Type.Object(
   {
     playerId: Type.Optional(Type.Integer({ minimum: 0, maximum: 1024 })),
-    origins: Type.Optional(Type.Array(Civ7MapLocationSchema)),
+    origins: Type.Optional(Type.Array(Civ7ControlOrpcMapLocationSchema)),
     candidateLimit: Type.Optional(Type.Integer({ minimum: 1, maximum: 8 })),
     scanRadius: Type.Optional(Type.Integer({ minimum: 1, maximum: 32 })),
     maxPlayers: Type.Optional(Type.Integer({ minimum: 1, maximum: 128 })),
@@ -65,7 +65,7 @@ export const Civ7StrategyFrontPointOfInterestSchema = Type.Object(
   {
     kind: Type.String(),
     severity: Type.String(),
-    location: Type.Union([Civ7MapLocationSchema, Type.Null()]),
+    location: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
     summary: Type.String(),
   },
   { additionalProperties: false },
@@ -103,7 +103,7 @@ export const Civ7StrategyFrontSummaryResultSchema = Type.Object(
   {
     playerId: Type.Integer({ minimum: 0 }),
     localPlayerId: Type.Integer({ minimum: 0 }),
-    origins: Type.Array(Civ7MapLocationSchema),
+    origins: Type.Array(Civ7ControlOrpcMapLocationSchema),
     sourceStatus: Civ7StrategyFrontSourceStatusSchema,
     relationshipLabelPolicy: Civ7StrategyRelationshipLabelPolicySchema,
     summary: Type.Object(

--- a/packages/civ7-control-orpc/src/modules/turn/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/turn/contract.ts
@@ -1,0 +1,137 @@
+import type { ContractProcedure } from "@orpc/contract";
+import { Type, type Static } from "typebox";
+
+import { civ7ControlOrpcContractBase } from "../../contract-base";
+import type { Civ7ControlOrpcErrorMap } from "../../errors";
+import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
+import { Civ7ControlOrpcComponentIdSchema } from "../../model/primitives";
+import { toStandardSchema } from "../../typebox-standard-schema";
+
+export const Civ7TurnCompletionInputSchema = Type.Object(
+  {},
+  { additionalProperties: false },
+);
+export type Civ7TurnCompletionInput = Static<
+  typeof Civ7TurnCompletionInputSchema
+>;
+
+export const Civ7TurnCompletionInputStandardSchema = toStandardSchema(
+  Civ7TurnCompletionInputSchema,
+);
+
+export const Civ7TurnCompletionRequestStatusSchema = Type.Union([
+  Type.Literal("sent-confirmed"),
+  Type.Literal("sent-guarded"),
+  Type.Literal("sent-unverified"),
+]);
+
+export const Civ7TurnCompletionPostconditionClassificationSchema = Type.Union(
+  [
+    Type.Literal("turn-advanced"),
+    Type.Literal("turn-complete-sent"),
+    Type.Literal("already-complete"),
+    Type.Literal("no-state-change"),
+    Type.Literal("missing-postcondition"),
+    Type.Literal("pending-runtime-proof"),
+  ],
+);
+
+export const Civ7TurnCompletionProofOutcomeSchema = Type.Union([
+  Type.Literal("cleared"),
+  Type.Literal("state-changed"),
+  Type.Literal("no-state-change"),
+  Type.Literal("unknown"),
+]);
+
+export const Civ7TurnCompletionProbeSummarySchema = Type.Object(
+  {
+    turn: Type.Union([Type.Number(), Type.Null()]),
+    turnDate: Type.Union([Type.String(), Type.Null()]),
+    hasSentTurnComplete: Type.Union([Type.Boolean(), Type.Null()]),
+    canEndTurn: Type.Union([Type.Boolean(), Type.Null()]),
+    blocker: Type.Union([Type.Number(), Type.String(), Type.Null()]),
+    firstReadyUnitId: Type.Union([
+      Civ7ControlOrpcComponentIdSchema,
+      Type.Null(),
+    ]),
+  },
+  { additionalProperties: false },
+);
+
+export const Civ7TurnCompletionPostconditionSummarySchema = Type.Object(
+  {
+    classification: Civ7TurnCompletionPostconditionClassificationSchema,
+    reason: Type.String(),
+    outcome: Civ7TurnCompletionProofOutcomeSchema,
+    confidence: Type.Union([
+      Type.Literal("confirmed"),
+      Type.Literal("unverified"),
+      Type.Literal("pending-runtime-proof"),
+    ]),
+    confirmed: Type.Boolean(),
+    noRepeatAfterUnverified: Type.Boolean(),
+  },
+  { additionalProperties: false },
+);
+
+export const Civ7TurnCompletionNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("refresh-attention"),
+      Type.Literal("do-not-repeat"),
+      Type.Literal("inspect-turn-completion"),
+    ]),
+    source: Type.Literal("turn.complete.request"),
+    label: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+export const Civ7TurnCompletionResultSchema = Type.Object(
+  {
+    sent: Type.Literal(true),
+    status: Civ7TurnCompletionRequestStatusSchema,
+    before: Civ7TurnCompletionProbeSummarySchema,
+    after: Civ7TurnCompletionProbeSummarySchema,
+    postcondition: Civ7TurnCompletionPostconditionSummarySchema,
+    nextSteps: Type.Array(Civ7TurnCompletionNextStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7TurnCompletionResult = Static<
+  typeof Civ7TurnCompletionResultSchema
+>;
+
+export const Civ7TurnCompletionResultStandardSchema = toStandardSchema(
+  Civ7TurnCompletionResultSchema,
+);
+
+export type Civ7TurnCompletionContract = ContractProcedure<
+  typeof Civ7TurnCompletionInputStandardSchema,
+  typeof Civ7TurnCompletionResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export const Civ7TurnCompletionContract: Civ7TurnCompletionContract =
+  civ7ControlOrpcContractBase
+    .input(Civ7TurnCompletionInputStandardSchema)
+    .output(Civ7TurnCompletionResultStandardSchema)
+    .meta({
+      family: "turn",
+      procedureKey: "turn.complete.request",
+      proofBoundary: "local-package-test",
+      risk: "mutation",
+    });
+
+export type Civ7TurnContract = Readonly<{
+  complete: Readonly<{
+    request: Civ7TurnCompletionContract;
+  }>;
+}>;
+
+export const Civ7TurnContract: Civ7TurnContract = {
+  complete: {
+    request: Civ7TurnCompletionContract,
+  },
+};

--- a/packages/civ7-control-orpc/src/modules/turn/procedures/complete-request.ts
+++ b/packages/civ7-control-orpc/src/modules/turn/procedures/complete-request.ts
@@ -1,0 +1,124 @@
+import {
+  turnCompletionProofPostcondition,
+  type Civ7RuntimeProbe,
+} from "@civ7/direct-control";
+import { Effect } from "effect";
+
+import type { Civ7ControlOrpcTurnCompletionActionResult } from "../../../dependencies/direct-control";
+import { civ7MutationApprovalMiddleware } from "../../../middleware/mutation-approval";
+import { civ7MutationReadinessMiddleware } from "../../../middleware/mutation-readiness";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import {
+  civ7MutationNextSteps,
+  civ7MutationRequestStatus,
+} from "../../../policy/mutation-result";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type { Civ7TurnCompletionResult } from "../contract";
+
+const turnCompleteRequestWithApproval =
+  civ7ControlOrpcImplementer.turn.complete.request.use(
+    civ7MutationApprovalMiddleware,
+  );
+const turnCompleteRequestReady =
+  turnCompleteRequestWithApproval.use(civ7MutationReadinessMiddleware);
+
+export const turnCompleteRequestProcedure =
+  turnCompleteRequestReady.effect(function* ({
+    context,
+    errors,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const result = await context.directControl.requestCiv7TurnComplete(
+          context.endpointDefaults,
+          context.approval,
+        );
+        return turnCompletionResult(result);
+      },
+      catch: () =>
+        errors.TURN_COMPLETION_UNAVAILABLE({
+          data: {
+            procedureKey: "turn.complete.request",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+function turnCompletionResult(
+  result: Civ7ControlOrpcTurnCompletionActionResult,
+): Civ7TurnCompletionResult {
+  const postcondition = turnCompletionPostconditionSummary(result);
+  const status = turnCompletionRequestStatus(postcondition);
+
+  return {
+    sent: true,
+    status,
+    before: turnCompletionProbeSummary(result.before),
+    after: turnCompletionProbeSummary(result.after),
+    postcondition,
+    nextSteps: civ7MutationNextSteps({
+      status,
+      postcondition,
+      source: "turn.complete.request",
+      inspectKind: "inspect-turn-completion",
+      inspectLabel: "Inspect current turn completion state before attempting another turn completion request.",
+      doNotRepeatLabel: "Do not repeat turn completion until fresh turn and attention evidence is read.",
+    }),
+  };
+}
+
+function turnCompletionRequestStatus(
+  postcondition: Civ7TurnCompletionResult["postcondition"],
+): Civ7TurnCompletionResult["status"] {
+  const status = civ7MutationRequestStatus({
+    sent: true,
+    postcondition,
+  });
+  if (status === "not-sent") {
+    throw new Error("turn.complete.request unexpectedly produced not-sent status");
+  }
+  return status;
+}
+
+function turnCompletionPostconditionSummary(
+  result: Civ7ControlOrpcTurnCompletionActionResult,
+): Civ7TurnCompletionResult["postcondition"] {
+  const postcondition = turnCompletionProofPostcondition(result, undefined);
+  const confirmed = postcondition.confidence === "confirmed";
+
+  return {
+    classification: postcondition.classification as
+      Civ7TurnCompletionResult["postcondition"]["classification"],
+    reason: postcondition.reason,
+    outcome: postcondition.outcome as
+      Civ7TurnCompletionResult["postcondition"]["outcome"],
+    confidence: postcondition.confidence,
+    confirmed,
+    noRepeatAfterUnverified: postcondition.noRepeatAfterUnverified,
+  };
+}
+
+function turnCompletionProbeSummary(
+  status: Civ7ControlOrpcTurnCompletionActionResult["before"],
+): Civ7TurnCompletionResult["before"] {
+  return {
+    turn: probeValue(status.turn),
+    turnDate: probeValue(status.turnDate),
+    hasSentTurnComplete: probeValue(status.hasSentTurnComplete),
+    canEndTurn: probeValue(status.canEndTurn),
+    blocker: blockerValue(status.blocker),
+    firstReadyUnitId: probeValue(status.firstReadyUnitId),
+  };
+}
+
+function blockerValue(probe: Civ7RuntimeProbe<unknown>): number | string | null {
+  const value = probeValue(probe);
+  if (typeof value === "number" || typeof value === "string") return value;
+  return null;
+}
+
+function probeValue<T>(probe: Civ7RuntimeProbe<T>): T | null {
+  return probe.ok ? probe.value : null;
+}

--- a/packages/civ7-control-orpc/src/modules/turn/router.ts
+++ b/packages/civ7-control-orpc/src/modules/turn/router.ts
@@ -1,0 +1,7 @@
+import { turnCompleteRequestProcedure } from "./procedures/complete-request";
+
+export const turnRouter = {
+  complete: {
+    request: turnCompleteRequestProcedure,
+  },
+};

--- a/packages/civ7-control-orpc/src/modules/unit/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/unit/contract.ts
@@ -1,6 +1,4 @@
 import {
-  Civ7ComponentIdSchema,
-  Civ7MapLocationSchema,
   Civ7UnitTargetActionInputSchema,
 } from "@civ7/direct-control";
 import type { ContractProcedure } from "@orpc/contract";
@@ -9,6 +7,10 @@ import { Type, type Static } from "typebox";
 import { civ7ControlOrpcContractBase } from "../../contract-base";
 import type { Civ7ControlOrpcErrorMap } from "../../errors";
 import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
+import {
+  Civ7ControlOrpcComponentIdSchema,
+  Civ7ControlOrpcMapLocationSchema,
+} from "../../model/primitives";
 import { toStandardSchema } from "../../typebox-standard-schema";
 
 export const Civ7UnitTargetActionInputStandardSchema = toStandardSchema(
@@ -81,8 +83,8 @@ export const Civ7UnitTargetActionPostconditionSummarySchema = Type.Object(
     confirmed: Type.Boolean(),
     noRepeatAfterUnverified: Type.Boolean(),
     destinationReached: Type.Union([Type.Boolean(), Type.Null()]),
-    requestedLocation: Civ7MapLocationSchema,
-    landedLocation: Type.Union([Civ7MapLocationSchema, Type.Null()]),
+    requestedLocation: Civ7ControlOrpcMapLocationSchema,
+    landedLocation: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
     source: Type.Union([
       Type.Literal("immediate"),
       Type.Literal("bounded-poll"),
@@ -107,8 +109,8 @@ export const Civ7UnitTargetActionNextStepSchema = Type.Object(
 
 export const Civ7UnitTargetActionResultSchema = Type.Object(
   {
-    unitId: Civ7ComponentIdSchema,
-    target: Civ7MapLocationSchema,
+    unitId: Civ7ControlOrpcComponentIdSchema,
+    target: Civ7ControlOrpcMapLocationSchema,
     sent: Type.Boolean(),
     status: Civ7UnitTargetActionRequestStatusSchema,
     validation: Civ7UnitTargetActionValidationSummarySchema,

--- a/packages/civ7-control-orpc/src/modules/unit/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/unit/contract.ts
@@ -1,6 +1,3 @@
-import {
-  Civ7UnitTargetActionInputSchema,
-} from "@civ7/direct-control";
 import type { ContractProcedure } from "@orpc/contract";
 import { Type, type Static } from "typebox";
 
@@ -12,6 +9,18 @@ import {
   Civ7ControlOrpcMapLocationSchema,
 } from "../../model/primitives";
 import { toStandardSchema } from "../../typebox-standard-schema";
+
+export const Civ7UnitTargetActionInputSchema = Type.Object(
+  {
+    unitId: Civ7ControlOrpcComponentIdSchema,
+    x: Type.Integer({ minimum: 0, maximum: 1_000_000 }),
+    y: Type.Integer({ minimum: 0, maximum: 1_000_000 }),
+  },
+  { additionalProperties: false },
+);
+export type Civ7UnitTargetActionInput = Static<
+  typeof Civ7UnitTargetActionInputSchema
+>;
 
 export const Civ7UnitTargetActionInputStandardSchema = toStandardSchema(
   Civ7UnitTargetActionInputSchema,

--- a/packages/civ7-control-orpc/src/policy/mutation-result.ts
+++ b/packages/civ7-control-orpc/src/policy/mutation-result.ts
@@ -39,6 +39,17 @@ export type Civ7MutationNextStep<
   label: string;
 }>;
 
+export type Civ7MutationProjection<
+  Classification extends string,
+  Outcome extends string,
+  Source extends string,
+  InspectKind extends string,
+> = Readonly<{
+  postcondition: Civ7MutationPostconditionSummary<Classification, Outcome>;
+  status: Exclude<Civ7MutationRequestStatus, "sent-guarded">;
+  nextSteps: Array<Civ7MutationNextStep<Source, InspectKind>>;
+}>;
+
 export function civ7MutationRequestStatus(
   input: Readonly<{
     sent: boolean;
@@ -138,4 +149,61 @@ export function civ7MutationNextSteps<
     label: input.refreshLabel
       ?? "Refresh current attention before choosing the next player action.",
   }];
+}
+
+export function civ7CloseoutMutationProjection<
+  Classification extends string,
+  Outcome extends string,
+  MissingClassification extends string,
+  MissingOutcome extends string,
+  Source extends string,
+  InspectKind extends string,
+>(
+  input: Readonly<{
+    sent: boolean;
+    postcondition:
+      | Civ7MutationProofPostcondition<Classification, Outcome>
+      | null
+      | undefined;
+    missing: Readonly<{
+      classification: MissingClassification;
+      reason: string;
+      outcome: MissingOutcome;
+    }>;
+    source: Source;
+    inspectKind: InspectKind;
+    inspectLabel: string;
+    doNotRepeatLabel: string;
+    refreshLabel?: string;
+  }>,
+): Civ7MutationProjection<
+  Classification | MissingClassification,
+  Outcome | MissingOutcome,
+  Source,
+  InspectKind
+> {
+  const postcondition = civ7MutationPostconditionSummary({
+    postcondition: input.postcondition,
+    missing: input.missing,
+  });
+  const status = civ7MutationRequestStatusWithoutGuarded({
+    sent: input.sent,
+    postcondition,
+  });
+
+  return {
+    postcondition,
+    status,
+    nextSteps: civ7MutationNextSteps({
+      status,
+      postcondition,
+      source: input.source,
+      inspectKind: input.inspectKind,
+      inspectLabel: input.inspectLabel,
+      doNotRepeatLabel: input.doNotRepeatLabel,
+      ...(input.refreshLabel === undefined
+        ? {}
+        : { refreshLabel: input.refreshLabel }),
+    }),
+  };
 }

--- a/packages/civ7-control-orpc/src/router.ts
+++ b/packages/civ7-control-orpc/src/router.ts
@@ -9,6 +9,7 @@ import { decisionsRouter } from "./modules/decisions/router";
 import { notificationsRouter } from "./modules/notifications/router";
 import { readinessRouter } from "./modules/readiness/router";
 import { strategyRouter } from "./modules/strategy/router";
+import { turnRouter } from "./modules/turn/router";
 import { unitRouter } from "./modules/unit/router";
 
 export const Civ7ControlOrpcRouter: Router<
@@ -21,5 +22,6 @@ export const Civ7ControlOrpcRouter: Router<
   notifications: notificationsRouter,
   readiness: readinessRouter,
   strategy: strategyRouter,
+  turn: turnRouter,
   unit: unitRouter,
 });

--- a/packages/civ7-control-orpc/src/runtime.ts
+++ b/packages/civ7-control-orpc/src/runtime.ts
@@ -1,0 +1,4 @@
+export {
+  liveCiv7ControlOrpcDirectControlFacade,
+  type Civ7ControlOrpcDirectControlFacade,
+} from "./dependencies/direct-control";

--- a/packages/civ7-control-orpc/test/city-production-choice-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/city-production-choice-procedure.test.ts
@@ -1,4 +1,5 @@
 import { call } from "@orpc/server";
+import { Value } from "typebox/value";
 import { describe, expect, test } from "vitest";
 
 import {
@@ -8,6 +9,8 @@ import {
   Civ7MutationApprovalRequiredError,
   Civ7MutationReadinessRequiredError,
   Civ7MutationReadinessUnavailableError,
+  Civ7CityProductionChoiceInputSchema,
+  Civ7CityProductionChoicePostconditionClassificationSchema,
   Civ7ProductionChoiceUnavailableError,
   createCiv7ControlOrpcServerClient,
   type Civ7ControlOrpcContext,
@@ -18,6 +21,40 @@ const cityId = { owner: 0, id: 65_536, type: 1 };
 const args = { ConstructibleType: 713_967_338, X: 22, Y: 31 };
 
 describe("city.production.choice.request control-oRPC procedure", () => {
+  test("owns the caller-facing production choice contract without raw fields", () => {
+    expect(Value.Check(Civ7CityProductionChoiceInputSchema, {
+      cityId,
+      args,
+    })).toBe(true);
+    expect(Value.Check(Civ7CityProductionChoiceInputSchema, {
+      cityId,
+      args,
+      rawCommand: "Game.CityOperations.sendRequest(...)",
+    })).toBe(false);
+    expect(Value.Check(Civ7CityProductionChoiceInputSchema, {
+      cityId,
+      args,
+      approvalReason: "test approved production choice",
+    })).toBe(false);
+    expect(Value.Check(Civ7CityProductionChoiceInputSchema, {
+      cityId,
+      args,
+      session: { state: "App UI" },
+    })).toBe(false);
+    expect(Value.Check(Civ7CityProductionChoiceInputSchema, {
+      cityId,
+      args: { UnitType: 102, ConstructibleType: 713_967_338 },
+    })).toBe(false);
+    expect(Value.Check(
+      Civ7CityProductionChoicePostconditionClassificationSchema,
+      "production-state-changed-blocker-still-live",
+    )).toBe(true);
+    expect(Value.Check(
+      Civ7CityProductionChoicePostconditionClassificationSchema,
+      "pending-runtime-proof",
+    )).toBe(false);
+  });
+
   test("calls the production choice mutation through native Effect/oRPC with context approval", async () => {
     const fake = fakeContext(
       productionChoiceResult("production-choice-cleared"),

--- a/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
+++ b/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "vitest";
+import { Value } from "typebox/value";
+
+import {
+  Civ7ControllerBridgeResponseSchema,
+  createCiv7ControllerBridgeIngress,
+  invokeCiv7ControllerBridgeRequest,
+  type Civ7ControlOrpcContext,
+  type Civ7ControlOrpcPlayableStatusResult,
+} from "../src/index";
+
+describe("Civ7 controller bridge ingress", () => {
+  test("invokes allowlisted readiness.current through the in-process router", async () => {
+    const fake = fakeContext(playableStatusResult());
+    const ingress = createCiv7ControllerBridgeIngress({
+      createContext: (request) => {
+        fake.contextRequests.push(request);
+        return fake.context;
+      },
+    });
+
+    const response = await ingress.invoke({
+      procedureKey: "readiness.current",
+      input: {},
+      correlationId: "controller-readiness-1",
+    });
+
+    expect(Value.Check(Civ7ControllerBridgeResponseSchema, response)).toBe(true);
+    expect(response).toMatchObject({
+      ok: true,
+      procedureKey: "readiness.current",
+      correlationId: "controller-readiness-1",
+      output: {
+        playable: true,
+        readiness: "tuner-ready",
+        capability: {
+          canObserve: true,
+          canMutate: true,
+        },
+      },
+    });
+    expect(fake.calls).toEqual([{ timeoutMs: 1_000 }]);
+    expect(fake.contextRequests).toEqual([{
+      procedureKey: "readiness.current",
+      input: {},
+      correlationId: "controller-readiness-1",
+    }]);
+
+    const serialized = JSON.stringify(response);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"session\"");
+    expect(serialized).not.toContain("\"rawCommand\"");
+    expect(serialized).not.toContain("Game.turn");
+    expect(serialized).not.toContain("Tuner");
+    expect(serialized).not.toContain("App UI");
+  });
+
+  test("rejects raw command, session, endpoint, and state envelope fields", async () => {
+    const invalidRequests = [
+      { procedureKey: "readiness.current", input: {}, host: "127.0.0.1" },
+      { procedureKey: "readiness.current", input: {}, port: 4318 },
+      { procedureKey: "readiness.current", input: {}, state: { role: "tuner" } },
+      { procedureKey: "readiness.current", input: {}, session: { state: "Tuner" } },
+      { procedureKey: "readiness.current", input: {}, command: "Game.turn" },
+      { procedureKey: "readiness.current", input: {}, rawCommand: "Game.turn" },
+      { procedureKey: "readiness.current", input: { rawCommand: "Game.turn" } },
+      { procedureKey: "readiness.current", input: {}, approval: { approved: true } },
+    ];
+
+    for (const request of invalidRequests) {
+      const fake = fakeContext(playableStatusResult());
+      const response = await invokeCiv7ControllerBridgeRequest(request, {
+        createContext: () => fake.context,
+      });
+
+      expect(response).toEqual({
+        ok: false,
+        error: {
+          code: "BRIDGE_BAD_REQUEST",
+          message: "Civ7 controller bridge request envelope is invalid.",
+          reason: "invalid-envelope",
+        },
+      });
+      expect(fake.calls).toEqual([]);
+    }
+  });
+
+  test("rejects procedures outside the bridge allowlist without dispatch", async () => {
+    const fake = fakeContext(playableStatusResult());
+
+    const response = await invokeCiv7ControllerBridgeRequest({
+      procedureKey: "unit.target.action.request",
+      input: {
+        unitId: { owner: 0, id: 1, type: 1 },
+        target: { x: 10, y: 12 },
+      },
+    }, {
+      createContext: () => fake.context,
+    });
+
+    expect(response).toEqual({
+      ok: false,
+      error: {
+        code: "BRIDGE_PROCEDURE_NOT_ALLOWED",
+        message: "Civ7 controller bridge procedure is not allowlisted.",
+        reason: "procedure-not-allowed",
+      },
+    });
+    expect(fake.calls).toEqual([]);
+  });
+
+  test("keeps raw direct-control failure details out of bridge failures", async () => {
+    const fake = fakeContext(new Error(
+      "Timed out waiting for Civ7 tuner response to CMD:65535:Game.turn",
+    ));
+
+    const response = await invokeCiv7ControllerBridgeRequest({
+      procedureKey: "readiness.current",
+      input: {},
+      correlationId: "controller-error-1",
+    }, {
+      createContext: () => fake.context,
+    });
+
+    expect(Value.Check(Civ7ControllerBridgeResponseSchema, response)).toBe(true);
+    expect(response).toEqual({
+      ok: false,
+      correlationId: "controller-error-1",
+      error: {
+        code: "READINESS_CURRENT_UNAVAILABLE",
+        message: "Current readiness view failed.",
+        reason: "procedure-failed",
+      },
+    });
+    const serialized = JSON.stringify(response);
+    expect(serialized).not.toContain("CMD");
+    expect(serialized).not.toContain("Game.turn");
+    expect(serialized).not.toContain("rawCommand");
+    expect(serialized).not.toContain("command-failed");
+  });
+});
+
+function fakeContext(
+  resultOrError: Civ7ControlOrpcPlayableStatusResult | Error,
+): {
+  calls: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+  contextRequests: unknown[];
+  context: Civ7ControlOrpcContext;
+} {
+  const calls: Array<Civ7ControlOrpcContext["endpointDefaults"]> = [];
+  return {
+    calls,
+    contextRequests: [],
+    context: {
+      endpointDefaults: { timeoutMs: 1_000 },
+      directControl: {
+        getCiv7PlayableStatus: async (options) => {
+          calls.push(options);
+          if (resultOrError instanceof Error) throw resultOrError;
+          return resultOrError;
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function playableStatusResult(): Civ7ControlOrpcPlayableStatusResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    playable: true,
+    readiness: "tuner-ready",
+    appUi: {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      snapshot: {
+        ui: {
+          inGame: { ok: true, value: true },
+          inShell: { ok: true, value: false },
+          inLoading: { ok: true, value: false },
+          canBeginGame: { ok: true, value: false },
+        },
+        currentState: "App UI",
+      },
+    },
+    tuner: {
+      ready: true,
+      health: {
+        ok: true,
+        host: "127.0.0.1",
+        port: 4318,
+        latencyMs: 1,
+      },
+    },
+    errors: ["raw Tuner detail"],
+  };
+}

--- a/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
+++ b/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
@@ -57,6 +57,68 @@ describe("Civ7 controller bridge ingress", () => {
     expect(serialized).not.toContain("App UI");
   });
 
+  test("invokes allowlisted attention.current through the in-process router", async () => {
+    const unitId = { owner: 0, id: 458_752, type: 26 };
+    const fake = fakeAttentionContext(unitId);
+    const ingress = createCiv7ControllerBridgeIngress({
+      createContext: (request) => {
+        fake.contextRequests.push(request);
+        return fake.context;
+      },
+    });
+
+    const response = await ingress.invoke({
+      procedureKey: "attention.current",
+      input: { maxNotifications: 4 },
+      correlationId: "controller-attention-1",
+    });
+
+    expect(Value.Check(Civ7ControllerBridgeResponseSchema, response)).toBe(true);
+    expect(response).toMatchObject({
+      ok: true,
+      procedureKey: "attention.current",
+      correlationId: "controller-attention-1",
+      output: {
+        playable: true,
+        readiness: "tuner-ready",
+        sourceStatus: {
+          playableStatus: "read",
+          notifications: "read",
+          turnCompletion: "read",
+          readyUnit: "read",
+          readyCity: "read",
+        },
+        summary: {
+          blockerCount: 1,
+          decisionCount: 0,
+          readyActorCount: 1,
+          nextStepCount: 1,
+        },
+      },
+    });
+    expect(fake.calls.notifications).toEqual([
+      { timeoutMs: 1_000, maxNotifications: 4 },
+    ]);
+    expect(fake.calls.readyUnit).toEqual([
+      { input: {}, options: { timeoutMs: 1_000 } },
+    ]);
+    expect(fake.contextRequests).toEqual([{
+      procedureKey: "attention.current",
+      input: { maxNotifications: 4 },
+      correlationId: "controller-attention-1",
+    }]);
+
+    const serialized = JSON.stringify(response);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"session\"");
+    expect(serialized).not.toContain("\"rawCommand\"");
+    expect(serialized).not.toContain("Game.turn");
+    expect(serialized).not.toContain("Tuner");
+    expect(serialized).not.toContain("App UI");
+  });
+
   test("rejects raw command, session, endpoint, and state envelope fields", async () => {
     const invalidRequests = [
       { procedureKey: "readiness.current", input: {}, host: "127.0.0.1" },
@@ -67,6 +129,11 @@ describe("Civ7 controller bridge ingress", () => {
       { procedureKey: "readiness.current", input: {}, rawCommand: "Game.turn" },
       { procedureKey: "readiness.current", input: { rawCommand: "Game.turn" } },
       { procedureKey: "readiness.current", input: {}, approval: { approved: true } },
+      { procedureKey: "attention.current", input: {}, host: "127.0.0.1" },
+      { procedureKey: "attention.current", input: {}, session: { state: "Tuner" } },
+      { procedureKey: "attention.current", input: {}, rawCommand: "Game.turn" },
+      { procedureKey: "attention.current", input: { rawCommand: "Game.turn" } },
+      { procedureKey: "attention.current", input: {}, approval: { approved: true } },
     ];
 
     for (const request of invalidRequests) {
@@ -166,6 +233,50 @@ function fakeContext(
   };
 }
 
+function fakeAttentionContext(unitId: { owner: number; id: number; type: number }): {
+  calls: {
+    notifications: Array<Record<string, unknown> | undefined>;
+    readyUnit: Array<{ input: unknown; options: unknown }>;
+  };
+  contextRequests: unknown[];
+  context: Civ7ControlOrpcContext;
+} {
+  const calls: {
+    notifications: Array<Record<string, unknown> | undefined>;
+    readyUnit: Array<{ input: unknown; options: unknown }>;
+  } = {
+    notifications: [],
+    readyUnit: [],
+  };
+  return {
+    calls,
+    contextRequests: [],
+    context: {
+      endpointDefaults: { timeoutMs: 1_000 },
+      directControl: {
+        getCiv7PlayableStatus: async () => playableStatusResult(),
+        getCiv7PlayNotificationView: async (options) => {
+          calls.notifications.push(options);
+          return cleanNotificationViewResult();
+        },
+        getCiv7TurnCompletionStatus: async () => turnCompletionStatusResult(),
+        getCiv7ReadyUnitView: async (input, options) => {
+          calls.readyUnit.push({ input, options });
+          return {
+            unitId,
+            legalOperations: [{ family: "unit-operation", operationType: "MOVE_TO" }],
+          };
+        },
+        getCiv7ReadyCityView: async () => ({
+          cityId: null,
+          blockingCityId: { ok: true, value: null },
+          legalOperations: [],
+        }),
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
 function playableStatusResult(): Civ7ControlOrpcPlayableStatusResult {
   return {
     host: "127.0.0.1",
@@ -196,5 +307,32 @@ function playableStatusResult(): Civ7ControlOrpcPlayableStatusResult {
       },
     },
     errors: ["raw Tuner detail"],
+  };
+}
+
+function cleanNotificationViewResult(): any {
+  return {
+    turn: { ok: true, value: 12 },
+    turnDate: { ok: true, value: "3400 BCE" },
+    canEndTurn: { ok: true, value: false },
+    selectedUnitId: { ok: true, value: null },
+    firstReadyUnitId: { ok: true, value: null },
+    selectedCityId: { ok: true, value: null },
+    blockingNotificationId: { ok: true, value: null },
+    hud: {
+      nextDecision: null,
+      decisionQueue: [],
+    },
+  };
+}
+
+function turnCompletionStatusResult(): any {
+  return {
+    turn: { ok: true, value: 12 },
+    turnDate: { ok: true, value: "3400 BCE" },
+    hasSentTurnComplete: { ok: true, value: false },
+    canEndTurn: { ok: true, value: false },
+    firstReadyUnitId: { ok: true, value: null },
+    blocker: { ok: true, value: 0 },
   };
 }

--- a/packages/civ7-control-orpc/test/decisions-progression-choice-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/decisions-progression-choice-procedure.test.ts
@@ -1,0 +1,532 @@
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  Civ7ProgressionChoiceUnavailableError,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+  type Civ7ControlOrpcPlayableStatusResult,
+} from "../src/index";
+import type {
+  Civ7ControlOrpcCultureChoiceCloseoutResult,
+  Civ7ControlOrpcPlayNotificationViewResult,
+  Civ7ControlOrpcTechnologyChoiceCloseoutResult,
+} from "../src/dependencies/direct-control";
+
+const technologyInput = {
+  kind: "technology",
+  playerId: 0,
+  node: 18_001,
+  notificationId: { owner: 0, id: 72, type: 20 },
+} as const;
+
+const cultureInput = {
+  kind: "culture",
+  playerId: 0,
+  node: 27_001,
+} as const;
+
+describe("decisions.progression.choice.request control-oRPC procedure", () => {
+  test("projects confirmed technology choices without raw command output", async () => {
+    const before = notificationView("NOTIFICATION_CHOOSE_TECH", {
+      currentResearching: probe(10),
+      targetNode: probe(20),
+    });
+    const after = cleanView({ canEndTurn: true });
+    const fake = fakeContext({
+      views: [before, after],
+      technologyResult: progressionCloseoutResult("technology"),
+    });
+
+    const result = await call(
+      Civ7ControlOrpcRouter.decisions.progression.choice.request,
+      technologyInput,
+      { context: fake.context },
+    );
+
+    expect(fake.calls.readiness).toHaveLength(1);
+    expect(fake.calls.views).toHaveLength(2);
+    expect(fake.calls.technology).toEqual([{
+      input: {
+        playerId: 0,
+        node: 18_001,
+        notificationId: { owner: 0, id: 72, type: 20 },
+      },
+      options: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      approval: {
+        approved: true,
+        reason: "local progression choice proof",
+      },
+    }]);
+    expect(fake.calls.culture).toEqual([]);
+    expect(result).toEqual({
+      kind: "technology",
+      playerId: 0,
+      node: 18_001,
+      notificationId: { owner: 0, id: 72, type: 20 },
+      sent: true,
+      status: "sent-confirmed",
+      evidence: {
+        beforeBlockerPresent: true,
+        afterBlockerPresent: false,
+        canEndTurnAfter: true,
+      },
+      postcondition: {
+        classification: "turn-unblocked",
+        reason: "The technology choice workflow left the turn unblocked.",
+        outcome: "cleared",
+        confidence: "confirmed",
+        confirmed: true,
+        noRepeatAfterUnverified: false,
+      },
+      nextSteps: [{
+        kind: "refresh-attention",
+        source: "decisions.progression.choice.request",
+        label: "Refresh current attention before choosing the next player action.",
+      }],
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"command\"");
+    expect(serialized).not.toContain("\"payload\"");
+    expect(serialized).not.toContain("\"verified\"");
+    expect(serialized).not.toContain("SET_TECH_TREE_NODE");
+  });
+
+  test("keeps sent culture choices no-repeat guarded while the blocker remains live", async () => {
+    const before = notificationView("NOTIFICATION_CHOOSE_CULTURE_NODE", {
+      currentResearching: probe(30),
+      targetNode: probe(40),
+    });
+    const after = notificationView("NOTIFICATION_CHOOSE_CULTURE_NODE", {
+      currentResearching: probe(31),
+      targetNode: probe(40),
+    });
+    const fake = fakeContext({
+      views: [before, after],
+      cultureResult: progressionCloseoutResult("culture"),
+    });
+
+    const result = await call(
+      Civ7ControlOrpcRouter.decisions.progression.choice.request,
+      cultureInput,
+      { context: fake.context },
+    );
+
+    expect(fake.calls.culture).toEqual([{
+      input: {
+        playerId: 0,
+        node: 27_001,
+      },
+      options: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      approval: {
+        approved: true,
+        reason: "local progression choice proof",
+      },
+    }]);
+    expect(fake.calls.technology).toEqual([]);
+    expect(result.status).toBe("sent-unverified");
+    expect(result.postcondition).toMatchObject({
+      classification: "culture-state-changed-blocker-still-live",
+      outcome: "still-blocked",
+      confidence: "unverified",
+      confirmed: false,
+      noRepeatAfterUnverified: true,
+    });
+    expect(result.nextSteps).toEqual([{
+      kind: "do-not-repeat",
+      source: "decisions.progression.choice.request",
+      label: "Do not repeat this progression choice request until fresh attention and progression evidence is read.",
+    }]);
+  });
+
+  test("projects unsent progression closeouts as not-sent", async () => {
+    const before = notificationView("NOTIFICATION_CHOOSE_TECH", {
+      currentResearching: probe(10),
+      targetNode: probe(20),
+    });
+    const fake = fakeContext({
+      views: [before, before],
+      technologyResult: progressionCloseoutResult("technology", {
+        sent: false,
+      }),
+    });
+
+    const result = await call(
+      Civ7ControlOrpcRouter.decisions.progression.choice.request,
+      technologyInput,
+      { context: fake.context },
+    );
+
+    expect(result).toMatchObject({
+      sent: false,
+      status: "not-sent",
+      postcondition: {
+        classification: "not-sent",
+        outcome: "not-sent",
+        confidence: "unverified",
+        confirmed: false,
+        noRepeatAfterUnverified: true,
+      },
+    });
+    expect(result.nextSteps).toEqual([{
+      kind: "inspect-progression-choice",
+      source: "decisions.progression.choice.request",
+      label: "Inspect current attention and progression choice state before attempting another progression request.",
+    }]);
+  });
+
+  test("requires approval before readiness, reads, or request execution", async () => {
+    const fake = fakeContext({
+      views: [cleanView(), cleanView()],
+      technologyResult: progressionCloseoutResult("technology"),
+      approved: false,
+    });
+
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.decisions.progression.choice.request,
+        technologyInput,
+        { context: fake.context },
+      ),
+    ).rejects.toMatchObject({
+      code: "MUTATION_APPROVAL_REQUIRED",
+      data: {
+        procedureKey: "decisions.progression.choice.request",
+        source: "context.approval",
+        risk: "mutation",
+      },
+    });
+    expect(fake.calls.readiness).toEqual([]);
+    expect(fake.calls.views).toEqual([]);
+    expect(fake.calls.technology).toEqual([]);
+    expect(fake.calls.culture).toEqual([]);
+  });
+
+  test("keeps endpoint/session/state/raw command fields and UI toggles out of procedure input", async () => {
+    const invalidInputs = [
+      { ...technologyInput, host: "127.0.0.1" },
+      { ...technologyInput, port: 4318 },
+      { ...technologyInput, state: { role: "tuner" } },
+      { ...technologyInput, session: { state: "Tuner" } },
+      { ...technologyInput, command: "Game.turn" },
+      { ...technologyInput, rawCommand: "Game.turn" },
+      { ...technologyInput, activateNotification: false },
+    ];
+
+    for (const input of invalidInputs) {
+      const fake = fakeContext({
+        views: [cleanView(), cleanView()],
+        technologyResult: progressionCloseoutResult("technology"),
+      });
+
+      await expect(
+        call(
+          Civ7ControlOrpcRouter.decisions.progression.choice.request,
+          input as never,
+          { context: fake.context },
+        ),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(fake.calls.readiness).toEqual([]);
+      expect(fake.calls.views).toEqual([]);
+      expect(fake.calls.technology).toEqual([]);
+    }
+  });
+
+  test("maps source failures to a tagged Effect/oRPC error without raw details", async () => {
+    const fake = fakeContext({
+      views: [cleanView(), cleanView()],
+      technologyResult: progressionCloseoutResult("technology"),
+    });
+    const failingContext: Civ7ControlOrpcContext = {
+      ...fake.context,
+      directControl: {
+        ...fake.context.directControl,
+        requestCiv7TechnologyChoiceCloseout: async () => {
+          throw new Error(
+            "Timed out waiting for Civ7 tuner response to CMD:65535:SET_TECH_TREE_NODE",
+          );
+        },
+      },
+    };
+
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.decisions.progression.choice.request,
+        technologyInput,
+        { context: failingContext },
+      ),
+    ).rejects.toMatchObject({
+      code: "PROGRESSION_CHOICE_UNAVAILABLE",
+      status: 503,
+      data: {
+        procedureKey: "decisions.progression.choice.request",
+        source: "direct-control-facade",
+      },
+    });
+
+    try {
+      await call(
+        Civ7ControlOrpcRouter.decisions.progression.choice.request,
+        technologyInput,
+        { context: failingContext },
+      );
+    } catch (err) {
+      const serialized = JSON.stringify(err);
+      expect(serialized).not.toContain("CMD");
+      expect(serialized).not.toContain("SET_TECH_TREE_NODE");
+      expect(serialized).not.toContain("rawCommand");
+      expect(serialized).not.toContain("command-failed");
+    }
+  });
+
+  test("supports the in-process server-side router client", async () => {
+    const before = notificationView("NOTIFICATION_CHOOSE_CULTURE_NODE", {});
+    const fake = fakeContext({
+      views: [before, cleanView()],
+      cultureResult: progressionCloseoutResult("culture"),
+    });
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    const result = await client.decisions.progression.choice.request(cultureInput);
+
+    expect(result.status).toBe("sent-confirmed");
+    expect(result.postcondition.classification).toBe("culture-choice-cleared");
+  });
+
+  test("publishes a contract-first progression decision service leaf", () => {
+    expect(
+      Civ7ControlOrpcContract.decisions.progression.choice.request["~orpc"],
+    ).toMatchObject({
+      meta: {
+        family: "decisions",
+        procedureKey: "decisions.progression.choice.request",
+        proofBoundary: "local-package-test",
+        risk: "mutation",
+      },
+    });
+    expect(
+      Civ7ControlOrpcContract.decisions.progression.choice.request["~orpc"].errorMap,
+    ).toHaveProperty("PROGRESSION_CHOICE_UNAVAILABLE");
+    expect(Civ7ProgressionChoiceUnavailableError.code).toBe(
+      "PROGRESSION_CHOICE_UNAVAILABLE",
+    );
+  });
+});
+
+function fakeContext(options: Readonly<{
+  views: readonly Civ7ControlOrpcPlayNotificationViewResult[];
+  technologyResult?: Civ7ControlOrpcTechnologyChoiceCloseoutResult;
+  cultureResult?: Civ7ControlOrpcCultureChoiceCloseoutResult;
+  approved?: boolean;
+  playable?: boolean;
+}>): {
+  calls: {
+    readiness: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+    views: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+    technology: Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+      approval: Civ7ControlOrpcContext["approval"];
+    }>>;
+    culture: Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+      approval: Civ7ControlOrpcContext["approval"];
+    }>>;
+  };
+  context: Civ7ControlOrpcContext;
+} {
+  const views = [...options.views];
+  const calls = {
+    readiness: [] as Array<Civ7ControlOrpcContext["endpointDefaults"]>,
+    views: [] as Array<Civ7ControlOrpcContext["endpointDefaults"]>,
+    technology: [] as Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+      approval: Civ7ControlOrpcContext["approval"];
+    }>>,
+    culture: [] as Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+      approval: Civ7ControlOrpcContext["approval"];
+    }>>,
+  };
+
+  return {
+    calls,
+    context: {
+      approval: options.approved === false
+        ? undefined
+        : { approved: true, reason: "local progression choice proof" },
+      endpointDefaults: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      directControl: {
+        getCiv7PlayableStatus: async (endpointDefaults) => {
+          calls.readiness.push(endpointDefaults);
+          return playableStatusResult(options.playable ?? true);
+        },
+        getCiv7PlayNotificationView: async (endpointDefaults) => {
+          calls.views.push(endpointDefaults);
+          return views.shift() ?? cleanView();
+        },
+        requestCiv7TechnologyChoiceCloseout: async (
+          input,
+          endpointDefaults,
+          approval,
+        ) => {
+          calls.technology.push({
+            input,
+            options: endpointDefaults,
+            approval,
+          });
+          return options.technologyResult
+            ?? progressionCloseoutResult("technology");
+        },
+        requestCiv7CultureChoiceCloseout: async (
+          input,
+          endpointDefaults,
+          approval,
+        ) => {
+          calls.culture.push({
+            input,
+            options: endpointDefaults,
+            approval,
+          });
+          return options.cultureResult ?? progressionCloseoutResult("culture");
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function progressionCloseoutResult(
+  kind: "technology",
+  options?: Partial<{ sent: boolean }>,
+): Civ7ControlOrpcTechnologyChoiceCloseoutResult;
+function progressionCloseoutResult(
+  kind: "culture",
+  options?: Partial<{ sent: boolean }>,
+): Civ7ControlOrpcCultureChoiceCloseoutResult;
+function progressionCloseoutResult(
+  kind: "technology" | "culture",
+  options: Partial<{ sent: boolean }> = {},
+):
+  | Civ7ControlOrpcTechnologyChoiceCloseoutResult
+  | Civ7ControlOrpcCultureChoiceCloseoutResult {
+  const operationType = kind === "technology"
+    ? "SET_TECH_TREE_NODE"
+    : "SET_CULTURE_TREE_NODE";
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    command: {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      output: [`${operationType} should remain hidden`],
+    },
+    payload: {
+      sent: options.sent ?? true,
+      rawCommand: operationType,
+    },
+    sent: options.sent ?? true,
+  } as
+    | Civ7ControlOrpcTechnologyChoiceCloseoutResult
+    | Civ7ControlOrpcCultureChoiceCloseoutResult;
+}
+
+function notificationView(
+  typeName: string,
+  details: Record<string, unknown>,
+  options: Readonly<{
+    id?: number;
+    canEndTurn?: boolean;
+  }> = {},
+): Civ7ControlOrpcPlayNotificationViewResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    schemaVersion: "civ7-play-notifications.v1",
+    localPlayerId: 0,
+    turn: probe(80),
+    turnDate: probe("2025 BCE"),
+    canEndTurn: probe(options.canEndTurn ?? false),
+    blocker: probe(1),
+    firstReadyUnitId: probe(null),
+    selectedUnitId: probe(null),
+    selectedCityId: probe(null),
+    blockingNotificationId: probe({ owner: 0, id: options.id ?? 72, type: 20 }),
+    notifications: [{
+      id: { owner: 0, id: options.id ?? 72, type: 20 },
+      typeName,
+      summary: typeName,
+      isEndTurnBlocking: true,
+      details,
+    }],
+  } as Civ7ControlOrpcPlayNotificationViewResult;
+}
+
+function cleanView(
+  options: Readonly<{ canEndTurn?: boolean }> = {},
+): Civ7ControlOrpcPlayNotificationViewResult {
+  return {
+    ...notificationView("NOTIFICATION_INFORMATIONAL", {}, options),
+    blocker: probe(0),
+    blockingNotificationId: probe(null),
+    notifications: [],
+  };
+}
+
+function probe<T>(value: T): Readonly<{ ok: true; value: T }> {
+  return { ok: true, value };
+}
+
+function playableStatusResult(playable: boolean): Civ7ControlOrpcPlayableStatusResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    playable,
+    readiness: playable ? "tuner-ready" : "shell",
+    appUi: {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      snapshot: {
+        ui: {
+          inGame: { ok: true, value: playable },
+          inShell: { ok: true, value: !playable },
+          inLoading: { ok: true, value: false },
+          canBeginGame: { ok: true, value: false },
+        },
+        errors: [],
+      },
+    },
+    tuner: {
+      host: "127.0.0.1",
+      port: 4318,
+      ready: playable,
+      states: [],
+      errors: [],
+    },
+    errors: [],
+  };
+}

--- a/packages/civ7-control-orpc/test/decisions-progression-choice-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/decisions-progression-choice-procedure.test.ts
@@ -74,6 +74,7 @@ describe("decisions.progression.choice.request control-oRPC procedure", () => {
       status: "sent-confirmed",
       evidence: {
         beforeBlockerPresent: true,
+        afterReadStatus: "read",
         afterBlockerPresent: false,
         canEndTurnAfter: true,
       },
@@ -174,6 +175,12 @@ describe("decisions.progression.choice.request control-oRPC procedure", () => {
     expect(result).toMatchObject({
       sent: false,
       status: "not-sent",
+      evidence: {
+        beforeBlockerPresent: true,
+        afterReadStatus: "skipped-not-sent",
+        afterBlockerPresent: null,
+        canEndTurnAfter: null,
+      },
       postcondition: {
         classification: "not-sent",
         outcome: "not-sent",
@@ -187,6 +194,51 @@ describe("decisions.progression.choice.request control-oRPC procedure", () => {
       source: "decisions.progression.choice.request",
       label: "Inspect current attention and progression choice state before attempting another progression request.",
     }]);
+    expect(fake.calls.views).toHaveLength(1);
+  });
+
+  test("keeps sent progression choices no-repeat guarded when the post-read fails", async () => {
+    const before = notificationView("NOTIFICATION_CHOOSE_TECH", {
+      currentResearching: probe(10),
+      targetNode: probe(20),
+    });
+    const fake = fakeContext({
+      views: [
+        before,
+        new Error("Timed out waiting for Civ7 tuner response to CMD:65535:Game.turn"),
+      ],
+      technologyResult: progressionCloseoutResult("technology"),
+    });
+
+    const result = await call(
+      Civ7ControlOrpcRouter.decisions.progression.choice.request,
+      technologyInput,
+      { context: fake.context },
+    );
+
+    expect(result).toMatchObject({
+      sent: true,
+      status: "sent-unverified",
+      evidence: {
+        beforeBlockerPresent: true,
+        afterReadStatus: "failed",
+        afterBlockerPresent: null,
+        canEndTurnAfter: null,
+      },
+      postcondition: {
+        classification: "pending-runtime-proof",
+        outcome: "unknown",
+        confidence: "pending-runtime-proof",
+        confirmed: false,
+        noRepeatAfterUnverified: true,
+      },
+    });
+    expect(result.nextSteps).toEqual([{
+      kind: "do-not-repeat",
+      source: "decisions.progression.choice.request",
+      label: "Do not repeat this progression choice request until fresh attention and progression evidence is read.",
+    }]);
+    expect(JSON.stringify(result)).not.toContain("CMD");
   });
 
   test("requires approval before readiness, reads, or request execution", async () => {
@@ -328,7 +380,7 @@ describe("decisions.progression.choice.request control-oRPC procedure", () => {
 });
 
 function fakeContext(options: Readonly<{
-  views: readonly Civ7ControlOrpcPlayNotificationViewResult[];
+  views: readonly (Civ7ControlOrpcPlayNotificationViewResult | Error)[];
   technologyResult?: Civ7ControlOrpcTechnologyChoiceCloseoutResult;
   cultureResult?: Civ7ControlOrpcCultureChoiceCloseoutResult;
   approved?: boolean;
@@ -384,7 +436,9 @@ function fakeContext(options: Readonly<{
         },
         getCiv7PlayNotificationView: async (endpointDefaults) => {
           calls.views.push(endpointDefaults);
-          return views.shift() ?? cleanView();
+          const view = views.shift() ?? cleanView();
+          if (view instanceof Error) throw view;
+          return view;
         },
         requestCiv7TechnologyChoiceCloseout: async (
           input,

--- a/packages/civ7-control-orpc/test/intelligence-bridge.test.ts
+++ b/packages/civ7-control-orpc/test/intelligence-bridge.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  createCiv7IntelligenceBridge,
+  installCiv7IntelligenceBridge,
+  type Civ7ControlOrpcContext,
+  type Civ7ControlOrpcPlayableStatusResult,
+  type Civ7IntelligenceBridge,
+  type Civ7IntelligenceBridgeGlobalTarget,
+} from "../src/index";
+
+describe("Civ7IntelligenceBridge global adapter", () => {
+  test("installs a serialized global bridge over the existing controller ingress", async () => {
+    const fake = fakeContext(playableStatusResult());
+    const target: Civ7IntelligenceBridgeGlobalTarget = {};
+
+    const bridge = installCiv7IntelligenceBridge({
+      target,
+      createContext: (request) => {
+        fake.contextRequests.push(request);
+        return fake.context;
+      },
+    });
+
+    expect(target.Civ7IntelligenceBridge).toBe(bridge);
+
+    const response = await target.Civ7IntelligenceBridge.invoke({
+      procedureKey: "readiness.current",
+      input: {},
+      correlationId: "global-readiness-1",
+    });
+
+    expect(response).toMatchObject({
+      ok: true,
+      procedureKey: "readiness.current",
+      correlationId: "global-readiness-1",
+      output: {
+        playable: true,
+        readiness: "tuner-ready",
+        capability: {
+          canObserve: true,
+          canMutate: true,
+        },
+      },
+    });
+    expect(fake.calls).toEqual([{ timeoutMs: 1_000 }]);
+    expect(fake.contextRequests).toEqual([{
+      procedureKey: "readiness.current",
+      input: {},
+      correlationId: "global-readiness-1",
+    }]);
+
+    const serialized = JSON.stringify(response);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"session\"");
+    expect(serialized).not.toContain("\"rawCommand\"");
+    expect(serialized).not.toContain("Game.turn");
+    expect(serialized).not.toContain("Tuner");
+  });
+
+  test("keeps raw bridge envelope fields rejected after global installation", async () => {
+    const fake = fakeContext(playableStatusResult());
+    const bridge = createCiv7IntelligenceBridge({
+      createContext: () => fake.context,
+    });
+
+    const response = await bridge.invoke({
+      procedureKey: "readiness.current",
+      input: {},
+      session: { state: "Tuner" },
+      rawCommand: "Game.turn",
+    });
+
+    expect(response).toEqual({
+      ok: false,
+      error: {
+        code: "BRIDGE_BAD_REQUEST",
+        message: "Civ7 controller bridge request envelope is invalid.",
+        reason: "invalid-envelope",
+      },
+    });
+    expect(fake.calls).toEqual([]);
+  });
+
+  test("does not overwrite an existing global bridge unless explicitly replaced", async () => {
+    const existing: Civ7IntelligenceBridge = {
+      invoke: async () => ({
+        ok: false,
+        error: {
+          code: "EXISTING",
+          message: "Existing bridge.",
+          reason: "procedure-failed",
+        },
+      }),
+    };
+    const target: Civ7IntelligenceBridgeGlobalTarget = {
+      Civ7IntelligenceBridge: existing,
+    };
+
+    expect(() => installCiv7IntelligenceBridge({
+      target,
+      createContext: () => fakeContext(playableStatusResult()).context,
+    })).toThrow("Civ7IntelligenceBridge is already installed.");
+    expect(target.Civ7IntelligenceBridge).toBe(existing);
+
+    const replacement = installCiv7IntelligenceBridge({
+      target,
+      replaceExisting: true,
+      createContext: () => fakeContext(playableStatusResult()).context,
+    });
+
+    expect(target.Civ7IntelligenceBridge).toBe(replacement);
+    expect(target.Civ7IntelligenceBridge).not.toBe(existing);
+  });
+});
+
+function fakeContext(
+  result: Civ7ControlOrpcPlayableStatusResult,
+): {
+  calls: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+  contextRequests: unknown[];
+  context: Civ7ControlOrpcContext;
+} {
+  const calls: Array<Civ7ControlOrpcContext["endpointDefaults"]> = [];
+  return {
+    calls,
+    contextRequests: [],
+    context: {
+      endpointDefaults: { timeoutMs: 1_000 },
+      directControl: {
+        getCiv7PlayableStatus: async (options) => {
+          calls.push(options);
+          return result;
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function playableStatusResult(): Civ7ControlOrpcPlayableStatusResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    playable: true,
+    readiness: "tuner-ready",
+    appUi: {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      snapshot: {
+        ui: {
+          inGame: { ok: true, value: true },
+          inShell: { ok: true, value: false },
+          inLoading: { ok: true, value: false },
+          canBeginGame: { ok: true, value: false },
+        },
+        currentState: "App UI",
+      },
+    },
+    tuner: {
+      ready: true,
+      health: {
+        ok: true,
+        host: "127.0.0.1",
+        port: 4318,
+        latencyMs: 1,
+      },
+    },
+    errors: ["raw Tuner detail"],
+  };
+}

--- a/packages/civ7-control-orpc/test/mutation-result-policy.test.ts
+++ b/packages/civ7-control-orpc/test/mutation-result-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  civ7CloseoutMutationProjection,
   civ7MutationPostconditionSummary,
   civ7MutationRequestStatusWithoutGuarded,
 } from "../src/policy/mutation-result";
@@ -85,5 +86,66 @@ describe("control-oRPC mutation result policy", () => {
       sent: true,
       postcondition,
     })).toBe("sent-confirmed");
+  });
+
+  test("projects closeout-style postconditions into status and next steps", () => {
+    const confirmed = civ7CloseoutMutationProjection({
+      sent: true,
+      postcondition: {
+        classification: "blocker-cleared",
+        reason: "The blocker was cleared.",
+        outcome: "cleared",
+        confidence: "confirmed",
+        noRepeatAfterUnverified: false,
+      },
+      missing: {
+        classification: "missing-postcondition",
+        reason: "No explicit postcondition evidence was returned.",
+        outcome: "unknown",
+      },
+      source: "decisions.progression.choice.request",
+      inspectKind: "inspect-progression-choice",
+      inspectLabel: "Inspect progression state before retrying.",
+      doNotRepeatLabel: "Do not repeat until fresh progression evidence is read.",
+    });
+
+    expect(confirmed.status).toBe("sent-confirmed");
+    expect(confirmed.postcondition).toMatchObject({
+      confirmed: true,
+      noRepeatAfterUnverified: false,
+    });
+    expect(confirmed.nextSteps).toEqual([{
+      kind: "refresh-attention",
+      source: "decisions.progression.choice.request",
+      label: "Refresh current attention before choosing the next player action.",
+    }]);
+
+    const pending = civ7CloseoutMutationProjection({
+      sent: true,
+      postcondition: {
+        classification: "pending-runtime-proof",
+        reason: "Live runtime proof has not been collected.",
+        outcome: "unknown",
+        confidence: "pending-runtime-proof",
+        noRepeatAfterUnverified: true,
+      },
+      missing: {
+        classification: "missing-postcondition",
+        reason: "No explicit postcondition evidence was returned.",
+        outcome: "unknown",
+      },
+      source: "decisions.progression.choice.request",
+      inspectKind: "inspect-progression-choice",
+      inspectLabel: "Inspect progression state before retrying.",
+      doNotRepeatLabel: "Do not repeat until fresh progression evidence is read.",
+    });
+
+    expect(pending.status).toBe("sent-unverified");
+    expect(pending.postcondition.confirmed).toBe(false);
+    expect(pending.nextSteps).toEqual([{
+      kind: "do-not-repeat",
+      source: "decisions.progression.choice.request",
+      label: "Do not repeat until fresh progression evidence is read.",
+    }]);
   });
 });

--- a/packages/civ7-control-orpc/test/notification-dismissal-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/notification-dismissal-procedure.test.ts
@@ -1,10 +1,13 @@
 import { call } from "@orpc/server";
 import { describe, expect, test } from "vitest";
+import { Value } from "typebox/value";
 
 import {
   Civ7ControlOrpcContract,
   Civ7ControlOrpcRouter,
   Civ7MutationApprovalRequiredError,
+  Civ7NotificationDismissInputSchema,
+  Civ7NotificationDismissalPostconditionClassificationSchema,
   Civ7NotificationDismissalUnavailableError,
   createCiv7ControlOrpcServerClient,
   type Civ7ControlOrpcContext,
@@ -14,6 +17,24 @@ import {
 const notificationId = { owner: 0, id: 113, type: 20 };
 
 describe("notifications.dismiss.request control-oRPC procedure", () => {
+  test("owns the caller-facing notification dismiss contract without raw fields", () => {
+    expect(Value.Check(Civ7NotificationDismissInputSchema, {
+      notificationId,
+    })).toBe(true);
+    expect(Value.Check(Civ7NotificationDismissInputSchema, {
+      notificationId,
+      rawCommand: "Game.turn",
+    })).toBe(false);
+    expect(Value.Check(
+      Civ7NotificationDismissalPostconditionClassificationSchema,
+      "engine-front-still-live",
+    )).toBe(true);
+    expect(Value.Check(
+      Civ7NotificationDismissalPostconditionClassificationSchema,
+      "pending-runtime-proof",
+    )).toBe(false);
+  });
+
   test("calls notification dismissal through native Effect/oRPC with context approval", async () => {
     const fake = fakeContext(
       notificationDismissalResult("notification-disappeared"),

--- a/packages/civ7-control-orpc/test/primitive-schemas.test.ts
+++ b/packages/civ7-control-orpc/test/primitive-schemas.test.ts
@@ -1,0 +1,41 @@
+import {
+  Civ7ComponentIdSchema,
+  Civ7MapLocationSchema,
+} from "@civ7/direct-control";
+import { describe, expect, test } from "vitest";
+import { Value } from "typebox/value";
+
+import {
+  Civ7ControlOrpcComponentIdSchema,
+  Civ7ControlOrpcMapLocationSchema,
+} from "../src/model/primitives";
+
+describe("control-oRPC primitive service schemas", () => {
+  test("keeps component id and map location contracts equivalent to direct-control primitives", () => {
+    const componentFixtures = [
+      { owner: 0, id: 458_752, type: 26 },
+      { owner: 1, id: 9001 },
+      { owner: 1, id: 2, type: 3, rawCommand: "Game.turn" },
+      { owner: 1, type: 3 },
+      { owner: "1", id: 2, type: 3 },
+    ];
+    for (const fixture of componentFixtures) {
+      expect(Value.Check(Civ7ControlOrpcComponentIdSchema, fixture)).toBe(
+        Value.Check(Civ7ComponentIdSchema, fixture),
+      );
+    }
+
+    const locationFixtures = [
+      { x: 25, y: 35 },
+      { x: 1.5, y: 0 },
+      { x: -1, y: 0 },
+      { x: 0, y: 1_000_001 },
+      { x: 25, y: 35, rawCommand: "MOVE_TO" },
+    ];
+    for (const fixture of locationFixtures) {
+      expect(Value.Check(Civ7ControlOrpcMapLocationSchema, fixture)).toBe(
+        Value.Check(Civ7MapLocationSchema, fixture),
+      );
+    }
+  });
+});

--- a/packages/civ7-control-orpc/test/turn-completion-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/turn-completion-procedure.test.ts
@@ -1,0 +1,373 @@
+import { call, ORPCError } from "@orpc/server";
+import { Value } from "typebox/value";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  Civ7MutationApprovalRequiredError,
+  Civ7TurnCompletionInputSchema,
+  Civ7TurnCompletionUnavailableError,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+  type Civ7TurnCompletionResult,
+} from "../src/index";
+import type { Civ7ControlOrpcTurnCompletionActionResult } from "../src/dependencies/direct-control";
+
+describe("turn.complete.request control-oRPC procedure", () => {
+  test("owns the caller-facing turn completion input without runtime controls", () => {
+    expect(Value.Check(Civ7TurnCompletionInputSchema, {})).toBe(true);
+    for (
+      const input of [
+        { host: "127.0.0.1" },
+        { port: 4318 },
+        { state: { role: "app-ui" } },
+        { session: { state: "App UI" } },
+        { command: "GameContext.sendTurnComplete()" },
+        { rawCommand: "GameContext.sendTurnComplete()" },
+        { approvalReason: "test approved turn completion" },
+      ]
+    ) {
+      expect(Value.Check(Civ7TurnCompletionInputSchema, input)).toBe(false);
+    }
+  });
+
+  test("calls the turn completion mutation through native Effect/oRPC with context approval", async () => {
+    const fake = fakeContext(turnCompletionActionResult({
+      after: turnCompletionStatus({ turn: 13, hasSentTurnComplete: false }),
+    }));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.turn.complete.request,
+      {},
+      { context: fake.context },
+    );
+
+    expect(fake.calls.readiness).toHaveLength(1);
+    expect(fake.calls.turnCompletion).toEqual([{
+      options: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      approval: {
+        approved: true,
+        reason: "test approved turn completion",
+      },
+    }]);
+    expect(result).toEqual({
+      sent: true,
+      status: "sent-confirmed",
+      before: {
+        turn: 12,
+        turnDate: "3990 BCE",
+        hasSentTurnComplete: false,
+        canEndTurn: true,
+        blocker: 0,
+        firstReadyUnitId: null,
+      },
+      after: {
+        turn: 13,
+        turnDate: "3980 BCE",
+        hasSentTurnComplete: false,
+        canEndTurn: true,
+        blocker: 0,
+        firstReadyUnitId: null,
+      },
+      postcondition: {
+        classification: "turn-advanced",
+        reason: "The turn advanced after the turn completion send.",
+        outcome: "cleared",
+        confidence: "confirmed",
+        confirmed: true,
+        noRepeatAfterUnverified: false,
+      },
+      nextSteps: [{
+        kind: "refresh-attention",
+        source: "turn.complete.request",
+        label: "Refresh current attention before choosing the next player action.",
+      }],
+    });
+    expectPublicResultOmitsRawRuntimeDetails(result);
+  });
+
+  test("keeps sent turn-complete state no-repeat guarded", async () => {
+    const fake = fakeContext(turnCompletionActionResult({
+      after: turnCompletionStatus({ turn: 12, hasSentTurnComplete: true }),
+    }));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.turn.complete.request,
+      {},
+      { context: fake.context },
+    );
+
+    expect(result).toMatchObject({
+      sent: true,
+      status: "sent-guarded",
+      postcondition: {
+        classification: "turn-complete-sent",
+        outcome: "state-changed",
+        confidence: "confirmed",
+        confirmed: true,
+        noRepeatAfterUnverified: true,
+      },
+      nextSteps: [{
+        kind: "do-not-repeat",
+        source: "turn.complete.request",
+      }],
+    });
+  });
+
+  test("keeps no-state-change results no-repeat guarded", async () => {
+    const fake = fakeContext(turnCompletionActionResult({
+      after: turnCompletionStatus({ turn: 12, hasSentTurnComplete: false }),
+    }));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.turn.complete.request,
+      {},
+      { context: fake.context },
+    );
+
+    expect(result).toMatchObject({
+      sent: true,
+      status: "sent-unverified",
+      postcondition: {
+        classification: "no-state-change",
+        outcome: "no-state-change",
+        confidence: "unverified",
+        confirmed: false,
+        noRepeatAfterUnverified: true,
+      },
+      nextSteps: [{
+        kind: "do-not-repeat",
+        source: "turn.complete.request",
+      }],
+    });
+  });
+
+  test("keeps missing postconditions no-repeat guarded", async () => {
+    const fake = fakeContext(turnCompletionActionResult({
+      after: turnCompletionStatus({
+        turn: 12,
+        hasSentTurnComplete: false,
+        hasSentTurnCompleteOk: false,
+      }),
+    }));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.turn.complete.request,
+      {},
+      { context: fake.context },
+    );
+
+    expect(result).toMatchObject({
+      sent: true,
+      status: "sent-unverified",
+      postcondition: {
+        classification: "missing-postcondition",
+        outcome: "unknown",
+        confidence: "unverified",
+        confirmed: false,
+        noRepeatAfterUnverified: true,
+      },
+    });
+  });
+
+  test("requires context approval before readiness and mutation ports run", async () => {
+    const fake = fakeContext(turnCompletionActionResult({}), {
+      approval: undefined,
+    });
+
+    await expect(
+      call(Civ7ControlOrpcRouter.turn.complete.request, {}, {
+        context: fake.context,
+      }),
+    ).rejects.toMatchObject({
+      code: "MUTATION_APPROVAL_REQUIRED",
+      status: 403,
+      data: {
+        procedureKey: "turn.complete.request",
+        source: "context.approval",
+        risk: "mutation",
+      },
+    });
+    expect(fake.calls.readiness).toEqual([]);
+    expect(fake.calls.turnCompletion).toEqual([]);
+  });
+
+  test("rejects raw caller fields before readiness and mutation ports run", async () => {
+    const fake = fakeContext(turnCompletionActionResult({}));
+
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.turn.complete.request,
+        { rawCommand: "GameContext.sendTurnComplete()" },
+        { context: fake.context },
+      ),
+    ).rejects.toBeInstanceOf(ORPCError);
+    expect(fake.calls.readiness).toEqual([]);
+    expect(fake.calls.turnCompletion).toEqual([]);
+  });
+
+  test("maps source failures to bounded tagged errors without raw cause details", async () => {
+    const fake = fakeContext(new Error(
+      "Timed out waiting for Civ7 tuner response to CMD:65535:GameContext.sendTurnComplete()",
+    ));
+
+    let caught: unknown;
+    try {
+      await call(Civ7ControlOrpcRouter.turn.complete.request, {}, {
+        context: fake.context,
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toMatchObject({
+      code: "TURN_COMPLETION_UNAVAILABLE",
+      status: 503,
+      data: {
+        procedureKey: "turn.complete.request",
+        source: "direct-control-facade",
+      },
+    });
+    const serialized = JSON.stringify(caught);
+    expect(serialized).not.toContain("CMD");
+    expect(serialized).not.toContain("GameContext.sendTurnComplete");
+    expect(serialized).not.toContain("rawCommand");
+    expect(serialized).not.toContain("command-failed");
+  });
+
+  test("supports the in-process server-side router client", async () => {
+    const fake = fakeContext(turnCompletionActionResult({
+      after: turnCompletionStatus({ turn: 13, hasSentTurnComplete: false }),
+    }));
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    const result = await client.turn.complete.request({});
+
+    expect(result.status).toBe("sent-confirmed");
+    expect(fake.calls.turnCompletion).toHaveLength(1);
+  });
+
+  test("publishes contract metadata and tagged error constructors", () => {
+    expect(
+      Civ7ControlOrpcContract.turn.complete.request["~orpc"].meta,
+    ).toMatchObject({
+      family: "turn",
+      procedureKey: "turn.complete.request",
+      risk: "mutation",
+      proofBoundary: "local-package-test",
+    });
+    expect(Civ7TurnCompletionUnavailableError).toBeTypeOf("function");
+    expect(Civ7MutationApprovalRequiredError).toBeTypeOf("function");
+  });
+});
+
+function expectPublicResultOmitsRawRuntimeDetails(
+  result: Civ7TurnCompletionResult,
+): void {
+  const serialized = JSON.stringify(result);
+  expect(serialized).not.toContain("\"host\"");
+  expect(serialized).not.toContain("\"port\"");
+  expect(serialized).not.toContain("\"state\"");
+  expect(serialized).not.toContain("\"command\"");
+  expect(serialized).not.toContain("CMD");
+  expect(serialized).not.toContain("GameContext.sendTurnComplete");
+  expect(serialized).not.toContain("\"verified\"");
+}
+
+function fakeContext(
+  resultOrError: Civ7ControlOrpcTurnCompletionActionResult | Error,
+  options: Readonly<{
+    approval?: Civ7ControlOrpcContext["approval"];
+  }> = {},
+): {
+  context: Civ7ControlOrpcContext;
+  calls: {
+    readiness: unknown[];
+    turnCompletion: unknown[];
+  };
+} {
+  const calls: {
+    readiness: unknown[];
+    turnCompletion: unknown[];
+  } = {
+    readiness: [],
+    turnCompletion: [],
+  };
+  const context: Civ7ControlOrpcContext = {
+    endpointDefaults: {
+      host: "127.0.0.1",
+      port: 4318,
+      timeoutMs: 1_000,
+    },
+    approval: "approval" in options ? options.approval : {
+      approved: true,
+      reason: "test approved turn completion",
+    },
+    directControl: {
+      getCiv7PlayableStatus: async (endpointDefaults) => {
+        calls.readiness.push(endpointDefaults);
+        return { playable: true, readiness: "tuner-ready" } as Awaited<
+          ReturnType<Civ7ControlOrpcContext["directControl"]["getCiv7PlayableStatus"]>
+        >;
+      },
+      requestCiv7TurnComplete: async (endpointDefaults, approval) => {
+        calls.turnCompletion.push({
+          options: endpointDefaults,
+          approval,
+        });
+        if (resultOrError instanceof Error) throw resultOrError;
+        return resultOrError;
+      },
+    } as Civ7ControlOrpcContext["directControl"],
+  };
+
+  return { context, calls };
+}
+
+function turnCompletionActionResult(
+  overrides: Partial<Civ7ControlOrpcTurnCompletionActionResult>,
+): Civ7ControlOrpcTurnCompletionActionResult {
+  return {
+    before: turnCompletionStatus({ turn: 12, hasSentTurnComplete: false }),
+    after: turnCompletionStatus({ turn: 12, hasSentTurnComplete: true }),
+    command: {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      output: [
+        "CMD:65535:GameContext.sendTurnComplete()",
+      ],
+    },
+    verified: true,
+    ...overrides,
+  } as Civ7ControlOrpcTurnCompletionActionResult;
+}
+
+function turnCompletionStatus(options: Readonly<{
+  turn: number;
+  hasSentTurnComplete: boolean;
+  turnOk?: boolean;
+  hasSentTurnCompleteOk?: boolean;
+}>): Civ7ControlOrpcTurnCompletionActionResult["before"] {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    turn: options.turnOk === false
+      ? { ok: false, reason: "missing turn" }
+      : { ok: true, value: options.turn },
+    turnDate: { ok: true, value: options.turn === 12 ? "3990 BCE" : "3980 BCE" },
+    hasSentTurnComplete: options.hasSentTurnCompleteOk === false
+      ? { ok: false, reason: "missing sent state" }
+      : { ok: true, value: options.hasSentTurnComplete },
+    canEndTurn: { ok: true, value: true },
+    blocker: { ok: true, value: 0 },
+    firstReadyUnitId: { ok: true, value: null },
+  };
+}

--- a/packages/civ7-control-orpc/test/unit-target-action-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/unit-target-action-procedure.test.ts
@@ -1,10 +1,12 @@
 import { call } from "@orpc/server";
+import { Value } from "typebox/value";
 import { describe, expect, test } from "vitest";
 
 import {
   Civ7ControlOrpcContract,
   Civ7ControlOrpcRouter,
   Civ7MutationApprovalRequiredError,
+  Civ7UnitTargetActionInputSchema,
   Civ7UnitTargetActionUnavailableError,
   createCiv7ControlOrpcServerClient,
   type Civ7ControlOrpcContext,
@@ -15,6 +17,43 @@ const unitId = { owner: 0, id: 42, type: 1 };
 const target = { x: 22, y: 31 };
 
 describe("unit.target.action.request control-oRPC procedure", () => {
+  test("owns the caller-facing unit target action contract without raw fields", () => {
+    expect(Value.Check(Civ7UnitTargetActionInputSchema, {
+      unitId,
+      ...target,
+    })).toBe(true);
+    expect(Value.Check(Civ7UnitTargetActionInputSchema, {
+      unitId,
+      ...target,
+      rawCommand: "Game.UnitOperations.sendRequest(...)",
+    })).toBe(false);
+    expect(Value.Check(Civ7UnitTargetActionInputSchema, {
+      unitId,
+      ...target,
+      approvalReason: "test approved unit target action",
+    })).toBe(false);
+    expect(Value.Check(Civ7UnitTargetActionInputSchema, {
+      unitId,
+      ...target,
+      session: { state: "App UI" },
+    })).toBe(false);
+    expect(Value.Check(Civ7UnitTargetActionInputSchema, {
+      unitId,
+      x: 22.5,
+      y: 31,
+    })).toBe(false);
+    expect(Value.Check(Civ7UnitTargetActionInputSchema, {
+      unitId,
+      x: -1,
+      y: 31,
+    })).toBe(false);
+    expect(Value.Check(Civ7UnitTargetActionInputSchema, {
+      unitId,
+      x: 22,
+      y: 1_000_001,
+    })).toBe(false);
+  });
+
   test("calls the unit target action mutation through native Effect/oRPC with context approval", async () => {
     const fake = fakeContext(unitTargetActionResult("target-reached"));
 

--- a/packages/civ7-control-orpc/tsup.config.ts
+++ b/packages/civ7-control-orpc/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/runtime.ts"],
   format: ["esm", "cjs"],
   target: "esnext",
   clean: true,

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -727,6 +727,19 @@ export type {
   Civ7TechnologyChoiceCloseoutResult,
 } from "./play/progression/technology.js";
 export { requestCiv7TechnologyChoiceCloseout } from "./play/progression/technology.js";
+export {
+  cultureChoicePostcondition,
+  findCultureChoiceNotification,
+  findTechnologyChoiceNotification,
+  technologyChoicePostcondition,
+} from "./play/progression/choice-postconditions.js";
+export type {
+  Civ7CultureChoicePostconditionClassification,
+  Civ7ProgressionChoiceNotification,
+  Civ7ProgressionChoiceNotificationView,
+  Civ7ProgressionChoicePostcondition,
+  Civ7TechnologyChoicePostconditionClassification,
+} from "./play/progression/choice-postconditions.js";
 export type {
   Civ7CultureChoiceCloseoutInput,
   Civ7CultureChoiceCloseoutResult,

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -800,6 +800,14 @@ export {
   sendCiv7TurnUnready,
 } from "./play/turn-completion.js";
 export {
+  turnCompletionPostconditionConfirmed,
+  turnCompletionProofOutcome,
+  turnCompletionProofPostcondition,
+} from "./proof/turn-completion-proof-policy";
+export type {
+  Civ7TurnCompletionPostconditionClassification,
+} from "./proof/turn-completion-proof-policy";
+export {
   callCiv7TurnCompletionStatusProcedure,
   Civ7TurnCompletionStatusProcedureDescriptor,
   Civ7TurnCompletionStatusProcedureSchemaArtifacts,

--- a/packages/civ7-direct-control/src/play/progression/choice-postconditions.ts
+++ b/packages/civ7-direct-control/src/play/progression/choice-postconditions.ts
@@ -1,0 +1,219 @@
+export type Civ7ProgressionChoiceNotification = Readonly<{
+  id?: unknown;
+  typeName?: unknown;
+  isEndTurnBlocking?: unknown;
+  details?: unknown;
+}>;
+
+export type Civ7ProgressionChoiceNotificationView = Readonly<{
+  canEndTurn?: unknown;
+  notifications: readonly Civ7ProgressionChoiceNotification[];
+}>;
+
+export type Civ7TechnologyChoicePostconditionClassification =
+  | "turn-unblocked"
+  | "technology-choice-cleared"
+  | "technology-choice-transitioned"
+  | "technology-state-changed-blocker-still-live"
+  | "technology-choice-sticky-blocker";
+
+export type Civ7CultureChoicePostconditionClassification =
+  | "turn-unblocked"
+  | "culture-choice-cleared"
+  | "culture-choice-transitioned"
+  | "culture-state-changed-blocker-still-live"
+  | "culture-choice-sticky-blocker";
+
+export type Civ7ProgressionChoicePostcondition<
+  Classification extends string,
+> = Readonly<{
+  classification: Classification;
+  verified: boolean;
+  reason: string;
+}>;
+
+type ProgressionChoicePolicy<Classification extends string> = Readonly<{
+  typeToken: string;
+  cleared: Classification;
+  transitioned: Classification;
+  stateChangedBlockerStillLive: Classification;
+  stickyBlocker: Classification;
+  unblockedReason: string;
+  clearedReason: string;
+  transitionedReason: string;
+  stateChangedBlockerStillLiveReason: string;
+  stickyBlockerReason: string;
+}>;
+
+export function technologyChoicePostcondition(
+  before: Civ7ProgressionChoiceNotificationView,
+  after: Civ7ProgressionChoiceNotificationView,
+): Civ7ProgressionChoicePostcondition<
+  Civ7TechnologyChoicePostconditionClassification
+> {
+  return progressionChoicePostcondition(before, after, {
+    typeToken: "CHOOSE_TECH",
+    cleared: "technology-choice-cleared",
+    transitioned: "technology-choice-transitioned",
+    stateChangedBlockerStillLive:
+      "technology-state-changed-blocker-still-live",
+    stickyBlocker: "technology-choice-sticky-blocker",
+    unblockedReason: "The technology choice workflow left the turn unblocked.",
+    clearedReason:
+      "The end-turn-blocking technology choice notification is no longer present.",
+    transitionedReason:
+      "The end-turn-blocking technology choice notification changed after the selection.",
+    stateChangedBlockerStillLiveReason:
+      "The technology state changed, but the same technology choice notification still blocks turn flow.",
+    stickyBlockerReason:
+      "The technology choice workflow returned, but the same technology choice notification still blocks turn flow.",
+  });
+}
+
+export function cultureChoicePostcondition(
+  before: Civ7ProgressionChoiceNotificationView,
+  after: Civ7ProgressionChoiceNotificationView,
+): Civ7ProgressionChoicePostcondition<
+  Civ7CultureChoicePostconditionClassification
+> {
+  return progressionChoicePostcondition(before, after, {
+    typeToken: "CHOOSE_CULTURE",
+    cleared: "culture-choice-cleared",
+    transitioned: "culture-choice-transitioned",
+    stateChangedBlockerStillLive: "culture-state-changed-blocker-still-live",
+    stickyBlocker: "culture-choice-sticky-blocker",
+    unblockedReason: "The culture choice workflow left the turn unblocked.",
+    clearedReason:
+      "The end-turn-blocking culture choice notification is no longer present.",
+    transitionedReason:
+      "The end-turn-blocking culture choice notification changed after the selection.",
+    stateChangedBlockerStillLiveReason:
+      "The culture state changed, but the same culture choice notification still blocks turn flow.",
+    stickyBlockerReason:
+      "The culture choice workflow returned, but the same culture choice notification still blocks turn flow.",
+  });
+}
+
+export function findTechnologyChoiceNotification(
+  view: Civ7ProgressionChoiceNotificationView,
+): Civ7ProgressionChoiceNotification | null {
+  return findProgressionChoiceNotification(view, "CHOOSE_TECH");
+}
+
+export function findCultureChoiceNotification(
+  view: Civ7ProgressionChoiceNotificationView,
+): Civ7ProgressionChoiceNotification | null {
+  return findProgressionChoiceNotification(view, "CHOOSE_CULTURE");
+}
+
+function progressionChoicePostcondition<Classification extends string>(
+  before: Civ7ProgressionChoiceNotificationView,
+  after: Civ7ProgressionChoiceNotificationView,
+  policy: ProgressionChoicePolicy<Classification>,
+): Civ7ProgressionChoicePostcondition<Classification | "turn-unblocked"> {
+  if (probeValue(after.canEndTurn) === true) {
+    return {
+      classification: "turn-unblocked",
+      verified: true,
+      reason: policy.unblockedReason,
+    };
+  }
+
+  const beforeBlocker = findProgressionChoiceNotification(
+    before,
+    policy.typeToken,
+  );
+  const afterBlocker = findProgressionChoiceNotification(after, policy.typeToken);
+  if (beforeBlocker && !afterBlocker) {
+    return {
+      classification: policy.cleared,
+      verified: true,
+      reason: policy.clearedReason,
+    };
+  }
+
+  if (
+    beforeBlocker && afterBlocker
+    && !sameNotificationId(beforeBlocker.id, afterBlocker.id)
+  ) {
+    return {
+      classification: policy.transitioned,
+      verified: true,
+      reason: policy.transitionedReason,
+    };
+  }
+
+  if (
+    beforeBlocker && afterBlocker
+    && progressionChoiceDetailsChanged(beforeBlocker.details, afterBlocker.details)
+  ) {
+    return {
+      classification: policy.stateChangedBlockerStillLive,
+      verified: false,
+      reason: policy.stateChangedBlockerStillLiveReason,
+    };
+  }
+
+  return {
+    classification: policy.stickyBlocker,
+    verified: false,
+    reason: policy.stickyBlockerReason,
+  };
+}
+
+function findProgressionChoiceNotification(
+  view: Civ7ProgressionChoiceNotificationView,
+  typeToken: string,
+): Civ7ProgressionChoiceNotification | null {
+  return view.notifications.find((notification) => {
+    const typeName = String(notification.typeName ?? "").toUpperCase();
+    return notification.isEndTurnBlocking === true && typeName.includes(typeToken);
+  }) ?? null;
+}
+
+function sameNotificationId(left: unknown, right: unknown): boolean {
+  if (!isRecord(left) || !isRecord(right)) return left == null && right == null;
+  return left.owner === right.owner && left.id === right.id
+    && left.type === right.type;
+}
+
+function progressionChoiceDetailsChanged(left: unknown, right: unknown): boolean {
+  if (!isRecord(left) || !isRecord(right)) return false;
+  return stableJson(probeValue(left.currentResearching))
+      !== stableJson(probeValue(right.currentResearching))
+    || stableJson(probeValue(left.targetNode))
+      !== stableJson(probeValue(right.targetNode));
+}
+
+function probeValue(value: unknown): unknown {
+  if (value && typeof value === "object" && "ok" in value) {
+    const probe = value as { ok?: unknown; value?: unknown };
+    return probe.ok === true ? probe.value ?? null : null;
+  }
+  return value ?? null;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value, Object.keys(flattenKeys(value)).sort())
+    ?? String(value);
+}
+
+function flattenKeys(
+  value: unknown,
+  keys: Record<string, true> = {},
+): Record<string, true> {
+  if (Array.isArray(value)) {
+    for (const item of value) flattenKeys(item, keys);
+    return keys;
+  }
+  if (!isRecord(value)) return keys;
+  for (const [key, child] of Object.entries(value)) {
+    keys[key] = true;
+    flattenKeys(child, keys);
+  }
+  return keys;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/civ7-direct-control/src/proof/turn-completion-proof-policy.ts
+++ b/packages/civ7-direct-control/src/proof/turn-completion-proof-policy.ts
@@ -1,0 +1,135 @@
+import type {
+  Civ7TurnCompletionActionResult,
+} from "../play/turn-completion";
+import type { Civ7RuntimeProbe } from "../runtime/probe";
+import type {
+  Civ7OperationProofBoundary,
+  Civ7OperationTelemetryPostcondition,
+  Civ7OperationTelemetryPostconditionOutcome,
+} from "./operation-telemetry";
+
+export type Civ7TurnCompletionPostconditionClassification =
+  | "turn-advanced"
+  | "turn-complete-sent"
+  | "already-complete"
+  | "no-state-change"
+  | "missing-postcondition"
+  | "pending-runtime-proof";
+
+export function turnCompletionProofPostcondition(
+  result: Civ7TurnCompletionActionResult,
+  proofBoundary: Civ7OperationProofBoundary | undefined,
+): Civ7OperationTelemetryPostcondition {
+  const classification = turnCompletionPostconditionClassification(result);
+
+  if (proofBoundary === "pending-runtime-proof") {
+    return {
+      classification,
+      reason: "Runtime postcondition proof is pending for the turn completion send.",
+      outcome: "unknown",
+      noRepeatAfterUnverified: true,
+      confidence: "pending-runtime-proof",
+    };
+  }
+
+  const outcome = turnCompletionProofOutcome(classification);
+  const confirmed = turnCompletionPostconditionConfirmed(classification);
+
+  return {
+    classification,
+    reason: turnCompletionPostconditionReason(classification),
+    outcome,
+    noRepeatAfterUnverified: turnCompletionNoRepeatAfterUnverified(
+      classification,
+    ),
+    confidence: confirmed ? "confirmed" : "unverified",
+  };
+}
+
+export function turnCompletionProofOutcome(
+  classification: Civ7TurnCompletionPostconditionClassification,
+): Civ7OperationTelemetryPostconditionOutcome {
+  switch (classification) {
+    case "turn-advanced":
+      return "cleared";
+    case "turn-complete-sent":
+    case "already-complete":
+      return "state-changed";
+    case "no-state-change":
+      return "no-state-change";
+    case "missing-postcondition":
+    case "pending-runtime-proof":
+      return "unknown";
+  }
+}
+
+export function turnCompletionPostconditionConfirmed(
+  classification: Civ7TurnCompletionPostconditionClassification,
+): boolean {
+  switch (classification) {
+    case "turn-advanced":
+    case "turn-complete-sent":
+    case "already-complete":
+      return true;
+    case "no-state-change":
+    case "missing-postcondition":
+    case "pending-runtime-proof":
+      return false;
+  }
+}
+
+function turnCompletionPostconditionClassification(
+  result: Civ7TurnCompletionActionResult,
+): Civ7TurnCompletionPostconditionClassification {
+  const beforeTurn = probeValue(result.before.turn);
+  const afterTurn = probeValue(result.after.turn);
+  const beforeSent = probeValue(result.before.hasSentTurnComplete);
+  const afterSent = probeValue(result.after.hasSentTurnComplete);
+
+  if (beforeTurn == null || afterTurn == null || afterSent == null) {
+    return "missing-postcondition";
+  }
+
+  if (afterTurn !== beforeTurn) return "turn-advanced";
+  if (beforeSent === true && afterSent === true) return "already-complete";
+  if (afterSent === true) return "turn-complete-sent";
+  return "no-state-change";
+}
+
+function turnCompletionPostconditionReason(
+  classification: Civ7TurnCompletionPostconditionClassification,
+): string {
+  switch (classification) {
+    case "turn-advanced":
+      return "The turn advanced after the turn completion send.";
+    case "turn-complete-sent":
+      return "GameContext reports that turn completion was sent; wait for a fresh turn/read before sending again.";
+    case "already-complete":
+      return "GameContext reported turn completion before and after the send; do not repeat without fresh turn evidence.";
+    case "no-state-change":
+      return "The turn completion send did not advance the turn or mark turn completion sent.";
+    case "missing-postcondition":
+      return "The turn completion result did not include readable before/after turn completion probes.";
+    case "pending-runtime-proof":
+      return "Runtime postcondition proof is pending for the turn completion send.";
+  }
+}
+
+function turnCompletionNoRepeatAfterUnverified(
+  classification: Civ7TurnCompletionPostconditionClassification,
+): boolean {
+  switch (classification) {
+    case "turn-advanced":
+      return false;
+    case "turn-complete-sent":
+    case "already-complete":
+    case "no-state-change":
+    case "missing-postcondition":
+    case "pending-runtime-proof":
+      return true;
+  }
+}
+
+function probeValue<T>(probe: Civ7RuntimeProbe<T>): T | undefined {
+  return probe.ok ? probe.value : undefined;
+}

--- a/packages/civ7-direct-control/test/progression-choice-postconditions.test.ts
+++ b/packages/civ7-direct-control/test/progression-choice-postconditions.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  cultureChoicePostcondition,
+  findCultureChoiceNotification,
+  findTechnologyChoiceNotification,
+  technologyChoicePostcondition,
+  type Civ7ProgressionChoiceNotificationView,
+} from "../src/index.js";
+
+describe("progression choice postconditions", () => {
+  test("classifies technology choice blocker outcomes", () => {
+    const before = notificationView("NOTIFICATION_CHOOSE_TECH", {
+      currentResearching: probe(10),
+      targetNode: probe(20),
+    });
+
+    expect(findTechnologyChoiceNotification(before)?.id).toEqual({
+      owner: 0,
+      id: 52,
+      type: 20,
+    });
+    expect(technologyChoicePostcondition(
+      before,
+      notificationView("NOTIFICATION_CHOOSE_TECH", {}, { canEndTurn: true }),
+    )).toMatchObject({
+      classification: "turn-unblocked",
+      verified: true,
+    });
+    expect(technologyChoicePostcondition(before, cleanView())).toMatchObject({
+      classification: "technology-choice-cleared",
+      verified: true,
+    });
+    expect(technologyChoicePostcondition(
+      before,
+      notificationView("NOTIFICATION_CHOOSE_TECH", {}, { id: 53 }),
+    )).toMatchObject({
+      classification: "technology-choice-transitioned",
+      verified: true,
+    });
+    expect(technologyChoicePostcondition(
+      before,
+      notificationView("NOTIFICATION_CHOOSE_TECH", {
+        currentResearching: probe(11),
+        targetNode: probe(20),
+      }),
+    )).toMatchObject({
+      classification: "technology-state-changed-blocker-still-live",
+      verified: false,
+    });
+    expect(technologyChoicePostcondition(before, before)).toMatchObject({
+      classification: "technology-choice-sticky-blocker",
+      verified: false,
+    });
+  });
+
+  test("classifies culture choice blocker outcomes", () => {
+    const before = notificationView("NOTIFICATION_CHOOSE_CULTURE_NODE", {
+      currentResearching: probe(30),
+      targetNode: probe(40),
+    });
+
+    expect(findCultureChoiceNotification(before)?.id).toEqual({
+      owner: 0,
+      id: 52,
+      type: 20,
+    });
+    expect(cultureChoicePostcondition(
+      before,
+      notificationView("NOTIFICATION_CHOOSE_CULTURE_NODE", {}, {
+        canEndTurn: true,
+      }),
+    )).toMatchObject({
+      classification: "turn-unblocked",
+      verified: true,
+    });
+    expect(cultureChoicePostcondition(before, cleanView())).toMatchObject({
+      classification: "culture-choice-cleared",
+      verified: true,
+    });
+    expect(cultureChoicePostcondition(
+      before,
+      notificationView("NOTIFICATION_CHOOSE_CULTURE_NODE", {}, { id: 53 }),
+    )).toMatchObject({
+      classification: "culture-choice-transitioned",
+      verified: true,
+    });
+    expect(cultureChoicePostcondition(
+      before,
+      notificationView("NOTIFICATION_CHOOSE_CULTURE_NODE", {
+        currentResearching: probe(31),
+        targetNode: probe(40),
+      }),
+    )).toMatchObject({
+      classification: "culture-state-changed-blocker-still-live",
+      verified: false,
+    });
+    expect(cultureChoicePostcondition(before, before)).toMatchObject({
+      classification: "culture-choice-sticky-blocker",
+      verified: false,
+    });
+  });
+});
+
+function notificationView(
+  typeName: string,
+  details: Record<string, unknown>,
+  options: Readonly<{
+    id?: number;
+    canEndTurn?: boolean;
+  }> = {},
+): Civ7ProgressionChoiceNotificationView {
+  return {
+    canEndTurn: probe(options.canEndTurn ?? false),
+    notifications: [{
+      id: { owner: 0, id: options.id ?? 52, type: 20 },
+      typeName,
+      isEndTurnBlocking: true,
+      details,
+    }],
+  };
+}
+
+function cleanView(): Civ7ProgressionChoiceNotificationView {
+  return {
+    canEndTurn: probe(false),
+    notifications: [],
+  };
+}
+
+function probe<T>(value: T): Readonly<{ ok: true; value: T }> {
+  return { ok: true, value };
+}

--- a/packages/civ7-direct-control/test/turn-completion-proof-policy.test.ts
+++ b/packages/civ7-direct-control/test/turn-completion-proof-policy.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  turnCompletionPostconditionConfirmed,
+  turnCompletionProofOutcome,
+  turnCompletionProofPostcondition,
+  type Civ7TurnCompletionPostconditionClassification,
+} from "../src/index";
+
+import type {
+  Civ7TurnCompletionActionResult,
+  Civ7TurnCompletionStatusResult,
+} from "../src/index";
+import type { Civ7OperationTelemetryPostconditionOutcome } from "../src/proof/operation-telemetry";
+
+type TurnCompletionProofCase = Readonly<{
+  classification: Civ7TurnCompletionPostconditionClassification;
+  result: Civ7TurnCompletionActionResult;
+  outcome: Civ7OperationTelemetryPostconditionOutcome;
+  confidence: "confirmed" | "unverified";
+  noRepeatAfterUnverified: boolean;
+}>;
+
+const turnCompletionProofCases: readonly TurnCompletionProofCase[] = [
+  {
+    classification: "turn-advanced",
+    result: turnCompletionActionResult({
+      before: turnCompletionStatus({ turn: 12, hasSentTurnComplete: false }),
+      after: turnCompletionStatus({ turn: 13, hasSentTurnComplete: false }),
+    }),
+    outcome: "cleared",
+    confidence: "confirmed",
+    noRepeatAfterUnverified: false,
+  },
+  {
+    classification: "turn-complete-sent",
+    result: turnCompletionActionResult({
+      before: turnCompletionStatus({ turn: 12, hasSentTurnComplete: false }),
+      after: turnCompletionStatus({ turn: 12, hasSentTurnComplete: true }),
+    }),
+    outcome: "state-changed",
+    confidence: "confirmed",
+    noRepeatAfterUnverified: true,
+  },
+  {
+    classification: "already-complete",
+    result: turnCompletionActionResult({
+      before: turnCompletionStatus({ turn: 12, hasSentTurnComplete: true }),
+      after: turnCompletionStatus({ turn: 12, hasSentTurnComplete: true }),
+    }),
+    outcome: "state-changed",
+    confidence: "confirmed",
+    noRepeatAfterUnverified: true,
+  },
+  {
+    classification: "no-state-change",
+    result: turnCompletionActionResult({
+      before: turnCompletionStatus({ turn: 12, hasSentTurnComplete: false }),
+      after: turnCompletionStatus({ turn: 12, hasSentTurnComplete: false }),
+    }),
+    outcome: "no-state-change",
+    confidence: "unverified",
+    noRepeatAfterUnverified: true,
+  },
+  {
+    classification: "missing-postcondition",
+    result: turnCompletionActionResult({
+      before: turnCompletionStatus({ turn: 12, hasSentTurnComplete: false }),
+      after: turnCompletionStatus({
+        turn: 12,
+        hasSentTurnComplete: false,
+        hasSentTurnCompleteOk: false,
+      }),
+    }),
+    outcome: "unknown",
+    confidence: "unverified",
+    noRepeatAfterUnverified: true,
+  },
+];
+
+describe("turn completion proof policy", () => {
+  for (
+    const {
+      classification,
+      result,
+      outcome,
+      confidence,
+      noRepeatAfterUnverified,
+    } of turnCompletionProofCases
+  ) {
+    test(`maps ${classification} into proof confidence and no-repeat policy`, () => {
+      const postcondition = turnCompletionProofPostcondition(result, undefined);
+
+      expect(turnCompletionProofOutcome(classification)).toBe(outcome);
+      expect(turnCompletionPostconditionConfirmed(classification)).toBe(
+        confidence === "confirmed",
+      );
+      expect(postcondition).toMatchObject({
+        classification,
+        outcome,
+        confidence,
+        noRepeatAfterUnverified,
+      });
+    });
+  }
+
+  test("keeps pending runtime proof no-repeat guarded", () => {
+    expect(turnCompletionProofPostcondition(turnCompletionActionResult({
+      before: turnCompletionStatus({ turn: 12, hasSentTurnComplete: false }),
+      after: turnCompletionStatus({ turn: 13, hasSentTurnComplete: false }),
+    }), "pending-runtime-proof")).toMatchObject({
+      classification: "turn-advanced",
+      outcome: "unknown",
+      confidence: "pending-runtime-proof",
+      noRepeatAfterUnverified: true,
+    });
+  });
+});
+
+function turnCompletionActionResult(
+  overrides: Partial<Civ7TurnCompletionActionResult>,
+): Civ7TurnCompletionActionResult {
+  return {
+    before: turnCompletionStatus({ turn: 12, hasSentTurnComplete: false }),
+    after: turnCompletionStatus({ turn: 12, hasSentTurnComplete: true }),
+    command: {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      output: ["null"],
+    },
+    verified: true,
+    ...overrides,
+  } as Civ7TurnCompletionActionResult;
+}
+
+function turnCompletionStatus(options: Readonly<{
+  turn: number;
+  hasSentTurnComplete: boolean;
+  turnOk?: boolean;
+  hasSentTurnCompleteOk?: boolean;
+}>): Civ7TurnCompletionStatusResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    turn: options.turnOk === false
+      ? { ok: false, reason: "missing turn" }
+      : { ok: true, value: options.turn },
+    turnDate: { ok: true, value: "3990 BCE" },
+    hasSentTurnComplete: options.hasSentTurnCompleteOk === false
+      ? { ok: false, reason: "missing sent state" }
+      : { ok: true, value: options.hasSentTurnComplete },
+    canEndTurn: { ok: true, value: true },
+    blocker: { ok: true, value: 0 },
+    firstReadyUnitId: { ok: true, value: null },
+  };
+}

--- a/packages/cli/src/commands/game/play/choose-culture.ts
+++ b/packages/cli/src/commands/game/play/choose-culture.ts
@@ -1,5 +1,10 @@
 import { Command, Flags } from '@oclif/core';
-import { getCiv7PlayNotificationView, requestCiv7CultureChoiceCloseout } from '@civ7/direct-control';
+import {
+  cultureChoicePostcondition,
+  findCultureChoiceNotification,
+  getCiv7PlayNotificationView,
+  requestCiv7CultureChoiceCloseout,
+} from '@civ7/direct-control';
 import {
   buildApproval,
   buildDirectControlOptions,
@@ -286,93 +291,6 @@ async function waitForCultureChoicePostcondition(
     last = await getCiv7PlayNotificationView(options);
   }
   return last;
-}
-
-function cultureChoicePostcondition(
-  before: Awaited<ReturnType<typeof getCiv7PlayNotificationView>>,
-  after: Awaited<ReturnType<typeof getCiv7PlayNotificationView>>,
-): {
-  classification:
-    | 'turn-unblocked'
-    | 'culture-choice-cleared'
-    | 'culture-choice-transitioned'
-    | 'culture-state-changed-blocker-still-live'
-    | 'culture-choice-sticky-blocker';
-  verified: boolean;
-  reason: string;
-} {
-  if (probeValue(after.canEndTurn) === true) {
-    return {
-      classification: 'turn-unblocked',
-      verified: true,
-      reason: 'The culture choice workflow left the turn unblocked.',
-    };
-  }
-  const beforeBlocker = findCultureChoiceNotification(before);
-  const afterBlocker = findCultureChoiceNotification(after);
-  if (beforeBlocker && !afterBlocker) {
-    return {
-      classification: 'culture-choice-cleared',
-      verified: true,
-      reason: 'The end-turn-blocking culture choice notification is no longer present.',
-    };
-  }
-  if (beforeBlocker && afterBlocker && !sameNotificationId(beforeBlocker.id, afterBlocker.id)) {
-    return {
-      classification: 'culture-choice-transitioned',
-      verified: true,
-      reason: 'The end-turn-blocking culture choice notification changed after the selection.',
-    };
-  }
-  if (beforeBlocker && afterBlocker && cultureChoiceDetailsChanged(beforeBlocker.details, afterBlocker.details)) {
-    return {
-      classification: 'culture-state-changed-blocker-still-live',
-      verified: false,
-      reason: 'The culture state changed, but the same culture choice notification still blocks turn flow.',
-    };
-  }
-  return {
-    classification: 'culture-choice-sticky-blocker',
-    verified: false,
-    reason: 'The culture choice workflow returned, but the same culture choice notification still blocks turn flow.',
-  };
-}
-
-function findCultureChoiceNotification(
-  view: Awaited<ReturnType<typeof getCiv7PlayNotificationView>>,
-): { id?: unknown; details?: unknown } | null {
-  return view.notifications.find((notification) => {
-    const typeName = String(notification.typeName ?? '').toUpperCase();
-    return notification.isEndTurnBlocking === true && typeName.includes('CHOOSE_CULTURE');
-  }) ?? null;
-}
-
-function sameNotificationId(left: unknown, right: unknown): boolean {
-  if (!isRecord(left) || !isRecord(right)) return left == null && right == null;
-  return left.owner === right.owner && left.id === right.id && left.type === right.type;
-}
-
-function cultureChoiceDetailsChanged(left: unknown, right: unknown): boolean {
-  if (!isRecord(left) || !isRecord(right)) return false;
-  return stableJson(probeValue(left.currentResearching)) !== stableJson(probeValue(right.currentResearching))
-    || stableJson(probeValue(left.targetNode)) !== stableJson(probeValue(right.targetNode));
-}
-
-function stableJson(value: unknown): string {
-  return JSON.stringify(value, Object.keys(flattenKeys(value)).sort()) ?? String(value);
-}
-
-function flattenKeys(value: unknown, keys: Record<string, true> = {}): Record<string, true> {
-  if (Array.isArray(value)) {
-    for (const item of value) flattenKeys(item, keys);
-    return keys;
-  }
-  if (!isRecord(value)) return keys;
-  for (const [key, child] of Object.entries(value)) {
-    keys[key] = true;
-    flattenKeys(child, keys);
-  }
-  return keys;
 }
 
 function isComponentId(value: unknown): value is { owner: number; id: number; type?: number } {

--- a/packages/cli/src/commands/game/play/choose-tech.ts
+++ b/packages/cli/src/commands/game/play/choose-tech.ts
@@ -1,5 +1,10 @@
 import { Command, Flags } from '@oclif/core';
-import { getCiv7PlayNotificationView, requestCiv7TechnologyChoiceCloseout } from '@civ7/direct-control';
+import {
+  findTechnologyChoiceNotification,
+  getCiv7PlayNotificationView,
+  requestCiv7TechnologyChoiceCloseout,
+  technologyChoicePostcondition,
+} from '@civ7/direct-control';
 import {
   buildApproval,
   buildDirectControlOptions,
@@ -287,93 +292,6 @@ async function waitForTechnologyChoicePostcondition(
     last = await getCiv7PlayNotificationView(options);
   }
   return last;
-}
-
-function technologyChoicePostcondition(
-  before: Awaited<ReturnType<typeof getCiv7PlayNotificationView>>,
-  after: Awaited<ReturnType<typeof getCiv7PlayNotificationView>>,
-): {
-  classification:
-    | 'turn-unblocked'
-    | 'technology-choice-cleared'
-    | 'technology-choice-transitioned'
-    | 'technology-state-changed-blocker-still-live'
-    | 'technology-choice-sticky-blocker';
-  verified: boolean;
-  reason: string;
-} {
-  if (probeValue(after.canEndTurn) === true) {
-    return {
-      classification: 'turn-unblocked',
-      verified: true,
-      reason: 'The technology choice workflow left the turn unblocked.',
-    };
-  }
-  const beforeBlocker = findTechnologyChoiceNotification(before);
-  const afterBlocker = findTechnologyChoiceNotification(after);
-  if (beforeBlocker && !afterBlocker) {
-    return {
-      classification: 'technology-choice-cleared',
-      verified: true,
-      reason: 'The end-turn-blocking technology choice notification is no longer present.',
-    };
-  }
-  if (beforeBlocker && afterBlocker && !sameNotificationId(beforeBlocker.id, afterBlocker.id)) {
-    return {
-      classification: 'technology-choice-transitioned',
-      verified: true,
-      reason: 'The end-turn-blocking technology choice notification changed after the selection.',
-    };
-  }
-  if (beforeBlocker && afterBlocker && technologyChoiceDetailsChanged(beforeBlocker.details, afterBlocker.details)) {
-    return {
-      classification: 'technology-state-changed-blocker-still-live',
-      verified: false,
-      reason: 'The technology state changed, but the same technology choice notification still blocks turn flow.',
-    };
-  }
-  return {
-    classification: 'technology-choice-sticky-blocker',
-    verified: false,
-    reason: 'The technology choice workflow returned, but the same technology choice notification still blocks turn flow.',
-  };
-}
-
-function findTechnologyChoiceNotification(
-  view: Awaited<ReturnType<typeof getCiv7PlayNotificationView>>,
-): { id?: unknown; details?: unknown } | null {
-  return view.notifications.find((notification) => {
-    const typeName = String(notification.typeName ?? '').toUpperCase();
-    return notification.isEndTurnBlocking === true && typeName.includes('CHOOSE_TECH');
-  }) ?? null;
-}
-
-function sameNotificationId(left: unknown, right: unknown): boolean {
-  if (!isRecord(left) || !isRecord(right)) return left == null && right == null;
-  return left.owner === right.owner && left.id === right.id && left.type === right.type;
-}
-
-function technologyChoiceDetailsChanged(left: unknown, right: unknown): boolean {
-  if (!isRecord(left) || !isRecord(right)) return false;
-  return stableJson(probeValue(left.currentResearching)) !== stableJson(probeValue(right.currentResearching))
-    || stableJson(probeValue(left.targetNode)) !== stableJson(probeValue(right.targetNode));
-}
-
-function stableJson(value: unknown): string {
-  return JSON.stringify(value, Object.keys(flattenKeys(value)).sort()) ?? String(value);
-}
-
-function flattenKeys(value: unknown, keys: Record<string, true> = {}): Record<string, true> {
-  if (Array.isArray(value)) {
-    for (const item of value) flattenKeys(item, keys);
-    return keys;
-  }
-  if (!isRecord(value)) return keys;
-  for (const [key, child] of Object.entries(value)) {
-    keys[key] = true;
-    flattenKeys(child, keys);
-  }
-  return keys;
 }
 
 function isComponentId(value: unknown): value is { owner: number; id: number; type?: number } {

--- a/packages/cli/src/commands/game/status.ts
+++ b/packages/cli/src/commands/game/status.ts
@@ -1,8 +1,6 @@
 import { Command, Flags } from '@oclif/core';
-import {
-  createCiv7ControlOrpcServerClient,
-  liveCiv7ControlOrpcDirectControlFacade,
-} from '@civ7/control-orpc';
+import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import type { Civ7DirectControlOptions } from '@civ7/direct-control';
 
 export default class GameStatus extends Command {

--- a/scripts/lint/lint-control-orpc-contract-ownership.mjs
+++ b/scripts/lint/lint-control-orpc-contract-ownership.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const contractRoot = join(
+  repoRoot,
+  "packages/civ7-control-orpc/src/modules",
+);
+
+const contractFiles = collectContractFiles(contractRoot);
+const violations = [];
+
+for (const file of contractFiles) {
+  const source = readFileSync(file, "utf8");
+  const lines = source.split(/\r?\n/);
+  lines.forEach((line, index) => {
+    if (line.includes("@civ7/direct-control")) {
+      violations.push({
+        path: relative(repoRoot, file),
+        line: index + 1,
+        text: line.trim(),
+      });
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error("control-oRPC contract ownership guard failed:");
+  for (const violation of violations) {
+    console.error(
+      `- ${violation.path}:${violation.line} imports direct-control in a service contract: ${violation.text}`,
+    );
+  }
+  console.error(
+    "Move caller-facing contract schemas into packages/civ7-control-orpc, or keep direct-control imports in runtime/proof procedures instead.",
+  );
+  process.exit(1);
+}
+
+console.log("control-oRPC contract ownership guard passed.");
+
+function collectContractFiles(directory) {
+  const files = [];
+  for (const entry of readdirSync(directory)) {
+    const path = join(directory, entry);
+    const stats = statSync(path);
+    if (stats.isDirectory()) {
+      files.push(...collectContractFiles(path));
+      continue;
+    }
+    if (entry === "contract.ts") files.push(path);
+  }
+  return files.sort();
+}


### PR DESCRIPTION
docs(control-orpc): plan controller bridge ingress

Refs: openspec/changes/civ7-control-orpc-native-slice

Records the in-game controller bridge preflight boundary for Task 7.3. The record keeps Civ7IntelligenceBridge.invoke(...) as serialized ingress only, requires a game-scoped UIScript to load an in-process oRPC/Effect router, and defines procedure allowlist, context ownership, approval/local-player proof, lifecycle certification, evidence sink, and raw command/session/tuner stop conditions before source implementation.

Keeps 7.3 implementation pending. This is not a source scaffold, bridge package, runtime proof, play-thread action, transport expansion, OpenAPI work, hand-maintained App UI method table, or ad hoc JSON product API.

Proof:
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check
- git diff --cached --check

feat(control-orpc): seed controller readiness ingress

Refs: openspec/changes/civ7-control-orpc-native-slice

Seeds a package-local read-only controller ingress core for readiness.current. The ingress validates a closed serialized envelope, allowlists readiness.current, constructs context through a caller-owned factory, injects correlation into typed control-oRPC context, and invokes the existing in-process router client.

Keeps global Civ7IntelligenceBridge installation, UIScript/mod packaging, mutation allowlists, local-player/hotseat proof, approval token handling, runtime/live proof, OpenAPI/transport work, and full 7.3 acceptance pending.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/controller-bridge-ingress.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check
- git diff --cached --check

Local package/OpenSpec proof only. No runtime/live-game proof, play-thread action, global bridge installation, UIScript packaging, mutation ingress, raw command/session/tuner payloads, custom router/procedure runner, or Task 5.x/6.x/7.3 parent acceptance.

feat(control-orpc): install controller bridge binding

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds a package-local Civ7IntelligenceBridge binding over the existing controller ingress. The binding exposes only invoke(request), installs on a caller-provided target, refuses accidental overwrite unless replacement is explicit, and delegates to the existing in-process router ingress for readiness.current.

Keeps ambient globalThis selection, Civ7 UIScript/modinfo packaging, mutation allowlists, local-player/hotseat proof, approval-token handling, runtime/live proof, and full 7.3 implementation pending.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/intelligence-bridge.test.ts test/controller-bridge-ingress.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check
- git diff --cached --check

Local package/OpenSpec proof only. No runtime/live-game proof, play-thread action, ambient globalThis installation, Civ7 UIScript packaging, mutation ingress, raw command/session/tuner payloads, custom router/procedure runner, or Task 5.x/6.x/7.3 parent acceptance.

feat(control-orpc): allow controller attention ingress

Refs: openspec/changes/civ7-control-orpc-native-slice

Allows the package-local controller ingress to accept service-owned read-only attention.current requests beside readiness.current. Requests validate through the existing attention input schema, delegate to the existing in-process router client, and keep raw command/session/tuner endpoint fields plus mutation approvals out of the serialized envelope.

Keeps Civ7 UIScript/modinfo packaging, ambient globalThis selection, mutation allowlists, local-player/hotseat proof, approval-token handling, runtime/live proof, and full 7.3 implementation pending.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/controller-bridge-ingress.test.ts test/intelligence-bridge.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check
- git diff --cached --check

Local package/OpenSpec proof only. No runtime/live-game proof, play-thread action, Civ7 UIScript packaging, ambient globalThis installation, mutation ingress, raw command/session/tuner payloads, custom router/procedure runner, or Task 5.x/6.x/7.3 parent acceptance.

chore(control-orpc): burn down raw root type exports

Refs: openspec/changes/civ7-control-orpc-native-slice

Removes root public exports of direct-control runtime-port result aliases from @civ7/control-orpc. The package root now keeps the semantic service contracts, routers, bridge/client entrypoints, tagged errors, context type, and direct-control facade/context dependency type while leaving raw result envelopes internal to service dependency typing or owned by @civ7/direct-control.

Updates the Studio RPCLink edge test so its fake playable-status runtime fixture imports the low-level result type from @civ7/direct-control instead of the control-oRPC root entrypoint.

Proof:
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun test apps/mapgen-studio/test/runInGame/civ7ControlOrpcClient.test.ts
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- rg -n "type Civ7ControlOrpc(PlayableStatus|PlayNotificationView|ProductionChoice|NotificationDismissal|ReadyCity|ReadyUnit|TurnCompletion|UnitTargetAction|DiplomacyResponse|NarrativeChoice)Result" packages/civ7-control-orpc/src/index.ts apps packages/cli || true
- git diff --check
- git diff --cached --check

Local package/API and OpenSpec proof only. No procedure behavior change, runtime/live-game proof, play-thread action, transport change, direct-control runtime/proof authority change, or Task 5.x/6.x/7.x parent acceptance.

chore(control-orpc): split runtime facade entrypoint

Refs: openspec/changes/civ7-control-orpc-native-slice

Moves the live direct-control facade and facade type out of the root @civ7/control-orpc service entrypoint and into an explicit @civ7/control-orpc/runtime subpath for edge-adapter context construction. The root entrypoint remains focused on service contracts, routers, server-side clients, bridge ingress/bindings, tagged errors, semantic procedure schemas/results, and context type.

Adds the runtime subpath to package exports, tsup entries, and typesVersions so older TypeScript node resolution used by the CLI can resolve @civ7/control-orpc/runtime. Updates CLI game status and Studio RPCHandler middleware to import service APIs from the root and the live direct-control facade from the runtime subpath.

Proof:
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun test apps/mapgen-studio/test/runInGame/civ7ControlOrpcClient.test.ts
- bun run --cwd apps/mapgen-studio check
- bun run --cwd packages/cli check
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- rg -n "liveCiv7ControlOrpcDirectControlFacade|Civ7ControlOrpcDirectControlFacade" packages/civ7-control-orpc/src/index.ts apps packages/cli packages/civ7-control-orpc/src/runtime.ts
- git diff --check
- git diff --cached --check

Local package/API, CLI/Studio type, and OpenSpec proof only. No procedure behavior change, runtime/live-game proof, play-thread action, transport expansion, direct-control runtime/proof authority change, raw result envelope export, or Task 5.x/6.x/7.x parent acceptance.

chore(control-orpc): own primitive service schemas

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds service-owned control-oRPC primitive schemas for component IDs and map locations, then switches attention, notification, city, unit, decisions, and strategy contracts to those primitives for caller-facing input/output fields. This reduces direct-control primitive value imports in service contracts while preserving direct-control as the runtime/proof authority.

Adds focused equivalence proof against the current direct-control primitive schemas so the service primitives do not drift from the accepted runtime-owner boundary. Operation-specific input schemas and proof helpers remain direct-control-owned for later domain-specific separation.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/primitive-schemas.test.ts test/attention-current-procedure.test.ts test/notification-dismissal-procedure.test.ts test/city-population-placement-procedure.test.ts test/strategy-front-summary-procedure.test.ts test/unit-target-action-procedure.test.ts test/decisions-narrative-choice-procedure.test.ts test/decisions-diplomacy-response-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- rg -n "Civ7ComponentIdSchema|Civ7MapLocationSchema" packages/civ7-control-orpc/src/modules packages/civ7-control-orpc/src/index.ts packages/civ7-control-orpc/src/model packages/civ7-control-orpc/test/primitive-schemas.test.ts
- git diff --check
- git diff --cached --check

Local package/schema and OpenSpec proof only. No procedure behavior change, runtime/live-game proof, play-thread action, schema-tech migration, transport change, direct-control runtime/proof authority change, or Task 5.x/6.x/7.x parent acceptance.

chore(control-orpc): own notification dismissal contract

Refs: openspec/changes/civ7-control-orpc-native-slice

Moves the caller-facing notifications.dismiss.request input schema and normal postcondition classification enum into the control-oRPC service contract. The notification dismissal procedure still calls the direct-control runtime facade and consumes the direct-control proof helper for runtime classification and no-repeat semantics.

Keeps raw command/session/tuner endpoint fields out of service input and keeps direct-control as runtime/proof authority for notification dismissal sends, validation, postconditions, and proof semantics.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/notification-dismissal-procedure.test.ts test/primitive-schemas.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- rg -n "from \"@civ7/direct-control\"|Civ7NotificationDismissInputSchema|Civ7NotificationDismissalPostconditionClassificationSchema" packages/civ7-control-orpc/src/modules/notifications packages/civ7-control-orpc/src/index.ts packages/civ7-control-orpc/test/notification-dismissal-procedure.test.ts
- git diff --check
- git diff --cached --check

Local package/contract and OpenSpec proof only. No procedure behavior change, runtime/live-game proof, play-thread action, telemetry, persistence, CLI/Studio/browser/controller change, direct-control runtime/proof authority change, or Task 5.x/6.x/7.x parent acceptance.

chore(control-orpc): own production choice contract

Refs: openspec/changes/civ7-control-orpc-native-slice

Moves the caller-facing city.production.choice.request input schema and normal postcondition classification enum into the control-oRPC service contract. The production choice procedure still calls the direct-control runtime facade and consumes direct-control proof helpers for runtime classification and no-repeat semantics.

Keeps approval, endpoint, session, state, and raw command fields out of service input and keeps direct-control as runtime/proof authority for production-choice sends, validation, postconditions, and proof semantics.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/city-production-choice-procedure.test.ts test/primitive-schemas.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- rg -n "from \"@civ7/direct-control\"|Civ7ProductionChoiceInputSchema|Civ7ProductionPostconditionClassificationSchema|Civ7CityProductionChoiceInputSchema|Civ7CityProductionChoicePostconditionClassificationSchema" packages/civ7-control-orpc/src/modules/city packages/civ7-control-orpc/src/index.ts packages/civ7-control-orpc/test/city-production-choice-procedure.test.ts openspec/changes/civ7-control-orpc-native-slice/workstream/production-choice-contract-slice.md openspec/changes/civ7-control-orpc-native-slice/tasks.md openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
- git diff --check
- git diff --cached --check

Local package/contract and OpenSpec proof only. No procedure behavior change, runtime/live-game proof, play-thread action, telemetry, persistence, CLI/Studio/browser/controller change, direct-control runtime/proof authority change, or Task 5.x/6.x/7.x parent acceptance.

chore(control-orpc): own unit target action contract

Refs: openspec/changes/civ7-control-orpc-native-slice

Moves the caller-facing unit.target.action.request input schema into the control-oRPC service contract. The unit target action procedure still calls the direct-control runtime facade and consumes the direct-control proof helper for runtime verification and no-repeat semantics.

Keeps approval, endpoint, session, state, and raw command fields out of service input and keeps direct-control as runtime/proof authority for unit target action sends, validation, verification classification, and proof semantics.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/unit-target-action-procedure.test.ts test/primitive-schemas.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- rg -n "from \"@civ7/direct-control\"|Civ7UnitTargetActionInputSchema|Civ7UnitTargetActionVerificationClassificationSchema|Civ7UnitTargetActionInput" packages/civ7-control-orpc/src/modules/unit packages/civ7-control-orpc/src/index.ts packages/civ7-control-orpc/test/unit-target-action-procedure.test.ts openspec/changes/civ7-control-orpc-native-slice/workstream/unit-target-action-contract-slice.md openspec/changes/civ7-control-orpc-native-slice/tasks.md openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
- git diff --check
- git diff --cached --check

Local package/contract and OpenSpec proof only. No procedure behavior change, runtime/live-game proof, play-thread action, telemetry, persistence, CLI/Studio/browser/controller change, direct-control runtime/proof authority change, or Task 5.x/6.x/7.x parent acceptance.

test(control-orpc): guard service contract ownership

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds a package lint guard that fails when control-oRPC module service contracts import direct-control. This locks in the caller-facing contract ownership burn-down while keeping direct-control runtime/proof imports available to procedures, dependency adapters, and focused equivalence proof.

Wires the guard into the control-oRPC package check and records the guard boundary in OpenSpec.

Proof:
- bun run --cwd packages/civ7-control-orpc lint:contract-ownership
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check
- git diff --cached --check

Local package/static and OpenSpec proof only. No procedure behavior change, runtime/live-game proof, play-thread action, controller packaging, transport, telemetry, persistence, direct-control runtime/proof authority change, or Task 5.x/6.x/7.x parent acceptance.

chore(direct-control): own progression choice proof policy

Refs: openspec/changes/civ7-control-orpc-native-slice

Move technology and culture choice blocker postcondition classification out of the CLI commands and into @civ7/direct-control progression proof ownership. The CLI keeps shell flags, send orchestration, and normal output while consuming the shared proof policy.

This prepares future native decisions procedures to consume source-owned postcondition evidence without copying CLI-local logic or inferring success from App UI closeout sends. Native control-oRPC procedure contracts, shared postcondition middleware, runtime proof, and parent Task 5.x/6.x acceptance remain pending.

Proof: bun run --cwd packages/civ7-direct-control test test/progression-choice-postconditions.test.ts; bun run --cwd packages/civ7-direct-control check; bun run --cwd packages/civ7-direct-control build; bun run test:cli:play; bun run openspec -- validate civ7-control-orpc-native-slice --strict; bun run openspec -- validate civ7-support-direct-control-modularization --strict; git diff --check; git diff --cached --check.

Local package and CLI proof only; no runtime/live-game proof, play-thread action, transport/CLI caller migration, control-oRPC procedure/middleware change, or raw command/session/payload projection.

feat(control-orpc): add progression choice decision procedure

Refs: openspec/changes/civ7-control-orpc-native-slice

Add decisions.progression.choice.request as a native service-owned decision procedure for technology and culture progression choices. The procedure reuses native approval and playable-readiness middleware, reads notification evidence before and after the direct-control closeout request, consumes source-owned progression postcondition helpers, and projects semantic status/evidence/postcondition/next-step output.

Keep direct-control as the runtime/proof port for App UI closeout command construction, Tuner/App UI execution, and progression choice classification. Normal control-oRPC input and output exclude endpoint/session/state, raw command, command payload, App UI activation toggles, closeout internals, and legacy proof booleans.

Proof: bun run --cwd packages/civ7-control-orpc test test/decisions-progression-choice-procedure.test.ts; bun run --cwd packages/civ7-direct-control test test/progression-choice-postconditions.test.ts; bun run --cwd packages/civ7-control-orpc test; bun run --cwd packages/civ7-control-orpc check; bun run --cwd packages/civ7-control-orpc build; bun run openspec -- validate civ7-control-orpc-native-slice --strict; bun run openspec -- validate civ7-support-direct-control-modularization --strict; git diff --check; git diff --cached --check.

Local package/procedure proof only; no runtime/live-game proof, play-thread action, CLI/Studio/RPCLink/bridge adapter change, broad decisions catalog, shared validator/postcondition middleware acceptance, or parent Task 5.x/6.x acceptance.

fix(control-orpc): guard progression choice after-read failures

Refs: openspec/changes/civ7-control-orpc-native-slice

When decisions.progression.choice.request sends a progression closeout but the post-send notification read fails, return a no-repeat guarded sent-unverified result with pending-runtime-proof confidence instead of throwing a generic unavailable error. The procedure now records afterReadStatus and avoids inventing after-state facts when the post-read failed or was skipped because nothing was sent.

This preserves the direct-control runtime/proof boundary: App UI closeout authority and notification classifiers stay in direct-control, while control-oRPC owns the caller-facing semantic proof projection and retry safety.

Proof: bun run --cwd packages/civ7-control-orpc test test/decisions-progression-choice-procedure.test.ts; bun run --cwd packages/civ7-control-orpc test; bun run --cwd packages/civ7-control-orpc check; bun run --cwd packages/civ7-control-orpc build; bun run openspec -- validate civ7-control-orpc-native-slice --strict; bun run openspec -- validate civ7-support-direct-control-modularization --strict; git diff --check; git diff --cached --check.

Local package/procedure proof only; no runtime/live-game proof, play-thread action, transport/adapter change, shared postcondition middleware acceptance, or parent Task 5.x/6.x acceptance.

feat(control-orpc): extend closeout projection policy

Refs: openspec/changes/civ7-control-orpc-native-slice

Extend the shared closeout-style mutation projection helper so notification dismissal, narrative choice, diplomacy response, and progression choice procedures derive caller-facing postcondition summaries, request status, and no-repeat next steps through the same service policy. Progression keeps direct-control-owned before/after notification classification and uses an explicit pending-runtime-proof boundary when the post-send read fails.

This remains a policy/helper slice, not shared validator/postcondition middleware. Direct-control remains the source authority for runtime sends, command serialization, postcondition classifiers, proof confidence, and no-repeat semantics; control-oRPC owns the semantic output projection.

Proof: bun run --cwd packages/civ7-control-orpc test test/mutation-result-policy.test.ts test/notification-dismissal-procedure.test.ts test/decisions-narrative-choice-procedure.test.ts test/decisions-diplomacy-response-procedure.test.ts test/decisions-progression-choice-procedure.test.ts; bun run --cwd packages/civ7-control-orpc test; bun run --cwd packages/civ7-control-orpc check; bun run --cwd packages/civ7-control-orpc build; bun run openspec -- validate civ7-control-orpc-native-slice --strict; bun run openspec -- validate civ7-support-direct-control-modularization --strict; git diff --check; git diff --cached --check.

Local package/OpenSpec proof only; no runtime/live-game proof, play-thread action, transport/adapter change, shared validator/postcondition middleware acceptance, or parent Task 5.x/6.x acceptance.

feat(direct-control): own turn completion proof policy

Refs: openspec/changes/civ7-control-orpc-native-slice

Add a direct-control-owned turn completion proof/no-repeat helper before any native turn-completion mutation procedure is accepted. The helper classifies turn-advanced, turn-complete-sent, already-complete, no-state-change, missing-postcondition, and pending-runtime-proof paths, preserving no-repeat guarding for sent-but-not-advanced and uncertain outcomes instead of relying on legacy verified.

This preserves direct-control as the runtime/proof port for GameContext.sendTurnComplete(), before/after reads, fallback preflight, approval assertion, command serialization, and proof classification. The slice records the service-enabling boundary for future control-oRPC composition without adding a procedure, router, middleware, transport, CLI change, or runtime proof claim.

Proof: bun run --cwd packages/civ7-direct-control test test/turn-completion-proof-policy.test.ts; bun run --cwd packages/civ7-direct-control test; bun run --cwd packages/civ7-direct-control check; bun run --cwd packages/civ7-direct-control build; bun run openspec -- validate civ7-control-orpc-native-slice --strict; bun run openspec -- validate civ7-support-direct-control-modularization --strict; git diff --check; git diff --cached --check.

Local package/OpenSpec proof only; no runtime/live-game proof, play-thread action, control-oRPC procedure exposure, transport/adapter change, shared validator/postcondition middleware acceptance, or parent Task 5.x/6.x/7.x acceptance.

feat(control-orpc): add turn completion procedure

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds native turn.complete.request under the semantic turn router. The procedure composes shared approval/readiness middleware, the direct-control turn-completion runtime port, source-owned turn-completion proof classification, tagged error projection, and semantic no-repeat next steps without exposing raw command/session/Tuner details or legacy verified output.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/turn-completion-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check
- git diff --cached --check

Boundary: local package proof only; no CLI end-turn migration, Studio/controller/transport edge work, play-thread wake, runtime/live proof claim, or parent Task 5.x/6.x/7.x acceptance.