### PR TITLE
feat(cli): route progress dashboard through progression service

### DIFF
--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -1706,6 +1706,36 @@ boundaries.
   rawCommand, direct-control runtime envelopes, approval/reason mechanics, or
   transport details as normal traditions output
 
+#### Scenario: Strategy tactical read services are implemented
+- **WHEN** a caller reads target candidates or destination analysis
+- **THEN** the reads are offered under the semantic `strategy` router as
+  `strategy.targetCandidates` and `strategy.destinationAnalysis`
+- **AND** they consume direct-control tactical runtime/read ports as low-level
+  App UI evidence rather than exposing direct-control result envelopes
+- **AND** the service procedures own bounded planning summaries, semantic
+  next-step descriptors, omitted-detail policy, and relationship-safe wording
+- **AND** caller-facing input accepts only tactical read selection fields such
+  as player id, origins, destination, radii, and bounds, while endpoint,
+  session, state, raw command, rawCommand, transport, and approval/reason
+  fields remain outside procedure input
+- **AND** normal service output omits raw host, port, state, session, command,
+  rawCommand, raw city/unit/plot samples, and direct-control runtime envelopes
+- **AND** normal output uses `relationship-unproven`/official-proof-neutral
+  wording and does not infer official diplomatic labels from owner mismatch,
+  proximity, contact, ranking, or action legality
+- **AND** local procedure tests do not claim live Civ7 runtime proof
+
+#### Scenario: CLI tactical reads use native strategy services
+- **WHEN** `civ7 game play target-candidates` or
+  `civ7 game play destination-analysis` reads tactical planning evidence
+- **THEN** the CLI calls the in-process `strategy.targetCandidates` or
+  `strategy.destinationAnalysis` server-side client
+- **AND** normal JSON uses the service-owned semantic strategy projection
+  rather than a CLI-owned direct-control runtime projection
+- **AND** the CLI does not expose raw host, port, state, session, command,
+  rawCommand, direct-control runtime envelopes, approval/reason mechanics, raw
+  city/unit/plot samples, or transport details as normal tactical-read output
+
 #### Scenario: Local procedure test passes
 - **WHEN** a local fake-context procedure test passes
 - **THEN** it may prove contract/middleware/projection behavior

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -1677,6 +1677,35 @@ boundaries.
   rawCommand, direct-control runtime envelopes, approval/reason mechanics, or
   transport details as normal progress-dashboard output
 
+#### Scenario: Progression traditions service is implemented
+- **WHEN** a caller reads `progression.traditions.current`
+- **THEN** it is offered under the semantic `progression` router
+- **AND** it consumes the direct-control traditions runtime port as low-level
+  App UI/Culture evidence
+- **AND** the service procedure owns tradition option projection, semantic
+  action descriptors, validation-success projection, omitted-detail policy,
+  and next-step descriptors
+- **AND** caller-facing input accepts only traditions read selection fields
+  such as optional player id, while endpoint, session, state, raw command,
+  rawCommand, transport, and approval/reason fields remain outside procedure
+  input
+- **AND** normal service output omits raw host, port, state, session, command,
+  rawCommand, direct-control `recommendedCli`, `actionHints[].cli`, runtime
+  envelopes, and CLI command strings
+- **AND** local procedure tests do not claim live Civ7 runtime proof
+
+#### Scenario: CLI traditions view uses native progression service
+- **WHEN** `civ7 game play traditions` reads current traditions
+- **THEN** the CLI calls the in-process
+  `progression.traditions.current` server-side client
+- **AND** normal JSON uses the service-owned semantic traditions projection
+  rather than a CLI-owned runtime projection
+- **AND** any CLI command-string presentation is mapped at the CLI edge from
+  semantic action descriptors, not embedded in the service contract
+- **AND** the CLI does not expose raw host, port, state, session, command,
+  rawCommand, direct-control runtime envelopes, approval/reason mechanics, or
+  transport details as normal traditions output
+
 #### Scenario: Local procedure test passes
 - **WHEN** a local fake-context procedure test passes
 - **THEN** it may prove contract/middleware/projection behavior

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -1649,6 +1649,34 @@ boundaries.
 - **AND** not-sent, sticky-blocker, state-changed-blocker-still-live, and other
   unverified paths remain no-repeat guarded
 
+#### Scenario: Progression dashboard service is implemented
+- **WHEN** a caller reads `progression.dashboard.current`
+- **THEN** it is offered under the semantic `progression` router
+- **AND** it consumes the direct-control progress dashboard runtime port as
+  low-level App UI evidence
+- **AND** the service procedure owns the summary-first progression projection,
+  compact legacy path calculations, warning policy, omitted-detail policy, and
+  semantic next-step descriptors
+- **AND** caller-facing input accepts only progression dashboard selection
+  fields such as optional player id, while endpoint, session, state, raw
+  command, rawCommand, transport, and approval/reason fields remain outside
+  procedure input
+- **AND** normal service output omits raw host, port, state, session, command,
+  rawCommand, direct-control runtime envelopes, and CLI command strings
+- **AND** local procedure tests do not claim live Civ7 runtime proof
+
+#### Scenario: CLI progress dashboard uses native progression service
+- **WHEN** `civ7 game play progress-dashboard` reads current progress
+- **THEN** the CLI calls the in-process
+  `progression.dashboard.current` server-side client
+- **AND** normal JSON uses the service-owned semantic progression dashboard
+  projection rather than a CLI-owned runtime projection
+- **AND** any CLI command-string presentation is mapped at the CLI edge from
+  semantic next-step descriptors, not embedded in the service contract
+- **AND** the CLI does not expose raw host, port, state, session, command,
+  rawCommand, direct-control runtime envelopes, approval/reason mechanics, or
+  transport details as normal progress-dashboard output
+
 #### Scenario: Local procedure test passes
 - **WHEN** a local fake-context procedure test passes
 - **THEN** it may prove contract/middleware/projection behavior

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -1707,9 +1707,11 @@ boundaries.
   transport details as normal traditions output
 
 #### Scenario: Strategy tactical read services are implemented
-- **WHEN** a caller reads target candidates or destination analysis
+- **WHEN** a caller reads battlefield scan, target candidates, or destination
+  analysis
 - **THEN** the reads are offered under the semantic `strategy` router as
-  `strategy.targetCandidates` and `strategy.destinationAnalysis`
+  `strategy.battlefieldScan`, `strategy.targetCandidates`, and
+  `strategy.destinationAnalysis`
 - **AND** they consume direct-control tactical runtime/read ports as low-level
   App UI evidence rather than exposing direct-control result envelopes
 - **AND** the service procedures own bounded planning summaries, semantic
@@ -1726,10 +1728,12 @@ boundaries.
 - **AND** local procedure tests do not claim live Civ7 runtime proof
 
 #### Scenario: CLI tactical reads use native strategy services
-- **WHEN** `civ7 game play target-candidates` or
+- **WHEN** `civ7 game play battlefield-scan`,
+  `civ7 game play target-candidates`, or
   `civ7 game play destination-analysis` reads tactical planning evidence
-- **THEN** the CLI calls the in-process `strategy.targetCandidates` or
-  `strategy.destinationAnalysis` server-side client
+- **THEN** the CLI calls the in-process `strategy.battlefieldScan`,
+  `strategy.targetCandidates`, or `strategy.destinationAnalysis` server-side
+  client
 - **AND** normal JSON uses the service-owned semantic strategy projection
   rather than a CLI-owned direct-control runtime projection
 - **AND** the CLI does not expose raw host, port, state, session, command,

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -133,13 +133,14 @@ adding more read-only facade shells.
     relationship-unproven policy; CLI command strings stay caller-local; no
     strategy catalog, action authority, runtime proof, or parent Task 5.x/6.x
     acceptance.
-  - [x] 5.4.4.1 Record `strategy.targetCandidates` and
-    `strategy.destinationAnalysis` as service-owned tactical read projections
-    over direct-control target-candidate and destination-analysis runtime/read
-    ports. The service owns bounded planning summaries, semantic next-step
-    descriptors, raw sample omission, and relationship-unproven policy; CLI
-    command strings stay caller-local; no strategy catalog, controller bridge,
-    action authority, runtime proof, or parent Task 5.x/6.x acceptance.
+  - [x] 5.4.4.1 Record `strategy.battlefieldScan`,
+    `strategy.targetCandidates`, and `strategy.destinationAnalysis` as
+    service-owned tactical read projections over direct-control battlefield,
+    target-candidate, and destination-analysis runtime/read ports. The service
+    owns bounded planning summaries, semantic next-step descriptors, raw
+    sample omission, and relationship-unproven policy; CLI command strings stay
+    caller-local; no strategy catalog, controller bridge, action authority,
+    runtime proof, or parent Task 5.x/6.x acceptance.
   - [x] 5.4.5 Record `narrative.choice.request` as a service-owned
     narrative boundary over direct-control narrative runtime, validator, and
     proof ports. The service owns the caller-facing semantic choice shape,
@@ -798,16 +799,18 @@ adding more read-only facade shells.
     raw host/port/state/session/Tuner payloads, and runtime envelopes from
     normal JSON, and avoid controller bridge, transport, broad read-wrapper
     revival, approval/reason mechanics, or runtime-proof claims.
-  - [x] 7.1.9.15 Route `civ7 game play target-candidates` and
+  - [x] 7.1.9.15 Route `civ7 game play battlefield-scan`,
+    `civ7 game play target-candidates`, and
     `civ7 game play destination-analysis` through the in-process
-    `strategy.targetCandidates` and `strategy.destinationAnalysis`
-    server-side clients under the `strategy` router. Move bounded target and
-    destination planning projection out of the CLI, keep endpoint flags as
-    context construction, emit relationship-safe semantic planning output,
-    omit raw host/port/state/session/Tuner payloads, raw city/unit/plot
-    samples, and direct-control envelopes from normal JSON, and avoid
-    controller bridge, transport, action-send, approval/reason mechanics, or
-    runtime-proof claims.
+    `strategy.battlefieldScan`, `strategy.targetCandidates`, and
+    `strategy.destinationAnalysis` server-side clients under the `strategy`
+    router. Move bounded battlefield, target, and destination planning
+    projection out of the CLI, keep endpoint flags as context construction,
+    emit relationship-safe semantic planning output, omit raw
+    host/port/state/session/Tuner payloads, raw city/unit/plot samples, and
+    direct-control envelopes from normal JSON, and avoid controller bridge,
+    transport, action-send, approval/reason mechanics, or runtime-proof
+    claims.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1631,14 +1634,15 @@ adding more read-only facade shells.
   tactical-read tests, control-oRPC package test/check/build, CLI play/check
   gates, strict OpenSpec validates, private procedure-schema export scan,
   active approval/caller-permission scan, service-output CLI-string scan, raw
-  runtime output scan, and diff hygiene for the `strategy.targetCandidates`
-  and `strategy.destinationAnalysis` service projections and
-  `game play target-candidates` / `destination-analysis` in-process oRPC
-  caller migration. This is local package/CLI proof only and does not claim
-  deployed Civ7 runtime proof, play-thread action, controller bridge,
-  transport expansion, broad strategy catalog support, relationship labels
-  beyond official evidence, approval/reason mechanics, raw runtime output, or
-  parent Task 5.x/6.x/7.x acceptance.
+  runtime output scan, and diff hygiene for the `strategy.battlefieldScan`,
+  `strategy.targetCandidates`, and `strategy.destinationAnalysis` service
+  projections and `game play battlefield-scan` / `target-candidates` /
+  `destination-analysis` in-process oRPC caller migration. This is local
+  package/CLI proof only and does not claim deployed Civ7 runtime proof,
+  play-thread action, controller bridge, transport expansion, broad strategy
+  catalog support, relationship labels beyond official evidence,
+  approval/reason mechanics, raw runtime output, or parent Task 5.x/6.x/7.x
+  acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -133,6 +133,13 @@ adding more read-only facade shells.
     relationship-unproven policy; CLI command strings stay caller-local; no
     strategy catalog, action authority, runtime proof, or parent Task 5.x/6.x
     acceptance.
+  - [x] 5.4.4.1 Record `strategy.targetCandidates` and
+    `strategy.destinationAnalysis` as service-owned tactical read projections
+    over direct-control target-candidate and destination-analysis runtime/read
+    ports. The service owns bounded planning summaries, semantic next-step
+    descriptors, raw sample omission, and relationship-unproven policy; CLI
+    command strings stay caller-local; no strategy catalog, controller bridge,
+    action authority, runtime proof, or parent Task 5.x/6.x acceptance.
   - [x] 5.4.5 Record `narrative.choice.request` as a service-owned
     narrative boundary over direct-control narrative runtime, validator, and
     proof ports. The service owns the caller-facing semantic choice shape,
@@ -791,6 +798,16 @@ adding more read-only facade shells.
     raw host/port/state/session/Tuner payloads, and runtime envelopes from
     normal JSON, and avoid controller bridge, transport, broad read-wrapper
     revival, approval/reason mechanics, or runtime-proof claims.
+  - [x] 7.1.9.15 Route `civ7 game play target-candidates` and
+    `civ7 game play destination-analysis` through the in-process
+    `strategy.targetCandidates` and `strategy.destinationAnalysis`
+    server-side clients under the `strategy` router. Move bounded target and
+    destination planning projection out of the CLI, keep endpoint flags as
+    context construction, emit relationship-safe semantic planning output,
+    omit raw host/port/state/session/Tuner payloads, raw city/unit/plot
+    samples, and direct-control envelopes from normal JSON, and avoid
+    controller bridge, transport, action-send, approval/reason mechanics, or
+    runtime-proof claims.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1610,6 +1627,18 @@ adding more read-only facade shells.
   action, controller bridge, transport expansion, broad read-wrapper revival,
   approval/reason mechanics, raw runtime output, or parent Task 5.x/6.x/7.x
   acceptance.
+- [x] 8.60.24 Run focused strategy tactical-read procedure tests, focused CLI
+  tactical-read tests, control-oRPC package test/check/build, CLI play/check
+  gates, strict OpenSpec validates, private procedure-schema export scan,
+  active approval/caller-permission scan, service-output CLI-string scan, raw
+  runtime output scan, and diff hygiene for the `strategy.targetCandidates`
+  and `strategy.destinationAnalysis` service projections and
+  `game play target-candidates` / `destination-analysis` in-process oRPC
+  caller migration. This is local package/CLI proof only and does not claim
+  deployed Civ7 runtime proof, play-thread action, controller bridge,
+  transport expansion, broad strategy catalog support, relationship labels
+  beyond official evidence, approval/reason mechanics, raw runtime output, or
+  parent Task 5.x/6.x/7.x acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -239,6 +239,14 @@ adding more read-only facade shells.
     postcondition projection, raw-output exclusion, and no-repeat guard; no
     generic player-operation catalog, approval/reason mechanic, runtime proof,
     controller bridge, or parent Task 5.x/6.x acceptance.
+  - [x] 5.4.23 Record `progression.dashboard.current` as a service-owned
+    progression dashboard boundary over the direct-control runtime progress
+    read port. The service owns the summary-first progress projection,
+    compact legacy path calculations, warnings, omitted-detail policy, and
+    semantic next-step descriptors; direct-control remains the low-level App
+    UI evidence source. Keep CLI command strings caller-local, keep contract
+    schemas private, and avoid runtime proof, controller bridge, transport,
+    broad progression catalogs, or parent Task 5.x/6.x acceptance.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -407,6 +415,14 @@ adding more read-only facade shells.
     pending-runtime-proof/no-repeat guarded, and keep runtime proof,
     controller bridge, transport expansion, approval/reason mechanics, broad
     operation catalog support, and parent Task 5.x/6.x/7.x acceptance pending.
+  - [x] 5.5.22 Seed `progression.dashboard.current` as a native service-owned
+    progression read that composes the direct-control progress dashboard
+    runtime port into caller-neutral semantic output. Keep input/output schemas
+    contract-local, omit raw host/port/state/session/command evidence, keep
+    service next steps as descriptors rather than CLI command strings, leave
+    game-UI/controller support unsupported, and keep runtime proof, transport
+    expansion, broad read-wrapper revival, approval/reason mechanics, and
+    parent Task 5.x/6.x/7.x acceptance pending.
 
 ## 6. Native Policy Layering
 
@@ -743,6 +759,14 @@ adding more read-only facade shells.
     raw `VIEWED_ADVISOR_WARNING` operation details, legacy `verified`, and
     approval/reason mechanics from normal send JSON, and avoid controller
     bridge, transport, broad operation catalogs, or runtime-proof claims.
+  - [x] 7.1.9.13 Route `civ7 game play progress-dashboard` through the
+    in-process `progression.dashboard.current` server-side client under the
+    `progression` router. Move the summary-first progress projection out of
+    the CLI into the native service, keep CLI command strings mapped only in
+    CLI presentation, omit raw host/port/state/session/Tuner payloads and
+    direct-control runtime envelopes from normal JSON, and avoid controller
+    bridge, transport, broad read-wrapper revival, approval/reason mechanics,
+    or runtime-proof claims.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1540,6 +1564,17 @@ adding more read-only facade shells.
   bridge, transport expansion, broad operation catalog support, approval/reason
   mechanics, raw player-operation output, or parent Task 5.x/6.x/7.x
   acceptance.
+- [x] 8.60.22 Run focused progression dashboard procedure tests, focused CLI
+  progression-read tests, control-oRPC package test/check/build, CLI
+  play/check gates, strict OpenSpec validates, private procedure-schema export
+  scan, active approval/caller-permission scan, service-output CLI-string
+  scan, raw runtime output scan, and diff hygiene for the
+  `progression.dashboard.current` service-composition expansion and `game play
+  progress-dashboard` in-process oRPC caller migration. This is local
+  package/CLI proof only and does not claim deployed Civ7 runtime proof,
+  play-thread action, controller bridge, transport expansion, broad
+  read-wrapper revival, approval/reason mechanics, raw runtime output, or
+  parent Task 5.x/6.x/7.x acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -247,6 +247,14 @@ adding more read-only facade shells.
     UI evidence source. Keep CLI command strings caller-local, keep contract
     schemas private, and avoid runtime proof, controller bridge, transport,
     broad progression catalogs, or parent Task 5.x/6.x acceptance.
+  - [x] 5.4.24 Record `progression.traditions.current` as a service-owned
+    traditions decision-read boundary over the direct-control traditions
+    runtime port. The service owns semantic tradition action descriptors,
+    validation-success projection, omitted CLI/runtime evidence policy, and
+    next-step descriptors; direct-control remains the low-level App UI/Culture
+    evidence source. Keep CLI command strings caller-local, keep contract
+    schemas private, and avoid runtime proof, controller bridge, transport,
+    broad progression catalogs, or parent Task 5.x/6.x acceptance.
 - [ ] 5.5 Compose the layered behavior into native oRPC/effect-orpc routers
   only after the hierarchy and ownership boundaries are real.
   - [x] 5.5.1 Seed `attention.current` as a native service-owned procedure
@@ -420,6 +428,14 @@ adding more read-only facade shells.
     runtime port into caller-neutral semantic output. Keep input/output schemas
     contract-local, omit raw host/port/state/session/command evidence, keep
     service next steps as descriptors rather than CLI command strings, leave
+    game-UI/controller support unsupported, and keep runtime proof, transport
+    expansion, broad read-wrapper revival, approval/reason mechanics, and
+    parent Task 5.x/6.x/7.x acceptance pending.
+  - [x] 5.5.23 Seed `progression.traditions.current` as a native service-owned
+    progression read that composes the direct-control traditions runtime port
+    into caller-neutral semantic action descriptors. Keep input/output schemas
+    contract-local, omit raw host/port/state/session/command evidence, omit
+    direct-control CLI recommendation fields and `actionHints[].cli`, leave
     game-UI/controller support unsupported, and keep runtime proof, transport
     expansion, broad read-wrapper revival, approval/reason mechanics, and
     parent Task 5.x/6.x/7.x acceptance pending.
@@ -767,6 +783,14 @@ adding more read-only facade shells.
     direct-control runtime envelopes from normal JSON, and avoid controller
     bridge, transport, broad read-wrapper revival, approval/reason mechanics,
     or runtime-proof claims.
+  - [x] 7.1.9.14 Route `civ7 game play traditions` through the in-process
+    `progression.traditions.current` server-side client under the
+    `progression` router. Move the traditions option projection out of the CLI
+    into the native service, keep CLI command strings mapped only in CLI
+    presentation, omit direct-control `recommendedCli` / `actionHints[].cli`,
+    raw host/port/state/session/Tuner payloads, and runtime envelopes from
+    normal JSON, and avoid controller bridge, transport, broad read-wrapper
+    revival, approval/reason mechanics, or runtime-proof claims.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1575,6 +1599,17 @@ adding more read-only facade shells.
   play-thread action, controller bridge, transport expansion, broad
   read-wrapper revival, approval/reason mechanics, raw runtime output, or
   parent Task 5.x/6.x/7.x acceptance.
+- [x] 8.60.23 Run focused progression traditions procedure tests, focused CLI
+  progression-read tests, control-oRPC package test/check/build, CLI
+  play/check gates, strict OpenSpec validates, private procedure-schema export
+  scan, active approval/caller-permission scan, service-output CLI-string
+  scan, raw runtime output scan, and diff hygiene for the
+  `progression.traditions.current` service-composition expansion and `game
+  play traditions` in-process oRPC caller migration. This is local package/CLI
+  proof only and does not claim deployed Civ7 runtime proof, play-thread
+  action, controller bridge, transport expansion, broad read-wrapper revival,
+  approval/reason mechanics, raw runtime output, or parent Task 5.x/6.x/7.x
+  acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-progress-dashboard-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-progress-dashboard-orpc-slice.md
@@ -1,0 +1,74 @@
+# CLI Progress Dashboard oRPC Slice
+
+## Status
+
+Local control-oRPC, CLI, and OpenSpec closure proof collected.
+
+## Purpose
+
+Route `civ7 game play progress-dashboard` through the native in-process
+`progression.dashboard.current` service procedure instead of letting the CLI
+own the summary-first progression dashboard projection.
+
+The control-oRPC service owns the caller-facing dashboard input, semantic
+progress summary, compact legacy-path calculations, warnings, omitted-detail
+policy, and next-step descriptors. `@civ7/direct-control` remains the
+low-level App UI runtime progress evidence source.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/dependencies/direct-control.ts`
+- `packages/civ7-control-orpc/src/errors.ts`
+- `packages/civ7-control-orpc/src/game-ui.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/src/modules/progression/contract.ts`
+- `packages/civ7-control-orpc/src/modules/progression/procedures/dashboard-current.ts`
+- `packages/civ7-control-orpc/src/modules/progression/router.ts`
+- `packages/civ7-control-orpc/test/progression-dashboard-procedure.test.ts`
+- `packages/cli/src/commands/game/play/progress-dashboard.ts`
+- `packages/cli/test/commands/game.play.progression-read.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-progress-dashboard-orpc-slice.md`
+
+## Boundary
+
+- `progression.dashboard.current` is a progression-domain read, not a broad
+  read-wrapper catalog or `operations` root.
+- The service result uses semantic next-step descriptors. CLI command strings
+  remain caller-local presentation mapping in `packages/cli`.
+- Normal service and CLI JSON omit raw host, port, state, session, command,
+  rawCommand, direct-control runtime envelopes, approval/reason mechanics, and
+  transport details.
+- Game-UI/controller progress dashboard support remains unsupported in this
+  slice.
+- Local tests do not prove deployed Civ7 runtime behavior.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/progression-dashboard-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run --cwd packages/cli test -- game.play.progression-read.test.ts`
+- `bun run check:cli`
+- `bun run test:cli:play`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Private procedure-schema export scan: progression dashboard input/result
+  schemas remain contract-local constants; no procedure schema bag is exported.
+- Active approval/caller-permission scan: hits are limited to negative
+  boundary wording and the focused bad-input assertion.
+- Service-output CLI-string scan: `progression.dashboard.current` source and
+  focused procedure output contain no literal `game play ...` command strings.
+- Raw runtime output scan: normal service/CLI send surfaces omit raw
+  direct-control runtime envelopes; endpoint/session/command fields stay
+  context-owned.
+- `git diff --check`
+
+## Residual Risk
+
+This is local package and CLI proof only. It does not prove deployed Civ7
+runtime behavior, game-UI/controller bridge support, transport expansion,
+approval/reason mechanics, a broad read-wrapper catalog, or parent Task
+5.x/6.x/7.x acceptance.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-strategy-tactical-reads-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-strategy-tactical-reads-orpc-slice.md
@@ -6,7 +6,7 @@ Local control-oRPC, CLI, and OpenSpec closure proof collected.
 
 ## Purpose
 
-Route `civ7 game play target-candidates` and
+Route `civ7 game play battlefield-scan`, `civ7 game play target-candidates`, and
 `civ7 game play destination-analysis` through native in-process strategy
 service procedures instead of letting the CLI expose direct-control tactical
 read envelopes.
