### PR TITLE
feat(cli): route end-turn sends through control oRPC

### DIFF
--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -255,6 +255,27 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
   exists
 - **AND** focused CLI tests do not claim live Civ7 runtime proof
 
+#### Scenario: CLI build-production send uses native city procedure
+- **WHEN** `game play build-production --send` requests an approved city
+  production choice
+- **THEN** the CLI constructs native control-oRPC context from endpoint flags
+  and approval reason
+- **AND** the send path calls the in-process `city.production.choice.request`
+  server-side client under the `city` router
+- **AND** the procedure's approval, readiness, direct-control production
+  validator, production postcondition projection, and no-repeat policy remain
+  authoritative for the send
+- **AND** the normal JSON result is the semantic city production choice
+  procedure projection without raw command/session/state/Tuner details,
+  UI-closeout payloads, send results, before/after runtime probes, or legacy
+  `verified`
+- **AND** the read-only `game play build-production` validation path remains
+  direct-control operation validation until a separate accepted service read
+  exists
+- **AND** `game play build-unit` remains outside this slice until a separate
+  caller migration reconciles that convenience command
+- **AND** focused CLI tests do not claim live Civ7 runtime proof
+
 #### Scenario: In-game controller bridge preflight is recorded
 - **WHEN** the in-game controller bridge is planned before source
   implementation

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -218,6 +218,24 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
   procedure exists
 - **AND** focused CLI tests do not claim live Civ7 runtime proof
 
+#### Scenario: CLI notification dismissal send uses native notification procedure
+- **WHEN** `game play dismiss-notification --send` requests an approved
+  notification dismissal
+- **THEN** the CLI constructs native control-oRPC context from endpoint flags
+  and approval reason
+- **AND** the send path calls the in-process `notifications.dismiss.request`
+  server-side client
+- **AND** the procedure's approval, readiness, direct-control validator,
+  postcondition projection, and no-repeat policy remain authoritative for the
+  send
+- **AND** the normal JSON result is the semantic notification dismissal
+  procedure projection without raw command/session/state/Tuner details, route
+  diagnostics, closeout path, verification attempts, or legacy `verified`
+- **AND** the read-only `game play dismiss-notification` inspection path
+  remains a direct-control notification dismissal read until a separate
+  accepted service read exists
+- **AND** focused CLI tests do not claim live Civ7 runtime proof
+
 #### Scenario: In-game controller bridge preflight is recorded
 - **WHEN** the in-game controller bridge is planned before source
   implementation

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -236,6 +236,25 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
   accepted service read exists
 - **AND** focused CLI tests do not claim live Civ7 runtime proof
 
+#### Scenario: CLI unit target send uses native unit procedure
+- **WHEN** `game play unit-target --send` requests an approved unit target
+  action
+- **THEN** the CLI constructs native control-oRPC context from endpoint flags
+  and approval reason
+- **AND** the send path calls the in-process `unit.target.action.request`
+  server-side client under the `unit` router
+- **AND** the procedure's approval, readiness, direct-control validator,
+  unit-target postcondition projection, and no-repeat policy remain
+  authoritative for the send
+- **AND** the normal JSON result is the semantic unit target action procedure
+  projection without raw command/session/state/Tuner details, send results,
+  before/after runtime probes, direct-control verification envelopes, or
+  legacy `verified`
+- **AND** the read-only `game play unit-target` planning path remains a
+  direct-control unit target action read until a separate accepted service read
+  exists
+- **AND** focused CLI tests do not claim live Civ7 runtime proof
+
 #### Scenario: In-game controller bridge preflight is recorded
 - **WHEN** the in-game controller bridge is planned before source
   implementation

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -199,6 +199,25 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** the adapter does not become an alternate product API or raw command
   tunnel
 
+#### Scenario: CLI end-turn send uses native turn procedure
+- **WHEN** `game play end-turn --send` requests an approved turn completion
+- **THEN** the CLI constructs native control-oRPC context from endpoint flags
+  and approval reason
+- **AND** the send path calls the in-process `turn.complete.request`
+  server-side client
+- **AND** the procedure's approval, readiness, direct-control guard, and
+  postcondition projection remain authoritative for the send
+- **AND** expected pre-send guard blocks project as semantic `not-sent`
+  turn-completion output with inspect/do-not-repeat next steps rather than
+  `TURN_COMPLETION_UNAVAILABLE`
+- **AND** the normal JSON result is the semantic turn-completion procedure
+  projection without raw command/session/state/Tuner details or legacy
+  `verified`
+- **AND** the read-only `game play end-turn` status path remains a
+  direct-control turn-completion status read until a separate accepted read
+  procedure exists
+- **AND** focused CLI tests do not claim live Civ7 runtime proof
+
 #### Scenario: In-game controller bridge preflight is recorded
 - **WHEN** the in-game controller bridge is planned before source
   implementation
@@ -405,6 +424,8 @@ modules before broad implementation.
 - **AND** the procedure consumes the direct-control turn-completion runtime
   port and turn-completion proof helper rather than inferring from legacy
   `verified`
+- **AND** expected direct-control guard-blocked requests are projected as
+  semantic `not-sent` output, not runtime unavailability
 - **AND** normal input is empty and endpoint, session, state, raw command, and
   approval fields remain context-owned
 - **AND** normal output projects before/after turn facts, postcondition

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -301,6 +301,31 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
   separate first-meet service procedure exists
 - **AND** focused CLI tests do not claim live Civ7 runtime proof
 
+#### Scenario: CLI narrative choice send uses native decision procedure
+- **WHEN** `game play choose-narrative --send` requests an approved narrative
+  story direction choice
+- **THEN** the CLI constructs native control-oRPC context from endpoint flags
+  and approval reason
+- **AND** the send path calls the in-process
+  `decisions.narrative.choice.request` server-side client under the
+  `decisions` router
+- **AND** the procedure's approval, readiness, direct-control narrative choice
+  port, narrative postcondition projection, and no-repeat policy remain
+  authoritative for the send
+- **AND** the send result uses direct-control source evidence for the acted
+  local player rather than treating the caller validation `--player-id` as send
+  authority
+- **AND** the normal JSON result is the semantic narrative choice procedure
+  projection without raw command/session/state/Tuner details, App UI closeout
+  payloads, panel/popup internals, direct-control runtime payloads, or legacy
+  `verified`
+- **AND** the read-only `game play choose-narrative --options` path remains a
+  direct-control notification/option read until a separate accepted service
+  read exists
+- **AND** the read-only validation path remains direct-control
+  player-operation validation until a separate accepted service read exists
+- **AND** focused CLI tests do not claim live Civ7 runtime proof
+
 #### Scenario: In-game controller bridge preflight is recorded
 - **WHEN** the in-game controller bridge is planned before source
   implementation
@@ -400,6 +425,9 @@ boundaries.
   runtime/proof ports rather than reimplementing postcondition truth
 - **AND** its normal output projects semantic status, validation summary,
   postcondition summary, and next steps
+- **AND** its normal output uses direct-control source evidence for the acted
+  player rather than echoing caller validation identity when runtime sends use
+  the local player
 - **AND** it excludes endpoint, session, state, raw command, payload, and
   legacy `verified` details from caller-facing input and output
 - **AND** unverified, stale, missing-postcondition, no-state-change, and

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -276,6 +276,31 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
   caller migration reconciles that convenience command
 - **AND** focused CLI tests do not claim live Civ7 runtime proof
 
+#### Scenario: CLI diplomacy response send uses native decision procedure
+- **WHEN** `game play respond-diplomacy --send` requests an approved diplomacy
+  response
+- **THEN** the CLI constructs native control-oRPC context from endpoint flags
+  and approval reason
+- **AND** the send path calls the in-process
+  `decisions.diplomacy.response.request` server-side client under the
+  `decisions` router
+- **AND** the procedure's approval, readiness, direct-control diplomacy
+  response port, diplomacy postcondition projection, and no-repeat policy
+  remain authoritative for the send
+- **AND** the send result uses direct-control source evidence for the acted
+  local player rather than treating the caller validation `--player-id` as send
+  authority
+- **AND** the normal JSON result is the semantic diplomacy response procedure
+  projection without raw command/session/state/Tuner details, UI closeout
+  payloads, diplomacy state internals, direct-control runtime payloads, or
+  legacy `verified`
+- **AND** the read-only `game play respond-diplomacy` validation path remains
+  direct-control player-operation validation until a separate accepted service
+  read exists
+- **AND** `game play respond-first-meet` remains outside this slice until a
+  separate first-meet service procedure exists
+- **AND** focused CLI tests do not claim live Civ7 runtime proof
+
 #### Scenario: In-game controller bridge preflight is recorded
 - **WHEN** the in-game controller bridge is planned before source
   implementation
@@ -391,6 +416,9 @@ boundaries.
   notification identity rather than direct-control UI toggles
 - **AND** its normal output projects semantic status, validation summary,
   postcondition summary, and next steps
+- **AND** its normal output uses direct-control source evidence for the acted
+  player rather than echoing caller validation identity when runtime sends use
+  the local player
 - **AND** it excludes endpoint, session, state, raw command, payload,
   notification internals, UI closeout internals, and legacy `verified` details
   from caller-facing input and output

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -421,6 +421,14 @@ adding more read-only facade shells.
     player-operation validation path for read-only mode, leave
     `game play respond-first-meet` outside this slice, and keep live runtime
     proof pending.
+  - [x] 7.1.7 Route `civ7 game play choose-narrative --send` through the
+    in-process `decisions.narrative.choice.request` server-side client under
+    the `decisions` router. Keep endpoint flags and approval reason as context
+    construction, emit the semantic narrative choice projection for send output
+    with direct-control acted/local-player evidence rather than treating
+    `--player-id` as send authority, preserve the existing direct-control
+    `--options` and player-operation validation paths for read-only mode, and
+    keep live runtime proof pending.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -549,3 +557,7 @@ adding more read-only facade shells.
 - [x] 8.29 Run focused CLI diplomacy response tests, `check:cli`,
   `test:cli:play`, relevant OpenSpec strict validates, and diff hygiene for
   the CLI diplomacy response send migration slice.
+- [x] 8.30 Run focused direct-control narrative request, control-oRPC
+  narrative decision, CLI narrative tests, `check:cli`, `test:cli:play`,
+  relevant OpenSpec strict validates, and diff hygiene for the CLI narrative
+  choice send migration slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -412,6 +412,15 @@ adding more read-only facade shells.
     output, preserve the existing direct-control operation validation path for
     read-only mode, leave `game play build-unit` outside this slice, and keep
     live runtime proof pending.
+  - [x] 7.1.6 Route `civ7 game play respond-diplomacy --send` through the
+    in-process `decisions.diplomacy.response.request` server-side client under
+    the `decisions` router. Keep endpoint flags and approval reason as context
+    construction, emit the semantic diplomacy response projection for send
+    output with direct-control acted/local-player evidence rather than treating
+    `--player-id` as send authority, preserve the existing direct-control
+    player-operation validation path for read-only mode, leave
+    `game play respond-first-meet` outside this slice, and keep live runtime
+    proof pending.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -537,3 +546,6 @@ adding more read-only facade shells.
 - [x] 8.28 Run focused CLI production tests, `check:cli`, `test:cli:play`,
   relevant OpenSpec strict validates, and diff hygiene for the CLI
   build-production send migration slice.
+- [x] 8.29 Run focused CLI diplomacy response tests, `check:cli`,
+  `test:cli:play`, relevant OpenSpec strict validates, and diff hygiene for
+  the CLI diplomacy response send migration slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -387,6 +387,12 @@ adding more read-only facade shells.
     `readiness.current` server-side client. Keep CLI endpoint flags as context
     construction, emit the semantic readiness projection, and keep raw
     direct-control playable-status internals out of normal status output.
+  - [x] 7.1.2 Route `civ7 game play end-turn --send` through the in-process
+    `turn.complete.request` server-side client. Keep endpoint flags and
+    approval reason as context construction, emit the semantic
+    turn-completion projection for send and expected guard-blocked `not-sent`
+    output, preserve the existing direct-control status read for check-only
+    mode, and keep live runtime proof pending.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -499,3 +505,7 @@ adding more read-only facade shells.
 - [x] 8.24 Run focused control-oRPC turn-completion procedure tests,
   control-oRPC package test/check/build, relevant OpenSpec strict validates,
   and diff hygiene for the native turn completion procedure slice.
+- [x] 8.25 Run focused direct-control request-result, control-oRPC turn
+  completion, and CLI end-turn tests, `check:cli`, `test:cli:play`, relevant
+  OpenSpec strict validates, and diff hygiene for the CLI turn-completion send
+  migration slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -405,6 +405,13 @@ adding more read-only facade shells.
     construction, emit the semantic unit target action projection for send
     output, preserve the existing direct-control unit target planning read for
     read-only mode, and keep live runtime proof pending.
+  - [x] 7.1.5 Route `civ7 game play build-production --send` through the
+    in-process `city.production.choice.request` server-side client under the
+    `city` router. Keep endpoint flags and approval reason as context
+    construction, emit the semantic city production choice projection for send
+    output, preserve the existing direct-control operation validation path for
+    read-only mode, leave `game play build-unit` outside this slice, and keep
+    live runtime proof pending.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -527,3 +534,6 @@ adding more read-only facade shells.
 - [x] 8.27 Run focused CLI unit target tests, `check:cli`, `test:cli:play`,
   relevant OpenSpec strict validates, and diff hygiene for the CLI unit target
   send migration slice.
+- [x] 8.28 Run focused CLI production tests, `check:cli`, `test:cli:play`,
+  relevant OpenSpec strict validates, and diff hygiene for the CLI
+  build-production send migration slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -381,8 +381,8 @@ adding more read-only facade shells.
 
 ## 7. Edge Adapters
 
-- [x] 7.1 Route one CLI caller through the in-process procedure client only
-  after the service-owned router shape is stable.
+- [x] 7.1 Route selected CLI callers through the in-process procedure client
+  only after the service-owned router shape is stable.
   - [x] 7.1.1 Route `civ7 game status` through the in-process
     `readiness.current` server-side client. Keep CLI endpoint flags as context
     construction, emit the semantic readiness projection, and keep raw
@@ -393,6 +393,12 @@ adding more read-only facade shells.
     turn-completion projection for send and expected guard-blocked `not-sent`
     output, preserve the existing direct-control status read for check-only
     mode, and keep live runtime proof pending.
+  - [x] 7.1.3 Route `civ7 game play dismiss-notification --send` through the
+    in-process `notifications.dismiss.request` server-side client. Keep
+    endpoint flags and approval reason as context construction, emit the
+    semantic notification dismissal projection for send output, preserve the
+    existing direct-control notification dismissal read for inspect-only mode,
+    and keep live runtime proof pending.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -509,3 +515,6 @@ adding more read-only facade shells.
   completion, and CLI end-turn tests, `check:cli`, `test:cli:play`, relevant
   OpenSpec strict validates, and diff hygiene for the CLI turn-completion send
   migration slice.
+- [x] 8.26 Run focused CLI notification dismissal tests, `check:cli`,
+  `test:cli:play`, relevant OpenSpec strict validates, and diff hygiene for
+  the CLI notification dismissal send migration slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -399,6 +399,12 @@ adding more read-only facade shells.
     semantic notification dismissal projection for send output, preserve the
     existing direct-control notification dismissal read for inspect-only mode,
     and keep live runtime proof pending.
+  - [x] 7.1.4 Route `civ7 game play unit-target --send` through the
+    in-process `unit.target.action.request` server-side client under the
+    `unit` router. Keep endpoint flags and approval reason as context
+    construction, emit the semantic unit target action projection for send
+    output, preserve the existing direct-control unit target planning read for
+    read-only mode, and keep live runtime proof pending.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -518,3 +524,6 @@ adding more read-only facade shells.
 - [x] 8.26 Run focused CLI notification dismissal tests, `check:cli`,
   `test:cli:play`, relevant OpenSpec strict validates, and diff hygiene for
   the CLI notification dismissal send migration slice.
