### PR TITLE
feat(direct-control): cinematic-moment dismissal primitive

### DIFF
--- a/packages/civ7-direct-control/src/index.ts
+++ b/packages/civ7-direct-control/src/index.ts
@@ -1290,6 +1290,26 @@ export {
   narrativeChoiceProofOutcome,
   narrativeChoiceProofPostcondition,
 } from "./proof/narrative-choice-proof-policy.js";
+export {
+  CIV7_CINEMATIC_CLOSE_BUTTON_SELECTOR,
+  CIV7_CINEMATIC_MOMENT_SELECTOR,
+  CIV7_CINEMATIC_TITLE_SELECTOR,
+  Civ7CinematicCameraRestoreResultSchema,
+  Civ7CinematicDismissalInputSchema,
+  Civ7CinematicDismissalResultSchema,
+  Civ7CinematicDismissalRowSchema,
+  DEFAULT_CIV7_CINEMATIC_MAX_DISMISSALS,
+  DEFAULT_CIV7_CINEMATIC_SETTLE_MS,
+  MAX_CIV7_CINEMATIC_MAX_DISMISSALS,
+  MAX_CIV7_CINEMATIC_SETTLE_MS,
+  dismissCiv7CinematicMoments,
+} from "./play/operations/cinematic-dismissal.js";
+export type {
+  Civ7CinematicCameraRestoreResult,
+  Civ7CinematicDismissalInput,
+  Civ7CinematicDismissalResult,
+  Civ7CinematicDismissalRow,
+} from "./play/operations/cinematic-dismissal.js";
 
 export { CIV7_SIGNED_INT_SEED_MAX, CIV7_SIGNED_INT_SEED_MIN, assessCiv7SignedIntSeed } from "./policy/setup.js";
 export const DEFAULT_CIV7_RESOURCE_FEASIBILITY_MAX_CELLS = 256;