@@ -24,6 +24,7 @@ low-level App UI tactical runtime evidence source.
 - `packages/civ7-control-orpc/src/modules/strategy/procedures/tactical-reads.ts`
 - `packages/civ7-control-orpc/src/modules/strategy/router.ts`
 - `packages/civ7-control-orpc/test/strategy-tactical-reads-procedure.test.ts`
+- `packages/cli/src/commands/game/play/battlefield-scan.ts`
 - `packages/cli/src/commands/game/play/destination-analysis.ts`
 - `packages/cli/src/commands/game/play/target-candidates.ts`
 - `packages/cli/test/commands/game.play.tactical-read.test.ts`
@@ -33,9 +34,9 @@ low-level App UI tactical runtime evidence source.
 
 ## Boundary
 
-- `strategy.targetCandidates` and `strategy.destinationAnalysis` are
-  strategy-domain read-only planning services, not a broad tactical catalog or
-  operation/send surface.
+- `strategy.battlefieldScan`, `strategy.targetCandidates`, and
+  `strategy.destinationAnalysis` are strategy-domain read-only planning
+  services, not a broad tactical catalog or operation/send surface.
 - The service result projects bounded counts, locations, route hints,
   relationship-unproven owner evidence, omitted-detail records, and semantic
   next-step descriptors. Raw direct-control city/unit/plot samples remain out
