### PR TITLE
fix(control): simplify notification action hints

### DIFF
--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -936,6 +936,13 @@ adding more read-only facade shells.
     deployed Civ7 proof, relationship authority, and parent Task 5.x/6.x/7.x
     acceptance unchanged; caller-provided approval remains retired and no
     approval-reason mechanic is introduced.
+  - [x] 7.1.9.30 Simplify `civ7 game play notifications` text action guidance so
+    the non-JSON HUD renderer emits semantic action/operation labels instead of
+    `shortcut`, `cli`, or common-action command recipes. Keep JSON diagnostic
+    output, direct-control notification materialization, parser flags, runtime
+    behavior, controller bridge, deployed Civ7 proof, relationship authority,
+    and parent Task 5.x/6.x/7.x acceptance unchanged; caller-provided approval
+    remains retired and no approval-reason mechanic is introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1936,6 +1943,16 @@ adding more read-only facade shells.
   play-thread state, transport/controller scope, relationship authority, or
   parent Task 5.x/6.x/7.x acceptance; caller-provided approval remains retired
   and no approval-reason mechanic is introduced.
+- [x] 8.60.43 Run focused CLI notification HUD tests, `check:cli`, strict
+  OpenSpec validates, notifications text command-recipe output scan, active
+  approval/caller-permission scan, relationship-label safety scan, and diff
+  hygiene for the notifications text action guidance simplification. This is
+  local CLI/OpenSpec proof only; it does not change service behavior or
+  contracts, JSON diagnostic output, runtime read behavior, parser flags,
+  deployed Civ7 runtime behavior, play-thread state, transport/controller
+  scope, relationship authority, or parent Task 5.x/6.x/7.x acceptance;
+  caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -877,6 +877,14 @@ adding more read-only facade shells.
     contracts, controller bridge, deployed Civ7 proof, relationship authority,
     and parent Task 5.x/6.x/7.x acceptance unchanged; caller-provided approval
     remains retired and no approval-reason mechanic is introduced.
+  - [x] 7.1.9.23 Simplify `civ7 game play priorities --compact` and
+    `progress-dashboard --compact` action guidance so compact JSON emits
+    semantic `nextAction` descriptors instead of command strings. Keep command
+    help responsible for exact flag combinations, and keep service behavior,
+    parser flags, runtime reads, controller bridge, deployed Civ7 proof,
+    relationship authority, and parent Task 5.x/6.x/7.x acceptance unchanged;
+    caller-provided approval remains retired and no approval-reason mechanic is
+    introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1809,6 +1817,16 @@ adding more read-only facade shells.
   transport/controller scope, relationship authority, or parent
   Task 5.x/6.x/7.x acceptance; caller-provided approval remains retired and no
   approval-reason mechanic is introduced.
+- [x] 8.60.36 Run focused CLI priorities, progress-dashboard, and semantic
+  envelope tests, `check:cli`, strict OpenSpec validates, compact command-recipe
+  output scan, active approval/caller-permission scan, relationship-label
+  safety scan, and diff hygiene for the compact priority/progression action
+  guidance simplification. This is local CLI/OpenSpec proof only; it does not
+  change service behavior or contracts, runtime read behavior, parser flags,
+  deployed Civ7 runtime behavior, play-thread state, transport/controller
+  scope, relationship authority, or parent Task 5.x/6.x/7.x acceptance;
+  caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -911,6 +911,14 @@ adding more read-only facade shells.
     authority, and parent Task 5.x/6.x/7.x acceptance unchanged;
     caller-provided approval remains retired and no approval-reason mechanic is
     introduced.
+  - [x] 7.1.9.27 Simplify `civ7 game play choose-celebration --options` and
+    `choose-government --options` action guidance so option JSON emits semantic
+    `nextAction` and `validationAction` descriptors instead of
+    `chooseCli`/`validateCli` command strings. Keep command help responsible for
+    exact flag combinations, and keep service behavior, parser flags, runtime
+    reads, controller bridge, deployed Civ7 proof, relationship authority, and
+    parent Task 5.x/6.x/7.x acceptance unchanged; caller-provided approval
+    remains retired and no approval-reason mechanic is introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1877,6 +1885,16 @@ adding more read-only facade shells.
   strict OpenSpec validates, technology/culture options command-recipe output
   scan, active approval/caller-permission scan, relationship-label safety scan,
   and diff hygiene for the progression choice option action guidance
+  simplification. This is local CLI/OpenSpec proof only; it does not change
+  service behavior or contracts, runtime read behavior, parser flags, deployed
+  Civ7 runtime behavior, play-thread state, transport/controller scope,
+  relationship authority, or parent Task 5.x/6.x/7.x acceptance;
+  caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+- [x] 8.60.40 Run focused CLI celebration/government tests, `check:cli`,
+  strict OpenSpec validates, celebration/government options command-recipe
+  output scan, active approval/caller-permission scan, relationship-label safety
+  scan, and diff hygiene for the celebration/government option action guidance
   simplification. This is local CLI/OpenSpec proof only; it does not change
   service behavior or contracts, runtime read behavior, parser flags, deployed
   Civ7 runtime behavior, play-thread state, transport/controller scope,

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -943,6 +943,15 @@ adding more read-only facade shells.
     behavior, controller bridge, deployed Civ7 proof, relationship authority,
     and parent Task 5.x/6.x/7.x acceptance unchanged; caller-provided approval
     remains retired and no approval-reason mechanic is introduced.
+  - [x] 7.1.9.31 Simplify `civ7 game play notifications --json` action
+    guidance so the normal JSON view omits direct-control `cli` command recipe
+    fields while preserving semantic categories, operation families,
+    operation types, required inputs, common actions, option data, validation
+    evidence, and notes. Keep direct-control notification materialization,
+    parser flags, runtime behavior, controller bridge, deployed Civ7 proof,
+    relationship authority, and parent Task 5.x/6.x/7.x acceptance unchanged;
+    caller-provided approval remains retired and no approval-reason mechanic is
+    introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1953,6 +1962,16 @@ adding more read-only facade shells.
   scope, relationship authority, or parent Task 5.x/6.x/7.x acceptance;
   caller-provided approval remains retired and no approval-reason mechanic is
   introduced.
+- [x] 8.60.44 Run focused CLI notification HUD tests, `check:cli`, strict
+  OpenSpec validates, notifications JSON command-recipe output scan, active
+  approval/caller-permission scan, relationship-label safety scan, and diff
+  hygiene for the notifications JSON action guidance simplification. This is
+  local CLI/OpenSpec proof only; it does not change service behavior or
+  contracts, direct-control notification materialization, runtime read
+  behavior, parser flags, deployed Civ7 runtime behavior, play-thread state,
+  transport/controller scope, relationship authority, or parent Task 5.x/6.x/7.x
+  acceptance; caller-provided approval remains retired and no approval-reason
+  mechanic is introduced.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -840,6 +840,12 @@ adding more read-only facade shells.
     instead of adding CLI command-string recipes to the queue JSON view. Keep
     text output concise by printing the semantic next-step label, and keep
     command help responsible for exhaustive flag/interface detail.
+  - [x] 7.1.9.18 Simplify `progression.traditions.current` omission metadata
+    so it describes service-level presentation and runtime evidence categories
+    instead of naming direct-control/CLI implementation fields. Keep the
+    service contract, CLI parser behavior, runtime reads, controller bridge,
+    approval/reason mechanics, deployed Civ7 proof, and parent
+    Task 5.x/6.x/7.x acceptance unchanged.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1727,6 +1733,14 @@ adding more read-only facade shells.
   package/CLI proof for a narrow queue service classifier cleanup plus CLI
   presentation cleanup; it does not change service contracts, CLI parser
   behavior, deployed Civ7 runtime behavior, play-thread state,
+  approval/reason mechanics, transport/controller scope, or parent
+  Task 5.x/6.x/7.x acceptance.
+- [x] 8.60.31 Run focused progression traditions procedure tests, focused CLI
+  progression-read tests, `check:cli`, control-oRPC check, strict OpenSpec
+  validates, service omission metadata scan, active approval/caller-permission
+  scan, and diff hygiene for the traditions omission metadata simplification.
+  This is local package/CLI proof only; it does not change service contracts,
+  CLI parser behavior, deployed Civ7 runtime behavior, play-thread state,
   approval/reason mechanics, transport/controller scope, or parent
   Task 5.x/6.x/7.x acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -928,6 +928,14 @@ adding more read-only facade shells.
     Civ7 proof, relationship authority, and parent Task 5.x/6.x/7.x acceptance
     unchanged; caller-provided approval remains retired and no approval-reason
     mechanic is introduced.
+  - [x] 7.1.9.29 Simplify `civ7 game play rehydrate` common action guidance so
+    restart snapshots emit semantic `commonActions` descriptors instead of
+    `cli` command recipes. Keep command help responsible for exact flag
+    combinations, and keep direct-control notification/ready-unit reads,
+    continuity checks, parser flags, runtime behavior, controller bridge,
+    deployed Civ7 proof, relationship authority, and parent Task 5.x/6.x/7.x
+    acceptance unchanged; caller-provided approval remains retired and no
+    approval-reason mechanic is introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1919,6 +1927,15 @@ adding more read-only facade shells.
   behavior, play-thread state, transport/controller scope, relationship
   authority, or parent Task 5.x/6.x/7.x acceptance; caller-provided approval
   remains retired and no approval-reason mechanic is introduced.
+- [x] 8.60.42 Run focused CLI rehydrate tests, `check:cli`, strict OpenSpec
+  validates, rehydrate common-action command-recipe output scan, active
+  approval/caller-permission scan, relationship-label safety scan, and diff
+  hygiene for the rehydrate common action guidance simplification. This is local
+  CLI/OpenSpec proof only; it does not change service behavior or contracts,
+  runtime read behavior, parser flags, deployed Civ7 runtime behavior,
+  play-thread state, transport/controller scope, relationship authority, or
+  parent Task 5.x/6.x/7.x acceptance; caller-provided approval remains retired
+  and no approval-reason mechanic is introduced.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -862,6 +862,14 @@ adding more read-only facade shells.
     controller bridge, deployed Civ7 proof, and parent Task 5.x/6.x/7.x
     acceptance unchanged; caller-provided approval remains retired and no
     approval-reason mechanic is introduced.
+  - [x] 7.1.9.21 Simplify `civ7 game play front-summary` follow-up suggestions
+    so CLI JSON/human output presents the service's semantic next-step labels
+    instead of expanding each descriptor into literal command-and-flag recipes.
+    Keep command help responsible for exhaustive interface detail, and keep
+    service behavior, parser flags, runtime reads, controller bridge, deployed
+    Civ7 proof, and parent Task 5.x/6.x/7.x acceptance unchanged;
+    caller-provided approval remains retired and no approval-reason mechanic is
+    introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1771,6 +1779,15 @@ adding more read-only facade shells.
   OpenSpec validates, formation command-recipe output scan, active
   approval/caller-permission scan, relationship-label safety scan, and diff
   hygiene for the formation follow-up simplification. This is local
+  CLI/OpenSpec proof only; it does not change service behavior or contracts,
+  parser flags, deployed Civ7 runtime behavior, play-thread state,
+  transport/controller scope, relationship authority, or parent
+  Task 5.x/6.x/7.x acceptance; caller-provided approval remains retired and no
+  approval-reason mechanic is introduced.
+- [x] 8.60.34 Run focused CLI tactical-read tests, `check:cli`, strict
+  OpenSpec validates, front-summary command-recipe output scan, active
+  approval/caller-permission scan, relationship-label safety scan, and diff
+  hygiene for the front-summary follow-up simplification. This is local
   CLI/OpenSpec proof only; it does not change service behavior or contracts,
   parser flags, deployed Civ7 runtime behavior, play-thread state,
   transport/controller scope, relationship authority, or parent

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -829,6 +829,12 @@ adding more read-only facade shells.
     direct-control envelopes from normal JSON, and avoid controller bridge,
     transport, action-send, approval/reason mechanics, or runtime-proof
     claims.
+  - [x] 7.1.9.16 Simplify notification action directions so common actions
+    carry semantic next-move guidance instead of repeating dry-run validation
+    and single-flag send variants. Keep named blocker recommendations
+    send-oriented where a semantic send surface exists, leave generic fallback
+    validation paths for operation families without named shortcuts, and keep
+    command help responsible for exhaustive flag/interface detail.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1700,6 +1706,14 @@ adding more read-only facade shells.
   Civ7 runtime proof, play-thread action, transport expansion,
   approval/reason mechanics, broader progression catalog support, or parent
   Task 5.x/6.x/7.x acceptance.
+- [x] 8.60.29 Run focused direct-control notification-view proof,
+  direct-control check/build, strict OpenSpec validates, stale validation-only
+  action hint scan, active approval/caller-permission scan, and diff hygiene
+  for the notification action direction simplification. This is local
+  source/test proof only and does not change CLI parser behavior, oRPC
+  contracts, controller bridge surfaces, deployed Civ7 runtime behavior,
+  play-thread state, approval/reason mechanics, or parent Task 5.x/6.x/7.x
+  acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -888,12 +888,12 @@ adding more read-only facade shells.
   - [x] 7.1.9.24 Simplify `civ7 game play traditions --compact` action guidance
     so compact JSON emits semantic row `nextAction` and `recommendedActions`
     descriptors instead of `change-tradition` command strings, with
-    `recommendedActions` limited to validation-success options. Keep command
-    help responsible for exact flag combinations, and keep service behavior,
-    parser flags, runtime reads, controller bridge, deployed Civ7 proof,
-    relationship authority, and parent Task 5.x/6.x/7.x acceptance unchanged;
-    caller-provided approval remains retired and no approval-reason mechanic is
-    introduced.
+    send-oriented actions limited to validation-success options and failed/null
+    validation rows kept as read-only validation guidance. Keep command help
+    responsible for exact flag combinations, and keep service behavior, parser
+    flags, runtime reads, controller bridge, deployed Civ7 proof, relationship
+    authority, and parent Task 5.x/6.x/7.x acceptance unchanged; caller-provided
+    approval remains retired and no approval-reason mechanic is introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1840,10 +1840,10 @@ adding more read-only facade shells.
   OpenSpec validates, compact traditions command-recipe output scan, active
   approval/caller-permission scan, relationship-label safety scan, and diff
   hygiene, including a validation-failed tradition falsifier for
-  `recommendedActions`, for the compact traditions action guidance
-  simplification. This is local CLI/OpenSpec proof only; it does not change
-  service behavior or contracts, runtime read behavior, parser flags, deployed
-  Civ7 runtime behavior, play-thread state, transport/controller scope,
+  read-only row guidance and `recommendedActions`, for the compact traditions
+  action guidance simplification. This is local CLI/OpenSpec proof only; it does
+  not change service behavior or contracts, runtime read behavior, parser flags,
+  deployed Civ7 runtime behavior, play-thread state, transport/controller scope,
   relationship authority, or parent Task 5.x/6.x/7.x acceptance;
   caller-provided approval remains retired and no approval-reason mechanic is
   introduced.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -854,6 +854,14 @@ adding more read-only facade shells.
     controller bridge, deployed Civ7 proof, and parent Task 5.x/6.x/7.x
     acceptance unchanged; caller-provided approval remains retired and no
     approval-reason mechanic is introduced.
+  - [x] 7.1.9.20 Simplify `civ7 game play formation-snapshot` follow-up
+    suggestions so CLI JSON/human output presents the service's semantic
+    next-step labels instead of expanding each descriptor into a literal
+    command-and-flag recipe. Keep command help responsible for exhaustive
+    interface detail, and keep service behavior, parser flags, runtime reads,
+    controller bridge, deployed Civ7 proof, and parent Task 5.x/6.x/7.x
+    acceptance unchanged; caller-provided approval remains retired and no
+    approval-reason mechanic is introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1757,6 +1765,15 @@ adding more read-only facade shells.
   follow-up simplification. This is local CLI/OpenSpec proof only; it does not
   change service behavior or contracts, parser flags, deployed Civ7 runtime
   behavior, play-thread state, transport/controller scope, or parent
+  Task 5.x/6.x/7.x acceptance; caller-provided approval remains retired and no
+  approval-reason mechanic is introduced.
+- [x] 8.60.33 Run focused CLI tactical-read tests, `check:cli`, strict
+  OpenSpec validates, formation command-recipe output scan, active
+  approval/caller-permission scan, relationship-label safety scan, and diff
+  hygiene for the formation follow-up simplification. This is local
+  CLI/OpenSpec proof only; it does not change service behavior or contracts,
+  parser flags, deployed Civ7 runtime behavior, play-thread state,
+  transport/controller scope, relationship authority, or parent
   Task 5.x/6.x/7.x acceptance; caller-provided approval remains retired and no
   approval-reason mechanic is introduced.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -919,6 +919,15 @@ adding more read-only facade shells.
     reads, controller bridge, deployed Civ7 proof, relationship authority, and
     parent Task 5.x/6.x/7.x acceptance unchanged; caller-provided approval
     remains retired and no approval-reason mechanic is introduced.
+  - [x] 7.1.9.28 Simplify `civ7 game play choose-narrative --options` action
+    guidance so option JSON emits semantic `nextAction`, `validationAction`,
+    and dismissal action descriptors instead of `command`, `chooseCli`,
+    `validateCli`, `dismissalDiagnosticCli`, or `unprovenDismissalCli` command
+    strings. Keep command help responsible for exact flag combinations, and keep
+    service behavior, parser flags, runtime reads, controller bridge, deployed
+    Civ7 proof, relationship authority, and parent Task 5.x/6.x/7.x acceptance
+    unchanged; caller-provided approval remains retired and no approval-reason
+    mechanic is introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1901,6 +1910,15 @@ adding more read-only facade shells.
   relationship authority, or parent Task 5.x/6.x/7.x acceptance;
   caller-provided approval remains retired and no approval-reason mechanic is
   introduced.
+- [x] 8.60.41 Run focused CLI narrative tests, `check:cli`, strict OpenSpec
+  validates, narrative options command-recipe output scan, active
+  approval/caller-permission scan, relationship-label safety scan, and diff
+  hygiene for the narrative option action guidance simplification. This is
+  local CLI/OpenSpec proof only; it does not change service behavior or
+  contracts, runtime read behavior, parser flags, deployed Civ7 runtime
+  behavior, play-thread state, transport/controller scope, relationship
+  authority, or parent Task 5.x/6.x/7.x acceptance; caller-provided approval
+  remains retired and no approval-reason mechanic is introduced.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -894,6 +894,14 @@ adding more read-only facade shells.
     flags, runtime reads, controller bridge, deployed Civ7 proof, relationship
     authority, and parent Task 5.x/6.x/7.x acceptance unchanged; caller-provided
     approval remains retired and no approval-reason mechanic is introduced.
+  - [x] 7.1.9.25 Simplify `civ7 game play ready-city --compact` action guidance
+    so compact JSON emits semantic row `nextAction` descriptors and top-level
+    `nextAction` instead of direct-control `cli`/`cliHints` command strings.
+    Keep command help responsible for exact flag combinations, and keep
+    direct-control ready-city source behavior, parser flags, runtime reads,
+    controller bridge, deployed Civ7 proof, relationship authority, and parent
+    Task 5.x/6.x/7.x acceptance unchanged; caller-provided approval remains
+    retired and no approval-reason mechanic is introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1847,6 +1855,15 @@ adding more read-only facade shells.
   relationship authority, or parent Task 5.x/6.x/7.x acceptance;
   caller-provided approval remains retired and no approval-reason mechanic is
   introduced.
+- [x] 8.60.38 Run focused CLI ready-city tests, `check:cli`, strict OpenSpec
+  validates, compact ready-city command-recipe output scan, active
+  approval/caller-permission scan, relationship-label safety scan, and diff
+  hygiene for the compact ready-city action guidance simplification. This is
+  local CLI/OpenSpec proof only; it does not change direct-control ready-city
+  source behavior, runtime read behavior, parser flags, deployed Civ7 runtime
+  behavior, play-thread state, transport/controller scope, relationship
+  authority, or parent Task 5.x/6.x/7.x acceptance; caller-provided approval
+  remains retired and no approval-reason mechanic is introduced.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -885,6 +885,15 @@ adding more read-only facade shells.
     relationship authority, and parent Task 5.x/6.x/7.x acceptance unchanged;
     caller-provided approval remains retired and no approval-reason mechanic is
     introduced.
+  - [x] 7.1.9.24 Simplify `civ7 game play traditions --compact` action guidance
+    so compact JSON emits semantic row `nextAction` and `recommendedActions`
+    descriptors instead of `change-tradition` command strings, with
+    `recommendedActions` limited to validation-success options. Keep command
+    help responsible for exact flag combinations, and keep service behavior,
+    parser flags, runtime reads, controller bridge, deployed Civ7 proof,
+    relationship authority, and parent Task 5.x/6.x/7.x acceptance unchanged;
+    caller-provided approval remains retired and no approval-reason mechanic is
+    introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1825,6 +1834,17 @@ adding more read-only facade shells.
   change service behavior or contracts, runtime read behavior, parser flags,
   deployed Civ7 runtime behavior, play-thread state, transport/controller
   scope, relationship authority, or parent Task 5.x/6.x/7.x acceptance;
+  caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+- [x] 8.60.37 Run focused CLI progression-read tests, `check:cli`, strict
+  OpenSpec validates, compact traditions command-recipe output scan, active
+  approval/caller-permission scan, relationship-label safety scan, and diff
+  hygiene, including a validation-failed tradition falsifier for
+  `recommendedActions`, for the compact traditions action guidance
+  simplification. This is local CLI/OpenSpec proof only; it does not change
+  service behavior or contracts, runtime read behavior, parser flags, deployed
+  Civ7 runtime behavior, play-thread state, transport/controller scope,
+  relationship authority, or parent Task 5.x/6.x/7.x acceptance;
   caller-provided approval remains retired and no approval-reason mechanic is
   introduced.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -835,6 +835,11 @@ adding more read-only facade shells.
     send-oriented where a semantic send surface exists, leave generic fallback
     validation paths for operation families without named shortcuts, and keep
     command help responsible for exhaustive flag/interface detail.
+  - [x] 7.1.9.17 Simplify `civ7 game play notification-queue` follow-up
+    suggestions by preserving the service-owned semantic `nextStep` objects
+    instead of adding CLI command-string recipes to the queue JSON view. Keep
+    text output concise by printing the semantic next-step label, and keep
+    command help responsible for exhaustive flag/interface detail.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1714,6 +1719,16 @@ adding more read-only facade shells.
   contracts, controller bridge surfaces, deployed Civ7 runtime behavior,
   play-thread state, approval/reason mechanics, or parent Task 5.x/6.x/7.x
   acceptance.
+- [x] 8.60.30 Run focused CLI notification-queue tests, focused control-oRPC
+  notification-queue procedure tests, `check:cli`,
+  `test:cli:play`, control-oRPC check, strict OpenSpec validates, queue
+  command-recipe output scan, active approval/caller-permission scan, and diff
+  hygiene for the notification queue next-action simplification. This is local
+  package/CLI proof for a narrow queue service classifier cleanup plus CLI
+  presentation cleanup; it does not change service contracts, CLI parser
+  behavior, deployed Civ7 runtime behavior, play-thread state,
+  approval/reason mechanics, transport/controller scope, or parent
+  Task 5.x/6.x/7.x acceptance.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -902,6 +902,15 @@ adding more read-only facade shells.
     controller bridge, deployed Civ7 proof, relationship authority, and parent
     Task 5.x/6.x/7.x acceptance unchanged; caller-provided approval remains
     retired and no approval-reason mechanic is introduced.
+  - [x] 7.1.9.26 Simplify `civ7 game play choose-tech --options` and
+    `choose-culture --options` action guidance so option JSON emits semantic
+    `nextAction`, `targetAction`, and `validationAction` descriptors instead of
+    `chooseCli`/`targetCli`/`validateCli` command strings. Keep command help
+    responsible for exact flag combinations, and keep service behavior, parser
+    flags, runtime reads, controller bridge, deployed Civ7 proof, relationship
+    authority, and parent Task 5.x/6.x/7.x acceptance unchanged;
+    caller-provided approval remains retired and no approval-reason mechanic is
+    introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1864,6 +1873,16 @@ adding more read-only facade shells.
   behavior, play-thread state, transport/controller scope, relationship
   authority, or parent Task 5.x/6.x/7.x acceptance; caller-provided approval
   remains retired and no approval-reason mechanic is introduced.
+- [x] 8.60.39 Run focused CLI technology/culture option tests, `check:cli`,
+  strict OpenSpec validates, technology/culture options command-recipe output
+  scan, active approval/caller-permission scan, relationship-label safety scan,
+  and diff hygiene for the progression choice option action guidance
+  simplification. This is local CLI/OpenSpec proof only; it does not change
+  service behavior or contracts, runtime read behavior, parser flags, deployed
+  Civ7 runtime behavior, play-thread state, transport/controller scope,
+  relationship authority, or parent Task 5.x/6.x/7.x acceptance;
+  caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -846,6 +846,14 @@ adding more read-only facade shells.
     service contract, CLI parser behavior, runtime reads, controller bridge,
     approval/reason mechanics, deployed Civ7 proof, and parent
     Task 5.x/6.x/7.x acceptance unchanged.
+  - [x] 7.1.9.19 Simplify `civ7 game play civilian-route-triage` follow-up
+    suggestions so CLI JSON/human output presents the service's semantic
+    next-step labels instead of expanding each descriptor into a literal
+    command-and-flag recipe. Keep command help responsible for exhaustive
+    interface detail, and keep service behavior, parser flags, runtime reads,
+    controller bridge, deployed Civ7 proof, and parent Task 5.x/6.x/7.x
+    acceptance unchanged; caller-provided approval remains retired and no
+    approval-reason mechanic is introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1743,6 +1751,14 @@ adding more read-only facade shells.
   CLI parser behavior, deployed Civ7 runtime behavior, play-thread state,
   approval/reason mechanics, transport/controller scope, or parent
   Task 5.x/6.x/7.x acceptance.
+- [x] 8.60.32 Run focused CLI tactical-read tests, `check:cli`, strict
+  OpenSpec validates, civilian-route command-recipe output scan, active
+  approval/caller-permission scan, and diff hygiene for the civilian-route
+  follow-up simplification. This is local CLI/OpenSpec proof only; it does not
+  change service behavior or contracts, parser flags, deployed Civ7 runtime
+  behavior, play-thread state, transport/controller scope, or parent
+  Task 5.x/6.x/7.x acceptance; caller-provided approval remains retired and no
+  approval-reason mechanic is introduced.
 - [x] 8.12 Run control-oRPC package check/build, the Studio RPCLink edge test,
   strict OpenSpec validates, public root-export scan, and diff hygiene for the
   raw runtime result root-export burn-down slice.

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -870,6 +870,13 @@ adding more read-only facade shells.
     Civ7 proof, and parent Task 5.x/6.x/7.x acceptance unchanged;
     caller-provided approval remains retired and no approval-reason mechanic is
     introduced.
+  - [x] 7.1.9.22 Simplify `civ7 game play unit-move-preview --compact` action
+    guidance so compact JSON emits semantic validation descriptors instead of
+    `game play unit-target` command recipes. Keep command help responsible for
+    exhaustive interface detail, and keep runtime reads, parser flags, service
+    contracts, controller bridge, deployed Civ7 proof, relationship authority,
+    and parent Task 5.x/6.x/7.x acceptance unchanged; caller-provided approval
+    remains retired and no approval-reason mechanic is introduced.
 - [x] 7.2 Add Studio `RPCHandler`/`RPCLink` only after the shared router shape
   is stable.
   - [x] 7.2.1 Mount the shared `Civ7ControlOrpcRouter` behind Studio's Vite
@@ -1790,6 +1797,15 @@ adding more read-only facade shells.
   hygiene for the front-summary follow-up simplification. This is local
   CLI/OpenSpec proof only; it does not change service behavior or contracts,
   parser flags, deployed Civ7 runtime behavior, play-thread state,
+  transport/controller scope, relationship authority, or parent
+  Task 5.x/6.x/7.x acceptance; caller-provided approval remains retired and no
+  approval-reason mechanic is introduced.
+- [x] 8.60.35 Run focused CLI unit-move-preview tests, `check:cli`, strict
+  OpenSpec validates, unit-move-preview command-recipe output scan, active
+  approval/caller-permission scan, relationship-label safety scan, and diff
+  hygiene for the compact action guidance simplification. This is local
+  CLI/OpenSpec proof only; it does not change runtime read behavior, parser
+  flags, service contracts, deployed Civ7 runtime behavior, play-thread state,
   transport/controller scope, relationship authority, or parent
   Task 5.x/6.x/7.x acceptance; caller-provided approval remains retired and no
   approval-reason mechanic is introduced.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-civilian-route-next-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-civilian-route-next-action-slice.md