+- [x] 8.27 Run focused CLI unit target tests, `check:cli`, `test:cli:play`,
+  relevant OpenSpec strict validates, and diff hygiene for the CLI unit target
+  send migration slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-build-production-orpc-send-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-build-production-orpc-send-slice.md
@@ -1,0 +1,45 @@
+# CLI Build Production oRPC Send Slice
+
+## Scope
+
+Route `civ7 game play build-production --send` through the native in-process
+`city.production.choice.request` server-side client under the `city` router.
+The CLI remains the shell-facing command owner; `packages/civ7-control-orpc`
+owns the semantic production choice send procedure; `@civ7/direct-control`
+remains the low-level runtime/proof port for production validation, closeout
+execution, post-read evidence, and production postcondition classification.
+
+The read-only `game play build-production` path remains direct-control
+operation validation. `game play build-unit` remains outside this slice because
+it is a separate convenience command over the older generic operation wrapper.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/build-production.ts`
+- `packages/cli/test/commands/game.play.production.test.ts`
+- This OpenSpec scenario/task/workstream record
+
+## Boundary
+
+- No Studio, controller bridge, RPCLink, OpenAPI, or transport work.
+- No direct-control procedure-core scaffolding.
+- No raw command/session/state/Tuner payloads, UI-closeout payloads, send
+  results, before/after runtime probes, production postcondition envelopes, or
+  legacy `verified` in normal send output.
+- No `game play build-unit` migration, production read procedure, or broad city
+  production catalog in this slice.
+- No play-thread wake and no live-game/runtime proof claim.
+- No parent Task 5.x/6.x/7.x acceptance by implication.
+
+## Proof
+
+- Focused CLI production tests prove the approved `build-production --send`
+  path reaches the existing direct-control production runtime command through
+  the in-process service client path, emits semantic
+  `city.production.choice.request` output, and keeps raw command/session/state,
+  UI-closeout payloads, runtime probes, direct-control production envelopes,
+  and legacy `verified` out of normal JSON.
+- Existing cleared and blocker-still-live fixtures continue to prove confirmed
+  and no-repeat guarded production outcomes in the CLI surface.
+- Closure still requires `check:cli`, `test:cli:play`, relevant strict
+  OpenSpec validates, diff hygiene, and a durable Graphite commit.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-diplomacy-response-orpc-send-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-diplomacy-response-orpc-send-slice.md
@@ -1,0 +1,59 @@
+# CLI Diplomacy Response oRPC Send Slice
+
+## Scope
+
+Route `civ7 game play respond-diplomacy --send` through the native in-process
+`decisions.diplomacy.response.request` server-side client under the
+`decisions` router. The CLI remains the shell-facing command owner;
+`packages/civ7-control-orpc` owns the semantic diplomacy response send
+procedure; `@civ7/direct-control` remains the low-level runtime/proof port for
+official UI closeout behavior, validation, post-read evidence, and diplomacy
+postcondition classification.
+
+The read-only `game play respond-diplomacy` path remains direct-control
+player-operation validation. `game play respond-first-meet` remains outside
+this slice because first-meet handling is a separate diplomacy capability.
+
+## Write Set
+
+- `packages/civ7-direct-control/src/play/operations/diplomacy-request.ts`
+- `packages/civ7-direct-control/test/diplomacy-response.test.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/procedures/diplomacy-response-request.ts`
+- `packages/civ7-control-orpc/test/decisions-diplomacy-response-procedure.test.ts`
+- `packages/cli/src/commands/game/play/respond-diplomacy.ts`
+- `packages/cli/test/commands/game.play.diplomacy-response.test.ts`
+- This OpenSpec scenario/task/workstream record
+
+## Boundary
+
+- Send output uses direct-control source evidence for the acted/local player.
+  The caller `--player-id` remains validation input and is not send authority
+  when official UI closeout uses `GameContext.localPlayerID`.
+- No Studio, controller bridge, RPCLink, OpenAPI, or transport work.
+- No direct-control procedure-core scaffolding.
+- No raw command/session/state/Tuner payloads, UI closeout payloads, activation
+  internals, diplomacy state internals, direct-control runtime payloads, or
+  legacy `verified` in normal send output.
+- No `game play respond-first-meet` migration, broad diplomacy catalog, or
+  hotseat/non-local send-player claim in this slice.
+- No play-thread wake and no live-game/runtime proof claim.
+- No parent Task 5.x/6.x/7.x acceptance by implication.
+
+## Proof
+
+- Focused direct-control diplomacy response tests prove the source-owned
+  request result carries top-level acted/local-player evidence from official
+  UI runtime reads: caller validation player `2` still returns and acts as
+  local player `0`.
+- Focused control-oRPC diplomacy response tests prove the service projection
+  reports source-owned acted-player evidence from the direct-control result
+  rather than echoing caller validation identity.
+- Focused CLI diplomacy response tests prove the approved
+  `respond-diplomacy --send` path reaches the existing direct-control official
+  UI closeout runtime command through the in-process service client path,
+  emits semantic `decisions.diplomacy.response.request` output, and keeps raw
+  command/session/state, UI closeout payloads, runtime payloads, diplomacy
+  internals, and legacy `verified` out of normal JSON.
+- Closure still requires relevant control-oRPC checks, `check:cli`,
+  `test:cli:play`, relevant strict OpenSpec validates, diff hygiene, and a
+  durable Graphite commit.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-end-turn-orpc-send-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-end-turn-orpc-send-slice.md
@@ -1,0 +1,42 @@
+# CLI End-Turn oRPC Send Slice
+
+## Scope
+
+Route `civ7 game play end-turn --send` through the native in-process
+`turn.complete.request` server-side client. The CLI remains the shell-facing
+command owner; `packages/civ7-control-orpc` owns the semantic send procedure;
+`@civ7/direct-control` remains the low-level runtime/proof port for the
+turn-completion guard, send command, and postcondition evidence.
+
+The check-only `game play end-turn` path remains the existing direct-control
+turn-completion status read. This slice does not invent a same-shaped read
+procedure only to wrap that status atom.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/end-turn.ts`
+- `packages/cli/test/commands/game.play.end-turn.test.ts`
+- This OpenSpec scenario/task/workstream record
+
+## Boundary
+
+- No Studio, controller bridge, RPCLink, OpenAPI, or transport work.
+- No direct-control procedure-core scaffolding.
+- No raw command/session/state/Tuner payloads or legacy `verified` in normal
+  send output.
+- No play-thread wake and no live-game/runtime proof claim.
+- No parent Task 5.x/6.x/7.x acceptance by implication.
+
+## Proof
+
+- Focused CLI test proves the approved send path reaches the real
+  `GameContext.sendTurnComplete()` runtime command only through the in-process
+  service client path, emits semantic `turn.complete.request` output, and keeps
+  raw command/session/state fields out of normal JSON.
+- Direct-control request-result and CLI blocked fixtures prove expected
+  pre-send guard blocks return semantic `not-sent` output with
+  inspect/do-not-repeat next steps while preventing sends for live blockers,
+  stale command-units with enabled closeouts, and still-front unit-loss
+  reports.
+- Closure still requires `check:cli`, `test:cli:play`, relevant strict
+  OpenSpec validates, diff hygiene, and a durable Graphite commit.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-narrative-choice-orpc-send-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-narrative-choice-orpc-send-slice.md
@@ -1,0 +1,60 @@
+# CLI Narrative Choice oRPC Send Slice
+
+## Scope
+
+Route `civ7 game play choose-narrative --send` through the native in-process
+`decisions.narrative.choice.request` server-side client under the `decisions`
+router. The CLI remains the shell-facing command owner;
+`packages/civ7-control-orpc` owns the semantic narrative choice send
+procedure; `@civ7/direct-control` remains the low-level runtime/proof port for
+official narrative UI closeout behavior, validation, post-read evidence, and
+narrative postcondition classification.
+
+The read-only `game play choose-narrative --options` path remains a
+direct-control notification/option read. The non-send validation path remains
+direct-control player-operation validation.
+
+## Write Set
+
+- `packages/civ7-direct-control/src/play/operations/narrative-request.ts`
+- `packages/civ7-direct-control/test/narrative-choice.test.ts`
+- `packages/civ7-control-orpc/src/modules/decisions/procedures/narrative-choice-request.ts`
+- `packages/civ7-control-orpc/test/decisions-narrative-choice-procedure.test.ts`
+- `packages/cli/src/commands/game/play/choose-narrative.ts`
+- `packages/cli/test/commands/game.play.narrative.test.ts`
+- This OpenSpec scenario/task/workstream record
+
+## Boundary
+
+- Send output uses direct-control source evidence for the acted/local player.
+  The caller `--player-id` remains validation input and is not send authority
+  when official UI closeout uses `GameContext.localPlayerID`.
+- No Studio, controller bridge, RPCLink, OpenAPI, or transport work.
+- No direct-control procedure-core scaffolding.
+- No raw command/session/state/Tuner payloads, App UI closeout payloads,
+  panel/popup internals, direct-control runtime payloads, or legacy `verified`
+  in normal send output.
+- No narrative options service read, broad decisions catalog, or hotseat or
+  non-local send-player claim in this slice.
+- No play-thread wake and no live-game/runtime proof claim.
+- No parent Task 5.x/6.x/7.x acceptance by implication.
+
+## Proof
+
+- Focused direct-control narrative choice tests prove the source-owned request
+  result carries top-level acted/local-player evidence from official UI runtime
+  reads: caller validation player `2` still returns and acts as local player
+  `0`.
+- Focused control-oRPC narrative choice tests prove the service projection
+  reports source-owned acted-player evidence from the direct-control result
+  rather than echoing caller validation identity.
+- Focused CLI narrative tests prove the approved `choose-narrative --send`
+  path accepts caller validation player `2`, reports source-owned acted/local
+  player `0`, reaches the existing direct-control official UI narrative
+  closeout runtime command through the in-process service client path, emits
+  semantic `decisions.narrative.choice.request` output, and keeps raw
+  command/session/state, App UI closeout payloads, runtime payloads, panel/
+  popup internals, and legacy `verified` out of normal JSON.
+- Closure still requires relevant direct-control/control-oRPC checks,
+  `check:cli`, `test:cli:play`, relevant strict OpenSpec validates, diff
+  hygiene, and a durable Graphite commit.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notification-dismissal-orpc-send-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notification-dismissal-orpc-send-slice.md
@@ -1,0 +1,41 @@
+# CLI Notification Dismissal oRPC Send Slice
+
+## Scope
+
+Route `civ7 game play dismiss-notification --send` through the native
+in-process `notifications.dismiss.request` server-side client. The CLI remains
+the shell-facing command owner; `packages/civ7-control-orpc` owns the semantic
+dismissal procedure; `@civ7/direct-control` remains the low-level
+runtime/proof port for notification dismissal reads, validation, closeout
+execution, and postcondition evidence.
+
+The inspect-only `game play dismiss-notification` path remains the existing
+direct-control notification dismissal read. This slice does not revive a
+facade-only notification read procedure.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/dismiss-notification.ts`
+- `packages/cli/test/commands/game/play/notification/dismiss.test.ts`
+- This OpenSpec scenario/task/workstream record
+
+## Boundary
+
+- No Studio, controller bridge, RPCLink, OpenAPI, or transport work.
+- No direct-control procedure-core scaffolding.
+- No raw command/session/state/Tuner payloads, route diagnostics, closeout
+  paths, verification attempts, or legacy `verified` in normal send output.
+- No play-thread wake and no live-game/runtime proof claim.
+- No parent Task 5.x/6.x/7.x acceptance by implication.
+
+## Proof
+
+- Focused CLI test proves the approved send path reaches the existing
+  direct-control notification dismissal runtime command through the in-process
+  service client path, emits semantic `notifications.dismiss.request` output,
+  and keeps raw command/session/state, route diagnostics, closeout path,
+  verification attempts, and legacy `verified` out of normal JSON.
+- Existing stale notification fixtures continue to prove engine-front-still-live
+  paths are sent-unverified and no-repeat guarded in the CLI surface.
+- Closure still requires `check:cli`, `test:cli:play`, relevant strict
+  OpenSpec validates, diff hygiene, and a durable Graphite commit.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-unit-target-orpc-send-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-unit-target-orpc-send-slice.md
@@ -1,0 +1,44 @@
+# CLI Unit Target oRPC Send Slice
+
+## Scope
+
+Route `civ7 game play unit-target --send` through the native in-process
+`unit.target.action.request` server-side client under the `unit` router. The
+CLI remains the shell-facing command owner; `packages/civ7-control-orpc` owns
+the semantic unit target action send procedure; `@civ7/direct-control` remains
+the low-level runtime/proof port for target-action planning, validator
+selection, send execution, bounded post-read, and unit-target postcondition
+evidence.
+
+The read-only `game play unit-target` path remains the existing direct-control
+unit target action planning read. This slice does not add a facade-only unit
+target read procedure.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/unit-target.ts`
+- `packages/cli/test/commands/game.play.unit-target.test.ts`
+- This OpenSpec scenario/task/workstream record
+
+## Boundary
+
+- No Studio, controller bridge, RPCLink, OpenAPI, or transport work.
+- No direct-control procedure-core scaffolding.
+- No raw command/session/state/Tuner payloads, send results, before/after
+  runtime probes, direct-control verification envelopes, or legacy `verified`
+  in normal send output.
+- No play-thread wake and no live-game/runtime proof claim.
+- No parent Task 5.x/6.x/7.x acceptance by implication.
+
+## Proof
+
+- Focused CLI test proves the approved send path reaches the existing
+  direct-control unit target runtime command through the in-process service
+  client path, emits semantic `unit.target.action.request` output, and keeps
+  raw command/session/state, send results, runtime probes, direct-control
+  verification envelopes, and legacy `verified` out of normal JSON.
+- Existing no-op, delayed postcondition, and path-shortfall fixtures continue
+  to prove unverified and no-repeat guarded unit target outcomes in the CLI
+  surface.
+- Closure still requires `check:cli`, `test:cli:play`, relevant strict
+  OpenSpec validates, diff hygiene, and a durable Graphite commit.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/narrative-choice-decision-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/narrative-choice-decision-slice.md
@@ -45,6 +45,8 @@ command wiring, or live-game/runtime proof claim.
   postcondition and no-repeat classification;
 - projects normal output as semantic choice status, validation summary,
   postcondition summary, and next steps;
+- projects acted player identity from source-owned direct-control runtime
+  evidence rather than echoing caller validation identity;
 - excludes endpoint host/port, state/session controls, raw command strings,
   raw payloads, and legacy `verified` details from procedure input and normal
   output.
@@ -71,6 +73,8 @@ Focused package proof covers:
 - approval is required before readiness and narrative request execution;
 - playable readiness middleware runs before direct-control request authority;
 - confirmed source-owned narrative postconditions project as sent-confirmed;
+- source-owned acted-player evidence is projected instead of caller validation
+  player identity when runtime sends use the local player;
 - validator-blocked and no-state-change paths remain guarded and do not infer
   repeat safety from legacy `verified`;
 - endpoint/session/state/raw command fields are rejected as procedure input;

--- a/openspec/changes/civ7-support-direct-control-modularization/tasks.md
+++ b/openspec/changes/civ7-support-direct-control-modularization/tasks.md
@@ -1726,6 +1726,13 @@ runtime/direct-control claims.
         proof, and leaving hotseat runtime proof, AI ingestion, CLI semantic
         projection, telemetry, Effect/oRPC procedure-core work, and Task 2.9.4
         matrix-row acceptance pending.
+  - [x] 4.13.9 Add a source-owned `requestCiv7TurnComplete` result port that
+        preserves the existing throwing `sendCiv7TurnComplete` compatibility
+        path while returning expected pre-send guard blocks as `sent:false`
+        turn-completion evidence, proving no command send occurs for guarded
+        blocks, and leaving hotseat runtime proof, AI ingestion, telemetry,
+        Effect/oRPC transport work, and Task 2.9.4 matrix-row acceptance
+        pending.
 - [x] 4.14 Extract setup/start lifecycle atoms.
   - [x] 4.14.1 Extract setup snapshot and setup map rows read/source owner while
         keeping public facade exports in `index.ts` and leaving