@@ -52,9 +53,9 @@ low-level App UI tactical runtime evidence source.
 
 - `bun run --cwd packages/civ7-control-orpc test test/strategy-tactical-reads-procedure.test.ts`
 - `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
 - `bun run --cwd packages/cli test -- game.play.tactical-read.test.ts`
 - `bun run --cwd packages/civ7-control-orpc test`
-- `bun run --cwd packages/civ7-control-orpc build`
 - `bun run check:cli`
 - `bun run test:cli:play`
 - `bun run openspec -- validate civ7-control-orpc-native-slice --strict`

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-strategy-tactical-reads-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-strategy-tactical-reads-orpc-slice.md
@@ -1,0 +1,79 @@
+# CLI Strategy Tactical Reads oRPC Slice
+
+## Status
+
+Local control-oRPC, CLI, and OpenSpec closure proof collected.
+
+## Purpose
+
+Route `civ7 game play target-candidates` and
+`civ7 game play destination-analysis` through native in-process strategy
+service procedures instead of letting the CLI expose direct-control tactical
+read envelopes.
+
+The control-oRPC service owns caller-facing tactical-read input, bounded target
+and destination planning summaries, relationship-safe wording, omitted-detail
+policy, and semantic next-step descriptors. `@civ7/direct-control` remains the
+low-level App UI tactical runtime evidence source.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/errors.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/contract.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/procedures/tactical-reads.ts`
+- `packages/civ7-control-orpc/src/modules/strategy/router.ts`
+- `packages/civ7-control-orpc/test/strategy-tactical-reads-procedure.test.ts`
+- `packages/cli/src/commands/game/play/destination-analysis.ts`
+- `packages/cli/src/commands/game/play/target-candidates.ts`
+- `packages/cli/test/commands/game.play.tactical-read.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-strategy-tactical-reads-orpc-slice.md`
+
+## Boundary
+
+- `strategy.targetCandidates` and `strategy.destinationAnalysis` are
+  strategy-domain read-only planning services, not a broad tactical catalog or
+  operation/send surface.
+- The service result projects bounded counts, locations, route hints,
+  relationship-unproven owner evidence, omitted-detail records, and semantic
+  next-step descriptors. Raw direct-control city/unit/plot samples remain out
+  of normal output.
+- Normal service and CLI JSON omit raw host, port, state, session, command,
+  rawCommand, direct-control runtime envelopes, approval/reason mechanics, and
+  transport details.
+- Normal output does not infer official diplomatic labels from owner mismatch,
+  proximity, contact, ranking, or action legality.
+- Controller bridge support, game-UI allowlisting, deployed Civ7 runtime proof,
+  action-send authority, and parent Task 5.x/6.x/7.x acceptance remain pending.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/strategy-tactical-reads-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/cli test -- game.play.tactical-read.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run check:cli`
+- `bun run test:cli:play`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Private procedure-schema export scan: target/destination input/result
+  schemas remain contract-local constants; no procedure schema bag is
+  exported.
+- Active approval/caller-permission scan: hits are limited to negative
+  boundary wording and the focused bad-input assertion.
+- Service-output CLI-string scan: strategy tactical-read procedure source and
+  focused procedure output contain no literal `game play ...` command strings.
+- Raw runtime output scan: normal service/CLI surfaces omit raw direct-control
+  runtime envelopes; endpoint/session/command fields stay context-owned.
+- `git diff --check`
+
+## Residual Risk
+
+This is local package and CLI proof only. It does not prove deployed Civ7
+runtime behavior, game-UI/controller bridge support, transport expansion,
+action-send authority, relationship labels beyond official evidence, a broad
+strategy catalog, approval/reason mechanics, or parent Task 5.x/6.x/7.x
+acceptance.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-traditions-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-traditions-orpc-slice.md
@@ -1,0 +1,75 @@
+# CLI Traditions oRPC Slice
+
+## Status
+
+Local control-oRPC, CLI, and OpenSpec closure proof collected.
+
+## Purpose
+
+Route `civ7 game play traditions` through the native in-process
+`progression.traditions.current` service procedure instead of letting the CLI
+own the traditions option projection or pass through direct-control CLI command
+strings.
+
+The control-oRPC service owns caller-facing traditions input, semantic
+tradition rows, action descriptors, validation-success projection,
+omitted-detail policy, and next-step descriptors. `@civ7/direct-control`
+remains the low-level App UI/Culture runtime evidence source.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/dependencies/direct-control.ts`
+- `packages/civ7-control-orpc/src/errors.ts`
+- `packages/civ7-control-orpc/src/game-ui.ts`
+- `packages/civ7-control-orpc/src/index.ts`
+- `packages/civ7-control-orpc/src/modules/progression/contract.ts`
+- `packages/civ7-control-orpc/src/modules/progression/procedures/traditions-current.ts`
+- `packages/civ7-control-orpc/src/modules/progression/router.ts`
+- `packages/civ7-control-orpc/test/progression-traditions-procedure.test.ts`
+- `packages/cli/src/commands/game/play/traditions.ts`
+- `packages/cli/test/commands/game.play.progression-read.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-traditions-orpc-slice.md`
+
+## Boundary
+
+- `progression.traditions.current` is a progression-domain decision read, not
+  a broad read-wrapper catalog or `operations` root.
+- The service result uses semantic action descriptors and next-step
+  descriptors. CLI command strings remain caller-local presentation mapping in
+  `packages/cli`.
+- Normal service and CLI JSON omit raw host, port, state, session, command,
+  rawCommand, direct-control runtime envelopes, direct-control
+  `recommendedCli`, direct-control `actionHints[].cli`, approval/reason
+  mechanics, and transport details.
+- Game-UI/controller traditions support remains unsupported in this slice.
+- Local tests do not prove deployed Civ7 runtime behavior.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/progression-traditions-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run --cwd packages/cli test -- game.play.progression-read.test.ts`
+- `bun run check:cli`
+- `bun run test:cli:play`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Private procedure-schema export scan: traditions input/result schemas remain
+  contract-local constants; no procedure schema bag is exported.
+- Active approval/caller-permission scan: hits are limited to negative
+  boundary wording and the focused bad-input assertion.
+- Service-output CLI-string scan: `progression.traditions.current` source and
+  focused procedure output contain no literal `game play ...` command strings.
+- Raw runtime output scan: normal service/CLI surfaces omit raw direct-control
+  runtime envelopes; endpoint/session/command fields stay context-owned.
+- `git diff --check`
+
+## Residual Risk
+
+This is local package and CLI proof only. It does not prove deployed Civ7
+runtime behavior, game-UI/controller bridge support, transport expansion,
+approval/reason mechanics, a broad read-wrapper catalog, or parent Task
+5.x/6.x/7.x acceptance.

--- a/packages/civ7-control-orpc/src/dependencies/direct-control.ts
+++ b/packages/civ7-control-orpc/src/dependencies/direct-control.ts
@@ -2,6 +2,7 @@ import {
   getCiv7PlayableStatus,
   getCiv7PlayNotificationView,
   getCiv7ProgressDashboard,
+  getCiv7TraditionsView,
   getCiv7BattlefieldScan,
   getCiv7DestinationAnalysis,
   getCiv7MapGrid,
@@ -87,6 +88,8 @@ import {
   type Civ7ProgressionPlayerChoiceResult,
   type Civ7ProgressDashboardInput,
   type Civ7ProgressDashboardResult,
+  type Civ7TraditionsViewInput,
+  type Civ7TraditionsViewResult,
   type Civ7TraditionChangeInput,
   type Civ7TraditionReviewInput,
   type Civ7TurnCompletionRequestResult,
@@ -121,6 +124,7 @@ export type Civ7ControlOrpcProgressionPlayerChoiceResult =
   Civ7ProgressionPlayerChoiceResult;
 export type Civ7ControlOrpcProgressDashboardResult =
   Civ7ProgressDashboardResult;
+export type Civ7ControlOrpcTraditionsViewResult = Civ7TraditionsViewResult;
 export type Civ7ControlOrpcTurnCompletionRequestResult =
   Civ7TurnCompletionRequestResult;
 type Civ7ControlOrpcPopulationPlacementRuntimeResult =
@@ -278,6 +282,10 @@ export type Civ7ControlOrpcDirectControlFacade = Readonly<{
     input?: Civ7ProgressDashboardInput,
     options?: Civ7DirectControlOptions,
   ): Promise<Civ7ControlOrpcProgressDashboardResult>;
+  getCiv7TraditionsView(
+    input?: Civ7TraditionsViewInput,
+    options?: Civ7DirectControlOptions,
+  ): Promise<Civ7ControlOrpcTraditionsViewResult>;
   getCiv7BattlefieldScan(
     input?: Civ7BattlefieldScanInput,
     options?: Civ7DirectControlOptions,
@@ -399,6 +407,8 @@ export const liveCiv7ControlOrpcDirectControlFacade:
     >,
   getCiv7ProgressDashboard: async (input, options) =>
     getCiv7ProgressDashboard(input, options),
+  getCiv7TraditionsView: async (input, options) =>
+    getCiv7TraditionsView(input, options),
   getCiv7BattlefieldScan: async (input, options) =>
     getCiv7BattlefieldScan(input, options) as Promise<
       Civ7ControlOrpcBattlefieldScanResult

--- a/packages/civ7-control-orpc/src/dependencies/direct-control.ts
+++ b/packages/civ7-control-orpc/src/dependencies/direct-control.ts
@@ -1,6 +1,7 @@
 import {
   getCiv7PlayableStatus,
   getCiv7PlayNotificationView,
+  getCiv7ProgressDashboard,
   getCiv7BattlefieldScan,
   getCiv7DestinationAnalysis,
   getCiv7MapGrid,
@@ -84,6 +85,8 @@ import {
   type Civ7ProgressionTargetInput,
   type Civ7ProgressionTargetResult,
   type Civ7ProgressionPlayerChoiceResult,
+  type Civ7ProgressDashboardInput,
+  type Civ7ProgressDashboardResult,
   type Civ7TraditionChangeInput,
   type Civ7TraditionReviewInput,
   type Civ7TurnCompletionRequestResult,
@@ -116,6 +119,8 @@ export type Civ7ControlOrpcProgressionTargetResult =
   Civ7ProgressionTargetResult;
 export type Civ7ControlOrpcProgressionPlayerChoiceResult =
   Civ7ProgressionPlayerChoiceResult;
+export type Civ7ControlOrpcProgressDashboardResult =
+  Civ7ProgressDashboardResult;
 export type Civ7ControlOrpcTurnCompletionRequestResult =
   Civ7TurnCompletionRequestResult;
 type Civ7ControlOrpcPopulationPlacementRuntimeResult =
@@ -269,6 +274,10 @@ export type Civ7ControlOrpcDirectControlFacade = Readonly<{
   getCiv7PlayNotificationView(
     options?: PlayNotificationViewOptions,
   ): Promise<Civ7ControlOrpcPlayNotificationViewResult>;
+  getCiv7ProgressDashboard(
+    input?: Civ7ProgressDashboardInput,
+    options?: Civ7DirectControlOptions,
+  ): Promise<Civ7ControlOrpcProgressDashboardResult>;
   getCiv7BattlefieldScan(
     input?: Civ7BattlefieldScanInput,
     options?: Civ7DirectControlOptions,
@@ -388,6 +397,8 @@ export const liveCiv7ControlOrpcDirectControlFacade:
     getCiv7PlayNotificationView(options) as Promise<
       Civ7ControlOrpcPlayNotificationViewResult
     >,
+  getCiv7ProgressDashboard: async (input, options) =>
+    getCiv7ProgressDashboard(input, options),
   getCiv7BattlefieldScan: async (input, options) =>
     getCiv7BattlefieldScan(input, options) as Promise<
       Civ7ControlOrpcBattlefieldScanResult

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -458,6 +458,30 @@ export class Civ7ProgressionDashboardUnavailableError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7ProgressionTraditionsUnavailableErrorDataSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("progression.traditions.current"),
+    source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties,
+  },
+  { additionalProperties: false },
+);
+export type Civ7ProgressionTraditionsUnavailableErrorData = Static<
+  typeof Civ7ProgressionTraditionsUnavailableErrorDataSchema
+>;
+
+export class Civ7ProgressionTraditionsUnavailableError extends ORPCTaggedError(
+  "Civ7ProgressionTraditionsUnavailableError",
+  {
+    code: "PROGRESSION_TRADITIONS_UNAVAILABLE",
+    message: "Direct-control progression traditions read failed.",
+    schema: toStandardSchema(
+      Civ7ProgressionTraditionsUnavailableErrorDataSchema,
+    ),
+    status: 503,
+  },
+) {}
+
 export const Civ7ProgressionPlayerChoiceUnavailableErrorDataSchema =
   Type.Object(
     {
@@ -721,6 +745,7 @@ export const civ7ControlOrpcErrorMap = {
   POPULATION_PLACEMENT_UNAVAILABLE: Civ7PopulationPlacementUnavailableError,
   PROGRESSION_CHOICE_UNAVAILABLE: Civ7ProgressionChoiceUnavailableError,
   PROGRESSION_DASHBOARD_UNAVAILABLE: Civ7ProgressionDashboardUnavailableError,
+  PROGRESSION_TRADITIONS_UNAVAILABLE: Civ7ProgressionTraditionsUnavailableError,
   PROGRESSION_PLAYER_CHOICE_UNAVAILABLE: Civ7ProgressionPlayerChoiceUnavailableError,
   PROGRESSION_TARGET_UNAVAILABLE: Civ7ProgressionTargetUnavailableError,
   PRODUCTION_CHOICE_UNAVAILABLE: Civ7ProductionChoiceUnavailableError,

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -103,6 +103,7 @@ export class Civ7StrategyFrontSummaryUnavailableError extends ORPCTaggedError(
 export const Civ7StrategyTacticalReadUnavailableErrorDataSchema = Type.Object(
   {
     procedureKey: Type.Union([
+      Type.Literal("strategy.battlefieldScan"),
       Type.Literal("strategy.targetCandidates"),
       Type.Literal("strategy.destinationAnalysis"),
     ]),

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -100,6 +100,33 @@ export class Civ7StrategyFrontSummaryUnavailableError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7StrategyTacticalReadUnavailableErrorDataSchema = Type.Object(
+  {
+    procedureKey: Type.Union([
+      Type.Literal("strategy.targetCandidates"),
+      Type.Literal("strategy.destinationAnalysis"),
+    ]),
+    source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties,
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyTacticalReadUnavailableErrorData = Static<
+  typeof Civ7StrategyTacticalReadUnavailableErrorDataSchema
+>;
+
+export class Civ7StrategyTacticalReadUnavailableError extends ORPCTaggedError(
+  "Civ7StrategyTacticalReadUnavailableError",
+  {
+    code: "STRATEGY_TACTICAL_READ_UNAVAILABLE",
+    message: "Strategy tactical read failed.",
+    schema: toStandardSchema(
+      Civ7StrategyTacticalReadUnavailableErrorDataSchema,
+    ),
+    status: 503,
+  },
+) {}
+
 export const Civ7StrategyCivilianRouteTriageUnavailableErrorDataSchema =
   Type.Object(
     {
@@ -755,6 +782,7 @@ export const civ7ControlOrpcErrorMap = {
   STRATEGY_FORMATION_SNAPSHOT_UNAVAILABLE:
     Civ7StrategyFormationSnapshotUnavailableError,
   STRATEGY_FRONT_SUMMARY_UNAVAILABLE: Civ7StrategyFrontSummaryUnavailableError,
+  STRATEGY_TACTICAL_READ_UNAVAILABLE: Civ7StrategyTacticalReadUnavailableError,
   TOWN_FOCUS_UNAVAILABLE: Civ7TownFocusUnavailableError,
   TURN_COMPLETION_UNAVAILABLE: Civ7TurnCompletionUnavailableError,
   UNIT_REQUEST_UNAVAILABLE: Civ7UnitRequestUnavailableError,

--- a/packages/civ7-control-orpc/src/errors.ts
+++ b/packages/civ7-control-orpc/src/errors.ts
@@ -434,6 +434,30 @@ export class Civ7ProgressionChoiceUnavailableError extends ORPCTaggedError(
   },
 ) {}
 
+export const Civ7ProgressionDashboardUnavailableErrorDataSchema = Type.Object(
+  {
+    procedureKey: Type.Literal("progression.dashboard.current"),
+    source: Type.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties,
+  },
+  { additionalProperties: false },
+);
+export type Civ7ProgressionDashboardUnavailableErrorData = Static<
+  typeof Civ7ProgressionDashboardUnavailableErrorDataSchema
+>;
+
+export class Civ7ProgressionDashboardUnavailableError extends ORPCTaggedError(
+  "Civ7ProgressionDashboardUnavailableError",
+  {
+    code: "PROGRESSION_DASHBOARD_UNAVAILABLE",
+    message: "Direct-control progression dashboard read failed.",
+    schema: toStandardSchema(
+      Civ7ProgressionDashboardUnavailableErrorDataSchema,
+    ),
+    status: 503,
+  },
+) {}
+
 export const Civ7ProgressionPlayerChoiceUnavailableErrorDataSchema =
   Type.Object(
     {
@@ -696,6 +720,7 @@ export const civ7ControlOrpcErrorMap = {
   NOTIFICATION_QUEUE_UNAVAILABLE: Civ7NotificationQueueUnavailableError,
   POPULATION_PLACEMENT_UNAVAILABLE: Civ7PopulationPlacementUnavailableError,
   PROGRESSION_CHOICE_UNAVAILABLE: Civ7ProgressionChoiceUnavailableError,
+  PROGRESSION_DASHBOARD_UNAVAILABLE: Civ7ProgressionDashboardUnavailableError,
   PROGRESSION_PLAYER_CHOICE_UNAVAILABLE: Civ7ProgressionPlayerChoiceUnavailableError,
   PROGRESSION_TARGET_UNAVAILABLE: Civ7ProgressionTargetUnavailableError,
   PRODUCTION_CHOICE_UNAVAILABLE: Civ7ProductionChoiceUnavailableError,

--- a/packages/civ7-control-orpc/src/game-ui.ts
+++ b/packages/civ7-control-orpc/src/game-ui.ts
@@ -380,6 +380,9 @@ function createCiv7GameUiDirectControlFacade(
     getCiv7ProgressDashboard: async () => {
       throw new Error("game-ui progress dashboard is not supported");
     },
+    getCiv7TraditionsView: async () => {
+      throw new Error("game-ui traditions view is not supported");
+    },
     getCiv7BattlefieldScan: async (input) =>
       await getCiv7GameUiBattlefieldScan(input, target),
     getCiv7DestinationAnalysis: async (input) =>

--- a/packages/civ7-control-orpc/src/game-ui.ts
+++ b/packages/civ7-control-orpc/src/game-ui.ts
@@ -377,6 +377,9 @@ function createCiv7GameUiDirectControlFacade(
       await getCiv7GameUiPlayNotificationView({
         maxNotifications: options?.maxNotifications,
       }, target),
+    getCiv7ProgressDashboard: async () => {
+      throw new Error("game-ui progress dashboard is not supported");
+    },
     getCiv7BattlefieldScan: async (input) =>
       await getCiv7GameUiBattlefieldScan(input, target),
     getCiv7DestinationAnalysis: async (input) =>

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -176,6 +176,8 @@ export {
   Civ7PopulationPlacementUnavailableErrorDataSchema,
   Civ7ProgressionChoiceUnavailableError,
   Civ7ProgressionChoiceUnavailableErrorDataSchema,
+  Civ7ProgressionDashboardUnavailableError,
+  Civ7ProgressionDashboardUnavailableErrorDataSchema,
   Civ7ProgressionPlayerChoiceUnavailableError,
   Civ7ProgressionPlayerChoiceUnavailableErrorDataSchema,
   Civ7ProgressionTargetUnavailableError,
@@ -220,6 +222,7 @@ export {
   type Civ7NotificationQueueUnavailableErrorData,
   type Civ7PopulationPlacementUnavailableErrorData,
   type Civ7ProgressionChoiceUnavailableErrorData,
+  type Civ7ProgressionDashboardUnavailableErrorData,
   type Civ7ProgressionPlayerChoiceUnavailableErrorData,
   type Civ7ProgressionTargetUnavailableErrorData,
   type Civ7ProductionChoiceUnavailableErrorData,
@@ -364,6 +367,8 @@ export type {
   Civ7ProgressionCultureChoiceResult,
   Civ7ProgressionCultureTargetContract as Civ7ProgressionCultureTargetContractType,
   Civ7ProgressionCultureTargetResult,
+  Civ7ProgressionDashboardInput,
+  Civ7ProgressionDashboardResult,
   Civ7ProgressionTechnologyChoiceContract as Civ7ProgressionTechnologyChoiceContractType,
   Civ7ProgressionTechnologyChoiceResult,
   Civ7ProgressionTechnologyTargetContract as Civ7ProgressionTechnologyTargetContractType,
@@ -371,6 +376,7 @@ export type {
   Civ7ProgressionTargetInput,
 } from "./modules/progression/contract";
 export { progressionRouter } from "./modules/progression/router";
+export { progressionDashboardCurrentProcedure } from "./modules/progression/procedures/dashboard-current";
 export {
   progressionCultureChoiceRequestProcedure,
   progressionTechnologyChoiceRequestProcedure,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -432,6 +432,7 @@ export type {
 export { readinessRouter } from "./modules/readiness/router";
 export { readinessCurrentProcedure } from "./modules/readiness/procedures/current";
 export {
+  Civ7StrategyBattlefieldScanContract,
   Civ7StrategyCivilianRouteTriageContract,
   Civ7StrategyContract,
   Civ7StrategyDestinationAnalysisContract,
@@ -440,6 +441,9 @@ export {
   Civ7StrategyTargetCandidatesContract,
 } from "./modules/strategy/contract";
 export type {
+  Civ7StrategyBattlefieldScanContract as Civ7StrategyBattlefieldScanContractType,
+  Civ7StrategyBattlefieldScanInput,
+  Civ7StrategyBattlefieldScanResult,
   Civ7StrategyCivilianRouteTriageContract as Civ7StrategyCivilianRouteTriageContractType,
   Civ7StrategyCivilianRouteTriageInput,
   Civ7StrategyCivilianRouteTriageResult,
@@ -462,6 +466,7 @@ export { strategyCivilianRouteTriageProcedure } from "./modules/strategy/procedu
 export { strategyFormationSnapshotProcedure } from "./modules/strategy/procedures/formation-snapshot";
 export { strategyFrontSummaryProcedure } from "./modules/strategy/procedures/front-summary";
 export {
+  strategyBattlefieldScanProcedure,
   strategyDestinationAnalysisProcedure,
   strategyTargetCandidatesProcedure,
 } from "./modules/strategy/procedures/tactical-reads";

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -182,6 +182,8 @@ export {
   Civ7ProgressionPlayerChoiceUnavailableErrorDataSchema,
   Civ7ProgressionTargetUnavailableError,
   Civ7ProgressionTargetUnavailableErrorDataSchema,
+  Civ7ProgressionTraditionsUnavailableError,
+  Civ7ProgressionTraditionsUnavailableErrorDataSchema,
   Civ7ProductionChoiceUnavailableError,
   Civ7ProductionChoiceUnavailableErrorDataSchema,
   Civ7ReadinessCurrentUnavailableError,
@@ -225,6 +227,7 @@ export {
   type Civ7ProgressionDashboardUnavailableErrorData,
   type Civ7ProgressionPlayerChoiceUnavailableErrorData,
   type Civ7ProgressionTargetUnavailableErrorData,
+  type Civ7ProgressionTraditionsUnavailableErrorData,
   type Civ7ProductionChoiceUnavailableErrorData,
   type Civ7ReadinessCurrentUnavailableErrorData,
   type Civ7StrategyCivilianRouteTriageUnavailableErrorData,
@@ -374,9 +377,12 @@ export type {
   Civ7ProgressionTechnologyTargetContract as Civ7ProgressionTechnologyTargetContractType,
   Civ7ProgressionTechnologyTargetResult,
   Civ7ProgressionTargetInput,
+  Civ7ProgressionTraditionsInput,
+  Civ7ProgressionTraditionsResult,
 } from "./modules/progression/contract";
 export { progressionRouter } from "./modules/progression/router";
 export { progressionDashboardCurrentProcedure } from "./modules/progression/procedures/dashboard-current";
+export { progressionTraditionsCurrentProcedure } from "./modules/progression/procedures/traditions-current";
 export {
   progressionCultureChoiceRequestProcedure,
   progressionTechnologyChoiceRequestProcedure,

--- a/packages/civ7-control-orpc/src/index.ts
+++ b/packages/civ7-control-orpc/src/index.ts
@@ -190,6 +190,8 @@ export {
   Civ7ReadinessCurrentUnavailableErrorDataSchema,
   Civ7StrategyCivilianRouteTriageUnavailableError,
   Civ7StrategyCivilianRouteTriageUnavailableErrorDataSchema,
+  Civ7StrategyTacticalReadUnavailableError,
+  Civ7StrategyTacticalReadUnavailableErrorDataSchema,
   Civ7StrategyFormationSnapshotUnavailableError,
   Civ7StrategyFormationSnapshotUnavailableErrorDataSchema,
   Civ7StrategyFrontSummaryUnavailableError,
@@ -231,6 +233,7 @@ export {
   type Civ7ProductionChoiceUnavailableErrorData,
   type Civ7ReadinessCurrentUnavailableErrorData,
   type Civ7StrategyCivilianRouteTriageUnavailableErrorData,
+  type Civ7StrategyTacticalReadUnavailableErrorData,
   type Civ7StrategyFormationSnapshotUnavailableErrorData,
   type Civ7StrategyFrontSummaryUnavailableErrorData,
   type Civ7TownFocusUnavailableErrorData,
@@ -431,25 +434,37 @@ export { readinessCurrentProcedure } from "./modules/readiness/procedures/curren
 export {
   Civ7StrategyCivilianRouteTriageContract,
   Civ7StrategyContract,
+  Civ7StrategyDestinationAnalysisContract,
   Civ7StrategyFormationSnapshotContract,
   Civ7StrategyFrontSummaryContract,
+  Civ7StrategyTargetCandidatesContract,
 } from "./modules/strategy/contract";
 export type {
   Civ7StrategyCivilianRouteTriageContract as Civ7StrategyCivilianRouteTriageContractType,
   Civ7StrategyCivilianRouteTriageInput,
   Civ7StrategyCivilianRouteTriageResult,
   Civ7StrategyContract as Civ7StrategyContractType,
+  Civ7StrategyDestinationAnalysisContract as Civ7StrategyDestinationAnalysisContractType,
+  Civ7StrategyDestinationAnalysisInput,
+  Civ7StrategyDestinationAnalysisResult,
   Civ7StrategyFormationSnapshotContract as Civ7StrategyFormationSnapshotContractType,
   Civ7StrategyFormationSnapshotInput,
   Civ7StrategyFormationSnapshotResult,
   Civ7StrategyFrontSummaryContract as Civ7StrategyFrontSummaryContractType,
   Civ7StrategyFrontSummaryInput,
   Civ7StrategyFrontSummaryResult,
+  Civ7StrategyTargetCandidatesContract as Civ7StrategyTargetCandidatesContractType,
+  Civ7StrategyTargetCandidatesInput,
+  Civ7StrategyTargetCandidatesResult,
 } from "./modules/strategy/contract";
 export { strategyRouter } from "./modules/strategy/router";
 export { strategyCivilianRouteTriageProcedure } from "./modules/strategy/procedures/civilian-route-triage";
 export { strategyFormationSnapshotProcedure } from "./modules/strategy/procedures/formation-snapshot";
 export { strategyFrontSummaryProcedure } from "./modules/strategy/procedures/front-summary";
+export {
+  strategyDestinationAnalysisProcedure,
+  strategyTargetCandidatesProcedure,
+} from "./modules/strategy/procedures/tactical-reads";
 export {
   Civ7TurnCompletionContract,
   Civ7TurnContract,

--- a/packages/civ7-control-orpc/src/modules/progression/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/contract.ts
@@ -58,6 +58,16 @@ export type Civ7ProgressionDashboardInput = Static<
   typeof Civ7ProgressionDashboardInputSchema
 >;
 
+const Civ7ProgressionTraditionsInputSchema = Type.Object(
+  {
+    playerId: Type.Optional(Type.Integer({ minimum: 0, maximum: 1024 })),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ProgressionTraditionsInput = Static<
+  typeof Civ7ProgressionTraditionsInputSchema
+>;
+
 const Civ7ProgressionTraditionChangeInputSchema = Type.Object(
   {
     traditionType: Type.Integer(),
@@ -557,6 +567,142 @@ export type Civ7ProgressionDashboardResult = Static<
   typeof Civ7ProgressionDashboardResultSchema
 >;
 
+const Civ7ProgressionTraditionActionDescriptorSchema = Type.Object(
+  {
+    kind: Type.Union([Type.Literal("activate"), Type.Literal("deactivate")]),
+    action: Type.Union([Type.Number(), Type.Null()]),
+    validationSuccess: Type.Union([Type.Boolean(), Type.Null()]),
+    parameters: Type.Object(
+      {
+        traditionType: Type.Number(),
+        action: Type.Union([Type.Number(), Type.Null()]),
+      },
+      { additionalProperties: false },
+    ),
+    nextSteps: Type.Array(Type.Object(
+      {
+        kind: Type.Union([
+          Type.Literal("validate-tradition-change"),
+          Type.Literal("request-tradition-change"),
+        ]),
+        source: Type.Literal("progression.traditions.current"),
+        label: Type.String(),
+        parameters: Type.Object(
+          {
+            traditionType: Type.Number(),
+            action: Type.Union([Type.Number(), Type.Null()]),
+          },
+          { additionalProperties: false },
+        ),
+      },
+      { additionalProperties: false },
+    )),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7ProgressionTraditionRowSchema = Type.Object(
+  {
+    id: Type.Number(),
+    type: Type.Union([Type.String(), Type.Null()]),
+    name: Type.Union([Type.String(), Type.Null()]),
+    description: Type.Union([Type.String(), Type.Null()]),
+    ageType: Type.Union([Type.String(), Type.Null()]),
+    cultureSlotType: Type.Union([Type.String(), Type.Null()]),
+    traitType: Type.Union([Type.String(), Type.Null()]),
+    isCrisis: Type.Boolean(),
+    active: Type.Boolean(),
+    unlocked: Type.Boolean(),
+    recentUnlock: Type.Boolean(),
+    actions: Type.Array(Civ7ProgressionTraditionActionDescriptorSchema),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7ProgressionTraditionsNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("inspect-tradition-change"),
+      Type.Literal("free-policy-slot"),
+      Type.Literal("observe"),
+    ]),
+    source: Type.Literal("progression.traditions.current"),
+    label: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7ProgressionTraditionsResultSchema = Type.Object(
+  {
+    playerId: Type.Integer({ minimum: 0 }),
+    sourceStatus: Type.Object(
+      {
+        traditions: Type.Literal("read"),
+      },
+      { additionalProperties: false },
+    ),
+    hiddenInfoPolicy: Type.Literal("player-culture-runtime"),
+    summary: Type.Object(
+      {
+        activeCount: Type.Integer({ minimum: 0 }),
+        availableCount: Type.Integer({ minimum: 0 }),
+        recentUnlockCount: Type.Integer({ minimum: 0 }),
+        openSlotCount: Type.Integer({ minimum: 0 }),
+        enabledAvailableCount: Type.Integer({ minimum: 0 }),
+        disabledAvailableCount: Type.Integer({ minimum: 0 }),
+        nextStepCount: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    ),
+    turn: Civ7ProgressionDashboardProbeSchema,
+    turnDate: Civ7ProgressionDashboardProbeSchema,
+    governmentType: Civ7ProgressionDashboardProbeSchema,
+    government: Type.Object(
+      {
+        type: Type.Union([Type.String(), Type.Null()]),
+        name: Type.Union([Type.String(), Type.Null()]),
+      },
+      { additionalProperties: false },
+    ),
+    slots: Type.Object(
+      {
+        total: Civ7ProgressionDashboardProbeSchema,
+        normal: Civ7ProgressionDashboardProbeSchema,
+        crisis: Civ7ProgressionDashboardProbeSchema,
+        active: Type.Integer({ minimum: 0 }),
+        unlocked: Type.Integer({ minimum: 0 }),
+        available: Type.Integer({ minimum: 0 }),
+        open: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    ),
+    actions: Type.Object(
+      {
+        activate: Type.Union([Type.Number(), Type.Null()]),
+        deactivate: Type.Union([Type.Number(), Type.Null()]),
+      },
+      { additionalProperties: false },
+    ),
+    active: Type.Array(Civ7ProgressionTraditionRowSchema),
+    available: Type.Array(Civ7ProgressionTraditionRowSchema),
+    recentUnlocks: Type.Array(Civ7ProgressionTraditionRowSchema),
+    traditions: Type.Array(Civ7ProgressionTraditionRowSchema),
+    omitted: Type.Array(Type.Object(
+      {
+        path: Type.String(),
+        reason: Type.String(),
+      },
+      { additionalProperties: false },
+    )),
+    notes: Type.Array(Type.String()),
+    nextSteps: Type.Array(Civ7ProgressionTraditionsNextStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ProgressionTraditionsResult = Static<
+  typeof Civ7ProgressionTraditionsResultSchema
+>;
+
 const Civ7ProgressionChoiceInputStandardSchema =
   toStandardSchema(Civ7ProgressionChoiceInputSchema);
 const Civ7ProgressionTargetInputStandardSchema =
@@ -567,6 +713,8 @@ const Civ7ProgressionPlayerReviewInputStandardSchema =
   toStandardSchema(Civ7ProgressionPlayerReviewInputSchema);
 const Civ7ProgressionDashboardInputStandardSchema =
   toStandardSchema(Civ7ProgressionDashboardInputSchema);
+const Civ7ProgressionTraditionsInputStandardSchema =
+  toStandardSchema(Civ7ProgressionTraditionsInputSchema);
 const Civ7ProgressionTraditionChangeInputStandardSchema =
   toStandardSchema(Civ7ProgressionTraditionChangeInputSchema);
 const Civ7ProgressionTechnologyChoiceResultStandardSchema =
@@ -587,6 +735,8 @@ const Civ7ProgressionTraditionReviewResultStandardSchema =
   toStandardSchema(Civ7ProgressionTraditionReviewResultSchema);
 const Civ7ProgressionDashboardResultStandardSchema =
   toStandardSchema(Civ7ProgressionDashboardResultSchema);
+const Civ7ProgressionTraditionsResultStandardSchema =
+  toStandardSchema(Civ7ProgressionTraditionsResultSchema);
 
 export type Civ7ProgressionTechnologyChoiceContract = ContractProcedure<
   typeof Civ7ProgressionChoiceInputStandardSchema,
@@ -750,9 +900,30 @@ const Civ7ProgressionDashboardContract:
       risk: "read-only",
     });
 
+type Civ7ProgressionTraditionsContract = ContractProcedure<
+  typeof Civ7ProgressionTraditionsInputStandardSchema,
+  typeof Civ7ProgressionTraditionsResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+const Civ7ProgressionTraditionsContract:
+  Civ7ProgressionTraditionsContract = civ7ControlOrpcContractBase
+    .input(Civ7ProgressionTraditionsInputStandardSchema)
+    .output(Civ7ProgressionTraditionsResultStandardSchema)
+    .meta({
+      family: "progression",
+      procedureKey: "progression.traditions.current",
+      proofBoundary: "local-package-test",
+      risk: "read-only",
+    });
+
 export type Civ7ProgressionContract = Readonly<{
   dashboard: Readonly<{
     current: Civ7ProgressionDashboardContract;
+  }>;
+  traditions: Readonly<{
+    current: Civ7ProgressionTraditionsContract;
   }>;
   technology: Readonly<{
     choice: Readonly<{
@@ -791,6 +962,9 @@ export type Civ7ProgressionContract = Readonly<{
 export const Civ7ProgressionContract: Civ7ProgressionContract = {
   dashboard: {
     current: Civ7ProgressionDashboardContract,
+  },
+  traditions: {
+    current: Civ7ProgressionTraditionsContract,
   },
   technology: {
     choice: {

--- a/packages/civ7-control-orpc/src/modules/progression/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/contract.ts
@@ -48,6 +48,16 @@ export type Civ7ProgressionPlayerReviewInput = Static<
   typeof Civ7ProgressionPlayerReviewInputSchema
 >;
 
+const Civ7ProgressionDashboardInputSchema = Type.Object(
+  {
+    playerId: Type.Optional(Type.Integer({ minimum: 0, maximum: 1024 })),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ProgressionDashboardInput = Static<
+  typeof Civ7ProgressionDashboardInputSchema
+>;
+
 const Civ7ProgressionTraditionChangeInputSchema = Type.Object(
   {
     traditionType: Type.Integer(),
@@ -419,6 +429,134 @@ export type Civ7ProgressionTraditionReviewResult = Static<
   typeof Civ7ProgressionTraditionReviewResultSchema
 >;
 
+const Civ7ProgressionDashboardProbeSchema = Type.Union([
+  Type.Object(
+    {
+      ok: Type.Literal(true),
+      value: Type.Unknown(),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      ok: Type.Literal(false),
+      error: Type.String(),
+    },
+    { additionalProperties: false },
+  ),
+]);
+
+const Civ7ProgressionDashboardLegacyPathSchema = Type.Object(
+  {
+    legacyPathType: Type.Union([Type.String(), Type.Null()]),
+    classType: Type.Union([Type.String(), Type.Null()]),
+    name: Type.Union([Type.String(), Type.Null()]),
+    score: Type.Union([Type.Number(), Type.Null()]),
+    finalRequiredPathPoints: Type.Union([Type.Number(), Type.Null()]),
+    progressPercent: Type.Union([Type.Number(), Type.Null()]),
+    nextMilestone: Type.Union([Type.String(), Type.Null()]),
+    enabledForPlayer: Type.Union([Type.Boolean(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7ProgressionDashboardNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("read-attention-priorities"),
+      Type.Literal("inspect-progression-choice"),
+      Type.Literal("inspect-victory-progress"),
+      Type.Literal("observe"),
+    ]),
+    source: Type.Literal("progression.dashboard.current"),
+    label: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7ProgressionDashboardResultSchema = Type.Object(
+  {
+    playerId: Type.Integer({ minimum: 0 }),
+    localPlayerId: Type.Integer({ minimum: 0 }),
+    sourceStatus: Type.Object(
+      {
+        progressDashboard: Type.Literal("read"),
+      },
+      { additionalProperties: false },
+    ),
+    hiddenInfoPolicy: Type.Literal("local-player-runtime-progress"),
+    summary: Type.Object(
+      {
+        headline: Type.String(),
+        legacyPathCount: Type.Integer({ minimum: 0 }),
+        victoryClassCount: Type.Integer({ minimum: 0 }),
+        triumphCount: Type.Integer({ minimum: 0 }),
+        nextStepCount: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    ),
+    turn: Civ7ProgressionDashboardProbeSchema,
+    turnDate: Civ7ProgressionDashboardProbeSchema,
+    age: Type.Object(
+      {
+        ageType: Type.Union([Type.String(), Type.Null()]),
+        name: Type.Union([Type.String(), Type.Null()]),
+        chronologyIndex: Type.Unknown(),
+        currentAgeProgressionPoints: Civ7ProgressionDashboardProbeSchema,
+        maxAgeProgressionPoints: Civ7ProgressionDashboardProbeSchema,
+        ageProgressPercent: Type.Union([Type.Number(), Type.Null()]),
+        isFinalAge: Civ7ProgressionDashboardProbeSchema,
+        isAgeOver: Civ7ProgressionDashboardProbeSchema,
+      },
+      { additionalProperties: false },
+    ),
+    player: Type.Object(
+      {
+        team: Type.Unknown(),
+        historicalLegacyPointCountForTeam: Civ7ProgressionDashboardProbeSchema,
+      },
+      { additionalProperties: false },
+    ),
+    legacyPaths: Type.Array(Civ7ProgressionDashboardLegacyPathSchema),
+    victories: Type.Object(
+      {
+        rowCount: Type.Integer({ minimum: 0 }),
+        classes: Type.Array(Type.String()),
+      },
+      { additionalProperties: false },
+    ),
+    triumphs: Type.Object(
+      {
+        count: Type.Integer({ minimum: 0 }),
+        source: Type.Literal("runtime-gameinfo"),
+        rows: Type.Array(Type.Unknown()),
+      },
+      { additionalProperties: false },
+    ),
+    proof: Type.Object(
+      {
+        victoryManagerGlobal: Civ7ProgressionDashboardProbeSchema,
+        sources: Type.Array(Type.String()),
+      },
+      { additionalProperties: false },
+    ),
+    warnings: Type.Array(Type.String()),
+    omitted: Type.Array(Type.Object(
+      {
+        path: Type.String(),
+        reason: Type.String(),
+      },
+      { additionalProperties: false },
+    )),
+    notes: Type.Array(Type.String()),
+    nextSteps: Type.Array(Civ7ProgressionDashboardNextStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ProgressionDashboardResult = Static<
+  typeof Civ7ProgressionDashboardResultSchema
+>;
+
 const Civ7ProgressionChoiceInputStandardSchema =
   toStandardSchema(Civ7ProgressionChoiceInputSchema);
 const Civ7ProgressionTargetInputStandardSchema =
@@ -427,6 +565,8 @@ const Civ7ProgressionAttributePurchaseInputStandardSchema =
   toStandardSchema(Civ7ProgressionAttributePurchaseInputSchema);
 const Civ7ProgressionPlayerReviewInputStandardSchema =
   toStandardSchema(Civ7ProgressionPlayerReviewInputSchema);
+const Civ7ProgressionDashboardInputStandardSchema =
+  toStandardSchema(Civ7ProgressionDashboardInputSchema);
 const Civ7ProgressionTraditionChangeInputStandardSchema =
   toStandardSchema(Civ7ProgressionTraditionChangeInputSchema);
 const Civ7ProgressionTechnologyChoiceResultStandardSchema =
@@ -445,6 +585,8 @@ const Civ7ProgressionTraditionChangeResultStandardSchema =
   toStandardSchema(Civ7ProgressionTraditionChangeResultSchema);
 const Civ7ProgressionTraditionReviewResultStandardSchema =
   toStandardSchema(Civ7ProgressionTraditionReviewResultSchema);
+const Civ7ProgressionDashboardResultStandardSchema =
+  toStandardSchema(Civ7ProgressionDashboardResultSchema);
 
 export type Civ7ProgressionTechnologyChoiceContract = ContractProcedure<
   typeof Civ7ProgressionChoiceInputStandardSchema,
@@ -590,7 +732,28 @@ const Civ7ProgressionTraditionReviewContract:
       risk: "mutation",
     });
 
+type Civ7ProgressionDashboardContract = ContractProcedure<
+  typeof Civ7ProgressionDashboardInputStandardSchema,
+  typeof Civ7ProgressionDashboardResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+const Civ7ProgressionDashboardContract:
+  Civ7ProgressionDashboardContract = civ7ControlOrpcContractBase
+    .input(Civ7ProgressionDashboardInputStandardSchema)
+    .output(Civ7ProgressionDashboardResultStandardSchema)
+    .meta({
+      family: "progression",
+      procedureKey: "progression.dashboard.current",
+      proofBoundary: "local-package-test",
+      risk: "read-only",
+    });
+
 export type Civ7ProgressionContract = Readonly<{
+  dashboard: Readonly<{
+    current: Civ7ProgressionDashboardContract;
+  }>;
   technology: Readonly<{
     choice: Readonly<{
       request: Civ7ProgressionTechnologyChoiceContract;
@@ -626,6 +789,9 @@ export type Civ7ProgressionContract = Readonly<{
 }>;
 
 export const Civ7ProgressionContract: Civ7ProgressionContract = {
+  dashboard: {
+    current: Civ7ProgressionDashboardContract,
+  },
   technology: {
     choice: {
       request: Civ7ProgressionTechnologyChoiceContract,

--- a/packages/civ7-control-orpc/src/modules/progression/procedures/dashboard-current.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/procedures/dashboard-current.ts
@@ -1,0 +1,225 @@
+import { Effect } from "effect";
+
+import type { Civ7ControlOrpcContext } from "../../../context";
+import type { Civ7ControlOrpcProgressDashboardResult } from "../../../dependencies/direct-control";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type {
+  Civ7ProgressionDashboardInput,
+  Civ7ProgressionDashboardResult,
+} from "../contract";
+
+type RuntimeProbe<T = unknown> =
+  | Readonly<{ ok: true; value: T }>
+  | Readonly<{ ok: false; error: string }>;
+
+export const progressionDashboardCurrentProcedure =
+  civ7ControlOrpcImplementer.progression.dashboard.current.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const dashboard = await context.directControl.getCiv7ProgressDashboard(
+          input,
+          context.endpointDefaults,
+        );
+        return progressionDashboardResult(input, dashboard);
+      },
+      catch: () =>
+        errors.PROGRESSION_DASHBOARD_UNAVAILABLE({
+          data: {
+            procedureKey: "progression.dashboard.current",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+function progressionDashboardResult(
+  _input: Civ7ProgressionDashboardInput,
+  dashboard: Civ7ControlOrpcProgressDashboardResult,
+): Civ7ProgressionDashboardResult {
+  const legacyPaths = dashboard.legacyPaths.map(compactLegacyPath);
+  const victoryClasses = uniqueStrings(
+    dashboard.victories.rows.map((row) => stringField(row, "victoryClassType")),
+  );
+  const warnings = progressionDashboardWarnings(dashboard);
+  const nextSteps = progressionDashboardNextSteps(dashboard);
+
+  return {
+    playerId: dashboard.playerId,
+    localPlayerId: dashboard.localPlayerId,
+    sourceStatus: {
+      progressDashboard: "read",
+    },
+    hiddenInfoPolicy: dashboard.hiddenInfoPolicy,
+    summary: {
+      headline: progressionDashboardHeadline(dashboard, legacyPaths),
+      legacyPathCount: legacyPaths.length,
+      victoryClassCount: victoryClasses.length,
+      triumphCount: dashboard.triumphs.count,
+      nextStepCount: nextSteps.length,
+    },
+    turn: dashboard.turn,
+    turnDate: dashboard.turnDate,
+    age: {
+      ageType: dashboard.age.ageType,
+      name: dashboard.age.name,
+      chronologyIndex: dashboard.age.chronologyIndex,
+      currentAgeProgressionPoints: dashboard.age.currentAgeProgressionPoints,
+      maxAgeProgressionPoints: dashboard.age.maxAgeProgressionPoints,
+      ageProgressPercent: ratioPercent(
+        probeValue(dashboard.age.currentAgeProgressionPoints),
+        probeValue(dashboard.age.maxAgeProgressionPoints),
+      ),
+      isFinalAge: dashboard.age.isFinalAge,
+      isAgeOver: dashboard.age.isAgeOver,
+    },
+    player: {
+      team: dashboard.player.team,
+      historicalLegacyPointCountForTeam:
+        dashboard.player.historicalLegacyPointCountForTeam,
+    },
+    legacyPaths,
+    victories: {
+      rowCount: dashboard.victories.rows.length,
+      classes: victoryClasses,
+    },
+    triumphs: {
+      count: dashboard.triumphs.count,
+      source: dashboard.triumphs.source,
+      rows: dashboard.triumphs.rows.slice(0, 8),
+    },
+    proof: {
+      victoryManagerGlobal: dashboard.proof.victoryManagerGlobal,
+      sources: [...dashboard.proof.sources],
+    },
+    warnings,
+    omitted: [
+      {
+        path: "dashboard.legacyPaths[].milestones",
+        reason: "Milestone probe details stay in the direct-control runtime evidence surface; this service result keeps a summary-first progression view.",
+      },
+      {
+        path: "dashboard.victories.rows",
+        reason: "Victory rows are summarized by class for the caller-facing progression view.",
+      },
+      {
+        path: "dashboard.triumphs.rows",
+        reason: "The service result includes only the first 8 runtime triumph rows.",
+      },
+    ],
+    notes: [...dashboard.notes],
+    nextSteps,
+  };
+}
+
+function compactLegacyPath(
+  path: Civ7ControlOrpcProgressDashboardResult["legacyPaths"][number],
+): Civ7ProgressionDashboardResult["legacyPaths"][number] {
+  const score = probeValue(path.score);
+  const nextMilestone = path.nextMilestone && typeof path.nextMilestone === "object"
+    ? path.nextMilestone as Record<string, unknown>
+    : null;
+
+  return {
+    legacyPathType: path.legacyPathType,
+    classType: shortClass(path.legacyPathClassType),
+    name: path.name,
+    score: typeof score === "number" ? score : null,
+    finalRequiredPathPoints: path.finalRequiredPathPoints,
+    progressPercent: ratioPercent(score, path.finalRequiredPathPoints),
+    nextMilestone: typeof nextMilestone?.ageProgressionMilestoneType === "string"
+      ? `${nextMilestone.ageProgressionMilestoneType} at ${nextMilestone.requiredPathPoints ?? "?"}`
+      : null,
+    enabledForPlayer: path.enabledForPlayer,
+  };
+}
+
+function progressionDashboardHeadline(
+  dashboard: Civ7ControlOrpcProgressDashboardResult,
+  legacyPaths: Civ7ProgressionDashboardResult["legacyPaths"],
+): string {
+  const pathSummary = legacyPaths
+    .map((path) =>
+      `${path.classType ?? path.legacyPathType}: ${path.score ?? "?"}/${path.finalRequiredPathPoints ?? "?"}`,
+    )
+    .join(", ");
+  return `${dashboard.age.ageType ?? "unknown age"} progress: ${pathSummary || "no current-age legacy paths surfaced"}`;
+}
+
+function progressionDashboardWarnings(
+  dashboard: Civ7ControlOrpcProgressDashboardResult,
+): string[] {
+  return [
+    probeValue(dashboard.proof.victoryManagerGlobal) === "undefined"
+      ? "VictoryManager is module-local in the official UI; this service uses exposed lower-level legacy and age-progress APIs."
+      : null,
+    dashboard.triumphs.count === 0
+      ? "Runtime GameInfo.Triumphs returned no rows; do not infer that all reward systems are absent."
+      : null,
+  ].filter((warning): warning is string => Boolean(warning));
+}
+
+function progressionDashboardNextSteps(
+  dashboard: Civ7ControlOrpcProgressDashboardResult,
+): Civ7ProgressionDashboardResult["nextSteps"] {
+  const steps: Civ7ProgressionDashboardResult["nextSteps"] = [{
+    kind: "read-attention-priorities",
+    source: "progression.dashboard.current",
+    label: "Read current attention priorities before choosing the next progression action.",
+  }];
+
+  if (dashboard.legacyPaths.length > 0) {
+    steps.push({
+      kind: "inspect-progression-choice",
+      source: "progression.dashboard.current",
+      label: "Inspect available technology, culture, attribute, or tradition choices before sending a progression mutation.",
+    });
+  }
+
+  if (dashboard.victories.rows.length > 0) {
+    steps.push({
+      kind: "inspect-victory-progress",
+      source: "progression.dashboard.current",
+      label: "Use victory classes as progress context, not as an automatic action plan.",
+    });
+  }
+
+  return steps.length > 0
+    ? steps
+    : [{
+        kind: "observe",
+        source: "progression.dashboard.current",
+        label: "Observe current attention before selecting a progression follow-up.",
+      }];
+}
+
+function probeValue<T>(probe: RuntimeProbe<T> | null | undefined): T | null {
+  return probe?.ok ? probe.value : null;
+}
+
+function ratioPercent(current: unknown, total: unknown): number | null {
+  return typeof current === "number" && typeof total === "number" && total > 0
+    ? Math.round((current / total) * 1000) / 10
+    : null;
+}
+
+function shortClass(value: string | null): string | null {
+  return value?.replace(/^LEGACY_PATH_CLASS_/, "").toLowerCase() ?? null;
+}
+
+function stringField(value: unknown, key: string): string | null {
+  return value &&
+    typeof value === "object" &&
+    typeof (value as Record<string, unknown>)[key] === "string"
+    ? (value as Record<string, string>)[key]
+    : null;
+}
+
+function uniqueStrings(values: ReadonlyArray<string | null>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))];
+}

--- a/packages/civ7-control-orpc/src/modules/progression/procedures/traditions-current.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/procedures/traditions-current.ts
@@ -1,0 +1,183 @@
+import { Effect } from "effect";
+
+import type { Civ7ControlOrpcTraditionsViewResult } from "../../../dependencies/direct-control";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type {
+  Civ7ProgressionTraditionsInput,
+  Civ7ProgressionTraditionsResult,
+} from "../contract";
+
+export const progressionTraditionsCurrentProcedure =
+  civ7ControlOrpcImplementer.progression.traditions.current.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const traditions = await context.directControl.getCiv7TraditionsView(
+          input,
+          context.endpointDefaults,
+        );
+        return progressionTraditionsResult(input, traditions);
+      },
+      catch: () =>
+        errors.PROGRESSION_TRADITIONS_UNAVAILABLE({
+          data: {
+            procedureKey: "progression.traditions.current",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+function progressionTraditionsResult(
+  _input: Civ7ProgressionTraditionsInput,
+  view: Civ7ControlOrpcTraditionsViewResult,
+): Civ7ProgressionTraditionsResult {
+  const active = view.active.map(traditionRow);
+  const available = view.available.map(traditionRow);
+  const recentUnlocks = view.recentUnlocks.map(traditionRow);
+  const traditions = view.traditions.map(traditionRow);
+  const nextSteps = traditionsNextSteps(view, available, active);
+
+  return {
+    playerId: view.playerId,
+    sourceStatus: {
+      traditions: "read",
+    },
+    hiddenInfoPolicy: view.hiddenInfoPolicy,
+    summary: {
+      activeCount: active.length,
+      availableCount: available.length,
+      recentUnlockCount: recentUnlocks.length,
+      openSlotCount: view.slots.open,
+      enabledAvailableCount: available.filter((tradition) =>
+        tradition.actions.some((action) => action.validationSuccess === true),
+      ).length,
+      disabledAvailableCount: available.filter((tradition) =>
+        !tradition.actions.some((action) => action.validationSuccess === true),
+      ).length,
+      nextStepCount: nextSteps.length,
+    },
+    turn: view.turn,
+    turnDate: view.turnDate,
+    governmentType: view.governmentType,
+    government: view.government,
+    slots: view.slots,
+    actions: view.actions,
+    active,
+    available,
+    recentUnlocks,
+    traditions,
+    omitted: [
+      {
+        path: "directControl.cliCommandSuggestions",
+        reason: "CLI command strings are caller presentation, not progression service output.",
+      },
+      {
+        path: "tradition.actionHints[].cli",
+        reason: "Tradition action hints are projected as semantic action descriptors with parameters.",
+      },
+      {
+        path: "tradition.actionHints[].validation",
+        reason: "Validation probe details remain low-level runtime evidence; service rows expose validationSuccess.",
+      },
+    ],
+    notes: [
+      ...view.notes,
+      "Read-only progression traditions view. It does not send CHANGE_TRADITION or review closeout mutations.",
+    ],
+    nextSteps,
+  };
+}
+
+function traditionRow(
+  tradition: Civ7ControlOrpcTraditionsViewResult["traditions"][number],
+): Civ7ProgressionTraditionsResult["traditions"][number] {
+  return {
+    id: tradition.id,
+    type: tradition.type,
+    name: tradition.name,
+    description: tradition.description,
+    ageType: tradition.ageType,
+    cultureSlotType: tradition.cultureSlotType,
+    traitType: tradition.traitType,
+    isCrisis: tradition.isCrisis,
+    active: tradition.active,
+    unlocked: tradition.unlocked,
+    recentUnlock: tradition.recentUnlock,
+    actions: tradition.actionHints.map((action) => ({
+      kind: action.kind,
+      action: action.action,
+      validationSuccess: validationSuccess(action.validation),
+      parameters: {
+        traditionType: tradition.id,
+        action: action.action,
+      },
+      nextSteps: [
+        {
+          kind: "validate-tradition-change",
+          source: "progression.traditions.current",
+          label: `Validate ${action.kind} for ${tradition.name ?? tradition.type ?? tradition.id}.`,
+          parameters: {
+            traditionType: tradition.id,
+            action: action.action,
+          },
+        },
+        {
+          kind: "request-tradition-change",
+          source: "progression.traditions.current",
+          label: `Request ${action.kind} for ${tradition.name ?? tradition.type ?? tradition.id} only after choosing this tradition.`,
+          parameters: {
+            traditionType: tradition.id,
+            action: action.action,
+          },
+        },
+      ],
+    })),
+  };
+}
+
+function traditionsNextSteps(
+  view: Civ7ControlOrpcTraditionsViewResult,
+  available: Civ7ProgressionTraditionsResult["available"],
+  active: Civ7ProgressionTraditionsResult["active"],
+): Civ7ProgressionTraditionsResult["nextSteps"] {
+  if (available.some((tradition) => tradition.actions.length > 0)) {
+    return [{
+      kind: "inspect-tradition-change",
+      source: "progression.traditions.current",
+      label: "Inspect available tradition action descriptors before requesting a tradition change.",
+    }];
+  }
+
+  if (view.slots.open === 0 && active.some((tradition) => tradition.actions.length > 0)) {
+    return [{
+      kind: "free-policy-slot",
+      source: "progression.traditions.current",
+      label: "If a policy slot is full, inspect active traditions before deactivating one.",
+    }];
+  }
+
+  return [{
+    kind: "observe",
+    source: "progression.traditions.current",
+    label: "Observe current attention before selecting a progression follow-up.",
+  }];
+}
+
+function validationSuccess(validation: unknown): boolean | null {
+  if (!validation || typeof validation !== "object") return null;
+  const probe = validation as Readonly<{
+    ok?: unknown;
+    value?: unknown;
+  }>;
+  if (probe.ok !== true) return null;
+  const value = probe.value;
+  return value && typeof value === "object" && "Success" in value
+    ? (value as Readonly<{ Success?: unknown }>).Success === true
+    : null;
+}

--- a/packages/civ7-control-orpc/src/modules/progression/router.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/router.ts
@@ -3,6 +3,9 @@ import {
   progressionTechnologyChoiceRequestProcedure,
 } from "./procedures/choice-request";
 import {
+  progressionDashboardCurrentProcedure,
+} from "./procedures/dashboard-current";
+import {
   progressionAttributePurchaseRequestProcedure,
   progressionAttributeReviewRequestProcedure,
   progressionTraditionChangeRequestProcedure,
@@ -14,6 +17,9 @@ import {
 } from "./procedures/target-request";
 
 export const progressionRouter = {
+  dashboard: {
+    current: progressionDashboardCurrentProcedure,
+  },
   technology: {
     choice: {
       request: progressionTechnologyChoiceRequestProcedure,

--- a/packages/civ7-control-orpc/src/modules/progression/router.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/router.ts
@@ -6,6 +6,9 @@ import {
   progressionDashboardCurrentProcedure,
 } from "./procedures/dashboard-current";
 import {
+  progressionTraditionsCurrentProcedure,
+} from "./procedures/traditions-current";
+import {
   progressionAttributePurchaseRequestProcedure,
   progressionAttributeReviewRequestProcedure,
   progressionTraditionChangeRequestProcedure,
@@ -19,6 +22,9 @@ import {
 export const progressionRouter = {
   dashboard: {
     current: progressionDashboardCurrentProcedure,
+  },
+  traditions: {
+    current: progressionTraditionsCurrentProcedure,
   },
   technology: {
     choice: {

--- a/packages/civ7-control-orpc/src/modules/strategy/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/contract.ts
@@ -378,6 +378,103 @@ export type Civ7StrategyDestinationAnalysisResult = Static<
   typeof Civ7StrategyDestinationAnalysisResultSchema
 >;
 
+const Civ7StrategyBattlefieldScanInputSchema = Type.Object(
+  {
+    playerId: Type.Optional(Type.Integer({ minimum: 0, maximum: 1024 })),
+    origins: Type.Optional(Type.Array(Civ7ControlOrpcMapLocationSchema)),
+    radius: Type.Optional(Type.Integer({ minimum: 1, maximum: 32 })),
+    maxPlayers: Type.Optional(Type.Integer({ minimum: 1, maximum: 128 })),
+    maxUnits: Type.Optional(Type.Integer({ minimum: 1, maximum: 256 })),
+    maxCities: Type.Optional(Type.Integer({ minimum: 1, maximum: 128 })),
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyBattlefieldScanInput = Static<
+  typeof Civ7StrategyBattlefieldScanInputSchema
+>;
+
+const Civ7StrategyBattlefieldNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("inspect-battlefield-point"),
+      Type.Literal("read-visibility"),
+      Type.Literal("validate-unit-action"),
+      Type.Literal("observe"),
+    ]),
+    source: Type.Literal("strategy.battlefieldScan"),
+    label: Type.String(),
+    parameters: Type.Object(
+      {
+        origin: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+        location: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyBattlefieldOwnerSchema = Type.Object(
+  {
+    owner: Type.Integer({ minimum: 0 }),
+    relationship: Civ7StrategyRelationshipClassificationSchema,
+    relationshipProof: Type.Union([Type.Literal("self"), Type.Literal("none")]),
+    unitCount: Type.Integer({ minimum: 0 }),
+    cityCount: Type.Integer({ minimum: 0 }),
+    apparentStrength: Type.Number(),
+    nearestDistance: Type.Union([Type.Number(), Type.Null()]),
+    roles: Type.Record(Type.String(), Type.Integer({ minimum: 0 })),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyBattlefieldPointOfInterestSchema = Type.Object(
+  {
+    kind: Type.String(),
+    severity: Type.String(),
+    location: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+    summary: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyBattlefieldScanResultSchema = Type.Object(
+  {
+    playerId: Type.Integer({ minimum: 0 }),
+    localPlayerId: Type.Integer({ minimum: 0 }),
+    origins: Type.Array(Civ7ControlOrpcMapLocationSchema),
+    radius: Type.Integer({ minimum: 1 }),
+    hiddenInfoPolicy: Type.String(),
+    relationshipLabelPolicy: Civ7StrategyRelationshipLabelPolicySchema,
+    summary: Type.Object(
+      {
+        unitCount: Type.Integer({ minimum: 0 }),
+        cityCount: Type.Integer({ minimum: 0 }),
+        observedOwnerCount: Type.Integer({ minimum: 0 }),
+        pointOfInterestCount: Type.Integer({ minimum: 0 }),
+        apparentStrengthTotal: Type.Number(),
+        nextStepCount: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    ),
+    owners: Type.Array(Civ7StrategyBattlefieldOwnerSchema),
+    pointsOfInterest: Type.Array(Civ7StrategyBattlefieldPointOfInterestSchema),
+    omitted: Type.Array(Type.Object(
+      {
+        path: Type.String(),
+        reason: Type.String(),
+      },
+      { additionalProperties: false },
+    )),
+    notes: Type.Array(Type.String()),
+    nextSteps: Type.Array(Civ7StrategyBattlefieldNextStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyBattlefieldScanResult = Static<
+  typeof Civ7StrategyBattlefieldScanResultSchema
+>;
+
 const Civ7StrategyFrontSummaryInputStandardSchema = toStandardSchema(
   Civ7StrategyFrontSummaryInputSchema,
 );
@@ -395,6 +492,12 @@ const Civ7StrategyDestinationAnalysisInputStandardSchema = toStandardSchema(
 );
 const Civ7StrategyDestinationAnalysisResultStandardSchema = toStandardSchema(
   Civ7StrategyDestinationAnalysisResultSchema,
+);
+const Civ7StrategyBattlefieldScanInputStandardSchema = toStandardSchema(
+  Civ7StrategyBattlefieldScanInputSchema,
+);
+const Civ7StrategyBattlefieldScanResultStandardSchema = toStandardSchema(
+  Civ7StrategyBattlefieldScanResultSchema,
 );
 
 const Civ7StrategyCivilianRouteTriageInputSchema = Type.Object(
@@ -727,6 +830,25 @@ export const Civ7StrategyDestinationAnalysisContract:
         risk: "read-only",
       });
 
+export type Civ7StrategyBattlefieldScanContract = ContractProcedure<
+  typeof Civ7StrategyBattlefieldScanInputStandardSchema,
+  typeof Civ7StrategyBattlefieldScanResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export const Civ7StrategyBattlefieldScanContract:
+  Civ7StrategyBattlefieldScanContract =
+    civ7ControlOrpcContractBase
+      .input(Civ7StrategyBattlefieldScanInputStandardSchema)
+      .output(Civ7StrategyBattlefieldScanResultStandardSchema)
+      .meta({
+        family: "strategy",
+        procedureKey: "strategy.battlefieldScan",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      });
+
 export type Civ7StrategyCivilianRouteTriageContract = ContractProcedure<
   typeof Civ7StrategyCivilianRouteTriageInputStandardSchema,
   typeof Civ7StrategyCivilianRouteTriageResultStandardSchema,
@@ -766,6 +888,7 @@ export const Civ7StrategyFormationSnapshotContract:
       });
 
 export type Civ7StrategyContract = Readonly<{
+  battlefieldScan: Civ7StrategyBattlefieldScanContract;
   civilianRouteTriage: Civ7StrategyCivilianRouteTriageContract;
   destinationAnalysis: Civ7StrategyDestinationAnalysisContract;
   formationSnapshot: Civ7StrategyFormationSnapshotContract;
@@ -774,6 +897,7 @@ export type Civ7StrategyContract = Readonly<{
 }>;
 
 export const Civ7StrategyContract: Civ7StrategyContract = {
+  battlefieldScan: Civ7StrategyBattlefieldScanContract,
   civilianRouteTriage: Civ7StrategyCivilianRouteTriageContract,
   destinationAnalysis: Civ7StrategyDestinationAnalysisContract,
   formationSnapshot: Civ7StrategyFormationSnapshotContract,

--- a/packages/civ7-control-orpc/src/modules/strategy/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/contract.ts
@@ -168,11 +168,233 @@ export type Civ7StrategyFrontSummaryResult = Static<
   typeof Civ7StrategyFrontSummaryResultSchema
 >;
 
+const Civ7StrategyTargetCandidatesInputSchema = Type.Object(
+  {
+    playerId: Type.Optional(Type.Integer({ minimum: 0, maximum: 1024 })),
+    origins: Type.Optional(Type.Array(Civ7ControlOrpcMapLocationSchema)),
+    maxCandidates: Type.Optional(Type.Integer({ minimum: 1, maximum: 64 })),
+    maxPlayers: Type.Optional(Type.Integer({ minimum: 1, maximum: 128 })),
+    unitRadius: Type.Optional(Type.Integer({ minimum: 0, maximum: 16 })),
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyTargetCandidatesInput = Static<
+  typeof Civ7StrategyTargetCandidatesInputSchema
+>;
+
+const Civ7StrategyTargetCandidatesNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("inspect-candidate"),
+      Type.Literal("read-visibility"),
+      Type.Literal("validate-unit-action"),
+      Type.Literal("observe"),
+    ]),
+    source: Type.Literal("strategy.targetCandidates"),
+    label: Type.String(),
+    parameters: Type.Object(
+      {
+        owner: Type.Optional(Type.Integer({ minimum: 0 })),
+        target: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyTargetCandidateApproachSchema = Type.Object(
+  {
+    nearestOrigin: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+    targetLocation: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+    directGridDistance: Type.Union([Type.Number(), Type.Null()]),
+    routeHint: Type.String(),
+    routeKind: Type.String(),
+    waterSampleCount: Type.Integer({ minimum: 0 }),
+    landSampleCount: Type.Integer({ minimum: 0 }),
+    notes: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyTargetCandidateResultSchema = Type.Object(
+  {
+    owner: Type.Integer({ minimum: 0 }),
+    relationship: Type.Literal("relationship-unproven"),
+    relationshipProof: Type.Literal("none"),
+    leaderName: Type.Union([Type.String(), Type.Null()]),
+    civilizationName: Type.Union([Type.String(), Type.Null()]),
+    isHuman: Type.Union([Type.Boolean(), Type.Null()]),
+    cityCount: Type.Integer({ minimum: 0 }),
+    unitCount: Type.Integer({ minimum: 0 }),
+    nearestDistance: Type.Union([Type.Number(), Type.Null()]),
+    nearbyUnitCount: Type.Integer({ minimum: 0 }),
+    apparentStrength: Type.Number(),
+    nearestCityLocation: Type.Union([
+      Civ7ControlOrpcMapLocationSchema,
+      Type.Null(),
+    ]),
+    approach: Civ7StrategyTargetCandidateApproachSchema,
+    reasons: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyTargetCandidatesResultSchema = Type.Object(
+  {
+    playerId: Type.Integer({ minimum: 0 }),
+    localPlayerId: Type.Integer({ minimum: 0 }),
+    origins: Type.Array(Civ7ControlOrpcMapLocationSchema),
+    unitRadius: Type.Integer({ minimum: 0 }),
+    hiddenInfoPolicy: Type.String(),
+    relationshipLabelPolicy: Civ7StrategyRelationshipLabelPolicySchema,
+    summary: Type.Object(
+      {
+        candidateCount: Type.Integer({ minimum: 0 }),
+        nearestDistance: Type.Union([Type.Number(), Type.Null()]),
+        observedOwnerCount: Type.Integer({ minimum: 0 }),
+        apparentStrengthTotal: Type.Number(),
+        nextStepCount: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    ),
+    candidates: Type.Array(Civ7StrategyTargetCandidateResultSchema),
+    omitted: Type.Array(Type.Object(
+      {
+        path: Type.String(),
+        reason: Type.String(),
+      },
+      { additionalProperties: false },
+    )),
+    notes: Type.Array(Type.String()),
+    nextSteps: Type.Array(Civ7StrategyTargetCandidatesNextStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyTargetCandidatesResult = Static<
+  typeof Civ7StrategyTargetCandidatesResultSchema
+>;
+
+const Civ7StrategyDestinationAnalysisInputSchema = Type.Object(
+  {
+    playerId: Type.Optional(Type.Integer({ minimum: 0, maximum: 1024 })),
+    origin: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+    destination: Civ7ControlOrpcMapLocationSchema,
+    corridorRadius: Type.Optional(Type.Integer({ minimum: 0, maximum: 8 })),
+    destinationRadius: Type.Optional(Type.Integer({ minimum: 1, maximum: 16 })),
+    maxPlayers: Type.Optional(Type.Integer({ minimum: 1, maximum: 128 })),
+    maxUnits: Type.Optional(Type.Integer({ minimum: 1, maximum: 256 })),
+    maxCities: Type.Optional(Type.Integer({ minimum: 1, maximum: 128 })),
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyDestinationAnalysisInput = Static<
+  typeof Civ7StrategyDestinationAnalysisInputSchema
+>;
+
+const Civ7StrategyDestinationAnalysisNextStepSchema = Type.Object(
+  {
+    kind: Type.Union([
+      Type.Literal("inspect-destination"),
+      Type.Literal("read-visibility"),
+      Type.Literal("validate-unit-action"),
+      Type.Literal("observe"),
+    ]),
+    source: Type.Literal("strategy.destinationAnalysis"),
+    label: Type.String(),
+    parameters: Type.Object(
+      {
+        origin: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+        destination: Type.Optional(Civ7ControlOrpcMapLocationSchema),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyDestinationPointOfInterestSchema = Type.Object(
+  {
+    kind: Type.String(),
+    severity: Type.String(),
+    location: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+    summary: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const Civ7StrategyDestinationAnalysisResultSchema = Type.Object(
+  {
+    playerId: Type.Integer({ minimum: 0 }),
+    localPlayerId: Type.Integer({ minimum: 0 }),
+    origin: Type.Union([Civ7ControlOrpcMapLocationSchema, Type.Null()]),
+    destination: Civ7ControlOrpcMapLocationSchema,
+    corridorRadius: Type.Integer({ minimum: 0 }),
+    destinationRadius: Type.Integer({ minimum: 1 }),
+    hiddenInfoPolicy: Type.String(),
+    relationshipLabelPolicy: Civ7StrategyRelationshipLabelPolicySchema,
+    summary: Type.Object(
+      {
+        pointOfInterestCount: Type.Integer({ minimum: 0 }),
+        corridorUnitCount: Type.Integer({ minimum: 0 }),
+        destinationUnitCount: Type.Integer({ minimum: 0 }),
+        destinationCityCount: Type.Integer({ minimum: 0 }),
+        apparentOtherStrength: Type.Number(),
+        nextStepCount: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    ),
+    corridor: Type.Object(
+      {
+        routeHint: Type.String(),
+        directGridDistance: Type.Union([Type.Number(), Type.Null()]),
+        sampleCount: Type.Integer({ minimum: 0 }),
+        unitCount: Type.Integer({ minimum: 0 }),
+      },
+      { additionalProperties: false },
+    ),
+    destinationPressure: Type.Object(
+      {
+        unitCount: Type.Integer({ minimum: 0 }),
+        cityCount: Type.Integer({ minimum: 0 }),
+        apparentOtherStrength: Type.Number(),
+      },
+      { additionalProperties: false },
+    ),
+    pointsOfInterest: Type.Array(Civ7StrategyDestinationPointOfInterestSchema),
+    omitted: Type.Array(Type.Object(
+      {
+        path: Type.String(),
+        reason: Type.String(),
+      },
+      { additionalProperties: false },
+    )),
+    notes: Type.Array(Type.String()),
+    nextSteps: Type.Array(Civ7StrategyDestinationAnalysisNextStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type Civ7StrategyDestinationAnalysisResult = Static<
+  typeof Civ7StrategyDestinationAnalysisResultSchema
+>;
+
 const Civ7StrategyFrontSummaryInputStandardSchema = toStandardSchema(
   Civ7StrategyFrontSummaryInputSchema,
 );
 const Civ7StrategyFrontSummaryResultStandardSchema = toStandardSchema(
   Civ7StrategyFrontSummaryResultSchema,
+);
+const Civ7StrategyTargetCandidatesInputStandardSchema = toStandardSchema(
+  Civ7StrategyTargetCandidatesInputSchema,
+);
+const Civ7StrategyTargetCandidatesResultStandardSchema = toStandardSchema(
+  Civ7StrategyTargetCandidatesResultSchema,
+);
+const Civ7StrategyDestinationAnalysisInputStandardSchema = toStandardSchema(
+  Civ7StrategyDestinationAnalysisInputSchema,
+);
+const Civ7StrategyDestinationAnalysisResultStandardSchema = toStandardSchema(
+  Civ7StrategyDestinationAnalysisResultSchema,
 );
 
 const Civ7StrategyCivilianRouteTriageInputSchema = Type.Object(
@@ -467,6 +689,44 @@ export const Civ7StrategyFrontSummaryContract: Civ7StrategyFrontSummaryContract 
       risk: "read-only",
     });
 
+export type Civ7StrategyTargetCandidatesContract = ContractProcedure<
+  typeof Civ7StrategyTargetCandidatesInputStandardSchema,
+  typeof Civ7StrategyTargetCandidatesResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export const Civ7StrategyTargetCandidatesContract:
+  Civ7StrategyTargetCandidatesContract =
+    civ7ControlOrpcContractBase
+      .input(Civ7StrategyTargetCandidatesInputStandardSchema)
+      .output(Civ7StrategyTargetCandidatesResultStandardSchema)
+      .meta({
+        family: "strategy",
+        procedureKey: "strategy.targetCandidates",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      });
+
+export type Civ7StrategyDestinationAnalysisContract = ContractProcedure<
+  typeof Civ7StrategyDestinationAnalysisInputStandardSchema,
+  typeof Civ7StrategyDestinationAnalysisResultStandardSchema,
+  Civ7ControlOrpcErrorMap,
+  Civ7ControlOrpcProcedureMeta
+>;
+
+export const Civ7StrategyDestinationAnalysisContract:
+  Civ7StrategyDestinationAnalysisContract =
+    civ7ControlOrpcContractBase
+      .input(Civ7StrategyDestinationAnalysisInputStandardSchema)
+      .output(Civ7StrategyDestinationAnalysisResultStandardSchema)
+      .meta({
+        family: "strategy",
+        procedureKey: "strategy.destinationAnalysis",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      });
+
 export type Civ7StrategyCivilianRouteTriageContract = ContractProcedure<
   typeof Civ7StrategyCivilianRouteTriageInputStandardSchema,
   typeof Civ7StrategyCivilianRouteTriageResultStandardSchema,
@@ -507,12 +767,16 @@ export const Civ7StrategyFormationSnapshotContract:
 
 export type Civ7StrategyContract = Readonly<{
   civilianRouteTriage: Civ7StrategyCivilianRouteTriageContract;
+  destinationAnalysis: Civ7StrategyDestinationAnalysisContract;
   formationSnapshot: Civ7StrategyFormationSnapshotContract;
   frontSummary: Civ7StrategyFrontSummaryContract;
+  targetCandidates: Civ7StrategyTargetCandidatesContract;
 }>;
 
 export const Civ7StrategyContract: Civ7StrategyContract = {
   civilianRouteTriage: Civ7StrategyCivilianRouteTriageContract,
+  destinationAnalysis: Civ7StrategyDestinationAnalysisContract,
   formationSnapshot: Civ7StrategyFormationSnapshotContract,
   frontSummary: Civ7StrategyFrontSummaryContract,
+  targetCandidates: Civ7StrategyTargetCandidatesContract,
 };

--- a/packages/civ7-control-orpc/src/modules/strategy/procedures/tactical-reads.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/procedures/tactical-reads.ts
@@ -1,0 +1,373 @@
+import { Effect } from "effect";
+
+import type {
+  Civ7ControlOrpcDestinationAnalysisResult,
+  Civ7ControlOrpcTargetCandidatesResult,
+} from "../../../dependencies/direct-control";
+import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
+import { civ7ControlOrpcImplementer } from "../../../procedure";
+import type {
+  Civ7StrategyDestinationAnalysisResult,
+  Civ7StrategyTargetCandidatesResult,
+} from "../contract";
+
+type MapLocation = Readonly<{ x: number; y: number }>;
+
+export const strategyTargetCandidatesProcedure =
+  civ7ControlOrpcImplementer.strategy.targetCandidates.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const result = await context.directControl.getCiv7TargetCandidates(
+          input,
+          context.endpointDefaults,
+        );
+        return targetCandidatesResult(result);
+      },
+      catch: () =>
+        errors.STRATEGY_TACTICAL_READ_UNAVAILABLE({
+          data: {
+            procedureKey: "strategy.targetCandidates",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+export const strategyDestinationAnalysisProcedure =
+  civ7ControlOrpcImplementer.strategy.destinationAnalysis.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const result = await context.directControl.getCiv7DestinationAnalysis(
+          input,
+          context.endpointDefaults,
+        );
+        return destinationAnalysisResult(result);
+      },
+      catch: () =>
+        errors.STRATEGY_TACTICAL_READ_UNAVAILABLE({
+          data: {
+            procedureKey: "strategy.destinationAnalysis",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
+
+function targetCandidatesResult(
+  result: Civ7ControlOrpcTargetCandidatesResult,
+): Civ7StrategyTargetCandidatesResult {
+  const candidates = result.candidates.map((candidate) => {
+    const targetLocation = locationFromUnknown(candidate.approach.targetLocation);
+    return {
+      owner: candidate.owner,
+      relationship: "relationship-unproven" as const,
+      relationshipProof: "none" as const,
+      leaderName: probeValue(candidate.leaderName, "string"),
+      civilizationName: probeValue(candidate.civilizationName, "string"),
+      isHuman: probeValue(candidate.isHuman, "boolean"),
+      cityCount: candidate.cityCount,
+      unitCount: candidate.unitCount,
+      nearestDistance: candidate.nearestDistance,
+      nearbyUnitCount: candidate.nearbyUnitCount,
+      apparentStrength: candidate.apparentStrength,
+      nearestCityLocation: locationFromUnknown(candidate.nearestCity),
+      approach: {
+        nearestOrigin: locationFromUnknown(candidate.approach.nearestOrigin),
+        targetLocation,
+        directGridDistance: candidate.approach.directGridDistance,
+        routeHint: candidate.approach.routeHint,
+        routeKind: candidate.approach.routeKind,
+        waterSampleCount: Math.max(0, Math.trunc(candidate.approach.waterSampleCount)),
+        landSampleCount: Math.max(0, Math.trunc(candidate.approach.landSampleCount)),
+        notes: [...candidate.approach.notes],
+      },
+      reasons: [...candidate.reasons],
+    };
+  });
+  const nextSteps = targetCandidateNextSteps(candidates);
+  return {
+    playerId: result.playerId,
+    localPlayerId: result.localPlayerId,
+    origins: result.origins,
+    unitRadius: result.unitRadius,
+    hiddenInfoPolicy: result.hiddenInfoPolicy,
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "Target candidates are planning evidence only. Other-owner contact, route ranking, proximity, and apparent strength do not prove official diplomatic status.",
+    },
+    summary: {
+      candidateCount: candidates.length,
+      nearestDistance: nearestDistance(candidates),
+      observedOwnerCount: new Set(candidates.map((candidate) => candidate.owner)).size,
+      apparentStrengthTotal: candidates.reduce(
+        (total, candidate) => total + candidate.apparentStrength,
+        0,
+      ),
+      nextStepCount: nextSteps.length,
+    },
+    candidates,
+    omitted: [
+      {
+        path: "directControl.host",
+        reason: "endpoint context is not normal service output",
+      },
+      {
+        path: "directControl.state",
+        reason: "runtime state selection is context/debug owned",
+      },
+      {
+        path: "candidate.cities",
+        reason: "raw city samples stay behind bounded candidate summaries",
+      },
+      {
+        path: "candidate.nearbyUnits",
+        reason: "raw unit samples stay behind bounded candidate summaries",
+      },
+    ],
+    notes: [
+      ...result.notes.map(normalizeRelationshipSummary),
+      "Use visibility reads and validator-backed unit action procedures before any mutation.",
+    ],
+    nextSteps,
+  };
+}
+
+function destinationAnalysisResult(
+  result: Civ7ControlOrpcDestinationAnalysisResult,
+): Civ7StrategyDestinationAnalysisResult {
+  const corridor = asRecord(result.corridor);
+  const destinationPressure = asRecord(result.destinationPressure);
+  const pointsOfInterest = asArray(result.pointsOfInterest).map((point) => {
+    const record = asRecord(point);
+    return {
+      kind: String(record?.kind ?? "unknown"),
+      severity: String(record?.severity ?? "unknown"),
+      location: locationFromUnknown(record?.location),
+      summary: normalizeRelationshipSummary(String(record?.summary ?? "")),
+    };
+  });
+  const nextSteps = destinationNextSteps({
+    origin: result.origin,
+    destination: result.destination,
+    pointsOfInterest,
+  });
+  const corridorUnitCount = numberFromUnknown(corridor?.unitCount);
+  const destinationUnitCount = numberFromUnknown(destinationPressure?.unitCount);
+  const destinationCityCount = numberFromUnknown(destinationPressure?.cityCount);
+  const apparentOtherStrength = numberFromUnknown(
+    destinationPressure?.apparentOtherStrength,
+  );
+  return {
+    playerId: result.playerId,
+    localPlayerId: result.localPlayerId,
+    origin: result.origin,
+    destination: result.destination,
+    corridorRadius: result.corridorRadius,
+    destinationRadius: result.destinationRadius,
+    hiddenInfoPolicy: result.hiddenInfoPolicy,
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "Destination analysis is planning evidence only. Other-owner contact, destination proximity, and apparent strength do not prove official diplomatic status.",
+    },
+    summary: {
+      pointOfInterestCount: pointsOfInterest.length,
+      corridorUnitCount,
+      destinationUnitCount,
+      destinationCityCount,
+      apparentOtherStrength,
+      nextStepCount: nextSteps.length,
+    },
+    corridor: {
+      routeHint: String(corridor?.routeHint ?? "unknown"),
+      directGridDistance: nullableNumber(corridor?.directGridDistance),
+      sampleCount: numberFromUnknown(corridor?.sampleCount),
+      unitCount: corridorUnitCount,
+    },
+    destinationPressure: {
+      unitCount: destinationUnitCount,
+      cityCount: destinationCityCount,
+      apparentOtherStrength,
+    },
+    pointsOfInterest,
+    omitted: [
+      {
+        path: "directControl.host",
+        reason: "endpoint context is not normal service output",
+      },
+      {
+        path: "directControl.state",
+        reason: "runtime state selection is context/debug owned",
+      },
+      {
+        path: "corridor.sampledPlots",
+        reason: "raw plot samples stay behind bounded corridor summaries",
+      },
+      {
+        path: "destinationPressure.units",
+        reason: "raw unit samples stay behind bounded pressure summaries",
+      },
+      {
+        path: "destinationPressure.cities",
+        reason: "raw city samples stay behind bounded pressure summaries",
+      },
+    ],
+    notes: [
+      ...result.notes.map(normalizeRelationshipSummary),
+      "Use visibility reads and validator-backed unit action procedures before any mutation.",
+    ],
+    nextSteps,
+  };
+}
+
+function targetCandidateNextSteps(
+  candidates: Civ7StrategyTargetCandidatesResult["candidates"],
+): Civ7StrategyTargetCandidatesResult["nextSteps"] {
+  const candidate = candidates[0];
+  if (candidate == null) {
+    return [{
+      kind: "observe",
+      source: "strategy.targetCandidates",
+      label: "No target candidates found; refresh strategy evidence or narrow origins.",
+      parameters: {},
+    }];
+  }
+  return [
+    {
+      kind: "inspect-candidate",
+      source: "strategy.targetCandidates",
+      label: `Inspect owner ${candidate.owner} candidate with visibility reads before treating it as actionable.`,
+      parameters: {
+        owner: candidate.owner,
+        ...(candidate.approach.targetLocation
+          ? { target: candidate.approach.targetLocation }
+          : {}),
+      },
+    },
+    {
+      kind: "read-visibility",
+      source: "strategy.targetCandidates",
+      label: "Read visibility/map evidence before promoting candidate ranking into an action.",
+      parameters: candidate.approach.targetLocation
+        ? { target: candidate.approach.targetLocation }
+        : {},
+    },
+    {
+      kind: "validate-unit-action",
+      source: "strategy.targetCandidates",
+      label: "Use unit action validation before any movement or target send.",
+      parameters: candidate.approach.targetLocation
+        ? { target: candidate.approach.targetLocation }
+        : {},
+    },
+  ];
+}
+
+function destinationNextSteps(
+  input: Readonly<{
+    origin: MapLocation | null;
+    destination: MapLocation;
+    pointsOfInterest: Civ7StrategyDestinationAnalysisResult["pointsOfInterest"];
+  }>,
+): Civ7StrategyDestinationAnalysisResult["nextSteps"] {
+  if (input.pointsOfInterest.length === 0) {
+    return [{
+      kind: "observe",
+      source: "strategy.destinationAnalysis",
+      label: "No destination pressure found; refresh map/visibility evidence before acting.",
+      parameters: { origin: input.origin ?? undefined, destination: input.destination },
+    }];
+  }
+  return [
+    {
+      kind: "inspect-destination",
+      source: "strategy.destinationAnalysis",
+      label: "Inspect destination contact and visibility before choosing a unit action.",
+      parameters: { origin: input.origin ?? undefined, destination: input.destination },
+    },
+    {
+      kind: "read-visibility",
+      source: "strategy.destinationAnalysis",
+      label: "Read visibility/map evidence before promoting destination pressure into an action.",
+      parameters: { destination: input.destination },
+    },
+    {
+      kind: "validate-unit-action",
+      source: "strategy.destinationAnalysis",
+      label: "Use unit action validation before any movement or target send.",
+      parameters: { origin: input.origin ?? undefined, destination: input.destination },
+    },
+  ];
+}
+
+function nearestDistance(
+  candidates: Civ7StrategyTargetCandidatesResult["candidates"],
+): number | null {
+  const distances = candidates
+    .map((candidate) => candidate.nearestDistance)
+    .filter((value): value is number => value != null);
+  if (distances.length === 0) return null;
+  return Math.min(...distances);
+}
+
+function probeValue<T extends "string" | "boolean">(
+  probe: unknown,
+  type: T,
+): T extends "string" ? string | null : boolean | null {
+  const record = asRecord(probe);
+  if (record?.ok !== true || typeof record.value !== type) return null as never;
+  return record.value as never;
+}
+
+function locationFromUnknown(value: unknown): MapLocation | null {
+  const direct = asRecord(value);
+  if (typeof direct?.x === "number" && typeof direct.y === "number") {
+    return { x: direct.x, y: direct.y };
+  }
+  const nested = asRecord(direct?.location);
+  if (typeof nested?.x === "number" && typeof nested.y === "number") {
+    return { x: nested.x, y: nested.y };
+  }
+  return null;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object"
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function numberFromUnknown(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function nullableNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function normalizeRelationshipSummary(summary: string): string {
+  return summary
+    .replace(/\bfriendly\b/gi, "own")
+    .replace(/\bpressure\b/gi, "contact")
+    .replace(/\bthreat\b/gi, "contact")
+    .replace(/\benemy\b/gi, "other-owner")
+    .replace(/\bhostile\b/gi, "other-owner")
+    .replace(/\bopponent\b/gi, "other-owner");
+}

--- a/packages/civ7-control-orpc/src/modules/strategy/procedures/tactical-reads.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/procedures/tactical-reads.ts
@@ -1,17 +1,44 @@
 import { Effect } from "effect";
 
 import type {
+  Civ7ControlOrpcBattlefieldScanResult,
   Civ7ControlOrpcDestinationAnalysisResult,
   Civ7ControlOrpcTargetCandidatesResult,
 } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
 import { civ7ControlOrpcImplementer } from "../../../procedure";
 import type {
+  Civ7StrategyBattlefieldScanResult,
   Civ7StrategyDestinationAnalysisResult,
   Civ7StrategyTargetCandidatesResult,
 } from "../contract";
 
 type MapLocation = Readonly<{ x: number; y: number }>;
+
+export const strategyBattlefieldScanProcedure =
+  civ7ControlOrpcImplementer.strategy.battlefieldScan.effect(function* ({
+    context,
+    errors,
+    input,
+  }) {
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const result = await context.directControl.getCiv7BattlefieldScan(
+          input,
+          context.endpointDefaults,
+        );
+        return battlefieldScanResult(result);
+      },
+      catch: () =>
+        errors.STRATEGY_TACTICAL_READ_UNAVAILABLE({
+          data: {
+            procedureKey: "strategy.battlefieldScan",
+            source: "direct-control-facade",
+            ...civ7ControlOrpcErrorCorrelationData(context),
+          },
+        }),
+    });
+  });
 
 export const strategyTargetCandidatesProcedure =
   civ7ControlOrpcImplementer.strategy.targetCandidates.effect(function* ({
@@ -62,6 +89,99 @@ export const strategyDestinationAnalysisProcedure =
         }),
     });
   });
+
+function battlefieldScanResult(
+  result: Civ7ControlOrpcBattlefieldScanResult,
+): Civ7StrategyBattlefieldScanResult {
+  const owners = asArray(result.owners).map((owner) => {
+    const record = asRecord(owner);
+    const relationshipProof = record?.relationshipProof === "self"
+      ? "self" as const
+      : "none" as const;
+    return {
+      owner: numberFromUnknown(record?.owner),
+      relationship: relationshipProof === "self"
+        ? "self" as const
+        : "relationship-unproven" as const,
+      relationshipProof,
+      unitCount: numberFromUnknown(record?.unitCount),
+      cityCount: numberFromUnknown(record?.cityCount),
+      apparentStrength: numberFromUnknown(record?.apparentStrength),
+      nearestDistance: nearestOwnerDistance(record),
+      roles: integerRecord(record?.roles),
+    };
+  });
+  const pointsOfInterest = asArray(result.pointsOfInterest).map((point) => {
+    const record = asRecord(point);
+    return {
+      kind: String(record?.kind ?? "unknown"),
+      severity: String(record?.severity ?? "unknown"),
+      location: locationFromUnknown(record?.location),
+      summary: normalizeRelationshipSummary(String(record?.summary ?? "")),
+    };
+  });
+  const nextSteps = battlefieldNextSteps({
+    origins: result.origins,
+    pointsOfInterest,
+  });
+  return {
+    playerId: result.playerId,
+    localPlayerId: result.localPlayerId,
+    origins: result.origins,
+    radius: result.radius,
+    hiddenInfoPolicy: result.hiddenInfoPolicy,
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "Battlefield scan is planning evidence only. Owner contact, proximity, role heuristics, and apparent strength do not prove official diplomatic status.",
+    },
+    summary: {
+      unitCount: asArray(result.units).length,
+      cityCount: asArray(result.cities).length,
+      observedOwnerCount: owners.length,
+      pointOfInterestCount: pointsOfInterest.length,
+      apparentStrengthTotal: owners.reduce(
+        (total, owner) => total + owner.apparentStrength,
+        0,
+      ),
+      nextStepCount: nextSteps.length,
+    },
+    owners,
+    pointsOfInterest,
+    omitted: [
+      {
+        path: "directControl.host",
+        reason: "endpoint context is not normal service output",
+      },
+      {
+        path: "directControl.state",
+        reason: "runtime state selection is context/debug owned",
+      },
+      {
+        path: "units",
+        reason: "raw unit samples stay behind bounded owner and point summaries",
+      },
+      {
+        path: "cities",
+        reason: "raw city samples stay behind bounded owner and point summaries",
+      },
+      {
+        path: "point.units",
+        reason: "raw point unit samples stay behind bounded point summaries",
+      },
+      {
+        path: "point.cities",
+        reason: "raw point city samples stay behind bounded point summaries",
+      },
+    ],
+    notes: [
+      ...result.notes.map(normalizeRelationshipSummary),
+      "Use visibility reads and validator-backed unit action procedures before any mutation.",
+    ],
+    nextSteps,
+  };
+}
 
 function targetCandidatesResult(
   result: Civ7ControlOrpcTargetCandidatesResult,
@@ -233,6 +353,47 @@ function destinationAnalysisResult(
   };
 }
 
+function battlefieldNextSteps(
+  input: Readonly<{
+    origins: ReadonlyArray<MapLocation>;
+    pointsOfInterest: Civ7StrategyBattlefieldScanResult["pointsOfInterest"];
+  }>,
+): Civ7StrategyBattlefieldScanResult["nextSteps"] {
+  const point = input.pointsOfInterest[0];
+  const origin = input.origins[0];
+  if (point == null) {
+    return [{
+      kind: "observe",
+      source: "strategy.battlefieldScan",
+      label: "No battlefield points found; refresh attention or narrow scan origins.",
+      parameters: origin ? { origin } : {},
+    }];
+  }
+  return [
+    {
+      kind: "inspect-battlefield-point",
+      source: "strategy.battlefieldScan",
+      label: `Inspect ${point.kind} battlefield point before choosing a unit action.`,
+      parameters: {
+        ...(origin ? { origin } : {}),
+        ...(point.location ? { location: point.location } : {}),
+      },
+    },
+    {
+      kind: "read-visibility",
+      source: "strategy.battlefieldScan",
+      label: "Read visibility/map evidence before promoting battlefield contact into an action.",
+      parameters: point.location ? { location: point.location } : {},
+    },
+    {
+      kind: "validate-unit-action",
+      source: "strategy.battlefieldScan",
+      label: "Use unit action validation before any movement or target send.",
+      parameters: point.location ? { location: point.location } : {},
+    },
+  ];
+}
+
 function targetCandidateNextSteps(
   candidates: Civ7StrategyTargetCandidatesResult["candidates"],
 ): Civ7StrategyTargetCandidatesResult["nextSteps"] {
@@ -330,6 +491,31 @@ function probeValue<T extends "string" | "boolean">(
   const record = asRecord(probe);
   if (record?.ok !== true || typeof record.value !== type) return null as never;
   return record.value as never;
+}
+
+function nearestOwnerDistance(owner: Record<string, unknown> | null): number | null {
+  const distances = [
+    distanceFromUnknown(owner?.nearestUnit),
+    distanceFromUnknown(owner?.nearestCity),
+  ].filter((distance): distance is number => distance != null);
+  if (distances.length === 0) return null;
+  return Math.min(...distances);
+}
+
+function distanceFromUnknown(value: unknown): number | null {
+  const record = asRecord(value);
+  return nullableNumber(record?.distance);
+}
+
+function integerRecord(value: unknown): Record<string, number> {
+  const record = asRecord(value);
+  if (record == null) return {};
+  const out: Record<string, number> = {};
+  for (const [key, candidate] of Object.entries(record)) {
+    const value = numberFromUnknown(candidate);
+    if (value > 0) out[key] = Math.trunc(value);
+  }
+  return out;
 }
 
 function locationFromUnknown(value: unknown): MapLocation | null {

--- a/packages/civ7-control-orpc/src/modules/strategy/router.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/router.ts
@@ -1,9 +1,15 @@
 import { strategyCivilianRouteTriageProcedure } from "./procedures/civilian-route-triage";
 import { strategyFormationSnapshotProcedure } from "./procedures/formation-snapshot";
 import { strategyFrontSummaryProcedure } from "./procedures/front-summary";
+import {
+  strategyDestinationAnalysisProcedure,
+  strategyTargetCandidatesProcedure,
+} from "./procedures/tactical-reads";
 
 export const strategyRouter = {
   civilianRouteTriage: strategyCivilianRouteTriageProcedure,
+  destinationAnalysis: strategyDestinationAnalysisProcedure,
   formationSnapshot: strategyFormationSnapshotProcedure,
   frontSummary: strategyFrontSummaryProcedure,
+  targetCandidates: strategyTargetCandidatesProcedure,
 };

--- a/packages/civ7-control-orpc/src/modules/strategy/router.ts
+++ b/packages/civ7-control-orpc/src/modules/strategy/router.ts
@@ -2,11 +2,13 @@ import { strategyCivilianRouteTriageProcedure } from "./procedures/civilian-rout
 import { strategyFormationSnapshotProcedure } from "./procedures/formation-snapshot";
 import { strategyFrontSummaryProcedure } from "./procedures/front-summary";
 import {
+  strategyBattlefieldScanProcedure,
   strategyDestinationAnalysisProcedure,
   strategyTargetCandidatesProcedure,
 } from "./procedures/tactical-reads";
 
 export const strategyRouter = {
+  battlefieldScan: strategyBattlefieldScanProcedure,
   civilianRouteTriage: strategyCivilianRouteTriageProcedure,
   destinationAnalysis: strategyDestinationAnalysisProcedure,
   formationSnapshot: strategyFormationSnapshotProcedure,

--- a/packages/civ7-control-orpc/test/progression-dashboard-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/progression-dashboard-procedure.test.ts
@@ -1,0 +1,277 @@
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+} from "../src/index";
+import type { Civ7ControlOrpcProgressDashboardResult } from "../src/dependencies/direct-control";
+
+describe("progression dashboard control-oRPC procedure", () => {
+  test("projects runtime progress evidence into a semantic dashboard result", async () => {
+    const fake = fakeContext(progressDashboardResult());
+
+    const result = await call(
+      Civ7ControlOrpcRouter.progression.dashboard.current,
+      {},
+      { context: fake.context },
+    );
+
+    expect(fake.calls.dashboard).toEqual([{
+      input: {},
+      options: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+    }]);
+    expect(result).toMatchObject({
+      playerId: 0,
+      localPlayerId: 0,
+      sourceStatus: {
+        progressDashboard: "read",
+      },
+      hiddenInfoPolicy: "local-player-runtime-progress",
+      summary: {
+        headline: expect.stringContaining("AGE_ANTIQUITY progress"),
+        legacyPathCount: 2,
+        victoryClassCount: 2,
+        triumphCount: 0,
+        nextStepCount: 3,
+      },
+      age: {
+        ageType: "AGE_ANTIQUITY",
+        ageProgressPercent: 10,
+      },
+      victories: {
+        rowCount: 2,
+        classes: ["VICTORY_CLASS_CULTURE", "VICTORY_CLASS_SCIENCE"],
+      },
+      warnings: [
+        expect.stringContaining("VictoryManager is module-local"),
+        expect.stringContaining("GameInfo.Triumphs returned no rows"),
+      ],
+    });
+    expect(result.legacyPaths[0]).toMatchObject({
+      classType: "culture",
+      score: 2,
+      finalRequiredPathPoints: 10,
+      progressPercent: 20,
+      nextMilestone: "ANTIQUITY_CULTURE_MILESTONE_1 at 4",
+    });
+    expect(result.nextSteps.map((step) => step.kind)).toEqual([
+      "read-attention-priorities",
+      "inspect-progression-choice",
+      "inspect-victory-progress",
+    ]);
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"command\"");
+    expect(serialized).not.toContain("game play ");
+    expect(serialized).not.toContain("CMD:");
+    expect(serialized).not.toContain("approval");
+  });
+
+  test("uses optional caller player id only as runtime read selection", async () => {
+    const fake = fakeContext(progressDashboardResult({ playerId: 2 }));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.progression.dashboard.current,
+      { playerId: 2 },
+      { context: fake.context },
+    );
+
+    expect(fake.calls.dashboard[0]?.input).toEqual({ playerId: 2 });
+    expect(result.playerId).toBe(2);
+    expect(result.localPlayerId).toBe(0);
+  });
+
+  test("rejects endpoint, session, raw command, and unknown input fields before facade execution", async () => {
+    const fake = fakeContext(progressDashboardResult());
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    for (const input of [
+      { host: "127.0.0.1" },
+      { port: 4318 },
+      { state: { role: "tuner" } },
+      { session: "abc" },
+      { command: "Game.turn" },
+      { rawCommand: "Game.turn" },
+      { approvalReason: "go" },
+    ]) {
+      await expect(
+        client.progression.dashboard.current(input as never),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+      });
+    }
+
+    expect(fake.calls.dashboard).toEqual([]);
+  });
+
+  test("maps direct-control failures to tagged unavailable errors without raw cause text", async () => {
+    const fake = fakeContext(
+      new Error("Timed out waiting for Civ7 tuner response to CMD:65535:Game.turn"),
+    );
+
+    try {
+      await call(
+        Civ7ControlOrpcRouter.progression.dashboard.current,
+        {},
+        { context: fake.context },
+      );
+      throw new Error("expected progression dashboard call to fail");
+    } catch (err) {
+      const serialized = JSON.stringify(err);
+      expect(serialized).toContain("PROGRESSION_DASHBOARD_UNAVAILABLE");
+      expect(serialized).not.toContain("CMD:");
+      expect(serialized).not.toContain("Game.turn");
+    }
+  });
+
+  test("keeps the dashboard leaf under the progression contract and router", () => {
+    expect(Civ7ControlOrpcContract.progression.dashboard.current).toBeDefined();
+    expect(Civ7ControlOrpcRouter.progression.dashboard.current).toBeDefined();
+  });
+});
+
+function fakeContext(
+  dashboard: Civ7ControlOrpcProgressDashboardResult | Error,
+): {
+  calls: {
+    dashboard: Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>;
+  };
+  context: Civ7ControlOrpcContext;
+} {
+  const calls = {
+    dashboard: [] as Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>,
+  };
+
+  return {
+    calls,
+    context: {
+      endpointDefaults: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      directControl: {
+        getCiv7ProgressDashboard: async (input, options) => {
+          calls.dashboard.push({
+            input,
+            options,
+          });
+          if (dashboard instanceof Error) throw dashboard;
+          return dashboard;
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function progressDashboardResult(
+  overrides: Partial<Pick<Civ7ControlOrpcProgressDashboardResult, "playerId">> = {},
+): Civ7ControlOrpcProgressDashboardResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    playerId: overrides.playerId ?? 0,
+    turn: probe(12),
+    turnDate: probe("3200 BCE"),
+    age: {
+      hash: 2077444219,
+      ageType: "AGE_ANTIQUITY",
+      name: "Antiquity Age",
+      chronologyIndex: 0,
+      isFinalAge: probe(false),
+      isSingleAge: probe(false),
+      isExtendedGame: probe(false),
+      isAgeOver: probe(false),
+      currentAgeProgressionPoints: probe(10),
+      maxAgeProgressionPoints: probe(100),
+      primaryAgeProgression: probe(-2084768148),
+    },
+    player: {
+      team: 0,
+      historicalLegacyPointCountForTeam: probe(2),
+    },
+    legacyPaths: [
+      legacyPath("LEGACY_PATH_ANTIQUITY_CULTURE", "LEGACY_PATH_CLASS_CULTURE", 2, 10, 4),
+      legacyPath("LEGACY_PATH_ANTIQUITY_SCIENCE", "LEGACY_PATH_CLASS_SCIENCE", 1, 8, 3),
+    ],
+    victories: {
+      rows: [
+        { victoryType: "VICTORY_CULTURE", victoryClassType: "VICTORY_CLASS_CULTURE", name: "Culture", description: null },
+        { victoryType: "VICTORY_SCIENCE", victoryClassType: "VICTORY_CLASS_SCIENCE", name: "Science", description: null },
+      ],
+    },
+    triumphs: {
+      count: 0,
+      rows: [],
+      source: "runtime-gameinfo",
+    },
+    proof: {
+      victoryManagerGlobal: probe("undefined"),
+      sources: [
+        "GameInfo.LegacyPaths",
+        "player.LegacyPaths.getScore",
+        "GameInfo.AgeProgressionMilestones",
+        "Game.AgeProgressManager",
+        "GameInfo.Victories",
+        "GameInfo.Triumphs",
+      ],
+    },
+    hiddenInfoPolicy: "local-player-runtime-progress",
+    notes: [
+      "Read-only progress dashboard; it does not choose technologies, civics, productions, policies, or victory strategy.",
+    ],
+  };
+}
+
+function legacyPath(
+  legacyPathType: string,
+  legacyPathClassType: string,
+  score: number,
+  finalRequiredPathPoints: number,
+  nextRequired: number,
+): Civ7ControlOrpcProgressDashboardResult["legacyPaths"][number] {
+  return {
+    legacyPathType,
+    legacyPathClassType,
+    ageType: "AGE_ANTIQUITY",
+    name: legacyPathType.replace("LEGACY_PATH_ANTIQUITY_", "Antiquity "),
+    description: null,
+    enabledByDefault: true,
+    enabledForPlayer: null,
+    score: probe(score),
+    finalRequiredPathPoints,
+    nextMilestone: {
+      ageProgressionMilestoneType:
+        `${legacyPathType.replace("LEGACY_PATH_", "")}_MILESTONE_1`,
+      legacyPathType,
+      requiredPathPoints: nextRequired,
+      finalMilestone: false,
+      progressionPoints: probe(5),
+      complete: probe(false),
+      reachedByScore: score >= nextRequired,
+    },
+    milestones: [],
+  };
+}
+
+function probe<T>(value: T): Readonly<{ ok: true; value: T }> {
+  return { ok: true, value };
+}

--- a/packages/civ7-control-orpc/test/progression-traditions-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/progression-traditions-procedure.test.ts
@@ -1,0 +1,288 @@
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+} from "../src/index";
+import type { Civ7ControlOrpcTraditionsViewResult } from "../src/dependencies/direct-control";
+
+describe("progression traditions control-oRPC procedure", () => {
+  test("projects traditions into semantic action descriptors without CLI strings", async () => {
+    const fake = fakeContext(traditionsViewResult());
+
+    const result = await call(
+      Civ7ControlOrpcRouter.progression.traditions.current,
+      {},
+      { context: fake.context },
+    );
+
+    expect(fake.calls.traditions).toEqual([{
+      input: {},
+      options: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+    }]);
+    expect(result).toMatchObject({
+      playerId: 0,
+      sourceStatus: {
+        traditions: "read",
+      },
+      hiddenInfoPolicy: "player-culture-runtime",
+      summary: {
+        activeCount: 1,
+        availableCount: 1,
+        recentUnlockCount: 1,
+        openSlotCount: 0,
+        enabledAvailableCount: 1,
+        disabledAvailableCount: 0,
+        nextStepCount: 1,
+      },
+      government: {
+        type: "GOVERNMENT_CHIEFDOM",
+        name: "Chiefdom",
+      },
+    });
+    expect(result.available[0]).toMatchObject({
+      id: 90243567,
+      name: "Oratory",
+      actions: [{
+        kind: "activate",
+        action: -1326475004,
+        validationSuccess: true,
+        parameters: {
+          traditionType: 90243567,
+          action: -1326475004,
+        },
+      }],
+    });
+    expect(result.nextSteps).toEqual([{
+      kind: "inspect-tradition-change",
+      source: "progression.traditions.current",
+      label: "Inspect available tradition action descriptors before requesting a tradition change.",
+    }]);
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"command\"");
+    expect(serialized).not.toContain("recommendedCli");
+    expect(serialized).not.toContain("game play ");
+    expect(serialized).not.toContain("CMD:");
+    expect(serialized).not.toContain("approval");
+  });
+
+  test("uses optional caller player id only as runtime read selection", async () => {
+    const fake = fakeContext(traditionsViewResult({ playerId: 2 }));
+
+    const result = await call(
+      Civ7ControlOrpcRouter.progression.traditions.current,
+      { playerId: 2 },
+      { context: fake.context },
+    );
+
+    expect(fake.calls.traditions[0]?.input).toEqual({ playerId: 2 });
+    expect(result.playerId).toBe(2);
+  });
+
+  test("rejects endpoint, session, raw command, and unknown input fields before facade execution", async () => {
+    const fake = fakeContext(traditionsViewResult());
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    for (const input of [
+      { host: "127.0.0.1" },
+      { port: 4318 },
+      { state: { role: "tuner" } },
+      { session: "abc" },
+      { command: "Game.turn" },
+      { rawCommand: "Game.turn" },
+      { approvalReason: "go" },
+    ]) {
+      await expect(
+        client.progression.traditions.current(input as never),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+      });
+    }
+
+    expect(fake.calls.traditions).toEqual([]);
+  });
+
+  test("maps direct-control failures to tagged unavailable errors without raw cause text", async () => {
+    const fake = fakeContext(
+      new Error("Timed out waiting for Civ7 tuner response to CMD:65535:Game.turn"),
+    );
+
+    try {
+      await call(
+        Civ7ControlOrpcRouter.progression.traditions.current,
+        {},
+        { context: fake.context },
+      );
+      throw new Error("expected progression traditions call to fail");
+    } catch (err) {
+      const serialized = JSON.stringify(err);
+      expect(serialized).toContain("PROGRESSION_TRADITIONS_UNAVAILABLE");
+      expect(serialized).not.toContain("CMD:");
+      expect(serialized).not.toContain("Game.turn");
+    }
+  });
+
+  test("keeps the traditions leaf under the progression contract and router", () => {
+    expect(Civ7ControlOrpcContract.progression.traditions.current).toBeDefined();
+    expect(Civ7ControlOrpcRouter.progression.traditions.current).toBeDefined();
+  });
+});
+
+function fakeContext(
+  traditions: Civ7ControlOrpcTraditionsViewResult | Error,
+): {
+  calls: {
+    traditions: Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>;
+  };
+  context: Civ7ControlOrpcContext;
+} {
+  const calls = {
+    traditions: [] as Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>,
+  };
+
+  return {
+    calls,
+    context: {
+      endpointDefaults: {
+        host: "127.0.0.1",
+        port: 4318,
+        timeoutMs: 1_000,
+      },
+      directControl: {
+        getCiv7TraditionsView: async (input, options) => {
+          calls.traditions.push({
+            input,
+            options,
+          });
+          if (traditions instanceof Error) throw traditions;
+          return traditions;
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function traditionsViewResult(
+  overrides: Partial<Pick<Civ7ControlOrpcTraditionsViewResult, "playerId">> = {},
+): Civ7ControlOrpcTraditionsViewResult {
+  const activate = -1326475004;
+  const deactivate = 1318334332;
+  const available = tradition({
+    id: 90243567,
+    type: "TRADITION_ORATORY",
+    name: "Oratory",
+    active: false,
+    recentUnlock: true,
+    action: {
+      kind: "activate",
+      action: activate,
+    },
+  });
+  const active = tradition({
+    id: -331546976,
+    type: "TRADITION_HONOR",
+    name: "Honor",
+    active: true,
+    recentUnlock: false,
+    action: {
+      kind: "deactivate",
+      action: deactivate,
+    },
+  });
+
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    playerId: overrides.playerId ?? 0,
+    turn: probe(92),
+    turnDate: probe("1780 BCE"),
+    governmentType: probe(101),
+    government: {
+      type: "GOVERNMENT_CHIEFDOM",
+      name: "Chiefdom",
+    },
+    slots: {
+      total: probe(1),
+      normal: probe(1),
+      crisis: probe(0),
+      active: 1,
+      unlocked: 2,
+      available: 1,
+      open: 0,
+    },
+    actions: {
+      activate,
+      deactivate,
+    },
+    active: [active],
+    available: [available],
+    recentUnlocks: [available],
+    traditions: [active, available],
+    recommendedCli: [
+      `game play change-tradition --player-id 0 --tradition-type 90243567 --action ${activate}`,
+    ],
+    hiddenInfoPolicy: "player-culture-runtime",
+    notes: [
+      "Read-only traditions view; it does not send CHANGE_TRADITION or CONSIDER_ASSIGN_TRADITIONS.",
+    ],
+  };
+}
+
+function tradition(input: Readonly<{
+  id: number;
+  type: string;
+  name: string;
+  active: boolean;
+  recentUnlock: boolean;
+  action: Readonly<{
+    kind: "activate" | "deactivate";
+    action: number;
+  }>;
+}>): Civ7ControlOrpcTraditionsViewResult["traditions"][number] {
+  return {
+    id: input.id,
+    type: input.type,
+    name: input.name,
+    description: "Culture-facing policy.",
+    ageType: null,
+    cultureSlotType: null,
+    traitType: null,
+    isCrisis: false,
+    active: input.active,
+    unlocked: true,
+    recentUnlock: input.recentUnlock,
+    actionHints: [{
+      kind: input.action.kind,
+      action: input.action.action,
+      operationType: "CHANGE_TRADITION",
+      args: {
+        TraditionType: input.id,
+        Action: input.action.action,
+      },
+      validation: probe({ Success: true }),
+      cli: `game play change-tradition --player-id 0 --tradition-type ${input.id} --action ${input.action.action}`,
+    }],
+  };
+}
+
+function probe<T>(value: T): Readonly<{ ok: true; value: T }> {
+  return { ok: true, value };
+}

--- a/packages/civ7-control-orpc/test/strategy-tactical-reads-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/strategy-tactical-reads-procedure.test.ts
@@ -1,0 +1,399 @@
+import { call } from "@orpc/server";
+import { describe, expect, test } from "vitest";
+
+import {
+  Civ7ControlOrpcContract,
+  Civ7ControlOrpcRouter,
+  Civ7StrategyTacticalReadUnavailableError,
+  createCiv7ControlOrpcServerClient,
+  type Civ7ControlOrpcContext,
+} from "../src/index";
+import type {
+  Civ7ControlOrpcDestinationAnalysisResult,
+  Civ7ControlOrpcTargetCandidatesResult,
+} from "../src/dependencies/direct-control";
+
+describe("strategy tactical read control-oRPC procedures", () => {
+  test("projects target candidates into neutral service output without raw runtime samples", async () => {
+    const fake = fakeContext();
+
+    const result = await call(Civ7ControlOrpcRouter.strategy.targetCandidates, {
+      playerId: 0,
+      origins: [{ x: 18, y: 20 }],
+      maxCandidates: 4,
+      maxPlayers: 12,
+      unitRadius: 4,
+    }, { context: fake.context });
+
+    expect(fake.calls.targetCandidates).toEqual([{
+      input: {
+        playerId: 0,
+        origins: [{ x: 18, y: 20 }],
+        maxCandidates: 4,
+        maxPlayers: 12,
+        unitRadius: 4,
+      },
+      options: { host: "127.0.0.1", port: 4318, timeoutMs: 1_000 },
+    }]);
+    expect(result).toMatchObject({
+      playerId: 0,
+      localPlayerId: 0,
+      relationshipLabelPolicy: {
+        relationshipSource: "not-classified",
+        relationshipProof: "none",
+        unprovenLabel: "relationship-unproven",
+      },
+      summary: {
+        candidateCount: 1,
+        nearestDistance: 5,
+        observedOwnerCount: 1,
+        apparentStrengthTotal: 42,
+      },
+    });
+    expect(result.candidates[0]).toMatchObject({
+      owner: 9,
+      relationship: "relationship-unproven",
+      relationshipProof: "none",
+      leaderName: "Independent Power",
+      civilizationName: "Independent",
+      cityCount: 2,
+      unitCount: 4,
+      nearestCityLocation: { x: 13, y: 17 },
+      approach: {
+        routeKind: "land",
+        waterSampleCount: 0,
+        landSampleCount: 6,
+      },
+    });
+    expect(result.nextSteps.map((step) => step.kind)).toEqual([
+      "inspect-candidate",
+      "read-visibility",
+      "validate-unit-action",
+    ]);
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("rawCommand");
+    expect(serialized).not.toContain("cities\":[");
+    expect(serialized).not.toContain("\"nearbyUnits\":[");
+    expectNoRelationshipOverclaim(serialized);
+  });
+
+  test("projects destination analysis into bounded planning output without raw samples", async () => {
+    const fake = fakeContext();
+    const client = createCiv7ControlOrpcServerClient(fake.context);
+
+    const result = await client.strategy.destinationAnalysis({
+      playerId: 0,
+      origin: { x: 20, y: 14 },
+      destination: { x: 13, y: 17 },
+      corridorRadius: 2,
+      destinationRadius: 4,
+    });
+
+    expect(fake.calls.destinationAnalysis).toEqual([{
+      input: {
+        playerId: 0,
+        origin: { x: 20, y: 14 },
+        destination: { x: 13, y: 17 },
+        corridorRadius: 2,
+        destinationRadius: 4,
+      },
+      options: { host: "127.0.0.1", port: 4318, timeoutMs: 1_000 },
+    }]);
+    expect(result).toMatchObject({
+      playerId: 0,
+      localPlayerId: 0,
+      origin: { x: 20, y: 14 },
+      destination: { x: 13, y: 17 },
+      relationshipLabelPolicy: {
+        relationshipSource: "not-classified",
+        relationshipProof: "none",
+        unprovenLabel: "relationship-unproven",
+      },
+      summary: {
+        pointOfInterestCount: 1,
+        corridorUnitCount: 1,
+        destinationUnitCount: 1,
+        destinationCityCount: 1,
+        apparentOtherStrength: 20,
+      },
+      corridor: {
+        routeHint: "straight-line-grid-corridor",
+        directGridDistance: 7,
+        sampleCount: 8,
+        unitCount: 1,
+      },
+      destinationPressure: {
+        unitCount: 1,
+        cityCount: 1,
+        apparentOtherStrength: 20,
+      },
+    });
+    expect(result.nextSteps.map((step) => step.kind)).toEqual([
+      "inspect-destination",
+      "read-visibility",
+      "validate-unit-action",
+    ]);
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"sampledPlots\":[");
+    expect(serialized).not.toContain("\"units\":[");
+    expect(serialized).not.toContain("\"cities\":[");
+    expectNoRelationshipOverclaim(serialized);
+  });
+
+  test("rejects endpoint, session, raw command, and unknown fields before facade execution", async () => {
+    const invalidInputs = [
+      { host: "127.0.0.1" },
+      { port: 4318 },
+      { state: { role: "tuner" } },
+      { session: { state: "App UI" } },
+      { command: "Game.turn" },
+      { rawCommand: "Game.turn" },
+      { approvalReason: "go" },
+    ];
+
+    for (const input of invalidInputs) {
+      const fake = fakeContext();
+      await expect(
+        call(Civ7ControlOrpcRouter.strategy.targetCandidates, input as never, {
+          context: fake.context,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      await expect(
+        call(Civ7ControlOrpcRouter.strategy.destinationAnalysis, {
+          destination: { x: 13, y: 17 },
+          ...input,
+        } as never, { context: fake.context }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      expect(fake.calls).toEqual({
+        targetCandidates: [],
+        destinationAnalysis: [],
+      });
+    }
+  });
+
+  test("maps raw-command-bearing read failures to bounded tagged errors", async () => {
+    const context: Civ7ControlOrpcContext = {
+      directControl: {
+        getCiv7TargetCandidates: async () => {
+          throw new Error(
+            "Timed out waiting for Civ7 tuner response to CMD:1:Game.turn",
+          );
+        },
+        getCiv7DestinationAnalysis: async () => {
+          throw new Error(
+            "Timed out waiting for Civ7 tuner response to CMD:2:Game.turn",
+          );
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    };
+
+    await expect(
+      call(Civ7ControlOrpcRouter.strategy.targetCandidates, {}, { context }),
+    ).rejects.toMatchObject({
+      code: "STRATEGY_TACTICAL_READ_UNAVAILABLE",
+      status: 503,
+      data: {
+        procedureKey: "strategy.targetCandidates",
+        source: "direct-control-facade",
+      },
+    });
+    await expect(
+      call(Civ7ControlOrpcRouter.strategy.destinationAnalysis, {
+        destination: { x: 13, y: 17 },
+      }, { context }),
+    ).rejects.toMatchObject({
+      code: "STRATEGY_TACTICAL_READ_UNAVAILABLE",
+      status: 503,
+      data: {
+        procedureKey: "strategy.destinationAnalysis",
+        source: "direct-control-facade",
+      },
+    });
+
+    try {
+      await call(Civ7ControlOrpcRouter.strategy.targetCandidates, {}, { context });
+    } catch (err) {
+      const serialized = JSON.stringify(err);
+      expect(serialized).not.toContain("CMD:");
+      expect(serialized).not.toContain("Game.turn");
+      expect(serialized).not.toContain("rawCommand");
+      expect(serialized).not.toContain("command-failed");
+    }
+  });
+
+  test("publishes contract-first strategy tactical read leaves", () => {
+    expect(Civ7ControlOrpcContract.strategy.targetCandidates["~orpc"]).toMatchObject({
+      meta: {
+        family: "strategy",
+        procedureKey: "strategy.targetCandidates",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      },
+    });
+    expect(Civ7ControlOrpcContract.strategy.destinationAnalysis["~orpc"]).toMatchObject({
+      meta: {
+        family: "strategy",
+        procedureKey: "strategy.destinationAnalysis",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      },
+    });
+    expect(Civ7ControlOrpcRouter.strategy).toHaveProperty("targetCandidates");
+    expect(Civ7ControlOrpcRouter.strategy).toHaveProperty("destinationAnalysis");
+    expect(
+      Civ7ControlOrpcContract.strategy.targetCandidates["~orpc"].errorMap,
+    ).toHaveProperty("STRATEGY_TACTICAL_READ_UNAVAILABLE");
+    expect(Civ7StrategyTacticalReadUnavailableError.code).toBe(
+      "STRATEGY_TACTICAL_READ_UNAVAILABLE",
+    );
+  });
+});
+
+function fakeContext(): {
+  calls: {
+    targetCandidates: Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>;
+    destinationAnalysis: Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>;
+  };
+  context: Civ7ControlOrpcContext;
+} {
+  const calls = {
+    targetCandidates: [] as Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>,
+    destinationAnalysis: [] as Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>,
+  };
+  return {
+    calls,
+    context: {
+      endpointDefaults: { host: "127.0.0.1", port: 4318, timeoutMs: 1_000 },
+      directControl: {
+        getCiv7TargetCandidates: async (input, options) => {
+          calls.targetCandidates.push({ input, options });
+          return targetCandidatesResult();
+        },
+        getCiv7DestinationAnalysis: async (input, options) => {
+          calls.destinationAnalysis.push({ input, options });
+          return destinationAnalysisResult();
+        },
+      } as Civ7ControlOrpcContext["directControl"],
+    },
+  };
+}
+
+function targetCandidatesResult(): Civ7ControlOrpcTargetCandidatesResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    playerId: 0,
+    origins: [{ x: 18, y: 20 }],
+    unitRadius: 4,
+    hiddenInfoPolicy: "runtime-debug-summary",
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "neutral",
+    },
+    candidates: [{
+      owner: 9,
+      leaderName: { ok: true, value: "Independent Power" },
+      civilizationName: { ok: true, value: "Independent" },
+      isHuman: { ok: true, value: false },
+      cityCount: 2,
+      unitCount: 4,
+      cities: [{ location: { x: 13, y: 17 } }],
+      nearestCity: { location: { x: 13, y: 17 } },
+      nearestDistance: 5,
+      nearbyUnits: [{ location: { x: 13, y: 16 } }],
+      nearbyUnitCount: 4,
+      apparentStrength: 42,
+      approach: {
+        nearestOrigin: { x: 18, y: 20 },
+        targetLocation: { x: 13, y: 17 },
+        directGridDistance: 5,
+        routeHint: "near-low-density",
+        routeKind: "land",
+        originWater: { ok: true, value: false },
+        targetWater: { ok: true, value: false },
+        waterSampleCount: 0,
+        landSampleCount: 6,
+        notes: ["Route kind is a sampled heuristic."],
+      },
+      reasons: ["nearest target distance 5"],
+    }],
+    notes: ["Read-only strategic target shortlist."],
+  };
+}
+
+function destinationAnalysisResult(): Civ7ControlOrpcDestinationAnalysisResult {
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    playerId: 0,
+    origin: { x: 20, y: 14 },
+    destination: { x: 13, y: 17 },
+    corridorRadius: 2,
+    destinationRadius: 4,
+    hiddenInfoPolicy: "runtime-debug-summary",
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "neutral",
+    },
+    corridor: {
+      routeHint: "straight-line-grid-corridor",
+      directGridDistance: 7,
+      sampleCount: 8,
+      sampledPlots: [{ location: { x: 20, y: 14 } }],
+      units: [{ location: { x: 13, y: 17 } }],
+      unitCount: 1,
+    },
+    destinationPressure: {
+      units: [{ location: { x: 13, y: 17 } }],
+      unitCount: 1,
+      cities: [{ location: { x: 13, y: 17 } }],
+      cityCount: 1,
+      apparentOtherStrength: 20,
+    },
+    pointsOfInterest: [{
+      kind: "destination-pressure",
+      severity: "medium",
+      location: { x: 13, y: 17 },
+      summary: "1 other-owner units near destination",
+    }],
+    notes: ["Read-only destination lens."],
+  };
+}
+
+function expectNoRelationshipOverclaim(text: string): void {
+  expect(text).not.toMatch(/\benemy\b/i);
+  expect(text).not.toMatch(/\bhostile\b/i);
+  expect(text).not.toMatch(/\bopponent\b/i);
+  expect(text).not.toMatch(/\bthreat\b/i);
+  expect(text).not.toMatch(/\bwar\b/i);
+  expect(text).not.toMatch(/\bally\b/i);
+  expect(text).not.toMatch(/\bsuzerain\b/i);
+}

--- a/packages/civ7-control-orpc/test/strategy-tactical-reads-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/strategy-tactical-reads-procedure.test.ts
@@ -9,11 +9,96 @@ import {
   type Civ7ControlOrpcContext,
 } from "../src/index";
 import type {
+  Civ7ControlOrpcBattlefieldScanResult,
   Civ7ControlOrpcDestinationAnalysisResult,
   Civ7ControlOrpcTargetCandidatesResult,
 } from "../src/dependencies/direct-control";
 
 describe("strategy tactical read control-oRPC procedures", () => {
+  test("projects battlefield scan into bounded owner and point summaries", async () => {
+    const fake = fakeContext();
+
+    const result = await call(Civ7ControlOrpcRouter.strategy.battlefieldScan, {
+      playerId: 0,
+      origins: [{ x: 17, y: 20 }],
+      radius: 8,
+      maxPlayers: 12,
+      maxUnits: 80,
+      maxCities: 32,
+    }, { context: fake.context });
+
+    expect(fake.calls.battlefieldScan).toEqual([{
+      input: {
+        playerId: 0,
+        origins: [{ x: 17, y: 20 }],
+        radius: 8,
+        maxPlayers: 12,
+        maxUnits: 80,
+        maxCities: 32,
+      },
+      options: { host: "127.0.0.1", port: 4318, timeoutMs: 1_000 },
+    }]);
+    expect(result).toMatchObject({
+      playerId: 0,
+      localPlayerId: 0,
+      origins: [{ x: 17, y: 20 }],
+      radius: 8,
+      relationshipLabelPolicy: {
+        relationshipSource: "not-classified",
+        relationshipProof: "none",
+        unprovenLabel: "relationship-unproven",
+      },
+      summary: {
+        unitCount: 3,
+        cityCount: 1,
+        observedOwnerCount: 2,
+        pointOfInterestCount: 2,
+        apparentStrengthTotal: 30.6,
+      },
+    });
+    expect(result.owners).toEqual([
+      {
+        owner: 0,
+        relationship: "self",
+        relationshipProof: "self",
+        unitCount: 2,
+        cityCount: 0,
+        apparentStrength: 10.6,
+        nearestDistance: 0,
+        roles: { ranged: 1, civilian: 1 },
+      },
+      {
+        owner: 9,
+        relationship: "relationship-unproven",
+        relationshipProof: "none",
+        unitCount: 1,
+        cityCount: 1,
+        apparentStrength: 20,
+        nearestDistance: 4,
+        roles: { melee: 1 },
+      },
+    ]);
+    expect(result.pointsOfInterest[0]).toMatchObject({
+      kind: "civilian-risk",
+      severity: "high",
+      location: { x: 16, y: 18 },
+    });
+    expect(result.nextSteps.map((step) => step.kind)).toEqual([
+      "inspect-battlefield-point",
+      "read-visibility",
+      "validate-unit-action",
+    ]);
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("\"host\"");
+    expect(serialized).not.toContain("\"port\"");
+    expect(serialized).not.toContain("\"state\"");
+    expect(serialized).not.toContain("\"units\":[");
+    expect(serialized).not.toContain("\"cities\":[");
+    expect(serialized).not.toContain("rawCommand");
+    expectNoRelationshipOverclaim(serialized);
+  });
+
   test("projects target candidates into neutral service output without raw runtime samples", async () => {
     const fake = fakeContext();
 
@@ -162,6 +247,11 @@ describe("strategy tactical read control-oRPC procedures", () => {
     for (const input of invalidInputs) {
       const fake = fakeContext();
       await expect(
+        call(Civ7ControlOrpcRouter.strategy.battlefieldScan, input as never, {
+          context: fake.context,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+      await expect(
         call(Civ7ControlOrpcRouter.strategy.targetCandidates, input as never, {
           context: fake.context,
         }),
@@ -173,6 +263,7 @@ describe("strategy tactical read control-oRPC procedures", () => {
         } as never, { context: fake.context }),
       ).rejects.toMatchObject({ code: "BAD_REQUEST" });
       expect(fake.calls).toEqual({
+        battlefieldScan: [],
         targetCandidates: [],
         destinationAnalysis: [],
       });
@@ -182,6 +273,11 @@ describe("strategy tactical read control-oRPC procedures", () => {
   test("maps raw-command-bearing read failures to bounded tagged errors", async () => {
     const context: Civ7ControlOrpcContext = {
       directControl: {
+        getCiv7BattlefieldScan: async () => {
+          throw new Error(
+            "Timed out waiting for Civ7 tuner response to CMD:0:Game.turn",
+          );
+        },
         getCiv7TargetCandidates: async () => {
           throw new Error(
             "Timed out waiting for Civ7 tuner response to CMD:1:Game.turn",
@@ -195,6 +291,16 @@ describe("strategy tactical read control-oRPC procedures", () => {
       } as Civ7ControlOrpcContext["directControl"],
     };
 
+    await expect(
+      call(Civ7ControlOrpcRouter.strategy.battlefieldScan, {}, { context }),
+    ).rejects.toMatchObject({
+      code: "STRATEGY_TACTICAL_READ_UNAVAILABLE",
+      status: 503,
+      data: {
+        procedureKey: "strategy.battlefieldScan",
+        source: "direct-control-facade",
+      },
+    });
     await expect(
       call(Civ7ControlOrpcRouter.strategy.targetCandidates, {}, { context }),
     ).rejects.toMatchObject({
@@ -230,6 +336,14 @@ describe("strategy tactical read control-oRPC procedures", () => {
   });
 
   test("publishes contract-first strategy tactical read leaves", () => {
+    expect(Civ7ControlOrpcContract.strategy.battlefieldScan["~orpc"]).toMatchObject({
+      meta: {
+        family: "strategy",
+        procedureKey: "strategy.battlefieldScan",
+        proofBoundary: "local-package-test",
+        risk: "read-only",
+      },
+    });
     expect(Civ7ControlOrpcContract.strategy.targetCandidates["~orpc"]).toMatchObject({
       meta: {
         family: "strategy",
@@ -246,10 +360,11 @@ describe("strategy tactical read control-oRPC procedures", () => {
         risk: "read-only",
       },
     });
+    expect(Civ7ControlOrpcRouter.strategy).toHaveProperty("battlefieldScan");
     expect(Civ7ControlOrpcRouter.strategy).toHaveProperty("targetCandidates");
     expect(Civ7ControlOrpcRouter.strategy).toHaveProperty("destinationAnalysis");
     expect(
-      Civ7ControlOrpcContract.strategy.targetCandidates["~orpc"].errorMap,
+      Civ7ControlOrpcContract.strategy.battlefieldScan["~orpc"].errorMap,
     ).toHaveProperty("STRATEGY_TACTICAL_READ_UNAVAILABLE");
     expect(Civ7StrategyTacticalReadUnavailableError.code).toBe(
       "STRATEGY_TACTICAL_READ_UNAVAILABLE",
@@ -259,6 +374,10 @@ describe("strategy tactical read control-oRPC procedures", () => {
 
 function fakeContext(): {
   calls: {
+    battlefieldScan: Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>;
     targetCandidates: Array<Readonly<{
       input: unknown;
       options: Civ7ControlOrpcContext["endpointDefaults"];
@@ -271,6 +390,10 @@ function fakeContext(): {
   context: Civ7ControlOrpcContext;
 } {
   const calls = {
+    battlefieldScan: [] as Array<Readonly<{
+      input: unknown;
+      options: Civ7ControlOrpcContext["endpointDefaults"];
+    }>>,
     targetCandidates: [] as Array<Readonly<{
       input: unknown;
       options: Civ7ControlOrpcContext["endpointDefaults"];
@@ -285,6 +408,10 @@ function fakeContext(): {
     context: {
       endpointDefaults: { host: "127.0.0.1", port: 4318, timeoutMs: 1_000 },
       directControl: {
+        getCiv7BattlefieldScan: async (input, options) => {
+          calls.battlefieldScan.push({ input, options });
+          return battlefieldScanResult();
+        },
         getCiv7TargetCandidates: async (input, options) => {
           calls.targetCandidates.push({ input, options });
           return targetCandidatesResult();
@@ -296,6 +423,102 @@ function fakeContext(): {
       } as Civ7ControlOrpcContext["directControl"],
     },
   };
+}
+
+function battlefieldScanResult(): Civ7ControlOrpcBattlefieldScanResult {
+  const friendlyUnit = {
+    owner: 0,
+    relationshipProof: "self",
+    relationshipLabel: "friendly",
+    role: "ranged",
+    location: { x: 17, y: 20 },
+    distance: 0,
+    strength: 9.6,
+  };
+  const civilianUnit = {
+    owner: 0,
+    relationshipProof: "self",
+    relationshipLabel: "friendly",
+    role: "civilian",
+    location: { x: 16, y: 18 },
+    distance: 1,
+    strength: 1,
+  };
+  const otherOwnerUnit = {
+    owner: 9,
+    relationshipProof: "none",
+    relationshipLabel: "relationship-unproven",
+    role: "melee",
+    location: { x: 13, y: 17 },
+    distance: 4,
+    strength: 20,
+  };
+  const city = {
+    owner: 9,
+    relationshipProof: "none",
+    relationshipLabel: "relationship-unproven",
+    location: { x: 13, y: 17 },
+    distance: 4,
+  };
+  return {
+    host: "127.0.0.1",
+    port: 4318,
+    state: { id: "65535", name: "App UI" },
+    localPlayerId: 0,
+    playerId: 0,
+    origins: [{ x: 17, y: 20 }],
+    radius: 8,
+    hiddenInfoPolicy: "runtime-debug-summary",
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "neutral",
+    },
+    units: [friendlyUnit, civilianUnit, otherOwnerUnit],
+    cities: [city],
+    owners: [
+      {
+        owner: 0,
+        relationshipProof: "self",
+        relationshipLabel: "friendly",
+        unitCount: 2,
+        cityCount: 0,
+        roles: { ranged: 1, civilian: 1 },
+        apparentStrength: 10.6,
+        nearestUnit: { distance: 0 },
+        nearestCity: null,
+      },
+      {
+        owner: 9,
+        relationshipProof: "none",
+        relationshipLabel: "relationship-unproven",
+        unitCount: 1,
+        cityCount: 1,
+        roles: { melee: 1 },
+        apparentStrength: 20,
+        nearestUnit: { distance: 4 },
+        nearestCity: { distance: 4 },
+      },
+    ],
+    pointsOfInterest: [
+      {
+        kind: "civilian-risk",
+        severity: "high",
+        location: civilianUnit.location,
+        summary: "friendly civilian has other-owner contact within 4 tiles",
+        units: [civilianUnit],
+      },
+      {
+        kind: "city-front",
+        severity: "medium",
+        location: city.location,
+        summary: "nearest relationship-unproven city in scan radius",
+        cities: [city],
+      },
+    ],
+    notes: ["Read-only battlefield lens."],
+  } as Civ7ControlOrpcBattlefieldScanResult;
 }
 
 function targetCandidatesResult(): Civ7ControlOrpcTargetCandidatesResult {

--- a/packages/cli/src/commands/game/play/battlefield-scan.ts
+++ b/packages/cli/src/commands/game/play/battlefield-scan.ts
@@ -1,12 +1,13 @@
 import { Command, Flags } from '@oclif/core';
-import { getCiv7BattlefieldScan } from '@civ7/direct-control';
+import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import { buildDirectControlOptions, resolveCoordinateFlags } from '../../../utils/game-play-shared';
 
 export default class GamePlayBattlefieldScan extends Command {
   static id = 'game play battlefield-scan';
   static summary = 'Read a tactical battlefield lens around one or more origins';
   static description =
-    'Returns a read-only scan of nearby units, cities, owner pressure, and tactical points of interest. It is a heads-up planning lens, not movement, pathfinding, attack, or war authority.';
+    'Returns a read-only scan of owner contact, apparent strength, and tactical points of interest. It is a heads-up planning lens, not movement, pathfinding, attack, or action authority.';
 
   static examples = [
     '<%= config.bin %> game play battlefield-scan --json',
@@ -74,14 +75,17 @@ export default class GamePlayBattlefieldScan extends Command {
       pairFlag: 'origin',
     });
     const origins = origin ? [origin] : undefined;
-    const view = await getCiv7BattlefieldScan({
+    const view = await createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults: buildDirectControlOptions(flags),
+    }).strategy.battlefieldScan({
       playerId: flags['player-id'],
       origins,
       radius: flags.radius,
       maxPlayers: flags['max-players'],
       maxUnits: flags['max-units'],
       maxCities: flags['max-cities'],
-    }, buildDirectControlOptions(flags));
+    });
 
     if (flags.json) {
       this.log(JSON.stringify({ ok: true, view }));
@@ -93,7 +97,7 @@ export default class GamePlayBattlefieldScan extends Command {
     for (const point of asArray(view.pointsOfInterest)) {
       this.log(`- ${formatValue(point)}`);
     }
-    for (const owner of asArray(view.owners).slice(0, 8)) {
+    for (const owner of view.owners.slice(0, 8)) {
       this.log(`owner: ${formatValue(owner)}`);
     }
     for (const note of view.notes) this.log(`Note: ${note}`);

--- a/packages/cli/src/commands/game/play/destination-analysis.ts
+++ b/packages/cli/src/commands/game/play/destination-analysis.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from '@oclif/core';
-import { getCiv7DestinationAnalysis } from '@civ7/direct-control';
+import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import { buildDirectControlOptions, resolveCoordinateFlags } from '../../../utils/game-play-shared';
 
 export default class GamePlayDestinationAnalysis extends Command {
@@ -100,7 +101,10 @@ export default class GamePlayDestinationAnalysis extends Command {
       required: true,
     });
     if (!destination) throw new Error('provide --destination or --to-x and --to-y');
-    const view = await getCiv7DestinationAnalysis({
+    const view = await createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults: buildDirectControlOptions(flags),
+    }).strategy.destinationAnalysis({
       playerId: flags['player-id'],
       origin,
       destination,
@@ -109,7 +113,7 @@ export default class GamePlayDestinationAnalysis extends Command {
       maxPlayers: flags['max-players'],
       maxUnits: flags['max-units'],
       maxCities: flags['max-cities'],
-    }, buildDirectControlOptions(flags));
+    });
 
     if (flags.json) {
       this.log(JSON.stringify({ ok: true, view }));

--- a/packages/cli/src/commands/game/play/progress-dashboard.ts
+++ b/packages/cli/src/commands/game/play/progress-dashboard.ts
@@ -1,9 +1,12 @@
 import { Command, Flags } from '@oclif/core';
-import { getCiv7ProgressDashboard } from '@civ7/direct-control';
+import {
+  createCiv7ControlOrpcServerClient,
+  type Civ7ProgressionDashboardResult,
+} from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import { buildDirectControlOptions } from '../../../utils/game-play-shared';
 
 type Probe<T = unknown> = { ok: true; value: T } | { ok: false; error: string };
-type ProgressDashboardView = Awaited<ReturnType<typeof getCiv7ProgressDashboard>>;
 
 export default class GamePlayProgressDashboard extends Command {
   static id = 'game play progress-dashboard';
@@ -43,156 +46,75 @@ export default class GamePlayProgressDashboard extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(GamePlayProgressDashboard);
-    const view = await getCiv7ProgressDashboard({
+    const view = await createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults: buildDirectControlOptions(flags),
+    }).progression.dashboard.current({
       playerId: flags['player-id'],
-    }, buildDirectControlOptions(flags));
+    });
 
     if (flags.json) {
       this.log(JSON.stringify(flags.compact ? buildCompactView(view) : { ok: true, view }));
       return;
     }
 
-    this.log(buildSummary(view));
-    for (const path of compactLegacyPaths(view)) {
+    this.log(view.summary.headline);
+    for (const path of view.legacyPaths) {
       this.log(`- ${path.classType}: ${path.score}/${path.finalRequiredPathPoints ?? '?'} ${path.legacyPathType}`);
       if (path.nextMilestone) this.log(`  next: ${path.nextMilestone}`);
     }
   }
 }
 
-function buildCompactView(view: ProgressDashboardView): {
+function buildCompactView(view: Civ7ProgressionDashboardResult): {
   ok: true;
   contractVersion: 'play-agent-v0';
   command: 'game play progress-dashboard';
   summary: string;
   turn: Probe;
   turnDate: Probe;
-  age: Record<string, unknown>;
-  player: Record<string, unknown>;
-  legacyPaths: ReturnType<typeof compactLegacyPaths>;
-  victories: Record<string, unknown>;
-  triumphs: Record<string, unknown>;
+  age: Civ7ProgressionDashboardResult['age'];
+  player: Civ7ProgressionDashboardResult['player'];
+  legacyPaths: Civ7ProgressionDashboardResult['legacyPaths'];
+  victories: Civ7ProgressionDashboardResult['victories'];
+  triumphs: Civ7ProgressionDashboardResult['triumphs'];
   next: string | null;
+  nextSteps: Civ7ProgressionDashboardResult['nextSteps'];
   warnings: string[];
   omitted: Array<{ path: string; reason: string }>;
-  hiddenInfoPolicy: ProgressDashboardView['hiddenInfoPolicy'];
-  proof: ProgressDashboardView['proof'];
+  hiddenInfoPolicy: Civ7ProgressionDashboardResult['hiddenInfoPolicy'];
+  proof: Civ7ProgressionDashboardResult['proof'];
 } {
-  const legacyPaths = compactLegacyPaths(view);
-  const warnings = [
-    probeValue(view.proof.victoryManagerGlobal) === 'undefined'
-      ? 'VictoryManager is module-local in the official UI; this command uses exposed lower-level legacy and age-progress APIs.'
-      : null,
-    view.triumphs.count === 0
-      ? 'Runtime GameInfo.Triumphs returned no rows; do not infer that all reward systems are absent.'
-      : null,
-  ].filter((warning): warning is string => Boolean(warning));
-
   return {
     ok: true,
     contractVersion: 'play-agent-v0',
     command: 'game play progress-dashboard',
-    summary: buildSummary(view),
+    summary: view.summary.headline,
     turn: view.turn,
     turnDate: view.turnDate,
-    age: {
-      ageType: view.age.ageType,
-      name: view.age.name,
-      chronologyIndex: view.age.chronologyIndex,
-      currentAgeProgressionPoints: view.age.currentAgeProgressionPoints,
-      maxAgeProgressionPoints: view.age.maxAgeProgressionPoints,
-      ageProgressPercent: ratioPercent(
-        probeValue(view.age.currentAgeProgressionPoints),
-        probeValue(view.age.maxAgeProgressionPoints),
-      ),
-      isFinalAge: view.age.isFinalAge,
-      isAgeOver: view.age.isAgeOver,
-    },
-    player: {
-      playerId: view.playerId,
-      team: view.player.team,
-      historicalLegacyPointCountForTeam: view.player.historicalLegacyPointCountForTeam,
-    },
-    legacyPaths,
-    victories: {
-      rowCount: view.victories.rows.length,
-      classes: uniqueStrings(view.victories.rows.map((row) => stringField(row, 'victoryClassType'))),
-    },
+    age: view.age,
+    player: view.player,
+    legacyPaths: view.legacyPaths,
+    victories: view.victories,
     triumphs: {
       count: view.triumphs.count,
       source: view.triumphs.source,
-      rows: view.triumphs.rows.slice(0, 8),
+      rows: view.triumphs.rows,
     },
-    next: 'game play priorities --compact --json',
-    warnings,
-    omitted: [
-      { path: 'view.legacyPaths[].milestones', reason: 'use --json without --compact for all milestone probe details' },
-      { path: 'view.victories.rows', reason: 'use --json without --compact for victory row details' },
-      { path: 'view.triumphs.rows', reason: 'compact output includes only the first 8 triumph rows' },
-    ],
+    next: cliCommandForNextStep(view.nextSteps[0]?.kind ?? null),
+    nextSteps: view.nextSteps,
+    warnings: view.warnings,
+    omitted: view.omitted,
     hiddenInfoPolicy: view.hiddenInfoPolicy,
     proof: view.proof,
   };
 }
 
-function compactLegacyPaths(view: ProgressDashboardView): Array<{
-  legacyPathType: string | null;
-  classType: string | null;
-  name: string | null;
-  score: number | null;
-  finalRequiredPathPoints: number | null;
-  progressPercent: number | null;
-  nextMilestone: string | null;
-  enabledForPlayer: boolean | null;
-}> {
-  return view.legacyPaths.map((path) => {
-    const score = probeValue(path.score);
-    const nextMilestone = path.nextMilestone && typeof path.nextMilestone === 'object'
-      ? path.nextMilestone as Record<string, unknown>
-      : null;
-    return {
-      legacyPathType: path.legacyPathType,
-      classType: shortClass(path.legacyPathClassType),
-      name: path.name,
-      score: typeof score === 'number' ? score : null,
-      finalRequiredPathPoints: path.finalRequiredPathPoints,
-      progressPercent: ratioPercent(score, path.finalRequiredPathPoints),
-      nextMilestone: typeof nextMilestone?.ageProgressionMilestoneType === 'string'
-        ? `${nextMilestone.ageProgressionMilestoneType} at ${nextMilestone.requiredPathPoints ?? '?'}`
-        : null,
-      enabledForPlayer: path.enabledForPlayer,
-    };
-  });
-}
-
-function buildSummary(view: ProgressDashboardView): string {
-  const ageType = view.age.ageType ?? 'unknown age';
-  const pathSummary = compactLegacyPaths(view)
-    .map((path) => `${path.classType ?? path.legacyPathType}: ${path.score ?? '?'}/${path.finalRequiredPathPoints ?? '?'}`)
-    .join(', ');
-  return `${ageType} progress: ${pathSummary || 'no current-age legacy paths surfaced'}`;
-}
-
-function probeValue<T>(probe: Probe<T> | null | undefined): T | null {
-  return probe?.ok ? probe.value : null;
-}
-
-function ratioPercent(current: unknown, total: unknown): number | null {
-  return typeof current === 'number' && typeof total === 'number' && total > 0
-    ? Math.round((current / total) * 1000) / 10
-    : null;
-}
-
-function shortClass(value: string | null): string | null {
-  return value?.replace(/^LEGACY_PATH_CLASS_/, '').toLowerCase() ?? null;
-}
-
-function stringField(value: unknown, key: string): string | null {
-  return value && typeof value === 'object' && typeof (value as Record<string, unknown>)[key] === 'string'
-    ? (value as Record<string, string>)[key]
-    : null;
-}
-
-function uniqueStrings(values: ReadonlyArray<string | null>): string[] {
-  return [...new Set(values.filter((value): value is string => Boolean(value)))];
+function cliCommandForNextStep(
+  kind: Civ7ProgressionDashboardResult['nextSteps'][number]['kind'] | null,
+): string | null {
+  if (kind === 'read-attention-priorities') {
+    return 'game play priorities --compact --json';
+  }
+  return null;
 }

--- a/packages/cli/src/commands/game/play/target-candidates.ts
+++ b/packages/cli/src/commands/game/play/target-candidates.ts
@@ -1,12 +1,13 @@
 import { Command, Flags } from '@oclif/core';
-import { getCiv7TargetCandidates } from '@civ7/direct-control';
+import { createCiv7ControlOrpcServerClient } from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import { buildDirectControlOptions, resolveCoordinateFlags } from '../../../utils/game-play-shared';
 
 export default class GamePlayTargetCandidates extends Command {
   static id = 'game play target-candidates';
   static summary = 'Read strategic target candidates from live city and unit summaries';
   static description =
-    'Returns a read-only shortlist of other-owner contacts ranked from a supplied siege/formation origin. It is planning support, not relationship, movement, diplomacy, or war authority.';
+    'Returns a read-only shortlist of other-owner contacts ranked from a supplied siege/formation origin. It is planning support, not relationship, movement, diplomacy, or action authority.';
 
   static examples = [
     '<%= config.bin %> game play target-candidates --json',
@@ -68,13 +69,16 @@ export default class GamePlayTargetCandidates extends Command {
       pairFlag: 'origin',
     });
     const origins = origin ? [origin] : undefined;
-    const view = await getCiv7TargetCandidates({
+    const view = await createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults: buildDirectControlOptions(flags),
+    }).strategy.targetCandidates({
       playerId: flags['player-id'],
       origins,
       maxCandidates: flags['max-candidates'],
       maxPlayers: flags['max-players'],
       unitRadius: flags['unit-radius'],
-    }, buildDirectControlOptions(flags));
+    });
 
     if (flags.json) {
       this.log(JSON.stringify({ ok: true, view }));
@@ -85,18 +89,12 @@ export default class GamePlayTargetCandidates extends Command {
     this.log(`Hidden info policy: ${view.hiddenInfoPolicy}`);
     for (const candidate of view.candidates) {
       this.log(`- owner ${candidate.owner}: distance=${candidate.nearestDistance ?? '<unknown>'}; cities=${candidate.cityCount}; units=${candidate.unitCount}; nearby=${candidate.nearbyUnitCount}; strength=${candidate.apparentStrength}`);
-      this.log(`  civ=${formatProbe(candidate.civilizationName)} leader=${formatProbe(candidate.leaderName)} route=${candidate.approach.routeHint} kind=${candidate.approach.routeKind ?? '<unknown>'}`);
-      this.log(`  nearest=${formatValue(candidate.nearestCity)}`);
-      this.log(`  settlements=${formatValue(candidate.cities)}`);
+      this.log(`  civ=${candidate.civilizationName ?? '<unknown>'} leader=${candidate.leaderName ?? '<unknown>'} route=${candidate.approach.routeHint} kind=${candidate.approach.routeKind ?? '<unknown>'}`);
+      this.log(`  nearest=${formatValue(candidate.nearestCityLocation)}`);
       if (candidate.reasons.length > 0) this.log(`  reasons=${candidate.reasons.join('; ')}`);
     }
     for (const note of view.notes) this.log(`Note: ${note}`);
   }
-}
-
-function formatProbe<T>(probe: { ok: true; value: T } | { ok: false; error: string }): string {
-  if (!probe.ok) return `<error: ${probe.error}>`;
-  return formatValue(probe.value);
 }
 
 function formatValue(value: unknown): string {

--- a/packages/cli/src/commands/game/play/traditions.ts
+++ b/packages/cli/src/commands/game/play/traditions.ts
@@ -1,5 +1,9 @@
 import { Command, Flags } from '@oclif/core';
-import { getCiv7TraditionsView } from '@civ7/direct-control';
+import {
+  createCiv7ControlOrpcServerClient,
+  type Civ7ProgressionTraditionsResult,
+} from '@civ7/control-orpc';
+import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import { buildDirectControlOptions } from '../../../utils/game-play-shared';
 
 export default class GamePlayTraditions extends Command {
@@ -39,9 +43,12 @@ export default class GamePlayTraditions extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(GamePlayTraditions);
-    const view = await getCiv7TraditionsView({
+    const view = await createCiv7ControlOrpcServerClient({
+      directControl: liveCiv7ControlOrpcDirectControlFacade,
+      endpointDefaults: buildDirectControlOptions(flags),
+    }).progression.traditions.current({
       playerId: flags['player-id'],
-    }, buildDirectControlOptions(flags));
+    });
 
     if (flags.json) {
       this.log(JSON.stringify(flags.compact ? buildCompactTraditionsView(view) : { ok: true, view }));
@@ -62,12 +69,12 @@ export default class GamePlayTraditions extends Command {
       this.log('Available:');
       for (const tradition of view.available) this.log(`- ${formatTradition(tradition)}`);
     }
-    for (const command of view.recommendedCli) this.log(`Next: ${command}`);
+    for (const step of view.nextSteps) this.log(`Next: ${step.label}`);
     for (const note of view.notes) this.log(`Note: ${note}`);
   }
 }
 
-function buildCompactTraditionsView(view: Awaited<ReturnType<typeof getCiv7TraditionsView>>): {
+function buildCompactTraditionsView(view: Civ7ProgressionTraditionsResult): {
   ok: true;
   contractVersion: 'play-agent-v0';
   command: 'game play traditions';
@@ -83,13 +90,26 @@ function buildCompactTraditionsView(view: Awaited<ReturnType<typeof getCiv7Tradi
   enabledAvailableCount: number;
   disabledAvailableCount: number;
   recommendedCli: ReadonlyArray<string>;
+  nextSteps: Civ7ProgressionTraditionsResult['nextSteps'];
   omitted: Array<{ path: string; reason: string }>;
   hiddenInfoPolicy: unknown;
   notes: ReadonlyArray<string>;
 } {
-  const active = view.active.map((tradition) => compactTraditionRow(tradition, { sendCloseout: false }));
-  const available = view.available.map((tradition) => compactTraditionRow(tradition, { sendCloseout: true }));
-  const recentUnlocks = view.recentUnlocks.map((tradition) => compactTraditionRow(tradition, { sendCloseout: true }));
+  const active = view.active.map((tradition) =>
+    compactTraditionRow(tradition, {
+      playerId: view.playerId,
+      sendCloseout: false,
+    }));
+  const available = view.available.map((tradition) =>
+    compactTraditionRow(tradition, {
+      playerId: view.playerId,
+      sendCloseout: true,
+    }));
+  const recentUnlocks = view.recentUnlocks.map((tradition) =>
+    compactTraditionRow(tradition, {
+      playerId: view.playerId,
+      sendCloseout: true,
+    }));
   return {
     ok: true,
     contractVersion: 'play-agent-v0',
@@ -105,12 +125,11 @@ function buildCompactTraditionsView(view: Awaited<ReturnType<typeof getCiv7Tradi
     recentUnlocks,
     enabledAvailableCount: available.filter((tradition) => tradition.validationSuccess === true).length,
     disabledAvailableCount: available.filter((tradition) => tradition.validationSuccess !== true).length,
-    recommendedCli: view.recommendedCli,
-    omitted: [
-      { path: 'view.traditions', reason: 'use game play traditions --json for the full active/unlocked/recent tradition packet' },
-      { path: 'tradition.actionHints[].validation', reason: 'compact rows expose validationSuccess only; use the full packet for raw validation evidence' },
-      { path: 'tradition.description', reason: 'compact rows keep names and action templates; use the full packet for localized descriptions' },
-    ],
+    recommendedCli: available
+      .map((tradition) => tradition.validateCli)
+      .filter((command): command is string => Boolean(command)),
+    nextSteps: view.nextSteps,
+    omitted: view.omitted,
     hiddenInfoPolicy: view.hiddenInfoPolicy,
     notes: [
       'Read-only compact tradition option surface. It does not choose or send CHANGE_TRADITION.',
@@ -121,12 +140,20 @@ function buildCompactTraditionsView(view: Awaited<ReturnType<typeof getCiv7Tradi
 }
 
 function compactTraditionRow(
-  tradition: Awaited<ReturnType<typeof getCiv7TraditionsView>>['traditions'][number],
-  options: { sendCloseout: boolean },
+  tradition: Civ7ProgressionTraditionsResult['traditions'][number],
+  options: { playerId: number; sendCloseout: boolean },
 ): Record<string, unknown> {
-  const action = tradition.actionHints[0];
-  const validationSuccess = action?.validation?.ok === true
-    && (action.validation.value as { Success?: unknown } | undefined)?.Success === true;
+  const action = tradition.actions[0];
+  const sendCli = action
+    ? traditionChangeCli(action.parameters.traditionType, action.parameters.action)
+    : null;
+  const validateCli = action
+    ? traditionValidationCli(
+        options.playerId,
+        action.parameters.traditionType,
+        action.parameters.action,
+      )
+    : null;
   return {
     id: tradition.id,
     type: tradition.type,
@@ -140,12 +167,11 @@ function compactTraditionRow(
     recentUnlock: tradition.recentUnlock,
     actionKind: action?.kind ?? null,
     action: action?.action ?? null,
-    operationType: action?.operationType ?? null,
-    validationSuccess,
-    validateCli: action?.cli ? `${action.cli} --json` : null,
-    sendCli: action?.cli ? `${action.cli} --send` : null,
-    sendCloseoutCli: options.sendCloseout && action?.cli
-      ? `${action.cli} --send --closeout`
+    validationSuccess: action?.validationSuccess ?? null,
+    validateCli: validateCli ? `${validateCli} --json` : null,
+    sendCli: sendCli ? `${sendCli} --send` : null,
+    sendCloseoutCli: options.sendCloseout && sendCli
+      ? `${sendCli} --send --closeout`
       : null,
   };
 }
@@ -155,10 +181,10 @@ function formatTradition(tradition: {
   type: string | null;
   name: string | null;
   description: string | null;
-  actionHints: ReadonlyArray<{ kind: string; action: number | null; validation: { ok: boolean; value?: unknown; error?: string } }>;
+  actions: ReadonlyArray<{ kind: string; action: number | null; validationSuccess: boolean | null }>;
 }): string {
-  const action = tradition.actionHints[0];
-  const validation = action ? formatValidation(action.validation) : 'no action';
+  const action = tradition.actions[0];
+  const validation = action ? String(action.validationSuccess) : 'no action';
   return `${tradition.name ?? tradition.type ?? tradition.id} (${tradition.id}) ${action?.kind ?? ''}=${action?.action ?? '<none>'}; validation=${validation}${tradition.description ? `; ${tradition.description}` : ''}`;
 }
 
@@ -167,11 +193,19 @@ function formatProbe<T>(probe: { ok: true; value: T } | { ok: false; error: stri
   return String(probe.value);
 }
 
-function formatValidation(validation: { ok: boolean; value?: unknown; error?: string }): string {
-  if (!validation.ok) return `<error: ${validation.error ?? 'unknown'}>`;
-  const value = validation.value;
-  if (value && typeof value === 'object' && 'Success' in value) {
-    return String((value as { Success?: unknown }).Success);
-  }
-  return JSON.stringify(value);
+function traditionChangeCli(
+  traditionType: number,
+  action: number | null,
+): string | null {
+  if (action == null) return null;
+  return `game play change-tradition --tradition-type ${traditionType} --action ${action}`;
+}
+
+function traditionValidationCli(
+  playerId: number,
+  traditionType: number,
+  action: number | null,
+): string | null {
+  if (action == null) return null;
+  return `game play change-tradition --player-id ${playerId} --tradition-type ${traditionType} --action ${action}`;
 }

--- a/packages/cli/test/commands/game.play.progression-read.test.ts
+++ b/packages/cli/test/commands/game.play.progression-read.test.ts
@@ -134,6 +134,8 @@ describe('game play progression reads', () => {
         legacyPaths: Array<{ classType: string; score: number; finalRequiredPathPoints: number; progressPercent: number; nextMilestone: string }>;
         triumphs: { count: number };
         proof: { sources: string[] };
+        next: string | null;
+        nextSteps: Array<{ kind: string; label: string }>;
         warnings: string[];
         omitted: Array<{ path: string }>;
         view?: unknown;
@@ -149,8 +151,11 @@ describe('game play progression reads', () => {
       expect(payload.legacyPaths.find((path) => path.classType === 'science')?.progressPercent).toBe(10);
       expect(payload.triumphs.count).toBe(0);
       expect(payload.proof.sources).toContain('player.LegacyPaths.getScore');
+      expect(payload.next).toBe('game play priorities --compact --json');
+      expect(payload.nextSteps[0].kind).toBe('read-attention-priorities');
+      expect(JSON.stringify(payload.nextSteps)).not.toContain('game play ');
       expect(payload.warnings.join(' ')).toContain('VictoryManager is module-local');
-      expect(payload.omitted.some((item) => item.path === 'view.legacyPaths[].milestones')).toBe(true);
+      expect(payload.omitted.some((item) => item.path === 'dashboard.legacyPaths[].milestones')).toBe(true);
       expect(payload.view).toBeUndefined();
       expect(server.received.some((message) => message.includes('readProgressDashboard'))).toBe(true);
       expect(server.received.some((message) => message.includes('getHistoricalLegacyPointCountForTeam'))).toBe(true);

--- a/packages/cli/test/commands/game.play.progression-read.test.ts
+++ b/packages/cli/test/commands/game.play.progression-read.test.ts
@@ -33,8 +33,8 @@ describe('game play progression reads', () => {
           slots: { active: number; available: number };
           actions: { activate: number; deactivate: number };
           active: Array<{ id: number; name: string }>;
-          available: Array<{ id: number; actionHints: Array<{ cli: string }> }>;
-          recommendedCli: string[];
+          available: Array<{ id: number; actions: Array<{ kind: string; parameters: { traditionType: number; action: number } }> }>;
+          recommendedCli?: unknown;
         };
       };
       expectNormalPlayPayloadToOmitDebugInternals(payload);
@@ -43,8 +43,15 @@ describe('game play progression reads', () => {
       expect(payload.view.actions.activate).toBe(-1326475004);
       expect(payload.view.actions.deactivate).toBe(1318334332);
       expect(payload.view.active[0].name).toBe('Honor');
-      expect(payload.view.available[0].actionHints[0].cli).toContain('game play change-tradition');
-      expect(payload.view.recommendedCli[0]).toContain('--tradition-type 90243567');
+      expect(payload.view.available[0].actions[0]).toMatchObject({
+        kind: 'activate',
+        parameters: {
+          traditionType: 90243567,
+          action: -1326475004,
+        },
+      });
+      expect(payload.view.recommendedCli).toBeUndefined();
+      expect(JSON.stringify(payload.view)).not.toContain('game play change-tradition');
       expect(server.received.some((message) => message.includes('readTraditionsView'))).toBe(true);
     } finally {
       await server.close();
@@ -94,10 +101,11 @@ describe('game play progression reads', () => {
         validationSuccess: true,
       });
       expect(payload.available[0].validateCli).toContain('game play change-tradition --player-id 0 --tradition-type 90243567 --action -1326475004 --json');
-      expect(payload.available[0].sendCloseoutCli).toContain('game play change-tradition --player-id 0 --tradition-type 90243567 --action -1326475004 --send --closeout');
+      expect(payload.available[0].sendCloseoutCli).toContain('game play change-tradition --tradition-type 90243567 --action -1326475004 --send --closeout');
       expect(payload.enabledAvailableCount).toBe(1);
       expect(payload.disabledAvailableCount).toBe(0);
-      expect(payload.omitted.map((item) => item.path)).toContain('view.traditions');
+      expect(payload.omitted.map((item) => item.path)).toContain('directControl.cliCommandSuggestions');
+      expect(payload.omitted.map((item) => item.path)).toContain('tradition.actionHints[].cli');
       expect(payload.omitted.map((item) => item.path)).toContain('tradition.actionHints[].validation');
       expect(server.received.some((message) => message.includes('readTraditionsView'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);

--- a/packages/cli/test/commands/game.play.tactical-read.test.ts
+++ b/packages/cli/test/commands/game.play.tactical-read.test.ts
@@ -52,16 +52,19 @@ describe('game play tactical read commands', () => {
         ok: true;
         view: {
           candidates: Array<{
-            cities: unknown[];
+            nearestCityLocation: { x: number; y: number } | null;
             approach: { routeKind: string; waterSampleCount: number; landSampleCount: number };
           }>;
+          omitted: Array<{ path: string; reason: string }>;
         };
       };
 
-      expect(payload.view.candidates[0]?.cities).toHaveLength(2);
+      expect(payload.view.candidates[0]?.nearestCityLocation).toEqual({ x: 13, y: 17 });
       expect(payload.view.candidates[0]?.approach.routeKind).toBe('land');
       expect(payload.view.candidates[0]?.approach.waterSampleCount).toBe(0);
       expect(payload.view.candidates[0]?.approach.landSampleCount).toBeGreaterThan(0);
+      expect(payload.view.omitted.map((item) => item.path)).toContain('candidate.cities');
+      expect(JSON.stringify(payload.view)).not.toContain('"nearbyUnits":[');
       expect(server.received.some((message) => message.includes('readTargetCandidates'))).toBe(true);
       expect(server.received.some((message) => message.includes('"origins":[{"x":18,"y":20}]'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendRequest'))).toBe(false);
@@ -120,6 +123,7 @@ describe('game play tactical read commands', () => {
         ok: true;
         view: {
           pointsOfInterest: Array<{ summary?: string; kind?: string }>;
+          omitted: Array<{ path: string; reason: string }>;
         };
       };
 
@@ -212,6 +216,12 @@ describe('game play tactical read commands', () => {
         unprovenLabel: 'relationship-unproven',
       });
       expectPositiveRelationshipLabels(payload.view.pointsOfInterest.map((item) => `${item.kind ?? ''}: ${item.summary ?? ''}`));
+      expect(payload.view.omitted.map((item) => item.path)).toEqual(expect.arrayContaining([
+        'corridor.sampledPlots',
+        'destinationPressure.units',
+        'destinationPressure.cities',
+      ]));
+      expect(JSON.stringify(payload.view)).not.toContain('"sampledPlots":[');
       expect(server.received.some((message) => message.includes('readDestinationAnalysis'))).toBe(true);
       expect(server.received.some((message) => message.includes('relationshipLabelPolicy: scan.relationshipLabelPolicy'))).toBe(true);
       expect(server.received.some((message) => message.includes('"origin":{"x":20,"y":14}'))).toBe(true);
@@ -259,11 +269,11 @@ async function startTacticalReadTunerServer(): Promise<FakeTunerServer> {
       if (message.includes('readTargetCandidates')) {
         return [JSON.stringify(targetCandidatesView())];
       }
-      if (message.includes('readBattlefieldScan')) {
-        return [JSON.stringify(battlefieldScanView())];
-      }
       if (message.includes('readDestinationAnalysis')) {
         return [JSON.stringify(destinationAnalysisView())];
+      }
+      if (message.includes('readBattlefieldScan')) {
+        return [JSON.stringify(battlefieldScanView())];
       }
       return undefined;
     },


### PR DESCRIPTION
feat(cli): route progress dashboard through progression service

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds progression.dashboard.current under the native progression router and moves the summary-first progress dashboard projection out of the CLI. The service composes the direct-control progress dashboard runtime port into semantic progress output: compact legacy path progress, warnings, omitted-detail policy, proof source summary, and caller-neutral next-step descriptors.

Routes civ7 game play progress-dashboard through the in-process control-oRPC server-side client. CLI compact output keeps CLI-local presentation such as command name and mapped next command, while the service contract itself does not emit literal game play command strings.

Normal service and CLI output omit raw host/port/state/session/command/rawCommand data, direct-control runtime envelopes, transport details, and approval/reason mechanics. Game-UI/controller progress dashboard support remains unsupported in this slice.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/progression-dashboard-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd packages/cli test -- game.play.progression-read.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- private procedure-schema export scan
- active approval/caller-permission scan
- service-output CLI-string scan
- raw runtime output scan
- git diff --check

Local package and CLI proof only; no deployed Civ7 runtime proof, play-thread action, game-UI/controller bridge support, transport expansion, broad read-wrapper revival, approval/reason mechanics, or parent Task 5.x/6.x/7.x acceptance.

feat(cli): route traditions through progression service

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds progression.traditions.current under the native progression router and moves the traditions option projection out of the CLI. The service composes the direct-control traditions runtime port into semantic tradition rows, action descriptors, validation-success projection, omitted-detail policy, and caller-neutral next-step descriptors.

Routes civ7 game play traditions through the in-process control-oRPC server-side client. CLI compact output keeps CLI-local helper strings such as validateCli, sendCli, and sendCloseoutCli, generated from service descriptors, while the service contract itself does not emit direct-control recommendedCli, actionHints[].cli, or literal game play command strings.

Normal service and CLI output omit raw host/port/state/session/command/rawCommand data, direct-control runtime envelopes, transport details, and approval/reason mechanics. Game-UI/controller traditions support remains unsupported in this slice.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/progression-traditions-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd packages/cli test -- game.play.progression-read.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- private procedure-schema export scan
- active approval/caller-permission scan
- service-output CLI-string scan
- raw runtime output scan
- git diff --check

Local package and CLI proof only; no deployed Civ7 runtime proof, play-thread action, game-UI/controller bridge support, transport expansion, broad read-wrapper revival, approval/reason mechanics, or parent Task 5.x/6.x/7.x acceptance.

feat(cli): route strategy tactical reads through orpc

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds strategy.targetCandidates and strategy.destinationAnalysis under the native strategy router. The procedures compose direct-control tactical runtime/read ports through oRPC context, then project bounded planning summaries, relationship-unproven policy, omitted raw-sample records, and semantic next-step descriptors.

Routes civ7 game play target-candidates and civ7 game play destination-analysis through the in-process control-oRPC server-side client. The CLI builds endpoint context and prints the service projection; raw direct-control host/port/state/session envelopes, city/unit/plot sample arrays, and transport details stay out of normal output.

Relationship wording remains neutral: owner mismatch, contact, proximity, ranking, and action legality do not become official diplomatic labels. This slice does not add controller bridge allowlisting, transport expansion, action-send authority, approval/reason mechanics, runtime proof, or parent Task 5.x/6.x/7.x acceptance.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/strategy-tactical-reads-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd packages/cli test -- game.play.tactical-read.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- private procedure-schema export scan
- active approval/caller-permission scan
- service-output CLI-string scan
- raw runtime output scan
- relationship-label scan
- git diff --check

Local package and CLI proof only; no deployed Civ7 runtime proof, play-thread action, game-UI/controller bridge support, transport expansion, broad strategy catalog support, approval/reason mechanics, or relationship labels beyond official evidence.

feat(cli): route battlefield scan through strategy service

Refs: openspec/changes/civ7-control-orpc-native-slice

Adds strategy.battlefieldScan to the native strategy tactical-read service family. The procedure composes the direct-control battlefield runtime port through oRPC context, then projects bounded owner summaries, points of interest, omitted raw-sample records, neutral relationship policy, and semantic next-step descriptors.

Routes civ7 game play battlefield-scan through the in-process control-oRPC server-side client. The CLI builds endpoint context and prints the service projection; raw direct-control host/port/state/session envelopes, raw unit/city/point sample arrays, and transport details stay out of normal output.

This extends the existing strategy tactical-read OpenSpec record for battlefield/target/destination planning reads. It does not add controller bridge allowlisting, transport expansion, action-send authority, approval/reason mechanics, runtime proof, or parent Task 5.x/6.x/7.x acceptance.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/strategy-tactical-reads-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd packages/cli test -- game.play.tactical-read.test.ts
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- private procedure-schema export scan
- active approval/caller-permission scan
- service-output CLI-string scan
- raw runtime output scan
- relationship-label scan
- git diff --check

Local package and CLI proof only; no deployed Civ7 runtime proof, play-thread action, game-UI/controller bridge support, transport expansion, broad strategy catalog support, approval/reason mechanics, or relationship labels beyond official evidence.