@@ -1,0 +1,50 @@
+# CLI Civilian Route Next-Action Slice
+
+## Status
+
+Implemented local CLI/OpenSpec proof slice.
+
+## Purpose
+
+Keep `civ7 game play civilian-route-triage` follow-up suggestions semantic.
+The service already emits next-step descriptors with labels and parameters; the
+CLI should not expand that into a list of literal command-and-flag recipes in
+normal JSON or text output. Command help remains responsible for exhaustive
+interface detail.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/civilian-route-triage.ts`
+- `packages/cli/test/commands/game.play.tactical-read.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-civilian-route-triage-orpc-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-civilian-route-next-action-slice.md`
+
+## Boundary
+
+- CLI `nextInspections` now contains concise semantic labels from
+  `strategy.civilianRouteTriage.nextSteps`.
+- The output no longer lists `game play ...` command recipes for each possible
+  follow-up.
+- This slice does not change service behavior, service contracts, parser flags,
+  runtime direct-control reads, controller bridge, generated bundles,
+  play-thread state, deployed Civ7 proof, or parent Task 5.x/6.x/7.x
+  acceptance.
+- Caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+
+## Proof Collected
+
+- `bun run test:cli:play -- game.play.tactical-read.test.ts`
+- `bun run check:cli`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Civilian-route command-recipe output scan over changed CLI source/test.
+- Active approval/caller-permission scan over changed files; no active hits.
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/OpenSpec proof only. It does not prove deployed Civ7 runtime
+behavior, change route-triage service behavior, or prove controller bridge
+behavior.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-civilian-route-triage-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-civilian-route-triage-orpc-slice.md
@@ -10,8 +10,9 @@ Route `civ7 game play civilian-route-triage` through the native in-process
 `strategy.civilianRouteTriage` server-side client. The control-oRPC service
 owns route-status composition over current notification, ready-unit, settlement
 recommendation, battlefield, and destination evidence. The CLI remains an edge
-adapter that builds endpoint context and maps semantic next-step descriptors
-into command suggestions for CLI presentation only.
+adapter that builds endpoint context and presents semantic next-step
+descriptors without making CLI command syntax part of the route-triage JSON
+contract.
 
 ## Write Set
 
@@ -33,6 +34,9 @@ into command suggestions for CLI presentation only.
 - `strategy.civilianRouteTriage` owns route status, source status, route
   reasons, safe settlement/battlefield/destination summaries, and semantic
   next-step descriptors.
+- `civ7 game play civilian-route-triage` presents the service next-step labels
+  as concise follow-up guidance; command help remains the source for exhaustive
+  flag/interface detail.
 - Direct-control remains the low-level runtime/read port provider for
   notification, ready-unit, settlement recommendation, battlefield, and
   destination evidence.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-compact-priority-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-compact-priority-action-slice.md
@@ -1,0 +1,57 @@
+# CLI Compact Priority Action Slice
+
+## Status
+
+Implemented local CLI/OpenSpec proof slice.
+
+## Purpose
+
+Keep compact player-agent output semantic for `civ7 game play priorities` and
+`civ7 game play progress-dashboard`. These compact views should describe the
+next play action or inspection as a semantic descriptor, not as literal CLI
+syntax. Command help remains responsible for exact flag combinations.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/priorities.ts`
+- `packages/cli/src/commands/game/play/progress-dashboard.ts`
+- `packages/cli/src/game-play/semantic-envelope.ts`
+- `packages/cli/test/commands/game/play/priorities.test.ts`
+- `packages/cli/test/commands/game.play.progression-read.test.ts`
+- `packages/cli/test/commands/game/play/semantic-envelope.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-priorities-orpc-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-progress-dashboard-orpc-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-compact-priority-action-slice.md`
+
+## Boundary
+
+- `priorities --compact` now emits priority `nextAction` descriptors and stores
+  semantic descriptors in the semantic envelope `actions` and `nextSteps`
+  slots.
+- `progress-dashboard --compact` now emits a semantic `nextAction` descriptor
+  from the service `nextSteps` array.
+- The compact outputs no longer expose `game play ...` command recipes as
+  normal JSON guidance.
+- This slice does not change control-oRPC service behavior, service contracts,
+  runtime direct-control reads, parser flags, controller bridge, generated
+  bundles, play-thread state, deployed Civ7 proof, relationship authority, or
+  parent Task 5.x/6.x/7.x acceptance.
+- Caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+
+## Proof Collected
+
+- `bun run test:cli:play -- game/play/priorities.test.ts game.play.progression-read.test.ts game/play/semantic-envelope.test.ts`
+- `bun run check:cli`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Compact command-recipe output scan over changed CLI source/test.
+- Active approval/caller-permission scan over changed files; no active hits.
+- Relationship-label safety scan over changed source/test.
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/OpenSpec proof only. It does not prove deployed Civ7 runtime
+behavior, change oRPC service behavior, or prove controller bridge behavior.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-formation-next-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-formation-next-action-slice.md
@@ -1,0 +1,51 @@
+# CLI Formation Next-Action Slice
+
+## Status
+
+Implemented local CLI/OpenSpec proof slice.
+
+## Purpose
+
+Keep `civ7 game play formation-snapshot` follow-up suggestions semantic. The
+service already emits formation next-step descriptors with labels and
+parameters; the CLI should not expand that into literal command-and-flag
+recipes in normal JSON or text output. Command help remains responsible for
+exhaustive interface detail.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/formation-snapshot.ts`
+- `packages/cli/test/commands/game.play.tactical-read.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-formation-snapshot-orpc-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-formation-next-action-slice.md`
+
+## Boundary
+
+- CLI `formation.nextInspections` now contains concise semantic labels from
+  `strategy.formationSnapshot.nextSteps`.
+- The output no longer lists `game play ...` command recipes for each possible
+  follow-up.
+- This slice does not change service behavior, service contracts, parser flags,
+  runtime direct-control reads, controller bridge, generated bundles,
+  play-thread state, deployed Civ7 proof, relationship authority, or parent
+  Task 5.x/6.x/7.x acceptance.
+- Caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+
+## Proof Collected
+
+- `bun run test:cli:play -- game.play.tactical-read.test.ts`
+- `bun run check:cli`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Formation command-recipe output scan over changed CLI source/test.
+- Active approval/caller-permission scan over changed files; no active hits.
+- Relationship-label safety scan over changed source/test.
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/OpenSpec proof only. It does not prove deployed Civ7 runtime
+behavior, change formation service behavior, or prove controller bridge
+behavior.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-formation-snapshot-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-formation-snapshot-orpc-slice.md
@@ -10,8 +10,8 @@ Route `civ7 game play formation-snapshot` through the native in-process
 `strategy.formationSnapshot` server-side client. The control-oRPC service owns
 formation posture composition over current notification, ready-unit, and
 battlefield evidence. The CLI remains an edge adapter that builds endpoint
-context and maps semantic next-step descriptors into command suggestions for
-CLI presentation only.
+context and presents semantic next-step descriptors without making CLI command
+syntax part of the formation JSON contract.
 
 ## Write Set
 
@@ -36,8 +36,9 @@ CLI presentation only.
 - Procedure input/output schemas stay contract-local; callers use the aggregate
   contract/router/server client rather than per-procedure schema exports.
 - Service output does not contain literal `game play ...` CLI command strings.
-- The CLI may still present command suggestions, but that translation is a CLI
-  presentation concern and not part of the native service contract.
+- `civ7 game play formation-snapshot` presents service next-step labels as
+  concise follow-up guidance; command help remains the source for exhaustive
+  flag/interface detail.
 - Controller bridge allowlisting and game-resident formation support remain
   pending.
 - Battlefield evidence is planning context only. Owner mismatch, proximity,

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-front-summary-next-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-front-summary-next-action-slice.md
@@ -1,0 +1,50 @@
+# CLI Front Summary Next-Action Slice
+
+## Status
+
+Implemented local CLI/OpenSpec proof slice.
+
+## Purpose
+
+Keep `civ7 game play front-summary` follow-up suggestions semantic. The service
+already emits front next-step descriptors with labels and parameters; the CLI
+should not expand that into literal command-and-flag recipes in normal JSON or
+text output. Command help remains responsible for exhaustive interface detail.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/front-summary.ts`
+- `packages/cli/test/commands/game.play.tactical-read.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-front-summary-orpc-slice.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-front-summary-next-action-slice.md`
+
+## Boundary
+
+- CLI `summary.nextInspections` now contains concise semantic labels from
+  `strategy.frontSummary.front.nextInspections`.
+- The output no longer lists `game play ...` command recipes for each possible
+  follow-up.
+- This slice does not change service behavior, service contracts, parser flags,
+  runtime direct-control reads, controller bridge, generated bundles,
+  play-thread state, deployed Civ7 proof, relationship authority, or parent
+  Task 5.x/6.x/7.x acceptance.
+- Caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+
+## Proof Collected
+
+- `bun run test:cli:play -- game.play.tactical-read.test.ts`
+- `bun run check:cli`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Front-summary command-recipe output scan over changed CLI source/test.
+- Active approval/caller-permission scan over changed files; no active hits.
+- Relationship-label safety scan over changed source/test.
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/OpenSpec proof only. It does not prove deployed Civ7 runtime
+behavior, change front-summary service behavior, or prove controller bridge
+behavior.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-front-summary-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-front-summary-orpc-slice.md
@@ -13,8 +13,9 @@ battlefield, optional destination-analysis, source-status, front posture, risk,
 relationship-safe wording, and semantic next-step descriptors.
 
 The CLI remains an edge adapter: it builds endpoint context, parses command
-flags, calls the server-side client, and maps semantic next-step descriptors
-into CLI command suggestions for CLI output only.
+flags, calls the server-side client, and presents semantic next-step
+descriptors without making CLI command syntax part of the front-summary JSON
+contract.
 
 ## Write Set
 
@@ -41,8 +42,9 @@ into CLI command suggestions for CLI output only.
 - The service output uses semantic next-step descriptors and relationship-safe
   planning language. It does not emit literal `game play ...` CLI command
   strings.
-- The CLI may still present command suggestions, but that translation is a CLI
-  presentation concern and not part of the native service contract.
+- `civ7 game play front-summary` presents service next-step labels as concise
+  follow-up guidance; command help remains the source for exhaustive
+  flag/interface detail.
 - The game-UI strategy adapter exposes destination-analysis evidence through
   the same low-level ambient owner/unit/city reads so the existing controller
   `strategy.frontSummary` path remains coherent after the richer service

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-government-option-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-government-option-action-slice.md
@@ -1,0 +1,55 @@
+# CLI Government Option Action Slice
+
+## Status
+
+Implemented local CLI/OpenSpec proof slice.
+
+## Purpose
+
+Keep `civ7 game play choose-celebration --options` and `civ7 game play
+choose-government --options` aligned with the semantic player-agent output
+rule. Option rows expose follow-up guidance as semantic descriptors, not
+`chooseCli` or `validateCli` command recipes. Command help remains responsible
+for exact flag combinations.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/choose-celebration.ts`
+- `packages/cli/src/commands/game/play/choose-government.ts`
+- `packages/cli/test/commands/game.play.celebration-government.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-government-option-action-slice.md`
+
+## Boundary
+
+- `choose-celebration --options` now emits
+  `surface: "celebration-choice-options"` and enabled row `nextAction` /
+  `validationAction` descriptors.
+- `choose-government --options` now emits `surface: "government-choice-options"`
+  and enabled row `nextAction` / `validationAction` descriptors.
+- Option output no longer emits `chooseCli`, `validateCli`, or `game play ...`
+  command recipes.
+- This slice does not change celebration/government service behavior, parser
+  flags, runtime reads, direct-control validators, controller bridge, generated
+  bundles, play-thread state, deployed Civ7 proof, relationship authority, or
+  parent Task 5.x/6.x/7.x acceptance.
+- Caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+
+## Proof Collected
+
+- `bun run --cwd packages/cli test -- game.play.celebration-government.test.ts`
+- `bun run check:cli`
+- Strict OpenSpec validates for `civ7-control-orpc-native-slice` and
+  `civ7-support-direct-control-modularization`.
+- Celebration/government options command-recipe output scan over changed CLI
+  source/test.
+- Active approval/caller-permission scan over changed files.
+- Relationship-label safety scan over changed source/test.
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/OpenSpec proof only. It does not prove deployed Civ7 runtime
+behavior, change celebration/government service behavior, or prove controller
+bridge behavior.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-narrative-option-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-narrative-option-action-slice.md
@@ -1,0 +1,53 @@
+# CLI Narrative Option Action Slice
+
+## Status
+
+Implemented local CLI/OpenSpec proof slice.
+
+## Purpose
+
+Keep `civ7 game play choose-narrative --options` aligned with the semantic
+player-agent output rule. Narrative option rows and empty-option dismissal
+guidance expose follow-up guidance as semantic descriptors, not command recipes.
+Command help remains responsible for exact flag combinations.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/choose-narrative.ts`
+- `packages/cli/test/commands/game.play.narrative.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-narrative-option-action-slice.md`
+
+## Boundary
+
+- `choose-narrative --options` now emits `surface: "narrative-choice-options"`.
+- Enabled option rows now expose `nextAction` and `validationAction`
+  descriptors.
+- Empty-option dismissal guidance now exposes `dismissalDiagnosticAction` and
+  `unprovenDismissalAction` descriptors.
+- Option output no longer emits `command`, `chooseCli`, `validateCli`,
+  `dismissalDiagnosticCli`, `unprovenDismissalCli`, or `game play ...` command
+  recipes.
+- This slice does not change narrative service behavior, parser flags, runtime
+  reads, direct-control validators, controller bridge, generated bundles,
+  play-thread state, deployed Civ7 proof, relationship authority, or parent Task
+  5.x/6.x/7.x acceptance.
+- Caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+
+## Proof Collected
+
+- `bun run --cwd packages/cli test -- game.play.narrative.test.ts`
+- `bun run check:cli`
+- Strict OpenSpec validates for `civ7-control-orpc-native-slice` and
+  `civ7-support-direct-control-modularization`.
+- Narrative options command-recipe output scan over changed CLI source/test.
+- Active approval/caller-permission scan over changed files.
+- Relationship-label safety scan over changed source/test.
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/OpenSpec proof only. It does not prove deployed Civ7 runtime
+behavior, change narrative service behavior, or prove controller bridge
+behavior.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notification-queue-next-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notification-queue-next-action-slice.md
@@ -1,0 +1,54 @@
+# CLI Notification Queue Next-Action Slice
+
+## Status
+
+Implemented local CLI/test/OpenSpec proof slice.
+
+## Purpose
+
+Keep `civ7 game play notification-queue` follow-up suggestions semantic instead
+of turning service `nextStep` objects back into literal CLI command recipes.
+The native service already owns queue disposition and next-step meaning; the
+CLI adapter should display that concise semantic guidance and leave exhaustive
+flag/interface detail to command help.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/notification-queue.ts`
+- `packages/cli/test/commands/game/play/notification/queue.test.ts`
+- `packages/civ7-control-orpc/src/modules/notifications/procedures/queue.ts`
+- `packages/civ7-control-orpc/test/notification-queue-procedure.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notification-queue-next-action-slice.md`
+
+## Boundary
+
+- JSON output preserves the service-owned `nextStep` objects and no longer adds
+  an adapter-only `command` field to queue rows.
+- Human-readable output prints the semantic next-step label, not a generated
+  command string.
+- Notification queue service classification uses semantic decision fields such
+  as `operationFamily`, not legacy direct-control `cli` hints.
+- The service contract, CLI parser flags, runtime direct-control reads,
+  controller bridge, generated bundles, approval/reason mechanics, play-thread
+  state, deployed Civ7 proof, and parent Task 5.x/6.x/7.x acceptance are
+  unchanged.
+
+## Proof Collected
+
+- `bun run test:cli:play -- game/play/notification/queue.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test test/notification-queue-procedure.test.ts`
+- `bun run check:cli`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Queue command-recipe output scan over the changed CLI source/test.
+- Active approval/caller-permission scan over changed files; hits are only
+  negative boundary wording.
+- `git diff --check`
+
+## Residual Risk
+
+This is local package/CLI proof only. It does not prove deployed Civ7 runtime
+behavior, change the notification queue service contract, or prove controller
+bridge behavior.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notifications-json-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notifications-json-action-slice.md
@@ -1,0 +1,52 @@
+# CLI Notifications JSON Action Slice
+
+## Status
+
+Implemented local CLI/OpenSpec proof slice.
+
+## Purpose
+
+Keep `civ7 game play notifications --json` aligned with the semantic
+player-agent output rule. The live notification HUD materializer may still
+carry legacy command recipe hints as low-level direct-control presentation
+debt, but the caller-facing CLI JSON should not publish `cli` command strings
+as the normal action surface.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/notifications.ts`
+- `packages/cli/test/commands/game/play/notification/hud.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notifications-json-action-slice.md`
+
+## Boundary
+
+- `notifications --json` now projects the notification view before output and
+  omits all `cli` fields from HUD decisions, decision details, option rows,
+  closeout candidates, and common actions.
+- The JSON output preserves semantic categories, operation families,
+  operation types, required inputs, common actions, option data, validation
+  evidence, notes, and blocker/notification evidence.
+- This slice does not change direct-control notification materialization,
+  control-oRPC service behavior, service contracts, parser flags, runtime
+  reads, controller bridge, generated bundles, play-thread state, deployed
+  Civ7 proof, relationship authority, or parent Task 5.x/6.x/7.x acceptance.
+- Caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+
+## Proof Collected
+
+- `bun run --cwd packages/cli test -- game/play/notification/hud.test.ts`
+- `bun run check:cli`
+- Strict OpenSpec validates for `civ7-control-orpc-native-slice` and
+  `civ7-support-direct-control-modularization`.
+- Notifications JSON command-recipe output scan over changed CLI source/test.
+- Active approval/caller-permission scan over changed files.
+- Relationship-label safety scan over changed source/test.
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/OpenSpec proof only. It does not prove deployed Civ7 runtime
+behavior, change the low-level direct-control notification materializer, change
+oRPC service behavior, or prove controller bridge behavior.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notifications-text-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notifications-text-action-slice.md
@@ -1,0 +1,54 @@
+# CLI Notifications Text Action Slice
+
+## Status
+
+Implemented local CLI/OpenSpec proof slice.
+
+## Purpose
+
+Keep `civ7 game play notifications` text output aligned with the semantic
+player-agent output rule. The non-JSON HUD renderer should describe the current
+decision/action semantically without printing exact command recipes. Command
+help remains responsible for exact flag combinations.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/notifications.ts`
+- `packages/cli/test/commands/game/play/notification/hud.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-notifications-text-action-slice.md`
+
+## Boundary
+
+- Text-mode Decision HUD rows now print `action: <category>` and operation
+  labels instead of `shortcut: <cli>`.
+- Text-mode notification rows now print `action: <category>` instead of
+  `cli: <command>`.
+- Text-mode common action rows omit command suffixes and keep only label and
+  timing guidance.
+- JSON output remains the raw direct-control notification view for diagnostic
+  fidelity; this slice does not remove upstream `cli` fields from JSON.
+- This slice does not change direct-control notification materialization, parser
+  flags, runtime behavior, controller bridge, generated bundles, play-thread
+  state, deployed Civ7 proof, relationship authority, or parent Task
+  5.x/6.x/7.x acceptance.
+- Caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+
+## Proof Collected
+
+- `bun run --cwd packages/cli test -- game/play/notification/hud.test.ts`
+- `bun run check:cli`
+- Strict OpenSpec validates for `civ7-control-orpc-native-slice` and
+  `civ7-support-direct-control-modularization`.
+- Notifications text command-recipe output scan over changed CLI source/test.
+- Active approval/caller-permission scan over changed files.
+- Relationship-label safety scan over changed source/test.
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/OpenSpec proof only. It does not prove deployed Civ7 runtime
+behavior, change notification materialization, or prove controller bridge
+behavior. JSON output still exposes the direct-control diagnostic view by
+design.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-priorities-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-priorities-orpc-slice.md
@@ -10,8 +10,8 @@ Route `civ7 game play priorities` through the native in-process
 `attention.priorities` server-side client. The control-oRPC service owns
 priority ranking, source-status, current HUD/ready actor, optional battlefield,
 and semantic next-step composition. The CLI remains an edge adapter that builds
-endpoint context and maps semantic next-step descriptors into command
-suggestions for CLI presentation only.
+endpoint context and presents semantic next-step descriptors without making CLI
+command syntax part of normal priority output.
 
 ## Write Set
 
@@ -32,9 +32,8 @@ suggestions for CLI presentation only.
 
 - CLI endpoint flags construct oRPC context; endpoint/session/state/raw command
   fields are not procedure input.
-- CLI output may include command suggestions, but those strings are mapped
-  locally from semantic service descriptors and are not part of the native
-  service contract.
+- CLI compact output presents semantic `nextAction` descriptors. Command help
+  remains the place for exact flag combinations.
 - The command stays read-only. It does not send unit/city/turn/progression
   operations or claim live runtime proof.
 - Normal JSON omits raw host, port, state, session, command, rawCommand, Tuner

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-progress-dashboard-orpc-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-progress-dashboard-orpc-slice.md
@@ -35,8 +35,8 @@ low-level App UI runtime progress evidence source.
 
 - `progression.dashboard.current` is a progression-domain read, not a broad
   read-wrapper catalog or `operations` root.
-- The service result uses semantic next-step descriptors. CLI command strings
-  remain caller-local presentation mapping in `packages/cli`.
+- The service and compact CLI result use semantic next-step descriptors.
+  Command help remains the place for exact flag combinations.
 - Normal service and CLI JSON omit raw host, port, state, session, command,
   rawCommand, direct-control runtime envelopes, approval/reason mechanics, and
   transport details.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-progression-choice-option-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-progression-choice-option-action-slice.md
@@ -1,0 +1,55 @@
+# CLI Progression Choice Option Action Slice
+
+## Status
+
+Implemented local CLI/OpenSpec proof slice.
+
+## Purpose
+
+Keep `civ7 game play choose-tech --options` and
+`civ7 game play choose-culture --options` aligned with the semantic
+player-agent output rule. Option rows should expose follow-up guidance as
+semantic descriptors, not `chooseCli`, `targetCli`, or `validateCli` command
+recipes. Command help remains responsible for exact flag combinations.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/choose-tech.ts`
+- `packages/cli/src/commands/game/play/choose-culture.ts`
+- `packages/cli/test/commands/game.play.technology.test.ts`
+- `packages/cli/test/commands/game.play.culture.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-progression-choice-option-action-slice.md`
+
+## Boundary
+
+- `choose-tech --options` now emits `surface: "technology-choice-options"` and
+  enabled row `nextAction`, `targetAction`, and `validationAction` descriptors.
+- `choose-culture --options` now emits `surface: "culture-choice-options"` and
+  enabled row `nextAction`, `targetAction`, and `validationAction` descriptors.
+- Option output no longer emits `chooseCli`, `targetCli`, `validateCli`, or
+  `game play ...` command recipes.
+- This slice does not change progression choice service behavior, parser flags,
+  runtime reads, direct-control validators, controller bridge, generated
+  bundles, play-thread state, deployed Civ7 proof, relationship authority, or
+  parent Task 5.x/6.x/7.x acceptance.
+- Caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+
+## Proof Collected
+
+- `bun run --cwd packages/cli test -- game.play.technology.test.ts game.play.culture.test.ts`
+- `bun run check:cli`
+- Strict OpenSpec validates for `civ7-control-orpc-native-slice` and
+  `civ7-support-direct-control-modularization`.
+- Technology/culture options command-recipe output scan over changed CLI
+  source/test.
+- Active approval/caller-permission scan over changed files.
+- Relationship-label safety scan over changed source/test.
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/OpenSpec proof only. It does not prove deployed Civ7 runtime
+behavior, change progression service behavior, or prove controller bridge
+behavior.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-ready-city-compact-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-ready-city-compact-action-slice.md
@@ -1,0 +1,51 @@
+# CLI Ready-City Compact Action Slice
+
+## Status
+
+Implemented local CLI/OpenSpec proof slice.
+
+## Purpose
+
+Keep `civ7 game play ready-city --compact` aligned with the semantic
+player-agent output rule. Compact city rows should expose production,
+population-placement, and expansion follow-up guidance as semantic descriptors,
+not direct-control `cli`/`cliHints` command recipes. Command help remains
+responsible for exact flag combinations.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/ready-city.ts`
+- `packages/cli/test/commands/game/play/ready-city.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-ready-city-compact-action-slice.md`
+
+## Boundary
+
+- `ready-city --compact` now emits `surface: "ready-city"`, row-level
+  `nextAction` descriptors, and top-level `nextAction` for the first compact
+  action candidate.
+- Compact output no longer emits direct-control `cli` strings, `cliHints`, or
+  `game play ...` command recipes.
+- This slice does not change direct-control ready-city source behavior,
+  runtime reads, parser flags, service contracts, controller bridge, generated
+  bundles, play-thread state, deployed Civ7 proof, relationship authority, or
+  parent Task 5.x/6.x/7.x acceptance.
+- Caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+
+## Proof Collected
+
+- `bun run --cwd packages/cli test -- game/play/ready-city.test.ts`
+- `bun run check:cli`
+- Strict OpenSpec validates for `civ7-control-orpc-native-slice` and
+  `civ7-support-direct-control-modularization`.
+- Compact ready-city command-recipe output scan over changed CLI source/test.
+- Active approval/caller-permission scan over changed files.
+- Relationship-label safety scan over changed source/test.
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/OpenSpec proof only. It does not prove deployed Civ7 runtime
+behavior, change the underlying direct-control ready-city source, or prove
+controller bridge behavior.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-rehydrate-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-rehydrate-action-slice.md
@@ -1,0 +1,49 @@
+# CLI Rehydrate Action Slice
+
+## Status
+
+Implemented local CLI/OpenSpec proof slice.
+
+## Purpose
+
+Keep `civ7 game play rehydrate` aligned with the semantic player-agent output
+rule. Restart snapshots should tell the agent which kind of follow-up is useful
+without embedding exact CLI recipes in `commonActions`. Command help remains
+responsible for exact flag combinations.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/rehydrate.ts`
+- `packages/cli/test/commands/game.play.rehydrate.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-rehydrate-action-slice.md`
+
+## Boundary
+
+- Rehydrate `commonActions` now emit semantic `kind`, `parameters`, `readOnly`,
+  and `sendsMutation` descriptors instead of `cli` command recipes.
+- The text-mode output prints the semantic action kind instead of a command
+  recipe.
+- This slice does not change direct-control notification/ready-unit reads,
+  continuity checks, parser flags, runtime behavior, controller bridge,
+  generated bundles, play-thread state, deployed Civ7 proof, relationship
+  authority, or parent Task 5.x/6.x/7.x acceptance.
+- Caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+
+## Proof Collected
+
+- `bun run --cwd packages/cli test -- game.play.rehydrate.test.ts`
+- `bun run check:cli`
+- Strict OpenSpec validates for `civ7-control-orpc-native-slice` and
+  `civ7-support-direct-control-modularization`.
+- Rehydrate common-action command-recipe output scan over changed CLI
+  source/test.
+- Active approval/caller-permission scan over changed files.
+- Relationship-label safety scan over changed source/test.
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/OpenSpec proof only. It does not prove deployed Civ7 runtime
+behavior, change rehydrate runtime reads, or prove controller bridge behavior.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-traditions-compact-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-traditions-compact-action-slice.md
@@ -1,0 +1,51 @@
+# CLI Traditions Compact Action Slice
+
+## Status
+
+Implemented local CLI/OpenSpec proof slice.
+
+## Purpose
+
+Keep `civ7 game play traditions --compact` aligned with the semantic
+player-agent output rule. Compact tradition rows should expose the available
+policy action as a small descriptor, not as repeated `change-tradition` command
+recipes. Command help remains responsible for exact flag combinations.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/traditions.ts`
+- `packages/cli/test/commands/game.play.progression-read.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-traditions-compact-action-slice.md`
+
+## Boundary
+
+- `traditions --compact` now emits `surface: "traditions"`, row-level
+  `nextAction` descriptors, and validation-success-only `recommendedActions`
+  for enabled available traditions.
+- Compact output no longer emits `validateCli`, `sendCli`, `sendCloseoutCli`,
+  `recommendedCli`, or `game play change-tradition ...` command recipes.
+- This slice does not change `progression.traditions.current` service behavior,
+  service contracts, runtime direct-control reads, parser flags, controller
+  bridge, generated bundles, play-thread state, deployed Civ7 proof,
+  relationship authority, or parent Task 5.x/6.x/7.x acceptance.
+- Caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+
+## Proof Collected
+
+- `bun run --cwd packages/cli test -- game.play.progression-read.test.ts`
+- `bun run check:cli`
+- Focused validation-failed tradition fixture proving disabled options do not
+  appear in send-oriented `recommendedActions`.
+- Strict OpenSpec validates for `civ7-control-orpc-native-slice` and
+  `civ7-support-direct-control-modularization`.
+- Compact traditions command-recipe output scan over changed CLI source/test.
+- Active approval/caller-permission scan over changed files.
+- Relationship-label safety scan over changed source/test.
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/OpenSpec proof only. It does not prove deployed Civ7 runtime
+behavior, change oRPC service behavior, or prove controller bridge behavior.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-traditions-compact-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-traditions-compact-action-slice.md
@@ -20,9 +20,10 @@ recipes. Command help remains responsible for exact flag combinations.
 
 ## Boundary
 
-- `traditions --compact` now emits `surface: "traditions"`, row-level
-  `nextAction` descriptors, and validation-success-only `recommendedActions`
-  for enabled available traditions.
+- `traditions --compact` now emits `surface: "traditions"` and row-level
+  `nextAction` descriptors. Validation-success options may expose send-oriented
+  actions; failed/null validation rows stay read-only validation guidance and do
+  not enter `recommendedActions`.
 - Compact output no longer emits `validateCli`, `sendCli`, `sendCloseoutCli`,
   `recommendedCli`, or `game play change-tradition ...` command recipes.
 - This slice does not change `progression.traditions.current` service behavior,
@@ -36,8 +37,9 @@ recipes. Command help remains responsible for exact flag combinations.
 
 - `bun run --cwd packages/cli test -- game.play.progression-read.test.ts`
 - `bun run check:cli`
-- Focused validation-failed tradition fixture proving disabled options do not
-  appear in send-oriented `recommendedActions`.
+- Focused validation-failed tradition fixture proving disabled options remain
+  read-only row guidance and do not appear in send-oriented
+  `recommendedActions`.
 - Strict OpenSpec validates for `civ7-control-orpc-native-slice` and
   `civ7-support-direct-control-modularization`.
 - Compact traditions command-recipe output scan over changed CLI source/test.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-unit-move-preview-next-action-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/cli-unit-move-preview-next-action-slice.md
@@ -1,0 +1,50 @@
+# CLI Unit Move Preview Next-Action Slice
+
+## Status
+
+Implemented local CLI/OpenSpec proof slice.
+
+## Purpose
+
+Keep `civ7 game play unit-move-preview --compact` action guidance semantic.
+The compact movement preview should help the player-agent decide the next
+movement validation target without expanding that into literal
+command-and-flag recipes. Command help remains responsible for exhaustive
+interface detail.
+
+## Write Set
+
+- `packages/cli/src/commands/game/play/unit-move-preview.ts`
+- `packages/cli/test/commands/game/play/unit-move-preview.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/cli-unit-move-preview-next-action-slice.md`
+
+## Boundary
+
+- Compact JSON now exposes semantic `nextAction` descriptors for the requested
+  destination and candidate plot rows.
+- The compact output no longer emits `game play unit-target ...` recipes or a
+  CLI command string as the output surface identifier.
+- This slice does not change runtime direct-control reads, parser flags,
+  service contracts, controller bridge, generated bundles, play-thread state,
+  deployed Civ7 proof, relationship authority, or parent Task 5.x/6.x/7.x
+  acceptance.
+- Caller-provided approval remains retired and no approval-reason mechanic is
+  introduced.
+
+## Proof Collected
+
+- `bun run test:cli:play -- game/play/unit-move-preview.test.ts`
+- `bun run check:cli`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Unit-move-preview command-recipe output scan over changed CLI source/test.
+- Active approval/caller-permission scan over changed files; no active hits.
+- Relationship-label safety scan over changed source/test.
+- `git diff --check`
+
+## Residual Risk
+
+This is local CLI/OpenSpec proof only. It does not prove deployed Civ7 runtime
+behavior, change movement-preview runtime evidence, or prove controller bridge
+behavior.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/notification-action-hint-simplification-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/notification-action-hint-simplification-slice.md
@@ -1,0 +1,53 @@
+# Notification Action Hint Simplification Slice
+
+## Status
+
+Implemented local source, test, and OpenSpec proof slice.
+
+## Purpose
+
+Simplify notification action directions so they help the player/agent choose
+the next semantic move instead of restating every dry-run and send flag
+variant. The command help and typed command hierarchy own interface detail;
+notification hints should carry only the differentiating context needed to
+play the blocker responsibly.
+
+## Write Set
+
+- `packages/civ7-direct-control/src/play/notifications/view.ts`
+- `packages/civ7-direct-control/test/play-notification-view.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/notification-action-hint-simplification-slice.md`
+
+## Boundary
+
+- Named blocker actions are send-oriented where a semantic send surface exists:
+  city expansion, town focus/review closeout, production, diplomacy,
+  narrative, and advisor-warning directions no longer duplicate separate
+  dry-run validation entries.
+- Read actions still point to the relevant option/candidate reader when live
+  evidence is needed before choosing a move.
+- Generic operation validation fallbacks remain for cases without a named
+  semantic shortcut.
+- No CLI parser behavior, oRPC contract/router/middleware, controller bridge
+  schema, generated bundle, direct-control runtime behavior, approval/reason
+  mechanic, play-thread action, runtime/live proof claim, or parent
+  Task 5.x/6.x/7.x acceptance is introduced.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-direct-control test test/play-notification-view.test.ts`
+- `bun run --cwd packages/civ7-direct-control check`
+- `bun run --cwd packages/civ7-direct-control build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Stale validation-only action hint scan for removed named blocker directions.
+- Active approval/caller-permission scan over changed files; hits are only
+  negative boundary wording.
+- `git diff --check`
+
+## Residual Risk
+
+This is local source/test proof only. It does not prove deployed Civ7 runtime
+behavior, controller bridge behavior, or close broader runtime/product
+acceptance.

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-traditions-omitted-metadata-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/progression-traditions-omitted-metadata-slice.md
@@ -1,0 +1,51 @@
+# Progression Traditions Omitted Metadata Slice
+
+## Status
+
+Implemented local package/CLI proof slice.
+
+## Purpose
+
+Keep `progression.traditions.current` omission metadata semantic. The service
+already omits command strings and low-level runtime probes from normal output;
+the omission records should name service-level presentation/runtime evidence
+categories instead of direct-control or CLI implementation field paths.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/modules/progression/procedures/traditions-current.ts`
+- `packages/civ7-control-orpc/test/progression-traditions-procedure.test.ts`
+- `packages/cli/test/commands/game.play.progression-read.test.ts`
+- `openspec/changes/civ7-control-orpc-native-slice/tasks.md`
+- `openspec/changes/civ7-control-orpc-native-slice/workstream/progression-traditions-omitted-metadata-slice.md`
+
+## Boundary
+
+- `progression.traditions.current` now reports omitted
+  `presentation.commandSuggestions`, `presentation.actionDirections`, and
+  `runtime.validationProbe` categories.
+- The output continues to omit CLI command strings, raw endpoint/session/state
+  fields, direct-control runtime envelopes, and approval/reason mechanics.
+- CLI compact traditions output still maps service semantics into CLI-local
+  presentation; this slice does not change parser flags or command help.
+- Service contract shape, runtime direct-control reads, controller bridge,
+  generated bundles, play-thread state, deployed Civ7 proof, and parent
+  Task 5.x/6.x/7.x acceptance are unchanged.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test test/progression-traditions-procedure.test.ts`
+- `bun run test:cli:play -- game.play.progression-read.test.ts`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run check:cli`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- Service omission metadata scan over changed source/tests.
+- Active approval/caller-permission scan over changed files; no active hits.
+- `git diff --check`
+
+## Residual Risk
+
+This is local package/CLI proof only. It does not prove deployed Civ7 runtime
+behavior, change the progression traditions service contract shape, or prove
+controller bridge behavior.

