### PR TITLE
fix(control-orpc): require controller proof for mutation readiness

### DIFF
--- a/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/specs/civ7-control-orpc/spec.md
@@ -1191,6 +1191,20 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** this gate does not add new procedure allowlist entries, transport
   scope, raw command/session output, or deployed Civ7 runtime proof claims
 
+#### Scenario: Native mutation readiness requires controller proof for controller-supported mutations
+- **WHEN** a mutating procedure runs through the native in-process router
+- **AND** direct-control playable status is false
+- **AND** controller context lists the procedure in `supportedMutationProcedures`
+- **THEN** native mutation readiness MUST still require context-owned
+  game-controller-ready lifecycle, `GameContext.localPlayerID`, and
+  single-local-player/hotseat proof before the mutation handler runs
+- **AND** an allowlist without valid controller proof fails through bounded
+  `MUTATION_READINESS_REQUIRED` output before any direct-control or game-UI
+  mutation port executes
+- **AND** the controller proof remains context metadata, not procedure input,
+  serialized caller authority, raw command/session output, or deployed Civ7
+  runtime proof
+
 #### Scenario: Game UI controller supports notification dismissal
 - **WHEN** the game-scoped controller context exposes notification dismissal
   game UI APIs
@@ -1204,8 +1218,9 @@ adding HTTP, OpenAPI, WebSocket, Studio, or in-game bridge edge adapters.
 - **AND** broad `readiness.current` mutation capability remains conservative
   until game UI mutation surfaces are actually implemented
 - **AND** native mutation readiness admits only the explicitly context-listed
-  `notifications.dismiss.request` game-UI mutation while other mutation ports
-  remain bounded as unsupported
+  `notifications.dismiss.request` game-UI mutation when context-owned
+  controller proof is present, while other mutation ports remain bounded as
+  unsupported
 - **AND** `readiness.current` exposes the same context-listed controller
   support as bounded procedure capability facts; read support may set
   `canObserve`, but mutation support MUST NOT set `canMutate` unless the

--- a/openspec/changes/civ7-control-orpc-native-slice/tasks.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/tasks.md
@@ -1506,6 +1506,16 @@ adding more read-only facade shells.
     materialization, parser flags, deployed Civ7 proof, play-thread action,
     transport expansion, public package-root procedure schema exports, and
     full `7.3` acceptance pending.
+  - [x] 7.3.38 Require controller mutation proof in native mutation readiness
+    before a context-listed controller mutation can bypass non-playable Tuner
+    readiness. Move the controller lifecycle/local-player/hotseat proof shape
+    into a shared context model reused by the bridge and the native
+    readiness middleware; keep proof context-owned rather than procedure input
+    or serialized caller authority; reject allowlist-only controller mutation
+    calls with bounded `MUTATION_READINESS_REQUIRED` output before any
+    mutation port runs. Keep new bridge allowlists, transport expansion,
+    deployed Civ7 proof, play-thread action, public package-root procedure
+    schema exports, and full `7.3` acceptance pending.
 - [ ] 7.4 Keep OpenAPI/external REST deferred until there is a documented
   external consumer.
 
@@ -2303,6 +2313,17 @@ adding more read-only facade shells.
   source/docs/OpenSpec proof only; it does not change procedure contracts,
   parser flags, runtime behavior, deployed Civ7 runtime behavior, play-thread
   state, transport/controller scope, relationship authority, or parent Task
+  5.x/6.x/7.x acceptance; caller-provided approval remains retired and no
+  approval-reason mechanic is introduced.
+- [x] 8.60.63 Run focused city-production-choice procedure tests,
+  controller-bridge ingress tests, control-oRPC package check/build/test,
+  strict OpenSpec validates, root-export scans for new controller-proof or
+  per-procedure schema exports, active
+  approval/caller-permission scan, relationship-label safety scan, and diff
+  hygiene for the controller mutation readiness proof slice. This is local
+  package/OpenSpec proof only; it does not change procedure contracts, normal
+  outputs, parser flags, deployed Civ7 runtime behavior, play-thread state,
+  transport/controller allowlists, relationship authority, or parent Task
   5.x/6.x/7.x acceptance; caller-provided approval remains retired and no
   approval-reason mechanic is introduced.
 - [x] 8.60.45 Run focused game-UI controller tests, control-oRPC package

