### PR TITLE
feat(control-orpc): add world current service

### DIFF
--- a/mods/mod-civ7-intelligence-bridge/mod/ui/civ7-intelligence-bridge.js
+++ b/mods/mod-civ7-intelligence-bridge/mod/ui/civ7-intelligence-bridge.js
@@ -26881,8 +26881,8 @@ function notificationDismissalPostconditionReason(classification) {
       return "The dismissal was sent, but notification identity evidence did not confirm disappearance, queue removal, or front movement.";
   }
 }
-function probeValue2(probe13) {
-  return probe13.ok ? probe13.value : void 0;
+function probeValue2(probe14) {
+  return probe14.ok ? probe14.value : void 0;
 }
 
 // ../../packages/civ7-direct-control/dist/chunk-DO73ZQ4V.js
@@ -27039,8 +27039,8 @@ function progressionChoiceDetailsChanged(left3, right3) {
 }
 function probeValue(value2) {
   if (value2 && typeof value2 === "object" && "ok" in value2) {
-    const probe13 = value2;
-    return probe13.ok === true ? probe13.value ?? null : null;
+    const probe14 = value2;
+    return probe14.ok === true ? probe14.value ?? null : null;
   }
   return value2 ?? null;
 }
@@ -27182,8 +27182,8 @@ function turnCompletionNoRepeatAfterUnverified(classification) {
       return true;
   }
 }
-function probeValue3(probe13) {
-  return probe13.ok ? probe13.value : void 0;
+function probeValue3(probe14) {
+  return probe14.ok ? probe14.value : void 0;
 }
 
 // ../../packages/civ7-direct-control/dist/chunk-ZGRAA6DD.js
@@ -27242,7 +27242,7 @@ function unitTargetProofNoRepeatAfterConfirmed(verification) {
   return verification.classification === "path-shortfall";
 }
 
-// ../../packages/civ7-control-orpc/dist/chunk-SLERNDVZ.js
+// ../../packages/civ7-control-orpc/dist/chunk-YCGAGJTW.js
 var Civ7ControlOrpcCorrelationIdSchema = typebox_exports.String({
   pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
 });
@@ -28196,6 +28196,27 @@ var Civ7WorldCurrentUnavailableError = class extends ORPCTaggedError(
   }
 ) {
 };
+var Civ7WorldReadUnavailableErrorDataSchema = typebox_exports.Object(
+  {
+    procedureKey: typebox_exports.Union([
+      typebox_exports.Literal("world.plot.read"),
+      typebox_exports.Literal("world.grid.read")
+    ]),
+    source: typebox_exports.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldReadUnavailableError = class extends ORPCTaggedError(
+  "Civ7WorldReadUnavailableError",
+  {
+    code: "WORLD_READ_UNAVAILABLE",
+    message: "World map read failed.",
+    schema: toStandardSchema(Civ7WorldReadUnavailableErrorDataSchema),
+    status: 503
+  }
+) {
+};
 var Civ7NotificationDismissalUnavailableErrorDataSchema = typebox_exports.Object(
   {
     procedureKey: typebox_exports.Literal("notifications.dismiss.request"),
@@ -28575,7 +28596,8 @@ var civ7ControlOrpcErrorMap = {
   TURN_COMPLETION_UNAVAILABLE: Civ7TurnCompletionUnavailableError,
   UNIT_REQUEST_UNAVAILABLE: Civ7UnitRequestUnavailableError,
   UNIT_TARGET_ACTION_UNAVAILABLE: Civ7UnitTargetActionUnavailableError,
-  WORLD_CURRENT_UNAVAILABLE: Civ7WorldCurrentUnavailableError
+  WORLD_CURRENT_UNAVAILABLE: Civ7WorldCurrentUnavailableError,
+  WORLD_READ_UNAVAILABLE: Civ7WorldReadUnavailableError
 };
 var civ7ControlOrpcContractBase = eoc.$meta({}).errors(civ7ControlOrpcErrorMap);
 var Civ7ControlOrpcComponentIdSchema = typebox_exports.Object(
@@ -30721,14 +30743,188 @@ var Civ7WorldCurrentInputStandardSchema = toStandardSchema(
 var Civ7WorldCurrentResultStandardSchema = toStandardSchema(
   Civ7WorldCurrentResultSchema
 );
+var Civ7WorldPlotFieldSchema = typebox_exports.Union([
+  typebox_exports.Literal("terrain"),
+  typebox_exports.Literal("biome"),
+  typebox_exports.Literal("feature"),
+  typebox_exports.Literal("resource"),
+  typebox_exports.Literal("climate"),
+  typebox_exports.Literal("hydrology"),
+  typebox_exports.Literal("yields"),
+  typebox_exports.Literal("owner"),
+  typebox_exports.Literal("visibility"),
+  typebox_exports.Literal("areaRegion"),
+  typebox_exports.Literal("tags"),
+  typebox_exports.Literal("city"),
+  typebox_exports.Literal("units")
+]);
+var Civ7WorldHiddenInfoPolicySchema = typebox_exports.Union([
+  typebox_exports.Literal("include-hidden"),
+  typebox_exports.Literal("visibility-filtered"),
+  typebox_exports.Literal("not-player-scoped")
+]);
+var Civ7WorldProbeSchema = typebox_exports.Union([
+  typebox_exports.Object(
+    {
+      ok: typebox_exports.Literal(true),
+      value: typebox_exports.Unknown()
+    },
+    { additionalProperties: false }
+  ),
+  typebox_exports.Object(
+    {
+      ok: typebox_exports.Literal(false),
+      error: typebox_exports.String()
+    },
+    { additionalProperties: false }
+  )
+]);
+var Civ7WorldPlotReadInputSchema = typebox_exports.Object(
+  {
+    location: Civ7ControlOrpcMapLocationSchema,
+    playerId: typebox_exports.Optional(typebox_exports.Integer({ minimum: 0 })),
+    fields: typebox_exports.Optional(typebox_exports.Array(Civ7WorldPlotFieldSchema)),
+    includeHidden: typebox_exports.Optional(typebox_exports.Boolean())
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldPlotSnapshotSchema = typebox_exports.Object(
+  {
+    location: typebox_exports.Object(
+      {
+        x: typebox_exports.Integer({ minimum: 0, maximum: 1e6 }),
+        y: typebox_exports.Integer({ minimum: 0, maximum: 1e6 }),
+        index: NullableNumberSchema
+      },
+      { additionalProperties: false }
+    ),
+    visibility: typebox_exports.Object(
+      {
+        revealedState: typebox_exports.Optional(Civ7WorldProbeSchema),
+        visible: typebox_exports.Optional(Civ7WorldProbeSchema)
+      },
+      { additionalProperties: false }
+    ),
+    hiddenInfoPolicy: Civ7WorldHiddenInfoPolicySchema,
+    facts: typebox_exports.Record(typebox_exports.String(), Civ7WorldProbeSchema),
+    summary: typebox_exports.Object(
+      {
+        factCount: typebox_exports.Integer({ minimum: 0 }),
+        probeErrorCount: typebox_exports.Integer({ minimum: 0 })
+      },
+      { additionalProperties: false }
+    )
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldPlotReadResultSchema = typebox_exports.Object(
+  {
+    sourceStatus: typebox_exports.Object(
+      {
+        plot: typebox_exports.Union([
+          typebox_exports.Literal("read"),
+          typebox_exports.Literal("read-with-probe-errors"),
+          typebox_exports.Literal("invalid-location")
+        ])
+      },
+      { additionalProperties: false }
+    ),
+    plot: Civ7WorldPlotSnapshotSchema
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldMapBoundsSchema = typebox_exports.Object(
+  {
+    x: typebox_exports.Integer({ minimum: 0, maximum: 1e6 }),
+    y: typebox_exports.Integer({ minimum: 0, maximum: 1e6 }),
+    width: typebox_exports.Integer({ minimum: 1, maximum: 1e4 }),
+    height: typebox_exports.Integer({ minimum: 1, maximum: 1e4 })
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldGridReadInputSchema = typebox_exports.Object(
+  {
+    bounds: Civ7WorldMapBoundsSchema,
+    fields: typebox_exports.Array(Civ7WorldPlotFieldSchema),
+    playerId: typebox_exports.Optional(typebox_exports.Integer({ minimum: 0 })),
+    includeHidden: typebox_exports.Optional(typebox_exports.Boolean()),
+    maxPlots: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 1e4 }))
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldGridReadResultSchema = typebox_exports.Object(
+  {
+    sourceStatus: typebox_exports.Object(
+      {
+        grid: typebox_exports.Union([
+          typebox_exports.Literal("read"),
+          typebox_exports.Literal("read-with-omissions"),
+          typebox_exports.Literal("read-with-probe-errors")
+        ]),
+        map: typebox_exports.Union([
+          typebox_exports.Literal("read"),
+          typebox_exports.Literal("skipped-unavailable")
+        ])
+      },
+      { additionalProperties: false }
+    ),
+    bounds: Civ7WorldMapBoundsSchema,
+    fields: typebox_exports.Array(Civ7WorldPlotFieldSchema),
+    plotCount: typebox_exports.Integer({ minimum: 0 }),
+    omitted: typebox_exports.Integer({ minimum: 0 }),
+    hiddenInfoPolicy: Civ7WorldHiddenInfoPolicySchema,
+    map: typebox_exports.Object(
+      {
+        width: NullableNumberSchema,
+        height: NullableNumberSchema
+      },
+      { additionalProperties: false }
+    ),
+    plots: typebox_exports.Array(Civ7WorldPlotSnapshotSchema),
+    summary: typebox_exports.Object(
+      {
+        returnedPlotCount: typebox_exports.Integer({ minimum: 0 }),
+        probeErrorCount: typebox_exports.Integer({ minimum: 0 })
+      },
+      { additionalProperties: false }
+    )
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldPlotReadInputStandardSchema = toStandardSchema(
+  Civ7WorldPlotReadInputSchema
+);
+var Civ7WorldPlotReadResultStandardSchema = toStandardSchema(
+  Civ7WorldPlotReadResultSchema
+);
+var Civ7WorldGridReadInputStandardSchema = toStandardSchema(
+  Civ7WorldGridReadInputSchema
+);
+var Civ7WorldGridReadResultStandardSchema = toStandardSchema(
+  Civ7WorldGridReadResultSchema
+);
 var Civ7WorldCurrentContract = civ7ControlOrpcContractBase.input(Civ7WorldCurrentInputStandardSchema).output(Civ7WorldCurrentResultStandardSchema).meta({
   family: "world",
   procedureKey: "world.current",
   proofBoundary: "local-package-test",
   risk: "read-only"
 });
+var Civ7WorldPlotReadContract = civ7ControlOrpcContractBase.input(Civ7WorldPlotReadInputStandardSchema).output(Civ7WorldPlotReadResultStandardSchema).meta({
+  family: "world",
+  procedureKey: "world.plot.read",
+  proofBoundary: "local-package-test",
+  risk: "read-only"
+});
+var Civ7WorldGridReadContract = civ7ControlOrpcContractBase.input(Civ7WorldGridReadInputStandardSchema).output(Civ7WorldGridReadResultStandardSchema).meta({
+  family: "world",
+  procedureKey: "world.grid.read",
+  proofBoundary: "local-package-test",
+  risk: "read-only"
+});
 var Civ7WorldContract = {
-  current: Civ7WorldCurrentContract
+  current: Civ7WorldCurrentContract,
+  plot: Civ7WorldPlotReadContract,
+  grid: Civ7WorldGridReadContract
 };
 var Civ7ControlOrpcContract = civ7ControlOrpcContractBase.router({
   attention: Civ7AttentionContract,
@@ -31105,11 +31301,11 @@ function skippedSourceStatus(playableStatus) {
     readyCity: skipped
   };
 }
-function probeValue4(probe13) {
-  if (probe13 == null || typeof probe13 !== "object") return null;
-  if (!("ok" in probe13) || probe13.ok !== true) return null;
-  if (!("value" in probe13)) return null;
-  return probe13.value;
+function probeValue4(probe14) {
+  if (probe14 == null || typeof probe14 !== "object") return null;
+  if (!("ok" in probe14) || probe14.ok !== true) return null;
+  if (!("value" in probe14)) return null;
+  return probe14.value;
 }
 function componentIdFromUnknown(value2) {
   if (value2 == null || typeof value2 !== "object") return null;
@@ -32112,8 +32308,8 @@ function booleanProbeValue(value2) {
 }
 function probeValue22(value2) {
   if (value2 && typeof value2 === "object" && "ok" in value2) {
-    const probe13 = value2;
-    return probe13.ok === true ? probe13.value ?? null : null;
+    const probe14 = value2;
+    return probe14.ok === true ? probe14.value ?? null : null;
   }
   return value2 ?? null;
 }
@@ -32591,8 +32787,8 @@ function supportsWorldCurrent(context5) {
 function supportedReadProcedures(context5) {
   return context5.controller?.supportedReadProcedures ?? [];
 }
-function probeValue32(probe13) {
-  return probe13.ok ? probe13.value : null;
+function probeValue32(probe14) {
+  return probe14.ok ? probe14.value : null;
 }
 var readinessRouter = {
   current: readinessCurrentProcedure
@@ -32887,13 +33083,13 @@ function turnCompletionProbeSummary(status) {
     firstReadyUnitId: probeValue42(status.firstReadyUnitId)
   };
 }
-function blockerValue(probe13) {
-  const value2 = probeValue42(probe13);
+function blockerValue(probe14) {
+  const value2 = probeValue42(probe14);
   if (typeof value2 === "number" || typeof value2 === "string") return value2;
   return null;
 }
-function probeValue42(probe13) {
-  return probe13.ok ? probe13.value : null;
+function probeValue42(probe14) {
+  return probe14.ok ? probe14.value : null;
 }
 var turnRouter = {
   complete: {
@@ -33300,8 +33496,8 @@ function mapSourceStatus(map16) {
 function playersSourceStatus(players) {
   return players.aliveIds.ok || players.aliveHumanIds.ok || players.numAliveHumans.ok ? "read" : "skipped-unavailable";
 }
-function probeValue5(probe13) {
-  return probe13.ok ? probe13.value : null;
+function probeValue5(probe14) {
+  return probe14.ok ? probe14.value : null;
 }
 function integerArrayOrEmpty(value2) {
   return Array.isArray(value2) ? value2.filter(
@@ -33311,8 +33507,155 @@ function integerArrayOrEmpty(value2) {
 function playerIdOrNull(value2) {
   return Number.isInteger(value2) && Number(value2) >= 0 ? Number(value2) : null;
 }
+var worldPlotReadProcedure = civ7ControlOrpcImplementer.world.plot.effect(function* ({
+  context: context5,
+  errors,
+  input
+}) {
+  return yield* Effect_exports.tryPromise({
+    try: async () => worldPlotReadResult(
+      await context5.directControl.getCiv7PlotSnapshot(
+        {
+          x: input.location.x,
+          y: input.location.y,
+          fields: input.fields,
+          playerId: input.playerId,
+          includeHidden: input.includeHidden
+        },
+        context5.endpointDefaults
+      )
+    ),
+    catch: () => errors.WORLD_READ_UNAVAILABLE({
+      data: {
+        procedureKey: "world.plot.read",
+        source: "direct-control-facade",
+        ...civ7ControlOrpcErrorCorrelationData(context5)
+      }
+    })
+  });
+});
+var worldGridReadProcedure = civ7ControlOrpcImplementer.world.grid.effect(function* ({
+  context: context5,
+  errors,
+  input
+}) {
+  return yield* Effect_exports.tryPromise({
+    try: async () => worldGridReadResult(
+      await context5.directControl.getCiv7MapGrid(
+        {
+          bounds: input.bounds,
+          fields: input.fields,
+          playerId: input.playerId,
+          includeHidden: input.includeHidden,
+          maxPlots: input.maxPlots
+        },
+        context5.endpointDefaults
+      )
+    ),
+    catch: () => errors.WORLD_READ_UNAVAILABLE({
+      data: {
+        procedureKey: "world.grid.read",
+        source: "direct-control-facade",
+        ...civ7ControlOrpcErrorCorrelationData(context5)
+      }
+    })
+  });
+});
+function worldPlotReadResult(result) {
+  const plot = worldPlotSnapshot(result);
+  const probeErrorCount = plot.summary.probeErrorCount;
+  const invalidLocation = plot.location.index == null && plot.summary.factCount === 0;
+  return {
+    sourceStatus: {
+      plot: invalidLocation ? "invalid-location" : probeErrorCount > 0 ? "read-with-probe-errors" : "read"
+    },
+    plot
+  };
+}
+function worldGridReadResult(result) {
+  const plots = result.plots.map(worldPlotSnapshot);
+  const probeErrorCount = plots.reduce(
+    (total, plot) => total + plot.summary.probeErrorCount,
+    0
+  ) + probeErrorCountForRecord(result.map ?? {});
+  return {
+    sourceStatus: {
+      grid: result.omitted > 0 ? "read-with-omissions" : probeErrorCount > 0 ? "read-with-probe-errors" : "read",
+      map: probeValue6(result.map?.width) != null || probeValue6(result.map?.height) != null ? "read" : "skipped-unavailable"
+    },
+    bounds: result.bounds ?? boundsFromPlots(plots),
+    fields: Array.from(result.fields),
+    plotCount: result.plotCount,
+    omitted: result.omitted,
+    hiddenInfoPolicy: result.hiddenInfoPolicy,
+    map: {
+      width: probeValue6(result.map?.width),
+      height: probeValue6(result.map?.height)
+    },
+    plots,
+    summary: {
+      returnedPlotCount: plots.length,
+      probeErrorCount
+    }
+  };
+}
+function worldPlotSnapshot(plot) {
+  const facts = probeRecord(plot.facts);
+  const visibility = {
+    ...plot.revealedState ? { revealedState: publicProbe(plot.revealedState) } : {},
+    ...plot.visible ? { visible: publicProbe(plot.visible) } : {}
+  };
+  return {
+    location: {
+      x: plot.location.x,
+      y: plot.location.y,
+      index: probeValue6(plot.location.index)
+    },
+    visibility,
+    hiddenInfoPolicy: plot.hiddenInfoPolicy,
+    facts,
+    summary: {
+      factCount: Object.keys(facts).length,
+      probeErrorCount: probeErrorCountForRecord(facts) + probeErrorCountForRecord(visibility) + (plot.location.index.ok ? 0 : 1)
+    }
+  };
+}
+function publicProbe(probe14) {
+  return probe14.ok ? { ok: true, value: probe14.value } : {
+    ok: false,
+    error: probe14.error
+  };
+}
+function probeRecord(facts) {
+  return Object.fromEntries(
+    Object.entries(facts).map(([key, value2]) => [key, publicProbe(value2)])
+  );
+}
+function probeValue6(probe14) {
+  return probe14?.ok ? probe14.value : null;
+}
+function probeErrorCountForRecord(record) {
+  return Object.values(record).filter(
+    (value2) => value2 != null && typeof value2 === "object" && "ok" in value2 && value2.ok === false
+  ).length;
+}
+function boundsFromPlots(plots) {
+  if (plots.length === 0) return { x: 0, y: 0, width: 1, height: 1 };
+  const xs = plots.map((plot) => plot.location.x);
+  const ys = plots.map((plot) => plot.location.y);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  return {
+    x: minX,
+    y: minY,
+    width: Math.max(...xs) - minX + 1,
+    height: Math.max(...ys) - minY + 1
+  };
+}
 var worldRouter = {
-  current: worldCurrentProcedure
+  current: worldCurrentProcedure,
+  plot: worldPlotReadProcedure,
+  grid: worldGridReadProcedure
 };
 var Civ7ControlOrpcRouter = civ7ControlOrpcImplementer.router({
   attention: attentionRouter,
@@ -33354,6 +33697,18 @@ var Civ7WorldCurrentInputSchema2 = typeboxInputSchemaFromContractProcedure(
 );
 var Civ7WorldCurrentResultSchema2 = typeboxOutputSchemaFromContractProcedure(
   Civ7ControlOrpcContract.world.current
+);
+var Civ7WorldPlotReadInputSchema2 = typeboxInputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.world.plot
+);
+var Civ7WorldPlotReadResultSchema2 = typeboxOutputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.world.plot
+);
+var Civ7WorldGridReadInputSchema2 = typeboxInputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.world.grid
+);
+var Civ7WorldGridReadResultSchema2 = typeboxOutputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.world.grid
 );
 var Civ7NotificationDismissInputSchema2 = typeboxInputSchemaFromContractProcedure(
   Civ7ControlOrpcContract.notifications.dismiss.request
@@ -33532,6 +33887,22 @@ var Civ7ControllerBridgeWorldCurrentRequestSchema = typebox_exports.Object(
   {
     procedureKey: typebox_exports.Literal("world.current"),
     input: Civ7WorldCurrentInputSchema2,
+    correlationId: typebox_exports.Optional(Civ7ControlOrpcCorrelationIdSchema)
+  },
+  { additionalProperties: false }
+);
+var Civ7ControllerBridgeWorldPlotReadRequestSchema = typebox_exports.Object(
+  {
+    procedureKey: typebox_exports.Literal("world.plot.read"),
+    input: Civ7WorldPlotReadInputSchema2,
+    correlationId: typebox_exports.Optional(Civ7ControlOrpcCorrelationIdSchema)
+  },
+  { additionalProperties: false }
+);
+var Civ7ControllerBridgeWorldGridReadRequestSchema = typebox_exports.Object(
+  {
+    procedureKey: typebox_exports.Literal("world.grid.read"),
+    input: Civ7WorldGridReadInputSchema2,
     correlationId: typebox_exports.Optional(Civ7ControlOrpcCorrelationIdSchema)
   },
   { additionalProperties: false }
@@ -33717,6 +34088,8 @@ var Civ7ControllerBridgeRequestSchema = typebox_exports.Union([
   Civ7ControllerBridgeAttentionCurrentRequestSchema,
   Civ7ControllerBridgeStrategyFrontSummaryRequestSchema,
   Civ7ControllerBridgeWorldCurrentRequestSchema,
+  Civ7ControllerBridgeWorldPlotReadRequestSchema,
+  Civ7ControllerBridgeWorldGridReadRequestSchema,
   Civ7ControllerBridgeNotificationDismissRequestSchema,
   Civ7ControllerBridgeTurnCompleteRequestSchema,
   Civ7ControllerBridgeCityProductionChoiceRequestSchema,
@@ -33785,6 +34158,24 @@ var Civ7ControllerBridgeWorldCurrentSuccessResponseSchema = typebox_exports.Obje
     ok: typebox_exports.Literal(true),
     procedureKey: typebox_exports.Literal("world.current"),
     output: Civ7WorldCurrentResultSchema2,
+    correlationId: typebox_exports.Optional(Civ7ControlOrpcCorrelationIdSchema)
+  },
+  { additionalProperties: false }
+);
+var Civ7ControllerBridgeWorldPlotReadSuccessResponseSchema = typebox_exports.Object(
+  {
+    ok: typebox_exports.Literal(true),
+    procedureKey: typebox_exports.Literal("world.plot.read"),
+    output: Civ7WorldPlotReadResultSchema2,
+    correlationId: typebox_exports.Optional(Civ7ControlOrpcCorrelationIdSchema)
+  },
+  { additionalProperties: false }
+);
+var Civ7ControllerBridgeWorldGridReadSuccessResponseSchema = typebox_exports.Object(
+  {
+    ok: typebox_exports.Literal(true),
+    procedureKey: typebox_exports.Literal("world.grid.read"),
+    output: Civ7WorldGridReadResultSchema2,
     correlationId: typebox_exports.Optional(Civ7ControlOrpcCorrelationIdSchema)
   },
   { additionalProperties: false }
@@ -33992,6 +34383,8 @@ var Civ7ControllerBridgeSuccessResponseSchema = typebox_exports.Union([
   Civ7ControllerBridgeAttentionCurrentSuccessResponseSchema,
   Civ7ControllerBridgeStrategyFrontSummarySuccessResponseSchema,
   Civ7ControllerBridgeWorldCurrentSuccessResponseSchema,
+  Civ7ControllerBridgeWorldPlotReadSuccessResponseSchema,
+  Civ7ControllerBridgeWorldGridReadSuccessResponseSchema,
   Civ7ControllerBridgeNotificationDismissSuccessResponseSchema,
   Civ7ControllerBridgeTurnCompleteSuccessResponseSchema,
   Civ7ControllerBridgeCityProductionChoiceSuccessResponseSchema,
@@ -34095,6 +34488,24 @@ async function invokeCiv7ControllerBridgeRequest(request2, options) {
       return {
         ok: true,
         procedureKey: "world.current",
+        output: output2,
+        ...request2.correlationId == null ? {} : { correlationId: request2.correlationId }
+      };
+    }
+    if (request2.procedureKey === "world.plot.read") {
+      const output2 = await client.world.plot(validatedInput);
+      return {
+        ok: true,
+        procedureKey: "world.plot.read",
+        output: output2,
+        ...request2.correlationId == null ? {} : { correlationId: request2.correlationId }
+      };
+    }
+    if (request2.procedureKey === "world.grid.read") {
+      const output2 = await client.world.grid(validatedInput);
+      return {
+        ok: true,
+        procedureKey: "world.grid.read",
         output: output2,
         ...request2.correlationId == null ? {} : { correlationId: request2.correlationId }
       };
@@ -34341,7 +34752,7 @@ function controllerProofFromContext(context5) {
 function isUnsupportedProcedureRequest(request2) {
   if (request2 == null || typeof request2 !== "object") return false;
   if (!("procedureKey" in request2)) return false;
-  return typeof request2.procedureKey === "string" && request2.procedureKey !== "readiness.current" && request2.procedureKey !== "attention.current" && request2.procedureKey !== "strategy.frontSummary" && request2.procedureKey !== "world.current" && request2.procedureKey !== "notifications.dismiss.request" && request2.procedureKey !== "turn.complete.request" && request2.procedureKey !== "city.production.choice.request" && request2.procedureKey !== "city.population.place.request" && request2.procedureKey !== "city.townFocus.change.request" && request2.procedureKey !== "city.townFocus.review.request" && request2.procedureKey !== "narrative.choice.request" && request2.procedureKey !== "diplomacy.response.request" && request2.procedureKey !== "diplomacy.firstMeet.response.request" && request2.procedureKey !== "government.choice.request" && request2.procedureKey !== "government.celebration.choice.request" && request2.procedureKey !== "unit.target.action.request" && request2.procedureKey !== "unit.upgrade.request" && request2.procedureKey !== "unit.resettle.request" && request2.procedureKey !== "progression.technology.choice.request" && request2.procedureKey !== "progression.culture.choice.request" && request2.procedureKey !== "progression.technology.target.request" && request2.procedureKey !== "progression.culture.target.request" && request2.procedureKey !== "progression.attribute.purchase.request" && request2.procedureKey !== "progression.attribute.review.request" && request2.procedureKey !== "progression.tradition.change.request" && request2.procedureKey !== "progression.tradition.review.request";
+  return typeof request2.procedureKey === "string" && request2.procedureKey !== "readiness.current" && request2.procedureKey !== "attention.current" && request2.procedureKey !== "strategy.frontSummary" && request2.procedureKey !== "world.current" && request2.procedureKey !== "world.plot.read" && request2.procedureKey !== "world.grid.read" && request2.procedureKey !== "notifications.dismiss.request" && request2.procedureKey !== "turn.complete.request" && request2.procedureKey !== "city.production.choice.request" && request2.procedureKey !== "city.population.place.request" && request2.procedureKey !== "city.townFocus.change.request" && request2.procedureKey !== "city.townFocus.review.request" && request2.procedureKey !== "narrative.choice.request" && request2.procedureKey !== "diplomacy.response.request" && request2.procedureKey !== "diplomacy.firstMeet.response.request" && request2.procedureKey !== "government.choice.request" && request2.procedureKey !== "government.celebration.choice.request" && request2.procedureKey !== "unit.target.action.request" && request2.procedureKey !== "unit.upgrade.request" && request2.procedureKey !== "unit.resettle.request" && request2.procedureKey !== "progression.technology.choice.request" && request2.procedureKey !== "progression.culture.choice.request" && request2.procedureKey !== "progression.technology.target.request" && request2.procedureKey !== "progression.culture.target.request" && request2.procedureKey !== "progression.attribute.purchase.request" && request2.procedureKey !== "progression.attribute.review.request" && request2.procedureKey !== "progression.tradition.change.request" && request2.procedureKey !== "progression.tradition.review.request";
 }
 function isControllerBridgeMutationRequest(request2) {
   return request2.procedureKey === "notifications.dismiss.request" || request2.procedureKey === "turn.complete.request" || request2.procedureKey === "city.production.choice.request" || request2.procedureKey === "city.population.place.request" || request2.procedureKey === "city.townFocus.change.request" || request2.procedureKey === "city.townFocus.review.request" || request2.procedureKey === "narrative.choice.request" || request2.procedureKey === "diplomacy.response.request" || request2.procedureKey === "diplomacy.firstMeet.response.request" || request2.procedureKey === "government.choice.request" || request2.procedureKey === "government.celebration.choice.request" || request2.procedureKey === "unit.target.action.request" || request2.procedureKey === "unit.upgrade.request" || request2.procedureKey === "unit.resettle.request" || request2.procedureKey === "progression.technology.choice.request" || request2.procedureKey === "progression.culture.choice.request" || request2.procedureKey === "progression.technology.target.request" || request2.procedureKey === "progression.culture.target.request" || request2.procedureKey === "progression.attribute.purchase.request" || request2.procedureKey === "progression.attribute.review.request" || request2.procedureKey === "progression.tradition.change.request" || request2.procedureKey === "progression.tradition.review.request";
@@ -34850,7 +35261,7 @@ async function requestCiv7GameUiTurnComplete(target = globalThis) {
       state: { id: "game-ui", name: "Game UI" },
       output: ["game-ui-turn-completion-requested"]
     },
-    verified: probeValue6(after3.hasSentTurnComplete) === true || probeValue6(after3.turn) !== probeValue6(before2.turn)
+    verified: probeValue7(after3.hasSentTurnComplete) === true || probeValue7(after3.turn) !== probeValue7(before2.turn)
   };
 }
 function gameUiNotificationSummaries(target, playerId, maxNotifications) {
@@ -35030,10 +35441,10 @@ function ok(value2) {
   return { ok: true, value: value2 };
 }
 function gameUiTurnCompletionAllowed(status) {
-  return probeValue6(status.canEndTurn) === true && probeValue6(status.hasSentTurnComplete) !== true;
+  return probeValue7(status.canEndTurn) === true && probeValue7(status.hasSentTurnComplete) !== true;
 }
-function probeValue6(probe13) {
-  return probe13.ok ? probe13.value : void 0;
+function probeValue7(probe14) {
+  return probe14.ok ? probe14.value : void 0;
 }
 function isPresent2(value2) {
   return value2 != null;
@@ -35340,8 +35751,8 @@ function probe3(fn2) {
     return { ok: false, error: String(err) };
   }
 }
-function probeValue23(probe13) {
-  return probe13?.ok ? probe13.value : void 0;
+function probeValue23(probe14) {
+  return probe14?.ok ? probe14.value : void 0;
 }
 function stableJson2(value2) {
   if (value2 == null || typeof value2 !== "object") return JSON.stringify(value2);
@@ -36400,8 +36811,8 @@ function probe5(fn2) {
     return { ok: false, error: String(err) };
   }
 }
-function probeValue33(probe13) {
-  return probe13?.ok ? probe13.value : void 0;
+function probeValue33(probe14) {
+  return probe14?.ok ? probe14.value : void 0;
 }
 function stableJson22(value2) {
   if (value2 == null || typeof value2 !== "object") return JSON.stringify(value2);
@@ -38583,6 +38994,256 @@ function probe11(fn2) {
     return { ok: false, error: String(err) };
   }
 }
+function civ7GameUiWorldMapReadsAvailable(target) {
+  return typeof target.GameplayMap?.getGridWidth === "function" && typeof target.GameplayMap?.getGridHeight === "function" && typeof target.GameplayMap?.isValidXY === "function" && typeof target.GameplayMap?.getIndexFromXY === "function";
+}
+async function getCiv7GameUiPlotSnapshot(input, target = globalThis) {
+  if (!civ7GameUiWorldMapReadsAvailable(target)) {
+    throw new Error("Civ7 game UI world map dependency is unavailable.");
+  }
+  return {
+    ...gameUiRuntimeIdentity(),
+    ...plotSnapshot(
+      {
+        x: boundedInteger2(input.x, 0, 1e6, "x"),
+        y: boundedInteger2(input.y, 0, 1e6, "y"),
+        fields: normalizePlotFields(input.fields),
+        playerId: input.playerId,
+        includeHidden: input.includeHidden
+      },
+      target
+    )
+  };
+}
+async function getCiv7GameUiMapGrid(input, target = globalThis) {
+  if (!civ7GameUiWorldMapReadsAvailable(target)) {
+    throw new Error("Civ7 game UI world map dependency is unavailable.");
+  }
+  const maxPlots = boundedInteger2(input.maxPlots ?? 256, 1, 1e4, "maxPlots");
+  const fields = normalizePlotFields(input.fields);
+  const bounds = input.bounds == null ? void 0 : mapBounds(input.bounds);
+  const explicitLocations = input.locations?.map(mapLocation);
+  if (bounds == null && explicitLocations == null) {
+    throw new Error("Civ7 game UI map grid reads require bounds or locations.");
+  }
+  if (bounds != null && explicitLocations != null) {
+    throw new Error("Civ7 game UI map grid reads accept bounds or locations, not both.");
+  }
+  const requestedCount = explicitLocations?.length ?? bounds.width * bounds.height;
+  const locations = (explicitLocations ?? locationsFromBounds(bounds, maxPlots)).slice(0, maxPlots);
+  return {
+    ...gameUiRuntimeIdentity(),
+    ...bounds == null ? {} : { bounds },
+    fields: Array.from(fields),
+    plotCount: requestedCount,
+    omitted: Math.max(0, requestedCount - locations.length),
+    hiddenInfoPolicy: hiddenInfoPolicy(input),
+    map: {
+      width: probe12(() => Number(target.GameplayMap.getGridWidth())),
+      height: probe12(() => Number(target.GameplayMap.getGridHeight()))
+    },
+    plots: locations.map(
+      (location) => plotSnapshot({
+        ...location,
+        fields,
+        playerId: input.playerId,
+        includeHidden: input.includeHidden
+      }, target)
+    )
+  };
+}
+function plotSnapshot(input, target) {
+  const visibility = visibilityFor(input, target);
+  if (target.GameplayMap?.isValidXY?.(input.x, input.y) !== true) {
+    return {
+      location: {
+        x: input.x,
+        y: input.y,
+        index: { ok: false, error: "invalid location" }
+      },
+      hiddenInfoPolicy: visibility.policy,
+      facts: {}
+    };
+  }
+  const facts = {};
+  const include = visibility.policy === "not-player-scoped" || visibility.includeFacts === true;
+  const add6 = (key, value2) => {
+    facts[key] = value2;
+  };
+  if (include) {
+    if (input.fields.includes("terrain")) {
+      add6("terrain", mapProbe(target, "getTerrainType", input));
+    }
+    if (input.fields.includes("biome")) {
+      add6("biome", mapProbe(target, "getBiomeType", input));
+    }
+    if (input.fields.includes("feature")) {
+      add6("feature", mapProbe(target, "getFeatureType", input));
+    }
+    if (input.fields.includes("resource")) {
+      add6("resource", mapProbe(target, "getResourceType", input));
+    }
+    if (input.fields.includes("climate")) {
+      add6("elevation", mapProbe(target, "getElevation", input));
+      add6("rainfall", mapProbe(target, "getRainfall", input));
+      add6("fertility", mapProbe(target, "getFertilityType", input));
+    }
+    if (input.fields.includes("hydrology")) {
+      add6("riverType", mapProbe(target, "getRiverType", input));
+      add6("water", mapProbe(target, "isWater", input));
+    }
+    if (input.fields.includes("yields")) {
+      add6("yields", mapProbe(target, "getYields", input));
+    }
+    if (input.fields.includes("owner")) {
+      add6("owner", mapProbe(target, "getOwner", input));
+      add6("ownerName", mapProbe(target, "getOwnerName", input));
+    }
+    if (input.fields.includes("areaRegion")) {
+      add6("areaId", mapProbe(target, "getAreaId", input));
+      add6("regionId", mapProbe(target, "getRegionId", input));
+      add6("landmassId", mapProbe(target, "getLandmassId", input));
+    }
+    if (input.fields.includes("tags")) {
+      add6("plotTag", mapProbe(target, "getPlotTag", input));
+    }
+    if (input.fields.includes("city")) {
+      add6("city", probe12(() => target.MapCities?.getCity?.(input.x, input.y) ?? null));
+    }
+    if (input.fields.includes("units")) {
+      add6("units", probe12(() => target.MapUnits?.getUnits?.(input.x, input.y) ?? []));
+    }
+  }
+  if (input.fields.includes("visibility")) {
+    add6(
+      "revealedState",
+      visibility.revealedState ?? { ok: false, error: "playerId required" }
+    );
+    add6(
+      "visible",
+      visibility.visible ?? { ok: false, error: "playerId required" }
+    );
+  }
+  return {
+    location: {
+      x: input.x,
+      y: input.y,
+      index: probe12(() => Number(target.GameplayMap.getIndexFromXY(input.x, input.y)))
+    },
+    ...visibility.revealedState ? { revealedState: visibility.revealedState } : {},
+    ...visibility.visible ? { visible: visibility.visible } : {},
+    hiddenInfoPolicy: visibility.policy,
+    facts
+  };
+}
+function visibilityFor(input, target) {
+  if (input.playerId == null) return { policy: "not-player-scoped" };
+  const revealedState = probe12(
+    () => target.GameplayMap.getRevealedState(input.playerId, input.x, input.y)
+  );
+  const visible = probe12(() => {
+    if (typeof target.Visibility?.isVisible === "function") {
+      return Boolean(target.Visibility.isVisible(input.playerId, input.x, input.y));
+    }
+    return revealedState.ok && revealedState.value !== 0;
+  });
+  return {
+    policy: input.includeHidden === true ? "include-hidden" : "visibility-filtered",
+    revealedState,
+    visible,
+    includeFacts: input.includeHidden === true || visible.ok && visible.value === true || revealedState.ok && revealedState.value !== 0
+  };
+}
+function mapProbe(target, name, location) {
+  return probe12(() => {
+    const fn2 = target.GameplayMap?.[name];
+    if (typeof fn2 !== "function") {
+      throw new Error(`GameplayMap.${name} is not a function`);
+    }
+    return fn2(location.x, location.y);
+  });
+}
+function locationsFromBounds(bounds, maxPlots) {
+  const out = [];
+  outer: for (let y = bounds.y; y < bounds.y + bounds.height; y += 1) {
+    for (let x = bounds.x; x < bounds.x + bounds.width; x += 1) {
+      out.push({ x, y });
+      if (out.length >= maxPlots) break outer;
+    }
+  }
+  return out;
+}
+function normalizePlotFields(fields) {
+  const selected = fields?.length ? fields : defaultPlotFields;
+  for (const field of selected) {
+    if (!allPlotFields.includes(field)) {
+      throw new Error(`Unsupported Civ7 plot field: ${field}`);
+    }
+  }
+  return Array.from(new Set(selected));
+}
+function hiddenInfoPolicy(input) {
+  if (input.playerId == null) return "not-player-scoped";
+  return input.includeHidden === true ? "include-hidden" : "visibility-filtered";
+}
+function mapBounds(bounds) {
+  return {
+    x: boundedInteger2(bounds.x, 0, 1e6, "bounds.x"),
+    y: boundedInteger2(bounds.y, 0, 1e6, "bounds.y"),
+    width: boundedInteger2(bounds.width, 1, 1e4, "bounds.width"),
+    height: boundedInteger2(bounds.height, 1, 1e4, "bounds.height")
+  };
+}
+function mapLocation(location) {
+  return {
+    x: boundedInteger2(location.x, 0, 1e6, "location.x"),
+    y: boundedInteger2(location.y, 0, 1e6, "location.y")
+  };
+}
+function boundedInteger2(value2, min3, max5, label) {
+  if (!Number.isInteger(value2) || value2 < min3 || value2 > max5) {
+    throw new Error(`${label} must be an integer ${min3}..${max5}.`);
+  }
+  return value2;
+}
+function gameUiRuntimeIdentity() {
+  return {
+    host: "game-ui",
+    port: 0,
+    state: { id: "game-ui", name: "Game UI" }
+  };
+}
+function probe12(fn2) {
+  try {
+    return { ok: true, value: fn2() };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}
+var defaultPlotFields = [
+  "terrain",
+  "biome",
+  "feature",
+  "resource",
+  "owner",
+  "visibility",
+  "areaRegion"
+];
+var allPlotFields = [
+  "terrain",
+  "biome",
+  "feature",
+  "resource",
+  "climate",
+  "hydrology",
+  "yields",
+  "owner",
+  "visibility",
+  "areaRegion",
+  "tags",
+  "city",
+  "units"
+];
 function installCiv7GameUiIntelligenceBridge(options = {}) {
   const target = options.target ?? globalThis;
   return installCiv7IntelligenceBridge({
@@ -38607,11 +39268,6 @@ function createCiv7GameUiControllerContextFactory(options) {
   });
 }
 function createCiv7GameUiDirectControlFacade(target) {
-  const unsupported = async () => {
-    throw new Error(
-      "Civ7 game UI controller dependency is not implemented for this procedure."
-    );
-  };
   return {
     requestCiv7ProductionChoice: async (input) => await requestCiv7GameUiProductionChoice(input, target),
     requestCiv7NotificationDismissal: async (input) => await requestCiv7GameUiNotificationDismissal(input, target),
@@ -38640,6 +39296,8 @@ function createCiv7GameUiDirectControlFacade(target) {
       maxNotifications: options?.maxNotifications
     }, target),
     getCiv7BattlefieldScan: async (input) => await getCiv7GameUiBattlefieldScan(input, target),
+    getCiv7PlotSnapshot: async (input) => await getCiv7GameUiPlotSnapshot(input, target),
+    getCiv7MapGrid: async (input) => await getCiv7GameUiMapGrid(input, target),
     getCiv7ReadyUnitView: async (input) => await getCiv7GameUiReadyUnitView(input, target),
     getCiv7ReadyCityView: async (input) => await getCiv7GameUiReadyCityView(input, target),
     getCiv7TargetCandidates: async (input) => await getCiv7GameUiTargetCandidates(input, target),
@@ -38648,10 +39306,10 @@ function createCiv7GameUiDirectControlFacade(target) {
 }
 function gameUiPlayableStatus(target) {
   const snapshot = gameUiSnapshot(target);
-  const inGame = probeValue7(snapshot.ui.inGame) === true;
-  const inShell = probeValue7(snapshot.ui.inShell) === true;
-  const inLoading = probeValue7(snapshot.ui.inLoading) === true;
-  const canBegin = probeValue7(snapshot.ui.canBeginGame) === true;
+  const inGame = probeValue72(snapshot.ui.inGame) === true;
+  const inShell = probeValue72(snapshot.ui.inShell) === true;
+  const inLoading = probeValue72(snapshot.ui.inLoading) === true;
+  const canBegin = probeValue72(snapshot.ui.canBeginGame) === true;
   const readiness = inGame ? "app-ui-game" : canBegin ? "begin-ready" : inLoading ? "loading" : inShell ? "shell" : "unavailable";
   return {
     host: "game-ui",
@@ -38744,6 +39402,9 @@ function gameUiSupportedReadProcedures(target) {
   if (gameUiWorldCurrentAvailable(target)) {
     supported2.push("world.current");
   }
+  if (civ7GameUiWorldMapReadsAvailable(target)) {
+    supported2.push("world.plot.read", "world.grid.read");
+  }
   return supported2;
 }
 function gameUiNotificationDismissalAvailable(target) {
@@ -38764,13 +39425,13 @@ function gameUiSnapshot(target) {
   return {
     network: {
       isInSession: ok2(Boolean(target.Network?.isInSession)),
-      numPlayers: probe12(() => target.Network?.getNumPlayers?.() ?? 0),
-      hostPlayerId: probe12(() => target.Network?.getHostPlayerId?.() ?? -1),
-      isConnectedToNetwork: probe12(
+      numPlayers: probe13(() => target.Network?.getNumPlayers?.() ?? 0),
+      hostPlayerId: probe13(() => target.Network?.getHostPlayerId?.() ?? -1),
+      isConnectedToNetwork: probe13(
         () => target.Network?.isConnectedToNetwork?.() ?? false
       ),
-      isAuthenticated: probe12(() => target.Network?.isAuthenticated?.() ?? false),
-      isLoggedIn: probe12(() => target.Network?.isLoggedIn?.() ?? false)
+      isAuthenticated: probe13(() => target.Network?.isAuthenticated?.() ?? false),
+      isLoggedIn: probe13(() => target.Network?.isLoggedIn?.() ?? false)
     },
     autoplay: {
       isActive: target.Autoplay?.isActive ?? false,
@@ -38784,18 +39445,18 @@ function gameUiSnapshot(target) {
       turn: target.Game?.turn ?? -1,
       age: target.Game?.age ?? -1,
       maxTurns: target.Game?.maxTurns ?? 0,
-      turnDate: probe12(() => target.Game?.getTurnDate?.() ?? ""),
-      hash: probe12(() => target.Game?.getHash?.() ?? 0)
+      turnDate: probe13(() => target.Game?.getTurnDate?.() ?? ""),
+      hash: probe13(() => target.Game?.getHash?.() ?? 0)
     },
     ui: {
-      inGame: probe12(() => target.UI?.isInGame?.() ?? false),
-      inShell: probe12(() => target.UI?.isInShell?.() ?? false),
-      inLoading: probe12(() => target.UI?.isInLoading?.() ?? false),
-      loadingState: probe12(() => target.UI?.getGameLoadingState?.() ?? -1),
+      inGame: probe13(() => target.UI?.isInGame?.() ?? false),
+      inShell: probe13(() => target.UI?.isInShell?.() ?? false),
+      inLoading: probe13(() => target.UI?.isInLoading?.() ?? false),
+      loadingState: probe13(() => target.UI?.getGameLoadingState?.() ?? -1),
       loadingStateName: loadingStateName(target),
       canBeginGame: canBeginGame(target),
       canNotifyUIReady: typeof target.UI?.notifyUIReady,
-      skipStartButton: probe12(
+      skipStartButton: probe13(
         () => target.Configuration?.getGame?.().skipStartButton ?? false
       ),
       automationActive: ok2(false)
@@ -38803,27 +39464,27 @@ function gameUiSnapshot(target) {
     gameContext: {
       localPlayerID: target.GameContext?.localPlayerID ?? -1,
       localObserverID: target.GameContext?.localObserverID ?? -1,
-      hasRequestedPause: probe12(
+      hasRequestedPause: probe13(
         () => target.GameContext?.hasRequestedPause?.() ?? false
       )
     },
     players: {
       maxPlayers: target.Players?.maxPlayers ?? 0,
-      aliveIds: probe12(() => target.Players?.getAliveIds?.() ?? []),
-      aliveHumanIds: probe12(() => target.Players?.getAliveHumanIds?.() ?? []),
-      numAliveHumans: probe12(() => target.Players?.getNumAliveHumans?.() ?? 0)
+      aliveIds: probe13(() => target.Players?.getAliveIds?.() ?? []),
+      aliveHumanIds: probe13(() => target.Players?.getAliveHumanIds?.() ?? []),
+      numAliveHumans: probe13(() => target.Players?.getNumAliveHumans?.() ?? 0)
     },
     map: {
-      width: probe12(() => target.GameplayMap?.getGridWidth?.() ?? 0),
-      height: probe12(() => target.GameplayMap?.getGridHeight?.() ?? 0),
-      plotCount: probe12(() => target.GameplayMap?.getPlotCount?.() ?? 0),
-      mapSize: probe12(() => target.GameplayMap?.getMapSize?.() ?? 0),
-      randomSeed: probe12(() => target.GameplayMap?.getRandomSeed?.() ?? 0)
+      width: probe13(() => target.GameplayMap?.getGridWidth?.() ?? 0),
+      height: probe13(() => target.GameplayMap?.getGridHeight?.() ?? 0),
+      plotCount: probe13(() => target.GameplayMap?.getPlotCount?.() ?? 0),
+      mapSize: probe13(() => target.GameplayMap?.getMapSize?.() ?? 0),
+      randomSeed: probe13(() => target.GameplayMap?.getRandomSeed?.() ?? 0)
     }
   };
 }
 function gameUiControllerMutationProof(target) {
-  if (probeValue7(probe12(() => target.UI?.isInGame?.() ?? false)) !== true) {
+  if (probeValue72(probe13(() => target.UI?.isInGame?.() ?? false)) !== true) {
     return null;
   }
   const localPlayerId = target.GameContext?.localPlayerID;
@@ -38845,18 +39506,18 @@ function gameUiControllerMutationProof(target) {
   };
 }
 function isSingleLocalHuman(target, localPlayerId) {
-  const aliveHumanIds = probe12(() => target.Players?.getAliveHumanIds?.());
+  const aliveHumanIds = probe13(() => target.Players?.getAliveHumanIds?.());
   if (aliveHumanIds.ok && Array.isArray(aliveHumanIds.value)) {
     return aliveHumanIds.value.length === 1 && aliveHumanIds.value[0] === localPlayerId;
   }
-  const aliveHumanCount = probe12(() => target.Players?.getNumAliveHumans?.());
+  const aliveHumanCount = probe13(() => target.Players?.getNumAliveHumans?.());
   return aliveHumanCount.ok && aliveHumanCount.value === 1;
 }
 function isControllerPlayerId(playerId) {
   return typeof playerId === "number" && Number.isInteger(playerId) && playerId >= 0 && playerId <= 255;
 }
 function canBeginGame(target) {
-  return probe12(() => {
+  return probe13(() => {
     const loadingState = target.UI?.getGameLoadingState?.();
     if (loadingState == null) return false;
     const states = target.UIGameLoadingState ?? {};
@@ -38870,7 +39531,7 @@ function loadingStateName(target) {
     ([, value2]) => value2 === loadingState
   )?.[0] ?? null;
 }
-function probe12(fn2) {
+function probe13(fn2) {
   try {
     return ok2(fn2());
   } catch (err) {
@@ -38880,8 +39541,8 @@ function probe12(fn2) {
 function ok2(value2) {
   return { ok: true, value: value2 };
 }
-function probeValue7(probe13) {
-  return probe13.ok ? probe13.value : void 0;
+function probeValue72(probe14) {
+  return probe14.ok ? probe14.value : void 0;
 }
 
 // src/ui/civ7-intelligence-bridge.ts

--- a/mods/mod-civ7-intelligence-bridge/mod/ui/civ7-intelligence-bridge.js
+++ b/mods/mod-civ7-intelligence-bridge/mod/ui/civ7-intelligence-bridge.js
@@ -27242,7 +27242,7 @@ function unitTargetProofNoRepeatAfterConfirmed(verification) {
   return verification.classification === "path-shortfall";
 }
 
-// ../../packages/civ7-control-orpc/dist/chunk-YCGAGJTW.js
+// ../../packages/civ7-control-orpc/dist/chunk-IXBCRY5S.js
 var Civ7ControlOrpcCorrelationIdSchema = typebox_exports.String({
   pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
 });
@@ -30187,9 +30187,14 @@ var Civ7StrategyFrontSummaryInputSchema = typebox_exports.Object(
   {
     playerId: typebox_exports.Optional(typebox_exports.Integer({ minimum: 0, maximum: 1024 })),
     origins: typebox_exports.Optional(typebox_exports.Array(Civ7ControlOrpcMapLocationSchema)),
+    target: typebox_exports.Optional(Civ7ControlOrpcMapLocationSchema),
     candidateLimit: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 8 })),
     scanRadius: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 32 })),
-    maxPlayers: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 128 }))
+    corridorRadius: typebox_exports.Optional(typebox_exports.Integer({ minimum: 0, maximum: 8 })),
+    destinationRadius: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 16 })),
+    maxPlayers: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 128 })),
+    maxUnits: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 256 })),
+    maxCities: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 128 }))
   },
   { additionalProperties: false }
 );
@@ -30209,7 +30214,11 @@ var Civ7StrategyRelationshipLabelPolicySchema = typebox_exports.Object(
 var Civ7StrategyFrontSourceStatusSchema = typebox_exports.Object(
   {
     targetCandidates: typebox_exports.Literal("read"),
-    battlefieldScan: typebox_exports.Literal("read")
+    battlefieldScan: typebox_exports.Literal("read"),
+    destinationAnalysis: typebox_exports.Union([
+      typebox_exports.Literal("read"),
+      typebox_exports.Literal("skipped-no-target")
+    ])
   },
   { additionalProperties: false }
 );
@@ -30234,7 +30243,24 @@ var Civ7StrategyFrontPointOfInterestSchema = typebox_exports.Object(
     kind: typebox_exports.String(),
     severity: typebox_exports.String(),
     location: typebox_exports.Union([Civ7ControlOrpcMapLocationSchema, typebox_exports.Null()]),
-    summary: typebox_exports.String()
+    summary: typebox_exports.String(),
+    source: typebox_exports.Union([
+      typebox_exports.Literal("battlefield"),
+      typebox_exports.Literal("destination")
+    ])
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyFrontPressureSchema = typebox_exports.Object(
+  {
+    kind: typebox_exports.String(),
+    severity: typebox_exports.String(),
+    summary: typebox_exports.String(),
+    location: typebox_exports.Union([Civ7ControlOrpcMapLocationSchema, typebox_exports.Null()]),
+    source: typebox_exports.Union([
+      typebox_exports.Literal("battlefield"),
+      typebox_exports.Literal("destination")
+    ])
   },
   { additionalProperties: false }
 );
@@ -30269,6 +30295,7 @@ var Civ7StrategyFrontSummaryResultSchema = typebox_exports.Object(
     playerId: typebox_exports.Integer({ minimum: 0 }),
     localPlayerId: typebox_exports.Integer({ minimum: 0 }),
     origins: typebox_exports.Array(Civ7ControlOrpcMapLocationSchema),
+    target: typebox_exports.Union([Civ7ControlOrpcMapLocationSchema, typebox_exports.Null()]),
     sourceStatus: Civ7StrategyFrontSourceStatusSchema,
     relationshipLabelPolicy: Civ7StrategyRelationshipLabelPolicySchema,
     summary: typebox_exports.Object(
@@ -30277,6 +30304,16 @@ var Civ7StrategyFrontSummaryResultSchema = typebox_exports.Object(
         pointOfInterestCount: typebox_exports.Integer({ minimum: 0 }),
         observedOwnerCount: typebox_exports.Integer({ minimum: 0 }),
         nextStepCount: typebox_exports.Integer({ minimum: 0 })
+      },
+      { additionalProperties: false }
+    ),
+    front: typebox_exports.Object(
+      {
+        posture: typebox_exports.String(),
+        headline: typebox_exports.String(),
+        risks: typebox_exports.Array(typebox_exports.String()),
+        nextInspections: typebox_exports.Array(Civ7StrategyFrontSummaryNextStepSchema),
+        pressure: typebox_exports.Array(Civ7StrategyFrontPressureSchema)
       },
       { additionalProperties: false }
     ),
@@ -32812,10 +32849,21 @@ var strategyFrontSummaryProcedure = civ7ControlOrpcImplementer.strategy.frontSum
           context5.endpointDefaults
         )
       ]);
+      const target = input.target ?? firstCandidateCityLocation(targetCandidates.candidates);
+      const destinationAnalysis = target == null ? null : await context5.directControl.getCiv7DestinationAnalysis(
+        destinationAnalysisInput({
+          input,
+          target,
+          origin: targetCandidates.origins[0] ?? battlefieldScan.origins[0]
+        }),
+        context5.endpointDefaults
+      );
       return strategyFrontSummaryResult({
         input,
         targetCandidates,
-        battlefieldScan
+        battlefieldScan,
+        destinationAnalysis,
+        target
       });
     },
     catch: () => errors.STRATEGY_FRONT_SUMMARY_UNAVAILABLE({
@@ -32842,13 +32890,31 @@ function battlefieldScanInput(input) {
     origins: input.origins,
     radius: input.scanRadius ?? 8,
     maxPlayers: input.maxPlayers,
-    maxUnits: 48,
-    maxCities: 24
+    maxUnits: input.maxUnits ?? 48,
+    maxCities: input.maxCities ?? 24
+  };
+}
+function destinationAnalysisInput({
+  input,
+  target,
+  origin
+}) {
+  return {
+    playerId: input.playerId,
+    origin,
+    destination: target,
+    corridorRadius: input.corridorRadius ?? 2,
+    destinationRadius: input.destinationRadius ?? 4,
+    maxPlayers: input.maxPlayers,
+    maxUnits: input.maxUnits,
+    maxCities: input.maxCities
   };
 }
 function strategyFrontSummaryResult({
   targetCandidates,
-  battlefieldScan
+  battlefieldScan,
+  destinationAnalysis,
+  target
 }) {
   const targetCandidateSummaries = targetCandidates.candidates.map(
     (candidate2) => ({
@@ -32865,12 +32931,22 @@ function strategyFrontSummaryResult({
       reasons: [...candidate2.reasons]
     })
   );
-  const pointsOfInterest2 = battlefieldScan.pointsOfInterest.map((point) => ({
-    kind: point.kind,
-    severity: point.severity,
-    location: point.location,
-    summary: normalizeRelationshipSummary(point.summary)
-  }));
+  const pointsOfInterest2 = [
+    ...battlefieldScan.pointsOfInterest.map((point) => ({
+      kind: point.kind,
+      severity: point.severity,
+      location: point.location,
+      summary: normalizeRelationshipSummary(point.summary),
+      source: "battlefield"
+    })),
+    ...destinationAnalysis?.pointsOfInterest.map((point) => ({
+      kind: point.kind,
+      severity: point.severity,
+      location: point.location,
+      summary: normalizeRelationshipSummary(point.summary),
+      source: "destination"
+    })) ?? []
+  ];
   const observedOwners = battlefieldScan.owners.map((owner) => ({
     owner: owner.owner,
     relationship: owner.relationshipProof === "self" ? "self" : "relationship-unproven",
@@ -32884,13 +32960,23 @@ function strategyFrontSummaryResult({
     targetCandidates: targetCandidateSummaries,
     pointsOfInterest: pointsOfInterest2
   });
+  const front = strategyFrontView({
+    origins: targetCandidates.origins.length > 0 ? targetCandidates.origins : battlefieldScan.origins,
+    target,
+    targetCandidates: targetCandidateSummaries,
+    pointsOfInterest: pointsOfInterest2,
+    destinationAnalysis,
+    nextSteps
+  });
   return {
     playerId: targetCandidates.playerId,
     localPlayerId: targetCandidates.localPlayerId,
     origins: targetCandidates.origins.length > 0 ? targetCandidates.origins : battlefieldScan.origins,
+    target,
     sourceStatus: {
       targetCandidates: "read",
-      battlefieldScan: "read"
+      battlefieldScan: "read",
+      destinationAnalysis: destinationAnalysis == null ? "skipped-no-target" : "read"
     },
     relationshipLabelPolicy: {
       relationshipSource: "not-classified",
@@ -32904,6 +32990,7 @@ function strategyFrontSummaryResult({
       observedOwnerCount: observedOwners.length,
       nextStepCount: nextSteps.length
     },
+    front,
     targetCandidates: targetCandidateSummaries,
     pointsOfInterest: pointsOfInterest2,
     observedOwners,
@@ -32970,8 +33057,98 @@ function strategyNextSteps({
   }
   return nextSteps;
 }
+function strategyFrontView({
+  origins,
+  target,
+  targetCandidates,
+  pointsOfInterest: pointsOfInterest2,
+  destinationAnalysis,
+  nextSteps
+}) {
+  const pressure = [...pointsOfInterest2].map((point) => ({
+    kind: point.kind,
+    severity: point.severity,
+    summary: point.summary,
+    location: point.location,
+    source: point.source
+  })).sort((a, b) => severityRank(b.severity) - severityRank(a.severity));
+  const highPressure = pressure.filter((item) => item.severity === "high");
+  const risks = uniqueStrings([
+    ...highPressure.map((item) => item.summary),
+    ...destinationRisks(destinationAnalysis)
+  ]).slice(0, 8);
+  const origin = origins[0] ?? null;
+  const candidate2 = targetCandidates[0];
+  const targetLabel = target ? `target/front (${target.x},${target.y})` : "no target/front selected";
+  const originLabel = origin ? `origin (${origin.x},${origin.y})` : "inferred runtime origins";
+  const candidateLabel = candidate2 ? `owner ${candidate2.owner}` : "no ranked target candidate";
+  return {
+    posture: postureFromPressure(pressure, destinationAnalysis),
+    headline: `${originLabel} toward ${targetLabel}; leading candidate: ${candidateLabel}`,
+    risks,
+    nextInspections: nextSteps,
+    pressure
+  };
+}
+function destinationRisks(destinationAnalysis) {
+  const pressure = asRecord(destinationAnalysis?.destinationPressure);
+  const risks = [];
+  const unitCount = Number(pressure?.unitCount ?? 0);
+  const cityCount = Number(pressure?.cityCount ?? 0);
+  const apparentOtherStrength = Number(pressure?.apparentOtherStrength ?? 0);
+  if (unitCount > 0) {
+    risks.push(`${unitCount} other-owner units near intended front`);
+  }
+  if (cityCount > 0) {
+    risks.push(`${cityCount} relationship-unproven cities near intended front`);
+  }
+  if (apparentOtherStrength > 0) {
+    risks.push(`apparent destination contact ${apparentOtherStrength}`);
+  }
+  return risks;
+}
+function postureFromPressure(pressure, destinationAnalysis) {
+  if (pressure.some(
+    (item) => item.kind === "civilian-risk" && item.severity === "high"
+  )) return "screen-civilians-before-advance";
+  if (pressure.some(
+    (item) => item.kind === "nearby-other-owners" && item.severity === "high"
+  )) return "stabilize-front-before-committing-siege";
+  const destinationPressure = asRecord(destinationAnalysis?.destinationPressure);
+  if (Number(destinationPressure?.unitCount ?? 0) > 0 || Number(destinationPressure?.cityCount ?? 0) > 0) {
+    return "stage-before-entering-target-contact";
+  }
+  return "inspect-and-advance-cautiously";
+}
+function severityRank(severity) {
+  if (severity === "high") return 3;
+  if (severity === "medium") return 2;
+  if (severity === "low") return 1;
+  return 0;
+}
 function normalizeRelationshipSummary(summary5) {
   return summary5.replace(/\bfriendly\b/gi, "own").replace(/\bpressure\b/gi, "contact").replace(/\bthreat\b/gi, "contact");
+}
+function firstCandidateCityLocation(candidates) {
+  for (const candidate2 of candidates) {
+    if (candidate2.approach.targetLocation != null) {
+      return candidate2.approach.targetLocation;
+    }
+    const cityLocation2 = locationFromUnknown(candidate2.nearestCity);
+    if (cityLocation2 != null) return cityLocation2;
+  }
+  return null;
+}
+function locationFromUnknown(value2) {
+  const record = asRecord(value2);
+  const location = asRecord(record?.location);
+  return typeof location?.x === "number" && typeof location.y === "number" ? { x: location.x, y: location.y } : null;
+}
+function asRecord(value2) {
+  return value2 !== null && typeof value2 === "object" ? value2 : null;
+}
+function uniqueStrings(values3) {
+  return [...new Set(values3.filter((value2) => value2.length > 0))];
 }
 var strategyRouter = {
   frontSummary: strategyFrontSummaryProcedure
@@ -38541,6 +38718,72 @@ async function getCiv7GameUiBattlefieldScan(input = {}, target = globalThis) {
     ]
   };
 }
+async function getCiv7GameUiDestinationAnalysis(input, target = globalThis) {
+  if (!civ7GameUiStrategyFrontAvailable(target)) {
+    throw new Error("Civ7 game UI strategy front dependency is unavailable.");
+  }
+  const localPlayerId = target.GameContext?.localPlayerID ?? 0;
+  const playerId = input.playerId ?? localPlayerId;
+  const destinationRadius = boundedInteger(input.destinationRadius ?? 4, 1, 16);
+  const corridorRadius = boundedInteger(input.corridorRadius ?? 2, 0, 8);
+  const scan = await getCiv7GameUiBattlefieldScan({
+    playerId,
+    origins: [input.destination],
+    radius: destinationRadius,
+    maxPlayers: input.maxPlayers,
+    maxUnits: input.maxUnits,
+    maxCities: input.maxCities
+  }, target);
+  const destinationUnits = scan.units.map((unit) => ({
+    ...unit,
+    destinationDistance: unit.distance
+  }));
+  const destinationCities = scan.cities.map((city) => ({
+    ...city,
+    destinationDistance: city.distance
+  }));
+  return {
+    host: "game-ui",
+    port: 0,
+    state: { id: "game-ui", name: "Game UI" },
+    localPlayerId,
+    playerId,
+    origin: input.origin ?? null,
+    destination: input.destination,
+    corridorRadius,
+    destinationRadius,
+    hiddenInfoPolicy: "game-ui-runtime-summary; may include game-resident unit or city summaries until paired with visibility reads",
+    relationshipLabelPolicy,
+    corridor: {
+      routeHint: "direct-grid",
+      directGridDistance: input.origin == null ? null : distance(input.origin, input.destination),
+      sampleCount: input.origin == null ? 0 : 2,
+      sampledPlots: input.origin == null ? [] : [input.origin, input.destination],
+      units: [],
+      unitCount: 0
+    },
+    destinationPressure: {
+      units: destinationUnits,
+      unitCount: destinationUnits.length,
+      cities: destinationCities,
+      cityCount: destinationCities.length,
+      apparentOtherStrength: scan.owners.filter((owner) => owner.relationshipProof !== "self").reduce((sum2, owner) => sum2 + owner.apparentStrength, 0)
+    },
+    pointsOfInterest: scan.pointsOfInterest.map((point) => ({
+      kind: point.kind,
+      severity: point.severity,
+      location: point.location,
+      summary: point.summary,
+      units: destinationUnits,
+      cities: destinationCities
+    })),
+    notes: [
+      "Read-only game UI destination-analysis runtime port for strategy.frontSummary.",
+      "Owner mismatch and proximity remain relationship-unproven planning evidence.",
+      "Use visibility and validator-backed unit action procedures before any mutation."
+    ]
+  };
+}
 var relationshipLabelPolicy = {
   relationshipSource: "not-classified",
   relationshipProof: "none",
@@ -39296,6 +39539,7 @@ function createCiv7GameUiDirectControlFacade(target) {
       maxNotifications: options?.maxNotifications
     }, target),
     getCiv7BattlefieldScan: async (input) => await getCiv7GameUiBattlefieldScan(input, target),
+    getCiv7DestinationAnalysis: async (input) => await getCiv7GameUiDestinationAnalysis(input, target),
     getCiv7PlotSnapshot: async (input) => await getCiv7GameUiPlotSnapshot(input, target),
     getCiv7MapGrid: async (input) => await getCiv7GameUiMapGrid(input, target),
     getCiv7ReadyUnitView: async (input) => await getCiv7GameUiReadyUnitView(input, target),

--- a/mods/mod-civ7-intelligence-bridge/mod/ui/civ7-intelligence-bridge.js
+++ b/mods/mod-civ7-intelligence-bridge/mod/ui/civ7-intelligence-bridge.js
@@ -27242,7 +27242,7 @@ function unitTargetProofNoRepeatAfterConfirmed(verification) {
   return verification.classification === "path-shortfall";
 }
 
-// ../../packages/civ7-control-orpc/dist/chunk-CR22UR4G.js
+// ../../packages/civ7-control-orpc/dist/chunk-SLERNDVZ.js
 var Civ7ControlOrpcCorrelationIdSchema = typebox_exports.String({
   pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
 });
@@ -28178,6 +28178,24 @@ var Civ7StrategyFrontSummaryUnavailableError = class extends ORPCTaggedError(
   }
 ) {
 };
+var Civ7WorldCurrentUnavailableErrorDataSchema = typebox_exports.Object(
+  {
+    procedureKey: typebox_exports.Literal("world.current"),
+    source: typebox_exports.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldCurrentUnavailableError = class extends ORPCTaggedError(
+  "Civ7WorldCurrentUnavailableError",
+  {
+    code: "WORLD_CURRENT_UNAVAILABLE",
+    message: "Current world view failed.",
+    schema: toStandardSchema(Civ7WorldCurrentUnavailableErrorDataSchema),
+    status: 503
+  }
+) {
+};
 var Civ7NotificationDismissalUnavailableErrorDataSchema = typebox_exports.Object(
   {
     procedureKey: typebox_exports.Literal("notifications.dismiss.request"),
@@ -28556,7 +28574,8 @@ var civ7ControlOrpcErrorMap = {
   TOWN_FOCUS_UNAVAILABLE: Civ7TownFocusUnavailableError,
   TURN_COMPLETION_UNAVAILABLE: Civ7TurnCompletionUnavailableError,
   UNIT_REQUEST_UNAVAILABLE: Civ7UnitRequestUnavailableError,
-  UNIT_TARGET_ACTION_UNAVAILABLE: Civ7UnitTargetActionUnavailableError
+  UNIT_TARGET_ACTION_UNAVAILABLE: Civ7UnitTargetActionUnavailableError,
+  WORLD_CURRENT_UNAVAILABLE: Civ7WorldCurrentUnavailableError
 };
 var civ7ControlOrpcContractBase = eoc.$meta({}).errors(civ7ControlOrpcErrorMap);
 var Civ7ControlOrpcComponentIdSchema = typebox_exports.Object(
@@ -30005,6 +30024,7 @@ var Civ7ReadinessNextStepSchema = typebox_exports.Object(
     kind: typebox_exports.Union([
       typebox_exports.Literal("read-attention"),
       typebox_exports.Literal("read-strategy-front"),
+      typebox_exports.Literal("read-world"),
       typebox_exports.Literal("restore-tuner"),
       typebox_exports.Literal("begin-game"),
       typebox_exports.Literal("wait-loading"),
@@ -30606,6 +30626,110 @@ var Civ7UnitContract = {
     request: Civ7UnitUpgradeContract
   }
 };
+var NullableNumberSchema = typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()]);
+var NullableIntegerSchema = typebox_exports.Union([typebox_exports.Integer(), typebox_exports.Null()]);
+var Civ7WorldCurrentInputSchema = typebox_exports.Object(
+  {},
+  { additionalProperties: false }
+);
+var Civ7WorldCurrentSourceStatusSchema = typebox_exports.Union([
+  typebox_exports.Literal("read"),
+  typebox_exports.Literal("skipped-not-playable"),
+  typebox_exports.Literal("skipped-unavailable")
+]);
+var Civ7WorldCurrentTurnSchema = typebox_exports.Object(
+  {
+    current: NullableNumberSchema,
+    date: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+    age: NullableNumberSchema,
+    maxTurns: NullableNumberSchema,
+    hash: NullableNumberSchema
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldCurrentLocalPlayerSchema = typebox_exports.Object(
+  {
+    playerId: NullableIntegerSchema,
+    observerId: NullableIntegerSchema
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldCurrentMapSchema = typebox_exports.Object(
+  {
+    width: NullableNumberSchema,
+    height: NullableNumberSchema,
+    plotCount: NullableNumberSchema,
+    mapSize: NullableNumberSchema,
+    randomSeed: NullableNumberSchema
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldCurrentPlayersSchema = typebox_exports.Object(
+  {
+    maxPlayers: NullableNumberSchema,
+    alivePlayerIds: typebox_exports.Array(typebox_exports.Integer({ minimum: 0 })),
+    aliveHumanIds: typebox_exports.Array(typebox_exports.Integer({ minimum: 0 })),
+    aliveHumanCount: NullableNumberSchema
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldCurrentNextStepSchema = typebox_exports.Object(
+  {
+    kind: typebox_exports.Union([
+      typebox_exports.Literal("read-attention"),
+      typebox_exports.Literal("restore-readiness"),
+      typebox_exports.Literal("enter-game"),
+      typebox_exports.Literal("inspect-world")
+    ]),
+    source: typebox_exports.Literal("world.current"),
+    label: typebox_exports.String()
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldCurrentResultSchema = typebox_exports.Object(
+  {
+    playable: typebox_exports.Boolean(),
+    readiness: typebox_exports.String(),
+    sourceStatus: typebox_exports.Object(
+      {
+        playableStatus: typebox_exports.Literal("read"),
+        game: Civ7WorldCurrentSourceStatusSchema,
+        map: Civ7WorldCurrentSourceStatusSchema,
+        players: Civ7WorldCurrentSourceStatusSchema
+      },
+      { additionalProperties: false }
+    ),
+    turn: Civ7WorldCurrentTurnSchema,
+    localPlayer: Civ7WorldCurrentLocalPlayerSchema,
+    map: Civ7WorldCurrentMapSchema,
+    players: Civ7WorldCurrentPlayersSchema,
+    summary: typebox_exports.Object(
+      {
+        hasMapDimensions: typebox_exports.Boolean(),
+        alivePlayerCount: NullableIntegerSchema,
+        nextStepCount: typebox_exports.Integer({ minimum: 0 })
+      },
+      { additionalProperties: false }
+    ),
+    nextSteps: typebox_exports.Array(Civ7WorldCurrentNextStepSchema)
+  },
+  { additionalProperties: false }
+);
+var Civ7WorldCurrentInputStandardSchema = toStandardSchema(
+  Civ7WorldCurrentInputSchema
+);
+var Civ7WorldCurrentResultStandardSchema = toStandardSchema(
+  Civ7WorldCurrentResultSchema
+);
+var Civ7WorldCurrentContract = civ7ControlOrpcContractBase.input(Civ7WorldCurrentInputStandardSchema).output(Civ7WorldCurrentResultStandardSchema).meta({
+  family: "world",
+  procedureKey: "world.current",
+  proofBoundary: "local-package-test",
+  risk: "read-only"
+});
+var Civ7WorldContract = {
+  current: Civ7WorldCurrentContract
+};
 var Civ7ControlOrpcContract = civ7ControlOrpcContractBase.router({
   attention: Civ7AttentionContract,
   city: Civ7CityContract,
@@ -30617,7 +30741,8 @@ var Civ7ControlOrpcContract = civ7ControlOrpcContractBase.router({
   readiness: Civ7ReadinessContract,
   strategy: Civ7StrategyContract,
   turn: Civ7TurnContract,
-  unit: Civ7UnitContract
+  unit: Civ7UnitContract,
+  world: Civ7WorldContract
 });
 var civ7ControlOrpcEffectRuntime = ManagedRuntime_exports.make(Layer_exports.empty);
 var civ7ControlOrpcBaseImplementer = implementEffect(
@@ -32413,6 +32538,13 @@ function readinessNextSteps(status, context5) {
       label: "Read strategy front summary before choosing tactical support actions."
     }];
   }
+  if (status.readiness === "app-ui-game" && supportsWorldCurrent(context5)) {
+    return [{
+      kind: "read-world",
+      source: "readiness.current",
+      label: "Read current world facts before choosing support actions."
+    }];
+  }
   switch (status.readiness) {
     case "app-ui-game":
       return [{
@@ -32452,6 +32584,9 @@ function supportsAttentionCurrent(context5) {
 }
 function supportsStrategyFront(context5) {
   return supportedReadProcedures(context5).includes("strategy.frontSummary");
+}
+function supportsWorldCurrent(context5) {
+  return supportedReadProcedures(context5).includes("world.current");
 }
 function supportedReadProcedures(context5) {
   return context5.controller?.supportedReadProcedures ?? [];
@@ -33029,6 +33164,156 @@ var unitRouter = {
     request: unitUpgradeRequestProcedure
   }
 };
+var worldCurrentProcedure = civ7ControlOrpcImplementer.world.current.effect(function* ({
+  context: context5,
+  errors
+}) {
+  return yield* Effect_exports.tryPromise({
+    try: async () => worldCurrentResult(
+      await context5.directControl.getCiv7PlayableStatus(
+        context5.endpointDefaults
+      )
+    ),
+    catch: () => errors.WORLD_CURRENT_UNAVAILABLE({
+      data: {
+        procedureKey: "world.current",
+        source: "direct-control-facade",
+        ...civ7ControlOrpcErrorCorrelationData(context5)
+      }
+    })
+  });
+});
+function worldCurrentResult(status) {
+  const inGame = status.playable || status.readiness === "app-ui-game";
+  const snapshot = status.appUi.snapshot;
+  const map16 = inGame ? worldMapFacts(status) : emptyMapFacts();
+  const players = inGame ? worldPlayerFacts(status) : emptyPlayerFacts();
+  const nextSteps = worldCurrentNextSteps(status, map16);
+  return {
+    playable: status.playable,
+    readiness: status.readiness,
+    sourceStatus: {
+      playableStatus: "read",
+      game: inGame ? "read" : "skipped-not-playable",
+      map: inGame ? mapSourceStatus(snapshot.map) : "skipped-not-playable",
+      players: inGame ? playersSourceStatus(snapshot.players) : "skipped-not-playable"
+    },
+    turn: inGame ? {
+      current: status.appUi.snapshot.game.turn,
+      date: probeValue5(status.appUi.snapshot.game.turnDate),
+      age: status.appUi.snapshot.game.age,
+      maxTurns: status.appUi.snapshot.game.maxTurns,
+      hash: probeValue5(status.appUi.snapshot.game.hash)
+    } : {
+      current: null,
+      date: null,
+      age: null,
+      maxTurns: null,
+      hash: null
+    },
+    localPlayer: inGame ? {
+      playerId: playerIdOrNull(status.appUi.snapshot.gameContext.localPlayerID),
+      observerId: playerIdOrNull(
+        status.appUi.snapshot.gameContext.localObserverID
+      )
+    } : {
+      playerId: null,
+      observerId: null
+    },
+    map: map16,
+    players,
+    summary: {
+      hasMapDimensions: map16.width != null && map16.height != null && map16.width > 0 && map16.height > 0,
+      alivePlayerCount: players.alivePlayerIds.length,
+      nextStepCount: nextSteps.length
+    },
+    nextSteps
+  };
+}
+function worldMapFacts(status) {
+  const map16 = status.appUi.snapshot.map;
+  return {
+    width: probeValue5(map16.width),
+    height: probeValue5(map16.height),
+    plotCount: probeValue5(map16.plotCount),
+    mapSize: probeValue5(map16.mapSize),
+    randomSeed: probeValue5(map16.randomSeed)
+  };
+}
+function emptyMapFacts() {
+  return {
+    width: null,
+    height: null,
+    plotCount: null,
+    mapSize: null,
+    randomSeed: null
+  };
+}
+function worldPlayerFacts(status) {
+  const players = status.appUi.snapshot.players;
+  return {
+    maxPlayers: status.appUi.snapshot.players.maxPlayers,
+    alivePlayerIds: integerArrayOrEmpty(probeValue5(players.aliveIds)),
+    aliveHumanIds: integerArrayOrEmpty(probeValue5(players.aliveHumanIds)),
+    aliveHumanCount: probeValue5(players.numAliveHumans)
+  };
+}
+function emptyPlayerFacts() {
+  return {
+    maxPlayers: null,
+    alivePlayerIds: [],
+    aliveHumanIds: [],
+    aliveHumanCount: null
+  };
+}
+function worldCurrentNextSteps(status, map16) {
+  if (status.playable || status.readiness === "app-ui-game") {
+    if (map16.width == null || map16.height == null) {
+      return [{
+        kind: "inspect-world",
+        source: "world.current",
+        label: "World map facts are incomplete; inspect current world evidence before acting."
+      }];
+    }
+    return [{
+      kind: "read-attention",
+      source: "world.current",
+      label: "Read current attention before choosing support actions."
+    }];
+  }
+  if (status.readiness === "shell") {
+    return [{
+      kind: "enter-game",
+      source: "world.current",
+      label: "Enter an active game before reading current world facts."
+    }];
+  }
+  return [{
+    kind: "restore-readiness",
+    source: "world.current",
+    label: "Restore playable or game UI readiness before reading current world facts."
+  }];
+}
+function mapSourceStatus(map16) {
+  return map16.width.ok || map16.height.ok || map16.plotCount.ok || map16.mapSize.ok ? "read" : "skipped-unavailable";
+}
+function playersSourceStatus(players) {
+  return players.aliveIds.ok || players.aliveHumanIds.ok || players.numAliveHumans.ok ? "read" : "skipped-unavailable";
+}
+function probeValue5(probe13) {
+  return probe13.ok ? probe13.value : null;
+}
+function integerArrayOrEmpty(value2) {
+  return Array.isArray(value2) ? value2.filter(
+    (item) => Number.isInteger(item) && item >= 0
+  ) : [];
+}
+function playerIdOrNull(value2) {
+  return Number.isInteger(value2) && Number(value2) >= 0 ? Number(value2) : null;
+}
+var worldRouter = {
+  current: worldCurrentProcedure
+};
 var Civ7ControlOrpcRouter = civ7ControlOrpcImplementer.router({
   attention: attentionRouter,
   city: cityRouter,
@@ -33040,7 +33325,8 @@ var Civ7ControlOrpcRouter = civ7ControlOrpcImplementer.router({
   readiness: readinessRouter,
   strategy: strategyRouter,
   turn: turnRouter,
-  unit: unitRouter
+  unit: unitRouter,
+  world: worldRouter
 });
 function createCiv7ControlOrpcServerClient(context5) {
   return createRouterClient(Civ7ControlOrpcRouter, { context: context5 });
@@ -33062,6 +33348,12 @@ var Civ7StrategyFrontSummaryInputSchema2 = typeboxInputSchemaFromContractProcedu
 );
 var Civ7StrategyFrontSummaryResultSchema2 = typeboxOutputSchemaFromContractProcedure(
   Civ7ControlOrpcContract.strategy.frontSummary
+);
+var Civ7WorldCurrentInputSchema2 = typeboxInputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.world.current
+);
+var Civ7WorldCurrentResultSchema2 = typeboxOutputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.world.current
 );
 var Civ7NotificationDismissInputSchema2 = typeboxInputSchemaFromContractProcedure(
   Civ7ControlOrpcContract.notifications.dismiss.request
@@ -33232,6 +33524,14 @@ var Civ7ControllerBridgeStrategyFrontSummaryRequestSchema = typebox_exports.Obje
   {
     procedureKey: typebox_exports.Literal("strategy.frontSummary"),
     input: Civ7StrategyFrontSummaryInputSchema2,
+    correlationId: typebox_exports.Optional(Civ7ControlOrpcCorrelationIdSchema)
+  },
+  { additionalProperties: false }
+);
+var Civ7ControllerBridgeWorldCurrentRequestSchema = typebox_exports.Object(
+  {
+    procedureKey: typebox_exports.Literal("world.current"),
+    input: Civ7WorldCurrentInputSchema2,
     correlationId: typebox_exports.Optional(Civ7ControlOrpcCorrelationIdSchema)
   },
   { additionalProperties: false }
@@ -33416,6 +33716,7 @@ var Civ7ControllerBridgeRequestSchema = typebox_exports.Union([
   Civ7ControllerBridgeReadinessCurrentRequestSchema,
   Civ7ControllerBridgeAttentionCurrentRequestSchema,
   Civ7ControllerBridgeStrategyFrontSummaryRequestSchema,
+  Civ7ControllerBridgeWorldCurrentRequestSchema,
   Civ7ControllerBridgeNotificationDismissRequestSchema,
   Civ7ControllerBridgeTurnCompleteRequestSchema,
   Civ7ControllerBridgeCityProductionChoiceRequestSchema,
@@ -33475,6 +33776,15 @@ var Civ7ControllerBridgeStrategyFrontSummarySuccessResponseSchema = typebox_expo
     ok: typebox_exports.Literal(true),
     procedureKey: typebox_exports.Literal("strategy.frontSummary"),
     output: Civ7StrategyFrontSummaryResultSchema2,
+    correlationId: typebox_exports.Optional(Civ7ControlOrpcCorrelationIdSchema)
+  },
+  { additionalProperties: false }
+);
+var Civ7ControllerBridgeWorldCurrentSuccessResponseSchema = typebox_exports.Object(
+  {
+    ok: typebox_exports.Literal(true),
+    procedureKey: typebox_exports.Literal("world.current"),
+    output: Civ7WorldCurrentResultSchema2,
     correlationId: typebox_exports.Optional(Civ7ControlOrpcCorrelationIdSchema)
   },
   { additionalProperties: false }
@@ -33681,6 +33991,7 @@ var Civ7ControllerBridgeSuccessResponseSchema = typebox_exports.Union([
   Civ7ControllerBridgeReadinessCurrentSuccessResponseSchema,
   Civ7ControllerBridgeAttentionCurrentSuccessResponseSchema,
   Civ7ControllerBridgeStrategyFrontSummarySuccessResponseSchema,
+  Civ7ControllerBridgeWorldCurrentSuccessResponseSchema,
   Civ7ControllerBridgeNotificationDismissSuccessResponseSchema,
   Civ7ControllerBridgeTurnCompleteSuccessResponseSchema,
   Civ7ControllerBridgeCityProductionChoiceSuccessResponseSchema,
@@ -33775,6 +34086,15 @@ async function invokeCiv7ControllerBridgeRequest(request2, options) {
       return {
         ok: true,
         procedureKey: "strategy.frontSummary",
+        output: output2,
+        ...request2.correlationId == null ? {} : { correlationId: request2.correlationId }
+      };
+    }
+    if (request2.procedureKey === "world.current") {
+      const output2 = await client.world.current(validatedInput);
+      return {
+        ok: true,
+        procedureKey: "world.current",
         output: output2,
         ...request2.correlationId == null ? {} : { correlationId: request2.correlationId }
       };
@@ -34021,7 +34341,7 @@ function controllerProofFromContext(context5) {
 function isUnsupportedProcedureRequest(request2) {
   if (request2 == null || typeof request2 !== "object") return false;
   if (!("procedureKey" in request2)) return false;
-  return typeof request2.procedureKey === "string" && request2.procedureKey !== "readiness.current" && request2.procedureKey !== "attention.current" && request2.procedureKey !== "strategy.frontSummary" && request2.procedureKey !== "notifications.dismiss.request" && request2.procedureKey !== "turn.complete.request" && request2.procedureKey !== "city.production.choice.request" && request2.procedureKey !== "city.population.place.request" && request2.procedureKey !== "city.townFocus.change.request" && request2.procedureKey !== "city.townFocus.review.request" && request2.procedureKey !== "narrative.choice.request" && request2.procedureKey !== "diplomacy.response.request" && request2.procedureKey !== "diplomacy.firstMeet.response.request" && request2.procedureKey !== "government.choice.request" && request2.procedureKey !== "government.celebration.choice.request" && request2.procedureKey !== "unit.target.action.request" && request2.procedureKey !== "unit.upgrade.request" && request2.procedureKey !== "unit.resettle.request" && request2.procedureKey !== "progression.technology.choice.request" && request2.procedureKey !== "progression.culture.choice.request" && request2.procedureKey !== "progression.technology.target.request" && request2.procedureKey !== "progression.culture.target.request" && request2.procedureKey !== "progression.attribute.purchase.request" && request2.procedureKey !== "progression.attribute.review.request" && request2.procedureKey !== "progression.tradition.change.request" && request2.procedureKey !== "progression.tradition.review.request";
+  return typeof request2.procedureKey === "string" && request2.procedureKey !== "readiness.current" && request2.procedureKey !== "attention.current" && request2.procedureKey !== "strategy.frontSummary" && request2.procedureKey !== "world.current" && request2.procedureKey !== "notifications.dismiss.request" && request2.procedureKey !== "turn.complete.request" && request2.procedureKey !== "city.production.choice.request" && request2.procedureKey !== "city.population.place.request" && request2.procedureKey !== "city.townFocus.change.request" && request2.procedureKey !== "city.townFocus.review.request" && request2.procedureKey !== "narrative.choice.request" && request2.procedureKey !== "diplomacy.response.request" && request2.procedureKey !== "diplomacy.firstMeet.response.request" && request2.procedureKey !== "government.choice.request" && request2.procedureKey !== "government.celebration.choice.request" && request2.procedureKey !== "unit.target.action.request" && request2.procedureKey !== "unit.upgrade.request" && request2.procedureKey !== "unit.resettle.request" && request2.procedureKey !== "progression.technology.choice.request" && request2.procedureKey !== "progression.culture.choice.request" && request2.procedureKey !== "progression.technology.target.request" && request2.procedureKey !== "progression.culture.target.request" && request2.procedureKey !== "progression.attribute.purchase.request" && request2.procedureKey !== "progression.attribute.review.request" && request2.procedureKey !== "progression.tradition.change.request" && request2.procedureKey !== "progression.tradition.review.request";
 }
 function isControllerBridgeMutationRequest(request2) {
   return request2.procedureKey === "notifications.dismiss.request" || request2.procedureKey === "turn.complete.request" || request2.procedureKey === "city.production.choice.request" || request2.procedureKey === "city.population.place.request" || request2.procedureKey === "city.townFocus.change.request" || request2.procedureKey === "city.townFocus.review.request" || request2.procedureKey === "narrative.choice.request" || request2.procedureKey === "diplomacy.response.request" || request2.procedureKey === "diplomacy.firstMeet.response.request" || request2.procedureKey === "government.choice.request" || request2.procedureKey === "government.celebration.choice.request" || request2.procedureKey === "unit.target.action.request" || request2.procedureKey === "unit.upgrade.request" || request2.procedureKey === "unit.resettle.request" || request2.procedureKey === "progression.technology.choice.request" || request2.procedureKey === "progression.culture.choice.request" || request2.procedureKey === "progression.technology.target.request" || request2.procedureKey === "progression.culture.target.request" || request2.procedureKey === "progression.attribute.purchase.request" || request2.procedureKey === "progression.attribute.review.request" || request2.procedureKey === "progression.tradition.change.request" || request2.procedureKey === "progression.tradition.review.request";
@@ -34530,7 +34850,7 @@ async function requestCiv7GameUiTurnComplete(target = globalThis) {
       state: { id: "game-ui", name: "Game UI" },
       output: ["game-ui-turn-completion-requested"]
     },
-    verified: probeValue5(after3.hasSentTurnComplete) === true || probeValue5(after3.turn) !== probeValue5(before2.turn)
+    verified: probeValue6(after3.hasSentTurnComplete) === true || probeValue6(after3.turn) !== probeValue6(before2.turn)
   };
 }
 function gameUiNotificationSummaries(target, playerId, maxNotifications) {
@@ -34710,9 +35030,9 @@ function ok(value2) {
   return { ok: true, value: value2 };
 }
 function gameUiTurnCompletionAllowed(status) {
-  return probeValue5(status.canEndTurn) === true && probeValue5(status.hasSentTurnComplete) !== true;
+  return probeValue6(status.canEndTurn) === true && probeValue6(status.hasSentTurnComplete) !== true;
 }
-function probeValue5(probe13) {
+function probeValue6(probe13) {
   return probe13.ok ? probe13.value : void 0;
 }
 function isPresent2(value2) {
@@ -36942,7 +37262,7 @@ function gameUiFirstMeetPostcondition(sent, before2, after3, metPlayerId) {
 }
 function classifyGameUiFirstMeetPostcondition(sent, before2, after3, metPlayerId) {
   if (!sent) return "not-sent";
-  if (probeValue6(after3.canEndTurn) === true) return "turn-unblocked";
+  if (probeValue62(after3.canEndTurn) === true) return "turn-unblocked";
   const beforeBlocker = findFirstMeetNotification(before2, metPlayerId);
   if (!beforeBlocker) return "first-meet-blocker-unmatched";
   const afterBlocker = findFirstMeetNotification(after3, metPlayerId);
@@ -37013,7 +37333,7 @@ function probe8(fn2) {
     return { ok: false, error: String(err) };
   }
 }
-function probeValue6(input) {
+function probeValue62(input) {
   return input.ok ? input.value : void 0;
 }
 var CIV7_GAME_UI_GOVERNMENT_ACTIVATE_ACTION = -1326475004;
@@ -38421,6 +38741,9 @@ function gameUiSupportedReadProcedures(target) {
   if (civ7GameUiStrategyFrontAvailable(target)) {
     supported2.push("strategy.frontSummary");
   }
+  if (gameUiWorldCurrentAvailable(target)) {
+    supported2.push("world.current");
+  }
   return supported2;
 }
 function gameUiNotificationDismissalAvailable(target) {
@@ -38430,6 +38753,9 @@ function gameUiNotificationDismissalAvailable(target) {
 }
 function gameUiAttentionReadAvailable(target) {
   return typeof target.Game?.Notifications?.getIdsForPlayer === "function" && typeof target.Game?.Notifications?.find === "function" && typeof target.UI?.Player?.getFirstReadyUnit === "function" && isControllerPlayerId(target.GameContext?.localPlayerID);
+}
+function gameUiWorldCurrentAvailable(target) {
+  return typeof target.UI?.isInGame === "function" && typeof target.GameplayMap?.getGridWidth === "function" && typeof target.GameplayMap?.getGridHeight === "function" && typeof target.Game?.getTurnDate === "function" && typeof target.Players?.getAliveIds === "function" && typeof target.Players?.getAliveHumanIds === "function" && typeof target.Players?.getNumAliveHumans === "function" && isControllerPlayerId(target.GameContext?.localPlayerID);
 }
 function gameUiTurnCompletionAvailable(target) {
   return gameUiAttentionReadAvailable(target) && typeof target.GameContext?.hasSentTurnComplete === "function" && typeof target.GameContext?.sendTurnComplete === "function" && typeof target.canEndTurn === "function" && typeof target.Game?.getTurnDate === "function" && typeof target.Game?.Notifications?.getEndTurnBlockingType === "function";

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -246,6 +246,31 @@ errors, and server-side callers.
   relationship-unproven semantics unless official relationship, team, war, or
   suzerain evidence proves stronger labels
 
+#### Scenario: Attention priorities service view is added
+- **WHEN** `attention.priorities` exposes a caller-facing priority dashboard
+  under the `attention` router
+- **THEN** control-oRPC owns the contract-local input/output schemas, native
+  service procedure, priority ranking, source-status projection, semantic
+  next-step descriptors, and normal output wording
+- **AND** the input is closed and admits only priority-read options such as
+  notification count, ready-unit bounds, and optional battlefield read bounds;
+  it does not accept endpoint, session, state, host, port, command, rawCommand,
+  transport, or send-operation fields
+- **AND** the procedure composes playable status, notification, turn-completion,
+  ready-unit/city, and optional battlefield runtime/read evidence from context
+  dependencies rather than adding same-shaped direct-control facade wrappers
+- **AND** normal service output emits semantic priority and next-step
+  descriptors rather than literal CLI `game play ...` command strings
+- **AND** battlefield evidence remains read-only planning context and must not
+  be treated as relationship status, action authority, target-send authority,
+  or hostile/enemy/opponent/threat/war/ally/suzerain proof
+- **AND** normal output omits host, port, state, session, command, rawCommand,
+  Tuner payloads, direct-control runtime envelopes, and raw transport details
+- **AND** local package tests prove only native service composition and fake
+  runtime behavior; deployed Civ7 runtime proof, action-send authority,
+  transport expansion, controller allowlisting, and parent Task 5.x/6.x/7.x
+  acceptance remain pending
+
 #### Scenario: Current world service view is added
 - **WHEN** `world.current` exposes a caller-facing current-world read
 - **THEN** control-oRPC owns the contract-local input/output schemas, native
@@ -309,6 +334,23 @@ errors, and server-side callers.
 - **AND** normal JSON results are semantic world plot/grid projections without
   raw host, port, state, session, command, rawCommand, Tuner payloads,
   direct-control runtime envelopes, actor catalogs, or relationship labels
+- **AND** focused CLI tests do not claim live Civ7 runtime proof
+
+#### Scenario: CLI priorities uses attention service projection
+- **WHEN** `game play priorities` reads the current priority dashboard
+- **THEN** the CLI constructs native control-oRPC context from endpoint flags
+- **AND** the priorities path calls the in-process `attention.priorities`
+  server-side client under the `attention` router
+- **AND** priority ranking, source-status, current-HUD, ready-actor, and
+  optional battlefield composition come from the service procedure
+- **AND** the CLI maps semantic next-step descriptors into command suggestions
+  in CLI output only; native service output remains caller-neutral and does not
+  contain literal CLI `game play ...` command strings
+- **AND** the normal JSON result omits raw host, port, state, session, command,
+  rawCommand, Tuner payloads, direct-control runtime envelopes, and transport
+  details
+- **AND** battlefield evidence remains relationship-safe read-only planning
+  context and does not authorize sends or hostile/enemy/opponent/threat labels
 - **AND** focused CLI tests do not claim live Civ7 runtime proof
 
 #### Scenario: Transitional facade-only procedure remains

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -1233,7 +1233,8 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
   for `Players`, `Players.Units`, `Players.Cities`, `Units`, `Cities`,
   `GameInfo.Units`, `GameplayMap`, and controller-owned local-player evidence
 - **THEN** the context may execute the service-owned `strategy.frontSummary`
-  procedure through the existing in-process router
+  procedure through the existing in-process router, including target-candidate,
+  battlefield-scan, and destination-analysis composition
 - **AND** `strategy.frontSummary` is listed as a supported game-UI read only
   when controller proof and the required ambient owner, unit, city, and map
   APIs are present
@@ -1242,14 +1243,17 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
   `canMutate: false`, and recommends `read-strategy-front` when
   `attention.current` is not supported
 - **AND** bridge ingress allowlists the semantic `strategy.frontSummary`
-  procedure only, not raw `targetCandidates`, `battlefieldScan`, or generic
-  tactical catalog leaves
+  procedure only, not raw `targetCandidates`, `battlefieldScan`,
+  `destinationAnalysis`, or generic tactical catalog leaves
 - **AND** the game-UI tactical read dependencies fail closed when required
   ambient owner/unit/city APIs are missing
 - **AND** normal bridge success output remains the semantic strategy front
   summary and omits host, port, state, command, rawCommand, session, tuner
   payloads, raw game-UI function names, direct-control socket details, and raw
   tactical read-port envelopes
+- **AND** normal service and bridge output uses semantic next-step descriptors
+  rather than literal CLI `game play ...` command strings; CLI callers may map
+  descriptors into command suggestions in their own presentation layer
 - **AND** normal output preserves `self` and `relationship-unproven` only; it
   does not infer hostile, enemy, opponent, threat, war, ally, or suzerain
   labels from owner mismatch, proximity, contact, ranking, or action legality

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -281,12 +281,12 @@ errors, and server-side callers.
   catalogs, and relationship labels
 - **AND** the procedures reject endpoint/session/state/raw command fields from
   caller input before invoking the direct-control facade
-- **AND** game-UI controller context does not advertise these reads as
-  supported until a separate game-resident map evidence path exists
+- **AND** game-UI controller context advertises these reads only when the
+  separate game-resident map evidence path is present
 - **AND** local package tests prove only service projection and fake runtime
-  behavior; deployed Civ7 runtime proof, controller bridge allowlisting,
-  transport expansion, broad world/actor catalog support, and parent
-  Task 5.x/6.x/7.x acceptance remain pending
+  behavior; deployed Civ7 runtime proof, transport expansion, broad
+  world/actor catalog support, and parent Task 5.x/6.x/7.x acceptance remain
+  pending
 
 #### Scenario: CLI map summary uses current world service projection
 - **WHEN** `game map --summary` reads current world/map facts
@@ -1280,6 +1280,30 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** local package and bundle tests prove source shape and local fake game
   runtime behavior only; deployed Civ7 runtime proof, broad world/actor
   catalogs, play-thread action, and full `7.3` implementation remain pending
+
+#### Scenario: Game UI controller supports world plot and grid reads
+- **WHEN** the game-scoped controller context exposes ambient `GameplayMap`
+  plot APIs for bounded map reads
+- **THEN** the context may execute the service-owned `world.plot.read` and
+  `world.grid.read` procedures through the existing in-process router
+- **AND** `world.plot.read` and `world.grid.read` are listed as supported
+  game-UI reads only when the exact plot-level map APIs required by the
+  low-level dependency are present
+- **AND** the game-UI dependency returns bounded low-level plot/grid runtime
+  evidence for the existing world service procedures to project; it does not
+  own normal output semantics, actor catalogs, relationship labels, or a
+  separate transport API
+- **AND** bridge ingress validates the semantic plot/grid request and output
+  envelopes from the aggregated `Civ7ControlOrpcContract` rather than
+  exporting per-procedure schema constants or using `Type.Unknown`
+- **AND** normal bridge success output remains the semantic world plot/grid
+  view and omits host, port, state, command, rawCommand, session, tuner
+  payloads, raw game-UI function names, direct-control socket details,
+  direct-control runtime envelopes, actor catalogs, and relationship labels
+- **AND** local package and bundle tests prove source shape and local fake game
+  runtime behavior only; deployed Civ7 runtime proof, broad world/actor
+  catalogs, play-thread action, transport expansion, and full `7.3`
+  implementation remain pending
 
 ### Requirement: Mutation Procedures Preserve Direct-Control Proof Semantics
 

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -299,6 +299,36 @@ errors, and server-side callers.
   authority, transport expansion, controller allowlisting, and parent Task
   5.x/6.x/7.x acceptance remain pending
 
+#### Scenario: Formation snapshot service view is added
+- **WHEN** `strategy.formationSnapshot` exposes a caller-facing formation
+  planning view under the `strategy` router
+- **THEN** control-oRPC owns the contract-local input/output schemas, native
+  service procedure, formation posture, source-status projection,
+  relationship-safe reasons, semantic next-step descriptors, and normal output
+  wording
+- **AND** the input is closed and admits only formation-read options such as
+  player id, origin, radius, screen radius, contact radius, and bounded
+  battlefield scan limits; it does not accept endpoint, session, state, host,
+  port, command, rawCommand, transport, approval, reason, or send-operation
+  fields
+- **AND** the procedure composes notification, ready-unit, and battlefield-scan
+  runtime/read evidence from context dependencies rather than keeping
+  formation posture logic in CLI code or adding a same-shaped direct-control
+  facade wrapper
+- **AND** normal service output emits semantic formation next-step descriptors
+  rather than literal CLI `game play ...` command strings
+- **AND** ready-unit and battlefield evidence remains read-only planning
+  context and must not be treated as relationship status, movement, target-send
+  authority, or hostile/enemy/opponent/threat/war/ally/suzerain proof
+- **AND** normal output omits host, port, state, session, command, rawCommand,
+  Tuner payloads, direct-control runtime envelopes, raw notification details,
+  raw ready-unit operations, raw unit evidence payloads, raw unit/city arrays,
+  and raw transport details
+- **AND** local package tests prove only native service composition and fake
+  runtime behavior; deployed Civ7 runtime proof, movement/action-send
+  authority, transport expansion, controller allowlisting, and parent Task
+  5.x/6.x/7.x acceptance remain pending
+
 #### Scenario: Current world service view is added
 - **WHEN** `world.current` exposes a caller-facing current-world read
 - **THEN** control-oRPC owns the contract-local input/output schemas, native

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -271,6 +271,34 @@ errors, and server-side callers.
   transport expansion, controller allowlisting, and parent Task 5.x/6.x/7.x
   acceptance remain pending
 
+#### Scenario: Civilian route triage service view is added
+- **WHEN** `strategy.civilianRouteTriage` exposes a caller-facing civilian
+  route planning view under the `strategy` router
+- **THEN** control-oRPC owns the contract-local input/output schemas, native
+  service procedure, route status, source-status projection, relationship-safe
+  reasons, semantic next-step descriptors, and normal output wording
+- **AND** the input is closed and admits only route-read options such as player
+  id, origin, destination, settlement count, and bounded battlefield/route scan
+  limits; it does not accept endpoint, session, state, host, port, command,
+  rawCommand, transport, approval, reason, or send-operation fields
+- **AND** the procedure composes notification, ready-unit, settlement
+  recommendation, battlefield-scan, and destination-analysis runtime/read
+  evidence from context dependencies rather than keeping route-status logic in
+  CLI code or adding a same-shaped direct-control facade wrapper
+- **AND** normal service output emits semantic route triage and next-step
+  descriptors rather than literal CLI `game play ...` command strings
+- **AND** settlement, battlefield, and destination evidence remains read-only
+  planning context and must not be treated as relationship status, movement,
+  founding, target-send authority, or hostile/enemy/opponent/threat/war/ally/
+  suzerain proof
+- **AND** normal output omits host, port, state, session, command, rawCommand,
+  Tuner payloads, direct-control runtime envelopes, raw notification details,
+  raw settlement factors, raw unit/city arrays, and raw transport details
+- **AND** local package tests prove only native service composition and fake
+  runtime behavior; deployed Civ7 runtime proof, movement/founding/action-send
+  authority, transport expansion, controller allowlisting, and parent Task
+  5.x/6.x/7.x acceptance remain pending
+
 #### Scenario: Current world service view is added
 - **WHEN** `world.current` exposes a caller-facing current-world read
 - **THEN** control-oRPC owns the contract-local input/output schemas, native
@@ -351,6 +379,27 @@ errors, and server-side callers.
   details
 - **AND** battlefield evidence remains relationship-safe read-only planning
   context and does not authorize sends or hostile/enemy/opponent/threat labels
+- **AND** focused CLI tests do not claim live Civ7 runtime proof
+
+#### Scenario: CLI civilian route triage uses strategy service projection
+- **WHEN** `game play civilian-route-triage` reads settlement, route, and
+  battlefield planning evidence
+- **THEN** the CLI constructs native control-oRPC context from endpoint flags
+- **AND** the route-triage path calls the in-process
+  `strategy.civilianRouteTriage` server-side client under the `strategy`
+  router
+- **AND** route status, source-status, ready-unit origin inference, settlement
+  destination inference, battlefield evidence, and optional destination
+  analysis composition come from the service procedure
+- **AND** the CLI maps semantic next-step descriptors into command suggestions
+  in CLI output only; native service output remains caller-neutral and does not
+  contain literal CLI `game play ...` command strings
+- **AND** the normal JSON result omits raw host, port, state, session, command,
+  rawCommand, Tuner payloads, direct-control runtime envelopes, raw
+  notification details, raw tactical read-port arrays, and transport details
+- **AND** planning evidence remains relationship-safe read-only context and
+  does not authorize movement, founding, sends, or hostile/enemy/opponent/
+  threat labels
 - **AND** focused CLI tests do not claim live Civ7 runtime proof
 
 #### Scenario: Transitional facade-only procedure remains

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -329,6 +329,38 @@ errors, and server-side callers.
   authority, transport expansion, controller allowlisting, and parent Task
   5.x/6.x/7.x acceptance remain pending
 
+#### Scenario: Notification queue service views are added
+- **WHEN** `notifications.queue.current` and
+  `notifications.queue.dismiss.request` expose caller-facing notification queue
+  surfaces under the `notifications` router
+- **THEN** control-oRPC owns the contract-local input/output schemas, native
+  service procedures, queue disposition, informational dismissal eligibility,
+  exclusion reasons, aggregate proof/no-repeat projection, semantic next-step
+  descriptors, and normal output wording
+- **AND** inputs are closed and admit only bounded queue-read and selected
+  bulk-dismissal options such as max notification count, max dismissal count,
+  and explicit send intent; they do not accept endpoint, session, state, host,
+  port, command, rawCommand, transport, approval, reason, raw operation, or
+  caller-supplied proof fields
+- **AND** the read procedure composes notification HUD decision queue evidence
+  from context dependencies rather than keeping queue scheduling behavior in
+  CLI code or exposing raw notification details as the service contract
+- **AND** the dismissal request procedure passes native mutation readiness and
+  proof/no-repeat middleware, invokes only item-scoped notification dismissal
+  runtime ports for eligible informational candidates, excludes operation-
+  bearing and unclassified notifications, and keeps aggregate unverified sends
+  do-not-repeat guarded
+- **AND** normal service output emits semantic notification next-step
+  descriptors rather than literal CLI `game play ...` command strings
+- **AND** normal output omits host, port, state, session, command, rawCommand,
+  Tuner payloads, direct-control runtime envelopes, raw App UI closeout
+  internals, legacy `verified`, approval/reason mechanics, raw operation
+  payloads, and raw transport details
+- **AND** local package tests prove only native service composition and fake
+  runtime behavior; deployed Civ7 runtime proof, controller bridge
+  allowlisting, transport expansion, broad operation catalog support, and
+  parent Task 5.x/6.x/7.x acceptance remain pending
+
 #### Scenario: Current world service view is added
 - **WHEN** `world.current` exposes a caller-facing current-world read
 - **THEN** control-oRPC owns the contract-local input/output schemas, native
@@ -409,6 +441,29 @@ errors, and server-side callers.
   details
 - **AND** battlefield evidence remains relationship-safe read-only planning
   context and does not authorize sends or hostile/enemy/opponent/threat labels
+- **AND** focused CLI tests do not claim live Civ7 runtime proof
+
+#### Scenario: CLI notification queue commands use notifications service projection
+- **WHEN** `game play notification-queue` schedules current notification work
+  or `game play dismiss-notification-queue` dry-runs or sends reviewed
+  informational closeouts
+- **THEN** the CLI constructs native control-oRPC context from endpoint flags
+- **AND** the queue scheduler calls the in-process
+  `notifications.queue.current` server-side client under the `notifications`
+  router
+- **AND** the queue closeout command calls the in-process
+  `notifications.queue.dismiss.request` server-side client under the
+  `notifications` router
+- **AND** queue disposition, eligibility/exclusion policy, readiness-gated
+  aggregate dismissal, and proof/no-repeat projection come from the service
+  procedures
+- **AND** the CLI maps semantic next-step descriptors into command suggestions
+  in CLI output only; native service output remains caller-neutral and does not
+  contain literal CLI `game play ...` command strings
+- **AND** the normal JSON result omits raw host, port, state, session, command,
+  rawCommand, Tuner payloads, direct-control runtime envelopes, raw App UI
+  closeout internals, legacy `verified`, approval/reason mechanics, and
+  transport details
 - **AND** focused CLI tests do not claim live Civ7 runtime proof
 
 #### Scenario: CLI civilian route triage uses strategy service projection

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -269,6 +269,20 @@ errors, and server-side callers.
   support, transport expansion, and parent Task 5.x/6.x/7.x acceptance remain
   pending
 
+#### Scenario: CLI map summary uses current world service projection
+- **WHEN** `game map --summary` reads current world/map facts
+- **THEN** the CLI constructs native control-oRPC context from endpoint flags
+- **AND** the summary path calls the in-process `world.current` server-side
+  client under the `world` router
+- **AND** the normal JSON result is the semantic current-world projection
+  without raw host, port, state, session, command, rawCommand, Tuner payloads,
+  raw App UI snapshot envelopes, direct-control summary envelopes, actor
+  catalogs, or relationship labels
+- **AND** `game map --plot` and `game map --bounds` remain bounded
+  direct-control map diagnostics until separate accepted world/map read
+  service leaves exist
+- **AND** focused CLI tests do not claim live Civ7 runtime proof
+
 #### Scenario: Transitional facade-only procedure remains
 - **WHEN** a current facade-only read leaf is retained while the native service
   shape is being corrected

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -246,6 +246,29 @@ errors, and server-side callers.
   relationship-unproven semantics unless official relationship, team, war, or
   suzerain evidence proves stronger labels
 
+#### Scenario: Current world service view is added
+- **WHEN** `world.current` exposes a caller-facing current-world read
+- **THEN** control-oRPC owns the contract-local input/output schemas, native
+  service procedure, normal projection, and next-step wording under the
+  `world` router
+- **AND** the input is a closed empty object and does not accept endpoint,
+  session, state, host, port, command, rawCommand, or transport fields
+- **AND** the procedure reads the existing playable/App UI snapshot runtime
+  port and projects bounded turn, local-player, map, and player-count facts
+  without exposing the raw playable-status envelope
+- **AND** the procedure does not call transitional direct-control
+  `map.summary.read`, `player.summary.read`, `unit.summary.read`, or
+  `city.summary.read` facade wrappers as runtime resources
+- **AND** normal output omits actor samples, owner grouping, relationship
+  labels, raw app-ui snapshot objects, host, port, state, command, rawCommand,
+  session, Tuner payloads, and direct-control runtime internals
+- **AND** world output does not infer hostile, enemy, opponent, threat, war,
+  ally, suzerain, or other relationship labels from owner ids or player counts
+- **AND** local package tests prove only native service projection and fake
+  runtime behavior; deployed Civ7 runtime proof, broad world/actor catalog
+  support, transport expansion, and parent Task 5.x/6.x/7.x acceptance remain
+  pending
+
 #### Scenario: Transitional facade-only procedure remains
 - **WHEN** a current facade-only read leaf is retained while the native service
   shape is being corrected
@@ -1192,6 +1215,29 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
   runtime behavior only; deployed Civ7 runtime proof, target-action send
   authority, broad strategy catalogs, play-thread action, and full `7.3`
   implementation remain pending
+
+#### Scenario: Game UI controller supports current world reads
+- **WHEN** the game-scoped controller context exposes ambient playable/App UI
+  snapshot facts for current world state
+- **THEN** the context may execute the service-owned `world.current` procedure
+  through the existing in-process router
+- **AND** `world.current` is listed as a supported game-UI read only when
+  controller proof and the required ambient game context, map, player, and turn
+  APIs are present
+- **AND** `readiness.current` reports observation capability for a controller
+  context that lists `world.current` as a supported read, keeps
+  `canMutate: false`, and recommends `read-world` when `attention.current` and
+  `strategy.frontSummary` are not supported
+- **AND** bridge ingress validates the semantic `world.current` input and
+  output envelopes from the aggregated `Civ7ControlOrpcContract` rather than
+  exporting per-procedure schema constants or using `Type.Unknown`
+- **AND** normal bridge success output remains the semantic current-world view
+  and omits host, port, state, command, rawCommand, session, tuner payloads,
+  raw game-UI function names, direct-control socket details, raw playable
+  status envelopes, actor catalogs, and relationship labels
+- **AND** local package and bundle tests prove source shape and local fake game
+  runtime behavior only; deployed Civ7 runtime proof, broad world/actor
+  catalogs, play-thread action, and full `7.3` implementation remain pending
 
 ### Requirement: Mutation Procedures Preserve Direct-Control Proof Semantics
 

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -269,6 +269,25 @@ errors, and server-side callers.
   support, transport expansion, and parent Task 5.x/6.x/7.x acceptance remain
   pending
 
+#### Scenario: World plot and grid service reads are added
+- **WHEN** `world.plot.read` and `world.grid.read` expose bounded map
+  diagnostics under the `world` router
+- **THEN** control-oRPC owns the contract-local caller input, normal output
+  projection, source-status wording, and tagged error boundary
+- **AND** direct-control remains only the low-level plot snapshot and map grid
+  runtime read port that can execute bounded Tuner map probes
+- **AND** normal output omits raw host, port, state, session, command,
+  rawCommand, Tuner payloads, direct-control runtime envelopes, actor
+  catalogs, and relationship labels
+- **AND** the procedures reject endpoint/session/state/raw command fields from
+  caller input before invoking the direct-control facade
+- **AND** game-UI controller context does not advertise these reads as
+  supported until a separate game-resident map evidence path exists
+- **AND** local package tests prove only service projection and fake runtime
+  behavior; deployed Civ7 runtime proof, controller bridge allowlisting,
+  transport expansion, broad world/actor catalog support, and parent
+  Task 5.x/6.x/7.x acceptance remain pending
+
 #### Scenario: CLI map summary uses current world service projection
 - **WHEN** `game map --summary` reads current world/map facts
 - **THEN** the CLI constructs native control-oRPC context from endpoint flags
@@ -278,9 +297,18 @@ errors, and server-side callers.
   without raw host, port, state, session, command, rawCommand, Tuner payloads,
   raw App UI snapshot envelopes, direct-control summary envelopes, actor
   catalogs, or relationship labels
-- **AND** `game map --plot` and `game map --bounds` remain bounded
-  direct-control map diagnostics until separate accepted world/map read
-  service leaves exist
+- **AND** focused CLI tests do not claim live Civ7 runtime proof
+
+#### Scenario: CLI map plot and bounds use world service projection
+- **WHEN** `game map --plot` and `game map --bounds` read bounded map facts
+- **THEN** the CLI constructs native control-oRPC context from endpoint flags
+- **AND** plot mode calls the in-process `world.plot.read` server-side client
+  under the `world` router
+- **AND** bounds mode calls the in-process `world.grid.read` server-side
+  client under the `world` router
+- **AND** normal JSON results are semantic world plot/grid projections without
+  raw host, port, state, session, command, rawCommand, Tuner payloads,
+  direct-control runtime envelopes, actor catalogs, or relationship labels
 - **AND** focused CLI tests do not claim live Civ7 runtime proof
 
 #### Scenario: Transitional facade-only procedure remains

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -222,6 +222,15 @@ adding more read-only facade shells.
     descriptors, raw-output exclusion, and relationship-unproven policy; CLI
     command strings stay caller-local; no movement/action authority, runtime
     proof, controller bridge, or parent Task 5.x/6.x acceptance.
+  - [x] 5.4.21 Record `notifications.queue.current` and
+    `notifications.queue.dismiss.request` as service-owned notification queue
+    scheduling and guarded informational-closeout boundaries over
+    notification HUD reads and item-scoped notification dismissal runtime/proof
+    ports. The service owns queue disposition, eligibility/exclusion reasons,
+    semantic next-step descriptors, aggregate proof/no-repeat projection, raw
+    output exclusion, and the no-CLI-string contract boundary; no broad
+    operation catalog, approval/reason mechanic, runtime proof, controller
+    bridge, or parent Task 5.x/6.x acceptance.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -370,6 +379,16 @@ adding more read-only facade shells.
     service output, keep battlefield evidence relationship-safe and read-only,
     omit raw ready-unit operation/evidence payloads, and keep runtime proof,
     movement/action authority, controller bridge, transport expansion, and
+    parent Task 5.x/6.x/7.x acceptance pending.
+  - [x] 5.5.20 Seed `notifications.queue.current` and
+    `notifications.queue.dismiss.request` as native service-owned notification
+    queue procedures that compose current notification HUD evidence, item
+    eligibility/exclusion policy, readiness-gated notification dismissal
+    runtime ports, and aggregate proof/no-repeat projection into semantic queue
+    output. Keep caller input/output schemas contract-local, keep CLI command
+    suggestions out of service output, omit raw App UI closeout internals and
+    legacy `verified`, and keep runtime proof, controller bridge, transport
+    expansion, broad operation catalog support, approval/reason mechanics, and
     parent Task 5.x/6.x/7.x acceptance pending.
 
 ## 6. Native Policy Layering
@@ -686,6 +705,18 @@ adding more read-only facade shells.
     ready-unit operation payloads, and raw battlefield unit evidence from
     normal JSON, and avoid controller bridge, transport, relationship-label,
     movement/action-send, or runtime-proof claims.
+  - [x] 7.1.9.11 Route `civ7 game play notification-queue` and
+    `civ7 game play dismiss-notification-queue` through the in-process
+    `notifications.queue.current` and `notifications.queue.dismiss.request`
+    server-side clients under the `notifications` router. Move queue
+    disposition, informational dismissal eligibility, exclusion reasons,
+    readiness-gated aggregate dismissal, and proof/no-repeat projection into
+    the service procedures. Keep endpoint flags as context construction, keep
+    CLI command-string suggestions as CLI presentation only, omit raw
+    host/port/state/session/Tuner payloads, direct-control envelopes, legacy
+    `verified`, and raw App UI dismissal internals from normal JSON, and avoid
+    controller bridge, transport, broad operation catalogs, approval/reason
+    mechanics, or runtime-proof claims.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1460,6 +1491,17 @@ adding more read-only facade shells.
   play-thread action, controller bridge, transport expansion, relationship
   labels beyond official evidence, movement/action-send authority, or parent
   Task 5.x/6.x/7.x acceptance.
+- [x] 8.60.20 Run focused notification-queue procedure tests and CLI
+  notification queue tests plus control-oRPC package test/check/build, CLI
+  play/check gates, strict OpenSpec validates, private procedure-schema export
+  scan, active approval/caller-permission scan, service-output CLI-string
+  scan, and diff hygiene for the `notifications.queue.*` service-composition
+  expansion and `game play notification-queue` / `dismiss-notification-queue`
+  in-process oRPC caller migration. This is local package/CLI proof only and
+  does not claim deployed Civ7 runtime proof, play-thread action, controller
+  bridge, transport expansion, broad operation catalog support, approval/reason
+  mechanics, raw App UI closeout output, or parent Task 5.x/6.x/7.x
+  acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -577,6 +577,12 @@ adding more read-only facade shells.
     migrated commands, and keep sent town-focus results
     pending-runtime-proof/no-repeat guarded until a real city-read owner proves
     town project review state changed.
+  - [x] 7.1.9.5 Route `civ7 game map --summary` through the in-process
+    `world.current` server-side client under the `world` router. Keep endpoint
+    flags as context construction, emit the semantic current-world projection,
+    omit raw host/port/state/session/Tuner payloads from normal summary JSON,
+    and leave plot/grid reads on bounded direct-control diagnostics until
+    separate accepted world/map read service leaves exist.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1274,6 +1280,13 @@ adding more read-only facade shells.
   deployed Civ7 runtime proof, play-thread action, transport expansion,
   revived summary wrappers, actor catalog support, relationship labels, public
   package-root procedure schema exports, or parent Task 5.x/6.x/7.x
+  acceptance.
+- [x] 8.60.13 Run focused CLI map summary proof, full CLI test, CLI check,
+  relevant OpenSpec strict validates, and diff hygiene for the
+  `game map --summary` migration to `world.current`. This is local
+  CLI/service proof only and does not claim deployed Civ7 runtime proof,
+  play-thread action, transport expansion, plot/grid service migration,
+  revived summary wrappers, relationship labels, or parent Task 5.x/6.x/7.x
   acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -127,10 +127,12 @@ adding more read-only facade shells.
     summary behavior into the control-oRPC service owner. See
     `workstream/world-runtime-resource-boundary.md`.
   - [x] 5.4.4 Record `strategy.frontSummary` as a service-owned planning
-    composition over target-candidate and battlefield-scan runtime/read ports.
-    The service owns the normal projection, next-step wording, raw-output
-    exclusion, and relationship-unproven policy; no strategy catalog, action
-    authority, runtime proof, or parent Task 5.x/6.x acceptance.
+    composition over target-candidate, battlefield-scan, and optional
+    destination-analysis runtime/read ports. The service owns the normal
+    projection, semantic next-step descriptors, raw-output exclusion, and
+    relationship-unproven policy; CLI command strings stay caller-local; no
+    strategy catalog, action authority, runtime proof, or parent Task 5.x/6.x
+    acceptance.
   - [x] 5.4.5 Record `narrative.choice.request` as a service-owned
     narrative boundary over direct-control narrative runtime, validator, and
     proof ports. The service owns the caller-facing semantic choice shape,
@@ -244,10 +246,11 @@ adding more read-only facade shells.
     postcondition/no-repeat authority procedure-local; shared
     validator/postcondition middleware remains pending.
   - [x] 5.5.9 Seed `strategy.frontSummary` as a native service-owned planning
-    procedure that composes target-candidate and battlefield-scan evidence into
-    neutral front planning output without adding same-shaped read wrappers,
-    operation sends, strategy catalogs, relationship labels beyond official
-    evidence, or runtime/live proof claims.
+    procedure that composes target-candidate, battlefield-scan, and optional
+    destination-analysis evidence into neutral front planning output without
+    adding same-shaped read wrappers, CLI syntax in service output, operation
+    sends, strategy catalogs, relationship labels beyond official evidence, or
+    runtime/live proof claims.
   - [x] 5.5.10 Seed `narrative.choice.request` as a native
     service-owned narrative procedure that composes playable
     readiness, direct-control narrative request authority, and source-owned
@@ -597,6 +600,15 @@ adding more read-only facade shells.
     host/port/state/session/Tuner payloads and direct-control envelopes from
     normal JSON, keep GameInfo/debug reads separate, and avoid controller,
     transport, relationship-label, or runtime-proof claims.
+  - [x] 7.1.9.7 Route `civ7 game play front-summary` through the in-process
+    `strategy.frontSummary` server-side client under the `strategy` router.
+    Move target-candidate, battlefield, and destination-analysis composition
+    into the service procedure, keep endpoint flags as context construction,
+    keep CLI command-string suggestions as CLI presentation only, emit
+    relationship-safe semantic planning output, omit raw
+    host/port/state/session/Tuner payloads and direct-control envelopes from
+    normal JSON, and avoid transport, relationship-label, action-send, or
+    runtime-proof claims.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -844,10 +856,11 @@ adding more read-only facade shells.
     `strategy.frontSummary`: expose ambient `Players`, `Players.Units`,
     `Players.Cities`, `Units`, `Cities`, `GameInfo.Units`, `GameplayMap`, and
     controller-owned local-player evidence as internal target-candidate and
-    battlefield-scan read ports behind the existing service-owned strategy
-    procedure; allowlist only `strategy.frontSummary` through bridge ingress,
-    not raw `targetCandidates` or `battlefieldScan` leaves; fail closed when
-    required ambient owner/unit/city APIs are missing; preserve
+    battlefield-scan/destination-analysis read ports behind the existing
+    service-owned strategy procedure; allowlist only `strategy.frontSummary`
+    through bridge ingress, not raw `targetCandidates`, `battlefieldScan`, or
+    `destinationAnalysis` leaves; fail closed when required ambient
+    owner/unit/city APIs are missing; preserve
     relationship-unproven normal output and raw host/port/state/session/command
     omission; keep target-action send authority, generic strategy catalogs,
     hostile/enemy/opponent/threat/war/ally/suzerain labels, deployed Civ7
@@ -1332,6 +1345,15 @@ adding more read-only facade shells.
   expansion, broad actor catalog support, relationship labels, public
   package-root procedure schema exports, or parent Task 5.x/6.x/7.x
   acceptance.
+- [x] 8.60.16 Run focused strategy-front-summary and CLI tactical-read tests
+  plus control-oRPC package test/check/build, CLI play/check gates, strict
+  OpenSpec validates, private procedure-schema export scan, active
+  approval/caller-permission scan, service-output CLI-string scan, and diff
+  hygiene for the `strategy.frontSummary` service-composition expansion and
+  `game play front-summary` in-process oRPC caller migration. This is local
+  package/CLI proof only and does not claim deployed Civ7 runtime proof,
+  play-thread action, transport expansion, relationship labels beyond official
+  evidence, action-send authority, or parent Task 5.x/6.x/7.x acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -215,6 +215,13 @@ adding more read-only facade shells.
     relationship-unproven policy; CLI command strings stay caller-local; no
     movement/founding/action authority, runtime proof, controller bridge, or
     parent Task 5.x/6.x acceptance.
+  - [x] 5.4.20 Record `strategy.formationSnapshot` as a service-owned
+    formation planning composition over notification, ready-unit, and
+    battlefield-scan runtime/read ports. The service owns formation posture,
+    source status, safe unit/contact projections, semantic next-step
+    descriptors, raw-output exclusion, and relationship-unproven policy; CLI
+    command strings stay caller-local; no movement/action authority, runtime
+    proof, controller bridge, or parent Task 5.x/6.x acceptance.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -356,6 +363,14 @@ adding more read-only facade shells.
     settlement and battlefield evidence relationship-safe and read-only, and
     keep runtime proof, movement/founding/action authority, controller bridge,
     transport expansion, and parent Task 5.x/6.x/7.x acceptance pending.
+  - [x] 5.5.19 Seed `strategy.formationSnapshot` as a native service-owned
+    strategy procedure that composes current notification, ready-unit, and
+    battlefield evidence into a semantic formation posture view. Keep caller
+    input/output schemas contract-local, keep CLI command suggestions out of
+    service output, keep battlefield evidence relationship-safe and read-only,
+    omit raw ready-unit operation/evidence payloads, and keep runtime proof,
+    movement/action authority, controller bridge, transport expansion, and
+    parent Task 5.x/6.x/7.x acceptance pending.
 
 ## 6. Native Policy Layering
 
@@ -660,6 +675,17 @@ adding more read-only facade shells.
     host/port/state/session/Tuner payloads and direct-control envelopes from
     normal JSON, and avoid controller bridge, transport, relationship-label,
     movement/founding/action-send, or runtime-proof claims.
+  - [x] 7.1.9.10 Route `civ7 game play formation-snapshot` through the
+    in-process `strategy.formationSnapshot` server-side client under the
+    `strategy` router. Move formation posture, source status, ready-unit,
+    battlefield, contact grouping, and semantic next-step composition into the
+    service procedure. Keep endpoint flags as context construction, keep CLI
+    command-string suggestions as CLI presentation only, emit
+    relationship-safe read-only formation output, omit raw
+    host/port/state/session/Tuner payloads, direct-control envelopes, raw
+    ready-unit operation payloads, and raw battlefield unit evidence from
+    normal JSON, and avoid controller bridge, transport, relationship-label,
+    movement/action-send, or runtime-proof claims.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1424,6 +1450,16 @@ adding more read-only facade shells.
   proof, play-thread action, controller bridge, transport expansion,
   relationship labels beyond official evidence, movement/founding/action-send
   authority, or parent Task 5.x/6.x/7.x acceptance.
+- [x] 8.60.19 Run focused strategy-formation-snapshot and CLI tactical-read
+  tests plus control-oRPC package test/check/build, CLI play/check gates,
+  strict OpenSpec validates, private procedure-schema export scan, active
+  approval/caller-permission scan, service-output CLI-string scan, and diff
+  hygiene for the `strategy.formationSnapshot` service-composition expansion
+  and `game play formation-snapshot` in-process oRPC caller migration. This is
+  local package/CLI proof only and does not claim deployed Civ7 runtime proof,
+  play-thread action, controller bridge, transport expansion, relationship
+  labels beyond official evidence, movement/action-send authority, or parent
+  Task 5.x/6.x/7.x acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -982,6 +982,17 @@ adding more read-only facade shells.
     names, command/session/state details, deployed Civ7 proof, play-thread
     action, transport expansion, public package-root procedure schema exports,
     and full `7.3` acceptance pending.
+  - [x] 7.3.36 Add game-resident world plot/grid read dependencies for
+    `world.plot.read` and `world.grid.read`: expose ambient `GameplayMap`
+    plot APIs as low-level map read evidence for the existing service-owned
+    world procedures, allowlist both leaves through closed controller bridge
+    envelopes derived from the aggregated `Civ7ControlOrpcContract`, advertise
+    the reads only when the exact plot-level map APIs exist, and keep normal
+    bridge output semantic without raw host/port/state/session/command,
+    direct-control runtime envelopes, actor catalogs, or relationship labels.
+    Keep deployed Civ7 proof, play-thread action, transport expansion, public
+    package-root procedure schema exports, broad world/actor catalogs, and
+    full `7.3` acceptance pending.
 - [ ] 7.4 Keep OpenAPI/external REST deferred until there is a documented
   external consumer.
 
@@ -1311,6 +1322,16 @@ adding more read-only facade shells.
   not claim deployed Civ7 runtime proof, play-thread action, controller bridge
   allowlisting, transport expansion, broad actor catalog support, relationship
   labels, or parent Task 5.x/6.x/7.x acceptance.
+- [x] 8.60.15 Run focused controller bridge, game-UI controller, world map
+  read, and readiness tests plus control-oRPC package check/build, strict
+  OpenSpec validates, private procedure-schema export scan, active
+  approval/caller-permission scan, generated bundle scan, and diff hygiene for
+  the game-resident world plot/grid read dependency and controller bridge
+  allowlist slice. This is local package and generated-bundle proof only and
+  does not claim deployed Civ7 runtime proof, play-thread action, transport
+  expansion, broad actor catalog support, relationship labels, public
+  package-root procedure schema exports, or parent Task 5.x/6.x/7.x
+  acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -207,6 +207,14 @@ adding more read-only facade shells.
     raw-output exclusion, and the no-CLI-string contract boundary;
     battlefield remains planning evidence only, with no send authority,
     runtime proof, or parent Task 5.x/6.x acceptance.
+  - [x] 5.4.19 Record `strategy.civilianRouteTriage` as a service-owned
+    civilian route planning composition over notification, ready-unit,
+    settlement recommendation, battlefield-scan, and destination-analysis
+    runtime/read ports. The service owns route status, reasons, source status,
+    semantic next-step descriptors, raw-output exclusion, and
+    relationship-unproven policy; CLI command strings stay caller-local; no
+    movement/founding/action authority, runtime proof, controller bridge, or
+    parent Task 5.x/6.x acceptance.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -340,6 +348,14 @@ adding more read-only facade shells.
     battlefield evidence relationship-safe and read-only, and keep runtime
     proof, action-send authority, transport expansion, and parent Task
     5.x/6.x/7.x acceptance pending.
+  - [x] 5.5.18 Seed `strategy.civilianRouteTriage` as a native service-owned
+    strategy procedure that composes current notification, ready-unit,
+    settlement recommendation, battlefield, and destination evidence into a
+    semantic civilian route triage. Keep caller input/output schemas
+    contract-local, keep CLI command suggestions out of service output, keep
+    settlement and battlefield evidence relationship-safe and read-only, and
+    keep runtime proof, movement/founding/action authority, controller bridge,
+    transport expansion, and parent Task 5.x/6.x/7.x acceptance pending.
 
 ## 6. Native Policy Layering
 
@@ -634,6 +650,16 @@ adding more read-only facade shells.
     host/port/state/session/Tuner payloads and direct-control envelopes from
     normal JSON, and avoid transport, relationship-label, action-send, or
     runtime-proof claims.
+  - [x] 7.1.9.9 Route `civ7 game play civilian-route-triage` through the
+    in-process `strategy.civilianRouteTriage` server-side client under the
+    `strategy` router. Move route-status, source-status, settlement,
+    battlefield, destination, and semantic next-step composition into the
+    service procedure. Keep endpoint flags as context construction, keep CLI
+    command-string suggestions as CLI presentation only, emit
+    relationship-safe read-only route planning output, omit raw
+    host/port/state/session/Tuner payloads and direct-control envelopes from
+    normal JSON, and avoid controller bridge, transport, relationship-label,
+    movement/founding/action-send, or runtime-proof claims.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1388,6 +1414,16 @@ adding more read-only facade shells.
   package/CLI proof only and does not claim deployed Civ7 runtime proof,
   play-thread action, transport expansion, relationship labels beyond official
   evidence, action-send authority, or parent Task 5.x/6.x/7.x acceptance.
+- [x] 8.60.18 Run focused strategy-civilian-route-triage and CLI tactical-read
+  tests plus control-oRPC package test/check/build, CLI play/check gates,
+  strict OpenSpec validates, private procedure-schema export scan, active
+  approval/caller-permission scan, service-output CLI-string scan, and diff
+  hygiene for the `strategy.civilianRouteTriage` service-composition expansion
+  and `game play civilian-route-triage` in-process oRPC caller migration. This
+  is local package/CLI proof only and does not claim deployed Civ7 runtime
+  proof, play-thread action, controller bridge, transport expansion,
+  relationship labels beyond official evidence, movement/founding/action-send
+  authority, or parent Task 5.x/6.x/7.x acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -200,6 +200,13 @@ adding more read-only facade shells.
     low-level playable/App UI snapshot port. This does not revive
     `map.summary.read`, `player.summary.read`, `unit.summary.read`, or
     `city.summary.read`.
+  - [x] 5.4.18 Record `attention.priorities` as a service-owned priority
+    dashboard over playable status, notification, turn-completion,
+    ready-unit/city, and optional battlefield runtime/read ports. The service
+    owns priority ranking, source status, semantic next-step descriptors,
+    raw-output exclusion, and the no-CLI-string contract boundary;
+    battlefield remains planning evidence only, with no send authority,
+    runtime proof, or parent Task 5.x/6.x acceptance.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -325,6 +332,14 @@ adding more read-only facade shells.
     normal output, reject endpoint/session/raw command fields before facade
     execution, and keep game-UI/controller allowlisting, runtime proof, broad
     actor catalog support, and parent Task 5.x/6.x/7.x acceptance pending.
+  - [x] 5.5.17 Seed `attention.priorities` as a native service-owned
+    attention procedure that composes playable status, notification,
+    turn-completion, ready-unit/city, and optional battlefield evidence into a
+    semantic priority dashboard. Keep caller input/output schemas
+    contract-local, keep CLI command suggestions out of service output, keep
+    battlefield evidence relationship-safe and read-only, and keep runtime
+    proof, action-send authority, transport expansion, and parent Task
+    5.x/6.x/7.x acceptance pending.
 
 ## 6. Native Policy Layering
 
@@ -606,6 +621,16 @@ adding more read-only facade shells.
     into the service procedure, keep endpoint flags as context construction,
     keep CLI command-string suggestions as CLI presentation only, emit
     relationship-safe semantic planning output, omit raw
+    host/port/state/session/Tuner payloads and direct-control envelopes from
+    normal JSON, and avoid transport, relationship-label, action-send, or
+    runtime-proof claims.
+  - [x] 7.1.9.8 Route `civ7 game play priorities` through the in-process
+    `attention.priorities` server-side client under the `attention` router.
+    Move priority ranking, source-status, current-HUD/ready-actor/optional
+    battlefield composition, and semantic next-step descriptors into the
+    service procedure. Keep endpoint flags as context construction, keep CLI
+    command-string suggestions as CLI presentation only, emit
+    relationship-safe read-only attention output, omit raw
     host/port/state/session/Tuner payloads and direct-control envelopes from
     normal JSON, and avoid transport, relationship-label, action-send, or
     runtime-proof claims.
@@ -1351,6 +1376,15 @@ adding more read-only facade shells.
   approval/caller-permission scan, service-output CLI-string scan, and diff
   hygiene for the `strategy.frontSummary` service-composition expansion and
   `game play front-summary` in-process oRPC caller migration. This is local
+  package/CLI proof only and does not claim deployed Civ7 runtime proof,
+  play-thread action, transport expansion, relationship labels beyond official
+  evidence, action-send authority, or parent Task 5.x/6.x/7.x acceptance.
+- [x] 8.60.17 Run focused attention-priorities and CLI priorities tests plus
+  control-oRPC package test/check/build, CLI play/check gates, strict
+  OpenSpec validates, private procedure-schema export scan, active
+  approval/caller-permission scan, service-output CLI-string scan, and diff
+  hygiene for the `attention.priorities` service-composition expansion and
+  `game play priorities` in-process oRPC caller migration. This is local
   package/CLI proof only and does not claim deployed Civ7 runtime proof,
   play-thread action, transport expansion, relationship labels beyond official
   evidence, action-send authority, or parent Task 5.x/6.x/7.x acceptance.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -191,6 +191,13 @@ adding more read-only facade shells.
     direct-control's low-level player-operation/city-command authority inside
     the live facade adapter and keep raw operation inputs out of the exported
     context-construction surface.
+  - [x] 5.4.17 Record `world.current` as a service-owned current-world
+    boundary over playable/App UI snapshot facts. The service owns the
+    contract-local schema, normal projection, next-step wording, raw-output
+    exclusion, and relationship-label absence; direct-control remains only the
+    low-level playable/App UI snapshot port. This does not revive
+    `map.summary.read`, `player.summary.read`, `unit.summary.read`, or
+    `city.summary.read`.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -303,6 +310,11 @@ adding more read-only facade shells.
     direct-control turn-completion send authority, and source-owned
     turn-completion proof classification into semantic output without exposing
     raw command/session/Tuner details or claiming runtime/live proof.
+  - [x] 5.5.15 Seed `world.current` as a native service-owned world procedure
+    that projects bounded turn, local-player, map, and player-count facts from
+    the playable/App UI snapshot without calling direct-control summary
+    wrappers, exposing actor catalogs, inferring relationship labels, or
+    claiming runtime/live proof.
 
 ## 6. Native Policy Layering
 
@@ -940,6 +952,16 @@ adding more read-only facade shells.
     command/session/state details, deployed Civ7 proof, play-thread action,
     transport expansion, direct-control game-UI semantic subpaths, public
     package-root procedure schema exports, and full `7.3` acceptance pending.
+  - [x] 7.3.35 Allowlist the read-only `world.current` service procedure
+    through the controller bridge and game-UI supported-read facts: derive the
+    closed bridge request/output schemas from the aggregated
+    `Civ7ControlOrpcContract`, dispatch only when controller context lists
+    `world.current` as supported, and let `readiness.current` recommend
+    `read-world` when current-world facts are the only supported controller
+    read. Keep actor summaries, relationship labels, raw game-UI function
+    names, command/session/state details, deployed Civ7 proof, play-thread
+    action, transport expansion, public package-root procedure schema exports,
+    and full `7.3` acceptance pending.
 - [ ] 7.4 Keep OpenAPI/external REST deferred until there is a documented
   external consumer.
 
@@ -1243,6 +1265,16 @@ adding more read-only facade shells.
   play-thread action, transport expansion, direct-control game-UI semantic
   subpaths, public package-root procedure schema exports, or parent
   Task 5.x/6.x/7.x acceptance.
+- [x] 8.60.12 Run focused world-current, readiness-current, and
+  controller-ingress tests plus control-oRPC package test/check/build,
+  controller mod package build/test/check with bundle scan, strict OpenSpec
+  validates, private procedure-schema export scans, and diff hygiene for the
+  service-owned `world.current` procedure and controller read allowlist slice.
+  These are local package and generated-bundle proofs only and do not claim
+  deployed Civ7 runtime proof, play-thread action, transport expansion,
+  revived summary wrappers, actor catalog support, relationship labels, public
+  package-root procedure schema exports, or parent Task 5.x/6.x/7.x
+  acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -315,6 +315,13 @@ adding more read-only facade shells.
     the playable/App UI snapshot without calling direct-control summary
     wrappers, exposing actor catalogs, inferring relationship labels, or
     claiming runtime/live proof.
+  - [x] 5.5.16 Seed `world.plot.read` and `world.grid.read` as native
+    service-owned world procedures over bounded direct-control plot snapshot
+    and map grid runtime read ports. Keep caller input/output schemas
+    contract-local, strip raw host/port/state/session/Tuner envelopes from
+    normal output, reject endpoint/session/raw command fields before facade
+    execution, and keep game-UI/controller allowlisting, runtime proof, broad
+    actor catalog support, and parent Task 5.x/6.x/7.x acceptance pending.
 
 ## 6. Native Policy Layering
 
@@ -583,6 +590,13 @@ adding more read-only facade shells.
     omit raw host/port/state/session/Tuner payloads from normal summary JSON,
     and leave plot/grid reads on bounded direct-control diagnostics until
     separate accepted world/map read service leaves exist.
+  - [x] 7.1.9.6 Route `civ7 game map --plot` and `civ7 game map --bounds`
+    through the in-process `world.plot.read` and `world.grid.read`
+    server-side clients under the `world` router. Keep endpoint flags as
+    context construction, emit semantic bounded map projections, omit raw
+    host/port/state/session/Tuner payloads and direct-control envelopes from
+    normal JSON, keep GameInfo/debug reads separate, and avoid controller,
+    transport, relationship-label, or runtime-proof claims.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1288,6 +1302,15 @@ adding more read-only facade shells.
   play-thread action, transport expansion, plot/grid service migration,
   revived summary wrappers, relationship labels, or parent Task 5.x/6.x/7.x
   acceptance.
+- [x] 8.60.14 Run focused world plot/grid procedure tests, control-oRPC
+  package check/build, focused CLI map command tests, CLI check, relevant
+  OpenSpec strict validates, private procedure-schema export scan,
+  active approval/caller-permission scan, and diff hygiene for the
+  `world.plot.read`/`world.grid.read` service leaves and `game map`
+  plot/bounds migration. This is local package/CLI service proof only and does
+  not claim deployed Civ7 runtime proof, play-thread action, controller bridge
+  allowlisting, transport expansion, broad actor catalog support, relationship
+  labels, or parent Task 5.x/6.x/7.x acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/attention-priorities-service-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/attention-priorities-service-slice.md
@@ -1,0 +1,68 @@
+# Attention Priorities Service Slice
+
+## Status
+
+Local package, OpenSpec, and boundary-scan proof collected.
+
+## Purpose
+
+Add `attention.priorities` as a native service-owned priority dashboard under
+the `attention` router. The procedure composes playable status, notification,
+turn-completion, ready-unit/city, and optional battlefield runtime/read
+evidence into ranked semantic priorities and next-step descriptors.
+
+This is a read-only attention service. It does not send operations, infer
+relationship labels, or expose CLI command syntax as service output.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/errors.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/src/modules/attention/contract.ts`
+- `packages/civ7-control-orpc/src/modules/attention/router.ts`
+- `packages/civ7-control-orpc/src/modules/attention/procedures/priorities.ts`
+- `packages/civ7-control-orpc/test/attention-priorities-procedure.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/attention-priorities-service-slice.md`
+
+## Boundary
+
+- `attention.priorities` owns priority ranking, source statuses, summaries,
+  notes, and semantic next-step descriptors.
+- Direct-control remains the low-level runtime/read port provider for playable
+  status, HUD/notification, turn-completion, ready-unit/city, and battlefield
+  evidence.
+- Procedure input/output schemas stay contract-local; callers use the aggregate
+  contract/router/server client rather than per-procedure schema exports.
+- Service output does not contain literal `game play ...` CLI command strings.
+- Battlefield evidence is planning context only. Owner mismatch, proximity,
+  contact, ranking, and action legality remain relationship-unproven without
+  official relationship, team, war, or suzerain evidence.
+- No raw host, port, state, session, command, rawCommand, Tuner payload,
+  direct-control runtime envelope, transport expansion, play-thread action,
+  action-send authority, or live runtime proof is claimed.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/attention-priorities-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Private procedure-schema export scan; the new `attention.priorities`
+  input/result schemas remain contract-local, with only the tagged error data
+  schema following the package's existing public error export pattern.
+- Active approval/caller-permission scan over changed surfaces; hits are only
+  approval-removal proof-scan/retirement language in OpenSpec.
+- Service-output CLI-string scan for `attention.priorities`; no literal
+  `game play` command strings appear in the control-oRPC attention service
+  source.
+- `git diff --check`
+
+## Residual Risk
+
+This is local package proof only. It does not prove deployed Civ7 runtime
+behavior, controller bridge allowlisting, transport behavior, relationship
+authority, action sends, or parent Task 5.x/6.x/7.x acceptance.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-civilian-route-triage-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-civilian-route-triage-orpc-slice.md
@@ -1,0 +1,79 @@
+# CLI Civilian Route Triage oRPC Slice
+
+## Status
+
+Local package, CLI, OpenSpec, and boundary-scan proof collected.
+
+## Purpose
+
+Route `civ7 game play civilian-route-triage` through the native in-process
+`strategy.civilianRouteTriage` server-side client. The control-oRPC service
+owns route-status composition over current notification, ready-unit, settlement
+recommendation, battlefield, and destination evidence. The CLI remains an edge
+adapter that builds endpoint context and maps semantic next-step descriptors
+into command suggestions for CLI presentation only.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/dependencies/direct-control.ts`
+- `packages/civ7-control-orpc/src/errors.ts`
+- `packages/civ7-control-orpc/src/game-ui.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/contract.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/router.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/procedures/civilian-route-triage.ts`
+- `packages/civ7-control-orpc/test/strategy-civilian-route-triage-procedure.test.ts`
+- `packages/cli/src/commands/game/play/civilian-route-triage.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-civilian-route-triage-orpc-slice.md`
+
+## Boundary
+
+- `strategy.civilianRouteTriage` owns route status, source status, route
+  reasons, safe settlement/battlefield/destination summaries, and semantic
+  next-step descriptors.
+- Direct-control remains the low-level runtime/read port provider for
+  notification, ready-unit, settlement recommendation, battlefield, and
+  destination evidence.
+- Procedure input/output schemas stay contract-local; callers use the aggregate
+  contract/router/server client rather than per-procedure schema exports.
+- Service output does not contain literal `game play ...` CLI command strings.
+- The game-UI direct-control facade fails closed for settlement recommendations
+  in this slice; controller bridge allowlisting and game-resident route triage
+  support remain pending.
+- Settlement, battlefield, and destination evidence is planning context only.
+  Owner mismatch, proximity, contact, ranking, and action legality remain
+  relationship-unproven without official relationship, team, war, or suzerain
+  evidence.
+- No raw host, port, state, session, command, rawCommand, Tuner payload,
+  notification details, raw unit/city arrays, direct-control runtime envelope,
+  approval/reason mechanic, transport expansion, play-thread action, movement,
+  founding, action-send authority, or live runtime proof is claimed.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/strategy-civilian-route-triage-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run --cwd packages/cli test -- game.play.tactical-read.test.ts`
+- `bun run test:cli:play`
+- `bun run check:cli`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Private procedure-schema export scan; the new
+  `strategy.civilianRouteTriage` input/result schemas remain contract-local,
+  with only tagged error data following the existing public error pattern.
+- Active approval/caller-permission scan over changed surfaces; hits are only
+  approval-removal proof-scan/retirement language in OpenSpec.
+- Service-output CLI-string scan; no literal `game play` command strings appear
+  in the control-oRPC service source.
+- `git diff --check`
+
+## Residual Risk
+
+This is local package and CLI proof only. It does not prove deployed Civ7
+runtime behavior, play-thread state, controller bridge behavior, transport
+behavior, relationship authority, movement/founding/action sends, or parent
+Task 5.x/6.x/7.x acceptance.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-formation-snapshot-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-formation-snapshot-orpc-slice.md
@@ -1,0 +1,80 @@
+# CLI Formation Snapshot oRPC Slice
+
+## Status
+
+Local package, CLI, OpenSpec, and boundary-scan proof collected.
+
+## Purpose
+
+Route `civ7 game play formation-snapshot` through the native in-process
+`strategy.formationSnapshot` server-side client. The control-oRPC service owns
+formation posture composition over current notification, ready-unit, and
+battlefield evidence. The CLI remains an edge adapter that builds endpoint
+context and maps semantic next-step descriptors into command suggestions for
+CLI presentation only.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/errors.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/contract.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/router.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/procedures/formation-snapshot.ts`
+- `packages/civ7-control-orpc/test/strategy-formation-snapshot-procedure.test.ts`
+- `packages/cli/src/commands/game/play/formation-snapshot.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-formation-snapshot-orpc-slice.md`
+
+## Boundary
+
+- `strategy.formationSnapshot` owns formation posture, source status, safe
+  unit/contact projections, relationship-safe reasons, and semantic next-step
+  descriptors.
+- Direct-control remains the low-level runtime/read port provider for
+  notification, ready-unit, and battlefield evidence.
+- Procedure input/output schemas stay contract-local; callers use the aggregate
+  contract/router/server client rather than per-procedure schema exports.
+- Service output does not contain literal `game play ...` CLI command strings.
+- The CLI may still present command suggestions, but that translation is a CLI
+  presentation concern and not part of the native service contract.
+- Controller bridge allowlisting and game-resident formation support remain
+  pending.
+- Battlefield evidence is planning context only. Owner mismatch, proximity,
+  contact, ranking, and action legality remain relationship-unproven without
+  official relationship, team, or equivalent diplomatic evidence.
+- No raw host, port, state, session, command, rawCommand, Tuner payload,
+  notification details, ready-unit operation payloads, raw unit evidence,
+  direct-control runtime envelope, approval/reason mechanic, transport
+  expansion, play-thread action, movement, founding, action-send authority, or
+  live runtime proof is claimed.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/strategy-formation-snapshot-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run --cwd packages/cli test -- game.play.tactical-read.test.ts`
+- `bun run test:cli:play`
+- `bun run check:cli`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Private procedure-schema export scan; the new `strategy.formationSnapshot`
+  input/result schemas remain contract-local, with only tagged error data
+  following the existing public error pattern.
+- Active approval/caller-permission scan over changed surfaces; hits are only
+  input exclusion text and approval-removal proof-scan/retirement language in
+  OpenSpec.
+- Service-output CLI-string scan; no literal `game play` command strings appear
+  in the control-oRPC service source.
+- Relationship-label safety scan; changed service, CLI, and focused test source
+  do not contain hostile/enemy/opponent/threat/war/ally/suzerain labels.
+- `git diff --check`
+
+## Residual Risk
+
+This is local package and CLI proof only. It does not prove deployed Civ7
+runtime behavior, play-thread state, controller bridge behavior, transport
+behavior, relationship authority, movement/action sends, or parent Task
+5.x/6.x/7.x acceptance.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-front-summary-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-front-summary-orpc-slice.md
@@ -1,0 +1,86 @@
+# CLI Front Summary oRPC Slice
+
+## Status
+
+Local package, CLI, OpenSpec, and generated-bundle proof collected.
+
+## Purpose
+
+Route `civ7 game play front-summary` through the native in-process
+`strategy.frontSummary` service procedure and move the remaining front-planning
+composition out of the CLI command. The service owns target-candidate,
+battlefield, optional destination-analysis, source-status, front posture, risk,
+relationship-safe wording, and semantic next-step descriptors.
+
+The CLI remains an edge adapter: it builds endpoint context, parses command
+flags, calls the server-side client, and maps semantic next-step descriptors
+into CLI command suggestions for CLI output only.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/dependencies/direct-control.ts`
+- `packages/civ7-control-orpc/src/game-ui-strategy-front.ts`
+- `packages/civ7-control-orpc/src/game-ui.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/contract.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/procedures/front-summary.ts`
+- `packages/civ7-control-orpc/test/game-ui-controller.test.ts`
+- `packages/civ7-control-orpc/test/strategy-front-summary-procedure.test.ts`
+- `packages/cli/src/commands/game/play/front-summary.ts`
+- `packages/cli/test/commands/game.play.tactical-read.test.ts`
+- `mods/mod-civ7-intelligence-bridge/mod/ui/civ7-intelligence-bridge.js`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/strategy-front-summary-service-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-front-summary-orpc-slice.md`
+
+## Boundary
+
+- `strategy.frontSummary` composes direct-control target-candidate,
+  battlefield-scan, and destination-analysis runtime/read ports through oRPC
+  context.
+- The service output uses semantic next-step descriptors and relationship-safe
+  planning language. It does not emit literal `game play ...` CLI command
+  strings.
+- The CLI may still present command suggestions, but that translation is a CLI
+  presentation concern and not part of the native service contract.
+- The game-UI strategy adapter exposes destination-analysis evidence through
+  the same low-level ambient owner/unit/city reads so the existing controller
+  `strategy.frontSummary` path remains coherent after the richer service
+  composition.
+- No raw host, port, state, session, command, rawCommand, direct-control
+  runtime envelopes, relationship labels beyond official evidence, action
+  sends, transport expansion, play-thread action, or live runtime proof is
+  claimed.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/strategy-front-summary-procedure.test.ts`
+- `bun run test:cli:play -- game.play.tactical-read.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run test:cli:play`
+- `bun run check:cli`
+- `bun run --cwd mods/mod-civ7-intelligence-bridge build`
+- `bun run --cwd mods/mod-civ7-intelligence-bridge check`
+- `bun run --cwd mods/mod-civ7-intelligence-bridge test`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Private procedure-schema export scan; the new `strategy.frontSummary`
+  input/result schemas remain contract-local, with bridge envelopes derived
+  from the aggregate contract.
+- Active approval/caller-permission scan over changed surfaces; hits are only
+  approval-removal proof-scan/retirement language in OpenSpec.
+- Service-output CLI-string scan for `strategy.frontSummary`; no literal
+  `game play` command strings appear in the control-oRPC service or generated
+  game-UI entrypoint.
+- Generated bundle/runtime leakage scan; no Node/direct-control socket runtime,
+  raw command/session payload symbols, RPC transport symbols, or retired
+  approval tokens appear in the rebuilt game UI bundle.
+- `git diff --check`
+
+## Residual Risk
+
+This is local package and CLI proof only. It does not prove deployed Civ7
+runtime behavior, controller bundle behavior, live relationship authority,
+target-action safety, or parent Task 5.x/6.x/7.x acceptance.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-map-summary-world-current-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-map-summary-world-current-slice.md
@@ -1,0 +1,47 @@
+# CLI Map Summary World Current Slice
+
+Status: local CLI/service proof collected.
+Date: 2026-06-06.
+
+## Purpose
+
+Route `civ7 game map --summary` through the native `world.current`
+server-side client now that current-world summary behavior is owned by
+`packages/civ7-control-orpc`.
+
+This is a CLI adapter slice over an existing service procedure. It is not a
+new world read service and it does not change plot/grid diagnostics.
+
+## Write Set
+
+- `packages/cli/src/commands/game/map.ts`
+- `packages/cli/test/commands/game.control.test.ts`
+- OpenSpec task/spec/workstream records for this CLI migration.
+
+## Behavior Boundary
+
+- Summary mode constructs native control-oRPC context from endpoint flags and
+  calls `world.current`.
+- Normal JSON summary output is the semantic current-world projection.
+- Summary output omits raw host, port, state, session, command, rawCommand,
+  Tuner payloads, raw App UI snapshots, direct-control summary envelopes,
+  actor catalogs, and relationship labels.
+- `game map --plot` and `game map --bounds` remain direct-control bounded map
+  diagnostics until separate accepted world/map read services exist.
+
+## Proof Collected
+
+- `bun run --cwd packages/cli test test/commands/game.control.test.ts`
+- `bun run --cwd packages/cli check`
+- `bun run check:cli`
+- `bun run test:cli`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Active approval/caller-permission scan over the changed CLI/OpenSpec
+  surfaces; hits are limited to explicit retirement or absence-scan language.
+- `git diff --check`.
+
+All proof remains local CLI/service proof only. No deployed Civ7 runtime proof,
+play-thread action, transport expansion, plot/grid service migration, revived
+summary wrappers, relationship labels, or parent Task 5.x/6.x/7.x acceptance
+is claimed.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notification-queue-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notification-queue-orpc-slice.md
@@ -1,0 +1,80 @@
+# CLI Notification Queue oRPC Slice
+
+## Status
+
+Local package, CLI, and OpenSpec proof collected.
+
+## Purpose
+
+Route `civ7 game play notification-queue` and
+`civ7 game play dismiss-notification-queue` through native in-process
+notification queue service procedures.
+
+The control-oRPC service owns queue disposition, informational dismissal
+eligibility, exclusion reasons, semantic next-step descriptors, readiness-gated
+aggregate dismissal, and proof/no-repeat projection. The CLI remains an edge
+adapter: it builds endpoint context, parses flags, calls the server-side client,
+and maps semantic next-step descriptors into command suggestions for CLI output
+only.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/errors.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/src/modules/notifications/contract.ts`
+- `packages/civ7-control-orpc/src/modules/notifications/procedures/dismiss-request.ts`
+- `packages/civ7-control-orpc/src/modules/notifications/procedures/queue.ts`
+- `packages/civ7-control-orpc/src/modules/notifications/router.ts`
+- `packages/civ7-control-orpc/test/notification-queue-procedure.test.ts`
+- `packages/cli/src/commands/game/play/notification-queue.ts`
+- `packages/cli/src/commands/game/play/dismiss-notification-queue.ts`
+- `packages/cli/test/commands/game/play/notification/queue.test.ts`
+- `packages/cli/test/commands/game/play/notification/dismiss-queue.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notification-queue-orpc-slice.md`
+
+## Boundary
+
+- `notifications.queue.current` composes the direct-control notification HUD
+  queue read into semantic schedule items without exposing raw notification
+  details as the service contract.
+- `notifications.queue.dismiss.request` passes native mutation readiness and
+  proof/no-repeat middleware, selects only eligible informational dismissal
+  candidates, invokes item-scoped notification dismissal runtime ports, and
+  keeps aggregate unverified sends do-not-repeat guarded.
+- Service output uses semantic next-step descriptors. Literal `game play ...`
+  command strings are CLI presentation only.
+- Normal output omits raw host, port, state, session, command, rawCommand,
+  direct-control runtime envelopes, raw App UI closeout internals, legacy
+  `verified`, approval/reason mechanics, raw operation payloads, and transport
+  details.
+- Operation-bearing, unit-command, production, diplomacy, narrative,
+  progression, population, and unclassified notifications remain excluded from
+  bulk dismissal.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/notification-queue-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run --cwd packages/cli test -- game/play/notification/queue.test.ts game/play/notification/dismiss-queue.test.ts`
+- `bun run check:cli`
+- `bun run test:cli:play`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Private procedure-schema export scan: queue input/result schemas remain
+  contract-local constants; no procedure schema bag is exported.
+- Active approval/caller-permission scan: hits are limited to negative
+  boundary wording and the focused bad-input assertion.
+- Service-output CLI-string scan: `notifications.queue.*` service source has
+  no literal `game play ...` command strings.
+- `git diff --check`
+
+## Residual Risk
+
+This is local package and CLI proof only. It does not prove deployed Civ7
+runtime behavior, controller bridge allowlisting, live notification queue
+mutation behavior, broad operation catalog support, transport expansion,
+approval/reason mechanics, or parent Task 5.x/6.x/7.x acceptance.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-priorities-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-priorities-orpc-slice.md
@@ -1,0 +1,71 @@
+# CLI Priorities oRPC Slice
+
+## Status
+
+Local CLI, package, OpenSpec, and boundary-scan proof collected.
+
+## Purpose
+
+Route `civ7 game play priorities` through the native in-process
+`attention.priorities` server-side client. The control-oRPC service owns
+priority ranking, source-status, current HUD/ready actor, optional battlefield,
+and semantic next-step composition. The CLI remains an edge adapter that builds
+endpoint context and maps semantic next-step descriptors into command
+suggestions for CLI presentation only.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/errors.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/src/modules/attention/contract.ts`
+- `packages/civ7-control-orpc/src/modules/attention/router.ts`
+- `packages/civ7-control-orpc/src/modules/attention/procedures/priorities.ts`
+- `packages/civ7-control-orpc/test/attention-priorities-procedure.test.ts`
+- `packages/cli/src/commands/game/play/priorities.ts`
+- `packages/cli/test/commands/game/play/priorities.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/attention-priorities-service-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-priorities-orpc-slice.md`
+
+## Boundary
+
+- CLI endpoint flags construct oRPC context; endpoint/session/state/raw command
+  fields are not procedure input.
+- CLI output may include command suggestions, but those strings are mapped
+  locally from semantic service descriptors and are not part of the native
+  service contract.
+- The command stays read-only. It does not send unit/city/turn/progression
+  operations or claim live runtime proof.
+- Normal JSON omits raw host, port, state, session, command, rawCommand, Tuner
+  payloads, direct-control runtime envelopes, and transport details.
+- Battlefield evidence remains relationship-safe planning context and does not
+  authorize hostile/enemy/opponent/threat labels or action sends.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/attention-priorities-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run --cwd packages/cli test -- game/play/priorities.test.ts`
+- `bun run test:cli:play`
+- `bun run check:cli`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Private procedure-schema export scan; the new `attention.priorities`
+  input/result schemas remain contract-local, with only the tagged error data
+  schema following the package's existing public error export pattern.
+- Active approval/caller-permission scan over changed surfaces; hits are only
+  approval-removal proof-scan/retirement language in OpenSpec.
+- Service-output CLI-string scan for `attention.priorities`; no literal
+  `game play` command strings appear in the control-oRPC attention service
+  source.
+- `git diff --check`
+
+## Residual Risk
+
+This is local package and CLI proof only. It does not prove deployed Civ7
+runtime behavior, play-thread state, controller bridge behavior, transport
+behavior, relationship authority, action sends, or parent Task 5.x/6.x/7.x
+acceptance.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-world-map-game-ui-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-world-map-game-ui-slice.md
@@ -1,0 +1,65 @@
+# Controller World Map Game UI Slice
+
+## Status
+
+Local package and generated-bundle proof collected.
+
+## Purpose
+
+Move the existing service-owned `world.plot.read` and `world.grid.read`
+procedures into the game-scoped controller path without creating a new
+transport API, exporting procedure input/result schema constants, or moving
+normal map-read semantics out of the `world` service procedures.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/game-ui-map.ts`
+- `packages/civ7-control-orpc/src/game-ui.ts`
+- `packages/civ7-control-orpc/src/bridge/controller-ingress.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts`
+- `packages/civ7-control-orpc/test/game-ui-controller.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/controller-world-map-game-ui-slice.md`
+
+## Boundary
+
+- The game-UI map dependency is a low-level runtime/read dependency for the
+  existing world procedures. It returns bounded plot/grid evidence shaped like
+  the direct-control runtime port; the service procedure still owns normal
+  projection, source-status wording, and raw-output omission.
+- Controller bridge envelopes are derived from the aggregated
+  `Civ7ControlOrpcContract`; no per-procedure input/result schema constants are
+  exported for callers and no `Type.Unknown` bridge input/output is used.
+- `world.plot.read` and `world.grid.read` are advertised as game-UI supported
+  reads only when the required plot-level `GameplayMap` APIs exist.
+- Normal bridge output omits host, port, state, session, command, rawCommand,
+  Tuner payloads, direct-control runtime envelopes, raw game-UI function names,
+  actor catalogs, and relationship labels.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/controller-bridge-ingress.test.ts test/game-ui-controller.test.ts test/world-map-read-procedure.test.ts test/readiness-current-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run --cwd mods/mod-civ7-intelligence-bridge build`
+- `bun run --cwd mods/mod-civ7-intelligence-bridge check`
+- `bun run --cwd mods/mod-civ7-intelligence-bridge test`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Private procedure-schema export scan; no exported world plot/grid
+  input/result schema constants were found outside the contract.
+- Active approval/caller-permission scan over changed surfaces; hits are only
+  approval-removal proof-scan language in OpenSpec records.
+- Generated bundle scan for direct-control root/socket/session runtime, raw
+  command/session payload symbols, RPC transport symbols, and retired
+  approval/caller-permission tokens; no hits in the rebuilt game UI bundle.
+- `git diff --check`
+
+## Residual Risk
+
+No deployed Civ7 runtime proof is claimed. Broad world/actor catalogs,
+relationship labels, transport expansion, play-thread action, and full parent
+Task 5.x/6.x/7.x acceptance remain pending.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/strategy-front-summary-service-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/strategy-front-summary-service-slice.md
@@ -7,8 +7,9 @@ Date: 2026-06-05.
 
 Seed the first native `strategy` service procedure after the workstream
 rebaseline stopped adding same-shaped read wrappers. `strategy.frontSummary`
-is a planning view for support/player agents that composes target-candidate
-and battlefield-scan evidence into one neutral front summary.
+is a planning view for support/player agents that composes target-candidate,
+battlefield-scan, and optional destination-analysis evidence into one neutral
+front summary.
 
 The slice advances semantic capability hierarchy and service-owned behavior
 without adding a strategy catalog, transport edge, direct-control procedure
@@ -33,12 +34,16 @@ core, action authority, or in-game/runtime proof.
 
 `strategy.frontSummary`:
 
-- calls `getCiv7TargetCandidates` and `getCiv7BattlefieldScan` as
+- calls `getCiv7TargetCandidates`, `getCiv7BattlefieldScan`, and, when a
+  target is supplied or inferred, `getCiv7DestinationAnalysis` as
   direct-control runtime/read ports through oRPC context;
 - owns the normal service projection in `packages/civ7-control-orpc`;
 - emits source status, target-candidate summaries, points of interest,
-  observed owner summaries, policy notes, and next steps for inspection,
-  visibility reads, and validator-backed action checks;
+  destination pressure, observed owner summaries, policy notes, and semantic
+  next-step descriptors for inspection, visibility reads, and
+  validator-backed action checks;
+- keeps concrete CLI command strings out of the service contract; CLI callers
+  may map semantic next-step descriptors into command suggestions locally;
 - excludes direct-control `host`, `port`, `state`, raw session, raw command,
   and transport/debug details from normal output;
 - preserves `relationship-unproven` for other owners unless official
@@ -55,8 +60,9 @@ declare war, send actions, validate a target action, or close a blocker.
   direct-control summary surface;
 - no mutation behavior, mutation policy change, validator/postcondition
   middleware, telemetry persistence, or raw proof/debug projection;
-- no CLI, Studio, RPCLink, OpenAPI, in-game bridge, transport, or
-  `Civ7IntelligenceBridge` implementation in this service seed;
+- no Studio, RPCLink, OpenAPI, transport, or `Civ7IntelligenceBridge`
+  implementation in this service seed; later CLI and controller slices may
+  call the same semantic procedure without moving CLI syntax into the service;
 - no runtime/live-game proof claim, play-thread action, or Task 5.x/6.x parent
   acceptance by implication.
 
@@ -64,10 +70,13 @@ declare war, send actions, validate a target action, or close a blocker.
 
 Focused package proof covers:
 
-- in-process router calls compose both direct-control runtime/read ports with
-  endpoint defaults supplied through context;
+- in-process router calls compose target-candidate, battlefield-scan, and
+  destination-analysis runtime/read ports with endpoint defaults supplied
+  through context;
 - normal output omits host, port, state, raw command, and command-source
   details;
+- normal service output uses semantic next-step descriptors, not `game play`
+  command strings;
 - other-owner target candidates and observed owners stay
   `relationship-unproven`;
 - endpoint/session/state/raw command fields are rejected as procedure input;
@@ -89,8 +98,8 @@ Closure gates:
 ## Residual Risk
 
 This is local package proof only. It proves native service composition and
-projection shape, not live Civ7 target-candidate or battlefield evidence, not
-runtime relationship authority, not a complete strategy family, and not parent
-Task 5.x/6.x completion. Later controller work may add game-resident
-dependencies for the same semantic `strategy.frontSummary` procedure without
-reviving raw target-candidate or battlefield-scan bridge leaves.
+projection shape, not live Civ7 target-candidate, battlefield, or destination
+evidence, not runtime relationship authority, not a complete strategy family,
+and not parent Task 5.x/6.x completion. Later caller/controller work may call
+the same semantic `strategy.frontSummary` procedure without reviving raw
+target-candidate, battlefield-scan, or destination-analysis bridge leaves.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/world-current-service-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/world-current-service-slice.md
@@ -1,0 +1,80 @@
+# World Current Service Slice
+
+Status: local package and generated-bundle proof collected.
+Date: 2026-06-06.
+
+## Purpose
+
+Add `world.current` as a bounded service-owned current-world read in
+`packages/civ7-control-orpc`. This is the replacement path for the stopped
+summary-catalog approach: the procedure projects current world facts from the
+existing playable/App UI snapshot runtime port, not from direct-control
+summary wrappers.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/modules/world/**` for the contract-local
+  schema, native procedure, and router.
+- `packages/civ7-control-orpc/src/contract.ts`,
+  `packages/civ7-control-orpc/src/router.ts`, and
+  `packages/civ7-control-orpc/src/index.ts` for aggregate service exposure.
+- `packages/civ7-control-orpc/src/errors.ts` for bounded tagged error data.
+- `packages/civ7-control-orpc/src/game-ui.ts`,
+  `packages/civ7-control-orpc/src/modules/readiness/**`, and
+  `packages/civ7-control-orpc/src/bridge/controller-ingress.ts` for
+  controller supported-read facts, `read-world` readiness next step, and closed
+  bridge ingress over the aggregate contract.
+- Focused control-oRPC tests for service projection, readiness, and bridge
+  ingress.
+- OpenSpec task/spec/workstream records for this bounded slice.
+
+## Behavior Boundary
+
+`world.current`:
+
+- accepts a closed empty input object;
+- reads the low-level playable/App UI snapshot evidence already exposed through
+  context;
+- projects bounded turn, local-player, map, and player-count facts;
+- returns source-status fields that distinguish read versus skipped coverage;
+- recommends attention/world inspection next steps without claiming runtime
+  proof from local tests.
+
+The slice deliberately does not:
+
+- call `getCiv7MapSummary`, `getCiv7PlayerSummary`,
+  `getCiv7UnitSummary`, or `getCiv7CitySummary`;
+- revive `map.summary.read`, `player.summary.read`, `unit.summary.read`, or
+  `city.summary.read`;
+- expose actor samples, owner grouping, relationship labels, raw app-ui
+  snapshot objects, host, port, state, session, command, rawCommand, Tuner
+  payloads, or direct-control runtime envelopes;
+- infer hostile, enemy, opponent, threat, war, ally, suzerain, or other
+  relationship labels from owner ids or player counts;
+- add transport, CLI, Studio, runtime proof, play-thread action, or parent
+  Task 5.x/6.x/7.x acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/game-ui-controller.test.ts test/world-current-procedure.test.ts test/readiness-current-procedure.test.ts test/controller-bridge-ingress.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run --cwd mods/mod-civ7-intelligence-bridge build`
+- `bun run --cwd mods/mod-civ7-intelligence-bridge test`
+- `bun run --cwd mods/mod-civ7-intelligence-bridge check`
+- Generated bundle absence scan for direct-control root/socket/session runtime,
+  raw command/session payload strings, RPC transport symbols, and retired
+  caller-permission tokens.
+- Private procedure-schema export scan over the world contract, package root,
+  and generated declaration surface.
+- Active approval/caller-permission scan over changed control-oRPC source,
+  tests, and OpenSpec records; hits are limited to explicit retirement or
+  absence-scan language.
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- `git diff --check`
+
+All proof remains local package and generated-bundle proof only until a
+support-owned deployed Civ7 runtime pass proves the shipped UIScript behavior
+in game.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/world-plot-grid-service-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/world-plot-grid-service-slice.md
@@ -1,0 +1,67 @@
+# World Plot/Grid Service Slice
+
+Status: local package/CLI proof collected.
+Date: 2026-06-06.
+
+## Purpose
+
+Add service-owned `world.plot.read` and `world.grid.read` leaves under the
+native `world` router, then route `civ7 game map --plot` and
+`civ7 game map --bounds` through the in-process server-side client.
+
+This completes the current `game map` command migration without reviving
+facade-only summary wrappers. Direct-control remains the low-level bounded map
+probe/runtime port; control-oRPC owns the caller-facing map read projection.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/modules/world/contract.ts`
+- `packages/civ7-control-orpc/src/modules/world/procedures/map-reads.ts`
+- `packages/civ7-control-orpc/src/modules/world/router.ts`
+- `packages/civ7-control-orpc/src/dependencies/direct-control.ts`
+- `packages/civ7-control-orpc/src/errors.ts`
+- `packages/civ7-control-orpc/src/game-ui.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/test/world-map-read-procedure.test.ts`
+- `packages/cli/src/commands/game/map.ts`
+- `packages/cli/test/commands/game.control.test.ts`
+- OpenSpec task/spec/workstream records for this service and CLI migration.
+
+## Behavior Boundary
+
+- `world.plot.read` projects one bounded plot snapshot into a semantic world
+  DTO without raw host, port, state, session, command, rawCommand, Tuner
+  payload, or direct-control runtime envelope fields.
+- `world.grid.read` projects a bounded map grid into a semantic world DTO with
+  omission and probe-error source status.
+- Caller input schemas are closed and reject endpoint/session/state/raw command
+  fields before facade execution.
+- `game map --plot` and `game map --bounds` construct native control-oRPC
+  context from endpoint flags and call the in-process world service client.
+- GameInfo/debug reads remain separate debug projection surfaces.
+- Game-UI controller context explicitly leaves plot/grid reads unsupported in
+  this slice; no controller bridge allowlist or game-resident map evidence path
+  is added.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/world-map-read-procedure.test.ts test/world-current-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run --cwd packages/cli test test/commands/game.control.test.ts`
+- `bun run --cwd packages/cli check`
+- `bun run check:cli`
+- `bun run test:cli`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Private procedure-schema export scan; no root/runtime/CLI export of
+  world plot/grid input/result schema constants was found.
+- Active approval/caller-permission scan over changed surfaces; hits are
+  limited to explicit retirement or proof-scan language.
+- `git diff --check`.
+
+All proof remains local package/CLI service proof only. No deployed Civ7
+runtime proof, play-thread action, controller bridge allowlisting, game-UI map
+support, transport expansion, broad actor catalog support, relationship labels,
+or parent Task 5.x/6.x/7.x acceptance is claimed.

--- a/packages/civ7-control-orpc/src/bridge/controller-ingress.ts
+++ b/packages/civ7-control-orpc/src/bridge/controller-ingress.ts
@@ -29,6 +29,12 @@ const Civ7StrategyFrontSummaryInputSchema = typeboxInputSchemaFromContractProced
 const Civ7StrategyFrontSummaryResultSchema = typeboxOutputSchemaFromContractProcedure(
   Civ7ControlOrpcContract.strategy.frontSummary,
 );
+const Civ7WorldCurrentInputSchema = typeboxInputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.world.current,
+);
+const Civ7WorldCurrentResultSchema = typeboxOutputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.world.current,
+);
 const Civ7NotificationDismissInputSchema = typeboxInputSchemaFromContractProcedure(
   Civ7ControlOrpcContract.notifications.dismiss.request,
 );
@@ -245,6 +251,18 @@ export const Civ7ControllerBridgeStrategyFrontSummaryRequestSchema =
   );
 export type Civ7ControllerBridgeStrategyFrontSummaryRequest = Static<
   typeof Civ7ControllerBridgeStrategyFrontSummaryRequestSchema
+>;
+
+export const Civ7ControllerBridgeWorldCurrentRequestSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("world.current"),
+    input: Civ7WorldCurrentInputSchema,
+    correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ControllerBridgeWorldCurrentRequest = Static<
+  typeof Civ7ControllerBridgeWorldCurrentRequestSchema
 >;
 
 export const Civ7ControllerBridgeNotificationDismissRequestSchema = Type.Object(
@@ -523,6 +541,7 @@ export const Civ7ControllerBridgeRequestSchema = Type.Union([
   Civ7ControllerBridgeReadinessCurrentRequestSchema,
   Civ7ControllerBridgeAttentionCurrentRequestSchema,
   Civ7ControllerBridgeStrategyFrontSummaryRequestSchema,
+  Civ7ControllerBridgeWorldCurrentRequestSchema,
   Civ7ControllerBridgeNotificationDismissRequestSchema,
   Civ7ControllerBridgeTurnCompleteRequestSchema,
   Civ7ControllerBridgeCityProductionChoiceRequestSchema,
@@ -550,6 +569,7 @@ export type Civ7ControllerBridgeRequest =
   | Civ7ControllerBridgeReadinessCurrentRequest
   | Civ7ControllerBridgeAttentionCurrentRequest
   | Civ7ControllerBridgeStrategyFrontSummaryRequest
+  | Civ7ControllerBridgeWorldCurrentRequest
   | Civ7ControllerBridgeNotificationDismissRequest
   | Civ7ControllerBridgeTurnCompleteRequest
   | Civ7ControllerBridgeCityProductionChoiceRequest
@@ -630,6 +650,20 @@ export const Civ7ControllerBridgeStrategyFrontSummarySuccessResponseSchema =
   );
 export type Civ7ControllerBridgeStrategyFrontSummarySuccessResponse = Static<
   typeof Civ7ControllerBridgeStrategyFrontSummarySuccessResponseSchema
+>;
+
+export const Civ7ControllerBridgeWorldCurrentSuccessResponseSchema =
+  Type.Object(
+    {
+      ok: Type.Literal(true),
+      procedureKey: Type.Literal("world.current"),
+      output: Civ7WorldCurrentResultSchema,
+      correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
+    },
+    { additionalProperties: false },
+  );
+export type Civ7ControllerBridgeWorldCurrentSuccessResponse = Static<
+  typeof Civ7ControllerBridgeWorldCurrentSuccessResponseSchema
 >;
 
 export const Civ7ControllerBridgeNotificationDismissSuccessResponseSchema =
@@ -951,6 +985,7 @@ export const Civ7ControllerBridgeSuccessResponseSchema = Type.Union([
   Civ7ControllerBridgeReadinessCurrentSuccessResponseSchema,
   Civ7ControllerBridgeAttentionCurrentSuccessResponseSchema,
   Civ7ControllerBridgeStrategyFrontSummarySuccessResponseSchema,
+  Civ7ControllerBridgeWorldCurrentSuccessResponseSchema,
   Civ7ControllerBridgeNotificationDismissSuccessResponseSchema,
   Civ7ControllerBridgeTurnCompleteSuccessResponseSchema,
   Civ7ControllerBridgeCityProductionChoiceSuccessResponseSchema,
@@ -978,6 +1013,7 @@ export type Civ7ControllerBridgeSuccessResponse =
   | Civ7ControllerBridgeReadinessCurrentSuccessResponse
   | Civ7ControllerBridgeAttentionCurrentSuccessResponse
   | Civ7ControllerBridgeStrategyFrontSummarySuccessResponse
+  | Civ7ControllerBridgeWorldCurrentSuccessResponse
   | Civ7ControllerBridgeNotificationDismissSuccessResponse
   | Civ7ControllerBridgeTurnCompleteSuccessResponse
   | Civ7ControllerBridgeCityProductionChoiceSuccessResponse
@@ -1113,6 +1149,18 @@ export async function invokeCiv7ControllerBridgeRequest(
       return {
         ok: true,
         procedureKey: "strategy.frontSummary",
+        output,
+        ...(request.correlationId == null
+          ? {}
+          : { correlationId: request.correlationId }),
+      };
+    }
+
+    if (request.procedureKey === "world.current") {
+      const output = await client.world.current(validatedInput);
+      return {
+        ok: true,
+        procedureKey: "world.current",
         output,
         ...(request.correlationId == null
           ? {}
@@ -1440,6 +1488,7 @@ function isUnsupportedProcedureRequest(
     && request.procedureKey !== "readiness.current"
     && request.procedureKey !== "attention.current"
     && request.procedureKey !== "strategy.frontSummary"
+    && request.procedureKey !== "world.current"
     && request.procedureKey !== "notifications.dismiss.request"
     && request.procedureKey !== "turn.complete.request"
     && request.procedureKey !== "city.production.choice.request"

--- a/packages/civ7-control-orpc/src/bridge/controller-ingress.ts
+++ b/packages/civ7-control-orpc/src/bridge/controller-ingress.ts
@@ -35,6 +35,18 @@ const Civ7WorldCurrentInputSchema = typeboxInputSchemaFromContractProcedure(
 const Civ7WorldCurrentResultSchema = typeboxOutputSchemaFromContractProcedure(
   Civ7ControlOrpcContract.world.current,
 );
+const Civ7WorldPlotReadInputSchema = typeboxInputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.world.plot,
+);
+const Civ7WorldPlotReadResultSchema = typeboxOutputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.world.plot,
+);
+const Civ7WorldGridReadInputSchema = typeboxInputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.world.grid,
+);
+const Civ7WorldGridReadResultSchema = typeboxOutputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.world.grid,
+);
 const Civ7NotificationDismissInputSchema = typeboxInputSchemaFromContractProcedure(
   Civ7ControlOrpcContract.notifications.dismiss.request,
 );
@@ -263,6 +275,30 @@ export const Civ7ControllerBridgeWorldCurrentRequestSchema = Type.Object(
 );
 export type Civ7ControllerBridgeWorldCurrentRequest = Static<
   typeof Civ7ControllerBridgeWorldCurrentRequestSchema
+>;
+
+export const Civ7ControllerBridgeWorldPlotReadRequestSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("world.plot.read"),
+    input: Civ7WorldPlotReadInputSchema,
+    correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ControllerBridgeWorldPlotReadRequest = Static<
+  typeof Civ7ControllerBridgeWorldPlotReadRequestSchema
+>;
+
+export const Civ7ControllerBridgeWorldGridReadRequestSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("world.grid.read"),
+    input: Civ7WorldGridReadInputSchema,
+    correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ControllerBridgeWorldGridReadRequest = Static<
+  typeof Civ7ControllerBridgeWorldGridReadRequestSchema
 >;
 
 export const Civ7ControllerBridgeNotificationDismissRequestSchema = Type.Object(
@@ -542,6 +578,8 @@ export const Civ7ControllerBridgeRequestSchema = Type.Union([
   Civ7ControllerBridgeAttentionCurrentRequestSchema,
   Civ7ControllerBridgeStrategyFrontSummaryRequestSchema,
   Civ7ControllerBridgeWorldCurrentRequestSchema,
+  Civ7ControllerBridgeWorldPlotReadRequestSchema,
+  Civ7ControllerBridgeWorldGridReadRequestSchema,
   Civ7ControllerBridgeNotificationDismissRequestSchema,
   Civ7ControllerBridgeTurnCompleteRequestSchema,
   Civ7ControllerBridgeCityProductionChoiceRequestSchema,
@@ -570,6 +608,8 @@ export type Civ7ControllerBridgeRequest =
   | Civ7ControllerBridgeAttentionCurrentRequest
   | Civ7ControllerBridgeStrategyFrontSummaryRequest
   | Civ7ControllerBridgeWorldCurrentRequest
+  | Civ7ControllerBridgeWorldPlotReadRequest
+  | Civ7ControllerBridgeWorldGridReadRequest
   | Civ7ControllerBridgeNotificationDismissRequest
   | Civ7ControllerBridgeTurnCompleteRequest
   | Civ7ControllerBridgeCityProductionChoiceRequest
@@ -664,6 +704,34 @@ export const Civ7ControllerBridgeWorldCurrentSuccessResponseSchema =
   );
 export type Civ7ControllerBridgeWorldCurrentSuccessResponse = Static<
   typeof Civ7ControllerBridgeWorldCurrentSuccessResponseSchema
+>;
+
+export const Civ7ControllerBridgeWorldPlotReadSuccessResponseSchema =
+  Type.Object(
+    {
+      ok: Type.Literal(true),
+      procedureKey: Type.Literal("world.plot.read"),
+      output: Civ7WorldPlotReadResultSchema,
+      correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
+    },
+    { additionalProperties: false },
+  );
+export type Civ7ControllerBridgeWorldPlotReadSuccessResponse = Static<
+  typeof Civ7ControllerBridgeWorldPlotReadSuccessResponseSchema
+>;
+
+export const Civ7ControllerBridgeWorldGridReadSuccessResponseSchema =
+  Type.Object(
+    {
+      ok: Type.Literal(true),
+      procedureKey: Type.Literal("world.grid.read"),
+      output: Civ7WorldGridReadResultSchema,
+      correlationId: Type.Optional(Civ7ControlOrpcCorrelationIdSchema),
+    },
+    { additionalProperties: false },
+  );
+export type Civ7ControllerBridgeWorldGridReadSuccessResponse = Static<
+  typeof Civ7ControllerBridgeWorldGridReadSuccessResponseSchema
 >;
 
 export const Civ7ControllerBridgeNotificationDismissSuccessResponseSchema =
@@ -986,6 +1054,8 @@ export const Civ7ControllerBridgeSuccessResponseSchema = Type.Union([
   Civ7ControllerBridgeAttentionCurrentSuccessResponseSchema,
   Civ7ControllerBridgeStrategyFrontSummarySuccessResponseSchema,
   Civ7ControllerBridgeWorldCurrentSuccessResponseSchema,
+  Civ7ControllerBridgeWorldPlotReadSuccessResponseSchema,
+  Civ7ControllerBridgeWorldGridReadSuccessResponseSchema,
   Civ7ControllerBridgeNotificationDismissSuccessResponseSchema,
   Civ7ControllerBridgeTurnCompleteSuccessResponseSchema,
   Civ7ControllerBridgeCityProductionChoiceSuccessResponseSchema,
@@ -1014,6 +1084,8 @@ export type Civ7ControllerBridgeSuccessResponse =
   | Civ7ControllerBridgeAttentionCurrentSuccessResponse
   | Civ7ControllerBridgeStrategyFrontSummarySuccessResponse
   | Civ7ControllerBridgeWorldCurrentSuccessResponse
+  | Civ7ControllerBridgeWorldPlotReadSuccessResponse
+  | Civ7ControllerBridgeWorldGridReadSuccessResponse
   | Civ7ControllerBridgeNotificationDismissSuccessResponse
   | Civ7ControllerBridgeTurnCompleteSuccessResponse
   | Civ7ControllerBridgeCityProductionChoiceSuccessResponse
@@ -1161,6 +1233,30 @@ export async function invokeCiv7ControllerBridgeRequest(
       return {
         ok: true,
         procedureKey: "world.current",
+        output,
+        ...(request.correlationId == null
+          ? {}
+          : { correlationId: request.correlationId }),
+      };
+    }
+
+    if (request.procedureKey === "world.plot.read") {
+      const output = await client.world.plot(validatedInput);
+      return {
+        ok: true,
+        procedureKey: "world.plot.read",
+        output,
+        ...(request.correlationId == null
+          ? {}
+          : { correlationId: request.correlationId }),
+      };
+    }
+
+    if (request.procedureKey === "world.grid.read") {
+      const output = await client.world.grid(validatedInput);
+      return {
+        ok: true,
+        procedureKey: "world.grid.read",
         output,
         ...(request.correlationId == null
           ? {}
@@ -1489,6 +1585,8 @@ function isUnsupportedProcedureRequest(
     && request.procedureKey !== "attention.current"
     && request.procedureKey !== "strategy.frontSummary"
     && request.procedureKey !== "world.current"
+    && request.procedureKey !== "world.plot.read"
+    && request.procedureKey !== "world.grid.read"
     && request.procedureKey !== "notifications.dismiss.request"
     && request.procedureKey !== "turn.complete.request"
     && request.procedureKey !== "city.production.choice.request"

--- a/packages/civ7-control-orpc/src/contract.ts
+++ b/packages/civ7-control-orpc/src/contract.ts
@@ -43,6 +43,10 @@ import {
   Civ7UnitContract,
   type Civ7UnitContract as Civ7UnitContractType,
 } from "./modules/unit/contract";
+import {
+  Civ7WorldContract,
+  type Civ7WorldContract as Civ7WorldContractType,
+} from "./modules/world/contract";
 
 export type Civ7ControlOrpcContract = Readonly<{
   attention: Civ7AttentionContractType;
@@ -56,6 +60,7 @@ export type Civ7ControlOrpcContract = Readonly<{
   strategy: Civ7StrategyContractType;
   turn: Civ7TurnContractType;
   unit: Civ7UnitContractType;
+  world: Civ7WorldContractType;
 }>;
 
 export const Civ7ControlOrpcContract: Civ7ControlOrpcContract =
@@ -71,4 +76,5 @@ export const Civ7ControlOrpcContract: Civ7ControlOrpcContract =
     strategy: Civ7StrategyContract,
     turn: Civ7TurnContract,
     unit: Civ7UnitContract,
+    world: Civ7WorldContract,
   });

--- a/packages/civ7-control-orpc/src/dependencies/direct-control.ts
+++ b/packages/civ7-control-orpc/src/dependencies/direct-control.ts
@@ -2,6 +2,7 @@ import {
   getCiv7PlayableStatus,
   getCiv7PlayNotificationView,
   getCiv7BattlefieldScan,
+  getCiv7DestinationAnalysis,
   getCiv7MapGrid,
   getCiv7PlotSnapshot,
   getCiv7ReadyCityView,
@@ -32,6 +33,7 @@ import {
   requestCiv7CultureTarget,
   type Civ7DirectControlOptions,
   Civ7BattlefieldScanResultSchema,
+  Civ7DestinationAnalysisResultSchema,
   type Civ7AttributePurchaseInput,
   type Civ7AttributeReviewInput,
   type Civ7DiplomacyResponseInput,
@@ -56,6 +58,7 @@ import {
   Civ7TurnCompletionStatusResultSchema,
   Civ7UnitTargetActionResultSchema,
   type Civ7BattlefieldScanInput,
+  type Civ7DestinationAnalysisInput,
   type Civ7NotificationDismissInput,
   type Civ7NotificationDismissalResult,
   type Civ7OperationRequestResult,
@@ -130,6 +133,9 @@ export type Civ7ControlOrpcPlayNotificationViewResult =
   Civ7PlayNotificationViewResult;
 export type Civ7ControlOrpcBattlefieldScanResult = Static<
   typeof Civ7BattlefieldScanResultSchema
+>;
+export type Civ7ControlOrpcDestinationAnalysisResult = Static<
+  typeof Civ7DestinationAnalysisResultSchema
 >;
 export type Civ7ControlOrpcPlotSnapshotResult = Civ7PlotSnapshotResult;
 export type Civ7ControlOrpcMapGridResult = Civ7MapGridResult;
@@ -252,6 +258,10 @@ export type Civ7ControlOrpcDirectControlFacade = Readonly<{
     input?: Civ7BattlefieldScanInput,
     options?: Civ7DirectControlOptions,
   ): Promise<Civ7ControlOrpcBattlefieldScanResult>;
+  getCiv7DestinationAnalysis(
+    input: Civ7DestinationAnalysisInput,
+    options?: Civ7DirectControlOptions,
+  ): Promise<Civ7ControlOrpcDestinationAnalysisResult>;
   getCiv7PlotSnapshot(
     input: Civ7PlotSnapshotInput,
     options?: Civ7DirectControlOptions,
@@ -360,6 +370,10 @@ export const liveCiv7ControlOrpcDirectControlFacade:
   getCiv7BattlefieldScan: async (input, options) =>
     getCiv7BattlefieldScan(input, options) as Promise<
       Civ7ControlOrpcBattlefieldScanResult
+    >,
+  getCiv7DestinationAnalysis: async (input, options) =>
+    getCiv7DestinationAnalysis(input, options) as Promise<
+      Civ7ControlOrpcDestinationAnalysisResult
     >,
   getCiv7PlotSnapshot: async (input, options) =>
     getCiv7PlotSnapshot(input, options),

--- a/packages/civ7-control-orpc/src/dependencies/direct-control.ts
+++ b/packages/civ7-control-orpc/src/dependencies/direct-control.ts
@@ -2,6 +2,8 @@ import {
   getCiv7PlayableStatus,
   getCiv7PlayNotificationView,
   getCiv7BattlefieldScan,
+  getCiv7MapGrid,
+  getCiv7PlotSnapshot,
   getCiv7ReadyCityView,
   getCiv7ReadyUnitView,
   getCiv7TargetCandidates,
@@ -41,6 +43,8 @@ import {
   type Civ7CultureChoiceCloseoutResult,
   type Civ7GovernmentChoiceInput,
   type Civ7GovernmentDomainChoiceResult,
+  type Civ7MapGridInput,
+  type Civ7MapGridResult,
   type Civ7NarrativeChoiceInput,
   type Civ7NarrativeChoiceResult,
   Civ7PlayNotificationViewResultSchema,
@@ -56,6 +60,8 @@ import {
   type Civ7NotificationDismissalResult,
   type Civ7OperationRequestResult,
   type Civ7PlayNotificationViewResult,
+  type Civ7PlotSnapshotInput,
+  type Civ7PlotSnapshotResult,
   type Civ7PopulationPlacementProofSource,
   type Civ7ProductionChoiceInput,
   type Civ7ReadyCityViewInput,
@@ -125,6 +131,8 @@ export type Civ7ControlOrpcPlayNotificationViewResult =
 export type Civ7ControlOrpcBattlefieldScanResult = Static<
   typeof Civ7BattlefieldScanResultSchema
 >;
+export type Civ7ControlOrpcPlotSnapshotResult = Civ7PlotSnapshotResult;
+export type Civ7ControlOrpcMapGridResult = Civ7MapGridResult;
 export type Civ7ControlOrpcReadyUnitViewResult = Static<
   typeof Civ7ReadyUnitViewResultSchema
 >;
@@ -244,6 +252,14 @@ export type Civ7ControlOrpcDirectControlFacade = Readonly<{
     input?: Civ7BattlefieldScanInput,
     options?: Civ7DirectControlOptions,
   ): Promise<Civ7ControlOrpcBattlefieldScanResult>;
+  getCiv7PlotSnapshot(
+    input: Civ7PlotSnapshotInput,
+    options?: Civ7DirectControlOptions,
+  ): Promise<Civ7ControlOrpcPlotSnapshotResult>;
+  getCiv7MapGrid(
+    input: Civ7MapGridInput,
+    options?: Civ7DirectControlOptions,
+  ): Promise<Civ7ControlOrpcMapGridResult>;
   getCiv7ReadyUnitView(
     input?: Civ7ReadyUnitViewInput,
     options?: Civ7DirectControlOptions,
@@ -345,6 +361,10 @@ export const liveCiv7ControlOrpcDirectControlFacade:
     getCiv7BattlefieldScan(input, options) as Promise<
       Civ7ControlOrpcBattlefieldScanResult
     >,
+  getCiv7PlotSnapshot: async (input, options) =>
+    getCiv7PlotSnapshot(input, options),
+  getCiv7MapGrid: async (input, options) =>
+    getCiv7MapGrid(input, options),
   getCiv7ReadyUnitView: async (input, options) =>
     getCiv7ReadyUnitView(input, options) as Promise<
       Civ7ControlOrpcReadyUnitViewResult

--- a/packages/civ7-control-orpc/src/dependencies/direct-control.ts
+++ b/packages/civ7-control-orpc/src/dependencies/direct-control.ts
@@ -7,6 +7,7 @@ import {
   getCiv7PlotSnapshot,
   getCiv7ReadyCityView,
   getCiv7ReadyUnitView,
+  getCiv7SettlementRecommendations,
   getCiv7TargetCandidates,
   getCiv7TurnCompletionStatus,
   requestCiv7AttributePurchase,
@@ -69,6 +70,8 @@ import {
   type Civ7ProductionChoiceInput,
   type Civ7ReadyCityViewInput,
   type Civ7ReadyUnitViewInput,
+  type Civ7SettlementRecommendationInput,
+  Civ7SettlementRecommendationResultSchema,
   type Civ7TargetCandidatesInput,
   type Civ7TechnologyChoiceCloseoutInput,
   type Civ7TechnologyChoiceCloseoutResult,
@@ -144,6 +147,9 @@ export type Civ7ControlOrpcReadyUnitViewResult = Static<
 >;
 export type Civ7ControlOrpcReadyCityViewResult = Static<
   typeof Civ7ReadyCityViewResultSchema
+>;
+export type Civ7ControlOrpcSettlementRecommendationsResult = Static<
+  typeof Civ7SettlementRecommendationResultSchema
 >;
 export type Civ7ControlOrpcTargetCandidatesResult = Static<
   typeof Civ7TargetCandidatesResultSchema
@@ -278,6 +284,10 @@ export type Civ7ControlOrpcDirectControlFacade = Readonly<{
     input?: Civ7ReadyCityViewInput,
     options?: Civ7DirectControlOptions,
   ): Promise<Civ7ControlOrpcReadyCityViewResult>;
+  getCiv7SettlementRecommendations(
+    input?: Civ7SettlementRecommendationInput,
+    options?: Civ7DirectControlOptions,
+  ): Promise<Civ7ControlOrpcSettlementRecommendationsResult>;
   getCiv7TargetCandidates(
     input?: Civ7TargetCandidatesInput,
     options?: Civ7DirectControlOptions,
@@ -386,6 +396,10 @@ export const liveCiv7ControlOrpcDirectControlFacade:
   getCiv7ReadyCityView: async (input, options) =>
     getCiv7ReadyCityView(input, options) as Promise<
       Civ7ControlOrpcReadyCityViewResult
+    >,
+  getCiv7SettlementRecommendations: async (input, options) =>
+    getCiv7SettlementRecommendations(input, options) as Promise<
+      Civ7ControlOrpcSettlementRecommendationsResult
     >,
   getCiv7TargetCandidates: async (input, options) =>
     getCiv7TargetCandidates(input, options) as Promise<

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -219,6 +219,31 @@ export class Civ7NotificationDismissalUnavailableError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7NotificationQueueUnavailableErrorDataSchema = Type.Object(
+  {
+    procedureKey: Type.Union([
+      Type.Literal("notifications.queue.current"),
+      Type.Literal("notifications.queue.dismiss.request"),
+    ]),
+    source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties,
+  },
+  { additionalProperties: false },
+);
+export type Civ7NotificationQueueUnavailableErrorData = Static<
+  typeof Civ7NotificationQueueUnavailableErrorDataSchema
+>;
+
+export class Civ7NotificationQueueUnavailableError extends ORPCTaggedError(
+  "Civ7NotificationQueueUnavailableError",
+  {
+    code: "NOTIFICATION_QUEUE_UNAVAILABLE",
+    message: "Notification queue service failed.",
+    schema: toStandardSchema(Civ7NotificationQueueUnavailableErrorDataSchema),
+    status: 503,
+  },
+) {}
+
 export const Civ7UnitTargetActionUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("unit.target.action.request"),
@@ -639,6 +664,7 @@ export const civ7ControlOrpcErrorMap = {
   MUTATION_READINESS_UNAVAILABLE: Civ7MutationReadinessUnavailableError,
   NARRATIVE_CHOICE_UNAVAILABLE: Civ7NarrativeChoiceUnavailableError,
   NOTIFICATION_DISMISSAL_UNAVAILABLE: Civ7NotificationDismissalUnavailableError,
+  NOTIFICATION_QUEUE_UNAVAILABLE: Civ7NotificationQueueUnavailableError,
   POPULATION_PLACEMENT_UNAVAILABLE: Civ7PopulationPlacementUnavailableError,
   PROGRESSION_CHOICE_UNAVAILABLE: Civ7ProgressionChoiceUnavailableError,
   PROGRESSION_PLAYER_CHOICE_UNAVAILABLE: Civ7ProgressionPlayerChoiceUnavailableError,

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -100,6 +100,31 @@ export class Civ7WorldCurrentUnavailableError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7WorldReadUnavailableErrorDataSchema = Type.Object(
+  {
+    procedureKey: Type.Union([
+      Type.Literal("world.plot.read"),
+      Type.Literal("world.grid.read"),
+    ]),
+    source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties,
+  },
+  { additionalProperties: false },
+);
+export type Civ7WorldReadUnavailableErrorData = Static<
+  typeof Civ7WorldReadUnavailableErrorDataSchema
+>;
+
+export class Civ7WorldReadUnavailableError extends ORPCTaggedError(
+  "Civ7WorldReadUnavailableError",
+  {
+    code: "WORLD_READ_UNAVAILABLE",
+    message: "World map read failed.",
+    schema: toStandardSchema(Civ7WorldReadUnavailableErrorDataSchema),
+    status: 503,
+  },
+) {}
+
 export const Civ7NotificationDismissalUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("notifications.dismiss.request"),
@@ -553,6 +578,7 @@ export const civ7ControlOrpcErrorMap = {
   UNIT_REQUEST_UNAVAILABLE: Civ7UnitRequestUnavailableError,
   UNIT_TARGET_ACTION_UNAVAILABLE: Civ7UnitTargetActionUnavailableError,
   WORLD_CURRENT_UNAVAILABLE: Civ7WorldCurrentUnavailableError,
+  WORLD_READ_UNAVAILABLE: Civ7WorldReadUnavailableError,
 } satisfies EffectErrorMap;
 
 export type Civ7ControlOrpcEffectErrorMap = typeof civ7ControlOrpcErrorMap;

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -125,6 +125,31 @@ export class Civ7StrategyCivilianRouteTriageUnavailableError extends ORPCTaggedE
   },
 ) {}
 
+export const Civ7StrategyFormationSnapshotUnavailableErrorDataSchema =
+  Type.Object(
+    {
+      procedureKey: Type.Literal("strategy.formationSnapshot"),
+      source: Type.Literal("direct-control-facade"),
+      ...Civ7ControlOrpcErrorCorrelationProperties,
+    },
+    { additionalProperties: false },
+  );
+export type Civ7StrategyFormationSnapshotUnavailableErrorData = Static<
+  typeof Civ7StrategyFormationSnapshotUnavailableErrorDataSchema
+>;
+
+export class Civ7StrategyFormationSnapshotUnavailableError extends ORPCTaggedError(
+  "Civ7StrategyFormationSnapshotUnavailableError",
+  {
+    code: "STRATEGY_FORMATION_SNAPSHOT_UNAVAILABLE",
+    message: "Strategy formation snapshot failed.",
+    schema: toStandardSchema(
+      Civ7StrategyFormationSnapshotUnavailableErrorDataSchema,
+    ),
+    status: 503,
+  },
+) {}
+
 export const Civ7WorldCurrentUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("world.current"),
@@ -622,6 +647,8 @@ export const civ7ControlOrpcErrorMap = {
   READINESS_CURRENT_UNAVAILABLE: Civ7ReadinessCurrentUnavailableError,
   STRATEGY_CIVILIAN_ROUTE_TRIAGE_UNAVAILABLE:
     Civ7StrategyCivilianRouteTriageUnavailableError,
+  STRATEGY_FORMATION_SNAPSHOT_UNAVAILABLE:
+    Civ7StrategyFormationSnapshotUnavailableError,
   STRATEGY_FRONT_SUMMARY_UNAVAILABLE: Civ7StrategyFrontSummaryUnavailableError,
   TOWN_FOCUS_UNAVAILABLE: Civ7TownFocusUnavailableError,
   TURN_COMPLETION_UNAVAILABLE: Civ7TurnCompletionUnavailableError,

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -100,6 +100,31 @@ export class Civ7StrategyFrontSummaryUnavailableError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7StrategyCivilianRouteTriageUnavailableErrorDataSchema =
+  Type.Object(
+    {
+      procedureKey: Type.Literal("strategy.civilianRouteTriage"),
+      source: Type.Literal("direct-control-facade"),
+      ...Civ7ControlOrpcErrorCorrelationProperties,
+    },
+    { additionalProperties: false },
+  );
+export type Civ7StrategyCivilianRouteTriageUnavailableErrorData = Static<
+  typeof Civ7StrategyCivilianRouteTriageUnavailableErrorDataSchema
+>;
+
+export class Civ7StrategyCivilianRouteTriageUnavailableError extends ORPCTaggedError(
+  "Civ7StrategyCivilianRouteTriageUnavailableError",
+  {
+    code: "STRATEGY_CIVILIAN_ROUTE_TRIAGE_UNAVAILABLE",
+    message: "Strategy civilian route triage failed.",
+    schema: toStandardSchema(
+      Civ7StrategyCivilianRouteTriageUnavailableErrorDataSchema,
+    ),
+    status: 503,
+  },
+) {}
+
 export const Civ7WorldCurrentUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("world.current"),
@@ -595,6 +620,8 @@ export const civ7ControlOrpcErrorMap = {
   PROGRESSION_TARGET_UNAVAILABLE: Civ7ProgressionTargetUnavailableError,
   PRODUCTION_CHOICE_UNAVAILABLE: Civ7ProductionChoiceUnavailableError,
   READINESS_CURRENT_UNAVAILABLE: Civ7ReadinessCurrentUnavailableError,
+  STRATEGY_CIVILIAN_ROUTE_TRIAGE_UNAVAILABLE:
+    Civ7StrategyCivilianRouteTriageUnavailableError,
   STRATEGY_FRONT_SUMMARY_UNAVAILABLE: Civ7StrategyFrontSummaryUnavailableError,
   TOWN_FOCUS_UNAVAILABLE: Civ7TownFocusUnavailableError,
   TURN_COMPLETION_UNAVAILABLE: Civ7TurnCompletionUnavailableError,

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -56,6 +56,28 @@ export class Civ7AttentionCurrentUnavailableError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7AttentionPrioritiesUnavailableErrorDataSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("attention.priorities"),
+    source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties,
+  },
+  { additionalProperties: false },
+);
+export type Civ7AttentionPrioritiesUnavailableErrorData = Static<
+  typeof Civ7AttentionPrioritiesUnavailableErrorDataSchema
+>;
+
+export class Civ7AttentionPrioritiesUnavailableError extends ORPCTaggedError(
+  "Civ7AttentionPrioritiesUnavailableError",
+  {
+    code: "ATTENTION_PRIORITIES_UNAVAILABLE",
+    message: "Attention priorities view failed.",
+    schema: toStandardSchema(Civ7AttentionPrioritiesUnavailableErrorDataSchema),
+    status: 503,
+  },
+) {}
+
 export const Civ7StrategyFrontSummaryUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("strategy.frontSummary"),
@@ -557,6 +579,7 @@ export class Civ7CorrelationIdInvalidError extends ORPCTaggedError(
 
 export const civ7ControlOrpcErrorMap = {
   ATTENTION_CURRENT_UNAVAILABLE: Civ7AttentionCurrentUnavailableError,
+  ATTENTION_PRIORITIES_UNAVAILABLE: Civ7AttentionPrioritiesUnavailableError,
   CORRELATION_ID_INVALID: Civ7CorrelationIdInvalidError,
   DIPLOMACY_RESPONSE_UNAVAILABLE: Civ7DiplomacyResponseUnavailableError,
   FIRST_MEET_RESPONSE_UNAVAILABLE: Civ7FirstMeetResponseUnavailableError,

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -78,6 +78,28 @@ export class Civ7StrategyFrontSummaryUnavailableError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7WorldCurrentUnavailableErrorDataSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("world.current"),
+    source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties,
+  },
+  { additionalProperties: false },
+);
+export type Civ7WorldCurrentUnavailableErrorData = Static<
+  typeof Civ7WorldCurrentUnavailableErrorDataSchema
+>;
+
+export class Civ7WorldCurrentUnavailableError extends ORPCTaggedError(
+  "Civ7WorldCurrentUnavailableError",
+  {
+    code: "WORLD_CURRENT_UNAVAILABLE",
+    message: "Current world view failed.",
+    schema: toStandardSchema(Civ7WorldCurrentUnavailableErrorDataSchema),
+    status: 503,
+  },
+) {}
+
 export const Civ7NotificationDismissalUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Literal("notifications.dismiss.request"),
@@ -530,6 +552,7 @@ export const civ7ControlOrpcErrorMap = {
   TURN_COMPLETION_UNAVAILABLE: Civ7TurnCompletionUnavailableError,
   UNIT_REQUEST_UNAVAILABLE: Civ7UnitRequestUnavailableError,
   UNIT_TARGET_ACTION_UNAVAILABLE: Civ7UnitTargetActionUnavailableError,
+  WORLD_CURRENT_UNAVAILABLE: Civ7WorldCurrentUnavailableError,
 } satisfies EffectErrorMap;
 
 export type Civ7ControlOrpcEffectErrorMap = typeof civ7ControlOrpcErrorMap;

--- a/packages/civ7-control-orpc/src/game-ui-map.ts
+++ b/packages/civ7-control-orpc/src/game-ui-map.ts
@@ -1,0 +1,401 @@
+import type {
+  Civ7ControlOrpcMapGridResult,
+  Civ7ControlOrpcPlotSnapshotResult,
+} from "./dependencies/direct-control";
+
+type RuntimeProbe<T> = Readonly<
+  | { ok: true; value: T }
+  | { ok: false; error: string }
+>;
+
+type PlotField =
+  Civ7ControlOrpcMapGridResult["fields"] extends ReadonlyArray<infer Field>
+    ? Field
+    : never;
+
+type MapLocation = Readonly<{ x: number; y: number }>;
+type MapBounds = Readonly<{
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}>;
+
+export type Civ7GameUiMapReadTarget = Readonly<{
+  GameplayMap?: {
+    getGridWidth?: () => unknown;
+    getGridHeight?: () => unknown;
+    isValidXY?: (x: number, y: number) => unknown;
+    getIndexFromXY?: (x: number, y: number) => unknown;
+    getTerrainType?: (x: number, y: number) => unknown;
+    getBiomeType?: (x: number, y: number) => unknown;
+    getFeatureType?: (x: number, y: number) => unknown;
+    getResourceType?: (x: number, y: number) => unknown;
+    getElevation?: (x: number, y: number) => unknown;
+    getRainfall?: (x: number, y: number) => unknown;
+    getFertilityType?: (x: number, y: number) => unknown;
+    getRiverType?: (x: number, y: number) => unknown;
+    isWater?: (x: number, y: number) => unknown;
+    getYields?: (x: number, y: number) => unknown;
+    getOwner?: (x: number, y: number) => unknown;
+    getOwnerName?: (x: number, y: number) => unknown;
+    getAreaId?: (x: number, y: number) => unknown;
+    getRegionId?: (x: number, y: number) => unknown;
+    getLandmassId?: (x: number, y: number) => unknown;
+    getPlotTag?: (x: number, y: number) => unknown;
+    getRevealedState?: (playerId: number, x: number, y: number) => unknown;
+  };
+  Visibility?: {
+    isVisible?: (playerId: number, x: number, y: number) => unknown;
+  };
+  MapCities?: {
+    getCity?: (x: number, y: number) => unknown;
+  };
+  MapUnits?: {
+    getUnits?: (x: number, y: number) => unknown;
+  };
+}>;
+
+export function civ7GameUiWorldMapReadsAvailable(
+  target: Civ7GameUiMapReadTarget,
+): boolean {
+  return typeof target.GameplayMap?.getGridWidth === "function"
+    && typeof target.GameplayMap?.getGridHeight === "function"
+    && typeof target.GameplayMap?.isValidXY === "function"
+    && typeof target.GameplayMap?.getIndexFromXY === "function";
+}
+
+export async function getCiv7GameUiPlotSnapshot(
+  input: Readonly<{
+    x: number;
+    y: number;
+    fields?: readonly PlotField[];
+    playerId?: number;
+    includeHidden?: boolean;
+  }>,
+  target: Civ7GameUiMapReadTarget = globalThis as Civ7GameUiMapReadTarget,
+): Promise<Civ7ControlOrpcPlotSnapshotResult> {
+  if (!civ7GameUiWorldMapReadsAvailable(target)) {
+    throw new Error("Civ7 game UI world map dependency is unavailable.");
+  }
+  return {
+    ...gameUiRuntimeIdentity(),
+    ...plotSnapshot(
+      {
+        x: boundedInteger(input.x, 0, 1_000_000, "x"),
+        y: boundedInteger(input.y, 0, 1_000_000, "y"),
+        fields: normalizePlotFields(input.fields),
+        playerId: input.playerId,
+        includeHidden: input.includeHidden,
+      },
+      target,
+    ),
+  };
+}
+
+export async function getCiv7GameUiMapGrid(
+  input: Readonly<{
+    bounds?: MapBounds;
+    locations?: readonly MapLocation[];
+    fields: readonly PlotField[];
+    playerId?: number;
+    includeHidden?: boolean;
+    maxPlots?: number;
+  }>,
+  target: Civ7GameUiMapReadTarget = globalThis as Civ7GameUiMapReadTarget,
+): Promise<Civ7ControlOrpcMapGridResult> {
+  if (!civ7GameUiWorldMapReadsAvailable(target)) {
+    throw new Error("Civ7 game UI world map dependency is unavailable.");
+  }
+  const maxPlots = boundedInteger(input.maxPlots ?? 256, 1, 10_000, "maxPlots");
+  const fields = normalizePlotFields(input.fields);
+  const bounds = input.bounds == null ? undefined : mapBounds(input.bounds);
+  const explicitLocations = input.locations?.map(mapLocation);
+  if (bounds == null && explicitLocations == null) {
+    throw new Error("Civ7 game UI map grid reads require bounds or locations.");
+  }
+  if (bounds != null && explicitLocations != null) {
+    throw new Error("Civ7 game UI map grid reads accept bounds or locations, not both.");
+  }
+
+  const requestedCount = explicitLocations?.length ?? bounds!.width * bounds!.height;
+  const locations = (explicitLocations ?? locationsFromBounds(bounds!, maxPlots))
+    .slice(0, maxPlots);
+
+  return {
+    ...gameUiRuntimeIdentity(),
+    ...(bounds == null ? {} : { bounds }),
+    fields: Array.from(fields),
+    plotCount: requestedCount,
+    omitted: Math.max(0, requestedCount - locations.length),
+    hiddenInfoPolicy: hiddenInfoPolicy(input),
+    map: {
+      width: probe(() => Number(target.GameplayMap!.getGridWidth!())),
+      height: probe(() => Number(target.GameplayMap!.getGridHeight!())),
+    },
+    plots: locations.map((location) =>
+      plotSnapshot({
+        ...location,
+        fields,
+        playerId: input.playerId,
+        includeHidden: input.includeHidden,
+      }, target)
+    ),
+  };
+}
+
+function plotSnapshot(
+  input: Readonly<{
+    x: number;
+    y: number;
+    fields: readonly PlotField[];
+    playerId?: number;
+    includeHidden?: boolean;
+  }>,
+  target: Civ7GameUiMapReadTarget,
+): Omit<Civ7ControlOrpcPlotSnapshotResult, "host" | "port" | "state"> {
+  const visibility = visibilityFor(input, target);
+  if (target.GameplayMap?.isValidXY?.(input.x, input.y) !== true) {
+    return {
+      location: {
+        x: input.x,
+        y: input.y,
+        index: { ok: false, error: "invalid location" },
+      },
+      hiddenInfoPolicy: visibility.policy,
+      facts: {},
+    };
+  }
+
+  const facts: Record<string, RuntimeProbe<unknown>> = {};
+  const include = visibility.policy === "not-player-scoped"
+    || visibility.includeFacts === true;
+  const add = (key: string, value: RuntimeProbe<unknown>) => {
+    facts[key] = value;
+  };
+
+  if (include) {
+    if (input.fields.includes("terrain")) {
+      add("terrain", mapProbe(target, "getTerrainType", input));
+    }
+    if (input.fields.includes("biome")) {
+      add("biome", mapProbe(target, "getBiomeType", input));
+    }
+    if (input.fields.includes("feature")) {
+      add("feature", mapProbe(target, "getFeatureType", input));
+    }
+    if (input.fields.includes("resource")) {
+      add("resource", mapProbe(target, "getResourceType", input));
+    }
+    if (input.fields.includes("climate")) {
+      add("elevation", mapProbe(target, "getElevation", input));
+      add("rainfall", mapProbe(target, "getRainfall", input));
+      add("fertility", mapProbe(target, "getFertilityType", input));
+    }
+    if (input.fields.includes("hydrology")) {
+      add("riverType", mapProbe(target, "getRiverType", input));
+      add("water", mapProbe(target, "isWater", input));
+    }
+    if (input.fields.includes("yields")) {
+      add("yields", mapProbe(target, "getYields", input));
+    }
+    if (input.fields.includes("owner")) {
+      add("owner", mapProbe(target, "getOwner", input));
+      add("ownerName", mapProbe(target, "getOwnerName", input));
+    }
+    if (input.fields.includes("areaRegion")) {
+      add("areaId", mapProbe(target, "getAreaId", input));
+      add("regionId", mapProbe(target, "getRegionId", input));
+      add("landmassId", mapProbe(target, "getLandmassId", input));
+    }
+    if (input.fields.includes("tags")) {
+      add("plotTag", mapProbe(target, "getPlotTag", input));
+    }
+    if (input.fields.includes("city")) {
+      add("city", probe(() => target.MapCities?.getCity?.(input.x, input.y) ?? null));
+    }
+    if (input.fields.includes("units")) {
+      add("units", probe(() => target.MapUnits?.getUnits?.(input.x, input.y) ?? []));
+    }
+  }
+
+  if (input.fields.includes("visibility")) {
+    add(
+      "revealedState",
+      visibility.revealedState ?? { ok: false, error: "playerId required" },
+    );
+    add(
+      "visible",
+      visibility.visible ?? { ok: false, error: "playerId required" },
+    );
+  }
+
+  return {
+    location: {
+      x: input.x,
+      y: input.y,
+      index: probe(() => Number(target.GameplayMap!.getIndexFromXY!(input.x, input.y))),
+    },
+    ...(visibility.revealedState ? { revealedState: visibility.revealedState } : {}),
+    ...(visibility.visible ? { visible: visibility.visible } : {}),
+    hiddenInfoPolicy: visibility.policy,
+    facts,
+  };
+}
+
+function visibilityFor(
+  input: Readonly<{
+    x: number;
+    y: number;
+    playerId?: number;
+    includeHidden?: boolean;
+  }>,
+  target: Civ7GameUiMapReadTarget,
+): Readonly<{
+  policy: Civ7ControlOrpcPlotSnapshotResult["hiddenInfoPolicy"];
+  revealedState?: RuntimeProbe<number | string>;
+  visible?: RuntimeProbe<boolean>;
+  includeFacts?: boolean;
+}> {
+  if (input.playerId == null) return { policy: "not-player-scoped" };
+  const revealedState = probe(() =>
+    target.GameplayMap!.getRevealedState!(input.playerId!, input.x, input.y) as number | string
+  );
+  const visible = probe(() => {
+    if (typeof target.Visibility?.isVisible === "function") {
+      return Boolean(target.Visibility.isVisible(input.playerId!, input.x, input.y));
+    }
+    return revealedState.ok && revealedState.value !== 0;
+  });
+  return {
+    policy: input.includeHidden === true
+      ? "include-hidden"
+      : "visibility-filtered",
+    revealedState,
+    visible,
+    includeFacts: input.includeHidden === true
+      || (visible.ok && visible.value === true)
+      || (revealedState.ok && revealedState.value !== 0),
+  };
+}
+
+function mapProbe(
+  target: Civ7GameUiMapReadTarget,
+  name: Exclude<keyof NonNullable<Civ7GameUiMapReadTarget["GameplayMap"]>,
+    "getGridWidth" | "getGridHeight" | "isValidXY" | "getIndexFromXY"
+    | "getRevealedState">,
+  location: MapLocation,
+): RuntimeProbe<unknown> {
+  return probe(() => {
+    const fn = target.GameplayMap?.[name];
+    if (typeof fn !== "function") {
+      throw new Error(`GameplayMap.${name} is not a function`);
+    }
+    return fn(location.x, location.y);
+  });
+}
+
+function locationsFromBounds(
+  bounds: MapBounds,
+  maxPlots: number,
+): MapLocation[] {
+  const out: MapLocation[] = [];
+  outer: for (let y = bounds.y; y < bounds.y + bounds.height; y += 1) {
+    for (let x = bounds.x; x < bounds.x + bounds.width; x += 1) {
+      out.push({ x, y });
+      if (out.length >= maxPlots) break outer;
+    }
+  }
+  return out;
+}
+
+function normalizePlotFields(
+  fields: readonly PlotField[] | undefined,
+): readonly PlotField[] {
+  const selected: readonly PlotField[] = fields?.length
+    ? fields
+    : defaultPlotFields;
+  for (const field of selected) {
+    if (!allPlotFields.includes(field)) {
+      throw new Error(`Unsupported Civ7 plot field: ${field}`);
+    }
+  }
+  return Array.from(new Set(selected));
+}
+
+function hiddenInfoPolicy(
+  input: Readonly<{ playerId?: number; includeHidden?: boolean }>,
+): Civ7ControlOrpcMapGridResult["hiddenInfoPolicy"] {
+  if (input.playerId == null) return "not-player-scoped";
+  return input.includeHidden === true ? "include-hidden" : "visibility-filtered";
+}
+
+function mapBounds(bounds: MapBounds): MapBounds {
+  return {
+    x: boundedInteger(bounds.x, 0, 1_000_000, "bounds.x"),
+    y: boundedInteger(bounds.y, 0, 1_000_000, "bounds.y"),
+    width: boundedInteger(bounds.width, 1, 10_000, "bounds.width"),
+    height: boundedInteger(bounds.height, 1, 10_000, "bounds.height"),
+  };
+}
+
+function mapLocation(location: MapLocation): MapLocation {
+  return {
+    x: boundedInteger(location.x, 0, 1_000_000, "location.x"),
+    y: boundedInteger(location.y, 0, 1_000_000, "location.y"),
+  };
+}
+
+function boundedInteger(
+  value: number,
+  min: number,
+  max: number,
+  label: string,
+): number {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`${label} must be an integer ${min}..${max}.`);
+  }
+  return value;
+}
+
+function gameUiRuntimeIdentity() {
+  return {
+    host: "game-ui",
+    port: 0,
+    state: { id: "game-ui", name: "Game UI" },
+  } as const;
+}
+
+function probe<T>(fn: () => T): RuntimeProbe<T> {
+  try {
+    return { ok: true, value: fn() };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}
+
+const defaultPlotFields: readonly PlotField[] = [
+  "terrain",
+  "biome",
+  "feature",
+  "resource",
+  "owner",
+  "visibility",
+  "areaRegion",
+];
+
+const allPlotFields: readonly PlotField[] = [
+  "terrain",
+  "biome",
+  "feature",
+  "resource",
+  "climate",
+  "hydrology",
+  "yields",
+  "owner",
+  "visibility",
+  "areaRegion",
+  "tags",
+  "city",
+  "units",
+];

--- a/packages/civ7-control-orpc/src/game-ui-strategy-front.ts
+++ b/packages/civ7-control-orpc/src/game-ui-strategy-front.ts
@@ -1,5 +1,6 @@
 import type {
   Civ7ControlOrpcBattlefieldScanResult,
+  Civ7ControlOrpcDestinationAnalysisResult,
   Civ7ControlOrpcTargetCandidatesResult,
 } from "./dependencies/direct-control";
 import type { Civ7ControlOrpcComponentId } from "./model/primitives";
@@ -196,6 +197,94 @@ export async function getCiv7GameUiBattlefieldScan(
       "Read-only game UI battlefield runtime port for strategy.frontSummary.",
       "Owner mismatch is contact evidence, not relationship proof.",
       "Use unit action validation before any movement or target send.",
+    ],
+  };
+}
+
+export async function getCiv7GameUiDestinationAnalysis(
+  input: Readonly<{
+    playerId?: number;
+    origin?: MapLocation;
+    destination: MapLocation;
+    corridorRadius?: number;
+    destinationRadius?: number;
+    maxPlayers?: number;
+    maxUnits?: number;
+    maxCities?: number;
+  }>,
+  target: Civ7GameUiStrategyFrontTarget =
+    globalThis as Civ7GameUiStrategyFrontTarget,
+): Promise<Civ7ControlOrpcDestinationAnalysisResult> {
+  if (!civ7GameUiStrategyFrontAvailable(target)) {
+    throw new Error("Civ7 game UI strategy front dependency is unavailable.");
+  }
+  const localPlayerId = target.GameContext?.localPlayerID ?? 0;
+  const playerId = input.playerId ?? localPlayerId;
+  const destinationRadius = boundedInteger(input.destinationRadius ?? 4, 1, 16);
+  const corridorRadius = boundedInteger(input.corridorRadius ?? 2, 0, 8);
+  const scan = await getCiv7GameUiBattlefieldScan({
+    playerId,
+    origins: [input.destination],
+    radius: destinationRadius,
+    maxPlayers: input.maxPlayers,
+    maxUnits: input.maxUnits,
+    maxCities: input.maxCities,
+  }, target);
+  const destinationUnits = scan.units.map((unit) => ({
+    ...unit,
+    destinationDistance: unit.distance,
+  }));
+  const destinationCities = scan.cities.map((city) => ({
+    ...city,
+    destinationDistance: city.distance,
+  }));
+
+  return {
+    host: "game-ui",
+    port: 0,
+    state: { id: "game-ui", name: "Game UI" },
+    localPlayerId,
+    playerId,
+    origin: input.origin ?? null,
+    destination: input.destination,
+    corridorRadius,
+    destinationRadius,
+    hiddenInfoPolicy:
+      "game-ui-runtime-summary; may include game-resident unit or city summaries until paired with visibility reads",
+    relationshipLabelPolicy,
+    corridor: {
+      routeHint: "direct-grid",
+      directGridDistance: input.origin == null
+        ? null
+        : distance(input.origin, input.destination),
+      sampleCount: input.origin == null ? 0 : 2,
+      sampledPlots: input.origin == null
+        ? []
+        : [input.origin, input.destination],
+      units: [],
+      unitCount: 0,
+    },
+    destinationPressure: {
+      units: destinationUnits,
+      unitCount: destinationUnits.length,
+      cities: destinationCities,
+      cityCount: destinationCities.length,
+      apparentOtherStrength: scan.owners
+        .filter((owner) => owner.relationshipProof !== "self")
+        .reduce((sum, owner) => sum + owner.apparentStrength, 0),
+    },
+    pointsOfInterest: scan.pointsOfInterest.map((point) => ({
+      kind: point.kind,
+      severity: point.severity,
+      location: point.location,
+      summary: point.summary,
+      units: destinationUnits,
+      cities: destinationCities,
+    })),
+    notes: [
+      "Read-only game UI destination-analysis runtime port for strategy.frontSummary.",
+      "Owner mismatch and proximity remain relationship-unproven planning evidence.",
+      "Use visibility and validator-backed unit action procedures before any mutation.",
     ],
   };
 }

--- a/packages/civ7-control-orpc/src/game-ui.ts
+++ b/packages/civ7-control-orpc/src/game-ui.ts
@@ -386,6 +386,9 @@ function createCiv7GameUiDirectControlFacade(
       await getCiv7GameUiReadyUnitView(input, target),
     getCiv7ReadyCityView: async (input) =>
       await getCiv7GameUiReadyCityView(input, target),
+    getCiv7SettlementRecommendations: async () => {
+      throw new Error("game-ui settlement recommendations are not supported");
+    },
     getCiv7TargetCandidates: async (input) =>
       await getCiv7GameUiTargetCandidates(input, target),
     getCiv7TurnCompletionStatus: async () =>

--- a/packages/civ7-control-orpc/src/game-ui.ts
+++ b/packages/civ7-control-orpc/src/game-ui.ts
@@ -496,6 +496,9 @@ function gameUiSupportedReadProcedures(
   if (civ7GameUiStrategyFrontAvailable(target)) {
     supported.push("strategy.frontSummary");
   }
+  if (gameUiWorldCurrentAvailable(target)) {
+    supported.push("world.current");
+  }
   return supported;
 }
 
@@ -516,6 +519,17 @@ function gameUiAttentionReadAvailable(target: Civ7GameUiRuntimeTarget): boolean 
   return typeof target.Game?.Notifications?.getIdsForPlayer === "function"
     && typeof target.Game?.Notifications?.find === "function"
     && typeof target.UI?.Player?.getFirstReadyUnit === "function"
+    && isControllerPlayerId(target.GameContext?.localPlayerID);
+}
+
+function gameUiWorldCurrentAvailable(target: Civ7GameUiRuntimeTarget): boolean {
+  return typeof target.UI?.isInGame === "function"
+    && typeof target.GameplayMap?.getGridWidth === "function"
+    && typeof target.GameplayMap?.getGridHeight === "function"
+    && typeof target.Game?.getTurnDate === "function"
+    && typeof target.Players?.getAliveIds === "function"
+    && typeof target.Players?.getAliveHumanIds === "function"
+    && typeof target.Players?.getNumAliveHumans === "function"
     && isControllerPlayerId(target.GameContext?.localPlayerID);
 }
 

--- a/packages/civ7-control-orpc/src/game-ui.ts
+++ b/packages/civ7-control-orpc/src/game-ui.ts
@@ -81,6 +81,7 @@ import {
 import {
   civ7GameUiStrategyFrontAvailable,
   getCiv7GameUiBattlefieldScan,
+  getCiv7GameUiDestinationAnalysis,
   getCiv7GameUiTargetCandidates,
   type Civ7GameUiStrategyFrontTarget,
 } from "./game-ui-strategy-front";
@@ -375,6 +376,8 @@ function createCiv7GameUiDirectControlFacade(
       }, target),
     getCiv7BattlefieldScan: async (input) =>
       await getCiv7GameUiBattlefieldScan(input, target),
+    getCiv7DestinationAnalysis: async (input) =>
+      await getCiv7GameUiDestinationAnalysis(input, target),
     getCiv7PlotSnapshot: async (input) =>
       await getCiv7GameUiPlotSnapshot(input, target),
     getCiv7MapGrid: async (input) =>

--- a/packages/civ7-control-orpc/src/game-ui.ts
+++ b/packages/civ7-control-orpc/src/game-ui.ts
@@ -84,6 +84,12 @@ import {
   getCiv7GameUiTargetCandidates,
   type Civ7GameUiStrategyFrontTarget,
 } from "./game-ui-strategy-front";
+import {
+  civ7GameUiWorldMapReadsAvailable,
+  getCiv7GameUiMapGrid,
+  getCiv7GameUiPlotSnapshot,
+  type Civ7GameUiMapReadTarget,
+} from "./game-ui-map";
 import type { Civ7ControlOrpcComponentId } from "./model/primitives";
 import type {
   Civ7ControlOrpcDirectControlFacade,
@@ -257,7 +263,9 @@ export type Civ7GameUiRuntimeTarget = {
     isWater?: Civ7GameUiStrategyFrontTarget["GameplayMap"] extends infer Map
       ? Map extends { isWater?: infer Fn } ? Fn : never
       : never;
-  };
+  } & Civ7GameUiMapReadTarget["GameplayMap"];
+  Visibility?: Civ7GameUiMapReadTarget["Visibility"];
+  MapCities?: Civ7GameUiMapReadTarget["MapCities"];
   MapUnits?: Civ7GameUiUnitTargetActionTarget["MapUnits"];
   Units?: Civ7GameUiUnitTargetActionTarget["Units"]
     & Civ7GameUiStrategyFrontTarget["Units"];
@@ -315,12 +323,6 @@ export function createCiv7GameUiControllerContextFactory(
 function createCiv7GameUiDirectControlFacade(
   target: Civ7GameUiRuntimeTarget,
 ): Civ7ControlOrpcDirectControlFacade {
-  const unsupported = async (): Promise<never> => {
-    throw new Error(
-      "Civ7 game UI controller dependency is not implemented for this procedure.",
-    );
-  };
-
   return {
     requestCiv7ProductionChoice: async (input) =>
       await requestCiv7GameUiProductionChoice(input, target),
@@ -373,8 +375,10 @@ function createCiv7GameUiDirectControlFacade(
       }, target),
     getCiv7BattlefieldScan: async (input) =>
       await getCiv7GameUiBattlefieldScan(input, target),
-    getCiv7PlotSnapshot: unsupported,
-    getCiv7MapGrid: unsupported,
+    getCiv7PlotSnapshot: async (input) =>
+      await getCiv7GameUiPlotSnapshot(input, target),
+    getCiv7MapGrid: async (input) =>
+      await getCiv7GameUiMapGrid(input, target),
     getCiv7ReadyUnitView: async (input) =>
       await getCiv7GameUiReadyUnitView(input, target),
     getCiv7ReadyCityView: async (input) =>
@@ -500,6 +504,9 @@ function gameUiSupportedReadProcedures(
   }
   if (gameUiWorldCurrentAvailable(target)) {
     supported.push("world.current");
+  }
+  if (civ7GameUiWorldMapReadsAvailable(target)) {
+    supported.push("world.plot.read", "world.grid.read");
   }
   return supported;
 }

--- a/packages/civ7-control-orpc/src/game-ui.ts
+++ b/packages/civ7-control-orpc/src/game-ui.ts
@@ -373,6 +373,8 @@ function createCiv7GameUiDirectControlFacade(
       }, target),
     getCiv7BattlefieldScan: async (input) =>
       await getCiv7GameUiBattlefieldScan(input, target),
+    getCiv7PlotSnapshot: unsupported,
+    getCiv7MapGrid: unsupported,
     getCiv7ReadyUnitView: async (input) =>
       await getCiv7GameUiReadyUnitView(input, target),
     getCiv7ReadyCityView: async (input) =>

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -136,6 +136,7 @@ export type {
 export { civ7ControlOrpcContractBase } from "./contract-base";
 export { Civ7ControlOrpcContract } from "./contract";
 export type { Civ7ControlOrpcContext } from "./context";
+export type { Civ7WorldPlotField } from "./modules/world/contract";
 export {
   Civ7AttentionCurrentUnavailableError,
   Civ7AttentionCurrentUnavailableErrorDataSchema,
@@ -181,6 +182,8 @@ export {
   Civ7UnitTargetActionUnavailableErrorDataSchema,
   Civ7WorldCurrentUnavailableError,
   Civ7WorldCurrentUnavailableErrorDataSchema,
+  Civ7WorldReadUnavailableError,
+  Civ7WorldReadUnavailableErrorDataSchema,
   civ7ControlOrpcErrorMap,
   type Civ7AttentionCurrentUnavailableErrorData,
   type Civ7ControlOrpcErrorMap,
@@ -206,6 +209,7 @@ export {
   type Civ7UnitRequestUnavailableErrorData,
   type Civ7UnitTargetActionUnavailableErrorData,
   type Civ7WorldCurrentUnavailableErrorData,
+  type Civ7WorldReadUnavailableErrorData,
 } from "./errors";
 export {
   Civ7ControlOrpcCorrelationIdSchema,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -168,6 +168,8 @@ export {
   Civ7NarrativeChoiceUnavailableErrorDataSchema,
   Civ7NotificationDismissalUnavailableError,
   Civ7NotificationDismissalUnavailableErrorDataSchema,
+  Civ7NotificationQueueUnavailableError,
+  Civ7NotificationQueueUnavailableErrorDataSchema,
   Civ7PopulationPlacementUnavailableError,
   Civ7PopulationPlacementUnavailableErrorDataSchema,
   Civ7ProgressionChoiceUnavailableError,
@@ -212,6 +214,7 @@ export {
   type Civ7MutationReadinessUnavailableErrorData,
   type Civ7NarrativeChoiceUnavailableErrorData,
   type Civ7NotificationDismissalUnavailableErrorData,
+  type Civ7NotificationQueueUnavailableErrorData,
   type Civ7PopulationPlacementUnavailableErrorData,
   type Civ7ProgressionChoiceUnavailableErrorData,
   type Civ7ProgressionPlayerChoiceUnavailableErrorData,
@@ -381,10 +384,18 @@ export type {
   Civ7NotificationDismissalContract as Civ7NotificationDismissalContractType,
   Civ7NotificationDismissInput,
   Civ7NotificationDismissalResult,
+  Civ7NotificationQueueDismissInput,
+  Civ7NotificationQueueDismissResult,
+  Civ7NotificationQueueInput,
+  Civ7NotificationQueueResult,
   Civ7NotificationsContract as Civ7NotificationsContractType,
 } from "./modules/notifications/contract";
 export { notificationsRouter } from "./modules/notifications/router";
 export { notificationsDismissRequestProcedure } from "./modules/notifications/procedures/dismiss-request";
+export {
+  notificationsQueueCurrentProcedure,
+  notificationsQueueDismissRequestProcedure,
+} from "./modules/notifications/procedures/queue";
 export {
   Civ7ReadinessContract,
   Civ7ReadinessCurrentContract,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -182,6 +182,8 @@ export {
   Civ7ReadinessCurrentUnavailableErrorDataSchema,
   Civ7StrategyCivilianRouteTriageUnavailableError,
   Civ7StrategyCivilianRouteTriageUnavailableErrorDataSchema,
+  Civ7StrategyFormationSnapshotUnavailableError,
+  Civ7StrategyFormationSnapshotUnavailableErrorDataSchema,
   Civ7StrategyFrontSummaryUnavailableError,
   Civ7StrategyFrontSummaryUnavailableErrorDataSchema,
   Civ7TownFocusUnavailableError,
@@ -217,6 +219,7 @@ export {
   type Civ7ProductionChoiceUnavailableErrorData,
   type Civ7ReadinessCurrentUnavailableErrorData,
   type Civ7StrategyCivilianRouteTriageUnavailableErrorData,
+  type Civ7StrategyFormationSnapshotUnavailableErrorData,
   type Civ7StrategyFrontSummaryUnavailableErrorData,
   type Civ7TownFocusUnavailableErrorData,
   type Civ7TurnCompletionUnavailableErrorData,
@@ -397,6 +400,7 @@ export { readinessCurrentProcedure } from "./modules/readiness/procedures/curren
 export {
   Civ7StrategyCivilianRouteTriageContract,
   Civ7StrategyContract,
+  Civ7StrategyFormationSnapshotContract,
   Civ7StrategyFrontSummaryContract,
 } from "./modules/strategy/contract";
 export type {
@@ -404,12 +408,16 @@ export type {
   Civ7StrategyCivilianRouteTriageInput,
   Civ7StrategyCivilianRouteTriageResult,
   Civ7StrategyContract as Civ7StrategyContractType,
+  Civ7StrategyFormationSnapshotContract as Civ7StrategyFormationSnapshotContractType,
+  Civ7StrategyFormationSnapshotInput,
+  Civ7StrategyFormationSnapshotResult,
   Civ7StrategyFrontSummaryContract as Civ7StrategyFrontSummaryContractType,
   Civ7StrategyFrontSummaryInput,
   Civ7StrategyFrontSummaryResult,
 } from "./modules/strategy/contract";
 export { strategyRouter } from "./modules/strategy/router";
 export { strategyCivilianRouteTriageProcedure } from "./modules/strategy/procedures/civilian-route-triage";
+export { strategyFormationSnapshotProcedure } from "./modules/strategy/procedures/formation-snapshot";
 export { strategyFrontSummaryProcedure } from "./modules/strategy/procedures/front-summary";
 export {
   Civ7TurnCompletionContract,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -180,6 +180,8 @@ export {
   Civ7ProductionChoiceUnavailableErrorDataSchema,
   Civ7ReadinessCurrentUnavailableError,
   Civ7ReadinessCurrentUnavailableErrorDataSchema,
+  Civ7StrategyCivilianRouteTriageUnavailableError,
+  Civ7StrategyCivilianRouteTriageUnavailableErrorDataSchema,
   Civ7StrategyFrontSummaryUnavailableError,
   Civ7StrategyFrontSummaryUnavailableErrorDataSchema,
   Civ7TownFocusUnavailableError,
@@ -214,6 +216,7 @@ export {
   type Civ7ProgressionTargetUnavailableErrorData,
   type Civ7ProductionChoiceUnavailableErrorData,
   type Civ7ReadinessCurrentUnavailableErrorData,
+  type Civ7StrategyCivilianRouteTriageUnavailableErrorData,
   type Civ7StrategyFrontSummaryUnavailableErrorData,
   type Civ7TownFocusUnavailableErrorData,
   type Civ7TurnCompletionUnavailableErrorData,
@@ -392,16 +395,21 @@ export type {
 export { readinessRouter } from "./modules/readiness/router";
 export { readinessCurrentProcedure } from "./modules/readiness/procedures/current";
 export {
+  Civ7StrategyCivilianRouteTriageContract,
   Civ7StrategyContract,
   Civ7StrategyFrontSummaryContract,
 } from "./modules/strategy/contract";
 export type {
+  Civ7StrategyCivilianRouteTriageContract as Civ7StrategyCivilianRouteTriageContractType,
+  Civ7StrategyCivilianRouteTriageInput,
+  Civ7StrategyCivilianRouteTriageResult,
   Civ7StrategyContract as Civ7StrategyContractType,
   Civ7StrategyFrontSummaryContract as Civ7StrategyFrontSummaryContractType,
   Civ7StrategyFrontSummaryInput,
   Civ7StrategyFrontSummaryResult,
 } from "./modules/strategy/contract";
 export { strategyRouter } from "./modules/strategy/router";
+export { strategyCivilianRouteTriageProcedure } from "./modules/strategy/procedures/civilian-route-triage";
 export { strategyFrontSummaryProcedure } from "./modules/strategy/procedures/front-summary";
 export {
   Civ7TurnCompletionContract,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -148,6 +148,8 @@ export type { Civ7WorldPlotField } from "./modules/world/contract";
 export {
   Civ7AttentionCurrentUnavailableError,
   Civ7AttentionCurrentUnavailableErrorDataSchema,
+  Civ7AttentionPrioritiesUnavailableError,
+  Civ7AttentionPrioritiesUnavailableErrorDataSchema,
   Civ7CorrelationIdInvalidError,
   Civ7CorrelationIdInvalidErrorDataSchema,
   Civ7DiplomacyResponseUnavailableError,
@@ -194,6 +196,7 @@ export {
   Civ7WorldReadUnavailableErrorDataSchema,
   civ7ControlOrpcErrorMap,
   type Civ7AttentionCurrentUnavailableErrorData,
+  type Civ7AttentionPrioritiesUnavailableErrorData,
   type Civ7ControlOrpcErrorMap,
   type Civ7ControlOrpcEffectErrorMap,
   type Civ7CorrelationIdInvalidErrorData,
@@ -244,15 +247,20 @@ export { Civ7ControlOrpcRouter } from "./router";
 export {
   Civ7AttentionContract,
   Civ7AttentionCurrentContract,
+  Civ7AttentionPrioritiesContract,
 } from "./modules/attention/contract";
 export type {
   Civ7AttentionContract as Civ7AttentionContractType,
   Civ7AttentionCurrentContract as Civ7AttentionCurrentContractType,
   Civ7AttentionCurrentInput,
   Civ7AttentionCurrentResult,
+  Civ7AttentionPrioritiesContract as Civ7AttentionPrioritiesContractType,
+  Civ7AttentionPrioritiesInput,
+  Civ7AttentionPrioritiesResult,
 } from "./modules/attention/contract";
 export { attentionRouter } from "./modules/attention/router";
 export { attentionCurrentProcedure } from "./modules/attention/procedures/current";
+export { attentionPrioritiesProcedure } from "./modules/attention/procedures/priorities";
 export {
   Civ7WorldContract,
   Civ7WorldCurrentContract,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -58,6 +58,10 @@ export {
   Civ7ControllerBridgeUnitUpgradeSuccessResponseSchema,
   Civ7ControllerBridgeWorldCurrentRequestSchema,
   Civ7ControllerBridgeWorldCurrentSuccessResponseSchema,
+  Civ7ControllerBridgeWorldGridReadRequestSchema,
+  Civ7ControllerBridgeWorldGridReadSuccessResponseSchema,
+  Civ7ControllerBridgeWorldPlotReadRequestSchema,
+  Civ7ControllerBridgeWorldPlotReadSuccessResponseSchema,
   createCiv7ControllerBridgeIngress,
   invokeCiv7ControllerBridgeRequest,
 } from "./bridge/controller-ingress";
@@ -122,6 +126,10 @@ export type {
   Civ7ControllerBridgeUnitUpgradeSuccessResponse,
   Civ7ControllerBridgeWorldCurrentRequest,
   Civ7ControllerBridgeWorldCurrentSuccessResponse,
+  Civ7ControllerBridgeWorldGridReadRequest,
+  Civ7ControllerBridgeWorldGridReadSuccessResponse,
+  Civ7ControllerBridgeWorldPlotReadRequest,
+  Civ7ControllerBridgeWorldPlotReadSuccessResponse,
 } from "./bridge/controller-ingress";
 export {
   CIV7_INTELLIGENCE_BRIDGE_GLOBAL_KEY,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -56,6 +56,8 @@ export {
   Civ7ControllerBridgeUnitTargetActionSuccessResponseSchema,
   Civ7ControllerBridgeUnitUpgradeRequestSchema,
   Civ7ControllerBridgeUnitUpgradeSuccessResponseSchema,
+  Civ7ControllerBridgeWorldCurrentRequestSchema,
+  Civ7ControllerBridgeWorldCurrentSuccessResponseSchema,
   createCiv7ControllerBridgeIngress,
   invokeCiv7ControllerBridgeRequest,
 } from "./bridge/controller-ingress";
@@ -118,6 +120,8 @@ export type {
   Civ7ControllerBridgeUnitTargetActionSuccessResponse,
   Civ7ControllerBridgeUnitUpgradeRequest,
   Civ7ControllerBridgeUnitUpgradeSuccessResponse,
+  Civ7ControllerBridgeWorldCurrentRequest,
+  Civ7ControllerBridgeWorldCurrentSuccessResponse,
 } from "./bridge/controller-ingress";
 export {
   CIV7_INTELLIGENCE_BRIDGE_GLOBAL_KEY,
@@ -175,6 +179,8 @@ export {
   Civ7UnitRequestUnavailableErrorDataSchema,
   Civ7UnitTargetActionUnavailableError,
   Civ7UnitTargetActionUnavailableErrorDataSchema,
+  Civ7WorldCurrentUnavailableError,
+  Civ7WorldCurrentUnavailableErrorDataSchema,
   civ7ControlOrpcErrorMap,
   type Civ7AttentionCurrentUnavailableErrorData,
   type Civ7ControlOrpcErrorMap,
@@ -199,6 +205,7 @@ export {
   type Civ7TurnCompletionUnavailableErrorData,
   type Civ7UnitRequestUnavailableErrorData,
   type Civ7UnitTargetActionUnavailableErrorData,
+  type Civ7WorldCurrentUnavailableErrorData,
 } from "./errors";
 export {
   Civ7ControlOrpcCorrelationIdSchema,
@@ -234,6 +241,18 @@ export type {
 } from "./modules/attention/contract";
 export { attentionRouter } from "./modules/attention/router";
 export { attentionCurrentProcedure } from "./modules/attention/procedures/current";
+export {
+  Civ7WorldContract,
+  Civ7WorldCurrentContract,
+} from "./modules/world/contract";
+export type {
+  Civ7WorldContract as Civ7WorldContractType,
+  Civ7WorldCurrentContract as Civ7WorldCurrentContractType,
+  Civ7WorldCurrentInput,
+  Civ7WorldCurrentResult,
+} from "./modules/world/contract";
+export { worldRouter } from "./modules/world/router";
+export { worldCurrentProcedure } from "./modules/world/procedures/current";
 export {
   Civ7CityContract,
   Civ7CityPopulationPlacementContract,

--- a/packages/civ7-control-orpc/src/metadata.ts
+++ b/packages/civ7-control-orpc/src/metadata.ts
@@ -13,7 +13,8 @@ export type Civ7ControlOrpcProcedureMeta = Readonly<{
     | "map"
     | "player"
     | "strategy"
-    | "turn";
+    | "turn"
+    | "world";
   procedureKey?: string;
   proofBoundary?: "local-package-test" | "pending-runtime-proof" | "runtime-proof";
   risk?: "read-only" | "runtime-support" | "mutation";

--- a/packages/civ7-control-orpc/src/modules/attention/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/attention/contract.ts
@@ -4,7 +4,10 @@ import { Type, type Static } from "typebox";
 import { civ7ControlOrpcContractBase } from "../../contract-base";
 import type { Civ7ControlOrpcErrorMap } from "../../errors";
 import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
-import { Civ7ControlOrpcComponentIdSchema } from "../../model/primitives";
+import {
+  Civ7ControlOrpcComponentIdSchema,
+  Civ7ControlOrpcMapLocationSchema,
+} from "../../model/primitives";
 import { toStandardSchema } from "../../typebox-standard-schema";
 
 const NullableComponentIdSchema = Type.Union([
@@ -143,11 +146,181 @@ export type Civ7AttentionCurrentResult = Static<
   typeof Civ7AttentionCurrentResultSchema
 >;
 
+const Civ7AttentionPrioritiesInputSchema = Type.Object(
+  {
+    maxNotifications: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+    includeBattlefield: Type.Optional(Type.Boolean()),
+    battlefieldRadius: Type.Optional(Type.Integer({ minimum: 1, maximum: 16 })),
+    maxBattlefieldUnits: Type.Optional(Type.Integer({ minimum: 1, maximum: 256 })),
+    readyUnitRadius: Type.Optional(Type.Integer({ minimum: 0, maximum: 16 })),
+    maxReadyUnitOperations: Type.Optional(Type.Integer({ minimum: 1, maximum: 256 })),
+  },
+  { additionalProperties: false },
+);
+export type Civ7AttentionPrioritiesInput = Static<
+  typeof Civ7AttentionPrioritiesInputSchema
+>;
+
+const Civ7AttentionPrioritySourceStatusSchema = Type.Object(
+  {
+    playableStatus: Type.Literal("read"),
+    notifications: Civ7AttentionSourceReadStatusSchema,
+    turnCompletion: Civ7AttentionSourceReadStatusSchema,
+    readyUnit: Civ7AttentionSourceReadStatusSchema,
+    readyCity: Civ7AttentionSourceReadStatusSchema,
+    battlefield: Type.Union([
+      Type.Literal("read"),
+      Type.Literal("skipped-disabled"),
+      Type.Literal("skipped-no-origin"),
+      Type.Literal("skipped-not-playable"),
+      Type.Literal("skipped-unsupported"),
+    ]),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7AttentionPriorityNextStepParametersSchema = Type.Object(
+  {
+    category: Type.Optional(Type.String()),
+    operationFamily: Type.Optional(Type.String()),
+    operationType: Type.Optional(Type.String()),
+    componentId: Type.Optional(Civ7ControlOrpcComponentIdSchema),
+    unitId: Type.Optional(Civ7ControlOrpcComponentIdSchema),
+    location: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+    hasSentTurnComplete: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7AttentionPriorityNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("restore-readiness"),
+      Type.Literal("inspect-decision"),
+      Type.Literal("inspect-notification"),
+      Type.Literal("inspect-progression"),
+      Type.Literal("inspect-ready-unit"),
+      Type.Literal("inspect-ready-city"),
+      Type.Literal("inspect-battlefield-point"),
+      Type.Literal("validate-unit-command"),
+      Type.Literal("validate-unit-target"),
+      Type.Literal("send-turn-complete"),
+      Type.Literal("observe-turn-advance"),
+      Type.Literal("end-turn"),
+      Type.Literal("observe"),
+    ]),
+    source: Type.Union([
+      Type.Literal("readiness"),
+      Type.Literal("notification"),
+      Type.Literal("ready-unit"),
+      Type.Literal("ready-city"),
+      Type.Literal("battlefield"),
+      Type.Literal("attention.priorities"),
+    ]),
+    label: Type.String(),
+    parameters: Civ7AttentionPriorityNextStepParametersSchema,
+  },
+  { additionalProperties: false },
+);
+
+const Civ7AttentionPriorityItemSchema = Type.Object(
+  {
+    priority: Type.Integer({ minimum: 0, maximum: 100 }),
+    kind: Type.String(),
+    summary: Type.String(),
+    reason: Type.String(),
+    blocking: Type.Boolean(),
+    nextStep: Type.Union([Civ7AttentionPriorityNextStepSchema, Type.Null()]),
+    evidenceLabels: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7AttentionPriorityReadyUnitSchema = Type.Object(
+  {
+    unitId: NullableComponentIdSchema,
+    legalOperationCount: Type.Integer({ minimum: 0 }),
+    promotionReadinessAvailable: Type.Boolean(),
+    summary: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7AttentionPriorityReadyCitySchema = Type.Object(
+  {
+    cityId: NullableComponentIdSchema,
+    legalOperationCount: Type.Integer({ minimum: 0 }),
+    productionCandidateCount: Type.Integer({ minimum: 0 }),
+    townFocusOptionCount: Type.Integer({ minimum: 0 }),
+    populationPlacementAvailable: Type.Boolean(),
+    summary: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7AttentionPriorityBattlefieldSchema = Type.Object(
+  {
+    origins: Type.Array(Civ7ControlOrpcMapLocationSchema),
+    radius: Type.Integer({ minimum: 1, maximum: 64 }),
+    hiddenInfoPolicy: Type.String(),
+    pointOfInterestCount: Type.Integer({ minimum: 0 }),
+    observedOwnerCount: Type.Integer({ minimum: 0 }),
+    pointsOfInterest: Type.Array(Type.Object(
+      {
+        kind: Type.String(),
+        severity: Type.String(),
+        summary: Type.String(),
+        location: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+      },
+      { additionalProperties: false },
+    )),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7AttentionPrioritiesResultSchema = Type.Object(
+  {
+    playable: Type.Boolean(),
+    readiness: Type.String(),
+    localPlayerId: Type.Union([Type.Integer({ minimum: -1 }), Type.Null()]),
+    turn: Type.Union([Type.Number(), Type.Null()]),
+    turnDate: Type.Union([Type.String(), Type.Null()]),
+    canEndTurn: Type.Union([Type.Boolean(), Type.Null()]),
+    sourceStatus: Civ7AttentionPrioritySourceStatusSchema,
+    turnCompletion: Civ7AttentionTurnCompletionSchema,
+    readyUnit: Type.Union([Civ7AttentionPriorityReadyUnitSchema, Type.Null()]),
+    readyCity: Type.Union([Civ7AttentionPriorityReadyCitySchema, Type.Null()]),
+    battlefield: Type.Union([Civ7AttentionPriorityBattlefieldSchema, Type.Null()]),
+    summary: Type.Object(
+      {
+        priorityCount: Type.Integer({ minimum: 0 }),
+        blockingPriorityCount: Type.Integer({ minimum: 0 }),
+        decisionCount: Type.Integer({ minimum: 0 }),
+        nextStepCount: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    ),
+    priorities: Type.Array(Civ7AttentionPriorityItemSchema),
+    nextSteps: Type.Array(Civ7AttentionPriorityNextStepSchema),
+    notes: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
+export type Civ7AttentionPrioritiesResult = Static<
+  typeof Civ7AttentionPrioritiesResultSchema
+>;
+
 const Civ7AttentionCurrentInputStandardSchema = toStandardSchema(
   Civ7AttentionCurrentInputSchema,
 );
 const Civ7AttentionCurrentResultStandardSchema = toStandardSchema(
   Civ7AttentionCurrentResultSchema,
+);
+const Civ7AttentionPrioritiesInputStandardSchema = toStandardSchema(
+  Civ7AttentionPrioritiesInputSchema,
+);
+const Civ7AttentionPrioritiesResultStandardSchema = toStandardSchema(
+  Civ7AttentionPrioritiesResultSchema,
 );
 
 export type Civ7AttentionCurrentContract = ContractProcedure<
@@ -168,10 +341,30 @@ export const Civ7AttentionCurrentContract: Civ7AttentionCurrentContract =
       risk: "read-only",
     });
 
+export type Civ7AttentionPrioritiesContract = ContractProcedure<
+  typeof Civ7AttentionPrioritiesInputStandardSchema,
+  typeof Civ7AttentionPrioritiesResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export const Civ7AttentionPrioritiesContract: Civ7AttentionPrioritiesContract =
+  civ7ControlOrpcContractBase
+    .input(Civ7AttentionPrioritiesInputStandardSchema)
+    .output(Civ7AttentionPrioritiesResultStandardSchema)
+    .meta({
+      family: "attention",
+      procedureKey: "attention.priorities",
+      proofBoundary: "local-package-test",
+      risk: "read-only",
+    });
+
 export type Civ7AttentionContract = Readonly<{
   current: Civ7AttentionCurrentContract;
+  priorities: Civ7AttentionPrioritiesContract;
 }>;
 
 export const Civ7AttentionContract: Civ7AttentionContract = {
   current: Civ7AttentionCurrentContract,
+  priorities: Civ7AttentionPrioritiesContract,
 };

--- a/packages/civ7-control-orpc/src/modules/attention/procedures/priorities.ts
+++ b/packages/civ7-control-orpc/src/modules/attention/procedures/priorities.ts
@@ -1,0 +1,783 @@
+import type {
+  Civ7ComponentId,
+  Civ7ReadyCityViewInput,
+  Civ7ReadyUnitViewInput,
+} from "@civ7/direct-control";
+import { Effect } from "effect";
+
+import type { Civ7ControlOrpcContext } from "../../../context";
+import type {
+  Civ7ControlOrpcBattlefieldScanResult,
+  Civ7ControlOrpcPlayableStatusResult,
+  Civ7ControlOrpcPlayNotificationViewResult,
+  Civ7ControlOrpcReadyCityViewResult,
+  Civ7ControlOrpcReadyUnitViewResult,
+  Civ7ControlOrpcTurnCompletionStatusResult,
+} from "../../../dependencies/direct-control";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import type { Civ7ControlOrpcMapLocation } from "../../../model/primitives";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type {
+  Civ7AttentionPrioritiesInput,
+  Civ7AttentionPrioritiesResult,
+} from "../contract";
+
+type PriorityItem = Civ7AttentionPrioritiesResult["priorities"][number];
+type PriorityNextStep = NonNullable<PriorityItem["nextStep"]>;
+
+export const attentionPrioritiesProcedure =
+  civ7ControlOrpcImplementer.attention.priorities.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const endpointDefaults = context.endpointDefaults;
+        const playableStatus = await context.directControl.getCiv7PlayableStatus(
+          endpointDefaults,
+        );
+        const canRead = canReadAttentionPriorities(playableStatus, context);
+
+        if (!canRead) {
+          return buildPrioritiesResult({
+            input,
+            playableStatus,
+            notifications: null,
+            turnCompletion: null,
+            readyUnit: null,
+            readyCity: null,
+            battlefield: null,
+            sourceStatus: skippedSourceStatus(playableStatus),
+          });
+        }
+
+        const [notifications, turnCompletion] = await Promise.all([
+          context.directControl.getCiv7PlayNotificationView({
+            ...endpointDefaults,
+            maxNotifications: input.maxNotifications,
+          }),
+          context.directControl.getCiv7TurnCompletionStatus(endpointDefaults),
+        ]);
+        const [readyUnit, readyCity] = await Promise.all([
+          context.directControl.getCiv7ReadyUnitView(
+            readyUnitInputFromSources(input, notifications, turnCompletion),
+            endpointDefaults,
+          ),
+          context.directControl.getCiv7ReadyCityView(
+            readyCityInputFromNotifications(notifications),
+            endpointDefaults,
+          ),
+        ]);
+        const battlefieldOrigin = readyUnitLocation(readyUnit);
+        const shouldReadBattlefield = input.includeBattlefield === true;
+        const battlefield = shouldReadBattlefield && battlefieldOrigin != null
+          ? await context.directControl.getCiv7BattlefieldScan({
+            origins: [battlefieldOrigin],
+            radius: input.battlefieldRadius ?? 6,
+            maxUnits: input.maxBattlefieldUnits ?? 80,
+          }, endpointDefaults)
+          : null;
+
+        return buildPrioritiesResult({
+          input,
+          playableStatus,
+          notifications,
+          turnCompletion,
+          readyUnit,
+          readyCity,
+          battlefield,
+          sourceStatus: {
+            playableStatus: "read",
+            notifications: "read",
+            turnCompletion: "read",
+            readyUnit: sourceReadStatus(true, readyUnit),
+            readyCity: sourceReadStatus(true, readyCity),
+            battlefield: shouldReadBattlefield
+              ? battlefield == null ? "skipped-no-origin" : "read"
+              : "skipped-disabled",
+          },
+        });
+      },
+      catch: () =>
+        errors.ATTENTION_PRIORITIES_UNAVAILABLE({
+          data: {
+            procedureKey: "attention.priorities",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+type BuildInput = Readonly<{
+  input: Civ7AttentionPrioritiesInput;
+  playableStatus: Civ7ControlOrpcPlayableStatusResult;
+  notifications: Civ7ControlOrpcPlayNotificationViewResult | null;
+  turnCompletion: Civ7ControlOrpcTurnCompletionStatusResult | null;
+  readyUnit: Civ7ControlOrpcReadyUnitViewResult | null;
+  readyCity: Civ7ControlOrpcReadyCityViewResult | null;
+  battlefield: Civ7ControlOrpcBattlefieldScanResult | null;
+  sourceStatus: Civ7AttentionPrioritiesResult["sourceStatus"];
+}>;
+
+function buildPrioritiesResult({
+  playableStatus,
+  notifications,
+  turnCompletion,
+  readyUnit,
+  readyCity,
+  battlefield,
+  sourceStatus,
+}: BuildInput): Civ7AttentionPrioritiesResult {
+  const priorities = priorityItems({
+    playableStatus,
+    notifications,
+    turnCompletion,
+    readyUnit,
+    readyCity,
+    battlefield,
+  }).sort((a, b) => b.priority - a.priority);
+  const nextSteps = priorities
+    .map((item) => item.nextStep)
+    .filter((item): item is PriorityNextStep => item != null);
+
+  return {
+    playable: playableStatus.playable,
+    readiness: playableStatus.readiness,
+    localPlayerId: numericValue(notifications?.localPlayerId)
+      ?? numericValue(readyUnit?.localPlayerId)
+      ?? numericValue(readyCity?.localPlayerId)
+      ?? numericValue(battlefield?.localPlayerId),
+    turn: probeValue<number>(turnCompletion?.turn)
+      ?? probeValue<number>(notifications?.turn),
+    turnDate: probeValue<string>(turnCompletion?.turnDate)
+      ?? probeValue<string>(notifications?.turnDate),
+    canEndTurn: turnCompletion == null
+      ? probeValue<boolean>(notifications?.canEndTurn)
+      : probeValue<boolean>(turnCompletion.canEndTurn),
+    sourceStatus,
+    turnCompletion: turnCompletionSummary(turnCompletion),
+    readyUnit: readyUnitSummary(readyUnit),
+    readyCity: readyCitySummary(readyCity),
+    battlefield: battlefieldSummary(battlefield),
+    summary: {
+      priorityCount: priorities.length,
+      blockingPriorityCount: priorities.filter((item) => item.blocking).length,
+      decisionCount: notifications?.hud.decisionQueue.length ?? 0,
+      nextStepCount: nextSteps.length,
+    },
+    priorities,
+    nextSteps,
+    notes: [
+      "Read-only attention priority dashboard. It does not send operations or choose strategy.",
+      "Next steps are semantic service descriptors; CLI command rendering is an adapter concern.",
+      "Battlefield evidence is planning context only and must not be treated as relationship status or action authority.",
+    ],
+  };
+}
+
+function priorityItems(input: Readonly<{
+  playableStatus: Civ7ControlOrpcPlayableStatusResult;
+  notifications: Civ7ControlOrpcPlayNotificationViewResult | null;
+  turnCompletion: Civ7ControlOrpcTurnCompletionStatusResult | null;
+  readyUnit: Civ7ControlOrpcReadyUnitViewResult | null;
+  readyCity: Civ7ControlOrpcReadyCityViewResult | null;
+  battlefield: Civ7ControlOrpcBattlefieldScanResult | null;
+}>): PriorityItem[] {
+  const items: PriorityItem[] = [];
+
+  if (!input.playableStatus.playable && input.notifications == null) {
+    items.push({
+      priority: 100,
+      kind: "readiness-unavailable",
+      summary: "playable Tuner/App UI readiness is not available",
+      reason: "Priority reads require current playable status before blockers can be trusted.",
+      blocking: true,
+      nextStep: {
+        kind: "restore-readiness",
+        source: "readiness",
+        label: "Restore playable readiness before reading priorities.",
+        parameters: {},
+      },
+      evidenceLabels: ["playable-status"],
+    });
+    return items;
+  }
+
+  const runtimeErrors = hudProbeErrors(input.notifications);
+  if (runtimeErrors.length > 0) {
+    items.push({
+      priority: 95,
+      kind: "runtime-state-error",
+      summary: "core HUD probes failed; live blocker state is not proven clean",
+      reason: "A missing turn, blocker, or blocking-notification probe means the attention read is partial.",
+      blocking: true,
+      nextStep: {
+        kind: "observe",
+        source: "attention.priorities",
+        label: "Refresh runtime attention evidence before treating the turn as clean.",
+        parameters: {},
+      },
+      evidenceLabels: runtimeErrors.map((item) => `probe-error:${item.field}`),
+    });
+  }
+
+  const nextDecision = input.notifications?.hud.nextDecision;
+  if (nextDecision != null) {
+    const stale = staleUnitCommandPriority(nextDecision);
+    items.push({
+      priority: nextDecision.isEndTurnBlocking === true ? 100 : 70,
+      kind: stale?.kind ?? `hud:${String(nextDecision.category)}`,
+      summary: stale?.summary ?? stringValue(
+        nextDecision.summary ?? nextDecision.message ?? nextDecision.typeName,
+        "current HUD decision",
+      ),
+      reason: stale?.reason ?? decisionReason(nextDecision),
+      blocking: nextDecision.isEndTurnBlocking === true,
+      nextStep: stale?.nextStep ?? decisionNextStep(nextDecision, input.readyUnit),
+      evidenceLabels: ["hud-next-decision"],
+    });
+  }
+
+  if (input.readyUnit?.unitId != null) {
+    const unit = probeValue<{ typeName?: string; location?: Civ7ControlOrpcMapLocation }>(
+      input.readyUnit.unit,
+    );
+    const location = unit?.location
+      ? ` at (${unit.location.x},${unit.location.y})`
+      : "";
+    items.push({
+      priority: 85,
+      kind: "ready-unit",
+      summary: `${unit?.typeName ?? "ready unit"}${location}`,
+      reason: "A ready unit blocks turn flow and any target action still needs validator-backed confirmation.",
+      blocking: true,
+      nextStep: {
+        kind: "inspect-ready-unit",
+        source: "ready-unit",
+        label: "Inspect ready unit orders.",
+        parameters: {
+          unitId: input.readyUnit.unitId,
+        },
+      },
+      evidenceLabels: readyUnitEvidence(input.readyUnit),
+    });
+  }
+
+  if (input.readyCity?.cityId != null) {
+    const city = probeValue<{ name?: string }>(input.readyCity.city);
+    items.push({
+      priority: 80,
+      kind: "ready-city",
+      summary: city?.name ?? "ready city",
+      reason: "City blockers branch between production, town focus, population placement, and expansion.",
+      blocking: true,
+      nextStep: {
+        kind: "inspect-ready-city",
+        source: "ready-city",
+        label: "Inspect ready city decision.",
+        parameters: {
+          componentId: input.readyCity.cityId,
+        },
+      },
+      evidenceLabels: readyCityEvidence(input.readyCity),
+    });
+  }
+
+  for (const point of input.battlefield?.pointsOfInterest ?? []) {
+    items.push({
+      priority: severityPriority(point.severity),
+      kind: `battlefield:${point.kind}`,
+      summary: point.summary,
+      reason: "Battlefield points identify inspection needs around the ready-unit origin; they are not mutation authority.",
+      blocking: false,
+      nextStep: {
+        kind: "inspect-battlefield-point",
+        source: "battlefield",
+        label: `Inspect ${point.kind} battlefield point.`,
+        parameters: {
+          ...(point.location == null ? {} : { location: point.location }),
+        },
+      },
+      evidenceLabels: ["battlefield-point-of-interest"],
+    });
+  }
+
+  if (items.length === 0) {
+    items.push({
+      priority: 10,
+      kind: "clean-read",
+      summary: "no HUD, ready-unit, ready-city, or battlefield priority surfaced",
+      reason: "Fresh clean reads can use the guarded end-turn path; it rechecks blockers before sending.",
+      blocking: false,
+      nextStep: {
+        kind: "end-turn",
+        source: "attention.priorities",
+        label: "No blockers found; guarded end-turn is available.",
+        parameters: {},
+      },
+      evidenceLabels: ["clean-attention-read"],
+    });
+  }
+
+  return items;
+}
+
+function decisionReason(nextDecision: Record<string, unknown>): string {
+  const category = String(nextDecision.category ?? "decision");
+  if (category === "unit-command") {
+    return "A ready unit decision exists; inspect ready-unit and target surfaces before treating command-units as stale.";
+  }
+  if (
+    category === "production-choice" || category === "population-placement"
+  ) {
+    return "A ready city decision exists; inspect the city decision surface before broad strategy.";
+  }
+  if (category === "informational-notification") {
+    return "HUD details include a live ComponentID; inspect notification postcondition evidence before any closeout send.";
+  }
+  const family = stringValue(nextDecision.operationFamily, null);
+  const operation = stringValue(nextDecision.operationType, null);
+  if (family != null || operation != null) {
+    return `HUD decision exposes validator-backed ${family ?? "operation"}${operation == null ? "" : `/${operation}`} evidence.`;
+  }
+  return "HUD decisions are short-lived attention authority and should be resolved or consciously deferred before broad strategy.";
+}
+
+function decisionNextStep(
+  nextDecision: Record<string, unknown>,
+  readyUnit: Civ7ControlOrpcReadyUnitViewResult | null,
+): PriorityNextStep | null {
+  const category = String(nextDecision.category ?? "decision");
+  const componentId = componentIdFromUnknown(nextDecision.notificationId);
+  const operationFamily = stringValue(nextDecision.operationFamily, undefined);
+  const operationType = stringValue(nextDecision.operationType, undefined);
+
+  if (category === "production-choice" || category === "population-placement") {
+    return {
+      kind: "inspect-ready-city",
+      source: "ready-city",
+      label: "Inspect ready city decision before choosing a city action.",
+      parameters: {
+        category,
+        operationFamily,
+        operationType,
+        ...(componentId == null ? {} : { componentId }),
+      },
+    };
+  }
+
+  if (
+    category === "technology-choice" || category === "culture-choice" ||
+    category === "tradition-review"
+  ) {
+    return {
+      kind: "inspect-progression",
+      source: "notification",
+      label: "Inspect progression options before choosing a progression action.",
+      parameters: {
+        category,
+        operationFamily,
+        operationType,
+        ...(componentId == null ? {} : { componentId }),
+      },
+    };
+  }
+
+  if (
+    category === "celebration-choice" || category === "government-choice" ||
+    category === "narrative-choice" || category === "first-meet-diplomacy"
+  ) {
+    if (category === "narrative-choice" && narrativeChoiceOptionsEmpty(nextDecision)) {
+      return {
+        kind: "inspect-notification",
+        source: "notification",
+        label: "Inspect narrative notification closeout evidence.",
+        parameters: {
+          category,
+          operationFamily,
+          operationType,
+          ...(componentId == null ? {} : { componentId }),
+        },
+      };
+    }
+    return {
+      kind: "inspect-decision",
+      source: "notification",
+      label: "Inspect decision options before choosing an action.",
+      parameters: {
+        category,
+        operationFamily,
+        operationType,
+        ...(componentId == null ? {} : { componentId }),
+      },
+    };
+  }
+
+  if (category === "unit-command" && readyUnit != null) {
+    return {
+      kind: "validate-unit-target",
+      source: "ready-unit",
+      label: "Inspect ready unit and validate a unit action.",
+      parameters: {
+        category,
+        operationFamily,
+        operationType,
+        ...(componentId == null ? {} : { componentId }),
+        ...(readyUnit.unitId == null ? {} : { unitId: readyUnit.unitId }),
+      },
+    };
+  }
+
+  if (category === "informational-notification") {
+    return {
+      kind: "inspect-notification",
+      source: "notification",
+      label: "Inspect notification closeout evidence.",
+      parameters: {
+        category,
+        operationFamily,
+        operationType,
+        ...(componentId == null ? {} : { componentId }),
+      },
+    };
+  }
+
+  return {
+    kind: "inspect-decision",
+    source: "notification",
+    label: "Inspect current decision evidence.",
+    parameters: {
+      category,
+      operationFamily,
+      operationType,
+      ...(componentId == null ? {} : { componentId }),
+    },
+  };
+}
+
+function narrativeChoiceOptionsEmpty(nextDecision: Record<string, unknown>): boolean {
+  const details = asRecord(nextDecision.details);
+  return details?.kind === "narrative-choice-options" &&
+    Array.isArray(details.enabledOptions) &&
+    details.enabledOptions.length === 0;
+}
+
+function staleUnitCommandPriority(
+  nextDecision: { details?: unknown },
+): Pick<PriorityItem, "kind" | "summary" | "reason" | "nextStep"> | null {
+  const details = asRecord(nextDecision.details);
+  if (details?.kind !== "unit-command-reconciliation") return null;
+  if (
+    details.staleExpiredWithoutEnabledCloseout !== true &&
+    details.classification !== "unit-command-stale-expired" &&
+    details.staleReadyPointerSuspected !== true
+  ) {
+    return null;
+  }
+
+  const enabledCandidate = asArray(details.enabledCloseoutCandidates)
+    .find((item) => typeof item.operationType === "string");
+  if (enabledCandidate != null) {
+    const unitId = componentIdFromUnknown(enabledCandidate.unitId);
+    return {
+      kind: "hud:unit-command",
+      summary: "COMMAND_UNITS closeout candidate needs validator-backed review",
+      reason: "Official command-units evidence exposes an enabled unit command candidate; validate it before any send.",
+      nextStep: {
+        kind: "validate-unit-command",
+        source: "notification",
+        label: "Validate the unit command candidate.",
+        parameters: {
+          operationType: String(enabledCandidate.operationType),
+          ...(unitId == null ? {} : { unitId }),
+        },
+      },
+    };
+  }
+
+  const hasSent = probeValue<boolean>(details.hasSentTurnComplete) === true;
+  return {
+    kind: "hud:unit-command-stale-expired",
+    summary: hasSent
+      ? "expired COMMAND_UNITS has no ready unit or enabled closeout after turn-complete was sent"
+      : "expired COMMAND_UNITS has no ready unit or enabled unit closeout",
+    reason: hasSent
+      ? "Official command-units activation has no selected/first-ready unit and every scanned unit closeout is disabled; turn-complete is already sent, so wait/watch for turn advance or a new blocker instead of repeating unit operations."
+      : "Official command-units activation has no selected/first-ready unit and every scanned unit closeout is disabled; use the normal end-turn path once, then verify the turn advances or a new blocker appears.",
+    nextStep: {
+      kind: hasSent ? "observe-turn-advance" : "send-turn-complete",
+      source: "attention.priorities",
+      label: hasSent
+        ? "Watch for turn advance or a new blocker."
+        : "Use guarded turn completion once.",
+      parameters: {
+        hasSentTurnComplete: hasSent,
+      },
+    },
+  };
+}
+
+function turnCompletionSummary(
+  turnCompletion: Civ7ControlOrpcTurnCompletionStatusResult | null,
+): Civ7AttentionPrioritiesResult["turnCompletion"] {
+  return {
+    hasSentTurnComplete: probeValue<boolean>(
+      turnCompletion?.hasSentTurnComplete,
+    ),
+    canEndTurn: probeValue<boolean>(turnCompletion?.canEndTurn),
+    firstReadyUnitId: probeValue<Civ7ComponentId>(
+      turnCompletion?.firstReadyUnitId,
+    ),
+    blockerStatus: turnCompletionBlockerStatus(turnCompletion),
+  };
+}
+
+function turnCompletionBlockerStatus(
+  turnCompletion: Civ7ControlOrpcTurnCompletionStatusResult | null,
+): Civ7AttentionPrioritiesResult["turnCompletion"]["blockerStatus"] {
+  const blocker = turnCompletion?.blocker;
+  if (blocker == null || typeof blocker !== "object") return "unknown";
+  if (!("ok" in blocker) || blocker.ok !== true) return "unknown";
+  if (!("value" in blocker)) return "unknown";
+  const value = blocker.value;
+  if (value === 0 || value === null || value === "NONE") return "none";
+  return "blocked";
+}
+
+function readyUnitSummary(
+  readyUnit: Civ7ControlOrpcReadyUnitViewResult | null,
+): Civ7AttentionPrioritiesResult["readyUnit"] {
+  if (readyUnit == null) return null;
+  const unit = probeValue<{ typeName?: string }>(readyUnit.unit);
+  return {
+    unitId: readyUnit.unitId,
+    legalOperationCount: readyUnit.legalOperations.length,
+    promotionReadinessAvailable: probeValue<unknown>(
+      readyUnit.promotionReadiness,
+    ) != null,
+    summary: unit?.typeName ?? "ready unit",
+  };
+}
+
+function readyCitySummary(
+  readyCity: Civ7ControlOrpcReadyCityViewResult | null,
+): Civ7AttentionPrioritiesResult["readyCity"] {
+  if (readyCity == null) return null;
+  const city = probeValue<{ name?: string }>(readyCity.city);
+  return {
+    cityId: readyCity.cityId,
+    legalOperationCount: readyCity.legalOperations.length,
+    productionCandidateCount: probeArrayLength(readyCity.productionCandidates),
+    townFocusOptionCount: probeArrayLength(readyCity.townFocusOptions),
+    populationPlacementAvailable: probeValue<unknown>(
+      readyCity.populationPlacement,
+    ) != null,
+    summary: city?.name ?? "ready city",
+  };
+}
+
+function battlefieldSummary(
+  battlefield: Civ7ControlOrpcBattlefieldScanResult | null,
+): Civ7AttentionPrioritiesResult["battlefield"] {
+  if (battlefield == null) return null;
+  return {
+    origins: battlefield.origins,
+    radius: battlefield.radius,
+    hiddenInfoPolicy: String(battlefield.hiddenInfoPolicy),
+    pointOfInterestCount: battlefield.pointsOfInterest.length,
+    observedOwnerCount: battlefield.owners.length,
+    pointsOfInterest: battlefield.pointsOfInterest.map((point) => ({
+      kind: point.kind,
+      severity: point.severity,
+      summary: point.summary,
+      location: point.location,
+    })),
+  };
+}
+
+function readyUnitInputFromSources(
+  input: Civ7AttentionPrioritiesInput,
+  notifications: Civ7ControlOrpcPlayNotificationViewResult,
+  turnCompletion: Civ7ControlOrpcTurnCompletionStatusResult,
+): Civ7ReadyUnitViewInput {
+  const unitId = probeValue<Civ7ComponentId>(notifications.selectedUnitId)
+    ?? probeValue<Civ7ComponentId>(notifications.firstReadyUnitId)
+    ?? probeValue<Civ7ComponentId>(turnCompletion.firstReadyUnitId);
+  return {
+    ...(unitId == null ? {} : { unitId }),
+    ...(input.readyUnitRadius == null ? {} : { radius: input.readyUnitRadius }),
+    ...(input.maxReadyUnitOperations == null
+      ? {}
+      : { maxOperations: input.maxReadyUnitOperations }),
+  };
+}
+
+function readyCityInputFromNotifications(
+  notifications: Civ7ControlOrpcPlayNotificationViewResult,
+): Civ7ReadyCityViewInput {
+  const cityId = probeValue<Civ7ComponentId>(notifications.selectedCityId)
+    ?? componentIdFromUnknown(notifications.hud.nextDecision?.target)
+    ?? notifications.hud.decisionQueue
+      .map((item) => componentIdFromUnknown(item.target))
+      .find((id): id is Civ7ComponentId => id != null)
+    ?? null;
+  return cityId == null ? {} : { cityId };
+}
+
+function readyUnitLocation(
+  readyUnit: Civ7ControlOrpcReadyUnitViewResult,
+): Civ7ControlOrpcMapLocation | null {
+  const unit = probeValue<{ location?: { x?: unknown; y?: unknown } }>(
+    readyUnit.unit,
+  );
+  const x = unit?.location?.x;
+  const y = unit?.location?.y;
+  return typeof x === "number" && typeof y === "number" ? { x, y } : null;
+}
+
+function sourceReadStatus(
+  attempted: boolean,
+  result:
+    | Civ7ControlOrpcReadyUnitViewResult
+    | Civ7ControlOrpcReadyCityViewResult
+    | null,
+): Civ7AttentionPrioritiesResult["sourceStatus"]["readyUnit"] {
+  if (!attempted || result == null) return "skipped-unsupported";
+  if (result.host !== "game-ui") return "read";
+  if ("unitId" in result) {
+    return result.firstReadyUnitId.ok === true
+      ? "read"
+      : "skipped-unsupported";
+  }
+  const readyCityId = result.cityId
+    ?? probeValue<Civ7ComponentId>(result.blockingCityId);
+  return readyCityId == null ? "skipped-unsupported" : "read";
+}
+
+function skippedSourceStatus(
+  playableStatus: Civ7ControlOrpcPlayableStatusResult,
+): Civ7AttentionPrioritiesResult["sourceStatus"] {
+  const skipped = playableStatus.playable
+    ? "skipped-unsupported"
+    : "skipped-not-playable";
+  return {
+    playableStatus: "read",
+    notifications: skipped,
+    turnCompletion: skipped,
+    readyUnit: skipped,
+    readyCity: skipped,
+    battlefield: playableStatus.playable
+      ? "skipped-unsupported"
+      : "skipped-not-playable",
+  };
+}
+
+function canReadAttentionPriorities(
+  playableStatus: Civ7ControlOrpcPlayableStatusResult,
+  context: Civ7ControlOrpcContext,
+): boolean {
+  return playableStatus.playable
+    || context.controller?.supportedReadProcedures?.includes(
+      "attention.priorities",
+    ) === true;
+}
+
+function hudProbeErrors(
+  notifications: Civ7ControlOrpcPlayNotificationViewResult | null,
+): Array<{ field: string; error: string }> {
+  if (notifications == null) return [];
+  return [
+    ["turn", notifications.turn],
+    ["turnDate", notifications.turnDate],
+    ["blocker", notifications.blocker],
+    ["blockingNotificationId", notifications.blockingNotificationId],
+  ].flatMap(([field, probe]) =>
+    isProbeError(probe)
+      ? [{ field: String(field), error: probe.error }]
+      : []
+  );
+}
+
+function readyUnitEvidence(
+  readyUnit: Civ7ControlOrpcReadyUnitViewResult,
+): string[] {
+  return readyUnit.host === "game-ui"
+    ? ["game-ui-ready-unit-source"]
+    : ["ready-unit-view"];
+}
+
+function readyCityEvidence(
+  readyCity: Civ7ControlOrpcReadyCityViewResult,
+): string[] {
+  return readyCity.host === "game-ui"
+    ? ["game-ui-ready-city-source"]
+    : ["ready-city-view"];
+}
+
+function severityPriority(severity: string): number {
+  if (severity === "high") return 75;
+  if (severity === "medium") return 55;
+  if (severity === "low") return 35;
+  return 45;
+}
+
+function isProbeError(probe: unknown): probe is { ok: false; error: string } {
+  return Boolean(
+    probe && typeof probe === "object" && "ok" in probe &&
+      (probe as { ok?: unknown }).ok === false,
+  );
+}
+
+function probeValue<T>(probe: unknown): T | null {
+  if (probe == null || typeof probe !== "object") return null;
+  if (!("ok" in probe) || probe.ok !== true) return null;
+  if (!("value" in probe)) return null;
+  return probe.value as T;
+}
+
+function probeArrayLength(probe: unknown): number {
+  const value = probeValue<unknown>(probe);
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function numericValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function stringValue<T extends string | null | undefined>(
+  value: unknown,
+  fallback: T,
+): string | T {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === "object"
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function asArray(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> =>
+      item != null && typeof item === "object"
+    )
+    : [];
+}
+
+function componentIdFromUnknown(value: unknown): Civ7ComponentId | null {
+  if (value == null || typeof value !== "object") return null;
+  const candidate = "cityId" in value ? value.cityId : value;
+  if (candidate == null || typeof candidate !== "object") return null;
+  if (!("owner" in candidate) || typeof candidate.owner !== "number") {
+    return null;
+  }
+  if (!("id" in candidate) || typeof candidate.id !== "number") return null;
+  const out: Civ7ComponentId = { owner: candidate.owner, id: candidate.id };
+  if ("type" in candidate && typeof candidate.type === "number") {
+    out.type = candidate.type;
+  }
+  return out;
+}

--- a/packages/civ7-control-orpc/src/modules/attention/router.ts
+++ b/packages/civ7-control-orpc/src/modules/attention/router.ts
@@ -1,5 +1,7 @@
 import { attentionCurrentProcedure } from "./procedures/current";
+import { attentionPrioritiesProcedure } from "./procedures/priorities";
 
 export const attentionRouter = {
   current: attentionCurrentProcedure,
+  priorities: attentionPrioritiesProcedure,
 };

--- a/packages/civ7-control-orpc/src/modules/notifications/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/notifications/contract.ts
@@ -21,6 +21,35 @@ const Civ7NotificationDismissInputStandardSchema = toStandardSchema(
   Civ7NotificationDismissInputSchema,
 );
 
+const Civ7NotificationQueueInputSchema = Type.Object(
+  {
+    maxNotifications: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+  },
+  { additionalProperties: false },
+);
+export type Civ7NotificationQueueInput = Static<
+  typeof Civ7NotificationQueueInputSchema
+>;
+
+const Civ7NotificationQueueDismissInputSchema = Type.Object(
+  {
+    maxNotifications: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+    maxDismissals: Type.Optional(Type.Integer({ minimum: 1, maximum: 25 })),
+    send: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);
+export type Civ7NotificationQueueDismissInput = Static<
+  typeof Civ7NotificationQueueDismissInputSchema
+>;
+
+const Civ7NotificationQueueInputStandardSchema = toStandardSchema(
+  Civ7NotificationQueueInputSchema,
+);
+const Civ7NotificationQueueDismissInputStandardSchema = toStandardSchema(
+  Civ7NotificationQueueDismissInputSchema,
+);
+
 export const Civ7NotificationDismissalProofOutcomeSchema = Type.Union([
   Type.Literal("cleared"),
   Type.Literal("state-changed"),
@@ -92,6 +121,86 @@ export const Civ7NotificationDismissalNextStepSchema = Type.Object(
   { additionalProperties: false },
 );
 
+const Civ7NotificationQueueDispositionSchema = Type.Union([
+  Type.Literal("operate-with-live-inputs"),
+  Type.Literal("reviewed-dismissal-candidate"),
+  Type.Literal("inspect-ready-unit"),
+  Type.Literal("inspect-handler"),
+  Type.Literal("review-only"),
+]);
+
+const Civ7NotificationQueueNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("inspect-ready-unit"),
+      Type.Literal("inspect-ready-city"),
+      Type.Literal("inspect-progression"),
+      Type.Literal("inspect-decision"),
+      Type.Literal("inspect-notification"),
+      Type.Literal("validate-operation"),
+      Type.Literal("dismiss-notification"),
+      Type.Literal("observe"),
+    ]),
+    source: Type.Literal("notifications.queue.current"),
+    label: Type.String(),
+    parameters: Type.Object(
+      {
+        notificationId: Type.Optional(Civ7ControlOrpcComponentIdSchema),
+        category: Type.Optional(Type.String()),
+        operationFamily: Type.Optional(Type.String()),
+        operationType: Type.Optional(Type.String()),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7NotificationQueueStepSchema = Type.Object(
+  {
+    step: Type.Integer({ minimum: 1 }),
+    priority: Type.Integer({ minimum: 0 }),
+    disposition: Civ7NotificationQueueDispositionSchema,
+    notificationId: Type.Union([Civ7ControlOrpcComponentIdSchema, Type.Null()]),
+    isEndTurnBlocking: Type.Boolean(),
+    category: Type.String(),
+    typeName: Type.Union([Type.String(), Type.Null()]),
+    summary: Type.Union([Type.String(), Type.Null()]),
+    message: Type.Union([Type.String(), Type.Null()]),
+    operationFamily: Type.Optional(Type.String()),
+    operationType: Type.Optional(Type.String()),
+    requiredInputs: Type.Array(Type.String()),
+    nextStep: Type.Union([Civ7NotificationQueueNextStepSchema, Type.Null()]),
+    safeToBatch: Type.Boolean(),
+    reason: Type.String(),
+    guardrails: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7NotificationQueueResultSchema = Type.Object(
+  {
+    localPlayerId: Type.Union([Type.Integer({ minimum: 0 }), Type.Null()]),
+    turn: Type.Unknown(),
+    turnDate: Type.Unknown(),
+    blocker: Type.Unknown(),
+    blockingNotificationId: Type.Union([
+      Civ7ControlOrpcComponentIdSchema,
+      Type.Null(),
+    ]),
+    canEndTurn: Type.Unknown(),
+    limits: Type.Unknown(),
+    queueLength: Type.Integer({ minimum: 0 }),
+    schedule: Type.Array(Civ7NotificationQueueStepSchema),
+    nextSteps: Type.Array(Civ7NotificationQueueNextStepSchema),
+    notes: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
+export type Civ7NotificationQueueResult = Static<
+  typeof Civ7NotificationQueueResultSchema
+>;
+
 const Civ7NotificationDismissalResultSchema = Type.Object(
   {
     notificationId: Civ7ControlOrpcComponentIdSchema,
@@ -107,8 +216,98 @@ export type Civ7NotificationDismissalResult = Static<
   typeof Civ7NotificationDismissalResultSchema
 >;
 
+const Civ7NotificationQueueExcludedSchema = Type.Object(
+  {
+    notificationId: Type.Union([Civ7ControlOrpcComponentIdSchema, Type.Null()]),
+    category: Type.String(),
+    typeName: Type.Union([Type.String(), Type.Null()]),
+    summary: Type.Union([Type.String(), Type.Null()]),
+    isEndTurnBlocking: Type.Boolean(),
+    reason: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7NotificationQueueDismissStatusSchema = Type.Union([
+  Type.Literal("not-sent"),
+  Type.Literal("sent-confirmed"),
+  Type.Literal("sent-guarded"),
+]);
+
+const Civ7NotificationQueueDismissPostconditionSchema = Type.Object(
+  {
+    classification: Type.Union([
+      Type.Literal("not-sent"),
+      Type.Literal("all-selected-confirmed"),
+      Type.Literal("selection-unverified"),
+    ]),
+    reason: Type.String(),
+    outcome: Type.Union([
+      Type.Literal("not-sent"),
+      Type.Literal("cleared"),
+      Type.Literal("unknown"),
+    ]),
+    confidence: Type.Union([
+      Type.Literal("confirmed"),
+      Type.Literal("unverified"),
+    ]),
+    confirmed: Type.Boolean(),
+    noRepeatAfterUnverified: Type.Boolean(),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7NotificationQueueDismissResultSchema = Type.Object(
+  {
+    localPlayerId: Type.Union([Type.Integer({ minimum: 0 }), Type.Null()]),
+    turn: Type.Unknown(),
+    turnDate: Type.Unknown(),
+    blocker: Type.Unknown(),
+    blockingNotificationId: Type.Union([
+      Civ7ControlOrpcComponentIdSchema,
+      Type.Null(),
+    ]),
+    canEndTurn: Type.Unknown(),
+    queueLength: Type.Integer({ minimum: 0 }),
+    sent: Type.Boolean(),
+    status: Civ7NotificationQueueDismissStatusSchema,
+    postcondition: Civ7NotificationQueueDismissPostconditionSchema,
+    maxDismissals: Type.Integer({ minimum: 1 }),
+    eligibleCount: Type.Integer({ minimum: 0 }),
+    selectedCount: Type.Integer({ minimum: 0 }),
+    omittedEligibleCount: Type.Integer({ minimum: 0 }),
+    candidates: Type.Array(Civ7NotificationQueueStepSchema),
+    excluded: Type.Array(Civ7NotificationQueueExcludedSchema),
+    results: Type.Array(Civ7NotificationDismissalResultSchema),
+    noRepeatAfterUnverified: Type.Boolean(),
+    nextSteps: Type.Array(Type.Object(
+      {
+        kind: Type.Union([
+          Type.Literal("refresh-attention"),
+          Type.Literal("do-not-repeat"),
+          Type.Literal("inspect-notification"),
+        ]),
+        source: Type.Literal("notifications.queue.dismiss.request"),
+        label: Type.String(),
+      },
+      { additionalProperties: false },
+    )),
+    notes: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
+export type Civ7NotificationQueueDismissResult = Static<
+  typeof Civ7NotificationQueueDismissResultSchema
+>;
+
 const Civ7NotificationDismissalResultStandardSchema = toStandardSchema(
   Civ7NotificationDismissalResultSchema,
+);
+const Civ7NotificationQueueResultStandardSchema = toStandardSchema(
+  Civ7NotificationQueueResultSchema,
+);
+const Civ7NotificationQueueDismissResultStandardSchema = toStandardSchema(
+  Civ7NotificationQueueDismissResultSchema,
 );
 
 export type Civ7NotificationDismissalContract = ContractProcedure<
@@ -129,14 +328,62 @@ export const Civ7NotificationDismissalContract: Civ7NotificationDismissalContrac
       risk: "mutation",
     });
 
+type Civ7NotificationQueueCurrentContract = ContractProcedure<
+  typeof Civ7NotificationQueueInputStandardSchema,
+  typeof Civ7NotificationQueueResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+const Civ7NotificationQueueCurrentContract:
+  Civ7NotificationQueueCurrentContract = civ7ControlOrpcContractBase
+    .input(Civ7NotificationQueueInputStandardSchema)
+    .output(Civ7NotificationQueueResultStandardSchema)
+    .meta({
+      family: "notifications",
+      procedureKey: "notifications.queue.current",
+      proofBoundary: "local-package-test",
+      risk: "read-only",
+    });
+
+type Civ7NotificationQueueDismissContract = ContractProcedure<
+  typeof Civ7NotificationQueueDismissInputStandardSchema,
+  typeof Civ7NotificationQueueDismissResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+const Civ7NotificationQueueDismissContract:
+  Civ7NotificationQueueDismissContract = civ7ControlOrpcContractBase
+    .input(Civ7NotificationQueueDismissInputStandardSchema)
+    .output(Civ7NotificationQueueDismissResultStandardSchema)
+    .meta({
+      family: "notifications",
+      procedureKey: "notifications.queue.dismiss.request",
+      proofBoundary: "local-package-test",
+      risk: "mutation",
+    });
+
 export type Civ7NotificationsContract = Readonly<{
   dismiss: Readonly<{
     request: Civ7NotificationDismissalContract;
+  }>;
+  queue: Readonly<{
+    current: Civ7NotificationQueueCurrentContract;
+    dismiss: Readonly<{
+      request: Civ7NotificationQueueDismissContract;
+    }>;
   }>;
 }>;
 
 export const Civ7NotificationsContract: Civ7NotificationsContract = {
   dismiss: {
     request: Civ7NotificationDismissalContract,
+  },
+  queue: {
+    current: Civ7NotificationQueueCurrentContract,
+    dismiss: {
+      request: Civ7NotificationQueueDismissContract,
+    },
   },
 };

--- a/packages/civ7-control-orpc/src/modules/notifications/procedures/dismiss-request.ts
+++ b/packages/civ7-control-orpc/src/modules/notifications/procedures/dismiss-request.ts
@@ -40,7 +40,7 @@ export const notificationsDismissRequestProcedure =
     });
   });
 
-function notificationDismissalResult(
+export function notificationDismissalResult(
   result: Civ7ControlOrpcNotificationDismissalResult,
 ): Civ7NotificationDismissalResult {
   const projection = civ7CloseoutMutationProjection({

--- a/packages/civ7-control-orpc/src/modules/notifications/procedures/queue.ts
+++ b/packages/civ7-control-orpc/src/modules/notifications/procedures/queue.ts
@@ -1,0 +1,448 @@
+import { Effect } from "effect";
+
+import type {
+  Civ7ControlOrpcNotificationDismissalResult,
+  Civ7ControlOrpcPlayNotificationViewResult,
+} from "../../../dependencies/direct-control";
+import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type {
+  Civ7NotificationQueueDismissResult,
+  Civ7NotificationQueueResult,
+} from "../contract";
+import { notificationDismissalResult } from "./dismiss-request";
+
+type QueueItem =
+  Civ7ControlOrpcPlayNotificationViewResult["hud"]["decisionQueue"][number];
+type QueueStep = Civ7NotificationQueueResult["schedule"][number];
+type QueueNextStep = NonNullable<QueueStep["nextStep"]>;
+type ExcludedNotification = Civ7NotificationQueueDismissResult["excluded"][number];
+type Probe<T = unknown> = { ok: true; value: T } | { ok: false; error: string };
+
+export const notificationsQueueCurrentProcedure =
+  civ7ControlOrpcImplementer.notifications.queue.current.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const view = await context.directControl.getCiv7PlayNotificationView({
+          ...context.endpointDefaults,
+          maxNotifications: input.maxNotifications ?? 50,
+        });
+        return notificationQueueResult(view);
+      },
+      catch: () =>
+        errors.NOTIFICATION_QUEUE_UNAVAILABLE({
+          data: {
+            procedureKey: "notifications.queue.current",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+export const notificationsQueueDismissRequestProcedure =
+  civ7ControlOrpcMutationProcedure(
+    civ7ControlOrpcImplementer.notifications.queue.dismiss.request,
+  ).effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const view = await context.directControl.getCiv7PlayNotificationView({
+          ...context.endpointDefaults,
+          maxNotifications: input.maxNotifications ?? 50,
+        });
+        const { candidates, excluded } = classifyQueue(view.hud.decisionQueue);
+        const maxDismissals = input.maxDismissals ?? 10;
+        const selected = candidates.slice(0, maxDismissals);
+        const results: Civ7ControlOrpcNotificationDismissalResult[] = [];
+        const send = input.send === true;
+
+        if (send) {
+          for (const candidate of selected) {
+            if (candidate.notificationId == null) continue;
+            results.push(
+              await context.directControl.requestCiv7NotificationDismissal(
+                { notificationId: candidate.notificationId },
+                context.endpointDefaults,
+              ),
+            );
+          }
+        }
+
+        return notificationQueueDismissResult({
+          view,
+          candidates,
+          excluded,
+          selected,
+          results,
+          send,
+          maxDismissals,
+        });
+      },
+      catch: () =>
+        errors.NOTIFICATION_QUEUE_UNAVAILABLE({
+          data: {
+            procedureKey: "notifications.queue.dismiss.request",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+function notificationQueueResult(
+  view: Civ7ControlOrpcPlayNotificationViewResult,
+): Civ7NotificationQueueResult {
+  const schedule = buildNotificationSchedule(view.hud.decisionQueue);
+  return {
+    localPlayerId: view.localPlayerId,
+    turn: view.turn,
+    turnDate: view.turnDate,
+    blocker: view.blocker,
+    blockingNotificationId: probeValue(view.blockingNotificationId),
+    canEndTurn: view.canEndTurn,
+    limits: view.limits,
+    queueLength: view.hud.decisionQueue.length,
+    schedule,
+    nextSteps: schedule
+      .map((item) => item.nextStep)
+      .filter((item): item is QueueNextStep => item != null),
+    notes: [
+      "Read-only notification queue scheduler; it does not dismiss notifications or send player/unit/city operations.",
+      "Informational dismissal candidates require summary and context review plus the specialized validator-backed dismissal request before any send.",
+      "Operation steps are templates. Re-read live inputs and use the specialized validator-backed command before sending.",
+    ],
+  };
+}
+
+function notificationQueueDismissResult(input: Readonly<{
+  view: Civ7ControlOrpcPlayNotificationViewResult;
+  candidates: QueueStep[];
+  excluded: ExcludedNotification[];
+  selected: QueueStep[];
+  results: Civ7ControlOrpcNotificationDismissalResult[];
+  send: boolean;
+  maxDismissals: number;
+}>): Civ7NotificationQueueDismissResult {
+  const projectedResults = input.results.map(notificationDismissalResult);
+  const allConfirmed = input.send && input.selected.length > 0 &&
+    projectedResults.length === input.selected.length &&
+    projectedResults.every((result) => result.status === "sent-confirmed");
+  const status = !input.send
+    ? "not-sent"
+    : allConfirmed
+    ? "sent-confirmed"
+    : "sent-guarded";
+  const postcondition = !input.send
+    ? {
+      classification: "not-sent" as const,
+      reason: "Dry run only; no notification dismissal was sent.",
+      outcome: "not-sent" as const,
+      confidence: "unverified" as const,
+      confirmed: false,
+      noRepeatAfterUnverified: true,
+    }
+    : allConfirmed
+    ? {
+      classification: "all-selected-confirmed" as const,
+      reason: "Every selected notification dismissal had confirmed postcondition evidence.",
+      outcome: "cleared" as const,
+      confidence: "confirmed" as const,
+      confirmed: true,
+      noRepeatAfterUnverified: false,
+    }
+    : {
+      classification: "selection-unverified" as const,
+      reason: "At least one selected notification dismissal lacked confirmed postcondition evidence.",
+      outcome: "unknown" as const,
+      confidence: "unverified" as const,
+      confirmed: false,
+      noRepeatAfterUnverified: true,
+    };
+
+  return {
+    localPlayerId: input.view.localPlayerId,
+    turn: input.view.turn,
+    turnDate: input.view.turnDate,
+    blocker: input.view.blocker,
+    blockingNotificationId: probeValue(input.view.blockingNotificationId),
+    canEndTurn: input.view.canEndTurn,
+    queueLength: input.view.hud.decisionQueue.length,
+    sent: input.send,
+    status,
+    postcondition,
+    maxDismissals: input.maxDismissals,
+    eligibleCount: input.candidates.length,
+    selectedCount: input.selected.length,
+    omittedEligibleCount: Math.max(0, input.candidates.length - input.selected.length),
+    candidates: input.selected,
+    excluded: input.excluded,
+    results: projectedResults,
+    noRepeatAfterUnverified: postcondition.noRepeatAfterUnverified,
+    nextSteps: status === "sent-confirmed"
+      ? [{
+        kind: "refresh-attention",
+        source: "notifications.queue.dismiss.request",
+        label: "Re-read notification queue and attention state before making further decisions.",
+      }]
+      : [
+        {
+          kind: "do-not-repeat",
+          source: "notifications.queue.dismiss.request",
+          label: input.send
+            ? "Do not repeat bulk dismissal until fresh notification evidence is read."
+            : "Dry run only; no dismissal was sent.",
+        },
+        {
+          kind: "inspect-notification",
+          source: "notifications.queue.dismiss.request",
+          label: "Inspect candidate notifications before sending dismissals.",
+        },
+      ],
+    notes: [
+      input.send
+        ? "Bulk dismissal sent only for eligible informational closeout candidates selected from a fresh HUD queue read."
+        : "Dry run only. Set send=true to dismiss eligible informational closeout candidates.",
+      "Operation-bearing, unit-command, production, diplomacy, narrative, progression, population, and unclassified notifications are excluded.",
+      "A completed App UI call is not aggregate confirmed unless every selected item has confirmed postcondition evidence.",
+      "Re-read the queue after this procedure before making further decisions.",
+    ],
+  };
+}
+
+function buildNotificationSchedule(
+  queue: ReadonlyArray<QueueItem>,
+): QueueStep[] {
+  return queue
+    .map((item, index) => buildQueueStep(item, index + 1))
+    .sort((left, right) => right.priority - left.priority || left.step - right.step)
+    .map((item, index) => ({ ...item, step: index + 1 }));
+}
+
+function classifyQueue(queue: ReadonlyArray<QueueItem>): {
+  candidates: QueueStep[];
+  excluded: ExcludedNotification[];
+} {
+  const candidates: QueueStep[] = [];
+  const excluded: ExcludedNotification[] = [];
+
+  for (const item of buildNotificationSchedule(queue)) {
+    if (item.disposition === "reviewed-dismissal-candidate" && item.safeToBatch) {
+      candidates.push(item);
+      continue;
+    }
+    excluded.push({
+      notificationId: item.notificationId,
+      category: item.category,
+      typeName: item.typeName,
+      summary: item.summary,
+      isEndTurnBlocking: item.isEndTurnBlocking,
+      reason: exclusionReason(item),
+    });
+  }
+
+  return { candidates, excluded };
+}
+
+function buildQueueStep(item: QueueItem, originalStep: number): QueueStep {
+  const disposition = dispositionFor(item);
+  const requiredInputs = item.requiredInputs
+    .filter((input) => input.required)
+    .map((input) => input.name);
+  const isDismissalCandidate = disposition === "reviewed-dismissal-candidate";
+  const safeToBatch = isDismissalCandidate && isBatchSafeDismissalCandidate(item);
+  const guardrails = guardrailsFor(item, disposition, requiredInputs);
+  const operationFamily = stringValueOrUndefined(item.operationFamily);
+  const operationType = stringValueOrUndefined(item.operationType);
+
+  return {
+    step: originalStep,
+    priority: priorityFor(item, disposition),
+    disposition,
+    notificationId: item.notificationId,
+    isEndTurnBlocking: item.isEndTurnBlocking,
+    category: item.category,
+    typeName: item.typeName,
+    summary: item.summary,
+    message: item.message,
+    ...(operationFamily == null ? {} : { operationFamily }),
+    ...(operationType == null ? {} : { operationType }),
+    requiredInputs,
+    nextStep: nextStepFor(item, disposition, operationFamily, operationType),
+    safeToBatch,
+    reason: reasonFor(item, disposition),
+    guardrails: isDismissalCandidate
+      ? [
+        "Review the message and context first; this schedule only identifies an eligible dismissal candidate.",
+        ...guardrails,
+      ]
+      : guardrails,
+  };
+}
+
+function dispositionFor(item: QueueItem): QueueStep["disposition"] {
+  if (
+    item.category === "informational-notification" &&
+    item.operationFamily === "app-ui-action"
+  ) {
+    return "reviewed-dismissal-candidate";
+  }
+  if (item.category === "unit-command") return "inspect-ready-unit";
+  if (item.operationFamily || item.cli) return "operate-with-live-inputs";
+  if (item.category === "notification" || item.category === "blocking-notification") {
+    return "inspect-handler";
+  }
+  return "review-only";
+}
+
+function isBatchSafeDismissalCandidate(item: QueueItem): boolean {
+  if (item.notificationId == null) return false;
+  if (item.operationType !== "Game.Notifications.dismiss") return false;
+  if (!item.isEndTurnBlocking) return true;
+  return item.typeName !== "NOTIFICATION_UNIT_LOST";
+}
+
+function priorityFor(
+  item: QueueItem,
+  disposition: QueueStep["disposition"],
+): number {
+  if (item.isEndTurnBlocking) return 100;
+  if (disposition === "operate-with-live-inputs") return 70;
+  if (disposition === "inspect-ready-unit") return 65;
+  if (disposition === "inspect-handler") return 50;
+  if (disposition === "reviewed-dismissal-candidate") return 35;
+  return 20;
+}
+
+function reasonFor(
+  item: QueueItem,
+  disposition: QueueStep["disposition"],
+): string {
+  if (item.isEndTurnBlocking) {
+    return "End-turn blocker; resolve or consciously defer before broad tactical planning.";
+  }
+  if (disposition === "reviewed-dismissal-candidate") {
+    return "Default-handler informational notification; useful for context, but closeout must stay item-scoped and postcondition-checked.";
+  }
+  if (disposition === "inspect-ready-unit") {
+    return "Unit command notification needs the current ready unit and target-specific validators.";
+  }
+  if (disposition === "operate-with-live-inputs") {
+    return "Known operation family; required live inputs must be read from the current surface before send.";
+  }
+  if (disposition === "inspect-handler") {
+    return "Unclassified notification; inspect official handler or live UI before choosing any operation.";
+  }
+  return "Queue context item; keep for strategy or tactics but do not mutate from this schedule alone.";
+}
+
+function exclusionReason(item: QueueStep): string {
+  if (item.notificationId == null) return "missing notification id";
+  if (item.isEndTurnBlocking && item.typeName === "NOTIFICATION_UNIT_LOST") {
+    return "front unit-loss reports require exact reviewed dismissal proof, not bulk dismissal";
+  }
+  if (item.category === "unit-command") return "unit command requires ready-unit inspection";
+  if (
+    item.operationFamily != null &&
+    item.operationFamily !== "app-ui-action"
+  ) {
+    return "gameplay operation requires live inputs and validator-backed command";
+  }
+  if (item.category === "notification" || item.category === "blocking-notification") {
+    return "unclassified notification needs handler evidence first";
+  }
+  if (item.category === "informational-notification") {
+    return "informational item is not exposed as App UI dismissal by the live HUD";
+  }
+  return "not an informational closeout candidate";
+}
+
+function guardrailsFor(
+  item: QueueItem,
+  disposition: QueueStep["disposition"],
+  requiredInputs: ReadonlyArray<string>,
+): string[] {
+  const guardrails: string[] = [];
+  if (requiredInputs.length > 0 && disposition !== "reviewed-dismissal-candidate") {
+    guardrails.push(`Read required live inputs first: ${requiredInputs.join(", ")}.`);
+  }
+  if (item.location && typeof item.location === "object") {
+    guardrails.push("Use the reported location as tactical context, not as proof of a valid operation target.");
+  }
+  if (disposition === "operate-with-live-inputs") {
+    guardrails.push("Validate with the specialized command before sending; this schedule does not prove the args.");
+  }
+  if (disposition === "inspect-handler") {
+    guardrails.push("Do not dismiss unclassified notifications in bulk.");
+  }
+  return guardrails;
+}
+
+function nextStepFor(
+  item: QueueItem,
+  disposition: QueueStep["disposition"],
+  operationFamily: string | undefined,
+  operationType: string | undefined,
+): QueueNextStep | null {
+  const baseParameters = {
+    ...(item.notificationId == null ? {} : { notificationId: item.notificationId }),
+    category: item.category,
+    ...(operationFamily == null ? {} : { operationFamily }),
+    ...(operationType == null ? {} : { operationType }),
+  };
+
+  if (disposition === "reviewed-dismissal-candidate") {
+    return {
+      kind: "dismiss-notification",
+      source: "notifications.queue.current",
+      label: "Review and dismiss this informational notification with the item-scoped dismissal request.",
+      parameters: baseParameters,
+    };
+  }
+  if (disposition === "inspect-ready-unit") {
+    return {
+      kind: "inspect-ready-unit",
+      source: "notifications.queue.current",
+      label: "Inspect current ready unit before choosing a unit operation.",
+      parameters: baseParameters,
+    };
+  }
+  if (disposition === "operate-with-live-inputs") {
+    return {
+      kind: operationFamily === "city-command" ? "inspect-ready-city" : "validate-operation",
+      source: "notifications.queue.current",
+      label: "Read the specialized current surface and validator evidence before any send.",
+      parameters: baseParameters,
+    };
+  }
+  if (disposition === "inspect-handler") {
+    return {
+      kind: "inspect-notification",
+      source: "notifications.queue.current",
+      label: "Inspect handler evidence before acting on this notification.",
+      parameters: baseParameters,
+    };
+  }
+  return {
+    kind: "observe",
+    source: "notifications.queue.current",
+    label: "Keep this queue item as read-only context.",
+    parameters: baseParameters,
+  };
+}
+
+function stringValueOrUndefined(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function probeValue<T>(probe: Probe<T> | null | undefined): T | null {
+  return probe?.ok ? probe.value : null;
+}

--- a/packages/civ7-control-orpc/src/modules/notifications/router.ts
+++ b/packages/civ7-control-orpc/src/modules/notifications/router.ts
@@ -1,7 +1,17 @@
 import { notificationsDismissRequestProcedure } from "./procedures/dismiss-request";
+import {
+  notificationsQueueCurrentProcedure,
+  notificationsQueueDismissRequestProcedure,
+} from "./procedures/queue";
 
 export const notificationsRouter = {
   dismiss: {
     request: notificationsDismissRequestProcedure,
+  },
+  queue: {
+    current: notificationsQueueCurrentProcedure,
+    dismiss: {
+      request: notificationsQueueDismissRequestProcedure,
+    },
   },
 };

--- a/packages/civ7-control-orpc/src/modules/readiness/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/readiness/contract.ts
@@ -78,6 +78,7 @@ export const Civ7ReadinessNextStepSchema = Type.Object(
     kind: Type.Union([
       Type.Literal("read-attention"),
       Type.Literal("read-strategy-front"),
+      Type.Literal("read-world"),
       Type.Literal("restore-tuner"),
       Type.Literal("begin-game"),
       Type.Literal("wait-loading"),

--- a/packages/civ7-control-orpc/src/modules/readiness/procedures/current.ts
+++ b/packages/civ7-control-orpc/src/modules/readiness/procedures/current.ts
@@ -152,6 +152,13 @@ function readinessNextSteps(
       label: "Read strategy front summary before choosing tactical support actions.",
     }];
   }
+  if (status.readiness === "app-ui-game" && supportsWorldCurrent(context)) {
+    return [{
+      kind: "read-world",
+      source: "readiness.current",
+      label: "Read current world facts before choosing support actions.",
+    }];
+  }
 
   switch (status.readiness) {
     case "app-ui-game":
@@ -194,6 +201,10 @@ function supportsAttentionCurrent(context: Civ7ControlOrpcContext): boolean {
 
 function supportsStrategyFront(context: Civ7ControlOrpcContext): boolean {
   return supportedReadProcedures(context).includes("strategy.frontSummary");
+}
+
+function supportsWorldCurrent(context: Civ7ControlOrpcContext): boolean {
+  return supportedReadProcedures(context).includes("world.current");
 }
 
 function supportedReadProcedures(context: Civ7ControlOrpcContext): readonly string[] {

--- a/packages/civ7-control-orpc/src/modules/strategy/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/contract.ts
@@ -315,6 +315,140 @@ const Civ7StrategyCivilianRouteTriageResultStandardSchema = toStandardSchema(
   Civ7StrategyCivilianRouteTriageResultSchema,
 );
 
+const Civ7StrategyFormationSnapshotInputSchema = Type.Object(
+  {
+    playerId: Type.Optional(Type.Integer({ minimum: 0, maximum: 1024 })),
+    origin: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+    radius: Type.Optional(Type.Integer({ minimum: 1, maximum: 16 })),
+    screenRadius: Type.Optional(Type.Integer({ minimum: 1, maximum: 6 })),
+    contactRadius: Type.Optional(Type.Integer({ minimum: 1, maximum: 8 })),
+    maxUnits: Type.Optional(Type.Integer({ minimum: 1, maximum: 256 })),
+    maxCities: Type.Optional(Type.Integer({ minimum: 1, maximum: 128 })),
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyFormationSnapshotInput = Static<
+  typeof Civ7StrategyFormationSnapshotInputSchema
+>;
+
+const Civ7StrategyFormationSourceStatusSchema = Type.Object(
+  {
+    notifications: Type.Literal("read"),
+    readyUnit: Type.Union([
+      Type.Literal("read"),
+      Type.Literal("skipped-explicit-origin"),
+      Type.Literal("skipped-no-ready-unit"),
+    ]),
+    battlefieldScan: Type.Literal("read"),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyFormationPostureSchema = Type.Union([
+  Type.Literal("screen-civilian"),
+  Type.Literal("hold-ready-unit"),
+  Type.Literal("stabilize-front"),
+  Type.Literal("advance-with-validation"),
+  Type.Literal("inspect-ready-unit"),
+]);
+
+const Civ7StrategyFormationUnitSchema = Type.Object(
+  {
+    id: Type.Union([Civ7ControlOrpcComponentIdSchema, Type.Null()]),
+    owner: Type.Union([Type.Integer({ minimum: 0 }), Type.Null()]),
+    stance: Type.String(),
+    role: Type.String(),
+    typeName: Type.Union([Type.String(), Type.Null()]),
+    location: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+    distance: Type.Union([Type.Number(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyFormationNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("read-priorities"),
+      Type.Literal("inspect-ready-unit"),
+      Type.Literal("inspect-battlefield"),
+      Type.Literal("inspect-civilian-route"),
+      Type.Literal("validate-unit-action"),
+    ]),
+    source: Type.Literal("strategy.formationSnapshot"),
+    label: Type.String(),
+    parameters: Type.Object(
+      {
+        origin: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+        civilian: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+        contact: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyFormationSnapshotResultSchema = Type.Object(
+  {
+    playerId: Type.Integer({ minimum: 0 }),
+    localPlayerId: Type.Integer({ minimum: 0 }),
+    turn: Type.Union([Type.Integer({ minimum: 0 }), Type.Null()]),
+    turnDate: Type.Union([Type.String(), Type.Null()]),
+    blocker: Type.Union([Type.Integer({ minimum: 0 }), Type.Null()]),
+    nextDecision: Type.Union([Type.String(), Type.Null()]),
+    origin: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+    sourceStatus: Civ7StrategyFormationSourceStatusSchema,
+    readyUnit: Type.Union([
+      Type.Object(
+        {
+          unitId: Type.Union([Civ7ControlOrpcComponentIdSchema, Type.Null()]),
+          typeName: Type.Union([Type.String(), Type.Null()]),
+          location: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+          legalNoTargetOperationCount: Type.Integer({ minimum: 0 }),
+        },
+        { additionalProperties: false },
+      ),
+      Type.Null(),
+    ]),
+    battlefield: Type.Object(
+      {
+        originCount: Type.Integer({ minimum: 0 }),
+        unitCount: Type.Integer({ minimum: 0 }),
+        pointOfInterestCount: Type.Integer({ minimum: 0 }),
+        hiddenInfoPolicy: Type.String(),
+      },
+      { additionalProperties: false },
+    ),
+    formation: Type.Object(
+      {
+        posture: Civ7StrategyFormationPostureSchema,
+        relationshipLabelPolicy: Civ7StrategyRelationshipLabelPolicySchema,
+        headline: Type.String(),
+        reasons: Type.Array(Type.String()),
+        civilians: Type.Array(Civ7StrategyFormationUnitSchema),
+        screens: Type.Array(Civ7StrategyFormationUnitSchema),
+        otherOwnerContacts: Type.Array(Civ7StrategyFormationUnitSchema),
+        nearbyContacts: Type.Array(Civ7StrategyFormationUnitSchema),
+        nextSteps: Type.Array(Civ7StrategyFormationNextStepSchema),
+      },
+      { additionalProperties: false },
+    ),
+    notes: Type.Array(Type.String()),
+    nextSteps: Type.Array(Civ7StrategyFormationNextStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyFormationSnapshotResult = Static<
+  typeof Civ7StrategyFormationSnapshotResultSchema
+>;
+
+const Civ7StrategyFormationSnapshotInputStandardSchema = toStandardSchema(
+  Civ7StrategyFormationSnapshotInputSchema,
+);
+const Civ7StrategyFormationSnapshotResultStandardSchema = toStandardSchema(
+  Civ7StrategyFormationSnapshotResultSchema,
+);
+
 export type Civ7StrategyFrontSummaryContract = ContractProcedure<
   typeof Civ7StrategyFrontSummaryInputStandardSchema,
   typeof Civ7StrategyFrontSummaryResultStandardSchema,
@@ -352,12 +486,33 @@ export const Civ7StrategyCivilianRouteTriageContract:
         risk: "read-only",
       });
 
+export type Civ7StrategyFormationSnapshotContract = ContractProcedure<
+  typeof Civ7StrategyFormationSnapshotInputStandardSchema,
+  typeof Civ7StrategyFormationSnapshotResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export const Civ7StrategyFormationSnapshotContract:
+  Civ7StrategyFormationSnapshotContract =
+    civ7ControlOrpcContractBase
+      .input(Civ7StrategyFormationSnapshotInputStandardSchema)
+      .output(Civ7StrategyFormationSnapshotResultStandardSchema)
+      .meta({
+        family: "strategy",
+        procedureKey: "strategy.formationSnapshot",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      });
+
 export type Civ7StrategyContract = Readonly<{
   civilianRouteTriage: Civ7StrategyCivilianRouteTriageContract;
+  formationSnapshot: Civ7StrategyFormationSnapshotContract;
   frontSummary: Civ7StrategyFrontSummaryContract;
 }>;
 
 export const Civ7StrategyContract: Civ7StrategyContract = {
   civilianRouteTriage: Civ7StrategyCivilianRouteTriageContract,
+  formationSnapshot: Civ7StrategyFormationSnapshotContract,
   frontSummary: Civ7StrategyFrontSummaryContract,
 };

--- a/packages/civ7-control-orpc/src/modules/strategy/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/contract.ts
@@ -4,7 +4,10 @@ import { Type, type Static } from "typebox";
 import { civ7ControlOrpcContractBase } from "../../contract-base";
 import type { Civ7ControlOrpcErrorMap } from "../../errors";
 import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
-import { Civ7ControlOrpcMapLocationSchema } from "../../model/primitives";
+import {
+  Civ7ControlOrpcComponentIdSchema,
+  Civ7ControlOrpcMapLocationSchema,
+} from "../../model/primitives";
 import { toStandardSchema } from "../../typebox-standard-schema";
 
 const Civ7StrategyFrontSummaryInputSchema = Type.Object(
@@ -172,6 +175,146 @@ const Civ7StrategyFrontSummaryResultStandardSchema = toStandardSchema(
   Civ7StrategyFrontSummaryResultSchema,
 );
 
+const Civ7StrategyCivilianRouteTriageInputSchema = Type.Object(
+  {
+    playerId: Type.Optional(Type.Integer({ minimum: 0, maximum: 1024 })),
+    origin: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+    destination: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+    settlementCount: Type.Optional(Type.Integer({ minimum: 1, maximum: 12 })),
+    scanRadius: Type.Optional(Type.Integer({ minimum: 1, maximum: 16 })),
+    corridorRadius: Type.Optional(Type.Integer({ minimum: 0, maximum: 8 })),
+    destinationRadius: Type.Optional(Type.Integer({ minimum: 1, maximum: 16 })),
+    maxUnits: Type.Optional(Type.Integer({ minimum: 1, maximum: 256 })),
+    maxCities: Type.Optional(Type.Integer({ minimum: 1, maximum: 128 })),
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyCivilianRouteTriageInput = Static<
+  typeof Civ7StrategyCivilianRouteTriageInputSchema
+>;
+
+const Civ7StrategyCivilianRouteTriageSourceStatusSchema = Type.Object(
+  {
+    notifications: Type.Literal("read"),
+    readyUnit: Type.Union([
+      Type.Literal("read"),
+      Type.Literal("skipped-explicit-origin"),
+      Type.Literal("skipped-no-ready-unit"),
+    ]),
+    settlementRecommendations: Type.Literal("read"),
+    battlefieldScan: Type.Literal("read"),
+    destinationAnalysis: Type.Union([
+      Type.Literal("read"),
+      Type.Literal("skipped-no-origin-or-destination"),
+    ]),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyCivilianRouteNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("read-priorities"),
+      Type.Literal("inspect-battlefield"),
+      Type.Literal("inspect-settlement"),
+      Type.Literal("inspect-destination"),
+      Type.Literal("inspect-front"),
+      Type.Literal("inspect-ready-unit"),
+      Type.Literal("validate-unit-action"),
+    ]),
+    source: Type.Literal("strategy.civilianRouteTriage"),
+    label: Type.String(),
+    parameters: Type.Object(
+      {
+        origin: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+        destination: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyCivilianRouteTriageStatusSchema = Type.Union([
+  Type.Literal("proceed-with-validation"),
+  Type.Literal("hold-or-screen"),
+  Type.Literal("reroute-or-stage"),
+  Type.Literal("inspect-candidate"),
+]);
+
+const Civ7StrategyCivilianRouteTriageResultSchema = Type.Object(
+  {
+    playerId: Type.Integer({ minimum: 0 }),
+    localPlayerId: Type.Integer({ minimum: 0 }),
+    origin: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+    destination: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+    sourceStatus: Civ7StrategyCivilianRouteTriageSourceStatusSchema,
+    relationshipLabelPolicy: Civ7StrategyRelationshipLabelPolicySchema,
+    readyUnit: Type.Union([
+      Type.Object(
+        {
+          unitId: Type.Union([Civ7ControlOrpcComponentIdSchema, Type.Null()]),
+          typeName: Type.Union([Type.String(), Type.Null()]),
+          location: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+          legalOperationCount: Type.Integer({ minimum: 0 }),
+        },
+        { additionalProperties: false },
+      ),
+      Type.Null(),
+    ]),
+    settlement: Type.Object(
+      {
+        originCount: Type.Integer({ minimum: 0 }),
+        recommendationCount: Type.Integer({ minimum: 0 }),
+        firstSuggestion: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+      },
+      { additionalProperties: false },
+    ),
+    battlefield: Type.Object(
+      {
+        pointOfInterestCount: Type.Integer({ minimum: 0 }),
+        observedOwnerCount: Type.Integer({ minimum: 0 }),
+        hiddenInfoPolicy: Type.String(),
+      },
+      { additionalProperties: false },
+    ),
+    destinationAnalysis: Type.Union([
+      Type.Object(
+        {
+          pointOfInterestCount: Type.Integer({ minimum: 0 }),
+          destinationUnitCount: Type.Integer({ minimum: 0 }),
+          destinationCityCount: Type.Integer({ minimum: 0 }),
+          apparentOtherStrength: Type.Number(),
+        },
+        { additionalProperties: false },
+      ),
+      Type.Null(),
+    ]),
+    triage: Type.Object(
+      {
+        status: Civ7StrategyCivilianRouteTriageStatusSchema,
+        summary: Type.String(),
+        reasons: Type.Array(Type.String()),
+        nextSteps: Type.Array(Civ7StrategyCivilianRouteNextStepSchema),
+      },
+      { additionalProperties: false },
+    ),
+    notes: Type.Array(Type.String()),
+    nextSteps: Type.Array(Civ7StrategyCivilianRouteNextStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyCivilianRouteTriageResult = Static<
+  typeof Civ7StrategyCivilianRouteTriageResultSchema
+>;
+
+const Civ7StrategyCivilianRouteTriageInputStandardSchema = toStandardSchema(
+  Civ7StrategyCivilianRouteTriageInputSchema,
+);
+const Civ7StrategyCivilianRouteTriageResultStandardSchema = toStandardSchema(
+  Civ7StrategyCivilianRouteTriageResultSchema,
+);
+
 export type Civ7StrategyFrontSummaryContract = ContractProcedure<
   typeof Civ7StrategyFrontSummaryInputStandardSchema,
   typeof Civ7StrategyFrontSummaryResultStandardSchema,
@@ -190,10 +333,31 @@ export const Civ7StrategyFrontSummaryContract: Civ7StrategyFrontSummaryContract 
       risk: "read-only",
     });
 
+export type Civ7StrategyCivilianRouteTriageContract = ContractProcedure<
+  typeof Civ7StrategyCivilianRouteTriageInputStandardSchema,
+  typeof Civ7StrategyCivilianRouteTriageResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export const Civ7StrategyCivilianRouteTriageContract:
+  Civ7StrategyCivilianRouteTriageContract =
+    civ7ControlOrpcContractBase
+      .input(Civ7StrategyCivilianRouteTriageInputStandardSchema)
+      .output(Civ7StrategyCivilianRouteTriageResultStandardSchema)
+      .meta({
+        family: "strategy",
+        procedureKey: "strategy.civilianRouteTriage",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      });
+
 export type Civ7StrategyContract = Readonly<{
+  civilianRouteTriage: Civ7StrategyCivilianRouteTriageContract;
   frontSummary: Civ7StrategyFrontSummaryContract;
 }>;
 
 export const Civ7StrategyContract: Civ7StrategyContract = {
+  civilianRouteTriage: Civ7StrategyCivilianRouteTriageContract,
   frontSummary: Civ7StrategyFrontSummaryContract,
 };

--- a/packages/civ7-control-orpc/src/modules/strategy/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/contract.ts
@@ -11,9 +11,14 @@ const Civ7StrategyFrontSummaryInputSchema = Type.Object(
   {
     playerId: Type.Optional(Type.Integer({ minimum: 0, maximum: 1024 })),
     origins: Type.Optional(Type.Array(Civ7ControlOrpcMapLocationSchema)),
+    target: Type.Optional(Civ7ControlOrpcMapLocationSchema),
     candidateLimit: Type.Optional(Type.Integer({ minimum: 1, maximum: 8 })),
     scanRadius: Type.Optional(Type.Integer({ minimum: 1, maximum: 32 })),
+    corridorRadius: Type.Optional(Type.Integer({ minimum: 0, maximum: 8 })),
+    destinationRadius: Type.Optional(Type.Integer({ minimum: 1, maximum: 16 })),
     maxPlayers: Type.Optional(Type.Integer({ minimum: 1, maximum: 128 })),
+    maxUnits: Type.Optional(Type.Integer({ minimum: 1, maximum: 256 })),
+    maxCities: Type.Optional(Type.Integer({ minimum: 1, maximum: 128 })),
   },
   { additionalProperties: false },
 );
@@ -40,6 +45,10 @@ export const Civ7StrategyFrontSourceStatusSchema = Type.Object(
   {
     targetCandidates: Type.Literal("read"),
     battlefieldScan: Type.Literal("read"),
+    destinationAnalysis: Type.Union([
+      Type.Literal("read"),
+      Type.Literal("skipped-no-target"),
+    ]),
   },
   { additionalProperties: false },
 );
@@ -67,6 +76,24 @@ export const Civ7StrategyFrontPointOfInterestSchema = Type.Object(
     severity: Type.String(),
     location: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
     summary: Type.String(),
+    source: Type.Union([
+      Type.Literal("battlefield"),
+      Type.Literal("destination"),
+    ]),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyFrontPressureSchema = Type.Object(
+  {
+    kind: Type.String(),
+    severity: Type.String(),
+    summary: Type.String(),
+    location: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+    source: Type.Union([
+      Type.Literal("battlefield"),
+      Type.Literal("destination"),
+    ]),
   },
   { additionalProperties: false },
 );
@@ -104,6 +131,7 @@ const Civ7StrategyFrontSummaryResultSchema = Type.Object(
     playerId: Type.Integer({ minimum: 0 }),
     localPlayerId: Type.Integer({ minimum: 0 }),
     origins: Type.Array(Civ7ControlOrpcMapLocationSchema),
+    target: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
     sourceStatus: Civ7StrategyFrontSourceStatusSchema,
     relationshipLabelPolicy: Civ7StrategyRelationshipLabelPolicySchema,
     summary: Type.Object(
@@ -112,6 +140,16 @@ const Civ7StrategyFrontSummaryResultSchema = Type.Object(
         pointOfInterestCount: Type.Integer({ minimum: 0 }),
         observedOwnerCount: Type.Integer({ minimum: 0 }),
         nextStepCount: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    ),
+    front: Type.Object(
+      {
+        posture: Type.String(),
+        headline: Type.String(),
+        risks: Type.Array(Type.String()),
+        nextInspections: Type.Array(Civ7StrategyFrontSummaryNextStepSchema),
+        pressure: Type.Array(Civ7StrategyFrontPressureSchema),
       },
       { additionalProperties: false },
     ),

--- a/packages/civ7-control-orpc/src/modules/strategy/procedures/civilian-route-triage.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/procedures/civilian-route-triage.ts
@@ -1,0 +1,378 @@
+import { Effect } from "effect";
+
+import type {
+  Civ7ControlOrpcBattlefieldScanResult,
+  Civ7ControlOrpcDestinationAnalysisResult,
+  Civ7ControlOrpcPlayNotificationViewResult,
+  Civ7ControlOrpcReadyUnitViewResult,
+  Civ7ControlOrpcSettlementRecommendationsResult,
+} from "../../../dependencies/direct-control";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import type { Civ7ControlOrpcMapLocation } from "../../../model/primitives";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type {
+  Civ7StrategyCivilianRouteTriageInput,
+  Civ7StrategyCivilianRouteTriageResult,
+} from "../contract";
+
+type TriageStatus = Civ7StrategyCivilianRouteTriageResult["triage"]["status"];
+type TriageNextStep =
+  Civ7StrategyCivilianRouteTriageResult["nextSteps"][number];
+
+export const strategyCivilianRouteTriageProcedure =
+  civ7ControlOrpcImplementer.strategy.civilianRouteTriage.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const endpointDefaults = context.endpointDefaults;
+        const notifications = await context.directControl.getCiv7PlayNotificationView({
+          ...endpointDefaults,
+          maxNotifications: 10,
+        });
+        const requestedOrigin = input.origin ?? null;
+        const readyUnitId = probeValue(notifications.firstReadyUnitId);
+        const readyUnit = requestedOrigin != null || readyUnitId == null
+          ? null
+          : await context.directControl.getCiv7ReadyUnitView({
+            unitId: readyUnitId,
+            radius: 2,
+          }, endpointDefaults);
+        const origin = requestedOrigin ?? readyUnitLocation(readyUnit);
+        const origins = origin == null ? undefined : [origin];
+        const settlement =
+          await context.directControl.getCiv7SettlementRecommendations({
+            playerId: input.playerId,
+            locations: origins,
+            count: input.settlementCount ?? 5,
+            includeSettlers: origin == null,
+            includeCities: false,
+          }, endpointDefaults);
+        const destination = input.destination ??
+          firstSettlementSuggestion(settlement);
+        const battlefield = await context.directControl.getCiv7BattlefieldScan({
+          playerId: input.playerId,
+          origins,
+          radius: input.scanRadius ?? 6,
+          maxUnits: input.maxUnits ?? 96,
+          maxCities: input.maxCities ?? 40,
+        }, endpointDefaults);
+        const destinationAnalysis = origin != null && destination != null
+          ? await context.directControl.getCiv7DestinationAnalysis({
+            playerId: input.playerId,
+            origin,
+            destination,
+            corridorRadius: input.corridorRadius ?? 2,
+            destinationRadius: input.destinationRadius ?? 4,
+            maxUnits: input.maxUnits ?? 96,
+            maxCities: input.maxCities ?? 40,
+          }, endpointDefaults)
+          : null;
+
+        return civilianRouteTriageResult({
+          input,
+          notifications,
+          readyUnit,
+          settlement,
+          battlefield,
+          destinationAnalysis,
+          origin,
+          destination,
+        });
+      },
+      catch: () =>
+        errors.STRATEGY_CIVILIAN_ROUTE_TRIAGE_UNAVAILABLE({
+          data: {
+            procedureKey: "strategy.civilianRouteTriage",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+function civilianRouteTriageResult({
+  input,
+  notifications,
+  readyUnit,
+  settlement,
+  battlefield,
+  destinationAnalysis,
+  origin,
+  destination,
+}: Readonly<{
+  input: Civ7StrategyCivilianRouteTriageInput;
+  notifications: Civ7ControlOrpcPlayNotificationViewResult;
+  readyUnit: Civ7ControlOrpcReadyUnitViewResult | null;
+  settlement: Civ7ControlOrpcSettlementRecommendationsResult;
+  battlefield: Civ7ControlOrpcBattlefieldScanResult;
+  destinationAnalysis: Civ7ControlOrpcDestinationAnalysisResult | null;
+  origin: Civ7ControlOrpcMapLocation | null;
+  destination: Civ7ControlOrpcMapLocation | null;
+}>): Civ7StrategyCivilianRouteTriageResult {
+  const reasons = triageReasons({ battlefield, destinationAnalysis });
+  const status = triageStatus({ destination, reasons });
+  const nextSteps = triageNextSteps({ origin, destination, status });
+  const unit = readyUnit == null ? null : probeValue(readyUnit.unit);
+  const firstSuggestion = firstSettlementSuggestion(settlement);
+
+  return {
+    playerId: settlement.playerId,
+    localPlayerId: settlement.localPlayerId,
+    origin,
+    destination,
+    sourceStatus: {
+      notifications: "read",
+      readyUnit: input.origin != null
+        ? "skipped-explicit-origin"
+        : readyUnit == null ? "skipped-no-ready-unit" : "read",
+      settlementRecommendations: "read",
+      battlefieldScan: "read",
+      destinationAnalysis: destinationAnalysis == null
+        ? "skipped-no-origin-or-destination"
+        : "read",
+    },
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "Civilian route triage composes planning evidence only. Other-owner contact, proximity, ranking, and action legality do not prove official diplomatic status.",
+    },
+    readyUnit: readyUnit == null
+      ? null
+      : {
+        unitId: readyUnit.unitId,
+        typeName: stringValue(asRecord(unit)?.typeName),
+        location: locationFromUnknown(asRecord(unit)?.location),
+        legalOperationCount: readyUnit.legalOperations.length,
+      },
+    settlement: {
+      originCount: settlement.origins.length,
+      recommendationCount: settlement.recommendations.length,
+      firstSuggestion,
+    },
+    battlefield: {
+      pointOfInterestCount: battlefield.pointsOfInterest.length,
+      observedOwnerCount: battlefield.owners.length,
+      hiddenInfoPolicy: battlefield.hiddenInfoPolicy,
+    },
+    destinationAnalysis: destinationAnalysis == null
+      ? null
+      : {
+        pointOfInterestCount: destinationAnalysis.pointsOfInterest.length,
+        destinationUnitCount: numericValue(
+          asRecord(destinationAnalysis.destinationPressure)?.unitCount,
+        ) ?? 0,
+        destinationCityCount: numericValue(
+          asRecord(destinationAnalysis.destinationPressure)?.cityCount,
+        ) ?? 0,
+        apparentOtherStrength: numericValue(
+          asRecord(destinationAnalysis.destinationPressure)
+            ?.apparentOtherStrength,
+        ) ?? 0,
+      },
+    triage: {
+      status,
+      summary: routeSummary(origin, destination),
+      reasons,
+      nextSteps,
+    },
+    notes: [
+      "Read-only civilian route triage. It does not move, found, buy, or reserve routes.",
+      "Settlement recommendations are site hints, not movement orders.",
+      "Use validator-backed unit procedures before any concrete movement or target send.",
+      "Relationship labels stay relationship-unproven unless official diplomatic evidence proves more.",
+    ],
+    nextSteps,
+  };
+}
+
+function triageReasons({
+  battlefield,
+  destinationAnalysis,
+}: Readonly<{
+  battlefield: Civ7ControlOrpcBattlefieldScanResult;
+  destinationAnalysis: Civ7ControlOrpcDestinationAnalysisResult | null;
+}>): string[] {
+  return uniqueStrings([
+    ...battlefield.pointsOfInterest.map((point) =>
+      `${point.severity} local ${point.kind}: ${normalizeRelationshipSummary(point.summary)}`
+    ),
+    ...(destinationAnalysis?.pointsOfInterest.map((point) =>
+      `${point.severity} route ${point.kind}: ${normalizeRelationshipSummary(point.summary)}`
+    ) ?? []),
+    ...destinationPressureReasons(destinationAnalysis),
+  ]).slice(0, 10);
+}
+
+function triageStatus({
+  destination,
+  reasons,
+}: Readonly<{
+  destination: Civ7ControlOrpcMapLocation | null;
+  reasons: readonly string[];
+}>): TriageStatus {
+  const hasCivilianRisk = reasons.some((reason) =>
+    reason.includes("civilian-risk")
+  );
+  const hasHighRouteRisk = reasons.some((reason) =>
+    reason.includes("high route") || reason.includes("high local")
+  );
+  if (destination == null) return "inspect-candidate";
+  if (hasCivilianRisk) return "hold-or-screen";
+  if (hasHighRouteRisk) return "reroute-or-stage";
+  return "proceed-with-validation";
+}
+
+function triageNextSteps({
+  origin,
+  destination,
+  status,
+}: Readonly<{
+  origin: Civ7ControlOrpcMapLocation | null;
+  destination: Civ7ControlOrpcMapLocation | null;
+  status: TriageStatus;
+}>): TriageNextStep[] {
+  const nextSteps: TriageNextStep[] = [{
+    kind: "read-priorities",
+    source: "strategy.civilianRouteTriage",
+    label: "Refresh current attention priorities before choosing a civilian action.",
+    parameters: {},
+  }];
+  if (origin != null) {
+    nextSteps.push({
+      kind: "inspect-battlefield",
+      source: "strategy.civilianRouteTriage",
+      label: "Inspect battlefield evidence at the civilian origin.",
+      parameters: { origin },
+    }, {
+      kind: "inspect-settlement",
+      source: "strategy.civilianRouteTriage",
+      label: "Inspect settlement recommendation evidence at the civilian origin.",
+      parameters: { origin },
+    });
+  }
+  if (origin != null && destination != null) {
+    nextSteps.push({
+      kind: "inspect-destination",
+      source: "strategy.civilianRouteTriage",
+      label: "Inspect route and destination evidence before moving.",
+      parameters: { origin, destination },
+    });
+  }
+  if (status === "hold-or-screen" || status === "reroute-or-stage") {
+    nextSteps.push({
+      kind: "inspect-front",
+      source: "strategy.civilianRouteTriage",
+      label: "Inspect the surrounding front before committing the civilian.",
+      parameters: { origin: origin ?? undefined, destination: destination ?? undefined },
+    });
+  }
+  nextSteps.push({
+    kind: "inspect-ready-unit",
+    source: "strategy.civilianRouteTriage",
+    label: "Re-read the ready unit before validating a route action.",
+    parameters: {},
+  }, {
+    kind: "validate-unit-action",
+    source: "strategy.civilianRouteTriage",
+    label: "Use unit action validation before any movement or target send.",
+    parameters: { destination: destination ?? undefined },
+  });
+  return nextSteps;
+}
+
+function destinationPressureReasons(
+  destinationAnalysis: Civ7ControlOrpcDestinationAnalysisResult | null,
+): string[] {
+  const pressure = asRecord(destinationAnalysis?.destinationPressure);
+  const reasons: string[] = [];
+  const unitCount = numericValue(pressure?.unitCount) ?? 0;
+  const cityCount = numericValue(pressure?.cityCount) ?? 0;
+  const apparentOtherStrength = numericValue(pressure?.apparentOtherStrength)
+    ?? 0;
+  if (unitCount > 0) {
+    reasons.push(`${unitCount} other-owner units near candidate destination`);
+  }
+  if (cityCount > 0) {
+    reasons.push(`${cityCount} relationship-unproven cities near candidate destination`);
+  }
+  if (apparentOtherStrength > 0) {
+    reasons.push(`apparent candidate contact ${apparentOtherStrength}`);
+  }
+  return reasons;
+}
+
+function firstSettlementSuggestion(
+  settlement: Civ7ControlOrpcSettlementRecommendationsResult,
+): Civ7ControlOrpcMapLocation | null {
+  for (const recommendation of settlement.recommendations) {
+    const suggestions = probeValue(recommendation.suggestions);
+    if (!Array.isArray(suggestions)) continue;
+    for (const suggestion of suggestions) {
+      const location = locationFromUnknown(asRecord(suggestion)?.location);
+      if (location != null) return location;
+    }
+  }
+  return null;
+}
+
+function readyUnitLocation(
+  readyUnit: Civ7ControlOrpcReadyUnitViewResult | null,
+): Civ7ControlOrpcMapLocation | null {
+  const unit = readyUnit == null ? null : probeValue(readyUnit.unit);
+  return locationFromUnknown(asRecord(unit)?.location);
+}
+
+function routeSummary(
+  origin: Civ7ControlOrpcMapLocation | null,
+  destination: Civ7ControlOrpcMapLocation | null,
+): string {
+  const originLabel = origin == null
+    ? "<unknown origin>"
+    : `(${origin.x},${origin.y})`;
+  const destinationLabel = destination == null
+    ? "<no candidate destination>"
+    : `(${destination.x},${destination.y})`;
+  return `civilian route ${originLabel} -> ${destinationLabel}`;
+}
+
+function normalizeRelationshipSummary(summary: string): string {
+  return summary
+    .replace(/\bfriendly\b/gi, "own")
+    .replace(/\bpressure\b/gi, "contact")
+    .replace(/\bthreat\b/gi, "contact");
+}
+
+function locationFromUnknown(value: unknown): Civ7ControlOrpcMapLocation | null {
+  const record = asRecord(value);
+  return typeof record?.x === "number" && typeof record.y === "number"
+    ? { x: record.x, y: record.y }
+    : null;
+}
+
+function probeValue<T>(
+  probe: { ok: true; value: T } | { ok: false; error: string } | null | undefined,
+): T | null {
+  return probe?.ok === true ? probe.value : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object"
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function numericValue(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function uniqueStrings(values: ReadonlyArray<string>): string[] {
+  return [...new Set(values.filter((value) => value.length > 0))];
+}

--- a/packages/civ7-control-orpc/src/modules/strategy/procedures/formation-snapshot.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/procedures/formation-snapshot.ts
@@ -1,0 +1,438 @@
+import { Effect } from "effect";
+
+import type {
+  Civ7ControlOrpcBattlefieldScanResult,
+  Civ7ControlOrpcPlayNotificationViewResult,
+  Civ7ControlOrpcReadyUnitViewResult,
+} from "../../../dependencies/direct-control";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import type {
+  Civ7ControlOrpcComponentId,
+  Civ7ControlOrpcMapLocation,
+} from "../../../model/primitives";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type {
+  Civ7StrategyFormationSnapshotInput,
+  Civ7StrategyFormationSnapshotResult,
+} from "../contract";
+
+type FormationPosture =
+  Civ7StrategyFormationSnapshotResult["formation"]["posture"];
+type FormationUnit =
+  Civ7StrategyFormationSnapshotResult["formation"]["civilians"][number];
+type FormationNextStep =
+  Civ7StrategyFormationSnapshotResult["nextSteps"][number];
+
+export const strategyFormationSnapshotProcedure =
+  civ7ControlOrpcImplementer.strategy.formationSnapshot.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const endpointDefaults = context.endpointDefaults;
+        const notifications = await context.directControl.getCiv7PlayNotificationView({
+          ...endpointDefaults,
+          maxNotifications: 10,
+        });
+        const readyUnitId = probeValue(notifications.firstReadyUnitId);
+        const requestedOrigin = input.origin ?? null;
+        const readyUnit = requestedOrigin != null || readyUnitId == null
+          ? null
+          : await context.directControl.getCiv7ReadyUnitView({
+            unitId: readyUnitId,
+            radius: 2,
+          }, endpointDefaults);
+        const origin = requestedOrigin ?? readyUnitLocation(readyUnit);
+        const battlefield = await context.directControl.getCiv7BattlefieldScan({
+          playerId: input.playerId,
+          origins: origin == null ? undefined : [origin],
+          radius: input.radius ?? 6,
+          maxUnits: input.maxUnits ?? 96,
+          maxCities: input.maxCities ?? 40,
+        }, endpointDefaults);
+
+        return formationSnapshotResult({
+          input,
+          notifications,
+          readyUnit,
+          battlefield,
+          origin,
+        });
+      },
+      catch: () =>
+        errors.STRATEGY_FORMATION_SNAPSHOT_UNAVAILABLE({
+          data: {
+            procedureKey: "strategy.formationSnapshot",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+function formationSnapshotResult({
+  input,
+  notifications,
+  readyUnit,
+  battlefield,
+  origin,
+}: Readonly<{
+  input: Civ7StrategyFormationSnapshotInput;
+  notifications: Civ7ControlOrpcPlayNotificationViewResult;
+  readyUnit: Civ7ControlOrpcReadyUnitViewResult | null;
+  battlefield: Civ7ControlOrpcBattlefieldScanResult;
+  origin: Civ7ControlOrpcMapLocation | null;
+}>): Civ7StrategyFormationSnapshotResult {
+  const units = asRecords(battlefield.units).map(toFormationUnit);
+  const civilians = units.filter((unit) =>
+    unit.stance === "own" && unit.role === "civilian"
+  );
+  const ownUnits = units.filter((unit) =>
+    unit.stance === "own" && unit.role !== "civilian"
+  );
+  const otherOwnerContacts = units.filter((unit) =>
+    unit.stance !== "own"
+  );
+  const screens = ownUnits.filter((unit) =>
+    civilians.some((civilian) =>
+      civilian.location != null && unit.location != null &&
+      gridDistance(civilian.location, unit.location) <=
+        (input.screenRadius ?? 2)
+    )
+  );
+  const nearbyContacts = otherOwnerContacts.filter((unit) =>
+    civilians.some((civilian) =>
+      civilian.location != null && unit.location != null &&
+      gridDistance(civilian.location, unit.location) <=
+        (input.contactRadius ?? 4)
+    )
+  );
+  const poiReasons = pointReasons(battlefield.pointsOfInterest);
+  const posture = postureFor({
+    civilians,
+    screens,
+    nearbyContacts,
+    poiReasons,
+    readyUnit,
+  });
+  const nextSteps = formationNextSteps({
+    origin,
+    civilians,
+    nearbyContacts,
+    posture,
+  });
+  const readyUnitValue = readyUnit == null
+    ? null
+    : probeValue(readyUnit.unit);
+
+  return {
+    playerId: battlefield.playerId,
+    localPlayerId: battlefield.localPlayerId,
+    turn: probeValue(notifications.turn),
+    turnDate: probeValue(notifications.turnDate),
+    blocker: numericValue(probeValue(notifications.blocker)),
+    nextDecision: stringValue(asRecord(notifications.hud)?.nextDecision),
+    origin,
+    sourceStatus: {
+      notifications: "read",
+      readyUnit: input.origin != null
+        ? "skipped-explicit-origin"
+        : readyUnit == null ? "skipped-no-ready-unit" : "read",
+      battlefieldScan: "read",
+    },
+    readyUnit: readyUnit == null
+      ? null
+      : {
+        unitId: readyUnit.unitId,
+        typeName: stringValue(asRecord(readyUnitValue)?.typeName),
+        location: locationFromUnknown(asRecord(readyUnitValue)?.location),
+        legalNoTargetOperationCount: readyUnit.legalOperations.length,
+      },
+    battlefield: {
+      originCount: battlefield.origins.length,
+      unitCount: units.length,
+      pointOfInterestCount: battlefield.pointsOfInterest.length,
+      hiddenInfoPolicy: battlefield.hiddenInfoPolicy,
+    },
+    formation: {
+      posture,
+      relationshipLabelPolicy: {
+        relationshipSource: "not-classified",
+        relationshipProof: "none",
+        unprovenLabel: "relationship-unproven",
+        guidance: "Formation snapshot treats owner mismatch and proximity as contact evidence only. Official diplomatic or team evidence is required for stronger labels.",
+      },
+      headline: formationHeadline({
+        origin,
+        readyUnit,
+        civilians,
+        screens,
+        nearbyContacts,
+      }),
+      reasons: uniqueStrings([
+        ...poiReasons,
+        ...civilianContactReasons(civilians, nearbyContacts),
+        ...screenReasons(civilians, screens),
+      ]).slice(0, 10),
+      civilians,
+      screens,
+      otherOwnerContacts,
+      nearbyContacts,
+      nextSteps,
+    },
+    notes: [
+      "Read-only formation snapshot. It does not move, attack, found, or reserve routes.",
+      "Use this lens to decide what to inspect next, then validate concrete plot actions with unit procedures.",
+      "Battlefield scan distances are cheap grid heuristics and may include debug-visible entities unless paired with visibility reads.",
+      "Relationship labels stay relationship-unproven unless official diplomatic evidence proves more.",
+    ],
+    nextSteps,
+  };
+}
+
+function postureFor(input: Readonly<{
+  civilians: readonly FormationUnit[];
+  screens: readonly FormationUnit[];
+  nearbyContacts: readonly FormationUnit[];
+  poiReasons: readonly string[];
+  readyUnit: Civ7ControlOrpcReadyUnitViewResult | null;
+}>): FormationPosture {
+  if (input.readyUnit == null) return "inspect-ready-unit";
+  if (input.civilians.length > 0 && input.nearbyContacts.length > 0) {
+    return "screen-civilian";
+  }
+  if (input.civilians.length > 0 && input.screens.length === 0) {
+    return "hold-ready-unit";
+  }
+  if (
+    input.poiReasons.some((reason) =>
+      reason.includes("nearby-other-owners") ||
+      reason.includes("owner-contact")
+    )
+  ) {
+    return "stabilize-front";
+  }
+  return "advance-with-validation";
+}
+
+function formationNextSteps({
+  origin,
+  civilians,
+  nearbyContacts,
+  posture,
+}: Readonly<{
+  origin: Civ7ControlOrpcMapLocation | null;
+  civilians: readonly FormationUnit[];
+  nearbyContacts: readonly FormationUnit[];
+  posture: FormationPosture;
+}>): FormationNextStep[] {
+  const nextSteps: FormationNextStep[] = [{
+    kind: "read-priorities",
+    source: "strategy.formationSnapshot",
+    label: "Refresh current attention priorities before choosing a formation action.",
+    parameters: {},
+  }, {
+    kind: "inspect-ready-unit",
+    source: "strategy.formationSnapshot",
+    label: "Re-read the ready unit before validating a concrete action.",
+    parameters: {},
+  }];
+  if (origin != null) {
+    nextSteps.push({
+      kind: "inspect-battlefield",
+      source: "strategy.formationSnapshot",
+      label: "Inspect bounded battlefield evidence around the formation origin.",
+      parameters: { origin },
+    });
+  }
+  const civilian = civilians.find((unit) => unit.location != null);
+  if (civilian?.location != null) {
+    nextSteps.push({
+      kind: "inspect-civilian-route",
+      source: "strategy.formationSnapshot",
+      label: "Inspect route options for the civilian before moving.",
+      parameters: { civilian: civilian.location },
+    });
+  }
+  const contact = nearbyContacts.find((unit) => unit.location != null);
+  if (contact?.location != null) {
+    nextSteps.push({
+      kind: "inspect-battlefield",
+      source: "strategy.formationSnapshot",
+      label: "Inspect battlefield evidence around nearby other-owner contact.",
+      parameters: { contact: contact.location },
+    });
+  }
+  nextSteps.push({
+    kind: "validate-unit-action",
+    source: "strategy.formationSnapshot",
+    label: posture === "screen-civilian" || posture === "stabilize-front"
+      ? "Validate a screen or contact action before any unit send."
+      : "Validate a concrete unit action before any unit send.",
+    parameters: {},
+  });
+  return uniqueNextSteps(nextSteps);
+}
+
+function toFormationUnit(unit: Record<string, unknown>): FormationUnit {
+  return {
+    id: componentIdFromUnknown(unit.id),
+    owner: numericValue(unit.owner),
+    stance: formationStance(unit.stance),
+    role: typeof unit.role === "string" ? unit.role : "unknown",
+    typeName: stringValue(unit.typeName),
+    location: locationFromUnknown(unit.location),
+    distance: numericValue(unit.distance),
+  };
+}
+
+function formationHeadline({
+  origin,
+  readyUnit,
+  civilians,
+  screens,
+  nearbyContacts,
+}: Readonly<{
+  origin: Civ7ControlOrpcMapLocation | null;
+  readyUnit: Civ7ControlOrpcReadyUnitViewResult | null;
+  civilians: readonly FormationUnit[];
+  screens: readonly FormationUnit[];
+  nearbyContacts: readonly FormationUnit[];
+}>): string {
+  const originLabel = origin == null
+    ? "<unknown origin>"
+    : `(${origin.x},${origin.y})`;
+  return `${readyUnitSummary(readyUnit)} formation at ${originLabel}: ${civilians.length} civilians, ${screens.length} local screens, ${nearbyContacts.length} nearby other-owner contacts`;
+}
+
+function readyUnitSummary(
+  readyUnit: Civ7ControlOrpcReadyUnitViewResult | null,
+): string {
+  const unit = readyUnit == null ? null : probeValue(readyUnit.unit);
+  return stringValue(asRecord(unit)?.typeName) ?? "ready unit";
+}
+
+function pointReasons(value: unknown): string[] {
+  return asRecords(value).map((point) => {
+    const severity = String(point.severity ?? "medium");
+    const kind = String(point.kind ?? "point-of-interest");
+    const summary = String(point.summary ?? kind);
+    return normalizeRelationshipSummary(`${severity} ${kind}: ${summary}`);
+  });
+}
+
+function civilianContactReasons(
+  civilians: readonly FormationUnit[],
+  nearbyContacts: readonly FormationUnit[],
+): string[] {
+  if (civilians.length === 0 || nearbyContacts.length === 0) return [];
+  return civilians.map((civilian) => {
+    const location = civilian.location == null
+      ? "<unknown>"
+      : `(${civilian.location.x},${civilian.location.y})`;
+    return `${civilian.typeName ?? "civilian"} at ${location} has ${nearbyContacts.length} other-owner units within contact radius`;
+  });
+}
+
+function screenReasons(
+  civilians: readonly FormationUnit[],
+  screens: readonly FormationUnit[],
+): string[] {
+  if (civilians.length === 0) return [];
+  if (screens.length === 0) {
+    return ["no own screen units are within local screen radius of the civilian"];
+  }
+  return [`${screens.length} own screen units are within local screen radius of the civilian`];
+}
+
+function readyUnitLocation(
+  readyUnit: Civ7ControlOrpcReadyUnitViewResult | null,
+): Civ7ControlOrpcMapLocation | null {
+  const unit = readyUnit == null ? null : probeValue(readyUnit.unit);
+  return locationFromUnknown(asRecord(unit)?.location);
+}
+
+function componentIdFromUnknown(
+  value: unknown,
+): Civ7ControlOrpcComponentId | null {
+  const record = asRecord(value);
+  return typeof record?.owner === "number" &&
+      typeof record.id === "number" &&
+      typeof record.type === "number"
+    ? { owner: record.owner, id: record.id, type: record.type }
+    : null;
+}
+
+function locationFromUnknown(value: unknown): Civ7ControlOrpcMapLocation | null {
+  const record = asRecord(value);
+  return typeof record?.x === "number" && typeof record.y === "number"
+    ? { x: record.x, y: record.y }
+    : null;
+}
+
+function gridDistance(
+  left: Civ7ControlOrpcMapLocation,
+  right: Civ7ControlOrpcMapLocation,
+): number {
+  return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
+}
+
+function probeValue<T>(
+  probe: { ok: true; value: T } | { ok: false; error: string } | null | undefined,
+): T | null {
+  return probe?.ok === true ? probe.value : null;
+}
+
+function asRecords(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> =>
+      item !== null && typeof item === "object"
+    )
+    : [];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object"
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function numericValue(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function normalizeRelationshipSummary(summary: string): string {
+  return summary
+    .replace(/\bfriendly\b/gi, "own")
+    .replace(/\bpressure\b/gi, "contact")
+    .replace(/\bthreat\b/gi, "contact");
+}
+
+function formationStance(value: unknown): string {
+  if (value === "friendly") return "own";
+  return typeof value === "string" ? value : "unknown";
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return [...new Set(values.filter((value) => value.length > 0))];
+}
+
+function uniqueNextSteps(
+  values: readonly FormationNextStep[],
+): FormationNextStep[] {
+  const seen = new Set<string>();
+  const nextSteps: FormationNextStep[] = [];
+  for (const value of values) {
+    const key = JSON.stringify([value.kind, value.parameters]);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    nextSteps.push(value);
+  }
+  return nextSteps;
+}

--- a/packages/civ7-control-orpc/src/modules/strategy/procedures/front-summary.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/procedures/front-summary.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect";
 import type {
   Civ7ControlOrpcDirectControlFacade,
   Civ7ControlOrpcBattlefieldScanResult,
+  Civ7ControlOrpcDestinationAnalysisResult,
   Civ7ControlOrpcTargetCandidatesResult,
 } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
@@ -18,6 +19,11 @@ type Civ7StrategyTargetCandidatesInput = NonNullable<
 type Civ7StrategyBattlefieldScanInput = NonNullable<
   Parameters<Civ7ControlOrpcDirectControlFacade["getCiv7BattlefieldScan"]>[0]
 >;
+type Civ7StrategyDestinationAnalysisInput = Parameters<
+  Civ7ControlOrpcDirectControlFacade["getCiv7DestinationAnalysis"]
+>[0];
+type Civ7StrategyPointOfInterest =
+  Civ7StrategyFrontSummaryResult["pointsOfInterest"][number];
 
 export const strategyFrontSummaryProcedure =
   civ7ControlOrpcImplementer.strategy.frontSummary.effect(function* ({
@@ -39,11 +45,25 @@ export const strategyFrontSummaryProcedure =
             context.endpointDefaults,
           ),
         ]);
+        const target = input.target ??
+          firstCandidateCityLocation(targetCandidates.candidates);
+        const destinationAnalysis = target == null
+          ? null
+          : await context.directControl.getCiv7DestinationAnalysis(
+            destinationAnalysisInput({
+              input,
+              target,
+              origin: targetCandidates.origins[0] ?? battlefieldScan.origins[0],
+            }),
+            context.endpointDefaults,
+          );
 
         return strategyFrontSummaryResult({
           input,
           targetCandidates,
           battlefieldScan,
+          destinationAnalysis,
+          target,
         });
       },
       catch: () =>
@@ -77,18 +97,43 @@ function battlefieldScanInput(
     origins: input.origins,
     radius: input.scanRadius ?? 8,
     maxPlayers: input.maxPlayers,
-    maxUnits: 48,
-    maxCities: 24,
+    maxUnits: input.maxUnits ?? 48,
+    maxCities: input.maxCities ?? 24,
+  };
+}
+
+function destinationAnalysisInput({
+  input,
+  target,
+  origin,
+}: Readonly<{
+  input: Civ7StrategyFrontSummaryInput;
+  target: NonNullable<Civ7StrategyFrontSummaryResult["target"]>;
+  origin: Civ7StrategyFrontSummaryResult["origins"][number] | undefined;
+}>): Civ7StrategyDestinationAnalysisInput {
+  return {
+    playerId: input.playerId,
+    origin,
+    destination: target,
+    corridorRadius: input.corridorRadius ?? 2,
+    destinationRadius: input.destinationRadius ?? 4,
+    maxPlayers: input.maxPlayers,
+    maxUnits: input.maxUnits,
+    maxCities: input.maxCities,
   };
 }
 
 function strategyFrontSummaryResult({
   targetCandidates,
   battlefieldScan,
+  destinationAnalysis,
+  target,
 }: Readonly<{
   input: Civ7StrategyFrontSummaryInput;
   targetCandidates: Civ7ControlOrpcTargetCandidatesResult;
   battlefieldScan: Civ7ControlOrpcBattlefieldScanResult;
+  destinationAnalysis: Civ7ControlOrpcDestinationAnalysisResult | null;
+  target: Civ7StrategyFrontSummaryResult["target"];
 }>): Civ7StrategyFrontSummaryResult {
   const targetCandidateSummaries = targetCandidates.candidates.map(
     (candidate) => ({
@@ -105,12 +150,22 @@ function strategyFrontSummaryResult({
       reasons: [...candidate.reasons],
     }),
   );
-  const pointsOfInterest = battlefieldScan.pointsOfInterest.map((point) => ({
-    kind: point.kind,
-    severity: point.severity,
-    location: point.location,
-    summary: normalizeRelationshipSummary(point.summary),
-  }));
+  const pointsOfInterest = [
+    ...battlefieldScan.pointsOfInterest.map((point) => ({
+      kind: point.kind,
+      severity: point.severity,
+      location: point.location,
+      summary: normalizeRelationshipSummary(point.summary),
+      source: "battlefield" as const,
+    })),
+    ...(destinationAnalysis?.pointsOfInterest.map((point) => ({
+      kind: point.kind,
+      severity: point.severity,
+      location: point.location,
+      summary: normalizeRelationshipSummary(point.summary),
+      source: "destination" as const,
+    })) ?? []),
+  ];
   const observedOwners = battlefieldScan.owners.map((owner) => ({
     owner: owner.owner,
     relationship: owner.relationshipProof === "self"
@@ -128,6 +183,16 @@ function strategyFrontSummaryResult({
     targetCandidates: targetCandidateSummaries,
     pointsOfInterest,
   });
+  const front = strategyFrontView({
+    origins: targetCandidates.origins.length > 0
+      ? targetCandidates.origins
+      : battlefieldScan.origins,
+    target,
+    targetCandidates: targetCandidateSummaries,
+    pointsOfInterest,
+    destinationAnalysis,
+    nextSteps,
+  });
 
   return {
     playerId: targetCandidates.playerId,
@@ -135,9 +200,13 @@ function strategyFrontSummaryResult({
     origins: targetCandidates.origins.length > 0
       ? targetCandidates.origins
       : battlefieldScan.origins,
+    target,
     sourceStatus: {
       targetCandidates: "read",
       battlefieldScan: "read",
+      destinationAnalysis: destinationAnalysis == null
+        ? "skipped-no-target"
+        : "read",
     },
     relationshipLabelPolicy: {
       relationshipSource: "not-classified",
@@ -151,6 +220,7 @@ function strategyFrontSummaryResult({
       observedOwnerCount: observedOwners.length,
       nextStepCount: nextSteps.length,
     },
+    front,
     targetCandidates: targetCandidateSummaries,
     pointsOfInterest,
     observedOwners,
@@ -185,7 +255,7 @@ function strategyNextSteps({
   pointsOfInterest,
 }: Readonly<{
   targetCandidates: Civ7StrategyFrontSummaryResult["targetCandidates"];
-  pointsOfInterest: Civ7StrategyFrontSummaryResult["pointsOfInterest"];
+  pointsOfInterest: readonly Civ7StrategyPointOfInterest[];
 }>): Civ7StrategyFrontSummaryResult["nextSteps"] {
   const nextSteps: Civ7StrategyFrontSummaryResult["nextSteps"] = [];
   const candidate = targetCandidates[0];
@@ -230,9 +300,141 @@ function strategyNextSteps({
   return nextSteps;
 }
 
+function strategyFrontView({
+  origins,
+  target,
+  targetCandidates,
+  pointsOfInterest,
+  destinationAnalysis,
+  nextSteps,
+}: Readonly<{
+  origins: Civ7StrategyFrontSummaryResult["origins"];
+  target: Civ7StrategyFrontSummaryResult["target"];
+  targetCandidates: Civ7StrategyFrontSummaryResult["targetCandidates"];
+  pointsOfInterest: readonly Civ7StrategyPointOfInterest[];
+  destinationAnalysis: Civ7ControlOrpcDestinationAnalysisResult | null;
+  nextSteps: Civ7StrategyFrontSummaryResult["nextSteps"];
+}>): Civ7StrategyFrontSummaryResult["front"] {
+  const pressure = [...pointsOfInterest]
+    .map((point) => ({
+      kind: point.kind,
+      severity: point.severity,
+      summary: point.summary,
+      location: point.location,
+      source: point.source,
+    }))
+    .sort((a, b) => severityRank(b.severity) - severityRank(a.severity));
+  const highPressure = pressure.filter((item) => item.severity === "high");
+  const risks = uniqueStrings([
+    ...highPressure.map((item) => item.summary),
+    ...destinationRisks(destinationAnalysis),
+  ]).slice(0, 8);
+  const origin = origins[0] ?? null;
+  const candidate = targetCandidates[0];
+  const targetLabel = target
+    ? `target/front (${target.x},${target.y})`
+    : "no target/front selected";
+  const originLabel = origin
+    ? `origin (${origin.x},${origin.y})`
+    : "inferred runtime origins";
+  const candidateLabel = candidate
+    ? `owner ${candidate.owner}`
+    : "no ranked target candidate";
+
+  return {
+    posture: postureFromPressure(pressure, destinationAnalysis),
+    headline: `${originLabel} toward ${targetLabel}; leading candidate: ${candidateLabel}`,
+    risks,
+    nextInspections: nextSteps,
+    pressure,
+  };
+}
+
+function destinationRisks(
+  destinationAnalysis: Civ7ControlOrpcDestinationAnalysisResult | null,
+): string[] {
+  const pressure = asRecord(destinationAnalysis?.destinationPressure);
+  const risks: string[] = [];
+  const unitCount = Number(pressure?.unitCount ?? 0);
+  const cityCount = Number(pressure?.cityCount ?? 0);
+  const apparentOtherStrength = Number(pressure?.apparentOtherStrength ?? 0);
+  if (unitCount > 0) {
+    risks.push(`${unitCount} other-owner units near intended front`);
+  }
+  if (cityCount > 0) {
+    risks.push(`${cityCount} relationship-unproven cities near intended front`);
+  }
+  if (apparentOtherStrength > 0) {
+    risks.push(`apparent destination contact ${apparentOtherStrength}`);
+  }
+  return risks;
+}
+
+function postureFromPressure(
+  pressure: ReadonlyArray<Civ7StrategyFrontSummaryResult["front"]["pressure"][number]>,
+  destinationAnalysis: Civ7ControlOrpcDestinationAnalysisResult | null,
+): string {
+  if (
+    pressure.some((item) =>
+      item.kind === "civilian-risk" && item.severity === "high"
+    )
+  ) return "screen-civilians-before-advance";
+  if (
+    pressure.some((item) =>
+      item.kind === "nearby-other-owners" && item.severity === "high"
+    )
+  ) return "stabilize-front-before-committing-siege";
+  const destinationPressure = asRecord(destinationAnalysis?.destinationPressure);
+  if (
+    Number(destinationPressure?.unitCount ?? 0) > 0 ||
+    Number(destinationPressure?.cityCount ?? 0) > 0
+  ) {
+    return "stage-before-entering-target-contact";
+  }
+  return "inspect-and-advance-cautiously";
+}
+
+function severityRank(severity: string): number {
+  if (severity === "high") return 3;
+  if (severity === "medium") return 2;
+  if (severity === "low") return 1;
+  return 0;
+}
+
 function normalizeRelationshipSummary(summary: string): string {
   return summary
     .replace(/\bfriendly\b/gi, "own")
     .replace(/\bpressure\b/gi, "contact")
     .replace(/\bthreat\b/gi, "contact");
+}
+
+function firstCandidateCityLocation(
+  candidates: ReadonlyArray<Civ7ControlOrpcTargetCandidatesResult["candidates"][number]>,
+): Civ7StrategyFrontSummaryResult["target"] {
+  for (const candidate of candidates) {
+    if (candidate.approach.targetLocation != null) {
+      return candidate.approach.targetLocation;
+    }
+    const cityLocation = locationFromUnknown(candidate.nearestCity);
+    if (cityLocation != null) return cityLocation;
+  }
+  return null;
+}
+
+function locationFromUnknown(value: unknown): Civ7StrategyFrontSummaryResult["target"] {
+  const record = asRecord(value);
+  const location = asRecord(record?.location);
+  return typeof location?.x === "number" && typeof location.y === "number"
+    ? { x: location.x, y: location.y }
+    : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object"
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function uniqueStrings(values: ReadonlyArray<string>): string[] {
+  return [...new Set(values.filter((value) => value.length > 0))];
 }

--- a/packages/civ7-control-orpc/src/modules/strategy/router.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/router.ts
@@ -1,7 +1,9 @@
 import { strategyCivilianRouteTriageProcedure } from "./procedures/civilian-route-triage";
+import { strategyFormationSnapshotProcedure } from "./procedures/formation-snapshot";
 import { strategyFrontSummaryProcedure } from "./procedures/front-summary";
 
 export const strategyRouter = {
   civilianRouteTriage: strategyCivilianRouteTriageProcedure,
+  formationSnapshot: strategyFormationSnapshotProcedure,
   frontSummary: strategyFrontSummaryProcedure,
 };

--- a/packages/civ7-control-orpc/src/modules/strategy/router.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/router.ts
@@ -1,5 +1,7 @@
+import { strategyCivilianRouteTriageProcedure } from "./procedures/civilian-route-triage";
 import { strategyFrontSummaryProcedure } from "./procedures/front-summary";
 
 export const strategyRouter = {
+  civilianRouteTriage: strategyCivilianRouteTriageProcedure,
   frontSummary: strategyFrontSummaryProcedure,
 };

--- a/packages/civ7-control-orpc/src/modules/world/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/world/contract.ts
@@ -1,0 +1,142 @@
+import type { ContractProcedure } from "@orpc/contract";
+import { Type, type Static } from "typebox";
+
+import { civ7ControlOrpcContractBase } from "../../contract-base";
+import type { Civ7ControlOrpcErrorMap } from "../../errors";
+import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
+import { toStandardSchema } from "../../typebox-standard-schema";
+
+const NullableNumberSchema = Type.Union([Type.Number(), Type.Null()]);
+const NullableIntegerSchema = Type.Union([Type.Integer(), Type.Null()]);
+
+const Civ7WorldCurrentInputSchema = Type.Object(
+  {},
+  { additionalProperties: false },
+);
+export type Civ7WorldCurrentInput = Static<typeof Civ7WorldCurrentInputSchema>;
+
+const Civ7WorldCurrentSourceStatusSchema = Type.Union([
+  Type.Literal("read"),
+  Type.Literal("skipped-not-playable"),
+  Type.Literal("skipped-unavailable"),
+]);
+
+const Civ7WorldCurrentTurnSchema = Type.Object(
+  {
+    current: NullableNumberSchema,
+    date: Type.Union([Type.String(), Type.Null()]),
+    age: NullableNumberSchema,
+    maxTurns: NullableNumberSchema,
+    hash: NullableNumberSchema,
+  },
+  { additionalProperties: false },
+);
+
+const Civ7WorldCurrentLocalPlayerSchema = Type.Object(
+  {
+    playerId: NullableIntegerSchema,
+    observerId: NullableIntegerSchema,
+  },
+  { additionalProperties: false },
+);
+
+const Civ7WorldCurrentMapSchema = Type.Object(
+  {
+    width: NullableNumberSchema,
+    height: NullableNumberSchema,
+    plotCount: NullableNumberSchema,
+    mapSize: NullableNumberSchema,
+    randomSeed: NullableNumberSchema,
+  },
+  { additionalProperties: false },
+);
+
+const Civ7WorldCurrentPlayersSchema = Type.Object(
+  {
+    maxPlayers: NullableNumberSchema,
+    alivePlayerIds: Type.Array(Type.Integer({ minimum: 0 })),
+    aliveHumanIds: Type.Array(Type.Integer({ minimum: 0 })),
+    aliveHumanCount: NullableNumberSchema,
+  },
+  { additionalProperties: false },
+);
+
+const Civ7WorldCurrentNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("read-attention"),
+      Type.Literal("restore-readiness"),
+      Type.Literal("enter-game"),
+      Type.Literal("inspect-world"),
+    ]),
+    source: Type.Literal("world.current"),
+    label: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7WorldCurrentResultSchema = Type.Object(
+  {
+    playable: Type.Boolean(),
+    readiness: Type.String(),
+    sourceStatus: Type.Object(
+      {
+        playableStatus: Type.Literal("read"),
+        game: Civ7WorldCurrentSourceStatusSchema,
+        map: Civ7WorldCurrentSourceStatusSchema,
+        players: Civ7WorldCurrentSourceStatusSchema,
+      },
+      { additionalProperties: false },
+    ),
+    turn: Civ7WorldCurrentTurnSchema,
+    localPlayer: Civ7WorldCurrentLocalPlayerSchema,
+    map: Civ7WorldCurrentMapSchema,
+    players: Civ7WorldCurrentPlayersSchema,
+    summary: Type.Object(
+      {
+        hasMapDimensions: Type.Boolean(),
+        alivePlayerCount: NullableIntegerSchema,
+        nextStepCount: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    ),
+    nextSteps: Type.Array(Civ7WorldCurrentNextStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7WorldCurrentResult = Static<
+  typeof Civ7WorldCurrentResultSchema
+>;
+
+const Civ7WorldCurrentInputStandardSchema = toStandardSchema(
+  Civ7WorldCurrentInputSchema,
+);
+const Civ7WorldCurrentResultStandardSchema = toStandardSchema(
+  Civ7WorldCurrentResultSchema,
+);
+
+export type Civ7WorldCurrentContract = ContractProcedure<
+  typeof Civ7WorldCurrentInputStandardSchema,
+  typeof Civ7WorldCurrentResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export const Civ7WorldCurrentContract: Civ7WorldCurrentContract =
+  civ7ControlOrpcContractBase
+    .input(Civ7WorldCurrentInputStandardSchema)
+    .output(Civ7WorldCurrentResultStandardSchema)
+    .meta({
+      family: "world",
+      procedureKey: "world.current",
+      proofBoundary: "local-package-test",
+      risk: "read-only",
+    });
+
+export type Civ7WorldContract = Readonly<{
+  current: Civ7WorldCurrentContract;
+}>;
+
+export const Civ7WorldContract: Civ7WorldContract = {
+  current: Civ7WorldCurrentContract,
+};

--- a/packages/civ7-control-orpc/src/modules/world/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/world/contract.ts
@@ -4,6 +4,7 @@ import { Type, type Static } from "typebox";
 import { civ7ControlOrpcContractBase } from "../../contract-base";
 import type { Civ7ControlOrpcErrorMap } from "../../errors";
 import type { Civ7ControlOrpcProcedureMeta } from "../../metadata";
+import { Civ7ControlOrpcMapLocationSchema } from "../../model/primitives";
 import { toStandardSchema } from "../../typebox-standard-schema";
 
 const NullableNumberSchema = Type.Union([Type.Number(), Type.Null()]);
@@ -115,9 +116,207 @@ const Civ7WorldCurrentResultStandardSchema = toStandardSchema(
   Civ7WorldCurrentResultSchema,
 );
 
+const Civ7WorldPlotFieldSchema = Type.Union([
+  Type.Literal("terrain"),
+  Type.Literal("biome"),
+  Type.Literal("feature"),
+  Type.Literal("resource"),
+  Type.Literal("climate"),
+  Type.Literal("hydrology"),
+  Type.Literal("yields"),
+  Type.Literal("owner"),
+  Type.Literal("visibility"),
+  Type.Literal("areaRegion"),
+  Type.Literal("tags"),
+  Type.Literal("city"),
+  Type.Literal("units"),
+]);
+export type Civ7WorldPlotField = Static<typeof Civ7WorldPlotFieldSchema>;
+
+const Civ7WorldHiddenInfoPolicySchema = Type.Union([
+  Type.Literal("include-hidden"),
+  Type.Literal("visibility-filtered"),
+  Type.Literal("not-player-scoped"),
+]);
+
+const Civ7WorldProbeSchema = Type.Union([
+  Type.Object(
+    {
+      ok: Type.Literal(true),
+      value: Type.Unknown(),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      ok: Type.Literal(false),
+      error: Type.String(),
+    },
+    { additionalProperties: false },
+  ),
+]);
+
+const Civ7WorldPlotReadInputSchema = Type.Object(
+  {
+    location: Civ7ControlOrpcMapLocationSchema,
+    playerId: Type.Optional(Type.Integer({ minimum: 0 })),
+    fields: Type.Optional(Type.Array(Civ7WorldPlotFieldSchema)),
+    includeHidden: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);
+export type Civ7WorldPlotReadInput = Static<
+  typeof Civ7WorldPlotReadInputSchema
+>;
+
+const Civ7WorldPlotSnapshotSchema = Type.Object(
+  {
+    location: Type.Object(
+      {
+        x: Type.Integer({ minimum: 0, maximum: 1_000_000 }),
+        y: Type.Integer({ minimum: 0, maximum: 1_000_000 }),
+        index: NullableNumberSchema,
+      },
+      { additionalProperties: false },
+    ),
+    visibility: Type.Object(
+      {
+        revealedState: Type.Optional(Civ7WorldProbeSchema),
+        visible: Type.Optional(Civ7WorldProbeSchema),
+      },
+      { additionalProperties: false },
+    ),
+    hiddenInfoPolicy: Civ7WorldHiddenInfoPolicySchema,
+    facts: Type.Record(Type.String(), Civ7WorldProbeSchema),
+    summary: Type.Object(
+      {
+        factCount: Type.Integer({ minimum: 0 }),
+        probeErrorCount: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+export type Civ7WorldPlotSnapshot = Static<typeof Civ7WorldPlotSnapshotSchema>;
+
+const Civ7WorldPlotReadResultSchema = Type.Object(
+  {
+    sourceStatus: Type.Object(
+      {
+        plot: Type.Union([
+          Type.Literal("read"),
+          Type.Literal("read-with-probe-errors"),
+          Type.Literal("invalid-location"),
+        ]),
+      },
+      { additionalProperties: false },
+    ),
+    plot: Civ7WorldPlotSnapshotSchema,
+  },
+  { additionalProperties: false },
+);
+export type Civ7WorldPlotReadResult = Static<
+  typeof Civ7WorldPlotReadResultSchema
+>;
+
+const Civ7WorldMapBoundsSchema = Type.Object(
+  {
+    x: Type.Integer({ minimum: 0, maximum: 1_000_000 }),
+    y: Type.Integer({ minimum: 0, maximum: 1_000_000 }),
+    width: Type.Integer({ minimum: 1, maximum: 10_000 }),
+    height: Type.Integer({ minimum: 1, maximum: 10_000 }),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7WorldGridReadInputSchema = Type.Object(
+  {
+    bounds: Civ7WorldMapBoundsSchema,
+    fields: Type.Array(Civ7WorldPlotFieldSchema),
+    playerId: Type.Optional(Type.Integer({ minimum: 0 })),
+    includeHidden: Type.Optional(Type.Boolean()),
+    maxPlots: Type.Optional(Type.Integer({ minimum: 1, maximum: 10_000 })),
+  },
+  { additionalProperties: false },
+);
+export type Civ7WorldGridReadInput = Static<
+  typeof Civ7WorldGridReadInputSchema
+>;
+
+const Civ7WorldGridReadResultSchema = Type.Object(
+  {
+    sourceStatus: Type.Object(
+      {
+        grid: Type.Union([
+          Type.Literal("read"),
+          Type.Literal("read-with-omissions"),
+          Type.Literal("read-with-probe-errors"),
+        ]),
+        map: Type.Union([
+          Type.Literal("read"),
+          Type.Literal("skipped-unavailable"),
+        ]),
+      },
+      { additionalProperties: false },
+    ),
+    bounds: Civ7WorldMapBoundsSchema,
+    fields: Type.Array(Civ7WorldPlotFieldSchema),
+    plotCount: Type.Integer({ minimum: 0 }),
+    omitted: Type.Integer({ minimum: 0 }),
+    hiddenInfoPolicy: Civ7WorldHiddenInfoPolicySchema,
+    map: Type.Object(
+      {
+        width: NullableNumberSchema,
+        height: NullableNumberSchema,
+      },
+      { additionalProperties: false },
+    ),
+    plots: Type.Array(Civ7WorldPlotSnapshotSchema),
+    summary: Type.Object(
+      {
+        returnedPlotCount: Type.Integer({ minimum: 0 }),
+        probeErrorCount: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+export type Civ7WorldGridReadResult = Static<
+  typeof Civ7WorldGridReadResultSchema
+>;
+
+const Civ7WorldPlotReadInputStandardSchema = toStandardSchema(
+  Civ7WorldPlotReadInputSchema,
+);
+const Civ7WorldPlotReadResultStandardSchema = toStandardSchema(
+  Civ7WorldPlotReadResultSchema,
+);
+const Civ7WorldGridReadInputStandardSchema = toStandardSchema(
+  Civ7WorldGridReadInputSchema,
+);
+const Civ7WorldGridReadResultStandardSchema = toStandardSchema(
+  Civ7WorldGridReadResultSchema,
+);
+
 export type Civ7WorldCurrentContract = ContractProcedure<
   typeof Civ7WorldCurrentInputStandardSchema,
   typeof Civ7WorldCurrentResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export type Civ7WorldPlotReadContract = ContractProcedure<
+  typeof Civ7WorldPlotReadInputStandardSchema,
+  typeof Civ7WorldPlotReadResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export type Civ7WorldGridReadContract = ContractProcedure<
+  typeof Civ7WorldGridReadInputStandardSchema,
+  typeof Civ7WorldGridReadResultStandardSchema,
   Civ7ControlOrpcErrorMap,
   Civ7ControlOrpcProcedureMeta
 >;
@@ -133,10 +332,36 @@ export const Civ7WorldCurrentContract: Civ7WorldCurrentContract =
       risk: "read-only",
     });
 
+export const Civ7WorldPlotReadContract: Civ7WorldPlotReadContract =
+  civ7ControlOrpcContractBase
+    .input(Civ7WorldPlotReadInputStandardSchema)
+    .output(Civ7WorldPlotReadResultStandardSchema)
+    .meta({
+      family: "world",
+      procedureKey: "world.plot.read",
+      proofBoundary: "local-package-test",
+      risk: "read-only",
+    });
+
+export const Civ7WorldGridReadContract: Civ7WorldGridReadContract =
+  civ7ControlOrpcContractBase
+    .input(Civ7WorldGridReadInputStandardSchema)
+    .output(Civ7WorldGridReadResultStandardSchema)
+    .meta({
+      family: "world",
+      procedureKey: "world.grid.read",
+      proofBoundary: "local-package-test",
+      risk: "read-only",
+    });
+
 export type Civ7WorldContract = Readonly<{
   current: Civ7WorldCurrentContract;
+  plot: Civ7WorldPlotReadContract;
+  grid: Civ7WorldGridReadContract;
 }>;
 
 export const Civ7WorldContract: Civ7WorldContract = {
   current: Civ7WorldCurrentContract,
+  plot: Civ7WorldPlotReadContract,
+  grid: Civ7WorldGridReadContract,
 };

--- a/packages/civ7-control-orpc/src/modules/world/procedures/current.ts
+++ b/packages/civ7-control-orpc/src/modules/world/procedures/current.ts
@@ -1,0 +1,202 @@
+import type { Civ7RuntimeProbe } from "@civ7/direct-control";
+import { Effect } from "effect";
+
+import type { Civ7ControlOrpcContext } from "../../../context";
+import type { Civ7ControlOrpcPlayableStatusResult } from "../../../dependencies/direct-control";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type { Civ7WorldCurrentResult } from "../contract";
+
+export const worldCurrentProcedure =
+  civ7ControlOrpcImplementer.world.current.effect(function* ({
+    context,
+    errors,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () =>
+        worldCurrentResult(
+          await context.directControl.getCiv7PlayableStatus(
+            context.endpointDefaults,
+          ),
+        ),
+      catch: () =>
+        errors.WORLD_CURRENT_UNAVAILABLE({
+          data: {
+            procedureKey: "world.current",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+function worldCurrentResult(
+  status: Civ7ControlOrpcPlayableStatusResult,
+): Civ7WorldCurrentResult {
+  const inGame = status.playable || status.readiness === "app-ui-game";
+  const snapshot = status.appUi.snapshot;
+  const map = inGame ? worldMapFacts(status) : emptyMapFacts();
+  const players = inGame ? worldPlayerFacts(status) : emptyPlayerFacts();
+  const nextSteps = worldCurrentNextSteps(status, map);
+
+  return {
+    playable: status.playable,
+    readiness: status.readiness,
+    sourceStatus: {
+      playableStatus: "read",
+      game: inGame ? "read" : "skipped-not-playable",
+      map: inGame ? mapSourceStatus(snapshot.map) : "skipped-not-playable",
+      players: inGame
+        ? playersSourceStatus(snapshot.players)
+        : "skipped-not-playable",
+    },
+    turn: inGame
+      ? {
+          current: status.appUi.snapshot.game.turn,
+          date: probeValue(status.appUi.snapshot.game.turnDate),
+          age: status.appUi.snapshot.game.age,
+          maxTurns: status.appUi.snapshot.game.maxTurns,
+          hash: probeValue(status.appUi.snapshot.game.hash),
+        }
+      : {
+          current: null,
+          date: null,
+          age: null,
+          maxTurns: null,
+          hash: null,
+        },
+    localPlayer: inGame
+      ? {
+          playerId: playerIdOrNull(status.appUi.snapshot.gameContext.localPlayerID),
+          observerId: playerIdOrNull(
+            status.appUi.snapshot.gameContext.localObserverID,
+          ),
+        }
+      : {
+          playerId: null,
+          observerId: null,
+        },
+    map,
+    players,
+    summary: {
+      hasMapDimensions: map.width != null && map.height != null
+        && map.width > 0 && map.height > 0,
+      alivePlayerCount: players.alivePlayerIds.length,
+      nextStepCount: nextSteps.length,
+    },
+    nextSteps,
+  };
+}
+
+function worldMapFacts(
+  status: Civ7ControlOrpcPlayableStatusResult,
+): Civ7WorldCurrentResult["map"] {
+  const map = status.appUi.snapshot.map;
+  return {
+    width: probeValue(map.width),
+    height: probeValue(map.height),
+    plotCount: probeValue(map.plotCount),
+    mapSize: probeValue(map.mapSize),
+    randomSeed: probeValue(map.randomSeed),
+  };
+}
+
+function emptyMapFacts(): Civ7WorldCurrentResult["map"] {
+  return {
+    width: null,
+    height: null,
+    plotCount: null,
+    mapSize: null,
+    randomSeed: null,
+  };
+}
+
+function worldPlayerFacts(
+  status: Civ7ControlOrpcPlayableStatusResult,
+): Civ7WorldCurrentResult["players"] {
+  const players = status.appUi.snapshot.players;
+  return {
+    maxPlayers: status.appUi.snapshot.players.maxPlayers,
+    alivePlayerIds: integerArrayOrEmpty(probeValue(players.aliveIds)),
+    aliveHumanIds: integerArrayOrEmpty(probeValue(players.aliveHumanIds)),
+    aliveHumanCount: probeValue(players.numAliveHumans),
+  };
+}
+
+function emptyPlayerFacts(): Civ7WorldCurrentResult["players"] {
+  return {
+    maxPlayers: null,
+    alivePlayerIds: [],
+    aliveHumanIds: [],
+    aliveHumanCount: null,
+  };
+}
+
+function worldCurrentNextSteps(
+  status: Civ7ControlOrpcPlayableStatusResult,
+  map: Civ7WorldCurrentResult["map"],
+): Civ7WorldCurrentResult["nextSteps"] {
+  if (status.playable || status.readiness === "app-ui-game") {
+    if (map.width == null || map.height == null) {
+      return [{
+        kind: "inspect-world",
+        source: "world.current",
+        label:
+          "World map facts are incomplete; inspect current world evidence before acting.",
+      }];
+    }
+
+    return [{
+      kind: "read-attention",
+      source: "world.current",
+      label: "Read current attention before choosing support actions.",
+    }];
+  }
+
+  if (status.readiness === "shell") {
+    return [{
+      kind: "enter-game",
+      source: "world.current",
+      label: "Enter an active game before reading current world facts.",
+    }];
+  }
+
+  return [{
+    kind: "restore-readiness",
+    source: "world.current",
+    label: "Restore playable or game UI readiness before reading current world facts.",
+  }];
+}
+
+function mapSourceStatus(
+  map: Civ7ControlOrpcPlayableStatusResult["appUi"]["snapshot"]["map"],
+): Civ7WorldCurrentResult["sourceStatus"]["map"] {
+  return map.width.ok || map.height.ok || map.plotCount.ok || map.mapSize.ok
+    ? "read"
+    : "skipped-unavailable";
+}
+
+function playersSourceStatus(
+  players: Civ7ControlOrpcPlayableStatusResult["appUi"]["snapshot"]["players"],
+): Civ7WorldCurrentResult["sourceStatus"]["players"] {
+  return players.aliveIds.ok || players.aliveHumanIds.ok
+      || players.numAliveHumans.ok
+    ? "read"
+    : "skipped-unavailable";
+}
+
+function probeValue<T>(probe: Civ7RuntimeProbe<T>): T | null {
+  return probe.ok ? probe.value : null;
+}
+
+function integerArrayOrEmpty(value: unknown): number[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is number =>
+        Number.isInteger(item) && item >= 0
+      )
+    : [];
+}
+
+function playerIdOrNull(value: unknown): number | null {
+  return Number.isInteger(value) && Number(value) >= 0 ? Number(value) : null;
+}

--- a/packages/civ7-control-orpc/src/modules/world/procedures/map-reads.ts
+++ b/packages/civ7-control-orpc/src/modules/world/procedures/map-reads.ts
@@ -1,0 +1,204 @@
+import type { Civ7RuntimeProbe } from "@civ7/direct-control";
+import { Effect } from "effect";
+
+import type {
+  Civ7ControlOrpcMapGridResult,
+  Civ7ControlOrpcPlotSnapshotResult,
+} from "../../../dependencies/direct-control";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type {
+  Civ7WorldGridReadResult,
+  Civ7WorldPlotReadResult,
+  Civ7WorldPlotSnapshot,
+} from "../contract";
+
+export const worldPlotReadProcedure =
+  civ7ControlOrpcImplementer.world.plot.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () =>
+        worldPlotReadResult(
+          await context.directControl.getCiv7PlotSnapshot(
+            {
+              x: input.location.x,
+              y: input.location.y,
+              fields: input.fields,
+              playerId: input.playerId,
+              includeHidden: input.includeHidden,
+            },
+            context.endpointDefaults,
+          ),
+        ),
+      catch: () =>
+        errors.WORLD_READ_UNAVAILABLE({
+          data: {
+            procedureKey: "world.plot.read",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+export const worldGridReadProcedure =
+  civ7ControlOrpcImplementer.world.grid.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () =>
+        worldGridReadResult(
+          await context.directControl.getCiv7MapGrid(
+            {
+              bounds: input.bounds,
+              fields: input.fields,
+              playerId: input.playerId,
+              includeHidden: input.includeHidden,
+              maxPlots: input.maxPlots,
+            },
+            context.endpointDefaults,
+          ),
+        ),
+      catch: () =>
+        errors.WORLD_READ_UNAVAILABLE({
+          data: {
+            procedureKey: "world.grid.read",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+function worldPlotReadResult(
+  result: Civ7ControlOrpcPlotSnapshotResult,
+): Civ7WorldPlotReadResult {
+  const plot = worldPlotSnapshot(result);
+  const probeErrorCount = plot.summary.probeErrorCount;
+  const invalidLocation = plot.location.index == null && plot.summary.factCount === 0;
+  return {
+    sourceStatus: {
+      plot: invalidLocation
+        ? "invalid-location"
+        : probeErrorCount > 0
+        ? "read-with-probe-errors"
+        : "read",
+    },
+    plot,
+  };
+}
+
+function worldGridReadResult(
+  result: Civ7ControlOrpcMapGridResult,
+): Civ7WorldGridReadResult {
+  const plots = result.plots.map(worldPlotSnapshot);
+  const probeErrorCount = plots.reduce(
+    (total, plot) => total + plot.summary.probeErrorCount,
+    0,
+  ) + probeErrorCountForRecord(result.map ?? {});
+  return {
+    sourceStatus: {
+      grid: result.omitted > 0
+        ? "read-with-omissions"
+        : probeErrorCount > 0
+        ? "read-with-probe-errors"
+        : "read",
+      map: probeValue(result.map?.width) != null || probeValue(result.map?.height) != null
+        ? "read"
+        : "skipped-unavailable",
+    },
+    bounds: result.bounds ?? boundsFromPlots(plots),
+    fields: Array.from(result.fields),
+    plotCount: result.plotCount,
+    omitted: result.omitted,
+    hiddenInfoPolicy: result.hiddenInfoPolicy,
+    map: {
+      width: probeValue(result.map?.width),
+      height: probeValue(result.map?.height),
+    },
+    plots,
+    summary: {
+      returnedPlotCount: plots.length,
+      probeErrorCount,
+    },
+  };
+}
+
+function worldPlotSnapshot(
+  plot: Omit<Civ7ControlOrpcPlotSnapshotResult, "host" | "port" | "state">,
+): Civ7WorldPlotSnapshot {
+  const facts = probeRecord(plot.facts);
+  const visibility = {
+    ...(plot.revealedState ? { revealedState: publicProbe(plot.revealedState) } : {}),
+    ...(plot.visible ? { visible: publicProbe(plot.visible) } : {}),
+  };
+  return {
+    location: {
+      x: plot.location.x,
+      y: plot.location.y,
+      index: probeValue(plot.location.index),
+    },
+    visibility,
+    hiddenInfoPolicy: plot.hiddenInfoPolicy,
+    facts,
+    summary: {
+      factCount: Object.keys(facts).length,
+      probeErrorCount: probeErrorCountForRecord(facts)
+        + probeErrorCountForRecord(visibility)
+        + (plot.location.index.ok ? 0 : 1),
+    },
+  };
+}
+
+function publicProbe<T>(probe: Civ7RuntimeProbe<T>): {
+  ok: true;
+  value: T;
+} | {
+  ok: false;
+  error: string;
+} {
+  return probe.ok ? { ok: true, value: probe.value } : {
+    ok: false,
+    error: probe.error,
+  };
+}
+
+function probeRecord(
+  facts: Readonly<Record<string, Civ7RuntimeProbe<unknown>>>,
+): Record<string, ReturnType<typeof publicProbe<unknown>>> {
+  return Object.fromEntries(
+    Object.entries(facts).map(([key, value]) => [key, publicProbe(value)]),
+  );
+}
+
+function probeValue<T>(probe: Civ7RuntimeProbe<T> | undefined): T | null {
+  return probe?.ok ? probe.value : null;
+}
+
+function probeErrorCountForRecord(record: Readonly<Record<string, unknown>>): number {
+  return Object.values(record).filter((value) =>
+    value != null && typeof value === "object"
+      && "ok" in value && (value as { ok?: unknown }).ok === false
+  ).length;
+}
+
+function boundsFromPlots(
+  plots: ReadonlyArray<Civ7WorldPlotSnapshot>,
+): Civ7WorldGridReadResult["bounds"] {
+  if (plots.length === 0) return { x: 0, y: 0, width: 1, height: 1 };
+  const xs = plots.map((plot) => plot.location.x);
+  const ys = plots.map((plot) => plot.location.y);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  return {
+    x: minX,
+    y: minY,
+    width: Math.max(...xs) - minX + 1,
+    height: Math.max(...ys) - minY + 1,
+  };
+}

--- a/packages/civ7-control-orpc/src/modules/world/router.ts
+++ b/packages/civ7-control-orpc/src/modules/world/router.ts
@@ -1,5 +1,11 @@
+import {
+  worldGridReadProcedure,
+  worldPlotReadProcedure,
+} from "./procedures/map-reads";
 import { worldCurrentProcedure } from "./procedures/current";
 
 export const worldRouter = {
   current: worldCurrentProcedure,
+  plot: worldPlotReadProcedure,
+  grid: worldGridReadProcedure,
 };

--- a/packages/civ7-control-orpc/src/modules/world/router.ts
+++ b/packages/civ7-control-orpc/src/modules/world/router.ts
@@ -1,0 +1,5 @@
+import { worldCurrentProcedure } from "./procedures/current";
+
+export const worldRouter = {
+  current: worldCurrentProcedure,
+};

--- a/packages/civ7-control-orpc/src/router.ts
+++ b/packages/civ7-control-orpc/src/router.ts
@@ -14,6 +14,7 @@ import { readinessRouter } from "./modules/readiness/router";
 import { strategyRouter } from "./modules/strategy/router";
 import { turnRouter } from "./modules/turn/router";
 import { unitRouter } from "./modules/unit/router";
+import { worldRouter } from "./modules/world/router";
 
 export const Civ7ControlOrpcRouter: Router<
   typeof Civ7ControlOrpcContract,
@@ -30,4 +31,5 @@ export const Civ7ControlOrpcRouter: Router<
   strategy: strategyRouter,
   turn: turnRouter,
   unit: unitRouter,
+  world: worldRouter,
 });

--- a/packages/civ7-control-orpc/test/attention-priorities-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/attention-priorities-procedure.test.ts
@@ -1,0 +1,490 @@
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7AttentionPrioritiesUnavailableError,
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+} from "../src/index";
+import type {
+  Civ7ControlOrpcBattlefieldScanResult,
+  Civ7ControlOrpcPlayableStatusResult,
+  Civ7ControlOrpcPlayNotificationViewResult,
+  Civ7ControlOrpcReadyCityViewResult,
+  Civ7ControlOrpcReadyUnitViewResult,
+  Civ7ControlOrpcTurnCompletionStatusResult,
+} from "../src/dependencies/direct-control";
+
+describe("attention.priorities control-oRPC procedure", () => {
+  test("composes current attention and battlefield evidence into semantic priorities", async () => {
+    const unitId = { owner: 0, id: 458_752, type: 26 };
+    const cityId = { owner: 0, id: 131_073, type: 1 };
+    const fake = fakeContext({
+      playableStatus: playableStatusResult(),
+      notifications: notificationViewResult({ unitId, cityId }),
+      turnCompletion: turnCompletionStatusResult({
+        canEndTurn: { ok: true, value: false },
+        blocker: { ok: true, value: -2026570723 },
+        firstReadyUnitId: { ok: true, value: unitId },
+      }),
+      readyUnit: readyUnitViewResult(unitId),
+      readyCity: readyCityViewResult(cityId),
+      battlefield: battlefieldScanResult(),
+    });
+
+    const result = await call(Civ7ControlOrpcRouter.attention.priorities, {
+      maxNotifications: 12,
+      includeBattlefield: true,
+      battlefieldRadius: 6,
+    }, {
+      context: fake.context,
+    });
+
+    expect(result).toMatchObject({
+      playable: true,
+      readiness: "tuner-ready",
+      localPlayerId: 0,
+      sourceStatus: {
+        playableStatus: "read",
+        notifications: "read",
+        turnCompletion: "read",
+        readyUnit: "read",
+        readyCity: "read",
+        battlefield: "read",
+      },
+      summary: {
+        decisionCount: 1,
+      },
+    });
+    expect(result.priorities.map((item) => item.kind)).toEqual([
+      "hud:production-choice",
+      "ready-unit",
+      "ready-city",
+      "battlefield:city-front",
+    ]);
+    expect(result.priorities[0]?.nextStep).toMatchObject({
+      kind: "inspect-ready-city",
+      source: "ready-city",
+      parameters: {
+        category: "production-choice",
+        operationFamily: "city-operation",
+      },
+    });
+    expect(result.nextSteps.map((step) => step.kind)).toContain(
+      "inspect-battlefield-point",
+    );
+    expect(JSON.stringify(result)).not.toContain("game play");
+    expect(JSON.stringify(result)).not.toContain("127.0.0.1");
+    expect(JSON.stringify(result)).not.toContain("65535");
+    expect(JSON.stringify(result)).not.toContain("\"host\"");
+    expect(JSON.stringify(result)).not.toContain("\"port\"");
+    expect(JSON.stringify(result)).not.toContain("\"state\"");
+    expect(JSON.stringify(result)).not.toContain("rawCommand");
+
+    expect(fake.calls.notifications).toEqual([
+      {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+        maxNotifications: 12,
+      },
+    ]);
+    expect(fake.calls.battlefield).toEqual([
+      {
+        input: {
+          origins: [{ x: 12, y: 18 }],
+          radius: 6,
+          maxUnits: 80,
+        },
+        options: { host: "127.0.0.1", port: 4318, timeoutMs: 1_000 },
+      },
+    ]);
+  });
+
+  test("does not treat partial HUD probe failures as clean end-turn proof", async () => {
+    const gameError = { ok: false as const, error: "ReferenceError: Game is not defined" };
+    const fake = fakeContext({
+      playableStatus: playableStatusResult(),
+      notifications: {
+        ...cleanNotificationViewResult(),
+        turn: gameError,
+        turnDate: gameError,
+        blocker: gameError,
+        blockingNotificationId: gameError,
+      },
+      turnCompletion: turnCompletionStatusResult(),
+      readyUnit: emptyReadyUnitViewResult(),
+      readyCity: emptyReadyCityViewResult(),
+    });
+
+    const result = await call(Civ7ControlOrpcRouter.attention.priorities, {}, {
+      context: fake.context,
+    });
+
+    expect(result.priorities[0]).toMatchObject({
+      kind: "runtime-state-error",
+      blocking: true,
+      nextStep: {
+        kind: "observe",
+      },
+    });
+    expect(result.priorities.map((item) => item.kind)).not.toContain(
+      "clean-read",
+    );
+    expect(result.nextSteps.map((step) => step.kind)).not.toContain("end-turn");
+  });
+
+  test("supports the in-process server-side router client", async () => {
+    const fake = fakeContext({
+      playableStatus: playableStatusResult(),
+      notifications: cleanNotificationViewResult(),
+      turnCompletion: turnCompletionStatusResult(),
+      readyUnit: emptyReadyUnitViewResult(),
+      readyCity: emptyReadyCityViewResult(),
+    });
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    const result = await client.attention.priorities({ maxNotifications: 7 });
+
+    expect(result.priorities).toEqual([
+      {
+        priority: 10,
+        kind: "clean-read",
+        summary: "no HUD, ready-unit, ready-city, or battlefield priority surfaced",
+        reason:
+          "Fresh clean reads can use the guarded end-turn path; it rechecks blockers before sending.",
+        blocking: false,
+        nextStep: {
+          kind: "end-turn",
+          source: "attention.priorities",
+          label: "No blockers found; guarded end-turn is available.",
+          parameters: {},
+        },
+        evidenceLabels: ["clean-attention-read"],
+      },
+    ]);
+    expect(fake.calls.battlefield).toEqual([]);
+  });
+
+  test("publishes a contract-first attention.priorities service procedure", () => {
+    expect(Civ7ControlOrpcContract.attention.priorities["~orpc"]).toMatchObject({
+      meta: {
+        family: "attention",
+        procedureKey: "attention.priorities",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      },
+    });
+    expect(
+      Civ7ControlOrpcContract.attention.priorities["~orpc"].errorMap,
+    ).toHaveProperty("ATTENTION_PRIORITIES_UNAVAILABLE");
+    expect(Civ7AttentionPrioritiesUnavailableError.code).toBe(
+      "ATTENTION_PRIORITIES_UNAVAILABLE",
+    );
+  });
+});
+
+type FakeContextOptions = Readonly<{
+  playableStatus: Civ7ControlOrpcPlayableStatusResult;
+  notifications?: Civ7ControlOrpcPlayNotificationViewResult;
+  turnCompletion?: Civ7ControlOrpcTurnCompletionStatusResult;
+  readyUnit?: Civ7ControlOrpcReadyUnitViewResult;
+  readyCity?: Civ7ControlOrpcReadyCityViewResult;
+  battlefield?: Civ7ControlOrpcBattlefieldScanResult;
+}>;
+
+function fakeContext(options: FakeContextOptions): {
+  context: Civ7ControlOrpcContext;
+  calls: {
+    playableStatus: unknown[];
+    notifications: unknown[];
+    turnCompletion: unknown[];
+    readyUnit: Array<{ input: unknown; options: unknown }>;
+    readyCity: Array<{ input: unknown; options: unknown }>;
+    battlefield: Array<{ input: unknown; options: unknown }>;
+  };
+} {
+  const calls = {
+    playableStatus: [] as unknown[],
+    notifications: [] as unknown[],
+    turnCompletion: [] as unknown[],
+    readyUnit: [] as Array<{ input: unknown; options: unknown }>,
+    readyCity: [] as Array<{ input: unknown; options: unknown }>,
+    battlefield: [] as Array<{ input: unknown; options: unknown }>,
+  };
+  const context: Civ7ControlOrpcContext = {
+    endpointDefaults: {
+      host: "127.0.0.1",
+      port: 4318,
+      timeoutMs: 1_000,
+    },
+    directControl: {
+      getCiv7PlayableStatus: async (endpointDefaults) => {
+        calls.playableStatus.push(endpointDefaults);
+        return options.playableStatus;
+      },
+      getCiv7PlayNotificationView: async (notificationOptions) => {
+        calls.notifications.push(notificationOptions);
+        if (options.notifications == null) {
+          throw new Error("missing notification fixture");
+        }
+        return options.notifications;
+      },
+      getCiv7ReadyCityView: async (input, endpointDefaults) => {
+        calls.readyCity.push({ input, options: endpointDefaults });
+        if (options.readyCity == null) {
+          throw new Error("missing ready-city fixture");
+        }
+        return options.readyCity;
+      },
+      getCiv7ReadyUnitView: async (input, endpointDefaults) => {
+        calls.readyUnit.push({ input, options: endpointDefaults });
+        if (options.readyUnit == null) {
+          throw new Error("missing ready-unit fixture");
+        }
+        return options.readyUnit;
+      },
+      getCiv7TurnCompletionStatus: async (endpointDefaults) => {
+        calls.turnCompletion.push(endpointDefaults);
+        return options.turnCompletion ?? turnCompletionStatusResult();
+      },
+      getCiv7BattlefieldScan: async (input, endpointDefaults) => {
+        calls.battlefield.push({ input, options: endpointDefaults });
+        if (options.battlefield == null) {
+          throw new Error("missing battlefield fixture");
+        }
+        return options.battlefield;
+      },
+    },
+  };
+
+  return { context, calls };
+}
+
+function playableStatusResult(
+  overrides: Partial<Civ7ControlOrpcPlayableStatusResult> = {},
+): Civ7ControlOrpcPlayableStatusResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    playable: true,
+    readiness: "tuner-ready",
+    appUi: {} as Civ7ControlOrpcPlayableStatusResult["appUi"],
+    tuner: {} as Civ7ControlOrpcPlayableStatusResult["tuner"],
+    errors: [],
+    ...overrides,
+  };
+}
+
+function notificationViewResult(
+  ids: {
+    unitId?: { owner: number; id: number; type?: number };
+    cityId?: { owner: number; id: number; type?: number };
+  } = {},
+): Civ7ControlOrpcPlayNotificationViewResult {
+  const unitId = ids.unitId ?? { owner: 0, id: 458_752, type: 26 };
+  const cityId = ids.cityId ?? { owner: 0, id: 131_073, type: 1 };
+  const queueItem = {
+    notificationId: { owner: 0, id: 42, type: 20 },
+    isEndTurnBlocking: true,
+    typeName: "NOTIFICATION_CHOOSE_PRODUCTION",
+    summary: "Production needed",
+    message: "Choose production in the capital.",
+    target: { cityId },
+    location: { x: 12, y: 18 },
+    player: 0,
+    category: "production-choice",
+    operationFamily: "city-operation" as const,
+    operationType: "BUILDING",
+    argsShape: "city-id, production-kind",
+    requiredInputs: [
+      {
+        name: "City",
+        source: "notification",
+        required: true,
+      },
+    ],
+    commonActions: [],
+    notes: [],
+  };
+
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    turn: { ok: true, value: 12 },
+    turnDate: { ok: true, value: "3400 BCE" },
+    hasSentTurnComplete: { ok: true, value: false },
+    canEndTurn: { ok: true, value: false },
+    blocker: { ok: true, value: -2026570723 },
+    blockingNotificationId: {
+      ok: true,
+      value: { owner: 0, id: 42, type: 20 },
+    },
+    selectedUnitId: { ok: true, value: unitId },
+    selectedCityId: { ok: true, value: cityId },
+    firstReadyUnitId: { ok: true, value: unitId },
+    notifications: [],
+    decisions: [],
+    hud: {
+      nextDecision: queueItem,
+      decisionQueue: [queueItem],
+    },
+    limits: {
+      maxNotifications: 25,
+      truncated: false,
+    },
+  };
+}
+
+function cleanNotificationViewResult(): Civ7ControlOrpcPlayNotificationViewResult {
+  return {
+    ...notificationViewResult(),
+    canEndTurn: { ok: true, value: true },
+    blocker: { ok: true, value: null },
+    blockingNotificationId: { ok: true, value: null },
+    selectedUnitId: { ok: true, value: null },
+    selectedCityId: { ok: true, value: null },
+    firstReadyUnitId: { ok: true, value: null },
+    hud: {
+      nextDecision: null,
+      decisionQueue: [],
+    },
+  };
+}
+
+function turnCompletionStatusResult(
+  overrides: Partial<Civ7ControlOrpcTurnCompletionStatusResult> = {},
+): Civ7ControlOrpcTurnCompletionStatusResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    turn: { ok: true, value: 12 },
+    turnDate: { ok: true, value: "3400 BCE" },
+    hasSentTurnComplete: { ok: true, value: false },
+    canEndTurn: { ok: true, value: true },
+    blocker: { ok: true, value: 0 },
+    firstReadyUnitId: { ok: true, value: null },
+    ...overrides,
+  };
+}
+
+function readyUnitViewResult(
+  unitId: { owner: number; id: number; type?: number },
+): Civ7ControlOrpcReadyUnitViewResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    requestedUnitId: unitId,
+    selectedUnitId: { ok: true, value: unitId },
+    firstReadyUnitId: { ok: true, value: unitId },
+    unitId,
+    unit: {
+      ok: true,
+      value: {
+        id: unitId,
+        typeName: "Scout",
+        location: { x: 12, y: 18 },
+      },
+    },
+    legalOperations: [
+      {
+        family: "unit-operation",
+        operationType: "SKIP_TURN",
+        enumValue: 1,
+        valid: true,
+        result: { Success: true },
+      },
+    ],
+    promotionReadiness: { ok: true, value: null },
+    nearby: { ok: true, value: [] },
+    notes: [],
+  };
+}
+
+function emptyReadyUnitViewResult(): Civ7ControlOrpcReadyUnitViewResult {
+  return {
+    ...readyUnitViewResult({ owner: 0, id: 458_752, type: 26 }),
+    requestedUnitId: null,
+    selectedUnitId: { ok: true, value: null },
+    firstReadyUnitId: { ok: true, value: null },
+    unitId: null,
+    unit: { ok: true, value: null },
+    legalOperations: [],
+  };
+}
+
+function readyCityViewResult(
+  cityId: { owner: number; id: number; type?: number },
+): Civ7ControlOrpcReadyCityViewResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    requestedCityId: cityId,
+    selectedCityId: { ok: true, value: cityId },
+    blockingCityId: { ok: true, value: cityId },
+    cityId,
+    city: { ok: true, value: { id: cityId, name: "Capital" } },
+    legalOperations: [
+      {
+        family: "city-operation",
+        operationType: "CONSIDER_TOWN_PROJECT",
+        enumValue: 1,
+        valid: true,
+        result: { Success: true },
+      },
+    ],
+    productionCandidates: { ok: true, value: [] },
+    townFocusOptions: { ok: true, value: [] },
+    populationPlacement: { ok: true, value: null },
+    notes: [],
+  };
+}
+
+function emptyReadyCityViewResult(): Civ7ControlOrpcReadyCityViewResult {
+  return {
+    ...readyCityViewResult({ owner: 0, id: 131_073, type: 1 }),
+    requestedCityId: null,
+    selectedCityId: { ok: true, value: null },
+    blockingCityId: { ok: true, value: null },
+    cityId: null,
+    city: { ok: true, value: null },
+    legalOperations: [],
+    productionCandidates: { ok: true, value: [] },
+    townFocusOptions: { ok: true, value: [] },
+    populationPlacement: { ok: true, value: null },
+  };
+}
+
+function battlefieldScanResult(): Civ7ControlOrpcBattlefieldScanResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    playerId: 0,
+    origins: [{ x: 12, y: 18 }],
+    radius: 6,
+    hiddenInfoPolicy: "debug-visible-runtime",
+    pointsOfInterest: [
+      {
+        kind: "city-front",
+        severity: "high",
+        location: { x: 14, y: 18 },
+        summary: "relationship-unproven city near ready unit",
+        evidence: [],
+      },
+    ],
+    owners: [],
+    notes: [],
+  };
+}

--- a/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
+++ b/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
@@ -45,6 +45,8 @@ import {
   Civ7ControllerBridgeUnitTargetActionSuccessResponseSchema,
   Civ7ControllerBridgeUnitUpgradeRequestSchema,
   Civ7ControllerBridgeUnitUpgradeSuccessResponseSchema,
+  Civ7ControllerBridgeWorldCurrentRequestSchema,
+  Civ7ControllerBridgeWorldCurrentSuccessResponseSchema,
   createCiv7ControllerBridgeIngress,
   invokeCiv7ControllerBridgeRequest,
   type Civ7ControlOrpcContext,
@@ -91,6 +93,8 @@ import {
   type Civ7ControllerBridgeUnitTargetActionSuccessResponse,
   type Civ7ControllerBridgeUnitUpgradeRequest,
   type Civ7ControllerBridgeUnitUpgradeSuccessResponse,
+  type Civ7ControllerBridgeWorldCurrentRequest,
+  type Civ7ControllerBridgeWorldCurrentSuccessResponse,
 } from "../src/index";
 
 type TestControllerContext = Civ7ControlOrpcContext & Readonly<{
@@ -160,6 +164,8 @@ const traditionChangeInput = {
 type PublicControllerBridgeSchemaTypeCoverage = Readonly<[
   Civ7ControllerBridgeStrategyFrontSummaryRequest,
   Civ7ControllerBridgeStrategyFrontSummarySuccessResponse,
+  Civ7ControllerBridgeWorldCurrentRequest,
+  Civ7ControllerBridgeWorldCurrentSuccessResponse,
   Civ7ControllerBridgeCityProductionChoiceRequest,
   Civ7ControllerBridgeCityProductionChoiceSuccessResponse,
   Civ7ControllerBridgeCityPopulationPlacementRequest,
@@ -209,6 +215,8 @@ describe("Civ7 controller bridge ingress", () => {
     const publicSchemas = [
       Civ7ControllerBridgeStrategyFrontSummaryRequestSchema,
       Civ7ControllerBridgeStrategyFrontSummarySuccessResponseSchema,
+      Civ7ControllerBridgeWorldCurrentRequestSchema,
+      Civ7ControllerBridgeWorldCurrentSuccessResponseSchema,
       Civ7ControllerBridgeCityProductionChoiceRequestSchema,
       Civ7ControllerBridgeCityProductionChoiceSuccessResponseSchema,
       Civ7ControllerBridgeCityPopulationPlacementRequestSchema,
@@ -371,6 +379,66 @@ describe("Civ7 controller bridge ingress", () => {
     expect(serialized).not.toContain("Game.turn");
     expect(serialized).not.toContain("Tuner");
     expect(serialized).not.toContain("App UI");
+  });
+
+  test("invokes allowlisted world.current through the in-process router", async () => {
+    const fake = fakeContext(playableStatusResult());
+    const ingress = createCiv7ControllerBridgeIngress({
+      createContext: (request) => {
+        fake.contextRequests.push(request);
+        return {
+          ...fake.context,
+          controller: {
+            supportedReadProcedures: ["world.current"],
+          },
+        };
+      },
+    });
+
+    const response = await ingress.invoke({
+      procedureKey: "world.current",
+      input: {},
+      correlationId: "controller-world-1",
+    });
+
+    expect(Value.Check(Civ7ControllerBridgeResponseSchema, response)).toBe(true);
+    expect(response).toMatchObject({
+      ok: true,
+      procedureKey: "world.current",
+      correlationId: "controller-world-1",
+      output: {
+        playable: true,
+        readiness: "tuner-ready",
+        sourceStatus: {
+          playableStatus: "read",
+          game: "read",
+          map: "read",
+          players: "read",
+        },
+        map: {
+          width: 84,
+          height: 52,
+        },
+        players: {
+          alivePlayerIds: [0, 1, 2],
+          aliveHumanIds: [0],
+        },
+      },
+    });
+    expect(fake.calls).toEqual([{ timeoutMs: 1_000 }]);
+    expect(fake.contextRequests).toEqual([{
+      procedureKey: "world.current",
+      input: {},
+      correlationId: "controller-world-1",
+    }]);
+
+    const serialized = JSON.stringify(response);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"session\"");
+    expect(serialized).not.toContain("\"rawCommand\"");
+    expect(serialized).not.toContain("relationship");
   });
 
   test("invokes allowlisted notifications.dismiss.request through the in-process router with controller proof", async () => {
@@ -2625,11 +2693,35 @@ function playableStatusResult(): Civ7ControlOrpcPlayableStatusResult {
       port: 4318,
       state: { id: "65535", name: "App UI" },
       snapshot: {
+        game: {
+          turn: 77,
+          age: 1,
+          maxTurns: 500,
+          turnDate: { ok: true, value: "Age 1, Turn 77" },
+          hash: { ok: true, value: 123_456 },
+        },
         ui: {
           inGame: { ok: true, value: true },
           inShell: { ok: true, value: false },
           inLoading: { ok: true, value: false },
           canBeginGame: { ok: true, value: false },
+        },
+        gameContext: {
+          localPlayerID: 0,
+          localObserverID: 1,
+        },
+        players: {
+          maxPlayers: 8,
+          aliveIds: { ok: true, value: [0, 1, 2] },
+          aliveHumanIds: { ok: true, value: [0] },
+          numAliveHumans: { ok: true, value: 1 },
+        },
+        map: {
+          width: { ok: true, value: 84 },
+          height: { ok: true, value: 52 },
+          plotCount: { ok: true, value: 4_368 },
+          mapSize: { ok: true, value: 3 },
+          randomSeed: { ok: true, value: 987_654 },
         },
         currentState: "App UI",
       },

--- a/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
+++ b/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
@@ -47,6 +47,10 @@ import {
   Civ7ControllerBridgeUnitUpgradeSuccessResponseSchema,
   Civ7ControllerBridgeWorldCurrentRequestSchema,
   Civ7ControllerBridgeWorldCurrentSuccessResponseSchema,
+  Civ7ControllerBridgeWorldGridReadRequestSchema,
+  Civ7ControllerBridgeWorldGridReadSuccessResponseSchema,
+  Civ7ControllerBridgeWorldPlotReadRequestSchema,
+  Civ7ControllerBridgeWorldPlotReadSuccessResponseSchema,
   createCiv7ControllerBridgeIngress,
   invokeCiv7ControllerBridgeRequest,
   type Civ7ControlOrpcContext,
@@ -95,6 +99,10 @@ import {
   type Civ7ControllerBridgeUnitUpgradeSuccessResponse,
   type Civ7ControllerBridgeWorldCurrentRequest,
   type Civ7ControllerBridgeWorldCurrentSuccessResponse,
+  type Civ7ControllerBridgeWorldGridReadRequest,
+  type Civ7ControllerBridgeWorldGridReadSuccessResponse,
+  type Civ7ControllerBridgeWorldPlotReadRequest,
+  type Civ7ControllerBridgeWorldPlotReadSuccessResponse,
 } from "../src/index";
 
 type TestControllerContext = Civ7ControlOrpcContext & Readonly<{
@@ -166,6 +174,10 @@ type PublicControllerBridgeSchemaTypeCoverage = Readonly<[
   Civ7ControllerBridgeStrategyFrontSummarySuccessResponse,
   Civ7ControllerBridgeWorldCurrentRequest,
   Civ7ControllerBridgeWorldCurrentSuccessResponse,
+  Civ7ControllerBridgeWorldPlotReadRequest,
+  Civ7ControllerBridgeWorldPlotReadSuccessResponse,
+  Civ7ControllerBridgeWorldGridReadRequest,
+  Civ7ControllerBridgeWorldGridReadSuccessResponse,
   Civ7ControllerBridgeCityProductionChoiceRequest,
   Civ7ControllerBridgeCityProductionChoiceSuccessResponse,
   Civ7ControllerBridgeCityPopulationPlacementRequest,
@@ -217,6 +229,10 @@ describe("Civ7 controller bridge ingress", () => {
       Civ7ControllerBridgeStrategyFrontSummarySuccessResponseSchema,
       Civ7ControllerBridgeWorldCurrentRequestSchema,
       Civ7ControllerBridgeWorldCurrentSuccessResponseSchema,
+      Civ7ControllerBridgeWorldPlotReadRequestSchema,
+      Civ7ControllerBridgeWorldPlotReadSuccessResponseSchema,
+      Civ7ControllerBridgeWorldGridReadRequestSchema,
+      Civ7ControllerBridgeWorldGridReadSuccessResponseSchema,
       Civ7ControllerBridgeCityProductionChoiceRequestSchema,
       Civ7ControllerBridgeCityProductionChoiceSuccessResponseSchema,
       Civ7ControllerBridgeCityPopulationPlacementRequestSchema,
@@ -439,6 +455,180 @@ describe("Civ7 controller bridge ingress", () => {
     expect(serialized).not.toContain("\"session\"");
     expect(serialized).not.toContain("\"rawCommand\"");
     expect(serialized).not.toContain("relationship");
+  });
+
+  test("invokes allowlisted world.plot.read through the in-process router", async () => {
+    const fake = fakeWorldMapContext();
+    const ingress = createCiv7ControllerBridgeIngress({
+      createContext: (request) => {
+        fake.contextRequests.push(request);
+        return fake.context;
+      },
+    });
+
+    const response = await ingress.invoke({
+      procedureKey: "world.plot.read",
+      input: {
+        location: { x: 3, y: 4 },
+        fields: ["terrain", "owner"],
+        playerId: 0,
+      },
+      correlationId: "controller-world-plot-1",
+    });
+
+    expect(Value.Check(Civ7ControllerBridgeResponseSchema, response)).toBe(true);
+    expect(response).toMatchObject({
+      ok: true,
+      procedureKey: "world.plot.read",
+      correlationId: "controller-world-plot-1",
+      output: {
+        sourceStatus: {
+          plot: "read",
+        },
+        plot: {
+          location: {
+            x: 3,
+            y: 4,
+            index: 3_004,
+          },
+          hiddenInfoPolicy: "visibility-filtered",
+          facts: {
+            terrain: { ok: true, value: 7 },
+            owner: { ok: true, value: 0 },
+          },
+        },
+      },
+    });
+    expect(fake.calls.plot).toEqual([{
+      input: {
+        x: 3,
+        y: 4,
+        fields: ["terrain", "owner"],
+        playerId: 0,
+        includeHidden: undefined,
+      },
+      options: { timeoutMs: 1_000 },
+    }]);
+    expect(fake.contextRequests).toEqual([{
+      procedureKey: "world.plot.read",
+      input: {
+        location: { x: 3, y: 4 },
+        fields: ["terrain", "owner"],
+        playerId: 0,
+      },
+      correlationId: "controller-world-plot-1",
+    }]);
+
+    const serialized = JSON.stringify(response);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"session\"");
+    expect(serialized).not.toContain("\"rawCommand\"");
+    expect(serialized).not.toContain("relationship");
+  });
+
+  test("invokes allowlisted world.grid.read through the in-process router", async () => {
+    const fake = fakeWorldMapContext();
+    const ingress = createCiv7ControllerBridgeIngress({
+      createContext: (request) => {
+        fake.contextRequests.push(request);
+        return fake.context;
+      },
+    });
+
+    const response = await ingress.invoke({
+      procedureKey: "world.grid.read",
+      input: {
+        bounds: { x: 3, y: 4, width: 2, height: 1 },
+        fields: ["terrain"],
+        maxPlots: 1,
+      },
+      correlationId: "controller-world-grid-1",
+    });
+
+    expect(Value.Check(Civ7ControllerBridgeResponseSchema, response)).toBe(true);
+    expect(response).toMatchObject({
+      ok: true,
+      procedureKey: "world.grid.read",
+      correlationId: "controller-world-grid-1",
+      output: {
+        sourceStatus: {
+          grid: "read-with-omissions",
+          map: "read",
+        },
+        bounds: { x: 3, y: 4, width: 2, height: 1 },
+        fields: ["terrain"],
+        plotCount: 2,
+        omitted: 1,
+        plots: [
+          {
+            location: { x: 3, y: 4, index: 3_004 },
+            facts: { terrain: { ok: true, value: 7 } },
+          },
+        ],
+      },
+    });
+    expect(fake.calls.grid).toEqual([{
+      input: {
+        bounds: { x: 3, y: 4, width: 2, height: 1 },
+        fields: ["terrain"],
+        playerId: undefined,
+        includeHidden: undefined,
+        maxPlots: 1,
+      },
+      options: { timeoutMs: 1_000 },
+    }]);
+
+    const serialized = JSON.stringify(response);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"session\"");
+    expect(serialized).not.toContain("\"rawCommand\"");
+    expect(serialized).not.toContain("relationship");
+  });
+
+  test("rejects raw world plot/grid controller envelopes before dispatch", async () => {
+    const fake = fakeWorldMapContext();
+    const ingress = createCiv7ControllerBridgeIngress({
+      createContext: () => fake.context,
+    });
+
+    const plotResponse = await ingress.invoke({
+      procedureKey: "world.plot.read",
+      input: {
+        location: { x: 3, y: 4 },
+        rawCommand: "GameplayMap.getTerrainType(3, 4)",
+      },
+    });
+    const gridResponse = await ingress.invoke({
+      procedureKey: "world.grid.read",
+      input: {
+        bounds: { x: 3, y: 4, width: 2, height: 1 },
+        fields: ["terrain"],
+        state: { id: "65535", name: "App UI" },
+      },
+    });
+
+    expect(plotResponse).toEqual({
+      ok: false,
+      error: {
+        code: "BRIDGE_BAD_REQUEST",
+        message: "Civ7 controller bridge request envelope is invalid.",
+        reason: "invalid-envelope",
+      },
+    });
+    expect(gridResponse).toEqual({
+      ok: false,
+      error: {
+        code: "BRIDGE_BAD_REQUEST",
+        message: "Civ7 controller bridge request envelope is invalid.",
+        reason: "invalid-envelope",
+      },
+    });
+    expect(fake.calls.plot).toEqual([]);
+    expect(fake.calls.grid).toEqual([]);
   });
 
   test("invokes allowlisted notifications.dismiss.request through the in-process router with controller proof", async () => {
@@ -1911,6 +2101,84 @@ function fakeContext(
       } as Civ7ControlOrpcContext["directControl"],
     },
   };
+}
+
+function fakeWorldMapContext(): {
+  calls: {
+    plot: Array<{ input: unknown; options: unknown }>;
+    grid: Array<{ input: unknown; options: unknown }>;
+  };
+  contextRequests: unknown[];
+  context: TestControllerContext;
+} {
+  const calls: {
+    plot: Array<{ input: unknown; options: unknown }>;
+    grid: Array<{ input: unknown; options: unknown }>;
+  } = {
+    plot: [],
+    grid: [],
+  };
+  return {
+    calls,
+    contextRequests: [],
+    context: {
+      endpointDefaults: { timeoutMs: 1_000 },
+      controllerProof: controllerMutationProof(),
+      controller: {
+        supportedReadProcedures: ["world.plot.read", "world.grid.read"],
+      },
+      directControl: {
+        getCiv7PlayableStatus: async () => playableStatusResult(),
+        getCiv7PlotSnapshot: async (input, options) => {
+          calls.plot.push({ input, options });
+          return plotSnapshotResult(input.x, input.y, input.fields ?? ["terrain"]);
+        },
+        getCiv7MapGrid: async (input, options) => {
+          calls.grid.push({ input, options });
+          const fields = input.fields;
+          return {
+            host: "127.0.0.1",
+            port: 4318,
+            state: { id: "65535", name: "App UI" },
+            bounds: input.bounds,
+            fields: Array.from(fields),
+            plotCount: 2,
+            omitted: 1,
+            hiddenInfoPolicy: "not-player-scoped",
+            map: {
+              width: { ok: true, value: 84 },
+              height: { ok: true, value: 52 },
+            },
+            plots: [plotSnapshotResult(3, 4, fields)],
+          };
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function plotSnapshotResult(
+  x: number,
+  y: number,
+  fields: readonly string[],
+) {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    location: {
+      x,
+      y,
+      index: { ok: true, value: x * 1_000 + y },
+    },
+    revealedState: { ok: true, value: 1 },
+    visible: { ok: true, value: true },
+    hiddenInfoPolicy: "visibility-filtered",
+    facts: Object.fromEntries(fields.map((field) => [
+      field,
+      { ok: true, value: field === "owner" ? 0 : 7 },
+    ])),
+  } as const;
 }
 
 function fakeAttentionContext(unitId: { owner: number; id: number; type: number }): {

--- a/packages/civ7-control-orpc/test/game-ui-controller.test.ts
+++ b/packages/civ7-control-orpc/test/game-ui-controller.test.ts
@@ -144,6 +144,139 @@ describe("Civ7 game UI controller bootstrap", () => {
     expect(serialized).not.toContain("suzerain");
   });
 
+  test("reads world plot and grid through game UI map service dependencies", async () => {
+    const bridge = installCiv7GameUiIntelligenceBridge({
+      target: gameUiMapReadTarget(),
+    });
+
+    const readiness = await bridge.invoke({
+      procedureKey: "readiness.current",
+      input: {},
+    });
+    expect(readiness).toMatchObject({
+      ok: true,
+      output: {
+        controller: {
+          supportedProcedures: expect.arrayContaining([
+            { procedureKey: "world.current", risk: "read-only" },
+            { procedureKey: "world.plot.read", risk: "read-only" },
+            { procedureKey: "world.grid.read", risk: "read-only" },
+          ]),
+        },
+      },
+    });
+
+    const plot = await bridge.invoke({
+      procedureKey: "world.plot.read",
+      input: {
+        location: { x: 3, y: 4 },
+        fields: ["terrain", "owner", "visibility"],
+        playerId: 0,
+      },
+      correlationId: "game-ui-world-plot-1",
+    });
+    expect(plot).toMatchObject({
+      ok: true,
+      procedureKey: "world.plot.read",
+      correlationId: "game-ui-world-plot-1",
+      output: {
+        sourceStatus: { plot: "read" },
+        plot: {
+          location: { x: 3, y: 4, index: 3_004 },
+          hiddenInfoPolicy: "visibility-filtered",
+          facts: {
+            terrain: { ok: true, value: 7 },
+            owner: { ok: true, value: 0 },
+            visible: { ok: true, value: true },
+          },
+        },
+      },
+    });
+
+    const grid = await bridge.invoke({
+      procedureKey: "world.grid.read",
+      input: {
+        bounds: { x: 3, y: 4, width: 2, height: 1 },
+        fields: ["terrain"],
+        maxPlots: 1,
+      },
+      correlationId: "game-ui-world-grid-1",
+    });
+    expect(grid).toMatchObject({
+      ok: true,
+      procedureKey: "world.grid.read",
+      correlationId: "game-ui-world-grid-1",
+      output: {
+        sourceStatus: {
+          grid: "read-with-omissions",
+          map: "read",
+        },
+        bounds: { x: 3, y: 4, width: 2, height: 1 },
+        fields: ["terrain"],
+        plotCount: 2,
+        omitted: 1,
+        plots: [
+          {
+            location: { x: 3, y: 4, index: 3_004 },
+            facts: { terrain: { ok: true, value: 7 } },
+          },
+        ],
+      },
+    });
+
+    const serialized = JSON.stringify({ plot, grid });
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"session\"");
+    expect(serialized).not.toContain("rawCommand");
+    expect(serialized).not.toContain("Game.");
+    expect(serialized).not.toContain("relationship");
+    expect(serialized).not.toContain("enemy");
+    expect(serialized).not.toContain("hostile");
+    expect(serialized).not.toContain("opponent");
+    expect(serialized).not.toContain("threat");
+    expect(serialized).not.toContain("war");
+    expect(serialized).not.toContain("ally");
+    expect(serialized).not.toContain("suzerain");
+  });
+
+  test("does not advertise world plot/grid without plot-level map APIs", async () => {
+    const bridge = installCiv7GameUiIntelligenceBridge({ target: gameUiTarget() });
+
+    const readiness = await bridge.invoke({
+      procedureKey: "readiness.current",
+      input: {},
+    });
+    expect(readiness).toMatchObject({
+      ok: true,
+      output: {
+        controller: {
+          supportedProcedures: [
+            { procedureKey: "world.current", risk: "read-only" },
+          ],
+        },
+      },
+    });
+
+    const response = await bridge.invoke({
+      procedureKey: "world.plot.read",
+      input: {
+        location: { x: 3, y: 4 },
+        fields: ["terrain"],
+      },
+    });
+    expect(response).toEqual({
+      ok: false,
+      error: {
+        code: "BRIDGE_PROCEDURE_NOT_SUPPORTED",
+        message:
+          "Civ7 controller bridge procedure is not supported by this controller context.",
+        reason: "procedure-not-supported",
+      },
+    });
+  });
+
   test("does not advertise current world without player count APIs", async () => {
     const bridge = installCiv7GameUiIntelligenceBridge({
       target: gameUiTarget({ Players: undefined }),
@@ -3558,6 +3691,24 @@ function gameUiTarget(
     ...target,
     ...overrides,
   };
+}
+
+function gameUiMapReadTarget(): Civ7GameUiRuntimeTarget {
+  const base = gameUiTarget();
+  return gameUiTarget({
+    GameplayMap: {
+      ...(base.GameplayMap ?? {}),
+      isValidXY: (x, y) => x >= 0 && y >= 0 && x < 74 && y < 46,
+      getIndexFromXY: (x, y) => x * 1_000 + y,
+      getTerrainType: () => 7,
+      getOwner: () => 0,
+      getOwnerName: () => "Local Player",
+      getRevealedState: () => 1,
+    },
+    Visibility: {
+      isVisible: () => true,
+    },
+  });
 }
 
 function gameUiStrategyFrontTarget(): Civ7GameUiRuntimeTarget {

--- a/packages/civ7-control-orpc/test/game-ui-controller.test.ts
+++ b/packages/civ7-control-orpc/test/game-ui-controller.test.ts
@@ -135,13 +135,13 @@ describe("Civ7 game UI controller bootstrap", () => {
     expect(serialized).not.toContain("\"session\"");
     expect(serialized).not.toContain("rawCommand");
     expect(serialized).not.toContain("Game.");
-    expect(serialized).not.toContain("enemy");
-    expect(serialized).not.toContain("hostile");
-    expect(serialized).not.toContain("opponent");
-    expect(serialized).not.toContain("threat");
-    expect(serialized).not.toContain("war");
-    expect(serialized).not.toContain("ally");
-    expect(serialized).not.toContain("suzerain");
+    expect(serialized).not.toMatch(/\benemy\b/i);
+    expect(serialized).not.toMatch(/\bhostile\b/i);
+    expect(serialized).not.toMatch(/\bopponent\b/i);
+    expect(serialized).not.toMatch(/\bthreat\b/i);
+    expect(serialized).not.toMatch(/\bwar\b/i);
+    expect(serialized).not.toMatch(/\bally\b/i);
+    expect(serialized).not.toMatch(/\bsuzerain\b/i);
   });
 
   test("reads world plot and grid through game UI map service dependencies", async () => {
@@ -232,13 +232,13 @@ describe("Civ7 game UI controller bootstrap", () => {
     expect(serialized).not.toContain("rawCommand");
     expect(serialized).not.toContain("Game.");
     expect(serialized).not.toContain("relationship");
-    expect(serialized).not.toContain("enemy");
-    expect(serialized).not.toContain("hostile");
-    expect(serialized).not.toContain("opponent");
-    expect(serialized).not.toContain("threat");
-    expect(serialized).not.toContain("war");
-    expect(serialized).not.toContain("ally");
-    expect(serialized).not.toContain("suzerain");
+    expect(serialized).not.toMatch(/\benemy\b/i);
+    expect(serialized).not.toMatch(/\bhostile\b/i);
+    expect(serialized).not.toMatch(/\bopponent\b/i);
+    expect(serialized).not.toMatch(/\bthreat\b/i);
+    expect(serialized).not.toMatch(/\bwar\b/i);
+    expect(serialized).not.toMatch(/\bally\b/i);
+    expect(serialized).not.toMatch(/\bsuzerain\b/i);
   });
 
   test("does not advertise world plot/grid without plot-level map APIs", async () => {
@@ -2268,13 +2268,13 @@ describe("Civ7 game UI controller bootstrap", () => {
     expect(serialized).not.toContain("Game.UnitCommands");
     expect(serialized).not.toContain("sendRequest");
     expect(serialized).not.toContain("friendly");
-    expect(serialized).not.toContain("enemy");
-    expect(serialized).not.toContain("hostile");
-    expect(serialized).not.toContain("opponent");
-    expect(serialized).not.toContain("threat");
-    expect(serialized).not.toContain("war");
-    expect(serialized).not.toContain("ally");
-    expect(serialized).not.toContain("suzerain");
+    expect(serialized).not.toMatch(/\benemy\b/i);
+    expect(serialized).not.toMatch(/\bhostile\b/i);
+    expect(serialized).not.toMatch(/\bopponent\b/i);
+    expect(serialized).not.toMatch(/\bthreat\b/i);
+    expect(serialized).not.toMatch(/\bwar\b/i);
+    expect(serialized).not.toMatch(/\bally\b/i);
+    expect(serialized).not.toMatch(/\bsuzerain\b/i);
   });
 
   test("does not advertise game UI strategy front without owner unit APIs", async () => {

--- a/packages/civ7-control-orpc/test/game-ui-controller.test.ts
+++ b/packages/civ7-control-orpc/test/game-ui-controller.test.ts
@@ -48,11 +48,16 @@ describe("Civ7 game UI controller bootstrap", () => {
         playable: false,
         readiness: "app-ui-game",
         capability: {
-          canObserve: false,
+          canObserve: true,
           canMutate: false,
         },
         controller: {
-          supportedProcedures: [],
+          supportedProcedures: [
+            {
+              procedureKey: "world.current",
+              risk: "read-only",
+            },
+          ],
         },
         sources: {
           gameUi: {
@@ -65,6 +70,115 @@ describe("Civ7 game UI controller bootstrap", () => {
             ready: null,
           },
         },
+      },
+    });
+    expect(response.ok && response.output.nextSteps).toEqual([{
+      kind: "read-world",
+      source: "readiness.current",
+      label: "Read current world facts before choosing support actions.",
+    }]);
+  });
+
+  test("reads current world through game UI service dependency", async () => {
+    const bridge = installCiv7GameUiIntelligenceBridge({ target: gameUiTarget() });
+
+    const response = await bridge.invoke({
+      procedureKey: "world.current",
+      input: {},
+      correlationId: "game-ui-world-1",
+    });
+
+    expect(response).toMatchObject({
+      ok: true,
+      procedureKey: "world.current",
+      correlationId: "game-ui-world-1",
+      output: {
+        playable: false,
+        readiness: "app-ui-game",
+        sourceStatus: {
+          playableStatus: "read",
+          game: "read",
+          map: "read",
+          players: "read",
+        },
+        turn: {
+          current: 42,
+          date: "Ancient Era",
+          age: 1,
+          maxTurns: 500,
+          hash: 123,
+        },
+        localPlayer: {
+          playerId: 0,
+          observerId: 0,
+        },
+        map: {
+          width: 74,
+          height: 46,
+          plotCount: 3404,
+          mapSize: 1,
+          randomSeed: 99,
+        },
+        players: {
+          maxPlayers: 8,
+          alivePlayerIds: [0],
+          aliveHumanIds: [0],
+          aliveHumanCount: 1,
+        },
+      },
+    });
+
+    const serialized = JSON.stringify(response);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"session\"");
+    expect(serialized).not.toContain("rawCommand");
+    expect(serialized).not.toContain("Game.");
+    expect(serialized).not.toContain("enemy");
+    expect(serialized).not.toContain("hostile");
+    expect(serialized).not.toContain("opponent");
+    expect(serialized).not.toContain("threat");
+    expect(serialized).not.toContain("war");
+    expect(serialized).not.toContain("ally");
+    expect(serialized).not.toContain("suzerain");
+  });
+
+  test("does not advertise current world without player count APIs", async () => {
+    const bridge = installCiv7GameUiIntelligenceBridge({
+      target: gameUiTarget({ Players: undefined }),
+    });
+
+    const readiness = await bridge.invoke({
+      procedureKey: "readiness.current",
+      input: {},
+    });
+
+    expect(readiness).toMatchObject({
+      ok: true,
+      output: {
+        capability: {
+          canObserve: false,
+          canMutate: false,
+        },
+        controller: {
+          supportedProcedures: [],
+        },
+      },
+    });
+
+    const world = await bridge.invoke({
+      procedureKey: "world.current",
+      input: {},
+    });
+
+    expect(world).toEqual({
+      ok: false,
+      error: {
+        code: "BRIDGE_PROCEDURE_NOT_SUPPORTED",
+        message:
+          "Civ7 controller bridge procedure is not supported by this controller context.",
+        reason: "procedure-not-supported",
       },
     });
   });
@@ -96,6 +210,10 @@ describe("Civ7 game UI controller bootstrap", () => {
           supportedProcedures: [
             {
               procedureKey: "attention.current",
+              risk: "read-only",
+            },
+            {
+              procedureKey: "world.current",
               risk: "read-only",
             },
             {
@@ -2042,7 +2160,12 @@ describe("Civ7 game UI controller bootstrap", () => {
       ok: true,
       output: {
         controller: {
-          supportedProcedures: [],
+          supportedProcedures: [
+            {
+              procedureKey: "world.current",
+              risk: "read-only",
+            },
+          ],
         },
       },
     });
@@ -3315,7 +3438,7 @@ describe("Civ7 game UI controller bootstrap", () => {
 
     expect(context.endpointDefaults).toEqual({ timeoutMs: 250 });
     expect(context.controller).toEqual({
-      supportedReadProcedures: [],
+      supportedReadProcedures: ["world.current"],
       supportedMutationProcedures: [],
     });
     expect(context.controllerProof).toEqual({
@@ -3355,7 +3478,7 @@ describe("Civ7 game UI controller bootstrap", () => {
     });
 
     expect(context.controller).toEqual({
-      supportedReadProcedures: ["attention.current"],
+      supportedReadProcedures: ["attention.current", "world.current"],
       supportedMutationProcedures: ["notifications.dismiss.request"],
     });
     expect(await context.directControl.getCiv7PlayableStatus()).toMatchObject({

--- a/packages/civ7-control-orpc/test/notification-queue-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/notification-queue-procedure.test.ts
@@ -1,0 +1,441 @@
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+import { Value } from "typebox/value";
+
+import {
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  Civ7NotificationQueueUnavailableError,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+  type Civ7ControlOrpcNotificationDismissalResult,
+} from "../src/index";
+import { typeboxInputSchemaFromContractProcedure } from "../src/typebox-standard-schema";
+import type {
+  Civ7ControlOrpcPlayNotificationViewResult,
+} from "../src/dependencies/direct-control";
+
+const informationalId = { owner: 0, id: 113, type: 20 };
+const unitLostId = { owner: 0, id: 114, type: 20 };
+const productionId = { owner: 0, id: 115, type: 20 };
+
+const QueueCurrentInputSchema = typeboxInputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.notifications.queue.current,
+);
+const QueueDismissInputSchema = typeboxInputSchemaFromContractProcedure(
+  Civ7ControlOrpcContract.notifications.queue.dismiss.request,
+);
+
+describe("notifications.queue control-oRPC procedures", () => {
+  test("schedules notification queue with semantic next steps and no CLI command strings", async () => {
+    const fake = fakeContext();
+    const result = await call(
+      Civ7ControlOrpcRouter.notifications.queue.current,
+      { maxNotifications: 12 },
+      { context: fake.context },
+    );
+
+    expect(fake.calls.notifications).toEqual([{
+      host: "127.0.0.1",
+      port: 4318,
+      timeoutMs: 1_000,
+      maxNotifications: 12,
+    }]);
+    expect(result).toMatchObject({
+      localPlayerId: 0,
+      queueLength: 3,
+      schedule: [
+        {
+          disposition: "inspect-ready-unit",
+          notificationId: unitLostId,
+          safeToBatch: false,
+        },
+        {
+          disposition: "operate-with-live-inputs",
+          notificationId: productionId,
+          safeToBatch: false,
+        },
+        {
+          disposition: "reviewed-dismissal-candidate",
+          notificationId: informationalId,
+          safeToBatch: true,
+        },
+      ],
+    });
+    expect(result.nextSteps.map((step) => step.kind)).toEqual([
+      "inspect-ready-unit",
+      "inspect-ready-city",
+      "dismiss-notification",
+    ]);
+    expectSafeQueueOutput(result);
+  });
+
+  test("bulk dismisses only safe informational queue candidates and keeps aggregate no-repeat guarded", async () => {
+    const fake = fakeContext({
+      dismissalResult: notificationDismissalResult("engine-front-still-live", {
+        notificationId: informationalId,
+        verified: true,
+      }),
+    });
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    const result = await client.notifications.queue.dismiss.request({
+      send: true,
+      maxDismissals: 5,
+    });
+
+    expect(fake.calls.dismissals).toEqual([{
+      input: { notificationId: informationalId },
+      options: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+    }]);
+    expect(result).toMatchObject({
+      sent: true,
+      status: "sent-guarded",
+      eligibleCount: 1,
+      selectedCount: 1,
+      noRepeatAfterUnverified: true,
+      candidates: [{
+        notificationId: informationalId,
+        disposition: "reviewed-dismissal-candidate",
+      }],
+      excluded: expect.arrayContaining([
+        expect.objectContaining({
+          notificationId: unitLostId,
+          reason: expect.stringContaining("not bulk dismissal"),
+        }),
+        expect.objectContaining({
+          notificationId: productionId,
+          reason: expect.stringContaining("gameplay operation"),
+        }),
+      ]),
+      results: [{
+        notificationId: informationalId,
+        status: "sent-unverified",
+        postcondition: {
+          classification: "engine-front-still-live",
+          noRepeatAfterUnverified: true,
+        },
+      }],
+      nextSteps: expect.arrayContaining([expect.objectContaining({
+        kind: "do-not-repeat",
+        source: "notifications.queue.dismiss.request",
+      })]),
+    });
+    expectSafeQueueOutput(result);
+  });
+
+  test("dry run does not call dismissal runtime ports", async () => {
+    const fake = fakeContext();
+
+    const result = await call(
+      Civ7ControlOrpcRouter.notifications.queue.dismiss.request,
+      { maxDismissals: 1 },
+      { context: fake.context },
+    );
+
+    expect(fake.calls.dismissals).toEqual([]);
+    expect(result).toMatchObject({
+      sent: false,
+      status: "not-sent",
+      eligibleCount: 1,
+      selectedCount: 1,
+      noRepeatAfterUnverified: true,
+    });
+  });
+
+  test("rejects raw endpoint/session/command input before facade reads", async () => {
+    const invalidInputs = [
+      { host: "127.0.0.1" },
+      { port: 4318 },
+      { state: { role: "tuner" } },
+      { session: { state: "App UI" } },
+      { command: "Game.Notifications.dismiss" },
+      { rawCommand: "Game.Notifications.dismiss" },
+      { maxNotifications: 0 },
+      { maxDismissals: 0 },
+    ];
+
+    for (const input of invalidInputs) {
+      const fake = fakeContext();
+      await expect(
+        call(
+          Civ7ControlOrpcRouter.notifications.queue.dismiss.request,
+          input as never,
+          { context: fake.context },
+        ),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(fake.calls.notifications).toEqual([]);
+      expect(fake.calls.dismissals).toEqual([]);
+    }
+
+    expect(Value.Check(QueueCurrentInputSchema, { maxNotifications: 50 })).toBe(true);
+    expect(Value.Check(QueueCurrentInputSchema, { rawCommand: "Game.turn" })).toBe(false);
+    expect(Value.Check(QueueDismissInputSchema, { send: true, maxDismissals: 2 })).toBe(true);
+    expect(Value.Check(QueueDismissInputSchema, { approvalReason: "go" })).toBe(false);
+  });
+
+  test("maps queue source failures to tagged errors without raw command details", async () => {
+    const fake = fakeContext({
+      notificationViewError: new Error(
+        "Timed out waiting for Civ7 tuner response to CMD:65535:Game.Notifications.dismiss(...)",
+      ),
+    });
+
+    await expect(
+      call(Civ7ControlOrpcRouter.notifications.queue.current, {}, {
+        context: fake.context,
+      }),
+    ).rejects.toMatchObject({
+      code: "NOTIFICATION_QUEUE_UNAVAILABLE",
+      status: 503,
+      data: {
+        procedureKey: "notifications.queue.current",
+        source: "direct-control-facade",
+      },
+    });
+
+    try {
+      await call(Civ7ControlOrpcRouter.notifications.queue.current, {}, {
+        context: fake.context,
+      });
+    } catch (err) {
+      const serialized = JSON.stringify(err);
+      expect(serialized).not.toContain("CMD");
+      expect(serialized).not.toContain("Game.Notifications");
+      expect(serialized).not.toContain("rawCommand");
+      expect(serialized).not.toContain("command-failed");
+    }
+  });
+
+  test("publishes contract-first notification queue leaves", () => {
+    expect(
+      Civ7ControlOrpcContract.notifications.queue.current["~orpc"],
+    ).toMatchObject({
+      meta: {
+        family: "notifications",
+        procedureKey: "notifications.queue.current",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      },
+    });
+    expect(
+      Civ7ControlOrpcContract.notifications.queue.dismiss.request["~orpc"],
+    ).toMatchObject({
+      meta: {
+        family: "notifications",
+        procedureKey: "notifications.queue.dismiss.request",
+        proofBoundary: "local-package-test",
+        risk: "mutation",
+      },
+    });
+    expect(
+      Civ7ControlOrpcContract.notifications.queue.current["~orpc"].errorMap,
+    ).toHaveProperty("NOTIFICATION_QUEUE_UNAVAILABLE");
+    expect(Civ7NotificationQueueUnavailableError.code).toBe(
+      "NOTIFICATION_QUEUE_UNAVAILABLE",
+    );
+  });
+});
+
+function fakeContext(options: {
+  notificationViewError?: Error;
+  dismissalResult?: Civ7ControlOrpcNotificationDismissalResult;
+} = {}): {
+  context: Civ7ControlOrpcContext;
+  calls: {
+    notifications: unknown[];
+    dismissals: Array<{ input: unknown; options: unknown }>;
+  };
+} {
+  const calls = {
+    notifications: [] as unknown[],
+    dismissals: [] as Array<{ input: unknown; options: unknown }>,
+  };
+
+  return {
+    calls,
+    context: {
+      endpointDefaults: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      directControl: {
+        getCiv7PlayableStatus: async () => ({
+          playable: true,
+          readiness: "tuner-ready",
+        }),
+        getCiv7PlayNotificationView: async (input) => {
+          calls.notifications.push(input);
+          if (options.notificationViewError) throw options.notificationViewError;
+          return notificationView();
+        },
+        requestCiv7NotificationDismissal: async (input, endpointDefaults) => {
+          calls.dismissals.push({ input, options: endpointDefaults });
+          return options.dismissalResult ??
+            notificationDismissalResult("notification-disappeared", {
+              notificationId: informationalId,
+            });
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function notificationView(): Civ7ControlOrpcPlayNotificationViewResult {
+  return {
+    localPlayerId: 0,
+    turn: { ok: true, value: 7 },
+    turnDate: { ok: true, value: "3800 BCE" },
+    blocker: { ok: true, value: 2_091_697_919 },
+    blockingNotificationId: { ok: true, value: unitLostId },
+    canEndTurn: { ok: true, value: false },
+    limits: { requested: 50, returned: 3, truncated: false },
+    hud: {
+      nextDecision: null,
+      decisionQueue: [
+        queueItem({
+          notificationId: informationalId,
+          category: "informational-notification",
+          typeName: "NOTIFICATION_WONDER_COMPLETED",
+          summary: "Wonder Completed",
+          operationFamily: "app-ui-action",
+          operationType: "Game.Notifications.dismiss",
+        }),
+        queueItem({
+          notificationId: unitLostId,
+          category: "unit-command",
+          typeName: "NOTIFICATION_UNIT_LOST",
+          summary: "Unit Lost",
+          isEndTurnBlocking: true,
+          operationFamily: "app-ui-action",
+          operationType: "Game.Notifications.dismiss",
+        }),
+        queueItem({
+          notificationId: productionId,
+          category: "production-choice",
+          typeName: "NOTIFICATION_PRODUCTION_NEEDED",
+          summary: "Production Needed",
+          operationFamily: "city-command",
+          operationType: "BUILD",
+          requiredInputs: [{ name: "cityId", required: true }],
+        }),
+      ],
+    },
+    notes: [],
+  } as Civ7ControlOrpcPlayNotificationViewResult;
+}
+
+function queueItem(overrides: Partial<Civ7ControlOrpcPlayNotificationViewResult["hud"]["decisionQueue"][number]> = {}): Civ7ControlOrpcPlayNotificationViewResult["hud"]["decisionQueue"][number] {
+  return {
+    notificationId: informationalId,
+    isEndTurnBlocking: false,
+    category: "informational-notification",
+    typeName: "NOTIFICATION_WONDER_COMPLETED",
+    summary: "Wonder Completed",
+    message: "Wonder Completed",
+    location: null,
+    target: null,
+    operationFamily: "app-ui-action",
+    operationType: "Game.Notifications.dismiss",
+    requiredInputs: [],
+    cli: null,
+    ...overrides,
+  } as Civ7ControlOrpcPlayNotificationViewResult["hud"]["decisionQueue"][number];
+}
+
+function notificationDismissalResult(
+  classification: Civ7ControlOrpcNotificationDismissalResult["postcondition"]["classification"],
+  options: {
+    notificationId?: typeof informationalId;
+    verified?: boolean;
+  } = {},
+): Civ7ControlOrpcNotificationDismissalResult {
+  const id = options.notificationId ?? informationalId;
+  const before = notificationSummary(id);
+  const after = classification === "engine-front-still-live"
+    ? notificationSummary(id, {
+      dismissed: true,
+      notificationTrainContains: { ok: true, value: false },
+      isNotificationTrainFront: { ok: true, value: false },
+      isEngineQueueFront: { ok: true, value: true },
+    })
+    : notificationSummary(id, { exists: false });
+
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    notificationId: id,
+    before,
+    after,
+    canDismiss: true,
+    sent: true,
+    result: {
+      notificationTrainManager: {
+        ok: true,
+        attempted: true,
+        available: true,
+        path: "NotificationModel.manager.dismiss",
+      },
+    },
+    closeoutPath: "NotificationModel.manager.dismiss",
+    verificationAttempts: [before, after],
+    verified: options.verified ?? classification === "notification-disappeared",
+    postcondition: {
+      classification,
+      reason: `test ${classification}`,
+    },
+    notes: ["fixture"],
+  };
+}
+
+function notificationSummary(
+  id: typeof informationalId,
+  overrides: Partial<Civ7ControlOrpcNotificationDismissalResult["before"]> = {},
+): Civ7ControlOrpcNotificationDismissalResult["before"] {
+  return {
+    id,
+    exists: true,
+    type: 2_091_697_919,
+    typeName: "NOTIFICATION_WONDER_COMPLETED",
+    summary: "Wonder Completed",
+    message: "Wonder Completed",
+    target: { owner: -1, id: -1, type: 0 },
+    location: { x: -9999, y: -9999 },
+    canUserDismiss: true,
+    expired: false,
+    dismissed: false,
+    blocksTurnAdvancement: { ok: true, value: true },
+    endTurnBlockingType: { ok: true, value: 2_091_697_919 },
+    isEndTurnBlocking: { ok: true, value: true },
+    engineQueueCount: { ok: true, value: 1 },
+    engineQueueContains: { ok: true, value: true },
+    engineQueueFirstId: { ok: true, value: id },
+    isEngineQueueFront: { ok: true, value: true },
+    notificationTrainCount: { ok: true, value: 1 },
+    notificationTrainContains: { ok: true, value: true },
+    notificationTrainFirstId: { ok: true, value: id },
+    isNotificationTrainFront: { ok: true, value: true },
+    ...overrides,
+  };
+}
+
+function expectSafeQueueOutput(output: unknown): void {
+  const serialized = JSON.stringify(output);
+  expect(serialized).not.toContain("127.0.0.1");
+  expect(serialized).not.toContain("65535");
+  expect(serialized).not.toContain("\"host\"");
+  expect(serialized).not.toContain("\"port\"");
+  expect(serialized).not.toContain("\"state\"");
+  expect(serialized).not.toContain("\"session\"");
+  expect(serialized).not.toContain("rawCommand");
+  expect(serialized).not.toContain("Game.Notifications.dismiss(");
+  expect(serialized).not.toContain("game play");
+  expect(serialized).not.toContain("approval");
+  expect(serialized).not.toContain("approvalReason");
+}

--- a/packages/civ7-control-orpc/test/readiness-current-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/readiness-current-procedure.test.ts
@@ -234,6 +234,47 @@ describe("readiness.current control-oRPC procedure", () => {
     );
   });
 
+  test("recommends current world when it is the supported controller read", async () => {
+    const fake = fakeContext(playableStatusResult({
+      playable: false,
+      readiness: "app-ui-game",
+      tunerReady: null,
+    }), {
+      controller: {
+        supportedReadProcedures: ["world.current"],
+      },
+    });
+
+    const result = await call(Civ7ControlOrpcRouter.readiness.current, {}, {
+      context: fake.context,
+    });
+
+    expect(result).toMatchObject({
+      playable: false,
+      readiness: "app-ui-game",
+      capability: {
+        canObserve: true,
+        canMutate: false,
+        reason:
+          "The game UI controller can read supported procedure evidence; broad runtime mutation remains unavailable.",
+      },
+      controller: {
+        supportedProcedures: [{
+          procedureKey: "world.current",
+          risk: "read-only",
+        }],
+      },
+      nextSteps: [{
+        kind: "read-world",
+        source: "readiness.current",
+        label: "Read current world facts before choosing support actions.",
+      }],
+    });
+    expect(result.nextSteps.map((step) => step.kind)).not.toContain(
+      "read-attention",
+    );
+  });
+
   test("keeps endpoint/session/state/raw command fields out of procedure input", async () => {
     const invalidInputs = [
       { host: "127.0.0.1" },

--- a/packages/civ7-control-orpc/test/strategy-civilian-route-triage-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/strategy-civilian-route-triage-procedure.test.ts
@@ -1,0 +1,456 @@
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  Civ7StrategyCivilianRouteTriageUnavailableError,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+} from "../src/index";
+import type {
+  Civ7ControlOrpcBattlefieldScanResult,
+  Civ7ControlOrpcDestinationAnalysisResult,
+  Civ7ControlOrpcPlayNotificationViewResult,
+  Civ7ControlOrpcReadyUnitViewResult,
+  Civ7ControlOrpcSettlementRecommendationsResult,
+} from "../src/dependencies/direct-control";
+
+describe("strategy.civilianRouteTriage control-oRPC procedure", () => {
+  test("composes route evidence into semantic civilian triage", async () => {
+    const fake = fakeContext({});
+
+    const result = await call(
+      Civ7ControlOrpcRouter.strategy.civilianRouteTriage,
+      {
+        origin: { x: 15, y: 23 },
+        settlementCount: 5,
+        scanRadius: 6,
+        maxUnits: 96,
+        maxCities: 40,
+      },
+      { context: fake.context },
+    );
+
+    expect(fake.calls).toMatchObject({
+      notifications: [{ maxNotifications: 10 }],
+      readyUnit: [],
+      settlement: [{
+        input: {
+          playerId: undefined,
+          locations: [{ x: 15, y: 23 }],
+          count: 5,
+          includeSettlers: false,
+          includeCities: false,
+        },
+      }],
+      battlefield: [{
+        input: {
+          playerId: undefined,
+          origins: [{ x: 15, y: 23 }],
+          radius: 6,
+          maxUnits: 96,
+          maxCities: 40,
+        },
+      }],
+      destinationAnalysis: [{
+        input: {
+          playerId: undefined,
+          origin: { x: 15, y: 23 },
+          destination: { x: 20, y: 20 },
+          corridorRadius: 2,
+          destinationRadius: 4,
+          maxUnits: 96,
+          maxCities: 40,
+        },
+      }],
+    });
+    expect(result).toMatchObject({
+      playerId: 0,
+      localPlayerId: 0,
+      origin: { x: 15, y: 23 },
+      destination: { x: 20, y: 20 },
+      sourceStatus: {
+        notifications: "read",
+        readyUnit: "skipped-explicit-origin",
+        settlementRecommendations: "read",
+        battlefieldScan: "read",
+        destinationAnalysis: "read",
+      },
+      relationshipLabelPolicy: {
+        relationshipSource: "not-classified",
+        relationshipProof: "none",
+        unprovenLabel: "relationship-unproven",
+      },
+      triage: {
+        status: "hold-or-screen",
+        summary: "civilian route (15,23) -> (20,20)",
+      },
+    });
+    expect(result.triage.nextSteps.map((step) => step.kind)).toContain(
+      "validate-unit-action",
+    );
+    expect(JSON.stringify(result.nextSteps)).not.toContain("game play");
+    expectSafeCivilianTriageOutput(result);
+  });
+
+  test("infers ready-unit origin and supports the in-process server client", async () => {
+    const fake = fakeContext({});
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    const result = await client.strategy.civilianRouteTriage({});
+
+    expect(fake.calls.readyUnit).toHaveLength(1);
+    expect(fake.calls.settlement[0]?.input).toMatchObject({
+      locations: [{ x: 17, y: 20 }],
+      includeSettlers: false,
+    });
+    expect(result.origin).toEqual({ x: 17, y: 20 });
+    expect(result.destination).toEqual({ x: 20, y: 20 });
+    expect(result.sourceStatus.readyUnit).toBe("read");
+    expect(result.readyUnit).toMatchObject({
+      unitId: { owner: 0, id: 458752, type: 26 },
+      typeName: "UNIT_SETTLER",
+      location: { x: 17, y: 20 },
+      legalOperationCount: 1,
+    });
+  });
+
+  test("rejects endpoint/session/raw command input before facade reads", async () => {
+    const invalidInputs = [
+      { host: "127.0.0.1" },
+      { port: 4318 },
+      { state: { role: "tuner" } },
+      { session: { state: "Tuner" } },
+      { command: "Game.turn" },
+      { rawCommand: "Game.turn" },
+    ];
+
+    for (const input of invalidInputs) {
+      const fake = fakeContext({});
+      await expect(
+        call(
+          Civ7ControlOrpcRouter.strategy.civilianRouteTriage,
+          input as never,
+          { context: fake.context },
+        ),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(fake.calls).toEqual(emptyCalls());
+    }
+  });
+
+  test("maps source failures to tagged errors without raw command details", async () => {
+    const context: Civ7ControlOrpcContext = {
+      directControl: {
+        getCiv7PlayNotificationView: async () => {
+          throw new Error(
+            "Timed out waiting for Civ7 tuner response to CMD:1:Game.turn",
+          );
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    };
+
+    await expect(
+      call(Civ7ControlOrpcRouter.strategy.civilianRouteTriage, {}, { context }),
+    ).rejects.toMatchObject({
+      code: "STRATEGY_CIVILIAN_ROUTE_TRIAGE_UNAVAILABLE",
+      status: 503,
+      data: {
+        procedureKey: "strategy.civilianRouteTriage",
+        source: "direct-control-facade",
+      },
+    });
+
+    try {
+      await call(Civ7ControlOrpcRouter.strategy.civilianRouteTriage, {}, {
+        context,
+      });
+    } catch (err) {
+      const serialized = JSON.stringify(err);
+      expect(serialized).not.toContain("CMD");
+      expect(serialized).not.toContain("Game.turn");
+      expect(serialized).not.toContain("rawCommand");
+      expect(serialized).not.toContain("command-failed");
+    }
+  });
+
+  test("publishes a contract-first strategy.civilianRouteTriage service leaf", () => {
+    expect(
+      Civ7ControlOrpcContract.strategy.civilianRouteTriage["~orpc"],
+    ).toMatchObject({
+      meta: {
+        family: "strategy",
+        procedureKey: "strategy.civilianRouteTriage",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      },
+    });
+    expect(
+      Civ7ControlOrpcContract.strategy.civilianRouteTriage["~orpc"].errorMap,
+    ).toHaveProperty("STRATEGY_CIVILIAN_ROUTE_TRIAGE_UNAVAILABLE");
+    expect(Civ7StrategyCivilianRouteTriageUnavailableError.code).toBe(
+      "STRATEGY_CIVILIAN_ROUTE_TRIAGE_UNAVAILABLE",
+    );
+  });
+});
+
+type Calls = ReturnType<typeof emptyCalls>;
+
+function emptyCalls() {
+  return {
+    notifications: [] as unknown[],
+    readyUnit: [] as Array<Readonly<{ input: unknown }>>,
+    settlement: [] as Array<Readonly<{ input: unknown }>>,
+    battlefield: [] as Array<Readonly<{ input: unknown }>>,
+    destinationAnalysis: [] as Array<Readonly<{ input: unknown }>>,
+  };
+}
+
+function fakeContext(
+  overrides: Partial<{
+    notifications: Civ7ControlOrpcPlayNotificationViewResult;
+    readyUnit: Civ7ControlOrpcReadyUnitViewResult;
+    settlement: Civ7ControlOrpcSettlementRecommendationsResult;
+    battlefield: Civ7ControlOrpcBattlefieldScanResult;
+    destinationAnalysis: Civ7ControlOrpcDestinationAnalysisResult;
+  }>,
+): { calls: Calls; context: Civ7ControlOrpcContext } {
+  const calls = emptyCalls();
+  const results = {
+    notifications: playNotificationView(),
+    readyUnit: readyUnitView(),
+    settlement: settlementRecommendations(),
+    battlefield: battlefieldScan(),
+    destinationAnalysis: destinationAnalysis(),
+    ...overrides,
+  };
+
+  return {
+    calls,
+    context: {
+      endpointDefaults: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      directControl: {
+        getCiv7PlayNotificationView: async (options) => {
+          calls.notifications.push(options);
+          return results.notifications;
+        },
+        getCiv7ReadyUnitView: async (input) => {
+          calls.readyUnit.push({ input });
+          return results.readyUnit;
+        },
+        getCiv7SettlementRecommendations: async (input) => {
+          calls.settlement.push({ input });
+          return results.settlement;
+        },
+        getCiv7BattlefieldScan: async (input) => {
+          calls.battlefield.push({ input });
+          return results.battlefield;
+        },
+        getCiv7DestinationAnalysis: async (input) => {
+          calls.destinationAnalysis.push({ input });
+          return results.destinationAnalysis;
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function playNotificationView(): Civ7ControlOrpcPlayNotificationViewResult {
+  const unitId = { owner: 0, id: 458752, type: 26 };
+  return {
+    localPlayerId: 0,
+    turn: { ok: true, value: 75 },
+    turnDate: { ok: true, value: "2150 BCE" },
+    hasSentTurnComplete: { ok: true, value: false },
+    canEndTurn: { ok: true, value: false },
+    blocker: { ok: true, value: 0 },
+    blockingNotificationId: { ok: true, value: null },
+    selectedUnitId: { ok: true, value: null },
+    selectedCityId: { ok: true, value: null },
+    firstReadyUnitId: { ok: true, value: unitId },
+    notifications: [],
+    decisions: [],
+    hud: { nextDecision: null, decisionQueue: [] },
+    limits: { maxNotifications: 10, truncated: false },
+  };
+}
+
+function readyUnitView(): Civ7ControlOrpcReadyUnitViewResult {
+  const unitId = { owner: 0, id: 458752, type: 26 };
+  return {
+    localPlayerId: 0,
+    requestedUnitId: unitId,
+    selectedUnitId: { ok: true, value: null },
+    firstReadyUnitId: { ok: true, value: unitId },
+    unitId,
+    unit: {
+      ok: true,
+      value: {
+        id: unitId,
+        owner: 0,
+        type: 333,
+        typeName: "UNIT_SETTLER",
+        location: { x: 17, y: 20 },
+        movementMovesRemaining: 2,
+        attacksRemaining: 0,
+        damage: 0,
+        hitPoints: 100,
+      },
+    },
+    legalOperations: [{
+      family: "unit-operation",
+      operationType: "SKIP_TURN",
+      enumValue: 1,
+      valid: true,
+      result: { Success: true },
+    }],
+    promotionReadiness: {
+      ok: true,
+      value: {
+        canPurchase: false,
+        promotionClass: "PROMOTION_CLASS_LAND_COMMANDER",
+        promotions: [],
+        notes: [],
+      },
+    },
+    nearby: { ok: true, value: [] },
+    notes: ["Ready unit fixture."],
+  };
+}
+
+function settlementRecommendations():
+  Civ7ControlOrpcSettlementRecommendationsResult {
+  return {
+    localPlayerId: 0,
+    playerId: 0,
+    count: 5,
+    requestedLocations: [{ x: 15, y: 23 }],
+    origins: [{
+      kind: "requested",
+      location: { x: 15, y: 23 },
+      plotIndex: { ok: true, value: 1927 },
+    }],
+    recommendations: [{
+      origin: {
+        kind: "requested",
+        location: { x: 15, y: 23 },
+        plotIndex: { ok: true, value: 1927 },
+      },
+      suggestions: {
+        ok: true,
+        value: [{
+          location: { x: 20, y: 20 },
+          plotIndex: { ok: true, value: 1660 },
+          factors: [{
+            positive: true,
+            title: "total yield",
+            description: "good total yield",
+          }],
+        }],
+      },
+    }],
+    notes: ["Settlement recommendation fixture."],
+  };
+}
+
+function battlefieldScan(): Civ7ControlOrpcBattlefieldScanResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    playerId: 0,
+    origins: [{ x: 17, y: 20 }],
+    radius: 6,
+    hiddenInfoPolicy: "runtime-debug-summary",
+    relationshipLabelPolicy: relationshipPolicy(),
+    units: [],
+    cities: [],
+    owners: [{
+      owner: 0,
+      stance: "friendly",
+      relationshipProof: "self",
+      relationshipLabel: "friendly",
+      unitCount: 1,
+      cityCount: 0,
+      roles: {},
+      apparentStrength: 1,
+      nearestUnit: { distance: 0 },
+      nearestCity: null,
+    }],
+    pointsOfInterest: [{
+      kind: "civilian-risk",
+      severity: "high",
+      location: { x: 16, y: 18 },
+      summary: "friendly civilian has other-owner contact within 4 tiles",
+    }],
+    notes: ["Battlefield fixture."],
+  };
+}
+
+function destinationAnalysis(): Civ7ControlOrpcDestinationAnalysisResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    playerId: 0,
+    origin: { x: 15, y: 23 },
+    destination: { x: 20, y: 20 },
+    corridorRadius: 2,
+    destinationRadius: 4,
+    hiddenInfoPolicy: "runtime-debug-summary",
+    relationshipLabelPolicy: relationshipPolicy(),
+    corridor: {
+      routeHint: "straight-line-grid-corridor",
+      directGridDistance: 5,
+      sampleCount: 2,
+      sampledPlots: [],
+      units: [],
+      unitCount: 0,
+    },
+    destinationPressure: {
+      units: [],
+      unitCount: 1,
+      cities: [],
+      cityCount: 1,
+      apparentOtherStrength: 20,
+    },
+    pointsOfInterest: [{
+      kind: "destination-pressure",
+      severity: "medium",
+      location: { x: 20, y: 20 },
+      summary: "1 other-owner units near destination",
+    }],
+    notes: ["Destination fixture."],
+  };
+}
+
+function relationshipPolicy() {
+  return {
+    relationshipSource: "not-classified" as const,
+    relationshipProof: "none" as const,
+    unprovenLabel: "relationship-unproven" as const,
+    guidance: "neutral relationship policy",
+  };
+}
+
+function expectSafeCivilianTriageOutput(value: unknown): void {
+  const serialized = JSON.stringify(value);
+  expect(serialized).not.toContain("\"host\"");
+  expect(serialized).not.toContain("\"port\"");
+  expect(serialized).not.toContain("\"state\"");
+  expect(serialized).not.toContain("Game.turn");
+  expect(serialized).not.toContain("rawCommand");
+  expect(serialized).not.toMatch(/\benemy\b/i);
+  expect(serialized).not.toMatch(/\bhostile\b/i);
+  expect(serialized).not.toMatch(/\bopponent\b/i);
+  expect(serialized).not.toMatch(/\bthreat\b/i);
+  expect(serialized).not.toMatch(/\bwar\b/i);
+  expect(serialized).not.toMatch(/\bally\b/i);
+  expect(serialized).not.toMatch(/\bsuzerain\b/i);
+}

--- a/packages/civ7-control-orpc/test/strategy-formation-snapshot-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/strategy-formation-snapshot-procedure.test.ts
@@ -1,0 +1,382 @@
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  Civ7StrategyFormationSnapshotUnavailableError,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+} from "../src/index";
+import type {
+  Civ7ControlOrpcBattlefieldScanResult,
+  Civ7ControlOrpcPlayNotificationViewResult,
+  Civ7ControlOrpcReadyUnitViewResult,
+} from "../src/dependencies/direct-control";
+
+describe("strategy.formationSnapshot control-oRPC procedure", () => {
+  test("composes ready-unit and battlefield evidence into a safe formation view", async () => {
+    const fake = fakeContext({});
+
+    const result = await call(
+      Civ7ControlOrpcRouter.strategy.formationSnapshot,
+      {
+        radius: 6,
+        screenRadius: 2,
+        contactRadius: 4,
+        maxUnits: 96,
+        maxCities: 40,
+      },
+      { context: fake.context },
+    );
+
+    expect(fake.calls).toEqual({
+      notifications: [{
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+        maxNotifications: 10,
+      }],
+      readyUnit: [{
+        input: {
+          unitId: { owner: 0, id: 458752, type: 26 },
+          radius: 2,
+        },
+      }],
+      battlefield: [{
+        input: {
+          playerId: undefined,
+          origins: [{ x: 17, y: 20 }],
+          radius: 6,
+          maxUnits: 96,
+          maxCities: 40,
+        },
+      }],
+    });
+    expect(result).toMatchObject({
+      playerId: 0,
+      localPlayerId: 0,
+      origin: { x: 17, y: 20 },
+      sourceStatus: {
+        notifications: "read",
+        readyUnit: "read",
+        battlefieldScan: "read",
+      },
+      readyUnit: {
+        unitId: { owner: 0, id: 458752, type: 26 },
+        typeName: "UNIT_ARMY_COMMANDER",
+        location: { x: 17, y: 20 },
+        legalNoTargetOperationCount: 1,
+      },
+      formation: {
+        posture: "screen-civilian",
+        relationshipLabelPolicy: {
+          relationshipSource: "not-classified",
+          relationshipProof: "none",
+          unprovenLabel: "relationship-unproven",
+        },
+      },
+    });
+    expect(result.formation.civilians).toHaveLength(1);
+    expect(result.formation.screens.length).toBeGreaterThan(0);
+    expect(result.formation.otherOwnerContacts.length).toBeGreaterThan(0);
+    expect(result.formation.nearbyContacts.length).toBeGreaterThan(0);
+    expect(result.formation.nextSteps.map((step) => step.kind)).toContain(
+      "inspect-civilian-route",
+    );
+    expect(JSON.stringify(result.nextSteps)).not.toContain("game play");
+    expectSafeFormationOutput(result);
+  });
+
+  test("skips ready-unit reads when caller provides an explicit origin", async () => {
+    const fake = fakeContext({});
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    const result = await client.strategy.formationSnapshot({
+      origin: { x: 22, y: 18 },
+      radius: 5,
+    });
+
+    expect(fake.calls.readyUnit).toEqual([]);
+    expect(fake.calls.battlefield[0]?.input).toMatchObject({
+      origins: [{ x: 22, y: 18 }],
+      radius: 5,
+    });
+    expect(result.sourceStatus.readyUnit).toBe("skipped-explicit-origin");
+    expect(result.origin).toEqual({ x: 22, y: 18 });
+  });
+
+  test("rejects endpoint/session/raw command input before facade reads", async () => {
+    const invalidInputs = [
+      { host: "127.0.0.1" },
+      { port: 4318 },
+      { state: { role: "tuner" } },
+      { session: { state: "Tuner" } },
+      { command: "Game.turn" },
+      { rawCommand: "Game.turn" },
+    ];
+
+    for (const input of invalidInputs) {
+      const fake = fakeContext({});
+      await expect(
+        call(
+          Civ7ControlOrpcRouter.strategy.formationSnapshot,
+          input as never,
+          { context: fake.context },
+        ),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(fake.calls).toEqual(emptyCalls());
+    }
+  });
+
+  test("maps source failures to tagged errors without raw command details", async () => {
+    const context: Civ7ControlOrpcContext = {
+      directControl: {
+        getCiv7PlayNotificationView: async () => {
+          throw new Error(
+            "Timed out waiting for Civ7 tuner response to CMD:1:Game.turn",
+          );
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    };
+
+    await expect(
+      call(Civ7ControlOrpcRouter.strategy.formationSnapshot, {}, { context }),
+    ).rejects.toMatchObject({
+      code: "STRATEGY_FORMATION_SNAPSHOT_UNAVAILABLE",
+      status: 503,
+      data: {
+        procedureKey: "strategy.formationSnapshot",
+        source: "direct-control-facade",
+      },
+    });
+
+    try {
+      await call(Civ7ControlOrpcRouter.strategy.formationSnapshot, {}, {
+        context,
+      });
+    } catch (err) {
+      const serialized = JSON.stringify(err);
+      expect(serialized).not.toContain("CMD");
+      expect(serialized).not.toContain("Game.turn");
+      expect(serialized).not.toContain("rawCommand");
+      expect(serialized).not.toContain("command-failed");
+    }
+  });
+
+  test("publishes a contract-first strategy.formationSnapshot service leaf", () => {
+    expect(
+      Civ7ControlOrpcContract.strategy.formationSnapshot["~orpc"],
+    ).toMatchObject({
+      meta: {
+        family: "strategy",
+        procedureKey: "strategy.formationSnapshot",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      },
+    });
+    expect(
+      Civ7ControlOrpcContract.strategy.formationSnapshot["~orpc"].errorMap,
+    ).toHaveProperty("STRATEGY_FORMATION_SNAPSHOT_UNAVAILABLE");
+    expect(Civ7StrategyFormationSnapshotUnavailableError.code).toBe(
+      "STRATEGY_FORMATION_SNAPSHOT_UNAVAILABLE",
+    );
+  });
+});
+
+type Calls = ReturnType<typeof emptyCalls>;
+
+function emptyCalls() {
+  return {
+    notifications: [] as unknown[],
+    readyUnit: [] as Array<Readonly<{ input: unknown }>>,
+    battlefield: [] as Array<Readonly<{ input: unknown }>>,
+  };
+}
+
+function fakeContext(
+  overrides: Partial<{
+    notifications: Civ7ControlOrpcPlayNotificationViewResult;
+    readyUnit: Civ7ControlOrpcReadyUnitViewResult;
+    battlefield: Civ7ControlOrpcBattlefieldScanResult;
+  }>,
+): { calls: Calls; context: Civ7ControlOrpcContext } {
+  const calls = emptyCalls();
+  const results = {
+    notifications: playNotificationView(),
+    readyUnit: readyUnitView(),
+    battlefield: battlefieldScan(),
+    ...overrides,
+  };
+
+  return {
+    calls,
+    context: {
+      endpointDefaults: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      directControl: {
+        getCiv7PlayNotificationView: async (options) => {
+          calls.notifications.push(options);
+          return results.notifications;
+        },
+        getCiv7ReadyUnitView: async (input) => {
+          calls.readyUnit.push({ input });
+          return results.readyUnit;
+        },
+        getCiv7BattlefieldScan: async (input) => {
+          calls.battlefield.push({ input });
+          return results.battlefield;
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function playNotificationView(): Civ7ControlOrpcPlayNotificationViewResult {
+  const unitId = { owner: 0, id: 458752, type: 26 };
+  return {
+    localPlayerId: 0,
+    turn: { ok: true, value: 75 },
+    turnDate: { ok: true, value: "2150 BCE" },
+    hasSentTurnComplete: { ok: true, value: false },
+    canEndTurn: { ok: true, value: false },
+    blocker: { ok: true, value: 0 },
+    blockingNotificationId: { ok: true, value: null },
+    selectedUnitId: { ok: true, value: null },
+    selectedCityId: { ok: true, value: null },
+    firstReadyUnitId: { ok: true, value: unitId },
+    notifications: [],
+    decisions: [],
+    hud: {
+      nextDecision: null,
+      decisionQueue: [],
+    },
+    limits: { maxNotifications: 10, truncated: false },
+  };
+}
+
+function readyUnitView(): Civ7ControlOrpcReadyUnitViewResult {
+  const unitId = { owner: 0, id: 458752, type: 26 };
+  return {
+    localPlayerId: 0,
+    requestedUnitId: unitId,
+    selectedUnitId: { ok: true, value: null },
+    firstReadyUnitId: { ok: true, value: unitId },
+    unitId,
+    unit: {
+      ok: true,
+      value: {
+        id: unitId,
+        owner: 0,
+        type: 111,
+        typeName: "UNIT_ARMY_COMMANDER",
+        location: { x: 17, y: 20 },
+        movementMovesRemaining: 2,
+        attacksRemaining: 0,
+        damage: 0,
+        hitPoints: 100,
+      },
+    },
+    legalOperations: [{
+      family: "unit-operation",
+      operationType: "SKIP_TURN",
+      enumValue: 1,
+      valid: true,
+      result: { Success: true },
+    }],
+    promotionReadiness: { ok: true, value: null },
+    nearby: { ok: true, value: [] },
+    notes: ["Read-only ready-unit fixture."],
+  } as Civ7ControlOrpcReadyUnitViewResult;
+}
+
+function battlefieldScan(): Civ7ControlOrpcBattlefieldScanResult {
+  const ownScreen = formationUnit({
+    id: { owner: 0, id: 458752, type: 26 },
+    role: "ranged",
+    typeName: "UNIT_SLINGER",
+    location: { x: 17, y: 20 },
+    distance: 0,
+  });
+  const ownCivilian = formationUnit({
+    id: { owner: 0, id: 1441800, type: 26 },
+    role: "civilian",
+    typeName: "UNIT_SETTLER",
+    location: { x: 16, y: 18 },
+    distance: 1,
+  });
+  const otherOwnerUnit = formationUnit({
+    id: { owner: 9, id: 196608, type: 26 },
+    owner: 9,
+    stance: "other",
+    relationshipProof: "none",
+    relationshipLabel: "relationship-unproven",
+    role: "melee",
+    typeName: "UNIT_WARRIOR",
+    location: { x: 13, y: 17 },
+    distance: 4,
+  });
+  return {
+    localPlayerId: 0,
+    playerId: 0,
+    origins: [{ x: 17, y: 20 }],
+    radius: 8,
+    hiddenInfoPolicy: "runtime-debug-summary; pair with visibility reads",
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "Owner mismatch is contact evidence only.",
+    },
+    units: [ownScreen, ownCivilian, otherOwnerUnit],
+    cities: [],
+    owners: [],
+    pointsOfInterest: [{
+      kind: "civilian-risk",
+      severity: "high",
+      location: ownCivilian.location,
+      summary: "friendly civilian has other-owner contact within 4 tiles",
+      units: [ownCivilian],
+    }],
+    notes: ["Read-only battlefield lens."],
+  };
+}
+
+function formationUnit(overrides: Partial<Record<string, unknown>>) {
+  return {
+    id: { owner: 0, id: 1, type: 26 },
+    owner: 0,
+    stance: "friendly",
+    relationshipProof: "self",
+    relationshipLabel: "friendly",
+    role: "ranged",
+    typeName: "UNIT_SLINGER",
+    location: { x: 17, y: 20 },
+    distance: 0,
+    strength: 10,
+    ...overrides,
+  };
+}
+
+function expectSafeFormationOutput(value: unknown): void {
+  const serialized = JSON.stringify(value);
+  expect(serialized).not.toContain("\"host\"");
+  expect(serialized).not.toContain("\"port\"");
+  expect(serialized).not.toContain("\"state\"");
+  expect(serialized).not.toContain("\"evidence\"");
+  expect(serialized).not.toContain("\"legalOperations\"");
+  expect(serialized).not.toContain("Game.turn");
+  expect(serialized).not.toContain("rawCommand");
+  expect(serialized).not.toMatch(/\bfriendly\b/i);
+  expect(serialized).not.toMatch(/\bnon-friendly\b/i);
+  expect(serialized).not.toMatch(/\benemy\b/i);
+  expect(serialized).not.toMatch(/\bhostile\b/i);
+  expect(serialized).not.toMatch(/\bopponent\b/i);
+  expect(serialized).not.toMatch(/\bthreat\b/i);
+  expect(serialized).not.toMatch(/\bwar\b/i);
+  expect(serialized).not.toMatch(/\bally\b/i);
+  expect(serialized).not.toMatch(/\bsuzerain\b/i);
+}

--- a/packages/civ7-control-orpc/test/strategy-front-summary-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/strategy-front-summary-procedure.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../src/index";
 import type {
   Civ7ControlOrpcBattlefieldScanResult,
+  Civ7ControlOrpcDestinationAnalysisResult,
   Civ7ControlOrpcTargetCandidatesResult,
 } from "../src/dependencies/direct-control";
 
@@ -18,6 +19,7 @@ describe("strategy.frontSummary control-oRPC procedure", () => {
     const fake = fakeContext({
       targetCandidates: targetCandidatesResult(),
       battlefieldScan: battlefieldScanResult(),
+      destinationAnalysis: destinationAnalysisResult(),
     });
 
     const result = await call(Civ7ControlOrpcRouter.strategy.frontSummary, {
@@ -26,6 +28,7 @@ describe("strategy.frontSummary control-oRPC procedure", () => {
       candidateLimit: 3,
       scanRadius: 6,
       maxPlayers: 12,
+      target: { x: 15, y: 20 },
     }, {
       context: fake.context,
     });
@@ -60,6 +63,23 @@ describe("strategy.frontSummary control-oRPC procedure", () => {
           timeoutMs: 1_000,
         },
       }],
+      destinationAnalysis: [{
+        input: {
+          playerId: 0,
+          origin: { x: 10, y: 20 },
+          destination: { x: 15, y: 20 },
+          corridorRadius: 2,
+          destinationRadius: 4,
+          maxPlayers: 12,
+          maxUnits: undefined,
+          maxCities: undefined,
+        },
+        options: {
+          host: "127.0.0.1",
+          port: 4318,
+          timeoutMs: 1_000,
+        },
+      }],
     });
     expect(result).toMatchObject({
       playerId: 0,
@@ -68,6 +88,7 @@ describe("strategy.frontSummary control-oRPC procedure", () => {
       sourceStatus: {
         targetCandidates: "read",
         battlefieldScan: "read",
+        destinationAnalysis: "read",
       },
       relationshipLabelPolicy: {
         relationshipSource: "not-classified",
@@ -76,10 +97,11 @@ describe("strategy.frontSummary control-oRPC procedure", () => {
       },
       summary: {
         targetCandidateCount: 1,
-        pointOfInterestCount: 1,
+        pointOfInterestCount: 2,
         observedOwnerCount: 2,
         nextStepCount: 4,
       },
+      target: { x: 15, y: 20 },
     });
     expect(result.targetCandidates).toEqual([{
       owner: 1,
@@ -99,7 +121,25 @@ describe("strategy.frontSummary control-oRPC procedure", () => {
       severity: "medium",
       location: { x: 11, y: 21 },
       summary: "2 other-owner units within 3 tiles of an origin",
+      source: "battlefield",
+    }, {
+      kind: "destination-contact",
+      severity: "high",
+      location: { x: 15, y: 20 },
+      summary: "destination contact near intended front",
+      source: "destination",
     }]);
+    expect(result.front).toMatchObject({
+      posture: "stage-before-entering-target-contact",
+      headline: "origin (10,20) toward target/front (15,20); leading candidate: owner 1",
+      risks: [
+        "destination contact near intended front",
+        "2 other-owner units near intended front",
+        "1 relationship-unproven cities near intended front",
+        "apparent destination contact 10",
+      ],
+    });
+    expect(JSON.stringify(result.front.nextInspections)).not.toContain("game play");
     expect(result.observedOwners).toEqual([
       {
         owner: 0,
@@ -133,13 +173,13 @@ describe("strategy.frontSummary control-oRPC procedure", () => {
     expect(serialized).not.toContain("\"state\"");
     expect(serialized).not.toContain("Game.turn");
     expect(serialized).not.toContain("rawCommand");
-    expect(serialized).not.toContain("enemy");
-    expect(serialized).not.toContain("hostile");
-    expect(serialized).not.toContain("opponent");
-    expect(serialized).not.toContain("threat");
-    expect(serialized).not.toContain("war");
-    expect(serialized).not.toContain("ally");
-    expect(serialized).not.toContain("suzerain");
+    expect(serialized).not.toMatch(/\benemy\b/i);
+    expect(serialized).not.toMatch(/\bhostile\b/i);
+    expect(serialized).not.toMatch(/\bopponent\b/i);
+    expect(serialized).not.toMatch(/\bthreat\b/i);
+    expect(serialized).not.toMatch(/\bwar\b/i);
+    expect(serialized).not.toMatch(/\bally\b/i);
+    expect(serialized).not.toMatch(/\bsuzerain\b/i);
   });
 
   test("supports the in-process server-side router client", async () => {
@@ -149,6 +189,7 @@ describe("strategy.frontSummary control-oRPC procedure", () => {
         owners: [],
         pointsOfInterest: [],
       }),
+      destinationAnalysis: destinationAnalysisResult(),
     });
     const client = createCiv7ControlOrpcServerClient(fake.context);
 
@@ -180,6 +221,7 @@ describe("strategy.frontSummary control-oRPC procedure", () => {
       const fake = fakeContext({
         targetCandidates: targetCandidatesResult(),
         battlefieldScan: battlefieldScanResult(),
+        destinationAnalysis: destinationAnalysisResult(),
       });
 
       await expect(
@@ -190,6 +232,7 @@ describe("strategy.frontSummary control-oRPC procedure", () => {
       expect(fake.calls).toEqual({
         targetCandidates: [],
         battlefieldScan: [],
+        destinationAnalysis: [],
       });
     }
   });
@@ -203,6 +246,7 @@ describe("strategy.frontSummary control-oRPC procedure", () => {
           );
         },
         getCiv7BattlefieldScan: async () => battlefieldScanResult(),
+        getCiv7DestinationAnalysis: async () => destinationAnalysisResult(),
       } as Civ7ControlOrpcContext["directControl"],
     };
 
@@ -250,6 +294,7 @@ function fakeContext(
   results: Readonly<{
     targetCandidates: Civ7ControlOrpcTargetCandidatesResult;
     battlefieldScan: Civ7ControlOrpcBattlefieldScanResult;
+    destinationAnalysis: Civ7ControlOrpcDestinationAnalysisResult;
   }>,
 ): {
   calls: {
@@ -258,6 +303,10 @@ function fakeContext(
       options: Civ7ControlOrpcContext["endpointDefaults"];
     }>>;
     battlefieldScan: Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>;
+    destinationAnalysis: Array<Readonly<{
       input: unknown;
       options: Civ7ControlOrpcContext["endpointDefaults"];
     }>>;
@@ -270,6 +319,10 @@ function fakeContext(
       options: Civ7ControlOrpcContext["endpointDefaults"];
     }>>,
     battlefieldScan: [] as Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>,
+    destinationAnalysis: [] as Array<Readonly<{
       input: unknown;
       options: Civ7ControlOrpcContext["endpointDefaults"];
     }>>,
@@ -291,6 +344,10 @@ function fakeContext(
         getCiv7BattlefieldScan: async (input, options) => {
           calls.battlefieldScan.push({ input, options });
           return results.battlefieldScan;
+        },
+        getCiv7DestinationAnalysis: async (input, options) => {
+          calls.destinationAnalysis.push({ input, options });
+          return results.destinationAnalysis;
         },
       } as Civ7ControlOrpcContext["directControl"],
     },
@@ -343,6 +400,52 @@ function targetCandidatesResult(
       reasons: ["nearest target distance 5"],
     }],
     notes: ["Target candidates are planning support."],
+    ...overrides,
+  };
+}
+
+function destinationAnalysisResult(
+  overrides: Partial<Civ7ControlOrpcDestinationAnalysisResult> = {},
+): Civ7ControlOrpcDestinationAnalysisResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    playerId: 0,
+    origin: { x: 10, y: 20 },
+    destination: { x: 15, y: 20 },
+    corridorRadius: 2,
+    destinationRadius: 4,
+    hiddenInfoPolicy: "runtime-debug-summary",
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "neutral",
+    },
+    corridor: {
+      routeHint: "land",
+      directGridDistance: 5,
+      sampleCount: 2,
+      sampledPlots: [],
+      units: [],
+      unitCount: 0,
+    },
+    destinationPressure: {
+      units: [],
+      unitCount: 2,
+      cities: [],
+      cityCount: 1,
+      apparentOtherStrength: 10,
+    },
+    pointsOfInterest: [{
+      kind: "destination-contact",
+      severity: "high",
+      location: { x: 15, y: 20 },
+      summary: "destination pressure near intended front",
+    }],
+    notes: ["Destination analysis is read-only."],
     ...overrides,
   };
 }

--- a/packages/civ7-control-orpc/test/world-current-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/world-current-procedure.test.ts
@@ -1,0 +1,258 @@
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  Civ7WorldCurrentUnavailableError,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+  type Civ7ControlOrpcPlayableStatusResult,
+} from "../src/index";
+
+describe("world.current control-oRPC procedure", () => {
+  test("projects bounded current-world facts from playable status snapshot evidence", async () => {
+    const fake = fakeContext(playableStatusResult());
+
+    const result = await call(Civ7ControlOrpcRouter.world.current, {}, {
+      context: fake.context,
+    });
+
+    expect(fake.calls).toEqual([{
+      host: "127.0.0.1",
+      port: 4318,
+      timeoutMs: 1_000,
+    }]);
+    expect(result).toEqual({
+      playable: true,
+      readiness: "tuner-ready",
+      sourceStatus: {
+        playableStatus: "read",
+        game: "read",
+        map: "read",
+        players: "read",
+      },
+      turn: {
+        current: 77,
+        date: "Age 1, Turn 77",
+        age: 1,
+        maxTurns: 500,
+        hash: 123_456,
+      },
+      localPlayer: {
+        playerId: 0,
+        observerId: 1,
+      },
+      map: {
+        width: 84,
+        height: 52,
+        plotCount: 4_368,
+        mapSize: 3,
+        randomSeed: 987_654,
+      },
+      players: {
+        maxPlayers: 8,
+        alivePlayerIds: [0, 1, 2],
+        aliveHumanIds: [0],
+        aliveHumanCount: 1,
+      },
+      summary: {
+        hasMapDimensions: true,
+        alivePlayerCount: 3,
+        nextStepCount: 1,
+      },
+      nextSteps: [{
+        kind: "read-attention",
+        source: "world.current",
+        label: "Read current attention before choosing support actions.",
+      }],
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("App UI");
+    expect(serialized).not.toContain("Tuner");
+    expect(serialized).not.toContain("relationship");
+    expect(serialized).not.toContain("enemy");
+    expect(serialized).not.toContain("threat");
+  });
+
+  test("supports the in-process server-side router client for shell state", async () => {
+    const fake = fakeContext(playableStatusResult({
+      playable: false,
+      readiness: "shell",
+    }));
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    const result = await client.world.current({});
+
+    expect(result).toMatchObject({
+      playable: false,
+      readiness: "shell",
+      sourceStatus: {
+        playableStatus: "read",
+        game: "skipped-not-playable",
+        map: "skipped-not-playable",
+        players: "skipped-not-playable",
+      },
+      map: {
+        width: null,
+        height: null,
+      },
+      nextSteps: [{
+        kind: "enter-game",
+        source: "world.current",
+      }],
+    });
+    expect(result.players.alivePlayerIds).toEqual([]);
+  });
+
+  test("rejects endpoint/session/state/raw command fields from procedure input", async () => {
+    const invalidInputs = [
+      { host: "127.0.0.1" },
+      { port: 4318 },
+      { state: { role: "tuner" } },
+      { session: { state: "Tuner" } },
+      { command: "Game.turn" },
+      { rawCommand: "Game.turn" },
+    ];
+
+    for (const input of invalidInputs) {
+      const fake = fakeContext(playableStatusResult());
+
+      await expect(
+        call(Civ7ControlOrpcRouter.world.current, input as never, {
+          context: fake.context,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(fake.calls).toEqual([]);
+    }
+  });
+
+  test("maps facade failures to a tagged Effect/oRPC error without raw details", async () => {
+    const context: Civ7ControlOrpcContext = {
+      directControl: {
+        getCiv7PlayableStatus: async () => {
+          throw new Error(
+            "Timed out waiting for Civ7 tuner response to CMD:1:Game.turn",
+          );
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    };
+
+    await expect(
+      call(Civ7ControlOrpcRouter.world.current, {}, { context }),
+    ).rejects.toMatchObject({
+      code: "WORLD_CURRENT_UNAVAILABLE",
+      status: 503,
+      data: {
+        procedureKey: "world.current",
+        source: "direct-control-facade",
+      },
+    });
+
+    try {
+      await call(Civ7ControlOrpcRouter.world.current, {}, { context });
+    } catch (err) {
+      const serialized = JSON.stringify(err);
+      expect(serialized).not.toContain("CMD");
+      expect(serialized).not.toContain("Game.turn");
+      expect(serialized).not.toContain("rawCommand");
+      expect(serialized).not.toContain("command-failed");
+    }
+  });
+
+  test("publishes a contract-first world.current service leaf", () => {
+    expect(Civ7ControlOrpcContract.world.current["~orpc"]).toMatchObject({
+      meta: {
+        family: "world",
+        procedureKey: "world.current",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      },
+    });
+    expect(Civ7ControlOrpcContract.world.current["~orpc"].errorMap)
+      .toHaveProperty("WORLD_CURRENT_UNAVAILABLE");
+    expect(Civ7WorldCurrentUnavailableError.code).toBe(
+      "WORLD_CURRENT_UNAVAILABLE",
+    );
+  });
+});
+
+function fakeContext(
+  result: Civ7ControlOrpcPlayableStatusResult,
+): {
+  calls: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+  context: Civ7ControlOrpcContext;
+} {
+  const calls: Array<Civ7ControlOrpcContext["endpointDefaults"]> = [];
+
+  return {
+    calls,
+    context: {
+      endpointDefaults: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      directControl: {
+        getCiv7PlayableStatus: async (options) => {
+          calls.push(options);
+          return result;
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function playableStatusResult(
+  overrides: Partial<{
+    playable: boolean;
+    readiness: Civ7ControlOrpcPlayableStatusResult["readiness"];
+  }> = {},
+): Civ7ControlOrpcPlayableStatusResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    playable: overrides.playable ?? true,
+    readiness: overrides.readiness ?? "tuner-ready",
+    appUi: {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      snapshot: {
+        game: {
+          turn: 77,
+          age: 1,
+          maxTurns: 500,
+          turnDate: probe("Age 1, Turn 77"),
+          hash: probe(123_456),
+        },
+        gameContext: {
+          localPlayerID: 0,
+          localObserverID: 1,
+        },
+        map: {
+          width: probe(84),
+          height: probe(52),
+          plotCount: probe(4_368),
+          mapSize: probe(3),
+          randomSeed: probe(987_654),
+        },
+        players: {
+          maxPlayers: 8,
+          aliveIds: probe([0, 1, 2]),
+          aliveHumanIds: probe([0]),
+          numAliveHumans: probe(1),
+        },
+      },
+    },
+    errors: [],
+  } as Civ7ControlOrpcPlayableStatusResult;
+}
+
+function probe<T>(value: T) {
+  return { ok: true as const, value };
+}

--- a/packages/civ7-control-orpc/test/world-map-read-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/world-map-read-procedure.test.ts
@@ -1,0 +1,299 @@
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  Civ7WorldReadUnavailableError,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+} from "../src/index";
+
+describe("world map read control-oRPC procedures", () => {
+  test("projects one plot without raw direct-control runtime envelope", async () => {
+    const fake = fakeContext();
+
+    const result = await call(Civ7ControlOrpcRouter.world.plot, {
+      location: { x: 3, y: 4 },
+      playerId: 0,
+      fields: ["terrain", "resource", "visibility"],
+    }, { context: fake.context });
+
+    expect(fake.plotCalls).toEqual([{
+      input: {
+        x: 3,
+        y: 4,
+        fields: ["terrain", "resource", "visibility"],
+        playerId: 0,
+        includeHidden: undefined,
+      },
+      options: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+    }]);
+    expect(result).toEqual({
+      sourceStatus: { plot: "read" },
+      plot: {
+        location: { x: 3, y: 4, index: 339 },
+        visibility: {
+          revealedState: { ok: true, value: 1 },
+          visible: { ok: true, value: true },
+        },
+        hiddenInfoPolicy: "visibility-filtered",
+        facts: {
+          terrain: { ok: true, value: 4 },
+          resource: { ok: true, value: -1 },
+        },
+        summary: {
+          factCount: 2,
+          probeErrorCount: 0,
+        },
+      },
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("rawCommand");
+    expect(serialized).not.toContain("enemy");
+    expect(serialized).not.toContain("hostile");
+    expect(serialized).not.toContain("opponent");
+    expect(serialized).not.toContain("threat");
+    expect(serialized).not.toContain("war");
+    expect(serialized).not.toContain("ally");
+    expect(serialized).not.toContain("suzerain");
+  });
+
+  test("projects bounded grids with omission and probe-error source status", async () => {
+    const fake = fakeContext({
+      gridResult: {
+        ...mapGridResult(),
+        omitted: 2,
+        map: {
+          width: { ok: false, error: "GameplayMap unavailable" },
+          height: { ok: true, value: 54 },
+        },
+        plots: [{
+          ...plotSnapshotResult(),
+          facts: {
+            terrain: { ok: false, error: "terrain unavailable" },
+          },
+        }],
+      },
+    });
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    const result = await client.world.grid({
+      bounds: { x: 0, y: 0, width: 2, height: 2 },
+      fields: ["terrain"],
+      maxPlots: 2,
+    });
+
+    expect(fake.gridCalls).toEqual([{
+      input: {
+        bounds: { x: 0, y: 0, width: 2, height: 2 },
+        fields: ["terrain"],
+        playerId: undefined,
+        includeHidden: undefined,
+        maxPlots: 2,
+      },
+      options: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+    }]);
+    expect(result).toMatchObject({
+      sourceStatus: {
+        grid: "read-with-omissions",
+        map: "read",
+      },
+      bounds: { x: 0, y: 0, width: 2, height: 2 },
+      fields: ["terrain"],
+      plotCount: 4,
+      omitted: 2,
+      map: {
+        width: null,
+        height: 54,
+      },
+      plots: [{
+        summary: {
+          factCount: 1,
+          probeErrorCount: 1,
+        },
+      }],
+      summary: {
+        returnedPlotCount: 1,
+        probeErrorCount: 2,
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain("\"host\"");
+  });
+
+  test("rejects raw endpoint and command fields before facade execution", async () => {
+    const invalidInputs = [
+      { location: { x: 3, y: 4 }, host: "127.0.0.1" },
+      { location: { x: 3, y: 4 }, state: { role: "tuner" } },
+      { location: { x: 3, y: 4 }, command: "GameplayMap.getTerrainType(3, 4)" },
+      { location: { x: 3, y: 4 }, rawCommand: "readPlotSnapshot()" },
+      {
+        bounds: { x: 0, y: 0, width: 2, height: 2 },
+        fields: ["terrain"],
+        session: { state: "Tuner" },
+      },
+    ];
+
+    for (const input of invalidInputs) {
+      const fake = fakeContext();
+      const target = "bounds" in input
+        ? Civ7ControlOrpcRouter.world.grid
+        : Civ7ControlOrpcRouter.world.plot;
+
+      await expect(
+        call(target as never, input as never, { context: fake.context }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(fake.plotCalls).toEqual([]);
+      expect(fake.gridCalls).toEqual([]);
+    }
+  });
+
+  test("maps facade failures to tagged errors without raw cause details", async () => {
+    const context: Civ7ControlOrpcContext = {
+      directControl: {
+        getCiv7PlotSnapshot: async () => {
+          throw new Error(
+            "Timed out waiting for Civ7 tuner response to CMD:1:GameplayMap.getTerrainType(3,4)",
+          );
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    };
+
+    await expect(
+      call(Civ7ControlOrpcRouter.world.plot, {
+        location: { x: 3, y: 4 },
+      }, { context }),
+    ).rejects.toMatchObject({
+      code: "WORLD_READ_UNAVAILABLE",
+      status: 503,
+      data: {
+        procedureKey: "world.plot.read",
+        source: "direct-control-facade",
+      },
+    });
+
+    try {
+      await call(Civ7ControlOrpcRouter.world.plot, {
+        location: { x: 3, y: 4 },
+      }, { context });
+    } catch (err) {
+      const serialized = JSON.stringify(err);
+      expect(serialized).not.toContain("CMD");
+      expect(serialized).not.toContain("GameplayMap.getTerrainType");
+      expect(serialized).not.toContain("rawCommand");
+    }
+  });
+
+  test("publishes contract-first world plot and grid leaves", () => {
+    expect(Civ7ControlOrpcContract.world.plot["~orpc"]).toMatchObject({
+      meta: {
+        family: "world",
+        procedureKey: "world.plot.read",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      },
+    });
+    expect(Civ7ControlOrpcContract.world.grid["~orpc"]).toMatchObject({
+      meta: {
+        family: "world",
+        procedureKey: "world.grid.read",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      },
+    });
+    expect(Civ7WorldReadUnavailableError.code).toBe("WORLD_READ_UNAVAILABLE");
+  });
+});
+
+function fakeContext(
+  overrides: Partial<{
+    plotResult: ReturnType<typeof plotSnapshotResult>;
+    gridResult: ReturnType<typeof mapGridResult>;
+  }> = {},
+): {
+  plotCalls: Array<{
+    input: unknown;
+    options: Civ7ControlOrpcContext["endpointDefaults"];
+  }>;
+  gridCalls: Array<{
+    input: unknown;
+    options: Civ7ControlOrpcContext["endpointDefaults"];
+  }>;
+  context: Civ7ControlOrpcContext;
+} {
+  const plotCalls: Array<{
+    input: unknown;
+    options: Civ7ControlOrpcContext["endpointDefaults"];
+  }> = [];
+  const gridCalls: Array<{
+    input: unknown;
+    options: Civ7ControlOrpcContext["endpointDefaults"];
+  }> = [];
+  return {
+    plotCalls,
+    gridCalls,
+    context: {
+      endpointDefaults: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      directControl: {
+        getCiv7PlotSnapshot: async (input, options) => {
+          plotCalls.push({ input, options });
+          return overrides.plotResult ?? plotSnapshotResult();
+        },
+        getCiv7MapGrid: async (input, options) => {
+          gridCalls.push({ input, options });
+          return overrides.gridResult ?? mapGridResult();
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function plotSnapshotResult() {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "1", name: "Tuner" },
+    location: { x: 3, y: 4, index: { ok: true as const, value: 339 } },
+    revealedState: { ok: true as const, value: 1 },
+    visible: { ok: true as const, value: true },
+    hiddenInfoPolicy: "visibility-filtered" as const,
+    facts: {
+      terrain: { ok: true as const, value: 4 },
+      resource: { ok: true as const, value: -1 },
+    },
+  };
+}
+
+function mapGridResult() {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "1", name: "Tuner" },
+    bounds: { x: 0, y: 0, width: 2, height: 2 },
+    fields: ["terrain"] as const,
+    plotCount: 4,
+    omitted: 0,
+    hiddenInfoPolicy: "not-player-scoped" as const,
+    map: {
+      width: { ok: true as const, value: 84 },
+      height: { ok: true as const, value: 54 },
+    },
+    plots: [plotSnapshotResult()],
+  };
+}

--- a/packages/cli/src/commands/game/map.ts
+++ b/packages/cli/src/commands/game/map.ts
@@ -1,11 +1,13 @@
 import { Command, Flags } from '@oclif/core';
-import { getCiv7MapGrid, getCiv7MapSummary, getCiv7PlotSnapshot, type Civ7PlotSnapshotField } from '@civ7/direct-control';
+import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
+import { getCiv7MapGrid, getCiv7PlotSnapshot, type Civ7PlotSnapshotField } from '@civ7/direct-control';
 
 export default class GameMap extends Command {
   static id = 'game map';
-  static summary = 'Read bounded Civ7 map state through direct control';
+  static summary = 'Read Civ7 current world and bounded map state';
   static description =
-    'Reads map summary, one plot, or a bounded plot grid through @civ7/direct-control.';
+    'Reads the service-owned current world summary through control-oRPC, or one plot/grid through bounded direct-control map diagnostics.';
 
   static examples = [
     '<%= config.bin %> game map --summary --json',
@@ -21,7 +23,7 @@ export default class GameMap extends Command {
       description: 'Civ7 tuner socket port',
     }),
     summary: Flags.boolean({
-      description: 'Read the map summary',
+      description: 'Read the current world summary',
       default: false,
     }),
     plot: Flags.string({
@@ -79,10 +81,11 @@ export default class GameMap extends Command {
         includeHidden: flags['include-hidden'],
       }, options);
     } else {
-      result = await getCiv7MapSummary({
-        ...options,
-        includeAreaRegionCounts: flags.summary,
+      const client = createCiv7ControlOrpcServerClient({
+        directControl: liveCiv7ControlOrpcDirectControlFacade,
+        endpointDefaults: options,
       });
+      result = await client.world.current({});
     }
 
     if (flags.json) {

--- a/packages/cli/src/commands/game/map.ts
+++ b/packages/cli/src/commands/game/map.ts
@@ -1,13 +1,13 @@
 import { Command, Flags } from '@oclif/core';
 import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import type { Civ7WorldPlotField } from '@civ7/control-orpc';
 import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
-import { getCiv7MapGrid, getCiv7PlotSnapshot, type Civ7PlotSnapshotField } from '@civ7/direct-control';
 
 export default class GameMap extends Command {
   static id = 'game map';
   static summary = 'Read Civ7 current world and bounded map state';
   static description =
-    'Reads the service-owned current world summary through control-oRPC, or one plot/grid through bounded direct-control map diagnostics.';
+    'Reads service-owned current world, plot, or bounded grid views through control-oRPC.';
 
   static examples = [
     '<%= config.bin %> game map --summary --json',
@@ -64,27 +64,27 @@ export default class GameMap extends Command {
     };
     const fields = parseFields(flags.fields);
     const playerId = flags['player-id'];
+    const client = createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults: options,
+    });
     let result: unknown;
     if (flags.bounds) {
-      result = await getCiv7MapGrid({
+      result = await client.world.grid({
         bounds: parseBounds(flags.bounds),
         fields,
         playerId,
         includeHidden: flags['include-hidden'],
         maxPlots: flags['max-plots'],
-      }, options);
+      });
     } else if (flags.plot) {
-      result = await getCiv7PlotSnapshot({
-        ...parseLocation(flags.plot),
+      result = await client.world.plot({
+        location: parseLocation(flags.plot),
         fields,
         playerId,
         includeHidden: flags['include-hidden'],
-      }, options);
-    } else {
-      const client = createCiv7ControlOrpcServerClient({
-        directControl: liveCiv7ControlOrpcDirectControlFacade,
-        endpointDefaults: options,
       });
+    } else {
       result = await client.world.current({});
     }
 
@@ -97,8 +97,8 @@ export default class GameMap extends Command {
   }
 }
 
-function parseFields(value: string | undefined): Civ7PlotSnapshotField[] {
-  return (value?.split(',').map((field) => field.trim()).filter(Boolean) as Civ7PlotSnapshotField[] | undefined)
+function parseFields(value: string | undefined): Civ7WorldPlotField[] {
+  return (value?.split(',').map((field) => field.trim()).filter(Boolean) as Civ7WorldPlotField[] | undefined)
     ?? ['terrain', 'biome', 'feature', 'resource', 'owner', 'visibility', 'areaRegion'];
 }
 

--- a/packages/cli/src/commands/game/play/civilian-route-triage.ts
+++ b/packages/cli/src/commands/game/play/civilian-route-triage.ts
@@ -1,23 +1,18 @@
 import { Command, Flags } from '@oclif/core';
 import {
-  getCiv7BattlefieldScan,
-  getCiv7DestinationAnalysis,
-  getCiv7PlayNotificationView,
-  getCiv7ReadyUnitView,
-  getCiv7SettlementRecommendations,
-} from '@civ7/direct-control';
+  createCiv7ControlOrpcServerClient,
+  type Civ7StrategyCivilianRouteTriageResult,
+} from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import { buildDirectControlOptions } from '../../../utils/game-play-shared';
 
 type Location = Readonly<{ x: number; y: number }>;
-
-type TriageStatus = 'proceed-with-validation' | 'hold-or-screen' | 'reroute-or-stage' | 'inspect-candidate';
-
-type CivilianRouteTriage = Readonly<{
-  status: TriageStatus;
-  summary: string;
-  reasons: ReadonlyArray<string>;
-  nextInspections: ReadonlyArray<string>;
-}>;
+type TriageNextStep = Civ7StrategyCivilianRouteTriageResult['nextSteps'][number];
+type CivilianRouteTriageCliView = Omit<Civ7StrategyCivilianRouteTriageResult, 'triage'> & {
+  triage: Civ7StrategyCivilianRouteTriageResult['triage'] & {
+    nextInspections: string[];
+  };
+};
 
 export default class GamePlayCivilianRouteTriage extends Command {
   static id = 'game play civilian-route-triage';
@@ -101,191 +96,80 @@ export default class GamePlayCivilianRouteTriage extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(GamePlayCivilianRouteTriage);
-    const options = buildDirectControlOptions(flags);
-    const hud = await getCiv7PlayNotificationView({
-      ...options,
-      maxNotifications: 10,
-    });
-    const requestedOrigin = flags.x === undefined || flags.y === undefined ? null : { x: flags.x, y: flags.y };
-    const readyUnitId = probeValue(hud.firstReadyUnitId);
-    const readyUnit = requestedOrigin || !readyUnitId
-      ? null
-      : await getCiv7ReadyUnitView({ unitId: readyUnitId, radius: 2 }, options);
-    const origin = requestedOrigin ?? getReadyUnitLocation(readyUnit);
-    const locations = origin ? [origin] : undefined;
-    const settlement = await getCiv7SettlementRecommendations({
-      playerId: flags['player-id'],
-      locations,
-      count: flags.count,
-      includeSettlers: !origin,
-      includeCities: false,
-    }, options);
-    const requestedDestination = flags['to-x'] === undefined || flags['to-y'] === undefined
-      ? null
+    const origin = flags.x === undefined || flags.y === undefined
+      ? undefined
+      : { x: flags.x, y: flags.y };
+    const destination = flags['to-x'] === undefined || flags['to-y'] === undefined
+      ? undefined
       : { x: flags['to-x'], y: flags['to-y'] };
-    const destination = requestedDestination ?? getFirstSettlementSuggestion(settlement);
-    const battlefield = await getCiv7BattlefieldScan({
+    const client = createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults: buildDirectControlOptions(flags),
+    });
+    const result = await client.strategy.civilianRouteTriage({
       playerId: flags['player-id'],
-      origins: locations,
-      radius: flags.radius,
-      maxUnits: flags['max-units'],
-      maxCities: flags['max-cities'],
-    }, options);
-    const destinationAnalysis = origin && destination
-      ? await getCiv7DestinationAnalysis({
-          playerId: flags['player-id'],
-          origin,
-          destination,
-          corridorRadius: flags['corridor-radius'],
-          destinationRadius: flags['destination-radius'],
-          maxUnits: flags['max-units'],
-          maxCities: flags['max-cities'],
-        }, options)
-      : null;
-    const triage = buildTriage({ origin, destination, battlefield, destinationAnalysis });
-    const view = {
-      localPlayerId: hud.localPlayerId,
-      turn: hud.turn,
-      turnDate: hud.turnDate,
-      blocker: hud.blocker,
-      nextDecision: hud.hud?.nextDecision ?? null,
       origin,
       destination,
-      readyUnit: readyUnit
-        ? {
-            unitId: readyUnit.unitId,
-            unit: readyUnit.unit,
-            legalOperationScope: 'no-target',
-            legalNoTargetOperationCount: readyUnit.legalOperations.length,
-          }
-        : null,
-      settlement,
-      battlefield,
-      destinationAnalysis,
-      triage,
-      notes: [
-        'Read-only civilian route triage; it does not move, found, buy, or reserve routes.',
-        'Settlement recommendations are site hints, not movement orders.',
-        'Use unit-target or operation validation for any concrete move after re-reading the ready unit.',
-      ],
-    };
+      settlementCount: flags.count,
+      scanRadius: flags.radius,
+      corridorRadius: flags['corridor-radius'],
+      destinationRadius: flags['destination-radius'],
+      maxUnits: flags['max-units'],
+      maxCities: flags['max-cities'],
+    });
+    const view = buildCliView(result);
 
     if (flags.json) {
       this.log(JSON.stringify({ ok: true, view }));
       return;
     }
 
-    this.log(triage.summary);
-    this.log(`Status: ${triage.status}`);
-    for (const reason of triage.reasons) this.log(`Reason: ${reason}`);
-    for (const command of triage.nextInspections) this.log(`Next: ${command}`);
+    this.log(view.triage.summary);
+    this.log(`Status: ${view.triage.status}`);
+    for (const reason of view.triage.reasons) this.log(`Reason: ${reason}`);
+    for (const command of view.triage.nextInspections) this.log(`Next: ${command}`);
   }
 }
 
-function buildTriage(input: {
-  origin: Location | null;
-  destination: Location | null;
-  battlefield: Awaited<ReturnType<typeof getCiv7BattlefieldScan>>;
-  destinationAnalysis: Awaited<ReturnType<typeof getCiv7DestinationAnalysis>> | null;
-}): CivilianRouteTriage {
-  const reasons = [
-    ...pointReasons(input.battlefield.pointsOfInterest, 'local'),
-    ...pointReasons(input.destinationAnalysis?.pointsOfInterest, 'route'),
-    ...destinationPressureReasons(input.destinationAnalysis),
-  ];
-  const hasCivilianRisk = reasons.some((reason) => reason.includes('civilian-risk'));
-  const hasHighRouteRisk = reasons.some((reason) => reason.includes('high route') || reason.includes('high local'));
-  const status: TriageStatus = !input.destination
-    ? 'inspect-candidate'
-    : hasCivilianRisk
-      ? 'hold-or-screen'
-      : hasHighRouteRisk
-        ? 'reroute-or-stage'
-        : 'proceed-with-validation';
-  const originLabel = input.origin ? `(${input.origin.x},${input.origin.y})` : '<unknown origin>';
-  const destinationLabel = input.destination ? `(${input.destination.x},${input.destination.y})` : '<no candidate destination>';
+function buildCliView(
+  result: Civ7StrategyCivilianRouteTriageResult,
+): CivilianRouteTriageCliView {
   return {
-    status,
-    summary: `civilian route ${originLabel} -> ${destinationLabel}`,
-    reasons: uniqueStrings(reasons).slice(0, 10),
-    nextInspections: nextInspectionCommands(input.origin, input.destination, status),
+    ...result,
+    triage: {
+      ...result.triage,
+      nextInspections: result.nextSteps
+        .map(commandForNextStep)
+        .filter((item): item is string => item != null),
+    },
   };
 }
 
-function pointReasons(value: unknown, scope: string): string[] {
-  return asRecords(value).map((point) => {
-    const severity = String(point.severity ?? 'medium');
-    const kind = String(point.kind ?? 'point-of-interest');
-    const summary = String(point.summary ?? kind);
-    return `${severity} ${scope} ${kind}: ${summary}`;
-  });
-}
-
-function destinationPressureReasons(destination: Awaited<ReturnType<typeof getCiv7DestinationAnalysis>> | null): string[] {
-  const pressure = destination?.destinationPressure as { unitCount?: unknown; cityCount?: unknown; apparentOtherStrength?: unknown } | undefined;
-  const reasons: string[] = [];
-  if (typeof pressure?.unitCount === 'number' && pressure.unitCount > 0) {
-    reasons.push(`${pressure.unitCount} other-owner units near candidate destination`);
+function commandForNextStep(step: TriageNextStep): string | null {
+  switch (step.kind) {
+    case 'read-priorities':
+      return 'game play priorities --json';
+    case 'inspect-battlefield':
+      return step.parameters.origin == null
+        ? 'game play battlefield-scan --json'
+        : `game play battlefield-scan ${locationFlags(step.parameters.origin)} --json`;
+    case 'inspect-settlement':
+      return step.parameters.origin == null
+        ? 'game play settlement-recommendations --json'
+        : `game play settlement-recommendations ${locationFlags(step.parameters.origin)} --json`;
+    case 'inspect-destination':
+      return step.parameters.origin != null && step.parameters.destination != null
+        ? `game play destination-analysis --from-x ${step.parameters.origin.x} --from-y ${step.parameters.origin.y} --to-x ${step.parameters.destination.x} --to-y ${step.parameters.destination.y} --json`
+        : 'game play destination-analysis --json';
+    case 'inspect-front':
+      return 'game play front-summary --x <screen-x> --y <screen-y> --json';
+    case 'inspect-ready-unit':
+      return 'game play ready-unit --json';
+    case 'validate-unit-action':
+      return "game play unit-target --unit-id '<unit-id>' --x <x> --y <y> --json";
   }
-  if (typeof pressure?.cityCount === 'number' && pressure.cityCount > 0) {
-    reasons.push(`${pressure.cityCount} relationship-unproven cities near candidate destination`);
-  }
-  if (typeof pressure?.apparentOtherStrength === 'number' && pressure.apparentOtherStrength > 0) {
-    reasons.push(`apparent candidate pressure ${pressure.apparentOtherStrength}`);
-  }
-  return reasons;
 }
 
-function nextInspectionCommands(origin: Location | null, destination: Location | null, status: TriageStatus): string[] {
-  const commands: string[] = ['game play priorities --json'];
-  if (origin) commands.push(`game play battlefield-scan --x ${origin.x} --y ${origin.y} --json`);
-  if (origin) commands.push(`game play settlement-recommendations --x ${origin.x} --y ${origin.y} --json`);
-  if (origin && destination) {
-    commands.push(`game play destination-analysis --from-x ${origin.x} --from-y ${origin.y} --to-x ${destination.x} --to-y ${destination.y} --json`);
-  }
-  if (status === 'hold-or-screen' || status === 'reroute-or-stage') {
-    commands.push('game play front-summary --x <screen-x> --y <screen-y> --json');
-  }
-  commands.push("game play ready-unit --json");
-  commands.push("game play unit-target --unit-id '<unit-id>' --x <x> --y <y> --json");
-  return uniqueStrings(commands);
-}
-
-function getFirstSettlementSuggestion(settlement: Awaited<ReturnType<typeof getCiv7SettlementRecommendations>>): Location | null {
-  for (const recommendation of settlement.recommendations) {
-    const suggestions = probeValue(recommendation.suggestions);
-    for (const suggestion of asRecords(suggestions)) {
-      const location = getLocation(suggestion.location);
-      if (location) return location;
-    }
-  }
-  return null;
-}
-
-function getReadyUnitLocation(readyUnit: Awaited<ReturnType<typeof getCiv7ReadyUnitView>> | null): Location | null {
-  const unit = readyUnit ? probeValue(readyUnit.unit) as { location?: unknown } | null : null;
-  return getLocation(unit?.location);
-}
-
-function getLocation(value: unknown): Location | null {
-  const location = asRecord(value);
-  return typeof location?.x === 'number' && typeof location.y === 'number'
-    ? { x: location.x, y: location.y }
-    : null;
-}
-
-function probeValue<T>(probe: { ok: true; value: T } | { ok: false; error: string } | null | undefined): T | null {
-  return probe?.ok ? probe.value : null;
-}
-
-function asRecords(value: unknown): Array<Record<string, unknown>> {
-  return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => item !== null && typeof item === 'object') : [];
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === 'object' ? value as Record<string, unknown> : null;
-}
-
-function uniqueStrings(values: ReadonlyArray<string>): string[] {
-  return [...new Set(values.filter((value) => value.length > 0))];
+function locationFlags(location: Location): string {
+  return `--x ${location.x} --y ${location.y}`;
 }

--- a/packages/cli/src/commands/game/play/dismiss-notification-queue.ts
+++ b/packages/cli/src/commands/game/play/dismiss-notification-queue.ts
@@ -1,34 +1,11 @@
 import { Command, Flags } from '@oclif/core';
 import {
-  type Civ7ComponentId,
-  type Civ7NotificationDismissalResult,
-  type Civ7PlayDecisionQueueItem,
-  getCiv7PlayNotificationView,
-  requestCiv7NotificationDismissal,
-} from '@civ7/direct-control';
+  createCiv7ControlOrpcServerClient,
+} from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import {
   buildDirectControlOptions,
 } from '../../../utils/game-play-shared';
-
-type DismissalCandidate = Readonly<{
-  notificationId: Civ7ComponentId;
-  category: string;
-  typeName: string | null;
-  summary: string | null;
-  message: string | null;
-  location: unknown;
-  isEndTurnBlocking: boolean;
-  reason: string;
-}>;
-
-type ExcludedNotification = Readonly<{
-  notificationId: Civ7ComponentId | null;
-  category: string;
-  typeName: string | null;
-  summary: string | null;
-  isEndTurnBlocking: boolean;
-  reason: string;
-}>;
 
 export default class GamePlayDismissNotificationQueue extends Command {
   static id = 'game play dismiss-notification-queue';
@@ -76,51 +53,16 @@ export default class GamePlayDismissNotificationQueue extends Command {
   };
 
   public async run(): Promise<void> {
-    const { flags } = await this.parse(GamePlayDismissNotificationQueue);    const options = buildDirectControlOptions(flags);
-    const hud = await getCiv7PlayNotificationView({
-      ...options,
-      maxNotifications: flags.max,
+    const { flags } = await this.parse(GamePlayDismissNotificationQueue);
+    const client = createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults: buildDirectControlOptions(flags),
     });
-    const { candidates, excluded } = classifyQueue(hud.hud.decisionQueue);
-    const selected = candidates.slice(0, flags['max-dismissals']);
-    const omittedEligibleCount = Math.max(0, candidates.length - selected.length);
-    const results: Civ7NotificationDismissalResult[] = [];
-
-    if (flags.send) {
-      for (const candidate of selected) {
-        results.push(await requestCiv7NotificationDismissal(
-          { notificationId: candidate.notificationId },
-          options,
-        ));
-      }
-    }
-
-    const view = {
-      localPlayerId: hud.localPlayerId,
-      turn: hud.turn,
-      turnDate: hud.turnDate,
-      blocker: hud.blocker,
-      blockingNotificationId: hud.blockingNotificationId,
-      canEndTurn: hud.canEndTurn,
-      queueLength: hud.hud.decisionQueue.length,
-      send: flags.send,
+    const view = await client.notifications.queue.dismiss.request({
+      maxNotifications: flags.max,
       maxDismissals: flags['max-dismissals'],
-      eligibleCount: candidates.length,
-      selectedCount: selected.length,
-      omittedEligibleCount,
-      candidates: selected,
-      excluded,
-      results,
-      verified: flags.send ? results.every((result) => result.verified) : false,
-      notes: [
-        flags.send
-          ? 'Bulk dismissal sent only for eligible informational closeout candidates selected from a fresh HUD queue read.'
-          : 'Dry run only. Add --send to dismiss eligible informational closeout candidates.',
-        'Operation-bearing, unit-command, production, diplomacy, narrative, progression, population, and unclassified notifications are excluded.',
-        'A completed App UI call is not counted as aggregate verified unless each item proves dismissal from post-send notification identity/queue/front evidence.',
-        'Re-read the queue after this command before making further decisions.',
-      ],
-    };
+      send: flags.send,
+    });
 
     if (flags.json) {
       this.log(JSON.stringify({ ok: true, view }));
@@ -128,74 +70,28 @@ export default class GamePlayDismissNotificationQueue extends Command {
     }
 
     this.log(`Turn ${formatProbe(view.turn)} (${formatProbe(view.turnDate)})`);
-    this.log(`Eligible: ${view.eligibleCount}; selected: ${view.selectedCount}; send: ${view.send}`);
-    for (const candidate of selected) {
+    this.log(`Eligible: ${view.eligibleCount}; selected: ${view.selectedCount}; send: ${view.sent}; status: ${view.status}`);
+    for (const candidate of view.candidates) {
       this.log(`- ${formatId(candidate.notificationId)} ${candidate.typeName ?? candidate.category}: ${candidate.summary ?? candidate.message ?? ''}`);
       this.log(`  why: ${candidate.reason}`);
     }
-    if (excluded.length > 0) this.log(`Excluded: ${excluded.length}`);
+    if (view.excluded.length > 0) this.log(`Excluded: ${view.excluded.length}`);
   }
 }
 
-function classifyQueue(queue: ReadonlyArray<Civ7PlayDecisionQueueItem>): {
-  candidates: DismissalCandidate[];
-  excluded: ExcludedNotification[];
-} {
-  const candidates: DismissalCandidate[] = [];
-  const excluded: ExcludedNotification[] = [];
-  for (const item of queue) {
-    if (isBulkDismissalCandidate(item)) {
-      candidates.push({
-        notificationId: item.notificationId,
-        category: item.category,
-        typeName: item.typeName,
-        summary: item.summary,
-        message: item.message,
-        location: item.location,
-        isEndTurnBlocking: item.isEndTurnBlocking,
-        reason: `${item.typeName ?? item.category} reviewed as informational closeout`,
-      });
-      continue;
-    }
-    excluded.push({
-      notificationId: item.notificationId,
-      category: item.category,
-      typeName: item.typeName,
-      summary: item.summary,
-      isEndTurnBlocking: item.isEndTurnBlocking,
-      reason: exclusionReason(item),
-    });
+function formatProbe(value: unknown): string {
+  if (value && typeof value === 'object' && 'ok' in value) {
+    const probe = value as { ok: boolean; value?: unknown; error?: string };
+    if (!probe.ok) return `<error: ${probe.error ?? 'unknown'}>`;
+    return formatValue(probe.value);
   }
-  return { candidates, excluded };
+  return formatValue(value);
 }
 
-function isBulkDismissalCandidate(item: Civ7PlayDecisionQueueItem): item is Civ7PlayDecisionQueueItem & { notificationId: Civ7ComponentId } {
-  return item.notificationId != null
-    && item.category === 'informational-notification'
-    && item.operationFamily === 'app-ui-action'
-    && item.operationType === 'Game.Notifications.dismiss'
-    && !isFrontUnitLostReport(item);
-}
-
-function exclusionReason(item: Civ7PlayDecisionQueueItem): string {
-  if (!item.notificationId) return 'missing notification id';
-  if (isFrontUnitLostReport(item)) return 'front unit-loss reports require exact reviewed dismissal proof, not bulk dismissal';
-  if (item.category === 'unit-command') return 'unit command requires ready-unit inspection';
-  if (item.operationFamily && item.operationFamily !== 'app-ui-action') return 'gameplay operation requires live inputs and validator-backed command';
-  if (item.category === 'notification' || item.category === 'blocking-notification') return 'unclassified notification needs handler evidence first';
-  if (item.category === 'informational-notification') return 'informational item is not exposed as App UI dismissal by the live HUD';
-  return 'not an informational closeout candidate';
-}
-
-function isFrontUnitLostReport(item: Civ7PlayDecisionQueueItem): boolean {
-  return item.isEndTurnBlocking === true && item.typeName === 'NOTIFICATION_UNIT_LOST';
-}
-
-function formatProbe<T>(probe: { ok: true; value: T } | { ok: false; error: string }): string {
-  if (!probe.ok) return `<error: ${probe.error}>`;
-  return typeof probe.value === 'object' ? JSON.stringify(probe.value) : String(probe.value);
-}
-
-function formatId(id: Civ7ComponentId): string {
+function formatId(id: unknown): string {
   return JSON.stringify(id);
+}
+
+function formatValue(value: unknown): string {
+  return value == null || typeof value === 'object' ? JSON.stringify(value) : String(value);
 }

--- a/packages/cli/src/commands/game/play/formation-snapshot.ts
+++ b/packages/cli/src/commands/game/play/formation-snapshot.ts
@@ -1,59 +1,19 @@
 import { Command, Flags } from '@oclif/core';
 import {
-  getCiv7BattlefieldScan,
-  getCiv7PlayNotificationView,
-  getCiv7ReadyUnitView,
-} from '@civ7/direct-control';
+  createCiv7ControlOrpcServerClient,
+  type Civ7StrategyFormationSnapshotResult,
+} from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import { buildDirectControlOptions } from '../../../utils/game-play-shared';
 
-type Location = Readonly<{ x: number; y: number }>;
-
-type FormationPosture =
-  | 'screen-civilian'
-  | 'hold-ready-unit'
-  | 'stabilize-front'
-  | 'advance-with-validation'
-  | 'inspect-ready-unit';
-
-type FormationUnit = Readonly<{
-  id: unknown;
-  owner: unknown;
-  stance: string;
-  role: string;
-  typeName: string | null;
-  location: Location | null;
-  distance: number | null;
-  evidence: unknown;
-}>;
-
-type FormationRelationshipLabelPolicy = Readonly<{
-  relationshipSource: 'not-classified';
-  relationshipProof: 'none';
-  unprovenLabel: 'relationship-unproven';
-  notes: ReadonlyArray<string>;
-}>;
-
-type FormationSnapshot = Readonly<{
-  posture: FormationPosture;
-  relationshipLabelPolicy: FormationRelationshipLabelPolicy;
-  headline: string;
-  reasons: ReadonlyArray<string>;
-  civilians: ReadonlyArray<FormationUnit>;
-  screens: ReadonlyArray<FormationUnit>;
-  otherOwnerContacts: ReadonlyArray<FormationUnit>;
-  nearbyContacts: ReadonlyArray<FormationUnit>;
-  nextInspections: ReadonlyArray<string>;
-}>;
-
-const FORMATION_RELATIONSHIP_LABEL_POLICY: FormationRelationshipLabelPolicy = {
-  relationshipSource: 'not-classified',
-  relationshipProof: 'none',
-  unprovenLabel: 'relationship-unproven',
-  notes: [
-    'Formation snapshot treats owner mismatch and proximity as contact evidence only.',
-    'Use official relationship/team/war/suzerain evidence or validator-backed operations before applying stronger relationship labels.',
-  ],
-};
+type FormationNextStep = Civ7StrategyFormationSnapshotResult['nextSteps'][number];
+type FormationSnapshotCliView =
+  Omit<Civ7StrategyFormationSnapshotResult, 'formation'> & {
+    formation: Omit<Civ7StrategyFormationSnapshotResult['formation'], 'nextSteps'> & {
+      nextSteps: Civ7StrategyFormationSnapshotResult['formation']['nextSteps'];
+      nextInspections: string[];
+    };
+  };
 
 export default class GamePlayFormationSnapshot extends Command {
   static id = 'game play formation-snapshot';
@@ -91,7 +51,7 @@ export default class GamePlayFormationSnapshot extends Command {
       max: 16,
     }),
     'screen-radius': Flags.integer({
-      description: 'Maximum grid distance for friendly units to count as local screens near a civilian',
+      description: 'Maximum grid distance for own units to count as local screens near a civilian',
       default: 2,
       min: 1,
       max: 6,
@@ -121,212 +81,71 @@ export default class GamePlayFormationSnapshot extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(GamePlayFormationSnapshot);
-    const options = buildDirectControlOptions(flags);
-    const hud = await getCiv7PlayNotificationView({
-      ...options,
-      maxNotifications: 10,
+    const endpointDefaults = buildDirectControlOptions(flags);
+    const origin = flags.x === undefined || flags.y === undefined
+      ? undefined
+      : { x: flags.x, y: flags.y };
+    const client = createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults,
     });
-    const requestedOrigin = flags.x === undefined || flags.y === undefined ? null : { x: flags.x, y: flags.y };
-    const readyUnitId = probeValue(hud.firstReadyUnitId);
-    const readyUnit = requestedOrigin || !readyUnitId
-      ? null
-      : await getCiv7ReadyUnitView({ unitId: readyUnitId, radius: 2 }, options);
-    const origin = requestedOrigin ?? getReadyUnitLocation(readyUnit);
-    const battlefield = await getCiv7BattlefieldScan({
+    const result = await client.strategy.formationSnapshot({
       playerId: flags['player-id'],
-      origins: origin ? [origin] : undefined,
+      origin,
       radius: flags.radius,
+      screenRadius: flags['screen-radius'],
+      contactRadius: flags['contact-radius'],
       maxUnits: flags['max-units'],
       maxCities: flags['max-cities'],
-    }, options);
-    const snapshot = buildFormationSnapshot({
-      origin,
-      readyUnit,
-      battlefield,
-      screenRadius: flags['screen-radius'],
-      contactRadius: flags['contact-radius'] ?? 4,
     });
-    const view = {
-      localPlayerId: hud.localPlayerId,
-      turn: hud.turn,
-      turnDate: hud.turnDate,
-      blocker: hud.blocker,
-      nextDecision: hud.hud?.nextDecision ?? null,
-      origin,
-      readyUnit: readyUnit
-        ? {
-            unitId: readyUnit.unitId,
-            unit: readyUnit.unit,
-            legalOperationScope: 'no-target',
-            legalNoTargetOperationCount: readyUnit.legalOperations.length,
-          }
-        : null,
-      battlefield,
-      formation: snapshot,
-      notes: [
-        'Read-only formation snapshot; it does not move, attack, found, or reserve routes.',
-        'Use this lens to decide what to inspect next, then validate concrete plot actions with game play unit-target.',
-        'Battlefield scan distances are cheap grid heuristics and may include debug-visible entities unless paired with visibility reads.',
-      ],
-    };
+    const view = formationCliView(result);
 
     if (flags.json) {
       this.log(JSON.stringify({ ok: true, view }));
       return;
     }
 
-    this.log(snapshot.headline);
-    this.log(`Posture: ${snapshot.posture}`);
-    for (const reason of snapshot.reasons) this.log(`Reason: ${reason}`);
-    for (const command of snapshot.nextInspections) this.log(`Next: ${command}`);
+    this.log(view.formation.headline);
+    this.log(`Posture: ${view.formation.posture}`);
+    for (const reason of view.formation.reasons) this.log(`Reason: ${reason}`);
+    for (const command of view.formation.nextInspections) {
+      this.log(`Next: ${command}`);
+    }
   }
 }
 
-function buildFormationSnapshot(input: {
-  origin: Location | null;
-  readyUnit: Awaited<ReturnType<typeof getCiv7ReadyUnitView>> | null;
-  battlefield: Awaited<ReturnType<typeof getCiv7BattlefieldScan>>;
-  screenRadius: number;
-  contactRadius: number;
-}): FormationSnapshot {
-  const units = asRecords(input.battlefield.units).map(toFormationUnit);
-  const civilians = units.filter((unit) => unit.stance === 'friendly' && unit.role === 'civilian');
-  const friendlies = units.filter((unit) => unit.stance === 'friendly' && unit.role !== 'civilian');
-  const otherOwnerContacts = units.filter((unit) => unit.stance !== 'friendly');
-  const screens = friendlies.filter((unit) =>
-    civilians.some((civilian) => civilian.location && unit.location && gridDistance(civilian.location, unit.location) <= input.screenRadius),
-  );
-  const nearbyContacts = otherOwnerContacts.filter((unit) =>
-    civilians.some((civilian) => civilian.location && unit.location && gridDistance(civilian.location, unit.location) <= input.contactRadius),
-  );
-  const poiReasons = pointReasons(input.battlefield.pointsOfInterest);
-  const ready = readyUnitSummary(input.readyUnit);
-  const posture = postureFor({ civilians, screens, nearbyContacts, poiReasons, readyUnit: input.readyUnit });
-  const originLabel = input.origin ? `(${input.origin.x},${input.origin.y})` : '<unknown origin>';
-  const headline = `${ready} formation at ${originLabel}: ${civilians.length} civilians, ${screens.length} local screens, ${nearbyContacts.length} nearby other-owner contacts`;
+function formationCliView(
+  result: Civ7StrategyFormationSnapshotResult,
+): FormationSnapshotCliView {
   return {
-    posture,
-    relationshipLabelPolicy: FORMATION_RELATIONSHIP_LABEL_POLICY,
-    headline,
-    reasons: uniqueStrings([
-      ...poiReasons,
-      ...civilianContactReasons(civilians, nearbyContacts),
-      ...screenReasons(civilians, screens),
-    ]).slice(0, 10),
-    civilians,
-    screens,
-    otherOwnerContacts,
-    nearbyContacts,
-    nextInspections: nextInspectionCommands(input.origin, civilians, nearbyContacts, posture),
+    ...result,
+    formation: {
+      ...result.formation,
+      nextInspections: result.formation.nextSteps.map(nextInspectionCommand),
+    },
   };
 }
 
-function postureFor(input: {
-  civilians: ReadonlyArray<FormationUnit>;
-  screens: ReadonlyArray<FormationUnit>;
-  nearbyContacts: ReadonlyArray<FormationUnit>;
-  poiReasons: ReadonlyArray<string>;
-  readyUnit: Awaited<ReturnType<typeof getCiv7ReadyUnitView>> | null;
-}): FormationPosture {
-  if (!input.readyUnit) return 'inspect-ready-unit';
-  if (input.civilians.length > 0 && input.nearbyContacts.length > 0) return 'screen-civilian';
-  if (input.civilians.length > 0 && input.screens.length === 0) return 'hold-ready-unit';
-  if (input.poiReasons.some((reason) =>
-    reason.includes('nearby-other-owners')
-    || reason.includes('owner-pressure')
-  )) return 'stabilize-front';
-  return 'advance-with-validation';
-}
-
-function toFormationUnit(unit: Record<string, unknown>): FormationUnit {
-  return {
-    id: unit.id ?? null,
-    owner: unit.owner ?? null,
-    stance: typeof unit.stance === 'string' ? unit.stance : 'unknown',
-    role: typeof unit.role === 'string' ? unit.role : 'unknown',
-    typeName: typeof unit.typeName === 'string' ? unit.typeName : null,
-    location: getLocation(unit.location),
-    distance: typeof unit.distance === 'number' ? unit.distance : null,
-    evidence: unit,
-  };
-}
-
-function pointReasons(value: unknown): string[] {
-  return asRecords(value).map((point) => {
-    const severity = String(point.severity ?? 'medium');
-    const kind = String(point.kind ?? 'point-of-interest');
-    const summary = String(point.summary ?? kind);
-    return `${severity} ${kind}: ${summary}`;
-  });
-}
-
-function civilianContactReasons(civilians: ReadonlyArray<FormationUnit>, nearbyContacts: ReadonlyArray<FormationUnit>): string[] {
-  if (civilians.length === 0 || nearbyContacts.length === 0) return [];
-  return civilians.map((civilian) => {
-    const location = civilian.location ? `(${civilian.location.x},${civilian.location.y})` : '<unknown>';
-    return `${civilian.typeName ?? 'civilian'} at ${location} has ${nearbyContacts.length} other-owner units within contact radius`;
-  });
-}
-
-function screenReasons(civilians: ReadonlyArray<FormationUnit>, screens: ReadonlyArray<FormationUnit>): string[] {
-  if (civilians.length === 0) return [];
-  if (screens.length === 0) return ['no friendly screen units are within local screen radius of the civilian'];
-  return [`${screens.length} friendly screen units are within local screen radius of the civilian`];
-}
-
-function nextInspectionCommands(
-  origin: Location | null,
-  civilians: ReadonlyArray<FormationUnit>,
-  nearbyContacts: ReadonlyArray<FormationUnit>,
-  posture: FormationPosture,
-): string[] {
-  const commands = ['game play priorities --json', 'game play ready-unit --json'];
-  if (origin) commands.push(`game play battlefield-scan --x ${origin.x} --y ${origin.y} --json`);
-  const civilian = civilians.find((unit) => unit.location);
-  if (civilian?.location) commands.push(`game play civilian-route-triage --x ${civilian.location.x} --y ${civilian.location.y} --json`);
-  const contact = nearbyContacts.find((unit) => unit.location);
-  if (contact?.location) commands.push(`game play battlefield-scan --x ${contact.location.x} --y ${contact.location.y} --json`);
-  if (posture === 'screen-civilian' || posture === 'stabilize-front') {
-    commands.push("game play unit-target --unit-id '<unit-id>' --x <screen-or-contact-x> --y <screen-or-contact-y> --json");
-  } else {
-    commands.push("game play unit-target --unit-id '<unit-id>' --x <x> --y <y> --json");
+function nextInspectionCommand(step: FormationNextStep): string {
+  if (step.kind === 'read-priorities') return 'game play priorities --json';
+  if (step.kind === 'inspect-ready-unit') return 'game play ready-unit --json';
+  if (step.kind === 'inspect-civilian-route') {
+    const civilian = step.parameters.civilian;
+    return civilian == null
+      ? 'game play civilian-route-triage --json'
+      : `game play civilian-route-triage --x ${civilian.x} --y ${civilian.y} --json`;
   }
-  return uniqueStrings(commands);
+  if (step.kind === 'inspect-battlefield') {
+    const location = step.parameters.origin ?? step.parameters.contact;
+    return location == null
+      ? 'game play battlefield-scan --json'
+      : `game play battlefield-scan --x ${location.x} --y ${location.y} --json`;
+  }
+  return unitTargetCommand(step);
 }
 
-function readyUnitSummary(readyUnit: Awaited<ReturnType<typeof getCiv7ReadyUnitView>> | null): string {
-  const unit = readyUnit ? probeValue(readyUnit.unit) as { typeName?: string } | null : null;
-  return unit?.typeName ?? 'ready unit';
-}
-
-function getReadyUnitLocation(readyUnit: Awaited<ReturnType<typeof getCiv7ReadyUnitView>> | null): Location | null {
-  const unit = readyUnit ? probeValue(readyUnit.unit) as { location?: unknown } | null : null;
-  return getLocation(unit?.location);
-}
-
-function getLocation(value: unknown): Location | null {
-  const location = asRecord(value);
-  return typeof location?.x === 'number' && typeof location.y === 'number'
-    ? { x: location.x, y: location.y }
-    : null;
-}
-
-function gridDistance(left: Location, right: Location): number {
-  return Math.max(Math.abs(left.x - right.x), Math.abs(left.y - right.y));
-}
-
-function probeValue<T>(probe: { ok: true; value: T } | { ok: false; error: string } | null | undefined): T | null {
-  return probe?.ok ? probe.value : null;
-}
-
-function asRecords(value: unknown): Array<Record<string, unknown>> {
-  return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => item !== null && typeof item === 'object') : [];
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === 'object' ? value as Record<string, unknown> : null;
-}
-
-function uniqueStrings(values: ReadonlyArray<string>): string[] {
-  return [...new Set(values.filter((value) => value.length > 0))];
+function unitTargetCommand(step: FormationNextStep): string {
+  return step.label.includes('screen or contact')
+    ? "game play unit-target --unit-id '<unit-id>' --x <screen-or-contact-x> --y <screen-or-contact-y> --json"
+    : "game play unit-target --unit-id '<unit-id>' --x <x> --y <y> --json";
 }

--- a/packages/cli/src/commands/game/play/front-summary.ts
+++ b/packages/cli/src/commands/game/play/front-summary.ts
@@ -1,31 +1,10 @@
 import { Command, Flags } from '@oclif/core';
-import {
-  getCiv7BattlefieldScan,
-  getCiv7DestinationAnalysis,
-  getCiv7PlayNotificationView,
-  getCiv7ReadyUnitView,
-  getCiv7TargetCandidates,
-} from '@civ7/direct-control';
+import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import type { Civ7StrategyFrontSummaryResult } from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import { buildDirectControlOptions, resolveCoordinateFlags } from '../../../utils/game-play-shared';
 
 type Location = Readonly<{ x: number; y: number }>;
-
-type FrontPressure = Readonly<{
-  kind: string;
-  severity: string;
-  summary: string;
-  location: Location | null;
-  source: string;
-  evidence: unknown;
-}>;
-
-type FrontSummary = Readonly<{
-  posture: string;
-  headline: string;
-  risks: ReadonlyArray<string>;
-  nextInspections: ReadonlyArray<string>;
-  pressure: ReadonlyArray<FrontPressure>;
-}>;
 
 export default class GamePlayFrontSummary extends Command {
   static id = 'game play front-summary';
@@ -131,10 +110,6 @@ export default class GamePlayFrontSummary extends Command {
   public async run(): Promise<void> {
     const { flags } = await this.parse(GamePlayFrontSummary);
     const options = buildDirectControlOptions(flags);
-    const hud = await getCiv7PlayNotificationView({
-      ...options,
-      maxNotifications: 10,
-    });
     const requestedOrigin = resolveCoordinateFlags({
       x: flags.x,
       y: flags.y,
@@ -143,72 +118,33 @@ export default class GamePlayFrontSummary extends Command {
       yFlag: 'y',
       pairFlag: 'origin',
     }) ?? null;
-    const readyUnitId = probeValue(hud.firstReadyUnitId);
-    const readyUnit = requestedOrigin || !readyUnitId
-      ? null
-      : await getCiv7ReadyUnitView({ unitId: readyUnitId, radius: 2 }, options);
-    const inferredOrigin = requestedOrigin ?? getReadyUnitLocation(readyUnit);
-    const origins = inferredOrigin ? [inferredOrigin] : undefined;
-    const targetCandidates = await getCiv7TargetCandidates({
-      playerId: flags['player-id'],
-      origins,
-      maxCandidates: flags['max-candidates'],
-      maxPlayers: flags['max-players'],
-      unitRadius: flags['unit-radius'],
-    }, options);
     const requestedTarget = resolveFrontTarget(flags);
-    const target = requestedTarget ?? getFirstCandidateCityLocation(targetCandidates.candidates);
-    const battlefield = await getCiv7BattlefieldScan({
+    const client = createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults: options,
+    });
+    const result = await client.strategy.frontSummary({
       playerId: flags['player-id'],
-      origins,
-      radius: flags.radius,
+      origins: requestedOrigin ? [requestedOrigin] : undefined,
+      target: requestedTarget ?? undefined,
+      candidateLimit: flags['max-candidates'],
+      scanRadius: flags.radius,
+      corridorRadius: flags['corridor-radius'],
+      destinationRadius: flags['destination-radius'],
       maxPlayers: flags['max-players'],
       maxUnits: flags['max-units'],
       maxCities: flags['max-cities'],
-    }, options);
-    const destination = target
-      ? await getCiv7DestinationAnalysis({
-          playerId: flags['player-id'],
-          origin: inferredOrigin ?? undefined,
-          destination: target,
-          corridorRadius: flags['corridor-radius'],
-          destinationRadius: flags['destination-radius'],
-          maxPlayers: flags['max-players'],
-          maxUnits: flags['max-units'],
-          maxCities: flags['max-cities'],
-        }, options)
-      : null;
-    const summary = buildFrontSummary({
-      origin: inferredOrigin,
-      target,
-      targetCandidates,
-      battlefield,
-      destination,
     });
     const view = {
-      localPlayerId: hud.localPlayerId,
-      turn: hud.turn,
-      turnDate: hud.turnDate,
-      blocker: hud.blocker,
-      nextDecision: hud.hud?.nextDecision ?? null,
-      origin: inferredOrigin,
-      target,
-      readyUnit: readyUnit
-        ? {
-            unitId: readyUnit.unitId,
-            unit: readyUnit.unit,
-            legalOperationScope: 'no-target',
-            legalNoTargetOperationCount: readyUnit.legalOperations.length,
-          }
-        : null,
-      targetCandidates,
-      battlefield,
-      destination,
-      summary,
+      ...result,
+      origin: result.origins[0] ?? null,
+      summary: {
+        ...result.front,
+        nextInspections: frontInspectionCommands(result),
+      },
       notes: [
-        'Read-only front summary; it does not move units, attack, declare war, or choose strategy.',
-        'Use this to pick the next inspection, then validate concrete unit actions with game play unit-target or operation.',
-        'Distances and corridors are cheap grid heuristics and may include debug-visible entities until paired with visibility reads.',
+        ...result.notes,
+        'Use this to pick the next inspection, then validate concrete unit actions with game play unit-target.',
       ],
     };
 
@@ -217,131 +153,14 @@ export default class GamePlayFrontSummary extends Command {
       return;
     }
 
-    this.log(summary.headline);
-    this.log(`Posture: ${summary.posture}`);
-    for (const risk of summary.risks) this.log(`Risk: ${risk}`);
-    for (const item of summary.pressure.slice(0, 8)) {
+    this.log(result.front.headline);
+    this.log(`Posture: ${result.front.posture}`);
+    for (const risk of result.front.risks) this.log(`Risk: ${risk}`);
+    for (const item of result.front.pressure.slice(0, 8)) {
       this.log(`- [${item.severity}] ${item.kind}: ${item.summary}`);
     }
-    for (const command of summary.nextInspections) this.log(`Next: ${command}`);
+    for (const command of frontInspectionCommands(result)) this.log(`Next: ${command}`);
   }
-}
-
-function buildFrontSummary(input: {
-  origin: Location | null;
-  target: Location | null;
-  targetCandidates: Awaited<ReturnType<typeof getCiv7TargetCandidates>>;
-  battlefield: Awaited<ReturnType<typeof getCiv7BattlefieldScan>>;
-  destination: Awaited<ReturnType<typeof getCiv7DestinationAnalysis>> | null;
-}): FrontSummary {
-  const candidate = input.targetCandidates.candidates[0];
-  const pressure = [
-    ...frontPressure(input.battlefield.pointsOfInterest, 'battlefield'),
-    ...frontPressure(input.destination?.pointsOfInterest, 'destination'),
-  ].sort((a, b) => severityRank(b.severity) - severityRank(a.severity));
-  const highPressure = pressure.filter((item) => item.severity === 'high');
-  const risks = [
-    ...highPressure.map((item) => item.summary),
-    ...unsupportedDestinationRisks(input.destination),
-  ];
-  const targetLabel = input.target
-    ? `target/front (${input.target.x},${input.target.y})`
-    : 'no target/front selected';
-  const originLabel = input.origin
-    ? `origin (${input.origin.x},${input.origin.y})`
-    : 'inferred runtime origins';
-  const candidateLabel = candidate
-    ? `owner ${candidate.owner}${candidate.nearestCity ? ` near ${formatCity(candidate.nearestCity)}` : ''}`
-    : 'no ranked target candidate';
-  const posture = postureFromPressure(pressure, input.destination);
-  const nextInspections = nextInspectionCommands(input.origin, input.target, pressure);
-  return {
-    posture,
-    headline: `${originLabel} toward ${targetLabel}; leading candidate: ${candidateLabel}`,
-    risks: uniqueStrings(risks).slice(0, 8),
-    nextInspections,
-    pressure,
-  };
-}
-
-function frontPressure(value: unknown, source: string): FrontPressure[] {
-  return asRecords(value).map((point) => {
-    const location = getLocation(point.location);
-    return {
-      kind: String(point.kind ?? 'point-of-interest'),
-      severity: String(point.severity ?? 'medium'),
-      summary: String(point.summary ?? point.kind ?? 'front pressure'),
-      location,
-      source,
-      evidence: point,
-    };
-  });
-}
-
-function unsupportedDestinationRisks(destination: Awaited<ReturnType<typeof getCiv7DestinationAnalysis>> | null): string[] {
-  const destinationPressure = destination?.destinationPressure as { unitCount?: unknown; cityCount?: unknown; apparentOtherStrength?: unknown } | undefined;
-  const risks: string[] = [];
-  if (typeof destinationPressure?.unitCount === 'number' && destinationPressure.unitCount > 0) {
-    risks.push(`${destinationPressure.unitCount} other-owner units near intended front`);
-  }
-  if (typeof destinationPressure?.cityCount === 'number' && destinationPressure.cityCount > 0) {
-    risks.push(`${destinationPressure.cityCount} relationship-unproven cities near intended front`);
-  }
-  if (typeof destinationPressure?.apparentOtherStrength === 'number' && destinationPressure.apparentOtherStrength > 0) {
-    risks.push(`apparent destination pressure ${destinationPressure.apparentOtherStrength}`);
-  }
-  return risks;
-}
-
-function nextInspectionCommands(origin: Location | null, target: Location | null, pressure: ReadonlyArray<FrontPressure>): string[] {
-  const commands: string[] = ['game play priorities --json'];
-  if (origin) commands.push(`game play battlefield-scan --x ${origin.x} --y ${origin.y} --json`);
-  if (origin && target) {
-    commands.push(`game play destination-analysis --from-x ${origin.x} --from-y ${origin.y} --to-x ${target.x} --to-y ${target.y} --json`);
-  }
-  const highestLocated = pressure.find((item) => item.location);
-  if (highestLocated?.location) {
-    commands.push(`game play battlefield-scan --x ${highestLocated.location.x} --y ${highestLocated.location.y} --json`);
-  }
-  commands.push("game play ready-unit --json");
-  commands.push("game play unit-target --unit-id '<unit-id>' --x <x> --y <y> --json");
-  return uniqueStrings(commands);
-}
-
-function postureFromPressure(
-  pressure: ReadonlyArray<FrontPressure>,
-  destination: Awaited<ReturnType<typeof getCiv7DestinationAnalysis>> | null,
-): string {
-  if (pressure.some((item) => item.kind === 'civilian-risk' && item.severity === 'high')) return 'screen-civilians-before-advance';
-  if (pressure.some((item) => item.kind === 'nearby-other-owners' && item.severity === 'high')) {
-    return 'stabilize-front-before-committing-siege';
-  }
-  const destinationPressure = destination?.destinationPressure as { unitCount?: unknown; cityCount?: unknown } | undefined;
-  if ((Number(destinationPressure?.unitCount) || 0) > 0 || (Number(destinationPressure?.cityCount) || 0) > 0) {
-    return 'stage-before-entering-target-pressure';
-  }
-  return 'inspect-and-advance-cautiously';
-}
-
-function severityRank(severity: string): number {
-  if (severity === 'high') return 3;
-  if (severity === 'medium') return 2;
-  if (severity === 'low') return 1;
-  return 0;
-}
-
-function getCandidateCityLocation(candidate: unknown): Location | null {
-  const record = asRecord(candidate);
-  const city = asRecord(record?.nearestCity);
-  return getLocation(city?.location);
-}
-
-function getFirstCandidateCityLocation(candidates: ReadonlyArray<unknown>): Location | null {
-  for (const candidate of candidates) {
-    const location = getCandidateCityLocation(candidate);
-    if (location) return location;
-  }
-  return null;
 }
 
 function resolveFrontTarget(flags: {
@@ -366,37 +185,22 @@ function resolveFrontTarget(flags: {
   }) ?? null;
 }
 
-function getReadyUnitLocation(readyUnit: Awaited<ReturnType<typeof getCiv7ReadyUnitView>> | null): Location | null {
-  const unit = readyUnit ? probeValue(readyUnit.unit) as { location?: unknown } | null : null;
-  return getLocation(unit?.location);
-}
-
-function getLocation(value: unknown): Location | null {
-  const location = asRecord(value);
-  return typeof location?.x === 'number' && typeof location.y === 'number'
-    ? { x: location.x, y: location.y }
-    : null;
-}
-
-function formatCity(city: unknown): string {
-  const record = asRecord(city);
-  const name = typeof record?.name === 'string' ? record.name : 'city';
-  const location = getLocation(record?.location);
-  return location ? `${name} (${location.x},${location.y})` : name;
-}
-
-function probeValue<T>(probe: { ok: true; value: T } | { ok: false; error: string } | null | undefined): T | null {
-  return probe?.ok ? probe.value : null;
-}
-
-function asRecords(value: unknown): Array<Record<string, unknown>> {
-  return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => item !== null && typeof item === 'object') : [];
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === 'object' ? value as Record<string, unknown> : null;
-}
-
-function uniqueStrings(values: ReadonlyArray<string>): string[] {
-  return [...new Set(values.filter((value) => value.length > 0))];
+function frontInspectionCommands(result: Civ7StrategyFrontSummaryResult): string[] {
+  const origin = result.origins[0] ?? null;
+  const target = result.target;
+  const commands: string[] = ['game play priorities --json'];
+  if (origin) commands.push(`game play battlefield-scan --x ${origin.x} --y ${origin.y} --json`);
+  if (origin && target) {
+    commands.push(`game play destination-analysis --origin ${origin.x},${origin.y} --destination ${target.x},${target.y} --json`);
+  }
+  const highestLocated = result.front.pressure.find((item) => item.location);
+  if (highestLocated?.location) {
+    commands.push(`game play battlefield-scan --x ${highestLocated.location.x} --y ${highestLocated.location.y} --json`);
+  }
+  if (result.front.nextInspections.some((step) => step.kind === 'observe')) {
+    commands.push('game play attention --json');
+  }
+  commands.push('game play ready-unit --json');
+  commands.push("game play unit-target --unit-id '<unit-id>' --x <x> --y <y> --json");
+  return [...new Set(commands)];
 }

--- a/packages/cli/src/commands/game/play/notification-queue.ts
+++ b/packages/cli/src/commands/game/play/notification-queue.ts
@@ -1,41 +1,19 @@
 import { Command, Flags } from '@oclif/core';
 import {
-  type Civ7PlayDecisionInput,
-  type Civ7PlayDecisionQueueItem,
-  getCiv7PlayNotificationView,
-} from '@civ7/direct-control';
+  createCiv7ControlOrpcServerClient,
+  type Civ7NotificationQueueResult,
+} from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import {
   buildDirectControlOptions,
-  recommendedCliFromDecisionDetails,
 } from '../../../utils/game-play-shared';
 
-type QueueDisposition =
-  | 'operate-with-live-inputs'
-  | 'reviewed-dismissal-candidate'
-  | 'inspect-ready-unit'
-  | 'inspect-handler'
-  | 'review-only';
-
-type QueueStep = Readonly<{
-  step: number;
-  priority: number;
-  disposition: QueueDisposition;
-  notificationId: Civ7PlayDecisionQueueItem['notificationId'];
-  isEndTurnBlocking: boolean;
-  category: string;
-  typeName: string | null;
-  summary: string | null;
-  message: string | null;
-  location: unknown;
-  target: unknown;
-  operationFamily?: Civ7PlayDecisionQueueItem['operationFamily'];
-  operationType?: string;
-  requiredInputs: ReadonlyArray<Civ7PlayDecisionInput>;
+type QueueStep = Civ7NotificationQueueResult['schedule'][number] & {
   command: string | null;
-  safeToBatch: boolean;
-  reason: string;
-  guardrails: ReadonlyArray<string>;
-}>;
+};
+type QueueView = Omit<Civ7NotificationQueueResult, 'schedule'> & {
+  schedule: QueueStep[];
+};
 
 export default class GamePlayNotificationQueue extends Command {
   static id = 'game play notification-queue';
@@ -73,37 +51,23 @@ export default class GamePlayNotificationQueue extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(GamePlayNotificationQueue);
-    const options = buildDirectControlOptions(flags);
-    const view = await getCiv7PlayNotificationView({
-      ...options,
+    const client = createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults: buildDirectControlOptions(flags),
+    });
+    const result = await client.notifications.queue.current({
       maxNotifications: flags.max,
     });
-    const schedule = buildNotificationSchedule(view.hud.decisionQueue);
-    const output = {
-      localPlayerId: view.localPlayerId,
-      turn: view.turn,
-      turnDate: view.turnDate,
-      blocker: view.blocker,
-      blockingNotificationId: view.blockingNotificationId,
-      canEndTurn: view.canEndTurn,
-      limits: view.limits,
-      queueLength: view.hud.decisionQueue.length,
-      schedule,
-      notes: [
-        'Read-only notification queue scheduler; it does not dismiss notifications or send player/unit/city operations.',
-        'Informational dismissal candidates still require summary/location review and item-level context before any validator-backed send.',
-        'Operation steps are templates. Re-read live inputs and use the specialized validator-backed command before sending.',
-      ],
-    };
+    const view = buildCliQueueView(result);
 
     if (flags.json) {
-      this.log(JSON.stringify({ ok: true, view: output }));
+      this.log(JSON.stringify({ ok: true, view }));
       return;
     }
 
-    this.log(`Turn ${formatProbe(output.turn)} (${formatProbe(output.turnDate)})`);
-    this.log(`Queue length: ${output.queueLength}; blocker: ${formatProbe(output.blocker)}`);
-    for (const item of schedule) {
+    this.log(`Turn ${formatProbe(view.turn)} (${formatProbe(view.turnDate)})`);
+    this.log(`Queue length: ${view.queueLength}; blocker: ${formatProbe(view.blocker)}`);
+    for (const item of view.schedule) {
       const marker = item.isEndTurnBlocking ? '*' : '-';
       this.log(`${marker} #${item.step} [${item.priority}] ${item.disposition}: ${item.summary ?? item.message ?? item.typeName ?? item.category}`);
       this.log(`  category: ${item.category}`);
@@ -114,176 +78,84 @@ export default class GamePlayNotificationQueue extends Command {
   }
 }
 
-function buildNotificationSchedule(queue: ReadonlyArray<Civ7PlayDecisionQueueItem>): QueueStep[] {
-  return queue
-    .map((item, index) => buildQueueStep(item, index + 1))
-    .sort((left, right) => right.priority - left.priority || left.step - right.step)
-    .map((item, index) => ({ ...item, step: index + 1 }));
-}
-
-function buildQueueStep(item: Civ7PlayDecisionQueueItem, originalStep: number): QueueStep {
-  const disposition = dispositionFor(item);
-  const command = commandFor(item, disposition);
-  const requiredInputs = item.requiredInputs.filter((input) => input.required);
-  const isDismissalCandidate = disposition === 'reviewed-dismissal-candidate';
-  const safeToBatch = isDismissalCandidate && isBatchSafeDismissalCandidate(item);
-  const guardrails = guardrailsFor(item, disposition, requiredInputs);
+function buildCliQueueView(result: Civ7NotificationQueueResult): QueueView {
   return {
-    step: originalStep,
-    priority: priorityFor(item, disposition),
-    disposition,
-    notificationId: item.notificationId,
-    isEndTurnBlocking: item.isEndTurnBlocking,
-    category: item.category,
-    typeName: item.typeName,
-    summary: item.summary,
-    message: item.message,
-    location: item.location,
-    target: item.target,
-    operationFamily: item.operationFamily,
-    operationType: item.operationType,
-    requiredInputs,
-    command,
-    safeToBatch,
-    reason: reasonFor(item, disposition),
-    guardrails: isDismissalCandidate
-      ? [
-          'Review the message and location first; this schedule only provides a guarded command template.',
-          ...guardrails,
-        ]
-      : guardrails,
+    ...result,
+    schedule: result.schedule.map((step) => ({
+      ...step,
+      command: commandForStep(step),
+    })),
   };
 }
 
-function dispositionFor(item: Civ7PlayDecisionQueueItem): QueueDisposition {
-  if (item.category === 'informational-notification' && item.operationFamily === 'app-ui-action') {
-    return 'reviewed-dismissal-candidate';
+function commandForStep(step: Civ7NotificationQueueResult['schedule'][number]): string | null {
+  const nextStep = step.nextStep;
+  if (nextStep == null) return null;
+  switch (nextStep.kind) {
+    case 'dismiss-notification':
+      return step.notificationId == null
+        ? null
+        : `game play dismiss-notification --target '${JSON.stringify(step.notificationId)}' --send`;
+    case 'inspect-ready-unit':
+      return 'game play ready-unit --json; game play unit-target --unit-id \'<unit-id>\' --x <x> --y <y> --json';
+    case 'inspect-ready-city':
+      return 'game play ready-city --compact --json';
+    case 'inspect-progression':
+      return progressionCommand(step.category);
+    case 'inspect-decision':
+      return decisionCommand(step.category);
+    case 'validate-operation':
+      return validateOperationCommand(step);
+    case 'inspect-notification':
+      return 'game play notifications --json';
+    case 'observe':
+      return 'game play priorities --compact --json';
   }
-  if (item.category === 'unit-command') return 'inspect-ready-unit';
-  if (item.operationFamily || item.cli) return 'operate-with-live-inputs';
-  if (item.category === 'notification' || item.category === 'blocking-notification') return 'inspect-handler';
-  return 'review-only';
 }
 
-function isBatchSafeDismissalCandidate(item: Civ7PlayDecisionQueueItem): boolean {
-  if (!item.isEndTurnBlocking) return true;
-  if (item.typeName === 'NOTIFICATION_UNIT_LOST') return false;
-  return true;
+function progressionCommand(category: string): string {
+  if (category === 'technology-choice') return 'game play choose-tech --options --json';
+  if (category === 'culture-choice') return 'game play choose-culture --options --json';
+  if (category === 'tradition-review') return 'game play traditions --compact --json';
+  return 'game play priorities --compact --json';
 }
 
-function commandFor(item: Civ7PlayDecisionQueueItem, disposition: QueueDisposition): string | null {
-  if (disposition === 'reviewed-dismissal-candidate' && item.notificationId) {
-    return `game play dismiss-notification --target '${JSON.stringify(item.notificationId)}' --send`;
-  }
-  const recommendedDetailCommand = recommendedCliFromDecisionDetails((item as { details?: unknown }).details);
-  if (recommendedDetailCommand) return recommendedDetailCommand;
-  const decisionCommand = commandFromDecision(item);
-  if (decisionCommand) return decisionCommand;
-  const detailCommand = commandFromDecisionDetails(item);
-  if (detailCommand) return detailCommand;
-  if (disposition === 'inspect-ready-unit') {
-    return 'game play ready-unit --json; game play unit-target --unit-id \'<unit-id>\' --x <x> --y <y> --json';
-  }
-  return item.cli ?? null;
+function decisionCommand(category: string): string {
+  if (category === 'celebration-choice') return 'game play choose-celebration --options --json';
+  if (category === 'government-choice') return 'game play choose-government --options --json';
+  if (category === 'narrative-choice') return 'game play choose-narrative --options --json';
+  if (category === 'first-meet-diplomacy') return 'game play respond-first-meet --json';
+  if (category === 'diplomacy-response') return 'game play respond-diplomacy --json';
+  return 'game play priorities --compact --json';
 }
 
-function priorityFor(item: Civ7PlayDecisionQueueItem, disposition: QueueDisposition): number {
-  if (item.isEndTurnBlocking) return 100;
-  if (disposition === 'operate-with-live-inputs') return 70;
-  if (disposition === 'inspect-ready-unit') return 65;
-  if (disposition === 'inspect-handler') return 50;
-  if (disposition === 'reviewed-dismissal-candidate') return 35;
-  return 20;
-}
-
-function reasonFor(item: Civ7PlayDecisionQueueItem, disposition: QueueDisposition): string {
-  if (item.isEndTurnBlocking) return 'End-turn blocker; resolve or consciously defer before broad tactical planning.';
-  if (disposition === 'reviewed-dismissal-candidate') {
-    return 'Default-handler informational notification; useful for context, but closeout should follow explicit review.';
+function validateOperationCommand(step: Civ7NotificationQueueResult['schedule'][number]): string {
+  if (step.category === 'technology-choice' || step.operationType === 'SET_TECH_TREE_NODE') {
+    return 'game play choose-tech --options --json';
   }
-  if (disposition === 'inspect-ready-unit') return 'Unit command notification needs the current ready unit and target-specific validators.';
-  if (disposition === 'operate-with-live-inputs') return 'Known operation family; required live inputs must be read from the current surface before send.';
-  if (disposition === 'inspect-handler') return 'Unclassified notification; inspect official handler or live UI before choosing any operation.';
-  return 'Queue context item; keep for strategy or tactics but do not mutate from this schedule alone.';
-}
-
-function guardrailsFor(
-  item: Civ7PlayDecisionQueueItem,
-  disposition: QueueDisposition,
-  requiredInputs: ReadonlyArray<Civ7PlayDecisionInput>,
-): string[] {
-  const guardrails: string[] = [];
-  if (requiredInputs.length > 0 && disposition !== 'reviewed-dismissal-candidate') {
-    guardrails.push(`Read required live inputs first: ${requiredInputs.map((input) => input.name).join(', ')}.`);
+  if (step.category === 'culture-choice' || step.operationType === 'SET_CULTURE_TREE_NODE') {
+    return 'game play choose-culture --options --json';
   }
-  if (item.location && typeof item.location === 'object') {
-    guardrails.push('Use the reported location as tactical context, not as proof of a valid operation target.');
-  }
-  if (disposition === 'operate-with-live-inputs') {
-    guardrails.push('Validate with the specialized command before sending; this schedule does not prove the args.');
-  }
-  if (disposition === 'inspect-handler') {
-    guardrails.push('Do not dismiss unclassified notifications in bulk.');
-  }
-  return guardrails;
-}
-
-function reasonSlug(item: Civ7PlayDecisionQueueItem): string {
-  const text = String(item.typeName ?? item.summary ?? item.category)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-  return text || 'notification-reviewed';
-}
-
-function commandFromDecision(item: Civ7PlayDecisionQueueItem): string | null {
-  if (item.category === 'production-choice' || item.category === 'population-placement') {
+  if (step.category === 'celebration-choice') return 'game play choose-celebration --options --json';
+  if (step.category === 'government-choice') return 'game play choose-government --options --json';
+  if (step.category === 'narrative-choice') return 'game play choose-narrative --options --json';
+  if (step.category === 'first-meet-diplomacy') return 'game play respond-first-meet --json';
+  if (step.category === 'diplomacy-response') return 'game play respond-diplomacy --json';
+  if (step.category === 'production-choice' || step.category === 'population-placement') {
     return 'game play ready-city --compact --json';
   }
-  if (item.category === 'tradition-review') {
-    return 'game play traditions --compact --json';
-  }
-  return null;
+  return 'game play priorities --compact --json';
 }
 
-function commandFromDecisionDetails(item: Civ7PlayDecisionQueueItem): string | null {
-  const details = (item as { details?: unknown }).details;
-  if (!details || typeof details !== 'object') return null;
-  const record = details as Record<string, unknown>;
-  if (record.kind === 'technology-choice-options') {
-    return hasEnabledOptions(record) ? 'game play choose-tech --options --json' : null;
+function formatProbe(value: unknown): string {
+  if (value && typeof value === 'object' && 'ok' in value) {
+    const probe = value as { ok: boolean; value?: unknown; error?: string };
+    if (!probe.ok) return `<error: ${probe.error ?? 'unknown'}>`;
+    return formatValue(probe.value);
   }
-  if (record.kind === 'culture-choice-options') {
-    return hasEnabledOptions(record) ? 'game play choose-culture --options --json' : null;
-  }
-  if (record.kind === 'celebration-choice-options') {
-    return hasEnabledOptions(record) ? 'game play choose-celebration --options --json' : null;
-  }
-  if (record.kind === 'government-choice-options') {
-    return hasEnabledOptions(record) ? 'game play choose-government --options --json' : null;
-  }
-  if (record.kind === 'narrative-choice-options') {
-    if (hasEnabledOptions(record)) return 'game play choose-narrative --options --json';
-    return typeof record.dismissalDiagnosticCli === 'string' && record.dismissalDiagnosticCli.length > 0
-      ? record.dismissalDiagnosticCli
-      : 'game play choose-narrative --options --json';
-  }
-  if (record.kind === 'unit-command-reconciliation' && record.staleReadyPointerSuspected === true) {
-    const candidate = asRecords(record.enabledCloseoutCandidates).find((entry) => typeof entry.cli === 'string' && entry.cli.length > 0);
-    return typeof candidate?.cli === 'string' ? candidate.cli : null;
-  }
-  return null;
+  return formatValue(value);
 }
 
-function hasEnabledOptions(record: Record<string, unknown>): boolean {
-  return asRecords(record.enabledOptions).length > 0;
-}
-
-function asRecords(value: unknown): Array<Record<string, unknown>> {
-  return Array.isArray(value) ? value.filter((entry): entry is Record<string, unknown> => entry !== null && typeof entry === 'object') : [];
-}
-
-function formatProbe<T>(probe: { ok: true; value: T } | { ok: false; error: string }): string {
-  if (!probe.ok) return `<error: ${probe.error}>`;
-  return typeof probe.value === 'object' ? JSON.stringify(probe.value) : String(probe.value);
+function formatValue(value: unknown): string {
+  return value == null || typeof value === 'object' ? JSON.stringify(value) : String(value);
 }

--- a/packages/cli/src/commands/game/play/priorities.ts
+++ b/packages/cli/src/commands/game/play/priorities.ts
@@ -1,63 +1,18 @@
 import { Command, Flags } from '@oclif/core';
 import {
-  getCiv7BattlefieldScan,
-  getCiv7PlayNotificationView,
-  getCiv7ReadyCityView,
-  getCiv7ReadyUnitView,
-} from '@civ7/direct-control';
-import {
-  buildDirectControlOptions,
-  recommendedCliFromDecisionDetails,
-} from '../../../utils/game-play-shared';
+  createCiv7ControlOrpcServerClient,
+  type Civ7AttentionPrioritiesResult,
+} from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import { createSemanticCliEnvelope, type SemanticCliEnvelope } from '../../../game-play/semantic-envelope';
+import { buildDirectControlOptions } from '../../../utils/game-play-shared';
 
-type PriorityItem = {
-  priority: number;
-  kind: string;
-  summary: string;
-  reason: string;
-  blocking: boolean;
+type PriorityItem = Civ7AttentionPrioritiesResult['priorities'][number] & {
   command?: string;
-  evidence?: unknown;
 };
-
-type Probe<T = unknown> = { ok: true; value: T } | { ok: false; error: string };
-
-type PriorityView = {
-  localPlayerId: unknown;
-  turn: Probe;
-  turnDate: Probe;
-  blocker: Probe;
-  canEndTurn: Probe;
-  hasSentTurnComplete: Probe;
-  firstReadyUnitId: Probe;
-  selectedCityId: Probe;
-  hud: unknown;
-  readyUnit: {
-    unitId: unknown;
-    unit: unknown;
-    legalOperationScope: string;
-    legalNoTargetOperationCount: number;
-    legalOperationCount: number;
-    promotionReadiness: unknown;
-  } | null;
-  readyCity: {
-    cityId: unknown;
-    city: unknown;
-    legalOperationCount: number;
-    productionCandidateCount: number;
-    townFocusOptionCount: number;
-    populationPlacement: unknown;
-  } | null;
-  battlefield: {
-    origins: unknown;
-    radius: unknown;
-    hiddenInfoPolicy: unknown;
-    pointsOfInterest: unknown;
-    owners: unknown;
-  } | null;
+type PriorityView = Omit<Civ7AttentionPrioritiesResult, 'priorities'> & {
   priorities: PriorityItem[];
-  notes: string[];
+  cliNotes: string[];
 };
 
 export default class GamePlayPriorities extends Command {
@@ -118,89 +73,48 @@ export default class GamePlayPriorities extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(GamePlayPriorities);
-    const options = buildDirectControlOptions(flags);
-    const hud = await getCiv7PlayNotificationView({
-      ...options,
-      maxNotifications: flags.max,
+    const client = createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults: buildDirectControlOptions(flags),
     });
-    const readyUnitId = probeValue(hud.firstReadyUnitId);
-    const readyUnit = readyUnitId
-      ? await getCiv7ReadyUnitView({
-          unitId: readyUnitId,
-          radius: 2,
-          maxOperations: flags['max-operations'],
-        }, options)
-      : null;
-    const readyCity = await getCiv7ReadyCityView({}, options);
-    const origin = getReadyUnitLocation(readyUnit);
-    const battlefield = !flags['no-battlefield'] && origin
-      ? await getCiv7BattlefieldScan({
-          origins: [origin],
-          radius: flags.radius,
-          maxUnits: flags['max-units'],
-        }, options)
-      : null;
-    const priorities = buildPriorities({ hud, readyUnit, readyCity, battlefield });
-    const view: PriorityView = {
-      localPlayerId: hud.localPlayerId,
-      turn: hud.turn,
-      turnDate: hud.turnDate,
-      blocker: hud.blocker,
-      canEndTurn: hud.canEndTurn,
-      hasSentTurnComplete: hud.hasSentTurnComplete,
-      firstReadyUnitId: hud.firstReadyUnitId,
-      selectedCityId: hud.selectedCityId,
-      hud: hud.hud,
-      readyUnit: readyUnit
-        ? {
-            unitId: readyUnit.unitId,
-            unit: readyUnit.unit,
-            legalOperationScope: 'no-target',
-            legalNoTargetOperationCount: readyUnit.legalOperations.length,
-            legalOperationCount: readyUnit.legalOperations.length,
-            promotionReadiness: readyUnit.promotionReadiness,
-          }
-        : null,
-      readyCity: readyCity.cityId
-        ? {
-            cityId: readyCity.cityId,
-            city: readyCity.city,
-            legalOperationCount: readyCity.legalOperations.length,
-            productionCandidateCount: probeArrayLength(readyCity.productionCandidates),
-            townFocusOptionCount: probeArrayLength(readyCity.townFocusOptions),
-            populationPlacement: readyCity.populationPlacement,
-          }
-        : null,
-      battlefield: battlefield
-        ? {
-            origins: battlefield.origins,
-            radius: battlefield.radius,
-            hiddenInfoPolicy: battlefield.hiddenInfoPolicy,
-            pointsOfInterest: battlefield.pointsOfInterest,
-            owners: battlefield.owners,
-          }
-        : null,
-      priorities,
-      notes: [
-        'Read-only priority dashboard; it does not send operations or choose strategy.',
-        'Use listed commands as next inspections, then validate mutations with the specific command family.',
-        'Battlefield scan distances are cheap grid heuristics and may include debug-visible entities unless paired with visibility reads.',
-      ],
-    };
+    const result = await client.attention.priorities({
+      maxNotifications: flags.max,
+      includeBattlefield: !flags['no-battlefield'],
+      battlefieldRadius: flags.radius,
+      maxBattlefieldUnits: flags['max-units'],
+      readyUnitRadius: 2,
+      maxReadyUnitOperations: flags['max-operations'],
+    });
+    const view = buildCliPriorityView(result);
 
     if (flags.json) {
       this.log(JSON.stringify(flags.compact ? buildCompactView(view) : { ok: true, view }));
       return;
     }
 
-    this.log(`Turn ${formatProbe(view.turn)} (${formatProbe(view.turnDate)})`);
-    this.log(`Blocker: ${formatProbe(view.blocker)}; can end turn: ${formatProbe(view.canEndTurn)}`);
-    for (const item of priorities) {
+    this.log(`Turn ${formatValue(view.turn)} (${formatValue(view.turnDate)})`);
+    this.log(`Readiness: ${view.readiness}; can end turn: ${formatValue(view.canEndTurn)}`);
+    for (const item of view.priorities) {
       this.log(`- [${item.priority}] ${item.kind}: ${item.summary}`);
       this.log(`  why: ${item.reason}`);
       if (item.command) this.log(`  next: ${item.command}`);
     }
   }
+}
+
+function buildCliPriorityView(result: Civ7AttentionPrioritiesResult): PriorityView {
+  return {
+    ...result,
+    priorities: result.priorities.map((item) => ({
+      ...item,
+      command: commandForPriority(item),
+    })),
+    cliNotes: [
+      'Read-only priority dashboard; it does not send operations or choose strategy.',
+      'Command suggestions are CLI presentation derived from service next-step descriptors.',
+      'Battlefield scan distances are planning heuristics and may include debug-visible entities unless paired with visibility reads.',
+    ],
+  };
 }
 
 function buildCompactView(view: PriorityView): {
@@ -234,32 +148,19 @@ function buildCompactView(view: PriorityView): {
     command,
   }));
   const decisionHud = {
+    playable: view.playable,
+    readiness: view.readiness,
     turn: view.turn,
     turnDate: view.turnDate,
-    blocker: view.blocker,
     canEndTurn: view.canEndTurn,
-    hasSentTurnComplete: view.hasSentTurnComplete,
-    firstReadyUnitId: view.firstReadyUnitId,
-    selectedCityId: view.selectedCityId,
-    readyUnit: view.readyUnit
-      ? {
-          unitId: view.readyUnit.unitId,
-          legalNoTargetOperationCount: view.readyUnit.legalNoTargetOperationCount,
-        }
-      : null,
-    readyCity: view.readyCity
-      ? {
-          cityId: view.readyCity.cityId,
-          legalOperationCount: view.readyCity.legalOperationCount,
-          populationPlacement: view.readyCity.populationPlacement,
-        }
-      : null,
-    battlefieldPoiCount: Array.isArray(view.battlefield?.pointsOfInterest)
-      ? view.battlefield.pointsOfInterest.length
-      : 0,
+    hasSentTurnComplete: view.turnCompletion.hasSentTurnComplete,
+    turnCompletion: view.turnCompletion,
+    readyUnit: view.readyUnit,
+    readyCity: view.readyCity,
+    battlefieldPoiCount: view.battlefield?.pointOfInterestCount ?? 0,
   };
   const next = top?.command ?? null;
-  const semanticBlockers = view.priorities.filter(isSemanticBlockerPriority).slice(0, 6);
+  const semanticBlockers = view.priorities.filter((item) => item.blocking).slice(0, 6);
   const semanticEnvelope = createSemanticCliEnvelope({
     scope: {
       surface: 'game play priorities',
@@ -295,7 +196,7 @@ function buildCompactView(view: PriorityView): {
     },
     nextSteps: next ? [next] : [],
     evidence: [{
-      label: 'local-cli-priorities-compact',
+      label: 'control-orpc-priorities-compact',
       proofClass: 'local-cli-output',
       command: 'game play priorities --compact --json',
     }],
@@ -318,278 +219,81 @@ function buildCompactView(view: PriorityView): {
     next,
     warnings,
     omitted: [
-      { path: 'view.hud', reason: 'use --json without --compact for full HUD details' },
-      { path: 'view.readyUnit.unit', reason: 'use --json without --compact or game play ready-unit --json for full unit details' },
-      { path: 'view.readyCity.city', reason: 'use --json without --compact or game play ready-city --json for full city details' },
-      { path: 'view.battlefield.pointsOfInterest[].evidence', reason: 'use --json without --compact or the listed tactical lens command for raw evidence' },
-      { path: 'priorities[].evidence', reason: 'use --json without --compact for raw priority evidence' },
+      { path: 'view.notes', reason: 'use --json without --compact for full service notes' },
+      { path: 'view.readyUnit', reason: 'use --json without --compact or game play ready-unit --json for ready-unit detail' },
+      { path: 'view.readyCity', reason: 'use --json without --compact or game play ready-city --json for ready-city detail' },
+      { path: 'view.battlefield.pointsOfInterest', reason: 'use --json without --compact or a tactical lens command for battlefield point detail' },
+      { path: 'priorities[].evidenceLabels', reason: 'use --json without --compact for bounded service evidence labels' },
     ],
     hiddenInfoPolicy: view.battlefield?.hiddenInfoPolicy ?? 'not-expanded',
   };
 }
 
-function buildPriorities(input: {
-  hud: Awaited<ReturnType<typeof getCiv7PlayNotificationView>>;
-  readyUnit: Awaited<ReturnType<typeof getCiv7ReadyUnitView>> | null;
-  readyCity: Awaited<ReturnType<typeof getCiv7ReadyCityView>>;
-  battlefield: Awaited<ReturnType<typeof getCiv7BattlefieldScan>> | null;
-}): PriorityItem[] {
-  const items: PriorityItem[] = [];
-  const runtimeErrors = hudProbeErrors(input.hud);
-  if (runtimeErrors.length > 0) {
-    items.push({
-      priority: 95,
-      kind: 'runtime-state-error',
-      summary: 'core HUD probes failed; live blocker state is not proven clean',
-      reason: 'A missing turn, blocker, or blocking-notification probe means the App UI read is partial. Do not treat an empty notification queue as end-turn proof.',
-      blocking: true,
-      command: 'game play rehydrate --json; game watch --count 1 --include-ready-unit --include-ready-city --jsonl',
-      evidence: runtimeErrors,
-    });
+function commandForPriority(item: Civ7AttentionPrioritiesResult['priorities'][number]): string | undefined {
+  const step = item.nextStep;
+  if (step == null) return undefined;
+  const params = step.parameters;
+  switch (step.kind) {
+    case 'restore-readiness':
+    case 'observe':
+      return 'game play rehydrate --json; game watch --count 1 --include-ready-unit --include-ready-city --jsonl';
+    case 'inspect-ready-unit':
+    case 'validate-unit-target':
+      return "game play ready-unit --json; game play unit-target --unit-id '<unit-id>' --x <x> --y <y> --json";
+    case 'inspect-ready-city':
+      return item.kind.startsWith('hud:')
+        ? 'game play ready-city --compact --json'
+        : 'game play ready-city --json';
+    case 'inspect-progression':
+      return progressionCommand(params.category);
+    case 'inspect-decision':
+      return decisionCommand(params.category);
+    case 'inspect-notification':
+      return params.componentId == null
+        ? 'game play dismiss-notification --json'
+        : params.category === 'narrative-choice'
+          ? `game play dismiss-notification --target '${JSON.stringify(params.componentId)}' --json`
+          : `game play dismiss-notification --target '${JSON.stringify(params.componentId)}' --send`;
+    case 'validate-unit-command':
+      return params.unitId != null && params.operationType != null
+        ? `game play operation --family unit --type ${params.operationType} --unit-id '${JSON.stringify(params.unitId)}' --send`
+        : 'game play operation --family unit --json';
+    case 'send-turn-complete':
+    case 'end-turn':
+      return 'game play end-turn --send --json';
+    case 'observe-turn-advance':
+      return 'game watch --count 3 --interval-ms 1000 --include-ready-unit --include-ready-city --jsonl';
+    case 'inspect-battlefield-point':
+      return battlefieldCommand(params.location, item.kind);
   }
-
-  const nextDecision = input.hud.hud?.nextDecision;
-  if (nextDecision) {
-    const isEndTurnBlocking = nextDecision.isEndTurnBlocking === true;
-    const priority = isEndTurnBlocking ? 100 : 70;
-    const staleUnitCommand = staleUnitCommandPriority(nextDecision);
-    const recommendedDetailCommand = recommendedCliFromDecisionDetails((nextDecision as { details?: unknown }).details);
-    const decisionCommand = commandFromDecision(nextDecision);
-    const detailCommand = commandFromDecisionDetails(nextDecision);
-    const readyUnitCommand = nextDecision.category === 'unit-command' && input.readyUnit
-      ? 'game play ready-unit --json; game play unit-target --unit-id \'<unit-id>\' --x <x> --y <y> --json'
-      : undefined;
-    items.push({
-      priority,
-      kind: staleUnitCommand?.kind ?? `hud:${nextDecision.category}`,
-      summary: staleUnitCommand?.summary ?? nextDecision.summary ?? nextDecision.message ?? nextDecision.typeName ?? 'current HUD decision',
-      reason: staleUnitCommand?.reason ?? (recommendedDetailCommand
-          ? detailCommandReason(recommendedDetailCommand)
-        : decisionCommand
-          ? 'HUD notification includes the live ComponentID; use the exact closeout command after reviewing the report context.'
-        : detailCommand
-          ? detailCommandReason(detailCommand)
-        : readyUnitCommand
-          ? 'A ready unit exists; inspect the ready-unit and target surfaces instead of treating COMMAND_UNITS as stale reconciliation.'
-        : 'HUD decisions are the shortest-lived live authority and should be resolved or consciously deferred before broad strategy.'),
-      blocking: isEndTurnBlocking,
-      command: staleUnitCommand?.command ?? recommendedDetailCommand ?? decisionCommand ?? detailCommand ?? readyUnitCommand ?? nextDecision.cli,
-      evidence: nextDecision,
-    });
-  }
-
-  if (input.readyUnit) {
-    const unit = probeValue(input.readyUnit.unit) as { typeName?: string; location?: { x: number; y: number } } | null;
-    const location = unit?.location ? ` at (${unit.location.x},${unit.location.y})` : '';
-    items.push({
-      priority: 85,
-      kind: 'ready-unit',
-      summary: `${unit?.typeName ?? 'ready unit'}${location}`,
-      reason: 'A ready unit blocks turn flow and target-plot actions require unit-target validation even when no-target operations are present.',
-      blocking: true,
-      command: 'game play ready-unit --json; game play unit-target --unit-id \'<unit-id>\' --x <x> --y <y> --json',
-      evidence: {
-        unitId: input.readyUnit.unitId,
-        legalNoTargetOperationCount: input.readyUnit.legalOperations.length,
-      },
-    });
-  }
-
-  if (input.readyCity.cityId) {
-    const city = probeValue(input.readyCity.city) as { name?: string } | null;
-    items.push({
-      priority: 80,
-      kind: 'ready-city',
-      summary: city?.name ?? 'ready city',
-      reason: 'City blockers often branch between production, town focus, population placement, and expansion.',
-      blocking: true,
-      command: 'game play ready-city --json',
-      evidence: {
-        cityId: input.readyCity.cityId,
-        legalOperationCount: input.readyCity.legalOperations.length,
-      },
-    });
-  }
-
-  for (const point of asArray(input.battlefield?.pointsOfInterest)) {
-    const severity = typeof point.severity === 'string' ? point.severity : 'medium';
-    items.push({
-      priority: severityPriority(severity),
-      kind: `battlefield:${String(point.kind ?? 'point-of-interest')}`,
-      summary: String(point.summary ?? point.kind ?? 'battlefield point of interest'),
-      reason: 'Battlefield POIs identify immediate inspection needs around the current ready-unit origin.',
-      blocking: false,
-      command: battlefieldCommandFor(point),
-      evidence: point,
-    });
-  }
-
-  if (items.length === 0) {
-    items.push({
-      priority: 10,
-      kind: 'clean-read',
-      summary: 'no HUD, ready-unit, ready-city, or battlefield priority surfaced',
-      reason: 'Fresh clean reads can use the guarded end-turn command; it rechecks blockers before sending.',
-      blocking: false,
-      command: "game play end-turn --send --json",
-    });
-  }
-
-  return items.sort((a, b) => b.priority - a.priority);
 }
 
-function isSemanticBlockerPriority(item: PriorityItem): boolean {
-  return item.blocking;
+function progressionCommand(category: unknown): string {
+  if (category === 'technology-choice') return 'game play choose-tech --options --json';
+  if (category === 'culture-choice') return 'game play choose-culture --options --json';
+  if (category === 'tradition-review') return 'game play traditions --compact --json';
+  return 'game play priorities --compact --json';
 }
 
-function hudProbeErrors(hud: Awaited<ReturnType<typeof getCiv7PlayNotificationView>>): Array<{ field: string; error: string }> {
-  return [
-    ['turn', hud.turn],
-    ['turnDate', hud.turnDate],
-    ['blocker', hud.blocker],
-    ['blockingNotificationId', hud.blockingNotificationId],
-  ].flatMap(([field, probe]) =>
-    isProbeError(probe)
-      ? [{ field: String(field), error: probe.error }]
-      : [],
-  );
+function decisionCommand(category: unknown): string {
+  if (category === 'celebration-choice') return 'game play choose-celebration --options --json';
+  if (category === 'government-choice') return 'game play choose-government --options --json';
+  if (category === 'narrative-choice') return 'game play choose-narrative --options --json';
+  if (category === 'first-meet-diplomacy') return 'game play respond-first-meet --json';
+  return 'game play priorities --compact --json';
 }
 
-function isProbeError(probe: unknown): probe is { ok: false; error: string } {
-  return Boolean(probe && typeof probe === 'object' && 'ok' in probe && (probe as { ok?: unknown }).ok === false);
-}
-
-function getReadyUnitLocation(readyUnit: Awaited<ReturnType<typeof getCiv7ReadyUnitView>> | null): { x: number; y: number } | null {
-  const unit = readyUnit ? probeValue(readyUnit.unit) as { location?: { x?: unknown; y?: unknown } } | null : null;
-  const x = unit?.location?.x;
-  const y = unit?.location?.y;
-  return typeof x === 'number' && typeof y === 'number' ? { x, y } : null;
-}
-
-function severityPriority(severity: string): number {
-  if (severity === 'high') return 75;
-  if (severity === 'medium') return 55;
-  if (severity === 'low') return 35;
-  return 45;
-}
-
-function battlefieldCommandFor(point: Record<string, unknown>): string {
-  const location = point.location as { x?: unknown; y?: unknown } | undefined;
-  if (location && typeof location.x === 'number' && typeof location.y === 'number') {
-    if (point.kind === 'city-front') {
-      return `game play destination-analysis --to-x ${location.x} --to-y ${location.y} --json`;
-    }
-    return `game play battlefield-scan --x ${location.x} --y ${location.y} --json`;
+function battlefieldCommand(
+  location: Readonly<{ x: number; y: number }> | undefined,
+  kind: string,
+): string {
+  if (location == null) return 'game play battlefield-scan --x <front-x> --y <front-y> --json';
+  if (kind === 'battlefield:city-front') {
+    return `game play destination-analysis --to-x ${location.x} --to-y ${location.y} --json`;
   }
-  return 'game play battlefield-scan --x <front-x> --y <front-y> --json';
+  return `game play battlefield-scan --x ${location.x} --y ${location.y} --json`;
 }
 
-function probeValue<T>(probe: { ok: true; value: T } | { ok: false; error: string } | null | undefined): T | null {
-  return probe?.ok ? probe.value : null;
-}
-
-function probeArrayLength(probe: { ok: true; value: unknown } | { ok: false; error: string }): number {
-  return probe.ok && Array.isArray(probe.value) ? probe.value.length : 0;
-}
-
-function asArray(value: unknown): Array<Record<string, unknown>> {
-  return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => item !== null && typeof item === 'object') : [];
-}
-
-function detailCommandReason(command: string): string {
-  if (command.includes('dismiss-notification') && !command.includes('--send')) {
-    return 'HUD details prove no live operation option is available; inspect dismissal postcondition evidence before attempting any closeout.';
-  }
-  if (command.includes('dismiss-notification')) {
-    return 'HUD details expose a reviewed notification closeout candidate; it is only successful if the dismissal command reports verified:true.';
-  }
-  if (command.includes('--options')) {
-    return 'HUD details expose a live option surface; read the compact options before selecting a validated command.';
-  }
-  return 'HUD details expose a validator-backed operation candidate; use that exact command or consciously defer before broad strategy.';
-}
-
-function commandFromDecision(nextDecision: Record<string, unknown>): string | undefined {
-  if (nextDecision.category === 'production-choice' || nextDecision.category === 'population-placement') {
-    return 'game play ready-city --compact --json';
-  }
-  if (nextDecision.category === 'tradition-review') {
-    return 'game play traditions --compact --json';
-  }
-  if (nextDecision.category === 'informational-notification' && nextDecision.operationFamily === 'app-ui-action') {
-    const notificationId = nextDecision.notificationId;
-    if (notificationId && typeof notificationId === 'object') {
-      return `game play dismiss-notification --target '${JSON.stringify(notificationId)}' --send`;
-    }
-  }
-  return undefined;
-}
-
-function commandFromDecisionDetails(nextDecision: { details?: unknown }): string | undefined {
-  const details = nextDecision.details;
-  if (!details || typeof details !== 'object') return undefined;
-  const record = details as Record<string, unknown>;
-  if (record.kind === 'technology-choice-options') {
-    const enabledOptions = asArray(record.enabledOptions);
-    return enabledOptions.length > 0 ? 'game play choose-tech --options --json' : undefined;
-  }
-  if (record.kind === 'culture-choice-options') {
-    const enabledOptions = asArray(record.enabledOptions);
-    return enabledOptions.length > 0 ? 'game play choose-culture --options --json' : undefined;
-  }
-  if (record.kind === 'celebration-choice-options') {
-    const enabledOptions = asArray(record.enabledOptions);
-    return enabledOptions.length > 0 ? 'game play choose-celebration --options --json' : undefined;
-  }
-  if (record.kind === 'government-choice-options') {
-    const enabledOptions = asArray(record.enabledOptions);
-    return enabledOptions.length > 0 ? 'game play choose-government --options --json' : undefined;
-  }
-  if (record.kind === 'narrative-choice-options') {
-    const enabledOptions = asArray(record.enabledOptions);
-    if (enabledOptions.length > 0) return 'game play choose-narrative --options --json';
-    return typeof record.dismissalDiagnosticCli === 'string' && record.dismissalDiagnosticCli.length > 0
-      ? record.dismissalDiagnosticCli
-      : 'game play choose-narrative --options --json';
-  }
-  if (record.kind !== 'unit-command-reconciliation') return undefined;
-  if (record.staleReadyPointerSuspected === true) {
-    const candidate = asArray(record.enabledCloseoutCandidates).find((item) => typeof item.cli === 'string' && item.cli.length > 0);
-    if (typeof candidate?.cli === 'string') return candidate.cli;
-  }
-  const repair = asArray(record.repairCandidates).find((item) => typeof item.cli === 'string' && item.cli.length > 0);
-  return typeof repair?.cli === 'string' ? repair.cli : undefined;
-}
-
-function staleUnitCommandPriority(nextDecision: { details?: unknown }): Pick<PriorityItem, 'kind' | 'summary' | 'reason' | 'command'> | null {
-  const details = nextDecision.details;
-  if (!details || typeof details !== 'object') return null;
-  const record = details as Record<string, unknown>;
-  if (record.kind !== 'unit-command-reconciliation') return null;
-  if (record.staleExpiredWithoutEnabledCloseout !== true && record.classification !== 'unit-command-stale-expired') return null;
-  const repair = asArray(record.repairCandidates).find((item) => typeof item.cli === 'string' && item.cli.length > 0);
-  const hasSent = probeValue(record.hasSentTurnComplete as Probe<boolean>) === true;
-  return {
-    kind: 'hud:unit-command-stale-expired',
-    summary: hasSent
-      ? 'expired COMMAND_UNITS has no ready unit or enabled closeout after turn-complete was sent'
-      : 'expired COMMAND_UNITS has no ready unit or enabled unit closeout',
-    reason: hasSent
-      ? 'Official command-units activation has no selected/first-ready unit and every scanned unit closeout is disabled; turn-complete is already sent, so wait/watch for turn advance or a new blocker instead of repeating unit operations.'
-      : 'Official command-units activation has no selected/first-ready unit and every scanned unit closeout is disabled; use the normal end-turn path once, then verify the turn advances or a new blocker appears.',
-    command: typeof repair?.cli === 'string' ? repair.cli : undefined,
-  };
-}
-
-function reasonSlug(item: Record<string, unknown>): string {
-  const text = String(item.typeName ?? item.summary ?? item.category)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-  return text || 'notification-reviewed';
-}
-
-function formatProbe<T>(probe: { ok: true; value: T } | { ok: false; error: string }): string {
-  if (!probe.ok) return `<error: ${probe.error}>`;
-  return typeof probe.value === 'object' ? JSON.stringify(probe.value) : String(probe.value);
+function formatValue(value: unknown): string {
+  return value == null || typeof value === 'object' ? JSON.stringify(value) : String(value);
 }

--- a/packages/cli/test/commands/game.control.test.ts
+++ b/packages/cli/test/commands/game.control.test.ts
@@ -605,6 +605,76 @@ describe('game direct-control commands', () => {
     }
   });
 
+  test('routes map summary through the current world service projection', async () => {
+    const server = await startTunerServer();
+    const writes: string[] = [];
+    const log = vi.spyOn(GameMap.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
+    try {
+      const { port } = server.address();
+      await GameMap.run(['--host', '127.0.0.1', '--port', String(port), '--summary', '--json']);
+
+      const payload = JSON.parse(writes.join('')) as {
+        ok: true;
+        result: {
+          readiness: string;
+          sourceStatus: Record<string, string>;
+          map: Record<string, unknown>;
+          players: Record<string, unknown>;
+          nextSteps: Array<Record<string, unknown>>;
+        };
+      };
+      expect(payload).toMatchObject({
+        ok: true,
+        result: {
+          readiness: 'tuner-ready',
+          sourceStatus: {
+            playableStatus: 'read',
+            game: 'read',
+            map: 'read',
+            players: 'read',
+          },
+          map: {
+            width: 84,
+            height: 54,
+            plotCount: 4536,
+          },
+          players: {
+            maxPlayers: 64,
+            alivePlayerIds: [0],
+            aliveHumanIds: [0],
+            aliveHumanCount: 1,
+          },
+          nextSteps: [
+            {
+              kind: 'read-attention',
+              source: 'world.current',
+            },
+          ],
+        },
+      });
+      expect(server.received.some((message) => message.includes('Network.isInSession'))).toBe(true);
+      expect(server.received.some((message) => message.includes('readPlotSnapshot'))).toBe(false);
+      const serialized = JSON.stringify(payload);
+      expect(serialized).not.toContain('"host"');
+      expect(serialized).not.toContain('"port"');
+      expect(serialized).not.toContain('"state"');
+      expect(serialized).not.toContain('"session"');
+      expect(serialized).not.toContain('rawCommand');
+      expect(serialized).not.toContain('enemy');
+      expect(serialized).not.toContain('hostile');
+      expect(serialized).not.toContain('opponent');
+      expect(serialized).not.toContain('threat');
+      expect(serialized).not.toContain('war');
+      expect(serialized).not.toContain('ally');
+      expect(serialized).not.toContain('suzerain');
+    } finally {
+      log.mockRestore();
+      await server.close();
+    }
+  });
+
   test('samples loaded AI levers through bounded GameInfo reads', async () => {
     const server = await startTunerServer();
     try {

--- a/packages/cli/test/commands/game.control.test.ts
+++ b/packages/cli/test/commands/game.control.test.ts
@@ -591,14 +591,124 @@ describe('game direct-control commands', () => {
     }
   });
 
-  test('reads bounded map and GameInfo surfaces', async () => {
+  test('routes plot map reads through the world service projection', async () => {
     const server = await startTunerServer();
+    const writes: string[] = [];
+    const log = vi.spyOn(GameMap.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
     try {
       const { port } = server.address();
       await GameMap.run(['--host', '127.0.0.1', '--port', String(port), '--plot', '3,4', '--player-id', '0', '--json']);
-      await GameGameInfo.run(['Resources', '--host', '127.0.0.1', '--port', String(port), '--limit', '2', '--json']);
 
       expect(server.received.some((message) => message.includes('readPlotSnapshot'))).toBe(true);
+      const payload = JSON.parse(writes.join('')) as {
+        ok: true;
+        result: {
+          sourceStatus: { plot: string };
+          plot: {
+            location: { x: number; y: number; index: number };
+            hiddenInfoPolicy: string;
+            facts: Record<string, { ok: boolean; value?: unknown; error?: string }>;
+            summary: { factCount: number; probeErrorCount: number };
+          };
+        };
+      };
+      expect(payload).toMatchObject({
+        ok: true,
+        result: {
+          sourceStatus: { plot: 'read' },
+          plot: {
+            location: { x: 3, y: 4, index: 339 },
+            hiddenInfoPolicy: 'visibility-filtered',
+            facts: {
+              terrain: { ok: true, value: 4 },
+              resource: { ok: true, value: -1 },
+            },
+            summary: { factCount: 4, probeErrorCount: 0 },
+          },
+        },
+      });
+      const serialized = JSON.stringify(payload);
+      expect(serialized).not.toContain('"host"');
+      expect(serialized).not.toContain('"port"');
+      expect(serialized).not.toContain('"state"');
+      expect(serialized).not.toContain('rawCommand');
+      expect(serialized).not.toContain('enemy');
+      expect(serialized).not.toContain('hostile');
+      expect(serialized).not.toContain('opponent');
+      expect(serialized).not.toContain('threat');
+      expect(serialized).not.toContain('war');
+      expect(serialized).not.toContain('ally');
+      expect(serialized).not.toContain('suzerain');
+    } finally {
+      log.mockRestore();
+      await server.close();
+    }
+  });
+
+  test('routes bounded grid map reads through the world service projection', async () => {
+    const server = await startTunerServer();
+    const writes: string[] = [];
+    const log = vi.spyOn(GameMap.prototype, 'log').mockImplementation((message?: string) => {
+      if (message) writes.push(message);
+    });
+    try {
+      const { port } = server.address();
+      await GameMap.run([
+        '--host',
+        '127.0.0.1',
+        '--port',
+        String(port),
+        '--bounds',
+        '0,0,2,1',
+        '--fields',
+        'terrain',
+        '--max-plots',
+        '1',
+        '--json',
+      ]);
+
+      expect(server.received.some((message) => message.includes('locationsFromBounds'))).toBe(true);
+      const payload = JSON.parse(writes.join('')) as {
+        ok: true;
+        result: {
+          sourceStatus: { grid: string; map: string };
+          bounds: { x: number; y: number; width: number; height: number };
+          plotCount: number;
+          omitted: number;
+          plots: Array<unknown>;
+        };
+      };
+      expect(payload).toMatchObject({
+        ok: true,
+        result: {
+          sourceStatus: { grid: 'read-with-omissions', map: 'read' },
+          bounds: { x: 0, y: 0, width: 2, height: 1 },
+          plotCount: 2,
+          omitted: 1,
+          map: { width: 84, height: 54 },
+          summary: { returnedPlotCount: 1, probeErrorCount: 0 },
+        },
+      });
+      expect(payload.result.plots).toHaveLength(1);
+      const serialized = JSON.stringify(payload);
+      expect(serialized).not.toContain('"host"');
+      expect(serialized).not.toContain('"port"');
+      expect(serialized).not.toContain('"state"');
+      expect(serialized).not.toContain('rawCommand');
+    } finally {
+      log.mockRestore();
+      await server.close();
+    }
+  });
+
+  test('reads GameInfo surfaces as debug projection', async () => {
+    const server = await startTunerServer();
+    try {
+      const { port } = server.address();
+      await GameGameInfo.run(['Resources', '--host', '127.0.0.1', '--port', String(port), '--limit', '2', '--json']);
+
       expect(server.received.some((message) => message.includes('GameInfo[input.table]'))).toBe(true);
     } finally {
       await server.close();
@@ -835,6 +945,29 @@ async function startTunerServer() {
                 aliveIds: { ok: true, value: [0] },
                 aliveHumanIds: { ok: true, value: [0] },
                 autoplayActive: { ok: true, value: false },
+              }),
+            ])
+          );
+        } else if (frame.message.includes('locationsFromBounds')) {
+          socket.write(
+            encodeResponse(frame.listenerId, [
+              JSON.stringify({
+                bounds: { x: 0, y: 0, width: 2, height: 1 },
+                fields: ['terrain'],
+                plotCount: 2,
+                omitted: 1,
+                hiddenInfoPolicy: 'not-player-scoped',
+                map: {
+                  width: { ok: true, value: 84 },
+                  height: { ok: true, value: 54 },
+                },
+                plots: [{
+                  location: { x: 0, y: 0, index: { ok: true, value: 0 } },
+                  hiddenInfoPolicy: 'not-player-scoped',
+                  facts: {
+                    terrain: { ok: true, value: 4 },
+                  },
+                }],
               }),
             ])
           );

--- a/packages/cli/test/commands/game.play.tactical-read.test.ts
+++ b/packages/cli/test/commands/game.play.tactical-read.test.ts
@@ -98,7 +98,7 @@ describe('game play tactical read commands', () => {
         ...payload.view.summary.pressure.map((item) => item.summary ?? ''),
         ...payload.view.summary.risks,
       ]);
-      expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
+      expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(false);
       expect(server.received.some((message) => message.includes('readTargetCandidates'))).toBe(true);
       expect(server.received.some((message) => message.includes('readBattlefieldScan'))).toBe(true);
       expect(server.received.some((message) => message.includes('readDestinationAnalysis'))).toBe(true);

--- a/packages/cli/test/commands/game/play/notification/dismiss-queue.test.ts
+++ b/packages/cli/test/commands/game/play/notification/dismiss-queue.test.ts
@@ -8,7 +8,7 @@ describe('game play dismiss-notification-queue command', () => {
   test('bulk dismisses only eligible informational queue items with send enabled', async () => {
     const dryRun = await runDismissNotificationQueue('mixed-queue');
     try {
-      expect(dryRun.payload.view.send).toBe(false);
+      expect(dryRun.payload.view.sent).toBe(false);
       expect(dryRun.payload.view.eligibleCount).toBe(1);
       expect(dryRun.payload.view.selectedCount).toBe(1);
       expect(dryRun.payload.view.excluded).toHaveLength(2);
@@ -22,12 +22,13 @@ describe('game play dismiss-notification-queue command', () => {
       '--send',
     ]);
     try {
-      expect(sent.payload.view.send).toBe(true);
+      expect(sent.payload.view.sent).toBe(true);
       expect(sent.payload.view.eligibleCount).toBe(1);
       expect(sent.payload.view.selectedCount).toBe(1);
       expect(sent.payload.view.results).toHaveLength(1);
       expect(sent.payload.view.results[0].sent).toBe(true);
-      expect(sent.payload.view.results[0].verified).toBe(true);
+      expect(sent.payload.view.results[0].status).toBe('sent-confirmed');
+      expect(sent.payload.view.postcondition.confirmed).toBe(true);
       expect(sent.server.received.filter((message) => message.includes('readNotificationDismissal')).length).toBeGreaterThan(1);
       expect(sent.server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -77,11 +78,13 @@ async function runDismissNotificationQueue(mode: DismissQueueMode, extraArgs: re
     payload: JSON.parse(writes.join('')) as {
       ok: true;
       view: {
-        send: boolean;
+        sent: boolean;
         eligibleCount: number;
         selectedCount: number;
         excluded: Array<{ typeName: string | null; reason: string }>;
-        results: Array<{ sent: boolean; verified: boolean }>;
+        status: string;
+        postcondition: { confirmed: boolean };
+        results: Array<{ sent: boolean; status: string }>;
       };
     },
     server,
@@ -94,6 +97,12 @@ async function startDismissNotificationQueueTunerServer(mode: DismissQueueMode):
     handle({ message }) {
       if (message.includes('readPlayNotifications')) {
         return [JSON.stringify(dismissNotificationQueueView(mode))];
+      }
+      if (message.includes('isInGame') && message.includes('GameContext.localPlayerID')) {
+        return [JSON.stringify(appUiSnapshot())];
+      }
+      if (message.includes('evalOk') && message.includes('GameplayMap.getGridWidth')) {
+        return [JSON.stringify(tunerHealthSnapshot())];
       }
       if (message.includes('readNotificationDismissal')) {
         const send = message.includes('"send":true');
@@ -119,6 +128,86 @@ function dismissNotificationQueueView(mode: DismissQueueMode) {
       nextDecision: decisionQueue.find((item) => item.isEndTurnBlocking) ?? null,
       decisionQueue,
     },
+  };
+}
+
+function appUiSnapshot() {
+  const ok = <T>(value: T) => ({ ok: true, value });
+  return {
+    network: {
+      isInSession: ok(true),
+      numPlayers: ok(2),
+      hostPlayerId: ok(0),
+      isConnectedToNetwork: ok(true),
+      isAuthenticated: ok(true),
+      isLoggedIn: ok(true),
+    },
+    autoplay: {
+      isActive: false,
+      turns: 0,
+      isPaused: false,
+      isPausedOrPending: false,
+      observeAsPlayer: -1,
+      returnAsPlayer: -1,
+    },
+    game: {
+      turn: 123,
+      age: 0,
+      maxTurns: 500,
+      turnDate: ok('1160 BCE'),
+      hash: ok(1),
+    },
+    ui: {
+      inGame: ok(true),
+      inShell: ok(false),
+      inLoading: ok(false),
+      loadingState: ok(0),
+      loadingStateName: null,
+      canBeginGame: ok(false),
+      canNotifyUIReady: 'function',
+      skipStartButton: ok(false),
+      automationActive: ok(false),
+    },
+    gameContext: {
+      localPlayerID: 0,
+      localObserverID: -1,
+      hasRequestedPause: ok(false),
+    },
+    players: {
+      maxPlayers: 8,
+      aliveIds: ok([0, 1]),
+      aliveHumanIds: ok([0]),
+      numAliveHumans: ok(1),
+    },
+    map: {
+      width: ok(80),
+      height: ok(52),
+      plotCount: ok(4160),
+      mapSize: ok(1),
+      randomSeed: ok(1234),
+    },
+  };
+}
+
+function tunerHealthSnapshot() {
+  const ok = <T>(value: T) => ({ ok: true, value });
+  return {
+    evalOk: 2,
+    ready: true,
+    globals: {
+      Game: 'object',
+      Autoplay: 'object',
+      GameplayMap: 'object',
+      Players: 'object',
+      Network: 'object',
+    },
+    turn: ok(123),
+    turnDate: ok('1160 BCE'),
+    width: ok(80),
+    height: ok(52),
+    aliveIds: ok([0, 1]),
+    aliveHumanIds: ok([0]),
+    autoplayActive: ok(false),
   };
 }
 

--- a/packages/cli/test/commands/game/play/notification/queue.test.ts
+++ b/packages/cli/test/commands/game/play/notification/queue.test.ts
@@ -27,7 +27,7 @@ describe('game play notification queue command', () => {
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
       expect(server.received.some((message) => message.includes('readNotificationDismissal'))).toBe(false);
-      expect(payload.view.notes.join('\n')).toContain('item-level context');
+      expect(payload.view.notes.join('\n')).toContain('summary and context review');
       expect(payload.view.notes.join('\n')).not.toMatch(/\breason\b/i);
     } finally {
       await server.close();
@@ -40,7 +40,7 @@ describe('game play notification queue command', () => {
       const step = payload.view.schedule[0];
       expect(step.category).toBe('first-meet-diplomacy');
       expect(step.disposition).toBe('operate-with-live-inputs');
-      expect(step.command).toBe('game play respond-first-meet --player-id 0 --met-player-id 2 --response neutral');
+      expect(step.command).toBe('game play respond-first-meet --json');
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
       await server.close();

--- a/packages/cli/test/commands/game/play/priorities.test.ts
+++ b/packages/cli/test/commands/game/play/priorities.test.ts
@@ -35,11 +35,10 @@ describe('game play priorities command', () => {
     try {
       const view = payload.view as {
         priorities: Array<{ kind: string }>;
-        readyUnit: { legalOperationScope: string; legalNoTargetOperationCount: number } | null;
+        readyUnit: { legalOperationCount: number } | null;
         battlefield: { pointsOfInterest: unknown[] } | null;
       };
-      expect(view.readyUnit?.legalOperationScope).toBe('no-target');
-      expect(view.readyUnit?.legalNoTargetOperationCount).toBeGreaterThan(0);
+      expect(view.readyUnit?.legalOperationCount).toBeGreaterThan(0);
       expect(view.battlefield?.pointsOfInterest.length).toBeGreaterThan(0);
       expect(view.priorities.some((item) => item.kind === 'ready-unit')).toBe(true);
       expect(view.priorities.some((item) => item.kind.startsWith('battlefield:'))).toBe(true);
@@ -56,11 +55,11 @@ describe('game play priorities command', () => {
     const { payload, server } = await runPriorities('runtime-error', { compact: false });
     try {
       const view = payload.view as {
-        priorities: Array<{ kind: string; command?: string; evidence?: Array<{ field: string; error: string }> }>;
+        priorities: Array<{ kind: string; command?: string; evidenceLabels?: string[] }>;
       };
       const runtimeError = view.priorities.find((item) => item.kind === 'runtime-state-error');
       expect(runtimeError?.command).toContain('game play rehydrate --json');
-      expect(runtimeError?.evidence?.some((item) => item.field === 'blocker' && item.error.includes('Game is not defined'))).toBe(true);
+      expect(runtimeError?.evidenceLabels?.some((item) => item === 'probe-error:blocker')).toBe(true);
       expect(view.priorities.some((item) => item.kind === 'clean-read')).toBe(false);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -76,7 +75,7 @@ describe('game play priorities command', () => {
       expect(payload.summary).toContain('runtime-state-error');
       expect(payload.next).toContain('game play rehydrate --json');
       expect(payload.warnings.join(' ')).toContain('Core HUD probes failed');
-      expect(payload.omitted.some((item) => item.path === 'priorities[].evidence')).toBe(true);
+      expect(payload.omitted.some((item) => item.path === 'priorities[].evidenceLabels')).toBe(true);
       expect(payload.priorities.some((item) => item.kind === 'clean-read')).toBe(false);
       expect(payload.priorities.every((item) => item.evidence === undefined)).toBe(true);
       expect(Object.keys(payload.semanticEnvelope)).toEqual(SEMANTIC_CLI_ENVELOPE_SLOTS);
@@ -136,7 +135,7 @@ describe('game play priorities command', () => {
       expect(top.command).toContain('game play operation --family unit --type SKIP_TURN');
       expect(top.command).toContain("--unit-id '{\"owner\":0,\"id\":196609,\"type\":26}'");
       expect(payload.next).toBe(top.command);
-      expect(top.reason).toContain('validator-backed operation candidate');
+      expect(top.reason).toContain('enabled unit command candidate');
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -149,9 +148,9 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:first-meet-diplomacy');
-      expect(top.command).toBe('game play respond-first-meet --player-id 0 --met-player-id 2 --response neutral');
+      expect(top.command).toBe('game play respond-first-meet --json');
       expect(payload.next).toBe(top.command);
-      expect(top.reason).toContain('validator-backed operation candidate');
+      expect(top.reason).toContain('validator-backed player-operation');
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
       await server.close();
@@ -424,7 +423,14 @@ async function startPrioritiesTunerServer(mode: PriorityHudMode): Promise<FakeTu
   return startFakeTunerServer({
     handle({ message }) {
       if (message.includes('readPlayNotifications')) return [JSON.stringify(priorityHudView(mode))];
-      if (message.includes('readReadyUnitView')) return [JSON.stringify(readyUnitView())];
+      if (message.includes('Network.isInSession')) return [JSON.stringify(appUiSnapshot())];
+      if (message.includes('evalOk') && message.includes('GameplayMap.getGridWidth')) {
+        return [JSON.stringify(tunerHealthSnapshot())];
+      }
+      if (message.includes('hasSentTurnComplete')) return [JSON.stringify(turnCompletionStatus(mode))];
+      if (message.includes('readReadyUnitView')) {
+        return [JSON.stringify(mode === 'clean-read' ? noReadyUnitView() : readyUnitView())];
+      }
       if (message.includes('readReadyCityView')) {
         return [JSON.stringify(mode === 'clean-read' ? noReadyCityView() : readyCityView())];
       }
@@ -787,6 +793,21 @@ function readyUnitView() {
   };
 }
 
+function noReadyUnitView() {
+  return {
+    ...readyUnitView(),
+    requestedUnitId: null,
+    selectedUnitId: { ok: true, value: null },
+    firstReadyUnitId: { ok: true, value: null },
+    unitId: null,
+    unit: { ok: true, value: null },
+    legalOperations: [],
+    promotionReadiness: { ok: true, value: null },
+    nearby: { ok: true, value: [] },
+    notes: ['No ready unit in clean-read fixture.'],
+  };
+}
+
 function readyCityView() {
   const cityId = { owner: 0, id: 131073, type: 1 };
   return {
@@ -825,6 +846,104 @@ function noReadyCityView() {
     townFocusOptions: { ok: true, value: [] },
     populationPlacement: { ok: true, value: null },
     notes: ['No ready city in clean-read fixture.'],
+  };
+}
+
+function appUiSnapshot() {
+  return {
+    network: {
+      isInSession: { ok: true, value: true },
+      numPlayers: { ok: true, value: 1 },
+      hostPlayerId: { ok: true, value: 0 },
+      isConnectedToNetwork: { ok: true, value: true },
+      isAuthenticated: { ok: true, value: false },
+      isLoggedIn: { ok: true, value: true },
+    },
+    autoplay: {
+      isActive: false,
+      turns: -1,
+      isPaused: false,
+      isPausedOrPending: false,
+      observeAsPlayer: -1,
+      returnAsPlayer: -1,
+    },
+    game: {
+      turn: 80,
+      age: 0,
+      maxTurns: 0,
+      turnDate: { ok: true, value: '2025 BCE' },
+      hash: { ok: true, value: 0 },
+    },
+    ui: {
+      inGame: { ok: true, value: true },
+      inShell: { ok: true, value: false },
+      inLoading: { ok: true, value: false },
+      loadingState: { ok: true, value: 6 },
+      loadingStateName: 'WaitingForUIReady',
+      canBeginGame: { ok: true, value: true },
+      canNotifyUIReady: 'function',
+      skipStartButton: { ok: true, value: false },
+      automationActive: { ok: true, value: false },
+    },
+    gameContext: {
+      localPlayerID: 0,
+      localObserverID: 0,
+      hasRequestedPause: { ok: true, value: false },
+    },
+    players: {
+      maxPlayers: 64,
+      aliveIds: { ok: true, value: [0] },
+      aliveHumanIds: { ok: true, value: [0] },
+      numAliveHumans: { ok: true, value: 1 },
+    },
+    map: {
+      width: { ok: true, value: 84 },
+      height: { ok: true, value: 54 },
+      plotCount: { ok: true, value: 4536 },
+      mapSize: { ok: true, value: 0 },
+      randomSeed: { ok: true, value: 1 },
+    },
+  };
+}
+
+function tunerHealthSnapshot() {
+  return {
+    evalOk: 2,
+    ready: true,
+    globals: {
+      Game: 'object',
+      Autoplay: 'object',
+      GameplayMap: 'object',
+      Players: 'object',
+      Network: 'undefined',
+    },
+    turn: { ok: true, value: 80 },
+    turnDate: { ok: true, value: '2025 BCE' },
+    width: { ok: true, value: 84 },
+    height: { ok: true, value: 54 },
+    aliveIds: { ok: true, value: [0] },
+    aliveHumanIds: { ok: true, value: [0] },
+    autoplayActive: { ok: true, value: false },
+  };
+}
+
+function turnCompletionStatus(mode: PriorityHudMode) {
+  const clean = mode === 'clean-read';
+  const pending = mode === 'stale-unit-command-pending';
+  return {
+    host: '127.0.0.1',
+    port: 0,
+    state: { id: '65535', name: 'App UI', role: 'app-ui' },
+    localPlayerId: 0,
+    turn: { ok: true, value: 80 },
+    turnDate: { ok: true, value: '2025 BCE' },
+    hasSentTurnComplete: { ok: true, value: pending },
+    canEndTurn: { ok: true, value: clean || mode === 'stale-unit-command-disabled' },
+    blocker: { ok: true, value: clean ? 0 : 1 },
+    firstReadyUnitId: {
+      ok: true,
+      value: mode === 'ready-unit' ? { owner: 0, id: 458752, type: 26 } : null,
+    },
   };
 }
 


### PR DESCRIPTION
feat(control-orpc): add world current service

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds service-owned world.current under the native world router, projecting bounded turn, local-player, map, and player-count facts from the existing playable/App UI snapshot runtime port. The procedure keeps input closed, keeps contract schemas private to the contract module, and does not call the burned-down direct-control summary wrappers or expose actor catalogs, relationship labels, raw app-ui snapshots, host/port/state/session, command, rawCommand, or Tuner payloads.

Allowlists world.current through the closed controller bridge envelope derived from the aggregate Civ7ControlOrpcContract, advertises it only through controller supported-read facts when the required game UI map/player/turn APIs are present, and lets readiness.current recommend read-world when no higher-priority attention or strategy read is supported. Regenerates the controller UI bundle for the updated game-ui entrypoint.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/game-ui-controller.test.ts test/world-current-procedure.test.ts test/readiness-current-procedure.test.ts test/controller-bridge-ingress.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd mods/mod-civ7-intelligence-bridge build
- bun run --cwd mods/mod-civ7-intelligence-bridge test
- bun run --cwd mods/mod-civ7-intelligence-bridge check
- generated bundle absence scan for direct-control root/socket/session runtime, raw command/session payload strings, RPC transport symbols, and retired caller-permission tokens
- private procedure-schema export scan
- active approval/caller-permission scan over changed control-oRPC source, tests, and OpenSpec records
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- git diff --check

Boundary: local package and generated-bundle proof only. No deployed Civ7 runtime proof, play-thread action, transport expansion, revived summary wrappers, actor catalog support, relationship labels, public package-root procedure schema exports, approval/reason mechanic, or parent Task 5.x/6.x/7.x acceptance.

feat(cli): route map summary through world current

Refs: openspec/changes/civ7-control-orpc-native-slice

Routes `civ7 game map --summary` through the native `world.current` server-side client while leaving `--plot` and `--bounds` on bounded direct-control map diagnostics until separate world/map read services exist.

Normal summary JSON now uses the semantic current-world projection and keeps endpoint flags as context construction only. The CLI proof asserts raw host/port/state/session/Tuner payloads, raw command fields, direct-control summary envelopes, actor catalogs, and relationship labels stay out of the summary output.

Proof:
- bun run --cwd packages/cli test test/commands/game.control.test.ts
- bun run --cwd packages/cli check
- bun run check:cli
- bun run test:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- active approval/caller-permission scan over changed CLI/OpenSpec surfaces
- git diff --check

Boundary: local CLI/service proof only. No deployed Civ7 runtime proof, play-thread action, transport expansion, plot/grid service migration, revived summary wrappers, relationship labels, approval/reason mechanic, or parent Task 5.x/6.x/7.x acceptance is claimed.

feat(cli): route map plot and grid through world service

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds native `world.plot.read` and `world.grid.read` service leaves over bounded direct-control plot/grid runtime reads, with contract-local schemas and semantic normal projections that omit raw host/port/state/session/Tuner/direct-control envelopes and relationship labels.

Routes `civ7 game map --plot` and `civ7 game map --bounds` through the in-process world service client while leaving GameInfo reads as debug projection. Game-UI/controller map support remains unsupported and pending.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/world-map-read-procedure.test.ts test/world-current-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd packages/cli test test/commands/game.control.test.ts
- bun run --cwd packages/cli check
- bun run check:cli
- bun run test:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- private procedure-schema export scan
- active approval/caller-permission scan over changed surfaces
- git diff --check

Boundary: local package/CLI service proof only. No deployed Civ7 runtime proof, play-thread action, controller bridge allowlisting, game-UI map support, transport expansion, broad actor catalog support, relationship labels, approval/reason mechanic, or parent Task 5.x/6.x/7.x acceptance is claimed.

feat(control-orpc): add game-ui world map reads

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds game-resident `world.plot.read` and `world.grid.read` dependencies over ambient `GameplayMap` evidence, while keeping normal map-read projection in the existing service-owned world procedures.

Allowlists both leaves through closed controller bridge envelopes derived from `Civ7ControlOrpcContract`, advertises them only when plot-level map APIs are present, and regenerates the game UI bridge bundle. Public bridge envelopes remain serialized ingress; procedure input/result schemas stay contract-local.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/controller-bridge-ingress.test.ts test/game-ui-controller.test.ts test/world-map-read-procedure.test.ts test/readiness-current-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd mods/mod-civ7-intelligence-bridge build
- bun run --cwd mods/mod-civ7-intelligence-bridge check
- bun run --cwd mods/mod-civ7-intelligence-bridge test
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- private procedure-schema export scan
- active approval/caller-permission scan over changed surfaces
- generated game UI bundle/runtime leakage scan
- git diff --check

Boundary: local package and generated-bundle proof only. No deployed Civ7 runtime proof, play-thread action, transport expansion, broad actor catalog support, relationship labels, approval/reason mechanic, public package-root procedure schema exports, or parent Task 5.x/6.x/7.x acceptance is claimed.

feat(cli): route front summary through strategy service

Refs: openspec/changes/civ7-control-orpc-native-slice

Moves front-summary composition into the native strategy.frontSummary service procedure: target candidates, battlefield scan, optional destination analysis, front posture, risk summaries, relationship-safe wording, and semantic next-step descriptors now live in control-oRPC.

Routes civ7 game play front-summary through the in-process server-side client. The CLI keeps endpoint flag parsing and maps semantic next-step descriptors into command suggestions as CLI presentation only; service output does not contain literal game play command strings.

Adds the destination-analysis runtime read to the direct-control facade and game-UI strategy adapter so the existing controller strategy path stays coherent after the richer service composition. Regenerates the game UI bridge bundle.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/strategy-front-summary-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run test:cli:play
- bun run check:cli
- bun run --cwd mods/mod-civ7-intelligence-bridge build
- bun run --cwd mods/mod-civ7-intelligence-bridge check
- bun run --cwd mods/mod-civ7-intelligence-bridge test
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- private procedure-schema export scan
- active approval/caller-permission scan over changed surfaces
- service-output CLI-string scan for strategy.frontSummary
- generated game UI bundle/runtime leakage scan
- git diff --check

Boundary: local package, CLI, OpenSpec, and generated-bundle proof only. No deployed Civ7 runtime proof, play-thread action, transport expansion, raw tactical read leaves, action-send authority, relationship labels beyond official evidence, approval/reason mechanic, public package-root procedure schema exports, or parent Task 5.x/6.x/7.x acceptance is claimed.

feat(cli): route priorities through attention service

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds attention.priorities as a service-owned read procedure under the attention router. The service composes playable status, notification, turn-completion, ready-unit/city, and optional battlefield evidence into semantic priority and next-step output while keeping procedure schemas contract-local and CLI command strings out of the service contract.

Routes game play priorities through the in-process control-oRPC server-side client. The CLI remains the presentation adapter that maps semantic next-step descriptors to command suggestions, with endpoint flags used only for context construction.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/attention-priorities-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd packages/cli test -- game/play/priorities.test.ts
- bun run test:cli:play
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- private procedure-schema export scan
- active approval/caller-permission scan
- service-output CLI-string scan
- git diff --check

Boundary: local package/CLI proof only. No deployed Civ7 runtime proof, play-thread action, transport expansion, relationship labels beyond official evidence, action-send authority, or parent Task 5.x/6.x/7.x acceptance.

feat(cli): route civilian triage through strategy service

Refs: openspec/changes/civ7-control-orpc-native-slice

Moves civilian-route-triage composition into the native strategy.civilianRouteTriage service procedure. The service reads notification, ready-unit, settlement recommendation, battlefield, and optional destination-analysis evidence through control-oRPC context and returns relationship-safe route status plus semantic next-step descriptors.

Routes civ7 game play civilian-route-triage through the in-process server-side client. The CLI keeps endpoint flag parsing and maps semantic next-step descriptors into command suggestions as CLI presentation only; service output does not contain literal game play command strings.

Adds the settlement recommendation runtime read to the control-oRPC direct-control facade and keeps the game-UI facade fail-closed for that unsupported read in this slice.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/strategy-civilian-route-triage-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd packages/cli test -- game.play.tactical-read.test.ts
- bun run test:cli:play
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- private procedure-schema export scan
- active approval/caller-permission scan over changed surfaces
- service-output CLI-string scan for strategy.civilianRouteTriage
- git diff --check

Boundary: local package, CLI, and OpenSpec proof only. No deployed Civ7 runtime proof, play-thread action, controller bridge or game-UI route triage support, transport expansion, movement/founding/action-send authority, relationship labels beyond official evidence, approval/reason mechanic, public package-root procedure schema exports, or parent Task 5.x/6.x/7.x acceptance is claimed.

feat(cli): route formation snapshot through strategy service

Refs: openspec/changes/civ7-control-orpc-native-slice

Moves formation-snapshot composition into the native strategy.formationSnapshot service procedure. The service reads notification, ready-unit, and battlefield evidence through control-oRPC context and returns relationship-safe formation posture, safe unit/contact projections, and semantic next-step descriptors.

Routes civ7 game play formation-snapshot through the in-process server-side client. The CLI keeps endpoint flag parsing and maps semantic next-step descriptors into command suggestions as CLI presentation only; service output does not contain literal game play command strings.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/strategy-formation-snapshot-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd packages/cli test -- game.play.tactical-read.test.ts
- bun run test:cli:play
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- private procedure-schema export scan
- active approval/caller-permission scan over changed surfaces
- service-output CLI-string scan for strategy.formationSnapshot
- relationship-label safety scan
- git diff --check

Boundary: local package, CLI, and OpenSpec proof only. No deployed Civ7 runtime proof, play-thread action, controller bridge or game-UI formation support, transport expansion, movement/action-send authority, relationship labels beyond official evidence, approval/reason mechanic, public package-root procedure schema exports, or parent Task 5.x/6.x/7.x acceptance is claimed.

feat(cli): route notification queue through notifications service

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds native notifications.queue.current and notifications.queue.dismiss.request service procedures for queue scheduling, informational dismissal eligibility, exclusion reasons, semantic next-step descriptors, and aggregate proof/no-repeat projection.

Routes civ7 game play notification-queue and dismiss-notification-queue through the in-process control-oRPC server-side client. CLI command-string suggestions stay in the CLI edge; service output remains semantic and caller-neutral.

Keeps notification queue input/result schemas contract-local, omits raw host/port/state/session/command/rawCommand payloads, direct-control runtime envelopes, legacy verified, approval/reason mechanics, and raw App UI closeout internals from normal output.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/notification-queue-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd packages/cli test -- game/play/notification/queue.test.ts game/play/notification/dismiss-queue.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- private procedure-schema export scan
- active approval/caller-permission scan
- service-output CLI-string scan
- git diff --check

Local package and CLI proof only; no deployed Civ7 runtime proof, play-thread action, controller bridge, transport expansion, broad operation catalog support, or parent Task 5.x/6.x/7.x acceptance.