--- a/packages/civ7-control-orpc/src/modules/notifications/procedures/queue.ts
+++ b/packages/civ7-control-orpc/src/modules/notifications/procedures/queue.ts
@@ -296,7 +296,7 @@ function dispositionFor(item: QueueItem): QueueStep["disposition"] {
     return "reviewed-dismissal-candidate";
   }
   if (item.category === "unit-command") return "inspect-ready-unit";
-  if (item.operationFamily || item.cli) return "operate-with-live-inputs";
+  if (item.operationFamily) return "operate-with-live-inputs";
   if (item.category === "notification" || item.category === "blocking-notification") {
     return "inspect-handler";
   }

--- a/packages/civ7-control-orpc/src/modules/progression/procedures/traditions-current.ts
+++ b/packages/civ7-control-orpc/src/modules/progression/procedures/traditions-current.ts
@@ -74,15 +74,15 @@ function progressionTraditionsResult(
     traditions,
     omitted: [
       {
-        path: "directControl.cliCommandSuggestions",
-        reason: "CLI command strings are caller presentation, not progression service output.",
+        path: "presentation.commandSuggestions",
+        reason: "Command-string suggestions are caller presentation, not progression service output.",
       },
       {
-        path: "tradition.actionHints[].cli",
-        reason: "Tradition action hints are projected as semantic action descriptors with parameters.",
+        path: "presentation.actionDirections",
+        reason: "Action directions are projected as semantic descriptors with parameters.",
       },
       {
-        path: "tradition.actionHints[].validation",
+        path: "runtime.validationProbe",
         reason: "Validation probe details remain low-level runtime evidence; service rows expose validationSuccess.",
       },
     ],

--- a/packages/civ7-control-orpc/test/notification-queue-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/notification-queue-procedure.test.ts
@@ -70,6 +70,42 @@ describe("notifications.queue control-oRPC procedures", () => {
     expectSafeQueueOutput(result);
   });
 
+  test("does not use legacy cli hints as operation classification evidence", async () => {
+    const fake = fakeContext({
+      notificationView: {
+        ...notificationView(),
+        hud: {
+          nextDecision: null,
+          decisionQueue: [
+            queueItem({
+              notificationId: { owner: 0, id: 116, type: 20 },
+              category: "blocking-notification",
+              typeName: "NOTIFICATION_UNKNOWN_BLOCKER",
+              summary: "Unknown blocker",
+              operationFamily: null,
+              operationType: null,
+              cli: "game play choose-tech --options --json",
+            }),
+          ],
+        },
+      },
+    });
+
+    const result = await call(
+      Civ7ControlOrpcRouter.notifications.queue.current,
+      {},
+      { context: fake.context },
+    );
+
+    expect(result.schedule).toEqual([
+      expect.objectContaining({
+        disposition: "inspect-handler",
+        nextStep: expect.objectContaining({ kind: "inspect-notification" }),
+      }),
+    ]);
+    expectSafeQueueOutput(result);
+  });
+
   test("bulk dismisses only safe informational queue candidates and keeps aggregate no-repeat guarded", async () => {
     const fake = fakeContext({
       dismissalResult: notificationDismissalResult("engine-front-still-live", {
@@ -243,6 +279,7 @@ describe("notifications.queue control-oRPC procedures", () => {
 
 function fakeContext(options: {
   notificationViewError?: Error;
+  notificationView?: Civ7ControlOrpcPlayNotificationViewResult;
   dismissalResult?: Civ7ControlOrpcNotificationDismissalResult;
 } = {}): {
   context: Civ7ControlOrpcContext;
@@ -272,7 +309,7 @@ function fakeContext(options: {
         getCiv7PlayNotificationView: async (input) => {
           calls.notifications.push(input);
           if (options.notificationViewError) throw options.notificationViewError;
-          return notificationView();
+          return options.notificationView ?? notificationView();
         },
         requestCiv7NotificationDismissal: async (input, endpointDefaults) => {
           calls.dismissals.push({ input, options: endpointDefaults });

--- a/packages/civ7-control-orpc/test/progression-traditions-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/progression-traditions-procedure.test.ts
@@ -65,12 +65,19 @@ describe("progression traditions control-oRPC procedure", () => {
       source: "progression.traditions.current",
       label: "Inspect available tradition action descriptors before requesting a tradition change.",
     }]);
+    expect(result.omitted.map((item) => item.path)).toEqual([
+      "presentation.commandSuggestions",
+      "presentation.actionDirections",
+      "runtime.validationProbe",
+    ]);
 
     const serialized = JSON.stringify(result);
     expect(serialized).not.toContain("\"host\"");
     expect(serialized).not.toContain("\"port\"");
     expect(serialized).not.toContain("\"state\"");
     expect(serialized).not.toContain("\"command\"");
+    expect(serialized).not.toContain("cliCommandSuggestions");
+    expect(serialized).not.toContain("actionHints[].cli");
     expect(serialized).not.toContain("recommendedCli");
     expect(serialized).not.toContain("game play ");
     expect(serialized).not.toContain("CMD:");

--- a/packages/civ7-direct-control/src/play/notifications/view.ts
+++ b/packages/civ7-direct-control/src/play/notifications/view.ts
@@ -1351,7 +1351,6 @@ export function playNotificationViewSource(): string {
           [requiredInput("ProgressionTreeNodeType", "live tech chooser/tree node", "Use the runtime node type hash from GameInfo/progression tree data, not the row index or notification id.")],
           [
             action("choose tech", "game play choose-tech --node <node> --send", "sequence", "SET_TECH_TREE_NODE then SET_TECH_TREE_TARGET_NODE", "{ ProgressionTreeNodeType: node } then { ProgressionTreeNodeType: NO_NODE }", "when one caller action should start research and finish the chooser workflow"),
-            action("validate tech choice", "game play choose-tech --player-id <id> --node <node>", "player-operation", "SET_TECH_TREE_NODE", "{ ProgressionTreeNodeType }", "after reading the candidate node"),
             action("set tech target", "game play set-tech-target --node <node> --send", "player-operation", "SET_TECH_TREE_TARGET_NODE", "{ ProgressionTreeNodeType }", "when the full tree UI targets a node or choose-node alone leaves the blocker unresolved"),
           ],
           ["Read the live tech node id before sending; choose-tech send mode mirrors the chooser by clearing the temporary target internally."],
@@ -1368,8 +1367,7 @@ export function playNotificationViewSource(): string {
           [requiredInput("ProgressionTreeNodeType", "live culture chooser/tree node", "Use the runtime node type hash from GameInfo/progression tree data, not the row index or notification id.")],
           [
             action("choose culture and close chooser", "game play choose-culture --node <node> --send", "sequence", "SET_CULTURE_TREE_NODE then SET_CULTURE_TREE_TARGET_NODE", "{ ProgressionTreeNodeType: node } then { ProgressionTreeNodeType: NO_NODE }", "when one caller action should start culture and close the chooser surface"),
-            action("read culture options", "game play choose-culture --options --json", undefined, undefined, "enabled culture nodes with validation and ready send templates", "before choosing a culture node"),
-            action("validate culture choice", "game play choose-culture --player-id <id> --node <node>", "player-operation", "SET_CULTURE_TREE_NODE", "{ ProgressionTreeNodeType }", "after reading the candidate node"),
+            action("read culture options", "game play choose-culture --options --json", undefined, undefined, "enabled culture nodes", "before choosing a culture node"),
             action("set culture target", "game play set-culture-target --node <node> --send", "player-operation", "SET_CULTURE_TREE_TARGET_NODE", "{ ProgressionTreeNodeType }", "when the full tree UI targets a node or choose-node alone leaves the blocker unresolved"),
           ],
           ["Read options from the live culture chooser before sending; send mode also clears the temporary culture target as one caller-level selection."],
@@ -1385,7 +1383,7 @@ export function playNotificationViewSource(): string {
           "official-ui",
           [requiredInput("GovernmentType", "live government picker option", "Use the government index from choose-government --options, not the visible row position.")],
           [
-            action("read government options", "game play choose-government --options --json", undefined, undefined, "enabled starting governments with validation and ready send templates", "before choosing a government"),
+            action("read government options", "game play choose-government --options --json", undefined, undefined, "enabled starting governments", "before choosing a government"),
             action("choose government", "game play choose-government --government-type <government-type> --action <action> --send", "player-operation", "CHANGE_GOVERNMENT", "{ GovernmentType, Action: Activate }", "after reading the live government option"),
           ],
           ["Read options from the live government picker before sending; the option surface includes celebration effects for context."],
@@ -1401,7 +1399,7 @@ export function playNotificationViewSource(): string {
           "official-ui",
           [requiredInput("GoldenAgeType", "live celebration chooser option", "Use the GoldenAgeType hash from choose-celebration --options, not old examples or visible row position.")],
           [
-            action("read celebration options", "game play choose-celebration --options --json", undefined, undefined, "enabled celebration choices with validation and ready send templates", "before choosing a celebration"),
+            action("read celebration options", "game play choose-celebration --options --json", undefined, undefined, "enabled celebration choices", "before choosing a celebration"),
             action("choose celebration", "game play choose-celebration --golden-age-type <golden-age-type> --send", "player-operation", "CHOOSE_GOLDEN_AGE", "{ GoldenAgeType }", "after reading the live celebration option"),
           ],
           ["Read options from the live celebration chooser before sending; this blocker is not dismissible and should not use notification dismissal."],
@@ -1422,7 +1420,7 @@ export function playNotificationViewSource(): string {
           [
             action("read city placement candidates", "game play ready-city --compact --json", "read-only", "ready-city population placement packet", "workable plots and expansion candidates", "before choosing assign-worker or expand-city"),
             action("assign worker to proven plot", "game play assign-worker --location <plot-index> --send", "player-operation", "ASSIGN_WORKER", "{ Location, Amount: 1 }", "when the chosen tile is already workable"),
-            action("validate city expansion", "game play expand-city --city-id '<city-id>' --x <x> --y <y>", "city-command", "EXPAND", "{ X, Y }", "when the chosen tile is an expansion purchase"),
+            action("expand city", "game play expand-city --city-id '<city-id>' --x <x> --y <y> --send", "city-command", "EXPAND", "{ X, Y }", "when the chosen tile is an expansion purchase"),
           ],
           ["The notification opens acquire-tile mode; the clicked plot determines whether worker assignment or expansion fires. Re-read candidates before choosing either branch."],
         );
@@ -1459,11 +1457,10 @@ export function playNotificationViewSource(): string {
             requiredInput("ProjectType", "live town focus option", "Paired project enum for the selected focus."),
           ],
           [
-            action("set town focus and close review", "game play set-town-focus --city-id '<city-id>' --growth-type <type> --project-type <project-type> --send --closeout", "sequence", "CHANGE_GROWTH_MODE then CONSIDER_TOWN_PROJECT", "{ Type, ProjectType, City } then {}", "when the selected focus should be applied and the blocker closed as one caller workflow"),
-            action("set town focus", "game play set-town-focus --city-id '<city-id>' --growth-type <type> --project-type <project-type>", "city-command", "CHANGE_GROWTH_MODE", "{ Type, ProjectType, City }", "when only validation or a single focus operation is wanted"),
-            action("close reviewed town project", "game play consider-town-project --city-id '<city-id>'", "city-operation", "CONSIDER_TOWN_PROJECT", "{}", "after the focus has already been set and the UI still needs closeout"),
+            action("set town focus", "game play set-town-focus --city-id '<city-id>' --growth-type <type> --project-type <project-type> --send", "city-command", "CHANGE_GROWTH_MODE", "{ Type, ProjectType, City }", "when the selected focus should be applied"),
+            action("close town project review", "game play consider-town-project --city-id '<city-id>' --send", "city-operation", "CONSIDER_TOWN_PROJECT", "{}", "after the focus has already been set and the UI still needs closeout"),
           ],
-          ["Town focus is not city-operation BUILD; use --closeout when one caller action should apply the focus and clear the review surface."],
+          ["Town focus is not city-operation BUILD; set the focus first, then close the review if the UI still requires it."],
         );
       }
       if (stringIncludes(haystack, "CHOOSE_CITY_PRODUCTION") || stringIncludes(haystack, "PRODUCTION")) {
@@ -1481,9 +1478,9 @@ export function playNotificationViewSource(): string {
           ],
           [
             action("read production candidates", "game play ready-city --compact --json", "read-only", "ready-city production candidate packet", "city summary and validated production candidates", "before choosing a production item"),
-            action("validate production", "game play build-production --city-id '<city-id>' --unit-type <unit-type>", "city-operation", "BUILD", "{ UnitType }", "when the live choice is a unit"),
-            action("place constructible production", "game play build-production --city-id '<city-id>' --constructible-type <constructible-type> --x <x> --y <y>", "city-operation", "BUILD", "{ ConstructibleType, X, Y }", "when validator or placement UI returns legal placement plots"),
-            action("validate city project production", "game play build-production --city-id '<city-id>' --project-type <project-type>", "city-operation", "BUILD", "{ ProjectType }", "when the live choice is an ordinary city project, not town focus"),
+            action("build unit production", "game play build-production --city-id '<city-id>' --unit-type <unit-type> --send", "city-operation", "BUILD", "{ UnitType }", "when the live choice is a unit"),
+            action("place constructible production", "game play build-production --city-id '<city-id>' --constructible-type <constructible-type> --x <x> --y <y> --send", "city-operation", "BUILD", "{ ConstructibleType, X, Y }", "when validator or placement UI returns legal placement plots"),
+            action("build city project", "game play build-production --city-id '<city-id>' --project-type <project-type> --send", "city-operation", "BUILD", "{ ProjectType }", "when the live choice is an ordinary city project, not town focus"),
           ],
           ["Use live chooser data to decide the item kind; constructible placement needs X/Y when the validator returns legal plots."],
         );
@@ -1497,7 +1494,7 @@ export function playNotificationViewSource(): string {
           "game play respond-first-meet",
           "live-proof",
           [
-            requiredInput("Player1", "local player id", "Usually the same value used as --player-id."),
+            requiredInput("Player1", "local player evidence", "Send mode derives this from the current local-player context."),
             requiredInput("Player2", "met player id", "Read this from the live first-meet notification or diplomacy panel."),
             requiredInput("Type", "chosen first-meet greeting", "Use the first-meet response enum from the live UI, not ordinary Support/Accept/Reject diplomacy response enums."),
           ],
@@ -1521,7 +1518,6 @@ export function playNotificationViewSource(): string {
           ],
           [
             action("choose diplomacy response and close blocker", "game play respond-diplomacy --action-id <action-id> --response-type <response-type> --notification-id '<notification-id>' --send", "player-operation", "RESPOND_DIPLOMATIC_ACTION", "{ ID, Type }", "after choosing one enabled response option from notification details"),
-            action("validate diplomacy response", "game play respond-diplomacy --action-id <action-id> --response-type <response-type>", "player-operation", "RESPOND_DIPLOMATIC_ACTION", "{ ID, Type }", "for dry-run validation only"),
           ],
           ["Use the enabled option list from the live notification details; send mode follows the official local-player response panel path and verifies notification/turn closeout."],
         );
@@ -1661,9 +1657,8 @@ export function playNotificationViewSource(): string {
             requiredInput("Action", "story option activation", "Official narrative UI sends PlayerOperationParameters.Activate."),
           ],
           [
-            action("read narrative options", "game play choose-narrative --options --json", undefined, undefined, "enabled narrative buttons with validation and ready send templates", "before choosing a narrative branch or closeout"),
+            action("read narrative options", "game play choose-narrative --options --json", undefined, undefined, "enabled narrative buttons", "before choosing a narrative branch or closeout"),
             action("send narrative choice", "game play choose-narrative --target-type <target-type> --target '<target>' --action <action> --send", "player-operation", "CHOOSE_NARRATIVE_STORY_DIRECTION", "{ TargetType, Target, Action }", "after choosing one enabled narrative option from the live story UI"),
-            action("validate narrative choice", "game play choose-narrative --player-id <id> --target-type <target-type> --target '<target>' --action <action>", "player-operation", "CHOOSE_NARRATIVE_STORY_DIRECTION", "{ TargetType, Target, Action }", "after reading the option key and activation from the story UI"),
           ],
           ["Use the option reader before sending; the notification target can be invalid because official narrative UI derives the target story from Players.Stories. If no pending story id is present, do not synthesize a narrative operation; inspect dismissal postcondition evidence separately."],
         );
@@ -1717,7 +1712,7 @@ export function playNotificationViewSource(): string {
           "live-proof",
           [requiredInput("Target", "notification ComponentID", "Use the notification id itself as Target.")],
           [
-            action("mark advisor warning viewed", "game play advisor-warning --player-id <id> --target '<notification-id>'", "player-operation", "VIEWED_ADVISOR_WARNING", "{ Target: notificationComponentId }", "when the warning has been inspected"),
+            action("mark advisor warning viewed", "game play advisor-warning --target '<notification-id>' --send", "player-operation", "VIEWED_ADVISOR_WARNING", "{ Target: notificationComponentId }", "when the warning has been inspected"),
           ],
           ["Do not use raw notification dismissal for advisor blockers."],
         );

--- a/packages/civ7-direct-control/test/play-notification-view.test.ts
+++ b/packages/civ7-direct-control/test/play-notification-view.test.ts
@@ -80,10 +80,28 @@ describe("getCiv7PlayNotificationView", () => {
       expect(notificationRead).toContain("game play buy-attribute --node <node> --send");
       expect(notificationRead).toContain("game play consider-traditions --send");
       expect(notificationRead).toContain("game play consider-attributes --send");
+      expect(notificationRead).toContain("game play expand-city --city-id '<city-id>' --x <x> --y <y> --send");
+      expect(notificationRead).toContain("game play set-town-focus --city-id '<city-id>' --growth-type <type> --project-type <project-type> --send");
+      expect(notificationRead).toContain("game play consider-town-project --city-id '<city-id>' --send");
+      expect(notificationRead).toContain("game play build-production --city-id '<city-id>' --unit-type <unit-type> --send");
+      expect(notificationRead).toContain("game play build-production --city-id '<city-id>' --project-type <project-type> --send");
+      expect(notificationRead).toContain("game play advisor-warning --target '<notification-id>' --send");
       expect(notificationRead).not.toContain("game play change-tradition --player-id <id> --tradition-type <tradition-type> --action <action> --send");
       expect(notificationRead).not.toContain("game play buy-attribute --player-id <id> --node <node> --send");
+      expect(notificationRead).not.toContain("game play advisor-warning --player-id <id> --target '<notification-id>'");
+      expect(notificationRead).not.toContain("set town focus and close review");
+      expect(notificationRead).not.toContain("close reviewed town project");
+      expect(notificationRead).not.toContain("validate tech choice");
+      expect(notificationRead).not.toContain("validate culture choice");
+      expect(notificationRead).not.toContain("validate diplomacy response");
+      expect(notificationRead).not.toContain("validate narrative choice");
+      expect(notificationRead).not.toContain("validate city expansion");
+      expect(notificationRead).not.toContain("validate production");
+      expect(notificationRead).not.toContain("validate city project production");
       expect(notificationRead).not.toContain("validate tradition change");
       expect(notificationRead).not.toContain("validate attribute purchase");
+      expect(notificationRead).not.toContain("when only validation");
+      expect(notificationRead).not.toContain("with validation and ready send templates");
     } finally {
       await server.close();
     }
@@ -149,13 +167,13 @@ function playNotificationView() {
       commonActions: [
         {
           label: "Set town focus",
-          cli: "game play set-town-focus --city-id '<city-id>' --growth-type <type> --project-type <project-type>",
-          when: "after choosing a live town focus option",
+          cli: "game play set-town-focus --city-id '<city-id>' --growth-type <type> --project-type <project-type> --send",
+          when: "when the selected focus should be applied",
         },
       ],
       confidence: "live-proof" as const,
       notes: [
-        "Town focus is not city-operation BUILD; use --closeout when one caller action should apply the focus and clear the review surface.",
+        "Town focus is not city-operation BUILD; set the focus first, then close the review if the UI still requires it.",
       ],
     },
   };

--- a/packages/cli/src/commands/game/play/choose-celebration.ts
+++ b/packages/cli/src/commands/game/play/choose-celebration.ts
@@ -10,6 +10,14 @@ import {
 
 const CHOOSE_GOLDEN_AGE = 'CHOOSE_GOLDEN_AGE';
 
+type CelebrationOptionAction = {
+  kind: 'choose-celebration' | 'validate-celebration-choice';
+  label: string;
+  parameters: Record<string, unknown>;
+  readOnly: boolean;
+  sendsMutation: boolean;
+};
+
 export default class GamePlayChooseCelebration extends Command {
   static id = 'game play choose-celebration';
   static summary = 'Validate or choose a celebration bonus';
@@ -62,18 +70,18 @@ export default class GamePlayChooseCelebration extends Command {
       const details = celebrationChoiceDetails(view);
       const surfaces = details.map(compactCelebrationChoiceSurface);
       emitPlayResult(this.log.bind(this), flags.json, {
-        command: 'game play choose-celebration --options',
+        surface: 'celebration-choice-options',
         surfaces,
         enabledOptionCount: surfaces.reduce((count, surface) => count + surface.enabledOptions.length, 0),
         disabledOptionCount: surfaces.reduce((count, surface) => count + surface.disabledOptionCount, 0),
         omitted: [
-          { path: 'details[].options', reason: 'use game play notifications --json for raw option and validation evidence' },
+          { path: 'details[].options', reason: 'use full notification JSON for raw option and validation evidence' },
           { path: 'details[].disabledOptions', reason: 'disabled choices are counted here; use notifications --json when disabled-choice evidence matters' },
           { path: 'details[].choices', reason: 'official chooser source choices are summarized per enabled row' },
         ],
         notes: [
           'Options come from the live notification HUD materializer, which mirrors the official celebration chooser and validates CHOOSE_GOLDEN_AGE through PlayerOperations.',
-          'Use a returned enabled option cli as the single caller-level celebration choice.',
+          'Action guidance is semantic; command help owns exact flag combinations.',
         ],
       });
       return;
@@ -143,8 +151,8 @@ function compactCelebrationChoiceSurface(details: Record<string, unknown>): {
       name: option.name,
       description: option.description,
       duration: option.duration,
-      chooseCli: celebrationChoiceSendCli(option),
-      validateCli: option.validateCli,
+      nextAction: celebrationOptionAction('choose-celebration', option),
+      validationAction: celebrationOptionAction('validate-celebration-choice', option),
     }));
   return {
     kind: 'celebration-choice-options',
@@ -158,9 +166,23 @@ function compactCelebrationChoiceSurface(details: Record<string, unknown>): {
   };
 }
 
-function celebrationChoiceSendCli(option: Record<string, unknown>): string | null {
-  if (typeof option.goldenAgeType !== 'number') return null;
-  return `game play choose-celebration --golden-age-type ${option.goldenAgeType} --send`;
+function celebrationOptionAction(
+  kind: CelebrationOptionAction['kind'],
+  option: Record<string, unknown>,
+): CelebrationOptionAction {
+  const readOnly = kind === 'validate-celebration-choice';
+  return {
+    kind,
+    label: readOnly
+      ? 'Validate this celebration choice before sending.'
+      : 'Choose this celebration after reviewing validation evidence.',
+    parameters: {
+      goldenAgeType: option.goldenAgeType,
+      goldenAgeTypeName: option.goldenAgeTypeName,
+    },
+    readOnly,
+    sendsMutation: !readOnly,
+  };
 }
 
 function asArray(value: unknown): unknown[] {

--- a/packages/cli/src/commands/game/play/choose-culture.ts
+++ b/packages/cli/src/commands/game/play/choose-culture.ts
@@ -10,6 +10,14 @@ import {
 
 const SET_CULTURE_TREE_NODE = 'SET_CULTURE_TREE_NODE';
 
+type ProgressionOptionAction = {
+  kind: 'choose-culture' | 'target-culture' | 'validate-culture-choice';
+  label: string;
+  parameters: Record<string, unknown>;
+  readOnly: boolean;
+  sendsMutation: boolean;
+};
+
 export default class GamePlayChooseCulture extends Command {
   static id = 'game play choose-culture';
   static summary = 'Validate or choose a culture tree node';
@@ -67,18 +75,18 @@ export default class GamePlayChooseCulture extends Command {
       const details = cultureChoiceDetails(view);
       const surfaces = details.map(compactCultureChoiceSurface);
       emitPlayResult(this.log.bind(this), flags.json, {
-        command: 'game play choose-culture --options',
+        surface: 'culture-choice-options',
         surfaces,
         enabledOptionCount: surfaces.reduce((count, surface) => count + surface.enabledOptions.length, 0),
         disabledOptionCount: surfaces.reduce((count, surface) => count + surface.disabledOptionCount, 0),
         omitted: [
-          { path: 'details[].options', reason: 'use game play notifications --json for raw option and validation evidence' },
+          { path: 'details[].options', reason: 'use full notification JSON for raw option and validation evidence' },
           { path: 'details[].disabledOptions', reason: 'disabled nodes are counted here; use notifications --json when disabled-node evidence matters' },
           { path: 'details[].availableNodeTypes', reason: 'official culture chooser source nodes are summarized per enabled row' },
         ],
         notes: [
           'Options come from the live notification HUD materializer, which validates SET_CULTURE_TREE_NODE and SET_CULTURE_TREE_TARGET_NODE through official PlayerOperations checks.',
-          'Use a returned enabled option cli for one caller-level chooser closeout workflow, or validate a specific node before sending.',
+          'Action guidance is semantic; command help owns exact flag combinations.',
         ],
       });
       return;
@@ -156,9 +164,9 @@ function compactCultureChoiceSurface(details: Record<string, unknown>): {
       maxDepth: option.maxDepth,
       turns: probeValue(option.turns),
       cost: probeValue(option.cost),
-      chooseCli: normalizeCultureChoiceCli(option.cli),
-      targetCli: option.targetCli,
-      validateCli: option.validateCli,
+      nextAction: progressionOptionAction('choose-culture', option),
+      targetAction: progressionOptionAction('target-culture', option),
+      validationAction: progressionOptionAction('validate-culture-choice', option),
     }));
   return {
     kind: 'culture-choice-options',
@@ -184,8 +192,23 @@ function probeValue(value: unknown): unknown {
   return value ?? null;
 }
 
-function normalizeCultureChoiceCli(value: unknown): unknown {
-  return typeof value === 'string'
-    ? value.replace(/\s+--closeout\b/g, '')
-    : value;
+function progressionOptionAction(
+  kind: ProgressionOptionAction['kind'],
+  option: Record<string, unknown>,
+): ProgressionOptionAction {
+  const readOnly = kind === 'validate-culture-choice';
+  return {
+    kind,
+    label: kind === 'choose-culture'
+      ? 'Choose this culture node after reviewing validation evidence.'
+      : kind === 'target-culture'
+        ? 'Set this culture node as the current target.'
+        : 'Validate this culture choice before sending.',
+    parameters: {
+      node: option.nodeType,
+      nodeTypeName: option.nodeTypeName,
+    },
+    readOnly,
+    sendsMutation: !readOnly,
+  };
 }

--- a/packages/cli/src/commands/game/play/choose-government.ts
+++ b/packages/cli/src/commands/game/play/choose-government.ts
@@ -10,6 +10,14 @@ import {
 
 const CHANGE_GOVERNMENT = 'CHANGE_GOVERNMENT';
 
+type GovernmentOptionAction = {
+  kind: 'choose-government' | 'validate-government-choice';
+  label: string;
+  parameters: Record<string, unknown>;
+  readOnly: boolean;
+  sendsMutation: boolean;
+};
+
 export default class GamePlayChooseGovernment extends Command {
   static id = 'game play choose-government';
   static summary = 'Validate or choose a government';
@@ -65,17 +73,17 @@ export default class GamePlayChooseGovernment extends Command {
       const details = governmentChoiceDetails(view);
       const surfaces = details.map(compactGovernmentChoiceSurface);
       emitPlayResult(this.log.bind(this), flags.json, {
-        command: 'game play choose-government --options',
+        surface: 'government-choice-options',
         surfaces,
         enabledOptionCount: surfaces.reduce((count, surface) => count + surface.enabledOptions.length, 0),
         disabledOptionCount: surfaces.reduce((count, surface) => count + surface.disabledOptionCount, 0),
         omitted: [
-          { path: 'details[].options', reason: 'use game play notifications --json for raw option and validation evidence' },
+          { path: 'details[].options', reason: 'use full notification JSON for raw option and validation evidence' },
           { path: 'details[].disabledOptions', reason: 'disabled governments are counted here; use notifications --json when disabled-option evidence matters' },
         ],
         notes: [
           'Options come from the live notification HUD materializer, which mirrors the official government picker and validates CHANGE_GOVERNMENT through PlayerOperations.',
-          'Use a returned enabled option cli as the single caller-level government choice.',
+          'Action guidance is semantic; command help owns exact flag combinations.',
         ],
       });
       return;
@@ -148,8 +156,8 @@ function compactGovernmentChoiceSurface(details: Record<string, unknown>): {
       description: option.description,
       action: option.action,
       celebrationOptions: option.celebrationOptions,
-      chooseCli: governmentChoiceSendCli(option),
-      validateCli: option.validateCli,
+      nextAction: governmentOptionAction('choose-government', option),
+      validationAction: governmentOptionAction('validate-government-choice', option),
     }));
   return {
     kind: 'government-choice-options',
@@ -163,10 +171,24 @@ function compactGovernmentChoiceSurface(details: Record<string, unknown>): {
   };
 }
 
-function governmentChoiceSendCli(option: Record<string, unknown>): string | null {
-  if (typeof option.governmentType !== 'number') return null;
-  const action = typeof option.action === 'number' ? ` --action ${option.action}` : '';
-  return `game play choose-government --government-type ${option.governmentType}${action} --send`;
+function governmentOptionAction(
+  kind: GovernmentOptionAction['kind'],
+  option: Record<string, unknown>,
+): GovernmentOptionAction {
+  const readOnly = kind === 'validate-government-choice';
+  return {
+    kind,
+    label: readOnly
+      ? 'Validate this government choice before sending.'
+      : 'Choose this government after reviewing validation evidence.',
+    parameters: {
+      governmentType: option.governmentType,
+      governmentTypeName: option.governmentTypeName,
+      action: option.action,
+    },
+    readOnly,
+    sendsMutation: !readOnly,
+  };
 }
 
 function asArray(value: unknown): unknown[] {

--- a/packages/cli/src/commands/game/play/choose-narrative.ts
+++ b/packages/cli/src/commands/game/play/choose-narrative.ts
@@ -11,6 +11,23 @@ import {
 
 const CHOOSE_NARRATIVE_STORY_DIRECTION = 'CHOOSE_NARRATIVE_STORY_DIRECTION';
 
+type NarrativeOptionAction = {
+  kind: 'choose-narrative' | 'validate-narrative-choice';
+  label: string;
+  parameters: Record<string, unknown>;
+  readOnly: boolean;
+  sendsMutation: boolean;
+};
+
+type NarrativeDismissalAction = {
+  kind: 'inspect-notification-dismissal' | 'dismiss-notification';
+  label: string;
+  parameters: Record<string, unknown>;
+  readOnly: boolean;
+  sendsMutation: boolean;
+  proofBoundary?: 'unproven-dismissal';
+};
+
 export default class GamePlayChooseNarrative extends Command {
   static id = 'game play choose-narrative';
   static summary = 'Validate or choose a narrative story direction';
@@ -69,18 +86,18 @@ export default class GamePlayChooseNarrative extends Command {
       const details = narrativeChoiceDetails(view);
       const surfaces = details.map(compactNarrativeChoiceSurface);
       emitPlayResult(this.log.bind(this), flags.json, {
-        command: 'game play choose-narrative --options',
+        surface: 'narrative-choice-options',
         surfaces,
         enabledOptionCount: surfaces.reduce((count, surface) => count + surface.enabledOptions.length, 0),
         disabledOptionCount: surfaces.reduce((count, surface) => count + surface.disabledOptionCount, 0),
         omitted: [
-          { path: 'details[].options', reason: 'use game play notifications --json for raw option and validation evidence' },
+          { path: 'details[].options', reason: 'use full notification JSON for raw option and validation evidence' },
           { path: 'details[].disabledOptions', reason: 'disabled narrative buttons are counted here; use notifications --json when disabled-option evidence matters' },
           { path: 'details[].storyLinks', reason: 'official story-link rows are summarized per enabled row' },
         ],
         notes: [
           'Options come from the live notification HUD materializer, which mirrors official narrative popup buttons and validates CHOOSE_NARRATIVE_STORY_DIRECTION through PlayerOperations.',
-          'Use a returned enabled option cli as the single caller-level narrative choice.',
+          'Action guidance is semantic; command help owns exact flag combinations.',
         ],
       });
       return;
@@ -158,8 +175,8 @@ function compactNarrativeChoiceSurface(details: Record<string, unknown>): {
   enabledOptions: Array<Record<string, unknown>>;
   enabledOptionCount: number;
   disabledOptionCount: number;
-  dismissalDiagnosticCli: unknown;
-  unprovenDismissalCli: unknown;
+  dismissalDiagnosticAction: NarrativeDismissalAction | null;
+  unprovenDismissalAction: NarrativeDismissalAction | null;
   notes: unknown;
 } {
   const visiblePanel = probeValue(details.visiblePanel);
@@ -179,9 +196,11 @@ function compactNarrativeChoiceSurface(details: Record<string, unknown>): {
       reward: option.reward,
       imperative: option.imperative,
       cost: option.cost,
-      chooseCli: option.cli,
-      validateCli: option.validateCli,
+      nextAction: narrativeOptionAction('choose-narrative', option),
+      validationAction: narrativeOptionAction('validate-narrative-choice', option),
     }));
+  const notificationId = details.notificationId ?? null;
+  const hasDismissalFallback = enabledOptions.length === 0 && notificationId !== null;
   return {
     kind: 'narrative-choice-options',
     classification: details.classification ?? null,
@@ -196,9 +215,50 @@ function compactNarrativeChoiceSurface(details: Record<string, unknown>): {
     enabledOptions,
     enabledOptionCount: enabledOptions.length,
     disabledOptionCount: asArray(details.disabledOptions).length,
-    dismissalDiagnosticCli: typeof details.dismissalDiagnosticCli === 'string' ? details.dismissalDiagnosticCli : null,
-    unprovenDismissalCli: typeof details.unprovenDismissalCli === 'string' ? details.unprovenDismissalCli : null,
+    dismissalDiagnosticAction: hasDismissalFallback
+      ? narrativeDismissalAction('inspect-notification-dismissal', notificationId)
+      : null,
+    unprovenDismissalAction: hasDismissalFallback
+      ? narrativeDismissalAction('dismiss-notification', notificationId)
+      : null,
     notes: asArray(details.notes),
+  };
+}
+
+function narrativeOptionAction(
+  kind: NarrativeOptionAction['kind'],
+  option: Record<string, unknown>,
+): NarrativeOptionAction {
+  const readOnly = kind === 'validate-narrative-choice';
+  return {
+    kind,
+    label: readOnly
+      ? 'Validate this narrative choice before sending.'
+      : 'Choose this narrative option after reviewing validation evidence.',
+    parameters: {
+      targetType: option.targetType,
+      target: option.target,
+      action: option.action,
+    },
+    readOnly,
+    sendsMutation: !readOnly,
+  };
+}
+
+function narrativeDismissalAction(
+  kind: NarrativeDismissalAction['kind'],
+  target: unknown,
+): NarrativeDismissalAction {
+  const readOnly = kind === 'inspect-notification-dismissal';
+  return {
+    kind,
+    label: readOnly
+      ? 'Inspect dismissal evidence for this notification.'
+      : 'Dismiss only after reviewing dismissal evidence.',
+    parameters: { target },
+    readOnly,
+    sendsMutation: !readOnly,
+    ...(readOnly ? {} : { proofBoundary: 'unproven-dismissal' as const }),
   };
 }
 

--- a/packages/cli/src/commands/game/play/choose-tech.ts
+++ b/packages/cli/src/commands/game/play/choose-tech.ts
@@ -12,6 +12,14 @@ import {
 
 const SET_TECH_TREE_NODE = 'SET_TECH_TREE_NODE';
 
+type ProgressionOptionAction = {
+  kind: 'choose-technology' | 'target-technology' | 'validate-technology-choice';
+  label: string;
+  parameters: Record<string, unknown>;
+  readOnly: boolean;
+  sendsMutation: boolean;
+};
+
 export default class GamePlayChooseTech extends Command {
   static id = 'game play choose-tech';
   static summary = 'Validate or choose a technology node';
@@ -70,18 +78,18 @@ export default class GamePlayChooseTech extends Command {
       const surfaces = details.map(compactTechnologyChoiceSurface);
       const enabledOptionCount = surfaces.reduce((count, surface) => count + surface.enabledOptions.length, 0);
       emitPlayResult(this.log.bind(this), flags.json, {
-        command: 'game play choose-tech --options',
+        surface: 'technology-choice-options',
         surfaces,
         enabledOptionCount,
         disabledOptionCount: surfaces.reduce((count, surface) => count + surface.disabledOptionCount, 0),
         omitted: [
-          { path: 'details[].options', reason: 'use game play notifications --json for raw option and validation evidence' },
+          { path: 'details[].options', reason: 'use full notification JSON for raw option and validation evidence' },
           { path: 'details[].disabledOptions', reason: 'disabled nodes are counted here; use notifications --json when disabled-node evidence matters' },
           { path: 'details[].techTrees', reason: 'tree proof is summarized per enabled row' },
         ],
         notes: [
           'Options come from the live notification HUD materializer, which validates SET_TECH_TREE_NODE and SET_TECH_TREE_TARGET_NODE through official PlayerOperations checks.',
-          'Use a returned enabled option cli for one caller-level technology selection, or validate a specific node before sending.',
+          'Action guidance is semantic; command help owns exact flag combinations.',
         ],
       });
       return;
@@ -159,9 +167,9 @@ function compactTechnologyChoiceSurface(details: Record<string, unknown>): {
       maxDepth: option.maxDepth,
       turns: probeValue(option.turns),
       cost: probeValue(option.cost),
-      chooseCli: option.cli,
-      targetCli: option.targetCli,
-      validateCli: option.validateCli,
+      nextAction: progressionOptionAction('choose-technology', option),
+      targetAction: progressionOptionAction('target-technology', option),
+      validationAction: progressionOptionAction('validate-technology-choice', option),
     }));
   return {
     kind: 'technology-choice-options',
@@ -172,6 +180,27 @@ function compactTechnologyChoiceSurface(details: Record<string, unknown>): {
     enabledOptions,
     enabledOptionCount: enabledOptions.length,
     disabledOptionCount: asArray(details.disabledOptions).length,
+  };
+}
+
+function progressionOptionAction(
+  kind: ProgressionOptionAction['kind'],
+  option: Record<string, unknown>,
+): ProgressionOptionAction {
+  const readOnly = kind === 'validate-technology-choice';
+  return {
+    kind,
+    label: kind === 'choose-technology'
+      ? 'Choose this technology after reviewing validation evidence.'
+      : kind === 'target-technology'
+        ? 'Set this technology as the current target.'
+        : 'Validate this technology choice before sending.',
+    parameters: {
+      node: option.nodeType,
+      nodeTypeName: option.nodeTypeName,
+    },
+    readOnly,
+    sendsMutation: !readOnly,
   };
 }
 

--- a/packages/cli/src/commands/game/play/civilian-route-triage.ts
+++ b/packages/cli/src/commands/game/play/civilian-route-triage.ts
@@ -6,7 +6,6 @@ import {
 import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import { buildDirectControlOptions } from '../../../utils/game-play-shared';
 
-type Location = Readonly<{ x: number; y: number }>;
 type TriageNextStep = Civ7StrategyCivilianRouteTriageResult['nextSteps'][number];
 type CivilianRouteTriageCliView = Omit<Civ7StrategyCivilianRouteTriageResult, 'triage'> & {
   triage: Civ7StrategyCivilianRouteTriageResult['triage'] & {
@@ -127,7 +126,7 @@ export default class GamePlayCivilianRouteTriage extends Command {
     this.log(view.triage.summary);
     this.log(`Status: ${view.triage.status}`);
     for (const reason of view.triage.reasons) this.log(`Reason: ${reason}`);
-    for (const command of view.triage.nextInspections) this.log(`Next: ${command}`);
+    for (const next of view.triage.nextInspections) this.log(`Next: ${next}`);
   }
 }
 
@@ -139,37 +138,22 @@ function buildCliView(
     triage: {
       ...result.triage,
       nextInspections: result.nextSteps
-        .map(commandForNextStep)
+        .map(nextInspectionLabel)
         .filter((item): item is string => item != null),
     },
   };
 }
 
-function commandForNextStep(step: TriageNextStep): string | null {
+function nextInspectionLabel(step: TriageNextStep): string | null {
   switch (step.kind) {
     case 'read-priorities':
-      return 'game play priorities --json';
     case 'inspect-battlefield':
-      return step.parameters.origin == null
-        ? 'game play battlefield-scan --json'
-        : `game play battlefield-scan ${locationFlags(step.parameters.origin)} --json`;
     case 'inspect-settlement':
-      return step.parameters.origin == null
-        ? 'game play settlement-recommendations --json'
-        : `game play settlement-recommendations ${locationFlags(step.parameters.origin)} --json`;
     case 'inspect-destination':
-      return step.parameters.origin != null && step.parameters.destination != null
-        ? `game play destination-analysis --from-x ${step.parameters.origin.x} --from-y ${step.parameters.origin.y} --to-x ${step.parameters.destination.x} --to-y ${step.parameters.destination.y} --json`
-        : 'game play destination-analysis --json';
     case 'inspect-front':
-      return 'game play front-summary --x <screen-x> --y <screen-y> --json';
     case 'inspect-ready-unit':
-      return 'game play ready-unit --json';
     case 'validate-unit-action':
-      return "game play unit-target --unit-id '<unit-id>' --x <x> --y <y> --json";
+      return step.label;
   }
-}
-
-function locationFlags(location: Location): string {
-  return `--x ${location.x} --y ${location.y}`;
+  return null;
 }

--- a/packages/cli/src/commands/game/play/formation-snapshot.ts
+++ b/packages/cli/src/commands/game/play/formation-snapshot.ts
@@ -108,8 +108,8 @@ export default class GamePlayFormationSnapshot extends Command {
     this.log(view.formation.headline);
     this.log(`Posture: ${view.formation.posture}`);
     for (const reason of view.formation.reasons) this.log(`Reason: ${reason}`);
-    for (const command of view.formation.nextInspections) {
-      this.log(`Next: ${command}`);
+    for (const next of view.formation.nextInspections) {
+      this.log(`Next: ${next}`);
     }
   }
 }
@@ -121,31 +121,11 @@ function formationCliView(
     ...result,
     formation: {
       ...result.formation,
-      nextInspections: result.formation.nextSteps.map(nextInspectionCommand),
+      nextInspections: result.formation.nextSteps.map(nextInspectionLabel),
     },
   };
 }
 
-function nextInspectionCommand(step: FormationNextStep): string {
-  if (step.kind === 'read-priorities') return 'game play priorities --json';
-  if (step.kind === 'inspect-ready-unit') return 'game play ready-unit --json';
-  if (step.kind === 'inspect-civilian-route') {
-    const civilian = step.parameters.civilian;
-    return civilian == null
-      ? 'game play civilian-route-triage --json'
-      : `game play civilian-route-triage --x ${civilian.x} --y ${civilian.y} --json`;
-  }
-  if (step.kind === 'inspect-battlefield') {
-    const location = step.parameters.origin ?? step.parameters.contact;
-    return location == null
-      ? 'game play battlefield-scan --json'
-      : `game play battlefield-scan --x ${location.x} --y ${location.y} --json`;
-  }
-  return unitTargetCommand(step);
-}
-
-function unitTargetCommand(step: FormationNextStep): string {
-  return step.label.includes('screen or contact')
-    ? "game play unit-target --unit-id '<unit-id>' --x <screen-or-contact-x> --y <screen-or-contact-y> --json"
-    : "game play unit-target --unit-id '<unit-id>' --x <x> --y <y> --json";
+function nextInspectionLabel(step: FormationNextStep): string {
+  return step.label;
 }

--- a/packages/cli/src/commands/game/play/front-summary.ts
+++ b/packages/cli/src/commands/game/play/front-summary.ts
@@ -140,11 +140,11 @@ export default class GamePlayFrontSummary extends Command {
       origin: result.origins[0] ?? null,
       summary: {
         ...result.front,
-        nextInspections: frontInspectionCommands(result),
+        nextInspections: frontInspectionLabels(result),
       },
       notes: [
         ...result.notes,
-        'Use this to pick the next inspection, then validate concrete unit actions with game play unit-target.',
+        'Use this to pick the next inspection, then validate concrete unit actions before sending.',
       ],
     };
 
@@ -159,7 +159,7 @@ export default class GamePlayFrontSummary extends Command {
     for (const item of result.front.pressure.slice(0, 8)) {
       this.log(`- [${item.severity}] ${item.kind}: ${item.summary}`);
     }
-    for (const command of frontInspectionCommands(result)) this.log(`Next: ${command}`);
+    for (const next of frontInspectionLabels(result)) this.log(`Next: ${next}`);
   }
 }
 
@@ -185,22 +185,6 @@ function resolveFrontTarget(flags: {
   }) ?? null;
 }
 
-function frontInspectionCommands(result: Civ7StrategyFrontSummaryResult): string[] {
-  const origin = result.origins[0] ?? null;
-  const target = result.target;
-  const commands: string[] = ['game play priorities --json'];
-  if (origin) commands.push(`game play battlefield-scan --x ${origin.x} --y ${origin.y} --json`);
-  if (origin && target) {
-    commands.push(`game play destination-analysis --origin ${origin.x},${origin.y} --destination ${target.x},${target.y} --json`);
-  }
-  const highestLocated = result.front.pressure.find((item) => item.location);
-  if (highestLocated?.location) {
-    commands.push(`game play battlefield-scan --x ${highestLocated.location.x} --y ${highestLocated.location.y} --json`);
-  }
-  if (result.front.nextInspections.some((step) => step.kind === 'observe')) {
-    commands.push('game play attention --json');
-  }
-  commands.push('game play ready-unit --json');
-  commands.push("game play unit-target --unit-id '<unit-id>' --x <x> --y <y> --json");
-  return [...new Set(commands)];
+function frontInspectionLabels(result: Civ7StrategyFrontSummaryResult): string[] {
+  return result.front.nextInspections.map((step) => step.label);
 }

--- a/packages/cli/src/commands/game/play/notification-queue.ts
+++ b/packages/cli/src/commands/game/play/notification-queue.ts
@@ -8,13 +8,6 @@ import {
   buildDirectControlOptions,
 } from '../../../utils/game-play-shared';
 
-type QueueStep = Civ7NotificationQueueResult['schedule'][number] & {
-  command: string | null;
-};
-type QueueView = Omit<Civ7NotificationQueueResult, 'schedule'> & {
-  schedule: QueueStep[];
-};
-
 export default class GamePlayNotificationQueue extends Command {
   static id = 'game play notification-queue';
   static summary = 'Read and schedule the current notification decision queue';
@@ -58,93 +51,23 @@ export default class GamePlayNotificationQueue extends Command {
     const result = await client.notifications.queue.current({
       maxNotifications: flags.max,
     });
-    const view = buildCliQueueView(result);
 
     if (flags.json) {
-      this.log(JSON.stringify({ ok: true, view }));
+      this.log(JSON.stringify({ ok: true, view: result }));
       return;
     }
 
-    this.log(`Turn ${formatProbe(view.turn)} (${formatProbe(view.turnDate)})`);
-    this.log(`Queue length: ${view.queueLength}; blocker: ${formatProbe(view.blocker)}`);
-    for (const item of view.schedule) {
+    this.log(`Turn ${formatProbe(result.turn)} (${formatProbe(result.turnDate)})`);
+    this.log(`Queue length: ${result.queueLength}; blocker: ${formatProbe(result.blocker)}`);
+    for (const item of result.schedule) {
       const marker = item.isEndTurnBlocking ? '*' : '-';
       this.log(`${marker} #${item.step} [${item.priority}] ${item.disposition}: ${item.summary ?? item.message ?? item.typeName ?? item.category}`);
       this.log(`  category: ${item.category}`);
-      if (item.command) this.log(`  next: ${item.command}`);
+      if (item.nextStep) this.log(`  next: ${item.nextStep.label}`);
       this.log(`  why: ${item.reason}`);
       for (const guardrail of item.guardrails) this.log(`  guard: ${guardrail}`);
     }
   }
-}
-
-function buildCliQueueView(result: Civ7NotificationQueueResult): QueueView {
-  return {
-    ...result,
-    schedule: result.schedule.map((step) => ({
-      ...step,
-      command: commandForStep(step),
-    })),
-  };
-}
-
-function commandForStep(step: Civ7NotificationQueueResult['schedule'][number]): string | null {
-  const nextStep = step.nextStep;
-  if (nextStep == null) return null;
-  switch (nextStep.kind) {
-    case 'dismiss-notification':
-      return step.notificationId == null
-        ? null
-        : `game play dismiss-notification --target '${JSON.stringify(step.notificationId)}' --send`;
-    case 'inspect-ready-unit':
-      return 'game play ready-unit --json; game play unit-target --unit-id \'<unit-id>\' --x <x> --y <y> --json';
-    case 'inspect-ready-city':
-      return 'game play ready-city --compact --json';
-    case 'inspect-progression':
-      return progressionCommand(step.category);
-    case 'inspect-decision':
-      return decisionCommand(step.category);
-    case 'validate-operation':
-      return validateOperationCommand(step);
-    case 'inspect-notification':
-      return 'game play notifications --json';
-    case 'observe':
-      return 'game play priorities --compact --json';
-  }
-}
-
-function progressionCommand(category: string): string {
-  if (category === 'technology-choice') return 'game play choose-tech --options --json';
-  if (category === 'culture-choice') return 'game play choose-culture --options --json';
-  if (category === 'tradition-review') return 'game play traditions --compact --json';
-  return 'game play priorities --compact --json';
-}
-
-function decisionCommand(category: string): string {
-  if (category === 'celebration-choice') return 'game play choose-celebration --options --json';
-  if (category === 'government-choice') return 'game play choose-government --options --json';
-  if (category === 'narrative-choice') return 'game play choose-narrative --options --json';
-  if (category === 'first-meet-diplomacy') return 'game play respond-first-meet --json';
-  if (category === 'diplomacy-response') return 'game play respond-diplomacy --json';
-  return 'game play priorities --compact --json';
-}
-
-function validateOperationCommand(step: Civ7NotificationQueueResult['schedule'][number]): string {
-  if (step.category === 'technology-choice' || step.operationType === 'SET_TECH_TREE_NODE') {
-    return 'game play choose-tech --options --json';
-  }
-  if (step.category === 'culture-choice' || step.operationType === 'SET_CULTURE_TREE_NODE') {
-    return 'game play choose-culture --options --json';
-  }
-  if (step.category === 'celebration-choice') return 'game play choose-celebration --options --json';
-  if (step.category === 'government-choice') return 'game play choose-government --options --json';
-  if (step.category === 'narrative-choice') return 'game play choose-narrative --options --json';
-  if (step.category === 'first-meet-diplomacy') return 'game play respond-first-meet --json';
-  if (step.category === 'diplomacy-response') return 'game play respond-diplomacy --json';
-  if (step.category === 'production-choice' || step.category === 'population-placement') {
-    return 'game play ready-city --compact --json';
-  }
-  return 'game play priorities --compact --json';
 }
 
 function formatProbe(value: unknown): string {

--- a/packages/cli/src/commands/game/play/notifications.ts
+++ b/packages/cli/src/commands/game/play/notifications.ts
@@ -47,7 +47,7 @@ export default class GamePlayNotifications extends Command {
     });
 
     if (flags.json) {
-      this.log(JSON.stringify({ ok: true, view }));
+      this.log(JSON.stringify({ ok: true, view: projectNotificationJsonView(view) }));
       return;
     }
 
@@ -96,6 +96,18 @@ export default class GamePlayNotifications extends Command {
 function formatProbe<T>(probe: { ok: true; value: T } | { ok: false; error: string }): string {
   if (!probe.ok) return `<error: ${probe.error}>`;
   return formatValue(probe.value);
+}
+
+function projectNotificationJsonView(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(projectNotificationJsonView);
+  if (!value || typeof value !== 'object') return value;
+
+  const output: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (key === 'cli') continue;
+    output[key] = projectNotificationJsonView(item);
+  }
+  return output;
 }
 
 function formatValue(value: unknown): string {

--- a/packages/cli/src/commands/game/play/notifications.ts
+++ b/packages/cli/src/commands/game/play/notifications.ts
@@ -1,0 +1,121 @@
+import { Command, Flags } from '@oclif/core';
+import {
+  type Civ7PlayDecisionAction,
+  type Civ7PlayDecisionInput,
+  getCiv7PlayNotificationView,
+} from '@civ7/direct-control';
+
+export default class GamePlayNotifications extends Command {
+  static id = 'game play notifications';
+  static summary = 'Read live play blockers with operation hints';
+  static description =
+    'Returns a read-only play-facing view of current notifications, blocker state, selected entities, and likely operation families.';
+
+  static examples = [
+    '<%= config.bin %> game play notifications --json',
+    '<%= config.bin %> game play notifications --max 10',
+  ];
+
+  static flags = {
+    host: Flags.string({
+      description: 'Civ7 tuner socket host',
+    }),
+    port: Flags.integer({
+      description: 'Civ7 tuner socket port',
+    }),
+    max: Flags.integer({
+      description: 'Maximum notifications to materialize',
+      default: 25,
+    }),
+    'timeout-ms': Flags.integer({
+      description: 'Socket timeout',
+      default: 45_000,
+    }),
+    json: Flags.boolean({
+      description: 'Emit machine-readable JSON',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = await this.parse(GamePlayNotifications);
+    const view = await getCiv7PlayNotificationView({
+      host: flags.host,
+      port: flags.port,
+      timeoutMs: flags['timeout-ms'],
+      maxNotifications: flags.max,
+    });
+
+    if (flags.json) {
+      this.log(JSON.stringify({ ok: true, view }));
+      return;
+    }
+
+    this.log(`Turn ${formatProbe(view.turn)} (${formatProbe(view.turnDate)})`);
+    this.log(`End turn: ${formatProbe(view.canEndTurn)}; blocker: ${formatProbe(view.blocker)}`);
+    this.log(`Blocking notification: ${formatProbe(view.blockingNotificationId)}`);
+    this.log(`Selected unit: ${formatProbe(view.selectedUnitId)}; first ready unit: ${formatProbe(view.firstReadyUnitId)}`);
+    this.log(`Selected city: ${formatProbe(view.selectedCityId)}`);
+
+    if (view.hud?.nextDecision) {
+      this.log('');
+      this.log('Decision HUD');
+      for (const item of view.hud.decisionQueue) {
+        const marker = item.isEndTurnBlocking ? '*' : '-';
+        this.log(`${marker} ${item.category}: ${item.summary ?? item.message ?? item.typeName ?? '<unknown notification>'}`);
+        this.log(`  action: ${item.category}`);
+        if (item.operationFamily || item.operationType) {
+          this.log(`  operation: ${[item.operationFamily, item.operationType].filter(Boolean).join(' ')}`);
+        }
+        if (item.argsShape) this.log(`  args: ${item.argsShape}`);
+        if (item.target !== null && item.target !== undefined) this.log(`  target: ${formatValue(item.target)}`);
+        if (item.location !== null && item.location !== undefined) this.log(`  location: ${formatValue(item.location)}`);
+        logInputs(this.log.bind(this), item.requiredInputs);
+        logActions(this.log.bind(this), item.commonActions);
+        for (const note of item.notes) this.log(`  note: ${note}`);
+      }
+    }
+
+    this.log('');
+    this.log('Notifications');
+    for (const notification of view.notifications) {
+      const marker = notification.isEndTurnBlocking ? '*' : '-';
+      this.log(`${marker} ${notification.typeName ?? notification.type ?? '<unknown notification>'}: ${notification.summary ?? notification.message ?? ''}`);
+      this.log(`  decision: ${notification.decision.category}`);
+      if (notification.decision.operationFamily && notification.decision.operationType) {
+        this.log(`  operation: ${notification.decision.operationFamily} ${notification.decision.operationType}`);
+      }
+      if (notification.decision.argsShape) this.log(`  args: ${notification.decision.argsShape}`);
+      this.log(`  action: ${notification.decision.category}`);
+      logInputs(this.log.bind(this), notification.decision.requiredInputs);
+      for (const note of notification.decision.notes) this.log(`  note: ${note}`);
+    }
+  }
+}
+
+function formatProbe<T>(probe: { ok: true; value: T } | { ok: false; error: string }): string {
+  if (!probe.ok) return `<error: ${probe.error}>`;
+  return formatValue(probe.value);
+}
+
+function formatValue(value: unknown): string {
+  return typeof value === 'object' ? JSON.stringify(value) : String(value);
+}
+
+function logInputs(log: (message: string) => void, inputs: ReadonlyArray<Civ7PlayDecisionInput>): void {
+  if (inputs.length === 0) return;
+  log(`  inputs:`);
+  for (const input of inputs) {
+    const marker = input.required ? 'required' : 'optional';
+    const note = input.note ? `; ${input.note}` : '';
+    log(`    - ${input.name} (${marker}) from ${input.source}${note}`);
+  }
+}
+
+function logActions(log: (message: string) => void, actions: ReadonlyArray<Civ7PlayDecisionAction>): void {
+  if (actions.length === 0) return;
+  log(`  actions:`);
+  for (const action of actions) {
+    log(`    - ${action.label}: ${action.when}`);
+  }
+}

--- a/packages/cli/src/commands/game/play/priorities.ts
+++ b/packages/cli/src/commands/game/play/priorities.ts
@@ -8,11 +8,19 @@ import { createSemanticCliEnvelope, type SemanticCliEnvelope } from '../../../ga
 import { buildDirectControlOptions } from '../../../utils/game-play-shared';
 
 type PriorityItem = Civ7AttentionPrioritiesResult['priorities'][number] & {
-  command?: string;
+  nextAction?: PriorityActionDescriptor;
 };
 type PriorityView = Omit<Civ7AttentionPrioritiesResult, 'priorities'> & {
   priorities: PriorityItem[];
   cliNotes: string[];
+};
+type PriorityNextStep = NonNullable<Civ7AttentionPrioritiesResult['priorities'][number]['nextStep']>;
+type PriorityActionDescriptor = {
+  kind: PriorityNextStep['kind'];
+  label: string;
+  parameters: PriorityNextStep['parameters'];
+  readOnly: boolean;
+  sendsMutation: boolean;
 };
 
 export default class GamePlayPriorities extends Command {
@@ -97,7 +105,7 @@ export default class GamePlayPriorities extends Command {
     for (const item of view.priorities) {
       this.log(`- [${item.priority}] ${item.kind}: ${item.summary}`);
       this.log(`  why: ${item.reason}`);
-      if (item.command) this.log(`  next: ${item.command}`);
+      if (item.nextAction) this.log(`  next: ${item.nextAction.label}`);
     }
   }
 }
@@ -107,11 +115,11 @@ function buildCliPriorityView(result: Civ7AttentionPrioritiesResult): PriorityVi
     ...result,
     priorities: result.priorities.map((item) => ({
       ...item,
-      command: commandForPriority(item),
+      nextAction: actionForPriority(item),
     })),
     cliNotes: [
       'Read-only priority dashboard; it does not send operations or choose strategy.',
-      'Command suggestions are CLI presentation derived from service next-step descriptors.',
+      'Action guidance is semantic; command help owns exact flag combinations.',
       'Battlefield scan distances are planning heuristics and may include debug-visible entities unless paired with visibility reads.',
     ],
   };
@@ -120,12 +128,12 @@ function buildCliPriorityView(result: Civ7AttentionPrioritiesResult): PriorityVi
 function buildCompactView(view: PriorityView): {
   ok: true;
   contractVersion: 'play-agent-v0';
-  command: 'game play priorities';
+  surface: 'priorities';
   summary: string;
   decisionHud: Record<string, unknown>;
-  priorities: Array<Pick<PriorityItem, 'priority' | 'kind' | 'summary' | 'reason' | 'command'>>;
+  priorities: Array<Pick<PriorityItem, 'priority' | 'kind' | 'summary' | 'reason' | 'nextAction'>>;
   semanticEnvelope: SemanticCliEnvelope;
-  next: string | null;
+  nextAction: PriorityActionDescriptor | null;
   warnings: string[];
   omitted: Array<{ path: string; reason: string }>;
   hiddenInfoPolicy: unknown;
@@ -140,12 +148,12 @@ function buildCompactView(view: PriorityView): {
       ? 'Battlefield scan is read-only planning evidence; validate and postcondition-check any mutation separately.'
       : null,
   ].filter((warning): warning is string => Boolean(warning));
-  const compactPriorities = view.priorities.slice(0, 6).map(({ priority, kind, summary, reason, command }) => ({
+  const compactPriorities = view.priorities.slice(0, 6).map(({ priority, kind, summary, reason, nextAction }) => ({
     priority,
     kind,
     summary,
     reason,
-    command,
+    nextAction,
   }));
   const decisionHud = {
     playable: view.playable,
@@ -159,11 +167,11 @@ function buildCompactView(view: PriorityView): {
     readyCity: view.readyCity,
     battlefieldPoiCount: view.battlefield?.pointOfInterestCount ?? 0,
   };
-  const next = top?.command ?? null;
+  const nextAction = top?.nextAction ?? null;
   const semanticBlockers = view.priorities.filter((item) => item.blocking).slice(0, 6);
   const semanticEnvelope = createSemanticCliEnvelope({
     scope: {
-      surface: 'game play priorities',
+      surface: 'priorities',
       playerScope: 'local-player',
       localPlayerId: view.localPlayerId,
     },
@@ -174,18 +182,16 @@ function buildCompactView(view: PriorityView): {
       summary,
       reason,
     })),
-    decisions: compactPriorities.map(({ kind, summary, command }) => ({
+    decisions: compactPriorities.map(({ kind, summary, nextAction }) => ({
       kind,
       summary,
-      command: command ?? null,
+      nextAction: nextAction ?? null,
     })),
-    actions: compactPriorities.flatMap(({ kind, command }) =>
-      command
+    actions: compactPriorities.flatMap(({ kind, nextAction }) =>
+      nextAction
         ? [{
             family: kind,
-            command,
-            readOnly: !command.includes('--send'),
-            sendsMutation: command.includes('--send'),
+            ...nextAction,
           }]
         : [],
     ),
@@ -194,11 +200,11 @@ function buildCompactView(view: PriorityView): {
       sent: false,
       classification: 'not-sent',
     },
-    nextSteps: next ? [next] : [],
+    nextSteps: nextAction ? [nextAction] : [],
     evidence: [{
       label: 'control-orpc-priorities-compact',
       proofClass: 'local-cli-output',
-      command: 'game play priorities --compact --json',
+      surface: 'priorities',
     }],
     notes: [
       'Read-only compact priorities semantic envelope; it does not prove live mutation behavior.',
@@ -209,19 +215,19 @@ function buildCompactView(view: PriorityView): {
   return {
     ok: true,
     contractVersion: 'play-agent-v0',
-    command: 'game play priorities',
+    surface: 'priorities',
     summary: top
       ? `${top.kind}: ${top.summary}`
       : 'no priorities surfaced',
     decisionHud,
     priorities: compactPriorities,
     semanticEnvelope,
-    next,
+    nextAction,
     warnings,
     omitted: [
       { path: 'view.notes', reason: 'use --json without --compact for full service notes' },
-      { path: 'view.readyUnit', reason: 'use --json without --compact or game play ready-unit --json for ready-unit detail' },
-      { path: 'view.readyCity', reason: 'use --json without --compact or game play ready-city --json for ready-city detail' },
+      { path: 'view.readyUnit', reason: 'use full JSON for ready-unit detail' },
+      { path: 'view.readyCity', reason: 'use full JSON for ready-city detail' },
       { path: 'view.battlefield.pointsOfInterest', reason: 'use --json without --compact or a tactical lens command for battlefield point detail' },
       { path: 'priorities[].evidenceLabels', reason: 'use --json without --compact for bounded service evidence labels' },
     ],
@@ -229,69 +235,16 @@ function buildCompactView(view: PriorityView): {
   };
 }
 
-function commandForPriority(item: Civ7AttentionPrioritiesResult['priorities'][number]): string | undefined {
+function actionForPriority(item: Civ7AttentionPrioritiesResult['priorities'][number]): PriorityActionDescriptor | undefined {
   const step = item.nextStep;
   if (step == null) return undefined;
-  const params = step.parameters;
-  switch (step.kind) {
-    case 'restore-readiness':
-    case 'observe':
-      return 'game play rehydrate --json; game watch --count 1 --include-ready-unit --include-ready-city --jsonl';
-    case 'inspect-ready-unit':
-    case 'validate-unit-target':
-      return "game play ready-unit --json; game play unit-target --unit-id '<unit-id>' --x <x> --y <y> --json";
-    case 'inspect-ready-city':
-      return item.kind.startsWith('hud:')
-        ? 'game play ready-city --compact --json'
-        : 'game play ready-city --json';
-    case 'inspect-progression':
-      return progressionCommand(params.category);
-    case 'inspect-decision':
-      return decisionCommand(params.category);
-    case 'inspect-notification':
-      return params.componentId == null
-        ? 'game play dismiss-notification --json'
-        : params.category === 'narrative-choice'
-          ? `game play dismiss-notification --target '${JSON.stringify(params.componentId)}' --json`
-          : `game play dismiss-notification --target '${JSON.stringify(params.componentId)}' --send`;
-    case 'validate-unit-command':
-      return params.unitId != null && params.operationType != null
-        ? `game play operation --family unit --type ${params.operationType} --unit-id '${JSON.stringify(params.unitId)}' --send`
-        : 'game play operation --family unit --json';
-    case 'send-turn-complete':
-    case 'end-turn':
-      return 'game play end-turn --send --json';
-    case 'observe-turn-advance':
-      return 'game watch --count 3 --interval-ms 1000 --include-ready-unit --include-ready-city --jsonl';
-    case 'inspect-battlefield-point':
-      return battlefieldCommand(params.location, item.kind);
-  }
-}
-
-function progressionCommand(category: unknown): string {
-  if (category === 'technology-choice') return 'game play choose-tech --options --json';
-  if (category === 'culture-choice') return 'game play choose-culture --options --json';
-  if (category === 'tradition-review') return 'game play traditions --compact --json';
-  return 'game play priorities --compact --json';
-}
-
-function decisionCommand(category: unknown): string {
-  if (category === 'celebration-choice') return 'game play choose-celebration --options --json';
-  if (category === 'government-choice') return 'game play choose-government --options --json';
-  if (category === 'narrative-choice') return 'game play choose-narrative --options --json';
-  if (category === 'first-meet-diplomacy') return 'game play respond-first-meet --json';
-  return 'game play priorities --compact --json';
-}
-
-function battlefieldCommand(
-  location: Readonly<{ x: number; y: number }> | undefined,
-  kind: string,
-): string {
-  if (location == null) return 'game play battlefield-scan --x <front-x> --y <front-y> --json';
-  if (kind === 'battlefield:city-front') {
-    return `game play destination-analysis --to-x ${location.x} --to-y ${location.y} --json`;
-  }
-  return `game play battlefield-scan --x ${location.x} --y ${location.y} --json`;
+  return {
+    kind: step.kind,
+    label: step.label,
+    parameters: step.parameters,
+    readOnly: !['send-turn-complete', 'end-turn', 'validate-unit-command'].includes(step.kind),
+    sendsMutation: ['send-turn-complete', 'end-turn', 'validate-unit-command'].includes(step.kind),
+  };
 }
 
 function formatValue(value: unknown): string {

--- a/packages/cli/src/commands/game/play/progress-dashboard.ts
+++ b/packages/cli/src/commands/game/play/progress-dashboard.ts
@@ -69,7 +69,7 @@ export default class GamePlayProgressDashboard extends Command {
 function buildCompactView(view: Civ7ProgressionDashboardResult): {
   ok: true;
   contractVersion: 'play-agent-v0';
-  command: 'game play progress-dashboard';
+  surface: 'progress-dashboard';
   summary: string;
   turn: Probe;
   turnDate: Probe;
@@ -78,7 +78,7 @@ function buildCompactView(view: Civ7ProgressionDashboardResult): {
   legacyPaths: Civ7ProgressionDashboardResult['legacyPaths'];
   victories: Civ7ProgressionDashboardResult['victories'];
   triumphs: Civ7ProgressionDashboardResult['triumphs'];
-  next: string | null;
+  nextAction: Civ7ProgressionDashboardResult['nextSteps'][number] | null;
   nextSteps: Civ7ProgressionDashboardResult['nextSteps'];
   warnings: string[];
   omitted: Array<{ path: string; reason: string }>;
@@ -88,7 +88,7 @@ function buildCompactView(view: Civ7ProgressionDashboardResult): {
   return {
     ok: true,
     contractVersion: 'play-agent-v0',
-    command: 'game play progress-dashboard',
+    surface: 'progress-dashboard',
     summary: view.summary.headline,
     turn: view.turn,
     turnDate: view.turnDate,
@@ -101,20 +101,11 @@ function buildCompactView(view: Civ7ProgressionDashboardResult): {
       source: view.triumphs.source,
       rows: view.triumphs.rows,
     },
-    next: cliCommandForNextStep(view.nextSteps[0]?.kind ?? null),
+    nextAction: view.nextSteps[0] ?? null,
     nextSteps: view.nextSteps,
     warnings: view.warnings,
     omitted: view.omitted,
     hiddenInfoPolicy: view.hiddenInfoPolicy,
     proof: view.proof,
   };
-}
-
-function cliCommandForNextStep(
-  kind: Civ7ProgressionDashboardResult['nextSteps'][number]['kind'] | null,
-): string | null {
-  if (kind === 'read-attention-priorities') {
-    return 'game play priorities --compact --json';
-  }
-  return null;
 }

--- a/packages/cli/src/commands/game/play/ready-city.ts
+++ b/packages/cli/src/commands/game/play/ready-city.ts
@@ -7,6 +7,13 @@ import {
 
 type Probe<T = unknown> = { ok: true; value: T } | { ok: false; error: string };
 type ReadyCityView = Awaited<ReturnType<typeof getCiv7ReadyCityView>>;
+type ReadyCityActionDescriptor = {
+  kind: string;
+  label: string;
+  parameters: Record<string, unknown>;
+  readOnly: false;
+  sendsMutation: true;
+};
 
 export default class GamePlayReadyCity extends Command {
   static id = 'game play ready-city';
@@ -74,7 +81,7 @@ export default class GamePlayReadyCity extends Command {
 function buildCompactView(view: ReadyCityView): {
   ok: true;
   contractVersion: 'play-agent-v0';
-  command: 'game play ready-city';
+  surface: 'ready-city';
   summary: string;
   cityId: ReadyCityView['cityId'];
   city: Record<string, unknown> | null;
@@ -89,7 +96,7 @@ function buildCompactView(view: ReadyCityView): {
     workablePlots: Array<Record<string, unknown>>;
     expansionCandidates: Array<Record<string, unknown>>;
   } | null;
-  next: string | null;
+  nextAction: ReadyCityActionDescriptor | null;
   warnings: string[];
   omitted: Array<{ path: string; reason: string }>;
 } {
@@ -98,14 +105,14 @@ function buildCompactView(view: ReadyCityView): {
   const workablePlots = compactWorkerPlots(probeArray(populationPlacement?.workablePlots));
   const expansionCandidates = compactExpansionCandidates(probeArray(populationPlacement?.expansionCandidates));
   const productionCandidates = compactProductionCandidates(probeArray(view.productionCandidates));
-  const next = stringField(workablePlots[0], 'cli')
-    ?? stringField(expansionCandidates[0], 'cli')
-    ?? stringField(productionCandidates[0], 'cli');
+  const nextAction = actionField(workablePlots[0])
+    ?? actionField(expansionCandidates[0])
+    ?? actionField(productionCandidates[0]);
 
   return {
     ok: true,
     contractVersion: 'play-agent-v0',
-    command: 'game play ready-city',
+    surface: 'ready-city',
     summary: city?.name
       ? `${String(city.name)}: ${workablePlots.length} assign-worker plots, ${expansionCandidates.length} expansion candidates`
       : 'no selected, requested, or blocker-target city',
@@ -124,7 +131,7 @@ function buildCompactView(view: ReadyCityView): {
           expansionCandidates,
         }
       : null,
-    next,
+    nextAction,
     warnings: [
       'Read-only city dashboard; validate and postcondition-check assign-worker, expand-city, production, or town-focus sends separately.',
       'Expansion candidate plot yields are map yield facts plus constructible context, not a post-send yield guarantee.',
@@ -166,7 +173,7 @@ function compactProductionCandidates(values: ReadonlyArray<Record<string, unknow
     baseYieldSummary: candidate.baseYieldSummary,
     valid: candidate.valid,
     placementPlots: candidate.placementPlots,
-    cli: candidate.cli,
+    nextAction: productionAction(candidate),
   }));
 }
 
@@ -179,7 +186,7 @@ function compactWorkerPlots(values: ReadonlyArray<Record<string, unknown>>): Arr
     nextYieldSummary: plot.nextYieldSummary,
     yieldDelta: plot.yieldDelta,
     maintenance: plot.maintenance,
-    cli: plot.cli,
+    nextAction: workerAction(plot),
   }));
 }
 
@@ -200,9 +207,54 @@ function compactExpansionCandidates(values: ReadonlyArray<Record<string, unknown
       resourceName: facts?.resourceName,
       yieldSource: facts?.yieldSource,
       yieldSummary: facts?.yieldSummary,
-      cli: candidate.cli,
+      nextAction: expansionAction(candidate),
     };
   });
+}
+
+function productionAction(candidate: Record<string, unknown>): ReadyCityActionDescriptor {
+  return {
+    kind: 'choose-production',
+    label: 'Choose this production candidate after reviewing placement and validation evidence.',
+    parameters: {
+      candidateKind: candidate.kind,
+      type: candidate.type,
+      typeName: candidate.typeName,
+      placementPlots: candidate.placementPlots,
+    },
+    readOnly: false,
+    sendsMutation: true,
+  };
+}
+
+function workerAction(plot: Record<string, unknown>): ReadyCityActionDescriptor {
+  return {
+    kind: 'assign-worker',
+    label: 'Assign one worker to this plot after reviewing the yield delta.',
+    parameters: {
+      location: plot.index,
+      x: plot.x,
+      y: plot.y,
+    },
+    readOnly: false,
+    sendsMutation: true,
+  };
+}
+
+function expansionAction(candidate: Record<string, unknown>): ReadyCityActionDescriptor {
+  return {
+    kind: 'expand-city',
+    label: 'Expand the city to this plot after reviewing map yield evidence.',
+    parameters: {
+      index: candidate.index,
+      x: candidate.x,
+      y: candidate.y,
+      constructibleType: candidate.constructibleType,
+      constructibleName: candidate.constructibleName,
+    },
+    readOnly: false,
+    sendsMutation: true,
+  };
 }
 
 function probeValue<T>(probe: Probe<T> | null | undefined): T | null {
@@ -214,8 +266,9 @@ function probeArray(probe: Probe<unknown> | null | undefined): Array<Record<stri
   return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => item !== null && typeof item === 'object') : [];
 }
 
-function stringField(value: Record<string, unknown> | undefined, key: string): string | null {
-  return typeof value?.[key] === 'string' ? value[key] : null;
+function actionField(value: Record<string, unknown> | undefined): ReadyCityActionDescriptor | null {
+  const action = value?.nextAction;
+  return action && typeof action === 'object' ? action as ReadyCityActionDescriptor : null;
 }
 
 function formatProbe<T>(probe: { ok: true; value: T } | { ok: false; error: string }): string {

--- a/packages/cli/src/commands/game/play/rehydrate.ts
+++ b/packages/cli/src/commands/game/play/rehydrate.ts
@@ -33,12 +33,17 @@ type RehydrateSnapshot = Readonly<{
     warnings: ReadonlyArray<string>;
   }>;
   commonActions: ReadonlyArray<{
+    kind: string;
     label: string;
-    cli: string;
+    parameters: Record<string, unknown>;
+    readOnly: boolean;
+    sendsMutation: boolean;
     when: string;
   }>;
   notes: ReadonlyArray<string>;
 }>;
+
+type RehydrateCommonAction = RehydrateSnapshot['commonActions'][number];
 
 export default class GamePlayRehydrate extends Command {
   static id = 'game play rehydrate';
@@ -130,7 +135,7 @@ export default class GamePlayRehydrate extends Command {
       this.log(`Ready-unit view: ${formatValue(readyUnit.unitId)} ${formatProbe(readyUnit.unit)}`);
     }
     this.log('Common actions:');
-    for (const action of snapshot.commonActions) this.log(`- ${action.label}: ${action.cli}`);
+    for (const action of snapshot.commonActions) this.log(`- ${action.label}: ${action.kind}`);
     for (const note of snapshot.notes) this.log(`Note: ${note}`);
   }
 }
@@ -217,30 +222,48 @@ function buildCommonActions(
   notifications: Civ7PlayNotificationViewResult,
   readyUnit: Civ7ReadyUnitViewResult | null,
 ): RehydrateSnapshot['commonActions'] {
-  const actions = [
+  const actions: RehydrateCommonAction[] = [
     {
+      kind: 'refresh-notifications',
       label: 'refresh live blocker HUD',
-      cli: 'game play notifications --json',
+      parameters: { maxNotifications: notifications.limits.maxNotifications },
+      readOnly: true,
+      sendsMutation: false,
       when: 'before acting on any stale watcher or active-agent assumption',
     },
   ];
   if (readyUnit?.unitId) {
     actions.push({
+      kind: 'inspect-ready-unit',
       label: 'inspect current ready unit',
-      cli: `game play ready-unit --unit-id '${JSON.stringify(readyUnit.unitId)}' --json`,
+      parameters: { unitId: readyUnit.unitId },
+      readOnly: true,
+      sendsMutation: false,
       when: 'before choosing movement, attack, fortify, skip, or other unit action',
     });
   } else if (probeValue(notifications.firstReadyUnitId)) {
     actions.push({
+      kind: 'inspect-ready-unit',
       label: 'inspect first ready unit',
-      cli: 'game play ready-unit --json',
+      parameters: {},
+      readOnly: true,
+      sendsMutation: false,
       when: 'before choosing a unit action',
     });
   }
-  if (notifications.hud.nextDecision?.cli) {
+  if (notifications.hud.nextDecision) {
+    const decision = notifications.hud.nextDecision as Record<string, unknown>;
     actions.push({
+      kind: 'handle-hud-decision',
       label: 'handle next HUD decision',
-      cli: notifications.hud.nextDecision.cli,
+      parameters: {
+        category: decision.category,
+        operationFamily: decision.operationFamily,
+        operationType: decision.operationType,
+        target: decision.target,
+      },
+      readOnly: false,
+      sendsMutation: true,
       when: 'after collecting the required inputs named by the HUD decision',
     });
   }

--- a/packages/cli/src/commands/game/play/traditions.ts
+++ b/packages/cli/src/commands/game/play/traditions.ts
@@ -11,8 +11,8 @@ type CompactTraditionAction = {
   label: string;
   parameters: Record<string, unknown>;
   validationSuccess: boolean | null;
-  readOnly: false;
-  sendsMutation: true;
+  readOnly: boolean;
+  sendsMutation: boolean;
   closeout: boolean;
 };
 
@@ -135,7 +135,7 @@ function buildCompactTraditionsView(view: Civ7ProgressionTraditionsResult): {
     recommendedActions: available
       .map((tradition) => tradition.nextAction)
       .filter((action): action is CompactTraditionAction => action != null)
-      .filter((action) => action.validationSuccess === true),
+      .filter((action) => action.sendsMutation && action.validationSuccess === true),
     nextSteps: view.nextSteps,
     omitted: view.omitted,
     hiddenInfoPolicy: view.hiddenInfoPolicy,
@@ -178,17 +178,19 @@ function compactTraditionAction(
   closeout: boolean,
 ): CompactTraditionAction {
   return {
-    kind: action.kind,
-    label: action.kind === 'activate'
-      ? 'Activate this tradition after reviewing the validation result.'
-      : 'Deactivate this tradition after reviewing the validation result.',
+    kind: action.validationSuccess === true ? action.kind : 'validate-tradition-change',
+    label: action.validationSuccess === true
+      ? action.kind === 'activate'
+        ? 'Activate this tradition.'
+        : 'Deactivate this tradition.'
+      : 'Review validation before treating this tradition as send-ready.',
     parameters: {
       traditionType: action.parameters.traditionType,
       action: action.parameters.action,
     },
     validationSuccess: action.validationSuccess,
-    readOnly: false,
-    sendsMutation: true,
+    readOnly: action.validationSuccess !== true,
+    sendsMutation: action.validationSuccess === true,
     closeout,
   };
 }

--- a/packages/cli/src/commands/game/play/traditions.ts
+++ b/packages/cli/src/commands/game/play/traditions.ts
@@ -6,6 +6,16 @@ import {
 import { liveCiv7ControlOrpcDirectControlFacade } from '@civ7/control-orpc/runtime';
 import { buildDirectControlOptions } from '../../../utils/game-play-shared';
 
+type CompactTraditionAction = {
+  kind: string;
+  label: string;
+  parameters: Record<string, unknown>;
+  validationSuccess: boolean | null;
+  readOnly: false;
+  sendsMutation: true;
+  closeout: boolean;
+};
+
 export default class GamePlayTraditions extends Command {
   static id = 'game play traditions';
   static summary = 'Read current tradition slots and available policy actions';
@@ -77,7 +87,7 @@ export default class GamePlayTraditions extends Command {
 function buildCompactTraditionsView(view: Civ7ProgressionTraditionsResult): {
   ok: true;
   contractVersion: 'play-agent-v0';
-  command: 'game play traditions';
+  surface: 'traditions';
   playerId: number;
   turn: unknown;
   turnDate: unknown;
@@ -89,7 +99,7 @@ function buildCompactTraditionsView(view: Civ7ProgressionTraditionsResult): {
   recentUnlocks: Array<Record<string, unknown>>;
   enabledAvailableCount: number;
   disabledAvailableCount: number;
-  recommendedCli: ReadonlyArray<string>;
+  recommendedActions: CompactTraditionAction[];
   nextSteps: Civ7ProgressionTraditionsResult['nextSteps'];
   omitted: Array<{ path: string; reason: string }>;
   hiddenInfoPolicy: unknown;
@@ -97,23 +107,20 @@ function buildCompactTraditionsView(view: Civ7ProgressionTraditionsResult): {
 } {
   const active = view.active.map((tradition) =>
     compactTraditionRow(tradition, {
-      playerId: view.playerId,
       sendCloseout: false,
     }));
   const available = view.available.map((tradition) =>
     compactTraditionRow(tradition, {
-      playerId: view.playerId,
       sendCloseout: true,
     }));
   const recentUnlocks = view.recentUnlocks.map((tradition) =>
     compactTraditionRow(tradition, {
-      playerId: view.playerId,
       sendCloseout: true,
     }));
   return {
     ok: true,
     contractVersion: 'play-agent-v0',
-    command: 'game play traditions',
+    surface: 'traditions',
     playerId: view.playerId,
     turn: view.turn,
     turnDate: view.turnDate,
@@ -125,15 +132,16 @@ function buildCompactTraditionsView(view: Civ7ProgressionTraditionsResult): {
     recentUnlocks,
     enabledAvailableCount: available.filter((tradition) => tradition.validationSuccess === true).length,
     disabledAvailableCount: available.filter((tradition) => tradition.validationSuccess !== true).length,
-    recommendedCli: available
-      .map((tradition) => tradition.validateCli)
-      .filter((command): command is string => Boolean(command)),
+    recommendedActions: available
+      .map((tradition) => tradition.nextAction)
+      .filter((action): action is CompactTraditionAction => action != null)
+      .filter((action) => action.validationSuccess === true),
     nextSteps: view.nextSteps,
     omitted: view.omitted,
     hiddenInfoPolicy: view.hiddenInfoPolicy,
     notes: [
       'Read-only compact tradition option surface. It does not choose or send CHANGE_TRADITION.',
-      'Use validateCli before mutation when proof matters; use sendCloseoutCli only after selecting a tradition for the review blocker.',
+      'Action guidance is semantic; command help owns exact flag combinations.',
       'If slots are full, deactivate an active tradition first, re-read, then activate the selected available tradition.',
     ],
   };
@@ -141,18 +149,11 @@ function buildCompactTraditionsView(view: Civ7ProgressionTraditionsResult): {
 
 function compactTraditionRow(
   tradition: Civ7ProgressionTraditionsResult['traditions'][number],
-  options: { playerId: number; sendCloseout: boolean },
+  options: { sendCloseout: boolean },
 ): Record<string, unknown> {
   const action = tradition.actions[0];
-  const sendCli = action
-    ? traditionChangeCli(action.parameters.traditionType, action.parameters.action)
-    : null;
-  const validateCli = action
-    ? traditionValidationCli(
-        options.playerId,
-        action.parameters.traditionType,
-        action.parameters.action,
-      )
+  const nextAction = action
+    ? compactTraditionAction(action, options.sendCloseout)
     : null;
   return {
     id: tradition.id,
@@ -168,11 +169,27 @@ function compactTraditionRow(
     actionKind: action?.kind ?? null,
     action: action?.action ?? null,
     validationSuccess: action?.validationSuccess ?? null,
-    validateCli: validateCli ? `${validateCli} --json` : null,
-    sendCli: sendCli ? `${sendCli} --send` : null,
-    sendCloseoutCli: options.sendCloseout && sendCli
-      ? `${sendCli} --send --closeout`
-      : null,
+    nextAction,
+  };
+}
+
+function compactTraditionAction(
+  action: Civ7ProgressionTraditionsResult['traditions'][number]['actions'][number],
+  closeout: boolean,
+): CompactTraditionAction {
+  return {
+    kind: action.kind,
+    label: action.kind === 'activate'
+      ? 'Activate this tradition after reviewing the validation result.'
+      : 'Deactivate this tradition after reviewing the validation result.',
+    parameters: {
+      traditionType: action.parameters.traditionType,
+      action: action.parameters.action,
+    },
+    validationSuccess: action.validationSuccess,
+    readOnly: false,
+    sendsMutation: true,
+    closeout,
   };
 }
 
@@ -191,21 +208,4 @@ function formatTradition(tradition: {
 function formatProbe<T>(probe: { ok: true; value: T } | { ok: false; error: string }): string {
   if (!probe.ok) return `<error: ${probe.error}>`;
   return String(probe.value);
-}
-
-function traditionChangeCli(
-  traditionType: number,
-  action: number | null,
-): string | null {
-  if (action == null) return null;
-  return `game play change-tradition --tradition-type ${traditionType} --action ${action}`;
-}
-
-function traditionValidationCli(
-  playerId: number,
-  traditionType: number,
-  action: number | null,
-): string | null {
-  if (action == null) return null;
-  return `game play change-tradition --player-id ${playerId} --tradition-type ${traditionType} --action ${action}`;
 }

--- a/packages/cli/src/commands/game/play/unit-move-preview.ts
+++ b/packages/cli/src/commands/game/play/unit-move-preview.ts
@@ -94,7 +94,7 @@ export default class GamePlayUnitMovePreview extends Command {
 function buildCompactView(view: UnitMovePreviewView): {
   ok: true;
   contractVersion: 'play-agent-v0';
-  command: 'game play unit-move-preview';
+  surface: 'unit-move-preview';
   summary: string;
   unitId: UnitMovePreviewView['unitId'];
   unit: Record<string, unknown> | null;
@@ -115,7 +115,7 @@ function buildCompactView(view: UnitMovePreviewView): {
     requested: Record<string, unknown> | null;
     queued: Record<string, unknown> | null;
   };
-  next: string | null;
+  nextAction: UnitMoveActionDescriptor | null;
   warnings: string[];
   omitted: Array<{ path: string; reason: string }>;
   hiddenInfoPolicy: string;
@@ -143,7 +143,7 @@ function buildCompactView(view: UnitMovePreviewView): {
   return {
     ok: true,
     contractVersion: 'play-agent-v0',
-    command: 'game play unit-move-preview',
+    surface: 'unit-move-preview',
     summary: unit
       ? `${String(unit.typeName ?? 'unit')} at ${formatLocation(unit.location)}`
       : 'no selected or ready unit for movement preview',
@@ -166,9 +166,7 @@ function buildCompactView(view: UnitMovePreviewView): {
       requested: requestedPath,
       queued: queuedPath,
     },
-    next: requestedDestination && view.unitId
-      ? `game play unit-target --unit-id '${JSON.stringify(view.unitId)}' --x ${requestedDestination.x} --y ${requestedDestination.y} --json`
-      : null,
+    nextAction: movementValidationDescriptor(view.unitId, requestedDestination),
     warnings,
     omitted: [
       { path: 'view.reachableMovement', reason: `compact includes up to ${candidateLimit} candidate rows; use --json without --compact for the full reachable movement plot list` },
@@ -240,10 +238,35 @@ function compactPlotCandidates(value: unknown, unitId: UnitMovePreviewView['unit
       y: plot.y,
       currentLocation: sameLocation(plot, unitLocation),
       distanceFromUnit: hexApproxDistance(plot, unitLocation),
-      validateCli: unitId && typeof plot.x === 'number' && typeof plot.y === 'number'
-        ? `game play unit-target --unit-id '${JSON.stringify(unitId)}' --x ${plot.x} --y ${plot.y} --json`
-        : null,
+      nextAction: movementValidationDescriptor(
+        unitId,
+        typeof plot.x === 'number' && typeof plot.y === 'number'
+          ? { x: plot.x, y: plot.y }
+          : null,
+      ),
     }));
+}
+
+type UnitMoveActionDescriptor = {
+  kind: 'validate-unit-action';
+  label: string;
+  unitId: UnitMovePreviewView['unitId'];
+  destination: { x: number; y: number };
+  sendReady: false;
+};
+
+function movementValidationDescriptor(
+  unitId: UnitMovePreviewView['unitId'],
+  destination: { x: number; y: number } | null,
+): UnitMoveActionDescriptor | null {
+  if (!unitId || !destination) return null;
+  return {
+    kind: 'validate-unit-action',
+    label: `validate unit action at (${destination.x},${destination.y}) before sending`,
+    unitId,
+    destination,
+    sendReady: false,
+  };
 }
 
 function flattenPlots(value: unknown): Array<{ index?: number; x?: number; y?: number }> {

--- a/packages/cli/src/game-play/semantic-envelope.ts
+++ b/packages/cli/src/game-play/semantic-envelope.ts
@@ -31,7 +31,7 @@ export type SemanticCliEnvelope = {
   decisions: unknown[];
   actions: unknown[];
   result: Record<string, unknown> | null;
-  nextSteps: string[];
+  nextSteps: unknown[];
   evidence: Array<Record<string, unknown>>;
   notes: string[];
 };

--- a/packages/cli/test/commands/game.play.celebration-government.test.ts
+++ b/packages/cli/test/commands/game.play.celebration-government.test.ts
@@ -105,12 +105,19 @@ describe('game play celebration and government commands', () => {
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
         result: {
+          surface: string;
           enabledOptionCount: number;
           disabledOptionCount: number;
           omitted: Array<{ path: string; reason: string }>;
           surfaces: Array<{
             kind: string;
-            enabledOptions: Array<{ goldenAgeType: number; name: string; chooseCli: string | null; duration: number }>;
+            enabledOptions: Array<{
+              goldenAgeType: number;
+              name: string;
+              nextAction: { kind: string; parameters: { goldenAgeType: number }; sendsMutation: boolean };
+              validationAction: { kind: string; parameters: { goldenAgeType: number }; readOnly: boolean };
+              duration: number;
+            }>;
             options?: unknown;
             disabledOptions?: unknown;
           }>;
@@ -118,6 +125,7 @@ describe('game play celebration and government commands', () => {
         };
       };
       expectNormalPlayPayloadToOmitDebugInternals(payload);
+      expect(payload.result.surface).toBe('celebration-choice-options');
       expect(payload.result.enabledOptionCount).toBe(2);
       expect(payload.result.disabledOptionCount).toBe(0);
       expect(payload.result.details).toBeUndefined();
@@ -127,7 +135,17 @@ describe('game play celebration and government commands', () => {
       const culture = payload.result.surfaces[0].enabledOptions.find((option) => option.goldenAgeType === -340825966);
       expect(culture?.name).toBe('Cultural Celebration');
       expect(culture?.duration).toBe(10);
-      expect(culture?.chooseCli).toContain('game play choose-celebration --golden-age-type -340825966 --send');
+      expect(culture?.nextAction).toMatchObject({
+        kind: 'choose-celebration',
+        parameters: { goldenAgeType: -340825966 },
+        sendsMutation: true,
+      });
+      expect(culture?.validationAction).toMatchObject({
+        kind: 'validate-celebration-choice',
+        parameters: { goldenAgeType: -340825966 },
+        readOnly: true,
+      });
+      expect(JSON.stringify(payload)).not.toContain('game play ');
       expect(payload.result.omitted.map((item) => item.path)).toContain('details[].options');
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
@@ -240,12 +258,19 @@ describe('game play celebration and government commands', () => {
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
         result: {
+          surface: string;
           enabledOptionCount: number;
           disabledOptionCount: number;
           omitted: Array<{ path: string; reason: string }>;
           surfaces: Array<{
             kind: string;
-            enabledOptions: Array<{ governmentType: number; name: string; chooseCli: string | null; celebrationOptions: Array<{ name: string }> }>;
+            enabledOptions: Array<{
+              governmentType: number;
+              name: string;
+              nextAction: { kind: string; parameters: { governmentType: number; action: number }; sendsMutation: boolean };
+              validationAction: { kind: string; parameters: { governmentType: number; action: number }; readOnly: boolean };
+              celebrationOptions: Array<{ name: string }>;
+            }>;
             options?: unknown;
             disabledOptions?: unknown;
           }>;
@@ -253,6 +278,7 @@ describe('game play celebration and government commands', () => {
         };
       };
       expectNormalPlayPayloadToOmitDebugInternals(payload);
+      expect(payload.result.surface).toBe('government-choice-options');
       expect(payload.result.enabledOptionCount).toBe(3);
       expect(payload.result.disabledOptionCount).toBe(0);
       expect(payload.result.details).toBeUndefined();
@@ -261,8 +287,24 @@ describe('game play celebration and government commands', () => {
       expect(payload.result.surfaces[0].disabledOptions).toBeUndefined();
       const republic = payload.result.surfaces[0].enabledOptions.find((option) => option.governmentType === 0);
       expect(republic?.name).toBe('Classical Republic');
-      expect(republic?.chooseCli).toContain('game play choose-government --government-type 0 --action -1326475004 --send');
+      expect(republic?.nextAction).toMatchObject({
+        kind: 'choose-government',
+        parameters: {
+          governmentType: 0,
+          action: -1326475004,
+        },
+        sendsMutation: true,
+      });
+      expect(republic?.validationAction).toMatchObject({
+        kind: 'validate-government-choice',
+        parameters: {
+          governmentType: 0,
+          action: -1326475004,
+        },
+        readOnly: true,
+      });
       expect(republic?.celebrationOptions[0].name).toBe('Cultural Celebration');
+      expect(JSON.stringify(payload)).not.toContain('game play ');
       expect(payload.result.omitted.map((item) => item.path)).toContain('details[].options');
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);

--- a/packages/cli/test/commands/game.play.culture.test.ts
+++ b/packages/cli/test/commands/game.play.culture.test.ts
@@ -49,12 +49,21 @@ describe('game play culture commands', () => {
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
         result: {
+          surface: string;
           enabledOptionCount: number;
           disabledOptionCount: number;
           omitted: Array<{ path: string; reason: string }>;
           surfaces: Array<{
             kind: string;
-            enabledOptions: Array<{ nodeType: number; name: string; chooseCli: string | null; turns: number | null; cost: number | null }>;
+            enabledOptions: Array<{
+              nodeType: number;
+              name: string;
+              nextAction: { kind: string; parameters: { node: number }; sendsMutation: boolean };
+              targetAction: { kind: string; parameters: { node: number }; sendsMutation: boolean };
+              validationAction: { kind: string; parameters: { node: number }; readOnly: boolean };
+              turns: number | null;
+              cost: number | null;
+            }>;
             options?: unknown;
             disabledOptions?: unknown;
           }>;
@@ -62,6 +71,7 @@ describe('game play culture commands', () => {
         };
       };
       expectNormalPlayPayloadToOmitDebugInternals(payload);
+      expect(payload.result.surface).toBe('culture-choice-options');
       expect(payload.result.enabledOptionCount).toBe(2);
       expect(payload.result.disabledOptionCount).toBe(1);
       expect(payload.result.details).toBeUndefined();
@@ -70,11 +80,24 @@ describe('game play culture commands', () => {
       expect(payload.result.surfaces[0].disabledOptions).toBeUndefined();
       const ekklesia = payload.result.surfaces[0].enabledOptions.find((option) => option.nodeType === -869902342);
       expect(ekklesia?.name).toBe('Ekklesia');
-      expect(ekklesia?.chooseCli).toContain('game play choose-culture --node -869902342 --send');
-      expect(ekklesia?.chooseCli).not.toContain('--player-id');
-      expect(ekklesia?.chooseCli).not.toContain('--closeout');
+      expect(ekklesia?.nextAction).toMatchObject({
+        kind: 'choose-culture',
+        parameters: { node: -869902342 },
+        sendsMutation: true,
+      });
+      expect(ekklesia?.targetAction).toMatchObject({
+        kind: 'target-culture',
+        parameters: { node: -869902342 },
+        sendsMutation: true,
+      });
+      expect(ekklesia?.validationAction).toMatchObject({
+        kind: 'validate-culture-choice',
+        parameters: { node: -869902342 },
+        readOnly: true,
+      });
       expect(ekklesia?.turns).toBe(4);
       expect(ekklesia?.cost).toBe(105);
+      expect(JSON.stringify(payload)).not.toContain('game play ');
       expect(payload.result.omitted.map((item) => item.path)).toContain('details[].options');
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);

--- a/packages/cli/test/commands/game.play.narrative.test.ts
+++ b/packages/cli/test/commands/game.play.narrative.test.ts
@@ -209,19 +209,26 @@ describe('game play narrative commands', () => {
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
         result: {
+          surface: string;
           enabledOptionCount: number;
           disabledOptionCount: number;
           omitted: Array<{ path: string; reason: string }>;
           surfaces: Array<{
             kind: string;
             targetStoryId: { owner: number; id: number; type: number } | null;
-            enabledOptions: Array<{ targetType: string; name: string; chooseCli: string | null; validateCli: string | null }>;
+            enabledOptions: Array<{
+              targetType: string;
+              name: string;
+              nextAction: { kind: string; parameters: { targetType: string; action: number }; sendsMutation: boolean };
+              validationAction: { kind: string; parameters: { targetType: string; action: number }; readOnly: boolean };
+            }>;
             options?: unknown;
             disabledOptions?: unknown;
           }>;
           details?: unknown;
         };
       };
+      expect(payload.result.surface).toBe('narrative-choice-options');
       expect(payload.result.enabledOptionCount).toBe(1);
       expect(payload.result.disabledOptionCount).toBe(0);
       expect(payload.result.details).toBeUndefined();
@@ -230,8 +237,17 @@ describe('game play narrative commands', () => {
       expect(payload.result.surfaces[0].disabledOptions).toBeUndefined();
       expect(payload.result.surfaces[0].targetStoryId).toEqual({ owner: 0, id: 45, type: 35 });
       expect(payload.result.surfaces[0].enabledOptions[0].targetType).toBe('CLOSE');
-      expect(payload.result.surfaces[0].enabledOptions[0].chooseCli).toContain('game play choose-narrative --target-type CLOSE');
-      expect(payload.result.surfaces[0].enabledOptions[0].validateCli).toContain('--action -1326475004 --json');
+      expect(payload.result.surfaces[0].enabledOptions[0].nextAction).toMatchObject({
+        kind: 'choose-narrative',
+        parameters: { targetType: 'CLOSE', action: -1326475004 },
+        sendsMutation: true,
+      });
+      expect(payload.result.surfaces[0].enabledOptions[0].validationAction).toMatchObject({
+        kind: 'validate-narrative-choice',
+        parameters: { targetType: 'CLOSE', action: -1326475004 },
+        readOnly: true,
+      });
+      expect(JSON.stringify(payload)).not.toContain('game play ');
       expect(payload.result.omitted.map((item) => item.path)).toContain('details[].storyLinks');
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
@@ -266,8 +282,13 @@ describe('game play narrative commands', () => {
             classification: string;
             targetStoryId: unknown;
             enabledOptions: unknown[];
-            dismissalDiagnosticCli: string | null;
-            unprovenDismissalCli: string | null;
+            dismissalDiagnosticAction: { kind: string; parameters: { target: { owner: number; id: number; type: number } }; readOnly: boolean } | null;
+            unprovenDismissalAction: {
+              kind: string;
+              parameters: { target: { owner: number; id: number; type: number } };
+              sendsMutation: boolean;
+              proofBoundary?: string;
+            } | null;
           }>;
         };
       };
@@ -275,12 +296,18 @@ describe('game play narrative commands', () => {
       expect(payload.result.surfaces[0].classification).toBe('narrative-choice-no-pending-story');
       expect(payload.result.surfaces[0].targetStoryId).toBeNull();
       expect(payload.result.surfaces[0].enabledOptions).toEqual([]);
-      expect(payload.result.surfaces[0].dismissalDiagnosticCli).toBe(
-        'game play dismiss-notification --target \'{"owner":0,"id":5,"type":20}\' --json',
-      );
-      expect(payload.result.surfaces[0].unprovenDismissalCli).toBe(
-        'game play dismiss-notification --target \'{"owner":0,"id":5,"type":20}\' --send',
-      );
+      expect(payload.result.surfaces[0].dismissalDiagnosticAction).toMatchObject({
+        kind: 'inspect-notification-dismissal',
+        parameters: { target: { owner: 0, id: 5, type: 20 } },
+        readOnly: true,
+      });
+      expect(payload.result.surfaces[0].unprovenDismissalAction).toMatchObject({
+        kind: 'dismiss-notification',
+        parameters: { target: { owner: 0, id: 5, type: 20 } },
+        sendsMutation: true,
+        proofBoundary: 'unproven-dismissal',
+      });
+      expect(JSON.stringify(payload)).not.toContain('game play ');
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
       log.mockRestore();
@@ -313,8 +340,12 @@ describe('game play narrative commands', () => {
             classification: string;
             targetStoryId: unknown;
             visiblePanelTargetStoryId: { owner: number; id: number; type: number } | null;
-            enabledOptions: Array<{ targetType: string; target: { owner: number; id: number; type: number }; chooseCli: string | null }>;
-            dismissalDiagnosticCli: string | null;
+            enabledOptions: Array<{
+              targetType: string;
+              target: { owner: number; id: number; type: number };
+              nextAction: { kind: string; parameters: { target: { owner: number; id: number; type: number } }; sendsMutation: boolean };
+            }>;
+            dismissalDiagnosticAction: unknown;
           }>;
         };
       };
@@ -326,8 +357,13 @@ describe('game play narrative commands', () => {
         'DISCOVERY_14001B',
         'DISCOVERY_14001C',
       ]);
-      expect(payload.result.surfaces[0].enabledOptions[0].chooseCli).toContain("--target '{\"owner\":0,\"id\":25,\"type\":35}'");
-      expect(payload.result.surfaces[0].dismissalDiagnosticCli).toBeNull();
+      expect(payload.result.surfaces[0].enabledOptions[0].nextAction).toMatchObject({
+        kind: 'choose-narrative',
+        parameters: { target: { owner: 0, id: 25, type: 35 } },
+        sendsMutation: true,
+      });
+      expect(payload.result.surfaces[0].dismissalDiagnosticAction).toBeNull();
+      expect(JSON.stringify(payload)).not.toContain('game play ');
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
       log.mockRestore();

--- a/packages/cli/test/commands/game.play.progression-read.test.ts
+++ b/packages/cli/test/commands/game.play.progression-read.test.ts
@@ -136,13 +136,13 @@ describe('game play progression reads', () => {
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
         contractVersion: string;
-        command: string;
+        surface: string;
         summary: string;
         age: { ageType: string; ageProgressPercent: number };
         legacyPaths: Array<{ classType: string; score: number; finalRequiredPathPoints: number; progressPercent: number; nextMilestone: string }>;
         triumphs: { count: number };
         proof: { sources: string[] };
-        next: string | null;
+        nextAction: { kind: string; label: string } | null;
         nextSteps: Array<{ kind: string; label: string }>;
         warnings: string[];
         omitted: Array<{ path: string }>;
@@ -150,7 +150,7 @@ describe('game play progression reads', () => {
       };
       expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(payload.contractVersion).toBe('play-agent-v0');
-      expect(payload.command).toBe('game play progress-dashboard');
+      expect(payload.surface).toBe('progress-dashboard');
       expect(payload.summary).toContain('AGE_ANTIQUITY progress');
       expect(payload.age.ageType).toBe('AGE_ANTIQUITY');
       expect(payload.age.ageProgressPercent).toBe(2.1);
@@ -159,9 +159,10 @@ describe('game play progression reads', () => {
       expect(payload.legacyPaths.find((path) => path.classType === 'science')?.progressPercent).toBe(10);
       expect(payload.triumphs.count).toBe(0);
       expect(payload.proof.sources).toContain('player.LegacyPaths.getScore');
-      expect(payload.next).toBe('game play priorities --compact --json');
+      expect(payload.nextAction).toMatchObject({ kind: 'read-attention-priorities' });
       expect(payload.nextSteps[0].kind).toBe('read-attention-priorities');
       expect(JSON.stringify(payload.nextSteps)).not.toContain('game play ');
+      expect(JSON.stringify(payload)).not.toContain('game play ');
       expect(payload.warnings.join(' ')).toContain('VictoryManager is module-local');
       expect(payload.omitted.some((item) => item.path === 'dashboard.legacyPaths[].milestones')).toBe(true);
       expect(payload.view).toBeUndefined();

--- a/packages/cli/test/commands/game.play.progression-read.test.ts
+++ b/packages/cli/test/commands/game.play.progression-read.test.ts
@@ -104,9 +104,9 @@ describe('game play progression reads', () => {
       expect(payload.available[0].sendCloseoutCli).toContain('game play change-tradition --tradition-type 90243567 --action -1326475004 --send --closeout');
       expect(payload.enabledAvailableCount).toBe(1);
       expect(payload.disabledAvailableCount).toBe(0);
-      expect(payload.omitted.map((item) => item.path)).toContain('directControl.cliCommandSuggestions');
-      expect(payload.omitted.map((item) => item.path)).toContain('tradition.actionHints[].cli');
-      expect(payload.omitted.map((item) => item.path)).toContain('tradition.actionHints[].validation');
+      expect(payload.omitted.map((item) => item.path)).toContain('presentation.commandSuggestions');
+      expect(payload.omitted.map((item) => item.path)).toContain('presentation.actionDirections');
+      expect(payload.omitted.map((item) => item.path)).toContain('runtime.validationProbe');
       expect(server.received.some((message) => message.includes('readTraditionsView'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
       expect(server.received.some((message) => message.includes('sendRequest('))).toBe(false);

--- a/packages/cli/test/commands/game.play.progression-read.test.ts
+++ b/packages/cli/test/commands/game.play.progression-read.test.ts
@@ -137,11 +137,13 @@ describe('game play progression reads', () => {
         name: 'Discipline',
         validationSuccess: false,
         nextAction: {
-          kind: 'activate',
+          kind: 'validate-tradition-change',
           validationSuccess: false,
-          sendsMutation: true,
+          readOnly: true,
+          sendsMutation: false,
         },
       });
+      expect(payload.recommendedActions.every((action) => action.kind !== 'validate-tradition-change')).toBe(true);
       expect(JSON.stringify(payload.recommendedActions)).not.toContain('111222333');
       expect(JSON.stringify(payload)).not.toContain('game play change-tradition');
       expect(payload.enabledAvailableCount).toBe(1);

--- a/packages/cli/test/commands/game.play.progression-read.test.ts
+++ b/packages/cli/test/commands/game.play.progression-read.test.ts
@@ -39,7 +39,7 @@ describe('game play progression reads', () => {
       };
       expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(payload.view.slots.active).toBe(1);
-      expect(payload.view.slots.available).toBe(1);
+      expect(payload.view.slots.available).toBe(2);
       expect(payload.view.actions.activate).toBe(-1326475004);
       expect(payload.view.actions.deactivate).toBe(1318334332);
       expect(payload.view.active[0].name).toBe('Honor');
@@ -79,31 +79,73 @@ describe('game play progression reads', () => {
 
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
-        command: string;
-        active: Array<{ id: number; name: string; sendCloseoutCli: string | null }>;
-        available: Array<{ id: number; name: string; validationSuccess: boolean; sendCloseoutCli: string | null; validateCli: string | null }>;
+        surface: string;
+        active: Array<{ id: number; name: string; nextAction: { kind: string; closeout: boolean } | null }>;
+        available: Array<{
+          id: number;
+          name: string;
+          validationSuccess: boolean;
+          nextAction: {
+            kind: string;
+            parameters: { traditionType: number; action: number };
+            validationSuccess: boolean;
+            closeout: boolean;
+            sendsMutation: boolean;
+          } | null;
+        }>;
+        recommendedActions: Array<{ kind: string; parameters: { traditionType: number; action: number } }>;
         enabledAvailableCount: number;
         disabledAvailableCount: number;
         omitted: Array<{ path: string }>;
         traditions?: unknown;
       };
       expectNormalPlayPayloadToOmitDebugInternals(payload);
-      expect(payload.command).toBe('game play traditions');
+      expect(payload.surface).toBe('traditions');
       expect(payload.traditions).toBeUndefined();
       expect(payload.active[0]).toMatchObject({
         id: -331546976,
         name: 'Honor',
-        sendCloseoutCli: null,
+        nextAction: {
+          kind: 'deactivate',
+          closeout: false,
+        },
       });
       expect(payload.available[0]).toMatchObject({
         id: 90243567,
         name: 'Oratory',
         validationSuccess: true,
+        nextAction: {
+          kind: 'activate',
+          parameters: {
+            traditionType: 90243567,
+            action: -1326475004,
+          },
+          validationSuccess: true,
+          closeout: true,
+          sendsMutation: true,
+        },
       });
-      expect(payload.available[0].validateCli).toContain('game play change-tradition --player-id 0 --tradition-type 90243567 --action -1326475004 --json');
-      expect(payload.available[0].sendCloseoutCli).toContain('game play change-tradition --tradition-type 90243567 --action -1326475004 --send --closeout');
+      expect(payload.recommendedActions[0]).toMatchObject({
+        kind: 'activate',
+        parameters: {
+          traditionType: 90243567,
+          action: -1326475004,
+        },
+      });
+      expect(payload.recommendedActions).toHaveLength(1);
+      expect(payload.available.find((tradition) => tradition.id === 111222333)).toMatchObject({
+        name: 'Discipline',
+        validationSuccess: false,
+        nextAction: {
+          kind: 'activate',
+          validationSuccess: false,
+          sendsMutation: true,
+        },
+      });
+      expect(JSON.stringify(payload.recommendedActions)).not.toContain('111222333');
+      expect(JSON.stringify(payload)).not.toContain('game play change-tradition');
       expect(payload.enabledAvailableCount).toBe(1);
-      expect(payload.disabledAvailableCount).toBe(0);
+      expect(payload.disabledAvailableCount).toBe(1);
       expect(payload.omitted.map((item) => item.path)).toContain('presentation.commandSuggestions');
       expect(payload.omitted.map((item) => item.path)).toContain('presentation.actionDirections');
       expect(payload.omitted.map((item) => item.path)).toContain('runtime.validationProbe');
@@ -215,6 +257,29 @@ function traditionsView() {
       },
     ],
   };
+  const disabledAvailable = {
+    id: 111222333,
+    type: 'TRADITION_DISCIPLINE',
+    name: 'Discipline',
+    description: 'Military-facing policy.',
+    ageType: null,
+    cultureSlotType: null,
+    traitType: null,
+    isCrisis: false,
+    active: false,
+    unlocked: true,
+    recentUnlock: false,
+    actionHints: [
+      {
+        kind: 'activate',
+        action: activate,
+        operationType: 'CHANGE_TRADITION',
+        args: { TraditionType: 111222333, Action: activate },
+        validation: { ok: true, value: { Success: false } },
+        cli: `game play change-tradition --player-id 0 --tradition-type 111222333 --action ${activate}`,
+      },
+    ],
+  };
   const active = {
     id: -331546976,
     type: 'TRADITION_HONOR',
@@ -252,15 +317,15 @@ function traditionsView() {
       normal: { ok: true, value: 1 },
       crisis: { ok: true, value: 0 },
       active: 1,
-      unlocked: 2,
-      available: 1,
+      unlocked: 3,
+      available: 2,
       open: 0,
     },
     actions: { activate, deactivate },
     active: [active],
-    available: [available],
+    available: [available, disabledAvailable],
     recentUnlocks: [available],
-    traditions: [active, available],
+    traditions: [active, available, disabledAvailable],
     recommendedCli: [available.actionHints[0].cli],
     hiddenInfoPolicy: 'player-culture-runtime',
     notes: ['Read-only traditions view; it does not send CHANGE_TRADITION or CONSIDER_ASSIGN_TRADITIONS.'],

--- a/packages/cli/test/commands/game.play.rehydrate.test.ts
+++ b/packages/cli/test/commands/game.play.rehydrate.test.ts
@@ -27,12 +27,31 @@ describe('game play rehydrate command', () => {
         snapshot: {
           readyUnit: unknown;
           continuity: { status: string; warnings: string[] };
+          commonActions: Array<{
+            kind: string;
+            parameters: Record<string, unknown>;
+            readOnly: boolean;
+            sendsMutation: boolean;
+          }>;
         };
       };
       expectNormalPlayPayloadToOmitDebugInternals(payload);
       expect(payload.snapshot.readyUnit).not.toBeNull();
       expect(payload.snapshot.continuity.status).toBe('mismatch');
       expect(payload.snapshot.continuity.warnings[0]).toMatch(/turn mismatch/);
+      expect(payload.snapshot.commonActions).toContainEqual(expect.objectContaining({
+        kind: 'refresh-notifications',
+        parameters: { maxNotifications: 25 },
+        readOnly: true,
+        sendsMutation: false,
+      }));
+      expect(payload.snapshot.commonActions).toContainEqual(expect.objectContaining({
+        kind: 'inspect-ready-unit',
+        parameters: { unitId: { owner: 0, id: 458752, type: 26 } },
+        readOnly: true,
+        sendsMutation: false,
+      }));
+      expect(JSON.stringify(payload.snapshot.commonActions)).not.toContain('game play ');
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('readReadyUnitView'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendRequest'))).toBe(false);

--- a/packages/cli/test/commands/game.play.tactical-read.test.ts
+++ b/packages/cli/test/commands/game.play.tactical-read.test.ts
@@ -177,7 +177,8 @@ describe('game play tactical read commands', () => {
         ...payload.view.formation.reasons,
         ...payload.view.formation.nextInspections,
       ]);
-      expect(payload.view.formation.nextInspections).toContain('game play civilian-route-triage --x 16 --y 18 --json');
+      expect(payload.view.formation.nextInspections).toContain('Inspect route options for the civilian before moving.');
+      expect(JSON.stringify(payload.view.formation.nextInspections)).not.toContain('game play ');
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('readReadyUnitView'))).toBe(true);
       expect(server.received.some((message) => message.includes('readBattlefieldScan'))).toBe(true);

--- a/packages/cli/test/commands/game.play.tactical-read.test.ts
+++ b/packages/cli/test/commands/game.play.tactical-read.test.ts
@@ -97,7 +97,8 @@ describe('game play tactical read commands', () => {
       expect(payload.view.target).toEqual({ x: 13, y: 17 });
       expect(payload.view.summary.pressure.some((item) => item.source === 'battlefield')).toBe(true);
       expect(payload.view.summary.pressure.some((item) => item.source === 'destination')).toBe(true);
-      expect(payload.view.summary.nextInspections.some((item) => item.includes('unit-target'))).toBe(true);
+      expect(payload.view.summary.nextInspections.some((item) => item.includes('unit action validation'))).toBe(true);
+      expect(JSON.stringify(payload.view.summary.nextInspections)).not.toContain('game play ');
       expectPositiveRelationshipLabels([
         ...payload.view.summary.pressure.map((item) => item.summary ?? ''),
         ...payload.view.summary.risks,

--- a/packages/cli/test/commands/game.play.tactical-read.test.ts
+++ b/packages/cli/test/commands/game.play.tactical-read.test.ts
@@ -29,7 +29,8 @@ describe('game play tactical read commands', () => {
       expect(payload.view.origin).toEqual({ x: 15, y: 23 });
       expect(payload.view.destination).toEqual({ x: 20, y: 20 });
       expect(payload.view.triage.status).toMatch(/hold|reroute|proceed|inspect/);
-      expect(payload.view.triage.nextInspections.some((item) => item.includes('unit-target'))).toBe(true);
+      expect(payload.view.triage.nextInspections.some((item) => item.includes('unit action validation'))).toBe(true);
+      expect(JSON.stringify(payload.view.triage.nextInspections)).not.toContain('game play ');
       expect(payload.view.triage.reasons.length).toBeGreaterThan(0);
       expectPositiveRelationshipLabels(payload.view.triage.reasons);
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);

--- a/packages/cli/test/commands/game.play.technology.test.ts
+++ b/packages/cli/test/commands/game.play.technology.test.ts
@@ -49,12 +49,21 @@ describe('game play technology commands', () => {
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
         result: {
+          surface: string;
           enabledOptionCount: number;
           disabledOptionCount: number;
           omitted: Array<{ path: string; reason: string }>;
           surfaces: Array<{
             kind: string;
-            enabledOptions: Array<{ nodeType: number; name: string; chooseCli: string | null; turns: number | null; cost: number | null }>;
+            enabledOptions: Array<{
+              nodeType: number;
+              name: string;
+              nextAction: { kind: string; parameters: { node: number }; sendsMutation: boolean };
+              targetAction: { kind: string; parameters: { node: number }; sendsMutation: boolean };
+              validationAction: { kind: string; parameters: { node: number }; readOnly: boolean };
+              turns: number | null;
+              cost: number | null;
+            }>;
             options?: unknown;
             disabledOptions?: unknown;
           }>;
@@ -62,6 +71,7 @@ describe('game play technology commands', () => {
         };
       };
       expectNormalPlayPayloadToOmitDebugInternals(payload);
+      expect(payload.result.surface).toBe('technology-choice-options');
       expect(payload.result.enabledOptionCount).toBe(2);
       expect(payload.result.disabledOptionCount).toBe(1);
       expect(payload.result.details).toBeUndefined();
@@ -70,11 +80,24 @@ describe('game play technology commands', () => {
       expect(payload.result.surfaces[0].disabledOptions).toBeUndefined();
       const masonry = payload.result.surfaces[0].enabledOptions.find((option) => option.nodeType === -1255676052);
       expect(masonry?.name).toBe('Masonry');
-      expect(masonry?.chooseCli).toContain('game play choose-tech --node -1255676052 --send');
-      expect(masonry?.chooseCli).not.toContain('--player-id');
-      expect(masonry?.chooseCli).not.toContain('--closeout');
+      expect(masonry?.nextAction).toMatchObject({
+        kind: 'choose-technology',
+        parameters: { node: -1255676052 },
+        sendsMutation: true,
+      });
+      expect(masonry?.targetAction).toMatchObject({
+        kind: 'target-technology',
+        parameters: { node: -1255676052 },
+        sendsMutation: true,
+      });
+      expect(masonry?.validationAction).toMatchObject({
+        kind: 'validate-technology-choice',
+        parameters: { node: -1255676052 },
+        readOnly: true,
+      });
       expect(masonry?.turns).toBe(2);
       expect(masonry?.cost).toBe(137);
+      expect(JSON.stringify(payload)).not.toContain('game play ');
       expect(payload.result.omitted.map((item) => item.path)).toContain('details[].options');
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);

--- a/packages/cli/test/commands/game/play/notification/hud.test.ts
+++ b/packages/cli/test/commands/game/play/notification/hud.test.ts
@@ -24,10 +24,10 @@ describe('game play notifications command', () => {
       expect(details?.actionId).toBe(8);
       expect(details?.options.map((option) => option.title)).toEqual(['Support', 'Accept', 'Reject']);
       expect(details?.disabledOptions[0].responseType).toBe(-1907089594);
-      expect(details?.disabledOptions[0].cli).toBeNull();
+      expect(details?.disabledOptions[0]).not.toHaveProperty('cli');
       expect(details?.enabledOptions.map((option) => option.responseType)).toEqual([926305338, -1200641623]);
-      expect(details?.enabledOptions[0].cli).toContain('game play respond-diplomacy --action-id 8 --response-type 926305338');
-      expect(details?.enabledOptions[0].cli).toContain("--notification-id '{\"owner\":0,\"id\":19,\"type\":20}'");
+      expect(details?.enabledOptions[0]).toMatchObject({ responseType: 926305338, title: 'Accept' });
+      expect(details?.enabledOptions[0]).not.toHaveProperty('cli');
       expect(payload.view.hud.nextDecision.details).toBeDefined();
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
     } finally {
@@ -43,11 +43,10 @@ describe('game play notifications command', () => {
       expect(details?.enabledOptions.map((option) => option.name).sort()).toEqual(['Masonry', 'Sailing']);
       const masonry = details?.enabledOptions.find((option) => option.nodeType === -1255676052);
       expect(masonry?.chooseValidation.value?.Success).toBe(true);
-      expect(masonry?.cli).toContain('game play choose-tech --node -1255676052 --send');
-      expect(masonry?.cli).not.toContain('--player-id');
-      expect(masonry?.cli).not.toContain('--closeout');
+      expect(masonry).toMatchObject({ nodeType: -1255676052, name: 'Masonry' });
+      expect(masonry).not.toHaveProperty('cli');
       expect(details?.disabledOptions[0].name).toBe('Agriculture');
-      expect(details?.disabledOptions[0].cli).toBeNull();
+      expect(details?.disabledOptions[0]).not.toHaveProperty('cli');
       expect(payload.view.hud.nextDecision.details).toBeDefined();
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
     } finally {
@@ -65,11 +64,10 @@ describe('game play notifications command', () => {
       expect(details?.enabledOptions.map((option) => option.name).sort()).toEqual(['Discipline', 'Ekklesia']);
       const ekklesia = details?.enabledOptions.find((option) => option.nodeType === -869902342);
       expect(ekklesia?.chooseValidation.value?.Success).toBe(true);
-      expect(ekklesia?.cli).toContain('game play choose-culture --node -869902342 --send');
-      expect(ekklesia?.cli).not.toContain('--closeout');
-      expect(ekklesia?.cli).not.toContain('--player-id');
+      expect(ekklesia).toMatchObject({ nodeType: -869902342, name: 'Ekklesia' });
+      expect(ekklesia).not.toHaveProperty('cli');
       expect(details?.disabledOptions[0].name).toBe('Mysticism');
-      expect(details?.disabledOptions[0].cli).toBeNull();
+      expect(details?.disabledOptions[0]).not.toHaveProperty('cli');
       expect(payload.view.hud.nextDecision.details).toBeDefined();
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
     } finally {
@@ -87,7 +85,8 @@ describe('game play notifications command', () => {
       expect(details?.enabledOptions.map((option) => option.name).sort()).toEqual(['Cultural Celebration', 'Wonder Production Celebration']);
       const culture = details?.enabledOptions.find((option) => option.goldenAgeType === -340825966);
       expect(culture?.validation.value?.Success).toBe(true);
-      expect(culture?.cli).toContain('game play choose-celebration --golden-age-type -340825966 --send');
+      expect(culture).toMatchObject({ goldenAgeType: -340825966, name: 'Cultural Celebration' });
+      expect(culture).not.toHaveProperty('cli');
       expect(details?.disabledOptions).toEqual([]);
       expect(payload.view.hud.nextDecision.details).toBeDefined();
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
@@ -106,7 +105,8 @@ describe('game play notifications command', () => {
       expect(details?.enabledOptions.map((option) => option.name)).toEqual(['Classical Republic', 'Despotism', 'Oligarchy']);
       const republic = details?.enabledOptions.find((option) => option.governmentType === 0);
       expect(republic?.validation.value?.Success).toBe(true);
-      expect(republic?.cli).toContain('game play choose-government --government-type 0 --action -1326475004 --send');
+      expect(republic).toMatchObject({ governmentType: 0, name: 'Classical Republic' });
+      expect(republic).not.toHaveProperty('cli');
       expect(details?.disabledOptions).toEqual([]);
       expect(payload.view.hud.nextDecision.details).toBeDefined();
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
@@ -126,7 +126,7 @@ describe('game play notifications command', () => {
       expect(details?.storyLinks.value).toEqual([]);
       expect(details?.enabledOptions[0].targetType).toBe('CLOSE');
       expect(details?.enabledOptions[0].validation.value?.Success).toBe(true);
-      expect(details?.enabledOptions[0].cli).toContain('game play choose-narrative --target-type CLOSE');
+      expect(details?.enabledOptions[0]).not.toHaveProperty('cli');
       expect(details?.disabledOptions).toEqual([]);
       expect(payload.view.hud.nextDecision.details).toBeDefined();
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
@@ -144,8 +144,7 @@ describe('game play notifications command', () => {
       expect(details?.enabledCloseoutCandidates).toHaveLength(1);
       expect(details?.enabledCloseoutCandidates[0].unitId).toEqual({ owner: 0, id: 196609, type: 26 });
       expect(details?.enabledCloseoutCandidates[0].operationType).toBe('SKIP_TURN');
-      expect(details?.enabledCloseoutCandidates[0].cli).toContain('game play operation --family unit --type SKIP_TURN');
-      expect(details?.enabledCloseoutCandidates[0].cli).toContain("--unit-id '{\"owner\":0,\"id\":196609,\"type\":26}'");
+      expect(details?.enabledCloseoutCandidates[0]).not.toHaveProperty('cli');
       expect(payload.view.hud.nextDecision.details).toBeDefined();
     } finally {
       await server.close();
@@ -185,7 +184,7 @@ describe('game play notifications command', () => {
       expect(payload.view.hud.nextDecision.category).toBe('informational-notification');
       expect(payload.view.hud.nextDecision.operationFamily).toBe('app-ui-action');
       expect(payload.view.hud.nextDecision.operationType).toBe('Game.Notifications.dismiss');
-      expect(payload.view.hud.nextDecision.cli).toBe('game play dismiss-notification');
+      expect(payload.view.hud.nextDecision).not.toHaveProperty('cli');
       expect(payload.view.hud.nextDecision.notes.join(' ')).toContain('do not send RESPOND_DIPLOMATIC_ACTION');
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -206,7 +205,7 @@ describe('game play notifications command', () => {
       expect(payload.view.hud.nextDecision.category).toBe('informational-notification');
       expect(payload.view.hud.nextDecision.operationFamily).toBe('app-ui-action');
       expect(payload.view.hud.nextDecision.operationType).toBe('Game.Notifications.dismiss');
-      expect(payload.view.hud.nextDecision.cli).toBe('game play dismiss-notification');
+      expect(payload.view.hud.nextDecision).not.toHaveProperty('cli');
       expect(payload.view.hud.nextDecision.notes.join(' ')).toContain('real diplomatic event id');
       expect(payload.view.hud.nextDecision.notes.join(' ')).toContain('reviewed report closeout');
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
@@ -254,10 +253,10 @@ async function runNotificationHud(mode: NotificationHudMode = 'default') {
           choices?: { ok: boolean; value?: string[] };
           startingGovernments?: { ok: boolean; value?: Array<{ GovernmentType: number }> };
           action?: number;
-          options?: Array<{ title?: string; responseType?: number; enabled?: boolean; disabled?: boolean; cli: string | null }>;
+          options?: Array<{ title?: string; responseType?: number; enabled?: boolean; disabled?: boolean }>;
           enabledOptions?: Array<Record<string, unknown>>;
           disabledOptions?: Array<Record<string, unknown>>;
-          enabledCloseoutCandidates?: Array<{ unitId: { owner: number; id: number; type: number }; operationType: string; cli: string | null }>;
+          enabledCloseoutCandidates?: Array<{ unitId: { owner: number; id: number; type: number }; operationType: string }>;
           staleReadyPointerSuspected?: boolean;
         };
       }>;
@@ -266,7 +265,6 @@ async function runNotificationHud(mode: NotificationHudMode = 'default') {
           category: string;
           operationFamily?: string;
           operationType?: string;
-          cli?: string | null;
           notes: string[];
           details?: unknown;
         };
@@ -274,6 +272,8 @@ async function runNotificationHud(mode: NotificationHudMode = 'default') {
     };
   };
   expectNormalPlayPayloadToOmitDebugInternals(payload);
+  expect(JSON.stringify(payload.view)).not.toContain('"cli"');
+  expect(JSON.stringify(payload.view)).not.toContain('game play ');
 
   return {
     payload,

--- a/packages/cli/test/commands/game/play/notification/hud.test.ts
+++ b/packages/cli/test/commands/game/play/notification/hud.test.ts
@@ -162,6 +162,23 @@ describe('game play notifications command', () => {
     }
   });
 
+  test('renders text action guidance without command recipes', async () => {
+    const { writes, server } = await runNotificationHudText('stale-diplomacy');
+    try {
+      const output = writes.join('\n');
+      expect(output).toContain('Decision HUD');
+      expect(output).toContain('action: diplomacy-response');
+      expect(output).toContain('operation: player-operation RESPOND_DIPLOMATIC_ACTION');
+      expect(output).not.toContain('shortcut:');
+      expect(output).not.toContain('  cli:');
+      expect(output).not.toContain('game play ');
+      expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
+      expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
+    } finally {
+      await server.close();
+    }
+  });
+
   test('classifies invalid-target diplomatic agenda notices as informational closeouts', async () => {
     const { payload, server } = await runNotificationHud('diplomatic-report');
     try {
@@ -260,6 +277,30 @@ async function runNotificationHud(mode: NotificationHudMode = 'default') {
 
   return {
     payload,
+    server,
+  };
+}
+
+async function runNotificationHudText(mode: NotificationHudMode = 'default') {
+  const server = await startNotificationHudTunerServer(mode);
+  const writes: string[] = [];
+  const log = vi.spyOn(GamePlayNotifications.prototype, 'log').mockImplementation((message?: string) => {
+    if (message) writes.push(message);
+  });
+  try {
+    const { port } = server.address();
+    await GamePlayNotifications.run([
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(port),
+    ]);
+  } finally {
+    log.mockRestore();
+  }
+
+  return {
+    writes,
     server,
   };
 }

--- a/packages/cli/test/commands/game/play/notification/queue.test.ts
+++ b/packages/cli/test/commands/game/play/notification/queue.test.ts
@@ -23,7 +23,9 @@ describe('game play notification queue command', () => {
       expect(payload.view.schedule[0].disposition).toBe('operate-with-live-inputs');
       expect(payload.view.schedule.some((step) => step.disposition === 'reviewed-dismissal-candidate')).toBe(true);
       expect(payload.view.schedule.some((step) => step.safeToBatch === true)).toBe(true);
-      expect(payload.view.schedule.some((step) => step.command?.includes('dismiss-notification'))).toBe(true);
+      expect(payload.view.schedule.some((step) => step.nextStep?.kind === 'dismiss-notification')).toBe(true);
+      expect(JSON.stringify(payload.view.schedule)).not.toContain('"command"');
+      expect(JSON.stringify(payload.view.schedule)).not.toContain('game play ');
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
       expect(server.received.some((message) => message.includes('readNotificationDismissal'))).toBe(false);
@@ -34,13 +36,16 @@ describe('game play notification queue command', () => {
     }
   });
 
-  test('schedules recommended operation commands from notification details', async () => {
+  test('schedules semantic operation next steps from notification details', async () => {
     const { payload, server } = await runNotificationQueue('first-meet');
     try {
       const step = payload.view.schedule[0];
       expect(step.category).toBe('first-meet-diplomacy');
       expect(step.disposition).toBe('operate-with-live-inputs');
-      expect(step.command).toBe('game play respond-first-meet --json');
+      expect(step.nextStep).toMatchObject({
+        kind: 'validate-operation',
+        label: 'Read the specialized current surface and validator evidence before any send.',
+      });
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
       await server.close();
@@ -48,17 +53,17 @@ describe('game play notification queue command', () => {
   });
 
   test.each([
-    ['tech-choice', 'NOTIFICATION_CHOOSE_TECH', 'game play choose-tech --options --json'],
-    ['culture-choice', 'NOTIFICATION_CHOOSE_CULTURE_NODE', 'game play choose-culture --options --json'],
-    ['celebration-choice', 'NOTIFICATION_CHOOSE_GOLDEN_AGE', 'game play choose-celebration --options --json'],
-    ['government-choice', 'NOTIFICATION_CHOOSE_GOVERNMENT', 'game play choose-government --options --json'],
-    ['narrative-choice', 'NOTIFICATION_CHOOSE_DISCOVERY_STORY_DIRECTION', 'game play choose-narrative --options --json'],
-  ] as const)('routes %s notification queue entries to compact option readers', async (mode, typeName, command) => {
+    ['tech-choice', 'NOTIFICATION_CHOOSE_TECH'],
+    ['culture-choice', 'NOTIFICATION_CHOOSE_CULTURE_NODE'],
+    ['celebration-choice', 'NOTIFICATION_CHOOSE_GOLDEN_AGE'],
+    ['government-choice', 'NOTIFICATION_CHOOSE_GOVERNMENT'],
+    ['narrative-choice', 'NOTIFICATION_CHOOSE_DISCOVERY_STORY_DIRECTION'],
+  ] as const)('routes %s notification queue entries to semantic operation validation', async (mode, typeName) => {
     const { payload, server } = await runNotificationQueue(mode);
     try {
       const step = payload.view.schedule.find((item) => item.typeName === typeName);
       expect(step?.disposition).toBe('operate-with-live-inputs');
-      expect(step?.command).toBe(command);
+      expect(step?.nextStep?.kind).toBe('validate-operation');
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
       await server.close();
@@ -72,7 +77,8 @@ describe('game play notification queue command', () => {
       expect(step.typeName).toBe('NOTIFICATION_LEGACY_COMPLETED');
       expect(step.disposition).toBe('reviewed-dismissal-candidate');
       expect(step.safeToBatch).toBe(true);
-      expect(step.command).toContain('dismiss-notification');      expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
+      expect(step.nextStep?.kind).toBe('dismiss-notification');
+      expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
       await server.close();
     }
@@ -84,7 +90,8 @@ describe('game play notification queue command', () => {
       const step = payload.view.schedule[0];
       expect(step.disposition).toBe('reviewed-dismissal-candidate');
       expect(step.typeName).toBe('NOTIFICATION_UNIT_LOST');
-      expect(step.command).toContain("game play dismiss-notification --target '{\"owner\":0,\"id\":34,\"type\":20}'");      expect(step.command).not.toMatch(/enemy|hostile|opponent/i);
+      expect(step.nextStep?.kind).toBe('dismiss-notification');
+      expect(step.nextStep?.label).not.toMatch(/enemy|hostile|opponent/i);
       expect(step.safeToBatch).toBe(false);
     } finally {
       await server.close();
@@ -117,9 +124,9 @@ async function runNotificationQueue(mode: QueueMode) {
       queueLength: number;
       schedule: Array<{
         category: string;
-        command: string | null;
         disposition: string;
         isEndTurnBlocking: boolean;
+        nextStep: { kind: string; label: string } | null;
         safeToBatch: boolean;
         typeName: string | null;
       }>;
@@ -171,7 +178,6 @@ function decisionQueueFor(mode: QueueMode) {
         summary: 'Lafayette has started a Diplomatic Action with you.',
         category: 'diplomacy-response',
         operationType: 'RESPOND_DIPLOMATIC_ACTION',
-        cli: 'game play respond-diplomacy',
         requiredInputs: [{ name: 'ID', source: 'live diplomatic action', required: true }],
         isEndTurnBlocking: true,
       }),
@@ -207,7 +213,6 @@ function decisionQueueFor(mode: QueueMode) {
         summary: 'You have met Ashoka, World Renouncer of Mauryan Empire.',
         category: 'first-meet-diplomacy',
         operationType: 'RESPOND_DIPLOMATIC_FIRST_MEET',
-        cli: 'game play respond-first-meet',
         isEndTurnBlocking: true,
         details: {
           kind: 'first-meet-diplomacy',
@@ -249,7 +254,6 @@ function decisionQueueFor(mode: QueueMode) {
       summary: optionModeSummary(mode),
       category: optionModeCategory(mode),
       operationType: optionModeOperation(mode),
-      cli: optionModeCli(mode),
       isEndTurnBlocking: true,
       details: {
         kind: optionModeDetailsKind(mode),
@@ -265,7 +269,6 @@ function operationDecision(input: {
   summary: string;
   category: string;
   operationType: string;
-  cli: string;
   requiredInputs?: Array<{ name: string; source: string; required: boolean }>;
   isEndTurnBlocking: boolean;
   details?: unknown;
@@ -282,7 +285,6 @@ function operationDecision(input: {
     operationFamily: 'player-operation',
     operationType: input.operationType,
     requiredInputs: input.requiredInputs ?? [],
-    cli: input.cli,
     details: input.details,
   };
 }
@@ -358,16 +360,6 @@ function optionModeOperation(mode: Exclude<QueueMode, 'mixed-queue' | 'first-mee
     'celebration-choice': 'CHOOSE_GOLDEN_AGE',
     'government-choice': 'CHANGE_GOVERNMENT',
     'narrative-choice': 'CHOOSE_NARRATIVE_STORY_DIRECTION',
-  }[mode];
-}
-
-function optionModeCli(mode: Exclude<QueueMode, 'mixed-queue' | 'first-meet' | 'legacy-completed' | 'unit-lost-report'>): string {
-  return {
-    'tech-choice': 'game play choose-tech',
-    'culture-choice': 'game play choose-culture',
-    'celebration-choice': 'game play choose-celebration',
-    'government-choice': 'game play choose-government',
-    'narrative-choice': 'game play choose-narrative',
   }[mode];
 }
 

--- a/packages/cli/test/commands/game/play/priorities.test.ts
+++ b/packages/cli/test/commands/game/play/priorities.test.ts
@@ -29,6 +29,14 @@ type PriorityHudMode =
   | 'unit-lost-report'
   | 'diplomatic-action-report';
 
+type CompactPriorityAction = {
+  kind: string;
+  label: string;
+  readOnly: boolean;
+  sendsMutation: boolean;
+  parameters?: Record<string, unknown>;
+};
+
 describe('game play priorities command', () => {
   test('reads play priorities without sending operations', async () => {
     const { payload, server } = await runPriorities('ready-unit', { compact: false, battlefield: true });
@@ -55,10 +63,10 @@ describe('game play priorities command', () => {
     const { payload, server } = await runPriorities('runtime-error', { compact: false });
     try {
       const view = payload.view as {
-        priorities: Array<{ kind: string; command?: string; evidenceLabels?: string[] }>;
+        priorities: Array<{ kind: string; nextAction?: CompactPriorityAction; evidenceLabels?: string[] }>;
       };
       const runtimeError = view.priorities.find((item) => item.kind === 'runtime-state-error');
-      expect(runtimeError?.command).toContain('game play rehydrate --json');
+      expect(runtimeError?.nextAction).toMatchObject({ kind: 'observe', readOnly: true, sendsMutation: false });
       expect(runtimeError?.evidenceLabels?.some((item) => item === 'probe-error:blocker')).toBe(true);
       expect(view.priorities.some((item) => item.kind === 'clean-read')).toBe(false);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
@@ -71,17 +79,18 @@ describe('game play priorities command', () => {
     const { payload, server } = await runPriorities('runtime-error');
     try {
       expect(payload.contractVersion).toBe('play-agent-v0');
-      expect(payload.command).toBe('game play priorities');
+      expect(payload.surface).toBe('priorities');
       expect(payload.summary).toContain('runtime-state-error');
-      expect(payload.next).toContain('game play rehydrate --json');
+      expect(payload.nextAction).toMatchObject({ kind: 'observe', readOnly: true, sendsMutation: false });
       expect(payload.warnings.join(' ')).toContain('Core HUD probes failed');
       expect(payload.omitted.some((item) => item.path === 'priorities[].evidenceLabels')).toBe(true);
       expect(payload.priorities.some((item) => item.kind === 'clean-read')).toBe(false);
       expect(payload.priorities.every((item) => item.evidence === undefined)).toBe(true);
       expect(Object.keys(payload.semanticEnvelope)).toEqual(SEMANTIC_CLI_ENVELOPE_SLOTS);
       expect(payload.semanticEnvelope.version).toBe(SEMANTIC_CLI_ENVELOPE_VERSION);
-      expect(payload.semanticEnvelope.nextSteps).toEqual([payload.next]);
-      expect(payload.semanticEnvelope.actions[0]?.command).toBe(payload.next);
+      expect(payload.semanticEnvelope.nextSteps).toEqual([payload.nextAction]);
+      expect(payload.semanticEnvelope.actions[0]).toMatchObject(payload.nextAction ?? {});
+      expect(JSON.stringify(payload)).not.toContain('game play ');
       expect(payload.semanticEnvelope.result).toMatchObject({
         status: 'read-only',
         sent: false,
@@ -100,11 +109,12 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('clean-read');
-      expect(top.command).toContain('game play end-turn --send');      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'end-turn', sendsMutation: true });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(top.reason).toContain('rechecks blockers before sending');
       expect(payload.semanticEnvelope.blockers).toEqual([]);
       expect(payload.semanticEnvelope.actions[0]).toMatchObject({
-        command: top.command,
+        kind: top.nextAction?.kind,
         sendsMutation: true,
       });
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
@@ -132,9 +142,12 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:unit-command');
-      expect(top.command).toContain('game play operation --family unit --type SKIP_TURN');
-      expect(top.command).toContain("--unit-id '{\"owner\":0,\"id\":196609,\"type\":26}'");
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'validate-unit-command', sendsMutation: true });
+      expect(top.nextAction?.parameters).toMatchObject({
+        operationType: 'SKIP_TURN',
+        unitId: { owner: 0, id: 196609, type: 26 },
+      });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(top.reason).toContain('enabled unit command candidate');
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
@@ -148,8 +161,9 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:first-meet-diplomacy');
-      expect(top.command).toBe('game play respond-first-meet --json');
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-decision', readOnly: true });
+      expect(top.nextAction?.parameters).toMatchObject({ category: 'first-meet-diplomacy' });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(top.reason).toContain('validator-backed player-operation');
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -162,8 +176,9 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:technology-choice');
-      expect(top.command).toBe('game play choose-tech --options --json');
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-progression', readOnly: true });
+      expect(top.nextAction?.parameters).toMatchObject({ category: 'technology-choice' });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -176,8 +191,9 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:culture-choice');
-      expect(top.command).toBe('game play choose-culture --options --json');
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-progression', readOnly: true });
+      expect(top.nextAction?.parameters).toMatchObject({ category: 'culture-choice' });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -190,8 +206,9 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:celebration-choice');
-      expect(top.command).toBe('game play choose-celebration --options --json');
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-decision', readOnly: true });
+      expect(top.nextAction?.parameters).toMatchObject({ category: 'celebration-choice' });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -204,8 +221,9 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:government-choice');
-      expect(top.command).toBe('game play choose-government --options --json');
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-decision', readOnly: true });
+      expect(top.nextAction?.parameters).toMatchObject({ category: 'government-choice' });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -218,8 +236,9 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:narrative-choice');
-      expect(top.command).toBe('game play choose-narrative --options --json');
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-decision', readOnly: true });
+      expect(top.nextAction?.parameters).toMatchObject({ category: 'narrative-choice' });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -232,8 +251,9 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:narrative-choice');
-      expect(top.command).toBe('game play dismiss-notification --target \'{"owner":0,"id":5,"type":20}\' --json');
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-notification', readOnly: true });
+      expect(top.nextAction?.parameters).toMatchObject({ componentId: { owner: 0, id: 5, type: 20 } });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
       await server.close();
@@ -245,8 +265,9 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:narrative-choice');
-      expect(top.command).toBe('game play choose-narrative --options --json');
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-decision', readOnly: true });
+      expect(top.nextAction?.parameters).toMatchObject({ category: 'narrative-choice' });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
       await server.close();
@@ -258,8 +279,9 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:tradition-review');
-      expect(top.command).toBe('game play traditions --compact --json');
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-progression', readOnly: true });
+      expect(top.nextAction?.parameters).toMatchObject({ category: 'tradition-review' });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(server.received.some((message) => message.includes('readPlayNotifications'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -272,8 +294,8 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:production-choice');
-      expect(top.command).toBe('game play ready-city --compact --json');
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-ready-city', readOnly: true });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(server.received.some((message) => message.includes('readReadyCityView'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -286,8 +308,8 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:population-placement');
-      expect(top.command).toBe('game play ready-city --compact --json');
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-ready-city', readOnly: true });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(server.received.some((message) => message.includes('readReadyCityView'))).toBe(true);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -295,13 +317,14 @@ describe('game play priorities command', () => {
     }
   });
 
-  test('surfaces exact informational dismissal command in compact priorities', async () => {
+  test('surfaces informational dismissal action in compact priorities', async () => {
     const { payload, server } = await runPriorities('stale-informational');
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:informational-notification');
-      expect(top.command).toContain('game play dismiss-notification');
-      expect(top.command).toContain("--target '{\"owner\":0,\"id\":89,\"type\":20}'");      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-notification', readOnly: true });
+      expect(top.nextAction?.parameters).toMatchObject({ componentId: { owner: 0, id: 89, type: 20 } });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(top.reason).toContain('live ComponentID');
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
@@ -314,9 +337,10 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:informational-notification');
-      expect(top.command).toContain('game play dismiss-notification');
-      expect(top.command).toContain("--target '{\"owner\":0,\"id\":34,\"type\":20}'");      expect(payload.next).toBe(top.command);
-      expect(top.command).not.toMatch(/enemy|hostile|opponent/i);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-notification', readOnly: true });
+      expect(top.nextAction?.parameters).toMatchObject({ componentId: { owner: 0, id: 34, type: 20 } });
+      expect(payload.nextAction).toEqual(top.nextAction);
+      expect(JSON.stringify(top.nextAction)).not.toMatch(/enemy|hostile|opponent/i);
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
       await server.close();
@@ -328,11 +352,12 @@ describe('game play priorities command', () => {
     try {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:informational-notification');
-      expect(top.command).toContain('game play dismiss-notification');
-      expect(top.command).toContain("--target '{\"owner\":0,\"id\":118,\"type\":20}'");      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'inspect-notification', readOnly: true });
+      expect(top.nextAction?.parameters).toMatchObject({ componentId: { owner: 0, id: 118, type: 20 } });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(top.reason).toContain('live ComponentID');
-      expect(top.command).not.toContain('respond-diplomacy');
-      expect(payload.next).not.toContain('respond-diplomacy');
+      expect(JSON.stringify(top.nextAction)).not.toContain('respond-diplomacy');
+      expect(JSON.stringify(payload.nextAction)).not.toContain('respond-diplomacy');
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
     } finally {
       await server.close();
@@ -345,8 +370,8 @@ describe('game play priorities command', () => {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:unit-command-stale-expired');
       expect(top.summary).toContain('no ready unit');
-      expect(top.command).toContain('game play end-turn --send');
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'send-turn-complete', sendsMutation: true });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(top.reason).toContain('normal end-turn path once');
       expect(JSON.stringify(payload.decisionHud.hasSentTurnComplete)).toContain('false');
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
@@ -361,8 +386,8 @@ describe('game play priorities command', () => {
       const top = payload.priorities[0];
       expect(top.kind).toBe('hud:unit-command-stale-expired');
       expect(top.summary).toContain('turn-complete was sent');
-      expect(top.command).toContain('game watch --count 3');
-      expect(payload.next).toBe(top.command);
+      expect(top.nextAction).toMatchObject({ kind: 'observe-turn-advance', readOnly: true });
+      expect(payload.nextAction).toEqual(top.nextAction);
       expect(top.reason).toContain('turn-complete is already sent');
       expect(JSON.stringify(payload.decisionHud.hasSentTurnComplete)).toContain('true');
       expect(server.received.some((message) => message.includes('sendOperation('))).toBe(false);
@@ -378,18 +403,18 @@ async function runPriorities(
 ): Promise<{
   payload: {
     contractVersion?: string;
-    command?: string;
+    surface?: string;
     summary?: string;
-    next?: string | null;
+    nextAction?: CompactPriorityAction | null;
     warnings: string[];
     omitted: Array<{ path: string }>;
-    priorities: Array<{ kind: string; command?: string; reason: string; summary: string; evidence?: unknown }>;
+    priorities: Array<{ kind: string; nextAction?: CompactPriorityAction; reason: string; summary: string; evidence?: unknown }>;
     semanticEnvelope: {
       version: string;
-      actions: Array<{ command?: string }>;
+      actions: CompactPriorityAction[];
       blockers: Array<{ kind: string }>;
       decisions: Array<{ kind: string }>;
-      nextSteps: string[];
+      nextSteps: unknown[];
       result: Record<string, unknown>;
     };
     decisionHud: { hasSentTurnComplete?: unknown };

--- a/packages/cli/test/commands/game/play/ready-city.test.ts
+++ b/packages/cli/test/commands/game/play/ready-city.test.ts
@@ -43,7 +43,7 @@ describe('game play ready-city command', () => {
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
         contractVersion: string;
-        command: string;
+        surface: string;
         summary: string;
         city: { name: string; buildQueue: unknown };
         productionCandidates: Array<{
@@ -56,26 +56,29 @@ describe('game play ready-city command', () => {
           baseYieldSummary: { YIELD_PRODUCTION: number };
           valid: boolean;
           placementPlots: Array<{ x: number; y: number }>;
-          cli: string;
+          nextAction: { kind: string; parameters: Record<string, unknown>; sendsMutation: boolean };
         }>;
         populationPlacement: {
           yieldTypeOrder: string[];
-          workablePlots: Array<{ yieldDelta: { YIELD_HAPPINESS: number; happiness?: number }; cli: string }>;
+          workablePlots: Array<{
+            yieldDelta: { YIELD_HAPPINESS: number; happiness?: number };
+            nextAction: { kind: string; parameters: { location: number; x: number; y: number }; sendsMutation: boolean };
+          }>;
           expansionCandidates: Array<{
             constructibleName: string;
             yieldSource: string;
             yieldSummary: { YIELD_FOOD: number; YIELD_PRODUCTION: number; food?: number };
             terrainName: string;
-            cli: string;
+            nextAction: { kind: string; parameters: { x: number; y: number }; sendsMutation: boolean };
           }>;
         };
-        next: string;
+        nextAction: { kind: string; parameters: { location: number }; sendsMutation: boolean };
         warnings: string[];
         omitted: Array<{ path: string }>;
         view?: unknown;
       };
       expect(payload.contractVersion).toBe('play-agent-v0');
-      expect(payload.command).toBe('game play ready-city');
+      expect(payload.surface).toBe('ready-city');
       expect(payload.summary).toContain('Dur-Sharrukin');
       expect(payload.productionCandidates[0]).toMatchObject({
         kind: 'constructible',
@@ -91,17 +94,43 @@ describe('game play ready-city command', () => {
         valid: true,
       });
       expect(payload.productionCandidates[0].placementPlots[0]).toMatchObject({ x: 22, y: 31 });
-      expect(payload.productionCandidates[0].cli).toContain('game play build-production');
+      expect(payload.productionCandidates[0].nextAction).toMatchObject({
+        kind: 'choose-production',
+        sendsMutation: true,
+      });
       expect(payload.populationPlacement.yieldTypeOrder).toContain('YIELD_DIPLOMACY');
       expect(payload.populationPlacement.workablePlots[0].yieldDelta.YIELD_HAPPINESS).toBe(2);
       expect(payload.populationPlacement.workablePlots[0].yieldDelta.happiness).toBeUndefined();
-      expect(payload.populationPlacement.workablePlots[0].cli).toContain('assign-worker');
+      expect(payload.populationPlacement.workablePlots[0].nextAction).toMatchObject({
+        kind: 'assign-worker',
+        parameters: {
+          location: 1457,
+          x: 22,
+          y: 31,
+        },
+        sendsMutation: true,
+      });
       expect(payload.populationPlacement.expansionCandidates[0].constructibleName).toBe('Walls');
       expect(payload.populationPlacement.expansionCandidates[0].yieldSource).toBe('GameplayMap.getYieldsWithCity(plotIndex, cityId)');
       expect(payload.populationPlacement.expansionCandidates[0].yieldSummary).toMatchObject({ YIELD_FOOD: 2, YIELD_PRODUCTION: 1 });
       expect(payload.populationPlacement.expansionCandidates[0].yieldSummary.food).toBeUndefined();
       expect(payload.populationPlacement.expansionCandidates[0].terrainName).toBe('Grassland');
-      expect(payload.next).toContain('assign-worker');
+      expect(payload.populationPlacement.expansionCandidates[0].nextAction).toMatchObject({
+        kind: 'expand-city',
+        parameters: {
+          x: 23,
+          y: 31,
+        },
+        sendsMutation: true,
+      });
+      expect(payload.nextAction).toMatchObject({
+        kind: 'assign-worker',
+        parameters: {
+          location: 1457,
+        },
+        sendsMutation: true,
+      });
+      expect(JSON.stringify(payload)).not.toContain('game play ');
       expect(payload.warnings.join(' ')).toContain('Read-only city dashboard');
       expect(payload.omitted.some((item) => item.path === 'view.productionCandidates[].result')).toBe(true);
       expect(payload.omitted.some((item) => item.path === 'view.populationPlacement.allPlacementInfo')).toBe(true);

--- a/packages/cli/test/commands/game/play/semantic-envelope.test.ts
+++ b/packages/cli/test/commands/game/play/semantic-envelope.test.ts
@@ -42,7 +42,7 @@ describe('semantic CLI envelope owner', () => {
       state: { summary: 'ready unit needs a safe action' },
       blockers: [{ kind: 'ready-unit', summary: 'scout is ready' }],
       actions: [{ family: 'unit', target: { owner: 0, id: 458752, type: 26 }, readOnly: true }],
-      nextSteps: ['game play ready-unit --json'],
+      nextSteps: [{ kind: 'inspect-ready-unit', label: 'Inspect the ready unit before choosing an action.' }],
       evidence: [{ label: 'local-cli-test' }],
       notes: ['local tests do not prove live runtime behavior'],
     };
@@ -55,10 +55,10 @@ describe('semantic CLI envelope owner', () => {
       scope: { surface: 'game play priorities' },
       state: { turn: { ok: true, value: 80 } },
       blockers: [{ kind: 'ready-unit', summary: 'unit needs orders' }],
-      decisions: [{ kind: 'ready-unit', command: 'game play ready-unit --json' }],
-      actions: [{ family: 'ready-unit', command: 'game play ready-unit --json', readOnly: true }],
+      decisions: [{ kind: 'ready-unit', nextAction: { kind: 'inspect-ready-unit' } }],
+      actions: [{ family: 'ready-unit', kind: 'inspect-ready-unit', readOnly: true }],
       result: { status: 'read-only', sent: false },
-      nextSteps: ['game play ready-unit --json'],
+      nextSteps: [{ kind: 'inspect-ready-unit', label: 'Inspect the ready unit before choosing an action.' }],
       evidence: [{ label: 'local-cli-test', proofClass: 'local-cli-output' }],
       notes: ['local tests do not prove live runtime behavior'],
     });

--- a/packages/cli/test/commands/game/play/unit-move-preview.test.ts
+++ b/packages/cli/test/commands/game/play/unit-move-preview.test.ts
@@ -3,6 +3,13 @@ import GamePlayUnitMovePreview from '../../../../src/commands/game/play/unit-mov
 import { type FakeTunerServer, startFakeTunerServer } from '../../fixtures/tuner-socket-server';
 import { expectNormalPlayPayloadToOmitDebugInternals } from './normal-output-boundary';
 
+type CompactNextAction = {
+  kind: string;
+  label: string;
+  destination: { x: number; y: number };
+  sendReady: boolean;
+};
+
 describe('game play unit-move-preview command', () => {
   test('reads official unit move preview with neutral relationship policy', async () => {
     const server = await startUnitMovePreviewTunerServer();
@@ -74,25 +81,25 @@ describe('game play unit-move-preview command', () => {
       const payload = JSON.parse(writes.join('')) as {
         ok: true;
         contractVersion: string;
-        command: string;
+        surface: string;
         summary: string;
         requestedDestination: { x: number; y: number };
         queuedDestination: { x: number; y: number } | null;
         reach: { movementPlotCount: number; targetPlotCount: number };
         candidates: {
-          reachableMovement: Array<{ x: number; y: number; currentLocation: boolean; validateCli: string | null }>;
-          reachableTargets: Array<{ x: number; y: number; validateCli: string | null }>;
+          reachableMovement: Array<{ x: number; y: number; currentLocation: boolean; nextAction: CompactNextAction | null }>;
+          reachableTargets: Array<{ x: number; y: number; nextAction: CompactNextAction | null }>;
           limit: number;
         };
         paths: { requested: { plotCount?: number } | null; queued: { plotCount?: number } | null };
-        next: string | null;
+        nextAction: CompactNextAction | null;
         warnings: string[];
         relationshipProof: string;
         omitted: Array<{ path: string }>;
         view?: unknown;
       };
       expect(payload.contractVersion).toBe('play-agent-v0');
-      expect(payload.command).toBe('game play unit-move-preview');
+      expect(payload.surface).toBe('unit-move-preview');
       expect(payload.summary).toContain('UNIT_GALLEY');
       expect(payload.requestedDestination).toEqual({ x: 25, y: 35 });
       expect(payload.queuedDestination).toEqual({ x: 25, y: 35 });
@@ -100,11 +107,21 @@ describe('game play unit-move-preview command', () => {
       expect(payload.reach.targetPlotCount).toBeGreaterThanOrEqual(0);
       expect(payload.candidates.limit).toBe(12);
       expect(payload.candidates.reachableMovement[0]).toMatchObject({ x: 25, y: 35, currentLocation: false });
-      expect(payload.candidates.reachableMovement[0].validateCli).toContain("game play unit-target --unit-id '{\"owner\":0,\"id\":65536,\"type\":26}' --x 25 --y 35 --json");
+      expect(payload.candidates.reachableMovement[0].nextAction).toMatchObject({
+        kind: 'validate-unit-action',
+        destination: { x: 25, y: 35 },
+        sendReady: false,
+      });
       expect(payload.candidates.reachableTargets[0]).toMatchObject({ x: 26, y: 35 });
       expect(payload.paths.requested?.plotCount).toBeGreaterThan(0);
       expect(payload.paths.queued?.plotCount).toBeGreaterThan(0);
-      expect(payload.next).toContain('game play unit-target');
+      expect(payload.nextAction).toMatchObject({
+        kind: 'validate-unit-action',
+        label: 'validate unit action at (25,35) before sending',
+        destination: { x: 25, y: 35 },
+        sendReady: false,
+      });
+      expect(JSON.stringify(payload)).not.toContain('game play ');
       expect(payload.relationshipProof).toBe('none');
       expect(payload.warnings.join(' ')).toContain('does not classify other-owner relationships');
       expect(payload.omitted.some((item) => item.path === 'view.reachableMovement')).toBe(true);


### PR DESCRIPTION
fix(control): simplify notification action hints

Refs: openspec/changes/civ7-control-orpc-native-slice

Trims notification common actions so named blocker recommendations describe the semantic next move instead of repeating dry-run validation and single-flag send variants. City expansion, town-focus/review closeout, production, diplomacy, narrative, and advisor-warning hints now point to the relevant semantic send action while option/candidate reads remain where live evidence is needed first. Generic validation fallbacks remain only for operation families without named shortcuts.

Proof:
- bun run --cwd packages/civ7-direct-control test test/play-notification-view.test.ts
- bun run --cwd packages/civ7-direct-control check
- bun run --cwd packages/civ7-direct-control build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- stale validation-only action hint scan
- active approval/caller-permission scan over changed files
- git diff --check

Boundary: local source/test/OpenSpec proof only. No CLI parser behavior, oRPC contract/router/middleware, controller bridge surface, generated bundle, direct-control runtime behavior, approval/reason mechanic, play-thread action, deployed Civ7 runtime proof, or parent Task 5.x/6.x/7.x acceptance is changed or claimed.

fix(cli): simplify notification queue next actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Preserves service-owned semantic nextStep objects in game play notification-queue output instead of adding adapter-only CLI command recipes to each queue row. Text output now prints the semantic next-step label, while command help remains the source for flag-level interface detail.

Also tightens notifications.queue.current classification so legacy direct-control cli hints do not make an otherwise unclassified notification look like an operation step; operation scheduling now relies on semantic fields such as operationFamily.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/notification-queue-procedure.test.ts
- bun run test:cli:play -- game/play/notification/queue.test.ts
- bun run --cwd packages/civ7-control-orpc check
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- queue command-recipe output scan
- active approval/caller-permission scan over changed files
- git diff --check

Boundary: local package/CLI proof only. Service contract, CLI parser behavior, controller bridge surfaces, transport, deployed Civ7 runtime behavior, play-thread state, approval/reason mechanics, and parent Task 5.x/6.x/7.x acceptance are unchanged and unclaimed.

fix(control): simplify traditions omitted metadata

Refs: openspec/changes/civ7-control-orpc-native-slice

Updates progression.traditions.current omitted metadata to use service-level presentation/runtime evidence categories instead of direct-control or CLI implementation field paths. Keeps command-string rendering in the CLI presenter and leaves the service contract, parser behavior, runtime reads, controller bridge, and generated bundles unchanged.

Proof:
- bun run --cwd packages/civ7-control-orpc test test/progression-traditions-procedure.test.ts
- bun run test:cli:play -- game.play.progression-read.test.ts
- bun run --cwd packages/civ7-control-orpc check
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- service omission metadata scan over changed source/tests
- active approval/caller-permission scan over changed files
- git diff --check

Local package/CLI proof only; no deployed Civ7 runtime proof, play-thread action, approval/reason mechanic, transport/controller expansion, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify civilian route next actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Changes civilian-route-triage CLI nextInspections to present semantic service next-step labels instead of expanding each descriptor into literal command-and-flag recipes. Keeps command examples in command help and leaves service behavior, contracts, parser flags, runtime reads, controller bridge, and generated bundles unchanged.

Proof:
- bun run test:cli:play -- game.play.tactical-read.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- civilian-route command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only explicit retirement/proof-scan wording
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, caller approval/reason mechanic, transport/controller expansion, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify formation next actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Changes formation-snapshot CLI nextInspections to present semantic service next-step labels instead of expanding each descriptor into literal command-and-flag recipes. Keeps command examples in command help and leaves service behavior, contracts, parser flags, runtime reads, controller bridge, and generated bundles unchanged.

Proof:
- bun run test:cli:play -- game.play.tactical-read.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- formation command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only explicit retirement/proof-scan wording
- relationship-label safety scan over changed source/test
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, caller approval/reason mechanic, transport/controller expansion, relationship authority change, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify front summary next actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Changes front-summary CLI summary.nextInspections to present semantic service next-step labels instead of expanding each descriptor into literal command-and-flag recipes. Keeps command examples in command help and leaves service behavior, contracts, parser flags, runtime reads, controller bridge, and generated bundles unchanged.

Proof:
- bun run test:cli:play -- game.play.tactical-read.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- front-summary command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only explicit retirement/proof-scan wording
- relationship-label safety scan over changed source/test
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, caller approval/reason mechanic, transport/controller expansion, relationship authority change, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify unit move preview actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Changes unit-move-preview compact JSON to expose semantic validation descriptors instead of literal unit-target command recipes. Replaces the compact output command string with a neutral surface id and keeps command examples in help, with runtime reads, parser flags, service contracts, controller bridge, and generated bundles unchanged.

Proof:
- bun run test:cli:play -- game/play/unit-move-preview.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- unit-move-preview command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only explicit retirement/proof-scan wording
- relationship-label safety scan over changed source/test
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, caller approval/reason mechanic, transport/controller expansion, relationship authority change, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify compact priority actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Changes priorities and progress-dashboard compact JSON to expose semantic nextAction descriptors instead of literal game play command recipes. Widens the local semantic CLI envelope nextSteps slot to carry descriptors, keeps exact flag combinations in command help, and leaves control-oRPC service behavior, parser flags, runtime reads, controller bridge, and generated bundles unchanged.

Proof:
- bun run test:cli:play -- game/play/priorities.test.ts game.play.progression-read.test.ts game/play/semantic-envelope.test.ts
- bun run --cwd packages/cli test -- game/play/priorities.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- compact command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only explicit retirement/proof-scan wording
- relationship-label safety scan over changed source/test; hit is a negative assertion only
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, caller approval/reason mechanic, transport/controller expansion, relationship authority change, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify compact traditions actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Changes traditions compact JSON to expose semantic row nextAction descriptors and validation-success-only recommendedActions instead of validateCli/sendCli/sendCloseoutCli command recipes. Keeps exact flag combinations in command help and leaves progression service behavior, parser flags, runtime reads, controller bridge, and generated bundles unchanged.

Proof:
- bun run --cwd packages/cli test -- game.play.progression-read.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- focused validation-failed tradition fixture proving disabled options do not enter recommendedActions
- compact traditions command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only explicit retirement/proof-scan wording
- relationship-label safety scan over changed source/test
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, caller approval/reason mechanic, transport/controller expansion, relationship authority change, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify compact traditions actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Changes traditions compact JSON to expose semantic row nextAction descriptors and validation-success-only recommendedActions instead of validateCli/sendCli/sendCloseoutCli command recipes. Failed or null validation rows now remain read-only validation guidance and are not send-oriented recommendations. Keeps exact flag combinations in command help and leaves progression service behavior, parser flags, runtime reads, controller bridge, and generated bundles unchanged.

Proof:
- bun run --cwd packages/cli test -- game.play.progression-read.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- focused validation-failed tradition fixture proving disabled options remain read-only and do not enter recommendedActions
- compact traditions command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only explicit retirement/proof-scan wording
- relationship-label safety scan over changed source/test
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, caller approval/reason mechanic, transport/controller expansion, relationship authority change, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify compact ready-city actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Changes ready-city compact JSON to expose semantic nextAction descriptors for worker assignment, city expansion, and production candidates instead of direct-control cli/cliHints command recipes. Keeps exact flag combinations in command help and leaves direct-control ready-city source behavior, parser flags, runtime reads, controller bridge, and generated bundles unchanged.

Proof:
- bun run --cwd packages/cli test -- game/play/ready-city.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- compact ready-city command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only explicit retirement/proof-scan wording
- relationship-label safety scan over changed source/test
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, caller approval/reason mechanic, transport/controller expansion, relationship authority change, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify progression option actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Changes choose-tech --options and choose-culture --options JSON to expose semantic nextAction, targetAction, and validationAction descriptors instead of chooseCli/targetCli/validateCli command recipes. Keeps exact flag combinations in command help and leaves progression service behavior, parser flags, runtime reads, controller bridge, and generated bundles unchanged.

Proof:
- bun run --cwd packages/cli test -- game.play.technology.test.ts game.play.culture.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- technology/culture options command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only explicit retirement/proof-scan wording
- relationship-label safety scan over changed source/test
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, caller approval/reason mechanic, transport/controller expansion, relationship authority change, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify government option actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Changes choose-celebration --options and choose-government --options JSON to expose semantic nextAction and validationAction descriptors instead of chooseCli/validateCli command recipes. Keeps exact flag combinations in command help and leaves government service behavior, parser flags, runtime reads, controller bridge, and generated bundles unchanged.

Proof:
- bun run --cwd packages/cli test -- game.play.celebration-government.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- celebration/government options command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only explicit retirement/proof-scan wording
- relationship-label safety scan over changed source/test
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, caller approval/reason mechanic, transport/controller expansion, relationship authority change, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify narrative option actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Changes choose-narrative --options JSON to expose semantic nextAction, validationAction, and dismissal action descriptors instead of command, chooseCli, validateCli, dismissalDiagnosticCli, and unprovenDismissalCli command recipes. Keeps exact flag combinations in command help and leaves narrative service behavior, parser flags, runtime reads, controller bridge, and generated bundles unchanged.

Proof:
- bun run --cwd packages/cli test -- game.play.narrative.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- narrative options command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only explicit retirement/proof-scan wording
- relationship-label safety scan over changed source/test
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, caller approval/reason mechanic, transport/controller expansion, relationship authority change, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify rehydrate actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Changes game play rehydrate snapshots to expose semantic commonActions descriptors instead of cli command recipes. Keeps exact flag combinations in command help and leaves direct-control notification/ready-unit reads, continuity checks, parser flags, runtime behavior, controller bridge, and generated bundles unchanged.

Proof:
- bun run --cwd packages/cli test -- game.play.rehydrate.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- rehydrate common-action command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only explicit retirement/proof-scan wording
- relationship-label safety scan over changed source/test
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, caller approval/reason mechanic, transport/controller expansion, relationship authority change, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify notifications text actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Changes game play notifications text output to render semantic action and operation labels instead of shortcut, cli, or common-action command recipes. Keeps JSON diagnostic output and direct-control notification materialization unchanged.

Proof:
- bun run --cwd packages/cli test -- game/play/notification/hud.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- notifications text command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only explicit retirement/proof-scan wording
- relationship-label safety scan over changed source/test; hits are only finally substrings
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, caller approval/reason mechanic, JSON diagnostic output change, transport/controller expansion, relationship authority change, or parent Task 5.x/6.x/7.x acceptance.

fix(cli): simplify notification json actions

Refs: openspec/changes/civ7-control-orpc-native-slice

Projects game play notifications --json through a CLI-local semantic boundary that omits direct-control cli command recipe fields from HUD decisions, option details, closeout candidates, and common actions. The output keeps categories, operation families/types, required inputs, option data, validation evidence, notes, and blocker evidence while leaving direct-control notification materialization, service contracts, parser flags, controller bridge, generated bundles, and runtime behavior unchanged.

Proof:
- bun run --cwd packages/cli test -- game/play/notification/hud.test.ts
- bun run check:cli
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- notifications JSON command-recipe output scan over changed CLI source/test
- active approval/caller-permission scan over changed files; hits are only retirement/proof-scan wording
- relationship-label safety scan over changed source/test
- git diff --check

Local CLI/OpenSpec proof only; no deployed Civ7 runtime proof, play-thread action, control-oRPC service contract change, direct-control materializer change, transport/controller expansion, relationship authority change, caller approval/reason mechanic, or parent Task 5.x/6.x/7.x acceptance.