--- a/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-mutation-readiness-proof-slice.md
+++ b/openspec/changes/civ7-control-orpc-native-slice/workstream/controller-mutation-readiness-proof-slice.md
@@ -1,0 +1,69 @@
+# Controller Mutation Readiness Proof Slice
+
+Status: implemented local package proof.
+Date: 2026-06-06.
+
+## Purpose
+
+Tighten native mutation readiness so controller-supported mutations cannot
+bypass non-playable Tuner readiness with an allowlist string alone.
+
+The serialized controller bridge already rejects mutation requests without
+closed controller lifecycle, local-player, and single-local-player/hotseat
+proof before dispatch. This slice moves the same proof shape into a shared
+context model and has the native oRPC mutation readiness middleware require it
+whenever a controller-supported mutation runs from a non-playable readiness
+source.
+
+## Write Set
+
+- `packages/civ7-control-orpc/src/model/controller-proof.ts`
+- `packages/civ7-control-orpc/src/context.ts`
+- `packages/civ7-control-orpc/src/bridge/controller-ingress.ts`
+- `packages/civ7-control-orpc/src/middleware/mutation-readiness.ts`
+- `packages/civ7-control-orpc/test/city-production-choice-procedure.test.ts`
+- this OpenSpec record, `tasks.md`, and
+  `specs/civ7-control-orpc/spec.md`
+
+## Behavior Boundary
+
+- Controller mutation proof remains context-owned metadata, not procedure input
+  or serialized caller authority.
+- Native mutation readiness still reads direct-control playable status first.
+- If playable status is false, a controller mutation may proceed only when the
+  procedure key is listed in `supportedMutationProcedures` and the same context
+  carries valid controller lifecycle, local-player, and hotseat proof.
+- A context that only lists `supportedMutationProcedures` still fails with
+  bounded `MUTATION_READINESS_REQUIRED` output before the mutation port runs.
+- The bridge reuses the shared proof model instead of owning a separate proof
+  shape.
+
+## Non-Goals
+
+- no new controller bridge allowlist entries;
+- no transport, CLI, Studio, RPCLink, OpenAPI, or deployed UIScript behavior
+  change;
+- no approval/reason mechanic;
+- no raw command/session/Tuner/game-UI runtime payload exposure;
+- no deployed Civ7 runtime proof, play-thread action, or full `7.3`
+  acceptance.
+
+## Proof Collected
+
+- `bun run --cwd packages/civ7-control-orpc test -- city-production-choice-procedure.test.ts`
+- `bun run --cwd packages/civ7-control-orpc test -- city-production-choice-procedure.test.ts controller-bridge-ingress.test.ts`
+- `bun run --cwd packages/civ7-control-orpc check`
+- `bun run --cwd packages/civ7-control-orpc test`
+- `bun run --cwd packages/civ7-control-orpc build`
+- `bun run openspec -- validate civ7-control-orpc-native-slice --strict`
+- `bun run openspec -- validate civ7-support-direct-control-modularization --strict`
+- root-export scan for new controller-proof or per-procedure schema exports
+- added-line scan for active approval/caller-permission mechanics
+- added-line relationship-label safety scan
+- `git diff --check`
+
+## Residual Risk
+
+This is local package proof only. It proves the native middleware gate for a
+fake controller context, not live Civ7 controller deployment or runtime
+mutation behavior.

--- a/packages/civ7-control-orpc/src/bridge/controller-ingress.ts
+++ b/packages/civ7-control-orpc/src/bridge/controller-ingress.ts
@@ -5,6 +5,11 @@ import { Value } from "typebox/value";
 import { createCiv7ControlOrpcServerClient } from "../client";
 import { Civ7ControlOrpcContract } from "../contract";
 import type { Civ7ControlOrpcContext } from "../context";
+import {
+  Civ7ControllerMutationProofSchema,
+  isCiv7ControllerMutationProof,
+  type Civ7ControllerMutationProof,
+} from "../model/controller-proof";
 import { Civ7ControlOrpcCorrelationIdSchema } from "../model/correlation";
 import {
   typeboxInputSchemaFromContractProcedure,
@@ -198,35 +203,9 @@ const Civ7ProgressionTraditionReviewResultSchema =
     Civ7ControlOrpcContract.progression.tradition.review.request,
   );
 