--- a/packages/civ7-direct-control/src/play/operations/cinematic-dismissal.ts
+++ b/packages/civ7-direct-control/src/play/operations/cinematic-dismissal.ts
@@ -1,0 +1,317 @@
+import { Type } from "typebox";
+
+import { jsLiteral } from "../../runtime/command-serialization.js";
+import { Civ7RuntimeProbeSchema, probeHelperSource } from "../../runtime/probe.js";
+import { jsonPayloadFromCommandResult } from "../../session/command-result.js";
+import { executeCiv7AppUiCommand } from "../../session/execute.js";
+import { sleep } from "../../timing.js";
+import { boundedInteger } from "../../validation.js";
+import { Civ7MapLocationSchema } from "../map/types.js";
+
+import type { Civ7RuntimeProbe } from "../../runtime/probe.js";
+import type {
+  Civ7CommandResult,
+  Civ7DirectControlOptions,
+  Civ7TunerState,
+} from "../../session/types.js";
+import type { Civ7MapLocation } from "../map/types.js";
+
+// Live-verified against a running Civ7 game on 2026-06-11
+// (docs/projects/placement-realignment/evidence/milestone-b-2026-06-11.md, placement stack):
+// map-reveal / wonder-discovery cinematics are DisplayQueueManager screens in the App UI
+// scripting state. One mounts at a time; closing one mounts the next after a beat
+// (~2s settle was reliable). Seven wonder cinematics were drained by name in one live run
+// (Zhangjiajie, Iguazú Falls, Gullfoss, Uluru, Machapuchare, Redwood Forest, Torres del Paine).
+//
+// Official handler provenance:
+// .civ7/outputs/resources/Base/modules/base-standard/ui/cinematic/cinematic-manager.chunk.js
+// — DisplayQueueManager.close(...) (line ~198); exit restores
+// InterfaceMode.switchTo(previousMode) / InterfaceMode.switchToDefault() (lines ~379-380).
+// InterfaceMode is an ES module, NOT a global: it is only reachable from exec via the shared
+// module registry — import('/core/ui/interface-modes/interface-modes.js').then(...) — which is
+// async, so its result is observable only via console.log. It is used for advisory logging
+// only, never for return payloads.
+
+/** DOM selector for the mounted cinematic screen's close button (live-verified). */
+export const CIV7_CINEMATIC_CLOSE_BUTTON_SELECTOR = "fxs-hero-button.cinematic-moment__close-button";
+/** DOM selector for the cinematic title header; textContent is the wonder name (live-verified). */
+export const CIV7_CINEMATIC_TITLE_SELECTOR = ".cinematic-moment_title-header";
+/** Drain check selector: zero matches means no cinematic-moment DOM remains (live-verified). */
+export const CIV7_CINEMATIC_MOMENT_SELECTOR = "[class*=cinematic-moment]";
+
+export const DEFAULT_CIV7_CINEMATIC_MAX_DISMISSALS = 20;
+export const MAX_CIV7_CINEMATIC_MAX_DISMISSALS = 100;
+export const DEFAULT_CIV7_CINEMATIC_SETTLE_MS = 2_000;
+export const MAX_CIV7_CINEMATIC_SETTLE_MS = 60_000;
+
+export type Civ7CinematicDismissalInput = Readonly<{
+  maxDismissals?: number;
+  settleMs?: number;
+  restoreCameraPlot?: Civ7MapLocation;
+}>;
+
+export const Civ7CinematicDismissalInputSchema = Type.Object({
+  maxDismissals: Type.Optional(Type.Integer({ minimum: 1, maximum: MAX_CIV7_CINEMATIC_MAX_DISMISSALS })),
+  settleMs: Type.Optional(Type.Integer({ minimum: 0, maximum: MAX_CIV7_CINEMATIC_SETTLE_MS })),
+  restoreCameraPlot: Type.Optional(Civ7MapLocationSchema),
+}, { additionalProperties: false });
+
+export type Civ7CinematicDismissalRow = Readonly<{
+  iteration: number;
+  title: string | null;
+}>;
+
+export const Civ7CinematicDismissalRowSchema = Type.Object({
+  iteration: Type.Integer({ minimum: 1 }),
+  title: Type.Union([Type.String(), Type.Null()]),
+}, { additionalProperties: false });
+
+export type Civ7CinematicCameraRestoreResult = Readonly<{
+  plot: Civ7MapLocation;
+  lookAt: Civ7RuntimeProbe<boolean>;
+}>;
+
+export const Civ7CinematicCameraRestoreResultSchema = Type.Object({
+  plot: Civ7MapLocationSchema,
+  lookAt: Civ7RuntimeProbeSchema(Type.Boolean()),
+}, { additionalProperties: false });
+
+const civ7TunerStateSchema = Type.Object({
+  id: Type.String(),
+  name: Type.String(),
+}, { additionalProperties: false });
+
+export const Civ7CinematicDismissalResultSchema = Type.Object({
+  host: Type.String(),
+  port: Type.Number(),
+  state: civ7TunerStateSchema,
+  dismissals: Type.Array(Civ7CinematicDismissalRowSchema),
+  drained: Type.Boolean(),
+  iterations: Type.Integer({ minimum: 1 }),
+  domClearCount: Type.Integer({ minimum: 0 }),
+  cameraRestore: Type.Union([Civ7CinematicCameraRestoreResultSchema, Type.Null()]),
+  notes: Type.Array(Type.String()),
+}, { additionalProperties: false });
+
+export type Civ7CinematicDismissalResult = Readonly<{
+  host: string;
+  port: number;
+  state: Civ7TunerState;
+  dismissals: ReadonlyArray<Civ7CinematicDismissalRow>;
+  drained: boolean;
+  iterations: number;
+  domClearCount: number;
+  cameraRestore: Civ7CinematicCameraRestoreResult | null;
+  notes: ReadonlyArray<string>;
+}>;
+
+type Civ7CinematicDismissalProbePayload = Readonly<{
+  host: string;
+  port: number;
+  state: Civ7TunerState;
+  cinematicPresent: boolean;
+  dismissedTitle: string | null;
+  activate: Civ7RuntimeProbe<boolean> | null;
+  click: Civ7RuntimeProbe<boolean> | null;
+  remainingSelectorCount: number;
+}>;
+
+type Civ7CinematicDrainCheckPayload = Readonly<{
+  host: string;
+  port: number;
+  state: Civ7TunerState;
+  domClearCount: number;
+}>;
+
+type Civ7CinematicCameraRestorePayload = Readonly<{
+  host: string;
+  port: number;
+  state: Civ7TunerState;
+  lookAt: Civ7RuntimeProbe<boolean>;
+}>;
+
+type CinematicDismissalDependencies = Readonly<{
+  boundedInteger: (value: number, min: number, max: number, label: string) => number;
+  executeAppUiCommand: (
+    options: Civ7DirectControlOptions & Readonly<{ command: string }>,
+  ) => Promise<Civ7CommandResult>;
+  jsLiteral: (value: unknown) => string;
+  parseProbePayload: (result: Civ7CommandResult, label: string) => Civ7CinematicDismissalProbePayload;
+  parseDrainCheckPayload: (result: Civ7CommandResult, label: string) => Civ7CinematicDrainCheckPayload;
+  parseCameraRestorePayload: (result: Civ7CommandResult, label: string) => Civ7CinematicCameraRestorePayload;
+  sleep: (ms: number) => Promise<void>;
+}>;
+
+const CIV7_CINEMATIC_DISMISSAL_NOTES: ReadonlyArray<string> = [
+  "Cinematic moments are DisplayQueueManager screens in the App UI scripting state; one mounts at a time and closing one mounts the next after a settle beat.",
+  "Dismissal mirrors the live-verified synthetic close: dispatch CustomEvent('action-activate', { bubbles: true }) on the close button, then btn.click() when present.",
+  "Official handler: cinematic-manager.chunk.js DisplayQueueManager.close (~line 198); exit restores InterfaceMode.switchTo(previousMode)/switchToDefault (~lines 379-380).",
+  "After a synthetic DOM close the cinematic's dynamic camera may linger; restoreCameraPlot performs the safe Camera.lookAtPlot restore instead of blind Camera.popCamera loops.",
+];
+
+export async function dismissCiv7CinematicMoments(
+  input: Civ7CinematicDismissalInput = {},
+  options: Civ7DirectControlOptions = {},
+  dependencies: CinematicDismissalDependencies = defaultCinematicDismissalDependencies,
+): Promise<Civ7CinematicDismissalResult> {
+  const maxDismissals = dependencies.boundedInteger(
+    input.maxDismissals ?? DEFAULT_CIV7_CINEMATIC_MAX_DISMISSALS,
+    1,
+    MAX_CIV7_CINEMATIC_MAX_DISMISSALS,
+    "maxDismissals",
+  );
+  const settleMs = dependencies.boundedInteger(
+    input.settleMs ?? DEFAULT_CIV7_CINEMATIC_SETTLE_MS,
+    0,
+    MAX_CIV7_CINEMATIC_SETTLE_MS,
+    "settleMs",
+  );
+  if (input.restoreCameraPlot) {
+    dependencies.boundedInteger(input.restoreCameraPlot.x, 0, 1_000_000, "restoreCameraPlot.x");
+    dependencies.boundedInteger(input.restoreCameraPlot.y, 0, 1_000_000, "restoreCameraPlot.y");
+  }
+
+  const dismissals: Civ7CinematicDismissalRow[] = [];
+  let iterations = 0;
+  for (;;) {
+    const probe = dependencies.parseProbePayload(
+      await dependencies.executeAppUiCommand({
+        ...options,
+        command: buildCinematicDismissalProbeCommand(dependencies),
+      }),
+      "Civ7 cinematic dismissal probe",
+    );
+    iterations += 1;
+    if (!probe.cinematicPresent) break;
+    dismissals.push({ iteration: iterations, title: probe.dismissedTitle });
+    if (dismissals.length >= maxDismissals) break;
+    // Closing one cinematic mounts the next DisplayQueueManager screen after a beat
+    // (~2s settle was reliable live), so wait before probing again.
+    await dependencies.sleep(settleMs);
+  }
+
+  // Let the last synthetic close settle before the final DOM-clear verification.
+  if (dismissals.length > 0) await dependencies.sleep(settleMs);
+  const verification = dependencies.parseDrainCheckPayload(
+    await dependencies.executeAppUiCommand({
+      ...options,
+      command: buildCinematicDrainCheckCommand(),
+    }),
+    "Civ7 cinematic drain check",
+  );
+
+  let cameraRestore: Civ7CinematicCameraRestoreResult | null = null;
+  if (input.restoreCameraPlot) {
+    const camera = dependencies.parseCameraRestorePayload(
+      await dependencies.executeAppUiCommand({
+        ...options,
+        command: buildCinematicCameraRestoreCommand(input.restoreCameraPlot, dependencies),
+      }),
+      "Civ7 cinematic camera restore",
+    );
+    cameraRestore = { plot: input.restoreCameraPlot, lookAt: camera.lookAt };
+  }
+
+  return {
+    host: verification.host,
+    port: verification.port,
+    state: verification.state,
+    dismissals,
+    drained: verification.domClearCount === 0,
+    iterations,
+    domClearCount: verification.domClearCount,
+    cameraRestore,
+    notes: CIV7_CINEMATIC_DISMISSAL_NOTES,
+  };
+}
+
+export function buildCinematicDismissalProbeCommand(
+  dependencies: Pick<CinematicDismissalDependencies, "jsLiteral">,
+): string {
+  // Probe + dismiss in a single App UI exec. The synthetic close that worked live is
+  // CustomEvent("action-activate", { bubbles: true }) followed by btn.click() when present.
+  return `(() => {
+    ${probeHelperSource()}
+    const dismissCinematicMoment = () => {
+      const remainingSelectorCount = () => document.querySelectorAll(${dependencies.jsLiteral(CIV7_CINEMATIC_MOMENT_SELECTOR)}).length;
+      const closeButton = document.querySelector(${dependencies.jsLiteral(CIV7_CINEMATIC_CLOSE_BUTTON_SELECTOR)});
+      if (!closeButton) {
+        return {
+          cinematicPresent: false,
+          dismissedTitle: null,
+          activate: null,
+          click: null,
+          remainingSelectorCount: remainingSelectorCount(),
+        };
+      }
+      const dismissedTitle = document.querySelector(${dependencies.jsLiteral(CIV7_CINEMATIC_TITLE_SELECTOR)})?.textContent ?? null;
+      const activate = probe(() => {
+        closeButton.dispatchEvent(new CustomEvent("action-activate", { bubbles: true }));
+        return true;
+      });
+      const click = probe(() => {
+        if (typeof closeButton.click !== "function") return false;
+        closeButton.click();
+        return true;
+      });
+      return {
+        cinematicPresent: true,
+        dismissedTitle,
+        activate,
+        click,
+        remainingSelectorCount: remainingSelectorCount(),
+      };
+    };
+    return JSON.stringify(dismissCinematicMoment());
+  })()`;
+}
+
+export function buildCinematicDrainCheckCommand(): string {
+  return `(() => {
+    const readCinematicDrainCheck = () => ({
+      domClearCount: document.querySelectorAll(${jsLiteral(CIV7_CINEMATIC_MOMENT_SELECTOR)}).length,
+    });
+    return JSON.stringify(readCinematicDrainCheck());
+  })()`;
+}
+
+export function buildCinematicCameraRestoreCommand(
+  plot: Civ7MapLocation,
+  dependencies: Pick<CinematicDismissalDependencies, "jsLiteral">,
+): string {
+  // Camera.lookAtPlot / Camera.popCamera are App UI globals (live-verified). After a synthetic
+  // DOM close the cinematic's dynamic camera may linger; Camera.lookAtPlot is the safe restore
+  // primitive (no blind popCamera loops). The InterfaceMode import below is advisory logging
+  // only: InterfaceMode is an ES module reachable solely via the shared module registry, the
+  // import is async, and its result is observable only via console.log — never in payloads.
+  return `(() => {
+    ${probeHelperSource()}
+    const restoreCinematicCamera = (plot) => {
+      const lookAt = probe(() => {
+        Camera.lookAtPlot(plot.x, plot.y);
+        return true;
+      });
+      probe(() => {
+        import("/core/ui/interface-modes/interface-modes.js")
+          .then((m) => console.log("[civ7-direct-control] cinematic camera restore: InterfaceMode " + (m?.InterfaceMode ? "module-available" : "module-missing")))
+          .catch((err) => console.log("[civ7-direct-control] cinematic camera restore: InterfaceMode advisory failed: " + String(err)));
+        return true;
+      });
+      return { lookAt };
+    };
+    return JSON.stringify(restoreCinematicCamera(${dependencies.jsLiteral(plot)}));
+  })()`;
+}
+
+const defaultCinematicDismissalDependencies: CinematicDismissalDependencies = {
+  boundedInteger,
+  executeAppUiCommand: executeCiv7AppUiCommand,
+  jsLiteral,
+  parseProbePayload: (result, label) =>
+    jsonPayloadFromCommandResult<Civ7CinematicDismissalProbePayload>(result, label),
+  parseDrainCheckPayload: (result, label) =>
+    jsonPayloadFromCommandResult<Civ7CinematicDrainCheckPayload>(result, label),
+  parseCameraRestorePayload: (result, label) =>
+    jsonPayloadFromCommandResult<Civ7CinematicCameraRestorePayload>(result, label),
+  sleep,
+};

