### PR TITLE
fix(control-orpc): remove government choice player input

### DIFF
--- a/docs/projects/civ7-live-play-support/topics/caller-level-closeout-workflows.md
+++ b/docs/projects/civ7-live-play-support/topics/caller-level-closeout-workflows.md
@@ -41,12 +41,12 @@ Use these when the selected action should be handled as one native workflow:
   sends `CHANGE_TRADITION` then `CONSIDER_ASSIGN_TRADITIONS`.
 - `game play buy-attribute --player-id <id> --node <node> --send --closeout`
   sends `BUY_ATTRIBUTE_TREE_NODE` then `CONSIDER_ASSIGN_ATTRIBUTE`.
-- `game play choose-tech --player-id <id> --node <node> --send`
+- `game play choose-tech --node <node> --send`
   runs the App UI tech chooser owner route: activate the current
   `NOTIFICATION_CHOOSE_TECH` when present, send `SET_TECH_TREE_NODE`, clear
   with `SET_TECH_TREE_TARGET_NODE`, then re-read the live technology-choice
   notification postcondition.
-- `game play choose-culture --player-id <id> --node <node> --send --closeout`
+- `game play choose-culture --node <node> --send`
   runs the App UI culture chooser owner route: activate the current
   `NOTIFICATION_CHOOSE_CULTURE_NODE` when present, send
   `SET_CULTURE_TREE_NODE`, clear with `SET_CULTURE_TREE_TARGET_NODE`, then

--- a/docs/projects/civ7-live-play-support/topics/caller-level-closeout-workflows.md
+++ b/docs/projects/civ7-live-play-support/topics/caller-level-closeout-workflows.md
@@ -51,7 +51,7 @@ Use these when the selected action should be handled as one native workflow:
   `NOTIFICATION_CHOOSE_CULTURE_NODE` when present, send
   `SET_CULTURE_TREE_NODE`, clear with `SET_CULTURE_TREE_TARGET_NODE`, then
   re-read the live culture-choice notification postcondition.
-- `game play choose-government --player-id <id> --government-type <government-type> --action <activate> --send`
+- `game play choose-government --government-type <government-type> --action <activate> --send`
   sends `CHANGE_GOVERNMENT` with the exact government/action pair returned by
   `choose-government --options`.
 - `game play set-town-focus --city-id '<city-id>' --growth-type <type> --project-type <project-type> --send --closeout`

--- a/docs/projects/civ7-live-play-support/topics/first-meet-diplomacy.md
+++ b/docs/projects/civ7-live-play-support/topics/first-meet-diplomacy.md
@@ -72,7 +72,7 @@ Live turn 80 proof for Napoleon:
   "player1": 0,
   "player2": 1,
   "recommendedResponse": "neutral",
-  "recommendedCli": "game play respond-first-meet --player-id 0 --met-player-id 1 --response neutral"
+  "recommendedCli": "game play respond-first-meet --met-player-id 1 --response neutral --send"
 }
 ```
 

--- a/docs/projects/civ7-live-play-support/topics/progression-tree-targets.md
+++ b/docs/projects/civ7-live-play-support/topics/progression-tree-targets.md
@@ -23,8 +23,9 @@ is one complete technology selection workflow: it starts the selected research
 node and clears the temporary chooser target behind the scenes. Use
 `game play set-tech-target` directly only when the full tree UI should
 deliberately target a later node or when diagnostics prove the primary chooser
-operation already applied. Culture still accepts `--closeout` for the same
-two-operation chooser workflow until it receives the same default-send contract.
+operation already applied. Culture still accepts hidden `--closeout` as a
+compatibility no-op, but callers should treat `--send` as the complete
+two-operation chooser workflow.
 
 For technology blockers, read `game play choose-tech --options --json` before
 sending if the node id is not already proven. For culture blockers, read
@@ -108,16 +109,14 @@ one caller-level workflow:
 
 ```bash
 civ7 game play choose-culture \
-  --player-id 0 \
   --node -1677668973 \
   --send \
-  --closeout \
   --json
 ```
 
-The JSON result includes `operationSent` and a `postcondition` when sent with
-`--closeout`. `operationSent:true` means the App UI route returned successful
-operation-send evidence; it is not proof that the culture blocker cleared.
+The JSON result includes semantic send status and a `postcondition`.
+`sent:true` means the App UI route returned successful operation-send evidence;
+it is not proof that the culture blocker cleared.
 Treat `culture-choice-sticky-blocker` and
 `culture-state-changed-blocker-still-live` as stop-and-diagnose outcomes, not as
 reasons to repeat `choose-culture` or `set-culture-target` blindly.

--- a/docs/projects/civ7-live-play-support/topics/progression-tree-targets.md
+++ b/docs/projects/civ7-live-play-support/topics/progression-tree-targets.md
@@ -126,7 +126,6 @@ Set only the culture target when the primary choice was already applied:
 
 ```bash
 civ7 game play set-culture-target \
-  --player-id 0 \
   --node -1677668973 \
   --send \
   --json
@@ -134,5 +133,6 @@ civ7 game play set-culture-target \
 
 The same distinction applies to technology with `game play choose-tech --send`
 for the complete App UI-owner chooser workflow and `game play set-tech-target`
-for deliberate full-tree target planning. Its JSON also reports `operationSent`
-separately from final `verified:true`.
+for deliberate full-tree target planning. Send mode reads the live local player
+before invoking the guarded target request; dry-run validation remains the
+player-scoped path.

--- a/mods/mod-civ7-intelligence-bridge/mod/ui/civ7-intelligence-bridge.js
+++ b/mods/mod-civ7-intelligence-bridge/mod/ui/civ7-intelligence-bridge.js
@@ -27262,7 +27262,7 @@ function unitTargetProofNoRepeatAfterConfirmed(verification) {
   return verification.classification === "path-shortfall";
 }
 
-// ../../packages/civ7-control-orpc/dist/chunk-JP4LQAUT.js
+// ../../packages/civ7-control-orpc/dist/chunk-FQTQS3NB.js
 var Civ7ControlOrpcCorrelationIdSchema = typebox_exports.String({
   pattern: "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
 });
@@ -28216,6 +28216,30 @@ var Civ7StrategyFrontSummaryUnavailableError = class extends ORPCTaggedError(
   }
 ) {
 };