-export const Civ7ControllerBridgeMutationProofSchema = Type.Object(
-  {
-    lifecycle: Type.Object(
-      {
-        source: Type.Literal("controller-runtime"),
-        status: Type.Literal("game-controller-ready"),
-      },
-      { additionalProperties: false },
-    ),
-    localPlayer: Type.Object(
-      {
-        source: Type.Literal("GameContext.localPlayerID"),
-        playerId: Type.Integer({ minimum: 0, maximum: 255 }),
-      },
-      { additionalProperties: false },
-    ),
-    hotseat: Type.Object(
-      {
-        source: Type.Literal("controller-runtime"),
-        status: Type.Literal("single-local-player"),
-      },
-      { additionalProperties: false },
-    ),
-  },
-  { additionalProperties: false },
-);
-export type Civ7ControllerBridgeMutationProof = Static<
-  typeof Civ7ControllerBridgeMutationProofSchema
->;
+export const Civ7ControllerBridgeMutationProofSchema =
+  Civ7ControllerMutationProofSchema;
+export type Civ7ControllerBridgeMutationProof = Civ7ControllerMutationProof;
 
 export const Civ7ControllerBridgeReadinessCurrentRequestSchema = Type.Object(
   {
@@ -1569,7 +1548,7 @@ export async function invokeCiv7ControllerBridgeRequest(
 function controllerProofFromContext(
   context: Civ7ControllerBridgeContext,
 ): Civ7ControllerBridgeMutationProof | null {
-  if (!Value.Check(Civ7ControllerBridgeMutationProofSchema, context.controllerProof)) {
+  if (!isCiv7ControllerMutationProof(context.controllerProof)) {
     return null;
   }
   return context.controllerProof;

--- a/packages/civ7-control-orpc/src/context.ts
+++ b/packages/civ7-control-orpc/src/context.ts
@@ -1,6 +1,7 @@
 import type { Civ7DirectControlOptions } from "@civ7/direct-control";
 
 import type { Civ7ControlOrpcDirectControlFacade } from "./dependencies/direct-control";
+import type { Civ7ControllerMutationProof } from "./model/controller-proof";
 import type { Civ7ControlOrpcCorrelationContext } from "./model/correlation";
 
 export type Civ7ControlOrpcContext = Readonly<{
@@ -11,4 +12,5 @@ export type Civ7ControlOrpcContext = Readonly<{
     supportedReadProcedures?: readonly string[];
     supportedMutationProcedures?: readonly string[];
   }>;
+  controllerProof?: Civ7ControllerMutationProof;
 }>;

--- a/packages/civ7-control-orpc/src/middleware/mutation-readiness.ts
+++ b/packages/civ7-control-orpc/src/middleware/mutation-readiness.ts
@@ -1,3 +1,5 @@
+import type { Civ7ControlOrpcContext } from "../context";
+import { isCiv7ControllerMutationProof } from "../model/controller-proof";
 import { civ7ControlOrpcErrorCorrelationData } from "../model/correlation";
 import { civ7ControlOrpcImplementer } from "../procedure";
 
@@ -23,7 +25,7 @@ export const civ7MutationReadinessMiddleware =
 
     if (
       !status.playable
-      && !context.controller?.supportedMutationProcedures?.includes(procedureKey)
+      && !civ7ControllerMutationReadinessBypass(context, procedureKey)
     ) {
       throw errors.MUTATION_READINESS_REQUIRED({
         data: {
@@ -39,3 +41,12 @@ export const civ7MutationReadinessMiddleware =
 
     return next();
   });
+
+function civ7ControllerMutationReadinessBypass(
+  context: Civ7ControlOrpcContext,
+  procedureKey: string,
+): boolean {
+  return context.controller?.supportedMutationProcedures?.includes(procedureKey)
+      === true
+    && isCiv7ControllerMutationProof(context.controllerProof);
+}

--- a/packages/civ7-control-orpc/src/model/controller-proof.ts
+++ b/packages/civ7-control-orpc/src/model/controller-proof.ts
@@ -1,0 +1,38 @@
+import { Type, type Static } from "typebox";
+import { Value } from "typebox/value";
+
+export const Civ7ControllerMutationProofSchema = Type.Object(
+  {
+    lifecycle: Type.Object(
+      {
+        source: Type.Literal("controller-runtime"),
+        status: Type.Literal("game-controller-ready"),
+      },
+      { additionalProperties: false },
+    ),
+    localPlayer: Type.Object(
+      {
+        source: Type.Literal("GameContext.localPlayerID"),
+        playerId: Type.Integer({ minimum: 0, maximum: 255 }),
+      },
+      { additionalProperties: false },
+    ),
+    hotseat: Type.Object(
+      {
+        source: Type.Literal("controller-runtime"),
+        status: Type.Literal("single-local-player"),
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+export type Civ7ControllerMutationProof = Static<
+  typeof Civ7ControllerMutationProofSchema
+>;
+
+export function isCiv7ControllerMutationProof(
+  proof: unknown,
+): proof is Civ7ControllerMutationProof {
+  return Value.Check(Civ7ControllerMutationProofSchema, proof);
+}

--- a/packages/civ7-control-orpc/test/city-production-choice-procedure.test.ts
+++ b/packages/civ7-control-orpc/test/city-production-choice-procedure.test.ts
@@ -134,6 +134,58 @@ describe("city.production.choice.request control-oRPC procedure", () => {
     expect(fake.calls).toEqual([]);
   });
 
+  test("does not let a controller mutation allowlist bypass readiness without proof", async () => {
+    const fake = fakeContext(productionChoiceResult("production-choice-cleared"), {
+      playableStatus: {
+        playable: false,
+        readiness: "app-ui-game",
+      },
+      controller: {
+        supportedMutationProcedures: ["city.production.choice.request"],
+      },
+    });
+
+    await expect(
+      call(Civ7ControlOrpcRouter.city.production.choice.request, {
+        cityId,
+        args,
+      }, { context: fake.context }),
+    ).rejects.toMatchObject({
+      code: "MUTATION_READINESS_REQUIRED",
+      status: 409,
+      data: {
+        procedureKey: "city.production.choice.request",
+        source: "readiness.current",
+        risk: "mutation",
+        playable: false,
+        readiness: "app-ui-game",
+      },
+    });
+    expect(fake.calls).toEqual([]);
+  });
+
+  test("allows controller-supported mutations with controller-runtime proof", async () => {
+    const fake = fakeContext(productionChoiceResult("production-choice-cleared"), {
+      playableStatus: {
+        playable: false,
+        readiness: "app-ui-game",
+      },
+      controller: {
+        supportedMutationProcedures: ["city.production.choice.request"],
+      },
+      controllerProof: controllerMutationProof(),
+    });
+
+    const result = await call(
+      Civ7ControlOrpcRouter.city.production.choice.request,
+      { cityId, args },
+      { context: fake.context },
+    );
+
+    expect(result.status).toBe("sent-confirmed");
+    expect(fake.calls).toHaveLength(1);
+  });
+
   test("maps readiness read failures before mutation without raw details", async () => {
     const fake = fakeContext(productionChoiceResult("production-choice-cleared"), {
       playableStatusError: new Error(
@@ -373,6 +425,8 @@ function fakeContext(
       readiness: string;
     }>;
     playableStatusError?: Error;
+    controller?: Civ7ControlOrpcContext["controller"];
+    controllerProof?: Civ7ControlOrpcContext["controllerProof"];
   } = {},
 ): {
   context: Civ7ControlOrpcContext;
@@ -412,8 +466,29 @@ function fakeContext(
       correlation: options.correlationId == null
         ? undefined
         : { correlationId: options.correlationId },
+      controller: options.controller,
+      controllerProof: options.controllerProof,
     },
     calls,
+  };
+}
+
+function controllerMutationProof(): NonNullable<
+  Civ7ControlOrpcContext["controllerProof"]
+> {
+  return {
+    lifecycle: {
+      source: "controller-runtime",
+      status: "game-controller-ready",
+    },
+    localPlayer: {
+      source: "GameContext.localPlayerID",
+      playerId: 0,
+    },
+    hotseat: {
+      source: "controller-runtime",
+      status: "single-local-player",
+    },
   };
 }
 


### PR DESCRIPTION
Refs: openspec/changes/civ7-control-orpc-native-slice

Adds a shared controller mutation proof model and wires it into typed control-oRPC context so native mutation readiness requires both supportedMutationProcedures and valid controller lifecycle/local-player/hotseat proof when direct-control playable status is false.

The controller bridge now reuses the shared proof schema instead of owning a separate proof shape, while procedure input and bridge request envelopes remain semantic and caller-proof-free.

Proof:
- bun run --cwd packages/civ7-control-orpc test -- city-production-choice-procedure.test.ts
- bun run --cwd packages/civ7-control-orpc test -- city-production-choice-procedure.test.ts controller-bridge-ingress.test.ts
- bun run --cwd packages/civ7-control-orpc check
- bun run --cwd packages/civ7-control-orpc test
- bun run --cwd packages/civ7-control-orpc build
- bun run openspec -- validate civ7-control-orpc-native-slice --strict
- bun run openspec -- validate civ7-support-direct-control-modularization --strict
- root-export scan for new controller-proof or per-procedure schema exports
- added-line scan for active approval/caller-permission mechanics
- added-line relationship-label safety scan
- git diff --check

Boundaries: local package/OpenSpec proof only; no procedure contract, normal output, parser flag, deployed Civ7 runtime behavior, play-thread state, transport/controller allowlist, relationship authority, or parent Task 5.x/6.x/7.x acceptance change. Caller-provided approval remains retired and no approval/reason mechanic is introduced.