--- a/packages/civ7-control-orpc/src/dependencies/direct-control.ts
+++ b/packages/civ7-control-orpc/src/dependencies/direct-control.ts
@@ -6,7 +6,7 @@ import {
   getCiv7ReadyUnitView,
   getCiv7TargetCandidates,
   getCiv7TurnCompletionStatus,
-  sendCiv7TurnComplete,
+  requestCiv7TurnComplete,
   requestCiv7DiplomacyResponse,
   requestCiv7CultureChoiceCloseout,
   requestCiv7NarrativeChoice,
@@ -45,7 +45,7 @@ import {
   type Civ7TargetCandidatesInput,
   type Civ7TechnologyChoiceCloseoutInput,
   type Civ7TechnologyChoiceCloseoutResult,
-  type Civ7TurnCompletionActionResult,
+  type Civ7TurnCompletionRequestResult,
   type Civ7UnitTargetActionInput,
   type PlayNotificationViewOptions,
 } from "@civ7/direct-control";
@@ -60,8 +60,8 @@ export type Civ7ControlOrpcCultureChoiceCloseoutResult =
 export type Civ7ControlOrpcNarrativeChoiceResult = Civ7NarrativeChoiceResult;
 export type Civ7ControlOrpcTechnologyChoiceCloseoutResult =
   Civ7TechnologyChoiceCloseoutResult;
-export type Civ7ControlOrpcTurnCompletionActionResult =
-  Civ7TurnCompletionActionResult;
+export type Civ7ControlOrpcTurnCompletionRequestResult =
+  Civ7TurnCompletionRequestResult;
 type Civ7ControlOrpcPopulationPlacementRuntimeResult =
   Civ7PopulationPlacementProofSource & Readonly<{
     before: Readonly<{ valid: boolean }>;
@@ -144,7 +144,7 @@ export type Civ7ControlOrpcDirectControlFacade = Readonly<{
   requestCiv7TurnComplete(
     options: Civ7DirectControlOptions | undefined,
     approval: Civ7ActionApproval,
-  ): Promise<Civ7ControlOrpcTurnCompletionActionResult>;
+  ): Promise<Civ7ControlOrpcTurnCompletionRequestResult>;
   getCiv7PlayableStatus(
     options?: Civ7DirectControlOptions,
   ): Promise<Civ7ControlOrpcPlayableStatusResult>;
@@ -203,7 +203,7 @@ export const liveCiv7ControlOrpcDirectControlFacade:
       Civ7ControlOrpcUnitTargetActionResult
     >,
   requestCiv7TurnComplete: async (options, approval) =>
-    sendCiv7TurnComplete(options, approval),
+    requestCiv7TurnComplete(options, approval),
   getCiv7PlayableStatus: async (options) =>
     getCiv7PlayableStatus(options) as Promise<
       Civ7ControlOrpcPlayableStatusResult

--- a/packages/civ7-control-orpc/src/modules/decisions/procedures/diplomacy-response-request.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/procedures/diplomacy-response-request.ts
@@ -68,7 +68,7 @@ function diplomacyResponseResult(
   });
 
   return {
-    playerId: input.playerId,
+    playerId: result.playerId,
     actionId: input.actionId,
     responseType: input.responseType,
     ...(input.notificationId === undefined ? {} : { notificationId: input.notificationId }),

--- a/packages/civ7-control-orpc/src/modules/decisions/procedures/narrative-choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/decisions/procedures/narrative-choice-request.ts
@@ -68,7 +68,7 @@ function narrativeChoiceResult(
   });
 
   return {
-    playerId: input.playerId,
+    playerId: result.playerId,
     targetType: input.targetType,
     target: input.target,
     action: input.action,

--- a/packages/civ7-control-orpc/src/modules/turn/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/turn/contract.ts
@@ -20,6 +20,7 @@ export const Civ7TurnCompletionInputStandardSchema = toStandardSchema(
 );
 
 export const Civ7TurnCompletionRequestStatusSchema = Type.Union([
+  Type.Literal("not-sent"),
   Type.Literal("sent-confirmed"),
   Type.Literal("sent-guarded"),
   Type.Literal("sent-unverified"),
@@ -30,6 +31,7 @@ export const Civ7TurnCompletionPostconditionClassificationSchema = Type.Union(
     Type.Literal("turn-advanced"),
     Type.Literal("turn-complete-sent"),
     Type.Literal("already-complete"),
+    Type.Literal("turn-completion-blocked"),
     Type.Literal("no-state-change"),
     Type.Literal("missing-postcondition"),
     Type.Literal("pending-runtime-proof"),
@@ -39,6 +41,7 @@ export const Civ7TurnCompletionPostconditionClassificationSchema = Type.Union(
 export const Civ7TurnCompletionProofOutcomeSchema = Type.Union([
   Type.Literal("cleared"),
   Type.Literal("state-changed"),
+  Type.Literal("not-sent"),
   Type.Literal("no-state-change"),
   Type.Literal("unknown"),
 ]);
@@ -89,10 +92,10 @@ export const Civ7TurnCompletionNextStepSchema = Type.Object(
 
 export const Civ7TurnCompletionResultSchema = Type.Object(
   {
-    sent: Type.Literal(true),
+    sent: Type.Boolean(),
     status: Civ7TurnCompletionRequestStatusSchema,
     before: Civ7TurnCompletionProbeSummarySchema,
-    after: Civ7TurnCompletionProbeSummarySchema,
+    after: Type.Union([Civ7TurnCompletionProbeSummarySchema, Type.Null()]),
     postcondition: Civ7TurnCompletionPostconditionSummarySchema,
     nextSteps: Type.Array(Civ7TurnCompletionNextStepSchema),
   },

--- a/packages/civ7-control-orpc/src/modules/turn/procedures/complete-request.ts
+++ b/packages/civ7-control-orpc/src/modules/turn/procedures/complete-request.ts
@@ -4,7 +4,7 @@ import {
 } from "@civ7/direct-control";
 import { Effect } from "effect";
 
-import type { Civ7ControlOrpcTurnCompletionActionResult } from "../../../dependencies/direct-control";
+import type { Civ7ControlOrpcTurnCompletionRequestResult } from "../../../dependencies/direct-control";
 import { civ7MutationApprovalMiddleware } from "../../../middleware/mutation-approval";
 import { civ7MutationReadinessMiddleware } from "../../../middleware/mutation-readiness";
 import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
@@ -47,8 +47,10 @@ export const turnCompleteRequestProcedure =
   });
 
 function turnCompletionResult(
-  result: Civ7ControlOrpcTurnCompletionActionResult,
+  result: Civ7ControlOrpcTurnCompletionRequestResult,
 ): Civ7TurnCompletionResult {
+  if (!result.sent) return blockedTurnCompletionResult(result);
+
   const postcondition = turnCompletionPostconditionSummary(result);
   const status = turnCompletionRequestStatus(postcondition);
 
@@ -69,6 +71,43 @@ function turnCompletionResult(
   };
 }
 
+function blockedTurnCompletionResult(
+  result: Extract<Civ7ControlOrpcTurnCompletionRequestResult, { sent: false }>,
+): Civ7TurnCompletionResult {
+  const postcondition: Civ7TurnCompletionResult["postcondition"] = {
+    classification: "turn-completion-blocked",
+    reason: "Direct-control turn-completion guards blocked the request before command execution.",
+    outcome: "not-sent",
+    confidence: "unverified",
+    confirmed: false,
+    noRepeatAfterUnverified: true,
+  };
+  const status = civ7MutationRequestStatus({
+    sent: false,
+    postcondition,
+  });
+
+  return {
+    sent: false,
+    status,
+    before: turnCompletionProbeSummary(result.before),
+    after: null,
+    postcondition,
+    nextSteps: [
+      {
+        kind: "inspect-turn-completion",
+        source: "turn.complete.request",
+        label: "Inspect current turn completion blockers before attempting another turn completion request.",
+      },
+      {
+        kind: "do-not-repeat",
+        source: "turn.complete.request",
+        label: "Do not repeat turn completion until fresh turn and attention evidence is read.",
+      },
+    ],
+  };
+}
+
 function turnCompletionRequestStatus(
   postcondition: Civ7TurnCompletionResult["postcondition"],
 ): Civ7TurnCompletionResult["status"] {
@@ -83,7 +122,7 @@ function turnCompletionRequestStatus(
 }
 
 function turnCompletionPostconditionSummary(
-  result: Civ7ControlOrpcTurnCompletionActionResult,
+  result: Extract<Civ7ControlOrpcTurnCompletionRequestResult, { sent: true }>,
 ): Civ7TurnCompletionResult["postcondition"] {
   const postcondition = turnCompletionProofPostcondition(result, undefined);
   const confirmed = postcondition.confidence === "confirmed";
@@ -101,7 +140,7 @@ function turnCompletionPostconditionSummary(
 }
 
 function turnCompletionProbeSummary(
-  status: Civ7ControlOrpcTurnCompletionActionResult["before"],
+  status: Civ7ControlOrpcTurnCompletionRequestResult["before"],
 ): Civ7TurnCompletionResult["before"] {
   return {
     turn: probeValue(status.turn),

--- a/packages/civ7-control-orpc/test/decisions-diplomacy-response-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/decisions-diplomacy-response-procedure.test.ts
@@ -77,6 +77,25 @@ describe("decisions.diplomacy.response.request control-oRPC procedure", () => {
     expect(serialized).not.toContain("Game.PlayerOperations.sendRequest");
   });
 
+  test("projects source-owned acted player evidence instead of caller validation player", async () => {
+    const input = {
+      ...diplomacyInput,
+      playerId: 2,
+    };
+    const fake = fakeContext(diplomacyResponseResult("diplomacy-blocker-cleared", {
+      playerId: 0,
+    }));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.decisions.diplomacy.response.request,
+      input,
+      { context: fake.context },
+    );
+
+    expect(fake.calls.request[0]?.input).toEqual(input);
+    expect(result.playerId).toBe(0);
+  });
+
   test("keeps sent no-state-change diplomacy responses no-repeat guarded", async () => {
     const fake = fakeContext(diplomacyResponseResult("no-state-change", {
       afterValid: true,
@@ -314,6 +333,7 @@ function fakeContext(
 function diplomacyResponseResult(
   classification: Civ7ControlOrpcDiplomacyResponseResult["postcondition"]["classification"],
   options: Partial<{
+    playerId: number;
     sent: boolean;
     beforeValid: boolean;
     afterValid: boolean;
@@ -322,6 +342,7 @@ function diplomacyResponseResult(
 ): Civ7ControlOrpcDiplomacyResponseResult {
   const sent = options.sent ?? classification !== "not-sent";
   return {
+    playerId: options.playerId ?? diplomacyInput.playerId,
     before: {} as Civ7ControlOrpcDiplomacyResponseResult["before"],
     beforeValidation: {
       valid: options.beforeValid ?? classification !== "not-sent",

--- a/packages/civ7-control-orpc/test/decisions-narrative-choice-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/decisions-narrative-choice-procedure.test.ts
@@ -77,6 +77,25 @@ describe("decisions.narrative.choice.request control-oRPC procedure", () => {
     expect(serialized).not.toContain("Game.turn");
   });
 
+  test("projects source-owned acted player evidence instead of caller validation player", async () => {
+    const input = {
+      ...narrativeInput,
+      playerId: 2,
+    };
+    const fake = fakeContext(narrativeChoiceResult("narrative-blocker-cleared", {
+      playerId: 0,
+    }));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.decisions.narrative.choice.request,
+      input,
+      { context: fake.context },
+    );
+
+    expect(fake.calls.request[0]?.input).toEqual(input);
+    expect(result.playerId).toBe(0);
+  });
+
   test("keeps sent no-state-change narrative choices no-repeat guarded", async () => {
     const fake = fakeContext(narrativeChoiceResult("no-state-change", {
       afterValid: true,
@@ -312,6 +331,7 @@ function fakeContext(
 function narrativeChoiceResult(
   classification: Civ7ControlOrpcNarrativeChoiceResult["postcondition"]["classification"],
   options: Partial<{
+    playerId: number;
     sent: boolean;
     beforeValid: boolean;
     afterValid: boolean;
@@ -320,6 +340,7 @@ function narrativeChoiceResult(
 ): Civ7ControlOrpcNarrativeChoiceResult {
   const sent = options.sent ?? classification !== "not-sent";
   return {
+    playerId: options.playerId ?? narrativeInput.playerId,
     before: {} as Civ7ControlOrpcNarrativeChoiceResult["before"],
     beforeValidation: {
       valid: options.beforeValid ?? classification !== "not-sent",

--- a/packages/civ7-control-orpc/test/turn-completion-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/turn-completion-procedure.test.ts
@@ -12,7 +12,7 @@ import {
   type Civ7ControlOrpcContext,
   type Civ7TurnCompletionResult,
 } from "../src/index";
-import type { Civ7ControlOrpcTurnCompletionActionResult } from "../src/dependencies/direct-control";
+import type { Civ7ControlOrpcTurnCompletionRequestResult } from "../src/dependencies/direct-control";
 
 describe("turn.complete.request control-oRPC procedure", () => {
   test("owns the caller-facing turn completion input without runtime controls", () => {
@@ -175,6 +175,47 @@ describe("turn.complete.request control-oRPC procedure", () => {
     });
   });
 
+  test("projects expected guard-blocked turn completion as semantic not-sent output", async () => {
+    const fake = fakeContext(turnCompletionBlockedResult());
+
+    const result = await call(
+      Civ7ControlOrpcRouter.turn.complete.request,
+      {},
+      { context: fake.context },
+    );
+
+    expect(result).toMatchObject({
+      sent: false,
+      status: "not-sent",
+      before: {
+        turn: 12,
+        hasSentTurnComplete: false,
+        canEndTurn: false,
+        blocker: 0,
+        firstReadyUnitId: null,
+      },
+      after: null,
+      postcondition: {
+        classification: "turn-completion-blocked",
+        outcome: "not-sent",
+        confidence: "unverified",
+        confirmed: false,
+        noRepeatAfterUnverified: true,
+      },
+      nextSteps: [
+        {
+          kind: "inspect-turn-completion",
+          source: "turn.complete.request",
+        },
+        {
+          kind: "do-not-repeat",
+          source: "turn.complete.request",
+        },
+      ],
+    });
+    expectPublicResultOmitsRawRuntimeDetails(result);
+  });
+
   test("requires context approval before readiness and mutation ports run", async () => {
     const fake = fakeContext(turnCompletionActionResult({}), {
       approval: undefined,
@@ -280,7 +321,7 @@ function expectPublicResultOmitsRawRuntimeDetails(
 }
 
 function fakeContext(
-  resultOrError: Civ7ControlOrpcTurnCompletionActionResult | Error,
+  resultOrError: Civ7ControlOrpcTurnCompletionRequestResult | Error,
   options: Readonly<{
     approval?: Civ7ControlOrpcContext["approval"];
   }> = {},
@@ -330,9 +371,10 @@ function fakeContext(
 }
 
 function turnCompletionActionResult(
-  overrides: Partial<Civ7ControlOrpcTurnCompletionActionResult>,
-): Civ7ControlOrpcTurnCompletionActionResult {
+  overrides: Partial<Extract<Civ7ControlOrpcTurnCompletionRequestResult, { sent: true }>>,
+): Extract<Civ7ControlOrpcTurnCompletionRequestResult, { sent: true }> {
   return {
+    sent: true,
     before: turnCompletionStatus({ turn: 12, hasSentTurnComplete: false }),
     after: turnCompletionStatus({ turn: 12, hasSentTurnComplete: true }),
     command: {
@@ -345,15 +387,38 @@ function turnCompletionActionResult(
     },
     verified: true,
     ...overrides,
-  } as Civ7ControlOrpcTurnCompletionActionResult;
+  } as Extract<Civ7ControlOrpcTurnCompletionRequestResult, { sent: true }>;
+}
+
+function turnCompletionBlockedResult(): Extract<
+  Civ7ControlOrpcTurnCompletionRequestResult,
+  { sent: false }
+> {
+  return {
+    sent: false,
+    reason: "turn-completion-blocked",
+    before: turnCompletionStatus({
+      turn: 12,
+      hasSentTurnComplete: false,
+      canEndTurn: false,
+    }),
+    fallbackPreflight: {
+      notifications: [{
+        isEndTurnBlocking: true,
+        typeName: "NOTIFICATION_CHOOSE_TOWN_PROJECT",
+        decision: { category: "town-focus" },
+      }],
+    },
+  } as Extract<Civ7ControlOrpcTurnCompletionRequestResult, { sent: false }>;
 }
 
 function turnCompletionStatus(options: Readonly<{
   turn: number;
   hasSentTurnComplete: boolean;
+  canEndTurn?: boolean;
   turnOk?: boolean;
   hasSentTurnCompleteOk?: boolean;
-}>): Civ7ControlOrpcTurnCompletionActionResult["before"] {
+}>): Civ7ControlOrpcTurnCompletionRequestResult["before"] {
   return {
     host: "127.0.0.1",
     port: 4318,
@@ -366,7 +431,7 @@ function turnCompletionStatus(options: Readonly<{
     hasSentTurnComplete: options.hasSentTurnCompleteOk === false
       ? { ok: false, reason: "missing sent state" }
       : { ok: true, value: options.hasSentTurnComplete },
-    canEndTurn: { ok: true, value: true },
+    canEndTurn: { ok: true, value: options.canEndTurn ?? true },
     blocker: { ok: true, value: 0 },
     firstReadyUnitId: { ok: true, value: null },
   };

--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -788,6 +788,8 @@ export {
 } from "./play/autoplay.js";
 export type {
   Civ7TurnCompletionActionResult,
+  Civ7TurnCompletionBlockedResult,
+  Civ7TurnCompletionRequestResult,
   Civ7TurnCompletionStatusDependencies,
   Civ7TurnCompletionStatusInput,
   Civ7TurnCompletionStatusResult,
@@ -796,6 +798,7 @@ export {
   Civ7TurnCompletionStatusInputSchema,
   Civ7TurnCompletionStatusResultSchema,
   getCiv7TurnCompletionStatus,
+  requestCiv7TurnComplete,
   sendCiv7TurnComplete,
   sendCiv7TurnUnready,
 } from "./play/turn-completion.js";

--- a/packages/civ7-direct-control/src/play/operations/diplomacy-request.ts
+++ b/packages/civ7-direct-control/src/play/operations/diplomacy-request.ts
@@ -62,6 +62,7 @@ export type Civ7DiplomacyResponseCommandPayload = Readonly<{
 }>;
 
 export type Civ7DiplomacyResponseResult = Readonly<{
+  playerId: number;
   before: Civ7PlayNotificationViewResult;
   beforeValidation: Civ7OperationValidationResult;
   command?: Civ7CommandResult;
@@ -114,6 +115,7 @@ export async function requestCiv7DiplomacyResponse(
   const beforeValidation = await dependencies.canStartPlayerOperation(operationInput, options);
   if (!beforeValidation.valid) {
     return {
+      playerId,
       before,
       beforeValidation,
       after: before,
@@ -149,6 +151,7 @@ export async function requestCiv7DiplomacyResponse(
     afterValidation,
   );
   return {
+    playerId,
     before,
     beforeValidation,
     command,

--- a/packages/civ7-direct-control/src/play/operations/narrative-request.ts
+++ b/packages/civ7-direct-control/src/play/operations/narrative-request.ts
@@ -53,6 +53,7 @@ export type Civ7NarrativeChoiceCommandPayload = Readonly<{
 }>;
 
 export type Civ7NarrativeChoiceResult = Readonly<{
+  playerId: number;
   before: Civ7PlayNotificationViewResult;
   beforeValidation: Civ7OperationValidationResult;
   command?: Civ7CommandResult;
@@ -102,8 +103,9 @@ export async function requestCiv7NarrativeChoice(
   if (!Number.isInteger(input.action)) dependencies.invalidActionError();
 
   const before = await dependencies.getPlayNotificationView(options);
+  const playerId = before.localPlayerId;
   const operationInput = {
-    playerId: input.playerId,
+    playerId,
     operationType: "CHOOSE_NARRATIVE_STORY_DIRECTION",
     args: {
       TargetType: input.targetType,
@@ -114,6 +116,7 @@ export async function requestCiv7NarrativeChoice(
   const beforeValidation = await dependencies.canStartPlayerOperation(operationInput, options);
   if (!beforeValidation.valid) {
     return {
+      playerId,
       before,
       beforeValidation,
       after: before,
@@ -150,6 +153,7 @@ export async function requestCiv7NarrativeChoice(
     payload,
   );
   return {
+    playerId,
     before,
     beforeValidation,
     command,

--- a/packages/civ7-direct-control/src/play/turn-completion.ts
+++ b/packages/civ7-direct-control/src/play/turn-completion.ts
@@ -66,6 +66,17 @@ export type Civ7TurnCompletionActionResult = Readonly<{
   verified: boolean;
 }>;
 
+export type Civ7TurnCompletionBlockedResult = Readonly<{
+  sent: false;
+  before: Civ7TurnCompletionStatusResult;
+  fallbackPreflight?: Civ7PlayNotificationViewResult;
+  reason: "turn-completion-blocked";
+}>;
+
+export type Civ7TurnCompletionRequestResult =
+  | (Civ7TurnCompletionActionResult & Readonly<{ sent: true }>)
+  | Civ7TurnCompletionBlockedResult;
+
 export async function getCiv7TurnCompletionStatus(
   options: Civ7DirectControlOptions = {},
   dependencies: Civ7TurnCompletionStatusDependencies =
@@ -83,15 +94,35 @@ export async function sendCiv7TurnComplete(
   approval: Civ7ActionApproval,
   dependencies: TurnCompletionDependencies = defaultTurnCompletionDependencies,
 ): Promise<Civ7TurnCompletionActionResult> {
-  dependencies.assertApproved(approval, "sending Civ7 turn complete");
+  const result = await requestCiv7TurnComplete(options, approval, dependencies);
+  if (!result.sent) {
+    throw new Civ7DirectControlError("command-failed", "Civ7 turn complete is blocked by current game state", {
+      details: { before: result.before, fallbackPreflight: result.fallbackPreflight },
+    });
+  }
+  const { sent: _sent, ...action } = result;
+  return action;
+}
+
+export async function requestCiv7TurnComplete(
+  options: Civ7DirectControlOptions = {},
+  approval: Civ7ActionApproval,
+  dependencies: TurnCompletionDependencies = defaultTurnCompletionDependencies,
+): Promise<Civ7TurnCompletionRequestResult> {
+  dependencies.assertApproved(approval, "requesting Civ7 turn complete");
   const before = await getCiv7TurnCompletionStatus(options, dependencies);
   const fallbackPreflight = probeValue(before.canEndTurn) === true
     ? undefined
     : await dependencies.getPlayNotificationView(options);
   if (!isTurnCompletionAllowed(before, fallbackPreflight)) {
-    throw new Civ7DirectControlError("command-failed", "Civ7 turn complete is blocked by current game state", {
-      details: { before, fallbackPreflight },
-    });
+    return fallbackPreflight === undefined
+      ? { sent: false, before, reason: "turn-completion-blocked" }
+      : {
+          sent: false,
+          before,
+          fallbackPreflight,
+          reason: "turn-completion-blocked",
+        };
   }
   const command = await dependencies.executeAppUiCommand({
     ...options,
@@ -99,7 +130,7 @@ export async function sendCiv7TurnComplete(
   });
   const after = await getCiv7TurnCompletionStatus(options, dependencies);
   const verified = probeValue(after.hasSentTurnComplete) === true || probeValue(after.turn) !== probeValue(before.turn);
-  return { before, after, command, verified };
+  return { sent: true, before, after, command, verified };
 }
 
 export async function sendCiv7TurnUnready(

--- a/packages/civ7-direct-control/test/autoplay-and-turn.test.ts
+++ b/packages/civ7-direct-control/test/autoplay-and-turn.test.ts
@@ -9,6 +9,7 @@ import {
   configureCiv7Autoplay,
   getCiv7AutoplayStatus,
   getCiv7TurnCompletionStatus,
+  requestCiv7TurnComplete,
   sendCiv7TurnComplete,
   sendCiv7TurnUnready,
   startCiv7Autoplay,
@@ -53,6 +54,89 @@ describe("Civ7 autoplay and turn completion", () => {
     await expect(sendCiv7TurnUnready({}, undefined as never)).rejects.toMatchObject({
       code: "command-failed",
     });
+  });
+
+  test("returns guard-blocked turn completion requests without sending", async () => {
+    const calls: string[] = [];
+    const blockedStatus = turnCompletionStatusResult({
+      canEndTurn: { ok: true, value: false },
+    });
+    const dependencies = {
+      assertApproved: () => {},
+      executeAppUiCommand: async (options: { command: string }) => {
+        calls.push(options.command);
+        return commandResult();
+      },
+      getPlayNotificationView: async () => ({
+        notifications: [{
+          isEndTurnBlocking: true,
+          typeName: "NOTIFICATION_CHOOSE_TOWN_PROJECT",
+          canUserDismiss: false,
+          decision: { category: "town-focus" },
+        }],
+      }),
+      parseTurnCompletionStatus: () => blockedStatus,
+    };
+
+    const request = await requestCiv7TurnComplete({}, {
+      approved: true,
+      reason: "test blocked turn completion request",
+    }, dependencies as never);
+
+    expect(request).toMatchObject({
+      sent: false,
+      reason: "turn-completion-blocked",
+      before: {
+        canEndTurn: { ok: true, value: false },
+      },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("GameContext.hasSentTurnComplete");
+    expect(calls).not.toContain("GameContext.sendTurnComplete()");
+    await expect(sendCiv7TurnComplete({}, {
+      approved: true,
+      reason: "test blocked legacy turn completion send",
+    }, dependencies as never)).rejects.toMatchObject({
+      code: "command-failed",
+    });
+  });
+
+  test("returns sent turn completion request results after command execution", async () => {
+    const calls: string[] = [];
+    const statuses = [
+      turnCompletionStatusResult(),
+      turnCompletionStatusResult({
+        turn: { ok: true, value: 13 },
+        hasSentTurnComplete: { ok: true, value: true },
+      }),
+    ];
+    const dependencies = {
+      assertApproved: () => {},
+      executeAppUiCommand: async (options: { command: string }) => {
+        calls.push(options.command);
+        return commandResult();
+      },
+      getPlayNotificationView: async () => ({ notifications: [] }),
+      parseTurnCompletionStatus: () => statuses.shift() ?? turnCompletionStatusResult(),
+    };
+
+    const request = await requestCiv7TurnComplete({}, {
+      approved: true,
+      reason: "test sent turn completion request",
+    }, dependencies as never);
+
+    expect(request).toMatchObject({
+      sent: true,
+      verified: true,
+      before: {
+        turn: { ok: true, value: 12 },
+      },
+      after: {
+        turn: { ok: true, value: 13 },
+      },
+    });
+    expect(calls.some((command) => command.includes("GameContext.hasSentTurnComplete"))).toBe(true);
+    expect(calls).toContain("GameContext.sendTurnComplete()");
   });
 
   test("routes autoplay configure and explicit unbounded start through App UI commands", async () => {
@@ -245,7 +329,16 @@ describe("Civ7 autoplay and turn completion", () => {
   });
 });
 
-function turnCompletionStatusResult() {
+function commandResult() {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    output: ["null"],
+  };
+}
+
+function turnCompletionStatusResult(overrides: Record<string, unknown> = {}) {
   return {
     host: "127.0.0.1",
     port: 4318,
@@ -257,6 +350,7 @@ function turnCompletionStatusResult() {
     canEndTurn: { ok: true as const, value: true },
     blocker: { ok: true as const, value: 0 },
     firstReadyUnitId: { ok: true as const, value: null },
+    ...overrides,
   };
 }
 

--- a/packages/civ7-direct-control/test/diplomacy-response.test.ts
+++ b/packages/civ7-direct-control/test/diplomacy-response.test.ts
@@ -60,7 +60,7 @@ describe("diplomacy response requests", () => {
     try {
       const { port } = server.address();
       const request = await requestCiv7DiplomacyResponse(
-        { playerId: 0, actionId, responseType, notificationId },
+        { playerId: 2, actionId, responseType, notificationId },
         { host: "127.0.0.1", port, timeoutMs: 1_000 },
         { approved: true, reason: "test diplomacy response closeout" }
       );
@@ -71,6 +71,7 @@ describe("diplomacy response requests", () => {
         classification: "turn-unblocked",
         reason: "The response and UI closeout left the turn unblocked.",
       });
+      expect(request.playerId).toBe(0);
       expect(request.before.localPlayerId).toBe(0);
       expect(request.before.notifications).toEqual([
         expect.objectContaining({

--- a/packages/civ7-direct-control/test/narrative-choice.test.ts
+++ b/packages/civ7-direct-control/test/narrative-choice.test.ts
@@ -65,7 +65,7 @@ describe("narrative choice requests", () => {
       const { port } = server.address();
       const target = { owner: 0, id: 421, type: 24 };
       const request = await requestCiv7NarrativeChoice(
-        { playerId: 0, targetType: "CLOSE", target, action: 1 },
+        { playerId: 2, targetType: "CLOSE", target, action: 1 },
         { host: "127.0.0.1", port, timeoutMs: 1_000 },
         { approved: true, reason: "test narrative choice send" }
       );
@@ -75,6 +75,7 @@ describe("narrative choice requests", () => {
       expect(request.postcondition).toMatchObject({
         classification: "narrative-blocker-cleared",
       });
+      expect(request.playerId).toBe(0);
       expect(request.payload).toMatchObject({
         localPlayerId: 0,
         playerId: 0,
@@ -107,7 +108,7 @@ describe("narrative choice requests", () => {
       ]);
       expect(server.narrativeChoiceRequests).toEqual([
         {
-          input: { playerId: 0, targetType: "CLOSE", target, action: 1 },
+          input: { playerId: 2, targetType: "CLOSE", target, action: 1 },
           playerOperation: {
             playerId: 0,
             operationType: "CHOOSE_NARRATIVE_STORY_DIRECTION",
@@ -412,7 +413,7 @@ function parseNarrativeChoiceRequest(message: string): NarrativeChoiceRequest | 
   return {
     input,
     playerOperation: {
-      playerId: input.playerId,
+      playerId: 0,
       operationType: "CHOOSE_NARRATIVE_STORY_DIRECTION",
       args: {
         TargetType: input.targetType,

--- a/packages/cli/src/commands/game/play/build-production.ts
+++ b/packages/cli/src/commands/game/play/build-production.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from '@oclif/core';
-import { requestCiv7ProductionChoice } from '@civ7/direct-control';
+import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import {
   buildApproval,
   buildDirectControlOptions,
@@ -30,7 +31,7 @@ export default class GamePlayBuildProduction extends Command {
   static id = 'game play build-production';
   static summary = 'Validate or choose city production';
   static description =
-    'Wraps city-operation BUILD for unit, constructible, and project production choices after the live production chooser has provided the item id.';
+    'Validates city-operation BUILD choices, or sends production through the native control-oRPC city procedure when --send and --reason are explicit.';
 
   static examples = [
     '<%= config.bin %> game play build-production --city-id \'{"owner":0,"id":65536,"type":25}\' --unit-type 1558890441 --json',
@@ -97,7 +98,11 @@ export default class GamePlayBuildProduction extends Command {
     };
     const options = buildDirectControlOptions(typedFlags);
     const result = typedFlags.send
-      ? await requestCiv7ProductionChoice({ cityId: input.cityId, args: input.args }, options, buildApproval(reason))
+      ? await createCiv7ControlOrpcServerClient({
+          directControl: liveCiv7ControlOrpcDirectControlFacade,
+          endpointDefaults: options,
+          approval: buildApproval(reason),
+        }).city.production.choice.request({ cityId: input.cityId, args: input.args })
       : await validatePlayOperation('city-operation', input, options);
 
     emitPlayResult(this.log.bind(this), typedFlags.json, result);

--- a/packages/cli/src/commands/game/play/choose-narrative.ts
+++ b/packages/cli/src/commands/game/play/choose-narrative.ts
@@ -1,5 +1,7 @@
 import { Command, Flags } from '@oclif/core';
-import { getCiv7PlayNotificationView, requestCiv7NarrativeChoice } from '@civ7/direct-control';
+import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
+import { getCiv7PlayNotificationView } from '@civ7/direct-control';
 import {
   buildApproval,
   buildDirectControlOptions,
@@ -15,7 +17,7 @@ export default class GamePlayChooseNarrative extends Command {
   static id = 'game play choose-narrative';
   static summary = 'Validate or choose a narrative story direction';
   static description =
-    'Wraps player-operation CHOOSE_NARRATIVE_STORY_DIRECTION with the live story target, target type, action, and official narrative UI close handling.';
+    'Validates narrative story direction choices as player operations, or sends them through the native control-oRPC decision procedure when --send and --reason are explicit.';
 
   static examples = [
     '<%= config.bin %> game play choose-narrative --options --json',
@@ -112,12 +114,16 @@ export default class GamePlayChooseNarrative extends Command {
       },
     };
     const result = flags.send
-      ? await requestCiv7NarrativeChoice({
+      ? await createCiv7ControlOrpcServerClient({
+          directControl: liveCiv7ControlOrpcDirectControlFacade,
+          endpointDefaults: options,
+          approval: buildApproval(reason),
+        }).decisions.narrative.choice.request({
           playerId: flags['player-id'],
           targetType: flags['target-type'],
           target,
           action: flags.action,
-        }, options, buildApproval(reason))
+        })
       : await validatePlayOperation('player-operation', input, options);
 
     emitPlayResult(this.log.bind(this), flags.json, result);

--- a/packages/cli/src/commands/game/play/dismiss-notification.ts
+++ b/packages/cli/src/commands/game/play/dismiss-notification.ts
@@ -1,0 +1,69 @@
+import { Command, Flags } from '@oclif/core';
+import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
+import {
+  getCiv7NotificationDismissal,
+} from '@civ7/direct-control';
+import {
+  buildApproval,
+  buildDirectControlOptions,
+  emitPlayResult,
+  parseComponentId,
+  requireSendReason,
+} from '../../../utils/game-play-shared';
+
+export default class GamePlayDismissNotification extends Command {
+  static id = 'game play dismiss-notification';
+  static summary = 'Inspect or dismiss a reviewed notification';
+  static description =
+    'Reads a notification through App UI state and optionally dismisses it through the native control-oRPC notification procedure when --send and --reason are explicit.';
+
+  static examples = [
+    '<%= config.bin %> game play dismiss-notification --target \'{"owner":0,"id":113,"type":20}\' --json',
+    '<%= config.bin %> game play dismiss-notification --target \'{"owner":0,"id":113,"type":20}\' --send --reason "reviewed wonder completed notice" --json',
+  ];
+
+  static flags = {
+    host: Flags.string({
+      description: 'Civ7 tuner socket host',
+    }),
+    port: Flags.integer({
+      description: 'Civ7 tuner socket port',
+    }),
+    target: Flags.string({
+      description: 'Notification ComponentID JSON',
+      required: true,
+    }),
+    send: Flags.boolean({
+      description: 'Dismiss the notification when canUserDismiss is true',
+      default: false,
+    }),
+    reason: Flags.string({
+      description: 'Required approval reason for --send',
+    }),
+    'timeout-ms': Flags.integer({
+      description: 'Socket timeout',
+      default: 45_000,
+    }),
+    json: Flags.boolean({
+      description: 'Emit machine-readable JSON',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(GamePlayDismissNotification);
+    const reason = requireSendReason(flags.send, flags.reason, 'game play dismiss-notification');
+    const input = { notificationId: parseComponentId(flags.target, 'target') };
+    const options = buildDirectControlOptions(flags);
+    const result = flags.send
+      ? await createCiv7ControlOrpcServerClient({
+          directControl: liveCiv7ControlOrpcDirectControlFacade,
+          endpointDefaults: options,
+          approval: buildApproval(reason),
+        }).notifications.dismiss.request(input)
+      : await getCiv7NotificationDismissal(input, options);
+
+    emitPlayResult(this.log.bind(this), flags.json, result);
+  }
+}

--- a/packages/cli/src/commands/game/play/end-turn.ts
+++ b/packages/cli/src/commands/game/play/end-turn.ts
@@ -1,0 +1,56 @@
+import { Command, Flags } from '@oclif/core';
+import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
+import { getCiv7TurnCompletionStatus } from '@civ7/direct-control';
+import { buildApproval, buildDirectControlOptions, emitPlayResult, requireSendReason } from '../../../utils/game-play-shared';
+
+export default class GamePlayEndTurn extends Command {
+  static id = 'game play end-turn';
+  static summary = 'Check or send Civ7 end turn';
+  static description =
+    'Reads the direct-control turn completion guard first, then optionally sends turn complete through the native control-oRPC turn procedure when --send and --reason are explicit.';
+
+  static examples = [
+    '<%= config.bin %> game play end-turn --json',
+    '<%= config.bin %> game play end-turn --send --reason "manual live-play turn handoff" --json',
+  ];
+
+  static flags = {
+    host: Flags.string({
+      description: 'Civ7 tuner socket host',
+    }),
+    port: Flags.integer({
+      description: 'Civ7 tuner socket port',
+    }),
+    send: Flags.boolean({
+      description: 'Send GameContext.sendTurnComplete() after direct-control guard approval',
+      default: false,
+    }),
+    reason: Flags.string({
+      description: 'Required approval reason for --send',
+    }),
+    'timeout-ms': Flags.integer({
+      description: 'Socket timeout',
+      default: 45_000,
+    }),
+    json: Flags.boolean({
+      description: 'Emit machine-readable JSON',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(GamePlayEndTurn);
+    const reason = requireSendReason(flags.send, flags.reason, 'game play end-turn');
+    const options = buildDirectControlOptions(flags);
+    const result = flags.send
+      ? await createCiv7ControlOrpcServerClient({
+          directControl: liveCiv7ControlOrpcDirectControlFacade,
+          endpointDefaults: options,
+          approval: buildApproval(reason ?? ''),
+        }).turn.complete.request({})
+      : await getCiv7TurnCompletionStatus(options);
+
+    emitPlayResult(this.log.bind(this), flags.json, result);
+  }
+}

--- a/packages/cli/src/commands/game/play/respond-diplomacy.ts
+++ b/packages/cli/src/commands/game/play/respond-diplomacy.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from '@oclif/core';
-import { requestCiv7DiplomacyResponse } from '@civ7/direct-control';
+import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import {
   buildApproval,
   buildDirectControlOptions,
@@ -15,7 +16,7 @@ export default class GamePlayRespondDiplomacy extends Command {
   static id = 'game play respond-diplomacy';
   static summary = 'Validate or send a diplomacy response';
   static description =
-    'Wraps player-operation RESPOND_DIPLOMATIC_ACTION with the live diplomatic action ID and response Type.';
+    'Validates diplomacy responses as player operations, or sends them through the native control-oRPC decision procedure when --send and --reason are explicit.';
 
   static examples = [
     '<%= config.bin %> game play respond-diplomacy --player-id 0 --action-id 56 --response-type -1907089594 --json',
@@ -67,18 +68,16 @@ export default class GamePlayRespondDiplomacy extends Command {
     const reason = requireSendReason(flags.send, flags.reason, 'game play respond-diplomacy');
     const options = buildDirectControlOptions(flags);
     if (flags.send) {
-      const result = await requestCiv7DiplomacyResponse(
-        {
-          playerId: flags['player-id'],
-          actionId: flags['action-id'],
-          responseType: flags['response-type'],
-          ...(flags['notification-id'] ? { notificationId: parseComponentId(flags['notification-id'], 'notification-id') } : {}),
-          activateNotification: true,
-          uiCloseout: true,
-        },
-        options,
-        buildApproval(reason),
-      );
+      const result = await createCiv7ControlOrpcServerClient({
+        directControl: liveCiv7ControlOrpcDirectControlFacade,
+        endpointDefaults: options,
+        approval: buildApproval(reason),
+      }).decisions.diplomacy.response.request({
+        playerId: flags['player-id'],
+        actionId: flags['action-id'],
+        responseType: flags['response-type'],
+        ...(flags['notification-id'] ? { notificationId: parseComponentId(flags['notification-id'], 'notification-id') } : {}),
+      });
       emitPlayResult(this.log.bind(this), flags.json, result);
       return;
     }

--- a/packages/cli/src/commands/game/play/unit-target.ts
+++ b/packages/cli/src/commands/game/play/unit-target.ts
@@ -1,7 +1,8 @@
 import { Command, Flags } from '@oclif/core';
+import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import {
   getCiv7UnitTargetAction,
-  requestCiv7UnitTargetAction,
 } from '@civ7/direct-control';
 import {
   buildApproval,
@@ -15,7 +16,7 @@ export default class GamePlayUnitTarget extends Command {
   static id = 'game play unit-target';
   static summary = 'Resolve a unit plot target through the official right-click action order';
   static description =
-    'Plans or sends a unit target action by trying the same high-level order as WorldInput: naval, air, ranged, overrun, swap, then move.';
+    'Plans a unit target action through direct-control, or sends it through the native control-oRPC unit procedure when --send and --reason are explicit.';
 
   static examples = [
     '<%= config.bin %> game play unit-target --unit-id \'{"owner":0,"id":65536,"type":26}\' --x 23 --y 33 --json',
@@ -68,7 +69,11 @@ export default class GamePlayUnitTarget extends Command {
     };
     const options = buildDirectControlOptions(flags);
     const result = flags.send
-      ? await requestCiv7UnitTargetAction(input, options, buildApproval(reason))
+      ? await createCiv7ControlOrpcServerClient({
+          directControl: liveCiv7ControlOrpcDirectControlFacade,
+          endpointDefaults: options,
+          approval: buildApproval(reason),
+        }).unit.target.action.request(input)
       : await getCiv7UnitTargetAction(input, options);
 
     emitPlayResult(this.log.bind(this), flags.json, result);

--- a/packages/cli/test/commands/game.play.diplomacy-response.test.ts
+++ b/packages/cli/test/commands/game.play.diplomacy-response.test.ts
@@ -85,20 +85,28 @@ describe('game play diplomacy response commands', () => {
 
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
-        result: {
-          sent: boolean;
-          verified: boolean;
-          payload: { playerId: number; notificationId: { id: number }; uiCloseout: { requested: boolean } };
-          postcondition: { classification: string; reason: string };
-        };
+        result: DiplomacyResponseSendResult;
       };
       expect(payload.result.sent).toBe(true);
-      expect(payload.result.verified).toBe(true);
-      expect(payload.result.payload.playerId).toBe(0);
-      expect(payload.result.payload.notificationId.id).toBe(19);
-      expect(payload.result.payload.uiCloseout.requested).toBe(true);
+      expect(payload.result.status).toBe('sent-confirmed');
+      expect(payload.result.playerId).toBe(0);
+      expect(payload.result.actionId).toBe(8);
+      expect(payload.result.responseType).toBe(926305338);
+      expect(payload.result.notificationId).toEqual({ owner: 0, id: 19, type: 20 });
+      expect(payload.result.validation).toEqual({ beforeValid: true, afterValid: true });
       expect(payload.result.postcondition.classification).toBe('turn-unblocked');
       expect(payload.result.postcondition.reason).toContain('turn unblocked');
+      expect(payload.result.postcondition).toMatchObject({
+        outcome: 'cleared',
+        confidence: 'confirmed',
+        confirmed: true,
+        noRepeatAfterUnverified: false,
+      });
+      expect(payload.result.nextSteps[0]).toMatchObject({
+        kind: 'refresh-attention',
+        source: 'decisions.diplomacy.response.request',
+      });
+      expectSemanticDiplomacyResponseOmitsRawRuntimeDetails(payload.result);
       expect(server.received.some((message) => message.includes('sendDiplomacyResponseCloseout'))).toBe(true);
       expect(server.received.some((message) => message.includes('GameContext.localPlayerID'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation("player-operation"'))).toBe(false);
@@ -116,6 +124,42 @@ type CommandClass = {
   prototype: { log(message?: string): void };
 };
 
+type DiplomacyResponseSendResult = {
+  playerId: number;
+  actionId: number;
+  responseType: number;
+  notificationId?: { owner: number; id: number; type: number };
+  sent: boolean;
+  status: string;
+  validation: { beforeValid: boolean; afterValid: boolean };
+  postcondition: {
+    classification: string;
+    reason: string;
+    outcome: string;
+    confidence: string;
+    confirmed: boolean;
+    noRepeatAfterUnverified: boolean;
+  };
+  nextSteps: Array<{ kind: string; source: string; label: string }>;
+};
+
+function expectSemanticDiplomacyResponseOmitsRawRuntimeDetails(result: unknown) {
+  const serialized = JSON.stringify(result);
+  expect(serialized).not.toContain('"host"');
+  expect(serialized).not.toContain('"port"');
+  expect(serialized).not.toContain('"state"');
+  expect(serialized).not.toContain('"session"');
+  expect(serialized).not.toContain('"rawCommand"');
+  expect(serialized).not.toContain('"command"');
+  expect(serialized).not.toContain('"payload"');
+  expect(serialized).not.toContain('"verified"');
+  expect(serialized).not.toContain('"uiCloseout"');
+  expect(serialized).not.toContain('"diplomacyState"');
+  expect(serialized).not.toContain('"activationResult"');
+  expect(serialized).not.toContain('Game.PlayerOperations');
+  expect(serialized).not.toContain('sendDiplomacyResponseCloseout');
+}
+
 async function runCommand(command: CommandClass, args: string[]) {
   const log = vi.spyOn(command.prototype, 'log').mockImplementation(() => {});
   try {
@@ -131,6 +175,12 @@ async function startDiplomacyResponseTunerServer(options: {
   let diplomacyCloseoutObserved = false;
   return startFakeTunerServer({
     handle({ message }) {
+      if (message.includes('Network.isInSession')) {
+        return [JSON.stringify(appUiSnapshot())];
+      }
+      if (message.includes('evalOk') && message.includes('GameplayMap.getGridWidth')) {
+        return [JSON.stringify(tunerHealthSnapshot())];
+      }
       if (message.includes('readPlayNotifications')) {
         return [JSON.stringify(playNotificationView(
           options.playNotificationMode ?? 'stale-diplomacy',
@@ -147,6 +197,84 @@ async function startDiplomacyResponseTunerServer(options: {
       return undefined;
     },
   });
+}
+
+function appUiSnapshot() {
+  return {
+    network: {
+      isInSession: { ok: true, value: true },
+      numPlayers: { ok: true, value: 1 },
+      hostPlayerId: { ok: true, value: 0 },
+      isConnectedToNetwork: { ok: true, value: true },
+      isAuthenticated: { ok: true, value: false },
+      isLoggedIn: { ok: true, value: true },
+    },
+    autoplay: {
+      isActive: false,
+      turns: -1,
+      isPaused: false,
+      isPausedOrPending: false,
+      observeAsPlayer: -1,
+      returnAsPlayer: -1,
+    },
+    game: {
+      turn: 1,
+      age: 0,
+      maxTurns: 0,
+      turnDate: { ok: true, value: '4000 BCE' },
+      hash: { ok: true, value: 0 },
+    },
+    ui: {
+      inGame: { ok: true, value: true },
+      inShell: { ok: true, value: false },
+      inLoading: { ok: true, value: false },
+      loadingState: { ok: true, value: 6 },
+      loadingStateName: 'WaitingForUIReady',
+      canBeginGame: { ok: true, value: true },
+      canNotifyUIReady: 'function',
+      skipStartButton: { ok: true, value: false },
+      automationActive: { ok: true, value: false },
+    },
+    gameContext: {
+      localPlayerID: 0,
+      localObserverID: 0,
+      hasRequestedPause: { ok: true, value: false },
+    },
+    players: {
+      maxPlayers: 64,
+      aliveIds: { ok: true, value: [0] },
+      aliveHumanIds: { ok: true, value: [0] },
+      numAliveHumans: { ok: true, value: 1 },
+    },
+    map: {
+      width: { ok: true, value: 84 },
+      height: { ok: true, value: 54 },
+      plotCount: { ok: true, value: 4536 },
+      mapSize: { ok: true, value: 0 },
+      randomSeed: { ok: true, value: 1 },
+    },
+  };
+}
+
+function tunerHealthSnapshot() {
+  return {
+    evalOk: 2,
+    ready: true,
+    globals: {
+      Game: 'object',
+      Autoplay: 'object',
+      GameplayMap: 'object',
+      Players: 'object',
+      Network: 'undefined',
+    },
+    turn: { ok: true, value: 1 },
+    turnDate: { ok: true, value: '4000 BCE' },
+    width: { ok: true, value: 84 },
+    height: { ok: true, value: 54 },
+    aliveIds: { ok: true, value: [0] },
+    aliveHumanIds: { ok: true, value: [0] },
+    autoplayActive: { ok: true, value: false },
+  };
 }
 
 function operationValidation(message: string) {

--- a/packages/cli/test/commands/game.play.end-turn.test.ts
+++ b/packages/cli/test/commands/game.play.end-turn.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import GamePlayEndTurn from '../../src/commands/game/play/end-turn';
 import { type FakeTunerServer, startFakeTunerServer } from './fixtures/tuner-socket-server';
 
@@ -20,6 +20,10 @@ describe('game play end-turn command', () => {
     await expect(GamePlayEndTurn.run(['--send', '--json'])).rejects.toThrow(/requires --reason/);
 
     const server = await startEndTurnTunerServer();
+    const writes: string[] = [];
+    const log = vi.spyOn(GamePlayEndTurn.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
     try {
       const { port } = server.address();
       await GamePlayEndTurn.run([
@@ -34,7 +38,37 @@ describe('game play end-turn command', () => {
       ]);
 
       expect(server.received).toContain('CMD:65535:GameContext.sendTurnComplete()');
+      const payload = JSON.parse(writes.join('')) as {
+        ok: true;
+        result: {
+          sent: true;
+          status: string;
+          postcondition: { classification: string };
+          nextSteps: Array<{ kind: string; source: string }>;
+        };
+      };
+      expect(payload).toMatchObject({
+        ok: true,
+        result: {
+          sent: true,
+          status: 'sent-confirmed',
+          postcondition: {
+            classification: 'turn-advanced',
+          },
+          nextSteps: [{
+            kind: 'refresh-attention',
+            source: 'turn.complete.request',
+          }],
+        },
+      });
+      expect(JSON.stringify(payload)).not.toContain('"host"');
+      expect(JSON.stringify(payload)).not.toContain('"port"');
+      expect(JSON.stringify(payload)).not.toContain('"state"');
+      expect(JSON.stringify(payload)).not.toContain('"command"');
+      expect(JSON.stringify(payload)).not.toContain('"verified"');
+      expect(JSON.stringify(payload)).not.toContain('GameContext.sendTurnComplete');
     } finally {
+      log.mockRestore();
       await server.close();
     }
   });
@@ -43,7 +77,7 @@ describe('game play end-turn command', () => {
     const server = await startEndTurnTunerServer({ canEndTurnBefore: false });
     try {
       const { port } = server.address();
-      await expect(GamePlayEndTurn.run([
+      const payload = await runGamePlayEndTurnJson([
         '--host',
         '127.0.0.1',
         '--port',
@@ -52,8 +86,9 @@ describe('game play end-turn command', () => {
         '--reason',
         'test approved end-turn',
         '--json',
-      ])).rejects.toThrow(/blocked by current game state/);
+      ]);
 
+      expectBlockedTurnCompletionPayload(payload);
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received).not.toContain('CMD:65535:GameContext.sendTurnComplete()');
     } finally {
@@ -68,7 +103,7 @@ describe('game play end-turn command', () => {
     });
     try {
       const { port } = server.address();
-      await expect(GamePlayEndTurn.run([
+      const payload = await runGamePlayEndTurnJson([
         '--host',
         '127.0.0.1',
         '--port',
@@ -77,8 +112,9 @@ describe('game play end-turn command', () => {
         '--reason',
         'test blocked because a unit closeout exists',
         '--json',
-      ])).rejects.toThrow(/blocked by current game state/);
+      ]);
 
+      expectBlockedTurnCompletionPayload(payload);
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received).not.toContain('CMD:65535:GameContext.sendTurnComplete()');
     } finally {
@@ -143,7 +179,7 @@ describe('game play end-turn command', () => {
     });
     try {
       const { port } = server.address();
-      await expect(GamePlayEndTurn.run([
+      const payload = await runGamePlayEndTurnJson([
         '--host',
         '127.0.0.1',
         '--port',
@@ -152,8 +188,9 @@ describe('game play end-turn command', () => {
         '--reason',
         'test blocked unit-lost report end-turn',
         '--json',
-      ])).rejects.toThrow(/blocked by current game state/);
+      ]);
 
+      expectBlockedTurnCompletionPayload(payload);
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received).not.toContain('CMD:65535:GameContext.sendTurnComplete()');
     } finally {
@@ -161,6 +198,69 @@ describe('game play end-turn command', () => {
     }
   });
 });
+
+async function runGamePlayEndTurnJson(args: string[]) {
+  const writes: string[] = [];
+  const log = vi.spyOn(GamePlayEndTurn.prototype, 'log').mockImplementation((message?: string) => {
+    if (message) writes.push(message);
+  });
+  try {
+    await GamePlayEndTurn.run(args);
+    return JSON.parse(writes.join('')) as {
+      ok: true;
+      result: {
+        sent: boolean;
+        status: string;
+        after: unknown;
+        postcondition: {
+          classification: string;
+          outcome: string;
+          confidence: string;
+          noRepeatAfterUnverified: boolean;
+        };
+        nextSteps: Array<{ kind: string; source: string }>;
+      };
+    };
+  } finally {
+    log.mockRestore();
+  }
+}
+
+function expectBlockedTurnCompletionPayload(
+  payload: Awaited<ReturnType<typeof runGamePlayEndTurnJson>>,
+) {
+  expect(payload).toMatchObject({
+    ok: true,
+    result: {
+      sent: false,
+      status: 'not-sent',
+      after: null,
+      postcondition: {
+        classification: 'turn-completion-blocked',
+        outcome: 'not-sent',
+        confidence: 'unverified',
+        noRepeatAfterUnverified: true,
+      },
+      nextSteps: [
+        {
+          kind: 'inspect-turn-completion',
+          source: 'turn.complete.request',
+        },
+        {
+          kind: 'do-not-repeat',
+          source: 'turn.complete.request',
+        },
+      ],
+    },
+  });
+  const serialized = JSON.stringify(payload);
+  expect(serialized).not.toContain('"host"');
+  expect(serialized).not.toContain('"port"');
+  expect(serialized).not.toContain('"state"');
+  expect(serialized).not.toContain('"command"');
+  expect(serialized).not.toContain('"verified"');
+  expect(serialized).not.toContain('GameContext.sendTurnComplete');
+}
 
 type EndTurnNotificationMode =
   | 'blocking-choice'
@@ -178,6 +278,12 @@ async function startEndTurnTunerServer(options: {
     handle({ message }) {
       if (message.includes('readPlayNotifications')) {
         return [JSON.stringify(endTurnNotificationView(options.playNotificationMode ?? 'blocking-choice'))];
+      }
+      if (message.includes('Network.isInSession')) {
+        return [JSON.stringify(appUiSnapshot())];
+      }
+      if (message.includes('evalOk') && message.includes('GameplayMap.getGridWidth')) {
+        return [JSON.stringify(tunerHealthSnapshot())];
       }
       if (message.includes('hasSentTurnComplete')) {
         return [JSON.stringify(turnCompletionStatus(turnCompleteSent, options.canEndTurnBefore ?? true))];
@@ -390,6 +496,84 @@ function notificationView(input: {
       decisionQueue: [queueItem],
     },
     limits: { maxNotifications: 25, truncated: false },
+  };
+}
+
+function appUiSnapshot() {
+  return {
+    network: {
+      isInSession: { ok: true, value: true },
+      numPlayers: { ok: true, value: 1 },
+      hostPlayerId: { ok: true, value: 0 },
+      isConnectedToNetwork: { ok: true, value: true },
+      isAuthenticated: { ok: true, value: false },
+      isLoggedIn: { ok: true, value: true },
+    },
+    autoplay: {
+      isActive: false,
+      turns: -1,
+      isPaused: false,
+      isPausedOrPending: false,
+      observeAsPlayer: -1,
+      returnAsPlayer: -1,
+    },
+    game: {
+      turn: 1,
+      age: 0,
+      maxTurns: 0,
+      turnDate: { ok: true, value: '4000 BCE' },
+      hash: { ok: true, value: 0 },
+    },
+    ui: {
+      inGame: { ok: true, value: true },
+      inShell: { ok: true, value: false },
+      inLoading: { ok: true, value: false },
+      loadingState: { ok: true, value: 6 },
+      loadingStateName: 'WaitingForUIReady',
+      canBeginGame: { ok: true, value: true },
+      canNotifyUIReady: 'function',
+      skipStartButton: { ok: true, value: false },
+      automationActive: { ok: true, value: false },
+    },
+    gameContext: {
+      localPlayerID: 0,
+      localObserverID: 0,
+      hasRequestedPause: { ok: true, value: false },
+    },
+    players: {
+      maxPlayers: 64,
+      aliveIds: { ok: true, value: [0] },
+      aliveHumanIds: { ok: true, value: [0] },
+      numAliveHumans: { ok: true, value: 1 },
+    },
+    map: {
+      width: { ok: true, value: 84 },
+      height: { ok: true, value: 54 },
+      plotCount: { ok: true, value: 4536 },
+      mapSize: { ok: true, value: 0 },
+      randomSeed: { ok: true, value: 1 },
+    },
+  };
+}
+
+function tunerHealthSnapshot() {
+  return {
+    evalOk: 2,
+    ready: true,
+    globals: {
+      Game: 'object',
+      Autoplay: 'object',
+      GameplayMap: 'object',
+      Players: 'object',
+      Network: 'undefined',
+    },
+    turn: { ok: true, value: 1 },
+    turnDate: { ok: true, value: '4000 BCE' },
+    width: { ok: true, value: 84 },
+    height: { ok: true, value: 54 },
+    aliveIds: { ok: true, value: [0] },
+    aliveHumanIds: { ok: true, value: [0] },
+    autoplayActive: { ok: true, value: false },
   };
 }
 

--- a/packages/cli/test/commands/game.play.narrative.test.ts
+++ b/packages/cli/test/commands/game.play.narrative.test.ts
@@ -13,7 +13,7 @@ describe('game play narrative commands', () => {
         '--port',
         String(port),
         '--player-id',
-        '0',
+        '2',
         '--target-type',
         'TOT_30001B',
         '--target',
@@ -47,7 +47,7 @@ describe('game play narrative commands', () => {
         '--port',
         String(port),
         '--player-id',
-        '0',
+        '2',
         '--target-type',
         'DISCOVERY_14001B',
         '--target',
@@ -62,18 +62,27 @@ describe('game play narrative commands', () => {
 
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
-        result: {
-          sent: boolean;
-          verified: boolean;
-          postcondition: { classification: string };
-          payload: { ui: { panelClose: unknown; popupClose: unknown } };
-        };
+        result: NarrativeChoiceSendResult;
       };
       expect(payload.result.sent).toBe(true);
-      expect(payload.result.verified).toBe(true);
+      expect(payload.result.status).toBe('sent-confirmed');
+      expect(payload.result.playerId).toBe(0);
+      expect(payload.result.targetType).toBe('DISCOVERY_14001B');
+      expect(payload.result.target).toEqual({ owner: 0, id: 25, type: 35 });
+      expect(payload.result.action).toBe(-1326475004);
+      expect(payload.result.validation).toEqual({ beforeValid: true, afterValid: true });
       expect(payload.result.postcondition.classification).toBe('narrative-blocker-cleared');
-      expect(payload.result.payload.ui.panelClose).toEqual({ ok: true, value: { attempted: 1, results: [{ panelType: 'SMALL-NARRATIVE-EVENT', closed: true }] } });
-      expect(payload.result.payload.ui.popupClose).toEqual({ ok: true, value: { available: true } });
+      expect(payload.result.postcondition).toMatchObject({
+        outcome: 'cleared',
+        confidence: 'confirmed',
+        confirmed: true,
+        noRepeatAfterUnverified: false,
+      });
+      expect(payload.result.nextSteps[0]).toMatchObject({
+        kind: 'refresh-attention',
+        source: 'decisions.narrative.choice.request',
+      });
+      expectSemanticNarrativeChoiceOmitsRawRuntimeDetails(payload.result);
       expect(server.received.some((message) => message.includes('sendNarrativeChoice'))).toBe(true);
       expect(server.received.some((message) => message.includes('NarrativePopupManager.closePopup'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation("player-operation"'))).toBe(false);
@@ -117,16 +126,23 @@ describe('game play narrative commands', () => {
 
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
-        result: {
-          sent: boolean;
-          verified: boolean;
-          postcondition: { classification: string; reason: string };
-        };
+        result: NarrativeChoiceSendResult;
       };
       expect(payload.result.sent).toBe(true);
-      expect(payload.result.verified).toBe(false);
+      expect(payload.result.status).toBe('sent-unverified');
       expect(payload.result.postcondition.classification).toBe('no-state-change');
       expect(payload.result.postcondition.reason).toContain('same narrative blocker remained live');
+      expect(payload.result.postcondition).toMatchObject({
+        outcome: 'no-state-change',
+        confidence: 'unverified',
+        confirmed: false,
+        noRepeatAfterUnverified: true,
+      });
+      expect(payload.result.nextSteps[0]).toMatchObject({
+        kind: 'do-not-repeat',
+        source: 'decisions.narrative.choice.request',
+      });
+      expectSemanticNarrativeChoiceOmitsRawRuntimeDetails(payload.result);
       expect(server.received.some((message) => message.includes('sendNarrativeChoice'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation("player-operation"'))).toBe(false);
     } finally {
@@ -169,18 +185,14 @@ describe('game play narrative commands', () => {
 
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
-        result: {
-          sent: boolean;
-          verified: boolean;
-          postcondition: { classification: string; reason: string };
-          payload: { ui: { after: { matchingPanelCount: number } } };
-        };
+        result: NarrativeChoiceSendResult;
       };
       expect(payload.result.sent).toBe(true);
-      expect(payload.result.payload.ui.after.matchingPanelCount).toBe(0);
-      expect(payload.result.verified).toBe(false);
+      expect(payload.result.status).toBe('sent-unverified');
       expect(payload.result.postcondition.classification).toBe('no-state-change');
       expect(payload.result.postcondition.reason).toContain('same narrative blocker remained live');
+      expect(payload.result.postcondition.noRepeatAfterUnverified).toBe(true);
+      expectSemanticNarrativeChoiceOmitsRawRuntimeDetails(payload.result);
       expect(server.received.some((message) => message.includes('sendNarrativeChoice'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation("player-operation"'))).toBe(false);
     } finally {
@@ -343,6 +355,43 @@ type CommandClass = {
   prototype: { log(message?: string): void };
 };
 
+type NarrativeChoiceSendResult = {
+  playerId: number;
+  targetType: string;
+  target: { owner: number; id: number; type?: number };
+  action: number;
+  sent: boolean;
+  status: string;
+  validation: { beforeValid: boolean; afterValid: boolean };
+  postcondition: {
+    classification: string;
+    reason: string;
+    outcome: string;
+    confidence: string;
+    confirmed: boolean;
+    noRepeatAfterUnverified: boolean;
+  };
+  nextSteps: Array<{ kind: string; source: string; label: string }>;
+};
+
+function expectSemanticNarrativeChoiceOmitsRawRuntimeDetails(result: unknown) {
+  const serialized = JSON.stringify(result);
+  expect(serialized).not.toContain('"host"');
+  expect(serialized).not.toContain('"port"');
+  expect(serialized).not.toContain('"state"');
+  expect(serialized).not.toContain('"session"');
+  expect(serialized).not.toContain('"rawCommand"');
+  expect(serialized).not.toContain('"command"');
+  expect(serialized).not.toContain('"payload"');
+  expect(serialized).not.toContain('"verified"');
+  expect(serialized).not.toContain('"ui"');
+  expect(serialized).not.toContain('"sendResult"');
+  expect(serialized).not.toContain('"panelClose"');
+  expect(serialized).not.toContain('"popupClose"');
+  expect(serialized).not.toContain('Game.PlayerOperations');
+  expect(serialized).not.toContain('sendNarrativeChoice');
+}
+
 type PlayNotificationMode = 'narrative-choice' | 'narrative-choice-empty' | 'narrative-choice-visible-panel' | 'ready-unit';
 type NarrativeChoiceMode = 'panel-cleared' | 'panel-cleared-blocker-live' | 'stale';
 
@@ -362,6 +411,12 @@ async function startNarrativeTunerServer(options: {
   let narrativeChoiceSent = false;
   return startFakeTunerServer({
     handle({ message }) {
+      if (message.includes('Network.isInSession')) {
+        return [JSON.stringify(appUiSnapshot())];
+      }
+      if (message.includes('evalOk') && message.includes('GameplayMap.getGridWidth')) {
+        return [JSON.stringify(tunerHealthSnapshot())];
+      }
       if (message.includes('readPlayNotifications')) {
         const playMode = options.playNotificationMode === 'narrative-choice-visible-panel'
           && narrativeChoiceSent
@@ -380,6 +435,84 @@ async function startNarrativeTunerServer(options: {
       return undefined;
     },
   });
+}
+
+function appUiSnapshot() {
+  return {
+    network: {
+      isInSession: { ok: true, value: true },
+      numPlayers: { ok: true, value: 1 },
+      hostPlayerId: { ok: true, value: 0 },
+      isConnectedToNetwork: { ok: true, value: true },
+      isAuthenticated: { ok: true, value: false },
+      isLoggedIn: { ok: true, value: true },
+    },
+    autoplay: {
+      isActive: false,
+      turns: -1,
+      isPaused: false,
+      isPausedOrPending: false,
+      observeAsPlayer: -1,
+      returnAsPlayer: -1,
+    },
+    game: {
+      turn: 8,
+      age: 0,
+      maxTurns: 0,
+      turnDate: { ok: true, value: '3825 BCE' },
+      hash: { ok: true, value: 0 },
+    },
+    ui: {
+      inGame: { ok: true, value: true },
+      inShell: { ok: true, value: false },
+      inLoading: { ok: true, value: false },
+      loadingState: { ok: true, value: 6 },
+      loadingStateName: 'WaitingForUIReady',
+      canBeginGame: { ok: true, value: true },
+      canNotifyUIReady: 'function',
+      skipStartButton: { ok: true, value: false },
+      automationActive: { ok: true, value: false },
+    },
+    gameContext: {
+      localPlayerID: 0,
+      localObserverID: 0,
+      hasRequestedPause: { ok: true, value: false },
+    },
+    players: {
+      maxPlayers: 64,
+      aliveIds: { ok: true, value: [0] },
+      aliveHumanIds: { ok: true, value: [0] },
+      numAliveHumans: { ok: true, value: 1 },
+    },
+    map: {
+      width: { ok: true, value: 84 },
+      height: { ok: true, value: 54 },
+      plotCount: { ok: true, value: 4536 },
+      mapSize: { ok: true, value: 0 },
+      randomSeed: { ok: true, value: 1 },
+    },
+  };
+}
+
+function tunerHealthSnapshot() {
+  return {
+    evalOk: 2,
+    ready: true,
+    globals: {
+      Game: 'object',
+      Autoplay: 'object',
+      GameplayMap: 'object',
+      Players: 'object',
+      Network: 'undefined',
+    },
+    turn: { ok: true, value: 8 },
+    turnDate: { ok: true, value: '3825 BCE' },
+    width: { ok: true, value: 84 },
+    height: { ok: true, value: 54 },
+    aliveIds: { ok: true, value: [0] },
+    aliveHumanIds: { ok: true, value: [0] },
+    autoplayActive: { ok: true, value: false },
+  };
 }
 
 function playNotificationView(mode: PlayNotificationMode = 'narrative-choice') {

--- a/packages/cli/test/commands/game.play.production.test.ts
+++ b/packages/cli/test/commands/game.play.production.test.ts
@@ -67,18 +67,27 @@ describe('game play production commands', () => {
 
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
-        result: {
-          sent: boolean;
-          verified: boolean;
-          productionPostcondition: { classification: string };
-          payload: { ui: { cityActivation: { ok: boolean }; interfaceClose: { ok: boolean } } };
-        };
+        result: ProductionChoiceSendResult;
       };
       expect(payload.result.sent).toBe(true);
-      expect(payload.result.verified).toBe(true);
-      expect(payload.result.productionPostcondition.classification).toBe('production-choice-cleared');
-      expect(payload.result.payload.ui.cityActivation.ok).toBe(true);
-      expect(payload.result.payload.ui.interfaceClose.ok).toBe(true);
+      expect(payload.result.status).toBe('sent-confirmed');
+      expect(payload.result.cityId).toEqual({ owner: 0, id: 65536, type: 1 });
+      expect(payload.result.args).toEqual({ ConstructibleType: 713967338, X: 22, Y: 31 });
+      expect(payload.result.validation).toEqual({ beforeValid: true, afterValid: true });
+      expect(payload.result.postcondition).toMatchObject({
+        classification: 'production-choice-cleared',
+        outcome: 'cleared',
+        confidence: 'confirmed',
+        confirmed: true,
+        noRepeatAfterUnverified: false,
+        productionStateChanged: true,
+        blockerStillLive: false,
+      });
+      expect(payload.result.nextSteps[0]).toMatchObject({
+        kind: 'refresh-attention',
+        source: 'city.production.choice.request',
+      });
+      expectSemanticProductionChoiceOmitsRawRuntimeDetails(payload.result);
       expect(server.received.some((message) => message.includes('BUILD'))).toBe(true);
       expect(server.received.some((message) => message.includes('"ConstructibleType":713967338'))).toBe(true);
       expect(server.received.some((message) => message.includes('"X":22'))).toBe(true);
@@ -118,23 +127,25 @@ describe('game play production commands', () => {
 
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
-        result: {
-          verified: boolean;
-          productionPostcondition: {
-            classification: string;
-            productionStateChanged: boolean;
-            blockerStillLive: boolean;
-            reason: string;
-          };
-        };
+        result: ProductionChoiceSendResult;
       };
-      expect(payload.result.verified).toBe(false);
-      expect(payload.result.productionPostcondition).toMatchObject({
+      expect(payload.result.sent).toBe(true);
+      expect(payload.result.status).toBe('sent-unverified');
+      expect(payload.result.postcondition).toMatchObject({
         classification: 'production-state-changed-blocker-still-live',
+        outcome: 'still-blocked',
+        confidence: 'unverified',
+        confirmed: false,
+        noRepeatAfterUnverified: true,
         productionStateChanged: true,
         blockerStillLive: true,
       });
-      expect(payload.result.productionPostcondition.reason).toContain('production-choice notification still blocks');
+      expect(payload.result.postcondition.reason).toContain('production-choice notification still blocks');
+      expect(payload.result.nextSteps[0]).toMatchObject({
+        kind: 'do-not-repeat',
+        source: 'city.production.choice.request',
+      });
+      expectSemanticProductionChoiceOmitsRawRuntimeDetails(payload.result);
     } finally {
       log.mockRestore();
       await server.close();
@@ -150,6 +161,45 @@ describe('game play production commands', () => {
   });
 });
 
+type ProductionChoiceSendResult = {
+  cityId: { owner: number; id: number; type: number };
+  args: Record<string, number>;
+  sent: boolean;
+  status: string;
+  validation: { beforeValid: boolean; afterValid: boolean };
+  postcondition: {
+    classification: string;
+    reason: string;
+    outcome: string;
+    confidence: string;
+    confirmed: boolean;
+    noRepeatAfterUnverified: boolean;
+    productionStateChanged: boolean | null;
+    blockerStillLive: boolean | null;
+  };
+  nextSteps: Array<{ kind: string; source: string; label: string }>;
+};
+
+function expectSemanticProductionChoiceOmitsRawRuntimeDetails(result: unknown) {
+  const serialized = JSON.stringify(result);
+  expect(serialized).not.toContain('"host"');
+  expect(serialized).not.toContain('"port"');
+  expect(serialized).not.toContain('"state"');
+  expect(serialized).not.toContain('"session"');
+  expect(serialized).not.toContain('"rawCommand"');
+  expect(serialized).not.toContain('"command"');
+  expect(serialized).not.toContain('"payload"');
+  expect(serialized).not.toContain('"sendResult"');
+  expect(serialized).not.toContain('"verified"');
+  expect(serialized).not.toContain('"beforeProductionPostcondition"');
+  expect(serialized).not.toContain('"afterProductionPostcondition"');
+  expect(serialized).not.toContain('"productionPostcondition"');
+  expect(serialized).not.toContain('"ui"');
+  expect(serialized).not.toContain('Game.CityOperations');
+  expect(serialized).not.toContain('UI?.Player?.selectCity');
+  expect(serialized).not.toContain('InterfaceMode?.switchToDefault');
+}
+
 type ProductionTunerServer = FakeTunerServer;
 
 async function startProductionTunerServer(options: {
@@ -158,6 +208,12 @@ async function startProductionTunerServer(options: {
   let productionChoiceSent = false;
   return startFakeTunerServer({
     handle({ message }) {
+      if (message.includes('Network.isInSession')) {
+        return [JSON.stringify(appUiSnapshot())];
+      }
+      if (message.includes('evalOk') && message.includes('GameplayMap.getGridWidth')) {
+        return [JSON.stringify(tunerHealthSnapshot())];
+      }
       if (message.includes('readProductionChoice')) {
         const send = message.includes('"send":true');
         if (send) productionChoiceSent = true;
@@ -180,6 +236,84 @@ async function startProductionTunerServer(options: {
       return undefined;
     },
   });
+}
+
+function appUiSnapshot() {
+  return {
+    network: {
+      isInSession: { ok: true, value: true },
+      numPlayers: { ok: true, value: 1 },
+      hostPlayerId: { ok: true, value: 0 },
+      isConnectedToNetwork: { ok: true, value: true },
+      isAuthenticated: { ok: true, value: false },
+      isLoggedIn: { ok: true, value: true },
+    },
+    autoplay: {
+      isActive: false,
+      turns: -1,
+      isPaused: false,
+      isPausedOrPending: false,
+      observeAsPlayer: -1,
+      returnAsPlayer: -1,
+    },
+    game: {
+      turn: 1,
+      age: 0,
+      maxTurns: 0,
+      turnDate: { ok: true, value: '4000 BCE' },
+      hash: { ok: true, value: 0 },
+    },
+    ui: {
+      inGame: { ok: true, value: true },
+      inShell: { ok: true, value: false },
+      inLoading: { ok: true, value: false },
+      loadingState: { ok: true, value: 6 },
+      loadingStateName: 'WaitingForUIReady',
+      canBeginGame: { ok: true, value: true },
+      canNotifyUIReady: 'function',
+      skipStartButton: { ok: true, value: false },
+      automationActive: { ok: true, value: false },
+    },
+    gameContext: {
+      localPlayerID: 0,
+      localObserverID: 0,
+      hasRequestedPause: { ok: true, value: false },
+    },
+    players: {
+      maxPlayers: 64,
+      aliveIds: { ok: true, value: [0] },
+      aliveHumanIds: { ok: true, value: [0] },
+      numAliveHumans: { ok: true, value: 1 },
+    },
+    map: {
+      width: { ok: true, value: 84 },
+      height: { ok: true, value: 54 },
+      plotCount: { ok: true, value: 4536 },
+      mapSize: { ok: true, value: 0 },
+      randomSeed: { ok: true, value: 1 },
+    },
+  };
+}
+
+function tunerHealthSnapshot() {
+  return {
+    evalOk: 2,
+    ready: true,
+    globals: {
+      Game: 'object',
+      Autoplay: 'object',
+      GameplayMap: 'object',
+      Players: 'object',
+      Network: 'undefined',
+    },
+    turn: { ok: true, value: 1 },
+    turnDate: { ok: true, value: '4000 BCE' },
+    width: { ok: true, value: 84 },
+    height: { ok: true, value: 54 },
+    aliveIds: { ok: true, value: [0] },
+    aliveHumanIds: { ok: true, value: [0] },
+    autoplayActive: { ok: true, value: false },
+  };
 }
 
 function operationValidation(message: string) {

--- a/packages/cli/test/commands/game.play.unit-target.test.ts
+++ b/packages/cli/test/commands/game.play.unit-target.test.ts
@@ -56,13 +56,33 @@ describe('game play unit target command', () => {
 
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
-        result: { sent: boolean; verified: boolean; verification: { status: string; classification: string; reason: string } };
+        result: UnitTargetActionSendResult;
       };
       expect(payload.result.sent).toBe(true);
-      expect(payload.result.verified).toBe(false);
-      expect(payload.result.verification.status).toBe('no-state-change');
-      expect(payload.result.verification.classification).toBe('no-state-change');
-      expect(payload.result.verification.reason).toMatch(/re-read .*before repeating/);
+      expect(payload.result.status).toBe('sent-unverified');
+      expect(payload.result.validation).toMatchObject({
+        candidateCount: 1,
+        acceptedCandidateCount: 1,
+        selected: {
+          family: 'unit-operation',
+          operationType: 'UNITOPERATION_RANGE_ATTACK',
+          valid: true,
+          targetInReturnedPlots: true,
+          rejectedReason: null,
+        },
+      });
+      expect(payload.result.postcondition).toMatchObject({
+        classification: 'no-state-change',
+        outcome: 'no-state-change',
+        confidence: 'unverified',
+        confirmed: false,
+        noRepeatAfterUnverified: true,
+      });
+      expect(payload.result.nextSteps[0]).toMatchObject({
+        kind: 'do-not-repeat',
+        source: 'unit.target.action.request',
+      });
+      expectSemanticUnitTargetOmitsRawRuntimeDetails(payload.result);
       expect(server.received.some((message) => message.includes('"send":true'))).toBe(true);
     } finally {
       log.mockRestore();
@@ -97,15 +117,23 @@ describe('game play unit target command', () => {
 
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
-        result: { sent: boolean; verified: boolean; verification: { status: string; classification: string; source: string; attempts: number; reason: string } };
+        result: UnitTargetActionSendResult;
       };
       expect(payload.result.sent).toBe(true);
-      expect(payload.result.verified).toBe(true);
-      expect(payload.result.verification.status).toBe('verified');
-      expect(payload.result.verification.classification).toBe('unit-state-changed');
-      expect(payload.result.verification.source).toBe('bounded-poll');
-      expect(payload.result.verification.attempts).toBeGreaterThan(0);
-      expect(payload.result.verification.reason).toMatch(/bounded post-send polling/);
+      expect(payload.result.status).toBe('sent-confirmed');
+      expect(payload.result.postcondition).toMatchObject({
+        classification: 'unit-state-changed',
+        outcome: 'state-changed',
+        confidence: 'confirmed',
+        confirmed: true,
+        noRepeatAfterUnverified: false,
+        source: 'bounded-poll',
+      });
+      expect(payload.result.nextSteps[0]).toMatchObject({
+        kind: 'refresh-attention',
+        source: 'unit.target.action.request',
+      });
+      expectSemanticUnitTargetOmitsRawRuntimeDetails(payload.result);
       expect(server.received.filter((message) => message.includes('readUnitTargetAction')).length).toBeGreaterThan(1);
     } finally {
       log.mockRestore();
@@ -140,25 +168,25 @@ describe('game play unit target command', () => {
 
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
-        result: {
-          verified: boolean;
-          verification: {
-            status: string;
-            classification: string;
-            destinationReached: boolean;
-            requestedLocation: { x: number; y: number };
-            landedLocation: { x: number; y: number };
-            reason: string;
-          };
-        };
+        result: UnitTargetActionSendResult;
       };
-      expect(payload.result.verified).toBe(true);
-      expect(payload.result.verification.status).toBe('verified');
-      expect(payload.result.verification.classification).toBe('path-shortfall');
-      expect(payload.result.verification.destinationReached).toBe(false);
-      expect(payload.result.verification.requestedLocation).toEqual({ x: 23, y: 33 });
-      expect(payload.result.verification.landedLocation).toEqual({ x: 22, y: 34 });
-      expect(payload.result.verification.reason).toMatch(/landed short/);
+      expect(payload.result.sent).toBe(true);
+      expect(payload.result.status).toBe('sent-guarded');
+      expect(payload.result.postcondition).toMatchObject({
+        classification: 'path-shortfall',
+        outcome: 'state-changed',
+        confidence: 'confirmed',
+        confirmed: true,
+        noRepeatAfterUnverified: true,
+        destinationReached: false,
+        requestedLocation: { x: 23, y: 33 },
+        landedLocation: { x: 22, y: 34 },
+      });
+      expect(payload.result.nextSteps[0]).toMatchObject({
+        kind: 'do-not-repeat',
+        source: 'unit.target.action.request',
+      });
+      expectSemanticUnitTargetOmitsRawRuntimeDetails(payload.result);
     } finally {
       log.mockRestore();
       await server.close();
@@ -166,12 +194,68 @@ describe('game play unit target command', () => {
   });
 });
 
+type UnitTargetActionSendResult = {
+  unitId: { owner: number; id: number; type: number };
+  target: { x: number; y: number };
+  sent: boolean;
+  status: string;
+  validation: {
+    candidateCount: number;
+    acceptedCandidateCount: number;
+    selected: null | {
+      family: string;
+      operationType: string;
+      valid: boolean;
+      targetInReturnedPlots: boolean | null;
+      rejectedReason: string | null;
+    };
+  };
+  postcondition: {
+    classification: string;
+    outcome: string;
+    confidence: string;
+    confirmed: boolean;
+    noRepeatAfterUnverified: boolean;
+    destinationReached: boolean | null;
+    requestedLocation: { x: number; y: number };
+    landedLocation: { x: number; y: number } | null;
+    source: string | null;
+  };
+  nextSteps: Array<{ kind: string; source: string; label: string }>;
+};
+
+function expectSemanticUnitTargetOmitsRawRuntimeDetails(result: unknown) {
+  const serialized = JSON.stringify(result);
+  expect(serialized).not.toContain('"host"');
+  expect(serialized).not.toContain('"port"');
+  expect(serialized).not.toContain('"state"');
+  expect(serialized).not.toContain('"session"');
+  expect(serialized).not.toContain('"rawCommand"');
+  expect(serialized).not.toContain('"command"');
+  expect(serialized).not.toContain('"sendResult"');
+  expect(serialized).not.toContain('"result"');
+  expect(serialized).not.toContain('"verified"');
+  expect(serialized).not.toContain('"verification"');
+  expect(serialized).not.toContain('"beforeUnit"');
+  expect(serialized).not.toContain('"afterUnit"');
+  expect(serialized).not.toContain('"beforeTargetUnits"');
+  expect(serialized).not.toContain('"afterTargetUnits"');
+  expect(serialized).not.toContain('Game.UnitOperations');
+  expect(serialized).not.toContain('Game.UnitCommands');
+}
+
 async function startUnitTargetTunerServer(options: {
   unitTargetMode?: 'verified' | 'no-op-after-send' | 'path-shortfall' | 'delayed-after-send';
 } = {}): Promise<FakeTunerServer> {
   let unitTargetSendObserved = false;
   return startFakeTunerServer({
     handle({ message }) {
+      if (message.includes('Network.isInSession')) {
+        return [JSON.stringify(appUiSnapshot())];
+      }
+      if (message.includes('evalOk') && message.includes('GameplayMap.getGridWidth')) {
+        return [JSON.stringify(tunerHealthSnapshot())];
+      }
       if (message.includes('readUnitTargetAction')) {
         const send = message.includes('"send":true');
         if (send) unitTargetSendObserved = true;
@@ -183,6 +267,84 @@ async function startUnitTargetTunerServer(options: {
       return undefined;
     },
   });
+}
+
+function appUiSnapshot() {
+  return {
+    network: {
+      isInSession: { ok: true, value: true },
+      numPlayers: { ok: true, value: 1 },
+      hostPlayerId: { ok: true, value: 0 },
+      isConnectedToNetwork: { ok: true, value: true },
+      isAuthenticated: { ok: true, value: false },
+      isLoggedIn: { ok: true, value: true },
+    },
+    autoplay: {
+      isActive: false,
+      turns: -1,
+      isPaused: false,
+      isPausedOrPending: false,
+      observeAsPlayer: -1,
+      returnAsPlayer: -1,
+    },
+    game: {
+      turn: 1,
+      age: 0,
+      maxTurns: 0,
+      turnDate: { ok: true, value: '4000 BCE' },
+      hash: { ok: true, value: 0 },
+    },
+    ui: {
+      inGame: { ok: true, value: true },
+      inShell: { ok: true, value: false },
+      inLoading: { ok: true, value: false },
+      loadingState: { ok: true, value: 6 },
+      loadingStateName: 'WaitingForUIReady',
+      canBeginGame: { ok: true, value: true },
+      canNotifyUIReady: 'function',
+      skipStartButton: { ok: true, value: false },
+      automationActive: { ok: true, value: false },
+    },
+    gameContext: {
+      localPlayerID: 0,
+      localObserverID: 0,
+      hasRequestedPause: { ok: true, value: false },
+    },
+    players: {
+      maxPlayers: 64,
+      aliveIds: { ok: true, value: [0] },
+      aliveHumanIds: { ok: true, value: [0] },
+      numAliveHumans: { ok: true, value: 1 },
+    },
+    map: {
+      width: { ok: true, value: 84 },
+      height: { ok: true, value: 54 },
+      plotCount: { ok: true, value: 4536 },
+      mapSize: { ok: true, value: 0 },
+      randomSeed: { ok: true, value: 1 },
+    },
+  };
+}
+
+function tunerHealthSnapshot() {
+  return {
+    evalOk: 2,
+    ready: true,
+    globals: {
+      Game: 'object',
+      Autoplay: 'object',
+      GameplayMap: 'object',
+      Players: 'object',
+      Network: 'undefined',
+    },
+    turn: { ok: true, value: 1 },
+    turnDate: { ok: true, value: '4000 BCE' },
+    width: { ok: true, value: 84 },
+    height: { ok: true, value: 54 },
+    aliveIds: { ok: true, value: [0] },
+    aliveHumanIds: { ok: true, value: [0] },
+    autoplayActive: { ok: true, value: false },
+  };
 }
 
 function unitTargetAction(send: boolean, mode: 'verified' | 'no-op-after-send' | 'path-shortfall' | 'delayed-after-send' | 'delayed-observed' = 'verified') {

--- a/packages/cli/test/commands/game/play/notification/dismiss.test.ts
+++ b/packages/cli/test/commands/game/play/notification/dismiss.test.ts
@@ -26,13 +26,25 @@ describe('game play dismiss-notification command', () => {
     ]);
     try {
       expect(payload.result.sent).toBe(true);
-      expect(payload.result.verified).toBe(true);
-      expect(payload.result.closeoutPath).toBe('NotificationModel.manager.dismiss');
-      expect(payload.result.result.notificationTrainManager.ok).toBe(true);
-      expect(payload.result.result.notificationTrainManager.attempted).toBe(true);
-      expect(payload.result.result.panelCloseControl.attempted).toBe(false);
-      expect(payload.result.result.panelCloseControl.reason).toMatch(/active end-turn blocker/);
-      expect(payload.result.verificationAttempts.length).toBeGreaterThan(1);
+      expect(payload.result.status).toBe('sent-confirmed');
+      expect(payload.result.validation).toMatchObject({
+        beforeExists: true,
+        canDismiss: true,
+        afterExists: false,
+      });
+      expect(payload.result.postcondition).toMatchObject({
+        classification: 'notification-disappeared',
+        outcome: 'cleared',
+        confidence: 'confirmed',
+        confirmed: true,
+        noRepeatAfterUnverified: false,
+      });
+      expect(payload.result.nextSteps).toEqual([{
+        kind: 'refresh-attention',
+        source: 'notifications.dismiss.request',
+        label: 'Refresh current attention before choosing the next player action.',
+      }]);
+      expectSemanticDismissalOmitsRawRuntimeDetails(payload.result);
       expect(server.received.some((message) => message.includes('readNotificationDismissal'))).toBe(true);
       expect(server.received.some((message) => message.includes('"send":true'))).toBe(true);
       expect(server.received.some((message) => message.includes('NotificationModel.manager'))).toBe(true);
@@ -51,19 +63,24 @@ describe('game play dismiss-notification command', () => {
     ]);
     try {
       expect(payload.result.sent).toBe(true);
-      expect(payload.result.verified).toBe(false);
-      expect(payload.result.result.notificationTrainManager).toMatchObject({ ok: true, attempted: true });
-      expect(payload.result.result.panelCloseControl).toMatchObject({ ok: true, attempted: true });
-      expect(payload.result.after).toMatchObject({
-        exists: true,
-        dismissed: false,
-        isEndTurnBlocking: { ok: true, value: false },
-        engineQueueContains: { ok: true, value: true },
-        isEngineQueueFront: { ok: true, value: true },
-        notificationTrainContains: { ok: true, value: true },
-        isNotificationTrainFront: { ok: true, value: true },
+      expect(payload.result.status).toBe('sent-unverified');
+      expect(payload.result.validation).toMatchObject({
+        beforeExists: true,
+        canDismiss: true,
+        afterExists: true,
       });
-      expect(payload.result.verificationAttempts.length).toBeGreaterThan(1);
+      expect(payload.result.postcondition).toMatchObject({
+        classification: 'engine-front-still-live',
+        outcome: 'stale',
+        confidence: 'unverified',
+        confirmed: false,
+        noRepeatAfterUnverified: true,
+      });
+      expect(payload.result.nextSteps[0]).toMatchObject({
+        kind: 'do-not-repeat',
+        source: 'notifications.dismiss.request',
+      });
+      expectSemanticDismissalOmitsRawRuntimeDetails(payload.result);
     } finally {
       await server.close();
     }
@@ -79,14 +96,24 @@ describe('game play dismiss-notification command', () => {
     ]);
     try {
       expect(payload.result.sent).toBe(true);
-      expect(payload.result.verified).toBe(false);
-      expect(payload.result.after).toMatchObject({
-        engineQueueContains: { ok: true, value: true },
-        isEngineQueueFront: { ok: true, value: true },
-        notificationTrainContains: { ok: true, value: false },
-        isNotificationTrainFront: { ok: true, value: false },
+      expect(payload.result.status).toBe('sent-unverified');
+      expect(payload.result.validation).toMatchObject({
+        beforeExists: true,
+        canDismiss: true,
+        afterExists: true,
       });
-      expect(payload.result.verificationAttempts.length).toBeGreaterThan(1);
+      expect(payload.result.postcondition).toMatchObject({
+        classification: 'engine-front-still-live',
+        outcome: 'stale',
+        confidence: 'unverified',
+        confirmed: false,
+        noRepeatAfterUnverified: true,
+      });
+      expect(payload.result.nextSteps[0]).toMatchObject({
+        kind: 'do-not-repeat',
+        source: 'notifications.dismiss.request',
+      });
+      expectSemanticDismissalOmitsRawRuntimeDetails(payload.result);
     } finally {
       await server.close();
     }
@@ -102,13 +129,24 @@ describe('game play dismiss-notification command', () => {
     ]);
     try {
       expect(payload.result.sent).toBe(true);
-      expect(payload.result.verified).toBe(false);
-      expect(payload.result.after).toMatchObject({
-        dismissed: true,
-        engineQueueContains: { ok: true, value: true },
-        isEngineQueueFront: { ok: true, value: true },
+      expect(payload.result.status).toBe('sent-unverified');
+      expect(payload.result.validation).toMatchObject({
+        beforeExists: true,
+        canDismiss: true,
+        afterExists: true,
       });
-      expect(payload.result.verificationAttempts.length).toBeGreaterThan(1);
+      expect(payload.result.postcondition).toMatchObject({
+        classification: 'engine-front-still-live',
+        outcome: 'stale',
+        confidence: 'unverified',
+        confirmed: false,
+        noRepeatAfterUnverified: true,
+      });
+      expect(payload.result.nextSteps[0]).toMatchObject({
+        kind: 'do-not-repeat',
+        source: 'notifications.dismiss.request',
+      });
+      expectSemanticDismissalOmitsRawRuntimeDetails(payload.result);
     } finally {
       await server.close();
     }
@@ -139,33 +177,54 @@ async function runDismissNotification(mode: DismissNotificationMode, extraArgs: 
     payload: JSON.parse(writes.join('')) as {
       ok: true;
       result: {
+        notificationId: { owner: number; id: number; type: number };
         sent: boolean;
-        verified: boolean;
-        closeoutPath: string | null;
-        result: {
-          notificationTrainManager: { ok: boolean; attempted: boolean; path?: string };
-          panelCloseControl: { ok: boolean; attempted: boolean; reason?: string };
+        status: string;
+        validation: {
+          beforeExists: boolean;
+          canDismiss: boolean;
+          afterExists: boolean | null;
         };
-        after: {
-          exists: boolean;
-          dismissed: boolean;
-          isEndTurnBlocking: { ok: boolean; value: boolean };
-          engineQueueContains: { ok: boolean; value: boolean };
-          isEngineQueueFront: { ok: boolean; value: boolean };
-          notificationTrainContains: { ok: boolean; value: boolean };
-          isNotificationTrainFront: { ok: boolean; value: boolean };
+        postcondition: {
+          classification: string;
+          outcome: string;
+          confidence: string;
+          confirmed: boolean;
+          noRepeatAfterUnverified: boolean;
         };
-        verificationAttempts: unknown[];
+        nextSteps: Array<{ kind: string; source: string; label: string }>;
       };
     },
     server,
   };
 }
 
+function expectSemanticDismissalOmitsRawRuntimeDetails(result: unknown) {
+  const serialized = JSON.stringify(result);
+  expect(serialized).not.toContain('"host"');
+  expect(serialized).not.toContain('"port"');
+  expect(serialized).not.toContain('"state"');
+  expect(serialized).not.toContain('"session"');
+  expect(serialized).not.toContain('"rawCommand"');
+  expect(serialized).not.toContain('"command"');
+  expect(serialized).not.toContain('"verified"');
+  expect(serialized).not.toContain('"closeoutPath"');
+  expect(serialized).not.toContain('"verificationAttempts"');
+  expect(serialized).not.toContain('"result"');
+  expect(serialized).not.toContain('NotificationModel.manager.dismiss');
+  expect(serialized).not.toContain('Game.Notifications.dismiss');
+}
+
 async function startDismissNotificationTunerServer(mode: DismissNotificationMode): Promise<FakeTunerServer> {
   let notificationDismissalSent = false;
   return startFakeTunerServer({
     handle({ message }) {
+      if (message.includes('Network.isInSession')) {
+        return [JSON.stringify(appUiSnapshot())];
+      }
+      if (message.includes('evalOk') && message.includes('GameplayMap.getGridWidth')) {
+        return [JSON.stringify(tunerHealthSnapshot())];
+      }
       if (message.includes('readNotificationDismissal')) {
         const send = message.includes('"send":true');
         if (send) notificationDismissalSent = true;
@@ -174,6 +233,84 @@ async function startDismissNotificationTunerServer(mode: DismissNotificationMode
       return undefined;
     },
   });
+}
+
+function appUiSnapshot() {
+  return {
+    network: {
+      isInSession: { ok: true, value: true },
+      numPlayers: { ok: true, value: 1 },
+      hostPlayerId: { ok: true, value: 0 },
+      isConnectedToNetwork: { ok: true, value: true },
+      isAuthenticated: { ok: true, value: false },
+      isLoggedIn: { ok: true, value: true },
+    },
+    autoplay: {
+      isActive: false,
+      turns: -1,
+      isPaused: false,
+      isPausedOrPending: false,
+      observeAsPlayer: -1,
+      returnAsPlayer: -1,
+    },
+    game: {
+      turn: 1,
+      age: 0,
+      maxTurns: 0,
+      turnDate: { ok: true, value: '4000 BCE' },
+      hash: { ok: true, value: 0 },
+    },
+    ui: {
+      inGame: { ok: true, value: true },
+      inShell: { ok: true, value: false },
+      inLoading: { ok: true, value: false },
+      loadingState: { ok: true, value: 6 },
+      loadingStateName: 'WaitingForUIReady',
+      canBeginGame: { ok: true, value: true },
+      canNotifyUIReady: 'function',
+      skipStartButton: { ok: true, value: false },
+      automationActive: { ok: true, value: false },
+    },
+    gameContext: {
+      localPlayerID: 0,
+      localObserverID: 0,
+      hasRequestedPause: { ok: true, value: false },
+    },
+    players: {
+      maxPlayers: 64,
+      aliveIds: { ok: true, value: [0] },
+      aliveHumanIds: { ok: true, value: [0] },
+      numAliveHumans: { ok: true, value: 1 },
+    },
+    map: {
+      width: { ok: true, value: 84 },
+      height: { ok: true, value: 54 },
+      plotCount: { ok: true, value: 4536 },
+      mapSize: { ok: true, value: 0 },
+      randomSeed: { ok: true, value: 1 },
+    },
+  };
+}
+
+function tunerHealthSnapshot() {
+  return {
+    evalOk: 2,
+    ready: true,
+    globals: {
+      Game: 'object',
+      Autoplay: 'object',
+      GameplayMap: 'object',
+      Players: 'object',
+      Network: 'undefined',
+    },
+    turn: { ok: true, value: 1 },
+    turnDate: { ok: true, value: '4000 BCE' },
+    width: { ok: true, value: 84 },
+    height: { ok: true, value: 54 },
+    aliveIds: { ok: true, value: [0] },
+    aliveHumanIds: { ok: true, value: [0] },
+    autoplayActive: { ok: true, value: false },
+  };
 }
 
 function notificationDismissal(send: boolean, mode: DismissNotificationMode = 'verified', settled = false) {


### PR DESCRIPTION
feat(cli): route end-turn sends through control oRPC

Refs: openspec/changes/civ7-control-orpc-native-slice

Route game play end-turn --send through the native in-process turn.complete.request client while preserving the direct-control status read for check-only mode.

Add a direct-control requestCiv7TurnComplete result port so expected pre-send guard blocks return sent:false evidence instead of being projected as runtime unavailability. The legacy sendCiv7TurnComplete API remains throwing-compatible.

Project guard-blocked turn completion as semantic not-sent output with inspect/do-not-repeat next steps, without raw command/session/state/Tuner details or legacy verified in normal CLI JSON.

Proof: bun run --cwd packages/civ7-direct-control test test/autoplay-and-turn.test.ts; bun run --cwd packages/civ7-control-orpc test test/turn-completion-procedure.test.ts; bun run --cwd packages/cli test -- game.play.end-turn.test.ts; bun run --cwd packages/civ7-direct-control check; bun run --cwd packages/civ7-control-orpc check; bun run --cwd packages/civ7-direct-control test; bun run --cwd packages/civ7-control-orpc test; bun run check:cli; bun run test:cli:play; bun run openspec -- validate civ7-control-orpc-native-slice --strict; bun run openspec -- validate civ7-support-direct-control-modularization --strict; git diff --check.

Boundary: no play-thread wake, no live/runtime proof claim, no transport/Studio/bridge work, no raw output expansion, no Task 2.9.4/5.x/6.x/7.x parent acceptance by implication.

feat(cli): route notification dismissal through control oRPC

Refs: openspec/changes/civ7-control-orpc-native-slice

Route `game play dismiss-notification --send` through the native in-process `notifications.dismiss.request` server-side client. The CLI now builds control-oRPC context from endpoint flags and the explicit approval reason for send mode, while the inspect-only notification dismissal path remains the existing direct-control read.

Normal send JSON now emits the semantic notification dismissal projection and omits raw command/session/state/Tuner details, route diagnostics, closeout paths, verification attempts, and legacy `verified` fields. Stale engine-front-still-live outcomes remain sent-unverified and no-repeat guarded.

Proof:
- bun run --cwd packages/cli test -- game/play/notification/dismiss.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check

Boundary: no play-thread wake, no live-game/runtime proof claim, no Studio/RPCLink/controller/OpenAPI transport, no broad CLI migration, and no parent Task 5.x/6.x/7.x acceptance by implication.

feat(cli): route unit target sends through control oRPC

Refs: openspec/changes/civ7-control-orpc-native-slice

Route `game play unit-target --send` through the native in-process `unit.target.action.request` server-side client under the `unit` router. The CLI now builds control-oRPC context from endpoint flags and the explicit approval reason for send mode, while the read-only unit target planning path remains the existing direct-control read.

Normal send JSON now emits the semantic unit target action projection and omits raw command/session/state/Tuner details, send results, before/after runtime probes, direct-control verification envelopes, and legacy `verified` fields. No-op sends remain sent-unverified and no-repeat guarded; path shortfalls remain sent-guarded.

Proof:
- bun run --cwd packages/cli test -- game.play.unit-target.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check

Boundary: no play-thread wake, no live-game/runtime proof claim, no Studio/RPCLink/controller/OpenAPI transport, no broad CLI migration, and no parent Task 5.x/6.x/7.x acceptance by implication.

feat(cli): route build-production sends through control oRPC

Refs: openspec/changes/civ7-control-orpc-native-slice

Route `game play build-production --send` through the native in-process `city.production.choice.request` server-side client under the `city` router. The CLI now builds control-oRPC context from endpoint flags and the explicit approval reason for send mode, while the read-only build-production validation path remains the existing direct-control operation validation path.

Normal send JSON now emits the semantic city production choice projection and omits raw command/session/state/Tuner details, UI-closeout payloads, send results, before/after runtime probes, direct-control production envelopes, and legacy `verified` fields. Cleared production choices remain sent-confirmed; blocker-still-live outcomes remain sent-unverified and no-repeat guarded.

Proof:
- bun run --cwd packages/cli test -- game.play.production.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check

Boundary: no play-thread wake, no live-game/runtime proof claim, no Studio/RPCLink/controller/OpenAPI transport, no build-unit migration, no broad production catalog, and no parent Task 5.x/6.x/7.x acceptance by implication.

feat(cli): route diplomacy responses through control oRPC

Refs: openspec/changes/civ7-control-orpc-native-slice

Routes civ7 game play respond-diplomacy --send through the native in-process decisions.diplomacy.response.request server-side client while preserving the existing direct-control player-operation validation path for read-only mode.

Adds source-owned acted-player evidence to the direct-control diplomacy response result so the service and CLI output report the actual local player used by official UI closeout, not the caller validation --player-id. Normal send output remains semantic and excludes raw command/session/state/Tuner details, UI closeout payloads, diplomacy internals, direct-control runtime payloads, and legacy verified.

Proof:
- bun run --cwd packages/civ7-direct-control test -- diplomacy-response.test.ts
- bun run --cwd packages/civ7-control-orpc test -- decisions-diplomacy-response-procedure.test.ts
- bun run --cwd packages/civ7-direct-control check
- bun run --cwd packages/civ7-direct-control build
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd packages/cli test -- game.play.diplomacy-response.test.ts
- bun run --cwd packages/civ7-direct-control test
- bun run --cwd packages/civ7-control-orpc test
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check

Local/package/CLI proof only; no live Civ7 runtime proof, play-thread wake, Studio/transport/bridge work, respond-first-meet migration, broad diplomacy catalog, hotseat/non-local authority claim, or parent Task 5.x/6.x/7.x acceptance.

feat(cli): route narrative choices through control oRPC

Refs: openspec/changes/civ7-control-orpc-native-slice

Routes civ7 game play choose-narrative --send through native in-process decisions.narrative.choice.request server-side client while preserving --options direct-control read and non-send player-operation validation paths.

Adds source-owned acted-player evidence to the direct-control narrative choice result and uses local-player runtime evidence for validation/send projection so service and CLI output report the actual local player, not caller --player-id. Normal send output remains semantic and excludes raw command/session/state/Tuner details, App UI closeout payloads, panel/popup internals, direct-control runtime payloads, and legacy verified.

Proof:
- bun run --cwd packages/civ7-direct-control test -- narrative-choice.test.ts
- bun run --cwd packages/civ7-control-orpc test -- decisions-narrative-choice-procedure.test.ts
- bun run --cwd packages/cli test -- game.play.narrative.test.ts
- bun run --cwd packages/civ7-direct-control check
- bun run --cwd packages/civ7-direct-control build
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd packages/civ7-direct-control test
- bun run --cwd packages/civ7-control-orpc test
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check

Local/package/CLI proof only; no live Civ7 runtime proof, play-thread wake, Studio/transport/bridge work, narrative options service read, broad decisions catalog, hotseat/non-local authority claim, or parent Task 5.x/6.x/7.x acceptance.