+var Civ7StrategyTacticalReadUnavailableErrorDataSchema = typebox_exports.Object(
+  {
+    procedureKey: typebox_exports.Union([
+      typebox_exports.Literal("strategy.battlefieldScan"),
+      typebox_exports.Literal("strategy.targetCandidates"),
+      typebox_exports.Literal("strategy.destinationAnalysis")
+    ]),
+    source: typebox_exports.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyTacticalReadUnavailableError = class extends ORPCTaggedError(
+  "Civ7StrategyTacticalReadUnavailableError",
+  {
+    code: "STRATEGY_TACTICAL_READ_UNAVAILABLE",
+    message: "Strategy tactical read failed.",
+    schema: toStandardSchema(
+      Civ7StrategyTacticalReadUnavailableErrorDataSchema
+    ),
+    status: 503
+  }
+) {
+};
 var Civ7StrategyCivilianRouteTriageUnavailableErrorDataSchema = typebox_exports.Object(
   {
     procedureKey: typebox_exports.Literal("strategy.civilianRouteTriage"),
@@ -28491,6 +28515,46 @@ var Civ7ProgressionChoiceUnavailableError = class extends ORPCTaggedError(
   }
 ) {
 };
+var Civ7ProgressionDashboardUnavailableErrorDataSchema = typebox_exports.Object(
+  {
+    procedureKey: typebox_exports.Literal("progression.dashboard.current"),
+    source: typebox_exports.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties
+  },
+  { additionalProperties: false }
+);
+var Civ7ProgressionDashboardUnavailableError = class extends ORPCTaggedError(
+  "Civ7ProgressionDashboardUnavailableError",
+  {
+    code: "PROGRESSION_DASHBOARD_UNAVAILABLE",
+    message: "Direct-control progression dashboard read failed.",
+    schema: toStandardSchema(
+      Civ7ProgressionDashboardUnavailableErrorDataSchema
+    ),
+    status: 503
+  }
+) {
+};
+var Civ7ProgressionTraditionsUnavailableErrorDataSchema = typebox_exports.Object(
+  {
+    procedureKey: typebox_exports.Literal("progression.traditions.current"),
+    source: typebox_exports.Literal("direct-control-facade"),
+    ...Civ7ControlOrpcErrorCorrelationProperties
+  },
+  { additionalProperties: false }
+);
+var Civ7ProgressionTraditionsUnavailableError = class extends ORPCTaggedError(
+  "Civ7ProgressionTraditionsUnavailableError",
+  {
+    code: "PROGRESSION_TRADITIONS_UNAVAILABLE",
+    message: "Direct-control progression traditions read failed.",
+    schema: toStandardSchema(
+      Civ7ProgressionTraditionsUnavailableErrorDataSchema
+    ),
+    status: 503
+  }
+) {
+};
 var Civ7ProgressionPlayerChoiceUnavailableErrorDataSchema = typebox_exports.Object(
   {
     procedureKey: typebox_exports.Union([
@@ -28711,6 +28775,8 @@ var civ7ControlOrpcErrorMap = {
   NOTIFICATION_QUEUE_UNAVAILABLE: Civ7NotificationQueueUnavailableError,
   POPULATION_PLACEMENT_UNAVAILABLE: Civ7PopulationPlacementUnavailableError,
   PROGRESSION_CHOICE_UNAVAILABLE: Civ7ProgressionChoiceUnavailableError,
+  PROGRESSION_DASHBOARD_UNAVAILABLE: Civ7ProgressionDashboardUnavailableError,
+  PROGRESSION_TRADITIONS_UNAVAILABLE: Civ7ProgressionTraditionsUnavailableError,
   PROGRESSION_PLAYER_CHOICE_UNAVAILABLE: Civ7ProgressionPlayerChoiceUnavailableError,
   PROGRESSION_TARGET_UNAVAILABLE: Civ7ProgressionTargetUnavailableError,
   PRODUCTION_CHOICE_UNAVAILABLE: Civ7ProductionChoiceUnavailableError,
@@ -28718,6 +28784,7 @@ var civ7ControlOrpcErrorMap = {
   STRATEGY_CIVILIAN_ROUTE_TRIAGE_UNAVAILABLE: Civ7StrategyCivilianRouteTriageUnavailableError,
   STRATEGY_FORMATION_SNAPSHOT_UNAVAILABLE: Civ7StrategyFormationSnapshotUnavailableError,
   STRATEGY_FRONT_SUMMARY_UNAVAILABLE: Civ7StrategyFrontSummaryUnavailableError,
+  STRATEGY_TACTICAL_READ_UNAVAILABLE: Civ7StrategyTacticalReadUnavailableError,
   TOWN_FOCUS_UNAVAILABLE: Civ7TownFocusUnavailableError,
   TURN_COMPLETION_UNAVAILABLE: Civ7TurnCompletionUnavailableError,
   UNIT_REQUEST_UNAVAILABLE: Civ7UnitRequestUnavailableError,
@@ -29108,7 +29175,6 @@ var Civ7CityPopulationPlacementInputSchema = typebox_exports.Union([
   typebox_exports.Object(
     {
       mode: typebox_exports.Literal("assign-worker"),
-      playerId: typebox_exports.Integer({ minimum: 0 }),
       location: typebox_exports.Integer({ minimum: 0 })
     },
     { additionalProperties: false }
@@ -29442,7 +29508,6 @@ var Civ7CityContract = {
 };
 var Civ7DiplomacyResponseInputSchema = typebox_exports.Object(
   {
-    playerId: typebox_exports.Integer({ minimum: 0, maximum: 1024 }),
     actionId: typebox_exports.Integer(),
     responseType: typebox_exports.Integer(),
     notificationId: typebox_exports.Optional(Civ7ControlOrpcComponentIdSchema)
@@ -29522,7 +29587,6 @@ var Civ7DiplomacyResponseResultSchema = typebox_exports.Object(
 );
 var Civ7FirstMeetResponseInputSchema = typebox_exports.Object(
   {
-    playerId: typebox_exports.Integer({ minimum: 0, maximum: 1024 }),
     metPlayerId: typebox_exports.Integer({ minimum: 0, maximum: 1024 }),
     responseType: typebox_exports.Integer()
   },
@@ -29631,7 +29695,6 @@ var Civ7DiplomacyContract = {
 };
 var Civ7GovernmentChoiceInputSchema = typebox_exports.Object(
   {
-    playerId: typebox_exports.Integer({ minimum: 0, maximum: 1024 }),
     governmentType: typebox_exports.Integer(),
     action: typebox_exports.Optional(typebox_exports.Integer())
   },
@@ -29639,7 +29702,6 @@ var Civ7GovernmentChoiceInputSchema = typebox_exports.Object(
 );
 var Civ7GovernmentCelebrationChoiceInputSchema = typebox_exports.Object(
   {
-    playerId: typebox_exports.Integer({ minimum: 0, maximum: 1024 }),
     goldenAgeType: typebox_exports.Integer()
   },
   { additionalProperties: false }
@@ -29753,7 +29815,6 @@ var Civ7GovernmentContract = {
 };
 var Civ7NarrativeChoiceInputSchema = typebox_exports.Object(
   {
-    playerId: typebox_exports.Integer({ minimum: 0, maximum: 1024 }),
     targetType: typebox_exports.String({ minLength: 1 }),
     target: Civ7ControlOrpcComponentIdSchema,
     action: typebox_exports.Integer()
@@ -29846,7 +29907,6 @@ var Civ7NarrativeContract = {
 };
 var Civ7ProgressionChoiceInputSchema = typebox_exports.Object(
   {
-    playerId: typebox_exports.Integer({ minimum: 0, maximum: 1024 }),
     node: typebox_exports.Integer(),
     notificationId: typebox_exports.Optional(Civ7ControlOrpcComponentIdSchema)
   },
@@ -29854,7 +29914,6 @@ var Civ7ProgressionChoiceInputSchema = typebox_exports.Object(
 );
 var Civ7ProgressionTargetInputSchema = typebox_exports.Object(
   {
-    playerId: typebox_exports.Integer({ minimum: 0, maximum: 1024 }),
     node: typebox_exports.Integer()
   },
   { additionalProperties: false }
@@ -29867,6 +29926,18 @@ var Civ7ProgressionAttributePurchaseInputSchema = typebox_exports.Object(
 );
 var Civ7ProgressionPlayerReviewInputSchema = typebox_exports.Object(
   {},
+  { additionalProperties: false }
+);
+var Civ7ProgressionDashboardInputSchema = typebox_exports.Object(
+  {
+    playerId: typebox_exports.Optional(typebox_exports.Integer({ minimum: 0, maximum: 1024 }))
+  },
+  { additionalProperties: false }
+);
+var Civ7ProgressionTraditionsInputSchema = typebox_exports.Object(
+  {
+    playerId: typebox_exports.Optional(typebox_exports.Integer({ minimum: 0, maximum: 1024 }))
+  },
   { additionalProperties: false }
 );
 var Civ7ProgressionTraditionChangeInputSchema = typebox_exports.Object(
@@ -30177,10 +30248,262 @@ var Civ7ProgressionTraditionReviewResultSchema = typebox_exports.Object(
   },
   { additionalProperties: false }
 );
+var Civ7ProgressionDashboardProbeSchema = typebox_exports.Union([
+  typebox_exports.Object(
+    {
+      ok: typebox_exports.Literal(true),
+      value: typebox_exports.Unknown()
+    },
+    { additionalProperties: false }
+  ),
+  typebox_exports.Object(
+    {
+      ok: typebox_exports.Literal(false),
+      error: typebox_exports.String()
+    },
+    { additionalProperties: false }
+  )
+]);
+var Civ7ProgressionDashboardLegacyPathSchema = typebox_exports.Object(
+  {
+    legacyPathType: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+    classType: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+    name: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+    score: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()]),
+    finalRequiredPathPoints: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()]),
+    progressPercent: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()]),
+    nextMilestone: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+    enabledForPlayer: typebox_exports.Union([typebox_exports.Boolean(), typebox_exports.Null()])
+  },
+  { additionalProperties: false }
+);
+var Civ7ProgressionDashboardNextStepSchema = typebox_exports.Object(
+  {
+    kind: typebox_exports.Union([
+      typebox_exports.Literal("read-attention-priorities"),
+      typebox_exports.Literal("inspect-progression-choice"),
+      typebox_exports.Literal("inspect-victory-progress"),
+      typebox_exports.Literal("observe")
+    ]),
+    source: typebox_exports.Literal("progression.dashboard.current"),
+    label: typebox_exports.String()
+  },
+  { additionalProperties: false }
+);
+var Civ7ProgressionDashboardResultSchema = typebox_exports.Object(
+  {
+    playerId: typebox_exports.Integer({ minimum: 0 }),
+    localPlayerId: typebox_exports.Integer({ minimum: 0 }),
+    sourceStatus: typebox_exports.Object(
+      {
+        progressDashboard: typebox_exports.Literal("read")
+      },
+      { additionalProperties: false }
+    ),
+    hiddenInfoPolicy: typebox_exports.Literal("local-player-runtime-progress"),
+    summary: typebox_exports.Object(
+      {
+        headline: typebox_exports.String(),
+        legacyPathCount: typebox_exports.Integer({ minimum: 0 }),
+        victoryClassCount: typebox_exports.Integer({ minimum: 0 }),
+        triumphCount: typebox_exports.Integer({ minimum: 0 }),
+        nextStepCount: typebox_exports.Integer({ minimum: 0 })
+      },
+      { additionalProperties: false }
+    ),
+    turn: Civ7ProgressionDashboardProbeSchema,
+    turnDate: Civ7ProgressionDashboardProbeSchema,
+    age: typebox_exports.Object(
+      {
+        ageType: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+        name: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+        chronologyIndex: typebox_exports.Unknown(),
+        currentAgeProgressionPoints: Civ7ProgressionDashboardProbeSchema,
+        maxAgeProgressionPoints: Civ7ProgressionDashboardProbeSchema,
+        ageProgressPercent: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()]),
+        isFinalAge: Civ7ProgressionDashboardProbeSchema,
+        isAgeOver: Civ7ProgressionDashboardProbeSchema
+      },
+      { additionalProperties: false }
+    ),
+    player: typebox_exports.Object(
+      {
+        team: typebox_exports.Unknown(),
+        historicalLegacyPointCountForTeam: Civ7ProgressionDashboardProbeSchema
+      },
+      { additionalProperties: false }
+    ),
+    legacyPaths: typebox_exports.Array(Civ7ProgressionDashboardLegacyPathSchema),
+    victories: typebox_exports.Object(
+      {
+        rowCount: typebox_exports.Integer({ minimum: 0 }),
+        classes: typebox_exports.Array(typebox_exports.String())
+      },
+      { additionalProperties: false }
+    ),
+    triumphs: typebox_exports.Object(
+      {
+        count: typebox_exports.Integer({ minimum: 0 }),
+        source: typebox_exports.Literal("runtime-gameinfo"),
+        rows: typebox_exports.Array(typebox_exports.Unknown())
+      },
+      { additionalProperties: false }
+    ),
+    proof: typebox_exports.Object(
+      {
+        victoryManagerGlobal: Civ7ProgressionDashboardProbeSchema,
+        sources: typebox_exports.Array(typebox_exports.String())
+      },
+      { additionalProperties: false }
+    ),
+    warnings: typebox_exports.Array(typebox_exports.String()),
+    omitted: typebox_exports.Array(typebox_exports.Object(
+      {
+        path: typebox_exports.String(),
+        reason: typebox_exports.String()
+      },
+      { additionalProperties: false }
+    )),
+    notes: typebox_exports.Array(typebox_exports.String()),
+    nextSteps: typebox_exports.Array(Civ7ProgressionDashboardNextStepSchema)
+  },
+  { additionalProperties: false }
+);
+var Civ7ProgressionTraditionActionDescriptorSchema = typebox_exports.Object(
+  {
+    kind: typebox_exports.Union([typebox_exports.Literal("activate"), typebox_exports.Literal("deactivate")]),
+    action: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()]),
+    validationSuccess: typebox_exports.Union([typebox_exports.Boolean(), typebox_exports.Null()]),
+    parameters: typebox_exports.Object(
+      {
+        traditionType: typebox_exports.Number(),
+        action: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()])
+      },
+      { additionalProperties: false }
+    ),
+    nextSteps: typebox_exports.Array(typebox_exports.Object(
+      {
+        kind: typebox_exports.Union([
+          typebox_exports.Literal("validate-tradition-change"),
+          typebox_exports.Literal("request-tradition-change")
+        ]),
+        source: typebox_exports.Literal("progression.traditions.current"),
+        label: typebox_exports.String(),
+        parameters: typebox_exports.Object(
+          {
+            traditionType: typebox_exports.Number(),
+            action: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()])
+          },
+          { additionalProperties: false }
+        )
+      },
+      { additionalProperties: false }
+    ))
+  },
+  { additionalProperties: false }
+);
+var Civ7ProgressionTraditionRowSchema = typebox_exports.Object(
+  {
+    id: typebox_exports.Number(),
+    type: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+    name: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+    description: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+    ageType: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+    cultureSlotType: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+    traitType: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+    isCrisis: typebox_exports.Boolean(),
+    active: typebox_exports.Boolean(),
+    unlocked: typebox_exports.Boolean(),
+    recentUnlock: typebox_exports.Boolean(),
+    actions: typebox_exports.Array(Civ7ProgressionTraditionActionDescriptorSchema)
+  },
+  { additionalProperties: false }
+);
+var Civ7ProgressionTraditionsNextStepSchema = typebox_exports.Object(
+  {
+    kind: typebox_exports.Union([
+      typebox_exports.Literal("inspect-tradition-change"),
+      typebox_exports.Literal("free-policy-slot"),
+      typebox_exports.Literal("observe")
+    ]),
+    source: typebox_exports.Literal("progression.traditions.current"),
+    label: typebox_exports.String()
+  },
+  { additionalProperties: false }
+);
+var Civ7ProgressionTraditionsResultSchema = typebox_exports.Object(
+  {
+    playerId: typebox_exports.Integer({ minimum: 0 }),
+    sourceStatus: typebox_exports.Object(
+      {
+        traditions: typebox_exports.Literal("read")
+      },
+      { additionalProperties: false }
+    ),
+    hiddenInfoPolicy: typebox_exports.Literal("player-culture-runtime"),
+    summary: typebox_exports.Object(
+      {
+        activeCount: typebox_exports.Integer({ minimum: 0 }),
+        availableCount: typebox_exports.Integer({ minimum: 0 }),
+        recentUnlockCount: typebox_exports.Integer({ minimum: 0 }),
+        openSlotCount: typebox_exports.Integer({ minimum: 0 }),
+        enabledAvailableCount: typebox_exports.Integer({ minimum: 0 }),
+        disabledAvailableCount: typebox_exports.Integer({ minimum: 0 }),
+        nextStepCount: typebox_exports.Integer({ minimum: 0 })
+      },
+      { additionalProperties: false }
+    ),
+    turn: Civ7ProgressionDashboardProbeSchema,
+    turnDate: Civ7ProgressionDashboardProbeSchema,
+    governmentType: Civ7ProgressionDashboardProbeSchema,
+    government: typebox_exports.Object(
+      {
+        type: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+        name: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()])
+      },
+      { additionalProperties: false }
+    ),
+    slots: typebox_exports.Object(
+      {
+        total: Civ7ProgressionDashboardProbeSchema,
+        normal: Civ7ProgressionDashboardProbeSchema,
+        crisis: Civ7ProgressionDashboardProbeSchema,
+        active: typebox_exports.Integer({ minimum: 0 }),
+        unlocked: typebox_exports.Integer({ minimum: 0 }),
+        available: typebox_exports.Integer({ minimum: 0 }),
+        open: typebox_exports.Integer({ minimum: 0 })
+      },
+      { additionalProperties: false }
+    ),
+    actions: typebox_exports.Object(
+      {
+        activate: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()]),
+        deactivate: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()])
+      },
+      { additionalProperties: false }
+    ),
+    active: typebox_exports.Array(Civ7ProgressionTraditionRowSchema),
+    available: typebox_exports.Array(Civ7ProgressionTraditionRowSchema),
+    recentUnlocks: typebox_exports.Array(Civ7ProgressionTraditionRowSchema),
+    traditions: typebox_exports.Array(Civ7ProgressionTraditionRowSchema),
+    omitted: typebox_exports.Array(typebox_exports.Object(
+      {
+        path: typebox_exports.String(),
+        reason: typebox_exports.String()
+      },
+      { additionalProperties: false }
+    )),
+    notes: typebox_exports.Array(typebox_exports.String()),
+    nextSteps: typebox_exports.Array(Civ7ProgressionTraditionsNextStepSchema)
+  },
+  { additionalProperties: false }
+);
 var Civ7ProgressionChoiceInputStandardSchema = toStandardSchema(Civ7ProgressionChoiceInputSchema);
 var Civ7ProgressionTargetInputStandardSchema = toStandardSchema(Civ7ProgressionTargetInputSchema);
 var Civ7ProgressionAttributePurchaseInputStandardSchema = toStandardSchema(Civ7ProgressionAttributePurchaseInputSchema);
 var Civ7ProgressionPlayerReviewInputStandardSchema = toStandardSchema(Civ7ProgressionPlayerReviewInputSchema);
+var Civ7ProgressionDashboardInputStandardSchema = toStandardSchema(Civ7ProgressionDashboardInputSchema);
+var Civ7ProgressionTraditionsInputStandardSchema = toStandardSchema(Civ7ProgressionTraditionsInputSchema);
 var Civ7ProgressionTraditionChangeInputStandardSchema = toStandardSchema(Civ7ProgressionTraditionChangeInputSchema);
 var Civ7ProgressionTechnologyChoiceResultStandardSchema = toStandardSchema(Civ7ProgressionTechnologyChoiceResultSchema);
 var Civ7ProgressionCultureChoiceResultStandardSchema = toStandardSchema(Civ7ProgressionCultureChoiceResultSchema);
@@ -30190,6 +30513,8 @@ var Civ7ProgressionAttributePurchaseResultStandardSchema = toStandardSchema(Civ7
 var Civ7ProgressionAttributeReviewResultStandardSchema = toStandardSchema(Civ7ProgressionAttributeReviewResultSchema);
 var Civ7ProgressionTraditionChangeResultStandardSchema = toStandardSchema(Civ7ProgressionTraditionChangeResultSchema);
 var Civ7ProgressionTraditionReviewResultStandardSchema = toStandardSchema(Civ7ProgressionTraditionReviewResultSchema);
+var Civ7ProgressionDashboardResultStandardSchema = toStandardSchema(Civ7ProgressionDashboardResultSchema);
+var Civ7ProgressionTraditionsResultStandardSchema = toStandardSchema(Civ7ProgressionTraditionsResultSchema);
 var Civ7ProgressionTechnologyChoiceContract = civ7ControlOrpcContractBase.input(Civ7ProgressionChoiceInputStandardSchema).output(Civ7ProgressionTechnologyChoiceResultStandardSchema).meta({
   family: "progression",
   procedureKey: "progression.technology.choice.request",
@@ -30238,7 +30563,25 @@ var Civ7ProgressionTraditionReviewContract = civ7ControlOrpcContractBase.input(C
   proofBoundary: "local-package-test",
   risk: "mutation"
 });
+var Civ7ProgressionDashboardContract = civ7ControlOrpcContractBase.input(Civ7ProgressionDashboardInputStandardSchema).output(Civ7ProgressionDashboardResultStandardSchema).meta({
+  family: "progression",
+  procedureKey: "progression.dashboard.current",
+  proofBoundary: "local-package-test",
+  risk: "read-only"
+});
+var Civ7ProgressionTraditionsContract = civ7ControlOrpcContractBase.input(Civ7ProgressionTraditionsInputStandardSchema).output(Civ7ProgressionTraditionsResultStandardSchema).meta({
+  family: "progression",
+  procedureKey: "progression.traditions.current",
+  proofBoundary: "local-package-test",
+  risk: "read-only"
+});
 var Civ7ProgressionContract = {
+  dashboard: {
+    current: Civ7ProgressionDashboardContract
+  },
+  traditions: {
+    current: Civ7ProgressionTraditionsContract
+  },
   technology: {
     choice: {
       request: Civ7ProgressionTechnologyChoiceContract
@@ -30881,11 +31224,304 @@ var Civ7StrategyFrontSummaryResultSchema = typebox_exports.Object(
   },
   { additionalProperties: false }
 );
+var Civ7StrategyTargetCandidatesInputSchema = typebox_exports.Object(
+  {
+    playerId: typebox_exports.Optional(typebox_exports.Integer({ minimum: 0, maximum: 1024 })),
+    origins: typebox_exports.Optional(typebox_exports.Array(Civ7ControlOrpcMapLocationSchema)),
+    maxCandidates: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 64 })),
+    maxPlayers: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 128 })),
+    unitRadius: typebox_exports.Optional(typebox_exports.Integer({ minimum: 0, maximum: 16 }))
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyTargetCandidatesNextStepSchema = typebox_exports.Object(
+  {
+    kind: typebox_exports.Union([
+      typebox_exports.Literal("inspect-candidate"),
+      typebox_exports.Literal("read-visibility"),
+      typebox_exports.Literal("validate-unit-action"),
+      typebox_exports.Literal("observe")
+    ]),
+    source: typebox_exports.Literal("strategy.targetCandidates"),
+    label: typebox_exports.String(),
+    parameters: typebox_exports.Object(
+      {
+        owner: typebox_exports.Optional(typebox_exports.Integer({ minimum: 0 })),
+        target: typebox_exports.Optional(Civ7ControlOrpcMapLocationSchema)
+      },
+      { additionalProperties: false }
+    )
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyTargetCandidateApproachSchema = typebox_exports.Object(
+  {
+    nearestOrigin: typebox_exports.Union([Civ7ControlOrpcMapLocationSchema, typebox_exports.Null()]),
+    targetLocation: typebox_exports.Union([Civ7ControlOrpcMapLocationSchema, typebox_exports.Null()]),
+    directGridDistance: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()]),
+    routeHint: typebox_exports.String(),
+    routeKind: typebox_exports.String(),
+    waterSampleCount: typebox_exports.Integer({ minimum: 0 }),
+    landSampleCount: typebox_exports.Integer({ minimum: 0 }),
+    notes: typebox_exports.Array(typebox_exports.String())
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyTargetCandidateResultSchema = typebox_exports.Object(
+  {
+    owner: typebox_exports.Integer({ minimum: 0 }),
+    relationship: typebox_exports.Literal("relationship-unproven"),
+    relationshipProof: typebox_exports.Literal("none"),
+    leaderName: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+    civilizationName: typebox_exports.Union([typebox_exports.String(), typebox_exports.Null()]),
+    isHuman: typebox_exports.Union([typebox_exports.Boolean(), typebox_exports.Null()]),
+    cityCount: typebox_exports.Integer({ minimum: 0 }),
+    unitCount: typebox_exports.Integer({ minimum: 0 }),
+    nearestDistance: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()]),
+    nearbyUnitCount: typebox_exports.Integer({ minimum: 0 }),
+    apparentStrength: typebox_exports.Number(),
+    nearestCityLocation: typebox_exports.Union([
+      Civ7ControlOrpcMapLocationSchema,
+      typebox_exports.Null()
+    ]),
+    approach: Civ7StrategyTargetCandidateApproachSchema,
+    reasons: typebox_exports.Array(typebox_exports.String())
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyTargetCandidatesResultSchema = typebox_exports.Object(
+  {
+    playerId: typebox_exports.Integer({ minimum: 0 }),
+    localPlayerId: typebox_exports.Integer({ minimum: 0 }),
+    origins: typebox_exports.Array(Civ7ControlOrpcMapLocationSchema),
+    unitRadius: typebox_exports.Integer({ minimum: 0 }),
+    hiddenInfoPolicy: typebox_exports.String(),
+    relationshipLabelPolicy: Civ7StrategyRelationshipLabelPolicySchema,
+    summary: typebox_exports.Object(
+      {
+        candidateCount: typebox_exports.Integer({ minimum: 0 }),
+        nearestDistance: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()]),
+        observedOwnerCount: typebox_exports.Integer({ minimum: 0 }),
+        apparentStrengthTotal: typebox_exports.Number(),
+        nextStepCount: typebox_exports.Integer({ minimum: 0 })
+      },
+      { additionalProperties: false }
+    ),
+    candidates: typebox_exports.Array(Civ7StrategyTargetCandidateResultSchema),
+    omitted: typebox_exports.Array(typebox_exports.Object(
+      {
+        path: typebox_exports.String(),
+        reason: typebox_exports.String()
+      },
+      { additionalProperties: false }
+    )),
+    notes: typebox_exports.Array(typebox_exports.String()),
+    nextSteps: typebox_exports.Array(Civ7StrategyTargetCandidatesNextStepSchema)
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyDestinationAnalysisInputSchema = typebox_exports.Object(
+  {
+    playerId: typebox_exports.Optional(typebox_exports.Integer({ minimum: 0, maximum: 1024 })),
+    origin: typebox_exports.Optional(Civ7ControlOrpcMapLocationSchema),
+    destination: Civ7ControlOrpcMapLocationSchema,
+    corridorRadius: typebox_exports.Optional(typebox_exports.Integer({ minimum: 0, maximum: 8 })),
+    destinationRadius: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 16 })),
+    maxPlayers: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 128 })),
+    maxUnits: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 256 })),
+    maxCities: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 128 }))
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyDestinationAnalysisNextStepSchema = typebox_exports.Object(
+  {
+    kind: typebox_exports.Union([
+      typebox_exports.Literal("inspect-destination"),
+      typebox_exports.Literal("read-visibility"),
+      typebox_exports.Literal("validate-unit-action"),
+      typebox_exports.Literal("observe")
+    ]),
+    source: typebox_exports.Literal("strategy.destinationAnalysis"),
+    label: typebox_exports.String(),
+    parameters: typebox_exports.Object(
+      {
+        origin: typebox_exports.Optional(Civ7ControlOrpcMapLocationSchema),
+        destination: typebox_exports.Optional(Civ7ControlOrpcMapLocationSchema)
+      },
+      { additionalProperties: false }
+    )
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyDestinationPointOfInterestSchema = typebox_exports.Object(
+  {
+    kind: typebox_exports.String(),
+    severity: typebox_exports.String(),
+    location: typebox_exports.Union([Civ7ControlOrpcMapLocationSchema, typebox_exports.Null()]),
+    summary: typebox_exports.String()
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyDestinationAnalysisResultSchema = typebox_exports.Object(
+  {
+    playerId: typebox_exports.Integer({ minimum: 0 }),
+    localPlayerId: typebox_exports.Integer({ minimum: 0 }),
+    origin: typebox_exports.Union([Civ7ControlOrpcMapLocationSchema, typebox_exports.Null()]),
+    destination: Civ7ControlOrpcMapLocationSchema,
+    corridorRadius: typebox_exports.Integer({ minimum: 0 }),
+    destinationRadius: typebox_exports.Integer({ minimum: 1 }),
+    hiddenInfoPolicy: typebox_exports.String(),
+    relationshipLabelPolicy: Civ7StrategyRelationshipLabelPolicySchema,
+    summary: typebox_exports.Object(
+      {
+        pointOfInterestCount: typebox_exports.Integer({ minimum: 0 }),
+        corridorUnitCount: typebox_exports.Integer({ minimum: 0 }),
+        destinationUnitCount: typebox_exports.Integer({ minimum: 0 }),
+        destinationCityCount: typebox_exports.Integer({ minimum: 0 }),
+        apparentOtherStrength: typebox_exports.Number(),
+        nextStepCount: typebox_exports.Integer({ minimum: 0 })
+      },
+      { additionalProperties: false }
+    ),
+    corridor: typebox_exports.Object(
+      {
+        routeHint: typebox_exports.String(),
+        directGridDistance: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()]),
+        sampleCount: typebox_exports.Integer({ minimum: 0 }),
+        unitCount: typebox_exports.Integer({ minimum: 0 })
+      },
+      { additionalProperties: false }
+    ),
+    destinationPressure: typebox_exports.Object(
+      {
+        unitCount: typebox_exports.Integer({ minimum: 0 }),
+        cityCount: typebox_exports.Integer({ minimum: 0 }),
+        apparentOtherStrength: typebox_exports.Number()
+      },
+      { additionalProperties: false }
+    ),
+    pointsOfInterest: typebox_exports.Array(Civ7StrategyDestinationPointOfInterestSchema),
+    omitted: typebox_exports.Array(typebox_exports.Object(
+      {
+        path: typebox_exports.String(),
+        reason: typebox_exports.String()
+      },
+      { additionalProperties: false }
+    )),
+    notes: typebox_exports.Array(typebox_exports.String()),
+    nextSteps: typebox_exports.Array(Civ7StrategyDestinationAnalysisNextStepSchema)
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyBattlefieldScanInputSchema = typebox_exports.Object(
+  {
+    playerId: typebox_exports.Optional(typebox_exports.Integer({ minimum: 0, maximum: 1024 })),
+    origins: typebox_exports.Optional(typebox_exports.Array(Civ7ControlOrpcMapLocationSchema)),
+    radius: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 32 })),
+    maxPlayers: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 128 })),
+    maxUnits: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 256 })),
+    maxCities: typebox_exports.Optional(typebox_exports.Integer({ minimum: 1, maximum: 128 }))
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyBattlefieldNextStepSchema = typebox_exports.Object(
+  {
+    kind: typebox_exports.Union([
+      typebox_exports.Literal("inspect-battlefield-point"),
+      typebox_exports.Literal("read-visibility"),
+      typebox_exports.Literal("validate-unit-action"),
+      typebox_exports.Literal("observe")
+    ]),
+    source: typebox_exports.Literal("strategy.battlefieldScan"),
+    label: typebox_exports.String(),
+    parameters: typebox_exports.Object(
+      {
+        origin: typebox_exports.Optional(Civ7ControlOrpcMapLocationSchema),
+        location: typebox_exports.Optional(Civ7ControlOrpcMapLocationSchema)
+      },
+      { additionalProperties: false }
+    )
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyBattlefieldOwnerSchema = typebox_exports.Object(
+  {
+    owner: typebox_exports.Integer({ minimum: 0 }),
+    relationship: Civ7StrategyRelationshipClassificationSchema,
+    relationshipProof: typebox_exports.Union([typebox_exports.Literal("self"), typebox_exports.Literal("none")]),
+    unitCount: typebox_exports.Integer({ minimum: 0 }),
+    cityCount: typebox_exports.Integer({ minimum: 0 }),
+    apparentStrength: typebox_exports.Number(),
+    nearestDistance: typebox_exports.Union([typebox_exports.Number(), typebox_exports.Null()]),
+    roles: typebox_exports.Record(typebox_exports.String(), typebox_exports.Integer({ minimum: 0 }))
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyBattlefieldPointOfInterestSchema = typebox_exports.Object(
+  {
+    kind: typebox_exports.String(),
+    severity: typebox_exports.String(),
+    location: typebox_exports.Union([Civ7ControlOrpcMapLocationSchema, typebox_exports.Null()]),
+    summary: typebox_exports.String()
+  },
+  { additionalProperties: false }
+);
+var Civ7StrategyBattlefieldScanResultSchema = typebox_exports.Object(
+  {
+    playerId: typebox_exports.Integer({ minimum: 0 }),
+    localPlayerId: typebox_exports.Integer({ minimum: 0 }),
+    origins: typebox_exports.Array(Civ7ControlOrpcMapLocationSchema),
+    radius: typebox_exports.Integer({ minimum: 1 }),
+    hiddenInfoPolicy: typebox_exports.String(),
+    relationshipLabelPolicy: Civ7StrategyRelationshipLabelPolicySchema,
+    summary: typebox_exports.Object(
+      {
+        unitCount: typebox_exports.Integer({ minimum: 0 }),
+        cityCount: typebox_exports.Integer({ minimum: 0 }),
+        observedOwnerCount: typebox_exports.Integer({ minimum: 0 }),
+        pointOfInterestCount: typebox_exports.Integer({ minimum: 0 }),
+        apparentStrengthTotal: typebox_exports.Number(),
+        nextStepCount: typebox_exports.Integer({ minimum: 0 })
+      },
+      { additionalProperties: false }
+    ),
+    owners: typebox_exports.Array(Civ7StrategyBattlefieldOwnerSchema),
+    pointsOfInterest: typebox_exports.Array(Civ7StrategyBattlefieldPointOfInterestSchema),
+    omitted: typebox_exports.Array(typebox_exports.Object(
+      {
+        path: typebox_exports.String(),
+        reason: typebox_exports.String()
+      },
+      { additionalProperties: false }
+    )),
+    notes: typebox_exports.Array(typebox_exports.String()),
+    nextSteps: typebox_exports.Array(Civ7StrategyBattlefieldNextStepSchema)
+  },
+  { additionalProperties: false }
+);
 var Civ7StrategyFrontSummaryInputStandardSchema = toStandardSchema(
   Civ7StrategyFrontSummaryInputSchema
 );
 var Civ7StrategyFrontSummaryResultStandardSchema = toStandardSchema(
   Civ7StrategyFrontSummaryResultSchema
+);
+var Civ7StrategyTargetCandidatesInputStandardSchema = toStandardSchema(
+  Civ7StrategyTargetCandidatesInputSchema
+);
+var Civ7StrategyTargetCandidatesResultStandardSchema = toStandardSchema(
+  Civ7StrategyTargetCandidatesResultSchema
+);
+var Civ7StrategyDestinationAnalysisInputStandardSchema = toStandardSchema(
+  Civ7StrategyDestinationAnalysisInputSchema
+);
+var Civ7StrategyDestinationAnalysisResultStandardSchema = toStandardSchema(
+  Civ7StrategyDestinationAnalysisResultSchema
+);
+var Civ7StrategyBattlefieldScanInputStandardSchema = toStandardSchema(
+  Civ7StrategyBattlefieldScanInputSchema
+);
+var Civ7StrategyBattlefieldScanResultStandardSchema = toStandardSchema(
+  Civ7StrategyBattlefieldScanResultSchema
 );
 var Civ7StrategyCivilianRouteTriageInputSchema = typebox_exports.Object(
   {
@@ -31142,6 +31778,24 @@ var Civ7StrategyFrontSummaryContract = civ7ControlOrpcContractBase.input(Civ7Str
   proofBoundary: "local-package-test",
   risk: "read-only"
 });
+var Civ7StrategyTargetCandidatesContract = civ7ControlOrpcContractBase.input(Civ7StrategyTargetCandidatesInputStandardSchema).output(Civ7StrategyTargetCandidatesResultStandardSchema).meta({
+  family: "strategy",
+  procedureKey: "strategy.targetCandidates",
+  proofBoundary: "local-package-test",
+  risk: "read-only"
+});
+var Civ7StrategyDestinationAnalysisContract = civ7ControlOrpcContractBase.input(Civ7StrategyDestinationAnalysisInputStandardSchema).output(Civ7StrategyDestinationAnalysisResultStandardSchema).meta({
+  family: "strategy",
+  procedureKey: "strategy.destinationAnalysis",
+  proofBoundary: "local-package-test",
+  risk: "read-only"
+});
+var Civ7StrategyBattlefieldScanContract = civ7ControlOrpcContractBase.input(Civ7StrategyBattlefieldScanInputStandardSchema).output(Civ7StrategyBattlefieldScanResultStandardSchema).meta({
+  family: "strategy",
+  procedureKey: "strategy.battlefieldScan",
+  proofBoundary: "local-package-test",
+  risk: "read-only"
+});
 var Civ7StrategyCivilianRouteTriageContract = civ7ControlOrpcContractBase.input(Civ7StrategyCivilianRouteTriageInputStandardSchema).output(Civ7StrategyCivilianRouteTriageResultStandardSchema).meta({
   family: "strategy",
   procedureKey: "strategy.civilianRouteTriage",
@@ -31155,9 +31809,12 @@ var Civ7StrategyFormationSnapshotContract = civ7ControlOrpcContractBase.input(Ci
   risk: "read-only"
 });
 var Civ7StrategyContract = {
+  battlefieldScan: Civ7StrategyBattlefieldScanContract,
   civilianRouteTriage: Civ7StrategyCivilianRouteTriageContract,
+  destinationAnalysis: Civ7StrategyDestinationAnalysisContract,
   formationSnapshot: Civ7StrategyFormationSnapshotContract,
-  frontSummary: Civ7StrategyFrontSummaryContract
+  frontSummary: Civ7StrategyFrontSummaryContract,
+  targetCandidates: Civ7StrategyTargetCandidatesContract
 };
 var Civ7TurnCompletionInputSchema = typebox_exports.Object(
   {},
@@ -33000,20 +33657,25 @@ var cityPopulationPlaceRequestProcedure = civ7ControlOrpcMutationProcedure(
 }) {
   return yield* Effect_exports.tryPromise({
     try: async () => {
-      const result = input.mode === "assign-worker" ? await context5.directControl.requestCiv7AssignWorkerPlacement(
+      const runtimeInput = input.mode === "assign-worker" ? {
+        mode: "assign-worker",
+        playerId: await readLocalPlayerId(context5),
+        location: input.location
+      } : input;
+      const result = runtimeInput.mode === "assign-worker" ? await context5.directControl.requestCiv7AssignWorkerPlacement(
         {
-          playerId: input.playerId,
-          location: input.location
+          playerId: runtimeInput.playerId,
+          location: runtimeInput.location
         },
         context5.endpointDefaults
       ) : await context5.directControl.requestCiv7ExpandCityPlacement(
         {
-          cityId: input.cityId,
-          destination: input.destination
+          cityId: runtimeInput.cityId,
+          destination: runtimeInput.destination
         },
         context5.endpointDefaults
       );
-      return cityPopulationPlacementResult(input, result);
+      return cityPopulationPlacementResult(runtimeInput, result);
     },
     catch: () => errors.POPULATION_PLACEMENT_UNAVAILABLE({
       data: {
@@ -33065,6 +33727,12 @@ function cityPopulationPlacementSummary(input) {
       y: input.destination.y
     }
   };
+}
+async function readLocalPlayerId(context5) {
+  const view = await context5.directControl.getCiv7PlayNotificationView(
+    context5.endpointDefaults
+  );
+  return view.localPlayerId;
 }
 function cityPopulationPlacementPostconditionSummary(result) {
   const sourcePostcondition = result.populationPostcondition;
@@ -33210,7 +33878,7 @@ var firstMeetResponseRequestProcedure = civ7ControlOrpcMutationProcedure(
 }) {
   return yield* Effect_exports.tryPromise({
     try: async () => {
-      const localPlayerId = await readLocalPlayerId(context5);
+      const localPlayerId = await readLocalPlayerId2(context5);
       const requestInput = {
         playerId: localPlayerId,
         metPlayerId: input.metPlayerId,
@@ -33231,7 +33899,7 @@ var firstMeetResponseRequestProcedure = civ7ControlOrpcMutationProcedure(
     })
   });
 });
-async function readLocalPlayerId(context5) {
+async function readLocalPlayerId2(context5) {
   const view = await context5.directControl.getCiv7PlayNotificationView(
     context5.endpointDefaults
   );
@@ -33274,11 +33942,18 @@ var diplomacyResponseRequestProcedure = civ7ControlOrpcMutationProcedure(
 }) {
   return yield* Effect_exports.tryPromise({
     try: async () => {
+      const localPlayerId = await readLocalPlayerId3(context5);
+      const requestInput = {
+        playerId: localPlayerId,
+        actionId: input.actionId,
+        responseType: input.responseType,
+        ...input.notificationId === void 0 ? {} : { notificationId: input.notificationId }
+      };
       const result = await context5.directControl.requestCiv7DiplomacyResponse(
-        input,
+        requestInput,
         context5.endpointDefaults
       );
-      return diplomacyResponseResult(input, result);
+      return diplomacyResponseResult(requestInput, result);
     },
     catch: () => errors.DIPLOMACY_RESPONSE_UNAVAILABLE({
       data: {
@@ -33289,6 +33964,12 @@ var diplomacyResponseRequestProcedure = civ7ControlOrpcMutationProcedure(
     })
   });
 });
+async function readLocalPlayerId3(context5) {
+  const view = await context5.directControl.getCiv7PlayNotificationView(
+    context5.endpointDefaults
+  );
+  return view.localPlayerId;
+}
 function diplomacyResponseResult(input, result) {
   const projection = civ7CloseoutMutationProjection({
     sent: result.sent,
@@ -33338,7 +34019,7 @@ var governmentChoiceRequestProcedure = civ7ControlOrpcMutationProcedure(
   const source2 = "government.choice.request";
   return yield* Effect_exports.tryPromise({
     try: async () => {
-      const localPlayerId = await readLocalPlayerId2(context5);
+      const localPlayerId = await readLocalPlayerId4(context5);
       const requestInput = {
         playerId: localPlayerId,
         governmentType: input.governmentType,
@@ -33369,7 +34050,7 @@ var governmentCelebrationChoiceRequestProcedure = civ7ControlOrpcMutationProcedu
   const source2 = "government.celebration.choice.request";
   return yield* Effect_exports.tryPromise({
     try: async () => {
-      const localPlayerId = await readLocalPlayerId2(context5);
+      const localPlayerId = await readLocalPlayerId4(context5);
       const requestInput = {
         playerId: localPlayerId,
         goldenAgeType: input.goldenAgeType
@@ -33389,7 +34070,7 @@ var governmentCelebrationChoiceRequestProcedure = civ7ControlOrpcMutationProcedu
     })
   });
 });
-async function readLocalPlayerId2(context5) {
+async function readLocalPlayerId4(context5) {
   const view = await context5.directControl.getCiv7PlayNotificationView(
     context5.endpointDefaults
   );
@@ -33454,11 +34135,18 @@ var narrativeChoiceRequestProcedure = civ7ControlOrpcMutationProcedure(
 }) {
   return yield* Effect_exports.tryPromise({
     try: async () => {
+      const localPlayerId = await readLocalPlayerId5(context5);
+      const requestInput = {
+        playerId: localPlayerId,
+        targetType: input.targetType,
+        target: input.target,
+        action: input.action
+      };
       const result = await context5.directControl.requestCiv7NarrativeChoice(
-        input,
+        requestInput,
         context5.endpointDefaults
       );
-      return narrativeChoiceResult(input, result);
+      return narrativeChoiceResult(requestInput, result);
     },
     catch: () => errors.NARRATIVE_CHOICE_UNAVAILABLE({
       data: {
@@ -33469,6 +34157,12 @@ var narrativeChoiceRequestProcedure = civ7ControlOrpcMutationProcedure(
     })
   });
 });
+async function readLocalPlayerId5(context5) {
+  const view = await context5.directControl.getCiv7PlayNotificationView(
+    context5.endpointDefaults
+  );
+  return view.localPlayerId;
+}
 function narrativeChoiceResult(input, result) {
   const projection = civ7CloseoutMutationProjection({
     sent: result.sent,
@@ -33513,7 +34207,7 @@ var notificationsAdvisorWarningViewedRequestProcedure = civ7ControlOrpcMutationP
 }) {
   return yield* Effect_exports.tryPromise({
     try: async () => {
-      const localPlayerId = await readLocalPlayerId3(context5);
+      const localPlayerId = await readLocalPlayerId6(context5);
       const result = await context5.directControl.requestCiv7AdvisorWarningViewed(
         {
           playerId: localPlayerId,
@@ -33532,7 +34226,7 @@ var notificationsAdvisorWarningViewedRequestProcedure = civ7ControlOrpcMutationP
     })
   });
 });
-async function readLocalPlayerId3(context5) {
+async function readLocalPlayerId6(context5) {
   const view = await context5.directControl.getCiv7PlayNotificationView(
     context5.endpointDefaults
   );
@@ -34162,6 +34856,318 @@ function probeValue42(value2) {
   }
   return value2 ?? null;
 }
+var progressionDashboardCurrentProcedure = civ7ControlOrpcImplementer.progression.dashboard.current.effect(function* ({
+  context: context5,
+  errors,
+  input
+}) {
+  return yield* Effect_exports.tryPromise({
+    try: async () => {
+      const dashboard = await context5.directControl.getCiv7ProgressDashboard(
+        input,
+        context5.endpointDefaults
+      );
+      return progressionDashboardResult(input, dashboard);
+    },
+    catch: () => errors.PROGRESSION_DASHBOARD_UNAVAILABLE({
+      data: {
+        procedureKey: "progression.dashboard.current",
+        source: "direct-control-facade",
+        ...civ7ControlOrpcErrorCorrelationData(context5)
+      }
+    })
+  });
+});
+function progressionDashboardResult(_input, dashboard) {
+  const legacyPaths = dashboard.legacyPaths.map(compactLegacyPath);
+  const victoryClasses = uniqueStrings(
+    dashboard.victories.rows.map((row) => stringField(row, "victoryClassType"))
+  );
+  const warnings = progressionDashboardWarnings(dashboard);
+  const nextSteps = progressionDashboardNextSteps(dashboard);
+  return {
+    playerId: dashboard.playerId,
+    localPlayerId: dashboard.localPlayerId,
+    sourceStatus: {
+      progressDashboard: "read"
+    },
+    hiddenInfoPolicy: dashboard.hiddenInfoPolicy,
+    summary: {
+      headline: progressionDashboardHeadline(dashboard, legacyPaths),
+      legacyPathCount: legacyPaths.length,
+      victoryClassCount: victoryClasses.length,
+      triumphCount: dashboard.triumphs.count,
+      nextStepCount: nextSteps.length
+    },
+    turn: dashboard.turn,
+    turnDate: dashboard.turnDate,
+    age: {
+      ageType: dashboard.age.ageType,
+      name: dashboard.age.name,
+      chronologyIndex: dashboard.age.chronologyIndex,
+      currentAgeProgressionPoints: dashboard.age.currentAgeProgressionPoints,
+      maxAgeProgressionPoints: dashboard.age.maxAgeProgressionPoints,
+      ageProgressPercent: ratioPercent(
+        probeValue5(dashboard.age.currentAgeProgressionPoints),
+        probeValue5(dashboard.age.maxAgeProgressionPoints)
+      ),
+      isFinalAge: dashboard.age.isFinalAge,
+      isAgeOver: dashboard.age.isAgeOver
+    },
+    player: {
+      team: dashboard.player.team,
+      historicalLegacyPointCountForTeam: dashboard.player.historicalLegacyPointCountForTeam
+    },
+    legacyPaths,
+    victories: {
+      rowCount: dashboard.victories.rows.length,
+      classes: victoryClasses
+    },
+    triumphs: {
+      count: dashboard.triumphs.count,
+      source: dashboard.triumphs.source,
+      rows: dashboard.triumphs.rows.slice(0, 8)
+    },
+    proof: {
+      victoryManagerGlobal: dashboard.proof.victoryManagerGlobal,
+      sources: [...dashboard.proof.sources]
+    },
+    warnings,
+    omitted: [
+      {
+        path: "dashboard.legacyPaths[].milestones",
+        reason: "Milestone probe details stay in the direct-control runtime evidence surface; this service result keeps a summary-first progression view."
+      },
+      {
+        path: "dashboard.victories.rows",
+        reason: "Victory rows are summarized by class for the caller-facing progression view."
+      },
+      {
+        path: "dashboard.triumphs.rows",
+        reason: "The service result includes only the first 8 runtime triumph rows."
+      }
+    ],
+    notes: [...dashboard.notes],
+    nextSteps
+  };
+}
+function compactLegacyPath(path) {
+  const score = probeValue5(path.score);
+  const nextMilestone = path.nextMilestone && typeof path.nextMilestone === "object" ? path.nextMilestone : null;
+  return {
+    legacyPathType: path.legacyPathType,
+    classType: shortClass(path.legacyPathClassType),
+    name: path.name,
+    score: typeof score === "number" ? score : null,
+    finalRequiredPathPoints: path.finalRequiredPathPoints,
+    progressPercent: ratioPercent(score, path.finalRequiredPathPoints),
+    nextMilestone: typeof nextMilestone?.ageProgressionMilestoneType === "string" ? `${nextMilestone.ageProgressionMilestoneType} at ${nextMilestone.requiredPathPoints ?? "?"}` : null,
+    enabledForPlayer: path.enabledForPlayer
+  };
+}
+function progressionDashboardHeadline(dashboard, legacyPaths) {
+  const pathSummary = legacyPaths.map(
+    (path) => `${path.classType ?? path.legacyPathType}: ${path.score ?? "?"}/${path.finalRequiredPathPoints ?? "?"}`
+  ).join(", ");
+  return `${dashboard.age.ageType ?? "unknown age"} progress: ${pathSummary || "no current-age legacy paths surfaced"}`;
+}
+function progressionDashboardWarnings(dashboard) {
+  return [
+    probeValue5(dashboard.proof.victoryManagerGlobal) === "undefined" ? "VictoryManager is module-local in the official UI; this service uses exposed lower-level legacy and age-progress APIs." : null,
+    dashboard.triumphs.count === 0 ? "Runtime GameInfo.Triumphs returned no rows; do not infer that all reward systems are absent." : null
+  ].filter((warning) => Boolean(warning));
+}
+function progressionDashboardNextSteps(dashboard) {
+  const steps = [{
+    kind: "read-attention-priorities",
+    source: "progression.dashboard.current",
+    label: "Read current attention priorities before choosing the next progression action."
+  }];
+  if (dashboard.legacyPaths.length > 0) {
+    steps.push({
+      kind: "inspect-progression-choice",
+      source: "progression.dashboard.current",
+      label: "Inspect available technology, culture, attribute, or tradition choices before sending a progression mutation."
+    });
+  }
+  if (dashboard.victories.rows.length > 0) {
+    steps.push({
+      kind: "inspect-victory-progress",
+      source: "progression.dashboard.current",
+      label: "Use victory classes as progress context, not as an automatic action plan."
+    });
+  }
+  return steps.length > 0 ? steps : [{
+    kind: "observe",
+    source: "progression.dashboard.current",
+    label: "Observe current attention before selecting a progression follow-up."
+  }];
+}
+function probeValue5(probe14) {
+  return probe14?.ok ? probe14.value : null;
+}
+function ratioPercent(current, total) {
+  return typeof current === "number" && typeof total === "number" && total > 0 ? Math.round(current / total * 1e3) / 10 : null;
+}
+function shortClass(value2) {
+  return value2?.replace(/^LEGACY_PATH_CLASS_/, "").toLowerCase() ?? null;
+}
+function stringField(value2, key) {
+  return value2 && typeof value2 === "object" && typeof value2[key] === "string" ? value2[key] : null;
+}
+function uniqueStrings(values3) {
+  return [...new Set(values3.filter((value2) => Boolean(value2)))];
+}
+var progressionTraditionsCurrentProcedure = civ7ControlOrpcImplementer.progression.traditions.current.effect(function* ({
+  context: context5,
+  errors,
+  input
+}) {
+  return yield* Effect_exports.tryPromise({
+    try: async () => {
+      const traditions = await context5.directControl.getCiv7TraditionsView(
+        input,
+        context5.endpointDefaults
+      );
+      return progressionTraditionsResult(input, traditions);
+    },
+    catch: () => errors.PROGRESSION_TRADITIONS_UNAVAILABLE({
+      data: {
+        procedureKey: "progression.traditions.current",
+        source: "direct-control-facade",
+        ...civ7ControlOrpcErrorCorrelationData(context5)
+      }
+    })
+  });
+});
+function progressionTraditionsResult(_input, view) {
+  const active2 = view.active.map(traditionRow);
+  const available = view.available.map(traditionRow);
+  const recentUnlocks = view.recentUnlocks.map(traditionRow);
+  const traditions = view.traditions.map(traditionRow);
+  const nextSteps = traditionsNextSteps(view, available, active2);
+  return {
+    playerId: view.playerId,
+    sourceStatus: {
+      traditions: "read"
+    },
+    hiddenInfoPolicy: view.hiddenInfoPolicy,
+    summary: {
+      activeCount: active2.length,
+      availableCount: available.length,
+      recentUnlockCount: recentUnlocks.length,
+      openSlotCount: view.slots.open,
+      enabledAvailableCount: available.filter(
+        (tradition) => tradition.actions.some((action) => action.validationSuccess === true)
+      ).length,
+      disabledAvailableCount: available.filter(
+        (tradition) => !tradition.actions.some((action) => action.validationSuccess === true)
+      ).length,
+      nextStepCount: nextSteps.length
+    },
+    turn: view.turn,
+    turnDate: view.turnDate,
+    governmentType: view.governmentType,
+    government: view.government,
+    slots: view.slots,
+    actions: view.actions,
+    active: active2,
+    available,
+    recentUnlocks,
+    traditions,
+    omitted: [
+      {
+        path: "directControl.cliCommandSuggestions",
+        reason: "CLI command strings are caller presentation, not progression service output."
+      },
+      {
+        path: "tradition.actionHints[].cli",
+        reason: "Tradition action hints are projected as semantic action descriptors with parameters."
+      },
+      {
+        path: "tradition.actionHints[].validation",
+        reason: "Validation probe details remain low-level runtime evidence; service rows expose validationSuccess."
+      }
+    ],
+    notes: [
+      ...view.notes,
+      "Read-only progression traditions view. It does not send CHANGE_TRADITION or review closeout mutations."
+    ],
+    nextSteps
+  };
+}
+function traditionRow(tradition) {
+  return {
+    id: tradition.id,
+    type: tradition.type,
+    name: tradition.name,
+    description: tradition.description,
+    ageType: tradition.ageType,
+    cultureSlotType: tradition.cultureSlotType,
+    traitType: tradition.traitType,
+    isCrisis: tradition.isCrisis,
+    active: tradition.active,
+    unlocked: tradition.unlocked,
+    recentUnlock: tradition.recentUnlock,
+    actions: tradition.actionHints.map((action) => ({
+      kind: action.kind,
+      action: action.action,
+      validationSuccess: validationSuccess(action.validation),
+      parameters: {
+        traditionType: tradition.id,
+        action: action.action
+      },
+      nextSteps: [
+        {
+          kind: "validate-tradition-change",
+          source: "progression.traditions.current",
+          label: `Validate ${action.kind} for ${tradition.name ?? tradition.type ?? tradition.id}.`,
+          parameters: {
+            traditionType: tradition.id,
+            action: action.action
+          }
+        },
+        {
+          kind: "request-tradition-change",
+          source: "progression.traditions.current",
+          label: `Request ${action.kind} for ${tradition.name ?? tradition.type ?? tradition.id} only after choosing this tradition.`,
+          parameters: {
+            traditionType: tradition.id,
+            action: action.action
+          }
+        }
+      ]
+    }))
+  };
+}
+function traditionsNextSteps(view, available, active2) {
+  if (available.some((tradition) => tradition.actions.length > 0)) {
+    return [{
+      kind: "inspect-tradition-change",
+      source: "progression.traditions.current",
+      label: "Inspect available tradition action descriptors before requesting a tradition change."
+    }];
+  }
+  if (view.slots.open === 0 && active2.some((tradition) => tradition.actions.length > 0)) {
+    return [{
+      kind: "free-policy-slot",
+      source: "progression.traditions.current",
+      label: "If a policy slot is full, inspect active traditions before deactivating one."
+    }];
+  }
+  return [{
+    kind: "observe",
+    source: "progression.traditions.current",
+    label: "Observe current attention before selecting a progression follow-up."
+  }];
+}
+function validationSuccess(validation) {
+  if (!validation || typeof validation !== "object") return null;
+  const probe14 = validation;
+  if (probe14.ok !== true) return null;
+  const value2 = probe14.value;
+  return value2 && typeof value2 === "object" && "Success" in value2 ? value2.Success === true : null;
+}
 var progressionTechnologyTargetRequestProcedure = civ7ControlOrpcMutationProcedure(
   civ7ControlOrpcImplementer.progression.technology.target.request
 ).effect(function* ({
@@ -34173,7 +35179,7 @@ var progressionTechnologyTargetRequestProcedure = civ7ControlOrpcMutationProcedu
   const source2 = "progression.technology.target.request";
   return yield* Effect_exports.tryPromise({
     try: async () => {
-      const localPlayerId = await readLocalPlayerId4(context5);
+      const localPlayerId = await readLocalPlayerId7(context5);
       const requestInput = progressionTargetRuntimeInput(input, localPlayerId);
       const result = await requestProgressionTarget(kind, requestInput, context5);
       return progressionTargetResult(source2, requestInput, result);
@@ -34198,7 +35204,7 @@ var progressionCultureTargetRequestProcedure = civ7ControlOrpcMutationProcedure(
   const source2 = "progression.culture.target.request";
   return yield* Effect_exports.tryPromise({
     try: async () => {
-      const localPlayerId = await readLocalPlayerId4(context5);
+      const localPlayerId = await readLocalPlayerId7(context5);
       const requestInput = progressionTargetRuntimeInput(input, localPlayerId);
       const result = await requestProgressionTarget(kind, requestInput, context5);
       return progressionTargetResult(source2, requestInput, result);
@@ -34212,7 +35218,7 @@ var progressionCultureTargetRequestProcedure = civ7ControlOrpcMutationProcedure(
     })
   });
 });
-async function readLocalPlayerId4(context5) {
+async function readLocalPlayerId7(context5) {
   const view = await context5.directControl.getCiv7PlayNotificationView(
     context5.endpointDefaults
   );
@@ -34273,7 +35279,7 @@ var progressionAttributePurchaseRequestProcedure = civ7ControlOrpcMutationProced
   const source2 = "progression.attribute.purchase.request";
   return yield* Effect_exports.tryPromise({
     try: async () => {
-      const localPlayerId = await readLocalPlayerId5(context5);
+      const localPlayerId = await readLocalPlayerId8(context5);
       const requestInput = {
         playerId: localPlayerId,
         node: input.node
@@ -34302,7 +35308,7 @@ var progressionAttributeReviewRequestProcedure = civ7ControlOrpcMutationProcedur
   const source2 = "progression.attribute.review.request";
   return yield* Effect_exports.tryPromise({
     try: async () => {
-      const localPlayerId = await readLocalPlayerId5(context5);
+      const localPlayerId = await readLocalPlayerId8(context5);
       const requestInput = { playerId: localPlayerId };
       const result = await context5.directControl.requestCiv7AttributeReviewCloseout(
         requestInput,
@@ -34329,7 +35335,7 @@ var progressionTraditionChangeRequestProcedure = civ7ControlOrpcMutationProcedur
   const source2 = "progression.tradition.change.request";
   return yield* Effect_exports.tryPromise({
     try: async () => {
-      const localPlayerId = await readLocalPlayerId5(context5);
+      const localPlayerId = await readLocalPlayerId8(context5);
       const requestInput = {
         playerId: localPlayerId,
         traditionType: input.traditionType,
@@ -34359,7 +35365,7 @@ var progressionTraditionReviewRequestProcedure = civ7ControlOrpcMutationProcedur
   const source2 = "progression.tradition.review.request";
   return yield* Effect_exports.tryPromise({
     try: async () => {
-      const localPlayerId = await readLocalPlayerId5(context5);
+      const localPlayerId = await readLocalPlayerId8(context5);
       const requestInput = { playerId: localPlayerId };
       const result = await context5.directControl.requestCiv7TraditionReviewCloseout(
         requestInput,
@@ -34376,7 +35382,7 @@ var progressionTraditionReviewRequestProcedure = civ7ControlOrpcMutationProcedur
     })
   });
 });
-async function readLocalPlayerId5(context5) {
+async function readLocalPlayerId8(context5) {
   const view = await context5.directControl.getCiv7PlayNotificationView(
     context5.endpointDefaults
   );
@@ -34429,6 +35435,12 @@ function progressionPlayerChoiceResult(source2, input, result) {
   throw new Error("invalid progression player-choice projection");
 }
 var progressionRouter = {
+  dashboard: {
+    current: progressionDashboardCurrentProcedure
+  },
+  traditions: {
+    current: progressionTraditionsCurrentProcedure
+  },
   technology: {
     choice: {
       request: progressionTechnologyChoiceRequestProcedure
@@ -34489,10 +35501,10 @@ function readinessCurrentResult(status, context5) {
     capability: readinessCapability(status, context5),
     sources: {
       gameUi: {
-        inGame: probeValue5(status.appUi.snapshot.ui.inGame),
-        inShell: probeValue5(status.appUi.snapshot.ui.inShell),
-        inLoading: probeValue5(status.appUi.snapshot.ui.inLoading),
-        canBeginGame: probeValue5(status.appUi.snapshot.ui.canBeginGame)
+        inGame: probeValue6(status.appUi.snapshot.ui.inGame),
+        inShell: probeValue6(status.appUi.snapshot.ui.inShell),
+        inLoading: probeValue6(status.appUi.snapshot.ui.inLoading),
+        canBeginGame: probeValue6(status.appUi.snapshot.ui.canBeginGame)
       },
       runtimeControl: {
         ready: status.tuner?.ready ?? null
@@ -34636,7 +35648,7 @@ function supportsWorldCurrent(context5) {
 function supportedReadProcedures(context5) {
   return context5.controller?.supportedReadProcedures ?? [];
 }
-function probeValue5(probe14) {
+function probeValue6(probe14) {
   return probe14.ok ? probe14.value : null;
 }
 var readinessRouter = {
@@ -34655,7 +35667,7 @@ var strategyCivilianRouteTriageProcedure = civ7ControlOrpcImplementer.strategy.c
         maxNotifications: 10
       });
       const requestedOrigin = input.origin ?? null;
-      const readyUnitId = probeValue6(notifications.firstReadyUnitId);
+      const readyUnitId = probeValue7(notifications.firstReadyUnitId);
       const readyUnit = requestedOrigin != null || readyUnitId == null ? null : await context5.directControl.getCiv7ReadyUnitView({
         unitId: readyUnitId,
         radius: 2
@@ -34719,7 +35731,7 @@ function civilianRouteTriageResult({
   const reasons = triageReasons({ battlefield, destinationAnalysis });
   const status = triageStatus({ destination, reasons });
   const nextSteps = triageNextSteps({ origin, destination, status });
-  const unit = readyUnit == null ? null : probeValue6(readyUnit.unit);
+  const unit = readyUnit == null ? null : probeValue7(readyUnit.unit);
   const firstSuggestion = firstSettlementSuggestion(settlement);
   return {
     playerId: settlement.playerId,
@@ -34786,7 +35798,7 @@ function triageReasons({
   battlefield,
   destinationAnalysis
 }) {
-  return uniqueStrings([
+  return uniqueStrings2([
     ...battlefield.pointsOfInterest.map(
       (point) => `${point.severity} local ${point.kind}: ${normalizeRelationshipSummary(point.summary)}`
     ),
@@ -34883,7 +35895,7 @@ function destinationPressureReasons(destinationAnalysis) {
 }
 function firstSettlementSuggestion(settlement) {
   for (const recommendation of settlement.recommendations) {
-    const suggestions = probeValue6(recommendation.suggestions);
+    const suggestions = probeValue7(recommendation.suggestions);
     if (!Array.isArray(suggestions)) continue;
     for (const suggestion of suggestions) {
       const location = locationFromUnknown(asRecord2(suggestion)?.location);
@@ -34893,7 +35905,7 @@ function firstSettlementSuggestion(settlement) {
   return null;
 }
 function readyUnitLocation2(readyUnit) {
-  const unit = readyUnit == null ? null : probeValue6(readyUnit.unit);
+  const unit = readyUnit == null ? null : probeValue7(readyUnit.unit);
   return locationFromUnknown(asRecord2(unit)?.location);
 }
 function routeSummary(origin, destination) {
@@ -34908,7 +35920,7 @@ function locationFromUnknown(value2) {
   const record = asRecord2(value2);
   return typeof record?.x === "number" && typeof record.y === "number" ? { x: record.x, y: record.y } : null;
 }
-function probeValue6(probe14) {
+function probeValue7(probe14) {
   return probe14?.ok === true ? probe14.value : null;
 }
 function asRecord2(value2) {
@@ -34920,7 +35932,7 @@ function numericValue2(value2) {
 function stringValue2(value2) {
   return typeof value2 === "string" ? value2 : null;
 }
-function uniqueStrings(values3) {
+function uniqueStrings2(values3) {
   return [...new Set(values3.filter((value2) => value2.length > 0))];
 }
 var strategyFormationSnapshotProcedure = civ7ControlOrpcImplementer.strategy.formationSnapshot.effect(function* ({
@@ -34935,7 +35947,7 @@ var strategyFormationSnapshotProcedure = civ7ControlOrpcImplementer.strategy.for
         ...endpointDefaults,
         maxNotifications: 10
       });
-      const readyUnitId = probeValue7(notifications.firstReadyUnitId);
+      const readyUnitId = probeValue8(notifications.firstReadyUnitId);
       const requestedOrigin = input.origin ?? null;
       const readyUnit = requestedOrigin != null || readyUnitId == null ? null : await context5.directControl.getCiv7ReadyUnitView({
         unitId: readyUnitId,
@@ -35007,13 +36019,13 @@ function formationSnapshotResult({
     nearbyContacts,
     posture
   });
-  const readyUnitValue = readyUnit == null ? null : probeValue7(readyUnit.unit);
+  const readyUnitValue = readyUnit == null ? null : probeValue8(readyUnit.unit);
   return {
     playerId: battlefield.playerId,
     localPlayerId: battlefield.localPlayerId,
-    turn: probeValue7(notifications.turn),
-    turnDate: probeValue7(notifications.turnDate),
-    blocker: numericValue3(probeValue7(notifications.blocker)),
+    turn: probeValue8(notifications.turn),
+    turnDate: probeValue8(notifications.turnDate),
+    blocker: numericValue3(probeValue8(notifications.blocker)),
     nextDecision: stringValue3(asRecord3(notifications.hud)?.nextDecision),
     origin,
     sourceStatus: {
@@ -35048,7 +36060,7 @@ function formationSnapshotResult({
         screens,
         nearbyContacts
       }),
-      reasons: uniqueStrings2([
+      reasons: uniqueStrings3([
         ...poiReasons,
         ...civilianContactReasons(civilians, nearbyContacts),
         ...screenReasons(civilians, screens)
@@ -35156,7 +36168,7 @@ function formationHeadline({
   return `${readyUnitSummary2(readyUnit)} formation at ${originLabel}: ${civilians.length} civilians, ${screens.length} local screens, ${nearbyContacts.length} nearby other-owner contacts`;
 }
 function readyUnitSummary2(readyUnit) {
-  const unit = readyUnit == null ? null : probeValue7(readyUnit.unit);
+  const unit = readyUnit == null ? null : probeValue8(readyUnit.unit);
   return stringValue3(asRecord3(unit)?.typeName) ?? "ready unit";
 }
 function pointReasons(value2) {
@@ -35182,7 +36194,7 @@ function screenReasons(civilians, screens) {
   return [`${screens.length} own screen units are within local screen radius of the civilian`];
 }
 function readyUnitLocation3(readyUnit) {
-  const unit = readyUnit == null ? null : probeValue7(readyUnit.unit);
+  const unit = readyUnit == null ? null : probeValue8(readyUnit.unit);
   return locationFromUnknown2(asRecord3(unit)?.location);
 }
 function componentIdFromUnknown3(value2) {
@@ -35196,7 +36208,7 @@ function locationFromUnknown2(value2) {
 function gridDistance(left3, right3) {
   return Math.max(Math.abs(left3.x - right3.x), Math.abs(left3.y - right3.y));
 }
-function probeValue7(probe14) {
+function probeValue8(probe14) {
   return probe14?.ok === true ? probe14.value : null;
 }
 function asRecords(value2) {
@@ -35220,7 +36232,7 @@ function formationStance(value2) {
   if (value2 === "friendly") return "own";
   return typeof value2 === "string" ? value2 : "unknown";
 }
-function uniqueStrings2(values3) {
+function uniqueStrings3(values3) {
   return [...new Set(values3.filter((value2) => value2.length > 0))];
 }
 function uniqueNextSteps(values3) {
@@ -35477,7 +36489,7 @@ function strategyFrontView({
     source: point.source
   })).sort((a, b) => severityRank(b.severity) - severityRank(a.severity));
   const highPressure = pressure.filter((item) => item.severity === "high");
-  const risks = uniqueStrings3([
+  const risks = uniqueStrings4([
     ...highPressure.map((item) => item.summary),
     ...destinationRisks(destinationAnalysis)
   ]).slice(0, 8);
@@ -35551,13 +36563,489 @@ function locationFromUnknown3(value2) {
 function asRecord4(value2) {
   return value2 !== null && typeof value2 === "object" ? value2 : null;
 }
-function uniqueStrings3(values3) {
+function uniqueStrings4(values3) {
   return [...new Set(values3.filter((value2) => value2.length > 0))];
 }
+var strategyBattlefieldScanProcedure = civ7ControlOrpcImplementer.strategy.battlefieldScan.effect(function* ({
+  context: context5,
+  errors,
+  input
+}) {
+  return yield* Effect_exports.tryPromise({
+    try: async () => {
+      const result = await context5.directControl.getCiv7BattlefieldScan(
+        input,
+        context5.endpointDefaults
+      );
+      return battlefieldScanResult(result);
+    },
+    catch: () => errors.STRATEGY_TACTICAL_READ_UNAVAILABLE({
+      data: {
+        procedureKey: "strategy.battlefieldScan",
+        source: "direct-control-facade",
+        ...civ7ControlOrpcErrorCorrelationData(context5)
+      }
+    })
+  });
+});
+var strategyTargetCandidatesProcedure = civ7ControlOrpcImplementer.strategy.targetCandidates.effect(function* ({
+  context: context5,
+  errors,
+  input
+}) {
+  return yield* Effect_exports.tryPromise({
+    try: async () => {
+      const result = await context5.directControl.getCiv7TargetCandidates(
+        input,
+        context5.endpointDefaults
+      );
+      return targetCandidatesResult(result);
+    },
+    catch: () => errors.STRATEGY_TACTICAL_READ_UNAVAILABLE({
+      data: {
+        procedureKey: "strategy.targetCandidates",
+        source: "direct-control-facade",
+        ...civ7ControlOrpcErrorCorrelationData(context5)
+      }
+    })
+  });
+});
+var strategyDestinationAnalysisProcedure = civ7ControlOrpcImplementer.strategy.destinationAnalysis.effect(function* ({
+  context: context5,
+  errors,
+  input
+}) {
+  return yield* Effect_exports.tryPromise({
+    try: async () => {
+      const result = await context5.directControl.getCiv7DestinationAnalysis(
+        input,
+        context5.endpointDefaults
+      );
+      return destinationAnalysisResult(result);
+    },
+    catch: () => errors.STRATEGY_TACTICAL_READ_UNAVAILABLE({
+      data: {
+        procedureKey: "strategy.destinationAnalysis",
+        source: "direct-control-facade",
+        ...civ7ControlOrpcErrorCorrelationData(context5)
+      }
+    })
+  });
+});
+function battlefieldScanResult(result) {
+  const owners = asArray2(result.owners).map((owner) => {
+    const record = asRecord5(owner);
+    const relationshipProof = record?.relationshipProof === "self" ? "self" : "none";
+    return {
+      owner: numberFromUnknown(record?.owner),
+      relationship: relationshipProof === "self" ? "self" : "relationship-unproven",
+      relationshipProof,
+      unitCount: numberFromUnknown(record?.unitCount),
+      cityCount: numberFromUnknown(record?.cityCount),
+      apparentStrength: numberFromUnknown(record?.apparentStrength),
+      nearestDistance: nearestOwnerDistance2(record),
+      roles: integerRecord(record?.roles)
+    };
+  });
+  const pointsOfInterest2 = asArray2(result.pointsOfInterest).map((point) => {
+    const record = asRecord5(point);
+    return {
+      kind: String(record?.kind ?? "unknown"),
+      severity: String(record?.severity ?? "unknown"),
+      location: locationFromUnknown4(record?.location),
+      summary: normalizeRelationshipSummary4(String(record?.summary ?? ""))
+    };
+  });
+  const nextSteps = battlefieldNextSteps({
+    origins: result.origins,
+    pointsOfInterest: pointsOfInterest2
+  });
+  return {
+    playerId: result.playerId,
+    localPlayerId: result.localPlayerId,
+    origins: result.origins,
+    radius: result.radius,
+    hiddenInfoPolicy: result.hiddenInfoPolicy,
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "Battlefield scan is planning evidence only. Owner contact, proximity, role heuristics, and apparent strength do not prove official diplomatic status."
+    },
+    summary: {
+      unitCount: asArray2(result.units).length,
+      cityCount: asArray2(result.cities).length,
+      observedOwnerCount: owners.length,
+      pointOfInterestCount: pointsOfInterest2.length,
+      apparentStrengthTotal: owners.reduce(
+        (total, owner) => total + owner.apparentStrength,
+        0
+      ),
+      nextStepCount: nextSteps.length
+    },
+    owners,
+    pointsOfInterest: pointsOfInterest2,
+    omitted: [
+      {
+        path: "directControl.host",
+        reason: "endpoint context is not normal service output"
+      },
+      {
+        path: "directControl.state",
+        reason: "runtime state selection is context/debug owned"
+      },
+      {
+        path: "units",
+        reason: "raw unit samples stay behind bounded owner and point summaries"
+      },
+      {
+        path: "cities",
+        reason: "raw city samples stay behind bounded owner and point summaries"
+      },
+      {
+        path: "point.units",
+        reason: "raw point unit samples stay behind bounded point summaries"
+      },
+      {
+        path: "point.cities",
+        reason: "raw point city samples stay behind bounded point summaries"
+      }
+    ],
+    notes: [
+      ...result.notes.map(normalizeRelationshipSummary4),
+      "Use visibility reads and validator-backed unit action procedures before any mutation."
+    ],
+    nextSteps
+  };
+}
+function targetCandidatesResult(result) {
+  const candidates = result.candidates.map((candidate2) => {
+    const targetLocation = locationFromUnknown4(candidate2.approach.targetLocation);
+    return {
+      owner: candidate2.owner,
+      relationship: "relationship-unproven",
+      relationshipProof: "none",
+      leaderName: probeValue9(candidate2.leaderName, "string"),
+      civilizationName: probeValue9(candidate2.civilizationName, "string"),
+      isHuman: probeValue9(candidate2.isHuman, "boolean"),
+      cityCount: candidate2.cityCount,
+      unitCount: candidate2.unitCount,
+      nearestDistance: candidate2.nearestDistance,
+      nearbyUnitCount: candidate2.nearbyUnitCount,
+      apparentStrength: candidate2.apparentStrength,
+      nearestCityLocation: locationFromUnknown4(candidate2.nearestCity),
+      approach: {
+        nearestOrigin: locationFromUnknown4(candidate2.approach.nearestOrigin),
+        targetLocation,
+        directGridDistance: candidate2.approach.directGridDistance,
+        routeHint: candidate2.approach.routeHint,
+        routeKind: candidate2.approach.routeKind,
+        waterSampleCount: Math.max(0, Math.trunc(candidate2.approach.waterSampleCount)),
+        landSampleCount: Math.max(0, Math.trunc(candidate2.approach.landSampleCount)),
+        notes: [...candidate2.approach.notes]
+      },
+      reasons: [...candidate2.reasons]
+    };
+  });
+  const nextSteps = targetCandidateNextSteps(candidates);
+  return {
+    playerId: result.playerId,
+    localPlayerId: result.localPlayerId,
+    origins: result.origins,
+    unitRadius: result.unitRadius,
+    hiddenInfoPolicy: result.hiddenInfoPolicy,
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "Target candidates are planning evidence only. Other-owner contact, route ranking, proximity, and apparent strength do not prove official diplomatic status."
+    },
+    summary: {
+      candidateCount: candidates.length,
+      nearestDistance: nearestDistance(candidates),
+      observedOwnerCount: new Set(candidates.map((candidate2) => candidate2.owner)).size,
+      apparentStrengthTotal: candidates.reduce(
+        (total, candidate2) => total + candidate2.apparentStrength,
+        0
+      ),
+      nextStepCount: nextSteps.length
+    },
+    candidates,
+    omitted: [
+      {
+        path: "directControl.host",
+        reason: "endpoint context is not normal service output"
+      },
+      {
+        path: "directControl.state",
+        reason: "runtime state selection is context/debug owned"
+      },
+      {
+        path: "candidate.cities",
+        reason: "raw city samples stay behind bounded candidate summaries"
+      },
+      {
+        path: "candidate.nearbyUnits",
+        reason: "raw unit samples stay behind bounded candidate summaries"
+      }
+    ],
+    notes: [
+      ...result.notes.map(normalizeRelationshipSummary4),
+      "Use visibility reads and validator-backed unit action procedures before any mutation."
+    ],
+    nextSteps
+  };
+}
+function destinationAnalysisResult(result) {
+  const corridor = asRecord5(result.corridor);
+  const destinationPressure = asRecord5(result.destinationPressure);
+  const pointsOfInterest2 = asArray2(result.pointsOfInterest).map((point) => {
+    const record = asRecord5(point);
+    return {
+      kind: String(record?.kind ?? "unknown"),
+      severity: String(record?.severity ?? "unknown"),
+      location: locationFromUnknown4(record?.location),
+      summary: normalizeRelationshipSummary4(String(record?.summary ?? ""))
+    };
+  });
+  const nextSteps = destinationNextSteps({
+    origin: result.origin,
+    destination: result.destination,
+    pointsOfInterest: pointsOfInterest2
+  });
+  const corridorUnitCount = numberFromUnknown(corridor?.unitCount);
+  const destinationUnitCount = numberFromUnknown(destinationPressure?.unitCount);
+  const destinationCityCount = numberFromUnknown(destinationPressure?.cityCount);
+  const apparentOtherStrength = numberFromUnknown(
+    destinationPressure?.apparentOtherStrength
+  );
+  return {
+    playerId: result.playerId,
+    localPlayerId: result.localPlayerId,
+    origin: result.origin,
+    destination: result.destination,
+    corridorRadius: result.corridorRadius,
+    destinationRadius: result.destinationRadius,
+    hiddenInfoPolicy: result.hiddenInfoPolicy,
+    relationshipLabelPolicy: {
+      relationshipSource: "not-classified",
+      relationshipProof: "none",
+      unprovenLabel: "relationship-unproven",
+      guidance: "Destination analysis is planning evidence only. Other-owner contact, destination proximity, and apparent strength do not prove official diplomatic status."
+    },
+    summary: {
+      pointOfInterestCount: pointsOfInterest2.length,
+      corridorUnitCount,
+      destinationUnitCount,
+      destinationCityCount,
+      apparentOtherStrength,
+      nextStepCount: nextSteps.length
+    },
+    corridor: {
+      routeHint: String(corridor?.routeHint ?? "unknown"),
+      directGridDistance: nullableNumber(corridor?.directGridDistance),
+      sampleCount: numberFromUnknown(corridor?.sampleCount),
+      unitCount: corridorUnitCount
+    },
+    destinationPressure: {
+      unitCount: destinationUnitCount,
+      cityCount: destinationCityCount,
+      apparentOtherStrength
+    },
+    pointsOfInterest: pointsOfInterest2,
+    omitted: [
+      {
+        path: "directControl.host",
+        reason: "endpoint context is not normal service output"
+      },
+      {
+        path: "directControl.state",
+        reason: "runtime state selection is context/debug owned"
+      },
+      {
+        path: "corridor.sampledPlots",
+        reason: "raw plot samples stay behind bounded corridor summaries"
+      },
+      {
+        path: "destinationPressure.units",
+        reason: "raw unit samples stay behind bounded pressure summaries"
+      },
+      {
+        path: "destinationPressure.cities",
+        reason: "raw city samples stay behind bounded pressure summaries"
+      }
+    ],
+    notes: [
+      ...result.notes.map(normalizeRelationshipSummary4),
+      "Use visibility reads and validator-backed unit action procedures before any mutation."
+    ],
+    nextSteps
+  };
+}
+function battlefieldNextSteps(input) {
+  const point = input.pointsOfInterest[0];
+  const origin = input.origins[0];
+  if (point == null) {
+    return [{
+      kind: "observe",
+      source: "strategy.battlefieldScan",
+      label: "No battlefield points found; refresh attention or narrow scan origins.",
+      parameters: origin ? { origin } : {}
+    }];
+  }
+  return [
+    {
+      kind: "inspect-battlefield-point",
+      source: "strategy.battlefieldScan",
+      label: `Inspect ${point.kind} battlefield point before choosing a unit action.`,
+      parameters: {
+        ...origin ? { origin } : {},
+        ...point.location ? { location: point.location } : {}
+      }
+    },
+    {
+      kind: "read-visibility",
+      source: "strategy.battlefieldScan",
+      label: "Read visibility/map evidence before promoting battlefield contact into an action.",
+      parameters: point.location ? { location: point.location } : {}
+    },
+    {
+      kind: "validate-unit-action",
+      source: "strategy.battlefieldScan",
+      label: "Use unit action validation before any movement or target send.",
+      parameters: point.location ? { location: point.location } : {}
+    }
+  ];
+}
+function targetCandidateNextSteps(candidates) {
+  const candidate2 = candidates[0];
+  if (candidate2 == null) {
+    return [{
+      kind: "observe",
+      source: "strategy.targetCandidates",
+      label: "No target candidates found; refresh strategy evidence or narrow origins.",
+      parameters: {}
+    }];
+  }
+  return [
+    {
+      kind: "inspect-candidate",
+      source: "strategy.targetCandidates",
+      label: `Inspect owner ${candidate2.owner} candidate with visibility reads before treating it as actionable.`,
+      parameters: {
+        owner: candidate2.owner,
+        ...candidate2.approach.targetLocation ? { target: candidate2.approach.targetLocation } : {}
+      }
+    },
+    {
+      kind: "read-visibility",
+      source: "strategy.targetCandidates",
+      label: "Read visibility/map evidence before promoting candidate ranking into an action.",
+      parameters: candidate2.approach.targetLocation ? { target: candidate2.approach.targetLocation } : {}
+    },
+    {
+      kind: "validate-unit-action",
+      source: "strategy.targetCandidates",
+      label: "Use unit action validation before any movement or target send.",
+      parameters: candidate2.approach.targetLocation ? { target: candidate2.approach.targetLocation } : {}
+    }
+  ];
+}
+function destinationNextSteps(input) {
+  if (input.pointsOfInterest.length === 0) {
+    return [{
+      kind: "observe",
+      source: "strategy.destinationAnalysis",
+      label: "No destination pressure found; refresh map/visibility evidence before acting.",
+      parameters: { origin: input.origin ?? void 0, destination: input.destination }
+    }];
+  }
+  return [
+    {
+      kind: "inspect-destination",
+      source: "strategy.destinationAnalysis",
+      label: "Inspect destination contact and visibility before choosing a unit action.",
+      parameters: { origin: input.origin ?? void 0, destination: input.destination }
+    },
+    {
+      kind: "read-visibility",
+      source: "strategy.destinationAnalysis",
+      label: "Read visibility/map evidence before promoting destination pressure into an action.",
+      parameters: { destination: input.destination }
+    },
+    {
+      kind: "validate-unit-action",
+      source: "strategy.destinationAnalysis",
+      label: "Use unit action validation before any movement or target send.",
+      parameters: { origin: input.origin ?? void 0, destination: input.destination }
+    }
+  ];
+}
+function nearestDistance(candidates) {
+  const distances = candidates.map((candidate2) => candidate2.nearestDistance).filter((value2) => value2 != null);
+  if (distances.length === 0) return null;
+  return Math.min(...distances);
+}
+function probeValue9(probe14, type) {
+  const record = asRecord5(probe14);
+  if (record?.ok !== true || typeof record.value !== type) return null;
+  return record.value;
+}
+function nearestOwnerDistance2(owner) {
+  const distances = [
+    distanceFromUnknown2(owner?.nearestUnit),
+    distanceFromUnknown2(owner?.nearestCity)
+  ].filter((distance2) => distance2 != null);
+  if (distances.length === 0) return null;
+  return Math.min(...distances);
+}
+function distanceFromUnknown2(value2) {
+  const record = asRecord5(value2);
+  return nullableNumber(record?.distance);
+}
+function integerRecord(value2) {
+  const record = asRecord5(value2);
+  if (record == null) return {};
+  const out = {};
+  for (const [key, candidate2] of Object.entries(record)) {
+    const value22 = numberFromUnknown(candidate2);
+    if (value22 > 0) out[key] = Math.trunc(value22);
+  }
+  return out;
+}
+function locationFromUnknown4(value2) {
+  const direct = asRecord5(value2);
+  if (typeof direct?.x === "number" && typeof direct.y === "number") {
+    return { x: direct.x, y: direct.y };
+  }
+  const nested2 = asRecord5(direct?.location);
+  if (typeof nested2?.x === "number" && typeof nested2.y === "number") {
+    return { x: nested2.x, y: nested2.y };
+  }
+  return null;
+}
+function asArray2(value2) {
+  return Array.isArray(value2) ? value2 : [];
+}
+function asRecord5(value2) {
+  return value2 !== null && typeof value2 === "object" ? value2 : null;
+}
+function numberFromUnknown(value2) {
+  return typeof value2 === "number" && Number.isFinite(value2) ? value2 : 0;
+}
+function nullableNumber(value2) {
+  return typeof value2 === "number" && Number.isFinite(value2) ? value2 : null;
+}
+function normalizeRelationshipSummary4(summary5) {
+  return summary5.replace(/\bfriendly\b/gi, "own").replace(/\bpressure\b/gi, "contact").replace(/\bthreat\b/gi, "contact").replace(/\benemy\b/gi, "other-owner").replace(/\bhostile\b/gi, "other-owner").replace(/\bopponent\b/gi, "other-owner");
+}
 var strategyRouter = {
+  battlefieldScan: strategyBattlefieldScanProcedure,
   civilianRouteTriage: strategyCivilianRouteTriageProcedure,
+  destinationAnalysis: strategyDestinationAnalysisProcedure,
   formationSnapshot: strategyFormationSnapshotProcedure,
-  frontSummary: strategyFrontSummaryProcedure
+  frontSummary: strategyFrontSummaryProcedure,
+  targetCandidates: strategyTargetCandidatesProcedure
 };
 var turnCompleteRequestProcedure = civ7ControlOrpcMutationProcedure(
   civ7ControlOrpcImplementer.turn.complete.request
@@ -35658,20 +37146,20 @@ function turnCompletionPostconditionSummary(result) {
 }
 function turnCompletionProbeSummary(status) {
   return {
-    turn: probeValue8(status.turn),
-    turnDate: probeValue8(status.turnDate),
-    hasSentTurnComplete: probeValue8(status.hasSentTurnComplete),
-    canEndTurn: probeValue8(status.canEndTurn),
+    turn: probeValue10(status.turn),
+    turnDate: probeValue10(status.turnDate),
+    hasSentTurnComplete: probeValue10(status.hasSentTurnComplete),
+    canEndTurn: probeValue10(status.canEndTurn),
     blocker: blockerValue(status.blocker),
-    firstReadyUnitId: probeValue8(status.firstReadyUnitId)
+    firstReadyUnitId: probeValue10(status.firstReadyUnitId)
   };
 }
 function blockerValue(probe14) {
-  const value2 = probeValue8(probe14);
+  const value2 = probeValue10(probe14);
   if (typeof value2 === "number" || typeof value2 === "string") return value2;
   return null;
 }
-function probeValue8(probe14) {
+function probeValue10(probe14) {
   return probe14.ok ? probe14.value : null;
 }
 var turnRouter = {
@@ -35979,10 +37467,10 @@ function worldCurrentResult(status) {
     },
     turn: inGame ? {
       current: status.appUi.snapshot.game.turn,
-      date: probeValue9(status.appUi.snapshot.game.turnDate),
+      date: probeValue11(status.appUi.snapshot.game.turnDate),
       age: status.appUi.snapshot.game.age,
       maxTurns: status.appUi.snapshot.game.maxTurns,
-      hash: probeValue9(status.appUi.snapshot.game.hash)
+      hash: probeValue11(status.appUi.snapshot.game.hash)
     } : {
       current: null,
       date: null,
@@ -36012,11 +37500,11 @@ function worldCurrentResult(status) {
 function worldMapFacts(status) {
   const map16 = status.appUi.snapshot.map;
   return {
-    width: probeValue9(map16.width),
-    height: probeValue9(map16.height),
-    plotCount: probeValue9(map16.plotCount),
-    mapSize: probeValue9(map16.mapSize),
-    randomSeed: probeValue9(map16.randomSeed)
+    width: probeValue11(map16.width),
+    height: probeValue11(map16.height),
+    plotCount: probeValue11(map16.plotCount),
+    mapSize: probeValue11(map16.mapSize),
+    randomSeed: probeValue11(map16.randomSeed)
   };
 }
 function emptyMapFacts() {
@@ -36032,9 +37520,9 @@ function worldPlayerFacts(status) {
   const players = status.appUi.snapshot.players;
   return {
     maxPlayers: status.appUi.snapshot.players.maxPlayers,
-    alivePlayerIds: integerArrayOrEmpty(probeValue9(players.aliveIds)),
-    aliveHumanIds: integerArrayOrEmpty(probeValue9(players.aliveHumanIds)),
-    aliveHumanCount: probeValue9(players.numAliveHumans)
+    alivePlayerIds: integerArrayOrEmpty(probeValue11(players.aliveIds)),
+    aliveHumanIds: integerArrayOrEmpty(probeValue11(players.aliveHumanIds)),
+    aliveHumanCount: probeValue11(players.numAliveHumans)
   };
 }
 function emptyPlayerFacts() {
@@ -36079,7 +37567,7 @@ function mapSourceStatus(map16) {
 function playersSourceStatus(players) {
   return players.aliveIds.ok || players.aliveHumanIds.ok || players.numAliveHumans.ok ? "read" : "skipped-unavailable";
 }
-function probeValue9(probe14) {
+function probeValue11(probe14) {
   return probe14.ok ? probe14.value : null;
 }
 function integerArrayOrEmpty(value2) {
@@ -36164,7 +37652,7 @@ function worldGridReadResult(result) {
   return {
     sourceStatus: {
       grid: result.omitted > 0 ? "read-with-omissions" : probeErrorCount > 0 ? "read-with-probe-errors" : "read",
-      map: probeValue10(result.map?.width) != null || probeValue10(result.map?.height) != null ? "read" : "skipped-unavailable"
+      map: probeValue12(result.map?.width) != null || probeValue12(result.map?.height) != null ? "read" : "skipped-unavailable"
     },
     bounds: result.bounds ?? boundsFromPlots(plots),
     fields: Array.from(result.fields),
@@ -36172,8 +37660,8 @@ function worldGridReadResult(result) {
     omitted: result.omitted,
     hiddenInfoPolicy: result.hiddenInfoPolicy,
     map: {
-      width: probeValue10(result.map?.width),
-      height: probeValue10(result.map?.height)
+      width: probeValue12(result.map?.width),
+      height: probeValue12(result.map?.height)
     },
     plots,
     summary: {
@@ -36192,7 +37680,7 @@ function worldPlotSnapshot(plot) {
     location: {
       x: plot.location.x,
       y: plot.location.y,
-      index: probeValue10(plot.location.index)
+      index: probeValue12(plot.location.index)
     },
     visibility,
     hiddenInfoPolicy: plot.hiddenInfoPolicy,
@@ -36214,7 +37702,7 @@ function probeRecord(facts) {
     Object.entries(facts).map(([key, value2]) => [key, publicProbe(value2)])
   );
 }
-function probeValue10(probe14) {
+function probeValue12(probe14) {
   return probe14?.ok ? probe14.value : null;
 }
 function probeErrorCountForRecord(record) {
@@ -37844,7 +39332,7 @@ async function requestCiv7GameUiTurnComplete(target = globalThis) {
       state: { id: "game-ui", name: "Game UI" },
       output: ["game-ui-turn-completion-requested"]
     },
-    verified: probeValue11(after3.hasSentTurnComplete) === true || probeValue11(after3.turn) !== probeValue11(before2.turn)
+    verified: probeValue13(after3.hasSentTurnComplete) === true || probeValue13(after3.turn) !== probeValue13(before2.turn)
   };
 }
 function gameUiNotificationSummaries(target, playerId, maxNotifications) {
@@ -38024,9 +39512,9 @@ function ok(value2) {
   return { ok: true, value: value2 };
 }
 function gameUiTurnCompletionAllowed(status) {
-  return probeValue11(status.canEndTurn) === true && probeValue11(status.hasSentTurnComplete) !== true;
+  return probeValue13(status.canEndTurn) === true && probeValue13(status.hasSentTurnComplete) !== true;
 }
-function probeValue11(probe14) {
+function probeValue13(probe14) {
   return probe14.ok ? probe14.value : void 0;
 }
 function isPresent2(value2) {
@@ -41947,6 +43435,12 @@ function createCiv7GameUiDirectControlFacade(target) {
     getCiv7PlayNotificationView: async (options) => await getCiv7GameUiPlayNotificationView({
       maxNotifications: options?.maxNotifications
     }, target),
+    getCiv7ProgressDashboard: async () => {
+      throw new Error("game-ui progress dashboard is not supported");
+    },
+    getCiv7TraditionsView: async () => {
+      throw new Error("game-ui traditions view is not supported");
+    },
     getCiv7BattlefieldScan: async (input) => await getCiv7GameUiBattlefieldScan(input, target),
     getCiv7DestinationAnalysis: async (input) => await getCiv7GameUiDestinationAnalysis(input, target),
     getCiv7PlotSnapshot: async (input) => await getCiv7GameUiPlotSnapshot(input, target),

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -716,6 +716,9 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** `assign-worker --send` is bounded to the source-owned one-worker
   placement atom rather than silently treating `--amount` as repeated send
   authority
+- **AND** `assign-worker --send` omits caller `--player-id`; the procedure
+  reads live local-player notification evidence and passes that value to the
+  low-level direct-control assign-worker runtime port
 - **AND** focused CLI tests do not claim live Civ7 runtime proof
 
 #### Scenario: CLI town-focus sends use native city procedures
@@ -1308,12 +1311,13 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** `city.population.place.request` is listed as a supported game-UI
   mutation only when controller proof and the required ambient validation,
   send, player, city, and postcondition-read APIs are present
-- **AND** assign-worker input remains semantic `{ playerId, location }` while
-  expand-city input remains semantic `{ cityId, destination }`; raw operation
-  types and raw command/session fields are not accepted as bridge input
-- **AND** assign-worker sends require the caller `playerId` to match
-  controller-owned `GameContext.localPlayerID` evidence before any
-  `PlayerOperations.sendRequest` call
+- **AND** assign-worker input remains semantic `{ location }` while expand-city
+  input remains semantic `{ cityId, destination }`; caller `playerId`, raw
+  operation types, and raw command/session fields are not accepted as bridge
+  input
+- **AND** assign-worker sends use controller-owned `GameContext.localPlayerID`
+  evidence through the service context before any `PlayerOperations.sendRequest`
+  call
 - **AND** validator-blocked population placements project semantic `not-sent`
   output and do not call the send API
 - **AND** `population-ready-cleared` requires pre-send city readiness evidence

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -749,9 +749,8 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** the procedure's readiness, direct-control diplomacy
   response port, diplomacy postcondition projection, and no-repeat policy
   remain authoritative for the send
-- **AND** the send result uses direct-control source evidence for the acted
-  local player rather than treating the caller validation `--player-id` as send
-  authority
+- **AND** send input omits caller `playerId`; the procedure reads live
+  local-player evidence before invoking the direct-control runtime port
 - **AND** the normal JSON result is the semantic diplomacy response procedure
   projection without raw command/session/state/Tuner details, UI closeout
   payloads, diplomacy state internals, direct-control runtime payloads, or
@@ -1372,8 +1371,8 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** `narrative.choice.request` is listed as a supported game-UI mutation
   only when controller proof and the required ambient validation, send, and
   notification APIs are present
-- **AND** caller `playerId` remains validation/input context while the runtime
-  send player is derived from controller-owned `GameContext.localPlayerID`
+- **AND** caller input omits `playerId`; the runtime send player is derived
+  from controller-owned `GameContext.localPlayerID`
 - **AND** validator-blocked narrative choices project semantic `not-sent`
   output and do not call the send API
 - **AND** sent choices preserve source-owned narrative proof semantics:
@@ -1402,8 +1401,8 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** `diplomacy.response.request` is listed as a supported game-UI
   mutation only when controller proof and the required ambient validation,
   send, notification, and blocker-read APIs are present
-- **AND** caller `playerId` remains validation/input context while the runtime
-  send player is derived from controller-owned `GameContext.localPlayerID`
+- **AND** caller input omits `playerId`; the runtime send player is derived
+  from controller-owned `GameContext.localPlayerID`
 - **AND** validator-blocked diplomacy responses project semantic `not-sent`
   output and do not call the send API
 - **AND** sent responses preserve source-owned diplomacy proof semantics:
@@ -1612,8 +1611,8 @@ boundaries.
   direct-control runtime authority
 - **AND** it consumes direct-control diplomacy validators and proof helpers as
   runtime/proof ports rather than inferring proof from legacy `verified`
-- **AND** its normal input exposes player, action, response, and optional
-  notification identity rather than direct-control UI toggles
+- **AND** its normal input exposes action, response, and optional notification
+  identity rather than caller player identity or direct-control UI toggles
 - **AND** its normal output projects semantic status, validation summary,
   postcondition summary, and next steps
 - **AND** its normal output uses direct-control source evidence for the acted

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -146,9 +146,11 @@ errors, and server-side callers.
   `progression.culture.choice.request` expose their caller-facing contracts
 - **THEN** control-oRPC owns the input, output, postcondition, evidence, and
   next-step schemas for those service procedures
-- **AND** the input admits only player ID, node ID, and optional notification
-  identity, with technology versus culture expressed by the domain procedure
-  path rather than a generic kind discriminator
+- **AND** the input admits only node ID and optional notification identity,
+  with technology versus culture expressed by the domain procedure path rather
+  than a generic kind discriminator
+- **AND** the procedure reads current local-player evidence before send and
+  does not admit caller-provided player ID as mutation authority
 - **AND** the evidence summary distinguishes read, failed, and skipped-not-sent
   post-read states without inventing after-state facts
 - **AND** endpoint, session, state, raw command, payload, App UI activation
@@ -817,8 +819,9 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** the procedure's readiness, before/after notification reads,
   direct-control progression closeout port, progression postcondition
   projection, and no-repeat policy remain authoritative for the send
-- **AND** the send result uses live notification local-player evidence rather
-  than treating caller validation `--player-id` as send authority
+- **AND** send mode omits caller `--player-id`; the send result uses live
+  notification local-player evidence rather than caller validation identity as
+  send authority
 - **AND** the normal JSON result is the semantic progression choice procedure
   projection without raw command/session/state/Tuner details, App UI closeout
   payloads, direct-control runtime payloads, before/after notification views, or
@@ -1339,9 +1342,9 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** progression choice procedures are listed as supported game-UI
   mutations only when controller proof and the required ambient validation,
   send, notification, and player progression APIs are present
-- **AND** caller `playerId` remains validation/input context while the runtime
-  send player is derived from controller-owned `GameContext.localPlayerID` and
-  the pre-read local-player notification evidence
+- **AND** the bridge request omits caller `playerId`; the runtime send player
+  is derived from controller-owned `GameContext.localPlayerID` and the pre-read
+  local-player notification evidence
 - **AND** validator-blocked progression choices project semantic `not-sent`
   output, do not call the choose send API, and do not clear the target node
   after a failed choose validation
@@ -1633,9 +1636,9 @@ boundaries.
 - **AND** it reads notification evidence before and after the closeout request
   and consumes direct-control progression postcondition helpers rather than
   reimplementing blocker proof truth
-- **AND** its normal input exposes player, node, and optional notification
-  identity rather than a generic `kind` discriminator or direct-control App UI
-  toggles
+- **AND** its normal input exposes node and optional notification identity
+  rather than player identity, a generic `kind` discriminator, or
+  direct-control App UI toggles
 - **AND** its closeout request and normal output use the local-player evidence
   from the before-notification read rather than treating caller `playerId` as
   controller/runtime send authority

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -183,12 +183,12 @@ errors, and server-side callers.
   `government.celebration.choice.request` expose their caller-facing contracts
 - **THEN** control-oRPC owns the input, output, postcondition, and next-step
   schemas for those service procedures under the `government` router
-- **AND** the input admits only player ID plus government type/action or player
-  ID plus golden-age type, with government versus celebration expressed by the
-  domain procedure path rather than a generic operation root or operation enum
-  input
+- **AND** the input omits caller player ID and admits only government
+  type/action or golden-age type, with government versus celebration expressed
+  by the domain procedure path rather than a generic operation root or
+  operation enum input
 - **AND** the procedure reads current local-player evidence before send and
-  does not treat caller-provided player ID as mutation authority by itself
+  does not treat caller-provided player ID as mutation authority
 - **AND** endpoint, session, state, raw command, generic operation type, raw
   args, direct-control operation envelopes, and legacy `verified` remain
   excluded from procedure input and normal output

--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -163,11 +163,11 @@ errors, and server-side callers.
   `progression.culture.target.request` expose their caller-facing contracts
 - **THEN** control-oRPC owns the input, output, postcondition, and next-step
   schemas for those service procedures under the `progression` router
-- **AND** the input admits only player ID and node ID, with technology versus
+- **AND** the input admits only node ID, with technology versus
   culture expressed by the domain procedure path rather than a generic
   operation root or operation enum input
 - **AND** the procedure reads current local-player evidence before send and
-  does not treat caller-provided player ID as mutation authority by itself
+  does not admit caller-provided player ID as mutation authority
 - **AND** endpoint, session, state, raw command, generic operation type, raw
   args, direct-control operation envelopes, and legacy `verified` remain
   excluded from procedure input and normal output
@@ -842,8 +842,8 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** the procedure's readiness, fresh local-player read,
   direct-control progression target runtime port, target proof projection, and
   no-repeat policy remain authoritative for the send
-- **AND** the send result uses live local-player evidence rather than treating
-  caller validation `--player-id` as send authority
+- **AND** the send path omits caller `--player-id` and the result uses live
+  local-player evidence rather than caller-provided player identity
 - **AND** the normal JSON result is the semantic progression target procedure
   projection without raw command/session/state/Tuner details, generic
   operation type or args fields, direct-control operation envelopes, or legacy

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -712,12 +712,12 @@ adding more read-only facade shells.
     sent player-choice results pending-runtime-proof/no-repeat guarded until a
     real post-read owner proves the live review state changed.
   - [x] 7.1.9.3.1 Remove stale caller `--player-id` from progression
-    player-choice notification send hints. Keep dry-run validation hints
-    player-scoped, but make tradition/attribute send and closeout workflow
-    recommendations match the playerless native oRPC send surfaces. Prove the
+    player-choice notification send hints. Keep action directions focused on
+    the semantic send moves and minimal closeout sequencing context, not every
+    validation/flag variant. Dry-run validation remains available through the
+    CLI interface, but it is not repeated as a notification action. Prove the
     generated notification-view source omits `--player-id` from send
-    templates while preserving validation templates and live runtime proof
-    pending.
+    templates and live runtime proof pending.
   - [x] 7.1.9.4 Route `civ7 game play set-town-focus --send` and
     `civ7 game play consider-town-project --send` through the in-process
     city town-focus server-side clients under the `city` router. Keep endpoint

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -337,9 +337,9 @@ adding more read-only facade shells.
     been used.
   - [x] 5.5.13.1 Bind progression choice closeout request identity to the
     before-notification read's local-player evidence before invoking
-    direct-control technology/culture closeout ports. Keep caller `playerId` as
-    validation/context input, not controller/runtime send authority, and keep
-    progression bridge allowlisting pending.
+    direct-control technology/culture closeout ports. Omit caller `playerId`
+    from the public service send input, keep direct-control dry-run validation
+    player-scoped, and keep progression bridge allowlisting pending.
   - [x] 5.5.13.2 Seed `progression.technology.target.request` and
     `progression.culture.target.request` as native service-owned progression
     target-setting leaves. Keep technology versus culture in the domain
@@ -667,9 +667,10 @@ adding more read-only facade shells.
     `progression` router. Keep endpoint flags as context construction, emit
     semantic progression choice projection for send output with live
     notification local-player evidence rather than treating `--player-id` as
-    send authority, preserve existing direct-control option reads and dry-run
-    validation paths, retire caller-visible `--closeout` workflow guidance, and
-    keep live runtime proof pending.
+    send authority, omit `--player-id` from send mode, preserve existing
+    direct-control option reads and dry-run validation paths, retire
+    caller-visible `--closeout` workflow guidance, and keep live runtime proof
+    pending.
   - [x] 7.1.9.1 Route `civ7 game play set-tech-target --send` and
     `civ7 game play set-culture-target --send` through the in-process
     `progression.technology.target.request` and
@@ -680,6 +681,13 @@ adding more read-only facade shells.
     player-operation validation for read-only mode, and keep sent target
     results pending-runtime-proof/no-repeat guarded until a real post-read
     owner proves target state changed.
+  - [x] 7.1.9.1.1 Remove caller `--player-id` from `civ7 game play
+    choose-tech --send` and `civ7 game play choose-culture --send`, matching
+    the node-only public `progression.technology.choice.request` and
+    `progression.culture.choice.request` service inputs. Keep dry-run
+    validation player-scoped through direct-control, keep generated option
+    send templates playerless, prove caller `playerId` rejection at the
+    procedure and bridge boundary, and keep live runtime proof pending.
   - [x] 7.1.9.2 Route `civ7 game play choose-government --send` and
     `civ7 game play choose-celebration --send` through the in-process
     `government.choice.request` and
@@ -1646,6 +1654,16 @@ adding more read-only facade shells.
   catalog support, relationship labels beyond official evidence,
   approval/reason mechanics, raw runtime output, or parent Task 5.x/6.x/7.x
   acceptance.
+- [x] 8.60.25 Run focused progression choice procedure/controller/game-UI
+  tests, focused CLI technology/culture/HUD tests, direct-control
+  notification-view proof, control-oRPC package test/check/build,
+  direct-control check/build, CLI play/check/build gates, strict OpenSpec
+  validates, private procedure-schema export scan, stale send-mode
+  `--player-id` scan, active approval/caller-permission scan, and diff hygiene
+  for the progression choice player-input cleanup. This is local
+  package/CLI proof only and does not claim deployed Civ7 runtime proof,
+  play-thread action, transport expansion, approval/reason mechanics, broad
+  progression catalog support, or parent Task 5.x/6.x/7.x acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -351,10 +351,11 @@ adding more read-only facade shells.
   - [x] 5.5.13.3 Seed `government.choice.request` and
     `government.celebration.choice.request` as native service-owned
     government-domain mutation leaves. Keep government versus celebration in
-    the domain procedure path, read current local-player evidence before send,
-    use direct-control only as the low-level player-operation runtime/proof
-    port, omit raw operation envelopes and legacy `verified` from normal
-    output, and keep sent government-domain choices
+    the domain procedure path, omit caller `playerId` from public send inputs,
+    read current local-player evidence before send, use direct-control only as
+    the low-level player-operation runtime/proof port, omit raw operation
+    envelopes and legacy `verified` from normal output, and keep sent
+    government-domain choices
     pending-runtime-proof/no-repeat guarded until a future source-owned read
     proves the live government or celebration blocker cleared.
   - [x] 5.5.13.4 Seed `progression.attribute.purchase.request`,
@@ -684,10 +685,11 @@ adding more read-only facade shells.
     `government.celebration.choice.request` server-side clients under the
     `government` router. Keep endpoint flags as context construction, emit
     semantic government-domain output, use fresh local-player evidence rather
-    than treating `--player-id` as send authority, preserve direct-control
-    option reads and player-operation validation for read-only mode, and keep
-    sent government-domain results pending-runtime-proof/no-repeat guarded
-    until a real post-read owner proves the live blocker cleared.
+    than treating `--player-id` as send authority, omit caller `--player-id`
+    from send mode, preserve direct-control option reads and player-operation
+    validation for read-only mode, and keep sent government-domain results
+    pending-runtime-proof/no-repeat guarded until a real post-read owner proves
+    the live blocker cleared.
   - [x] 7.1.9.3 Route `civ7 game play buy-attribute --send`,
     `civ7 game play consider-attributes --send`,
     `civ7 game play change-tradition --send`, and

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -343,8 +343,9 @@ adding more read-only facade shells.
   - [x] 5.5.13.2 Seed `progression.technology.target.request` and
     `progression.culture.target.request` as native service-owned progression
     target-setting leaves. Keep technology versus culture in the domain
-    procedure path, read current local-player evidence before send, use
-    direct-control only as the low-level player-operation runtime/proof port,
+    procedure path, omit caller `playerId` from public send inputs, read
+    current local-player evidence before send, use direct-control only as the
+    low-level player-operation runtime/proof port,
     omit raw operation envelopes and legacy `verified` from normal output, and
     keep sent target results pending-runtime-proof/no-repeat guarded until a
     future source-owned progression read proves target state changed.
@@ -674,8 +675,8 @@ adding more read-only facade shells.
     `progression.technology.target.request` and
     `progression.culture.target.request` server-side clients under the
     `progression` router. Keep endpoint flags as context construction, emit
-    semantic progression target output, use fresh local-player evidence rather
-    than treating `--player-id` as send authority, preserve direct-control
+    semantic progression target output, omit caller `--player-id` from send
+    mode, use fresh local-player evidence, preserve direct-control
     player-operation validation for read-only mode, and keep sent target
     results pending-runtime-proof/no-repeat guarded until a real post-read
     owner proves target state changed.
@@ -1422,7 +1423,7 @@ adding more read-only facade shells.
   focused control-oRPC progression target procedure tests, focused CLI
   technology/culture target send tests, direct-control and control-oRPC
   check/build/package gates, `check:cli`, `test:cli:play`, relevant OpenSpec
-  strict validates, and diff hygiene for the CLI progression target send
+  strict validates, stale send-player scans, and diff hygiene for the CLI progression target send
   migration slice. These are local CLI and package proofs only and do not claim
   deployed Civ7 runtime proof, play-thread action, transport expansion, a
   progression read service, controller ingress, or parent Task 5.x/6.x/7.x

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -1674,6 +1674,17 @@ adding more read-only facade shells.
   package/CLI proof only and does not claim deployed Civ7 runtime proof,
   play-thread action, transport expansion, approval/reason mechanics,
   diplomacy/narrative catalog support, or parent Task 5.x/6.x/7.x acceptance.
+- [x] 8.60.27 Run focused population placement procedure/controller/game-UI
+  tests, focused CLI population placement and ready-city tests,
+  direct-control ready-city/notification-view proof, control-oRPC package
+  test/check/build, direct-control check/build, CLI play/check/build gates,
+  strict OpenSpec validates, private procedure-schema export scan, stale
+  assign-worker send-mode `--player-id` scan, active approval/caller-permission
+  scan, generated bundle scan, and diff hygiene for the population placement
+  player-input cleanup. This is local package/CLI/controller-bundle proof only
+  and does not claim deployed Civ7 runtime proof, play-thread action,
+  transport expansion, approval/reason mechanics, city catalog support, or
+  parent Task 5.x/6.x/7.x acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -711,6 +711,13 @@ adding more read-only facade shells.
     `sendPlayOperation` fallback branches from migrated commands, and keep
     sent player-choice results pending-runtime-proof/no-repeat guarded until a
     real post-read owner proves the live review state changed.
+  - [x] 7.1.9.3.1 Remove stale caller `--player-id` from progression
+    player-choice notification send hints. Keep dry-run validation hints
+    player-scoped, but make tradition/attribute send and closeout workflow
+    recommendations match the playerless native oRPC send surfaces. Prove the
+    generated notification-view source omits `--player-id` from send
+    templates while preserving validation templates and live runtime proof
+    pending.
   - [x] 7.1.9.4 Route `civ7 game play set-town-focus --send` and
     `civ7 game play consider-town-project --send` through the in-process
     city town-focus server-side clients under the `city` router. Keep endpoint
@@ -1685,6 +1692,14 @@ adding more read-only facade shells.
   and does not claim deployed Civ7 runtime proof, play-thread action,
   transport expansion, approval/reason mechanics, city catalog support, or
   parent Task 5.x/6.x/7.x acceptance.
+- [x] 8.60.28 Run focused direct-control notification-view proof,
+  direct-control check/build, strict OpenSpec validates, stale progression
+  send-hint `--player-id` scan, active approval/caller-permission scan, and
+  diff hygiene for the progression player-choice notification send-hint
+  cleanup. This is local source/test proof only and does not claim deployed
+  Civ7 runtime proof, play-thread action, transport expansion,
+  approval/reason mechanics, broader progression catalog support, or parent
+  Task 5.x/6.x/7.x acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -1147,8 +1147,8 @@ adding more read-only facade shells.
     government procedures; allowlist those leaves through closed controller
     bridge envelopes that derive concrete schemas from the aggregated
     `Civ7ControlOrpcContract`; advertise the mutations only when those exact
-    game UI APIs and controller proof exist; route caller player input through
-    fresh `GameContext.localPlayerID` evidence before send; preserve
+    game UI APIs and controller proof exist; omit caller `playerId` and route
+    sends through fresh `GameContext.localPlayerID` evidence before send; preserve
     validator-blocked not-sent output and pending-runtime-proof/no-repeat
     guarded sent output; keep raw game-UI function names,
     command/session/state details, deployed Civ7 proof, play-thread action,
@@ -1163,7 +1163,7 @@ adding more read-only facade shells.
     allowlist the leaf through a closed controller bridge envelope that
     derives concrete schemas from the aggregated `Civ7ControlOrpcContract`;
     advertise the mutation only when those exact game UI APIs and controller
-    proof exist; route caller player input through fresh
+    proof exist; omit caller `playerId` and route sends through fresh
     `GameContext.localPlayerID` evidence before send; preserve
     validator-blocked not-sent output and keep unmatched/sticky first-meet
     blocker evidence no-repeat guarded; keep raw game-UI function names,
@@ -1664,6 +1664,16 @@ adding more read-only facade shells.
   package/CLI proof only and does not claim deployed Civ7 runtime proof,
   play-thread action, transport expansion, approval/reason mechanics, broad
   progression catalog support, or parent Task 5.x/6.x/7.x acceptance.
+- [x] 8.60.26 Run focused narrative/diplomacy procedure/controller/game-UI
+  tests, focused CLI narrative/diplomacy/first-meet/HUD tests, direct-control
+  notification-view proof, control-oRPC package test/check/build,
+  direct-control check/build, CLI play/check/build gates, strict OpenSpec
+  validates, private procedure-schema export scan, stale send-mode
+  `--player-id` scan, active approval/caller-permission scan, and diff hygiene
+  for the narrative/diplomacy player-input cleanup. This is local
+  package/CLI proof only and does not claim deployed Civ7 runtime proof,
+  play-thread action, transport expansion, approval/reason mechanics,
+  diplomacy/narrative catalog support, or parent Task 5.x/6.x/7.x acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-diplomacy-response-orpc-send-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-diplomacy-response-orpc-send-slice.md
@@ -26,9 +26,9 @@ this slice because first-meet handling is a separate diplomacy capability.
 
 ## Boundary
 
-- Send output uses direct-control source evidence for the acted/local player.
-  The caller `--player-id` remains validation input and is not send authority
-  when official UI closeout uses `GameContext.localPlayerID`.
+- Send input omits caller `--player-id`; the service reads live local-player
+  evidence before invoking the direct-control runtime port. The non-send
+  validation path remains player-scoped.
 - No Studio, controller bridge, RPCLink, OpenAPI, or transport work.
 - No direct-control procedure-core scaffolding.
 - No raw command/session/state/Tuner payloads, UI closeout payloads, activation
@@ -45,9 +45,9 @@ this slice because first-meet handling is a separate diplomacy capability.
   request result carries top-level acted/local-player evidence from official
   UI runtime reads: caller validation player `2` still returns and acts as
   local player `0`.
-- Focused control-oRPC diplomacy response tests prove the service projection
-  reports source-owned acted-player evidence from the direct-control result
-  rather than echoing caller validation identity.
+- Focused control-oRPC diplomacy response tests prove the service rejects
+  caller `playerId`, reads local-player evidence before facade execution, and
+  reports source-owned acted-player evidence from the direct-control result.
 - Focused CLI diplomacy response tests prove the accepted
   `respond-diplomacy --send` path reaches the existing direct-control official
   UI closeout runtime command through the in-process service client path,

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-government-choice-orpc-send-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-government-choice-orpc-send-slice.md
@@ -18,6 +18,13 @@ cleared. Sent results therefore remain `sent-unverified` with do-not-repeat
 next steps until a future source-owned government-domain read/postcondition
 owner proves blocker clearance.
 
+Post-slice public-input repair: the government-domain oRPC send inputs now
+omit caller `playerId`. Procedures continue to read live local-player evidence
+before invoking direct-control runtime ports, and CLI send mode no longer
+requires or passes `--player-id`. The dry-run validation path may still require
+`--player-id` because it intentionally calls the low-level direct-control
+validator rather than the semantic send service.
+
 ## Write Set
 
 - `packages/civ7-direct-control/src/play/government/choice-request.ts`
@@ -52,6 +59,8 @@ owner proves blocker clearance.
 - No raw command/session/state/Tuner payloads, generic operation type/args,
   direct-control operation envelopes, or legacy `verified` in normal send
   output.
+- No caller player-id send authority; public service inputs contain only the
+  requested government/celebration choice fields.
 - No government-domain read service or blocker-clearance postcondition owner
   in this slice.
 - No play-thread wake and no live-game/runtime proof claim.
@@ -64,12 +73,14 @@ owner proves blocker clearance.
   source-owned default government action evidence, and pending-runtime/no-repeat
   proof classification.
 - Focused control-oRPC government procedure proof covers native government
-  domain leaves, fresh local-player evidence before send, caller `playerId` not
-  becoming send authority, raw input rejection, safe tagged error projection,
-  semantic output closure, and sent choices staying no-repeat guarded.
+  domain leaves, fresh local-player evidence before send, caller `playerId`
+  rejection from public procedure input, raw input rejection, safe tagged error
+  projection, semantic output closure, and sent choices staying no-repeat
+  guarded.
 - Focused CLI celebration/government tests cover `choose-celebration --send`
   and `choose-government --send` through the in-process service client path,
-  semantic output, local-player substitution, and raw runtime/detail omission.
+  semantic output, playerless send-mode service inputs, local-player
+  substitution, and raw runtime/detail omission.
 - Closure proof collected: focused direct-control request test,
   direct-control check/build, focused and full control-oRPC package tests,
   control-oRPC check/build, focused CLI celebration/government tests,

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-narrative-choice-orpc-send-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-narrative-choice-orpc-send-slice.md
@@ -26,9 +26,9 @@ direct-control player-operation validation.
 
 ## Boundary
 
-- Send output uses direct-control source evidence for the acted/local player.
-  The caller `--player-id` remains validation input and is not send authority
-  when official UI closeout uses `GameContext.localPlayerID`.
+- Send input omits caller `--player-id`; the service reads live local-player
+  evidence before invoking the direct-control runtime port. The non-send
+  validation path remains player-scoped.
 - No Studio, controller bridge, RPCLink, OpenAPI, or transport work.
 - No direct-control procedure-core scaffolding.
 - No raw command/session/state/Tuner payloads, App UI closeout payloads,
@@ -45,12 +45,12 @@ direct-control player-operation validation.
   result carries top-level acted/local-player evidence from official UI runtime
   reads: caller validation player `2` still returns and acts as local player
   `0`.
-- Focused control-oRPC narrative choice tests prove the service projection
-  reports source-owned acted-player evidence from the direct-control result
-  rather than echoing caller validation identity.
+- Focused control-oRPC narrative choice tests prove the service rejects caller
+  `playerId`, reads local-player evidence before facade execution, and reports
+  source-owned acted-player evidence from the direct-control result.
 - Focused CLI narrative tests prove the accepted `choose-narrative --send`
-  path accepts caller validation player `2`, reports source-owned acted/local
-  player `0`, reaches the existing direct-control official UI narrative
+  path omits caller `--player-id`, reports source-owned acted/local player
+  `0`, reaches the existing direct-control official UI narrative
   closeout runtime command through the in-process service client path, emits
   semantic `narrative.choice.request` output, and keeps raw
   command/session/state, App UI closeout payloads, runtime payloads, panel/

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-narrative-diplomacy-player-input-cleanup-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-narrative-diplomacy-player-input-cleanup-slice.md
@@ -1,0 +1,82 @@
+# CLI Narrative/Diplomacy Player Input Cleanup Slice
+
+## Scope
+
+Remove caller `playerId` from the native send inputs for
+`narrative.choice.request`, `diplomacy.response.request`, and
+`diplomacy.firstMeet.response.request`.
+
+The service procedures remain under their existing domain routers. The
+contract-owned schemas stay private to their contract modules, and bridge
+ingress continues to derive concrete request/response schemas from the
+aggregated `Civ7ControlOrpcContract`.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/modules/narrative/contract.ts`
+- `packages/civ7-control-orpc/src/modules/narrative/procedures/choice-request.ts`
+- `packages/civ7-control-orpc/src/modules/diplomacy/contract.ts`
+- `packages/civ7-control-orpc/src/modules/diplomacy/procedures/response-request.ts`
+- `packages/civ7-control-orpc/src/modules/diplomacy/procedures/first-meet-response-request.ts`
+- `packages/civ7-control-orpc/test/narrative-choice-procedure.test.ts`
+- `packages/civ7-control-orpc/test/diplomacy-response-procedure.test.ts`
+- `packages/civ7-control-orpc/test/first-meet-response-procedure.test.ts`
+- `packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts`
+- `packages/civ7-control-orpc/test/game-ui-controller.test.ts`
+- `packages/civ7-direct-control/src/play/notifications/view.ts`
+- `packages/cli/src/commands/game/play/choose-narrative.ts`
+- `packages/cli/src/commands/game/play/respond-diplomacy.ts`
+- `packages/cli/src/commands/game/play/respond-first-meet.ts`
+- `packages/cli/test/commands/game.play.narrative.test.ts`
+- `packages/cli/test/commands/game.play.diplomacy-response.test.ts`
+- `packages/cli/test/commands/game.play.first-meet.test.ts`
+- `packages/cli/test/commands/game/play/notification/hud.test.ts`
+- `docs/projects/civ7-live-play-support/topics/first-meet-diplomacy.md`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-diplomacy-response-orpc-send-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-narrative-choice-orpc-send-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/controller-diplomacy-response-ingress-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/game-ui-diplomacy-response-runtime-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/game-ui-first-meet-runtime-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/game-ui-narrative-choice-runtime-slice.md`
+- this workstream note
+
+## Boundary
+
+- Send-mode public inputs omit caller `playerId`.
+- The service reads live notification/local-player evidence before invoking the
+  direct-control runtime port.
+- Dry-run validation commands may remain direct-control/player-scoped and keep
+  `--player-id`.
+- Normal procedure/CLI/bridge output still projects source-owned acted-player
+  evidence and omits raw command/session/state/Tuner payloads, runtime
+  envelopes, UI closeout internals, and legacy `verified`.
+- No exported per-procedure schema constants or duplicate standard-schema bags.
+- No approval/reason mechanic, transport expansion, play-thread action,
+  runtime proof claim, generic decisions root, or parent Task 5.x/6.x/7.x
+  acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/narrative-choice-procedure.test.ts test/diplomacy-response-procedure.test.ts test/first-meet-response-procedure.test.ts test/controller-bridge-ingress.test.ts test/game-ui-controller.test.ts`
+- `bun run test:cli:play -- game.play.narrative.test.ts game.play.diplomacy-response.test.ts game.play.first-meet.test.ts game/play/notification/hud.test.ts`
+- `bun run --cwd packages/civ7-direct-control test test/play-notification-view.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run --cwd packages/civ7-direct-control check`
+- `bun run --cwd packages/civ7-direct-control build`
+- `bun run check:cli`
+- `bun run build:cli`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- private procedure-schema export scan; contract standard-schema constants remain
+  contract-local/private
+- stale send-mode `--player-id` scan; no hits
+- active approval/caller-permission scan; hits are limited to negative
+  exclusion, proof-scan, retirement, or bad-input rejection language
+- `git diff --check`
+
+These are local package/CLI proofs only and do not claim deployed Civ7 runtime
+proof.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-population-placement-orpc-send-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-population-placement-orpc-send-slice.md
@@ -14,13 +14,19 @@ classification.
 The read-only `game play assign-worker` and `game play expand-city` paths remain
 direct-control operation validation. `assign-worker --send` is bounded to the
 source-owned one-worker placement atom rather than treating `--amount` as
-repeated-send authority.
+repeated-send authority, and send mode omits caller `--player-id` while the
+service reads live local-player notification evidence.
 
 ## Write Set
 
 - `packages/cli/src/commands/game/play/assign-worker.ts`
 - `packages/cli/src/commands/game/play/expand-city.ts`
 - `packages/cli/test/commands/game.play.population-placement.test.ts`
+- `packages/civ7-direct-control/src/play/notifications/view.ts`
+- `packages/civ7-direct-control/src/play/ready/city.ts`
+- `packages/civ7-direct-control/test/ready-city-view.test.ts`
+- `packages/civ7-direct-control/test/ready-city-procedure.test.ts`
+- `packages/cli/test/commands/game/play/ready-city.test.ts`
 - This OpenSpec scenario/task/workstream record
 
 ## Boundary
@@ -32,6 +38,9 @@ repeated-send authority.
   legacy `verified` in normal send output.
 - No population read procedure, repeated-worker send loop, broad city operation
   catalog, or generic operation tunnel in this slice.
+- No caller `--player-id` send authority for assign-worker; dry-run validation
+  may remain player-scoped because it intentionally calls direct-control
+  validation.
 - No play-thread wake and no live-game/runtime proof claim.
 - No parent Task 5.x/6.x/7.x acceptance by implication.
 
@@ -46,5 +55,8 @@ repeated-send authority.
 - The focused CLI proof also rejects `assign-worker --send --amount` values
   outside the source-owned one-worker atom instead of silently ignoring or
   repeating the requested worker count.
+- Focused procedure and CLI proof rejects caller `playerId` on assign-worker
+  service input, reads local-player evidence for send mode, and keeps ready-city
+  and notification send hints playerless.
 - Closure still requires `check:cli`, `test:cli:play`, relevant strict
   OpenSpec validates, diff hygiene, and a durable Graphite commit.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-progression-choice-player-input-cleanup-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-progression-choice-player-input-cleanup-slice.md
@@ -1,0 +1,79 @@
+# CLI Progression Choice Player Input Cleanup Slice
+
+## Scope
+
+Remove caller player identity from the public progression choice send surface:
+
+- `progression.technology.choice.request`
+- `progression.culture.choice.request`
+- `civ7 game play choose-tech --send`
+- `civ7 game play choose-culture --send`
+
+The service procedures already read current notification evidence and bind
+runtime closeout requests to that local-player source. This slice aligns the
+public contract, controller bridge ingress, CLI send path, generated
+notification option templates, and durable guidance with that ownership.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/modules/progression/contract.ts`
+- `packages/civ7-control-orpc/src/modules/progression/procedures/choice-request.ts`
+- `packages/civ7-control-orpc/test/progression-choice-procedure.test.ts`
+- `packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts`
+- `packages/civ7-control-orpc/test/game-ui-controller.test.ts`
+- `packages/cli/src/commands/game/play/choose-tech.ts`
+- `packages/cli/src/commands/game/play/choose-culture.ts`
+- `packages/cli/test/commands/game.play.technology.test.ts`
+- `packages/cli/test/commands/game.play.culture.test.ts`
+- `packages/cli/test/commands/game/play/notification/hud.test.ts`
+- `packages/civ7-direct-control/src/play/notifications/view.ts`
+- `docs/projects/civ7-live-play-support/topics/caller-level-closeout-workflows.md`
+- `docs/projects/civ7-live-play-support/topics/progression-tree-targets.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/controller-progression-choice-ingress-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/progression-choice-local-player-evidence-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/game-ui-progression-choice-runtime-slice.md`
+- this workstream record
+
+## Boundary
+
+- Send-mode progression choice inputs admit `node` plus optional
+  `notificationId`; caller `playerId` is rejected before readiness or
+  direct-control ports run.
+- The CLI send path does not require or pass `--player-id`; dry-run validation
+  remains direct-control/player-scoped and still requires `--player-id`.
+- Direct-control notification `cli` send templates are playerless and no
+  longer advertise the hidden culture `--closeout` compatibility no-op;
+  `validateCli` remains player-scoped.
+- Controller bridge request schemas continue to come from the aggregate
+  `Civ7ControlOrpcContract`; no per-procedure input/result schema exports are
+  added.
+- No approval/reason mechanic, transport expansion, play-thread action,
+  runtime/live proof claim, or parent task acceptance is introduced.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/progression-choice-procedure.test.ts test/controller-bridge-ingress.test.ts test/game-ui-controller.test.ts`
+- `bun run --cwd packages/cli test -- game.play.technology.test.ts game.play.culture.test.ts game/play/notification/hud.test.ts`
+- `bun run --cwd packages/civ7-direct-control test -- play-notification-view.test.ts`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-direct-control check`
+- `bun run --cwd packages/civ7-direct-control build`
+- `bun run build:cli`
+- `bun run check:cli`
+- `bun run test:cli:play`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- stale send-mode `--player-id` scan over `packages`, `docs`, and `openspec`
+- changed-file scan for exported progression choice input/result schemas or
+  public progression choice `playerId` call patterns
+- active approval/caller-permission scan; hits are limited to negative
+  exclusion and approval-removal retirement language in OpenSpec
+- `git diff --check`
+
+These are local package, CLI, and OpenSpec proofs only. Deployed Civ7 runtime
+proof, play-thread action, transport expansion, broad progression catalog
+support, and parent Task 5.x/6.x/7.x acceptance remain pending.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-progression-target-orpc-send-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-progression-target-orpc-send-slice.md
@@ -22,6 +22,7 @@ state changes.
 ## Write Set
 
 - `packages/civ7-direct-control/src/play/progression/target-request.ts`
+- `packages/civ7-direct-control/src/play/notifications/view.ts`
 - `packages/civ7-direct-control/src/proof/progression-target-proof-policy.ts`
 - `packages/civ7-direct-control/src/index.ts`
 - `packages/civ7-direct-control/package.json`
@@ -33,12 +34,16 @@ state changes.
 - `packages/civ7-control-orpc/src/modules/progression/contract.ts`
 - `packages/civ7-control-orpc/src/modules/progression/router.ts`
 - `packages/civ7-control-orpc/src/modules/progression/procedures/target-request.ts`
+- `packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts`
+- `packages/civ7-control-orpc/test/game-ui-controller.test.ts`
 - `packages/civ7-control-orpc/test/progression-target-procedure.test.ts`
 - `packages/cli/src/commands/game/play/set-tech-target.ts`
 - `packages/cli/src/commands/game/play/set-culture-target.ts`
 - `packages/cli/test/commands/game.play.technology.test.ts`
 - `packages/cli/test/commands/game.play.culture.test.ts`
-- This OpenSpec scenario/task/workstream record
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- This OpenSpec workstream record
 
 ## Boundary
 
@@ -53,6 +58,10 @@ state changes.
   output.
 - No progression read service or target-state postcondition owner in this
   slice.
+- Public `progression.technology.target.request` and
+  `progression.culture.target.request` send inputs omit caller `playerId`.
+  Dry-run CLI validation remains player-scoped because it still calls the
+  low-level direct-control player-operation validator.
 - No play-thread wake and no live-game/runtime proof claim.
 - No controller ingress or parent Task 5.x/6.x/7.x acceptance by implication.
 
@@ -62,12 +71,13 @@ state changes.
   operation mapping, validator-blocked `not-sent`, and pending-runtime/no-repeat
   proof classification.
 - Focused control-oRPC target procedure proof covers native progression domain
-  leaves, fresh local-player evidence before send, caller `playerId` not
-  becoming send authority, raw input rejection, safe tagged error projection,
+  leaves, fresh local-player evidence before send, caller `playerId` rejection
+  from public input, raw input rejection, safe tagged error projection,
   semantic output closure, and sent target results staying no-repeat guarded.
 - Focused CLI technology/culture tests cover `set-tech-target --send` and
-  `set-culture-target --send` through the in-process service client path,
-  semantic output, local-player substitution, and raw runtime/detail omission.
+  `set-culture-target --send` through the in-process service client path
+  without caller `--player-id`, semantic output, local-player substitution, and
+  raw runtime/detail omission.
 - Closure proof collected: focused direct-control request test,
   direct-control check/build, focused and full control-oRPC package tests,
   control-oRPC check/build, focused CLI technology/culture tests,

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-diplomacy-response-ingress-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-diplomacy-response-ingress-slice.md
@@ -26,8 +26,8 @@ The controller ingress now:
 
 - accepts `diplomacy.response.request` as an additional allowlisted mutation
   procedure key;
-- validates the existing semantic diplomacy response input shape: `playerId`,
-  `actionId`, `responseType`, and optional `notificationId`;
+- validates the existing semantic diplomacy response input shape: `actionId`,
+  `responseType`, and optional `notificationId`;
 - requires closed controller lifecycle, local-player, and hotseat proof
   metadata without accepting caller-provided mutation metadata fields;
 - requires closed controller lifecycle proof for game-controller-ready lifecycle,

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-population-placement-ingress-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-population-placement-ingress-slice.md
@@ -28,7 +28,8 @@ The controller ingress now:
 - accepts `city.population.place.request` as an additional allowlisted
   mutation procedure key;
 - validates the existing semantic population-placement input shape:
-  `assign-worker` or `expand-city`;
+  `assign-worker` with `location` or `expand-city` with `cityId` and
+  `destination`;
 - requires closed controller lifecycle, local-player, and hotseat proof
   metadata without accepting caller-provided mutation metadata fields;
 - requires closed controller lifecycle proof for game-controller-ready lifecycle,
@@ -42,6 +43,9 @@ The controller ingress now:
   authoritative;
 - delegates to
   `createCiv7ControlOrpcServerClient(context).city.population.place.request(...)`;
+- rejects caller `playerId` on the assign-worker bridge input before context
+  construction or router dispatch; the service uses controller/local-player
+  evidence from context instead;
 - returns the existing semantic population placement procedure output;
 - rejects raw host, port, session, state, command, rawCommand, generic
   `operationType`, raw operation `args`, and raw direct-control

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-progression-choice-ingress-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-progression-choice-ingress-slice.md
@@ -26,8 +26,8 @@ request/output identity to the before-notification read's `localPlayerId`.
 
 - accepts `progression.technology.choice.request` and
   `progression.culture.choice.request` as additional allowlisted mutations;
-- validates the existing semantic progression input shape: `playerId`, `node`,
-  and optional `notificationId`;
+- validates the existing semantic progression input shape: `node` and optional
+  `notificationId`;
 - requires the controller lifecycle proof envelope plus game-controller-ready
   lifecycle evidence, `GameContext.localPlayerID` local-player evidence, and
   single-local-player/hotseat status;

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/game-ui-diplomacy-response-runtime-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/game-ui-diplomacy-response-runtime-slice.md
@@ -35,7 +35,7 @@ validation/send evidence.
 - The game-UI adapter returns the internal runtime-port result shape required
   by the existing service-owned diplomacy procedure; the procedure still owns
   caller-facing semantic projection and no-repeat next steps.
-- Caller `playerId` is not send authority. The adapter sends with
+- Caller input omits `playerId`. The adapter sends with
   `GameContext.localPlayerID` where present, and the normal result projects
   that acted player evidence.
 - Validator-blocked responses remain semantic `not-sent` results and do not

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/game-ui-first-meet-runtime-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/game-ui-first-meet-runtime-slice.md
@@ -36,8 +36,9 @@ The slice:
 - derives the serialized bridge envelope schemas from the aggregated
   `Civ7ControlOrpcContract` rather than importing a separate procedure-schema
   surface or accepting unknown payloads;
-- routes caller player input through fresh `GameContext.localPlayerID` evidence
-  before ambient send functions are called;
+- omits caller `playerId` from bridge input and routes sends through fresh
+  `GameContext.localPlayerID` evidence before ambient send functions are
+  called;
 - uses strict end-turn-blocking `NOTIFICATION_PLAYER_MET` target evidence for
   `metPlayerId` before treating a cleared first-meet blocker as confirmed;
 - preserves validator-blocked `not-sent` output;

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/game-ui-narrative-choice-runtime-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/game-ui-narrative-choice-runtime-slice.md
@@ -33,7 +33,7 @@ notification activation plus `PlayerOperations` validation/send evidence.
 - The game-UI adapter returns the internal runtime-port result shape required
   by the existing service-owned narrative procedure; the procedure still owns
   caller-facing semantic projection and no-repeat next steps.
-- Caller `playerId` is not send authority. The adapter sends with
+- Caller input omits `playerId`. The adapter sends with
   `GameContext.localPlayerID` where present, and the normal result projects
   that acted player evidence.
 - Validator-blocked choices remain semantic `not-sent` results and do not call

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/game-ui-progression-choice-runtime-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/game-ui-progression-choice-runtime-slice.md
@@ -35,9 +35,10 @@ evidence.
 - The game-UI adapter returns the internal runtime-port result shape required
   by the existing service-owned progression procedures; the procedures still
   own caller-facing semantic projection and post-send attention rereads.
-- Caller `playerId` is not send authority. The service derives runtime
-  `playerId` from the game-UI notification view's local-player evidence, and
-  the adapter sends with `GameContext.localPlayerID` where present.
+- Caller `playerId` is not part of the public send input or send authority.
+  The service derives runtime `playerId` from the game-UI notification view's
+  local-player evidence, and the adapter sends with `GameContext.localPlayerID`
+  where present.
 - Validator-blocked choices remain semantic `not-sent` results. The adapter
   does not call the clear-target send when the choose send did not validate.
 - Sticky blockers, state-changed blockers, failed post-reads, and

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/population-placement-native-procedure-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/population-placement-native-procedure-slice.md
@@ -33,8 +33,11 @@ and proof/no-repeat owner.
 - lives under the semantic `city` router family and keeps
   `procedureKey: "city.population.place.request"` as the stable capability key;
 - accepts a semantic placement mode instead of generic operation vocabulary:
-  `assign-worker` with `playerId` and `location`, or `expand-city` with
-  `cityId` and bounded map `destination`;
+  `assign-worker` with `location`, or `expand-city` with `cityId` and bounded
+  map `destination`;
+- reads live local-player notification evidence for assign-worker sends and
+  passes that value to the low-level direct-control assign-worker runtime port
+  instead of accepting caller `playerId` as send authority;
 - takes explicit readiness from typed oRPC context through the shared
   native effect-oRPC readiness middleware, not normal procedure input;
 - maps `assign-worker` to the control-oRPC runtime facade's semantic
@@ -85,8 +88,10 @@ and proof/no-repeat owner.
 - `git diff --check`
 
 Focused proof covers in-process procedure calls, server-side router client
-calls, shared readiness middleware refusal before mutation, endpoint/session/raw
-operation input rejection, safe tagged error projection, confirmed
+calls, live local-player notification evidence for assign-worker sends,
+caller `playerId` rejection before facade execution, shared readiness
+middleware refusal before mutation, endpoint/session/raw operation input
+rejection, safe tagged error projection, confirmed
 `population-ready-cleared` repeat-safe postconditions, confirmed
 `placement-state-changed` guarded postconditions, unverified validation-only
 and missing-postcondition guarding, and validator-blocked not-sent projection.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/population-placement-player-input-cleanup-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/population-placement-player-input-cleanup-slice.md
@@ -1,0 +1,85 @@
+# Population Placement Player Input Cleanup Slice
+
+## Status
+
+Implemented local package, CLI, controller, OpenSpec, and generated-bundle
+proof slice.
+
+## Purpose
+
+Remove caller `playerId` from the public `city.population.place.request`
+assign-worker send surface. Assign-worker send mode now accepts only
+`{ mode: "assign-worker", location }`; the service reads live local-player
+notification evidence and passes that value to the low-level direct-control
+assign-worker runtime/proof port. Dry-run validation remains direct-control
+and player-scoped.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/modules/city/contract.ts`
+- `packages/civ7-control-orpc/src/modules/city/procedures/population-place-request.ts`
+- `packages/civ7-control-orpc/test/city-population-placement-procedure.test.ts`
+- `packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts`
+- `packages/civ7-control-orpc/test/game-ui-controller.test.ts`
+- `packages/cli/src/commands/game/play/assign-worker.ts`
+- `packages/cli/test/commands/game.play.population-placement.test.ts`
+- `packages/cli/test/commands/game/play/ready-city.test.ts`
+- `packages/civ7-direct-control/src/play/notifications/view.ts`
+- `packages/civ7-direct-control/src/play/ready/city.ts`
+- `packages/civ7-direct-control/test/ready-city-procedure.test.ts`
+- `packages/civ7-direct-control/test/ready-city-view.test.ts`
+- `mods/mod-civ7-intelligence-bridge/mod/ui/civ7-intelligence-bridge.js`
+- `openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-population-placement-orpc-send-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/controller-population-placement-ingress-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/population-placement-native-procedure-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/population-placement-player-input-cleanup-slice.md`
+
+## Boundary
+
+- The caller-facing assign-worker input omits `playerId`.
+- The procedure reads local-player evidence from `getCiv7PlayNotificationView`
+  and uses that value only as runtime-port input.
+- Ready-city and notification hints no longer recommend `--player-id` for
+  assign-worker send mode.
+- The controller bridge rejects caller `playerId` in assign-worker request
+  envelopes before dispatch.
+- No approval/reason mechanic, generic operation tunnel, custom oRPC plumbing,
+  transport expansion, play-thread action, runtime/live proof claim, or parent
+  Task 5.x/6.x/7.x acceptance is introduced.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/city-population-placement-procedure.test.ts test/game-ui-controller.test.ts`
+- `bun run test:cli:play -- game.play.population-placement.test.ts game/play/ready-city.test.ts`
+- `bun run --cwd packages/civ7-direct-control test test/ready-city-view.test.ts test/ready-city-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run --cwd packages/civ7-direct-control check`
+- `bun run --cwd packages/civ7-direct-control build`
+- `bun run check:cli`
+- `bun run build:cli`
+- `bun run --cwd mods/mod-civ7-intelligence-bridge build`
+- `bun run --cwd mods/mod-civ7-intelligence-bridge check`
+- `bun run --cwd mods/mod-civ7-intelligence-bridge test`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Private procedure-schema export scan; city procedure schemas remain
+  contract-local and are not exported as package API.
+- Stale assign-worker send-mode `--player-id` scan; remaining hits are dry-run
+  validation guidance, invalid-input tests, negative OpenSpec wording, or the
+  internal runtime input type supplied by the service.
+- Active approval/caller-permission scan; hits are negative exclusion,
+  approval-removal retirement language, or invalid-input tests.
+- Generated bundle/runtime scan; no direct-control socket/runtime, Node
+  built-in imports, RPC transport symbols, raw command/session payload strings,
+  or retired approval tokens appear in the rebuilt game UI bundle.
+- `git diff --check`
+
+## Residual Risk
+
+This is local package, CLI, controller-bundle, and OpenSpec proof only. It does
+not prove deployed Civ7 runtime behavior or close parent controller/runtime
+acceptance rows.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-choice-local-player-evidence-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-choice-local-player-evidence-slice.md
@@ -27,9 +27,9 @@ instead of treating caller `playerId` as controller/runtime send authority.
 - `packages/civ7-control-orpc` owns the service behavior that composes
   readiness, before/after notification evidence, closeout runtime
   ports, and semantic output.
-- Caller `playerId` remains part of the caller-facing progression input, but
-  the service binds the closeout request and normal output to the source-owned
-  local-player evidence from the before-notification read.
+- Caller `playerId` is no longer part of the caller-facing progression choice
+  send input. The service binds the closeout request and normal output to the
+  source-owned local-player evidence from the before-notification read.
 - Progression controller bridge ingress remains rejected until a separate
   allowlist slice adds the request/response union, dispatch branch, closed
   controller proof envelope, and package/OpenSpec proof.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-player-send-hint-cleanup-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-player-send-hint-cleanup-slice.md
@@ -6,12 +6,13 @@ Implemented local source, test, and OpenSpec proof slice.
 
 ## Purpose
 
-Remove stale caller `--player-id` guidance from progression player-choice
-notification send recommendations. Native progression player-choice send
-surfaces already derive local-player evidence inside the
-`progression.attribute.*` and `progression.tradition.*` service procedures.
-Notification action hints should not teach callers to pass a player id for
-those mutation sends.
+Remove stale caller `--player-id` guidance and repeated flag variants from
+progression player-choice notification send recommendations. Native
+progression player-choice send surfaces already derive local-player evidence
+inside the `progression.attribute.*` and `progression.tradition.*` service
+procedures. Notification action hints should describe the semantic next move
+with minimal differentiating context, not restate every validation and closeout
+command combination.
 
 ## Write Set
 
@@ -22,10 +23,12 @@ those mutation sends.
 
 ## Boundary
 
-- Progression tradition/attribute send and send-closeout notification action
-  hints are playerless.
-- Dry-run validation hints remain player-scoped because direct-control
-  validation still needs a player id.
+- Progression tradition/attribute notification action hints are playerless for
+  mutation sends.
+- Action directions avoid separate entries for dry-run validation variants and
+  closeout flag variants.
+- Dry-run validation remains available through CLI command help and existing
+  direct-control validation paths.
 - No oRPC contract, router, middleware, bridge, CLI parser, generated bundle,
   direct-control runtime behavior, approval/reason mechanic, play-thread
   action, runtime/live proof claim, or parent Task 5.x/6.x/7.x acceptance is

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-player-send-hint-cleanup-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-player-send-hint-cleanup-slice.md
@@ -1,0 +1,51 @@
+# Progression Player Send Hint Cleanup Slice
+
+## Status
+
+Implemented local source, test, and OpenSpec proof slice.
+
+## Purpose
+
+Remove stale caller `--player-id` guidance from progression player-choice
+notification send recommendations. Native progression player-choice send
+surfaces already derive local-player evidence inside the
+`progression.attribute.*` and `progression.tradition.*` service procedures.
+Notification action hints should not teach callers to pass a player id for
+those mutation sends.
+
+## Write Set
+
+- `packages/civ7-direct-control/src/play/notifications/view.ts`
+- `packages/civ7-direct-control/test/play-notification-view.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/progression-player-send-hint-cleanup-slice.md`
+
+## Boundary
+
+- Progression tradition/attribute send and send-closeout notification action
+  hints are playerless.
+- Dry-run validation hints remain player-scoped because direct-control
+  validation still needs a player id.
+- No oRPC contract, router, middleware, bridge, CLI parser, generated bundle,
+  direct-control runtime behavior, approval/reason mechanic, play-thread
+  action, runtime/live proof claim, or parent Task 5.x/6.x/7.x acceptance is
+  introduced.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-direct-control test test/play-notification-view.test.ts`
+- `bun run --cwd packages/civ7-direct-control check`
+- `bun run --cwd packages/civ7-direct-control build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Stale progression send hint scan for `change-tradition --player-id ... --send`
+  and `buy-attribute --player-id ... --send`; remaining hits are focused
+  negative assertions.
+- Active approval/caller-permission scan over changed files; hits are only
+  negative boundary wording.
+- `git diff --check`
+
+## Residual Risk
+
+This is local source/test proof only. It does not prove deployed Civ7 runtime
+behavior or close broader progression/runtime acceptance.

--- a/packages/civ7-control-orpc/src/modules/city/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/city/contract.ts
@@ -87,7 +87,6 @@ const Civ7CityPopulationPlacementInputSchema = Type.Union([
   Type.Object(
     {
       mode: Type.Literal("assign-worker"),
-      playerId: Type.Integer({ minimum: 0 }),
       location: Type.Integer({ minimum: 0 }),
     },
     { additionalProperties: false },

--- a/packages/civ7-control-orpc/src/modules/city/procedures/population-place-request.ts
+++ b/packages/civ7-control-orpc/src/modules/city/procedures/population-place-request.ts
@@ -19,6 +19,9 @@ type Civ7ControlOrpcPopulationPlacementRuntimeResult = Awaited<
     Civ7ControlOrpcContext["directControl"]["requestCiv7AssignWorkerPlacement"]
   >
 >;
+type Civ7CityPopulationPlacementRuntimeInput =
+  | Readonly<{ mode: "assign-worker"; playerId: number; location: number }>
+  | Extract<Civ7CityPopulationPlacementInput, { mode: "expand-city" }>;
 
 export const cityPopulationPlaceRequestProcedure =
   civ7ControlOrpcMutationProcedure(
@@ -30,22 +33,29 @@ export const cityPopulationPlaceRequestProcedure =
   }) {
     return yield* Effect.tryPromise({
       try: async () => {
-        const result = input.mode === "assign-worker"
+        const runtimeInput = input.mode === "assign-worker"
+          ? {
+              mode: "assign-worker",
+              playerId: await readLocalPlayerId(context),
+              location: input.location,
+            } as const
+          : input;
+        const result = runtimeInput.mode === "assign-worker"
           ? await context.directControl.requestCiv7AssignWorkerPlacement(
             {
-              playerId: input.playerId,
-              location: input.location,
+              playerId: runtimeInput.playerId,
+              location: runtimeInput.location,
             },
             context.endpointDefaults,
           )
           : await context.directControl.requestCiv7ExpandCityPlacement(
             {
-              cityId: input.cityId,
-              destination: input.destination,
+              cityId: runtimeInput.cityId,
+              destination: runtimeInput.destination,
             },
             context.endpointDefaults,
           );
-        return cityPopulationPlacementResult(input, result);
+        return cityPopulationPlacementResult(runtimeInput, result);
       },
       catch: () =>
         errors.POPULATION_PLACEMENT_UNAVAILABLE({
@@ -59,7 +69,7 @@ export const cityPopulationPlaceRequestProcedure =
   });
 
 function cityPopulationPlacementResult(
-  input: Civ7CityPopulationPlacementInput,
+  input: Civ7CityPopulationPlacementRuntimeInput,
   result: Civ7ControlOrpcPopulationPlacementRuntimeResult,
 ): Civ7CityPopulationPlacementResult {
   const postcondition = cityPopulationPlacementPostconditionSummary(result);
@@ -89,7 +99,7 @@ function cityPopulationPlacementResult(
 }
 
 function cityPopulationPlacementSummary(
-  input: Civ7CityPopulationPlacementInput,
+  input: Civ7CityPopulationPlacementRuntimeInput,
 ): Civ7CityPopulationPlacementResult["placement"] {
   if (input.mode === "assign-worker") {
     return {
@@ -107,6 +117,15 @@ function cityPopulationPlacementSummary(
       y: input.destination.y,
     },
   };
+}
+
+async function readLocalPlayerId(
+  context: Civ7ControlOrpcContext,
+): Promise<number> {
+  const view = await context.directControl.getCiv7PlayNotificationView(
+    context.endpointDefaults,
+  );
+  return view.localPlayerId;
 }
 
 function cityPopulationPlacementPostconditionSummary(

--- a/packages/civ7-control-orpc/src/modules/diplomacy/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/diplomacy/contract.ts
@@ -9,7 +9,6 @@ import { toStandardSchema } from "../../typebox-standard-schema";
 
 const Civ7DiplomacyResponseInputSchema = Type.Object(
   {
-    playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
     actionId: Type.Integer(),
     responseType: Type.Integer(),
     notificationId: Type.Optional(Civ7ControlOrpcComponentIdSchema),
@@ -104,7 +103,6 @@ export type Civ7DiplomacyResponseResult = Static<
 
 const Civ7FirstMeetResponseInputSchema = Type.Object(
   {
-    playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
     metPlayerId: Type.Integer({ minimum: 0, maximum: 1024 }),
     responseType: Type.Integer(),
   },

--- a/packages/civ7-control-orpc/src/modules/diplomacy/procedures/first-meet-response-request.ts
+++ b/packages/civ7-control-orpc/src/modules/diplomacy/procedures/first-meet-response-request.ts
@@ -14,6 +14,10 @@ import type {
   Civ7FirstMeetResponseResult,
 } from "../contract";
 
+type FirstMeetResponseRuntimeInput = Civ7FirstMeetResponseInput & Readonly<{
+  playerId: number;
+}>;
+
 export const firstMeetResponseRequestProcedure =
   civ7ControlOrpcMutationProcedure(
     civ7ControlOrpcImplementer.diplomacy.firstMeet.response.request,
@@ -57,7 +61,7 @@ async function readLocalPlayerId(
 }
 
 function firstMeetResponseResult(
-  input: Civ7FirstMeetResponseInput,
+  input: FirstMeetResponseRuntimeInput,
   result: Civ7ControlOrpcFirstMeetResponseResult,
 ): Civ7FirstMeetResponseResult {
   const projection = civ7CloseoutMutationProjection({

--- a/packages/civ7-control-orpc/src/modules/diplomacy/procedures/response-request.ts
+++ b/packages/civ7-control-orpc/src/modules/diplomacy/procedures/response-request.ts
@@ -1,6 +1,7 @@
 import { diplomacyResponseProofPostcondition } from "@civ7/direct-control/proof/diplomacy-response-proof-policy";
 import { Effect } from "effect";
 
+import type { Civ7ControlOrpcContext } from "../../../context";
 import type { Civ7ControlOrpcDiplomacyResponseResult } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
 import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
@@ -13,6 +14,10 @@ import type {
   Civ7DiplomacyResponseResult,
 } from "../contract";
 
+type DiplomacyResponseRuntimeInput = Civ7DiplomacyResponseInput & Readonly<{
+  playerId: number;
+}>;
+
 export const diplomacyResponseRequestProcedure =
   civ7ControlOrpcMutationProcedure(
     civ7ControlOrpcImplementer.diplomacy.response.request,
@@ -23,11 +28,20 @@ export const diplomacyResponseRequestProcedure =
   }) {
     return yield* Effect.tryPromise({
       try: async () => {
+        const localPlayerId = await readLocalPlayerId(context);
+        const requestInput = {
+          playerId: localPlayerId,
+          actionId: input.actionId,
+          responseType: input.responseType,
+          ...(input.notificationId === undefined
+            ? {}
+            : { notificationId: input.notificationId }),
+        };
         const result = await context.directControl.requestCiv7DiplomacyResponse(
-          input,
+          requestInput,
           context.endpointDefaults,
         );
-        return diplomacyResponseResult(input, result);
+        return diplomacyResponseResult(requestInput, result);
       },
       catch: () =>
         errors.DIPLOMACY_RESPONSE_UNAVAILABLE({
@@ -40,8 +54,17 @@ export const diplomacyResponseRequestProcedure =
     });
   });
 
+async function readLocalPlayerId(
+  context: Civ7ControlOrpcContext,
+): Promise<number> {
+  const view = await context.directControl.getCiv7PlayNotificationView(
+    context.endpointDefaults,
+  );
+  return view.localPlayerId;
+}
+
 function diplomacyResponseResult(
-  input: Civ7DiplomacyResponseInput,
+  input: DiplomacyResponseRuntimeInput,
   result: Civ7ControlOrpcDiplomacyResponseResult,
 ): Civ7DiplomacyResponseResult {
   const projection = civ7CloseoutMutationProjection({

--- a/packages/civ7-control-orpc/src/modules/government/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/government/contract.ts
@@ -8,7 +8,6 @@ import { toStandardSchema } from "../../typebox-standard-schema";
 
 const Civ7GovernmentChoiceInputSchema = Type.Object(
   {
-    playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
     governmentType: Type.Integer(),
     action: Type.Optional(Type.Integer()),
   },
@@ -20,7 +19,6 @@ export type Civ7GovernmentChoiceInput = Static<
 
 const Civ7GovernmentCelebrationChoiceInputSchema = Type.Object(
   {
-    playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
     goldenAgeType: Type.Integer(),
   },
   { additionalProperties: false },

--- a/packages/civ7-control-orpc/src/modules/government/procedures/choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/government/procedures/choice-request.ts
@@ -22,6 +22,9 @@ type GovernmentChoiceSource =
 type GovernmentChoiceResult =
   | Civ7GovernmentChoiceResult
   | Civ7GovernmentCelebrationChoiceResult;
+type GovernmentChoiceRuntimeInput =
+  | (Civ7GovernmentChoiceInput & Readonly<{ playerId: number }>)
+  | (Civ7GovernmentCelebrationChoiceInput & Readonly<{ playerId: number }>);
 
 export const governmentChoiceRequestProcedure =
   civ7ControlOrpcMutationProcedure(
@@ -101,17 +104,17 @@ async function readLocalPlayerId(
 
 function governmentChoiceResult(
   source: "government.choice.request",
-  input: Civ7GovernmentChoiceInput,
+  input: Civ7GovernmentChoiceInput & Readonly<{ playerId: number }>,
   result: Civ7ControlOrpcGovernmentChoiceResult,
 ): Civ7GovernmentChoiceResult;
 function governmentChoiceResult(
   source: "government.celebration.choice.request",
-  input: Civ7GovernmentCelebrationChoiceInput,
+  input: Civ7GovernmentCelebrationChoiceInput & Readonly<{ playerId: number }>,
   result: Civ7ControlOrpcGovernmentChoiceResult,
 ): Civ7GovernmentCelebrationChoiceResult;
 function governmentChoiceResult(
   source: GovernmentChoiceSource,
-  input: Civ7GovernmentChoiceInput | Civ7GovernmentCelebrationChoiceInput,
+  input: GovernmentChoiceRuntimeInput,
   result: Civ7ControlOrpcGovernmentChoiceResult,
 ): GovernmentChoiceResult {
   const projection = civ7CloseoutMutationProjection({

--- a/packages/civ7-control-orpc/src/modules/narrative/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/narrative/contract.ts
@@ -9,7 +9,6 @@ import { toStandardSchema } from "../../typebox-standard-schema";
 
 const Civ7NarrativeChoiceInputSchema = Type.Object(
   {
-    playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
     targetType: Type.String({ minLength: 1 }),
     target: Civ7ControlOrpcComponentIdSchema,
     action: Type.Integer(),

--- a/packages/civ7-control-orpc/src/modules/narrative/procedures/choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/narrative/procedures/choice-request.ts
@@ -1,6 +1,7 @@
 import { narrativeChoiceProofPostcondition } from "@civ7/direct-control/proof/narrative-choice-proof-policy";
 import { Effect } from "effect";
 
+import type { Civ7ControlOrpcContext } from "../../../context";
 import type { Civ7ControlOrpcNarrativeChoiceResult } from "../../../dependencies/direct-control";
 import { civ7ControlOrpcMutationProcedure } from "../../../middleware/mutation-procedure";
 import { civ7ControlOrpcErrorCorrelationData } from "../../../model/correlation";
@@ -13,6 +14,10 @@ import type {
   Civ7NarrativeChoiceResult,
 } from "../contract";
 
+type NarrativeChoiceRuntimeInput = Civ7NarrativeChoiceInput & Readonly<{
+  playerId: number;
+}>;
+
 export const narrativeChoiceRequestProcedure =
   civ7ControlOrpcMutationProcedure(
     civ7ControlOrpcImplementer.narrative.choice.request,
@@ -23,11 +28,18 @@ export const narrativeChoiceRequestProcedure =
   }) {
     return yield* Effect.tryPromise({
       try: async () => {
+        const localPlayerId = await readLocalPlayerId(context);
+        const requestInput = {
+          playerId: localPlayerId,
+          targetType: input.targetType,
+          target: input.target,
+          action: input.action,
+        };
         const result = await context.directControl.requestCiv7NarrativeChoice(
-          input,
+          requestInput,
           context.endpointDefaults,
         );
-        return narrativeChoiceResult(input, result);
+        return narrativeChoiceResult(requestInput, result);
       },
       catch: () =>
         errors.NARRATIVE_CHOICE_UNAVAILABLE({
@@ -40,8 +52,17 @@ export const narrativeChoiceRequestProcedure =
     });
   });
 
+async function readLocalPlayerId(
+  context: Civ7ControlOrpcContext,
+): Promise<number> {
+  const view = await context.directControl.getCiv7PlayNotificationView(
+    context.endpointDefaults,
+  );
+  return view.localPlayerId;
+}
+
 function narrativeChoiceResult(
-  input: Civ7NarrativeChoiceInput,
+  input: NarrativeChoiceRuntimeInput,
   result: Civ7ControlOrpcNarrativeChoiceResult,
 ): Civ7NarrativeChoiceResult {
   const projection = civ7CloseoutMutationProjection({

--- a/packages/civ7-control-orpc/src/modules/progression/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/contract.ts
@@ -9,7 +9,6 @@ import { toStandardSchema } from "../../typebox-standard-schema";
 
 const Civ7ProgressionChoiceInputSchema = Type.Object(
   {
-    playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
     node: Type.Integer(),
     notificationId: Type.Optional(Civ7ControlOrpcComponentIdSchema),
   },

--- a/packages/civ7-control-orpc/src/modules/progression/contract.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/contract.ts
@@ -21,7 +21,6 @@ export type Civ7ProgressionChoiceInput = Static<
 
 const Civ7ProgressionTargetInputSchema = Type.Object(
   {
-    playerId: Type.Integer({ minimum: 0, maximum: 1024 }),
     node: Type.Integer(),
   },
   { additionalProperties: false },

--- a/packages/civ7-control-orpc/src/modules/progression/procedures/choice-request.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/procedures/choice-request.ts
@@ -29,6 +29,9 @@ type ProgressionChoiceCloseoutResult =
   | Civ7ControlOrpcTechnologyChoiceCloseoutResult
   | Civ7ControlOrpcCultureChoiceCloseoutResult;
 type ProgressionChoiceKind = "technology" | "culture";
+type ProgressionChoiceRuntimeInput = Civ7ProgressionChoiceInput & Readonly<{
+  playerId: number;
+}>;
 type ProgressionChoiceResult =
   | Civ7ProgressionTechnologyChoiceResult
   | Civ7ProgressionCultureChoiceResult;
@@ -118,7 +121,7 @@ export const progressionCultureChoiceRequestProcedure =
 
 async function requestProgressionChoice(
   kind: ProgressionChoiceKind,
-  input: Civ7ProgressionChoiceInput,
+  input: ProgressionChoiceRuntimeInput,
   dependencies: Readonly<{
     context: Civ7ControlOrpcContext;
   }>,
@@ -147,7 +150,7 @@ async function requestProgressionChoice(
 function progressionChoiceRuntimeInput(
   input: Civ7ProgressionChoiceInput,
   before: Civ7ControlOrpcPlayNotificationViewResult,
-): Civ7ProgressionChoiceInput {
+): ProgressionChoiceRuntimeInput {
   return {
     playerId: before.localPlayerId,
     node: input.node,
@@ -160,7 +163,7 @@ function progressionChoiceRuntimeInput(
 function progressionChoiceResult(
   kind: "technology",
   source: "progression.technology.choice.request",
-  input: Civ7ProgressionChoiceInput,
+  input: ProgressionChoiceRuntimeInput,
   result: ProgressionChoiceCloseoutResult,
   before: Civ7ControlOrpcPlayNotificationViewResult,
   after: ProgressionChoicePostRead,
@@ -168,7 +171,7 @@ function progressionChoiceResult(
 function progressionChoiceResult(
   kind: "culture",
   source: "progression.culture.choice.request",
-  input: Civ7ProgressionChoiceInput,
+  input: ProgressionChoiceRuntimeInput,
   result: ProgressionChoiceCloseoutResult,
   before: Civ7ControlOrpcPlayNotificationViewResult,
   after: ProgressionChoicePostRead,
@@ -178,7 +181,7 @@ function progressionChoiceResult(
   source:
     | "progression.technology.choice.request"
     | "progression.culture.choice.request",
-  input: Civ7ProgressionChoiceInput,
+  input: ProgressionChoiceRuntimeInput,
   result: ProgressionChoiceCloseoutResult,
   before: Civ7ControlOrpcPlayNotificationViewResult,
   after: ProgressionChoicePostRead,

--- a/packages/civ7-control-orpc/src/modules/progression/procedures/target-request.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/procedures/target-request.ts
@@ -22,6 +22,8 @@ type ProgressionTargetSource =
 type ProgressionTargetResult =
   | Civ7ProgressionTechnologyTargetResult
   | Civ7ProgressionCultureTargetResult;
+type ProgressionTargetRuntimeInput =
+  Civ7ProgressionTargetInput & Readonly<{ playerId: number }>;
 
 export const progressionTechnologyTargetRequestProcedure =
   civ7ControlOrpcMutationProcedure(
@@ -91,7 +93,7 @@ async function readLocalPlayerId(
 function progressionTargetRuntimeInput(
   input: Civ7ProgressionTargetInput,
   localPlayerId: number,
-): Civ7ProgressionTargetInput {
+): ProgressionTargetRuntimeInput {
   return {
     playerId: localPlayerId,
     node: input.node,
@@ -100,7 +102,7 @@ function progressionTargetRuntimeInput(
 
 async function requestProgressionTarget(
   kind: ProgressionTargetKind,
-  input: Civ7ProgressionTargetInput,
+  input: ProgressionTargetRuntimeInput,
   context: Civ7ControlOrpcContext,
 ): Promise<Civ7ControlOrpcProgressionTargetResult> {
   if (kind === "technology") {
@@ -118,17 +120,17 @@ async function requestProgressionTarget(
 
 function progressionTargetResult(
   source: "progression.technology.target.request",
-  input: Civ7ProgressionTargetInput,
+  input: ProgressionTargetRuntimeInput,
   result: Civ7ControlOrpcProgressionTargetResult,
 ): Civ7ProgressionTechnologyTargetResult;
 function progressionTargetResult(
   source: "progression.culture.target.request",
-  input: Civ7ProgressionTargetInput,
+  input: ProgressionTargetRuntimeInput,
   result: Civ7ControlOrpcProgressionTargetResult,
 ): Civ7ProgressionCultureTargetResult;
 function progressionTargetResult(
   source: ProgressionTargetSource,
-  input: Civ7ProgressionTargetInput,
+  input: ProgressionTargetRuntimeInput,
   result: Civ7ControlOrpcProgressionTargetResult,
 ): ProgressionTargetResult {
   const projection = civ7CloseoutMutationProjection({

--- a/packages/civ7-control-orpc/test/city-population-placement-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/city-population-placement-procedure.test.ts
@@ -23,7 +23,7 @@ describe("city.population.place.request control-oRPC procedure", () => {
 
     const result = await call(
       Civ7ControlOrpcRouter.city.population.place.request,
-      { mode: "assign-worker", playerId: 0, location: 2543 },
+      { mode: "assign-worker", location: 2543 },
       { context: fake.context },
     );
 
@@ -62,10 +62,51 @@ describe("city.population.place.request control-oRPC procedure", () => {
     expect(serialized).not.toContain("\"state\"");
     expect(serialized).not.toContain("\"command\"");
     expect(serialized).not.toContain("\"verified\"");
-    expect(fake.calls).toEqual([{
+    expect(fake.calls).toEqual([
+      {
+        method: "getCiv7PlayNotificationView",
+        options: {
+          host: "127.0.0.1",
+          port: 4318,
+          timeoutMs: 1_000,
+        },
+      },
+      {
+        method: "requestCiv7AssignWorkerPlacement",
+        input: {
+          playerId: 0,
+          location: 2543,
+        },
+        options: {
+          host: "127.0.0.1",
+          port: 4318,
+          timeoutMs: 1_000,
+        },
+      },
+    ]);
+  });
+
+  test("uses live local-player evidence instead of caller player input for assign-worker sends", async () => {
+    const fake = fakeContext(
+      operationRequestResult("population-ready-cleared", "assign-worker"),
+      { localPlayerId: 2 },
+    );
+
+    const result = await call(
+      Civ7ControlOrpcRouter.city.population.place.request,
+      { mode: "assign-worker", location: 2543 },
+      { context: fake.context },
+    );
+
+    expect(result.placement).toEqual({
+      mode: "assign-worker",
+      playerId: 2,
+      location: 2543,
+    });
+    expect(fake.calls).toContainEqual({
       method: "requestCiv7AssignWorkerPlacement",
       input: {
-        playerId: 0,
+        playerId: 2,
         location: 2543,
       },
       options: {
@@ -73,7 +114,7 @@ describe("city.population.place.request control-oRPC procedure", () => {
         port: 4318,
         timeoutMs: 1_000,
       },
-    }]);
+    });
   });
 
   test("maps expand-city placement to the semantic population runtime port through the server-side router client", async () => {
@@ -117,7 +158,7 @@ describe("city.population.place.request control-oRPC procedure", () => {
 
     const result = await call(
       Civ7ControlOrpcRouter.city.population.place.request,
-      { mode: "assign-worker", playerId: 0, location: 2543 },
+      { mode: "assign-worker", location: 2543 },
       { context: fake.context },
     );
 
@@ -154,7 +195,7 @@ describe("city.population.place.request control-oRPC procedure", () => {
 
       const result = await call(
         Civ7ControlOrpcRouter.city.population.place.request,
-        { mode: "assign-worker", playerId: 0, location: 2543 },
+        { mode: "assign-worker", location: 2543 },
         { context: fake.context },
       );
 
@@ -184,7 +225,7 @@ describe("city.population.place.request control-oRPC procedure", () => {
 
     const result = await call(
       Civ7ControlOrpcRouter.city.population.place.request,
-      { mode: "assign-worker", playerId: 0, location: 2543 },
+      { mode: "assign-worker", location: 2543 },
       { context: fake.context },
     );
 
@@ -210,35 +251,31 @@ describe("city.population.place.request control-oRPC procedure", () => {
 
   test("keeps endpoint, session, operation, and raw command fields out of procedure input", async () => {
     const invalidInputs = [
-      { mode: "assign-worker", playerId: 0, location: 2543, host: "127.0.0.1" },
-      { mode: "assign-worker", playerId: 0, location: 2543, port: 4318 },
-      { mode: "assign-worker", playerId: 0, location: 2543, stateName: "App UI" },
+      { mode: "assign-worker", location: 2543, host: "127.0.0.1" },
+      { mode: "assign-worker", location: 2543, port: 4318 },
+      { mode: "assign-worker", location: 2543, stateName: "App UI" },
       {
         mode: "assign-worker",
-        playerId: 0,
         location: 2543,
         session: { state: "App UI" },
       },
       {
         mode: "assign-worker",
-        playerId: 0,
         location: 2543,
         operationType: "ASSIGN_WORKER",
       },
       {
         mode: "assign-worker",
-        playerId: 0,
         location: 2543,
         args: { Location: 2543, Amount: 1 },
       },
       {
         mode: "assign-worker",
-        playerId: 0,
         location: 2543,
         rawCommand: "Game.PlayerOperations.sendRequest(...)",
       },
-      { mode: "assign-worker", playerId: -1, location: 2543 },
-      { mode: "assign-worker", playerId: 0, location: 2543.5 },
+      { mode: "assign-worker", playerId: 2, location: 2543 },
+      { mode: "assign-worker", location: 2543.5 },
       { mode: "expand-city", cityId, destination: { x: 1.5, y: 19 } },
       { mode: "expand-city", cityId, destination: { x: 16, y: -1 } },
     ];
@@ -267,7 +304,6 @@ describe("city.population.place.request control-oRPC procedure", () => {
     await expect(
       call(Civ7ControlOrpcRouter.city.population.place.request, {
         mode: "assign-worker",
-        playerId: 0,
         location: 2543,
       }, { context: fake.context }),
     ).rejects.toMatchObject({
@@ -282,7 +318,6 @@ describe("city.population.place.request control-oRPC procedure", () => {
     try {
       await call(Civ7ControlOrpcRouter.city.population.place.request, {
         mode: "assign-worker",
-        playerId: 0,
         location: 2543,
       }, { context: fake.context });
     } catch (err) {
@@ -316,18 +351,25 @@ describe("city.population.place.request control-oRPC procedure", () => {
 function fakeContext(
   resultOrError: PopulationPlacementRuntimeResult | Error,
   options: {
+    localPlayerId?: number;
   } = {},
 ): {
   context: Civ7ControlOrpcContext;
   calls: Array<{
-    method: "requestCiv7AssignWorkerPlacement" | "requestCiv7ExpandCityPlacement";
-    input: unknown;
+    method:
+      | "getCiv7PlayNotificationView"
+      | "requestCiv7AssignWorkerPlacement"
+      | "requestCiv7ExpandCityPlacement";
+    input?: unknown;
     options: unknown;
   }>;
 } {
   const calls: Array<{
-    method: "requestCiv7AssignWorkerPlacement" | "requestCiv7ExpandCityPlacement";
-    input: unknown;
+    method:
+      | "getCiv7PlayNotificationView"
+      | "requestCiv7AssignWorkerPlacement"
+      | "requestCiv7ExpandCityPlacement";
+    input?: unknown;
     options: unknown;
   }> = [];
 
@@ -343,6 +385,13 @@ function fakeContext(
           playable: true,
           readiness: "tuner-ready",
         }),
+        getCiv7PlayNotificationView: async (endpointDefaults) => {
+          calls.push({
+            method: "getCiv7PlayNotificationView",
+            options: endpointDefaults,
+          });
+          return { localPlayerId: options.localPlayerId ?? 0 };
+        },
         requestCiv7AssignWorkerPlacement: async (input, endpointDefaults) => {
           calls.push({
             method: "requestCiv7AssignWorkerPlacement",

--- a/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
+++ b/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
@@ -970,7 +970,6 @@ describe("Civ7 controller bridge ingress", () => {
       procedureKey: "city.population.place.request",
       input: {
         mode: "assign-worker",
-        playerId: 0,
         location: workerLocation,
       },
       correlationId: "controller-population-1",
@@ -997,6 +996,7 @@ describe("Civ7 controller bridge ingress", () => {
       },
     });
     expect(fake.calls.status).toEqual([{ timeoutMs: 1_000 }]);
+    expect(fake.calls.views).toEqual([{ timeoutMs: 1_000 }]);
     expect(fake.calls.population).toEqual([{
       method: "requestCiv7AssignWorkerPlacement",
       input: { playerId: 0, location: workerLocation },
@@ -1006,7 +1006,6 @@ describe("Civ7 controller bridge ingress", () => {
       procedureKey: "city.population.place.request",
       input: {
         mode: "assign-worker",
-        playerId: 0,
         location: workerLocation,
       },
       correlationId: "controller-population-1",
@@ -1764,6 +1763,13 @@ describe("Civ7 controller bridge ingress", () => {
           mode: "assign-worker",
           playerId: 0,
           location: workerLocation,
+        },
+      },
+      {
+        procedureKey: "city.population.place.request",
+        input: {
+          mode: "assign-worker",
+          location: workerLocation,
           rawCommand: "Game.PlayerOperations.sendRequest(...)",
         },
       },
@@ -2470,6 +2476,7 @@ function fakeProductionChoiceContext(): {
 function fakePopulationPlacementContext(): {
   calls: {
     status: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+    views: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
     population: Array<{
       method: "requestCiv7AssignWorkerPlacement" | "requestCiv7ExpandCityPlacement";
       input: unknown;
@@ -2481,6 +2488,7 @@ function fakePopulationPlacementContext(): {
 } {
   const calls: {
     status: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+    views: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
     population: Array<{
       method: "requestCiv7AssignWorkerPlacement" | "requestCiv7ExpandCityPlacement";
       input: unknown;
@@ -2488,6 +2496,7 @@ function fakePopulationPlacementContext(): {
     }>;
   } = {
     status: [],
+    views: [],
     population: [],
   };
   return {
@@ -2503,6 +2512,10 @@ function fakePopulationPlacementContext(): {
         getCiv7PlayableStatus: async (options) => {
           calls.status.push(options);
           return playableStatusResult();
+        },
+        getCiv7PlayNotificationView: async (options) => {
+          calls.views.push(options);
+          return cleanNotificationViewResult();
         },
         requestCiv7AssignWorkerPlacement: async (input, options) => {
           calls.population.push({

--- a/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
+++ b/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
@@ -122,19 +122,16 @@ const townFocusInput = {
 };
 const narrativeTarget = { owner: 0, id: 7_001, type: 12 };
 const narrativeInput = {
-  playerId: 2,
   targetType: "DISCOVERY_STORY",
   target: narrativeTarget,
   action: 1,
 };
 const diplomacyInput = {
-  playerId: 2,
   actionId: 8_821,
   responseType: -1_713_616_684,
   notificationId,
 };
 const firstMeetInput = {
-  playerId: 2,
   metPlayerId: 2,
   responseType: 673_478_009,
 };
@@ -1174,8 +1171,12 @@ describe("Civ7 controller bridge ingress", () => {
       },
     });
     expect(fake.calls.status).toEqual([{ timeoutMs: 1_000 }]);
+    expect(fake.calls.views).toEqual([{ timeoutMs: 1_000 }]);
     expect(fake.calls.narrative).toEqual([{
-      input: narrativeInput,
+      input: {
+        playerId: 0,
+        ...narrativeInput,
+      },
       options: { timeoutMs: 1_000 },
     }]);
     expect(fake.contextRequests).toEqual([{
@@ -1235,8 +1236,12 @@ describe("Civ7 controller bridge ingress", () => {
       },
     });
     expect(fake.calls.status).toEqual([{ timeoutMs: 1_000 }]);
+    expect(fake.calls.views).toEqual([{ timeoutMs: 1_000 }]);
     expect(fake.calls.diplomacy).toEqual([{
-      input: diplomacyInput,
+      input: {
+        playerId: 0,
+        ...diplomacyInput,
+      },
       options: { timeoutMs: 1_000 },
     }]);
     expect(fake.contextRequests).toEqual([{
@@ -2584,6 +2589,7 @@ function fakeTownFocusContext(): {
 function fakeNarrativeChoiceContext(): {
   calls: {
     status: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+    views: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
     narrative: Array<{
       input: unknown;
       options: unknown;
@@ -2594,12 +2600,14 @@ function fakeNarrativeChoiceContext(): {
 } {
   const calls: {
     status: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+    views: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
     narrative: Array<{
       input: unknown;
       options: unknown;
     }>;
   } = {
     status: [],
+    views: [],
     narrative: [],
   };
   return {
@@ -2616,6 +2624,10 @@ function fakeNarrativeChoiceContext(): {
           calls.status.push(options);
           return playableStatusResult();
         },
+        getCiv7PlayNotificationView: async (options) => {
+          calls.views.push(options);
+          return cleanNotificationViewResult();
+        },
         requestCiv7NarrativeChoice: async (input, options) => {
           calls.narrative.push({ input, options });
           return narrativeChoiceResult();
@@ -2628,6 +2640,7 @@ function fakeNarrativeChoiceContext(): {
 function fakeDiplomacyResponseContext(): {
   calls: {
     status: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+    views: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
     diplomacy: Array<{
       input: unknown;
       options: unknown;
@@ -2638,12 +2651,14 @@ function fakeDiplomacyResponseContext(): {
 } {
   const calls: {
     status: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+    views: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
     diplomacy: Array<{
       input: unknown;
       options: unknown;
     }>;
   } = {
     status: [],
+    views: [],
     diplomacy: [],
   };
   return {
@@ -2659,6 +2674,10 @@ function fakeDiplomacyResponseContext(): {
         getCiv7PlayableStatus: async (options) => {
           calls.status.push(options);
           return playableStatusResult();
+        },
+        getCiv7PlayNotificationView: async (options) => {
+          calls.views.push(options);
+          return cleanNotificationViewResult();
         },
         requestCiv7DiplomacyResponse: async (input, options) => {
           calls.diplomacy.push({ input, options });

--- a/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
+++ b/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
@@ -146,12 +146,10 @@ const celebrationInput = {
   goldenAgeType: -340_825_966,
 };
 const progressionTechnologyInput = {
-  playerId: 2,
   node: 18_001,
   notificationId,
 };
 const progressionCultureInput = {
-  playerId: 2,
   node: 27_001,
   notificationId,
 };
@@ -1873,6 +1871,13 @@ describe("Civ7 controller bridge ingress", () => {
         input: {
           ...celebrationInput,
           operationType: "CHOOSE_GOLDEN_AGE",
+        },
+      },
+      {
+        procedureKey: "progression.technology.choice.request",
+        input: {
+          ...progressionTechnologyInput,
+          playerId: 2,
         },
       },
       {

--- a/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
+++ b/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
@@ -139,12 +139,10 @@ const firstMeetInput = {
   responseType: 673_478_009,
 };
 const governmentInput = {
-  playerId: 2,
   governmentType: 0,
   action: -1_326_475_004,
 };
 const celebrationInput = {
-  playerId: 2,
   goldenAgeType: -340_825_966,
 };
 const progressionTechnologyInput = {

--- a/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
+++ b/packages/civ7-control-orpc/test/controller-bridge-ingress.test.ts
@@ -156,7 +156,6 @@ const progressionCultureInput = {
   notificationId,
 };
 const progressionTargetInput = {
-  playerId: 2,
   node: 18_001,
 };
 const attributePurchaseInput = {
@@ -1893,6 +1892,13 @@ describe("Civ7 controller bridge ingress", () => {
         input: {
           ...progressionCultureInput,
           rawCommand: "Game.PlayerOperations.sendRequest(...)",
+        },
+      },
+      {
+        procedureKey: "progression.technology.target.request",
+        input: {
+          ...progressionTargetInput,
+          playerId: 2,
         },
       },
       {

--- a/packages/civ7-control-orpc/test/diplomacy-response-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/diplomacy-response-procedure.test.ts
@@ -9,10 +9,12 @@ import {
   type Civ7ControlOrpcContext,
   type Civ7ControlOrpcPlayableStatusResult,
 } from "../src/index";
-import type { Civ7ControlOrpcDiplomacyResponseResult } from "../src/dependencies/direct-control";
+import type {
+  Civ7ControlOrpcDiplomacyResponseResult,
+  Civ7ControlOrpcPlayNotificationViewResult,
+} from "../src/dependencies/direct-control";
 
 const diplomacyInput = {
-  playerId: 0,
   actionId: 8_821,
   responseType: -1_713_616_684,
   notificationId: { owner: 0, id: 44, type: 20 },
@@ -29,8 +31,12 @@ describe("diplomacy.response.request control-oRPC procedure", () => {
     );
 
     expect(fake.calls.readiness).toHaveLength(1);
+    expect(fake.calls.views).toHaveLength(1);
     expect(fake.calls.request).toEqual([{
-      input: diplomacyInput,
+      input: {
+        playerId: 0,
+        ...diplomacyInput,
+      },
       options: {
         host: "127.0.0.1",
         port: 4318,
@@ -73,23 +79,37 @@ describe("diplomacy.response.request control-oRPC procedure", () => {
     expect(serialized).not.toContain("Game.PlayerOperations.sendRequest");
   });
 
-  test("projects source-owned acted player evidence instead of caller validation player", async () => {
-    const input = {
-      ...diplomacyInput,
-      playerId: 2,
-    };
+  test("derives send player from live notification evidence", async () => {
     const fake = fakeContext(diplomacyResponseResult("diplomacy-blocker-cleared", {
       playerId: 0,
-    }));
+    }), { localPlayerId: 2 });
 
     const result = await call(
       Civ7ControlOrpcRouter.diplomacy.response.request,
-      input,
+      diplomacyInput,
       { context: fake.context },
     );
 
-    expect(fake.calls.request[0]?.input).toEqual(input);
+    expect(fake.calls.request[0]?.input).toEqual({
+      playerId: 2,
+      ...diplomacyInput,
+    });
     expect(result.playerId).toBe(0);
+  });
+
+  test("rejects caller playerId before facade execution", async () => {
+    const fake = fakeContext(diplomacyResponseResult("diplomacy-blocker-cleared"));
+
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.diplomacy.response.request,
+        { ...diplomacyInput, playerId: 2 } as never,
+        { context: fake.context },
+      ),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(fake.calls.readiness).toEqual([]);
+    expect(fake.calls.views).toEqual([]);
+    expect(fake.calls.request).toEqual([]);
   });
 
   test("keeps sent no-state-change diplomacy responses no-repeat guarded", async () => {
@@ -177,6 +197,7 @@ describe("diplomacy.response.request control-oRPC procedure", () => {
         ),
       ).rejects.toMatchObject({ code: "BAD_REQUEST" });
       expect(fake.calls.readiness).toEqual([]);
+      expect(fake.calls.views).toEqual([]);
       expect(fake.calls.request).toEqual([]);
     }
   });
@@ -263,10 +284,11 @@ describe("diplomacy.response.request control-oRPC procedure", () => {
 
 function fakeContext(
   result: Civ7ControlOrpcDiplomacyResponseResult,
-  options: Partial<{ playable: boolean }> = {},
+  options: Partial<{ playable: boolean; localPlayerId: number }> = {},
 ): {
   calls: {
     readiness: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+    views: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
     request: Array<Readonly<{
       input: unknown;
       options: Civ7ControlOrpcContext["endpointDefaults"];
@@ -276,6 +298,7 @@ function fakeContext(
 } {
   const calls = {
     readiness: [] as Array<Civ7ControlOrpcContext["endpointDefaults"]>,
+    views: [] as Array<Civ7ControlOrpcContext["endpointDefaults"]>,
     request: [] as Array<Readonly<{
       input: unknown;
       options: Civ7ControlOrpcContext["endpointDefaults"];
@@ -294,6 +317,12 @@ function fakeContext(
         getCiv7PlayableStatus: async (endpointDefaults) => {
           calls.readiness.push(endpointDefaults);
           return playableStatusResult(options.playable ?? true);
+        },
+        getCiv7PlayNotificationView: async (endpointDefaults) => {
+          calls.views.push(endpointDefaults);
+          return {
+            localPlayerId: options.localPlayerId ?? 0,
+          } as Civ7ControlOrpcPlayNotificationViewResult;
         },
         requestCiv7DiplomacyResponse: async (input, endpointDefaults) => {
           calls.request.push({ input, options: endpointDefaults });
@@ -316,7 +345,7 @@ function diplomacyResponseResult(
 ): Civ7ControlOrpcDiplomacyResponseResult {
   const sent = options.sent ?? classification !== "not-sent";
   return {
-    playerId: options.playerId ?? diplomacyInput.playerId,
+    playerId: options.playerId ?? 0,
     before: {} as Civ7ControlOrpcDiplomacyResponseResult["before"],
     beforeValidation: {
       valid: options.beforeValid ?? classification !== "not-sent",

--- a/packages/civ7-control-orpc/test/first-meet-response-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/first-meet-response-procedure.test.ts
@@ -15,7 +15,6 @@ import type {
 } from "../src/dependencies/direct-control";
 
 const firstMeetInput = {
-  playerId: 2,
   metPlayerId: 2,
   responseType: 673_478_009,
 } as const;
@@ -142,6 +141,21 @@ describe("diplomacy.firstMeet.response.request control-oRPC procedure", () => {
     }]);
   });
 
+  test("rejects caller playerId before facade execution", async () => {
+    const fake = fakeContext(firstMeetResponseResult("first-meet-cleared"));
+
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.diplomacy.firstMeet.response.request,
+        { ...firstMeetInput, playerId: 2 } as never,
+        { context: fake.context },
+      ),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(fake.calls.readiness).toEqual([]);
+    expect(fake.calls.views).toEqual([]);
+    expect(fake.calls.request).toEqual([]);
+  });
+
   test("keeps endpoint/session/state/raw command fields out of procedure input", async () => {
     const invalidInputs = [
       { ...firstMeetInput, host: "127.0.0.1" },
@@ -165,6 +179,7 @@ describe("diplomacy.firstMeet.response.request control-oRPC procedure", () => {
         ),
       ).rejects.toMatchObject({ code: "BAD_REQUEST" });
       expect(fake.calls.readiness).toEqual([]);
+      expect(fake.calls.views).toEqual([]);
       expect(fake.calls.request).toEqual([]);
     }
   });

--- a/packages/civ7-control-orpc/test/game-ui-controller.test.ts
+++ b/packages/civ7-control-orpc/test/game-ui-controller.test.ts
@@ -801,7 +801,7 @@ describe("Civ7 game UI controller bootstrap", () => {
 
     const response = await bridge.invoke({
       procedureKey: "city.population.place.request",
-      input: { mode: "assign-worker", playerId: 0, location: 2543 },
+      input: { mode: "assign-worker", location: 2543 },
       correlationId: "game-ui-population-assign-worker-1",
     });
 
@@ -901,7 +901,7 @@ describe("Civ7 game UI controller bootstrap", () => {
 
     const response = await bridge.invoke({
       procedureKey: "city.population.place.request",
-      input: { mode: "assign-worker", playerId: 0, location: 2543 },
+      input: { mode: "assign-worker", location: 2543 },
     });
 
     expect(response).toMatchObject({
@@ -927,7 +927,7 @@ describe("Civ7 game UI controller bootstrap", () => {
     expect(sendCalls).toEqual([]);
   });
 
-  test("blocks game UI assign-worker sends for non-local players", async () => {
+  test("rejects caller player ids on game UI assign-worker bridge input", async () => {
     const sendCalls: unknown[] = [];
     const target = gameUiNotificationTarget(notificationId, {
       populationPlacement: {
@@ -944,25 +944,12 @@ describe("Civ7 game UI controller bootstrap", () => {
       input: { mode: "assign-worker", playerId: 2, location: 2543 },
     });
 
-    expect(response).toMatchObject({
-      ok: true,
-      output: {
-        placement: {
-          mode: "assign-worker",
-          playerId: 2,
-          location: 2543,
-        },
-        sent: false,
-        status: "not-sent",
-        validation: {
-          beforeValid: false,
-          afterValid: false,
-        },
-        postcondition: {
-          classification: "not-sent",
-          confirmed: false,
-          noRepeatAfterUnverified: true,
-        },
+    expect(response).toEqual({
+      ok: false,
+      error: {
+        code: "BRIDGE_BAD_REQUEST",
+        message: "Civ7 controller bridge request envelope is invalid.",
+        reason: "invalid-envelope",
       },
     });
     expect(sendCalls).toEqual([]);
@@ -981,7 +968,7 @@ describe("Civ7 game UI controller bootstrap", () => {
 
     const response = await bridge.invoke({
       procedureKey: "city.population.place.request",
-      input: { mode: "assign-worker", playerId: 0, location: 2543 },
+      input: { mode: "assign-worker", location: 2543 },
     });
 
     expect(response).toMatchObject({
@@ -1018,7 +1005,7 @@ describe("Civ7 game UI controller bootstrap", () => {
 
     const response = await bridge.invoke({
       procedureKey: "city.population.place.request",
-      input: { mode: "assign-worker", playerId: 0, location: 2543 },
+      input: { mode: "assign-worker", location: 2543 },
     });
 
     expect(response).toMatchObject({
@@ -1051,7 +1038,7 @@ describe("Civ7 game UI controller bootstrap", () => {
 
     const response = await bridge.invoke({
       procedureKey: "city.population.place.request",
-      input: { mode: "assign-worker", playerId: 0, location: 2543 },
+      input: { mode: "assign-worker", location: 2543 },
     });
 
     expect(response).toMatchObject({

--- a/packages/civ7-control-orpc/test/game-ui-controller.test.ts
+++ b/packages/civ7-control-orpc/test/game-ui-controller.test.ts
@@ -1807,7 +1807,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "narrative.choice.request",
       input: {
-        playerId: 2,
         targetType: "DISCOVERY_STORY",
         target: notificationId,
         action: 1,
@@ -1880,7 +1879,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "narrative.choice.request",
       input: {
-        playerId: 0,
         targetType: "DISCOVERY_STORY",
         target: notificationId,
         action: 1,
@@ -1922,7 +1920,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "narrative.choice.request",
       input: {
-        playerId: 0,
         targetType: "DISCOVERY_STORY",
         target: notificationId,
         action: 1,
@@ -1987,7 +1984,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "diplomacy.response.request",
       input: {
-        playerId: 2,
         actionId: diplomacyActionId,
         responseType: diplomacyResponseType,
         notificationId,
@@ -2055,7 +2051,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "diplomacy.response.request",
       input: {
-        playerId: 0,
         actionId: diplomacyActionId,
         responseType: diplomacyResponseType,
         notificationId,
@@ -2098,7 +2093,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "diplomacy.response.request",
       input: {
-        playerId: 0,
         actionId: diplomacyActionId,
         responseType: diplomacyResponseType,
         notificationId,
@@ -2144,7 +2138,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "diplomacy.response.request",
       input: {
-        playerId: 0,
         actionId: diplomacyActionId,
         responseType: diplomacyResponseType,
       },
@@ -2350,7 +2343,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "diplomacy.firstMeet.response.request",
       input: {
-        playerId: 2,
         metPlayerId: 2,
         responseType: firstMeetResponseType,
       },
@@ -2418,7 +2410,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "diplomacy.firstMeet.response.request",
       input: {
-        playerId: 2,
         metPlayerId: 2,
         responseType: firstMeetResponseType,
       },
@@ -2464,7 +2455,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "diplomacy.firstMeet.response.request",
       input: {
-        playerId: 2,
         metPlayerId: 2,
         responseType: firstMeetResponseType,
       },

--- a/packages/civ7-control-orpc/test/game-ui-controller.test.ts
+++ b/packages/civ7-control-orpc/test/game-ui-controller.test.ts
@@ -2531,7 +2531,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "government.choice.request",
       input: {
-        playerId: 2,
         governmentType,
         action: governmentAction,
       },
@@ -2595,7 +2594,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "government.choice.request",
       input: {
-        playerId: 2,
         governmentType,
         action: governmentAction,
       },
@@ -2641,7 +2639,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "government.celebration.choice.request",
       input: {
-        playerId: 2,
         goldenAgeType,
       },
       correlationId: "game-ui-celebration-choice-1",

--- a/packages/civ7-control-orpc/test/game-ui-controller.test.ts
+++ b/packages/civ7-control-orpc/test/game-ui-controller.test.ts
@@ -1525,7 +1525,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "progression.technology.target.request",
       input: {
-        playerId: 2,
         node: 18_001,
       },
       correlationId: "game-ui-progression-target-1",

--- a/packages/civ7-control-orpc/test/game-ui-controller.test.ts
+++ b/packages/civ7-control-orpc/test/game-ui-controller.test.ts
@@ -1348,7 +1348,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "progression.technology.choice.request",
       input: {
-        playerId: 2,
         node: 18_001,
         notificationId,
       },
@@ -1416,7 +1415,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "progression.culture.choice.request",
       input: {
-        playerId: 0,
         node: 27_001,
         notificationId,
       },
@@ -1462,7 +1460,6 @@ describe("Civ7 game UI controller bootstrap", () => {
     const response = await bridge.invoke({
       procedureKey: "progression.technology.choice.request",
       input: {
-        playerId: 0,
         node: 18_001,
         notificationId,
       },

--- a/packages/civ7-control-orpc/test/government-choice-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/government-choice-procedure.test.ts
@@ -15,13 +15,11 @@ import type {
 } from "../src/dependencies/direct-control";
 
 const governmentInput = {
-  playerId: 2,
   governmentType: 0,
   action: -1_326_475_004,
 } as const;
 
 const celebrationInput = {
-  playerId: 2,
   goldenAgeType: -340_825_966,
 } as const;
 
@@ -171,6 +169,7 @@ describe("government choice control-oRPC procedures", () => {
 
   test("keeps endpoint/session/state/raw command fields out of procedure input", async () => {
     const invalidInputs = [
+      { ...governmentInput, playerId: 2 },
       { ...governmentInput, host: "127.0.0.1" },
       { ...governmentInput, port: 4318 },
       { ...governmentInput, state: { role: "tuner" } },
@@ -199,6 +198,7 @@ describe("government choice control-oRPC procedures", () => {
     }
 
     const celebrationInvalidInputs = [
+      { ...celebrationInput, playerId: 2 },
       { ...celebrationInput, host: "127.0.0.1" },
       { ...celebrationInput, command: "Game.PlayerOperations.sendRequest" },
       { ...celebrationInput, operationType: "CHOOSE_GOLDEN_AGE" },

--- a/packages/civ7-control-orpc/test/narrative-choice-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/narrative-choice-procedure.test.ts
@@ -9,10 +9,12 @@ import {
   type Civ7ControlOrpcContext,
   type Civ7ControlOrpcPlayableStatusResult,
 } from "../src/index";
-import type { Civ7ControlOrpcNarrativeChoiceResult } from "../src/dependencies/direct-control";
+import type {
+  Civ7ControlOrpcNarrativeChoiceResult,
+  Civ7ControlOrpcPlayNotificationViewResult,
+} from "../src/dependencies/direct-control";
 
 const narrativeInput = {
-  playerId: 0,
   targetType: "DISCOVERY_STORY",
   target: { owner: 0, id: 7_001, type: 12 },
   action: 1,
@@ -29,8 +31,12 @@ describe("narrative.choice.request control-oRPC procedure", () => {
     );
 
     expect(fake.calls.readiness).toHaveLength(1);
+    expect(fake.calls.views).toHaveLength(1);
     expect(fake.calls.request).toEqual([{
-      input: narrativeInput,
+      input: {
+        playerId: 0,
+        ...narrativeInput,
+      },
       options: {
         host: "127.0.0.1",
         port: 4318,
@@ -73,23 +79,37 @@ describe("narrative.choice.request control-oRPC procedure", () => {
     expect(serialized).not.toContain("Game.turn");
   });
 
-  test("projects source-owned acted player evidence instead of caller validation player", async () => {
-    const input = {
-      ...narrativeInput,
-      playerId: 2,
-    };
+  test("derives send player from live notification evidence", async () => {
     const fake = fakeContext(narrativeChoiceResult("narrative-blocker-cleared", {
       playerId: 0,
-    }));
+    }), { localPlayerId: 2 });
 
     const result = await call(
       Civ7ControlOrpcRouter.narrative.choice.request,
-      input,
+      narrativeInput,
       { context: fake.context },
     );
 
-    expect(fake.calls.request[0]?.input).toEqual(input);
+    expect(fake.calls.request[0]?.input).toEqual({
+      playerId: 2,
+      ...narrativeInput,
+    });
     expect(result.playerId).toBe(0);
+  });
+
+  test("rejects caller playerId before facade execution", async () => {
+    const fake = fakeContext(narrativeChoiceResult("narrative-blocker-cleared"));
+
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.narrative.choice.request,
+        { ...narrativeInput, playerId: 2 } as never,
+        { context: fake.context },
+      ),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(fake.calls.readiness).toEqual([]);
+    expect(fake.calls.views).toEqual([]);
+    expect(fake.calls.request).toEqual([]);
   });
 
   test("keeps sent no-state-change narrative choices no-repeat guarded", async () => {
@@ -175,6 +195,7 @@ describe("narrative.choice.request control-oRPC procedure", () => {
         ),
       ).rejects.toMatchObject({ code: "BAD_REQUEST" });
       expect(fake.calls.readiness).toEqual([]);
+      expect(fake.calls.views).toEqual([]);
       expect(fake.calls.request).toEqual([]);
     }
   });
@@ -261,10 +282,11 @@ describe("narrative.choice.request control-oRPC procedure", () => {
 
 function fakeContext(
   result: Civ7ControlOrpcNarrativeChoiceResult,
-  options: Partial<{ playable: boolean }> = {},
+  options: Partial<{ playable: boolean; localPlayerId: number }> = {},
 ): {
   calls: {
     readiness: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
+    views: Array<Civ7ControlOrpcContext["endpointDefaults"]>;
     request: Array<Readonly<{
       input: unknown;
       options: Civ7ControlOrpcContext["endpointDefaults"];
@@ -274,6 +296,7 @@ function fakeContext(
 } {
   const calls = {
     readiness: [] as Array<Civ7ControlOrpcContext["endpointDefaults"]>,
+    views: [] as Array<Civ7ControlOrpcContext["endpointDefaults"]>,
     request: [] as Array<Readonly<{
       input: unknown;
       options: Civ7ControlOrpcContext["endpointDefaults"];
@@ -292,6 +315,12 @@ function fakeContext(
         getCiv7PlayableStatus: async (endpointDefaults) => {
           calls.readiness.push(endpointDefaults);
           return playableStatusResult(options.playable ?? true);
+        },
+        getCiv7PlayNotificationView: async (endpointDefaults) => {
+          calls.views.push(endpointDefaults);
+          return {
+            localPlayerId: options.localPlayerId ?? 0,
+          } as Civ7ControlOrpcPlayNotificationViewResult;
         },
         requestCiv7NarrativeChoice: async (input, endpointDefaults) => {
           calls.request.push({ input, options: endpointDefaults });
@@ -314,7 +343,7 @@ function narrativeChoiceResult(
 ): Civ7ControlOrpcNarrativeChoiceResult {
   const sent = options.sent ?? classification !== "not-sent";
   return {
-    playerId: options.playerId ?? narrativeInput.playerId,
+    playerId: options.playerId ?? 0,
     before: {} as Civ7ControlOrpcNarrativeChoiceResult["before"],
     beforeValidation: {
       valid: options.beforeValid ?? classification !== "not-sent",

--- a/packages/civ7-control-orpc/test/progression-choice-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/progression-choice-procedure.test.ts
@@ -16,13 +16,11 @@ import type {
 } from "../src/dependencies/direct-control";
 
 const technologyInput = {
-  playerId: 0,
   node: 18_001,
   notificationId: { owner: 0, id: 72, type: 20 },
 } as const;
 
 const cultureInput = {
-  playerId: 0,
   node: 27_001,
 } as const;
 
@@ -96,40 +94,27 @@ describe("progression choice control-oRPC procedures", () => {
     expect(serialized).not.toContain("SET_TECH_TREE_NODE");
   });
 
-  test("uses local-player notification evidence rather than caller player id for progression sends", async () => {
-    const before = notificationView("NOTIFICATION_CHOOSE_TECH", {
-      currentResearching: probe(10),
-      targetNode: probe(20),
-    });
-    const after = cleanView({ canEndTurn: true });
+  test("rejects caller player id before progression send dependencies are called", async () => {
     const fake = fakeContext({
-      views: [before, after],
+      views: [cleanView(), cleanView()],
       technologyResult: progressionCloseoutResult("technology"),
     });
 
-    const result = await call(
-      Civ7ControlOrpcRouter.progression.technology.choice.request,
-      {
-        ...technologyInput,
-        playerId: 2,
-      },
-      { context: fake.context },
-    );
+    await expect(
+      call(
+        Civ7ControlOrpcRouter.progression.technology.choice.request,
+        {
+          ...technologyInput,
+          playerId: 2,
+        } as never,
+        { context: fake.context },
+      ),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
-    expect(fake.calls.technology).toEqual([{
-      input: {
-        playerId: 0,
-        node: 18_001,
-        notificationId: { owner: 0, id: 72, type: 20 },
-      },
-      options: {
-        host: "127.0.0.1",
-        port: 4318,
-        timeoutMs: 1_000,
-      },
-    }]);
-    expect(result.playerId).toBe(0);
-    expect(result.status).toBe("sent-confirmed");
+    expect(fake.calls.readiness).toEqual([]);
+    expect(fake.calls.views).toEqual([]);
+    expect(fake.calls.technology).toEqual([]);
+    expect(fake.calls.culture).toEqual([]);
   });
 
   test("keeps sent culture choices no-repeat guarded while the blocker remains live", async () => {

--- a/packages/civ7-control-orpc/test/progression-target-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/progression-target-procedure.test.ts
@@ -15,12 +15,10 @@ import type {
 } from "../src/dependencies/direct-control";
 
 const technologyInput = {
-  playerId: 2,
   node: 18_001,
 } as const;
 
 const cultureInput = {
-  playerId: 2,
   node: 27_001,
 } as const;
 
@@ -167,6 +165,7 @@ describe("progression target control-oRPC procedures", () => {
 
   test("keeps endpoint/session/state/raw command fields out of procedure input", async () => {
     const invalidInputs = [
+      { ...technologyInput, playerId: 2 },
       { ...technologyInput, host: "127.0.0.1" },
       { ...technologyInput, port: 4318 },
       { ...technologyInput, state: { role: "tuner" } },

--- a/packages/civ7-direct-control/src/play/notifications/view.ts
+++ b/packages/civ7-direct-control/src/play/notifications/view.ts
@@ -1421,7 +1421,7 @@ export function playNotificationViewSource(): string {
           ],
           [
             action("read city placement candidates", "game play ready-city --compact --json", "read-only", "ready-city population placement packet", "workable plots and expansion candidates", "before choosing assign-worker or expand-city"),
-            action("assign worker to proven plot", "game play assign-worker --player-id <id> --location <plot-index>", "player-operation", "ASSIGN_WORKER", "{ Location, Amount: 1 }", "when the chosen tile is already workable"),
+            action("assign worker to proven plot", "game play assign-worker --location <plot-index> --send", "player-operation", "ASSIGN_WORKER", "{ Location, Amount: 1 }", "when the chosen tile is already workable"),
             action("validate city expansion", "game play expand-city --city-id '<city-id>' --x <x> --y <y>", "city-command", "EXPAND", "{ X, Y }", "when the chosen tile is an expansion purchase"),
           ],
           ["The notification opens acquire-tile mode; the clicked plot determines whether worker assignment or expansion fires. Re-read candidates before choosing either branch."],

--- a/packages/civ7-direct-control/src/play/notifications/view.ts
+++ b/packages/civ7-direct-control/src/play/notifications/view.ts
@@ -678,8 +678,7 @@ export function playNotificationViewSource(): string {
             chooseValidation,
             targetValidation,
             cli: chooseEnabled
-              ? "game play choose-tech --player-id " + String(localPlayerId)
-                + " --node " + String(numericNodeType)
+              ? "game play choose-tech --node " + String(numericNodeType)
                 + " --send"
               : null,
             validateCli: "game play choose-tech --player-id " + String(localPlayerId)
@@ -788,9 +787,8 @@ export function playNotificationViewSource(): string {
           chooseValidation,
           targetValidation,
           cli: chooseEnabled
-            ? "game play choose-culture --player-id " + String(localPlayerId)
-              + " --node " + String(numericNodeType)
-              + " --send --closeout"
+            ? "game play choose-culture --node " + String(numericNodeType)
+              + " --send"
             : null,
           validateCli: "game play choose-culture --player-id " + String(localPlayerId)
             + " --node " + String(numericNodeType) + " --json",
@@ -1355,7 +1353,7 @@ export function playNotificationViewSource(): string {
           "live-proof",
           [requiredInput("ProgressionTreeNodeType", "live tech chooser/tree node", "Use the runtime node type hash from GameInfo/progression tree data, not the row index or notification id.")],
           [
-            action("choose tech", "game play choose-tech --player-id <id> --node <node> --send", "sequence", "SET_TECH_TREE_NODE then SET_TECH_TREE_TARGET_NODE", "{ ProgressionTreeNodeType: node } then { ProgressionTreeNodeType: NO_NODE }", "when one caller action should start research and finish the chooser workflow"),
+            action("choose tech", "game play choose-tech --node <node> --send", "sequence", "SET_TECH_TREE_NODE then SET_TECH_TREE_TARGET_NODE", "{ ProgressionTreeNodeType: node } then { ProgressionTreeNodeType: NO_NODE }", "when one caller action should start research and finish the chooser workflow"),
             action("validate tech choice", "game play choose-tech --player-id <id> --node <node>", "player-operation", "SET_TECH_TREE_NODE", "{ ProgressionTreeNodeType }", "after reading the candidate node"),
             action("set tech target", "game play set-tech-target --node <node> --send", "player-operation", "SET_TECH_TREE_TARGET_NODE", "{ ProgressionTreeNodeType }", "when the full tree UI targets a node or choose-node alone leaves the blocker unresolved"),
           ],
@@ -1372,12 +1370,12 @@ export function playNotificationViewSource(): string {
           "live-proof",
           [requiredInput("ProgressionTreeNodeType", "live culture chooser/tree node", "Use the runtime node type hash from GameInfo/progression tree data, not the row index or notification id.")],
           [
-            action("choose culture and close chooser", "game play choose-culture --player-id <id> --node <node> --send --closeout", "sequence", "SET_CULTURE_TREE_NODE then SET_CULTURE_TREE_TARGET_NODE", "{ ProgressionTreeNodeType: node } then { ProgressionTreeNodeType: NO_NODE }", "when one caller action should start culture and close the chooser surface"),
+            action("choose culture and close chooser", "game play choose-culture --node <node> --send", "sequence", "SET_CULTURE_TREE_NODE then SET_CULTURE_TREE_TARGET_NODE", "{ ProgressionTreeNodeType: node } then { ProgressionTreeNodeType: NO_NODE }", "when one caller action should start culture and close the chooser surface"),
             action("read culture options", "game play choose-culture --options --json", undefined, undefined, "enabled culture nodes with validation and ready send templates", "before choosing a culture node"),
             action("validate culture choice", "game play choose-culture --player-id <id> --node <node>", "player-operation", "SET_CULTURE_TREE_NODE", "{ ProgressionTreeNodeType }", "after reading the candidate node"),
             action("set culture target", "game play set-culture-target --node <node> --send", "player-operation", "SET_CULTURE_TREE_TARGET_NODE", "{ ProgressionTreeNodeType }", "when the full tree UI targets a node or choose-node alone leaves the blocker unresolved"),
           ],
-          ["Read options from the live culture chooser before sending; some UI paths also set the culture target node, so use --closeout for one caller-level selection."],
+          ["Read options from the live culture chooser before sending; send mode also clears the temporary culture target as one caller-level selection."],
         );
       }
       if (stringIncludes(haystack, "CHOOSE_GOVERNMENT")) {

--- a/packages/civ7-direct-control/src/play/notifications/view.ts
+++ b/packages/civ7-direct-control/src/play/notifications/view.ts
@@ -473,7 +473,7 @@ export function playNotificationViewSource(): string {
         recommendedResponse: "neutral",
         recommendedCli: player2 == null
           ? null
-          : "game play respond-first-meet --player-id " + String(player1) + " --met-player-id " + String(player2) + " --response neutral",
+          : "game play respond-first-meet --met-player-id " + String(player2) + " --response neutral --send",
         note: "Neutral is the conservative default when Influence cost or payoff is not proven.",
       };
     };
@@ -1089,8 +1089,7 @@ export function playNotificationViewSource(): string {
           disabled: !enabled,
           validation,
           cli: enabled && targetJson
-            ? "game play choose-narrative --player-id " + String(localPlayerId)
-              + " --target-type " + String(link.ToNarrativeStoryType)
+            ? "game play choose-narrative --target-type " + String(link.ToNarrativeStoryType)
               + " --target '" + targetJson + "'"
               + " --action " + String(activate)
               + " --send"
@@ -1132,8 +1131,7 @@ export function playNotificationViewSource(): string {
           disabled: !enabled,
           validation,
           cli: enabled
-            ? "game play choose-narrative --player-id " + String(localPlayerId)
-              + " --target-type CLOSE"
+            ? "game play choose-narrative --target-type CLOSE"
               + " --target '" + targetJson + "'"
               + " --action " + String(activate)
               + " --send"
@@ -1177,8 +1175,7 @@ export function playNotificationViewSource(): string {
             disabled: !enabled,
             validation,
             cli: enabled
-              ? "game play choose-narrative --player-id " + String(localPlayerId)
-                + " --target-type " + String(visibleOption.targetType)
+              ? "game play choose-narrative --target-type " + String(visibleOption.targetType)
                 + " --target '" + targetJson + "'"
                 + " --action " + String(activate)
                 + " --send"
@@ -1505,7 +1502,7 @@ export function playNotificationViewSource(): string {
             requiredInput("Type", "chosen first-meet greeting", "Use the first-meet response enum from the live UI, not ordinary Support/Accept/Reject diplomacy response enums."),
           ],
           [
-            action("send neutral first-meet greeting", "game play respond-first-meet --player-id <id> --met-player-id <other-player-id> --response neutral", "player-operation", "RESPOND_DIPLOMATIC_FIRST_MEET", "{ Player1, Player2, Type }", "after validating the greeting options from the live first-meet UI"),
+            action("send neutral first-meet greeting", "game play respond-first-meet --met-player-id <other-player-id> --response neutral --send", "player-operation", "RESPOND_DIPLOMATIC_FIRST_MEET", "{ Player1, Player2, Type }", "after validating the greeting options from the live first-meet UI"),
           ],
           ["First-meet greetings are real player operations, not notification dismissals. Neutral is the conservative default when Influence cost or strategic payoff is not proven."],
         );
@@ -1665,6 +1662,7 @@ export function playNotificationViewSource(): string {
           ],
           [
             action("read narrative options", "game play choose-narrative --options --json", undefined, undefined, "enabled narrative buttons with validation and ready send templates", "before choosing a narrative branch or closeout"),
+            action("send narrative choice", "game play choose-narrative --target-type <target-type> --target '<target>' --action <action> --send", "player-operation", "CHOOSE_NARRATIVE_STORY_DIRECTION", "{ TargetType, Target, Action }", "after choosing one enabled narrative option from the live story UI"),
             action("validate narrative choice", "game play choose-narrative --player-id <id> --target-type <target-type> --target '<target>' --action <action>", "player-operation", "CHOOSE_NARRATIVE_STORY_DIRECTION", "{ TargetType, Target, Action }", "after reading the option key and activation from the story UI"),
           ],
           ["Use the option reader before sending; the notification target can be invalid because official narrative UI derives the target story from Players.Stories. If no pending story id is present, do not synthesize a narrative operation; inspect dismissal postcondition evidence separately."],

--- a/packages/civ7-direct-control/src/play/notifications/view.ts
+++ b/packages/civ7-direct-control/src/play/notifications/view.ts
@@ -1682,13 +1682,13 @@ export function playNotificationViewSource(): string {
           ],
           [
             action("read tradition options", "game play traditions --compact --json", "read-only", "Players.Culture tradition slot/candidate packet", "active and available traditions with action templates", "before choosing a tradition activation or deactivation"),
-            action("change tradition and close review", "game play change-tradition --tradition-type <tradition-type> --action <action> --send --closeout", "sequence", "CHANGE_TRADITION then CONSIDER_ASSIGN_TRADITIONS", "{ TraditionType, Action } then {}", "when a specific tradition slot change should be applied and the blocker closed as one caller workflow"),
             action("change tradition", "game play change-tradition --tradition-type <tradition-type> --action <action> --send", "player-operation", "CHANGE_TRADITION", "{ TraditionType, Action }", "when one selected tradition operation should be sent"),
-            action("validate tradition change", "game play change-tradition --player-id <id> --tradition-type <tradition-type> --action <action>", "player-operation", "CHANGE_TRADITION", "{ TraditionType, Action }", "when dry-run validation is wanted before sending"),
             action("close tradition review", "game play consider-traditions --send", "player-operation", "CONSIDER_ASSIGN_TRADITIONS", "{}", "after valid assignments are already in place"),
-            action("validate tradition review closeout", "game play consider-traditions --player-id <id>", "player-operation", "CONSIDER_ASSIGN_TRADITIONS", "{}", "when dry-run closeout validation is wanted before sending"),
           ],
-          ["Full slots may need deactivate, activate, then closeout; use --closeout on the final selected change when one caller action should clear the review surface."],
+          [
+            "Full slots may need deactivate, re-read, then activate.",
+            "Use --closeout on the selected change only when the same move should also clear the review surface.",
+          ],
         );
       }
       if (stringIncludes(haystack, "ATTRIBUTE")) {
@@ -1701,11 +1701,8 @@ export function playNotificationViewSource(): string {
           "live-proof",
           [requiredInput("ProgressionTreeNodeType", "live attribute tree node", "Use the buyable attribute node id from the runtime tree.")],
           [
-            action("buy attribute and close review", "game play buy-attribute --node <node> --send --closeout", "sequence", "BUY_ATTRIBUTE_TREE_NODE then CONSIDER_ASSIGN_ATTRIBUTE", "{ ProgressionTreeNodeType } then {}", "when a buyable node should be purchased and the blocker closed as one caller workflow"),
             action("buy attribute node", "game play buy-attribute --node <node> --send", "player-operation", "BUY_ATTRIBUTE_TREE_NODE", "{ ProgressionTreeNodeType }", "when one selected attribute purchase should be sent"),
-            action("validate attribute purchase", "game play buy-attribute --player-id <id> --node <node>", "player-operation", "BUY_ATTRIBUTE_TREE_NODE", "{ ProgressionTreeNodeType }", "when dry-run validation is wanted before sending"),
             action("close attribute review", "game play consider-attributes --send", "player-operation", "CONSIDER_ASSIGN_ATTRIBUTE", "{}", "after no attribute purchase is needed or after buying"),
-            action("validate attribute review closeout", "game play consider-attributes --player-id <id>", "player-operation", "CONSIDER_ASSIGN_ATTRIBUTE", "{}", "when dry-run closeout validation is wanted before sending"),
           ],
           ["Use --closeout when one caller action should buy the node and clear the review surface."],
         );

--- a/packages/civ7-direct-control/src/play/notifications/view.ts
+++ b/packages/civ7-direct-control/src/play/notifications/view.ts
@@ -868,8 +868,7 @@ export function playNotificationViewSource(): string {
           disabled: !enabled,
           validation,
           cli: enabled && args
-            ? "game play choose-celebration --player-id " + String(localPlayerId)
-              + " --golden-age-type " + String(args.GoldenAgeType)
+            ? "game play choose-celebration --golden-age-type " + String(args.GoldenAgeType)
               + " --send"
             : null,
           validateCli: args
@@ -961,8 +960,7 @@ export function playNotificationViewSource(): string {
           disabled: !enabled,
           validation,
           cli: enabled && governmentIndex != null && activate != null
-            ? "game play choose-government --player-id " + String(localPlayerId)
-              + " --government-type " + String(governmentIndex)
+            ? "game play choose-government --government-type " + String(governmentIndex)
               + " --action " + String(activate)
               + " --send"
             : null,
@@ -1395,7 +1393,7 @@ export function playNotificationViewSource(): string {
           [requiredInput("GovernmentType", "live government picker option", "Use the government index from choose-government --options, not the visible row position.")],
           [
             action("read government options", "game play choose-government --options --json", undefined, undefined, "enabled starting governments with validation and ready send templates", "before choosing a government"),
-            action("choose government", "game play choose-government --player-id <id> --government-type <government-type> --action <action> --send", "player-operation", "CHANGE_GOVERNMENT", "{ GovernmentType, Action: Activate }", "after reading the live government option"),
+            action("choose government", "game play choose-government --government-type <government-type> --action <action> --send", "player-operation", "CHANGE_GOVERNMENT", "{ GovernmentType, Action: Activate }", "after reading the live government option"),
           ],
           ["Read options from the live government picker before sending; the option surface includes celebration effects for context."],
         );
@@ -1411,7 +1409,7 @@ export function playNotificationViewSource(): string {
           [requiredInput("GoldenAgeType", "live celebration chooser option", "Use the GoldenAgeType hash from choose-celebration --options, not old examples or visible row position.")],
           [
             action("read celebration options", "game play choose-celebration --options --json", undefined, undefined, "enabled celebration choices with validation and ready send templates", "before choosing a celebration"),
-            action("choose celebration", "game play choose-celebration --player-id <id> --golden-age-type <golden-age-type> --send", "player-operation", "CHOOSE_GOLDEN_AGE", "{ GoldenAgeType }", "after reading the live celebration option"),
+            action("choose celebration", "game play choose-celebration --golden-age-type <golden-age-type> --send", "player-operation", "CHOOSE_GOLDEN_AGE", "{ GoldenAgeType }", "after reading the live celebration option"),
           ],
           ["Read options from the live celebration chooser before sending; this blocker is not dismissible and should not use notification dismissal."],
         );

--- a/packages/civ7-direct-control/src/play/notifications/view.ts
+++ b/packages/civ7-direct-control/src/play/notifications/view.ts
@@ -685,8 +685,7 @@ export function playNotificationViewSource(): string {
             validateCli: "game play choose-tech --player-id " + String(localPlayerId)
               + " --node " + String(numericNodeType) + " --json",
             targetCli: targetEnabled
-              ? "game play set-tech-target --player-id " + String(localPlayerId)
-                + " --node " + String(numericNodeType)
+              ? "game play set-tech-target --node " + String(numericNodeType)
                 + " --send"
               : null,
           });
@@ -796,8 +795,7 @@ export function playNotificationViewSource(): string {
           validateCli: "game play choose-culture --player-id " + String(localPlayerId)
             + " --node " + String(numericNodeType) + " --json",
           targetCli: targetEnabled
-            ? "game play set-culture-target --player-id " + String(localPlayerId)
-              + " --node " + String(numericNodeType)
+            ? "game play set-culture-target --node " + String(numericNodeType)
               + " --send"
             : null,
         });
@@ -1359,7 +1357,7 @@ export function playNotificationViewSource(): string {
           [
             action("choose tech", "game play choose-tech --player-id <id> --node <node> --send", "sequence", "SET_TECH_TREE_NODE then SET_TECH_TREE_TARGET_NODE", "{ ProgressionTreeNodeType: node } then { ProgressionTreeNodeType: NO_NODE }", "when one caller action should start research and finish the chooser workflow"),
             action("validate tech choice", "game play choose-tech --player-id <id> --node <node>", "player-operation", "SET_TECH_TREE_NODE", "{ ProgressionTreeNodeType }", "after reading the candidate node"),
-            action("set tech target", "game play set-tech-target --player-id <id> --node <node>", "player-operation", "SET_TECH_TREE_TARGET_NODE", "{ ProgressionTreeNodeType }", "when the full tree UI targets a node or choose-node alone leaves the blocker unresolved"),
+            action("set tech target", "game play set-tech-target --node <node> --send", "player-operation", "SET_TECH_TREE_TARGET_NODE", "{ ProgressionTreeNodeType }", "when the full tree UI targets a node or choose-node alone leaves the blocker unresolved"),
           ],
           ["Read the live tech node id before sending; choose-tech send mode mirrors the chooser by clearing the temporary target internally."],
         );
@@ -1377,7 +1375,7 @@ export function playNotificationViewSource(): string {
             action("choose culture and close chooser", "game play choose-culture --player-id <id> --node <node> --send --closeout", "sequence", "SET_CULTURE_TREE_NODE then SET_CULTURE_TREE_TARGET_NODE", "{ ProgressionTreeNodeType: node } then { ProgressionTreeNodeType: NO_NODE }", "when one caller action should start culture and close the chooser surface"),
             action("read culture options", "game play choose-culture --options --json", undefined, undefined, "enabled culture nodes with validation and ready send templates", "before choosing a culture node"),
             action("validate culture choice", "game play choose-culture --player-id <id> --node <node>", "player-operation", "SET_CULTURE_TREE_NODE", "{ ProgressionTreeNodeType }", "after reading the candidate node"),
-            action("set culture target", "game play set-culture-target --player-id <id> --node <node>", "player-operation", "SET_CULTURE_TREE_TARGET_NODE", "{ ProgressionTreeNodeType }", "when the full tree UI targets a node or choose-node alone leaves the blocker unresolved"),
+            action("set culture target", "game play set-culture-target --node <node> --send", "player-operation", "SET_CULTURE_TREE_TARGET_NODE", "{ ProgressionTreeNodeType }", "when the full tree UI targets a node or choose-node alone leaves the blocker unresolved"),
           ],
           ["Read options from the live culture chooser before sending; some UI paths also set the culture target node, so use --closeout for one caller-level selection."],
         );

--- a/packages/civ7-direct-control/src/play/notifications/view.ts
+++ b/packages/civ7-direct-control/src/play/notifications/view.ts
@@ -1682,9 +1682,11 @@ export function playNotificationViewSource(): string {
           ],
           [
             action("read tradition options", "game play traditions --compact --json", "read-only", "Players.Culture tradition slot/candidate packet", "active and available traditions with action templates", "before choosing a tradition activation or deactivation"),
-            action("change tradition and close review", "game play change-tradition --player-id <id> --tradition-type <tradition-type> --action <action> --send --closeout", "sequence", "CHANGE_TRADITION then CONSIDER_ASSIGN_TRADITIONS", "{ TraditionType, Action } then {}", "when a specific tradition slot change should be applied and the blocker closed as one caller workflow"),
-            action("change tradition", "game play change-tradition --player-id <id> --tradition-type <tradition-type> --action <action>", "player-operation", "CHANGE_TRADITION", "{ TraditionType, Action }", "when only validation or a single tradition operation is wanted"),
-            action("close tradition review", "game play consider-traditions --player-id <id>", "player-operation", "CONSIDER_ASSIGN_TRADITIONS", "{}", "after valid assignments are already in place"),
+            action("change tradition and close review", "game play change-tradition --tradition-type <tradition-type> --action <action> --send --closeout", "sequence", "CHANGE_TRADITION then CONSIDER_ASSIGN_TRADITIONS", "{ TraditionType, Action } then {}", "when a specific tradition slot change should be applied and the blocker closed as one caller workflow"),
+            action("change tradition", "game play change-tradition --tradition-type <tradition-type> --action <action> --send", "player-operation", "CHANGE_TRADITION", "{ TraditionType, Action }", "when one selected tradition operation should be sent"),
+            action("validate tradition change", "game play change-tradition --player-id <id> --tradition-type <tradition-type> --action <action>", "player-operation", "CHANGE_TRADITION", "{ TraditionType, Action }", "when dry-run validation is wanted before sending"),
+            action("close tradition review", "game play consider-traditions --send", "player-operation", "CONSIDER_ASSIGN_TRADITIONS", "{}", "after valid assignments are already in place"),
+            action("validate tradition review closeout", "game play consider-traditions --player-id <id>", "player-operation", "CONSIDER_ASSIGN_TRADITIONS", "{}", "when dry-run closeout validation is wanted before sending"),
           ],
           ["Full slots may need deactivate, activate, then closeout; use --closeout on the final selected change when one caller action should clear the review surface."],
         );
@@ -1699,9 +1701,11 @@ export function playNotificationViewSource(): string {
           "live-proof",
           [requiredInput("ProgressionTreeNodeType", "live attribute tree node", "Use the buyable attribute node id from the runtime tree.")],
           [
-            action("buy attribute and close review", "game play buy-attribute --player-id <id> --node <node> --send --closeout", "sequence", "BUY_ATTRIBUTE_TREE_NODE then CONSIDER_ASSIGN_ATTRIBUTE", "{ ProgressionTreeNodeType } then {}", "when a buyable node should be purchased and the blocker closed as one caller workflow"),
-            action("buy attribute node", "game play buy-attribute --player-id <id> --node <node>", "player-operation", "BUY_ATTRIBUTE_TREE_NODE", "{ ProgressionTreeNodeType }", "when only validation or a single attribute operation is wanted"),
-            action("close attribute review", "game play consider-attributes --player-id <id>", "player-operation", "CONSIDER_ASSIGN_ATTRIBUTE", "{}", "after no attribute purchase is needed or after buying"),
+            action("buy attribute and close review", "game play buy-attribute --node <node> --send --closeout", "sequence", "BUY_ATTRIBUTE_TREE_NODE then CONSIDER_ASSIGN_ATTRIBUTE", "{ ProgressionTreeNodeType } then {}", "when a buyable node should be purchased and the blocker closed as one caller workflow"),
+            action("buy attribute node", "game play buy-attribute --node <node> --send", "player-operation", "BUY_ATTRIBUTE_TREE_NODE", "{ ProgressionTreeNodeType }", "when one selected attribute purchase should be sent"),
+            action("validate attribute purchase", "game play buy-attribute --player-id <id> --node <node>", "player-operation", "BUY_ATTRIBUTE_TREE_NODE", "{ ProgressionTreeNodeType }", "when dry-run validation is wanted before sending"),
+            action("close attribute review", "game play consider-attributes --send", "player-operation", "CONSIDER_ASSIGN_ATTRIBUTE", "{}", "after no attribute purchase is needed or after buying"),
+            action("validate attribute review closeout", "game play consider-attributes --player-id <id>", "player-operation", "CONSIDER_ASSIGN_ATTRIBUTE", "{}", "when dry-run closeout validation is wanted before sending"),
           ],
           ["Use --closeout when one caller action should buy the node and clear the review surface."],
         );

--- a/packages/civ7-direct-control/src/play/ready/city.ts
+++ b/packages/civ7-direct-control/src/play/ready/city.ts
@@ -597,7 +597,7 @@ export function readyCityViewSource(): string {
           yieldDelta: yieldDelta(info?.CurrentYields, info?.NextYields),
           maintenance: info?.Maintenance ?? null,
           placementInfo: safeResult(info),
-          cli: "game play assign-worker --player-id <id> --location " + plotIndex,
+          cli: "game play assign-worker --location " + plotIndex + " --send",
         };
       };
       const expansionValue = expansionResult.ok && expansionResult.value && typeof expansionResult.value === "object"
@@ -627,7 +627,7 @@ export function readyCityViewSource(): string {
         expansionCandidates: probe(() => expansionCandidatesValue),
         expansionResult,
         cliHints: [
-          "game play assign-worker --player-id <id> --location <plot-index>",
+          "game play assign-worker --location <plot-index> --send",
           "game play expand-city --city-id '<city-id>' --x <x> --y <y>",
           "For NEW_POPULATION, compare workablePlots against expansionCandidates; assign-worker and expand-city are different acquire-tile branches.",
         ],

--- a/packages/civ7-direct-control/test/play-notification-view.test.ts
+++ b/packages/civ7-direct-control/test/play-notification-view.test.ts
@@ -76,14 +76,14 @@ describe("getCiv7PlayNotificationView", () => {
       const notificationRead = server.received.find((message) => message.includes("readPlayNotifications")) ?? "";
       expect(notificationRead).toContain("CHOOSE_AUTO_NARRATIVE_STORY_DIRECTION");
       expect(notificationRead).toContain("getFirstPendingDiscoveryLastMetID");
-      expect(notificationRead).toContain("game play change-tradition --tradition-type <tradition-type> --action <action> --send --closeout");
-      expect(notificationRead).toContain("game play buy-attribute --node <node> --send --closeout");
+      expect(notificationRead).toContain("game play change-tradition --tradition-type <tradition-type> --action <action> --send");
+      expect(notificationRead).toContain("game play buy-attribute --node <node> --send");
       expect(notificationRead).toContain("game play consider-traditions --send");
       expect(notificationRead).toContain("game play consider-attributes --send");
-      expect(notificationRead).toContain("game play change-tradition --player-id <id> --tradition-type <tradition-type> --action <action>");
-      expect(notificationRead).toContain("game play buy-attribute --player-id <id> --node <node>");
       expect(notificationRead).not.toContain("game play change-tradition --player-id <id> --tradition-type <tradition-type> --action <action> --send");
       expect(notificationRead).not.toContain("game play buy-attribute --player-id <id> --node <node> --send");
+      expect(notificationRead).not.toContain("validate tradition change");
+      expect(notificationRead).not.toContain("validate attribute purchase");
     } finally {
       await server.close();
     }

--- a/packages/civ7-direct-control/test/play-notification-view.test.ts
+++ b/packages/civ7-direct-control/test/play-notification-view.test.ts
@@ -76,6 +76,14 @@ describe("getCiv7PlayNotificationView", () => {
       const notificationRead = server.received.find((message) => message.includes("readPlayNotifications")) ?? "";
       expect(notificationRead).toContain("CHOOSE_AUTO_NARRATIVE_STORY_DIRECTION");
       expect(notificationRead).toContain("getFirstPendingDiscoveryLastMetID");
+      expect(notificationRead).toContain("game play change-tradition --tradition-type <tradition-type> --action <action> --send --closeout");
+      expect(notificationRead).toContain("game play buy-attribute --node <node> --send --closeout");
+      expect(notificationRead).toContain("game play consider-traditions --send");
+      expect(notificationRead).toContain("game play consider-attributes --send");
+      expect(notificationRead).toContain("game play change-tradition --player-id <id> --tradition-type <tradition-type> --action <action>");
+      expect(notificationRead).toContain("game play buy-attribute --player-id <id> --node <node>");
+      expect(notificationRead).not.toContain("game play change-tradition --player-id <id> --tradition-type <tradition-type> --action <action> --send");
+      expect(notificationRead).not.toContain("game play buy-attribute --player-id <id> --node <node> --send");
     } finally {
       await server.close();
     }

--- a/packages/civ7-direct-control/test/ready-city-procedure.test.ts
+++ b/packages/civ7-direct-control/test/ready-city-procedure.test.ts
@@ -220,7 +220,7 @@ function readyCityViewResult() {
         expansionCandidates: { ok: true, value: [{ index: 1458, x: 23, y: 31 }] },
         expansionResult: { ok: true, value: { Success: true, Plots: [1458] } },
         cliHints: [
-          "game play assign-worker --player-id <id> --location <plot-index>",
+          "game play assign-worker --location <plot-index> --send",
           "game play expand-city --city-id '<city-id>' --x <x> --y <y>",
         ],
       },

--- a/packages/civ7-direct-control/test/ready-city-view.test.ts
+++ b/packages/civ7-direct-control/test/ready-city-view.test.ts
@@ -190,7 +190,7 @@ function readyCityView() {
         expansionCandidates: { ok: true, value: [{ index: 1458, x: 23, y: 31 }] },
         expansionResult: { ok: true, value: { Success: true, Plots: [1458] } },
         cliHints: [
-          "game play assign-worker --player-id <id> --location <plot-index>",
+          "game play assign-worker --location <plot-index> --send",
           "game play expand-city --city-id '<city-id>' --x <x> --y <y>",
         ],
       },

--- a/packages/cli/src/commands/game/play/assign-worker.ts
+++ b/packages/cli/src/commands/game/play/assign-worker.ts
@@ -17,7 +17,7 @@ export default class GamePlayAssignWorker extends Command {
 
   static examples = [
     '<%= config.bin %> game play assign-worker --player-id 0 --location 2543 --json',
-    '<%= config.bin %> game play assign-worker --player-id 0 --location 2543 --send --json',
+    '<%= config.bin %> game play assign-worker --location 2543 --send --json',
   ];
 
   static flags = {
@@ -28,8 +28,7 @@ export default class GamePlayAssignWorker extends Command {
       description: 'Civ7 tuner socket port',
     }),
     'player-id': Flags.integer({
-      description: 'Player id',
-      required: true,
+      description: 'Player id for dry-run validation; send mode reads local player evidence from live notifications',
     }),
     location: Flags.integer({
       description: 'Plot index/location selected for worker placement',
@@ -55,6 +54,27 @@ export default class GamePlayAssignWorker extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(GamePlayAssignWorker);
+    const options = buildDirectControlOptions(flags);
+    if (flags.send && flags.amount !== 1) {
+      throw new Error('game play assign-worker --send supports the source-owned one-worker placement atom; omit --amount or use --amount 1');
+    }
+    if (flags.send) {
+      const result = await createCiv7ControlOrpcServerClient({
+        directControl: liveCiv7ControlOrpcDirectControlFacade,
+        endpointDefaults: options,
+      }).city.population.place.request({
+        mode: 'assign-worker',
+        location: flags.location,
+      });
+
+      emitPlayResult(this.log.bind(this), flags.json, result);
+      return;
+    }
+
+    if (typeof flags['player-id'] !== 'number') {
+      throw new Error('game play assign-worker requires --player-id for dry-run validation');
+    }
+
     const input = {
       operationType: ASSIGN_WORKER,
       playerId: flags['player-id'],
@@ -63,20 +83,7 @@ export default class GamePlayAssignWorker extends Command {
         Amount: flags.amount,
       },
     };
-    const options = buildDirectControlOptions(flags);
-    if (flags.send && flags.amount !== 1) {
-      throw new Error('game play assign-worker --send supports the source-owned one-worker placement atom; omit --amount or use --amount 1');
-    }
-    const result = flags.send
-      ? await createCiv7ControlOrpcServerClient({
-          directControl: liveCiv7ControlOrpcDirectControlFacade,
-          endpointDefaults: options,
-        }).city.population.place.request({
-          mode: 'assign-worker',
-          playerId: input.playerId,
-          location: flags.location,
-        })
-      : await validatePlayOperation('player-operation', input, options);
+    const result = await validatePlayOperation('player-operation', input, options);
 
     emitPlayResult(this.log.bind(this), flags.json, result);
   }

--- a/packages/cli/src/commands/game/play/choose-celebration.ts
+++ b/packages/cli/src/commands/game/play/choose-celebration.ts
@@ -19,7 +19,7 @@ export default class GamePlayChooseCelebration extends Command {
   static examples = [
     '<%= config.bin %> game play choose-celebration --options --json',
     '<%= config.bin %> game play choose-celebration --player-id 0 --golden-age-type -340825966 --json',
-    '<%= config.bin %> game play choose-celebration --player-id 0 --golden-age-type -340825966 --send --json',
+    '<%= config.bin %> game play choose-celebration --golden-age-type -340825966 --send --json',
   ];
 
   static flags = {
@@ -78,11 +78,21 @@ export default class GamePlayChooseCelebration extends Command {
       });
       return;
     }
-    if (typeof flags['player-id'] !== 'number') {
-      throw new Error('game play choose-celebration requires --player-id unless --options is used');
-    }
     if (typeof flags['golden-age-type'] !== 'number') {
       throw new Error('game play choose-celebration requires --golden-age-type unless --options is used');
+    }
+    if (flags.send) {
+      const result = await createCiv7ControlOrpcServerClient({
+        directControl: liveCiv7ControlOrpcDirectControlFacade,
+        endpointDefaults: options,
+      }).government.celebration.choice.request({
+        goldenAgeType: flags['golden-age-type'],
+      });
+      emitPlayResult(this.log.bind(this), flags.json, result);
+      return;
+    }
+    if (typeof flags['player-id'] !== 'number') {
+      throw new Error('game play choose-celebration requires --player-id unless --options is used');
     }
     const input = {
       operationType: CHOOSE_GOLDEN_AGE,
@@ -91,15 +101,7 @@ export default class GamePlayChooseCelebration extends Command {
         GoldenAgeType: flags['golden-age-type'],
       },
     };
-    const result = flags.send
-      ? await createCiv7ControlOrpcServerClient({
-          directControl: liveCiv7ControlOrpcDirectControlFacade,
-          endpointDefaults: options,
-        }).government.celebration.choice.request({
-          playerId: flags['player-id'],
-          goldenAgeType: flags['golden-age-type'],
-        })
-      : await validatePlayOperation('player-operation', input, options);
+    const result = await validatePlayOperation('player-operation', input, options);
 
     emitPlayResult(this.log.bind(this), flags.json, result);
   }
@@ -141,7 +143,7 @@ function compactCelebrationChoiceSurface(details: Record<string, unknown>): {
       name: option.name,
       description: option.description,
       duration: option.duration,
-      chooseCli: option.cli,
+      chooseCli: celebrationChoiceSendCli(option),
       validateCli: option.validateCli,
     }));
   return {
@@ -154,6 +156,11 @@ function compactCelebrationChoiceSurface(details: Record<string, unknown>): {
     enabledOptionCount: enabledOptions.length,
     disabledOptionCount: asArray(details.disabledOptions).length,
   };
+}
+
+function celebrationChoiceSendCli(option: Record<string, unknown>): string | null {
+  if (typeof option.goldenAgeType !== 'number') return null;
+  return `game play choose-celebration --golden-age-type ${option.goldenAgeType} --send`;
 }
 
 function asArray(value: unknown): unknown[] {

--- a/packages/cli/src/commands/game/play/choose-culture.ts
+++ b/packages/cli/src/commands/game/play/choose-culture.ts
@@ -19,7 +19,7 @@ export default class GamePlayChooseCulture extends Command {
   static examples = [
     '<%= config.bin %> game play choose-culture --options --json',
     '<%= config.bin %> game play choose-culture --player-id 0 --node 115 --json',
-    '<%= config.bin %> game play choose-culture --player-id 0 --node 115 --send --json',
+    '<%= config.bin %> game play choose-culture --node 115 --send --json',
   ];
 
   static flags = {
@@ -83,11 +83,21 @@ export default class GamePlayChooseCulture extends Command {
       });
       return;
     }
-    if (typeof flags['player-id'] !== 'number') {
-      throw new Error('game play choose-culture requires --player-id unless --options is used');
-    }
     if (typeof flags.node !== 'number') {
       throw new Error('game play choose-culture requires --node unless --options is used');
+    }
+    if (flags.send) {
+      const result = await createCiv7ControlOrpcServerClient({
+        directControl: liveCiv7ControlOrpcDirectControlFacade,
+        endpointDefaults: options,
+      }).progression.culture.choice.request({
+        node: flags.node,
+      });
+      emitPlayResult(this.log.bind(this), flags.json, result);
+      return;
+    }
+    if (typeof flags['player-id'] !== 'number') {
+      throw new Error('game play choose-culture requires --player-id unless --options or --send is used');
     }
     const input = {
       operationType: SET_CULTURE_TREE_NODE,
@@ -96,15 +106,7 @@ export default class GamePlayChooseCulture extends Command {
         ProgressionTreeNodeType: flags.node,
       },
     };
-    const result = flags.send
-      ? await createCiv7ControlOrpcServerClient({
-          directControl: liveCiv7ControlOrpcDirectControlFacade,
-          endpointDefaults: options,
-        }).progression.culture.choice.request({
-          playerId: flags['player-id'],
-          node: flags.node,
-        })
-      : await validatePlayOperation('player-operation', input, options);
+    const result = await validatePlayOperation('player-operation', input, options);
 
     emitPlayResult(this.log.bind(this), flags.json, result);
   }

--- a/packages/cli/src/commands/game/play/choose-government.ts
+++ b/packages/cli/src/commands/game/play/choose-government.ts
@@ -19,7 +19,7 @@ export default class GamePlayChooseGovernment extends Command {
   static examples = [
     '<%= config.bin %> game play choose-government --options --json',
     '<%= config.bin %> game play choose-government --player-id 0 --government-type 0 --json',
-    '<%= config.bin %> game play choose-government --player-id 0 --government-type 0 --send --json',
+    '<%= config.bin %> game play choose-government --government-type 0 --send --json',
   ];
 
   static flags = {
@@ -80,11 +80,22 @@ export default class GamePlayChooseGovernment extends Command {
       });
       return;
     }
-    if (typeof flags['player-id'] !== 'number') {
-      throw new Error('game play choose-government requires --player-id unless --options is used');
-    }
     if (typeof flags['government-type'] !== 'number') {
       throw new Error('game play choose-government requires --government-type unless --options is used');
+    }
+    if (flags.send) {
+      const result = await createCiv7ControlOrpcServerClient({
+        directControl: liveCiv7ControlOrpcDirectControlFacade,
+        endpointDefaults: options,
+      }).government.choice.request({
+        governmentType: flags['government-type'],
+        ...(flags.action === undefined ? {} : { action: flags.action }),
+      });
+      emitPlayResult(this.log.bind(this), flags.json, result);
+      return;
+    }
+    if (typeof flags['player-id'] !== 'number') {
+      throw new Error('game play choose-government requires --player-id unless --options is used');
     }
     const input = {
       operationType: CHANGE_GOVERNMENT,
@@ -94,16 +105,7 @@ export default class GamePlayChooseGovernment extends Command {
         Action: flags.action ?? -1326475004,
       },
     };
-    const result = flags.send
-      ? await createCiv7ControlOrpcServerClient({
-          directControl: liveCiv7ControlOrpcDirectControlFacade,
-          endpointDefaults: options,
-        }).government.choice.request({
-          playerId: flags['player-id'],
-          governmentType: flags['government-type'],
-          ...(flags.action === undefined ? {} : { action: flags.action }),
-        })
-      : await validatePlayOperation('player-operation', input, options);
+    const result = await validatePlayOperation('player-operation', input, options);
 
     emitPlayResult(this.log.bind(this), flags.json, result);
   }
@@ -146,7 +148,7 @@ function compactGovernmentChoiceSurface(details: Record<string, unknown>): {
       description: option.description,
       action: option.action,
       celebrationOptions: option.celebrationOptions,
-      chooseCli: option.cli,
+      chooseCli: governmentChoiceSendCli(option),
       validateCli: option.validateCli,
     }));
   return {
@@ -159,6 +161,12 @@ function compactGovernmentChoiceSurface(details: Record<string, unknown>): {
     enabledOptionCount: enabledOptions.length,
     disabledOptionCount: asArray(details.disabledOptions).length,
   };
+}
+
+function governmentChoiceSendCli(option: Record<string, unknown>): string | null {
+  if (typeof option.governmentType !== 'number') return null;
+  const action = typeof option.action === 'number' ? ` --action ${option.action}` : '';
+  return `game play choose-government --government-type ${option.governmentType}${action} --send`;
 }
 
 function asArray(value: unknown): unknown[] {

--- a/packages/cli/src/commands/game/play/choose-narrative.ts
+++ b/packages/cli/src/commands/game/play/choose-narrative.ts
@@ -20,7 +20,7 @@ export default class GamePlayChooseNarrative extends Command {
   static examples = [
     '<%= config.bin %> game play choose-narrative --options --json',
     '<%= config.bin %> game play choose-narrative --player-id 0 --target-type TOT_30001B --target \'{"owner":0,"id":45,"type":35}\' --action -1326475004 --json',
-    '<%= config.bin %> game play choose-narrative --player-id 0 --target-type TOT_30001B --target \'{"owner":0,"id":45,"type":35}\' --action -1326475004 --send --json',
+    '<%= config.bin %> game play choose-narrative --target-type TOT_30001B --target \'{"owner":0,"id":45,"type":35}\' --action -1326475004 --send --json',
   ];
 
   static flags = {
@@ -31,7 +31,7 @@ export default class GamePlayChooseNarrative extends Command {
       description: 'Civ7 tuner socket port',
     }),
     'player-id': Flags.integer({
-      description: 'Player id',
+      description: 'Player id used for dry-run validation. Send mode reads the local player from live notification evidence.',
     }),
     'target-type': Flags.string({
       description: 'Narrative TargetType value from the live story direction UI',
@@ -85,9 +85,6 @@ export default class GamePlayChooseNarrative extends Command {
       });
       return;
     }
-    if (typeof flags['player-id'] !== 'number') {
-      throw new Error('game play choose-narrative requires --player-id unless --options is used');
-    }
     if (!flags['target-type']) {
       throw new Error('game play choose-narrative requires --target-type unless --options is used');
     }
@@ -98,6 +95,22 @@ export default class GamePlayChooseNarrative extends Command {
       throw new Error('game play choose-narrative requires --action unless --options is used');
     }
     const target = parseComponentId(flags.target, 'target');
+    if (flags.send) {
+      const result = await createCiv7ControlOrpcServerClient({
+        directControl: liveCiv7ControlOrpcDirectControlFacade,
+        endpointDefaults: options,
+      }).narrative.choice.request({
+        targetType: flags['target-type'],
+        target,
+        action: flags.action,
+      });
+      emitPlayResult(this.log.bind(this), flags.json, result);
+      return;
+    }
+
+    if (typeof flags['player-id'] !== 'number') {
+      throw new Error('game play choose-narrative requires --player-id for dry-run validation');
+    }
     const input = {
       operationType: CHOOSE_NARRATIVE_STORY_DIRECTION,
       playerId: flags['player-id'],
@@ -107,17 +120,7 @@ export default class GamePlayChooseNarrative extends Command {
         Action: flags.action,
       },
     };
-    const result = flags.send
-      ? await createCiv7ControlOrpcServerClient({
-          directControl: liveCiv7ControlOrpcDirectControlFacade,
-          endpointDefaults: options,
-        }).narrative.choice.request({
-          playerId: flags['player-id'],
-          targetType: flags['target-type'],
-          target,
-          action: flags.action,
-        })
-      : await validatePlayOperation('player-operation', input, options);
+    const result = await validatePlayOperation('player-operation', input, options);
 
     emitPlayResult(this.log.bind(this), flags.json, result);
   }

--- a/packages/cli/src/commands/game/play/choose-tech.ts
+++ b/packages/cli/src/commands/game/play/choose-tech.ts
@@ -21,7 +21,7 @@ export default class GamePlayChooseTech extends Command {
   static examples = [
     '<%= config.bin %> game play choose-tech --options --json',
     '<%= config.bin %> game play choose-tech --player-id 0 --node -1255676052 --json',
-    '<%= config.bin %> game play choose-tech --player-id 0 --node -1255676052 --send --json',
+    '<%= config.bin %> game play choose-tech --node -1255676052 --send --json',
   ];
 
   static flags = {
@@ -86,11 +86,21 @@ export default class GamePlayChooseTech extends Command {
       });
       return;
     }
-    if (typeof flags['player-id'] !== 'number') {
-      throw new Error('game play choose-tech requires --player-id unless --options is used');
-    }
     if (typeof flags.node !== 'number') {
       throw new Error('game play choose-tech requires --node unless --options is used');
+    }
+    if (flags.send) {
+      const result = await createCiv7ControlOrpcServerClient({
+        directControl: liveCiv7ControlOrpcDirectControlFacade,
+        endpointDefaults: options,
+      }).progression.technology.choice.request({
+        node: flags.node,
+      });
+      emitPlayResult(this.log.bind(this), flags.json, result);
+      return;
+    }
+    if (typeof flags['player-id'] !== 'number') {
+      throw new Error('game play choose-tech requires --player-id unless --options or --send is used');
     }
     const input = {
       operationType: SET_TECH_TREE_NODE,
@@ -99,15 +109,7 @@ export default class GamePlayChooseTech extends Command {
         ProgressionTreeNodeType: flags.node,
       },
     };
-    const result = flags.send
-      ? await createCiv7ControlOrpcServerClient({
-          directControl: liveCiv7ControlOrpcDirectControlFacade,
-          endpointDefaults: options,
-        }).progression.technology.choice.request({
-          playerId: flags['player-id'],
-          node: flags.node,
-        })
-      : await validatePlayOperation('player-operation', input, options);
+    const result = await validatePlayOperation('player-operation', input, options);
 
     emitPlayResult(this.log.bind(this), flags.json, result);
   }

--- a/packages/cli/src/commands/game/play/respond-diplomacy.ts
+++ b/packages/cli/src/commands/game/play/respond-diplomacy.ts
@@ -18,7 +18,7 @@ export default class GamePlayRespondDiplomacy extends Command {
 
   static examples = [
     '<%= config.bin %> game play respond-diplomacy --player-id 0 --action-id 56 --response-type -1907089594 --json',
-    '<%= config.bin %> game play respond-diplomacy --player-id 0 --action-id 56 --response-type -1907089594 --send --json',
+    '<%= config.bin %> game play respond-diplomacy --action-id 56 --response-type -1907089594 --send --json',
     '<%= config.bin %> game play respond-diplomacy --action-id 56 --response-type 926305338 --notification-id \'{"owner":0,"id":19,"type":20}\' --send --json',
   ];
 
@@ -66,7 +66,6 @@ export default class GamePlayRespondDiplomacy extends Command {
         directControl: liveCiv7ControlOrpcDirectControlFacade,
         endpointDefaults: options,
       }).diplomacy.response.request({
-        playerId: flags['player-id'],
         actionId: flags['action-id'],
         responseType: flags['response-type'],
         ...(flags['notification-id'] ? { notificationId: parseComponentId(flags['notification-id'], 'notification-id') } : {}),

--- a/packages/cli/src/commands/game/play/respond-first-meet.ts
+++ b/packages/cli/src/commands/game/play/respond-first-meet.ts
@@ -28,7 +28,7 @@ export default class GamePlayRespondFirstMeet extends Command {
 
   static examples = [
     '<%= config.bin %> game play respond-first-meet --player-id 0 --met-player-id 2 --response neutral --json',
-    '<%= config.bin %> game play respond-first-meet --player-id 0 --met-player-id 2 --response neutral --send --json',
+    '<%= config.bin %> game play respond-first-meet --met-player-id 2 --response neutral --send --json',
   ];
 
   static flags = {
@@ -39,8 +39,7 @@ export default class GamePlayRespondFirstMeet extends Command {
       description: 'Civ7 tuner socket port',
     }),
     'player-id': Flags.integer({
-      description: 'Local player id',
-      required: true,
+      description: 'Local player id used for dry-run validation. Send mode reads the local player from live notification evidence.',
     }),
     'met-player-id': Flags.integer({
       description: 'Other player id from the live first-meet notification or diplomacy panel',
@@ -78,12 +77,14 @@ export default class GamePlayRespondFirstMeet extends Command {
         directControl: liveCiv7ControlOrpcDirectControlFacade,
         endpointDefaults: options,
       }).diplomacy.firstMeet.response.request({
-        playerId: flags['player-id'],
         metPlayerId: flags['met-player-id'],
         responseType,
       });
       emitPlayResult(this.log.bind(this), flags.json, result);
       return;
+    }
+    if (typeof flags['player-id'] !== 'number') {
+      throw new Error('game play respond-first-meet requires --player-id for dry-run validation');
     }
 
     const input = {

--- a/packages/cli/src/commands/game/play/set-culture-target.ts
+++ b/packages/cli/src/commands/game/play/set-culture-target.ts
@@ -17,7 +17,7 @@ export default class GamePlaySetCultureTarget extends Command {
 
   static examples = [
     '<%= config.bin %> game play set-culture-target --player-id 0 --node -1677668973 --json',
-    '<%= config.bin %> game play set-culture-target --player-id 0 --node -1677668973 --send --json',
+    '<%= config.bin %> game play set-culture-target --node -1677668973 --send --json',
   ];
 
   static flags = {
@@ -28,8 +28,7 @@ export default class GamePlaySetCultureTarget extends Command {
       description: 'Civ7 tuner socket port',
     }),
     'player-id': Flags.integer({
-      description: 'Player id',
-      required: true,
+      description: 'Player id for read-only validation; send mode uses live local-player evidence',
     }),
     node: Flags.integer({
       description: 'ProgressionTreeNodeType id from live GameInfo/progression tree reads',
@@ -51,6 +50,22 @@ export default class GamePlaySetCultureTarget extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(GamePlaySetCultureTarget);
+    const options = buildDirectControlOptions(flags);
+    if (flags.send) {
+      const result = await createCiv7ControlOrpcServerClient({
+        directControl: liveCiv7ControlOrpcDirectControlFacade,
+        endpointDefaults: options,
+      }).progression.culture.target.request({
+        node: flags.node,
+      });
+
+      emitPlayResult(this.log.bind(this), flags.json, result);
+      return;
+    }
+
+    if (typeof flags['player-id'] !== 'number') {
+      throw new Error('game play set-culture-target requires --player-id unless --send is used');
+    }
     const input = {
       operationType: SET_CULTURE_TREE_TARGET_NODE,
       playerId: flags['player-id'],
@@ -58,16 +73,7 @@ export default class GamePlaySetCultureTarget extends Command {
         ProgressionTreeNodeType: flags.node,
       },
     };
-    const options = buildDirectControlOptions(flags);
-    const result = flags.send
-      ? await createCiv7ControlOrpcServerClient({
-          directControl: liveCiv7ControlOrpcDirectControlFacade,
-          endpointDefaults: options,
-        }).progression.culture.target.request({
-          playerId: flags['player-id'],
-          node: flags.node,
-        })
-      : await validatePlayOperation('player-operation', input, options);
+    const result = await validatePlayOperation('player-operation', input, options);
 
     emitPlayResult(this.log.bind(this), flags.json, result);
   }

--- a/packages/cli/src/commands/game/play/set-tech-target.ts
+++ b/packages/cli/src/commands/game/play/set-tech-target.ts
@@ -17,7 +17,7 @@ export default class GamePlaySetTechTarget extends Command {
 
   static examples = [
     '<%= config.bin %> game play set-tech-target --player-id 0 --node -1255676052 --json',
-    '<%= config.bin %> game play set-tech-target --player-id 0 --node -1255676052 --send --json',
+    '<%= config.bin %> game play set-tech-target --node -1255676052 --send --json',
   ];
 
   static flags = {
@@ -28,8 +28,7 @@ export default class GamePlaySetTechTarget extends Command {
       description: 'Civ7 tuner socket port',
     }),
     'player-id': Flags.integer({
-      description: 'Player id',
-      required: true,
+      description: 'Player id for read-only validation; send mode uses live local-player evidence',
     }),
     node: Flags.integer({
       description: 'ProgressionTreeNodeType id from live GameInfo/progression tree reads',
@@ -51,6 +50,22 @@ export default class GamePlaySetTechTarget extends Command {
 
   public async run(): Promise<void> {
     const { flags } = await this.parse(GamePlaySetTechTarget);
+    const options = buildDirectControlOptions(flags);
+    if (flags.send) {
+      const result = await createCiv7ControlOrpcServerClient({
+        directControl: liveCiv7ControlOrpcDirectControlFacade,
+        endpointDefaults: options,
+      }).progression.technology.target.request({
+        node: flags.node,
+      });
+
+      emitPlayResult(this.log.bind(this), flags.json, result);
+      return;
+    }
+
+    if (typeof flags['player-id'] !== 'number') {
+      throw new Error('game play set-tech-target requires --player-id unless --send is used');
+    }
     const input = {
       operationType: SET_TECH_TREE_TARGET_NODE,
       playerId: flags['player-id'],
@@ -58,16 +73,7 @@ export default class GamePlaySetTechTarget extends Command {
         ProgressionTreeNodeType: flags.node,
       },
     };
-    const options = buildDirectControlOptions(flags);
-    const result = flags.send
-      ? await createCiv7ControlOrpcServerClient({
-          directControl: liveCiv7ControlOrpcDirectControlFacade,
-          endpointDefaults: options,
-        }).progression.technology.target.request({
-          playerId: flags['player-id'],
-          node: flags.node,
-        })
-      : await validatePlayOperation('player-operation', input, options);
+    const result = await validatePlayOperation('player-operation', input, options);
 
     emitPlayResult(this.log.bind(this), flags.json, result);
   }

--- a/packages/cli/test/commands/game.play.celebration-government.test.ts
+++ b/packages/cli/test/commands/game.play.celebration-government.test.ts
@@ -42,8 +42,6 @@ describe('game play celebration and government commands', () => {
         '127.0.0.1',
         '--port',
         String(port),
-        '--player-id',
-        '2',
         '--golden-age-type',
         '-340825966',
         '--send',
@@ -129,7 +127,7 @@ describe('game play celebration and government commands', () => {
       const culture = payload.result.surfaces[0].enabledOptions.find((option) => option.goldenAgeType === -340825966);
       expect(culture?.name).toBe('Cultural Celebration');
       expect(culture?.duration).toBe(10);
-      expect(culture?.chooseCli).toContain('game play choose-celebration --player-id 0 --golden-age-type -340825966 --send');
+      expect(culture?.chooseCli).toContain('game play choose-celebration --golden-age-type -340825966 --send');
       expect(payload.result.omitted.map((item) => item.path)).toContain('details[].options');
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
@@ -178,8 +176,6 @@ describe('game play celebration and government commands', () => {
         '127.0.0.1',
         '--port',
         String(port),
-        '--player-id',
-        '2',
         '--government-type',
         '0',
         '--send',
@@ -265,7 +261,7 @@ describe('game play celebration and government commands', () => {
       expect(payload.result.surfaces[0].disabledOptions).toBeUndefined();
       const republic = payload.result.surfaces[0].enabledOptions.find((option) => option.governmentType === 0);
       expect(republic?.name).toBe('Classical Republic');
-      expect(republic?.chooseCli).toContain('game play choose-government --player-id 0 --government-type 0 --action -1326475004 --send');
+      expect(republic?.chooseCli).toContain('game play choose-government --government-type 0 --action -1326475004 --send');
       expect(republic?.celebrationOptions[0].name).toBe('Cultural Celebration');
       expect(payload.result.omitted.map((item) => item.path)).toContain('details[].options');
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
@@ -458,7 +454,7 @@ function celebrationChoiceView() {
     enabled: true,
     disabled: false,
     validation: { ok: true, value: { Success: true } },
-    cli: `game play choose-celebration --player-id 0 --golden-age-type ${row.goldenAgeType} --send`,
+    cli: `game play choose-celebration --golden-age-type ${row.goldenAgeType} --send`,
     validateCli: `game play choose-celebration --player-id 0 --golden-age-type ${row.goldenAgeType} --json`,
   }));
   const details = {
@@ -511,7 +507,7 @@ function governmentChoiceView() {
     enabled: true,
     disabled: false,
     validation: { ok: true, value: { Success: true } },
-    cli: `game play choose-government --player-id 0 --government-type ${row.governmentType} --action ${action} --send`,
+    cli: `game play choose-government --government-type ${row.governmentType} --action ${action} --send`,
     validateCli: `game play choose-government --player-id 0 --government-type ${row.governmentType} --action ${action} --json`,
   }));
   const details = {

--- a/packages/cli/test/commands/game.play.culture.test.ts
+++ b/packages/cli/test/commands/game.play.culture.test.ts
@@ -97,8 +97,6 @@ describe('game play culture commands', () => {
         '127.0.0.1',
         '--port',
         String(port),
-        '--player-id',
-        '2',
         '--node',
         '-1677668973',
         '--send',
@@ -657,7 +655,7 @@ function playNotificationView(mode: 'culture-choice' | 'ready-unit', cultureStat
       : null,
     validateCli: `game play choose-culture --player-id 0 --node ${row.nodeType} --json`,
     targetCli: row.enabled
-      ? `game play set-culture-target --player-id 0 --node ${row.nodeType} --send`
+      ? `game play set-culture-target --node ${row.nodeType} --send`
       : null,
   }));
   const details = {

--- a/packages/cli/test/commands/game.play.culture.test.ts
+++ b/packages/cli/test/commands/game.play.culture.test.ts
@@ -70,7 +70,8 @@ describe('game play culture commands', () => {
       expect(payload.result.surfaces[0].disabledOptions).toBeUndefined();
       const ekklesia = payload.result.surfaces[0].enabledOptions.find((option) => option.nodeType === -869902342);
       expect(ekklesia?.name).toBe('Ekklesia');
-      expect(ekklesia?.chooseCli).toContain('game play choose-culture --player-id 0 --node -869902342 --send');
+      expect(ekklesia?.chooseCli).toContain('game play choose-culture --node -869902342 --send');
+      expect(ekklesia?.chooseCli).not.toContain('--player-id');
       expect(ekklesia?.chooseCli).not.toContain('--closeout');
       expect(ekklesia?.turns).toBe(4);
       expect(ekklesia?.cost).toBe(105);
@@ -154,12 +155,9 @@ describe('game play culture commands', () => {
           '127.0.0.1',
           '--port',
           String(port),
-          '--player-id',
-          '0',
           '--node',
           '-1677668973',
           '--send',
-          '--closeout',
           '--json',
         ]);
       } finally {
@@ -223,7 +221,6 @@ describe('game play culture commands', () => {
         '--node',
         '-1404789184',
         '--send',
-        '--closeout',
         '--timeout-ms',
         '1000',
         '--json',
@@ -279,7 +276,6 @@ describe('game play culture commands', () => {
         '--node',
         '-1404789184',
         '--send',
-        '--closeout',
         '--timeout-ms',
         '1000',
         '--json',
@@ -651,7 +647,7 @@ function playNotificationView(mode: 'culture-choice' | 'ready-unit', cultureStat
     chooseValidation: { ok: true, value: { Success: row.enabled } },
     targetValidation: { ok: true, value: { Success: row.enabled } },
     cli: row.enabled
-      ? `game play choose-culture --player-id 0 --node ${row.nodeType} --send --closeout`
+      ? `game play choose-culture --node ${row.nodeType} --send`
       : null,
     validateCli: `game play choose-culture --player-id 0 --node ${row.nodeType} --json`,
     targetCli: row.enabled

--- a/packages/cli/test/commands/game.play.diplomacy-response.test.ts
+++ b/packages/cli/test/commands/game.play.diplomacy-response.test.ts
@@ -69,8 +69,6 @@ describe('game play diplomacy response commands', () => {
         '127.0.0.1',
         '--port',
         String(port),
-        '--player-id',
-        '2',
         '--action-id',
         '8',
         '--response-type',

--- a/packages/cli/test/commands/game.play.first-meet.test.ts
+++ b/packages/cli/test/commands/game.play.first-meet.test.ts
@@ -44,8 +44,6 @@ describe('game play first-meet diplomacy command', () => {
         '127.0.0.1',
         '--port',
         String(port),
-        '--player-id',
-        '0',
         '--met-player-id',
         '2',
         '--response',
@@ -98,8 +96,6 @@ describe('game play first-meet diplomacy command', () => {
         '127.0.0.1',
         '--port',
         String(port),
-        '--player-id',
-        '0',
         '--met-player-id',
         '2',
         '--response',
@@ -336,7 +332,7 @@ function firstMeetNotificationView(mode: 'first-meet' | 'ready-unit') {
     commonActions: [
       {
         label: 'send neutral first-meet greeting',
-        cli: 'game play respond-first-meet --player-id 0 --met-player-id 2 --response neutral',
+        cli: 'game play respond-first-meet --met-player-id 2 --response neutral --send',
         operationFamily: 'player-operation',
         operationType: 'RESPOND_DIPLOMATIC_FIRST_MEET',
         argsShape: '{ Player1, Player2, Type }',
@@ -357,7 +353,7 @@ function firstMeetNotificationView(mode: 'first-meet' | 'ready-unit') {
         },
       ],
       recommendedResponse: 'neutral',
-      recommendedCli: 'game play respond-first-meet --player-id 0 --met-player-id 2 --response neutral',
+      recommendedCli: 'game play respond-first-meet --met-player-id 2 --response neutral --send',
     },
   };
   const notification = {

--- a/packages/cli/test/commands/game.play.narrative.test.ts
+++ b/packages/cli/test/commands/game.play.narrative.test.ts
@@ -46,8 +46,6 @@ describe('game play narrative commands', () => {
         '127.0.0.1',
         '--port',
         String(port),
-        '--player-id',
-        '2',
         '--target-type',
         'DISCOVERY_14001B',
         '--target',
@@ -106,8 +104,6 @@ describe('game play narrative commands', () => {
         '127.0.0.1',
         '--port',
         String(port),
-        '--player-id',
-        '0',
         '--target-type',
         'DISCOVERY_14001C',
         '--target',
@@ -163,8 +159,6 @@ describe('game play narrative commands', () => {
         '127.0.0.1',
         '--port',
         String(port),
-        '--player-id',
-        '0',
         '--target-type',
         'DISCOVERY_14001C',
         '--target',
@@ -236,7 +230,7 @@ describe('game play narrative commands', () => {
       expect(payload.result.surfaces[0].disabledOptions).toBeUndefined();
       expect(payload.result.surfaces[0].targetStoryId).toEqual({ owner: 0, id: 45, type: 35 });
       expect(payload.result.surfaces[0].enabledOptions[0].targetType).toBe('CLOSE');
-      expect(payload.result.surfaces[0].enabledOptions[0].chooseCli).toContain('game play choose-narrative --player-id 0 --target-type CLOSE');
+      expect(payload.result.surfaces[0].enabledOptions[0].chooseCli).toContain('game play choose-narrative --target-type CLOSE');
       expect(payload.result.surfaces[0].enabledOptions[0].validateCli).toContain('--action -1326475004 --json');
       expect(payload.result.omitted.map((item) => item.path)).toContain('details[].storyLinks');
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
@@ -589,7 +583,7 @@ function playNotificationView(mode: PlayNotificationMode = 'narrative-choice') {
       enabled: true,
       disabled: false,
       validation: { ok: true, value: { Success: true } },
-      cli: "game play choose-narrative --player-id 0 --target-type CLOSE --target '{\"owner\":0,\"id\":45,\"type\":35}' --action -1326475004 --send",
+      cli: "game play choose-narrative --target-type CLOSE --target '{\"owner\":0,\"id\":45,\"type\":35}' --action -1326475004 --send",
       validateCli: "game play choose-narrative --player-id 0 --target-type CLOSE --target '{\"owner\":0,\"id\":45,\"type\":35}' --action -1326475004 --json",
     },
   ];
@@ -612,7 +606,7 @@ function playNotificationView(mode: PlayNotificationMode = 'narrative-choice') {
       enabled: true,
       disabled: false,
       validation: { ok: true, value: { Success: true } },
-      cli: "game play choose-narrative --player-id 0 --target-type DISCOVERY_14001B --target '{\"owner\":0,\"id\":25,\"type\":35}' --action -1326475004 --send",
+      cli: "game play choose-narrative --target-type DISCOVERY_14001B --target '{\"owner\":0,\"id\":25,\"type\":35}' --action -1326475004 --send",
       validateCli: "game play choose-narrative --player-id 0 --target-type DISCOVERY_14001B --target '{\"owner\":0,\"id\":25,\"type\":35}' --action -1326475004 --json",
     },
     {
@@ -630,7 +624,7 @@ function playNotificationView(mode: PlayNotificationMode = 'narrative-choice') {
       enabled: true,
       disabled: false,
       validation: { ok: true, value: { Success: true } },
-      cli: "game play choose-narrative --player-id 0 --target-type DISCOVERY_14001C --target '{\"owner\":0,\"id\":25,\"type\":35}' --action -1326475004 --send",
+      cli: "game play choose-narrative --target-type DISCOVERY_14001C --target '{\"owner\":0,\"id\":25,\"type\":35}' --action -1326475004 --send",
       validateCli: "game play choose-narrative --player-id 0 --target-type DISCOVERY_14001C --target '{\"owner\":0,\"id\":25,\"type\":35}' --action -1326475004 --json",
     },
   ];

--- a/packages/cli/test/commands/game.play.population-placement.test.ts
+++ b/packages/cli/test/commands/game.play.population-placement.test.ts
@@ -44,8 +44,6 @@ describe('game play population placement commands', () => {
         '127.0.0.1',
         '--port',
         String(port),
-        '--player-id',
-        '0',
         '--location',
         '2543',
         '--send',
@@ -234,6 +232,9 @@ async function startPopulationPlacementTunerServer(): Promise<FakeTunerServer> {
       if (message.includes('evalOk') && message.includes('GameplayMap.getGridWidth')) {
         return [JSON.stringify(tunerHealthSnapshot())];
       }
+      if (message.includes('GameContext.localPlayerID') && message.includes('decisionQueue')) {
+        return [JSON.stringify(playNotificationView())];
+      }
       if (message.includes('return JSON.stringify(validateOperation')) {
         return [JSON.stringify(operationValidation(message))];
       }
@@ -247,6 +248,40 @@ async function startPopulationPlacementTunerServer(): Promise<FakeTunerServer> {
       return undefined;
     },
   });
+}
+
+function playNotificationView() {
+  return {
+    host: '127.0.0.1',
+    port: 0,
+    state: { id: '65535', name: 'App UI' },
+    localPlayerId: 0,
+    turn: { ok: true, value: 1 },
+    turnDate: { ok: true, value: '4000 BCE' },
+    loadingStateName: null,
+    blocker: { ok: true, value: 0 },
+    blockingNotificationId: { ok: true, value: null },
+    selectedUnitId: { ok: true, value: null },
+    selectedCityId: { ok: true, value: null },
+    firstReadyUnitId: { ok: true, value: null },
+    nextDecision: null,
+    hud: {
+      decisionQueue: [],
+      currentBlocker: null,
+      advisories: [],
+      units: [],
+      cities: [],
+      localPlayer: { ok: true, value: 0 },
+      selectedUnit: { ok: true, value: null },
+      selectedCity: { ok: true, value: null },
+      firstReadyUnit: { ok: true, value: null },
+    },
+    limits: {
+      maxNotifications: 25,
+      truncated: false,
+    },
+    notes: [],
+  };
 }
 
 function appUiSnapshot() {

--- a/packages/cli/test/commands/game.play.technology.test.ts
+++ b/packages/cli/test/commands/game.play.technology.test.ts
@@ -121,8 +121,6 @@ describe('game play technology commands', () => {
         '127.0.0.1',
         '--port',
         String(port),
-        '--player-id',
-        '2',
         '--node',
         '-1255676052',
         '--send',
@@ -672,7 +670,7 @@ function playNotificationView(mode: 'tech-choice' | 'ready-unit', technologyStat
       : null,
     validateCli: `game play choose-tech --player-id 0 --node ${row.nodeType} --json`,
     targetCli: row.enabled
-      ? `game play set-tech-target --player-id 0 --node ${row.nodeType} --send`
+      ? `game play set-tech-target --node ${row.nodeType} --send`
       : null,
   }));
   const details = {

--- a/packages/cli/test/commands/game.play.technology.test.ts
+++ b/packages/cli/test/commands/game.play.technology.test.ts
@@ -70,7 +70,8 @@ describe('game play technology commands', () => {
       expect(payload.result.surfaces[0].disabledOptions).toBeUndefined();
       const masonry = payload.result.surfaces[0].enabledOptions.find((option) => option.nodeType === -1255676052);
       expect(masonry?.name).toBe('Masonry');
-      expect(masonry?.chooseCli).toContain('game play choose-tech --player-id 0 --node -1255676052 --send');
+      expect(masonry?.chooseCli).toContain('game play choose-tech --node -1255676052 --send');
+      expect(masonry?.chooseCli).not.toContain('--player-id');
       expect(masonry?.chooseCli).not.toContain('--closeout');
       expect(masonry?.turns).toBe(2);
       expect(masonry?.cost).toBe(137);
@@ -177,8 +178,6 @@ describe('game play technology commands', () => {
           '127.0.0.1',
           '--port',
           String(port),
-          '--player-id',
-          '0',
           '--node',
           '-1255676052',
           '--send',
@@ -666,7 +665,7 @@ function playNotificationView(mode: 'tech-choice' | 'ready-unit', technologyStat
     chooseValidation: { ok: true, value: { Success: row.enabled } },
     targetValidation: { ok: true, value: { Success: row.enabled } },
     cli: row.enabled
-      ? `game play choose-tech --player-id 0 --node ${row.nodeType} --send`
+      ? `game play choose-tech --node ${row.nodeType} --send`
       : null,
     validateCli: `game play choose-tech --player-id 0 --node ${row.nodeType} --json`,
     targetCli: row.enabled

--- a/packages/cli/test/commands/game/play/notification/hud.test.ts
+++ b/packages/cli/test/commands/game/play/notification/hud.test.ts
@@ -84,7 +84,7 @@ describe('game play notifications command', () => {
       expect(details?.enabledOptions.map((option) => option.name).sort()).toEqual(['Cultural Celebration', 'Wonder Production Celebration']);
       const culture = details?.enabledOptions.find((option) => option.goldenAgeType === -340825966);
       expect(culture?.validation.value?.Success).toBe(true);
-      expect(culture?.cli).toContain('game play choose-celebration --player-id 0 --golden-age-type -340825966 --send');
+      expect(culture?.cli).toContain('game play choose-celebration --golden-age-type -340825966 --send');
       expect(details?.disabledOptions).toEqual([]);
       expect(payload.view.hud.nextDecision.details).toBeDefined();
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
@@ -103,7 +103,7 @@ describe('game play notifications command', () => {
       expect(details?.enabledOptions.map((option) => option.name)).toEqual(['Classical Republic', 'Despotism', 'Oligarchy']);
       const republic = details?.enabledOptions.find((option) => option.governmentType === 0);
       expect(republic?.validation.value?.Success).toBe(true);
-      expect(republic?.cli).toContain('game play choose-government --player-id 0 --government-type 0 --action -1326475004 --send');
+      expect(republic?.cli).toContain('game play choose-government --government-type 0 --action -1326475004 --send');
       expect(details?.disabledOptions).toEqual([]);
       expect(payload.view.hud.nextDecision.details).toBeDefined();
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
@@ -498,13 +498,13 @@ function celebrationChoiceHudView() {
       {
         goldenAgeType: -340825966,
         name: 'Cultural Celebration',
-        cli: "game play choose-celebration --player-id 0 --golden-age-type -340825966 --send",
+        cli: "game play choose-celebration --golden-age-type -340825966 --send",
         validation: { ok: true as const, value: { Success: true } },
       },
       {
         goldenAgeType: 1923496232,
         name: 'Wonder Production Celebration',
-        cli: "game play choose-celebration --player-id 0 --golden-age-type 1923496232 --send",
+        cli: "game play choose-celebration --golden-age-type 1923496232 --send",
         validation: { ok: true as const, value: { Success: true } },
       },
     ],
@@ -543,19 +543,19 @@ function governmentChoiceHudView() {
       {
         governmentType: 0,
         name: 'Classical Republic',
-        cli: "game play choose-government --player-id 0 --government-type 0 --action -1326475004 --send",
+        cli: "game play choose-government --government-type 0 --action -1326475004 --send",
         validation: { ok: true as const, value: { Success: true } },
       },
       {
         governmentType: 1,
         name: 'Despotism',
-        cli: "game play choose-government --player-id 0 --government-type 1 --action -1326475004 --send",
+        cli: "game play choose-government --government-type 1 --action -1326475004 --send",
         validation: { ok: true as const, value: { Success: true } },
       },
       {
         governmentType: 2,
         name: 'Oligarchy',
-        cli: "game play choose-government --player-id 0 --government-type 2 --action -1326475004 --send",
+        cli: "game play choose-government --government-type 2 --action -1326475004 --send",
         validation: { ok: true as const, value: { Success: true } },
       },
     ],

--- a/packages/cli/test/commands/game/play/notification/hud.test.ts
+++ b/packages/cli/test/commands/game/play/notification/hud.test.ts
@@ -43,7 +43,8 @@ describe('game play notifications command', () => {
       expect(details?.enabledOptions.map((option) => option.name).sort()).toEqual(['Masonry', 'Sailing']);
       const masonry = details?.enabledOptions.find((option) => option.nodeType === -1255676052);
       expect(masonry?.chooseValidation.value?.Success).toBe(true);
-      expect(masonry?.cli).toContain('game play choose-tech --player-id 0 --node -1255676052 --send');
+      expect(masonry?.cli).toContain('game play choose-tech --node -1255676052 --send');
+      expect(masonry?.cli).not.toContain('--player-id');
       expect(masonry?.cli).not.toContain('--closeout');
       expect(details?.disabledOptions[0].name).toBe('Agriculture');
       expect(details?.disabledOptions[0].cli).toBeNull();
@@ -64,7 +65,9 @@ describe('game play notifications command', () => {
       expect(details?.enabledOptions.map((option) => option.name).sort()).toEqual(['Discipline', 'Ekklesia']);
       const ekklesia = details?.enabledOptions.find((option) => option.nodeType === -869902342);
       expect(ekklesia?.chooseValidation.value?.Success).toBe(true);
-      expect(ekklesia?.cli).toContain('game play choose-culture --player-id 0 --node -869902342 --send --closeout');
+      expect(ekklesia?.cli).toContain('game play choose-culture --node -869902342 --send');
+      expect(ekklesia?.cli).not.toContain('--closeout');
+      expect(ekklesia?.cli).not.toContain('--player-id');
       expect(details?.disabledOptions[0].name).toBe('Mysticism');
       expect(details?.disabledOptions[0].cli).toBeNull();
       expect(payload.view.hud.nextDecision.details).toBeDefined();
@@ -405,13 +408,13 @@ function techChoiceHudView() {
       {
         nodeType: -1255676052,
         name: 'Masonry',
-        cli: "game play choose-tech --player-id 0 --node -1255676052 --send",
+        cli: "game play choose-tech --node -1255676052 --send",
         chooseValidation: { ok: true as const, value: { Success: true } },
       },
       {
         nodeType: -1558948215,
         name: 'Sailing',
-        cli: "game play choose-tech --player-id 0 --node -1558948215 --send",
+        cli: "game play choose-tech --node -1558948215 --send",
         chooseValidation: { ok: true as const, value: { Success: true } },
       },
     ],
@@ -451,13 +454,13 @@ function cultureChoiceHudView() {
       {
         nodeType: -869902342,
         name: 'Ekklesia',
-        cli: "game play choose-culture --player-id 0 --node -869902342 --send --closeout",
+        cli: "game play choose-culture --node -869902342 --send",
         chooseValidation: { ok: true as const, value: { Success: true } },
       },
       {
         nodeType: -1404789184,
         name: 'Discipline',
-        cli: "game play choose-culture --player-id 0 --node -1404789184 --send --closeout",
+        cli: "game play choose-culture --node -1404789184 --send",
         chooseValidation: { ok: true as const, value: { Success: true } },
       },
     ],

--- a/packages/cli/test/commands/game/play/notification/hud.test.ts
+++ b/packages/cli/test/commands/game/play/notification/hud.test.ts
@@ -126,7 +126,7 @@ describe('game play notifications command', () => {
       expect(details?.storyLinks.value).toEqual([]);
       expect(details?.enabledOptions[0].targetType).toBe('CLOSE');
       expect(details?.enabledOptions[0].validation.value?.Success).toBe(true);
-      expect(details?.enabledOptions[0].cli).toContain('game play choose-narrative --player-id 0 --target-type CLOSE');
+      expect(details?.enabledOptions[0].cli).toContain('game play choose-narrative --target-type CLOSE');
       expect(details?.disabledOptions).toEqual([]);
       expect(payload.view.hud.nextDecision.details).toBeDefined();
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
@@ -596,7 +596,7 @@ function narrativeChoiceHudView() {
     enabledOptions: [
       {
         targetType: 'CLOSE',
-        cli: "game play choose-narrative --player-id 0 --target-type CLOSE --target '{\"owner\":0,\"id\":45,\"type\":35}' --action -1326475004 --send",
+        cli: "game play choose-narrative --target-type CLOSE --target '{\"owner\":0,\"id\":45,\"type\":35}' --action -1326475004 --send",
         validation: { ok: true as const, value: { Success: true } },
       },
     ],

--- a/packages/cli/test/commands/game/play/ready-city.test.ts
+++ b/packages/cli/test/commands/game/play/ready-city.test.ts
@@ -253,7 +253,7 @@ function readyCityView() {
               },
               maintenance: null,
               placementInfo: { PlotIndex: 1457, IsBlocked: false },
-              cli: 'game play assign-worker --player-id <id> --location 1457',
+              cli: 'game play assign-worker --location 1457 --send',
             },
           ],
         },
@@ -293,7 +293,7 @@ function readyCityView() {
           value: { Success: true, Plots: [1458], ConstructibleTypes: [713967338] },
         },
         cliHints: [
-          'game play assign-worker --player-id <id> --location <plot-index>',
+          'game play assign-worker --location <plot-index> --send',
           "game play expand-city --city-id '<city-id>' --x <x> --y <y>",
         ],
       },


### PR DESCRIPTION
fix(control-orpc): remove government choice player input

Refs: openspec/changes/civ7-control-orpc-native-slice

Removes caller playerId from the public government.choice.request and government.celebration.choice.request inputs. The procedures continue to read live local-player evidence before sending through direct-control runtime/proof ports, and normal output still reports the acted local player.

Updates CLI send mode for choose-government and choose-celebration so --send no longer requires or passes --player-id. Dry-run validation still requires --player-id because that path intentionally calls the low-level direct-control validator. Notification HUD send templates and live-play guidance now point at the playerless send commands, while validateCli remains player-scoped.

Updates controller bridge and game-UI fixtures to the corrected request shape and keeps raw runtime/session/command payloads out of normal output.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/government-choice-procedure.test.ts
- bun run --cwd packages/civ7-direct-control test -- notification-view.test.ts government-choice-request.test.ts
- bun run --cwd packages/cli test -- game.play.celebration-government.test.ts game/play/notification/hud.test.ts
- bun run --cwd packages/civ7-direct-control check
- bun run --cwd packages/civ7-direct-control build
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc build
- bun run build:cli
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- stale government/celebration send playerId scan
- active approval/caller-permission scan over changed surfaces
- government procedure public-input playerId adjacency scan
- git diff --check

Local package/CLI proof only; no deployed Civ7 runtime proof, play-thread action, transport expansion, approval/reason mechanic, relationship labels, or parent Task 5.x/6.x/7.x acceptance.

fix(control-orpc): remove progression target player input

Refs: openspec/changes/civ7-control-orpc-native-slice

Removes caller playerId from the public progression.technology.target.request and progression.culture.target.request inputs. The procedures still read live local-player evidence before invoking direct-control target runtime ports, and normal output continues to report the acted local player.

Updates set-tech-target and set-culture-target so --send no longer requires or passes --player-id. Dry-run validation remains player-scoped because that path intentionally calls the low-level direct-control player-operation validator. Source-backed notification targetCli hints and live-play guidance now point at playerless target send commands.

Updates controller bridge and game-UI request fixtures to the corrected request shape, and adds explicit public-input rejection proof for caller playerId while preserving raw command/session/state rejection.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/progression-target-procedure.test.ts test/controller-bridge-ingress.test.ts test/game-ui-controller.test.ts
- bun run --cwd packages/civ7-direct-control test -- notification-view.test.ts progression-target-request.test.ts
- bun run --cwd packages/cli test -- game.play.technology.test.ts game.play.culture.test.ts
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd packages/civ7-direct-control check
- bun run --cwd packages/civ7-direct-control build
- bun run --cwd packages/civ7-control-orpc test
- bun run build:cli
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- stale set-tech/set-culture target send playerId scan
- progression target public-input playerId adjacency scan
- active approval/caller-permission scan over changed surfaces
- target procedure schema export scan
- git diff --check

Local package/CLI proof only; no deployed Civ7 runtime proof, play-thread action, transport expansion, approval/reason mechanic, relationship labels, or parent Task 5.x/6.x/7.x acceptance.

fix(control-orpc): remove progression choice player input

Refs: openspec/changes/civ7-control-orpc-native-slice

Removes caller playerId from progression.technology.choice.request and progression.culture.choice.request public send inputs. The procedures continue to derive runtime player identity from live notification local-player evidence before invoking direct-control closeout ports.

Updates choose-tech/choose-culture send mode to call the native progression service with node-only input while keeping direct-control dry-run validation player-scoped. Generated notification send templates are playerless, and culture no longer advertises the hidden --closeout compatibility no-op.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/progression-choice-procedure.test.ts test/controller-bridge-ingress.test.ts test/game-ui-controller.test.ts
- bun run --cwd packages/cli test -- game.play.technology.test.ts game.play.culture.test.ts game/play/notification/hud.test.ts
- bun run --cwd packages/civ7-direct-control test -- play-notification-view.test.ts
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc build
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-direct-control check
- bun run --cwd packages/civ7-direct-control build
- bun run build:cli
- bun run check:cli
- bun run test:cli:play
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- stale send-mode --player-id and culture --closeout scans
- changed-file private schema export scan
- active approval/caller-permission scan
- git diff --check

Local package, CLI, and OpenSpec proof only. No deployed Civ7 runtime proof, play-thread action, transport expansion, approval/reason mechanic, broad progression catalog, or parent Task 5.x/6.x/7.x acceptance.

fix(control-orpc): remove narrative diplomacy player input

Refs: openspec/changes/civ7-control-orpc-native-slice

Removes caller playerId from narrative.choice.request, diplomacy.response.request, and diplomacy.firstMeet.response.request send inputs. The native service procedures now read live notification/local-player evidence before invoking the direct-control runtime ports, while dry-run CLI validation remains player-scoped.

Updates CLI send examples, notification-view hints, controller/game-UI tests, and OpenSpec workstream records so send mode is playerless and acted-player evidence remains source-owned in normal output.

Proof: bun run --cwd packages/civ7-control-orpc test test/narrative-choice-procedure.test.ts test/diplomacy-response-procedure.test.ts test/first-meet-response-procedure.test.ts test/controller-bridge-ingress.test.ts test/game-ui-controller.test.ts; bun run test:cli:play -- game.play.narrative.test.ts game.play.diplomacy-response.test.ts game.play.first-meet.test.ts game/play/notification/hud.test.ts; bun run --cwd packages/civ7-direct-control test test/play-notification-view.test.ts; bun run --cwd packages/civ7-control-orpc test; bun run --cwd packages/civ7-control-orpc check; bun run --cwd packages/civ7-control-orpc build; bun run --cwd packages/civ7-direct-control check; bun run --cwd packages/civ7-direct-control build; bun run check:cli; bun run build:cli; bun run openspec -- validate civ7-control-orpc-native-slice --strict; bun run openspec -- validate civ7-support-direct-control-modularization --strict; git diff --check; git diff --cached --check.

Boundary: local package/CLI proof only. No deployed Civ7 runtime proof, play-thread action, transport expansion, approval/reason mechanic, exported procedure schema constants, generic decisions root, broad diplomacy/narrative catalog, or parent Task 5.x/6.x/7.x acceptance.

fix(control-orpc): remove population placement player input

Refs: openspec/changes/civ7-control-orpc-native-slice

Removes caller playerId from the public city.population.place.request assign-worker input and has the service read live local-player notification evidence before calling the direct-control assign-worker runtime port.

Updates CLI send mode and ready-city/notification hints so assign-worker sends are playerless, while dry-run validation remains direct-control/player-scoped. Controller bridge and game-UI tests reject stale caller playerId and prove the regenerated bridge bundle has the playerless request schema.

Proof: bun run --cwd packages/civ7-control-orpc test test/city-population-placement-procedure.test.ts test/game-ui-controller.test.ts; bun run test:cli:play -- game.play.population-placement.test.ts game/play/ready-city.test.ts; bun run --cwd packages/civ7-direct-control test test/ready-city-view.test.ts test/ready-city-procedure.test.ts; bun run --cwd packages/civ7-control-orpc test; bun run --cwd packages/civ7-control-orpc check; bun run --cwd packages/civ7-control-orpc build; bun run --cwd packages/civ7-direct-control check; bun run --cwd packages/civ7-direct-control build; bun run check:cli; bun run build:cli; bun run --cwd mods/mod-civ7-intelligence-bridge build; bun run --cwd mods/mod-civ7-intelligence-bridge check; bun run --cwd mods/mod-civ7-intelligence-bridge test; bun run openspec -- validate civ7-control-orpc-native-slice --strict; bun run openspec -- validate civ7-support-direct-control-modularization --strict; private schema export scan; stale assign-worker send player-id scan; active approval/caller-permission scan; generated bundle runtime scan; git diff --check.

Local package, CLI, controller-bundle, and OpenSpec proof only. No deployed Civ7 runtime proof, play-thread action, approval/reason mechanic, transport expansion, broad city catalog, or parent Task 5.x/6.x/7.x acceptance.

fix(control): remove progression send hint player ids

Refs: openspec/changes/civ7-control-orpc-native-slice

Removes stale caller --player-id guidance from progression player-choice notification send recommendations. Tradition and attribute mutation send/closeout templates now match the playerless native oRPC send surfaces, while dry-run validation templates remain player-scoped.

Proof:
- bun run --cwd packages/civ7-direct-control test test/play-notification-view.test.ts
- bun run --cwd packages/civ7-direct-control check
- bun run --cwd packages/civ7-direct-control build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- stale progression send-hint --player-id scan
- active approval/caller-permission scan over changed files
- git diff --check

Boundary: local source/test/OpenSpec proof only. No oRPC contract/router/middleware change, no CLI parser change, no approval/reason mechanic, no play-thread action, no deployed Civ7 runtime proof, and no parent Task 5.x/6.x/7.x acceptance is claimed.

fix(control): simplify progression action hints

Refs: openspec/changes/civ7-control-orpc-native-slice

Removes stale caller --player-id guidance from progression player-choice notification send recommendations and trims repeated flag variants from the action directions. Tradition and attribute hints now describe the semantic send moves plus minimal closeout sequencing context, while dry-run validation remains available through the CLI interface instead of being repeated as separate notification actions.

Proof:
- bun run --cwd packages/civ7-direct-control test test/play-notification-view.test.ts
- bun run --cwd packages/civ7-direct-control check
- bun run --cwd packages/civ7-direct-control build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- stale progression send-hint --player-id and duplicate validation-action scan
- active approval/caller-permission scan over changed files
- git diff --check

Boundary: local source/test/OpenSpec proof only. No oRPC contract/router/middleware change, no CLI parser change, no approval/reason mechanic, no play-thread action, no deployed Civ7 runtime proof, and no parent Task 5.x/6.x/7.x acceptance is claimed.