### PR TITLE
fix(placement): engine-safe warn logging — Civ7 runtime has no console.warn (S9)

### DIFF
--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/log.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/log.ts
@@ -1,0 +1,22 @@
+/**
+ * Engine-safe warn logging for placement steps.
+ *
+ * The Civ7 live scripting runtime exposes `console.log` but NOT
+ * `console.warn` (discovered during the Milestone A live proof:
+ * `place-resources` failed the whole generation with
+ * "console.warn is not a function"). Loud fallback/shortfall reporting must
+ * stay visible on live runs, so it routes through `console.warn` where it
+ * exists (tests, browser studio, node) and falls back to `console.log` in
+ * the engine.
+ */
+export function warnLog(message: string): void {
+  const sink = console as unknown as {
+    warn?: (msg: string) => void;
+    log: (msg: string) => void;
+  };
+  if (typeof sink.warn === "function") {
+    sink.warn(message);
+    return;
+  }
+  sink.log(`[warn] ${message}`);
+}

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/adjust-resources/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/adjust-resources/index.ts
@@ -5,6 +5,7 @@ import { createStep, implementArtifacts } from "@swooper/mapgen-core/authoring";
 import AdjustResourcesStepContract from "./contract.js";
 import { placementArtifacts } from "../../artifacts.js";
 import { validateResourcePlanAdjustedArtifact } from "./validate.js";
+import { warnLog } from "../../log.js";
 import {
   PLACEMENT_TILE_SPACE_ID,
   PLACEMENT_VIZ_GROUP,
@@ -64,7 +65,7 @@ export default createStep(AdjustResourcesStepContract, {
       const summary = adjusted.shortfalls
         .map((row) => `seat ${row.seatIndex}: ${row.reason} x${row.missing}`)
         .join("; ");
-      console.warn(
+      warnLog(
         `[Placement] Resource support pass recorded ${adjusted.shortfalls.length} typed shortfall(s): ${summary}.`
       );
       context.trace?.event(() => ({

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/materialize.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/assign-starts/materialize.ts
@@ -3,6 +3,7 @@ import { defineVizMeta } from "@swooper/mapgen-core";
 import type { DeepReadonly, Static } from "@swooper/mapgen-core/authoring";
 
 import placement from "@mapgen/domain/placement";
+import { warnLog } from "../../log.js";
 
 import {
   PLACEMENT_VIZ_GROUP,
@@ -69,7 +70,7 @@ function colorForStartPosition(index: number): [number, number, number, number] 
 
 /**
  * Loud degradation surfacing (E1.7): every non-regional seat and every
- * below-floor spacing is reported via console.warn (visible on live runs)
+ * below-floor spacing is reported via warnLog (engine-safe; visible on live runs)
  * and a warn-tagged trace event (visible in verbose/studio traces). The
  * decisions themselves were already made — and recorded — by the plan-starts
  * op; this only makes them audible.
@@ -87,7 +88,7 @@ function warnStartDegradations(
     byRung.set(key, list);
   }
   for (const [path, seatIndices] of byRung) {
-    console.warn(
+    warnLog(
       `[Placement] Start assignment degraded to ${path} for ${seatIndices.length} seat(s) ` +
         `(seat indices: ${seatIndices.join(", ")}); regional viability guarantees were relaxed for those seats.`
     );
@@ -102,7 +103,7 @@ function warnStartDegradations(
   for (const seat of seats) {
     if (seat.plotIndex < 0) continue;
     if (!seat.imputedFlags.includes("spacing-below-floor")) continue;
-    console.warn(
+    warnLog(
       `[Placement] Seat ${seat.seatIndex} seated below the hard spacing floor ` +
         `(achievedSpacing=${seat.achievedSpacing}); the alternative was an unseated player.`
     );
@@ -116,7 +117,7 @@ function warnStartDegradations(
   const reassigned = seats.filter((seat) => seat.imputedFlags.includes("region-reassigned"));
   if (reassigned.length) {
     const seatIndices = reassigned.map((seat) => seat.seatIndex);
-    console.warn(
+    warnLog(
       `[Placement] ${reassigned.length} seat(s) region-reassigned (seat indices: ` +
         `${seatIndices.join(", ")}); their configured landmass region has zero start candidates on this map.`
     );

--- a/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/index.ts
+++ b/mods/mod-swooper-maps/src/recipes/standard/stages/placement/steps/place-resources/index.ts
@@ -8,6 +8,7 @@ import {
 } from "./materialize.js";
 import { placementArtifacts } from "../../artifacts.js";
 import PlaceResourcesStepContract from "./contract.js";
+import { warnLog } from "../../log.js";
 import {
   PLACEMENT_TILE_SPACE_ID,
   PLACEMENT_VIZ_GROUP,
@@ -142,7 +143,7 @@ export default createStep(PlaceResourcesStepContract, {
     if (outcomes.reconciliation.rejectedCount > 0) {
       // Typed reconcile (D4): engine-legality rejections are recorded as
       // shortfalls with reasons; the plan's type-at-plot is never re-decided.
-      console.warn(
+      warnLog(
         `[Placement] Resource reconciliation recorded ${outcomes.reconciliation.rejectedCount}/` +
           `${outcomes.reconciliation.plannedCount} typed rejections (no relocation, no type re-decision).`
       );


### PR DESCRIPTION
Discovered during the Milestone A live proof: the Civ7 scripting context
exposes console.log but not console.warn, so the S1/S3/S5 loud
fallback/shortfall paths crashed live map generation at
placement.place-resources (step 50/53) with 'console.warn is not a
function'. Route all placement warn reporting through an engine-safe
warnLog helper (console.warn when present, console.log '[warn]' fallback).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>