### PR TITLE
feat(mapgen): resource-start support pass — stamp reordered after starts, bounded plan adjustment (S5)

### DIFF
--- a/docs/projects/placement-realignment/evidence/s5-results-2026-06-10.md
+++ b/docs/projects/placement-realignment/evidence/s5-results-2026-06-10.md
@@ -1,0 +1,145 @@
+# Placement Realignment — S5 Results (2026-06-10)
+
+Slice: S5 resource↔start support pass (OpenSpec change
+`placement-realignment-s5-support`). Harness:
+`bun run verify:placement-metrics -- --seed 1337 --seeds 5 --size standard
+--json /tmp/pm-s5-5.json` (mock adapter, swooper-earthlike config, 84x54,
+8 players, seeds 1337–1341) plus the 20-seed gate window (`--seeds 20`,
+seeds 1337–1356, `/tmp/pm-s5.json`) and the studio-mapinfo probe
+(`--seeds 1 --studio-mapinfo`). Before = S4
+(`s4-results-2026-06-10.md`).
+
+Step order changed this slice (D3 contract change):
+`prepare-placement-surface → plan-resources → assign-starts →
+adjust-resources(support pass) → place-resources(stamp) →
+place-discoveries`, effect chain `surfacePrepared → resourcesPlanned →
+startsAssigned → resourcesAdjusted → resourcesPlaced → discoveriesPlaced`.
+Starts score PLANNED resource sites; the stamp consumes the ADJUSTED plan.
+
+## E3 gates (must-pass for S5)
+
+| ID | Gate | Before (S4) | After (S5) | Verdict |
+| --- | --- | --- | --- | --- |
+| E3.1 | ≥2 resources within radius 4 of every start | min/start 1.8 [1..2], startsBelowFloor 0.2/8 per seed (red) | 5-seed min/start **3.2** [3..4]; 20-seed **2.8** [2..4]; **startsBelowFloor 0 on all 160 seats**; mean/start 3.94 | **PASS** |
+| E3.2 | per-player support gap max−min ≤ 2 | maxMinGap 7.0 [4..9] (red) | 5-seed **2.0** [2..2]; 20-seed **2.0** [2..2]; planned gap before→after **5.45 → 2.0** (20-seed means; per-seed before up to 9) | **PASS** |
+| E3.3 | guarantee (floor AND equity) holds across seeds | n/a (resources stamped before starts existed) | **20/20 seeds** (and 5/5 on the canonical run) | **PASS** |
+| E3.4 | sparsity/exclusion expressiveness | sparsity 48→12, exclusion 22→0 | **identical** (op-probe unchanged) | HOLD |
+
+Adjustment provenance (20-seed window): **93 moves / 0 adds / 0 recorded
+shortfalls** — 11 `support-floor` moves, 82 `support-equity` moves; per-seed
+moves 4.65 mean [1..10]. Every move is count-preserving (per-type counts,
+rarity stratification, and region minimums untouched by construction); the
+add arm and the typed-shortfall arm are exercised by op-contract tests.
+
+## E1 non-regression (start scoring input: placed → planned sites)
+
+Start-side numbers are **bit-identical** to S4 on both windows: on the mock
+harness the planned site set IS the placed set (E2.9 planned == assigned ==
+final since S3, zero engine rejections), so swapping the resource-support
+scoring input from placed outcomes to plan intents changes no values.
+
+| ID | S4 (20-seed) | S5 (20-seed) | Verdict |
+| --- | --- | --- | --- |
+| E1.1 | invalid 0 | **0** | HOLD |
+| E1.2 | 8/8 seated, no doubling; studio probe 8 | **identical** (probe seats 8/8, doubling false) | HOLD |
+| E1.3 | 0.944 [0.75..1.00] | **0.944** [0.75..1.00] | HOLD |
+| E1.4 | 1.136 [1.083..1.183] | **1.136** [1.083..1.183] | HOLD (amended ≥1.05 gate) |
+| E1.5 | 8.1 [6..10], pairsBelow6 0 | **8.1** [6..10], pairsBelow6 **0** | HOLD |
+| E1.6 | 0.176 [0.055..0.300], 0 seeds over | **0.176** [0.055..0.300], balanced 20/20 | HOLD |
+| E1.7 | 3.1% non-regional, 4 region-reassigned | **3.1%** (5/160 open-pool), regionReassigned 4 (seed 1348), allDegradationsSurfaced 20/20 | HOLD |
+| E1.8 | 0.0% | **0.0%** | HOLD |
+
+## E2 non-regression (5-seed canonical vs S4, 20-seed where noted)
+
+| ID | S4 | S5 | Verdict |
+| --- | --- | --- | --- |
+| E2.1 | Spearman −1.0; min/max per type 2/19.2 | **−1.0**; **2/19.2**; CV 0.558 | HOLD (moves preserve counts exactly) |
+| E2.2 | 1.2/2 satisfied, totalShortfall 4 [0..8], recorded 5/5 | **identical** | HOLD |
+| E2.3 | 0.972 [0.953..0.991] | **0.970** [0.948..0.986]; 20-seed 0.974 [0.936..0.991] | HOLD (≥0.9 gate; habitat-first destinations) |
+| E2.4 | 26 marine / 6 types | **26 / 6** | HOLD |
+| E2.5 | 1.128 [1.013..1.201] | **1.123 [1.012..1.195]** (5-seed canonical, gate frame) | HOLD — see measurement note below |
+| E2.6 | 0 below floor, min same-type dist 3 | **0 / 3** | HOLD |
+| E2.7 | 97.6% in range / 97.1% near target, belowMinWithoutShortfall 0 | **97.6% / 97.1% / 0** (20-seed 97.5%/96.6%/0) | HOLD |
+| E2.8 | 1.07 [1.00..1.19] | **1.06 [1.00..1.14]** (20-seed 1.14 [1.00..1.52], ≤2 gate) | HOLD |
+| E2.9 | reassignment 0, preferredLegality 1.0, planned==placed==216 | **0 / 1.0 / 216==216==216** (joins now against the adjusted plan) | HOLD |
+
+### E2.5 measurement note (recorded, not faked)
+
+S5 widened E2.5 observation to the 20-seed window (S3/S4 measured the
+5-seed canonical run only). One seed (1353) sits at **0.974 < CSR 1.0 both
+before and after** the support pass — the new
+`basePlanGeologicalPairCorrelation` counterfactual shows delta **0.000** on
+that seed and an aggregation-neutral pass overall (adjusted mean 1.1538 vs
+base-plan 1.1539 over 20 seeds; largest per-seed delta ±0.05). The sub-CSR
+seed is pre-existing S3 selection geography, out of S5's write set; the
+5-seed canonical gate frame holds at 1.123 [1.012..1.195]. The adjuster
+protects aggregation by penalizing sources that participate in same-family
+annulus pairs (isolated sites move first) and requiring in-lane tiles for
+free-map destinations.
+
+## Knob inventory (new this slice, derived schema)
+
+`placement.support` (public) ⇄ `resources/adjust-resource-support` default
+strategy config; Earth-like defaults reproduce the gates with NO shipped
+config change:
+
+| Knob | Default | Range | Meaning |
+| --- | --- | --- | --- |
+| enabled | true | bool | false = pass-through + `adjustment-disabled` shortfalls |
+| supportFloor | 2 | 0..6 | E3.1 per-start floor within radius |
+| supportRadiusTiles | 4 | 1..8 | E3.1/E3.2 counting radius |
+| equityTolerance | 2 | 0..8 | E3.2 max−min gap |
+| strength | 1 | 0..1 | scales floor-fill + equity budgets (0 = record-only) |
+
+## Raw aggregates
+
+5-seed canonical (seeds 1337–1341, `/tmp/pm-s5-5.json`):
+
+```
+E3.1 minPerStart 3.2 [3..4]  meanPerStart 4.275  belowFloor 0  moves 6.8 [3..10]  adds 0  shortfalls 0
+E3.2 maxMinGap 2.0 [2..2]  plannedGapBefore 7.0 [4..9]  plannedGapAfter 2.0
+E3.3 5/5
+E2.3 fidelity 0.9695 [0.9484..0.9859]   E2.5 geo pairCorr 1.1226 [1.0123..1.1951]
+E2.9 planned == assigned == final == 216 [213..225]
+```
+
+20-seed window (seeds 1337–1356, `/tmp/pm-s5.json`):
+
+```
+E3.1 minPerStart 2.8 [2..4]  belowFloor 0/160  moves/seed [9,6,3,6,10,3,2,3,3,4,8,1,1,3,7,5,3,9,4,3]
+E3.2 maxMinGap 2.0 [2..2]  plannedGapBefore 5.45 [3..9]
+E3.3 trueCount 20/20
+E1.3 0.944 [0.75..1.00]  E1.4 1.136 [1.083..1.183]  E1.5 8.1 pairsBelow6 0
+E1.6 0.176 [0.055..0.300]  E1.7 nonRegional 5/160  E1.8 0.0
+E2.3 0.9736 [0.9356..0.9910]
+E2.5 adjusted 1.1538 [0.9737..1.4273] vs basePlan 1.1539 [0.9737..1.3848]
+E2.7 inRange 0.975  nearTarget 0.966  belowMinWithoutShortfall 0
+E2.8 spread 1.144 [1.00..1.52]
+adjustments: 93 moves (11 support-floor, 82 support-equity), 0 adds, 0 shortfalls
+```
+
+Studio probe (`--studio-mapinfo`, seed 1337): seated 8 for 8 intended,
+doubling false.
+
+Regenerate: the harness is deterministic per seed; commands above.
+
+## Verification gates run
+
+- `bun --cwd mods/mod-swooper-maps test` — **506 pass / 0 fail** (8 new
+  op-contract tests: floor fill with typed provenance, invariant
+  preservation, equity gap, typed shortfalls instead of forcing,
+  add-with-headroom, exclusion + legality at destinations, determinism,
+  disabled pass-through; order-encoding tests updated: placement-contracts,
+  landmass-region-id-projection, resource-placement-diagnostics,
+  maps-schema-valid + fixture, standard-authoring-surface-guards;
+  world-balance stats join against the adjusted plan).
+- `bun run --cwd mods/mod-swooper-maps check` — clean.
+- `bun run --cwd mods/mod-swooper-maps build:studio-recipes` — generated
+  recipe schema/defaults + map artifacts regenerated (new `support` knob
+  surface).
+- `openspec validate --all` — 86 passed, 0 failed.
+
+Milestone B (live) is NOT claimed: live engine legality could reject
+adjusted intents post-stamp (mock legality matches policy masks, so plan ==
+placed here); the typed shortfall + provenance surfaces are the hooks for
+the live measurement.

--- a/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/live-parity.ts
@@ -414,6 +414,7 @@ type LocalTraceEvidence = {
   naturalWonderPlanInput?: unknown;
   naturalWonderPlacement?: unknown;
   resourcePlan?: unknown;
+  resourcePlanAdjusted?: unknown;
   resourcePlacementOutcomes?: unknown;
   terrainProjection?: unknown;
 };
@@ -522,6 +523,10 @@ export function runLocalFinalSurfaceSnapshot(input: RunLocalFinalSurfaceInput): 
   if (naturalWonderPlacement !== undefined) evidence.naturalWonderPlacement = naturalWonderPlacement;
   const resourcePlan = context.artifacts.get(placementArtifacts.resourcePlan.id);
   if (resourcePlan !== undefined) evidence.resourcePlan = resourcePlan;
+  // S5: the stamped intents are the support-ADJUSTED plan; capture it so the
+  // per-plot parity join classifies against what was actually stamped.
+  const resourcePlanAdjusted = context.artifacts.get(placementArtifacts.resourcePlanAdjusted.id);
+  if (resourcePlanAdjusted !== undefined) evidence.resourcePlanAdjusted = resourcePlanAdjusted;
   const resourcePlacementOutcomes = context.artifacts.get(
     placementArtifacts.resourcePlacementOutcomes.id
   );
@@ -1872,9 +1877,13 @@ function readLocalResourcePlacementEvidence(local: FinalSurfaceSnapshot): {
     }
   >;
 } {
-  const resourcePlan = isPlainObject(local.evidence?.resourcePlan)
-    ? local.evidence.resourcePlan
-    : undefined;
+  // S5: prefer the support-ADJUSTED plan when present — its intents are the
+  // ones actually stamped; the base resourcePlan stays as fallback evidence.
+  const resourcePlan = isPlainObject(local.evidence?.resourcePlanAdjusted)
+    ? local.evidence.resourcePlanAdjusted
+    : isPlainObject(local.evidence?.resourcePlan)
+      ? local.evidence.resourcePlan
+      : undefined;
   const resourcePlacementOutcomes = isPlainObject(local.evidence?.resourcePlacementOutcomes)
     ? local.evidence.resourcePlacementOutcomes
     : undefined;

--- a/mods/mod-swooper-maps/src/dev/diagnostics/placement-metrics.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/placement-metrics.ts
@@ -148,7 +148,7 @@ type ResourcePlanArtifact = {
     family: "aquatic" | "cultivated" | "terrestrial" | "geological";
     laneId: string;
     laneKind: "land" | "water";
-    phase: "rotation" | "range-floor" | "region-minimum";
+    phase: "rotation" | "range-floor" | "region-minimum" | "support";
     inHabitat: boolean;
   }>;
   perType: ReadonlyArray<{
@@ -174,6 +174,31 @@ type ResourcePlanArtifact = {
     forced: number;
     shortfall: number;
   }>;
+};
+
+type ResourcePlanAdjustedArtifact = {
+  plannedCount: number;
+  moveCount: number;
+  addCount: number;
+  intents: ResourcePlanArtifact["intents"];
+  adjustments: ReadonlyArray<{
+    action: "move" | "add";
+    reason: "support-floor" | "support-equity";
+    resourceType: string;
+    resourceTypeId: number;
+    fromPlotIndex?: number;
+    toPlotIndex: number;
+    seatIndex: number;
+  }>;
+  shortfalls: ReadonlyArray<{ seatIndex: number; reason: string; missing: number }>;
+  perStart: ReadonlyArray<{
+    seatIndex: number;
+    playerId: number;
+    plotIndex: number;
+    supportBefore: number;
+    supportAfter: number;
+  }>;
+  equity: { gapBefore: number | null; gapAfter: number | null; tolerance: number };
 };
 
 type ResourceOutcomesArtifact = {
@@ -382,6 +407,9 @@ export function computePlacementMetricsFromRun(args: ComputeArgs): Record<string
   const resourcePlan = context.artifacts.get(placementArtifacts.resourcePlan.id) as
     | ResourcePlanArtifact
     | undefined;
+  const resourcePlanAdjusted = context.artifacts.get(placementArtifacts.resourcePlanAdjusted.id) as
+    | ResourcePlanAdjustedArtifact
+    | undefined;
   const resourceOutcomes = context.artifacts.get(placementArtifacts.resourcePlacementOutcomes.id) as
     | ResourceOutcomesArtifact
     | undefined;
@@ -407,6 +435,11 @@ export function computePlacementMetricsFromRun(args: ComputeArgs): Record<string
   if (!startAssignment) throw new Error("Missing artifact:placement.startAssignment.");
   if (!resourceOutcomes) throw new Error("Missing artifact:placement.resourcePlacementOutcomes.");
   if (!resourcePlan) throw new Error("Missing artifact:placement.resourcePlan.");
+  if (!resourcePlanAdjusted) throw new Error("Missing artifact:placement.resourcePlanAdjusted.");
+  // S5: place-resources stamps the support-ADJUSTED intents; every per-plot
+  // join against stamped outcomes uses these. The base plan stays authority
+  // for per-type ranges, spacing floors, weights, and region minimums.
+  const stampedIntents = resourcePlanAdjusted.intents;
   const landMask = topography?.landMask;
   if (!(landMask instanceof Uint8Array) || landMask.length !== size) {
     throw new Error("Missing artifact:morphology.topography landMask.");
@@ -742,7 +775,7 @@ export function computePlacementMetricsFromRun(args: ComputeArgs): Record<string
 
   // --- E2.3 habitat fidelity ------------------------------------------------------------------------------
   {
-    const intentByPlot = new Map(resourcePlan.intents.map((row) => [row.plotIndex, row]));
+    const intentByPlot = new Map(stampedIntents.map((row) => [row.plotIndex, row]));
     let placedWithIntent = 0;
     let placedInHabitat = 0;
     for (const outcome of placed) {
@@ -760,7 +793,7 @@ export function computePlacementMetricsFromRun(args: ComputeArgs): Record<string
 
   // --- E2.5 aggregation above the spacing floor (pair-correlation proxy) ---------------------------------
   {
-    const intentByPlot = new Map(resourcePlan.intents.map((row) => [row.plotIndex, row]));
+    const intentByPlot = new Map(stampedIntents.map((row) => [row.plotIndex, row]));
     const floorByTypeId = new Map(
       resourcePlan.perType.map((row) => [row.resourceTypeId, row.spacingFloorTiles])
     );
@@ -819,6 +852,12 @@ export function computePlacementMetricsFromRun(args: ComputeArgs): Record<string
       return { family, placedCount: plots.length, floor, pairCorrelationRatio: pairRatioFor(plots, floor) };
     });
     const geological = detail.find((row) => row.family === "geological");
+    // Counterfactual (S5): the same ratio on the BASE plan's geological
+    // sites, before the support pass moved any — attributes aggregation
+    // movement to the adjustment instead of seed geography.
+    const baseGeologicalPlots = resourcePlan.intents
+      .filter((row) => row.family === "geological" && row.laneKind === "land")
+      .map((row) => row.plotIndex);
     metrics["E2.5"] = metric(
       "E2.5",
       "Aggregation above spacing floor via habitat intensity (pair-correlation > CSR for geological)",
@@ -826,11 +865,12 @@ export function computePlacementMetricsFromRun(args: ComputeArgs): Record<string
       {
         geologicalPairCorrelationAtRGtFloor: geological?.pairCorrelationRatio ?? null,
         geologicalPlacedCount: geological?.placedCount ?? 0,
+        basePlanGeologicalPairCorrelation: pairRatioFor(baseGeologicalPlots, geoFloor),
       },
       {
         detail,
         note:
-          "Ratio of observed same-family pair counts in the annulus (floor, floor+2] to the CSR expectation over land. > 1 means regional aggregation above the blue-noise floor; floorByTypeId guards E2.6 separately.",
+          "Ratio of observed same-family pair counts in the annulus (floor, floor+2] to the CSR expectation over land. > 1 means regional aggregation above the blue-noise floor; floorByTypeId guards E2.6 separately. basePlanGeologicalPairCorrelation is the pre-support-pass counterfactual (S5).",
       }
     );
     void floorByTypeId;
@@ -990,7 +1030,7 @@ export function computePlacementMetricsFromRun(args: ComputeArgs): Record<string
     // Reassignment is computed honestly from artifacts even though type
     // re-decision is gone by construction: the stamped type at each plot is
     // compared against the plan intent at that plot.
-    const intentByPlot = new Map(resourcePlan.intents.map((row) => [row.plotIndex, row]));
+    const intentByPlot = new Map(stampedIntents.map((row) => [row.plotIndex, row]));
     let stampedWithIntent = 0;
     let reassignedCount = 0;
     for (const outcome of resourceOutcomes.outcomes) {
@@ -1001,11 +1041,11 @@ export function computePlacementMetricsFromRun(args: ComputeArgs): Record<string
     }
 
     let preferredLegalRows = 0;
-    for (const intent of resourcePlan.intents) {
+    for (const intent of stampedIntents) {
       if (adapter.canHaveResource(intent.x, intent.y, intent.resourceTypeId)) preferredLegalRows++;
     }
 
-    const plannedCount = resourcePlan.intents.length;
+    const plannedCount = stampedIntents.length;
     const assignedCount = resourceOutcomes.reconciliation.plannedCount;
     const finalPlacedCount = resourceOutcomes.summary.placedCount;
 
@@ -1097,18 +1137,40 @@ export function computePlacementMetricsFromRun(args: ComputeArgs): Record<string
     }
     const minPerStart = perStartCounts.length ? Math.min(...perStartCounts) : null;
     const maxPerStart = perStartCounts.length ? Math.max(...perStartCounts) : null;
+    const supportShortfallMissing = resourcePlanAdjusted.shortfalls.reduce(
+      (sum, row) => sum + row.missing,
+      0
+    );
     metrics["E3.1"] = metric("E3.1", "Resources within radius 4 of each start >= 2", "computed", {
       minResourcesPerStart: minPerStart,
       meanResourcesPerStart: mean(perStartCounts),
       startsBelowFloor: perStartCounts.filter((count) => count < START_SUPPORT_FLOOR).length,
       startsTotal: perStartCounts.length,
-    }, { detail: perStartCounts });
+      supportMoves: resourcePlanAdjusted.moveCount,
+      supportAdds: resourcePlanAdjusted.addCount,
+      supportShortfallMissing,
+    }, {
+      detail: {
+        perStartPlacedCounts: perStartCounts,
+        perStartPlanned: resourcePlanAdjusted.perStart,
+        adjustments: resourcePlanAdjusted.adjustments,
+        shortfalls: resourcePlanAdjusted.shortfalls,
+      },
+      note:
+        "Measured on PLACED outcomes (post-stamp). supportMoves/supportAdds and the per-adjustment provenance come from the adjusted-plan artifact (S5).",
+    });
     metrics["E3.2"] = metric("E3.2", "Start support equity: max-min per-player count <= 2", "computed", {
       maxMinGap: minPerStart != null && maxPerStart != null ? maxPerStart - minPerStart : null,
+      plannedGapBefore: resourcePlanAdjusted.equity.gapBefore,
+      plannedGapAfter: resourcePlanAdjusted.equity.gapAfter,
     });
     metrics["E3.3"] = metric("E3.3", "Support guarantee holds across seeds (20/20)", "computed", {
-      guaranteeHolds: minPerStart != null && minPerStart >= START_SUPPORT_FLOOR,
-    }, { note: "Aggregate trueCount across seeds gives the N/N guarantee rate." });
+      guaranteeHolds:
+        minPerStart != null &&
+        minPerStart >= START_SUPPORT_FLOOR &&
+        maxPerStart != null &&
+        maxPerStart - minPerStart <= 2,
+    }, { note: "guaranteeHolds = floor (E3.1) AND equity (E3.2) on this seed; aggregate trueCount across seeds gives the N/N guarantee rate." });
   }
 
   // --- E3.4 / E4.* -----------------------------------------------------------------------------------------------------