--- a/packages/civ7-direct-control/test/cinematic-dismissal.test.ts
+++ b/packages/civ7-direct-control/test/cinematic-dismissal.test.ts
@@ -1,0 +1,277 @@
+import { once } from "node:events";
+import { type AddressInfo, createServer, type Socket } from "node:net";
+import { describe, expect, test } from "vitest";
+import { Value } from "typebox/value";
+
+import {
+  Civ7CinematicDismissalInputSchema,
+  Civ7CinematicDismissalResultSchema,
+  dismissCiv7CinematicMoments,
+  encodeCiv7TunerRequest,
+  parseCiv7TunerFrame,
+} from "../src/index";
+
+type CinematicProbePayload = {
+  cinematicPresent: boolean;
+  dismissedTitle: string | null;
+  activate: { ok: boolean; value?: boolean; error?: string } | null;
+  click: { ok: boolean; value?: boolean; error?: string } | null;
+  remainingSelectorCount: number;
+};
+
+type FakeCinematicServer = {
+  received: string[];
+  address(): AddressInfo;
+  close(): Promise<void>;
+};
+
+describe("cinematic-moment dismissal", () => {
+  test("exports bounded input and result schemas", () => {
+    expect(Value.Check(Civ7CinematicDismissalInputSchema, {
+      maxDismissals: 20,
+      settleMs: 2_000,
+      restoreCameraPlot: { x: 31, y: 7 },
+    })).toBe(true);
+    expect(Value.Check(Civ7CinematicDismissalInputSchema, { maxDismissals: 0 })).toBe(false);
+    expect(Value.Check(Civ7CinematicDismissalInputSchema, { maxDismissals: 101 })).toBe(false);
+    expect(Value.Check(Civ7CinematicDismissalInputSchema, { settleMs: -1 })).toBe(false);
+    expect(Value.Check(Civ7CinematicDismissalInputSchema, { rawCommand: "Camera.popCamera()" })).toBe(false);
+
+    expect(Value.Check(Civ7CinematicDismissalResultSchema, {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      dismissals: [{ iteration: 1, title: "Zhangjiajie" }],
+      drained: true,
+      iterations: 2,
+      domClearCount: 0,
+      cameraRestore: { plot: { x: 31, y: 7 }, lookAt: { ok: true, value: true } },
+      notes: ["..."],
+    })).toBe(true);
+    expect(Value.Check(Civ7CinematicDismissalResultSchema, {
+      host: "127.0.0.1",
+      port: 4318,
+      state: { id: "65535", name: "App UI" },
+      dismissals: [],
+      drained: true,
+      iterations: 1,
+      domClearCount: 0,
+      cameraRestore: null,
+      notes: [],
+      command: "document.querySelectorAll",
+    })).toBe(false);
+  });
+
+  test("drains queued cinematics by title, then verifies the DOM is clear", async () => {
+    const server = await startCinematicTunerServer({
+      probes: [
+        presentProbe("Zhangjiajie", 4),
+        presentProbe("Iguazú Falls", 4),
+        absentProbe(),
+      ],
+      domClearCount: 0,
+    });
+    try {
+      const { port } = server.address();
+      const result = await dismissCiv7CinematicMoments(
+        { settleMs: 0 },
+        { host: "127.0.0.1", port, timeoutMs: 1_000 },
+      );
+
+      expect(result.dismissals).toEqual([
+        { iteration: 1, title: "Zhangjiajie" },
+        { iteration: 2, title: "Iguazú Falls" },
+      ]);
+      expect(result.iterations).toBe(3);
+      expect(result.drained).toBe(true);
+      expect(result.domClearCount).toBe(0);
+      expect(result.cameraRestore).toBeNull();
+      expect(result.state).toEqual({ id: "65535", name: "App UI" });
+      expect(Value.Check(Civ7CinematicDismissalResultSchema, result)).toBe(true);
+
+      const probeCommands = server.received.filter((message) => message.includes("dismissCinematicMoment"));
+      expect(probeCommands).toHaveLength(3);
+      expect(probeCommands[0]).toContain("fxs-hero-button.cinematic-moment__close-button");
+      expect(probeCommands[0]).toContain(".cinematic-moment_title-header");
+      expect(probeCommands[0]).toContain('new CustomEvent("action-activate", { bubbles: true })');
+      expect(probeCommands[0]).toContain("closeButton.click()");
+      const drainCommands = server.received.filter((message) => message.includes("readCinematicDrainCheck"));
+      expect(drainCommands).toHaveLength(1);
+      expect(drainCommands[0]).toContain("[class*=cinematic-moment]");
+      expect(server.received.some((message) => message.includes("restoreCinematicCamera"))).toBe(false);
+      expect(server.received.some((message) => message.includes("popCamera"))).toBe(false);
+      expect(server.received.some((message) => message.includes("sendRequest"))).toBe(false);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("stops at maxDismissals when cinematics keep mounting", async () => {
+    const server = await startCinematicTunerServer({
+      probes: [],
+      fallbackProbe: presentProbe("Uluru", 4),
+      domClearCount: 3,
+    });
+    try {
+      const { port } = server.address();
+      const result = await dismissCiv7CinematicMoments(
+        { maxDismissals: 2, settleMs: 0 },
+        { host: "127.0.0.1", port, timeoutMs: 1_000 },
+      );
+
+      expect(result.dismissals).toEqual([
+        { iteration: 1, title: "Uluru" },
+        { iteration: 2, title: "Uluru" },
+      ]);
+      expect(result.iterations).toBe(2);
+      expect(result.drained).toBe(false);
+      expect(result.domClearCount).toBe(3);
+      expect(server.received.filter((message) => message.includes("dismissCinematicMoment"))).toHaveLength(2);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("returns the zero-cinematic fast path without dismissing anything", async () => {
+    const server = await startCinematicTunerServer({
+      probes: [absentProbe()],
+      domClearCount: 0,
+    });
+    try {
+      const { port } = server.address();
+      const result = await dismissCiv7CinematicMoments(
+        { settleMs: 0 },
+        { host: "127.0.0.1", port, timeoutMs: 1_000 },
+      );
+
+      expect(result.dismissals).toEqual([]);
+      expect(result.iterations).toBe(1);
+      expect(result.drained).toBe(true);
+      expect(result.domClearCount).toBe(0);
+      expect(result.cameraRestore).toBeNull();
+      expect(server.received.filter((message) => message.includes("dismissCinematicMoment"))).toHaveLength(1);
+      expect(server.received.filter((message) => message.includes("readCinematicDrainCheck"))).toHaveLength(1);
+      expect(server.received.some((message) => message.includes("restoreCinematicCamera"))).toBe(false);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("optionally restores the camera with Camera.lookAtPlot after draining", async () => {
+    const server = await startCinematicTunerServer({
+      probes: [presentProbe("Gullfoss", 4), absentProbe()],
+      domClearCount: 0,
+    });
+    try {
+      const { port } = server.address();
+      const result = await dismissCiv7CinematicMoments(
+        { settleMs: 0, restoreCameraPlot: { x: 31, y: 7 } },
+        { host: "127.0.0.1", port, timeoutMs: 1_000 },
+      );
+
+      expect(result.dismissals).toEqual([{ iteration: 1, title: "Gullfoss" }]);
+      expect(result.drained).toBe(true);
+      expect(result.cameraRestore).toEqual({
+        plot: { x: 31, y: 7 },
+        lookAt: { ok: true, value: true },
+      });
+      const cameraCommands = server.received.filter((message) => message.includes("restoreCinematicCamera"));
+      expect(cameraCommands).toHaveLength(1);
+      expect(cameraCommands[0]).toContain("Camera.lookAtPlot(plot.x, plot.y)");
+      expect(cameraCommands[0]).toContain('{"x":31,"y":7}');
+      expect(cameraCommands[0]).toContain("interface-modes.js");
+      expect(cameraCommands[0]).toContain("console.log");
+      expect(cameraCommands[0]).not.toContain("popCamera");
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("rejects out-of-bounds inputs before opening any command", async () => {
+    await expect(dismissCiv7CinematicMoments({ maxDismissals: 0 })).rejects.toMatchObject({
+      code: "command-failed",
+    });
+    await expect(dismissCiv7CinematicMoments({ maxDismissals: 101 })).rejects.toMatchObject({
+      code: "command-failed",
+    });
+    await expect(dismissCiv7CinematicMoments({ settleMs: -1 })).rejects.toMatchObject({
+      code: "command-failed",
+    });
+    await expect(dismissCiv7CinematicMoments({ settleMs: 0, restoreCameraPlot: { x: -1, y: 0 } })).rejects.toMatchObject({
+      code: "command-failed",
+    });
+  });
+});
+
+function presentProbe(title: string, remainingSelectorCount: number): CinematicProbePayload {
+  return {
+    cinematicPresent: true,
+    dismissedTitle: title,
+    activate: { ok: true, value: true },
+    click: { ok: true, value: true },
+    remainingSelectorCount,
+  };
+}
+
+function absentProbe(): CinematicProbePayload {
+  return {
+    cinematicPresent: false,
+    dismissedTitle: null,
+    activate: null,
+    click: null,
+    remainingSelectorCount: 0,
+  };
+}
+
+async function startCinematicTunerServer(options: {
+  probes: CinematicProbePayload[];
+  fallbackProbe?: CinematicProbePayload;
+  domClearCount: number;
+  cameraLookAt?: { ok: boolean; value?: boolean; error?: string };
+}): Promise<FakeCinematicServer> {
+  const probes = [...options.probes];
+  const received: string[] = [];
+  const sockets = new Set<Socket>();
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    let buffer = Buffer.alloc(0);
+    socket.on("data", (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      for (;;) {
+        const parsed = parseCiv7TunerFrame(buffer);
+        if (!parsed) return;
+        buffer = buffer.subarray(parsed.bytesRead);
+        const message = parsed.frame.parts.join("\0");
+        received.push(message);
+        const respond = (parts: string[]) => {
+          socket.write(encodeCiv7TunerRequest(parsed.frame.listenerId, parts.join("\0")));
+        };
+        if (message === "LSQ:") {
+          respond(["65535", "App UI", "1", "Tuner"]);
+        } else if (message.includes("dismissCinematicMoment")) {
+          const payload = probes.shift() ?? options.fallbackProbe ?? absentProbe();
+          respond([JSON.stringify(payload)]);
+        } else if (message.includes("readCinematicDrainCheck")) {
+          respond([JSON.stringify({ domClearCount: options.domClearCount })]);
+        } else if (message.includes("restoreCinematicCamera")) {
+          respond([JSON.stringify({ lookAt: options.cameraLookAt ?? { ok: true, value: true } })]);
+        } else {
+          respond(["null"]);
+        }
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return {
+    received,
+    address: () => server.address() as AddressInfo,
+    close: async () => {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}


### PR DESCRIPTION
Promote a live-session discovery (proven against a running Civ7 game on
2026-06-11) into @civ7/direct-control as dismissCiv7CinematicMoments.

Map-reveal / wonder-discovery cinematics are DisplayQueueManager screens
in the App UI scripting state: one mounts at a time, and closing one
mounts the next after a beat (~2s settle was reliable). The mounted
screen exposes a close button at
fxs-hero-button.cinematic-moment__close-button with the wonder name at
.cinematic-moment_title-header; the dismissal that works live is
dispatching CustomEvent("action-activate", { bubbles: true }) on the
button followed by btn.click() when present. Seven wonder cinematics
were drained by name in one live run (Zhangjiajie, Iguazu Falls,
Gullfoss, Uluru, Machapuchare, Redwood Forest, Torres del Paine), with
document.querySelectorAll('[class*=cinematic-moment]').length === 0 as
the drain check.

The primitive loops TS-side (one App UI exec per iteration: probe +
dismiss returning { cinematicPresent, dismissedTitle,
remainingSelectorCount }), sleeps settleMs between iterations, stops at
maxDismissals (default 20) or when nothing is mounted, then runs a final
DOM-clear verification exec. An optional restoreCameraPlot input runs a
Camera.lookAtPlot restore exec (Camera.* are App UI globals,
live-verified); blind Camera.popCamera loops are deliberately avoided.

Official handler provenance:
.civ7/outputs/resources/Base/modules/base-standard/ui/cinematic/cinematic-manager.chunk.js
- DisplayQueueManager.close(...) (line ~198); exit restores
InterfaceMode.switchTo(previousMode) / InterfaceMode.switchToDefault()
(lines ~379-380). InterfaceMode is an ES module, not a global; it is
reachable from exec only via the shared module registry import, which is
async, so it is used for advisory console logging only.

Evidence: docs/projects/placement-realignment/evidence/milestone-b-2026-06-11.md
(placement stack, not on main).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>