--- a/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
+++ b/mods/mod-swooper-maps/src/dev/diagnostics/surface-delta-context.ts
@@ -1797,11 +1797,19 @@ function readResourcePlanEvidence(evidence: unknown): {
   minSpacingTiles: number | null;
 } {
   const preferredByPlot = new Map<number, number>();
-  const plan = isRecord(evidence) ? evidence.resourcePlan : undefined;
+  // S5: prefer the support-ADJUSTED plan when present — its intents are the
+  // ones actually stamped; the base resourcePlan stays as fallback evidence.
+  const evidenceRecord = isRecord(evidence) ? evidence : undefined;
+  const plan = isRecord(evidenceRecord?.resourcePlanAdjusted)
+    ? evidenceRecord.resourcePlanAdjusted
+    : evidenceRecord?.resourcePlan;
   // S3 plan shape: typed per-plot intents (plan authority); the planned type
   // IS the stamped type, so "preferred" == planned resourceTypeId.
   const intents = isRecord(plan) && Array.isArray(plan.intents) ? plan.intents : [];
-  const minSpacingTiles = isRecord(plan) ? finiteInteger(plan.siteSpacingTiles) : null;
+  // siteSpacingTiles lives on the BASE plan (the adjusted plan does not
+  // re-declare selection settings).
+  const basePlan = evidenceRecord?.resourcePlan;
+  const minSpacingTiles = isRecord(basePlan) ? finiteInteger(basePlan.siteSpacingTiles) : null;
   for (const intent of intents) {
     if (!isRecord(intent)) continue;
     const plotIndex = finiteInteger(intent.plotIndex);
@@ -1847,7 +1855,10 @@ function readResourcePlanIntentEvidence(evidence: unknown): {
   byPlot: ReadonlyMap<number, ResourcePlanIntentContext>;
 } {
   const byPlot = new Map<number, ResourcePlanIntentContext>();
-  const plan = isRecord(evidence) ? evidence.resourcePlan : undefined;
+  const evidenceRecord = isRecord(evidence) ? evidence : undefined;
+  const plan = isRecord(evidenceRecord?.resourcePlanAdjusted)
+    ? evidenceRecord.resourcePlanAdjusted
+    : evidenceRecord?.resourcePlan;
   const intents = isRecord(plan) && Array.isArray(plan.intents) ? plan.intents : [];
   for (const row of intents) {
     if (!isRecord(row)) continue;

--- a/mods/mod-swooper-maps/src/domain/placement/ops/plan-starts/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/ops/plan-starts/contract.ts
@@ -295,12 +295,13 @@ const PlanStartsContract = defineOp({
     ),
     resourceSupport: Type.Optional(
       TypedArraySchemas.u8({
-        description: "Per-tile nearby placed-resource support score (0..255).",
+        description: "Per-tile nearby planned-resource support score (0..255).",
       })
     ),
-    placedResourcePlotIndices: Type.Optional(
+    plannedResourcePlotIndices: Type.Optional(
       Type.Array(Type.Integer({ minimum: 0 }), {
-        description: "Placed resource plot indices used to derive nearby start support.",
+        description:
+          "PLANNED resource site plot indices (select-resource-sites intents) used to derive nearby start support. Planned, not placed: since S5 (D3 contract change) resource stamping runs after starts + the support pass, so plan intents are the only resource signal that exists at start time.",
       })
     ),
   }),
@@ -461,13 +462,13 @@ const PlanStartsContract = defineOp({
         minimum: 0,
         maximum: 4,
         default: 0.5,
-        description: "Weight for nearby placed-resource support in start score.",
+        description: "Weight for nearby planned-resource support in start score.",
       }),
       resourceSupportRadiusTiles: Type.Integer({
         minimum: 0,
         maximum: 8,
         default: 4,
-        description: "Radius used to count nearby placed-resource support for starts.",
+        description: "Radius used to count nearby planned-resource support for starts.",
       }),
       freshwaterWeight: Type.Number({
         minimum: 0,

--- a/mods/mod-swooper-maps/src/domain/placement/ops/plan-starts/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/placement/ops/plan-starts/strategies/default.ts
@@ -231,13 +231,13 @@ function buildResourceSupport(args: {
   width: number;
   height: number;
   radius: number;
-  placedResourcePlotIndices?: readonly number[];
+  plannedResourcePlotIndices?: readonly number[];
 }): Uint8Array | undefined {
-  if (!args.placedResourcePlotIndices?.length || args.radius <= 0) return undefined;
+  if (!args.plannedResourcePlotIndices?.length || args.radius <= 0) return undefined;
   const size = Math.max(0, args.width * args.height);
   const counts = new Uint16Array(size);
   let maxCount = 0;
-  for (const raw of args.placedResourcePlotIndices) {
+  for (const raw of args.plannedResourcePlotIndices) {
     const plotIndex = raw | 0;
     if (plotIndex < 0 || plotIndex >= size) continue;
     for (const idx of getHexRadiusIndicesOddQ(plotIndex, args.width, args.height, args.radius)) {
@@ -401,7 +401,7 @@ export const defaultStrategy = createStrategy(PlanStartsContract, "default", {
         width,
         height,
         radius: Math.max(0, config.resourceSupportRadiusTiles | 0),
-        placedResourcePlotIndices: input.placedResourcePlotIndices,
+        plannedResourcePlotIndices: input.plannedResourcePlotIndices,
       });
 
     const climateThresholds = computeClimateComfortThresholds({

--- a/mods/mod-swooper-maps/src/domain/resources/ops/adjust-resource-support/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/adjust-resource-support/contract.ts
@@ -1,0 +1,276 @@
+import { Type, TypedArraySchemas, defineOp } from "@swooper/mapgen-core/authoring";
+
+import SelectResourceSitesContract from "../select-resource-sites/contract.js";
+
+/**
+ * Resource↔start support pass (placement-realignment S5, E3.1–E3.3).
+ *
+ * Takes the typed resource site plan (select-resource-sites output) plus the
+ * seated StartRecord seats and produces an ADJUSTED intent set that satisfies
+ * a per-start support floor within a radius and a cross-player support equity
+ * tolerance, as a bounded adjustment: move or add the minimum number of
+ * sites, with typed provenance per adjusted site (which start it serves and
+ * why). Every S3 plan invariant is respected — policy-table legality, per-type
+ * spacing floors, per-type [min,max] ranges (moves preserve counts; adds stay
+ * under max), affinity/exclusion rules, and the per-landmass equity ceiling.
+ * Adjustments that cannot be made without violating an invariant are recorded
+ * as typed shortfalls, never forced.
+ *
+ * Ordering (D3 contract change, refactor-plan S5): resource PLANNING stays
+ * before starts; resource STAMPING moves after this pass. Post-stamp mutation
+ * is rejected — the engine has no resource-removal adapter capability and a
+ * stamped surface would need its own typed outcome surface.
+ */
+
+const FamilySchema = Type.Union([
+  Type.Literal("aquatic"),
+  Type.Literal("cultivated"),
+  Type.Literal("terrestrial"),
+  Type.Literal("geological"),
+]);
+
+const LaneKindSchema = Type.Union([Type.Literal("land"), Type.Literal("water")]);
+
+const AdjustedPhaseSchema = Type.Union(
+  [
+    Type.Literal("rotation"),
+    Type.Literal("range-floor"),
+    Type.Literal("region-minimum"),
+    Type.Literal("support"),
+  ],
+  {
+    description:
+      "Planning provenance phase. Moved intents keep their original phase; support-pass additions carry the new 'support' phase.",
+  }
+);
+
+const SupportProvenanceSchema = Type.Object(
+  {
+    action: Type.Union([Type.Literal("move"), Type.Literal("add")], {
+      description: "Whether the site was relocated from elsewhere in the plan or newly added.",
+    }),
+    reason: Type.Union([Type.Literal("support-floor"), Type.Literal("support-equity")], {
+      description:
+        "Why the adjustment happened: filling a start below the support floor (E3.1) or shrinking the cross-player support gap (E3.2).",
+    }),
+    seatIndex: Type.Integer({
+      minimum: 0,
+      description: "Seat the adjustment serves (deficit seat for floor; trimmed/filled seat for equity).",
+    }),
+    fromPlotIndex: Type.Optional(
+      Type.Integer({
+        minimum: 0,
+        description: "Original plot of a moved site (absent for additions).",
+      })
+    ),
+  },
+  { additionalProperties: false }
+);
+
+const AdjustedIntentSchema = Type.Object(
+  {
+    plotIndex: Type.Integer({ minimum: 0 }),
+    x: Type.Integer({ minimum: 0 }),
+    y: Type.Integer({ minimum: 0 }),
+    resourceType: Type.String({ pattern: "^RESOURCE_[A-Z0-9_]+$" }),
+    resourceTypeId: Type.Integer({ minimum: 0 }),
+    family: FamilySchema,
+    laneId: Type.String(),
+    laneKind: LaneKindSchema,
+    phase: AdjustedPhaseSchema,
+    order: Type.Integer({ minimum: 0 }),
+    regionSlot: Type.Integer({ minimum: 0, maximum: 2 }),
+    landmassId: Type.Integer({ minimum: -1 }),
+    inHabitat: Type.Boolean(),
+    support: Type.Optional(SupportProvenanceSchema),
+  },
+  { additionalProperties: false }
+);
+
+const AdjustmentSchema = Type.Object(
+  {
+    action: Type.Union([Type.Literal("move"), Type.Literal("add")]),
+    reason: Type.Union([Type.Literal("support-floor"), Type.Literal("support-equity")]),
+    resourceType: Type.String(),
+    resourceTypeId: Type.Integer({ minimum: 0 }),
+    fromPlotIndex: Type.Optional(Type.Integer({ minimum: 0 })),
+    toPlotIndex: Type.Integer({ minimum: 0 }),
+    seatIndex: Type.Integer({ minimum: 0 }),
+  },
+  { additionalProperties: false }
+);
+
+const SupportShortfallSchema = Type.Object(
+  {
+    seatIndex: Type.Integer({ minimum: 0 }),
+    reason: Type.Union([
+      Type.Literal("no-legal-tile-in-radius"),
+      Type.Literal("spacing-floor-preserved"),
+      Type.Literal("no-movable-site"),
+      Type.Literal("equity-unresolvable"),
+      Type.Literal("adjustment-budget-exhausted"),
+      Type.Literal("adjustment-disabled"),
+    ]),
+    missing: Type.Integer({ minimum: 1 }),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Typed record of a support adjustment that could not be made without violating an S3 plan invariant (or with adjustments disabled). Never silently forced.",
+  }
+);
+
+const EligibilityRowSchema = Type.Object(
+  {
+    resourceType: Type.String({ pattern: "^RESOURCE_[A-Z0-9_]+$" }),
+    resourceTypeId: Type.Integer({ minimum: 0 }),
+    habitatMask: TypedArraySchemas.u8({
+      shape: null,
+      description: "Habitat lane eligibility (1=in-lane); preferred for adjusted destinations.",
+    }),
+    legalMask: TypedArraySchemas.u8({
+      shape: null,
+      description:
+        "Per-resource policy legality from Resource_ValidPlacements rows (1=legal); hard gate for adjusted destinations.",
+    }),
+    intensity: TypedArraySchemas.f32({
+      shape: null,
+      description: "Habitat intensity (0..1) scoring destination preference.",
+    }),
+  },
+  { additionalProperties: false }
+);
+
+const StartSeatInputSchema = Type.Object(
+  {
+    seatIndex: Type.Integer({ minimum: 0 }),
+    playerId: Type.Integer({ minimum: 0 }),
+    plotIndex: Type.Integer({
+      minimum: -1,
+      description: "Seat plot from the StartRecord; -1 (unseated) seats are skipped.",
+    }),
+  },
+  { additionalProperties: false }
+);
+
+const AdjustResourceSupportContract = defineOp({
+  kind: "plan",
+  id: "resources/adjust-resource-support",
+  input: Type.Object(
+    {
+      seed: Type.Integer({ description: "Deterministic seed (from env.seed)." }),
+      plan: SelectResourceSitesContract.output,
+      eligibility: Type.Array(EligibilityRowSchema, {
+        description:
+          "Per-type habitat/legality/intensity fields from the planning step, so adjusted destinations obey the same policy tables.",
+      }),
+      starts: Type.Array(StartSeatInputSchema, {
+        description: "Seated StartRecord seats from the start assignment (seat order).",
+      }),
+      landmassIdByTile: TypedArraySchemas.i32({
+        description: "Landmass id per tile (-1 for water).",
+      }),
+      landmassTileCounts: Type.Array(Type.Integer({ minimum: 0 }), {
+        description: "Tile count per landmass id (index-aligned).",
+      }),
+      regionSlotByTile: TypedArraySchemas.u8({
+        description: "Landmass region slot per tile (0=none, 1=west, 2=east).",
+      }),
+    },
+    { additionalProperties: false }
+  ),
+  output: Type.Object(
+    {
+      width: Type.Integer({ minimum: 1 }),
+      height: Type.Integer({ minimum: 1 }),
+      seed: Type.Integer(),
+      plannedCount: Type.Integer({ minimum: 0 }),
+      moveCount: Type.Integer({ minimum: 0 }),
+      addCount: Type.Integer({ minimum: 0 }),
+      intents: Type.Array(AdjustedIntentSchema, {
+        description:
+          "The FULL adjusted intent set (original intents with moves applied, plus support additions). place-resources stamps exactly this.",
+      }),
+      adjustments: Type.Array(AdjustmentSchema, {
+        description: "Every applied adjustment with typed provenance.",
+      }),
+      shortfalls: Type.Array(SupportShortfallSchema),
+      perStart: Type.Array(
+        Type.Object(
+          {
+            seatIndex: Type.Integer({ minimum: 0 }),
+            playerId: Type.Integer({ minimum: 0 }),
+            plotIndex: Type.Integer({ minimum: 0 }),
+            supportBefore: Type.Integer({ minimum: 0 }),
+            supportAfter: Type.Integer({ minimum: 0 }),
+          },
+          { additionalProperties: false }
+        ),
+        { description: "Per seated start: planned-site support within the radius, before/after." }
+      ),
+      equity: Type.Object(
+        {
+          gapBefore: Type.Union([Type.Integer({ minimum: 0 }), Type.Null()]),
+          gapAfter: Type.Union([Type.Integer({ minimum: 0 }), Type.Null()]),
+          tolerance: Type.Integer({ minimum: 0 }),
+        },
+        {
+          additionalProperties: false,
+          description: "Cross-player max−min support gap before/after the pass (null with <2 seats).",
+        }
+      ),
+      settings: Type.Object(
+        {
+          enabled: Type.Boolean(),
+          supportFloor: Type.Integer({ minimum: 0 }),
+          supportRadiusTiles: Type.Integer({ minimum: 0 }),
+          equityTolerance: Type.Integer({ minimum: 0 }),
+          strength: Type.Number(),
+        },
+        { additionalProperties: false }
+      ),
+    },
+    { additionalProperties: false }
+  ),
+  strategies: {
+    default: Type.Object(
+      {
+        enabled: Type.Boolean({
+          default: true,
+          description:
+            "Runs the support pass. When false the plan passes through unchanged and unmet floors are recorded as typed shortfalls (reason adjustment-disabled).",
+        }),
+        supportFloor: Type.Integer({
+          minimum: 0,
+          maximum: 6,
+          default: 2,
+          description:
+            "Minimum planned resource sites within supportRadiusTiles of every seated start (E3.1 guarantee at the default 2).",
+        }),
+        supportRadiusTiles: Type.Integer({
+          minimum: 1,
+          maximum: 8,
+          default: 4,
+          description: "Hex radius around each start within which support sites are counted (E3.1 measures 4).",
+        }),
+        equityTolerance: Type.Integer({
+          minimum: 0,
+          maximum: 8,
+          default: 2,
+          description:
+            "Maximum allowed max−min per-player support-count gap after the pass (E3.2 measures 2).",
+        }),
+        strength: Type.Number({
+          minimum: 0,
+          maximum: 1,
+          default: 1,
+          description:
+            "Scales the adjustment budget: per-start floor fills apply ceil(strength × deficit) units and the equity pass budget scales with strength. 1 = fully enforce the gates; 0 = record-only (like disabled, but the pass still measures).",
+        }),
+      },
+      { additionalProperties: false }
+    ),
+  },
+});
+
+export default AdjustResourceSupportContract;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/adjust-resource-support/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/adjust-resource-support/index.ts
@@ -1,0 +1,13 @@
+import { createOp } from "@swooper/mapgen-core/authoring";
+
+import AdjustResourceSupportContract from "./contract.js";
+import { defaultStrategy } from "./strategies/index.js";
+
+const adjustResourceSupport = createOp(AdjustResourceSupportContract, {
+  strategies: { default: defaultStrategy },
+});
+
+export type * from "./contract.js";
+export type * from "./types.js";
+
+export default adjustResourceSupport;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/adjust-resource-support/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/adjust-resource-support/strategies/default.ts
@@ -1,0 +1,806 @@
+import { createStrategy } from "@swooper/mapgen-core/authoring";
+import {
+  getHexRadiusIndicesOddQ,
+  hexDistanceOddQPeriodicX,
+} from "@swooper/mapgen-core/lib/grid";
+
+import AdjustResourceSupportContract from "../contract.js";
+
+/**
+ * Default support pass: bounded move/add adjustment over the resource plan.
+ *
+ * Phase 1 (floor, E3.1): every seated start gets at least supportFloor
+ * planned sites within supportRadiusTiles. Each deficit unit prefers MOVING a
+ * site that serves no start (count-preserving — per-type ranges, Spearman
+ * stratification, and region minimums hold exactly) and falls back to ADDING
+ * a site for a type with maxCount headroom.
+ *
+ * Phase 2 (equity, E3.2): while max−min support exceeds equityTolerance,
+ * move one site out of the richest start's radius — preferably into the
+ * poorest start's radius, otherwise to a neutral in-habitat plot — with
+ * removal/gain safety checks so no seat drops below the floor or the current
+ * minimum and no destination recreates the old maximum.
+ *
+ * All destination tiles are policy-legal for their type, hold the per-type
+ * same-type spacing floor, keep cross-type adjacency clearance (the official
+ * force-pass convention used by the region-minimum pass), respect
+ * affinity/exclusion rules echoed in the plan settings, and respect the
+ * per-landmass equity ceiling. Unsatisfiable units become typed shortfalls.
+ *
+ * Determinism: candidate scans run in ascending plot/intent order; score ties
+ * break on a splitmix-style hash of (seed, plotIndex, salt) — no call-order
+ * coupling.
+ */
+
+type PlanIntent = {
+  plotIndex: number;
+  x: number;
+  y: number;
+  resourceType: string;
+  resourceTypeId: number;
+  family: "aquatic" | "cultivated" | "terrestrial" | "geological";
+  laneId: string;
+  laneKind: "land" | "water";
+  phase: "rotation" | "range-floor" | "region-minimum" | "support";
+  order: number;
+  regionSlot: number;
+  landmassId: number;
+  inHabitat: boolean;
+  support?: {
+    action: "move" | "add";
+    reason: "support-floor" | "support-equity";
+    seatIndex: number;
+    fromPlotIndex?: number;
+  };
+};
+
+type Adjustment = {
+  action: "move" | "add";
+  reason: "support-floor" | "support-equity";
+  resourceType: string;
+  resourceTypeId: number;
+  fromPlotIndex?: number;
+  toPlotIndex: number;
+  seatIndex: number;
+};
+
+type ShortfallReason =
+  | "no-legal-tile-in-radius"
+  | "spacing-floor-preserved"
+  | "no-movable-site"
+  | "equity-unresolvable"
+  | "adjustment-budget-exhausted"
+  | "adjustment-disabled";
+
+const EQUITY_ITERATION_CAP = 64;
+const CROSS_TYPE_CLEARANCE = 2;
+
+function hash32(seed: number, a: number, b: number): number {
+  let h = (seed ^ 0x9e3779b9) >>> 0;
+  h = Math.imul(h ^ a, 0x85ebca6b) >>> 0;
+  h = (h ^ (h >>> 13)) >>> 0;
+  h = Math.imul(h ^ b, 0xc2b2ae35) >>> 0;
+  h = (h ^ (h >>> 16)) >>> 0;
+  return h;
+}
+
+function hash01(seed: number, a: number, b: number): number {
+  return hash32(seed, a, b) / 0x100000000;
+}
+
+export const defaultStrategy = createStrategy(AdjustResourceSupportContract, "default", {
+  run: (input, config) => {
+    const plan = input.plan;
+    const width = plan.width | 0;
+    const height = plan.height | 0;
+    const size = width * height;
+    const seed = input.seed | 0;
+    if (!Number.isSafeInteger(size) || size <= 0) {
+      throw new Error(`[resources] Invalid grid for adjust-resource-support: ${width}x${height}.`);
+    }
+    if (input.landmassIdByTile.length !== size || input.regionSlotByTile.length !== size) {
+      throw new Error(
+        "[resources] adjust-resource-support landmass/region fields must match grid size."
+      );
+    }
+    const landmassIdByTile = input.landmassIdByTile;
+    const regionSlotByTile = input.regionSlotByTile;
+
+    const enabled = config.enabled;
+    const supportFloor = Math.max(0, config.supportFloor | 0);
+    const radius = Math.max(1, config.supportRadiusTiles | 0);
+    const equityTolerance = Math.max(0, config.equityTolerance | 0);
+    const strength = Math.min(1, Math.max(0, config.strength));
+
+    const settings = {
+      enabled,
+      supportFloor,
+      supportRadiusTiles: radius,
+      equityTolerance,
+      strength,
+    };
+
+    // --- eligibility / per-type metadata -----------------------------------------------------
+    type Eligibility = {
+      resourceType: string;
+      resourceTypeId: number;
+      habitatMask: Uint8Array;
+      legalMask: Uint8Array;
+      intensity: Float32Array;
+    };
+    const eligibilityByType = new Map<string, Eligibility>();
+    for (const row of input.eligibility) {
+      if (row.habitatMask.length !== size || row.legalMask.length !== size) {
+        throw new Error(
+          `[resources] adjust-resource-support eligibility masks for ${row.resourceType} must match grid size ${size}.`
+        );
+      }
+      if (row.intensity.length !== size) {
+        throw new Error(
+          `[resources] adjust-resource-support intensity for ${row.resourceType} must match grid size.`
+        );
+      }
+      eligibilityByType.set(row.resourceType, {
+        resourceType: row.resourceType,
+        resourceTypeId: row.resourceTypeId,
+        habitatMask: row.habitatMask as Uint8Array,
+        legalMask: row.legalMask as Uint8Array,
+        intensity: row.intensity as Float32Array,
+      });
+    }
+
+    type TypeMeta = {
+      spacingFloorTiles: number;
+      minCount: number;
+      maxCount: number;
+    };
+    const metaByType = new Map<string, TypeMeta>();
+    for (const row of plan.perType) {
+      metaByType.set(row.resourceType, {
+        spacingFloorTiles: row.spacingFloorTiles,
+        minCount: row.minCount,
+        maxCount: row.maxCount,
+      });
+    }
+
+    // Region-minimum guard: a move must not drop a type's per-region count to
+    // (or below) its satisfied requirement (E2.2).
+    const requiredByTypeRegion = new Map<string, number>();
+    for (const row of plan.regionMinimums) {
+      requiredByTypeRegion.set(`${row.resourceType}:${row.regionSlot}`, row.required);
+    }
+
+    // Exclusion/affinity rules echoed from selection settings (E3.4 parity).
+    type CompiledRule = { partner: string; relation: "affinity" | "exclusion"; radius: number };
+    const rulesByType = new Map<string, CompiledRule[]>();
+    for (const rule of plan.settings.affinityRules ?? []) {
+      const push = (from: string, partner: string) => {
+        const list = rulesByType.get(from) ?? [];
+        list.push({ partner, relation: rule.relation, radius: rule.radiusTiles });
+        rulesByType.set(from, list);
+      };
+      push(rule.resourceA, rule.resourceB);
+      push(rule.resourceB, rule.resourceA);
+    }
+
+    // --- mutable plan state --------------------------------------------------------------------
+    const intents: PlanIntent[] = plan.intents.map((intent) => ({
+      plotIndex: intent.plotIndex,
+      x: intent.x,
+      y: intent.y,
+      resourceType: intent.resourceType,
+      resourceTypeId: intent.resourceTypeId,
+      family: intent.family,
+      laneId: intent.laneId,
+      laneKind: intent.laneKind,
+      phase: intent.phase,
+      order: intent.order,
+      regionSlot: intent.regionSlot,
+      landmassId: intent.landmassId,
+      inHabitat: intent.inHabitat,
+    }));
+    let nextOrder = intents.reduce((acc, intent) => Math.max(acc, intent.order + 1), 0);
+
+    const usedPlots = new Set<number>(intents.map((intent) => intent.plotIndex));
+    const plotsByType = new Map<string, number[]>();
+    const countByType = new Map<string, number>();
+    const countByTypeRegion = new Map<string, number>();
+    for (const intent of intents) {
+      const typePlots = plotsByType.get(intent.resourceType) ?? [];
+      typePlots.push(intent.plotIndex);
+      plotsByType.set(intent.resourceType, typePlots);
+      countByType.set(intent.resourceType, (countByType.get(intent.resourceType) ?? 0) + 1);
+      const regionKey = `${intent.resourceType}:${intent.regionSlot}`;
+      countByTypeRegion.set(regionKey, (countByTypeRegion.get(regionKey) ?? 0) + 1);
+    }
+
+    // --- landmass equity state (E2.8) ----------------------------------------------------------
+    const totalLand = input.landmassTileCounts.reduce((acc, count) => acc + count, 0);
+    const qualifyingLandmassIds = new Set(
+      input.landmassTileCounts
+        .map((count, id) => ({ id, count }))
+        .filter((row) => totalLand > 0 && row.count / totalLand >= 0.1)
+        .map((row) => row.id)
+    );
+    const qualifyingLandTiles = input.landmassTileCounts.reduce(
+      (acc, count, id) => (qualifyingLandmassIds.has(id) ? acc + count : acc),
+      0
+    );
+    const placedByLandmass = new Map<number, number>();
+    let placedOnQualifyingLand = 0;
+    for (const intent of intents) {
+      if (intent.landmassId >= 0 && qualifyingLandmassIds.has(intent.landmassId)) {
+        placedByLandmass.set(
+          intent.landmassId,
+          (placedByLandmass.get(intent.landmassId) ?? 0) + 1
+        );
+        placedOnQualifyingLand += 1;
+      }
+    }
+    const equityMaxDensityRatio = plan.settings.equityMaxDensityRatio;
+
+    // --- seat zones ----------------------------------------------------------------------------
+    const seats = input.starts.filter(
+      (seat) => seat.plotIndex >= 0 && seat.plotIndex < size
+    );
+    const seatPlots = new Set(seats.map((seat) => seat.plotIndex));
+    const seatZones: Array<Set<number>> = seats.map(
+      (seat) => new Set(getHexRadiusIndicesOddQ(seat.plotIndex, width, height, radius))
+    );
+    const seatsByPlot = new Map<number, number[]>();
+    seatZones.forEach((zone, seatPos) => {
+      for (const plot of zone) {
+        const list = seatsByPlot.get(plot) ?? [];
+        list.push(seatPos);
+        seatsByPlot.set(plot, list);
+      }
+    });
+
+    const counts = seats.map((_seat, seatPos) => {
+      let count = 0;
+      for (const intent of intents) if (seatZones[seatPos]!.has(intent.plotIndex)) count += 1;
+      return count;
+    });
+    const supportBefore = [...counts];
+
+    const adjustments: Adjustment[] = [];
+    const shortfallCounts = new Map<string, number>();
+    const recordShortfall = (seatIndex: number, reason: ShortfallReason, missing: number): void => {
+      if (missing <= 0) return;
+      const key = `${seatIndex}:${reason}`;
+      shortfallCounts.set(key, (shortfallCounts.get(key) ?? 0) + missing);
+    };
+
+    const gapOf = (): number | null => {
+      if (counts.length < 2) return null;
+      return Math.max(...counts) - Math.min(...counts);
+    };
+    const gapBefore = gapOf();
+
+    // --- invariant helpers ---------------------------------------------------------------------
+    const violatesTypeSpacing = (
+      plotIndex: number,
+      resourceType: string,
+      ignorePlot: number | null
+    ): boolean => {
+      const meta = metaByType.get(resourceType);
+      const floor = meta ? meta.spacingFloorTiles : 0;
+      if (floor <= 0) return false;
+      for (const placed of plotsByType.get(resourceType) ?? []) {
+        if (ignorePlot !== null && placed === ignorePlot) continue;
+        if (hexDistanceOddQPeriodicX(plotIndex, placed, width) < floor) return true;
+      }
+      return false;
+    };
+
+    // CROSS_TYPE_CLEARANCE = 2 means "no other site on the plot or adjacent
+    // to it" (the official force-pass convention), so an O(7) neighborhood
+    // membership test suffices.
+    const violatesCrossClearance = (plotIndex: number, ignorePlot: number | null): boolean => {
+      for (const idx of getHexRadiusIndicesOddQ(plotIndex, width, height, CROSS_TYPE_CLEARANCE - 1)) {
+        if (ignorePlot !== null && idx === ignorePlot) continue;
+        if (usedPlots.has(idx)) return true;
+      }
+      return false;
+    };
+
+    const excludedAt = (resourceType: string, plotIndex: number, ignorePlot: number | null): {
+      excluded: boolean;
+      affinityBonus: number;
+    } => {
+      const rules = rulesByType.get(resourceType);
+      if (!rules || rules.length === 0) return { excluded: false, affinityBonus: 0 };
+      let affinityBonus = 0;
+      for (const rule of rules) {
+        for (const partnerPlot of plotsByType.get(rule.partner) ?? []) {
+          if (ignorePlot !== null && partnerPlot === ignorePlot) continue;
+          if (hexDistanceOddQPeriodicX(plotIndex, partnerPlot, width) <= rule.radius) {
+            if (rule.relation === "exclusion") return { excluded: true, affinityBonus: 0 };
+            affinityBonus += 0.75;
+            break;
+          }
+        }
+      }
+      return { excluded: false, affinityBonus };
+    };
+
+    const exceedsLandmassCeiling = (plotIndex: number, removedLandmassId: number | null): boolean => {
+      const landmassId = landmassIdByTile[plotIndex] ?? -1;
+      if (landmassId < 0 || !qualifyingLandmassIds.has(landmassId)) return false;
+      if (qualifyingLandmassIds.size < 2) return false;
+      let total = placedOnQualifyingLand;
+      let onLandmass = placedByLandmass.get(landmassId) ?? 0;
+      if (removedLandmassId !== null && removedLandmassId >= 0 && qualifyingLandmassIds.has(removedLandmassId)) {
+        total -= 1;
+        if (removedLandmassId === landmassId) onLandmass -= 1;
+      }
+      if (total < qualifyingLandmassIds.size * 2) return false;
+      const tiles = input.landmassTileCounts[landmassId] ?? 0;
+      const meanDensity = qualifyingLandTiles > 0 ? (total + 1) / qualifyingLandTiles : 0;
+      const landmassDensity = tiles > 0 ? (onLandmass + 1) / tiles : 0;
+      return meanDensity > 0 && landmassDensity > equityMaxDensityRatio * meanDensity;
+    };
+
+    /**
+     * A move out of a region must not break a satisfied region minimum and
+     * must not deepen an existing region-minimum shortfall (E2.2).
+     */
+    const moveAllowedFrom = (intent: PlanIntent, destRegionSlot: number): boolean => {
+      if (intent.regionSlot === destRegionSlot) return true;
+      const required = requiredByTypeRegion.get(`${intent.resourceType}:${intent.regionSlot}`) ?? 0;
+      if (required <= 0) return true;
+      const current = countByTypeRegion.get(`${intent.resourceType}:${intent.regionSlot}`) ?? 0;
+      return current > required;
+    };
+
+    type Destination = { plotIndex: number; score: number };
+
+    const destinationFor = (
+      resourceType: string,
+      candidatePlots: Iterable<number>,
+      args: {
+        ignorePlot: number | null;
+        removedLandmassId: number | null;
+        gainSafe?: (plotIndex: number) => boolean;
+        /** Hard habitat gate (used for free-map destinations so adjustments do not erode E2.3). */
+        requireHabitat?: boolean;
+      }
+    ): Destination | null => {
+      const eligibility = eligibilityByType.get(resourceType);
+      if (!eligibility) return null;
+      let best: Destination | null = null;
+      for (const plotIndex of candidatePlots) {
+        if (plotIndex < 0 || plotIndex >= size) continue;
+        if (eligibility.legalMask[plotIndex] === 0) continue;
+        if (args.requireHabitat && eligibility.habitatMask[plotIndex] === 0) continue;
+        if (usedPlots.has(plotIndex) && plotIndex !== args.ignorePlot) continue;
+        if (seatPlots.has(plotIndex)) continue;
+        if (violatesTypeSpacing(plotIndex, resourceType, args.ignorePlot)) continue;
+        if (violatesCrossClearance(plotIndex, args.ignorePlot)) continue;
+        const ruleState = excludedAt(resourceType, plotIndex, args.ignorePlot);
+        if (ruleState.excluded) continue;
+        if (exceedsLandmassCeiling(plotIndex, args.removedLandmassId)) continue;
+        if (args.gainSafe && !args.gainSafe(plotIndex)) continue;
+        // Habitat dominates (E2.3): in-lane destinations always outrank
+        // out-of-lane ones; intensity + affinity order within the lane.
+        const score =
+          (eligibility.habitatMask[plotIndex] !== 0 ? 10 : 0) +
+          (eligibility.intensity[plotIndex] ?? 0) +
+          ruleState.affinityBonus +
+          hash01(seed, plotIndex, 0x5e5 + eligibility.resourceTypeId) * 1e-3;
+        if (best === null || score > best.score) best = { plotIndex, score };
+      }
+      return best;
+    };
+
+    // Fidelity-aware pair ranking (E2.3): relocating an out-of-lane site is
+    // fidelity-neutral-or-positive, so out-of-lane sources get a bonus that
+    // sits between the habitat-destination bonus (10) and the intensity term.
+    // Aggregation-aware (E2.5): moving a site that participates in a
+    // same-family proximity pair erodes the blue-noise-above-floor clustering
+    // the geological gate measures, so paired sources are penalized —
+    // isolated sites move first.
+    const breaksAggregationPair = (sourceIntent: PlanIntent): boolean => {
+      const meta = metaByType.get(sourceIntent.resourceType);
+      const floor = meta ? meta.spacingFloorTiles : 0;
+      for (const other of intents) {
+        if (other === sourceIntent) continue;
+        if (other.family !== sourceIntent.family) continue;
+        const d = hexDistanceOddQPeriodicX(sourceIntent.plotIndex, other.plotIndex, width);
+        if (d > floor && d <= floor + 2) return true;
+      }
+      return false;
+    };
+    const movePairScore = (sourceIntent: PlanIntent, dest: Destination): number =>
+      dest.score +
+      (sourceIntent.inHabitat ? 0 : 5) -
+      (breaksAggregationPair(sourceIntent) ? 4 : 0);
+
+    const applyAdjustment = (args: {
+      action: "move" | "add";
+      reason: "support-floor" | "support-equity";
+      seatIndex: number;
+      resourceType: string;
+      toPlotIndex: number;
+      sourceIntent?: PlanIntent;
+    }): void => {
+      const eligibility = eligibilityByType.get(args.resourceType)!;
+      const toPlot = args.toPlotIndex;
+      const y = (toPlot / width) | 0;
+      const x = toPlot - y * width;
+      const destRegionSlot = regionSlotByTile[toPlot] ?? 0;
+      const destLandmassId = landmassIdByTile[toPlot] ?? -1;
+
+      if (args.sourceIntent) {
+        const intent = args.sourceIntent;
+        const fromPlot = intent.plotIndex;
+        usedPlots.delete(fromPlot);
+        const typePlots = plotsByType.get(intent.resourceType) ?? [];
+        const fromIdx = typePlots.indexOf(fromPlot);
+        if (fromIdx >= 0) typePlots.splice(fromIdx, 1);
+        typePlots.push(toPlot);
+        const fromRegionKey = `${intent.resourceType}:${intent.regionSlot}`;
+        countByTypeRegion.set(fromRegionKey, (countByTypeRegion.get(fromRegionKey) ?? 1) - 1);
+        if (intent.landmassId >= 0 && qualifyingLandmassIds.has(intent.landmassId)) {
+          placedByLandmass.set(intent.landmassId, (placedByLandmass.get(intent.landmassId) ?? 1) - 1);
+          placedOnQualifyingLand -= 1;
+        }
+        for (const seatPos of seatsByPlot.get(fromPlot) ?? []) counts[seatPos]! -= 1;
+
+        intent.plotIndex = toPlot;
+        intent.x = x;
+        intent.y = y;
+        intent.regionSlot = destRegionSlot;
+        intent.landmassId = destLandmassId;
+        intent.inHabitat = eligibility.habitatMask[toPlot] !== 0;
+        intent.support = {
+          action: "move",
+          reason: args.reason,
+          seatIndex: args.seatIndex,
+          fromPlotIndex: fromPlot,
+        };
+        adjustments.push({
+          action: "move",
+          reason: args.reason,
+          resourceType: intent.resourceType,
+          resourceTypeId: intent.resourceTypeId,
+          fromPlotIndex: fromPlot,
+          toPlotIndex: toPlot,
+          seatIndex: args.seatIndex,
+        });
+      } else {
+        const templates = plan.perType.find((row) => row.resourceType === args.resourceType);
+        const intent: PlanIntent = {
+          plotIndex: toPlot,
+          x,
+          y,
+          resourceType: args.resourceType,
+          resourceTypeId: eligibility.resourceTypeId,
+          family: templates ? templates.family : "terrestrial",
+          laneId: templates ? templates.laneId : "unknown",
+          laneKind: templates ? templates.laneKind : "land",
+          phase: "support",
+          order: nextOrder++,
+          regionSlot: destRegionSlot,
+          landmassId: destLandmassId,
+          inHabitat: eligibility.habitatMask[toPlot] !== 0,
+          support: { action: "add", reason: args.reason, seatIndex: args.seatIndex },
+        };
+        intents.push(intent);
+        const typePlots = plotsByType.get(args.resourceType) ?? [];
+        typePlots.push(toPlot);
+        plotsByType.set(args.resourceType, typePlots);
+        countByType.set(args.resourceType, (countByType.get(args.resourceType) ?? 0) + 1);
+        adjustments.push({
+          action: "add",
+          reason: args.reason,
+          resourceType: args.resourceType,
+          resourceTypeId: eligibility.resourceTypeId,
+          toPlotIndex: toPlot,
+          seatIndex: args.seatIndex,
+        });
+      }
+
+      usedPlots.add(toPlot);
+      const toRegionKey = `${args.resourceType}:${destRegionSlot}`;
+      countByTypeRegion.set(toRegionKey, (countByTypeRegion.get(toRegionKey) ?? 0) + 1);
+      if (destLandmassId >= 0 && qualifyingLandmassIds.has(destLandmassId)) {
+        placedByLandmass.set(destLandmassId, (placedByLandmass.get(destLandmassId) ?? 0) + 1);
+        placedOnQualifyingLand += 1;
+      }
+      for (const seatPos of seatsByPlot.get(toPlot) ?? []) counts[seatPos]! += 1;
+    };
+
+    // Deterministic type order for destination probing: corpus order from the plan.
+    const typeOrder = plan.perType.map((row) => row.resourceType);
+
+    const classifyFloorShortfall = (seatPos: number): ShortfallReason => {
+      // Dominant-cause classification for an unfillable deficit unit.
+      const zone = seatZones[seatPos]!;
+      let anyLegalFree = false;
+      for (const resourceType of typeOrder) {
+        const eligibility = eligibilityByType.get(resourceType);
+        if (!eligibility) continue;
+        for (const plotIndex of zone) {
+          if (eligibility.legalMask[plotIndex] === 0) continue;
+          if (usedPlots.has(plotIndex) || seatPlots.has(plotIndex)) continue;
+          anyLegalFree = true;
+          if (
+            !violatesTypeSpacing(plotIndex, resourceType, null) &&
+            !violatesCrossClearance(plotIndex, null)
+          ) {
+            // A destination existed; the limit was source/headroom availability.
+            return "no-movable-site";
+          }
+        }
+      }
+      return anyLegalFree ? "spacing-floor-preserved" : "no-legal-tile-in-radius";
+    };
+
+    if (!enabled || strength === 0) {
+      for (let seatPos = 0; seatPos < seats.length; seatPos++) {
+        const deficit = supportFloor - counts[seatPos]!;
+        if (deficit > 0) recordShortfall(seats[seatPos]!.seatIndex, "adjustment-disabled", deficit);
+      }
+    } else {
+      // --- phase 1: per-start support floor (E3.1) --------------------------------------------
+      const seatOrder = seats
+        .map((_seat, seatPos) => seatPos)
+        .sort((a, b) => counts[a]! - counts[b]! || a - b);
+      for (const seatPos of seatOrder) {
+        const seat = seats[seatPos]!;
+        const deficit = supportFloor - counts[seatPos]!;
+        if (deficit <= 0) continue;
+        const budget = Math.ceil(strength * deficit);
+        let filled = 0;
+        while (counts[seatPos]! < supportFloor && filled < budget) {
+          let applied = false;
+
+          // Prefer MOVE of a site serving no start (count-preserving).
+          let bestMove: { intent: PlanIntent; dest: Destination; score: number } | null = null;
+          for (const intent of intents) {
+            if (seatsByPlot.has(intent.plotIndex)) continue;
+            const dest = destinationFor(intent.resourceType, seatZones[seatPos]!, {
+              ignorePlot: intent.plotIndex,
+              removedLandmassId: intent.landmassId,
+            });
+            if (!dest) continue;
+            const destRegion = regionSlotByTile[dest.plotIndex] ?? 0;
+            if (!moveAllowedFrom(intent, destRegion)) continue;
+            const score = movePairScore(intent, dest);
+            if (bestMove === null || score > bestMove.score) {
+              bestMove = { intent, dest, score };
+            }
+          }
+          if (bestMove) {
+            applyAdjustment({
+              action: "move",
+              reason: "support-floor",
+              seatIndex: seat.seatIndex,
+              resourceType: bestMove.intent.resourceType,
+              toPlotIndex: bestMove.dest.plotIndex,
+              sourceIntent: bestMove.intent,
+            });
+            applied = true;
+          }
+
+          // Fall back to ADD for a type with maxCount headroom.
+          if (!applied) {
+            let bestAdd: { resourceType: string; dest: Destination } | null = null;
+            for (const resourceType of typeOrder) {
+              const meta = metaByType.get(resourceType);
+              if (!meta) continue;
+              if ((countByType.get(resourceType) ?? 0) >= meta.maxCount) continue;
+              const dest = destinationFor(resourceType, seatZones[seatPos]!, {
+                ignorePlot: null,
+                removedLandmassId: null,
+              });
+              if (!dest) continue;
+              if (bestAdd === null || dest.score > bestAdd.dest.score) {
+                bestAdd = { resourceType, dest };
+              }
+            }
+            if (bestAdd) {
+              applyAdjustment({
+                action: "add",
+                reason: "support-floor",
+                seatIndex: seat.seatIndex,
+                resourceType: bestAdd.resourceType,
+                toPlotIndex: bestAdd.dest.plotIndex,
+              });
+              applied = true;
+            }
+          }
+
+          if (!applied) {
+            recordShortfall(
+              seat.seatIndex,
+              classifyFloorShortfall(seatPos),
+              supportFloor - counts[seatPos]!
+            );
+            break;
+          }
+          filled += 1;
+        }
+        if (counts[seatPos]! < supportFloor && filled >= budget && budget < deficit) {
+          recordShortfall(
+            seat.seatIndex,
+            "adjustment-budget-exhausted",
+            supportFloor - counts[seatPos]!
+          );
+        }
+      }
+
+      // --- phase 2: cross-player support equity (E3.2) ----------------------------------------
+      if (counts.length >= 2) {
+        const equityBudget = Math.min(
+          EQUITY_ITERATION_CAP,
+          Math.ceil(strength * seats.length * Math.max(1, supportFloor) * 2)
+        );
+        let equityApplied = 0;
+        while (equityApplied < equityBudget) {
+          const max = Math.max(...counts);
+          const min = Math.min(...counts);
+          if (max - min <= equityTolerance) break;
+          const richestPos = counts.findIndex((count) => count === max);
+          const poorestPos = counts.findIndex((count) => count === min);
+          const richest = seats[richestPos]!;
+          const poorest = seats[poorestPos]!;
+
+          // Removal safety: every seat covering the source plot stays at or
+          // above both the floor and the current minimum. (Sources are
+          // restricted to the richest seat's zone, so removal always lowers
+          // the maximum.)
+          const removalSafe = (plotIndex: number): boolean => {
+            for (const seatPos of seatsByPlot.get(plotIndex) ?? []) {
+              const after = counts[seatPos]! - 1;
+              if (after < supportFloor || after < min) return false;
+            }
+            return true;
+          };
+          // Gain safety: no seat covering the destination reaches the old max.
+          const gainSafe = (plotIndex: number): boolean => {
+            for (const seatPos of seatsByPlot.get(plotIndex) ?? []) {
+              if (counts[seatPos]! + 1 >= max) return false;
+            }
+            return true;
+          };
+
+          let bestMove: { intent: PlanIntent; dest: Destination; score: number } | null = null;
+          for (const intent of intents) {
+            if (!seatZones[richestPos]!.has(intent.plotIndex)) continue;
+            if (!removalSafe(intent.plotIndex)) continue;
+            // Preferred destination: the poorest seat's zone.
+            let dest = destinationFor(intent.resourceType, seatZones[poorestPos]!, {
+              ignorePlot: intent.plotIndex,
+              removedLandmassId: intent.landmassId,
+              gainSafe,
+            });
+            // Fallback: a neutral plot covered by no seat zone. The whole map
+            // is available, so in-lane is required (E2.3 must not erode).
+            if (!dest) {
+              dest = destinationFor(intent.resourceType, neutralPlotStream(), {
+                ignorePlot: intent.plotIndex,
+                removedLandmassId: intent.landmassId,
+                gainSafe: (plotIndex) => !seatsByPlot.has(plotIndex),
+                requireHabitat: true,
+              });
+            }
+            if (!dest) continue;
+            const destRegion = regionSlotByTile[dest.plotIndex] ?? 0;
+            if (!moveAllowedFrom(intent, destRegion)) continue;
+            const score = movePairScore(intent, dest);
+            if (bestMove === null || score > bestMove.score) {
+              bestMove = { intent, dest, score };
+            }
+          }
+
+          if (bestMove) {
+            applyAdjustment({
+              action: "move",
+              reason: "support-equity",
+              // Served seat: the poorest when the site lands in its radius,
+              // otherwise the richest whose excess the move trims.
+              seatIndex: seatZones[poorestPos]!.has(bestMove.dest.plotIndex)
+                ? poorest.seatIndex
+                : richest.seatIndex,
+              resourceType: bestMove.intent.resourceType,
+              toPlotIndex: bestMove.dest.plotIndex,
+              sourceIntent: bestMove.intent,
+            });
+            equityApplied += 1;
+            continue;
+          }
+
+          // No safe move: try ADD near the poorest seat (raises the minimum).
+          let bestAdd: { resourceType: string; dest: Destination } | null = null;
+          for (const resourceType of typeOrder) {
+            const meta = metaByType.get(resourceType);
+            if (!meta) continue;
+            if ((countByType.get(resourceType) ?? 0) >= meta.maxCount) continue;
+            const dest = destinationFor(resourceType, seatZones[poorestPos]!, {
+              ignorePlot: null,
+              removedLandmassId: null,
+              gainSafe,
+            });
+            if (!dest) continue;
+            if (bestAdd === null || dest.score > bestAdd.dest.score) {
+              bestAdd = { resourceType, dest };
+            }
+          }
+          if (bestAdd) {
+            applyAdjustment({
+              action: "add",
+              reason: "support-equity",
+              seatIndex: poorest.seatIndex,
+              resourceType: bestAdd.resourceType,
+              toPlotIndex: bestAdd.dest.plotIndex,
+            });
+            equityApplied += 1;
+            continue;
+          }
+
+          recordShortfall(poorest.seatIndex, "equity-unresolvable", max - min - equityTolerance);
+          break;
+        }
+        const finalGap = gapOf();
+        if (
+          finalGap !== null &&
+          finalGap > equityTolerance &&
+          equityApplied >= equityBudget &&
+          !Array.from(shortfallCounts.keys()).some((key) => key.endsWith(":equity-unresolvable"))
+        ) {
+          const poorestPos = counts.findIndex((count) => count === Math.min(...counts));
+          recordShortfall(
+            seats[poorestPos]!.seatIndex,
+            "adjustment-budget-exhausted",
+            finalGap - equityTolerance
+          );
+        }
+      }
+    }
+
+    function* neutralPlotStream(): Iterable<number> {
+      for (let plotIndex = 0; plotIndex < size; plotIndex++) {
+        if (seatsByPlot.has(plotIndex)) continue;
+        yield plotIndex;
+      }
+    }
+
+    const shortfalls = Array.from(shortfallCounts.entries())
+      .map(([key, missing]) => {
+        const splitAt = key.indexOf(":");
+        return {
+          seatIndex: Number(key.slice(0, splitAt)),
+          reason: key.slice(splitAt + 1) as ShortfallReason,
+          missing,
+        };
+      })
+      .sort((a, b) => a.seatIndex - b.seatIndex || a.reason.localeCompare(b.reason));
+
+    return {
+      width,
+      height,
+      seed,
+      plannedCount: intents.length,
+      moveCount: adjustments.filter((adjustment) => adjustment.action === "move").length,
+      addCount: adjustments.filter((adjustment) => adjustment.action === "add").length,
+      intents,
+      adjustments,
+      shortfalls,
+      perStart: seats.map((seat, seatPos) => ({
+        seatIndex: seat.seatIndex,
+        playerId: seat.playerId,
+        plotIndex: seat.plotIndex,
+        supportBefore: supportBefore[seatPos]!,
+        supportAfter: counts[seatPos]!,
+      })),
+      equity: {
+        gapBefore,
+        gapAfter: gapOf(),
+        tolerance: equityTolerance,
+      },
+      settings,
+    };
+  },
+});

--- a/mods/mod-swooper-maps/src/domain/resources/ops/adjust-resource-support/strategies/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/adjust-resource-support/strategies/index.ts
@@ -1,0 +1,1 @@
+export { defaultStrategy } from "./default.js";

--- a/mods/mod-swooper-maps/src/domain/resources/ops/adjust-resource-support/types.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/adjust-resource-support/types.ts
@@ -1,0 +1,3 @@
+import type { OpTypeBagOf } from "@swooper/mapgen-core/authoring";
+
+export type AdjustResourceSupportTypes = OpTypeBagOf<typeof import("./contract.js").default>;

--- a/mods/mod-swooper-maps/src/domain/resources/ops/contracts.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/contracts.ts
@@ -1,3 +1,4 @@
+import AdjustResourceSupportContract from "./adjust-resource-support/contract.js";
 import DeriveHabitatFieldsContract from "./derive-habitat-fields/contract.js";
 import PlanAquaticResourcesContract from "./plan-aquatic-resources/contract.js";
 import PlanCultivatedResourcesContract from "./plan-cultivated-resources/contract.js";
@@ -7,6 +8,7 @@ import PlanTerrestrialResourcesContract from "./plan-terrestrial-resources/contr
 import SelectResourceSitesContract from "./select-resource-sites/contract.js";
 
 export const contracts = {
+  adjustResourceSupport: AdjustResourceSupportContract,
   deriveHabitatFields: DeriveHabitatFieldsContract,
   planAquaticResources: PlanAquaticResourcesContract,
   planCultivatedResources: PlanCultivatedResourcesContract,
@@ -19,6 +21,7 @@ export const contracts = {
 export default contracts;
 
 export {
+  AdjustResourceSupportContract,
   DeriveHabitatFieldsContract,
   PlanAquaticResourcesContract,
   PlanCultivatedResourcesContract,

--- a/mods/mod-swooper-maps/src/domain/resources/ops/index.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/index.ts
@@ -1,6 +1,7 @@
 import type { DomainOpImplementationsForContracts } from "@swooper/mapgen-core/authoring";
 import type { contracts } from "./contracts.js";
 
+import adjustResourceSupport from "./adjust-resource-support/index.js";
 import deriveHabitatFields from "./derive-habitat-fields/index.js";
 import planAquaticResources from "./plan-aquatic-resources/index.js";
 import planCultivatedResources from "./plan-cultivated-resources/index.js";
@@ -10,6 +11,7 @@ import planTerrestrialResources from "./plan-terrestrial-resources/index.js";
 import selectResourceSites from "./select-resource-sites/index.js";
 
 const implementations = {
+  adjustResourceSupport,
   deriveHabitatFields,
   planAquaticResources,
   planCultivatedResources,
@@ -22,6 +24,7 @@ const implementations = {
 export default implementations;
 
 export {
+  adjustResourceSupport,
   deriveHabitatFields,
   planAquaticResources,
   planCultivatedResources,

--- a/mods/mod-swooper-maps/src/domain/resources/ops/select-resource-sites/contract.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/select-resource-sites/contract.ts
@@ -60,7 +60,7 @@ const DemandRowSchema = Type.Object(
   { additionalProperties: false }
 );
 
-const AffinityRuleSchema = Type.Object(
+export const AffinityRuleSchema = Type.Object(
   {
     resourceA: Type.String({
       pattern: "^RESOURCE_[A-Z0-9_]+$",
@@ -217,6 +217,10 @@ const SelectResourceSitesContract = defineOp({
           perTypeSpacingFloorScale: Type.Number(),
           equityMaxDensityRatio: Type.Number(),
           affinityRuleCount: Type.Integer({ minimum: 0 }),
+          affinityRules: Type.Array(AffinityRuleSchema, {
+            description:
+              "Echo of the affinity/exclusion rules the plan was selected under, so downstream plan adjusters (S5 support pass) respect the same rules without duplicating config.",
+          }),
         },
         { additionalProperties: false }
       ),

--- a/mods/mod-swooper-maps/src/domain/resources/ops/select-resource-sites/strategies/default.ts
+++ b/mods/mod-swooper-maps/src/domain/resources/ops/select-resource-sites/strategies/default.ts
@@ -555,6 +555,12 @@ export const defaultStrategy = createStrategy(SelectResourceSitesContract, "defa
         perTypeSpacingFloorScale,
         equityMaxDensityRatio,
         affinityRuleCount: (config.affinityRules ?? []).length,
+        affinityRules: (config.affinityRules ?? []).map((rule) => ({
+          resourceA: rule.resourceA,
+          resourceB: rule.resourceB,
+          relation: rule.relation,
+          radiusTiles: rule.radiusTiles,
+        })),
       },
     };
   },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement-public-config.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement-public-config.ts
@@ -93,17 +93,23 @@ export const PlacementStartsSchema = defaultStrategyConfigSchema(
   "Start placement controls: first-age expansion viability and island-start tiers, spacing floor/target (official 6/12 buffers), scoring weights (fertility, freshwater, climate comfort, resource support, roughness with tunable divisor), tier bias, ranking blend, fairness tolerance for the balancing pass, and coastal/river start preference."
 );
 
+export const PlacementSupportSchema = defaultStrategyConfigSchema(
+  resources.ops.adjustResourceSupport.config,
+  "Resource-to-start support pass controls (S5; runs after start assignment and before resource stamping): per-start support floor within a radius, cross-player equity tolerance, enable switch, and adjustment strength. Earth-like defaults reproduce the E3.1/E3.2 gates."
+);
+
 export const PlacementPublicSchema = Type.Object(
   {
     naturalWonders: Type.Optional(PlacementNaturalWondersSchema),
     discoveries: Type.Optional(PlacementDiscoveriesSchema),
     resources: Type.Optional(PlacementResourcesSchema),
     starts: Type.Optional(PlacementStartsSchema),
+    support: Type.Optional(PlacementSupportSchema),
   },
   {
     additionalProperties: false,
     description:
-      "Placement authoring controls for late gameplay products: natural wonders, discoveries, resources, and first-age viable starts. Runtime map-size start counts and adapter catalogs are supplied by the run environment rather than authored here.",
+      "Placement authoring controls for late gameplay products: natural wonders, discoveries, resources, first-age viable starts, and the resource-to-start support pass. Runtime map-size start counts and adapter catalogs are supplied by the run environment rather than authored here.",
   }
 );
 
@@ -120,10 +126,13 @@ export function compilePlacementPublicConfig(config: Record<string, unknown>) {
     "plan-resources": {
       selectSites: defaultEnvelope(config.resources),
     },
-    "place-resources": {},
     "assign-starts": {
       starts: defaultEnvelope(config.starts),
     },
+    "adjust-resources": {
+      support: defaultEnvelope(config.support),
+    },
+    "place-resources": {},
     "place-discoveries": {},
     "assign-advanced-starts": {},
     placement: {},

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/artifacts.ts
@@ -132,6 +132,36 @@ const PlacementSurfacePreparationSchema = Type.Object(
   }
 );
 
+const ResourceEligibilityArtifactSchema = Type.Object(
+  {
+    width: Type.Integer({ minimum: 1 }),
+    height: Type.Integer({ minimum: 1 }),
+    rows: Type.Array(
+      Type.Object(
+        {
+          resourceType: Type.String({ pattern: "^RESOURCE_[A-Z0-9_]+$" }),
+          resourceTypeId: Type.Integer({ minimum: 0 }),
+          habitatMask: TypedArraySchemas.u8({
+            description: "Habitat lane eligibility (1=in-lane).",
+          }),
+          legalMask: TypedArraySchemas.u8({
+            description: "Per-resource policy legality from Resource_ValidPlacements rows (1=legal).",
+          }),
+          intensity: TypedArraySchemas.f32({
+            description: "Habitat intensity (0..1).",
+          }),
+        },
+        { additionalProperties: false }
+      )
+    ),
+  },
+  {
+    additionalProperties: false,
+    description:
+      "Per-type habitat/legality/intensity fields the resource plan was selected under (S5). Published by the planning step so the post-starts support pass adjusts the plan inside the SAME policy constraints instead of re-deriving them.",
+  }
+);
+
 const PlanStartsOutputSchema = placement.ops.planStarts.output;
 
 const StartAssignmentArtifactSchema = Type.Object(
@@ -403,12 +433,22 @@ const ResourceReconciliationSummarySchema = Type.Object(
         rotation: Type.Integer({ minimum: 0 }),
         rangeFloor: Type.Integer({ minimum: 0 }),
         regionMinimum: Type.Integer({ minimum: 0 }),
+        support: Type.Integer({
+          minimum: 0,
+          description:
+            "Placed counts for support-pass ADDITIONS (S5). Support-driven moves keep their original planning phase; full per-adjustment provenance lives in the adjusted-plan artifact.",
+        }),
       },
       {
         additionalProperties: false,
-        description: "Placed counts by planning phase (joined from the resource plan intents).",
+        description: "Placed counts by planning phase (joined from the adjusted resource plan intents).",
       }
     ),
+    supportAdjustedPlacedCount: Type.Integer({
+      minimum: 0,
+      description:
+        "How many placed outcomes came from support-adjusted intents (moves + adds), making the S5 provenance visible in the stamped outcomes (additive field).",
+    }),
   },
   { additionalProperties: false }
 );
@@ -453,6 +493,16 @@ export const placementArtifacts = {
     name: "resourcePlan",
     id: "artifact:placement.resourcePlan",
     schema: resources.ops.selectResourceSites.output,
+  }),
+  resourceEligibility: defineArtifact({
+    name: "resourceEligibility",
+    id: "artifact:placement.resourceEligibility",
+    schema: ResourceEligibilityArtifactSchema,
+  }),
+  resourcePlanAdjusted: defineArtifact({
+    name: "resourcePlanAdjusted",
+    id: "artifact:placement.resourcePlanAdjusted",
+    schema: resources.ops.adjustResourceSupport.output,
   }),
   naturalWonderPlan: defineArtifact({
     name: "naturalWonderPlan",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/index.ts
@@ -1,5 +1,6 @@
 import { createStage } from "@swooper/mapgen-core/authoring";
 import {
+  adjustResources,
   assignAdvancedStarts,
   assignStarts,
   derivePlacementInputs,
@@ -22,6 +23,10 @@ import {
  * preparation remains grouped because terrain validation, area recalc, water
  * storage, and landmass-region restamping form one transactional precondition
  * for all downstream placement products.
+ *
+ * Resource ordering (S5, D3 contract change): planning stays before starts;
+ * stamping runs after the resource↔start support pass —
+ * plan-resources → assign-starts → adjust-resources → place-resources.
  */
 export default createStage({
   id: "placement",
@@ -33,8 +38,9 @@ export default createStage({
     placeNaturalWonders,
     preparePlacementSurface,
     planResources,
-    placeResources,
     assignStarts,
+    adjustResources,
+    placeResources,
     placeDiscoveries,
     assignAdvancedStarts,
     placement,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/adjust-resources/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/adjust-resources/contract.ts
@@ -1,0 +1,40 @@
+import { Type, defineStep } from "@swooper/mapgen-core/authoring";
+import resources from "@mapgen/domain/resources";
+
+import { PLACEMENT_PRODUCT_EFFECT_TAGS } from "../../../../tags.js";
+import { mapArtifacts } from "../../../../map-artifacts.js";
+import { morphologyArtifacts } from "../../../morphology/artifacts.js";
+import { placementArtifacts } from "../../artifacts.js";
+
+/**
+ * Resource↔start support pass (placement-realignment S5, D3 contract change).
+ *
+ * Runs AFTER start assignment and BEFORE resource stamping:
+ * resourcesPlanned → startsAssigned → resourcesAdjusted → resourcesPlaced.
+ * The domain op produces a bounded move/add adjustment of the resource plan
+ * so every start meets the support floor (E3.1) and cross-player support
+ * stays within the equity tolerance (E3.2), with typed provenance and typed
+ * shortfalls. place-resources stamps the ADJUSTED intents.
+ */
+const AdjustResourcesStepContract = defineStep({
+  id: "adjust-resources",
+  phase: "placement",
+  requires: [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.startsAssigned],
+  provides: [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesAdjusted],
+  artifacts: {
+    requires: [
+      placementArtifacts.resourcePlan,
+      placementArtifacts.resourceEligibility,
+      placementArtifacts.startAssignment,
+      mapArtifacts.landmassRegionSlotByTile,
+      morphologyArtifacts.landmasses,
+    ],
+    provides: [placementArtifacts.resourcePlanAdjusted],
+  },
+  ops: {
+    support: resources.ops.adjustResourceSupport,
+  },
+  schema: Type.Object({}),
+});
+
+export default AdjustResourcesStepContract;

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/adjust-resources/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/adjust-resources/index.ts
@@ -1,0 +1,66 @@
+import { deriveStepSeed } from "@swooper/mapgen-core";
+import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
+
+import AdjustResourcesStepContract from "./contract.js";
+import { placementArtifacts } from "../../artifacts.js";
+import { validateResourcePlanAdjustedArtifact } from "./validate.js";
+
+export default createStep(AdjustResourcesStepContract, {
+  artifacts: implementArtifacts([placementArtifacts.resourcePlanAdjusted], {
+    resourcePlanAdjusted: {
+      validate: (value) => validateResourcePlanAdjustedArtifact(value),
+    },
+  }),
+  run: (context, config, ops, deps) => {
+    const plan = deps.artifacts.resourcePlan.read(context);
+    const eligibility = deps.artifacts.resourceEligibility.read(context);
+    const startAssignment = deps.artifacts.startAssignment.read(context);
+    const regionSlots = deps.artifacts.landmassRegionSlotByTile.read(context);
+    const landmasses = deps.artifacts.landmasses.read(context);
+
+    const adjusted = ops.support(
+      {
+        seed: deriveStepSeed(context.env.seed, "resources:adjustResourceSupport"),
+        plan,
+        eligibility: eligibility.rows,
+        starts: startAssignment.seats.map((seat) => ({
+          seatIndex: seat.seatIndex,
+          playerId: seat.playerId,
+          plotIndex: seat.plotIndex,
+        })),
+        landmassIdByTile: landmasses.landmassIdByTile as Int32Array,
+        landmassTileCounts: landmasses.landmasses.map((landmass) => landmass.tileCount),
+        regionSlotByTile: regionSlots.slotByTile as Uint8Array,
+      } as unknown as Parameters<typeof ops.support>[0],
+      config.support
+    );
+
+    if (adjusted.shortfalls.length > 0) {
+      // Typed shortfalls (S5): adjustments that would violate an S3 plan
+      // invariant are recorded loudly, never forced.
+      const summary = adjusted.shortfalls
+        .map((row) => `seat ${row.seatIndex}: ${row.reason} x${row.missing}`)
+        .join("; ");
+      console.warn(
+        `[Placement] Resource support pass recorded ${adjusted.shortfalls.length} typed shortfall(s): ${summary}.`
+      );
+      context.trace?.event(() => ({
+        type: "placement.resources.supportShortfall",
+        level: "warn",
+        shortfalls: adjusted.shortfalls,
+      }));
+    }
+
+    deps.artifacts.resourcePlanAdjusted.publish(context, adjusted);
+
+    context.trace?.event(() => ({
+      type: "placement.resources.supportAdjust",
+      plannedCount: adjusted.plannedCount,
+      moveCount: adjusted.moveCount,
+      addCount: adjusted.addCount,
+      gapBefore: adjusted.equity.gapBefore,
+      gapAfter: adjusted.equity.gapAfter,
+      shortfallCount: adjusted.shortfalls.length,
+    }));
+  },
+});

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/adjust-resources/validate.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/adjust-resources/validate.ts
@@ -1,0 +1,104 @@
+type ValidationIssue = { message: string };
+
+function issue(message: string): ValidationIssue {
+  return { message };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Validate hook for the adjusted resource plan (placement-realignment S5).
+ * Cross-field invariants the schema cannot express: count coherence, unique
+ * plots, and provenance coherence (support-phase intents are additions; every
+ * adjustment row maps onto an intent that carries matching provenance).
+ */
+export function validateResourcePlanAdjustedArtifact(value: unknown): ValidationIssue[] {
+  if (!isRecord(value)) return [issue("resourcePlanAdjusted artifact must be an object.")];
+  const issues: ValidationIssue[] = [];
+  const width = Number(value.width);
+  const height = Number(value.height);
+  const size = width * height;
+  if (!Number.isSafeInteger(size) || size <= 0) {
+    return [
+      issue(`resourcePlanAdjusted has invalid dimensions ${String(value.width)}x${String(value.height)}.`),
+    ];
+  }
+  const intents = Array.isArray(value.intents) ? value.intents : null;
+  const adjustments = Array.isArray(value.adjustments) ? value.adjustments : null;
+  if (!intents) return [issue("resourcePlanAdjusted.intents must be an array.")];
+  if (!adjustments) return [issue("resourcePlanAdjusted.adjustments must be an array.")];
+
+  if (value.plannedCount !== intents.length) {
+    issues.push(
+      issue(
+        `resourcePlanAdjusted.plannedCount ${String(value.plannedCount)} != intents.length ${intents.length}.`
+      )
+    );
+  }
+
+  const seenPlots = new Set<number>();
+  const adjustedByPlot = new Map<number, Record<string, unknown>>();
+  let supportPhaseCount = 0;
+  let provenancedCount = 0;
+  for (const intent of intents) {
+    if (!isRecord(intent)) continue;
+    const plotIndex = Number(intent.plotIndex);
+    if (!Number.isInteger(plotIndex) || plotIndex < 0 || plotIndex >= size) {
+      issues.push(issue(`resourcePlanAdjusted intent plotIndex ${String(intent.plotIndex)} out of bounds.`));
+      continue;
+    }
+    if (seenPlots.has(plotIndex)) {
+      issues.push(issue(`resourcePlanAdjusted plans two intents on plot ${plotIndex}.`));
+    }
+    seenPlots.add(plotIndex);
+    const support = isRecord(intent.support) ? intent.support : null;
+    if (intent.phase === "support") {
+      supportPhaseCount += 1;
+      if (!support || support.action !== "add") {
+        issues.push(issue(`support-phase intent on plot ${plotIndex} must carry add provenance.`));
+      }
+    }
+    if (support) {
+      provenancedCount += 1;
+      adjustedByPlot.set(plotIndex, support);
+      if (support.action === "move" && typeof support.fromPlotIndex !== "number") {
+        issues.push(issue(`moved intent on plot ${plotIndex} must record fromPlotIndex.`));
+      }
+    }
+  }
+
+  const moveCount = Number(value.moveCount);
+  const addCount = Number(value.addCount);
+  const moves = adjustments.filter((row) => isRecord(row) && row.action === "move").length;
+  const adds = adjustments.filter((row) => isRecord(row) && row.action === "add").length;
+  if (moves !== moveCount || adds !== addCount) {
+    issues.push(
+      issue(
+        `adjustment counts (moves ${moves}, adds ${adds}) != recorded moveCount ${moveCount}/addCount ${addCount}.`
+      )
+    );
+  }
+  if (adds !== supportPhaseCount) {
+    issues.push(issue(`add adjustments ${adds} != support-phase intents ${supportPhaseCount}.`));
+  }
+  if (adjustments.length !== provenancedCount) {
+    issues.push(
+      issue(
+        `adjustments ${adjustments.length} != intents carrying support provenance ${provenancedCount}.`
+      )
+    );
+  }
+  for (const row of adjustments) {
+    if (!isRecord(row)) continue;
+    const toPlot = Number(row.toPlotIndex);
+    const provenance = adjustedByPlot.get(toPlot);
+    if (!provenance || provenance.action !== row.action) {
+      issues.push(
+        issue(`adjustment to plot ${toPlot} has no matching intent provenance (${String(row.action)}).`)
+      );
+    }
+  }
+  return issues;
+}

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/contract.ts
@@ -8,16 +8,21 @@ import { hydrologyHydrographyArtifacts } from "../../../hydrology-hydrography/ar
 import { ecologyArtifacts } from "../../../ecology/artifacts.js";
 import { placementArtifacts } from "../../artifacts.js";
 
+/**
+ * S5 (D3 contract change): starts assign against the resource PLAN, not the
+ * stamped outcomes — stamping happens after the resource↔start support pass.
+ * The resource-support scoring term reads planned site intents.
+ */
 const AssignStartsStepContract = defineStep({
   id: "assign-starts",
   phase: "placement",
-  requires: [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesPlaced],
+  requires: [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesPlanned],
   provides: [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.startsAssigned],
   artifacts: {
     requires: [
       placementArtifacts.placementInputs,
       placementArtifacts.placementSurfacePreparation,
-      placementArtifacts.resourcePlacementOutcomes,
+      placementArtifacts.resourcePlan,
       placementArtifacts.naturalWonderPlacement,
       mapArtifacts.landmassRegionSlotByTile,
       morphologyArtifacts.topography,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/index.ts
@@ -20,7 +20,7 @@ export default createStep(AssignStartsStepContract, {
   run: (context, config, _ops, deps) => {
     const placementInputs = deps.artifacts.placementInputs.read(context);
     deps.artifacts.placementSurfacePreparation.read(context);
-    const resourcePlacement = deps.artifacts.resourcePlacementOutcomes.read(context);
+    const resourcePlan = deps.artifacts.resourcePlan.read(context);
     const naturalWonderPlacement = deps.artifacts.naturalWonderPlacement.read(context);
     const landmassRegionSlotByTile = deps.artifacts.landmassRegionSlotByTile.read(context);
     const topography = deps.artifacts.topography.read(context);
@@ -65,9 +65,10 @@ export default createStep(AssignStartsStepContract, {
         mountainMask: mountains.mountainMask as Uint8Array,
         volcanoMask: volcanoes.volcanoMask as Uint8Array,
         naturalWonderPlotIndices,
-        placedResourcePlotIndices: resourcePlacement.outcomes
-          .filter((outcome) => outcome.status === "placed")
-          .map((outcome) => outcome.plotIndex),
+        // D3 (S5): resource-support scoring works off PLANNED site intents —
+        // stamping runs after the support pass, so placed outcomes do not
+        // exist yet when starts are chosen.
+        plannedResourcePlotIndices: resourcePlan.intents.map((intent) => intent.plotIndex),
         // seatBiases: per-civ StartBias rows need live player→civ data; the
         // offline default is neutral (Milestone A wires the live half).
       },

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/index.ts
@@ -3,8 +3,9 @@ export { default as plotLandmassRegions } from "./plot-landmass-regions/index.js
 export { default as placeNaturalWonders } from "./place-natural-wonders/index.js";
 export { default as preparePlacementSurface } from "./prepare-placement-surface/index.js";
 export { default as planResources } from "./plan-resources/index.js";
-export { default as placeResources } from "./place-resources/index.js";
 export { default as assignStarts } from "./assign-starts/index.js";
+export { default as adjustResources } from "./adjust-resources/index.js";
+export { default as placeResources } from "./place-resources/index.js";
 export { default as placeDiscoveries } from "./place-discoveries/index.js";
 export { default as assignAdvancedStarts } from "./assign-advanced-starts/index.js";
 export { default as placement } from "./placement/index.js";

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-discoveries/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-discoveries/contract.ts
@@ -6,7 +6,12 @@ import { placementArtifacts } from "../../artifacts.js";
 const PlaceDiscoveriesStepContract = defineStep({
   id: "place-discoveries",
   phase: "placement",
-  requires: [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.startsAssigned],
+  // S5 chain: discoveries follow the resource stamp — resourcesPlaced now
+  // lands after startsAssigned + the support pass (D3 reorder).
+  requires: [
+    PLACEMENT_PRODUCT_EFFECT_TAGS.placement.startsAssigned,
+    PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesPlaced,
+  ],
   provides: [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.discoveriesPlaced],
   artifacts: {
     requires: [placementArtifacts.discoveryPlan, placementArtifacts.startAssignment],

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/contract.ts
@@ -3,13 +3,25 @@ import { Type, defineStep } from "@swooper/mapgen-core/authoring";
 import { PLACEMENT_PRODUCT_EFFECT_TAGS } from "../../../../tags.js";
 import { placementArtifacts } from "../../artifacts.js";
 
+/**
+ * Thin resource stamp (S3, reordered by S5/D3): stamps the ADJUSTED intent
+ * set produced by the post-starts support pass. Stamping is the last
+ * resource authority point — post-stamp mutation is rejected (no engine
+ * resource-removal capability; the plan is adjusted pre-stamp instead).
+ */
 const PlaceResourcesStepContract = defineStep({
   id: "place-resources",
   phase: "placement",
-  requires: [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.surfacePrepared],
+  requires: [
+    PLACEMENT_PRODUCT_EFFECT_TAGS.placement.surfacePrepared,
+    PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesAdjusted,
+  ],
   provides: [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesPlaced],
   artifacts: {
-    requires: [placementArtifacts.resourcePlan, placementArtifacts.placementSurfacePreparation],
+    requires: [
+      placementArtifacts.resourcePlanAdjusted,
+      placementArtifacts.placementSurfacePreparation,
+    ],
     provides: [placementArtifacts.resourcePlacementOutcomes],
   },
   schema: Type.Object({}, { additionalProperties: false }),

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/index.ts
@@ -50,7 +50,7 @@ export default createStep(PlaceResourcesStepContract, {
     },
   }),
   run: (context, _config, _ops, deps) => {
-    const plan = deps.artifacts.resourcePlan.read(context);
+    const plan = deps.artifacts.resourcePlanAdjusted.read(context);
     deps.artifacts.placementSurfacePreparation.read(context);
     const { width, height } = context.dimensions;
     const emit = (payload: Record<string, unknown>): void => {

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/materialize.ts
@@ -9,7 +9,7 @@ import type { DeepReadonly, Static } from "@swooper/mapgen-core/authoring";
 
 import resources from "@mapgen/domain/resources";
 
-type ResourcePlanOutput = Static<(typeof resources.ops.selectResourceSites)["output"]>;
+type ResourcePlanOutput = Static<(typeof resources.ops.adjustResourceSupport)["output"]>;
 type ResourcePlacementOutcomes = Static<
   (typeof import("../../artifacts.js").placementArtifacts)["resourcePlacementOutcomes"]["schema"]
 >;
@@ -359,14 +359,16 @@ function assertResourceOutcomeMatchesIntent(
 }
 
 /**
- * Thin materializer (placement-realignment S3 / D4): stamps the typed plot
- * intents from the domain/resources site-selection plan and reconciles
- * engine legality with typed outcomes.
+ * Thin materializer (placement-realignment S3 / D4, reordered by S5 / D3):
+ * stamps the typed plot intents from the ADJUSTED resource plan (site
+ * selection + post-starts support pass) and reconciles engine legality with
+ * typed outcomes.
  *
- * The plan is authority for type-at-plot. Engine rejections are recorded as
- * typed shortfalls per resource type; there is NO type re-decision, NO
- * relocation, and NO whole-map fallback here. Wrong-type readback
- * (mismatch) remains fail-hard.
+ * The adjusted plan is authority for type-at-plot. Engine rejections are
+ * recorded as typed shortfalls per resource type; there is NO type
+ * re-decision, NO relocation, and NO whole-map fallback here. Wrong-type
+ * readback (mismatch) remains fail-hard. Support-pass provenance is carried
+ * into the outcomes (byPhase.support + supportAdjustedPlacedCount).
  */
 export function placeResourcesWithTypedOutcomes({
   adapter,
@@ -386,7 +388,8 @@ export function placeResourcesWithTypedOutcomes({
   }
 
   const outcomes: ResourcePlacementOutcome[] = [];
-  const byPhase = { rotation: 0, rangeFloor: 0, regionMinimum: 0 };
+  const byPhase = { rotation: 0, rangeFloor: 0, regionMinimum: 0, support: 0 };
+  let supportAdjustedPlacedCount = 0;
   const shortfallCounts = new Map<string, number>();
 
   for (const planned of plan.intents) {
@@ -400,7 +403,9 @@ export function placeResourcesWithTypedOutcomes({
     if (outcome.status === "placed") {
       if (planned.phase === "rotation") byPhase.rotation += 1;
       else if (planned.phase === "range-floor") byPhase.rangeFloor += 1;
-      else byPhase.regionMinimum += 1;
+      else if (planned.phase === "region-minimum") byPhase.regionMinimum += 1;
+      else byPhase.support += 1;
+      if (planned.support) supportAdjustedPlacedCount += 1;
     } else if (outcome.status === "rejected") {
       const key = `${planned.resourceTypeId}:${outcome.reason}`;
       shortfallCounts.set(key, (shortfallCounts.get(key) ?? 0) + 1);
@@ -441,6 +446,7 @@ export function placeResourcesWithTypedOutcomes({
       rejectedCount: plan.intents.length - placedCount,
       shortfalls,
       byPhase,
+      supportAdjustedPlacedCount,
     },
     outcomes,
   };

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/contract.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/contract.ts
@@ -13,9 +13,9 @@ import { ecologyArtifacts } from "../../../ecology/artifacts.js";
  * Resource planning (placement-realignment S3): habitat-lane derivation +
  * family demand planning + site selection, all owned by domain/resources
  * (ADR-008). Runs after surface preparation so policy legality is evaluated
- * against the final engine surface; the stamp step (place-resources) stays a
- * separate thin shell so a later slice can reorder stamping after starts
- * (refactor-plan S5) without touching planning.
+ * against the final engine surface. Since S5 the plan is a first-class effect
+ * (resourcesPlanned): starts assign against the PLAN, the support pass
+ * adjusts it, and only then does place-resources stamp (D3 contract change).
  *
  * Declared engine-surface read (ADR-009): per-tile terrain/biome/feature and
  * water readings feed the policy legality masks. This mirrors exactly what
@@ -26,7 +26,7 @@ const PlanResourcesStepContract = defineStep({
   id: "plan-resources",
   phase: "placement",
   requires: [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.surfacePrepared],
-  provides: [],
+  provides: [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesPlanned],
   artifacts: {
     requires: [
       morphologyArtifacts.topography,
@@ -42,7 +42,11 @@ const PlanResourcesStepContract = defineStep({
       ecologyArtifacts.pedology,
       mapArtifacts.landmassRegionSlotByTile,
     ],
-    provides: [placementArtifacts.resourceDemandPlan, placementArtifacts.resourcePlan],
+    provides: [
+      placementArtifacts.resourceDemandPlan,
+      placementArtifacts.resourcePlan,
+      placementArtifacts.resourceEligibility,
+    ],
   },
   ops: {
     habitat: resources.ops.deriveHabitatFields,

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/index.ts
@@ -12,18 +12,26 @@ import {
 import { placementArtifacts } from "../../artifacts.js";
 import {
   validateResourceDemandPlanArtifact,
+  validateResourceEligibilityArtifact,
   validateResourcePlanArtifact,
 } from "./validate.js";
 
 export default createStep(PlanResourcesStepContract, {
   artifacts: implementArtifacts(
-    [placementArtifacts.resourceDemandPlan, placementArtifacts.resourcePlan],
+    [
+      placementArtifacts.resourceDemandPlan,
+      placementArtifacts.resourcePlan,
+      placementArtifacts.resourceEligibility,
+    ],
     {
       resourceDemandPlan: {
         validate: (value) => validateResourceDemandPlanArtifact(value),
       },
       resourcePlan: {
         validate: (value) => validateResourcePlanArtifact(value),
+      },
+      resourceEligibility: {
+        validate: (value) => validateResourceEligibilityArtifact(value),
       },
     }
   ),
@@ -162,6 +170,20 @@ export default createStep(PlanResourcesStepContract, {
 
     deps.artifacts.resourceDemandPlan.publish(context, demandPlan);
     deps.artifacts.resourcePlan.publish(context, plan);
+    // S5: the post-starts support pass adjusts this plan inside the same
+    // policy constraints, so the eligibility fields the plan was selected
+    // under are published once here rather than re-derived later.
+    deps.artifacts.resourceEligibility.publish(context, {
+      width,
+      height,
+      rows: demandResult.demands.map((row) => ({
+        resourceType: row.resourceType,
+        resourceTypeId: row.resourceTypeId,
+        habitatMask: row.habitatMask,
+        legalMask: row.legalMask,
+        intensity: row.intensity,
+      })),
+    });
 
     context.trace?.event(() => ({
       type: "placement.resources.plan",

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/validate.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/plan-resources/validate.ts
@@ -65,6 +65,36 @@ export function validateResourceDemandPlanArtifact(value: unknown): ValidationIs
   return issues;
 }
 
+export function validateResourceEligibilityArtifact(value: unknown): ValidationIssue[] {
+  if (!isRecord(value)) return [issue("resourceEligibility artifact must be an object.")];
+  const issues: ValidationIssue[] = [];
+  const width = Number(value.width);
+  const height = Number(value.height);
+  const size = width * height;
+  if (!Number.isSafeInteger(size) || size <= 0) {
+    return [issue(`resourceEligibility has invalid dimensions ${String(value.width)}x${String(value.height)}.`)];
+  }
+  const rows = Array.isArray(value.rows) ? value.rows : null;
+  if (!rows) return [issue("resourceEligibility.rows must be an array.")];
+  const seenTypes = new Set<string>();
+  for (const row of rows) {
+    if (!isRecord(row)) {
+      issues.push(issue("resourceEligibility row must be an object."));
+      continue;
+    }
+    const type = String(row.resourceType);
+    if (seenTypes.has(type)) issues.push(issue(`resourceEligibility row ${type} appears more than once.`));
+    seenTypes.add(type);
+    for (const field of ["habitatMask", "legalMask", "intensity"] as const) {
+      const mask = row[field] as { length?: number } | undefined;
+      if (!mask || mask.length !== size) {
+        issues.push(issue(`resourceEligibility ${type}.${field} length must equal ${size}.`));
+      }
+    }
+  }
+  return issues;
+}
+
 export function validateResourcePlanArtifact(value: unknown): ValidationIssue[] {
   if (!isRecord(value)) return [issue("resourcePlan artifact must be an object.")];
   const issues: ValidationIssue[] = [];

--- a/mods/mod-swooper-maps/src/recipes/standard/tags.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/tags.ts
@@ -48,6 +48,12 @@ export const PLACEMENT_PRODUCT_EFFECT_TAGS = {
   placement: {
     naturalWondersPlaced: "effect:placement.naturalWondersPlaced",
     surfacePrepared: "effect:placement.surfacePrepared",
+    // S5 (D3 contract change): planning and stamping are separate effects so
+    // starts assign against the PLAN and the support pass adjusts the plan
+    // before any engine stamping:
+    // resourcesPlanned → startsAssigned → resourcesAdjusted → resourcesPlaced.
+    resourcesPlanned: "effect:placement.resourcesPlanned",
+    resourcesAdjusted: "effect:placement.resourcesAdjusted",
     resourcesPlaced: "effect:placement.resourcesPlaced",
     startsAssigned: "effect:placement.startsAssigned",
     discoveriesPlaced: "effect:placement.discoveriesPlaced",
@@ -145,6 +151,16 @@ const EFFECT_OWNERS: Record<string, TagOwner> = {
     pkg: "mod-swooper-maps",
     phase: "placement",
     stepId: "prepare-placement-surface",
+  },
+  [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesPlanned]: {
+    pkg: "mod-swooper-maps",
+    phase: "placement",
+    stepId: "plan-resources",
+  },
+  [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesAdjusted]: {
+    pkg: "mod-swooper-maps",
+    phase: "placement",
+    stepId: "adjust-resources",
   },
   [PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesPlaced]: {
     pkg: "mod-swooper-maps",

--- a/mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts
+++ b/mods/mod-swooper-maps/test/config/maps-schema-valid.test.ts
@@ -198,6 +198,7 @@ const PLACEMENT_PUBLIC_KEYS = [
   "discoveries",
   "resources",
   "starts",
+  "support",
 ] as const;
 
 const DEFAULT_STARTS_CONFIG = {
@@ -240,8 +241,10 @@ const PLACEMENT_INTERNAL_STAGE_KEYS = [
   "plot-landmass-regions",
   "place-natural-wonders",
   "prepare-placement-surface",
-  "place-resources",
+  "plan-resources",
   "assign-starts",
+  "adjust-resources",
+  "place-resources",
   "place-discoveries",
   "assign-advanced-starts",
   "placement",

--- a/mods/mod-swooper-maps/test/config/standard-authoring-surface-guards.test.ts
+++ b/mods/mod-swooper-maps/test/config/standard-authoring-surface-guards.test.ts
@@ -85,7 +85,7 @@ const STANDARD_PUBLIC_KEYS: Record<string, readonly string[]> = {
     "plotEffectCoverage",
   ],
   "map-ecology": ["knobs", "biomeBindings"],
-  placement: ["knobs", "naturalWonders", "discoveries", "resources", "starts"],
+  placement: ["knobs", "naturalWonders", "discoveries", "resources", "starts", "support"],
 };
 
 function isObject(value: unknown): value is Record<string, unknown> {

--- a/mods/mod-swooper-maps/test/fixtures/legacy-placement-compiled.json
+++ b/mods/mod-swooper-maps/test/fixtures/legacy-placement-compiled.json
@@ -1,6 +1,18 @@
 {
   "shattered-ring": {
     "placement": {
+      "adjust-resources": {
+        "support": {
+          "config": {
+            "enabled": true,
+            "equityTolerance": 2,
+            "strength": 1,
+            "supportFloor": 2,
+            "supportRadiusTiles": 4
+          },
+          "strategy": "default"
+        }
+      },
       "assign-advanced-starts": {},
       "assign-starts": {},
       "derive-placement-inputs": {
@@ -76,6 +88,18 @@
   },
   "sundered-archipelago": {
     "placement": {
+      "adjust-resources": {
+        "support": {
+          "config": {
+            "enabled": true,
+            "equityTolerance": 2,
+            "strength": 1,
+            "supportFloor": 2,
+            "supportRadiusTiles": 4
+          },
+          "strategy": "default"
+        }
+      },
       "assign-advanced-starts": {},
       "assign-starts": {},
       "derive-placement-inputs": {
@@ -151,6 +175,18 @@
   },
   "swooper-desert-mountains": {
     "placement": {
+      "adjust-resources": {
+        "support": {
+          "config": {
+            "enabled": true,
+            "equityTolerance": 2,
+            "strength": 1,
+            "supportFloor": 2,
+            "supportRadiusTiles": 4
+          },
+          "strategy": "default"
+        }
+      },
       "assign-advanced-starts": {},
       "assign-starts": {},
       "derive-placement-inputs": {
@@ -226,6 +262,18 @@
   },
   "swooper-earthlike": {
     "placement": {
+      "adjust-resources": {
+        "support": {
+          "config": {
+            "enabled": true,
+            "equityTolerance": 2,
+            "strength": 1,
+            "supportFloor": 2,
+            "supportRadiusTiles": 4
+          },
+          "strategy": "default"
+        }
+      },
       "assign-advanced-starts": {},
       "assign-starts": {},
       "derive-placement-inputs": {

--- a/mods/mod-swooper-maps/test/placement/landmass-region-id-projection.test.ts
+++ b/mods/mod-swooper-maps/test/placement/landmass-region-id-projection.test.ts
@@ -71,7 +71,9 @@ describe("placement landmass region projection", () => {
     expect(firstProjection).toBeGreaterThanOrEqual(0);
     expect(firstResourceIntent).toBeGreaterThan(firstProjection);
     expect(firstStart).toBeGreaterThan(firstProjection);
-    expect(firstStart).toBeGreaterThan(firstResourceIntent);
+    // S5 (D3 reorder): starts stamp BEFORE resources — resource stamping now
+    // runs after the resource-to-start support pass.
+    expect(firstResourceIntent).toBeGreaterThan(firstStart);
     expect(adapter.calls.generateOfficialResources.length).toBe(0);
     expect(adapter.calls.setResourceType.length).toBeGreaterThan(0);
 

--- a/mods/mod-swooper-maps/test/placement/placement-contracts.test.ts
+++ b/mods/mod-swooper-maps/test/placement/placement-contracts.test.ts
@@ -8,8 +8,10 @@ import {
   STANDARD_ENGINE_EFFECT_TAGS,
 } from "../../src/recipes/standard/tags.js";
 import { placementArtifacts } from "../../src/recipes/standard/stages/placement/artifacts.js";
+import adjustResourcesStep from "../../src/recipes/standard/stages/placement/steps/adjust-resources/index.js";
 import assignAdvancedStartsStep from "../../src/recipes/standard/stages/placement/steps/assign-advanced-starts/index.js";
 import assignStartsStep from "../../src/recipes/standard/stages/placement/steps/assign-starts/index.js";
+import planResourcesStep from "../../src/recipes/standard/stages/placement/steps/plan-resources/index.js";
 import placeNaturalWondersStep from "../../src/recipes/standard/stages/placement/steps/place-natural-wonders/index.js";
 import placeDiscoveriesStep from "../../src/recipes/standard/stages/placement/steps/place-discoveries/index.js";
 import placeResourcesStep from "../../src/recipes/standard/stages/placement/steps/place-resources/index.js";
@@ -71,23 +73,63 @@ describe("placement product/effect contracts", () => {
     expect(placementStepIds).toEqual(
       expect.arrayContaining([
         "mod-swooper-maps.standard.placement.prepare-placement-surface",
-        "mod-swooper-maps.standard.placement.place-resources",
+        "mod-swooper-maps.standard.placement.plan-resources",
         "mod-swooper-maps.standard.placement.assign-starts",
+        "mod-swooper-maps.standard.placement.adjust-resources",
+        "mod-swooper-maps.standard.placement.place-resources",
         "mod-swooper-maps.standard.placement.place-discoveries",
         "mod-swooper-maps.standard.placement.assign-advanced-starts",
         "mod-swooper-maps.standard.placement.placement",
       ])
     );
+    // S5 (D3 contract change): plan-resources -> assign-starts ->
+    // adjust-resources (support pass) -> place-resources (stamp) ->
+    // place-discoveries. Planning stays before starts; stamping moves after
+    // the support pass.
     expect(
-      placementStepIds.indexOf("mod-swooper-maps.standard.placement.place-resources")
+      placementStepIds.indexOf("mod-swooper-maps.standard.placement.plan-resources")
     ).toBeLessThan(placementStepIds.indexOf("mod-swooper-maps.standard.placement.assign-starts"));
     expect(
       placementStepIds.indexOf("mod-swooper-maps.standard.placement.assign-starts")
     ).toBeLessThan(
+      placementStepIds.indexOf("mod-swooper-maps.standard.placement.adjust-resources")
+    );
+    expect(
+      placementStepIds.indexOf("mod-swooper-maps.standard.placement.adjust-resources")
+    ).toBeLessThan(
+      placementStepIds.indexOf("mod-swooper-maps.standard.placement.place-resources")
+    );
+    expect(
+      placementStepIds.indexOf("mod-swooper-maps.standard.placement.place-resources")
+    ).toBeLessThan(
       placementStepIds.indexOf("mod-swooper-maps.standard.placement.place-discoveries")
     );
 
+    expect(planResourcesStep.contract.provides).toContain(
+      PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesPlanned
+    );
+    expect(assignStartsStep.contract.requires).toContain(
+      PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesPlanned
+    );
+    expect(adjustResourcesStep.contract.requires).toContain(
+      PLACEMENT_PRODUCT_EFFECT_TAGS.placement.startsAssigned
+    );
+    expect(adjustResourcesStep.contract.provides).toContain(
+      PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesAdjusted
+    );
+    expect(adjustResourcesStep.contract.artifacts.provides).toContain(
+      placementArtifacts.resourcePlanAdjusted
+    );
+    expect(placeResourcesStep.contract.requires).toContain(
+      PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesAdjusted
+    );
+    expect(placeResourcesStep.contract.artifacts.requires).toContain(
+      placementArtifacts.resourcePlanAdjusted
+    );
     expect(placeResourcesStep.contract.provides).toContain(
+      PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesPlaced
+    );
+    expect(placeDiscoveriesStep.contract.requires).toContain(
       PLACEMENT_PRODUCT_EFFECT_TAGS.placement.resourcesPlaced
     );
     expect(assignStartsStep.contract.provides).toContain(

--- a/mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts
+++ b/mods/mod-swooper-maps/test/placement/resource-placement-diagnostics.test.ts
@@ -17,11 +17,17 @@ type PlanIntent = {
   family: "aquatic" | "cultivated" | "terrestrial" | "geological";
   laneId: string;
   laneKind: "land" | "water";
-  phase: "rotation" | "range-floor" | "region-minimum";
+  phase: "rotation" | "range-floor" | "region-minimum" | "support";
   order: number;
   regionSlot: number;
   landmassId: number;
   inHabitat: boolean;
+  support?: {
+    action: "move" | "add";
+    reason: "support-floor" | "support-equity";
+    seatIndex: number;
+    fromPlotIndex?: number;
+  };
 };
 
 function intent(
@@ -48,27 +54,26 @@ function intent(
   };
 }
 
+// S5: place-resources stamps the support-ADJUSTED plan shape.
 function plan(width: number, height: number, intents: PlanIntent[]) {
   return {
     width,
     height,
     seed: 1,
     plannedCount: intents.length,
-    rotationCount: intents.filter((row) => row.phase === "rotation").length,
-    rangeFloorCount: intents.filter((row) => row.phase === "range-floor").length,
-    regionMinimumCount: intents.filter((row) => row.phase === "region-minimum").length,
-    siteSpacingTiles: 3,
-    equitySkippedSiteCount: 0,
+    moveCount: 0,
+    addCount: intents.filter((row) => row.phase === "support").length,
     intents,
-    perType: [],
-    regionMinimums: [],
+    adjustments: [],
+    shortfalls: [],
+    perStart: [],
+    equity: { gapBefore: null, gapAfter: null, tolerance: 2 },
     settings: {
-      density: 1,
-      sparsity: 0,
-      rarityFidelity: 1,
-      perTypeSpacingFloorScale: 1,
-      equityMaxDensityRatio: 1.8,
-      affinityRuleCount: 0,
+      enabled: true,
+      supportFloor: 2,
+      supportRadiusTiles: 4,
+      equityTolerance: 2,
+      strength: 1,
     },
   } as unknown as Parameters<typeof placeResourcesWithTypedOutcomes>[0]["plan"];
 }
@@ -119,7 +124,8 @@ describe("resource placement diagnostics", () => {
       placedCount: 2,
       rejectedCount: 2,
       shortfalls: [{ resourceType: 9, reason: "cannot-have-resource", count: 2 }],
-      byPhase: { rotation: 2, rangeFloor: 0, regionMinimum: 0 },
+      byPhase: { rotation: 2, rangeFloor: 0, regionMinimum: 0, support: 0 },
+      supportAdjustedPlacedCount: 0,
     });
   });
 
@@ -184,7 +190,8 @@ describe("resource placement diagnostics", () => {
         placedCount: 3,
         rejectedCount: 1,
         shortfalls: [{ resourceType: 44, reason: "cannot-have-resource", count: 1 }],
-        byPhase: { rotation: 3, rangeFloor: 0, regionMinimum: 0 },
+        byPhase: { rotation: 3, rangeFloor: 0, regionMinimum: 0, support: 0 },
+        supportAdjustedPlacedCount: 0,
       },
       [
         { index: 13, resourceType: "RESOURCE_GOLD", resourceClassType: null, name: null },
@@ -237,7 +244,7 @@ describe("resource placement diagnostics", () => {
         plannedCount: 4,
         placedCount: 3,
         rejectedCount: 1,
-        byPhase: { rotation: 3, rangeFloor: 0, regionMinimum: 0 },
+        byPhase: { rotation: 3, rangeFloor: 0, regionMinimum: 0, support: 0 },
         shortfalls: [{ resourceType: 44, reason: "cannot-have-resource", count: 1 }],
       },
       byReason: [{ reason: "cannot-have-resource", count: 1 }],
@@ -275,7 +282,8 @@ describe("resource placement diagnostics", () => {
         placedCount: 159,
         rejectedCount: 0,
         shortfalls: [],
-        byPhase: { rotation: 140, rangeFloor: 15, regionMinimum: 4 },
+        byPhase: { rotation: 140, rangeFloor: 15, regionMinimum: 4, support: 0 },
+        supportAdjustedPlacedCount: 0,
       },
       Array.from({ length: 55 }, (_, index) => ({
         index,
@@ -301,7 +309,7 @@ describe("resource placement diagnostics", () => {
         plannedCount: 159,
         placedCount: 159,
         rejectedCount: 0,
-        byPhase: { rotation: 140, rangeFloor: 15, regionMinimum: 4 },
+        byPhase: { rotation: 140, rangeFloor: 15, regionMinimum: 4, support: 0 },
       },
     });
     expect(telemetry).not.toHaveProperty("unmappedPlacedResourceTypes");

--- a/mods/mod-swooper-maps/test/placement/start-viability.test.ts
+++ b/mods/mod-swooper-maps/test/placement/start-viability.test.ts
@@ -33,7 +33,7 @@ type StartInput = {
   aridityIndex: Float32Array;
   riverClass: Uint8Array;
   lakeMask: Uint8Array;
-  placedResourcePlotIndices?: number[];
+  plannedResourcePlotIndices?: number[];
 };
 
 function idx(width: number, x: number, y: number): number {
@@ -174,7 +174,7 @@ describe("start viability planning", () => {
     );
     const supportedPlot = idx(input.width, 2, 2);
     const unsupportedPlot = idx(input.width, 8, 6);
-    input.placedResourcePlotIndices = [supportedPlot];
+    input.plannedResourcePlotIndices = [supportedPlot];
 
     const result = plan(input, {
       resourceSupportRadiusTiles: 2,

--- a/mods/mod-swooper-maps/test/resources/resource-support-adjust-op-contract.test.ts
+++ b/mods/mod-swooper-maps/test/resources/resource-support-adjust-op-contract.test.ts
@@ -1,0 +1,475 @@
+import { describe, expect, it } from "bun:test";
+
+import resources from "@mapgen/domain/resources/ops";
+import {
+  getHexRadiusIndicesOddQ,
+  hexDistanceOddQPeriodicX,
+} from "@swooper/mapgen-core/lib/grid";
+
+import { runOpValidated } from "../support/compiler-helpers.js";
+
+const WIDTH = 24;
+const HEIGHT = 14;
+const SIZE = WIDTH * HEIGHT;
+
+type PlanIntent = {
+  plotIndex: number;
+  x: number;
+  y: number;
+  resourceType: string;
+  resourceTypeId: number;
+  family: "aquatic" | "cultivated" | "terrestrial" | "geological";
+  laneId: string;
+  laneKind: "land" | "water";
+  phase: "rotation" | "range-floor" | "region-minimum";
+  order: number;
+  regionSlot: number;
+  landmassId: number;
+  inHabitat: boolean;
+};
+
+type AdjustResult = {
+  plannedCount: number;
+  moveCount: number;
+  addCount: number;
+  intents: ReadonlyArray<
+    PlanIntent & {
+      phase: PlanIntent["phase"] | "support";
+      support?: {
+        action: "move" | "add";
+        reason: "support-floor" | "support-equity";
+        seatIndex: number;
+        fromPlotIndex?: number;
+      };
+    }
+  >;
+  adjustments: ReadonlyArray<{
+    action: "move" | "add";
+    reason: "support-floor" | "support-equity";
+    resourceType: string;
+    fromPlotIndex?: number;
+    toPlotIndex: number;
+    seatIndex: number;
+  }>;
+  shortfalls: ReadonlyArray<{ seatIndex: number; reason: string; missing: number }>;
+  perStart: ReadonlyArray<{
+    seatIndex: number;
+    plotIndex: number;
+    supportBefore: number;
+    supportAfter: number;
+  }>;
+  equity: { gapBefore: number | null; gapAfter: number | null; tolerance: number };
+};
+
+function plotAt(x: number, y: number): number {
+  return y * WIDTH + x;
+}
+
+function intentAt(args: {
+  x: number;
+  y: number;
+  resourceType: string;
+  resourceTypeId: number;
+  order: number;
+  inHabitat?: boolean;
+}): PlanIntent {
+  const plotIndex = plotAt(args.x, args.y);
+  return {
+    plotIndex,
+    x: args.x,
+    y: args.y,
+    resourceType: args.resourceType,
+    resourceTypeId: args.resourceTypeId,
+    family: "geological",
+    laneId: "probe",
+    laneKind: "land",
+    phase: "rotation",
+    order: args.order,
+    regionSlot: args.x < WIDTH / 2 ? 1 : 2,
+    landmassId: 0,
+    inHabitat: args.inHabitat ?? true,
+  };
+}
+
+function perTypeRow(args: {
+  resourceType: string;
+  resourceTypeId: number;
+  plannedCount: number;
+  minCount: number;
+  maxCount: number;
+  spacingFloorTiles?: number;
+}) {
+  return {
+    resourceType: args.resourceType,
+    resourceTypeId: args.resourceTypeId,
+    family: "geological" as const,
+    laneId: "probe",
+    laneKind: "land" as const,
+    weight: 10,
+    effectiveWeight: 1,
+    authoredTargetCount: args.plannedCount,
+    effectiveTargetCount: args.plannedCount,
+    minCount: args.minCount,
+    maxCount: args.maxCount,
+    spacingFloorTiles: args.spacingFloorTiles ?? 4,
+    habitatTileCount: SIZE,
+    legalTileCount: SIZE,
+    eligibleTileCount: SIZE,
+    plannedCount: args.plannedCount,
+    rotationCount: args.plannedCount,
+    rangeFloorCount: 0,
+    regionMinimumCount: 0,
+    shortfalls: [],
+  };
+}
+
+function buildInput(args: {
+  intents: PlanIntent[];
+  perType: ReturnType<typeof perTypeRow>[];
+  starts: Array<{ seatIndex: number; playerId: number; plotIndex: number }>;
+  regionMinimums?: Array<{
+    resourceType: string;
+    regionSlot: number;
+    required: number;
+    fromRotation: number;
+    forced: number;
+    shortfall: number;
+  }>;
+  affinityRules?: Array<{
+    resourceA: string;
+    resourceB: string;
+    relation: "affinity" | "exclusion";
+    radiusTiles: number;
+  }>;
+  legalMaskByType?: Record<string, Uint8Array>;
+}) {
+  const allOnes = new Uint8Array(SIZE).fill(1);
+  const intensity = new Float32Array(SIZE).fill(1);
+  const regionSlotByTile = new Uint8Array(SIZE);
+  for (let i = 0; i < SIZE; i++) {
+    regionSlotByTile[i] = i % WIDTH < WIDTH / 2 ? 1 : 2;
+  }
+  return {
+    seed: 1337,
+    plan: {
+      width: WIDTH,
+      height: HEIGHT,
+      seed: 1337,
+      plannedCount: args.intents.length,
+      rotationCount: args.intents.length,
+      rangeFloorCount: 0,
+      regionMinimumCount: 0,
+      siteSpacingTiles: 3,
+      equitySkippedSiteCount: 0,
+      intents: args.intents,
+      perType: args.perType,
+      regionMinimums: args.regionMinimums ?? [],
+      settings: {
+        density: 1,
+        sparsity: 0,
+        rarityFidelity: 1,
+        perTypeSpacingFloorScale: 1,
+        equityMaxDensityRatio: 1.8,
+        affinityRuleCount: (args.affinityRules ?? []).length,
+        affinityRules: args.affinityRules ?? [],
+      },
+    },
+    eligibility: args.perType.map((row) => ({
+      resourceType: row.resourceType,
+      resourceTypeId: row.resourceTypeId,
+      habitatMask: allOnes,
+      legalMask: args.legalMaskByType?.[row.resourceType] ?? allOnes,
+      intensity,
+    })),
+    starts: args.starts,
+    landmassIdByTile: new Int32Array(SIZE),
+    landmassTileCounts: [SIZE],
+    regionSlotByTile,
+  };
+}
+
+function run(
+  input: ReturnType<typeof buildInput>,
+  config: Record<string, unknown> = {}
+): AdjustResult {
+  return runOpValidated(resources.ops.adjustResourceSupport, input as never, {
+    strategy: "default",
+    config,
+  }) as unknown as AdjustResult;
+}
+
+function supportCount(
+  intents: AdjustResult["intents"],
+  seatPlot: number,
+  radius: number
+): number {
+  const zone = new Set(getHexRadiusIndicesOddQ(seatPlot, WIDTH, HEIGHT, radius));
+  return intents.filter((intent) => zone.has(intent.plotIndex)).length;
+}
+
+/** Two seats: one inside a NW site cluster, one in the empty SE corner. */
+function clusterScenario(args?: { maxCountA?: number }) {
+  const intents = [
+    intentAt({ x: 1, y: 1, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 0 }),
+    intentAt({ x: 5, y: 1, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 1 }),
+    intentAt({ x: 1, y: 5, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 2 }),
+    intentAt({ x: 5, y: 5, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 3 }),
+    intentAt({ x: 9, y: 1, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 4 }),
+    intentAt({ x: 9, y: 5, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 5 }),
+  ];
+  return buildInput({
+    intents,
+    perType: [
+      perTypeRow({
+        resourceType: "RESOURCE_A",
+        resourceTypeId: 901,
+        plannedCount: intents.length,
+        minCount: 2,
+        maxCount: args?.maxCountA ?? intents.length,
+      }),
+    ],
+    starts: [
+      { seatIndex: 0, playerId: 0, plotIndex: plotAt(3, 3) },
+      { seatIndex: 1, playerId: 1, plotIndex: plotAt(20, 11) },
+    ],
+  });
+}
+
+describe("adjust-resource-support operation contract", () => {
+  it("fills every start to the support floor via count-preserving moves with typed provenance (E3.1)", () => {
+    const input = clusterScenario();
+    const result = run(input);
+
+    for (const seat of result.perStart) {
+      expect(seat.supportAfter, `seat ${seat.seatIndex} support`).toBeGreaterThanOrEqual(2);
+      expect(supportCount(result.intents, seat.plotIndex, 4)).toBe(seat.supportAfter);
+    }
+
+    // Moves only (maxCount has no headroom): per-type counts are preserved.
+    expect(result.addCount).toBe(0);
+    expect(result.moveCount).toBeGreaterThan(0);
+    expect(result.plannedCount).toBe(input.plan.intents.length);
+    expect(result.intents.filter((row) => row.resourceType === "RESOURCE_A").length).toBe(6);
+
+    // Typed provenance per adjusted site.
+    for (const adjustment of result.adjustments) {
+      expect(adjustment.reason).toMatch(/^support-(floor|equity)$/);
+      const moved = result.intents.find((row) => row.plotIndex === adjustment.toPlotIndex);
+      expect(moved?.support?.action).toBe(adjustment.action);
+      if (adjustment.action === "move") {
+        expect(moved?.support?.fromPlotIndex).toBe(adjustment.fromPlotIndex!);
+      }
+    }
+    expect(result.shortfalls).toEqual([]);
+  });
+
+  it("preserves S3 invariants: unique plots, per-type spacing floors, cross-type clearance", () => {
+    const result = run(clusterScenario());
+
+    const plots = result.intents.map((row) => row.plotIndex);
+    expect(new Set(plots).size).toBe(plots.length);
+
+    // Per-type same-type spacing floor (4 here) holds on the adjusted set.
+    const aPlots = result.intents
+      .filter((row) => row.resourceType === "RESOURCE_A")
+      .map((row) => row.plotIndex);
+    for (let i = 0; i < aPlots.length; i++) {
+      for (let j = i + 1; j < aPlots.length; j++) {
+        expect(
+          hexDistanceOddQPeriodicX(aPlots[i]!, aPlots[j]!, WIDTH),
+          `pair ${aPlots[i]}/${aPlots[j]}`
+        ).toBeGreaterThanOrEqual(4);
+      }
+    }
+
+    // Cross-type adjacency clearance (force-pass convention).
+    for (let i = 0; i < plots.length; i++) {
+      for (let j = i + 1; j < plots.length; j++) {
+        expect(hexDistanceOddQPeriodicX(plots[i]!, plots[j]!, WIDTH)).toBeGreaterThanOrEqual(2);
+      }
+    }
+
+    // Sites never land on a seat plot.
+    expect(plots).not.toContain(plotAt(3, 3));
+    expect(plots).not.toContain(plotAt(20, 11));
+  });
+
+  it("shrinks the cross-player support gap within the equity tolerance (E3.2)", () => {
+    const result = run(clusterScenario());
+    expect(result.equity.gapBefore).toBeGreaterThan(2);
+    expect(result.equity.gapAfter).toBeLessThanOrEqual(2);
+    const counts = result.perStart.map((seat) => seat.supportAfter);
+    expect(Math.max(...counts) - Math.min(...counts)).toBeLessThanOrEqual(2);
+  });
+
+  it("records typed shortfalls instead of forcing when no movable source or headroom exists", () => {
+    // All sites sit inside the rich seat's radius (so a move would strip its
+    // own support guard) and region minimums pin type A to the west; no
+    // maxCount headroom for adds.
+    const intents = [
+      intentAt({ x: 2, y: 2, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 0 }),
+      intentAt({ x: 6, y: 2, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 1 }),
+    ];
+    const input = buildInput({
+      intents,
+      perType: [
+        perTypeRow({
+          resourceType: "RESOURCE_A",
+          resourceTypeId: 901,
+          plannedCount: 2,
+          minCount: 2,
+          maxCount: 2,
+        }),
+      ],
+      starts: [
+        { seatIndex: 0, playerId: 0, plotIndex: plotAt(4, 2) },
+        { seatIndex: 1, playerId: 1, plotIndex: plotAt(20, 11) },
+      ],
+      regionMinimums: [
+        {
+          resourceType: "RESOURCE_A",
+          regionSlot: 1,
+          required: 2,
+          fromRotation: 2,
+          forced: 0,
+          shortfall: 0,
+        },
+      ],
+    });
+    const result = run(input);
+
+    // The plan is untouched and the deficit is recorded, not forced.
+    expect(result.moveCount + result.addCount).toBe(0);
+    expect(result.intents.map((row) => row.plotIndex).sort()).toEqual(
+      intents.map((row) => row.plotIndex).sort()
+    );
+    const seatOne = result.shortfalls.filter((row) => row.seatIndex === 1);
+    expect(seatOne.length).toBeGreaterThan(0);
+    expect(seatOne.every((row) =>
+      ["no-movable-site", "no-legal-tile-in-radius", "spacing-floor-preserved", "equity-unresolvable", "adjustment-budget-exhausted"].includes(row.reason)
+    )).toBe(true);
+  });
+
+  it("adds within maxCount headroom when moves are blocked, with support phase provenance", () => {
+    const intents = [
+      intentAt({ x: 2, y: 2, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 0 }),
+      intentAt({ x: 6, y: 2, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 1 }),
+    ];
+    const input = buildInput({
+      intents,
+      perType: [
+        perTypeRow({
+          resourceType: "RESOURCE_A",
+          resourceTypeId: 901,
+          plannedCount: 2,
+          minCount: 2,
+          maxCount: 6,
+        }),
+      ],
+      starts: [
+        { seatIndex: 0, playerId: 0, plotIndex: plotAt(4, 2) },
+        { seatIndex: 1, playerId: 1, plotIndex: plotAt(20, 11) },
+      ],
+    });
+    const result = run(input);
+
+    expect(result.addCount).toBeGreaterThan(0);
+    const aCount = result.intents.filter((row) => row.resourceType === "RESOURCE_A").length;
+    expect(aCount).toBeLessThanOrEqual(6);
+    const added = result.intents.filter((row) => row.phase === "support");
+    expect(added.length).toBe(result.addCount);
+    for (const intent of added) {
+      expect(intent.support?.action).toBe("add");
+    }
+    const poor = result.perStart.find((seat) => seat.seatIndex === 1)!;
+    expect(poor.supportAfter).toBeGreaterThanOrEqual(2);
+  });
+
+  it("respects exclusion rules and per-type policy legality at adjusted destinations", () => {
+    // Type B owns the poor seat's neighborhood via an exclusion rule, and
+    // type A is policy-illegal in the seat zone except two tiles.
+    const legalA = new Uint8Array(SIZE).fill(1);
+    const poorSeatPlot = plotAt(20, 11);
+    for (const idx of getHexRadiusIndicesOddQ(poorSeatPlot, WIDTH, HEIGHT, 4)) {
+      legalA[idx] = 0;
+    }
+    legalA[plotAt(18, 9)] = 1;
+    legalA[plotAt(22, 13)] = 1;
+
+    const intents = [
+      intentAt({ x: 1, y: 1, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 0 }),
+      intentAt({ x: 5, y: 1, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 1 }),
+      intentAt({ x: 1, y: 5, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 2 }),
+      intentAt({ x: 5, y: 5, resourceType: "RESOURCE_A", resourceTypeId: 901, order: 3 }),
+      intentAt({ x: 9, y: 1, resourceType: "RESOURCE_B", resourceTypeId: 902, order: 4 }),
+      intentAt({ x: 20, y: 8, resourceType: "RESOURCE_B", resourceTypeId: 902, order: 5 }),
+    ];
+    const input = buildInput({
+      intents,
+      perType: [
+        perTypeRow({
+          resourceType: "RESOURCE_A",
+          resourceTypeId: 901,
+          plannedCount: 4,
+          minCount: 1,
+          maxCount: 4,
+        }),
+        perTypeRow({
+          resourceType: "RESOURCE_B",
+          resourceTypeId: 902,
+          plannedCount: 2,
+          minCount: 1,
+          maxCount: 2,
+        }),
+      ],
+      starts: [
+        { seatIndex: 0, playerId: 0, plotIndex: plotAt(3, 3) },
+        { seatIndex: 1, playerId: 1, plotIndex: poorSeatPlot },
+      ],
+      affinityRules: [
+        { resourceA: "RESOURCE_A", resourceB: "RESOURCE_B", relation: "exclusion", radiusTiles: 2 },
+      ],
+      legalMaskByType: { RESOURCE_A: legalA },
+    });
+    const result = run(input);
+
+    const aPlots = result.intents
+      .filter((row) => row.resourceType === "RESOURCE_A")
+      .map((row) => row.plotIndex);
+    const bPlots = result.intents
+      .filter((row) => row.resourceType === "RESOURCE_B")
+      .map((row) => row.plotIndex);
+    // Exclusion holds on the adjusted set.
+    for (const a of aPlots) {
+      for (const b of bPlots) {
+        expect(hexDistanceOddQPeriodicX(a, b, WIDTH)).toBeGreaterThan(2);
+      }
+    }
+    // Legality holds: every adjusted A destination is on a legal tile.
+    for (const adjustment of result.adjustments) {
+      if (adjustment.resourceType !== "RESOURCE_A") continue;
+      expect(legalA[adjustment.toPlotIndex]).toBe(1);
+    }
+  });
+
+  it("is deterministic for identical inputs", () => {
+    const a = run(clusterScenario());
+    const b = run(clusterScenario());
+    expect(JSON.parse(JSON.stringify(b))).toEqual(JSON.parse(JSON.stringify(a)));
+  });
+
+  it("passes the plan through unchanged when disabled, recording deficits as typed shortfalls", () => {
+    const input = clusterScenario();
+    const result = run(input, { enabled: false });
+
+    expect(result.moveCount).toBe(0);
+    expect(result.addCount).toBe(0);
+    expect(result.adjustments).toEqual([]);
+    expect(result.intents.map((row) => row.plotIndex)).toEqual(
+      input.plan.intents.map((row) => row.plotIndex)
+    );
+    const disabled = result.shortfalls.filter((row) => row.reason === "adjustment-disabled");
+    expect(disabled.length).toBeGreaterThan(0);
+    expect(disabled[0]!.seatIndex).toBe(1);
+  });
+});

--- a/mods/mod-swooper-maps/test/support/world-balance-stats.ts
+++ b/mods/mod-swooper-maps/test/support/world-balance-stats.ts
@@ -732,6 +732,19 @@ export function collectWorldBalanceStats(args: Readonly<{
   if (!Array.isArray(resourcePlan?.intents) || !Array.isArray(resourcePlan?.perType)) {
     throw new Error("Missing placement.resourcePlan.");
   }
+  // S5: place-resources stamps the support-ADJUSTED plan, so every per-plot
+  // join against placed outcomes must use the adjusted intents (the base plan
+  // remains authority for per-type ranges, spacing floors, and shortfalls).
+  const resourcePlanAdjusted = context.artifacts.get(placementArtifacts.resourcePlanAdjusted.id) as
+    | {
+        intents?: ReadonlyArray<
+          Readonly<{ plotIndex?: number; resourceTypeId?: number; inHabitat?: boolean }>
+        >;
+      }
+    | undefined;
+  const stampedResourceIntents = Array.isArray(resourcePlanAdjusted?.intents)
+    ? resourcePlanAdjusted.intents
+    : resourcePlan.intents;
   if (!Array.isArray(resourcePlacement?.outcomes)) {
     throw new Error("Missing placement.resourcePlacementOutcomes.");
   }
@@ -905,7 +918,7 @@ export function collectWorldBalanceStats(args: Readonly<{
     }
   }
   const resourceIntentByPlot = new Map<number, { resourceTypeId: number; inHabitat: boolean }>();
-  for (const intent of resourcePlan.intents) {
+  for (const intent of stampedResourceIntents) {
     if (Number.isFinite(intent.resourceTypeId)) {
       incrementCount(resourcePlanTypeCounts, intent.resourceTypeId as number);
     }
@@ -917,7 +930,7 @@ export function collectWorldBalanceStats(args: Readonly<{
       });
     }
   }
-  const resourcePlannedPlotIndices = resourcePlan.intents
+  const resourcePlannedPlotIndices = stampedResourceIntents
     .map((intent) =>
       Number.isFinite(intent.plotIndex) ? Math.trunc(intent.plotIndex as number) : -1
     )

--- a/openspec/changes/placement-realignment-s5-support/proposal.md
+++ b/openspec/changes/placement-realignment-s5-support/proposal.md
@@ -1,0 +1,167 @@
+# Placement Realignment S5 — Resource↔Start Support Pass
+
+## Why
+
+The resource↔start relationship was one-directional (diagnosis RC7;
+audit-register resources lane): starts scored placed resources via
+`resourceSupportWeight`/`resourceSupportRadiusTiles`, but resources were
+planned and stamped completely blind to starts. The E3 expectation family
+was red at S4: minimum support per start 1.8 within radius 4 (E3.1 floor 2),
+cross-player support gap 7.0 (E3.2 tolerance 2), and no order in the
+pipeline at which a support guarantee COULD hold (E3.3) because resources
+stamped before starts existed.
+
+## Target Authority Refs
+
+- `docs/projects/placement-realignment/refactor-plan.md` (S5 scope; the D3
+  ordering decision is pre-made there: planning before starts, stamping
+  after the support pass; post-stamp mutation explicitly rejected)
+- `docs/projects/placement-realignment/expectations.md` (E3.1–E3.3 gates;
+  E1/E2 non-regression)
+- `docs/projects/placement-realignment/diagnosis.md` (RC7)
+- `docs/system/ADR.md` ADR-008 (domain/resources owns resource planning),
+  ADR-009 (deterministic plan authority)
+- `.agents/skills/civ7-architecture-authority/references/ownership-boundaries.md`
+  (domain module layout)
+
+## What Changes
+
+1. **Step reorder (D3 contract change).** The placement effect chain is
+   rewired from `surfacePrepared → resourcesPlaced → startsAssigned → ...`
+   to `surfacePrepared → resourcesPlanned → startsAssigned →
+   resourcesAdjusted → resourcesPlaced → discoveriesPlaced → ...`. New stage
+   order: plan-resources → assign-starts → adjust-resources →
+   place-resources. Resource PLANNING stays before starts (it still reads
+   the prepared engine surface for policy legality); resource STAMPING moves
+   after the support pass. Post-stamp mutation is rejected: the engine has
+   no resource-removal adapter capability and a stamped surface would need
+   its own typed outcome surface. `prepare-placement-surface` keeps its
+   position — it gates the legality surface read by planning AND the engine
+   stamping, both of which still run after it.
+2. **assign-starts consumes the PLAN (D3 input change).** The step requires
+   `resourcesPlanned` + the `resourcePlan` artifact instead of
+   `resourcesPlaced` + stamped outcomes; the `plan-starts` op input is
+   renamed `placedResourcePlotIndices → plannedResourcePlotIndices` with the
+   resource-support scoring term unchanged in mechanics (counts within
+   `resourceSupportRadiusTiles`, rank-normalized) but fed from planned site
+   intents.
+3. **New op `resources/adjust-resource-support` (domain/resources).** Takes
+   the site-selection plan + eligibility fields + seated StartRecord seats
+   and produces an adjusted intent set as a bounded move/add pass:
+   - Phase 1 (E3.1): per-start support floor within radius — prefer MOVING a
+     site that serves no start (count-preserving: ranges, rarity counts, and
+     region minimums hold exactly), fall back to ADDING within maxCount
+     headroom.
+   - Phase 2 (E3.2): cross-player equity — move sites out of the richest
+     start's radius into the poorest's (or to a neutral in-habitat plot)
+     with removal/gain safety so no seat drops below floor or current min.
+   - ALL S3 invariants enforced at destinations: policy-table legality
+     (hard), per-type same-type spacing floors, cross-type adjacency
+     clearance (the official force-pass convention), affinity/exclusion
+     rules (echoed through the plan settings), per-landmass equity ceiling,
+     [min,max] ranges, region-minimum guard on cross-region moves.
+   - Typed provenance per adjusted site (`support: {action, reason,
+     seatIndex, fromPlotIndex?}`); unsatisfiable units recorded as typed
+     shortfalls (never forced).
+4. **Knobs (derived schema, foundation pattern).** `placement.support`
+   public section derived from the op default-strategy config: `enabled`
+   (default true), `supportFloor` (default 2, range 0..6),
+   `supportRadiusTiles` (default 4, range 1..8), `equityTolerance` (default
+   2, range 0..8), `strength` (default 1, range 0..1 — scales the
+   adjustment budget). Earth-like defaults reproduce the E3 gates with no
+   shipped-config change.
+5. **Artifacts + outcomes provenance.** `resourceEligibility` (per-type
+   habitat/legal/intensity fields, published once by plan-resources so the
+   adjuster works inside the same constraints) and `resourcePlanAdjusted`
+   (the adjusted plan; validate hook enforces count/provenance coherence,
+   unique plots, move bookkeeping). `place-resources` stamps the ADJUSTED
+   intents; `resourcePlacementOutcomes.reconciliation` gains
+   `byPhase.support` and `supportAdjustedPlacedCount` (additive provenance
+   in outcomes).
+6. **Metrics harness extended.** E3.1 gains supportMoves/supportAdds/
+   shortfall counts + per-start planned-vs-placed distribution + adjustment
+   provenance detail; E3.2 gains plannedGapBefore/After; E3.3 now asserts
+   floor AND equity per seed (trueCount aggregate = N/N guarantee). All
+   per-plot stamped joins (E2.3 habitat fidelity, E2.5 aggregation, E2.9
+   reassignment/legality/drift) switch to the adjusted intents; E2.5 gains a
+   `basePlanGeologicalPairCorrelation` counterfactual that attributes
+   aggregation movement to the pass vs seed geography.
+
+## Decision Log
+
+- **No interrupted prior S5 attempt existed:** the worktree was clean at
+  dd6ffd091 (S0–S4); this change is a fresh implementation (decision-logged
+  per the slice brief's adopt-or-reset gate).
+- **assign-starts resource-support input (planned vs placed):** the scoring
+  term now reads PLANNED site intents. On the mock-adapter harness this is
+  observed value-identical (E2.9 has planned == placed == stamped since S3:
+  zero engine rejections), and the E1.* 20-seed numbers are bit-identical to
+  S4. On live engines the planned set is a superset of placed (engine
+  rejections become typed shortfalls), so start scoring sees slightly more
+  optimistic support — acceptable: the support pass runs after starts and
+  guarantees the floor on the same planned frame, and Milestone B re-proves
+  live.
+- **Adjustment algorithm bounds:** floor phase applies `ceil(strength ×
+  deficit)` units per seat; equity phase budget is `ceil(strength × seats ×
+  supportFloor × 2)` hard-capped at 64 iterations; each iteration either
+  applies one move/add or records a typed shortfall and stops — termination
+  is structural. Moves are preferred over adds everywhere because they
+  preserve per-type counts exactly (E2.1/E2.7 untouched by construction).
+- **Equity safety predicates:** a source site may leave the richest zone
+  only if every seat covering it stays ≥ floor and ≥ the current minimum; a
+  destination may not push any covering seat back to the old maximum. This
+  makes per-iteration progress monotone (max strictly shrinks or min
+  strictly grows) and prevents oscillation without global search.
+- **E2.3/E2.5 protection inside the adjuster:** destinations hard-require
+  policy legality and rank habitat first (in-lane +10 dominates intensity);
+  free-map (neutral) destinations REQUIRE habitat; out-of-lane sources get a
+  move bonus (relocating them is fidelity-neutral-or-positive); sources
+  participating in a same-family aggregation pair in the (floor, floor+2]
+  annulus are penalized so isolated sites move first. Measured: E2.3 holds
+  (0.974 mean over 20 seeds), E2.5 is aggregation-neutral (mean 1.1538
+  adjusted vs 1.1539 base-plan counterfactual).
+- **Tag-chain subtleties found:** `prepare-placement-surface` gates BOTH the
+  planning step's engine legality surface read (ADR-009 declared read) and
+  the stamp — the reorder keeps both downstream of it, so its position is
+  unchanged. `place-discoveries` previously chained only off
+  `startsAssigned`; it now also requires `resourcesPlaced` so the serialized
+  product chain stays explicit (discoveries were always after the resource
+  stamp in stage order; the tag now says so). The placement-final
+  maintenance step needed no change (it requires `advancedStartsAssigned`
+  and reads `resourcePlacementOutcomes`, both still upstream).
+- **Eligibility published, not re-derived:** the adjuster needs the per-type
+  habitat/legal/intensity fields the plan was selected under. Re-running
+  habitat derivation + legality reads in the adjust step would duplicate
+  compute and risk divergence with the planning surface; the planning step
+  publishes them once as `resourceEligibility` (single-publish, validated).
+  The select op output additionally echoes its `affinityRules` in
+  `settings` so the adjuster honors the same exclusion/affinity config
+  without a second config path.
+- **Stage artifacts.ts growth:** the two new artifact contracts were added
+  to the existing placement stage `artifacts.ts` (S3/S4 precedent for stage
+  surfaces); the per-file `artifacts/contract/` normalization for this
+  collection is S6 scope (artifact hygiene slice), not grown here ad hoc.
+- **Proof-surface preservation:** live-parity and surface-delta evidence
+  readers prefer `resourcePlanAdjusted` for per-plot stamped joins (its
+  intents ARE what was stamped) and keep the base `resourcePlan` as
+  authority for selection settings (siteSpacingTiles) and fallback; the
+  world-balance stats support joins the same way. Without this, moved sites
+  read as habitat-mismatches against the stale base plan (observed: an
+  artificial E2.3 dip to 0.897 that vanished once the join used the stamped
+  plan).
+
+## Known Limits / Open Items (recorded, not faked)
+
+- **E2.5 20-seed window:** seed 1353 sits at 0.974 (< CSR 1.0) both BEFORE
+  and AFTER the support pass (delta 0.000) — pre-existing seed geography,
+  first observed because S5 widened E2.5 measurement to 20 seeds (S3/S4
+  measured the 5-seed canonical run, which holds: 1.123 [1.012..1.195]).
+  The counterfactual summary field makes this attribution permanent.
+- **Tiny-map equity shortfalls:** on small test grids (240 plots, 2–4 seats
+  with heavily overlapping radius-4 zones) the equity pass can be
+  structurally unresolvable; it records `equity-unresolvable` shortfalls
+  loudly. The standard-size gates are unaffected (20/20 seeds green).
+- **Live half:** mock-adapter legality matches policy masks, so plan ==
+  placed here; live engine rejections could drop a start below the floor
+  post-stamp. Milestone B measures this; the typed shortfall surface is the
+  hook for any live-only repair decision.

--- a/openspec/changes/placement-realignment-s5-support/specs/mapgen-normalization-workstreams/spec.md
+++ b/openspec/changes/placement-realignment-s5-support/specs/mapgen-normalization-workstreams/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Resource Stamping Runs After Starts And The Support Pass (D3 Contract Change)
+
+The placement stage SHALL order its resource product as
+plan → starts → support-adjust → stamp, carried by the effect chain
+`resourcesPlanned → startsAssigned → resourcesAdjusted → resourcesPlaced`.
+Resource planning SHALL remain after `surfacePrepared` (it reads the
+prepared engine surface for policy legality); resource stamping SHALL
+consume the ADJUSTED intent set and remain the last resource authority
+point. Post-stamp mutation of resources is rejected: no step may alter
+stamped resources, and any start-aware correction happens on the plan
+before stamping. `assign-starts` SHALL consume the resource PLAN
+(`plannedResourcePlotIndices` from the site intents) for its
+resource-support scoring term — placed outcomes do not exist at start time.
+
+#### Scenario: The effect chain serializes the reorder
+- **WHEN** the standard recipe compiles
+- **THEN** plan-resources provides `resourcesPlanned`, assign-starts
+  requires it and provides `startsAssigned`, adjust-resources requires
+  `startsAssigned` and provides `resourcesAdjusted`, place-resources
+  requires `resourcesAdjusted` (plus `surfacePrepared`) and provides
+  `resourcesPlaced`, and place-discoveries requires `resourcesPlaced`
+
+#### Scenario: Starts stamp before resources on the engine
+- **WHEN** the recipe runs against an adapter recording call order
+- **THEN** every `setStartPosition` call precedes the first
+  `placeResourceIntent` call
+
+### Requirement: A Bounded Support Pass Guarantees Per-Start Resource Support And Equity
+
+The `resources/adjust-resource-support` operation SHALL adjust the resource
+plan so every seated start has at least `supportFloor` planned sites within
+`supportRadiusTiles` (default 2 within 4, E3.1) and the cross-player
+support-count gap is at most `equityTolerance` (default 2, E3.2), as a
+bounded pass that moves or adds the minimum number of sites. Moves SHALL be
+preferred over adds (count-preserving); adds SHALL stay within the type's
+authored maxCount. Every destination SHALL satisfy the S3 plan invariants:
+per-resource policy-table legality, per-type same-type spacing floors,
+cross-type adjacency clearance, affinity/exclusion rules, the per-landmass
+equity ceiling, and the region-minimum guard for cross-region moves.
+Adjustments that cannot be made without violating an invariant SHALL be
+recorded as typed shortfalls, never forced. The knob surface
+(`enabled`, `supportFloor`, `supportRadiusTiles`, `equityTolerance`,
+`strength`) SHALL be derived from the op schema with declared ranges, and
+Earth-like defaults SHALL reproduce the E3 gates.
+
+#### Scenario: The guarantee holds across the seed window
+- **WHEN** the metrics harness runs the 20-seed standard window at defaults
+- **THEN** every seed has zero starts below the floor and a max−min support
+  gap of at most 2 (E3.3: 20/20)
+
+#### Scenario: Invariants beat the floor
+- **WHEN** no legal, spacing-valid, non-excluded destination exists within a
+  start's radius and no type has maxCount headroom
+- **THEN** the plan is left untouched for that unit and a typed shortfall
+  (seatIndex, reason, missing) is recorded and surfaced as a warning
+
+#### Scenario: Disabled is pass-through, not silent
+- **WHEN** the pass runs with `enabled: false`
+- **THEN** the adjusted plan equals the input plan and unmet floors are
+  recorded as `adjustment-disabled` shortfalls
+
+### Requirement: Adjusted Plans Carry Typed Support Provenance Into Artifacts And Outcomes
+
+The adjusted plan SHALL be published once as a validated artifact carrying
+the full adjusted intent set, every adjustment (`action: move|add`,
+`reason: support-floor|support-equity`, the seat it serves, source plot for
+moves), per-start support before/after, the equity gap before/after, and
+typed shortfalls. Adjusted intents SHALL carry per-site provenance
+(`support` field; additions use the `support` planning phase). The stamped
+outcomes SHALL surface the provenance additively:
+`reconciliation.byPhase.support` and `supportAdjustedPlacedCount`.
+
+#### Scenario: Provenance joins plan to outcomes
+- **WHEN** the support pass moves or adds sites and the stamp succeeds
+- **THEN** each adjustment row maps onto exactly one adjusted intent with
+  matching provenance, and `supportAdjustedPlacedCount` in the outcomes
+  equals the number of placed support-adjusted intents
+
+#### Scenario: The validate hook rejects incoherent adjustments
+- **WHEN** an adjusted plan is published with a support-phase intent lacking
+  add provenance, duplicate plots, or adjustment counts that disagree with
+  moveCount/addCount
+- **THEN** artifact validation fails with named issues

--- a/openspec/changes/placement-realignment-s5-support/tasks.md
+++ b/openspec/changes/placement-realignment-s5-support/tasks.md
@@ -1,0 +1,78 @@
+# Tasks — Placement Realignment S5 (Resource↔Start Support Pass)
+
+## 1. Step reorder (D3 contract change)
+
+- [x] 1.1 New effect tags `resourcesPlanned` (plan-resources) and
+  `resourcesAdjusted` (adjust-resources) with owners; chain rewired
+  resourcesPlanned → startsAssigned → resourcesAdjusted → resourcesPlaced →
+  discoveriesPlaced.
+- [x] 1.2 Stage order: plan-resources → assign-starts → adjust-resources →
+  place-resources; prepare-placement-surface position verified unchanged
+  (it gates the planning legality read AND the stamp).
+- [x] 1.3 assign-starts: requires resourcesPlanned + resourcePlan artifact;
+  plan-starts op input renamed placedResourcePlotIndices →
+  plannedResourcePlotIndices (D3 input change, scoring mechanics unchanged).
+- [x] 1.4 place-resources: requires resourcesAdjusted + resourcePlanAdjusted;
+  stamps the adjusted intents; place-discoveries chains off resourcesPlaced.
+
+## 2. Support-adjust op (domain/resources)
+
+- [x] 2.1 `resources/adjust-resource-support` contract: plan + eligibility +
+  StartRecord seats in; adjusted intents + adjustments + shortfalls +
+  perStart + equity out; knobs enabled/supportFloor/supportRadiusTiles/
+  equityTolerance/strength with declared min/max + descriptions.
+- [x] 2.2 Default strategy: floor phase (move-preferred, add fallback) +
+  equity phase (removal/gain safety predicates, bounded budget, hard cap);
+  deterministic hash ordering; invariant checks (legality, type floors,
+  cross-type clearance, exclusion/affinity, landmass ceiling, region-minimum
+  guard, [min,max] ranges); E2.3/E2.5 protection (habitat-first
+  destinations, out-of-lane source preference, aggregation-pair penalty).
+- [x] 2.3 select-resource-sites output echoes `settings.affinityRules`
+  (additive) so the adjuster honors the same rules without dual config.
+- [x] 2.4 Registered in domain contracts/implementations.
+
+## 3. Artifacts + validators + provenance
+
+- [x] 3.1 `resourceEligibility` published once by plan-resources (validated).
+- [x] 3.2 `resourcePlanAdjusted` published once by adjust-resources with
+  validate hook (counts, unique plots, provenance coherence); shortfalls
+  warned + traced.
+- [x] 3.3 Outcomes provenance additive: reconciliation.byPhase.support +
+  supportAdjustedPlacedCount; materializer typed against the adjusted plan.
+- [x] 3.4 Evidence readers (live-parity, surface-delta-context,
+  world-balance stats) prefer the adjusted plan for stamped joins; base plan
+  kept for selection settings.
+
+## 4. Knobs
+
+- [x] 4.1 `placement.support` public schema derived from op config
+  (foundation pattern); compile maps to adjust-resources.support envelope;
+  generated studio recipe schema/defaults + map artifacts regenerated.
+
+## 5. Verification
+
+- [x] 5.1 Metrics harness: stamped joins use adjusted intents (E2.3/E2.5/
+  E2.9); E3.1 += supportMoves/supportAdds/shortfalls + provenance detail;
+  E3.2 += plannedGapBefore/After; E3.3 = floor AND equity per seed; E2.5 +=
+  basePlanGeologicalPairCorrelation counterfactual.
+- [x] 5.2 Op-contract tests (8): floor fill with provenance, invariant
+  preservation, equity gap, typed shortfalls (no forcing), add-with-headroom,
+  exclusion + legality at destinations, determinism, disabled pass-through.
+- [x] 5.3 Order-encoding tests updated: placement-contracts (new chain +
+  step order), landmass-region-id-projection (starts before resources),
+  resource-placement-diagnostics (adjusted-plan shape + byPhase.support),
+  maps-schema-valid (+support key, +adjust-resources internal key, fixture),
+  standard-authoring-surface-guards (+support).
+- [x] 5.4 `bun --cwd mods/mod-swooper-maps test` — 506 pass / 0 fail;
+  `bun run --cwd mods/mod-swooper-maps check` clean.
+- [x] 5.5 `bun run verify:placement-metrics -- --seed 1337 --seeds 20 --size
+  standard --json /tmp/pm-s5.json`: E3.1 min 2.8 [2..4], belowFloor 0/160;
+  E3.2 gap 2.0 [2..2]; E3.3 20/20; E1.* bit-identical to S4; E2.* hold
+  (E2.5 worst seed pre-existing, delta 0.000 vs counterfactual).
+- [x] 5.6 `openspec validate placement-realignment-s5-support` passes.
+
+## 6. Docs
+
+- [x] 6.1 Evidence doc
+  `docs/projects/placement-realignment/evidence/s5-results-2026-06-10.md`
+  (gate table before/after per E-ID, raw aggregates, counterfactual note).


### PR DESCRIPTION
feat(mapgen): resource-start support pass — stamp reordered after starts, bounded plan adjustment (S5)

D3 contract change (refactor-plan S5): the placement effect chain is rewired
surfacePrepared -> resourcesPlanned -> startsAssigned -> resourcesAdjusted ->
resourcesPlaced -> discoveriesPlaced; stage order plan-resources ->
assign-starts -> adjust-resources -> place-resources. Resource planning stays
before starts; stamping moves after the support pass; post-stamp mutation is
rejected. assign-starts scores PLANNED site intents (plan-starts input
renamed placedResourcePlotIndices -> plannedResourcePlotIndices).

New domain op resources/adjust-resource-support: bounded move/add adjustment
of the resource plan against StartRecord seats — per-start support floor
(E3.1), cross-player equity (E3.2) — with typed per-site provenance and typed
shortfalls (never forced). Destinations respect every S3 invariant: policy
legality (hard), per-type spacing floors, cross-type clearance,
affinity/exclusion (echoed via select-sites settings), landmass equity
ceiling, [min,max] ranges, region-minimum guard. E2.3/E2.5 protection:
habitat-first destinations, out-of-lane source preference, aggregation-pair
penalty. Knobs (derived schema): enabled, supportFloor 2 (0..6),
supportRadiusTiles 4 (1..8), equityTolerance 2 (0..8), strength 1 (0..1).

Artifacts: resourceEligibility (single-publish from planning),
resourcePlanAdjusted (validated; full provenance); outcomes gain
reconciliation.byPhase.support + supportAdjustedPlacedCount (additive).
Evidence readers (live-parity, surface-delta, world-balance stats) join
stamped outcomes against the adjusted plan.

Validation:
- bun --cwd mods/mod-swooper-maps test: 506 pass / 0 fail (8 new op-contract
  tests; order-encoding tests updated to the new chain)
- bun run --cwd mods/mod-swooper-maps check: clean
- verify:placement-metrics --seeds 20: E3.1 min 2.8 [2..4], belowFloor 0/160;
  E3.2 gap 2.0 [2..2] (planned 5.45 -> 2.0); E3.3 20/20; E1.* bit-identical
  to S4; E2.* hold (E2.5 worst seed pre-existing, delta 0.000 vs new
  base-plan counterfactual)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

docs(placement): S5 evidence + OpenSpec change for the resource-start support pass

Evidence (s5-results-2026-06-10.md): E3.1 1.8 -> 2.8 min/start (0/160 below
floor), E3.2 gap 7.0 -> 2.0, E3.3 20/20; E1.* bit-identical to S4 under the
planned-sites scoring input; E2.* non-regression table with the E2.5 20-seed
measurement note (seed 1353 sub-CSR pre-exists S5; counterfactual delta
0.000); knob inventory; adjustment provenance (93 moves / 0 adds / 0
shortfalls over 20 seeds).

OpenSpec change placement-realignment-s5-support: D3 reorder recorded as an
explicit spec delta (effect chain + stamp-after-support requirements),
support-pass guarantee + invariants requirement, provenance requirement;
decision log covers the planned-vs-placed input change, algorithm bounds and
safety predicates, tag-chain subtleties (prepare-placement-surface gating,
place-discoveries chain), eligibility publication, and proof-surface
preservation.

Validation: openspec validate --all (86 passed / 0 failed).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>